### PR TITLE
[sglang-miles] Add SGLANG_DISABLE_MULTIMEM_AG to force the NCCL all-gather path

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
+++ b/python/sglang/srt/distributed/device_communicators/triton_symm_mem_ag.py
@@ -16,6 +16,8 @@ import torch.distributed._symmetric_memory as symm_mem
 import triton
 import triton.language as tl
 
+from sglang.srt.environ import envs
+
 logger = logging.getLogger(__name__)
 
 # Each thread moves _NUMEL_PER_THREAD bf16 via one 128-bit multimem op; the
@@ -460,6 +462,8 @@ class MultimemAllGatherer:
     ):
         self._max_tokens = int(max_tokens)
         self._skip_entry_sync = skip_entry_sync
+        if envs.SGLANG_DISABLE_MULTIMEM_AG.get():
+            enabled = False
         # None => always NCCL; _UNINIT => build on first eager call.
         self._state = self._UNINIT if enabled else None
         if self._state is self._UNINIT:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1107,6 +1107,7 @@ class Envs:
     # Symmetric Memory
     SGLANG_SYMM_MEM_PREALLOC_GB_SIZE = EnvInt(-1)
     SGLANG_DEBUG_SYMM_MEM = EnvBool(False)
+    SGLANG_DISABLE_MULTIMEM_AG = EnvBool(False)
 
     # Aiter
     SGLANG_USE_AITER_FP8_PER_TOKEN = EnvBool(False)


### PR DESCRIPTION
## Motivation

On GB300 NVL72 running 8 colocated tp8 engines (miles RL, DeepSeek-V4-Flash-0731), the multimem all-gather's symmetric-memory rendezvous is unreliable when many engines initialize concurrently: some ranks time out after 600s ("multimem all-gather disabled (wait timeout ...)") and others deadlock inside the rendezvous right after "Registering N cuda graph addresses", which blocks engine init forever (the ray init handle never resolves and the whole colocate bring-up hangs).

## Modifications

Add an `SGLANG_DISABLE_MULTIMEM_AG` env (default off, no behavior change) that forces `MultimemAllGatherer` to the NCCL fallback path, skipping the symm-mem rendezvous entirely. Correctness is unaffected — the NCCL path is the existing fallback the gatherer already uses whenever multimem is unavailable.

Validated on the 8-node GB300 bringup: with the gate set, all 8 engines initialize reliably and training runs (6+ consecutive rollout/train cycles).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32698829006](https://github.com/sgl-project/sglang/actions/runs/32698829006)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32698828336](https://github.com/sgl-project/sglang/actions/runs/32698828336)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->