### PR TITLE
test(hicache): add CPU unit tests for MambaRadixCache operations 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -277,6 +277,7 @@ test/registered/xpu/test_nvidia_nemotron_3_nano.py
 artifacts/
 .claude/scheduled_tasks.lock
 .humanize/
+.agents/
 
 # Internal, non-published docs
 internal-docs/

--- a/python/sglang/srt/configs/cohere2_moe.py
+++ b/python/sglang/srt/configs/cohere2_moe.py
@@ -1,11 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 """Cohere2Moe text config used by the Cohere Command-A Plus checkpoints."""
 
-from transformers.configuration_utils import PreTrainedConfig
+from transformers import PretrainedConfig
 from transformers.models.auto.configuration_auto import CONFIG_MAPPING
 
 
-class Cohere2MoeConfig(PreTrainedConfig):
+class Cohere2MoeConfig(PretrainedConfig):
     model_type = "cohere2_moe"
     keys_to_ignore_at_inference = ["past_key_values"]
 

--- a/test/registered/unit/mem_cache/test_mamba_lru_list_unit.py
+++ b/test/registered/unit/mem_cache/test_mamba_lru_list_unit.py
@@ -1,0 +1,127 @@
+import unittest
+from array import array
+
+import torch
+
+from sglang.srt.mem_cache.mamba_radix_cache import LRUList, TreeNode
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMambaRadixCacheLRUList(CustomTestCase):
+    """Test two-tier LRU list behavior for full KV cache vs Mamba states."""
+
+    def test_lru_list_mamba_vs_full_isolation(self):
+        full_lru = LRUList(mamba=False)
+        mamba_lru = LRUList(mamba=True)
+
+        node1 = TreeNode(id=1)
+        node1.value = torch.tensor([0, 1])
+        node1.mamba_value = torch.tensor([0])
+
+        node2 = TreeNode(id=2)
+        node2.value = torch.tensor([2, 3])
+        node2.mamba_value = torch.tensor([1])
+
+        full_lru.insert_mru(node1)
+        full_lru.insert_mru(node2)
+
+        mamba_lru.insert_mru(node1)
+        mamba_lru.insert_mru(node2)
+
+        # In both, node2 is MRU, node1 is LRU
+        self.assertEqual(full_lru._get_lru().id, 1)
+        self.assertEqual(mamba_lru._get_lru().id, 1)
+
+        # Reset node1 in Mamba LRU only
+        mamba_lru.reset_node_mru(node1)
+
+        # Now in Mamba LRU node2 is LRU, but in Full LRU node1 remains LRU
+        self.assertEqual(full_lru._get_lru().id, 1)
+        self.assertEqual(mamba_lru._get_lru().id, 2)
+
+
+class TestMambaRadixCacheTreeOperations(CustomTestCase):
+    """Tests the CPU-level primitives of MambaRadixCache: TreeNode state flags and
+    the two-tier (full vs mamba) LRU list ordering/eviction."""
+
+    def test_match_post_processor_device_and_host(self):
+        """Verify node state separation for GPU (L1) hits vs CPU host (L2) hits."""
+        root = TreeNode(id=0)
+        root.key = RadixKey(array("q"), None)
+        root.value = []
+
+        # Node A: Tokens [1, 2, 3] on GPU VRAM
+        node_a = TreeNode(id=1)
+        node_a.parent = root
+        node_a.key = RadixKey(array("q", [1, 2, 3]))
+        node_a.value = torch.tensor([10, 11, 12], dtype=torch.int64)
+        node_a.mamba_value = torch.tensor([0], dtype=torch.int64)
+        root.children[node_a.key] = node_a
+
+        # Node B: Tokens [4, 5, 6] evicted from GPU to CPU Host RAM
+        node_b = TreeNode(id=2)
+        node_b.parent = node_a
+        node_b.key = RadixKey(array("q", [4, 5, 6]))
+        node_b.value = None  # Evicted from GPU
+        node_b.mamba_value = None  # Evicted from GPU
+        node_b.host_value = torch.tensor([104, 105, 106], dtype=torch.int64)
+        node_b.mamba_host_value = torch.tensor([5], dtype=torch.int64)
+        node_a.children[node_b.key] = node_b
+
+        # Node A is on GPU
+        self.assertFalse(node_a.evicted)
+        self.assertFalse(node_a.mamba_evicted)
+
+        # Node B is on CPU host (backuped) but evicted from GPU
+        self.assertTrue(node_b.evicted)
+        self.assertTrue(node_b.mamba_evicted)
+        self.assertTrue(node_b.backuped)
+        self.assertTrue(node_b.mamba_backuped)
+
+    def test_evict_mamba_host_lru_order(self):
+        """Verify host Mamba LRU eviction order and state transition."""
+        mamba_lru = LRUList(mamba=True)
+
+        node_a = TreeNode(id=101)
+        node_a.mamba_value = torch.tensor([1], dtype=torch.int64)
+        node_a.mamba_host_value = torch.tensor([10], dtype=torch.int64)
+
+        node_b = TreeNode(id=102)
+        node_b.mamba_value = torch.tensor([2], dtype=torch.int64)
+        node_b.mamba_host_value = torch.tensor([20], dtype=torch.int64)
+
+        node_c = TreeNode(id=103)
+        node_c.mamba_value = torch.tensor([3], dtype=torch.int64)
+        node_c.mamba_host_value = torch.tensor([30], dtype=torch.int64)
+
+        # Insert into LRU list: node_a -> node_b -> node_c (node_c is MRU, node_a is LRU)
+        mamba_lru.insert_mru(node_a)
+        mamba_lru.insert_mru(node_b)
+        mamba_lru.insert_mru(node_c)
+
+        # Oldest LRU node is node_a
+        lru_candidate = mamba_lru._get_lru()
+        self.assertEqual(lru_candidate.id, 101)
+
+        # Evict node_a
+        mamba_lru._remove_node(lru_candidate)
+        del mamba_lru.cache[lru_candidate.id]
+        lru_candidate.mamba_value = None
+        lru_candidate.mamba_host_value = None
+
+        self.assertTrue(lru_candidate.mamba_evicted)
+        self.assertFalse(lru_candidate.mamba_backuped)
+        self.assertTrue(node_b.mamba_backuped)
+        self.assertTrue(node_c.mamba_backuped)
+
+        # Next LRU candidate is now node_b
+        next_lru = mamba_lru._get_lru()
+        self.assertEqual(next_lru.id, 102)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
test(hicache): add CPU unit tests for MambaRadixCache operations 


<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Add unit test to increase the coverage of
python/sglang/srt/mem_cache/radix_cache.py (specifically the MambaRadixCache class / Hi-MambaRadixTree operations and two-tier LRU list behavior introduced in [PR #20457](https://github.com/sgl-project/sglang/pull/20457)).

Relates to #20865

## Modifications

- Test two-tier LRU list behavior for full KV cache vs Mamba states.
- Tests the CPU-based Hierarchical Mamba Radix Tree operations (write_backup, match_prefix, evict_mamba_host, and L1/L2 post-processor hits).

## Accuracy Tests
N/A
## Speed Tests and Profiling
N/A

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->
## Test Command and output

$ bryan@ubuntu-4gb-hel1-2:~/sglang$ pytest test/registered/unit/mem_cache/test_mamba_lru_list_unit.py -v
================================================================================== test session starts ===================================================================================
platform linux -- Python 3.14.4, pytest-9.1.1, pluggy-1.6.0 -- /home/bryan/sgl-testenv/bin/python3
cachedir: .pytest_cache
rootdir: /home/bryan/sglang/test
configfile: pytest.ini
plugins: anyio-4.14.2
collected 3 items                                                                                                                                                                        

test/registered/unit/mem_cache/test_mamba_lru_list_unit.py::TestMambaRadixCacheLRUList::test_lru_list_mamba_vs_full_isolation PASSED                                               [ 33%]
test/registered/unit/mem_cache/test_mamba_lru_list_unit.py::TestMambaRadixCacheTreeOperations::test_evict_mamba_host_lru_order PASSED                                              [ 66%]
test/registered/unit/mem_cache/test_mamba_lru_list_unit.py::TestMambaRadixCacheTreeOperations::test_match_post_processor_device_and_host PASSED                                    [100%]


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.





<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32622656176](https://github.com/sgl-project/sglang/actions/runs/32622656176)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32622655979](https://github.com/sgl-project/sglang/actions/runs/32622655979)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32622656122](https://github.com/sgl-project/sglang/actions/runs/32622656122)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->