### PR TITLE
[Spec] Warm multi-request extend attention before serving

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2183,6 +2183,44 @@ async def _send_disaggregation_warmup_requests(
         )
 
 
+def _build_speculative_multi_request_warmup(
+    server_args: ServerArgs,
+    *,
+    dp_size: int,
+    is_generation: bool,
+    max_new_tokens: int,
+) -> Optional[Dict[str, Any]]:
+    """Build a warmup for the non-singleton extend-attention specialization.
+
+    The default request only covers batch size one, which Triton specializes as
+    a constexpr. The first concurrent prefill otherwise compiles the generic
+    runtime-batch kernel after the server has advertised readiness.
+    """
+    if (
+        not is_generation
+        or server_args.speculative_algorithm is None
+        or server_args.max_running_requests == 1
+    ):
+        return None
+
+    # DP dispatch is round-robin, so submit two requests per rank to make every
+    # local scheduler observe a multi-request batch.
+    batch_size = max(2, 2 * dp_size)
+    sampling_params = {
+        "temperature": 0,
+        "max_new_tokens": max_new_tokens,
+    }
+    if server_args.skip_tokenizer_init:
+        return {
+            "input_ids": [[10, 11, 12] for _ in range(batch_size)],
+            "sampling_params": sampling_params,
+        }
+    return {
+        "text": ["The capital city of France is"] * batch_size,
+        "sampling_params": sampling_params,
+    }
+
+
 def _execute_server_warmup(server_args: ServerArgs):
     headers = {}
     url = server_args.url()
@@ -2308,6 +2346,21 @@ def _execute_server_warmup(server_args: ServerArgs):
                 verify=ssl_verify,
             )
             assert res.status_code == 200, f"{res.text}"
+            speculative_batch_warmup = _build_speculative_multi_request_warmup(
+                server_args,
+                dp_size=get_parallel().dp_size,
+                is_generation=model_info["is_generation"],
+                max_new_tokens=max_new_tokens,
+            )
+            if speculative_batch_warmup is not None:
+                res = requests.post(
+                    url + "/generate",
+                    json=speculative_batch_warmup,
+                    headers=headers,
+                    timeout=warmup_timeout if warmup_timeout > 0 else 600,
+                    verify=ssl_verify,
+                )
+                assert res.status_code == 200, f"{res.text}"
             # Skip server_status update for Rust server
             if not envs.SGLANG_RUST_SERVER.get():
                 _global_state.tokenizer_manager.server_status = ServerStatus.Up

--- a/test/registered/unit/entrypoints/test_http_server_warmup.py
+++ b/test/registered/unit/entrypoints/test_http_server_warmup.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST
 from sglang.srt.entrypoints.http_server import (
+    _build_speculative_multi_request_warmup,
     _send_disaggregation_warmup_requests,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -83,6 +84,50 @@ class TestDisaggregationServerWarmup(unittest.IsolatedAsyncioTestCase):
             self.assertEqual(kwargs["json"]["bootstrap_host"], FAKE_BOOTSTRAP_HOST)
             self.assertEqual(kwargs["json"]["bootstrap_room"], dp_rank)
             self.assertFalse(kwargs["ssl"])
+
+
+def make_server_args(**overrides):
+    values = {
+        "max_running_requests": None,
+        "skip_tokenizer_init": False,
+        "speculative_algorithm": "EAGLE",
+    }
+    values.update(overrides)
+    return SimpleNamespace(**values)
+
+
+class TestSpeculativeMultiRequestWarmup(unittest.TestCase):
+    def build(self, server_args=None, *, dp_size=1, is_generation=True):
+        return _build_speculative_multi_request_warmup(
+            server_args or make_server_args(),
+            dp_size=dp_size,
+            is_generation=is_generation,
+            max_new_tokens=8,
+        )
+
+    def test_text_warmup_has_two_requests_per_dp_rank(self):
+        payload = self.build(dp_size=2)
+
+        self.assertEqual(payload["text"], ["The capital city of France is"] * 4)
+        self.assertEqual(
+            payload["sampling_params"],
+            {"temperature": 0, "max_new_tokens": 8},
+        )
+
+    def test_skip_tokenizer_init_uses_input_ids(self):
+        payload = self.build(make_server_args(skip_tokenizer_init=True))
+
+        self.assertNotIn("text", payload)
+        self.assertEqual(payload["input_ids"], [[10, 11, 12], [10, 11, 12]])
+
+    def test_non_speculative_server_is_unchanged(self):
+        self.assertIsNone(self.build(make_server_args(speculative_algorithm=None)))
+
+    def test_single_request_server_skips_multi_request_warmup(self):
+        self.assertIsNone(self.build(make_server_args(max_running_requests=1)))
+
+    def test_non_generation_server_skips_warmup(self):
+        self.assertIsNone(self.build(is_generation=False))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The built-in server warmup submits a single request. Triton's extend-attention kernel specializes that path with a constexpr batch size, while a concurrent prefill uses the generic runtime-batch specialization. On a fresh Triton cache, the latter was first compiled after the server advertised readiness.

For Qwen3.8-27B native MTP on one H20, the first C4 request triggered a 1.07-second serving-time compile of `sglang.kernels.ops.attention.extend_attention._fwd_kernel`; the first-batch maximum TTFT was 10.820 seconds.

## Changes

- Add a second built-in warmup for local speculative generation servers.
- Submit two requests per DP rank so every local scheduler observes a multi-request batch.
- Use token IDs when `--skip-tokenizer-init` is enabled.
- Skip the extra warmup for non-generation, non-speculative, and `--max-running-requests=1` servers.
- Add CPU unit coverage without changing the existing disaggregation warmup behavior.

## Focused fresh-cache result

| Cell | Current main | This PR |
|---|---:|---:|
| First C4 max TTFT | 10.820 s | 3.027 s |
| Reduction | — | 72.0% |
| Triton compiles after ready | 1 | 0 |
| Exact prompt hashes | 4/4 | 4/4 |
| Exact output token IDs | 4/4 | 4/4 |

Configuration: Qwen3.8-27B native MTP, TP1, H20, Triton attention, CUDA graph disabled, 1K input / 32 output, four concurrent requests, and an isolated empty `SGLANG_CACHE_DIR` for each side.

The tradeoff is approximately 10 seconds of additional startup warmup. The work is shifted before readiness rather than paid by the first concurrent production batch.

## Tests

```text
python test/registered/unit/entrypoints/test_http_server_warmup.py -v
# 6 tests passed

pre-commit run --files \
  python/sglang/srt/entrypoints/http_server.py \
  test/registered/unit/entrypoints/test_http_server_warmup.py
# all hooks passed
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32625997677](https://github.com/sgl-project/sglang/actions/runs/32625997677)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32625997588](https://github.com/sgl-project/sglang/actions/runs/32625997588)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32625997659](https://github.com/sgl-project/sglang/actions/runs/32625997659)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->