### PR TITLE
perf(mamba): defer device free-list merging until allocation needs released slots

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1276,7 +1276,7 @@ class SchedulerBatchResultProcessor:
             pool = batch.req_to_token_pool
             keep_idx = req.mamba_next_track_idx
             keep_val = req.mamba_ping_pong_track_buffer[keep_idx]
-            pool.mamba_allocator.free(keep_val.unsqueeze(0))
+            pool.mamba_allocator.free(keep_val.unsqueeze(0).clone())
             pool.set_mamba_ping_pong_slot(req, keep_idx, -1)
             req.mamba_next_track_idx = planned_pos
         # else: in-place fallback, or promoted by an earlier confirmation —
@@ -1337,6 +1337,6 @@ class SchedulerBatchResultProcessor:
         if other_val != -1:
             pool = batch.req_to_token_pool
             pool.mamba_allocator.free(
-                req.mamba_ping_pong_track_buffer[other_idx].unsqueeze(0)
+                req.mamba_ping_pong_track_buffer[other_idx].unsqueeze(0).clone()
             )
             pool.set_mamba_ping_pong_slot(req, other_idx, -1)

--- a/python/sglang/srt/managers/scheduler_components/invariant_checker.py
+++ b/python/sglang/srt/managers/scheduler_components/invariant_checker.py
@@ -172,6 +172,8 @@ class SchedulerInvariantChecker:
             )
             mamba_allocator = self.req_to_token_pool.mamba_allocator
             free_mamba_pages = set(mamba_allocator.free_slots.tolist())
+            for released_slots in getattr(mamba_allocator, "release_slots", ()):
+                free_mamba_pages.update(released_slots.tolist())
             cached_mamba_pages = set(
                 self.tree_cache.all_mamba_values_flatten().tolist()
             )

--- a/python/sglang/srt/mem_cache/allocator/mamba.py
+++ b/python/sglang/srt/mem_cache/allocator/mamba.py
@@ -46,7 +46,7 @@ class MambaSlotAllocator:
         self.clear()
 
     def available_size(self) -> int:
-        return len(self.free_slots)
+        return len(self.free_slots) + self.num_release_slots
 
     def schedulable_available_size(self) -> int:
         """Planner-facing free count. Identity to ``available_size`` for the
@@ -79,8 +79,12 @@ class MambaSlotAllocator:
         return self._do_alloc(need_size)
 
     def _do_alloc(self, need_size: int) -> Optional[torch.Tensor]:
-        if need_size > len(self.free_slots):
+        if need_size > self.available_size():
             return None
+
+        if need_size > len(self.free_slots):
+            self._merge_release_slots()
+
         select_index = self.free_slots[:need_size]
         self.free_slots = self.free_slots[need_size:]
         return select_index
@@ -88,10 +92,32 @@ class MambaSlotAllocator:
     def free(self, free_index: torch.Tensor):
         if free_index.numel() == 0:
             return
-        self.free_slots = torch.cat((self.free_slots, free_index))
+
+        # Keep released slots out of the active free-list until allocation
+        # needs them. Concatenating the entire device free-list for every
+        # request release makes a request-turnover path O(pool_size) and
+        # allocates a new GPU tensor each time.
+        # Mutable views are snapshotted by their callers before the backing
+        # storage can be reused.
+        self.release_slots.append(free_index)
+        self.num_release_slots += free_index.numel()
+
+    def _merge_release_slots(self):
+        if self.num_release_slots == 0:
+            return
+
+        if len(self.free_slots) == 0 and len(self.release_slots) == 1:
+            self.free_slots = self.release_slots[0]
+        else:
+            self.free_slots = torch.cat([self.free_slots, *self.release_slots])
+
+        self.release_slots = []
+        self.num_release_slots = 0
 
     def clear(self):
         # Slot 0 is reserved as a dummy write target for padded tokens.
         self.free_slots = torch.arange(
             1, self.size + 1, dtype=torch.int64, device=self.device
         )
+        self.release_slots = []
+        self.num_release_slots = 0

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1488,7 +1488,9 @@ class HybridReqToTokenPool(ReqToTokenPool):
 
         if self.enable_mamba_extra_buffer:
             mamba_ping_pong_track_buffer_to_free = (
-                self.req_index_to_mamba_ping_pong_track_buffer_mapping[req.req_pool_idx]
+                self.req_index_to_mamba_ping_pong_track_buffer_mapping[
+                    req.req_pool_idx
+                ]
             )
             if mamba_ping_pong_track_buffer_to_keep is not None:
                 assert mamba_ping_pong_track_buffer_to_keep in [
@@ -1523,7 +1525,7 @@ class HybridReqToTokenPool(ReqToTokenPool):
                         mamba_ping_pong_track_buffer_to_free != -1
                     ]
                 )
-            self.mamba_allocator.free(mamba_ping_pong_track_buffer_to_free)
+            self.mamba_allocator.free(mamba_ping_pong_track_buffer_to_free.clone())
             # Match the req.mamba_pool_idx=None clear above so the next
             # alloc() doesn't see a stale ping-pong reference on the req
             # and skip allocation (which would silently reuse a freed


### PR DESCRIPTION
## Motivation

`MambaSlotAllocator.free()` currently rebuilds the complete device free-list on
every release:

```python
self.free_slots = torch.cat((self.free_slots, free_index))
```

The cost is proportional to the current free-list size, rather than the number
of slots being released. During request turnover, releasing one request can
therefore allocate and copy a large device tensor on the scheduler bookkeeping
path.

The host pool already uses a lazy free-list release design: record released
chunks first, keep them in the available-size accounting, and merge them only
when the primary free-list cannot satisfy an allocation. This PR applies the
same design to the device-side Mamba slot allocator, removing the eager large
`torch.cat` from the hot `free()` path.

## Modifications

Apply the same deferred free-list strategy used by the host pool:

- `python/sglang/srt/mem_cache/allocator/mamba.py`
  - `MambaSlotAllocator.free()` records released tensors in
    `release_slots` and updates `num_release_slots`.
  - `available_size()` includes both active and pending released slots.
  - `_do_alloc()` merges pending chunks only when the active free-list is
    insufficient.
  - A single pending chunk is reused directly; multiple chunks are merged in
    one operation.
  - `clear()` resets all deferred-release state.
- `python/sglang/srt/mem_cache/memory_pool.py`
  - `HybridReqToTokenPool.free_mamba_cache()` snapshots the small mutable
    ping-pong mapping view before the request buffer is cleared or reused.
- `python/sglang/srt/managers/scheduler_components/batch_result_processor.py`
  - The two lazy ping-pong release paths snapshot the slot index before the
    original buffer is updated to `-1`.
- `python/sglang/srt/managers/scheduler_components/invariant_checker.py`
  - Pending Mamba releases are included in the free-slot leak diagnosis.

The allocator interface, allocation order, slot reuse semantics, and Mamba
state computation remain unchanged. Active free slots are consumed first, and
pending released slots are consumed after the deferred merge.

## Alignment with the host pool design

The device-side implementation follows the same state transition as the host
pool:

```text
free()  -> record released chunk in release_slots
alloc() -> use free_slots directly when possible
           merge release_slots only when free_slots is insufficient
clear() -> reset free_slots and pending-release state
```

Both implementations use `release_slots`, `num_release_slots`,
`available_size()`, and allocation-time `_merge_release_slots()`. The only
device-specific difference is that Mamba indices remain on the device instead
of being moved to CPU.

## Accuracy Tests

This change only modifies device-side slot bookkeeping. It does not modify:

- model weights or forward computation;
- Mamba state values or KV cache contents;
- cache keys or page-table mappings;
- attention, sampling, or CUDA kernels.

The focused validation checks slot allocation and reuse behavior, including
pending releases, partial frees, empty frees, exhaustion, grouped allocation,
`clear()`, request-slot reuse, and mutable ping-pong views on CPU and CUDA.

## Speed Tests and Profiling

Before this change, releasing `K` slots with `F` active free slots performs a
full free-list rebuild:

```text
free-list maintenance: O(F + K)
```

After this change, `free()` only records the released tensor and updates a
counter:

```text
free-list maintenance: O(1)
```

The larger merge is deferred until released slots are needed, and multiple
releases can be merged together in one allocation-side operation.

Representative allocator benchmark results are shown below. Each iteration
performs `alloc(batch_size)` followed by `free()`. Values are median wall-clock
microseconds per iteration over five runs; CUDA measurements synchronize before
and after the timed loop.

```text
device  pool    batch  old (us)  new (us)  speedup
CPU       256       1     10.02      7.47    1.34x
CPU     8,192       1     12.10      7.22    1.68x
CPU    16,384       1     14.06      7.16    1.96x
CPU    65,536       1     35.33      8.98    3.93x
CUDA      256       1     18.28      8.55    2.14x
CUDA    8,192       1     18.24      8.32    2.19x
CUDA   16,384       1     18.36      8.28    2.22x
CUDA   65,536       1     18.43      8.19    2.25x
```

The batch-size sweep also covered batches 4 and 32. CUDA speedups ranged from
1.79x to 2.25x, and the largest CPU-pool case reached 5.05x. The benchmark
measures allocator bookkeeping directly; end-to-end throughput depends on the
request mix and model execution time.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32565651798](https://github.com/sgl-project/sglang/actions/runs/32565651798)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32565651596](https://github.com/sgl-project/sglang/actions/runs/32565651596)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32565651694](https://github.com/sgl-project/sglang/actions/runs/32565651694)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->