### PR TITLE
fix: keep eager unified SWA freeing opt-in

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -601,7 +601,10 @@ class Envs:
     # Kill-switch for the shared-index (IndexShare) swap-in prefetch
     # (auto-enabled for GLM-5.2-style DSA); set True to A/B synchronous swap-in.
     SGLANG_DISABLE_HISPARSE_PREFETCH = EnvBool(False)
-    SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS = EnvBool(True)
+    # Keep eager SWA slot freeing opt-in. Freeing SWA KV inside a cached prompt
+    # removes the window needed to branch at arbitrary prefix positions, so the
+    # unified cache can only match back to an earlier chunk boundary.
+    SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS = EnvBool(False)
     # Decode batches between SWA out-of-window evictions.
     SGLANG_SWA_EVICTION_INTERVAL = EnvInt(128)
     # Deprecated: the unified radix tree is the default tree cache now, so the

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1,6 +1,7 @@
 """Unit tests for UnifiedRadixCache"""
 
 import json
+import os
 import shutil
 import sys
 import tempfile
@@ -92,6 +93,60 @@ from sglang.srt.server_args import (
 from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
+
+
+class TestUnifiedCacheEnvDefaults(CustomTestCase):
+    def test_eager_swa_slot_freeing_is_opt_in(self):
+        flag = envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(flag.name, None)
+            self.assertFalse(flag.get())
+
+    def test_default_preserves_unaligned_swa_prefix_branch(self):
+        cfg = CacheConfig(
+            page_size=1,
+            components=(ComponentType.FULL, ComponentType.SWA),
+            sliding_window_size=4,
+            kv_size=64,
+            max_context_len=64,
+        )
+        cache, allocator, req_to_token_pool = build_fixture(cfg)
+        tokens = list(range(1, 21))
+        req = Req(
+            rid="unaligned-branch",
+            origin_input_text="",
+            origin_input_ids=array("q", tokens),
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=1),
+        )
+        req_to_token_pool.alloc([req])
+        kv_indices = allocator.alloc(len(tokens))
+        req_to_token_pool.write((req.req_pool_idx, slice(0, len(tokens))), kv_indices)
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(0, len(tokens))
+        req.kv_committed_len = len(tokens)
+        req.kv = ReqKvInfo(kv_allocated_len=len(tokens), swa_evicted_seqlen=0)
+        req.last_node = cache.root_node.id
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+
+        flag = envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop(flag.name, None)
+            cache.cache_unfinished_req(req)
+
+        # Branch before the inserted chunk's retained SWA tail. Eager freeing
+        # used to make this fall all the way back to an earlier tree boundary.
+        branch = tokens[:18]
+        match = cache.match_prefix(MatchPrefixParams(key=RadixKey(array("q", branch))))
+        self.assertEqual(len(match.device_indices), len(branch))
+
+        cache.dec_lock_ref(
+            req.last_node,
+            DecLockRefParams(swa_uuid_for_lock=req.swa_uuid_for_lock),
+        )
+        cache.sanity_check()
+
 
 register_cuda_ci(est_time=50, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=50, suite="stage-b-test-1-gpu-small-amd")


### PR DESCRIPTION
[by Codex]

## Summary

- keep `SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS` opt-in
- document why eager SWA freeing weakens arbitrary prefix branching
- add a regression test for a shared-prefix branch that ends before the retained SWA tail

Fixes #36131.

## Root cause

Eager out-of-window freeing runs while `UnifiedRadixCache.cache_unfinished_req()` incrementally inserts a long prompt. For the SWA component, each inserted chunk keeps only a trailing sliding window of live SWA KV and represents the older span as a tombstone.

Unified matching currently chooses one reusable prefix length that is valid for every component. A branch inside a chunk is therefore reusable only if enough live SWA KV ends at that exact branch. If the branch falls before the chunk's retained tail, the full-attention component may still have all of its KV, but the unified match must fall back to an earlier node where the SWA validator is also satisfied.

For a long shared-prefix workload, a branch that lands before the retained SWA tail cannot reuse the full-attention KV through that branch. Matching instead falls back to an earlier cache node and performs extra prefill work.

Supporting component-specific hit lengths while recomputing only the missing SWA window would require a larger scheduler/cache representation change. Until that exists, enabling eager freeing by default trades away normal arbitrary-prefix reuse. This PR restores the safe default while retaining the environment variable for explicit memory/cache-granularity experiments.

## Validation

- `python3 -m pytest -q test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py -k TestUnifiedCacheEnvDefaults`
  - `2 passed, 2209 deselected`
- complete `test_unified_radix_cache_unittest.py`
  - `1118 passed, 1093 skipped, 50 subtests passed`
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`
  - passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32696687708](https://github.com/sgl-project/sglang/actions/runs/32696687708)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32696687385](https://github.com/sgl-project/sglang/actions/runs/32696687385)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32696687522](https://github.com/sgl-project/sglang/actions/runs/32696687522)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->