### PR TITLE
refactor(disagg): hoist staging helper imports out of the bootstrap loops

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -29,6 +29,8 @@ from sglang.srt.disaggregation.common.staging_handler import (
     PrefillStagingContext,
     StagingManagerMixin,
     StagingTransferInfo,
+    handle_staging_rsp,
+    handle_watermark_msg,
 )
 from sglang.srt.disaggregation.common.utils import (
     AuxDataCodec,
@@ -1944,18 +1946,10 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 room = waiting_req_bytes[0].decode("ascii")
                 # Staging: decode reports consumption watermark back to prefill
                 if room == "WATERMARK":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_watermark_msg,
-                    )
-
                     handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
                     continue
                 # Staging: decode replies with allocated staging offset
                 if room == "STAGING_RSP":
-                    from sglang.srt.disaggregation.common.staging_handler import (
-                        handle_staging_rsp,
-                    )
-
                     handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
                     continue
                 # Decode-side abort notification: mark room as failed and ACK

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -28,6 +28,8 @@ from sglang.srt.disaggregation.common.conn import (
 from sglang.srt.disaggregation.common.staging_handler import (
     STAGING_WATERMARK_WAIT_S,
     StagingManagerMixin,
+    handle_staging_rsp,
+    handle_watermark_msg,
 )
 from sglang.srt.disaggregation.common.utils import (
     FastQueue,
@@ -2674,20 +2676,12 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 # Staging: decode reports consumption watermark back to prefill
                 if waiting_req_bytes[0] == b"WATERMARK":
                     if self.enable_staging:
-                        from sglang.srt.disaggregation.common.staging_handler import (
-                            handle_watermark_msg,
-                        )
-
                         handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
                     continue
 
                 # Staging: decode replies with allocated staging offset
                 if waiting_req_bytes[0] == b"STAGING_RSP":
                     if self.enable_staging:
-                        from sglang.srt.disaggregation.common.staging_handler import (
-                            handle_staging_rsp,
-                        )
-
                         handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
                     continue
 


### PR DESCRIPTION
## Motivation

`handle_watermark_msg` and `handle_staging_rsp` were imported **inside** the prefill bootstrap `while True` loops in both the mooncake and NIXL backends, so the import statement executed once per matching `WATERMARK` / `STAGING_RSP` message:

```python
while True:
    waiting_req_bytes = self.server_socket.recv_multipart()
    ...
    if room == "WATERMARK":
        from sglang.srt.disaggregation.common.staging_handler import (
            handle_watermark_msg,
        )

        handle_watermark_msg(self._staging_ctx, waiting_req_bytes)
        continue
```

There is no circular-import reason for this. Both files **already** import other names from `common.staging_handler` at module level (`STAGING_WATERMARK_WAIT_S`, `StagingManagerMixin`, and in mooncake's case the staging contexts), and `common/staging_handler.py` imports nothing from `sglang` at module scope — only stdlib and `torch`. So moving these two names into the existing top-level import blocks is free.

## Modifications

2 files, +4 / -16. Adds the two names to each file's existing `common.staging_handler` import block and deletes the four in-loop import statements. After this change neither file has any import inside a loop.

Two other in-loop imports in the module are **deliberately left alone**, because their laziness is load-bearing:

- `decode.py`: `dsv4_state_payloads` from `sglang.srt.hardware_backend.npu.dsv4`, guarded by `_is_npu and isinstance(token_to_kv_pool, DeepSeekV4TokenToKVPool)` — keeping it local avoids importing NPU hooks on non-NPU builds.
- `decode_schedule_batch_mixin.py`: `FINISH_ABORT` from `sglang.srt.managers.schedule_batch`, imported inside an `except ValueError` handler — that direction is a plausible import cycle.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched.

## Speed Tests and Profiling

Not applicable, and not worth measuring: a repeat import is a `sys.modules` dict hit, so the win is readability rather than throughput. It does remove work from a per-message control-plane path.

## Verification performed

- Confirmed `common/staging_handler.py` has no module-level `sglang` imports, so hoisting cannot introduce a cycle.
- Confirmed both files already import from that exact module at top level, so no new module dependency is created.
- Checked for name shadowing: each of `handle_watermark_msg` / `handle_staging_rsp` now appears exactly twice per file — the import and the call site.
- Verified by AST that zero import statements remain inside any loop in either file.
- Confirmed the `if self.enable_staging:` guard bodies in NIXL still contain their statement after the import removal.
- Pinned `ruff 0.15.1 --select=F401,F821,UP037` (the pre-commit config) passes, plus pinned `black 26.1.0` and `isort 7.0.0` — isort chose the placement within the existing blocks.

The staging paths were **not** exercised locally: they need a live PD pair with heterogeneous prefill/decode TP and `SGLANG_DISAGG_STAGING_BUFFER=1`, i.e. multi-GPU hardware. The change is import placement only, and F821 would flag an unresolved name at either call site.

Part of a series of disaggregation cleanups. Related: #35838, #35843, #35844, #35847, #35886, #35890, #35948, #35950.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: import placement only, no behavior to cover.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32571373140](https://github.com/sgl-project/sglang/actions/runs/32571373140)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32571373069](https://github.com/sgl-project/sglang/actions/runs/32571373069)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32571373145](https://github.com/sgl-project/sglang/actions/runs/32571373145)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->