### PR TITLE
[NPU] Fix DSpark sparse-attention op namespace mismatch on Ascend

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1547,7 +1547,7 @@ class DeepseekV4AscendAttnBackend(
                 max_seqlen_q=max_seqlen_q,
                 max_seqlen_kv=max_seqlen_kv,
             )
-            c1a_metadata = torch.ops._C_ascend.npu_sparse_attn_sharedkv_metadata(
+            c1a_metadata = torch.ops.custom.npu_sparse_attn_sharedkv_metadata(
                 device=str(actual_seq_lengths_kv.device),
                 **c1a_kwargs,
             )
@@ -1665,10 +1665,7 @@ class DeepseekV4AscendAttnBackend(
         if ori_sparse_indices is not None:
             attn_kwargs["ori_sparse_indices"] = ori_sparse_indices
         q_arg = attn_kwargs.pop("q")
-        if self._is_dspark_draft_worker:
-            out, _ = torch.ops._C_ascend.npu_sparse_attn_sharedkv(q_arg, **attn_kwargs)
-        else:
-            out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(q_arg, **attn_kwargs)
+        out, _ = torch.ops.custom.npu_sparse_attn_sharedkv(q_arg, **attn_kwargs)
         return out
 
     def _forward_compressed(

--- a/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
+++ b/python/sglang/srt/hardware_backend/npu/extra_ops_loader.py
@@ -112,7 +112,7 @@ def initialize_dspark_sparse_attn_ops() -> Optional[Path]:
     spec = OpLibSpec(
         name="DSpark sparse-attention",
         so_env="SGLANG_DSPARK_EXTRA_OPS_SO",
-        namespace="_C_ascend",
+        namespace="custom",
         required_ops=(
             "npu_sparse_attn_sharedkv_metadata",
             "npu_sparse_attn_sharedkv",


### PR DESCRIPTION
## Motivation

On NPU, initialize_dspark_sparse_attn_ops() validated the _C_ascend namespace and the draft-worker forward path called torch.ops._C_ascend.npu_sparse_attn_sharedkv* . However, these operators are provided by the custom_ops package and are registered under torch.ops.custom . This mismatch made the scheduler fail at startup with "The DSpark sparse-attention operators are not registered."

## Modifications

- extra_ops_loader.py : switch the DSpark sparse-attention operator namespace checked by the loader from _C_ascend to custom .
- ascend_dsv4_backend.py : change the draft-worker calls to torch.ops.custom.npu_sparse_attn_sharedkv* to match the registered namespace, and drop the now-redundant draft/non-draft branch in the forward call.

## Accuracy Tests

No impact on model outputs; this only fixes operator namespace resolution during initialization.

## Speed Tests and Profiling

No impact on inference speed; no changes to kernel logic.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32687205129](https://github.com/sgl-project/sglang/actions/runs/32687205129)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32687204598](https://github.com/sgl-project/sglang/actions/runs/32687204598)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32687204791](https://github.com/sgl-project/sglang/actions/runs/32687204791)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->