### PR TITLE
refactor(disagg): move _is_watermark_ready into StagingManagerMixin

### DIFF
--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -833,6 +833,11 @@ class StagingManagerMixin:
     optionally ``kv_buffer_tensors``.
     """
 
+    def _is_watermark_ready(
+        self, session_id: str, alloc_round: int, alloc_end: int
+    ) -> bool:
+        return is_watermark_ready(self._staging_ctx, session_id, alloc_round, alloc_end)
+
     def _handle_staging_req(self, msg):
         room = int(msg[1].decode("ascii"))
         session_id = msg[4].decode("ascii")

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -364,15 +364,6 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         )
         self.kv_buffer_tensors = None
 
-    def _is_watermark_ready(
-        self, session_id: str, alloc_round: int, alloc_end: int
-    ) -> bool:
-        from sglang.srt.disaggregation.common.staging_handler import (
-            is_watermark_ready,
-        )
-
-        return is_watermark_ready(self._staging_ctx, session_id, alloc_round, alloc_end)
-
     def _try_create_staging_strategy(self, staging_buffer):
         if not self.enable_staging or self.kv_buffer_tensors is None:
             return None

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -589,15 +589,6 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         self._staging_ctx.room_bootstrap[room] = bootstrap_infos
         self._staging_ctx.room_receivers[room] = receiver
 
-    def _is_watermark_ready(
-        self, agent_name: str, alloc_round: int, alloc_end: int
-    ) -> bool:
-        from sglang.srt.disaggregation.common.staging_handler import (
-            is_watermark_ready,
-        )
-
-        return is_watermark_ready(self._staging_ctx, agent_name, alloc_round, alloc_end)
-
     def _start_decode_listener_thread(self):
         """Decode-side ZMQ listener for STAGING_REQ and ABORT_ACK. A thread, not
         NIXL notifs: the decode agent has no progress thread, so notifs only drain


### PR DESCRIPTION
## Motivation

Mooncake and NIXL carried the same 8-line wrapper, differing only in the parameter *name*:

```python
# mooncake/conn.py                                  # nixl/conn.py
def _is_watermark_ready(                            def _is_watermark_ready(
    self, session_id: str, ...                          self, agent_name: str, ...
) -> bool:                                          ) -> bool:
    from ...staging_handler import (                    from ...staging_handler import (
        is_watermark_ready,                                 is_watermark_ready,
    )                                                   )

    return is_watermark_ready(                          return is_watermark_ready(
        self._staging_ctx, session_id, ...)                 self._staging_ctx, agent_name, ...)
```

`session_id` and `agent_name` are the same value — a peer identity used as the watermark key. Each copy also did a **per-call local import** of the helper it delegates to, on a path invoked once per staging chunk.

## Modifications

3 files, +5 / -18.

Moves the wrapper to `StagingManagerMixin`, which both managers already inherit (added in #35948) and which lives in the *same module* as `is_watermark_ready` — so the local import disappears entirely rather than merely being hoisted. Settles on `session_id`, matching the shared helper's signature.

This is the second wrapper to move into that mixin, after `_handle_staging_req`.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched.

## Speed Tests and Profiling

Not applicable. Same computation; removes a `sys.modules` lookup per staging chunk.

## Verification performed

- **Bodies proven identical**: both old copies and the new mixin method extracted via AST and compared with the parameter name normalized and the dropped import elided — `old mooncake == old nixl` and `new mixin == old` both True. This is a move, not a rewrite.
- **The parameter rename is safe**: the sole call site is `self.kv_manager._is_watermark_ready(session_id, c_round, c_end)` in `PrefillStagingStrategy` — positional, no keyword arguments.
- `is_watermark_ready` now has **0** references in both backend files, so no import is left orphaned (pinned `ruff --select=F401` confirms).
- Both `MooncakeKVManager` and `NixlKVManager` already declare `StagingManagerMixin` as their first base, so resolution is unchanged; `AscendKVManager` inherits through Mooncake. `MoriKVManager` has no staging and does not inherit the mixin, so it is unaffected.
- Pinned `ruff 0.15.1 --select=F401,F821,UP037`, `black 26.1.0`, `isort 7.0.0` all pass.

Staging was **not** exercised locally — it needs a live PD pair with heterogeneous prefill/decode TP and `SGLANG_DISAGG_STAGING_BUFFER=1`, i.e. multi-GPU hardware.

Part of a series of disaggregation cleanups. Related: #35948, #35980, #36006.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: no behavior change; the AST equivalence check is described above.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: internal helper.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32618877388](https://github.com/sgl-project/sglang/actions/runs/32618877388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32618877203](https://github.com/sgl-project/sglang/actions/runs/32618877203)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32618877353](https://github.com/sgl-project/sglang/actions/runs/32618877353)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->