### PR TITLE
Fix output_dtype typo in block-wise quantization docstrings

### DIFF
--- a/benchmark/kernels/quantization/tuning_block_wise_kernel.py
+++ b/benchmark/kernels/quantization/tuning_block_wise_kernel.py
@@ -70,7 +70,7 @@ def w8a8_block_matmul(
         As: The per-token-group quantization scale for `A`.
         Bs: The per-block quantization scale for `B`.
         block_size: The block size for per-block quantization. It should be 2-dim, e.g., [128, 128].
-        output_dytpe: The dtype of the returned tensor.
+        output_dtype: The dtype of the returned tensor.
 
     Returns:
         torch.Tensor: The result of matmul.

--- a/python/sglang/kernels/ops/quantization/fp8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/fp8_kernel.py
@@ -1443,7 +1443,7 @@ def w8a8_block_fp8_matmul_triton(
         As: The per-token-group quantization scale for `A`.
         Bs: The per-block quantization scale for `B`.
         block_size: The block size for per-block quantization. It should be 2-dim, e.g., [128, 128].
-        output_dytpe: The dtype of the returned tensor.
+        output_dtype: The dtype of the returned tensor.
 
     Returns:
         torch.Tensor: The result of matmul.

--- a/python/sglang/kernels/ops/quantization/int8_kernel.py
+++ b/python/sglang/kernels/ops/quantization/int8_kernel.py
@@ -356,7 +356,7 @@ def w8a8_block_int8_matmul(
         As: The per-token-group quantization scale for `A`.
         Bs: The per-block quantization scale for `B`.
         block_size: The block size for per-block quantization. It should be 2-dim, e.g., [128, 128].
-        output_dytpe: The dtype of the returned tensor.
+        output_dtype: The dtype of the returned tensor.
 
     Returns:
         torch.Tensor: The result of matmul.


### PR DESCRIPTION
Same docstring got copied into all three block-wise matmuls, typo and all. Grepped the tree after fixing, no other occurrences left.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32592935158](https://github.com/sgl-project/sglang/actions/runs/32592935158)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32592934964](https://github.com/sgl-project/sglang/actions/runs/32592934964)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32592935144](https://github.com/sgl-project/sglang/actions/runs/32592935144)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->