### PR TITLE
[Fix] fa3_mla: dequantize only referenced FP8 KV pages

### DIFF
--- a/python/sglang/kernels/ops/kvcache/mla_buffer.py
+++ b/python/sglang/kernels/ops/kvcache/mla_buffer.py
@@ -384,3 +384,203 @@ def get_mla_kv_buffer_triton(
         nope_dim,
         rope_dim,
     )
+
+
+@triton.jit
+def dequantize_mla_fp8_page_table_kernel(
+    src_ptr,
+    dst_ptr,
+    page_table_ptr,
+    cache_seqlens_ptr,
+    page_epochs_ptr,
+    epoch_ptr,
+    src_row_stride: tl.constexpr,
+    dst_row_stride: tl.constexpr,
+    page_table_row_stride: tl.constexpr,
+    row_width: tl.constexpr,
+    PROGRAMS_PER_SEQUENCE: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Copy referenced FP8 MLA pages to their original ids in a dense shadow."""
+    seq_idx = tl.program_id(0)
+    page_offset = tl.program_id(1)
+    cache_seqlen = tl.load(cache_seqlens_ptr + seq_idx).to(tl.int64)
+    epoch = tl.load(epoch_ptr)
+    col_offsets = tl.arange(0, BLOCK_SIZE)
+    col_mask = col_offsets < row_width
+
+    while page_offset < cache_seqlen:
+        page_id = tl.load(
+            page_table_ptr + seq_idx * page_table_row_stride + page_offset
+        ).to(tl.int64)
+        previous_epoch = tl.atomic_xchg(page_epochs_ptr + page_id, epoch)
+        if previous_epoch != epoch:
+            values = tl.load(
+                src_ptr + page_id * src_row_stride + col_offsets,
+                mask=col_mask,
+            )
+            tl.store(
+                dst_ptr + page_id * dst_row_stride + col_offsets,
+                values,
+                mask=col_mask,
+            )
+        page_offset += PROGRAMS_PER_SEQUENCE
+
+
+def dequantize_mla_fp8_page_table(
+    src: torch.Tensor,
+    dst: torch.Tensor,
+    page_table: torch.Tensor,
+    cache_seqlens: torch.Tensor,
+    page_epochs: torch.Tensor,
+    epoch: torch.Tensor,
+    max_programs: int = 1024,
+) -> None:
+    """Dequantize only MLA KV pages referenced by ``page_table``.
+
+    The destination keeps the source page ids, so FA3 can consume it with the
+    original page table. ``page_epochs`` deduplicates pages shared by requests
+    without allocating or clearing temporary state on every invocation. Both
+    it and ``epoch`` must be persistent tensors to keep this CUDA-graph safe.
+
+    This first implementation intentionally supports only page size 1. The
+    caller owns that policy check; tensors here are viewed as dense rows.
+    """
+    if src.ndim < 2 or dst.shape != src.shape:
+        raise ValueError(
+            f"Expected matching row-major MLA buffers, got src.shape={src.shape!r} "
+            f"and dst.shape={dst.shape!r}"
+        )
+    if page_table.ndim != 2:
+        raise ValueError(
+            f"Expected a 2D page table, got page_table.shape={page_table.shape!r}"
+        )
+    if cache_seqlens.ndim != 1 or cache_seqlens.shape[0] != page_table.shape[0]:
+        raise ValueError(
+            "cache_seqlens must have one entry for every page-table row, got "
+            f"cache_seqlens.shape={cache_seqlens.shape!r} and "
+            f"page_table.shape={page_table.shape!r}"
+        )
+    if page_epochs.numel() != src.shape[0] or epoch.numel() != 1:
+        raise ValueError(
+            "Epoch state does not match the MLA buffer: "
+            f"page_epochs.shape={page_epochs.shape!r}, epoch.shape={epoch.shape!r}, "
+            f"pages={src.shape[0]}"
+        )
+
+    if page_table.numel() == 0:
+        return
+
+    row_width = src.numel() // src.shape[0]
+    block_size = triton.next_power_of_2(row_width)
+    programs_per_sequence = min(
+        max(1, max_programs // page_table.shape[0]), page_table.shape[1]
+    )
+
+    epoch.add_(1)
+    grid = (page_table.shape[0], programs_per_sequence)
+    dequantize_mla_fp8_page_table_kernel[grid](
+        src,
+        dst,
+        page_table,
+        cache_seqlens,
+        page_epochs,
+        epoch,
+        src.stride(0),
+        dst.stride(0),
+        page_table.stride(0),
+        row_width,
+        PROGRAMS_PER_SEQUENCE=programs_per_sequence,
+        BLOCK_SIZE=block_size,
+        num_warps=8,
+    )
+
+
+_SUPPORTED_FP8_DTYPES = (torch.float8_e4m3fn, torch.float8_e5m2)
+_SUPPORTED_OUTPUT_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def is_fa3_mla_fp8_shadow_enabled(
+    *,
+    fa_impl_ver: int,
+    use_mla: bool,
+    page_size: int,
+    unified_dense: bool,
+    attn_cp_size: int,
+    is_draft_runner: bool,
+    dcp_enabled: bool,
+    dsa_kv_cache_store_fp8: bool,
+) -> bool:
+    """Return whether a backend configuration can use the shared shadow."""
+    return (
+        fa_impl_ver == 3
+        and use_mla
+        and page_size == 1
+        and not unified_dense
+        and attn_cp_size == 1
+        and not is_draft_runner
+        and not dcp_enabled
+        and not dsa_kv_cache_store_fp8
+    )
+
+
+class FA3MLAFP8KVShadow:
+    """Persistent page-id-preserving shadow used by FA3 absorbed MLA.
+
+    One instance is shared by all MLA layers. Layers execute serially on the
+    current CUDA stream, so only the pages needed by the current layer have to
+    be materialized before FA3 consumes the buffer.
+    """
+
+    def __init__(self, source: torch.Tensor, output_dtype: torch.dtype):
+        self.buffer = torch.empty_like(source, dtype=output_dtype)
+        self.page_epochs = torch.zeros(
+            source.shape[0], dtype=torch.int32, device=source.device
+        )
+        self.epoch = torch.zeros((), dtype=torch.int32, device=source.device)
+        self.source_shape = source.shape
+        self.source_dtype = source.dtype
+        self.output_dtype = output_dtype
+
+    @classmethod
+    def maybe_create(
+        cls, source: torch.Tensor, output_dtype: torch.dtype
+    ) -> FA3MLAFP8KVShadow | None:
+        if not cls.is_supported_source(source, output_dtype):
+            return None
+        return cls(source, output_dtype)
+
+    @staticmethod
+    def is_supported_source(source: torch.Tensor, output_dtype: torch.dtype) -> bool:
+        return source.dtype in _SUPPORTED_FP8_DTYPES and (
+            output_dtype in _SUPPORTED_OUTPUT_DTYPES
+            and source.ndim >= 2
+            and source.is_cuda
+            and source.is_contiguous()
+        )
+
+    def can_materialize(self, source: torch.Tensor, output_dtype: torch.dtype) -> bool:
+        return (
+            source.shape == self.source_shape
+            and source.dtype == self.source_dtype
+            and output_dtype == self.output_dtype
+            and source.device == self.buffer.device
+            and source.is_cuda
+            and source.is_contiguous()
+        )
+
+    def materialize(
+        self,
+        source: torch.Tensor,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+    ) -> torch.Tensor:
+        dequantize_mla_fp8_page_table(
+            source,
+            self.buffer,
+            page_table,
+            cache_seqlens,
+            self.page_epochs,
+            self.epoch,
+        )
+        return self.buffer

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -13,6 +13,10 @@ from sglang.kernels.ops.attention.metadata import (
 )
 from sglang.kernels.ops.attention.pa_page_table import _build_pa_page_table
 from sglang.kernels.ops.attention.utils import assert_buffer_fits
+from sglang.kernels.ops.kvcache.mla_buffer import (
+    FA3MLAFP8KVShadow,
+    is_fa3_mla_fp8_shadow_enabled,
+)
 from sglang.kernels.ops.kvcache.trtllm_mha_page_table import (
     build_trtllm_mha_page_table,
 )
@@ -352,6 +356,26 @@ class FlashAttentionBackend(AttentionBackend):
             and not self.use_mla
         )
 
+        self._fa3_mla_fp8_shadow = None
+        can_allocate_mla_fp8_shadow = is_fa3_mla_fp8_shadow_enabled(
+            fa_impl_ver=self.fa_impl_ver,
+            use_mla=self.use_mla,
+            page_size=self.page_size,
+            unified_dense=self._unified_dense,
+            attn_cp_size=self.attn_cp_size,
+            is_draft_runner=self.is_draft_runner,
+            dcp_enabled=get_parallel().dcp_enabled,
+            dsa_kv_cache_store_fp8=getattr(
+                self.token_to_kv_pool, "dsa_kv_cache_store_fp8", False
+            ),
+        )
+        if can_allocate_mla_fp8_shadow:
+            first_layer = getattr(self.token_to_kv_pool, "start_layer", 0)
+            source = self.token_to_kv_pool.get_key_buffer(first_layer)
+            self._fa3_mla_fp8_shadow = FA3MLAFP8KVShadow.maybe_create(
+                source, model_runner.dtype
+            )
+
         # Skip the FA3 scheduler_metadata precompute (PR #21104) when distributed
         # attention modes can change live cache_seqlens/num_splits across ranks.
         # A stale precomputed buffer can lead to an OOB read in the split-KV
@@ -389,6 +413,27 @@ class FlashAttentionBackend(AttentionBackend):
             has_softcap=self.has_softcap,
             num_splits=self.num_splits,
         )
+
+    def _get_mla_kv_cache_for_fa3(
+        self,
+        layer_id: int,
+        output_dtype: torch.dtype,
+        page_table: torch.Tensor,
+        cache_seqlens: torch.Tensor,
+        use_fp8_shadow: bool,
+    ) -> torch.Tensor:
+        source = self.token_to_kv_pool.get_key_buffer(layer_id)
+        shadow = self._fa3_mla_fp8_shadow
+
+        if (
+            use_fp8_shadow
+            and shadow is not None
+            and shadow.can_materialize(source, output_dtype)
+        ):
+            return shadow.materialize(source, page_table, cache_seqlens)
+
+        # Preserve the existing path for every unsupported configuration.
+        return source.to(output_dtype)
 
     def _mxfp8_sf_kwargs(self, layer, forward_batch, q_descale=None):
         """Block-scaled UE8M0 scale factors for the FA4 MXFP8 attention path.
@@ -1617,8 +1662,25 @@ class FlashAttentionBackend(AttentionBackend):
                 # call takes the same qv/ver arguments as this extend path.
                 assert self.fa_impl_ver in (3, 4), "Only FA3/FA4 support here"
                 # Do absorbed multi-latent attention
-                kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id).to(
-                    q.dtype
+                use_fp8_shadow = (
+                    forward_batch.forward_mode
+                    in (
+                        ForwardMode.EXTEND,
+                        ForwardMode.MIXED,
+                        ForwardMode.SPLIT_PREFILL,
+                    )
+                    and not is_cp_mode
+                    and not use_cascade_attn
+                    and not use_local_attn
+                    and not is_swa_layer
+                    and not layer.is_cross_attention
+                )
+                kv_cache = self._get_mla_kv_cache_for_fa3(
+                    layer_id=layer.layer_id,
+                    output_dtype=q.dtype,
+                    page_table=page_table,
+                    cache_seqlens=cache_seqlens,
+                    use_fp8_shadow=use_fp8_shadow,
                 )
                 k_rope = kv_cache[:, :, layer.v_head_dim :]
                 c_kv = kv_cache[:, :, : layer.v_head_dim]
@@ -2031,8 +2093,22 @@ class FlashAttentionBackend(AttentionBackend):
                 else:
                     o = result
         else:
+            use_fp8_shadow = (
+                forward_batch.forward_mode.is_decode_or_idle()
+                and forward_batch.spec_info is None
+                and not use_cascade_attn
+                and not use_local_attn
+                and not is_swa_layer
+                and not layer.is_cross_attention
+            )
             # Do absorbed multi-latent attention
-            kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id).to(q.dtype)
+            kv_cache = self._get_mla_kv_cache_for_fa3(
+                layer_id=layer.layer_id,
+                output_dtype=q.dtype,
+                page_table=metadata.page_table,
+                cache_seqlens=metadata.cache_seqlens_int32,
+                use_fp8_shadow=use_fp8_shadow,
+            )
             k_rope = kv_cache[:, :, layer.v_head_dim :]
             c_kv = kv_cache[:, :, : layer.v_head_dim]
             k_rope_cache = k_rope.view(

--- a/test/registered/kernels/ops/kvcache/test_mla_fp8_page_table_dequant.py
+++ b/test/registered/kernels/ops/kvcache/test_mla_fp8_page_table_dequant.py
@@ -1,0 +1,325 @@
+"""GPU tests for FA3's page-id-preserving MLA FP8 shadow.
+
+The production path must copy only live page-table rows, preserve physical page
+ids, deduplicate pages shared by requests, reuse one workspace across layers,
+and remain correct when page-table contents change between CUDA Graph replays.
+Unsupported sources and backend routes must keep the legacy full-pool cast.
+"""
+
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from sglang.kernels.ops.kvcache.mla_buffer import (
+    FA3MLAFP8KVShadow,
+    dequantize_mla_fp8_page_table,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires a CUDA GPU"
+)
+
+DEVICE = "cuda"
+NUM_PAGES = 64
+ROW_WIDTH = 576
+
+
+def _make_state(fp8_dtype, output_dtype):
+    source = torch.randn(NUM_PAGES, 1, ROW_WIDTH, device=DEVICE).to(fp8_dtype)
+    shadow = torch.full(
+        (NUM_PAGES, 1, ROW_WIDTH),
+        float("nan"),
+        dtype=output_dtype,
+        device=DEVICE,
+    )
+    page_table = torch.tensor(
+        [
+            [1, 2, 3, 4, 5, 0, 0, 0],
+            [1, 2, 8, 9, 0, 0, 0, 0],
+            [0, 0, 0, 0, 0, 0, 0, 0],
+        ],
+        dtype=torch.int32,
+        device=DEVICE,
+    )
+    cache_seqlens = torch.tensor([5, 4, 0], dtype=torch.int32, device=DEVICE)
+    page_epochs = torch.zeros(NUM_PAGES, dtype=torch.int32, device=DEVICE)
+    epoch = torch.zeros((), dtype=torch.int32, device=DEVICE)
+    return source, shadow, page_table, cache_seqlens, page_epochs, epoch
+
+
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+@pytest.mark.parametrize("output_dtype", [torch.bfloat16, torch.float16])
+def test_dequantize_only_referenced_pages(fp8_dtype, output_dtype):
+    source, shadow, page_table, cache_seqlens, page_epochs, epoch = _make_state(
+        fp8_dtype, output_dtype
+    )
+
+    dequantize_mla_fp8_page_table(
+        source, shadow, page_table, cache_seqlens, page_epochs, epoch
+    )
+
+    referenced = torch.tensor([1, 2, 3, 4, 5, 8, 9], device=DEVICE)
+    torch.testing.assert_close(
+        shadow[referenced], source[referenced].to(output_dtype), rtol=0, atol=0
+    )
+    assert torch.isnan(shadow[6]).all()
+    assert epoch.item() == 1
+    assert torch.count_nonzero(page_epochs == epoch).item() == referenced.numel()
+
+    source[10:12] = torch.randn(2, 1, ROW_WIDTH, device=DEVICE).to(fp8_dtype)
+    page_table.copy_(
+        torch.tensor(
+            [
+                [10, 11, 0, 0, 0, 0, 0, 0],
+                [10, 0, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=torch.int32,
+            device=DEVICE,
+        )
+    )
+    cache_seqlens.copy_(torch.tensor([2, 1, 0], dtype=torch.int32, device=DEVICE))
+    dequantize_mla_fp8_page_table(
+        source, shadow, page_table, cache_seqlens, page_epochs, epoch
+    )
+
+    torch.testing.assert_close(
+        shadow[10:12], source[10:12].to(output_dtype), rtol=0, atol=0
+    )
+    assert epoch.item() == 2
+    assert torch.count_nonzero(page_epochs == epoch).item() == 2
+
+
+def test_dequantize_is_cuda_graph_replay_safe():
+    source, shadow, page_table, cache_seqlens, page_epochs, epoch = _make_state(
+        torch.float8_e4m3fn, torch.bfloat16
+    )
+    dequantize_mla_fp8_page_table(
+        source, shadow, page_table, cache_seqlens, page_epochs, epoch
+    )
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        dequantize_mla_fp8_page_table(
+            source, shadow, page_table, cache_seqlens, page_epochs, epoch
+        )
+
+    new_values = torch.randn(3, 1, ROW_WIDTH, device=DEVICE).to(torch.float8_e4m3fn)
+    source[20:23].copy_(new_values)
+    page_table.copy_(
+        torch.tensor(
+            [
+                [20, 21, 0, 0, 0, 0, 0, 0],
+                [20, 22, 0, 0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0, 0, 0, 0],
+            ],
+            dtype=torch.int32,
+            device=DEVICE,
+        )
+    )
+    cache_seqlens.copy_(torch.tensor([2, 2, 0], dtype=torch.int32, device=DEVICE))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        shadow[20:23], source[20:23].to(torch.bfloat16), rtol=0, atol=0
+    )
+    assert epoch.item() == 2
+
+    newer_values = torch.randn(2, 1, ROW_WIDTH, device=DEVICE).to(torch.float8_e4m3fn)
+    source[30:32].copy_(newer_values)
+    page_table.zero_()
+    page_table[0, :2] = torch.tensor([30, 31], dtype=torch.int32, device=DEVICE)
+    cache_seqlens.copy_(torch.tensor([2, 0, 0], dtype=torch.int32, device=DEVICE))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        shadow[30:32], source[30:32].to(torch.bfloat16), rtol=0, atol=0
+    )
+    assert epoch.item() == 3
+
+
+def test_empty_page_table_is_a_noop():
+    source = torch.randn(NUM_PAGES, 1, ROW_WIDTH, device=DEVICE).to(torch.float8_e4m3fn)
+    shadow = torch.full_like(source, float("nan"), dtype=torch.bfloat16)
+    page_epochs = torch.zeros(NUM_PAGES, dtype=torch.int32, device=DEVICE)
+    epoch = torch.zeros((), dtype=torch.int32, device=DEVICE)
+
+    dequantize_mla_fp8_page_table(
+        source,
+        shadow,
+        torch.empty((0, 0), dtype=torch.int32, device=DEVICE),
+        torch.empty(0, dtype=torch.int32, device=DEVICE),
+        page_epochs,
+        epoch,
+    )
+
+    assert torch.isnan(shadow).all()
+    assert epoch.item() == 0
+    assert torch.count_nonzero(page_epochs).item() == 0
+
+
+@pytest.mark.parametrize(
+    ("mutation", "message"),
+    [
+        (lambda state: state.__setitem__(1, state[1][:-1]), "matching row-major"),
+        (lambda state: state.__setitem__(2, state[2].flatten()), "2D page table"),
+        (
+            lambda state: state.__setitem__(3, state[3][:-1]),
+            "one entry for every page-table row",
+        ),
+        (
+            lambda state: state.__setitem__(4, state[4][:-1]),
+            "Epoch state does not match",
+        ),
+        (
+            lambda state: state.__setitem__(5, torch.zeros(2, device=DEVICE)),
+            "Epoch state does not match",
+        ),
+    ],
+)
+def test_input_validation_fails_before_launch(mutation, message):
+    state = list(_make_state(torch.float8_e4m3fn, torch.bfloat16))
+    mutation(state)
+    with pytest.raises(ValueError, match=message):
+        dequantize_mla_fp8_page_table(*state)
+
+
+@pytest.mark.parametrize(
+    ("source_factory", "output_dtype"),
+    [
+        (
+            lambda: torch.zeros(
+                NUM_PAGES, 1, ROW_WIDTH, dtype=torch.bfloat16, device=DEVICE
+            ),
+            torch.bfloat16,
+        ),
+        (
+            lambda: torch.zeros(
+                NUM_PAGES, 1, ROW_WIDTH, dtype=torch.float8_e4m3fn, device=DEVICE
+            ),
+            torch.float32,
+        ),
+        (
+            lambda: torch.zeros(
+                NUM_PAGES,
+                1,
+                ROW_WIDTH * 2,
+                dtype=torch.float8_e4m3fn,
+                device=DEVICE,
+            )[..., ::2],
+            torch.bfloat16,
+        ),
+    ],
+)
+def test_shadow_factory_rejects_unsupported_sources(source_factory, output_dtype):
+    assert FA3MLAFP8KVShadow.maybe_create(source_factory(), output_dtype) is None
+
+
+def test_shadow_workspace_is_shared_across_layers():
+    first_layer = torch.randn(NUM_PAGES, 1, ROW_WIDTH, device=DEVICE).to(
+        torch.float8_e4m3fn
+    )
+    second_layer = torch.randn(NUM_PAGES, 1, ROW_WIDTH, device=DEVICE).to(
+        torch.float8_e4m3fn
+    )
+    page_table = torch.tensor([[1, 2, 8]], dtype=torch.int32, device=DEVICE)
+    cache_seqlens = torch.tensor([3], dtype=torch.int32, device=DEVICE)
+
+    shadow = FA3MLAFP8KVShadow.maybe_create(first_layer, torch.bfloat16)
+    assert shadow is not None
+    assert shadow.buffer.shape == first_layer.shape
+    assert shadow.buffer.dtype == torch.bfloat16
+    assert shadow.page_epochs.shape == (NUM_PAGES,)
+    first_result = shadow.materialize(first_layer, page_table, cache_seqlens)
+    first_pointer = first_result.data_ptr()
+    torch.testing.assert_close(
+        first_result[page_table[0]], first_layer[page_table[0]].to(torch.bfloat16)
+    )
+
+    second_result = shadow.materialize(second_layer, page_table, cache_seqlens)
+    assert second_result.data_ptr() == first_pointer
+    torch.testing.assert_close(
+        second_result[page_table[0]], second_layer[page_table[0]].to(torch.bfloat16)
+    )
+    torch.testing.assert_close(
+        page_table, torch.tensor([[1, 2, 8]], dtype=torch.int32, device=DEVICE)
+    )
+
+    assert not shadow.can_materialize(second_layer, torch.float16)
+    assert not shadow.can_materialize(second_layer[:-1], torch.bfloat16)
+    noncontiguous_layer = torch.zeros(
+        NUM_PAGES,
+        1,
+        ROW_WIDTH * 2,
+        dtype=torch.float8_e4m3fn,
+        device=DEVICE,
+    )[..., ::2]
+    assert noncontiguous_layer.shape == second_layer.shape
+    assert not noncontiguous_layer.is_contiguous()
+    assert not shadow.can_materialize(noncontiguous_layer, torch.bfloat16)
+
+
+def test_backend_selects_shadow_and_preserves_page_table():
+    backend_module = pytest.importorskip(
+        "sglang.srt.layers.attention.flashattention_backend",
+        reason="requires a loadable sgl_kernel build",
+        exc_type=ImportError,
+    )
+    FlashAttentionBackend = backend_module.FlashAttentionBackend
+
+    source = torch.randn(NUM_PAGES, 1, ROW_WIDTH, device=DEVICE).to(torch.float8_e4m3fn)
+    materialized = torch.empty_like(source, dtype=torch.bfloat16)
+    page_table = torch.tensor([[1, 2]], dtype=torch.int32, device=DEVICE)
+    cache_seqlens = torch.tensor([2], dtype=torch.int32, device=DEVICE)
+
+    pool = Mock()
+    pool.get_key_buffer.return_value = source
+    shadow = Mock()
+    shadow.can_materialize.return_value = True
+    shadow.materialize.return_value = materialized
+
+    backend = object.__new__(FlashAttentionBackend)
+    backend.token_to_kv_pool = pool
+    backend._fa3_mla_fp8_shadow = shadow
+
+    result = backend._get_mla_kv_cache_for_fa3(
+        layer_id=3,
+        output_dtype=torch.bfloat16,
+        page_table=page_table,
+        cache_seqlens=cache_seqlens,
+        use_fp8_shadow=True,
+    )
+    assert result is materialized
+    pool.get_key_buffer.assert_called_once_with(3)
+    shadow.materialize.assert_called_once_with(source, page_table, cache_seqlens)
+    torch.testing.assert_close(
+        page_table, torch.tensor([[1, 2]], dtype=torch.int32, device=DEVICE)
+    )
+
+    fallback = backend._get_mla_kv_cache_for_fa3(
+        3, torch.bfloat16, page_table, cache_seqlens, use_fp8_shadow=False
+    )
+    torch.testing.assert_close(fallback, source.to(torch.bfloat16), rtol=0, atol=0)
+    shadow.materialize.assert_called_once()
+
+    shadow.can_materialize.return_value = False
+    incompatible = backend._get_mla_kv_cache_for_fa3(
+        3, torch.bfloat16, page_table, cache_seqlens, use_fp8_shadow=True
+    )
+    torch.testing.assert_close(incompatible, source.to(torch.bfloat16), rtol=0, atol=0)
+    shadow.materialize.assert_called_once()
+
+    backend._fa3_mla_fp8_shadow = None
+    missing_shadow = backend._get_mla_kv_cache_for_fa3(
+        3, torch.bfloat16, page_table, cache_seqlens, use_fp8_shadow=True
+    )
+    torch.testing.assert_close(
+        missing_shadow, source.to(torch.bfloat16), rtol=0, atol=0
+    )

--- a/test/registered/unit/layers/attention/test_fa3_mla_fp8_shadow.py
+++ b/test/registered/unit/layers/attention/test_fa3_mla_fp8_shadow.py
@@ -1,0 +1,131 @@
+"""CPU guard tests for FA3's shared MLA FP8 shadow.
+
+The GPU suite validates the Triton conversion and CUDA Graph replay. This file
+pins every backend/source eligibility condition independently, so unsupported
+configurations cannot accidentally leave the legacy full-pool cast path.
+"""
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang.kernels.ops.kvcache.mla_buffer import (
+    FA3MLAFP8KVShadow,
+    is_fa3_mla_fp8_shadow_enabled,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestBackendEligibilityGuard(CustomTestCase):
+    QUALIFYING = dict(
+        fa_impl_ver=3,
+        use_mla=True,
+        page_size=1,
+        unified_dense=False,
+        attn_cp_size=1,
+        is_draft_runner=False,
+        dcp_enabled=False,
+        dsa_kv_cache_store_fp8=False,
+    )
+
+    def test_qualifying_config_enables_shadow(self):
+        self.assertTrue(is_fa3_mla_fp8_shadow_enabled(**self.QUALIFYING))
+
+    def test_each_disqualifier_disables_shadow(self):
+        overrides = (
+            ("FA4", dict(fa_impl_ver=4)),
+            ("non-MLA model", dict(use_mla=False)),
+            ("page size greater than one", dict(page_size=64)),
+            ("unified dense pool", dict(unified_dense=True)),
+            ("attention CP", dict(attn_cp_size=2)),
+            ("draft runner", dict(is_draft_runner=True)),
+            ("decode context parallelism", dict(dcp_enabled=True)),
+            ("DSA FP8 storage", dict(dsa_kv_cache_store_fp8=True)),
+        )
+        for name, override in overrides:
+            with self.subTest(name):
+                config = {**self.QUALIFYING, **override}
+                self.assertFalse(is_fa3_mla_fp8_shadow_enabled(**config))
+
+
+class TestSourceEligibilityGuard(CustomTestCase):
+    @staticmethod
+    def _source(**overrides):
+        attrs = dict(
+            dtype=torch.float8_e4m3fn,
+            ndim=3,
+            is_cuda=True,
+            is_contiguous=lambda: True,
+        )
+        return SimpleNamespace(**{**attrs, **overrides})
+
+    def test_supported_dtype_pairs(self):
+        for source_dtype in (torch.float8_e4m3fn, torch.float8_e5m2):
+            for output_dtype in (torch.bfloat16, torch.float16):
+                with self.subTest(source_dtype=source_dtype, output_dtype=output_dtype):
+                    source = self._source(dtype=source_dtype)
+                    self.assertTrue(
+                        FA3MLAFP8KVShadow.is_supported_source(source, output_dtype)
+                    )
+
+    def test_each_source_disqualifier_is_rejected(self):
+        cases = (
+            (
+                "non-FP8 source",
+                self._source(dtype=torch.bfloat16),
+                torch.bfloat16,
+            ),
+            (
+                "unsupported output dtype",
+                self._source(),
+                torch.float32,
+            ),
+            (
+                "one-dimensional source",
+                self._source(ndim=1),
+                torch.bfloat16,
+            ),
+            (
+                "CPU source",
+                self._source(is_cuda=False),
+                torch.bfloat16,
+            ),
+            (
+                "non-contiguous source",
+                self._source(is_contiguous=lambda: False),
+                torch.bfloat16,
+            ),
+        )
+        for name, source, output_dtype in cases:
+            with self.subTest(name):
+                self.assertFalse(
+                    FA3MLAFP8KVShadow.is_supported_source(source, output_dtype)
+                )
+
+    def test_factory_does_not_allocate_for_cpu_tensor(self):
+        source = torch.zeros(8, 1, 576, dtype=torch.uint8).view(torch.float8_e4m3fn)
+        self.assertIsNone(FA3MLAFP8KVShadow.maybe_create(source, torch.bfloat16))
+
+
+class TestShadowStateLayout(CustomTestCase):
+    def test_persistent_state_matches_source_pool(self):
+        source = torch.zeros(8, 1, 576, dtype=torch.uint8).view(torch.float8_e4m3fn)
+        shadow = FA3MLAFP8KVShadow(source, torch.bfloat16)
+
+        self.assertEqual(shadow.buffer.shape, source.shape)
+        self.assertEqual(shadow.buffer.dtype, torch.bfloat16)
+        self.assertEqual(shadow.buffer.device, source.device)
+        self.assertEqual(shadow.page_epochs.shape, (source.shape[0],))
+        self.assertEqual(shadow.page_epochs.dtype, torch.int32)
+        self.assertEqual(shadow.epoch.shape, torch.Size([]))
+        self.assertEqual(shadow.epoch.dtype, torch.int32)
+        self.assertEqual(shadow.epoch.item(), 0)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation and scope

Related to #35291. This PR addresses the FA3 MLA path and does not automatically close the issue. The corresponding native FP8 solution for `flashinfer_mla` is tracked separately in #35322, which covers decode and paged prefill on qualifying SM90 configurations and is still open.

FA3 absorbed MLA currently converts the entire per-layer FP8 KV pool to the query dtype on every forward, even when the page table references only a small fraction of the pool. This change converts only the referenced physical pages.

## Modifications

- Add a Triton kernel for referenced-page FP8 E4M3/E5M2 to BF16/FP16 conversion, preserving physical page IDs and the original page table.
- Support multi-token pages: compute live pages with `ceil(cache_seqlen / page_size)` and map physical page IDs to token rows. Copy shared tail pages in full regardless of which request claims the page first.
- Share a persistent shadow across MLA layers on a rank. Persistent epoch state deduplicates pages and supports CUDA Graph capture/replay.
- Enable the optimized path for normal FA3 MLA decode and eager extend; real FA3 comparisons cover page sizes 1, 16, 64, and 128.
- Preserve fallback behavior for speculative, cascade, local/SWA, cross-attention, CP/DCP, draft, unified-dense, and other unsupported configurations.
- Synchronize with current main and use the upstream `cp_active` state for the CP fallback guard.

## Correctness tests

Revalidated on the final integrated tree on 2026-09-21: H800/SM90, PyTorch 2.9.1+cu129.

```text
70 passed, 48 subtests passed
0 failed, 0 skipped
```

Coverage includes:

- Backend/source eligibility and every disqualifier, including fallback guards with larger page sizes.
- Exact E4M3/E5M2 to BF16/FP16 conversion; page sizes 1/3/16/64/128; page boundaries, shared tails, highest physical page, empty sequences, and invalid inputs.
- Cross-layer workspace reuse, page recycling, and CUDA Graph replay with updated source data, page tables, and sequence lengths.
- Padded, non-contiguous page-table rows; out-of-range sentinels in inactive entries and empty requests; bounded-program traversal across multiple pages.
- Bitwise equality against full-pool conversion through real FA3 with page sizes 1/16/64/128 and query lengths 1/8 (`rtol=0`, `atol=0`).

Ruff lint/format, isort, codespell, Python compilation, test-registration checks, registered-test placement checks, pytest entry-point checks, and `git diff --check` pass locally. GitHub Lint passed on the identical code tree before the history-only squash to a single commit. The squashed commit is `c78a96e97725d0d462da215c3afe1d236c314732`. The full upstream test workflow is gated on the maintainer-controlled `run-ci` label; its tests have not run.

## End-to-end performance and output comparison

These measurements were collected on 2026-09-17, before synchronizing with current main. Performance has not been rerun on the newly integrated main revision.

Single H800/SM90, real DeepSeek-V2-Lite-Chat weights, TP=1, FA3, FP8 E4M3 KV, 131072-token pool, decode CUDA Graph enabled, radix cache disabled. The baseline uses the same source tree with shadow allocation disabled to select the original full-pool conversion. Each workload was warmed up and measured five times; values below are medians.

| Page size | Concurrency | Input/output tokens | Full-pool conversion | Selective conversion | Output throughput: baseline → selective |
|---:|---:|---:|---:|---:|---:|
| 1 | 8 | 1024/256 | 2.8342 s | 1.3878 s | 722.6 → 1475.7 token/s |
| 64 | 8 | 1024/256 | 2.8388 s | 1.3619 s | 721.4 → 1503.7 token/s |

Across two page sizes, five workloads, and five measured repetitions per version, 1140 output sequences containing 166400 generated tokens matched token-for-token within each page-size/workload comparison. Counts include repeated workloads for consistency validation; this is not a task-accuracy evaluation.

In a short decode profile, 108 full-pool conversions took approximately 24.84 ms in total. The selective kernels took approximately 0.50 ms at page size 1 and 1.15 ms at page size 64, with no corresponding full-pool conversion kernel in the optimized traces. A CUDA Graph microbenchmark with 131073 pool rows, width 576, and 1440 live tokens reduced page-size-1 conversion from 225.82 μs to 5.60 μs. This kernel-level speedup is not an end-to-end speedup.

Both temporary end-to-end test trees used the same `only_qv=False` adapter for the test host's older FA3 interface. That environment adapter is not part of this PR. Results should not be extrapolated directly to multi-GPU DeepSeek-R1, other live-KV ratios, or production traffic distributions.

## Checklist

- [x] Formatting and static checks.
- [x] Registered CPU/GPU regression tests.
- [x] Correctness, end-to-end performance, and profiling results.
- [x] Explicit FA3/FlashInfer scope without auto-closing #35291.
- [ ] Documentation update (not applicable: no new public API or configuration).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35599611565](https://github.com/sgl-project/sglang/actions/runs/35599611565)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35599611156](https://github.com/sgl-project/sglang/actions/runs/35599611156)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35599611586](https://github.com/sgl-project/sglang/actions/runs/35599611586)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
