### PR TITLE
[diffusion] Keep Cosmos3 Nano resident on high-memory GPUs

### DIFF
--- a/docs/cookbook/diffusion/Cosmos/Cosmos3.mdx
+++ b/docs/cookbook/diffusion/Cosmos/Cosmos3.mdx
@@ -62,6 +62,12 @@ sglang serve \
   --num-gpus 1
 ```
 
+With `--performance-mode auto`, a Cosmos3 Nano checkpoint keeps its DiT and
+VAE resident when every selected GPU has at least 120 GiB available at
+startup. Below that threshold, auto mode retains the conservative DiT
+component-offload policy. This high-memory override is limited to Nano;
+Cosmos3 Super checkpoints keep their existing multi-GPU placement defaults.
+
 For `Cosmos3-Super`, split the model across multiple GPUs:
 
 ```bash Command

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/cosmos3.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/cosmos3.py
@@ -19,6 +19,9 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.model_deployment_config import (
+    ModelDeploymentConfig,
+)
 
 COSMOS3_EDGE_BACKBONE_TYPE = "cosmos3_edge_nemotron_dense"
 
@@ -165,3 +168,12 @@ class Cosmos3Config(PipelineConfig):
         # and action-capable checkpoints. The loaded transformer validates that
         # an action head is actually present when an action request is submitted.
         return True
+
+    def get_model_deployment_config(self) -> ModelDeploymentConfig:
+        if "cosmos3-nano" not in self.model_path.lower():
+            return ModelDeploymentConfig()
+
+        return ModelDeploymentConfig(
+            keep_resident_min_available_gb=120,
+            keep_resident_components=("dit", "vae"),
+        )

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -16,6 +16,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.base import (
     ModelTaskType,
     PipelineConfig,
 )
+from sglang.multimodal_gen.configs.pipeline_configs.cosmos3 import Cosmos3Config
 from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import FastHunyuanConfig
 from sglang.multimodal_gen.configs.pipeline_configs.lingbot_world import (
     LingBotWorldCausalDMDConfig,
@@ -1367,6 +1368,9 @@ class TestOffloadDefaults(unittest.TestCase):
 
     def test_pipeline_configs_declare_auto_tune_hints(self):
         qwen_deployment = QwenImagePipelineConfig().get_model_deployment_config()
+        cosmos3_deployment = Cosmos3Config(
+            model_path="nvidia/Cosmos3-Nano"
+        ).get_model_deployment_config()
         wan_deployment = WanT2V480PConfig().get_model_deployment_config()
         mova_deployment = MOVAPipelineConfig().get_model_deployment_config()
         zimage_deployment = ZImagePipelineConfig().get_model_deployment_config()
@@ -1377,6 +1381,9 @@ class TestOffloadDefaults(unittest.TestCase):
 
         self.assertIsNone(qwen_deployment.fsdp_auto_min_available_memory_gb)
         self.assertEqual(qwen_deployment.dit_layerwise_offload_modes, ())
+
+        self.assertEqual(cosmos3_deployment.keep_resident_min_available_gb, 120)
+        self.assertEqual(cosmos3_deployment.keep_resident_components, ("dit", "vae"))
 
         self.assertIsNone(wan_deployment.fsdp_auto_min_available_memory_gb)
         self.assertEqual(wan_deployment.dit_layerwise_offload_modes, ("memory",))
@@ -1825,6 +1832,49 @@ class TestOffloadDefaults(unittest.TestCase):
             args.layerwise_offload_components,
             ["text_encoder", "image_encoder"],
         )
+
+    def test_auto_cosmos3_keeps_dit_resident_on_high_memory_gpu(self):
+        args = self._from_dict_with_pipeline_config(
+            Cosmos3Config(model_path="nvidia/Cosmos3-Nano"),
+            available_memory_gb=139,
+            kwargs={
+                "model_path": "nvidia/Cosmos3-Nano",
+                "performance_mode": "auto",
+            },
+        )
+
+        self.assertFalse(args.dit_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
+        self.assertEqual(
+            args.layerwise_offload_components,
+            ["text_encoder", "image_encoder"],
+        )
+
+    def test_auto_cosmos3_offloads_dit_below_resident_threshold(self):
+        args = self._from_dict_with_pipeline_config(
+            Cosmos3Config(model_path="nvidia/Cosmos3-Nano"),
+            available_memory_gb=100,
+            kwargs={
+                "model_path": "nvidia/Cosmos3-Nano",
+                "performance_mode": "auto",
+            },
+        )
+
+        self.assertTrue(args.dit_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
+
+    def test_auto_cosmos3_super_keeps_default_offload_policy(self):
+        args = self._from_dict_with_pipeline_config(
+            Cosmos3Config(model_path="nvidia/Cosmos3-Super"),
+            available_memory_gb=139,
+            kwargs={
+                "model_path": "nvidia/Cosmos3-Super",
+                "performance_mode": "auto",
+            },
+        )
+
+        self.assertTrue(args.dit_cpu_offload)
+        self.assertFalse(args.vae_cpu_offload)
 
     def test_memory_sana_wm_layerwise_offload_adds_dit(self):
         args = self._from_dict_with_pipeline_config(


### PR DESCRIPTION
## Summary

- keep Cosmos3 Nano's DiT and VAE resident in `performance-mode=auto` when every selected GPU has at least 120 GiB available
- retain the existing offload policy below the threshold and for Cosmos3 Super checkpoints
- document the Nano high-memory behavior and cover the high-/low-memory and Super branches

## H200 benchmark

1x H200, `nvidia/Cosmos3-Nano`, 832x480, 9 frames, 4 steps, seed 42, eager execution, `torch.compile` disabled. Prompt: `A blue box slides across a clean warehouse floor.` Each row is a same-GPU ABBA mean with request warmup excluded.

| Quality | main denoise / e2e | PR denoise / e2e | E2E change |
| --- | ---: | ---: | ---: |
| lossless | 0.250050 / 1.574075 s | 0.247213 / 0.427688 s | -72.83% |
| high | 0.250723 / 1.576087 s | 0.246815 / 0.427532 s | -72.87% |

Peak reserved memory increases from 34.650 to 36.123 GiB. The baseline full-stage trace spends 1,109.636 ms in GPU memcpy (73.98% of 1.500 s); the resident trace reduces memcpy to 0.947 ms and total recorded GPU time to 396.181 ms.

All main, PR, and profile outputs are byte-identical:
`bb75a29d3072b7943d501a04ce4bbbd068347b91e95d6b37db421a626346d02a`.

- [main video](https://github.com/BBuf/sglang/blob/pr-media/diffusion-prs/cosmos3-nano-residency/main.mp4?raw=1)
- [PR video](https://github.com/BBuf/sglang/blob/pr-media/diffusion-prs/cosmos3-nano-residency/pr.mp4?raw=1)

The baseline, high ABBA/profile, and lossless ABBA isolated caches were cleaned from 34,986,985,384 B, 34,986,978,853 B, and 34,987,064,698 B to zero files and zero weight files after their model groups.

## Tests

- `pre-commit run --files python/sglang/multimodal_gen/configs/pipeline_configs/cosmos3.py python/sglang/multimodal_gen/test/unit/test_server_args.py docs/cookbook/diffusion/Cosmos/Cosmos3.mdx`
- `PYTHONPATH=python python -m pytest -q python/sglang/multimodal_gen/test/unit/test_server_args.py -k "not auto_ltx_original_replaces_component_cpu_offload"` (`179 passed`, one existing H200-dependent LTX test deselected; it fails unchanged on main)
- final rebased Nano high-quality model smoke on H200

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32585149587](https://github.com/sgl-project/sglang/actions/runs/32585149587)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32647202694](https://github.com/sgl-project/sglang/actions/runs/32647202694)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32585149590](https://github.com/sgl-project/sglang/actions/runs/32585149590)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->