### PR TITLE
[diffusion] Flatten Wan VAE RMSNorm row addressing

### DIFF
--- a/python/sglang/kernels/ops/diffusion/README.md
+++ b/python/sglang/kernels/ops/diffusion/README.md
@@ -104,7 +104,7 @@ Several norms look interchangeable and are not. Start here.
 |---|---|---|---|
 | `triton_group_norm_silu` / `apply_group_norm_silu` | Triton | close | NCHW-contiguous, any channels-per-group, always applies SiLU |
 | `group_norm_silu_4d` / `group_norm_silu_rows` | Triton | close | **channels_last only**; power-of-two `C <= 2048`; optional SiLU. This is what lets a VAE decoder run channels_last end-to-end with no `nchwToNhwc` |
-| `wan_rmsnorm_silu` | Triton | close | `channels_last_3d` 5D, Wan VAE channel-first RMSNorm + SiLU |
+| `wan_rmsnorm_silu` | Triton | close | dense `channels_last_3d` 5D (`stride(C) == 1`), Wan VAE channel-first RMSNorm + SiLU |
 | `rmsnorm_scale` / `rmsnorm_tanh_residual` | Triton | bf16-native statistics | Z-Image (matches its own reference exactly), Ideogram 4 (gated) |
 | `zimage_qk_rmsnorm_native` | Triton | bit-exact | Z-Image per-head QK RMSNorm |
 | `fused_qk_head_layernorm` | Triton | bit-exact | per-head LN on q/k, `dim_head % 4 == 0`, `<= 128` |

--- a/python/sglang/kernels/ops/diffusion/norm/wan_rmsnorm_silu_triton.py
+++ b/python/sglang/kernels/ops/diffusion/norm/wan_rmsnorm_silu_triton.py
@@ -34,19 +34,6 @@ def _wan_rmsnorm_silu_kernel(
     bias_ptr,
     out_ptr,
     channels: tl.constexpr,
-    t_size,
-    h_size,
-    w_size,
-    x_stride_b,
-    x_stride_c,
-    x_stride_t,
-    x_stride_h,
-    x_stride_w,
-    out_stride_b,
-    out_stride_c,
-    out_stride_t,
-    out_stride_h,
-    out_stride_w,
     rms_scale,
     eps,
     has_bias: tl.constexpr,
@@ -55,20 +42,11 @@ def _wan_rmsnorm_silu_kernel(
     row = tl.program_id(0).to(tl.int64)
     offsets = tl.arange(0, block_c)
     mask = offsets < channels
+    # Dense channels-last-3d stores each pixel as one contiguous channel row.
+    # Address it directly instead of recovering b/t/h/w with integer div/mod.
+    row_offsets = row * channels + offsets
 
-    w = row % w_size
-    tmp = row // w_size
-    h = tmp % h_size
-    tmp = tmp // h_size
-    t = tmp % t_size
-    b = tmp // t_size
-
-    x_base = b * x_stride_b + t * x_stride_t + h * x_stride_h + w * x_stride_w
-    out_base = b * out_stride_b + t * out_stride_t + h * out_stride_h + w * out_stride_w
-
-    x = tl.load(x_ptr + x_base + offsets * x_stride_c, mask=mask, other=0.0).to(
-        tl.float32
-    )
+    x = tl.load(x_ptr + row_offsets, mask=mask, other=0.0).to(tl.float32)
     norm = tl.sqrt(tl.sum(x * x, axis=0))
     inv_norm = 1.0 / tl.maximum(norm, eps)
 
@@ -84,7 +62,7 @@ def _wan_rmsnorm_silu_kernel(
     y = y.to(tl.float32)
     y = y * tl.sigmoid(y)
 
-    tl.store(out_ptr + out_base + offsets * out_stride_c, y, mask=mask)
+    tl.store(out_ptr + row_offsets, y, mask=mask)
 
 
 def _fake_wan_rmsnorm_silu(
@@ -125,11 +103,6 @@ def _triton_wan_rmsnorm_silu_cuda(
             bias,
             out,
             channels,
-            t_size,
-            h_size,
-            w_size,
-            *x.stride(),
-            *out.stride(),
             rms_scale,
             eps,
             has_bias,
@@ -163,6 +136,9 @@ def can_use_wan_rmsnorm_silu(
         and x.numel() > 0
         and 0 < x.shape[1] <= _MAX_CHANNELS
         and x.is_contiguous(memory_format=torch.channels_last_3d)
+        # Size-one channel tensors can satisfy the memory-format predicate
+        # while retaining channel-first strides, so require dense rows too.
+        and x.stride(1) == 1
         and _affine_supported(x, gamma)
         and (bias is None or _affine_supported(x, bias))
     )

--- a/test/registered/kernels/benchmark/diffusion/bench_wan_rmsnorm_silu.py
+++ b/test/registered/kernels/benchmark/diffusion/bench_wan_rmsnorm_silu.py
@@ -1,0 +1,107 @@
+from dataclasses import dataclass
+
+import torch
+import torch.nn.functional as F
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.ops.diffusion import wan_rmsnorm_silu
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=20,
+    stage="base-b-kernel-benchmark",
+    runner_config="1-gpu-large",
+    disabled="standalone benchmark",
+)
+
+DEVICE = "cuda"
+
+
+@dataclass(frozen=True)
+class Case:
+    name: str
+    shape: tuple[int, int, int, int, int]
+    x_dtype: torch.dtype
+    affine_dtype: torch.dtype
+    atol: float
+    rtol: float
+
+
+CASES = [
+    Case(
+        "fastwan21_c96_t4_h480_w832",
+        (1, 96, 4, 480, 832),
+        torch.bfloat16,
+        torch.float32,
+        1.5e-1,
+        3e-2,
+    ),
+    Case(
+        "fastwan22_c256_t4_h384_w576",
+        (1, 256, 4, 384, 576),
+        torch.float32,
+        torch.float32,
+        1e-5,
+        1e-5,
+    ),
+]
+CASE_BY_NAME = {case.name: case for case in CASES}
+CASE_NAMES = list(CASE_BY_NAME)
+
+
+@torch.no_grad()
+def native_wan_rmsnorm_silu(
+    x: torch.Tensor, gamma: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    return F.silu(F.normalize(x, dim=1) * x.shape[1] ** 0.5 * gamma + bias)
+
+
+@torch.no_grad()
+def sglang_wan_rmsnorm_silu(
+    x: torch.Tensor, gamma: torch.Tensor, bias: torch.Tensor
+) -> torch.Tensor:
+    return wan_rmsnorm_silu(x, gamma, bias)
+
+
+def make_inputs(case: Case) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    generator = torch.Generator(device=DEVICE)
+    generator.manual_seed(case.shape[1] * 1009 + case.shape[-1])
+    x = torch.randn(
+        case.shape,
+        device=DEVICE,
+        dtype=case.x_dtype,
+        generator=generator,
+    ).contiguous(memory_format=torch.channels_last_3d)
+    gamma = torch.randn(
+        (case.shape[1], 1, 1, 1),
+        device=DEVICE,
+        dtype=case.affine_dtype,
+        generator=generator,
+    )
+    bias = torch.randn_like(gamma)
+    return x, gamma, bias
+
+
+@marker.parametrize("case_name", CASE_NAMES)
+@marker.benchmark("provider", ["torch", "sglang"])
+def benchmark(case_name: str, provider: str) -> marker.BenchResult:
+    case = CASE_BY_NAME[case_name]
+    x, gamma, bias = make_inputs(case)
+    expected = native_wan_rmsnorm_silu(x, gamma, bias)
+    actual = sglang_wan_rmsnorm_silu(x, gamma, bias)
+    torch.testing.assert_close(actual, expected, atol=case.atol, rtol=case.rtol)
+    assert actual.stride() == x.stride()
+
+    fn = native_wan_rmsnorm_silu if provider == "torch" else sglang_wan_rmsnorm_silu
+    return marker.do_bench(
+        fn,
+        input_args=(x, gamma, bias),
+        use_cuda_graph=False,
+        replay_iters=100,
+        memory_args=(x, gamma, bias),
+        memory_output="out",
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/ops/diffusion/test_norm.py
+++ b/test/registered/kernels/ops/diffusion/test_norm.py
@@ -282,6 +282,19 @@ def test_wan_rmsnorm_silu_rejects_empty_input():
         wan_rmsnorm_silu(x, gamma)
 
 
+@torch.no_grad()
+def test_wan_rmsnorm_silu_rejects_non_dense_channel_rows():
+    # C=1 can report channels_last_3d compatibility while retaining NCTHW
+    # strides. The flat-row kernel requires stride(C)=1 and must fall back.
+    x = torch.randn(1, 1, 2, 3, 4, device=DEVICE, dtype=torch.bfloat16)
+    assert x.is_contiguous(memory_format=torch.channels_last_3d)
+    assert x.stride(1) != 1
+    gamma = torch.ones(1, 1, 1, 1, device=DEVICE, dtype=torch.float32)
+    assert not can_use_wan_rmsnorm_silu(x, gamma, None)
+    with pytest.raises(ValueError):
+        wan_rmsnorm_silu(x, gamma)
+
+
 # ---------------------------------------------------------------------------
 # CuTe-DSL fused (residual +) norm + scale/shift
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- address dense channels-last-3d Wan VAE activations as flat `[pixel, channel]` rows
- remove the per-program `b/t/h/w` div/mod chain and general stride reconstruction
- keep the normalization, dtype boundaries, SiLU path, launch geometry, and output layout unchanged
- add the dense-row guard, unit coverage, a registered benchmark, and kernel documentation

## Why

Nsight Compute on the representative FastWan2.1 shape (`[1, 96, 4, 480, 832]`, BF16 input / FP32 affine) shows 80.58% SM throughput but only 9.14% DRAM throughput and 93.93% achieved occupancy. Source counters attribute 120,771 / 196,793 samples to integer/index instructions. The hottest PCs are the reciprocal-based lowering of the row-to-`b/t/h/w` div/mod chain (`I2F.RP`, `IABS`, and `MUFU.RCP`).

Dense channels-last-3d already stores every pixel as a contiguous channel row, so those coordinates are unnecessary. `stride(C) == 1` is checked explicitly because size-one channel tensors can satisfy the memory-format predicate with channel-first strides.

## Performance

Single NVIDIA H200, cold-L2 registered benchmark:

| Shape | main | PR | Speedup |
|---|---:|---:|---:|
| FastWan2.1 BF16 `[1,96,4,480,832]` | 1550.848 us | 972.576 us | 37.29% |
| FastWan2.2 FP32 `[1,256,4,384,576]` | 921.184 us | 553.760 us | 39.89% |

FastWan2.1 end-to-end ABBA, one H200, eager, 832x480x61, 3 steps, no compile, resident DiT:

| Mode | main mean denoise / e2e | PR mean denoise / e2e | e2e change |
|---|---:|---:|---:|
| lossless | 0.8554 / 2.2129 s | 0.8553 / 2.2151 s | -0.10% (control; kernel is not mounted) |
| quality=high | 0.8513 / 1.9575 s | 0.8533 / 1.8823 s | **+3.84%** |

The quality-high full-stage trace reduces all 415 Wan RMSNorm+SiLU launches from 215.234 ms to 127.128 ms (40.94%). The largest C96 shape falls from 171.438 ms to 101.697 ms over 105 launches. Peak reserved memory stays at 31.402 GiB.

TurboWan2.1 T2V 1.3B provides a second model-level check at 832x480x81, 4 steps, quality=high, and no compile. Its main trace spends 286.083 ms across 545 Wan RMSNorm+SiLU launches (11.84% of GPU time). A clean main/PR/PR/main ABBA measured:

| Model | main mean denoise / e2e | PR mean denoise / e2e | e2e change |
|---|---:|---:|---:|
| TurboWan2.1 T2V 1.3B | 1.0106 / 2.4235 s | 1.0163 / 2.3325 s | **+3.76%** |

Denoise is 0.57% slower, confirming that the request gain comes from the VAE path rather than timing drift in the DiT. Peak reserved memory remains 30.729 GiB.

The 14B TurboWan checkpoints provide resolution scaling checks with the same 545 launches:

| Model | main mean denoise / e2e | PR mean denoise / e2e | kernel time | e2e change |
|---|---:|---:|---:|---:|
| 14B 480P | 6.6050 / 8.3559 s | 6.6067 / 8.2559 s | 289.647 -> 169.135 ms (-41.61%) | +1.20% |
| 14B 720P | 17.6763 / 21.2482 s | 17.7044 / 21.0438 s | 669.365 -> 389.957 ms (-41.74%) | +0.96% |

Both ABBA brackets are byte-exact across main and PR. These longer DiT-heavy requests dilute the VAE gain, but independently confirm the kernel reduction at both production resolutions.

TurboWan2.2 I2V A14B adds a four-H200 CFG/Ulysses check at 1280x720x81. Main averaged 7.6857 / 12.1847 s and the PR averaged 7.6780 / 12.2241 s. Rank-0 recorded GPU time fell from 12,020.198 to 11,866.292 ms (-1.28%), but synchronized e2e regressed 0.32%, so this checkpoint is validation evidence rather than a claimed request speedup. All five outputs are byte-exact.

## Output comparison

Prompt: `A curious raccoon walks through a sunlit forest.` Seed: `42`.

![main and PR contact sheet](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/wan-rmsnorm-flat-rows/contact-sheet.jpg)

[main video](https://github.com/BBuf/sglang/blob/pr-media/diffusion-prs/wan-rmsnorm-flat-rows/main.mp4) · [PR video](https://github.com/BBuf/sglang/blob/pr-media/diffusion-prs/wan-rmsnorm-flat-rows/pr.mp4) · [side-by-side video](https://github.com/BBuf/sglang/blob/pr-media/diffusion-prs/wan-rmsnorm-flat-rows/side-by-side.mp4)

All four FastWan quality-high outputs have the same SHA256: `fcd22372b15c84dca9b7e18848a4642103bbe6f52dc7fbb3314e9d3e81bceb8a`. All four TurboWan ABBA outputs have the same SHA256: `4eaef46a23e5e8c1e5a7a16941ba4c8b9080e2620ec2551848a11e0060270e46`.

## Validation

- `pytest -q test/registered/kernels/ops/diffusion/test_norm.py -k wan_rmsnorm_silu`: 4 passed
- `pytest -q test/registered/kernels/ops/diffusion/test_model_fast_paths.py -k wan_vae_gate`: 1 passed
- pre-commit on all changed files: passed after rebase onto current main
- all FastWan and TurboWan ABBA GPU-process boundaries were empty
- FastWan isolated cache cleanup: 29,228,743,029 bytes / 7 weight files -> 0
- TurboWan isolated cache cleanup: 16,777,680,195 bytes / 5 weight files -> 0
- TurboWan 14B 480P cache cleanup: baseline 42,521,216,678 bytes and ABBA 42,521,168,645 bytes / 7 weight files each -> 0
- TurboWan 14B 720P cache cleanup: baseline 42,519,295,635 bytes and ABBA 42,519,361,308 bytes / 7 weight files each -> 0
- TurboWan2.2 I2V A14B cache cleanup: baseline 71,103,355,450 bytes and ABBA 71,103,387,813 bytes / 10 weight files each -> 0

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32644106273](https://github.com/sgl-project/sglang/actions/runs/32644106273)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32661657125](https://github.com/sgl-project/sglang/actions/runs/32661657125)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32644106161](https://github.com/sgl-project/sglang/actions/runs/32644106161)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->