### PR TITLE
[AMD][MORI] Deduplicate CP-replicated state transfers

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -288,6 +288,20 @@ class CommonKVManager(BaseKVManager):
                 f"Unsupported DisaggregationMode: {self.disaggregation_mode}"
             )
 
+    def _should_skip_cp_replicated_state_transfer(self) -> bool:
+        """Whether this prefill rank should omit CP-replicated state.
+
+        Prefill CP materializes global token order before writing state pools, so
+        every CP rank holds the same state. When all CP ranks transfer their KV
+        shards, only rank 0 needs to send that state. Cache layer split is the
+        exception because each CP rank owns different state layers.
+        """
+        return (
+            self.attn_cp_size > 1
+            and self.attn_cp_rank != 0
+            and not get_parallel().enable_dsa_cache_layer_split
+        )
+
     def requires_dcp_relayout(self, dst_dcp_size: int, dst_dcp_rank: int) -> bool:
         if self.dcp_size == dst_dcp_size:
             if self.dcp_rank != dst_dcp_rank:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1195,11 +1195,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         # structure about the state rows, so we don't split them across CP ranks
         # -- just let rank 0 send the whole thing (unless layer split already
         # shards it per rank).
-        if (
-            self.attn_cp_size > 1
-            and self.attn_cp_rank != 0
-            and not get_parallel().enable_dsa_cache_layer_split
-        ):
+        if self._should_skip_cp_replicated_state_transfer():
             skip_state = True
 
         if not self.is_hybrid_mla_backend:

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -62,7 +62,7 @@ from sglang.srt.observability.trace import (
     TraceReqContext,
     trace_set_thread_info,
 )
-from sglang.srt.runtime_context import get_memory, get_parallel, get_schedule
+from sglang.srt.runtime_context import get_memory, get_schedule
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils.network import NetworkAddress
 

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1425,12 +1425,17 @@ class MoriKVSender(CommonKVSender):
         if should_skip:
             return
 
+        transfer_state_indices = (
+            None
+            if self.kv_mgr._should_skip_cp_replicated_state_transfer()
+            else state_indices
+        )
         normalized_state = (
-            _normalize_state_indices_per_component(state_indices)
+            _normalize_state_indices_per_component(transfer_state_indices)
             if is_last_chunk
             else None
         )
-        self._record_transfer_indices(kv_indices, state_indices)
+        self._record_transfer_indices(kv_indices, transfer_state_indices)
         wait_event = getattr(self, "_early_send_wait_event", None)
         self._early_send_wait_event = None
         self.kv_mgr.enqueue_transfer(

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -8,6 +8,7 @@ import numpy as np
 import torch
 
 from sglang.srt.disaggregation.base.conn import KVArgs, StateType
+from sglang.srt.disaggregation.common.conn import CommonKVManager
 from sglang.srt.disaggregation.common.staging_handler import (
     handle_staging_req,
 )
@@ -136,6 +137,53 @@ class TestDisaggregationWire(unittest.TestCase):
     def test_list_of_buffers_roundtrip(self):
         bufs = [b"abc", b"", b"de", b"x" * 17]
         self.assertEqual(unpack_list_of_buffers(pack_list_of_buffers(bufs)), bufs)
+
+
+class TestCPReplicatedStateTransfer(unittest.TestCase):
+    def test_only_nonzero_cp_ranks_without_layer_split_skip_state(self):
+        cases = [
+            (1, 0, False, False),
+            (8, 0, False, False),
+            (8, 1, False, True),
+            (8, 7, False, True),
+            (8, 1, True, False),
+        ]
+
+        for cp_size, cp_rank, layer_split, expected in cases:
+            with self.subTest(
+                cp_size=cp_size,
+                cp_rank=cp_rank,
+                layer_split=layer_split,
+            ):
+                manager = object.__new__(CommonKVManager)
+                manager.attn_cp_size = cp_size
+                manager.attn_cp_rank = cp_rank
+                parallel = SimpleNamespace(
+                    enable_dsa_cache_layer_split=layer_split,
+                )
+                with patch(
+                    "sglang.srt.disaggregation.common.conn.get_parallel",
+                    return_value=parallel,
+                ):
+                    self.assertEqual(
+                        manager._should_skip_cp_replicated_state_transfer(),
+                        expected,
+                    )
+
+    def test_mooncake_uses_common_cp_state_policy(self):
+        manager = object.__new__(MooncakeKVManager)
+        manager.attn_cp_size = 8
+        manager.attn_cp_rank = 3
+        manager.is_hybrid_mla_backend = False
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.get_parallel",
+            return_value=SimpleNamespace(enable_dsa_cache_layer_split=False),
+        ):
+            self.assertEqual(
+                manager._get_dsa_cache_transfer_skip_flags(None),
+                (False, True),
+            )
 
 
 class TestGroupConcurrentContiguous(unittest.TestCase):


### PR DESCRIPTION
## Motivation

With Prefill CP and `SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER=1`, MORI shards KV pages across CP ranks but passes `state_indices` through unchanged. Every CP rank therefore sends the full replicated state, multiplying state traffic by `cp_size`.

This is the MORI counterpart to #32620.

## Modifications

- Move the CP-replicated state policy into `CommonKVManager` and reuse it from Mooncake.
- In MORI, omit state on nonzero prefill CP ranks before enqueueing and accounting the transfer. KV shards, auxiliary data, and completion notifications are unchanged.
- Preserve cache layer-split behavior, where each rank must send its owned state layers.
- Add unit coverage for CP rank 0, nonzero CP ranks, single-rank CP, and layer split.

## Accuracy Tests

No model forward or kernel changes.

On MI355X with DeepSeek-V4-Pro, Prefill CP8 / Decode TP8:
- 16/16 long-prompt requests succeeded with identical generated outputs.
- Deterministic first-token probes at 129, 257, 4,097, and 65,537 tokens matched top-1 in 4/4 cases; mean absolute top-1 logprob delta was `3.4e-5`.
- Focused unit tests: 2 passed, 5 parameterized subtests passed.

## Speed Tests and Profiling

Setup: MI355X, DeepSeek-V4-Pro, Prefill CP8 / Decode TP8, MORI, 16 × 65,536-token prompts, OSL=1, concurrency=4.

- SGLang-reported aggregate `kv_transfer_total_mb` across 8 prefill ranks: `2,470,901.8 → 371,486.9 MiB` (`-84.97%`).
- TTFT p50: `6,557.8 → 6,575.9 ms` (`+0.28%`).
- TTFT p95: `9,353.7 → 9,370.7 ms` (`+0.18%`).
- Input throughput: `29,154.5 → 29,117.2 tok/s` (`-0.13%`).

The redundant traffic is removed, but this workload showed no measurable latency or throughput improvement.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32631065313](https://github.com/sgl-project/sglang/actions/runs/32631065313)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32631065291](https://github.com/sgl-project/sglang/actions/runs/32631065291)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32631065362](https://github.com/sgl-project/sglang/actions/runs/32631065362)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

