### PR TITLE
[Fix] Qwen3.5 MTP: ask the checkpoint whether mtp.* is quantized

### DIFF
--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -7,6 +7,7 @@
 import collections
 import concurrent.futures
 import fnmatch
+import functools
 import glob
 import hashlib
 import itertools
@@ -129,6 +130,81 @@ def probe_routed_expert_weight_dtype(model_path: str) -> Optional[str]:
         if _ROUTED_EXPERT_KEY_RE.search(k):
             return meta.get("dtype")
     return None
+
+
+_SAFETENSORS_INDEX_NAME = "model.safetensors.index.json"
+
+# Suffixes a serialized checkpoint attaches to a quantized weight. Whether any
+# of them appears under a module prefix is what separates "this submodule ships
+# quantized" from "this submodule ships in the compute dtype".
+_QUANT_COMPANION_SUFFIXES = (
+    "weight_scale",
+    "weight_scale_inv",
+    "weight_scale_2",
+    "weight_zero_point",
+    "weight_packed",
+    "input_scale",
+)
+
+
+def _module_quantization_from_keys(keys: Iterable[str], prefix: str) -> Optional[bool]:
+    found = False
+    for key in keys:
+        if not key.startswith(prefix):
+            continue
+        found = True
+        if key.endswith(_QUANT_COMPANION_SUFFIXES):
+            return True
+    return False if found else None
+
+
+def _unindexed_safetensors_keys(model_path: str) -> List[str]:
+    keys: List[str] = []
+    for shard in sorted(Path(model_path).glob("*.safetensors")):
+        with open(shard, "rb") as f:
+            (header_len,) = struct.unpack("<Q", f.read(8))
+            header = json.loads(f.read(header_len))
+        keys.extend(k for k in header if k != "__metadata__")
+    return keys
+
+
+@functools.lru_cache(maxsize=None)
+def probe_module_is_quantized(
+    model_path: str, prefix: str, revision: Optional[str] = None
+) -> Optional[bool]:
+    """Whether the checkpoint ships the ``prefix`` submodule quantized.
+
+    ``True`` when some tensor under ``prefix`` carries a quantization companion
+    (a scale / zero-point), ``False`` when the submodule is present and carries
+    none, and ``None`` when the answer is unknown -- no tensor under ``prefix``,
+    or no locally readable index. Tensor *names* settle this, so the safetensors
+    index is enough and no shard is opened when the checkpoint has one.
+
+    A `quantization_config` that does not enumerate an unquantized submodule
+    under `exclude` is indistinguishable from one that quantizes the submodule,
+    and building it for the wrong precision surfaces only as a shape mismatch
+    deep in the weight loader. This asks the checkpoint instead. Cached: the
+    checkpoint does not change under a live process, and the index of a large
+    MoE model is tens of MB to parse.
+    """
+    if os.path.isdir(model_path):
+        index_file = os.path.join(model_path, _SAFETENSORS_INDEX_NAME)
+        if not os.path.exists(index_file):
+            return _module_quantization_from_keys(
+                _unindexed_safetensors_keys(model_path), prefix
+            )
+    else:
+        cached_index = huggingface_hub.try_to_load_from_cache(
+            model_path, _SAFETENSORS_INDEX_NAME, revision=revision
+        )
+        # Also returns a `_CACHED_NO_EXIST` sentinel, not just `None`.
+        if not isinstance(cached_index, str):
+            return None
+        index_file = cached_index
+
+    with open(index_file) as f:
+        weight_map = json.load(f).get("weight_map", {}) or {}
+    return _module_quantization_from_keys(weight_map.keys(), prefix)
 
 
 # Block size for sequential checkpoint prefetch reads (page cache warming).

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -32,7 +32,10 @@ from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
-from sglang.srt.model_loader.weight_utils import default_weight_loader
+from sglang.srt.model_loader.weight_utils import (
+    default_weight_loader,
+    probe_module_is_quantized,
+)
 from sglang.srt.models.qwen3_5 import QWEN3_5_KV_SCALE_MAPPER, Qwen3_5ForCausalLM
 from sglang.srt.runtime_context import (
     get_model,
@@ -42,6 +45,9 @@ from sglang.srt.runtime_context import (
 from sglang.srt.utils import add_prefix, is_npu
 
 logger = logging.getLogger(__name__)
+
+# Prefix every MTP tensor carries in a Qwen3.5 checkpoint.
+_MTP_WEIGHT_PREFIX = "mtp."
 
 
 def _mtp_quant_config(quant_config):
@@ -64,18 +70,54 @@ def _mtp_quant_config(quant_config):
         return None
     if is_npu() and get_spec().speculative_draft_model_quantization is None:
         return None
-    # Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module in bf16;
-    # every `mtp.*` layer appears under the quantization exclude list. Detect
-    # that and skip quantization here so linear/MoE weight loaders allocate
-    # bf16 shapes (see sgl-project/sglang#23113).
+    # Quark-quantized Qwen3.5 MXFP4 checkpoints ship the MTP module in bf16.
+    # Skip quantization for those so linear/MoE weight loaders allocate bf16
+    # shapes (see sgl-project/sglang#23113).
     if quant_config and quant_config.get_name() == "quark":
-        exclude_layers = getattr(quant_config, "exclude_layers", [])
-        if any(
-            isinstance(layer, str) and layer.startswith("mtp.")
-            for layer in exclude_layers
-        ):
+        if _quark_mtp_is_unquantized(quant_config):
             return None
     return quant_config
+
+
+def _quark_mtp_is_unquantized(quant_config) -> bool:
+    """Whether a quark checkpoint keeps its MTP module out of quantization.
+
+    `amd/Qwen3.5-397B-A17B-MXFP4` declares this by listing every `mtp.*` layer
+    under `quantization_config.exclude`. Its successor
+    `amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2` ships the same bf16 `mtp.*`
+    tensors but declares none of them, so the declaration alone is not a
+    reliable signal: believing it allocates packed MXFP4 experts for bf16
+    weights, and `_load_w13` dies on a 2048-vs-4096 shape mismatch. Ask the
+    checkpoint whenever the exclude list is silent.
+    """
+    if any(
+        isinstance(layer, str) and layer.startswith(_MTP_WEIGHT_PREFIX)
+        for layer in quant_config.exclude_layers
+    ):
+        return True
+
+    # Quark also requantizes bf16 / FP8 / NVFP4 sources on load. Those pair a
+    # quark config with unquantized `mtp.*` weights by design, and the probe
+    # would misread them as an undeclared exclude.
+    if not quant_config.is_prequantized:
+        return False
+
+    try:
+        return (
+            probe_module_is_quantized(
+                model_path=get_spec().speculative_draft_model_path
+                or get_model().model_path,
+                prefix=_MTP_WEIGHT_PREFIX,
+                revision=get_spec().speculative_draft_model_revision
+                or get_model().revision,
+            )
+            is False
+        )
+    except Exception as e:
+        # A probe that cannot answer must not keep the server from starting;
+        # the declared exclude list stays authoritative.
+        logger.warning("Could not probe the checkpoint for MTP quantization: %s", e)
+        return False
 
 
 class Qwen3_5ForCausalLMMTP(nn.Module):

--- a/test/registered/unit/models/test_qwen3_5_mtp_quant_config.py
+++ b/test/registered/unit/models/test_qwen3_5_mtp_quant_config.py
@@ -1,0 +1,124 @@
+"""The quantization a Qwen3.5 MTP module is built with.
+
+The MTP module is embedded in the target checkpoint, so it inherits the
+target's `quantization_config` unless something says otherwise. Quark MXFP4
+checkpoints ship it in bf16; `amd/Qwen3.5-397B-A17B-MXFP4` declares that by
+listing every `mtp.*` layer under `exclude`, but its successor
+`amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2` ships the same bf16 tensors and
+declares none of them. Trusting the declaration alone allocates packed MXFP4
+experts for bf16 weights, and the only symptom is a shape mismatch deep inside
+`FusedMoE._load_w13` — so these cases pin what the checkpoint itself is asked.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.model_loader.weight_utils import probe_module_is_quantized
+from sglang.srt.models.qwen3_5_mtp import _mtp_quant_config
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# One `mtp.*` and one target tensor per layout, enough for the name-only probe.
+_UNQUANTIZED_MTP_KEYS = [
+    "mtp.fc.weight",
+    "mtp.layers.0.mlp.experts.0.gate_proj.weight",
+    "model.language_model.layers.0.mlp.experts.0.gate_proj.weight",
+    "model.language_model.layers.0.mlp.experts.0.gate_proj.weight_scale",
+]
+_QUANTIZED_MTP_KEYS = _UNQUANTIZED_MTP_KEYS + [
+    "mtp.layers.0.mlp.experts.0.gate_proj.weight_scale",
+]
+
+
+def _quark_config(exclude_layers=(), is_prequantized=True):
+    return SimpleNamespace(
+        get_name=lambda: "quark",
+        exclude_layers=list(exclude_layers),
+        is_prequantized=is_prequantized,
+    )
+
+
+class _MtpQuantConfigCase(CustomTestCase):
+    def _checkpoint(self, keys):
+        """A checkpoint directory carrying just a safetensors index."""
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        model_path = tmp.name
+        with open(os.path.join(model_path, "model.safetensors.index.json"), "w") as f:
+            json.dump({"weight_map": {k: "model-00001.safetensors" for k in keys}}, f)
+        # The probe caches per (path, prefix, revision); tempfile paths are
+        # unique per case, so cases cannot bleed into one another.
+        return model_path
+
+    def _seed(self, model_path):
+        override = get_context().override_server_args(model_path=model_path)
+        override.install()
+        self.addCleanup(override.restore)
+
+
+class TestProbeModuleIsQuantized(_MtpQuantConfigCase):
+    def test_a_bf16_submodule_reads_as_unquantized(self):
+        path = self._checkpoint(_UNQUANTIZED_MTP_KEYS)
+        self.assertIs(probe_module_is_quantized(path, "mtp."), False)
+
+    def test_a_scaled_submodule_reads_as_quantized(self):
+        path = self._checkpoint(_QUANTIZED_MTP_KEYS)
+        self.assertIs(probe_module_is_quantized(path, "mtp."), True)
+        # The target side of the same checkpoint is quantized either way.
+        self.assertIs(probe_module_is_quantized(path, "model.language_model."), True)
+
+    def test_an_absent_submodule_has_no_answer(self):
+        path = self._checkpoint(_UNQUANTIZED_MTP_KEYS)
+        self.assertIsNone(probe_module_is_quantized(path, "draft."))
+
+    def test_an_uncached_remote_checkpoint_has_no_answer(self):
+        self.assertIsNone(
+            probe_module_is_quantized("sglang-test/definitely-not-a-repo", "mtp.")
+        )
+
+
+class TestQwen3_5MtpQuantConfig(_MtpQuantConfigCase):
+    def test_an_exclude_list_naming_mtp_drops_quantization(self):
+        # `amd/Qwen3.5-397B-A17B-MXFP4`: the declaration alone settles it, so
+        # the checkpoint is never opened.
+        self._seed(self._checkpoint(_QUANTIZED_MTP_KEYS))
+        quant_config = _quark_config(exclude_layers=["mtp.mlp.experts"])
+        self.assertIsNone(_mtp_quant_config(quant_config))
+
+    def test_an_undeclared_bf16_mtp_module_drops_quantization(self):
+        # `amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2`: nothing declared, bf16 on
+        # disk. Inheriting MXFP4 here is the 2048-vs-4096 crash.
+        self._seed(self._checkpoint(_UNQUANTIZED_MTP_KEYS))
+        self.assertIsNone(_mtp_quant_config(_quark_config()))
+
+    def test_a_quantized_mtp_module_keeps_quantization(self):
+        self._seed(self._checkpoint(_QUANTIZED_MTP_KEYS))
+        quant_config = _quark_config()
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+    def test_an_online_requantizing_source_keeps_quantization(self):
+        # Quark requantizing a bf16 / FP8 / NVFP4 source converts the MTP
+        # weights on load, so bf16 `mtp.*` tensors are expected there.
+        self._seed(self._checkpoint(_UNQUANTIZED_MTP_KEYS))
+        quant_config = _quark_config(is_prequantized=False)
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+    def test_a_checkpoint_without_an_mtp_module_keeps_quantization(self):
+        self._seed(self._checkpoint(["model.language_model.layers.0.mlp.gate.weight"]))
+        quant_config = _quark_config()
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+    def test_an_unreadable_checkpoint_keeps_quantization(self):
+        self._seed("sglang-test/definitely-not-a-repo")
+        quant_config = _quark_config()
+        self.assertIs(_mtp_quant_config(quant_config), quant_config)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

The Qwen3.5 MTP module is embedded in the target checkpoint, so it inherits the target's `quantization_config` unless something says otherwise. For quark MXFP4, the only "otherwise" today is the exclude list — `_mtp_quant_config` in `python/sglang/srt/models/qwen3_5_mtp.py` reads an exclude entry starting with `mtp.` as "the MTP module ships bf16" (added for #23113). `amd/Qwen3.5-397B-A17B-MXFP4` declares exactly that: every `mtp.*` layer is enumerated under `quantization_config.exclude`.

Its successor `amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2` ships the same bf16 `mtp.*` tensors but declares none of them. Its 172 exclude entries cover only the visual blocks, `shared_expert_gate`, and `lm_head` — zero `mtp.*` entries. The draft model is then built MXFP4, `FusedMoE` allocates packed-uint8 `w13_weight`, and the expert load dies in `_load_w13`:

```
  File "python/sglang/srt/models/qwen3_5_mtp.py", line 376, in load_weights
  File "python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 633, in _load_w13
    expert_data.copy_(loaded_weight)
RuntimeError: The size of tensor a (2048) must match the size of tensor b (4096) at non-singleton dimension 1
```

2048 is the fp4-packed hidden dim (`hidden_size=4096`, two fp4 values per byte); 4096 is the bf16 tensor the checkpoint actually hands over. Comparing the two checkpoints' safetensors headers:

| tensor | `…-MXFP4` | `…-MXFP4-AttnFP8-V2` |
|---|---|---|
| `model.language_model.layers.N.mlp.experts.0.gate_proj.weight` | U8 `[1024, 2048]` + `weight_scale` | U8 `[1024, 2048]` + `weight_scale` |
| `mtp.layers.0.mlp.experts.0.gate_proj.weight` | BF16 `[1024, 4096]`, no scale | BF16 `[1024, 4096]`, no scale |
| `mtp.*` entries in `quantization_config.exclude` | all of them | **none** |

So the declaration is not a reliable signal, and its absence is indistinguishable from "the module is quantized" until the loader crashes. Only MTP arms fail; the target model loads fine on the same checkpoint.

## Modifications

**`python/sglang/srt/model_loader/weight_utils.py`** — add `probe_module_is_quantized(model_path, prefix, revision)` alongside the existing `probe_routed_expert_weight_dtype`. A tensor under `prefix` carries a `weight_scale` / `weight_zero_point` / … companion iff the submodule ships quantized, so tensor *names* settle it: the safetensors index answers without opening a shard (falling back to shard headers for an unindexed checkpoint, and to `huggingface_hub.try_to_load_from_cache` for a repo id). Returns `True` / `False` / `None` (unknown — no tensor under `prefix`, or no locally readable index), and is `lru_cache`d because a checkpoint does not change under a live process and a large MoE index is tens of MB to parse.

**`python/sglang/srt/models/qwen3_5_mtp.py`** — split the quark branch of `_mtp_quant_config` into `_quark_mtp_is_unquantized`. The declared exclude list stays the fast path and is unchanged; when it is silent, ask the checkpoint. Two guards keep the blast radius at "Qwen3.5 quark checkpoints that would otherwise crash":

- Only for pre-quantized sources. Quark also requantizes bf16 / FP8 / NVFP4 checkpoints on load, and those pair a quark config with bf16 `mtp.*` weights by design — `is_prequantized` separates them.
- A probe that cannot answer (unreadable path, no index, no `mtp.*` keys) leaves the quantization untouched and logs, so this can never keep a server from starting that starts today.

**`test/registered/unit/models/test_qwen3_5_mtp_quant_config.py`** — new CPU unit test (10 cases) over both the probe and `_mtp_quant_config`: bf16 vs scaled submodule, absent submodule, uncached remote repo, the declared-exclude path (`…-MXFP4`), the undeclared-bf16 path (`…-MXFP4-AttnFP8-V2`), a genuinely quantized MTP module, an online-requantizing source, and an unreadable checkpoint.

Note the underlying issue is a checkpoint-metadata one: `amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2` should list its MTP module under `exclude` as its predecessor does. This PR makes SGLang robust to the omission rather than depending on every publisher getting the declaration right.

## Accuracy Tests

MI355X, TP2, `amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2`, `--attention-backend aiter --page-size 16 --disable-radix-cache`, MTP arm `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`.

Before this patch the MTP arm does not reach a servable state at all — it dies at draft weight load with the `RuntimeError` above. After it, the draft loads and serves:

| | draft weight load | `spec_accept_rate` | `spec_accept_length` |
|---|---|---|---|
| before | **crash** (2048 vs 4096) | — | — |
| after | `Qwen3_5ForCausalLMMTP`, 60.3 s, 7.91 GB | 0.656 | 3.00 / 4 |

The 7.91 GB draft footprint is bf16 sizing for one 512-expert layer at TP2; an MXFP4 draft would be roughly a quarter of that. An accept length of 3.00 out of a 4-token draft budget is the substantive check that the weights landed correctly — mis-loaded draft weights produce near-1.0 accept lengths.

`sglang.test.few_shot_gsm8k`, 200 questions, parallel 32, same server config with and without MTP:

| max_new_tokens | no MTP (target only) | MTP (this patch) |
|---|---|---|
| 512 | 0.370 | 0.450 |
| 2048 | 0.450 | 0.485 |

The MTP path is not worse than the target-only baseline, as expected — EAGLE verification makes the target model the source of truth for accepted tokens. Both configurations report a ~0.37–0.47 "invalid" rate from this harness because its answer extraction does not match this model's thinking-style output; that artifact is present with and without MTP and is unrelated to this change, so these numbers are a same-harness A/B rather than an absolute accuracy claim.

Unit tests: `test/registered/unit/models/test_qwen3_5_mtp_quant_config.py` → 10 passed. `test/registered/unit/models/test_shared_experts_fusion_gates.py` (existing coverage of `_mtp_quant_config`) → unchanged.

## Speed Tests and Profiling

No effect on the steady-state forward path — this only changes which dtype the draft model's parameters are allocated in at construction, and only for checkpoints that currently crash.

Startup cost is one cached read of the safetensors index, taken only when a quark checkpoint's exclude list does not mention `mtp.`: 0.06 s for the 20 MB index of `amd/Qwen3.5-397B-A17B-MXFP4-AttnFP8-V2`, against an ~890 s weight load. `amd/Qwen3.5-397B-A17B-MXFP4` short-circuits on the declared exclude list and never opens the index.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32703534705](https://github.com/sgl-project/sglang/actions/runs/32703534705)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32703543747](https://github.com/sgl-project/sglang/actions/runs/32703543747)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32703534558](https://github.com/sgl-project/sglang/actions/runs/32703534558)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->