### PR TITLE
[diffusion] Fix test_model_fast_paths import after sana_ln_modulate rename

### DIFF
--- a/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
+++ b/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
@@ -99,7 +99,7 @@ from sglang.multimodal_gen.runtime.models.dits.sana import (
     _eager_ln_modulate as _sana_eager_ln_modulate,
 )
 from sglang.multimodal_gen.runtime.models.dits.sana import (
-    _sana_ln_modulate,
+    sana_ln_modulate,
 )
 from sglang.multimodal_gen.runtime.models.vaes import flux2_vae_cuda_opt as vae_opt
 from sglang.multimodal_gen.runtime.models.vaes.autoencoder import AutoencoderKL
@@ -361,7 +361,7 @@ def test_sana_fused_ln_modulate_is_bit_exact(shape, nmod, transposed):
     shift, scale = emb.chunk(nmod, dim=1)[0], emb.chunk(nmod, dim=1)[-1]
     # default-stream eager serving must stay on the untouched eager chain
     n_sigs = len(sana._SANA_LN_MOD.verified_sigs)
-    _sana_ln_modulate(norm, x, scale, shift)
+    sana_ln_modulate(norm, x, scale, shift)
     assert len(sana._SANA_LN_MOD.verified_sigs) == n_sigs
     # The fusion engages on non-default streams (the BCG warmup/capture path).
     # x/scale/shift were filled on the default stream, so the side stream must
@@ -373,9 +373,9 @@ def test_sana_fused_ln_modulate_is_bit_exact(shape, nmod, transposed):
     side = torch.cuda.Stream()
     side.wait_stream(torch.cuda.current_stream())
     with torch.cuda.stream(side):
-        out = _sana_ln_modulate(norm, x, scale, shift)
+        out = sana_ln_modulate(norm, x, scale, shift)
         assert len(sana._SANA_LN_MOD.verified_sigs) == n_sigs + 1  # verified
-        out2 = _sana_ln_modulate(norm, x, scale, shift)  # verified-sig lane
+        out2 = sana_ln_modulate(norm, x, scale, shift)  # verified-sig lane
     torch.cuda.current_stream().wait_stream(side)
     torch.cuda.synchronize()
     assert torch.equal(out, _sana_eager_ln_modulate(norm, x, scale, shift))


### PR DESCRIPTION
## Motivation

`test/registered/kernels/ops/diffusion/test_model_fast_paths.py` fails at import on `main`, which takes down the whole `jit-kernel-unit-test` job and, through fast-fail, cascades into `wait-for-base-a`, `base-a-test-1-gpu-small`, `pr-test-finish`, and the extra/AMD finish jobs on unrelated PRs.

```
File "test/registered/kernels/ops/diffusion/test_model_fast_paths.py", line 101, in <module>
    from sglang.multimodal_gen.runtime.models.dits.sana import (
ImportError: cannot import name '_sana_ln_modulate' from
    'sglang.multimodal_gen.runtime.models.dits.sana'
```

#35961 (`f4448e67`, merged 2026-08-24T00:47Z) renamed the helper:

```diff
-def _sana_ln_modulate(
+def sana_ln_modulate(
```

and updated the three call sites inside `sana.py`, but the commit does not touch the test, which still imports the old private name. The neighbouring `_eager_ln_modulate as _sana_eager_ln_modulate` import on the line above is unaffected, since that symbol was not renamed.

101 of 103 files in the job pass; this one fails during collection, so the failure is not related to any kernel behaviour.

## Modifications

Import the public name and update the three call sites. No aliasing back to the old private name, since `sana_ln_modulate` is now the exported spelling and the symbol already carries its own `sana` prefix.

Nothing else in the tree references the old name. `grep` for `_sana_ln_modulate` across the repo returns only this test and a doc line that happens to contain the filename `test_sana_ln_modulate.py`, which is a different file and is left alone.

## Accuracy Tests

No behaviour change: this is a rename of a reference, and the assertions, streams, and `verified_sigs` counting in the test are untouched. `python -m ast` parses the modified file, and the resulting diff is four lines.

I could not execute the test locally, since it needs a CUDA device and the diffusion runtime, so CI on this PR is the real check.

## Checklist

- [x] Format the code
- [x] Add unit tests as outlined in the Contribution Guide (not applicable, this repairs an existing test)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32723734444](https://github.com/sgl-project/sglang/actions/runs/32723734444)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32723733995](https://github.com/sgl-project/sglang/actions/runs/32723733995)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32723734288](https://github.com/sgl-project/sglang/actions/runs/32723734288)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->