### PR TITLE
[npu] Combine NPU test fixes from #35472 and #34516

### DIFF
--- a/.github/workflows/pr-test-npu.yml
+++ b/.github/workflows/pr-test-npu.yml
@@ -297,7 +297,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.main_package == 'true' }}
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
-      runner: linux-aarch64-a3-2-
+      runner: linux-aarch64-a3-800t-2
       test_type: 'accuracy'
       test_suite: base-c-test-acc-2-npu-a3
       image: ${{ needs.set-image-config.outputs.CANN_image_a3 }}
@@ -310,7 +310,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.main_package == 'true' }}
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
-      runner: linux-aarch64-a3-4-
+      runner: linux-aarch64-a3-800t-4
       test_type: 'accuracy'
       test_suite: base-c-test-acc-4-npu-a3
       image: ${{ needs.set-image-config.outputs.CANN_image_a3 }}
@@ -323,7 +323,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.main_package == 'true' }}
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
-      runner: linux-aarch64-a3-8-
+      runner: linux-aarch64-a3-800t-8
       test_type: 'accuracy'
       test_suite: base-c-test-acc-8-npu-a3
       image: ${{ needs.set-image-config.outputs.CANN_image_a3 }}
@@ -336,7 +336,7 @@ jobs:
     if: ${{ !failure() && !cancelled() && needs.check-changes.outputs.main_package == 'true' }}
     uses: ./.github/workflows/_npu-single-node-test-stage.yml
     with:
-      runner: linux-aarch64-a3-16-
+      runner: linux-aarch64-a3-800t-16
       test_type: 'accuracy'
       test_suite: base-c-test-acc-16-npu-a3
       image: ${{ needs.set-image-config.outputs.CANN_image_a3 }}

--- a/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_accuracy_utils.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import threading
@@ -17,6 +16,7 @@ from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.e2e.test_npu_multi_node_utils import (
     SERVICE_PORT,
     check_role,
+    kill_process_group,
     launch_pd_mix_node,
     launch_pd_separation_node,
     launch_router,
@@ -103,21 +103,6 @@ def get_max_retries(datasets):
     if dataset in DATASET_FLUCTUATION:
         return MAX_RETRY_COUNT
     return 1
-
-
-def _kill_evalscope_session(process):
-    """Kill the whole evalscope session (process.pid is the leader == pgid)."""
-    if process is None:
-        return
-    try:
-        os.killpg(process.pid, signal.SIGKILL)
-        logger.info(f"run_evalscope killed session pgid={process.pid}")
-    except ProcessLookupError:
-        logger.info(f"run_evalscope session pgid={process.pid} already gone")
-    except PermissionError:
-        logger.warning(
-            f"run_evalscope no permission to kill session pgid={process.pid}"
-        )
 
 
 def run_evalscope(
@@ -215,7 +200,7 @@ def run_evalscope(
             f"returncode={process.returncode}"
         )
 
-        _kill_evalscope_session(process)
+        kill_process_group(process)
 
         if process.returncode != 0:
             logger.error(f"Command failed with return code: {process.returncode}")
@@ -272,14 +257,14 @@ def run_evalscope(
             logger.warning("Process did not terminate gracefully, killing it...")
             process.kill()
             logger.info("Process killed")
-        _kill_evalscope_session(process)
+        kill_process_group(process)
         raise
 
     except Exception as e:
         logger.error(f"Error executing command: {e}")
         process.terminate()
         process.wait(timeout=5)
-        _kill_evalscope_session(process)
+        kill_process_group(process)
         raise
 
 

--- a/python/sglang/test/ascend/e2e/test_npu_multi_node_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_multi_node_utils.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import signal
 import socket
 import subprocess
 import threading
@@ -1079,3 +1080,22 @@ class TestNpuMultiNodePdSepTestCaseBase(CustomTestCase):
             expect_accuracy,
             f'Accuracy is {str(metrics["accuracy"])}, is lower than {expect_accuracy}',
         )
+
+
+def kill_process_group(process):
+    """SIGKILL the whole process group led by ``process.pid`` (== pgid).
+
+    ``process`` is a ``subprocess.Popen`` launched with ``start_new_session=True``,
+    so its pid equals the process-group id. A ``None`` process is ignored.
+    """
+    if process is None:
+        return
+    try:
+        os.killpg(process.pid, signal.SIGKILL)
+        logger.info(f"killed process group pgid={process.pid}")
+    except ProcessLookupError:
+        logger.info(f"process group pgid={process.pid} already gone")
+    except PermissionError:
+        logger.warning(f"no permission to kill process group pgid={process.pid}")
+    except OSError as e:
+        logger.warning(f"failed to kill process group pgid={process.pid}: {e}")

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -511,7 +511,7 @@ def run_bench_serving(
                 return
             # stdout has drained, but the direct child may still be alive:
             # give it a bounded time to exit, otherwise nuke the group.
-            if reader_done.is_set():    
+            if reader_done.is_set():
                 try:
                     process.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE)
                 except subprocess.TimeoutExpired:

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -5,6 +5,7 @@ import logging
 import os
 import re
 import shutil
+import signal
 import subprocess
 import sys
 import threading
@@ -12,6 +13,8 @@ import time
 from datetime import datetime
 from functools import wraps
 from urllib.parse import urlparse
+
+import psutil
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.e2e.gen_dataset_fixed_len import (
@@ -26,6 +29,7 @@ from sglang.test.ascend.e2e.test_npu_multi_node_utils import (
     NAMESPACE,
     SERVICE_PORT,
     check_role,
+    kill_process_group,
     launch_pd_mix_node,
     launch_pd_separation_node,
     launch_router,
@@ -205,6 +209,10 @@ MAX_SERVER_KEEP_ALIVE_TIME = 3600
 
 # Timeouts and delays
 SERVER_INITIALIZATION_DELAY = 120
+BENCHMARK_SERVING_TIMEOUT = 3600
+BENCHMARK_STDOUT_DRAIN_GRACE = 10
+BENCHMARK_STDOUT_IDLE_TIMEOUT = 300
+BENCHMARK_WATCHDOG_POLL_INTERVAL = 30
 
 # Test parameters
 PROMPTS_MULTIPLIER = 4
@@ -474,6 +482,9 @@ def run_bench_serving(
     # Run benchmark command and capture output
     metrics = {"mean_ttft": None, "mean_tpot": None, "total_tps": None}
 
+    # Launch the benchmark in its own session/process group so a dead server
+    # cannot wedge the run: on timeout we nuke the whole group (including any
+    # re-parented descendants) instead of waiting forever on its stdout.
     process = subprocess.Popen(
         cmd_args,
         stdout=subprocess.PIPE,
@@ -481,11 +492,67 @@ def run_bench_serving(
         text=True,
         bufsize=1,
         env=env,
+        start_new_session=True,
     )
+
+    reader_done = threading.Event()
+    # Shared holder for the reader thread to refresh its activity timestamp;
+    # the watchdog polls it to detect a silent/stuck benchmark before the
+    # 1-hour ceiling is reached.
+    last_activity = [time.time()]
+
+    def _kill_on_timeout():
+        deadline = time.time() + BENCHMARK_SERVING_TIMEOUT
+        while True:
+            if process.poll() is not None:
+                if reader_done.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE):
+                    return
+                logger.error(
+                    f"Benchmark stdout still open after process exit, "
+                    f"killing process group {process.pid}"
+                )
+                kill_process_group(process)
+                return
+            if reader_done.is_set():
+                # stdout has drained, but the direct child may still be alive:
+                # give it a bounded time to exit, otherwise nuke the group.
+                try:
+                    process.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE)
+                except subprocess.TimeoutExpired:
+                    logger.error(
+                        f"Benchmark {process.pid} still alive after stdout EOF, "
+                        f"killing process group {process.pid}"
+                    )
+                    kill_process_group(process)
+                return
+            # No output for too long while still alive -> likely hung.
+            idle = time.time() - last_activity[0]
+            if idle > BENCHMARK_STDOUT_IDLE_TIMEOUT:
+                logger.error(
+                    f"Benchmark produced no output for {idle:.0f}s "
+                    f"(> {BENCHMARK_STDOUT_IDLE_TIMEOUT}s), "
+                    f"killing process group {process.pid}"
+                )
+                kill_process_group(process)
+                return
+            # Absolute ceiling.
+            if time.time() >= deadline:
+                logger.error(
+                    f"Benchmark exceeded {BENCHMARK_SERVING_TIMEOUT}s, "
+                    f"killing process group {process.pid}"
+                )
+                kill_process_group(process)
+                return
+            time.sleep(BENCHMARK_WATCHDOG_POLL_INTERVAL)
+
+    watchdog = threading.Thread(target=_kill_on_timeout, daemon=True)
+    watchdog.start()
+
     try:
         # Read output line by line
         with open(result_file, "a", encoding="utf-8") as f:
             for line in process.stdout:
+                last_activity[0] = time.time()
                 if line.strip():
                     print(line, end="")
                 f.write(line)
@@ -508,6 +575,7 @@ def run_bench_serving(
                     parts = stripped_line.split()
                     if len(parts) >= 5:
                         metrics["mean_e2e_latency"] = parts[4]
+        reader_done.set()
         process.wait()
         if process.returncode != 0:
             logger.error(
@@ -516,6 +584,7 @@ def run_bench_serving(
     except Exception as e:
         logger.error(f"Error running benchmark: {e}")
     finally:
+        reader_done.set()
         if process.stdout is not None and not process.stdout.closed:
             process.stdout.close()
 
@@ -883,6 +952,73 @@ def assert_metrics(self, metrics):
         )
 
 
+def _collect_process_tree(root_pid):
+    """Snapshot every PID under ``root_pid`` while they are still children.
+
+    Returns a mapping ``{pid: create_time}``. Recording ``create_time`` lets
+    ``_kill_recorded_pids`` skip a PID that has since been recycled, avoiding
+    an accidental SIGKILL of an unrelated process.
+
+    A crashed scheduler can leave deep-ep/HCCL workers re-parented to init;
+    ``kill_process_tree`` walks the live parent->child links and misses those
+    orphans. Recording the tree at launch lets ``tearDownClass`` SIGKILL the
+    same PIDs later even after re-parenting.
+    """
+    procs = {}
+    try:
+        root = psutil.Process(root_pid)
+    except psutil.NoSuchProcess:
+        logger.warning(f"_collect_process_tree: root_pid {root_pid} not found")
+        return procs
+    try:
+        for proc in [root] + root.children(recursive=True):
+            try:
+                procs[proc.pid] = proc.create_time()
+            except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
+                logger.debug(
+                    f"_collect_process_tree: skip PID {proc.pid} ({exc.__class__.__name__})"
+                )
+    except psutil.NoSuchProcess:
+        logger.warning(
+            f"_collect_process_tree: root_pid {root_pid} vanished while walking children"
+        )
+    logger.info(f"_collect_process_tree: recorded {len(procs)} PIDs")
+    return procs
+
+
+def _kill_recorded_pids(procs):
+    """Best-effort SIGKILL of a previously recorded PID snapshot.
+
+    ``procs`` maps ``pid -> create_time``; the recorded ``create_time`` is
+    re-checked before killing so a recycled PID is never killed by mistake.
+    Complements ``kill_process_tree`` so re-parented orphans that still hold
+    the runner's stdout pipe (or NPU device memory) do not wedge the suite.
+    """
+    logger.info(f"_kill_recorded_pids: attempting SIGKILL on {len(procs)} PIDs")
+    for pid, create_time in procs.items():
+        try:
+            if psutil.Process(pid).create_time() != create_time:
+                logger.warning(
+                    f"_kill_recorded_pids: skip PID {pid} (create_time mismatch, likely reused)"
+                )
+                continue
+        except psutil.NoSuchProcess:
+            logger.debug(f"_kill_recorded_pids: skip PID {pid} (no longer exists)")
+            continue
+        except psutil.AccessDenied as exc:
+            logger.warning(
+                f"_kill_recorded_pids: skip PID {pid} ({exc.__class__.__name__})"
+            )
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+            logger.debug(f"_kill_recorded_pids: SIGKILL sent to PID {pid}")
+        except (ProcessLookupError, PermissionError, OSError) as e:
+            logger.warning(
+                f"_kill_recorded_pids: skip PID {pid} ({e.__class__.__name__}: {e})"
+            )
+
+
 class TestNpuPerformanceTestCaseBase(CustomTestCase):
     model = None
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
@@ -1061,14 +1197,23 @@ class TestNpuPerformanceTestCaseBase(CustomTestCase):
             other_args=other_args,
             env=env,
         )
+        cls._server_pids = _collect_process_tree(cls.process.pid)
 
     @classmethod
     def tearDownClass(cls):
         if hasattr(cls, "process") and cls.process:
             try:
+                # Union the launch-time snapshot (catches re-parented orphans)
+                # with the current child tree (catches workers spawned lazily
+                # after launch) before tearing the server down.
+                cls._server_pids = {
+                    **getattr(cls, "_server_pids", {}),
+                    **_collect_process_tree(cls.process.pid),
+                }
                 kill_process_tree(cls.process.pid)
             except Exception as e:
                 logger.error(f"Error during tearDown: {e}")
+            _kill_recorded_pids(getattr(cls, "_server_pids", {}))
         cls._save_metrics_json()
         cls._backup_plog()
 

--- a/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
+++ b/python/sglang/test/ascend/e2e/test_npu_performance_utils.py
@@ -5,7 +5,6 @@ import logging
 import os
 import re
 import shutil
-import signal
 import subprocess
 import sys
 import threading
@@ -13,8 +12,6 @@ import time
 from datetime import datetime
 from functools import wraps
 from urllib.parse import urlparse
-
-import psutil
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ascend.e2e.gen_dataset_fixed_len import (
@@ -209,10 +206,9 @@ MAX_SERVER_KEEP_ALIVE_TIME = 3600
 
 # Timeouts and delays
 SERVER_INITIALIZATION_DELAY = 120
-BENCHMARK_SERVING_TIMEOUT = 3600
-BENCHMARK_STDOUT_DRAIN_GRACE = 10
-BENCHMARK_STDOUT_IDLE_TIMEOUT = 300
-BENCHMARK_WATCHDOG_POLL_INTERVAL = 30
+BENCHMARK_STDOUT_DRAIN_GRACE = 10  # Grace seconds to wait for the direct child to exit after it drains stdout / exits
+BENCHMARK_STDOUT_IDLE_TIMEOUT = 300  # Idle timeout: no output for this long means the benchmark is stuck, then force-kill
+BENCHMARK_WATCHDOG_POLL_INTERVAL = 30  # Watchdog polling interval (seconds)
 
 # Test parameters
 PROMPTS_MULTIPLIER = 4
@@ -496,26 +492,26 @@ def run_bench_serving(
     )
 
     reader_done = threading.Event()
-    # Shared holder for the reader thread to refresh its activity timestamp;
-    # the watchdog polls it to detect a silent/stuck benchmark before the
-    # 1-hour ceiling is reached.
-    last_activity = [time.time()]
+    # Timestamp of the last output line; the watchdog reads it to detect a
+    # silent/stuck benchmark.
+    last_activity = time.time()
 
     def _kill_on_timeout():
-        deadline = time.time() + BENCHMARK_SERVING_TIMEOUT
         while True:
+            # Direct child has exited, but stdout may still be held open by a
+            # grandchild; wait for the reader to drain within the grace period,
+            # otherwise force-kill the whole process group.
             if process.poll() is not None:
-                if reader_done.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE):
-                    return
-                logger.error(
-                    f"Benchmark stdout still open after process exit, "
-                    f"killing process group {process.pid}"
-                )
-                kill_process_group(process)
+                if not reader_done.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE):
+                    logger.error(
+                        f"Benchmark stdout still open after process exit, "
+                        f"killing process group {process.pid}"
+                    )
+                    kill_process_group(process)
                 return
-            if reader_done.is_set():
-                # stdout has drained, but the direct child may still be alive:
-                # give it a bounded time to exit, otherwise nuke the group.
+            # stdout has drained, but the direct child may still be alive:
+            # give it a bounded time to exit, otherwise nuke the group.
+            if reader_done.is_set():    
                 try:
                     process.wait(timeout=BENCHMARK_STDOUT_DRAIN_GRACE)
                 except subprocess.TimeoutExpired:
@@ -526,19 +522,11 @@ def run_bench_serving(
                     kill_process_group(process)
                 return
             # No output for too long while still alive -> likely hung.
-            idle = time.time() - last_activity[0]
+            idle = time.time() - last_activity
             if idle > BENCHMARK_STDOUT_IDLE_TIMEOUT:
                 logger.error(
                     f"Benchmark produced no output for {idle:.0f}s "
                     f"(> {BENCHMARK_STDOUT_IDLE_TIMEOUT}s), "
-                    f"killing process group {process.pid}"
-                )
-                kill_process_group(process)
-                return
-            # Absolute ceiling.
-            if time.time() >= deadline:
-                logger.error(
-                    f"Benchmark exceeded {BENCHMARK_SERVING_TIMEOUT}s, "
                     f"killing process group {process.pid}"
                 )
                 kill_process_group(process)
@@ -552,7 +540,7 @@ def run_bench_serving(
         # Read output line by line
         with open(result_file, "a", encoding="utf-8") as f:
             for line in process.stdout:
-                last_activity[0] = time.time()
+                last_activity = time.time()
                 if line.strip():
                     print(line, end="")
                 f.write(line)
@@ -952,73 +940,6 @@ def assert_metrics(self, metrics):
         )
 
 
-def _collect_process_tree(root_pid):
-    """Snapshot every PID under ``root_pid`` while they are still children.
-
-    Returns a mapping ``{pid: create_time}``. Recording ``create_time`` lets
-    ``_kill_recorded_pids`` skip a PID that has since been recycled, avoiding
-    an accidental SIGKILL of an unrelated process.
-
-    A crashed scheduler can leave deep-ep/HCCL workers re-parented to init;
-    ``kill_process_tree`` walks the live parent->child links and misses those
-    orphans. Recording the tree at launch lets ``tearDownClass`` SIGKILL the
-    same PIDs later even after re-parenting.
-    """
-    procs = {}
-    try:
-        root = psutil.Process(root_pid)
-    except psutil.NoSuchProcess:
-        logger.warning(f"_collect_process_tree: root_pid {root_pid} not found")
-        return procs
-    try:
-        for proc in [root] + root.children(recursive=True):
-            try:
-                procs[proc.pid] = proc.create_time()
-            except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
-                logger.debug(
-                    f"_collect_process_tree: skip PID {proc.pid} ({exc.__class__.__name__})"
-                )
-    except psutil.NoSuchProcess:
-        logger.warning(
-            f"_collect_process_tree: root_pid {root_pid} vanished while walking children"
-        )
-    logger.info(f"_collect_process_tree: recorded {len(procs)} PIDs")
-    return procs
-
-
-def _kill_recorded_pids(procs):
-    """Best-effort SIGKILL of a previously recorded PID snapshot.
-
-    ``procs`` maps ``pid -> create_time``; the recorded ``create_time`` is
-    re-checked before killing so a recycled PID is never killed by mistake.
-    Complements ``kill_process_tree`` so re-parented orphans that still hold
-    the runner's stdout pipe (or NPU device memory) do not wedge the suite.
-    """
-    logger.info(f"_kill_recorded_pids: attempting SIGKILL on {len(procs)} PIDs")
-    for pid, create_time in procs.items():
-        try:
-            if psutil.Process(pid).create_time() != create_time:
-                logger.warning(
-                    f"_kill_recorded_pids: skip PID {pid} (create_time mismatch, likely reused)"
-                )
-                continue
-        except psutil.NoSuchProcess:
-            logger.debug(f"_kill_recorded_pids: skip PID {pid} (no longer exists)")
-            continue
-        except psutil.AccessDenied as exc:
-            logger.warning(
-                f"_kill_recorded_pids: skip PID {pid} ({exc.__class__.__name__})"
-            )
-            continue
-        try:
-            os.kill(pid, signal.SIGKILL)
-            logger.debug(f"_kill_recorded_pids: SIGKILL sent to PID {pid}")
-        except (ProcessLookupError, PermissionError, OSError) as e:
-            logger.warning(
-                f"_kill_recorded_pids: skip PID {pid} ({e.__class__.__name__}: {e})"
-            )
-
-
 class TestNpuPerformanceTestCaseBase(CustomTestCase):
     model = None
     benchmark_tool = BENCHMARK_TOOL_DEFAULT
@@ -1197,23 +1118,14 @@ class TestNpuPerformanceTestCaseBase(CustomTestCase):
             other_args=other_args,
             env=env,
         )
-        cls._server_pids = _collect_process_tree(cls.process.pid)
 
     @classmethod
     def tearDownClass(cls):
         if hasattr(cls, "process") and cls.process:
             try:
-                # Union the launch-time snapshot (catches re-parented orphans)
-                # with the current child tree (catches workers spawned lazily
-                # after launch) before tearing the server down.
-                cls._server_pids = {
-                    **getattr(cls, "_server_pids", {}),
-                    **_collect_process_tree(cls.process.pid),
-                }
                 kill_process_tree(cls.process.pid)
             except Exception as e:
                 logger.error(f"Error during tearDown: {e}")
-            _kill_recorded_pids(getattr(cls, "_server_pids", {}))
         cls._save_metrics_json()
         cls._backup_plog()
 

--- a/test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
+++ b/test/registered/npu/accuracy/qwen3_vl_30b_a3b_thinking/test_npu_qwen3_vl_30b_a3b_thinking_1p_mmmu.py
@@ -20,7 +20,7 @@ ENVS = {
     "HCCL_SOCKET_IFNAME": "lo",
     "GLOO_SOCKET_IFNAME": "lo",
     "HCCL_OP_EXPANSION_MODE": "AIV",
-    "HCCL_BUFFSIZE": "2000",
+    "DEEPEP_HCCL_BUFFSIZE": "2000",
 }
 
 OTHER_ARGS = [
@@ -54,7 +54,7 @@ OTHER_ARGS = [
 ]
 
 
-class TestQwen3(TestNpuAccuracyTestCaseBase):
+class TestQwen3_VL_30B_A3B_Thinking_MMMU(TestNpuAccuracyTestCaseBase):
     model = QWEN3_VL_30B_A3B_THINKING_MODEL_PATH
     envs = ENVS
     other_args = OTHER_ARGS

--- a/test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
+++ b/test/registered/npu/accuracy/qwen3_vl_8b_thinking/test_npu_qwen3_vl_8b_thinking_1p_mmmu.py
@@ -10,7 +10,7 @@ from sglang.test.ascend.e2e.test_npu_performance_utils import (
 from sglang.test.ci.ci_register import register_npu_ci
 
 register_npu_ci(est_time=3600, suite="base-c-test-perf-2-npu-a3")
-register_npu_ci(est_time=6500, suite="nightly-acc-2-npu-a3", nightly=True)
+register_npu_ci(est_time=12000, suite="nightly-acc-2-npu-a3", nightly=True)
 
 _is_pr_pipeline = os.environ.get("GITHUB_EVENT_NAME") == "pull_request"
 
@@ -20,7 +20,7 @@ ENVS = {
     "HCCL_SOCKET_IFNAME": "lo",
     "GLOO_SOCKET_IFNAME": "lo",
     "HCCL_OP_EXPANSION_MODE": "AIV",
-    "HCCL_BUFFSIZE": "2000",
+    "DEEPEP_HCCL_BUFFSIZE": "2000",
 }
 
 OTHER_ARGS = [
@@ -52,7 +52,7 @@ OTHER_ARGS = [
 ]
 
 
-class TestQwen3(TestNpuAccuracyTestCaseBase):
+class TestQwen3_VL_8B_Thinking_MMMU(TestNpuAccuracyTestCaseBase):
     model = QWEN3_VL_8B_THINKING_MODEL_PATH
     envs = ENVS
     other_args = OTHER_ARGS

--- a/test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_8p_in3k5_out1k5_20ms.py
+++ b/test/registered/npu/performance/kimi_k2_6/test_npu_kimi_k2_6_w4a8_8p_in3k5_out1k5_20ms.py
@@ -53,6 +53,8 @@ KIMI_K2_6_OTHER_ARGS = [
     6144,
     "--max-prefill-tokens",
     65536,
+    "--max-total-tokens",
+    32256,
     "--enable-multimodal",
     "--mm-attention-backend",
     "ascend_attn",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Improve reliability of Ascend NPU benchmark and accuracy tests by detecting hung benchmark processes earlier and cleaning up orphaned process groups, and align several NPU test configurations and test class naming.

## Modifications

- Add `kill_process_group` and use it in the NPU accuracy/benchmark helpers to reap re-parented deep-ep/HCCL worker processes.
- Add `BENCHMARK_STDOUT_IDLE_TIMEOUT` and rework the benchmark watchdog to detect no-output stalls and to drain/reap the process group on exit, EOF, or timeout.
- Bump `qwen3_vl_8b_thinking` `est_time` from 6500 to 12000.
- Rename `HCCL_BUFFSIZE` to `DEEPEP_HCCL_BUFFSIZE` for `qwen3_vl_8b_thinking` and `qwen3_vl_30b_a3b_thinking`.
- Rename the MMMU accuracy test classes for the two Qwen3-VL thinking models.
- Add `--max-total-tokens 32256` to the `kimi_k2_6` performance test.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32738605326](https://github.com/sgl-project/sglang/actions/runs/32738605326)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32738603530](https://github.com/sgl-project/sglang/actions/runs/32738603530)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32738603408](https://github.com/sgl-project/sglang/actions/runs/32738603408)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->