### PR TITLE
Add Q/K Hadamard rotation for KV cache FP4 quantization to improve the accuracy.

### DIFF
--- a/python/sglang/srt/layers/attention/kvrot.py
+++ b/python/sglang/srt/layers/attention/kvrot.py
@@ -1,0 +1,36 @@
+import math
+from typing import Optional
+
+import torch
+
+from sglang.kernels.ops.quantization.hadamard import hadamard_transform
+
+
+def get_qkrot_block() -> Optional[int]:
+    """Return the configured Q/K Hadamard rotation block size, if any."""
+    try:
+        from sglang.srt.runtime_context import get_server_args
+
+        return getattr(get_server_args(), "qkrot_block", None)
+    except ValueError:
+        return None
+
+
+def apply_block_hadamard_rotation(x: torch.Tensor, block_size: int) -> torch.Tensor:
+    """Apply an orthonormal block Hadamard rotation over the last dimension."""
+    if block_size <= 0:
+        raise ValueError(f"rotation block size must be positive, got {block_size}.")
+
+    head_dim = x.shape[-1]
+    if head_dim % block_size != 0:
+        raise ValueError(
+            f"rotation block size {block_size} must divide head_dim {head_dim}."
+        )
+
+    if head_dim == block_size:
+        return hadamard_transform(x.contiguous(), scale=1.0 / math.sqrt(block_size))
+
+    original_shape = x.shape
+    x = x.reshape(*original_shape[:-1], head_dim // block_size, block_size)
+    x = hadamard_transform(x.contiguous(), scale=1.0 / math.sqrt(block_size))
+    return x.reshape(original_shape)

--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -24,6 +24,10 @@ import torch
 from torch import nn
 
 from sglang.srt.compilation.compilation_config import register_split_op
+from sglang.srt.layers.attention.kvrot import (
+    apply_block_hadamard_rotation,
+    get_qkrot_block,
+)
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
@@ -146,6 +150,7 @@ class RadixAttention(nn.Module):
         self.pos_encoding_mode = pos_encoding_mode
         self.logit_capping_method = logit_capping_method
         self.xai_temperature_len = -1
+        self.qkrot_block = get_qkrot_block()
 
     def forward(
         self,
@@ -163,6 +168,13 @@ class RadixAttention(nn.Module):
             if "k_rope" not in kwargs:
                 k = k.view(-1, self.tp_k_head_num, self.qk_head_dim)
                 v = v.view(-1, self.tp_v_head_num, self.v_head_dim)
+                if self.qkrot_block is not None:
+                    q_shape = q.shape
+                    q = q.view(-1, self.tp_q_head_num, self.qk_head_dim)
+                    q = apply_block_hadamard_rotation(q, self.qkrot_block).reshape(
+                        q_shape
+                    )
+                    k = apply_block_hadamard_rotation(k, self.qkrot_block)
             else:
                 k = k.view(-1, self.tp_k_head_num, self.v_head_dim)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -735,6 +735,18 @@ class ServerArgs:
         ),
         NS("model"),
     ] = "auto"
+    qkrot_block: A[
+        Optional[int],
+        Arg(
+            help=(
+                "Enable Q/K block Hadamard rotation for FP4 KV cache. The value "
+                "is the rotation block size and must be a positive power of two. "
+                "16 matches SGLang's FP4 KV cache quantization block size. "
+                "Requires --kv-cache-dtype nvfp4 or --kv-cache-dtype fp4_mx_block16."
+            ),
+        ),
+        NS("model"),
+    ] = None
     enable_fp32_lm_head: A[
         bool, "If set, the LM head outputs (logits) are in FP32.", NS("exec.features")
     ] = False
@@ -3888,6 +3900,7 @@ class ServerArgs:
         self._handle_int8_mamba_checkpoint()
         self._handle_linear_attn_backend()
         self._handle_kv4_compatibility()
+        self._handle_qkrot_compatibility()
         self._handle_mxfp8_kv_cache_compatibility()
         self._handle_page_size()
         self._handle_amd_specifics()
@@ -6525,6 +6538,23 @@ class ServerArgs:
                         )
         else:
             raise RuntimeError("KV4 is not tested on non-CUDA platforms.")
+
+    def _handle_qkrot_compatibility(self):
+        """Validate Q/K block Hadamard rotation settings for FP4 KV cache."""
+        if self.qkrot_block is None:
+            return
+
+        if self.kv_cache_dtype not in ("nvfp4", "fp4_mx_block16"):
+            raise ValueError(
+                "--qkrot-block currently requires --kv-cache-dtype nvfp4 or "
+                "--kv-cache-dtype fp4_mx_block16."
+            )
+
+        if self.qkrot_block <= 0 or self.qkrot_block & (self.qkrot_block - 1) != 0:
+            raise ValueError("--qkrot-block must be a positive power of two.")
+
+        if not is_cuda():
+            raise RuntimeError("--qkrot-block uses the CUDA Hadamard kernel.")
 
     def _handle_page_size(self):
         # Moved to the resolution pipeline (arg_groups/overrides.py:

--- a/test/registered/kernels/ops/quantization/test_hadamard_jit.py
+++ b/test/registered/kernels/ops/quantization/test_hadamard_jit.py
@@ -14,6 +14,7 @@ from sglang.kernels.ops.quantization.hadamard import (
     hadamard_transform_28n,
     hadamard_transform_40n,
 )
+from sglang.srt.layers.attention.kvrot import apply_block_hadamard_rotation
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=128, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -315,6 +316,24 @@ def test_hadamard_transform_scale_one(dtype):
     out_ref = hadamard_transform_ref(x.detach().clone().float(), scale=1.0)
 
     torch.testing.assert_close(out.float(), out_ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_block_hadamard_rotation_is_self_inverse(dtype):
+    device = "cuda"
+
+    if dtype == torch.bfloat16:
+        rtol, atol = 1e-2, 5e-2
+    else:
+        rtol, atol = 3e-3, 5e-3
+
+    torch.random.manual_seed(0)
+    x = torch.randn(4, 8, 128, device=device, dtype=dtype)
+
+    rotated = apply_block_hadamard_rotation(x, block_size=16)
+    restored = apply_block_hadamard_rotation(rotated, block_size=16)
+
+    torch.testing.assert_close(restored.float(), x.float(), rtol=rtol, atol=atol)
 
 
 # Test dimensions for M×N variants: dim = M * N where N = 2^k.

--- a/test/registered/unit/layers/attention/test_kvrot.py
+++ b/test/registered/unit/layers/attention/test_kvrot.py
@@ -1,0 +1,35 @@
+"""Unit tests for Q/K block Hadamard rotation helpers — CPU only."""
+
+import argparse
+import unittest
+
+import torch
+
+from sglang.srt.layers.attention.kvrot import apply_block_hadamard_rotation
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestApplyBlockHadamardRotation(CustomTestCase):
+    def test_rejects_non_positive_block_size(self):
+        x = torch.randn(2, 4, 16)
+        with self.assertRaisesRegex(ValueError, "must be positive"):
+            apply_block_hadamard_rotation(x, block_size=0)
+
+    def test_rejects_block_size_that_does_not_divide_head_dim(self):
+        x = torch.randn(2, 4, 16)
+        with self.assertRaisesRegex(ValueError, "must divide head_dim"):
+            apply_block_hadamard_rotation(x, block_size=12)
+
+    def test_cli_parses_qkrot_block(self):
+        parser = argparse.ArgumentParser()
+        ServerArgs.add_cli_args(parser)
+        args = parser.parse_args(["--model", "dummy", "--qkrot-block", "16"])
+        self.assertEqual(args.qkrot_block, 16)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Based on existing FP4 KV (`--kv-cache-dtype nvfp4` or `fp4_mx_block16`), this PR adds an optional block Hadamard rotation on Q/K before FP4 KV quantization via `--qkrot-block`. For example, `--qkrot-block 16` matches the FP4 quantization block size.

## Motivation

SGLang already supports FP4 KV cache (`nvfp4` / `fp4_mx_block16`). This PR adds an optional Q/K Hadamard rotation so quantization happens in a rotated space, which can reduce quantization error.

## Modifications

- Add `--qkrot-block` for `--kv-cache-dtype nvfp4` or `fp4_mx_block16`.
- Apply block Hadamard rotation on Q/K in `RadixAttention` before KV is stored.
- Add CPU unit tests and a GPU self-inverse Hadamard test.

## Accuracy Tests

We evaluated Qwen3-8B, Qwen3-32B, Qwen3.5-35B-A3B, and GPT-OSS-120B on GSM8K, GPQA-Diamond (198), and MATH500 (500).
KV-FP4 used `--kv-cache-dtype fp4_e2m1` (now `fp4_mx_block16`) with block size 16.
QK rotation used `--qkrot-block 16`.

| Model | Dataset | KV-BF16 | KV-FP4 | KV-FP4 + QKrot16 | QKrot − FP4 |
| --- | --- | ---: | ---: | ---: | ---: |
| Qwen3-8B | GSM8K | 91.17% | 88.96% | 90.41% | +1.45 |
| Qwen3-8B | GPQA-Diamond | 57.07% | 53.54% | 55.56% | +2.02 |
| Qwen3-8B | MATH500 | 75.40% | 74.40% | 74.60% | +0.20 |
| Qwen3-32B | GSM8K | 96.35% | 95.59% | 96.27% | +0.68 |
| Qwen3-32B | GPQA-Diamond | 62.12% | 58.08% | 61.11% | +3.03 |
| Qwen3-32B | MATH500 | 71.60% | 71.40% | 72.20% | +0.80 |
| Qwen3.5-35B-A3B | GSM8K | 70.85% | 73.74% | 71.40% | -2.34 |
| Qwen3.5-35B-A3B | GPQA-Diamond | 84.34% | 82.32% | 84.34% | +2.02 |
| Qwen3.5-35B-A3B | MATH500 | 85.00% | 83.80% | 86.00% | +2.20 |
| GPT-OSS-120B | GSM8K | 95.43% | 92.62% | 92.77% | +0.15 |
| GPT-OSS-120B | GPQA-Diamond | 66.16% | 62.63% | 67.68% | +5.05 |
| GPT-OSS-120B | MATH500 | 68.20% | 64.40% | 62.00% | -2.40 |

**Conclusion:** Relative to plain KV-FP4, `--qkrot-block 16` recovers accuracy on most settings, especially GPQA-Diamond (+2.02 to +5.05). Qwen3-8B and Qwen3-32B improve on all three datasets. There are two regressions (Qwen3.5-35B-A3B GSM8K −2.34, GPT-OSS-120B MATH500 −2.40); overall QK rotation is a net accuracy win versus FP4 without rotation.

## Speed Tests and Profiling

The main goal of this PR is to improve the accuracy of FP4 KV quantization, not speed. But we still evaluated the latency and throughput. These numbers come from the same `run_eval` / checkpointed eval jobs used for accuracy (wall-clock `latency` and `output_throughput`). They are **not** a `bench_serving` profile. The fair comparison for this PR is **KV-FP4 vs KV-FP4 + `--qkrot-block 16`**. Eval wall time is also affected by generated length, so these numbers are a system-level check that QK rotation does not add a large overhead.

### Qwen3.5-35B-A3B
| Dataset | Concurrency | Latency FP4 (s) | Latency FP4+QKrot (s) | Throughput FP4 (tok/s) | Throughput FP4+QKrot (tok/s) |
| --- | ---: | ---: | ---: | ---: | ---: |
| GPQA-Diamond | 128 | 5490.2 | 5436.8 | 295.9 | 300.9 |
| MATH500 | 128 | 9838.2 | 9581.9 | 468.9 | 451.2 |
| GSM8K | 512 | 5544.6 | 5809.2 | 610.8 | 613.4 |

### Qwen3-8B
| Dataset | Concurrency | Latency FP4 (s) | Latency FP4+QKrot (s) | Throughput FP4 (tok/s) | Throughput FP4+QKrot (tok/s) |
| --- | ---: | ---: | ---: | ---: | ---: |
| GPQA-Diamond | 128 | 12637.1 | 9690.5 | 120.5 | 149.4 |
| MATH500 | 128 | 14619.1 | 14396.6 | 205.2 | 171.7 |

### Qwen3-32B
| Dataset | Concurrency | Latency FP4 (s) | Latency FP4+QKrot (s) | Throughput FP4 (tok/s) | Throughput FP4+QKrot (tok/s) |
| --- | ---: | ---: | ---: | ---: | ---: |
| GPQA-Diamond | 128 | 13567.5 | 10335.1 | 85.2 | 102.9 |
| MATH500 | 128 | 15988.0 | 15023.2 | 121.7 | 129.8 |

### GPT-OSS-120B
| Dataset | Concurrency | Latency FP4 (s) | Latency FP4+QKrot (s) | Throughput FP4 (tok/s) | Throughput FP4+QKrot (tok/s) |
| --- | ---: | ---: | ---: | ---: | ---: |
| GPQA-Diamond | 128 | 788.0 | 622.6 | 454.0 | 592.0 |
| MATH500 | 128 | 1872.8 | 1428.1 | 320.9 | 460.2 |
| GSM8K | 512 | 214.5 | 268.9 | 2188.1 | 2022.4 |

Notes:
- Latency is end-to-end eval wall time; throughput is `output_throughput` from the eval JSON.

**Conclusion:** Adding `--qkrot-block 16` does not introduce a systematic latency or throughput penalty versus plain KV-FP4. Eval-level latency and output throughput stay in the same range; several jobs are slightly faster, which is consistent with similar or shorter generated length rather than extra Hadamard cost.

## Generated length

### Qwen3.5-35B-A3B
| Benchmark | Method | N | Total tokens | P50 | P90 | Max | Mean | vs BF16 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| GPQA | BF16 | 198 | 1,536,848 | 7332 | 11954 | 20348 | 7762 | — |
| GPQA | KV-FP4 | 198 | 1,624,705 | 7330 | 13431 | 32768 | 8206 | +5.72% |
| GPQA | KV-FP4+QKrot16 | 198 | 1,636,151 | 7708 | 13420 | 32768 | 8263 | +6.46% |
| MATH500 | BF16 | 500 | 4,556,381 | 6328 | 23034 | 32768 | 9113 | — |
| MATH500 | KV-FP4 | 500 | 4,613,404 | 6659 | 20961 | 32768 | 9227 | +1.25% |
| MATH500 | KV-FP4+QKrot16 | 500 | 4,323,767 | 6291 | 18457 | 32768 | 8648 | -5.11% |

### Qwen3-8B
| Benchmark | Method | N | Total tokens | P50 | P90 | Max | Mean | vs BF16 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| GPQA | KV-FP4 | 198 | 1,523,223 | 7062 | 13387 | 32745 | 7693 | N/A |
| GPQA | KV-FP4+QKrot16 | 198 | 1,447,763 | 6638 | 12435 | 23572 | 7312 | N/A |
| MATH500 | BF16 | 500 | 2,341,446 | 2916 | 9722 | 32768 | 4683 | — |
| MATH500 | KV-FP4 | 500 | 2,999,728 | 3475 | 13644 | 32768 | 5999 | +28.11% |
| MATH500 | KV-FP4+QKrot16 | 500 | 2,471,284 | 2839 | 10916 | 32768 | 4943 | +5.55% |

### Qwen3-32B
| Benchmark | Method | N | Total tokens | P50 | P90 | Max | Mean | vs BF16 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| GPQA | BF16 | 198 | 995,015 | 4033 | 10398 | 19750 | 5025 | — |
| GPQA | KV-FP4 | 198 | 1,156,066 | 4233 | 12271 | 32768 | 5839 | +16.19% |
| GPQA | KV-FP4+QKrot16 | 198 | 1,063,993 | 4118 | 10625 | 21389 | 5374 | +6.93% |
| MATH500 | BF16 | 500 | 1,948,663 | 2387 | 7896 | 32768 | 3897 | — |
| MATH500 | KV-FP4 | 500 | 1,945,691 | 2477 | 7872 | 32768 | 3891 | -0.15% |
| MATH500 | KV-FP4+QKrot16 | 500 | 1,949,977 | 2400 | 8300 | 28689 | 3900 | +0.07% |

### GPT-OSS-120B
| Benchmark | Method | N | Total tokens | P50 | P90 | Max | Mean | vs BF16 |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| GPQA | BF16 | 198 | 370,660 | 1297 | 3966 | 8275 | 1872 | — |
| GPQA | KV-FP4 | 198 | 346,693 | 1109 | 4189 | 10655 | 1751 | -6.47% |
| GPQA | KV-FP4+QKrot16 | 198 | 357,331 | 1339 | 4243 | 9560 | 1805 | -3.60% |
| MATH500 | KV-FP4 | 500 | 601,005 | 583 | 3074 | 24267 | 1202 | N/A |
| MATH500 | KV-FP4+QKrot16 | 500 | 657,234 | 582 | 3102 | 19014 | 1314 | N/A |

**Conclusion:** QK rotation does not inflate generation length versus plain KV-FP4. Mean tokens are similar or lower in most settings (Qwen3-8B/32B GPQA and MATH500, Qwen3.5 MATH500). The remaining cases are small (Qwen3.5 GPQA +0.7% vs FP4, GPT-OSS MATH500 +9.3% vs FP4). On several traces, QKrot is closer to BF16 than FP4 is, which suggests less over-generation from quantization error.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Happy to add a short `--qkrot-block` note in the quantized KV cache docs if reviewers want it.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Eval-job latency/throughput is included above; we can add a dedicated `bench_serving` profile if requested.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

This is a fork PR. Please help with review and CI:

1. Please tag a Merge Oncall / CODEOWNER for KV cache / attention to start review.
2. Fork PRs do not run CI by default. An authorized reviewer can comment `/tag-and-rerun-ci` on the current commit.
3. After CI is green and approvals are in, please merge. I can iterate quickly on review comments.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32713294192](https://github.com/sgl-project/sglang/actions/runs/32713294192)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32713293935](https://github.com/sgl-project/sglang/actions/runs/32713293935)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32713294258](https://github.com/sgl-project/sglang/actions/runs/32713294258)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->