### PR TITLE
[diffusion] feat: resolve hub component subfolders

### DIFF
--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -143,9 +143,13 @@ For a native text encoder:
 
 The same contract applies to every weighted component: path routing is generic,
 while quantized materialization is capability-based. Native auxiliary loaders
-that only understand unquantized state dicts reject quantization metadata before
-model construction. See [Quantized Component Repositories](../quantization#quantized-component-repositories)
+whose current materializer expects plain state dicts reject unsupported
+quantization metadata before model construction. See
+[Quantized Component Repositories](../quantization#quantized-component-repositories)
 for the current component matrix.
+
+Component overrides accept a local component directory, a standalone Hub
+repository, or a Hub component subfolder written as `owner/repo/subfolder`.
 
 For supported realtime causal video models, `--kv-cache-quant {off|int4|int2}`
 compresses completed KV-cache chunks independently of transformer weight

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -53,6 +53,7 @@ from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     maybe_download_model,
+    prepare_diffusers_component_path_for_loading,
     verify_model_config_and_directory,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
@@ -349,8 +350,9 @@ class ComposedPipelineBase(ABC):
     ) -> str:
         override_path = server_args.component_paths.get(module_name)
         if override_path is not None:
-            # overridden with args like --vae-path
-            component_model_path = maybe_download_model(override_path)
+            component_model_path = prepare_diffusers_component_path_for_loading(
+                override_path
+            )
         else:
             component_model_path = os.path.join(self.model_path, load_module_name)
 

--- a/python/sglang/multimodal_gen/test/unit/test_hf_diffusers_utils.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hf_diffusers_utils.py
@@ -1,9 +1,14 @@
 import json
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import modelscope
 import pytest
 from huggingface_hub.errors import LocalEntryNotFoundError
 
+from sglang.multimodal_gen.runtime.pipelines_core.composed_pipeline_base import (
+    ComposedPipelineBase,
+)
 from sglang.multimodal_gen.runtime.utils import hf_diffusers_utils
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     _check_index_files_for_missing_shards,
@@ -12,6 +17,35 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     maybe_download_model,
 )
 from sglang.srt.environ import envs
+
+
+def test_component_override_resolves_hub_subfolder_before_loading(tmp_path):
+    repo_root = tmp_path / "FLUX.1-dev-bnb-4bit"
+    component_root = repo_root / "text_encoder_2"
+    component_root.mkdir(parents=True)
+    pipeline = SimpleNamespace(model_path="/base")
+    server_args = SimpleNamespace(
+        component_paths={
+            "text_encoder_2": "diffusers/FLUX.1-dev-bnb-4bit/text_encoder_2"
+        }
+    )
+
+    with patch(
+        "sglang.multimodal_gen.runtime.utils.hf_diffusers_utils.maybe_download_model",
+        return_value=str(repo_root),
+    ) as download:
+        component_path = ComposedPipelineBase._resolve_component_path(
+            pipeline,
+            server_args,
+            "text_encoder_2",
+            "text_encoder_2",
+        )
+
+    assert component_path == str(component_root)
+    download.assert_called_once_with(
+        "diffusers/FLUX.1-dev-bnb-4bit",
+        allow_patterns=["text_encoder_2/**", "text_encoder_2/*"],
+    )
 
 
 def _write_model_index(root):


### PR DESCRIPTION
## Summary

- route `--component-paths.<name> owner/repo/subfolder` through the existing component-path resolver
- download only the selected Hub subfolder instead of treating the full slash-delimited value as a repo ID
- document local directories, standalone Hub repos, and Hub component subfolders as the supported component override forms

## Motivation

Many independently quantized encoders and VAEs are published as component subfolders inside a complete Diffusers repository. The loader-side resolver already supports that source form, but the composed-pipeline entry point called the generic whole-repo downloader first, so the request never reached it.

## Scope and churn

No new CLI or resolver is introduced. Existing production code is `+3/-2`; the rest is one cross-boundary test (`+34`) and docs (`+7/-2`). Total: 3 files, 48 lines of churn.

## Validation

- changed-file pre-commit suite passed
- `git diff --check` passed
- the focused test exercises the real pipeline-to-component resolver and mocks only external Hub download
- standard PR CI is enabled

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32544030665](https://github.com/sgl-project/sglang/actions/runs/32544030665)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32544035359](https://github.com/sgl-project/sglang/actions/runs/32544035359)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32544030688](https://github.com/sgl-project/sglang/actions/runs/32544030688)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->