### PR TITLE
fix(openai): guard before-validators against non-dict request bodies

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -964,6 +964,8 @@ class ChatCompletionRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def set_tool_choice_default(cls, values):
+        if not isinstance(values, dict):
+            return values
         if values.get("tool_choice") is None:
             if values.get("tools") is None and not _has_message_level_tools(
                 values.get("messages")
@@ -983,6 +985,8 @@ class ChatCompletionRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def normalize_reasoning_inputs(cls, values: Dict):
+        if not isinstance(values, dict):
+            return values
         r = values.get("reasoning")
         thinking = None
 
@@ -1042,8 +1046,10 @@ class ChatCompletionRequest(BaseModel):
     @model_validator(mode="before")
     @classmethod
     def set_json_schema(cls, values):
+        if not isinstance(values, dict):
+            return values
         response_format = values.get("response_format")
-        if not response_format:
+        if not isinstance(response_format, dict):
             return values
 
         if response_format.get("type") != "json_schema":

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -152,6 +152,26 @@ class TestChatCompletionRequest(unittest.TestCase):
                     {**base_request, "response_format": response_format}
                 )
 
+    def test_non_dict_body_raises_validation_error(self):
+        """A JSON body that is not an object must fail pydantic validation,
+        not crash inside a mode="before" validator with AttributeError
+        (which FastAPI surfaces as HTTP 500 instead of 422)."""
+        for body in ([], "hello", 42, [{"role": "user", "content": "hi"}]):
+            with self.subTest(body=body), self.assertRaises(ValidationError):
+                ChatCompletionRequest.model_validate(body)
+
+    def test_non_dict_response_format_raises_validation_error(self):
+        """A response_format that is not an object (e.g. the common typo
+        "json") must be reported as a validation error, not crash
+        set_json_schema with AttributeError."""
+        request = {
+            "model": "test-model",
+            "messages": [{"role": "user", "content": "Hello"}],
+            "response_format": "json",
+        }
+        with self.assertRaises(ValidationError):
+            ChatCompletionRequest.model_validate(request)
+
     def test_basic_chat_completion_request(self):
         """Test basic chat completion request"""
         messages = [{"role": "user", "content": "Hello"}]


### PR DESCRIPTION
## Motivation

`ChatCompletionRequest` has three `mode="before"` model validators that call `values.get(...)` before checking that the parsed JSON body is a dict. Two kinds of request crash inside validation with `AttributeError`, which FastAPI surfaces as HTTP 500 instead of the 422 validation error the client should get:

1. A body that is not a JSON object at all:

```bash
curl -s http://localhost:30000/v1/chat/completions \
  -H 'Content-Type: application/json' -d '[]'
# -> 500, AttributeError: 'list' object has no attribute 'get'
```

2. A well-formed request whose `response_format` is not an object — e.g. the common typo `"response_format": "json"` — because `set_json_schema` calls `response_format.get("type")` before pydantic has validated the field:

```bash
curl -s http://localhost:30000/v1/chat/completions \
  -H 'Content-Type: application/json' \
  -d '{"model": "x", "messages": [{"role": "user", "content": "hi"}], "response_format": "json"}'
# -> 500, AttributeError: 'str' object has no attribute 'get'
```

The codebase already treats this correctly elsewhere: `normalize_reasoning_to_thinking` and `normalize_responses_input` (responses protocol) and `_migrate_deprecated_dp_rank` (used by `CompletionRequest`, which returns a proper 422 for the same inputs today) all return early on non-dict input. This PR brings the remaining three validators in line with them.

For reference, vLLM recently merged the same class of fix for its before-validators (vllm-project/vllm#52528).

## Modifications

- `set_tool_choice_default`, `normalize_reasoning_inputs`, `set_json_schema`: return `values` unchanged when it is not a dict, so pydantic reports the type error normally.
- `set_json_schema`: also return early when `response_format` itself is not a dict.
- Tests: two new cases in `TestChatCompletionRequest` asserting `ValidationError` (not `AttributeError`) for non-dict bodies and for a non-dict `response_format`. Both fail on `main` and pass with this change.

## Accuracy Tests

Not applicable — request validation only, no change to model outputs.

## Speed Tests and Profiling

Not applicable.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32590863677](https://github.com/sgl-project/sglang/actions/runs/32590863677)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32590863654](https://github.com/sgl-project/sglang/actions/runs/32590863654)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32590863704](https://github.com/sgl-project/sglang/actions/runs/32590863704)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->