### PR TITLE
docs(npu): add NPU profiler analysis skill (#1102)

### DIFF
--- a/.claude/skills/sglang-npu-profiler-analysis/SKILL.md
+++ b/.claude/skills/sglang-npu-profiler-analysis/SKILL.md
@@ -1,0 +1,162 @@
+---
+name: sglang-npu-profiler-analysis
+description: "End-to-end Ascend NPU profiling workflow for SGLang: capture traces with torch_npu profiler, parse ASCEND_PROFILER_OUTPUT, and produce a standard bottleneck report. Use when tuning SGLang on Atlas 800T A2/A3, analyzing operator_details.csv / trace_view.json, or building NPU performance reports from bench_serving --profile output."
+---
+
+# SGLang NPU Profiler Analysis
+
+## When to Use
+
+- Ascend NPU inference bottleneck analysis for SGLang (`Atlas 800T A2` / `A3`)
+- After collecting traces with `bench_serving --profile`, `/start_profile`, or `sglang.profiler`
+- Before/after tuning graph mode, quantization, PD, speculative decoding, or MoE switches
+- When you need a **repeatable report** from `operator_details.csv` / `kernel_details.csv`
+
+Human-readable capture instructions live in [docs/.../optimization/profiling.mdx](../../../docs/docs/hardware-platforms/ascend-npus/optimization/profiling.mdx).
+
+## Inputs
+
+| Input | Required | Notes |
+| --- | --- | --- |
+| `trace_dir` | yes | Directory containing `*_ascend_pt/` or `ASCEND_PROFILER_OUTPUT/` |
+| `model` | recommended | Model name for report header |
+| `launch_cmd` | recommended | Exact `sglang serve` command |
+| `workload` | optional | bench_serving dataset / concurrency description |
+| `baseline_trace_dir` | optional | Second trace for before/after comparison |
+
+## Outputs
+
+Produce **one markdown report** with these sections (template: [references/report-template.md](references/report-template.md)):
+
+1. Environment summary (hardware, CANN/TorchNPU, SGLang commit)
+2. Capture method and parameters
+3. Top operators table (from `operator_details.csv`)
+4. Top kernels table (from `kernel_details.csv`, if present)
+5. Bottleneck hypothesis (memory bound / compute bound / launch bound / comm bound)
+6. Recommended next experiments (≤5 bullets)
+7. Optional before/after delta table when `baseline_trace_dir` is provided
+
+Optional JSON sidecar: `report.json` with the same tables for automation.
+
+## Workflow
+
+### Step 1 — Capture (production-like)
+
+Preferred one-shot command on a running server:
+
+```bash
+export SGLANG_TORCH_PROFILER_DIR=./sglang_profile
+
+python -m sglang.bench_serving \
+  --backend sglang \
+  --base-url http://127.0.0.1:30000 \
+  --model /path/to/model \
+  --tokenizer /path/to/model \
+  --dataset-name random \
+  --random-input-len 1024 \
+  --random-output-len 128 \
+  --num-prompts 8 \
+  --profile \
+  --profile-steps 5 \
+  --profile-output-dir ./sglang_profile
+```
+
+Rules:
+
+- Keep `--num-prompts` and output lengths small to avoid huge traces.
+- Set `start_step` / `--profile-steps` to skip warmup (see profiling doc Method B).
+- On NPU, `activities: ["CPU", "GPU"]` maps to NPU events via `torch_npu` patches.
+
+### Step 2 — Locate parsed output
+
+After capture completes, open the directory logged by the server:
+
+`Profiling done. Traces are saved to: <path>`
+
+Inside `<path>/*/ASCEND_PROFILER_OUTPUT/` expect:
+
+| File | Use |
+| --- | --- |
+| `operator_details.csv` | Primary bottleneck table |
+| `kernel_details.csv` | Kernel-level breakdown |
+| `trace_view.json` | Timeline view in MindStudio Insight / Perfetto |
+| `analysis.db` | Advanced DB queries |
+
+See [references/npu-trace-layout.md](references/npu-trace-layout.md).
+
+### Step 3 — Summarize CSVs
+
+Run the helper script on the `ASCEND_PROFILER_OUTPUT` directory:
+
+```bash
+python .claude/skills/sglang-npu-profiler-analysis/scripts/summarize_npu_trace.py \
+  --trace-dir ./sglang_profile/<timestamp>/<host>_*_ascend_pt/ASCEND_PROFILER_OUTPUT \
+  --top 20 \
+  --markdown-out ./npu_profile_report.md
+```
+
+If only raw `*_ascend_pt/` exists (interrupted capture), re-parse with:
+
+```python
+from torch_npu.profiler.profiler import analyse
+analyse("./sglang_profile/<host>_*_ascend_pt/")
+```
+
+### Step 4 — Classify bottlenecks
+
+Use this decision table:
+
+| Signal in top operators | Likely bottleneck | Next knob |
+| --- | --- | --- |
+| Attention / FIA / MLA ops dominate | Compute or memory bandwidth | quant, MLAPO, page size, graph mode |
+| AllGather / ReduceScatter / HCCL | Communication | TP/EP layout, DP attention, batch size |
+| Small op fan-out + launch gaps | Launch overhead | `--cuda-graph-bs`, reduce capture sizes |
+| Prefill-heavy timeline | Prefill scheduling | chunked prefill, PD split |
+| Decode steady-state gaps | Decode batching | `--max-running-requests`, graph sizes |
+
+### Step 5 — Graph-mode-specific profiling
+
+| Goal | Server flag | Output |
+| --- | --- | --- |
+| Production-like decode with graphs | default / `--cuda-graph-bs ...` | normal `ASCEND_PROFILER_OUTPUT` |
+| Python stack visibility | `--disable-cuda-graph` | clearer stacks, slower decode |
+| Capture overhead debugging | `--enable-profile-cuda-graph` | `graph_capture_profile/` traces |
+
+See [NPU Graph Mode Usage Guide](../../../docs/docs/hardware-platforms/ascend-npus/optimization/npu_graph_mode.mdx).
+
+### Step 6 — Multi-hardware adaptation methodology
+
+When porting this workflow off Ascend:
+
+1. Keep the **same report schema** (sections 1–7 above).
+2. Swap capture backend (CUDA Nsight, ROCm RPD, etc.) but preserve workload JSON.
+3. Map operator CSV columns to the local profiler export format.
+4. Record incompatible activities (NPU ignores `MEM`; ROCm `RPD` is unsupported on Ascend).
+5. Store before/after artifacts under `out/<issue>/profiles/{baseline,tuned}/`.
+
+For cross-framework torch-profiler triage on existing `trace.json`, also see `.claude/skills/llm-torch-profiler-analysis/`.
+
+## Quality Gates
+
+Before marking analysis complete:
+
+- [ ] Trace directory path recorded in the report
+- [ ] Capture command and server flags recorded
+- [ ] Top operators table includes ≥10 rows or all rows if fewer
+- [ ] At least one bottleneck hypothesis tied to evidence (operator name / time share)
+- [ ] Recommendations are actionable SGLang flags or env vars (not generic advice)
+- [ ] Graph-mode state documented (`enabled` / `disabled` / capture list)
+
+## Anti-Patterns
+
+- Do not compare traces captured with different graph-mode settings without labeling the delta.
+- Do not use `--disable-cuda-graph` numbers as production TPOT baselines.
+- Do not merge multi-node Ascend traces unless validated; prefer per-node `trace_view.json`.
+- Do not run `analyse()` on already parsed trees unless you backed up `ASCEND_PROFILER_OUTPUT`.
+
+## References
+
+- [Capture guide (docs)](../../../docs/docs/hardware-platforms/ascend-npus/optimization/profiling.mdx)
+- [Graph mode guide](../../../docs/docs/hardware-platforms/ascend-npus/optimization/npu_graph_mode.mdx)
+- [Report template](references/report-template.md)
+- [Trace layout](references/npu-trace-layout.md)

--- a/.claude/skills/sglang-npu-profiler-analysis/references/npu-trace-layout.md
+++ b/.claude/skills/sglang-npu-profiler-analysis/references/npu-trace-layout.md
@@ -1,0 +1,34 @@
+# NPU Trace Layout
+
+After a successful SGLang NPU profile capture, directories typically look like:
+
+```text
+<output_dir>/
+  <timestamp>/                     # present when using bench_serving --profile
+    <hostname>_<pid>_<ts>_ascend_pt/
+      ASCEND_PROFILER_OUTPUT/
+        trace_view.json
+        analysis.db
+        ascend_pytorch_profiler_0.db
+        kernel_details.csv
+        operator_details.csv
+        step_trace_time.csv
+```
+
+## Key files
+
+| File | Contents |
+| --- | --- |
+| `operator_details.csv` | Operator name, duration, device time — primary ranking input |
+| `kernel_details.csv` | Lower-level kernel entries |
+| `trace_view.json` | Chrome trace / MindStudio Insight timeline |
+| `step_trace_time.csv` | Step boundaries for prefill/decode separation |
+
+## Server log anchors
+
+Search logs for:
+
+- `Profiling starts. Traces will be saved to:`
+- `Profiling done. Traces are saved to:`
+
+Those lines are authoritative when multiple timestamp folders exist.

--- a/.claude/skills/sglang-npu-profiler-analysis/references/report-template.md
+++ b/.claude/skills/sglang-npu-profiler-analysis/references/report-template.md
@@ -1,0 +1,55 @@
+# SGLang NPU Profiling Report
+
+## 1. Summary
+
+| Field | Value |
+| --- | --- |
+| Date | YYYY-MM-DD |
+| Model | |
+| Hardware | Atlas 800T A2 / A3, N cards |
+| SGLang commit | |
+| Trace directory | |
+| Capture method | bench_serving --profile / API / sglang.profiler |
+| Graph mode | enabled / disabled / capture list |
+
+## 2. Workload
+
+```
+<paste bench_serving or curl workload here>
+```
+
+## 3. Top Operators
+
+| Rank | Operator | Time (ms) | Share (%) |
+| --- | --- | ---: | ---: |
+| 1 | | | |
+
+## 4. Top Kernels
+
+| Rank | Kernel | Time (ms) | Share (%) |
+| --- | --- | ---: | ---: |
+| 1 | | | |
+
+## 5. Bottleneck Analysis
+
+- **Primary bottleneck:**
+- **Evidence:**
+- **Secondary effects:**
+
+## 6. Recommended Next Steps
+
+1.
+2.
+3.
+
+## 7. Before / After (optional)
+
+| Metric / operator | Baseline | Tuned | Delta |
+| --- | ---: | ---: | ---: |
+| Top operator #1 | | | |
+
+## 8. Artifacts
+
+- Trace path:
+- MindStudio / Perfetto file:
+- Raw CSV paths:

--- a/.claude/skills/sglang-npu-profiler-analysis/scripts/summarize_npu_trace.py
+++ b/.claude/skills/sglang-npu-profiler-analysis/scripts/summarize_npu_trace.py
@@ -10,7 +10,12 @@ def _read_csv(path: Path) -> list[dict[str, str]]:
     if not path.is_file():
         return []
     with path.open(newline="", encoding="utf-8", errors="replace") as f:
-        return list(csv.DictReader(f))
+        sample = f.read(4096)
+    if not sample.strip():
+        return []
+    delimiter = "\t" if sample.count("\t") > sample.count(",") else ","
+    with path.open(newline="", encoding="utf-8", errors="replace") as f:
+        return list(csv.DictReader(f, delimiter=delimiter))
 
 
 def _pick_name(row: dict[str, str]) -> str:
@@ -22,18 +27,29 @@ def _pick_name(row: dict[str, str]) -> str:
 
 def _pick_time(row: dict[str, str]) -> float:
     for key in (
+        "Device Total Duration(us)",
+        "Device Self Duration(us)",
+        "Host Total Duration(us)",
+        "Host Self Duration(us)",
+        "Device Total Duration With AICore(us)",
+        "Device Self Duration With AICore(us)",
         "Total Time (us)",
         "Total Time (ms)",
         "Duration (us)",
         "Duration (ms)",
+        "Duration(us)",
         "Device Duration (us)",
         "Device Duration (ms)",
+        "aicore_time(us)",
     ):
         if key in row and row[key]:
-            val = float(str(row[key]).replace(",", ""))
+            val = float(str(row[key]).replace(",", "").strip())
             if "ms" in key.lower():
                 return val
             return val / 1000.0
+    for key, raw in row.items():
+        if "duration" in key.lower() and "(us)" in key.lower() and raw:
+            return float(str(raw).replace(",", "").strip()) / 1000.0
     return 0.0
 
 

--- a/.claude/skills/sglang-npu-profiler-analysis/scripts/summarize_npu_trace.py
+++ b/.claude/skills/sglang-npu-profiler-analysis/scripts/summarize_npu_trace.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Summarize Ascend NPU profiler CSV exports into a markdown report."""
+
+import argparse
+import csv
+from pathlib import Path
+
+
+def _read_csv(path: Path) -> list[dict[str, str]]:
+    if not path.is_file():
+        return []
+    with path.open(newline="", encoding="utf-8", errors="replace") as f:
+        return list(csv.DictReader(f))
+
+
+def _pick_name(row: dict[str, str]) -> str:
+    for key in ("Op Name", "Operator Name", "Name", "Kernel Name", "op_name"):
+        if key in row and row[key]:
+            return row[key]
+    return next(iter(row.values()), "unknown")
+
+
+def _pick_time(row: dict[str, str]) -> float:
+    for key in (
+        "Total Time (us)",
+        "Total Time (ms)",
+        "Duration (us)",
+        "Duration (ms)",
+        "Device Duration (us)",
+        "Device Duration (ms)",
+    ):
+        if key in row and row[key]:
+            val = float(str(row[key]).replace(",", ""))
+            if "ms" in key.lower():
+                return val
+            return val / 1000.0
+    return 0.0
+
+
+def _top_rows(rows: list[dict[str, str]], top: int) -> list[tuple[str, float]]:
+    ranked: list[tuple[str, float]] = []
+    for row in rows:
+        t = _pick_time(row)
+        if t <= 0:
+            continue
+        ranked.append((_pick_name(row), t))
+    ranked.sort(key=lambda x: x[1], reverse=True)
+    return ranked[:top]
+
+
+def _render_table(title: str, ranked: list[tuple[str, float]]) -> str:
+    if not ranked:
+        return f"## {title}\n\n_No data found._\n"
+    total = sum(t for _, t in ranked) or 1.0
+    lines = [
+        f"## {title}",
+        "",
+        "| Rank | Name | Time (ms) | Share (%) |",
+        "| ---: | --- | ---: | ---: |",
+    ]
+    for i, (name, ms) in enumerate(ranked, start=1):
+        share = 100.0 * ms / total
+        lines.append(f"| {i} | {name} | {ms:.3f} | {share:.1f} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--trace-dir", required=True, help="ASCEND_PROFILER_OUTPUT directory")
+    ap.add_argument("--top", type=int, default=20)
+    ap.add_argument("--markdown-out", required=True)
+    args = ap.parse_args()
+
+    trace_dir = Path(args.trace_dir)
+    op_rows = _read_csv(trace_dir / "operator_details.csv")
+    kernel_rows = _read_csv(trace_dir / "kernel_details.csv")
+
+    op_ranked = _top_rows(op_rows, args.top)
+    kernel_ranked = _top_rows(kernel_rows, min(args.top, 10))
+
+    parts = [
+        "# SGLang NPU Trace Summary",
+        "",
+        f"Trace directory: `{trace_dir}`",
+        "",
+        _render_table("Top Operators", op_ranked),
+        _render_table("Top Kernels", kernel_ranked),
+    ]
+
+    out = Path(args.markdown_out)
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text("\n".join(parts), encoding="utf-8")
+    print(f"Wrote {out}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/docs/hardware-platforms/ascend-npus/optimization/profiling.mdx
+++ b/docs/docs/hardware-platforms/ascend-npus/optimization/profiling.mdx
@@ -531,6 +531,14 @@ If the original data is still needed, back it up before running `analyse()`.
   workers must be profiled separately — see
   [Profile In PD Disaggregation Mode](/docs/developer_guide/benchmark_and_profiling#profile-in-pd-disaggregation-mode).
 
+## Agent Workflow (SKILL)
+
+For a repeatable end-to-end bottleneck report from `operator_details.csv` /
+`trace_view.json`, use the repository skill at
+`.claude/skills/sglang-npu-profiler-analysis/SKILL.md`. It wraps the capture
+methods above and emits a standard markdown report via
+`summarize_npu_trace.py`.
+
 ## See Also
 
 - [SGLang Benchmark and Profiling](/docs/developer_guide/benchmark_and_profiling)


### PR DESCRIPTION
## Summary
- Add .claude/skills/sglang-npu-profiler-analysis/ with end-to-end NPU trace analysis workflow, report template, and CSV summary helper.
- Link the skill from the Ascend profiling doc.

## Ascend issue
https://github.com/Ascend/sglang/issues/1102

## Deliverables
- [x] SKILL.md + references + scripts/summarize_npu_trace.py
- [x] Profiling doc cross-link

## Test plan
- [ ] python .claude/skills/sglang-npu-profiler-analysis/scripts/summarize_npu_trace.py --help
- [ ] Run helper against a sample ASCEND_PROFILER_OUTPUT/ directory on NPU server

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35582511748](https://github.com/sgl-project/sglang/actions/runs/35582511748)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35582511600](https://github.com/sgl-project/sglang/actions/runs/35582511600)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->