### PR TITLE
[PD] Clean up stale staging watermark subscribers

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1136,6 +1136,15 @@ class CommonKVManager(BaseKVManager):
             keys_to_remove = [
                 k for k in self.connection_pool if k.startswith(failed_bootstrap_addr)
             ]
+            stale_bootstrap_info_groups = [
+                list(self.connection_pool[k]) for k in keys_to_remove
+            ]
+            staging_handler = getattr(self, "_staging_handler", None)
+            subscriber_tokens = (
+                staging_handler.snapshot_wm_subscribers(stale_bootstrap_info_groups)
+                if staging_handler is not None
+                else []
+            )
             # Collect TCP endpoints from cached bootstrap_infos before deletion
             stale_endpoints = set()
             for k in keys_to_remove:
@@ -1153,6 +1162,9 @@ class CommonKVManager(BaseKVManager):
                 self.addr_to_rooms_tracker.get(failed_bootstrap_addr, [])
             )
             self.addr_to_rooms_tracker.pop(failed_bootstrap_addr, None)
+
+        if staging_handler is not None:
+            staging_handler.unregister_wm_subscribers(subscriber_tokens)
 
         for endpoint in stale_endpoints:
             CommonKVReceiver.disconnect_endpoint(endpoint)

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -99,6 +99,8 @@ class DecodeStagingHandler:
         # before unregister runs, but release_room still needs it.
         self._room_to_receiver: dict = {}
         self._wm_subscribers: dict = {}
+        self._wm_subscribers_lock = threading.Lock()
+        self._wm_next_generation = 0
         # room -> chunk_idx -> [(page_start, num_pages, writer_id)] fan-in
         # arrivals; handler-owned so room teardown can purge them.
         self._writer_counts: dict = {}
@@ -108,17 +110,56 @@ class DecodeStagingHandler:
         if receiver is None or not receiver.bootstrap_infos:
             return
         key = tuple(str(bi) for bi in receiver.bootstrap_infos)
-        if key in self._wm_subscribers:
-            return
-
-        self._wm_subscribers[key] = (receiver, session_id)
-        # Watermark state is per prefill session. Send the current value so a
-        # new session's first allocation cannot wait on a missed update.
+        # Receivers are request-scoped. Refresh an existing endpoint entry so
+        # watermark sends never retain a receiver from an earlier request.
+        with self._wm_subscribers_lock:
+            self._wm_next_generation += 1
+            self._wm_subscribers[key] = (
+                receiver,
+                session_id,
+                self._wm_next_generation,
+            )
+        # Watermark state is per prefill session. Send the current value after
+        # publishing the subscriber, but outside the registry lock so a slow
+        # endpoint cannot block registration or failure cleanup.
         self._send_watermark(
             receiver,
             session_id,
             self.staging_allocator.get_watermark(),
         )
+
+    def snapshot_wm_subscribers(self, bootstrap_info_groups) -> list:
+        """Snapshot generation tokens for known watermark subscribers."""
+        keys = [
+            tuple(str(bootstrap_info) for bootstrap_info in bootstrap_infos)
+            for bootstrap_infos in bootstrap_info_groups
+            if bootstrap_infos
+        ]
+        with self._wm_subscribers_lock:
+            return [
+                (key, self._wm_subscribers[key][2])
+                for key in keys
+                if key in self._wm_subscribers
+            ]
+
+    def unregister_wm_subscribers(self, subscriber_tokens) -> int:
+        """Remove watermark subscribers whose generations still match."""
+        removed = 0
+        with self._wm_subscribers_lock:
+            for key, generation in subscriber_tokens:
+                subscriber = self._wm_subscribers.get(key)
+                if subscriber is None or subscriber[2] != generation:
+                    continue
+                _receiver, session_id, _generation = self._wm_subscribers.pop(key)
+                removed += 1
+                logger.info(
+                    "[STAGING] removed watermark subscriber key=%s "
+                    "session=%s generation=%s",
+                    key,
+                    session_id,
+                    generation,
+                )
+        return removed
 
     def num_writers_for(self, receiver) -> int:
         """Compute all TP and PP writers expected for a staging chunk."""
@@ -457,7 +498,9 @@ class DecodeStagingHandler:
         """Free a staging allocation and broadcast watermark to all prefills."""
         self.staging_allocator.free(alloc_id)
         post_wm = self.staging_allocator.get_watermark()
-        for receiver, session_id in list(self._wm_subscribers.values()):
+        with self._wm_subscribers_lock:
+            subscribers = list(self._wm_subscribers.values())
+        for receiver, session_id, _generation in subscribers:
             self._send_watermark(receiver, session_id, post_wm)
 
     @staticmethod

--- a/test/registered/unit/disaggregation/test_disaggregation_wire.py
+++ b/test/registered/unit/disaggregation/test_disaggregation_wire.py
@@ -248,6 +248,8 @@ class TestStagingWatermark(unittest.TestCase):
         handler.staging_allocator = Mock()
         handler.staging_allocator.get_watermark.return_value = (3, 0)
         handler._wm_subscribers = {}
+        handler._wm_subscribers_lock = threading.Lock()
+        handler._wm_next_generation = 0
 
         handler.register_wm_subscriber(receiver, "session-new")
 

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -13,7 +13,10 @@ import numpy as np
 
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import CommonKVManager
-from sglang.srt.disaggregation.common.staging_handler import PrefillStagingContext
+from sglang.srt.disaggregation.common.staging_handler import (
+    DecodeStagingHandler,
+    PrefillStagingContext,
+)
 from sglang.srt.disaggregation.common.utils import pack_int_lists
 from sglang.srt.disaggregation.nixl.conn import (
     KVArgsRegisterInfo,
@@ -776,10 +779,17 @@ class TestNixlNodeFailure(CustomTestCase):
         mgr.connection_lock = threading.Lock()
         # Connection keys are "{addr}_{dp_rank}_{cp_rank}_{tp_rank}".
         mgr.connection_pool = {
-            "10.0.0.1:8998_0_0_0": [{"rank_ip": "10.0.0.1"}],
-            "10.0.0.1:8998_0_0_1": [{"rank_ip": "10.0.0.1"}],
-            "10.0.0.2:8998_0_0_0": [{"rank_ip": "10.0.0.2"}],
+            "10.0.0.1:8998_0_0_0": [{"rank_ip": "10.0.0.1", "rank_port": 1}],
+            "10.0.0.1:8998_0_0_1": [{"rank_ip": "10.0.0.1", "rank_port": 2}],
+            "10.0.0.2:8998_0_0_0": [{"rank_ip": "10.0.0.2", "rank_port": 3}],
         }
+        mgr._staging_handler = object.__new__(DecodeStagingHandler)
+        mgr._staging_handler._wm_subscribers = {}
+        mgr._staging_handler._wm_subscribers_lock = threading.Lock()
+        mgr._staging_handler._wm_next_generation = 0
+        mgr._staging_handler.staging_allocator = SimpleNamespace(
+            get_watermark=lambda: (0, 0)
+        )
         mgr.prefill_info_table = {
             "10.0.0.1:8998": object(),
             "10.0.0.2:8998": object(),
@@ -802,8 +812,34 @@ class TestNixlNodeFailure(CustomTestCase):
 
     def test_handle_node_failure_removes_connections_and_marks_pending_rooms(self):
         mgr = self._make_manager()
+        failed_infos = mgr.connection_pool["10.0.0.1:8998_0_0_0"]
+        healthy_infos = mgr.connection_pool["10.0.0.2:8998_0_0_0"]
+        failed_receiver = SimpleNamespace(bootstrap_infos=failed_infos)
+        healthy_receiver = SimpleNamespace(bootstrap_infos=healthy_infos)
+        mgr._staging_handler.register_wm_subscriber(failed_receiver, "decode-session")
+        mgr._staging_handler.register_wm_subscriber(healthy_receiver, "decode-session")
 
-        mgr._handle_node_failure("10.0.0.1:8998")
+        snapshot_impl = mgr._staging_handler.snapshot_wm_subscribers
+        unregister_impl = mgr._staging_handler.unregister_wm_subscribers
+
+        def snapshot_while_connections_are_present(groups):
+            self.assertIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+            return snapshot_impl(groups)
+
+        def unregister_after_connection_cleanup(tokens):
+            self.assertNotIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
+            return unregister_impl(tokens)
+
+        with patch.object(
+            mgr._staging_handler,
+            "snapshot_wm_subscribers",
+            side_effect=snapshot_while_connections_are_present,
+        ) as snapshot, patch.object(
+            mgr._staging_handler,
+            "unregister_wm_subscribers",
+            side_effect=unregister_after_connection_cleanup,
+        ) as unregister:
+            mgr._handle_node_failure("10.0.0.1:8998")
 
         self.assertNotIn("10.0.0.1:8998_0_0_0", mgr.connection_pool)
         self.assertNotIn("10.0.0.1:8998_0_0_1", mgr.connection_pool)
@@ -816,6 +852,17 @@ class TestNixlNodeFailure(CustomTestCase):
         self.assertIn(3, mgr.failure_records)
         self.assertIn(4, mgr.failure_records)
         self.assertNotIn(5, mgr.failure_records)
+        snapshot.assert_called_once_with(
+            [
+                [{"rank_ip": "10.0.0.1", "rank_port": 1}],
+                [{"rank_ip": "10.0.0.1", "rank_port": 2}],
+            ]
+        )
+        failed_key = tuple(str(info) for info in failed_infos)
+        healthy_key = tuple(str(info) for info in healthy_infos)
+        unregister.assert_called_once_with([(failed_key, 1)])
+        self.assertNotIn(failed_key, mgr._staging_handler._wm_subscribers)
+        self.assertIn(healthy_key, mgr._staging_handler._wm_subscribers)
 
     def test_late_failed_update_does_not_resurrect_cleared_room(self):
         mgr = object.__new__(CommonKVManager)
@@ -824,6 +871,86 @@ class TestNixlNodeFailure(CustomTestCase):
         CommonKVManager.update_status(mgr, 9, KVPoll.Failed)
 
         self.assertNotIn(9, mgr.request_status)
+
+
+class TestStagingWatermarkSubscriberLifecycle(CustomTestCase):
+    def _make_handler(self):
+        handler = object.__new__(DecodeStagingHandler)
+        handler._wm_subscribers = {}
+        handler._wm_subscribers_lock = threading.Lock()
+        handler._wm_next_generation = 0
+        handler.staging_allocator = SimpleNamespace(get_watermark=lambda: (0, 0))
+        return handler
+
+    def test_register_refreshes_receiver_and_bumps_generation(self):
+        handler = self._make_handler()
+        bootstrap_infos = [{"rank_ip": "10.0.0.1", "rank_port": 1234}]
+        old_receiver = SimpleNamespace(bootstrap_infos=bootstrap_infos)
+        new_receiver = SimpleNamespace(bootstrap_infos=bootstrap_infos)
+
+        handler.register_wm_subscriber(old_receiver, "decode-session")
+        key = tuple(str(info) for info in bootstrap_infos)
+        self.assertEqual(
+            handler._wm_subscribers[key],
+            (old_receiver, "decode-session", 1),
+        )
+        handler.register_wm_subscriber(new_receiver, "decode-session")
+
+        self.assertEqual(
+            list(handler._wm_subscribers.values()),
+            [(new_receiver, "decode-session", 2)],
+        )
+
+    def test_snapshot_returns_tokens_only_for_known_subscribers(self):
+        handler = self._make_handler()
+        known_infos = [{"rank_ip": "10.0.0.1", "rank_port": 1234}]
+        unknown_infos = [{"rank_ip": "10.0.0.9", "rank_port": 9999}]
+        receiver = SimpleNamespace(bootstrap_infos=known_infos)
+        handler.register_wm_subscriber(receiver, "decode-session")
+
+        tokens = handler.snapshot_wm_subscribers([known_infos, [], unknown_infos])
+
+        known_key = tuple(str(info) for info in known_infos)
+        self.assertEqual(tokens, [(known_key, 1)])
+
+    def test_unregister_current_token_leaves_healthy_subscriber(self):
+        handler = self._make_handler()
+        failed_infos = [{"rank_ip": "10.0.0.1", "rank_port": 1234}]
+        healthy_infos = [{"rank_ip": "10.0.0.2", "rank_port": 5678}]
+        failed_receiver = SimpleNamespace(bootstrap_infos=failed_infos)
+        healthy_receiver = SimpleNamespace(bootstrap_infos=healthy_infos)
+        handler.register_wm_subscriber(failed_receiver, "failed-session")
+        handler.register_wm_subscriber(healthy_receiver, "healthy-session")
+
+        tokens = handler.snapshot_wm_subscribers([failed_infos])
+        removed = handler.unregister_wm_subscribers(tokens)
+
+        self.assertEqual(removed, 1)
+        failed_key = tuple(str(info) for info in failed_infos)
+        healthy_key = tuple(str(info) for info in healthy_infos)
+        self.assertNotIn(failed_key, handler._wm_subscribers)
+        self.assertEqual(
+            list(handler._wm_subscribers.values()),
+            [(healthy_receiver, "healthy-session", 2)],
+        )
+        self.assertIn(healthy_key, handler._wm_subscribers)
+
+    def test_unregister_stale_token_preserves_reregistered_subscriber(self):
+        handler = self._make_handler()
+        bootstrap_infos = [{"rank_ip": "10.0.0.1", "rank_port": 1234}]
+        old_receiver = SimpleNamespace(bootstrap_infos=bootstrap_infos)
+        new_receiver = SimpleNamespace(bootstrap_infos=bootstrap_infos)
+        handler.register_wm_subscriber(old_receiver, "decode-session")
+        stale_tokens = handler.snapshot_wm_subscribers([bootstrap_infos])
+
+        handler.register_wm_subscriber(new_receiver, "decode-session")
+        removed = handler.unregister_wm_subscribers(stale_tokens)
+
+        self.assertEqual(removed, 0)
+        self.assertEqual(
+            list(handler._wm_subscribers.values()),
+            [(new_receiver, "decode-session", 2)],
+        )
 
 
 class TestNixlStaging(CustomTestCase):


### PR DESCRIPTION
## Motivation

In PD disaggregation with the staging buffer path (used whenever prefill and
decode parallelism differ, e.g. prefill attn-TP=2 → decode TP=1), the decode
side keeps `_wm_subscribers`: a registry of prefill peers that receive
`WATERMARK` broadcasts after each staging ring-buffer free. The registry has
two lifecycle bugs on main:

1. `register_wm_subscriber` only stores the first receiver seen for an
   endpoint key and never refreshes it. Receivers are request-scoped, so after
   a prefill restarts on the same endpoints, watermark sends keep using the
   receiver cached from an earlier request.
2. Nothing ever removes an entry. After a prefill node goes away for good,
   every `_free_and_send_watermark` still sends to the dead peer synchronously
   on the scheduler path; each free can stall the decode scheduler for up to
   `SGLANG_DISAGGREGATION_ZMQ_SEND_TIMEOUT × len(bootstrap_infos)` per dead
   subscriber, and dead entries accumulate across restarts.

A prefill that stops receiving `WATERMARK` cannot advance
`remote_watermarks[session]`, so `is_watermark_ready` never turns true and its
transfer worker requeues chunks forever: in-flight requests hang.

Both NIXL and Mooncake are affected (the registry lives in
`common/staging_handler.py`). Reproduction needs no special hardware: on any
3-GPU host with stock sglang, run prefill TP=2 → decode TP=1 with
`SGLANG_DISAGG_STAGING_BUFFER=1`, kill the prefill under load, and restart it
on the same endpoints.

We hit this in a production heterogeneous-TP PD deployment; the fix below has
been running there (backported to v0.5.16) since 2026-08-12.

## Modifications

- `register_wm_subscriber` now always overwrites the entry and bumps a
  monotonic generation counter, storing `(receiver, session_id, generation)`.
- `CommonKVManager._handle_node_failure` snapshots `(key, generation)` tokens
  for the failed node's endpoint groups while still holding `connection_lock`,
  runs the existing cleanup, then removes only entries whose generation still
  matches the snapshot.

The generation check is needed because cleanup and registration run on
different threads (node-failure handling vs. the decode ZMQ thread handling
`STAGING_REQ`). An unconditional pop by endpoint key can race with a restarted
prefill re-registering on the same endpoints and delete its fresh subscriber,
recreating exactly the hang this cleanup is meant to prevent. With the token
check, the replacement's newer generation survives the old node's cleanup.

Deliberately out of scope, to keep this PR small: making the WATERMARK send
path asynchronous, and NIXL handle-wait timeouts.

Unit tests (CPU-only, in
`test/registered/unit/disaggregation/test_nixl_backend_basic.py`) cover
register/refresh semantics, snapshot/unregister ordering around pool cleanup,
selective removal that leaves healthy peers alone, and the race above: a
cleanup armed with pre-restart tokens must not remove a re-registered
subscriber. The full file passes locally (47 tests).

Production validation of the backported fix, prefill TP=2 → decode TP=1 with
NIXL staging: a static soak (N=3000, C=128, ~10.3 full wraps of a 20 GiB
staging ring) finished 3000/3000 with no send-blocked or watermark-wait
incidents, and a prefill restart under load was cleanly absorbed — decode
dropped the old generation, the restarted prefill registered a new one, and
the run still finished 3000/3000. One caveat for honesty: in that restart
round the new prefill came back on new ephemeral ports, so the same-endpoint
race window is exercised by the unit test rather than the live run.

## Accuracy Tests

Not applicable — control-plane lifecycle change only; no model forward or
kernel code is touched.

## Speed Tests and Profiling

No hot-path overhead expected: the new lock guards short dict operations only,
and `_free_and_send_watermark` copies the subscriber list under the lock but
performs ZMQ sends outside it. Removing dead subscribers strictly reduces
scheduler-path work after a prefill failure.

## Related

Builds on #31217 (staging robustness and failure handling). Replaces my
earlier draft #34738, which cleaned up by endpoint key without the generation
check and was vulnerable to the race described above; now closed in favor of
this PR. Fixes #34737.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33599986154](https://github.com/sgl-project/sglang/actions/runs/33599986154)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33599985933](https://github.com/sgl-project/sglang/actions/runs/33599985933)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33599986037](https://github.com/sgl-project/sglang/actions/runs/33599986037)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->