### PR TITLE
Fix canonical YAML options shadowed by deprecated aliases

### DIFF
--- a/python/sglang/srt/server_args_config_parser.py
+++ b/python/sglang/srt/server_args_config_parser.py
@@ -31,12 +31,23 @@ class ConfigArgumentMerger:
                 for action in parser._actions
                 if isinstance(action, argparse._StoreTrueAction)
             ]
+            # Deprecated aliases can share a destination with a supported
+            # canonical action, so support must be decided across all actions.
+            supported_action_dests = {
+                action.dest
+                for action in parser._actions
+                if isinstance(
+                    action,
+                    (argparse._StoreTrueAction, argparse._StoreAction),
+                )
+            }
             self.unsupported_actions = {
                 a.dest: a
                 for a in parser._actions
                 if a.option_strings
                 and not isinstance(a, argparse._StoreTrueAction)
                 and not isinstance(a, argparse._StoreAction)
+                and a.dest not in supported_action_dests
                 and "--config" not in a.option_strings
                 and "--help" not in a.option_strings
                 and "-h" not in a.option_strings

--- a/test/registered/unit/server_args/test_server_args_config_parser.py
+++ b/test/registered/unit/server_args/test_server_args_config_parser.py
@@ -1,0 +1,83 @@
+"""Unit tests for YAML configuration argument merging."""
+
+import argparse
+import os
+import tempfile
+import unittest
+
+from sglang.srt.arg_groups.argparse_actions import (
+    DeprecatedAliasStoreAction,
+    DeprecatedStoreTrueAction,
+)
+from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestConfigArgumentMerger(CustomTestCase):
+    def _write_config(self, content: str) -> str:
+        with tempfile.NamedTemporaryFile(
+            mode="w", suffix=".yaml", delete=False
+        ) as config_file:
+            config_file.write(content)
+        self.addCleanup(os.unlink, config_file.name)
+        return config_file.name
+
+    def test_canonical_store_action_is_not_hidden_by_deprecated_alias(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--config")
+        parser.add_argument("--cuda-graph-max-bs-decode", type=int)
+        parser.add_argument(
+            "--cuda-graph-max-bs",
+            action=DeprecatedAliasStoreAction,
+            dest="cuda_graph_max_bs_decode",
+            new_flag="--cuda-graph-max-bs-decode",
+            type=int,
+        )
+        config_path = self._write_config("cuda-graph-max-bs-decode: 8\n")
+
+        merged_args = ConfigArgumentMerger(parser).merge_config_with_args(
+            ["--config", config_path]
+        )
+        parsed_args = parser.parse_args(merged_args)
+
+        self.assertEqual(parsed_args.cuda_graph_max_bs_decode, 8)
+
+    def test_canonical_store_true_is_not_hidden_by_deprecated_alias(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--config")
+        parser.add_argument("--enable-feature", action="store_true")
+        parser.add_argument(
+            "--old-enable-feature",
+            action=DeprecatedStoreTrueAction,
+            dest="enable_feature",
+            new_flag="--enable-feature",
+        )
+        config_path = self._write_config("enable-feature: true\n")
+
+        merged_args = ConfigArgumentMerger(parser).merge_config_with_args(
+            ["--config", config_path]
+        )
+        parsed_args = parser.parse_args(merged_args)
+
+        self.assertTrue(parsed_args.enable_feature)
+
+    def test_action_without_supported_canonical_option_is_rejected(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--config")
+        parser.add_argument("--item", action="append")
+        config_path = self._write_config("item: value\n")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Unsupported config option 'item' with action '_AppendAction'",
+        ):
+            ConfigArgumentMerger(parser).merge_config_with_args(
+                ["--config", config_path]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- decide YAML support using every argparse action registered for a destination;
- keep canonical `_StoreAction` and `_StoreTrueAction` options available when a deprecated alias shares the same `dest`;
- continue rejecting destinations that only have unsupported custom actions;
- add focused coverage for canonical value options, canonical boolean options, and custom-only actions.

## Problem

`ConfigArgumentMerger` currently builds `unsupported_actions` one action at a
time. A deprecated alias is a custom argparse action and can share its
destination with a supported canonical option. When that happens, the alias
marks the whole destination as unsupported, so a valid YAML option such as
`cuda-graph-max-bs-decode: 8` raises `Unsupported config option`.

Support belongs to the complete action set for a destination, not whichever
custom action happens to be registered last. This change first collects the
destinations backed by a standard store action, then excludes those
destinations from `unsupported_actions`.

The deprecated CLI alias still parses and emits its warning. The change does
not expose the deprecated alias as a new YAML key.

This addresses the YAML parsing regression reported in #29184. It is a narrow
parser fix and does not implement the broader device-graph naming RFC.

## Tests

- focused regression tests: 3/3 passed;
- real `ServerArgs` check: canonical YAML resolved to `8`; deprecated CLI alias
  resolved to `9` and retained its deprecation warning;
- isort, Ruff, Black, codespell, registered-test validation, bare-pytest-main
  validation, `py_compile`, and `git diff --check` passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32832362694](https://github.com/sgl-project/sglang/actions/runs/32832362694)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32832362611](https://github.com/sgl-project/sglang/actions/runs/32832362611)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32832362656](https://github.com/sgl-project/sglang/actions/runs/32832362656)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->