### PR TITLE
[diffusion] Keep LongLive2 components resident on large GPUs

### DIFF
--- a/docs/cookbook/diffusion/LongLive/LongLive-2.0.mdx
+++ b/docs/cookbook/diffusion/LongLive/LongLive-2.0.mdx
@@ -25,6 +25,11 @@ Please refer to the [official SGLang-diffusion installation guide](/docs/sglang-
 sglang serve --model-path Rabinovich/LongLive-2.0-5B-Diffusers
 ```
 
+In `auto` mode, GPUs with at least 60 GiB available keep the DiT, text encoder,
+and VAE resident. This uses about 44 GiB on H200 for the 832x480 preset and
+avoids moving encoder and decoder layers from host memory on every request.
+Smaller GPUs retain the layerwise-offload defaults.
+
 If the GPU runs out of memory, move the text encoder, VAE, and DiT to CPU between stages:
 
 ```bash Command

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/longlive2.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/longlive2.py
@@ -6,6 +6,9 @@ from dataclasses import dataclass, field
 from sglang.multimodal_gen.configs.models import DiTConfig
 from sglang.multimodal_gen.configs.models.dits.longlive2 import LongLive2VideoConfig
 from sglang.multimodal_gen.configs.pipeline_configs.base import ModelTaskType
+from sglang.multimodal_gen.configs.pipeline_configs.model_deployment_config import (
+    ModelDeploymentConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.wan import Wan2_2_TI2V_5B_Config
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
@@ -27,6 +30,13 @@ class LongLive2T2VConfig(Wan2_2_TI2V_5B_Config):
     expand_timesteps: bool = False
 
     dit_config: DiTConfig = field(default_factory=LongLive2VideoConfig)
+
+    def get_model_deployment_config(self) -> ModelDeploymentConfig:
+        return ModelDeploymentConfig(
+            dit_layerwise_offload_modes=("memory",),
+            keep_resident_min_available_gb=60,
+            keep_resident_components=("dit", "text_encoder", "vae"),
+        )
 
     def adjust_num_frames(self, num_frames: int) -> int:
         num_frames = super().adjust_num_frames(num_frames)

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
@@ -2713,8 +2713,8 @@
             "expected_e2e_ms": 5648.49,
             "expected_avg_denoise_ms": 477.49,
             "expected_median_denoise_ms": 56.74,
-            "load_peak_vram_mb": 16110.0,
-            "runtime_peak_vram_mb": 45756.0,
+            "load_peak_vram_mb": 32892.0,
+            "runtime_peak_vram_mb": 61190.0,
             "estimated_full_test_time_s": 153.1
         },
         "longlive2_i2v": {
@@ -2731,8 +2731,8 @@
             "expected_e2e_ms": 9086.81,
             "expected_avg_denoise_ms": 492.02,
             "expected_median_denoise_ms": 151.9,
-            "load_peak_vram_mb": 16110.0,
-            "runtime_peak_vram_mb": 45756.0,
+            "load_peak_vram_mb": 32892.0,
+            "runtime_peak_vram_mb": 62510.0,
             "estimated_full_test_time_s": 149.4
         },
         "lingbot_video_moe_t2v": {

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -23,6 +23,9 @@ from sglang.multimodal_gen.configs.pipeline_configs.lingbot_world import (
 from sglang.multimodal_gen.configs.pipeline_configs.longcat_image import (
     LongCatImagePipelineConfig,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.longlive2 import (
+    LongLive2T2VConfig,
+)
 from sglang.multimodal_gen.configs.pipeline_configs.ltx_2 import (
     LTX2PipelineConfig,
     LTX23PipelineConfig,
@@ -1389,6 +1392,7 @@ class TestOffloadDefaults(unittest.TestCase):
         lingbot_deployment = LingBotWorldCausalDMDConfig().get_model_deployment_config()
         ltx_deployment = LTX2PipelineConfig().get_model_deployment_config()
         ltx23_config = LTX23PipelineConfig()
+        longlive_deployment = LongLive2T2VConfig().get_model_deployment_config()
         sana_wm_deployment = SanaWMPipelineConfig().get_model_deployment_config()
 
         self.assertIsNone(qwen_deployment.fsdp_auto_min_available_memory_gb)
@@ -1423,6 +1427,11 @@ class TestOffloadDefaults(unittest.TestCase):
         self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(4), 1)
         self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(8), 1)
         self.assertEqual(ltx_deployment.get_auto_cfg_parallel_degree(2), 2)
+        self.assertEqual(longlive_deployment.keep_resident_min_available_gb, 60)
+        self.assertEqual(
+            longlive_deployment.keep_resident_components,
+            ("dit", "text_encoder", "vae"),
+        )
         self.assertFalse(
             LTX2PipelineConfig().dit_config.arch_config.enable_packed_qkv_input_a2a
         )
@@ -1454,6 +1463,25 @@ class TestOffloadDefaults(unittest.TestCase):
         # default keeps only vae resident (encoders are large, dit owned by FSDP)
         self.assertEqual(qwen_deployment.keep_resident_components, ("vae",))
         self.assertIsNone(qwen_deployment.keep_resident_min_available_gb)
+
+    def test_longlive_residency_scales_with_available_memory(self):
+        high_memory_args = self._from_dict_with_pipeline_config(
+            LongLive2T2VConfig(),
+            memory_gb=80,
+            kwargs={"performance_mode": "auto"},
+        )
+        high_memory_offload = high_memory_args.layerwise_offload_components or []
+        self.assertNotIn("text_encoder", high_memory_offload)
+        self.assertNotIn("vae", high_memory_offload)
+
+        constrained_args = self._from_dict_with_pipeline_config(
+            LongLive2T2VConfig(),
+            memory_gb=50,
+            kwargs={"performance_mode": "auto"},
+        )
+        constrained_offload = constrained_args.layerwise_offload_components or []
+        self.assertIn("text_encoder", constrained_offload)
+        self.assertIn("vae", constrained_offload)
 
     def test_qwen_ar_generation_residency_scales_with_available_memory(self):
         pipeline_configs = (


### PR DESCRIPTION
## Motivation

LongLive2 inherits the Wan memory defaults, which layerwise-offload the text encoder and VAE even when a large GPU has enough memory to keep the full pipeline resident. On H200 this adds roughly 280 ms of host/device traffic to every request.

## Changes

- Keep the LongLive2 DiT, text encoder, and VAE resident when at least 60 GiB is available.
- Preserve the current layerwise-offload path on smaller GPUs.
- Add coverage for both memory-policy branches and document the H200 behavior.

## H200 benchmark

Base: `3c69a4c744525be0146629fc5933e3ddab609fb2`  
Model: `Rabinovich/LongLive-2.0-5B-Diffusers`  
Shape: 832x480, 61 frames, 4 steps, seed 42  
Prompt: `A curious raccoon`  
Method: fresh process per sample, request warmup, ABBA order, two measured samples per variant

| Quality | Metric | Main | PR | Change |
| --- | ---: | ---: | ---: | ---: |
| lossless | Denoise | 0.5630 s | 0.5653 s | +0.40% |
| lossless | End-to-end | 2.1594 s | 1.8766 s | **-13.10%** |
| high | Denoise | 0.5620 s | 0.5635 s | +0.27% |
| high | End-to-end | 1.9162 s | 1.6508 s | **-13.85%** |
| lossless | Peak reserved | 24.18 GiB | 44.17 GiB | +19.99 GiB |
| high | Peak reserved | 23.68 GiB | 43.85 GiB | +20.17 GiB |

The high-quality profile reduced GPU memcpy time from about 617 ms to 6.7 ms. Denoise time is unchanged; the gain comes from removing repeated encoder/VAE transfers.

## Output check

Main and PR videos are byte-identical in every repeated run:

- lossless SHA256: `0f57a6ddd031773cea922d0b36bec3f436b1096a2432eee81a1cce53c67524ea`
- high SHA256: `344b36d477d62891c28bb1777c54743955accaa41f10336b31a2c119b6a7eebf`

## Tests

- `pytest -q python/sglang/multimodal_gen/test/unit/test_server_args.py -k 'pipeline_configs_declare_auto_tune_hints or longlive_residency_scales_with_available_memory'`
- `pytest -q python/sglang/multimodal_gen/test/unit/test_longlive2_pipeline_config.py`
- `pre-commit run --files docs/cookbook/diffusion/LongLive/LongLive-2.0.mdx python/sglang/multimodal_gen/configs/pipeline_configs/longlive2.py python/sglang/multimodal_gen/test/unit/test_server_args.py`

The combined unit files report 180 passed plus 48 subtests and one unrelated LTX2 device-mode failure. The same failure reproduces on the base commit on H200.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32644662988](https://github.com/sgl-project/sglang/actions/runs/32644662988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32651539133](https://github.com/sgl-project/sglang/actions/runs/32651539133)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32644662882](https://github.com/sgl-project/sglang/actions/runs/32644662882)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->