### PR TITLE
[Fix] : support MiniMax-M3 pipeline parallelism in PD disaggregation

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -1387,12 +1387,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     or rc
                 )
             elif st == StateType.MINIMAX_INDEX_K:
-                # Equal-TP / PP=1 only. Sub-pools are compacted sparse-layer
-                # lists, so PP>1 mis-slices and heterogeneous TP is unsupported.
-                if self.pp_size is not None and self.pp_size > 1:
-                    raise RuntimeError(
-                        "PD disagg: PP>1 not supported for MiniMax sparse index yet."
-                    )
+                # Equal attention-TP only. Sparse sub-pools are compacted per
+                # pipeline stage, so pair their entries by global layer id.
                 if (
                     target_rank_registration_info is not None
                     and self.attn_tp_size
@@ -1418,6 +1414,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
                         force_flat=True,
+                        src_layer_ids=src_state_layer_ids,
+                        dst_layer_ids=dst_state_layer_ids,
                     )
                     or rc
                 )

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -1011,7 +1011,14 @@ def setup_state_kv_args(
             )
         if token_to_kv_pool.index_k_pool is not None:
             dp, dl, il = token_to_kv_pool.get_index_k_state_buf_infos()
-            append_state_component(kv_args, StateType.MINIMAX_INDEX_K, dp, dl, il)
+            append_state_component(
+                kv_args,
+                StateType.MINIMAX_INDEX_K,
+                dp,
+                dl,
+                il,
+                layer_ids=list(token_to_kv_pool.index_k_layer_id_mapping),
+            )
     elif hasattr(token_to_kv_pool, "get_state_buf_infos"):
         data_ptrs, data_lens, item_lens = token_to_kv_pool.get_state_buf_infos()
 

--- a/python/sglang/srt/models/minimax_m3.py
+++ b/python/sglang/srt/models/minimax_m3.py
@@ -230,6 +230,34 @@ class _FusedQKVIndexProj(nn.Module):
         return self._qm.apply(self, x, None)
 
 
+def _normalize_scattered_pp_proxy_tensors_for_cuda_graph(
+    pp_proxy_tensors: PPProxyTensors,
+    *,
+    positions: torch.Tensor,
+    attn_tp_size: int,
+) -> PPProxyTensors:
+    """Slice graph dummy PP inputs to the token-local shape used by EP."""
+    global_num_tokens = positions.shape[0]
+    if attn_tp_size <= 1 or global_num_tokens % attn_tp_size != 0:
+        return pp_proxy_tensors
+
+    token_keys = ("hidden_states", "residual")
+    if not all(
+        key in pp_proxy_tensors.tensors
+        and pp_proxy_tensors[key].shape[0] == global_num_tokens
+        for key in token_keys
+    ):
+        return pp_proxy_tensors
+
+    local_num_tokens = global_num_tokens // attn_tp_size
+    return PPProxyTensors(
+        {
+            key: (value[:local_num_tokens] if key in token_keys else value)
+            for key, value in pp_proxy_tensors.tensors.items()
+        }
+    )
+
+
 def build_minimax_fused_qkv_index(model: nn.Module) -> None:
     for module in model.modules():
         if isinstance(module, MiniMaxM3Attention):
@@ -1488,6 +1516,16 @@ class MiniMaxM3Model(nn.Module):
             residual = None
         else:
             assert pp_proxy_tensors is not None
+            first_layer = self.layers[self.start_layer]
+            if (
+                first_layer.layer_scatter_modes.layer_input_mode
+                == ScatterMode.SCATTERED
+            ):
+                pp_proxy_tensors = _normalize_scattered_pp_proxy_tensors_for_cuda_graph(
+                    pp_proxy_tensors,
+                    positions=positions,
+                    attn_tp_size=get_parallel().attn_tp_size,
+                )
             hidden_states = pp_proxy_tensors["hidden_states"]
             residual = pp_proxy_tensors["residual"]
 

--- a/test/registered/unit/disaggregation/test_minimax_sparse_disagg_state_kv_args.py
+++ b/test/registered/unit/disaggregation/test_minimax_sparse_disagg_state_kv_args.py
@@ -61,6 +61,7 @@ class TestMiniMaxSparseDisaggStateKvArgs(unittest.TestCase):
         self.assertEqual(len(kv_args.state_data_ptrs), 1)
         self.assertEqual(len(kv_args.state_data_ptrs[0]), pool.index_k_pool.layer_num)
         self.assertEqual(len(kv_args.state_item_lens[0]), pool.index_k_pool.layer_num)
+        self.assertEqual(kv_args.state_layer_ids, [[3, 4, 5, 6]])
 
     def test_index_kv_pool_raises(self):
         pool = _make_kv_pool()

--- a/test/registered/unit/models/test_minimax_m3_pp_cuda_graph.py
+++ b/test/registered/unit/models/test_minimax_m3_pp_cuda_graph.py
@@ -1,0 +1,51 @@
+import unittest
+
+import torch
+
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+from sglang.srt.models.minimax_m3 import (
+    _normalize_scattered_pp_proxy_tensors_for_cuda_graph,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMiniMaxM3PPCudaGraph(unittest.TestCase):
+    def test_slices_graph_dummy_proxy_to_local_tp_tokens(self):
+        proxy = PPProxyTensors(
+            {
+                "hidden_states": torch.arange(24).reshape(8, 3),
+                "residual": torch.arange(24).reshape(8, 3),
+            }
+        )
+
+        normalized = _normalize_scattered_pp_proxy_tensors_for_cuda_graph(
+            proxy,
+            positions=torch.zeros(8, dtype=torch.int64),
+            attn_tp_size=4,
+        )
+
+        self.assertEqual(normalized["hidden_states"].shape, (2, 3))
+        self.assertEqual(normalized["residual"].shape, (2, 3))
+        torch.testing.assert_close(normalized["residual"], proxy["residual"][:2])
+
+    def test_keeps_runtime_proxy_that_is_already_scattered(self):
+        proxy = PPProxyTensors(
+            {
+                "hidden_states": torch.zeros((2, 3)),
+                "residual": torch.zeros((2, 3)),
+            }
+        )
+
+        normalized = _normalize_scattered_pp_proxy_tensors_for_cuda_graph(
+            proxy,
+            positions=torch.zeros(8, dtype=torch.int64),
+            attn_tp_size=4,
+        )
+
+        self.assertIs(normalized, proxy)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

This PR enables MiniMax-M3 pipeline parallelism under PD disaggregation with the Mooncake transfer backend.

It fixes two MiniMax-M3 PP blockers:

1. MiniMax sparse index state registration did not preserve global sparse layer IDs, so Mooncake could not safely map `index_k` transfer entries across pipeline stages.
2. Decode CUDA Graph capture built PP proxy tensors with global token shapes even when the PP boundary tensor layout was already scattered by attention TP, causing hidden/residual shape mismatches during CUDA Graph replay.

With this PR, MiniMax-M3 can run symmetric PP disaggregated serving such as `TP4/PP2/EP4` on both Prefill and Decode nodes, while keeping Decode CUDA Graph enabled.

## Motivation

MiniMax-M3 has sparse attention states in addition to the standard KV cache. These sparse states are stored in `index_k_pool` and only correspond to a subset of model layers.

Before this PR, pipeline parallelism was explicitly blocked for MiniMax sparse index transfer because each PP stage only sees a local sparse-index list. Without the original global layer IDs, the disaggregation backend cannot know whether source and destination sparse-index entries refer to the same model layer.

After fixing sparse-index transfer, Decode CUDA Graph exposed another issue. In PP + EP / scattered-layout cases, CUDA Graph dummy `PPProxyTensors` were constructed using the global token count, while the actual hidden states had already been scattered by attention TP. This led to residual and hidden tensors having incompatible shapes during graph capture/replay.

## Changes

### MiniMax sparse-index state registration

- Preserve global sparse layer IDs when registering `StateType.MINIMAX_INDEX_K`.
- Store the global sparse layer IDs in the disaggregation state metadata.
- Use those layer IDs to map sparse-index transfer entries under pipeline parallelism.
- Keep the existing heterogeneous attention-TP guard for MiniMax sparse index transfer.

### Mooncake sparse-index transfer

- Remove the blanket `PP > 1` rejection for MiniMax sparse index transfer in the Mooncake backend.
- Map source and destination sparse-index entries by global layer ID instead of local sparse-index position.
- Reuse the existing transfer-entry pairing logic with explicit source/destination layer IDs.

### Decode CUDA Graph PP proxy normalization

- Normalize scattered PP proxy tensors during Decode CUDA Graph capture.
- Only apply the normalization on non-first PP stages.
- Only apply it when the first layer expects `ScatterMode.SCATTERED`.
- Convert global dummy proxy token shapes into local scattered token shapes using the attention TP size.
- Leave normal runtime proxy tensors unchanged if they already use local token shapes.

### Tests

- Add regression coverage for MiniMax sparse-index state registration with global layer IDs.
- Add regression coverage for scattered PP proxy tensor normalization during CUDA Graph capture.
- Cover both CUDA Graph dummy proxy tensors and normal runtime proxy tensors to avoid double slicing.

## Why this is safe

The sparse-index transfer change does not alter the internal layout of a MiniMax `index_k` buffer. It only adds the missing global layer identity needed to map source and destination entries correctly under PP.

The CUDA Graph proxy normalization is guarded by MiniMax PP/scattered-layout conditions. It does not affect the first PP stage, non-scattered PP layouts, or normal runtime proxy tensors that already have local token shapes.

This PR does not enable heterogeneous attention TP for MiniMax sparse index transfer. That guard is intentionally preserved because changing attention TP would require a separate index-K layout conversion.

## Validation

Unit tests:

```bash
python3 -m pytest -q
test/registered/unit/disaggregation/test_minimax_sparse_disagg_state_kv_args.py
test/registered/unit/models/test_minimax_m3_pp_cuda_graph.py
```
Result on both nodes: 4 passed



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32824056060](https://github.com/sgl-project/sglang/actions/runs/32824056060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32824055609](https://github.com/sgl-project/sglang/actions/runs/32824055609)<!-- slot:pr-test-extra:end -->
<!-- pr-states:end -->