### PR TITLE
[Fix] Align GDN target-verify beta semantics with packed decode

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_sigmoid_gating_recurrent.py
@@ -216,7 +216,10 @@ def fused_sigmoid_gating_delta_rule_update_kernel(
             b_g = -tl.exp(b_A_log) * softplus_x
 
         # Compute beta = sigmoid(b)
-        b_beta = 1.0 / (1.0 + tl.exp(-b_b))
+        if IS_KDA or not DISABLE_STATE_UPDATE:
+            b_beta = 1.0 / (1.0 + tl.exp(-b_b))
+        else:
+            b_beta = tl.sigmoid(b_b).to(b.dtype.element_ty).to(tl.float32)
 
         # fused ring-write: stash this step's raw inputs + in-kernel gate/beta
         # into the per-slot ring for the commit fold to replay. Must sit here --

--- a/test/registered/kernels/ops/attention/test_fused_verify_triton_gdn.py
+++ b/test/registered/kernels/ops/attention/test_fused_verify_triton_gdn.py
@@ -16,6 +16,7 @@ from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 try:
     from sglang.kernels.ops.attention.fla.fused_gdn_gating import fused_gdn_gating
     from sglang.kernels.ops.attention.fla.fused_recurrent import (
+        fused_recurrent_gated_delta_rule_packed_decode,
         fused_recurrent_gated_delta_rule_update,
     )
     from sglang.kernels.ops.attention.fla.fused_sigmoid_gating_recurrent import (
@@ -133,6 +134,69 @@ def run_fused_mtp(
         intermediate_state_indices=intermediate_state_indices,
         cache_steps=cache_steps,
         retrieve_parent_token=retrieve_parent_token,
+    )
+
+
+@pytest.mark.skipif(not KERNELS_AVAILABLE, reason="Kernel not available")
+def test_target_verify_matches_packed_decode_beta_semantics():
+    """Target verify must preserve the existing packed-decode transition."""
+    H = HV = 1
+    K = V = 128
+    dtype = torch.bfloat16
+    device = "cuda"
+
+    q = torch.ones(1, 1, H, K, dtype=dtype, device=device)
+    k = torch.ones_like(q)
+    v = torch.ones(1, 1, HV, V, dtype=dtype, device=device)
+    mixed_qkv = torch.cat(
+        (q.reshape(1, -1), k.reshape(1, -1), v.reshape(1, -1)), dim=-1
+    ).contiguous()
+    a = torch.zeros(1, HV, dtype=dtype, device=device)
+    # sigmoid(-0.5) is not exactly representable in BF16, exposing whether the
+    # target path preserves packed decode's activation-dtype rounding.
+    b = torch.full((1, HV), -0.5, dtype=dtype, device=device)
+    A_log = torch.zeros(HV, dtype=torch.float32, device=device)
+    dt_bias = torch.zeros(HV, dtype=dtype, device=device)
+    indices = torch.zeros(1, dtype=torch.int32, device=device)
+    cu_seqlens = torch.tensor([0, 1], dtype=torch.int32, device=device)
+
+    packed_state = torch.zeros(1, HV, V, K, dtype=torch.float32, device=device)
+    packed_out = torch.empty(1, 1, HV, V, dtype=dtype, device=device)
+    fused_recurrent_gated_delta_rule_packed_decode(
+        mixed_qkv=mixed_qkv,
+        a=a,
+        b=b,
+        A_log=A_log,
+        dt_bias=dt_bias,
+        scale=K**-0.5,
+        initial_state=packed_state,
+        out=packed_out,
+        ssm_state_indices=indices,
+        use_qk_l2norm_in_kernel=True,
+    )
+
+    verify_state = torch.zeros_like(packed_state)
+    intermediate_state = torch.empty(1, 1, HV, V, K, dtype=torch.float32, device=device)
+    verify_out = run_fused_mtp(
+        A_log,
+        dt_bias,
+        q,
+        k,
+        v,
+        a,
+        b,
+        verify_state,
+        indices,
+        cu_seqlens,
+        disable_state_update=True,
+        intermediate_states_buffer=intermediate_state,
+        intermediate_state_indices=indices,
+        cache_steps=1,
+    )
+
+    torch.testing.assert_close(verify_out, packed_out, rtol=0, atol=0)
+    torch.testing.assert_close(
+        intermediate_state[0, 0], packed_state[0], rtol=0, atol=0
     )
 
 


### PR DESCRIPTION
## Motivation

The Triton GDN packed-decode and speculative target-verify paths currently use
different precision semantics for `beta = sigmoid(b)` when `b` is BF16:

```text
packed decode: sigmoid -> BF16 materialization -> FP32 recurrent update
target verify: sigmoid -> retained FP32 -> recurrent update
```

As a result, identical Q/K/V, gating inputs, and initial recurrent state can
produce different recurrent output and state. This is particularly relevant to
speculative verification because the recurrent state persists across decode
steps.

## Modification

- Align GDN target-verify beta with the existing packed-decode
  activation-dtype rounding semantics.
- Keep KDA and non-verify calls on their existing FP32 beta path.
- Add a focused, model-free packed-decode-vs-target-verify regression covering
  both recurrent output and FP32 state.

The normal packed-decode kernel is unchanged.

## Regression

The new test uses deterministic BF16 inputs with one sequence/head and
production `K=V=128` head dimensions. `b=-0.5` makes the BF16 beta
materialization observable without random inputs or a model checkpoint.

On current `main` before the fix, three runs fail consistently:

```text
output unequal: 128 / 128 elements
output max abs diff: 0.000244140625
```

After the fix, packed decode and T=1 target verify are bitwise equal for both
the BF16 output and updated/intermediate FP32 state.

As an additional development-only check, a real captured Qwen3.8 recurrent
transition changed from:

```text
state unequal: 770774 / 786432
output unequal: 321 / 6144
```

to zero differences for both tensors. The capture is not part of the test or
this commit.

## Validation

- `test_fused_verify_triton_gdn.py`: 13 passed
- `test_gdn_noncontiguous_stride.py`: 8 passed
- `test_kda_kernels.py`: 14 passed, 3 subtests passed
- Ruff, Black, isort, registered-test registry check, and `git diff --check`

Local kernel validation used an NVIDIA GeForce RTX 4090 with PyTorch
2.11.0+cu130 and Triton 3.6.0.

## Scope

This PR intentionally addresses only the isolated GDN beta precision mismatch.
It does not claim to resolve all Qwen3.8 or speculative-decode numerical
divergence, and it does not close #35150.

## Related

Related: #35150, #35541, #34734.

The related open PRs also identified the beta alignment. This PR keeps the
change intentionally minimal, narrows it to GDN target verify, and adds focused
packed-decode-vs-target-verify regression coverage on current main.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34223952622](https://github.com/sgl-project/sglang/actions/runs/34223952622)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34223952289](https://github.com/sgl-project/sglang/actions/runs/34223952289)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34223952653](https://github.com/sgl-project/sglang/actions/runs/34223952653)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->