### PR TITLE
[Bugfix] Fix CLIP text embedding batching

### DIFF
--- a/python/sglang/srt/models/clip.py
+++ b/python/sglang/srt/models/clip.py
@@ -578,8 +578,35 @@ class CLIPModel(nn.Module):
             return EmbeddingPoolerOutput(embeddings=image_embeds)
 
         else:
-            text_outputs = self.text_model(input_ids, position_ids=positions)
-            pooled_output = self.pooler(text_outputs[0], forward_batch)
+            extend_seq_lens = forward_batch.extend_seq_lens_cpu
+            seq_lens = (
+                [int(x) for x in extend_seq_lens]
+                if extend_seq_lens is not None
+                else None
+            )
+            if seq_lens is not None and len(seq_lens) > 1:
+                batch_input_ids = torch.nn.utils.rnn.pad_sequence(
+                    input_ids.split(seq_lens), batch_first=True
+                )
+                batch_positions = torch.nn.utils.rnn.pad_sequence(
+                    positions.split(seq_lens), batch_first=True
+                )
+                text_outputs = self.text_model(
+                    batch_input_ids, position_ids=batch_positions
+                )
+                text_outputs = torch.cat(
+                    torch.nn.utils.rnn.unpad_sequence(
+                        text_outputs,
+                        torch.tensor(seq_lens, device=text_outputs.device),
+                        batch_first=True,
+                    ),
+                    dim=0,
+                )
+            else:
+                text_outputs = self.text_model(input_ids, position_ids=positions)
+            if text_outputs.dim() == 3:
+                text_outputs = text_outputs[0]
+            pooled_output = self.pooler(text_outputs, forward_batch)
             return EmbeddingPoolerOutput(
                 embeddings=self.text_projection(pooled_output.embeddings)
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

`CLIPModel` crashes on any batched embedding request whose concatenated token length exceeds max_position_embeddings` (77):

```
ValueError: Sequence length 107 exceeds the maximum 77.
```
Root cause: the SRT CLIP text encoder was never adapted to SRT's per-request-flattened batch layout, unlike every other encoder model, which segments inputs via `forward_batch.extend_seq_lens`.

## Modifications

<!-- Detail the changes made in this pull request. -->
In `python/sglang/srt/models/clip.py`:

- When the batch has more than one request, the flattened `input_ids` / `positions` (the concatenation of all requests, as laid out by `ScheduleBatch`) are batched as a padded 2D tensor `(n_req, max_seq_len)` and run through `CLIPTextTransformer` **once**:
    - the padded batch is built with `split(seq_lens)` + `pad_sequence` (the flattened inputs are exactly the concatenation of the per-request segments), and the output is truncated back to the real per-request lengths with `unpad_sequence` + `cat`;
    - each row runs independently (SDPA `is_causal` per row), so causal attention never leaks across requests, and
    - the `max_position_embeddings` check in `CLIPTextEmbeddings` applies per request — the padded batch length is the max request length, and every request is already within the 77-token model limit.
- `seq_lens` is read from `forward_batch.extend_seq_lens_cpu`; single-request batches keep the exact original path.

No scheduler, tokenizer, pooling, or `CLIPTextTransformer` changes; other model paths (vision/LLM usage of CLIP as encoder, multimodal_gen reuse of `CLIPTextTransformer`) are unaffected.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
Before the fix, the test crashed with `ValueError: Sequence length 107 exceeds the maximum 77.` With this fix, the test passes (`Ran 1 test in 37.941s OK`) and all five similarity diffs drop to ~1e-7 (2.3842e-07 / 4.1723e-07 / 3.5763e-07 / 5.9605e-07 / 4.1723e-07), i.e. batched output is bit-close to the per-prompt HF reference.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

NPU (Ascend 910, cann9.1.0) microbenchmark of the CLIP text transformer with real `clip-vit-large-patch14-336` weights (5 requests, lengths `76/9/10/12/76`, fp16, 30 iters):

- per-request forward (5 separate forwards): 28.73 ms per batch of 5
- **the fix**: **5.47 ms per batch**

The padded 2D batch forward is ~5.2x faster than running the transformer once per request. This fix uses the faster single-forward form; the batched path only exists when there is more than one request in the batch.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35051746109](https://github.com/sgl-project/sglang/actions/runs/35051746109)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35051745635](https://github.com/sgl-project/sglang/actions/runs/35051745635)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35051745931](https://github.com/sgl-project/sglang/actions/runs/35051745931)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->