### PR TITLE
refactor(npu): centralize stream management (#1104)

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/cmo.py
+++ b/python/sglang/srt/hardware_backend/npu/cmo.py
@@ -1,83 +1,24 @@
-import torch
+# SPDX-License-Identifier: Apache-2.0
+"""CMO helpers — stream state lives in stream_management."""
 
-cmo_stream = None
-share_stream = None
+from sglang.srt.hardware_backend.npu.stream_management import (
+    get_cmo_stream,
+    get_share_stream,
+    prepare_weight_cache,
+    set_cmo_stream,
+    set_share_stream,
+    shared_expert_on_independent_stream,
+    wait_cmo_stream,
+    wait_share_stream,
+)
 
-
-def get_cmo_stream():
-    """
-    Cache Management Operation(CMO).
-    Launch a new stream to prefetch the weight of matmul when running other
-    AIV or communication kernels, aiming to overlap the memory access time.
-    """
-    global cmo_stream
-    return cmo_stream
-
-
-def set_cmo_stream(stream):
-    global cmo_stream
-    cmo_stream = stream
-
-
-def prepare_weight_cache(handle, cache, PREFETCH_MAX_SIZE=1000000000):
-    """
-    PREFETCH_MAX_SIZE: maximum size (bytes) for each prefetch operation.
-    This affects the time spent in prefetch:
-        time ≈ PREFETCH_MAX_SIZE / system_bandwidth
-    """
-    import torch_npu
-
-    stream = get_cmo_stream()
-    if stream is None:
-        stream = torch.npu.Stream()
-        set_cmo_stream(stream)
-    stream.wait_stream(torch.npu.current_stream())
-    with torch.npu.stream(stream):
-        if isinstance(cache, list):
-            for weight in cache:
-                torch_npu.npu_prefetch(
-                    weight,
-                    handle,
-                    PREFETCH_MAX_SIZE,
-                )
-        else:
-            torch_npu.npu_prefetch(
-                cache,
-                handle,
-                PREFETCH_MAX_SIZE,
-            )
-
-
-def wait_cmo_stream():
-    stream = get_cmo_stream()
-    if stream is not None:
-        cur_stream = torch.npu.current_stream()
-        cur_stream.wait_stream(stream)
-
-
-def get_share_stream():
-    global share_stream
-    return share_stream
-
-
-def set_share_stream(stream):
-    global share_stream
-    share_stream = stream
-
-
-def wait_share_stream():
-    stream = get_share_stream()
-    if stream is not None:
-        cur_stream = torch.npu.current_stream()
-        cur_stream.wait_stream(stream)
-
-
-def shared_expert_on_independent_stream(hidden_states, forward_func):
-    stream = get_share_stream()
-    if stream is None:
-        stream = torch.npu.Stream()
-        set_share_stream(stream)
-    stream.wait_stream(torch.npu.current_stream())
-    with torch.npu.stream(stream):
-        shared_output = forward_func(hidden_states)
-        return shared_output
+__all__ = [
+    "get_cmo_stream",
+    "set_cmo_stream",
+    "prepare_weight_cache",
+    "wait_cmo_stream",
+    "get_share_stream",
+    "set_share_stream",
+    "wait_share_stream",
+    "shared_expert_on_independent_stream",
+]

--- a/python/sglang/srt/hardware_backend/npu/stream_management.py
+++ b/python/sglang/srt/hardware_backend/npu/stream_management.py
@@ -1,0 +1,120 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Centralized NPU stream management for SGLang hardware backend."""
+
+from __future__ import annotations
+
+import torch
+
+cmo_stream = None
+share_stream = None
+routed_stream = None
+indexer_weight_stream = None
+
+
+def _device_module():
+    return torch.get_device_module()
+
+
+# --- CMO (cache management / weight prefetch) streams ---
+
+
+def get_cmo_stream():
+    """Return the CMO prefetch stream, or None if not initialized."""
+    return cmo_stream
+
+
+def set_cmo_stream(stream):
+    global cmo_stream
+    cmo_stream = stream
+
+
+def prepare_weight_cache(handle, cache, PREFETCH_MAX_SIZE=1000000000):
+    """Prefetch weight tensors on a dedicated stream for overlap with compute."""
+    import torch_npu
+
+    stream = get_cmo_stream()
+    if stream is None:
+        stream = torch.npu.Stream()
+        set_cmo_stream(stream)
+    stream.wait_stream(torch.npu.current_stream())
+    with torch.npu.stream(stream):
+        if isinstance(cache, list):
+            for weight in cache:
+                torch_npu.npu_prefetch(weight, handle, PREFETCH_MAX_SIZE)
+        else:
+            torch_npu.npu_prefetch(cache, handle, PREFETCH_MAX_SIZE)
+
+
+def wait_cmo_stream():
+    stream = get_cmo_stream()
+    if stream is not None:
+        torch.npu.current_stream().wait_stream(stream)
+
+
+# --- Shared / routed expert streams ---
+
+
+def get_share_stream():
+    return share_stream
+
+
+def set_share_stream(stream):
+    global share_stream
+    share_stream = stream
+
+
+def get_routed_stream():
+    return routed_stream
+
+
+def set_routed_stream(stream):
+    global routed_stream
+    routed_stream = stream
+
+
+def wait_share_stream():
+    stream = get_share_stream()
+    if stream is not None:
+        _device_module().current_stream().wait_stream(stream)
+
+
+def wait_routed_stream():
+    stream = get_routed_stream()
+    if stream is not None:
+        _device_module().current_stream().wait_stream(stream)
+
+
+def process_shared_expert(hidden_states, forward_func):
+    stream = get_share_stream()
+    dev = _device_module()
+    if stream is None:
+        stream = dev.Stream()
+        set_share_stream(stream)
+    stream.wait_stream(dev.current_stream())
+    with dev.stream(stream):
+        return forward_func(hidden_states)
+
+
+def process_routed_expert(hidden_states, topk_output, forward_func):
+    stream = get_routed_stream()
+    dev = _device_module()
+    if stream is None:
+        stream = dev.Stream()
+        set_routed_stream(stream)
+    stream.wait_stream(dev.current_stream())
+    with dev.stream(stream):
+        return forward_func(hidden_states, topk_output)
+
+
+# Backward-compatible alias used by qwen2_moe via cmo.py
+shared_expert_on_independent_stream = process_shared_expert
+
+
+# --- Indexer weight stream (DSA) ---
+
+
+def get_indexer_weight_stream():
+    global indexer_weight_stream
+    if indexer_weight_stream is None:
+        indexer_weight_stream = torch.npu.Stream()
+    return indexer_weight_stream

--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -15,7 +15,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _is_npu = is_npu()
-indexer_weight_stream = None
 gva_is_inited = False
 
 
@@ -251,11 +250,17 @@ def npu_format_cast(
     return torch.ops.npu.npu_format_cast(tensor, acl_format.value)
 
 
-def get_indexer_weight_stream():
-    global indexer_weight_stream
-    if indexer_weight_stream is None:
-        indexer_weight_stream = torch.npu.Stream()
-    return indexer_weight_stream
+from sglang.srt.hardware_backend.npu.stream_management import (
+    get_indexer_weight_stream,
+    get_routed_stream,
+    get_share_stream,
+    process_routed_expert,
+    process_shared_expert,
+    set_routed_stream,
+    set_share_stream,
+    wait_routed_stream,
+    wait_share_stream,
+)
 
 
 def init_zbal(world_size, gpu_id, world_rank, do_check=True):
@@ -348,65 +353,3 @@ def lazy_init_zbal_gva_mem(
     return res
 
 
-share_stream = None
-routed_stream = None
-
-
-def get_share_stream():
-    global share_stream
-    return share_stream
-
-
-def set_share_stream(stream):
-    global share_stream
-    share_stream = stream
-    # TODO LKL: set stream limit has impact on precision
-    # torch.npu.set_stream_limit(share_stream, 8, 16)
-
-
-def get_routed_stream():
-    global routed_stream
-    return routed_stream
-
-
-def set_routed_stream(stream):
-    global routed_stream
-    routed_stream = stream
-    # TODO LKL: set stream limit has impact on precision
-    # torch.npu.set_stream_limit(routed_stream, 16, 32)
-
-
-def wait_share_stream():
-    stream = get_share_stream()
-    if stream is not None:
-        cur_stream = torch.get_device_module().current_stream()
-        cur_stream.wait_stream(stream)
-
-
-def wait_routed_stream():
-    stream = get_routed_stream()
-    if stream is not None:
-        cur_stream = torch.get_device_module().current_stream()
-        cur_stream.wait_stream(stream)
-
-
-def process_shared_expert(hidden_states, forward_func):
-    stream = get_share_stream()
-    if stream is None:
-        stream = torch.get_device_module().Stream()
-        set_share_stream(stream)
-    stream.wait_stream(torch.get_device_module().current_stream())
-    with torch.get_device_module().stream(stream):
-        shared_output = forward_func(hidden_states)
-    return shared_output
-
-
-def process_routed_expert(hidden_states, topk_output, forward_func):
-    stream = get_routed_stream()
-    if stream is None:
-        stream = torch.get_device_module().Stream()
-        set_routed_stream(stream)
-    stream.wait_stream(torch.get_device_module().current_stream())
-    with torch.get_device_module().stream(stream):
-        shared_output = forward_func(hidden_states, topk_output)
-    return shared_output

--- a/test/registered/ascend/test_npu_stream_management.py
+++ b/test/registered/ascend/test_npu_stream_management.py
@@ -1,0 +1,62 @@
+"""Unit tests for NPU stream_management module (no real NPU required)."""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.hardware_backend.npu import stream_management as sm
+
+
+class TestNpuStreamManagement(unittest.TestCase):
+    def setUp(self):
+        sm.cmo_stream = None
+        sm.share_stream = None
+        sm.routed_stream = None
+        sm.indexer_weight_stream = None
+
+    def test_share_stream_lifecycle(self):
+        fake = MagicMock(name="share_stream")
+        sm.set_share_stream(fake)
+        self.assertIs(sm.get_share_stream(), fake)
+        sm.wait_share_stream()  # should not raise when stream set
+
+    def test_routed_stream_lifecycle(self):
+        fake = MagicMock(name="routed_stream")
+        sm.set_routed_stream(fake)
+        self.assertIs(sm.get_routed_stream(), fake)
+
+    def test_cmo_stream_setters(self):
+        fake = MagicMock(name="cmo_stream")
+        sm.set_cmo_stream(fake)
+        self.assertIs(sm.get_cmo_stream(), fake)
+
+    @patch("sglang.srt.hardware_backend.npu.stream_management.torch.npu")
+    def test_get_indexer_weight_stream_lazy_init(self, mock_npu):
+        mock_npu.Stream.return_value = MagicMock(name="idx_stream")
+        s1 = sm.get_indexer_weight_stream()
+        s2 = sm.get_indexer_weight_stream()
+        self.assertIs(s1, s2)
+        mock_npu.Stream.assert_called_once()
+
+    @patch("sglang.srt.hardware_backend.npu.stream_management._device_module")
+    def test_process_shared_expert_creates_stream(self, mock_dev_mod):
+        dev = MagicMock()
+        stream = MagicMock()
+        ctx = MagicMock()
+        dev.Stream.return_value = stream
+        dev.current_stream.return_value = MagicMock()
+        dev.stream.return_value.__enter__ = MagicMock(return_value=None)
+        dev.stream.return_value.__exit__ = MagicMock(return_value=False)
+        mock_dev_mod.return_value = dev
+
+        out = sm.process_shared_expert("hidden", lambda h: "ok")
+        self.assertEqual(out, "ok")
+        dev.Stream.assert_called_once()
+
+    def test_shared_expert_alias(self):
+        self.assertIs(sm.shared_expert_on_independent_stream, sm.process_shared_expert)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Centralize NPU stream management into `stream_management.py` for Ascend/sglang #1104.

- Extract CMO / share / routed / indexer streams from `utils.py` and `cmo.py`
- Keep backward-compatible re-exports in `cmo.py` and `utils.py`
- Add `test/registered/ascend/test_npu_stream_management.py` (mock-based, no real NPU)

## Related

- https://github.com/Ascend/sglang/issues/1104

## Test plan

- [x] Unit tests added (mock streams)
- [ ] CI ascend unit tests
- [ ] Optional NPU smoke on 910B3

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35582495761](https://github.com/sgl-project/sglang/actions/runs/35582495761)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35582495589](https://github.com/sgl-project/sglang/actions/runs/35582495589)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35582495887](https://github.com/sgl-project/sglang/actions/runs/35582495887)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->