### PR TITLE
[cli] fix: detect model-path from --config in sglang serve

### DIFF
--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -4,6 +4,7 @@ import os
 import subprocess
 from functools import lru_cache
 
+import yaml
 from huggingface_hub import HfApi
 
 from sglang.srt.environ import envs
@@ -96,8 +97,55 @@ def get_is_diffusion_model(model_path: str) -> bool:
         return False
 
 
+def _try_get_model_path_from_config(extra_argv) -> str | None:
+    """Best-effort read of a --config YAML file for backend detection.
+
+    Returns the model path declared by a model-path / model config key, or
+    None if the file is missing, unreadable, malformed, or has no model key.
+    Non-string or empty model values are ignored (the authoritative parser
+    reports them later). This is only a hint for backend auto-detection;
+    authoritative parsing and validation still happen later in
+    `prepare_server_args`.
+    """
+
+    config_path = None
+    for i, arg in enumerate(extra_argv):
+        if arg == "--config" and i + 1 < len(extra_argv):
+            config_path = extra_argv[i + 1]
+            break
+
+    if config_path is None:
+        return None
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+    except Exception as e:
+        logger.debug("Failed to read config file %s: %s", config_path, e)
+        return None
+
+    if not isinstance(config, dict):
+        return None
+
+    model_path = None
+    for key, value in config.items():
+        if (
+            isinstance(key, str)
+            and isinstance(value, str)
+            and value
+            and key.replace("-", "_") in ("model_path", "model")
+        ):
+            model_path = value
+
+    return model_path
+
+
 def try_get_model_path(extra_argv) -> str | None:
-    """Return a model path from command-line arguments when one is present."""
+    """Return a model path from command-line arguments when one is present.
+
+    Explicit CLI flags take precedence; when none are present, falls back to
+    a best-effort read of the model path from a --config YAML file.
+    """
 
     model_path = None
     for i, arg in enumerate(extra_argv):
@@ -108,6 +156,9 @@ def try_get_model_path(extra_argv) -> str | None:
         elif arg.startswith("--model-path=") or arg.startswith("--model="):
             model_path = arg.split("=", 1)[1]
             break
+
+    if model_path is None:
+        model_path = _try_get_model_path_from_config(extra_argv)
 
     return model_path
 

--- a/test/registered/unit/cli/test_cli_utils.py
+++ b/test/registered/unit/cli/test_cli_utils.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+import tempfile
+import unittest
+
+from sglang.cli.utils import try_get_model_path
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestTryGetModelPathFromConfig(unittest.TestCase):
+    def _detect_from_config(self, content, extra_argv=()):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(content)
+            config_file = f.name
+
+        try:
+            return try_get_model_path(["--config", config_file, *extra_argv])
+        finally:
+            os.unlink(config_file)
+
+    def test_model_path_key_from_config(self):
+        self.assertEqual(self._detect_from_config("model-path: X\n"), "X")
+
+    def test_model_path_underscore_key_from_config(self):
+        self.assertEqual(self._detect_from_config("model_path: X\n"), "X")
+
+    def test_model_alias_key_from_config(self):
+        self.assertEqual(self._detect_from_config("model: X\n"), "X")
+
+    def test_cli_flag_takes_precedence_over_config(self):
+        self.assertEqual(
+            self._detect_from_config(
+                "model-path: CFG_VAL\n", extra_argv=["--model-path", "CLI_VAL"]
+            ),
+            "CLI_VAL",
+        )
+
+    def test_nonexistent_config_file_returns_none(self):
+        self.assertIsNone(try_get_model_path(["--config", "/no/such/file.yaml"]))
+
+    def test_config_flag_without_path_returns_none(self):
+        self.assertIsNone(try_get_model_path(["--config"]))
+
+    def test_no_config_and_no_model_flag_returns_none(self):
+        self.assertIsNone(try_get_model_path(["--some-flag", "value"]))
+
+    def test_config_without_model_key_returns_none(self):
+        self.assertIsNone(self._detect_from_config("host: 127.0.0.1\n"))
+
+    def test_last_config_model_key_in_file_order_wins(self):
+        self.assertEqual(
+            self._detect_from_config("model-path: First\nmodel: Second\n"),
+            "Second",
+        )
+
+    def test_model_path_flag_still_detected(self):
+        self.assertEqual(try_get_model_path(["--model-path", "X"]), "X")
+
+    def test_model_equals_form_still_detected(self):
+        self.assertEqual(try_get_model_path(["--model=X"]), "X")
+
+    def test_non_string_config_key_does_not_raise(self):
+        self.assertEqual(
+            self._detect_from_config("123: junk\nmodel-path: Qwen/Qwen2-7B\n"),
+            "Qwen/Qwen2-7B",
+        )
+
+    def test_only_non_string_key_returns_none(self):
+        self.assertIsNone(self._detect_from_config("123: junk\n"))
+
+    def test_empty_config_file_returns_none(self):
+        self.assertIsNone(self._detect_from_config(""))
+
+    def test_non_dict_config_root_returns_none(self):
+        self.assertIsNone(self._detect_from_config("- a\n- b\n"))
+
+    def test_falsy_or_non_string_model_value_returns_none(self):
+        self.assertIsNone(self._detect_from_config('model-path: ""\n'))
+        self.assertIsNone(self._detect_from_config("model-path: 123\n"))
+        self.assertIsNone(self._detect_from_config("model-path: [a, b]\n"))
+
+    def test_model_space_form_still_detected(self):
+        self.assertEqual(try_get_model_path(["--model", "X"]), "X")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Fixes #36105

Running `sglang serve --config my_config.yaml` fails with `Error: --model-path is required` even when the YAML config contains a `model-path` key, while `python -m sglang.launch_server --config my_config.yaml` works fine. This is because `try_get_model_path()` in `python/sglang/cli/utils.py` only scanned the raw CLI argv for `--model-path`/`--model` and ignored values supplied through `--config`, so backend auto-detection was skipped and `get_model_path()` raised.

## Modifications

- Added `_try_get_model_path_from_config()` in `python/sglang/cli/utils.py`: a best-effort helper that reads the `--config <file>` YAML and returns the value of a `model-path` / `model_path` / `model` key. It mirrors `ConfigArgumentMerger` semantics (space-form `--config` only, key normalization, last-in-file wins) and never raises — missing/unreadable/malformed files, non-dict roots, and non-string keys or empty/non-string values all return `None`, so the authoritative parser in `prepare_server_args` remains the source of truth.
- `try_get_model_path()` now falls back to this helper only when no explicit `--model-path`/`--model` CLI flag is present, preserving CLI > config > defaults precedence.
- Added `import yaml` (PyYAML is already a hard dependency).

## Accuracy Tests

- New `test/registered/unit/cli/test_cli_utils.py` (17 tests, registered in `base-a-test-cpu`): config-key detection (`model-path`/`model_path`/`model`), CLI-flag precedence, nonexistent/empty/malformed/non-dict configs, non-string keys, falsy/non-string values, last-key-wins, and CLI flag sanity (`--model-path X`, `--model X`, `--model=X`). All pass.
- Existing `test/registered/unit/cli/test_serve_backends.py` (12 tests) still passes, including `test_explicit_backend_can_support_config_only_requests` (missing `pipeline.yaml` → `model_path is None`, never raises).

## Speed Tests and Profiling

N/A — pure CLI argument-parsing helper, best-effort, not on any serving hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (ruff/black/isort verified clean)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (17 new tests in `test/registered/unit/cli/test_cli_utils.py`)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A — no user-facing docs affected)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A — not on any serving hot path)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32662327838](https://github.com/sgl-project/sglang/actions/runs/32662327838)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32662327718](https://github.com/sgl-project/sglang/actions/runs/32662327718)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32662327869](https://github.com/sgl-project/sglang/actions/runs/32662327869)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->