### PR TITLE
[PD] Propagate stable request ID across prefill and decode workers

### DIFF
--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -244,6 +244,13 @@ where
 
         let request_id = request_id.unwrap_or_else(|| generate_request_id(req.uri().path()));
 
+        // Make the resolved ID available before dispatch. In PD mode the router
+        // copies this header into both worker requests, so the same ID can be
+        // used in router, prefill, and decode logs.
+        if let Ok(value) = HeaderValue::from_str(&request_id) {
+            req.headers_mut().insert("x-request-id", value);
+        }
+
         // Insert request ID into request extensions for other middleware/handlers to use
         req.extensions_mut().insert(RequestId(request_id.clone()));
 
@@ -982,6 +989,8 @@ pub async fn wasm_middleware(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::body::Body;
+    use tower::{service_fn, ServiceExt};
 
     #[test]
     fn test_normalize_path_no_ids() {
@@ -1045,5 +1054,71 @@ mod tests {
         // Regular words
         assert!(!is_dynamic_id("completions"));
         assert!(!is_dynamic_id("chat"));
+    }
+
+    #[tokio::test]
+    async fn test_request_id_is_forwarded_to_downstream_and_response() {
+        let middleware = RequestIdLayer::new(vec!["x-request-id".to_string()]).layer(service_fn(
+            |request: Request<Body>| async move {
+                assert_eq!(
+                    request
+                        .headers()
+                        .get("x-request-id")
+                        .and_then(|value| value.to_str().ok()),
+                    Some("client-request-id"),
+                );
+                Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
+            },
+        ));
+
+        let response = middleware
+            .oneshot(
+                Request::builder()
+                    .uri("/generate")
+                    .header("x-request-id", "client-request-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(
+            response
+                .headers()
+                .get("x-request-id")
+                .and_then(|value| value.to_str().ok()),
+            Some("client-request-id"),
+        );
+    }
+
+    #[tokio::test]
+    async fn test_generated_request_id_is_forwarded_to_downstream() {
+        let middleware = RequestIdLayer::new(vec!["x-request-id".to_string()]).layer(service_fn(
+            |request: Request<Body>| async move {
+                assert!(request
+                    .headers()
+                    .get("x-request-id")
+                    .and_then(|value| value.to_str().ok())
+                    .is_some_and(|value| value.starts_with("gnt-")),);
+                Ok::<_, std::convert::Infallible>(Response::new(Body::empty()))
+            },
+        ));
+
+        let response = middleware
+            .oneshot(
+                Request::builder()
+                    .uri("/generate")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let response_request_id = response
+            .headers()
+            .get("x-request-id")
+            .and_then(|value| value.to_str().ok())
+            .unwrap();
+        assert!(response_request_id.starts_with("gnt-"));
     }
 }

--- a/sgl-model-gateway/src/middleware.rs
+++ b/sgl-model-gateway/src/middleware.rs
@@ -988,9 +988,10 @@ pub async fn wasm_middleware(
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use axum::body::Body;
     use tower::{service_fn, ServiceExt};
+
+    use super::*;
 
     #[test]
     fn test_normalize_path_no_ids() {

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -201,6 +201,36 @@ impl PDRouter {
         error::internal_error("serialization_failed", "Failed to serialize request")
     }
 
+    /// Add the request identity used by both PD workers.
+    ///
+    /// This runs once before the retry loop. A retry may select a different
+    /// worker pair and bootstrap room, but it must remain the same logical
+    /// request and therefore keep the same `rid`.
+    fn inject_request_id_into_value(
+        mut original: Value,
+        request_id: &str,
+        batch_size: Option<usize>,
+    ) -> Result<Value, String> {
+        if original.get("rid").is_some_and(|value| !value.is_null()) {
+            return Ok(original);
+        }
+
+        let obj = original
+            .as_object_mut()
+            .ok_or_else(|| "Request must be a JSON object".to_string())?;
+
+        let rid = match batch_size {
+            Some(size) => Value::Array(
+                (0..size)
+                    .map(|index| Value::from(format!("{request_id}_{index}")))
+                    .collect(),
+            ),
+            None => Value::from(request_id),
+        };
+        obj.insert("rid".to_string(), rid);
+        Ok(original)
+    }
+
     fn get_generate_batch_size(req: &GenerateRequest) -> Option<usize> {
         // GenerateRequest doesn't support batch via arrays, only via input_ids
         if let Some(InputIds::Batch(batches)) = &req.input_ids {
@@ -362,7 +392,7 @@ impl PDRouter {
         Ok((prefill_request, decode_request))
     }
 
-    async fn execute_dual_dispatch<T: Serialize + Clone>(
+    async fn execute_dual_dispatch<T: Serialize>(
         &self,
         headers: Option<&HeaderMap>,
         original_request: &T,
@@ -383,15 +413,42 @@ impl PDRouter {
             endpoint,
             bool_to_static_str(context.is_stream),
         );
-        // Clone request once outside the retry loop, then use Arc to share across attempts
-        // This avoids O(retries) clones by sharing the same data
-        let shared_request = Arc::new(original_request.clone());
+        // Resolve the logical request ID once, outside the retry loop. The
+        // middleware normally supplies x-request-id; the fallback keeps direct
+        // router calls and non-standard entry points on the same code path.
+        let request_id = headers
+            .and_then(|headers| headers.get("x-request-id"))
+            .and_then(|value| value.to_str().ok())
+            .map(ToOwned::to_owned)
+            .unwrap_or_else(|| format!("req-{}", uuid::Uuid::new_v4().simple()));
+
+        // Keep the generated fallback in the worker headers as well as the
+        // JSON body. This preserves one identity even if RequestIdLayer was
+        // bypassed.
+        let mut dispatch_headers = headers.cloned().unwrap_or_default();
+        if let Ok(value) = HeaderValue::from_str(&request_id) {
+            dispatch_headers.insert("x-request-id", value);
+        }
+        let dispatch_headers = Arc::new(dispatch_headers);
+
+        // Serialize and inject once. Each retry clones this prepared request,
+        // then adds a fresh bootstrap_room for the new transfer attempt.
+        let shared_request = match serde_json::to_value(original_request) {
+            Ok(request) => {
+                match Self::inject_request_id_into_value(request, &request_id, context.batch_size) {
+                    Ok(request) => Arc::new(request),
+                    Err(error) => return Self::handle_serialization_error(error),
+                }
+            }
+            Err(error) => return Self::handle_serialization_error(error),
+        };
+
         let response = RetryExecutor::execute_response_with_retry(
             &self.retry_config,
             {
                 move |attempt: u32| {
-                    // Clone Arc (cheap reference count increment) instead of cloning the entire request
                     let shared_request = Arc::clone(&shared_request);
+                    let dispatch_headers = Arc::clone(&dispatch_headers);
                     let context = context.clone();
                     async move {
                         let (prefill, decode) = match self
@@ -415,10 +472,7 @@ impl PDRouter {
                             decode.url()
                         );
 
-                        let mut json_request = match serde_json::to_value(shared_request.as_ref()) {
-                            Ok(v) => v,
-                            Err(e) => return Self::handle_serialization_error(e),
-                        };
+                        let mut json_request = shared_request.as_ref().clone();
 
                         json_request = match Self::inject_bootstrap_into_value(
                             json_request,
@@ -432,7 +486,7 @@ impl PDRouter {
                         let ctx_is_stream = context.is_stream;
                         let response = self
                             .execute_dual_dispatch_internal(
-                                headers,
+                                Some(dispatch_headers.as_ref()),
                                 json_request,
                                 context,
                                 Arc::clone(&prefill),
@@ -1927,6 +1981,48 @@ mod tests {
         assert!(decode_request.body.get("disagg_prefill_dp_rank").is_none());
         assert!(matches!(prefill_request.body, Cow::Borrowed(_)));
         assert!(matches!(decode_request.body, Cow::Borrowed(_)));
+    }
+
+    #[test]
+    fn test_build_post_with_headers_forwards_request_id() {
+        let router = create_test_pd_router();
+        let mut headers = HeaderMap::new();
+        headers.insert("x-request-id", HeaderValue::from_static("request-123"));
+
+        let request = router
+            .build_post_with_headers(
+                &router.client,
+                "http://prefill:30000/generate",
+                &json!({"prompt": "hello"}),
+                Some(&headers),
+                false,
+            )
+            .build()
+            .unwrap();
+
+        assert_eq!(
+            request.headers().get("x-request-id"),
+            Some(&HeaderValue::from_static("request-123")),
+        );
+    }
+
+    #[test]
+    fn test_inject_request_id_preserves_existing_and_expands_batch() {
+        let existing = PDRouter::inject_request_id_into_value(
+            json!({"rid": "client-rid"}),
+            "router-rid",
+            None,
+        )
+        .unwrap();
+        assert_eq!(existing["rid"], "client-rid");
+
+        let batch = PDRouter::inject_request_id_into_value(
+            json!({"prompt": ["a", "b"]}),
+            "router-rid",
+            Some(2),
+        )
+        .unwrap();
+        assert_eq!(batch["rid"], json!(["router-rid_0", "router-rid_1"]));
     }
 
     #[test]

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -209,7 +209,6 @@ impl PDRouter {
     fn inject_request_id_into_value(
         mut original: Value,
         request_id: &str,
-        batch_size: Option<usize>,
     ) -> Result<Value, String> {
         if original.get("rid").is_some_and(|value| !value.is_null()) {
             return Ok(original);
@@ -219,15 +218,10 @@ impl PDRouter {
             .as_object_mut()
             .ok_or_else(|| "Request must be a JSON object".to_string())?;
 
-        let rid = match batch_size {
-            Some(size) => Value::Array(
-                (0..size)
-                    .map(|index| Value::from(format!("{request_id}_{index}")))
-                    .collect(),
-            ),
-            None => Value::from(request_id),
-        };
-        obj.insert("rid".to_string(), rid);
+        // Keep one logical request ID here. The engine expands scalar IDs when
+        // handling true batches or parallel sampling, so the gateway must not
+        // interpret chat `n` as the batch size.
+        obj.insert("rid".to_string(), Value::from(request_id));
         Ok(original)
     }
 
@@ -435,7 +429,7 @@ impl PDRouter {
         // then adds a fresh bootstrap_room for the new transfer attempt.
         let shared_request = match serde_json::to_value(original_request) {
             Ok(request) => {
-                match Self::inject_request_id_into_value(request, &request_id, context.batch_size) {
+                match Self::inject_request_id_into_value(request, &request_id) {
                     Ok(request) => Arc::new(request),
                     Err(error) => return Self::handle_serialization_error(error),
                 }
@@ -2007,22 +2001,20 @@ mod tests {
     }
 
     #[test]
-    fn test_inject_request_id_preserves_existing_and_expands_batch() {
+    fn test_inject_request_id_preserves_existing_and_injects_scalar() {
         let existing = PDRouter::inject_request_id_into_value(
             json!({"rid": "client-rid"}),
             "router-rid",
-            None,
         )
         .unwrap();
         assert_eq!(existing["rid"], "client-rid");
 
-        let batch = PDRouter::inject_request_id_into_value(
+        let request = PDRouter::inject_request_id_into_value(
             json!({"prompt": ["a", "b"]}),
             "router-rid",
-            Some(2),
         )
         .unwrap();
-        assert_eq!(batch["rid"], json!(["router-rid_0", "router-rid_1"]));
+        assert_eq!(request["rid"], "router-rid");
     }
 
     #[test]

--- a/sgl-model-gateway/src/routers/http/pd_router.rs
+++ b/sgl-model-gateway/src/routers/http/pd_router.rs
@@ -428,12 +428,10 @@ impl PDRouter {
         // Serialize and inject once. Each retry clones this prepared request,
         // then adds a fresh bootstrap_room for the new transfer attempt.
         let shared_request = match serde_json::to_value(original_request) {
-            Ok(request) => {
-                match Self::inject_request_id_into_value(request, &request_id) {
-                    Ok(request) => Arc::new(request),
-                    Err(error) => return Self::handle_serialization_error(error),
-                }
-            }
+            Ok(request) => match Self::inject_request_id_into_value(request, &request_id) {
+                Ok(request) => Arc::new(request),
+                Err(error) => return Self::handle_serialization_error(error),
+            },
             Err(error) => return Self::handle_serialization_error(error),
         };
 
@@ -2002,18 +2000,14 @@ mod tests {
 
     #[test]
     fn test_inject_request_id_preserves_existing_and_injects_scalar() {
-        let existing = PDRouter::inject_request_id_into_value(
-            json!({"rid": "client-rid"}),
-            "router-rid",
-        )
-        .unwrap();
+        let existing =
+            PDRouter::inject_request_id_into_value(json!({"rid": "client-rid"}), "router-rid")
+                .unwrap();
         assert_eq!(existing["rid"], "client-rid");
 
-        let request = PDRouter::inject_request_id_into_value(
-            json!({"prompt": ["a", "b"]}),
-            "router-rid",
-        )
-        .unwrap();
+        let request =
+            PDRouter::inject_request_id_into_value(json!({"prompt": ["a", "b"]}), "router-rid")
+                .unwrap();
         assert_eq!(request["rid"], "router-rid");
     }
 


### PR DESCRIPTION
## Motivation

When a PD request does not provide an explicit rid, the prefill and decode
workers normalize the request independently and generate different local
request IDs. This makes it difficult to correlate logs and latency metrics
across the router, prefill worker, and decode worker.

## What this PR does

- Expose the resolved router request ID to downstream handlers through
  x-request-id.
- Generate or preserve one logical request ID before PD retry dispatch.
- Propagate the same rid to prefill and decode workers.
- Keep rid stable across retries.
- Preserve bootstrap_room as an attempt-scoped KV transfer identifier.
- Add unit tests for middleware propagation, PD header forwarding, batch IDs,
  and explicit rid preservation.

## Validation

- cargo fmt --check passes.
- git diff --check passes.
- Targeted Rust tests are currently blocked locally by the missing
  pkg-config/pkgconf dependency required by openssl-sys.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33038157569](https://github.com/sgl-project/sglang/actions/runs/33038157569)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33038157445](https://github.com/sgl-project/sglang/actions/runs/33038157445)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->