### PR TITLE
[Bugfix] Reject empty input_embeds during request normalization

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -451,6 +451,8 @@ class GenerateReqInput:
                 self.batch_size = len(self.input_ids)
             self.input_embeds = None
         else:
+            if len(self.input_embeds) == 0 or len(self.input_embeds[0]) == 0:
+                raise ValueError("input_embeds cannot be empty.")
             if isinstance(self.input_embeds[0][0], float):
                 self.is_single = True
                 self.batch_size = 1

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1087,6 +1087,15 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             )
             req.normalize_batch_and_arguments()
 
+        # Test empty input_embeds dimensions
+        for input_embeds in ([], [[]]):
+            with self.subTest(input_embeds=input_embeds):
+                with self.assertRaisesRegex(
+                    ValueError, "input_embeds cannot be empty"
+                ):
+                    req = GenerateReqInput(input_embeds=input_embeds)
+                    req.normalize_batch_and_arguments()
+
     def test_data_parallel_rank_alias_maps_to_routed_dp_rank(self):
         req = GenerateReqInput(text="Hello", sampling_params={}, data_parallel_rank=2)
         req.normalize_batch_and_arguments()


### PR DESCRIPTION
## Motivation

Empty `input_embeds` payloads currently reach `_determine_batch_size`, which indexes `input_embeds[0][0]` and raises `IndexError`. Since the generate endpoint handles `ValueError` as invalid input, this turns a malformed request into a server error instead of a clear client error.

## Modifications

- Reject empty outer and first nested `input_embeds` dimensions with `ValueError`.
- Add regression coverage for both `[]` and `[[]]`.

## Accuracy Tests

Not applicable; this only validates malformed request inputs.

## Speed Tests and Profiling

Not applicable; the validation is a constant-time check during request normalization.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Tested with:

```bash
PYTHONPATH=python python -m pytest test/registered/unit/managers/test_io_struct.py -q
```

Result: 47 passed, 2 skipped.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32716292317](https://github.com/sgl-project/sglang/actions/runs/32716292317)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32716291915](https://github.com/sgl-project/sglang/actions/runs/32716291915)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32716292347](https://github.com/sgl-project/sglang/actions/runs/32716292347)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->