### PR TITLE
[XPU] Support DeepEP expert parallelism on Intel XPU

### DIFF
--- a/docs/docs/hardware-platforms/xpu.mdx
+++ b/docs/docs/hardware-platforms/xpu.mdx
@@ -283,6 +283,50 @@ via `--cuda-graph-backend-prefill` or `--cuda-graph-config`.
 | Two-batch overlap (`--enable-two-batch-overlap`) | Not yet supported |
 | Speculative decoding | Not yet implemented |
 
+## Expert Parallelism with DeepEP on Intel XPU [Experimental]
+
+MoE expert parallelism on Intel XPU uses the DeepEP all-to-all dispatcher
+(`--moe-a2a-backend deepep`). The SGLang side of the integration is in tree; the
+all-to-all transport itself is not part of SGLang, so you must install a
+`deep_ep`-API-compatible package built for Intel GPUs (importable as `deep_ep`
+and exposing `Buffer` with `get_dispatch_layout` / `dispatch` / `combine`).
+The upstream CUDA DeepEP wheel is NVLink/RDMA-specific and will not work here.
+
+The Intel XPU port used to validate this integration is
+[frameworks.ai.pytorch.deepep, branch `deepep_xpu_us`](https://github.com/dayanandav/frameworks.ai.pytorch.deepep/tree/deepep_xpu_us),
+which implements the transport over ISHMEM instead of NVSHMEM. Build and install
+it before launching with `--moe-a2a-backend deepep`.
+
+**Supported configuration.** Only one combination is runnable on XPU:
+
+```bash
+python -m sglang.launch_server \
+    --model-path <MOE_MODEL> --device xpu --trust-remote-code \
+    --tp 2 --ep-size 2 \
+    --moe-a2a-backend deepep \
+    --deepep-mode normal \
+    --moe-runner-backend triton \
+    --deepep-dispatcher-output-dtype bf16
+```
+
+`--deepep-mode`, `--moe-runner-backend` and `--deepep-dispatcher-output-dtype`
+can be left at their defaults (`auto`); XPU resolves them to the values above.
+`--deepep-mode low_latency` and a non-`triton` MoE runner are rejected at startup
+rather than failing later in a kernel.
+
+### Limitations
+
+| Feature | Status on XPU |
+|---|---|
+| DeepEP transport | Provided out of tree — SGLang only requires a `deep_ep`-compatible package |
+| `--deepep-mode normal` | Supported (flat, contiguous recv layout consumed by the triton MoE runner) |
+| `--deepep-mode low_latency` / `auto`→low_latency | Not supported: the masked `[experts, tokens, hidden]` layout needs a masked grouped GEMM (DeepGEMM on CUDA), which XPU has no equivalent for |
+| Dispatch dtype | BF16 only. FP8/INT8 dispatch is downgraded to BF16 with a warning; NVFP4 dispatch raises |
+| MoE runner backend | `triton` only — the DeepEP recv-layout permutes are registered for that runner |
+| Other A2A backends (`mori`, `pplx`, `flashinfer`, `megamoe`, ...) | Not ported to XPU (they require ROCm or CUDA kernels) |
+| XPU graph with DeepEP | Disabled automatically, because `deepep_mode=normal` disables decode and prefill graph capture |
+| Two-batch overlap (`--enable-two-batch-overlap`) | Not yet supported (see the XPU Graph limitations above) |
+
 ## Prefill-Decode (P/D) Disaggregation on Intel XPU [Experimental]
 
 SGLang supports prefill-decode disaggregation on Intel XPU using the [NIXL](https://github.com/ai-dynamo/nixl) KV-transfer backend.

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -42,7 +42,7 @@ from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context
 from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph import (
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.utils import get_bool_env_var, is_hip, is_npu
+from sglang.srt.utils import get_bool_env_var, is_hip, is_npu, is_xpu
 
 if TYPE_CHECKING:
     from sglang.srt.layers.moe.token_dispatcher import (
@@ -53,6 +53,7 @@ if TYPE_CHECKING:
 
 _is_hip = is_hip()
 _is_npu = is_npu()
+_is_xpu = is_xpu()
 _is_fp8_fnuz = is_fp8_fnuz()
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
@@ -108,6 +109,9 @@ class DeepEPMoE(FusedMoE):
         elif _use_aiter:
             self.deprecate_flag = True
         elif _is_npu:
+            self.deprecate_flag = True
+        elif _is_xpu:
+            # No DeepGEMM on XPU: use the modern runner (triton deepep_normal permutes).
             self.deprecate_flag = True
         elif deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM and isinstance(
             quant_config, Fp8Config

--- a/python/sglang/srt/layers/moe/moe_runner/triton.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton.py
@@ -19,6 +19,10 @@ from sglang.srt.layers.moe.utils import MoeRunnerBackend
 from sglang.srt.utils import is_cuda, is_gfx95_supported, is_hip
 
 if TYPE_CHECKING:
+    from sglang.srt.layers.moe.token_dispatcher.deepep import (
+        DeepEPNormalCombineInput,
+        DeepEPNormalDispatchOutput,
+    )
     from sglang.srt.layers.moe.token_dispatcher.standard import (
         StandardCombineInput,
         StandardDispatchOutput,
@@ -34,6 +38,7 @@ class TritonRunnerInput(RunnerInput):
     sorted_token_ids: torch.Tensor
     expert_ids: torch.Tensor
     num_tokens_post_padded: torch.Tensor
+    apply_routed_scaling_factor: bool = True
 
     @property
     def runner_backend(self) -> MoeRunnerBackend:
@@ -86,6 +91,14 @@ class TritonRunnerCore(MoeRunnerCore):
         running_state: dict,
         hooks: Optional[Any] = None,
     ) -> TritonRunnerOutput:
+        # A DeepEP combine reduces across ranks, so it needs the unscaled
+        # partial sum and scales after the reduction.
+        routed_scaling_factor = (
+            self.config.routed_scaling_factor
+            if runner_input.apply_routed_scaling_factor
+            else None
+        )
+
         if quant_info.use_mxfp8 and is_hip() and is_gfx95_supported():
             from sglang.kernels.ops.moe.mxfp8_moe_amd_gfx95 import (
                 fused_experts_mxfp8,
@@ -106,7 +119,7 @@ class TritonRunnerCore(MoeRunnerCore):
                 no_combine=self.config.no_combine,
                 inplace=self.config.inplace,
                 apply_router_weight_on_input=self.config.apply_router_weight_on_input,
-                routed_scaling_factor=self.config.routed_scaling_factor,
+                routed_scaling_factor=routed_scaling_factor,
                 gemm1_alpha=self.config.gemm1_alpha,
                 gemm1_limit=self.config.gemm1_clamp_limit,
                 swiglu_limit=self.config.swiglu_limit,
@@ -161,7 +174,7 @@ class TritonRunnerCore(MoeRunnerCore):
             no_combine=self.config.no_combine,
             inplace=self.config.inplace,
             apply_router_weight_on_input=self.config.apply_router_weight_on_input,
-            routed_scaling_factor=self.config.routed_scaling_factor,
+            routed_scaling_factor=routed_scaling_factor,
             gemm1_alpha=self.config.gemm1_alpha,
             gemm1_limit=self.config.gemm1_clamp_limit,
             filter_expert=filter_expert,
@@ -260,27 +273,16 @@ def fused_experts_none_to_triton(
     )
 
 
-@register_pre_permute("standard", "triton")
-def pre_permute_standard_to_triton(
-    dispatch_output: StandardDispatchOutput,
+def _align_experts_and_stash_config(
+    *,
+    hidden_states: torch.Tensor,
+    topk_ids: torch.Tensor,
     quant_info: TritonMoeQuantInfo,
-    runner_config: MoeRunnerConfig,
     running_state: dict,
-) -> TritonRunnerInput:
-
-    # Registered fallback for format-conversion tests and examples.
-
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import (
         _prepare_fused_moe_run,
     )
-    from sglang.srt.layers.moe.topk import TopKOutputChecker
-
-    hidden_states, topk_output = (
-        dispatch_output.hidden_states,
-        dispatch_output.topk_output,
-    )
-
-    assert TopKOutputChecker.format_is_standard(topk_output)
 
     (
         config,
@@ -294,7 +296,7 @@ def pre_permute_standard_to_triton(
         hidden_states,
         quant_info.w13_weight,
         quant_info.w2_weight,
-        topk_output.topk_ids,
+        topk_ids,
         use_fp8_w8a8=quant_info.use_fp8_w8a8,
         use_int8_w8a8=quant_info.use_int8_w8a8,
         use_int8_w8a16=quant_info.use_int8_w8a16,
@@ -308,6 +310,37 @@ def pre_permute_standard_to_triton(
     running_state["down_moe_use_tma"] = down_moe_use_tma
     running_state["up_moe_use_tma"] = up_moe_use_tma
 
+    return sorted_token_ids, expert_ids, num_tokens_post_padded
+
+
+@register_pre_permute("standard", "triton")
+def pre_permute_standard_to_triton(
+    dispatch_output: StandardDispatchOutput,
+    quant_info: TritonMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> TritonRunnerInput:
+
+    # Registered fallback for format-conversion tests and examples.
+
+    from sglang.srt.layers.moe.topk import TopKOutputChecker
+
+    hidden_states, topk_output = (
+        dispatch_output.hidden_states,
+        dispatch_output.topk_output,
+    )
+
+    assert TopKOutputChecker.format_is_standard(topk_output)
+
+    sorted_token_ids, expert_ids, num_tokens_post_padded = (
+        _align_experts_and_stash_config(
+            hidden_states=hidden_states,
+            topk_ids=topk_output.topk_ids,
+            quant_info=quant_info,
+            running_state=running_state,
+        )
+    )
+
     return TritonRunnerInput(
         hidden_states=hidden_states,
         topk_weights=topk_output.topk_weights,
@@ -315,6 +348,55 @@ def pre_permute_standard_to_triton(
         sorted_token_ids=sorted_token_ids,
         expert_ids=expert_ids,
         num_tokens_post_padded=num_tokens_post_padded,
+    )
+
+
+@register_pre_permute("deepep_normal", "triton")
+def pre_permute_deepep_normal_to_triton(
+    dispatch_output: DeepEPNormalDispatchOutput,
+    quant_info: TritonMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> TritonRunnerInput:
+    (
+        hidden_states,
+        hidden_states_scale,
+        topk_ids,
+        topk_weights,
+        _num_recv_tokens_per_expert,
+    ) = dispatch_output
+
+    assert hidden_states_scale is None, (
+        "The triton MoE runner needs a bf16 DeepEP dispatch; set "
+        "--deepep-dispatcher-output-dtype bf16."
+    )
+    assert (
+        not runner_config.apply_router_weight_on_input
+    ), "apply_router_weight_on_input is not supported for DeepEP normal dispatch"
+
+    # Recv topk ids are local expert ids, -1 where another rank owns the slot;
+    # moe_align_block_size and the kernel's filter_expert branch handle that,
+    # so the recv layout needs no re-scatter.
+    sorted_token_ids, expert_ids, num_tokens_post_padded = (
+        _align_experts_and_stash_config(
+            hidden_states=hidden_states,
+            topk_ids=topk_ids,
+            quant_info=quant_info,
+            running_state=running_state,
+        )
+    )
+
+    running_state["topk_ids"] = topk_ids
+    running_state["topk_weights"] = topk_weights
+
+    return TritonRunnerInput(
+        hidden_states=hidden_states,
+        topk_weights=topk_weights,
+        topk_ids=topk_ids,
+        sorted_token_ids=sorted_token_ids,
+        expert_ids=expert_ids,
+        num_tokens_post_padded=num_tokens_post_padded,
+        apply_routed_scaling_factor=False,
     )
 
 
@@ -332,4 +414,23 @@ def post_permute_triton_to_standard(
 
     return StandardCombineInput(
         hidden_states=runner_output.hidden_states,
+    )
+
+
+@register_post_permute("triton", "deepep_normal")
+def post_permute_triton_to_deepep_normal(
+    runner_output: TritonRunnerOutput,
+    quant_info: TritonMoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+    running_state: dict,
+) -> DeepEPNormalCombineInput:
+
+    # The kernel already applied topk_weights and reduced over topk.
+
+    from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPNormalCombineInput
+
+    return DeepEPNormalCombineInput(
+        hidden_states=runner_output.hidden_states,
+        topk_ids=running_state["topk_ids"],
+        topk_weights=running_state["topk_weights"],
     )

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -32,13 +32,17 @@ from sglang.srt.utils import (
     get_bool_env_var,
     get_cuda_version,
     is_blackwell,
+    is_cuda,
     is_flashinfer_available,
     is_hip,
     is_npu,
+    is_xpu,
     load_json_config,
 )
 
+_is_cuda = is_cuda()
 _is_npu = is_npu()
+_is_xpu = is_xpu()
 _use_zbal = _is_npu and envs.SGLANG_ZBAL_LOCAL_MEM_SIZE.get() > 0
 
 if TYPE_CHECKING:
@@ -51,7 +55,8 @@ try:
     else:
         from deep_ep import Buffer, Config
 
-    if not _is_npu:
+    # NPU/XPU always dispatch bf16: don't gate DeepEP on the fp8 kernel.
+    if not _is_npu and not _is_xpu:
         from sglang.kernels.ops.quantization.fp8_kernel import (
             sglang_per_token_group_quant_fp8,
         )
@@ -83,6 +88,10 @@ def _set_nvshmem_qp_depth(num_max_dispatch_tokens_per_rank: int) -> None:
 
 
 def _is_mnnvl_fabric_supported() -> bool:
+    # NVIDIA-only transport, and the probe below touches torch.cuda.
+    if not _is_cuda:
+        return False
+
     if not is_flashinfer_available():
         return False
 
@@ -261,7 +270,8 @@ class DeepEPBuffer:
         else:
             raise NotImplementedError
 
-        if not _is_npu:
+        # SM occupancy is CUDA/HIP-only; XPU/NPU size their comm kernels.
+        if not _is_npu and not _is_xpu:
             total_num_sms = torch.cuda.get_device_properties(
                 device="cuda"
             ).multi_processor_count
@@ -484,6 +494,21 @@ class _DeepEPDispatcherImplBase:
                 raise RuntimeError(
                     "Ascend A2/A3 NPU does not support nvfp4 deepep_dispatcher_output_dtype."
                 )
+        elif _is_xpu:
+            # No fp8 expert path on XPU (supports_fp8() is False): stay bf16.
+            if self.deepep_output_dtype in (
+                DispatcherOutputDtype.FP8,
+                DispatcherOutputDtype.INT8,
+            ):
+                logger.warning_once(
+                    f"Intel XPU does not support {self.deepep_output_dtype.value} "
+                    "deepep_dispatcher_output_dtype, switching to bf16..."
+                )
+                self.deepep_output_dtype = DispatcherOutputDtype.BF16
+            elif self.deepep_output_dtype == DispatcherOutputDtype.NVFP4:
+                raise RuntimeError(
+                    "Intel XPU does not support nvfp4 deepep_dispatcher_output_dtype."
+                )
         else:
             if self.deepep_output_dtype == DispatcherOutputDtype.INT8:
                 logger.warning_once(
@@ -629,7 +654,8 @@ class _DeepEPDispatcherImplNormal(_DeepEPDispatcherImplBase):
         topk_weights: torch.Tensor,
     ):
 
-        if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM or _use_aiter or _is_npu:
+        if deep_gemm_wrapper.ENABLE_JIT_DEEPGEMM or _use_aiter or _is_npu or _is_xpu:
+            # XPU's bf16 triton post-permute already returns the recv layout.
             output = hidden_states
         else:
             raise NotImplementedError()  # triton runner was supported but it's temporarily disabled
@@ -829,7 +855,7 @@ class _DeepEPDispatcherImplLowLatency(_DeepEPDispatcherImplBase):
         ctx = nullcontext()
         if overlap_args is not None:
             overlap_args.stream.wait_event(overlap_args.wait_event)
-            ctx = torch.cuda.stream(overlap_args.stream)
+            ctx = self.device_module.stream(overlap_args.stream)
 
             if is_blackwell():
                 overlap_args_dict = dict(

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -13,9 +13,10 @@ from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
 from sglang.srt.runtime_context import get_exec, get_flags, get_forward, get_parallel
-from sglang.srt.utils import is_cuda, is_npu
+from sglang.srt.utils import is_cuda, is_npu, is_xpu
 
 _is_npu = is_npu()
+_is_xpu = is_xpu()
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -235,7 +236,7 @@ def get_deepep_output_dtype(self) -> DispatcherOutputDtype:
     3. Parse a mode-specific dtype from quant_config.
     4. Parse a generic dtype from quant_config.
     5. If flashinfer_cutedsl or is_cutlass backend is active → BF16 (it quantizes hidden_states internally).
-    6. Otherwise default for NPU → BF16 (the default for NPU).
+    6. Otherwise default for NPU / XPU → BF16.
     7. Otherwise → FP8 (the default for most models like DeepSeek-V3).
     """
 
@@ -283,8 +284,8 @@ def get_deepep_output_dtype(self) -> DispatcherOutputDtype:
     ):
         return DispatcherOutputDtype.BF16
 
-    # 6. Default on NPU → BF16
-    if _is_npu:
+    # 6. Default on NPU / XPU → BF16 (no fp8 expert path)
+    if _is_npu or _is_xpu:
         return DispatcherOutputDtype.BF16
 
     # 7. Default → FP8

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -933,12 +933,12 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, BaseFusedOp):
     def forward_xpu(
         self,
         layer: torch.nn.Module,
-        dispatch_output: StandardDispatchOutput,
+        dispatch_output: DispatchOutput,
     ) -> CombineInput:
-        from sglang.srt.layers.moe.token_dispatcher import StandardCombineInput
-
-        x = dispatch_output.hidden_states
-        topk_output = dispatch_output.topk_output
+        from sglang.srt.layers.moe.token_dispatcher import (
+            DispatchOutputChecker,
+            StandardCombineInput,
+        )
 
         moe_runner_config = self.moe_runner_config
         assert moe_runner_config.activation in [
@@ -946,6 +946,14 @@ class UnquantizedFusedMoEMethod(FusedMoEMethodBase, BaseFusedOp):
             "gelu",
             "relu2",  # Nemotron-H (NemotronHForCausalLM) uses squared-ReLU.
         ], f"activation = {moe_runner_config.activation} is not supported."
+
+        if not DispatchOutputChecker.format_is_standard(dispatch_output):
+            # A2A recv layouts (DeepEP normal) carry local expert ids; only the
+            # runner's permutes handle them, fused_experts below cannot.
+            return self.runner.run(dispatch_output, self.get_triton_quant_info(layer))
+
+        x = dispatch_output.hidden_states
+        topk_output = dispatch_output.topk_output
 
         backend = self.runner.runner_backend
         if use_intel_xpu_backend():

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7340,6 +7340,30 @@ class ServerArgs:
             logger.info(f"Waterfill is enabled with moe_a2a_backend='{a2a_backend}'.")
 
         if a2a_backend == "deepep":
+            if self.device == "xpu":
+                # low_latency's masked [experts, tokens, hidden] layout needs a
+                # masked grouped GEMM (DeepGEMM on CUDA), which XPU has no
+                # equivalent for, and no deepep_ll permute is registered there.
+                if self.deepep_mode == "auto":
+                    self._declare(
+                        "_handle_a2a_moe",
+                        deepep_mode="normal",
+                    )
+                    logger.warning("auto set deepep_mode=`normal` for Intel XPU")
+                elif self.deepep_mode != "normal":
+                    raise ValueError(
+                        f"--deepep-mode {self.deepep_mode} needs a masked grouped "
+                        "GEMM that Intel XPU does not provide; pass "
+                        "--deepep-mode normal."
+                    )
+                # Only the triton runner registers DeepEP recv-layout permutes
+                # for an unquantized MoE; the others have no XPU kernels and
+                # would fail in the permute lookup instead.
+                assert resolved_view(self).moe_runner_backend in ("auto", "triton"), (
+                    f"--moe-runner-backend {resolved_view(self).moe_runner_backend} "
+                    "cannot consume a DeepEP dispatch on Intel XPU; pass "
+                    "--moe-runner-backend triton."
+                )
             if self.moe_runner_backend == "flashinfer_cutedsl":
                 if self.deepep_mode == "auto":
                     self._declare(

--- a/test/registered/unit/layers/moe/test_triton_runner_deepep.py
+++ b/test/registered/unit/layers/moe/test_triton_runner_deepep.py
@@ -1,0 +1,196 @@
+"""Triton MoE runner <-> DeepEP normal permutes (used by Intel XPU EP)."""
+
+import sys
+
+import pytest
+import torch
+
+import sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe as fused_moe_module
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig, PermuteMethodPool
+from sglang.srt.layers.moe.moe_runner.triton import (
+    TritonMoeQuantInfo,
+    TritonRunnerCore,
+    TritonRunnerInput,
+    TritonRunnerOutput,
+    post_permute_triton_to_deepep_normal,
+    pre_permute_deepep_normal_to_triton,
+)
+from sglang.srt.layers.moe.token_dispatcher.deepep import DeepEPNormalDispatchOutput
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+NUM_LOCAL_EXPERTS = 2
+HIDDEN = 4
+
+
+def _dispatch_output(hidden_states_scale=None):
+    # Local expert ids, with -1 in the slots owned by another EP rank.
+    topk_ids = torch.tensor([[0, -1], [-1, 1]], dtype=torch.int64)
+    return DeepEPNormalDispatchOutput(
+        hidden_states=torch.zeros((2, HIDDEN), dtype=torch.bfloat16),
+        hidden_states_scale=hidden_states_scale,
+        topk_ids=topk_ids,
+        topk_weights=torch.full(topk_ids.shape, 0.5, dtype=torch.float32),
+        num_recv_tokens_per_expert=[1, 1],
+    )
+
+
+def _quant_info():
+    return TritonMoeQuantInfo(
+        w13_weight=torch.empty((NUM_LOCAL_EXPERTS, 2 * HIDDEN, HIDDEN)),
+        w2_weight=torch.empty((NUM_LOCAL_EXPERTS, HIDDEN, HIDDEN)),
+    )
+
+
+def _runner_config(**overrides):
+    kwargs = dict(
+        num_experts=4,
+        num_local_experts=NUM_LOCAL_EXPERTS,
+        top_k=2,
+        routed_scaling_factor=2.5,
+    )
+    kwargs.update(overrides)
+    return MoeRunnerConfig(**kwargs)
+
+
+def _stub_prepare(monkeypatch):
+    """Replace the block-alignment kernels with fixed CPU tensors."""
+
+    def _prepare_fused_moe_run(*args, **kwargs):
+        return (
+            {"BLOCK_SIZE_M": 16},
+            None,
+            False,
+            False,
+            torch.zeros(4, dtype=torch.int32),
+            torch.tensor([0, -1], dtype=torch.int32),
+            torch.tensor([4], dtype=torch.int32),
+        )
+
+    monkeypatch.setattr(
+        fused_moe_module, "_prepare_fused_moe_run", _prepare_fused_moe_run
+    )
+
+
+def test_permutes_are_registered():
+    assert (
+        PermuteMethodPool.get_pre_permute("deepep_normal", "triton")
+        is pre_permute_deepep_normal_to_triton
+    )
+    assert (
+        PermuteMethodPool.get_post_permute("triton", "deepep_normal")
+        is post_permute_triton_to_deepep_normal
+    )
+
+
+def test_pre_permute_passes_recv_layout_through(monkeypatch):
+    _stub_prepare(monkeypatch)
+    dispatch_output = _dispatch_output()
+    running_state = {}
+
+    runner_input = pre_permute_deepep_normal_to_triton(
+        dispatch_output,
+        _quant_info(),
+        _runner_config(),
+        running_state,
+    )
+
+    assert isinstance(runner_input, TritonRunnerInput)
+    # The recv tokens and their local expert ids are consumed as-is.
+    assert runner_input.hidden_states is dispatch_output.hidden_states
+    assert runner_input.topk_ids is dispatch_output.topk_ids
+    assert runner_input.topk_weights is dispatch_output.topk_weights
+    assert running_state["config"] == {"BLOCK_SIZE_M": 16}
+    # DeepEP combine still has to reduce across ranks, so the scaling is left
+    # to the caller.
+    assert runner_input.apply_routed_scaling_factor is False
+
+
+def test_pre_permute_rejects_quantized_dispatch(monkeypatch):
+    _stub_prepare(monkeypatch)
+
+    with pytest.raises(AssertionError, match="bf16 DeepEP dispatch"):
+        pre_permute_deepep_normal_to_triton(
+            _dispatch_output(hidden_states_scale=torch.ones((2, 1))),
+            _quant_info(),
+            _runner_config(),
+            {},
+        )
+
+
+def test_pre_permute_rejects_router_weight_on_input(monkeypatch):
+    _stub_prepare(monkeypatch)
+
+    with pytest.raises(AssertionError, match="apply_router_weight_on_input"):
+        pre_permute_deepep_normal_to_triton(
+            _dispatch_output(),
+            _quant_info(),
+            _runner_config(apply_router_weight_on_input=True),
+            {},
+        )
+
+
+def test_post_permute_carries_topk_for_combine():
+    dispatch_output = _dispatch_output()
+    running_state = {
+        "topk_ids": dispatch_output.topk_ids,
+        "topk_weights": dispatch_output.topk_weights,
+    }
+    hidden_states = torch.zeros((2, HIDDEN), dtype=torch.bfloat16)
+
+    combine_input = post_permute_triton_to_deepep_normal(
+        TritonRunnerOutput(hidden_states=hidden_states),
+        _quant_info(),
+        _runner_config(),
+        running_state,
+    )
+
+    assert combine_input.format.value == "deepep_normal"
+    assert combine_input.hidden_states is hidden_states
+    assert combine_input.topk_ids is dispatch_output.topk_ids
+    assert combine_input.topk_weights is dispatch_output.topk_weights
+
+
+def test_runner_core_honors_apply_routed_scaling_factor(monkeypatch):
+    captured = {}
+
+    def _fused_moe_kernel_sequence(*args, **kwargs):
+        captured.update(kwargs)
+        return args[0]
+
+    monkeypatch.setattr(
+        fused_moe_module, "_fused_moe_kernel_sequence", _fused_moe_kernel_sequence
+    )
+
+    def _runner_input(**overrides):
+        dispatch_output = _dispatch_output()
+        return TritonRunnerInput(
+            hidden_states=dispatch_output.hidden_states,
+            topk_weights=dispatch_output.topk_weights,
+            topk_ids=dispatch_output.topk_ids,
+            sorted_token_ids=torch.zeros(4, dtype=torch.int32),
+            expert_ids=torch.tensor([0, -1], dtype=torch.int32),
+            num_tokens_post_padded=torch.tensor([4], dtype=torch.int32),
+            **overrides,
+        )
+
+    core = TritonRunnerCore(_runner_config())
+    running_state = {"config": {"BLOCK_SIZE_M": 16}}
+
+    core.run(
+        _runner_input(apply_routed_scaling_factor=False),
+        _quant_info(),
+        running_state,
+    )
+    assert captured["routed_scaling_factor"] is None
+    # Local expert ids mean the kernel must skip the -1 blocks.
+    assert captured["filter_expert"] is True
+
+    captured.clear()
+    core.run(_runner_input(), _quant_info(), running_state)
+    assert captured["routed_scaling_factor"] == 2.5
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2335,5 +2335,46 @@ class TestDcpKvEventContract(CustomTestCase):
         self.assertEqual(args.kv_event_block_size, 8)
 
 
+class TestXpuDeepEPArgs(CustomTestCase):
+    def _args(self, device="xpu", **overrides):
+        # dummy-model path short-circuits __post_init__; invoke the handler directly.
+        args = ServerArgs(
+            model_path="dummy", device=device, moe_a2a_backend="deepep", **overrides
+        )
+        # deepep_mode=normal reaches into cuda_graph_config, which the pipeline
+        # builds in an earlier handler.
+        args._parse_cuda_graph_config()
+        return args
+
+    def test_auto_deepep_mode_resolves_to_normal(self):
+        args = self._args(deepep_mode="auto")
+        args._handle_a2a_moe()
+        self.assertEqual(args.deepep_mode, "normal")
+
+    def test_low_latency_deepep_mode_raises(self):
+        args = self._args(deepep_mode="low_latency")
+        with self.assertRaisesRegex(ValueError, "--deepep-mode normal"):
+            args._handle_a2a_moe()
+
+    def test_non_triton_moe_runner_backend_raises(self):
+        args = self._args(deepep_mode="normal", moe_runner_backend="deep_gemm")
+        with self.assertRaisesRegex(AssertionError, "--moe-runner-backend triton"):
+            args._handle_a2a_moe()
+
+    def test_other_devices_are_untouched(self):
+        """Both configs below are rejected on XPU, so a missing device check
+        would turn them into startup failures on cuda / npu / cpu."""
+        for device in ("cuda", "npu", "cpu"):
+            with self.subTest(device=device):
+                args = self._args(
+                    device=device,
+                    deepep_mode="low_latency",
+                    moe_runner_backend="deep_gemm",
+                )
+                args._handle_a2a_moe()
+                self.assertEqual(args.deepep_mode, "low_latency")
+                self.assertEqual(args.moe_runner_backend, "deep_gemm")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

MoE expert parallelism has no working all-to-all path on Intel XPU today.
`--moe-a2a-backend deepep` fails on XPU for several independent reasons: the
DeepEP dispatcher gates itself on CUDA-only facilities (the fp8 quant kernel,
`torch.cuda.get_device_properties` for SM occupancy, an MNNVL probe that touches
`torch.cuda`), the DeepEP `normal` recv layout has no permute registered for the
triton MoE runner, and `UnquantizedFusedMoEMethod.forward_xpu` accepts only a
standard (non-A2A) dispatch output. The result is that EP on XPU either raises
deep inside a kernel or silently has no route from dispatch to the experts.

This PR adds the SGLang-side integration for a bf16 DeepEP `normal` dispatch
consumed by the triton MoE runner, which is the one combination that has kernels
on XPU.

The all-to-all transport itself is **not** part of SGLang. The upstream CUDA
DeepEP wheel is NVLink/NVSHMEM/RDMA-specific and will not run here, so an
Intel-GPU `deep_ep`-API-compatible package is required. The port used to
validate this PR is
https://github.com/dayanandav/frameworks.ai.pytorch.deepep/tree/deepep_xpu_us
(branch `deepep_xpu_us`), which implements the transport over ISHMEM instead of
NVSHMEM. SGLang only requires that it be importable as `deep_ep` and expose
`Buffer` with `get_dispatch_layout` / `dispatch` / `combine`.

## Modifications

Startup resolution (`server_args.py`, `_handle_a2a_moe`):
- An XPU sub-branch in the existing `deepep` block, alongside the
  `flashinfer_cutedsl` / `mori` / `pplx` ones: `--deepep-mode auto` resolves to
  `normal` and `low_latency` is rejected (its masked
  `[experts, tokens, hidden]` layout needs a masked grouped GEMM, i.e. DeepGEMM
  on CUDA, and no `deepep_ll` permute is registered for XPU), and the MoE runner
  backend is asserted to be `auto`/`triton`.
- This is the only resolution XPU needs. Other a2a backends and other MoE
  runners are not guarded here -- they fail at their own CUDA/ROCm imports, and
  hard-coding a device deny-list would block any future XPU port. The dispatch
  dtype is not guarded either: it can be selected by the model's quant config
  with no user flag involved, so the downgrade lives in the dispatcher (below)
  where it sees the real value.

Triton MoE runner (`layers/moe/moe_runner/triton.py`):
- New `deepep_normal -> triton` pre-permute and `triton -> deepep_normal`
  post-permute. Recv topk ids are already local expert ids with `-1` in slots
  another rank owns, which `moe_align_block_size` and the kernel's
  `filter_expert` branch already handle, so the recv layout is consumed with no
  re-scatter.
- Factored the block-alignment/config resolution shared by the standard and
  deepep_normal pre-permutes into `_align_experts_and_stash_config`.
- `TritonRunnerInput` gains `apply_routed_scaling_factor: bool = True`, matching
  the existing convention in `humming.py` / `flashinfer_cutlass.py`. The
  deepep_normal pre-permute sets it `False` because a DeepEP combine reduces
  across ranks and must scale after the reduction, not before.

DeepEP dispatcher (`layers/moe/token_dispatcher/deepep.py`):
- Skip the CUDA-only gating on XPU: the fp8 quant-kernel import, the
  `torch.cuda.get_device_properties` SM-occupancy sizing, and the MNNVL fabric
  probe (now short-circuited off CUDA entirely).
- XPU dtype policy: fp8/int8 dispatch downgrades to bf16 with a warning, nvfp4
  raises. `get_deepep_output_dtype` defaults to BF16 on XPU, as it already does
  on NPU (`layers/moe/utils.py`).
- `_DeepEPDispatcherImplNormal` treats XPU like NPU/aiter and returns the recv
  layout as-is.
- `torch.cuda.stream(...)` -> `self.device_module.stream(...)` in the
  low-latency overlap path.

MoE layers:
- `DeepEPMoE` uses the modern runner on XPU (`ep_moe/layer.py`), since there is
  no DeepGEMM there.
- `UnquantizedFusedMoEMethod.forward_xpu` now accepts a `DispatchOutput` and
  routes non-standard (A2A recv) formats through the runner's permutes;
  `fused_experts` below cannot consume local expert ids
  (`layers/quantization/unquant.py`).

Docs and tests:
- `docs/docs/hardware-platforms/xpu.mdx`: new "Expert Parallelism with DeepEP on
  Intel XPU [Experimental]" section with the supported launch command, the
  out-of-tree transport requirement and its repo, and a limitations table.
- `test/registered/unit/layers/moe/test_triton_runner_deepep.py` (new, CPU CI):
  permute registration, recv-layout pass-through, the deferred routed scaling,
  and the bf16 / `apply_router_weight_on_input` rejections.
- `TestXpuDeepEPArgs` in `test/registered/unit/server_args/test_server_args.py`:
  the `auto -> normal` resolution, both rejections, and that neither fires on
  cuda / npu / cpu.

## Accuracy Tests

Not available yet, and I would rather say so than post a number I cannot stand
behind. Two reasons:

- The XPU DeepEP bring-up runs were launched with `--load-format dummy` (random
  weights), so their outputs carry no accuracy signal.
- The transport is out of tree, so an accuracy job cannot run in SGLang CI as
  submitted.

GSM8K on real weights for `Qwen/Qwen1.5-MoE-A2.7B` with
`--moe-a2a-backend deepep` versus the same model with `--moe-a2a-backend none`
is the missing piece, and is why this is a draft. Numbers will be posted here
before the PR is marked ready.

What is covered meanwhile: the new CPU unit tests pin the permute contracts
(local expert ids consumed without re-scatter, routed scaling deferred to after
the combine, bf16-only dispatch) and both branches of the XPU deepep resolution,
including that neither touches cuda / npu / cpu.

## Speed Tests and Profiling

Functional bring-up measurements only -- these establish that the path runs
end to end on real hardware, not that it is fast. Please read the caveats.

Setup: `Qwen/Qwen1.5-MoE-A2.7B`, `--device xpu --tp 2 --ep-size 2`,
`--moe-a2a-backend deepep --deepep-mode normal --moe-runner-backend triton
--deepep-dispatcher-output-dtype bf16`, triton attention backend,
`--load-format dummy`, `mem-fraction-static 0.6`. PyTorch 2.13.0+xpu, oneAPI
2026.0, Intel DeepEP over ISHMEM, 2 of 8 XPUs. `bench_serving`, random dataset,
5 repeats per shape.

| Shape (ISL/OSL) | Concurrency | Requests | Output tok/s (min-max over 5 repeats) | Median TPOT (ms) |
|---|---|---|---|---|
| 256 / 32 | 1 | 4 | 1.2 - 13.2 | 64 - 773 |
| 512 / 128 | 4 | 8 | 3.4 - 39.9 | 64 - 772 |

Caveats, stated plainly:

- **The spread is ~10x and the numbers are not steady state.** Each shape ran
  only 4-8 requests, and the first repeat is cold, so this is dominated by
  warm-up rather than by the dispatch path. These are smoke-test numbers.
- **No comparable baseline.** The one `--moe-a2a-backend none` capture I have
  used a different shape (ISL 2048 / OSL 4), so it cannot be differenced
  against the above. No speedup or regression is claimed in either direction.
- **Dummy weights**, so these say nothing about output quality.
- No profiling traces collected yet.

A matched-shape A/B against `--moe-a2a-backend none`, with enough requests to
reach steady state, is pending along with the accuracy run.

Also worth noting for reviewers: `deepep_mode=normal` disables decode and
prefill graph capture, so XPU graph is off on this path
(`Cuda graph is disabled because deepep_mode='normal'` in the launch log). That
is documented in the limitations table rather than worked around.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Speed is a bring-up smoke test only and accuracy is pending -- see the sections above. This is why the PR is a draft.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
