### PR TITLE
xeon ci fail fast strategy change

### DIFF
--- a/.github/workflows/pr-test-xeon.yml
+++ b/.github/workflows/pr-test-xeon.yml
@@ -83,7 +83,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
 
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         include:
           # GNR runs only the TP suite (needs >=6 NUMA nodes for --tp 6),


### PR DESCRIPTION
Enable fail-fast in the Xeon PR-test matrix so any failing job (SPR or GNR) cancels the others instead of letting them run to completion.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32694232553](https://github.com/sgl-project/sglang/actions/runs/32694232553)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32695023625](https://github.com/sgl-project/sglang/actions/runs/32695023625)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->