### PR TITLE
fix: make FlashInfer NVFP4 speculative decoding graph-safe

### DIFF
--- a/python/sglang/kernels/ops/quantization/nvfp4_kv_cache.py
+++ b/python/sglang/kernels/ops/quantization/nvfp4_kv_cache.py
@@ -32,7 +32,7 @@ def _e2m1_to_float(value):
 
 
 @triton.jit
-def _dequantize_nvfp4_kv_for_target_verify_kernel(
+def _dequantize_nvfp4_kv_for_speculative_extend_kernel(
     k_fp4_ptr,
     v_fp4_ptr,
     k_block_scales_ptr,
@@ -49,13 +49,14 @@ def _dequantize_nvfp4_kv_for_target_verify_kernel(
     prefix_lens_ptr,
     num_reqs,
     num_current_tokens_per_req,
+    prefix_len_delta,
     req_to_token_stride,
     k_current_row_stride,
     v_current_row_stride,
     ROW_ELEMENTS: tl.constexpr,
     BLOCK_ELEMENTS: tl.constexpr,
 ):
-    """Dequantize cached prefixes and copy verify-token KV by physical slot."""
+    """Dequantize cached prefixes and copy speculative-token KV by physical slot."""
     worker_id = tl.program_id(0)
     num_workers = tl.num_programs(0)
     element_offsets = tl.arange(0, BLOCK_ELEMENTS)
@@ -69,7 +70,10 @@ def _dequantize_nvfp4_kv_for_target_verify_kernel(
 
     for request_offset in tl.range(0, num_reqs):
         req_idx = tl.load(req_pool_indices_ptr + request_offset)
-        prefix_len = tl.load(prefix_lens_ptr + request_offset).to(tl.int32)
+        prefix_len = (
+            tl.load(prefix_lens_ptr + request_offset).to(tl.int32) - prefix_len_delta
+        )
+        prefix_len = tl.maximum(prefix_len, 0)
         req_row = req_idx.to(tl.int64) * req_to_token_stride
         current_row_base = request_offset * num_current_tokens_per_req
 
@@ -116,9 +120,9 @@ def _dequantize_nvfp4_kv_for_target_verify_kernel(
             tl.store(dq_k_ptr + output_offsets, k_dequant, mask=element_mask)
             tl.store(dq_v_ptr + output_offsets, v_dequant, mask=element_mask)
 
-        # Current verify tokens have not been committed to the quantized cache
-        # yet. Keep the existing prefill behavior and expose their unquantized
-        # K/V through the FP8 workspace directly.
+        # Current speculative tokens have not been committed to the quantized
+        # cache yet. Keep the existing prefill behavior and expose their
+        # unquantized K/V through the FP8 workspace directly.
         for current_offset in tl.range(
             worker_id, num_current_tokens_per_req, num_workers
         ):
@@ -144,7 +148,7 @@ def _dequantize_nvfp4_kv_for_target_verify_kernel(
 _cached_num_workers = None
 
 
-def dequantize_nvfp4_kv_for_target_verify(
+def dequantize_nvfp4_kv_for_speculative_extend(
     k_fp4: torch.Tensor,
     v_fp4: torch.Tensor,
     k_block_scales: torch.Tensor,
@@ -160,16 +164,34 @@ def dequantize_nvfp4_kv_for_target_verify(
     prefix_lens: torch.Tensor,
     current_locs: torch.Tensor,
     num_current_tokens_per_req: int,
+    prefix_len_delta: int,
 ) -> None:
-    """Populate the physical-slot FP8 workspace for speculative verification.
+    """Populate the physical-slot FP8 workspace for a speculative extend.
 
     This wrapper performs no allocation or device-to-host synchronization. The
     Triton launch shape depends only on static KV-row metadata, while request
     indices and prefix lengths remain device tensors read by the kernel. It is
     therefore safe to record once and replay with different requests/lengths.
+
+    ``prefix_lens`` may contain either committed prefix lengths (target verify)
+    or full post-write sequence lengths (draft extend). ``prefix_len_delta`` is
+    zero for the former and the fixed current-token width for the latter.
+
+    Each workspace row is one tensor-parallel rank's flattened KV head row:
+    ``per_rank_kv_heads * head_dim`` elements.
     """
     if req_pool_indices.numel() == 0:
         return
+
+    if num_current_tokens_per_req <= 0:
+        raise ValueError(
+            "num_current_tokens_per_req must be positive for speculative NVFP4 "
+            f"workspace preparation, got {num_current_tokens_per_req}."
+        )
+    if prefix_len_delta < 0:
+        raise ValueError(
+            f"prefix_len_delta must be non-negative, got {prefix_len_delta}."
+        )
 
     if not (
         k_fp4.is_contiguous()
@@ -179,7 +201,12 @@ def dequantize_nvfp4_kv_for_target_verify(
         and dq_k.is_contiguous()
         and dq_v.is_contiguous()
     ):
-        raise ValueError("NVFP4 target-verify workspace tensors must be contiguous.")
+        raise ValueError("NVFP4 speculative workspace tensors must be contiguous.")
+
+    if prefix_lens.numel() != req_pool_indices.numel():
+        raise ValueError(
+            "NVFP4 speculative prefix lengths must match the request batch size."
+        )
 
     row_elements = dq_k[0].numel()
     if row_elements % 16 != 0:
@@ -192,12 +219,12 @@ def dequantize_nvfp4_kv_for_target_verify(
         raise ValueError("Current K/V rows must match the dequant workspace row size.")
     if k_current.shape[0] != req_pool_indices.numel() * num_current_tokens_per_req:
         raise ValueError(
-            "Current target-verify K/V rows must equal "
+            "Current speculative K/V rows must equal "
             "batch_size * num_current_tokens_per_req."
         )
     if current_locs.numel() != k_current.shape[0]:
         raise ValueError(
-            "Target-verify KV write locations must match the current K/V rows."
+            "Speculative KV write locations must match the current K/V rows."
         )
 
     global _cached_num_workers
@@ -205,7 +232,7 @@ def dequantize_nvfp4_kv_for_target_verify(
         _cached_num_workers = max(1, get_device_core_count())
 
     block_elements = triton.next_power_of_2(row_elements)
-    _dequantize_nvfp4_kv_for_target_verify_kernel[(_cached_num_workers,)](
+    _dequantize_nvfp4_kv_for_speculative_extend_kernel[(_cached_num_workers,)](
         k_fp4,
         v_fp4,
         k_block_scales,
@@ -222,6 +249,7 @@ def dequantize_nvfp4_kv_for_target_verify(
         prefix_lens,
         req_pool_indices.numel(),
         num_current_tokens_per_req,
+        prefix_len_delta,
         req_to_token.stride(0),
         k_current.stride(0),
         v_current.stride(0),

--- a/python/sglang/kernels/ops/quantization/nvfp4_kv_cache.py
+++ b/python/sglang/kernels/ops/quantization/nvfp4_kv_cache.py
@@ -1,0 +1,231 @@
+# Copyright 2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""CUDA Graph-safe NVFP4 KV-cache workspace helpers."""
+
+import torch
+import triton
+import triton.language as tl
+
+from sglang.srt.utils import get_device_core_count
+
+
+@triton.jit
+def _e2m1_to_float(value):
+    magnitude = value & 0x7
+    decoded = tl.where(
+        magnitude < 5,
+        magnitude.to(tl.float32) * 0.5,
+        tl.where(magnitude == 5, 3.0, tl.where(magnitude == 6, 4.0, 6.0)),
+    )
+    return tl.where((value & 0x8) != 0, -decoded, decoded)
+
+
+@triton.jit
+def _dequantize_nvfp4_kv_for_target_verify_kernel(
+    k_fp4_ptr,
+    v_fp4_ptr,
+    k_block_scales_ptr,
+    v_block_scales_ptr,
+    k_global_scale_ptr,
+    v_global_scale_ptr,
+    k_current_ptr,
+    v_current_ptr,
+    current_locs_ptr,
+    dq_k_ptr,
+    dq_v_ptr,
+    req_to_token_ptr,
+    req_pool_indices_ptr,
+    prefix_lens_ptr,
+    num_reqs,
+    num_current_tokens_per_req,
+    req_to_token_stride,
+    k_current_row_stride,
+    v_current_row_stride,
+    ROW_ELEMENTS: tl.constexpr,
+    BLOCK_ELEMENTS: tl.constexpr,
+):
+    """Dequantize cached prefixes and copy verify-token KV by physical slot."""
+    worker_id = tl.program_id(0)
+    num_workers = tl.num_programs(0)
+    element_offsets = tl.arange(0, BLOCK_ELEMENTS)
+    element_mask = element_offsets < ROW_ELEMENTS
+
+    packed_row_elements: tl.constexpr = ROW_ELEMENTS // 2
+    scale_row_elements: tl.constexpr = ROW_ELEMENTS // 16
+
+    k_global_scale = tl.load(k_global_scale_ptr).to(tl.float32)
+    v_global_scale = tl.load(v_global_scale_ptr).to(tl.float32)
+
+    for request_offset in tl.range(0, num_reqs):
+        req_idx = tl.load(req_pool_indices_ptr + request_offset)
+        prefix_len = tl.load(prefix_lens_ptr + request_offset).to(tl.int32)
+        req_row = req_idx.to(tl.int64) * req_to_token_stride
+        current_row_base = request_offset * num_current_tokens_per_req
+
+        # CUDA Graph padding uses request row 0 but reserves KV slot 0 as its
+        # write sink. Suppress the padded request entirely so it neither repeats
+        # row 0's prefix work nor races a live request's workspace writes.
+        first_current_slot = tl.load(current_locs_ptr + current_row_base)
+        prefix_len = tl.where(first_current_slot > 0, prefix_len, 0)
+
+        # The worker grid is capture-stable. Runtime prefix lengths stay on the
+        # GPU, so replay can select different physical KV slots without baking
+        # capture-time host values into the graph.
+        for token_offset in tl.range(worker_id, prefix_len, num_workers):
+            kv_slot = tl.load(req_to_token_ptr + req_row + token_offset).to(tl.int64)
+            packed_row = kv_slot * packed_row_elements
+            packed_offsets = packed_row + element_offsets // 2
+
+            k_packed = tl.load(k_fp4_ptr + packed_offsets, mask=element_mask, other=0)
+            v_packed = tl.load(v_fp4_ptr + packed_offsets, mask=element_mask, other=0)
+            use_high_nibble = (element_offsets & 1) != 0
+            k_e2m1 = tl.where(use_high_nibble, (k_packed >> 4) & 0xF, k_packed & 0xF)
+            v_e2m1 = tl.where(use_high_nibble, (v_packed >> 4) & 0xF, v_packed & 0xF)
+
+            scale_row = kv_slot * scale_row_elements
+            scale_offsets = scale_row + element_offsets // 16
+            k_block_scale = tl.load(
+                k_block_scales_ptr + scale_offsets,
+                mask=element_mask,
+                other=0.0,
+            ).to(tl.float32)
+            v_block_scale = tl.load(
+                v_block_scales_ptr + scale_offsets,
+                mask=element_mask,
+                other=0.0,
+            ).to(tl.float32)
+
+            output_offsets = kv_slot * ROW_ELEMENTS + element_offsets
+            k_dequant = (_e2m1_to_float(k_e2m1) * k_block_scale * k_global_scale).to(
+                tl.bfloat16
+            )
+            v_dequant = (_e2m1_to_float(v_e2m1) * v_block_scale * v_global_scale).to(
+                tl.bfloat16
+            )
+            tl.store(dq_k_ptr + output_offsets, k_dequant, mask=element_mask)
+            tl.store(dq_v_ptr + output_offsets, v_dequant, mask=element_mask)
+
+        # Current verify tokens have not been committed to the quantized cache
+        # yet. Keep the existing prefill behavior and expose their unquantized
+        # K/V through the FP8 workspace directly.
+        for current_offset in tl.range(
+            worker_id, num_current_tokens_per_req, num_workers
+        ):
+            current_row = current_row_base + current_offset
+            # Graph padding points current_locs at the reserved slot 0. Reading
+            # current locations directly prevents padded req_pool_indices (also
+            # zero) from aliasing a live request's req_to_token row.
+            kv_slot = tl.load(current_locs_ptr + current_row).to(tl.int64)
+            current_mask = element_mask & (kv_slot > 0)
+            k_current_offsets = current_row * k_current_row_stride + element_offsets
+            v_current_offsets = current_row * v_current_row_stride + element_offsets
+            output_offsets = kv_slot * ROW_ELEMENTS + element_offsets
+            current_k = tl.load(
+                k_current_ptr + k_current_offsets, mask=current_mask, other=0.0
+            )
+            current_v = tl.load(
+                v_current_ptr + v_current_offsets, mask=current_mask, other=0.0
+            )
+            tl.store(dq_k_ptr + output_offsets, current_k, mask=current_mask)
+            tl.store(dq_v_ptr + output_offsets, current_v, mask=current_mask)
+
+
+_cached_num_workers = None
+
+
+def dequantize_nvfp4_kv_for_target_verify(
+    k_fp4: torch.Tensor,
+    v_fp4: torch.Tensor,
+    k_block_scales: torch.Tensor,
+    v_block_scales: torch.Tensor,
+    k_global_scale: torch.Tensor,
+    v_global_scale: torch.Tensor,
+    k_current: torch.Tensor,
+    v_current: torch.Tensor,
+    dq_k: torch.Tensor,
+    dq_v: torch.Tensor,
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    prefix_lens: torch.Tensor,
+    current_locs: torch.Tensor,
+    num_current_tokens_per_req: int,
+) -> None:
+    """Populate the physical-slot FP8 workspace for speculative verification.
+
+    This wrapper performs no allocation or device-to-host synchronization. The
+    Triton launch shape depends only on static KV-row metadata, while request
+    indices and prefix lengths remain device tensors read by the kernel. It is
+    therefore safe to record once and replay with different requests/lengths.
+    """
+    if req_pool_indices.numel() == 0:
+        return
+
+    if not (
+        k_fp4.is_contiguous()
+        and v_fp4.is_contiguous()
+        and k_block_scales.is_contiguous()
+        and v_block_scales.is_contiguous()
+        and dq_k.is_contiguous()
+        and dq_v.is_contiguous()
+    ):
+        raise ValueError("NVFP4 target-verify workspace tensors must be contiguous.")
+
+    row_elements = dq_k[0].numel()
+    if row_elements % 16 != 0:
+        raise ValueError(
+            f"NVFP4 KV row size must be divisible by 16, got {row_elements}."
+        )
+    if dq_v[0].numel() != row_elements:
+        raise ValueError("NVFP4 K/V workspace rows must have the same size.")
+    if k_current[0].numel() != row_elements or v_current[0].numel() != row_elements:
+        raise ValueError("Current K/V rows must match the dequant workspace row size.")
+    if k_current.shape[0] != req_pool_indices.numel() * num_current_tokens_per_req:
+        raise ValueError(
+            "Current target-verify K/V rows must equal "
+            "batch_size * num_current_tokens_per_req."
+        )
+    if current_locs.numel() != k_current.shape[0]:
+        raise ValueError(
+            "Target-verify KV write locations must match the current K/V rows."
+        )
+
+    global _cached_num_workers
+    if _cached_num_workers is None:
+        _cached_num_workers = max(1, get_device_core_count())
+
+    block_elements = triton.next_power_of_2(row_elements)
+    _dequantize_nvfp4_kv_for_target_verify_kernel[(_cached_num_workers,)](
+        k_fp4,
+        v_fp4,
+        k_block_scales,
+        v_block_scales,
+        k_global_scale,
+        v_global_scale,
+        k_current,
+        v_current,
+        current_locs,
+        dq_k,
+        dq_v,
+        req_to_token,
+        req_pool_indices,
+        prefix_lens,
+        req_pool_indices.numel(),
+        num_current_tokens_per_req,
+        req_to_token.stride(0),
+        k_current.stride(0),
+        v_current.stride(0),
+        ROW_ELEMENTS=row_elements,
+        BLOCK_ELEMENTS=block_elements,
+        num_warps=8 if block_elements >= 1024 else 4,
+    )

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1270,18 +1270,44 @@ class FlashInferAttnBackend(AttentionBackend):
         # We perform dequant for chunk prefill/cache reuse.
         pool = self.token_to_kv_pool
         if self.prefill_uses_dequant_workspace:
-            kv_cache = pool.get_flashinfer_dequant_workspace_kv_buffer(
-                layer,
-                self.req_to_token_pool.req_to_token,
-                self.cpu_req_pool_indices,
-                forward_batch.extend_prefix_lens_cpu,
-                forward_batch.extend_seq_lens_cpu,
-                self.page_size,
-                prepare_workspace=self.dq_page_table is not None,
-                use_ragged=self.forward_metadata.use_ragged,
-                k_cur=k,
-                v_cur=v,
-            )
+            if forward_batch.forward_mode.is_target_verify():
+                if k is None or v is None:
+                    raise RuntimeError(
+                        "NVFP4 target verification requires current K/V tensors."
+                    )
+                if forward_batch.spec_info is None:
+                    raise RuntimeError(
+                        "NVFP4 target verification requires speculative metadata."
+                    )
+                if cache_loc is None:
+                    raise RuntimeError(
+                        "NVFP4 target verification requires KV write locations."
+                    )
+                kv_cache = (
+                    pool.get_flashinfer_target_verify_dequant_workspace_kv_buffer(
+                        layer,
+                        self.req_to_token_pool.req_to_token,
+                        forward_batch.req_pool_indices,
+                        forward_batch.seq_lens,
+                        k,
+                        v,
+                        cache_loc,
+                        forward_batch.spec_info.num_tokens_per_req,
+                    )
+                )
+            else:
+                kv_cache = pool.get_flashinfer_dequant_workspace_kv_buffer(
+                    layer,
+                    self.req_to_token_pool.req_to_token,
+                    self.cpu_req_pool_indices,
+                    forward_batch.extend_prefix_lens_cpu,
+                    forward_batch.extend_seq_lens_cpu,
+                    self.page_size,
+                    prepare_workspace=self.dq_page_table is not None,
+                    use_ragged=self.forward_metadata.use_ragged,
+                    k_cur=k,
+                    v_cur=v,
+                )
         else:
             kv_cache = pool.get_kv_buffer(layer.layer_id)
 

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -757,6 +757,11 @@ class FlashInferAttnBackend(AttentionBackend):
                 spec_info=None,
             )
         elif forward_mode.is_draft_extend_v2():
+            if spec_info is None or spec_info.num_tokens_per_req <= 0:
+                raise RuntimeError(
+                    "FlashInfer draft extend requires speculative metadata with "
+                    "num_tokens_per_req > 0."
+                )
             self.indices_updater_prefill.update(
                 req_pool_indices[:bs],
                 seq_lens[:bs],
@@ -942,6 +947,39 @@ class FlashInferAttnBackend(AttentionBackend):
             )
             self.forward_metadata = PrefillMetadata(
                 self.prefill_wrappers_verify,
+                False,
+                False,
+                swa_out_cache_loc=swa_out_cache_loc,
+            )
+        elif forward_batch.forward_mode.is_draft_extend_v2():
+            spec_info = forward_batch.spec_info
+            if spec_info is None or spec_info.num_tokens_per_req <= 0:
+                raise RuntimeError(
+                    "FlashInfer draft extend requires speculative metadata with "
+                    "num_tokens_per_req > 0."
+                )
+            prefix_lens = forward_batch.extend_prefix_lens
+            if prefix_lens is None:
+                prefix_lens = forward_batch.seq_lens - spec_info.num_tokens_per_req
+
+            # Draft extend uses the same physical-slot page table as target
+            # verification. It intentionally ignores dq_page_table and the CPU
+            # mirrors owned by prompt/chunk prefill; those may remain bound to a
+            # capture-stable full-prefill graph.
+            self.indices_updater_prefill.update(
+                forward_batch.req_pool_indices,
+                forward_batch.seq_lens,
+                forward_batch.seq_lens_cpu,
+                forward_batch.seq_lens_sum,
+                prefix_lens,
+                prefill_wrappers=self.prefill_wrappers_paged,
+                use_ragged=False,
+                encoder_lens=forward_batch.encoder_lens,
+                spec_info=spec_info,
+                fixed_split_size=self.prefill_split_tile_size,
+            )
+            self.forward_metadata = PrefillMetadata(
+                self.prefill_wrappers_paged,
                 False,
                 False,
                 swa_out_cache_loc=swa_out_cache_loc,
@@ -1270,30 +1308,40 @@ class FlashInferAttnBackend(AttentionBackend):
         # We perform dequant for chunk prefill/cache reuse.
         pool = self.token_to_kv_pool
         if self.prefill_uses_dequant_workspace:
-            if forward_batch.forward_mode.is_target_verify():
+            if (
+                forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend_v2()
+            ):
+                phase = (
+                    "target verification"
+                    if forward_batch.forward_mode.is_target_verify()
+                    else "draft extend"
+                )
                 if k is None or v is None:
+                    raise RuntimeError(f"NVFP4 {phase} requires current K/V tensors.")
+                spec_info = forward_batch.spec_info
+                if spec_info is None or spec_info.num_tokens_per_req <= 0:
                     raise RuntimeError(
-                        "NVFP4 target verification requires current K/V tensors."
-                    )
-                if forward_batch.spec_info is None:
-                    raise RuntimeError(
-                        "NVFP4 target verification requires speculative metadata."
+                        f"NVFP4 {phase} requires speculative metadata with "
+                        "num_tokens_per_req > 0."
                     )
                 if cache_loc is None:
-                    raise RuntimeError(
-                        "NVFP4 target verification requires KV write locations."
-                    )
-                kv_cache = (
-                    pool.get_flashinfer_target_verify_dequant_workspace_kv_buffer(
-                        layer,
-                        self.req_to_token_pool.req_to_token,
-                        forward_batch.req_pool_indices,
-                        forward_batch.seq_lens,
-                        k,
-                        v,
-                        cache_loc,
-                        forward_batch.spec_info.num_tokens_per_req,
-                    )
+                    raise RuntimeError(f"NVFP4 {phase} requires KV write locations.")
+                prefix_len_delta = (
+                    spec_info.num_tokens_per_req
+                    if forward_batch.forward_mode.is_draft_extend_v2()
+                    else 0
+                )
+                kv_cache = pool.get_flashinfer_speculative_dequant_workspace_kv_buffer(
+                    layer,
+                    self.req_to_token_pool.req_to_token,
+                    forward_batch.req_pool_indices,
+                    forward_batch.seq_lens,
+                    k,
+                    v,
+                    cache_loc,
+                    spec_info.num_tokens_per_req,
+                    prefix_len_delta,
                 )
             else:
                 kv_cache = pool.get_flashinfer_dequant_workspace_kv_buffer(

--- a/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
+++ b/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
@@ -279,6 +279,29 @@ class KVCacheQuantMethodBase(ABC):
             f"KV cache method {self.name!r} does not support plain KV dequant reads."
         )
 
+    def dequantize_target_verify_prefix_to_workspace(
+        self,
+        k_fp4: Tensor,
+        v_fp4: Tensor,
+        k_scales: Tensor,
+        v_scales: Tensor,
+        k_current: Tensor,
+        v_current: Tensor,
+        dq_k: Tensor,
+        dq_v: Tensor,
+        req_to_token: Tensor,
+        req_pool_indices: Tensor,
+        prefix_lens: Tensor,
+        current_locs: Tensor,
+        num_current_tokens_per_req: int,
+        layer_id: int,
+    ) -> None:
+        """Populate a physical-slot workspace for speculative verification."""
+        raise NotImplementedError(
+            f"KV cache method {self.name!r} does not support target-verify "
+            "dequant workspaces."
+        )
+
     @abstractmethod
     def compute_cell_size(
         self, head_num: int, head_dim: int, num_layers: int, kv_size: int
@@ -532,6 +555,45 @@ class NVFP4KVCacheMethod(KVCacheQuantMethodBase):
             v_fp4.view(torch.uint8), v_scales, cur_v_scale
         )
         return k_bf16.to(torch.float8_e4m3fn), v_bf16.to(torch.float8_e4m3fn)
+
+    def dequantize_target_verify_prefix_to_workspace(
+        self,
+        k_fp4: Tensor,
+        v_fp4: Tensor,
+        k_scales: Tensor,
+        v_scales: Tensor,
+        k_current: Tensor,
+        v_current: Tensor,
+        dq_k: Tensor,
+        dq_v: Tensor,
+        req_to_token: Tensor,
+        req_pool_indices: Tensor,
+        prefix_lens: Tensor,
+        current_locs: Tensor,
+        num_current_tokens_per_req: int,
+        layer_id: int,
+    ) -> None:
+        from sglang.kernels.ops.quantization.nvfp4_kv_cache import (
+            dequantize_nvfp4_kv_for_target_verify,
+        )
+
+        dequantize_nvfp4_kv_for_target_verify(
+            k_fp4,
+            v_fp4,
+            k_scales,
+            v_scales,
+            self.k_scales_gpu[layer_id : layer_id + 1],
+            self.v_scales_gpu[layer_id : layer_id + 1],
+            k_current,
+            v_current,
+            dq_k,
+            dq_v,
+            req_to_token,
+            req_pool_indices,
+            prefix_lens,
+            current_locs,
+            num_current_tokens_per_req,
+        )
 
     def compute_cell_size(
         self, head_num: int, head_dim: int, num_layers: int, kv_size: int

--- a/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
+++ b/python/sglang/srt/layers/quantization/fp4_kv_cache_quant_method.py
@@ -279,7 +279,7 @@ class KVCacheQuantMethodBase(ABC):
             f"KV cache method {self.name!r} does not support plain KV dequant reads."
         )
 
-    def dequantize_target_verify_prefix_to_workspace(
+    def dequantize_speculative_prefix_to_workspace(
         self,
         k_fp4: Tensor,
         v_fp4: Tensor,
@@ -294,11 +294,12 @@ class KVCacheQuantMethodBase(ABC):
         prefix_lens: Tensor,
         current_locs: Tensor,
         num_current_tokens_per_req: int,
+        prefix_len_delta: int,
         layer_id: int,
     ) -> None:
-        """Populate a physical-slot workspace for speculative verification."""
+        """Populate a physical-slot workspace for a speculative extend."""
         raise NotImplementedError(
-            f"KV cache method {self.name!r} does not support target-verify "
+            f"KV cache method {self.name!r} does not support speculative "
             "dequant workspaces."
         )
 
@@ -556,7 +557,7 @@ class NVFP4KVCacheMethod(KVCacheQuantMethodBase):
         )
         return k_bf16.to(torch.float8_e4m3fn), v_bf16.to(torch.float8_e4m3fn)
 
-    def dequantize_target_verify_prefix_to_workspace(
+    def dequantize_speculative_prefix_to_workspace(
         self,
         k_fp4: Tensor,
         v_fp4: Tensor,
@@ -571,13 +572,14 @@ class NVFP4KVCacheMethod(KVCacheQuantMethodBase):
         prefix_lens: Tensor,
         current_locs: Tensor,
         num_current_tokens_per_req: int,
+        prefix_len_delta: int,
         layer_id: int,
     ) -> None:
         from sglang.kernels.ops.quantization.nvfp4_kv_cache import (
-            dequantize_nvfp4_kv_for_target_verify,
+            dequantize_nvfp4_kv_for_speculative_extend,
         )
 
-        dequantize_nvfp4_kv_for_target_verify(
+        dequantize_nvfp4_kv_for_speculative_extend(
             k_fp4,
             v_fp4,
             k_scales,
@@ -593,6 +595,7 @@ class NVFP4KVCacheMethod(KVCacheQuantMethodBase):
             prefix_lens,
             current_locs,
             num_current_tokens_per_req,
+            prefix_len_delta,
         )
 
     def compute_cell_size(

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2551,6 +2551,16 @@ class MHATokenToKVPool(KVCache):
             )
 
         if prepare_workspace:
+            if (
+                req_pool_indices_cpu is None
+                or extend_prefix_lens_cpu is None
+                or extend_seq_lens_cpu is None
+            ):
+                raise RuntimeError(
+                    "FlashInfer FP4 extend workspace preparation requires CPU "
+                    "request indices, prefix lengths, and extend lengths. Fixed-width "
+                    "speculative forwards must use the GPU-resident workspace path."
+                )
             transfer_cur_kv = not use_ragged
             k_cur_fp8 = (
                 k_cur.to(torch.float8_e4m3fn)
@@ -2607,7 +2617,7 @@ class MHATokenToKVPool(KVCache):
             v_buffer_dq.view(-1, layer.tp_v_head_num, layer.head_dim),
         )
 
-    def get_flashinfer_target_verify_dequant_workspace_kv_buffer(
+    def get_flashinfer_speculative_dequant_workspace_kv_buffer(
         self,
         layer: RadixAttention,
         req_to_token: torch.Tensor,
@@ -2617,20 +2627,21 @@ class MHATokenToKVPool(KVCache):
         v_current: torch.Tensor,
         current_locs: torch.Tensor,
         num_current_tokens_per_req: int,
+        prefix_len_delta: int,
         *,
         layer_id_override: Optional[int] = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
-        """Build a graph-safe FP8 workspace for speculative target verify.
+        """Build a graph-safe FP8 workspace for a speculative extend.
 
-        FlashInfer verify metadata indexes the regular physical KV slots, unlike
-        the page-aligned contiguous workspace used by prompt/chunk prefill. The
-        quant method therefore dequantizes cached prefixes directly into their
-        physical workspace slots and writes current verify-token K/V to the same
-        slots, using only GPU-resident request metadata.
+        FlashInfer speculative metadata indexes regular physical KV slots,
+        unlike the page-aligned contiguous workspace used by prompt/chunk
+        prefill. The quant method therefore dequantizes cached prefixes directly
+        into their physical workspace slots and writes current-token K/V to the
+        same slots, using only GPU-resident request metadata.
         """
         if not self.is_quantized_kv_cache:
             raise RuntimeError(
-                "FlashInfer target-verify dequant workspace requested from a "
+                "FlashInfer speculative dequant workspace requested from a "
                 "non-quantized KV pool."
             )
 
@@ -2639,7 +2650,19 @@ class MHATokenToKVPool(KVCache):
         )
         k_fp4, v_fp4, k_scales, v_scales = self.get_raw_kv_buffer(local_layer_id)
         dq_k, dq_v = self.get_dequant_workspace()
-        self.quant_method.dequantize_target_verify_prefix_to_workspace(
+        expected_k_row_elements = layer.tp_k_head_num * layer.head_dim
+        expected_v_row_elements = layer.tp_v_head_num * layer.head_dim
+        if (
+            dq_k[0].numel() != expected_k_row_elements
+            or dq_v[0].numel() != expected_v_row_elements
+        ):
+            raise RuntimeError(
+                "NVFP4 dequant workspace rows must match this tensor-parallel "
+                "rank's KV heads * head_dim: "
+                f"K expected {expected_k_row_elements}, got {dq_k[0].numel()}; "
+                f"V expected {expected_v_row_elements}, got {dq_v[0].numel()}."
+            )
+        self.quant_method.dequantize_speculative_prefix_to_workspace(
             k_fp4,
             v_fp4,
             k_scales,
@@ -2653,6 +2676,7 @@ class MHATokenToKVPool(KVCache):
             prefix_lens,
             current_locs,
             num_current_tokens_per_req,
+            prefix_len_delta,
             layer.layer_id,
         )
         return (
@@ -3940,15 +3964,13 @@ class HybridLinearKVPool(KVCache):
             layer, *args, layer_id_override=local_layer_id, **kwargs
         )
 
-    def get_flashinfer_target_verify_dequant_workspace_kv_buffer(
+    def get_flashinfer_speculative_dequant_workspace_kv_buffer(
         self, layer, *args, **kwargs
     ):
         self._wait_for_layer(layer.layer_id)
         local_layer_id = self._transfer_full_attention_id(layer.layer_id)
-        return (
-            self.full_kv_pool.get_flashinfer_target_verify_dequant_workspace_kv_buffer(
-                layer, *args, layer_id_override=local_layer_id, **kwargs
-            )
+        return self.full_kv_pool.get_flashinfer_speculative_dequant_workspace_kv_buffer(
+            layer, *args, layer_id_override=local_layer_id, **kwargs
         )
 
     def get_kv_scale_buffer(self, layer_id: int):

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2607,6 +2607,59 @@ class MHATokenToKVPool(KVCache):
             v_buffer_dq.view(-1, layer.tp_v_head_num, layer.head_dim),
         )
 
+    def get_flashinfer_target_verify_dequant_workspace_kv_buffer(
+        self,
+        layer: RadixAttention,
+        req_to_token: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        prefix_lens: torch.Tensor,
+        k_current: torch.Tensor,
+        v_current: torch.Tensor,
+        current_locs: torch.Tensor,
+        num_current_tokens_per_req: int,
+        *,
+        layer_id_override: Optional[int] = None,
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Build a graph-safe FP8 workspace for speculative target verify.
+
+        FlashInfer verify metadata indexes the regular physical KV slots, unlike
+        the page-aligned contiguous workspace used by prompt/chunk prefill. The
+        quant method therefore dequantizes cached prefixes directly into their
+        physical workspace slots and writes current verify-token K/V to the same
+        slots, using only GPU-resident request metadata.
+        """
+        if not self.is_quantized_kv_cache:
+            raise RuntimeError(
+                "FlashInfer target-verify dequant workspace requested from a "
+                "non-quantized KV pool."
+            )
+
+        local_layer_id = (
+            layer.layer_id if layer_id_override is None else layer_id_override
+        )
+        k_fp4, v_fp4, k_scales, v_scales = self.get_raw_kv_buffer(local_layer_id)
+        dq_k, dq_v = self.get_dequant_workspace()
+        self.quant_method.dequantize_target_verify_prefix_to_workspace(
+            k_fp4,
+            v_fp4,
+            k_scales,
+            v_scales,
+            k_current,
+            v_current,
+            dq_k,
+            dq_v,
+            req_to_token,
+            req_pool_indices,
+            prefix_lens,
+            current_locs,
+            num_current_tokens_per_req,
+            layer.layer_id,
+        )
+        return (
+            dq_k.view(-1, layer.tp_k_head_num, layer.head_dim),
+            dq_v.view(-1, layer.tp_v_head_num, layer.head_dim),
+        )
+
     @staticmethod
     def _to_cpu_int_list(values) -> list[int]:
         if isinstance(values, list):
@@ -3885,6 +3938,17 @@ class HybridLinearKVPool(KVCache):
         local_layer_id = self._transfer_full_attention_id(layer.layer_id)
         return self.full_kv_pool.get_flashinfer_decode_dequant_workspace_kv_buffer(
             layer, *args, layer_id_override=local_layer_id, **kwargs
+        )
+
+    def get_flashinfer_target_verify_dequant_workspace_kv_buffer(
+        self, layer, *args, **kwargs
+    ):
+        self._wait_for_layer(layer.layer_id)
+        local_layer_id = self._transfer_full_attention_id(layer.layer_id)
+        return (
+            self.full_kv_pool.get_flashinfer_target_verify_dequant_workspace_kv_buffer(
+                layer, *args, layer_id_override=local_layer_id, **kwargs
+            )
         )
 
     def get_kv_scale_buffer(self, layer_id: int):

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -75,9 +75,10 @@ def _resolve_eagle_aux_hidden_state(
     if (
         (spec_algorithm.is_eagle() or spec_algorithm.is_standalone())
         and not is_draft_worker
-        and server_args.speculative_draft_model_path
     ):
-        # Load draft config to get layer count for KV cache sizing
+        # Mirror the draft worker's ModelConfig construction to get its KV layer
+        # count. For integrated MTP, a None draft path intentionally falls back
+        # to the target checkpoint and applies the is_draft_model conversion.
         draft_model_config = ModelConfig.from_server_args(
             server_args,
             model_path=server_args.speculative_draft_model_path,

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -209,9 +209,19 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                     )
                     self._cell_size += draft_kv_size + draft_indexer_size
                 else:
-                    self._cell_size = int(
-                        self._cell_size * (1 + draft_num_layers / int(num_layers))
-                    )
+                    if is_float4_e2m1fn_x2(kvc.kv_cache_dtype):
+                        # FP4 has a per-worker dequant workspace shared across
+                        # layers. The draft therefore needs its own full
+                        # workspace, not a layer-proportional fraction of the
+                        # target workspace.
+                        self._cell_size += self._compute_cell_size(
+                            kvc, draft_num_layers
+                        )
+                    else:
+                        self._cell_size = int(
+                            self._cell_size
+                            * (1 + draft_num_layers / int(num_layers))
+                        )
 
         # DFLASH/DSPARK: scale cell_size to account for draft model KV cache
         if kvc.spec_algorithm.is_dflash_family() and not kvc.is_draft_worker:

--- a/test/registered/kernels/ops/quantization/test_nvfp4_kv_cache.py
+++ b/test/registered/kernels/ops/quantization/test_nvfp4_kv_cache.py
@@ -1,0 +1,193 @@
+import pytest
+import torch
+
+from sglang.kernels.ops.quantization.nvfp4_kv_cache import (
+    dequantize_nvfp4_kv_for_target_verify,
+)
+from sglang.srt.layers.quantization.kvfp4_tensor import E2M1_VALUES
+from sglang.srt.utils import is_sm100_supported, is_sm120_supported
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+
+
+def _dequantize_reference(fp4_data, block_scales, global_scale):
+    unpacked = torch.empty(
+        *fp4_data.shape[:-1],
+        fp4_data.shape[-1] * 2,
+        dtype=torch.uint8,
+        device=fp4_data.device,
+    )
+    unpacked[..., 0::2] = fp4_data & 0xF
+    unpacked[..., 1::2] = (fp4_data >> 4) & 0xF
+    values = torch.tensor(E2M1_VALUES, dtype=torch.float32, device=fp4_data.device)
+    return (
+        (
+            values[unpacked.long()]
+            * block_scales.float().repeat_interleave(16, dim=-1)
+            * global_scale
+        )
+        .to(torch.bfloat16)
+        .to(torch.float8_e4m3fn)
+    )
+
+
+@pytest.mark.skipif(
+    not (is_sm100_supported() or is_sm120_supported()),
+    reason="NVFP4 KV cache requires SM100 or SM120",
+)
+def test_target_verify_workspace_graph_replay_uses_runtime_prefix_lens():
+    torch.manual_seed(7)
+    device = "cuda"
+    size, heads, head_dim = 64, 4, 128
+    real_batch_size, graph_batch_size = 2, 3
+    current_tokens_per_req, max_context = 4, 16
+
+    k_fp4 = torch.randint(
+        0, 256, (size, heads, head_dim // 2), dtype=torch.uint8, device=device
+    )
+    v_fp4 = torch.randint(
+        0, 256, (size, heads, head_dim // 2), dtype=torch.uint8, device=device
+    )
+    k_block_scales = (torch.rand(size, heads, head_dim // 16, device=device) * 0.2).to(
+        torch.float8_e4m3fn
+    )
+    v_block_scales = (torch.rand(size, heads, head_dim // 16, device=device) * 0.2).to(
+        torch.float8_e4m3fn
+    )
+    k_global_scale = torch.tensor([0.02], dtype=torch.float32, device=device)
+    v_global_scale = torch.tensor([0.03], dtype=torch.float32, device=device)
+
+    req_to_token = torch.zeros(
+        real_batch_size, max_context, dtype=torch.int32, device=device
+    )
+    req_to_token[0] = torch.arange(2, 18, dtype=torch.int32, device=device)
+    req_to_token[1] = torch.arange(30, 46, dtype=torch.int32, device=device)
+    # The third row models CUDA Graph padding: graph buffers use request row 0
+    # and reserved KV slot 0 for padded requests.
+    req_pool_indices = torch.tensor([0, 1, 0], dtype=torch.int32, device=device)
+    prefix_lens = torch.tensor([1, 2, 1], dtype=torch.int32, device=device)
+
+    # QKV splits can have a larger per-token stride. Exercise that layout so
+    # target verify does not add a contiguous() allocation inside the graph.
+    num_current_rows = graph_batch_size * current_tokens_per_req
+    k_current_storage = torch.randn(
+        num_current_rows,
+        heads * head_dim + 13,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    v_current_storage = torch.randn(
+        num_current_rows,
+        heads * head_dim + 17,
+        dtype=torch.bfloat16,
+        device=device,
+    )
+    k_current = k_current_storage[:, : heads * head_dim].view(
+        num_current_rows, heads, head_dim
+    )
+    v_current = v_current_storage[:, : heads * head_dim].view(
+        num_current_rows, heads, head_dim
+    )
+    assert not k_current.is_contiguous()
+    assert not v_current.is_contiguous()
+
+    dq_k = torch.full(
+        (size, heads, head_dim),
+        float("nan"),
+        dtype=torch.float8_e4m3fn,
+        device=device,
+    )
+    dq_v = torch.full_like(dq_k, float("nan"))
+
+    def make_current_locs(real_prefix_lens):
+        locs = torch.zeros(
+            graph_batch_size,
+            current_tokens_per_req,
+            dtype=torch.int32,
+            device=device,
+        )
+        for req_offset, prefix_len in enumerate(real_prefix_lens):
+            locs[req_offset].copy_(
+                req_to_token[
+                    req_offset,
+                    prefix_len : prefix_len + current_tokens_per_req,
+                ]
+            )
+        return locs.flatten()
+
+    current_locs = make_current_locs([1, 2])
+
+    def run_kernel():
+        dequantize_nvfp4_kv_for_target_verify(
+            k_fp4,
+            v_fp4,
+            k_block_scales,
+            v_block_scales,
+            k_global_scale,
+            v_global_scale,
+            k_current,
+            v_current,
+            dq_k,
+            dq_v,
+            req_to_token,
+            req_pool_indices,
+            prefix_lens,
+            current_locs,
+            current_tokens_per_req,
+        )
+
+    # Compile before capture, then capture with short prefixes.
+    run_kernel()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        run_kernel()
+
+    # Replay the same graph with different device-resident prefix lengths. If
+    # capture-time host values were baked in, slots 3..7 would remain NaN.
+    dq_k.fill_(float("nan"))
+    dq_v.fill_(float("nan"))
+    replay_prefix_lens = [6, 7]
+    prefix_lens.copy_(torch.tensor([*replay_prefix_lens, 1], device=device))
+    current_locs.copy_(make_current_locs(replay_prefix_lens))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    k_prefix_reference = _dequantize_reference(k_fp4, k_block_scales, k_global_scale)
+    v_prefix_reference = _dequantize_reference(v_fp4, v_block_scales, v_global_scale)
+    for req_offset, prefix_len in enumerate(replay_prefix_lens):
+        prefix_slots = req_to_token[req_offset, :prefix_len].long()
+        torch.testing.assert_close(
+            dq_k[prefix_slots].float(),
+            k_prefix_reference[prefix_slots].float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            dq_v[prefix_slots].float(),
+            v_prefix_reference[prefix_slots].float(),
+            rtol=0,
+            atol=0,
+        )
+
+        current_slots = req_to_token[
+            req_offset,
+            prefix_len : prefix_len + current_tokens_per_req,
+        ].long()
+        current_rows = slice(
+            req_offset * current_tokens_per_req,
+            (req_offset + 1) * current_tokens_per_req,
+        )
+        torch.testing.assert_close(
+            dq_k[current_slots].float(),
+            k_current[current_rows].to(torch.float8_e4m3fn).float(),
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(
+            dq_v[current_slots].float(),
+            v_current[current_rows].to(torch.float8_e4m3fn).float(),
+            rtol=0,
+            atol=0,
+        )

--- a/test/registered/kernels/ops/quantization/test_nvfp4_kv_cache.py
+++ b/test/registered/kernels/ops/quantization/test_nvfp4_kv_cache.py
@@ -2,13 +2,13 @@ import pytest
 import torch
 
 from sglang.kernels.ops.quantization.nvfp4_kv_cache import (
-    dequantize_nvfp4_kv_for_target_verify,
+    dequantize_nvfp4_kv_for_speculative_extend,
 )
 from sglang.srt.layers.quantization.kvfp4_tensor import E2M1_VALUES
 from sglang.srt.utils import is_sm100_supported, is_sm120_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
-register_cuda_ci(est_time=5, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
 
 
 def _dequantize_reference(fp4_data, block_scales, global_scale):
@@ -36,7 +36,11 @@ def _dequantize_reference(fp4_data, block_scales, global_scale):
     not (is_sm100_supported() or is_sm120_supported()),
     reason="NVFP4 KV cache requires SM100 or SM120",
 )
-def test_target_verify_workspace_graph_replay_uses_runtime_prefix_lens():
+@pytest.mark.parametrize(
+    "prefix_len_delta",
+    [pytest.param(0, id="target_verify"), pytest.param(4, id="draft_extend")],
+)
+def test_speculative_workspace_graph_replay_uses_runtime_lengths(prefix_len_delta):
     torch.manual_seed(7)
     device = "cuda"
     size, heads, head_dim = 64, 4, 128
@@ -66,7 +70,11 @@ def test_target_verify_workspace_graph_replay_uses_runtime_prefix_lens():
     # The third row models CUDA Graph padding: graph buffers use request row 0
     # and reserved KV slot 0 for padded requests.
     req_pool_indices = torch.tensor([0, 1, 0], dtype=torch.int32, device=device)
-    prefix_lens = torch.tensor([1, 2, 1], dtype=torch.int32, device=device)
+    sequence_lens = torch.tensor(
+        [1 + prefix_len_delta, 2 + prefix_len_delta, 1],
+        dtype=torch.int32,
+        device=device,
+    )
 
     # QKV splits can have a larger per-token stride. Exercise that layout so
     # target verify does not add a contiguous() allocation inside the graph.
@@ -119,7 +127,7 @@ def test_target_verify_workspace_graph_replay_uses_runtime_prefix_lens():
     current_locs = make_current_locs([1, 2])
 
     def run_kernel():
-        dequantize_nvfp4_kv_for_target_verify(
+        dequantize_nvfp4_kv_for_speculative_extend(
             k_fp4,
             v_fp4,
             k_block_scales,
@@ -132,9 +140,10 @@ def test_target_verify_workspace_graph_replay_uses_runtime_prefix_lens():
             dq_v,
             req_to_token,
             req_pool_indices,
-            prefix_lens,
+            sequence_lens,
             current_locs,
             current_tokens_per_req,
+            prefix_len_delta,
         )
 
     # Compile before capture, then capture with short prefixes.
@@ -149,7 +158,15 @@ def test_target_verify_workspace_graph_replay_uses_runtime_prefix_lens():
     dq_k.fill_(float("nan"))
     dq_v.fill_(float("nan"))
     replay_prefix_lens = [6, 7]
-    prefix_lens.copy_(torch.tensor([*replay_prefix_lens, 1], device=device))
+    sequence_lens.copy_(
+        torch.tensor(
+            [
+                *(length + prefix_len_delta for length in replay_prefix_lens),
+                1,
+            ],
+            device=device,
+        )
+    )
     current_locs.copy_(make_current_locs(replay_prefix_lens))
     graph.replay()
     torch.cuda.synchronize()

--- a/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
+++ b/test/registered/unit/model_executor/model_runner_components/test_spec_aux_hidden_state.py
@@ -1,10 +1,13 @@
 import sys
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import pytest
 
 from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state import (
+    SpecAuxHiddenStateConfig,
     _map_muse_target_layer_ids,
+    _resolve_eagle_aux_hidden_state,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 
@@ -31,6 +34,43 @@ def test_muse_target_layer_id_mapping(target_model_type, draft_architecture, exp
             layer_ids=[1, 13, 25, 37, 49],
         )
         == expected
+    )
+
+
+@patch(
+    "sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state."
+    "ModelConfig.from_server_args"
+)
+def test_integrated_mtp_resolves_draft_layer_count(mock_from_server_args):
+    mock_from_server_args.return_value = SimpleNamespace(
+        num_nextn_predict_layers=1,
+        is_hybrid_swa=False,
+        is_deepseek_v4_arch=False,
+    )
+    server_args = SimpleNamespace(
+        speculative_draft_model_path=None,
+        speculative_draft_model_revision=None,
+    )
+    spec_algorithm = SimpleNamespace(
+        is_eagle=lambda: True,
+        is_standalone=lambda: False,
+        is_eagle3=lambda: False,
+    )
+    config = SpecAuxHiddenStateConfig()
+
+    _resolve_eagle_aux_hidden_state(
+        config=config,
+        server_args=server_args,
+        spec_algorithm=spec_algorithm,
+        is_draft_worker=False,
+    )
+
+    assert config.eagle_draft_num_layers == 1
+    mock_from_server_args.assert_called_once_with(
+        server_args,
+        model_path=None,
+        model_revision=None,
+        is_draft_model=True,
     )
 
 

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -711,6 +711,37 @@ class TestEagleConfigurator(CustomTestCase):
         self.assertLessEqual(used, available)
 
     @patch(
+        "sglang.srt.model_executor.pool_configurator.is_float4_e2m1fn_x2",
+        return_value=True,
+    )
+    def test_fp4_eagle_accounts_for_separate_draft_workspace(self, _mock_is_fp4):
+        available = 10_000_000
+        num_layers = 32
+        draft_num_layers = 4
+
+        mr = _make_model_runner(self, num_layers=num_layers)
+        mr.spec_algorithm.is_eagle.return_value = True
+        mr.spec_algorithm.is_none.return_value = False
+        mr.spec_aux_config.eagle_draft_num_layers = draft_num_layers
+
+        with mock_cpu_env(kv_size=1):
+            from sglang.srt.model_executor.pool_configurator import (
+                DefaultPoolConfigurator,
+            )
+
+            cfg = DefaultPoolConfigurator(mr)
+            config = cfg.calculate_pool_sizes(available, page_size=1)
+
+        # Each worker owns packed data/scales for its layers and one shared
+        # FP8 K/V dequant workspace. Target: 9728 B/token; draft: 1664 B/token.
+        actual_bytes_per_token = 9_728 + 1_664
+        self.assertEqual(cfg._cell_size, actual_bytes_per_token)
+        self.assertLessEqual(
+            config.max_total_num_tokens * actual_bytes_per_token,
+            available,
+        )
+
+    @patch(
         "sglang.srt.mem_cache.kv_cache_configurator.calculate_mla_kv_cache_dim",
         return_value=576,
     )


### PR DESCRIPTION
## Motivation

Alternative to #36038. While #36038 routes speculative execution through TRTLLM MHA's native FP4 decode path, this PR preserves FlashInfer speculative prefill by making its dequant workspace GPU-resident and CUDA Graph safe.

With NVFP4 KV cache, FlashInfer's existing workspace path depends on CPU-side prefix metadata. Runtime speculative metadata does not always provide that mirror, so target verification—and, because the draft worker inherits the explicit NVFP4 KV dtype, draft extend—can fail or reuse stale prefill workspace metadata.

## Modifications

- Add a fixed-grid Triton kernel that dequantizes cached NVFP4 prefixes directly into the FP8 workspace at physical KV slots.
- Cover both target verification and `DRAFT_EXTEND_V2`; all request indices, sequence lengths, mappings, and output locations remain device-resident during capture/replay.
- Preserve graph-padding isolation through reserved slot 0, and support noncontiguous current K/V row strides without allocating in the graph.
- Route eager and CUDA Graph draft-extend metadata away from the CPU/page-aligned prefill workspace.
- Add explicit guards for missing speculative metadata/current K/V/write locations and for accidental entry into the CPU workspace without all host mirrors.
- Document and enforce that each workspace row equals this TP rank's `kv_heads * head_dim`.
- Account for the draft worker's independent FP4 dequant workspace when sizing the shared token budget, including integrated MTP checkpoints whose draft path is implicit.
- Extend registered CUDA and CPU regression tests for target/draft graph replay and FP4 EAGLE pool sizing.

## Accuracy Tests

Validation used the current PR source with the SGLang v0.5.18 dependency stack (`torch==2.13.0+cu130`, `flashinfer-python==0.6.17`, `sgl-kernel==0.4.6.post1`) on an RTX PRO 5000 Blackwell (SM120), TP=1.

Exact checkpoint: `RadixArk/Qwen3.8-27B-NVFP4` at `/mnt/data/modelscope-RadixArk-Qwen3.8-27B-NVFP4`. Loader output confirmed `Detected nvfp4 checkpoint`; the target loaded as ModelOpt mixed precision (20.14 GB) and the integrated `Qwen3_5ForCausalLMMTP` draft as ModelOpt mixed precision (5.53 GB).

The #36010 flags were exercised with NVFP4 KV, FlashInfer prefill, TRTLLM MHA decode, NEXTN/MTP 3/1/4, 131072 context, `mem_fraction_static=0.93`, graph BS 1/2, and radix cache disabled.

- Target prefill, target verify, draft decode, and draft extend CUDA Graph capture all completed.
- Graph replay passed at batch sizes 1 and 2; the BS=2 request specifically exercises graph padding.
- Eager speculative target/draft execution passed with CUDA Graph disabled.
- Exact 32K and 128K input-ID requests, each generating 16 tokens, returned HTTP 200 with an observed speculative acceptance length of 4.0.

| Input tokens | CUDA Graph wall time | Eager wall time |
| ---: | ---: | ---: |
| 32,000 | 8.158 s | 5.259 s |
| 128,000 | 39.283 s | 39.248 s |

The original `mem_fraction_static=0.93` startup also succeeds after pricing the independent draft FP4 workspace: the resolved token pool changes from the overcommitted 2,035,968 slots to 1,760,832 slots, leaving 10.30 GB after the target pool and 5.05 GB after the draft pool.

Local regression results:

- `test_nvfp4_kv_cache.py`: 2 passed (target verify and draft extend, bit-exact PyTorch reference plus changed-length CUDA Graph replay).
- `test_pool_configurator.py`: 36 passed, 2 subtests passed.
- `test_spec_aux_hidden_state.py`: 6 passed.
- `compileall` and `git diff --check`: passed.

## Speed Tests and Profiling

SM120 physical-workspace microbenchmark using the exact Qwen3.8 TP=1 KV row (`4 heads * 256 head_dim = 1024` elements), measured over CUDA Graph replay:

| Cached prefix | Target verify / layer | Draft extend / layer | Minimum traffic | Effective bandwidth |
| ---: | ---: | ---: | ---: | ---: |
| 32,000 | 0.229 ms | 0.228 ms | 102.4 MB | ~448 GB/s |
| 128,000 | 1.021 ms | 1.021 ms | 409.6 MB | ~401 GB/s |

For this 64-layer hybrid checkpoint (16 full-attention target layers plus one MTP draft layer), that isolates to approximately 3.89 ms per speculative cycle at 32K and 17.35 ms at 128K. The cost is linear in committed prefix length; reuse/layer batching can be explored separately if long-context profiling warrants it.

## Checklist

- [x] Format code according to the pre-commit guidance.
- [x] Add unit tests according to the testing guidance.
- [x] Update documentation (not applicable; no user-facing API or configuration change).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

Fixes #36010

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32635570522](https://github.com/sgl-project/sglang/actions/runs/32635570522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32635570520](https://github.com/sgl-project/sglang/actions/runs/32635570520)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32635570441](https://github.com/sgl-project/sglang/actions/runs/32635570441)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->