### PR TITLE
fix(hicache): support HF3FS with logical KV anchors

### DIFF
--- a/python/sglang/srt/mem_cache/storage/backend_factory.py
+++ b/python/sglang/srt/mem_cache/storage/backend_factory.py
@@ -13,6 +13,24 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _get_hf3fs_bytes_per_page(mem_pool_host: Any) -> int:
+    """Return the HF3FS page size for a host pool.
+
+    DeepSeek-V4 uses a logical KV anchor for the primary pool.  The anchor
+    owns page indices but no KV buffer, so its per-token size is zero.  HF3FS
+    still needs a non-zero page size to initialize its metadata/file client;
+    the actual KV data is registered later through the hybrid pool v2 paths.
+    """
+    if getattr(mem_pool_host, "kv_buffer", None) is None:
+        return 4096 if mem_pool_host.layout in ["page_first", "page_first_direct"] else 1
+
+    if mem_pool_host.layout in ["page_first", "page_first_direct"]:
+        return mem_pool_host.get_ksize_per_token() * mem_pool_host.page_size
+    if mem_pool_host.layout == "layer_first":
+        return mem_pool_host.get_size_per_token() * mem_pool_host.page_size
+    raise ValueError(f"Unsupported host pool layout: {mem_pool_host.layout!r}")
+
+
 class StorageBackendFactory:
     """Factory for creating storage backend instances with support for dynamic loading."""
 
@@ -170,14 +188,7 @@ class StorageBackendFactory:
             return backend
         elif backend_name == "hf3fs":
             # Calculate bytes_per_page based on memory pool layout
-            if mem_pool_host.layout in ["page_first", "page_first_direct"]:
-                bytes_per_page = (
-                    mem_pool_host.get_ksize_per_token() * mem_pool_host.page_size
-                )
-            elif mem_pool_host.layout == "layer_first":
-                bytes_per_page = (
-                    mem_pool_host.get_size_per_token() * mem_pool_host.page_size
-                )
+            bytes_per_page = _get_hf3fs_bytes_per_page(mem_pool_host)
 
             dtype = mem_pool_host.dtype
             return backend_class.from_env_config(bytes_per_page, dtype, storage_config)

--- a/python/sglang/srt/mem_cache/storage/backend_factory.py
+++ b/python/sglang/srt/mem_cache/storage/backend_factory.py
@@ -22,7 +22,9 @@ def _get_hf3fs_bytes_per_page(mem_pool_host: Any) -> int:
     the actual KV data is registered later through the hybrid pool v2 paths.
     """
     if getattr(mem_pool_host, "kv_buffer", None) is None:
-        return 4096 if mem_pool_host.layout in ["page_first", "page_first_direct"] else 1
+        return (
+            4096 if mem_pool_host.layout in ["page_first", "page_first_direct"] else 1
+        )
 
     if mem_pool_host.layout in ["page_first", "page_first_direct"]:
         return mem_pool_host.get_ksize_per_token() * mem_pool_host.page_size

--- a/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
+++ b/python/sglang/srt/mem_cache/storage/hf3fs/storage_hf3fs.py
@@ -159,7 +159,7 @@ def create_hf3fs_client(
     if use_mock:
         from sglang.srt.mem_cache.storage.hf3fs.hf3fs_client import Hf3fsMockClient
 
-        logger.info(f"[Rank Using Hf3fsMockClient for testing")
+        logger.info("[Rank Using Hf3fsMockClient for testing")
         return Hf3fsMockClient(path, size, bytes_per_page, entries)
     else:
         from sglang.srt.mem_cache.storage.hf3fs.hf3fs_usrbio_client import (
@@ -303,7 +303,7 @@ class HiCacheHF3FS(HiCacheStorage):
                 False,
             )
 
-        mla_unsupported_msg = f"MLA model is not supported without global metadata server, please refer to https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/hf3fs/docs/deploy_sglang_3fs_multinode.md"
+        mla_unsupported_msg = "MLA model is not supported without global metadata server, please refer to https://github.com/sgl-project/sglang/blob/main/python/sglang/srt/mem_cache/storage/hf3fs/docs/deploy_sglang_3fs_multinode.md"
 
         config_path = os.getenv(HiCacheHF3FS.default_env_var)
         if not config_path:
@@ -519,6 +519,8 @@ class HiCacheHF3FS(HiCacheStorage):
     def batch_exists(
         self, keys: List[str], extra_info: Optional[HiCacheStorageExtraInfo] = None
     ) -> int:
+        if getattr(self, "_logical_anchor", False):
+            return len(keys)
         factor = 1
         if self.mha_zero_copy:
             keys = self._get_mha_zero_copy_keys(keys)
@@ -567,6 +569,10 @@ class HiCacheHF3FS(HiCacheStorage):
 
     def register_mem_pool_host(self, mem_pool_host: HostKVCache):
         super().register_mem_pool_host(mem_pool_host)
+        # DeepSeek-V4's primary KV pool is a logical anchor.  Its physical
+        # compressed pools are registered through the v2 API below, so the v1
+        # anchor operations must not try to read/write an empty KV page.
+        self._logical_anchor = getattr(self.mem_pool_host, "kv_buffer", None) is None
         self.is_zero_copy = self.mem_pool_host.layout in [
             "page_first",
             "page_first_direct",
@@ -885,6 +891,8 @@ class HiCacheHF3FS(HiCacheStorage):
         host_indices: torch.Tensor,
         extra_info: Optional[HiCacheStorageExtraInfo] = None,
     ) -> List[bool]:
+        if getattr(self, "_logical_anchor", False):
+            return [True] * len(keys)
         keys, values = self._batch_get_preprocess(keys, host_indices)
         results = self._batch_get(keys, values)
         return self._batch_get_postprocess(host_indices, values, results)
@@ -912,7 +920,8 @@ class HiCacheHF3FS(HiCacheStorage):
         host_indices: torch.Tensor,
         extra_info: Optional[HiCacheStorageExtraInfo] = None,
     ) -> List[bool]:
-        len_keys = len(keys)
+        if getattr(self, "_logical_anchor", False):
+            return [True] * len(keys)
         keys, values = self._batch_set_preprocess(keys, host_indices)
         results = self._batch_set(keys, values)
         return results

--- a/test/registered/unit/hicache/test_hf3fs_logical_anchor.py
+++ b/test/registered/unit/hicache/test_hf3fs_logical_anchor.py
@@ -4,6 +4,9 @@ import torch
 
 from sglang.srt.mem_cache.storage.backend_factory import _get_hf3fs_bytes_per_page
 from sglang.srt.mem_cache.storage.hf3fs.storage_hf3fs import HiCacheHF3FS
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 def test_hf3fs_uses_marker_page_for_logical_anchor():

--- a/test/registered/unit/hicache/test_hf3fs_logical_anchor.py
+++ b/test/registered/unit/hicache/test_hf3fs_logical_anchor.py
@@ -1,0 +1,30 @@
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.storage.backend_factory import _get_hf3fs_bytes_per_page
+from sglang.srt.mem_cache.storage.hf3fs.storage_hf3fs import HiCacheHF3FS
+
+
+def test_hf3fs_uses_marker_page_for_logical_anchor():
+    logical_pool = SimpleNamespace(
+        kv_buffer=None,
+        layout="page_first_direct",
+        page_size=16,
+        dtype=torch.uint8,
+        get_ksize_per_token=lambda: 0,
+        get_size_per_token=lambda: 0,
+    )
+
+    assert _get_hf3fs_bytes_per_page(logical_pool) == 4096
+
+
+def test_hf3fs_logical_anchor_v1_operations_are_noops():
+    backend = object.__new__(HiCacheHF3FS)
+    backend._logical_anchor = True
+    keys = ["a", "b"]
+    host_indices = torch.tensor([0, 1], dtype=torch.int64)
+
+    assert backend.batch_exists(keys) == len(keys)
+    assert backend.batch_get_v1(keys, host_indices) == [True, True]
+    assert backend.batch_set_v1(keys, host_indices) == [True, True]


### PR DESCRIPTION
Fixes #34969

DeepSeek-V4 uses a logical host pool as the primary HiCache anchor. That pool only owns page indices, so its KV page size is zero. HF3FS currently uses that value to initialize the backend and hits a division-by-zero before the server starts.

Use a small marker page for logical anchors and treat the anchor's v1 metadata operations as no-ops. The physical KV data is still handled by the existing v2 side-pool registrations.

Added a focused regression test for the page-size calculation and logical-anchor v1 behavior.

Checks:
- ruff check (changed files)
- compileall
- targeted regression checks

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32701343093](https://github.com/sgl-project/sglang/actions/runs/32701343093)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32701342967](https://github.com/sgl-project/sglang/actions/runs/32701342967)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32701343097](https://github.com/sgl-project/sglang/actions/runs/32701343097)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->