### PR TITLE
[Bugfix] Fix Dots NextN post-load initialization

### DIFF
--- a/python/sglang/srt/models/dots3_common/nextn.py
+++ b/python/sglang/srt/models/dots3_common/nextn.py
@@ -191,6 +191,11 @@ class Dots3NoteForCausalLMNextN(Dots3LanguageModelForCausalLM):
         )
         super().load_weights(weights, is_nextn=True)
 
+    def post_load_weights(self, is_nextn=True, weight_names=None):
+        # The generic loader invokes this hook without model-specific arguments.
+        # A NextN instance must never fall back to the target-model layer walk.
+        super().post_load_weights(is_nextn=True, weight_names=weight_names)
+
     def set_embed_and_head(self, embed, head):
         # Preserve a checkpoint-provided MTP embedding; share the output head.
         if not self._mtp_loaded_embed:


### PR DESCRIPTION
## Motivation

The generic model loader invokes `post_load_weights()` without model-specific arguments and relies on NextN subclasses to pin their own post-load mode. `Dots3NoteForCausalLMNextN` pins `is_nextn=True` for weight loading but does not do the same for the post-load hook.

As a result, the documented Dots NextN top-k=1 configuration enters the target-model layer walk and fails at startup because `Dot3NoteModelNextN` intentionally has `heads` rather than `start_layer` / `end_layer`.

## Modifications

- Override `Dots3NoteForCausalLMNextN.post_load_weights()` and always delegate with `is_nextn=True`.
- Keep the inherited signature compatible with both the generic loader and weight-loader callbacks.

The fix follows the existing DeepSeek/DeepSeek-V4 NextN contract; the generic loader remains model-agnostic.

## Accuracy Tests

This fixes model initialization and does not alter loaded tensor values or forward math.

H200 server E2E with the documented Dots NextN top-k=1 settings, TP/DP/EP 8, FA3, and dummy target/draft weights:

- target and draft initialization completed;
- `/health` returned 200;
- no `Dot3NoteModelNextN.start_layer` exception occurred.

## Speed Tests and Profiling

Not applicable. The change only corrects a one-time post-load dispatch.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Validated with the H200 server E2E above; no unit test added.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing documentation change is needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (E2E result above; no hot-path change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32856133445](https://github.com/sgl-project/sglang/actions/runs/32856133445)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32856133134](https://github.com/sgl-project/sglang/actions/runs/32856133134)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32856133506](https://github.com/sgl-project/sglang/actions/runs/32856133506)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->