### PR TITLE
[PD] Add load-aware cache-off DP prefill routing

### DIFF
--- a/python/sglang/srt/managers/data_parallel_controller.py
+++ b/python/sglang/srt/managers/data_parallel_controller.py
@@ -179,6 +179,9 @@ class DataParallelController:
         )
 
         self.dp_budget = DPBudget(get_parallel().dp_size)
+        self._dp_prefill_load_aware_routing = (
+            server_args.enable_dp_prefill_load_aware_routing
+        )
         self.load_snapshot_reader = create_load_snapshot_reader(
             port_args,
             caller="DataParallelController",
@@ -737,6 +740,8 @@ class DataParallelController:
 
     def maybe_external_dp_rank_routing(self, req: Req):
         if req.routed_dp_rank is not None:
+            if self._dp_prefill_load_aware_routing:
+                return False
             rank = req.routed_dp_rank
             if (
                 rank < 0

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1008,6 +1008,11 @@ class ServerArgs:
         "The interval to poll requests in scheduler. Can be set to >1 to reduce the overhead of this.",
         NS("schedule"),
     ] = 1
+    enable_dp_prefill_load_aware_routing: A[
+        bool,
+        "Let cache-disabled disaggregated prefill route by SGLang worker token load instead of an external DP-rank hint.",
+        NS("schedule"),
+    ] = False
     enable_mixed_chunk: A[
         bool,
         "Enabling mixing prefill and decode in a batch when using chunked prefill.",
@@ -8631,6 +8636,24 @@ class ServerArgs:
             raise ValueError("--prefill-decode-interval must be non-negative.")
 
     def _handle_other_validations(self):
+        if self.enable_dp_prefill_load_aware_routing:
+            unsupported = []
+            if not self.enable_dp_attention:
+                unsupported.append("--enable-dp-attention")
+            if self.disaggregation_mode != "prefill":
+                unsupported.append("--disaggregation-mode prefill")
+            if self.dp_size <= 1:
+                unsupported.append("--dp-size > 1")
+            if not self.disable_radix_cache:
+                unsupported.append("--disable-radix-cache")
+            if self.load_balance_method != "total_tokens":
+                unsupported.append("--load-balance-method total_tokens")
+            if unsupported:
+                raise ValueError(
+                    "--enable-dp-prefill-load-aware-routing requires "
+                    + ", ".join(unsupported)
+                )
+
         if self.default_chat_template_kwargs is not None and not isinstance(
             self.default_chat_template_kwargs, dict
         ):

--- a/test/registered/unit/managers/test_data_parallel_controller.py
+++ b/test/registered/unit/managers/test_data_parallel_controller.py
@@ -50,6 +50,7 @@ def _make_controller(dp_size: int) -> DataParallelController:
     ctl.status = [True] * dp_size
     ctl._active_workers = list(range(dp_size))
     ctl.round_robin_counter = 0
+    ctl._dp_prefill_load_aware_routing = False
     ctl.dp_budget = DPBudget(dp_size=dp_size)
     return ctl
 
@@ -260,6 +261,20 @@ class TestTotalRequestsScheduler(CustomTestCase):
             [5, 3, 1, 4],
             "external routing must not mutate DPBudget state",
         )
+
+
+class TestDPPrefillLoadAwareRouting(CustomTestCase):
+    def test_treats_external_rank_as_hint_and_uses_token_load(self):
+        ctl = _make_controller(dp_size=4)
+        ctl._dp_prefill_load_aware_routing = True
+        ctl.dp_budget.total_tokens = [100, 50, 200, 150]
+        ctl.dp_budget.total_requests = [0, 0, 0, 0]
+
+        ctl.total_tokens_scheduler(_req(routed_dp_rank=2, input_ids=[1] * 8192))
+
+        ctl.workers[1].send_pyobj.assert_called_once()
+        ctl.workers[2].send_pyobj.assert_not_called()
+        self.assertEqual(ctl.dp_budget.total_tokens, [100, 8242, 200, 150])
 
 
 class TestStatusAwarenessInconsistency(CustomTestCase):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -42,6 +42,29 @@ _mock_device = patch("sglang.srt.server_args.get_device", return_value="cuda")
 _mock_device.start()
 
 
+class TestDPPrefillLoadAwareRoutingArgs(CustomTestCase):
+    @staticmethod
+    def make_args(**overrides):
+        kwargs = dict(
+            model_path="dummy",
+            enable_dp_attention=True,
+            disaggregation_mode="prefill",
+            dp_size=4,
+            disable_radix_cache=True,
+            load_balance_method="total_tokens",
+            enable_dp_prefill_load_aware_routing=True,
+        )
+        kwargs.update(overrides)
+        return ServerArgs(**kwargs)
+
+    def test_accepts_cache_disabled_prefill_total_tokens(self):
+        self.make_args()._handle_other_validations()
+
+    def test_rejects_cache_enabled_mode(self):
+        with self.assertRaisesRegex(ValueError, "--disable-radix-cache"):
+            self.make_args(disable_radix_cache=False)._handle_other_validations()
+
+
 class TestPrepareServerArgs(CustomTestCase):
     def test_enable_w4a4_mxfp4_megamoe_sets_deepgemm_env(self):
         deepgemm_env = {


### PR DESCRIPTION
# [PD] Add load-aware cache-off DP prefill routing

## Motivation

An external DP-aware router answers which rank a request should prefer, but its
rank decision is currently authoritative in `DataParallelController`. That
short-circuits SGLang's existing `total_tokens` scheduler even when RadixCache
is disabled and there is no cache affinity to preserve.

This matters for mixed-length prefill. Equal request counts are not equal token
work:

```text
external placement: DP0=14.18M, DP1=5.66M, DP2=6.37M, DP3=8.07M tokens
                     ^^^^^^^^^^
                     one rank owns 2.5x another rank's prompt work
```

With DP attention and EP MoE, rank-local token skew becomes global idle time.
The DataParallelController already receives per-worker token snapshots and its
`DPBudget` already reserves newly dispatched prompt tokens. The missing link is
allowing that scheduler to run when an external request also carries
`routed_dp_rank`.

This PR adds a narrow opt-in mode for cache-disabled disaggregated prefill:

```mermaid
flowchart LR
    R[External router<br/>session identity + rank hint] --> D[SGL DataParallelController]
    L[Worker token-load snapshots] --> D
    D -->|total_tokens| P[Actual prefill DP rank]
    P --> S[Ordinary rank-local scheduler]
    P --> K[Register actual rank<br/>for decode bootstrap]
```

It does not add an admission barrier or a Dynamo-specific queue. Controlled
direct-rank experiments showed that SGLang's ordinary scheduler is already the
faster admission path once placement is equal; an added request-level cohort
gate regressed static 16K by 21.8% and mixed AgentX by 27.8%.

## Modifications

- Add `--enable-dp-prefill-load-aware-routing`.
- In that mode only, treat `routed_dp_rank` as a hint and let the existing
  `total_tokens` scheduler choose the actual worker.
- Require all of the following at startup:
  - DP attention;
  - disaggregation mode `prefill`;
  - DP size greater than one;
  - RadixCache disabled;
  - load-balance method `total_tokens`.
- Reject cache-enabled use so conversation/prefix affinity remains
  authoritative on the existing path.
- Preserve the existing behavior by default.

The existing Common KV sender registers the actual executing prefill DP rank
with the decode bootstrap path when no prefill rank was supplied separately,
so P/D KV transfer follows the rank selected inside SGLang.

## Accuracy Tests

This changes only cache-off request placement. It does not change model math,
weights, kernels, KV contents, or sampling. Both performance arms completed all
384 measured requests with zero cancellations/overflows, and no
`SGLANG_SIMULATE_ACC_*` setting was present.

Targeted correctness tests:

- Production Linux container gate: 20 targeted tests passed (`3229638`).
- Standalone source/mount gate passed (`3229852`).
- Added unit coverage verifies:
  - default behavior preserves an external target;
  - opt-in behavior dispatches to the worker with the lowest token load and
    reserves the incoming prompt tokens;
  - the exact cache-off prefill configuration is accepted;
  - cache-enabled use is rejected.
- The delivery commit was rebased onto current `main`; its stable patch ID is
  identical to the commit used by the container and performance runs.

## Speed Tests and Profiling

Paired natural AgentX cache-off prefill-only diagnostic:

- Qwen3.5-397B-A17B NVFP4;
- 1 prefill server with DP attention / DEP4 plus one decode server;
- concurrency 16, OSL 1;
- global/per-rank chunk 32768/8192;
- Breakable prefill CUDA graph;
- 128 warmup + 384 measured requests per arm;
- identical source and `total_tokens` configuration in both arms; the only
  functional difference is this flag.

| Arm | New-prefill tok/s/chip | Actual rank prompt tokens | Token min/max |
|---|---:|---|---:|
| external rank authoritative (`3229863`) | 13,301.16 | [14.18M, 5.66M, 6.37M, 8.07M] | 39.91% |
| SGL worker-token placement (`3229868`) | 15,128.90 | [11.70M, 7.90M, 7.39M, 7.33M] | 62.63% |

Throughput improved by **13.74% (1.137x)**. Both arms completed 384/384
measured requests with zero cache observations and zero cancellations or
overflows. Aggregate new-prefill tokens differed by only 0.133%.

The warmup independently showed the same mechanism and direction: token
min/max improved from 72.42% to 96.73%, normalized throughput improved by
5.88%, and wall time fell by 5.57%.

These are deliberately reported as paired diagnostics, not leaderboard
results: the artifacts are `PASS_VALIDITY_SMOKE` because the requested 660s
scenario coverage is shorter than the dashboard's 900s performance gate.

## Scope

This PR does not change chunk size, batch size, concurrency, kernels, MoE/A2A
backend, cache contents, model math, sampling, or CUDA graph backend. It does
not use deprecated piecewise graphs. Cache-on routing stays unchanged.

## Checklist

- [x] Run the relevant pre-commit formatting/lint hooks for the changed files.
- [x] Add targeted unit tests for default routing, opt-in token-load routing,
  valid arguments, and cache-on rejection.
- [x] Provide mechanism-level and request-level speed evidence.
- [ ] Add user-facing documentation after maintainer agreement on the new
  opt-in flag.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32561092364](https://github.com/sgl-project/sglang/actions/runs/32561092364)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32561092201](https://github.com/sgl-project/sglang/actions/runs/32561092201)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32561092338](https://github.com/sgl-project/sglang/actions/runs/32561092338)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->