### PR TITLE
refactor(disagg): hoist duplicated _handle_staging_req into a mixin

### DIFF
--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -824,6 +824,46 @@ def handle_staging_req(
                 pass
 
 
+class StagingManagerMixin:
+    """Shared STAGING_REQ handling for KV managers that support staging.
+
+    Mixed into the managers whose decode thread receives STAGING_REQ messages
+    (currently Mooncake and NIXL). Expects the concrete manager to provide
+    ``_staging_handler``, ``_staging_ctx``, ``kv_args``, ``attn_tp_size`` and
+    optionally ``kv_buffer_tensors``.
+    """
+
+    def _handle_staging_req(self, msg):
+        room = int(msg[1].decode("ascii"))
+        session_id = msg[4].decode("ascii")
+        handler = self._staging_handler
+        assert (
+            handler is not None
+        ), "STAGING_REQ received before staging handler initialized"
+        decode_req = handler._room_to_decode_req.get(room)
+        if decode_req is None:
+            logger.warning(
+                "STAGING_REQ received for unregistered room=%s, skipping",
+                room,
+            )
+            return
+        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
+        handle_staging_req(
+            msg,
+            self._staging_ctx.allocator,
+            self.kv_args,
+            self.attn_tp_size,
+            prefill_tp,
+            getattr(self, "kv_buffer_tensors", None),
+            self._staging_ctx.room_receivers,
+            self._staging_ctx.room_bootstrap,
+        )
+
+        receiver = self._staging_ctx.room_receivers.get(room)
+        if receiver is not None:
+            handler.register_wm_subscriber(receiver, session_id)
+
+
 def prefetch_staging_reqs(
     room: int,
     transfer_infos: dict,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -27,6 +27,7 @@ from sglang.srt.disaggregation.common.staging_handler import (
     STAGING_WATERMARK_WAIT_S,
     DecodeStagingContext,
     PrefillStagingContext,
+    StagingManagerMixin,
     StagingTransferInfo,
 )
 from sglang.srt.disaggregation.common.utils import (
@@ -192,7 +193,7 @@ class KVArgsRegisterInfo:
         )
 
 
-class MooncakeKVManager(CommonKVManager):
+class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
 
     def __init__(
@@ -360,40 +361,6 @@ class MooncakeKVManager(CommonKVManager):
             self.kv_args,
         )
         self.kv_buffer_tensors = None
-
-    def _handle_staging_req(self, msg):
-        from sglang.srt.disaggregation.common.staging_handler import (
-            handle_staging_req,
-        )
-
-        room = int(msg[1].decode("ascii"))
-        session_id = msg[4].decode("ascii")
-        handler = self._staging_handler
-        assert (
-            handler is not None
-        ), "STAGING_REQ received before staging handler initialized"
-        decode_req = handler._room_to_decode_req.get(room)
-        if decode_req is None:
-            logger.warning(
-                "STAGING_REQ received for unregistered room=%s, skipping",
-                room,
-            )
-            return
-        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
-        handle_staging_req(
-            msg,
-            self._staging_ctx.allocator,
-            self.kv_args,
-            self.attn_tp_size,
-            prefill_tp,
-            getattr(self, "kv_buffer_tensors", None),
-            self._staging_ctx.room_receivers,
-            self._staging_ctx.room_bootstrap,
-        )
-
-        receiver = self._staging_ctx.room_receivers.get(room)
-        if receiver is not None:
-            handler.register_wm_subscriber(receiver, session_id)
 
     def _is_watermark_ready(
         self, session_id: str, alloc_round: int, alloc_end: int

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -25,7 +25,10 @@ from sglang.srt.disaggregation.common.conn import (
     CommonKVSender,
     KVTransferError,
 )
-from sglang.srt.disaggregation.common.staging_handler import STAGING_WATERMARK_WAIT_S
+from sglang.srt.disaggregation.common.staging_handler import (
+    STAGING_WATERMARK_WAIT_S,
+    StagingManagerMixin,
+)
 from sglang.srt.disaggregation.common.utils import (
     FastQueue,
     TransferKVChunk,
@@ -390,7 +393,7 @@ class TransferStatus:
         return True
 
 
-class NixlKVManager(CommonKVManager):
+class NixlKVManager(StagingManagerMixin, CommonKVManager):
     def __init__(
         self,
         args: KVArgs,
@@ -617,40 +620,6 @@ class NixlKVManager(CommonKVManager):
                 )
 
         threading.Thread(target=decode_listener_thread, daemon=True).start()
-
-    def _handle_staging_req(self, msg):
-        from sglang.srt.disaggregation.common.staging_handler import (
-            handle_staging_req,
-        )
-
-        room = int(msg[1].decode("ascii"))
-        session_id = msg[4].decode("ascii")
-        handler = self._staging_handler
-        assert (
-            handler is not None
-        ), "STAGING_REQ received before staging handler initialized"
-        decode_req = handler._room_to_decode_req.get(room)
-        if decode_req is None:
-            logger.warning(
-                "STAGING_REQ received for unregistered room=%s, skipping",
-                room,
-            )
-            return
-        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
-        handle_staging_req(
-            msg,
-            self._staging_ctx.allocator,
-            self.kv_args,
-            self.attn_tp_size,
-            prefill_tp,
-            getattr(self, "kv_buffer_tensors", None),
-            self._staging_ctx.room_receivers,
-            self._staging_ctx.room_bootstrap,
-        )
-
-        receiver = self._staging_ctx.room_receivers.get(room)
-        if receiver is not None:
-            handler.register_wm_subscriber(receiver, session_id)
 
     def _prefetch_staging_reqs(self, room: int):
         """Send STAGING_REQ for all chunks before the prefill forward starts.


### PR DESCRIPTION
## Motivation

`_handle_staging_req` was **byte-identical**, 33 lines, in both `MooncakeKVManager` and `NixlKVManager` — `diff` between the two reported zero differences. It was a straight copy-paste.

Tellingly, both copies already delegated the real work to `common/staging_handler.handle_staging_req`. The shared helper was already there; only the wrapper around it had been duplicated.

## Modifications

3 files, +47 / -71 (net -24 lines, and one fewer copy of the method).

- Adds `StagingManagerMixin` to `common/staging_handler.py`, placed immediately after the `handle_staging_req` function it wraps.
- Mixes it into `MooncakeKVManager` and `NixlKVManager`, deleting both copies of the method.

The method body is unchanged except for dropping its local `from ...staging_handler import handle_staging_req`, which is now redundant because the mixin lives in that module. That import is the *only* textual difference between the old method and the new one.

### Why a mixin rather than a method on `CommonKVManager`

`MoriKVManager` also extends `CommonKVManager` but has no staging support — `_staging_ctx` does not exist anywhere in `mori/conn.py`. Putting the method on the shared base would give Mori a method that would `AttributeError` if it were ever reached. The mixin scopes it to the two backends that can honor it.

The mixin's docstring names the attributes a concrete manager must provide (`_staging_handler`, `_staging_ctx`, `kv_args`, `attn_tp_size`, and optionally `kv_buffer_tensors`), since a mixin depending on subclass-set state is otherwise an undocumented contract.

Resolution was verified rather than assumed, including the fourth backend that inherits transitively:

| Class | Has `_handle_staging_req` | Resolves from |
|---|---|---|
| `MooncakeKVManager` | yes | `StagingManagerMixin` |
| `NixlKVManager` | yes | `StagingManagerMixin` |
| `AscendKVManager` | yes | `StagingManagerMixin` (via `MooncakeKVManager`) |
| `MoriKVManager` | no | — |

MRO for the Mooncake case: `MooncakeKVManager -> StagingManagerMixin -> CommonKVManager -> BaseKVManager`. No conflict.

### One behavior delta

All three modules use `logging.getLogger(__name__)`, so the "STAGING_REQ received for unregistered room" warning is now emitted on the `common.staging_handler` logger rather than the per-backend `mooncake.conn` / `nixl.conn` logger. Message text and level are unchanged; only the module attribution of that one log line shifts. Nothing in the repo filters on it, but flagging it in case external log tooling keys on per-backend logger names. It is avoidable by threading a logger through the mixin, at the cost of extra plumbing — happy to do that if maintainers prefer.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched. This moves a ZMQ message handler between classes.

## Speed Tests and Profiling

Not applicable. Same work per STAGING_REQ message; one extra MRO hop on an already-ZMQ-bound path.

## Verification performed

**The move was proven to be a move, not a rewrite.** Both old copies (at this PR's base commit) and the new mixin method were extracted via AST and normalized to ignore the dropped local import:

- `old nixl == old mooncake` -> True (confirming they really were identical)
- `new mixin == old` -> True

Also confirmed: zero remaining `def _handle_staging_req` in either backend; both call sites (`mooncake/conn.py`, `nixl/conn.py`) still intact; MRO resolution table above.

Pinned `ruff 0.15.1 --select=F401,F821,UP037` (the pre-commit config) passes, plus pinned `black 26.1.0` and `isort 7.0.0`.

Staging paths were **not** exercised locally — they need a live PD pair with heterogeneous prefill/decode TP and `SGLANG_DISAGG_STAGING_BUFFER=1`, i.e. multi-GPU hardware.

Last of a series of disaggregation cleanups. Related: #35838, #35843, #35844, #35847, #35886, #35890.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: no behavior change; the AST equivalence check and MRO verification are described above.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: internal handler, not documented.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32554000395](https://github.com/sgl-project/sglang/actions/runs/32554000395)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32554000352](https://github.com/sgl-project/sglang/actions/runs/32554000352)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32554000407](https://github.com/sgl-project/sglang/actions/runs/32554000407)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->