### PR TITLE
refactor(disagg): dedupe mooncake failure_exception into a mixin

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2244,7 +2244,34 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             self._run_one_probe_pass()
 
 
-class MooncakeKVSender(CommonKVSender):
+class MooncakeFailureExceptionMixin:
+    """Shared `failure_exception` for the Mooncake sender and receiver.
+
+    Both sides conclude a failed room identically: latch Failed, clear local
+    state, then raise with the recorded reason -- or, when no reason was
+    recorded locally, report it as propagated from another rank. Expects the
+    concrete class to provide ``conclude_state``, ``clear()``,
+    ``bootstrap_room`` and ``kv_mgr``.
+    """
+
+    def failure_exception(self):
+        # A room with no locally recorded reason failed on another rank.
+        if self.conclude_state is None:
+            self.conclude_state = KVPoll.Failed
+
+        self.clear()
+
+        with self.kv_mgr.failure_lock:
+            failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
+        is_propagated = failure_reason is None
+        if is_propagated:
+            failure_reason = "Failed due to an unknown reason from another rank"
+        raise KVTransferError(
+            self.bootstrap_room, failure_reason, is_from_another_rank=is_propagated
+        )
+
+
+class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
 
     def __init__(
         self,
@@ -2324,22 +2351,6 @@ class MooncakeKVSender(CommonKVSender):
         else:
             return self.conclude_state
 
-    def failure_exception(self):
-        # Explicitly set the status to failure since this request has failed in another rank
-        if self.conclude_state is None:
-            self.conclude_state = KVPoll.Failed
-
-        self.clear()
-
-        with self.kv_mgr.failure_lock:
-            failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
-        is_propagated = failure_reason is None
-        if is_propagated:
-            failure_reason = "Failed due to an unknown reason from another rank"
-        raise KVTransferError(
-            self.bootstrap_room, failure_reason, is_from_another_rank=is_propagated
-        )
-
     def _init_trace_ctx(self):
         if self.kv_mgr.enable_trace:
             self.trace_ctx = TraceReqContext(
@@ -2361,7 +2372,7 @@ class MooncakeKVSender(CommonKVSender):
         self.trace_ctx.trace_req_finish()
 
 
-class MooncakeKVReceiver(CommonKVReceiver):
+class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):
     def __init__(
         self,
         mgr: MooncakeKVManager,
@@ -2531,21 +2542,6 @@ class MooncakeKVReceiver(CommonKVReceiver):
                 return timeout_result
 
         return status
-
-    def failure_exception(self):
-        if self.conclude_state is None:
-            self.conclude_state = KVPoll.Failed
-
-        self.clear()
-
-        with self.kv_mgr.failure_lock:
-            failure_reason = self.kv_mgr.failure_records.pop(self.bootstrap_room, None)
-        is_propagated = failure_reason is None
-        if is_propagated:
-            failure_reason = "Failed due to an unknown reason from another rank"
-        raise KVTransferError(
-            self.bootstrap_room, failure_reason, is_from_another_rank=is_propagated
-        )
 
 
 class MooncakeKVBootstrapServer(CommonKVBootstrapServer):


### PR DESCRIPTION
## Motivation

`MooncakeKVSender.failure_exception` and `MooncakeKVReceiver.failure_exception` were identical apart from **one comment line** — `diff` across the 15- and 14-line bodies reported a single differing line.

Both conclude a failed room the same way: latch `Failed`, `clear()` local state, pop the recorded reason under `failure_lock`, then raise `KVTransferError` — reporting the failure as propagated from another rank when no reason was recorded locally.

## Modifications

1 file, +29 / -33.

Hoists the body into `MooncakeFailureExceptionMixin` and mixes it into both classes. The mixin docstring names the attributes a concrete class must provide (`conclude_state`, `clear()`, `bootstrap_room`, `kv_mgr`), since a mixin depending on subclass state is otherwise an undocumented contract.

This composes with #35950, which removed the placeholder `failure_exception` from `CommonKVSender` / `CommonKVReceiver`. The mixin now supplies the abstractmethod those bases deliberately leave open — nothing is shadowed, and both classes remain concrete.

### Not extended to the other backends

Deliberately scoped to mooncake:

- **Mori**'s pair is 94% similar, but its *sender* calls `_finalize_failure()` rather than latching `conclude_state`, and its default reason differs.
- **NIXL**'s sender is substantially different — it re-raises `self._send_error` or a stored `exceptions[room]` before falling back.

Unifying across backends would mean duck-typing a helper over both sender and receiver shapes in three backends' error paths. That trades a little duplication for a loose implicit contract in code that only runs once something has already gone wrong — not a good trade.

## Accuracy Tests

Not applicable — no model output, kernel, or forward path is touched.

## Speed Tests and Profiling

Not applicable. Same work on a failure path; one extra MRO hop.

## Verification performed

- **Proven to be a move, not a rewrite.** Both old bodies and the new mixin body extracted via AST and compared with comments stripped: `old sender == old receiver` -> True, `new mixin == old` -> True. Confirmed no `failure_exception` remains on either concrete class.
- **MRO reach checked, including the backend that inherits transitively.** `AscendKVSender` / `AscendKVReceiver` extend the Mooncake classes and declare no `failure_exception` of their own — verified by grep — so they resolve through the mixin. Simulated all four classes: each resolves from the mixin.
- Pinned `ruff 0.15.1 --select=F401,F821,UP037`, `black 26.1.0`, `isort 7.0.0` all pass.

PD failure paths were **not** exercised locally — they need multi-GPU hardware.

Part of a series of disaggregation cleanups. Related: #35948, #35950, #35980, #36006, #36030.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: no behavior change; AST equivalence and MRO checks above.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: internal error path.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32618947122](https://github.com/sgl-project/sglang/actions/runs/32618947122)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32618947032](https://github.com/sgl-project/sglang/actions/runs/32618947032)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32618947159](https://github.com/sgl-project/sglang/actions/runs/32618947159)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->