### PR TITLE
Fix --model-path required error when using --config with sglang serve

### DIFF
--- a/python/sglang/cli/utils.py
+++ b/python/sglang/cli/utils.py
@@ -96,20 +96,39 @@ def get_is_diffusion_model(model_path: str) -> bool:
         return False
 
 
-def try_get_model_path(extra_argv) -> str | None:
-    """Return a model path from command-line arguments when one is present."""
-
-    model_path = None
-    for i, arg in enumerate(extra_argv):
+def _scan_argv_for_model_path(argv) -> str | None:
+    for i, arg in enumerate(argv):
         if arg in ("--model-path", "--model"):
-            if i + 1 < len(extra_argv):
-                model_path = extra_argv[i + 1]
-                break
+            if i + 1 < len(argv):
+                return argv[i + 1]
         elif arg.startswith("--model-path=") or arg.startswith("--model="):
-            model_path = arg.split("=", 1)[1]
-            break
+            return arg.split("=", 1)[1]
 
-    return model_path
+    return None
+
+
+def try_get_model_path(extra_argv) -> str | None:
+    """Return a model path from command-line arguments when one is present.
+
+    Backend auto-detection runs before ``prepare_server_args`` merges a
+    ``--config`` YAML file into argv, so a model-path given only inside the
+    config file must be resolved here too, or detection sees no model path
+    at all (GH #36105).
+    """
+
+    model_path = _scan_argv_for_model_path(extra_argv)
+    if model_path is not None or "--config" not in extra_argv:
+        return model_path
+
+    from sglang.srt.server_args_config_parser import ConfigArgumentMerger
+
+    try:
+        merged_argv = ConfigArgumentMerger().merge_config_with_args(list(extra_argv))
+    except ValueError:
+        # Malformed --config usage; defer to the real parser's error message.
+        return None
+
+    return _scan_argv_for_model_path(merged_argv)
 
 
 def get_model_path(extra_argv):

--- a/test/registered/unit/cli/test_serve_backends.py
+++ b/test/registered/unit/cli/test_serve_backends.py
@@ -1,7 +1,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import tempfile
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
+
+import yaml
 
 from sglang.cli.serve import serve
 from sglang.cli.serve_backends import (
@@ -12,6 +16,7 @@ from sglang.cli.serve_backends import (
     ServeBackendRegistry,
     ServeRequest,
 )
+from sglang.cli.utils import try_get_model_path
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
@@ -243,6 +248,41 @@ class TestServeBackendDispatch(unittest.TestCase):
         self.assertIsNone(request.model_path)
         mock_load_plugins.assert_not_called()
         mock_kill.assert_not_called()
+
+
+class TestTryGetModelPath(unittest.TestCase):
+    """Regression tests for GH #36105: `sglang serve --config x.yaml` raised
+    "--model-path is required" even when the config supplied model-path,
+    because backend auto-detection scanned raw argv before the --config
+    file was merged in."""
+
+    def test_resolves_model_path_from_config_file(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yaml"
+            config_path.write_text(
+                yaml.safe_dump({"model-path": "meta-llama/Llama-3-8B"})
+            )
+
+            self.assertEqual(
+                try_get_model_path(["--config", str(config_path)]),
+                "meta-llama/Llama-3-8B",
+            )
+
+    def test_explicit_cli_flag_takes_precedence_over_config(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            config_path = Path(tmpdir) / "config.yaml"
+            config_path.write_text(yaml.safe_dump({"model-path": "from-config"}))
+
+            self.assertEqual(
+                try_get_model_path(
+                    ["--model-path", "from-cli", "--config", str(config_path)]
+                ),
+                "from-cli",
+            )
+
+    def test_missing_config_file_returns_none_instead_of_raising(self):
+        result = try_get_model_path(["--config", "/no/such/config.yaml"])
+        self.assertIsNone(result)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #36105.

`sglang serve --config my_config.yaml` raised `Error: --model-path is required` even when the config file supplied `model-path:`, while `python3 -m sglang.launch_server --config my_config.yaml` worked fine.

## Root cause

`sglang serve`'s backend auto-detection (`ServeBackendRegistry.auto_detect` via `serve()` in `python/sglang/cli/serve.py`) needs to know the model path *before* dispatching to a backend, to pick between the LLM and diffusion backends and to raise an actionable error when no backend requires a model path be missing. It gets that from `try_get_model_path()`, which only scanned raw argv for `--model-path`/`--model`.

`--config` YAML merging happens later, inside `prepare_server_args()` (`python/sglang/srt/server_args.py`), via `ConfigArgumentMerger`. So when the model path was given only inside the config file, `try_get_model_path()` saw nothing, and `serve()` raised before ever reaching `prepare_server_args()`.

`python -m sglang.launch_server` doesn't hit this because it calls `prepare_server_args()` directly, without a backend-detection pre-check.

## Fix

`try_get_model_path()` now falls back to running the real `ConfigArgumentMerger` against the referenced `--config` file (only when no `--model-path`/`--model` flag is given directly), so backend detection sees the same model path `prepare_server_args` would later resolve. An explicit CLI flag still takes precedence over the config file, and a missing/malformed config file falls back to `None` instead of raising here — the authoritative error still comes from the real parser later.

## Test plan

- [x] Added `TestTryGetModelPath` to `test/registered/unit/cli/test_serve_backends.py`: model-path resolved purely from `--config`, explicit `--model-path` takes precedence over config, missing config file returns `None` instead of raising
- [x] Verified the fix logic in isolation against the real `ConfigArgumentMerger` (reproduces the exact reported bug and confirms the fix)
- [x] `black`, `isort`, `ruff --select=F401,F821,UP037` pass on both changed files
- [ ] Full test suite via CI (same as my other open PR, couldn't install the full CUDA-dependent package stack locally)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32707500441](https://github.com/sgl-project/sglang/actions/runs/32707500441)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32707500128](https://github.com/sgl-project/sglang/actions/runs/32707500128)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32707500290](https://github.com/sgl-project/sglang/actions/runs/32707500290)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->