### PR TITLE
[AMD] Disable DSA dense decode graphs with DP attention

### DIFF
--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -256,10 +256,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         # --- DSA dense-decode dual-graph -------------------------------
         # Capture a "dense" (k-only, skip-indexer) and a "sparse" (full indexer)
         # decode graph per bs bucket, and dispatch on max_kv_len vs index_topk at
-        # replay. Auto-enabled for DSA models (index_topk present in the HF
-        # config) — correct for mixed lengths since any request with
-        # kv_len > index_topk falls back to the sparse graph. Adds ~52 graphs and
-        # ~2x capture time.
+        # replay. Auto-enabled for DSA models without DP attention (index_topk
+        # present in the HF config) — correct for mixed lengths since any request
+        # with kv_len > index_topk falls back to the sparse graph. Adds ~52 graphs
+        # and ~2x capture time.
         #
         # Scoped to HIP (AMD): the k-only dense-decode fast path has only been
         # validated on MI355X. This is common (non-hardware-gated) code, so on
@@ -274,7 +274,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         )
 
         hf_config = model_runner.model_config.hf_config
-        if is_hip() and is_deepseek_dsa(hf_config):
+        if (
+            is_hip()
+            and is_deepseek_dsa(hf_config)
+            and not get_parallel().enable_dp_attention
+        ):
             self.dsa_index_topk = get_dsa_index_topk(hf_config)
             self.dsa_dual_graph = True
             logger.info(


### PR DESCRIPTION
## Summary

- Do not enable the HIP DSA dense/sparse dual decode graphs when DP attention is active.
- Keep the existing dual-graph optimization enabled for HIP DSA deployments without DP attention.
- DP-attention deployments still use decode CUDA graphs; they capture the existing full-indexer graph, which is valid for all KV lengths.

## Why

#31324 automatically enabled a dense k-only graph for DSA decode when `max_kv_len <= index_topk`. As isolated in #36071, replaying that graph on GLM-5.2 with DP attention can produce all-NaN logits on every attention-TP rank. The same topology is clean with eager decode and with the full-indexer graph, including when MTP and overlap scheduling are disabled.

This change applies the narrow correctness guard requested in #36071. It does not attempt to claim or mask a root-cause fix for the HIP k-only graph; that path should be re-enabled with DP attention only after its capture/replay buffer and stream contracts are qualified on the affected hardware.

## Scope

- HIP + DSA + DP attention: use the correct-for-all full-indexer decode graph.
- HIP + DSA without DP attention: unchanged; retain dense/sparse dual graphs.
- CUDA and non-DSA models: unchanged.

Fixes #36071
