### PR TITLE
[AMD][CI] Temporarily bypass local-registry image pulls

### DIFF
--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -158,15 +158,7 @@ find_latest_image() {
     fi
   done
 
-  # If not found locally, fall back to pulling from public registry.
-  # We intentionally do not probe ${LOCAL_DOCKER_REGISTRY} here with
-  # `docker manifest inspect --insecure` because that command runs in the
-  # runner pod's network namespace, which on every observed AMD scale set
-  # cannot reach 10.44.14.109:5000 (every probe either fast-fails with TLS
-  # reject or hits a 30s TCP timeout, multiplied across 7 daily candidates).
-  # The actual local-registry pull still happens in the call site below via
-  # `docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}"`, which goes through the
-  # docker daemon on the host and inherits its insecure-registries config.
+  # If not found locally, resolve the latest tag from the public registry.
   for days_back in {0..6}; do
     image_tag="${base_tag}-$(date -d "${days_back} days ago" +%Y%m%d)"
     echo "Checking for image: rocm/sgl-dev:${image_tag}" >&2
@@ -272,19 +264,9 @@ elif [[ -n "${BUILD_FROM_DOCKERFILE}" ]]; then
 else
   # Find the latest pre-built image
   IMAGE=$(find_latest_image "${GPU_ARCH}")
-  # Try the local docker registry first (avoids Docker Hub rate limits and is
-  # faster on the LAN); if that fails for any reason, fall back to the
-  # public registry with exponential-backoff retries. Capture stderr so the
-  # real failure reason (TLS handshake, 404, connection refused, etc.) is
-  # visible in the job log instead of being silently swallowed.
-  if local_pull_output=$(docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" 2>&1); then
-    echo "Pulled from local docker registry: ${LOCAL_DOCKER_REGISTRY}/${IMAGE}"
-    docker tag "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" "${IMAGE}"
-  else
-    echo "Local docker registry pull failed; falling back to public registry: ${IMAGE}" >&2
-    printf '%s\n' "${local_pull_output}" | sed 's/^/  [local-pull] /' >&2
-    retry_with_backoff 6 docker pull "${IMAGE}"
-  fi
+  # Temporarily bypass the shared local registry while concurrent CI pulls
+  # saturate it. Keep using the authenticated, retried public-registry path.
+  retry_with_backoff 6 docker pull "${IMAGE}"
 fi
 
 CACHE_HOST=/home/runner/sglang-data

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -143,11 +143,7 @@ find_latest_image() {
     fi
   done
 
-  # If not found locally, fall back to pulling from public registry.
-  # See amd_ci_start_container.sh for why we don't probe
-  # ${LOCAL_DOCKER_REGISTRY} with `docker manifest inspect --insecure` from
-  # the runner pod's network namespace; the actual local-registry pull
-  # happens at the call site below via the docker daemon on the host.
+  # If not found locally, resolve the latest tag from the public registry.
   for days_back in {0..6}; do
     image_tag="${base_tag}-$(date -d "${days_back} days ago" +%Y%m%d)"
     echo "Checking for image: rocm/sgl-dev:${image_tag}" >&2
@@ -225,19 +221,9 @@ if [[ -n "${CUSTOM_IMAGE}" ]]; then
   fi
 else
   IMAGE=$(find_latest_image "${GPU_ARCH}")
-  # Try the local docker registry first (avoids Docker Hub rate limits and is
-  # faster on the LAN); if that fails for any reason, fall back to the
-  # public registry with exponential-backoff retries. Capture stderr so the
-  # real failure reason (TLS handshake, 404, connection refused, etc.) is
-  # visible in the job log instead of being silently swallowed.
-  if local_pull_output=$(docker pull "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" 2>&1); then
-    echo "Pulled from local docker registry: ${LOCAL_DOCKER_REGISTRY}/${IMAGE}"
-    docker tag "${LOCAL_DOCKER_REGISTRY}/${IMAGE}" "${IMAGE}"
-  else
-    echo "Local docker registry pull failed; falling back to public registry: ${IMAGE}" >&2
-    printf '%s\n' "${local_pull_output}" | sed 's/^/  [local-pull] /' >&2
-    retry_with_backoff 6 docker pull "${IMAGE}"
-  fi
+  # Temporarily bypass the shared local registry while concurrent CI pulls
+  # saturate it. Keep using the authenticated, retried public-registry path.
+  retry_with_backoff 6 docker pull "${IMAGE}"
 fi
 
 CACHE_HOST=/home/runner/sglang-data


### PR DESCRIPTION
## Motivation

AMD CI currently tries the shared local registry before Docker Hub. The nightly jobs that explicitly push newly published images into the local registry are disabled, so a cold image can still trigger a large upstream transfer through that shared path.

During the current incident, [job 97284747841](https://github.com/sgl-project/sglang/actions/runs/32676220314/job/97284747841#step:4:1590) spent about 4 hours 16 minutes pulling `rocm/sgl-dev:v0.5.18-rocm724-mi30x-20260823` through the local registry while many AMD runners were active.

## Changes

- Bypass the automatic local-registry pull/tag path in both the standard and disaggregated AMD container launchers.
- Pull the selected public `rocm/sgl-dev` image with the existing authenticated, six-attempt exponential-backoff path.
- Preserve the local Docker daemon cache check.
- Preserve explicit local-registry custom images passed by `--custom-image`; this only changes automatic prebuilt-image selection.

This is an intentionally narrow incident-mitigation change. Image selection and container launch behavior are otherwise unchanged.

## Risk and rollback

This shifts CI image traffic to Docker Hub and may expose jobs to rate limits or public-network instability. The existing optional Docker Hub login and retry path reduce that risk.

Rollback is straightforward: restore the local-first blocks after local-registry publishing or pre-warming is enabled and the path is verified under expected concurrency.

## Testing

```bash
bash -n scripts/ci/amd/amd_ci_start_container.sh
bash -n scripts/ci/amd/amd_ci_start_container_disagg.sh
git diff --check
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32711860839](https://github.com/sgl-project/sglang/actions/runs/32711860839)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32711860836](https://github.com/sgl-project/sglang/actions/runs/32711860836)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32711860962](https://github.com/sgl-project/sglang/actions/runs/32711860962)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->