### PR TITLE
perf: split mixed GDN prefill and decode kernels

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -510,6 +510,139 @@ class GDNAttnBackend(MambaAttnBackendBase):
 
         return core_attn_out
 
+    def _mixed_split_bounds(
+        self,
+        forward_batch: ForwardBatch,
+        seq_len: int,
+        forward_metadata,
+        layer_cache,
+        needs_state_gather: bool,
+    ) -> Optional[Tuple[int, int, int]]:
+        """Return ``(num_prefill_reqs, num_prefill_tokens, num_decodes)``
+        when the scheduler-provided MIXED layout can use the split fast path.
+
+        Breakable prefill graphs normalize MIXED to EXTEND, so boundary
+        presence is the authoritative mixed-batch marker here. Every excluded
+        feature keeps the existing all-extend path as a correctness fallback.
+        """
+        num_prefill_reqs = forward_batch.mixed_num_prefill_reqs
+        num_prefill_tokens = forward_batch.mixed_num_prefill_tokens
+        if num_prefill_reqs is None or num_prefill_tokens is None:
+            return None
+
+        num_decodes = forward_batch.batch_size - num_prefill_reqs
+        if not (
+            is_cuda()
+            and forward_batch.forward_mode.is_extend()
+            and forward_batch.spec_info is None
+            and forward_batch._original_batch_size is None
+            and forward_batch.tbo_split_seq_index is None
+            and self.kernel_dispatcher.supports_packed_decode
+            and not forward_metadata.has_mamba_track_mask
+            and forward_metadata.num_state_checkpoints == 0
+            and not needs_state_gather
+            and num_prefill_reqs > 0
+            and num_prefill_tokens > 0
+            and num_decodes > 0
+            and num_prefill_reqs + num_decodes == forward_batch.batch_size
+            and num_prefill_tokens + num_decodes == seq_len
+            and forward_batch.extend_seq_lens_cpu is not None
+            and len(forward_batch.extend_seq_lens_cpu) == forward_batch.batch_size
+            and forward_metadata.query_start_loc.shape[0]
+            == forward_batch.batch_size + 1
+            and forward_metadata.mamba_cache_indices.shape[0]
+            == forward_batch.batch_size
+            and layer_cache.replayssm_d is None
+            and layer_cache.replayssm_k is None
+            and layer_cache.replayssm_g is None
+        ):
+            return None
+        return num_prefill_reqs, num_prefill_tokens, num_decodes
+
+    def _forward_mixed_split(
+        self,
+        layer: RadixLinearAttention,
+        forward_batch: ForwardBatch,
+        mixed_qkv: torch.Tensor,
+        a: torch.Tensor,
+        b: torch.Tensor,
+        conv_states: torch.Tensor,
+        ssm_states: torch.Tensor,
+        cache_indices: torch.Tensor,
+        query_start_loc: torch.Tensor,
+        bounds: Tuple[int, int, int],
+    ) -> torch.Tensor:
+        """Run prefill rows with extend kernels and the decode suffix recurrently."""
+        num_prefill_reqs, num_prefill_tokens, num_decodes = bounds
+        prefill_cache_indices = cache_indices[:num_prefill_reqs]
+        decode_cache_indices = cache_indices[num_prefill_reqs:]
+        prefill_query_start_loc = query_start_loc[: num_prefill_reqs + 1]
+
+        # The two request groups own disjoint state slots. Prefill updates each
+        # row's whole conv window; decode shifts/appends exactly one token.
+        prefill_qkv = causal_conv1d_fn(
+            mixed_qkv[:num_prefill_tokens].transpose(0, 1),
+            layer.conv_weights,
+            layer.bias,
+            activation=layer.activation,
+            conv_states=conv_states,
+            has_initial_state=(forward_batch.extend_prefix_lens[:num_prefill_reqs] > 0),
+            cache_indices=prefill_cache_indices,
+            query_start_loc=prefill_query_start_loc,
+            seq_lens_cpu=forward_batch.extend_seq_lens_cpu[:num_prefill_reqs],
+        ).transpose(0, 1)[:num_prefill_tokens]
+        decode_qkv = causal_conv1d_update(
+            mixed_qkv[num_prefill_tokens:],
+            conv_states,
+            layer.conv_weights,
+            layer.bias,
+            layer.activation,
+            conv_state_indices=decode_cache_indices,
+        )
+
+        query, key, value = fused_qkv_split_gdn_prefill(
+            prefill_qkv,
+            layer.num_q_heads,
+            layer.num_k_heads,
+            layer.num_v_heads,
+            layer.head_q_dim,
+            layer.head_k_dim,
+            layer.head_v_dim,
+        )
+        g, beta = fused_gdn_gating(
+            layer.A_log,
+            a[:num_prefill_tokens],
+            b[:num_prefill_tokens],
+            layer.dt_bias,
+        )
+        prefill_out, _, _ = self.kernel_dispatcher.extend(
+            q=query,
+            k=key,
+            v=value,
+            g=g,
+            beta=beta,
+            ssm_states=ssm_states,
+            cache_indices=prefill_cache_indices,
+            query_start_loc=prefill_query_start_loc,
+            state_checkpoint_cu_starts=None,
+            num_state_checkpoints=0,
+            state_checkpoint_every_n_tokens=0,
+        )
+        decode_out = self.kernel_dispatcher.packed_decode(
+            mixed_qkv=decode_qkv,
+            a=a[num_prefill_tokens:],
+            b=b[num_prefill_tokens:],
+            A_log=layer.A_log,
+            dt_bias=layer.dt_bias,
+            scale=layer.head_k_dim**-0.5,
+            ssm_states=ssm_states,
+            cache_indices=decode_cache_indices,
+            num_v_heads=layer.num_v_heads,
+            head_v_dim=layer.head_v_dim,
+        )
+        assert decode_out is not None and decode_out.shape[1] == num_decodes
+        return torch.cat((prefill_out, decode_out), dim=1)
+
     def forward_extend(
         self,
         layer: RadixLinearAttention,
@@ -575,6 +708,27 @@ class GDNAttnBackend(MambaAttnBackendBase):
             conv_states_contig = conv_states
             ssm_states_contig = ssm_states
             state_cache_indices = cache_indices
+
+        mixed_split_bounds = self._mixed_split_bounds(
+            forward_batch,
+            seq_len,
+            forward_metadata,
+            mamba_cache_params,
+            needs_state_gather,
+        )
+        if mixed_split_bounds is not None:
+            return self._forward_mixed_split(
+                layer,
+                forward_batch,
+                mixed_qkv,
+                a,
+                b,
+                conv_states,
+                ssm_states,
+                cache_indices,
+                query_start_loc,
+                mixed_split_bounds,
+            )
 
         if is_target_verify:
             batch_size = seq_len // forward_batch.spec_info.draft_token_num

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2159,6 +2159,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # The sum of all sequence lengths
     seq_lens_sum: int = None
     extend_num_tokens: Optional[int] = None
+    # Request/token boundary of the prefill prefix in a MIXED batch. The
+    # scheduler lays out prefill requests/tokens first and one-token running
+    # decode requests second; linear-attention backends use this boundary to
+    # route the two portions to their native kernels.
+    mixed_num_prefill_reqs: Optional[int] = None
+    mixed_num_prefill_tokens: Optional[int] = None
 
     # Diffusion LLM
     dllm_config: Optional[DllmConfig] = None
@@ -2756,6 +2762,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.forward_mode = ForwardMode.SPLIT_PREFILL
 
     def mix_with_running(self, running_batch: ScheduleBatch):
+        # Capture the boundary before merge_batch appends the running requests.
+        # Do not infer it later from extend_lens: both real one-token prefills
+        # and appended decode rows can have an extend length of one.
+        self.mixed_num_prefill_reqs = self.batch_size()
+        self.mixed_num_prefill_tokens = self.extend_num_tokens
         self.forward_mode = ForwardMode.MIXED
         running_bs = running_batch.batch_size()
 
@@ -3341,6 +3352,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             launch_ts=self.launch_ts,
             after_idle_gap=self.after_idle_gap,
             extend_num_tokens=self.extend_num_tokens,
+            mixed_num_prefill_reqs=self.mixed_num_prefill_reqs,
+            mixed_num_prefill_tokens=self.mixed_num_prefill_tokens,
         )
 
     def maybe_evict_swa(self):

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -453,6 +453,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     # For two-batch overlap
     tbo_split_seq_index: Optional[int] = None
 
+    # Request/token boundary of the prefill prefix in a scheduler MIXED batch.
+    # These remain populated when breakable prefill graphs normalize MIXED to
+    # EXTEND, allowing eager linear-attention graph breaks to keep the split.
+    mixed_num_prefill_reqs: Optional[int] = None
+    mixed_num_prefill_tokens: Optional[int] = None
+
     # === Borrowed from ScheduleBatch: host metadata (CPU lists / mirrors) ===
     # Optional seq_lens on cpu (CPU mirror of seq_lens)
     seq_lens_cpu: Optional[torch.Tensor] = None
@@ -796,6 +802,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             capture_hidden_mode=capture_hidden_mode,
             return_hidden_states_before_norm=return_hidden_states_before_norm,
             tbo_split_seq_index=batch.tbo_split_seq_index,
+            mixed_num_prefill_reqs=batch.mixed_num_prefill_reqs,
+            mixed_num_prefill_tokens=batch.mixed_num_prefill_tokens,
             # Host-side metadata
             top_logprobs_nums=batch.top_logprobs_nums,
             token_ids_logprobs=batch.token_ids_logprobs,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1556,6 +1556,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             token_ids_logprobs=forward_batch.token_ids_logprobs,
             multi_item_delimiter_indices=forward_batch.multi_item_delimiter_indices,
             extend_num_tokens=forward_batch.extend_num_tokens,
+            mixed_num_prefill_reqs=forward_batch.mixed_num_prefill_reqs,
+            mixed_num_prefill_tokens=forward_batch.mixed_num_prefill_tokens,
             extend_input_logprob_token_ids_gpu=forward_batch.extend_input_logprob_token_ids_gpu,
             positions=positions,
             global_num_tokens_gpu=forward_batch.global_num_tokens_gpu,

--- a/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
+++ b/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
@@ -22,6 +22,7 @@ from sglang.srt.layers.attention.linear.utils import (
     LinearAttnKernelBackend,
     resolve_linear_attn_backends,
 )
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.runtime_context import get_context
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -243,6 +244,92 @@ class TestFlashInferGDNPrefillBackendPolicy(CustomTestCase):
             backend.init_forward_metadata(forward_batch)
 
         torch.testing.assert_close(metadata.conv_states_mask_indices, torch.tensor([7]))
+
+    def test_mixed_split_bounds_accept_breakable_graph_extend_mode(self):
+        backend = object.__new__(GDNAttnBackend)
+        backend.kernel_dispatcher = SimpleNamespace(supports_packed_decode=True)
+        forward_batch = SimpleNamespace(
+            mixed_num_prefill_reqs=2,
+            mixed_num_prefill_tokens=10,
+            batch_size=5,
+            forward_mode=ForwardMode.EXTEND,
+            spec_info=None,
+            _original_batch_size=None,
+            tbo_split_seq_index=None,
+            extend_seq_lens_cpu=[4, 6, 1, 1, 1],
+        )
+        metadata = SimpleNamespace(
+            has_mamba_track_mask=False,
+            num_state_checkpoints=0,
+            query_start_loc=torch.empty(6),
+            mamba_cache_indices=torch.empty(5),
+        )
+        layer_cache = SimpleNamespace(
+            replayssm_d=None,
+            replayssm_k=None,
+            replayssm_g=None,
+        )
+
+        with patch.object(gdn_backend, "is_cuda", return_value=True):
+            bounds = backend._mixed_split_bounds(
+                forward_batch,
+                seq_len=13,
+                forward_metadata=metadata,
+                layer_cache=layer_cache,
+                needs_state_gather=False,
+            )
+
+        self.assertEqual(bounds, (2, 10, 3))
+
+    def test_mixed_split_bounds_fall_back_for_unsupported_state_modes(self):
+        backend = object.__new__(GDNAttnBackend)
+        backend.kernel_dispatcher = SimpleNamespace(supports_packed_decode=True)
+        forward_batch = SimpleNamespace(
+            mixed_num_prefill_reqs=1,
+            mixed_num_prefill_tokens=8,
+            batch_size=3,
+            forward_mode=ForwardMode.MIXED,
+            spec_info=None,
+            _original_batch_size=None,
+            tbo_split_seq_index=None,
+            extend_seq_lens_cpu=[8, 1, 1],
+        )
+        metadata = SimpleNamespace(
+            has_mamba_track_mask=False,
+            num_state_checkpoints=0,
+            query_start_loc=torch.empty(4),
+            mamba_cache_indices=torch.empty(3),
+        )
+        layer_cache = SimpleNamespace(
+            replayssm_d=None,
+            replayssm_k=None,
+            replayssm_g=None,
+        )
+
+        cases = (
+            ("checkpoint", {"num_state_checkpoints": 1}, {}, False),
+            ("tracking", {"has_mamba_track_mask": True}, {}, False),
+            ("page_major", {}, {}, True),
+            ("replayssm", {}, {"replayssm_d": torch.empty(0)}, False),
+        )
+        with patch.object(gdn_backend, "is_cuda", return_value=True):
+            for name, metadata_fields, cache_fields, needs_gather in cases:
+                with self.subTest(name=name):
+                    current_metadata = SimpleNamespace(
+                        **{**vars(metadata), **metadata_fields}
+                    )
+                    current_cache = SimpleNamespace(
+                        **{**vars(layer_cache), **cache_fields}
+                    )
+                    self.assertIsNone(
+                        backend._mixed_split_bounds(
+                            forward_batch,
+                            seq_len=10,
+                            forward_metadata=current_metadata,
+                            layer_cache=current_cache,
+                            needs_state_gather=needs_gather,
+                        )
+                    )
 
     def test_tree_verify_uses_triton_kernel(self):
         flashinfer_kernel = MagicMock(supports_target_verify=True)

--- a/test/registered/unit/managers/test_schedule_batch_out_of_place.py
+++ b/test/registered/unit/managers/test_schedule_batch_out_of_place.py
@@ -157,6 +157,8 @@ class TestMixWithRunningOutOfPlace(unittest.TestCase):
         self.assertEqual(extend_batch.prefix_lens, [0, 0, 5])
         self.assertEqual(extend_batch.extend_lens, [3, 3, 1])
         self.assertEqual(extend_batch.extend_num_tokens, 7)
+        self.assertEqual(extend_batch.mixed_num_prefill_reqs, 2)
+        self.assertEqual(extend_batch.mixed_num_prefill_tokens, 6)
         self.assertEqual(extend_batch.extend_logprob_start_lens, [0, 0, 0])
         self.assertFalse(extend_batch.is_prefill_only)
         self.assertIsNot(extend_batch.prefix_lens, extend_prefix_before)


### PR DESCRIPTION
## Motivation

With mixed chunk enabled, `ScheduleBatch.mix_with_running()` lays a batch out as
`[prefill requests | running decode requests]` and marks it `MIXED`. The hybrid
linear-attention wrapper currently routes that whole batch through
`GDNAttnBackend.forward_extend()`. As a result, every one-token decode suffix is
processed by causal-conv and FlashInfer prefill kernels in all 48 GDN layers of
Qwen3.8-27B.

This becomes material at high decode concurrency. The change is inspired by the
mixed GDN invariant in vLLM #44700, but is implemented using SGLang's existing
`ScheduleBatch`, `ForwardBatch`, GDN dispatcher, and state pools.

This does not duplicate #34387: that WIP splits Ascend full-attention FIA calls
and explicitly leaves the linear/GDN side on its extend path. This PR targets
CUDA GDN causal-conv and recurrent decode. It uses the same proposed mixed
boundary field names to reduce future integration conflicts.

## Modifications

- Capture the prefill request/token boundary before running decode requests are
  appended to the mixed batch, and carry the two host scalars through
  `ForwardBatch` and breakable-prefill-graph replay.
- In the guarded CUDA GDN path, run the prefill prefix through the existing
  causal-conv + FlashInfer extend kernels and the one-token decode suffix through
  the existing causal-conv update + Triton packed recurrent decode kernels.
- Concatenate outputs in the scheduler's original prefill-first token order.
- Keep the old unified extend path as fallback for speculation, DP padding, TBO,
  state tracking/checkpoints, non-contiguous/page-major state, ReplaySSM, invalid
  boundaries, and backends without packed decode support.
- Keep breakable prefill CUDA graphs enabled; no graph mode is disabled.

The production change is 4 files and 177 insertions. Two focused unit-test files
add 89 lines.

## Accuracy Tests

Deterministic serving A/B on Qwen3.8-27B, TP=2 (2x H20), with 128 already-running
decoders overlapping one 16,384-token prefill, followed by a pure-request
control:

- 130 requests and 8,232 generated tokens compared.
- Output token-ID mismatches: 0.
- Output logprob token-ID mismatches: 0.
- Maximum and mean output-logprob absolute difference: 0.0.
- All requests completed.

Focused tests on the rebased commit:

```bash
PYTHONPATH="$PWD/python" python -m pytest -q \
  test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py \
  test/registered/unit/managers/test_schedule_batch_out_of_place.py
# 17 passed
```

Pure 64K prefill control, three samples per side, showed 0.080% median E2E and
0.083% median TTFT regression. Pure decode uses the unchanged `forward_decode`
path.

## Speed Tests and Profiling

Serving A/B used Qwen3.8-27B, TP=2 on 2x H20, chunked prefill size 8192,
speculation off, radix cache disabled, and breakable prefill graph enabled. Each
cell overlaps one 64K prefill with `D` already-running decoders. Baseline and
candidate used identical model revision, seed, requests, backend choices, and
server arguments.

| Decode concurrency | Baseline prefill TTFT | Candidate prefill TTFT | TTFT gain | Baseline mixed window | Candidate mixed window | Mixed-window gain |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 17.810 s | 16.612 s | 6.73% | 17,297.6 ms | 16,158.1 ms | 6.59% |
| 512 | 21.110 s | 17.825 s | 15.56% | 19,857.7 ms | 16,664.0 ms | 16.08% |
| 953 | 25.171 s | 18.674 s | 25.81% | 24,268.5 ms | 17,948.2 ms | 26.04% |

At D=953, baseline GDN mixed-window kernels spent 4,516.5 ms in causal-conv
prefill plus 1,327.2 ms in prefill delta. The split path spent 47.9 ms in prefill
conv, 24.6 ms in decode conv update, and 403.0 ms in recurrent decode. All 954
requests completed.

The serving measurements were collected on `bd3cc97e7ee49c8dcdae1679eca6b1f1cc36bbeb`.
This branch is rebased onto `e3a008a9db5e0575ab273a33ad5937cc40cacff6`;
the intervening changes in touched files are config-access refactors and do not
change mixed routing or GDN kernels.

## Checklist

- [x] Format changed Python files with Black.
- [x] Add focused unit tests (17 passed).
- [x] Provide deterministic accuracy results.
- [x] Provide serving speed and profiler results.
- [x] Keep unsupported configurations on the existing fallback path.
- [x] Documentation is not needed for this internal kernel routing change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32632871184](https://github.com/sgl-project/sglang/actions/runs/32632871184)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32632870907](https://github.com/sgl-project/sglang/actions/runs/32632870907)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32632870994](https://github.com/sgl-project/sglang/actions/runs/32632870994)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->