### PR TITLE
[Diffusion] Fix extension loader facade import

### DIFF
--- a/python/sglang/kernels/ops/diffusion/__init__.py
+++ b/python/sglang/kernels/ops/diffusion/__init__.py
@@ -345,6 +345,7 @@ for _op, _backend, _target, _caps, _description in _SPECS:
 # then symbol; a new public kernel belongs here and nowhere else.
 # ---------------------------------------------------------------------------
 _EXPORTS: dict[str, str] = {
+    "load_extension_with_recovery": "ext.loader",
     # Normalization: RMSNorm / LayerNorm / GroupNorm and their fused epilogues
     "FLYDSL_NORM_MIN_ALIGNED_DIM": "norm.fused_residual_norm_flydsl",
     "flydsl_fused_residual_norm_scale_shift": "norm.fused_residual_norm_flydsl",

--- a/python/sglang/multimodal_gen/test/unit/test_cpp_extension_loader.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cpp_extension_loader.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from unittest.mock import patch
 
-from sglang.kernels.ops.diffusion.ext.loader import load_extension_with_recovery
+from sglang.kernels.ops.diffusion import load_extension_with_recovery
 
 
 def test_stale_torch_lock_is_removed_before_loading(tmp_path: Path):


### PR DESCRIPTION
## Summary

Fix the diffusion facade import regression introduced in #35989

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32604385168](https://github.com/sgl-project/sglang/actions/runs/32604385168)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32604385080](https://github.com/sgl-project/sglang/actions/runs/32604385080)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32604385134](https://github.com/sgl-project/sglang/actions/runs/32604385134)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->