### PR TITLE
[ROCm] Enable overlap WAR barrier by default

### DIFF
--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -1381,7 +1381,7 @@ SGLang supports various environment variables that can be used to configure its 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_ENABLE_WAR_BARRIER</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Force-enable the write-after-read barrier for the overlap scheduler even when CUDA is not detected (e.g. AMD/ROCm). On CUDA the barrier is always enabled.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Force-enable the write-after-read barrier for the overlap scheduler on platforms where it is not enabled automatically. The barrier is always enabled on CUDA and ROCm.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
     </tr>
     <tr>

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -578,8 +578,8 @@ class Envs:
     # and reducing the impact of sampling overhead on the critical path.
     SGLANG_ENABLE_DELAY_SAMPLE = EnvBool(False)
     # Force-enable the WAR (write-after-read) barrier for the overlap scheduler
-    # even when is_cuda() is False (e.g. AMD/ROCm). On CUDA the barrier is
-    # already enabled regardless of this flag (see start_event_loop).
+    # on platforms where it is not enabled automatically. CUDA and ROCm enable
+    # the barrier regardless of this flag (see start_event_loop).
     SGLANG_ENABLE_WAR_BARRIER = EnvBool(False)
     # Force the WAR barrier to wait for the whole forward instead of the
     # read-done fastpath event.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1727,7 +1727,9 @@ class Scheduler(
                 _redraws += 1
         # The global WAR barrier fences the scheduler's next shared-buffer write
         # on the previous forward's read of the unified memory pool.
-        self._war_barrier_enabled = is_cuda() or envs.SGLANG_ENABLE_WAR_BARRIER.get()
+        self._war_barrier_enabled = (
+            is_cuda() or _is_hip or envs.SGLANG_ENABLE_WAR_BARRIER.get()
+        )
         with self.device_module.StreamContext(self.schedule_stream):
             dispatch_event_loop(self)
 


### PR DESCRIPTION
## Motivation

PR #27967 added `SGLANG_ENABLE_WAR_BARRIER` because the overlap scheduler has the same shared-buffer write-after-read hazard on AMD/ROCm as on CUDA. However, leaving the barrier opt-in means ROCm users must know about an internal correctness flag.

ROCm already uses the CUDA-like stream path in `Scheduler.run_event_loop`, including separate schedule/forward streams and event/stream waits. The WAR barrier should therefore be part of the default HIP behavior, as it is on CUDA.

## Changes

- Enable the overlap-scheduler WAR barrier automatically when HIP is detected.
- Keep `SGLANG_ENABLE_WAR_BARRIER` as a force-enable override for other platforms.
- Update the environment-variable documentation and source comments.

## Behavior

| Platform | Barrier with default environment |
| --- | --- |
| CUDA | Enabled, unchanged |
| ROCm/HIP | Enabled, changed from opt-in |
| Other | Disabled unless `SGLANG_ENABLE_WAR_BARRIER=1`, unchanged |

## Validation

- `git diff --check`
- `python3 -m py_compile python/sglang/srt/managers/scheduler.py python/sglang/srt/environ.py`

No GPU runtime was used for this source-only follow-up.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32627512451](https://github.com/sgl-project/sglang/actions/runs/32627512451)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32627512344](https://github.com/sgl-project/sglang/actions/runs/32627512344)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32627512443](https://github.com/sgl-project/sglang/actions/runs/32627512443)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->