### PR TITLE
[AMD][CI] Add a model cache audit that counts per-commit workflows

### DIFF
--- a/.github/workflows/ci-model-inventory.yml
+++ b/.github/workflows/ci-model-inventory.yml
@@ -29,6 +29,8 @@ on:
       - "scripts/ci/list_stage_models.py"
       - "scripts/ci/test_list_stage_models.py"
       - "scripts/ci/stage_models_overrides.json"
+      - "scripts/ci/utils/amd_cache_audit.py"
+      - "scripts/ci/test_amd_cache_audit.py"
       - ".github/workflows/ci-model-inventory.yml"
   schedule:
     # Nightly safety net (09:00 UTC) so the artifact never goes stale even if a
@@ -48,6 +50,11 @@ jobs:
 
       - name: Run extractor unit tests
         run: python3 -m unittest discover -s scripts/ci -p 'test_list_stage_models.py'
+
+      # The AMD cache audit reuses this extractor and is run by no workflow of
+      # its own, so a refactor above would otherwise break it unnoticed.
+      - name: Run AMD cache audit unit tests
+        run: python3 -m unittest discover -s scripts/ci -p 'test_amd_cache_audit.py'
 
       - name: Generate model inventory
         run: |

--- a/scripts/ci/test_amd_cache_audit.py
+++ b/scripts/ci/test_amd_cache_audit.py
@@ -1,0 +1,173 @@
+"""Unit tests for amd_cache_audit extraction and join logic.
+
+Pure-logic plus one end-to-end smoke test (stdlib only, no GPU, no sglang
+import), mirroring test_list_stage_models.py so both run in the
+ci-model-inventory workflow without installing dependencies:
+
+    python -m unittest discover -s scripts/ci -p 'test_amd_cache_audit.py'
+
+The end-to-end case is the point of this file. amd_cache_audit.py is a CLI
+tool that no workflow executes, and it reuses list_stage_models.py for the
+suite -> models half; without a test, a refactor there would break the audit
+silently and nobody would notice until someone deleted the wrong checkpoints.
+So `test_compute_smoke` runs the real join against the real repo and asserts
+the contract -- not exact counts, which move every time a test is added.
+"""
+
+import importlib.util
+import os
+import tempfile
+import unittest
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+MODULE_PATH = os.path.join(REPO_ROOT, "scripts", "ci", "utils", "amd_cache_audit.py")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("amd_cache_audit", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+audit = _load_module()
+
+
+class TestJobRunnerLabels(unittest.TestCase):
+    """`--runner` scoping is only as good as the labels pulled off each job."""
+
+    def test_plain_string(self):
+        self.assertEqual(
+            audit._job_runner_labels({"runs-on": "linux-mi35x-gpu-8"}),
+            ["linux-mi35x-gpu-8"],
+        )
+
+    def test_list_form(self):
+        self.assertEqual(
+            audit._job_runner_labels({"runs-on": ["self-hosted", "linux-mi300"]}),
+            ["self-hosted", "linux-mi300"],
+        )
+
+    def test_matrix_form(self):
+        """AMD jobs commonly say `runs-on: ${{ matrix.runner }}`; the literal
+        labels live in strategy.matrix, and the unexpanded expression itself
+        must not be mistaken for a label."""
+        job = {
+            "runs-on": "${{ matrix.runner }}",
+            "strategy": {"matrix": {"runner": ["linux-mi35x-gpu-1"]}},
+        }
+        self.assertEqual(audit._job_runner_labels(job), ["linux-mi35x-gpu-1"])
+
+    def test_drops_unexpanded_expressions(self):
+        job = {"runs-on": "${{ inputs.runner }}"}
+        self.assertEqual(audit._job_runner_labels(job), [])
+
+    def test_missing_and_malformed_keys(self):
+        self.assertEqual(audit._job_runner_labels({}), [])
+        self.assertEqual(audit._job_runner_labels({"strategy": "not-a-dict"}), [])
+
+
+class TestJobText(unittest.TestCase):
+    def test_concatenates_run_blocks_only(self):
+        job = {
+            "steps": [
+                {"uses": "actions/checkout@v4"},
+                {"run": "echo one"},
+                {"name": "no run key"},
+                {"run": "echo two"},
+            ]
+        }
+        self.assertEqual(audit._job_text(job), "echo one\necho two")
+
+    def test_no_steps(self):
+        self.assertEqual(audit._job_text({}), "")
+
+
+class TestReadCache(unittest.TestCase):
+    """`models--org--name` is HuggingFace's on-disk spelling of `org/name`."""
+
+    def test_listing_round_trip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "hub.txt")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write(
+                    "models--amd--Qwen3.8-2.4T-A95B-Quark-MXFP4\n"
+                    "models--moonshotai--Kimi-K3\n"
+                    "datasets--foo--bar\n"  # not a model dir
+                    "\n"
+                )
+            self.assertEqual(
+                audit._read_cache(None, path),
+                {"amd/Qwen3.8-2.4T-A95B-Quark-MXFP4", "moonshotai/Kimi-K3"},
+            )
+
+    def test_only_first_separator_splits_org(self):
+        """Repo names may themselves contain `--`; only the org boundary counts."""
+        with tempfile.TemporaryDirectory() as tmp:
+            path = os.path.join(tmp, "hub.txt")
+            with open(path, "w", encoding="utf-8") as fh:
+                fh.write("models--org--name--with--dashes\n")
+            self.assertEqual(audit._read_cache(None, path), {"org/name--with--dashes"})
+
+    def test_directory_form(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            os.mkdir(os.path.join(tmp, "models--meta-llama--Llama-3.2-1B-Instruct"))
+            os.mkdir(os.path.join(tmp, "tmp-not-a-model"))
+            self.assertEqual(
+                audit._read_cache(tmp, None), {"meta-llama/Llama-3.2-1B-Instruct"}
+            )
+
+    def test_missing_directory_is_not_fatal(self):
+        self.assertEqual(audit._read_cache("/nonexistent/path", None), set())
+
+
+class TestComputeSmoke(unittest.TestCase):
+    """End-to-end against the real repo: the guard against silent rot."""
+
+    @classmethod
+    def setUpClass(cls):
+        cls.result = audit.compute()
+
+    def test_shape(self):
+        for key in ("suite_count", "suite_reachability", "models", "suite_jobs"):
+            self.assertIn(key, self.result)
+        self.assertGreater(self.result["suite_count"], 0, "no AMD suites resolved")
+        self.assertGreater(len(self.result["models"]), 0, "no checkpoints resolved")
+
+    def test_per_commit_dispatch_is_counted(self):
+        """The bug this tool exists to prevent: joining nightly only. If the
+        per-commit bucket is ever empty, the reachability join has regressed
+        and every per-commit-only checkpoint would read as reclaimable."""
+        reach = self.result["suite_reachability"]
+        self.assertGreater(
+            len(reach["per_commit_only"]) + len(reach["both"]),
+            0,
+            "no AMD suite resolved to a per-commit workflow",
+        )
+
+    def test_constant_resolution_survives(self):
+        """Models reached only through a shared constant must resolve. This one
+        is named nowhere as a literal in an AMD test -- it arrives via
+        DEFAULT_SMALL_MODEL_NAME_FOR_TEST -- so it catches the case where the
+        extractor degrades to plain string matching."""
+        self.assertIn("meta-llama/Llama-3.2-1B-Instruct", self.result["models"])
+
+    def test_runner_scoping_narrows(self):
+        """--runner must actually filter; without it a cluster gets compared
+        against every AMD suite and the other cluster's models read as missing."""
+        scoped = audit.compute(runner="mi35x")
+        needed_all = {
+            m
+            for m, i in self.result["models"].items()
+            if i["verdict"] != "undispatched"
+        }
+        needed_mi35x = {
+            m for m, i in scoped["models"].items() if i["verdict"] != "undispatched"
+        }
+        self.assertTrue(needed_mi35x, "mi35x scoping resolved nothing")
+        self.assertLess(len(needed_mi35x), len(needed_all))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/scripts/ci/utils/amd_cache_audit.py
+++ b/scripts/ci/utils/amd_cache_audit.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""Audit the AMD CI model cache: which checkpoints are needed, missing, or dead.
+
+The AMD runners share one HuggingFace cache PVC per cluster, nothing evicts
+from it, and it fills up -- a full cache kills a multi-hundred-GB download
+partway through with ENOSPC. Deciding what is safe to drop needs the join this
+script performs: `register_amd_ci` test registrations -> the checkpoints those
+tests name -> whether any AMD workflow actually dispatches them.
+
+Getting that join wrong is expensive in both directions. A 2026-08-20 audit
+joined only the two nightly workflows and concluded 939 GiB was reclaimable;
+937 GiB of it was live, because 289 of 429 AMD registrations are dispatched
+*only* by the per-commit `pr-test-amd*.yml` workflows, which run on
+`linux-mi35x-gpu-1` and share the same PVC as the 8-GPU nightly jobs. Deleting
+by that list would have broken AMD CI on every PR. So `--reachability` counts
+per-commit and nightly separately and never reports one without the other.
+
+The suite -> models half is not reimplemented here: it comes from
+`scripts/ci/list_stage_models.py`, which already does the AST extraction,
+constant resolution and override handling for any backend.
+
+Usage:
+    # What each AMD suite needs, and who dispatches it
+    python3 scripts/ci/utils/amd_cache_audit.py
+
+    # Diff against a live cache (run where /sgl-data is mounted)
+    python3 scripts/ci/utils/amd_cache_audit.py --cache-dir /sgl-data/hf-cache/hub
+
+    # Same, from a listing captured elsewhere (one `models--org--name` per line)
+    ls /sgl-data/hf-cache/hub > hub.txt
+    python3 scripts/ci/utils/amd_cache_audit.py --cache-listing hub.txt --json out.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import json
+import os
+import re
+import sys
+from typing import Dict, List, Optional, Set, Tuple
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+# Workflows that dispatch AMD suites, split by cadence. Both families mount the
+# same per-cluster cache PVC, so both must be consulted before calling a
+# checkpoint unused.
+NIGHTLY_WORKFLOWS = ("nightly-test-amd.yml", "nightly-test-amd-rocm720.yml")
+PER_COMMIT_WORKFLOWS = (
+    "pr-test-amd.yml",
+    "pr-test-amd-rocm720.yml",
+    "pr-test-amd-extra.yml",
+)
+
+# HuggingFace stores `org/name` under `models--org--name`.
+CACHE_DIR_RE = re.compile(r"^models--(?P<slug>.+)$")
+
+
+def _load_inventory(
+    include_disabled: bool,
+) -> Tuple[Dict[str, object], Dict[str, List[str]]]:
+    """Reuse list_stage_models.py rather than duplicating its extraction.
+
+    Returns the inventory (suite -> models) plus the suite -> test files map,
+    which the inventory itself does not expose in full -- it only carries the
+    files whose models could not be resolved.
+    """
+    path = os.path.join(REPO_ROOT, "scripts", "ci", "list_stage_models.py")
+    spec = importlib.util.spec_from_file_location("list_stage_models", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {path}")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+
+    overrides = mod.load_overrides(
+        os.path.join(REPO_ROOT, "scripts", "ci", "stage_models_overrides.json")
+    )
+    inventory = mod.build_inventory(
+        REPO_ROOT, "amd", overrides, commit="", include_disabled=include_disabled
+    )
+    suite_files = mod.collect_suite_files(REPO_ROOT, "amd", include_disabled)[0]
+    return inventory, suite_files
+
+
+def _job_runner_labels(job: dict) -> List[str]:
+    """`runs-on` as a flat label list, covering the matrix form AMD jobs use."""
+    runs_on = job.get("runs-on")
+    labels: List[str] = []
+    if isinstance(runs_on, str):
+        labels.append(runs_on)
+    elif isinstance(runs_on, list):
+        labels.extend(str(x) for x in runs_on)
+    # `runs-on: ${{ matrix.runner }}` with `strategy.matrix.runner: [label, ...]`
+    matrix = (
+        ((job.get("strategy") or {}).get("matrix") or {})
+        if isinstance(job.get("strategy"), dict)
+        else {}
+    )
+    for value in matrix.values():
+        if isinstance(value, list):
+            labels.extend(str(x) for x in value if isinstance(x, (str, int)))
+    return [l for l in labels if "${{" not in l]
+
+
+def _job_text(job: dict) -> str:
+    """Everything a job's steps run, so both dispatch styles are visible."""
+    parts: List[str] = []
+    for step in job.get("steps") or []:
+        if isinstance(step, dict) and isinstance(step.get("run"), str):
+            parts.append(step["run"])
+    return "\n".join(parts)
+
+
+def _scan_workflows() -> Dict[str, List[dict]]:
+    """suite/file token -> [{workflow, job, cadence, labels}] for AMD workflows.
+
+    Indexed by both `--suite <name>` and bare test filename, because the AMD
+    workflows use both: several perf steps call
+    `python3 registered/amd/perf/mi35x/<file>.py` directly with no `--suite`,
+    and matching only `--suite` would report those checkpoints as unused.
+    """
+    import yaml
+
+    index: Dict[str, List[dict]] = {}
+    families = (
+        ("nightly", NIGHTLY_WORKFLOWS),
+        ("per-commit", PER_COMMIT_WORKFLOWS),
+    )
+    for cadence, names in families:
+        for name in names:
+            path = os.path.join(REPO_ROOT, ".github", "workflows", name)
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    doc = yaml.safe_load(fh)
+            except (OSError, yaml.YAMLError):
+                continue
+            for job_name, job in (doc.get("jobs") or {}).items():
+                if not isinstance(job, dict):
+                    continue
+                entry = {
+                    "workflow": name,
+                    "job": job_name,
+                    "cadence": cadence,
+                    "labels": _job_runner_labels(job),
+                }
+                text = _job_text(job)
+                for token in re.findall(r"--suite\s+(\S+)", text):
+                    index.setdefault(token, []).append(entry)
+                for token in re.findall(r"([A-Za-z0-9_.-]+\.py)", text):
+                    index.setdefault(token, []).append(entry)
+    return index
+
+
+def compute(
+    include_disabled: bool = False, runner: Optional[str] = None
+) -> Dict[str, object]:
+    """Join AMD suites to the jobs that dispatch them, optionally per cluster.
+
+    `runner` is a substring matched against the dispatching job's `runs-on`
+    labels (e.g. "mi35x" for the tw cluster, "mi300" for ccs). Scoping matters
+    for a cache diff: tw only ever runs the mi35x jobs, so comparing it against
+    every AMD suite reports the mi300-only checkpoints as missing.
+    """
+    inventory, suite_files_map = _load_inventory(include_disabled)
+    suites: Dict[str, dict] = inventory.get("suites") or {}  # type: ignore[assignment]
+    index = _scan_workflows()
+
+    suite_reach: Dict[str, List[str]] = {}
+    suite_jobs: Dict[str, List[str]] = {}
+    # model -> {"nightly": [suites], "per-commit": [suites], "undispatched": [suites]}
+    model_need: Dict[str, Dict[str, List[str]]] = {}
+
+    for suite, info in suites.items():
+        tokens = [suite] + [
+            os.path.basename(f) for f in suite_files_map.get(suite) or []
+        ]
+        entries = [e for t in tokens for e in index.get(t, [])]
+        if runner:
+            entries = [e for e in entries if any(runner in l for l in e["labels"])]
+
+        where = sorted({e["cadence"] for e in entries})
+        suite_reach[suite] = where
+        suite_jobs[suite] = sorted({e["job"] for e in entries})
+
+        bucket = where or ["undispatched"]
+        for model in info.get("models") or []:
+            entry = model_need.setdefault(
+                model, {"nightly": [], "per-commit": [], "undispatched": []}
+            )
+            for w in bucket:
+                entry[w].append(suite)
+
+    def verdict(entry: Dict[str, List[str]]) -> str:
+        if entry["nightly"]:
+            return "nightly"
+        if entry["per-commit"]:
+            return "per-commit"
+        return "undispatched"
+
+    models = {
+        model: {
+            "verdict": verdict(entry),
+            "nightly_suites": sorted(set(entry["nightly"])),
+            "per_commit_suites": sorted(set(entry["per-commit"])),
+            "undispatched_suites": sorted(set(entry["undispatched"])),
+        }
+        for model, entry in model_need.items()
+    }
+
+    return {
+        "suite_count": len(suites),
+        "runner_filter": runner,
+        "suite_jobs": suite_jobs,
+        "suite_reachability": {
+            "nightly_only": sorted(
+                s for s, w in suite_reach.items() if w == ["nightly"]
+            ),
+            "per_commit_only": sorted(
+                s for s, w in suite_reach.items() if w == ["per-commit"]
+            ),
+            "both": sorted(s for s, w in suite_reach.items() if len(w) == 2),
+            "undispatched": sorted(s for s, w in suite_reach.items() if not w),
+        },
+        "models": models,
+    }
+
+
+def _read_cache(cache_dir: Optional[str], listing: Optional[str]) -> Set[str]:
+    """Cached repo ids, from a live cache dir or a captured `ls` listing."""
+    names: List[str] = []
+    if cache_dir:
+        try:
+            names = os.listdir(cache_dir)
+        except OSError as exc:
+            print(f"ERROR: cannot read {cache_dir}: {exc}", file=sys.stderr)
+            return set()
+    elif listing:
+        with open(listing, encoding="utf-8") as fh:
+            names = [line.strip() for line in fh if line.strip()]
+
+    cached: Set[str] = set()
+    for name in names:
+        match = CACHE_DIR_RE.match(os.path.basename(name.rstrip("/")))
+        if match:
+            cached.add(match.group("slug").replace("--", "/", 1))
+    return cached
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--cache-dir",
+        help="Live HF hub cache to diff against, e.g. /sgl-data/hf-cache/hub.",
+    )
+    parser.add_argument(
+        "--cache-listing",
+        help="File with one `models--org--name` entry per line, from `ls` elsewhere.",
+    )
+    parser.add_argument(
+        "--runner",
+        help="Scope to jobs whose runs-on label contains this substring, e.g. "
+        "'mi35x' for the tw cluster or 'mi300' for ccs. Without it every AMD "
+        "suite counts, which reports the other cluster's models as missing.",
+    )
+    parser.add_argument(
+        "--include-disabled",
+        action="store_true",
+        help="Count tests registered with disabled=. Off by default: a disabled "
+        "test does not pull weights, so its models are not needed.",
+    )
+    parser.add_argument("--json", help="Write the full result as JSON to this path.")
+    args = parser.parse_args()
+
+    result = compute(include_disabled=args.include_disabled, runner=args.runner)
+    reach = result["suite_reachability"]  # type: ignore[index]
+    models: Dict[str, dict] = result["models"]  # type: ignore[assignment]
+
+    print("AMD suite reachability")
+    for key in ("nightly_only", "per_commit_only", "both", "undispatched"):
+        print(f"  {key:<16} {len(reach[key]):>4} suites")
+    needed = {m for m, i in models.items() if i["verdict"] != "undispatched"}
+    print(
+        f"\n{len(models)} distinct checkpoints referenced; "
+        f"{len(needed)} needed by a dispatched suite, "
+        f"{len(models) - len(needed)} referenced only by undispatched tests."
+    )
+
+    if args.cache_dir or args.cache_listing:
+        cached = _read_cache(args.cache_dir, args.cache_listing)
+        missing = sorted(needed - cached)
+        reclaimable = sorted(cached - set(models))
+        dead = sorted(
+            c for c in cached if c in models and models[c]["verdict"] == "undispatched"
+        )
+
+        print(f"\nCache holds {len(cached)} checkpoints")
+        print(f"  needed but MISSING : {len(missing)}")
+        for m in missing:
+            info = models[m]
+            src = ", ".join(info["nightly_suites"] + info["per_commit_suites"])[:70]
+            print(f"      {m}  <- {src}")
+        print(f"  cached, no AMD test reference (safe to drop): {len(reclaimable)}")
+        for m in reclaimable:
+            print(f"      {m}")
+        print(f"  cached, test exists but no job dispatches it: {len(dead)}")
+        for m in dead:
+            print(f"      {m}  <- {', '.join(models[m]['undispatched_suites'])[:60]}")
+        print(
+            "\nOnly the 'no AMD test reference' group is unconditionally safe. The "
+            "dead group becomes needed again the moment someone wires its suite up."
+        )
+        result["cache"] = {
+            "cached_count": len(cached),
+            "missing": missing,
+            "reclaimable": reclaimable,
+            "dead_coverage": dead,
+        }
+
+    if args.json:
+        with open(args.json, "w", encoding="utf-8") as fh:
+            json.dump(result, fh, indent=2, sort_keys=True)
+        print(f"\nWrote {args.json}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Motivation

The AMD runners share one HuggingFace cache PVC per cluster, nothing evicts from it, and it fills up — a multi-hundred-GB download then dies partway through with `ENOSPC`. Deciding what is safe to drop needs a join: `register_amd_ci` tests → the checkpoints those tests name → whether any AMD workflow actually dispatches them.

Getting that join wrong is expensive. A recent audit of the tw MI35x PVC joined **only the two nightly workflows** and reported 939 GiB as reclaimable. Every byte of it was live: **289 of 429 AMD registrations are dispatched only by the per-commit `pr-test-amd*.yml` workflows**, whose jobs run on `linux-mi35x-gpu-1` and mount the same PVC as the 8-GPU nightly jobs. Deleting by that list would have broken AMD CI on every PR.

## Modifications

**`scripts/ci/utils/amd_cache_audit.py`** (new) — performs the join, counting per-commit and nightly separately and never reporting one without the other. With `--cache-dir` or `--cache-listing` it diffs against a live cache and sorts the result into three buckets, of which only the first is unconditionally safe:

| Bucket | Meaning |
| --- | --- |
| cached, no AMD test reference | nothing names it — safe to drop |
| cached, test exists but no job dispatches | becomes needed again the moment someone wires the suite up |
| needed but missing | a dispatched suite wants it; next run pays the download |

Two details it exists to get right, both of which a hand-rolled scan got wrong on the first pass:

- **`--runner` scopes to a cluster** by the dispatching job's `runs-on` label. Without it, tw is compared against every AMD suite and the mi300-only checkpoints all read as missing — 134 rather than 24.
- **Model ids resolve through `list_stage_models.py`'s constant table**, not string literals. `meta-llama/Llama-3.2-1B-Instruct` looks unreferenced to a literal search but reaches five per-commit suites through `DEFAULT_SMALL_MODEL_NAME_FOR_TEST`.

Dispatch detection accepts both `--suite <name>` and a bare test path, since several MI35x perf steps invoke the file directly rather than going through a suite.

The suite → models extraction is **reused from `scripts/ci/list_stage_models.py`** rather than reimplemented; it already handles AST extraction, constant resolution and overrides for any backend, and already supports `--backend amd`.

**`scripts/ci/test_amd_cache_audit.py`** (new) — unit tests for the label/text/cache-path helpers, plus an end-to-end case that runs the real join against the real repo. That last one is the point: no workflow executes this tool, so a refactor in `list_stage_models.py` would break it silently and nobody would notice until someone deleted the wrong checkpoints. It asserts the contract rather than exact counts, which move whenever a test is added — including specifically that the per-commit bucket is non-empty and that constant-resolved models still appear.

**`.github/workflows/ci-model-inventory.yml`** — runs those tests beside the extractor's own, and adds both files to the PR path filter.

## Accuracy Tests

Not applicable — CI tooling, no product code.

`python3 -m unittest discover -s scripts/ci -p 'test_amd_cache_audit.py'` → 15 tests, ~15 s, stdlib only, no GPU and no sglang import.

Behaviour on the current tree: `--runner mi35x` resolves `nightly_only 39 / per_commit_only 3 / both 2 / undispatched 75` over 157 checkpoints; a cache diff against a planted listing correctly sorts an unreferenced entry into "safe to drop" and reports the rest as missing.

## Speed Tests and Profiling

Not applicable. The end-to-end test adds ~15 s to `ci-model-inventory`, which is an `ubuntu-latest` job.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — the module docstring documents usage.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers — AMD CI owners are the right audience here.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829100796](https://github.com/sgl-project/sglang/actions/runs/34829100796)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829100514](https://github.com/sgl-project/sglang/actions/runs/34829100514)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829100651](https://github.com/sgl-project/sglang/actions/runs/34829100651)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->