### PR TITLE
test: cover token sequence matcher

### DIFF
--- a/test/registered/unit/utils/test_token_sequence_matcher.py
+++ b/test/registered/unit/utils/test_token_sequence_matcher.py
@@ -1,0 +1,60 @@
+"""Unit tests for the token-sequence matcher used by reasoning parsers."""
+
+import unittest
+
+from sglang.srt.utils.token_sequence_matcher import TokenSequenceMatcher
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestTokenSequenceMatcher(CustomTestCase):
+    def test_rejects_empty_pattern(self):
+        with self.assertRaisesRegex(
+            ValueError, "pattern must contain at least one token"
+        ):
+            TokenSequenceMatcher([])
+
+    def test_builds_prefix_lengths_for_overlapping_pattern(self):
+        matcher = TokenSequenceMatcher([1, 2, 1, 2, 1])
+
+        self.assertEqual(len(matcher), 5)
+        self.assertEqual(matcher.pattern, (1, 2, 1, 2, 1))
+        self.assertEqual(matcher.prefix_lengths, (0, 0, 1, 2, 3))
+
+    def test_advance_matches_tokens(self):
+        matcher = TokenSequenceMatcher([1, 2, 1, 2])
+        matched = 0
+
+        for token in [1, 2, 1, 2]:
+            matched = matcher.advance(matched, token)
+
+        self.assertEqual(matched, len(matcher))
+
+        # A completed match can be restarted by the caller without creating a
+        # new matcher.
+        matched = 0
+        for token in [1, 2, 1, 2]:
+            matched = matcher.advance(matched, token)
+        self.assertEqual(matched, len(matcher))
+
+    def test_advance_falls_back_after_mismatch(self):
+        matcher = TokenSequenceMatcher([1, 2, 1, 3])
+        matched = 0
+
+        for token in [1, 2, 1, 2, 1, 3]:
+            matched = matcher.advance(matched, token)
+
+        self.assertEqual(matched, len(matcher))
+
+    def test_advance_ignores_unmatched_tokens(self):
+        matcher = TokenSequenceMatcher([4, 5])
+
+        self.assertEqual(matcher.advance(0, 9), 0)
+        self.assertEqual(matcher.advance(0, 4), 1)
+        self.assertEqual(matcher.advance(1, 9), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Closes a unit-test coverage gap tracked in #20865. `TokenSequenceMatcher` is used by reasoning parsers and scheduling code but had no dedicated unit tests.

## What

- cover empty-pattern validation
- cover KMP prefix-table construction for overlapping patterns
- cover successful matching, mismatch fallback, and unmatched tokens

## Tests

- `python -m py_compile test/registered/unit/utils/test_token_sequence_matcher.py`
- isolated execution of all 5 test cases: 5 passed
- `pre-commit run --files test/registered/unit/utils/test_token_sequence_matcher.py`

Related: #20865

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32572009394](https://github.com/sgl-project/sglang/actions/runs/32572009394)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32572009332](https://github.com/sgl-project/sglang/actions/runs/32572009332)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32572009340](https://github.com/sgl-project/sglang/actions/runs/32572009340)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->