### PR TITLE
[Bugfix] Fix Dots hybrid DSA/SWA default backend

### DIFF
--- a/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
+++ b/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
@@ -40,10 +40,19 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
     overrides: Dict[str, Any] = {}
 
     if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
-        # Set attention backend for DeepSeek
+        # Pure DSA models use the top-level backend for sparse attention. Hybrid
+        # DSA/SWA models build their sparse backend separately and use this slot
+        # for the dense SWA executor instead.
         if is_attention_backend_not_set(cfg):
-            overrides["attention_backend"] = "dsa"
-            logger.info("Use dsa attention backend for DeepSeek with DSA.")
+            if getattr(hf_config, "is_hybrid_swa", False):
+                overrides["attention_backend"] = "fa3"
+                logger.info(
+                    "Use fa3 as the dense SWA backend for hybrid DSA/SWA; "
+                    "full-attention layers use the separate DSA backend."
+                )
+            else:
+                overrides["attention_backend"] = "dsa"
+                logger.info("Use dsa attention backend for DeepSeek with DSA.")
         if not get_platform().is_npu and not get_platform().is_xpu:  # CUDA or ROCm GPU
             if cfg.enable_prefill_cp:
                 logger.warning(

--- a/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
+++ b/python/sglang/srt/arg_groups/model_overrides/deepseek_v2.py
@@ -35,7 +35,7 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
     before it by _set_default_dsa_kv_cache_dtype) and the env writes stay in
     the branch."""
     cfg = resolving_view(server_args)
-    from sglang.srt.configs.model_config import is_deepseek_dsa
+    from sglang.srt.configs.model_config import _hf_attr, is_deepseek_dsa
 
     overrides: Dict[str, Any] = {}
 
@@ -44,7 +44,7 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
         # DSA/SWA models build their sparse backend separately and use this slot
         # for the dense SWA executor instead.
         if is_attention_backend_not_set(cfg):
-            if getattr(hf_config, "is_hybrid_swa", False):
+            if _hf_attr(hf_config, "is_hybrid_swa"):
                 overrides["attention_backend"] = "fa3"
                 logger.info(
                     "Use fa3 as the dense SWA backend for hybrid DSA/SWA; "

--- a/python/sglang/srt/layers/attention/dots_hybrid_backend.py
+++ b/python/sglang/srt/layers/attention/dots_hybrid_backend.py
@@ -527,54 +527,50 @@ class DotsHybridAttnBackend(AttentionBackend):
         backend.init_mha_chunk_metadata(forward_batch)
 
 
-def _wrap_dots_swa_backend(backend: AttentionBackend) -> AttentionBackend:
-    """Add latent-cache SWA behavior when a backend uses FlashAttention."""
+def _require_dots_swa_backend(backend: AttentionBackend) -> DotsSWAMLAAttnBackend:
+    """Add latent-cache SWA behavior around a FlashAttention executor."""
     from sglang.srt.layers.attention.flashattention_backend import (
         FlashAttentionBackend,
     )
 
-    if isinstance(backend, FlashAttentionBackend) or (
-        isinstance(backend, HybridAttnBackend)
-        and all(
-            isinstance(child, FlashAttentionBackend)
-            for child in (backend.prefill_backend, backend.decode_backend)
-        )
-    ):
-        return DotsSWAMLAAttnBackend(backend)
-    return backend
-
-
-def _require_dots_swa_backend(backend: AttentionBackend) -> DotsSWAMLAAttnBackend:
-    wrapped = _wrap_dots_swa_backend(backend)
-    if not isinstance(wrapped, DotsSWAMLAAttnBackend):
+    executors = (
+        (backend.prefill_backend, backend.decode_backend)
+        if isinstance(backend, HybridAttnBackend)
+        else (backend,)
+    )
+    # Dots SWA prefill reads sliding_window_size off the executor and SWA decode
+    # reads swa_page_table off its metadata; only FlashAttention supplies both.
+    if not all(isinstance(child, FlashAttentionBackend) for child in executors):
         raise ValueError(
-            "Dots hybrid DSA/SWA requires FlashAttention for both prefill and "
-            "decode SWA execution. Configure --attention-backend fa3, or set "
-            "both --prefill-attention-backend and --decode-attention-backend "
-            "to FA3/FA4."
+            "Dots SWA layers require FlashAttention for both prefill and decode "
+            f"execution, got {type(backend).__name__}. Configure "
+            "--attention-backend fa3, or set both --prefill-attention-backend "
+            "and --decode-attention-backend to fa3/fa4."
         )
-    return wrapped
+    return DotsSWAMLAAttnBackend(backend)
 
 
 def wrap_dots_draft_decode_backend(backend: AttentionBackend) -> AttentionBackend:
     """Wrap each per-step backend used by the Dots NextN draft container."""
     backend.attn_backends = [
-        _wrap_dots_swa_backend(child) for child in backend.attn_backends
+        _require_dots_swa_backend(child) for child in backend.attn_backends
     ]
     return backend
 
 
 def wrap_dots_attention_backend(runner, full_attn_backend: AttentionBackend):
     """Construct the Dots target or draft attention backend."""
-    if runner.model_config.is_draft_model:
-        return _wrap_dots_swa_backend(full_attn_backend)
-
-    if runner.model_config.hf_text_config.index_topk is None:
-        return _require_dots_swa_backend(full_attn_backend)
+    swa_backend = _require_dots_swa_backend(full_attn_backend)
+    # Draft layers are pure SWA, and a target without an indexer has no DSA half.
+    if (
+        runner.model_config.is_draft_model
+        or runner.model_config.hf_text_config.index_topk is None
+    ):
+        return swa_backend
 
     from sglang.srt.layers.attention.attention_registry import create_dsa_backend
 
     return DotsHybridAttnBackend(
         dsa_backend=create_dsa_backend(runner),
-        swa_backend=_require_dots_swa_backend(full_attn_backend),
+        swa_backend=swa_backend,
     )

--- a/python/sglang/srt/layers/attention/dots_hybrid_backend.py
+++ b/python/sglang/srt/layers/attention/dots_hybrid_backend.py
@@ -535,13 +535,25 @@ def _wrap_dots_swa_backend(backend: AttentionBackend) -> AttentionBackend:
 
     if isinstance(backend, FlashAttentionBackend) or (
         isinstance(backend, HybridAttnBackend)
-        and (
-            isinstance(backend.prefill_backend, FlashAttentionBackend)
-            or isinstance(backend.decode_backend, FlashAttentionBackend)
+        and all(
+            isinstance(child, FlashAttentionBackend)
+            for child in (backend.prefill_backend, backend.decode_backend)
         )
     ):
         return DotsSWAMLAAttnBackend(backend)
     return backend
+
+
+def _require_dots_swa_backend(backend: AttentionBackend) -> DotsSWAMLAAttnBackend:
+    wrapped = _wrap_dots_swa_backend(backend)
+    if not isinstance(wrapped, DotsSWAMLAAttnBackend):
+        raise ValueError(
+            "Dots hybrid DSA/SWA requires FlashAttention for both prefill and "
+            "decode SWA execution. Configure --attention-backend fa3, or set "
+            "both --prefill-attention-backend and --decode-attention-backend "
+            "to FA3/FA4."
+        )
+    return wrapped
 
 
 def wrap_dots_draft_decode_backend(backend: AttentionBackend) -> AttentionBackend:
@@ -558,16 +570,11 @@ def wrap_dots_attention_backend(runner, full_attn_backend: AttentionBackend):
         return _wrap_dots_swa_backend(full_attn_backend)
 
     if runner.model_config.hf_text_config.index_topk is None:
-        return DotsSWAMLAAttnBackend(full_attn_backend)
+        return _require_dots_swa_backend(full_attn_backend)
 
     from sglang.srt.layers.attention.attention_registry import create_dsa_backend
 
-    swa_backend = (
-        full_attn_backend.prefill_backend
-        if isinstance(full_attn_backend, HybridAttnBackend)
-        else full_attn_backend
-    )
     return DotsHybridAttnBackend(
         dsa_backend=create_dsa_backend(runner),
-        swa_backend=DotsSWAMLAAttnBackend(swa_backend),
+        swa_backend=_require_dots_swa_backend(full_attn_backend),
     )

--- a/test/registered/unit/layers/attention/test_dots_hybrid_backend.py
+++ b/test/registered/unit/layers/attention/test_dots_hybrid_backend.py
@@ -16,8 +16,13 @@ from sglang.srt.layers.attention.dots_hybrid_backend import (
     _metadata_mismatches_dp_padded_batch,
     _normalize_cache_seqlens_rows,
     _require_dots_swa_backend,
+    wrap_dots_draft_decode_backend,
 )
-from sglang.srt.layers.attention.flashattention_backend import FlashAttentionMetadata
+from sglang.srt.layers.attention.flashattention_backend import (
+    FlashAttentionBackend,
+    FlashAttentionMetadata,
+)
+from sglang.srt.layers.attention.hybrid_attn_backend import HybridAttnBackend
 from sglang.srt.layers.attention.swa_mla_fallback.ops import (
     gather_page64_kv_latent,
 )
@@ -33,6 +38,23 @@ def _batch(*, bs: int, num_tokens: int, original_bs: int | None = None):
         forward_mode=SimpleNamespace(),
         _original_batch_size=original_bs,
     )
+
+
+def _fa_backend():
+    """A real FlashAttentionBackend without a ModelRunner behind it."""
+    backend = object.__new__(FlashAttentionBackend)
+    backend.token_to_kv_pool = None
+    backend.req_to_token_pool = None
+    return backend
+
+
+def _split_backend(*, prefill, decode):
+    backend = object.__new__(HybridAttnBackend)
+    backend.prefill_backend = prefill
+    backend.decode_backend = decode
+    backend.token_to_kv_pool = None
+    backend.req_to_token_pool = None
+    return backend
 
 
 def _fa_metadata(*, bs: int, num_tokens: int):
@@ -102,9 +124,36 @@ def test_normalize_cache_seqlens_truncates_extra_rows():
     assert torch.equal(normalized, torch.tensor([17, 23], dtype=torch.int32))
 
 
-def test_dots_swa_backend_rejects_sparse_executor_during_initialization():
-    with pytest.raises(ValueError, match="requires FlashAttention"):
+def test_swa_backend_wraps_a_flash_attention_executor():
+    assert isinstance(_require_dots_swa_backend(_fa_backend()), DotsSWAMLAAttnBackend)
+
+
+def test_swa_backend_keeps_both_halves_of_a_split_flash_attention_backend():
+    split = _split_backend(prefill=_fa_backend(), decode=_fa_backend())
+
+    wrapped = _require_dots_swa_backend(split)
+
+    assert isinstance(wrapped, DotsSWAMLAAttnBackend)
+    assert wrapped.backend is split
+
+
+def test_swa_backend_rejects_a_non_flash_decode_executor():
+    split = _split_backend(prefill=_fa_backend(), decode=SimpleNamespace())
+
+    with pytest.raises(ValueError, match="require FlashAttention"):
+        _require_dots_swa_backend(split)
+
+
+def test_swa_backend_rejects_a_sparse_executor_during_initialization():
+    with pytest.raises(ValueError, match="require FlashAttention"):
         _require_dots_swa_backend(SimpleNamespace())
+
+
+def test_draft_decode_container_rejects_a_non_flash_step_backend():
+    container = SimpleNamespace(attn_backends=[_fa_backend(), SimpleNamespace()])
+
+    with pytest.raises(ValueError, match="require FlashAttention"):
+        wrap_dots_draft_decode_backend(container)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/test/registered/unit/layers/attention/test_dots_hybrid_backend.py
+++ b/test/registered/unit/layers/attention/test_dots_hybrid_backend.py
@@ -15,6 +15,7 @@ from sglang.srt.layers.attention.dots_hybrid_backend import (
     DotsSWAMLAAttnBackend,
     _metadata_mismatches_dp_padded_batch,
     _normalize_cache_seqlens_rows,
+    _require_dots_swa_backend,
 )
 from sglang.srt.layers.attention.flashattention_backend import FlashAttentionMetadata
 from sglang.srt.layers.attention.swa_mla_fallback.ops import (
@@ -99,6 +100,11 @@ def test_normalize_cache_seqlens_truncates_extra_rows():
     normalized = _normalize_cache_seqlens_rows(cache_seqlens, seq_lens, 2)
 
     assert torch.equal(normalized, torch.tensor([17, 23], dtype=torch.int32))
+
+
+def test_dots_swa_backend_rejects_sparse_executor_during_initialization():
+    with pytest.raises(ValueError, match="requires FlashAttention"):
+        _require_dots_swa_backend(SimpleNamespace())
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="requires CUDA")

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2854,6 +2854,12 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                             _deepseek_family_overrides(_args(), None),
                             {"attention_backend": "dsa", "page_size": 64},
                         )
+                        self.assertEqual(
+                            _deepseek_family_overrides(
+                                _args(), SimpleNamespace(is_hybrid_swa=True)
+                            ),
+                            {"attention_backend": "fa3", "page_size": 64},
+                        )
                     # HIP without the preshuffle path: page 1
                     with override_platform(is_hip=True):
                         with patch(

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -2860,6 +2860,13 @@ class TestGoldenModelOverrides(_IsolatedPublish):
                             ),
                             {"attention_backend": "fa3", "page_size": 64},
                         )
+                        # A dict-shaped hf_config reaches the same branch.
+                        self.assertEqual(
+                            _deepseek_family_overrides(
+                                _args(), {"is_hybrid_swa": True}
+                            ),
+                            {"attention_backend": "fa3", "page_size": 64},
+                        )
                     # HIP without the preshuffle path: page 1
                     with override_platform(is_hip=True):
                         with patch(


### PR DESCRIPTION
## Motivation

The Dots hybrid DSA/SWA model currently inherits the pure-DSA default and builds `DeepseekSparseAttnBackend` as its top-level backend. The Dots wrapper then reuses that sparse executor for SWA metadata, so a default launch fails during warmup because the sparse backend has no `sliding_window_size`.

This regressed the default launch path added by #33829.

## Modifications

- Treat the top-level backend as the dense SWA executor for hybrid DSA/SWA configs, while continuing to build the full-attention DSA executor separately.
- Default that dense executor to FA3 without changing pure-DSA defaults.
- Preserve a user-provided split prefill/decode backend instead of discarding its decode side.
- Validate the SWA executor during backend construction and fail with an actionable configuration error when either side is incompatible.
- Add unit coverage for hybrid default resolution and initialization-time validation.

## Accuracy Tests

This changes backend composition, not attention math.

- `PYTHONPATH=python python3 -m pytest -q test/registered/unit/layers/attention/test_dots_hybrid_backend.py test/registered/unit/test_model_overrides.py`
  - 78 passed, 2 subtests passed.
- H200 server E2E with the original failing default configuration (no attention backend flags), TP/DP/EP 8, dummy weights:
  - server completed warmup;
  - `/health` returned 200;
  - no `sliding_window_size` exception occurred.

## Speed Tests and Profiling

Not applicable. The change only selects and composes backends during initialization and adds no work to the attention hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing documentation change is needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (E2E result above; no hot-path change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33620473250](https://github.com/sgl-project/sglang/actions/runs/33620473250)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33620473070](https://github.com/sgl-project/sglang/actions/runs/33620473070)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33620473098](https://github.com/sgl-project/sglang/actions/runs/33620473098)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->