### PR TITLE
[Diffusion] Fetch metadata beside nested LoRA weights

### DIFF
--- a/python/sglang/multimodal_gen/runtime/utils/hf_diffusers_utils.py
+++ b/python/sglang/multimodal_gen/runtime/utils/hf_diffusers_utils.py
@@ -663,12 +663,16 @@ def maybe_download_lora(
         return os.path.join(source.local_path, selected_file)
 
     assert source.repo_id is not None
+    allow_patterns = ["*.json", selected_file]
+    selected_parent = os.path.dirname(selected_file)
+    if selected_parent:
+        allow_patterns.insert(1, f"{selected_parent}/*.json")
     local_path = maybe_download_model(
         source.repo_id,
         local_dir,
         download,
         is_lora=True,
-        allow_patterns=["*.json", selected_file],
+        allow_patterns=allow_patterns,
         revision=resolved_weight.inventory.resolved_revision or source.revision,
     )
     target = os.path.join(local_path, selected_file)

--- a/python/sglang/multimodal_gen/test/unit/test_lora_pipeline.py
+++ b/python/sglang/multimodal_gen/test/unit/test_lora_pipeline.py
@@ -176,6 +176,7 @@ def test_lora_tree_url_selects_one_pinned_weight(tmp_path):
     assert download.call_args.kwargs["revision"] == "immutable-sha"
     assert download.call_args.kwargs["allow_patterns"] == [
         "*.json",
+        "adapters/*.json",
         f"adapters/{weight_name}",
     ]
 


### PR DESCRIPTION
## Summary

- download JSON metadata beside a selected nested LoRA weight, in addition to repository-root metadata
- preserve the existing deterministic single-weight selection and immutable revision pin
- let PEFT adapter_config.json remain effective when publishers organize adapters in subfolders

This is generic repository-layout support; it does not add a model-specific LoRA format or guess missing alpha metadata.

## Size

- existing production code: +5/-1
- new production files: 0
- tests: +1
- docs: 0

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32630219488](https://github.com/sgl-project/sglang/actions/runs/32630219488)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32630219352](https://github.com/sgl-project/sglang/actions/runs/32630219352)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32630219426](https://github.com/sgl-project/sglang/actions/runs/32630219426)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->