### PR TITLE
Use model-native video preprocessing for Qwen3-VL

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/preprocessor.py
+++ b/python/sglang/srt/disaggregation/encoder/preprocessor.py
@@ -26,6 +26,9 @@ from sglang.srt.multimodal.encoder_preprocessing import (
     EncoderPreprocessOutput,
     invoke_encoder_preprocessor,
 )
+from sglang.srt.multimodal.processors.qwen3_vl import (
+    preprocess_video as qwen3_preprocess_video,
+)
 from sglang.srt.multimodal.processors.qwen_vl import preprocess_video
 from sglang.srt.runtime_context import (
     get_device,
@@ -411,8 +414,16 @@ class EncoderPreprocessor:
 
         video_processor_kwargs = {}
         if "qwen" in self.model_type:
+            # Qwen3-VL/3.5 defer spatial resizing to the model processor; the
+            # legacy path pre-resizes and would double-resize them.
+            qwen3_model_types = ("qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe")
+            video_preprocess = (
+                qwen3_preprocess_video
+                if self.model_type in qwen3_model_types
+                else preprocess_video
+            )
             video_processed = [
-                await preprocess_video(
+                await video_preprocess(
                     video, video_config=self.vision_config.get("video", {})
                 )
                 for video in video_items

--- a/python/sglang/srt/disaggregation/encoder/preprocessor.py
+++ b/python/sglang/srt/disaggregation/encoder/preprocessor.py
@@ -27,6 +27,9 @@ from sglang.srt.multimodal.encoder_preprocessing import (
     invoke_encoder_preprocessor,
 )
 from sglang.srt.multimodal.processors.qwen3_vl import (
+    QWEN3_VL_MODEL_TYPES,
+)
+from sglang.srt.multimodal.processors.qwen3_vl import (
     preprocess_video as qwen3_preprocess_video,
 )
 from sglang.srt.multimodal.processors.qwen_vl import preprocess_video
@@ -223,7 +226,21 @@ class EncoderPreprocessor:
                 self.vision_config[modality_str]["device"] = self.device
 
             if modality_str == "video":
-                video_defaults = {"fps": 2.0, "max_frames": 768, "min_frames": 4}
+                if self.model_type in QWEN3_VL_MODEL_TYPES:
+                    video_defaults = {
+                        key: getattr(self.video_processor, key, fallback)
+                        for key, fallback in (
+                            ("fps", 2.0),
+                            ("max_frames", 768),
+                            ("min_frames", 4),
+                        )
+                    }
+                else:
+                    video_defaults = {
+                        "fps": 2.0,
+                        "max_frames": 768,
+                        "min_frames": 4,
+                    }
                 for k, v in video_defaults.items():
                     self.vision_config["video"].setdefault(k, v)
 
@@ -414,22 +431,19 @@ class EncoderPreprocessor:
 
         video_processor_kwargs = {}
         if "qwen" in self.model_type:
-            # Qwen3-VL/3.5 defer spatial resizing to the model processor; the
-            # legacy path pre-resizes and would double-resize them.
-            qwen3_model_types = ("qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe")
-            video_preprocess = (
-                qwen3_preprocess_video
-                if self.model_type in qwen3_model_types
-                else preprocess_video
-            )
+            is_qwen3 = self.model_type in QWEN3_VL_MODEL_TYPES
+            video_preprocess = qwen3_preprocess_video if is_qwen3 else preprocess_video
+            preprocess_kwargs = {"video_config": self.vision_config.get("video", {})}
+            if is_qwen3:
+                preprocess_kwargs["video_processor"] = self.video_processor
             video_processed = [
-                await video_preprocess(
-                    video, video_config=self.vision_config.get("video", {})
-                )
+                await video_preprocess(video, **preprocess_kwargs)
                 for video in video_items
             ]
             videos, video_metadata = map(list, zip(*video_processed))
             video_processor_kwargs["do_sample_frames"] = False
+            if is_qwen3 and all(metadata is not None for metadata in video_metadata):
+                video_processor_kwargs["do_resize"] = False
             if video_metadata:
                 video_processor_kwargs["video_metadata"] = video_metadata
             return videos, video_processor_kwargs

--- a/python/sglang/srt/disaggregation/encoder/preprocessor.py
+++ b/python/sglang/srt/disaggregation/encoder/preprocessor.py
@@ -32,6 +32,9 @@ from sglang.srt.multimodal.processors.qwen3_vl import (
 from sglang.srt.multimodal.processors.qwen3_vl import (
     preprocess_video as qwen3_preprocess_video,
 )
+from sglang.srt.multimodal.processors.qwen3_vl import (
+    validate_qwen3_video_config,
+)
 from sglang.srt.multimodal.processors.qwen_vl import preprocess_video
 from sglang.srt.runtime_context import (
     get_device,
@@ -227,6 +230,7 @@ class EncoderPreprocessor:
 
             if modality_str == "video":
                 if self.model_type in QWEN3_VL_MODEL_TYPES:
+                    validate_qwen3_video_config(self.vision_config["video"])
                     video_defaults = {
                         key: getattr(self.video_processor, key, fallback)
                         for key, fallback in (

--- a/python/sglang/srt/managers/rust_server.py
+++ b/python/sglang/srt/managers/rust_server.py
@@ -110,25 +110,27 @@ class NativeMmFamily(msgspec.Struct, frozen=True, kw_only=True):
         return mm_processor_cls is cls and model_type in self.model_types
 
 
+_QWEN_VL_IMAGE_PROCESSORS = {
+    "Qwen2VLImageProcessor": "aten_u8",
+    "Qwen2VLImageProcessorFast": "aten_u8",
+    "Qwen2VLImageProcessorPil": "pil",
+}
+
 NATIVE_MM_FAMILIES: Tuple[NativeMmFamily, ...] = (
     NativeMmFamily(
         name="qwen_vl",
         mm_processor="sglang.srt.multimodal.processors.qwen_vl:QwenVLImageProcessor",
-        model_types=frozenset(
-            (
-                "qwen2_vl",
-                "qwen2_5_vl",
-                "qwen3_vl",
-                "qwen3_vl_moe",
-                "qwen3_5",
-                "qwen3_5_moe",
-            )
-        ),
-        image_processors={
-            "Qwen2VLImageProcessor": "aten_u8",
-            "Qwen2VLImageProcessorFast": "aten_u8",
-            "Qwen2VLImageProcessorPil": "pil",
-        },
+        model_types=frozenset(("qwen2_vl", "qwen2_5_vl")),
+        image_processors=_QWEN_VL_IMAGE_PROCESSORS,
+    ),
+    # Qwen3-VL/3.5 register their own processor subclass (qwen3_vl.py); the
+    # identity check in `serves` does not follow subclassing, so they need a
+    # separate entry pointing at that class.
+    NativeMmFamily(
+        name="qwen_vl",
+        mm_processor="sglang.srt.multimodal.processors.qwen3_vl:Qwen3VLImageProcessor",
+        model_types=frozenset(("qwen3_vl", "qwen3_vl_moe", "qwen3_5", "qwen3_5_moe")),
+        image_processors=_QWEN_VL_IMAGE_PROCESSORS,
     ),
 )
 

--- a/python/sglang/srt/multimodal/processors/qwen3_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen3_vl.py
@@ -1,4 +1,9 @@
-"""Multimodal processor registration for Qwen3-VL and Qwen3.5."""
+"""Multimodal preprocessing for Qwen3-VL and Qwen3.5."""
+
+import time
+from typing import Optional
+
+import numpy as np
 
 from sglang.srt.models.qwen3_5 import (
     Qwen3_5ForConditionalGeneration,
@@ -7,11 +12,47 @@ from sglang.srt.models.qwen3_5 import (
 from sglang.srt.models.qwen3_5_mtp import Qwen3_5ForCausalLMMTP
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
 from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
-from sglang.srt.multimodal.processors.qwen_vl import QwenVLImageProcessor
+from sglang.srt.multimodal.processors.qwen_vl import (
+    QwenVLImageProcessor,
+    smart_nframes,
+)
+from sglang.srt.utils.video_decoder import VideoDecoderWrapper
+from sglang.utils import logger
+
+
+async def preprocess_video(vr, video_config: Optional[dict] = None):
+    """Sample video frames and defer spatial processing to the model processor."""
+    if not isinstance(vr, VideoDecoderWrapper):
+        return vr, None
+
+    video_config = video_config or {}
+    entry_time = time.perf_counter()
+    total_frames, video_fps = len(vr), vr.avg_fps
+    nframes = smart_nframes(
+        video_config, total_frames=total_frames, video_fps=video_fps
+    )
+    indices = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
+    indices = np.unique(indices)
+
+    video = vr.get_frames_as_tensor(indices.tolist())
+    video = video.permute(0, 3, 1, 2).pin_memory()
+    metadata = {
+        "fps": video_fps,
+        "duration": total_frames / video_fps,
+        "total_num_frames": total_frames,
+        "frames_indices": indices,
+        "video_backend": "torchvision",
+    }
+    logger.debug(
+        f"[Qwen3VL preprocess_video Perf], "
+        f"spatial_resize: downstream_processor, "
+        f"total_time: {(time.perf_counter() - entry_time) * 1000:.2f} ms"
+    )
+    return video, metadata
 
 
 class Qwen3VLImageProcessor(QwenVLImageProcessor):
-    """Qwen3-family processor with an independent model registration boundary."""
+    """Qwen3-family processor with model-specific video preprocessing."""
 
     models = [
         Qwen3VLForConditionalGeneration,
@@ -20,3 +61,6 @@ class Qwen3VLImageProcessor(QwenVLImageProcessor):
         Qwen3_5MoeForConditionalGeneration,
         Qwen3_5ForCausalLMMTP,
     ]
+
+    async def _preprocess_video(self, video):
+        return await preprocess_video(video, video_config=self.video_config)

--- a/python/sglang/srt/multimodal/processors/qwen3_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen3_vl.py
@@ -21,7 +21,8 @@ from sglang.utils import logger
 
 
 async def preprocess_video(vr, video_config: Optional[dict] = None):
-    """Sample video frames and defer spatial processing to the model processor."""
+    # Spatial resize stays with the model-native processor; pre-resizing here
+    # (as the Qwen2 path does) double-resizes with the wrong geometry.
     if not isinstance(vr, VideoDecoderWrapper):
         return vr, None
 
@@ -52,8 +53,6 @@ async def preprocess_video(vr, video_config: Optional[dict] = None):
 
 
 class Qwen3VLImageProcessor(QwenVLImageProcessor):
-    """Qwen3-family processor with model-specific video preprocessing."""
-
     models = [
         Qwen3VLForConditionalGeneration,
         Qwen3VLMoeForConditionalGeneration,

--- a/python/sglang/srt/multimodal/processors/qwen3_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen3_vl.py
@@ -1,0 +1,22 @@
+"""Multimodal processor registration for Qwen3-VL and Qwen3.5."""
+
+from sglang.srt.models.qwen3_5 import (
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5MoeForConditionalGeneration,
+)
+from sglang.srt.models.qwen3_5_mtp import Qwen3_5ForCausalLMMTP
+from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
+from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
+from sglang.srt.multimodal.processors.qwen_vl import QwenVLImageProcessor
+
+
+class Qwen3VLImageProcessor(QwenVLImageProcessor):
+    """Qwen3-family processor with an independent model registration boundary."""
+
+    models = [
+        Qwen3VLForConditionalGeneration,
+        Qwen3VLMoeForConditionalGeneration,
+        Qwen3_5ForConditionalGeneration,
+        Qwen3_5MoeForConditionalGeneration,
+        Qwen3_5ForCausalLMMTP,
+    ]

--- a/python/sglang/srt/multimodal/processors/qwen3_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen3_vl.py
@@ -1,6 +1,7 @@
 """Multimodal preprocessing for Qwen3-VL and Qwen3.5."""
 
 import time
+from collections.abc import Mapping
 
 import numpy as np
 from transformers.image_utils import SizeDict
@@ -31,13 +32,80 @@ QWEN3_VL_MODEL_TYPES = frozenset(
         "qwen3_5_moe",
     }
 )
+QWEN3_LEGACY_VIDEO_SIZE_KEYS = frozenset(
+    {
+        "max_pixels",
+        "min_pixels",
+        "resized_height",
+        "resized_width",
+        "total_pixels",
+    }
+)
+QWEN3_PROCESSOR_GEOMETRY_KEYS = frozenset(
+    {"merge_size", "patch_size", "temporal_patch_size"}
+)
 QWEN3_EARLY_VIDEO_CONFIG_KEYS = frozenset(
     {"fps", "max_frames", "min_frames", "nframes", "resample", "size"}
 )
 
 
-def _as_size_dict(size) -> SizeDict:
-    return size if isinstance(size, SizeDict) else SizeDict(**size)
+def _native_size(size) -> SizeDict:
+    if isinstance(size, SizeDict):
+        shortest_edge = size.shortest_edge
+        longest_edge = size.longest_edge
+    elif isinstance(size, Mapping):
+        expected = {"longest_edge", "shortest_edge"}
+        actual = set(size)
+        if actual != expected:
+            raise ValueError(
+                "Qwen3 video `size` must contain exactly `shortest_edge` and "
+                f"`longest_edge`; got {sorted(actual)}."
+            )
+        shortest_edge = size["shortest_edge"]
+        longest_edge = size["longest_edge"]
+    else:
+        raise TypeError(
+            "Qwen3 video `size` must be a mapping with `shortest_edge` and "
+            f"`longest_edge`, not {type(size).__name__}."
+        )
+
+    if any(
+        isinstance(value, bool) or not isinstance(value, int) or value <= 0
+        for value in (shortest_edge, longest_edge)
+    ):
+        raise ValueError(
+            "Qwen3 video `size.shortest_edge` and `size.longest_edge` must be "
+            "positive integers."
+        )
+    if shortest_edge > longest_edge:
+        raise ValueError(
+            "Qwen3 video `size.shortest_edge` cannot exceed `size.longest_edge`."
+        )
+    return SizeDict(shortest_edge=shortest_edge, longest_edge=longest_edge)
+
+
+def validate_qwen3_video_config(video_config) -> None:
+    legacy_keys = sorted(QWEN3_LEGACY_VIDEO_SIZE_KEYS.intersection(video_config))
+    if legacy_keys:
+        raise ValueError(
+            "Qwen3 video preprocessing does not support the legacy Qwen2 sizing "
+            f"fields {legacy_keys}. Use `video.size` with `shortest_edge` and "
+            "`longest_edge` instead."
+        )
+
+    geometry_keys = sorted(QWEN3_PROCESSOR_GEOMETRY_KEYS.intersection(video_config))
+    if geometry_keys:
+        raise ValueError(
+            "Qwen3 video processor geometry is loaded from the Hugging Face "
+            f"processor and cannot be overridden via mm-process-config: {geometry_keys}."
+        )
+    if "do_resize" in video_config:
+        raise ValueError(
+            "Qwen3 video `do_resize` is managed by SGLang's bounded preprocessing; "
+            "configure the target with `video.size` instead."
+        )
+    if "size" in video_config:
+        _native_size(video_config["size"])
 
 
 def _sampling_config(video_processor, video_config):
@@ -51,18 +119,13 @@ def _sampling_config(video_processor, video_config):
 
 
 def _resize_geometry(video_processor, video_config, *, num_frames, height, width):
-    size = _as_size_dict(video_config.get("size", video_processor.size))
-    patch_size = video_config.get("patch_size", video_processor.patch_size)
-    merge_size = video_config.get("merge_size", video_processor.merge_size)
-    temporal_patch_size = video_config.get(
-        "temporal_patch_size", video_processor.temporal_patch_size
-    )
+    size = _native_size(video_config.get("size", video_processor.size))
     resized_height, resized_width = smart_resize_video(
         num_frames=num_frames,
         height=height,
         width=width,
-        temporal_factor=temporal_patch_size,
-        factor=patch_size * merge_size,
+        temporal_factor=video_processor.temporal_patch_size,
+        factor=video_processor.patch_size * video_processor.merge_size,
         min_pixels=size.shortest_edge,
         max_pixels=size.longest_edge,
     )
@@ -119,16 +182,14 @@ async def preprocess_video(
         return vr, None
 
     video_config = video_config or {}
+    validate_qwen3_video_config(video_config)
     entry_time = time.perf_counter()
     total_frames, video_fps = len(vr), vr.avg_fps
-    temporal_patch_size = video_config.get(
-        "temporal_patch_size", video_processor.temporal_patch_size
-    )
     nframes = smart_nframes(
         _sampling_config(video_processor, video_config),
         total_frames=total_frames,
         video_fps=video_fps,
-        frame_factor=temporal_patch_size,
+        frame_factor=video_processor.temporal_patch_size,
     )
     indices = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
     indices = np.unique(indices)
@@ -163,6 +224,10 @@ class Qwen3VLImageProcessor(QwenVLImageProcessor):
         Qwen3_5MoeForConditionalGeneration,
         Qwen3_5ForCausalLMMTP,
     ]
+
+    def __init__(self, hf_config, server_args, _processor, *args, **kwargs):
+        super().__init__(hf_config, server_args, _processor, *args, **kwargs)
+        validate_qwen3_video_config(self.video_config)
 
     async def _preprocess_video(self, video):
         return await preprocess_video(

--- a/python/sglang/srt/multimodal/processors/qwen3_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen3_vl.py
@@ -1,9 +1,12 @@
 """Multimodal preprocessing for Qwen3-VL and Qwen3.5."""
 
 import time
-from typing import Optional
 
 import numpy as np
+from transformers.image_utils import SizeDict
+from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
+    smart_resize as smart_resize_video,
+)
 
 from sglang.srt.models.qwen3_5 import (
     Qwen3_5ForConditionalGeneration,
@@ -19,24 +22,124 @@ from sglang.srt.multimodal.processors.qwen_vl import (
 from sglang.srt.utils.video_decoder import VideoDecoderWrapper
 from sglang.utils import logger
 
+MAX_VIDEO_DECODE_CHUNK_BYTES = 512 * 1024 * 1024
+QWEN3_VL_MODEL_TYPES = frozenset(
+    {
+        "qwen3_vl",
+        "qwen3_vl_moe",
+        "qwen3_5",
+        "qwen3_5_moe",
+    }
+)
+QWEN3_EARLY_VIDEO_CONFIG_KEYS = frozenset(
+    {"fps", "max_frames", "min_frames", "nframes", "resample", "size"}
+)
 
-async def preprocess_video(vr, video_config: Optional[dict] = None):
-    # Spatial resize stays with the model-native processor; pre-resizing here
-    # (as the Qwen2 path does) double-resizes with the wrong geometry.
+
+def _as_size_dict(size) -> SizeDict:
+    return size if isinstance(size, SizeDict) else SizeDict(**size)
+
+
+def _sampling_config(video_processor, video_config):
+    config = dict(video_config)
+    if "nframes" not in config:
+        for key in ("fps", "min_frames", "max_frames"):
+            value = getattr(video_processor, key, None)
+            if value is not None:
+                config.setdefault(key, value)
+    return config
+
+
+def _resize_geometry(video_processor, video_config, *, num_frames, height, width):
+    size = _as_size_dict(video_config.get("size", video_processor.size))
+    patch_size = video_config.get("patch_size", video_processor.patch_size)
+    merge_size = video_config.get("merge_size", video_processor.merge_size)
+    temporal_patch_size = video_config.get(
+        "temporal_patch_size", video_processor.temporal_patch_size
+    )
+    resized_height, resized_width = smart_resize_video(
+        num_frames=num_frames,
+        height=height,
+        width=width,
+        temporal_factor=temporal_patch_size,
+        factor=patch_size * merge_size,
+        min_pixels=size.shortest_edge,
+        max_pixels=size.longest_edge,
+    )
+    return SizeDict(height=resized_height, width=resized_width)
+
+
+def _decode_and_resize(
+    vr,
+    indices,
+    *,
+    video_processor,
+    video_config,
+    max_decode_chunk_bytes,
+):
+    height, width, channels = vr.frame_shape
+    frame_bytes = height * width * channels
+    frames_per_chunk = max_decode_chunk_bytes // frame_bytes
+    if frames_per_chunk < 1:
+        raise ValueError(
+            f"A single decoded video frame requires {frame_bytes} bytes, exceeding "
+            f"the {max_decode_chunk_bytes}-byte Qwen3 video preprocessing limit."
+        )
+
+    resize_size = _resize_geometry(
+        video_processor,
+        video_config,
+        num_frames=len(indices),
+        height=height,
+        width=width,
+    )
+    resample = video_config.get("resample", video_processor.resample)
+    video = None
+    for start in range(0, len(indices), frames_per_chunk):
+        chunk_indices = indices[start : start + frames_per_chunk]
+        chunk = vr.get_frames_as_tensor(chunk_indices).permute(0, 3, 1, 2)
+        resized_chunk = video_processor.resize(
+            chunk, size=resize_size, resample=resample
+        )
+        if video is None:
+            video = resized_chunk.new_empty((len(indices), *resized_chunk.shape[1:]))
+        video[start : start + len(chunk_indices)].copy_(resized_chunk)
+        del chunk, resized_chunk
+    return video
+
+
+async def preprocess_video(
+    vr,
+    *,
+    video_processor,
+    video_config: dict | None = None,
+    max_decode_chunk_bytes: int = MAX_VIDEO_DECODE_CHUNK_BYTES,
+):
     if not isinstance(vr, VideoDecoderWrapper):
         return vr, None
 
     video_config = video_config or {}
     entry_time = time.perf_counter()
     total_frames, video_fps = len(vr), vr.avg_fps
+    temporal_patch_size = video_config.get(
+        "temporal_patch_size", video_processor.temporal_patch_size
+    )
     nframes = smart_nframes(
-        video_config, total_frames=total_frames, video_fps=video_fps
+        _sampling_config(video_processor, video_config),
+        total_frames=total_frames,
+        video_fps=video_fps,
+        frame_factor=temporal_patch_size,
     )
     indices = np.linspace(0, total_frames - 1, num=nframes, dtype=np.int64)
     indices = np.unique(indices)
 
-    video = vr.get_frames_as_tensor(indices.tolist())
-    video = video.permute(0, 3, 1, 2).pin_memory()
+    video = _decode_and_resize(
+        vr,
+        indices.tolist(),
+        video_processor=video_processor,
+        video_config=video_config,
+        max_decode_chunk_bytes=max_decode_chunk_bytes,
+    )
     metadata = {
         "fps": video_fps,
         "duration": total_frames / video_fps,
@@ -46,7 +149,7 @@ async def preprocess_video(vr, video_config: Optional[dict] = None):
     }
     logger.debug(
         f"[Qwen3VL preprocess_video Perf], "
-        f"spatial_resize: downstream_processor, "
+        f"spatial_resize: chunked_model_native, "
         f"total_time: {(time.perf_counter() - entry_time) * 1000:.2f} ms"
     )
     return video, metadata
@@ -62,4 +165,16 @@ class Qwen3VLImageProcessor(QwenVLImageProcessor):
     ]
 
     async def _preprocess_video(self, video):
-        return await preprocess_video(video, video_config=self.video_config)
+        return await preprocess_video(
+            video,
+            video_processor=self._processor.video_processor,
+            video_config=self.video_config,
+        )
+
+    def _processor_video_config(self, video_metadata):
+        config = super()._processor_video_config(video_metadata)
+        if config is not None:
+            for key in QWEN3_EARLY_VIDEO_CONFIG_KEYS:
+                config.pop(key, None)
+            config["do_resize"] = False
+        return config

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -23,14 +23,7 @@ from sglang.srt.models.interns2_mobius import (
 from sglang.srt.models.interns2preview import InternS2PreviewForConditionalGeneration
 from sglang.srt.models.qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
 from sglang.srt.models.qwen2_vl import Qwen2VLForConditionalGeneration
-from sglang.srt.models.qwen3_5 import (
-    Qwen3_5ForConditionalGeneration,
-    Qwen3_5MoeForConditionalGeneration,
-)
-from sglang.srt.models.qwen3_5_mtp import Qwen3_5ForCausalLMMTP
 from sglang.srt.models.qwen3_omni_moe import Qwen3OmniMoeForConditionalGeneration
-from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
-from sglang.srt.models.qwen3_vl_moe import Qwen3VLMoeForConditionalGeneration
 from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor as SGLangBaseProcessor,
 )
@@ -292,11 +285,6 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
     models = [
         Qwen2VLForConditionalGeneration,
         Qwen2_5_VLForConditionalGeneration,
-        Qwen3VLForConditionalGeneration,
-        Qwen3VLMoeForConditionalGeneration,
-        Qwen3_5ForConditionalGeneration,
-        Qwen3_5MoeForConditionalGeneration,
-        Qwen3_5ForCausalLMMTP,
         InternS2PreviewForConditionalGeneration,
         InternS2MobiusForConditionalGeneration,
         Qwen3OmniMoeForConditionalGeneration,
@@ -356,6 +344,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
     @property
     def spatial_merge_size(self):
         return self._spatial_merge_size
+
+    async def _preprocess_video(self, video):
+        return await preprocess_video(video, video_config=self.video_config)
 
     def build_input_ids_with_timestamps(
         self, prompt, embeddings, img_grid_thw, video_grid_thw, video_timestamps
@@ -745,8 +736,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         video_metadata = None
         if base_output.videos and not isinstance(base_output.videos[0], dict):
             videos_processed = [
-                await preprocess_video(video, video_config=self.video_config)
-                for video in base_output.videos
+                await self._preprocess_video(video) for video in base_output.videos
             ]
             base_output.videos, video_metadata = map(list, zip(*videos_processed))
 

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -152,6 +152,7 @@ def smart_nframes(
     ele: dict,
     total_frames: int,
     video_fps: int | float,
+    frame_factor: int = FRAME_FACTOR,
 ) -> int:
     """calculate the number of frames for video used for model inputs.
 
@@ -164,9 +165,10 @@ def smart_nframes(
                     - max_frames: the maximum number of frames of the video, only used when fps is provided.
         total_frames (int): the original total number of frames of the video.
         video_fps (int | float): the original fps of the video.
+        frame_factor (int): temporal patch-size multiple required by the processor.
 
     Raises:
-        ValueError: nframes should in interval [FRAME_FACTOR, total_frames].
+        ValueError: nframes should be in [frame_factor, total_frames].
 
     Returns:
         int: the number of frames for video used for model inputs.
@@ -175,12 +177,12 @@ def smart_nframes(
         "fps" in ele and "nframes" in ele
     ), "Only accept either `fps` or `nframes`"
     if "nframes" in ele:
-        nframes = round_by_factor(ele["nframes"], FRAME_FACTOR)
+        nframes = round_by_factor(ele["nframes"], frame_factor)
     else:
         fps = ele.get("fps", FPS)
-        min_frames = ceil_by_factor(ele.get("min_frames", FPS_MIN_FRAMES), FRAME_FACTOR)
+        min_frames = ceil_by_factor(ele.get("min_frames", FPS_MIN_FRAMES), frame_factor)
         max_frames = floor_by_factor(
-            ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), FRAME_FACTOR
+            ele.get("max_frames", min(FPS_MAX_FRAMES, total_frames)), frame_factor
         )
         nframes = total_frames / video_fps * fps
         if nframes > total_frames:
@@ -188,10 +190,10 @@ def smart_nframes(
                 f"smart_nframes: nframes[{nframes}] > total_frames[{total_frames}]"
             )
         nframes = min(min(max(nframes, min_frames), max_frames), total_frames)
-        nframes = floor_by_factor(nframes, FRAME_FACTOR)
-    if not (FRAME_FACTOR <= nframes and nframes <= total_frames):
+        nframes = floor_by_factor(nframes, frame_factor)
+    if not (frame_factor <= nframes and nframes <= total_frames):
         raise ValueError(
-            f"nframes should in interval [{FRAME_FACTOR}, {total_frames}], but got {nframes}."
+            f"nframes should in interval [{frame_factor}, {total_frames}], but got {nframes}."
         )
     return nframes
 
@@ -347,6 +349,9 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
 
     async def _preprocess_video(self, video):
         return await preprocess_video(video, video_config=self.video_config)
+
+    def _processor_video_config(self, video_metadata):
+        return _get_processor_video_config(self.video_config, video_metadata)
 
     def build_input_ids_with_timestamps(
         self, prompt, embeddings, img_grid_thw, video_grid_thw, video_timestamps
@@ -743,9 +748,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         preprocess_time = time.perf_counter()
 
         processor_kwargs = {}
-        processor_video_config = _get_processor_video_config(
-            self.video_config, video_metadata
-        )
+        processor_video_config = self._processor_video_config(video_metadata)
         if processor_video_config is not None:
             processor_kwargs["processor_video_config"] = processor_video_config
 

--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -52,6 +52,7 @@ class VideoDecoderWrapper:
         self._source_bytes = source if isinstance(source, bytes) else None
         self._source_path = source if isinstance(source, str) else None
         self._tmp_path = None
+        self._frame_shape = None
         if _BACKEND == "torchcodec":
             kwargs = {"dimension_order": "NHWC"}
             if device == "cuda" and _try_cuda_backend():
@@ -100,6 +101,12 @@ class VideoDecoderWrapper:
             return self._decoder.metadata.average_fps
         else:
             return self._decoder.get_avg_fps()
+
+    @property
+    def frame_shape(self) -> tuple[int, int, int]:
+        if self._frame_shape is None:
+            self._frame_shape = tuple(self._decoder[0].shape)
+        return self._frame_shape
 
     def get_frames_at(self, indices: list) -> np.ndarray:
         """Return frames at given indices as numpy array with shape (N, H, W, C)."""

--- a/test/registered/unit/models/test_qwen3_vl_feature_materialization.py
+++ b/test/registered/unit/models/test_qwen3_vl_feature_materialization.py
@@ -8,7 +8,7 @@ import torch
 
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
-from sglang.srt.multimodal.processors.qwen_vl import QwenVLImageProcessor
+from sglang.srt.multimodal.processors.qwen3_vl import Qwen3VLImageProcessor
 from sglang.srt.multimodal.transport.cuda_ipc import (
     DEFER_CUDA_IPC_FEATURE_RECONSTRUCTION_KEY,
 )
@@ -44,7 +44,7 @@ class TestQwen3VLFeatureMaterialization(CustomTestCase):
     def test_processor_defers_gpu_transport_for_encoder_dp(self):
         for transport in ("cuda_ipc", "cuda_vmm"):
             with self.subTest(transport=transport):
-                processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)
+                processor = Qwen3VLImageProcessor.__new__(Qwen3VLImageProcessor)
                 processor.mm_feature_transport = transport
                 processor.server_args = SimpleNamespace(mm_enable_dp_encoder=True)
                 processor.model_type = "qwen3_vl"
@@ -72,7 +72,7 @@ class TestQwen3VLFeatureMaterialization(CustomTestCase):
                 )
 
     def test_processor_does_not_defer_cpu_transport(self):
-        processor = QwenVLImageProcessor.__new__(QwenVLImageProcessor)
+        processor = Qwen3VLImageProcessor.__new__(Qwen3VLImageProcessor)
         processor.mm_feature_transport = "cpu"
         processor.server_args = SimpleNamespace(mm_enable_dp_encoder=True)
         processor.model_type = "qwen3_vl"

--- a/test/registered/unit/multimodal/rust/shared/test_native_mm_gate.py
+++ b/test/registered/unit/multimodal/rust/shared/test_native_mm_gate.py
@@ -41,6 +41,13 @@ class TestNativeMmGate(CustomTestCase):
         family = native_mm_family_for(cls, "qwen2_5_vl")
         self.assertEqual(family and family.name, "qwen_vl")
 
+    def test_qwen3_vl_resolves_its_family(self):
+        # The Qwen3 processor is a separate class from QwenVLImageProcessor;
+        # the gate must still match it or launch hard-errors.
+        cls = processor_cls_for("Qwen3VLForConditionalGeneration", "qwen3_vl")
+        family = native_mm_family_for(cls, "qwen3_vl")
+        self.assertEqual(family and family.name, "qwen_vl")
+
     def test_inkling_keeps_its_python_processor(self):
         from sglang.srt.multimodal.processors.inkling import InklingMultimodalProcessor
 

--- a/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
+++ b/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
@@ -1,0 +1,139 @@
+"""CPU tests for model-specific Qwen3-VL video preprocessing."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import asyncio
+import unittest
+from unittest.mock import patch
+
+import numpy as np
+
+from sglang.srt.multimodal.processors import qwen3_vl, qwen_vl
+from sglang.test.test_utils import CustomTestCase
+
+
+class _FakeTensor:
+    def __init__(self, shape):
+        self.shape = shape
+        self.pinned = False
+
+    def permute(self, *dims):
+        self.shape = tuple(self.shape[dim] for dim in dims)
+        return self
+
+    def pin_memory(self):
+        self.pinned = True
+        return self
+
+
+class _FakeVideoDecoder:
+    def __init__(self, *, total_frames=4304, fps=30.0, height=5, width=7):
+        self.total_frames = total_frames
+        self.avg_fps = fps
+        self.height = height
+        self.width = width
+        self.requested_indices = None
+
+    def __len__(self):
+        return self.total_frames
+
+    def get_frames_as_tensor(self, indices):
+        self.requested_indices = indices
+        return _FakeTensor((len(indices), self.height, self.width, 3))
+
+
+class TestQwen3VLVideoPreprocess(CustomTestCase):
+    def _assert_uses_existing_evenly_spaced_selection(self, fps):
+        decoder = _FakeVideoDecoder()
+        video_config = {"fps": fps}
+        with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
+            video, metadata = asyncio.run(
+                qwen3_vl.preprocess_video(decoder, video_config=video_config)
+            )
+
+        nframes = qwen_vl.smart_nframes(
+            video_config,
+            total_frames=decoder.total_frames,
+            video_fps=decoder.avg_fps,
+        )
+        expected_indices = np.unique(
+            np.linspace(
+                0,
+                decoder.total_frames - 1,
+                num=nframes,
+                dtype=np.int64,
+            )
+        )
+        self.assertEqual(video.shape, (nframes, 3, 5, 7))
+        self.assertTrue(video.pinned)
+        np.testing.assert_array_equal(decoder.requested_indices, expected_indices)
+        np.testing.assert_array_equal(metadata["frames_indices"], expected_indices)
+
+    def test_qwen3_keeps_existing_evenly_spaced_selection_at_one_fps(self):
+        self._assert_uses_existing_evenly_spaced_selection(fps=1)
+
+    def test_qwen3_keeps_existing_evenly_spaced_selection_at_two_fps(self):
+        self._assert_uses_existing_evenly_spaced_selection(fps=2)
+
+    def test_qwen3_preserves_source_geometry_for_model_processor(self):
+        decoder = _FakeVideoDecoder(total_frames=10, fps=2.0)
+        with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
+            video, metadata = asyncio.run(
+                qwen3_vl.preprocess_video(
+                    decoder,
+                    video_config={"nframes": 4},
+                )
+            )
+
+        self.assertEqual(video.shape, (4, 3, 5, 7))
+        self.assertEqual(decoder.requested_indices, [0, 3, 6, 9])
+        np.testing.assert_array_equal(metadata["frames_indices"], [0, 3, 6, 9])
+
+    def test_qwen3_max_frames_still_spans_full_video(self):
+        decoder = _FakeVideoDecoder(total_frames=3000, fps=30.0)
+        with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
+            video, _ = asyncio.run(
+                qwen3_vl.preprocess_video(
+                    decoder,
+                    video_config={"fps": 2, "max_frames": 10},
+                )
+            )
+
+        self.assertEqual(video.shape, (10, 3, 5, 7))
+        self.assertEqual(decoder.requested_indices[0], 0)
+        self.assertEqual(decoder.requested_indices[-1], 2999)
+        self.assertTrue(np.all(np.diff(np.asarray(decoder.requested_indices)) > 0))
+
+    def test_qwen2_keeps_legacy_factor_28_resize(self):
+        decoder = _FakeVideoDecoder(
+            total_frames=10,
+            fps=2.0,
+            height=56,
+            width=84,
+        )
+        resized = _FakeTensor((4, 3, 56, 84))
+        with (
+            patch.object(qwen_vl, "VideoDecoderWrapper", _FakeVideoDecoder),
+            patch.object(
+                qwen_vl.torchvision.transforms.functional,
+                "resize",
+                return_value=resized,
+            ) as resize,
+        ):
+            video, _ = asyncio.run(
+                qwen_vl.preprocess_video(
+                    decoder,
+                    video_config={"nframes": 4},
+                )
+            )
+
+        resize.assert_called_once()
+        self.assertEqual(resize.call_args.args[1], [280, 392])
+        self.assertIs(video, resized)
+        self.assertTrue(video.pinned)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
+++ b/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
@@ -17,19 +17,17 @@ from sglang.test.test_utils import CustomTestCase
 class _FakeTensor:
     def __init__(self, shape):
         self.shape = shape
-        self.pinned = False
 
     def permute(self, *dims):
         self.shape = tuple(self.shape[dim] for dim in dims)
         return self
 
     def pin_memory(self):
-        self.pinned = True
         return self
 
 
 class _FakeVideoDecoder:
-    def __init__(self, *, total_frames=4304, fps=30.0, height=5, width=7):
+    def __init__(self, *, total_frames, fps, height=5, width=7):
         self.total_frames = total_frames
         self.avg_fps = fps
         self.height = height
@@ -45,46 +43,11 @@ class _FakeVideoDecoder:
 
 
 class TestQwen3VLVideoPreprocess(CustomTestCase):
-    def _assert_uses_existing_evenly_spaced_selection(self, fps):
-        decoder = _FakeVideoDecoder()
-        video_config = {"fps": fps}
-        with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
-            video, metadata = asyncio.run(
-                qwen3_vl.preprocess_video(decoder, video_config=video_config)
-            )
-
-        nframes = qwen_vl.smart_nframes(
-            video_config,
-            total_frames=decoder.total_frames,
-            video_fps=decoder.avg_fps,
-        )
-        expected_indices = np.unique(
-            np.linspace(
-                0,
-                decoder.total_frames - 1,
-                num=nframes,
-                dtype=np.int64,
-            )
-        )
-        self.assertEqual(video.shape, (nframes, 3, 5, 7))
-        self.assertTrue(video.pinned)
-        np.testing.assert_array_equal(decoder.requested_indices, expected_indices)
-        np.testing.assert_array_equal(metadata["frames_indices"], expected_indices)
-
-    def test_qwen3_keeps_existing_evenly_spaced_selection_at_one_fps(self):
-        self._assert_uses_existing_evenly_spaced_selection(fps=1)
-
-    def test_qwen3_keeps_existing_evenly_spaced_selection_at_two_fps(self):
-        self._assert_uses_existing_evenly_spaced_selection(fps=2)
-
     def test_qwen3_preserves_source_geometry_for_model_processor(self):
         decoder = _FakeVideoDecoder(total_frames=10, fps=2.0)
         with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
             video, metadata = asyncio.run(
-                qwen3_vl.preprocess_video(
-                    decoder,
-                    video_config={"nframes": 4},
-                )
+                qwen3_vl.preprocess_video(decoder, video_config={"nframes": 4})
             )
 
         self.assertEqual(video.shape, (4, 3, 5, 7))
@@ -107,12 +70,7 @@ class TestQwen3VLVideoPreprocess(CustomTestCase):
         self.assertTrue(np.all(np.diff(np.asarray(decoder.requested_indices)) > 0))
 
     def test_qwen2_keeps_legacy_factor_28_resize(self):
-        decoder = _FakeVideoDecoder(
-            total_frames=10,
-            fps=2.0,
-            height=56,
-            width=84,
-        )
+        decoder = _FakeVideoDecoder(total_frames=10, fps=2.0, height=56, width=84)
         resized = _FakeTensor((4, 3, 56, 84))
         with (
             patch.object(qwen_vl, "VideoDecoderWrapper", _FakeVideoDecoder),
@@ -123,16 +81,12 @@ class TestQwen3VLVideoPreprocess(CustomTestCase):
             ) as resize,
         ):
             video, _ = asyncio.run(
-                qwen_vl.preprocess_video(
-                    decoder,
-                    video_config={"nframes": 4},
-                )
+                qwen_vl.preprocess_video(decoder, video_config={"nframes": 4})
             )
 
         resize.assert_called_once()
         self.assertEqual(resize.call_args.args[1], [280, 392])
         self.assertIs(video, resized)
-        self.assertTrue(video.pinned)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
+++ b/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
@@ -248,6 +248,55 @@ class TestQwen3VLVideoPreprocess(CustomTestCase):
             {"do_normalize": False, "do_resize": False},
         )
 
+    def test_qwen3_rejects_legacy_qwen2_size_fields(self):
+        for key in (
+            "min_pixels",
+            "max_pixels",
+            "total_pixels",
+            "resized_height",
+            "resized_width",
+        ):
+            with (
+                self.subTest(key=key),
+                self.assertRaisesRegex(ValueError, "legacy Qwen2 sizing fields"),
+            ):
+                qwen3_vl.validate_qwen3_video_config({key: 1})
+
+    def test_qwen3_rejects_processor_geometry_overrides(self):
+        for key in ("patch_size", "merge_size", "temporal_patch_size"):
+            with (
+                self.subTest(key=key),
+                self.assertRaisesRegex(ValueError, "loaded from the Hugging Face"),
+            ):
+                qwen3_vl.validate_qwen3_video_config({key: 1})
+
+        with self.assertRaisesRegex(ValueError, "do_resize.*managed by SGLang"):
+            qwen3_vl.validate_qwen3_video_config({"do_resize": False})
+
+    def test_qwen3_validates_native_size(self):
+        qwen3_vl.validate_qwen3_video_config(
+            {"size": {"shortest_edge": 4096, "longest_edge": 8192}}
+        )
+
+        invalid_sizes = (
+            {"height": 64, "width": 96},
+            {"shortest_edge": 8192, "longest_edge": 4096},
+            {"shortest_edge": 0, "longest_edge": 8192},
+        )
+        for size in invalid_sizes:
+            with self.subTest(size=size), self.assertRaises((TypeError, ValueError)):
+                qwen3_vl.validate_qwen3_video_config({"size": size})
+
+    def test_qwen3_rejects_legacy_size_during_processor_initialization(self):
+        def fake_base_init(processor, *_args, **_kwargs):
+            processor.video_config = {"max_pixels": 8192}
+
+        with (
+            patch.object(qwen3_vl.QwenVLImageProcessor, "__init__", fake_base_init),
+            self.assertRaisesRegex(ValueError, "legacy Qwen2 sizing fields"),
+        ):
+            qwen3_vl.Qwen3VLImageProcessor(None, None, None)
+
     def test_qwen2_keeps_legacy_factor_28_resize(self):
         decoder = _FakeVideoDecoder(total_frames=10, fps=2.0, height=56, width=84)
         resized = _FakeTensor((4, 3, 56, 84))

--- a/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
+++ b/test/registered/unit/multimodal/test_qwen3_vl_video_preprocess.py
@@ -9,6 +9,11 @@ import unittest
 from unittest.mock import patch
 
 import numpy as np
+import torch
+from transformers.image_utils import SizeDict
+from transformers.models.qwen3_vl.video_processing_qwen3_vl import (
+    Qwen3VLVideoProcessor,
+)
 
 from sglang.srt.multimodal.processors import qwen3_vl, qwen_vl
 from sglang.test.test_utils import CustomTestCase
@@ -25,49 +30,223 @@ class _FakeTensor:
     def pin_memory(self):
         return self
 
+    def new_empty(self, shape):
+        return _FakeTensor(shape)
+
+    def __getitem__(self, item):
+        if not isinstance(item, slice):
+            raise TypeError(f"unsupported fake tensor index: {item!r}")
+        start = item.start or 0
+        stop = item.stop if item.stop is not None else self.shape[0]
+        return _FakeTensor((stop - start, *self.shape[1:]))
+
+    def copy_(self, other):
+        if self.shape != other.shape:
+            raise ValueError(f"shape mismatch: {self.shape} != {other.shape}")
+        return self
+
 
 class _FakeVideoDecoder:
-    def __init__(self, *, total_frames, fps, height=5, width=7):
+    def __init__(self, *, total_frames, fps, height=64, width=80):
         self.total_frames = total_frames
         self.avg_fps = fps
         self.height = height
         self.width = width
         self.requested_indices = None
+        self.requested_chunks = []
 
     def __len__(self):
         return self.total_frames
 
+    @property
+    def frame_shape(self):
+        return self.height, self.width, 3
+
     def get_frames_as_tensor(self, indices):
         self.requested_indices = indices
+        self.requested_chunks.append(indices)
         return _FakeTensor((len(indices), self.height, self.width, 3))
 
 
+class _FakeVideoProcessor:
+    def __init__(self):
+        self.size = SizeDict(shortest_edge=1, longest_edge=10**9)
+        self.patch_size = 16
+        self.merge_size = 2
+        self.temporal_patch_size = 2
+        self.fps = 2.0
+        self.min_frames = 4
+        self.max_frames = 768
+        self.resample = None
+        self.resize_calls = []
+
+    def resize(self, video, *, size, resample):
+        self.resize_calls.append((video.shape, size, resample))
+        return _FakeTensor((video.shape[0], video.shape[1], size.height, size.width))
+
+
+class _TensorVideoDecoder:
+    def __init__(self, frames, fps):
+        self.frames = frames
+        self.avg_fps = fps
+        self.requested_chunks = []
+
+    def __len__(self):
+        return self.frames.shape[0]
+
+    @property
+    def frame_shape(self):
+        return tuple(self.frames.shape[1:])
+
+    def get_frames_as_tensor(self, indices):
+        self.requested_chunks.append(indices)
+        return self.frames[indices]
+
+
 class TestQwen3VLVideoPreprocess(CustomTestCase):
-    def test_qwen3_preserves_source_geometry_for_model_processor(self):
+    def test_qwen3_resizes_source_frames_in_bounded_chunks(self):
         decoder = _FakeVideoDecoder(total_frames=10, fps=2.0)
+        video_processor = _FakeVideoProcessor()
+        frame_bytes = decoder.height * decoder.width * 3
         with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
             video, metadata = asyncio.run(
-                qwen3_vl.preprocess_video(decoder, video_config={"nframes": 4})
+                qwen3_vl.preprocess_video(
+                    decoder,
+                    video_processor=video_processor,
+                    video_config={"nframes": 4},
+                    max_decode_chunk_bytes=2 * frame_bytes,
+                )
             )
 
-        self.assertEqual(video.shape, (4, 3, 5, 7))
-        self.assertEqual(decoder.requested_indices, [0, 3, 6, 9])
+        self.assertEqual(video.shape, (4, 3, 64, 64))
+        self.assertEqual(decoder.requested_chunks, [[0, 3], [6, 9]])
+        self.assertEqual(
+            [call[0] for call in video_processor.resize_calls],
+            [(2, 3, 64, 80), (2, 3, 64, 80)],
+        )
         np.testing.assert_array_equal(metadata["frames_indices"], [0, 3, 6, 9])
 
     def test_qwen3_max_frames_still_spans_full_video(self):
         decoder = _FakeVideoDecoder(total_frames=3000, fps=30.0)
+        video_processor = _FakeVideoProcessor()
         with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
             video, _ = asyncio.run(
                 qwen3_vl.preprocess_video(
                     decoder,
+                    video_processor=video_processor,
                     video_config={"fps": 2, "max_frames": 10},
                 )
             )
 
-        self.assertEqual(video.shape, (10, 3, 5, 7))
-        self.assertEqual(decoder.requested_indices[0], 0)
-        self.assertEqual(decoder.requested_indices[-1], 2999)
-        self.assertTrue(np.all(np.diff(np.asarray(decoder.requested_indices)) > 0))
+        requested_indices = [
+            index for chunk in decoder.requested_chunks for index in chunk
+        ]
+        self.assertEqual(video.shape, (10, 3, 64, 64))
+        self.assertEqual(requested_indices[0], 0)
+        self.assertEqual(requested_indices[-1], 2999)
+        self.assertTrue(np.all(np.diff(np.asarray(requested_indices)) > 0))
+
+    def test_qwen3_uses_loaded_processor_sampling_defaults(self):
+        decoder = _FakeVideoDecoder(total_frames=3000, fps=30.0)
+        video_processor = _FakeVideoProcessor()
+        video_processor.fps = 1.0
+        video_processor.max_frames = 13
+        video_processor.temporal_patch_size = 4
+        with patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder):
+            video, _ = asyncio.run(
+                qwen3_vl.preprocess_video(
+                    decoder,
+                    video_processor=video_processor,
+                )
+            )
+
+        requested_indices = [
+            index for chunk in decoder.requested_chunks for index in chunk
+        ]
+        self.assertEqual(video.shape[0], 12)
+        self.assertEqual(requested_indices[0], 0)
+        self.assertEqual(requested_indices[-1], 2999)
+
+    def test_qwen3_rejects_a_source_frame_larger_than_the_chunk_limit(self):
+        decoder = _FakeVideoDecoder(total_frames=10, fps=2.0)
+        video_processor = _FakeVideoProcessor()
+        frame_bytes = decoder.height * decoder.width * 3
+        with (
+            patch.object(qwen3_vl, "VideoDecoderWrapper", _FakeVideoDecoder),
+            self.assertRaisesRegex(ValueError, "single decoded video frame"),
+        ):
+            asyncio.run(
+                qwen3_vl.preprocess_video(
+                    decoder,
+                    video_processor=video_processor,
+                    video_config={"nframes": 4},
+                    max_decode_chunk_bytes=frame_bytes - 1,
+                )
+            )
+
+        self.assertEqual(decoder.requested_chunks, [])
+
+    def test_chunked_resize_matches_the_hf_processor(self):
+        frames = torch.arange(4 * 64 * 96 * 3, dtype=torch.int64)
+        frames = frames.remainder(256).to(torch.uint8).reshape(4, 64, 96, 3)
+        decoder = _TensorVideoDecoder(frames, fps=2.0)
+        native_size = {
+            "shortest_edge": 4 * 32 * 32,
+            "longest_edge": 8 * 32 * 32,
+        }
+        video_processor = Qwen3VLVideoProcessor(
+            patch_size=16,
+            merge_size=2,
+            temporal_patch_size=2,
+            do_sample_frames=False,
+        )
+        source_video = frames.permute(0, 3, 1, 2)
+        expected = video_processor(
+            videos=[source_video],
+            size=native_size,
+            do_sample_frames=False,
+            return_tensors="pt",
+        )
+        frame_bytes = decoder.frame_shape[0] * decoder.frame_shape[1] * 3
+
+        with patch.object(qwen3_vl, "VideoDecoderWrapper", _TensorVideoDecoder):
+            resized_video, _ = asyncio.run(
+                qwen3_vl.preprocess_video(
+                    decoder,
+                    video_processor=video_processor,
+                    video_config={"nframes": 4, "size": native_size},
+                    max_decode_chunk_bytes=2 * frame_bytes,
+                )
+            )
+
+        actual = video_processor(
+            videos=[resized_video],
+            do_sample_frames=False,
+            do_resize=False,
+            return_tensors="pt",
+        )
+        torch.testing.assert_close(
+            actual["pixel_values_videos"],
+            expected["pixel_values_videos"],
+            rtol=0,
+            atol=0,
+        )
+        torch.testing.assert_close(actual["video_grid_thw"], expected["video_grid_thw"])
+
+    def test_qwen3_disables_the_downstream_video_resize(self):
+        processor = qwen3_vl.Qwen3VLImageProcessor.__new__(
+            qwen3_vl.Qwen3VLImageProcessor
+        )
+        processor.video_config = {
+            "do_normalize": False,
+            "resample": 3,
+            "size": {"shortest_edge": 4096, "longest_edge": 8192},
+        }
+
+        self.assertEqual(
+            processor._processor_video_config([{"fps": 30.0}]),
+            {"do_normalize": False, "do_resize": False},
+        )
 
     def test_qwen2_keeps_legacy_factor_28_resize(self):
         decoder = _FakeVideoDecoder(total_frames=10, fps=2.0, height=56, width=84)


### PR DESCRIPTION
## Motivation

SGLang currently pre-resizes Qwen2/2.5 and Qwen3 video frames through the same factor-28 path. The processor stacks differ: Hugging Face's [Qwen2 video processor](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen2_vl/video_processing_qwen2_vl.py) uses 14-pixel patches, while Qwen3 has a dedicated [Qwen3VLVideoProcessor](https://github.com/huggingface/transformers/blob/main/src/transformers/models/qwen3_vl/video_processing_qwen3_vl.py) with 16-pixel patches and a temporal-spatial resize budget. Consequently, Qwen3 frames are resized using the legacy geometry before being resized again by their model-native processor. See also the [Qwen3-VL technical report](https://arxiv.org/abs/2511.21631).

## Modifications

- Split Qwen3-VL/Qwen3.5 registration into `qwen3_vl.py`.
- Preserve SGLang's existing equally-spaced frame selection and `max_frames` behavior.
- Pass decoded Qwen3 frames at source geometry so the model processor owns spatial resizing.
- Add CPU regression coverage for Qwen2 and Qwen3 behavior.
- Memory: frames are now pinned at source resolution. Worst case at the 768-frame cap with 1080p is ~4.8 GB pinned uint8 vs ~0.6 GB pre-resized before.
 
## Accuracy Tests

On an 18-example temporal-localization evaluation with eight samples per example, macro F1@1s/3s/5s changed from `0.4298/0.6851/0.7458` to `0.4628/0.6970/0.7655`.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33363366562](https://github.com/sgl-project/sglang/actions/runs/33363366562)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33363366357](https://github.com/sgl-project/sglang/actions/runs/33363366357)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33363366546](https://github.com/sgl-project/sglang/actions/runs/33363366546)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->