### PR TITLE
refactor(disagg): drop dead placeholder overrides in Common KV sender/receiver

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1298,12 +1298,6 @@ class CommonKVSender(BaseKVSender):
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
         return KVPoll.Failed
 
-    def poll(self) -> KVPoll:
-        pass
-
-    def failure_exception(self):
-        raise Exception("Fake KVReceiver Exception")
-
     def clear(self) -> None:
         self.kv_mgr.request_status.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
@@ -1561,9 +1555,6 @@ class CommonKVReceiver(BaseKVReceiver):
             self._send_abort_notification()
             self.abort_notified = True
         return KVPoll.Failed
-
-    def failure_exception(self):
-        raise Exception("Fake KVReceiver Exception")
 
     def clear(self) -> None:
         self.kv_mgr.request_status.pop(self.bootstrap_room, None)


### PR DESCRIPTION
## Motivation

`CommonKVSender` carried two adjacent stub overrides, and `CommonKVReceiver` one:

```python
    def poll(self) -> KVPoll:
        pass

    def failure_exception(self):
        raise Exception("Fake KVReceiver Exception")
```

`poll` is annotated `-> KVPoll` but returns `None`.

The exception string belongs to the fake backend — `fake/conn.py` has `FakeKVSender` raising `"Fake KVSender Exception"` and `FakeKVReceiver` raising `"Fake KVReceiver Exception"`. It was copy-pasted into `common/conn.py` twice, and in the **Sender** case even the noun is wrong. A real backend reaching it would report a "Fake" failure from a production path.

All three are unreachable. Every subclass overrides both methods:

| Base | Subclasses | Override `poll` | Override `failure_exception` |
|---|---|---|---|
| `CommonKVSender` | `NixlKVSender`, `MooncakeKVSender`, `MoriKVSender` | yes | yes |
| `CommonKVReceiver` | `NixlKVReceiver`, `MooncakeKVReceiver`, `MoriKVReceiver` | yes | yes |

`AscendKVSender` / `AscendKVReceiver` extend the Mooncake classes and inherit real implementations. No subclass delegates upward via `super().poll()` or `super().failure_exception()`, and neither Common class is instantiated directly anywhere in `python/` or `test/`.

## Modifications

Removes all three dead overrides. 1 file, 0 insertions / 9 deletions. After this change the "Fake ..." strings exist only in `fake/conn.py`, where they belong.

Deleting is preferable to correcting them, because it restores ABC enforcement where it was missing:

- **`CommonKVSender`** implemented all six of `BaseKVSender`'s abstractmethods, so it was fully concrete. Dropping these two leaves it abstract for `poll` and `failure_exception`. A future backend that forgets either now fails at construction —

  ```
  TypeError: Can't instantiate abstract class NewBackendKVSender
  with abstract method failure_exception
  ```

  — rather than constructing fine and later returning `None` from `poll`, or raising a bewildering "Fake KVReceiver Exception".

- **`CommonKVReceiver`** was **already** abstract: it never implemented `poll`. So for the receiver this is dead-code cleanup only, with no change to instantiation behavior.

### Compatibility note

An out-of-tree backend subclassing `CommonKVSender` without implementing `poll` or `failure_exception` would now fail at instantiation instead of at first use. That is arguably a fix rather than a break — such a backend was already broken, it just failed later and far less intelligibly — but it is the one behavioral consequence worth a reviewer's attention.

No behavior change for any in-tree backend.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched. This removes unreachable stubs.

## Speed Tests and Profiling

Not applicable — the removed code never executed.

## Verification performed

- Override table above derived by AST walk over the whole disaggregation module, not by eye.
- Confirmed no `super().poll()` / `super().failure_exception()` delegation anywhere in `python/` or `test/`.
- Abstractmethod sets compared programmatically per class, which is what established that `CommonKVSender` was concrete while `CommonKVReceiver` was already abstract via the missing `poll`.
- The before/after construction behavior quoted above was executed against stand-in classes mirroring the real abstract surface, rather than assumed.
- Confirmed `KVPoll` remains heavily used in the file (38 references), so removing the annotated stub orphans no import.
- Pinned `ruff 0.15.1 --select=F401,F821,UP037` (the pre-commit config) passes, plus pinned `black 26.1.0` and `isort 7.0.0`.

PD failure paths were **not** exercised locally — they need multi-GPU hardware.

Part of a series of disaggregation cleanups. Related: #35838, #35843, #35844, #35847, #35886, #35890, #35948.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: removes unreachable code; the ABC-enforcement consequence is demonstrated above.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: internal stubs, not documented.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32555605820](https://github.com/sgl-project/sglang/actions/runs/32555605820)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32555605688](https://github.com/sgl-project/sglang/actions/runs/32555605688)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32555605779](https://github.com/sgl-project/sglang/actions/runs/32555605779)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->