### PR TITLE
[diffusion] Fix Hunyuan QKV pack indexing at production video shapes

### DIFF
--- a/python/sglang/kernels/ops/diffusion/rope/hunyuan_qkv_pack_triton.py
+++ b/python/sglang/kernels/ops/diffusion/rope/hunyuan_qkv_pack_triton.py
@@ -52,7 +52,10 @@ def _hunyuan_qkv_rope_pack_kernel(
     BLOCK_HEADS: tl.constexpr,
     BLOCK_HALF: tl.constexpr,
 ):
-    token = tl.program_id(0)
+    # Merged Hunyuan projections can have row offsets above INT32_MAX at
+    # production video shapes (for example, 115200 * 21504). Keep all row
+    # address arithmetic in int64, as the other diffusion layout kernels do.
+    token = tl.program_id(0).to(tl.int64)
     head_block = tl.program_id(1)
     total_tokens = img_tokens + txt_tokens
     batch = token // total_tokens

--- a/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
+++ b/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
@@ -42,6 +42,7 @@ from sglang.kernels.ops.diffusion import (
     can_use_fused_rmsnorm_scale_shift,
     can_use_wan_rmsnorm_silu,
     fused_ltx2_rms_norm_modulate,
+    hunyuan_qkv_rope_pack,
     mark_fused_ln_modulate_site,
     mark_hunyuan_qknorm_site,
     mark_ltx2_rms_norm_modulate_site,
@@ -583,6 +584,47 @@ def test_hunyuan_qkv_rope_pack_is_bit_exact(img_tokens, txt_tokens):
     assert torch.equal(q, q_ref)
     assert torch.equal(k, k_ref)
     assert torch.equal(v, v_ref)
+
+
+def test_hunyuan_qkv_rope_pack_uses_int64_row_offsets():
+    if torch.cuda.get_device_properties(0).total_memory < 16 * 2**30:
+        pytest.skip("needs >= 16 GB GPU memory")
+
+    img_tokens, txt_tokens = 115200, 8
+    num_heads, head_dim = 24, 128
+    total_tokens = img_tokens + txt_tokens
+    projection_width = 21504
+
+    projection = torch.zeros(
+        (1, total_tokens, projection_width),
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    qkv = projection[..., : 3 * num_heads * head_dim].view(
+        1, total_tokens, 3, num_heads, head_dim
+    )
+    q = qkv[:, :, 0].contiguous()
+    k = qkv[:, :, 1].contiguous()
+    v = qkv[:, :, 2]
+    assert (img_tokens - 1) * v.stride(1) > torch.iinfo(torch.int32).max
+
+    cos = torch.ones((img_tokens, head_dim // 2), device="cuda")
+    sin = torch.zeros_like(cos)
+    packed = hunyuan_qkv_rope_pack(
+        q[:, :img_tokens],
+        k[:, :img_tokens],
+        v[:, :img_tokens],
+        q[:, img_tokens:],
+        k[:, img_tokens:],
+        v[:, img_tokens:],
+        cos,
+        sin,
+    )
+    torch.cuda.synchronize()
+
+    expected_shape = (1, total_tokens, num_heads, head_dim)
+    assert all(x.shape == expected_shape for x in packed)
+    assert all(x[0, img_tokens - 1, -1, -1].item() == 0 for x in packed)
 
 
 def test_hunyuan_quality_qknorm_matches_rmsnorm():


### PR DESCRIPTION
## Summary

- keep Hunyuan QKV-pack row indexing in int64
- add a production-shaped regression whose merged-projection offset crosses INT32_MAX

## Root cause

FastHunyuan at 1280x720x125 frames produces 115,200 image tokens. The merged projection has a 21,504-element row stride, so the final row offset is 2,477,239,296 elements. The Triton program ID was inferred as int32 and overflowed while addressing the strided V view, causing an illegal memory access.

Casting the token index to int64 keeps the derived row-address arithmetic wide without changing the kernel layout or numerics.

## H200 validation

- production shape: FastVideo/FastHunyuan-diffusers, 1280x720, 125 frames, 6 steps, BF16, native SGLang
- lossless: 103.456 s denoise / 120.824 s saved-request e2e
- quality=high: 102.366 s denoise / 119.697 s saved-request e2e
- PyTorch-reference fallback versus fixed kernel ABBA: 121.001 s -> 120.393 s mean e2e (0.505%); all four MP4 files are byte-exact
- output SHA256: f4a8bffb62398b23e0884ea07b823d5857b436253bf0809fca65a28cf79016e2
- 41.91 GB isolated model caches were deleted after each model group, with zero weight files left

This is a production-shape correctness fix, not a >=1.5% performance claim.

## Tests

- python3 -m pytest -q test/registered/kernels/ops/diffusion/test_model_fast_paths.py -k hunyuan_qkv_rope_pack (3 passed on H200)
- pre-commit run --files python/sglang/kernels/ops/diffusion/rope/hunyuan_qkv_pack_triton.py test/registered/kernels/ops/diffusion/test_model_fast_paths.py

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32643228721](https://github.com/sgl-project/sglang/actions/runs/32643228721)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32664629121](https://github.com/sgl-project/sglang/actions/runs/32664629121)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32643228882](https://github.com/sgl-project/sglang/actions/runs/32643228882)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->