### PR TITLE
[NPU] add Ascend MemCache storage backend (HiCache L3) and fix L2 cache release issues

### DIFF
--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -64,6 +64,10 @@ class AscendTransferEngine(MooncakeTransferEngine):
         transfer_protocol = self._get_transfer_protocol()
         if transfer_protocol is None or transfer_protocol == "sdma":
             trans_op_type = TransferEngine.TransDataOpType.SDMA
+        elif transfer_protocol == "device_urma":
+            trans_op_type = TransferEngine.TransDataOpType.DEVICE_URMA
+        elif transfer_protocol == "device_uboe":
+            trans_op_type = TransferEngine.TransDataOpType.DEVICE_UBOE
         else:
             trans_op_type = TransferEngine.TransDataOpType.DEVICE_RDMA
             """with device RDMA for PD transfer"""

--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -99,7 +99,7 @@ class AscendTransferEngine(MooncakeTransferEngine):
     @staticmethod
     def _get_transfer_protocol():
         protocol = os.getenv("ASCEND_MF_TRANSFER_PROTOCOL")
-        allowed_protocols = {"device_rdma", "sdma"}
+        allowed_protocols = {"device_rdma", "sdma", "device_urma", "device_uboe"}
         if protocol and protocol.lower() in allowed_protocols:
             return protocol.lower()
         else:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1160,6 +1160,19 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             if self.req_to_token_pool.available_size() <= 0:
                 break
 
+            # Hybrid models (e.g. K3 with KDA): guard against prealloc
+            # draining the mamba pool before the KV pool (would assert "Not
+            # enough space for mamba cache"). Evict a cached mamba slot from
+            # the radix tree first (only if it manages mamba states;
+            # ChunkCache.evict is a no-op), else stop.
+            mamba_allocator = getattr(self.req_to_token_pool, "mamba_allocator", None)
+            if mamba_allocator is not None and mamba_allocator.available_size() <= 0:
+                supports_mamba = self.tree_cache.supports_mamba()
+                if supports_mamba and hasattr(self.tree_cache, "evict"):
+                    self.tree_cache.evict(EvictParams(num_tokens=0, mamba_num=1))
+                if mamba_allocator.available_size() <= 0:
+                    break
+
             if self.req_to_metadata_buffer_idx_allocator.available_size() <= 0:
                 break
 

--- a/python/sglang/srt/disaggregation/decode_hicache_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_hicache_mixin.py
@@ -197,6 +197,10 @@ class DecodeHiCacheTransferMixin:
             self.tree_cache.pop_prefetch_loaded_tokens(dr.req.rid)
 
         # Re-match: req.last_node / prefix_indices updated to current device state.
+        # The re-match overwrites cache_protected_len; restore the
+        # admission-time value that _release_finished_req uses to free the
+        # owned prefix slots and release the admission lock.
+        saved_cache_protected_len = dr.req.cache_protected_len
         rematch = match_prefix_for_req(
             self.tree_cache,
             dr.req,
@@ -204,6 +208,7 @@ class DecodeHiCacheTransferMixin:
             cow_mamba=False,
             include_req=True,
         )
+        dr.req.cache_protected_len = saved_cache_protected_len
         new_indices, restored_node = self.tree_cache.init_load_back(
             InitLoadBackParams(
                 best_match_node=rematch.best_match_node,

--- a/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
+++ b/python/sglang/srt/disaggregation/decode_kvcache_offload_manager.py
@@ -17,6 +17,8 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
     build_kv_host_pool,
 )
 from sglang.srt.mem_cache.memory_pool import (
+    HybridLinearKVPool,
+    HybridReqToTokenPool,
     MHATokenToKVPool,
     MLATokenToKVPool,
     ReqToTokenPool,
@@ -59,6 +61,12 @@ class DecodeKVCacheOffloadManager:
                 self.page_size, (env_stride // self.page_size) * self.page_size
             )
         kv_cache = self.token_to_kv_pool_allocator.get_kvcache()
+        if isinstance(kv_cache, HybridLinearKVPool):
+            # Hybrid model (e.g. K3 with MLA + KDA): offload only the full
+            # attention KV pool. Mamba/SSM state is ephemeral and does not
+            # require L3 offload on the decode side.
+            kv_cache = kv_cache.full_kv_pool
+
         if not isinstance(kv_cache, (MHATokenToKVPool, MLATokenToKVPool)):
             raise ValueError("Unsupported KV cache type for decode offload")
         self.decode_host_mem_pool = build_kv_host_pool(
@@ -255,17 +263,19 @@ class DecodeKVCacheOffloadManager:
 
         kv_committed_len = req.effective_kv_committed_len()
 
-        # Free the prefill-aligned slots. Previously this was done
-        # eagerly in offload_kv_cache (mid-decode), which raced with
-        # concurrent admission. Now consolidated here at request
-        # finish, where the request is guaranteed to no longer attend
-        # to those slots.
+        # Free prefill-aligned slots here at finish (previously done
+        # mid-decode in offload_kv_cache, racing concurrent admission).
+        # Skip [0, cache_protected_len): tree-managed prefix tokens (L1
+        # device hits or L2/L3 restored), locked via inc_lock_ref.  Only
+        # the request-owned delta prefill slots are freed.
         state = self.offloaded_state.get(req.rid)
         if state is not None and state.prefill_len > 0:
-            prefill_indices = self.req_to_token_pool.req_to_token[
-                req.req_pool_idx, : state.prefill_len
-            ]
-            self.token_to_kv_pool_allocator.free(prefill_indices)
+            free_start = max(req.cache_protected_len, 0)
+            if free_start < state.prefill_len:
+                prefill_indices = self.req_to_token_pool.req_to_token[
+                    req.req_pool_idx, free_start : state.prefill_len
+                ]
+                self.token_to_kv_pool_allocator.free(prefill_indices)
         start = start_offset
         end = kv_committed_len
         # Free the incremental part of the request (DSA-aware)
@@ -283,9 +293,26 @@ class DecodeKVCacheOffloadManager:
             ]
             self.token_to_kv_pool_allocator.free(overalloc_indices)
 
+        # Hybrid models (e.g. K3 with KDA) need manual mamba slot release
+        # here since the offload path skips release_kv_cache.  Must run
+        # before req_to_token_pool.free(req), which nulls req_pool_idx
+        # that free_mamba_cache indexes the ping-pong track buffer with.
+        if isinstance(self.req_to_token_pool, HybridReqToTokenPool) and (
+            not self.tree_cache.supports_mamba()
+        ):
+            if req.mamba_pool_idx is not None:
+                self.req_to_token_pool.free_mamba_cache(req)
+
         self.req_to_token_pool.free(req)
         req.kv = None
-        self.tree_cache.protected_size_ -= len(req.prefix_indices)
+        # Release the tree-cache lock taken at admission (inc_lock_ref in
+        # _match_prefix_and_lock).  dec_lock_ref keeps lock_ref and the
+        # protected/evictable size accounting consistent.  req.last_node is
+        # the currently-locked node: the L1 prefix node (L1-only), or the
+        # restored node (L2/L3 restore already released the L1 lock via
+        # _commit_hicache_local_restore_to_req), so no double release.
+        if req.cache_protected_len > 0 and req.last_node is not None:
+            self.tree_cache.dec_lock_ref(req.last_node)
         if req.rid in self.offloaded_state:
             del self.offloaded_state[req.rid]
 

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2718,9 +2718,27 @@ def create_custom_parallel_group(
     rank = torch.distributed.get_rank()
 
     local_config = sorted(list(set(group_ranks)))
-    gathered_configs = [None for _ in range(world_size)]
+    group_size = len(local_config)
 
-    torch.distributed.all_gather_object(gathered_configs, local_config)
+    # Standard TP/DP partitioning: contiguous, group-aligned ranks.
+    is_standard_partition = (
+        world_size % group_size == 0
+        and local_config == list(range(local_config[0], local_config[0] + group_size))
+        and local_config[0] % group_size == 0
+    )
+
+    if not (_is_npu and is_standard_partition):
+        # General path: collect every rank's group via all_gather_object.
+        gathered_configs = [None for _ in range(world_size)]
+        torch.distributed.all_gather_object(gathered_configs, local_config)
+    else:
+        # NPU fast path: all_gather_object on the default HCCL PG allocates
+        # an HCCL buffer; instead derive the standard TP/DP groups locally.
+        num_groups = world_size // group_size
+        gathered_configs = [
+            list(range(i * group_size, (i + 1) * group_size))
+            for i in range(num_groups)
+        ]
 
     unique_groups = []
     seen_signatures = set()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -737,6 +737,12 @@ class Envs:
     MOONCAKE_TENANT_ID = EnvStr("default")
 
     # ===================================================================
+    # Ascend MemCache (HiCache L3); see https://gitcode.com/Ascend/memcache
+    # ===================================================================
+    SGLANG_HICACHE_MEMCACHE_CONFIG_PATH = EnvStr(None)
+    SGLANG_ASCEND_MEMCACHE_ENABLE_WARMUP = EnvBool(False)
+
+    # ===================================================================
     # MoRI transport and expert dispatch
     # ===================================================================
     # Send CPU-resident AUX data via RDMA instead of ZMQ TCP (default: TCP).

--- a/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/memory_pool_npu.py
@@ -651,15 +651,19 @@ class NPUMLATokenToKVPool(MLATokenToKVPool):
     # for disagg
     def get_contiguous_buf_infos(self):
         # MLA has only one kv_buffer, so only the information of this buffer needs to be returned.
-        kv_data_ptrs = [self.k_buffer[i].data_ptr() for i in range(self.layer_num)] + [
-            self.v_buffer[i].data_ptr() for i in range(self.layer_num)
-        ]
-        kv_data_lens = [self.k_buffer[i].nbytes for i in range(self.layer_num)] + [
-            self.v_buffer[i].nbytes for i in range(self.layer_num)
-        ]
-        kv_item_lens = [self.k_buffer[i][0].nbytes for i in range(self.layer_num)] + [
-            self.v_buffer[i][0].nbytes for i in range(self.layer_num)
-        ]
+        kv_data_ptrs = [self.k_buffer[i].data_ptr() for i in range(self.layer_num)]
+        kv_data_lens = [self.k_buffer[i].nbytes for i in range(self.layer_num)]
+        kv_item_lens = [self.k_buffer[i][0].nbytes for i in range(self.layer_num)]
+        # When DSA KV cache is packed into the FP8 k_buffer, the v_buffer is
+        # intentionally empty (kr_cache_dim == 0). Its data_ptr() is null
+        if not self.dsa_kv_cache_store_fp8:
+            kv_data_ptrs += [
+                self.v_buffer[i].data_ptr() for i in range(self.layer_num)
+            ]
+            kv_data_lens += [self.v_buffer[i].nbytes for i in range(self.layer_num)]
+            kv_item_lens += [
+                self.v_buffer[i][0].nbytes for i in range(self.layer_num)
+            ]
         if self.index_head_dim is not None:
             kv_data_ptrs += [
                 self.index_k_buffer[i].data_ptr() for i in range(self.layer_num)

--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -106,8 +106,11 @@ def set_default_server_args(args: "ServerArgs"):
         disable_custom_all_reduce=True,
     )
 
-    # handles hierarchical cache configs
-    if args.enable_hierarchical_cache:
+    # handles hierarchical cache / decode-offload configs
+    if (
+        args.enable_hierarchical_cache
+        or args.disaggregation_decode_enable_offload_kvcache
+    ):
         declare_resolution(
             args,
             "set_default_server_args",

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -550,7 +550,7 @@ class HiCacheController:
 
             if (
                 self.storage_backend_type
-                in ["hf3fs", "mooncake", "eic", "nixl", "simm", "mori"]
+                in ["hf3fs", "mooncake", "ascend_memcache", "eic", "nixl", "simm", "mori"]
             ) or (
                 self.storage_backend_type == "dynamic"
                 and bool(self.storage_config.extra_config.get("interface_v1", 0))

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -228,9 +228,9 @@ def release_kv_cache(req: Req, tree_cache: BasePrefixCache, is_insert: bool = Tr
     _release_overallocated_kv_indices(req, start_p, end_p, tree_cache)
 
     # If the prefix cache doesn't manage mamba states, we must free them here.
-    if isinstance(tree_cache.req_to_token_pool, HybridReqToTokenPool) and (
-        not tree_cache.supports_mamba()
-    ):
+    supports_mamba = tree_cache.supports_mamba()
+    is_hybrid = isinstance(tree_cache.req_to_token_pool, HybridReqToTokenPool)
+    if is_hybrid and (not supports_mamba):
         assert (
             req.mamba_pool_idx is not None
         ), "mamba state is freed while the tree cache does not manage mamba states"

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -720,12 +720,21 @@ def build_hybrid_mamba_stack(
             target_device_layer_num=kv_pool.layer_num,
             draft_layer_num=len(mtp_draft_device_pools),
         )
+    # MambaPoolHost only supports page_first_direct; the global layout may be
+    # page_first_kv_split (e.g. MLA + KDA hybrid on NPU). The Mamba/KDA state
+    # pool has no separate K/V buffers, so kv_split does not apply; override
+    # to page_first_direct.
+    mamba_layout = (
+        "page_first_direct"
+        if server_args.hicache_mem_layout == "page_first_kv_split"
+        else server_args.hicache_mem_layout
+    )
     mamba_host_pool = MambaPoolHost(
         mamba_pool,
         get_memory().hicache_ratio,
         mamba_host_size,
         allocator_type=_get_allocator_type(server_args),
-        layout=get_memory().hicache_mem_layout,
+        layout=mamba_layout,
     )
     entries = [
         build_pool_entry(
@@ -977,6 +986,12 @@ def _build_mha_mla_host_pool(
     pool_label: str,
 ):
     from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool
+
+    # The global layout is page_first_kv_split only when the target model
+    # uses MLA; that layout is MLA-specific, so MHA draft pools must use
+    # the non-MLA layout (NPU default: page_first_direct).
+    if isinstance(pool, MHATokenToKVPool) and layout == "page_first_kv_split":
+        layout = "page_first_direct"
 
     kwargs = dict(
         host_to_device_ratio=host_to_device_ratio,

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -126,6 +126,11 @@ def _register_legacy_hicache_draft(
         pool_label="draft",
     )
     if isinstance(pool, MHATokenToKVPool):
+        # The global layout is page_first_kv_split only when the target model
+        # uses MLA; that layout is MLA-specific, so MHA draft pools must use
+        # the non-MLA layout (NPU default: page_first_direct).
+        if host_pool_kwargs["layout"] == "page_first_kv_split":
+            host_pool_kwargs["layout"] = "page_first_direct"
         draft_host_pool = get_mha_host_pool_cls(pool)(pool, **host_pool_kwargs)
     elif isinstance(pool, MLATokenToKVPool):
         draft_host_pool = MLATokenToKVPoolHost(pool, **host_pool_kwargs)

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -3800,7 +3800,7 @@ class HybridLinearKVPool(KVCache):
     def get_kv_layer_ids(self):
         """Global layer ids aligned with the full-attention KV buffers."""
         layer_ids = list(self.full_attention_layer_id_mapping)
-        return layer_ids if self.use_mla else layer_ids * 2
+        return layer_ids if self.use_mla or self.dsa_kv_cache_store_fp8 else layer_ids * 2
 
     def get_state_buf_infos(self):
         mamba_data_ptrs, mamba_data_lens, mamba_item_lens = (

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1019,6 +1019,14 @@ class HostPoolGroup:
         return self.anchor_entry.host_pool.kv_buffer
 
     @property
+    def v_buffer(self):
+        return getattr(self.anchor_entry.host_pool, "v_buffer", None)
+
+    @property
+    def index_k_buffer(self):
+        return getattr(self.anchor_entry.host_pool, "index_k_buffer", None)
+
+    @property
     def size_per_token(self):
         return self.anchor_entry.host_pool.size_per_token
 

--- a/python/sglang/srt/mem_cache/memory_pool_host.py
+++ b/python/sglang/srt/mem_cache/memory_pool_host.py
@@ -1027,6 +1027,19 @@ class HostPoolGroup:
         return getattr(self.anchor_entry.host_pool, "index_k_buffer", None)
 
     @property
+    def index_k_scale_buffer(self):
+        # Delegate to the anchor pool so AscendMemcacheStore sees the same
+        # buffer set as get_page_buffer_meta (which also delegates), keeping
+        # the per-page component-key count consistent (k, v, index_k, scale).
+        return getattr(self.anchor_entry.host_pool, "index_k_scale_buffer", None)
+
+    @property
+    def dsa_kv_cache_store_fp8(self):
+        # Delegate so the L3 store skips the dead v component exactly when
+        # get_page_buffer_meta (which also delegates) skips it.
+        return getattr(self.anchor_entry.host_pool, "dsa_kv_cache_store_fp8", False)
+
+    @property
     def size_per_token(self):
         return self.anchor_entry.host_pool.size_per_token
 

--- a/python/sglang/srt/mem_cache/pool_host/mamba.py
+++ b/python/sglang/srt/mem_cache/pool_host/mamba.py
@@ -18,10 +18,11 @@ from sglang.srt.mem_cache.pool_host.common import (
     ALLOC_MEMORY_FUNCS,
     get_allocator_from_storage,
 )
-from sglang.srt.utils import is_cuda, is_hip
+from sglang.srt.utils import is_cuda, is_hip, is_npu
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_is_npu = is_npu()
 if _is_cuda or _is_hip:
     from sgl_kernel.kvcacheio import (
         transfer_kv_all_layer_direct_lf_pf,
@@ -34,6 +35,12 @@ if _is_cuda or _is_hip:
         transfer_kv_mamba_lf_pf,
         transfer_kv_mamba_pf_lf,
     )
+if _is_npu:
+    from sgl_kernel_npu.kvcacheio import TransferDirection
+    try:
+        from sgl_kernel_npu.kvcacheio import transfer_mamba_state
+    except ImportError:
+        transfer_mamba_state = None
 
 logger = logging.getLogger(__name__)
 
@@ -318,6 +325,13 @@ class MambaPoolHost(HostKVCache):
                 dst_indices=dst_indices,
                 page_size=1,
             )
+        elif io_backend == "kernel_ascend":
+            # Per-layer indexed copy: this method transfers a single layer
+            # (layer_first layout). The all-layer kernel path is handled by
+            # _copy_tensor_all_layers_lf_pf / load_to_device_per_layer.
+            dst[dst_indices.to(dst.device)] = src[src_indices.to(src.device)].to(
+                dst.device
+            )
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
 
@@ -358,6 +372,13 @@ class MambaPoolHost(HostKVCache):
                 layer_id=layer_id,
                 page_size=1,
             )
+        elif io_backend == "kernel_ascend":
+            # NPU fallback: page-first host buffer -> per-layer device buffer.
+            # host buffer layout is (size, num_layers, 1, *shape); the trailing 1
+            # is the page placeholder dim, so index it out explicitly.
+            dst[dst_indices.to(dst.device)] = src[
+                src_indices.to(src.device), layer_id, 0
+            ].to(dst.device)
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
 
@@ -401,6 +422,24 @@ class MambaPoolHost(HostKVCache):
                 dst_indices=dst_indices,
                 page_size=1,
             )
+        elif io_backend == "kernel_ascend":
+            # NPU: mirror the load path — the dedicated kernel transfers all
+            # layers at once via a single 2D strided copy
+            # (device layer-first -> host page-first).
+            if transfer_mamba_state is not None:
+                transfer_mamba_state(
+                    device_buf=src_layers,
+                    host_buf=dst,
+                    device_indices=src_indices,
+                    host_indices=dst_indices,
+                    direction=TransferDirection.D2H,
+                )
+            else:
+                # Per-layer fallback when the dedicated kernel is unavailable.
+                for lid in range(num_layers):
+                    dst[dst_indices.to(dst.device), lid, 0] = src_layers[
+                        lid
+                    ][src_indices.to(dst.device)].to(dst.device)
         else:
             raise ValueError(f"Unsupported io_backend: {io_backend}")
 
@@ -415,27 +454,47 @@ class MambaPoolHost(HostKVCache):
         is_draft: bool = False,
     ):
         if self.layout in ["page_first", "page_first_direct"]:
-            # no ssm state on conv-only models: nothing to transfer
-            if self.temporal_state_elem_size > 0:
-                self._copy_tensor_pf_lf(
-                    src=self.temporal_buffer,
-                    dst=device_pool.mamba_cache.temporal[layer_id],
-                    src_indices=host_indices,
-                    dst_indices=device_indices,
-                    layer_id=layer_id,
-                    num_layers=self.num_mamba_layers,
-                    io_backend=io_backend,
-                )
-            for conv_idx in range(len(self.conv_state_shapes)):
-                self._copy_tensor_pf_lf(
-                    src=self.conv_buffer[conv_idx],
-                    dst=device_pool.mamba_cache.conv[conv_idx][layer_id],
-                    src_indices=host_indices,
-                    dst_indices=device_indices,
-                    layer_id=layer_id,
-                    num_layers=self.num_mamba_layers,
-                    io_backend=io_backend,
-                )
+            if io_backend == "kernel_ascend" and transfer_mamba_state is not None:
+                # NPU: transfer all layers at once via dedicated kernel.
+                # layer_id == 0 covers every layer, so later calls must skip.
+                if layer_id == 0:
+                    transfer_mamba_state(
+                        device_buf=device_pool.mamba_cache.temporal,
+                        host_buf=self.temporal_buffer,
+                        device_indices=device_indices,
+                        host_indices=host_indices,
+                        direction=TransferDirection.H2D,
+                    )
+                    for conv_idx in range(len(self.conv_state_shapes)):
+                        transfer_mamba_state(
+                            device_buf=device_pool.mamba_cache.conv[conv_idx],
+                            host_buf=self.conv_buffer[conv_idx],
+                            device_indices=device_indices,
+                            host_indices=host_indices,
+                            direction=TransferDirection.H2D,
+                        )
+            else:
+                # no ssm state on conv-only models: nothing to transfer
+                if self.temporal_state_elem_size > 0:
+                    self._copy_tensor_pf_lf(
+                        src=self.temporal_buffer,
+                        dst=device_pool.mamba_cache.temporal[layer_id],
+                        src_indices=host_indices,
+                        dst_indices=device_indices,
+                        layer_id=layer_id,
+                        num_layers=self.num_mamba_layers,
+                        io_backend=io_backend,
+                    )
+                for conv_idx in range(len(self.conv_state_shapes)):
+                    self._copy_tensor_pf_lf(
+                        src=self.conv_buffer[conv_idx],
+                        dst=device_pool.mamba_cache.conv[conv_idx][layer_id],
+                        src_indices=host_indices,
+                        dst_indices=device_indices,
+                        layer_id=layer_id,
+                        num_layers=self.num_mamba_layers,
+                        io_backend=io_backend,
+                    )
         else:
             self._copy_tensor(
                 self.temporal_buffer[layer_id],

--- a/python/sglang/srt/mem_cache/pool_host/mha.py
+++ b/python/sglang/srt/mem_cache/pool_host/mha.py
@@ -152,6 +152,10 @@ class MHATokenToKVPoolHost(HostKVCache):
         self.layer_num = self.target_layer_num + len(self.mtp_draft_device_pools)
         return self.head_dim * self.head_num * self.layer_num * self.dtype.itemsize * 2
 
+    def get_hybrid_pool_buffer(self):
+        # Expose the K/V host tensors required for zero-copy I/O registration.
+        return [self.k_buffer, self.v_buffer]
+
     def get_ksize_per_token(self):
         return self.get_size_per_token() // 2
 

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -436,9 +436,13 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 )
             return
 
-        device_data_ptrs, device_kv_buffers = self._resolve_device_transfer_buffers(
-            device_pool
-        )
+        # data_ptrs/kv_buffers are only needed by the kernel/direct backends;
+        # kernel_ascend (NPU) uses k_buffer/v_buffer/index_k_buffer instead and
+        # NPU device pools do not expose data_ptrs.
+        if io_backend != "kernel_ascend":
+            device_data_ptrs, device_kv_buffers = self._resolve_device_transfer_buffers(
+                device_pool
+            )
 
         if io_backend == "kernel":
             if self.layout == "layer_first":
@@ -588,6 +592,44 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
         ptr_list = []
         kv_buffer_data_ptr = self.kv_buffer.data_ptr()
         indices = indices.tolist()
+        if self.layout == "page_first_kv_split":
+            # TODO (iforgetmyname): merge mla kv
+            k_buffer_data_ptr = self.k_buffer.data_ptr()
+            v_buffer_data_ptr = self.v_buffer.data_ptr()
+            for index in range(0, len(indices), self.page_size):
+                k_ptr = (
+                    k_buffer_data_ptr
+                    + indices[index]
+                    * self.layer_num
+                    * self.kv_lora_rank
+                    * self.dtype.itemsize
+                )
+                v_ptr = (
+                    v_buffer_data_ptr
+                    + indices[index]
+                    * self.layer_num
+                    * self.qk_rope_head_dim
+                    * self.dtype.itemsize
+                )
+                ptr_list.append(k_ptr)
+                ptr_list.append(v_ptr)
+            k_element_size = (
+                self.layer_num
+                * self.dtype.itemsize
+                * self.page_size
+                * self.kv_lora_rank
+            )
+            v_element_size = (
+                self.layer_num
+                * self.dtype.itemsize
+                * self.page_size
+                * self.qk_rope_head_dim
+            )
+            element_size_list = []
+            for _ in range(0, len(indices), self.page_size):
+                element_size_list.append(k_element_size)
+                element_size_list.append(v_element_size)
+            return ptr_list, element_size_list
         if self.layout == "layer_first":
             for index in range(0, len(indices), self.page_size):
                 for layer_id in range(self.layer_num):

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -125,12 +125,38 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
     def get_size_per_token(self):
         self.kv_lora_rank = self.device_pool.kv_lora_rank
         self.qk_rope_head_dim = self.device_pool.qk_rope_head_dim
+        # FP8 DSA packs K/V into the single device k_buffer (device v_buffer is
+        # empty and never transferred). Exposed for the L3 store to skip the
+        # dead v component when generating per-page keys/pointers.
+        self.dsa_kv_cache_store_fp8 = getattr(
+            self.device_pool, "dsa_kv_cache_store_fp8", False
+        )
         self.target_layer_num = self._effective_host_layer_num()
         self.layer_num = self.target_layer_num + len(self.mtp_draft_device_pools)
         self.kv_cache_dim = self.override_kv_cache_dim or (
             self.kv_lora_rank + self.qk_rope_head_dim
         )
-        return self.kv_cache_dim * self.dtype.itemsize * self.layer_num
+        size_per_token = self.kv_cache_dim * self.dtype.itemsize * self.layer_num
+        if (
+            self.layout == "page_first_kv_split"
+            and self.device_pool.index_head_dim is not None
+        ):
+            # Indexer buffers only exist for physical Indexer layers, which can
+            # be a subset of all layers (e.g. GLM 5.2: 21 of 78).  Mirror the
+            # layer count used by init_kv_buffer so host capacity sizing stays
+            # consistent with the actually-allocated buffers.
+            num_indexer_layers = getattr(self.device_pool, "num_indexer_layers", None)
+            if num_indexer_layers is None:
+                num_indexer_layers = self.layer_num
+            size_per_token += (
+                self.device_pool.index_head_dim
+                * self.dtype.itemsize
+                * num_indexer_layers
+            )
+            if getattr(self.device_pool, "index_k_scale_buffer", None) is not None:
+                # FP32 quantization scale per token per indexer layer.
+                size_per_token += 4 * num_indexer_layers
+        return size_per_token
 
     def get_ksize_per_token(self):
         return self.get_size_per_token()
@@ -167,9 +193,31 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 self.page_size,
                 1,
             )
+            # Indexer buffers only exist for physical Indexer layers, which can
+            # be a subset of all layers (e.g. GLM 5.2: 21 of 78).  The device
+            # pool packs them as (num_indexer_layers, page, ...); mirror that
+            # layer count here so transfer_kv_dim_exchange's layer check
+            # (device dim0 == host dim1) holds.
+            num_indexer_layers = getattr(
+                self.device_pool, "num_indexer_layers", None
+            )
+            if num_indexer_layers is None:
+                num_indexer_layers = self.layer_num
+            indexer_dims = (
+                self.page_num,
+                num_indexer_layers,
+                self.page_size,
+                1,
+            )
             alloc_func = ALLOC_MEMORY_FUNCS[self.device_pool.device]
+            if getattr(self.device_pool, "dsa_kv_cache_store_fp8", False):
+                # FP8 DSA packs latent+RoPE+scale into the device k_buffer;
+                # mirror the packed width so the 2D memcpy row width matches.
+                k_width = self.device_pool.kv_cache_dim
+            else:
+                k_width = self.kv_lora_rank
             self.k_buffer = alloc_func(
-                (*base_dims, self.kv_lora_rank),
+                (*base_dims, k_width),
                 dtype=self.dtype,
                 device=self.device,
                 pin_memory=self.pin_memory,
@@ -185,8 +233,20 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
             self.index_k_buffer = None
             if self.device_pool.index_head_dim is not None:
                 self.index_k_buffer = alloc_func(
-                    (*base_dims, self.device_pool.index_head_dim),
+                    (*indexer_dims, self.device_pool.index_head_dim),
                     dtype=self.dtype,
+                    device=self.device,
+                    pin_memory=self.pin_memory,
+                    allocator=self.allocator,
+                )
+            # Host-side mirror of the NPU quantized-Indexer FP32 scale cache
+            # (see NPUMLATokenToKVPool.index_k_scale_buffer). Only present when
+            # the device pool carries one (FP8 DSA + npu_quant_lightning_indexer).
+            self.index_k_scale_buffer = None
+            if getattr(self.device_pool, "index_k_scale_buffer", None) is not None:
+                self.index_k_scale_buffer = alloc_func(
+                    (*indexer_dims, 1),
+                    dtype=torch.float32,
                     device=self.device,
                     pin_memory=self.pin_memory,
                     allocator=self.allocator,
@@ -330,6 +390,10 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                         host_v=self.v_buffer,
                         device_index_k=device_pool.index_k_buffer,
                         host_index_k=self.index_k_buffer,
+                        device_index_k_scale=getattr(
+                            device_pool, "index_k_scale_buffer", None
+                        ),
+                        host_index_k_scale=self.index_k_scale_buffer,
                         page_size=self.page_size,
                         direction=TransferDirection.H2D,
                     )
@@ -517,6 +581,10 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                     host_v=self.v_buffer,
                     device_index_k=device_pool.index_k_buffer,
                     host_index_k=self.index_k_buffer,
+                    device_index_k_scale=getattr(
+                        device_pool, "index_k_scale_buffer", None
+                    ),
+                    host_index_k_scale=self.index_k_scale_buffer,
                     page_size=self.page_size,
                     direction=TransferDirection.D2H,
                 )
@@ -596,39 +664,88 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
             # TODO (iforgetmyname): merge mla kv
             k_buffer_data_ptr = self.k_buffer.data_ptr()
             v_buffer_data_ptr = self.v_buffer.data_ptr()
+            index_k_buffer = getattr(self, "index_k_buffer", None)
+            index_k_buffer_data_ptr = (
+                index_k_buffer.data_ptr() if index_k_buffer is not None else None
+            )
+            scale_buffer = getattr(self, "index_k_scale_buffer", None)
+            scale_buffer_data_ptr = (
+                scale_buffer.data_ptr() if scale_buffer is not None else None
+            )
+            # k row width mirrors the device pool (packed dim for FP8 DSA).
+            k_width = self.k_buffer.shape[-1]
+            k_item_size = self.k_buffer.element_size()
+            # Indexer buffers cover only physical Indexer layers, which can be
+            # a subset of all layers (e.g. GLM 5.2: 21 of 78).
+            num_indexer_layers = (
+                index_k_buffer.shape[1] if index_k_buffer is not None else 0
+            )
+            index_k_width = (
+                index_k_buffer.shape[-1] if index_k_buffer is not None else 0
+            )
+            index_k_item_size = (
+                index_k_buffer.element_size() if index_k_buffer is not None else 0
+            )
+            # FP8 DSA packs V into k_buffer; the device v_buffer is empty and
+            # never transferred, so the host v mirror holds no valid data and
+            # must not be persisted to storage.
+            skip_v = getattr(self, "dsa_kv_cache_store_fp8", False)
             for index in range(0, len(indices), self.page_size):
                 k_ptr = (
                     k_buffer_data_ptr
                     + indices[index]
                     * self.layer_num
-                    * self.kv_lora_rank
-                    * self.dtype.itemsize
-                )
-                v_ptr = (
-                    v_buffer_data_ptr
-                    + indices[index]
-                    * self.layer_num
-                    * self.qk_rope_head_dim
-                    * self.dtype.itemsize
+                    * k_width
+                    * k_item_size
                 )
                 ptr_list.append(k_ptr)
-                ptr_list.append(v_ptr)
-            k_element_size = (
-                self.layer_num
-                * self.dtype.itemsize
-                * self.page_size
-                * self.kv_lora_rank
-            )
+                if not skip_v:
+                    v_ptr = (
+                        v_buffer_data_ptr
+                        + indices[index]
+                        * self.layer_num
+                        * self.qk_rope_head_dim
+                        * self.dtype.itemsize
+                    )
+                    ptr_list.append(v_ptr)
+                if index_k_buffer_data_ptr is not None:
+                    # Host index_k layout is (page_num, num_indexer_layers,
+                    # page_size, 1, index_head_dim).
+                    ptr_list.append(
+                        index_k_buffer_data_ptr
+                        + indices[index]
+                        * num_indexer_layers
+                        * index_k_width
+                        * index_k_item_size
+                    )
+                if scale_buffer_data_ptr is not None:
+                    # Host scale layout is (page_num, num_indexer_layers,
+                    # page_size, 1, 1) FP32: one scale value per token per
+                    # indexer layer.
+                    ptr_list.append(
+                        scale_buffer_data_ptr
+                        + indices[index] * num_indexer_layers * 4
+                    )
+            k_element_size = self.layer_num * k_item_size * self.page_size * k_width
             v_element_size = (
                 self.layer_num
                 * self.dtype.itemsize
                 * self.page_size
                 * self.qk_rope_head_dim
             )
+            index_k_element_size = (
+                num_indexer_layers * index_k_item_size * self.page_size * index_k_width
+            )
+            scale_element_size = num_indexer_layers * 4 * self.page_size
             element_size_list = []
             for _ in range(0, len(indices), self.page_size):
                 element_size_list.append(k_element_size)
-                element_size_list.append(v_element_size)
+                if not skip_v:
+                    element_size_list.append(v_element_size)
+                if index_k_buffer_data_ptr is not None:
+                    element_size_list.append(index_k_element_size)
+                if scale_buffer_data_ptr is not None:
+                    element_size_list.append(scale_element_size)
             return ptr_list, element_size_list
         if self.layout == "layer_first":
             for index in range(0, len(indices), self.page_size):

--- a/python/sglang/srt/mem_cache/storage/ascend_memcache/README.md
+++ b/python/sglang/srt/mem_cache/storage/ascend_memcache/README.md
@@ -1,0 +1,103 @@
+# Ascend MemCache as L3 KV Cache
+
+This document explains how to use **Ascend MemCache** as the L3 KV Cache backend for **SGLang HiCache**.
+
+Related documentation:
+
+- [Ascend MemCache Build Guide](https://gitcode.com/Ascend/memcache/blob/master/doc/build.md)
+- [Ascend MemCache Config Guide](https://gitcode.com/Ascend/memcache/blob/master/doc/memcache_config.md)
+- [Ascend MemCache Python API](https://gitcode.com/Ascend/memcache/blob/master/doc/memcache_python_api.md)
+- [SGLang HiCache Design](https://docs.sglang.io/advanced_features/hicache_design.html)
+- [Ascend MemFabric](https://gitcode.com/Ascend/memfabric_hybrid)
+- [Ascend MemCache](https://gitcode.com/Ascend/memcache)
+
+## About MemCache
+
+MemCache is a distributed cache system from Ascend, built on MemFabric underneath, and can provide a high-performance distributed memory pool.
+In SGLang HiCache, MemCache can be used as the L3 KV Cache backend to store and reuse KV cache.
+
+
+## Install Ascend Memcache
+
+[Memcache Official Document](https://gitcode.com/Ascend/memcache/blob/master/doc/install_run.md)
+
+```bash
+pip install memcache_hybrid
+```
+
+## Deploy MemCache
+### Metaservice
+add `metaservice_config.json`
+```json
+{
+    // Meta service start-up url; in K8s meta service master-standby HA, auto-set to Pod IP at startup
+    "meta_service_url": "tcp://127.0.0.1:5000",
+
+    // Config store url; in K8s, auto-set to Pod IP at startup
+    "config_store_url": "tcp://127.0.0.1:6000",
+
+    // HTTP metrics service url
+    "metrics_url": "http://127.0.0.1:8000",
+
+    // Log level: debug, info, warn, error
+    "log_level": "info"
+}
+```
+
+Pass MetaService options via `metaservice_config.json` (see above). Keys below match `memcache_hybrid.MetaConfig` field names.
+
+| Key | Type | Required | Default | Valid range | Description |
+| --- | --- | --- | --- | --- | --- |
+| `meta_service_url` | string | optional | `tcp://127.0.0.1:5000` | `tcp://<ip>:<port>` | Meta service listen address. Port in [1025, 65535]. |
+| `config_store_url` | string | optional | `tcp://127.0.0.1:6000` | `tcp://<ip>:<port>` | Config store address. Port in [1025, 65535]. |
+| `metrics_url` | string | optional | `http://127.0.0.1:8000` | `http://<ip>:<port>` | HTTP metrics endpoint. Port in [1025, 65535]. |
+| `ha_enable` | boolean | optional | `false` | `true` / `false` | Enable MetaService master/backup HA in a K8s cluster. |
+| `log_level` | string | optional | `info` | `debug` / `info` / `warn` / `error` | Log level. |
+| `log_path` | string | optional | `/var/log/memcache_hybrid` | relative or absolute path | Log directory. Absolute paths start with `/`. |
+| `log_rotation_file_size` | integer | optional | `20` | [1, 500] | Log rotation file size in MB. |
+| `log_rotation_file_count` | integer | optional | `50` | [1, 50] | Number of rotated log files to keep. |
+| `evict_threshold_high` | integer | optional | `90` | [1, 99] | Eviction high-water mark (%). Max is 99. Eviction is skipped when a single put exceeds 1% of capacity. |
+| `evict_threshold_low` | integer | optional | `80` | [0, 98] | Eviction low-water mark (%) after eviction completes. |
+
+For more options, see [MemCache Configuration Guide — MetaService Config](https://gitcode.com/Ascend/memcache/blob/master/doc/memcache_config.md#metaservice-config).
+
+
+## Quick Start Ascend_memcache as L3 backend
+
+### Shell 1: Start Meta service
+
+```bash
+python -m sglang.srt.mem_cache.storage.ascend_memcache.start_meta_service --config_path "${metaservice_config_path}"
+```
+
+### Shell 2: Start SGLang Server
+
+
+```bash
+python -m sglang.launch_server \
+  --model-path ${model_path} \
+  --hicache-io-backend kernel_ascend \
+  --attention-backend ascend \
+  --enable-hierarchical-cache \
+  --hicache-storage-backend ascend_memcache \
+  --hicache-mem-layout page_first_kv_split \
+  --hicache-storage-backend-extra-config '{"meta_service_url":"tcp://127.0.0.1:5000", "config_store_url":"tcp://127.0.0.1:6000", "log_level":"info", "world_size":256, "protocol": "device_sdma", "dram_size": "1GB"}'
+```
+
+Pass LocalService options via `--hicache-storage-backend-extra-config` (JSON). Keys below match `memcache_hybrid.LocalConfig` field names.
+
+| Key | Type | Required | Default | Valid range | Description |
+| --- | --- | --- | --- | --- | --- |
+| `meta_service_url` | string | optional | `tcp://127.0.0.1:5000` | `tcp://<ip>:<port>` | Meta service address. Port in [1025, 65535]. In HA, `<ip>` is the cluster IP. |
+| `config_store_url` | string | optional | `tcp://127.0.0.1:6000` | `tcp://<ip>:<port>` | Config store address. Port in [1025, 65535]. |
+| `log_level` | string | optional | `info` | `debug` / `info` / `warn` / `error` | Log level. |
+| `world_size` | integer | optional | `256` | [1, 1024] | Max rank count. Cannot change after ranks connect; restart Meta to update. |
+| `protocol` | string | **required** | `host_rdma` | `host_rdma`, `host_urma`, `host_tcp`, `host_shm`, `device_sdma`, `device_rdma` | Transport protocol. `host_shm` requires `dram_size` > 0, `hbm_size` = 0, and no hcom. |
+| `hcom_url` | string | optional | `tcp://127.0.0.1:7000` | `tcp://<ip>:<port>` | HCOM address for the DRAM pool. Port in [1024, 65535]. |
+| `dram_size` | string / integer | **required** | `1GB` | [0, 1TB] | DRAM pool size. Accepts `134217728`, `2048KB`, `200mb`, `2.5G`, `1TB`, etc. Auto-aligned to 2MB (`host_rdma` / `host_tcp` / `host_shm`) or 1GB (`device_sdma` / `device_rdma`). |
+| `hbm_size` | string / integer | optional | `0` | [0, 1TB] | HBM pool size (same format as `dram_size`). Must be `0` when using `host_shm`. |
+| `max_dram_size` | string / integer | optional | `64GB` | [0, 1TB] | Max `dram_size` across all local processes. |
+| `max_hbm_size` | string / integer | optional | `0` | [0, 1TB] | Max `hbm_size` across all local processes. |
+
+
+For more options, see [MemCache Configuration Guide — LocalService Config](https://gitcode.com/Ascend/memcache/blob/master/doc/memcache_config.md#localservice-config).

--- a/python/sglang/srt/mem_cache/storage/ascend_memcache/__init__.py
+++ b/python/sglang/srt/mem_cache/storage/ascend_memcache/__init__.py
@@ -1,0 +1,3 @@
+from sglang.srt.mem_cache.storage.ascend_memcache.ascend_memcache_store import (
+    AscendMemcacheStore,
+)

--- a/python/sglang/srt/mem_cache/storage/ascend_memcache/ascend_memcache_store.py
+++ b/python/sglang/srt/mem_cache/storage/ascend_memcache/ascend_memcache_store.py
@@ -1,0 +1,901 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to SGLang project
+
+"""HiCache L3 storage backend for Ascend MemCache.
+
+This backend is implemented in parallel to Mooncake (not inheriting MooncakeStore).
+It follows the same HiCacheStorage contract and key layout strategy, while using
+`memcache_hybrid.DistributedObjectStore` as the underlying object store.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+from typing import Any, List, Optional, Tuple
+
+import requests
+import torch
+
+from sglang.srt.environ import envs
+from sglang.srt.mem_cache.hicache_storage import (
+    HiCacheStorage,
+    HiCacheStorageConfig,
+    HiCacheStorageExtraInfo,
+    PoolHitPolicy,
+    PoolName,
+    PoolTransfer,
+    PoolTransferResult,
+)
+from sglang.srt.mem_cache.memory_pool_host import HostKVCache
+from sglang.srt.observability.metrics_collector import StorageMetrics
+
+SETUP_TIMEOUT = 600  # seconds
+
+logger = logging.getLogger(__name__)
+
+# Keys handled by SGLang only; not applied to memcache_hybrid.LocalConfig.
+_MEMCACHE_CTRL_KEYS = frozenset(
+    {
+        "device_id",
+        "init_bm",
+        "conf_file_path",
+        "check_server",
+        "metrics_url",
+        "memcache_metrics_url",
+        "extra_backend_tag",
+    }
+)
+
+
+@dataclass
+class AscendMemcacheConfig:
+    """Merged Memcache LocalConfig/control fields from JSON and ``extra_config``."""
+
+    local_fields: dict
+    ctrl: dict
+
+    @staticmethod
+    def from_sources(
+        storage_config: Optional[HiCacheStorageConfig],
+    ) -> AscendMemcacheConfig:
+        merged: dict = {}
+        if envs.SGLANG_HICACHE_MEMCACHE_CONFIG_PATH.is_set():
+            path = envs.SGLANG_HICACHE_MEMCACHE_CONFIG_PATH.get()
+            try:
+                with open(path, encoding="utf-8") as fin:
+                    merged.update(json.load(fin))
+                logger.info("Memcache configuration loaded from %s", path)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to load memcache configuration from %s: %s", path, exc
+                )
+
+        extra = getattr(storage_config, "extra_config", None) or {}
+        merged.update(extra)
+
+        local_fields = {k: v for k, v in merged.items() if k not in _MEMCACHE_CTRL_KEYS}
+        ctrl = {k: merged[k] for k in _MEMCACHE_CTRL_KEYS if k in merged}
+
+        return AscendMemcacheConfig(local_fields=local_fields, ctrl=ctrl)
+
+    def apply_to_local_config(self, local_cfg: Any) -> List[str]:
+        unknown: List[str] = []
+        for key, value in self.local_fields.items():
+            if hasattr(local_cfg, key):
+                setattr(local_cfg, key, value)
+            else:
+                unknown.append(key)
+        return unknown
+
+
+def _default_memcache_device_id(
+    storage_config: Optional[HiCacheStorageConfig],
+) -> int:
+    """Infer NPU device id for the current process (respects ASCEND_RT_VISIBLE_DEVICES)."""
+    try:
+        if hasattr(torch, "npu") and torch.npu.is_available():
+            return int(torch.npu.current_device())
+    except Exception:
+        pass
+    if storage_config is not None:
+        return storage_config.tp_rank
+    return 0
+
+
+def _resolve_memcache_device_id(
+    ctrl: dict,
+    storage_config: Optional[HiCacheStorageConfig],
+) -> int:
+    """Resolve memcache ``init(device_id)`` for the current scheduler process.
+
+    SGLang runs one TP worker process per card; each process constructs its own
+    ``AscendMemcacheStore`` and must call ``init`` with that process's NPU id.
+
+    Resolution order:
+    - ``device_id`` omitted: ``torch.npu.current_device()`` or ``tp_rank``
+    - ``device_id`` JSON object / JSON string: per-``tp_rank`` map (Mooncake-style)
+    - scalar ``device_id``: use as configured (caller must set correctly per node)
+    """
+    if "device_id" not in ctrl:
+        return _default_memcache_device_id(storage_config)
+
+    raw = ctrl["device_id"]
+    device_config = raw if isinstance(raw, dict) else None
+    if device_config is None and isinstance(raw, str) and raw.strip().startswith("{"):
+        try:
+            device_config = json.loads(raw)
+        except (json.JSONDecodeError, TypeError):
+            logger.warning("Failed to parse device_id as JSON: %s", raw)
+            device_config = None
+
+    if isinstance(device_config, dict):
+        tp_rank = storage_config.tp_rank if storage_config is not None else 0
+        if tp_rank in device_config:
+            return int(device_config[tp_rank])
+        if str(tp_rank) in device_config:
+            return int(device_config[str(tp_rank)])
+        logger.warning(
+            "device_id map has no entry for tp_rank=%s; falling back to auto device id",
+            tp_rank,
+        )
+        return _default_memcache_device_id(storage_config)
+
+    device_id = int(raw)
+    if storage_config is not None and storage_config.tp_size > 1:
+        logger.warning(
+            "Ascend memcache device_id=%s is shared by all TP ranks; for multi-card "
+            "deployments omit device_id from config or use a per-rank JSON map.",
+            ctrl["device_id"],
+        )
+    return device_id
+
+
+class AscendMemcacheStore(HiCacheStorage):
+    """HiCache storage backend backed by Ascend MemCache (`memcache_hybrid`)."""
+
+    def __init__(
+        self,
+        storage_config: HiCacheStorageConfig = None,
+        mem_pool: HostKVCache = None,
+    ):
+        self.store = None
+        self.storage_config = storage_config
+
+        try:
+            from memcache_hybrid import DistributedObjectStore, LocalConfig
+        except ImportError as e:
+            raise ImportError(
+                "Ascend Memcache HiCache backend requires `memcache_hybrid`. "
+                "Install it with `pip install memcache_hybrid` and deploy "
+                "MetaService/LocalService according to https://gitcode.com/Ascend/memcache"
+            ) from e
+
+        try:
+            config = AscendMemcacheConfig.from_sources(storage_config)
+            local_cfg = LocalConfig()
+            unknown_fields = config.apply_to_local_config(local_cfg)
+            if unknown_fields:
+                logger.warning(
+                    "Ignoring unknown Memcache LocalConfig keys: %s", unknown_fields
+                )
+
+            self.store = DistributedObjectStore()
+            if self.store.setup(local_cfg) != 0:
+                raise RuntimeError(
+                    "memcache_hybrid.DistributedObjectStore.setup failed"
+                )
+
+            ctrl = config.ctrl
+            device_id = _resolve_memcache_device_id(ctrl, storage_config)
+            init_bm = bool(ctrl.get("init_bm", True))
+            if self.store.init(device_id, init_bm) != 0:
+                raise RuntimeError("memcache_hybrid.DistributedObjectStore.init failed")
+            tp_rank = storage_config.tp_rank if storage_config is not None else 0
+            logger.info(
+                "Ascend memcache store initialized (tp_rank=%s, device_id=%s, init_bm=%s)",
+                tp_rank,
+                device_id,
+                init_bm,
+            )
+
+            self._memcache_metrics_url = ctrl.get("metrics_url") or ctrl.get(
+                "memcache_metrics_url"
+            )
+            self._check_server_enabled = bool(ctrl.get("check_server", False))
+            self.extra_backend_tag = ctrl.get("extra_backend_tag")
+
+            if self._check_server_enabled:
+                self.check_server()
+
+            if not init_bm:
+                logger.info(
+                    "Memcache init_bm is False; skip warmup because read/write is unavailable in pure client mode."
+                )
+            elif not envs.SGLANG_ASCEND_MEMCACHE_ENABLE_WARMUP.get():
+                logger.warning(
+                    "Ascend memcache warmup is disabled "
+                    f"({envs.SGLANG_ASCEND_MEMCACHE_ENABLE_WARMUP.name}=0). "
+                    "Set it to true to run the register-time warmup probe."
+                )
+            self._init_runtime_fields(storage_config)
+
+        except ValueError as e:
+            logger.error("Ascend Memcache configuration failed: %s", e)
+            raise
+        except Exception as exc:
+            logger.error("Ascend Memcache store initialization failed: %s", exc)
+            raise
+
+    def _init_runtime_fields(
+        self, storage_config: Optional[HiCacheStorageConfig]
+    ) -> None:
+        self.enable_storage_metrics = False
+        if storage_config is not None:
+            self.is_mla_backend = storage_config.is_mla_model
+            self.local_rank = storage_config.tp_rank
+            self.pp_rank = storage_config.pp_rank
+            self.pp_size = storage_config.pp_size
+            self.attn_cp_rank = storage_config.attn_cp_rank
+            self.attn_cp_size = storage_config.attn_cp_size
+            self.enable_storage_metrics = storage_config.enable_storage_metrics
+        else:
+            self.is_mla_backend = False
+            self.local_rank = 0
+            self.pp_rank = 0
+            self.pp_size = 1
+            self.attn_cp_rank = 0
+            self.attn_cp_size = 1
+
+        self.enable_pp = self.pp_size > 1
+        self.enable_cp = self.attn_cp_size > 1
+        if self.enable_pp or self.enable_cp:
+            self.mha_suffix = f"{self.local_rank}_{self.pp_rank}_{self.attn_cp_rank}"
+            self.mla_suffix = f"{self.pp_rank}_{self.attn_cp_rank}"
+        else:
+            self.mha_suffix = f"{self.local_rank}"
+            self.mla_suffix = ""
+
+        self.split_factor = 0
+        if self.storage_config is not None and self.storage_config.should_split_heads:
+            self.split_factor = (
+                self.storage_config.tp_lcm_size // self.storage_config.tp_size
+            )
+            base_rank = self.local_rank * self.split_factor
+            target_ranks = [base_rank + i for i in range(self.split_factor)]
+            if self.enable_pp or self.enable_cp:
+                self.mha_suffix = [
+                    f"{rank}_{self.pp_rank}_{self.attn_cp_rank}"
+                    for rank in target_ranks
+                ]
+            else:
+                self.mha_suffix = [f"{rank}" for rank in target_ranks]
+
+        self.registered_pools = {}
+        self.gb_per_page = None
+        self.prefetch_pgs = []
+        self.backup_pgs = []
+        self.prefetch_bandwidth = []
+        self.backup_bandwidth = []
+
+    def register_buffer(self, tensor: torch.Tensor):
+        if self.store is None:
+            raise RuntimeError("Ascend Memcache store is not initialized.")
+        ptr = tensor.data_ptr()
+        size = tensor.numel() * tensor.element_size()
+        ret_code = self.store.register_buffer(ptr, size)
+        if ret_code != 0:
+            logger.error("Failed to register buffer, error code: %s", ret_code)
+            raise RuntimeError(
+                f"Failed to register buffer to Ascend Memcache, error code: {ret_code}"
+            )
+
+    def check_server(self) -> None:
+        url = self._memcache_metrics_url
+        if not url:
+            logger.warning(
+                "Memcache check_server is true but no metrics_url/memcache_metrics_url was provided; skipping readiness wait."
+            )
+            return
+
+        start = time.perf_counter()
+        while time.perf_counter() - start < SETUP_TIMEOUT:
+            try:
+                resp = requests.get(url, timeout=3)
+                if resp.status_code == 200:
+                    logger.info("Memcache metrics endpoint is reachable.")
+                    return
+            except Exception:
+                pass
+            logger.debug(
+                "Waiting for Memcache metrics endpoint at %s (%.1fs elapsed).",
+                url,
+                time.perf_counter() - start,
+            )
+            time.sleep(3)
+
+        raise TimeoutError(
+            f"Timed out after {SETUP_TIMEOUT}s waiting for Memcache metrics URL {url}"
+        )
+
+    def warmup(self):
+        warmup_key = "sglang_ascend_memcache_store_warmup_key" + uuid.uuid4().hex
+        # memcache_hybrid Python API examples use mutable bytearray in put().
+        warmup_value = bytearray(4 * 1024)
+        put_ret = self.store.put(warmup_key, warmup_value)
+        if put_ret != 0:
+            raise RuntimeError(f"warmup put failed: {put_ret}")
+
+        exist_ret = self.store.is_exist(warmup_key)
+        if exist_ret != 1:
+            raise RuntimeError(f"warmup is_exist failed: {exist_ret}")
+
+        get_val = self.store.get(warmup_key)
+        if get_val != warmup_value:
+            raise RuntimeError("warmup get payload mismatch")
+
+    def register_mem_pool_host(self, mem_pool_host: HostKVCache):
+        super().register_mem_pool_host(mem_pool_host)
+        assert self.mem_pool_host.layout in [
+            "page_first",
+            "page_first_direct",
+            "page_head",
+            "page_first_kv_split",
+        ], (
+            "ascend_memcache storage backend only support page_first, page_first_direct, "
+            "page_head and page_first_kv_split layout"
+        )
+        try:
+            self.register_buffer(self.mem_pool_host.kv_buffer)
+            if self._mla_uses_kv_split():
+                self.register_buffer(self.mem_pool_host.v_buffer)
+                if getattr(self.mem_pool_host, "index_k_buffer", None) is not None:
+                    self.register_buffer(self.mem_pool_host.index_k_buffer)
+        except TypeError as err:
+            logger.error("Failed to register buffer to Ascend Memcache Store: %s", err)
+            raise TypeError("Ascend Memcache Store Register Buffer Error.") from err
+
+        if envs.SGLANG_ASCEND_MEMCACHE_ENABLE_WARMUP.get():
+            self.warmup()
+            logger.info("Ascend memcache store warmup completed successfully.")
+
+        bytes_per_page = mem_pool_host.get_ksize_per_token() * mem_pool_host.page_size
+        self.gb_per_page = bytes_per_page / (1 << 30)
+
+    def register_mem_host_pool_v2(self, host_pool: HostKVCache, host_pool_name):
+        # KV anchor memory is already registered via register_mem_pool_host().
+        # v2 here only registers additional hybrid pools.
+        if host_pool_name == PoolName.KV:
+            return
+        # Keep a name->pool mapping so batch v2 can resolve PoolTransfer.name to
+        # the corresponding host pool implementation at runtime.
+        self.registered_pools[host_pool_name] = host_pool
+
+        # Hybrid pools expose the tensors that memcache requires for zero-copy I/O.
+        # The storage backend only depends on this accessor, not concrete fields.
+        buf_list = host_pool.get_hybrid_pool_buffer()
+        for buf in buf_list:
+            self.register_buffer(buf)
+
+    def _tag_keys(self, keys: List[str]) -> List[str]:
+        if self.extra_backend_tag is None:
+            return keys
+        return [f"{self.extra_backend_tag}_{key}" for key in keys]
+
+    def _mla_uses_kv_split(self) -> bool:
+        return (
+            self.is_mla_backend
+            and self.mem_pool_host is not None
+            and getattr(self.mem_pool_host, "layout", None) == "page_first_kv_split"
+        )
+
+    def _get_hybrid_page_component_keys(
+        self, page_keys: List[str], transfer: PoolTransfer
+    ) -> Tuple[List[str], int]:
+        # A logical "page" may map to multiple physical objects in storage.
+        # - INDEXER: one key per page
+        # - MAMBA  : one temporal key + N conv keys per page (temporal is dropped
+        #             for conv-only models, mirroring get_page_buffer_meta)
+        # - DRAFT  : one k + one v key per page
+        # key_multiplier records how many component keys are generated per page.
+        name = transfer.name
+        suffixes = []
+        if name == PoolName.INDEXER:
+            suffixes = [f"_{self.mla_suffix}_{PoolName.INDEXER}"]
+        elif name == PoolName.MAMBA:
+            mamba_pool = getattr(self, "registered_pools", {}).get(PoolName.MAMBA)
+            conv_num = len(getattr(mamba_pool, "conv_buffer", None) or [])
+            base_suffix = f"_{self.mha_suffix}"
+            # Must stay aligned with MambaPoolHost.get_page_buffer_meta(): it
+            # drops the temporal pointer when there is no SSM state, so the
+            # temporal key must be dropped under the same condition.
+            if getattr(mamba_pool, "temporal_state_elem_size", 1) > 0:
+                suffixes = [f"{base_suffix}_temporal"]
+            suffixes += [f"{base_suffix}_conv_{i}" for i in range(conv_num)]
+        elif name == PoolName.DRAFT:
+            # MHA draft KV: one k key + one v key per page, matching the
+            # (k_ptr, v_ptr) order of get_page_buffer_meta.
+            base_suffix = f"_{self.mha_suffix}"
+            suffixes = [f"{base_suffix}_k", f"{base_suffix}_v"]
+        else:
+            raise ValueError(f"Unsupported hybrid pool for batch v2 I/O: {name}")
+        if not suffixes:
+            raise ValueError(f"No storage component keys for hybrid pool: {name}")
+        key_multiplier = len(suffixes)
+        component_keys = [
+            f"{page_key}{suffix}" for page_key in page_keys for suffix in suffixes
+        ]
+        return component_keys, key_multiplier
+
+    def batch_exists_v2(
+        self,
+        keys: List[str],
+        pool_transfers: Optional[List[PoolTransfer]] = None,
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> PoolTransferResult:
+        qkeys = self._tag_keys(keys)
+        kv_pages = self.batch_exists(keys, extra_info)
+
+        hit_count: dict = {PoolName.KV: kv_pages} if kv_pages else {}
+        final_pages = kv_pages
+
+        for transfer in pool_transfers or []:
+            if final_pages == 0:
+                break
+            component_keys, key_multiplier = self._get_hybrid_page_component_keys(
+                qkeys, transfer
+            )
+            ex = self._batch_exist(component_keys)
+            page_exists = [
+                all(
+                    r == 1
+                    for r in ex[i * key_multiplier : (i + 1) * key_multiplier]
+                )
+                for i in range(kv_pages)
+            ]
+            boundary = 0
+            if transfer.hit_policy == PoolHitPolicy.ALL_PAGES:
+                try:
+                    boundary = page_exists.index(False)
+                except ValueError:
+                    boundary = kv_pages
+            elif transfer.hit_policy == PoolHitPolicy.TRAILING_PAGES:
+                trailing = max(1, len(transfer.keys) if transfer.keys else 1)
+                for prefix_len in range(kv_pages, 0, -1):
+                    if all(
+                        page_exists[i]
+                        for i in range(max(0, prefix_len - trailing), prefix_len)
+                    ):
+                        boundary = prefix_len
+                        break
+            if boundary:
+                hit_count[transfer.name] = boundary
+            final_pages = min(final_pages, boundary)
+
+        return PoolTransferResult(final_pages, hit_count)
+
+    def _batch_io_v2(self, transfers: List[PoolTransfer], is_set: bool):
+        # Unified v2 I/O path: each PoolTransfer can expand to one or more
+        # storage objects per logical page, but API still reports page-level result.
+        results: dict = {}
+        for transfer in transfers:
+            host_pool = getattr(self, "registered_pools", {}).get(transfer.name)
+            if host_pool is None:
+                raise RuntimeError(
+                    f"Host pool '{transfer.name}' is not registered. "
+                    "Call register_mem_host_pool_v2() before batch_get_v2/batch_set_v2."
+                )
+            keys = transfer.keys or []
+            page_size = getattr(host_pool, "page_size", 1) or 1
+            host_indices = transfer.host_indices
+            if len(keys) == 0:
+                raise ValueError(
+                    f"PoolTransfer '{transfer.name}' has empty keys in batch v2 I/O."
+                )
+            if host_indices is None:
+                raise ValueError(
+                    f"PoolTransfer '{transfer.name}' has null host_indices in batch v2 I/O."
+                )
+            if len(keys) != len(host_indices) // page_size:
+                raise ValueError(
+                    f"PoolTransfer '{transfer.name}' keys/host_indices mismatch: "
+                    f"len(keys)={len(keys)}, len(host_indices)={len(host_indices)}, page_size={page_size}."
+                )
+
+            ptr_list, element_size_list = host_pool.get_page_buffer_meta(host_indices)
+            key_strs, key_multiplier = self._get_hybrid_page_component_keys(
+                keys, transfer
+            )
+            key_strs = self._tag_keys(key_strs)
+
+            if is_set:
+                exist_result = self._batch_exist(key_strs)
+                io_results = [0 if state == 1 else -1 for state in exist_result]
+                missing_idx = [i for i, state in enumerate(exist_result) if state != 1]
+                if missing_idx:
+                    put_results = self._put_batch_zero_copy_impl(
+                        [key_strs[i] for i in missing_idx],
+                        [ptr_list[i] for i in missing_idx],
+                        [element_size_list[i] for i in missing_idx],
+                    )
+                    for i, res in zip(missing_idx, put_results):
+                        io_results[i] = res
+            else:
+                io_results = self._get_batch_zero_copy_impl(
+                    key_strs, ptr_list, element_size_list
+                )
+            pool_results = self._batch_postprocess(
+                io_results, is_set_operate=is_set, key_multiplier=key_multiplier
+            )
+            results[transfer.name] = pool_results
+        return results
+
+    def batch_get_v2(
+        self,
+        transfers: List[PoolTransfer],
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> dict:
+        return self._batch_io_v2(transfers, is_set=False)
+
+    def batch_set_v2(
+        self,
+        transfers: List[PoolTransfer],
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> dict:
+        return self._batch_io_v2(transfers, is_set=True)
+
+    def _get_mha_split_heads_buffer_meta(self, keys, indices):
+        ptr_list, element_size_list = (
+            self.mem_pool_host.get_split_heads_page_buffer_meta(
+                indices, self.split_factor
+            )
+        )
+        key_list = []
+        for key_ in keys:
+            for suffix in self.mha_suffix:
+                key_list.append(f"{key_}_{suffix}_k")
+                key_list.append(f"{key_}_{suffix}_v")
+        assert len(key_list) == len(ptr_list)
+        return key_list, ptr_list, element_size_list
+
+    def _get_mha_buffer_meta(self, keys, indices):
+        ptr_list, element_size_list = self.mem_pool_host.get_page_buffer_meta(indices)
+        key_list = []
+        for key_ in keys:
+            key_list.append(f"{key_}_{self.mha_suffix}_k")
+            key_list.append(f"{key_}_{self.mha_suffix}_v")
+        assert len(key_list) == len(ptr_list)
+        return key_list, ptr_list, element_size_list
+
+    def _get_mla_buffer_meta(self, keys, indices):
+        ptr_list, element_size_list = self.mem_pool_host.get_page_buffer_meta(indices)
+        key_list = []
+        for key_ in keys:
+            key_list.append(f"{key_}_{self.mla_suffix}_k")
+            if self._mla_uses_kv_split():
+                key_list.append(f"{key_}_{self.mla_suffix}_v")
+        assert len(key_list) == len(ptr_list)
+        return key_list, ptr_list, element_size_list
+
+    def _batch_preprocess(self, keys, host_indices):
+        assert len(keys) > 0
+        assert len(keys) == len(host_indices) // self.mem_pool_host.page_size
+        if self.is_mla_backend:
+            return self._get_mla_buffer_meta(keys, host_indices)
+        if self.storage_config and self.storage_config.should_split_heads:
+            return self._get_mha_split_heads_buffer_meta(keys, host_indices)
+        return self._get_mha_buffer_meta(keys, host_indices)
+
+    def _get_key_multiplier(self) -> int:
+        """Number of storage component objects per logical page (v1 path)."""
+        if self.is_mla_backend:
+            return 2 if self._mla_uses_kv_split() else 1
+        if self.storage_config and self.storage_config.should_split_heads:
+            return 2 * self.split_factor
+        return 2
+
+    def _batch_postprocess(
+        self, results: List[int], is_set_operate: bool = False, key_multiplier=None
+    ):
+        """
+        After `_get_batch_zero_copy_impl()`, each element is a positive byte length on a
+        successful read, or negative on error.
+
+        ``batch_put_from`` return codes passed into this path use 0 for success and
+        negative values for errors (`_batch_io_v2` / `batch_set_v1`).
+        """
+
+        if key_multiplier is None:
+            key_multiplier = self._get_key_multiplier()
+
+        result_groups = [
+            results[i : i + key_multiplier]
+            for i in range(0, len(results), key_multiplier)
+        ]
+        return [
+            (
+                all(res == 0 for res in group)
+                if is_set_operate
+                else all(res > 0 for res in group)
+            )
+            for group in result_groups
+        ]
+
+    def batch_get_v1(
+        self,
+        keys: List[str],
+        host_indices: torch.Tensor,
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> List[bool]:
+        # Apply extra_backend_tag prefix if available
+        keys = self._tag_keys(keys)
+
+        key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(keys, host_indices)
+
+        start_time = time.perf_counter()
+        get_results = self._get_batch_zero_copy_impl(
+            key_strs, buffer_ptrs, buffer_sizes
+        )
+        end_time = time.perf_counter()
+
+        if self.enable_storage_metrics and end_time > start_time:
+            self.prefetch_pgs.append(len(keys))
+            self.prefetch_bandwidth.append(
+                len(keys) / (end_time - start_time) * self.gb_per_page
+            )
+
+        return self._batch_postprocess(get_results, is_set_operate=False)
+
+    def batch_set_v1(
+        self,
+        keys: List[str],
+        host_indices: torch.Tensor,
+        extra_info: Optional[HiCacheStorageExtraInfo] = None,
+    ) -> List[bool]:
+        # Apply extra_backend_tag prefix if available
+        page_keys = self._tag_keys(keys)
+
+        key_strs, buffer_ptrs, buffer_sizes = self._batch_preprocess(
+            page_keys, host_indices
+        )
+        exist_result = self._batch_exist(key_strs)
+        existing_keys = sum(1 for state in exist_result if state == 1)
+
+        set_keys = []
+        set_buffer_ptrs = []
+        set_buffer_sizes = []
+        set_indices = []
+        set_results = [-1] * len(key_strs)
+        for i in range(len(key_strs)):
+            if exist_result[i] != 1:
+                set_keys.append(key_strs[i])
+                set_buffer_ptrs.append(buffer_ptrs[i])
+                set_buffer_sizes.append(buffer_sizes[i])
+                set_indices.append(i)
+            else:
+                set_results[i] = 0
+
+        if set_keys:
+            start_time = time.perf_counter()
+            put_results = self._put_batch_zero_copy_impl(
+                set_keys, set_buffer_ptrs, set_buffer_sizes
+            )
+            end_time = time.perf_counter()
+
+            if self.enable_storage_metrics and end_time > start_time:
+                # set_keys are component-level (k/v per page); normalize to pages.
+                pages = len(set_keys) // self._get_key_multiplier()
+                self.backup_pgs.append(pages)
+                self.backup_bandwidth.append(
+                    pages / (end_time - start_time) * self.gb_per_page
+                )
+
+            for i in range(len(set_indices)):
+                set_results[set_indices[i]] = put_results[i]
+        page_results = self._batch_postprocess(set_results, is_set_operate=True)
+        return page_results
+
+    def set(
+        self,
+        key: str,
+        value: Optional[Any] = None,
+        target_location: Optional[Any] = None,
+        target_sizes: Optional[Any] = None,
+    ) -> bool:
+        _ = value
+        assert target_location is not None and target_sizes is not None
+        exist_result = self._batch_exist([key])
+        if exist_result[0] == 1:
+            return True
+        put_result = self._put_batch_zero_copy_impl(
+            [key], [target_location], [target_sizes]
+        )
+        return put_result[0] == 0
+
+    def batch_set(
+        self,
+        keys: List[str],
+        values: Optional[List[torch.Tensor]] = None,
+        target_locations: Optional[Any] = None,
+        target_sizes: Optional[Any] = None,
+    ) -> bool:
+        _ = values
+        assert target_locations is not None and target_sizes is not None
+        assert len(keys) == len(target_locations) == len(target_sizes)
+
+        if len(keys) == 0:
+            return False
+
+        for i in range(len(keys)):
+            if (
+                keys[i] is None
+                or target_locations[i] is None
+                or target_sizes[i] is None
+            ):
+                return False
+
+        exist_result = self._batch_exist(keys)
+        set_keys = []
+        set_target_locations = []
+        set_target_sizes = []
+        set_indices = []
+        for i in range(len(keys)):
+            if exist_result[i] != 1:
+                set_keys.append(keys[i])
+                set_target_locations.append(target_locations[i])
+                set_target_sizes.append(target_sizes[i])
+                set_indices.append(i)
+
+        start_time = time.perf_counter()
+        put_result = self._put_batch_zero_copy_impl(
+            set_keys, set_target_locations, set_target_sizes
+        )
+        end_time = time.perf_counter()
+
+        if self.enable_storage_metrics and set_keys and end_time > start_time:
+            self.backup_pgs.append(len(set_keys))
+            self.backup_bandwidth.append(
+                len(set_keys) / (end_time - start_time) * self.gb_per_page
+            )
+
+        for i in range(len(set_indices)):
+            if put_result[i] == 0:
+                exist_result[set_indices[i]] = 1
+
+        success_count = 0
+        for i in range(len(keys)):
+            if exist_result[i] == 0:
+                break
+            success_count += 1
+        return success_count == len(keys)
+
+    def get(
+        self,
+        key: str,
+        target_location: Optional[Any] = None,
+        target_sizes: Optional[Any] = None,
+    ) -> bool:
+        assert target_location is not None and target_sizes is not None
+        get_result = self._get_batch_zero_copy_impl(
+            [key], [target_location], [target_sizes]
+        )
+        return get_result[0] > 0
+
+    def batch_get(
+        self,
+        keys: List[str],
+        target_locations: Optional[Any] = None,
+        target_sizes: Optional[Any] = None,
+    ) -> int:
+        assert len(keys) == len(target_locations) == len(target_sizes)
+        if len(keys) == 0:
+            return 0
+
+        start_time = time.perf_counter()
+        get_result = self._get_batch_zero_copy_impl(
+            keys, target_locations, target_sizes
+        )
+        end_time = time.perf_counter()
+        hit_keys = sum(1 for r in get_result if r > 0)
+
+        if self.is_mla_backend:
+            key_multiplier = 2 if self._mla_uses_kv_split() else 1
+        else:
+            key_multiplier = 2
+
+        if self.enable_storage_metrics and end_time > start_time:
+            self.prefetch_pgs.append(len(keys))
+            self.prefetch_bandwidth.append(
+                len(keys) / (end_time - start_time) * self.gb_per_page
+            )
+
+        for i in range(len(keys)):
+            if get_result[i] < 0:
+                return i // key_multiplier
+        return len(keys) // key_multiplier
+
+    def exists(self, key: str) -> bool:
+        exist_result = self._batch_exist([key])
+        return exist_result[0] == 1
+
+    def batch_exists(
+        self, keys: List[str], extra_info: Optional[HiCacheStorageExtraInfo] = None
+    ) -> int:
+        page_keys = self._tag_keys(keys)
+
+        if self.is_mla_backend:
+            query_keys = []
+            for key in page_keys:
+                query_keys.append(f"{key}_{self.mla_suffix}_k")
+                if self._mla_uses_kv_split():
+                    query_keys.append(f"{key}_{self.mla_suffix}_v")
+            key_multiplier = 2 if self._mla_uses_kv_split() else 1
+        else:
+            query_keys = []
+            if self.storage_config and self.storage_config.should_split_heads:
+                for key in page_keys:
+                    for suffix in self.mha_suffix:
+                        query_keys.append(f"{key}_{suffix}_k")
+                        query_keys.append(f"{key}_{suffix}_v")
+                key_multiplier = 2 * self.split_factor
+            else:
+                for key in page_keys:
+                    query_keys.append(f"{key}_{self.mha_suffix}_k")
+                    query_keys.append(f"{key}_{self.mha_suffix}_v")
+                key_multiplier = 2
+
+        exist_result = self._batch_exist(query_keys)
+        for i in range(len(query_keys)):
+            if exist_result[i] != 1:
+                return i // key_multiplier
+        return len(query_keys) // key_multiplier
+
+    def clear(self) -> None:
+        self.store.remove_all()
+
+    def close(self) -> None:
+        if self.store is None:
+            return
+        try:
+            self.store.close()
+        except Exception as e:
+            logger.warning("Ascend Memcache store.close failed: %s", e)
+        self.store = None
+
+    def _put_batch_zero_copy_impl(
+        self, key_strs: List[str], buffer_ptrs: List[int], buffer_sizes: List[int]
+    ) -> List[int]:
+        return self.store.batch_put_from(key_strs, buffer_ptrs, buffer_sizes)
+
+    def _get_batch_zero_copy_impl(
+        self, key_strs: List[str], buffer_ptrs: List[int], buffer_sizes: List[int]
+    ) -> List[int]:
+        raw = self.store.batch_get_into(key_strs, buffer_ptrs, buffer_sizes)
+        # memcache_hybrid reports 0 on success, but HiCache read postprocess expects
+        # positive values for success and negative values for failures.
+        out: List[int] = []
+        for code, sz in zip(raw, buffer_sizes):
+            code = int(code)
+            if code == 0:
+                out.append(int(sz))
+            else:
+                out.append(-abs(code))
+        return out
+
+    def _batch_exist(self, key_strs: List[str]) -> List[int]:
+        return self.store.batch_is_exist(key_strs)
+
+    def get_stats(self):
+        storage_metrics = StorageMetrics()
+        storage_metrics.prefetch_pgs.extend(self.prefetch_pgs)
+        storage_metrics.backup_pgs.extend(self.backup_pgs)
+        storage_metrics.prefetch_bandwidth.extend(self.prefetch_bandwidth)
+        storage_metrics.backup_bandwidth.extend(self.backup_bandwidth)
+        self.prefetch_pgs.clear()
+        self.backup_pgs.clear()
+        self.prefetch_bandwidth.clear()
+        self.backup_bandwidth.clear()
+        return storage_metrics

--- a/python/sglang/srt/mem_cache/storage/ascend_memcache/ascend_memcache_store.py
+++ b/python/sglang/srt/mem_cache/storage/ascend_memcache/ascend_memcache_store.py
@@ -354,6 +354,8 @@ class AscendMemcacheStore(HiCacheStorage):
                 self.register_buffer(self.mem_pool_host.v_buffer)
                 if getattr(self.mem_pool_host, "index_k_buffer", None) is not None:
                     self.register_buffer(self.mem_pool_host.index_k_buffer)
+                if getattr(self.mem_pool_host, "index_k_scale_buffer", None) is not None:
+                    self.register_buffer(self.mem_pool_host.index_k_scale_buffer)
         except TypeError as err:
             logger.error("Failed to register buffer to Ascend Memcache Store: %s", err)
             raise TypeError("Ascend Memcache Store Register Buffer Error.") from err
@@ -391,6 +393,36 @@ class AscendMemcacheStore(HiCacheStorage):
             and self.mem_pool_host is not None
             and getattr(self.mem_pool_host, "layout", None) == "page_first_kv_split"
         )
+
+    def _mla_has_index_scale(self) -> bool:
+        """Whether the MLA host pool carries the quantized-Indexer FP32 scale cache."""
+        return self.mem_pool_host is not None and getattr(
+            self.mem_pool_host, "index_k_scale_buffer", None
+        ) is not None
+
+    def _mla_has_index_k(self) -> bool:
+        """Whether the MLA host pool carries the DSA Indexer K cache."""
+        return self.mem_pool_host is not None and getattr(
+            self.mem_pool_host, "index_k_buffer", None
+        ) is not None
+
+    def _mla_fp8_packed_kv(self) -> bool:
+        """FP8 DSA packs K/V into one buffer; v has no separate component key."""
+        return self.mem_pool_host is not None and getattr(
+            self.mem_pool_host, "dsa_kv_cache_store_fp8", False
+        )
+
+    def _mla_key_multiplier(self) -> int:
+        """Number of per-page memcache component keys for the MLA backend.
+
+        Order matters and must match get_page_buffer_meta's ptr order:
+        k, [v], [index_k], [scale]. v is skipped for FP8-packed DSA where the
+        device v_buffer is empty and never transferred.
+        """
+        if not self._mla_uses_kv_split():
+            return 1
+        base = 1 if self._mla_fp8_packed_kv() else 2
+        return base + int(self._mla_has_index_k()) + int(self._mla_has_index_scale())
 
     def _get_hybrid_page_component_keys(
         self, page_keys: List[str], transfer: PoolTransfer
@@ -576,7 +608,12 @@ class AscendMemcacheStore(HiCacheStorage):
         for key_ in keys:
             key_list.append(f"{key_}_{self.mla_suffix}_k")
             if self._mla_uses_kv_split():
-                key_list.append(f"{key_}_{self.mla_suffix}_v")
+                if not self._mla_fp8_packed_kv():
+                    key_list.append(f"{key_}_{self.mla_suffix}_v")
+                if self._mla_has_index_k():
+                    key_list.append(f"{key_}_{self.mla_suffix}_index_k")
+                if self._mla_has_index_scale():
+                    key_list.append(f"{key_}_{self.mla_suffix}_scale")
         assert len(key_list) == len(ptr_list)
         return key_list, ptr_list, element_size_list
 
@@ -592,7 +629,7 @@ class AscendMemcacheStore(HiCacheStorage):
     def _get_key_multiplier(self) -> int:
         """Number of storage component objects per logical page (v1 path)."""
         if self.is_mla_backend:
-            return 2 if self._mla_uses_kv_split() else 1
+            return self._mla_key_multiplier()
         if self.storage_config and self.storage_config.should_split_heads:
             return 2 * self.split_factor
         return 2
@@ -802,7 +839,7 @@ class AscendMemcacheStore(HiCacheStorage):
         hit_keys = sum(1 for r in get_result if r > 0)
 
         if self.is_mla_backend:
-            key_multiplier = 2 if self._mla_uses_kv_split() else 1
+            key_multiplier = self._mla_key_multiplier()
         else:
             key_multiplier = 2
 
@@ -831,8 +868,13 @@ class AscendMemcacheStore(HiCacheStorage):
             for key in page_keys:
                 query_keys.append(f"{key}_{self.mla_suffix}_k")
                 if self._mla_uses_kv_split():
-                    query_keys.append(f"{key}_{self.mla_suffix}_v")
-            key_multiplier = 2 if self._mla_uses_kv_split() else 1
+                    if not self._mla_fp8_packed_kv():
+                        query_keys.append(f"{key}_{self.mla_suffix}_v")
+                    if self._mla_has_index_k():
+                        query_keys.append(f"{key}_{self.mla_suffix}_index_k")
+                    if self._mla_has_index_scale():
+                        query_keys.append(f"{key}_{self.mla_suffix}_scale")
+            key_multiplier = self._mla_key_multiplier()
         else:
             query_keys = []
             if self.storage_config and self.storage_config.should_split_heads:

--- a/python/sglang/srt/mem_cache/storage/ascend_memcache/start_meta_service.py
+++ b/python/sglang/srt/mem_cache/storage/ascend_memcache/start_meta_service.py
@@ -1,0 +1,82 @@
+import argparse
+import json
+import logging
+import os
+import sys
+from typing import Any
+
+from memcache_hybrid import MetaConfig, MetaService
+
+logger = logging.getLogger("ascend_memcache.start_meta_service")
+
+
+def _load_json_config(config_path: str) -> dict[str, Any]:
+    with open(config_path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Config file must contain a JSON object: {config_path}")
+    return data
+
+
+def _apply_meta_config(config: MetaConfig, data: dict[str, Any]) -> list[str]:
+    unknown: list[str] = []
+    for key, value in data.items():
+        if hasattr(config, key):
+            setattr(config, key, value)
+        else:
+            unknown.append(key)
+    return unknown
+
+
+def launch_meta_service(config_path: str) -> int:
+    try:
+        config_data = _load_json_config(config_path)
+    except Exception as e:
+        logger.error("Failed to load meta service config from %s: %s", config_path, e)
+        return 1
+
+    meta_cfg = MetaConfig()
+    unknown = _apply_meta_config(meta_cfg, config_data)
+    if unknown:
+        logger.warning("Ignoring unknown MetaConfig keys: %s", unknown)
+
+    try:
+        setup_ret = MetaService.setup(meta_cfg)
+        if isinstance(setup_ret, int) and setup_ret != 0:
+            logger.error("MetaService.setup failed, ret=%s", setup_ret)
+            return setup_ret
+        logger.info("MetaService setup succeeded with config=%s", config_path)
+        MetaService.main()
+        return 0
+    except KeyboardInterrupt:
+        logger.info("MetaService interrupted by user.")
+        return 0
+    except Exception as e:
+        logger.error("MetaService failed to run: %s", e)
+        return 2
+
+
+def main() -> int:
+    script_dir = os.path.dirname(os.path.abspath(__file__))
+    default_path = os.path.join(script_dir, "metaservice_config.json")
+
+    parser = argparse.ArgumentParser(
+        description="Launch Ascend MemCache MetaService via JSON."
+    )
+    parser.add_argument(
+        "--config_path",
+        type=str,
+        default=default_path,
+        help=f"Path to meta service JSON config (default: {default_path})",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+    )
+    return launch_meta_service(args.config_path)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/sglang/srt/mem_cache/storage/backend_factory.py
+++ b/python/sglang/srt/mem_cache/storage/backend_factory.py
@@ -165,6 +165,9 @@ class StorageBackendFactory:
         elif backend_name == "mooncake":
             backend = backend_class(storage_config, mem_pool_host)
             return backend
+        elif backend_name == "ascend_memcache":
+            backend = backend_class(storage_config, mem_pool_host)
+            return backend
         elif backend_name == "aibrix":
             backend = backend_class(storage_config, mem_pool_host)
             return backend
@@ -212,6 +215,12 @@ StorageBackendFactory.register_backend(
     "mooncake",
     "sglang.srt.mem_cache.storage.mooncake_store.mooncake_store",
     "MooncakeStore",
+)
+
+StorageBackendFactory.register_backend(
+    "ascend_memcache",
+    "sglang.srt.mem_cache.storage.ascend_memcache.ascend_memcache_store",
+    "AscendMemcacheStore",
 )
 
 StorageBackendFactory.register_backend(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2782,11 +2782,12 @@ class ServerArgs:
     hicache_storage_backend: A[
         Optional[str],
         Arg(
-            help="The storage backend for hierarchical KV cache. Built-in backends: file, mooncake, hf3fs, nixl, aibrix. For dynamic backend, use --hicache-storage-backend-extra-config to specify: backend_name (custom name), module_path (Python module path), class_name (backend class name).",
+            help="The storage backend for hierarchical KV cache. Built-in backends: file, mooncake, ascend_memcache, hf3fs, nixl, aibrix. For dynamic backend, use --hicache-storage-backend-extra-config to specify: backend_name (custom name), module_path (Python module path), class_name (backend class name).",
             choices=[
                 "file",
                 "sim",
                 "mooncake",
+                "ascend_memcache",
                 "hf3fs",
                 "nixl",
                 "aibrix",
@@ -8015,7 +8016,7 @@ class ServerArgs:
 
     def _resolve_storage_layout_compatibility(self):
         if (
-            self.hicache_storage_backend != "mooncake"
+            self.hicache_storage_backend not in ("mooncake", "ascend_memcache")
             or self.hicache_mem_layout != "layer_first"
         ):
             return
@@ -8033,7 +8034,7 @@ class ServerArgs:
             hicache_mem_layout=new_layout,
         )
         logger.warning(
-            f"Mooncake storage backend does not support layer_first layout, "
+            f"Mooncake/Ascend Memcache storage backend does not support layer_first layout, "
             f"switching to {new_layout} layout for {self.hicache_io_backend} io backend"
         )
 


### PR DESCRIPTION
## Motivation

Add the Ascend MemCache storage backend as the third tier (L3) of HiCache for NPU, extending KV caches from device/host memory to persistent storage via zero-copy batch I/O. This improves cache hit rate and throughput for long-context and large-cache serving.

Also fix host-side (L2) KV cache release bugs found while integrating L3: double release of prefill KV, double decrement of protected_size_ , and cache_protected_len being overwritten during load-back rematching (which caused lock leaks on Mamba state slots).

## Modifications

- Ascend MemCache storage backend (L3)

  - New AscendMemcacheStore implementing the HiCacheStorage interface: zero-copy batch get/put, page-level component-key management, and storage metrics.
  - Support for hybrid pools (MHA / MLA / Mamba), Mamba state transfer, and multi-suffix key handling.
  - MLA support for page_first_kv_split layout: FP8 DSA packed K/V (dead v component skipped), Indexer K cache, and quantized-Indexer FP32 scale cache components.
  - Storage backend factory wiring, meta service script, and server/env configuration toggles.
- Host pool adaptations

  - mamba.py : dedicated per-layer transfer path for the NPU kernel_ascend backend.
  - mla.py : host mirrors for FP8 packed K/V width, Indexer-K layers ( num_indexer_layers fallback), and the Indexer scale buffer; consistent capacity sizing in get_size_per_token .
  - memory_pool_host.py : HostPoolGroup property delegation for the new MLA components.
- L2 cache release fixes

  - decode_kvcache_offload_manager.py : correct Mamba state release, deduplicate prefill release, fix protected_size_ double-counting.
  - decode_hicache_mixin.py : save/restore cache_protected_len around load-back rematch.
  - decode.py : Mamba pool capacity check with LRU eviction during preallocation.
- NPU-specific adaptations

  - parallel_state.py : derive gathered configs locally to avoid all_gather_object HCCL buffer allocation.
  - memory_pool.py / memory_pool_npu.py : align KV layer IDs and buffer info for DSA FP8 packed storage.
  - transfer_engine.py : support device_urma / device_uboe transfer protocols.
  - hybrid_pool_assembler.py / kv_cache_builder.py : layout fallbacks for MHA/Mamba pools.

## Accuracy Tests

To be supplemented.

## Speed Tests and Profiling

To be supplemented.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32802280310](https://github.com/sgl-project/sglang/actions/runs/32802280310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32802280171](https://github.com/sgl-project/sglang/actions/runs/32802280171)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32802280384](https://github.com/sgl-project/sglang/actions/runs/32802280384)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->