### PR TITLE
[Mamba] fix mamba index h unexpected assertion for dcp

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2651,7 +2651,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         checkpoint_grid = mamba_checkpoint_grid(self.tree_cache.page_size)
 
         def _force_track_h(i: int) -> int:
-            assert i % chunk_size == 0
+            # h is indexed relative to the extend start, so check that offset.
+            assert (i - len(req.prefix_indices)) % chunk_size == 0, (
+                f"The force track calculation only handles last-position or "
+                f"unaligned seqlens, so it needs a chunk-aligned offset to "
+                f"start from. But i={i} prefix_len={len(req.prefix_indices)} "
+                f"chunk_size={chunk_size} checkpoint_grid={checkpoint_grid}"
+            )
             # There are 3 cases for mamba_track_seqlen passed to mamba_track_seqlens_cpu:
             # 1) aligned with chunk_size-> retrieve from last_recurrent_state
             #    a) is the last position -> retrieve from last_recurrent_state


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

This patch is to fix the following mamba assertion which will make sglang server crash unexpected :
```
File "sglang/srt/managers/scheduler.py", line 3171, in get_next_batch_to_run
      prefill_plan = self.get_new_batch_prefill(running_batch)
  File "sglang/srt/managers/scheduler.py", line 3233, in get_new_batch_prefill
      ret, running_batch = self._get_new_batch_prefill_raw(
  File "sglang/srt/managers/scheduler.py", line 3493, in _get_new_batch_prefill_raw
      new_batch.prepare_for_extend()
  File "sglang/srt/managers/schedule_batch.py", line 2509, in prepare_for_extend
      track_entry = self._mamba_radix_cache_v2_req_prepare_for_extend(req)
  File "sglang/srt/managers/schedule_batch.py", line 2695, in _mamba_radix_cache_v2_req_prepare_for_extend
      mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)
  File "sglang/srt/managers/schedule_batch.py", line 2654, in _force_track_h
      assert i % chunk_size == 0
             ^^^^^^^^^^^^^^^^^^^
  AssertionError
```
Issue was initially found on AMD mi355x platform and can also be reproduced on latest Nvidia image:
`lmsysorg/sglang:nightly-dev-20260822-7fd54543`

How to reproduce it:

```bash
# server
python3 -m sglang.launch_server \
      --model-path moonshotai/Kimi-Linear-48B-A3B-Instruct --trust-remote-code \
      --tp-size 8 --dcp-size 8 --page-size 32 \
      --dtype bfloat16 --context-length 32768 --chunked-prefill-size 8224 \
      --mem-fraction-static 0.85 --host 127.0.0.1 --port 8100

# client
curl -s http://127.0.0.1:8100/generate -H 'Content-Type: application/json' -d "{
    \"text\": \"$(python3 -c 'print(\"The capital of France is Paris. \" * 1700, end=\"\")')\",
    \"sampling_params\": {\"temperature\": 0, \"max_new_tokens\": 4}}"
```

Root cause is that h is indexed in extend-relative coordinates, but the original assertion checked the absolute seqlen. The two differ by prefix_len, so the assertion indeed contains an assumption that prefix_len itself must be divisible by tree page size. While chunked prefill only guarantees alignment to page_size. DCP is what lets page_size be decoupled to tree page size, this is how issue happened.


## Modifications

<!-- Detail the changes made in this pull request. -->

Only change the assertion check the extend index


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

```bash
python benchmark/gsm8k/bench_sglang.py --num-shots 5 --num-questions 1300 --parallel 64 --port 8100
Accuracy:          0.898
Invalid:           0.000
Latency:           82.124 s
Output throughput: 1566.428 token/s
```

  

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32647356387](https://github.com/sgl-project/sglang/actions/runs/32647356387)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32647356105](https://github.com/sgl-project/sglang/actions/runs/32647356105)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32647356404](https://github.com/sgl-project/sglang/actions/runs/32647356404)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->