### PR TITLE
[npu] Kill evalscope session by process group and fix report score parsing

### DIFF
--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -274,7 +274,7 @@ def run_evalscope(
             logger.info("Process killed")
         _kill_evalscope_session(process)
         raise
-    
+
     except Exception as e:
         logger.error(f"Error executing command: {e}")
         process.terminate()

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -104,6 +105,21 @@ def get_max_retries(datasets):
     return 1
 
 
+def _kill_evalscope_session(process):
+    """Kill the whole evalscope session (process.pid is the leader == pgid)."""
+    if process is None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+        logger.info(f"run_evalscope killed session pgid={process.pid}")
+    except ProcessLookupError:
+        logger.info(f"run_evalscope session pgid={process.pid} already gone")
+    except PermissionError:
+        logger.warning(
+            f"run_evalscope no permission to kill session pgid={process.pid}"
+        )
+
+
 def run_evalscope(
     host,
     port,
@@ -177,6 +193,12 @@ def run_evalscope(
         text=True,
         bufsize=1,
         shell=True,
+        start_new_session=True,
+    )
+
+    logger.info(
+        f"run_evalscope spawned: pid={process.pid} "
+        f"pgid={os.getpgid(process.pid)} cmd={cmd}"
     )
 
     output_lines = []
@@ -187,6 +209,13 @@ def run_evalscope(
             output_lines.append(line.strip())
 
         process.wait()
+
+        logger.info(
+            f"run_evalscope finished: pid={process.pid} "
+            f"returncode={process.returncode}"
+        )
+
+        _kill_evalscope_session(process)
 
         if process.returncode != 0:
             logger.error(f"Command failed with return code: {process.returncode}")
@@ -204,12 +233,10 @@ def run_evalscope(
             try:
                 with open(report_path, "r") as rf:
                     report_data = json.load(rf)
-                for item in report_data:
-                    score = item.get("score")
-                    if score is not None:
-                        metrics["accuracy"] = float(score)
-                        logger.info(f"The Final Accuracy from report: {score}")
-                        break
+                score = report_data.get("score")
+                if score is not None:
+                    metrics["accuracy"] = float(score)
+                    logger.info(f"The Final Accuracy from report: {score}")
             except Exception as e:
                 logger.warning(f"Failed to read report file {report_path}: {e}")
 
@@ -245,11 +272,14 @@ def run_evalscope(
             logger.warning("Process did not terminate gracefully, killing it...")
             process.kill()
             logger.info("Process killed")
+        _kill_evalscope_session(process)
         raise
+    
     except Exception as e:
         logger.error(f"Error executing command: {e}")
         process.terminate()
         process.wait(timeout=5)
+        _kill_evalscope_session(process)
         raise
 
 


### PR DESCRIPTION
## Motivation

Fix evalscope process cleanup on Ascend NPU and evalscope report score parsing.

Nightly accuracy suites (e.g. acc-16 / acc-2) were OOM-killed (exit 137) because orphan evalscope/forkserver processes accumulated memory between test cases. The report parser also emitted `'str' object has no attribute 'get'`.

## Modifications

- Run evalscope in its own session (`start_new_session=True`) and kill the whole process group via `os.killpg` on every exit path (normal / KeyboardInterrupt / Exception), so no orphan processes remain.
- Fix report parsing to read the top-level `score` field instead of iterating the JSON object as a list.

## Accuracy Tests

N/A (no change to model forward / outputs).

## Speed Tests and Profiling

N/A

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32583633112](https://github.com/sgl-project/sglang/actions/runs/32583633112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32583633104](https://github.com/sgl-project/sglang/actions/runs/32583633104)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32583633290](https://github.com/sgl-project/sglang/actions/runs/32583633290)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->