### PR TITLE
fix: resolve CPU device compatibility issues of Hy3

### DIFF
--- a/python/sglang/srt/models/hunyuan_v3_nextn.py
+++ b/python/sglang/srt/models/hunyuan_v3_nextn.py
@@ -32,6 +32,7 @@ from sglang.srt.layers.vocab_parallel_embedding import (
 from sglang.srt.managers.schedule_batch import ForwardBatch
 from sglang.srt.model_loader.weight_utils import default_weight_loader
 from sglang.srt.models.hunyuan_v3 import HYV3DecoderLayer
+from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_stream
 from sglang.srt.utils import is_cuda
 
@@ -156,8 +157,8 @@ class HYV3ForCausalLMNextN(nn.Module):
         del self.lm_head.weight
         self.model.embed_tokens.weight = embed
         self.lm_head.weight = head
-        torch.cuda.empty_cache()
-        torch.cuda.synchronize()
+        current_platform.empty_cache()
+        current_platform.synchronize()
 
     def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
         nextn_layer_id = self.config.num_hidden_layers


### PR DESCRIPTION
## Motivation

When serving Hy3 (HunyuanV3) on a CPU-only environment, initialization can fail in `set_embed_and_head` in hunyuan_v3_nextn.py because it calls `torch.cuda.synchronize()` unconditionally.  
With a CPU-only PyTorch build, this triggers:

`AssertionError: Torch not compiled with CUDA enabled`

This blocks CPU startup and should be fixed without regressing CUDA behavior.

## Modifications

A minimal, targeted fix was applied in `hunyuan_v3_nextn.py`:

1. Added platform abstraction import: `current_platform`
2. Replaced CUDA-specific cache/sync calls in `set_embed_and_head`:
- `torch.cuda.empty_cache()` -> `current_platform.empty_cache()`
- `torch.cuda.synchronize()` -> `current_platform.synchronize()`

This avoids forcing CUDA initialization on CPU, while preserving equivalent cache/sync semantics on CUDA via the platform implementation.

## Accuracy Tests

This change does not alter model forward math or logits computation; it only changes the backend synchronization/cache-clear entrypoint.

Completed:
1. Static check passes for the modified file (no new errors)

Recommended runtime validation:
1. Re-run CPU startup and verify the `Torch not compiled with CUDA enabled` failure is gone
2. Run a minimal CUDA serving + generation sanity check to confirm no behavior/perf regression

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32705344894](https://github.com/sgl-project/sglang/actions/runs/32705344894)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32705344729](https://github.com/sgl-project/sglang/actions/runs/32705344729)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32705344801](https://github.com/sgl-project/sglang/actions/runs/32705344801)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->