### PR TITLE
[AMD][DSV4] perf: use full 1024-thread block for indexer top-k on ROCm

### DIFF
--- a/python/sglang/kernels/aot/csrc/elementwise/deepseek_v4_topk.cu
+++ b/python/sglang/kernels/aot/csrc/elementwise/deepseek_v4_topk.cu
@@ -28,7 +28,16 @@ limitations under the License.
 namespace {
 
 constexpr uint32_t kMaxTopK = 1024;
+#ifdef USE_ROCM
+// CDNA3/CDNA4: this kernel is one block per row and is latency-bound on its
+// O(c4_len) histogram and emit passes. A full 1024-thread block (16 wavefronts
+// of 64 lanes) instead of 512 doubles the per-block scan parallelism, which is
+// ~1.6x faster at 128k context (c4_len = 32768) and never slower at short
+// context. The selected index set is unchanged. CUDA keeps 512.
+constexpr uint32_t kBlockSize = 1024;
+#else
 constexpr uint32_t kBlockSize = 512;
+#endif
 
 #ifdef SGL_TOPK_DYNAMIC_SMEM_BYTES
 constexpr size_t kSMEM = static_cast<size_t>(SGL_TOPK_DYNAMIC_SMEM_BYTES);

--- a/python/sglang/kernels/aot/tests/test_topk.py
+++ b/python/sglang/kernels/aot/tests/test_topk.py
@@ -249,5 +249,48 @@ def test_topk_transform_ragged_kernel(
     )
 
 
+@pytest.mark.skipif(
+    torch.version.hip is None,
+    reason="deepseek_v4_topk_transform_512 is only built on ROCm",
+)
+@pytest.mark.parametrize("bs", [1, 48])
+@pytest.mark.parametrize("c4_len", [2048, 8192, 32768])
+@torch.inference_mode()
+def test_deepseek_v4_topk_transform(bs: int, c4_len: int) -> None:
+    # c4_len 32768 is the 128k-context decode shape, i.e. the longest scan the
+    # kernel runs and the one most sensitive to the block size it launches with.
+    from sgl_kernel import deepseek_v4_topk_transform_512
+
+    torch.manual_seed(42)
+    topk, page_size = 1024, 64
+
+    scores = torch.randn(bs, c4_len, dtype=torch.float32, device="cuda")
+    seq_lens = torch.full((bs,), c4_len, dtype=torch.int32, device="cuda")
+    # Identity page table, so emitted paged slots equal raw token positions and
+    # can be compared against torch.topk indices directly.
+    num_pages = (c4_len + page_size - 1) // page_size
+    page_table = (
+        torch.arange(num_pages, dtype=torch.int32, device="cuda")
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+    page_indices = torch.full((bs, topk), -1, dtype=torch.int32, device="cuda")
+
+    deepseek_v4_topk_transform_512(
+        scores, seq_lens, page_table, page_indices, page_size
+    )
+
+    indices_ref = torch.topk(scores, topk, dim=-1, sorted=False).indices
+    assert_equal(
+        scores,
+        torch.sort(indices_ref, dim=-1).values,
+        torch.sort(page_indices, dim=-1).values,
+        bs,
+        topk,
+        c4_len,
+    )
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

`deepseek_v4_topk_transform` launches **one block per row** and is latency-bound on its `O(c4_len)` histogram and emit passes, not throughput-bound. Measured kernel time is essentially flat from batch 8 to batch 256 at 128k context (~36.8 us), confirming the cost is per-block scan latency rather than occupancy.

On CDNA the wavefront is 64 lanes, so a 512-thread block is only 8 wavefronts and uses half the scan width a block can provide. Raising `kBlockSize` to 1024 on ROCm doubles per-block scan parallelism.

## Modification

`kBlockSize` becomes 1024 under `USE_ROCM`. The CUDA path keeps 512. One file, 9 lines added.

## Accuracy

GSM8K 5-shot, all 1319 test questions:

```bash
python3 benchmark/gsm8k/bench_sglang.py --num-questions 2000 --parallel 1200
```

| arm | correct | accuracy |
|---|---|---|
| baseline | 1248/1319 | 94.62% |
| this PR  | 1246/1319 | 94.47% |


## Performance

DeepSeek-V4-Pro, MI355X (gfx950) TP8, 128k input / 256 output, `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260821`.

```bash
# per arm, CONC in {16, 32, 48, 64}
SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE=1 \
SGLANG_OPT_NATIVE_BPRESHUFFLE_SCALE=1 \
AITER_BF16_FP8_MOE_BOUND=0 \
SGLANG_OPT_USE_AITER_BATCHED_GEMM=1 \
python -m sglang.launch_server \
  --model-path deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 8 \
  --attention-backend dsv4 \
  --page-size 256 \
  --kv-cache-dtype fp8_e4m3 \
  --enforce-shared-experts-fusion \
  --context-length 133120 \
  --chunked-prefill-size 8192 \
  --mem-fraction-static 0.89 \
  --max-running-requests $CONC \
  --cuda-graph-max-bs $CONC
```

Client: `$CONC` concurrent `/generate` requests, 128000-token prompts, `max_new_tokens=256`, `temperature=0`, `ignore_eos=true`. Total token throughput is the server's steady-state `Decode batch ... gen throughput (token/s)` while `#running-req == $CONC`; TPOT is derived as `CONC / throughput`.

| conc | TPOT base (ms) | TPOT PR (ms) | TPOT | Total tput base (tok/s) | Total tput PR (tok/s) | Tput |
|---|---|---|---|---|---|---|
| 16 | 15.52 | 15.07 | -2.9% | 1031.1 | 1061.6 | +3.0% |
| 32 | 17.98 | 17.45 | -2.9% | 1780.1 | 1833.7 | +3.0% |
| 48 | 19.84 | 19.46 | -1.9% | 2418.8 | 2466.8 | +2.0% |
| 64 | 22.49 | 22.13 | -1.6% | 2845.3 | 2891.5 | +1.6% |

The gain shrinks as concurrency rises because the top-k cost is batch-invariant while the rest of the decode step grows with batch, so a fixed saving becomes a smaller share of a larger step. Same-server repeats at conc 16 were tight (0.15% baseline, 0.71% this PR).

### Kernel level

Isolated, at the real decode shapes (`topk=1024`, `page_size=256`):

| context | c4_len | baseline | this PR | speedup |
|---|---|---|---|---|
| 128k | 32768 | 36.8 us | 23.0 us | 1.60x |
| 64k  | 16384 | -        | -       | 1.43x |
| 32k  | 8192  | -        | -       | 1.30x |
| 8k   | 2048  | -        | -       | 1.07x |

No regression at any context length.

A torch-profiler capture of a full decode step (batch 48, 128k) shows the kernel runs 30 times per step at 44.26 us, dropping to 29.90 us with this change: 431 us saved out of a 21.5 ms step, i.e. 2.0%, which matches the measured end-to-end 2.0% at conc 48.

## Unit test

`deepseek_v4_topk_transform_512` had no test, so this PR adds one to the existing
`python/sglang/kernels/aot/tests/test_topk.py`, reusing that file's `assert_equal`
helper (which forgives equal-score ties but nothing else):

```bash
pytest python/sglang/kernels/aot/tests/test_topk.py -k deepseek_v4_topk_transform
```

It asserts the selected index set matches `torch.topk` for `c4_len` in {2048, 8192, 32768}
x batch in {1, 48}, with `c4_len=32768` being the 128k-context decode shape this PR
targets. Passes with both 512 and 1024 (6 passed each) — it pins the kernel's contract
rather than the block size, so it keeps guarding the CUDA path too. The op is only
exported when `torch.version.hip is not None`, so the test is skipped on NVIDIA.

## Checklist

- [x] Correctness: selected index set is identical to the current kernel across 3860 rows (`c4_len` 2048-32768, batch 1/64/128, 4 seeds), and covers `torch.topk` ground truth.
- [x] End-to-end benchmarked on MI355X TP8 (table above).
- [x] CUDA path unchanged (`#else` branch keeps 512).
- [x] Unit test added for the previously untested op; passes at both 512 and 1024.

Made with [Cursor](https://cursor.com)


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32587159218](https://github.com/sgl-project/sglang/actions/runs/32587159218)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32624966316](https://github.com/sgl-project/sglang/actions/runs/32624966316)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32587159333](https://github.com/sgl-project/sglang/actions/runs/32587159333)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
