### PR TITLE
[NPU] Revert fused Triton MRoPE for Qwen3.x and fall back to native multimodal RoPE

### DIFF
--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -283,20 +283,7 @@ class MRotaryEmbedding(RotaryEmbedding):
         assert (
             fused_set_kv_buffer_arg is None
         ), "fused_set_kv_buffer_arg is not supported for npu implementation"
-        if query.shape[1] > 4096:
-            return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)
-        rotary_mode = "half" if self.is_neox_style else "interleave"
-        mrope_section = [0, 0, 0]
-        query_out, key_out = torch_npu.npu_mrope(
-            positions,
-            query,
-            key,
-            self.cos_sin_cache,
-            self.head_size,
-            mrope_section=mrope_section,
-            rotary_mode=rotary_mode,
-        )
-        return query_out, key_out
+        return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)
 
     def forward_xpu(
         self,

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -22,21 +22,16 @@ from sglang.srt.runtime_context import attention_backends
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cuda,
-    is_npu,
     is_xpu,
     support_triton,
 )
 
 _is_cuda = is_cuda()
-_is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_cpu_amx_available = cpu_has_amx_support()
 
 if _is_cuda:
     from sglang.kernels.ops.attention.rope import apply_rope_with_cos_sin_cache_inplace
-
-if _is_npu:
-    import torch_npu
 
 if _is_xpu:
     from sgl_kernel import multimodal_rotary_embedding

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -250,8 +250,8 @@ def _select_fused_ar_input_for_linear(hidden_states, linear: nn.Module):
 
 
 if _is_npu:
-    from sgl_kernel_npu.norm.split_qkv_rmsnorm_mrope import (
-        triton_split_qkv_rmsnorm_mrope,
+    from sgl_kernel_npu.norm.split_qkv_rmsnorm_rope import (
+        split_qkvgate_gemma_rmsnorm_rope,
     )
 
 
@@ -1158,23 +1158,21 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
     def forward_prepare_npu(self, positions, hidden_states, forward_batch):
         qkv, _ = self.qkv_proj(hidden_states)
-        cos_sin = self.rotary_emb.cos_sin_cache[positions]
-        if cos_sin.device != qkv.device or cos_sin.dtype != qkv.dtype:
-            cos_sin = cos_sin.to(device=qkv.device, dtype=qkv.dtype)
+        # Calculate first full attention layer ID based on config
+        if self.attn.layer_id == (self.config.full_attention_interval - 1):
+            self.rotary_emb.get_cos_sin_with_position(positions)
 
-        q, k, v, gate = triton_split_qkv_rmsnorm_mrope(
-            qkv=qkv,
-            q_weight=self.q_norm.gemma_weight,
-            k_weight=self.k_norm.gemma_weight,
-            cos_sin=cos_sin,
-            num_q_heads=self.num_heads,
-            num_kv_heads=self.num_kv_heads,
-            head_size=self.head_dim,
+        q, k, v, gate = split_qkvgate_gemma_rmsnorm_rope(
+            qkv,
+            self.rotary_emb.position_sin,
+            self.rotary_emb.position_cos,
+            self.q_size,
+            self.kv_size,
+            self.head_dim,
+            int(self.head_dim * self.partial_rotary_factor),
             eps=self.q_norm.variance_epsilon,
-            mrope_section=self.rotary_emb.mrope_section,
-            is_interleaved=self.rotary_emb.mrope_interleaved,
-            rope_dim=self.rotary_emb.rotary_dim,
-            has_gate=self.attn_output_gate,
+            q_weight=self.q_norm.weight,
+            k_weight=self.k_norm.weight,
         )
         return q, k, v, gate
 
@@ -1195,7 +1193,11 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
                 positions=positions,
                 hidden_states=hidden_states,
             )
-        elif not _is_npu or not self.attn_output_gate:
+        elif (
+            not _is_npu
+            or forward_batch.forward_mode.is_extend_or_draft_extend_or_mixed()
+            or not self.attn_output_gate
+        ):
             q, k, v, gate = self.forward_prepare_native(
                 positions=positions,
                 hidden_states=hidden_states,


### PR DESCRIPTION
## Description

Revert the fused Triton MRoPE integration for Qwen3.x on NPU (#35817) and fall back to the native multimodal RoPE implementation for consistent text and multimodal position handling.

## Changes

1. **Revert "[NPU] Use fused Triton MRoPE for Qwen3.x (#35817)"** (reverts 47129c650)
   - `qwen3_5.py`: switch back from `triton_split_qkv_rmsnorm_mrope` to `split_qkvgate_gemma_rmsnorm_rope`
   - Restore the native forward path logic, including the `full_attention_interval`-based cos/sin computation
   - Force the native path in extend / draft_extend / mixed forward modes

2. **fix(npu): fall back to native multimodal RoPE**
   - `mrope.py`: remove the `torch_npu.npu_mrope` fused path so NPU MRoPE always uses `forward_native`

## Commits

- 0658d24c5 Revert "[NPU] Use fused Triton MRoPE for Qwen3.x (#35817)"
- 24bac8a41 fix(npu): fall back to native multimodal RoPE

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32583224051](https://github.com/sgl-project/sglang/actions/runs/32583224051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32583223844](https://github.com/sgl-project/sglang/actions/runs/32583223844)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32583224018](https://github.com/sgl-project/sglang/actions/runs/32583224018)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->