### PR TITLE
[Scheduler] Gate and batch request generation tracking for DSpark

### DIFF
--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -88,6 +88,7 @@ from sglang.srt.mem_cache.memory_pool import (
     HybridReqToTokenPool,
     KVCache,
     ReqToTokenPool,
+    _bump_req_generations,
 )
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.observability.req_time_stats import (
@@ -162,6 +163,10 @@ class DecodeReqToTokenPool:
         # here: HybridMambaDecodeReqToTokenPool borrows this __init__ while
         # inheriting ReqToTokenPool.alloc, which bumps it.
         self.req_generation = torch.zeros(self._alloc_size, dtype=torch.int64)
+        self.track_req_generation = False
+
+    def enable_req_generation_tracking(self) -> None:
+        self.track_req_generation = True
 
     def write(self, indices, values):
         self.req_to_token[indices] = values
@@ -186,11 +191,12 @@ class DecodeReqToTokenPool:
             return None
         select_index = self.free_slots[:need_size]
         self.free_slots = self.free_slots[need_size:]
+        if self.track_req_generation:
+            _bump_req_generations(self.req_generation, select_index)
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:
                 r.req_pool_idx = select_index[offset]
-                self.req_generation[r.req_pool_idx] += 1
                 offset += 1
         return [r.req_pool_idx for r in reqs]
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -138,6 +138,17 @@ def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
     return np.prod(t.shape) * t.dtype.itemsize
 
 
+def _bump_req_generations(
+    req_generation: torch.Tensor, indices: List[int]
+) -> None:
+    # Preserve the cheaper scalar path for the common bs=1 DSpark case,
+    # while avoiding one torch dispatcher call per request for batches.
+    if len(indices) == 1:
+        req_generation[indices[0]] += 1
+    elif indices:
+        req_generation[indices] += 1
+
+
 def _set_kv_buffer_impl(
     k: torch.Tensor,
     v: torch.Tensor,
@@ -281,6 +292,13 @@ class ReqToTokenPool:
             )
         self.free_slots = list(range(1, self._alloc_size))
         self.req_generation = torch.zeros(self._alloc_size, dtype=torch.int64)
+        # Only DSpark's confidence relay consumes slot generations. Keep the
+        # tensor available for a stable pool interface, but avoid updating it
+        # for every request in all other serving modes.
+        self.track_req_generation = False
+
+    def enable_req_generation_tracking(self) -> None:
+        self.track_req_generation = True
 
     def write(self, indices, values):
         self.req_to_token[indices] = values
@@ -314,11 +332,12 @@ class ReqToTokenPool:
         else:
             # Handled separately: free_slots[-0:] is the entire list, not [].
             select_index = []
+        if self.track_req_generation:
+            _bump_req_generations(self.req_generation, select_index)
         offset = 0
         for r in reqs:
             if r.req_pool_idx is None:
                 r.req_pool_idx = select_index[offset]
-                self.req_generation[r.req_pool_idx] += 1
                 offset += 1
         return [r.req_pool_idx for r in reqs]
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -138,9 +138,7 @@ def get_tensor_size_bytes(t: Union[torch.Tensor, List[torch.Tensor]]):
     return np.prod(t.shape) * t.dtype.itemsize
 
 
-def _bump_req_generations(
-    req_generation: torch.Tensor, indices: List[int]
-) -> None:
+def _bump_req_generations(req_generation: torch.Tensor, indices: List[int]) -> None:
     # Preserve the cheaper scalar path for the common bs=1 DSpark case,
     # while avoiding one torch dispatcher call per request for batches.
     if len(indices) == 1:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -834,6 +834,8 @@ class ModelRunner:
         self.max_total_num_tokens = result.max_total_num_tokens
         self.max_running_requests = result.max_running_requests
         self.req_to_token_pool = result.req_to_token_pool
+        if self.spec_algorithm.is_dspark():
+            self.req_to_token_pool.enable_req_generation_tracking()
         self.token_to_kv_pool = result.token_to_kv_pool
         self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
         self.memory_pool_config = result.memory_pool_config


### PR DESCRIPTION
## Motivation

`req_generation` prevents DSpark's delayed confidence relay from associating
confidence from an old request with a new request that reuses the same
request-pool slot.

However, it is currently incremented unconditionally for every newly allocated
request, even though non-DSpark serving modes never consume it. Batched
admission also performs one CPU Torch scalar operation per new request.

This adds unnecessary overhead to the scheduler admission path of every
request.

## Modifications

- Make request-generation tracking opt-in in `ReqToTokenPool` and
  `DecodeReqToTokenPool`.
- Enable tracking from `ModelRunner` only when the speculative algorithm is
  DSpark.
- Keep the scalar update for single-request DSpark admission.
- Use one vectorized operation for batched DSpark admission.
- Share the generation-update implementation between the regular and
  disaggregated decode request pools.
- Keep the `req_generation` tensor in every pool to preserve the existing
  request-pool interface.

## Accuracy Tests

This PR does not change model forward computation, sampling, or output tensors.

Non-DSpark serving does not consume `req_generation`. For DSpark, tracking
remains enabled and preserves the existing slot-reuse semantics.

A randomized allocation/free/chunked-prefill trace produced identical
generation states between the baseline and the updated DSpark path.

A slot-reuse experiment also verified that delayed confidence is accepted for
the same request generation and rejected after the slot is reassigned to a new
request.

The existing request-pool and DSpark scheduler tests pass.

## Speed Tests and Profiling

### Request-pool allocation

The benchmark measures `ReqToTokenPool.alloc()` directly. Results are medians
across seven runs.

| Admission batch size | Baseline | Updated, non-DSpark | Updated, DSpark |
|---:|---:|---:|---:|
| 1 | 9.652 us | 1.225 us | 10.256 us |
| 8 | 64.089 us | 2.676 us | 26.182 us |
| 64 | 496.762 us | 12.307 us | 50.736 us |
| 256 | 1,986.969 us | 46.222 us | 138.670 us |
| 1024 | 8,024.461 us | 201.693 us | 507.782 us |

Non-DSpark request-pool allocation improves by approximately 7.9x for
single-request admission and about 40x for larger admission batches.

DSpark single-request admission changes by less than one microsecond. Batched
DSpark admission is faster because it replaces one scalar Torch operation per
request with a single indexed update.

### End-to-end serving sanity check

The end-to-end workload sends batches of one-token prompts to `/generate` with
one generated token. Each result is the median of seven measured runs after
warmup.

| Request batch size | Baseline | Updated | Change |
|---:|---:|---:|---:|
| 1 | 71.675 ms | 70.220 ms | -2.03% |
| 8 | 164.406 ms | 162.349 ms | -1.25% |
| 64 | 861.392 ms | 856.217 ms | -0.60% |
| 256 | 3,252.842 ms | 3,231.302 ms | -0.66% |

The end-to-end test primarily serves as a full-stack regression check because
model execution dominates total latency. The request-pool microbenchmark
directly measures the optimized scheduler path.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). No new test file is included; existing tests and local differential validation were run.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is needed because there is no user-facing API change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32647050061](https://github.com/sgl-project/sglang/actions/runs/32647050061)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32647050004](https://github.com/sgl-project/sglang/actions/runs/32647050004)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32647050053](https://github.com/sgl-project/sglang/actions/runs/32647050053)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->