### PR TITLE
Add NPU 950 (CANN 9.1.0) NPU Docker image release

### DIFF
--- a/.github/workflows/release-docker-npu-nightly.yml
+++ b/.github/workflows/release-docker-npu-nightly.yml
@@ -84,7 +84,7 @@ jobs:
           push: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
           provenance: false
           build-args: |
-            SGLANG_KERNEL_NPU_TAG=2026.8.21
+            SGLANG_KERNEL_NPU_TAG=2026.08.21
             CANN_VERSION=${{ matrix.cann_version }}
             DEVICE_TYPE=${{ matrix.device_type }}
 
@@ -156,6 +156,6 @@ jobs:
           push: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
           provenance: false
           build-args: |
-            SGLANG_KERNEL_NPU_TAG=2026.8.21
+            SGLANG_KERNEL_NPU_TAG=2026.08.21
             CANN_VERSION=${{ matrix.cann_version }}
             DEVICE_TYPE=${{ matrix.device_type }}

--- a/.github/workflows/release-docker-npu-nightly.yml
+++ b/.github/workflows/release-docker-npu-nightly.yml
@@ -1,4 +1,5 @@
 name: Release Docker Images Nightly (NPU)
+
 on:
   pull_request:
     branches:
@@ -21,6 +22,7 @@ jobs:
       matrix:
         cann_version: ["9.0.0"]
         device_type: ["910b", "a3"]
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -49,6 +51,7 @@ jobs:
           flavor: |
             latest=false
             suffix=-cann${{ matrix.cann_version }}-${{ matrix.device_type }},onlatest=true
+
       # Login against a Docker registry except on PR
       # https://github.com/docker/login-action
       - name: Log into docker hub
@@ -62,6 +65,7 @@ jobs:
       # Emulate non-native architectures
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       # Required for building and pushing multi-arch Docker images
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -80,6 +84,78 @@ jobs:
           push: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
           provenance: false
           build-args: |
-            SGLANG_KERNEL_NPU_TAG=2026.8.13
+            SGLANG_KERNEL_NPU_TAG=2026.8.21
+            CANN_VERSION=${{ matrix.cann_version }}
+            DEVICE_TYPE=${{ matrix.device_type }}
+
+  build-950-a3:
+    runs-on: ubuntu-22.04-arm
+    strategy:
+      matrix:
+        cann_version: ["9.1.0"]
+        device_type: ["950", "a3"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          docker-images: false
+
+      - name: Setup Docker buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            lmsysorg/sglang
+          # push with schedule event
+          # push with workflow_dispatch event
+          tags: |
+            type=ref,event=pr
+            type=ref,event=branch
+            type=schedule,pattern=main
+          flavor: |
+            latest=false
+            suffix=-cann${{ matrix.cann_version }}-${{ matrix.device_type }},onlatest=true
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Log into docker hub
+        uses: docker/login-action@v3
+        if: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Enable Docker multi-architecture build environment
+      # Emulate non-native architectures
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Required for building and pushing multi-arch Docker images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Build and push Docker image with Buildx (don't push on PR)
+      # https://github.com/docker/build-push-action
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/npu-950.Dockerfile
+          platforms: linux/arm64,linux/amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags }}
+          push: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
+          provenance: false
+          build-args: |
+            SGLANG_KERNEL_NPU_TAG=2026.8.21
             CANN_VERSION=${{ matrix.cann_version }}
             DEVICE_TYPE=${{ matrix.device_type }}

--- a/.github/workflows/release-docker-npu.yml
+++ b/.github/workflows/release-docker-npu.yml
@@ -1,4 +1,5 @@
 name: Release Docker Images (NPU)
+
 on:
   push:
     tags:
@@ -16,6 +17,7 @@ jobs:
       matrix:
         cann_version: ["9.0.0"]
         device_type: ["910b", "a3"]
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -26,7 +28,7 @@ jobs:
           tool-cache: true
           docker-images: false
 
-        # push with tag
+      # push with tag
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v5
@@ -67,10 +69,12 @@ jobs:
           fi
           echo "version=v${VERSION}" >> $GITHUB_OUTPUT
           echo "TAG=lmsysorg/sglang:v${VERSION}-cann${{ matrix.cann_version }}-${{ matrix.device_type }}" >> $GITHUB_OUTPUT
+
       # Enable Docker multi-architecture build environment
       # Emulate non-native architectures
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
+
       # Required for building and pushing multi-arch Docker images
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -81,6 +85,92 @@ jobs:
         with:
           context: docker
           file: docker/npu.Dockerfile
+          platforms: linux/arm64,linux/amd64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ${{ steps.meta.outputs.tags || steps.version.outputs.TAG }}
+          push: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
+          provenance: false
+          build-args: |
+            SGLANG_KERNEL_NPU_TAG=2026.8.13
+            CANN_VERSION=${{ matrix.cann_version }}
+            DEVICE_TYPE=${{ matrix.device_type }}
+            SGLANG_TAG=${{ steps.version.outputs.version }}
+
+  # 新增：950/a3，CANN 9.1.0，用 npu-950.Dockerfile
+  build-950-a3:
+    runs-on: ubuntu-22.04-arm
+    strategy:
+      matrix:
+        cann_version: ["9.1.0"]
+        device_type: ["950", "a3"]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Free up disk space
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        with:
+          tool-cache: true
+          docker-images: false
+
+      # push with tag
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            lmsysorg/sglang
+          tags: |
+            type=ref,event=pr
+          flavor: |
+            latest=false
+
+      # Login against a Docker registry except on PR
+      # https://github.com/docker/login-action
+      - name: Login to Docker Hub
+        uses: docker/login-action@v2
+        if: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Get version from tag
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            # Extract version from tag (e.g., v0.5.7 -> 0.5.7)
+            VERSION="${GITHUB_REF_NAME#v}"
+          fi
+          # Validate version format
+          if [ -z "$VERSION" ]; then
+            echo "::error::Version is empty"
+            exit 1
+          fi
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+'; then
+            echo "::error::Invalid version format: $VERSION (expected: X.Y.Z)"
+            exit 1
+          fi
+          echo "version=v${VERSION}" >> $GITHUB_OUTPUT
+          echo "TAG=lmsysorg/sglang:v${VERSION}-cann${{ matrix.cann_version }}-${{ matrix.device_type }}" >> $GITHUB_OUTPUT
+
+      # Enable Docker multi-architecture build environment
+      # Emulate non-native architectures
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      # Required for building and pushing multi-arch Docker images
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: docker
+          file: docker/npu-950.Dockerfile
           platforms: linux/arm64,linux/amd64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags || steps.version.outputs.TAG }}

--- a/.github/workflows/release-docker-npu.yml
+++ b/.github/workflows/release-docker-npu.yml
@@ -96,7 +96,7 @@ jobs:
             DEVICE_TYPE=${{ matrix.device_type }}
             SGLANG_TAG=${{ steps.version.outputs.version }}
 
-  # add 950/a3，CANN 9.1.0，用 npu-950.Dockerfile
+  # add 950/a3，CANN 9.1.0，npu-950.Dockerfile
   build-950-a3:
     runs-on: ubuntu-22.04-arm
     strategy:

--- a/.github/workflows/release-docker-npu.yml
+++ b/.github/workflows/release-docker-npu.yml
@@ -91,7 +91,7 @@ jobs:
           push: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
           provenance: false
           build-args: |
-            SGLANG_KERNEL_NPU_TAG=2026.8.13
+            SGLANG_KERNEL_NPU_TAG=2026.08.21
             CANN_VERSION=${{ matrix.cann_version }}
             DEVICE_TYPE=${{ matrix.device_type }}
             SGLANG_TAG=${{ steps.version.outputs.version }}
@@ -177,7 +177,7 @@ jobs:
           push: ${{ github.repository == 'sgl-project/sglang' && github.event_name != 'pull_request' }}
           provenance: false
           build-args: |
-            SGLANG_KERNEL_NPU_TAG=2026.8.13
+            SGLANG_KERNEL_NPU_TAG=2026.08.21
             CANN_VERSION=${{ matrix.cann_version }}
             DEVICE_TYPE=${{ matrix.device_type }}
             SGLANG_TAG=${{ steps.version.outputs.version }}

--- a/.github/workflows/release-docker-npu.yml
+++ b/.github/workflows/release-docker-npu.yml
@@ -96,7 +96,7 @@ jobs:
             DEVICE_TYPE=${{ matrix.device_type }}
             SGLANG_TAG=${{ steps.version.outputs.version }}
 
-  # 新增：950/a3，CANN 9.1.0，用 npu-950.Dockerfile
+  # add 950/a3，CANN 9.1.0，用 npu-950.Dockerfile
   build-950-a3:
     runs-on: ubuntu-22.04-arm
     strategy:

--- a/docker/npu-950.Dockerfile
+++ b/docker/npu-950.Dockerfile
@@ -1,0 +1,137 @@
+ARG CANN_VERSION=9.1.0
+ARG DEVICE_TYPE=950
+ARG OS=ubuntu22.04
+ARG PYTHON_VERSION=py3.12
+ARG arch
+
+FROM quay.io/ascend/cann:$CANN_VERSION-$DEVICE_TYPE-$OS-$PYTHON_VERSION
+
+# Update pip & apt sources
+ARG TARGETARCH
+ARG CANN_VERSION
+ARG DEVICE_TYPE
+ARG arch
+ARG PIP_INDEX_URL="https://pypi.org/simple/"
+ARG APTMIRROR=""
+ARG PYTORCH_VERSION="2.10.0"
+ARG TORCHVISION_VERSION="0.25.0"
+ARG TORCHAUDIO_VERSION="2.10.0"
+ARG PTA_URL_ARM64="https://gitcode.com/Ascend/pytorch/releases/download/v26.1.0-pytorch2.10.0/torch_npu-2.10.0.post4-cp312-cp312-manylinux_2_28_aarch64.whl"
+ARG PTA_URL_AMD64="https://gitcode.com/Ascend/pytorch/releases/download/v26.1.0-pytorch2.10.0/torch_npu-2.10.0.post4-cp312-cp312-manylinux_2_28_x86_64.whl"
+ARG SGLANG_TAG=main
+ARG ASCEND_CANN_PATH=/usr/local/Ascend/ascend-toolkit
+ARG SGLANG_KERNEL_NPU_TAG=20260821
+ARG PIP_INSTALL="python3 -m pip install --no-cache-dir"
+ARG DEVICE_TYPE
+
+
+
+RUN if [ "$TARGETARCH" = "amd64" ]; then \
+      echo "Using x86_64 dependencies"; \
+      echo "export PTA_URL=$PTA_URL_AMD64" >> /etc/environment_new; \
+    elif [ "$TARGETARCH" = "arm64" ]; then \
+      echo "Using aarch64 dependencies"; \
+      echo "export PTA_URL=$PTA_URL_ARM64" >> /etc/environment_new; \
+    else \
+      echo "Unsupported TARGETARCH: $TARGETARCH"; exit 1; \
+    fi
+
+WORKDIR /workspace
+
+# Define environments
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN pip config set global.index-url $PIP_INDEX_URL
+RUN if [ -n "$APTMIRROR" ];then sed -i "s|.*.ubuntu.com|$APTMIRROR|g" /etc/apt/sources.list ;fi
+
+# Install development tools and utilities
+RUN apt-get update -y && apt upgrade -y && apt-get install -y \
+    unzip \
+    build-essential \
+    cmake \
+    vim \
+    wget \
+    curl \
+    net-tools \
+    zlib1g-dev \
+    lld \
+    clang \
+    locales \
+    ccache \
+    openssl \
+    libssl-dev \
+    pkg-config \
+    libgl1-mesa-glx \
+    libgl1-mesa-dri \
+    ca-certificates \
+    && rm -rf /var/cache/apt/* \
+    && rm -rf /var/lib/apt/lists/* \
+    && update-ca-certificates \
+    && locale-gen en_US.UTF-8
+
+ENV LANG=en_US.UTF-8
+ENV LANGUAGE=en_US:en
+ENV LC_ALL=en_US.UTF-8
+
+
+### Install MemFabric
+RUN ${PIP_INSTALL} memfabric-hybrid==1.2.0
+
+### Install memfabric-zbal
+RUN ${PIP_INSTALL} memfabric-zbal==1.1.3 -i https://pypi.org/simple/
+### Install SGLang Model Gateway
+RUN ${PIP_INSTALL} sglang-router
+
+
+### Install PyTorch and PTA
+RUN . /etc/environment_new && \
+    (${PIP_INSTALL} torch==${PYTORCH_VERSION} torchvision==${TORCHVISION_VERSION} torchaudio==${TORCHAUDIO_VERSION} --index-url https://download.pytorch.org/whl/cpu) \
+    && (${PIP_INSTALL} ${PTA_URL})
+
+
+## Install triton-ascend
+RUN . /etc/environment_new && \
+    ${PIP_INSTALL} pybind11 && \
+    if [ "$TARGETARCH" = "arm64" ]; then \
+        ${PIP_INSTALL} https://github.com/triton-lang/triton-ascend/releases/download/v3.2.2/triton_ascend-3.2.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl; \
+    elif [ "$TARGETARCH" = "amd64" ]; then \
+        ${PIP_INSTALL} https://github.com/triton-lang/triton-ascend/releases/download/v3.2.2/triton_ascend-3.2.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl; \
+    else \
+        echo "Unsupported architecture: $TARGETARCH"; \
+        exit 1; \
+    fi
+
+# Install SGLang
+RUN git clone https://github.com/sgl-project/sglang --branch ${SGLANG_TAG} /sgl-workspace/sglang && \
+    cd /sgl-workspace/sglang/python && rm -rf pyproject.toml && mv pyproject_npu.toml pyproject.toml && \
+    ${PIP_INSTALL} -v -e .[all_npu]
+
+RUN mkdir cann-custom-ops && \
+    cd cann-custom-ops && \
+    source /usr/local/Ascend/cann-${CANN_VERSION}/set_env.sh && \
+    wget https://github.com/sgl-project/sgl-kernel-npu/releases/download/${SGLANG_KERNEL_NPU_TAG}/custom-ops-${SGLANG_KERNEL_NPU_TAG}-torch2.10.0-cann${CANN_VERSION}-${DEVICE_TYPE}-$(arch).zip && \
+    wget https://github.com/sgl-project/sgl-kernel-npu/releases/download/${SGLANG_KERNEL_NPU_TAG}/ops-transformer-${SGLANG_KERNEL_NPU_TAG}-torch2.10.0-cann${CANN_VERSION}-${DEVICE_TYPE}-$(arch).zip && \
+    unzip custom-ops-${SGLANG_KERNEL_NPU_TAG}-torch2.10.0-cann${CANN_VERSION}-${DEVICE_TYPE}-$(arch).zip && \
+    unzip ops-transformer-${SGLANG_KERNEL_NPU_TAG}-torch2.10.0-cann${CANN_VERSION}-${DEVICE_TYPE}-$(arch).zip && \
+    chmod +x *.run && \
+    ./CANN-custom_ops-none-linux.$(arch).run --install-path=/usr/local/Ascend/cann-${CANN_VERSION}/opp && \
+    ./cann-ops-transformer-custom_linux-$(arch).run --install-path=/usr/local/Ascend/cann-${CANN_VERSION}/opp && \
+    source /usr/local/Ascend/cann-${CANN_VERSION}/opp/vendors/customize/bin/set_env.bash && \
+    source /usr/local/Ascend/cann-${CANN_VERSION}/opp/vendors/custom_transformer/bin/set_env.bash && \
+    source /usr/local/Ascend/ascend-toolkit/latest/set_env.sh && \
+    source /usr/local/Ascend/nnal/atb/set_env.sh && \
+    ${PIP_INSTALL} custom_ops-1.0-cp312-cp312-linux_$(arch).whl && \
+    cd .. && rm -rf cann-custom-ops
+
+# Install Deep-ep
+# pin wheel to 0.45.1 ref: https://github.com/pypa/wheel/issues/662
+RUN ${PIP_INSTALL} wheel==0.45.1 pybind11 pyyaml decorator scipy attrs psutil \
+    && mkdir sgl-kernel-npu \
+    && cd sgl-kernel-npu \
+    && wget https://github.com/sgl-project/sgl-kernel-npu/releases/download/${SGLANG_KERNEL_NPU_TAG}/sgl-kernel-npu-${SGLANG_KERNEL_NPU_TAG}-torch2.10.0-py312-cann${CANN_VERSION}-${DEVICE_TYPE}-$(arch).zip \
+    && unzip sgl-kernel-npu-${SGLANG_KERNEL_NPU_TAG}-torch2.10.0-py312-cann${CANN_VERSION}-${DEVICE_TYPE}-$(arch).zip \
+    && ${PIP_INSTALL} deep_ep*.whl sgl_kernel_npu*.whl torch_memory_saver*.whl \
+    && cd .. && rm -rf sgl-kernel-npu \
+    && cd "$(python3 -m pip show deep-ep | awk '/^Location:/ {print $2}')" && ln -sf deep_ep/deep_ep_cpp*.so
+
+CMD ["/bin/bash"]

--- a/docker/npu-950.Dockerfile
+++ b/docker/npu-950.Dockerfile
@@ -20,7 +20,7 @@ ARG PTA_URL_ARM64="https://gitcode.com/Ascend/pytorch/releases/download/v26.1.0-
 ARG PTA_URL_AMD64="https://gitcode.com/Ascend/pytorch/releases/download/v26.1.0-pytorch2.10.0/torch_npu-2.10.0.post4-cp312-cp312-manylinux_2_28_x86_64.whl"
 ARG SGLANG_TAG=main
 ARG ASCEND_CANN_PATH=/usr/local/Ascend/ascend-toolkit
-ARG SGLANG_KERNEL_NPU_TAG=20260821
+ARG SGLANG_KERNEL_NPU_TAG=2026.08.21
 ARG PIP_INSTALL="python3 -m pip install --no-cache-dir"
 ARG DEVICE_TYPE
 


### PR DESCRIPTION
## Motivation

NPU 950 (CANN 9.1.0, Python 3.12) is not covered by the current NPU Docker
release pipeline, so users on 950 hardware have no prebuilt image to pull.
This PR adds a dedicated Dockerfile for the 950 / CANN 9.1.0 stack and extends
the release and nightly workflows to build and push it, while keeping the
existing CANN 9.0.0 (910b / a3) pipeline unchanged.

## Modifications

- Add `docker/npu-950.Dockerfile`:
  - Base image: CANN 9.1.0 / 950 / ubuntu22.04 / py3.12
  - torch_npu 2.10.0.post4 (cp312) from gitcode
  - triton-ascend 3.2.2 official wheels (aarch64 / x86_64)
  - Installs sgl-kernel-npu custom-ops / ops-transformer / sgl-kernel-npu
    release assets (tag `2026.8.13`), DeepEP and torch-memory-saver wheels
- Extend `.github/workflows/release-docker-npu.yml`:
  - Add `build-950-a3` job (CANN 9.1.0 x [950, a3]) building
    `docker/npu-950.Dockerfile`; existing `build` job is untouched
  - New tags: `lmsysorg/sglang:v<version>-cann9.1.0-950`,
    `lmsysorg/sglang:v<version>-cann9.1.0-a3`
- Extend `.github/workflows/release-docker-npu-nightly.yml`:
  - Add the same `build-950-a3` job for nightly images
    (`-cann9.1.0-950` / `-cann9.1.0-a3` suffixes)

## Accuracy Tests

N/A — this PR only changes Docker packaging and CI workflows; no kernel or
model forward code is modified. The built image should be smoke-tested
(start the server and run a small inference) on 950 / a3 hardware.

## Speed Tests and Profiling

N/A — no runtime code changes; performance characteristics are inherited from
the existing NPU stack.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A — CI/Docker change)
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (optional: add 950 image tag to the NPU docker docs)
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32708523196](https://github.com/sgl-project/sglang/actions/runs/32708523196)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32708522932](https://github.com/sgl-project/sglang/actions/runs/32708522932)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->