### PR TITLE
feat(native-mtp): prototype Qwen3-Next native MTP path

### DIFF
--- a/python/sglang/srt/models/qwen3_next.py
+++ b/python/sglang/srt/models/qwen3_next.py
@@ -1,5 +1,7 @@
+import copy
 import enum
 import logging
+from contextlib import ExitStack
 from typing import Any, Iterable, Optional, Set, Tuple
 
 import torch
@@ -13,6 +15,7 @@ from sglang.kernels.ops.attention.triton_gdn_fused_proj import (
 )
 from sglang.srt.configs.qwen3_next import Qwen3NextConfig
 from sglang.srt.distributed import get_pp_group
+from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.attention.mamba.mamba import mamba_v2_sharded_weight_loader
@@ -49,7 +52,13 @@ from sglang.srt.model_loader.weight_utils import (
     sharded_weight_loader,
 )
 from sglang.srt.models.qwen2_moe import Qwen2MoeMLP, Qwen2MoeSparseMoeBlock
-from sglang.srt.runtime_context import get_forward, get_parallel, get_stream
+from sglang.srt.runtime_context import (
+    get_forward,
+    get_model,
+    get_parallel,
+    get_spec,
+    get_stream,
+)
 from sglang.srt.utils import (
     LazyValue,
     add_prefix,
@@ -987,6 +996,95 @@ class HybridLayerType(enum.Enum):
     mamba2 = "mamba"
 
 
+class Qwen3NextMTPBlock(nn.Module):
+    def __init__(
+        self,
+        config: Qwen3NextConfig,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        super().__init__()
+        config = copy.deepcopy(config)
+        self.config = config
+        if _is_npu and get_spec().speculative_draft_model_quantization is None:
+            quant_config = None
+        self.quant_config = quant_config
+
+        self.fc = nn.Linear(2 * config.hidden_size, config.hidden_size, bias=False)
+        self.pre_fc_norm_embedding = GemmaRMSNorm(
+            config.hidden_size, config.rms_norm_eps
+        )
+        self.pre_fc_norm_hidden = GemmaRMSNorm(config.hidden_size, config.rms_norm_eps)
+
+        mtp_config = copy.deepcopy(config)
+        mtp_config.num_hidden_layers = 1
+        mtp_config.full_attention_interval = 1
+        self.model = Qwen3NextModel(
+            mtp_config,
+            quant_config,
+            prefix=add_prefix("model", prefix),
+            is_nextn=True,
+        )
+        self.lm_head = ParallelLMHead(
+            config.vocab_size,
+            config.hidden_size,
+            quant_config=quant_config,
+            prefix=add_prefix("model.shared_head.head", prefix),
+            use_attn_tp_group=get_parallel().enable_dp_lm_head,
+        )
+        self.logits_processor = LogitsProcessor(config)
+
+    @torch.no_grad()
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        forward_batch: ForwardBatch,
+        input_embeds: Optional[torch.Tensor] = None,
+        **kwargs,
+    ):
+        exit_stack = ExitStack()
+        if (
+            _is_npu
+            and self.quant_config is None
+            and get_model().quantization is not None
+        ):
+            exit_stack.enter_context(envs.SGLANG_DEEPEP_BF16_DISPATCH.override(True))
+            exit_stack.enter_context(
+                envs.DEEP_NORMAL_MODE_USE_INT8_QUANT.override(False)
+            )
+
+        try:
+            if input_embeds is None:
+                input_embeds = self.model.embed_tokens(input_ids)
+
+            hidden_states = forward_batch.spec_info.hidden_states
+            if not forward_batch.forward_mode.is_idle():
+                input_embeds = self.pre_fc_norm_embedding(input_embeds)
+                hidden_states = self.pre_fc_norm_hidden(hidden_states)
+            hidden_states = self.fc(torch.cat((input_embeds, hidden_states), dim=-1))
+
+            with get_global_expert_distribution_recorder().disable_this_region():
+                hidden_states = self.model(
+                    input_ids,
+                    positions,
+                    forward_batch,
+                    hidden_states,
+                )
+        finally:
+            exit_stack.close()
+
+        return self.logits_processor(
+            input_ids, hidden_states, self.lm_head, forward_batch
+        )
+
+    def set_embed_and_head(self, embed, head):
+        del self.model.embed_tokens.weight
+        del self.lm_head.weight
+        self.model.embed_tokens.weight = embed
+        self.lm_head.weight = head
+
+
 class Qwen3NextForCausalLM(nn.Module):
     fall_back_to_pt_during_load = False
 
@@ -1029,6 +1127,7 @@ class Qwen3NextForCausalLM(nn.Module):
             prefix=add_prefix("lm_head", prefix),
             use_attn_tp_group=get_parallel().enable_dp_lm_head,
         )
+        self.maybe_enable_native_mtp(config, quant_config, prefix)
         self.logits_processor = LogitsProcessor(config)
         # For EAGLE3 support
         self.capture_aux_hidden_states = False
@@ -1053,6 +1152,44 @@ class Qwen3NextForCausalLM(nn.Module):
     @property
     def routed_experts_weights_of_layer(self):
         return self._routed_experts_weights_of_layer.value
+
+    def maybe_enable_native_mtp(
+        self,
+        config: Qwen3NextConfig,
+        quant_config: Optional[QuantizationConfig],
+        prefix: str,
+    ) -> None:
+        self.mtp = None
+        if not getattr(config, "enable_native_mtp", False):
+            return
+
+        self.mtp = Qwen3NextMTPBlock(
+            config,
+            quant_config,
+            prefix=add_prefix("mtp", prefix),
+        )
+        self.mtp.set_embed_and_head(self.model.embed_tokens.weight, self.lm_head.weight)
+
+    def _remap_native_mtp_weight_name(self, name: str) -> Optional[str]:
+        if self.mtp is None:
+            return None
+
+        if name.startswith(("mtp.embed_tokens.", "mtp.model.embed_tokens.")):
+            return None
+        if name.startswith(
+            (
+                "mtp.lm_head.",
+                "mtp.shared_head.head.",
+                "mtp.model.shared_head.head.",
+            )
+        ):
+            return None
+
+        if name.startswith("mtp.layers."):
+            return name.replace("mtp.layers.", "mtp.model.layers.", 1)
+        if name.startswith("mtp.norm."):
+            return name.replace("mtp.norm.", "mtp.model.norm.", 1)
+        return name
 
     def _get_num_fused_shared_experts(self) -> int:
         if not hasattr(self.model, "layers"):
@@ -1144,7 +1281,19 @@ class Qwen3NextForCausalLM(nn.Module):
 
         params_dict = dict(self.named_parameters())
         loaded_params: Set[str] = set()
+        expect_native_mtp_weights = not is_mtp and self.mtp is not None
+        found_native_mtp_weight = False
         for name, loaded_weight in weights:
+            if expect_native_mtp_weights and name.startswith(
+                (
+                    "mtp.fc.",
+                    "mtp.pre_fc_norm_embedding.",
+                    "mtp.pre_fc_norm_hidden.",
+                    "mtp.layers.",
+                    "mtp.norm.",
+                )
+            ):
+                found_native_mtp_weight = True
 
             if is_mtp:
 
@@ -1161,7 +1310,9 @@ class Qwen3NextForCausalLM(nn.Module):
                     name = name.replace("mtp", "model")
 
             if not is_mtp and "mtp" in name:
-                continue
+                name = self._remap_native_mtp_weight_name(name)
+                if name is None:
+                    continue
 
             if "rotary_emb.inv_freq" in name:
                 continue
@@ -1250,6 +1401,11 @@ class Qwen3NextForCausalLM(nn.Module):
                     )
                     weight_loader(param, loaded_weight)
             loaded_params.add(name)
+        if expect_native_mtp_weights and not found_native_mtp_weight:
+            raise ValueError(
+                "--enable-native-mtp requires checkpoint weights with the 'mtp.' "
+                "prefix, but none were found."
+            )
         return loaded_params
 
     @classmethod

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2094,6 +2094,17 @@ class ServerArgs:
         "Speculative algorithm. Builtins: EAGLE, EAGLE3, NEXTN, STANDALONE, NGRAM, DFLASH, DSPARK. Or any name registered via `SpeculativeAlgorithm.register`.",
         NS("spec"),
     ] = None
+    enable_native_mtp: A[
+        bool,
+        Arg(
+            help=(
+                "Enable native MTP inside the target model instead of loading "
+                "the MTP block as a separate draft model."
+            ),
+            aliases=["--enable_native_mtp"],
+        ),
+        NS("spec"),
+    ] = False
     speculative_draft_model_path: A[
         Optional[str],
         Arg(
@@ -3863,6 +3874,7 @@ class ServerArgs:
 
         # Set missing default values.
         self._handle_missing_default_values()
+        self._handle_native_mtp()
 
         # expert_pack may replace a raw GGUF input with its generated local
         # model metadata before any model-specific handler calls get_model_config.
@@ -4648,6 +4660,37 @@ class ServerArgs:
                 "_handle_missing_default_values",
                 speculative_draft_model_quantization=None,
             )
+
+    def _handle_native_mtp(self):
+        if not self.enable_native_mtp:
+            return
+
+        logger.warning(
+            "--enable-native-mtp is experimental. Native MTP draft CUDA graph "
+            "capture for decode/extend is temporarily disabled and may affect "
+            "decode performance."
+        )
+
+        if self.speculative_draft_model_path is not None:
+            raise ValueError(
+                "--enable-native-mtp loads the MTP block from the target model; "
+                "do not set --speculative-draft-model-path."
+            )
+
+        try:
+            model_override_args = json.loads(self.json_model_override_args)
+        except json.JSONDecodeError as e:
+            raise ValueError(
+                "--json-model-override-args must be valid JSON when "
+                "--enable-native-mtp is set."
+            ) from e
+        if not isinstance(model_override_args, dict):
+            raise ValueError("--json-model-override-args must decode to a JSON object.")
+
+        model_override_args["enable_native_mtp"] = True
+        self.json_model_override_args = json.dumps(
+            model_override_args, separators=(",", ":")
+        )
 
     def _handle_modelscope_paths(self):
         """Resolve model / tokenizer / speculative-draft paths from the local

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -158,6 +158,32 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         self._rebuild_topk1_chain_buffers()
 
+        self.draft_worker = self._build_draft_worker(
+            server_args=server_args,
+            gpu_id=gpu_id,
+            ps=ps,
+            nccl_port=nccl_port,
+            target_worker=target_worker,
+        )
+
+        # Alias for better readability
+        self.draft_runner = self._build_draft_runner()
+        self._init_dsa_index_share_state()
+        # Eager draft-extend seed buffer (graph paths use their own static ones).
+        self.dsa_extend_topk_buf: Optional[torch.Tensor] = None
+        self.draft_tp_context = self._build_draft_tp_context()
+        self.tree_mask_mode = default_tree_mask_mode()
+
+        self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
+
+    def _build_draft_worker(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        ps: ParallelState,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
         # Load draft model weights only.
         if (
             get_parallel().enable_dp_attention
@@ -169,7 +195,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         with (
             ctx
         ), speculative_moe_backend_context(), speculative_moe_a2a_backend_context(), draft_model_build_scope():
-            self.draft_worker = TpModelWorker(
+            return TpModelWorker(
                 server_args=server_args,
                 gpu_id=gpu_id,
                 # spec workers don't support pipeline parallelism
@@ -180,17 +206,11 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 context_length=target_worker.model_runner.model_config.context_len,
             )
 
-        # Alias for better readability
-        self.draft_runner = self.draft_worker.model_runner
-        self._init_dsa_index_share_state()
-        # Eager draft-extend seed buffer (graph paths use their own static ones).
-        self.dsa_extend_topk_buf: Optional[torch.Tensor] = None
-        self.draft_tp_context = (
-            draft_tp_context if get_parallel().enable_dp_attention else empty_context
-        )
-        self.tree_mask_mode = default_tree_mask_mode()
+    def _build_draft_runner(self):
+        return self.draft_worker.model_runner
 
-        self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
+    def _build_draft_tp_context(self):
+        return draft_tp_context if get_parallel().enable_dp_attention else empty_context
 
     def alloc_memory_pool(
         self,
@@ -1078,12 +1098,12 @@ class EAGLEWorkerV2(BaseSpecWorker):
             get_spec().speculative_algorithm
         )
 
-        self._draft_worker = EagleDraftWorker(
-            server_args,
-            gpu_id,
-            ps,
-            nccl_port,
-            target_worker,
+        self._draft_worker = self._build_draft_worker(
+            server_args=server_args,
+            gpu_id=gpu_id,
+            ps=ps,
+            nccl_port=nccl_port,
+            target_worker=target_worker,
         )
 
         # Adaptive speculative
@@ -1101,6 +1121,22 @@ class EAGLEWorkerV2(BaseSpecWorker):
         self.extend_lens = torch.empty((), dtype=torch.int64, device=self.device)
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
+
+    def _build_draft_worker(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        ps: ParallelState,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        return EagleDraftWorker(
+            server_args,
+            gpu_id,
+            ps,
+            nccl_port,
+            target_worker,
+        )
 
     @property
     def last_shared_read_runner(self):

--- a/python/sglang/srt/speculative/native_mtp_worker.py
+++ b/python/sglang/srt/speculative/native_mtp_worker.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import replace
+
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.layers.moe.utils import (
+    speculative_moe_a2a_backend_context,
+    speculative_moe_backend_context,
+)
+from sglang.srt.managers.tp_worker import TpModelWorker
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+from sglang.srt.model_executor.forward_context import (
+    ForwardContext,
+    forward_context,
+)
+from sglang.srt.model_executor.model_runner import ModelRunner, ModelRunnerOutput
+from sglang.srt.model_executor.model_runner_components.attention_backend_setup import (
+    resolve_attention_backend_strs,
+)
+from sglang.srt.model_executor.model_runner_components.layer_setup import (
+    resolve_layer_indices,
+)
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker, EAGLEWorkerV2
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.utils.common import empty_context
+
+
+class NativeMTPModelRunner(ModelRunner):
+    """Small ModelRunner-compatible facade over target_model.mtp."""
+
+    def __init__(self, target_runner: ModelRunner, server_args: ServerArgs) -> None:
+        self._target_runner = target_runner
+        self.server_args = server_args
+        self.model = target_runner.model.mtp
+        self.model_config = copy.copy(target_runner.model_config)
+        mtp_hf_config = copy.deepcopy(self.model.model.config)
+        mtp_hf_config.architectures = ["Qwen3NextForCausalLMMTP"]
+        mtp_hf_config.num_nextn_predict_layers = 1
+        self.model_config.hf_config = mtp_hf_config
+        self.model_config.hf_text_config = mtp_hf_config.get_text_config()
+        self.model_config.num_hidden_layers = 1
+        self.model_config.num_attention_layers = 1
+        self.model_config.num_nextn_predict_layers = 1
+        setattr(self.model, "num_stages", 1)
+        self.device = target_runner.device
+        self.gpu_id = target_runner.gpu_id
+        self.ps = replace(target_runner.ps, pp_rank=0)
+        self.pp_group = target_runner.pp_group
+        self.tp_group = target_runner.tp_group
+        self.dtype = target_runner.dtype
+        self.is_draft_worker = True
+        self.draft_attention_backend = server_args.speculative_draft_attention_backend
+        resolved_backend_strs = resolve_attention_backend_strs(model_runner=self)
+        self.prefill_attention_backend_str = resolved_backend_strs.prefill
+        self.decode_attention_backend_str = resolved_backend_strs.decode
+        self.attn_backend = None
+        self.decode_attn_backend = None
+        self.decode_attn_backend_group = []
+        self.draft_attn_backend = None
+        self.use_mla_backend = target_runner.use_mla_backend
+        self.attention_chunk_size = target_runner.attention_chunk_size
+        self.page_size = target_runner.page_size
+        self.sliding_window_size = target_runner.sliding_window_size
+        self.is_hybrid_swa = target_runner.is_hybrid_swa
+        self.is_hybrid_swa_compress = target_runner.is_hybrid_swa_compress
+        self.kv_cache_dtype = target_runner.kv_cache_dtype
+        self.kv_cache_dtype_str = target_runner.kv_cache_dtype_str
+        self.pre_model_load_memory = target_runner.pre_model_load_memory
+        self.spec_aux_config = target_runner.spec_aux_config
+        self.forward_stream = target_runner.forward_stream
+        self.draft_model_idx = 0
+        self.enable_hisparse = target_runner.enable_hisparse
+        self._token_oracle_manager = None
+        self.spec_algorithm = SpeculativeAlgorithm.from_string(
+            server_args.speculative_algorithm
+        )
+        self.layer_info = resolve_layer_indices(
+            model=self.model,
+            model_config=self.model_config,
+            is_draft_worker=True,
+            spec_algorithm=self.spec_algorithm,
+        )
+        self.ngram_embedding_manager = None
+        self.lora_manager = None
+        self.canary_manager = None
+        self.hisparse_coordinator = None
+        self.decode_cuda_graph_runner = None
+        self.prefill_cuda_graph_runner = None
+        self.graph_memory_usage: dict[str, float] = {}
+        self.graph_time_usage: dict[str, float] = {}
+        self.weight_load_time = 0.0
+        self.forward_pass_id = 0
+        self.max_running_requests = server_args.max_running_requests
+        self.mtp_draft_device_pools = ()
+        self.init_new_workspace = False
+        self.enable_elastic_ep = False
+        self.eplb_manager = None
+
+        self.memory_pool_config = target_runner.memory_pool_config
+        self.req_to_token_pool = target_runner.req_to_token_pool
+        self.token_to_kv_pool_allocator = target_runner.token_to_kv_pool_allocator
+        self.token_to_kv_pool = None
+
+    def __getattr__(self, name: str):
+        return getattr(self._target_runner, name)
+
+    def alloc_memory_pool(
+        self,
+        memory_pool_config=None,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+    ) -> None:
+        self.memory_pool_config = memory_pool_config
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        ModelRunner.alloc_memory_pool(self, memory_pool_config)
+
+    def forward(self, forward_batch: ForwardBatch) -> ModelRunnerOutput:
+        self.forward_pass_id += 1
+        attn_backend = self.attn_backend or self.draft_attn_backend
+        if attn_backend is None:
+            raise RuntimeError("Native MTP attention backend is not initialized.")
+        with forward_context(ForwardContext(attn_backend=attn_backend)):
+            ModelRunner._prepare_eager_forward_batch(self, forward_batch)
+            if forward_batch.needs_forward_metadata_init():
+                if hasattr(self.model, "prepare_forward_batch"):
+                    self.model.prepare_forward_batch(forward_batch)
+                attn_backend.init_forward_metadata(forward_batch)
+            ret = self.model(
+                forward_batch.input_ids,
+                forward_batch.positions,
+                forward_batch,
+                input_embeds=forward_batch.input_embeds,
+            )
+            if (
+                forward_batch.global_num_tokens_cpu is not None
+                and self.pp_group.is_last_rank
+            ):
+                forward_batch.post_forward_mlp_sync_batch(ret)
+
+        return ModelRunnerOutput(logits_output=ret, can_run_graph=False)
+
+
+class NativeMTPDraftWorker(EagleDraftWorker):
+    """EAGLE draft worker that runs an embedded target-model MTP block."""
+
+    def _build_draft_worker(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        ps: ParallelState,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        del server_args, gpu_id, ps, nccl_port, target_worker
+        return None
+
+    def _build_draft_runner(self):
+        target_runner = self.target_worker.model_runner
+        if getattr(target_runner.model, "mtp", None) is None:
+            raise ValueError(
+                "--enable-native-mtp requires the target model to initialize "
+                "an embedded mtp block."
+            )
+
+        return NativeMTPModelRunner(target_runner, self.server_args)
+
+    def _build_draft_tp_context(self):
+        return empty_context
+
+    def alloc_memory_pool(
+        self,
+        memory_pool_config=None,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+    ):
+        self.req_to_token_pool = req_to_token_pool
+        self.token_to_kv_pool_allocator = token_to_kv_pool_allocator
+        self.draft_runner.alloc_memory_pool(
+            memory_pool_config=memory_pool_config,
+            req_to_token_pool=req_to_token_pool,
+            token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        )
+        self.init_token_map()
+        self.init_lm_head()
+
+    def init_attention_backends(self):
+        with speculative_moe_backend_context(), speculative_moe_a2a_backend_context():
+            self.init_attention_backend()
+
+    def init_attention_backend(self):
+        super().init_attention_backend()
+        if self.draft_runner.attn_backend is None:
+            self.draft_runner.attn_backend = self.draft_attn_backend
+
+    def init_cuda_graphs(self):
+        self.cuda_graph_runner = None
+        self.cuda_graph_runner_for_draft_extend = None
+        if (c := self.draft_runner.canary_manager) is not None:
+            c.mark_init_finished()
+
+
+class NativeMTPWorkerV2(EAGLEWorkerV2):
+    """EAGLE v2 orchestration with native embedded MTP as the draft side."""
+
+    def _build_draft_worker(
+        self,
+        server_args: ServerArgs,
+        gpu_id: int,
+        ps: ParallelState,
+        nccl_port: int,
+        target_worker: TpModelWorker,
+    ):
+        return NativeMTPDraftWorker(
+            server_args,
+            gpu_id,
+            ps,
+            nccl_port,
+            target_worker,
+        )

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -286,6 +286,11 @@ class SpeculativeAlgorithm(Enum):
 
         # EAGLE / EAGLE3 / STANDALONE / MULTI_LAYER always use the V2 worker,
         # even with overlap disabled (scheduler drives it synchronously).
+        if self.is_eagle() and cfg.enable_native_mtp:
+            from sglang.srt.speculative.native_mtp_worker import NativeMTPWorkerV2
+
+            return NativeMTPWorkerV2
+
         if self.is_eagle() and cfg.enable_multi_layer_eagle:
             from sglang.srt.speculative.multi_layer_eagle_worker_v2 import (
                 MultiLayerEagleWorkerV2,


### PR DESCRIPTION
This is an early prototype to discuss the native Qwen3-Next MTP direction with the community.

The goal is to keep the MTP block inside the target model, load its weights with the target checkpoint, and reuse the existing EAGLE v2 orchestration with minimal changes.

## Motivation

Prototype native Qwen3-Next MTP: keep the MTP block inside the target model and load its weights with the target checkpoint.

This avoids a separate draft model loading path and makes MTP initialization/debugging simpler. Draft KV stays separate to avoid corrupting target KV.

## Modifications

  - Added `--enable-native-mtp`.
  - Qwen3-Next initializes an embedded MTP block inside the target model when the flag is enabled.
  - MTP checkpoint weights are loaded through the target model weight-loading path.
  - Added a native MTP speculative path that reuses EAGLE v2 orchestration and overrides only draft runner construction.
  - Draft execution calls the embedded target-model MTP block.
  - Draft KV remains separate from target KV.

## Prototype Limitation

Draft CUDA graph capture is intentionally disabled at this prototype stage. Native MTP currently runs draft decode/extend through eager execution.

So current performance numbers should not be treated as final.

The main risk with enabling CUDA graph capture is correctness around static graph buffers and KV writes: the existing EAGLE graph path was built around a separate draft runner, while this prototype uses an embedded MTP block exposed through a lightweight runner
facade. Before enabling graphs, we need to verify that draft decode/extend writes only to draft KV and produces logits matching the separate draft model path.

## Startup Check

Both the baseline separate-draft flow and the native MTP prototype start successfully and handle a `/generate` request.

From the startup logs:

  - Baseline loads the target model first:
    - `Qwen3NextForCausalLM`
    - memory usage: `74.31 GB`
  - Baseline then loads a separate draft model:
    - `Qwen3NextForCausalLMMTP`
    - additional memory usage: `2.12 GB`
  - Native MTP loads only the target model:
    - `Qwen3NextForCausalLM`
    - memory usage: `75.84 GB`

So on `tp=2`, native MTP avoids the second draft model load and saves about: `74.31 GB + 2.12 GB - 75.84 GB = 0.59 GB`

This is expected because native MTP shares target `embed_tokens` and `lm_head` instead of keeping separate draft copies.



## Accuracy Tests

In progress. This is currently a prototype for validating the native MTP direction.

## Speed Tests and Profiling

In progress. Performance numbers will be collected after the prototype path is validated.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33168198039](https://github.com/sgl-project/sglang/actions/runs/33168198039)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33168197972](https://github.com/sgl-project/sglang/actions/runs/33168197972)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33168198049](https://github.com/sgl-project/sglang/actions/runs/33168198049)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->