### PR TITLE
[Bugfix] Retain Dots towers for adaptive encoder dispatch

### DIFF
--- a/python/sglang/srt/models/dots3_common/modeling.py
+++ b/python/sglang/srt/models/dots3_common/modeling.py
@@ -115,6 +115,7 @@ from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
 from sglang.srt.models.dots3_common.fp8 import per_token_group_quant_einsum_fp8
 from sglang.srt.runtime_context import (
     get_device,
+    get_disagg,
     get_exec,
     get_parallel,
 )
@@ -2606,8 +2607,13 @@ class DotsNoteOmniThinkerForConditionalGeneration(nn.Module):
             quant_config=quant_config,
             prefix=add_prefix("language_model", prefix),
         )
-        # Load multimodal towers only where embeddings are produced.
-        if self.pp_group.is_first_rank and not config.language_only:
+        # Adaptive encoder dispatch deliberately keeps small media requests on
+        # the language worker. Retain local towers for that fallback even when
+        # the worker otherwise runs in language-only mode.
+        load_local_towers = (
+            not config.language_only or get_disagg().enable_adaptive_dispatch_to_encoder
+        )
+        if self.pp_group.is_first_rank and load_local_towers:
             self.audio_tower = DotsNoteOmniAudioEncoder(str(model_dir))
             self.visual = DotsNoteOmniVisionEncoder(str(model_dir))
         else:


### PR DESCRIPTION
## Motivation

Adaptive encoder dispatch intentionally keeps small multimodal requests on the language worker and sends larger requests to remote encoders. The Dots model currently removes both local towers whenever `--language-only` is set, even when adaptive dispatch is enabled.

A valid single-image request is therefore preprocessed locally as designed, but the scheduler then reaches `get_image_feature()` with `visual=None` and exits on an assertion.

## Modifications

- Retain the Dots audio and vision towers on the first pipeline rank when adaptive encoder dispatch is enabled, including on a language-only worker.
- Preserve the existing lightweight language-only behavior when adaptive dispatch is disabled.

This keeps the existing adaptive routing policy intact: small requests can run locally because the required model state is now present, while non-adaptive language-only workers still omit encoder towers.

## Accuracy Tests

H200 OpenAI API E2E with `--language-only --enable-adaptive-dispatch-to-encoder`, TP/DP/EP 8, FA3, and dummy weights:

- server completed warmup;
- a valid 32x32 PNG request to `/v1/chat/completions` returned HTTP 200;
- the response accounted for 4 image tokens;
- `/health` remained healthy after the request and no scheduler exception occurred.

Dummy weights were used because the regression is structural; output semantics were not evaluated.

## Speed Tests and Profiling

No inference hot-path code changed. Adaptive language workers now intentionally retain local tower memory so that the advertised local fallback is executable; non-adaptive language-only workers are unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Validated with the H200 API E2E above; no unit test added.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (The existing adaptive-dispatch behavior is preserved.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (E2E result above; no hot-path change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32856150671](https://github.com/sgl-project/sglang/actions/runs/32856150671)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32856150462](https://github.com/sgl-project/sglang/actions/runs/32856150462)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32856150777](https://github.com/sgl-project/sglang/actions/runs/32856150777)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
