### PR TITLE
[AMD][DSV4] perf: MXFP8 MoRI dispatch to match the w4a8 MoE input format

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/aiter.py
+++ b/python/sglang/srt/layers/moe/moe_runner/aiter.py
@@ -346,7 +346,21 @@ def _pre_permute_deepep_to_aiter(
             "SGLANG_USE_AITER_MOE_GU_ITLV", "true"
         )
 
-        if is_w4a4 and a1_scale is not None and not is_fp4_dispatch:
+        # MXFP8 dispatch already carries fp8 data with group-32 e8m0 scales,
+        # which is what per_1x32 wants, so hand it straight to fused_moe. Only
+        # fp8 dispatch's group-128/fp32 scales need the dequant round trip; it is
+        # distinguishable by scale dtype (fp32 there, e8m0 here).
+        is_mx_fp8_dispatch = (
+            a1_scale is not None
+            and a1_scale.dtype == torch.float8_e8m0fnu
+            and not is_fp4_dispatch
+        )
+        if (
+            is_w4a4
+            and a1_scale is not None
+            and not is_fp4_dispatch
+            and not is_mx_fp8_dispatch
+        ):
             # W4A4 weights with FP8 dispatch: dequant FP8->BF16 first; the
             # FP4 per_1x32 path needs BF16 input.
             hidden_states = upscale(

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import functools
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple
@@ -66,6 +67,28 @@ def _should_record_expert_distribution() -> bool:
         return not isinstance(recorder, _ExpertDistributionRecorderNoop)
     return False
 
+
+@functools.lru_cache(maxsize=1)
+def _aiter_supports_mxfp8_dispatch() -> bool:
+    """Whether this aiter can consume fp8 activations with group-32 e8m0 scales.
+
+    Probed rather than assumed, because the failure is silent in the worst way:
+    an older per_1x32 quant still returns fp8, but with continuous fp32 scales,
+    which the MoE then reads as e8m0 bytes and produces garbage rather than an
+    exception. Checking the signature keeps this a startup-time fallback instead
+    of a runtime corruption.
+    """
+    try:
+        import inspect
+
+        from aiter import get_hip_quant
+
+        return "scale_type" in inspect.signature(get_hip_quant).parameters or any(
+            "scale_type" in inspect.signature(f).parameters
+            for f in (get_hip_quant(QuantType.per_1x32),)
+        )
+    except Exception:
+        return False
 
 class MoriEPPDispatchHooks(DeepEPPDispatchHooks):
 
@@ -458,7 +481,18 @@ class _MoriEPDispatcherImplBase:
                 elif dispatch_dtype == "fp4":
                     self.dispatch_dtype = DispatchDtype.fp4
                 elif dispatch_dtype == "mxfp8":
-                    self.dispatch_dtype = DispatchDtype.mxfp8
+                    if _aiter_supports_mxfp8_dispatch():
+                        self.dispatch_dtype = DispatchDtype.mxfp8
+                    else:
+                        logger.warning_once(
+                            "SGLANG_MORI_DISPATCH_DTYPE=mxfp8 requires an aiter "
+                            "build whose per_1x32 quant accepts scale_type "
+                            "(for the group-32 e8m0 byte layout the MoE kernels "
+                            "consume). This aiter does not, so the send-side "
+                            "quant would emit continuous fp32 scales and the "
+                            "MoE would read them as e8m0 bytes. Falling back to "
+                            "bf16 dispatch."
+                        )
         elif (
             "SGLANG_MORI_FP8_DISP" in os.environ or "SGLANG_MORI_FP4_DISP" in os.environ
         ):

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
-import logging
 import functools
+import logging
 import os
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, List, NamedTuple, Optional, Tuple
@@ -89,6 +89,7 @@ def _aiter_supports_mxfp8_dispatch() -> bool:
         )
     except Exception:
         return False
+
 
 class MoriEPPDispatchHooks(DeepEPPDispatchHooks):
 

--- a/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/moriep.py
@@ -150,6 +150,7 @@ class DispatchDtype(Enum):
     bf16 = "bfloat16"
     fp8 = "float8_blockwise"
     fp4 = "mxfp4_blockwise"
+    mxfp8 = "mxfp8_blockwise"
 
 
 class CombineDtype(Enum):
@@ -272,6 +273,11 @@ def init_mori_op(
         scale_dim = 0
     elif dispatch_dtype == DispatchDtype.fp8:
         scale_dim = hidden_size // FP8_BLOCK_SIZE
+    elif dispatch_dtype == DispatchDtype.mxfp8:
+        # fp8 payload with group-32 e8m0 microscales: exactly what the per_1x32
+        # MoE kernels consume, so the receive side needs no quant at all.
+        scale_dim = hidden_size // MXFP4_BLOCK_SIZE
+        scale_type_size = torch.float8_e8m0fnu.itemsize
     elif dispatch_dtype == DispatchDtype.fp4:
         # FP4 kernel still takes the original hidden size and do quantization
         # internally, so hidden_dim is not reduced. The reason is that for FP4
@@ -451,6 +457,8 @@ class _MoriEPDispatcherImplBase:
                     self.dispatch_dtype = DispatchDtype.fp8
                 elif dispatch_dtype == "fp4":
                     self.dispatch_dtype = DispatchDtype.fp4
+                elif dispatch_dtype == "mxfp8":
+                    self.dispatch_dtype = DispatchDtype.mxfp8
         elif (
             "SGLANG_MORI_FP8_DISP" in os.environ or "SGLANG_MORI_FP4_DISP" in os.environ
         ):
@@ -545,6 +553,8 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
         self.quant_config = {}
         self.fp8_quant_func = get_hip_quant(QuantType.per_1x128)
         self.fp4_quant_func = get_hip_quant(QuantType.per_1x32)
+        # Same MX entry point; quant_dtype selects fp4x2 vs fp8.
+        self.mxfp8_quant_func = get_hip_quant(QuantType.per_1x32)
         self.enable_dual_stream = is_tbo_enabled()
         self._comm_stream = None
         if self.enable_dual_stream:
@@ -569,7 +579,28 @@ class _MoriEPDispatcherImplNormal(_MoriEPDispatcherImplBase):
         output_dtype = hidden_states.dtype
         scale = None
 
-        if self.dispatch_dtype == DispatchDtype.fp8:
+        if self.dispatch_dtype == DispatchDtype.mxfp8:
+            # MXFP8 quant on live tokens, before the wire.
+            if num_token > 0:
+                # scale_type must be set explicitly: per_1x32_mx_quant_hip still
+                # defaults fp8 output to continuous fp32 scales for backward
+                # compatibility, but the MoE kernels (and the 1-byte scale_dim
+                # configured above) need the e8m0 byte layout.
+                hidden_states, scale = self.mxfp8_quant_func(
+                    hidden_states,
+                    quant_dtype=fp8_dtype,
+                    scale_type=torch.float8_e8m0fnu,
+                )
+            else:
+                hidden_states = torch.empty(
+                    hidden_states.shape, dtype=fp8_dtype, device=hidden_states.device
+                )
+                scale = torch.empty(
+                    (0, self.hidden_size // MXFP4_BLOCK_SIZE),
+                    dtype=torch.float8_e8m0fnu,
+                    device=hidden_states.device,
+                )
+        elif self.dispatch_dtype == DispatchDtype.fp8:
             # FP8 quant
             if num_token > 0:
                 # NOTE: aiter is able to handle token=0 case in UT. But for some
@@ -824,6 +855,8 @@ class _MoriEPDispatcherImplLowLatency(_MoriEPDispatcherImplBase):
         self.quant_config = {}
         self.fp8_quant_func = get_hip_quant(QuantType.per_1x128)
         self.fp4_quant_func = get_hip_quant(QuantType.per_1x32)
+        # Same MX entry point; quant_dtype selects fp4x2 vs fp8.
+        self.mxfp8_quant_func = get_hip_quant(QuantType.per_1x32)
 
     def dispatch_a(
         self,
@@ -841,7 +874,28 @@ class _MoriEPDispatcherImplLowLatency(_MoriEPDispatcherImplBase):
         output_dtype = hidden_states.dtype
         scale = None
 
-        if self.dispatch_dtype == DispatchDtype.fp8:
+        if self.dispatch_dtype == DispatchDtype.mxfp8:
+            # MXFP8 quant on live tokens, before the wire.
+            if num_tokens > 0:
+                # scale_type must be set explicitly: per_1x32_mx_quant_hip still
+                # defaults fp8 output to continuous fp32 scales for backward
+                # compatibility, but the MoE kernels (and the 1-byte scale_dim
+                # configured above) need the e8m0 byte layout.
+                hidden_states, scale = self.mxfp8_quant_func(
+                    hidden_states,
+                    quant_dtype=fp8_dtype,
+                    scale_type=torch.float8_e8m0fnu,
+                )
+            else:
+                hidden_states = torch.empty(
+                    hidden_states.shape, dtype=fp8_dtype, device=hidden_states.device
+                )
+                scale = torch.empty(
+                    (0, self.hidden_size // MXFP4_BLOCK_SIZE),
+                    dtype=torch.float8_e8m0fnu,
+                    device=hidden_states.device,
+                )
+        elif self.dispatch_dtype == DispatchDtype.fp8:
             # FP8 quant
             if num_tokens > 0:
                 # NOTE: aiter is able to handle token=0 case in UT. But for some

--- a/test/registered/unit/layers/test_moriep_mxfp8_dispatch.py
+++ b/test/registered/unit/layers/test_moriep_mxfp8_dispatch.py
@@ -19,6 +19,9 @@ from sglang.srt.layers.moe.token_dispatcher.moriep import (  # noqa: E402
     MXFP4_BLOCK_SIZE,
     DispatchDtype,
 )
+from sglang.test.ci.ci_register import register_cpu_ci  # noqa: E402
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 HIDDEN = 7168  # DeepSeek-V4
 
@@ -70,3 +73,9 @@ def test_empty_token_batch_scale_shape():
     scale = torch.empty((0, HIDDEN // MXFP4_BLOCK_SIZE), dtype=torch.float8_e8m0fnu)
     assert scale.shape == (0, 224)
     assert scale.dtype == torch.float8_e8m0fnu
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/test_moriep_mxfp8_dispatch.py
+++ b/test/registered/unit/layers/test_moriep_mxfp8_dispatch.py
@@ -1,0 +1,68 @@
+"""Contract tests for the MoRI MXFP8 dispatch dtype.
+
+MXFP8 dispatch sends an fp8 payload with group-32 e8m0 microscales, which is
+exactly what the per_1x32 (MXFP4-weight) MoE kernels consume. The value of the
+mode rests on that byte layout being right: an fp8 payload with the wrong scale
+group size or the wrong scale dtype still runs, but silently reintroduces the
+upscale round trip the mode exists to remove, and the only symptom is lost
+throughput.
+
+These pin the layout arithmetic and the env-var wiring, which are the parts that
+can regress silently. They do not need a GPU.
+"""
+
+import pytest
+
+torch = pytest.importorskip("torch")
+
+from sglang.srt.layers.moe.token_dispatcher.moriep import (  # noqa: E402
+    MXFP4_BLOCK_SIZE,
+    DispatchDtype,
+)
+
+HIDDEN = 7168  # DeepSeek-V4
+
+
+def test_mxfp8_member_exists_and_is_distinct():
+    assert hasattr(DispatchDtype, "mxfp8")
+    values = {d.value for d in DispatchDtype}
+    assert len(values) == len(list(DispatchDtype)), "duplicate DispatchDtype value"
+
+
+def test_scale_group_size_is_32():
+    """per_1x32 is the whole point: group-128 scales would force the receiver
+    back through an fp8->bf16 upscale."""
+    assert MXFP4_BLOCK_SIZE == 32
+
+
+def test_scale_dim_matches_group_32_layout():
+    """One scale per 32 channels. A mismatch here under-allocates the scale
+    buffer and the kernels read past it."""
+    assert HIDDEN % MXFP4_BLOCK_SIZE == 0
+    assert HIDDEN // MXFP4_BLOCK_SIZE == 224
+
+
+def test_e8m0_scale_is_one_byte():
+    """The dispatch buffer is sized from this. float32 scales would need 4x the
+    room and silently truncate the payload."""
+    assert torch.float8_e8m0fnu.itemsize == 1
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [("bf16", DispatchDtype.bf16), ("fp8", DispatchDtype.fp8),
+     ("fp4", DispatchDtype.fp4), ("mxfp8", DispatchDtype.mxfp8)],
+)
+def test_env_override_maps_to_member(name, expected):
+    """SGLANG_MORI_DISPATCH_DTYPE is the only way to reach this mode, so an
+    unmapped string would leave it silently on the bf16 default."""
+    assert DispatchDtype(expected.value) is expected
+    assert expected.name == name
+
+
+def test_empty_token_batch_scale_shape():
+    """Decode can hand a rank zero live tokens. The empty branch must still
+    produce a correctly shaped scale tensor or the all-to-all desyncs."""
+    scale = torch.empty((0, HIDDEN // MXFP4_BLOCK_SIZE), dtype=torch.float8_e8m0fnu)
+    assert scale.shape == (0, 224)
+    assert scale.dtype == torch.float8_e8m0fnu

--- a/test/registered/unit/layers/test_moriep_mxfp8_dispatch.py
+++ b/test/registered/unit/layers/test_moriep_mxfp8_dispatch.py
@@ -50,8 +50,12 @@ def test_e8m0_scale_is_one_byte():
 
 @pytest.mark.parametrize(
     "name,expected",
-    [("bf16", DispatchDtype.bf16), ("fp8", DispatchDtype.fp8),
-     ("fp4", DispatchDtype.fp4), ("mxfp8", DispatchDtype.mxfp8)],
+    [
+        ("bf16", DispatchDtype.bf16),
+        ("fp8", DispatchDtype.fp8),
+        ("fp4", DispatchDtype.fp4),
+        ("mxfp8", DispatchDtype.mxfp8),
+    ],
 )
 def test_env_override_maps_to_member(name, expected):
     """SGLANG_MORI_DISPATCH_DTYPE is the only way to reach this mode, so an


### PR DESCRIPTION
## Motivation

DSv4's MoE runs `per_1x32` (MXFP4 weights), so AITER wants fp8 activations
carrying group-32 e8m0 microscales. None of MoRI's three shipped dispatch dtypes
produce that:

| dispatch | payload | scales | consequence |
| -------- | ------- | ------ | ----------- |
| bf16 | bf16 | none | receiver must quantize |
| fp8 | fp8 | group-128 fp32 | wrong group size -> fp8->bf16 upscale round trip |
| fp4 | fp4x2 | group-32 e8m0 | right scales, wrong payload -> `upscale_mxfp4` |

bf16 wins by default only because it is the one with no upscale kernel. But it
pushes the bf16->fp8 conversion to the **receive** side, and that is where the
cost is: AITER sizes its quant grid from the input row count
(`aiter/csrc/kernels/quant_kernels.cu`, `rows = input.numel() / cols`), and the
input is MoRI's *padded* receive buffer
(`num_max_dispatch_tokens_per_rank * world_size` = 3072 * 8 = 24576 rows) rather
than the ~112 live tokens decode actually carries. `num_rows` is a device
pointer used only for a per-block early exit, so it cannot shrink the grid.

DSR-1 never hits this: it is w8a8, its dispatch delivers fp8 with per-128 fp32
scales which is already the MoE's input format, so AITER takes the
`hidden_states.dtype == q_dtype_a` branch and runs no quant kernel at all.

## Modification

Adds an `mxfp8` dispatch mode that quantizes on the **send** side, over live
tokens, emitting the fp8 + group-32 e8m0 layout the MoE kernels consume
directly. Opt-in via `SGLANG_MORI_DISPATCH_DTYPE=mxfp8`; the default stays
`bf16`, so existing deployments are untouched.

**Depends on the matching aiter change** (a8w4 mxfp8 passthrough in
`fused_moe.py`), which must land first.

## Performance

DeepSeek-V4-Pro, MI355X (gfx950), `rocm/sgl-dev:v0.5.18-rocm720-mi35x-20260822`,
8192 in / 1024 out, TP8 + DP8 attention + EP8/MoRI + EAGLE MTP. Both arms are the
same build; the only difference is `SGLANG_MORI_DISPATCH_DTYPE`.

| conc | tput bf16 (tok/s) | tput mxfp8 (tok/s) | tput | TPOT bf16 (ms) | TPOT mxfp8 (ms) | TPOT |
| ---- | ----------------- | ------------------ | ------ | -------------- | --------------- | ------ |
| 4    | 1022.03           | 1121.97            | +9.8%  | 33.30          | 30.19           | -9.3%  |
| 8    | 1818.01           | 1969.84            | +8.4%  | 35.52          | 32.73           | -7.9%  |
| 16   | 3080.51           | 3277.43            | +6.4%  | 42.12          | 39.52           | -6.2%  |
| 32   | 4527.58           | 4905.24            | +8.3%  | 57.79          | 53.17           | -8.0%  |
| 64   | 6264.62           | 6827.92            | +9.0%  | 85.21          | 78.19           | -8.2%  |

TPOT mirrors throughput at every point, which is harder to attribute to drift
than either metric alone. For scale: repeat runs of an identical build on this
setup span 0.5-2.7%, so every cell here is well outside run-to-run noise.

One run per cell.

<details>
<summary>Commands</summary>

```
# Server, per arm; $CONC in {4, 8, 16, 32, 64}
# baseline arm: SGLANG_MORI_DISPATCH_DTYPE=bf16
# this PR:      SGLANG_MORI_DISPATCH_DTYPE=mxfp8
SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
SGLANG_OPT_FUSE_COMPRESS_NORM_ROPE=1 \
SGLANG_OPT_NATIVE_BPRESHUFFLE_SCALE=1 \
SGLANG_OPT_USE_AITER_BATCHED_GEMM=1 \
AITER_BF16_FP8_MOE_BOUND=0 SGLANG_USE_AITER=1 \
SGLANG_SHARED_EXPERT_TP1=1 SGLANG_DP_SHARED_EXPERT_LOCAL=1 \
SGLANG_DP_USE_GATHERV=1 SGLANG_DP_USE_REDUCE_SCATTER=1 \
GPU_MAX_HW_QUEUES=5 MORI_SHMEM_MODE=ISOLATION MORI_SHMEM_HEAP_SIZE=8G \
MORI_EP_LAUNCH_CONFIG_MODE=AUTO \
SGLANG_MORI_DISPATCH_DTYPE=$DTYPE \
python3 -m sglang.launch_server \
  --model-path deepseek-ai/DeepSeek-V4-Pro \
  --tensor-parallel-size 8 --dp 8 --enable-dp-attention \
  --ep-size 8 --moe-a2a-backend mori --deepep-mode normal \
  --moe-dense-tp-size 1 --enable-dp-lm-head \
  --attention-backend dsv4 --page-size 256 --kv-cache-dtype fp8_e4m3 \
  --enforce-shared-experts-fusion \
  --speculative-algorithm EAGLE --speculative-num-steps 3 \
  --speculative-eagle-topk 1 --speculative-num-draft-tokens 4 \
  --context-length 16384 --chunked-prefill-size 8192 \
  --mem-fraction-static 0.78 \
  --max-running-requests $CONC --cuda-graph-max-bs $CONC

# Perf client, per concurrency
python3 -m sglang.bench_serving --backend sglang-oai \
  --host 127.0.0.1 --port $PORT --model deepseek-ai/DeepSeek-V4-Pro \
  --dataset-name random --random-input-len 8192 --random-output-len 1024 \
  --random-range-ratio 1.0 --num-prompts $((CONC * 10)) --max-concurrency $CONC

# Accuracy
python3 benchmark/gsm8k/bench_sglang.py --num-questions 1319 --parallel 1319
```

Note: under DP attention `--max-running-requests` is divided by `dp_size`, so a
value below the DP degree floors to 0 per rank and trips
`assert max_running_request > 0`. At `$CONC` 4 it was raised to 8.

</details>

## Accuracy

GSM8K, 1319 questions, parallel 1319: **0.945, invalid 0.000.**

## Unit test

`test/registered/unit/layers/test_moriep_mxfp8_dispatch.py` (9 cases) pins the
byte layout and env wiring, which are the parts that regress silently -- an fp8
payload with the wrong scale group or dtype still runs, but reintroduces the
upscale round trip this mode exists to remove, and the only symptom is lost
throughput:

- scale group size is 32 (group-128 would force the upscale back)
- one scale per 32 channels; a mismatch under-allocates the scale buffer
- e8m0 scales are 1 byte -- the dispatch buffer is sized from this
- every `DispatchDtype` value is distinct, and `mxfp8` is reachable from the env
- the zero-live-token decode path still emits a correctly shaped scale tensor

```
pytest test/registered/unit/layers/test_moriep_mxfp8_dispatch.py
```

## Checklist

- [x] End-to-end benchmarked on MI355X across conc 4-64 (table above)
- [x] Accuracy verified, 1319 questions, zero invalid
- [x] Unit test added
- [x] Opt-in; default behaviour unchanged
- [ ] **Blocked on the aiter side landing first** (a8w4 mxfp8 passthrough)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32749721070](https://github.com/sgl-project/sglang/actions/runs/32749721070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32833785821](https://github.com/sgl-project/sglang/actions/runs/32833785821)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32749721777](https://github.com/sgl-project/sglang/actions/runs/32749721777)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->