### PR TITLE
[docs] Slurm: fix multi-node example, add single-node and offline batch examples

### DIFF
--- a/docs/docs/references/multi_node_deployment/multi_node.mdx
+++ b/docs/docs/references/multi_node_deployment/multi_node.mdx
@@ -56,7 +56,7 @@ This example showcases how to serve SGLang server across multiple nodes by SLURM
 #SBATCH --gres=gpu:8
 #SBATCH --time=12:00:00
 
-echo "[INFO] Activating environment on node $SLURM_PROCID"
+echo "[INFO] Activating environment on $(hostname)"
 if ! source ENV_FOLDER/bin/activate; then
     echo "[ERROR] Failed to activate environment" >&2
     exit 1
@@ -70,7 +70,8 @@ echo "[INFO] Running inference"
 echo "[INFO] Model: $model"
 echo "[INFO] TP Size: $tp_size"
 
-# Set NCCL initialization address using the hostname of the head node
+# Set NCCL initialization address using the hostname of the head node.
+# If port 8000 is already used by another job, pick a different one.
 HEAD_NODE=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
 NCCL_INIT_ADDR="${HEAD_NODE}:8000"
 echo "[INFO] NCCL_INIT_ADDR: $NCCL_INIT_ADDR"
@@ -86,9 +87,15 @@ srun --ntasks=2 --nodes=2 --output="SLURM_Logs/%x_%j_node$SLURM_NODEID.out" \
     --nnodes 2 \
     --node-rank "$SLURM_NODEID" &
 
-# Wait for the NCCL server to be ready on port 30000
+# Wait for the server to be ready on port 30000 (give up after 10 minutes)
+waited=0
 while ! nc -z "$HEAD_NODE" 30000; do
-    sleep 1
+    sleep 5
+    waited=$((waited + 5))
+    if [ "$waited" -ge 600 ]; then
+        echo "[ERROR] $HEAD_NODE:30000 did not become ready in time" >&2
+        exit 1
+    fi
     echo "[INFO] Waiting for $HEAD_NODE:30000 to accept connections"
 done
 
@@ -101,3 +108,93 @@ wait
 Then, you can test the server by sending requests following other [documents](../../basic_usage/openai_api_completions).
 
 Thanks for [aflah02](https://github.com/aflah02) for providing the example, based on his [blog post](https://aflah02.substack.com/p/multi-node-llm-inference-with-sglang).
+
+## Single-Node Serving on SLURM
+
+For a single node, submit the following job. It picks a free port automatically, which avoids collisions with other jobs on shared clusters.
+
+```bash Command
+#!/bin/bash
+
+#SBATCH -o SLURM_Logs/%x_%j.out
+#SBATCH -e SLURM_Logs/%x_%j.err
+#SBATCH -J sglang-single-node
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --gres=gpu:1
+#SBATCH --time=12:00:00
+
+source ENV_FOLDER/bin/activate
+
+model=MODEL_PATH
+
+# Pick a free port to avoid collisions with other jobs
+port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+
+python3 -m sglang.launch_server \
+    --model-path "$model" \
+    --host 0.0.0.0 \
+    --port "$port" &
+server_pid=$!
+
+# Wait until the server is healthy (give up after 10 minutes)
+ready=0
+for _ in $(seq 1 120); do
+    if curl -fsS "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
+        ready=1
+        break
+    fi
+    sleep 5
+done
+if [ "$ready" -ne 1 ]; then
+    echo "[ERROR] Server did not become healthy in time" >&2
+    kill "$server_pid"
+    exit 1
+fi
+
+echo "[INFO] Server ready on $(hostname):${port}"
+echo "[INFO] From a login node, forward the port with:"
+echo "[INFO]   ssh -L ${port}:$(hostname):${port} <login-node>"
+
+# Keep the job alive while the server runs
+wait "$server_pid"
+```
+
+## Offline Batch Inference on SLURM
+
+Batch jobs that process a fixed dataset do not need a long-running server; the job exits when inference finishes.
+
+```bash Command
+#!/bin/bash
+
+#SBATCH -o SLURM_Logs/%x_%j.out
+#SBATCH -e SLURM_Logs/%x_%j.err
+#SBATCH -J sglang-batch-inference
+#SBATCH --nodes=1
+#SBATCH --cpus-per-task=8
+#SBATCH --gres=gpu:1
+#SBATCH --time=4:00:00
+
+source ENV_FOLDER/bin/activate
+
+python3 - <<'EOF'
+import sglang as sgl
+
+prompts = ["Hello, my name is", "The capital of France is"]
+
+llm = sgl.Engine(model_path="MODEL_PATH")
+outputs = llm.generate(prompts, {"max_new_tokens": 64})
+for o in outputs:
+    print(o["text"])
+llm.shutdown()
+EOF
+```
+
+A more complete example is [offline_batch_inference.py](https://github.com/sgl-project/sglang/blob/main/examples/runtime/engine/offline_batch_inference.py).
+
+## Notes for Shared Clusters
+
+- **Ports**: the server listens on port 30000 by default. On shared clusters, pass `--port` with a port unique to your job (or pick a free one as above), and choose a free port for `--dist-init-addr` in multi-node runs.
+- **Network interfaces**: on nodes with several interfaces (InfiniBand plus Ethernet), NCCL and Gloo may pick the wrong one. Pin them with `export NCCL_SOCKET_IFNAME=<iface>` and `export GLOO_SOCKET_IFNAME=<iface>` before launching.
+- **Model weights**: loading large weights from a shared filesystem can be slow when many jobs start at once. Stage the weights to node-local storage, or set `--download-dir` to a fast cache.

--- a/docs/docs/references/multi_node_deployment/multi_node.mdx
+++ b/docs/docs/references/multi_node_deployment/multi_node.mdx
@@ -35,86 +35,114 @@ python -m sglang.launch_server --model-path meta-llama/Meta-Llama-3.1-405B-Instr
 
 Please refer to [DeepSeek documents for reference](/cookbook/autoregressive/DeepSeek/DeepSeek-V3#4-2-5-multi-node-deployment).
 
-## Multi-Node Inference on SLURM
+## Slurm prerequisites
 
-This example showcases how to serve SGLang server across multiple nodes by SLURM. Submit the following job to the SLURM cluster.
+Replace `ENV_FOLDER`, `MODEL_PATH`, and `PARTITION` in the examples below with values for your cluster, and adjust the resource requests as needed. The SGLang environment and any local model path must be accessible from every allocated node. The serving examples also require `curl` on the node that runs the batch script.
+
+Create the log directory before submitting a job because Slurm opens the output files before the batch script starts:
+
+```bash Command
+mkdir -p SLURM_Logs
+```
+
+## Multi-node inference on Slurm
+
+The following job starts one SGLang launcher on each of two nodes.
 
 ```bash Command
 #!/bin/bash -l
 
 #SBATCH -o SLURM_Logs/%x_%j_master.out
 #SBATCH -e SLURM_Logs/%x_%j_master.err
-#SBATCH -D ./
 #SBATCH -J Llama-405B-Online-Inference-TP16-SGL
 
 #SBATCH --nodes=2
 #SBATCH --ntasks=2
-#SBATCH --ntasks-per-node=1  # Ensure 1 task per node
+#SBATCH --ntasks-per-node=1
 #SBATCH --cpus-per-task=18
-#SBATCH --mem=224GB
-#SBATCH --partition="lmsys.org"
+#SBATCH --mem=224G
+#SBATCH --partition=PARTITION
 #SBATCH --gres=gpu:8
 #SBATCH --time=12:00:00
 
-echo "[INFO] Activating environment on $(hostname)"
-if ! source ENV_FOLDER/bin/activate; then
-    echo "[ERROR] Failed to activate environment" >&2
-    exit 1
-fi
+set -euo pipefail
 
-# Define parameters
+echo "[INFO] Activating environment on $(hostname)"
+source ENV_FOLDER/bin/activate
+
 model=MODEL_PATH
 tp_size=16
+server_port="${SGLANG_PORT:-30000}"
+dist_port="${SGLANG_DIST_PORT:-20000}"
 
 echo "[INFO] Running inference"
 echo "[INFO] Model: $model"
 echo "[INFO] TP Size: $tp_size"
 
-# Set NCCL initialization address using the hostname of the head node.
-# If port 8000 is already used by another job, pick a different one.
-HEAD_NODE=$(scontrol show hostname "$SLURM_NODELIST" | head -n 1)
-NCCL_INIT_ADDR="${HEAD_NODE}:8000"
-echo "[INFO] NCCL_INIT_ADDR: $NCCL_INIT_ADDR"
+head_node=$(scontrol show hostnames "$SLURM_JOB_NODELIST" | sed -n '1p')
+dist_init_addr="${head_node}:${dist_port}"
+echo "[INFO] Distributed initialization address: $dist_init_addr"
 
-# Launch the model server on each node using SLURM
-srun --ntasks=2 --nodes=2 --output="SLURM_Logs/%x_%j_node$SLURM_NODEID.out" \
-    --error="SLURM_Logs/%x_%j_node$SLURM_NODEID.err" \
-    python3 -m sglang.launch_server \
-    --model-path "$model" \
-    --grammar-backend "xgrammar" \
-    --tp "$tp_size" \
-    --dist-init-addr "$NCCL_INIT_ADDR" \
-    --nnodes 2 \
-    --node-rank "$SLURM_NODEID" &
+# Export values that the shell started by srun expands on each task.
+export SGLANG_MODEL_PATH="$model"
+export SGLANG_TP_SIZE="$tp_size"
+export SGLANG_SERVER_PORT="$server_port"
+export SGLANG_DIST_INIT_ADDR="$dist_init_addr"
 
-# Wait for the server to be ready on port 30000 (give up after 10 minutes)
-waited=0
-while ! nc -z "$HEAD_NODE" 30000; do
-    sleep 5
-    waited=$((waited + 5))
-    if [ "$waited" -ge 600 ]; then
-        echo "[ERROR] $HEAD_NODE:30000 did not become ready in time" >&2
+# SLURM_PROCID is expanded inside each srun task, producing ranks 0 and 1.
+srun --ntasks=2 --nodes=2 --ntasks-per-node=1 \
+    --output="SLURM_Logs/%x_%j_node%n.out" \
+    --error="SLURM_Logs/%x_%j_node%n.err" \
+    bash -c '
+        exec python3 -m sglang.launch_server \
+            --model-path "$SGLANG_MODEL_PATH" \
+            --host 0.0.0.0 \
+            --port "$SGLANG_SERVER_PORT" \
+            --tp "$SGLANG_TP_SIZE" \
+            --dist-init-addr "$SGLANG_DIST_INIT_ADDR" \
+            --nnodes 2 \
+            --node-rank "$SLURM_PROCID"
+    ' &
+server_step_pid=$!
+
+# Wait up to 10 minutes for the HTTP server on the head node.
+ready=0
+for ((attempt = 1; attempt <= 120; attempt++)); do
+    if curl -fsS "http://${head_node}:${server_port}/health" >/dev/null 2>&1; then
+        ready=1
+        break
+    fi
+    if ! kill -0 "$server_step_pid" 2>/dev/null; then
+        echo "[ERROR] The Slurm step exited before the server became healthy" >&2
+        wait "$server_step_pid" || true
         exit 1
     fi
-    echo "[INFO] Waiting for $HEAD_NODE:30000 to accept connections"
+    sleep 5
 done
 
-echo "[INFO] $HEAD_NODE:30000 is ready to accept connections"
+if [ "$ready" -ne 1 ]; then
+    echo "[ERROR] ${head_node}:${server_port} did not become healthy within 10 minutes" >&2
+    kill "$server_step_pid" 2>/dev/null || true
+    wait "$server_step_pid" 2>/dev/null || true
+    exit 1
+fi
 
-# Keep the script running until the SLURM job times out
-wait
+echo "[INFO] Server ready at http://${head_node}:${server_port}"
+
+# Keep the allocation active while the server is running.
+wait "$server_step_pid"
 ```
 
-Then, you can test the server by sending requests following other [documents](../../basic_usage/openai_api_completions).
+Send requests to the server as described in the [OpenAI-compatible APIs](/docs/basic_usage/openai_api_completions) documentation.
 
-Thanks for [aflah02](https://github.com/aflah02) for providing the example, based on his [blog post](https://aflah02.substack.com/p/multi-node-llm-inference-with-sglang).
+Thanks to [aflah02](https://github.com/aflah02) for the original example, based on [their blog post](https://aflah02.substack.com/p/multi-node-llm-inference-with-sglang).
 
-## Single-Node Serving on SLURM
+## Single-node serving on Slurm
 
-For a single node, submit the following job. It picks a free port automatically, which avoids collisions with other jobs on shared clusters.
+This job starts an HTTP server on one GPU. It uses port 30000 unless `SGLANG_PORT` is set in the job environment.
 
 ```bash Command
-#!/bin/bash
+#!/bin/bash -l
 
 #SBATCH -o SLURM_Logs/%x_%j.out
 #SBATCH -e SLURM_Logs/%x_%j.err
@@ -122,15 +150,16 @@ For a single node, submit the following job. It picks a free port automatically,
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
+#SBATCH --partition=PARTITION
 #SBATCH --gres=gpu:1
 #SBATCH --time=12:00:00
+
+set -euo pipefail
 
 source ENV_FOLDER/bin/activate
 
 model=MODEL_PATH
-
-# Pick a free port to avoid collisions with other jobs
-port=$(python3 -c 'import socket; s=socket.socket(); s.bind(("", 0)); print(s.getsockname()[1]); s.close()')
+port="${SGLANG_PORT:-30000}"
 
 python3 -m sglang.launch_server \
     --model-path "$model" \
@@ -138,63 +167,94 @@ python3 -m sglang.launch_server \
     --port "$port" &
 server_pid=$!
 
-# Wait until the server is healthy (give up after 10 minutes)
+cleanup() {
+    kill "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# Wait up to 10 minutes for the server to become healthy.
 ready=0
-for _ in $(seq 1 120); do
+for ((attempt = 1; attempt <= 120; attempt++)); do
     if curl -fsS "http://127.0.0.1:${port}/health" >/dev/null 2>&1; then
         ready=1
         break
     fi
+    if ! kill -0 "$server_pid" 2>/dev/null; then
+        echo "[ERROR] The server exited before becoming healthy" >&2
+        wait "$server_pid" || true
+        exit 1
+    fi
     sleep 5
 done
+
 if [ "$ready" -ne 1 ]; then
-    echo "[ERROR] Server did not become healthy in time" >&2
-    kill "$server_pid"
+    echo "[ERROR] The server did not become healthy within 10 minutes" >&2
     exit 1
 fi
 
-echo "[INFO] Server ready on $(hostname):${port}"
-echo "[INFO] From a login node, forward the port with:"
-echo "[INFO]   ssh -L ${port}:$(hostname):${port} <login-node>"
+compute_node=$(hostname)
+echo "[INFO] Server ready on ${compute_node}:${port}"
+echo "[INFO] If your cluster permits SSH forwarding, run this on your local machine:"
+echo "[INFO]   ssh -N -L ${port}:${compute_node}:${port} <login-node>"
 
-# Keep the job alive while the server runs
+# Keep the allocation active while the server is running.
 wait "$server_pid"
+trap - EXIT
 ```
 
-## Offline Batch Inference on SLURM
+## Offline batch inference on Slurm
 
-Batch jobs that process a fixed dataset do not need a long-running server; the job exits when inference finishes.
+Batch jobs that process a fixed set of prompts do not need an HTTP server. SGLang uses Python's `spawn` multiprocessing method, so write the program to a real file and protect the entry point with `if __name__ == "__main__"`.
 
 ```bash Command
-#!/bin/bash
+#!/bin/bash -l
 
 #SBATCH -o SLURM_Logs/%x_%j.out
 #SBATCH -e SLURM_Logs/%x_%j.err
 #SBATCH -J sglang-batch-inference
 #SBATCH --nodes=1
+#SBATCH --ntasks=1
 #SBATCH --cpus-per-task=8
+#SBATCH --partition=PARTITION
 #SBATCH --gres=gpu:1
 #SBATCH --time=4:00:00
 
+set -euo pipefail
+
 source ENV_FOLDER/bin/activate
 
-python3 - <<'EOF'
+export SGLANG_MODEL_PATH=MODEL_PATH
+script_path=$(mktemp "${SLURM_TMPDIR:-/tmp}/sglang-offline.XXXXXX.py")
+trap 'rm -f "$script_path"' EXIT
+
+cat >"$script_path" <<'PY'
+import os
+
 import sglang as sgl
 
-prompts = ["Hello, my name is", "The capital of France is"]
 
-llm = sgl.Engine(model_path="MODEL_PATH")
-outputs = llm.generate(prompts, {"max_new_tokens": 64})
-for o in outputs:
-    print(o["text"])
-llm.shutdown()
-EOF
+def main():
+    prompts = ["Hello, my name is", "The capital of France is"]
+    with sgl.Engine(model_path=os.environ["SGLANG_MODEL_PATH"]) as engine:
+        outputs = engine.generate(prompts, {"max_new_tokens": 64})
+
+    for output in outputs:
+        print(output["text"])
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+srun --ntasks=1 python3 "$script_path"
 ```
 
-A more complete example is [offline_batch_inference.py](https://github.com/sgl-project/sglang/blob/main/examples/runtime/engine/offline_batch_inference.py).
+See the [Offline Engine API](/docs/basic_usage/offline_engine_api) for more examples.
 
-## Notes for Shared Clusters
+## Notes for shared clusters
 
-- **Ports**: the server listens on port 30000 by default. On shared clusters, pass `--port` with a port unique to your job (or pick a free one as above), and choose a free port for `--dist-init-addr` in multi-node runs.
+- **Scheduler settings**: partitions, GPU resource names, memory limits, and account settings vary by cluster. Update the `#SBATCH` directives before submitting these examples.
+- **Ports**: the examples use port 30000 for HTTP and port 20000 for distributed initialization. Set `SGLANG_PORT` and `SGLANG_DIST_PORT` to unused ports permitted by your cluster.
 - **Network interfaces**: on nodes with several interfaces (InfiniBand plus Ethernet), NCCL and Gloo may pick the wrong one. Pin them with `export NCCL_SOCKET_IFNAME=<iface>` and `export GLOO_SOCKET_IFNAME=<iface>` before launching.
-- **Model weights**: loading large weights from a shared filesystem can be slow when many jobs start at once. Stage the weights to node-local storage, or set `--download-dir` to a fast cache.
+- **Model weights**: loading large weights from a shared filesystem can be slow when many jobs start at once. Pass a node-local model path, or add `--download-dir` to a serving command to place model downloads in a faster cache.


### PR DESCRIPTION
## Motivation

Contributes to #3244.

The existing multi-node example expands `$SLURM_NODEID` in the batch shell, before `srun` creates its per-task environments. Both launches can therefore receive the same node rank. The existing readiness loop also checks only whether a TCP port is open.

This PR covers basic multi-node serving, single-node serving, and offline batch inference. #29991 has a separate scope around PD disaggregation and Apptainer.

## Changes

- Evaluate `$SLURM_PROCID` inside each `srun` task and use Slurm `%n` patterns for per-node logs.
- Use configurable HTTP and distributed-init ports, a bounded `/health` check, and early process-exit detection.
- Add a single-node serving job with cleanup and an SSH forwarding hint.
- Add an offline job that writes a real Python file with a `__main__` guard, as required by the Engine multiprocessing setup.
- Document the log-directory prerequisite and cluster-specific scheduler, network, port, and model-cache settings.

## Validation

- `bash -n` on all three batch scripts.
- `mint validate`.
- `mint broken-links`.
- Parsed and mock-executed the offline Python example, including Engine context cleanup.
- Checked task-side rank expansion with `SLURM_PROCID=0` and `SLURM_PROCID=1`.
- Cross-checked the Engine `spawn` setup, context-manager support, `/health` behavior, and referenced server arguments against the PR base revision.

I did not run these examples end to end on a Slurm GPU cluster. The `#SBATCH` resource values, partition name, network interfaces, and port availability remain site-specific.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32676790313](https://github.com/sgl-project/sglang/actions/runs/32676790313)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32676790204](https://github.com/sgl-project/sglang/actions/runs/32676790204)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->