### PR TITLE
fix(mini-lb): forward the flush_cache timeout param to workers

### DIFF
--- a/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/mini_lb.py
@@ -258,12 +258,18 @@ async def health_generate():
 
 
 @app.post("/flush_cache")
-async def flush_cache():
+async def flush_cache(timeout: Optional[float] = None):
+    # `timeout` must reach the workers. The scheduler treats a missing or
+    # non-positive timeout as "flush now, skip the idle check", so dropping it
+    # here frees KV buffers while a PD KV transfer is still reading them: the
+    # transfer then fails for real and the peer session gets blacklisted.
+    # Forwarding it keeps the scheduler on its deferred, drain-first path.
+    params = None if timeout is None else {"timeout": timeout}
     async with aiohttp.ClientSession() as session:
         # Create the tasks
         tasks = []
         for server in chain(lb.prefill_urls, lb.decode_urls):
-            tasks.append(session.post(f"{server}/flush_cache"))
+            tasks.append(session.post(f"{server}/flush_cache", params=params))
         for i, response in enumerate(asyncio.as_completed(tasks)):
             await response
     return Response(status_code=200)


### PR DESCRIPTION
## Motivation

`mini_lb`'s `/flush_cache` handler took **no parameters** and posted to a bare `{server}/flush_cache`, dropping any `?timeout=` the caller sent:

```python
@app.post("/flush_cache")
async def flush_cache():
    async with aiohttp.ClientSession() as session:
        tasks = []
        for server in chain(lb.prefill_urls, lb.decode_urls):
            tasks.append(session.post(f"{server}/flush_cache"))   # no query string
```

The scheduler treats a missing or non-positive timeout as *"flush now, skip the idle check"* (`scheduler_components/flush_wrapper.py`):

```python
timeout_s = float(recv_req.timeout_s or 0.0)
if timeout_s <= 0.0:
    return FlushCacheReqOutput(success=self._flush_cache())   # immediate, no idle gate
if self._is_fully_idle():
    ...
```

So `SchedulerFlushWrapper`'s deferral path — which waits for `is_fully_idle()`, and that **already** accounts for `disagg_prefill_inflight_queue`, `disagg_decode_transfer_queue` and the prealloc/retracted queues — was unreachable. The drain-first machinery was correct and complete; nothing could reach it.

This is the path used by PD disaggregation CI: `PDDisaggregationServerBase.launch_lb` passes `--mini-lb`, and `launch_router.py:40-42` dispatches to `MiniLoadBalancer`.

### The consequence

A destructive KV-cache flush landing under an in-flight PD transfer. Observed on an 8xH20 run of `test_disaggregation_dp_attention.py::test_bench_serving`, where `bench_serving` explicitly asks for a deferred flush after warmup (`params={"timeout": 60.0}`, `benchmark/serving.py:991`):

```
transfer_metadata_dump.cpp:33  buffer type cuda:0, address 0x7fa53a000000--...
Session 192.168.0.235:15436 failed.
Prefill transfer failed for request rank=0 ...
Decode transfer failed for request rank=0 ...
Cache flushed successfully!   (DP0, DP2, DP1, DP3)
POST /flush_cache HTTP/1.1 200 OK
```

Mooncake is **right** to fail there — it is reading buffers that were just freed. This is not flaky hardware and not a spurious transfer error.

The amplification lives in `MooncakeKVManager`, where a single `ret != 0` blacklists a peer session permanently (`session_failures >= 1`) with the recovery probe off by default (`SGLANG_ENABLE_FAILED_SESSION_PROBE = EnvBool(False)`, 30s interval — longer than the 32.65s benchmark):

| | attempt 1 (FAIL) | attempt 2 (PASS) |
|---|---|---|
| `Session ... failed.` events | 12 (4 each × 3 sessions) | **0** |
| requests rejected by the blacklist | ~1465 | 0 |
| decode DP ranks knocked out | **3 of 4** | 0 |
| empty responses | **86.9%** | 15.1% |
| honest output throughput (retokenized) | 2,039 tok/s | 9,994 tok/s |

Same commit, two attempts, different runners. 12 real transfer failures became ~1465 failed requests. `assertLess(mean_tpot_ms, 20)` was the only thing that noticed.

## Modifications

1 file, +8 / -2. `/flush_cache` accepts an optional `timeout` query parameter and forwards it to each worker, **only when the caller supplied one** — a caller that omits it keeps today's behavior exactly.

## Accuracy Tests

Not applicable — load-balancer admin endpoint; no model output, kernel, or forward path is touched.

## Speed Tests and Profiling

Not applicable. One optional query parameter per worker on an admin fan-out.

## Verification performed

Both halves of the forwarding were executed, not assumed:

| Check | Result |
|---|---|
| FastAPI binds `?timeout=60` to the handler | `60.0` |
| FastAPI with no parameter | `None` |
| aiohttp `params={"timeout": 60.0}` | `.../flush_cache?timeout=60.0` |
| aiohttp `params=None` | `.../flush_cache` (no query string) |

Plus `ruff 0.15.1 --select=F401,F821,UP037`, `black 26.1.0`, `isort 7.0.0` clean, and `py_compile` passes.

`mini_lb` has no unit-test harness in-tree, so the fix is covered by the behavioral verification above rather than a committed test. Happy to introduce a harness if maintainers want one here.

Not verified end-to-end on a live PD deployment — that needs 8 GPUs plus RDMA. The chain from dropped parameter to `timeout_s = 0.0` to the immediate-flush branch is established from the code, and the CI log above shows the flush landing between the session failure and `Cache flushed successfully!`.

## Scope notes

Three related items deliberately left out of this PR:

- **The Rust router** (`experimental/sgl-router/src/server/routes/cache.rs`) has the same defect independently — no query extractor, bare worker URL. It is not in the PD test path. Left for a separate change.
- **The scheduler's `timeout_s <= 0` fast path** is still a footgun for any caller that omits the parameter; `mini_lb` was just the caller that exposed it. Changing it would alter `/flush_cache` semantics for callers relying on a synchronous flush.
- **The single-strike permanent session blacklist** in `MooncakeKVManager` is what turned 12 legitimate failures into ~1465. Even a correct one-off failure should not condemn a rank for the process lifetime with recovery disabled by default.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — `mini_lb` has no test harness in-tree; behavior verified as above.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: existing endpoint, behavior now matches documented intent.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32698036872](https://github.com/sgl-project/sglang/actions/runs/32698036872)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32698036756](https://github.com/sgl-project/sglang/actions/runs/32698036756)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->