### PR TITLE
Sandbox: verify full main CI

### DIFF
--- a/python/sglang/version.py
+++ b/python/sglang/version.py
@@ -1,4 +1,4 @@
-# sandbox-verify-main-ci: 20260824T122303Z (do not merge)
+# sandbox-verify-main-ci: 20260824T122541Z (do not merge)
 try:
     from sglang._version import __version__, __version_tuple__
 except ImportError:

--- a/python/sglang/version.py
+++ b/python/sglang/version.py
@@ -1,3 +1,4 @@
+# sandbox-verify-main-ci: 20260824T122303Z (do not merge)
 try:
     from sglang._version import __version__, __version_tuple__
 except ImportError:


### PR DESCRIPTION
Permanent sandbox PR for validating full CI against the latest upstream main. Do not merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32727074339](https://github.com/sgl-project/sglang/actions/runs/32727074339)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #32727073912](https://github.com/sgl-project/sglang/actions/runs/32727073912)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32727074192](https://github.com/sgl-project/sglang/actions/runs/32727074192)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->