### PR TITLE
fix(test): unbreak test_kv_transfer_replica_metric after #35950

### DIFF
--- a/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
+++ b/test/registered/unit/disaggregation/test_kv_transfer_replica_metric.py
@@ -45,9 +45,23 @@ def _make_kv_mgr(is_mla_backend):
     return mgr
 
 
+class _ConcreteKVSender(CommonKVSender):
+    """CommonKVSender is abstract: `poll` and `failure_exception` are backend
+    duties, so it cannot be instantiated (not even via __new__, which enforces
+    ABC completeness). This stub supplies them so the shared metric path can be
+    exercised without pulling in a transfer backend.
+    """
+
+    def poll(self):
+        raise NotImplementedError
+
+    def failure_exception(self):
+        raise NotImplementedError
+
+
 def _make_sender(kv_mgr):
     """CommonKVSender bypassing __init__, wiring only the fields the path reads."""
-    sender = CommonKVSender.__new__(CommonKVSender)
+    sender = _ConcreteKVSender.__new__(_ConcreteKVSender)
     sender._transfer_metric = KVTransferMetric()
     sender._transfer_num_kv_indices = 0
     sender._transfer_num_state_indices = 0


### PR DESCRIPTION
## Motivation

**`base-a-test-cpu` is currently red on main, and it is my fault.** This unbreaks it.

#35950 removed the dead placeholder `poll` and `failure_exception` overrides from `CommonKVSender`. That left the class abstract with respect to those two methods, which was the intent — it restores ABC enforcement so a backend that forgets either fails loudly at construction.

What I missed is that **`object.__new__` enforces abstractmethod completeness too**, not just `cls(...)`. So this fixture in `test_kv_transfer_replica_metric.py`:

```python
sender = CommonKVSender.__new__(CommonKVSender)
```

started raising:

```
TypeError: Can't instantiate abstract class CommonKVSender
with abstract methods failure_exception, poll
```

Before landing #35950 I did check for direct instantiation — but grepped only for call syntax (`CommonKVSender(`), which does not match the `__new__` form. That is the gap.

## Modifications

1 file, +14 / -1, test-only.

Fixes it in the test rather than by restoring the stubs, so the ABC enforcement #35950 added is preserved. The fixture now builds a minimal concrete subclass supplying exactly the two abstract methods. Both raise `NotImplementedError`, because this test never calls them — it exercises `_record_transfer_indices` and `get_transfer_metric`.

### Blast radius

Only this one site was affected. The other `__new__` fixtures all target `CommonKVManager`, which implements every abstractmethod of `BaseKVManager` (`__init__`, `register_to_bootstrap`) and so remains concrete:

| Site | Class | Still concrete? |
|---|---|---|
| `test_kv_transfer_replica_metric.py:50` | `CommonKVSender` | **no — fixed here** |
| `test_kv_transfer_replica_metric.py:40` | `CommonKVManager` | yes |
| `test_deferred_decode_kv_release.py:27` | `CommonKVManager` | yes |
| `test_nixl_deferred_kv_release.py:62,175` | `CommonKVManager` | yes |
| `test_priority_scheduling_disaggregation.py:283` | `CommonKVManager` | yes |

No `CommonKVReceiver.__new__` sites exist.

## Accuracy Tests

Not applicable — test-only change, no production code touched.

## Speed Tests and Profiling

Not applicable.

## Verification performed

- Reproduced the exact mechanism in isolation: a subclass of an ABC with two unimplemented abstractmethods raises `TypeError` on `cls.__new__(cls)`, and stops raising once both are supplied.
- Verified structurally by AST that `_ConcreteKVSender` supplies **exactly** `BaseKVSender`'s abstractmethods minus what `CommonKVSender` implements — `{failure_exception, poll}`, with no extras — and that no `CommonKVSender.__new__` call site remains in the file.
- Enumerated every `Common*.__new__` fixture across `python/` and `test/` for the blast-radius table above.
- Pinned `ruff 0.15.1 --select=F401,F821,UP037`, `black 26.1.0`, `isort 7.0.0` all pass.

The test itself could **not** be run locally: `common/conn.py` imports `torch.distributed` and this machine has no torch. The failure mode and the fix are both established by the ABC mechanics above, which are exact rather than approximate. `base-a-test-cpu` will confirm.

Follows #35950.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — this repairs an existing unit test; no new coverage is warranted.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A.
- [x] Provide accuracy and speed benchmark results. — N/A, test-only.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32566562216](https://github.com/sgl-project/sglang/actions/runs/32566562216)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32566562020](https://github.com/sgl-project/sglang/actions/runs/32566562020)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #32566562224](https://github.com/sgl-project/sglang/actions/runs/32566562224)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->