### PR TITLE
[diffusion] Default Hunyuan VAE to tiled decode

### DIFF
--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -199,6 +199,15 @@ vae_sp: true
 enable_torch_compile: false
 ```
 
+HunyuanVideo and FastHunyuan use tiled VAE decode by default so multi-GPU runs
+distribute VAE tiles instead of selecting spatial-shard decode. At
+HunyuanVideo's supported 960×544×77 shape, spatial-shard decode can consume
+99.8 GiB per rank before requesting another 49.61 GiB causal mask. At
+FastHunyuan's default 1280×720×125 shape, the mask alone would require
+197.75 GiB. You can still override the policy with
+`--vae-config.parallel-decode-mode`, but `spatial` and `spatial_shard` should
+only be used for smaller validated shapes.
+
 ## Generate
 
 `sglang generate` runs a single generation job and exits when the job finishes.

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
@@ -93,7 +93,9 @@ class HunyuanConfig(PipelineConfig):
     # DiT
     dit_config: DiTConfig = field(default_factory=HunyuanVideoConfig)
     # VAE
-    vae_config: VAEConfig = field(default_factory=HunyuanVAEConfig)
+    vae_config: VAEConfig = field(
+        default_factory=lambda: HunyuanVAEConfig(parallel_decode_mode="tiled")
+    )
     # Denoising stage
     embedded_cfg_scale: int = 6
     flow_shift: int = 7

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuan_config.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuan_config.py
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import (
+    FastHunyuanConfig,
+    HunyuanConfig,
+)
+
+
+def test_hunyuan_configs_default_to_parallel_tiled_vae_decode():
+    for config_cls in (HunyuanConfig, FastHunyuanConfig):
+        assert config_cls().vae_config.parallel_decode_mode == "tiled"
+
+
+def test_hunyuan_parallel_decode_mode_can_be_overridden():
+    for config_cls in (HunyuanConfig, FastHunyuanConfig):
+        config = config_cls()
+
+        config.update_config_from_dict(
+            {"vae_config.parallel_decode_mode": "spatial_shard"}
+        )
+
+        assert config.vae_config.parallel_decode_mode == "spatial_shard"


### PR DESCRIPTION
## Motivation

The shared Hunyuan VAE `auto` policy can select an unsafe spatial-shard decode
on ordinary HunyuanVideo and FastHunyuan multi-GPU shapes:

- HunyuanVideo at a supported 960x544x77 shape reaches 99.8 GiB allocated per
  rank, then OOMs while requesting another 49.61 GiB causal mask.
- FastHunyuan at its default 1280x720x125 shape would materialize a
  230,400 x 230,400 FP32 causal mask, or 197.75 GiB per rank.

At a slightly smaller 848x480x77 shape, `auto` rejects spatial sharding and
falls back to sequential tiled decode, leaving the other sequence-parallel
ranks idle during the VAE stage.

## Changes

- Default the shared `HunyuanConfig` VAE to parallel tiled decode, covering
  both HunyuanVideo and FastHunyuan.
- Preserve explicit `--vae-config.parallel-decode-mode` overrides.
- Add focused config tests and document the validated multi-GPU boundary.

## H200 performance

Native backend, 4x H200, Ulysses degree 4, 848x480x77, 30 steps, seed 42,
eager, no compile. Each row is a main/PR/PR/main ABBA mean:

| Quality | main denoise / e2e | PR denoise / e2e | E2E change |
| --- | ---: | ---: | ---: |
| lossless | 17.795 / 24.377 s | 17.581 / 19.908 s | **+18.33%** |
| high | 17.358 / 23.737 s | 17.778 / 20.438 s | **+13.90%** |

Lossless decode falls from a 5.713 s mean to 1.654 s. All four lossless
outputs share SHA256 `78474b64741a...`; all four high outputs share
`d4210008dde6...`.

The full-stage high trace shows the expected VAE reduction on rank 0:

| GPU work | main | PR |
| --- | ---: | ---: |
| total | 23.302 s | 19.852 s |
| cuDNN convolution | 2.323 s | 0.700 s |
| replication pad | 2.177 s | 0.334 s |
| nearest-3D upsample | 0.275 s | 0.085 s |

At the model-supported 960x544x77 shape, the PR completes at
25.088/27.639 s with 34.217 GiB peak reserved per rank; main OOMs in VAE
mid-block causal-mask construction before producing an artifact.

## FastHunyuan regression

Native backend, 4x H200, Ulysses degree 4, 1280x720x125, 6 steps, seed 42,
eager, no compile, and no VAE mode flag:

| Path | Quality | Denoise | E2E | Peak reserved / rank |
| --- | --- | ---: | ---: | ---: |
| main `auto` | lossless | 27.732 s | OOM in VAE decode | N/A |
| PR default | lossless | 27.718 s | 33.278 s | 38.30 GiB |
| PR default | high | 27.574 s | 33.156 s | 38.38 GiB |

The PR outputs are byte-identical to explicit tiled decode. Against the
one-H200 reference, all 125 frames pass the default video thresholds:

| Quality | Min / mean SSIM | Min / mean PSNR |
| --- | ---: | ---: |
| lossless | 0.93393 / 0.94760 | 35.17 / 36.33 dB |
| high | 0.93341 / 0.94664 | 35.12 / 36.22 dB |

## Validation

- `pytest -q .../test_hunyuan_config.py .../test_server_args.py -k hunyuan`:
  4 passed, 175 deselected
- pre-commit on all changed files: passed
- every ABBA/profile GPU-process boundary was empty
- each isolated HunyuanVideo cache removed 41.91 GB and 12 weight files to zero
- the FastHunyuan default regression removed 41,911,122,591 bytes and 12
  weight files to zero

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32595912679](https://github.com/sgl-project/sglang/actions/runs/32595912679)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32647700663](https://github.com/sgl-project/sglang/actions/runs/32647700663)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32595912523](https://github.com/sgl-project/sglang/actions/runs/32595912523)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
