### PR TITLE
Clean up forkserver orphan processes and restrict nightly NPU tests to accuracy

### DIFF
--- a/.github/workflows/nightly-test-npu.yml
+++ b/.github/workflows/nightly-test-npu.yml
@@ -122,162 +122,162 @@ jobs:
           # Write to GITHUB_OUTPUT and print to the log in one command.
           echo "run_start_metadata=${RUN_START_METADATA}" | tee -a $GITHUB_OUTPUT
 
-  nightly-1-npu-a2:
-    name: nightly-1-npu-a2
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-single-node-test-stage.yml
-    with:
-      runner: linux-aarch64-a2-4
-      test_type: 'perf'
-      test_suite: nightly-1-npu-a2
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-      image: ${{ needs.set-image-config.outputs.image_a2 }}
-      install_sglang_deps: false
-      device_type_for_deps: '910b'
-      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+  # nightly-1-npu-a2:
+  #   name: nightly-1-npu-a2
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-single-node-test-stage.yml
+  #   with:
+  #     runner: linux-aarch64-a2-4
+  #     test_type: 'perf'
+  #     test_suite: nightly-1-npu-a2
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #     image: ${{ needs.set-image-config.outputs.image_a2 }}
+  #     install_sglang_deps: false
+  #     device_type_for_deps: '910b'
+  #     run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
 
-  nightly-1-npu-a3:
-    name: nightly-1-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-pr-test-stage.yml
-    with:
-      self_name: nightly-1-npu-a3
-      runner_config: linux-aarch64-a3-2-
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      run_timeout_minutes: '60'
-      timeout_per_file: '3600'
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-    secrets: inherit
+  # nightly-1-npu-a3:
+  #   name: nightly-1-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-pr-test-stage.yml
+  #   with:
+  #     self_name: nightly-1-npu-a3
+  #     runner_config: linux-aarch64-a3-2-
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     run_timeout_minutes: '60'
+  #     timeout_per_file: '3600'
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #   secrets: inherit
 
-  nightly-2-npu-a3:
-    name: nightly-2-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-pr-test-stage.yml
-    with:
-      self_name: nightly-2-npu-a3
-      runner_config: linux-aarch64-a3-2-
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      run_timeout_minutes: '60'
-      timeout_per_file: '3600'
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-    secrets: inherit
+  # nightly-2-npu-a3:
+  #   name: nightly-2-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-pr-test-stage.yml
+  #   with:
+  #     self_name: nightly-2-npu-a3
+  #     runner_config: linux-aarch64-a3-2-
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     run_timeout_minutes: '60'
+  #     timeout_per_file: '3600'
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #   secrets: inherit
 
   # The nightly-4-npu-a3 suite is split across 2 parallel partition jobs, mirroring base-b-test-4-npu-a3 in the PR pipeline.
-  nightly-4-npu-a3:
-    name: nightly-4-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-pr-test-stage.yml
-    with:
-      self_name: nightly-4-npu-a3
-      runner_config: linux-aarch64-a3-4-
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      run_timeout_minutes: '120'
-      timeout_per_file: '3600'
-      partitions: '{"size":2,"arr":[0,1]}'
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-    secrets: inherit
+  # nightly-4-npu-a3:
+  #   name: nightly-4-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-pr-test-stage.yml
+  #   with:
+  #     self_name: nightly-4-npu-a3
+  #     runner_config: linux-aarch64-a3-4-
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     run_timeout_minutes: '120'
+  #     timeout_per_file: '3600'
+  #     partitions: '{"size":2,"arr":[0,1]}'
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #   secrets: inherit
 
-  nightly-8-npu-a3:
-    name: nightly-8-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-pr-test-stage.yml
-    with:
-      self_name: nightly-8-npu-a3
-      runner_config: linux-aarch64-a3-8-
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      run_timeout_minutes: '60'
-      timeout_per_file: '3600'
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-    secrets: inherit
+  # nightly-8-npu-a3:
+  #   name: nightly-8-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-pr-test-stage.yml
+  #   with:
+  #     self_name: nightly-8-npu-a3
+  #     runner_config: linux-aarch64-a3-8-
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     run_timeout_minutes: '60'
+  #     timeout_per_file: '3600'
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #   secrets: inherit
 
-  nightly-16-npu-a3:
-    name: nightly-16-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-pr-test-stage.yml
-    with:
-      self_name: nightly-16-npu-a3
-      runner_config: linux-aarch64-a3-16-
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      run_timeout_minutes: '120'
-      timeout_per_file: '3600'
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-    secrets: inherit
+  # nightly-16-npu-a3:
+  #   name: nightly-16-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-pr-test-stage.yml
+  #   with:
+  #     self_name: nightly-16-npu-a3
+  #     runner_config: linux-aarch64-a3-16-
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     run_timeout_minutes: '120'
+  #     timeout_per_file: '3600'
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #   secrets: inherit
 
-  nightly-perf-2-npu-a3:
-    name: nightly-perf-2-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-single-node-test-stage.yml
-    with:
-      runner: linux-aarch64-a3-800t-2
-      test_type: 'perf'
-      test_suite: nightly-perf-2-npu-a3
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_deps: false
-      device_type_for_deps: 'a3'
-      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+  # nightly-perf-2-npu-a3:
+  #   name: nightly-perf-2-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-single-node-test-stage.yml
+  #   with:
+  #     runner: linux-aarch64-a3-800t-2
+  #     test_type: 'perf'
+  #     test_suite: nightly-perf-2-npu-a3
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     install_sglang_deps: false
+  #     device_type_for_deps: 'a3'
+  #     run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
 
-  nightly-perf-4-npu-a3:
-    name: nightly-perf-4-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-single-node-test-stage.yml
-    with:
-      runner: linux-aarch64-a3-800t-4
-      test_type: 'perf'
-      test_suite: nightly-perf-4-npu-a3
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_deps: false
-      device_type_for_deps: 'a3'
-      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+  # nightly-perf-4-npu-a3:
+  #   name: nightly-perf-4-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-single-node-test-stage.yml
+  #   with:
+  #     runner: linux-aarch64-a3-800t-4
+  #     test_type: 'perf'
+  #     test_suite: nightly-perf-4-npu-a3
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     install_sglang_deps: false
+  #     device_type_for_deps: 'a3'
+  #     run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
 
-  nightly-perf-8-npu-a3:
-    name: nightly-perf-8-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-single-node-test-stage.yml
-    with:
-      runner: linux-aarch64-a3-800t-8
-      test_type: 'perf'
-      test_suite: nightly-perf-8-npu-a3
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_deps: false
-      device_type_for_deps: 'a3'
-      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+  # nightly-perf-8-npu-a3:
+  #   name: nightly-perf-8-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-single-node-test-stage.yml
+  #   with:
+  #     runner: linux-aarch64-a3-800t-8
+  #     test_type: 'perf'
+  #     test_suite: nightly-perf-8-npu-a3
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     install_sglang_deps: false
+  #     device_type_for_deps: 'a3'
+  #     run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
 
-  nightly-perf-16-npu-a3:
-    name: nightly-perf-16-npu-a3
-    if: ${{ !cancelled() }}
-    needs: [set-image-config]
-    uses: ./.github/workflows/_npu-single-node-test-stage.yml
-    with:
-      runner: linux-aarch64-a3-800t-16
-      test_type: 'perf'
-      test_suite: nightly-perf-16-npu-a3
-      is_nightly_pipeline_job: true
-      skip_pr_test_health_check: 'true'
-      image: ${{ needs.set-image-config.outputs.image_a3 }}
-      install_sglang_deps: false
-      device_type_for_deps: 'a3'
-      run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
+  # nightly-perf-16-npu-a3:
+  #   name: nightly-perf-16-npu-a3
+  #   if: ${{ !cancelled() }}
+  #   needs: [set-image-config]
+  #   uses: ./.github/workflows/_npu-single-node-test-stage.yml
+  #   with:
+  #     runner: linux-aarch64-a3-800t-16
+  #     test_type: 'perf'
+  #     test_suite: nightly-perf-16-npu-a3
+  #     is_nightly_pipeline_job: true
+  #     skip_pr_test_health_check: 'true'
+  #     image: ${{ needs.set-image-config.outputs.image_a3 }}
+  #     install_sglang_deps: false
+  #     device_type_for_deps: 'a3'
+  #     run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
 
   # The acc-2 suite is split across 4 parallel partition jobs via the single `partitions` input.
   nightly-acc-2-npu-a3:
@@ -332,20 +332,12 @@ jobs:
   nightly-poc-multi-node-tests:
     name: multi-node-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-perf-2-npu-a3, nightly-perf-4-npu-a3, nightly-perf-16-npu-a3, nightly-acc-2-npu-a3, nightly-acc-4-npu-a3, nightly-acc-16-npu-a3]
+    needs: [set-image-config, nightly-acc-2-npu-a3, nightly-acc-4-npu-a3, nightly-acc-16-npu-a3]
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
         test_config:
-          # glm5_1 performance tests
-          - name: glm5_1_w4a8_1p1d_32p_in64k_out1k_50ms
-            prefill_size: 2
-            decode_size: 2
-            router_size: 1
-            test_case: test/registered/npu/performance/glm5_1/test_npu_glm5_1_w4a8_1p1d_32p_in64k_out1k_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
           - name: glm5_1_w4a8_1p1d_32p_in64k_out1k_50ms_aime26
             prefill_size: 2
             decode_size: 2
@@ -353,29 +345,37 @@ jobs:
             test_case: test/registered/npu/accuracy/glm5_1/test_npu_glm5_1_w4a8_1p1d_32p_in64k_out1k_50ms_aime26.py
             test_type: 'accuracy'
             prefill_decode_deployment: 'separation'
-          # mimo_v2_flash performance tests
-          - name: test_npu_mimo_v2_flash_1p1d_12p_in16k_out1_ttft_5s
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/npu/performance/mimo_v2_flash/test_npu_mimo_v2_flash_1p1d_12p_in16k_out1_ttft_5s.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          - name: test_npu_mimo_v2_flash_1p1d_12p_in16k_out1k_tpot_20ms
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/npu/performance/mimo_v2_flash/test_npu_mimo_v2_flash_1p1d_12p_in16k_out1k_tpot_20ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
-          # deepseek_v4_flash performance tests
-          - name: deepseek_v4_flash_w8a8_1p1d_16p_in8k_out1k_50ms
-            prefill_size: 1
-            decode_size: 1
-            router_size: 1
-            test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_1p1d_16p_in8k_out1k_50ms.py
-            test_type: 'perf'
-            prefill_decode_deployment: 'separation'
+          # # glm5_1 performance tests
+          # - name: glm5_1_w4a8_1p1d_32p_in64k_out1k_50ms
+          #   prefill_size: 2
+          #   decode_size: 2
+          #   router_size: 1
+          #   test_case: test/registered/npu/performance/glm5_1/test_npu_glm5_1_w4a8_1p1d_32p_in64k_out1k_50ms.py
+          #   test_type: 'perf'
+          #   prefill_decode_deployment: 'separation'
+          # # mimo_v2_flash performance tests
+          # - name: test_npu_mimo_v2_flash_1p1d_12p_in16k_out1_ttft_5s
+          #   prefill_size: 1
+          #   decode_size: 1
+          #   router_size: 1
+          #   test_case: test/registered/npu/performance/mimo_v2_flash/test_npu_mimo_v2_flash_1p1d_12p_in16k_out1_ttft_5s.py
+          #   test_type: 'perf'
+          #   prefill_decode_deployment: 'separation'
+          # - name: test_npu_mimo_v2_flash_1p1d_12p_in16k_out1k_tpot_20ms
+          #   prefill_size: 1
+          #   decode_size: 1
+          #   router_size: 1
+          #   test_case: test/registered/npu/performance/mimo_v2_flash/test_npu_mimo_v2_flash_1p1d_12p_in16k_out1k_tpot_20ms.py
+          #   test_type: 'perf'
+          #   prefill_decode_deployment: 'separation'
+          # # deepseek_v4_flash performance tests
+          # - name: deepseek_v4_flash_w8a8_1p1d_16p_in8k_out1k_50ms
+          #   prefill_size: 1
+          #   decode_size: 1
+          #   router_size: 1
+          #   test_case: test/registered/npu/performance/deepseek_v4_flash/test_npu_deepseek_v4_flash_w8a8_1p1d_16p_in8k_out1k_50ms.py
+          #   test_type: 'perf'
+          #   prefill_decode_deployment: 'separation'
     uses: ./.github/workflows/nightly-test-npu-e2e-multi-node.yml
     with:
       runner: linux-amd64-cpu-4
@@ -394,17 +394,17 @@ jobs:
   nightly-poc-multi-node-mix-tests:
     name: multi-node-mix-poc
     if: ${{ !cancelled() }}
-    needs: [set-image-config, nightly-perf-2-npu-a3, nightly-perf-4-npu-a3, nightly-perf-16-npu-a3, nightly-acc-2-npu-a3, nightly-acc-4-npu-a3, nightly-acc-16-npu-a3, nightly-poc-multi-node-tests]
+    needs: [set-image-config, nightly-acc-2-npu-a3, nightly-acc-4-npu-a3, nightly-acc-16-npu-a3, nightly-poc-multi-node-tests]
     strategy:
       fail-fast: false
       max-parallel: 1
       matrix:
         test_config:
-          # kimi_k2_6 performance tests
-          - name: kimi_k2_6_w4a8_16p_in64k_out1k_100ms
-            node_size: 2
-            test_case: test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_16p_in64k_out1k_100ms.py
-            test_type: 'perf'
+          # # kimi_k2_6 performance tests
+          # - name: kimi_k2_6_w4a8_16p_in64k_out1k_100ms
+          #   node_size: 2
+          #   test_case: test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_16p_in64k_out1k_100ms.py
+          #   test_type: 'perf'
           - name: kimi_k2_6_w4a8_16p_in64k_out1k_100ms_aime25
             node_size: 2
             test_case: test/registered/npu/accuracy/kimi_k2_6/test_npu_kimi_k2_6_w4a8_16p_in64k_out1k_100ms_aime25.py
@@ -427,133 +427,135 @@ jobs:
       transformers_version: ''
       run_start_metadata: ${{ needs.set-image-config.outputs.run_start_metadata }}
 
-  check-all-jobs:
-    if: ${{ !cancelled() }}
-    needs:
-      - nightly-1-npu-a2
-      - nightly-1-npu-a3
-      - nightly-2-npu-a3
-      - nightly-4-npu-a3
-      - nightly-8-npu-a3
-      - nightly-16-npu-a3
-      - nightly-perf-2-npu-a3
-      - nightly-perf-4-npu-a3
-      - nightly-perf-8-npu-a3
-      - nightly-perf-16-npu-a3
-      - nightly-acc-2-npu-a3
-      - nightly-acc-4-npu-a3
-      - nightly-acc-16-npu-a3
-      - nightly-poc-multi-node-tests
-      - nightly-poc-multi-node-mix-tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download all metrics
-        uses: actions/download-artifact@v4
-        with:
-          pattern: metrics-*
-          path: /tmp/metrics
-          merge-multiple: false
-
-      - name: Generate results table
-        run: |
-          single_result_a2="${{ needs.nightly-1-npu-a2.result }}"
-          multi_result="${{ needs.nightly-poc-multi-node-tests.result }}"
-          mix_result="${{ needs.nightly-poc-multi-node-mix-tests.result }}"
-
-          # single-node suites are reported per suite; overall status is success if none failed
-          single_result="success"
-          for r in \
-            "${{ needs.nightly-1-npu-a3.result }}" \
-            "${{ needs.nightly-2-npu-a3.result }}" \
-            "${{ needs.nightly-4-npu-a3.result }}" \
-            "${{ needs.nightly-8-npu-a3.result }}" \
-            "${{ needs.nightly-16-npu-a3.result }}" \
-            "${{ needs.nightly-perf-2-npu-a3.result }}" \
-            "${{ needs.nightly-perf-4-npu-a3.result }}" \
-            "${{ needs.nightly-perf-8-npu-a3.result }}" \
-            "${{ needs.nightly-perf-16-npu-a3.result }}" \
-            "${{ needs.nightly-acc-2-npu-a3.result }}" \
-            "${{ needs.nightly-acc-4-npu-a3.result }}" \
-            "${{ needs.nightly-acc-16-npu-a3.result }}"; do
-            if [ "${r}" != "success" ] && [ "${r}" != "skipped" ]; then
-              single_result="failure"
-            fi
-          done
-
-          group_icon() {
-            case "$1" in
-              success)   echo "✅" ;;
-              failure)   echo "❌" ;;
-              cancelled) echo "⏭️" ;;
-              skipped)   echo "⏭️" ;;
-              *)         echo "❓" ;;
-            esac
-          }
-
-          echo "## Nightly Test Results" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "| Group | Status |" >> $GITHUB_STEP_SUMMARY
-          echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
-          echo "| nightly-1-npu-a2 | $(group_icon ${single_result_a2}) ${single_result_a2} |" >> $GITHUB_STEP_SUMMARY
-          for entry in \
-            "nightly-1-npu-a3:${{ needs.nightly-1-npu-a3.result }}" \
-            "nightly-2-npu-a3:${{ needs.nightly-2-npu-a3.result }}" \
-            "nightly-4-npu-a3:${{ needs.nightly-4-npu-a3.result }}" \
-            "nightly-8-npu-a3:${{ needs.nightly-8-npu-a3.result }}" \
-            "nightly-16-npu-a3:${{ needs.nightly-16-npu-a3.result }}" \
-            "nightly-perf-2-npu-a3:${{ needs.nightly-perf-2-npu-a3.result }}" \
-            "nightly-perf-4-npu-a3:${{ needs.nightly-perf-4-npu-a3.result }}" \
-            "nightly-perf-8-npu-a3:${{ needs.nightly-perf-8-npu-a3.result }}" \
-            "nightly-perf-16-npu-a3:${{ needs.nightly-perf-16-npu-a3.result }}" \
-            "nightly-acc-2-npu-a3:${{ needs.nightly-acc-2-npu-a3.result }}" \
-            "nightly-acc-4-npu-a3:${{ needs.nightly-acc-4-npu-a3.result }}" \
-            "nightly-acc-16-npu-a3:${{ needs.nightly-acc-16-npu-a3.result }}"; do
-            suite="${entry%%:*}"
-            r="${entry##*:}"
-            echo "| ${suite} | $(group_icon ${r}) ${r} |" >> $GITHUB_STEP_SUMMARY
-          done
-          echo "| multi-node-poc | $(group_icon ${multi_result}) ${multi_result} |" >> $GITHUB_STEP_SUMMARY
-          echo "| multi-node-mix-poc | $(group_icon ${mix_result}) ${mix_result} |" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          echo "## Per-Test Metrics" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          has_metrics=false
-          # Each suite job uploads its METRICS_DATA_FILE directory, which
-          # contains per-case subdirectories with their own metrics.json.
-          # Recursively find every metrics.json and render one table row per
-          # test case.
-          for file in $(find /tmp/metrics -name metrics.json 2>/dev/null); do
-            if [ -f "$file" ]; then
-              has_metrics=true
-              echo "import json" > /tmp/parse_metrics.py
-              echo "with open('$file') as f:" >> /tmp/parse_metrics.py
-              echo "    d = json.load(f)" >> /tmp/parse_metrics.py
-              echo "tc = d.get('test_case', '-')" >> /tmp/parse_metrics.py
-              echo "tp = d.get('test_type', '-')" >> /tmp/parse_metrics.py
-              echo "st = d.get('status', 'unknown')" >> /tmp/parse_metrics.py
-              echo "icon = '✅' if st == 'pass' else '❌'" >> /tmp/parse_metrics.py
-              echo "metrics = d.get('metrics', {})" >> /tmp/parse_metrics.py
-              echo "baselines = d.get('baselines', {})" >> /tmp/parse_metrics.py
-              echo "mstr = ', '.join(f'{k}={v}' for k,v in metrics.items()) if metrics else '-'" >> /tmp/parse_metrics.py
-              echo "bstr = ', '.join(f'{k}={v}' for k,v in baselines.items()) if baselines else '-'" >> /tmp/parse_metrics.py
-              echo "print(f'| {tc} | {tp} | {icon} {st} | {mstr} | {bstr} |')" >> /tmp/parse_metrics.py
-              python3 /tmp/parse_metrics.py
-            fi
-          done > /tmp/metrics_table.txt
-
-          if [ "${has_metrics}" = "true" ]; then
-            echo "| Test Case | Type | Status | Metrics | Baseline |" >> $GITHUB_STEP_SUMMARY
-            echo "|-----------|------|--------|---------|----------|" >> $GITHUB_STEP_SUMMARY
-            cat /tmp/metrics_table.txt >> $GITHUB_STEP_SUMMARY
-          else
-            echo "No per-test metrics available (artifacts not found)." >> $GITHUB_STEP_SUMMARY
-          fi
-          echo "" >> $GITHUB_STEP_SUMMARY
-
-          FAIL=0
-          for r in "${single_result_a2}" "${single_result}" "${multi_result}" "${mix_result}"; do
-            if [ "${r}" != "success" ] && [ "${r}" != "skipped" ]; then FAIL=1; fi
-          done
-          exit $FAIL
+  # check-all-jobs (aggregation job) is disabled because it references the
+  # perf/general suites that are commented out in this accuracy-only run.
+  # check-all-jobs:
+  #   if: ${{ !cancelled() }}
+  #   needs:
+  #     - nightly-1-npu-a2
+  #     - nightly-1-npu-a3
+  #     - nightly-2-npu-a3
+  #     - nightly-4-npu-a3
+  #     - nightly-8-npu-a3
+  #     - nightly-16-npu-a3
+  #     - nightly-perf-2-npu-a3
+  #     - nightly-perf-4-npu-a3
+  #     - nightly-perf-8-npu-a3
+  #     - nightly-perf-16-npu-a3
+  #     - nightly-acc-2-npu-a3
+  #     - nightly-acc-4-npu-a3
+  #     - nightly-acc-16-npu-a3
+  #     - nightly-poc-multi-node-tests
+  #     - nightly-poc-multi-node-mix-tests
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - name: Download all metrics
+  #       uses: actions/download-artifact@v4
+  #       with:
+  #         pattern: metrics-*
+  #         path: /tmp/metrics
+  #         merge-multiple: false
+  #
+  #     - name: Generate results table
+  #       run: |
+  #         single_result_a2="${{ needs.nightly-1-npu-a2.result }}"
+  #         multi_result="${{ needs.nightly-poc-multi-node-tests.result }}"
+  #         mix_result="${{ needs.nightly-poc-multi-node-mix-tests.result }}"
+  #
+  #         # single-node suites are reported per suite; overall status is success if none failed
+  #         single_result="success"
+  #         for r in \
+  #           "${{ needs.nightly-1-npu-a3.result }}" \
+  #           "${{ needs.nightly-2-npu-a3.result }}" \
+  #           "${{ needs.nightly-4-npu-a3.result }}" \
+  #           "${{ needs.nightly-8-npu-a3.result }}" \
+  #           "${{ needs.nightly-16-npu-a3.result }}" \
+  #           "${{ needs.nightly-perf-2-npu-a3.result }}" \
+  #           "${{ needs.nightly-perf-4-npu-a3.result }}" \
+  #           "${{ needs.nightly-perf-8-npu-a3.result }}" \
+  #           "${{ needs.nightly-perf-16-npu-a3.result }}" \
+  #           "${{ needs.nightly-acc-2-npu-a3.result }}" \
+  #           "${{ needs.nightly-acc-4-npu-a3.result }}" \
+  #           "${{ needs.nightly-acc-16-npu-a3.result }}"; do
+  #           if [ "${r}" != "success" ] && [ "${r}" != "skipped" ]; then
+  #             single_result="failure"
+  #           fi
+  #         done
+  #
+  #         group_icon() {
+  #           case "$1" in
+  #             success)   echo "✅" ;;
+  #             failure)   echo "❌" ;;
+  #             cancelled) echo "⏭️" ;;
+  #             skipped)   echo "⏭️" ;;
+  #             *)         echo "❓" ;;
+  #           esac
+  #         }
+  #
+  #         echo "## Nightly Test Results" >> $GITHUB_STEP_SUMMARY
+  #         echo "" >> $GITHUB_STEP_SUMMARY
+  #         echo "| Group | Status |" >> $GITHUB_STEP_SUMMARY
+  #         echo "|-------|--------|" >> $GITHUB_STEP_SUMMARY
+  #         echo "| nightly-1-npu-a2 | $(group_icon ${single_result_a2}) ${single_result_a2} |" >> $GITHUB_STEP_SUMMARY
+  #         for entry in \
+  #           "nightly-1-npu-a3:${{ needs.nightly-1-npu-a3.result }}" \
+  #           "nightly-2-npu-a3:${{ needs.nightly-2-npu-a3.result }}" \
+  #           "nightly-4-npu-a3:${{ needs.nightly-4-npu-a3.result }}" \
+  #           "nightly-8-npu-a3:${{ needs.nightly-8-npu-a3.result }}" \
+  #           "nightly-16-npu-a3:${{ needs.nightly-16-npu-a3.result }}" \
+  #           "nightly-perf-2-npu-a3:${{ needs.nightly-perf-2-npu-a3.result }}" \
+  #           "nightly-perf-4-npu-a3:${{ needs.nightly-perf-4-npu-a3.result }}" \
+  #           "nightly-perf-8-npu-a3:${{ needs.nightly-perf-8-npu-a3.result }}" \
+  #           "nightly-perf-16-npu-a3:${{ needs.nightly-perf-16-npu-a3.result }}" \
+  #           "nightly-acc-2-npu-a3:${{ needs.nightly-acc-2-npu-a3.result }}" \
+  #           "nightly-acc-4-npu-a3:${{ needs.nightly-acc-4-npu-a3.result }}" \
+  #           "nightly-acc-16-npu-a3:${{ needs.nightly-acc-16-npu-a3.result }}"; do
+  #           suite="${entry%%:*}"
+  #           r="${entry##*:}"
+  #           echo "| ${suite} | $(group_icon ${r}) ${r} |" >> $GITHUB_STEP_SUMMARY
+  #         done
+  #         echo "| multi-node-poc | $(group_icon ${multi_result}) ${multi_result} |" >> $GITHUB_STEP_SUMMARY
+  #         echo "| multi-node-mix-poc | $(group_icon ${mix_result}) ${mix_result} |" >> $GITHUB_STEP_SUMMARY
+  #         echo "" >> $GITHUB_STEP_SUMMARY
+  #
+  #         echo "## Per-Test Metrics" >> $GITHUB_STEP_SUMMARY
+  #         echo "" >> $GITHUB_STEP_SUMMARY
+  #
+  #         has_metrics=false
+  #         # Each suite job uploads its METRICS_DATA_FILE directory, which
+  #         # contains per-case subdirectories with their own metrics.json.
+  #         # Recursively find every metrics.json and render one table row per
+  #         # test case.
+  #         for file in $(find /tmp/metrics -name metrics.json 2>/dev/null); do
+  #           if [ -f "$file" ]; then
+  #             has_metrics=true
+  #             echo "import json" > /tmp/parse_metrics.py
+  #             echo "with open('$file') as f:" >> /tmp/parse_metrics.py
+  #             echo "    d = json.load(f)" >> /tmp/parse_metrics.py
+  #             echo "tc = d.get('test_case', '-')" >> /tmp/parse_metrics.py
+  #             echo "tp = d.get('test_type', '-')" >> /tmp/parse_metrics.py
+  #             echo "st = d.get('status', 'unknown')" >> /tmp/parse_metrics.py
+  #             echo "icon = '✅' if st == 'pass' else '❌'" >> /tmp/parse_metrics.py
+  #             echo "metrics = d.get('metrics', {})" >> /tmp/parse_metrics.py
+  #             echo "baselines = d.get('baselines', {})" >> /tmp/parse_metrics.py
+  #             echo "mstr = ', '.join(f'{k}={v}' for k,v in metrics.items()) if metrics else '-'" >> /tmp/parse_metrics.py
+  #             echo "bstr = ', '.join(f'{k}={v}' for k,v in baselines.items()) if baselines else '-'" >> /tmp/parse_metrics.py
+  #             echo "print(f'| {tc} | {tp} | {icon} {st} | {mstr} | {bstr} |')" >> /tmp/parse_metrics.py
+  #             python3 /tmp/parse_metrics.py
+  #           fi
+  #         done > /tmp/metrics_table.txt
+  #
+  #         if [ "${has_metrics}" = "true" ]; then
+  #           echo "| Test Case | Type | Status | Metrics | Baseline |" >> $GITHUB_STEP_SUMMARY
+  #           echo "|-----------|------|--------|---------|----------|" >> $GITHUB_STEP_SUMMARY
+  #           cat /tmp/metrics_table.txt >> $GITHUB_STEP_SUMMARY
+  #         else
+  #           echo "No per-test metrics available (artifacts not found)." >> $GITHUB_STEP_SUMMARY
+  #         fi
+  #         echo "" >> $GITHUB_STEP_SUMMARY
+  #
+  #         FAIL=0
+  #         for r in "${single_result_a2}" "${single_result}" "${multi_result}" "${mix_result}"; do
+  #           if [ "${r}" != "success" ] && [ "${r}" != "skipped" ]; then FAIL=1; fi
+  #         done
+  #         exit $FAIL

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -106,6 +107,49 @@ def get_max_retries(datasets):
     return 1
 
 
+def _kill_evalscope_session(process):
+    """Kill the whole evalscope session (process.pid is the leader == pgid)."""
+    if process is None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+        logger.info(f"run_evalscope killed session pgid={process.pid}")
+    except ProcessLookupError:
+        logger.info(f"run_evalscope session pgid={process.pid} already gone")
+    except PermissionError:
+        logger.warning(
+            f"run_evalscope no permission to kill session pgid={process.pid}"
+        )
+
+    leftovers = []
+    for p in psutil.process_iter(["pid", "name", "cmdline"]):
+        try:
+            if p.pid == process.pid:
+                continue
+            if os.getpgid(p.pid) != process.pid:
+                continue
+            cmdline = " ".join(p.info["cmdline"] or [])
+            leftovers.append(
+                f"pid={p.pid} name={p.info['name']} cmdline={cmdline}"
+            )
+        except (
+            psutil.NoSuchProcess,
+            psutil.AccessDenied,
+            ProcessLookupError,
+            PermissionError,
+        ):
+            continue
+    if leftovers:
+        logger.warning(
+            f"run_evalscope session pgid={process.pid} leftovers: "
+            + "; ".join(leftovers)
+        )
+    else:
+        logger.info(
+            f"run_evalscope session pgid={process.pid} cleanup verified: no leftovers"
+        )
+
+
 def run_evalscope(
     host,
     port,
@@ -179,6 +223,12 @@ def run_evalscope(
         text=True,
         bufsize=1,
         shell=True,
+        start_new_session=True,
+    )
+
+    logger.info(
+        f"run_evalscope spawned: pid={process.pid} "
+        f"pgid={os.getpgid(process.pid)} cmd={cmd}"
     )
 
     output_lines = []
@@ -189,6 +239,13 @@ def run_evalscope(
             output_lines.append(line.strip())
 
         process.wait()
+
+        logger.info(
+            f"run_evalscope finished: pid={process.pid} "
+            f"returncode={process.returncode}"
+        )
+
+        _kill_evalscope_session(process)
 
         if process.returncode != 0:
             logger.error(f"Command failed with return code: {process.returncode}")
@@ -247,11 +304,13 @@ def run_evalscope(
             logger.warning("Process did not terminate gracefully, killing it...")
             process.kill()
             logger.info("Process killed")
+        _kill_evalscope_session(process)
         raise
     except Exception as e:
         logger.error(f"Error executing command: {e}")
         process.terminate()
         process.wait(timeout=5)
+        _kill_evalscope_session(process)
         raise
 
 
@@ -298,8 +357,14 @@ def _kill_forkserver_group():
             f"(pgid={pgid}), refusing to kill the parent suite"
         )
         return
-    logger.info(f"Cleaning up orphan forkserver processes in group pgid={pgid}")
-    for pid in psutil.pids():
+    all_pids = psutil.pids()
+    logger.info(
+        f"[forkserver-cleanup] start pgid={pgid} me={me} "
+        f"total_pids_scanned={len(all_pids)}"
+    )
+    killed = 0
+    still_parented = 0
+    for pid in all_pids:
         if pid == me:
             continue
         try:
@@ -308,9 +373,26 @@ def _kill_forkserver_group():
                 continue
             ppid = proc.ppid()
             if ppid != 1:
+                still_parented += 1
+                name = proc.name()
+                cmdline = " ".join(proc.cmdline())
+                if any(
+                    k in (name + " " + cmdline)
+                    for k in ("forkserver", "evalscope", "multiprocessing")
+                ):
+                    logger.info(
+                        f"[forkserver-cleanup] skip still-parented pid={pid} "
+                        f"ppid={ppid} name={name} cmdline={cmdline}"
+                    )
                 continue
-            logger.info(f"Killing leftover forkserver pid={pid} ppid={ppid} pgid={pgid}")
+            name = proc.name()
+            cmdline = " ".join(proc.cmdline())
+            logger.info(
+                f"Killing leftover forkserver pid={pid} ppid={ppid} pgid={pgid} "
+                f"name={name} cmdline={cmdline}"
+            )
             kill_process_tree(pid)
+            killed += 1
         except (
             psutil.NoSuchProcess,
             psutil.AccessDenied,
@@ -318,6 +400,9 @@ def _kill_forkserver_group():
             PermissionError,
         ):
             continue
+    logger.info(
+        f"[forkserver-cleanup] done killed={killed} still_parented={still_parented}"
+    )
 
 
 class TestNpuAccuracyTestCaseBase(CustomTestCase):
@@ -495,8 +580,6 @@ class TestNpuAccuracyTestCaseBase(CustomTestCase):
         cls._save_metrics_json()
         cls._backup_plog()
         try:
-            if cls.benchmark_tool == EVALSCOPE:
-                _kill_forkserver_group()
             if hasattr(cls, "process") and cls.process:
                 kill_process_tree(cls.process.pid)
         except Exception as e:
@@ -638,11 +721,7 @@ class TestNpuAccuracyMultiNodePdMixTestCaseBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        try:
-            if cls.benchmark_tool == EVALSCOPE:
-                _kill_forkserver_group()
-        except Exception as e:
-            logger.error(f"Error during tearDown: {e}")
+        pass
 
     @classmethod
     @check_role(allowed_roles=["master"])
@@ -753,8 +832,6 @@ class TestNpuAccuracyMultiNodePdSepTestCaseBase(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         try:
-            if cls.benchmark_tool == EVALSCOPE:
-                _kill_forkserver_group()
             if cls.process:
                 kill_process_tree(cls.process.pid)
         except Exception as e:

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -5,12 +5,15 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
 import time
 from datetime import datetime
 from urllib.parse import urlparse
+
+import psutil
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.e2e.test_npu_multi_node_utils import (
@@ -276,6 +279,51 @@ def assert_metrics(self, metrics):
         )
 
 
+def _kill_forkserver_group(orphans_only=False):
+    """Kill processes in the current process group except this process.
+
+    By default kills every process in the group (server and forkserver alike).
+    With orphans_only=True, only stray forkserver children reparented to PID 1,
+    together with their descendants, are killed; the directly spawned server is
+    left alive.
+    """
+    me = os.getpid()
+    try:
+        pgid = os.getpgid(me)
+    except ProcessLookupError:
+        logger.warning(f"Cannot resolve own process group for pid {me}")
+        return
+    if pgid != me:
+        logger.warning(
+            f"Skip process-group cleanup: pid {me} is not the group leader "
+            f"(pgid={pgid}), refusing to kill the parent suite"
+        )
+        return
+    logger.info(f"Cleaning up process group pgid={pgid}, orphans_only={orphans_only}")
+    for pid in psutil.pids():
+        if pid == me:
+            continue
+        try:
+            proc = psutil.Process(pid)
+            if proc.pgid() != pgid:
+                continue
+            ppid = proc.ppid()
+            if orphans_only and ppid != 1:
+                continue
+            logger.info(f"Killing leftover process pid={pid} ppid={ppid} pgid={pgid}")
+            if orphans_only:
+                kill_process_tree(pid)
+            else:
+                os.kill(pid, signal.SIGKILL)
+        except (
+            psutil.NoSuchProcess,
+            psutil.AccessDenied,
+            ProcessLookupError,
+            PermissionError,
+        ):
+            continue
+
+
 class TestNpuAccuracyTestCaseBase(CustomTestCase):
     model = None
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
@@ -422,6 +470,10 @@ class TestNpuAccuracyTestCaseBase(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
+        try:
+            os.setsid()
+        except OSError:
+            pass
         cls._setup_per_case_output()
         cls.base_url = DEFAULT_URL_FOR_TEST
         env = os.environ.copy()
@@ -444,13 +496,15 @@ class TestNpuAccuracyTestCaseBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if hasattr(cls, "process") and cls.process:
-            try:
-                kill_process_tree(cls.process.pid)
-            except Exception as e:
-                logger.error(f"Error during tearDown: {e}")
         cls._save_metrics_json()
         cls._backup_plog()
+        try:
+            if cls.benchmark_tool == EVALSCOPE:
+                _kill_forkserver_group()
+            elif hasattr(cls, "process") and cls.process:
+                kill_process_tree(cls.process.pid)
+        except Exception as e:
+            logger.error(f"Error during tearDown: {e}")
 
     def run_accuracy(self):
         parsed_url = urlparse(self.base_url)
@@ -571,6 +625,10 @@ class TestNpuAccuracyMultiNodePdMixTestCaseBase(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
+        try:
+            os.setsid()
+        except OSError:
+            pass
         cls.local_ip = "127.0.0.1"
         cls.host = os.getenv("POD_IP")
         cls.port = SERVICE_PORT
@@ -584,7 +642,11 @@ class TestNpuAccuracyMultiNodePdMixTestCaseBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        pass
+        try:
+            if cls.benchmark_tool == EVALSCOPE:
+                _kill_forkserver_group(orphans_only=True)
+        except Exception as e:
+            logger.error(f"Error during tearDown: {e}")
 
     @classmethod
     @check_role(allowed_roles=["master"])
@@ -672,6 +734,10 @@ class TestNpuAccuracyMultiNodePdSepTestCaseBase(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
+        try:
+            os.setsid()
+        except OSError:
+            pass
         cls.process = None
         cls.local_ip = "127.0.0.1"
         cls.host = os.getenv("POD_IP")
@@ -690,11 +756,13 @@ class TestNpuAccuracyMultiNodePdSepTestCaseBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        if cls.process:
-            try:
+        try:
+            if cls.benchmark_tool == EVALSCOPE:
+                _kill_forkserver_group()
+            elif cls.process:
                 kill_process_tree(cls.process.pid)
-            except Exception as e:
-                logger.error(f"Error during tearDown: {e}")
+        except Exception as e:
+            logger.error(f"Error during tearDown: {e}")
 
     @classmethod
     @check_role(allowed_roles=["router"])

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -13,8 +13,6 @@ import time
 from datetime import datetime
 from urllib.parse import urlparse
 
-import psutil
-
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.e2e.test_npu_multi_node_utils import (
     SERVICE_PORT,
@@ -119,34 +117,6 @@ def _kill_evalscope_session(process):
     except PermissionError:
         logger.warning(
             f"run_evalscope no permission to kill session pgid={process.pid}"
-        )
-
-    leftovers = []
-    for p in psutil.process_iter(["pid", "name", "cmdline"]):
-        try:
-            if p.pid == process.pid:
-                continue
-            if os.getpgid(p.pid) != process.pid:
-                continue
-            cmdline = " ".join(p.info["cmdline"] or [])
-            leftovers.append(
-                f"pid={p.pid} name={p.info['name']} cmdline={cmdline}"
-            )
-        except (
-            psutil.NoSuchProcess,
-            psutil.AccessDenied,
-            ProcessLookupError,
-            PermissionError,
-        ):
-            continue
-    if leftovers:
-        logger.warning(
-            f"run_evalscope session pgid={process.pid} leftovers: "
-            + "; ".join(leftovers)
-        )
-    else:
-        logger.info(
-            f"run_evalscope session pgid={process.pid} cleanup verified: no leftovers"
         )
 
 
@@ -263,12 +233,10 @@ def run_evalscope(
             try:
                 with open(report_path, "r") as rf:
                     report_data = json.load(rf)
-                for item in report_data:
-                    score = item.get("score")
-                    if score is not None:
-                        metrics["accuracy"] = float(score)
-                        logger.info(f"The Final Accuracy from report: {score}")
-                        break
+                score = report_data.get("score")
+                if score is not None:
+                    metrics["accuracy"] = float(score)
+                    logger.info(f"The Final Accuracy from report: {score}")
             except Exception as e:
                 logger.warning(f"Failed to read report file {report_path}: {e}")
 
@@ -306,6 +274,7 @@ def run_evalscope(
             logger.info("Process killed")
         _kill_evalscope_session(process)
         raise
+    
     except Exception as e:
         logger.error(f"Error executing command: {e}")
         process.terminate()
@@ -335,74 +304,6 @@ def assert_metrics(self, metrics):
             threshold,
             f"Accuracy check failed. Expected >= {threshold}, Got: {metrics['accuracy']}",
         )
-
-
-def _kill_forkserver_group():
-    """Kill orphan forkserver processes in the current process group.
-
-    Forkserver children spawned by the evalscope benchmark get reparented to PID 1
-    after their parent eval subprocess exits, but keep holding open pipe write
-    ends. Only these orphans and their descendants are killed here; the directly
-    spawned server process is left for `kill_process_tree` to clean up.
-    """
-    me = os.getpid()
-    try:
-        pgid = os.getpgid(me)
-    except ProcessLookupError:
-        logger.warning(f"Cannot resolve own process group for pid {me}")
-        return
-    if pgid != me:
-        logger.warning(
-            f"Skip process-group cleanup: pid {me} is not the group leader "
-            f"(pgid={pgid}), refusing to kill the parent suite"
-        )
-        return
-    all_pids = psutil.pids()
-    logger.info(
-        f"[forkserver-cleanup] start pgid={pgid} me={me} "
-        f"total_pids_scanned={len(all_pids)}"
-    )
-    killed = 0
-    still_parented = 0
-    for pid in all_pids:
-        if pid == me:
-            continue
-        try:
-            proc = psutil.Process(pid)
-            if os.getpgid(pid) != pgid:
-                continue
-            ppid = proc.ppid()
-            if ppid != 1:
-                still_parented += 1
-                name = proc.name()
-                cmdline = " ".join(proc.cmdline())
-                if any(
-                    k in (name + " " + cmdline)
-                    for k in ("forkserver", "evalscope", "multiprocessing")
-                ):
-                    logger.info(
-                        f"[forkserver-cleanup] skip still-parented pid={pid} "
-                        f"ppid={ppid} name={name} cmdline={cmdline}"
-                    )
-                continue
-            name = proc.name()
-            cmdline = " ".join(proc.cmdline())
-            logger.info(
-                f"Killing leftover forkserver pid={pid} ppid={ppid} pgid={pgid} "
-                f"name={name} cmdline={cmdline}"
-            )
-            kill_process_tree(pid)
-            killed += 1
-        except (
-            psutil.NoSuchProcess,
-            psutil.AccessDenied,
-            ProcessLookupError,
-            PermissionError,
-        ):
-            continue
-    logger.info(
-        f"[forkserver-cleanup] done killed={killed} still_parented={still_parented}"
-    )
 
 
 class TestNpuAccuracyTestCaseBase(CustomTestCase):
@@ -551,10 +452,6 @@ class TestNpuAccuracyTestCaseBase(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        try:
-            os.setsid()
-        except OSError:
-            pass
         cls._setup_per_case_output()
         cls.base_url = DEFAULT_URL_FOR_TEST
         env = os.environ.copy()
@@ -577,13 +474,13 @@ class TestNpuAccuracyTestCaseBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
+        if hasattr(cls, "process") and cls.process:
+            try:
+                kill_process_tree(cls.process.pid)
+            except Exception as e:
+                logger.error(f"Error during tearDown: {e}")
         cls._save_metrics_json()
         cls._backup_plog()
-        try:
-            if hasattr(cls, "process") and cls.process:
-                kill_process_tree(cls.process.pid)
-        except Exception as e:
-            logger.error(f"Error during tearDown: {e}")
 
     def run_accuracy(self):
         parsed_url = urlparse(self.base_url)
@@ -704,10 +601,6 @@ class TestNpuAccuracyMultiNodePdMixTestCaseBase(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        try:
-            os.setsid()
-        except OSError:
-            pass
         cls.local_ip = "127.0.0.1"
         cls.host = os.getenv("POD_IP")
         cls.port = SERVICE_PORT
@@ -809,10 +702,6 @@ class TestNpuAccuracyMultiNodePdSepTestCaseBase(CustomTestCase):
 
     @classmethod
     def setUpClass(cls):
-        try:
-            os.setsid()
-        except OSError:
-            pass
         cls.process = None
         cls.local_ip = "127.0.0.1"
         cls.host = os.getenv("POD_IP")
@@ -831,11 +720,11 @@ class TestNpuAccuracyMultiNodePdSepTestCaseBase(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        try:
-            if cls.process:
+        if cls.process:
+            try:
                 kill_process_tree(cls.process.pid)
-        except Exception as e:
-            logger.error(f"Error during tearDown: {e}")
+            except Exception as e:
+                logger.error(f"Error during tearDown: {e}")
 
     @classmethod
     @check_role(allowed_roles=["router"])

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -305,7 +305,7 @@ def _kill_forkserver_group(orphans_only=False):
             continue
         try:
             proc = psutil.Process(pid)
-            if proc.pgid() != pgid:
+            if os.getpgid(pid) != pgid:
                 continue
             ppid = proc.ppid()
             if orphans_only and ppid != 1:

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import threading
@@ -279,13 +278,13 @@ def assert_metrics(self, metrics):
         )
 
 
-def _kill_forkserver_group(orphans_only=False):
-    """Kill processes in the current process group except this process.
+def _kill_forkserver_group():
+    """Kill orphan forkserver processes in the current process group.
 
-    By default kills every process in the group (server and forkserver alike).
-    With orphans_only=True, only stray forkserver children reparented to PID 1,
-    together with their descendants, are killed; the directly spawned server is
-    left alive.
+    Forkserver children spawned by the evalscope benchmark get reparented to PID 1
+    after their parent eval subprocess exits, but keep holding open pipe write
+    ends. Only these orphans and their descendants are killed here; the directly
+    spawned server process is left for `kill_process_tree` to clean up.
     """
     me = os.getpid()
     try:
@@ -299,7 +298,7 @@ def _kill_forkserver_group(orphans_only=False):
             f"(pgid={pgid}), refusing to kill the parent suite"
         )
         return
-    logger.info(f"Cleaning up process group pgid={pgid}, orphans_only={orphans_only}")
+    logger.info(f"Cleaning up orphan forkserver processes in group pgid={pgid}")
     for pid in psutil.pids():
         if pid == me:
             continue
@@ -308,13 +307,10 @@ def _kill_forkserver_group(orphans_only=False):
             if os.getpgid(pid) != pgid:
                 continue
             ppid = proc.ppid()
-            if orphans_only and ppid != 1:
+            if ppid != 1:
                 continue
-            logger.info(f"Killing leftover process pid={pid} ppid={ppid} pgid={pgid}")
-            if orphans_only:
-                kill_process_tree(pid)
-            else:
-                os.kill(pid, signal.SIGKILL)
+            logger.info(f"Killing leftover forkserver pid={pid} ppid={ppid} pgid={pgid}")
+            kill_process_tree(pid)
         except (
             psutil.NoSuchProcess,
             psutil.AccessDenied,
@@ -501,7 +497,7 @@ class TestNpuAccuracyTestCaseBase(CustomTestCase):
         try:
             if cls.benchmark_tool == EVALSCOPE:
                 _kill_forkserver_group()
-            elif hasattr(cls, "process") and cls.process:
+            if hasattr(cls, "process") and cls.process:
                 kill_process_tree(cls.process.pid)
         except Exception as e:
             logger.error(f"Error during tearDown: {e}")
@@ -644,7 +640,7 @@ class TestNpuAccuracyMultiNodePdMixTestCaseBase(CustomTestCase):
     def tearDownClass(cls):
         try:
             if cls.benchmark_tool == EVALSCOPE:
-                _kill_forkserver_group(orphans_only=True)
+                _kill_forkserver_group()
         except Exception as e:
             logger.error(f"Error during tearDown: {e}")
 
@@ -759,7 +755,7 @@ class TestNpuAccuracyMultiNodePdSepTestCaseBase(CustomTestCase):
         try:
             if cls.benchmark_tool == EVALSCOPE:
                 _kill_forkserver_group()
-            elif cls.process:
+            if cls.process:
                 kill_process_tree(cls.process.pid)
         except Exception as e:
             logger.error(f"Error during tearDown: {e}")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On Ascend NPU, accuracy test cases that use the evalscope benchmark tool spawn a `forkserver` process for dataset preprocessing. When a test finishes, these forkserver processes can be reparented to PID 1 and become orphans that keep holding the write end of pipe file descriptors. During multi-process test runs this leaves the suite runner blocked on `stdout` waiting for EOF even after all test cases have completed.

This PR adds explicit cleanup of these leftover forkserver processes during test teardown, while preserving the directly spawned server in the mixed prefill/decode (PdMix) distributed scenario to avoid cross-node side effects.

## Modifications

- Add a `_kill_forkserver_group()` helper that terminates orphan forkserver processes (reparented to PID 1) together with their descendants in the current test process group.
  - It verifies the current process is the process-group leader before killing anything, so it never kills the parent suite process group.
  - Only stray forkserver children are killed; the directly spawned server is left for `kill_process_tree` to clean up.
- Call `os.setsid()` in `setUpClass` of the single-node, PdMix, and PdSep accuracy test base classes so each test process becomes its own process-group leader.
- Wire the cleanup into `tearDownClass` for all three scenarios; single-node and PdSep additionally kill the spawned server process tree via `kill_process_tree`.
- Restrict `nightly-test-npu.yml` to run only the accuracy test suites so the change can be validated in CI.

## Accuracy Tests

Not applicable. This change only affects test-process lifecycle management and CI workflow configuration; it does not touch model or inference code.

## Speed Tests and Profiling

Not applicable. No change to inference speed.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32575971342](https://github.com/sgl-project/sglang/actions/runs/32575971342)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32575971247](https://github.com/sgl-project/sglang/actions/runs/32575971247)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32575971364](https://github.com/sgl-project/sglang/actions/runs/32575971364)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->