### PR TITLE
Fix FA3 page_table OOB near context wall under speculative decoding

### DIFF
--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -225,6 +225,18 @@ class FlashAttentionBackend(AttentionBackend):
                 is_draft_worker=True,
                 num_draft_tokens=int(self.speculative_num_draft_tokens),
             )
+        # Spec decode (draft_extend / target_verify) sets cache_seqlens to
+        # seq_lens + num_draft_tokens. page_table / strided_indices are sized
+        # from max_context_len; without this headroom FA indexes past the
+        # page_table near the context wall (CUDA illegal memory access).
+        if self.speculative_num_draft_tokens:
+            self.max_context_len = (
+                int(model_runner.model_config.context_len)
+                + int(self.speculative_num_draft_tokens)
+            )
+            self.max_num_pages = (
+                self.max_context_len + self.page_size - 1
+            ) // self.page_size
         self.speculative_step_id = speculative_step_id
 
         # Local attention settings

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -230,9 +230,8 @@ class FlashAttentionBackend(AttentionBackend):
         # from max_context_len; without this headroom FA indexes past the
         # page_table near the context wall (CUDA illegal memory access).
         if self.speculative_num_draft_tokens:
-            self.max_context_len = (
-                int(model_runner.model_config.context_len)
-                + int(self.speculative_num_draft_tokens)
+            self.max_context_len = int(model_runner.model_config.context_len) + int(
+                self.speculative_num_draft_tokens
             )
             self.max_num_pages = (
                 self.max_context_len + self.page_size - 1

--- a/test/manual/spec/test_nextn_decode_context_boundary.py
+++ b/test/manual/spec/test_nextn_decode_context_boundary.py
@@ -89,7 +89,9 @@ def fetch_server_context_settings(base_url: str) -> tuple[int, int, int]:
 
     server_context = info.get("context_length")
     if server_context is None:
-        models_resp = requests.get(f"{root}/v1/models", timeout=SERVER_QUERY_TIMEOUT_SEC)
+        models_resp = requests.get(
+            f"{root}/v1/models", timeout=SERVER_QUERY_TIMEOUT_SEC
+        )
         models_resp.raise_for_status()
         models = models_resp.json()
         data = models.get("data") or []
@@ -282,7 +284,15 @@ def parse_stream(resp, tokenizer, *, log_prefix: str | None = None):
     return "".join(pieces), finish_reason
 
 
-def send_chat(args, messages, label: str, *, max_tokens: int, ignore_eos: bool = False, tokenizer=None):
+def send_chat(
+    args,
+    messages,
+    label: str,
+    *,
+    max_tokens: int,
+    ignore_eos: bool = False,
+    tokenizer=None,
+):
     url = args.base_url
     payload = {
         "model": args.model,
@@ -324,7 +334,9 @@ def send_chat(args, messages, label: str, *, max_tokens: int, ignore_eos: bool =
         return None, f"{type(exc).__name__}: {exc}", ""
 
 
-def long_decode_worker(args, tokenizer, crash: CrashFlag, stop: threading.Event, state: LongDecodeState):
+def long_decode_worker(
+    args, tokenizer, crash: CrashFlag, stop: threading.Event, state: LongDecodeState
+):
     messages, prompt_n = grow_prompt(tokenizer, args.long_prompt_tokens, "long-prompt")
     ceiling = max(1, args.long_max_tokens - TOKEN_SLACK)
     probe_max = ceiling
@@ -387,7 +399,9 @@ def long_decode_worker(args, tokenizer, crash: CrashFlag, stop: threading.Event,
 
 
 def _prefill_messages(tokenizer, prompt_tokens_n: int, label: str) -> tuple[list, int]:
-    messages = [{"role": "user", "content": make_text(tokenizer, prompt_tokens_n, label)}]
+    messages = [
+        {"role": "user", "content": make_text(tokenizer, prompt_tokens_n, label)}
+    ]
     return messages, prompt_tokens(tokenizer, messages)
 
 
@@ -422,7 +436,9 @@ def _background_prefill_loop(
             return
 
 
-def background_worker(args, tokenizer, crash: CrashFlag, stop: threading.Event, state: LongDecodeState):
+def background_worker(
+    args, tokenizer, crash: CrashFlag, stop: threading.Event, state: LongDecodeState
+):
     long_tokens = max(1, args.long_prompt_tokens // 2)
     print(
         f"background: 1x long_prefill≈{long_tokens}tok "
@@ -513,7 +529,9 @@ def main() -> int:
         flush=True,
     )
     print(f"loading tokenizer: {args.tokenizer_path}", flush=True)
-    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_path, trust_remote_code=True)
+    tokenizer = AutoTokenizer.from_pretrained(
+        args.tokenizer_path, trust_remote_code=True
+    )
 
     stop = threading.Event()
     crash = CrashFlag()

--- a/test/manual/spec/test_nextn_decode_context_boundary.py
+++ b/test/manual/spec/test_nextn_decode_context_boundary.py
@@ -1,0 +1,561 @@
+#!/usr/bin/env python3
+"""
+Manual test: NEXTN decode near the context boundary (FA3).
+
+Exercises long decode toward the server context limit with overlapping
+background prefills. Originally added to reproduce FA3 illegal memory access
+when ``draft_extend`` publishes ``seq_lens + num_draft_tokens`` past a
+page table sized to ``context_len`` only; still useful as a boundary stress
+script after the fix.
+
+Workload:
+  1) One long decode (ignore_eos) climbing toward the effective context wall
+  2) Background worker while decode is alive: 1 long-prefill thread + 2 short-prefill threads
+
+Context-length tuning (automatic)
+-------------------------------
+On startup the script queries the running server:
+
+- ``GET /server_info`` for ``context_length`` and ``speculative_num_draft_tokens``
+- ``GET /v1/models`` for ``max_model_len`` when ``context_length`` is unset
+
+It then **automatically sizes the long-decode request** so generation climbs
+toward the server's context limit — no manual ``--context-length`` tuning:
+
+- ``script_context = server_context_length``
+- ``long_prompt_tokens = int(script_context * 0.9)`` — most of the window is prefilled prompt
+- ``long_max_tokens = script_context - long_prompt_tokens + 200`` — first attempt asks for
+  slightly *more* generate tokens than the nominal remainder, so the server often returns a
+  4xx context overflow
+- ``context_probe_step = speculative_num_draft_tokens // 2`` — on overflow, reduce
+  ``max_tokens`` by this step and retry until the request is accepted
+
+That step-down search finds the **largest generate budget whose prompt+gen total fits
+the server wall** — i.e. long decode runs with total context as close as possible to
+``context_length``, which is where speculative ``draft_extend`` boundary bugs show up.
+
+Example:
+
+  python3 test/manual/spec/test_nextn_decode_context_boundary.py \\
+    --base-url http://127.0.0.1:8000/v1/chat/completions \\
+    --tokenizer-path /path/to/model
+
+Success signal: server dies / client sees connection or 5xx errors near the wall.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import threading
+import time
+from urllib.parse import urlparse
+
+import requests
+from transformers import AutoTokenizer
+
+TOKEN_SLACK = 8
+SERVER_QUERY_TIMEOUT_SEC = 30.0
+TIMEOUT_SEC = 3600.0
+RESTART_DELAY_SEC = 2.0
+ROUND_TIMEOUT_SEC = 7200.0
+BG_PREFILL_INTERVAL_SEC = 1.0
+SHORT_PREFILL_PROMPT_TOKENS = 32
+PREFILL_MAX_TOKENS = 16
+
+LONG_DECODE_INSTRUCTION = """
+FINAL LONG-DECODE TASK:
+Generate a very long deterministic continuation. Do not summarize. Do not stop early.
+Print numbered diagnostic lines until max_tokens is reached:
+line 000001 nextn context_wall
+line 000002 nextn context_wall
+Continue with increasing line numbers.
+"""
+
+
+def server_root(base_url: str) -> str:
+    parsed = urlparse(base_url)
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def fetch_server_context_settings(base_url: str) -> tuple[int, int, int]:
+    """Return (server_context_length, script_context_length, context_probe_step)."""
+    root = server_root(base_url)
+    info_resp = requests.get(f"{root}/server_info", timeout=SERVER_QUERY_TIMEOUT_SEC)
+    info_resp.raise_for_status()
+    info = info_resp.json()
+
+    server_context = info.get("context_length")
+    if server_context is None:
+        models_resp = requests.get(f"{root}/v1/models", timeout=SERVER_QUERY_TIMEOUT_SEC)
+        models_resp.raise_for_status()
+        models = models_resp.json()
+        data = models.get("data") or []
+        if not data:
+            raise RuntimeError("/v1/models returned no models")
+        server_context = data[0].get("max_model_len")
+    server_context = int(server_context)
+
+    num_draft = info.get("speculative_num_draft_tokens")
+    if not num_draft:
+        raise RuntimeError(
+            "server speculative_num_draft_tokens is missing or zero; "
+            "launch with speculative decoding enabled"
+        )
+    num_draft = int(num_draft)
+
+    script_context = server_context
+    probe_step = max(1, num_draft // 2)
+    return server_context, script_context, probe_step
+
+
+def content_tokens(tokenizer, text: str) -> int:
+    if not text:
+        return 0
+    return len(tokenizer.encode(text, add_special_tokens=False))
+
+
+def make_text(tokenizer, target_tokens: int, label: str) -> str:
+    if target_tokens <= 0:
+        return ""
+    seed = f"\n[{label}] nextn-decode-context-boundary.\n"
+    seed_ids = tokenizer.encode(seed, add_special_tokens=False) or tokenizer.encode(
+        " x", add_special_tokens=False
+    )
+    ids = (seed_ids * ((target_tokens // len(seed_ids)) + 2))[:target_tokens]
+    text = tokenizer.decode(ids)
+    for _ in range(16):
+        n = content_tokens(tokenizer, text)
+        if n == target_tokens:
+            return text
+        if n > target_tokens:
+            text = tokenizer.decode(
+                tokenizer.encode(text, add_special_tokens=False)[:target_tokens]
+            )
+        else:
+            text += " x" * (target_tokens - n)
+    return text
+
+
+def count_token_ids(value) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, dict) or hasattr(value, "get"):
+        try:
+            input_ids = value.get("input_ids")
+            if input_ids is not None:
+                return count_token_ids(input_ids)
+        except Exception:
+            pass
+    if hasattr(value, "input_ids") and not isinstance(value, (list, tuple, str)):
+        try:
+            return count_token_ids(value.input_ids)
+        except Exception:
+            pass
+    if hasattr(value, "shape"):
+        shape = tuple(value.shape)
+        if shape:
+            return int(shape[-1])
+    if isinstance(value, (list, tuple)):
+        if not value:
+            return 0
+        first = value[0]
+        if isinstance(first, (list, tuple)) or hasattr(first, "shape"):
+            return count_token_ids(first)
+        return len(value)
+    if isinstance(value, str):
+        return 0
+    return len(value)
+
+
+def prompt_tokens(tokenizer, messages) -> int:
+    try:
+        ids = tokenizer.apply_chat_template(
+            messages, tokenize=True, add_generation_prompt=True
+        )
+        n = count_token_ids(ids)
+        if n > 0:
+            return n
+    except Exception:
+        pass
+    raw = "\n".join(f"{m['role']}: {m.get('content', '')}" for m in messages)
+    return content_tokens(tokenizer, raw)
+
+
+def grow_prompt(tokenizer, target_tokens: int, label: str) -> tuple[list, int]:
+    messages = [
+        {
+            "role": "system",
+            "content": (
+                "You are a deterministic assistant for a NEXTN decode "
+                "context-boundary manual test."
+            ),
+        }
+    ]
+    low, high = 0, target_tokens + 2048
+    best, best_n = messages, prompt_tokens(tokenizer, messages)
+    while low <= high:
+        mid = (low + high) // 2
+        trial = messages + [
+            {"role": "user", "content": make_text(tokenizer, mid, label)}
+        ]
+        n = prompt_tokens(tokenizer, trial)
+        if n <= target_tokens:
+            best, best_n = trial, n
+            low = mid + 1
+        else:
+            high = mid - 1
+    if best and best[-1]["role"] == "user":
+        best[-1]["content"] = LONG_DECODE_INSTRUCTION + "\n" + best[-1]["content"]
+    else:
+        best = best + [{"role": "user", "content": LONG_DECODE_INSTRUCTION}]
+    return best, prompt_tokens(tokenizer, best)
+
+
+class LongDecodeState:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.alive = threading.Event()
+
+    def start(self):
+        self.alive.set()
+
+    def finish(self):
+        self.alive.clear()
+
+    def wait_alive(self, timeout: float) -> bool:
+        return self.alive.wait(timeout=timeout)
+
+
+class CrashFlag:
+    def __init__(self):
+        self.lock = threading.Lock()
+        self.reason = None
+
+    def set(self, reason: str):
+        with self.lock:
+            if self.reason is None:
+                self.reason = reason
+
+    def get(self):
+        with self.lock:
+            return self.reason
+
+
+def is_context_overflow(status: int, body: str) -> bool:
+    if status not in (400, 413, 422):
+        return False
+    lowered = (body or "").lower()
+    return any(
+        n in lowered
+        for n in ("context", "max_tokens", "too long", "exceed", "overflow")
+    )
+
+
+def parse_stream(resp, tokenizer, *, log_prefix: str | None = None):
+    pieces: list[str] = []
+    chunks = 0
+    finish_reason = None
+    for line in resp.iter_lines(decode_unicode=True):
+        if not line or not line.startswith("data: "):
+            continue
+        payload = line[6:]
+        if payload == "[DONE]":
+            break
+        chunks += 1
+        try:
+            data = json.loads(payload)
+            choice = data["choices"][0]
+            finish_reason = choice.get("finish_reason") or finish_reason
+            delta = choice.get("delta", {}) or {}
+            for key in ("content", "reasoning_content"):
+                part = delta.get(key)
+                if part:
+                    pieces.append(part)
+        except Exception:
+            pass
+        if log_prefix and chunks % 256 == 0:
+            full = content_tokens(tokenizer, "".join(pieces))
+            print(f"{log_prefix}: gen≈{full} chunks={chunks}", flush=True)
+    return "".join(pieces), finish_reason
+
+
+def send_chat(args, messages, label: str, *, max_tokens: int, ignore_eos: bool = False, tokenizer=None):
+    url = args.base_url
+    payload = {
+        "model": args.model,
+        "messages": messages,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": True,
+        "chat_template_kwargs": {"enable_thinking": False},
+    }
+    if ignore_eos:
+        payload["ignore_eos"] = True
+
+    started = time.time()
+    try:
+        with requests.post(url, json=payload, stream=True, timeout=TIMEOUT_SEC) as resp:
+            print(
+                f"{label}: status={resp.status_code} max_tokens={max_tokens} "
+                f"t={time.time() - started:.2f}s",
+                flush=True,
+            )
+            if resp.status_code >= 400:
+                body = resp.text[:1500]
+                print(f"{label}: body={body[:800]}", flush=True)
+                if resp.status_code >= 500:
+                    return None, f"http_{resp.status_code}", body
+                return "", f"http_{resp.status_code}", body
+            text, finish_reason = parse_stream(
+                resp,
+                tokenizer,
+                log_prefix=label if ignore_eos else None,
+            )
+            print(
+                f"{label}: done chars={len(text)} finish_reason={finish_reason} "
+                f"elapsed={time.time() - started:.1f}s",
+                flush=True,
+            )
+            return text, None, ""
+    except requests.exceptions.RequestException as exc:
+        return None, f"{type(exc).__name__}: {exc}", ""
+
+
+def long_decode_worker(args, tokenizer, crash: CrashFlag, stop: threading.Event, state: LongDecodeState):
+    messages, prompt_n = grow_prompt(tokenizer, args.long_prompt_tokens, "long-prompt")
+    ceiling = max(1, args.long_max_tokens - TOKEN_SLACK)
+    probe_max = ceiling
+    step = max(1, args.context_probe_step)
+    attempt = 0
+
+    print(
+        f"long-decode: prompt={prompt_n} context={args.context_length} "
+        f"long_prompt={args.long_prompt_tokens} ceiling={ceiling} step={step}",
+        flush=True,
+    )
+
+    while not stop.is_set() and crash.get() is None:
+        attempt += 1
+        max_tokens = max(1, min(probe_max, ceiling))
+        state.start()
+        print(f"long-decode: attempt={attempt} max_tokens={max_tokens}", flush=True)
+
+        text, err, body = send_chat(
+            args,
+            messages,
+            f"long-decode-a{attempt}",
+            max_tokens=max_tokens,
+            ignore_eos=True,
+            tokenizer=tokenizer,
+        )
+        state.finish()
+
+        status = None
+        if err and err.startswith("http_"):
+            try:
+                status = int(err.split("_", 1)[1])
+            except ValueError:
+                status = None
+
+        if status is not None and is_context_overflow(status, body):
+            # Step down max_tokens to probe the server's effective context-length.
+            probe_max = max(1, max_tokens - step)
+            print(
+                f"long-decode: CONTEXT_OVERFLOW status={status} "
+                f"-> probe down max_tokens by {step} to {probe_max} "
+                f"(effective full≈{prompt_n + probe_max})",
+                flush=True,
+            )
+            continue
+
+        if err and text is None:
+            crash.set(f"long-decode: {err}")
+            stop.set()
+            return
+
+        gen = content_tokens(tokenizer, text or "")
+        print(
+            f"long-decode: attempt={attempt} finished gen≈{gen} full≈{prompt_n + gen}",
+            flush=True,
+        )
+        if stop.is_set() or crash.get() is not None:
+            return
+        time.sleep(RESTART_DELAY_SEC)
+
+
+def _prefill_messages(tokenizer, prompt_tokens_n: int, label: str) -> tuple[list, int]:
+    messages = [{"role": "user", "content": make_text(tokenizer, prompt_tokens_n, label)}]
+    return messages, prompt_tokens(tokenizer, messages)
+
+
+def _background_prefill_loop(
+    args,
+    tokenizer,
+    crash: CrashFlag,
+    stop: threading.Event,
+    state: LongDecodeState,
+    *,
+    name: str,
+    prompt_tokens_n: int,
+):
+    seq = 0
+    while not stop.is_set() and crash.get() is None:
+        if not state.wait_alive(timeout=1.0):
+            continue
+        seq += 1
+        messages, n = _prefill_messages(tokenizer, prompt_tokens_n, name)
+        text, err, _ = send_chat(
+            args,
+            messages,
+            f"{name}-{seq}-p{n}",
+            max_tokens=PREFILL_MAX_TOKENS,
+            tokenizer=tokenizer,
+        )
+        if err and text is None:
+            crash.set(f"{name}: {err}")
+            stop.set()
+            return
+        if stop.wait(BG_PREFILL_INTERVAL_SEC):
+            return
+
+
+def background_worker(args, tokenizer, crash: CrashFlag, stop: threading.Event, state: LongDecodeState):
+    long_tokens = max(1, args.long_prompt_tokens // 2)
+    print(
+        f"background: 1x long_prefill≈{long_tokens}tok "
+        f"2x short_prefill≈{SHORT_PREFILL_PROMPT_TOKENS}tok",
+        flush=True,
+    )
+    threads = [
+        threading.Thread(
+            target=_background_prefill_loop,
+            args=(args, tokenizer, crash, stop, state),
+            kwargs={
+                "name": "bg-long-prefill",
+                "prompt_tokens_n": long_tokens,
+            },
+            daemon=True,
+            name="bg-long-prefill",
+        ),
+    ]
+    for i in range(2):
+        threads.append(
+            threading.Thread(
+                target=_background_prefill_loop,
+                args=(args, tokenizer, crash, stop, state),
+                kwargs={
+                    "name": f"bg-short-prefill-{i}",
+                    "prompt_tokens_n": SHORT_PREFILL_PROMPT_TOKENS,
+                },
+                daemon=True,
+                name=f"bg-short-prefill-{i}",
+            )
+        )
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+
+def derive_lengths(context_length: int) -> tuple[int, int]:
+    # Size long decode so prompt+gen total is driven toward context_length via
+    # overflow step-down in long_decode_worker (see module docstring).
+    long_prompt_tokens = max(1, int(context_length * 0.9))
+    long_max_tokens = max(1, context_length - long_prompt_tokens + 200)
+    return long_prompt_tokens, long_max_tokens
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "--base-url",
+        default=os.getenv("BASE_URL", "http://127.0.0.1:8000/v1/chat/completions"),
+    )
+    p.add_argument(
+        "--model",
+        default=os.getenv("MODEL", "/data/models/Qwen/Qwen3.5-397B-A17B-FP8"),
+    )
+    p.add_argument(
+        "--tokenizer-path",
+        default=os.getenv(
+            "TOKENIZER_PATH",
+            os.getenv("MODEL_PATH", "/data/models/Qwen/Qwen3.5-397B-A17B-FP8"),
+        ),
+    )
+    args = p.parse_args()
+
+    try:
+        (
+            args.server_context_length,
+            args.context_length,
+            args.context_probe_step,
+        ) = fetch_server_context_settings(args.base_url)
+    except (requests.RequestException, RuntimeError, TypeError, ValueError) as exc:
+        print(f"failed to read server context settings: {exc}", file=sys.stderr)
+        return 2
+
+    args.long_prompt_tokens, args.long_max_tokens = derive_lengths(args.context_length)
+    if args.context_probe_step >= args.long_max_tokens:
+        print(
+            "derived context-probe-step must be < script long_max_tokens",
+            file=sys.stderr,
+        )
+        return 2
+
+    print(
+        f"config: server_context={args.server_context_length} "
+        f"script_context={args.context_length} "
+        f"long_prompt={args.long_prompt_tokens} long_max={args.long_max_tokens} "
+        f"step={args.context_probe_step} (num_draft//2)",
+        flush=True,
+    )
+    print(f"loading tokenizer: {args.tokenizer_path}", flush=True)
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_path, trust_remote_code=True)
+
+    stop = threading.Event()
+    crash = CrashFlag()
+    state = LongDecodeState()
+    threads = [
+        threading.Thread(
+            target=long_decode_worker,
+            args=(args, tokenizer, crash, stop, state),
+            daemon=True,
+            name="long-decode",
+        ),
+        threading.Thread(
+            target=background_worker,
+            args=(args, tokenizer, crash, stop, state),
+            daemon=True,
+            name="background",
+        ),
+    ]
+    for t in threads:
+        t.start()
+
+    deadline = time.time() + ROUND_TIMEOUT_SEC
+    while time.time() < deadline:
+        reason = crash.get()
+        if reason is not None:
+            stop.set()
+            print(f"CRASH / server unreachable: {reason}", flush=True)
+            return 1
+        if not any(t.is_alive() for t in threads):
+            break
+        time.sleep(0.5)
+
+    stop.set()
+    for t in threads:
+        t.join(timeout=5)
+    reason = crash.get()
+    if reason is not None:
+        print(f"CRASH / server unreachable: {reason}", flush=True)
+        return 1
+    print("finished without observing a crash", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/test/registered/unit/layers/attention/test_flashattention_spec_context_headroom.py
+++ b/test/registered/unit/layers/attention/test_flashattention_spec_context_headroom.py
@@ -1,0 +1,146 @@
+"""Regression: FA3 page_table width must reserve draft_extend headroom.
+
+Speculative ``draft_extend`` / ``target_verify`` paths set ``cache_seqlens`` to
+``seq_lens + speculative_num_draft_tokens``. ``FlashAttentionBackend`` sizes CUDA
+graph page tables from ``max_context_len``; without widening by
+``num_draft_tokens``, FA indexes past the page table near the context wall
+(CUDA illegal memory access).
+
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.configs.model_config import AttentionArch
+from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+CONTEXT_LEN = 64
+NUM_DRAFT = 4
+
+
+def _make_runner(*, context_len: int = CONTEXT_LEN, page_size: int = 16):
+    device = "cuda"
+    req_to_token_pool = SimpleNamespace(
+        size=4,
+        req_to_token=torch.zeros(
+            5,
+            context_len + NUM_DRAFT,
+            dtype=torch.int32,
+            device=device,
+        ),
+    )
+    model_config = SimpleNamespace(
+        is_encoder_decoder=False,
+        context_len=context_len,
+        attention_arch=AttentionArch.MHA,
+        is_local_attention_model=False,
+        head_dim=8,
+        hf_text_config=SimpleNamespace(
+            num_attention_heads=2, attn_logit_softcapping=None
+        ),
+        get_num_kv_heads=lambda tp_size: 2,
+    )
+    return SimpleNamespace(
+        sliding_window_size=None,
+        model_config=model_config,
+        device=device,
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool=object(),
+        token_to_kv_pool_allocator=object(),
+        kv_cache_dtype=torch.float16,
+        kv_cache_dtype_str="auto",
+        page_size=page_size,
+        ps=SimpleNamespace(attn_cp_size=1, tp_size=1),
+        is_draft_worker=False,
+        server_args=None,
+        attention_chunk_size=None,
+        prefill_aware_swa=False,
+    )
+
+
+def _expected_num_pages(context_len: int, page_size: int) -> int:
+    return (context_len + page_size - 1) // page_size
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "Test requires CUDA")
+class TestFlashAttentionSpecContextHeadroom(CustomTestCase):
+    def _publish_runner(self, runner, **fields):
+        override = get_context().override_server_args(**fields)
+        server_args = override.install()
+        runner.server_args = server_args
+        runner.kv_cache_dtype_str = server_args.kv_cache_dtype
+        self.addCleanup(override.restore)
+        return runner
+
+    def _backend(self, *, page_size: int = 16, **server_args_fields):
+        runner = self._publish_runner(_make_runner(page_size=page_size), **server_args_fields)
+        backend = FlashAttentionBackend(runner)
+        return runner, backend
+
+    def test_no_spec_uses_model_context_len(self):
+        runner, backend = self._backend(page_size=16)
+
+        self.assertIsNone(runner.server_args.speculative_num_draft_tokens)
+        self.assertEqual(backend.max_context_len, CONTEXT_LEN)
+        self.assertEqual(
+            backend.max_num_pages,
+            _expected_num_pages(CONTEXT_LEN, runner.page_size),
+        )
+
+    def test_spec_adds_draft_headroom(self):
+        runner, backend = self._backend(
+            page_size=16,
+            speculative_algorithm="EAGLE",
+            speculative_num_draft_tokens=NUM_DRAFT,
+            speculative_num_steps=NUM_DRAFT - 1,
+        )
+
+        self.assertEqual(runner.server_args.speculative_num_draft_tokens, NUM_DRAFT)
+        expected_len = CONTEXT_LEN + NUM_DRAFT
+        self.assertEqual(backend.max_context_len, expected_len)
+        self.assertEqual(
+            backend.max_num_pages,
+            _expected_num_pages(expected_len, runner.page_size),
+        )
+
+    def test_cuda_graph_buffers_match_widened_bound(self):
+        runner, backend = self._backend(
+            page_size=16,
+            speculative_algorithm="EAGLE",
+            speculative_num_draft_tokens=NUM_DRAFT,
+            speculative_num_steps=NUM_DRAFT - 1,
+        )
+        max_bs = 4
+        backend.init_cuda_graph_state(max_bs=max_bs, max_num_tokens=16)
+
+        expected_pages = _expected_num_pages(CONTEXT_LEN + NUM_DRAFT, runner.page_size)
+        decode_meta = backend.decode_cuda_graph_metadata
+        self.assertEqual(decode_meta["page_table"].shape, (max_bs, expected_pages))
+        self.assertEqual(
+            decode_meta["strided_indices"].numel(),
+            expected_pages,
+        )
+        self.assertIn("draft_extend_metadata", backend.__dict__)
+        self.assertEqual(
+            backend.draft_extend_metadata["page_table"].shape,
+            (max_bs, expected_pages),
+        )
+        self.assertEqual(
+            backend.draft_extend_metadata["strided_indices"].numel(),
+            expected_pages,
+        )
+        self.assertEqual(
+            backend.target_verify_metadata["page_table"].shape,
+            (max_bs, expected_pages),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_flashattention_spec_context_headroom.py
+++ b/test/registered/unit/layers/attention/test_flashattention_spec_context_headroom.py
@@ -80,7 +80,9 @@ class TestFlashAttentionSpecContextHeadroom(CustomTestCase):
         return runner
 
     def _backend(self, *, page_size: int = 16, **server_args_fields):
-        runner = self._publish_runner(_make_runner(page_size=page_size), **server_args_fields)
+        runner = self._publish_runner(
+            _make_runner(page_size=page_size), **server_args_fields
+        )
         backend = FlashAttentionBackend(runner)
         return runner, backend
 


### PR DESCRIPTION
## Motivation
Fixes #34239

Fixes a CUDA illegal memory access (IMA) in `FlashAttentionBackend` when speculative decoding (`EAGLE` / `NEXTN`) runs long decode near the model context limit with FA3.
The FA3 CUDA-graph page table is sized at backend init from `max_context_len`. Speculative `draft_extend` and `target_verify` publish `cache_seqlens = seq_lens + speculative_num_draft_tokens`, but the page table was only wide enough for `model_config.context_len`. Near the context wall, FA indexes past the static page-table bound → IMA (often surfaced asynchronously at unrelated ops like `all_gather` / `copy_done.synchronize()`).
This PR widens `max_context_len` and `max_num_pages` by `speculative_num_draft_tokens` whenever spec is enabled, so static page-table / `strided_indices` buffers match what spec metadata already publishes. 

## Root cause

1. **`prepare_for_draft_extend`** bumps the forward batch length before attention metadata is built:
   ```python
   forward_batch.seq_lens = forward_batch.seq_lens + num_draft_tokens
FA3 replay copies that length into cache_seqlens for DRAFT_EXTEND_V2 / TARGET_VERIFY CUDA-graph paths.

Page-table width was derived only from model_config.context_len at FlashAttentionBackend.__init__, while req_to_token rows already reserve extra headroom via get_req_to_token_extra_context_len(). The mismatch is specifically in FA’s device-side page-table buffers (draft_extend_metadata, target_verify_metadata, decode graph tables), not in req_to_token.

When plain decode still fits (seq_len ≈ context_len - k) but seq_len + num_draft_tokens exceeds the page-table width, the FA kernel reads OOB from block_table.

## Modifications

In FlashAttentionBackend.__init__, after resolving speculative_num_draft_tokens:

if self.speculative_num_draft_tokens:
    self.max_context_len = context_len + speculative_num_draft_tokens
    self.max_num_pages = ceil(max_context_len / page_size)
Applied for any FA backend instance with spec enabled (target worker and draft worker). Both draft_extend and target_verify use the widened bound.

## Test plan

CI: 
python3 test/registered/unit/layers/attention/test_flashattention_spec_context_headroom.py

Manual (pre-fix crashes, post-fix survives):
Server (example; match your hardware):
python -m sglang.launch_server \
  --model-path <Qwen3.5-397B-FP8> \
  --context-length 65600 \
  --speculative-algorithm NEXTN \
  --speculative-num-steps 7 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 8 \
  --attention-backend fa3 \
  ...
Repro client:
python3 test/manual/spec/test_nextn_decode_context_boundary.py \
  --base-url http://127.0.0.1:8000/v1/chat/completions \
--model /path/to/model
  --tokenizer-path /path/to/model

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
