### PR TITLE
[diffusion][Minimax-h3] Fix:   read LoRA alpha from the adapter's safetensors header

### DIFF
--- a/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/lora/pipeline.py
@@ -9,7 +9,7 @@ from typing import Any
 
 import torch
 import torch.distributed as dist
-from safetensors.torch import load_file
+from safetensors.torch import load_file, safe_open
 from torch.distributed.tensor import DTensor
 
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
@@ -57,6 +57,30 @@ def _swap_peft_swiglu_fc1_lora_b(
         return weight
     value, gate = weight.chunk(2, dim=0)
     return torch.cat([gate, value], dim=0)
+
+
+def _lora_alpha_from_safetensors_header(lora_local_path: str) -> int | None:
+    # load_file drops the header's __metadata__, so alpha is only reachable by
+    # reopening the file. A header is not a config file: it cannot fail a load.
+    if not lora_local_path.endswith(".safetensors"):
+        return None
+    with safe_open(lora_local_path, framework="pt") as adapter_file:
+        metadata = adapter_file.metadata() or {}
+    alpha = metadata.get("alpha")
+    if alpha is None:
+        return None
+    try:
+        parsed_alpha = float(alpha)
+    except ValueError:
+        parsed_alpha = 0.0
+    if parsed_alpha <= 0.0 or not parsed_alpha.is_integer():
+        logger.warning(
+            "Ignoring unusable LoRA alpha %r in %s",
+            alpha,
+            os.path.basename(lora_local_path),
+        )
+        return None
+    return int(parsed_alpha)
 
 
 def stack_or_compose_fused_lora(
@@ -844,6 +868,8 @@ class LoRAPipeline(ComposedPipelineBase):
         adapter_lora_alpha = lora_alpha
         if adapter_lora_alpha is None:
             adapter_lora_alpha = get_peft_lora_alpha(adapter_config)
+        if adapter_lora_alpha is None:
+            adapter_lora_alpha = _lora_alpha_from_safetensors_header(lora_local_path)
 
         if lora_nickname in self.lora_adapters:
             self.lora_adapters[lora_nickname].clear()

--- a/python/sglang/multimodal_gen/test/unit/test_lora_alpha_metadata.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lora_alpha_metadata.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Alpha resolution for adapters that carry it in the safetensors header.
+
+An adapter published as a loose `.safetensors` file has no sibling
+`adapter_config.json` and no per-layer `.alpha` tensors, so alpha falls back to
+rank. For a distilled adapter trained at alpha 8 with rank 128 that scales the
+delta 16x while still loading and generating.
+"""
+
+import torch
+from safetensors.torch import save_file
+
+from sglang.multimodal_gen.runtime.pipelines_core.lora.pipeline import (
+    _lora_alpha_from_safetensors_header,
+)
+
+
+def _write_adapter(path, metadata=None):
+    save_file({"blocks.0.attn.qkv_proj.lora_A": torch.zeros(2, 2)}, path, metadata)
+    return str(path)
+
+
+def test_alpha_is_read_from_the_safetensors_header(tmp_path):
+    path = _write_adapter(tmp_path / "turbo.safetensors", {"alpha": "8"})
+    assert _lora_alpha_from_safetensors_header(path) == 8
+
+
+def test_published_h3_turbo_alphas_are_per_checkpoint(tmp_path):
+    """lightx2v/Minimax-h3-Turbo ships alpha 8 and alpha 128 side by side.
+
+    Both are rank 128, so no repo-level default can serve them: the ref2v and
+    8-step adapters want scale 8/128 while the 768p ones want scale 1.
+    """
+    for alpha in ("8", "128"):
+        path = _write_adapter(tmp_path / f"turbo_{alpha}.safetensors", {"alpha": alpha})
+        assert _lora_alpha_from_safetensors_header(path) == int(alpha)
+
+
+def test_float_spelled_alpha_is_accepted(tmp_path):
+    path = _write_adapter(tmp_path / "float.safetensors", {"alpha": "8.0"})
+    assert _lora_alpha_from_safetensors_header(path) == 8
+
+
+def test_header_without_alpha_defers_to_the_caller(tmp_path):
+    path = _write_adapter(tmp_path / "bare.safetensors", {"format": "pt"})
+    assert _lora_alpha_from_safetensors_header(path) is None
+    path = _write_adapter(tmp_path / "nometa.safetensors")
+    assert _lora_alpha_from_safetensors_header(path) is None
+
+
+def test_unusable_alpha_defers_instead_of_raising(tmp_path):
+    for spelling in ("", "none", "0", "-8", "8.5"):
+        path = _write_adapter(tmp_path / "bad.safetensors", {"alpha": spelling})
+        assert _lora_alpha_from_safetensors_header(path) is None
+
+
+def test_non_safetensors_adapter_is_not_probed(tmp_path):
+    """`.bin` adapters are still accepted by the loader and have no header."""
+    path = tmp_path / "adapter.bin"
+    path.write_bytes(b"not safetensors")
+    assert _lora_alpha_from_safetensors_header(str(path)) is None


### PR DESCRIPTION


## Motivation

LoRA alpha is resolved from `--lora-alpha`, then a sibling `adapter_config.json`,
then per-layer `<layer>.alpha` tensors, and falls back to rank when none of them
carry it. An adapter published as a single `.safetensors` file has none of the
three, so its trained alpha is unreachable even though the file records it in the
safetensors header.

This is the default path rather than an unusual one: it happens whenever an
adapter is served with `--lora-path` alone. Passing `--lora-alpha` avoids it, and
so does any adapter whose trained alpha equals its rank.

`lightx2v/Minimax-h3-Turbo` publishes five rank-128 adapters with no
`adapter_config.json`, no per-layer `.alpha`, and headers that disagree:

| adapter | header `alpha` | resolved today | scale |
| --- | ---: | ---: | ---: |
| `ref2v_turbo_4step_v0.1_bf16` | 8 | 128 | 1.0 |
| `fl2v_turbo_8step_v1.0_bf16` | 8 | 128 | 1.0 |
| `fl2v_turbo_4step_v1.0_768p_bf16` | 128 | 128 | 1.0 |
| `fl2v_turbo_4step_v1.1_768p_bf16` | 128 | 128 | 1.0 |
| `fl2v_turbo_4step_v0.1` | absent | 128 | 1.0 |

The two alpha-8 adapters run a 16x delta, and nothing reports it: the adapter
loads, covers 208 of 266 wrapped layers, and generates.

#34359 documented this same 16x and addressed it by adding `--lora-alpha`. That
works, but it asks the operator to supply per file a number the checkpoint
already carries, with no error when the number is wrong. Reading the header makes
the two alpha-8 adapters correct by default and changes nothing for the two
alpha-128 ones, since 128 == rank is what they already resolve to. The adapter
that records no alpha still falls back to rank.

`load_file` returns tensors only and discards the header's `__metadata__`, so
reaching the value needs `safe_open`.

## Modifications

`_lora_alpha_from_safetensors_header` reopens the selected weight file with
`safe_open` and reads `alpha` from the header. It is consulted last, after
`--lora-alpha` and after `adapter_config.json`, so any deployment that resolves
alpha today keeps resolving it from the same source. Per-layer `.alpha` tensors
still win at apply time.

Header values are strings. A missing, unparsable, non-positive, or non-integer
value is logged and ignored rather than raised, since a header is not a config
file and should not be able to fail a load. Non-`.safetensors` paths are not
probed. The integer requirement matches `get_peft_lora_alpha`.

Tests write real adapters with `save_file(..., metadata=...)` instead of mocking
the reader: header alpha, two checkpoints in one directory resolving to 8 and
128, a float-spelled `"8.0"`, a header with no alpha, the unusable spellings
(`""`, `"none"`, `"0"`, `"-8"`, `"8.5"`), and a `.bin` adapter left alone.

## Accuracy Tests

8x RTX 5090, TP 8, layerwise offload, MiniMax-H3 `ref2va` with
`minimax_h3_ref2v_turbo_4step_v0.1_bf16.safetensors` (sha256
`9e642fc8749c74f8da5e2382877ab5c7aa37b9a73b7fd0d6d457bd1b3cb1ae99`, matching the
Hub LFS oid), one image reference condition, 1344x768, 4 s,
`num_inference_steps=5`, `seed=1234`, identical prompt.

| run | alpha source | resolved | scale | bytes | md5 |
| --- | --- | ---: | ---: | ---: | --- |
| A | none (falls back to rank) | 128 | 1.0 | 1499254 | `719ebb00...` |
| A2 | replay of A | 128 | 1.0 | 1499255 | `3609b025...` |
| C | `--lora-alpha 8` | 8 | 0.0625 | 731983 | `e71a2075...` |
| B | header, this PR | 8 | 0.0625 | 731983 | `e71a2075...` |

A2 replays A against the same server and sets the floor: decoded video frames are
bit-identical (PSNR inf, MAE 0.0000/255), while the container differs by one byte
and audio by MAE 0.000695. Video comparison is therefore meaningful here.

- **B vs C**: PSNR inf, video MAE 0.0000/255, audio MAE 0.000000, md5 identical.
  Reading the header reproduces the `--lora-alpha 8` result exactly.
- **B vs A**: PSNR 13.76 dB, video MAE 42.9857/255, max 185.0/255, 99.41% of
  pixels differ, audio MAE 0.025081.

The 16x run is also the larger file, 1499254 against 731983 bytes, while carrying
far less pixel contrast (std 8.42 against 52.17): flatter and higher-entropy, as
an overdriven delta would be.


https://github.com/user-attachments/assets/f5e426d4-b04f-41f8-874d-ba60f45ec29c



6 unit tests pass.

## Speed Tests and Profiling

None. One additional header read per adapter at load time; the forward path is
untouched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

No document states the alpha resolution order, and behaviour is unchanged when
alpha is already resolvable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32555885902](https://github.com/sgl-project/sglang/actions/runs/32555885902)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32555885762](https://github.com/sgl-project/sglang/actions/runs/32555885762)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32555886140](https://github.com/sgl-project/sglang/actions/runs/32555886140)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->