### PR TITLE
test: the 5090 consumer case runs two warm requests on the full recipe

### DIFF
--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -1179,7 +1179,7 @@ def _make_5090_h3_consumer_budget_case() -> DiffusionTestCase:
                 "--layerwise-offload-components",
                 "dit,text_encoder,vae",
                 "--layerwise-resident-layers",
-                "video_vae=24",
+                "video_vae=36",
             ],
             env_vars={
                 "SGLANG_DIFFUSION_TEST_FORCE_HOST_AVAILABLE_GIB": "32",
@@ -1212,6 +1212,7 @@ def _make_5090_h3_consumer_budget_case() -> DiffusionTestCase:
             },
         ),
         run_perf_check=True,
+        perf_repeat_requests=2,
         run_consistency_check=False,
         run_component_accuracy_check=False,
         run_models_api_check=False,

--- a/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
+++ b/python/sglang/multimodal_gen/test/server/perf_baselines/5090.json
@@ -138,7 +138,7 @@
             "stages_ms": {
                 "MiniMaxH3TextEncodingStage": 11900.0,
                 "MiniMaxH3DenoisingStage": 76100.0,
-                "MiniMaxH3DecodingStage": 26550.0
+                "MiniMaxH3DecodingStage": 13000.0
             },
             "denoise_step_ms": {
                 "0": 14000.0,
@@ -150,12 +150,12 @@
                 "6": 14000.0,
                 "7": 14000.0
             },
-            "expected_e2e_ms": 125000.0,
+            "expected_e2e_ms": 105000.0,
             "expected_avg_denoise_ms": 12000.0,
             "expected_median_denoise_ms": 11000.0,
             "load_peak_vram_mb": 6000.0,
             "runtime_peak_vram_mb": 12288.0,
-            "estimated_full_test_time_s": 900.0
+            "estimated_full_test_time_s": 1050.0
         }
     }
 }

--- a/python/sglang/multimodal_gen/test/server/test_server_common.py
+++ b/python/sglang/multimodal_gen/test/server/test_server_common.py
@@ -1546,14 +1546,18 @@ Pinned revision used by this check: {SGL_TEST_FILES_CI_DATA_REVISION}
             sampling_params=case.sampling_params,
         )
 
-        # Single generation - output is reused for both validations
+        # Generation - output of the last request is used for both validations.
+        # perf_repeat_requests > 1 asserts a warm second request meets the same
+        # baselines as the first: residency or courier state leaking between
+        # requests shows up here as degradation or an OOM.
         is_realtime_case = case.sampling_params.realtime_num_chunks is not None
-        perf_record, content = self.run_and_collect(
-            diffusion_server,
-            case.id,
-            generate_fn,
-            collect_perf=not is_gt_gen_mode and not is_realtime_case,
-        )
+        for _ in range(max(1, case.perf_repeat_requests)):
+            perf_record, content = self.run_and_collect(
+                diffusion_server,
+                case.id,
+                generate_fn,
+                collect_perf=not is_gt_gen_mode and not is_realtime_case,
+            )
 
         if is_gt_gen_mode:
             # GT generation mode: save output and skip all validations/tests

--- a/python/sglang/multimodal_gen/test/server/testcase_configs.py
+++ b/python/sglang/multimodal_gen/test/server/testcase_configs.py
@@ -295,6 +295,12 @@ class DiffusionTestCase:
     server_args: DiffusionServerArgs
     sampling_params: DiffusionSamplingParams | None = None
     run_perf_check: bool = True
+    # Send the request this many times in one server session; performance and
+    # consistency are validated on the last one. >1 asserts a warm second
+    # request meets the same baselines -- a leak in residency arming, courier
+    # in-flight tracking, or host copies shows up as the second request
+    # degrading or dying.
+    perf_repeat_requests: int = 1
     run_consistency_check: bool = True
     run_component_accuracy_check: bool = True
     run_models_api_check: bool = True


### PR DESCRIPTION
## Summary

The consumer-budget case moves to `video_vae=36` — the cookbook recipe now that decoder weights load in their decode dtype (#35967) — and gains `perf_repeat_requests=2`: the request is sent twice in one server session and performance is validated on the second. State leaking across requests (residency arming, courier in-flight tracking, host copies) shows up as the warm request degrading or dying, which a single-request case cannot see. Verified off-CI on a matched run: two sequential and two concurrent requests hold GPU/host memory flat with no OOM.

Decode and e2e baselines tighten to the fp16-decoder figures (decode 26550 → 13000 ms bound, e2e 125000 → 105000 ms); the peak-VRAM budget stays 12288 MB under the same hard cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32619588802](https://github.com/sgl-project/sglang/actions/runs/32619588802)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32619595749](https://github.com/sgl-project/sglang/actions/runs/32619595749)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32619588780](https://github.com/sgl-project/sglang/actions/runs/32619588780)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->