### PR TITLE
Fix MTP draft embed/lm_head dedup running after KV pool sizing

### DIFF
--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -191,6 +191,18 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
+        # Initialize the token map and (optionally) share the target
+        # embed/lm_head with the draft model here, i.e. before the KV cache
+        # pools are sized. ``init_lm_head`` may drop the draft-side duplicate
+        # ``embed_tokens``/``lm_head`` tensors and release them back to the
+        # driver. When it ran later, inside ``alloc_memory_pool``, the freed
+        # memory was only reclaimed *after* the main KV pool had already been
+        # sized, leaving it permanently unused. For MTP (NEXTN) drafts the
+        # duplicates are ~2.5GB on a 27B model, which shrinks the max
+        # available KV tokens by roughly 100K.
+        self.init_token_map()
+        self.init_lm_head()
+
     def alloc_memory_pool(
         self,
         memory_pool_config=None,
@@ -205,8 +217,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             req_to_token_pool=req_to_token_pool,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
-        self.init_token_map()
-        self.init_lm_head()
+        # init_token_map/init_lm_head are called in __init__ so that the
+        # embed/lm_head dedup happens before KV pool sizing; see above.
 
         if get_spec().speculative_use_rejection_sampling:
             target_vocab_size = self.target_worker.model_config.vocab_size


### PR DESCRIPTION
## 📌 Summary

Fixes an MTP (NEXTN) memory-accounting bug where ~2.5GB of VRAM on a 27B-class model was permanently left unused after startup, because the draft model's `embed_tokens`/`lm_head` dedup ran **after** the KV cache pool had already been sized.

## 🔍 Problem

With `--speculative-algo NEXTN` (MTP draft, e.g. Qwen3.5/3.8), the draft model initially owns its own `embed_tokens` and `lm_head`. `EagleWorkerV2.init_lm_head()` shares the target model's tensors with the draft (`set_embed_and_head` / `set_lm_head_from_target`), deleting the draft-side duplicates and calling `torch.cuda.empty_cache()`.

However, `init_token_map()` / `init_lm_head()` were only called from `alloc_memory_pool()`, which the scheduler invokes **after** `init_target_memory_pool()` has already computed the KV budget from current free memory. The freed ~2.5GB was therefore invisible to the sizing pass and stayed idle until the next process restart:

```
Load weight end ... type=Qwen3_5ForConditionalGeneration, mem usage=28.39 GB
Load weight end ... type=Qwen3_5ForCausalLMMTP, mem usage=5.18 GB   <- includes ~2.5GB dup embed/lm_head
KV Cache VA upper bound ... #tokens: 273K
```

## ✅ Solution

Move `init_token_map()` and `init_lm_head()` from `alloc_memory_pool()` to the end of `EagleWorkerV2.__init__`, i.e. before the scheduler sizes the main KV pool. Both calls only depend on state already set earlier in `__init__` (`target_worker`, `draft_runner`, `speculative_algorithm`); `hot_token_id` is itself assigned *inside* `init_token_map()`, so nothing breaks.

## 📊 Measured effect

RTX 4090D 48GB, Qwen3.5-27B fp8 + NEXTN MTP, `--mem-fraction-static 0.96`, `--kv-cache-dtype fp8_e4m3`:

| | max_total_num_tokens |
|---|---|
| before | ~273K-286K |
| after | **397K (+111K, ~+38%)** |

Generation verified working after the change (speculative verify accept path active).

## 🧪 Test environment

- Hardware: NVIDIA RTX 4090D 48GB, single GPU
- SGLang v0.5.18 (Docker `lmsysorg/sglang:v0.5.18`), CUDA 12.x
- Model: Qwen3.5-27B (fp8_w8a8 block) with built-in MTP layer
- Args: `--speculative-algo NEXTN --speculative-num-steps 1 --speculative-eagle-topk 1 --speculative-num-draft-tokens 2`

## 📝 Application scenario

Single-user / long-context serving where KV capacity is the bottleneck. Any MTP deployment on a memory-constrained single GPU benefits directly; non-MTP and non-shared-head draft paths are unaffected (the two calls simply run earlier and are idempotent-safe no-ops there).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32583136799](https://github.com/sgl-project/sglang/actions/runs/32583136799)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32583136792](https://github.com/sgl-project/sglang/actions/runs/32583136792)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32583136761](https://github.com/sgl-project/sglang/actions/runs/32583136761)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->