### PR TITLE
[Fix] Skip quantized MoE compatibility check for dense models whose configs inherit MoE fields

### DIFF
--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1050,6 +1050,7 @@ class ModelRunner:
             tp_size=self.ps.tp_size,
             moe_ep_size=self.ps.moe_ep_size,
             moe_dp_size=self.ps.moe_dp_size,
+            model=self.model,
         )
 
     def init_torch_distributed(self):

--- a/python/sglang/srt/model_executor/model_runner_components/moe_ep_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/moe_ep_setup.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import torch
+
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_location import get_global_expert_location_metadata
 from sglang.srt.eplb.lplb_solver import (
@@ -104,12 +106,19 @@ def init_lplb_solvers(*, model_config: ModelConfig) -> None:
     logger.info(f"Initialized LPLB solvers for {metadata.num_layers} layers")
 
 
+def _has_moe_module(model: torch.nn.Module) -> bool:
+    from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+
+    return any(isinstance(m, FusedMoE) for m in model.modules())
+
+
 def check_quantized_moe_compatibility(
     *,
     model_config: ModelConfig,
     tp_size: int,
     moe_ep_size: int,
     moe_dp_size: int,
+    model: torch.nn.Module | None = None,
 ) -> None:
     if (
         quantization_config := getattr(
@@ -130,6 +139,13 @@ def check_quantized_moe_compatibility(
             model_config.hf_text_config, "moe_intermediate_size", None
         )
         if moe_intermediate_size is None:
+            return
+
+        if model is not None and not _has_moe_module(model):
+            logger.debug(
+                "Skipping quantized MoE compatibility check: model has no "
+                "FusedMoE layers (dense model with inherited MoE config fields)."
+            )
             return
 
         if moe_intermediate_size % moe_tp_size != 0:


### PR DESCRIPTION
## Motivation

Dense Qwen3.5-family checkpoints (e.g. a 27B FP8 checkpoint whose text config is
`Qwen3_5TextConfig`, `model_type="qwen3_5_text"`) fail to launch with `--tp 8`:

```
ValueError: For quantized MoE models, please make sure (moe_intermediate_size=512 / moe_tp_size=8) % weight_block_size_n=128 == 0 where moe_tp_size is equal to tp_size (8) divided by ep_size (1). You can fix this by setting arguments '--tp' and '--ep' correctly.
```

Root cause:

- `Qwen3_5TextConfig` inherits from `Qwen3NextConfig`, whose `__init__` unconditionally
  sets MoE fields with defaults (`moe_intermediate_size=512`, `num_experts=512`, ...),
  even for dense checkpoints whose `config.json` never specifies them.
- `check_quantized_moe_compatibility()` gates the check only on whether
  `moe_intermediate_size` exists on `hf_text_config`, so dense Qwen3.5 models are
  misdetected as MoE and fail the FP8 block-size sharding check (`512 / 8 = 64`,
  `64 % 128 != 0`).
- The dense model implementation (`models/qwen3_5.py`) builds plain `Qwen2MoeMLP`
  layers and contains no MoE layers at all — the check is a false positive.

The same pitfall was already identified and worked around in
`srt/lora/mem_pool.py::_has_moe_module`, whose comment reads: "Config-only detection
isn't reliable: some dense configs (e.g. `Qwen3_5TextConfig`) inherit `num_experts > 1`
from an MoE parent." This PR applies the same approach to the MoE/EP quantization
compatibility check.

## Modification

- `python/sglang/srt/model_executor/model_runner_components/moe_ep_setup.py`
  - Add `_has_moe_module(model)` helper that walks the loaded model for an actual
    `FusedMoE` instance (lazy import to avoid circular imports), mirroring
    `srt/lora/mem_pool.py`.
  - `check_quantized_moe_compatibility()` accepts an optional
    `model: torch.nn.Module | None = None`. When the model is provided and contains no
    `FusedMoE` layers, the MoE sharding checks are skipped (dense model whose config
    merely inherits MoE fields). When `model is None`, behavior is unchanged.
  - `FusedMoE` covers all MoE implementations: `get_moe_impl_class()` returns only
    `FusedMoE` or `DeepEPMoE` (a `FusedMoE` subclass), so the walk cannot miss real
    MoE layers.
- `python/sglang/srt/model_executor/model_runner.py`
  - Pass `model=self.model` to the check. It runs right after `ModelRunner.initialize()`
    (model already loaded), so the module walk is cheap and exact.

The `tp_size % moe_ep_size` divisibility assertion and all existing checks for
genuinely-MoE models are unchanged.

## Test Plan

- [√] Before the fix: dense Qwen3.5-family FP8 checkpoint with `--tp 8` reproduces the
      `ValueError` above.
- [√] After the fix: same launch passes the check (no `FusedMoE` layers → check skipped).
- [√] Genuinely MoE models still behave as before:
      - `moe_intermediate_size=512`, `--tp 8` → still raises (512/8=64, 64%128≠0);
      - `moe_intermediate_size=512`, `--tp 4` → still passes (512/4=128).
- [√] `model=None` fallback keeps the legacy config-only behavior.
- [√] Config without `moe_intermediate_size` → early return, unchanged.
- [ ] CI / maintainer: full launch test of a dense Qwen3.5 FP8 checkpoint and a
      Qwen3-Next / Qwen3.5-MoE FP8 checkpoint on multi-GPU.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35484481022](https://github.com/sgl-project/sglang/actions/runs/35484481022)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35484480914](https://github.com/sgl-project/sglang/actions/runs/35484480914)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35484480939](https://github.com/sgl-project/sglang/actions/runs/35484480939)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->