### PR TITLE
[diffusion] Honor XDG cache for model overlays

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/model_overlay.py
+++ b/python/sglang/multimodal_gen/runtime/utils/model_overlay.py
@@ -17,6 +17,7 @@ from huggingface_hub.errors import (
 from requests.exceptions import ConnectionError as RequestsConnectionError
 from requests.exceptions import RequestException
 
+from sglang.multimodal_gen import envs
 from sglang.multimodal_gen.runtime.loader.weight_utils import get_lock
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.utils import load_diffusion_overlay_registry_from_env
@@ -106,9 +107,7 @@ def _resolve_bundled_overlay_dir(overlay_spec: dict[str, Any]) -> str | None:
 
 
 def get_diffusion_cache_root() -> str:
-    return os.path.expanduser(
-        os.getenv("SGLANG_DIFFUSION_CACHE_ROOT", "~/.cache/sgl_diffusion")
-    )
+    return envs.SGLANG_DIFFUSION_CACHE_ROOT
 
 
 def clear_model_overlay_registry_cache() -> None:

--- a/python/sglang/multimodal_gen/test/unit/test_model_overlay.py
+++ b/python/sglang/multimodal_gen/test/unit/test_model_overlay.py
@@ -1,0 +1,19 @@
+"""Unit tests for diffusion model-overlay cache paths."""
+
+from sglang.multimodal_gen.runtime.utils.model_overlay import (
+    get_diffusion_cache_root,
+)
+
+
+def test_uses_xdg_cache_home_by_default(monkeypatch):
+    monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/sglang-xdg-cache")
+    monkeypatch.delenv("SGLANG_DIFFUSION_CACHE_ROOT", raising=False)
+
+    assert get_diffusion_cache_root() == "/tmp/sglang-xdg-cache/sgl_diffusion"
+
+
+def test_explicit_diffusion_cache_root_takes_precedence(monkeypatch):
+    monkeypatch.setenv("SGLANG_DIFFUSION_CACHE_ROOT", "/tmp/sglang-diffusion-cache")
+    monkeypatch.setenv("XDG_CACHE_HOME", "/tmp/sglang-xdg-cache")
+
+    assert get_diffusion_cache_root() == "/tmp/sglang-diffusion-cache"


### PR DESCRIPTION
## Summary

- resolve model-overlay materialization through the canonical diffusion cache setting
- honor `XDG_CACHE_HOME` when `SGLANG_DIFFUSION_CACHE_ROOT` is not set
- keep the explicit diffusion cache root as the highest-priority override

This prevents overlay checkpoints such as LTX-2.3 and JoyEcho from materializing weights outside task-owned isolated caches. In the H200 sweep, LTX-2.3 left about 146 GB and 31 weight files under `/root/.cache/sgl_diffusion` even though `XDG_CACHE_HOME` pointed at the task cache. The leaked overlay was removed and verified at zero after the run.

## Validation

- `PYTHONPATH=python python3 test/registered/unit/multimodal_gen/test_model_overlay.py` (2 passed)
- pre-commit on both changed files

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32644479281](https://github.com/sgl-project/sglang/actions/runs/32644479281)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32651539424](https://github.com/sgl-project/sglang/actions/runs/32651539424)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32644479267](https://github.com/sgl-project/sglang/actions/runs/32644479267)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->