### PR TITLE
feat(sgl-router): add GCS token export

### DIFF
--- a/experimental/sgl-router/Cargo.toml
+++ b/experimental/sgl-router/Cargo.toml
@@ -88,6 +88,7 @@ axum = { version = "0.8", features = ["macros", "tracing", "http2"] }
 tower = { version = "0.5", features = ["full"] }
 tower-http = { version = "0.6", features = ["trace", "compression-gzip", "cors", "timeout", "request-id", "catch-panic"] }
 reqwest = { version = "0.12", features = ["stream", "json", "rustls-tls", "http2"], default-features = false }
+gcp_auth = "0.12.7"
 
 # Serialization
 serde = { version = "1", features = ["derive"] }

--- a/experimental/sgl-router/README.md
+++ b/experimental/sgl-router/README.md
@@ -53,8 +53,9 @@ with `--prefill-selector` and `--decode-selector`.
 ## Token dataset export
 
 The optional token-export tee writes gzipped NDJSON batches without blocking
-request serving. A full queue or upload backlog drops export records and
-increments `sgl_router_token_export_total`.
+request serving. Credential and upload failures do not affect router readiness.
+A full queue or upload backlog drops export records and increments
+`sgl_router_token_export_total`.
 
 Amazon S3 uses static SigV4 credentials:
 

--- a/experimental/sgl-router/README.md
+++ b/experimental/sgl-router/README.md
@@ -50,6 +50,35 @@ Omit `--service-discovery-namespace` to watch all namespaces (requires
 cluster-wide RBAC). For prefill/decode disaggregation, replace `--selector`
 with `--prefill-selector` and `--decode-selector`.
 
+## Token dataset export
+
+The optional token-export tee writes gzipped NDJSON batches without blocking
+request serving. A full queue or upload backlog drops export records and
+increments `sgl_router_token_export_total`.
+
+Amazon S3 uses static SigV4 credentials:
+
+```bash
+export RADIXARK_TOKEN_EXPORT_S3_URI=s3://bucket/prefix/
+export AWS_ACCESS_KEY_ID=...
+export AWS_SECRET_ACCESS_KEY=...
+export AWS_REGION=us-west-2
+```
+
+Google Cloud Storage uses [Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials):
+
+```bash
+export RADIXARK_TOKEN_EXPORT_GCS_URI=gs://bucket/prefix/
+```
+
+ADC supports `GOOGLE_APPLICATION_CREDENTIALS`, local `gcloud` ADC, and the
+metadata service used by GCE service accounts and GKE Workload Identity.
+Production deployments should use a dedicated service account with
+`roles/storage.objectCreator` on the destination bucket. Export objects contain
+prompt/output token sequences and client key identifiers, so bucket readers and
+retention must be restricted accordingly. S3 and GCS export are mutually
+exclusive.
+
 ## License
 
 Apache-2.0.

--- a/experimental/sgl-router/src/config/cli.rs
+++ b/experimental/sgl-router/src/config/cli.rs
@@ -436,8 +436,20 @@ pub struct Cli {
     /// writes each request's ingest/extend token sequences as NDJSON+gzip.
     /// Credentials and region come from the standard AWS environment variables.
     /// When absent, export is disabled.
-    #[arg(long, env = "RADIXARK_TOKEN_EXPORT_S3_URI")]
+    #[arg(
+        long,
+        env = "RADIXARK_TOKEN_EXPORT_S3_URI",
+        conflicts_with = "token_export_gcs_uri"
+    )]
     pub token_export_s3_uri: Option<String>,
+    /// `gs://bucket/prefix/` target. Uses Google Application Default
+    /// Credentials and the Cloud Storage JSON API. Mutually exclusive with S3.
+    #[arg(
+        long,
+        env = "RADIXARK_TOKEN_EXPORT_GCS_URI",
+        conflicts_with = "token_export_s3_uri"
+    )]
+    pub token_export_gcs_uri: Option<String>,
 }
 
 impl Cli {
@@ -711,6 +723,7 @@ impl Cli {
                 cache_sim_url: self.cache_sim_url,
                 cache_sim_max_concurrent_captures: self.cache_sim_max_concurrent_captures,
                 token_export_s3_uri: self.token_export_s3_uri,
+                token_export_gcs_uri: self.token_export_gcs_uri,
             },
             model: ModelConfig {
                 // Default the tokenizer source to the model id (treated as a
@@ -2625,6 +2638,47 @@ mod tests {
             err.contains("--sticky-eviction-interval-secs must be greater than 0"),
             "got: {err}"
         );
+    }
+
+    #[test]
+    fn token_export_selects_one_object_store() {
+        let s3 = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--token-export-s3-uri",
+            "s3://bucket/prefix",
+        ]))
+        .unwrap();
+        assert_eq!(
+            s3.observability.token_export_s3_uri.as_deref(),
+            Some("s3://bucket/prefix")
+        );
+        assert!(s3.observability.token_export_gcs_uri.is_none());
+
+        let gcs = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--token-export-gcs-uri",
+            "gs://bucket/prefix",
+        ]))
+        .unwrap();
+        assert_eq!(
+            gcs.observability.token_export_gcs_uri.as_deref(),
+            Some("gs://bucket/prefix")
+        );
+        assert!(gcs.observability.token_export_s3_uri.is_none());
+
+        let error = into_config_owned(with_model(&[
+            "--worker-urls",
+            "http://x:30000",
+            "--token-export-s3-uri",
+            "s3://bucket/prefix",
+            "--token-export-gcs-uri",
+            "gs://bucket/prefix",
+        ]))
+        .unwrap_err()
+        .to_string();
+        assert!(error.contains("cannot be used with"), "got: {error}");
     }
 
     #[test]

--- a/experimental/sgl-router/src/config/types.rs
+++ b/experimental/sgl-router/src/config/types.rs
@@ -294,9 +294,11 @@ pub struct ObservabilityConfig {
     /// Excess streams simply aren't captured. Only meaningful with
     /// `cache_sim_url`.
     pub cache_sim_max_concurrent_captures: usize,
-    /// `s3://bucket/prefix/` target; when set, enables the token-export tee;
-    /// when absent, the tee is disabled. See `crate::server::s3_export`.
+    /// `s3://bucket/prefix/` target; when set, enables the token-export tee.
     pub token_export_s3_uri: Option<String>,
+    /// `gs://bucket/prefix/` target authenticated with Google Application
+    /// Default Credentials; mutually exclusive with `token_export_s3_uri`.
+    pub token_export_gcs_uri: Option<String>,
 }
 
 /// Default concurrent-capture budget: 256 × 16 MiB = 4 GiB ceiling on aggregate
@@ -329,6 +331,7 @@ impl Default for ObservabilityConfig {
             cache_sim_url: None,
             cache_sim_max_concurrent_captures: default_cache_sim_max_concurrent_captures(),
             token_export_s3_uri: None,
+            token_export_gcs_uri: None,
         }
     }
 }

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -246,17 +246,32 @@ async fn main() -> Result<()> {
         std::time::Duration::from_secs(60),
     );
 
-    let ctx = Arc::new(
-        sgl_router::server::app_context::AppContext::with_active_load_and_itl(
-            cfg.clone(),
-            tokenizers,
-            proxy,
-            registry,
-            policies,
-            active_load,
-            itl,
-        ),
+    let mut ctx = sgl_router::server::app_context::AppContext::with_active_load_and_itl(
+        cfg.clone(),
+        tokenizers,
+        proxy,
+        registry,
+        policies,
+        active_load,
+        itl,
     );
+    if let Some(sink) = ctx.token_export_sink.take() {
+        match sink.preflight().await {
+            Ok(()) => {
+                tracing::info!(backend = sink.backend(), "token export enabled");
+                ctx.token_export_sink = Some(sink);
+            }
+            Err(error) => {
+                tracing::error!(
+                    backend = sink.backend(),
+                    %error,
+                    "token export credentials unavailable; disabling export"
+                );
+                sink.drain().await;
+            }
+        }
+    }
+    let ctx = Arc::new(ctx);
     // `/readyz` needs the index to know whether peer bootstrap has settled, and
     // `/internal/kv_snapshot` needs it to serve siblings.
     ctx.attach_kv_index(Arc::clone(&kv_index));

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -260,11 +260,6 @@ async fn main() -> Result<()> {
     // `/readyz` needs the index to know whether peer bootstrap has settled, and
     // `/internal/kv_snapshot` needs it to serve siblings.
     ctx.attach_kv_index(Arc::clone(&kv_index));
-    if let Some(sink) = ctx.token_export_sink.as_ref() {
-        sink.preflight()
-            .await
-            .context("initialize token export credentials")?;
-    }
     ctx.mark_ready();
 
     let app = sgl_router::server::app::build_router(ctx.clone());

--- a/experimental/sgl-router/src/main.rs
+++ b/experimental/sgl-router/src/main.rs
@@ -260,6 +260,11 @@ async fn main() -> Result<()> {
     // `/readyz` needs the index to know whether peer bootstrap has settled, and
     // `/internal/kv_snapshot` needs it to serve siblings.
     ctx.attach_kv_index(Arc::clone(&kv_index));
+    if let Some(sink) = ctx.token_export_sink.as_ref() {
+        sink.preflight()
+            .await
+            .context("initialize token export credentials")?;
+    }
     ctx.mark_ready();
 
     let app = sgl_router::server::app::build_router(ctx.clone());
@@ -282,14 +287,18 @@ async fn main() -> Result<()> {
     let server_result = serve.await.context("axum serve");
 
     // After stopping accepting new connections and draining in-flight requests,
-    // flush the S3 token-export queue/buffers before exiting so a rolling
+    // flush the token-export queue/buffers before exiting so a rolling
     // restart does not lose records. Cap, not floor: the total shutdown must
     // stay within the pod termination grace period, which operators size off
     // shutdown_drain_secs.
-    if let Some(sink) = ctx.s3_export_sink.as_ref() {
+    if let Some(sink) = ctx.token_export_sink.as_ref() {
         let budget = std::time::Duration::from_secs(cfg.server.shutdown_drain_secs.min(60));
-        sgl_router::server::shutdown::await_with_timeout(sink.drain(), budget, "s3 export drain")
-            .await;
+        sgl_router::server::shutdown::await_with_timeout(
+            sink.drain(),
+            budget,
+            "token export drain",
+        )
+        .await;
     }
 
     // Best-effort: cancel discovery + manager + janitor on shutdown.

--- a/experimental/sgl-router/src/server/app_context.rs
+++ b/experimental/sgl-router/src/server/app_context.rs
@@ -11,7 +11,7 @@ use crate::proxy::Proxy;
 use crate::server::admission::AdmissionQueue;
 use crate::server::cache_sim_tee::CacheSimTee;
 use crate::server::metrics::MetricsRegistry;
-use crate::server::s3_export::S3ExportSink;
+use crate::server::token_export::TokenExportSink;
 use crate::tokenizer::TokenizerRegistry;
 use crate::workers::WorkerRegistry;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -48,10 +48,9 @@ pub struct AppContext {
     /// unset. The chat/completions handler offers to it after tokenizing;
     /// see [`crate::server::cache_sim_tee`].
     pub cache_sim_tee: Option<Arc<CacheSimTee>>,
-    /// Best-effort S3 token-export sink. `None` when
-    /// `observability.token_export_s3_uri` is unset or AWS credentials are
-    /// missing. Zero overhead on the hot path when `None`.
-    pub s3_export_sink: Option<Arc<S3ExportSink>>,
+    /// Best-effort object-storage token-export sink. Zero overhead on the hot
+    /// path when neither S3 nor GCS export is configured.
+    pub token_export_sink: Option<Arc<TokenExportSink>>,
     /// KV-event index, when cache-aware-zmq routing is active.
     ///
     /// Injected rather than constructed here for the same reason as the
@@ -152,13 +151,31 @@ impl AppContext {
         // Read the pod name for object-key deduplication; fall back to
         // "unknown-pod" when the downward-API env var is not injected.
         let pod = std::env::var("POD_NAME").unwrap_or_else(|_| "unknown-pod".to_string());
-        let s3_export_sink = config
+        let s3_uri = config
             .observability
             .token_export_s3_uri
-            .as_ref()
-            .map(|u| u.trim())
-            .filter(|u| !u.is_empty())
-            .and_then(|uri| S3ExportSink::spawn(uri, pod, Arc::clone(&metrics), max_captures));
+            .as_deref()
+            .map(str::trim)
+            .filter(|uri| !uri.is_empty());
+        let gcs_uri = config
+            .observability
+            .token_export_gcs_uri
+            .as_deref()
+            .map(str::trim)
+            .filter(|uri| !uri.is_empty());
+        let token_export_sink = match (s3_uri, gcs_uri) {
+            (Some(uri), None) => {
+                TokenExportSink::spawn_s3(uri, pod, Arc::clone(&metrics), max_captures)
+            }
+            (None, Some(uri)) => {
+                TokenExportSink::spawn_gcs(uri, pod, Arc::clone(&metrics), max_captures)
+            }
+            (None, None) => None,
+            (Some(_), Some(_)) => {
+                tracing::error!("S3 and GCS token export cannot both be enabled");
+                None
+            }
+        };
         Self {
             config,
             tokenizers,
@@ -170,7 +187,7 @@ impl AppContext {
             admission,
             itl,
             cache_sim_tee,
-            s3_export_sink,
+            token_export_sink,
             kv_index: OnceLock::new(),
             ready: AtomicBool::new(false),
         }
@@ -265,7 +282,7 @@ impl AppContext {
             metrics,
             itl: ItlTable::new(),
             cache_sim_tee: None,
-            s3_export_sink: None,
+            token_export_sink: None,
             // Unset: a stub has no KV index, so `kv_bootstrap_settled()`
             // reports true and the readiness gate is inert unless a test
             // attaches one.

--- a/experimental/sgl-router/src/server/cache_sim_extend.rs
+++ b/experimental/sgl-router/src/server/cache_sim_extend.rs
@@ -179,7 +179,7 @@ pub(crate) fn spawn_extend_tee(
     slug: Option<String>,
     key_id: Option<String>,
 ) {
-    if ctx.cache_sim_tee.is_none() && ctx.s3_export_sink.is_none() {
+    if ctx.cache_sim_tee.is_none() && ctx.token_export_sink.is_none() {
         return;
     }
     tokio::spawn(async move {
@@ -267,7 +267,7 @@ pub(crate) fn spawn_extend_tee(
                         per_choice_output,
                     );
                 }
-                if let Some(sink) = ctx.s3_export_sink.as_ref() {
+                if let Some(sink) = ctx.token_export_sink.as_ref() {
                     sink.offer_extend(
                         &model,
                         &ids,

--- a/experimental/sgl-router/src/server/metrics.rs
+++ b/experimental/sgl-router/src/server/metrics.rs
@@ -586,15 +586,10 @@ pub struct MetricsRegistry {
     /// broken tee is failing while serving stays healthy — `http_error` +
     /// `error` are the two that indict it.
     cache_sim_tee_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
-    /// Outcomes of the best-effort S3 token-export tee (see
-    /// [`crate::server::s3_export`]), keyed by `result` — one of `enqueued`,
-    /// `dropped_queue_full`, `dropped_capture_capped`, `dropped_upload_backlog`,
-    /// `dropped_closed`, `object_put`, `put_failed`, `drain_flushed`.
-    s3_export_total: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
-    /// Total records (NDJSON lines) successfully uploaded to S3 by the token
-    /// export sink — records-out counterpart to `s3_export_total{result="enqueued"}`
-    /// (records-in). A persistent gap between the two reveals silent loss.
-    s3_export_records_uploaded: AtomicU64,
+    /// Best-effort token-export outcomes, keyed by storage backend and result.
+    token_export_total: Mutex<HashMap<(&'static str, &'static str), Arc<AtomicU64>>>,
+    /// Successfully uploaded NDJSON records, keyed by storage backend.
+    token_export_records_uploaded: Mutex<HashMap<&'static str, Arc<AtomicU64>>>,
     /// Extensions teed with a prompt/output boundary that could not be true
     /// (0, or >= the sequence length). Deliberately NOT a `result` label on
     /// cache_sim_tee_total: those partition delivery attempts and the message
@@ -664,8 +659,8 @@ impl Default for MetricsRegistry {
             sticky_total: Default::default(),
             mm_affinity_total: Default::default(),
             cache_sim_tee_total: Default::default(),
-            s3_export_total: Default::default(),
-            s3_export_records_uploaded: AtomicU64::new(0),
+            token_export_total: Default::default(),
+            token_export_records_uploaded: Default::default(),
             cache_sim_boundary_impossible_total: AtomicU64::new(0),
             ingress_tokenize_errors_total: Default::default(),
             backpressure_rejected_total: Default::default(),
@@ -1183,22 +1178,19 @@ impl MetricsRegistry {
         counter.fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Bump `sgl_router_s3_export_total{result}`. `result` is a fixed
-    /// `&'static str` (enqueued|dropped_queue_full|dropped_capture_capped|dropped_upload_backlog|dropped_closed|object_put|put_failed|drain_flushed), so label
-    /// cardinality is bounded regardless of traffic.
-    pub fn record_s3_export(&self, result: &'static str) {
-        let mut guard = self.s3_export_total.lock();
+    pub fn record_token_export(&self, backend: &'static str, result: &'static str) {
+        let mut guard = self.token_export_total.lock();
         guard
-            .entry(result)
+            .entry((backend, result))
             .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .fetch_add(1, Ordering::Relaxed);
     }
 
-    /// Add `n` to `sgl_router_s3_export_records_uploaded_total` — the NDJSON
-    /// record count of a successfully uploaded S3 object. Compare against
-    /// `s3_export_total{result="enqueued"}` (records-in) to detect silent loss.
-    pub fn add_s3_export_records_uploaded(&self, n: u64) {
-        self.s3_export_records_uploaded
+    pub fn add_token_export_records_uploaded(&self, backend: &'static str, n: u64) {
+        let mut guard = self.token_export_records_uploaded.lock();
+        guard
+            .entry(backend)
+            .or_insert_with(|| Arc::new(AtomicU64::new(0)))
             .fetch_add(n, Ordering::Relaxed);
     }
 
@@ -1795,28 +1787,62 @@ impl MetricsRegistry {
         }
         drop(guard);
 
-        // s3_export_total
         out.push_str(
-            "# HELP sgl_router_s3_export_total Token-export S3 tee outcomes (result=enqueued|dropped_queue_full|dropped_capture_capped|dropped_upload_backlog|dropped_closed|object_put|put_failed|drain_flushed).\n",
+            "# HELP sgl_router_token_export_total Token-export tee outcomes by object-storage backend.\n",
         );
-        out.push_str("# TYPE sgl_router_s3_export_total counter\n");
-        let guard = self.s3_export_total.lock();
-        for (result, v) in guard.iter() {
+        out.push_str("# TYPE sgl_router_token_export_total counter\n");
+        let guard = self.token_export_total.lock();
+        let mut entries: Vec<(&(&str, &str), u64)> = guard
+            .iter()
+            .map(|(key, value)| (key, value.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by_key(|entry| *entry.0);
+        for ((backend, result), value) in &entries {
             out.push_str(&format!(
-                "sgl_router_s3_export_total{{result=\"{}\"}} {}\n",
-                result,
-                v.load(Ordering::Relaxed)
+                "sgl_router_token_export_total{{backend=\"{}\",result=\"{}\"}} {}\n",
+                backend, result, value
             ));
         }
+        out.push_str("# HELP sgl_router_s3_export_total Deprecated S3-only alias of sgl_router_token_export_total.\n");
+        out.push_str("# TYPE sgl_router_s3_export_total counter\n");
+        for ((backend, result), value) in &entries {
+            if *backend == "s3" {
+                out.push_str(&format!(
+                    "sgl_router_s3_export_total{{result=\"{}\"}} {}\n",
+                    result, value
+                ));
+            }
+        }
         drop(guard);
+
         out.push_str(
-            "# HELP sgl_router_s3_export_records_uploaded_total Records (NDJSON lines) successfully uploaded to S3 by the token export sink (records-out; compare to s3_export_total{result=\"enqueued\"} records-in to detect loss).\n",
+            "# HELP sgl_router_token_export_records_uploaded_total NDJSON records successfully uploaded by storage backend.\n",
         );
+        out.push_str("# TYPE sgl_router_token_export_records_uploaded_total counter\n");
+        let guard = self.token_export_records_uploaded.lock();
+        let mut entries: Vec<(&&str, u64)> = guard
+            .iter()
+            .map(|(backend, value)| (backend, value.load(Ordering::Relaxed)))
+            .collect();
+        entries.sort_by_key(|entry| *entry.0);
+        for (backend, value) in &entries {
+            out.push_str(&format!(
+                "sgl_router_token_export_records_uploaded_total{{backend=\"{}\"}} {}\n",
+                backend, value
+            ));
+        }
+        out.push_str("# HELP sgl_router_s3_export_records_uploaded_total Deprecated S3-only alias of sgl_router_token_export_records_uploaded_total.\n");
         out.push_str("# TYPE sgl_router_s3_export_records_uploaded_total counter\n");
+        let s3_records = entries
+            .iter()
+            .find(|(backend, _)| **backend == "s3")
+            .map(|(_, value)| *value)
+            .unwrap_or(0);
         out.push_str(&format!(
             "sgl_router_s3_export_records_uploaded_total {}\n",
-            self.s3_export_records_uploaded.load(Ordering::Relaxed)
+            s3_records
         ));
+        drop(guard);
 
         // cache_sim_boundary_impossible_total — rendered unconditionally (not
         // a lazily-created label child), so a dashboard sees a 0 rather than
@@ -2888,22 +2914,28 @@ mod tests {
     }
 
     #[test]
-    fn record_s3_export_counts_by_result() {
+    fn record_token_export_counts_by_backend_and_result() {
         let m = MetricsRegistry::new();
-        m.record_s3_export("enqueued");
-        m.record_s3_export("enqueued");
-        m.record_s3_export("dropped_queue_full");
+        m.record_token_export("s3", "enqueued");
+        m.record_token_export("s3", "enqueued");
+        m.record_token_export("gcs", "enqueued");
         let out = m.render();
+        assert!(out.contains("sgl_router_token_export_total{backend=\"s3\",result=\"enqueued\"} 2"));
+        assert!(
+            out.contains("sgl_router_token_export_total{backend=\"gcs\",result=\"enqueued\"} 1")
+        );
         assert!(out.contains("sgl_router_s3_export_total{result=\"enqueued\"} 2"));
-        assert!(out.contains("sgl_router_s3_export_total{result=\"dropped_queue_full\"} 1"));
     }
 
     #[test]
-    fn add_s3_export_records_uploaded_sums() {
+    fn add_token_export_records_uploaded_sums_by_backend() {
         let m = MetricsRegistry::new();
-        m.add_s3_export_records_uploaded(30);
-        m.add_s3_export_records_uploaded(12);
+        m.add_token_export_records_uploaded("s3", 30);
+        m.add_token_export_records_uploaded("s3", 12);
+        m.add_token_export_records_uploaded("gcs", 9);
         let out = m.render();
+        assert!(out.contains("sgl_router_token_export_records_uploaded_total{backend=\"s3\"} 42"));
+        assert!(out.contains("sgl_router_token_export_records_uploaded_total{backend=\"gcs\"} 9"));
         assert!(out.contains("sgl_router_s3_export_records_uploaded_total 42"));
     }
 }

--- a/experimental/sgl-router/src/server/mod.rs
+++ b/experimental/sgl-router/src/server/mod.rs
@@ -10,5 +10,5 @@ pub mod error;
 pub mod header_utils;
 pub mod metrics;
 pub mod routes;
-pub mod s3_export;
 pub mod shutdown;
+pub mod token_export;

--- a/experimental/sgl-router/src/server/routes/chat.rs
+++ b/experimental/sgl-router/src/server/routes/chat.rs
@@ -358,7 +358,7 @@ async fn chat_completions_inner(
     // extension must be matchable at all (`extension_can_match`: DSV4 thinking
     // mode without tools re-renders history divergently, so its extensions
     // could only ever be dead blocks — mirroring the engine's own miss).
-    let extend_tee_armed = (ctx.cache_sim_tee.is_some() || ctx.s3_export_sink.is_some())
+    let extend_tee_armed = (ctx.cache_sim_tee.is_some() || ctx.token_export_sink.is_some())
         && request_tokens.is_some()
         && request_value
             .as_ref()
@@ -483,7 +483,7 @@ async fn chat_completions_inner(
     if let (Some(tee), Some(t)) = (ctx.cache_sim_tee.as_ref(), request_tokens.as_ref()) {
         tee.offer(&model_str, &t.ids, &derived_request_id, tee_attr.clone());
     }
-    if let (Some(sink), Some(t)) = (ctx.s3_export_sink.as_ref(), request_tokens.as_ref()) {
+    if let (Some(sink), Some(t)) = (ctx.token_export_sink.as_ref(), request_tokens.as_ref()) {
         sink.offer_ingest(
             &model_str,
             &t.ids,
@@ -703,23 +703,25 @@ async fn chat_completions_inner(
             //
             // When cache-sim is on, draw from the cache-sim tee's pool and record
             // `capture_capped` there. Also record `dropped_capture_capped` on the
-            // S3 sink so both consumers reflect the drop.
-            // When cache-sim is off but the S3 sink is on, draw from the sink's
-            // own permit pool so S3-only mode is equally memory-bounded.
+            // token-export sink so both consumers reflect the drop.
+            // When cache-sim is off but token export is on, draw from the sink's
+            // own permit pool so export-only mode is equally memory-bounded.
             let permit = if let Some(tee) = ctx.cache_sim_tee.as_ref() {
                 let p = tee.try_acquire_capture_permit();
                 if p.is_none() {
                     ctx.metrics.record_cache_sim_tee("capture_capped");
-                    if ctx.s3_export_sink.is_some() {
-                        ctx.metrics.record_s3_export("dropped_capture_capped");
+                    if let Some(sink) = ctx.token_export_sink.as_ref() {
+                        ctx.metrics
+                            .record_token_export(sink.backend(), "dropped_capture_capped");
                     }
                     return None;
                 }
                 p
-            } else if let Some(sink) = ctx.s3_export_sink.as_ref() {
+            } else if let Some(sink) = ctx.token_export_sink.as_ref() {
                 let p = sink.try_acquire_capture_permit();
                 if p.is_none() {
-                    ctx.metrics.record_s3_export("dropped_capture_capped");
+                    ctx.metrics
+                        .record_token_export(sink.backend(), "dropped_capture_capped");
                     return None;
                 }
                 p

--- a/experimental/sgl-router/src/server/token_export.rs
+++ b/experimental/sgl-router/src/server/token_export.rs
@@ -342,6 +342,14 @@ impl Uploader {
             Self::Gcs { .. } => ExportBackend::Gcs,
         }
     }
+
+    async fn preflight(&self) -> anyhow::Result<()> {
+        if let Self::Gcs { auth, .. } = self {
+            auth.bearer_token().await?;
+        }
+        Ok(())
+    }
+
     async fn put(&self, key: &str, body: Vec<u8>) -> anyhow::Result<()> {
         match self {
             Uploader::S3 {
@@ -503,6 +511,7 @@ pub struct TokenExportSink {
     tx: mpsc::Sender<PumpMsg>,
     metrics: Arc<MetricsRegistry>,
     backend: ExportBackend,
+    uploader: Arc<Uploader>,
     join: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
     capture_sem: Arc<tokio::sync::Semaphore>,
 }
@@ -583,7 +592,7 @@ impl TokenExportSink {
             region,
             bucket,
         };
-        tracing::info!(bucket_uri = uri, "S3 token export enabled");
+        tracing::info!(bucket_uri = uri, "S3 token export configured");
         Some(Self::spawn_uploader(
             uploader,
             prefix,
@@ -626,7 +635,7 @@ impl TokenExportSink {
             bucket,
             endpoint: GCS_UPLOAD_ENDPOINT.to_string(),
         };
-        tracing::info!(bucket_uri = uri, "GCS token export enabled");
+        tracing::info!(bucket_uri = uri, "GCS token export configured");
         Some(Self::spawn_uploader(
             uploader,
             prefix,
@@ -639,6 +648,10 @@ impl TokenExportSink {
 
     pub const fn backend(&self) -> &'static str {
         self.backend.as_str()
+    }
+
+    pub async fn preflight(&self) -> anyhow::Result<()> {
+        self.uploader.preflight().await
     }
 
     /// Try to acquire one capture permit. Returns `None` when the pool is
@@ -668,6 +681,7 @@ impl TokenExportSink {
             tx,
             metrics,
             backend,
+            uploader,
             join: AsyncMutex::new(Some(join)),
             capture_sem: Arc::new(tokio::sync::Semaphore::new(max_captures.max(1))),
         })

--- a/experimental/sgl-router/src/server/token_export.rs
+++ b/experimental/sgl-router/src/server/token_export.rs
@@ -342,13 +342,6 @@ impl Uploader {
             Self::Gcs { .. } => ExportBackend::Gcs,
         }
     }
-    async fn preflight(&self) -> anyhow::Result<()> {
-        if let Self::Gcs { auth, .. } = self {
-            auth.bearer_token().await?;
-        }
-        Ok(())
-    }
-
     async fn put(&self, key: &str, body: Vec<u8>) -> anyhow::Result<()> {
         match self {
             Uploader::S3 {
@@ -510,7 +503,6 @@ pub struct TokenExportSink {
     tx: mpsc::Sender<PumpMsg>,
     metrics: Arc<MetricsRegistry>,
     backend: ExportBackend,
-    uploader: Arc<Uploader>,
     join: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
     capture_sem: Arc<tokio::sync::Semaphore>,
 }
@@ -649,10 +641,6 @@ impl TokenExportSink {
         self.backend.as_str()
     }
 
-    pub async fn preflight(&self) -> anyhow::Result<()> {
-        self.uploader.preflight().await
-    }
-
     /// Try to acquire one capture permit. Returns `None` when the pool is
     /// exhausted. Mirrors `CacheSimTee::try_acquire_capture_permit` so the
     /// same backpressure logic applies whether cache-sim is on or off.
@@ -680,7 +668,6 @@ impl TokenExportSink {
             tx,
             metrics,
             backend,
-            uploader,
             join: AsyncMutex::new(Some(join)),
             capture_sem: Arc::new(tokio::sync::Semaphore::new(max_captures.max(1))),
         })

--- a/experimental/sgl-router/src/server/token_export.rs
+++ b/experimental/sgl-router/src/server/token_export.rs
@@ -1,12 +1,27 @@
-//! S3 token-dataset export: a second tee independent of the cache-sim that
-//! writes ingest/extend token sequences as NDJSON+gzip batches to S3 for
-//! offline cache-hit recomputation.
+//! Object-storage token-dataset export: a second tee independent of the
+//! cache-sim that writes ingest/extend token sequences as NDJSON+gzip batches
+//! to S3 or Google Cloud Storage for offline cache-hit recomputation.
 
 use std::collections::HashMap;
 use std::io::Write;
 use std::time::{Duration, Instant};
 
 use serde::Serialize;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ExportBackend {
+    S3,
+    Gcs,
+}
+
+impl ExportBackend {
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::S3 => "s3",
+            Self::Gcs => "gcs",
+        }
+    }
+}
 
 #[derive(Clone, Copy, Debug, Serialize, PartialEq, Eq)]
 #[serde(rename_all = "lowercase")]
@@ -57,15 +72,20 @@ impl ExportRecord {
     }
 }
 
-/// Parse `s3://bucket/prefix/...` into `(bucket, key_prefix)`.
-/// `key_prefix` is stripped of leading and trailing `/` (re-added when
-/// constructing the key). Returns `None` for non-s3:// URIs.
-pub fn parse_s3_uri(uri: &str) -> Option<(String, String)> {
-    let rest = uri.trim().strip_prefix("s3://")?;
+fn parse_bucket_uri(uri: &str, scheme: &str) -> Option<(String, String)> {
+    let rest = uri.trim().strip_prefix(scheme)?;
     let mut parts = rest.splitn(2, '/');
     let bucket = parts.next().filter(|b| !b.is_empty())?.to_string();
     let prefix = parts.next().unwrap_or("").trim_matches('/').to_string();
     Some((bucket, prefix))
+}
+
+pub fn parse_s3_uri(uri: &str) -> Option<(String, String)> {
+    parse_bucket_uri(uri, "s3://")
+}
+
+pub fn parse_gcs_uri(uri: &str) -> Option<(String, String)> {
+    parse_bucket_uri(uri, "gs://")
 }
 
 /// Hive-style partitioned object key. `unix_nanos + seq` prevents collisions
@@ -87,7 +107,7 @@ pub(crate) fn object_key(
 }
 
 /// The slug is a client-suppliable header (x-radixark-endpoint-slug). Only a
-/// strict allowlist may reach S3 key paths or the batcher map: hostile values
+/// strict allowlist may reach object key paths or the batcher map: hostile values
 /// (path separators, huge/high-cardinality strings) collapse to "unknown".
 fn safe_slug(slug: Option<&str>) -> String {
     match slug {
@@ -110,7 +130,7 @@ pub(crate) struct ReadyObject {
     pub slug: String,
     pub raw_bytes: Vec<u8>,
     /// NDJSON record count in this batch; added to
-    /// `sgl_router_s3_export_records_uploaded_total` on successful upload.
+    /// `sgl_router_token_export_records_uploaded_total` on successful upload.
     pub records: u64,
 }
 
@@ -271,6 +291,32 @@ pub(crate) fn string_to_sign(
     )
 }
 
+const GCS_SCOPE: &str = "https://www.googleapis.com/auth/devstorage.read_write";
+const GCS_UPLOAD_ENDPOINT: &str = "https://storage.googleapis.com";
+
+pub(crate) enum GcsAuth {
+    Adc(tokio::sync::OnceCell<Arc<dyn gcp_auth::TokenProvider>>),
+    #[cfg(test)]
+    Static(String),
+}
+
+impl GcsAuth {
+    fn adc() -> Self {
+        Self::Adc(tokio::sync::OnceCell::new())
+    }
+
+    async fn bearer_token(&self) -> anyhow::Result<String> {
+        match self {
+            Self::Adc(cell) => {
+                let provider = cell.get_or_try_init(gcp_auth::provider).await?;
+                Ok(provider.token(&[GCS_SCOPE]).await?.as_str().to_string())
+            }
+            #[cfg(test)]
+            Self::Static(token) => Ok(token.clone()),
+        }
+    }
+}
+
 pub(crate) enum Uploader {
     S3 {
         http: reqwest::Client,
@@ -279,12 +325,30 @@ pub(crate) enum Uploader {
         region: String,
         bucket: String,
     },
-    // Test-only variant; suppressed outside #[cfg(test)] builds.
+    Gcs {
+        http: reqwest::Client,
+        auth: GcsAuth,
+        bucket: String,
+        endpoint: String,
+    },
     #[cfg_attr(not(test), allow(dead_code))]
     Fake(Arc<FakeStore>),
 }
 
 impl Uploader {
+    pub(crate) const fn backend(&self) -> ExportBackend {
+        match self {
+            Self::S3 { .. } | Self::Fake(_) => ExportBackend::S3,
+            Self::Gcs { .. } => ExportBackend::Gcs,
+        }
+    }
+    async fn preflight(&self) -> anyhow::Result<()> {
+        if let Self::Gcs { auth, .. } = self {
+            auth.bearer_token().await?;
+        }
+        Ok(())
+    }
+
     async fn put(&self, key: &str, body: Vec<u8>) -> anyhow::Result<()> {
         match self {
             Uploader::S3 {
@@ -343,6 +407,42 @@ impl Uploader {
                     anyhow::bail!("s3 put returned {status}: {body}");
                 }
             }
+            Uploader::Gcs {
+                http,
+                auth,
+                bucket,
+                endpoint,
+            } => {
+                let token = auth.bearer_token().await?;
+                let url = format!(
+                    "{}/upload/storage/v1/b/{}/o",
+                    endpoint.trim_end_matches('/'),
+                    uri_encode(bucket, true)
+                );
+                let resp = http
+                    .post(url)
+                    .query(&[
+                        ("uploadType", "media"),
+                        ("name", key),
+                        ("ifGenerationMatch", "0"),
+                    ])
+                    .bearer_auth(token)
+                    .header("content-encoding", "gzip")
+                    .header("content-type", "application/x-ndjson")
+                    .body(body)
+                    .send()
+                    .await?;
+                let status = resp.status();
+                // A retry after a successful upload whose response was lost returns 412
+                // because ifGenerationMatch=0 made the first write immutable.
+                if status.is_success() || status == reqwest::StatusCode::PRECONDITION_FAILED {
+                    resp.bytes().await?;
+                    Ok(())
+                } else {
+                    let body = resp.text().await.unwrap_or_default();
+                    anyhow::bail!("gcs object upload returned {status}: {body}");
+                }
+            }
             Uploader::Fake(store) => {
                 if store.fail_first.load(Ordering::SeqCst) > 0 {
                     store.fail_first.fetch_sub(1, Ordering::SeqCst);
@@ -369,7 +469,13 @@ pub(crate) async fn put_with_retry(
         match up.put(key, body.clone()).await {
             Ok(()) => return true,
             Err(e) => {
-                tracing::warn!(key, attempt, error = %e, "s3 export put failed; will retry");
+                tracing::warn!(
+                    backend = up.backend().as_str(),
+                    key,
+                    attempt,
+                    error = %e,
+                    "token export upload failed; will retry"
+                );
                 if attempt == max_attempts {
                     return false;
                 }
@@ -391,7 +497,7 @@ const TICK: Duration = Duration::from_secs(1);
 /// on the shared 8-core container while allowing parallelism.
 const UPLOAD_CONCURRENCY: usize = 4;
 /// Bounds pending raw-batch memory (~32×8 MiB) and keeps the pump loop live
-/// during an S3 outage — a best-effort tee sheds, never stalls its own
+/// during an object-store outage — a best-effort tee sheds, never stalls its own
 /// heartbeat.
 const MAX_PENDING_UPLOADS: usize = 32;
 
@@ -400,34 +506,38 @@ enum PumpMsg {
     Drain(tokio::sync::oneshot::Sender<()>),
 }
 
-pub struct S3ExportSink {
+pub struct TokenExportSink {
     tx: mpsc::Sender<PumpMsg>,
     metrics: Arc<MetricsRegistry>,
+    backend: ExportBackend,
+    uploader: Arc<Uploader>,
     join: AsyncMutex<Option<tokio::task::JoinHandle<()>>>,
-    /// Semaphore bounding the number of concurrent captures in S3-only mode.
-    /// Mirrors `CacheSimTee::try_acquire_capture_permit` so S3-only deployments
-    /// have the same aggregate-capture memory bound as cache-sim deployments.
     capture_sem: Arc<tokio::sync::Semaphore>,
 }
 
-impl std::fmt::Debug for S3ExportSink {
+impl std::fmt::Debug for TokenExportSink {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("S3ExportSink").finish_non_exhaustive()
+        f.debug_struct("TokenExportSink").finish_non_exhaustive()
     }
 }
 
-impl S3ExportSink {
-    /// Production entry point: parse `uri`, read credentials/region from the
-    /// standard AWS environment variables, build an S3 uploader, and start the
-    /// pump. Returns `None` if the URI is invalid, credentials are missing, or
-    /// temporary (session-token) credentials are detected.
-    pub fn spawn(
+impl TokenExportSink {
+    pub fn spawn_s3(
         uri: &str,
         pod: String,
         metrics: Arc<MetricsRegistry>,
         max_captures: usize,
     ) -> Option<Arc<Self>> {
-        let (bucket, prefix) = parse_s3_uri(uri)?;
+        let (bucket, prefix) = match parse_s3_uri(uri) {
+            Some(parts) => parts,
+            None => {
+                tracing::error!(
+                    uri,
+                    "invalid S3 token export URI; expected s3://bucket/prefix"
+                );
+                return None;
+            }
+        };
         // `.trim()`: a secretKeyRef-injected value can carry a trailing newline
         // (if the stored secret was created with a trailing `\n`); an untrimmed
         // key silently breaks SigV4 with SignatureDoesNotMatch. Creds/region
@@ -481,28 +591,66 @@ impl S3ExportSink {
             region,
             bucket,
         };
-
-        let metrics2 = Arc::clone(&metrics);
-        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let join = tokio::spawn(async move {
-            run_pump(
-                rx,
-                Arc::new(uploader),
-                prefix,
-                pod,
-                metrics2,
-                DEFAULT_MAX_BATCH_BYTES,
-            )
-            .await;
-        });
-        let capture_sem = Arc::new(tokio::sync::Semaphore::new(max_captures.max(1)));
-        tracing::info!("s3 token export enabled");
-        Some(Arc::new(Self {
-            tx,
+        tracing::info!(bucket_uri = uri, "S3 token export enabled");
+        Some(Self::spawn_uploader(
+            uploader,
+            prefix,
+            pod,
             metrics,
-            join: AsyncMutex::new(Some(join)),
-            capture_sem,
-        }))
+            max_captures,
+            DEFAULT_MAX_BATCH_BYTES,
+        ))
+    }
+
+    pub fn spawn_gcs(
+        uri: &str,
+        pod: String,
+        metrics: Arc<MetricsRegistry>,
+        max_captures: usize,
+    ) -> Option<Arc<Self>> {
+        let (bucket, prefix) = match parse_gcs_uri(uri) {
+            Some(parts) => parts,
+            None => {
+                tracing::error!(
+                    uri,
+                    "invalid GCS token export URI; expected gs://bucket/prefix"
+                );
+                return None;
+            }
+        };
+        let http = match reqwest::Client::builder()
+            .timeout(Duration::from_secs(30))
+            .build()
+        {
+            Ok(client) => client,
+            Err(error) => {
+                tracing::error!(%error, "failed to build GCS token export client");
+                return None;
+            }
+        };
+        let uploader = Uploader::Gcs {
+            http,
+            auth: GcsAuth::adc(),
+            bucket,
+            endpoint: GCS_UPLOAD_ENDPOINT.to_string(),
+        };
+        tracing::info!(bucket_uri = uri, "GCS token export enabled");
+        Some(Self::spawn_uploader(
+            uploader,
+            prefix,
+            pod,
+            metrics,
+            max_captures,
+            DEFAULT_MAX_BATCH_BYTES,
+        ))
+    }
+
+    pub const fn backend(&self) -> &'static str {
+        self.backend.as_str()
+    }
+
+    pub async fn preflight(&self) -> anyhow::Result<()> {
+        self.uploader.preflight().await
     }
 
     /// Try to acquire one capture permit. Returns `None` when the pool is
@@ -512,7 +660,32 @@ impl S3ExportSink {
         Arc::clone(&self.capture_sem).try_acquire_owned().ok()
     }
 
-    /// Test entry point: inject an uploader (does not touch AWS).
+    fn spawn_uploader(
+        uploader: Uploader,
+        prefix: String,
+        pod: String,
+        metrics: Arc<MetricsRegistry>,
+        max_captures: usize,
+        max_batch_bytes: usize,
+    ) -> Arc<Self> {
+        let backend = uploader.backend();
+        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
+        let metrics2 = Arc::clone(&metrics);
+        let uploader = Arc::new(uploader);
+        let pump_uploader = Arc::clone(&uploader);
+        let join = tokio::spawn(async move {
+            run_pump(rx, pump_uploader, prefix, pod, metrics2, max_batch_bytes).await;
+        });
+        Arc::new(Self {
+            tx,
+            metrics,
+            backend,
+            uploader,
+            join: AsyncMutex::new(Some(join)),
+            capture_sem: Arc::new(tokio::sync::Semaphore::new(max_captures.max(1))),
+        })
+    }
+
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn spawn_with_uploader(
         uploader: Uploader,
@@ -520,11 +693,9 @@ impl S3ExportSink {
         pod: String,
         metrics: Arc<MetricsRegistry>,
     ) -> Arc<Self> {
-        Self::spawn_with_uploader_batch(uploader, prefix, pod, metrics, DEFAULT_MAX_BATCH_BYTES)
+        Self::spawn_uploader(uploader, prefix, pod, metrics, 64, DEFAULT_MAX_BATCH_BYTES)
     }
 
-    /// Test entry point (configurable batch size): for tests that need to
-    /// trigger multiple batches from a small number of records.
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn spawn_with_uploader_batch(
         uploader: Uploader,
@@ -533,32 +704,18 @@ impl S3ExportSink {
         metrics: Arc<MetricsRegistry>,
         max_batch_bytes: usize,
     ) -> Arc<Self> {
-        let (tx, rx) = mpsc::channel(CHANNEL_CAPACITY);
-        let metrics2 = Arc::clone(&metrics);
-        let uploader = Arc::new(uploader);
-        let join = tokio::spawn(async move {
-            run_pump(rx, uploader, prefix, pod, metrics2, max_batch_bytes).await;
-        });
-        let capture_sem = Arc::new(tokio::sync::Semaphore::new(64));
-        Arc::new(Self {
-            tx,
-            metrics,
-            join: AsyncMutex::new(Some(join)),
-            capture_sem,
-        })
+        Self::spawn_uploader(uploader, prefix, pod, metrics, 64, max_batch_bytes)
     }
 
     fn enqueue(&self, rec: ExportRecord) {
         match self.tx.try_send(PumpMsg::Record(Box::new(rec))) {
-            Ok(()) => self.metrics.record_s3_export("enqueued"),
-            Err(mpsc::error::TrySendError::Full(_)) => {
-                self.metrics.record_s3_export("dropped_queue_full")
-            }
-            Err(mpsc::error::TrySendError::Closed(_)) => {
-                // Pump is gone (post-drain offers). Make these visible so a
-                // closed sink doesn't look like zero traffic.
-                self.metrics.record_s3_export("dropped_closed")
-            }
+            Ok(()) => self.metrics.record_token_export(self.backend(), "enqueued"),
+            Err(mpsc::error::TrySendError::Full(_)) => self
+                .metrics
+                .record_token_export(self.backend(), "dropped_queue_full"),
+            Err(mpsc::error::TrySendError::Closed(_)) => self
+                .metrics
+                .record_token_export(self.backend(), "dropped_closed"),
         }
     }
 
@@ -692,7 +849,7 @@ async fn upload_job(args: UploadJobArgs) {
     let gz = match tokio::task::spawn_blocking(move || gzip_fast(raw_bytes)).await {
         Ok(Some(gz)) => gz,
         Ok(None) | Err(_) => {
-            metrics.record_s3_export("put_failed");
+            metrics.record_token_export(uploader.backend().as_str(), "put_failed");
             return;
         }
     };
@@ -702,13 +859,14 @@ async fn upload_job(args: UploadJobArgs) {
     let key = object_key(&prefix, &slug, &date, &pod, nanos, seq);
 
     if put_with_retry(&uploader, &key, gz, PUT_MAX_ATTEMPTS).await {
-        metrics.record_s3_export("object_put");
-        metrics.add_s3_export_records_uploaded(records);
+        let backend = uploader.backend().as_str();
+        metrics.record_token_export(backend, "object_put");
+        metrics.add_token_export_records_uploaded(backend, records);
         if is_drain {
-            metrics.record_s3_export("drain_flushed");
+            metrics.record_token_export(backend, "drain_flushed");
         }
     } else {
-        metrics.record_s3_export("put_failed");
+        metrics.record_token_export(uploader.backend().as_str(), "put_failed");
     }
     // _permit is dropped here, releasing the semaphore slot.
 }
@@ -808,7 +966,7 @@ fn dispatch_ready(
         // The drain/close path (`force`) is exempt — shutdown must flush every
         // remaining batch.
         if !force && join_set.len() >= MAX_PENDING_UPLOADS {
-            metrics.record_s3_export("dropped_upload_backlog");
+            metrics.record_token_export(uploader.backend().as_str(), "dropped_upload_backlog");
             continue;
         }
 
@@ -900,6 +1058,20 @@ mod tests {
         );
         assert_eq!(parse_s3_uri("https://x"), None);
         assert_eq!(parse_s3_uri("s3://"), None);
+    }
+
+    #[test]
+    fn parse_gcs_uri_splits_bucket_and_prefix() {
+        assert_eq!(
+            parse_gcs_uri("gs://my-bucket/token-export/"),
+            Some(("my-bucket".into(), "token-export".into()))
+        );
+        assert_eq!(
+            parse_gcs_uri("gs://only-bucket"),
+            Some(("only-bucket".into(), "".into()))
+        );
+        assert_eq!(parse_gcs_uri("s3://my-bucket"), None);
+        assert_eq!(parse_gcs_uri("gs://"), None);
     }
 
     #[test]
@@ -1007,11 +1179,110 @@ mod tests {
         assert!(store.puts.lock().unwrap().is_empty());
     }
 
+    #[tokio::test]
+    async fn gcs_put_is_authenticated_and_idempotent() {
+        use axum::extract::{Path, Query, State};
+        use axum::http::{HeaderMap, StatusCode};
+        use axum::routing::post;
+        use axum::Router;
+
+        #[derive(Debug)]
+        struct CapturedRequest {
+            bucket: String,
+            query: HashMap<String, String>,
+            authorization: String,
+            content_encoding: String,
+            content_type: String,
+            body: Vec<u8>,
+        }
+
+        async fn capture(
+            State(state): State<Arc<Mutex<Vec<CapturedRequest>>>>,
+            Path(bucket): Path<String>,
+            Query(query): Query<HashMap<String, String>>,
+            headers: HeaderMap,
+            body: bytes::Bytes,
+        ) -> StatusCode {
+            let mut requests = state.lock().unwrap();
+            requests.push(CapturedRequest {
+                bucket,
+                query,
+                authorization: headers["authorization"].to_str().unwrap().to_string(),
+                content_encoding: headers["content-encoding"].to_str().unwrap().to_string(),
+                content_type: headers["content-type"].to_str().unwrap().to_string(),
+                body: body.to_vec(),
+            });
+            if requests.len() == 1 {
+                StatusCode::OK
+            } else {
+                StatusCode::PRECONDITION_FAILED
+            }
+        }
+
+        let captured = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/upload/storage/v1/b/{bucket}/o", post(capture))
+            .with_state(Arc::clone(&captured));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let endpoint = format!("http://{}", listener.local_addr().unwrap());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let uploader = Uploader::Gcs {
+            http: reqwest::Client::new(),
+            auth: GcsAuth::Static("test-token".into()),
+            bucket: "test-bucket".into(),
+            endpoint: endpoint.clone(),
+        };
+        let body = gzip_fast(b"{\"kind\":\"ingest\"}\n".to_vec()).unwrap();
+        for _ in 0..2 {
+            uploader
+                .put("prefix/slug=x/object.ndjson.gz", body.clone())
+                .await
+                .unwrap();
+        }
+
+        let metrics = test_metrics();
+        let sink = TokenExportSink::spawn_with_uploader(
+            Uploader::Gcs {
+                http: reqwest::Client::new(),
+                auth: GcsAuth::Static("test-token".into()),
+                bucket: "test-bucket".into(),
+                endpoint,
+            },
+            "prefix".into(),
+            "pod-1".into(),
+            Arc::clone(&metrics),
+        );
+        sink.offer_ingest("m", &[1, 2], "rid", Some("slug-x"), None);
+        sink.drain().await;
+        server.abort();
+
+        let rendered = metrics.render();
+        assert!(rendered
+            .contains("sgl_router_token_export_total{backend=\"gcs\",result=\"object_put\"} 1"));
+        assert!(
+            rendered.contains("sgl_router_token_export_records_uploaded_total{backend=\"gcs\"} 1")
+        );
+
+        let mut requests = captured.lock().unwrap();
+        assert_eq!(requests.len(), 3);
+        let request = requests.remove(0);
+        assert_eq!(request.bucket, "test-bucket");
+        assert_eq!(request.query["uploadType"], "media");
+        assert_eq!(request.query["name"], "prefix/slug=x/object.ndjson.gz");
+        assert_eq!(request.query["ifGenerationMatch"], "0");
+        assert_eq!(request.authorization, "Bearer test-token");
+        assert_eq!(request.content_encoding, "gzip");
+        assert_eq!(request.content_type, "application/x-ndjson");
+        assert_eq!(request.body, body);
+        assert_eq!(gunzip(&request.body), "{\"kind\":\"ingest\"}\n");
+    }
+
     /// Real S3 round-trip against the actual `Uploader::S3` SigV4 path.
     /// Ignored by default (no creds in CI). Run manually with STATIC keys:
     ///   AWS_ACCESS_KEY_ID=.. AWS_SECRET_ACCESS_KEY=.. AWS_REGION=us-west-2 \
     ///   TEST_S3_URI=s3://<bucket>/<prefix>/ \
-    ///   cargo test --lib s3_export::tests::real_s3_roundtrip -- --ignored --nocapture
+    ///   cargo test --lib token_export::tests::real_s3_roundtrip -- --ignored --nocapture
     /// (SSO/temporary creds won't work — we don't sign x-amz-security-token.)
     #[tokio::test]
     #[ignore]
@@ -1077,6 +1348,41 @@ mod tests {
             }
         }
         panic!("real S3 PutObject to {key} failed: {}", last_err.unwrap());
+    }
+
+    /// Real GCS round-trip using Application Default Credentials.
+    /// Run with `TEST_GCS_URI=gs://bucket/prefix/ cargo test --lib
+    /// token_export::tests::real_gcs_roundtrip -- --ignored --nocapture`.
+    #[tokio::test]
+    #[ignore]
+    async fn real_gcs_roundtrip() {
+        let uri = match std::env::var("TEST_GCS_URI") {
+            Ok(uri) => uri,
+            Err(_) => {
+                eprintln!("real_gcs_roundtrip skipped: set TEST_GCS_URI=gs://bucket/prefix/");
+                return;
+            }
+        };
+        let (bucket, prefix) = parse_gcs_uri(&uri).expect("TEST_GCS_URI must use gs://");
+        let uploader = Uploader::Gcs {
+            http: reqwest::Client::builder()
+                .timeout(Duration::from_secs(30))
+                .build()
+                .unwrap(),
+            auth: GcsAuth::adc(),
+            bucket,
+            endpoint: GCS_UPLOAD_ENDPOINT.to_string(),
+        };
+        let key = if prefix.is_empty() {
+            "roundtrip-check.txt".to_string()
+        } else {
+            format!("{prefix}/roundtrip-check.txt")
+        };
+        let body = gzip_fast(b"{\"source\":\"sgl-router-gcs-roundtrip\"}\n".to_vec()).unwrap();
+        uploader
+            .put(&key, body)
+            .await
+            .unwrap_or_else(|error| panic!("real GCS object upload to {key} failed: {error}"));
     }
 
     // ---- SigV4 building blocks ----
@@ -1162,7 +1468,7 @@ mod tests {
         let store = Arc::new(FakeStore::new(0));
         let up = Uploader::Fake(Arc::clone(&store));
         let sink =
-            S3ExportSink::spawn_with_uploader(up, "pfx".into(), "pod-1".into(), test_metrics());
+            TokenExportSink::spawn_with_uploader(up, "pfx".into(), "pod-1".into(), test_metrics());
         sink.offer_ingest("m", &[1, 2, 3], "rid", Some("slugA"), Some("key-abc"));
         sink.offer_extend(
             "m",
@@ -1194,7 +1500,7 @@ mod tests {
     #[tokio::test]
     async fn offer_never_blocks_and_missing_slug_becomes_unknown() {
         let store = Arc::new(FakeStore::new(0));
-        let sink = S3ExportSink::spawn_with_uploader(
+        let sink = TokenExportSink::spawn_with_uploader(
             Uploader::Fake(Arc::clone(&store)),
             "".into(),
             "pod-1".into(),
@@ -1214,7 +1520,7 @@ mod tests {
     async fn drain_waits_for_all_concurrent_uploads() {
         // Use a 1-byte batch threshold to force one object per record.
         let store = Arc::new(FakeStore::new(0));
-        let sink = S3ExportSink::spawn_with_uploader_batch(
+        let sink = TokenExportSink::spawn_with_uploader_batch(
             Uploader::Fake(Arc::clone(&store)),
             "pfx".into(),
             "pod-1".into(),


### PR DESCRIPTION
## Motivation

The experimental router's token-dataset tee currently uploads only to Amazon S3. Deployments on Google Cloud need the same bounded, non-blocking export path without static AWS credentials.

This is a follow-up to #34246 and #35261.

## Modifications

- Add `--token-export-gcs-uri gs://bucket/prefix/` and `RADIXARK_TOKEN_EXPORT_GCS_URI`.
- Authenticate through Google Application Default Credentials using `gcp_auth`.
  - service-account credential files
  - local ADC / `gcloud` fallback
  - GCE/GKE metadata credentials
- Upload gzipped NDJSON through the Cloud Storage JSON API.
- Use `ifGenerationMatch=0`; treat HTTP 412 as success so retry-after-lost-response is idempotent.
- Match S3 credential handling: unusable credentials disable only export while router readiness and request serving continue.
- Keep S3 and GCS mutually exclusive.
- Generalize export metrics with a bounded `backend={s3,gcs}` label while preserving the existing S3 metric names as deprecated aliases.
- Rename the internal sink from `S3ExportSink` to `TokenExportSink`.
- Document GCS configuration, least-privilege IAM, and data-retention/privacy requirements.

The existing queue, capture semaphore, batch limits, upload concurrency, retries, and graceful drain remain shared by both backends. No local spool is introduced.

## Accuracy Tests

N/A. This change does not modify model inputs, outputs, kernels, or sampling.

## Speed Tests and Profiling

N/A for model performance. Export remains disabled by default. When enabled, the request path still uses the existing non-blocking `try_send` tee and bounded capture permits.

## Validation

- `cargo +nightly fmt -- --check`
- `cargo check --all-targets`
- `cargo check --features profiling --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo clippy --features profiling --all-targets -- -D warnings`
- `cargo test --release -- --skip parity_matrix`
  - 1,204 passed; 0 failed
- `cargo test --release --features profiling -- --skip parity_matrix`
  - 1,208 passed; 0 failed
- `cargo build --release --all-targets`
- KV-event hash fixture regeneration: no diff
- `cargo deny check licenses bans sources`
- GCS mock verifies:
  - JSON media-upload path and query
  - bearer authentication
  - gzip and NDJSON headers
  - idempotent 412 handling
  - drain-to-GCS metrics
- Real GCS round-trip with ADC passed; the temporary object was deleted after verification.
- Actual compiled-router E2E passed:
  - buffered and SSE requests completed through a fake OpenAI worker
  - graceful shutdown flushed one GCS batch
  - downloaded batch contained 2 ingest + 2 extend records
  - all temporary objects were deleted
- Broken-ADC binary smoke test reached `/readyz` with HTTP 200 and kept the compiled router alive.

`cargo deny check advisories` still reports the branch's pre-existing `pprof 0.13` / RUSTSEC-2024-0408 finding. This PR does not add or modify `pprof`; licenses, bans, and sources pass.

## Checklist

- [x] Format code according to the contribution guide.
- [x] Add unit and integration coverage.
- [x] Update documentation.
- [x] Verify model accuracy impact is N/A.
- [x] Verify request-path performance design remains non-blocking and bounded.
- [x] Follow SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32593093831](https://github.com/sgl-project/sglang/actions/runs/32593093831)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32593093614](https://github.com/sgl-project/sglang/actions/runs/32593093614)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

