### PR TITLE
Add engine streaming response handler

### DIFF
--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -23,6 +23,7 @@ import asyncio
 import atexit
 import dataclasses
 import gc
+import inspect
 import logging
 import multiprocessing as mp
 import os
@@ -91,7 +92,11 @@ from sglang.srt.managers.multi_tokenizer_mixin import (
     run_multi_detokenizer_router_process,
 )
 from sglang.srt.managers.scheduler import run_scheduler_process
-from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.srt.managers.tokenizer_manager import (  # noqa: F401
+    ResponseHandler,
+    ResponseHandlerOutput,
+    TokenizerManager,
+)
 from sglang.srt.observability.startup_time import build_engine_startup_time
 from sglang.srt.observability.trace import process_tracing_init, trace_set_thread_info
 from sglang.srt.parser.template_detection import resolve_auto_parsers
@@ -231,10 +236,14 @@ class Engine(EngineScoreMixin, EngineBase):
     # placement group. Not config — a live cluster object.
     _placement_group = None
 
-    def __init__(self, **kwargs):
+    def __init__(self, *, response_handler: Optional[ResponseHandler] = None, **kwargs):
         """
         The arguments of this function is the same as `sglang/srt/server_args.py::ServerArgs`.
         Please refer to `ServerArgs` for the documentation.
+
+        ``response_handler`` is an Engine-only extension point for synchronous,
+        non-blocking delivery of intermediate streaming output batches. When it
+        is set, streaming iterators receive terminal and error outputs only.
         """
 
         # Ensure plugins are loaded before ServerArgs construction,
@@ -253,6 +262,16 @@ class Engine(EngineScoreMixin, EngineBase):
             server_args = self.server_args_class(**kwargs)
         self.server_args = server_args
         logger.info(f"{server_args=}")
+
+        if response_handler is not None:
+            handle_batch = getattr(response_handler, "handle_batch", None)
+            if not callable(handle_batch):
+                raise TypeError("response_handler must define handle_batch()")
+            if inspect.iscoroutinefunction(handle_batch):
+                raise TypeError("response_handler.handle_batch() must be synchronous")
+            if server_args.tokenizer_worker_num != 1:
+                raise ValueError("response_handler requires tokenizer_worker_num=1")
+        self.response_handler = response_handler
 
         # Rust Server is not supported with the offline Engine API
         if envs.SGLANG_RUST_SERVER.get():
@@ -285,6 +304,8 @@ class Engine(EngineScoreMixin, EngineBase):
             placement_group=self._placement_group,
         )
         self.tokenizer_manager = tokenizer_manager
+        if tokenizer_manager is not None:
+            tokenizer_manager.response_handler = response_handler
         self.template_manager = template_manager
         self._scheduler_init_result = scheduler_init_result
         # Engine-spawned weight cache daemons owned by *this* instance (empty

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -34,7 +34,18 @@ from datetime import datetime
 from enum import Enum
 from functools import lru_cache
 from http import HTTPStatus
-from typing import Any, Awaitable, Dict, Iterable, List, Optional, Tuple, Union
+from typing import (
+    Any,
+    Awaitable,
+    Dict,
+    Iterable,
+    List,
+    Optional,
+    Protocol,
+    Sequence,
+    Tuple,
+    Union,
+)
 
 import fastapi
 import numpy as np
@@ -212,6 +223,24 @@ _INCREMENTAL_STREAMING_META_INFO_KEYS = (
     "output_token_sampling_mask",
     "output_token_sampling_logprobs",
 )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class ResponseHandlerOutput:
+    """One materialized intermediate streaming output."""
+
+    rid: str
+    output: Dict[str, Any]
+
+
+class ResponseHandler(Protocol):
+    """Synchronous handler for one detokenizer output batch.
+
+    ``handle_batch`` runs on the tokenizer-manager event loop. Implementations
+    must not block.
+    """
+
+    def handle_batch(self, outputs: Sequence[ResponseHandlerOutput]) -> None: ...
 
 
 @dataclasses.dataclass
@@ -422,6 +451,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.skip_tokenizer_init = get_serving().skip_tokenizer_init
         self.preferred_sampling_params = get_serving().preferred_sampling_params
         self.crash_dump_folder = get_observability().crash_dump_folder
+        self.response_handler: Optional[ResponseHandler] = None
 
         # Init model config
         self.init_model_config()
@@ -774,6 +804,13 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         # Normalize the request
         obj.normalize_batch_and_arguments()
+        if self.response_handler is not None and isinstance(obj, GenerateReqInput):
+            if obj.parallel_sample_num != 1:
+                raise ValueError("response_handler does not support parallel sampling")
+            if not obj.is_single:
+                raise ValueError(
+                    "response_handler does not support batched generation requests"
+                )
         self._set_default_priority(obj)
         if (
             isinstance(obj, GenerateReqInput)
@@ -2179,6 +2216,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
             customized_info = unwrap_from_pickle(recv_obj.customized_info)
         else:
             customized_info = None
+        response_handler = self.response_handler
+        response_handler_outputs: Optional[List[ResponseHandlerOutput]] = (
+            [] if response_handler is not None else None
+        )
         pending_notify: dict[str, ReqState] = {}
         batch_notify_size = get_serving().batch_notify_size
         for i, rid in enumerate(recv_obj.rids):
@@ -2449,7 +2490,29 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 if self.enable_lora and state.obj.lora_path:
                     asyncio.create_task(self.lora_registry.release(state.obj.lora_id))
 
-            if out_dict is not None:
+            is_intermediate_stream = (
+                response_handler_outputs is not None
+                and out_dict is not None
+                and not state.finished
+                and getattr(state.obj, "stream", False)
+            )
+            if is_intermediate_stream:
+                if "text" in out_dict and out_dict["text"] is None:
+                    out_dict = dict(out_dict)
+                    out_dict["text"] = state.get_text()
+                if out_dict.get("output_ids") is state.output_ids:
+                    out_dict = dict(out_dict)
+                    out_dict["output_ids"] = state.output_ids.copy()
+
+                if not state.time_stats.response_sent_to_client_time:
+                    state.time_stats.set_response_sent_to_client_time()
+                    out_dict["meta_info"][
+                        "response_sent_to_client_ts"
+                    ] = state.time_stats.get_response_sent_to_client_realtime()
+                response_handler_outputs.append(
+                    ResponseHandlerOutput(rid=rid, output=out_dict)
+                )
+            elif out_dict is not None:
                 state.out_list.append(out_dict)
                 pending_notify[rid] = state
 
@@ -2465,6 +2528,37 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 self.dump_requests(state, out_dict)
             if self.crash_dump_folder and state.finished and state.obj.log_metrics:
                 self.record_request_for_crash_dump(state, out_dict)
+
+        if response_handler_outputs:
+            assert response_handler is not None
+            try:
+                response_handler.handle_batch(tuple(response_handler_outputs))
+            except Exception as error:
+                logger.exception(
+                    "The response handler failed; aborting affected requests"
+                )
+                message = f"Response handler failed: {error}"
+                for output in response_handler_outputs:
+                    state = self.rid_to_state.get(output.rid)
+                    if state is None:
+                        continue
+                    self.abort_request(output.rid)
+                    self._handle_abort_req(
+                        AbortReq(
+                            rid=output.rid,
+                            finished_reason={
+                                "type": "abort",
+                                "status_code": HTTPStatus.INTERNAL_SERVER_ERROR,
+                                "message": message,
+                            },
+                            abort_message=message,
+                        )
+                    )
+                    # The handler may have delivered part of the batch before
+                    # it raised. The terminal error must not replay that text
+                    # or those token IDs.
+                    state.out_list[-1]["text"] = ""
+                    state.out_list[-1]["output_ids"] = []
 
         # handle_loop awaits next recv immediately
         for s in pending_notify.values():

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -14,6 +14,7 @@ Covers:
 
 import asyncio
 import unittest
+from http import HTTPStatus
 from unittest.mock import AsyncMock, MagicMock, Mock
 
 import msgspec
@@ -136,6 +137,7 @@ def _make_tokenizer_manager(case) -> TokenizerManager:
     tm.skip_tokenizer_init = False
     tm.dump_requests_folder = ""
     tm.crash_dump_folder = ""
+    tm.response_handler = None
     tm.send_to_scheduler = MagicMock()
     return tm
 
@@ -167,8 +169,14 @@ def _make_abort_req(rid: str, abort_message: str = "Aborted") -> AbortReq:
     )
 
 
-def _make_batch_str_output(rid: str, finished_reason=None) -> BatchStrOutput:
-    """Create a minimal BatchStrOutput for a single request.
+def _make_batch_str_outputs(
+    rids: list[str],
+    finished_reasons: list,
+    *,
+    output_strs: list[str] | None = None,
+    output_ids: list[list[int]] | None = None,
+) -> BatchStrOutput:
+    """Create a minimal BatchStrOutput for one or more requests.
 
     Uses struct field introspection so that new or renamed fields in
     BatchStrOutput don't break this test.  Only the fields that matter for
@@ -176,29 +184,24 @@ def _make_batch_str_output(rid: str, finished_reason=None) -> BatchStrOutput:
     all others receive type-appropriate defaults based on naming patterns.
     Fields with class-level defaults are left alone automatically.
     """
-    if finished_reason is _NOT_FINISHED:
-        fr = None
-    elif finished_reason is None:
-        fr = {"type": "length"}
-    else:
-        fr = finished_reason
-
     kwargs = {}
     for f in msgspec.structs.fields(BatchStrOutput):
         if f.name == "rids":
-            kwargs[f.name] = [rid]
+            kwargs[f.name] = rids
         elif f.name == "finished_reasons":
-            kwargs[f.name] = [fr]
+            kwargs[f.name] = finished_reasons
         elif f.name == "output_strs":
-            kwargs[f.name] = ["hello"]
+            kwargs[f.name] = output_strs or ["hello"] * len(rids)
+        elif f.name == "output_ids":
+            kwargs[f.name] = output_ids or [[] for _ in rids]
         elif f.name in _PER_REQUEST_INT_FIELDS:
-            kwargs[f.name] = [0]
+            kwargs[f.name] = [0] * len(rids)
         elif f.name in _PER_REQUEST_FLOAT_FIELDS:
-            kwargs[f.name] = [0.0]
+            kwargs[f.name] = [0.0] * len(rids)
         elif f.name in _PER_REQUEST_NESTED_LIST_FIELDS:
-            kwargs[f.name] = [[]]
+            kwargs[f.name] = [[] for _ in rids]
         elif f.name in _PER_REQUEST_OPTIONAL_FIELDS:
-            kwargs[f.name] = [None]
+            kwargs[f.name] = [None] * len(rids)
         # Fields with class defaults — skip, let the default be used
         elif (
             f.default is not msgspec.NODEFAULT
@@ -210,9 +213,20 @@ def _make_batch_str_output(rid: str, finished_reason=None) -> BatchStrOutput:
         # List[List[...]] and is unlikely to crash on [i] indexing for
         # List[int] either (the inner [] just means "no data").
         else:
-            kwargs[f.name] = [[]]
+            kwargs[f.name] = [[] for _ in rids]
 
     return BatchStrOutput(**kwargs)
+
+
+def _make_batch_str_output(rid: str, finished_reason=None) -> BatchStrOutput:
+    """Create a minimal BatchStrOutput for a single request."""
+    if finished_reason is _NOT_FINISHED:
+        fr = None
+    elif finished_reason is None:
+        fr = {"type": "length"}
+    else:
+        fr = finished_reason
+    return _make_batch_str_outputs([rid], [fr])
 
 
 class TestRidToStateCleanupOnAbort(CustomTestCase):
@@ -317,6 +331,111 @@ class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
         asyncio.run(tm._handle_batch_output(batch_output))
 
         self.assertIn(rid, tm.rid_to_state)
+
+
+class TestResponseHandler(CustomTestCase):
+    def test_receives_one_materialized_intermediate_batch(self):
+        tm = _make_tokenizer_manager(self)
+        calls = []
+
+        class Handler:
+            def handle_batch(self, outputs):
+                calls.append(outputs)
+
+        tm.response_handler = Handler()
+        rids = ["stream_a", "stream_b", "final"]
+        states = {rid: _make_req_state(rid) for rid in rids}
+        for state in states.values():
+            state.obj.stream = True
+        tm.rid_to_state.update(states)
+
+        asyncio.run(
+            tm._handle_batch_output(
+                _make_batch_str_outputs(
+                    rids,
+                    [None, None, {"type": "length"}],
+                    output_strs=["a", "b", "done"],
+                    output_ids=[[1], [2], [3]],
+                )
+            )
+        )
+
+        self.assertEqual(len(calls), 1)
+        self.assertEqual([item.rid for item in calls[0]], rids[:2])
+        self.assertEqual([item.output["text"] for item in calls[0]], ["a", "b"])
+        self.assertEqual([item.output["output_ids"] for item in calls[0]], [[1], [2]])
+        self.assertTrue(
+            all(
+                "response_sent_to_client_ts" in item.output["meta_info"]
+                for item in calls[0]
+            )
+        )
+
+        states["stream_a"].output_ids.append(9)
+        self.assertEqual(calls[0][0].output["output_ids"], [1])
+        self.assertFalse(states["stream_a"].event.is_set())
+        self.assertFalse(states["stream_b"].event.is_set())
+        self.assertTrue(states["final"].event.is_set())
+        self.assertEqual(len(states["final"].out_list), 1)
+        self.assertNotIn("final", tm.rid_to_state)
+
+    def test_exception_aborts_without_replaying_intermediate_output(self):
+        tm = _make_tokenizer_manager(self)
+
+        class Handler:
+            def handle_batch(self, outputs):
+                raise RuntimeError("delivery failed")
+
+        tm.response_handler = Handler()
+        tm.abort_request = Mock()
+        rids = ["failed_a", "failed_b"]
+        states = {rid: _make_req_state(rid) for rid in rids}
+        for state in states.values():
+            state.obj.stream = True
+        tm.rid_to_state.update(states)
+
+        with self.assertLogs(level="ERROR"):
+            asyncio.run(
+                tm._handle_batch_output(
+                    _make_batch_str_outputs(
+                        rids,
+                        [None, None],
+                        output_ids=[[1], [2]],
+                    )
+                )
+            )
+
+        self.assertEqual(
+            {call.args[0] for call in tm.abort_request.call_args_list}, set(rids)
+        )
+        for rid, state in states.items():
+            self.assertNotIn(rid, tm.rid_to_state)
+            self.assertTrue(state.finished)
+            self.assertTrue(state.event.is_set())
+            self.assertEqual(len(state.out_list), 1)
+            self.assertEqual(state.out_list[0]["text"], "")
+            self.assertEqual(state.out_list[0]["output_ids"], [])
+            finish_reason = state.out_list[0]["meta_info"]["finish_reason"]
+            self.assertEqual(finish_reason["type"], "abort")
+            self.assertEqual(
+                finish_reason["status_code"], HTTPStatus.INTERNAL_SERVER_ERROR
+            )
+
+    def test_no_handler_keeps_existing_notification_path(self):
+        tm = _make_tokenizer_manager(self)
+        rid = "normal_stream"
+        state = _make_req_state(rid)
+        state.obj.stream = True
+        tm.rid_to_state[rid] = state
+
+        asyncio.run(
+            tm._handle_batch_output(
+                _make_batch_str_outputs([rid], [None], output_ids=[[1]])
+            )
+        )
+
+        self.assertTrue(state.event.is_set())
+        self.assertEqual(len(state.out_list), 1)
 
 
 class TestInitReqStateDuplicateDetection(CustomTestCase):
@@ -452,6 +571,40 @@ def _make_generate_obj(rid, is_single):
     if not is_single:
         obj.__getitem__.side_effect = lambda i: Mock()
     return obj
+
+
+class TestResponseHandlerRequestValidation(CustomTestCase):
+    def _assert_rejected(self, obj, message):
+        tm = _make_tm_for_generate(self)
+        tm.response_handler = Mock()
+
+        async def consume_first():
+            await tm.generate_request(obj).__anext__()
+
+        with self.assertRaisesRegex(ValueError, message):
+            asyncio.run(consume_first())
+
+    def test_batched_prompt_is_rejected(self):
+        self._assert_rejected(
+            GenerateReqInput(
+                input_ids=[[1], [2]],
+                sampling_params=[{}, {}],
+                stream=True,
+                rid=["batch_a", "batch_b"],
+            ),
+            "batched generation requests",
+        )
+
+    def test_parallel_sampling_is_rejected(self):
+        self._assert_rejected(
+            GenerateReqInput(
+                input_ids=[1],
+                sampling_params={"n": 2},
+                stream=True,
+                rid="parallel",
+            ),
+            "parallel sampling",
+        )
 
 
 class TestDiscardPendingReqStates(CustomTestCase):


### PR DESCRIPTION
## Summary

- Add an optional, Engine-only `response_handler` constructor argument.
- Deliver all intermediate streaming outputs from one detokenizer message in one synchronous `handle_batch()` call.
- Keep terminal output, errors, logging, metrics, cancellation, LoRA cleanup, and request-state removal on the existing iterator path.
- Materialize deferred text and copy growing token ID lists before handler delivery.
- Abort affected requests without replay if the handler raises.
- Reject handler use with multiple tokenizer processes, batched prompts, and parallel sampling in this first version.

The handler runs on the tokenizer-manager event loop and must be synchronous and non-blocking. It is installed per `Engine`; there is no CLI or `ServerArgs` field.

## Validation

- `test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py`: 23 passed.
- SGLang isort, Ruff, and Black passed for all changed files.
- `py_compile` passed for all changed Python files.
- `git diff --check` passed.

Prior prototype evidence from the matched Dynamo E2E test was 45,157 output tok/s versus 15,450 output tok/s for the control. This PR replaces that prototype callback with the Engine-wide interface. No new Tyche benchmark was run for this revision.