### PR TITLE
Batch DFlash/DSpark replacement prefills using observed request demand

### DIFF
--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -93,10 +93,12 @@ def run_resolution_pipeline(server_args: Any) -> None:
     handle_hicache_ratio_default(server_args)
     from sglang.srt.arg_groups.validation_hook import (
         validate_experimental_sgl_marlin,
+        validate_min_free_slots_max_delay_passes,
         validate_prefill_decode_interval,
     )
 
     validate_prefill_decode_interval(server_args)
+    validate_min_free_slots_max_delay_passes(server_args)
 
     # Reject an explicitly enabled but incompatible hardware runtime before
     # model path resolution, downloads, or the dummy-model short circuit.

--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -413,6 +413,15 @@ def validate_experimental_sgl_marlin(server_args: Any):
     validate_experimental_sgl_marlin_server_args(server_args, view)
 
 
+def validate_min_free_slots_max_delay_passes(server_args: Any):
+    cfg = resolving_view(server_args)
+    if (
+        cfg.min_free_slots_max_delay_passes is not None
+        and cfg.min_free_slots_max_delay_passes < 0
+    ):
+        raise ValueError("--min-free-slots-max-delay-passes must be non-negative.")
+
+
 def validate_prefill_decode_interval(server_args: Any):
     cfg = resolving_view(server_args)
     if cfg.prefill_decode_interval < 0:

--- a/python/sglang/srt/managers/min_free_slots_delayer.py
+++ b/python/sglang/srt/managers/min_free_slots_delayer.py
@@ -1,6 +1,14 @@
 from typing import Optional
 
 
+def resolve_auto_min_free_slots(request_target: int) -> Optional[int]:
+    """Scale a refill threshold from the observed request target."""
+    request_target = max(0, int(request_target))
+    if request_target < 8:
+        return None
+    return min(4, max(2, (request_target + 5) // 6))
+
+
 def resolve_min_free_slots(
     user_value: Optional[int],
     max_running_requests: int,
@@ -9,30 +17,142 @@ def resolve_min_free_slots(
     """Resolve the min-free-slots threshold (None = disabled).
 
     An explicit user value always wins, capped by max_running_requests
-    (<= 1 disables). When unset, DFlash workloads fall back to the legacy
-    formula (preserving the always-on behavior, disabled when
-    max_running_requests < 8); other workloads stay disabled.
+    (<= 1 disables). When unset, configured DFlash capacity decides whether the
+    delay is enabled; the effective automatic threshold is rescaled per pass
+    from observed request demand. Other workloads stay disabled.
     """
     max_running_requests = max(0, int(max_running_requests))
     if user_value is not None:
         threshold = min(user_value, max_running_requests)
         return threshold if threshold > 1 else None
-    if is_dflash_family and max_running_requests >= 8:
-        return min(4, max(2, (max_running_requests + 5) // 6))
+    if is_dflash_family:
+        return resolve_auto_min_free_slots(max_running_requests)
     return None
 
 
 class MinFreeSlotsDelayer:
-    """Delay fresh prefill admissions until at least ``min_free_slots`` running-
-    request slots free up, batching them into one admission instead of one at a
-    time. Useful when each admission is expensive (e.g. DFlash's draft prefill).
+    """Batch replacement prefills after enough active requests complete.
+
+    ``num_allocatable_reqs`` includes request-pool capacity that may never have
+    been occupied. Counting it directly makes the delay ineffective whenever
+    configured capacity is larger than workload concurrency. Track the request
+    target established by actual admissions instead, while allowing a growing
+    workload to use idle capacity immediately. Unless explicitly overridden,
+    that observed target also bounds the delay in scheduler passes.
 
     Per-rank local: running-batch slots are private to each DP rank, so a rank
     with free slots does not wait for a congested peer.
     """
 
-    def __init__(self, min_free_slots: int):
+    def __init__(
+        self,
+        min_free_slots: int,
+        *,
+        scale_with_observed_target: bool = False,
+        max_delay_passes: Optional[int] = None,
+    ):
+        if max_delay_passes is not None and max_delay_passes < 0:
+            raise ValueError("max_delay_passes must be non-negative")
         self._min_free_slots = min_free_slots
+        self._scale_with_observed_target = scale_with_observed_target
+        self._max_delay_passes = max_delay_passes
+        self._delay_passes = 0
+        self._target_running_bs = 0
 
-    def should_delay(self, *, running_bs: int, num_allocatable_reqs: int) -> bool:
-        return running_bs > 0 and num_allocatable_reqs < self._min_free_slots
+    def should_delay(
+        self,
+        *,
+        running_bs: int,
+        num_allocatable_reqs: int,
+        waiting_bs: int,
+        active_running_bs: Optional[int] = None,
+    ) -> bool:
+        """Return whether this prefill attempt should wait for a larger batch.
+
+        ``running_bs`` is raw scheduler occupancy, including requests that
+        finished since the last decode update. ``active_running_bs`` excludes
+        those finished requests. The former determines which slots are already
+        reusable; the latter distinguishes replacements from real demand
+        growth. Callers without deferred completion state may omit the latter.
+        """
+        running_bs = max(0, int(running_bs))
+        if running_bs == 0:
+            self._target_running_bs = 0
+            self._delay_passes = 0
+            return False
+
+        if active_running_bs is None:
+            active_running_bs = running_bs
+        active_running_bs = min(running_bs, max(0, int(active_running_bs)))
+        self._target_running_bs = max(self._target_running_bs, active_running_bs)
+        waiting_bs = max(0, int(waiting_bs))
+        if waiting_bs == 0:
+            self._delay_passes = 0
+            return False
+        refillable_bs = min(max(0, int(num_allocatable_reqs)), waiting_bs)
+        if refillable_bs == 0:
+            # No admission is possible on this pass. Preserve a finite delay
+            # budget so an alternating capacity signal cannot restart it.
+            return False
+
+        active_demand = active_running_bs + refillable_bs
+        if active_demand > self._target_running_bs:
+            # Do not delay a real increase in workload concurrency.
+            self._delay_passes = 0
+            return False
+
+        min_free_slots = self._resolve_threshold()
+        if min_free_slots is None:
+            self._delay_passes = 0
+            return False
+
+        # Adapt after a real workload contraction without mistaking a staggered
+        # replacement for a lower target. Equality proves that the decode update
+        # already removed finished requests; the threshold-sized hysteresis
+        # leaves one refill batch of room for replacements still in transit.
+        if (
+            running_bs == active_running_bs
+            and self._target_running_bs - active_demand >= min_free_slots
+        ):
+            self._target_running_bs = active_demand
+            self._delay_passes = 0
+            # The waiting work is genuine demand relative to the contracted
+            # target. Admit it now instead of immediately delaying against the
+            # target that this pass just established.
+            return False
+
+        # Finished requests remain in the raw running batch until the next
+        # decode update filters them. Do not treat those slots as reusable yet:
+        # delaying this pass lets filtering happen and gives replacement
+        # requests a chance to accumulate into one prefill batch.
+        num_freed_slots = max(0, self._target_running_bs - running_bs)
+        if num_freed_slots >= min_free_slots:
+            self._delay_passes = 0
+            return False
+        max_delay_passes = (
+            self._target_running_bs
+            if self._max_delay_passes is None
+            else self._max_delay_passes
+        )
+        if self._delay_passes >= max_delay_passes:
+            self._delay_passes = 0
+            return False
+
+        self._delay_passes += 1
+        return True
+
+    def _resolve_threshold(self) -> Optional[int]:
+        if self._scale_with_observed_target:
+            # The constructor threshold enabled automatic batching from
+            # configured capacity; observed demand owns the per-pass value.
+            return resolve_auto_min_free_slots(self._target_running_bs)
+        threshold = min(self._min_free_slots, self._target_running_bs)
+        return threshold if threshold > 1 else None
+
+    def on_prefill_admitted(self, *, active_running_bs: int, admitted_bs: int) -> None:
+        """Record the request target established by an actual prefill batch."""
+        self._target_running_bs = max(
+            self._target_running_bs,
+            max(0, int(active_running_bs)) + max(0, int(admitted_bs)),
+        )
+        self._delay_passes = 0

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1167,7 +1167,11 @@ class Scheduler(
         )
         if min_free_slots is not None:
             self.min_free_slots_delayer = MinFreeSlotsDelayer(
-                min_free_slots=min_free_slots
+                min_free_slots=min_free_slots,
+                scale_with_observed_target=(
+                    get_schedule().min_free_slots_delay is None
+                ),
+                max_delay_passes=get_schedule().min_free_slots_max_delay_passes,
             )
         if not get_parallel().pp_max_micro_batch_size:
             get_context().override(
@@ -3697,18 +3701,25 @@ class Scheduler(
             return None, running_batch
 
         running_bs = len(running_batch.reqs)
-        # Skipped during a chunked prefill: that pass must proceed regardless.
-        if (
+        track_min_free_slots_admission = (
             self.min_free_slots_delayer is not None
             and self.chunked_req is None
-            and self.min_free_slots_delayer.should_delay(
+            and not running_batch.is_prefill_only
+            and not self.enable_priority_preemption
+        )
+        # Chunked prefills must proceed, and priority preemption must inspect the
+        # queue before any refill-batching delay can hold an admission.
+        if track_min_free_slots_admission:
+            active_running_bs = sum(not req.finished() for req in running_batch.reqs)
+            if self.min_free_slots_delayer.should_delay(
                 running_bs=running_bs,
+                active_running_bs=active_running_bs,
                 num_allocatable_reqs=self.get_num_allocatable_reqs(
                     running_bs, running_batch=running_batch
                 ),
-            )
-        ):
-            return None, running_batch
+                waiting_bs=len(self.waiting_queue),
+            ):
+                return None, running_batch
 
         # Ignore the check if self.chunked_req is not None.
         # In the non-PP case, when self.chunked_req is not None, num_allocatable_reqs should always be greater than 0,
@@ -3903,6 +3914,12 @@ class Scheduler(
         can_run_list: List[Req] = adder.can_run_list
         if len(can_run_list) == 0:
             return None, running_batch
+
+        if track_min_free_slots_admission:
+            self.min_free_slots_delayer.on_prefill_admitted(
+                active_running_bs=sum(not req.finished() for req in running_batch.reqs),
+                admitted_bs=len(can_run_list),
+            )
 
         can_run_set = set(can_run_list)
         self.waiting_queue = [x for x in self.waiting_queue if x not in can_run_set]

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3508,9 +3508,21 @@ class ServerArgs:
             "Useful when each admission is disproportionately expensive, e.g. "
             "speculative decoding with a separate draft prefill pass. An "
             "explicit value always wins, capped by max-running-requests "
-            "(1 disables). When unset, DFlash workloads auto-enable the "
-            "formula; other workloads stay disabled. Not supported with "
-            "pipeline parallelism."
+            "(1 disables). When unset, DFlash workloads scale the formula "
+            "from active request demand; other workloads stay disabled. Not "
+            "supported with pipeline parallelism; bypassed when priority "
+            "preemption is enabled."
+        ),
+        NS("schedule"),
+    ] = None
+    min_free_slots_max_delay_passes: A[
+        Optional[int],
+        (
+            "Maximum scheduler passes to wait while accumulating the "
+            "requested free slots. Unset waits at most the observed running-"
+            "request target in scheduler passes; 0 disables waiting. Only "
+            "applies when the min-free-slots delay is explicitly or "
+            "automatically enabled."
         ),
         NS("schedule"),
     ] = None

--- a/test/registered/scheduler/test_min_free_slots_delayer.py
+++ b/test/registered/scheduler/test_min_free_slots_delayer.py
@@ -2,6 +2,7 @@ import unittest
 
 from sglang.srt.managers.min_free_slots_delayer import (
     MinFreeSlotsDelayer,
+    resolve_auto_min_free_slots,
     resolve_min_free_slots,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -10,6 +11,15 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestResolveMinFreeSlots(unittest.TestCase):
+    def test_auto_formula_scales_with_request_target(self):
+        self.assertIsNone(resolve_auto_min_free_slots(0))
+        self.assertIsNone(resolve_auto_min_free_slots(7))
+        self.assertEqual(resolve_auto_min_free_slots(8), 2)
+        self.assertEqual(resolve_auto_min_free_slots(12), 2)
+        self.assertEqual(resolve_auto_min_free_slots(13), 3)
+        self.assertEqual(resolve_auto_min_free_slots(24), 4)
+        self.assertEqual(resolve_auto_min_free_slots(512), 4)
+
     def test_unset_non_dflash_disables(self):
         self.assertIsNone(resolve_min_free_slots(None, 512, is_dflash_family=False))
 
@@ -51,17 +61,409 @@ class TestResolveMinFreeSlots(unittest.TestCase):
 class TestMinFreeSlotsDelayer(unittest.TestCase):
     def test_delays_below_threshold(self):
         delayer = MinFreeSlotsDelayer(min_free_slots=4)
-        self.assertTrue(delayer.should_delay(running_bs=100, num_allocatable_reqs=2))
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=100)
+        self.assertTrue(
+            delayer.should_delay(running_bs=98, num_allocatable_reqs=414, waiting_bs=2)
+        )
 
     def test_no_delay_at_or_above_threshold(self):
         delayer = MinFreeSlotsDelayer(min_free_slots=4)
-        self.assertFalse(delayer.should_delay(running_bs=100, num_allocatable_reqs=4))
-        self.assertFalse(delayer.should_delay(running_bs=100, num_allocatable_reqs=8))
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=100)
+        self.assertFalse(
+            delayer.should_delay(running_bs=96, num_allocatable_reqs=416, waiting_bs=4)
+        )
 
     def test_no_delay_when_idle(self):
         # Nothing running: no decode batch to protect, prefill at once.
         delayer = MinFreeSlotsDelayer(min_free_slots=4)
-        self.assertFalse(delayer.should_delay(running_bs=0, num_allocatable_reqs=0))
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+        self.assertFalse(
+            delayer.should_delay(running_bs=0, num_allocatable_reqs=48, waiting_bs=8)
+        )
+        self.assertEqual(delayer._target_running_bs, 0)
+
+    def test_explicit_threshold_does_not_delay_single_request_workload(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=1)
+
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=1,
+                active_running_bs=0,
+                num_allocatable_reqs=47,
+                waiting_bs=1,
+            )
+        )
+
+    def test_unused_request_capacity_does_not_count_as_freed_slots(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=6, num_allocatable_reqs=42, waiting_bs=2)
+        )
+
+    def test_workload_growth_is_admitted_immediately(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertFalse(
+            delayer.should_delay(running_bs=8, num_allocatable_reqs=40, waiting_bs=1)
+        )
+
+    def test_replacement_plus_growth_is_admitted_immediately(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=8,
+                active_running_bs=7,
+                num_allocatable_reqs=40,
+                waiting_bs=2,
+            )
+        )
+
+    def test_actual_admission_resets_request_target(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+        self.assertFalse(
+            delayer.should_delay(running_bs=6, num_allocatable_reqs=42, waiting_bs=2)
+        )
+
+        delayer.on_prefill_admitted(active_running_bs=6, admitted_bs=2)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+    def test_auto_threshold_scales_with_observed_target(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=6, num_allocatable_reqs=42, waiting_bs=2)
+        )
+
+    def test_auto_incomplete_refill_waits_for_nearby_completion(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        for _ in range(4):
+            self.assertTrue(
+                delayer.should_delay(
+                    running_bs=7, num_allocatable_reqs=41, waiting_bs=1
+                )
+            )
+        self.assertFalse(
+            delayer.should_delay(running_bs=6, num_allocatable_reqs=42, waiting_bs=2)
+        )
+
+    def test_auto_incomplete_refill_has_observed_target_deadline(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        for _ in range(8):
+            self.assertTrue(
+                delayer.should_delay(
+                    running_bs=7, num_allocatable_reqs=41, waiting_bs=1
+                )
+            )
+        self.assertFalse(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+    def test_explicit_threshold_uses_observed_target_deadline_by_default(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=4)
+
+        for _ in range(4):
+            self.assertTrue(
+                delayer.should_delay(
+                    running_bs=3, num_allocatable_reqs=45, waiting_bs=1
+                )
+            )
+        self.assertFalse(
+            delayer.should_delay(running_bs=3, num_allocatable_reqs=45, waiting_bs=1)
+        )
+
+    def test_explicit_max_delay_overrides_automatic_deadline(self):
+        delayer = MinFreeSlotsDelayer(
+            min_free_slots=4,
+            scale_with_observed_target=True,
+            max_delay_passes=2,
+        )
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+    def test_finished_requests_do_not_count_as_reusable_slots(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertTrue(
+            delayer.should_delay(
+                running_bs=8,
+                active_running_bs=6,
+                num_allocatable_reqs=40,
+                waiting_bs=1,
+            )
+        )
+
+    def test_filtered_slots_release_at_the_threshold(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=6,
+                active_running_bs=6,
+                num_allocatable_reqs=42,
+                waiting_bs=2,
+            )
+        )
+
+    def test_partial_refill_does_not_lower_established_target(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+        delayer.on_prefill_admitted(active_running_bs=6, admitted_bs=1)
+
+        self.assertTrue(
+            delayer.should_delay(
+                running_bs=7,
+                active_running_bs=7,
+                num_allocatable_reqs=41,
+                waiting_bs=1,
+            )
+        )
+
+    def test_target_adapts_after_large_workload_contraction(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=32)
+
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=8,
+                active_running_bs=8,
+                num_allocatable_reqs=40,
+                waiting_bs=1,
+            )
+        )
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=7,
+                active_running_bs=7,
+                num_allocatable_reqs=41,
+                waiting_bs=2,
+            )
+        )
+
+    def test_unfiltered_completions_do_not_trigger_target_contraction(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=32)
+
+        self.assertTrue(
+            delayer.should_delay(
+                running_bs=32,
+                active_running_bs=8,
+                num_allocatable_reqs=16,
+                waiting_bs=1,
+            )
+        )
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=8,
+                active_running_bs=8,
+                num_allocatable_reqs=40,
+                waiting_bs=1,
+            )
+        )
+
+    def test_new_demand_after_quiesced_burst_is_admitted_immediately(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=512)
+
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=20,
+                active_running_bs=20,
+                num_allocatable_reqs=492,
+                waiting_bs=1,
+            )
+        )
+
+    def test_unused_capacity_does_not_change_decision(self):
+        small_pool = MinFreeSlotsDelayer(min_free_slots=2)
+        large_pool = MinFreeSlotsDelayer(min_free_slots=2)
+        for delayer in (small_pool, large_pool):
+            delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertEqual(
+            small_pool.should_delay(running_bs=7, num_allocatable_reqs=1, waiting_bs=1),
+            large_pool.should_delay(
+                running_bs=7, num_allocatable_reqs=505, waiting_bs=1
+            ),
+        )
+
+    def test_auto_threshold_uses_larger_active_batch_formula(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=16)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=14, num_allocatable_reqs=34, waiting_bs=2)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=13, num_allocatable_reqs=35, waiting_bs=3)
+        )
+
+    def test_auto_threshold_is_shape_independent(self):
+        for target in (8, 12, 13, 24, 48, 128):
+            with self.subTest(target=target):
+                threshold = resolve_auto_min_free_slots(target)
+                assert threshold is not None
+                delayer = MinFreeSlotsDelayer(
+                    min_free_slots=4, scale_with_observed_target=True
+                )
+                delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=target)
+
+                self.assertTrue(
+                    delayer.should_delay(
+                        running_bs=target - threshold + 1,
+                        num_allocatable_reqs=512,
+                        waiting_bs=1,
+                    )
+                )
+                self.assertFalse(
+                    delayer.should_delay(
+                        running_bs=target - threshold,
+                        num_allocatable_reqs=512,
+                        waiting_bs=threshold,
+                    )
+                )
+
+    def test_staggered_closed_loop_refill_sequence(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=4, scale_with_observed_target=True)
+
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=1)
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=1,
+                active_running_bs=1,
+                num_allocatable_reqs=47,
+                waiting_bs=7,
+            )
+        )
+        delayer.on_prefill_admitted(active_running_bs=1, admitted_bs=7)
+
+        self.assertTrue(
+            delayer.should_delay(
+                running_bs=8,
+                active_running_bs=6,
+                num_allocatable_reqs=40,
+                waiting_bs=1,
+            )
+        )
+        self.assertFalse(
+            delayer.should_delay(
+                running_bs=6,
+                active_running_bs=6,
+                num_allocatable_reqs=42,
+                waiting_bs=2,
+            )
+        )
+        delayer.on_prefill_admitted(active_running_bs=6, admitted_bs=2)
+
+        self.assertTrue(
+            delayer.should_delay(
+                running_bs=7,
+                active_running_bs=7,
+                num_allocatable_reqs=41,
+                waiting_bs=1,
+            )
+        )
+
+    def test_max_delay_passes_releases_an_incomplete_refill(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2, max_delay_passes=1)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+    def test_admission_resets_max_delay_passes(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2, max_delay_passes=1)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+        delayer.on_prefill_admitted(active_running_bs=7, admitted_bs=1)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+    def test_unavailable_capacity_does_not_reset_max_delay_passes(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2, max_delay_passes=2)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=8, num_allocatable_reqs=0, waiting_bs=1)
+        )
+        self.assertTrue(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+        self.assertFalse(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+    def test_active_running_count_is_clamped_to_raw_occupancy(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertTrue(
+            delayer.should_delay(
+                running_bs=7,
+                active_running_bs=100,
+                num_allocatable_reqs=41,
+                waiting_bs=1,
+            )
+        )
+
+    def test_zero_max_delay_passes_disables_waiting(self):
+        delayer = MinFreeSlotsDelayer(min_free_slots=2, max_delay_passes=0)
+        delayer.on_prefill_admitted(active_running_bs=0, admitted_bs=8)
+
+        self.assertFalse(
+            delayer.should_delay(running_bs=7, num_allocatable_reqs=41, waiting_bs=1)
+        )
+
+    def test_negative_max_delay_passes_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be non-negative"):
+            MinFreeSlotsDelayer(min_free_slots=2, max_delay_passes=-1)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -163,6 +163,19 @@ class TestPrepareServerArgs(CustomTestCase):
         ):
             ServerArgs(model_path="dummy", prefill_decode_interval=-1).resolve_once()
 
+    def test_min_free_slots_max_delay_passes(self):
+        args = ServerArgs(model_path="dummy", min_free_slots_max_delay_passes=1)
+        args.resolve_once()
+        self.assertEqual(resolution_result(args, "min_free_slots_max_delay_passes"), 1)
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "--min-free-slots-max-delay-passes must be non-negative",
+        ):
+            ServerArgs(
+                model_path="dummy", min_free_slots_max_delay_passes=-1
+            ).resolve_once()
+
     def test_dsv4_prefill_backend_cli_choices(self):
         parser = server_args_module.argparse.ArgumentParser()
         ServerArgs.add_cli_args(parser)


### PR DESCRIPTION
## Motivation

DFlash/DSpark automatically delays replacement-prefill admission so completed requests can be replaced in batches. The existing decision compares a threshold derived from `--max-running-requests` with all allocatable request-pool slots. Those slots include capacity that the workload never occupied. When workload concurrency is below the configured limit, the unused capacity satisfies the free-slot threshold immediately, so replacements are admitted one at a time and each admission can run a separate draft-prefill pass.

## Modifications

- Track a per-rank request target established by actual admissions and observed active requests, and use that target, rather than unused configured capacity, to decide when a replacement batch is ready.
- Scale the automatic threshold from observed demand: automatic batching stays off until the observed target reaches 8, then uses two to four free slots. It remains limited to DFlash/DSpark; other workloads change only when `--min-free-slots-delay` is set explicitly.
- Separate active requests from finished requests that have not yet been filtered, admit workload growth immediately, preserve the target across partial refills, lower it after a real contraction, and clear it when the running batch drains.
- Bound an incomplete refill by scheduler passes. The default bound is the observed request target. `--min-free-slots-max-delay-passes` overrides the bound, `0` disables waiting, and negative values are rejected.
- Bypass replacement batching for prefill-only batches and priority preemption. Chunked prefills and the pipeline-parallelism restriction are unchanged.

## Accuracy Tests

Author CPU validation passed 232 tests and 26 subtests across the scheduler-delay and ServerArgs suites. The rebase moves argument validation into the current resolution pipeline and retains the current running-batch admission API.

Rebased on main `2c05ed4e77`. [Author test logs and source bindings](https://github.com/ormandj/sglang-glm53-flash-sm120/blob/main/evidence/v0.3.2/pr-maintenance/README.md) record the tested snapshots. The subsequent main refresh changes only unrelated ROCm/NPU files; each repaired patch is byte-identical across that refresh.

## Speed Tests and Profiling

The following are retained author measurements of release-pinned source `6200c54c71`, before this main-based API adaptation. They were not rerun on the rebased head and do not establish its serving throughput.

The same DeepSeek-V4-Flash DSpark TP2 image was measured with automatic replacement batching enabled and with only `--min-free-slots-max-delay-passes 0` added to disable the wait. HiCache was disabled. Each configuration used five turnover repetitions at concurrency 8 with identical requests and one warmed server process.

| Configuration | Repetitions | Output tokens/s, mean | Inter-token latency, mean | TTFT, mean | Requests per prefill pass, mean |
|---|---:|---:|---:|---:|---:|
| Waiting disabled | 5 | 591.29 | 11.89 ms | 241.54 ms | 1.3256 |
| Automatic replacement batching | 5 | 610.91 | 11.13 ms | 352.72 ms | 2.0603 |

Automatic replacement batching increased mean output throughput by 3.3%, reduced mean inter-token latency by 6.4%, increased mean TTFT by 46.0%, and increased the mean requests admitted per prefill pass by 55.4%. The control changes only the new wait bound; image, source, request limit, CUDA-graph configuration, workload, and other runtime settings are identical.

## Related work

[#23709](https://github.com/sgl-project/sglang/pull/23709) changes the separate adaptive prefill delayer. [#32775](https://github.com/sgl-project/sglang/pull/32775) and [#34058](https://github.com/sgl-project/sglang/pull/34058) limit consecutive prefills to protect decode. [#30173](https://github.com/sgl-project/sglang/pull/30173) adds tests for the existing min-free-slots helper. None changes DFlash/DSpark replacement admission from configured capacity to observed demand.

## Checklist

- [x] Format your code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Developed with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34058832962](https://github.com/sgl-project/sglang/actions/runs/34058832962)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34058832812](https://github.com/sgl-project/sglang/actions/runs/34058832812)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34058832924](https://github.com/sgl-project/sglang/actions/runs/34058832924)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->