### PR TITLE
Radix Cache] Add C++ unified radix tree backend with FULL+SWA support

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -599,8 +599,10 @@ class Envs:
     # registry no longer reads this. Kept because a few model/arch call sites
     # still assert on it; do not use in new code.
     SGLANG_ENABLE_UNIFIED_RADIX_TREE = EnvBool(False)
-    # Registered TreeCore backend serving the unified radix cache.
-    SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND = EnvStr("python")
+    # Registered TreeCore backend serving the unified radix cache. ``auto``
+    # selects C++ for the supported FULL/device-only configuration and falls
+    # back to Python for features that have not been ported yet.
+    SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND = EnvStr("auto")
     # TODO(DSV4): @ispobock this has bug on main branch when retract
     SGLANG_OPT_SWA_RADIX_CACHE_COMPACT = EnvBool(False)
     SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT = EnvBool(False)

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -32,6 +32,10 @@ class CacheInitParams:
     enable_metrics: bool = False
     enable_kv_cache_events: bool = False
     enable_session_radix_cache: bool = False
+    # Construction-time signal used by TreeCore auto-selection. HiCache is
+    # attached after UnifiedRadixCache builds its tree, so the core cannot
+    # otherwise know that host-tier operations will be required.
+    enable_hicache: bool = False
 
     enable_mamba_extra_buffer: bool = False
     enable_mamba_extra_buffer_lazy: bool = False

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/common.h
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/common.h
@@ -9,7 +9,10 @@
 
 namespace radix_tree_v2 {
 
-using token_t = std::int32_t;
+// RadixKey is backed by Python's array("q").  Keeping the native token type
+// identical lets pybind expose that storage as a read-only span instead of
+// materializing a std::vector for every tree operation.
+using token_t = std::int64_t;
 using token_vec_t = std::vector<token_t>;
 using token_slice = std::span<const token_t>;
 using NodeHandle = std::size_t;

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/radix_tree.py
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/radix_tree.py
@@ -36,6 +36,7 @@ if TYPE_CHECKING:
             host_size: Optional[int],
             page_size: int,
             write_through_threshold: int,
+            sliding_window_size: int = 0,
         ):
             """
             Initializes the RadixTreeCpp instance.
@@ -44,9 +45,14 @@ if TYPE_CHECKING:
                 host_size (Optional[int]): Size of the radix tree on the CPU. None means no CPU tree.
                 page_size (int): Size of the page for the radix tree.
                 write_through_threshold (int): Threshold for writing through from GPU to CPU.
+                sliding_window_size (int): Sliding-window size; zero disables SWA bookkeeping.
             """
             self.tree = radix_tree_cpp.RadixTree(  # type: ignore
-                disabled, host_size, page_size, write_through_threshold
+                disabled,
+                host_size,
+                page_size,
+                write_through_threshold,
+                sliding_window_size,
             )
 
         def match_prefix(
@@ -99,7 +105,8 @@ if TYPE_CHECKING:
                        These IOhandles require write-through to the CPU in python side.
                     1. The number of indices that are matched on device.
             """
-            return self.tree.writing_through(key, indices)
+            pending, prefix_len, _ = self.tree.writing_through(key, indices)
+            return pending, prefix_len
 
         def loading_onboard(
             self,

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.cpp
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.cpp
@@ -140,4 +140,8 @@ std::size_t RadixTree::total_size() const {
   return m_impl->total_size();
 }
 
+std::vector<at::Tensor> RadixTree::all_values() const {
+  return m_impl->all_values();
+}
+
 }  // namespace radix_tree_v2

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.cpp
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.cpp
@@ -7,9 +7,10 @@
 #include <c10/util/irange.h>
 
 #include <cstddef>
+#include <limits>
 #include <memory>
-#include <queue>
 #include <stdexcept>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -23,21 +24,42 @@ static NodeHandle node2id(TreeNode* node) {
   return node->node_id;
 }
 
-// compare function for the TreeNode pointers based on their time
-// we use LRU, so we want to evict the least recently used nodes
-// since std::priority_queue is a max-heap, we need to reverse the comparison
-static constexpr auto cmp = [](TreeNode* lhs, TreeNode* rhs) { return lhs->time() > rhs->time(); };
+static bool swa_prefix_valid(TreeNode* node, std::size_t sliding_window_size) {
+  std::size_t covered = 0;
+  while (!node->is_root() && covered < sliding_window_size) {
+    if (!node->has_swa()) return false;
+    covered += node->swa_indices().size(0);
+    node = node->parent();
+  }
+  return true;
+}
 
-RadixTree::RadixTree(bool disabled, std::optional<std::size_t> host_size, std::size_t page_size, std::size_t threshold)
-    : m_impl(std::make_unique<Impl>(disabled, host_size.has_value(), page_size, host_size.value_or(0), threshold)) {}
+static std::vector<TreeNode*> root_path(TreeNode* node) {
+  std::vector<TreeNode*> path;
+  while (!node->is_root()) {
+    path.push_back(node);
+    node = node->parent();
+  }
+  std::reverse(path.begin(), path.end());
+  return path;
+}
+
+RadixTree::RadixTree(
+    bool disabled,
+    std::optional<std::size_t> host_size,
+    std::size_t page_size,
+    std::size_t threshold,
+    std::size_t sliding_window_size)
+    : m_impl(
+          std::make_unique<Impl>(
+              disabled, host_size.has_value(), page_size, host_size.value_or(0), threshold, sliding_window_size)) {}
 
 RadixTree::~RadixTree() = default;
 
-std::tuple<std::vector<at::Tensor>, std::size_t, NodeHandle, NodeHandle>
-RadixTree::match_prefix(const token_vec_t& _key) {
+std::tuple<std::vector<at::Tensor>, std::size_t, NodeHandle, NodeHandle> RadixTree::match_prefix(token_slice _key) {
   if (m_impl->disabled) return {};
 
-  const auto key = token_slice{_key.data(), m_impl->align(_key.size())};
+  const auto key = _key.first(m_impl->align(_key.size()));
   const auto [host_node, _] = m_impl->tree_walk(key);
 
   // walk up to the first non-evicted node
@@ -52,15 +74,31 @@ RadixTree::match_prefix(const token_vec_t& _key) {
   return {std::move(indices), host_hit_length, node2id(device_node), node2id(host_node)};
 }
 
+std::tuple<std::vector<at::Tensor>, NodeHandle, std::size_t> RadixTree::match_prefix_swa(token_slice _key) {
+  if (m_impl->disabled) return {};
+  _assert(m_impl->sliding_window_size > 0, "SWA matching is not enabled");
+
+  const auto key = _key.first(m_impl->align(_key.size()));
+  const auto [full_node, full_hit_length] = m_impl->tree_walk(key);
+  auto* best_node = full_node;
+  while (!best_node->is_root() && !swa_prefix_valid(best_node, m_impl->sliding_window_size))
+    best_node = best_node->parent();
+
+  std::vector<at::Tensor> indices;
+  walk_to_root(best_node, [&](TreeNode* n) { indices.push_back(n->device_indices()); });
+  std::reverse(indices.begin(), indices.end());
+  m_impl->touch_swa_window(best_node);
+  return {std::move(indices), node2id(best_node), full_hit_length};
+}
+
 std::vector<at::Tensor> RadixTree::evict(std::size_t num_tokens) {
   if (m_impl->disabled || num_tokens == 0) return {};
-  auto heap = std::priority_queue{cmp, m_impl->collect_leaves_device()};
   std::vector<at::Tensor> evicted_values;
   // evict nodes until we reach the desired number of tokens
   std::size_t num_evict = 0;
-  while (num_evict < num_tokens && !heap.empty()) {
-    const auto node = heap.top();
-    heap.pop();
+  while (num_evict < num_tokens) {
+    const auto node = m_impl->pop_full_lru_candidate();
+    if (node == nullptr) break;
     // when ref_count == 0, can't be writing through
     _assert(node->on_gpu() && node->ref_count == 0);
     if (!node->is_io_free()) continue;  // skip nodes that are undergoing IO (i.e. indices protected)
@@ -68,27 +106,28 @@ std::vector<at::Tensor> RadixTree::evict(std::size_t num_tokens) {
     num_evict += node->length();
     const auto parent = node->parent();
     m_impl->remove_device_node(node);
-    if (parent->is_leaf_device() && parent->ref_count == 0)
-      heap.push(parent);  // push parent to the heap if it is now a free leaf
+    if (!parent->is_root() && parent->is_leaf_device() && parent->ref_count == 0 && parent->swa_ref_count == 0)
+      m_impl->touch_full(parent);
   }
 
   return evicted_values;
 }
 
-std::tuple<std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>>, std::size_t>
-RadixTree::writing_through(const token_vec_t& _key, at::Tensor value) {
+std::tuple<std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>>, std::size_t, NodeHandle>
+RadixTree::writing_through(token_slice _key, at::Tensor value) {
   if (m_impl->disabled) return {};
   _assert(_key.size() == std::size_t(value.size(0)), "Key and value must have the same size");
 
   // just align the key to the page size, clip the unaligned tail
-  const auto key = token_slice{_key.data(), m_impl->align(_key.size())};
+  const auto key = _key.first(m_impl->align(_key.size()));
 
   // walk the tree to find the right place to insert
   const auto [host_node, host_prefix_length] = m_impl->tree_walk(key);
 
   // insert and create a new node if the remaining part of the key is not empty
+  auto* target = host_node;
   if (host_prefix_length != key.size()) {
-    m_impl->create_device_node(
+    target = m_impl->create_device_node(
         host_node,
         {key.begin() + host_prefix_length, key.end()},
         value.slice(/*dim=*/0, host_prefix_length, key.size()));
@@ -100,8 +139,159 @@ RadixTree::writing_through(const token_vec_t& _key, at::Tensor value) {
   std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>> result;
 
   // don't write through if hicache is disabled (no host memory), fast path
-  if (!m_impl->use_hicache) return {std::move(result), host_prefix_length};
+  if (!m_impl->use_hicache) return {std::move(result), host_prefix_length, node2id(target)};
   throw std::runtime_error("Not implemented yet");
+}
+
+std::tuple<
+    std::size_t,
+    NodeHandle,
+    std::vector<at::Tensor>,
+    std::vector<std::tuple<NodeHandle, at::Tensor>>,
+    std::vector<std::tuple<NodeHandle, at::Tensor, at::Tensor>>>
+RadixTree::writing_through_swa(
+    token_slice _key, at::Tensor value, std::size_t prev_prefix_len, std::size_t swa_evicted_seqlen) {
+  if (m_impl->disabled) return {};
+  _assert(m_impl->sliding_window_size > 0, "SWA insertion is not enabled");
+  _assert(_key.size() == std::size_t(value.size(0)), "Key and value must have the same size");
+
+  const auto key = _key.first(m_impl->align(_key.size()));
+  const auto [matched_node, prefix_length] = m_impl->tree_walk(key);
+  std::vector<at::Tensor> duplicate_frees;
+  std::vector<std::tuple<NodeHandle, at::Tensor>> rebuilds;
+  std::vector<std::tuple<NodeHandle, at::Tensor, at::Tensor>> recoveries;
+
+  std::size_t total = 0;
+  for (auto* walked : root_path(matched_node)) {
+    const std::size_t node_len = walked->length();
+    auto incoming = value.slice(0, total, total + node_len);
+    std::size_t consumed_from = node_len;
+
+    // The request already owns [0, prev_prefix_len).  Mirroring
+    // SWAComponent.update_component_on_insert_overlap, do not consume that
+    // protected prefix to recover a tombstone: it may alias the tree's current
+    // FULL value, so replacing and freeing it would release live request KV.
+    const bool can_consume_for_swa = prev_prefix_len < total + node_len;
+    if (!walked->has_swa() && can_consume_for_swa) {
+      if (swa_evicted_seqlen <= total) {
+        if (walked->ref_count > 0) {
+          recoveries.emplace_back(node2id(walked), walked->device_indices(), incoming);
+        } else {
+          auto old_full = walked->device_indices();
+          walked->_unsafe_device_indices() = incoming.clone();
+          duplicate_frees.push_back(old_full);
+          rebuilds.emplace_back(node2id(walked), walked->device_indices());
+        }
+        consumed_from = 0;
+      } else if (swa_evicted_seqlen < total + node_len) {
+        const std::size_t start = swa_evicted_seqlen - total;
+        m_impl->split_node(walked, start);
+        auto incoming_tail = incoming.slice(0, start, node_len);
+        if (walked->ref_count > 0) {
+          recoveries.emplace_back(node2id(walked), walked->device_indices(), incoming_tail);
+        } else {
+          auto old_full = walked->device_indices();
+          walked->_unsafe_device_indices() = incoming_tail.clone();
+          duplicate_frees.push_back(old_full);
+          rebuilds.emplace_back(node2id(walked), walked->device_indices());
+        }
+        consumed_from = start;
+      }
+    }
+
+    const std::size_t duplicate_start = prev_prefix_len > total ? std::min(node_len, prev_prefix_len - total) : 0;
+    if (duplicate_start < consumed_from) duplicate_frees.push_back(incoming.slice(0, duplicate_start, consumed_from));
+    m_impl->touch_full(walked);
+    total += node_len;
+  }
+
+  TreeNode* target = matched_node;
+  bool is_new_leaf = false;
+  if (prefix_length != key.size()) {
+    target = m_impl->create_device_node(
+        matched_node, {key.begin() + prefix_length, key.end()}, value.slice(0, prefix_length, key.size()));
+    is_new_leaf = true;
+  }
+
+  if (is_new_leaf) {
+    const std::size_t node_start = prefix_length;
+    const std::size_t leaf_len = target->length();
+    if (swa_evicted_seqlen < node_start + leaf_len) {
+      const std::size_t split_pos = swa_evicted_seqlen > node_start ? swa_evicted_seqlen - node_start : 0;
+      if (split_pos > 0) m_impl->split_node(target, split_pos);
+
+      const std::size_t tail_size =
+          ((m_impl->sliding_window_size + m_impl->page_size - 1) / m_impl->page_size) * m_impl->page_size;
+      if (target->length() > tail_size) {
+        auto* capped_parent = m_impl->split_node(target, target->length() - tail_size);
+        rebuilds.emplace_back(node2id(capped_parent), capped_parent->device_indices());
+      }
+      rebuilds.emplace_back(node2id(target), target->device_indices());
+    }
+  }
+
+  m_impl->touch_swa_window(target);
+  return {prefix_length, node2id(target), std::move(duplicate_frees), std::move(rebuilds), std::move(recoveries)};
+}
+
+std::tuple<std::vector<at::Tensor>, NodeHandle, std::size_t, std::optional<std::size_t>, std::vector<NodeHandle>>
+RadixTree::match_node_and_lock(NodeHandle node_id, bool lock_full, bool lock_swa) {
+  auto [indices, best_node, best_prefix_length, full_hit_length, swa_uuid, skipped] =
+      match_node_range_and_lock(node_id, 0, std::numeric_limits<std::size_t>::max(), lock_full, lock_swa);
+  return {std::move(indices), best_node, full_hit_length, swa_uuid, std::move(skipped)};
+}
+
+std::tuple<
+    std::vector<at::Tensor>,
+    NodeHandle,
+    std::size_t,
+    std::size_t,
+    std::optional<std::size_t>,
+    std::vector<NodeHandle>>
+RadixTree::match_node_range_and_lock(
+    NodeHandle node_id, std::size_t range_start, std::size_t range_end, bool lock_full, bool lock_swa) {
+  if (m_impl->disabled) return {};
+  _assert(range_start <= range_end, "Invalid inserted-prefix result range");
+  ++m_impl->m_node_match_calls;
+  auto* target = m_impl->id2node(node_id);
+  m_impl->touch_full_path(target);
+
+  std::size_t full_hit_length = 0;
+  walk_to_root(target, [&](TreeNode* node) { full_hit_length += node->length(); });
+
+  auto* best_node = target;
+  if (m_impl->sliding_window_size > 0) {
+    while (!best_node->is_root() && !swa_prefix_valid(best_node, m_impl->sliding_window_size))
+      best_node = best_node->parent();
+    m_impl->touch_swa_window(best_node);
+  } else {
+    _assert(!lock_swa, "Cannot lock SWA when SWA is disabled");
+  }
+
+  const auto path = root_path(best_node);
+  std::size_t best_prefix_length = 0;
+  for (const auto* node : path)
+    best_prefix_length += node->length();
+
+  const auto clipped_start = std::min(range_start, best_prefix_length);
+  const auto clipped_end = std::min(range_end, best_prefix_length);
+  std::vector<at::Tensor> indices;
+  if (clipped_start < clipped_end) {
+    std::size_t node_start = 0;
+    for (auto* node : path) {
+      const auto node_end = node_start + node->length();
+      if (node_end > clipped_start && node_start < clipped_end) {
+        const auto slice_start = clipped_start > node_start ? clipped_start - node_start : 0;
+        const auto slice_end = std::min(clipped_end, node_end) - node_start;
+        indices.push_back(node->device_indices().slice(0, slice_start, slice_end));
+      }
+      node_start = node_end;
+      if (node_start >= clipped_end) break;
+    }
+  }
+
+  auto [swa_uuid, skipped] = lock_ref_swa(node2id(best_node), lock_full, lock_swa);
+  return {std::move(indices), node2id(best_node), best_prefix_length, full_hit_length, swa_uuid, std::move(skipped)};
 }
 
 std::tuple<IOTicket, std::vector<at::Tensor>> RadixTree::loading_onboard(NodeHandle, at::Tensor) {
@@ -128,6 +318,140 @@ void RadixTree::lock_ref(NodeHandle node_id, bool increment) {
   m_impl->lock_ref(node_id, increment);
 }
 
+std::tuple<std::optional<std::size_t>, std::vector<NodeHandle>>
+RadixTree::lock_ref_swa(NodeHandle node_id, bool lock_full, bool lock_swa) {
+  if (m_impl->disabled) return {};
+  auto* node = m_impl->id2node(node_id);
+  if (lock_full) m_impl->lock_ref(node, true);
+
+  std::optional<std::size_t> boundary_uuid;
+  std::vector<NodeHandle> skipped;
+  if (lock_swa) {
+    std::size_t covered = 0;
+    auto* cur = node;
+    while (!cur->is_root() && covered < m_impl->sliding_window_size) {
+      if (!cur->has_swa()) {
+        skipped.push_back(node2id(cur));
+        cur = cur->parent();
+        continue;
+      }
+      m_impl->lock_swa(cur, true);
+      covered += cur->swa_indices().size(0);
+      if (covered >= m_impl->sliding_window_size) {
+        if (!cur->swa_uuid.has_value()) cur->swa_uuid = m_impl->next_swa_uuid();
+        boundary_uuid = cur->swa_uuid;
+      }
+      cur = cur->parent();
+    }
+  }
+  return {boundary_uuid, std::move(skipped)};
+}
+
+void RadixTree::unlock_ref_swa(
+    NodeHandle node_id,
+    bool unlock_full,
+    bool unlock_swa,
+    std::optional<std::size_t> swa_uuid,
+    const std::vector<NodeHandle>& skip_swa_nodes) {
+  if (m_impl->disabled) return;
+  auto* node = m_impl->id2node(node_id);
+  if (unlock_full) m_impl->lock_ref(node, false);
+  if (!unlock_swa) return;
+
+  std::unordered_set<NodeHandle> skipped(skip_swa_nodes.begin(), skip_swa_nodes.end());
+  auto* cur = node;
+  bool keep_going = true;
+  while (!cur->is_root() && keep_going) {
+    if (!skipped.contains(node2id(cur)) && cur->swa_ref_count > 0) m_impl->lock_swa(cur, false);
+    if (swa_uuid.has_value() && cur->swa_uuid == swa_uuid) keep_going = false;
+    cur = cur->parent();
+  }
+}
+
+std::tuple<std::vector<at::Tensor>, std::size_t>
+RadixTree::unlock_swa_only(NodeHandle node_id, std::optional<std::size_t> swa_uuid) {
+  if (m_impl->disabled) return {};
+  std::vector<at::Tensor> frees;
+  std::size_t freed = 0;
+  auto* cur = m_impl->id2node(node_id);
+  bool keep_going = true;
+  while (!cur->is_root() && keep_going) {
+    const bool is_boundary = swa_uuid.has_value() && cur->swa_uuid == swa_uuid;
+    if (cur->has_swa() && cur->swa_ref_count > 0) {
+      m_impl->lock_swa(cur, false);
+      if (cur->swa_ref_count == 0 && cur->ref_count == 0 && cur->is_leaf_device()) {
+        frees.push_back(cur->device_indices());
+        freed += cur->length();
+        m_impl->clear_swa_value(cur);
+      }
+    }
+    if (is_boundary) keep_going = false;
+    cur = cur->parent();
+  }
+  return {std::move(frees), freed};
+}
+
+void RadixTree::set_swa_value(NodeHandle node_id, at::Tensor value) {
+  if (m_impl->disabled) return;
+  m_impl->set_swa_value(m_impl->id2node(node_id), std::move(value));
+}
+
+at::Tensor RadixTree::get_swa_value(NodeHandle node_id) const {
+  if (m_impl->disabled) return {};
+  return m_impl->id2node(node_id)->swa_indices();
+}
+
+std::tuple<std::vector<at::Tensor>, std::vector<at::Tensor>, std::size_t, std::size_t>
+RadixTree::evict_component(std::size_t component_type, std::size_t num_tokens) {
+  if (m_impl->disabled || num_tokens == 0) return {};
+  _assert(component_type <= 1, "Only FULL and SWA eviction are supported");
+
+  std::vector<at::Tensor> full_frees;
+  std::vector<at::Tensor> swa_frees;
+  std::size_t full_evicted = 0;
+  std::size_t swa_evicted = 0;
+
+  if (component_type == 0) {
+    while (full_evicted < num_tokens) {
+      auto* node = m_impl->pop_full_lru_candidate();
+      if (node == nullptr) break;
+      const auto* parent = node->parent();
+      full_frees.push_back(node->device_indices());
+      full_evicted += node->length();
+      if (node->has_swa()) {
+        swa_frees.push_back(node->device_indices());
+        swa_evicted += node->length();
+      }
+      m_impl->remove_device_node(node);
+      auto* mutable_parent = const_cast<TreeNode*>(parent);
+      if (!mutable_parent->is_root() && mutable_parent->is_leaf_device() && mutable_parent->ref_count == 0 &&
+          mutable_parent->swa_ref_count == 0)
+        m_impl->touch_full(mutable_parent);
+    }
+  } else {
+    while (swa_evicted < num_tokens) {
+      TreeNode* victim = m_impl->pop_swa_lru_candidate();
+      if (victim == nullptr) break;
+
+      if (victim->is_leaf_device() && victim->ref_count == 0) {
+        auto* parent = victim->parent();
+        full_frees.push_back(victim->device_indices());
+        full_evicted += victim->length();
+        swa_frees.push_back(victim->device_indices());
+        swa_evicted += victim->length();
+        m_impl->remove_device_node(victim);
+        if (!parent->is_root() && parent->is_leaf_device() && parent->ref_count == 0 && parent->swa_ref_count == 0)
+          m_impl->touch_full(parent);
+      } else {
+        swa_frees.push_back(victim->device_indices());
+        swa_evicted += victim->length();
+        m_impl->clear_swa_value(victim);
+      }
+    }
+  }
+  return {std::move(full_frees), std::move(swa_frees), full_evicted, swa_evicted};
+}
+
 std::size_t RadixTree::evictable_size() const {
   return m_impl->evictable_size();
 }
@@ -140,8 +464,28 @@ std::size_t RadixTree::total_size() const {
   return m_impl->total_size();
 }
 
+std::size_t RadixTree::component_evictable_size(std::size_t component_type) const {
+  return m_impl->component_evictable_size(component_type);
+}
+
+std::size_t RadixTree::component_protected_size(std::size_t component_type) const {
+  return m_impl->component_protected_size(component_type);
+}
+
 std::vector<at::Tensor> RadixTree::all_values() const {
   return m_impl->all_values();
+}
+
+std::unordered_map<std::string, std::uint64_t> RadixTree::debug_stats() const {
+  return {
+      {"tree_walk_calls", m_impl->m_tree_walk_calls},
+      {"tree_walk_tokens", m_impl->m_tree_walk_tokens},
+      {"node_match_calls", m_impl->m_node_match_calls},
+      {"full_lru_pops", m_impl->m_full_lru_pops},
+      {"swa_lru_pops", m_impl->m_swa_lru_pops},
+      {"lru_stale_pops", m_impl->m_lru_stale_pops},
+      {"lru_rebuilds", m_impl->m_lru_rebuilds},
+  };
 }
 
 }  // namespace radix_tree_v2

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.h
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.h
@@ -6,6 +6,7 @@
 #include <memory>
 #include <optional>
 #include <tuple>
+#include <unordered_map>
 #include <vector>
 
 #include "common.h"
@@ -14,7 +15,12 @@ namespace radix_tree_v2 {
 
 struct RadixTree {
  public:
-  RadixTree(bool disabled, std::optional<std::size_t> host_size, std::size_t page_size, std::size_t threshold);
+  RadixTree(
+      bool disabled,
+      std::optional<std::size_t> host_size,
+      std::size_t page_size,
+      std::size_t threshold,
+      std::size_t sliding_window_size = 0);
   ~RadixTree();
 
   // Trees should not be copied or moved, as they manage their own memory and state.
@@ -24,14 +30,53 @@ struct RadixTree {
   RadixTree& operator=(RadixTree&&) = delete;
 
   /// @return (device indices that are matched, host indices length, device node, host node)
-  std::tuple<std::vector<at::Tensor>, std::size_t, NodeHandle, NodeHandle> match_prefix(const token_vec_t& key);
+  std::tuple<std::vector<at::Tensor>, std::size_t, NodeHandle, NodeHandle> match_prefix(token_slice key);
+  std::tuple<std::vector<at::Tensor>, NodeHandle, std::size_t> match_prefix_swa(token_slice key);
   /// @return Device indices that need to be evicted (on python side).
   std::vector<at::Tensor> evict(std::size_t num_tokens);
   /// @brief (Un-)Lock a node.
   void lock_ref(NodeHandle node_id, bool increment /* increment or decrement */);
+  std::tuple<std::optional<std::size_t>, std::vector<NodeHandle>>
+  lock_ref_swa(NodeHandle node_id, bool lock_full, bool lock_swa);
+  void unlock_ref_swa(
+      NodeHandle node_id,
+      bool unlock_full,
+      bool unlock_swa,
+      std::optional<std::size_t> swa_uuid,
+      const std::vector<NodeHandle>& skip_swa_nodes);
+  std::tuple<std::vector<at::Tensor>, std::size_t>
+  unlock_swa_only(NodeHandle node_id, std::optional<std::size_t> swa_uuid);
   /// @brief Update new key-value pair and try to perform write-through.
-  std::tuple<std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>>, std::size_t>
-  writing_through(const token_vec_t& key, at::Tensor value);
+  std::tuple<std::vector<std::tuple<IOTicket, at::Tensor, at::Tensor>>, std::size_t, NodeHandle>
+  writing_through(token_slice key, at::Tensor value);
+  std::tuple<
+      std::size_t,
+      NodeHandle,
+      std::vector<at::Tensor>,
+      std::vector<std::tuple<NodeHandle, at::Tensor>>,
+      std::vector<std::tuple<NodeHandle, at::Tensor, at::Tensor>>>
+  writing_through_swa(token_slice key, at::Tensor value, std::size_t prev_prefix_len, std::size_t swa_evicted_seqlen);
+  /// Collect an already-inserted prefix and acquire its FULL/SWA locks in one
+  /// native call.  This avoids a second key traversal and Python/C++ crossing.
+  std::tuple<std::vector<at::Tensor>, NodeHandle, std::size_t, std::optional<std::size_t>, std::vector<NodeHandle>>
+  match_node_and_lock(NodeHandle node_id, bool lock_full, bool lock_swa);
+  /// Collect only [range_start, range_end) from an already inserted prefix,
+  /// then acquire its locks.  best_prefix_length describes the complete
+  /// usable prefix, allowing Python to reuse the insertion value for the
+  /// untouched ranges instead of concatenating the whole root path again.
+  std::tuple<
+      std::vector<at::Tensor>,
+      NodeHandle,
+      std::size_t,
+      std::size_t,
+      std::optional<std::size_t>,
+      std::vector<NodeHandle>>
+  match_node_range_and_lock(
+      NodeHandle node_id, std::size_t range_start, std::size_t range_end, bool lock_full, bool lock_swa);
+  void set_swa_value(NodeHandle node_id, at::Tensor value);
+  at::Tensor get_swa_value(NodeHandle node_id) const;
+  std::tuple<std::vector<at::Tensor>, std::vector<at::Tensor>, std::size_t, std::size_t>
+  evict_component(std::size_t component_type, std::size_t num_tokens);
   /// @brief Load to device from host within a range of nodes.
   std::tuple<IOTicket, std::vector<at::Tensor>> loading_onboard(NodeHandle host_id, at::Tensor indices);
   /// @brief Commit a transaction of write-through.
@@ -47,8 +92,11 @@ struct RadixTree {
   std::size_t protected_size() const;
   /// @return How many size are used on device.
   std::size_t total_size() const;
+  std::size_t component_evictable_size(std::size_t component_type) const;
+  std::size_t component_protected_size(std::size_t component_type) const;
   /// @return All device indices owned by the tree, grouped by tree node.
   std::vector<at::Tensor> all_values() const;
+  std::unordered_map<std::string, std::uint64_t> debug_stats() const;
 
   /// @brief Print debug information of the tree.
   void debug_print() const;

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.h
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2.h
@@ -47,6 +47,8 @@ struct RadixTree {
   std::size_t protected_size() const;
   /// @return How many size are used on device.
   std::size_t total_size() const;
+  /// @return All device indices owned by the tree, grouped by tree node.
+  std::vector<at::Tensor> all_values() const;
 
   /// @brief Print debug information of the tree.
   void debug_print() const;

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_binding.cpp
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_binding.cpp
@@ -1,30 +1,154 @@
+#include <ATen/ops/cat.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <torch/extension.h>
 
 #include <cstddef>
+#include <cstdint>
 #include <optional>
+#include <stdexcept>
 
 #include "tree_v2.h"
+
+namespace {
+
+radix_tree_v2::token_slice token_buffer(const pybind11::buffer& key, const std::optional<std::size_t> key_len) {
+  namespace py = pybind11;
+  const py::buffer_info info = key.request();
+  if (info.ndim != 1 || info.itemsize != sizeof(radix_tree_v2::token_t) || info.strides[0] != info.itemsize) {
+    throw std::invalid_argument("radix key must be a contiguous one-dimensional int64 buffer");
+  }
+  const auto available = static_cast<std::size_t>(info.shape[0]);
+  const auto length = key_len.value_or(available);
+  if (length > available) {
+    throw std::invalid_argument("radix key length exceeds its backing buffer");
+  }
+  return {static_cast<const radix_tree_v2::token_t*>(info.ptr), length};
+}
+
+std::optional<at::Tensor> flatten_chunks(std::vector<at::Tensor> chunks) {
+  if (chunks.empty()) return std::nullopt;
+  if (chunks.size() == 1) return std::move(chunks.front());
+  return at::cat(chunks);
+}
+
+}  // namespace
 
 PYBIND11_MODULE(radix_tree_cpp, m) {
   using namespace radix_tree_v2;
   namespace py = pybind11;
   py::class_<RadixTree>(m, "RadixTree")
       .def(
-          py::init<bool, std::optional<std::size_t>, std::size_t, std::size_t>(),
+          py::init<bool, std::optional<std::size_t>, std::size_t, std::size_t, std::size_t>(),
           py::arg("disabled"),
           py::arg("host_size"),
           py::arg("page_size"),
-          py::arg("write_through_threshold"))
-      .def("match_prefix", &RadixTree::match_prefix)
+          py::arg("write_through_threshold"),
+          py::arg("sliding_window_size") = 0)
+      .def(
+          "match_prefix",
+          [](RadixTree& tree, const py::buffer& key, std::optional<std::size_t> key_len) {
+            return tree.match_prefix(token_buffer(key, key_len));
+          },
+          py::arg("key"),
+          py::arg("key_len") = py::none())
+      .def(
+          "match_prefix_flat",
+          [](RadixTree& tree, const py::buffer& key, std::optional<std::size_t> key_len) {
+            auto [chunks, host_hit_length, device_node, host_node] = tree.match_prefix(token_buffer(key, key_len));
+            return std::make_tuple(flatten_chunks(std::move(chunks)), host_hit_length, device_node, host_node);
+          },
+          py::arg("key"),
+          py::arg("key_len") = py::none())
+      .def(
+          "match_prefix_swa",
+          [](RadixTree& tree, const py::buffer& key, std::optional<std::size_t> key_len) {
+            return tree.match_prefix_swa(token_buffer(key, key_len));
+          },
+          py::arg("key"),
+          py::arg("key_len") = py::none())
+      .def(
+          "match_prefix_swa_flat",
+          [](RadixTree& tree, const py::buffer& key, std::optional<std::size_t> key_len) {
+            auto [chunks, device_node, full_hit_length] = tree.match_prefix_swa(token_buffer(key, key_len));
+            return std::make_tuple(flatten_chunks(std::move(chunks)), device_node, full_hit_length);
+          },
+          py::arg("key"),
+          py::arg("key_len") = py::none())
       .def("evict", &RadixTree::evict)
       .def("lock_ref", &RadixTree::lock_ref)
+      .def("lock_ref_swa", &RadixTree::lock_ref_swa)
+      .def("unlock_ref_swa", &RadixTree::unlock_ref_swa)
+      .def("unlock_swa_only", &RadixTree::unlock_swa_only)
       .def("evictable_size", &RadixTree::evictable_size)
       .def("protected_size", &RadixTree::protected_size)
       .def("total_size", &RadixTree::total_size)
+      .def("component_evictable_size", &RadixTree::component_evictable_size)
+      .def("component_protected_size", &RadixTree::component_protected_size)
       .def("all_values", &RadixTree::all_values)
-      .def("writing_through", &RadixTree::writing_through)
+      .def("debug_stats", &RadixTree::debug_stats)
+      .def(
+          "writing_through",
+          [](RadixTree& tree, const py::buffer& key, at::Tensor value, std::optional<std::size_t> key_len) {
+            return tree.writing_through(token_buffer(key, key_len), std::move(value));
+          },
+          py::arg("key"),
+          py::arg("value"),
+          py::arg("key_len") = py::none())
+      .def(
+          "writing_through_swa",
+          [](RadixTree& tree,
+             const py::buffer& key,
+             at::Tensor value,
+             std::size_t prev_prefix_len,
+             std::size_t swa_evicted_seqlen,
+             std::optional<std::size_t> key_len) {
+            return tree.writing_through_swa(
+                token_buffer(key, key_len), std::move(value), prev_prefix_len, swa_evicted_seqlen);
+          },
+          py::arg("key"),
+          py::arg("value"),
+          py::arg("prev_prefix_len"),
+          py::arg("swa_evicted_seqlen"),
+          py::arg("key_len") = py::none())
+      .def("match_node_and_lock", &RadixTree::match_node_and_lock)
+      .def(
+          "match_node_and_lock_flat",
+          [](RadixTree& tree, NodeHandle node_id, bool lock_full, bool lock_swa) {
+            auto [chunks, best_node, full_hit_length, swa_uuid, skipped] =
+                tree.match_node_and_lock(node_id, lock_full, lock_swa);
+            return std::make_tuple(
+                flatten_chunks(std::move(chunks)), best_node, full_hit_length, swa_uuid, std::move(skipped));
+          },
+          py::arg("node_id"),
+          py::arg("lock_full"),
+          py::arg("lock_swa"))
+      .def(
+          "match_node_range_and_lock_flat",
+          [](RadixTree& tree,
+             NodeHandle node_id,
+             std::size_t range_start,
+             std::size_t range_end,
+             bool lock_full,
+             bool lock_swa) {
+            auto [chunks, best_node, best_prefix_length, full_hit_length, swa_uuid, skipped] =
+                tree.match_node_range_and_lock(node_id, range_start, range_end, lock_full, lock_swa);
+            return std::make_tuple(
+                flatten_chunks(std::move(chunks)),
+                best_node,
+                best_prefix_length,
+                full_hit_length,
+                swa_uuid,
+                std::move(skipped));
+          },
+          py::arg("node_id"),
+          py::arg("range_start"),
+          py::arg("range_end"),
+          py::arg("lock_full"),
+          py::arg("lock_swa"))
+      .def("set_swa_value", &RadixTree::set_swa_value)
+      .def("get_swa_value", &RadixTree::get_swa_value)
+      .def("evict_component", &RadixTree::evict_component)
       .def("loading_onboard", &RadixTree::loading_onboard)
       .def("commit_writing_through", &RadixTree::commit_writing_through)
       .def("commit_loading_onboard", &RadixTree::commit_loading_onboard)

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_binding.cpp
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_binding.cpp
@@ -23,6 +23,7 @@ PYBIND11_MODULE(radix_tree_cpp, m) {
       .def("evictable_size", &RadixTree::evictable_size)
       .def("protected_size", &RadixTree::protected_size)
       .def("total_size", &RadixTree::total_size)
+      .def("all_values", &RadixTree::all_values)
       .def("writing_through", &RadixTree::writing_through)
       .def("loading_onboard", &RadixTree::loading_onboard)
       .def("commit_writing_through", &RadixTree::commit_writing_through)

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_impl.h
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_impl.h
@@ -4,7 +4,9 @@
 #include <chrono>
 #include <cstddef>
 #include <iosfwd>
+#include <list>
 #include <memory>
+#include <stdexcept>
 #include <unordered_map>
 #include <utility>
 #include <vector>
@@ -19,21 +21,32 @@ using node_iterator_t = typename TreeNode::iterator_t;
 
 struct RadixTree::Impl {
  public:
-  Impl(bool disabled, bool use_hicache, std::size_t page_size, std::size_t host_size, std::size_t threshold)
+  using lru_list_t = std::list<TreeNode*>;
+  using lru_position_map_t = std::unordered_map<NodeHandle, lru_list_t::iterator>;
+
+  Impl(
+      bool disabled,
+      bool use_hicache,
+      std::size_t page_size,
+      std::size_t host_size,
+      std::size_t threshold,
+      std::size_t sliding_window_size)
       : m_root(/*node_id_=*/0),
         m_evictable_size(0),
         m_protected_size(0),
-        m_cached_vec(),
+        m_swa_evictable_size(0),
+        m_swa_protected_size(0),
         m_node_map(),
         m_node_counter(1),  // start from 1 to avoid confusion with root node
+        m_swa_uuid_counter(1),
         disabled(disabled),
         use_hicache(use_hicache),
         page_size(page_size),
-        threshold(threshold) {
+        threshold(threshold),
+        sliding_window_size(sliding_window_size) {
     _assert(page_size > 0, "Page size must be greater than zero");
     _assert(use_hicache == (host_size > 0), "Hierarchical cache is enabled iff host size > 0");
     m_root.ref_count = 1;                  // root node is always protected
-    m_cached_vec.reserve(page_size);       // to avoid repeated allocations
     m_node_map[m_root.node_id] = &m_root;  // add root to the map
   }
 
@@ -51,7 +64,21 @@ struct RadixTree::Impl {
     add_child(new_node, std::move(old_node_ptr));
     add_child(parent, std::move(new_node_ptr), iterator);
     m_node_map[new_node->node_id] = new_node;  // add to the map
+    // Invalidate the old node's lazy heap entries and register both halves.
+    touch_full(new_node);
+    touch_full(old_node);
+    touch_swa(new_node);
+    touch_swa(old_node);
     return new_node;
+  }
+
+  TreeNode* split_node(TreeNode* old_node, std::size_t prefix_length) {
+    auto* parent = old_node->parent();
+    const auto tokens = token_slice{old_node->_unsafe_tokens()};
+    _assert(tokens.size() >= page_size, "Node key should be at least page-sized");
+    auto it = parent->find_child(tokens.first(page_size));
+    _assert(it != parent->end() && it->second.get() == old_node, "Child node not found while splitting");
+    return split_node(it, prefix_length);
   }
 
   // node: x -> [GPU]
@@ -63,15 +90,26 @@ struct RadixTree::Impl {
     m_evictable_size += new_node_ptr->length();
     add_child(parent, std::move(new_node_ptr));
     m_node_map[new_node->node_id] = new_node;  // add to the map
+    touch_full(new_node);
     return new_node;
   }
 
   // node: [GPU] -> x
   void remove_device_node(TreeNode* node) {
     _assert(node->on_gpu_only() && node->ref_count == 0);
+    _assert(node->swa_ref_count == 0, "Cannot remove a node with a protected SWA value");
     m_evictable_size -= node->length();
-    node->parent()->erase_child(get_key(node));
-    m_node_map.erase(node->node_id);  // remove from the map
+    if (node->has_swa()) m_swa_evictable_size -= node->length();
+    auto* parent = node->parent();
+    const auto node_id = node->node_id;
+    erase_lru_entry(node, /*swa=*/false);
+    erase_lru_entry(node, /*swa=*/true);
+    const auto tokens = token_slice{node->_unsafe_tokens()};
+    _assert(tokens.size() >= page_size, "Node key should be at least page-sized");
+    auto iterator = parent->find_child(tokens.first(page_size));
+    _assert(iterator != parent->end() && iterator->second.get() == node, "Child node not found while removing");
+    m_node_map.erase(node_id);  // invalidate lazy LRU entries before destruction
+    parent->erase_child(iterator);
   }
 
   /**
@@ -82,13 +120,15 @@ struct RadixTree::Impl {
    */
   std::pair<TreeNode*, std::size_t> tree_walk(token_slice key) {
     _assert(key.size() % page_size == 0, "Key should be page-aligned");
+    ++m_tree_walk_calls;
+    m_tree_walk_tokens += key.size();
 
     std::size_t total_prefix_length = 0;
     TreeNode* node = &m_root;
 
     const auto now = std::chrono::steady_clock::now();
     while (key.size() > 0) {
-      const auto iterator = node->find_child(get_key(key));
+      const auto iterator = node->find_child(key.first(page_size));
       if (iterator == node->end()) break;
 
       // walk to the child node
@@ -105,7 +145,7 @@ struct RadixTree::Impl {
       }
 
       // we have matched the whole key, continue to the next node
-      node->access(now);
+      touch_full(node, now);
       key = key.subspan(prefix_length);
     }
 
@@ -118,7 +158,7 @@ struct RadixTree::Impl {
 
     auto process_node = [&](TreeNode* node) {
       if (node->is_leaf()) {
-        if (node->ref_count == 0) {
+        if (node->ref_count == 0 && node->swa_ref_count == 0) {
           leaves.push_back(node);
         }
       } else {
@@ -148,7 +188,7 @@ struct RadixTree::Impl {
       if (!node->on_gpu()) return;  // skip nodes that are not on GPU
 
       if (node->is_leaf_device()) {
-        if (node->ref_count == 0) {
+        if (node->ref_count == 0 && node->swa_ref_count == 0) {
           leaves.push_back(node);
         }
       } else {
@@ -169,6 +209,82 @@ struct RadixTree::Impl {
     return leaves;
   }
 
+  std::vector<TreeNode*> collect_all_nodes() const {
+    std::vector<TreeNode*> nodes;
+    std::vector<TreeNode*> stack;
+    for (const auto& [_, child] : m_root)
+      stack.push_back(child.get());
+    while (!stack.empty()) {
+      auto* node = stack.back();
+      stack.pop_back();
+      nodes.push_back(node);
+      for (const auto& [_, child] : *node)
+        stack.push_back(child.get());
+    }
+    return nodes;
+  }
+
+  void touch_full(TreeNode* node, TreeNode::timestamp_t now = std::chrono::steady_clock::now()) {
+    if (node->is_root()) return;
+    node->access(now);
+    if (node->on_gpu()) {
+      move_lru_to_mru(node, /*swa=*/false);
+    }
+  }
+
+  void touch_full_path(TreeNode* node) {
+    const auto now = std::chrono::steady_clock::now();
+    walk_to_root(node, [&](TreeNode* current) { touch_full(current, now); });
+  }
+
+  void touch_swa(TreeNode* node, TreeNode::timestamp_t now = std::chrono::steady_clock::now()) {
+    if (node->is_root() || !node->has_swa()) return;
+    node->access_swa(now);
+    move_lru_to_mru(node, /*swa=*/true);
+  }
+
+  void touch_swa_window(TreeNode* node) {
+    std::size_t covered = 0;
+    const auto now = std::chrono::steady_clock::now();
+    while (!node->is_root() && covered < sliding_window_size) {
+      if (node->has_swa()) {
+        touch_swa(node, now);
+        covered += node->swa_indices().size(0);
+      }
+      node = node->parent();
+    }
+  }
+
+  TreeNode* pop_full_lru_candidate() {
+    while (!m_full_lru.empty()) {
+      auto* node = m_full_lru.back();
+      m_full_lru.pop_back();
+      m_full_lru_positions.erase(node->node_id);
+      ++m_full_lru_pops;
+      if (!node->on_gpu() || node->ref_count != 0 || node->swa_ref_count != 0 || !node->is_leaf_device() ||
+          !node->is_io_free())
+        continue;
+      return node;
+    }
+    return nullptr;
+  }
+
+  TreeNode* pop_swa_lru_candidate() {
+    while (!m_swa_lru.empty()) {
+      auto* node = m_swa_lru.back();
+      m_swa_lru.pop_back();
+      m_swa_lru_positions.erase(node->node_id);
+      ++m_swa_lru_pops;
+      if (!node->has_swa() || node->swa_ref_count != 0) continue;
+      return node;
+    }
+    return nullptr;
+  }
+
+  std::size_t next_swa_uuid() {
+    return m_swa_uuid_counter++;
+  }
+
   void lock_ref(TreeNode* node, bool increment) {
     if (node->is_root()) return;  // skip root node
     _assert(node->on_gpu(), "Cannot lock reference on an evicted node");
@@ -187,8 +303,56 @@ struct RadixTree::Impl {
         if (n->ref_count == 0) {
           m_protected_size -= n->length();
           m_evictable_size += n->length();
+          touch_full(n);
         }
       });
+  }
+
+  void lock_swa(TreeNode* node, bool increment) {
+    _assert(node->has_swa(), "Cannot lock a SWA tombstone");
+    if (increment) {
+      if (node->swa_ref_count == 0) {
+        m_swa_evictable_size -= node->length();
+        m_swa_protected_size += node->length();
+      }
+      node->swa_ref_count++;
+    } else {
+      _assert(node->swa_ref_count != 0, "Cannot decrement SWA reference count = zero");
+      node->swa_ref_count--;
+      if (node->swa_ref_count == 0) {
+        m_swa_protected_size -= node->length();
+        m_swa_evictable_size += node->length();
+        touch_swa(node);
+        // FULL eviction also requires swa_ref_count == 0.  Its prior heap
+        // entry may have been consumed while this SWA lock was held.
+        touch_full(node);
+      }
+    }
+  }
+
+  void set_swa_value(TreeNode* node, at::Tensor value) {
+    _assert(!node->is_root(), "Root cannot own a SWA value");
+    _assert(!node->has_swa(), "SWA value already exists on node");
+    _assert(static_cast<std::size_t>(value.size(0)) == node->length(), "SWA value length mismatch");
+    node->_unsafe_swa_indices() = std::move(value);
+    if (node->swa_ref_count == 0)
+      m_swa_evictable_size += node->length();
+    else
+      m_swa_protected_size += node->length();
+    touch_swa(node);
+  }
+
+  void clear_swa_value(TreeNode* node) {
+    if (!node->has_swa()) return;
+    erase_lru_entry(node, /*swa=*/true);
+    if (node->swa_ref_count == 0)
+      m_swa_evictable_size -= node->length();
+    else
+      m_swa_protected_size -= node->length();
+    node->_unsafe_swa_indices() = at::Tensor();
+    node->swa_ref_count = 0;
+    node->swa_uuid.reset();
+    touch_full(node);
   }
 
   void lock_ref(NodeHandle node_ptr, bool increment) {
@@ -237,6 +401,18 @@ struct RadixTree::Impl {
     return m_protected_size;
   }
 
+  std::size_t component_evictable_size(std::size_t component_type) const {
+    if (component_type == 0) return m_evictable_size;
+    if (component_type == 1) return m_swa_evictable_size;
+    return 0;
+  }
+
+  std::size_t component_protected_size(std::size_t component_type) const {
+    if (component_type == 0) return m_protected_size;
+    if (component_type == 1) return m_swa_protected_size;
+    return 0;
+  }
+
   std::size_t align(std::size_t size) const {
     return (size / page_size) * page_size;  // align to page size
   }
@@ -253,6 +429,20 @@ struct RadixTree::Impl {
     m_root.root_reset();
     m_evictable_size = 0;
     m_protected_size = 0;
+    m_swa_evictable_size = 0;
+    m_swa_protected_size = 0;
+    m_swa_uuid_counter = 1;
+    m_tree_walk_calls = 0;
+    m_tree_walk_tokens = 0;
+    m_node_match_calls = 0;
+    m_full_lru_pops = 0;
+    m_swa_lru_pops = 0;
+    m_lru_stale_pops = 0;
+    m_lru_rebuilds = 0;
+    m_full_lru = {};
+    m_swa_lru = {};
+    m_full_lru_positions.clear();
+    m_swa_lru_positions.clear();
     m_node_map.clear();
     m_node_map[m_root.node_id] = &m_root;  // re-add root to the map
   }
@@ -260,40 +450,62 @@ struct RadixTree::Impl {
   void debug_print(std::ostream& os) const;
 
  private:
-  // some auxiliary functions
-  token_vec_t& get_key(token_slice tokens) {
-    _assert(tokens.size() >= page_size, "Key should be at least page-sized");
-    tokens = tokens.subspan(0, page_size);
-    m_cached_vec.assign(tokens.begin(), tokens.end());
-    return m_cached_vec;
+  void erase_lru_entry(TreeNode* node, bool swa) {
+    auto& positions = swa ? m_swa_lru_positions : m_full_lru_positions;
+    auto& lru = swa ? m_swa_lru : m_full_lru;
+    const auto iterator = positions.find(node->node_id);
+    if (iterator == positions.end()) return;
+    lru.erase(iterator->second);
+    positions.erase(iterator);
   }
 
-  // justify for _unsafe call: we need to read the key part of the tokens
-  token_vec_t& get_key(TreeNode* node) {
-    return get_key(node->_unsafe_tokens());
+  void move_lru_to_mru(TreeNode* node, bool swa) {
+    auto& positions = swa ? m_swa_lru_positions : m_full_lru_positions;
+    auto& lru = swa ? m_swa_lru : m_full_lru;
+    const auto iterator = positions.find(node->node_id);
+    if (iterator != positions.end()) lru.erase(iterator->second);
+    lru.push_front(node);
+    positions[node->node_id] = lru.begin();
   }
 
   void add_child(TreeNode* parent, std::unique_ptr<TreeNode>&& child) {
-    parent->add_child(get_key(child.get()), std::move(child));
+    const auto tokens = token_slice{child->_unsafe_tokens()};
+    _assert(tokens.size() >= page_size, "Node key should be at least page-sized");
+    parent->add_child(token_vec_t(tokens.begin(), tokens.begin() + page_size), std::move(child));
   }
 
   void add_child(TreeNode* parent, std::unique_ptr<TreeNode>&& child, node_iterator_t it) {
     parent->add_child(it, std::move(child));
   }
 
-  TreeNode m_root;                                        // root node of the tree
-  std::size_t m_evictable_size;                           // number of evictable tokens on GPU (lock ref = 0)
-  std::size_t m_protected_size;                           // number of protected tokens on GPU (lock ref > 0)
-  token_vec_t m_cached_vec;                               // cached vector of tokens for the current operation
+  TreeNode m_root;               // root node of the tree
+  std::size_t m_evictable_size;  // number of evictable tokens on GPU (lock ref = 0)
+  std::size_t m_protected_size;  // number of protected tokens on GPU (lock ref > 0)
+  std::size_t m_swa_evictable_size;
+  std::size_t m_swa_protected_size;
   std::unordered_map<std::size_t, TreeNode*> m_node_map;  // map of node keys to nodes
   std::size_t m_node_counter;                             // counter for node IDs
+  std::size_t m_swa_uuid_counter;
+  lru_list_t m_full_lru;
+  lru_list_t m_swa_lru;
+  lru_position_map_t m_full_lru_positions;
+  lru_position_map_t m_swa_lru_positions;
 
  public:
+  std::uint64_t m_tree_walk_calls = 0;
+  std::uint64_t m_tree_walk_tokens = 0;
+  std::uint64_t m_node_match_calls = 0;
+  std::uint64_t m_full_lru_pops = 0;
+  std::uint64_t m_swa_lru_pops = 0;
+  std::uint64_t m_lru_stale_pops = 0;
+  std::uint64_t m_lru_rebuilds = 0;
+
   // some public constant configurations (without m_ prefix)
   const bool disabled;          // whether the cache is enabled, or just a temporary cache
   const bool use_hicache;       // whether to use the HiCache for this tree
   const std::size_t page_size;  // size of each page in the cache
   const std::size_t threshold;  // threshold for write_through
+  const std::size_t sliding_window_size;
 };
 
 }  // namespace radix_tree_v2

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_impl.h
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_impl.h
@@ -216,6 +216,19 @@ struct RadixTree::Impl {
     return size;
   }
 
+  std::vector<at::Tensor> all_values() const {
+    std::vector<at::Tensor> values;
+    std::vector<const TreeNode*> stack = {&m_root};
+    while (!stack.empty()) {
+      const auto* node = stack.back();
+      stack.pop_back();
+      if (node->on_gpu()) values.push_back(node->device_indices());
+      for (const auto& [_, child] : *node)
+        stack.push_back(child.get());
+    }
+    return values;
+  }
+
   std::size_t evictable_size() const {
     return m_evictable_size;
   }

--- a/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_node.h
+++ b/python/sglang/srt/mem_cache/cpp_radix_tree/tree_v2_node.h
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstddef>
 #include <cstdint>
+#include <cstring>
 #include <memory>
 #include <optional>
 #include <ranges>
@@ -16,35 +17,64 @@
 namespace radix_tree_v2 {
 
 struct std_vector_hash {
+  using is_transparent = void;
+
   // see https://stackoverflow.com/questions/20511347/a-good-hash-function-for-a-vector
-  std::size_t operator()(const token_vec_t& vec) const {
+  std::size_t operator()(token_slice vec) const {
     std::size_t hash = 0;
     for (const auto& token : vec) {
       hash ^= token + 0x9e3779b9 + (hash << 6) + (hash >> 2);
     }
     return hash;
   }
+
+  std::size_t operator()(const token_vec_t& vec) const {
+    return (*this)(token_slice{vec});
+  }
+};
+
+struct std_vector_equal {
+  using is_transparent = void;
+
+  bool operator()(token_slice lhs, token_slice rhs) const {
+    return std::ranges::equal(lhs, rhs);
+  }
+
+  bool operator()(const token_vec_t& lhs, const token_vec_t& rhs) const {
+    return (*this)(token_slice{lhs}, token_slice{rhs});
+  }
+
+  bool operator()(const token_vec_t& lhs, token_slice rhs) const {
+    return (*this)(token_slice{lhs}, rhs);
+  }
+
+  bool operator()(token_slice lhs, const token_vec_t& rhs) const {
+    return (*this)(lhs, token_slice{rhs});
+  }
 };
 
 struct TreeNode {
  public:
-  using childern_map_t = std::unordered_map<token_vec_t, std::unique_ptr<TreeNode>, std_vector_hash>;
+  using childern_map_t = std::unordered_map<token_vec_t, std::unique_ptr<TreeNode>, std_vector_hash, std_vector_equal>;
   using iterator_t = typename childern_map_t::iterator;
   using const_iterator_t = typename childern_map_t::const_iterator;
   using timestamp_t = std::chrono::steady_clock::time_point;
 
   TreeNode(std::size_t node_id_)
       : ref_count(0),
+        swa_ref_count(0),
         hit_count(0),
         m_io_locked(std::nullopt),
         m_io_status(IOStatus::None),
         m_io_ticket(),
         m_tokens(),
         m_device_indices(),
+        m_swa_indices(),
         m_host_indices(),
         m_parent(),
         m_children(),
         m_last_access_time(std::chrono::steady_clock::now()),
+        m_swa_last_access_time(std::chrono::steady_clock::now()),
         node_id(node_id_) {}
 
   void access(timestamp_t time = std::chrono::steady_clock::now()) {
@@ -57,6 +87,14 @@ struct TreeNode {
 
   timestamp_t time() const {
     return m_last_access_time;
+  }
+
+  void access_swa(timestamp_t time = std::chrono::steady_clock::now()) {
+    m_swa_last_access_time = time;
+  }
+
+  timestamp_t swa_time() const {
+    return m_swa_last_access_time;
   }
 
   bool on_gpu() const {
@@ -107,7 +145,16 @@ struct TreeNode {
     _assert(m_children.erase(v) > 0, "Child node not found");
   }
 
+  void erase_child(iterator_t it) {
+    _assert(it != m_children.end(), "Child node not found");
+    m_children.erase(it);
+  }
+
   iterator_t find_child(const token_vec_t& v) {
+    return m_children.find(v);
+  }
+
+  iterator_t find_child(token_slice v) {
     return m_children.find(v);
   }
 
@@ -154,10 +201,19 @@ struct TreeNode {
       new_node->m_host_indices = std::move(new_indices[0]);
       old_node->m_host_indices = std::move(new_indices[1]);
     }
+    if (old_node->m_swa_indices.defined()) {
+      auto new_indices = old_node->m_swa_indices.split_with_sizes({new_size, old_size});
+      new_node->m_swa_indices = std::move(new_indices[0]);
+      old_node->m_swa_indices = std::move(new_indices[1]);
+    }
 
     // set up ref counts and hit counts
     new_node->ref_count = old_node->ref_count;
+    new_node->swa_ref_count = old_node->swa_ref_count;
+    new_node->swa_uuid = old_node->swa_uuid;
+    old_node->swa_uuid.reset();
     new_node->hit_count = old_node->hit_count;
+    new_node->m_swa_last_access_time = old_node->m_swa_last_access_time;
 
     // If the old node (child) was locked for IO, the new node (parent) does not need
     // to be locked, since it is naturally protected by the child node's lock.
@@ -172,6 +228,11 @@ struct TreeNode {
   std::size_t diff_key(token_slice key, std::size_t offset) const {
     const auto a = token_slice{key}.subspan(offset);
     const auto b = token_slice{m_tokens}.subspan(offset);
+    const auto common_size = std::min(a.size(), b.size());
+    if (common_size == 0) return 0;
+    if (std::memcmp(a.data(), b.data(), common_size * sizeof(token_t)) == 0) {
+      return common_size;
+    }
     const auto [it_a, it_b] = std::ranges::mismatch(a, b);
     return it_a - a.begin();  // return the index of the first differing token
   }
@@ -181,6 +242,12 @@ struct TreeNode {
   }
   at::Tensor host_indices() const {
     return m_host_indices;
+  }
+  at::Tensor swa_indices() const {
+    return m_swa_indices;
+  }
+  bool has_swa() const {
+    return m_swa_indices.defined();
   }
 
   // visiting tokens are always unsafe (use `diff_key` instead)
@@ -192,6 +259,9 @@ struct TreeNode {
   }
   at::Tensor& _unsafe_host_indices() {
     return m_host_indices;
+  }
+  at::Tensor& _unsafe_swa_indices() {
+    return m_swa_indices;
   }
 
   bool is_io_free() const {
@@ -221,6 +291,8 @@ struct TreeNode {
 
  public:
   std::size_t ref_count;
+  std::size_t swa_ref_count;
+  std::optional<std::size_t> swa_uuid;
   std::size_t hit_count;
 
  private:
@@ -236,10 +308,12 @@ struct TreeNode {
 
   token_vec_t m_tokens;
   at::Tensor m_device_indices;  // indices of device value
+  at::Tensor m_swa_indices;     // physical SWA indices; undefined is a tombstone
   at::Tensor m_host_indices;    // indices of host value
   TreeNode* m_parent;
   childern_map_t m_children;
   timestamp_t m_last_access_time;
+  timestamp_t m_swa_last_access_time;
 
  public:
   const std::size_t node_id;  // unique ID for the node

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -128,7 +128,9 @@ class RadixCacheCpp(BasePrefixCache):
         Returns:
             int: Number of device indices that were already present in the tree before the insertion.
         """
-        ongoing_write, length = self.tree.writing_through(key.token_ids, value)
+        ongoing_write, length, _ = self.tree.writing_through(
+            key.token_ids, value, len(key)
+        )
         if self.cache_controller is None:
             assert len(ongoing_write) == 0, "Implementation error"
             return length

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -184,6 +184,13 @@ def _create_unified_radix_cache(
         params.component_registry_override = {
             ComponentType.MAMBA: MlxAuxiliaryStateComponent,
         }
+    # HiCache attaches after UnifiedRadixCache constructs the TreeCore. Carry
+    # that future requirement into construction so the default ``auto`` core
+    # selector does not choose the current device-only C++ implementation.
+    params.enable_hicache = (
+        ctx.enable_hierarchical_cache
+        or get_disagg().disaggregation_decode_retraction_backup == "host_pool"
+    )
     cache = UnifiedRadixCache(params)
     if (
         ctx.enable_hierarchical_cache

--- a/python/sglang/srt/mem_cache/unified_cache/cpp_unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/cpp_unified_tree_core.py
@@ -1,0 +1,313 @@
+"""C++ TreeCore backend for the FULL, device-only unified radix cache.
+
+This is intentionally a narrow first stage.  UnifiedRadixCache remains the
+controller and owns allocator side effects, while the C++ radix tree owns the
+trie, node values, reference counts, LRU timestamps, and eviction decisions.
+Unsupported unified-cache features fail during construction instead of
+silently falling back to the Python tree.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Optional, Sequence
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import (
+    DecLockRefParams,
+    DecLockRefResult,
+    IncLockRefResult,
+    InsertParams,
+    InsertResult,
+    MatchPrefixParams,
+    MatchResult,
+)
+from sglang.srt.mem_cache.cpp_radix_tree.radix_tree import RadixTreeCpp
+from sglang.srt.mem_cache.unified_cache.cache_action import FreeDeviceKV
+from sglang.srt.mem_cache.unified_cache.component_type import (
+    BASE_COMPONENT_TYPE,
+    ComponentType,
+)
+from sglang.srt.mem_cache.unified_cache.unified_tree_core import UnifiedTreeCore
+from sglang.srt.mem_cache.unified_cache.unified_tree_core_interface import (
+    DecSwaLockOnlyResult,
+    EvictDeviceNextNodeResult,
+    NodeId,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class CppUnifiedTreeCore(UnifiedTreeCore):
+    """FULL/device-only implementation backed by ``radix_tree_v2``.
+
+    Subclassing keeps the broad TreeCore surface available while the first
+    stage is deliberately restricted.  Every operation used by the supported
+    path is overridden below and operates on ``self.tree``.
+    """
+
+    def __init__(self, params, components):
+        from sglang.srt.mem_cache.unified_cache.tree_core_registry import (
+            cpp_tree_core_unsupported_reason,
+        )
+
+        unsupported_reason = cpp_tree_core_unsupported_reason(params, components)
+        if unsupported_reason is not None:
+            raise NotImplementedError(
+                "The C++ unified TreeCore does not support this configuration "
+                f"yet: {unsupported_reason}"
+            )
+
+        # Initializes common configuration and the inert Python root facade.
+        # The C++ tree below is the authoritative tree for the supported path.
+        super().__init__(params, components)
+        self.tree = RadixTreeCpp(
+            disabled=params.disable,
+            host_size=None,
+            page_size=self.page_size,
+            write_through_threshold=self.write_through_threshold,
+        )
+        self._pending_evicted_values: list[torch.Tensor] = []
+        self._ongoing_cpp_insert = False
+        self._reset_root_facade()
+        logger.info("Using C++ unified radix TreeCore (FULL component, device-only).")
+
+    def _reset_root_facade(self) -> None:
+        # C++ reserves node id 0 for its root.  A Python root object is retained
+        # only for compatibility with callers that inspect ``cache.root_node``.
+        self.root_node.id = 0
+        self._node_arena = {0: self.root_node}
+        self._empty_match_result = MatchResult(
+            device_indices=torch.empty(0, dtype=torch.int64, device=self.device),
+            last_device_node=0,
+            last_host_node=0,
+            best_match_node=0,
+            cache_actions=[],
+        )
+
+    @staticmethod
+    def _validate_key(key) -> None:
+        if key.extra_key is not None:
+            raise ValueError(
+                "The C++ unified TreeCore does not support RadixKey.extra_key yet"
+            )
+        if key.cache_salt is not None:
+            raise ValueError("The C++ unified TreeCore does not support cache_salt yet")
+        if key.is_bigram:
+            raise ValueError(
+                "The C++ unified TreeCore does not support bigram keys yet"
+            )
+
+    def reset(self) -> None:
+        # UnifiedTreeCore.__init__ calls this before ``self.tree`` exists.
+        super().reset()
+        if hasattr(self, "tree"):
+            self.tree.reset()
+            self._pending_evicted_values = []
+            self._ongoing_cpp_insert = False
+            self._reset_root_facade()
+
+    def node_by_id(self, node_id: NodeId):
+        if node_id == 0:
+            return self.root_node
+        raise NotImplementedError(
+            "Materializing non-root C++ nodes as Python objects is not supported"
+        )
+
+    def is_backuped(self, node_id: NodeId) -> bool:
+        return False
+
+    def is_root(self, node_id: NodeId) -> bool:
+        return node_id == 0
+
+    def root_node_handle(self, extra_key: Optional[str] = None) -> NodeId:
+        if extra_key is not None:
+            raise ValueError(
+                "The C++ unified TreeCore does not support extra_key namespaces yet"
+            )
+        return 0
+
+    def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
+        key = params.key.page_aligned(self.page_size)
+        self._validate_key(key)
+        if len(key) == 0:
+            return self._empty_match_result
+
+        chunks, host_hit_length, device_node, host_node = self.tree.match_prefix(
+            key.raw_token_ids()
+        )
+        if chunks:
+            device_indices = chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+        else:
+            device_indices = self._empty_match_result.device_indices
+        return MatchResult(
+            device_indices=device_indices,
+            last_device_node=device_node,
+            last_host_node=host_node,
+            best_match_node=host_node,
+            host_hit_length=host_hit_length,
+            full_kv_hit_length=len(device_indices) + host_hit_length,
+            cache_actions=[],
+        )
+
+    def begin_insert(self, params: InsertParams):
+        from sglang.srt.mem_cache.unified_cache.unified_tree_core_interface import (
+            InsertStepResult,
+        )
+
+        assert not self._ongoing_cpp_insert, "concurrent insert walks"
+        key = params.key.page_aligned(self.page_size)
+        self._validate_key(key)
+        value = params.value
+        if value is None:
+            value = torch.tensor(
+                key.raw_token_ids(), dtype=torch.int64, device=self.device
+            )
+        value = value[: len(key)]
+        self._ongoing_cpp_insert = True
+        if len(key) == 0:
+            return InsertStepResult(
+                actions=[], result=InsertResult(prefix_len=0, last_device_node=0)
+            )
+
+        try:
+            pending_io, prefix_len = self.tree.writing_through(
+                key.raw_token_ids(), value
+            )
+            assert not pending_io, "device-only C++ tree emitted an unexpected I/O"
+            _, _, last_device_node, _ = self.tree.match_prefix(key.raw_token_ids())
+        except BaseException:
+            self._ongoing_cpp_insert = False
+            raise
+
+        # The request already owns [0, prev_prefix_len).  Any additional
+        # overlap is a duplicate allocation and must be returned by the
+        # unified controller; the unmatched suffix is now owned by C++.
+        duplicate_start = min(max(params.prev_prefix_len, 0), prefix_len)
+        actions = []
+        if duplicate_start < prefix_len:
+            actions.append(FreeDeviceKV([value[duplicate_start:prefix_len]]))
+        return InsertStepResult(
+            actions=actions,
+            result=InsertResult(
+                prefix_len=prefix_len, last_device_node=last_device_node
+            ),
+        )
+
+    def resume_insert(self):
+        raise AssertionError("The device-only C++ insert never suspends")
+
+    def has_ongoing_insert(self) -> bool:
+        return self._ongoing_cpp_insert
+
+    def end_insert(self):
+        self._ongoing_cpp_insert = False
+        return []
+
+    def inc_lock_ref(
+        self,
+        node_id: NodeId,
+        skip_lock_components: Sequence[ComponentType] = (),
+    ) -> IncLockRefResult:
+        if skip_lock_components:
+            raise NotImplementedError(
+                "The FULL-only C++ tree cannot skip component locks"
+            )
+        self.tree.lock_ref(node_id, True)
+        return IncLockRefResult()
+
+    def dec_lock_ref(
+        self,
+        node_id: NodeId,
+        params: Optional[DecLockRefParams] = None,
+        skip_swa: bool = False,
+    ) -> DecLockRefResult:
+        if skip_swa:
+            raise NotImplementedError("The C++ unified TreeCore has no SWA component")
+        self.tree.lock_ref(node_id, False)
+        return DecLockRefResult()
+
+    def dec_swa_lock_only(
+        self,
+        node_id: NodeId,
+        swa_uuid_for_lock: Optional[int],
+        skip_lock_node_ids: Optional[dict] = None,
+    ) -> DecSwaLockOnlyResult:
+        raise NotImplementedError("The C++ unified TreeCore has no SWA component")
+
+    def evict_device_start(
+        self, component_type: ComponentType, request_cnt: int
+    ) -> None:
+        if component_type != BASE_COMPONENT_TYPE:
+            raise NotImplementedError(
+                f"Unsupported C++ eviction component: {component_type}"
+            )
+        assert not self._pending_evicted_values, "nested C++ eviction walk"
+        self._pending_evicted_values = self.tree.evict(request_cnt)
+
+    def evict_device_next_node(
+        self, component_type: ComponentType, tracker: dict[ComponentType, int]
+    ) -> EvictDeviceNextNodeResult:
+        result = EvictDeviceNextNodeResult(node_id=None)
+        if self._pending_evicted_values:
+            values, self._pending_evicted_values = self._pending_evicted_values, []
+            result.device_frees[BASE_COMPONENT_TYPE].extend(values)
+            result.tracker[BASE_COMPONENT_TYPE] = sum(len(v) for v in values)
+        return result
+
+    def evict_device_end(self, component_type: ComponentType) -> None:
+        self._pending_evicted_values = []
+
+    def evictable_size(self) -> int:
+        return self.tree.evictable_size()
+
+    def protected_size(self) -> int:
+        return self.tree.protected_size()
+
+    def component_evictable_size(self, component_type: ComponentType) -> int:
+        return self.evictable_size() if component_type == BASE_COMPONENT_TYPE else 0
+
+    def full_evictable_size(self) -> int:
+        return self.evictable_size()
+
+    def full_protected_size(self) -> int:
+        return self.protected_size()
+
+    def swa_evictable_size(self) -> int:
+        return 0
+
+    def mamba_evictable_size(self) -> int:
+        return 0
+
+    def swa_protected_size(self) -> int:
+        return 0
+
+    def mamba_protected_size(self) -> int:
+        return 0
+
+    def total_size(self) -> tuple[int, int]:
+        return self.tree.total_size(), 0
+
+    def all_values_flatten(self) -> torch.Tensor:
+        values = self.tree.all_values()
+        if not values:
+            return self._empty_match_result.device_indices
+        return values[0] if len(values) == 1 else torch.cat(values)
+
+    def all_mamba_values_flatten(self) -> torch.Tensor:
+        return self._empty_match_result.device_indices
+
+    def set_hicache_enabled(self) -> None:
+        raise NotImplementedError(
+            "The C++ unified TreeCore does not support HiCache yet"
+        )
+
+    def sanity_check(self, ongoing_write_through, ongoing_load_back) -> None:
+        if ongoing_write_through or ongoing_load_back:
+            raise AssertionError("Device-only C++ tree cannot have in-flight I/O")
+        total = self.tree.total_size()
+        assert total == self.tree.evictable_size() + self.tree.protected_size()
+
+    def pretty_print(self) -> None:
+        self.tree.debug_print()

--- a/python/sglang/srt/mem_cache/unified_cache/cpp_unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/cpp_unified_tree_core.py
@@ -1,4 +1,4 @@
-"""C++ TreeCore backend for the FULL, device-only unified radix cache.
+"""C++ TreeCore backend for device-only FULL and FULL+SWA unified caches.
 
 This is intentionally a narrow first stage.  UnifiedRadixCache remains the
 controller and owns allocator side effects, while the C++ radix tree owns the
@@ -24,7 +24,11 @@ from sglang.srt.mem_cache.base_prefix_cache import (
     MatchResult,
 )
 from sglang.srt.mem_cache.cpp_radix_tree.radix_tree import RadixTreeCpp
-from sglang.srt.mem_cache.unified_cache.cache_action import FreeDeviceKV
+from sglang.srt.mem_cache.unified_cache.cache_action import (
+    FreeDeviceKV,
+    RecoverSWAWithLockedFull,
+    SWARebuild,
+)
 from sglang.srt.mem_cache.unified_cache.component_type import (
     BASE_COMPONENT_TYPE,
     ComponentType,
@@ -40,7 +44,7 @@ logger = logging.getLogger(__name__)
 
 
 class CppUnifiedTreeCore(UnifiedTreeCore):
-    """FULL/device-only implementation backed by ``radix_tree_v2``.
+    """FULL or FULL+SWA device-only implementation backed by ``radix_tree_v2``.
 
     Subclassing keeps the broad TreeCore surface available while the first
     stage is deliberately restricted.  Every operation used by the supported
@@ -62,16 +66,22 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         # Initializes common configuration and the inert Python root facade.
         # The C++ tree below is the authoritative tree for the supported path.
         super().__init__(params, components)
+        self._has_swa = ComponentType.SWA in components
+        self._sliding_window_size = params.sliding_window_size or 0
         self.tree = RadixTreeCpp(
             disabled=params.disable,
             host_size=None,
             page_size=self.page_size,
             write_through_threshold=self.write_through_threshold,
+            sliding_window_size=(self._sliding_window_size if self._has_swa else 0),
         )
-        self._pending_evicted_values: list[torch.Tensor] = []
+        self._pending_evicted_values: Optional[tuple] = None
         self._ongoing_cpp_insert = False
         self._reset_root_facade()
-        logger.info("Using C++ unified radix TreeCore (FULL component, device-only).")
+        logger.info(
+            "Using C++ unified radix TreeCore (%s, device-only).",
+            "FULL+SWA" if self._has_swa else "FULL",
+        )
 
     def _reset_root_facade(self) -> None:
         # C++ reserves node id 0 for its root.  A Python root object is retained
@@ -99,12 +109,22 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
                 "The C++ unified TreeCore does not support bigram keys yet"
             )
 
+    def _key_buffer(self, key):
+        """Return RadixKey storage plus the page-aligned logical length.
+
+        The backing ``array('q')`` stays alive for the complete pybind call.
+        Passing the length separately honors both RadixKey.limit and page
+        alignment without constructing an aligned Python slice.
+        """
+        self._validate_key(key)
+        return key.token_ids, len(key) // self.page_size * self.page_size
+
     def reset(self) -> None:
         # UnifiedTreeCore.__init__ calls this before ``self.tree`` exists.
         super().reset()
         if hasattr(self, "tree"):
             self.tree.reset()
-            self._pending_evicted_values = []
+            self._pending_evicted_values = None
             self._ongoing_cpp_insert = False
             self._reset_root_facade()
 
@@ -129,17 +149,26 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         return 0
 
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
-        key = params.key.page_aligned(self.page_size)
-        self._validate_key(key)
-        if len(key) == 0:
+        key_buffer, key_len = self._key_buffer(params.key)
+        if key_len == 0:
             return self._empty_match_result
 
-        chunks, host_hit_length, device_node, host_node = self.tree.match_prefix(
-            key.raw_token_ids()
-        )
-        if chunks:
-            device_indices = chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+        if self._has_swa:
+            device_indices, device_node, full_kv_hit_length = (
+                self.tree.match_prefix_swa_flat(key_buffer, key_len)
+            )
+            host_hit_length = 0
+            host_node = device_node
         else:
+            device_indices, host_hit_length, device_node, host_node = (
+                self.tree.match_prefix_flat(key_buffer, key_len)
+            )
+            full_kv_hit_length = (
+                len(device_indices) + host_hit_length
+                if device_indices is not None
+                else host_hit_length
+            )
+        if device_indices is None:
             device_indices = self._empty_match_result.device_indices
         return MatchResult(
             device_indices=device_indices,
@@ -147,7 +176,7 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
             last_host_node=host_node,
             best_match_node=host_node,
             host_hit_length=host_hit_length,
-            full_kv_hit_length=len(device_indices) + host_hit_length,
+            full_kv_hit_length=full_kv_hit_length,
             cache_actions=[],
         )
 
@@ -157,26 +186,54 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         )
 
         assert not self._ongoing_cpp_insert, "concurrent insert walks"
-        key = params.key.page_aligned(self.page_size)
-        self._validate_key(key)
+        key_buffer, key_len = self._key_buffer(params.key)
         value = params.value
         if value is None:
             value = torch.tensor(
-                key.raw_token_ids(), dtype=torch.int64, device=self.device
+                key_buffer[:key_len], dtype=torch.int64, device=self.device
             )
-        value = value[: len(key)]
+        value = value[:key_len]
         self._ongoing_cpp_insert = True
-        if len(key) == 0:
+        if key_len == 0:
             return InsertStepResult(
                 actions=[], result=InsertResult(prefix_len=0, last_device_node=0)
             )
 
         try:
-            pending_io, prefix_len = self.tree.writing_through(
-                key.raw_token_ids(), value
-            )
-            assert not pending_io, "device-only C++ tree emitted an unexpected I/O"
-            _, _, last_device_node, _ = self.tree.match_prefix(key.raw_token_ids())
+            if self._has_swa:
+                (
+                    prefix_len,
+                    last_device_node,
+                    duplicate_frees,
+                    rebuilds,
+                    recoveries,
+                ) = self.tree.writing_through_swa(
+                    key_buffer,
+                    value,
+                    max(params.prev_prefix_len, 0),
+                    max(params.swa_evicted_seqlen, 0),
+                    key_len,
+                )
+                actions = []
+                if duplicate_frees:
+                    actions.append(FreeDeviceKV(list(duplicate_frees)))
+                actions.extend(
+                    SWARebuild(node_id, source_value)
+                    for node_id, source_value in rebuilds
+                )
+                actions.extend(
+                    RecoverSWAWithLockedFull(node_id, kept_full, incoming_full)
+                    for node_id, kept_full, incoming_full in recoveries
+                )
+            else:
+                pending_io, prefix_len, last_device_node = self.tree.writing_through(
+                    key_buffer, value, key_len
+                )
+                assert not pending_io, "device-only C++ tree emitted an unexpected I/O"
+                duplicate_start = min(max(params.prev_prefix_len, 0), prefix_len)
+                actions = []
+                if duplicate_start < prefix_len:
+                    actions.append(FreeDeviceKV([value[duplicate_start:prefix_len]]))
         except BaseException:
             self._ongoing_cpp_insert = False
             raise
@@ -184,16 +241,88 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         # The request already owns [0, prev_prefix_len).  Any additional
         # overlap is a duplicate allocation and must be returned by the
         # unified controller; the unmatched suffix is now owned by C++.
-        duplicate_start = min(max(params.prev_prefix_len, 0), prefix_len)
-        actions = []
-        if duplicate_start < prefix_len:
-            actions.append(FreeDeviceKV([value[duplicate_start:prefix_len]]))
         return InsertStepResult(
             actions=actions,
             result=InsertResult(
                 prefix_len=prefix_len, last_device_node=last_device_node
             ),
         )
+
+    def match_inserted_prefix_and_lock(
+        self,
+        node_id: NodeId,
+        skip_lock_components: Sequence[ComponentType] = (),
+        inserted_value: Optional[torch.Tensor] = None,
+        existing_prefix_len: int = 0,
+        reused_prefix_len: int = 0,
+    ) -> tuple[MatchResult, IncLockRefResult]:
+        """Finish insert rematching and locking without sending the key again.
+
+        ``inserted_value`` is already a private int64 copy of the request's
+        full KV index vector.  Only the overlap discovered after the request's
+        previous protected prefix can differ from the authoritative tree.
+        Patch that small range in place and reuse the vector, avoiding a
+        second full-prefix Tensor concatenation for every chunked prefill.
+        """
+        unsupported = set(skip_lock_components) - {
+            ComponentType.FULL,
+            ComponentType.SWA,
+        }
+        if unsupported:
+            raise NotImplementedError(f"Unsupported skipped C++ locks: {unsupported}")
+        if not self._has_swa and skip_lock_components:
+            raise NotImplementedError(
+                "The FULL-only C++ tree cannot skip component locks"
+            )
+
+        if inserted_value is None:
+            device_indices, best_node, full_hit_length, swa_uuid, skipped = (
+                self.tree.match_node_and_lock_flat(
+                    node_id,
+                    ComponentType.FULL not in skip_lock_components,
+                    self._has_swa and ComponentType.SWA not in skip_lock_components,
+                )
+            )
+            if device_indices is None:
+                device_indices = self._empty_match_result.device_indices
+        else:
+            value_len = len(inserted_value)
+            range_start = min(max(reused_prefix_len, 0), value_len)
+            range_end = min(max(existing_prefix_len, range_start), value_len)
+            (
+                authoritative_overlap,
+                best_node,
+                best_prefix_len,
+                full_hit_length,
+                swa_uuid,
+                skipped,
+            ) = self.tree.match_node_range_and_lock_flat(
+                node_id,
+                range_start,
+                range_end,
+                ComponentType.FULL not in skip_lock_components,
+                self._has_swa and ComponentType.SWA not in skip_lock_components,
+            )
+            best_prefix_len = min(best_prefix_len, value_len)
+            patch_end = min(range_end, best_prefix_len)
+            if patch_end > range_start:
+                assert authoritative_overlap is not None
+                assert len(authoritative_overlap) == patch_end - range_start
+                inserted_value[range_start:patch_end].copy_(authoritative_overlap)
+            device_indices = inserted_value[:best_prefix_len]
+        match_result = MatchResult(
+            device_indices=device_indices,
+            last_device_node=best_node,
+            last_host_node=best_node,
+            best_match_node=best_node,
+            host_hit_length=0,
+            full_kv_hit_length=full_hit_length,
+            cache_actions=[],
+        )
+        lock_result = IncLockRefResult(swa_uuid_for_lock=swa_uuid)
+        if skipped:
+            lock_result.skip_lock_node_ids[ComponentType.SWA] = set(skipped)
+        return match_result, lock_result
 
     def resume_insert(self):
         raise AssertionError("The device-only C++ insert never suspends")
@@ -210,12 +339,28 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         node_id: NodeId,
         skip_lock_components: Sequence[ComponentType] = (),
     ) -> IncLockRefResult:
-        if skip_lock_components:
-            raise NotImplementedError(
-                "The FULL-only C++ tree cannot skip component locks"
-            )
-        self.tree.lock_ref(node_id, True)
-        return IncLockRefResult()
+        if not self._has_swa:
+            if skip_lock_components:
+                raise NotImplementedError(
+                    "The FULL-only C++ tree cannot skip component locks"
+                )
+            self.tree.lock_ref(node_id, True)
+            return IncLockRefResult()
+        unsupported = set(skip_lock_components) - {
+            ComponentType.FULL,
+            ComponentType.SWA,
+        }
+        if unsupported:
+            raise NotImplementedError(f"Unsupported skipped C++ locks: {unsupported}")
+        swa_uuid, skipped_swa_nodes = self.tree.lock_ref_swa(
+            node_id,
+            ComponentType.FULL not in skip_lock_components,
+            ComponentType.SWA not in skip_lock_components,
+        )
+        result = IncLockRefResult(swa_uuid_for_lock=swa_uuid)
+        if skipped_swa_nodes:
+            result.skip_lock_node_ids[ComponentType.SWA] = set(skipped_swa_nodes)
+        return result
 
     def dec_lock_ref(
         self,
@@ -223,9 +368,25 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         params: Optional[DecLockRefParams] = None,
         skip_swa: bool = False,
     ) -> DecLockRefResult:
-        if skip_swa:
-            raise NotImplementedError("The C++ unified TreeCore has no SWA component")
-        self.tree.lock_ref(node_id, False)
+        if not self._has_swa:
+            if skip_swa:
+                raise NotImplementedError(
+                    "The C++ unified TreeCore has no SWA component"
+                )
+            self.tree.lock_ref(node_id, False)
+            return DecLockRefResult()
+        skip_ids = []
+        swa_uuid = None
+        if params is not None:
+            skip_ids = list(params.skip_lock_node_ids.get(ComponentType.SWA, ()))
+            swa_uuid = params.swa_uuid_for_lock
+        self.tree.unlock_ref_swa(
+            node_id,
+            True,
+            not skip_swa,
+            swa_uuid,
+            skip_ids,
+        )
         return DecLockRefResult()
 
     def dec_swa_lock_only(
@@ -234,30 +395,50 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         swa_uuid_for_lock: Optional[int],
         skip_lock_node_ids: Optional[dict] = None,
     ) -> DecSwaLockOnlyResult:
-        raise NotImplementedError("The C++ unified TreeCore has no SWA component")
+        if not self._has_swa:
+            raise NotImplementedError("The C++ unified TreeCore has no SWA component")
+        swa_frees, freed = self.tree.unlock_swa_only(node_id, swa_uuid_for_lock)
+        result = DecSwaLockOnlyResult()
+        if swa_frees:
+            result.device_frees[ComponentType.SWA].extend(swa_frees)
+            result.tracker[ComponentType.SWA] = freed
+        return result
 
     def evict_device_start(
         self, component_type: ComponentType, request_cnt: int
     ) -> None:
-        if component_type != BASE_COMPONENT_TYPE:
+        if component_type not in self.components_by_type:
             raise NotImplementedError(
                 f"Unsupported C++ eviction component: {component_type}"
             )
-        assert not self._pending_evicted_values, "nested C++ eviction walk"
-        self._pending_evicted_values = self.tree.evict(request_cnt)
+        assert self._pending_evicted_values is None, "nested C++ eviction walk"
+        if self._has_swa:
+            self._pending_evicted_values = self.tree.evict_component(
+                int(component_type), request_cnt
+            )
+        else:
+            values = self.tree.evict(request_cnt)
+            self._pending_evicted_values = (values, [], sum(map(len, values)), 0)
 
     def evict_device_next_node(
         self, component_type: ComponentType, tracker: dict[ComponentType, int]
     ) -> EvictDeviceNextNodeResult:
         result = EvictDeviceNextNodeResult(node_id=None)
-        if self._pending_evicted_values:
-            values, self._pending_evicted_values = self._pending_evicted_values, []
-            result.device_frees[BASE_COMPONENT_TYPE].extend(values)
-            result.tracker[BASE_COMPONENT_TYPE] = sum(len(v) for v in values)
+        if self._pending_evicted_values is not None:
+            full_values, swa_values, full_count, swa_count = (
+                self._pending_evicted_values
+            )
+            self._pending_evicted_values = None
+            if full_values:
+                result.device_frees[BASE_COMPONENT_TYPE].extend(full_values)
+                result.tracker[BASE_COMPONENT_TYPE] = full_count
+            if swa_values:
+                result.device_frees[ComponentType.SWA].extend(swa_values)
+                result.tracker[ComponentType.SWA] = swa_count
         return result
 
     def evict_device_end(self, component_type: ComponentType) -> None:
-        self._pending_evicted_values = []
+        self._pending_evicted_values = None
 
     def evictable_size(self) -> int:
         return self.tree.evictable_size()
@@ -266,7 +447,7 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         return self.tree.protected_size()
 
     def component_evictable_size(self, component_type: ComponentType) -> int:
-        return self.evictable_size() if component_type == BASE_COMPONENT_TYPE else 0
+        return self.tree.component_evictable_size(int(component_type))
 
     def full_evictable_size(self) -> int:
         return self.evictable_size()
@@ -275,13 +456,17 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
         return self.protected_size()
 
     def swa_evictable_size(self) -> int:
-        return 0
+        return self.component_evictable_size(ComponentType.SWA) if self._has_swa else 0
 
     def mamba_evictable_size(self) -> int:
         return 0
 
     def swa_protected_size(self) -> int:
-        return 0
+        return (
+            self.tree.component_protected_size(int(ComponentType.SWA))
+            if self._has_swa
+            else 0
+        )
 
     def mamba_protected_size(self) -> int:
         return 0
@@ -298,6 +483,23 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
     def all_mamba_values_flatten(self) -> torch.Tensor:
         return self._empty_match_result.device_indices
 
+    def set_component_device_value(
+        self, node_id: NodeId, component_type: ComponentType, value: torch.Tensor
+    ) -> None:
+        if component_type != ComponentType.SWA or not self._has_swa:
+            raise NotImplementedError(
+                f"Unsupported C++ component value store: {component_type}"
+            )
+        self.tree.set_swa_value(node_id, value)
+
+    def get_component_device_value(
+        self, node_id: NodeId, component_type: ComponentType
+    ) -> Optional[torch.Tensor]:
+        if component_type != ComponentType.SWA or not self._has_swa:
+            return None
+        value = self.tree.get_swa_value(node_id)
+        return value if value is not None and value.numel() else None
+
     def set_hicache_enabled(self) -> None:
         raise NotImplementedError(
             "The C++ unified TreeCore does not support HiCache yet"
@@ -308,6 +510,9 @@ class CppUnifiedTreeCore(UnifiedTreeCore):
             raise AssertionError("Device-only C++ tree cannot have in-flight I/O")
         total = self.tree.total_size()
         assert total == self.tree.evictable_size() + self.tree.protected_size()
+        if self._has_swa:
+            swa_total = self.swa_evictable_size() + self.swa_protected_size()
+            assert 0 <= swa_total <= total
 
     def pretty_print(self) -> None:
         self.tree.debug_print()

--- a/python/sglang/srt/mem_cache/unified_cache/tree_core_registry.py
+++ b/python/sglang/srt/mem_cache/unified_cache/tree_core_registry.py
@@ -61,7 +61,7 @@ def _python_tree_core_factory(
 def _cpp_tree_core_factory(
     params: CacheInitParams, components: dict[ComponentType, TreeComponent]
 ) -> UnifiedTreeCoreInterface:
-    """The experimental C++ FULL/device-only TreeCore.
+    """The experimental C++ FULL or FULL+SWA device-only TreeCore.
 
     Keep the extension import lazy: selecting the Python backend must not pay
     the C++ JIT build cost.
@@ -78,8 +78,17 @@ def cpp_tree_core_unsupported_reason(
 ) -> Optional[str]:
     """Return why the first-stage C++ core cannot serve this configuration."""
     component_types = tuple(components)
-    if component_types != (ComponentType.FULL,):
-        return f"components={component_types!r} (only FULL is supported)"
+    supported_components = (
+        (ComponentType.FULL,),
+        (ComponentType.FULL, ComponentType.SWA),
+    )
+    if component_types not in supported_components:
+        return (
+            f"components={component_types!r} "
+            "(only FULL and device-only FULL+SWA are supported)"
+        )
+    if ComponentType.SWA in component_types and not params.sliding_window_size:
+        return "SWA component has no sliding_window_size"
     if params.enable_hicache:
         return "HiCache/host-tier caching is enabled"
     if params.enable_session_radix_cache:

--- a/python/sglang/srt/mem_cache/unified_cache/tree_core_registry.py
+++ b/python/sglang/srt/mem_cache/unified_cache/tree_core_registry.py
@@ -1,18 +1,20 @@
 """Registry for pluggable TreeCore implementations.
 
 The unified cache constructs its TreeCore through `create_tree_core`, selected
-by SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND (default "python"). To plug in a custom
+by SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND (default "auto"). To plug in a custom
 implementation, register it under a string name via
 `register_tree_core_backend(name, factory)`.
 """
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING, Callable, Optional
+
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
 
 if TYPE_CHECKING:
     from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-    from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
     from sglang.srt.mem_cache.unified_cache.components import TreeComponent
     from sglang.srt.mem_cache.unified_cache.unified_tree_core_interface import (
         UnifiedTreeCoreInterface,
@@ -24,6 +26,8 @@ TreeCoreFactory = Callable[
 ]
 
 _TREE_CORE_REGISTRY: dict[str, TreeCoreFactory] = {}
+
+logger = logging.getLogger(__name__)
 
 
 def register_tree_core_backend(name: str, factory: TreeCoreFactory) -> None:
@@ -54,7 +58,60 @@ def _python_tree_core_factory(
     return UnifiedTreeCore(params, components)
 
 
+def _cpp_tree_core_factory(
+    params: CacheInitParams, components: dict[ComponentType, TreeComponent]
+) -> UnifiedTreeCoreInterface:
+    """The experimental C++ FULL/device-only TreeCore.
+
+    Keep the extension import lazy: selecting the Python backend must not pay
+    the C++ JIT build cost.
+    """
+    from sglang.srt.mem_cache.unified_cache.cpp_unified_tree_core import (
+        CppUnifiedTreeCore,
+    )
+
+    return CppUnifiedTreeCore(params, components)
+
+
+def cpp_tree_core_unsupported_reason(
+    params: CacheInitParams, components: dict[ComponentType, TreeComponent]
+) -> Optional[str]:
+    """Return why the first-stage C++ core cannot serve this configuration."""
+    component_types = tuple(components)
+    if component_types != (ComponentType.FULL,):
+        return f"components={component_types!r} (only FULL is supported)"
+    if params.enable_hicache:
+        return "HiCache/host-tier caching is enabled"
+    if params.enable_session_radix_cache:
+        return "session radix cache is enabled"
+    if params.enable_kv_cache_events:
+        return "KV cache events are enabled"
+    if params.is_eagle:
+        return "EAGLE/bigram keys are enabled"
+    if params.eviction_policy.lower() != "lru":
+        return f"eviction policy is {params.eviction_policy!r} (only LRU is supported)"
+    return None
+
+
+def _auto_tree_core_factory(
+    params: CacheInitParams, components: dict[ComponentType, TreeComponent]
+) -> UnifiedTreeCoreInterface:
+    """Prefer C++ when its current feature envelope covers the configuration."""
+    reason = cpp_tree_core_unsupported_reason(params, components)
+    if reason is None:
+        return _cpp_tree_core_factory(params, components)
+
+    logger.info(
+        "Using Python unified radix TreeCore because the C++ backend does not "
+        "support this configuration yet: %s.",
+        reason,
+    )
+    return _python_tree_core_factory(params, components)
+
+
 register_tree_core_backend("python", _python_tree_core_factory)
+register_tree_core_backend("cpp", _cpp_tree_core_factory)
+register_tree_core_backend("auto", _auto_tree_core_factory)
 
 
 def create_tree_core(

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -901,9 +901,37 @@ class UnifiedRadixCache(BasePrefixCache):
         insert_params.value = values
         result = self.insert(insert_params)
 
-        # Match prefix. SWA insertion retains one extra window before the
-        # page-aligned boundary, so the normal match remains safe to repoint.
-        match_result = self.match_prefix(MatchPrefixParams(key=radix_key, req=req))
+        # Opt-in: leave the matched-prefix mamba evictable during decode (it is
+        # already COW'd to the request's own slot, never read from this node again).
+        # Safe only because any future COW source is the COWing request's own
+        # admission-locked last_node (recorded only if still present, locked before
+        # the next alloc) -- not this evictable node. A scheduler that matched a
+        # whole batch before locking would break that. Off = original full lock.
+        skip_lock_components = (
+            (ComponentType.MAMBA,)
+            if envs.SGLANG_OPT_MAMBA_SKIP_DECODE_LOCK.get()
+            else ()
+        )
+
+        # The C++ core already knows the exact node returned by insert.  It can
+        # collect that prefix and lock FULL/SWA in one native call, avoiding a
+        # second radix walk and another large-key Python/C++ boundary crossing.
+        fused_match_lock = getattr(
+            self.tree_core, "match_inserted_prefix_and_lock", None
+        )
+        lock_result = None
+        if fused_match_lock is not None:
+            match_result, lock_result = fused_match_lock(
+                result.last_device_node,
+                skip_lock_components=skip_lock_components,
+                inserted_value=values,
+                existing_prefix_len=result.prefix_len,
+                reused_prefix_len=req.cache_protected_len,
+            )
+        else:
+            # SWA insertion retains one extra window before the page-aligned
+            # boundary, so the normal match remains safe to repoint.
+            match_result = self.match_prefix(MatchPrefixParams(key=radix_key, req=req))
         new_indices = match_result.device_indices
         new_last_node = match_result.last_device_node
         new_prefix_len = result.prefix_len
@@ -919,20 +947,10 @@ class UnifiedRadixCache(BasePrefixCache):
         )
 
         self._dec_req_lock(req)
-        # Opt-in: leave the matched-prefix mamba evictable during decode (it is
-        # already COW'd to the request's own slot, never read from this node again).
-        # Safe only because any future COW source is the COWing request's own
-        # admission-locked last_node (recorded only if still present, locked before
-        # the next alloc) -- not this evictable node. A scheduler that matched a
-        # whole batch before locking would break that. Off = original full lock.
-        skip_lock_components = (
-            (ComponentType.MAMBA,)
-            if envs.SGLANG_OPT_MAMBA_SKIP_DECODE_LOCK.get()
-            else ()
-        )
-        lock_result = self.inc_lock_ref(
-            new_last_node, skip_lock_components=skip_lock_components
-        )
+        if lock_result is None:
+            lock_result = self.inc_lock_ref(
+                new_last_node, skip_lock_components=skip_lock_components
+            )
 
         # Update req fields
         if len(new_indices) < len(kv_indices_orig):

--- a/test/manual/perf/bench_cpp_dspark_tree.py
+++ b/test/manual/perf/bench_cpp_dspark_tree.py
@@ -1,0 +1,90 @@
+"""Microbenchmark the C++ unified-tree shape used by DSPARK long prefixes."""
+
+import argparse
+from array import array
+from time import perf_counter_ns
+
+import torch
+
+from sglang.srt.mem_cache.cpp_radix_tree.radix_tree import RadixTreeCpp
+
+
+def percentile(values: list[int], fraction: float) -> float:
+    return sorted(values)[int((len(values) - 1) * fraction)] / 1e3
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--rounds", type=int, default=1024)
+    parser.add_argument("--page-size", type=int, default=256)
+    parser.add_argument("--window-size", type=int, default=4096)
+    parser.add_argument("--shared-len", type=int, default=61440)
+    parser.add_argument("--branch-len", type=int, default=5120)
+    args = parser.parse_args()
+
+    tree = RadixTreeCpp(False, None, args.page_size, 256, args.window_size)
+    shared = array("q", (i % 32000 for i in range(args.shared_len)))
+    match_ns: list[int] = []
+    insert_ns: list[int] = []
+    finish_ns: list[int] = []
+
+    for branch in range(args.rounds):
+        key = array("q", shared)
+        key.extend([100000 + branch] * args.page_size)
+        key.extend(
+            (token + branch) % 32000
+            for token in range(args.branch_len - args.page_size)
+        )
+        value = torch.arange(len(key), dtype=torch.int64)
+
+        start = perf_counter_ns()
+        _, _, full_hit = tree.match_prefix_swa_flat(key, len(key))
+        match_ns.append(perf_counter_ns() - start)
+
+        start = perf_counter_ns()
+        prefix_len, node_id, _, rebuilds, _ = tree.writing_through_swa(
+            key,
+            value,
+            min(full_hit, args.shared_len),
+            len(key) - args.window_size,
+            len(key),
+        )
+        insert_ns.append(perf_counter_ns() - start)
+
+        start = perf_counter_ns()
+        for rebuild_node_id, source in rebuilds:
+            tree.set_swa_value(rebuild_node_id, source)
+        overlap, locked_node, _, _, swa_uuid, skipped = (
+            tree.match_node_range_and_lock_flat(
+                node_id,
+                min(full_hit, args.shared_len),
+                prefix_len,
+                True,
+                True,
+            )
+        )
+        if overlap is not None:
+            value[min(full_hit, args.shared_len) : prefix_len].copy_(overlap)
+        tree.unlock_ref_swa(locked_node, True, True, swa_uuid, skipped)
+        finish_ns.append(perf_counter_ns() - start)
+        assert prefix_len <= len(key)
+
+    quarter = max(1, args.rounds // 4)
+    print(
+        {
+            "rounds": args.rounds,
+            "match_mean_us": sum(match_ns) / len(match_ns) / 1e3,
+            "match_p50_us": percentile(match_ns, 0.50),
+            "match_p99_us": percentile(match_ns, 0.99),
+            "insert_mean_us": sum(insert_ns) / len(insert_ns) / 1e3,
+            "insert_first_quarter_us": sum(insert_ns[:quarter]) / quarter / 1e3,
+            "insert_last_quarter_us": sum(insert_ns[-quarter:]) / quarter / 1e3,
+            "insert_p99_us": percentile(insert_ns, 0.99),
+            "finish_mean_us": sum(finish_ns) / len(finish_ns) / 1e3,
+            "stats": tree.debug_stats(),
+        }
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/unit/mem_cache/test_cpp_unified_tree_core.py
+++ b/test/registered/unit/mem_cache/test_cpp_unified_tree_core.py
@@ -1,0 +1,150 @@
+"""Unit tests for the FULL/device-only C++ unified TreeCore backend."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.cache_action import FreeDeviceKV
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+from sglang.srt.mem_cache.unified_cache.cpp_unified_tree_core import (
+    CppUnifiedTreeCore,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+def _params(**kwargs) -> CacheInitParams:
+    return CacheInitParams(
+        disable=False,
+        req_to_token_pool=None,
+        token_to_kv_pool_allocator=None,
+        page_size=2,
+        tree_components=(ComponentType.FULL,),
+        **kwargs,
+    )
+
+
+def _key(*tokens: int) -> RadixKey:
+    return RadixKey(array("q", tokens))
+
+
+class CppUnifiedTreeCoreTest(CustomTestCase):
+    def setUp(self):
+        component = SimpleNamespace(tree_core=None)
+        self.core = CppUnifiedTreeCore(_params(), {ComponentType.FULL: component})
+
+    def _insert(self, tokens, values, prev_prefix_len=0):
+        step = self.core.begin_insert(
+            InsertParams(
+                key=_key(*tokens),
+                value=torch.tensor(values, dtype=torch.int64),
+                prev_prefix_len=prev_prefix_len,
+            )
+        )
+        self.assertIsNotNone(step.result)
+        self.core.end_insert()
+        return step
+
+    def test_insert_match_split_and_flatten(self):
+        step = self._insert([1, 2, 3, 4], [10, 11, 12, 13])
+        self.assertEqual(step.result.prefix_len, 0)
+
+        result = self.core.match_prefix(MatchPrefixParams(key=_key(1, 2, 9, 9)))
+        self.assertEqual(result.device_indices.tolist(), [10, 11])
+        self.assertEqual(result.full_kv_hit_length, 2)
+        self.assertNotEqual(result.last_device_node, 0)
+        self.assertCountEqual(self.core.all_values_flatten().tolist(), [10, 11, 12, 13])
+        self.assertEqual(self.core.total_size(), (4, 0))
+
+    def test_duplicate_insert_returns_unowned_slots_as_action(self):
+        self._insert([1, 2, 3, 4], [10, 11, 12, 13])
+        step = self._insert([1, 2, 3, 4], [20, 21, 22, 23], prev_prefix_len=1)
+        self.assertEqual(step.result.prefix_len, 4)
+        self.assertEqual(len(step.actions), 1)
+        self.assertIsInstance(step.actions[0], FreeDeviceKV)
+        self.assertEqual(step.actions[0].indices[0].tolist(), [21, 22, 23])
+
+        result = self.core.match_prefix(MatchPrefixParams(key=_key(1, 2, 3, 4)))
+        self.assertEqual(result.device_indices.tolist(), [10, 11, 12, 13])
+
+    def test_lock_accounting_and_eager_eviction_bridge(self):
+        self._insert([1, 2, 3, 4], [10, 11, 12, 13])
+        result = self.core.match_prefix(MatchPrefixParams(key=_key(1, 2)))
+        node_id = result.last_device_node
+
+        self.core.inc_lock_ref(node_id)
+        self.assertEqual(self.core.protected_size(), 2)
+        self.assertEqual(self.core.evictable_size(), 2)
+        self.core.dec_lock_ref(node_id)
+        self.assertEqual(self.core.protected_size(), 0)
+
+        self.core.evict_device_start(ComponentType.FULL, 3)
+        evicted = self.core.evict_device_next_node(
+            ComponentType.FULL, {ComponentType.FULL: 0}
+        )
+        try:
+            self.assertIsNone(evicted.node_id)
+            self.assertGreaterEqual(evicted.tracker[ComponentType.FULL], 3)
+            self.assertEqual(
+                sum(len(v) for v in evicted.device_frees[ComponentType.FULL]),
+                evicted.tracker[ComponentType.FULL],
+            )
+        finally:
+            # Results assert that allocator-owned values are consumed.
+            evicted.device_frees.clear()
+            evicted.host_frees.clear()
+        self.core.evict_device_end(ComponentType.FULL)
+        self.assertEqual(self.core.total_size(), (0, 0))
+
+    def test_reset_clears_tree_and_restores_cpp_root_handle(self):
+        self._insert([1, 2], [10, 11])
+        self.core.reset()
+        self.assertEqual(self.core.root_node_handle(), 0)
+        self.assertEqual(self.core.total_size(), (0, 0))
+        self.assertEqual(
+            self.core.match_prefix(MatchPrefixParams(key=_key(1, 2))).last_device_node,
+            0,
+        )
+
+    def test_unsupported_namespace_fails_closed(self):
+        with self.assertRaisesRegex(ValueError, "extra_key"):
+            self.core.match_prefix(
+                MatchPrefixParams(key=RadixKey(array("q", [1, 2]), "tenant"))
+            )
+
+    def test_hicache_configuration_fails_closed(self):
+        with self.assertRaisesRegex(NotImplementedError, "HiCache"):
+            CppUnifiedTreeCore(
+                _params(enable_hicache=True),
+                {ComponentType.FULL: SimpleNamespace(tree_core=None)},
+            )
+
+    def test_rejected_insert_does_not_poison_the_next_insert(self):
+        with self.assertRaisesRegex(ValueError, "extra_key"):
+            self.core.begin_insert(
+                InsertParams(
+                    key=RadixKey(array("q", [1, 2]), "tenant"),
+                    value=torch.tensor([10, 11], dtype=torch.int64),
+                )
+            )
+        self.assertFalse(self.core.has_ongoing_insert())
+
+        step = self._insert([3, 4], [12, 13])
+        self.assertEqual(step.result.prefix_len, 0)
+        self.assertEqual(
+            self.core.match_prefix(
+                MatchPrefixParams(key=_key(3, 4))
+            ).device_indices.tolist(),
+            [12, 13],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_cpp_unified_tree_core.py
+++ b/test/registered/unit/mem_cache/test_cpp_unified_tree_core.py
@@ -1,4 +1,4 @@
-"""Unit tests for the FULL/device-only C++ unified TreeCore backend."""
+"""Unit tests for the device-only C++ unified TreeCore backend."""
 
 import unittest
 from array import array
@@ -9,7 +9,11 @@ import torch
 from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.radix_cache import RadixKey
-from sglang.srt.mem_cache.unified_cache.cache_action import FreeDeviceKV
+from sglang.srt.mem_cache.unified_cache.cache_action import (
+    FreeDeviceKV,
+    RecoverSWAWithLockedFull,
+    SWARebuild,
+)
 from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
 from sglang.srt.mem_cache.unified_cache.cpp_unified_tree_core import (
     CppUnifiedTreeCore,
@@ -20,13 +24,13 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=30, suite="base-a-test-cpu")
 
 
-def _params(**kwargs) -> CacheInitParams:
+def _params(tree_components=(ComponentType.FULL,), **kwargs) -> CacheInitParams:
     return CacheInitParams(
         disable=False,
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
         page_size=2,
-        tree_components=(ComponentType.FULL,),
+        tree_components=tree_components,
         **kwargs,
     )
 
@@ -39,6 +43,56 @@ class CppUnifiedTreeCoreTest(CustomTestCase):
     def setUp(self):
         component = SimpleNamespace(tree_core=None)
         self.core = CppUnifiedTreeCore(_params(), {ComponentType.FULL: component})
+
+    def _new_swa_core(self, sliding_window_size=4):
+        components = {
+            ComponentType.FULL: SimpleNamespace(tree_core=None),
+            ComponentType.SWA: SimpleNamespace(tree_core=None),
+        }
+        return CppUnifiedTreeCore(
+            _params(
+                tree_components=(ComponentType.FULL, ComponentType.SWA),
+                sliding_window_size=sliding_window_size,
+            ),
+            components,
+        )
+
+    def _apply_swa_actions(self, core, actions):
+        """Model the controller's SWA action barrier without a real allocator."""
+        for action in actions:
+            if isinstance(action, FreeDeviceKV):
+                continue
+            if isinstance(action, SWARebuild):
+                source = action.source_value
+            elif isinstance(action, RecoverSWAWithLockedFull):
+                source = action.incoming_full
+            else:
+                self.fail(f"unexpected insert action: {action!r}")
+            core.set_component_device_value(
+                action.node_id, ComponentType.SWA, source + 1000
+            )
+
+    def _insert_swa(
+        self,
+        core,
+        tokens,
+        values,
+        *,
+        prev_prefix_len=0,
+        swa_evicted_seqlen=0,
+    ):
+        step = core.begin_insert(
+            InsertParams(
+                key=_key(*tokens),
+                value=torch.tensor(values, dtype=torch.int64),
+                prev_prefix_len=prev_prefix_len,
+                swa_evicted_seqlen=swa_evicted_seqlen,
+            )
+        )
+        self.assertIsNotNone(step.result)
+        self._apply_swa_actions(core, step.actions)
+        core.end_insert()
+        return step
 
     def _insert(self, tokens, values, prev_prefix_len=0):
         step = self.core.begin_insert(
@@ -62,6 +116,103 @@ class CppUnifiedTreeCoreTest(CustomTestCase):
         self.assertNotEqual(result.last_device_node, 0)
         self.assertCountEqual(self.core.all_values_flatten().tolist(), [10, 11, 12, 13])
         self.assertEqual(self.core.total_size(), (4, 0))
+
+    def test_zero_copy_buffer_honors_radix_key_limit_and_page_alignment(self):
+        backing = array("q", [1, 2, 3, 4, 90, 91, 92])
+        limited = RadixKey(backing, limit=5)
+        step = self.core.begin_insert(
+            InsertParams(
+                key=limited,
+                value=torch.tensor([10, 11, 12, 13, 99], dtype=torch.int64),
+            )
+        )
+        self.core.end_insert()
+        self.assertEqual(step.result.prefix_len, 0)
+
+        # The binding sees the original seven-token buffer, but the explicit
+        # logical length exposes only the four page-aligned tokens.
+        result = self.core.match_prefix(MatchPrefixParams(key=limited))
+        self.assertEqual(result.device_indices.tolist(), [10, 11, 12, 13])
+        self.assertEqual(self.core.total_size(), (4, 0))
+        with self.assertRaisesRegex(ValueError, "int64 buffer"):
+            self.core.tree.match_prefix(array("i", [1, 2, 3, 4]))
+
+    def test_inserted_node_match_and_lock_avoids_second_tree_walk(self):
+        step = self._insert([1, 2, 3, 4], [10, 11, 12, 13])
+        before = self.core.tree.debug_stats()
+        match, lock = self.core.match_inserted_prefix_and_lock(
+            step.result.last_device_node
+        )
+        after = self.core.tree.debug_stats()
+
+        self.assertEqual(match.device_indices.tolist(), [10, 11, 12, 13])
+        self.assertEqual(after["tree_walk_calls"], before["tree_walk_calls"])
+        self.assertEqual(after["node_match_calls"], before["node_match_calls"] + 1)
+        self.assertEqual(self.core.protected_size(), 4)
+        self.core.dec_lock_ref(match.last_device_node, lock.to_dec_params())
+        self.assertEqual(self.core.protected_size(), 0)
+
+    def test_inserted_node_match_reuses_value_and_patches_only_overlap(self):
+        self._insert([1, 2, 3, 4], [10, 11, 12, 13])
+        incoming = torch.tensor([10, 11, 20, 21, 30, 31], dtype=torch.int64)
+        step = self.core.begin_insert(
+            InsertParams(
+                key=_key(1, 2, 3, 4, 5, 6),
+                value=incoming,
+                prev_prefix_len=2,
+            )
+        )
+        self.core.end_insert()
+        self.assertEqual(step.result.prefix_len, 4)
+
+        before = self.core.tree.debug_stats()
+        match, lock = self.core.match_inserted_prefix_and_lock(
+            step.result.last_device_node,
+            inserted_value=incoming,
+            existing_prefix_len=step.result.prefix_len,
+            reused_prefix_len=2,
+        )
+        after = self.core.tree.debug_stats()
+
+        # [0, 2) was already protected by the request, [2, 4) is patched from
+        # the authoritative tree, and [4, 6) remains the newly inserted suffix.
+        self.assertEqual(match.device_indices.tolist(), [10, 11, 12, 13, 30, 31])
+        self.assertEqual(match.device_indices.data_ptr(), incoming.data_ptr())
+        self.assertEqual(after["tree_walk_calls"], before["tree_walk_calls"])
+        self.assertEqual(after["node_match_calls"], before["node_match_calls"] + 1)
+        self.core.dec_lock_ref(match.last_device_node, lock.to_dec_params())
+
+    def test_persistent_full_lru_evicts_untouched_branch_first(self):
+        self._insert([1, 2, 3, 4], [10, 11, 12, 13])
+        self._insert([5, 6, 7, 8], [20, 21, 22, 23])
+        self.core.match_prefix(MatchPrefixParams(key=_key(1, 2, 3, 4)))
+
+        self.core.evict_device_start(ComponentType.FULL, 4)
+        evicted = self.core.evict_device_next_node(
+            ComponentType.FULL, {ComponentType.FULL: 0}
+        )
+        try:
+            self.assertEqual(evicted.tracker[ComponentType.FULL], 4)
+            self.assertEqual(
+                evicted.device_frees[ComponentType.FULL][0].tolist(),
+                [20, 21, 22, 23],
+            )
+        finally:
+            evicted.device_frees.clear()
+            evicted.host_frees.clear()
+        self.core.evict_device_end(ComponentType.FULL)
+        self.assertEqual(
+            self.core.match_prefix(
+                MatchPrefixParams(key=_key(1, 2, 3, 4))
+            ).device_indices.tolist(),
+            [10, 11, 12, 13],
+        )
+        self.assertEqual(
+            self.core.match_prefix(
+                MatchPrefixParams(key=_key(5, 6, 7, 8))
+            ).device_indices.numel(),
+            0,
+        )
 
     def test_duplicate_insert_returns_unowned_slots_as_action(self):
         self._insert([1, 2, 3, 4], [10, 11, 12, 13])
@@ -144,6 +295,201 @@ class CppUnifiedTreeCoreTest(CustomTestCase):
             ).device_indices.tolist(),
             [12, 13],
         )
+
+    def test_swa_insert_match_boundary_and_component_sizes(self):
+        core = self._new_swa_core(sliding_window_size=4)
+        step = self._insert_swa(
+            core,
+            range(1, 9),
+            range(10, 18),
+            swa_evicted_seqlen=4,
+        )
+        self.assertEqual(step.result.prefix_len, 0)
+        self.assertEqual(
+            sum(isinstance(action, SWARebuild) for action in step.actions), 1
+        )
+        self.assertEqual(core.full_evictable_size(), 8)
+        self.assertEqual(core.swa_evictable_size(), 4)
+
+        full_match = core.match_prefix(MatchPrefixParams(key=_key(*range(1, 9))))
+        self.assertEqual(full_match.device_indices.tolist(), list(range(10, 18)))
+        self.assertEqual(full_match.full_kv_hit_length, 8)
+
+        # FULL still matches six tokens, but the SWA suffix only covers two of
+        # the four required window tokens, so the usable cache prefix is empty.
+        partial_match = core.match_prefix(MatchPrefixParams(key=_key(*range(1, 7))))
+        self.assertEqual(partial_match.device_indices.numel(), 0)
+        self.assertEqual(partial_match.full_kv_hit_length, 6)
+
+    def test_swa_native_flat_match_and_many_sibling_splits(self):
+        """SWA leaf splitting stays correct with a wide shared-prefix node.
+
+        Every insertion below splits a fresh child below the same parent.  This
+        is the DSPARK/shared-system-prompt shape that previously linearly
+        scanned every existing sibling in split_node(TreeNode*).
+        """
+        core = self._new_swa_core(sliding_window_size=4)
+        common = [1, 2, 3, 4]
+        paths = []
+        for branch in range(128):
+            path = common + [1000 + branch, 2000 + branch] + [7, 8, 9, 10, 11, 12]
+            paths.append(path)
+            self._insert_swa(
+                core,
+                path,
+                range(branch * 100, branch * 100 + len(path)),
+                prev_prefix_len=len(common),
+                swa_evicted_seqlen=len(path) - 4,
+            )
+
+        for path in paths:
+            result = core.match_prefix(MatchPrefixParams(key=_key(*path)))
+            self.assertEqual(result.full_kv_hit_length, len(path))
+            self.assertEqual(result.device_indices.numel(), len(path))
+
+        flat, _, full_hit_length = core.tree.match_prefix_swa_flat(
+            array("q", paths[-1]), len(paths[-1])
+        )
+        self.assertIsInstance(flat, torch.Tensor)
+        self.assertEqual(flat.numel(), len(paths[-1]))
+        self.assertEqual(full_hit_length, len(paths[-1]))
+
+    def test_swa_window_lock_and_early_release(self):
+        core = self._new_swa_core(sliding_window_size=4)
+        self._insert_swa(
+            core,
+            range(1, 9),
+            range(10, 18),
+            swa_evicted_seqlen=4,
+        )
+        matched = core.match_prefix(MatchPrefixParams(key=_key(*range(1, 9))))
+        lock_result = core.inc_lock_ref(matched.last_device_node)
+        self.assertIsNotNone(lock_result.swa_uuid_for_lock)
+        self.assertEqual(core.full_protected_size(), 8)
+        self.assertEqual(core.swa_protected_size(), 4)
+
+        early = core.dec_swa_lock_only(
+            matched.last_device_node, lock_result.swa_uuid_for_lock
+        )
+        try:
+            self.assertEqual(core.full_protected_size(), 8)
+            self.assertEqual(core.swa_protected_size(), 0)
+            self.assertFalse(early.device_frees)
+        finally:
+            early.device_frees.clear()
+            early.host_frees.clear()
+        core.dec_lock_ref(
+            matched.last_device_node,
+            lock_result.to_dec_params(),
+            skip_swa=True,
+        )
+        self.assertEqual(core.full_protected_size(), 0)
+
+    def test_swa_eviction_atomically_removes_an_unlocked_full_leaf(self):
+        core = self._new_swa_core(sliding_window_size=4)
+        self._insert_swa(
+            core,
+            range(1, 9),
+            range(10, 18),
+            swa_evicted_seqlen=4,
+        )
+        core.evict_device_start(ComponentType.SWA, 1)
+        evicted = core.evict_device_next_node(
+            ComponentType.SWA,
+            {ComponentType.FULL: 0, ComponentType.SWA: 0},
+        )
+        try:
+            self.assertEqual(evicted.tracker[ComponentType.FULL], 4)
+            self.assertEqual(evicted.tracker[ComponentType.SWA], 4)
+            self.assertEqual(
+                sum(len(value) for value in evicted.device_frees[ComponentType.FULL]),
+                4,
+            )
+            # SWA frees deliberately carry FULL logical indices; the allocator
+            # uses them to release only the paired SWA slots.
+            self.assertEqual(
+                sum(len(value) for value in evicted.device_frees[ComponentType.SWA]),
+                4,
+            )
+        finally:
+            evicted.device_frees.clear()
+            evicted.host_frees.clear()
+        core.evict_device_end(ComponentType.SWA)
+        self.assertEqual(core.total_size(), (4, 0))
+        self.assertEqual(core.swa_evictable_size(), 0)
+
+    def test_swa_tombstone_recovery_respects_owned_prefix_and_full_lock(self):
+        core = self._new_swa_core(sliding_window_size=4)
+        path_a = list(range(1, 13))
+        path_b = list(range(1, 9)) + [90, 91, 92, 93]
+        self._insert_swa(
+            core,
+            path_a,
+            range(10, 22),
+            swa_evicted_seqlen=4,
+        )
+        self._insert_swa(
+            core,
+            path_b,
+            range(30, 42),
+            prev_prefix_len=8,
+            swa_evicted_seqlen=4,
+        )
+
+        # Touch the A leaf.  Its four-token SWA value covers the entire window,
+        # leaving the shared internal SWA node as the oldest eviction victim.
+        match_a = core.match_prefix(MatchPrefixParams(key=_key(*path_a)))
+        self.assertEqual(match_a.device_indices.numel(), 12)
+        core.evict_device_start(ComponentType.SWA, 1)
+        evicted = core.evict_device_next_node(
+            ComponentType.SWA,
+            {ComponentType.FULL: 0, ComponentType.SWA: 0},
+        )
+        try:
+            self.assertEqual(evicted.tracker.get(ComponentType.FULL, 0), 0)
+            self.assertEqual(evicted.tracker[ComponentType.SWA], 4)
+        finally:
+            evicted.device_frees.clear()
+            evicted.host_frees.clear()
+        core.evict_device_end(ComponentType.SWA)
+        self.assertEqual(core.total_size(), (16, 0))
+
+        # A tombstone wholly inside the request-owned prefix must not consume,
+        # replace, or free that FULL value.
+        owned = self._insert_swa(
+            core,
+            path_a,
+            range(10, 22),
+            prev_prefix_len=12,
+            swa_evicted_seqlen=4,
+        )
+        self.assertFalse(
+            any(
+                isinstance(action, (SWARebuild, RecoverSWAWithLockedFull))
+                for action in owned.actions
+            )
+        )
+
+        # Once fresh KV covers the tombstone, a concurrent FULL lock requires
+        # the recovery action to preserve the locked FULL allocation.
+        match_a = core.match_prefix(MatchPrefixParams(key=_key(*path_a)))
+        lock_result = core.inc_lock_ref(match_a.last_device_node)
+        recovered = self._insert_swa(
+            core,
+            path_a,
+            range(100, 112),
+            prev_prefix_len=4,
+            swa_evicted_seqlen=4,
+        )
+        self.assertEqual(
+            sum(
+                isinstance(action, RecoverSWAWithLockedFull)
+                for action in recovered.actions
+            ),
+            1,
+        )
+        core.dec_lock_ref(match_a.last_device_node, lock_result.to_dec_params())
+        self.assertEqual(core.swa_evictable_size(), 12)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_tree_core_registry.py
+++ b/test/registered/unit/mem_cache/test_tree_core_registry.py
@@ -13,6 +13,7 @@ from sglang.srt.mem_cache.unified_cache.components.tree_component import (
 )
 from sglang.srt.mem_cache.unified_cache.tree_core_registry import (
     _TREE_CORE_REGISTRY,
+    cpp_tree_core_unsupported_reason,
     create_tree_core,
     register_tree_core_backend,
     registered_tree_core_backends,
@@ -25,13 +26,15 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
-def _cache_init_params(**kwargs) -> CacheInitParams:
+def _cache_init_params(
+    tree_components=(ComponentType.FULL,), **kwargs
+) -> CacheInitParams:
     return CacheInitParams(
         disable=False,
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
         page_size=2,
-        tree_components=(ComponentType.FULL,),
+        tree_components=tree_components,
         **kwargs,
     )
 
@@ -90,6 +93,12 @@ class TreeCoreRegistryTest(CustomTestCase):
     def test_registry_contains_python(self):
         self.assertIn("python", registered_tree_core_backends())
 
+    def test_registry_contains_cpp(self):
+        self.assertIn("cpp", registered_tree_core_backends())
+
+    def test_registry_contains_auto(self):
+        self.assertIn("auto", registered_tree_core_backends())
+
     def test_python_backend_builds_the_python_tree(self):
         component = mock.MagicMock()
         core = create_tree_core(
@@ -126,6 +135,48 @@ class TreeCoreRegistryTest(CustomTestCase):
         result = create_tree_core(name="custom", params=params, components=components)
         factory.assert_called_once_with(params, components)
         self.assertIs(result, core)
+
+    def test_auto_selects_cpp_for_full_device_only(self):
+        params = _cache_init_params()
+        components = {ComponentType.FULL: mock.MagicMock()}
+        cpp_core = mock.MagicMock()
+        with mock.patch(
+            "sglang.srt.mem_cache.unified_cache.tree_core_registry._cpp_tree_core_factory",
+            return_value=cpp_core,
+        ) as cpp_factory:
+            result = create_tree_core("auto", params, components)
+        cpp_factory.assert_called_once_with(params, components)
+        self.assertIs(result, cpp_core)
+
+    def test_auto_falls_back_to_python_for_unsupported_components(self):
+        params = _cache_init_params(
+            tree_components=(ComponentType.FULL, ComponentType.MAMBA)
+        )
+        components = {
+            ComponentType.FULL: mock.MagicMock(),
+            ComponentType.MAMBA: mock.MagicMock(),
+        }
+        python_core = mock.MagicMock()
+        with (
+            mock.patch(
+                "sglang.srt.mem_cache.unified_cache.tree_core_registry._python_tree_core_factory",
+                return_value=python_core,
+            ) as python_factory,
+            mock.patch(
+                "sglang.srt.mem_cache.unified_cache.tree_core_registry._cpp_tree_core_factory"
+            ) as cpp_factory,
+        ):
+            result = create_tree_core("auto", params, components)
+        python_factory.assert_called_once_with(params, components)
+        cpp_factory.assert_not_called()
+        self.assertIs(result, python_core)
+
+    def test_cpp_compatibility_rejects_hicache(self):
+        params = _cache_init_params(enable_hicache=True)
+        reason = cpp_tree_core_unsupported_reason(
+            params, {ComponentType.FULL: mock.MagicMock()}
+        )
+        self.assertIn("HiCache", reason)
 
 
 class UnifiedRadixCacheTreeCoreSelectionTest(CustomTestCase):
@@ -174,11 +225,16 @@ class UnifiedRadixCacheTreeCoreSelectionTest(CustomTestCase):
         cache = UnifiedRadixCache(params)
         self.assertTrue(cache.tree_core.is_eagle)
 
-    def test_default_backend_builds_the_python_tree_core(self):
-        cache = UnifiedRadixCache(params=self._cache_params())
-        self.assertIsInstance(cache.tree_core, UnifiedTreeCore)
+    def test_default_backend_routes_to_auto(self):
+        core = mock.MagicMock()
+        factory = mock.MagicMock(return_value=core)
+        _TREE_CORE_REGISTRY["auto"] = factory
+        with envs.SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND.override("auto"):
+            cache = UnifiedRadixCache(params=self._cache_params())
+        factory.assert_called_once()
+        self.assertIs(cache.tree_core, core)
         component = cache.components[ComponentType.FULL]
-        self.assertIs(component.tree_core, cache.tree_core)
+        self.assertIs(component.tree_core, core)
 
     def test_env_var_routes_construction_to_the_selected_backend(self):
         """SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND selects the registered factory

--- a/test/registered/unit/mem_cache/test_tree_core_registry.py
+++ b/test/registered/unit/mem_cache/test_tree_core_registry.py
@@ -148,6 +148,37 @@ class TreeCoreRegistryTest(CustomTestCase):
         cpp_factory.assert_called_once_with(params, components)
         self.assertIs(result, cpp_core)
 
+    def test_auto_selects_cpp_for_full_swa_device_only(self):
+        params = _cache_init_params(
+            tree_components=(ComponentType.FULL, ComponentType.SWA),
+            sliding_window_size=4,
+        )
+        components = {
+            ComponentType.FULL: mock.MagicMock(),
+            ComponentType.SWA: mock.MagicMock(),
+        }
+        cpp_core = mock.MagicMock()
+        with mock.patch(
+            "sglang.srt.mem_cache.unified_cache.tree_core_registry._cpp_tree_core_factory",
+            return_value=cpp_core,
+        ) as cpp_factory:
+            result = create_tree_core("auto", params, components)
+        cpp_factory.assert_called_once_with(params, components)
+        self.assertIs(result, cpp_core)
+
+    def test_cpp_compatibility_rejects_swa_without_window_size(self):
+        params = _cache_init_params(
+            tree_components=(ComponentType.FULL, ComponentType.SWA)
+        )
+        reason = cpp_tree_core_unsupported_reason(
+            params,
+            {
+                ComponentType.FULL: mock.MagicMock(),
+                ComponentType.SWA: mock.MagicMock(),
+            },
+        )
+        self.assertIn("sliding_window_size", reason)
+
     def test_auto_falls_back_to_python_for_unsupported_components(self):
         params = _cache_init_params(
             tree_components=(ComponentType.FULL, ComponentType.MAMBA)


### PR DESCRIPTION
## Motivation

The Python unified radix tree can introduce noticeable CPU overhead for
long-prefix and wide-branch workloads, especially with chunked prefill and
DSPARK.

This PR adds an optional C++ TreeCore backend for the unified radix cache and
extends it to support device-only FULL and FULL+SWA configurations.

## Changes

- Add a pluggable unified TreeCore registry with three backends:
  - `python`: always use the Python implementation
  - `cpp`: require the C++ implementation
  - `auto`: prefer C++ and fall back to Python for unsupported configurations
- Add a C++ unified TreeCore implementation for:
  - FULL KV cache
  - FULL+SWA KV cache
  - DeepSeek-V4-Flash with DSPARK
- Implement SWA-specific behavior:
  - SWA prefix validation
  - FULL/SWA lock accounting
  - SWA tombstone recovery and rebuild
  - Component-aware eviction
- Optimize long-prefix radix operations:
  - Use zero-copy token buffers across the Python/C++ boundary
  - Use transparent page-key lookup without temporary vectors
  - Use a `memcmp` fast path for long-prefix comparison
  - Replace linear sibling lookup during node splitting
  - Flatten matched tensor chunks inside C++
  - Fuse inserted-node matching and lock acquisition
  - Reuse the insertion tensor and patch only the authoritative overlap
  - Replace lazy priority-queue LRU updates with O(1) intrusive LRU movement
- Add unit tests and a DSPARK-shaped C++ tree microbenchmark.

## Backend Selection

The backend can be selected with:

```bash
export SGLANG_UNIFIED_RADIX_TREE_CORE_BACKEND=auto
```

Supported values are auto, cpp, and python.
When cpp is selected explicitly, unsupported configurations fail instead of silently falling back to Python.

## Performance
DSPARK-shaped long-prefix microbenchmark:
Operation	                            Before	                After
match_prefix mean	           108.87 us	        77.18 us
Insert mean.             	           220.02 us	        199.32 us
Insert result/lock finalization	   11696.37 us	        51.09 us

The insert finalization path is about 229x faster because it no longer
concatenates the entire ~65K-token prefix after every insertion.
DeepSeek-V4-Flash DSPARK serving benchmark:
- 1024/1024 successful requests
- 61,440-token shared system prefix
- 4,096-token question
- 1,024-token output
- Concurrency: 32
- C++ backend duration: 275.99 s
- Python backend duration: 274.37 s
- C++ backend output throughput: 3799.28 tok/s
- Python backend output throughput: 3821.77 tok/s
The end-to-end difference is within the observed run-to-run variance, while the
radix tree CPU paths show stable improvements in the microbenchmark.
Correctness
- C++ unified TreeCore tests: 16 passed
- TreeCore registry and fallback tests: 17 passed
- DeepSeek-V4-Flash DSPARK stability test: 1024/1024 requests passed
- DeepSeek-V4-Flash GSM8K:
  - Accuracy: 0.980
  - Invalid: 0.000
- Qwen3-14B functional and accuracy validation passed
Current Limitations
The C++ backend currently supports only:
- Device-only FULL
- Device-only FULL+SWA
- LRU eviction
- Non-EAGLE radix keys
The following configurations continue to use the Python backend in auto
mode:
- HiCache
- Session radix cache
- KV cache events
- EAGLE/bigram keys
- Mamba components
- Non-LRU eviction policies

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32684478702](https://github.com/sgl-project/sglang/actions/runs/32684478702)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32684478540](https://github.com/sgl-project/sglang/actions/runs/32684478540)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32684478703](https://github.com/sgl-project/sglang/actions/runs/32684478703)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->