### PR TITLE
fix(xpu): read enable_deterministic_inference from the config bag

### DIFF
--- a/python/sglang/srt/layers/attention/xpu_backend.py
+++ b/python/sglang/srt/layers/attention/xpu_backend.py
@@ -16,6 +16,7 @@ from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
 from sglang.srt.runtime_context import (
+    get_exec,
     get_schedule,
     get_spec,
 )
@@ -106,7 +107,7 @@ class XPUAttentionBackend(AttentionBackend):
         # when deterministic inference is enabled to keep attention reduction
         # order fixed. This mirrors the flash-attention (fa3) backend.
         self.num_splits = (
-            1 if model_runner.server_args.enable_deterministic_inference else 0
+            1 if get_exec().deterministic.enable_deterministic_inference else 0
         )
         self.is_encoder_decoder = model_runner.model_config.is_encoder_decoder
 


### PR DESCRIPTION
## Motivation

`test/registered/unit/test_chain_read_ratchet.py` is currently failing on `main`:

```
AssertionError: Lists differ: ['srt/layers/attention/xpu_backend.py:109 ...'] != []

First extra element 0:
'srt/layers/attention/xpu_backend.py:109 model_runner.server_args.enable_deterministic_inference'
```

`XPUAttentionBackend.__init__` reaches the startup record through another object (`model_runner.server_args`) for a value that resolution decides, so it answers with the raw CLI default once the record stays raw.

This looks like a merge race: #29143 added the `num_splits` block using the pre-migration spelling while the config-bag migration (#35907 / #35910) landed alongside it. Every other attention backend already reads this field through `get_exec().deterministic` — `dsa_backend.py:316`, `flashattention_backend.py:320`, `flashinfer_backend.py:409`, `triton_backend.py:292`, `linear/gdn_backend.py:75` — so XPU was the last holdout, and it is the only borrowed-record chain read of a resolution-written field left in `srt/`.

## Modifications

Read `enable_deterministic_inference` from the config bag instead of the borrowed record:

```python
self.num_splits = (
    1 if get_exec().deterministic.enable_deterministic_inference else 0
)
```

plus the corresponding `get_exec` import. One line of behavior, matching the fa3 backend the surrounding comment already points at.

## Accuracy Tests

No output change on the default path: `enable_deterministic_inference` defaults to off, and both spellings read the same field — the config bag simply returns the resolved value rather than the CLI default. With the flag on, XPU now actually pins `num_splits = 1` in the case where resolution would have set it, which is the intent of #29143.

## Speed Tests and Profiling

N/A — a startup-time config read, not on any hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

The existing ratchet test is the unit test for this — it goes green with this change and no new test is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32694848718](https://github.com/sgl-project/sglang/actions/runs/32694848718)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32694848571](https://github.com/sgl-project/sglang/actions/runs/32694848571)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32694848660](https://github.com/sgl-project/sglang/actions/runs/32694848660)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->