### PR TITLE
[diffusion] fix: stabilize LTX-2.3 two-stage cold requests

### DIFF
--- a/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
+++ b/python/sglang/multimodal_gen/runtime/warmup_request_builder.py
@@ -39,6 +39,7 @@ SERVER_WARMUP_IMAGE_MAX_AREA = 768 * 768
 SERVER_WARMUP_DIFFUSERS_IMAGE_MAX_AREA = 512 * 512
 SERVER_WARMUP_VIDEO_MAX_AREA = 832 * 480
 SERVER_WARMUP_MAX_VIDEO_FRAMES = 17
+SERVER_WARMUP_LTX2_TWO_STAGE_MAX_VIDEO_FRAMES = 25
 SERVER_WARMUP_IMAGE_STEPS = 2
 SERVER_WARMUP_VIDEO_STEPS = 2
 
@@ -245,7 +246,15 @@ def _resolve_warmup_num_frames(
     ):
         warmup_num_frames = num_frames
     else:
-        warmup_num_frames = min(num_frames, SERVER_WARMUP_MAX_VIDEO_FRAMES)
+        # Multi-GPU LTX two-stage aligns a one-second request to 25 frames;
+        # cover its latent shape during warmup
+        frame_budget = (
+            SERVER_WARMUP_LTX2_TWO_STAGE_MAX_VIDEO_FRAMES
+            if is_ltx2_two_stage_pipeline_name(server_args.pipeline_class_name)
+            and server_args.num_gpus > 1
+            else SERVER_WARMUP_MAX_VIDEO_FRAMES
+        )
+        warmup_num_frames = min(num_frames, frame_budget)
 
     return server_args.pipeline_config.adjust_num_frames(warmup_num_frames)
 

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/h100.json
@@ -2652,7 +2652,7 @@
                 "LTX2AVLatentPreparationStage": 0.13,
                 "LTX2ImageEncodingStage": 27.58,
                 "LTX2AVDenoisingStage": 7506.38,
-                "LTX2UpsampleStage": 2.31,
+                "LTX2UpsampleStage": 172.53,
                 "LTX2RefinementStage": 670.53,
                 "LTX2AVDecodingStage": 250.93,
                 "per_frame_generation": null

--- a/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cfg_parallel_warmup.py
@@ -502,6 +502,7 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         server_args = SimpleNamespace(
             pipeline_config=pipeline_config,
             enable_breakable_cuda_graph=False,
+            pipeline_class_name=None,
         )
 
         num_frames = _resolve_warmup_num_frames(
@@ -563,7 +564,8 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
 
         server_args.pipeline_config.task_type = ModelTaskType.T2V
         server_args.pipeline_config.vae_scale_factor = 32
-        server_args.pipeline_config.adjust_num_frames.side_effect = lambda value: value
+        server_args.pipeline_config.adjust_num_frames.return_value = 25
+        server_args.num_gpus = 2
 
         sampling_defaults = SamplingParams(
             width=1920,
@@ -584,6 +586,23 @@ class TestWarmupReqCfgParallel(unittest.TestCase):
         self.assertEqual((reqs[0].width, reqs[0].height), (832, 448))
         self.assertEqual(reqs[0].width % 64, 0)
         self.assertEqual(reqs[0].height % 64, 0)
+        self.assertEqual(reqs[0].num_frames, 25)
+        server_args.pipeline_config.adjust_num_frames.assert_called_once_with(25)
+
+    def test_ltx2_two_stage_single_gpu_keeps_generic_frame_cap(self):
+        server_args = MagicMock()
+        server_args.pipeline_class_name = "LTX2TwoStagePipeline"
+        server_args.num_gpus = 1
+        server_args.pipeline_config.task_type = ModelTaskType.T2V
+        server_args.pipeline_config.adjust_num_frames.side_effect = lambda value: value
+
+        num_frames = _resolve_warmup_num_frames(
+            server_args,
+            SamplingParams(num_frames=121),
+            server_based_warmup=True,
+        )
+
+        self.assertEqual(num_frames, 17)
 
     def test_server_based_warmup_uses_representative_image_fallback(self):
         server_args = MagicMock()


### PR DESCRIPTION
## Motivation

The multi-GPU LTX-2.3 two-stage CI case intermittently paid first-request shape setup after server warmup. Its generic 17-frame warmup produces a temporal latent size of 3, while the common one-second two-GPU request is aligned from 24 to 25 frames and produces a temporal latent size of 4.

The failure was not a denoising throughput regression: the failing CI attempt spent 8.01s in denoising versus 8.12s on its successful retry. The extra latency appeared around the two-stage transition on the first request.

## Modifications

- Warm up multi-GPU LTX two-stage pipelines with a 25-frame cap so upsampling and refinement see the serving latent shape before the first request.
- Keep the generic 17-frame cap for single-GPU LTX and all other video pipelines.
- Add unit coverage for both multi-GPU and single-GPU selection.
- Refresh only this case's stale H100 `LTX2UpsampleStage` baseline from 2.31ms to 172.53ms. A fresh unmodified-main run measured 174.51ms; the patched cold-cache runs measured 170.40-173.56ms. E2E, denoising, VRAM, and consistency thresholds remain unchanged.

## Accuracy Tests

The exact `ltx_2_3_two_stage_ti2v_2gpus` server case passed its existing consistency comparison in all six cold-cache runs. This change does not modify sampling or model computation.

## Speed Tests and Profiling

Environment: 2x H100 80GB, torch compile disabled, independent CUDA/Triton/Inductor caches per run.

| Metric | Unmodified main | Patched cold-cache runs |
| --- | ---: | ---: |
| E2E latency | 10.73s | 9.01-9.52s |
| First denoise step | 690.52ms | 255-265ms |
| First refinement step | 512.36ms | 209-220ms |
| Runtime peak VRAM | 60,272MiB | 60,728-60,772MiB |

After the baseline refresh, three consecutive full performance, consistency, and peak-VRAM validations passed at 9.225s, 9.446s, and 9.011s E2E.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not needed for this internal warmup policy correction.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32583386492](https://github.com/sgl-project/sglang/actions/runs/32583386492)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32583386368](https://github.com/sgl-project/sglang/actions/runs/32583386368)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32583386482](https://github.com/sgl-project/sglang/actions/runs/32583386482)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->