### PR TITLE
[Bugfix] Skip singleton grammar token sync

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -498,6 +498,9 @@ class Sampler(nn.Module):
         self, batch_next_token_ids: torch.Tensor, sampling_info: SamplingBatchInfo
     ):
         if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
+            if dist.get_world_size(self.tp_sync_group) <= 1:
+                return
+
             # For performance reasons, SGLang does not sync the final token IDs across TP ranks by default.
             # This saves one all-reduce, but the correctness of this approach depends on the determinism of several operators:
             # the last all-reduce, the last lm_head matmul, and all sampling kernels.

--- a/test/registered/unit/layers/test_sampler_token_sync.py
+++ b/test/registered/unit/layers/test_sampler_token_sync.py
@@ -1,0 +1,49 @@
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+import torch.distributed as dist
+
+from sglang.srt.layers.sampler import Sampler
+
+
+def _sampler_with_group(group):
+    sampler = Sampler.__new__(Sampler)
+    object.__setattr__(sampler, "tp_sync_group", group)
+    return sampler
+
+
+def test_token_sync_skips_singleton_group():
+    group = object()
+    sampler = _sampler_with_group(group)
+    token_ids = torch.tensor([3], dtype=torch.int64)
+    sampling_info = SimpleNamespace(grammars=[object()])
+
+    with (
+        mock.patch.object(dist, "get_world_size", return_value=1) as get_world_size,
+        mock.patch.object(dist, "all_reduce") as all_reduce,
+    ):
+        sampler._sync_token_ids_across_tp(token_ids, sampling_info)
+
+    get_world_size.assert_called_once_with(group)
+    all_reduce.assert_not_called()
+
+
+def test_token_sync_preserves_min_reduce_for_multi_rank_group():
+    group = object()
+    sampler = _sampler_with_group(group)
+    token_ids = torch.tensor([3], dtype=torch.int64)
+    sampling_info = SimpleNamespace(grammars=[object()])
+
+    with (
+        mock.patch.object(dist, "get_world_size", return_value=2) as get_world_size,
+        mock.patch.object(dist, "all_reduce") as all_reduce,
+    ):
+        sampler._sync_token_ids_across_tp(token_ids, sampling_info)
+
+    get_world_size.assert_called_once_with(group)
+    all_reduce.assert_called_once_with(
+        token_ids,
+        op=dist.ReduceOp.MIN,
+        group=group,
+    )

--- a/test/registered/unit/layers/test_sampler_token_sync.py
+++ b/test/registered/unit/layers/test_sampler_token_sync.py
@@ -7,7 +7,6 @@ import torch.distributed as dist
 from sglang.srt.layers.sampler import Sampler
 from sglang.test.ci.ci_register import register_cpu_ci
 
-
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 

--- a/test/registered/unit/layers/test_sampler_token_sync.py
+++ b/test/registered/unit/layers/test_sampler_token_sync.py
@@ -5,6 +5,10 @@ import torch
 import torch.distributed as dist
 
 from sglang.srt.layers.sampler import Sampler
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 def _sampler_with_group(group):


### PR DESCRIPTION
## Summary
- skip distributed token synchronization when the TP group has one rank
- preserve the existing MIN all-reduce path for multi-rank groups
- add CPU-mocked coverage for singleton and multi-rank behavior

Fixes #35826

## Verification
- targeted CPU mock harness: 2 passed
- Ruff lint and format checks
- Python bytecode compilation

Full repository pytest was not run locally because the current environment does not include the SGLang runtime dependencies.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32554359177](https://github.com/sgl-project/sglang/actions/runs/32554359177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32554359016](https://github.com/sgl-project/sglang/actions/runs/32554359016)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32554359158](https://github.com/sgl-project/sglang/actions/runs/32554359158)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->