### PR TITLE
fix(function-call): preserve text after DeepSeek tool calls

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -259,9 +259,20 @@ class DeepSeekV32Detector(BaseFormatDetector):
             return StreamingParseResult(normal_text=current_text)
 
         all_calls: list[ToolCallItem] = []
-        # Only recovered for the first call: the DSML guard above never releases a
-        # buffer that still holds a marker, so later prose stays buffered.
-        preamble = ""
+        normal_text_parts: list[str] = []
+
+        def normal_prefix(end: int) -> str:
+            """Return ordinary text before an invoke, excluding DSML wrappers."""
+            prefix = current_text[:end]
+            bot_pos = current_text.rfind(self.bot_token, 0, end)
+            if bot_pos != -1:
+                prefix = current_text[:bot_pos]
+            for token in (self.eot_token, self.invoke_end_token):
+                prefix = prefix.replace(token, "")
+            if self.eot_token in current_text[:end]:
+                prefix = prefix.lstrip("\n")
+            return prefix.removesuffix("\n\n")
+
         try:
             # Loop to handle multiple consecutive invoke blocks
             while True:
@@ -278,8 +289,11 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     invoke_match
                 )
 
-                # Initialize state if this is the first tool call
-                if self.current_tool_id == -1:
+                # Record the text before each invoke.  The first call's
+                # preamble and any text between later calls are both normal
+                # response content, not part of the tool-call payload.
+                first_tool_call = self.current_tool_id == -1
+                if first_tool_call:
                     self.current_tool_id = 0
                     self.prev_tool_call_arr = []
                     self.streamed_args_for_tool = [""]
@@ -288,7 +302,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     if bot_pos != -1:
                         call_start = bot_pos
                     # Same trailing-newline trim as detect_and_parse, so both agree.
-                    preamble = current_text[:call_start].removesuffix("\n\n")
+                    normal_text_parts.append(normal_prefix(call_start))
+                else:
+                    normal_text_parts.append(normal_prefix(invoke_match.start()))
 
                 # Ensure arrays are large enough for current tool
                 while len(self.prev_tool_call_arr) <= self.current_tool_id:
@@ -363,8 +379,29 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     # Wait for more chunks until we see </｜DSML｜invoke>
                     break
 
-            # No more invoke blocks found
-            return StreamingParseResult(normal_text=preamble, calls=all_calls)
+            # Preserve ordinary text after a completed invoke.  Previously this
+            # suffix stayed in ``_buffer`` but was omitted from the result, so
+            # streaming responses lost text generated after a tool call.
+            postamble = current_text
+            had_wrapper_end = self.eot_token in postamble
+            for token in (self.eot_token, self.invoke_end_token):
+                postamble = postamble.replace(token, "")
+            if had_wrapper_end:
+                postamble = postamble.lstrip("\n")
+
+            if (
+                postamble
+                and not any(marker in postamble for marker in dsml_markers)
+                and not any(
+                    postamble.rstrip().endswith(prefix) for prefix in dsml_prefixes
+                )
+            ):
+                normal_text_parts.append(postamble)
+                self._buffer = ""
+
+            return StreamingParseResult(
+                normal_text="".join(normal_text_parts), calls=all_calls
+            )
 
         except Exception as e:
             logger.error(f"Error in parse_streaming_increment: {e}")
@@ -373,8 +410,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
             # Calls are dropped on purpose: the failure can land between a tool's
             # name and its arguments, and a half-formed call is worse than none.
             self._buffer = ""
-            if not current_text.startswith(preamble):
-                current_text = preamble + current_text
+            normal_text = "".join(normal_text_parts)
+            if not current_text.startswith(normal_text):
+                current_text = normal_text + current_text
             return StreamingParseResult(normal_text=current_text)
 
     def structure_info(self) -> _GetInfoFunc:

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -68,6 +68,23 @@ class TestDeepSeekV4Streaming(CustomTestCase):
             normal, DeepSeekV4Detector().detect_and_parse(text, self.tools).normal_text
         )
 
+    def test_text_after_tool_call_is_not_dropped(self):
+        """Plain text following a completed invoke must survive streaming."""
+        text = _weather_call() + "\nThe rest of the answer."
+        normal, calls = self._feed([text])
+
+        self.assertEqual(normal, "The rest of the answer.")
+        self.assertEqual([c.name for c in calls if c.name], ["get_weather"])
+
+    def test_text_between_multiple_tool_calls_is_not_dropped(self):
+        text = _weather_call("SF") + "\nChecking another city.\n" + _weather_call("NY")
+        normal, calls = self._feed([text])
+
+        self.assertEqual(normal, "Checking another city.\n")
+        self.assertEqual(
+            [c.name for c in calls if c.name], ["get_weather", "get_weather"]
+        )
+
     def test_preamble_before_bare_invoke_without_wrapper(self):
         """The bare `<｜DSML｜invoke …>` form has no tool_calls wrapper to walk
         back to, so the preamble is computed from the invoke itself."""


### PR DESCRIPTION
## Motivation

Fixes #34214. DeepSeek V3.2/V4 streaming parsing dropped ordinary text that followed a completed DSML invoke, and also dropped text between multiple invokes. This made mixed content + tool-call responses incomplete.

## What

- preserve text before, between, and after streamed invokes
- strip DSML wrapper tokens from the returned normal text
- keep partial future tool-call markers buffered
- add DeepSeek V4 regression tests for postamble and inter-call text

## Tests

- `PYTHONPATH=/tmp/sglang-test-stubs:python python -m pytest -q test/registered/unit/function_call/test_deepseekv4_detector.py test/registered/unit/function_call/test_function_call_parser.py` (213 passed)
- `pre-commit run --files python/sglang/srt/function_call/deepseekv32_detector.py test/registered/unit/function_call/test_deepseekv4_detector.py` (all passed)

Related: #34214

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32700282374](https://github.com/sgl-project/sglang/actions/runs/32700282374)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32700282240](https://github.com/sgl-project/sglang/actions/runs/32700282240)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32700282348](https://github.com/sgl-project/sglang/actions/runs/32700282348)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->