### PR TITLE
[Fix] Preserve YAML lists for single-value config args

### DIFF
--- a/python/sglang/srt/utils/server_args_config_parser.py
+++ b/python/sglang/srt/utils/server_args_config_parser.py
@@ -31,6 +31,14 @@ class ConfigArgumentMerger:
                 for action in parser._actions
                 if isinstance(action, argparse._StoreTrueAction)
             ]
+            self.single_value_actions = set()
+            for action in parser._actions:
+                if isinstance(action, argparse._StoreAction) and action.nargs is None:
+                    self.single_value_actions.add(action.dest)
+                    self.single_value_actions.update(
+                        option.lstrip("-").replace("-", "_")
+                        for option in action.option_strings
+                    )
             self.unsupported_actions = {
                 a.dest: a
                 for a in parser._actions
@@ -44,9 +52,11 @@ class ConfigArgumentMerger:
         elif boolean_actions is not None:
             # Legacy interface for compatibility
             self.store_true_actions = boolean_actions
+            self.single_value_actions = set()
             self.unsupported_actions = {}
         else:
             self.store_true_actions = []
+            self.single_value_actions = set()
             self.unsupported_actions = {}
 
     def merge_config_with_args(self, cli_args: List[str]) -> List[str]:
@@ -178,7 +188,10 @@ class ConfigArgumentMerger:
 
     def _add_list_arg(self, args: List[str], key: str, value: List[Any]) -> None:
         """Add list argument to the list."""
-        if value:  # Only add if list is not empty
+        key_norm = key.replace("-", "_")
+        if key_norm in self.single_value_actions:
+            self._add_scalar_arg(args, key, json.dumps(value))
+        elif value:  # Only add non-empty lists for multi-value actions
             args.append(f"--{key}")
             args.extend(str(item) for item in value)
 

--- a/test/registered/unit/server_args/test_server_args_config_parser.py
+++ b/test/registered/unit/server_args/test_server_args_config_parser.py
@@ -1,0 +1,60 @@
+# SPDX-License-Identifier: Apache-2.0
+
+import argparse
+import json
+import os
+import tempfile
+import unittest
+
+from sglang.srt.utils.server_args_config_parser import ConfigArgumentMerger
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestConfigArgumentMerger(unittest.TestCase):
+    def _merge(self, parser, config):
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write(config)
+            config_file = f.name
+
+        try:
+            return ConfigArgumentMerger(parser).merge_config_with_args(
+                ["--config", config_file]
+            )
+        finally:
+            os.unlink(config_file)
+
+    def test_yaml_list_is_json_for_single_value_action(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--forward-hooks", type=json.loads)
+
+        merged = self._merge(
+            parser,
+            "forward-hooks:\n  - type: capture\n    layers: [1, 2]\n",
+        )
+
+        self.assertEqual(
+            parser.parse_args(merged).forward_hooks,
+            [{"type": "capture", "layers": [1, 2]}],
+        )
+
+    def test_empty_yaml_list_is_preserved_for_single_value_action(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--sidecar-args", type=json.loads)
+
+        merged = self._merge(parser, "sidecar-args: []\n")
+
+        self.assertEqual(parser.parse_args(merged).sidecar_args, [])
+
+    def test_yaml_list_is_expanded_for_multi_value_action(self):
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--cuda-graph-bs", type=int, nargs="+")
+
+        merged = self._merge(parser, "cuda-graph-bs: [1, 4]\n")
+
+        self.assertEqual(parser.parse_args(merged).cuda_graph_bs, [1, 4])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`ConfigArgumentMerger` currently expands every YAML list into separate argv entries. That is correct for multi-value arguments such as `--cuda-graph-bs`, but it breaks arguments that consume one JSON array string, including `--sidecar-args`, `--decoupled-spec-connect-endpoints`, `--remote-instance-weight-loader-send-weights-group-ports`, and `--forward-hooks`.

For example, a natural YAML value for `forward-hooks` is split into Python string representations instead of being passed as one valid JSON array, so argument parsing fails before the server starts. Empty lists are also dropped and become `None`.

## Modifications

- Track parser actions that consume a single value.
- Serialize YAML lists for those actions as one JSON argument, including empty lists.
- Keep the existing item-by-item expansion for actions with `nargs`.
- Add registered CPU tests for structured JSON lists, empty lists, and ordinary multi-value lists.

## Accuracy Tests

N/A — this only changes startup argument conversion.

- 3 new CPU unit tests pass.
- Python compilation checks pass.
- Pre-commit passes on both changed files.

## Speed Tests and Profiling

N/A — configuration parsing is only performed during startup.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A; no interface change.)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A; no model or hot-path change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33933231604](https://github.com/sgl-project/sglang/actions/runs/33933231604)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33933231599](https://github.com/sgl-project/sglang/actions/runs/33933231599)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33933231691](https://github.com/sgl-project/sglang/actions/runs/33933231691)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->