### PR TITLE
fix(function_call): flush buffered text on Hermes stream end

### DIFF
--- a/python/sglang/srt/function_call/hermes_detector.py
+++ b/python/sglang/srt/function_call/hermes_detector.py
@@ -118,3 +118,40 @@ class HermesDetector(BaseFormatDetector):
             end="}</tool_call>",
             trigger="<tool_call>",
         )
+
+    def finish(self, tools: List[Tool]) -> StreamingParseResult:
+        """Flush whatever ``_buffer``/``_normal_text_buffer`` were holding
+        back for a marker that can no longer arrive, since the stream just
+        ended.
+
+        If a ``<tool_call>`` was opened but never closed, the buffered
+        content is not valid normal text and not a parseable tool call
+        either, so it is dropped with a warning rather than being emitted
+        (mirrors KimiK3Detector.finish()).
+        """
+        if self.bot_token in self._buffer:
+            logger.warning(
+                "Hermes stream ended with an unterminated tool call; "
+                "dropping %d buffered chars",
+                len(self._buffer),
+            )
+            self._buffer = ""
+            self._normal_text_buffer = ""
+            return StreamingParseResult()
+
+        # _normal_text_buffer holds text held back by _clean_normal_text on
+        # the chance it was the start of "</tool_call>"; _buffer holds text
+        # held back on the chance it was the start of "<tool_call>" (e.g. the
+        # "<tool_" in "...looks like <tool_call" truncated by max_tokens).
+        # Neither marker can complete now, so release everything, in the
+        # order it was produced, instead of running it back through
+        # _clean_normal_text (which would just re-buffer an unresolved
+        # partial marker forever).
+        pending = self._normal_text_buffer + self._buffer
+        self._normal_text_buffer = ""
+        self._buffer = ""
+        if not pending:
+            return StreamingParseResult()
+        if self.eot_token in pending:
+            pending = pending.replace(self.eot_token, "")
+        return StreamingParseResult(normal_text=pending)

--- a/test/registered/unit/function_call/test_hermes_detector.py
+++ b/test/registered/unit/function_call/test_hermes_detector.py
@@ -172,6 +172,98 @@ class TestHermesDetector(CustomTestCase):
         params = json.loads(full_params)
         self.assertEqual(params["city"], "Tokyo")
 
+    # ==================== finish() / stream-end Tests ====================
+    # These cover the finish() override added for the base-class contract:
+    # "Called once when the stream ends; flush any buffered state. Detectors
+    # that hold text back while waiting for a marker that can no longer
+    # arrive (the stream is over) override this to release it." Before this
+    # override existed, HermesDetector inherited the no-op default and
+    # silently dropped whatever was still buffered.
+
+    def test_finish_flushes_partial_marker_at_stream_end(self):
+        """Generation stops (e.g. hits max_tokens) right after a chunk
+        boundary makes the tail look like the start of '<tool_call>'. That
+        text can never complete now that the stream is over, so finish()
+        must hand it back instead of losing it."""
+        detector = HermesDetector()
+        chunks = ["The format looks like ", "<tool_", "call"]
+        streamed = ""
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            streamed += result.normal_text
+
+        # Without finish(), "<tool_call" is stuck in the buffer forever.
+        self.assertEqual(streamed, "The format looks like ")
+        self.assertEqual(detector._buffer, "<tool_call")
+
+        final = detector.finish(self.tools)
+        self.assertEqual(final.normal_text, "<tool_call")
+        self.assertEqual(len(final.calls), 0)
+        self.assertEqual(
+            streamed + final.normal_text, "The format looks like <tool_call"
+        )
+        # Buffers are drained so a reused detector instance can't leak state.
+        self.assertEqual(detector._buffer, "")
+        self.assertEqual(detector._normal_text_buffer, "")
+
+    def test_finish_after_complete_tool_call_is_unchanged(self):
+        """Regression: a complete, well-formed tool call must still parse
+        exactly as before, and finish() afterwards must be a no-op."""
+        detector = HermesDetector()
+        chunks = [
+            "Sure, let me check. ",
+            '<tool_call>{"name": "get_weather",',
+            ' "arguments": {"city": "Tokyo"',
+            "}}</tool_call>",
+        ]
+        all_calls = []
+        all_normal_text = ""
+        for chunk in chunks:
+            result = detector.parse_streaming_increment(chunk, self.tools)
+            all_calls.extend(result.calls)
+            all_normal_text += result.normal_text
+
+        self.assertEqual(all_normal_text, "Sure, let me check. ")
+        func_calls = [c for c in all_calls if c.name]
+        self.assertEqual(len(func_calls), 1)
+        self.assertEqual(func_calls[0].name, "get_weather")
+        full_params = "".join(c.parameters for c in all_calls if c.parameters)
+        self.assertEqual(json.loads(full_params), {"city": "Tokyo"})
+
+        final = detector.finish(self.tools)
+        self.assertEqual(final.normal_text, "")
+        self.assertEqual(len(final.calls), 0)
+
+    def test_finish_drops_unterminated_tool_call_without_raising(self):
+        """If generation stops mid-argument (bot_token seen, no eot_token),
+        the buffered content is neither valid normal text nor a parseable
+        tool call. finish() must warn and drop it, not raise or emit
+        garbage as a call/normal_text."""
+        detector = HermesDetector()
+        chunks = ['<tool_call>{"name": "get_weather", "arguments": {"ci']
+        for chunk in chunks:
+            detector.parse_streaming_increment(chunk, self.tools)
+
+        self.assertIn(detector.bot_token, detector._buffer)
+
+        final = detector.finish(self.tools)  # must not raise
+        self.assertEqual(final.normal_text, "")
+        self.assertEqual(len(final.calls), 0)
+        self.assertEqual(detector._buffer, "")
+
+    def test_finish_with_no_partial_marker_is_unchanged(self):
+        """Regression: a stream that ends cleanly, with nothing buffered,
+        must be unaffected by the new finish() override."""
+        detector = HermesDetector()
+        result = detector.parse_streaming_increment(
+            "The weather is nice today.", self.tools
+        )
+        self.assertEqual(result.normal_text, "The weather is nice today.")
+
+        final = detector.finish(self.tools)
+        self.assertEqual(final.normal_text, "")
+        self.assertEqual(len(final.calls), 0)
+
 
 if __name__ == "__main__":
     import unittest


### PR DESCRIPTION
## Motivation

`BaseFormatDetector.finish()` is documented to be overridden by detectors that hold text back while waiting for a marker that can no longer arrive once the stream is over. `HermesDetector` never implemented it, so the base no-op silently discarded whatever was still buffered.

`HermesDetector` buffers text at chunk boundaries whenever the tail of a chunk could be the start of `<tool_call>` or `</tool_call>`. If generation stops right there (e.g. `max_tokens` hits mid-marker), that text sits in `_buffer` or `_normal_text_buffer` forever: the client gets truncated content with no error and no signal that anything is missing.

## Modifications

- Added `finish()` to `HermesDetector` to flush buffered text as normal text when the stream ends, instead of dropping it.
- If `_buffer` contains an opening `<tool_call>` with no closing `</tool_call>`, the content is an incomplete tool call and is dropped with a warning, mirroring `KimiK3Detector.finish()`.
- Buffers are cleared after `finish()` so a reused detector instance starts clean.
- Added four test cases: partial marker at stream end, complete tool call at stream end, unterminated tool call, and a clean stream with nothing buffered.

## Accuracy Tests

Not applicable; this only affects how already-buffered text is flushed at stream end, not model output.

```
python -m pytest test/registered/unit/function_call/test_hermes_detector.py -v
```

157 passed, 8 deselected (integration tests).

## Speed Tests and Profiling

Not applicable; no hot-path change, only stream-end cleanup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change is needed for this internal correctness fix.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; see above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32684669792](https://github.com/sgl-project/sglang/actions/runs/32684669792)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32684669657](https://github.com/sgl-project/sglang/actions/runs/32684669657)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32684669772](https://github.com/sgl-project/sglang/actions/runs/32684669772)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
