### PR TITLE
[NPU] Keep DeepSeek router GEMM output in fp32

### DIFF
--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -477,8 +477,11 @@ class MoEGate(nn.Module):
         super().__init__()
         self.is_nextn = is_nextn
         self.is_deepseek_v4 = is_deepseek_v4
+        weight_shape = (config.n_routed_experts, config.hidden_size)
         self.weight = nn.Parameter(
-            torch.empty((config.n_routed_experts, config.hidden_size))
+            torch.empty(weight_shape, dtype=torch.float32)
+            if _is_npu
+            else torch.empty(weight_shape)
         )
 
         if config.topk_method == "noaux_tc" and not is_hash_moe:
@@ -501,6 +504,9 @@ class MoEGate(nn.Module):
         self.dsa_enable_prefill_cp = dsa_enable_prefill_cp
         self.mla_enable_prefill_cp = mla_enable_prefill_cp
 
+    def _npu_router_gemm_fp32(self, hidden_states: torch.Tensor) -> torch.Tensor:
+        return F.linear(hidden_states.float(), self.weight, None)
+
     def forward(
         self,
         hidden_states,
@@ -516,6 +522,8 @@ class MoEGate(nn.Module):
             )
 
         if get_exec().deterministic.enable_deterministic_inference:
+            if _is_npu:
+                return self._npu_router_gemm_fp32(hidden_states)
             return F.linear(hidden_states, self.weight, None)
 
         if (
@@ -530,6 +538,8 @@ class MoEGate(nn.Module):
                 from sglang.kernels.ops.attention.dsv4 import linear_bf16_fp32
 
                 return linear_bf16_fp32(hidden_states, self.weight)
+            if _is_npu:
+                return self._npu_router_gemm_fp32(hidden_states)
             return F.linear(hidden_states, self.weight, None)
         else:
             if (
@@ -545,6 +555,8 @@ class MoEGate(nn.Module):
 
             elif _use_aiter:
                 logits = aiter_dsv3_router_gemm(hidden_states, self.weight)
+            elif _is_npu:
+                logits = self._npu_router_gemm_fp32(hidden_states)
             elif not _is_cuda:
                 logits = F.linear(hidden_states, self.weight, None)
             else:

--- a/test/registered/unit/models/test_deepseek_v2_npu_router.py
+++ b/test/registered/unit/models/test_deepseek_v2_npu_router.py
@@ -1,0 +1,195 @@
+"""Unit tests for the DeepSeek MoE gate's NPU FP32 router projection."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+import torch.nn.functional as F
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.model_loader.weight_utils import default_weight_loader  # noqa: E402
+from sglang.srt.models import deepseek_v2  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _gate_config(*, hidden_size=16, n_routed_experts=8):
+    return SimpleNamespace(
+        architectures=["DeepseekV2ForCausalLM"],
+        hidden_size=hidden_size,
+        n_routed_experts=n_routed_experts,
+        topk_method="greedy",
+    )
+
+
+def _exec_config(*, deterministic=False):
+    return SimpleNamespace(
+        deterministic=SimpleNamespace(
+            enable_deterministic_inference=deterministic,
+        )
+    )
+
+
+class TestDeepseekV2NpuRouter(CustomTestCase):
+    def _make_gate(self, *, is_npu):
+        original_dtype = torch.get_default_dtype()
+        try:
+            torch.set_default_dtype(torch.bfloat16)
+            with patch.object(deepseek_v2, "_is_npu", is_npu):
+                return deepseek_v2.MoEGate(_gate_config(), quant_config=None)
+        finally:
+            torch.set_default_dtype(original_dtype)
+
+    def _run_npu_gate(
+        self,
+        gate,
+        hidden_states,
+        *,
+        deterministic=False,
+        prefill_context_parallel=False,
+    ):
+        forward_batch = object() if prefill_context_parallel else None
+        with (
+            patch.object(deepseek_v2, "_is_npu", True),
+            patch.object(deepseek_v2, "_is_cuda", False),
+            patch.object(deepseek_v2, "_use_aiter", False),
+            patch.object(
+                deepseek_v2,
+                "get_exec",
+                return_value=_exec_config(deterministic=deterministic),
+            ),
+            patch.object(
+                deepseek_v2,
+                "dsa_use_prefill_cp",
+                return_value=prefill_context_parallel,
+            ),
+            patch.object(
+                deepseek_v2,
+                "mla_use_prefill_cp",
+                return_value=False,
+            ),
+        ):
+            return gate(hidden_states, forward_batch=forward_batch)
+
+    def test_bf16_writeback_differs_from_fp32_projection(self):
+        torch.manual_seed(34861)
+        hidden_states = torch.randn(16, 32, dtype=torch.bfloat16)
+        weight = torch.randn(12, 32, dtype=torch.bfloat16)
+
+        bf16_then_fp32 = F.linear(hidden_states, weight).float()
+        fp32_reference = F.linear(hidden_states.float(), weight.float())
+
+        self.assertFalse(torch.equal(bf16_then_fp32, fp32_reference))
+        self.assertGreater(
+            (bf16_then_fp32 - fp32_reference).abs().max().item(),
+            0.0,
+        )
+
+    def test_npu_gate_weight_stays_fp32_after_load_and_update(self):
+        gate = self._make_gate(is_npu=True)
+        self.assertEqual(gate.weight.dtype, torch.float32)
+
+        checkpoint_weight = torch.randn_like(gate.weight, dtype=torch.bfloat16)
+        default_weight_loader(gate.weight, checkpoint_weight)
+        self.assertEqual(gate.weight.dtype, torch.float32)
+        torch.testing.assert_close(gate.weight, checkpoint_weight.float())
+
+        updated_weight = torch.full_like(checkpoint_weight, 0.25)
+        default_weight_loader(gate.weight, updated_weight)
+        self.assertEqual(gate.weight.dtype, torch.float32)
+        torch.testing.assert_close(gate.weight, updated_weight.float())
+
+    def test_non_npu_gate_keeps_default_parameter_dtype(self):
+        gate = self._make_gate(is_npu=False)
+        self.assertEqual(gate.weight.dtype, torch.bfloat16)
+
+    def test_regular_npu_routing_returns_fp32_reference(self):
+        gate = self._make_gate(is_npu=True)
+        torch.manual_seed(1)
+        checkpoint_weight = torch.randn_like(gate.weight, dtype=torch.bfloat16)
+        default_weight_loader(gate.weight, checkpoint_weight)
+        hidden_states = torch.randn(4, gate.weight.shape[1], dtype=torch.bfloat16)
+
+        logits = self._run_npu_gate(gate, hidden_states)
+        reference = F.linear(hidden_states.float(), gate.weight)
+
+        self.assertEqual(logits.dtype, torch.float32)
+        torch.testing.assert_close(logits, reference)
+
+    def test_all_npu_branches_use_shared_fp32_projection(self):
+        hidden_states = torch.randn(4, 16, dtype=torch.bfloat16)
+        cases = (
+            ("regular", False, False),
+            ("prefill_context_parallel", False, True),
+            ("deterministic", True, False),
+        )
+
+        for name, deterministic, prefill_context_parallel in cases:
+            with self.subTest(name=name):
+                gate = self._make_gate(is_npu=True)
+                expected = torch.randn(4, 8, dtype=torch.float32)
+                with patch.object(
+                    gate,
+                    "_npu_router_gemm_fp32",
+                    return_value=expected,
+                ) as mock_projection:
+                    logits = self._run_npu_gate(
+                        gate,
+                        hidden_states,
+                        deterministic=deterministic,
+                        prefill_context_parallel=prefill_context_parallel,
+                    )
+
+                self.assertIs(logits, expected)
+                mock_projection.assert_called_once_with(hidden_states)
+
+    def test_non_npu_routing_does_not_use_npu_projection(self):
+        gate = self._make_gate(is_npu=False)
+        hidden_states = torch.randn(4, 16, dtype=torch.bfloat16)
+        with (
+            patch.object(deepseek_v2, "_is_npu", False),
+            patch.object(deepseek_v2, "_is_cuda", False),
+            patch.object(deepseek_v2, "_use_aiter", False),
+            patch.object(
+                deepseek_v2,
+                "get_exec",
+                return_value=_exec_config(deterministic=False),
+            ),
+            patch.object(
+                gate,
+                "_npu_router_gemm_fp32",
+                side_effect=AssertionError("unexpected NPU projection"),
+            ) as mock_projection,
+        ):
+            logits = gate(hidden_states)
+
+        self.assertEqual(logits.dtype, torch.bfloat16)
+        mock_projection.assert_not_called()
+
+    def test_runtime_weight_update_changes_next_projection(self):
+        gate = self._make_gate(is_npu=True)
+        hidden_states = torch.ones(2, 16, dtype=torch.bfloat16)
+        default_weight_loader(
+            gate.weight,
+            torch.zeros_like(gate.weight, dtype=torch.bfloat16),
+        )
+        before_update = self._run_npu_gate(gate, hidden_states)
+
+        default_weight_loader(
+            gate.weight,
+            torch.ones_like(gate.weight, dtype=torch.bfloat16),
+        )
+        after_update = self._run_npu_gate(gate, hidden_states)
+
+        self.assertEqual(after_update.dtype, torch.float32)
+        self.assertFalse(torch.equal(before_update, after_update))
+        torch.testing.assert_close(after_update, torch.full_like(after_update, 16.0))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

DeepSeek MoE router logits should preserve FP32 precision before expert
selection.

On NPU, the existing fallback uses `F.linear` with BF16 activations and
weights, which writes the router logits in BF16. The downstream NPU top-k
path converts those logits to FP32, but that post-hoc conversion cannot
recover the mantissa bits already lost during BF16 writeback.

This affects all three NPU execution paths in `MoEGate.forward`:

- regular routing
- prefill context-parallel routing
- deterministic inference

Fixes #34861

## Modifications

- Keep the authoritative `MoEGate.weight` parameter in FP32 on NPU.
  Checkpoint loading and runtime weight updates continue to write into the
  same live parameter, avoiding a stale derived cache.
- Add a shared NPU FP32 router projection:
  `F.linear(hidden_states.float(), weight_fp32)`.
- Route regular, prefill context-parallel, and deterministic NPU execution
  through the shared projection.
- Preserve the existing CUDA, ROCm/aiter, CPU, and XPU dispatch paths.
- Do not change NPU top-k, correction bias, grouped routing, checkpoint
  format, or public APIs.

Keeping the live NPU gate weight in FP32 avoids converting the entire router
weight on every forward pass. It increases persistent gate storage by two
bytes per weight element compared with BF16.

## Accuracy Tests

### CPU CI-compatible tests

Environment:

- Python 3.11.15
- PyTorch 2.10.0+cpu

Command:

```bash
python -m pytest test/registered/unit/models/test_deepseek_v2_npu_router.py -v
```

Results:

- New focused test `test/registered/unit/models/test_deepseek_v2_npu_router.py`:
  7 passed, including 3 branch subtests.
- Nearby DeepSeek model unit tests: 25 passed, 4 skipped
  (skipped branches need CUDA/MUSA/NPU quant kernels; CPU CI skips them too).

The focused test covers:

- BF16 writeback followed by `.float()` differs from a direct FP32 projection
- NPU gate construction and checkpoint loading preserve the FP32 live parameter
- regular, prefill context-parallel, and deterministic NPU routing all use
  the shared FP32 projection
- non-NPU routing does not use the NPU projection
- runtime gate-weight updates affect the next projection

### Ascend NPU operator-level correctness validation

Environment:

- Ascend910ProA
- PyTorch 2.1.0
- torch_npu 2.1.0.post3
- CANN 8.0.RC1

| Projection path | Output dtype | Max abs error vs FP32 reference |
| --- | --- | ---: |
| Existing BF16 projection | BF16 | 0.0256 |
| This PR's FP32 projection | FP32 | 0.0 |

This operator-level test reproduces the precision loss described in the
issue and verifies that the new projection matches the FP32 reference on
an Ascend device.

The available host could not run the repository's official PyTorch 2.10 /
TorchNPU 2.10 / CANN 9.0 combination because its local CANN runtime is
8.0.RC1. Therefore, this result validates numerical correctness and
operator support only; it is not an official-stack performance result.

## Speed Tests and Profiling

Official-stack router latency, memory, and end-to-end decode throughput
have not been measured yet. This PR does not claim negligible performance
overhead.

Performance validation on PyTorch 2.10 / TorchNPU 2.10 / CANN 9.0 is
pending NPU CI or follow-up profiling.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable: no public API or configuration changes.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Accuracy results are included; official-stack speed profiling is pending.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32580939763](https://github.com/sgl-project/sglang/actions/runs/32580939763)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32580939582](https://github.com/sgl-project/sglang/actions/runs/32580939582)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32580939740](https://github.com/sgl-project/sglang/actions/runs/32580939740)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->