### PR TITLE
[Bugfix] Fail fast when hierarchical cache is enabled with FP4 KV cache dtype

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7880,6 +7880,19 @@ class ServerArgs:
         ):
             return
 
+        if self.kv_cache_dtype in ("nvfp4", "fp4_mx_block16"):
+            raise ValueError(
+                f"--kv-cache-dtype {self.kv_cache_dtype} is not compatible with "
+                "the hierarchical cache (HiCache) host pool: the L2 write-back/"
+                "load-back path only transfers the packed KV data buffers "
+                "(k_data_ptrs/v_data_ptrs) and never the FP4 block scale "
+                "buffers, so reloaded pages would silently lose their scales; "
+                "the host pool also sizes tokens with a full-width dtype "
+                "formula that does not account for FP4's half-width data plus "
+                "separate scale buffers. Please use either HiCache or an FP4 "
+                "KV cache dtype, not both."
+            )
+
         self._validate_hicache_host_memory_mode()
 
         # Step 1: Initial layout-io compatibility normalization.

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1333,6 +1333,16 @@ class TestHiCacheArgs(unittest.TestCase):
         if expected_decode_backend is not None:
             self.assertEqual(args.decode_attention_backend, expected_decode_backend)
 
+    def test_hicache_rejects_fp4_kv_cache_dtype(self):
+        for kv_cache_dtype in ("nvfp4", "fp4_mx_block16"):
+            with self.subTest(kv_cache_dtype=kv_cache_dtype):
+                server_args = self._make_args(enable_hierarchical_cache=True)
+                server_args.kv_cache_dtype = kv_cache_dtype
+                with self.assertRaisesRegex(
+                    ValueError, "not compatible with the hierarchical cache"
+                ):
+                    server_args._handle_hicache()
+
     def test_hicache_io_backend_and_mem_layout_compatibility(self):
         cases = [
             {


### PR DESCRIPTION
## Motivation

Enabling the hierarchical cache (HiCache) together with an FP4 KV cache dtype (`--kv-cache-dtype nvfp4` / `fp4_mx_block16`) currently passes server args validation but silently produces corrupted outputs after write-back/load-back. Two concrete gaps on current main:

1. **Scale buffers are never transferred to/from the host pool.** All L2 write-back/load-back transfers in `python/sglang/srt/mem_cache/pool_host/mha.py` operate exclusively on the packed data buffers (`k_data_ptrs` / `v_data_ptrs`); `k_scale_buffer` / `v_scale_buffer` do not appear in any host transfer set. After a page is written back and later reloaded, its FP4 block scales are lost, so attention consumes packed FP4 data with missing/garbage scales — silent corruption, no error anywhere.
2. **Host pool capacity is computed with a full-width dtype formula.** `MHATokenToKVPoolHost.get_size_per_token()` (`pool_host/mha.py`, the `head_dim * head_num * layer_num * dtype.itemsize * 2` formula) does not account for FP4's half-width packed data plus the separate scale buffers, so the host pool size is also wrong for FP4.

There is no existing guard rejecting this combination (checked on v0.5.17, v0.5.18, and main).

## Modifications

Add a minimal fail-fast guard in `ServerArgs._handle_hicache()` (`python/sglang/srt/server_args.py`): when any of the paths that build a hierarchical-cache host pool is active (`--enable-hierarchical-cache`, decode KV-cache offload, or decode `host_pool` retraction backup) and `--kv-cache-dtype` is `nvfp4` or `fp4_mx_block16`, raise a `ValueError` explaining that the L2 write-back/load-back path does not transfer FP4 scale buffers and that the host pool sizes tokens with a full-width formula, directing users to pick either HiCache or an FP4 KV dtype.

Also add a unit test (`TestHiCacheArgs.test_hicache_rejects_fp4_kv_cache_dtype`) covering both FP4 dtypes.

## Why fail-fast instead of a fix

Full FP4 HiCache support requires host-side scale-buffer transfer in every write-back/load-back path, an FP4-aware host-pool capacity formula, and dedicated correctness validation — each of which is meaningful follow-up work on top of the FP4 KV cache roadmap (#29913). Until then, rejecting the combination at startup is the safe behavior; this mirrors the fail-fast precedent for unsupported NVFP4 KV cache platforms in vLLM (vLLM PR #43669). Related area: #36010.

## Verification

- `python -m py_compile` on both changed files.
- `pytest test/registered/unit/server_args/test_server_args.py`: 150 passed; the 2 failures present (`TestFa4PageSizeAutoForce::test_explicit_prefill_fa4_forces_page_size_128`, `TestGrpcServerArgs::test_start_server_call_site_matches_native_signature`) also fail on unmodified upstream `main` in this CPU-only environment, i.e. pre-existing and unrelated.
- New `TestHiCacheArgs` tests: all pass.
- ruff (repo pre-commit selection `F401,F821,UP037`), black, and isort clean on the changed files.
- No GPU available locally, so runtime behavior was verified by code inspection plus the args-validation unit tests only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32680970506](https://github.com/sgl-project/sglang/actions/runs/32680970506)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32680970320](https://github.com/sgl-project/sglang/actions/runs/32680970320)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32680970426](https://github.com/sgl-project/sglang/actions/runs/32680970426)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->