### PR TITLE
[diffusion] docs: desktop-safe 24 GB recipe and the DGX Spark tier

### DIFF
--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -1399,10 +1399,14 @@ figures are anchored at 480P — activations grow with the pixel count, so at
 768P drop the resident DiT layers to 0 first, then `video_vae` to 24 if the
 decode still collides. And the host convention holds the weights in page
 cache; a physical 32 GB machine re-reads them from disk each step, so the
-drive holding the checkpoint bounds the step time — roughly 15–20 s/step from
-a good NVMe, 35–50 from a SATA or fatigued QLC drive, unusable from a spinning
-archive drive. Put the checkpoint on the fastest drive in the machine, not the
-biggest. The
+page cache cannot hold the per-step weight sweep, so every step re-reads it
+from disk and the drive becomes the denoise clock: a real desktop 4090 with a
+990 Pro measured 38 s/step, reading 52.9 GB per step (faulted sequentially, so
+almost none of it shows in majflt — measure `read_bytes`, not major faults).
+Two things cut that read directly: resident DiT layers (~1 GB/step each — on a
+physically small host raise them as far as VRAM allows, the opposite of the
+capped-host guidance above), and more RAM (64 GB caches the sweep and returns
+to the quoted times). The
 VRAM axis holds too: capped at 16 GiB the same recipe wins ~250 vs 292–301 s,
 and at 24 GiB (with `--dit-layerwise-resident-layers 6` — measured at a
 22 GiB cap so a desktop's own allocations fit; a headless card can raise it

--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -1398,8 +1398,11 @@ Same GPU, same load window, unpruned bf16 checkpoints, outputs verified. All
 figures are anchored at 480P — activations grow with the pixel count, so at
 768P drop the resident DiT layers to 0 first, then `video_vae` to 24 if the
 decode still collides. And the host convention holds the weights in page
-cache; a physical 32 GB machine re-reads them from disk each step (a real
-desktop 4090 measured ~38 s/step at 480P from NVMe). The
+cache; a physical 32 GB machine re-reads them from disk each step, so the
+drive holding the checkpoint sets the step time — roughly 15–20 s/step from a
+good NVMe, 35–50 from a SATA or fatigued QLC drive (a real desktop 4090
+measured 38), unusable from a spinning archive drive. Put the checkpoint on
+the fastest drive in the machine, not the biggest. The
 VRAM axis holds too: capped at 16 GiB the same recipe wins ~250 vs 292–301 s,
 and at 24 GiB (with `--dit-layerwise-resident-layers 6` — measured at a
 22 GiB cap so a desktop's own allocations fit; a headless card can raise it

--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -1396,8 +1396,9 @@ Under that cap, Recipe A wins the whole request at every host size:
 
 Same GPU, same load window, unpruned bf16 checkpoints, outputs verified. The
 VRAM axis holds too: capped at 16 GiB the same recipe wins ~250 vs 292–301 s,
-and at 24 GiB (with `--dit-layerwise-resident-layers 10`, which only a 24 GB
-card has headroom for) ~230 vs 249–260 s. Four changes carry it: the VAE staying on its checkpoint mapping (#35862, root fix
+and at 24 GiB (with `--dit-layerwise-resident-layers 6` — measured at a
+22 GiB cap so a desktop's own allocations fit; a headless card can raise it
+to 10 for under 1% more) ~8.5 s/step vs ComfyUI's 249–260 s requests. Four changes carry it: the VAE staying on its checkpoint mapping (#35862, root fix
 #35946), per-layer pinning with net-cost accounting (#35867), the courier
 thread that ships still-mapped layers through pinned slots (#35882), and
 decoder weights held in their decode dtype from load (#35967) — which is what

--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -1394,7 +1394,12 @@ Under that cap, Recipe A wins the whole request at every host size:
 | 48 GB host | 15.8 + 192.1 + 10.0 ≈ **218 s** | 246–267 s |
 | 64 GB host | 7.5 + 162.4 + 10.3 ≈ **180 s** | 194–195 s |
 
-Same GPU, same load window, unpruned bf16 checkpoints, outputs verified. The
+Same GPU, same load window, unpruned bf16 checkpoints, outputs verified. All
+figures are anchored at 480P — activations grow with the pixel count, so at
+768P drop the resident DiT layers to 0 first, then `video_vae` to 24 if the
+decode still collides. And the host convention holds the weights in page
+cache; a physical 32 GB machine re-reads them from disk each step (a real
+desktop 4090 measured ~38 s/step at 480P from NVMe). The
 VRAM axis holds too: capped at 16 GiB the same recipe wins ~250 vs 292–301 s,
 and at 24 GiB (with `--dit-layerwise-resident-layers 6` — measured at a
 22 GiB cap so a desktop's own allocations fit; a headless card can raise it

--- a/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
+++ b/docs/cookbook/diffusion/MiniMax/MiniMax-H3.mdx
@@ -1399,10 +1399,10 @@ figures are anchored at 480P — activations grow with the pixel count, so at
 768P drop the resident DiT layers to 0 first, then `video_vae` to 24 if the
 decode still collides. And the host convention holds the weights in page
 cache; a physical 32 GB machine re-reads them from disk each step, so the
-drive holding the checkpoint sets the step time — roughly 15–20 s/step from a
-good NVMe, 35–50 from a SATA or fatigued QLC drive (a real desktop 4090
-measured 38), unusable from a spinning archive drive. Put the checkpoint on
-the fastest drive in the machine, not the biggest. The
+drive holding the checkpoint bounds the step time — roughly 15–20 s/step from
+a good NVMe, 35–50 from a SATA or fatigued QLC drive, unusable from a spinning
+archive drive. Put the checkpoint on the fastest drive in the machine, not the
+biggest. The
 VRAM axis holds too: capped at 16 GiB the same recipe wins ~250 vs 292–301 s,
 and at 24 GiB (with `--dit-layerwise-resident-layers 6` — measured at a
 22 GiB cap so a desktop's own allocations fit; a headless card can raise it

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -134,6 +134,8 @@ function consumerHints(s) {
     hints.push("a 32 GB host cannot cache the 108 GB checkpoint: NVMe is required, and real runs land above the quoted step time");
   }
   hints.push('the startup log should say "leaving ... GiB of weights on the checkpoint mapping" -- if it does not, the host is not the constraint you set');
+  hints.push("every figure here is anchored at 480P: activations grow with the pixel count, so at 768P drop the resident DiT layers to 0 first, then video_vae to 24 if the decode still collides -- the flags trade speed for headroom in that order");
+  hints.push("on a physical 32 GB host the 108 GB checkpoint cannot stay cached: expect the stream to re-read from disk (a real desktop 4090 measured ~38 s/step at 480P on NVMe, warming from ~46) -- the quoted step times assume the page cache holds the weights");
   return hints;
 }
 

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -57,12 +57,14 @@ function consumerFlags(s) {
   if (CONSUMER_VRAM_16_PLUS.includes(s.hw) && s.host_ram === "ram96") {
     flags.push("--dit-layerwise-resident-layers 4");
   }
-  // A 24 GB card on a 32 GB host has allocator headroom to keep ten DiT
-  // layers resident (measured 10.4 vs 11.6 s/step); a 16 GB card does not --
-  // there even four resident layers measured slower than none, so it keeps
-  // the plain recipe.
+  // A 24 GB card has headroom for resident DiT layers, but their benefit
+  // flattened once the decoder went fp16 and the courier overlapped the
+  // streaming: measured at a 22 GiB cap (2 GiB desktop headroom), r10/r6/r4
+  // land at 8.41/8.48/8.51 s/step. Six layers keep ~2.4 GiB more free than
+  // ten for under 1% of speed -- the desktop-safe point. A 16 GB card keeps
+  // the plain recipe; even four resident layers measured slower there.
   if (CONSUMER_24G.includes(s.hw) && s.host_ram === "ram32") {
-    flags.push("--dit-layerwise-resident-layers 10");
+    flags.push("--dit-layerwise-resident-layers 6");
   }
   if (WORKSTATION_48G.includes(s.hw)) {
     flags.push("--dit-layerwise-resident-layers 40");
@@ -97,13 +99,14 @@ function consumerHints(s) {
   if (bigHost) {
     if (CONSUMER_VRAM_16_PLUS.includes(s.hw)) {
       hints.push("verified end to end: ~6 s per denoise step, 13 s decode");
+      hints.push("fewer resident layers than the 32 GB rows is not a typo: with the DiT pinned in a big host, streamed layers arrive at pinned-copy speed and GPU residency buys little; on a 32 GB host the stream is the bottleneck residency cuts");
     } else {
       hints.push("~6 s per step once the host pins the DiT; the decode holds all 36 blocks in their fp16 decode dtype and takes ~10 s");
     }
     return hints;
   }
   if (CONSUMER_24G.includes(s.hw)) {
-    hints.push("measured at 32 GB host: ~10.4 s per denoise step with ten resident layers, ~9.6 s decode, ~230 s per request -- ahead of ComfyUI (249-260 s) under the same hard 24 GiB cap");
+    hints.push("measured at 32 GB host under a 22 GiB cap (desktop headroom): ~8.5 s per denoise step with six resident layers, ~9.6 s decode -- ahead of ComfyUI (249-260 s at the 24 GiB cap); a headless card can raise to ten layers for under 1% more");
   } else if (CONSUMER_16G.includes(s.hw)) {
     hints.push("measured at 32 GB host: ~11.9 s per denoise step, ~11 s decode, ~250 s per request -- ahead of ComfyUI (292-301 s) under the same hard 16 GiB cap");
   } else {

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -136,6 +136,7 @@ function consumerHints(s) {
   hints.push('the startup log should say "leaving ... GiB of weights on the checkpoint mapping" -- if it does not, the host is not the constraint you set');
   hints.push("every figure here is anchored at 480P: activations grow with the pixel count, so at 768P drop the resident DiT layers to 0 first, then video_vae to 24 if the decode still collides -- the flags trade speed for headroom in that order");
   hints.push("on a physical 32 GB host the page cache cannot hold the per-step weight sweep, so every step re-reads ~40-65 GB from disk and the drive is the denoise clock: a real desktop 4090 with a 990 Pro measured 38 s/step (52.9 GB read per step). Resident DiT layers cut that read directly (~1 GB/step each), so raise them as far as VRAM allows; 64 GB of RAM caches the sweep and returns to the quoted times");
+  hints.push("on Windows run under WSL2, and keep the checkpoint inside the ext4 side (under ~), never on /mnt/c -- the NTFS bridge reads an order of magnitude slower and multiplies the disk clock");
   return hints;
 }
 

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -135,7 +135,7 @@ function consumerHints(s) {
   }
   hints.push('the startup log should say "leaving ... GiB of weights on the checkpoint mapping" -- if it does not, the host is not the constraint you set');
   hints.push("every figure here is anchored at 480P: activations grow with the pixel count, so at 768P drop the resident DiT layers to 0 first, then video_vae to 24 if the decode still collides -- the flags trade speed for headroom in that order");
-  hints.push("on a physical 32 GB host the 108 GB checkpoint cannot stay cached: expect the stream to re-read from disk (a real desktop 4090 measured ~38 s/step at 480P on NVMe, warming from ~46) -- the quoted step times assume the page cache holds the weights");
+  hints.push("on a physical 32 GB host the 108 GB checkpoint cannot stay cached, so the drive it sits on sets the step time: a good NVMe lands ~15-20 s/step, a SATA or fatigued QLC drive ~35-50 (a real desktop 4090 measured 38), a spinning archive drive is unusable -- put the checkpoint on the fastest drive in the machine, not the big one");
   return hints;
 }
 

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -135,7 +135,7 @@ function consumerHints(s) {
   }
   hints.push('the startup log should say "leaving ... GiB of weights on the checkpoint mapping" -- if it does not, the host is not the constraint you set');
   hints.push("every figure here is anchored at 480P: activations grow with the pixel count, so at 768P drop the resident DiT layers to 0 first, then video_vae to 24 if the decode still collides -- the flags trade speed for headroom in that order");
-  hints.push("on a physical 32 GB host the 108 GB checkpoint cannot stay cached, so the drive it sits on sets the step time: a good NVMe lands ~15-20 s/step, a SATA or fatigued QLC drive ~35-50 (a real desktop 4090 measured 38), a spinning archive drive is unusable -- put the checkpoint on the fastest drive in the machine, not the big one");
+  hints.push("on a physical 32 GB host the 108 GB checkpoint cannot stay cached, so the drive it sits on bounds the step time: a good NVMe supports ~15-20 s/step, a SATA or fatigued QLC drive ~35-50, a spinning archive drive is unusable -- put the checkpoint on the fastest drive in the machine, not the big one");
   return hints;
 }
 

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -135,7 +135,7 @@ function consumerHints(s) {
   }
   hints.push('the startup log should say "leaving ... GiB of weights on the checkpoint mapping" -- if it does not, the host is not the constraint you set');
   hints.push("every figure here is anchored at 480P: activations grow with the pixel count, so at 768P drop the resident DiT layers to 0 first, then video_vae to 24 if the decode still collides -- the flags trade speed for headroom in that order");
-  hints.push("on a physical 32 GB host the 108 GB checkpoint cannot stay cached, so the drive it sits on bounds the step time: a good NVMe supports ~15-20 s/step, a SATA or fatigued QLC drive ~35-50, a spinning archive drive is unusable -- put the checkpoint on the fastest drive in the machine, not the big one");
+  hints.push("on a physical 32 GB host the page cache cannot hold the per-step weight sweep, so every step re-reads ~40-65 GB from disk and the drive is the denoise clock: a real desktop 4090 with a 990 Pro measured 38 s/step (52.9 GB read per step). Resident DiT layers cut that read directly (~1 GB/step each), so raise them as far as VRAM allows; 64 GB of RAM caches the sweep and returns to the quoted times");
   return hints;
 }
 

--- a/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
+++ b/docs/src/snippets/configs/MiniMaxAI/minimax-h3.jsx
@@ -24,17 +24,24 @@ const CONSUMER_24G = ["rtx4090", "rtx3090"];
 // their recipes are derived from the tier logic, not verified runs.
 const WORKSTATION_48G = ["rtx6000ada"];
 const WORKSTATION_96G = ["rtxpro6000"];
+// GB10 unified memory: 128 GB shared between CPU and GPU, so the VRAM/host
+// split that shapes every tier above does not exist. The whole 108 GB
+// deployment fits, and an offloaded component's "copy to device" is an
+// in-memory copy on the coherent bus. No hard-cap anchor was measured.
+const UNIFIED_128G = ["dgx-spark"];
 const CONSUMER_SINGLE = [
   ...CONSUMER_12G,
   ...CONSUMER_16G,
   ...CONSUMER_24G,
   ...WORKSTATION_48G,
   ...WORKSTATION_96G,
+  ...UNIFIED_128G,
 ];
 const CONSUMER_VRAM_16_PLUS = [...CONSUMER_16G, ...CONSUMER_24G];
 const CONSUMER_AMPERE = ["rtx3060", "rtx3090"];
 
 function consumerFlags(s) {
+  if (UNIFIED_128G.includes(s.hw)) return unified128Flags();
   if (WORKSTATION_96G.includes(s.hw)) return workstation96Flags();
   // The whole video decoder held for the decode only: residency arms at the
   // decoder's first block and releases when it finishes, so the denoise still
@@ -61,6 +68,17 @@ function consumerFlags(s) {
     flags.push("--dit-layerwise-resident-layers 40");
   }
   return flags;
+}
+
+function unified128Flags() {
+  // Unified memory holds the whole deployment: the memory manager pins every
+  // component (the budget sees ~128 GB), and streamed copies move at memory
+  // speed on the coherent bus. video_vae=36 still buys the fast decode.
+  return [
+    "--performance-mode memory",
+    "--layerwise-offload-components dit,text_encoder,vae",
+    "--layerwise-resident-layers video_vae=36",
+  ];
 }
 
 function workstation96Flags() {
@@ -94,6 +112,12 @@ function consumerHints(s) {
   if (CONSUMER_AMPERE.includes(s.hw)) {
     hints.push("the recipe and its memory behavior are tier-exact for this card; the step times above were measured on 40-series compute, and Ampere lands above them");
   }
+  if (UNIFIED_128G.includes(s.hw)) {
+    return [
+      "derived recipe, not yet verified: the 128 GB unified pool holds the whole 108 GB deployment, so the memory manager pins every component and offload copies run at memory speed on the coherent bus",
+      "expect step times above the discrete-GPU rows: the GB10's ~273 GB/s memory bandwidth is the denoise ceiling, not the placement",
+    ];
+  }
   if (WORKSTATION_96G.includes(s.hw)) {
     hints.push("derived recipe, not yet verified: 96 GB holds the whole 61.7 GB DiT resident, so only the text encoder and VAEs stream -- expect near-datacenter step times rather than the offload figures above");
   }
@@ -122,6 +146,7 @@ return {
     "mi355x",
     "rtxpro6000",
     "rtx6000ada",
+    "dgx-spark",
     "rtx5090",
     "rtx4090",
     "rtx3090",
@@ -158,7 +183,8 @@ return {
       scope: "serve",
       description: "System memory decides where the DiT weights wait between steps: pinned when they fit, on the checkpoint mapping when they do not.",
       default: "ram32",
-      showWhen: (s) => CONSUMER_SINGLE.includes(s.hw),
+      showWhen: (s) =>
+        CONSUMER_SINGLE.includes(s.hw) && !UNIFIED_128G.includes(s.hw),
       options: [
         { id: "ram32", label: "32 GB" },
         { id: "ram64", label: "48-64 GB" },
@@ -525,6 +551,7 @@ return {
         { id: "mi355x-resident-2", hw: "mi355x", nodes: 1, gpus_per_node: 2, placement: "resident", tp_size: 1, ulysses_degree: 2, ring_degree: 1, encoder: "auto" },
         { id: "mi355x-resident-4", hw: "mi355x", nodes: 1, gpus_per_node: 4, placement: "resident", tp_size: 1, ulysses_degree: 4, ring_degree: 1, encoder: "auto" },
         { id: "mi355x-resident-8", hw: "mi355x", nodes: 1, gpus_per_node: 8, placement: "resident", tp_size: 1, ulysses_degree: 8, ring_degree: 1, encoder: "auto", default: true },
+        { id: "dgx-spark-offload-1", hw: "dgx-spark", nodes: 1, gpus_per_node: 1, placement: "offload", tp_size: 1, ulysses_degree: 1, ring_degree: 1, encoder: "auto", default: true, unverified: true },
         { id: "rtxpro6000-offload-1", hw: "rtxpro6000", nodes: 1, gpus_per_node: 1, placement: "offload", tp_size: 1, ulysses_degree: 1, ring_degree: 1, encoder: "auto", default: true, unverified: true },
         { id: "rtx6000ada-offload-1", hw: "rtx6000ada", nodes: 1, gpus_per_node: 1, placement: "offload", tp_size: 1, ulysses_degree: 1, ring_degree: 1, encoder: "auto", default: true, unverified: true },
         { id: "rtx5090-offload-1", hw: "rtx5090", nodes: 1, gpus_per_node: 1, placement: "offload", tp_size: 1, ulysses_degree: 1, ring_degree: 1, encoder: "auto", default: true },


### PR DESCRIPTION
## Summary

Two consumer-catalog updates driven by a field report and a new hardware tier.

**Desktop-safe 24 GB recipe.** A user's real desktop 4090 OOMed on the `r10` recipe. Two compounding causes: their build predates #35967 (the fp32 decoder residency alone was 9.7 GiB), and our 24 GiB anchor had a methodology hole — `set_per_process_memory_fraction` clamps at 1.0, so "capped at 24 GiB" on a 24 GiB card was actually an empty-card, uncapped run. Re-anchored at a 22 GiB cap (leaving the desktop its 2 GiB) on current main: r10/r6/r4 measure 8.41/8.48/8.51 s/step — residency benefit flattened once the decoder went fp16 and the courier overlapped the streaming — so the recipe drops to `--dit-layerwise-resident-layers 6`, keeping ~2.4 GiB more free for under 1% of speed. Hints carry the headless-can-raise-to-10 note, and the 96 GB rows' smaller layer count gets its explanation (with the DiT pinned, streamed layers arrive at pinned-copy speed; residency only pays when the stream is the bottleneck).

**DGX Spark tier.** GB10's 128 GB unified pool holds the whole 108 GB deployment: the memory recipe pins everything, offload copies run at memory speed on the coherent bus, and `video_vae=36` still buys the fast decode. The Host RAM dimension is hidden for it (no VRAM/host split exists), and the recipe is marked derived/unverified until a GB10 run anchors it — the hint says step times will sit above the discrete rows because ~273 GB/s of memory bandwidth is the denoise ceiling there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32840778785](https://github.com/sgl-project/sglang/actions/runs/32840778785)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32840778576](https://github.com/sgl-project/sglang/actions/runs/32840778576)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->