### PR TITLE
[NPU] keep Qwen3.6 hybrid SSM state stable across radix modes

### DIFF
--- a/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
+++ b/python/sglang/srt/layers/attention/hybrid_linear_attn_backend.py
@@ -31,6 +31,7 @@ from sglang.srt.model_executor.model_runner import ModelRunner
 from sglang.srt.runtime_context import (
     get_exec,
     get_memory,
+    get_server_args,
     mamba_cache_chunk_size,
 )
 from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
@@ -38,11 +39,8 @@ from sglang.srt.speculative.spec_info import SpecInput
 
 if TYPE_CHECKING:
     from sglang.srt.layers.attention.verify_mask import VerifyMask
-from sglang.srt.utils import is_npu
 
 logger = logging.getLogger(__name__)
-if is_npu():
-    FLA_CHUNK_SIZE_NPU = 64
 
 
 class MambaAttnBackendBase(AttentionBackend):
@@ -326,9 +324,7 @@ class MambaAttnBackendBase(AttentionBackend):
         """src/dst indices to track SSM states for prefix caching: aligned seqs
         cache last_recurrent_state, unaligned cache intermediate `h` at the last
         chunk boundary."""
-        chunk_size = mamba_cache_chunk_size()
-        if is_npu():
-            h_chunk_size = FLA_CHUNK_SIZE_NPU
+        mamba_state_chunk_size = get_server_args().mamba_state_chunk_size
         # CPU to avoid kernel launches for the masking ops
         mamba_track_mask = forward_batch.mamba_track_mask.cpu()
         extend_seq_lens = forward_batch.extend_seq_lens.cpu()
@@ -338,11 +334,9 @@ class MambaAttnBackendBase(AttentionBackend):
         prefix_lens = forward_batch.extend_prefix_lens.cpu()
 
         if isinstance(self, Mamba2AttnBackend):
-            num_h_states = extend_seq_lens // chunk_size
+            num_h_states = extend_seq_lens // mamba_state_chunk_size
         else:
-            num_h_states = (extend_seq_lens - 1) // chunk_size + 1
-            if is_npu():
-                num_h_states = (extend_seq_lens - 1) // h_chunk_size + 1
+            num_h_states = (extend_seq_lens - 1) // mamba_state_chunk_size + 1
 
         track_ssm_src_offset = torch.zeros_like(num_h_states)
         track_ssm_src_offset[1:] = torch.cumsum(num_h_states[:-1], dim=0)
@@ -352,24 +346,17 @@ class MambaAttnBackendBase(AttentionBackend):
         offset_masked = track_ssm_src_offset[mamba_track_mask]
         dst_masked = mamba_track_indices[mamba_track_mask]
 
-        is_aligned = (lens_masked % chunk_size) == 0
+        is_aligned = (lens_masked % mamba_state_chunk_size) == 0
 
         # Aligned: last_recurrent_state from ssm_states.
         track_ssm_final_src = mamba_cache_indices[mamba_track_mask][is_aligned]
         track_ssm_final_dst = dst_masked[is_aligned]
 
         # Unaligned: intermediate state from h.
-        # TODO: handle chunk_size % page size != 0
         not_aligned = ~is_aligned
         track_ssm_h_src = offset_masked[not_aligned] + (
-            lens_masked[not_aligned] // chunk_size
+            lens_masked[not_aligned] // mamba_state_chunk_size
         )
-        if is_npu():
-            track_ssm_h_src = (
-                offset_masked[not_aligned]
-                + ((lens_masked[not_aligned] // chunk_size) * chunk_size)
-                // h_chunk_size
-            )
         track_ssm_h_dst = dst_masked[not_aligned]
 
         return (

--- a/python/sglang/srt/layers/rotary_embedding/mrope.py
+++ b/python/sglang/srt/layers/rotary_embedding/mrope.py
@@ -22,16 +22,21 @@ from sglang.srt.runtime_context import attention_backends
 from sglang.srt.utils import (
     cpu_has_amx_support,
     is_cuda,
+    is_npu,
     is_xpu,
     support_triton,
 )
 
 _is_cuda = is_cuda()
+_is_npu = is_npu()
 _is_xpu = is_xpu()
 _is_cpu_amx_available = cpu_has_amx_support()
 
 if _is_cuda:
     from sglang.kernels.ops.attention.rope import apply_rope_with_cos_sin_cache_inplace
+
+if _is_npu:
+    import torch_npu
 
 if _is_xpu:
     from sgl_kernel import multimodal_rotary_embedding
@@ -278,7 +283,20 @@ class MRotaryEmbedding(RotaryEmbedding):
         assert (
             fused_set_kv_buffer_arg is None
         ), "fused_set_kv_buffer_arg is not supported for npu implementation"
-        return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)
+        if query.shape[1] > 4096:
+            return self.forward_native(positions, query, key, fused_set_kv_buffer_arg)
+        rotary_mode = "half" if self.is_neox_style else "interleave"
+        mrope_section = [0, 0, 0]
+        query_out, key_out = torch_npu.npu_mrope(
+            positions,
+            query,
+            key,
+            self.cos_sin_cache,
+            self.head_size,
+            mrope_section=mrope_section,
+            rotary_mode=rotary_mode,
+        )
+        return query_out, key_out
 
     def forward_xpu(
         self,

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -5,6 +5,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.runtime_context import (
     get_disagg,
     get_schedule,
+    get_server_args,
     get_serving,
     get_spec,
     mamba_cache_chunk_size,
@@ -2680,6 +2681,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self,
         req: Req,
     ) -> _MambaRadixCacheV2TrackEntry:
+        mamba_state_chunk_size = get_server_args().mamba_state_chunk_size
         chunk_size = mamba_cache_chunk_size()
         # The donated depth has to be a radix node boundary. Read the tree's own
         # page rather than re-deriving how DCP widens it; the kernel still
@@ -2717,15 +2719,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 + (req.extend_range.length // checkpoint_grid) * checkpoint_grid
             )
 
-            # mamba_track_fla_chunk_aligned is the aligned seqlen based on chunk_size
-            # If mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned, which is true when
-            # checkpoint_grid is coarser than chunk_size, we need to force the math calculation to
-            # retrieve the correct mamba state from h by _force_track_h()
-            mamba_track_fla_chunk_aligned = (
+            # Cache boundaries can be coarser than the kernel's intermediate-state
+            # boundaries (for example 128-token pages with 64-token states).
+            mamba_track_state_chunk_aligned = (
                 len(req.prefix_indices)
-                + (req.extend_range.length // chunk_size) * chunk_size
+                + (req.extend_range.length // mamba_state_chunk_size)
+                * mamba_state_chunk_size
             )
-            if mamba_track_fla_chunk_aligned != mamba_track_seqlen_aligned:
+            if mamba_track_state_chunk_aligned != mamba_track_seqlen_aligned:
                 # We want to track mamba_track_seqlen_aligned, and it's not the last position,
                 # so we need to add 1 to the seqlen to retrieve the correct mamba state from h.
                 mamba_track_seqlen = _force_track_h(mamba_track_seqlen_aligned)

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -528,6 +528,7 @@ class PrefillAdder:
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
         prefill_tile_block_m: int = 64,
+        mamba_prefill_align_size: Optional[int] = None,
     ):
         self.page_size = page_size
         self.prefill_tile_block_m = prefill_tile_block_m
@@ -620,6 +621,7 @@ class PrefillAdder:
         self.max_prefill_mm_patch_tokens = max_prefill_mm_patch_tokens
         self.prefill_delayer_single_pass = prefill_delayer_single_pass
         self.max_prefill_bs = max_prefill_bs
+        self.mamba_prefill_align_size = mamba_prefill_align_size
         # Snapshot of scheduler waiting_queue length at the start of this
         # prefill pass. Used by PrefillDelayer's queue-based trigger.
         self.waiting_queue_len = waiting_queue_len
@@ -1035,8 +1037,9 @@ class PrefillAdder:
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
-        truncated = cand_extend_input_len > _rem_tokens
         new_len = min(cand_extend_input_len, _rem_tokens)
+        new_len = self._align_mamba_prefill_chunk(req, new_len)
+        truncated = new_len < cand_extend_input_len
         req.set_extend_range(len(req.prefix_indices), len(req.prefix_indices) + new_len)
         self.can_run_list.append(req)
         self._update_prefill_budget(
@@ -1053,6 +1056,25 @@ class PrefillAdder:
 
         # Return if chunked prefill not finished
         return req if truncated else None
+
+    def _align_mamba_prefill_chunk(self, req: Req, new_len: int) -> int:
+        """Stop before an unaligned tail so it runs at its real token length."""
+        align_size = self.mamba_prefill_align_size
+        # This protects the recurrent state transition itself, not just radix
+        # checkpoints.  ChunkCache (``--disable-radix-cache``) still pads the
+        # physical NPU prefill batch to a page boundary; letting an unaligned
+        # logical tail share that physical chunk advances GDN state through the
+        # padding rows.  The scheduler supplies an alignment only for hybrid
+        # SSM models, so honor it independently of the cache implementation.
+        if align_size is None:
+            return new_len
+
+        start = len(req.prefix_indices)
+        end = start + new_len
+        aligned_end = end // align_size * align_size
+        if start < aligned_end < end:
+            return aligned_end - start
+        return new_len
 
     @contextmanager
     def _lock_node(self, last_node: TreeNode):
@@ -1348,8 +1370,15 @@ class PrefillAdder:
                 prefix_len = len(req.prefix_indices)
                 req.cache_protected_len = prefix_len
 
-            input_tokens = self.ceil_paged_tokens(
-                len(req.full_untruncated_fill_ids) - len(req.prefix_indices)
+            current_extend_input_len = len(req.full_untruncated_fill_ids) - len(
+                req.prefix_indices
+            )
+            input_tokens = self.ceil_paged_tokens(current_extend_input_len)
+            mamba_aligned_input_len = self._align_mamba_prefill_chunk(
+                req, current_extend_input_len
+            )
+            needs_mamba_tail_split = (
+                mamba_aligned_input_len < current_extend_input_len
             )
 
             if (
@@ -1377,7 +1406,9 @@ class PrefillAdder:
 
                 self._add_dllm_req(req, prefix_len)
                 self._req_inc_lock_ref(req)
-            elif chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit:
+            elif (
+                chunk_tokens_limit is None or input_tokens <= chunk_tokens_limit
+            ) and not needs_mamba_tail_split:
                 if (
                     tile_stop := self._check_prefill_tile_budget(input_tokens)
                 ) is not None:
@@ -1404,7 +1435,12 @@ class PrefillAdder:
                 )
             else:
                 # Make sure at least one page is available
-                trunc_len = chunk_tokens_limit // self.page_size * self.page_size
+                trunc_len = (
+                    current_extend_input_len
+                    if chunk_tokens_limit is None
+                    else min(current_extend_input_len, chunk_tokens_limit)
+                )
+                trunc_len = trunc_len // self.page_size * self.page_size
 
                 if trunc_len <= 0:
                     return AddReqResult.OTHER
@@ -1423,6 +1459,7 @@ class PrefillAdder:
                 now_input_len = trunc_len + len(req.prefix_indices)
                 now_input_len = now_input_len // self.page_size * self.page_size
                 trunc_len = now_input_len - len(req.prefix_indices)
+                trunc_len = self._align_mamba_prefill_chunk(req, trunc_len)
 
                 if trunc_len <= 0:
                     return AddReqResult.OTHER

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -1377,9 +1377,7 @@ class PrefillAdder:
             mamba_aligned_input_len = self._align_mamba_prefill_chunk(
                 req, current_extend_input_len
             )
-            needs_mamba_tail_split = (
-                mamba_aligned_input_len < current_extend_input_len
-            )
+            needs_mamba_tail_split = mamba_aligned_input_len < current_extend_input_len
 
             if (
                 self.rem_chunk_tokens is None

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3337,6 +3337,11 @@ class Scheduler(
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
             prefill_tile_block_m=prefill_tile_block_m,
+            mamba_prefill_align_size=(
+                self.server_args.mamba_cache_chunk_size
+                if self.is_hybrid_ssm
+                else None
+            ),
         )
 
         if self.chunked_req is not None:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3338,9 +3338,7 @@ class Scheduler(
             waiting_queue_len=len(self.waiting_queue),
             prefill_tile_block_m=prefill_tile_block_m,
             mamba_prefill_align_size=(
-                self.server_args.mamba_cache_chunk_size
-                if self.is_hybrid_ssm
-                else None
+                self.server_args.mamba_cache_chunk_size if self.is_hybrid_ssm else None
             ),
         )
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9203,12 +9203,9 @@ class ServerArgs:
         return max(candidate_steps) + 1
 
     @property
-    def mamba_cache_chunk_size(self) -> int:
-        # For mamba cache with extra buffer, the chunk size is the max of FLA_CHUNK_SIZE
-        # (or mamba_chunk_size if it is defined in the model's config) and page_size.
-        # It is used to determine the caching point in a sequence during prefill.
-        if not hasattr(self, "_mamba_cache_chunk_size"):
-
+    def mamba_state_chunk_size(self) -> int:
+        """Chunk size used by the linear-attention kernel's intermediate states."""
+        if not hasattr(self, "_mamba_state_chunk_size"):
             try:
                 from sglang.kernels.ops.attention.fla.chunk_delta_h import (
                     CHUNK_SIZE as FLA_CHUNK_SIZE,
@@ -9218,7 +9215,16 @@ class ServerArgs:
                 FLA_CHUNK_SIZE = 64
 
             hf_config = self.get_model_config().hf_config
-            chunk_size = getattr(hf_config, "mamba_chunk_size", FLA_CHUNK_SIZE)
+            self._mamba_state_chunk_size = getattr(
+                hf_config, "mamba_chunk_size", FLA_CHUNK_SIZE
+            )
+        return self._mamba_state_chunk_size
+
+    @property
+    def mamba_cache_chunk_size(self) -> int:
+        """Radix checkpoint grid aligned to both state chunks and KV pages."""
+        if not hasattr(self, "_mamba_cache_chunk_size"):
+            chunk_size = self.mamba_state_chunk_size
             page_size = resolved_view(self).page_size
             assert (
                 max(chunk_size, page_size) % min(chunk_size, page_size) == 0

--- a/test/registered/unit/layers/attention/test_mamba_track_chunk_size.py
+++ b/test/registered/unit/layers/attention/test_mamba_track_chunk_size.py
@@ -1,0 +1,83 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
+    MambaAttnBackendBase,
+)
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+
+
+class TestMambaTrackChunkSize(unittest.TestCase):
+    def _prepare_track_entry(self, extend_length: int):
+        batch = object.__new__(ScheduleBatch)
+        batch.req_to_token_pool = SimpleNamespace(
+            get_mamba_ping_pong_other_idx=lambda _: 1
+        )
+        batch.tree_cache = SimpleNamespace(page_size=128)
+        req = SimpleNamespace(
+            extend_range=SimpleNamespace(length=extend_length),
+            prefix_indices=range(16384),
+            mamba_ping_pong_track_buffer=torch.tensor([7, 8]),
+            mamba_next_track_idx=0,
+            mamba_branching_seqlen=None,
+        )
+        server_args = SimpleNamespace(
+            mamba_cache_chunk_size=128,
+            mamba_state_chunk_size=64,
+        )
+
+        with patch(
+            "sglang.srt.managers.schedule_batch.get_server_args",
+            return_value=server_args,
+        ), patch(
+            "sglang.srt.managers.schedule_batch.mamba_cache_chunk_size",
+            return_value=128,
+        ), patch(
+            "sglang.srt.managers.schedule_batch.mamba_checkpoint_grid",
+            return_value=128,
+        ), patch(
+            "sglang.srt.managers.schedule_batch.mamba_extra_buffer_lazy_enabled",
+            return_value=False,
+        ):
+            entry = batch._mamba_radix_cache_v2_req_prepare_for_extend(req)
+
+        return entry, req
+
+    def test_scheduler_tracks_cache_boundary_with_finer_state_chunks(self):
+        entry, req = self._prepare_track_entry(12739)
+        self.assertTrue(entry.track_mask)
+        self.assertEqual(entry.track_index, 7)
+        self.assertEqual(entry.track_seqlen, 29057)
+        self.assertEqual(req.mamba_last_track_seqlen, 29056)
+
+    def test_ssm_index_uses_kernel_state_chunk_size(self):
+        backend = object.__new__(MambaAttnBackendBase)
+        backend.device = torch.device("cpu")
+        forward_batch = SimpleNamespace(
+            mamba_track_mask=torch.tensor([True]),
+            extend_seq_lens=torch.tensor([12739]),
+            mamba_track_indices=torch.tensor([7]),
+            mamba_track_seqlens=torch.tensor([29057]),
+            extend_prefix_lens=torch.tensor([16384]),
+        )
+        server_args = SimpleNamespace(mamba_state_chunk_size=64)
+
+        with patch(
+            "sglang.srt.layers.attention.hybrid_linear_attn_backend.get_server_args",
+            return_value=server_args,
+        ):
+            h_src, h_dst, final_src, final_dst = backend._init_track_ssm_indices(
+                torch.tensor([3]), forward_batch
+            )
+
+        self.assertEqual(h_src.tolist(), [198])
+        self.assertEqual(h_dst.tolist(), [7])
+        self.assertEqual(final_src.tolist(), [])
+        self.assertEqual(final_dst.tolist(), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/attention/test_mamba_track_chunk_size.py
+++ b/test/registered/unit/layers/attention/test_mamba_track_chunk_size.py
@@ -8,6 +8,10 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
     MambaAttnBackendBase,
 )
 from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.test.ci.ci_register import register_cpu_ci
+
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 class TestMambaTrackChunkSize(unittest.TestCase):

--- a/test/registered/unit/layers/attention/test_mamba_track_chunk_size.py
+++ b/test/registered/unit/layers/attention/test_mamba_track_chunk_size.py
@@ -10,7 +10,6 @@ from sglang.srt.layers.attention.hybrid_linear_attn_backend import (
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.test.ci.ci_register import register_cpu_ci
 
-
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -534,6 +534,89 @@ class TestPrefillAdder(CustomTestCase):
         req.set_extend_range.assert_not_called()
         self.assertEqual(len(adder.can_run_list), 0)
 
+    def test_mamba_chunked_prefill_splits_unaligned_tail_at_cache_boundary(self):
+        self.mock_tree_cache.supports_mamba.return_value = True
+        adder, req = self._build_hybrid_swa_chunked_req(
+            page_size=128,
+            rem_swa=100_000,
+            rem_chunk=16_384,
+            is_hybrid_swa=False,
+            full_available=100_000,
+        )
+        adder.is_hybrid_ssm_cache = True
+        adder.mamba_prefill_align_size = 128
+        req.prefix_indices = list(range(16_384))
+        req.full_untruncated_fill_ids = list(range(29_123))
+
+        result = adder.add_chunked_req(req)
+
+        self.assertIs(result, req)
+        req.set_extend_range.assert_called_once_with(16_384, 29_056)
+
+    def test_mamba_chunked_prefill_splits_unaligned_tail_without_radix(self):
+        self.mock_tree_cache.supports_mamba.return_value = False
+        adder, req = self._build_hybrid_swa_chunked_req(
+            page_size=128,
+            rem_swa=100_000,
+            rem_chunk=16_384,
+            is_hybrid_swa=False,
+            full_available=100_000,
+        )
+        # ChunkCache does not expose Mamba radix state, but the model-level
+        # scheduler still supplies the recurrent-state alignment.
+        adder.is_hybrid_ssm_cache = False
+        adder.mamba_prefill_align_size = 128
+        req.prefix_indices = list(range(16_384))
+        req.full_untruncated_fill_ids = list(range(29_123))
+
+        result = adder.add_chunked_req(req)
+
+        self.assertIs(result, req)
+        req.set_extend_range.assert_called_once_with(16_384, 29_056)
+
+    def test_mamba_chunked_prefill_keeps_short_tail_after_cache_boundary(self):
+        self.mock_tree_cache.supports_mamba.return_value = True
+        adder, req = self._build_hybrid_swa_chunked_req(
+            page_size=128,
+            rem_swa=100_000,
+            rem_chunk=16_384,
+            is_hybrid_swa=False,
+            full_available=100_000,
+        )
+        adder.is_hybrid_ssm_cache = True
+        adder.mamba_prefill_align_size = 128
+        req.prefix_indices = list(range(29_056))
+        req.full_untruncated_fill_ids = list(range(29_123))
+
+        result = adder.add_chunked_req(req)
+
+        self.assertIsNone(result)
+        req.set_extend_range.assert_called_once_with(29_056, 29_123)
+
+    def test_mamba_prefill_creates_boundary_chunk_before_unaligned_tail(self):
+        self.mock_tree_cache.supports_mamba.return_value = True
+        adder, req = self._build_hybrid_swa_chunked_req(
+            page_size=128,
+            rem_swa=100_000,
+            rem_chunk=16_384,
+            extend_input_len=1_000,
+            is_hybrid_swa=False,
+            full_available=100_000,
+        )
+        adder.is_hybrid_ssm_cache = True
+        adder.mamba_prefill_align_size = 128
+        req.host_hit_length = 0
+        req.swa_host_hit_length = 0
+        req.last_node = MagicMock()
+        req.sampling_params.ignore_eos = False
+
+        adder.add_one_req(
+            req, has_chunked_req=False, truncation_align_size=None
+        )
+
+        self.assertIs(adder.new_chunked_req, req)
+        req.set_extend_range.assert_called_once_with(0, 896)
+
     def test_swa_budget_for_req(self):
         # budget = max(alloc - window, 0) + min(extend + max_new, window) + page,
         # where alloc = min(extend, rem_chunk). The decode headroom is the SWA the

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -610,9 +610,7 @@ class TestPrefillAdder(CustomTestCase):
         req.last_node = MagicMock()
         req.sampling_params.ignore_eos = False
 
-        adder.add_one_req(
-            req, has_chunked_req=False, truncation_align_size=None
-        )
+        adder.add_one_req(req, has_chunked_req=False, truncation_align_size=None)
 
         self.assertIs(adder.new_chunked_req, req)
         req.set_extend_range.assert_called_once_with(0, 896)


### PR DESCRIPTION
Summary: restore the stable torch_npu NPU MRoPE path, separate the kernel intermediate-state chunk size from the radix checkpoint grid, and split an unaligned Mamba prefill tail even when ChunkCache disables radix caching. This prevents padding rows and incorrect h-state indices from advancing the Qwen3.6 GDN recurrent state. Companion native AscendC causal_conv1d fix: https://github.com/sgl-project/sgl-kernel-npu/pull/742. Validation: on machine 152 with NEXTN enabled, radix cold/hot and recold passed 5 of 5, and no-radix passed 2 of 2 with identical stopped output. Unit coverage includes state-grid indexing and no-radix tail splitting. Machine 3 validation is pending because its SSH endpoint is currently unreachable.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829102711](https://github.com/sgl-project/sglang/actions/runs/34829102711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829102544](https://github.com/sgl-project/sglang/actions/runs/34829102544)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829102868](https://github.com/sgl-project/sglang/actions/runs/34829102868)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->