### PR TITLE
[DSV4] Add native H16 CuTe sparse prefill backend

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -308,6 +308,33 @@ Two options are available for running DeepSeek-V4 on Hopper:
 
 On these FP8 checkpoints you can additionally enable the all-FP8 **MegaMoE** path on SM90 for higher long-context / large-decode throughput — see the **SM90 (Hopper) FP8 MegaMoE** note in Configuration Tips below.
 
+The experimental native-H16 CuTe DSL sparse-prefill kernel can be selected on
+SM90 when tensor parallelism leaves exactly 16 query heads per rank:
+
+```bash Command
+sglang serve \
+  --model-path <deepseek-v4-model> \
+  --tp 8 \
+  --dsv4-prefill-backend cutedsl_h16 \
+  <other args>
+```
+
+This path requires BF16 query and sparse-workspace tensors with 512-wide Q/K/V
+heads. It is used only for ordinary eager prefill. Speculative forwards and
+prefill CUDA graphs retain the existing FlashMLA implementation. The default
+`auto` backend is unchanged. For C128 layers the combined TOPK width is fixed
+from `--context-length` and
+padded to a multiple of 128, allowing different live chunk lengths to reuse the
+same compiled kernel. The first use of each distinct query-storage-head and
+TOPK bucket triggers its own JIT specialization, so warm up every bucket used
+by the serving configuration before measuring steady state. The padded C4 and
+C128 combined TOPK widths must not exceed 8192; unsupported configurations fail
+during server startup. When the live C128 width is smaller than the fixed width,
+the cached padded tensor adds
+`4 * TQ * fixed_combined_topk` bytes of int32 indices per active prefill chunk
+(for example, TQ=4096 at the 8192 limit adds 128 MiB), in addition to the live
+combined-indices tensor. No extra tensor is allocated when the widths match.
+
 PD-Disagg recipes on H200 may require `docker run --privileged --ulimit memlock=-1`
 (or `--device /dev/infiniband:/dev/infiniband --cap-add IPC_LOCK`) so mooncake
 can discover the IB HCAs; without IB exposure mooncake silently falls back to

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -212,8 +212,7 @@ DeepSeek-V4 uses hybrid compressed attention for long-context efficiency. `SGLAN
 ```bash Command
 SGLANG_DSV4_COMPRESS_STATE_DTYPE=bf16 \
 sglang serve \
-  --model-path deepseek-ai/DeepSeek-V4-Flash \
-  <other args>
+  --model-path deepseek-ai/DeepSeek-V4-Flash
 ```
 
 This BF16 setting applies only to the compressed attention state pools and reduces the GPU memory footprint of each compressed-state slot. It does not change model weight precision or the main KV cache dtype. With automatic pool sizing and no explicit capacity cap, the same memory budget holds more slots, and the startup log shows larger `c4_state` and `c128_state` pool sizes. Keep the default `float32` setting for the most conservative behavior.
@@ -312,11 +311,12 @@ The experimental native-H16 CuTe DSL sparse-prefill kernel can be selected on
 SM90 when tensor parallelism leaves exactly 16 query heads per rank:
 
 ```bash Command
+MODEL_PATH=deepseek-ai/DeepSeek-V4-Flash
+
 sglang serve \
-  --model-path <deepseek-v4-model> \
+  --model-path "$MODEL_PATH" \
   --tp 8 \
-  --dsv4-prefill-backend cutedsl_h16 \
-  <other args>
+  --dsv4-prefill-backend cutedsl_h16
 ```
 
 This path requires BF16 query and sparse-workspace tensors with 512-wide Q/K/V

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1456,6 +1456,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Auto (hardware-dependent)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>flashmla_sparse</code>, <code>flashmla_kv</code>, <code>flashmla_auto</code>, <code>fa3</code>, <code>tilelang</code>, <code>aiter</code>, <code>trtllm</code></td>
     </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--dsv4-prefill-backend`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DeepSeek-V4 sparse prefill backend. The experimental <code>cutedsl_h16</code> path is specialized for BF16, 16 TP-local query heads, and SM90; speculative and CUDA-graph forwards retain FlashMLA. Its first eligible shape triggers JIT compilation, and its padded combined TOPK width is limited to 8192.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>auto</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>auto</code>, <code>flashmla_sparse</code>, <code>flashmla_sparse_q8</code>, <code>cutedsl_h16</code></td>
+    </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--dsa-topk-backend`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the DSA indexer top-k backend. The `torch` backend currently requires `SGLANG_DSA_FUSE_TOPK=false`.</td>

--- a/python/sglang/kernels/ops/attention/dsv4/cute_sparse_mla_h16.py
+++ b/python/sglang/kernels/ops/attention/dsv4/cute_sparse_mla_h16.py
@@ -1,0 +1,889 @@
+"""SM90 CuTe sparse-MLA kernel for SGLang DSV4 TP=8 prefill.
+
+This kernel is specialized for SGLang's DSV4 sparse-prefill contract:
+
+* Q is padded to 64 heads by the model, while only the first 16 are logical.
+* Q/K/V width is 512 (448 NoPE + 64 RoPE; V uses the same 512-wide row).
+* indices address a per-call, rebased BF16 workspace and are already causal.
+* topk_length is per query and attn_sink is a per-head virtual zero-value key.
+
+The kernel below preserves the useful H=16 ``m64n16`` WGMMA decomposition,
+uses a single-pass numerically stable online softmax, rescales FP32 PV state
+when the running maximum changes, and overlaps the next sparse gather with the
+current tile's PV WGMMA retirement.  This tuning variant also reduces the
+transposed KQ fragment in registers: lane-XOR 4/8/16 covers the 16 rows owned
+by each warp and only four per-warp partials per head cross shared memory.
+To match FlashMLA's BF16 probability path, the online maximum covers real KV
+rows only; the virtual attention sink is merged in the final denominator.
+Its four 128-channel QK stages match the DSV4-512 layout, and the reduced
+shared-memory footprint is launched with a two-CTA-per-SM occupancy request.
+
+The public entry point returns only the 16 logical heads, with shape
+``[TQ, 16, 512]``.  Callers must keep other architectures and DSV4 shapes on
+their existing attention backend.
+"""
+
+from __future__ import annotations
+
+import math
+import threading
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.utils as utils
+import torch
+from cutlass.cute.nvgpu import OperandMajorMode, cpasync, warpgroup
+from cutlass.cute.nvgpu.warpgroup import MmaF16BF16Op, OperandSource
+from cutlass.cute.runtime import from_dlpack
+
+from sglang.kernels.ops.attention.dsv4.cutedsl_h16_contract import (
+    DSV4_CUTEDSL_H16_MAX_TOPK as MAX_TOPK,
+)
+from sglang.kernels.ops.attention.dsv4.cutedsl_h16_contract import (
+    DSV4_CUTEDSL_H16_TOPK_ALIGNMENT as TOPK_ALIGNMENT,
+)
+from sglang.srt.utils.custom_op import register_custom_op
+
+# SGLang DSV4 TP=8 contract.
+H = 16
+DQK = 512
+DV = 512
+BN = 64
+NTHR = 128
+NG_QK = 4  # four 128-channel WGMMA groups cover DQK=512
+
+# Interleaved shared-memory layout inherited from the tuned benchmark kernel.
+DB_STRIDE = 72
+# Eight 64-channel chunks.  The original DQK=576 kernel used 72 d-blocks
+# (nine chunks); DSV4-512 only needs 64 and saves 9 KiB of shared memory.
+NB_STRIDE = 64 * DB_STRIDE
+KV_ELEMS = 8 * NB_STRIDE
+CHUNK_SB = 8 * DB_STRIDE * 2
+
+Q_CHUNK = H * 64
+Q_ELEMS = (DQK // 64) * Q_CHUNK
+P_ELEMS = BN * H
+OT_STRIDE = DV + 8
+
+LOG2E = 1.4426950408889634
+NO_SINK = -1.0e30
+# Must stay below the conventional no-sink score after LOG2E conversion so
+# invalid rows can never raise the running maximum during the shuffle reduce.
+INVALID_SCORE = -3.0e38
+
+
+def _gp(addr):
+    return cute.make_ptr(
+        cutlass.BFloat16,
+        addr,
+        cute.AddressSpace.gmem,
+        assumed_align=16,
+    )
+
+
+def _sp(addr):
+    return cute.make_ptr(
+        cutlass.BFloat16,
+        addr,
+        cute.AddressSpace.smem,
+        assumed_align=16,
+    )
+
+
+def _resolve_rows(
+    kv_ptr,
+    idx_ptr,
+    skv_ptr,
+    smask_ptr,
+    base,
+    g8,
+    k8,
+    topk_length,
+    s_kv,
+):
+    """Resolve four gathered rows per 8-thread group and emit validity masks.
+
+    SGLang has already applied causal/request masking before rebasing indices
+    into its flat workspace.  Validity is therefore only:
+      slot < topk_length and 0 <= index < s_kv.
+    """
+
+    ga = []
+    sa = []
+    predicates = []
+    for c in range(4):
+        n = c * 16 + g8
+        slot = base + n
+        row_raw = idx_ptr[slot]
+
+        # Keep the helper branch-free and redirect every invalid address to
+        # row zero. The copy predicate below zero-fills shared memory, while
+        # the emitted score mask removes the row from attention.
+        prefix_ok = cutlass.max(
+            cutlass.min(topk_length - slot, cutlass.Int32(1)), cutlass.Int32(0)
+        )
+        lower_ok = cutlass.max(
+            cutlass.min(row_raw + 1, cutlass.Int32(1)), cutlass.Int32(0)
+        )
+        upper_ok = cutlass.max(
+            cutlass.min(s_kv - row_raw, cutlass.Int32(1)), cutlass.Int32(0)
+        )
+        ok = prefix_ok * lower_ok * upper_ok
+        row = row_raw * ok
+        smask_ptr[n] = ok.to(cutlass.Float32)
+
+        # cp.async predication zero-fills the shared-memory destination for an
+        # invalid row.  Merely redirecting the address to row zero is not
+        # sufficient: a later BF16 ``0 * NaN`` in PV would still propagate a
+        # poisoned value from kv[0].
+        predicate = cute.make_rmem_tensor((1,), cute.Boolean)
+        predicate.fill(ok != cutlass.Int32(0))
+        predicates.append(predicate)
+
+        ga.append((kv_ptr + row * DQK + k8 * 8).toint())
+        sa.append(
+            (skv_ptr + (n // 8) * NB_STRIDE + (n % 8) * 8 + k8 * DB_STRIDE).toint()
+        )
+    return ga, sa, predicates
+
+
+def _prefetch_chunk(ga, sa, predicates, chunk):
+    """Gather one 64-channel chunk for all 64 selected KV rows."""
+
+    g2s = cute.make_copy_atom(
+        cpasync.CopyG2SOp(), cutlass.BFloat16, num_bits_per_copy=128
+    )
+    # Expose the 128-bit BF16 copy atom explicitly as ATOM_V=8 and
+    # ATOM_REST=1.  With a flat (8, 1) profile CuTe DSL 4.6 treats the vector
+    # mode as predicate-visible and rejects our one-predicate-per-row tensor.
+    # The nested profile makes the source/destination
+    # ((ATOM_V, ATOM_REST), REST) and the predicate (ATOM_REST, REST), exactly
+    # matching the documented predicated-copy contract while still emitting
+    # one 16-byte cp.async transaction.
+    l8 = cute.make_layout(((8, 1), 1))
+    for c in range(4):
+        cute.copy(
+            g2s,
+            cute.make_tensor(_gp(ga[c] + chunk * 128), l8),
+            cute.make_tensor(_sp(sa[c] + chunk * CHUNK_SB), l8),
+            pred=predicates[c],
+        )
+
+
+def _prefetch_tile(ga, sa, predicates):
+    for chunk in range(DQK // 64):
+        _prefetch_chunk(ga, sa, predicates, chunk)
+        # Keep each cp.async group to two 64-channel chunks (eight copies per
+        # thread).  Issuing all eight chunks in one uncommitted group exceeds
+        # the conservative Hopper pipeline shape used by the proven kernel.
+        if chunk % 2 == 1:
+            cute.arch.cp_async_commit_group()
+
+
+def _make_qk_fragments(mma_qk, thr_qk, skv_ptr, sq_ptr):
+    """Build four K/Q fragments, each covering 128 of the 512 channels."""
+
+    kv_frags = []
+    q_frags = []
+    channels = DQK // NG_QK
+    dblocks = channels // 8
+    for group in range(NG_QK):
+        s_k = cute.make_tensor(
+            skv_ptr + group * dblocks * DB_STRIDE,
+            cute.make_layout(
+                ((8, 8), (8, dblocks)),
+                stride=((8, NB_STRIDE), (1, DB_STRIDE)),
+            ),
+        )
+        s_q = cute.make_tensor(
+            sq_ptr + group * 2 * Q_CHUNK,
+            cute.make_layout(
+                ((8, 2), (64, 2)),
+                stride=((64, 512), (1, Q_CHUNK)),
+            ),
+        )
+        kv_frags.append(mma_qk.make_fragment_A(thr_qk.partition_A(s_k)))
+        q_frags.append(mma_qk.make_fragment_B(thr_qk.partition_B(s_q)))
+    return kv_frags, q_frags
+
+
+def _make_pv_fragments(mma_pv, thr_pv, skv_ptr):
+    """Build eight 64-channel V fragments and FP32 output accumulators."""
+
+    v_frags = []
+    out_acc = []
+    id_o = cute.make_identity_tensor((64, H))
+    for chunk in range(DV // 64):
+        s_v = cute.make_tensor(
+            skv_ptr + 8 * chunk * DB_STRIDE,
+            cute.make_layout(
+                ((8, 8), (8, 8)),
+                stride=((1, DB_STRIDE), (8, NB_STRIDE)),
+            ),
+        )
+        v_frags.append(mma_pv.make_fragment_A(thr_pv.partition_A(s_v)))
+        acc = cute.make_rmem_tensor(thr_pv.partition_C(id_o).shape, cutlass.Float32)
+        acc.fill(0.0)
+        out_acc.append(acc)
+    return v_frags, out_acc
+
+
+def _issue_qk_staged(mma_qk, score_acc, k_frags, q_frags):
+    """Consume four cp.async groups and enqueue four 128-channel QK MMAs."""
+
+    cute.nvgpu.warpgroup.fence()
+    mma_qk.set(warpgroup.Field.ACCUMULATE, False)
+    for group in range(NG_QK):
+        cute.arch.cp_async_wait_group(NG_QK - 1 - group)
+        cute.arch.barrier()
+        cute.gemm(mma_qk, score_acc, k_frags[group], q_frags[group], score_acc)
+        cute.nvgpu.warpgroup.commit_group()
+        mma_qk.set(warpgroup.Field.ACCUMULATE, True)
+
+
+def _pv_step(mma_pv, out_acc, v_frags, prob_frag, chunk, fence=False):
+    if fence:
+        cute.nvgpu.warpgroup.fence()
+    cute.gemm(
+        mma_pv,
+        out_acc[chunk],
+        v_frags[chunk],
+        prob_frag,
+        out_acc[chunk],
+    )
+    cute.nvgpu.warpgroup.commit_group()
+
+
+def _queue_pv_final(mma_pv, out_acc, v_frags, prob_frag):
+    """Last tile: enqueue PV and let denominator reduction hide its latency."""
+
+    _pv_step(mma_pv, out_acc, v_frags, prob_frag, 0, fence=True)
+    for chunk in range(1, DV // 64):
+        _pv_step(mma_pv, out_acc, v_frags, prob_frag, chunk)
+
+
+def _run_pv_rolling(
+    mma_pv,
+    out_acc,
+    v_frags,
+    prob_frag,
+    next_ga,
+    next_sa,
+    next_predicates,
+):
+    """Accumulate PV while each retired V chunk is refilled for the next tile."""
+
+    _pv_step(mma_pv, out_acc, v_frags, prob_frag, 0, fence=True)
+    _pv_step(mma_pv, out_acc, v_frags, prob_frag, 1)
+    for chunk in range(6):
+        _pv_step(mma_pv, out_acc, v_frags, prob_frag, chunk + 2)
+        cute.nvgpu.warpgroup.wait_group(2)
+        _prefetch_chunk(next_ga, next_sa, next_predicates, chunk)
+        if chunk % 2 == 1:
+            cute.arch.cp_async_commit_group()
+    cute.nvgpu.warpgroup.wait_group(1)
+    _prefetch_chunk(next_ga, next_sa, next_predicates, 6)
+    cute.nvgpu.warpgroup.wait_group(0)
+    _prefetch_chunk(next_ga, next_sa, next_predicates, 7)
+    cute.arch.cp_async_commit_group()
+
+
+def _reduce_kq_fragment_heads(fragment, op):
+    """Reduce the two rows/thread then the 16 rows/warp for four heads.
+
+    The ``m64n16`` accumulator TV layout expected by this reduction is::
+
+      Shape ((4, 8, 4), (2, 2, 2))
+      Stride((128,1,16), (64,8,512))
+
+    The value coordinates therefore flatten as ``v0 + 2*v1 + 4*v2``.
+    ``v1`` selects the two M rows held by a thread while ``(v0,v2)``
+    selects its four N/head values.  For a fixed head, lanes with the same
+    ``lane % 4`` own all 16 rows in a warp, hence XOR 4, 8 and 16.
+    """
+
+    r0 = op(fragment[0], fragment[2])
+    r1 = op(fragment[1], fragment[3])
+    r2 = op(fragment[4], fragment[6])
+    r3 = op(fragment[5], fragment[7])
+    for offset in (4, 8, 16):
+        r0 = op(r0, cute.arch.shuffle_sync_bfly(r0, offset=offset))
+        r1 = op(r1, cute.arch.shuffle_sync_bfly(r1, offset=offset))
+        r2 = op(r2, cute.arch.shuffle_sync_bfly(r2, offset=offset))
+        r3 = op(r3, cute.arch.shuffle_sync_bfly(r3, offset=offset))
+    return r0, r1, r2, r3
+
+
+def _store_output(thr_pv, sout_ptr, inv_den_ptr, out_acc):
+    den_view = cute.make_tensor(inv_den_ptr, cute.make_layout((64, H), stride=(0, 1)))
+    den_frag = thr_pv.partition_C(den_view)
+    for chunk in range(DV // 64):
+        out_view = cute.make_tensor(
+            sout_ptr + chunk * 64,
+            cute.make_layout((64, H), stride=(1, OT_STRIDE)),
+        )
+        out_frag = thr_pv.partition_C(out_view)
+        for i in range(cute.size(out_acc[chunk])):
+            out_frag[i] = (out_acc[chunk][i] * den_frag[i]).to(cutlass.BFloat16)
+
+
+@cute.kernel
+def _kernel(
+    m_q: cute.Tensor,
+    m_kv: cute.Tensor,
+    m_indices: cute.Tensor,
+    m_topk_length: cute.Tensor,
+    m_attn_sink: cute.Tensor,
+    m_out: cute.Tensor,
+    mma_qk: cute.TiledMma,
+    mma_pv: cute.TiledMma,
+    sm_scale: cutlass.Float32,
+    tq: cutlass.Int32,
+    s_kv: cutlass.Int32,
+    topk: cutlass.Constexpr[int],
+):
+    tidx, _, _ = cute.arch.thread_idx()
+    bidx, _, _ = cute.arch.block_idx()
+    # Reverse query order to retain the benchmark kernel's launch behaviour;
+    # unlike the old kernel, this value is not used as a causal KV position.
+    qpos = cutlass.Int32(tq - 1) - cutlass.Int32(bidx)
+    g8 = tidx // 8
+    k8 = tidx % 8
+
+    smem = utils.SmemAllocator()
+    skv_ptr = smem.allocate_array(cutlass.BFloat16, KV_ELEMS, byte_alignment=1024)
+    sq_raw = smem.allocate_array(cutlass.BFloat16, Q_ELEMS, byte_alignment=1024)
+    q_atom = warpgroup.make_smem_layout_atom(
+        warpgroup.SmemLayoutAtomKind.K_SW128, cutlass.BFloat16
+    )
+    sq_ptr = cute.recast_ptr(sq_raw, q_atom.inner)
+    sp_ptr = smem.allocate_array(cutlass.BFloat16, P_ELEMS, byte_alignment=1024)
+    # Four warp-local partials per head replace the old full 64x16 FP32
+    # score spill.  The same allocation is reused for max and denominator.
+    spartial_ptr = smem.allocate_array(cutlass.Float32, 4 * H, byte_alignment=128)
+    smask_ptr = smem.allocate_array(cutlass.Float32, 2 * BN, byte_alignment=128)
+    smax_ptr = smem.allocate_array(cutlass.Float32, H, byte_alignment=128)
+    salpha_ptr = smem.allocate_array(cutlass.Float32, H, byte_alignment=128)
+    ssink_ptr = smem.allocate_array(cutlass.Float32, H, byte_alignment=128)
+    inv_den_ptr = smem.allocate_array(cutlass.Float32, H, byte_alignment=128)
+
+    # The output epilogue aliases the consumed KV staging storage.
+    sout_ptr = skv_ptr
+
+    # Accept SGLang's native compact H64 row without materializing q[:,:16].
+    # Only the first H*DQK elements of each row are loaded.
+    q_ptr = m_q.iterator + qpos * m_q.stride[0]
+    kv_ptr = m_kv.iterator
+    idx_ptr = m_indices.iterator + qpos * topk
+    out_ptr = m_out.iterator + qpos * (H * DV)
+    # Keep malformed metadata from repeating the final tile.  This scalar
+    # clamp lives in the CTA, so it adds no host-side tensor allocation or
+    # auxiliary CUDA launch on the production path.
+    topk_length = cutlass.max(
+        cutlass.min(m_topk_length.iterator[qpos], cutlass.Int32(topk)),
+        cutlass.Int32(0),
+    )
+    # Run one masked tile for length=0 so the launch has a uniform prologue.
+    n_tiles = cutlass.max((topk_length + (BN - 1)) // BN, cutlass.Int32(1))
+    scale_log2 = sm_scale * LOG2E
+
+    # Load the full 16x512 logical Q tile once.  Keep this cp.async group in
+    # flight while the four tile-0 KV groups are issued below.
+    g2s = cute.make_copy_atom(
+        cpasync.CopyG2SOp(), cutlass.BFloat16, num_bits_per_copy=128
+    )
+    l8 = cute.make_layout((8, 1))
+    for j in cutlass.range_constexpr(DQK // 64):
+        linear = (j * NTHR + tidx) * 8
+        head = linear // DQK
+        dim = linear - head * DQK
+        qoff = (dim // 64) * Q_CHUNK + (head // 8) * 512 + (head % 8) * 64 + (dim % 64)
+        qdst = cute.make_ptr(
+            cutlass.BFloat16,
+            (sq_raw + qoff).toint(),
+            cute.AddressSpace.smem,
+            assumed_align=16,
+        )
+        qdst = cute.recast_ptr(qdst, q_atom.inner)
+        cute.copy(
+            g2s,
+            cute.make_tensor(_gp((q_ptr + linear).toint()), l8),
+            cute.make_tensor(qdst, l8),
+        )
+    cute.arch.cp_async_commit_group()
+
+    if tidx < H:
+        sink = m_attn_sink.iterator[tidx] * LOG2E
+        ssink_ptr[tidx] = sink
+        # Match FlashMLA's numerical path: the online maximum is formed from
+        # real K rows only.  The virtual zero-value sink is merged into the
+        # denominator in the epilogue, after P has been rounded to BF16.
+        smax_ptr[tidx] = cutlass.Float32(NO_SINK)
+        salpha_ptr[tidx] = cutlass.Float32(1.0)
+    cute.arch.barrier()
+
+    # Tile-0 prologue.  Together with Q this leaves five committed groups;
+    # _issue_qk_staged(wait=3,2,1,0) releases Q+each 128-channel KV pair just in
+    # time for the corresponding WGMMA.
+    ga0, sa0, predicates0 = _resolve_rows(
+        kv_ptr,
+        idx_ptr,
+        skv_ptr,
+        smask_ptr,
+        cutlass.Int32(0),
+        g8,
+        k8,
+        topk_length,
+        s_kv,
+    )
+    _prefetch_tile(ga0, sa0, predicates0)
+
+    thr_qk = mma_qk.get_slice(tidx)
+    thr_pv = mma_pv.get_slice(tidx)
+    k_frags, q_frags = _make_qk_fragments(mma_qk, thr_qk, skv_ptr, sq_ptr)
+    v_frags, out_acc = _make_pv_fragments(mma_pv, thr_pv, skv_ptr)
+
+    id_score = cute.make_identity_tensor((BN, H))
+    score_acc = cute.make_rmem_tensor(
+        thr_qk.partition_C(id_score).shape, cutlass.Float32
+    )
+    prob_acc = cute.make_rmem_tensor(score_acc.shape, cutlass.BFloat16)
+    sum_acc = cute.make_rmem_tensor(score_acc.shape, cutlass.Float32)
+    sum_acc.fill(0.0)
+
+    # QK writes P through the C-fragment view.  PV must consume the same bytes
+    # through a distinct transposed B-fragment view; the two MMA layouts are
+    # not interchangeable even though they alias the same shared allocation.
+    prob_store_view = cute.make_tensor(
+        sp_ptr,
+        cute.make_layout(((8, 8), (8, 2)), stride=((8, 128), (1, 64))),
+    )
+    prob_store_frag = thr_qk.partition_C(prob_store_view)
+    prob_mma_view = cute.make_tensor(
+        sp_ptr,
+        cute.make_layout(((8, 2), (8, 8)), stride=((1, 64), (8, 128))),
+    )
+    prob_mma_frag = mma_pv.make_fragment_B(thr_pv.partition_B(prob_mma_view))
+
+    max_view = cute.make_tensor(smax_ptr, cute.make_layout((BN, H), stride=(0, 1)))
+    max_frag = thr_qk.partition_C(max_view)
+    alpha_qk_view = cute.make_tensor(
+        salpha_ptr, cute.make_layout((BN, H), stride=(0, 1))
+    )
+    alpha_qk_frag = thr_qk.partition_C(alpha_qk_view)
+    alpha_pv_view = cute.make_tensor(
+        salpha_ptr, cute.make_layout((64, H), stride=(0, 1))
+    )
+    alpha_pv_frag = thr_pv.partition_C(alpha_pv_view)
+
+    mma_pv.set(warpgroup.Field.ACCUMULATE, True)
+
+    # Single-pass stable online softmax.  Each tile updates the per-head max,
+    # rescales the FP32 denominator and PV accumulators by exp(old_max-new_max),
+    # then accumulates probabilities relative to the new max.
+    for tile in cutlass.range(n_tiles, unroll=1):
+        buf = tile % 2
+        next_buf = cutlass.Int32(1) - buf
+        current_mask_ptr = smask_ptr + buf * BN
+
+        _issue_qk_staged(mma_qk, score_acc, k_frags, q_frags)
+
+        # Hide next-index loads/address arithmetic under the four in-flight QK
+        # WGMMA groups.  The alternate mask buffer stays live until next tile.
+        next_base = cutlass.min((tile + 1) * BN, cutlass.Int32(topk - BN))
+        next_ga, next_sa, next_predicates = _resolve_rows(
+            kv_ptr,
+            idx_ptr,
+            skv_ptr,
+            smask_ptr + next_buf * BN,
+            next_base,
+            g8,
+            k8,
+            topk_length,
+            s_kv,
+        )
+
+        cute.nvgpu.warpgroup.wait_group(0)
+
+        current_mask_view = cute.make_tensor(
+            current_mask_ptr, cute.make_layout((BN, H), stride=(1, 0))
+        )
+        current_mask_frag = thr_qk.partition_C(current_mask_view)
+
+        # QK sets ACCUMULATE=False at the next tile, so scale/mask in place.
+        for i in cutlass.range_constexpr(cute.size(score_acc)):
+            score_acc[i] = (
+                score_acc[i] * scale_log2
+                if current_mask_frag[i] > 0.0
+                else cutlass.Float32(INVALID_SCORE)
+            )
+        warp_max = _reduce_kq_fragment_heads(score_acc, cutlass.max)
+        # Keep this dynamic lane branch directly in @cute.kernel so its SSA
+        # values remain in the kernel's traced control flow.
+        lane_partial = tidx % 32
+        if lane_partial < 4:
+            warp_partial = tidx // 32
+            head_lo = 2 * lane_partial
+            spartial_ptr[warp_partial * H + head_lo] = warp_max[0]
+            spartial_ptr[warp_partial * H + head_lo + 1] = warp_max[1]
+            spartial_ptr[warp_partial * H + head_lo + 8] = warp_max[2]
+            spartial_ptr[warp_partial * H + head_lo + 9] = warp_max[3]
+        cute.arch.barrier()
+
+        if tidx < H:
+            old_max = smax_ptr[tidx]
+            new_max = old_max
+            for warp in cutlass.range_constexpr(4):
+                new_max = cutlass.max(new_max, spartial_ptr[warp * H + tidx])
+            smax_ptr[tidx] = new_max
+            salpha_ptr[tidx] = (
+                cutlass.Float32(1.0)
+                if old_max == new_max
+                else cute.math.exp2(old_max - new_max, fastmath=True)
+            )
+        cute.arch.barrier()
+
+        if tile > 0:
+            for i in cutlass.range_constexpr(cute.size(score_acc)):
+                sum_acc[i] = sum_acc[i] * alpha_qk_frag[i]
+
+        # Multiplying after exp2 is essential for length=0: the uniform masked
+        # tile must contribute exactly zero to both P and the denominator.
+        for i in cutlass.range_constexpr(cute.size(score_acc)):
+            p = (
+                cute.math.exp2(score_acc[i] - max_frag[i], fastmath=True)
+                * current_mask_frag[i]
+            )
+            prob_acc[i] = p.to(cutlass.BFloat16)
+            sum_acc[i] = sum_acc[i] + p
+
+        # PV accumulators have a different C-fragment distribution from QK;
+        # use the matching broadcast view when applying the same head alpha.
+        if tile > 0:
+            for i in cutlass.range_constexpr(cute.size(out_acc[0])):
+                alpha = alpha_pv_frag[i]
+                for chunk in cutlass.range_constexpr(DV // 64):
+                    out_acc[chunk][i] = out_acc[chunk][i] * alpha
+
+        cute.autovec_copy(prob_acc, prob_store_frag)
+        cute.arch.fence_proxy("async.shared", space="cta")
+        cute.arch.barrier()
+
+        if tile + 1 < n_tiles:
+            _run_pv_rolling(
+                mma_pv,
+                out_acc,
+                v_frags,
+                prob_mma_frag,
+                next_ga,
+                next_sa,
+                next_predicates,
+            )
+        else:
+            _queue_pv_final(mma_pv, out_acc, v_frags, prob_mma_frag)
+
+    # Reduce the real-key denominator directly from its distributed register
+    # fragment and add the zero-value sink term.  This avoids a second 64x16
+    # FP32 spill plus the old 16-thread serial scan of 64 rows.
+    warp_sum = _reduce_kq_fragment_heads(sum_acc, lambda x, y: x + y)
+    lane_partial = tidx % 32
+    if lane_partial < 4:
+        warp_partial = tidx // 32
+        head_lo = 2 * lane_partial
+        spartial_ptr[warp_partial * H + head_lo] = warp_sum[0]
+        spartial_ptr[warp_partial * H + head_lo + 1] = warp_sum[1]
+        spartial_ptr[warp_partial * H + head_lo + 8] = warp_sum[2]
+        spartial_ptr[warp_partial * H + head_lo + 9] = warp_sum[3]
+    cute.arch.barrier()
+    if tidx < H:
+        denom = cutlass.Float32(0.0)
+        for warp in cutlass.range_constexpr(4):
+            denom = denom + spartial_ptr[warp * H + tidx]
+        sink_mass = (
+            cutlass.Float32(1.0)
+            if ssink_ptr[tidx] == smax_ptr[tidx]
+            else cute.math.exp2(ssink_ptr[tidx] - smax_ptr[tidx], fastmath=True)
+        )
+        denom = denom + sink_mass
+        inv_den_ptr[tidx] = (
+            cutlass.Float32(1.0) / denom if denom > 0.0 else cutlass.Float32(0.0)
+        )
+    cute.arch.barrier()
+
+    # The final tile's PV groups were deliberately left in flight while the
+    # independent denominator reduction ran above.
+    cute.nvgpu.warpgroup.wait_group(0)
+    _store_output(thr_pv, sout_ptr, inv_den_ptr, out_acc)
+    cute.arch.barrier()
+
+    for chunk in cutlass.range_constexpr(DV // 64):
+        linear = chunk * NTHR + tidx
+        head = linear // 64
+        dim = linear % 64
+        cute.autovec_copy(
+            cute.make_tensor(_sp((sout_ptr + head * OT_STRIDE + dim * 8).toint()), l8),
+            cute.make_tensor(_gp((out_ptr + head * DV + dim * 8).toint()), l8),
+        )
+
+
+@cute.jit
+def _launch(
+    m_q: cute.Tensor,
+    m_kv: cute.Tensor,
+    m_indices: cute.Tensor,
+    m_topk_length: cute.Tensor,
+    m_attn_sink: cute.Tensor,
+    m_out: cute.Tensor,
+    tq: cutlass.Int32,
+    s_kv: cutlass.Int32,
+    sm_scale: cutlass.Float32,
+    stream,
+):
+    topk = cute.size(m_indices, mode=[1])
+
+    op_qk = MmaF16BF16Op(
+        cutlass.BFloat16,
+        cutlass.Float32,
+        (64, H, 16),
+        OperandSource.SMEM,
+        OperandMajorMode.K,
+        OperandMajorMode.K,
+    )
+    mma_qk = cute.make_tiled_mma(cute.make_mma_atom(op_qk), (1, 1, 1))
+    op_pv = MmaF16BF16Op(
+        cutlass.BFloat16,
+        cutlass.Float32,
+        (64, H, 16),
+        OperandSource.SMEM,
+        OperandMajorMode.MN,
+        OperandMajorMode.MN,
+    )
+    mma_pv = cute.make_tiled_mma(cute.make_mma_atom(op_pv), (1, 1, 1))
+
+    _kernel(
+        m_q,
+        m_kv,
+        m_indices,
+        m_topk_length,
+        m_attn_sink,
+        m_out,
+        mma_qk,
+        mma_pv,
+        sm_scale,
+        tq,
+        s_kv,
+        topk,
+    ).launch(
+        grid=(tq, 1, 1),
+        block=(NTHR, 1, 1),
+        stream=stream,
+        min_blocks_per_mp=2,
+    )
+
+
+_COMPILE_CACHE: dict[tuple, object] = {}
+_COMPILE_LOCK = threading.Lock()
+
+
+def _validate_inputs(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+    sm_scale: float,
+) -> tuple[
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    torch.Tensor,
+    float,
+]:
+    """Validate the allocation-free DSV4 H16 launch contract."""
+
+    if q.ndim != 3 or q.shape[1] not in (H, 64) or q.shape[2] != DQK:
+        raise ValueError(f"q must have shape [TQ, 16|64, 512], got {tuple(q.shape)}")
+    if kv.ndim != 2 or kv.shape[1] != DQK:
+        raise ValueError(f"kv must have shape [SKV, 512], got {tuple(kv.shape)}")
+    if indices.ndim != 2 or indices.shape[0] != q.shape[0]:
+        raise ValueError(
+            f"indices must have shape [TQ, TOPK], got {tuple(indices.shape)}"
+        )
+    if topk_length.shape != (q.shape[0],):
+        raise ValueError(
+            f"topk_length must have shape [{q.shape[0]}], "
+            f"got {tuple(topk_length.shape)}"
+        )
+    if attn_sink.ndim != 1 or attn_sink.numel() < H:
+        raise ValueError(
+            f"attn_sink must have shape [>=16], got {tuple(attn_sink.shape)}"
+        )
+
+    topk = indices.shape[1]
+    if topk == 0 or topk % TOPK_ALIGNMENT != 0 or topk > MAX_TOPK:
+        raise ValueError(
+            f"TOPK width must be in [{TOPK_ALIGNMENT}, {MAX_TOPK}] and divisible by "
+            f"{TOPK_ALIGNMENT}; got {topk}"
+        )
+    if kv.shape[0] == 0:
+        raise ValueError("kv workspace must contain at least one row")
+
+    tensors = (q, kv, indices, topk_length, attn_sink)
+    if not all(t.is_cuda for t in tensors):
+        raise ValueError(
+            "q, kv, indices, topk_length, and attn_sink must be CUDA tensors"
+        )
+    if not all(t.device == q.device for t in tensors):
+        raise ValueError("all inputs must be on the same CUDA device")
+    if q.dtype != torch.bfloat16 or kv.dtype != torch.bfloat16:
+        raise TypeError(f"q and kv must be bfloat16, got {q.dtype} and {kv.dtype}")
+    if indices.dtype != torch.int32:
+        raise TypeError(f"indices must be int32, got {indices.dtype}")
+    if topk_length.dtype != torch.int32:
+        raise TypeError(f"topk_length must be int32, got {topk_length.dtype}")
+    if attn_sink.dtype != torch.float32:
+        raise TypeError(f"attn_sink must be float32, got {attn_sink.dtype}")
+    if not all(t.is_contiguous() for t in tensors):
+        raise ValueError("all inputs must be contiguous")
+    if q.data_ptr() % 16 != 0 or kv.data_ptr() % 16 != 0:
+        raise ValueError("q and kv storage must be aligned to 16 bytes")
+
+    capability = torch.cuda.get_device_capability(q.device)
+    if capability != (9, 0):
+        raise ValueError(
+            "cute_sparse_mla_h16_fwd requires a Hopper SM90 GPU, "
+            f"got compute capability {capability[0]}.{capability[1]}"
+        )
+
+    scale = float(sm_scale)
+    if not math.isfinite(scale) or scale <= 0.0:
+        raise ValueError(f"sm_scale must be finite and positive, got {sm_scale}")
+
+    # The model may carry a sink padded to the query's H64 storage shape.  A
+    # leading contiguous view keeps only the 16 logical heads without a copy.
+    return q, kv, indices, topk_length, attn_sink[:H], scale
+
+
+def _run_impl(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+    sm_scale: float,
+) -> None:
+    with torch.cuda.device(q.device):
+        # The leading extents are dynamic.  Inner modes, compact strides,
+        # dtypes, and alignment remain specialized in the cached executor.
+        m_q = from_dlpack(q, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
+        m_kv = from_dlpack(kv, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1), divisibility=1
+        )
+        m_indices = from_dlpack(indices, assumed_align=4).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1), divisibility=1
+        )
+        m_topk_length = from_dlpack(
+            topk_length, assumed_align=4
+        ).mark_compact_shape_dynamic(mode=0, stride_order=(0,), divisibility=1)
+        m_attn_sink = from_dlpack(attn_sink, assumed_align=4)
+        m_out = from_dlpack(output, assumed_align=16).mark_compact_shape_dynamic(
+            mode=0, stride_order=(0, 1, 2), divisibility=1
+        )
+        stream = cuda.CUstream(torch.cuda.current_stream(q.device).cuda_stream)
+        tq = cutlass.Int32(int(q.shape[0]))
+        s_kv = cutlass.Int32(int(kv.shape[0]))
+        scale = cutlass.Float32(sm_scale)
+
+        # TQ, KV mode 0, and s_kv are runtime values, so one executor is
+        # reusable across changing chunk and workspace lengths.
+        capability = torch.cuda.get_device_capability(q.device)
+        key = (
+            q.device.index,
+            capability,
+            int(q.shape[1]),
+            int(indices.shape[1]),
+        )
+        fn = _COMPILE_CACHE.get(key)
+        if fn is None:
+            with _COMPILE_LOCK:
+                fn = _COMPILE_CACHE.get(key)
+                if fn is None:
+                    fn = cute.compile(
+                        _launch,
+                        m_q,
+                        m_kv,
+                        m_indices,
+                        m_topk_length,
+                        m_attn_sink,
+                        m_out,
+                        tq,
+                        s_kv,
+                        scale,
+                        stream,
+                    )
+                    _COMPILE_CACHE[key] = fn
+        fn(
+            m_q,
+            m_kv,
+            m_indices,
+            m_topk_length,
+            m_attn_sink,
+            m_out,
+            tq,
+            s_kv,
+            scale,
+            stream,
+        )
+
+
+@register_custom_op(
+    op_name="cute_sparse_mla_h16",
+    mutates_args=["output"],
+)
+def _cute_sparse_mla_h16_op(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+    output: torch.Tensor,
+    sm_scale: float,
+) -> None:
+    _run_impl(q, kv, indices, topk_length, attn_sink, output, sm_scale)
+
+
+def cute_sparse_mla_h16_fwd(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """Run native-H16 DSV4 sparse prefill and return ``[TQ, 16, 512]``."""
+
+    q, kv, indices, topk_length, attn_sink, scale = _validate_inputs(
+        q, kv, indices, topk_length, attn_sink, sm_scale
+    )
+    output = torch.empty((q.shape[0], H, DV), dtype=torch.bfloat16, device=q.device)
+    if q.shape[0] == 0:
+        return output
+
+    _cute_sparse_mla_h16_op(
+        q,
+        kv,
+        indices,
+        topk_length,
+        attn_sink,
+        output,
+        scale,
+    )
+    return output
+
+
+__all__ = ["cute_sparse_mla_h16_fwd"]

--- a/python/sglang/kernels/ops/attention/dsv4/cutedsl_h16_contract.py
+++ b/python/sglang/kernels/ops/attention/dsv4/cutedsl_h16_contract.py
@@ -1,0 +1,8 @@
+"""Lightweight shared shape limits for the DSV4 CuTe DSL H16 path.
+
+Keep this module free of Torch, CUDA, and CuTe imports so runtime validation
+can use the same contract as the lazily imported kernel.
+"""
+
+DSV4_CUTEDSL_H16_TOPK_ALIGNMENT = 128
+DSV4_CUTEDSL_H16_MAX_TOPK = 8192

--- a/python/sglang/srt/layers/attention/attention_registry.py
+++ b/python/sglang/srt/layers/attention/attention_registry.py
@@ -150,6 +150,13 @@ def _create_nsa_compat(runner):
 
 @register_attention_backend("dsv4")
 def create_dsv4_backend(runner):
+    dsv4_prefill_backend = getattr(runner.server_args, "dsv4_prefill_backend", "auto")
+    if dsv4_prefill_backend == "cutedsl_h16" and (_is_npu or _is_hip):
+        platform = "NPU" if _is_npu else "HIP"
+        raise ValueError(
+            "DeepSeek-V4 cutedsl_h16 prefill is supported only on CUDA SM90; "
+            f"it cannot be selected on {platform}."
+        )
     if _is_npu:
         from sglang.srt.hardware_backend.npu.attention.ascend_dsv4_backend import (
             DeepseekV4AscendAttnBackend,

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -18,6 +18,9 @@ from typing import (
 import torch
 import torch.nn.functional as F
 
+from sglang.kernels.ops.attention.dsv4.cutedsl_h16_contract import (
+    DSV4_CUTEDSL_H16_MAX_TOPK,
+)
 from sglang.kernels.ops.attention.dsv4.dequant_k_cache import (
     cast_q_fp8_for_q8kv8_prefill,
     dequantize_k_cache_paged,
@@ -60,6 +63,7 @@ from sglang.srt.layers.attention.dsv4.metadata import (
 from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     SparsePrefillChunkCache,
     SparsePrefillWorkspace,
+    combined_topk_width,
     use_dsv4_q8kv8_sparse_prefill,
 )
 from sglang.srt.layers.attention.verify_mask import (
@@ -69,6 +73,13 @@ from sglang.srt.layers.attention.verify_mask import (
 from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import DeepSeekV4TokenToKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
+    is_in_breakable_cuda_graph,
+)
+from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
+    get_tc_piecewise_forward_context,
+    is_in_tc_piecewise_cuda_graph,
+)
 from sglang.srt.runtime_context import get_parallel, get_spec
 from sglang.srt.speculative.eagle_utils import per_step_draft_out_cache_loc
 from sglang.srt.speculative.ragged_verify import (
@@ -97,6 +108,101 @@ logger = logging.getLogger(__name__)
 SWA_WINDOW = 128
 C4_TOPK = 512
 PAGE_INDEX_ALIGNED_SIZE = 64
+DSV4_CUTEDSL_H16_PREFILL_BACKEND = "cutedsl_h16"
+
+
+def _validate_dsv4_cutedsl_h16_combined_topk(
+    max_context_len: int,
+    c4_topk: int,
+) -> int:
+    """Validate configured sparse widths and return fixed C128 width."""
+    c128_topk = max(max_context_len // 128, 1)
+    combined_widths = {
+        "c4": combined_topk_width(c4_topk, SWA_WINDOW),
+        "c128": combined_topk_width(c128_topk, SWA_WINDOW),
+    }
+    for ratio, width in combined_widths.items():
+        if width > DSV4_CUTEDSL_H16_MAX_TOPK:
+            raise ValueError(
+                f"DeepSeek-V4 cutedsl_h16 {ratio} combined TOPK width "
+                f"{width} exceeds the kernel limit "
+                f"{DSV4_CUTEDSL_H16_MAX_TOPK}. Reduce the configured "
+                "maximum context length or index_topk."
+            )
+    return combined_widths["c128"]
+
+
+def _use_dsv4_cutedsl_h16_sparse_prefill(
+    dsv4_prefill_backend: str,
+    q: torch.Tensor,
+    forward_batch: ForwardBatch,
+    logical_num_heads: int,
+) -> bool:
+    """Select ordinary eager EXTEND and validate the CuTe DSL contract.
+
+    Prefill CUDA graphs and speculative forwards deliberately retain the
+    existing FlashMLA path: the H16 kernel returns a compact 16-head output and
+    does not currently support SGLang's fixed graph output buffers.
+    """
+    if dsv4_prefill_backend != DSV4_CUTEDSL_H16_PREFILL_BACKEND:
+        return False
+    if (
+        forward_batch.forward_mode != ForwardMode.EXTEND
+        or forward_batch._original_forward_mode is not None
+        or forward_batch.tbo_parent_token_range is not None
+    ):
+        return False
+
+    piecewise_context = get_tc_piecewise_forward_context()
+    if (
+        is_in_breakable_cuda_graph()
+        or is_in_tc_piecewise_cuda_graph()
+        or (piecewise_context is not None and piecewise_context.full_graph)
+        or (q.is_cuda and torch.cuda.is_current_stream_capturing())
+    ):
+        return False
+
+    if logical_num_heads != 16:
+        raise ValueError(
+            "DeepSeek-V4 cutedsl_h16 prefill requires exactly 16 TP-local "
+            f"query heads, got {logical_num_heads}."
+        )
+    if (
+        q.ndim != 4
+        or q.shape[1] != 1
+        or q.shape[-2] not in (16, 64)
+        or q.shape[-1] != 512
+        or q.dtype != torch.bfloat16
+    ):
+        raise ValueError(
+            "DeepSeek-V4 cutedsl_h16 prefill requires BF16 Q shaped "
+            f"[TQ, 1, H, 512] with H in {{16, 64}}, got "
+            f"shape={tuple(q.shape)} dtype={q.dtype}."
+        )
+    return True
+
+
+def _run_dsv4_cutedsl_h16_sparse_prefill(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """Lazily load the native-H16 kernel and preserve its Tensor-only API."""
+    from sglang.kernels.ops.attention.dsv4.cute_sparse_mla_h16 import (
+        cute_sparse_mla_h16_fwd,
+    )
+
+    return cute_sparse_mla_h16_fwd(
+        q=q,
+        kv=kv,
+        indices=indices,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+        sm_scale=sm_scale,
+    )
 
 
 def _get_logical_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
@@ -563,6 +669,36 @@ class DeepseekV4AttnBackend(
         self.dsv4_prefill_backend: str = getattr(
             model_runner.server_args, "dsv4_prefill_backend", "auto"
         )
+        self._cutedsl_h16_c128_combined_topk: Optional[int] = None
+        if self.dsv4_prefill_backend == DSV4_CUTEDSL_H16_PREFILL_BACKEND:
+            self._cutedsl_h16_c128_combined_topk = (
+                _validate_dsv4_cutedsl_h16_combined_topk(
+                    self.max_context_len,
+                    self.c4_topk,
+                )
+            )
+            if not is_sm90_supported():
+                raise ValueError(
+                    "DeepSeek-V4 cutedsl_h16 prefill requires SM90 CUDA GPUs."
+                )
+            if model_runner.dtype != torch.bfloat16:
+                raise ValueError(
+                    "DeepSeek-V4 cutedsl_h16 prefill requires a BF16 model, "
+                    f"got {model_runner.dtype}."
+                )
+            local_num_heads = model_runner.model_config.get_num_attention_heads(
+                get_parallel().attn_tp_size
+            )
+            if local_num_heads != 16:
+                raise ValueError(
+                    "DeepSeek-V4 cutedsl_h16 prefill requires exactly 16 "
+                    f"TP-local query heads, got {local_num_heads}."
+                )
+            if self.head_dim_v != 512:
+                raise ValueError(
+                    "DeepSeek-V4 cutedsl_h16 prefill requires d_v=512, "
+                    f"got {self.head_dim_v}."
+                )
         if use_dsv4_q8kv8_sparse_prefill(self.dsv4_prefill_backend):
             if not is_sm90_supported():
                 raise ValueError(
@@ -1688,6 +1824,13 @@ class DeepseekV4AttnBackend(
                     extra_indices.shape[-1] % 64 == 0
                 ), f"{extra_indices.shape=}'s last dimension is not aligned to 64"
 
+            use_cutedsl_h16_prefill = _use_dsv4_cutedsl_h16_sparse_prefill(
+                self.dsv4_prefill_backend,
+                q,
+                forward_batch,
+                layer.tp_q_head_num,
+            )
+
             # sparse_prefill_fwd does not support SM120.
             if (
                 forward_batch.forward_mode.is_extend_without_speculative()
@@ -1695,6 +1838,7 @@ class DeepseekV4AttnBackend(
                 and (
                     q.shape[0] > _LARGE_INDEXER_QUERY_THRESHOLD
                     or envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.get()
+                    or use_cutedsl_h16_prefill
                 )
             ):
                 if use_dsv4_q8kv8_sparse_prefill(self.dsv4_prefill_backend):
@@ -1715,6 +1859,7 @@ class DeepseekV4AttnBackend(
                     token_to_kv_pool=token_to_kv_pool,
                     core_attn_metadata=core_attn_metadata,
                     attn_sink=attn_sink,
+                    use_cutedsl_h16=use_cutedsl_h16_prefill,
                 )
 
             if _is_sm120:
@@ -1771,21 +1916,18 @@ class DeepseekV4AttnBackend(
         token_to_kv_pool: DeepSeekV4TokenToKVPool,
         core_attn_metadata: DSV4AttnMetadata,
         attn_sink: torch.Tensor,
+        use_cutedsl_h16: bool = False,
     ) -> torch.Tensor:
-        """Unified prefill via flash_mla_sparse_fwd. Replaces the
-        flash_mla_with_kvcache call on the extend path. Per request,
-        positionally gathers the SWA window (always) and the compressed
-        cache (c4/c128) into a flat bf16 workspace, then lets
-        flash_mla_sparse_fwd consume the workspace via per-query rebased
-        indices. Chunk-invariant scaffolding lives in
+        """Unified sparse prefill over a compact gathered BF16 workspace.
+
+        Replaces the flash_mla_with_kvcache call on the extend path. Per
+        request, it positionally gathers the SWA window (always) and the
+        compressed cache (c4/c128) into a flat workspace, then dispatches the
+        selected sparse attention kernel over per-query rebased indices.
+        Chunk-invariant scaffolding lives in
         ``self.forward_metadata.sparse_prefill_cache``.
         """
-        if _is_xpu:
-            from sgl_kernel import flash_mla_sparse_fwd
-        else:
-            from sgl_kernel.flash_mla import flash_mla_sparse_fwd
-
-        # q is (b, 1, h_q, d_qk); flash_mla_sparse_fwd takes (s_q, h_q, d_qk).
+        # q is (b, 1, h_q, d_qk); sparse kernels take (s_q, h_q, d_qk).
         q_flat = q.squeeze(1)
 
         cache = self.forward_metadata.sparse_prefill_cache
@@ -1834,8 +1976,13 @@ class DeepseekV4AttnBackend(
                 assert core_attn_metadata.c128_page_indices is not None
                 cache.ensure_c128(core_attn_metadata.c128_page_indices)
                 flat_token_ids = cache.c128_flat_token_ids
-                combined_indices = cache.c128_combined_indices
-                combined_lens = cache.c128_combined_lens
+                if use_cutedsl_h16:
+                    assert self._cutedsl_h16_c128_combined_topk is not None
+                    combined_indices, combined_lens = cache.get_c128_combined(
+                        self._cutedsl_h16_c128_combined_topk
+                    )
+                else:
+                    combined_indices, combined_lens = cache.get_c128_combined()
             else:
                 assert core_attn_metadata.c4_sparse_raw_indices is not None, (
                     "sparse-prefill c4 path requires c4_sparse_raw_indices "
@@ -1869,6 +2016,34 @@ class DeepseekV4AttnBackend(
             out=swa_slice,
         )
         kv = workspace
+
+        if use_cutedsl_h16:
+            if not getattr(self, "_cutedsl_h16_prefill_log_emitted", False):
+                logger.info(
+                    "DSV4_CUTEDSL_H16_SPARSE_PREFILL_HIT layer_id=%s "
+                    "compress_ratio=%s q_shape=%s topk=%s",
+                    layer_id,
+                    compress_ratio,
+                    tuple(q_flat.shape),
+                    combined_indices.shape[1],
+                )
+                self._cutedsl_h16_prefill_log_emitted = True
+            # The model normally supplies an H64 padded Q whose first 16 heads
+            # are live. The kernel returns compact H16; the model's subsequent
+            # ``o[:, :logical_heads, :]`` slice therefore remains valid.
+            return _run_dsv4_cutedsl_h16_sparse_prefill(
+                q=q_flat,
+                kv=kv.squeeze(1),
+                indices=combined_indices,
+                topk_length=combined_lens,
+                attn_sink=attn_sink,
+                sm_scale=self.softmax_scale,
+            )
+
+        if _is_xpu:
+            from sgl_kernel import flash_mla_sparse_fwd
+        else:
+            from sgl_kernel.flash_mla import flash_mla_sparse_fwd
 
         o, _, _ = flash_mla_sparse_fwd(
             q=q_flat,

--- a/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
+++ b/python/sglang/srt/layers/attention/dsv4/sparse_prefill_utils.py
@@ -60,10 +60,18 @@ from sglang.kernels.ops.attention.dsv4.sparse_prefill_kernels import (
 def use_dsv4_q8kv8_sparse_prefill(dsv4_prefill_backend: str = "auto") -> bool:
     """Return whether DeepSeek-V4 sparse prefill should use Q8KV8.
 
-    ``dsv4_prefill_backend`` is the production configuration. The environment
-    variable remains as a debug override while the runtime path is being
-    hardened: truthy values force Q8 on, falsy values force it off.
+    ``dsv4_prefill_backend`` is the production configuration. For the existing
+    auto/FlashMLA choices, the environment variable remains a debug override:
+    truthy values force Q8 on and falsy values force it off. An explicitly
+    selected ``cutedsl_h16`` backend always takes precedence over that legacy
+    override.
     """
+    # An explicitly selected production backend must not be silently replaced
+    # by this legacy debug override. In particular, the native-H16 CuTe path
+    # has a different dtype/head contract from Q8KV8.
+    if dsv4_prefill_backend == "cutedsl_h16":
+        return False
+
     env_value = os.getenv(DSV4_Q8KV8_PREFILL_ENV)
     if env_value is not None:
         return env_value.lower() in {
@@ -324,6 +332,10 @@ class SparsePrefillChunkCache:
     c128_flat_token_ids: Optional[torch.Tensor] = None  # (num_reqs * c128_max,) int32
     c128_combined_indices: Optional[torch.Tensor] = None
     c128_combined_lens: Optional[torch.Tensor] = None
+    # CuTe H16 specializes on the combined TOPK width. Cache any wider,
+    # configuration-sized C128 padding once per prefill chunk so every layer
+    # reuses the same tensor and JIT specialization.
+    c128_padded_combined_indices: dict[int, torch.Tensor] = field(default_factory=dict)
 
     # c4: positional layout of the c4 cache (combine output is per-layer).
     c4_flat_token_ids: Optional[torch.Tensor] = None  # (num_reqs * c4_max,) int32
@@ -455,6 +467,44 @@ class SparsePrefillChunkCache:
         self.c128_flat_token_ids = flat_c128_ids
         self.c128_combined_indices = combined_indices
         self.c128_combined_lens = combined_lens
+
+    def get_c128_combined(
+        self, padded_width: Optional[int] = None
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        """Return C128 metadata, optionally padded to a fixed aligned width.
+
+        The live combine remains unchanged for FlashMLA/Q8KV8. CuTe H16 passes
+        the width derived from the configured maximum context length, avoiding
+        a new compiled kernel when live chunks (for example 31K and 40K) have
+        different C128 extents.
+        """
+        assert self.c128_combined_indices is not None
+        assert self.c128_combined_lens is not None
+        if padded_width is None or padded_width == self.c128_combined_indices.shape[1]:
+            return self.c128_combined_indices, self.c128_combined_lens
+        if padded_width < self.c128_combined_indices.shape[1]:
+            raise ValueError(
+                f"C128 padded width {padded_width} is smaller than live width "
+                f"{self.c128_combined_indices.shape[1]}"
+            )
+        if padded_width % SPARSE_PREFILL_TOPK_ALIGNMENT != 0:
+            raise ValueError(
+                f"C128 padded width {padded_width} must be aligned to "
+                f"{SPARSE_PREFILL_TOPK_ALIGNMENT}"
+            )
+
+        padded = self.c128_padded_combined_indices.get(padded_width)
+        if padded is None:
+            live_width = self.c128_combined_indices.shape[1]
+            padded = torch.full(
+                (self.num_qo_tokens, padded_width),
+                -1,
+                dtype=torch.int32,
+                device=self.c128_combined_indices.device,
+            )
+            padded[:, :live_width].copy_(self.c128_combined_indices)
+            self.c128_padded_combined_indices[padded_width] = padded
+        return padded, self.c128_combined_lens
 
     def ensure_c4(
         self,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -378,6 +378,7 @@ DSV4_PREFILL_BACKEND_CHOICES = [
     "auto",
     "flashmla_sparse",
     "flashmla_sparse_q8",
+    "cutedsl_h16",
 ]
 
 DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
@@ -1836,7 +1837,11 @@ class ServerArgs:
             help=(
                 "DeepSeek-V4 sparse prefill backend. 'auto' and "
                 "'flashmla_sparse' use the existing BF16 sparse prefill path; "
-                "'flashmla_sparse_q8' enables the Q8KV8 sparse prefill path."
+                "'flashmla_sparse_q8' enables the Q8KV8 sparse prefill path; "
+                "'cutedsl_h16' enables the experimental BF16 CuTe DSL path "
+                "specialized for 16 TP-local query heads on SM90. The CuTe DSL "
+                "path applies only to non-speculative eager prefill; CUDA-graph "
+                "and speculative paths keep the existing FlashMLA backend."
             ),
             choices=DSV4_PREFILL_BACKEND_CHOICES,
         ),

--- a/test/registered/kernels/benchmark/attention/bench_cute_sparse_mla_h16_sm90.py
+++ b/test/registered/kernels/benchmark/attention/bench_cute_sparse_mla_h16_sm90.py
@@ -1,0 +1,193 @@
+"""DSV4 sparse-prefill public-path CUDA stream latency on SM90.
+
+CUDA events time each provider's public API call; this is neither host
+wall-clock allocation latency nor a raw-kernel-only measurement. FlashMLA BF16
+and Q8 allocate H64 output plus max-logit/LSE auxiliaries through their public
+contracts, while CuTe allocates one compact H16 output. Those contract-level
+differences are intentionally part of the result.
+
+Q8 inputs are quantized before timing. Its Q cast and DSV4 KV
+gather/dequantize/requantize pipeline are excluded, so Q8 numbers represent a
+prequantized attention call rather than backend or end-to-end latency.
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import torch
+import triton
+import triton.testing
+
+from sglang.kernels.jit.benchmark.utils import (
+    get_benchmark_range,
+    run_benchmark_no_cudagraph,
+)
+from sglang.srt.utils import is_sm90_supported
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=240, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+
+H_LOGICAL = 16
+H_FLASHMLA = 64
+D_QK = 512
+D_V = 512
+
+CASES = get_benchmark_range(
+    full_range=[
+        (4096, 49152, 128),
+        (4096, 49152, 384),
+        (4096, 49152, 512),
+        (4096, 49152, 640),
+        (4096, 49152, 1152),
+    ],
+    ci_range=[
+        (64, 2048, 128),
+        (64, 2048, 512),
+        (64, 2048, 640),
+        (64, 2048, 1152),
+    ],
+)
+
+
+def _make_case(tq: int, skv: int, topk: int):
+    generator = torch.Generator(device="cuda").manual_seed(1000 + skv + topk)
+    q = (
+        torch.randn(
+            (tq, H_LOGICAL, D_QK),
+            dtype=torch.float32,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.1
+    ).to(torch.bfloat16)
+    kv = (
+        torch.randn(
+            (skv, 1, D_QK),
+            dtype=torch.float32,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.1
+    ).to(torch.bfloat16)
+    indices = torch.randint(
+        0,
+        skv,
+        (tq, 1, topk),
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )
+    topk_length = torch.full((tq,), topk, dtype=torch.int32, device="cuda")
+    sink = torch.linspace(0.05, 0.90, H_LOGICAL, dtype=torch.float32, device="cuda")
+
+    q_padded = (
+        torch.randn(
+            (tq, H_FLASHMLA, D_QK),
+            dtype=torch.float32,
+            device="cuda",
+            generator=generator,
+        )
+        * 0.1
+    ).to(torch.bfloat16)
+    q_padded[:, :H_LOGICAL].copy_(q)
+    sink_padded = torch.linspace(
+        -0.5, 0.9, H_FLASHMLA, dtype=torch.float32, device="cuda"
+    )
+    sink_padded[:H_LOGICAL].copy_(sink)
+    return q, q_padded, kv, indices, topk_length, sink, sink_padded
+
+
+@triton.testing.perf_report(
+    triton.testing.Benchmark(
+        x_names=["tq", "skv", "topk"],
+        x_vals=CASES,
+        line_arg="provider",
+        line_vals=["flashmla_h64", "flashmla_q8_h64", "cute_h16"],
+        line_names=[
+            "FlashMLA BF16 H64 public (out + max + LSE)",
+            "FlashMLA Q8 H64 public, prequantized (out + max + LSE)",
+            "CuTe BF16 H16 public (compact out only)",
+        ],
+        styles=[("orange", "--"), ("green", "-."), ("blue", "-")],
+        ylabel="public-path CUDA stream latency (us)",
+        plot_name="dsv4-cute-sparse-mla-h16-sm90-performance",
+        args={},
+    )
+)
+def bench_cute_sparse_mla_h16_sm90(tq: int, skv: int, topk: int, provider: str):
+    if not is_sm90_supported():
+        raise RuntimeError("native H16 CuTe sparse MLA benchmark requires SM90 CUDA")
+
+    _q, q_padded, kv, indices, topk_length, _sink, sink_padded = _make_case(
+        tq, skv, topk
+    )
+    kv_compact = kv.squeeze(1)
+    indices_compact = indices.squeeze(1)
+    sm_scale = D_QK**-0.5
+
+    if provider == "flashmla_h64":
+        from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+        def fn():
+            return flash_mla_sparse_fwd(
+                q=q_padded,
+                kv=kv,
+                indices=indices,
+                sm_scale=sm_scale,
+                d_v=D_V,
+                attn_sink=sink_padded,
+                topk_length=topk_length,
+            )
+
+    elif provider == "flashmla_q8_h64":
+        from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
+            sparse_mla_q8kv8_prefill_fwd,
+        )
+
+        q_fp8 = q_padded.to(torch.float8_e4m3fn)
+        kv_fp8 = kv.to(torch.float8_e4m3fn)
+        identity_scale = torch.ones((), dtype=torch.float32, device="cuda")
+
+        def fn():
+            return sparse_mla_q8kv8_prefill_fwd(
+                q=q_fp8,
+                kv=kv_fp8,
+                indices=indices,
+                sm_scale=sm_scale,
+                q_scale=identity_scale,
+                kv_scale=identity_scale,
+                d_v=D_V,
+                attn_sink=sink_padded,
+                topk_length=topk_length,
+            )
+
+    elif provider == "cute_h16":
+        cute_h16 = importlib.import_module(
+            "sglang.kernels.ops.attention.dsv4.cute_sparse_mla_h16"
+        )
+
+        def fn():
+            return cute_h16.cute_sparse_mla_h16_fwd(
+                q=q_padded,
+                kv=kv_compact,
+                indices=indices_compact,
+                topk_length=topk_length,
+                attn_sink=sink_padded,
+                sm_scale=sm_scale,
+            )
+
+    else:
+        raise ValueError(f"unknown provider: {provider}")
+
+    # CUDA-event timing retains public-wrapper work/synchronization issued on
+    # the stream, but must not be interpreted as host wall-clock or raw-kernel
+    # latency; see the module docstring for each provider's output contract.
+    return run_benchmark_no_cudagraph(fn)
+
+
+if __name__ == "__main__":
+    bench_cute_sparse_mla_h16_sm90.run(print_data=True)

--- a/test/registered/kernels/ops/attention/test_cute_sparse_mla_h16_sm90.py
+++ b/test/registered/kernels/ops/attention/test_cute_sparse_mla_h16_sm90.py
@@ -1,0 +1,786 @@
+from __future__ import annotations
+
+import importlib
+import math
+
+import pytest
+import torch
+
+from sglang.srt.utils import is_sm90_supported
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=420, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+
+H_LOGICAL = 16
+H_FLASHMLA = 64
+D_QK = 512
+D_V = 512
+NO_SINK = -1.0e30
+
+# The fixed-input H20 comparison against FlashMLA observed <=2.44e-4 maximum
+# and roughly 6.5e-7 mean absolute error. Keep the elementwise limit within a
+# small number of BF16 output ULPs and independently lock down aggregate drift.
+MAX_ABS_ERROR = 5.0e-4
+MAX_MEAN_ABS_ERROR = 5.0e-6
+STRESS_MAX_ABS_ERROR = 2.0e-3
+STRESS_MAX_MEAN_ABS_ERROR = 1.0e-4
+TORCH_REF_MAX_ABS_ERROR = 1.0e-3
+# The CPU-FP32 oracle intentionally includes the BF16 WGMMA and final-output
+# rounding gap. On SM90 that active-row mean is about 5.4e-5 even when the
+# CuTe result is bitwise identical to FlashMLA, so retain margin without
+# weakening the much tighter implementation-to-implementation parity gates.
+TORCH_REF_MAX_MEAN_ABS_ERROR = 1.0e-4
+
+
+def _sm90_available() -> bool:
+    return is_sm90_supported()
+
+
+requires_sm90 = pytest.mark.skipif(
+    not _sm90_available(), reason="native H16 CuTe sparse MLA requires SM90 CUDA"
+)
+
+
+def _load_implementations():
+    # Keep the CuTe DSL import inside an SM90-gated test. This lets CPU-only
+    # collection succeed while making a missing GPU dependency fail on the
+    # runner where the kernel is expected to execute.
+    cute_h16 = importlib.import_module(
+        "sglang.kernels.ops.attention.dsv4.cute_sparse_mla_h16"
+    )
+    from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+    return cute_h16, flash_mla_sparse_fwd
+
+
+def _make_case(
+    *,
+    tq: int,
+    skv: int,
+    topk: int,
+    lengths: list[int],
+    seed: int,
+    invalid_in_prefix: bool = True,
+    std: float = 0.1,
+):
+    assert len(lengths) == tq
+    assert all(0 <= length <= topk for length in lengths)
+
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    q = (
+        torch.randn(
+            (tq, H_LOGICAL, D_QK),
+            dtype=torch.float32,
+            device="cuda",
+            generator=generator,
+        )
+        * std
+    ).to(torch.bfloat16)
+    kv = (
+        torch.randn(
+            (skv, 1, D_QK),
+            dtype=torch.float32,
+            device="cuda",
+            generator=generator,
+        )
+        * std
+    ).to(torch.bfloat16)
+    indices = torch.randint(
+        0,
+        skv,
+        (tq, 1, topk),
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )
+    topk_length = torch.tensor(lengths, dtype=torch.int32, device="cuda")
+
+    # Garbage outside the declared prefix must never be gathered. Alternate
+    # negative and high sentinels so both invalid-index predicates execute.
+    for row, length in enumerate(lengths):
+        # Keep at least one active row ID above the signed-int16 range when the
+        # workspace is large enough; rebased production workspaces commonly
+        # exceed 32K rows.
+        if length > 0 and skv > 32768:
+            indices[row, 0, 0] = 32768 + (row * 97) % (skv - 32768)
+        if length < topk:
+            tail = torch.arange(topk - length, device="cuda")
+            indices[row, 0, length:] = torch.where(
+                tail % 2 == 0,
+                torch.full_like(tail, -1),
+                torch.full_like(tail, skv + 17),
+            ).to(torch.int32)
+
+        # FlashMLA documents both -1 and values >= SKV as invalid even when
+        # they occur inside topk_length. Exercise that contract independently
+        # from the trailing-prefix mask.
+        if invalid_in_prefix and length >= 4:
+            indices[row, 0, 1] = -1
+            indices[row, 0, 3] = skv + 31
+
+    attn_sink = torch.linspace(
+        0.05, 0.90, H_LOGICAL, dtype=torch.float32, device="cuda"
+    )
+    return q, kv, indices, topk_length, attn_sink
+
+
+def _length_boundaries(topk: int) -> list[int]:
+    candidates = (0, 1, 63, 64, 65, 127, 128, 129, topk - 1, topk)
+    return [
+        value
+        for position, value in enumerate(candidates)
+        if 0 <= value <= topk and value not in candidates[:position]
+    ]
+
+
+def _pad_flashmla_inputs(
+    q: torch.Tensor, attn_sink: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    q_padded = torch.zeros(
+        (q.shape[0], H_FLASHMLA, D_QK), dtype=q.dtype, device=q.device
+    )
+    q_padded[:, :H_LOGICAL].copy_(q)
+    sink_padded = torch.full(
+        (H_FLASHMLA,), NO_SINK, dtype=torch.float32, device=q.device
+    )
+    sink_padded[:H_LOGICAL].copy_(attn_sink)
+    return q_padded, sink_padded
+
+
+def _unaligned_contiguous_copy(tensor: torch.Tensor) -> torch.Tensor:
+    storage = torch.empty(tensor.numel() + 1, dtype=tensor.dtype, device=tensor.device)
+    result = storage[1:].view(tensor.shape)
+    result.copy_(tensor)
+    assert result.is_contiguous()
+    assert result.data_ptr() % 16 != 0
+    return result
+
+
+def _flashmla_reference(
+    flash_mla_sparse_fwd,
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+) -> torch.Tensor:
+    # FlashMLA's SM90 sparse-prefill WGMMA specialization pays for an H64
+    # query tile. Explicit padding makes that baseline visible while keeping
+    # the first 16 heads numerically identical to the production TP=8 input.
+    q_padded, sink_padded = _pad_flashmla_inputs(q, attn_sink)
+    out, _, _ = flash_mla_sparse_fwd(
+        q=q_padded,
+        kv=kv,
+        indices=indices,
+        sm_scale=D_QK**-0.5,
+        d_v=D_V,
+        attn_sink=sink_padded,
+        topk_length=topk_length,
+    )
+    return out[:, :H_LOGICAL]
+
+
+def _torch_fp32_reference(
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: torch.Tensor,
+    attn_sink: torch.Tensor,
+    sm_scale: float,
+) -> torch.Tensor:
+    """Small, direct FP32 definition of sparse attention plus a zero-V sink."""
+
+    assert q.ndim == 3 and q.shape[1:] == (H_LOGICAL, D_QK)
+    assert kv.ndim == 2 and kv.shape[1] == D_QK
+    assert indices.ndim == 2 and indices.shape[0] == q.shape[0]
+
+    # CPU float32 keeps this oracle independent from both SM90 attention
+    # implementations and from any CUDA TF32 matmul policy on the test runner.
+    q = q.detach().cpu().float()
+    kv = kv.detach().cpu().float()
+    indices = indices.detach().cpu()
+    topk_length = topk_length.detach().cpu()
+    attn_sink = attn_sink.detach().cpu().float()
+
+    rows = []
+    for row in range(q.shape[0]):
+        # Only the declared prefix participates. Invalid IDs inside that prefix
+        # are absent from both the softmax denominator and the value reduction.
+        length = int(topk_length[row].item())
+        prefix = indices[row, :length].long()
+        valid_ids = prefix[(prefix >= 0) & (prefix < kv.shape[0])]
+        selected_kv = kv[valid_ids]
+
+        q_row = q[row]
+        logits = torch.matmul(q_row, selected_kv.T) * sm_scale
+        # The virtual sink is appended after all valid key logits. Its value is
+        # exactly zero, so its probability contributes only to normalization.
+        logits_with_sink = torch.cat((logits, attn_sink.unsqueeze(1)), dim=1)
+        key_prob = torch.softmax(logits_with_sink, dim=1)[:, : valid_ids.numel()]
+        rows.append(torch.matmul(key_prob, selected_kv))
+
+    return torch.stack(rows)
+
+
+def _assert_matches_flashmla(
+    actual: torch.Tensor,
+    expected: torch.Tensor,
+    *,
+    topk_length: torch.Tensor,
+    max_abs_error: float = MAX_ABS_ERROR,
+    max_mean_abs_error: float = MAX_MEAN_ABS_ERROR,
+) -> None:
+    assert actual.shape == expected.shape
+    assert actual.shape[1:] == (H_LOGICAL, D_V)
+    assert actual.dtype == expected.dtype == torch.bfloat16
+    assert torch.isfinite(actual.float()).all()
+    assert torch.isfinite(expected.float()).all()
+
+    diff = (actual.float() - expected.float()).abs()
+    assert diff.max().item() <= max_abs_error
+    assert diff.mean().item() <= max_mean_abs_error
+    torch.testing.assert_close(
+        actual.float(), expected.float(), atol=max_abs_error, rtol=1.0e-3
+    )
+
+    # With no real key, the positive virtual sink has a zero value vector, so
+    # both implementations must return exact zero rather than NaN/Inf.
+    zero_rows = topk_length == 0
+    if bool(zero_rows.any()):
+        assert torch.count_nonzero(actual[zero_rows]).item() == 0
+        assert torch.count_nonzero(expected[zero_rows]).item() == 0
+
+
+@requires_sm90
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_matches_independent_torch_fp32_reference():
+    """Check the mathematical contract without using FlashMLA as the oracle."""
+
+    cute_h16 = importlib.import_module(
+        "sglang.kernels.ops.attention.dsv4.cute_sparse_mla_h16"
+    )
+    tq, skv, topk = 4, 17, 128
+    q, kv, indices, topk_length, attn_sink = _make_case(
+        tq=tq,
+        skv=skv,
+        topk=topk,
+        lengths=[0, 5, 6, 8],
+        seed=77,
+        invalid_in_prefix=False,
+    )
+
+    # Valid-looking data after each prefix catches implementations that ignore
+    # topk_length. The active prefixes cover mixed invalid IDs, an all-invalid
+    # row, duplicates, and both negative and high out-of-bounds sentinels.
+    indices.fill_(10)
+    indices[1, 0, :5] = torch.tensor(
+        [2, -1, 7, skv + 3, 4], dtype=torch.int32, device="cuda"
+    )
+    indices[2, 0, :6] = torch.tensor(
+        [-1, skv, -7, skv + 1, -1, skv + 99],
+        dtype=torch.int32,
+        device="cuda",
+    )
+    indices[3, 0, :8] = torch.tensor(
+        [1, 3, 3, 5, -1, skv + 2, 8, 2],
+        dtype=torch.int32,
+        device="cuda",
+    )
+
+    q_padded, sink_padded = _pad_flashmla_inputs(q, attn_sink)
+    kv_compact = kv.squeeze(1)
+    indices_compact = indices.squeeze(1)
+    sm_scale = D_QK**-0.5
+    actual = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q_padded,
+        kv=kv_compact,
+        indices=indices_compact,
+        topk_length=topk_length,
+        attn_sink=sink_padded,
+        sm_scale=sm_scale,
+    )
+    expected_fp32 = _torch_fp32_reference(
+        q=q,
+        kv=kv_compact,
+        indices=indices_compact,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+        sm_scale=sm_scale,
+    )
+    torch.cuda.synchronize()
+
+    assert actual.shape == expected_fp32.shape == (tq, H_LOGICAL, D_V)
+    assert actual.dtype == torch.bfloat16
+    assert expected_fp32.dtype == torch.float32
+    assert torch.isfinite(actual.float()).all()
+    assert torch.isfinite(expected_fp32).all()
+    # Rows with zero valid keys contain only the zero-valued virtual sink.
+    assert torch.count_nonzero(actual[[0, 2]]).item() == 0
+    assert torch.count_nonzero(expected_fp32[[0, 2]]).item() == 0
+    assert torch.count_nonzero(expected_fp32[[1, 3]]).item() > 0
+
+    actual_fp32 = actual.float().cpu()
+    diff = (actual_fp32 - expected_fp32).abs()
+    # This compares BF16 WGMMA/output rounding directly with an FP32 definition;
+    # the max gate is a few BF16 ULPs at this test's ~1e-2 output scale, while
+    # the mean gate prevents a broad low-amplitude drift from hiding underneath.
+    assert diff.max().item() <= TORCH_REF_MAX_ABS_ERROR
+    assert diff[[1, 3]].mean().item() <= TORCH_REF_MAX_MEAN_ABS_ERROR
+    torch.testing.assert_close(
+        actual_fp32, expected_fp32, atol=TORCH_REF_MAX_ABS_ERROR, rtol=1.0e-2
+    )
+
+
+@requires_sm90
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_multitile_matches_independent_torch_fp32_reference():
+    """Check multi-tile online softmax against an implementation-independent oracle."""
+
+    cute_h16 = importlib.import_module(
+        "sglang.kernels.ops.attention.dsv4.cute_sparse_mla_h16"
+    )
+    tq, skv, topk = 3, 521, 256
+    q, kv, indices, topk_length, _ = _make_case(
+        tq=tq,
+        skv=skv,
+        topk=topk,
+        lengths=[129, 191, 256],
+        seed=88,
+        invalid_in_prefix=False,
+        std=0.25,
+    )
+    kv_compact = kv.squeeze(1)
+    indices_compact = indices.squeeze(1)
+    sm_scale = D_QK**-0.5
+
+    # Make every later 64-row tile raise head 0's running maximum. This forces
+    # the online-softmax path to rescale already accumulated PV state.
+    generator = torch.Generator(device="cuda").manual_seed(89)
+    for row in range(tq):
+        selected = torch.randperm(skv, device="cuda", generator=generator)[:topk]
+        scores = torch.mv(kv_compact[selected].float(), q[row, 0].float()) * sm_scale
+        indices_compact[row].copy_(selected[torch.argsort(scores)].to(torch.int32))
+
+    full_scores = (
+        torch.mv(kv_compact[indices_compact[-1].long()].float(), q[-1, 0].float())
+        * sm_scale
+    )
+    tile_max = full_scores.view(-1, 64).amax(dim=1)
+    assert bool(torch.all(tile_max[1:] > tile_max[:-1]))
+
+    sink_cases = {
+        "disabled": NO_SINK,
+        "negative": -2.0,
+        "dominant": 2.0,
+    }
+    for name, sink_score in sink_cases.items():
+        attn_sink = torch.full(
+            (H_LOGICAL,), sink_score, dtype=torch.float32, device="cuda"
+        )
+        q_padded, sink_padded = _pad_flashmla_inputs(q, attn_sink)
+        actual = cute_h16.cute_sparse_mla_h16_fwd(
+            q=q_padded,
+            kv=kv_compact,
+            indices=indices_compact,
+            topk_length=topk_length,
+            attn_sink=sink_padded,
+            sm_scale=sm_scale,
+        )
+        expected_fp32 = _torch_fp32_reference(
+            q=q,
+            kv=kv_compact,
+            indices=indices_compact,
+            topk_length=topk_length,
+            attn_sink=attn_sink,
+            sm_scale=sm_scale,
+        )
+        torch.cuda.synchronize()
+
+        actual_fp32 = actual.float().cpu()
+        diff = (actual_fp32 - expected_fp32).abs()
+        assert torch.isfinite(actual_fp32).all(), name
+        assert diff.max().item() <= TORCH_REF_MAX_ABS_ERROR, name
+        assert diff.mean().item() <= TORCH_REF_MAX_MEAN_ABS_ERROR, name
+        torch.testing.assert_close(
+            actual_fp32,
+            expected_fp32,
+            atol=TORCH_REF_MAX_ABS_ERROR,
+            rtol=1.0e-2,
+            msg=lambda message: f"sink case {name}: {message}",
+        )
+
+
+@requires_sm90
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_fresh_jit_dynamic_shapes_and_repeat_allocation():
+    """Compile once, reuse dynamic shapes, and return independent outputs."""
+
+    cute_h16, flash_mla_sparse_fwd = _load_implementations()
+    cute_h16._COMPILE_CACHE.clear()
+
+    q1, kv1, indices1, lengths1, sink1 = _make_case(
+        tq=2,
+        skv=257,
+        topk=128,
+        lengths=[128, 65],
+        seed=101,
+    )
+    q1_padded, sink1_padded = _pad_flashmla_inputs(q1, sink1)
+    actual1 = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q1_padded,
+        kv=kv1.squeeze(1),
+        indices=indices1.squeeze(1),
+        topk_length=lengths1,
+        attn_sink=sink1_padded,
+        sm_scale=D_QK**-0.5,
+    )
+    torch.cuda.synchronize()
+
+    assert actual1.is_contiguous()
+    assert len(cute_h16._COMPILE_CACHE) == 1
+    expected1 = _flashmla_reference(
+        flash_mla_sparse_fwd, q1, kv1, indices1, lengths1, sink1
+    )
+    torch.cuda.synchronize()
+    _assert_matches_flashmla(actual1, expected1, topk_length=lengths1)
+
+    # Every public call owns its output. A repeated launch must not alias or
+    # overwrite the first allocation and must remain deterministic.
+    snapshot1 = actual1.clone()
+    actual1_repeat = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q1_padded,
+        kv=kv1.squeeze(1),
+        indices=indices1.squeeze(1),
+        topk_length=lengths1,
+        attn_sink=sink1_padded,
+        sm_scale=D_QK**-0.5,
+    )
+    torch.cuda.synchronize()
+    assert actual1_repeat.data_ptr() != actual1.data_ptr()
+    assert torch.equal(actual1, snapshot1)
+    assert torch.equal(actual1_repeat, snapshot1)
+
+    # TQ and SKV are runtime dimensions. Changing both while H and TOPK stay
+    # fixed must reuse the one compiled executor rather than specialize again.
+    q2, kv2, indices2, lengths2, sink2 = _make_case(
+        tq=5,
+        skv=40009,
+        topk=128,
+        lengths=[0, 1, 64, 127, 128],
+        seed=202,
+    )
+    q2_padded, sink2_padded = _pad_flashmla_inputs(q2, sink2)
+    actual2 = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q2_padded,
+        kv=kv2.squeeze(1),
+        indices=indices2.squeeze(1),
+        topk_length=lengths2,
+        attn_sink=sink2_padded,
+        sm_scale=D_QK**-0.5,
+    )
+    expected2 = _flashmla_reference(
+        flash_mla_sparse_fwd, q2, kv2, indices2, lengths2, sink2
+    )
+    torch.cuda.synchronize()
+
+    assert len(cute_h16._COMPILE_CACHE) == 1
+    _assert_matches_flashmla(actual2, expected2, topk_length=lengths2)
+
+
+@requires_sm90
+@pytest.mark.parametrize("topk", [128, 384, 512, 640, 1152, 8192])
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_matches_flashmla_boundaries(topk: int):
+    cute_h16, flash_mla_sparse_fwd = _load_implementations()
+    lengths = _length_boundaries(topk)
+    q, kv, indices, topk_length, attn_sink = _make_case(
+        tq=len(lengths),
+        skv=40009 + topk,
+        topk=topk,
+        lengths=lengths,
+        seed=1000 + topk,
+    )
+    q_padded, sink_padded = _pad_flashmla_inputs(q, attn_sink)
+
+    actual = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q_padded,
+        kv=kv.squeeze(1),
+        indices=indices.squeeze(1),
+        topk_length=topk_length,
+        attn_sink=sink_padded,
+        sm_scale=1.0 / math.sqrt(D_QK),
+    )
+    expected = _flashmla_reference(
+        flash_mla_sparse_fwd, q, kv, indices, topk_length, attn_sink
+    )
+    torch.cuda.synchronize()
+
+    _assert_matches_flashmla(actual, expected, topk_length=topk_length)
+
+
+@requires_sm90
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_rms1_multitile_online_rescale():
+    """Stress repeated online-max/PV rescaling across all 18 K tiles."""
+
+    cute_h16, flash_mla_sparse_fwd = _load_implementations()
+    tq, skv, topk = 4, 4096, 1152
+    q, kv, indices, topk_length, attn_sink = _make_case(
+        tq=tq,
+        skv=skv,
+        topk=topk,
+        lengths=[topk] * tq,
+        seed=7001,
+        invalid_in_prefix=False,
+        std=1.0,
+    )
+    kv_compact = kv.squeeze(1)
+    indices_compact = indices.squeeze(1)
+
+    # Sort each query's unique gather rows by head-0 score. Every successive
+    # 64-row tile then raises that head's running maximum, forcing the old PV
+    # state to be rescaled instead of merely accumulating under a fixed max.
+    generator = torch.Generator(device="cuda").manual_seed(7002)
+    sm_scale = D_QK**-0.5
+    for row in range(tq):
+        selected = torch.randperm(skv, device="cuda", generator=generator)[:topk]
+        scores = torch.mv(kv_compact[selected].float(), q[row, 0].float()) * sm_scale
+        indices_compact[row].copy_(selected[torch.argsort(scores)].to(torch.int32))
+
+    ordered_scores = (
+        torch.mv(kv_compact[indices_compact[0].long()].float(), q[0, 0].float())
+        * sm_scale
+    )
+    tile_max = ordered_scores.view(-1, 64).amax(dim=1)
+    assert bool(torch.all(tile_max[1:] > tile_max[:-1]))
+    assert 0.9 < q.float().square().mean().sqrt().item() < 1.1
+    assert 0.9 < kv.float().square().mean().sqrt().item() < 1.1
+
+    q_padded, sink_padded = _pad_flashmla_inputs(q, attn_sink)
+    actual = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q_padded,
+        kv=kv_compact,
+        indices=indices_compact,
+        topk_length=topk_length,
+        attn_sink=sink_padded,
+        sm_scale=sm_scale,
+    )
+    expected = _flashmla_reference(
+        flash_mla_sparse_fwd, q, kv, indices, topk_length, attn_sink
+    )
+    torch.cuda.synchronize()
+
+    stress_diff = (actual.float() - expected.float()).abs()
+    print(
+        "\nRMS1 K=1152 FlashMLA parity: "
+        f"max_abs={stress_diff.max().item():.8e}, "
+        f"mean_abs={stress_diff.mean().item():.8e}"
+    )
+    # A legacy normalized-input H20 run reached 1.953125e-3 max error. Keep
+    # this stress-only gate independent from the tight ordinary-input gate;
+    # tighten it after measuring this exact test on the rebased upstream main.
+    _assert_matches_flashmla(
+        actual,
+        expected,
+        topk_length=topk_length,
+        max_abs_error=STRESS_MAX_ABS_ERROR,
+        max_mean_abs_error=STRESS_MAX_MEAN_ABS_ERROR,
+    )
+
+
+@requires_sm90
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_h16_and_h64_inputs_are_bitwise_equal():
+    cute_h16, _ = _load_implementations()
+    q, kv, indices, topk_length, attn_sink = _make_case(
+        tq=3,
+        skv=1024,
+        topk=128,
+        lengths=[1, 65, 128],
+        seed=8001,
+    )
+    q_padded, sink_padded = _pad_flashmla_inputs(q, attn_sink)
+    generator = torch.Generator(device="cuda").manual_seed(8002)
+    q_padded[:, H_LOGICAL:].copy_(
+        torch.randn(
+            q_padded[:, H_LOGICAL:].shape,
+            dtype=torch.bfloat16,
+            device="cuda",
+            generator=generator,
+        )
+    )
+    sink_padded[H_LOGICAL:] = torch.linspace(
+        -4.0,
+        4.0,
+        H_FLASHMLA - H_LOGICAL,
+        dtype=torch.float32,
+        device="cuda",
+    )
+
+    kwargs = dict(
+        kv=kv.squeeze(1),
+        indices=indices.squeeze(1),
+        topk_length=topk_length,
+        sm_scale=D_QK**-0.5,
+    )
+    out_h16 = cute_h16.cute_sparse_mla_h16_fwd(q=q, attn_sink=attn_sink, **kwargs)
+    out_h64 = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q_padded, attn_sink=sink_padded, **kwargs
+    )
+    torch.cuda.synchronize()
+
+    assert torch.equal(out_h16, out_h64)
+
+
+@requires_sm90
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_invalid_redirects_mask_poisoned_kv_zero():
+    cute_h16, flash_mla_sparse_fwd = _load_implementations()
+    lengths = [1, 65, 128]
+    q, kv, indices, topk_length, attn_sink = _make_case(
+        tq=len(lengths),
+        skv=257,
+        topk=128,
+        lengths=lengths,
+        seed=9001,
+    )
+    indices[indices == 0] = 1
+    kv[0, 0, :3] = torch.tensor(
+        [float("nan"), float("inf"), float("-inf")],
+        dtype=torch.bfloat16,
+        device="cuda",
+    )
+
+    for row, length in enumerate(lengths):
+        prefix = indices[row, 0, :length]
+        valid = (prefix >= 0) & (prefix < kv.shape[0])
+        assert not bool(torch.any(prefix[valid] == 0))
+
+    q_padded, sink_padded = _pad_flashmla_inputs(q, attn_sink)
+    actual = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q_padded,
+        kv=kv.squeeze(1),
+        indices=indices.squeeze(1),
+        topk_length=topk_length,
+        attn_sink=sink_padded,
+        sm_scale=D_QK**-0.5,
+    )
+    expected = _flashmla_reference(
+        flash_mla_sparse_fwd, q, kv, indices, topk_length, attn_sink
+    )
+    torch.cuda.synchronize()
+
+    assert torch.isfinite(actual.float()).all()
+    assert torch.isfinite(expected.float()).all()
+    _assert_matches_flashmla(actual, expected, topk_length=topk_length)
+
+
+@requires_sm90
+@pytest.mark.parametrize("unaligned_input", ["q", "kv"])
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_rejects_unaligned_contiguous_storage(
+    unaligned_input: str,
+):
+    cute_h16, _ = _load_implementations()
+    q, kv, indices, topk_length, attn_sink = _make_case(
+        tq=1,
+        skv=257,
+        topk=128,
+        lengths=[128],
+        seed=10001,
+    )
+    kv_compact = kv.squeeze(1)
+    if unaligned_input == "q":
+        q = _unaligned_contiguous_copy(q)
+    else:
+        kv_compact = _unaligned_contiguous_copy(kv_compact)
+
+    with pytest.raises(ValueError, match="aligned to 16 bytes"):
+        cute_h16.cute_sparse_mla_h16_fwd(
+            q=q,
+            kv=kv_compact,
+            indices=indices.squeeze(1),
+            topk_length=topk_length,
+            attn_sink=attn_sink,
+            sm_scale=D_QK**-0.5,
+        )
+
+
+@requires_sm90
+@torch.inference_mode()
+def test_cute_sparse_mla_h16_two_nondefault_streams_share_executor():
+    cute_h16, flash_mla_sparse_fwd = _load_implementations()
+    cute_h16._COMPILE_CACHE.clear()
+    topk = 512
+    case_a = _make_case(
+        tq=3,
+        skv=1024,
+        topk=topk,
+        lengths=[65, 129, topk],
+        seed=11001,
+    )
+    case_b = _make_case(
+        tq=5,
+        skv=40009,
+        topk=topk,
+        lengths=[0, 1, 128, 384, topk],
+        seed=11002,
+    )
+    q_a, kv_a, indices_a, lengths_a, sink_a = case_a
+    q_b, kv_b, indices_b, lengths_b, sink_b = case_b
+    q_a64, sink_a64 = _pad_flashmla_inputs(q_a, sink_a)
+    q_b64, sink_b64 = _pad_flashmla_inputs(q_b, sink_b)
+
+    warm_a = cute_h16.cute_sparse_mla_h16_fwd(
+        q=q_a64,
+        kv=kv_a.squeeze(1),
+        indices=indices_a.squeeze(1),
+        topk_length=lengths_a,
+        attn_sink=sink_a64,
+        sm_scale=D_QK**-0.5,
+    )
+    torch.cuda.synchronize()
+    assert len(cute_h16._COMPILE_CACHE) == 1
+
+    default_stream = torch.cuda.current_stream(q_a.device)
+    stream_a = torch.cuda.Stream(device=q_a.device)
+    stream_b = torch.cuda.Stream(device=q_b.device)
+    stream_a.wait_stream(default_stream)
+    stream_b.wait_stream(default_stream)
+    with torch.cuda.stream(stream_a):
+        actual_a = cute_h16.cute_sparse_mla_h16_fwd(
+            q=q_a64,
+            kv=kv_a.squeeze(1),
+            indices=indices_a.squeeze(1),
+            topk_length=lengths_a,
+            attn_sink=sink_a64,
+            sm_scale=D_QK**-0.5,
+        )
+    with torch.cuda.stream(stream_b):
+        actual_b = cute_h16.cute_sparse_mla_h16_fwd(
+            q=q_b64,
+            kv=kv_b.squeeze(1),
+            indices=indices_b.squeeze(1),
+            topk_length=lengths_b,
+            attn_sink=sink_b64,
+            sm_scale=D_QK**-0.5,
+        )
+    stream_a.synchronize()
+    stream_b.synchronize()
+
+    assert len(cute_h16._COMPILE_CACHE) == 1
+    assert torch.equal(actual_a, warm_a)
+    expected_a = _flashmla_reference(
+        flash_mla_sparse_fwd, q_a, kv_a, indices_a, lengths_a, sink_a
+    )
+    expected_b = _flashmla_reference(
+        flash_mla_sparse_fwd, q_b, kv_b, indices_b, lengths_b, sink_b
+    )
+    torch.cuda.synchronize()
+    _assert_matches_flashmla(actual_a, expected_a, topk_length=lengths_a)
+    _assert_matches_flashmla(actual_b, expected_b, topk_length=lengths_b)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/registered/unit/layers/attention/test_dsv4_cutedsl_h16_dispatch.py
+++ b/test/registered/unit/layers/attention/test_dsv4_cutedsl_h16_dispatch.py
@@ -1,0 +1,473 @@
+import os
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestDSV4CutedslH16Dispatch(CustomTestCase):
+    @staticmethod
+    def _select(
+        *,
+        backend: str = "cutedsl_h16",
+        forward_mode: ForwardMode = ForwardMode.EXTEND,
+        original_forward_mode: ForwardMode | None = None,
+        num_heads: int = 16,
+        q: object | None = None,
+        in_breakable_graph: bool = False,
+        in_piecewise_graph: bool = False,
+        in_full_graph: bool = False,
+        current_stream_capture: bool = False,
+        tbo_parent_token_range: object | None = None,
+    ) -> bool:
+        from sglang.srt.layers.attention import deepseek_v4_backend
+
+        if q is None:
+            q = torch.empty((2, 1, 16, 512), dtype=torch.bfloat16)
+        forward_batch = SimpleNamespace(
+            forward_mode=forward_mode,
+            _original_forward_mode=original_forward_mode,
+            tbo_parent_token_range=tbo_parent_token_range,
+        )
+        piecewise_context = SimpleNamespace(full_graph=True) if in_full_graph else None
+        with (
+            mock.patch.object(
+                deepseek_v4_backend,
+                "is_in_breakable_cuda_graph",
+                return_value=in_breakable_graph,
+            ),
+            mock.patch.object(
+                deepseek_v4_backend,
+                "is_in_tc_piecewise_cuda_graph",
+                return_value=in_piecewise_graph,
+            ),
+            mock.patch.object(
+                deepseek_v4_backend,
+                "get_tc_piecewise_forward_context",
+                return_value=piecewise_context,
+            ),
+            mock.patch.object(
+                torch.cuda,
+                "is_current_stream_capturing",
+                return_value=current_stream_capture,
+            ),
+        ):
+            return deepseek_v4_backend._use_dsv4_cutedsl_h16_sparse_prefill(
+                backend,
+                q,
+                forward_batch,
+                num_heads,
+            )
+
+    def test_explicit_backend_selects_supported_eager_extend(self):
+        self.assertTrue(self._select())
+
+    def test_production_h64_padded_query_is_supported(self):
+        q = torch.empty((2, 1, 64, 512), dtype=torch.bfloat16)
+        self.assertTrue(self._select(q=q))
+
+    def test_default_backends_keep_existing_path(self):
+        for backend in ("auto", "flashmla_sparse", "flashmla_sparse_q8"):
+            with self.subTest(backend=backend):
+                self.assertFalse(self._select(backend=backend))
+
+    def test_explicit_backend_takes_precedence_over_q8_debug_override(self):
+        from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
+            DSV4_Q8KV8_PREFILL_ENV,
+            use_dsv4_q8kv8_sparse_prefill,
+        )
+
+        with mock.patch.dict(os.environ, {DSV4_Q8KV8_PREFILL_ENV: "1"}):
+            self.assertFalse(use_dsv4_q8kv8_sparse_prefill("cutedsl_h16"))
+            self.assertTrue(use_dsv4_q8kv8_sparse_prefill("auto"))
+
+    def test_non_cuda_dsv4_backends_reject_explicit_cutedsl_h16(self):
+        from sglang.srt.layers.attention import attention_registry
+
+        runner = SimpleNamespace(
+            server_args=SimpleNamespace(dsv4_prefill_backend="cutedsl_h16")
+        )
+        for platform_flag, platform_name in (("_is_hip", "HIP"), ("_is_npu", "NPU")):
+            flags = {"_is_hip": False, "_is_npu": False, platform_flag: True}
+            with (
+                self.subTest(platform=platform_name),
+                mock.patch.multiple(attention_registry, **flags),
+                self.assertRaisesRegex(ValueError, f"CUDA SM90.*{platform_name}"),
+            ):
+                attention_registry.create_dsv4_backend(runner)
+
+    def test_speculative_and_cuda_graph_paths_fall_back(self):
+        self.assertFalse(self._select(forward_mode=ForwardMode.DRAFT_EXTEND_V2))
+        self.assertFalse(self._select(in_breakable_graph=True))
+        self.assertFalse(self._select(in_piecewise_graph=True))
+        self.assertFalse(self._select(in_full_graph=True))
+
+        cuda_q = SimpleNamespace(is_cuda=True)
+        self.assertFalse(self._select(q=cuda_q, current_stream_capture=True))
+
+    def test_max_len_rewritten_extend_paths_fall_back(self):
+        for original_mode in (
+            ForwardMode.TARGET_VERIFY,
+            ForwardMode.DRAFT_EXTEND_V2,
+            ForwardMode.IDLE,
+        ):
+            with self.subTest(original_mode=original_mode):
+                self.assertFalse(self._select(original_forward_mode=original_mode))
+
+    def test_tbo_split_extend_falls_back(self):
+        self.assertFalse(self._select(tbo_parent_token_range=(0, 16)))
+
+    def test_selected_backend_rejects_unsupported_eager_contracts(self):
+        cases = (
+            ("heads", {"num_heads": 32}),
+            (
+                "dtype",
+                {"q": torch.empty((2, 1, 16, 512), dtype=torch.float16)},
+            ),
+            (
+                "dimension",
+                {"q": torch.empty((2, 1, 16, 256), dtype=torch.bfloat16)},
+            ),
+            (
+                "storage_heads",
+                {"q": torch.empty((2, 1, 32, 512), dtype=torch.bfloat16)},
+            ),
+        )
+        for name, kwargs in cases:
+            with (
+                self.subTest(name=name),
+                self.assertRaisesRegex(ValueError, "cutedsl_h16"),
+            ):
+                self._select(**kwargs)
+
+    def test_lazy_adapter_preserves_tensor_api_and_2d_indices(self):
+        from sglang.srt.layers.attention import deepseek_v4_backend
+
+        module_name = "sglang.kernels.ops.attention.dsv4.cute_sparse_mla_h16"
+        fake_module = types.ModuleType(module_name)
+        expected = torch.empty((2, 16, 512), dtype=torch.bfloat16)
+        fake_kernel = mock.Mock(return_value=expected)
+        setattr(fake_module, "cute_sparse_mla_h16_fwd", fake_kernel)
+
+        q = torch.empty((2, 64, 512), dtype=torch.bfloat16)
+        kv = torch.empty((128, 512), dtype=torch.bfloat16)
+        indices = torch.zeros((2, 128), dtype=torch.int32)
+        topk_length = torch.full((2,), 128, dtype=torch.int32)
+        attn_sink = torch.zeros(64, dtype=torch.float32)
+
+        with mock.patch.dict(sys.modules, {module_name: fake_module}):
+            actual = deepseek_v4_backend._run_dsv4_cutedsl_h16_sparse_prefill(
+                q,
+                kv,
+                indices,
+                topk_length,
+                attn_sink,
+                512**-0.5,
+            )
+
+        self.assertIs(actual, expected)
+        kwargs = fake_kernel.call_args.kwargs
+        self.assertIs(kwargs["kv"], kv)
+        self.assertEqual(kwargs["kv"].ndim, 2)
+        self.assertIs(kwargs["indices"], indices)
+        self.assertEqual(kwargs["indices"].ndim, 2)
+        self.assertNotIn("d_v", kwargs)
+        self.assertNotIn("trusted_prefix", kwargs)
+
+    def test_c128_fixed_width_validation_and_chunk_cache(self):
+        from sglang.kernels.ops.attention.dsv4.cutedsl_h16_contract import (
+            DSV4_CUTEDSL_H16_MAX_TOPK,
+            DSV4_CUTEDSL_H16_TOPK_ALIGNMENT,
+        )
+        from sglang.srt.layers.attention import deepseek_v4_backend
+        from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
+            SPARSE_PREFILL_TOPK_ALIGNMENT,
+            SparsePrefillChunkCache,
+        )
+
+        self.assertEqual(DSV4_CUTEDSL_H16_MAX_TOPK, 8192)
+        self.assertEqual(
+            DSV4_CUTEDSL_H16_TOPK_ALIGNMENT,
+            SPARSE_PREFILL_TOPK_ALIGNMENT,
+        )
+        self.assertEqual(
+            deepseek_v4_backend._validate_dsv4_cutedsl_h16_combined_topk(
+                max_context_len=31744,
+                c4_topk=512,
+            ),
+            384,
+        )
+        self.assertEqual(
+            deepseek_v4_backend._validate_dsv4_cutedsl_h16_combined_topk(
+                max_context_len=40960,
+                c4_topk=512,
+            ),
+            512,
+        )
+        self.assertEqual(
+            deepseek_v4_backend._validate_dsv4_cutedsl_h16_combined_topk(
+                max_context_len=8064 * 128,
+                c4_topk=8064,
+            ),
+            DSV4_CUTEDSL_H16_MAX_TOPK,
+        )
+        with self.assertRaisesRegex(ValueError, "8192"):
+            deepseek_v4_backend._validate_dsv4_cutedsl_h16_combined_topk(
+                max_context_len=8065 * 128,
+                c4_topk=512,
+            )
+        with self.assertRaisesRegex(ValueError, "8192"):
+            deepseek_v4_backend._validate_dsv4_cutedsl_h16_combined_topk(
+                max_context_len=40960,
+                c4_topk=8065,
+            )
+
+        cache = object.__new__(SparsePrefillChunkCache)
+        cache.num_qo_tokens = 2
+        cache.c128_combined_indices = torch.arange(
+            2 * 384,
+            dtype=torch.int32,
+        ).reshape(2, 384)
+        cache.c128_combined_lens = torch.tensor([321, 384], dtype=torch.int32)
+        cache.c128_padded_combined_indices = {}
+
+        base_indices, base_lens = cache.get_c128_combined()
+        self.assertIs(base_indices, cache.c128_combined_indices)
+        self.assertIs(base_lens, cache.c128_combined_lens)
+
+        padded, padded_lens = cache.get_c128_combined(512)
+        self.assertEqual(tuple(padded.shape), (2, 512))
+        torch.testing.assert_close(padded[:, :384], cache.c128_combined_indices)
+        self.assertTrue(torch.all(padded[:, 384:] == -1))
+        self.assertIs(padded_lens, cache.c128_combined_lens)
+        cached_again, _ = cache.get_c128_combined(512)
+        self.assertIs(cached_again, padded)
+
+        with self.assertRaisesRegex(ValueError, "smaller than live width"):
+            cache.get_c128_combined(256)
+        with self.assertRaisesRegex(ValueError, "aligned"):
+            cache.get_c128_combined(450)
+
+    def test_unbound_c128_sparse_prefill_uses_fixed_cached_bucket(self):
+        from sglang.srt.layers.attention import deepseek_v4_backend
+        from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
+            SparsePrefillChunkCache,
+        )
+
+        num_queries = 2
+        num_compressed_tokens = 3
+        num_swa_tokens = 2
+        q = torch.empty(
+            (num_queries, 1, 64, 512),
+            dtype=torch.bfloat16,
+        )
+        workspace = torch.empty(
+            (num_compressed_tokens + num_swa_tokens, 1, 512),
+            dtype=torch.bfloat16,
+        )
+        live_indices = torch.zeros((num_queries, 384), dtype=torch.int32)
+        lengths = torch.tensor([321, 384], dtype=torch.int32)
+        sink = torch.arange(64, dtype=torch.float32)
+        expected = torch.empty(
+            (num_queries, 16, 512),
+            dtype=torch.bfloat16,
+        )
+
+        cache = object.__new__(SparsePrefillChunkCache)
+        cache.num_qo_tokens = num_queries
+        cache.swa_token_ids = torch.arange(num_swa_tokens, dtype=torch.int32)
+        cache.swa_page_size = 256
+        cache.c128_flat_token_ids = torch.arange(
+            num_compressed_tokens,
+            dtype=torch.int32,
+        )
+        cache.c128_combined_indices = live_indices
+        cache.c128_combined_lens = lengths
+        cache.c128_padded_combined_indices = {}
+
+        workspace_get = mock.Mock(return_value=workspace)
+        extra_buffer = object()
+        swa_buffer = object()
+        token_to_kv_pool = SimpleNamespace(
+            get_extra_key_page_size=mock.Mock(return_value=16),
+            get_extra_key_buffer=mock.Mock(return_value=extra_buffer),
+            get_swa_key_buffer_radix=mock.Mock(return_value=swa_buffer),
+        )
+        backend = SimpleNamespace(
+            forward_metadata=SimpleNamespace(sparse_prefill_cache=cache),
+            sparse_prefill_workspace=SimpleNamespace(get=workspace_get),
+            softmax_scale=512**-0.5,
+            _cutedsl_h16_c128_combined_topk=512,
+            _cutedsl_h16_prefill_log_emitted=True,
+        )
+        core_attn_metadata = SimpleNamespace(
+            c128_page_indices=torch.zeros((num_queries, 1), dtype=torch.int32),
+        )
+
+        with (
+            mock.patch.object(
+                deepseek_v4_backend,
+                "dequantize_k_cache_paged",
+            ) as dequantize,
+            mock.patch.object(
+                deepseek_v4_backend,
+                "_run_dsv4_cutedsl_h16_sparse_prefill",
+                return_value=expected,
+            ) as run_cutedsl,
+        ):
+            first = deepseek_v4_backend.DeepseekV4AttnBackend._forward_prefill_sparse(
+                backend,
+                q=q,
+                layer_id=3,
+                compress_ratio=128,
+                forward_batch=SimpleNamespace(),
+                token_to_kv_pool=token_to_kv_pool,
+                core_attn_metadata=core_attn_metadata,
+                attn_sink=sink,
+                use_cutedsl_h16=True,
+            )
+            first_indices = run_cutedsl.call_args.kwargs["indices"]
+            second = deepseek_v4_backend.DeepseekV4AttnBackend._forward_prefill_sparse(
+                backend,
+                q=q,
+                layer_id=3,
+                compress_ratio=128,
+                forward_batch=SimpleNamespace(),
+                token_to_kv_pool=token_to_kv_pool,
+                core_attn_metadata=core_attn_metadata,
+                attn_sink=sink,
+                use_cutedsl_h16=True,
+            )
+            second_kwargs = run_cutedsl.call_args.kwargs
+
+        self.assertIs(first, expected)
+        self.assertIs(second, expected)
+        workspace_get.assert_has_calls([mock.call(5), mock.call(5)])
+        self.assertEqual(dequantize.call_count, 4)
+        self.assertEqual(tuple(first_indices.shape), (num_queries, 512))
+        torch.testing.assert_close(first_indices[:, :384], live_indices)
+        self.assertTrue(torch.all(first_indices[:, 384:] == -1))
+        self.assertIs(first_indices, second_kwargs["indices"])
+        self.assertIs(
+            first_indices,
+            cache.c128_padded_combined_indices[512],
+        )
+        self.assertEqual(tuple(second_kwargs["q"].shape), (num_queries, 64, 512))
+        self.assertEqual(second_kwargs["q"].data_ptr(), q.data_ptr())
+        self.assertEqual(tuple(second_kwargs["kv"].shape), (5, 512))
+        self.assertEqual(second_kwargs["kv"].data_ptr(), workspace.data_ptr())
+        self.assertIs(second_kwargs["topk_length"], lengths)
+        self.assertIs(second_kwargs["attn_sink"], sink)
+        self.assertEqual(second_kwargs["sm_scale"], 512**-0.5)
+
+        compressed_call, swa_call = dequantize.call_args_list[:2]
+        self.assertIs(compressed_call.args[0], extra_buffer)
+        self.assertIs(compressed_call.args[1], cache.c128_flat_token_ids)
+        self.assertEqual(compressed_call.kwargs["page_size"], 16)
+        self.assertEqual(
+            tuple(compressed_call.kwargs["out"].shape),
+            (num_compressed_tokens, 1, 512),
+        )
+        self.assertIs(swa_call.args[0], swa_buffer)
+        self.assertIs(swa_call.args[1], cache.swa_token_ids)
+        self.assertEqual(swa_call.kwargs["page_size"], 256)
+        self.assertEqual(
+            tuple(swa_call.kwargs["out"].shape),
+            (num_swa_tokens, 1, 512),
+        )
+
+    def test_unbound_sparse_prefill_dispatch_preserves_cutedsl_contract(self):
+        from sglang.srt.layers.attention import deepseek_v4_backend
+
+        num_queries = 2
+        num_workspace_tokens = 3
+        q = torch.empty(
+            (num_queries, 1, 64, 512),
+            dtype=torch.bfloat16,
+        )
+        workspace = torch.empty(
+            (num_workspace_tokens, 1, 512),
+            dtype=torch.bfloat16,
+        )
+        indices = torch.zeros((num_queries, 128), dtype=torch.int32)
+        lengths = torch.tensor([127, 128], dtype=torch.int32)
+        sink = torch.arange(64, dtype=torch.float32)
+        expected = torch.empty(
+            (num_queries, 16, 512),
+            dtype=torch.bfloat16,
+        )
+        cache = SimpleNamespace(
+            swa_token_ids=torch.arange(num_workspace_tokens, dtype=torch.int32),
+            swa_page_size=256,
+            c0_combined_indices=indices,
+            c0_combined_lens=lengths,
+        )
+        workspace_get = mock.Mock(return_value=workspace)
+        swa_buffer = object()
+        get_swa_buffer = mock.Mock(return_value=swa_buffer)
+        backend = SimpleNamespace(
+            forward_metadata=SimpleNamespace(sparse_prefill_cache=cache),
+            sparse_prefill_workspace=SimpleNamespace(get=workspace_get),
+            softmax_scale=512**-0.5,
+            _cutedsl_h16_prefill_log_emitted=True,
+        )
+        token_to_kv_pool = SimpleNamespace(
+            get_swa_key_buffer_radix=get_swa_buffer,
+        )
+
+        with (
+            mock.patch.object(
+                deepseek_v4_backend,
+                "dequantize_k_cache_paged",
+            ) as dequantize,
+            mock.patch.object(
+                deepseek_v4_backend,
+                "_run_dsv4_cutedsl_h16_sparse_prefill",
+                return_value=expected,
+            ) as run_cutedsl,
+        ):
+            actual = deepseek_v4_backend.DeepseekV4AttnBackend._forward_prefill_sparse(
+                backend,
+                q=q,
+                layer_id=3,
+                compress_ratio=0,
+                forward_batch=SimpleNamespace(),
+                token_to_kv_pool=token_to_kv_pool,
+                core_attn_metadata=SimpleNamespace(),
+                attn_sink=sink,
+                use_cutedsl_h16=True,
+            )
+
+        self.assertIs(actual, expected)
+        self.assertEqual(tuple(actual.shape), (num_queries, 16, 512))
+        workspace_get.assert_called_once_with(num_workspace_tokens)
+        get_swa_buffer.assert_called_once_with(3)
+        dequantize.assert_called_once_with(
+            swa_buffer,
+            cache.swa_token_ids,
+            page_size=256,
+            out=workspace,
+        )
+        kwargs = run_cutedsl.call_args.kwargs
+        self.assertEqual(tuple(kwargs["q"].shape), (num_queries, 64, 512))
+        self.assertEqual(kwargs["q"].data_ptr(), q.data_ptr())
+        self.assertEqual(tuple(kwargs["kv"].shape), (num_workspace_tokens, 512))
+        self.assertEqual(kwargs["kv"].data_ptr(), workspace.data_ptr())
+        self.assertIs(kwargs["indices"], indices)
+        self.assertEqual(kwargs["indices"].ndim, 2)
+        self.assertIs(kwargs["topk_length"], lengths)
+        self.assertIs(kwargs["attn_sink"], sink)
+        self.assertEqual(kwargs["sm_scale"], 512**-0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -98,6 +98,11 @@ class TestPrepareServerArgs(CustomTestCase):
         )
         self.assertEqual(q8_args.dsv4_prefill_backend, "flashmla_sparse_q8")
 
+        cutedsl_args = parser.parse_args(
+            base_args + ["--dsv4-prefill-backend", "cutedsl_h16"]
+        )
+        self.assertEqual(cutedsl_args.dsv4_prefill_backend, "cutedsl_h16")
+
         with self.assertRaises(SystemExit):
             parser.parse_args(base_args + ["--dsv4-prefill-backend", "flashmla_kv"])
 


### PR DESCRIPTION
## Motivation

DeepSeek-V4 has 128 global query heads, so tensor parallelism with TP=8 leaves
16 logical query heads per rank. The existing SM90 FlashMLA sparse-prefill path
operates on an H64-padded query.

This PR adds an explicit, experimental native-H16 CuTe DSL backend:

```bash
--dsv4-prefill-backend cutedsl_h16
```

The backend avoids computing and materializing the 48 padded query heads and
returns a compact `[TQ, 16, 512]` output. The default `auto` behavior is
unchanged.

## Modifications

- Add an SM90 BF16 native-H16 CuTe DSL sparse-prefill kernel using an `m64n16`
  WGMMA decomposition and online softmax.
- Add `cutedsl_h16` to the DeepSeek-V4 sparse-prefill backend selection.
- Validate the supported launch contract:
  - CUDA SM90;
  - BF16 query and sparse workspace;
  - exactly 16 TP-local logical query heads;
  - Q/K/V width 512;
  - combined TOPK aligned to 128 and no greater than 8192.
- Use a configuration-sized aligned C128 TOPK bucket so changing live chunk
  lengths does not introduce a new JIT specialization.
- Cache the padded combined-index representation for reuse across layers.
- Keep decode, speculative, TBO, non-eager EXTEND, and CUDA graph/capture
  forwards on their existing paths.
- Reject explicit `cutedsl_h16` selection on unsupported HIP/NPU platforms
  instead of silently ignoring it.
- Add SM90 kernel tests, independent oracle/parity coverage, dispatch and CLI
  tests, a three-provider CUDA benchmark, and user documentation.

## Accuracy Tests

Validation used source commit
`5d0e688a3ca49bb521be4e20e835d415bb4f72af` on 8x NVIDIA H20-3e (SM90), with
CUDA 13.0, PyTorch 2.13.0+cu130, Triton 3.7.1,
`nvidia-cutlass-dsl==4.6.2`, `sglang-kernel==0.4.6.post1`,
`sgl-deep-gemm==0.1.5.post3`, and FlashInfer 0.6.17. A later docs-only commit
makes the launch examples copy/pasteable and does not change the tested code.

### Kernel and integration tests

```text
FlashInfer DSV4 MXFP4 direct-parity preflight: 3 passed
Native-H16 SM90 GPU test suite:             15 passed
DSV4 dispatch and server-argument tests:    14 passed
```

For the RMS1 / TOPK=1152 parity fixture:

```text
max absolute error:  9.765625e-04
mean absolute error: 8.782039e-06
```

The GPU suite covers dynamic query and KV lengths, TOPK 128 through 8192,
invalid indices, poisoned row zero, H16/H64 storage parity, alignment
validation, repeated allocation, non-default CUDA streams, and online-rescale
stress cases.

### Full-model accuracy

Both variants used DeepSeek-V4-Pro with TP=8, context length 49,152, random
seed 1234, maximum 16 running requests, chunked prefill size 4096, maximum
16,384 prefill tokens, and identical server/evaluation arguments except for
the backend and port.

GSM8K used all 1,314 questions, 5-shot prompting, maximum 512 new tokens,
parallelism 32, and temperature 0.

| Backend | Accuracy | Invalid | Latency (s) | Output tok/s | Exit code |
|---|---:|---:|---:|---:|---:|
| `flashmla_sparse` | 0.951 | 0.000 | 505.030 | 236.364 | 0 |
| `cutedsl_h16` | 0.952 | 0.000 | 493.418 | 243.384 | 0 |

On this public full-model evaluation, H16 reduced latency by 2.3% and increased
output throughput by 3.0% while preserving accuracy.

The candidate server emitted 8
`DSV4_CUTEDSL_H16_SPARSE_PREFILL_HIT` markers, one from each TP rank,
confirming that the full-model workload reached the new backend.

## Speed Tests and Profiling

### Sparse-prefill CUDA microbenchmark

Warmed public-API CUDA-event latency at TQ=4096 and SKV=49152:

| TOPK | FlashMLA BF16 H64 p50 (us) | FlashMLA Q8 H64 p50 (us) | CuTe BF16 H16 p50 (us) | H16 vs BF16 | H16 vs Q8 |
|---:|---:|---:|---:|---:|---:|
| 128 | 700.592 | 538.000 | 235.008 | 2.9811x | 2.2893x |
| 384 | 1676.160 | 1136.352 | 557.120 | 3.0086x | 2.0397x |
| 512 | 2165.616 | 1438.640 | 718.672 | 3.0134x | 2.0018x |
| 640 | 2655.984 | 1740.064 | 880.208 | 3.0175x | 1.9769x |
| 1152 | 4557.152 | 2913.088 | 1511.008 | 3.0160x | 1.9279x |

These numbers measure each provider's public attention call, not a
raw-kernel-only launch or end-to-end serving latency. FlashMLA BF16 and Q8
produce an H64 output plus max/LSE auxiliaries, while CuTe returns a compact H16
output. Q8 inputs are prequantized before timing; its query cast and DSV4 KV
gather/dequantize/requantize pipeline are excluded.

## Checklist

- [x] Format the code according to the repository configuration. The changed
  files pass the repository-pinned Black, isort, Ruff selection, codespell,
  whitespace, AST, and registered-test lint checks.
- [x] Add unit tests.
- [x] Update documentation.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code-style guidance.

