### PR TITLE
[Fix] Snapshot SWA mappings before deferred frees

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -96,6 +96,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.is_not_in_free_group = True
         self.free_group = []
         self.swa_free_group = []
+        self.swa_deferred_free_group = []
 
         self._kvcache = kvcache
         self.clear()
@@ -302,6 +303,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if alloc_full_indices is None or alloc_swa_indices is None:
             return None
 
+        self._snapshot_swa_free_group()
         if _is_npu:
             indices_2d = alloc_full_indices.to(torch.int64).unsqueeze(-1)
             torch_npu.npu_scatter_nd_update_(
@@ -341,11 +343,16 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         assert full_indices.numel() == swa_indices.numel()
         full_indices = full_indices.to(torch.int64)
         swa_indices = swa_indices.to(self.full_to_swa_index_mapping.dtype)
+        self._snapshot_swa_free_group()
         self.full_to_swa_index_mapping[full_indices] = swa_indices
 
     def clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
         if full_indices.numel() == 0:
             return
+        self._snapshot_swa_free_group()
+        self._clear_full_to_swa_mapping(full_indices)
+
+    def _clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
         # index_fill_ passes the 0 as a kernel argument; mapping[idx] = 0 copies a
         # host-resident scalar and blocks until the stream drains.
         self.full_to_swa_index_mapping.index_fill_(0, full_indices.to(torch.int64), 0)
@@ -354,33 +361,52 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if free_index.numel() == 0:
             return
 
+        if not self.is_not_in_free_group:
+            self.swa_free_group.append(self._copy_for_free_group(free_index))
+            return
+
         if self.page_size == 1:
             mapping_indices = free_index
         else:
             mapping_indices = self._expand_to_full_pages(free_index)
 
-        # Snapshot and detach the current SWA ownership before deferring the
-        # physical free. A tombstone recovery in the same free group can remap
-        # these Full slots to newly allocated SWA slots.
         swa_indices = self.full_to_swa_index_mapping[mapping_indices]
-        self.clear_full_to_swa_mapping(mapping_indices)
+        self.swa_attn_allocator.free(swa_indices[swa_indices > 0])
+        self._clear_full_to_swa_mapping(mapping_indices)
 
-        if not self.is_not_in_free_group:
-            self.swa_free_group.append(swa_indices)
+    def _snapshot_swa_free_group(self) -> None:
+        """Detach queued SWA ownership before a mapping update can replace it."""
+        if not self.swa_free_group:
             return
 
-        self.swa_attn_allocator.free(swa_indices[swa_indices > 0])
+        swa_free_group = self.swa_free_group
+        self.swa_free_group = []
+        free_index = torch.cat(swa_free_group)
+        if self.page_size == 1:
+            mapping_indices = free_index
+        else:
+            mapping_indices = self._expand_to_full_pages(free_index)
+
+        swa_indices = self.full_to_swa_index_mapping[mapping_indices]
+        self._clear_full_to_swa_mapping(mapping_indices)
+        self.swa_deferred_free_group.append(swa_indices)
 
     def free_group_begin(self):
         super().free_group_begin()
         self.swa_free_group = []
+        self.swa_deferred_free_group = []
 
     def free_group_end(self):
+        self._snapshot_swa_free_group()
         super().free_group_end()
-        if self.swa_free_group:
-            swa_free_group = self.swa_free_group
-            self.swa_free_group = []
-            swa_indices = torch.cat(swa_free_group)
+        if self.swa_deferred_free_group:
+            swa_deferred_free_group = self.swa_deferred_free_group
+            self.swa_deferred_free_group = []
+            swa_indices = (
+                swa_deferred_free_group[0]
+                if len(swa_deferred_free_group) == 1
+                else torch.cat(swa_deferred_free_group)
+            )
             self.swa_attn_allocator.free(swa_indices[swa_indices > 0])
 
     def _expand_to_full_pages(self, indices: torch.Tensor) -> torch.Tensor:
@@ -412,6 +438,7 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.is_not_in_free_group = True
         self.free_group = []
         self.swa_free_group = []
+        self.swa_deferred_free_group = []
 
     def get_cpu_copy(self, indices, mamba_indices=None):
         return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -354,19 +354,22 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if free_index.numel() == 0:
             return
 
-        if not self.is_not_in_free_group:
-            self.swa_free_group.append(self._copy_for_free_group(free_index))
-            return
-
         if self.page_size == 1:
             mapping_indices = free_index
         else:
             mapping_indices = self._expand_to_full_pages(free_index)
 
+        # Snapshot and detach the current SWA ownership before deferring the
+        # physical free. A tombstone recovery in the same free group can remap
+        # these Full slots to newly allocated SWA slots.
         swa_indices = self.full_to_swa_index_mapping[mapping_indices]
-        swa_indices = swa_indices[swa_indices > 0]
-        self.swa_attn_allocator.free(swa_indices)
         self.clear_full_to_swa_mapping(mapping_indices)
+
+        if not self.is_not_in_free_group:
+            self.swa_free_group.append(swa_indices)
+            return
+
+        self.swa_attn_allocator.free(swa_indices[swa_indices > 0])
 
     def free_group_begin(self):
         super().free_group_begin()
@@ -377,7 +380,8 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         if self.swa_free_group:
             swa_free_group = self.swa_free_group
             self.swa_free_group = []
-            self.free_swa(torch.cat(swa_free_group))
+            swa_indices = torch.cat(swa_free_group)
+            self.swa_attn_allocator.free(swa_indices[swa_indices > 0])
 
     def _expand_to_full_pages(self, indices: torch.Tensor) -> torch.Tensor:
         pages = torch.unique(indices // self.page_size)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1322,8 +1322,11 @@ class UnifiedRadixCacheSuite:
     def test_swa_unfinished_recovery_preserves_locked_full_value(self):
         if not self.cfg.has_swa or self.cfg.has_mamba:
             self.skipTest("requires SWA without Mamba")
-        if self.cfg.page_size != 1 or self.cfg.sliding_window_size != 4:
-            self.skipTest("requires page_size=1, sliding_window_size=4")
+        if (self.cfg.page_size, self.cfg.sliding_window_size) not in {
+            (1, 4),
+            (4, 4),
+        }:
+            self.skipTest("requires page_size/window_size of 1/4 or 4/4")
         cache, allocator, req_to_token_pool = build_fixture(self.cfg)
 
         tokens = self._make_seq(1, 4)
@@ -1340,6 +1343,9 @@ class UnifiedRadixCacheSuite:
         swa_component = cache.components[ComponentType.SWA]
         tracker = {ct: 0 for ct in cache.tree_components}
         device_frees = defaultdict(list)
+        # Batch-result processing defers allocator frees across cache updates.
+        # The recovery below replaces this Full slot's SWA mapping in that group.
+        allocator.free_group_begin()
         cache.tree_core._evict_component_and_detach_lru(
             node,
             swa_component,
@@ -1369,6 +1375,7 @@ class UnifiedRadixCacheSuite:
         full_available_before_insert = allocator.full_attn_allocator.available_size()
 
         cache.cache_unfinished_req(req)
+        allocator.free_group_end()
 
         self.assertEqual(
             allocator.full_attn_allocator.available_size(),
@@ -1388,6 +1395,12 @@ class UnifiedRadixCacheSuite:
                 swa_value,
             )
         )
+        mapped = allocator.full_to_swa_index_mapping
+        mapped_pages = torch.unique(mapped[mapped > 0] // self.cfg.page_size).numel()
+        physical_used_pages = (
+            allocator.size_swa - allocator.swa_available_size()
+        ) // self.cfg.page_size
+        self.assertEqual(physical_used_pages, mapped_pages)
         self.assertEqual(req.cache_protected_len, len(tokens))
 
         cache.dec_lock_ref(


### PR DESCRIPTION
## Motivation

Fixes #36081.

SGLang v0.5.18 can report a one-page SWA pool leak after grouped cache frees. `SWATokenToKVPoolAllocator.free_swa()` previously deferred Full-pool indices and resolved their Full-to-SWA mapping only in `free_group_end()`. Tombstone recovery can replace that mapping in the same free group, so the flush frees the replacement SWA page while the old physical page becomes unreachable.

I minimized this on an RTX PRO 5000 using the exact v0.5.18 Docker source revision. The unpatched allocator ended with 2 physical SWA pages in use but only 1 mapped page, reproducing the one-page discrepancy from the issue. The patched allocator preserves the invariant.

## Modifications

- Keep Full indices batched while a free group is open.
- Before any Full-to-SWA mapping write (or at `free_group_end()`), snapshot and detach the queued ownership so a tombstone recovery cannot replace it.
- Defer the captured physical SWA indices until `free_group_end()`, preserving one batched lookup/clear on the steady-state path.
- Extend the unified radix-cache recovery test to cover grouped frees for both token and paged allocators.
- Assert that mapped SWA pages equal physically allocated SWA pages after recovery.

## Accuracy Tests

This change does not affect model outputs.

Validated on an NVIDIA RTX PRO 5000:

- Exact v0.5.18 minimized reproduction, before fix: fails with 2 physical pages used vs. 1 mapped.
- Exact v0.5.18 minimized reproduction, after fix: passes.
- Targeted recovery test on current `main`: 2 passed, 17 skipped.
- `test_swa_unittest.py`: 13 passed.
- Full+SWA unified-cache configurations: 904 tests passed, 359 skipped.
- Black 26.1.0 and Ruff 0.15.1 checks passed.

The host does not provide `/usr/local/cuda/bin/nvcc`, so optional HiCache JIT kernels used their existing fallback in the broader unified-cache run.

## Speed Tests and Profiling

Allocator-bookkeeping microbenchmark on an NVIDIA RTX PRO 5000 72GB Blackwell (PyTorch 2.11.0+cu130), with 50 warmups and 500 interleaved A/B samples. It mirrors grouped `free_swa()` bookkeeping and excludes the identical physical allocator release. These steady-state cases contain no mapping replacement, so the baseline is correct and directly comparable. Values are medians per free group; wall time includes Python launch and synchronization overhead.

| page size | calls/group | pages/call | GPU before/after (us) | GPU delta | wall before/after (us) | wall delta |
|---:|---:|---:|---:|---:|---:|---:|
| 256 | 1 | 1 | 117.3 / 117.4 | +0.1% | 122.6 / 122.7 | +0.1% |
| 256 | 8 | 1 | 149.5 / 149.9 | +0.3% | 154.7 / 155.2 | +0.3% |
| 256 | 8 | 16 | 215.6 / 216.3 | +0.3% | 221.1 / 221.7 | +0.2% |
| 256 | 64 | 1 | 458.8 / 459.6 | +0.2% | 464.2 / 464.9 | +0.2% |

The page-size-1 cases (1, 8, and 64 calls/group) had wall-time deltas of +0.5%, -0.1%, and +0.4%. Across all seven cases, the final implementation stayed within -0.1% to +0.5%, i.e. measurement noise. It achieves this by inserting a snapshot barrier only before a mapping update or group end instead of performing a gather/clear on every `free_swa()` call.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: internal allocator correctness fix.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32713782397](https://github.com/sgl-project/sglang/actions/runs/32713782397)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32713782164](https://github.com/sgl-project/sglang/actions/runs/32713782164)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32713782533](https://github.com/sgl-project/sglang/actions/runs/32713782533)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->