### PR TITLE
[diffusion] hold VAE decoder weights in their decode dtype from load

### DIFF
--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     SGLANG_DIFFUSION_LOGGING_LEVEL: str = "INFO"
     SGLANG_DIFFUSION_LOGGING_PREFIX: str = ""
     SGLANG_DIFFUSION_TRACE_FUNCTION: int = 0
+    SGLANG_DIFFUSION_DISABLE_EARLY_VAE_DECODER_CAST: bool = False
     SGLANG_DIFFUSION_WORKER_MULTIPROC_METHOD: str = "fork"
     SGLANG_DIFFUSION_TARGET_DEVICE: str = "cuda"
     SGLANG_DIFFUSION_PLATFORM_OVERRIDE: str = ""
@@ -232,6 +233,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     ),
     "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D": _lazy_str(
         "SGLANG_DIFFUSION_VAE_CHANNELS_LAST_3D", "auto"
+    ),
+    # Kill-switch: keep VAE decoder weights in their checkpoint dtype at load
+    # instead of the decode compute dtype the decode stage would round them to
+    # on first use anyway.
+    "SGLANG_DIFFUSION_DISABLE_EARLY_VAE_DECODER_CAST": _lazy_bool(
+        "SGLANG_DIFFUSION_DISABLE_EARLY_VAE_DECODER_CAST"
     ),
     # ================== cache-dit Env Vars ==================
     # Enable cache-dit acceleration for DiT inference

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 from safetensors.torch import load_file as safetensors_load_file
 
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import LTX2PipelineConfig
 from sglang.multimodal_gen.configs.pipeline_configs.qwen_image import (
     QwenImagePipelineConfig,
@@ -30,7 +31,11 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     get_diffusers_component_config,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.runtime.utils.precision import resolve_component_precision
+from sglang.multimodal_gen.runtime.utils.precision import (
+    autocast_enabled,
+    resolve_component_precision,
+    resolve_decode_precision,
+)
 from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 from sglang.srt.model_loader.checkpoint_quantization import (
     resolve_checkpoint_quant_spec,
@@ -124,6 +129,41 @@ def _should_use_channels_last_3d(
     ):
         return True
     return False
+
+
+def _hold_decoder_weights_in_decode_dtype(
+    vae, server_args: ServerArgs, component_name: str
+) -> None:
+    """Round decoder weights to their decode compute dtype at load.
+
+    The decode stage persists these frozen weights in the autocast dtype on
+    first use (``prepare_autocast_linear_weights``), so the rounding itself is
+    already part of the output. Doing it at load makes residency plans, host
+    pins, and every host-to-device copy carry the halved size: MiniMax-H3's
+    video decoder drops from 9.7 to ~4.9 GiB, which is the difference between
+    restreaming a third of it per tile and holding all 36 blocks on a 12 GiB
+    card for the decode.
+    """
+    if component_name not in ("vae", "video_vae"):
+        return
+    if envs.SGLANG_DIFFUSION_DISABLE_EARLY_VAE_DECODER_CAST:
+        return
+    prepare = getattr(vae, "prepare_decoder_autocast_weights", None)
+    if prepare is None:
+        return
+    dtype = resolve_decode_precision(server_args, component_name)
+    if dtype == torch.float32:
+        return
+    if not autocast_enabled(dtype, server_args.disable_autocast):
+        return
+    converted = prepare(dtype)
+    if converted:
+        logger.info(
+            "VAE: %s holds %d decoder weights in %s from load",
+            component_name,
+            converted,
+            dtype,
+        )
 
 
 def _match_checkpoint_dtypes(loaded: dict, target_state: dict) -> dict:
@@ -235,6 +275,7 @@ class VAELoader(ComponentLoader):
                     logger.info(
                         "VAE: converted %d Conv3d weights to channels_last_3d", n
                     )
+            _hold_decoder_weights_in_decode_dtype(vae, server_args, component_name)
             vae = current_platform.optimize_vae(vae)
             return vae
 
@@ -303,5 +344,6 @@ class VAELoader(ComponentLoader):
             if n > 0:
                 logger.info("VAE: converted %d Conv3d weights to channels_last_3d", n)
 
+        _hold_decoder_weights_in_decode_dtype(vae, server_args, component_name)
         vae = current_platform.optimize_vae(vae)
         return vae

--- a/python/sglang/multimodal_gen/test/unit/test_vae_loader_decode_dtype.py
+++ b/python/sglang/multimodal_gen/test/unit/test_vae_loader_decode_dtype.py
@@ -1,0 +1,81 @@
+"""The loader rounds VAE decoder weights to the decode dtype it will compute in.
+
+The decode stage persists these frozen weights in the autocast dtype on first
+use, so the rounding is already part of every output; what the tests pin down
+is when the loader is allowed to do it early and when it must leave the
+checkpoint dtype alone.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.loader.component_loaders.vae_loader import (
+    _hold_decoder_weights_in_decode_dtype,
+)
+
+
+class _RecordingVAE:
+    def __init__(self):
+        self.prepared_with = None
+
+    def prepare_decoder_autocast_weights(self, dtype) -> int:
+        self.prepared_with = dtype
+        return 144
+
+
+def _server_args(decode_precision="fp16", disable_autocast=False):
+    return SimpleNamespace(
+        pipeline_config=SimpleNamespace(
+            vae_decode_precision=decode_precision,
+            vae_precision="fp32",
+        ),
+        disable_autocast=disable_autocast,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _amp_supported(monkeypatch):
+    from sglang.multimodal_gen.runtime.utils import precision
+
+    monkeypatch.setattr(precision.current_platform, "is_amp_supported", lambda: True)
+
+
+def test_the_decoder_is_rounded_to_the_decode_dtype_at_load():
+    vae = _RecordingVAE()
+    _hold_decoder_weights_in_decode_dtype(vae, _server_args(), "video_vae")
+    assert vae.prepared_with == torch.float16
+
+
+def test_disabling_autocast_keeps_the_checkpoint_dtype():
+    vae = _RecordingVAE()
+    _hold_decoder_weights_in_decode_dtype(
+        vae, _server_args(disable_autocast=True), "video_vae"
+    )
+    assert vae.prepared_with is None
+
+
+def test_the_kill_switch_keeps_the_checkpoint_dtype(monkeypatch):
+    monkeypatch.setenv("SGLANG_DIFFUSION_DISABLE_EARLY_VAE_DECODER_CAST", "1")
+    vae = _RecordingVAE()
+    _hold_decoder_weights_in_decode_dtype(vae, _server_args(), "video_vae")
+    assert vae.prepared_with is None
+
+
+def test_an_fp32_decode_precision_is_left_alone():
+    vae = _RecordingVAE()
+    _hold_decoder_weights_in_decode_dtype(
+        vae, _server_args(decode_precision="fp32"), "video_vae"
+    )
+    assert vae.prepared_with is None
+
+
+def test_the_audio_vae_is_not_touched():
+    vae = _RecordingVAE()
+    _hold_decoder_weights_in_decode_dtype(vae, _server_args(), "audio_vae")
+    assert vae.prepared_with is None
+
+
+def test_a_vae_without_the_hook_is_skipped():
+    _hold_decoder_weights_in_decode_dtype(object(), _server_args(), "video_vae")


### PR DESCRIPTION
## Summary

The decode stage already rounds VAE decoder weights to the autocast compute dtype on first use (`prepare_autocast_linear_weights`, whose docstring notes the persisted rounding is numerically equivalent). This PR performs that rounding at load instead, so residency plans, host pins, and every host-to-device copy carry the compute size rather than the checkpoint size. A kill switch (`SGLANG_DIFFUSION_DISABLE_EARLY_VAE_DECODER_CAST`) restores the old placement; `--disable-autocast` and fp32 decode precisions are untouched.

## Measured (MiniMax-H3, RTX 4090, 12 GiB cap + 32 GiB host convention, 5s/480p/20 steps)

| | decoder bytes | `video_vae` residency | decode | output |
| --- | ---: | --- | ---: | --- |
| before | 9.7 GiB (fp32 store) | 24 of 36 blocks, rest restreamed per tile | 60 s | baseline |
| after | 4.9 GiB (fp16 from load) | all 36 blocks held for the decode | **9.4 s** | **bit-identical** (same sha256) |

Denoise is unchanged (11.17 s/it, inside the 10.5–11.3 baseline band). No OOM; the run stays inside the 12 GiB cap.

Bit-identity holds because the decode already computed in fp16: casting fp32→fp16 at load lands on the same round-to-nearest-even values the stage produced per call. The embedding and output projections stay fp32 (their calls explicitly disable autocast), as does the encoder.

This also aligns the storage dtype with ComfyUI's H3 pipeline, which stages this VAE as fp16 (4965 MB); its decode-side advantage on 12 GB cards came entirely from that.

## Notes

- Applies to any VAE exposing `prepare_decoder_autocast_weights` (duck-typed); others are untouched.
- A cast parameter is no longer a checkpoint-mapping view, so the mapped-weights gate naturally excludes it; the fp16 copy is anonymous host memory accounted by the existing budget.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32563976293](https://github.com/sgl-project/sglang/actions/runs/32563976293)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32564000895](https://github.com/sgl-project/sglang/actions/runs/32564000895)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32563976139](https://github.com/sgl-project/sglang/actions/runs/32563976139)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->