### PR TITLE
 Support x-request-id header for rid pass-through 

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -110,7 +110,10 @@ from sglang.srt.entrypoints.openai.serving_tokenize import (
 from sglang.srt.entrypoints.openai.serving_transcription import (
     OpenAIServingTranscription,
 )
-from sglang.srt.entrypoints.request_headers import apply_header_overrides
+from sglang.srt.entrypoints.request_headers import (
+    apply_header_overrides,
+    resolve_rid_from_headers,
+)
 from sglang.srt.entrypoints.warmup import execute_warmups
 from sglang.srt.environ import envs
 from sglang.srt.function_call.function_call_parser import FunctionCallParser
@@ -907,6 +910,9 @@ if os.environ.get("DUMPER_SERVER_PORT") == "reuse":
 )
 async def generate_request(obj: GenerateReqInput, request: Request):
     """Handle a generate request."""
+    header_rid = resolve_rid_from_headers(request.headers)
+    if header_rid is not None:
+        obj.rid = header_rid
     if envs.SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES.get():
         apply_header_overrides(obj, request.headers)
     if obj.stream:

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -291,3 +291,19 @@ class OpenAIServingBase(ABC):
                 )
 
         return body_routed_dp_rank
+
+    def extract_rid_from_header(
+        self, raw_request: Request, body_rid: Optional[str] = None
+    ) -> Optional[str]:
+        """Extract rid from HTTP header, with higher priority than rid in body.
+
+        Header name: x-request-id (case-insensitive in HTTP/1.1/2)
+        """
+        if raw_request is None:
+            return body_rid
+
+        header_value = raw_request.headers.get("x-request-id")
+        if header_value is not None:
+            return header_value
+
+        return body_rid

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -12,6 +12,7 @@ from fastapi.responses import ORJSONResponse, StreamingResponse
 
 from sglang.srt.entrypoints.openai.encoding_dsv32 import DS32EncodingError
 from sglang.srt.entrypoints.openai.protocol import ErrorResponse, OpenAIServingRequest
+from sglang.srt.entrypoints.request_headers import resolve_rid_from_headers
 from sglang.srt.managers.io_struct import EmbeddingReqInput, GenerateReqInput
 from sglang.srt.observability.req_time_stats import monotonic_time
 from sglang.srt.server_args import ServerArgs
@@ -297,18 +298,13 @@ class OpenAIServingBase(ABC):
         raw_request: Request,
         body_rid: Optional[Union[List[str], str]] = None,
     ) -> Optional[Union[List[str], str]]:
-        """Extract rid from the x-request-id header, taking precedence over the body rid.
+        """Resolve the rid, preferring the x-request-id header over the body rid.
 
-        A single rid is returned as a string; "rid_0, rid_1" yields a list of two.
+        One header value labels the whole request and a batch expands it into
+        per-item rids; several values label the items directly.
         """
         if raw_request is None:
             return body_rid
 
-        header_value = raw_request.headers.get("x-request-id")
-        if header_value is None:
-            return body_rid
-
-        rids = [segment.strip() for segment in header_value.split(",") if segment.strip()]
-        if not rids:
-            return body_rid
-        return rids[0] if len(rids) == 1 else rids
+        header_rid = resolve_rid_from_headers(raw_request.headers)
+        return header_rid if header_rid is not None else body_rid

--- a/python/sglang/srt/entrypoints/openai/serving_base.py
+++ b/python/sglang/srt/entrypoints/openai/serving_base.py
@@ -293,17 +293,22 @@ class OpenAIServingBase(ABC):
         return body_routed_dp_rank
 
     def extract_rid_from_header(
-        self, raw_request: Request, body_rid: Optional[str] = None
-    ) -> Optional[str]:
-        """Extract rid from HTTP header, with higher priority than rid in body.
+        self,
+        raw_request: Request,
+        body_rid: Optional[Union[List[str], str]] = None,
+    ) -> Optional[Union[List[str], str]]:
+        """Extract rid from the x-request-id header, taking precedence over the body rid.
 
-        Header name: x-request-id (case-insensitive in HTTP/1.1/2)
+        A single rid is returned as a string; "rid_0, rid_1" yields a list of two.
         """
         if raw_request is None:
             return body_rid
 
         header_value = raw_request.headers.get("x-request-id")
-        if header_value is not None:
-            return header_value
+        if header_value is None:
+            return body_rid
 
-        return body_rid
+        rids = [segment.strip() for segment in header_value.split(",") if segment.strip()]
+        if not rids:
+            return body_rid
+        return rids[0] if len(rids) == 1 else rids

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1173,7 +1173,7 @@ class OpenAIServingChat(OpenAIServingBase):
             return_hidden_states=request.return_hidden_states,
             return_routed_experts=request.return_routed_experts,
             routed_experts_start_len=request.routed_experts_start_len,
-            rid=request.rid,
+            rid=self.extract_rid_from_header(raw_request, request.rid),
             session_id=request.session_id,
             extra_key=request.extra_key,
             cache_salt=request.cache_salt,

--- a/python/sglang/srt/entrypoints/openai/serving_classify.py
+++ b/python/sglang/srt/entrypoints/openai/serving_classify.py
@@ -70,7 +70,7 @@ class OpenAIServingClassify(OpenAIServingBase):
 
         adapted_request = EmbeddingReqInput(
             **prompt_kwargs,
-            rid=request.rid,
+            rid=self.extract_rid_from_header(raw_request, request.rid),
             priority=request.priority,
         )
 

--- a/python/sglang/srt/entrypoints/openai/serving_completions.py
+++ b/python/sglang/srt/entrypoints/openai/serving_completions.py
@@ -129,7 +129,7 @@ class OpenAIServingCompletion(OpenAIServingBase):
             return_routed_experts=request.return_routed_experts,
             routed_experts_start_len=request.routed_experts_start_len,
             return_prompt_token_ids=request.return_token_ids,
-            rid=request.rid,
+            rid=self.extract_rid_from_header(raw_request, request.rid),
             session_id=request.session_id,
             extra_key=request.extra_key,
             cache_salt=request.cache_salt,

--- a/python/sglang/srt/entrypoints/openai/serving_embedding.py
+++ b/python/sglang/srt/entrypoints/openai/serving_embedding.py
@@ -172,7 +172,7 @@ class OpenAIServingEmbedding(OpenAIServingBase):
 
         adapted_request = EmbeddingReqInput(
             **prompt_kwargs,
-            rid=request.rid,
+            rid=self.extract_rid_from_header(raw_request, request.rid),
             priority=request.priority,
             routing_key=self.extract_routing_key(raw_request),
             dimensions=request.dimensions,

--- a/python/sglang/srt/entrypoints/request_headers.py
+++ b/python/sglang/srt/entrypoints/request_headers.py
@@ -1,10 +1,22 @@
-"""Override object fields based on _HEADER_OVERRIDES from header values.
+"""Read request fields from HTTP header values.
 
-This mechanism allows upstream callers to leave the body opaque
-(no parse/merge/re-serialize).
+Two independent mechanisms:
+
+- ``apply_header_overrides`` writes header values straight onto declared fields.
+  It also steers placement and scheduling, so it stays behind
+  ``SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES`` and, being applied last, wins over
+  anything below.
+- ``resolve_rid_from_headers`` reads the standard ``x-request-id`` header. It is
+  honored on every request and only contributes an identity, which the caller
+  resolves against the body rid.
+
+Both allow upstream callers to leave the body opaque (no parse/merge/re-serialize).
 """
 
+from typing import List, Optional, Union
+
 from fastapi import HTTPException
+from starlette.datastructures import Headers
 
 # request header -> (target attribute, value type)
 _HEADER_OVERRIDES = {
@@ -31,3 +43,34 @@ def apply_header_overrides(obj, headers) -> None:
             raise HTTPException(
                 status_code=400, detail=f"invalid {header} header {value!r}: {e}"
             ) from e
+
+
+def resolve_rid_from_headers(headers: Headers) -> Optional[Union[List[str], str]]:
+    """Resolve the rids carried by the x-request-id header.
+
+    The header is list-valued: values may be comma separated on one line or split
+    across repeated lines, which RFC 9110 5.3 makes equivalent. Every line is read
+    and blank entries are dropped, so the two spellings are interchangeable.
+
+    A request may name itself once, once per batch item, or once per sample; the
+    counts a batch accepts are enforced during normalization. The readable way to
+    name every sample of a batch is one line per batch item, holding that item's
+    n ids in order:
+
+        x-request-id: req-a-0, req-a-1, req-a-2     # first input, n = 3
+        x-request-id: req-b-0, req-b-1, req-b-2     # second input
+
+    which is the same request as a single line reading "req-a-0, ..., req-b-2".
+
+    A lone value is returned as a string; several are returned as a list.
+    """
+    rids = []
+    for name, value in headers.items():
+        if name.lower() != "x-request-id":
+            continue
+        rids.extend(entry.strip() for entry in value.split(",") if entry.strip())
+
+    if not rids:
+        return None
+
+    return rids[0] if len(rids) == 1 else rids

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -351,14 +351,6 @@ class GenerateReqInput:
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[Union[List[str], str]] = None
 
-    def regenerate_rid(self):
-        """Generate a new request ID and return it."""
-        if isinstance(self.rid, list):
-            self.rid = [uuid.uuid4().hex for _ in range(len(self.rid))]
-        else:
-            self.rid = uuid.uuid4().hex
-        return self.rid
-
     def _validate_rid_uniqueness(self):
         """Validate that request IDs within a batch are unique."""
         if isinstance(self.rid, list) and len(set(self.rid)) != len(self.rid):
@@ -518,6 +510,9 @@ class GenerateReqInput:
             self.sampling_params = {}
         if self.rid is None:
             self.rid = uuid.uuid4().hex
+        elif not isinstance(self.rid, str):
+            # rid keys rid_to_state, so a list here reaches the dict unhashable.
+            raise ValueError(f"A single request takes one rid, got {self.rid!r}.")
         if self.return_logprob is None:
             self.return_logprob = False
         if self.logprob_start_len is None:
@@ -539,16 +534,13 @@ class GenerateReqInput:
 
     def _normalize_batch_inputs(self):
         """Normalize inputs for a batch of examples, including parallel sampling expansion."""
-        # Calculate expanded batch size
-        if self.parallel_sample_num == 1:
-            num = self.batch_size
-        else:
-            # Expand parallel_sample_num
-            num = self.batch_size * self.parallel_sample_num
+        batch_size = self.batch_size
+        n = self.parallel_sample_num
+        num = batch_size * n
 
         # Expand input based on type
-        self._expand_inputs(num)
-        self._normalize_rid(num)
+        self._expand_inputs(n=n)
+        self._normalize_rid(batch_size=batch_size, n=n)
         self._normalize_lora_paths(num)
         self._normalize_image_data(num)
         self._normalize_mm_hashes(num)
@@ -562,12 +554,17 @@ class GenerateReqInput:
         self._normalize_cache_salt(num)
         self._normalize_bootstrap_params(num)
 
-    def _expand_inputs(self, num):
-        """Expand the main inputs (text, input_ids, input_embeds) for parallel sampling."""
+    def _expand_inputs(self, n: int):
+        """Expand the main inputs (text, input_ids, input_embeds) for parallel sampling.
+
+        Repeating the whole list makes one full pass over the prompts per sample,
+        so index ``k`` is prompt ``k % batch_size`` and sample ``k // batch_size``.
+        Every other expanded list, `_normalize_rid` included, follows this layout.
+        """
         if self.text is not None:
             if not isinstance(self.text, list):
                 raise ValueError("Text should be a list for batch processing.")
-            self.text = self.text * self.parallel_sample_num
+            self.text = self.text * n
         elif self.input_ids is not None:
             if not isinstance(self.input_ids, list) or not isinstance(
                 self.input_ids[0], list
@@ -575,11 +572,11 @@ class GenerateReqInput:
                 raise ValueError(
                     "input_ids should be a list of lists for batch processing."
                 )
-            self.input_ids = self.input_ids * self.parallel_sample_num
+            self.input_ids = self.input_ids * n
         elif self.input_embeds is not None:
             if not isinstance(self.input_embeds, list):
                 raise ValueError("input_embeds should be a list for batch processing.")
-            self.input_embeds = self.input_embeds * self.parallel_sample_num
+            self.input_embeds = self.input_embeds * n
 
     def _normalize_lora_paths(self, num):
         """Normalize LoRA paths for batch processing."""
@@ -695,22 +692,59 @@ class GenerateReqInput:
         else:  # Already a list
             self.sampling_params = self.sampling_params * self.parallel_sample_num
 
-    def _normalize_rid(self, num):
-        """Normalize request IDs for batch processing."""
+    def _normalize_rid(self, batch_size: int, n: int):
+        """Assign one rid per sub-request, keeping the caller's rid as the prefix.
+
+        A suffix level is added only for a dimension that expands, so one prompt
+        sampled n times yields ``rid_0 .. rid_{n-1}``. The shared prefix is what
+        lets the scheduler abort a whole family at once. A caller may name every
+        sample instead, in which case nothing is derived.
+
+        Ordering follows `_expand_inputs`, so index ``k`` labels the same
+        sub-request in every normalized list.
+        """
         if self.rid is None:
-            self.rid = [uuid.uuid4().hex for _ in range(num)]
+            parents = [uuid.uuid4().hex for _ in range(batch_size)]
         elif isinstance(self.rid, str):
-            new_rids = [f"{self.rid}_{i}" for i in range(num)]
-            self.rid = new_rids
+            parents = (
+                [self.rid]
+                if batch_size == 1
+                else [f"{self.rid}_{i}" for i in range(batch_size)]
+            )
         elif isinstance(self.rid, list):
-            # Note: the length of rid shall be the same as the batch_size,
-            # as the rid would be expanded for parallel sampling in tokenizer_manager
-            if len(self.rid) != self.batch_size:
+            if n > 1 and len(self.rid) == batch_size * n:
+                # Every sub-request is named already. Callers group by prompt, the
+                # way choices come back, so reorder into the sample-major layout
+                # the expanded lists use.
+                per_sample = self.rid
+                self.rid = [
+                    per_sample[prompt * n + sample]
+                    for sample in range(n)
+                    for prompt in range(batch_size)
+                ]
+                return
+            if len(self.rid) != batch_size:
+                if n == 1:
+                    raise ValueError(
+                        f"A batch of {batch_size} requests takes {batch_size} "
+                        f"rids, but got {len(self.rid)}."
+                    )
                 raise ValueError(
-                    "The specified rids length mismatch with the batch_size for batch processing."
+                    f"A batch of {batch_size} requests sampled {n} times takes "
+                    f"either {batch_size} rids, one per request, or "
+                    f"{batch_size * n} rids, one per sample, "
+                    f"but got {len(self.rid)}."
                 )
+            parents = self.rid
         else:
             raise ValueError("The rid should be a string or a list of strings.")
+
+        if n == 1:
+            self.rid = parents
+        else:
+            self.rid = [
+                f"{parent}_{sample}" for sample in range(n) for parent in parents
+            ]
 
     def _normalize_logprob_params(self, num):
         """Normalize logprob-related parameters for batch processing."""
@@ -1163,14 +1197,6 @@ class EmbeddingReqInput:
     # Batch-level: List[List[int]] (one per request). After __getitem__: List[int].
     multi_item_delimiter_indices: Optional[Union[List[List[int]], List[int]]] = None
 
-    def regenerate_rid(self):
-        """Generate a new request ID and return it."""
-        if isinstance(self.rid, list):
-            self.rid = [uuid.uuid4().hex for _ in range(len(self.rid))]
-        else:
-            self.rid = uuid.uuid4().hex
-        return self.rid
-
     def _validate_rid_uniqueness(self):
         """Validate that request IDs within a batch are unique."""
         if isinstance(self.rid, list) and len(set(self.rid)) != len(self.rid):
@@ -1215,6 +1241,9 @@ class EmbeddingReqInput:
         if self.is_single:
             if self.rid is None:
                 self.rid = uuid.uuid4().hex
+            elif not isinstance(self.rid, str):
+                # rid keys rid_to_state, so a list here reaches the dict unhashable.
+                raise ValueError(f"A single request takes one rid, got {self.rid!r}.")
             if self.sampling_params is None:
                 self.sampling_params = {}
             self.sampling_params["max_new_tokens"] = 0
@@ -1222,11 +1251,9 @@ class EmbeddingReqInput:
             if self.rid is None:
                 self.rid = [uuid.uuid4().hex for _ in range(self.batch_size)]
             elif isinstance(self.rid, str):
-                # A batch cannot be labeled by a single rid; require one per item.
-                raise ValueError(
-                    f"Batch of {self.batch_size} requests requires {self.batch_size} "
-                    f"rids, but got a single rid {self.rid!r}."
-                )
+                # One rid labels the whole batch, expanded per item with the same
+                # prefix scheme as GenerateReqInput._normalize_rid.
+                self.rid = [f"{self.rid}_{i}" for i in range(self.batch_size)]
             elif isinstance(self.rid, list):
                 if len(self.rid) != self.batch_size:
                     raise ValueError(

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -1221,8 +1221,19 @@ class EmbeddingReqInput:
         else:
             if self.rid is None:
                 self.rid = [uuid.uuid4().hex for _ in range(self.batch_size)]
+            elif isinstance(self.rid, str):
+                # A batch cannot be labeled by a single rid; require one per item.
+                raise ValueError(
+                    f"Batch of {self.batch_size} requests requires {self.batch_size} "
+                    f"rids, but got a single rid {self.rid!r}."
+                )
+            elif isinstance(self.rid, list):
+                if len(self.rid) != self.batch_size:
+                    raise ValueError(
+                        "The specified rids length mismatch with the batch_size for batch processing."
+                    )
             else:
-                assert isinstance(self.rid, list), "The rid should be a list."
+                raise ValueError("The rid should be a string or a list of strings.")
 
             if self.sampling_params is None:
                 self.sampling_params = [{}] * self.batch_size

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1907,19 +1907,29 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     tokenized_obj.mm_inputs.mm_items = [
                         copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
                     ]
-                tokenized_obj.rid = tmp_obj.regenerate_rid()
+                # This request only warms the radix cache. It is named under the
+                # first sample of its prompt, the one rid reachable from here, so
+                # that it still falls inside the family a prefix abort covers.
+                tmp_obj.rid = f"{objs[i].rid}_prime"
+                tokenized_obj.rid = tmp_obj.rid
                 tokenized_obj.sampling_params = copy.copy(tokenized_obj.sampling_params)
                 tokenized_obj.sampling_params.max_new_tokens = 0
                 tokenized_obj.stream = False
                 self._init_req_state(tmp_obj)
+                # _tokenize_one_request pointed time_stats at the first sample's
+                # state; warmup timings belong to this request instead.
+                tokenized_obj.time_stats = self.rid_to_state[tmp_obj.rid].time_stats
+                # The "_prime" rid is minted here, so it is not covered by the
+                # request_rids the caller derived from obj.rid.
                 request_rids.add(tmp_obj.rid)
                 await self._send_one_request(tokenized_obj)
                 await self._wait_one_response(tmp_obj, request).__anext__()
 
-            # Expand requests, assign new rids for them, and send them
+            # Send one request per sample, consuming the rids normalization already
+            # derived. Their states were created up front by _init_req_state.
             for i in range(batch_size):
-                for _ in range(obj.parallel_sample_num):
-                    tmp_obj = copy.copy(objs[i])
+                for j in range(obj.parallel_sample_num):
+                    sub_obj = obj[i + batch_size * j]
                     tokenized_obj = copy.copy(tokenized_objs[i])
                     # Ensure independent mm_items so wrap_shm_features won't mutate the original
                     if hasattr(tokenized_obj, "mm_inputs") and tokenized_obj.mm_inputs:
@@ -1927,19 +1937,14 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                         tokenized_obj.mm_inputs.mm_items = [
                             copy.copy(item) for item in tokenized_obj.mm_inputs.mm_items
                         ]
-                    tokenized_obj.rid = tmp_obj.regenerate_rid()
-                    self._init_req_state(tmp_obj)
-                    request_rids.add(tmp_obj.rid)
-                    state = self.rid_to_state[tmp_obj.rid]
+                    tokenized_obj.rid = sub_obj.rid
+                    state = self.rid_to_state[sub_obj.rid]
                     tokenized_obj.time_stats = state.time_stats
-                    if tmp_obj.return_prompt_token_ids:
+                    if sub_obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_objs[i].input_ids)
                     await self._send_one_request(tokenized_obj)
-                    generators.append(self._wait_one_response(tmp_obj, request))
-                    rids.append(tmp_obj.rid)
-
-                self.rid_to_state[objs[i].rid].time_stats.set_finished_time()
-                del self.rid_to_state[objs[i].rid]
+                    generators.append(self._wait_one_response(sub_obj, request))
+                    rids.append(sub_obj.rid)
 
         # Wait for all requests
         is_stream = hasattr(obj, "stream") and obj.stream

--- a/test/registered/cpu/test_request_headers.py
+++ b/test/registered/cpu/test_request_headers.py
@@ -4,7 +4,10 @@ from types import SimpleNamespace
 from fastapi import HTTPException
 from starlette.datastructures import Headers
 
-from sglang.srt.entrypoints.request_headers import apply_header_overrides
+from sglang.srt.entrypoints.request_headers import (
+    apply_header_overrides,
+    resolve_rid_from_headers,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=4, suite="stage-a-test-cpu-intel")
@@ -103,6 +106,59 @@ class TestApplyRoutingHeaders(unittest.TestCase):
         obj = _obj()
         with self.assertRaises(HTTPException):
             apply_header_overrides(obj, Headers({"x-override-priority": "high"}))
+
+
+class TestResolveRidFromHeaders(unittest.TestCase):
+    """x-request-id is list-valued, so both wire forms must parse the same way."""
+
+    def test_absent_or_blank_header_names_no_identity(self):
+        self.assertIsNone(resolve_rid_from_headers(Headers({})))
+        self.assertIsNone(resolve_rid_from_headers(Headers({"x-request-id": "  "})))
+        self.assertIsNone(resolve_rid_from_headers(Headers({"x-request-id": " , "})))
+
+    def test_one_value_is_a_string(self):
+        self.assertEqual(
+            resolve_rid_from_headers(Headers({"x-request-id": "abc"})), "abc"
+        )
+
+    def test_blank_entries_are_dropped(self):
+        for value in ("abc,", ",abc", "abc, "):
+            self.assertEqual(
+                resolve_rid_from_headers(Headers({"x-request-id": value})), "abc"
+            )
+
+    def test_comma_separated_values_become_a_list(self):
+        self.assertEqual(
+            resolve_rid_from_headers(Headers({"x-request-id": "a, b ,c"})),
+            ["a", "b", "c"],
+        )
+
+    def test_repeated_lines_are_equivalent_to_one_comma_joined_line(self):
+        """RFC 9110 5.3: repeated lines of a list-valued field carry one list.
+
+        The documented way to name every sample of a batch is one line per batch
+        item, so the merged and split spellings must resolve identically.
+        """
+        two_lines = Headers(raw=[(b"x-request-id", b"a"), (b"x-request-id", b"b")])
+        self.assertEqual(resolve_rid_from_headers(two_lines), ["a", "b"])
+
+        per_batch_item = Headers(
+            raw=[(b"x-request-id", b"a-0, a-1"), (b"x-request-id", b"b-0, b-1")]
+        )
+        self.assertEqual(
+            resolve_rid_from_headers(per_batch_item), ["a-0", "a-1", "b-0", "b-1"]
+        )
+        self.assertEqual(
+            resolve_rid_from_headers(
+                Headers({"x-request-id": "a-0, a-1, b-0, b-1"}),
+            ),
+            resolve_rid_from_headers(per_batch_item),
+        )
+
+    def test_wire_order_is_preserved(self):
+        """Position is the only thing mapping a rid to its batch item."""
+        headers = Headers(raw=[(b"x-request-id", b"b, a"), (b"x-request-id", b"c")])
+        self.assertEqual(resolve_rid_from_headers(headers), ["b", "a", "c"])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_serving_completions.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_completions.py
@@ -113,6 +113,27 @@ class ServingCompletionTestCase(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "single request"):
             internal.normalize_batch_and_arguments()
 
+    # ---------- rid pass-through ----------
+    def test_rid_from_header_overrides_body(self):
+        """x-request-id header takes precedence over the body rid field."""
+        req = CompletionRequest(
+            model="x", prompt=[1, 2, 3, 4], max_tokens=1, rid="body-rid"
+        )
+        raw = Mock(spec=Request)
+        raw.headers = {"x-request-id": "header-rid"}
+        internal, _ = self.sc._convert_to_internal_request(req, raw)
+        self.assertEqual(internal.rid, "header-rid")
+
+    def test_rid_falls_back_to_body_without_header(self):
+        """Without an x-request-id header, rid falls back to the body value."""
+        req = CompletionRequest(
+            model="x", prompt=[1, 2, 3, 4], max_tokens=1, rid="body-rid"
+        )
+        raw = Mock(spec=Request)
+        raw.headers = {}
+        internal, _ = self.sc._convert_to_internal_request(req, raw)
+        self.assertEqual(internal.rid, "body-rid")
+
     # ---------- echo-handling ----------
     def test_echo_with_list_of_strings_streaming(self):
         req = CompletionRequest(

--- a/test/registered/unit/entrypoints/openai/test_serving_embedding.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_embedding.py
@@ -49,6 +49,7 @@ if "sgl_kernel" not in sys.modules:
     sys.meta_path.insert(0, _SglKernelMockFinder())
 
 from fastapi import Request
+from starlette.datastructures import Headers
 
 from sglang.srt.entrypoints.openai.protocol import (
     EmbeddingRequest,
@@ -366,85 +367,34 @@ class ServingEmbeddingTestCase(unittest.TestCase):
         )
 
     # ---------- x-request-id header passthrough ----------
-    def test_rid_from_header_single_value(self):
-        """A single x-request-id header value maps to a plain string rid."""
-        raw = Mock(spec=Request)
-        raw.headers = {"x-request-id": "single-rid"}
-        self.assertEqual(
-            self.serving_embedding.extract_rid_from_header(raw, None), "single-rid"
-        )
+    def test_batch_expands_one_header_rid_per_item(self):
+        """One header rid labels a batch, expanded into per-item rids.
 
-    def test_rid_from_header_comma_separated_list(self):
-        """Comma-separated header values map to a stripped rid list."""
-        raw = Mock(spec=Request)
-        raw.headers = {"x-request-id": "a, b ,c"}
-        self.assertEqual(
-            self.serving_embedding.extract_rid_from_header(raw, None),
-            ["a", "b", "c"],
-        )
-
-    def test_rid_from_header_trailing_comma_ignored(self):
-        """An empty trailing segment is dropped, leaving the single rid."""
-        raw = Mock(spec=Request)
-        raw.headers = {"x-request-id": "abc,"}
-        self.assertEqual(
-            self.serving_embedding.extract_rid_from_header(raw, None), "abc"
-        )
-
-    def test_rid_from_header_falls_back_to_body(self):
-        """Missing or blank headers fall back to the body rid field."""
-        raw = Mock(spec=Request)
-        raw.headers = {}
-        self.assertEqual(
-            self.serving_embedding.extract_rid_from_header(raw, "body-rid"),
-            "body-rid",
-        )
-
-        raw.headers = {"x-request-id": ", "}
-        self.assertEqual(
-            self.serving_embedding.extract_rid_from_header(raw, "body-rid"),
-            "body-rid",
-        )
-
-        self.assertEqual(
-            self.serving_embedding.extract_rid_from_header(None, "body-rid"),
-            "body-rid",
-        )
-
-    def test_batch_rid_list_from_header_normalizes_per_item(self):
-        """A comma-separated header rid maps to each item of a batch."""
-        batch_req = EmbeddingRequest(
-            model="test-model",
-            input=["first", "second"],
-            encoding_format="float",
-        )
-        raw = Mock(spec=Request)
-        raw.headers = {"x-request-id": "batch_0, batch_1"}
-
-        adapted, _ = self.serving_embedding._convert_to_internal_request(
-            batch_req, raw
-        )
-        adapted.normalize_batch_and_arguments()
-
+        A gateway emits a single x-request-id per HTTP request and cannot know the
+        batch size, so a batch must not require one rid per item.
+        """
+        adapted = self._adapt_batch({"x-request-id": "batch"})
         self.assertEqual(adapted.rid, ["batch_0", "batch_1"])
-        self.assertEqual(adapted[0].rid, "batch_0")
-        self.assertEqual(adapted[1].rid, "batch_1")
+        self.assertEqual([adapted[0].rid, adapted[1].rid], ["batch_0", "batch_1"])
 
-    def test_batch_with_single_header_rid_is_rejected(self):
-        """One header rid for a batch is a ValueError (400), not an assertion crash."""
+    def test_batch_takes_per_item_rids_from_the_header(self):
+        """Several header values label the batch items directly, in wire order."""
+        adapted = self._adapt_batch({"x-request-id": "first, second"})
+        self.assertEqual(adapted.rid, ["first", "second"])
+        self.assertEqual([adapted[0].rid, adapted[1].rid], ["first", "second"])
+
+    def _adapt_batch(self, headers: dict):
         batch_req = EmbeddingRequest(
             model="test-model",
             input=["first", "second"],
             encoding_format="float",
         )
         raw = Mock(spec=Request)
-        raw.headers = {"x-request-id": "batch"}
+        raw.headers = Headers(headers)
 
-        adapted, _ = self.serving_embedding._convert_to_internal_request(
-            batch_req, raw
-        )
-        with self.assertRaisesRegex(ValueError, "requires 2 rids"):
-            adapted.normalize_batch_and_arguments()
+        adapted, _ = self.serving_embedding._convert_to_internal_request(batch_req, raw)
+        adapted.normalize_batch_and_arguments()
+        return adapted
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/entrypoints/openai/test_serving_embedding.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_embedding.py
@@ -365,6 +365,87 @@ class ServingEmbeddingTestCase(unittest.TestCase):
             self.serving_embedding._validate_request(invalid_request),
         )
 
+    # ---------- x-request-id header passthrough ----------
+    def test_rid_from_header_single_value(self):
+        """A single x-request-id header value maps to a plain string rid."""
+        raw = Mock(spec=Request)
+        raw.headers = {"x-request-id": "single-rid"}
+        self.assertEqual(
+            self.serving_embedding.extract_rid_from_header(raw, None), "single-rid"
+        )
+
+    def test_rid_from_header_comma_separated_list(self):
+        """Comma-separated header values map to a stripped rid list."""
+        raw = Mock(spec=Request)
+        raw.headers = {"x-request-id": "a, b ,c"}
+        self.assertEqual(
+            self.serving_embedding.extract_rid_from_header(raw, None),
+            ["a", "b", "c"],
+        )
+
+    def test_rid_from_header_trailing_comma_ignored(self):
+        """An empty trailing segment is dropped, leaving the single rid."""
+        raw = Mock(spec=Request)
+        raw.headers = {"x-request-id": "abc,"}
+        self.assertEqual(
+            self.serving_embedding.extract_rid_from_header(raw, None), "abc"
+        )
+
+    def test_rid_from_header_falls_back_to_body(self):
+        """Missing or blank headers fall back to the body rid field."""
+        raw = Mock(spec=Request)
+        raw.headers = {}
+        self.assertEqual(
+            self.serving_embedding.extract_rid_from_header(raw, "body-rid"),
+            "body-rid",
+        )
+
+        raw.headers = {"x-request-id": ", "}
+        self.assertEqual(
+            self.serving_embedding.extract_rid_from_header(raw, "body-rid"),
+            "body-rid",
+        )
+
+        self.assertEqual(
+            self.serving_embedding.extract_rid_from_header(None, "body-rid"),
+            "body-rid",
+        )
+
+    def test_batch_rid_list_from_header_normalizes_per_item(self):
+        """A comma-separated header rid maps to each item of a batch."""
+        batch_req = EmbeddingRequest(
+            model="test-model",
+            input=["first", "second"],
+            encoding_format="float",
+        )
+        raw = Mock(spec=Request)
+        raw.headers = {"x-request-id": "batch_0, batch_1"}
+
+        adapted, _ = self.serving_embedding._convert_to_internal_request(
+            batch_req, raw
+        )
+        adapted.normalize_batch_and_arguments()
+
+        self.assertEqual(adapted.rid, ["batch_0", "batch_1"])
+        self.assertEqual(adapted[0].rid, "batch_0")
+        self.assertEqual(adapted[1].rid, "batch_1")
+
+    def test_batch_with_single_header_rid_is_rejected(self):
+        """One header rid for a batch is a ValueError (400), not an assertion crash."""
+        batch_req = EmbeddingRequest(
+            model="test-model",
+            input=["first", "second"],
+            encoding_format="float",
+        )
+        raw = Mock(spec=Request)
+        raw.headers = {"x-request-id": "batch"}
+
+        adapted, _ = self.serving_embedding._convert_to_internal_request(
+            batch_req, raw
+        )
+        with self.assertRaisesRegex(ValueError, "requires 2 rids"):
+            adapted.normalize_batch_and_arguments()
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)

--- a/test/registered/unit/entrypoints/test_generate_rid_header.py
+++ b/test/registered/unit/entrypoints/test_generate_rid_header.py
@@ -1,0 +1,85 @@
+"""Endpoint-level tests for rid propagation on the native `/generate` route.
+
+`/generate` builds its `GenerateReqInput` straight from the body, so the
+`x-request-id` header has to be applied by the handler itself rather than by the
+OpenAI serving layer. These tests exercise the handler against a stub global
+state: it is an `async def` reading module-level `_global_state`, so awaiting the
+coroutine directly is enough, with no model server booted.
+"""
+
+import asyncio
+import unittest
+from types import SimpleNamespace
+
+from starlette.datastructures import Headers
+
+from sglang.srt.entrypoints import http_server
+from sglang.srt.environ import envs
+from sglang.srt.managers.io_struct import GenerateReqInput
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _StubTokenizerManager:
+    def __init__(self):
+        self.received = []
+
+    def generate_request(self, obj, request=None):
+        self.received.append(obj)
+        return self._one_response()
+
+    async def _one_response(self):
+        yield {"text": "ok", "meta_info": {"id": "stub"}}
+
+
+def _dispatch(headers: dict, body_rid=None) -> GenerateReqInput:
+    """Run the `/generate` handler and return the object it sent downstream."""
+    obj = GenerateReqInput(text="hi", rid=body_rid)
+    request = SimpleNamespace(headers=Headers(headers))
+    tokenizer_manager = _StubTokenizerManager()
+
+    prior_state = http_server.get_global_state()
+    http_server.set_global_state(
+        SimpleNamespace(tokenizer_manager=tokenizer_manager, scheduler_info={})
+    )
+    try:
+        asyncio.run(http_server.generate_request(obj, request))
+    finally:
+        http_server._global_state = prior_state
+
+    return tokenizer_manager.received[0]
+
+
+class TestGenerateRequestIdHeader(CustomTestCase):
+    def test_header_rid_reaches_the_tokenizer_manager(self):
+        """`/generate` honors x-request-id so PD workers derive the same rid.
+
+        The router dispatches one request to a prefill and a decode worker; each
+        normalizes independently, so without a shared header rid the two sides
+        generate unrelated ids and cannot be correlated.
+        """
+        sent = _dispatch({"x-request-id": "header-rid"}, body_rid="body-rid")
+        self.assertEqual(sent.rid, "header-rid")
+
+    def test_body_rid_survives_without_the_header(self):
+        """A caller that sets no header keeps the rid it put in the body."""
+        sent = _dispatch({}, body_rid="body-rid")
+        self.assertEqual(sent.rid, "body-rid")
+
+    def test_override_header_wins_over_the_request_id(self):
+        """x-override-rid is the explicit, gated mechanism, so it is applied last.
+
+        A trusted upstream that names an exact rid must not be overruled by the
+        correlation id a client happened to attach.
+        """
+        with envs.SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES.override(True):
+            sent = _dispatch(
+                {"x-request-id": "header-rid", "x-override-rid": "override-rid"}
+            )
+        self.assertEqual(sent.rid, "override-rid")
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1193,6 +1193,28 @@ class TestEmbeddingReqInputGetItem(CustomTestCase):
         with self.assertRaisesRegex(ValueError, "must match batch size"):
             req.normalize_batch_and_arguments()
 
+    def test_batch_requires_one_rid_per_item(self):
+        """A single rid cannot label a batch: each item is an independent request."""
+        req = EmbeddingReqInput(text=["first", "second"], rid="batch")
+        with self.assertRaisesRegex(ValueError, "requires 2 rids"):
+            req.normalize_batch_and_arguments()
+
+    def test_batch_rid_list_must_match_item_count(self):
+        """Exact rid lists are preserved per item; a wrong length is rejected."""
+        req = EmbeddingReqInput(text=["first", "second"], rid=["a", "b"])
+        req.normalize_batch_and_arguments()
+        self.assertEqual([req[0].rid, req[1].rid], ["a", "b"])
+
+        bad_req = EmbeddingReqInput(text=["first", "second"], rid=["a", "b", "c"])
+        with self.assertRaisesRegex(ValueError, "length mismatch"):
+            bad_req.normalize_batch_and_arguments()
+
+    def test_single_rid_string_stays_string(self):
+        """A single embedding request keeps its string rid untouched."""
+        req = EmbeddingReqInput(text="only one", rid="single")
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.rid, "single")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -706,11 +706,112 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         )
         batch.normalize_batch_and_arguments()
 
-        self.assertEqual(batch.rid, ["batch_0", "batch_1", "batch_2", "batch_3"])
+        self.assertEqual(
+            batch.rid, ["batch_0_0", "batch_1_0", "batch_0_1", "batch_1_1"]
+        )
         self.assertEqual(
             [batch[i].rid for i in range(4)],
-            ["batch_0", "batch_1", "batch_2", "batch_3"],
+            ["batch_0_0", "batch_1_0", "batch_0_1", "batch_1_1"],
         )
+
+    def test_rid_expansion_pairs_each_rid_with_its_prompt(self):
+        """A derived rid must sit at the index of the prompt it labels.
+
+        The expanded arrays are sample-major (`text * parallel_sample_num`), so a
+        rid array built prompt-major would attach every rid to the wrong prompt
+        from the second sample onwards, and nothing else would notice.
+        """
+        req = GenerateReqInput(text=["p0", "p1"], rid="R", sampling_params={"n": 3})
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(
+            [(req[k].text, req[k].rid) for k in range(6)],
+            [
+                ("p0", "R_0_0"),
+                ("p1", "R_1_0"),
+                ("p0", "R_0_1"),
+                ("p1", "R_1_1"),
+                ("p0", "R_0_2"),
+                ("p1", "R_1_2"),
+            ],
+        )
+
+    def test_rid_suffix_is_added_only_for_dimensions_that_expand(self):
+        """A single prompt sampled n times gets one suffix level, not two."""
+        single = GenerateReqInput(text="hi", rid="R", sampling_params={"n": 3})
+        single.normalize_batch_and_arguments()
+        self.assertEqual(single.rid, ["R_0", "R_1", "R_2"])
+
+        no_sampling = GenerateReqInput(text=["p0", "p1"], rid="R")
+        no_sampling.normalize_batch_and_arguments()
+        self.assertEqual(no_sampling.rid, ["R_0", "R_1"])
+
+    def test_caller_rids_become_prefixes_of_their_samples(self):
+        """Per-prompt rids stay the prefix of the samples derived from them.
+
+        The scheduler aborts a family by prefix, so a caller-supplied rid has to
+        remain a prefix of every request it expands into.
+        """
+        req = GenerateReqInput(
+            text=["p0", "p1"], rid=["a", "b"], sampling_params={"n": 3}
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(req.rid, ["a_0", "b_0", "a_1", "b_1", "a_2", "b_2"])
+        self.assertTrue(all(rid.startswith(("a_", "b_")) for rid in req.rid))
+
+    def test_caller_may_name_every_sample_itself(self):
+        """Per-sample rids are grouped by prompt, the way choices come back.
+
+        Choices are ordered prompt-major (`idx // n`) while the expanded lists are
+        sample-major, so the two orders must not be confused: reading the caller's
+        list positionally would attach every rid past the first sample to the
+        wrong prompt.
+        """
+        req = GenerateReqInput(
+            text=["p0", "p1"],
+            rid=["a", "b", "c", "d", "e", "f"],
+            sampling_params={"n": 3},
+        )
+        req.normalize_batch_and_arguments()
+
+        self.assertEqual(
+            [(req[k].text, req[k].rid) for k in range(6)],
+            [
+                ("p0", "a"),
+                ("p1", "d"),
+                ("p0", "b"),
+                ("p1", "e"),
+                ("p0", "c"),
+                ("p1", "f"),
+            ],
+        )
+
+    def test_rid_list_length_must_match_requests_or_samples(self):
+        req = GenerateReqInput(
+            text=["p0", "p1"], rid=["a", "b", "c"], sampling_params={"n": 3}
+        )
+        with self.assertRaisesRegex(
+            ValueError, "either 2 rids, one per request, or 6 rids, one per sample"
+        ):
+            req.normalize_batch_and_arguments()
+
+        without_sampling = GenerateReqInput(text=["p0", "p1"], rid=["a", "b", "c"])
+        with self.assertRaisesRegex(ValueError, "takes 2 rids, but got 3"):
+            without_sampling.normalize_batch_and_arguments()
+
+    def test_per_item_n_is_rejected(self):
+        """rid derivation lays out a rectangle, which a per-item n would break.
+
+        `_normalize_rid` emits one full pass over the prompts per sample. That
+        layout only lines up with the other expanded lists while every item of
+        the batch shares one n.
+        """
+        req = GenerateReqInput(text=["p0", "p1"], sampling_params=[{"n": 2}, {"n": 3}])
+        with self.assertRaisesRegex(
+            ValueError, "parallel_sample_num should be the same"
+        ):
+            req.normalize_batch_and_arguments()
 
     def test_audio_data_handling(self):
         """Test handling of audio_data."""
@@ -1091,17 +1192,6 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertTrue(req[0].return_prompt_token_ids)
         self.assertTrue(req[1].return_prompt_token_ids)
 
-    def test_regenerate_rid(self):
-        """Test the regenerate_rid method."""
-        req = GenerateReqInput(text="Hello")
-        req.normalize_batch_and_arguments()
-
-        original_rid = req.rid
-        new_rid = req.regenerate_rid()
-
-        self.assertNotEqual(original_rid, new_rid)
-        self.assertEqual(req.rid, new_rid)
-
     def test_error_cases(self):
         """Test various error cases."""
         # Test when neither text, input_ids, nor input_embeds is provided
@@ -1193,11 +1283,28 @@ class TestEmbeddingReqInputGetItem(CustomTestCase):
         with self.assertRaisesRegex(ValueError, "must match batch size"):
             req.normalize_batch_and_arguments()
 
-    def test_batch_requires_one_rid_per_item(self):
-        """A single rid cannot label a batch: each item is an independent request."""
+    def test_batch_expands_a_single_rid_per_item(self):
+        """One rid labels a whole batch, suffixed per item as GenerateReqInput does.
+
+        Before, a string rid hit `assert isinstance(self.rid, list)`, so any batch
+        embedding carrying an x-request-id header failed as a 500.
+        """
         req = EmbeddingReqInput(text=["first", "second"], rid="batch")
-        with self.assertRaisesRegex(ValueError, "requires 2 rids"):
-            req.normalize_batch_and_arguments()
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.rid, ["batch_0", "batch_1"])
+        self.assertEqual([req[0].rid, req[1].rid], ["batch_0", "batch_1"])
+
+    def test_single_request_rejects_a_rid_list(self):
+        """A non-batch request must not carry several rids.
+
+        rid keys `rid_to_state`, so a list reaches the dict and raises an
+        unhashable-type TypeError, which surfaces as a 500 rather than a 400.
+        """
+        for cls in (GenerateReqInput, EmbeddingReqInput):
+            with self.subTest(cls=cls.__name__):
+                req = cls(text="only one", rid=["a", "b"])
+                with self.assertRaisesRegex(ValueError, "takes one rid"):
+                    req.normalize_batch_and_arguments()
 
     def test_batch_rid_list_must_match_item_count(self):
         """Exact rid lists are preserved per item; a wrong length is rejected."""

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -15,6 +15,7 @@ Covers:
 
 import asyncio
 import unittest
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, Mock, patch
 
 import msgspec
@@ -726,6 +727,77 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
             asyncio.run(drive())
 
         self.assertFalse(tm.rid_to_state)
+
+
+class TestParallelSamplingRidDerivation(CustomTestCase):
+    """Parallel sampling must dispatch the rids normalization already derived.
+
+    The sample requests used to be re-keyed with fresh uuids, which left the
+    states pre-created for them (one per sub-request) without an owner: nothing
+    ever sent those rids to the scheduler, so the response path never removed
+    them. With a caller-supplied rid the leaked keys are deterministic, so the
+    next request carrying the same x-request-id collided on them.
+    """
+
+    def _dispatch(self, tm, rid, n, text="hi"):
+        dispatched = []
+
+        async def fake_tokenize(sub_obj):
+            return SimpleNamespace(
+                rid=sub_obj.rid,
+                input_ids=[1, 2, 3],
+                mm_inputs=None,
+                sampling_params=SimpleNamespace(max_new_tokens=8),
+                stream=False,
+                time_stats=None,
+            )
+
+        async def fake_wait(sub_obj, request=None):
+            # Stand in for the scheduler response path, the only remover.
+            tm.rid_to_state.pop(sub_obj.rid, None)
+            yield {"meta_info": {"id": sub_obj.rid}}
+
+        async def fake_send(tokenized):
+            dispatched.append(tokenized.rid)
+
+        tm._tokenize_one_request = fake_tokenize
+        tm._send_one_request = fake_send
+        tm._wait_one_response = fake_wait
+
+        obj = GenerateReqInput(text=text, rid=rid, sampling_params={"n": n})
+
+        async def run():
+            async for _ in tm.generate_request(obj):
+                pass
+
+        asyncio.run(run())
+        return dispatched
+
+    def test_samples_are_dispatched_under_the_caller_rid(self):
+        tm = _make_tm_for_generate(self)
+        dispatched = self._dispatch(tm, rid="R", n=4)
+        self.assertEqual(dispatched, ["R_0_prime", "R_0", "R_1", "R_2", "R_3"])
+
+    def test_parallel_sampling_leaves_no_state_behind(self):
+        tm = _make_tm_for_generate(self)
+        self._dispatch(tm, rid="R", n=4)
+        self.assertEqual(tm.rid_to_state, {})
+
+    def test_the_same_rid_can_be_reused_by_a_later_request(self):
+        """A router retry forwards the same x-request-id, so reuse must work."""
+        tm = _make_tm_for_generate(self)
+        for _ in range(3):
+            self._dispatch(tm, rid="R", n=4)
+        self.assertEqual(tm.rid_to_state, {})
+
+    def test_each_prompt_of_a_batch_gets_its_own_warmup_and_samples(self):
+        tm = _make_tm_for_generate(self)
+        dispatched = self._dispatch(tm, rid="R", n=2, text=["p0", "p1"])
+        self.assertEqual(
+            dispatched,
+            ["R_0_0_prime", "R_1_0_prime", "R_0_0", "R_0_1", "R_1_0", "R_1_1"],
+        )
+        self.assertEqual(tm.rid_to_state, {})
 
 
 class TestWaitOneResponseAfterStateFreed(CustomTestCase):


### PR DESCRIPTION
## Motivation

The engine takes the request id from the body `rid` field only — the sole header that
can set it today is `x-override-rid`, which is off unless
`SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES` is enabled — so a client- or
gateway-supplied `x-request-id` is silently ignored. Honoring it lets the caller and
the engine label the same request with the same id, which is what makes their logs
and metrics joinable for end-to-end tracing.

The case that needs this most is PD disaggregation. The router dispatches one
logical request to a prefill worker and to a decode worker; each normalizes
independently, so each mints its own rid, and router / prefill / decode logs and
latency metrics cannot be joined for exactly the requests where joining matters. Both
workers are handed the same `x-request-id` when the caller sets one, so honoring it on
the engine side is what makes the two sides agree.

Honoring the header is not sufficient on its own, though: parallel sampling replaced
every sub-request's rid with a fresh `uuid4()`, so whatever the caller sent had no
effect once `n > 1`. This PR does both halves — it consumes `x-request-id` on every
generation and embedding entry point, and makes the resulting rid survive batching
and parallel sampling.

## Modifications

### Reading the header

`resolve_rid_from_headers` in `python/sglang/srt/entrypoints/request_headers.py`
resolves the rids a request carries, next to the existing `apply_header_overrides`.
It reads **every** `x-request-id` line, not just the first: the field is
list-valued, and RFC 9110 §5.3 makes repeated lines equivalent to a single
comma-joined line, so header APIs that append instead of joining (Go's
`Header.Add`, `curl -H` twice) no longer lose values silently.

It is wired in at two levels:

- `OpenAIServingBase.extract_rid_from_header(raw_request, body_rid)` resolves the
  header against the body `rid` and is used by the `chat`, `completions`,
  `embeddings` and `classify` handlers in `_convert_to_internal_request`
  (`rid=self.extract_rid_from_header(raw_request, request.rid)`). It is safe when
  `raw_request` is `None`.
- `/generate` builds `GenerateReqInput` straight from the body and never looked at
  the headers, so the handler reads them itself. This runs *before*
  `apply_header_overrides`, so an explicit `x-override-rid` keeps priority.
  `/vertex_generate` reuses the same handler and follows automatically.

Precedence is `x-request-id` > body `rid` > generated. On the two endpoints that
also apply `apply_header_overrides` — chat completions (#35001) and `/generate`,
both behind `SGLANG_ENABLE_REQUEST_HEADER_OVERRIDES` — that runs last, so an
explicit `x-override-rid` still wins over the correlation id.

### Keeping the rid through parallel sampling

For `n > 1` nothing the caller supplied reached the scheduler, because
`_handle_batch_request` replaced every sub-request's rid with a fresh uuid, so
scheduler logs, per-request metrics and the OpenAI response `id` all carried an
unrelated value.

`_normalize_rid` now derives one rid per sub-request and keeps the caller's rid as
the prefix, so every engine request a caller's id fans out into is still findable
from that id. A suffix level is added only for a dimension that actually expands, so
a single prompt sampled `n` times stays `rid_0 .. rid_{n-1}` — unchanged from what
normalization already produced, and now actually dispatched.
`_handle_batch_request` consumes those rids instead of regenerating them.

The cache-warming request that parallel sampling issues before the samples keeps a
rid of its own inside the family, and now also its own `time_stats`: the tokenized
object it copies points at the first sample's state, which would otherwise absorb the
warmup's timings.

`_expand_inputs` took a `num` it never used; it now takes `n`, matching
`_normalize_rid(batch_size, n)`, which makes the shared source of the expansion
layout visible.

### Removed: `GenerateReqInput.regenerate_rid` / `EmbeddingReqInput.regenerate_rid`

Those two calls in `_handle_batch_request` were `regenerate_rid`'s only callers, so
the method is now dead and is removed from both request structs, along with its unit
test. `EmbeddingReqInput.regenerate_rid` had no caller even before this PR —
`EmbeddingReqInput` has no parallel sampling — so it is dropped as part of the same
cleanup rather than left as a lone twin.

This is the one API-visible removal here: the method was public, so any external
caller of `GenerateReqInput.regenerate_rid()` would break. No caller remains under
`python/sglang/srt`, including the offline `Engine` path; `multimodal_gen` defines an
unrelated method of the same name on its own request type, untouched. A rid is now
assigned once during normalization and never rewritten afterwards, so re-deriving one
mid-flight would detach a request from the state keyed under its original id.

### Bug fixes

**`rid_to_state` leak, `batch_size * (n - 1)` entries per request.**
`_init_req_state` pre-creates one state per sub-request, but once parallel sampling
re-keyed the samples nothing owned those entries: they were never sent to the
scheduler, so the response path never removed them. They leaked on the success path
and were only cleaned up on failure. With a caller-supplied rid the abandoned keys
are deterministic, so the *second* request carrying the same `x-request-id` with
`n > 1` failed with `Duplicate request ID detected`, and the third collided on the
first key as well. Verified before and after:

```
before                                after
req#1: ok, leaked=[R_1,R_2,R_3]       req#1: ok, leaked=[]
req#2: 400 Duplicate ... R_1          req#2: ok, leaked=[]
req#3: 400 Duplicate ... R_0          req#3: ok, leaked=[]
```

This matters for the router: a retry forwards the same `x-request-id`.

**Align `EmbeddingReqInput` with `GenerateReqInput` on a single rid.** On the
generate path a string rid has expanded across a batch to `rid_0 .. rid_{N-1}` since
[#7508](https://github.com/sgl-project/sglang/pull/7508), which added the expansion
there only; `EmbeddingReqInput` kept an `assert isinstance(self.rid, list)`, so
`input: [...]` carrying one rid raised an `AssertionError` — a 500, since only
`ValueError` is caught. It now expands the same way. A single rid is also the shape
a gateway sends: with
[#34108](https://github.com/sgl-project/sglang/pull/34108) it generates one id per
HTTP request, and by design it does not parse the body, so it cannot supply one rid
per batch item.

**A non-batch request accepted a rid list.** The list passed normalization untouched
and reached `self.rid_to_state[rid]`, raising
`TypeError: unhashable type: 'list'` — a 500, since only `ValueError` is caught.
Both request structs now reject it with a 400. Reachable from the body alone today
(`{"text": "hi", "rid": ["a", "b"]}`), independent of the header.

## `x-request-id` usage

The header is list-valued. Values may be comma separated on one line or split across
repeated lines; the two spellings are equivalent, so an intermediary that merges
them does not change the request.

A request may name itself once, once per batch item, or once per sample:

```http
# One id for the whole request. A batch expands it to req-1_0, req-1_1, ...;
# n samples expand it to req-1_0 .. req-1_{n-1}. This is what a gateway sends.
x-request-id: req-1

# One id per batch item, for `input`/`prompt` arrays. Samples are derived from
# each, so item "a" with n=3 becomes a_0, a_1, a_2.
x-request-id: a, b

# One id per sample, for a single prompt sampled 3 times.
x-request-id: req-1-0, req-1-1, req-1-2

# One id per sample of a batch, grouped by prompt: the first n ids belong to the
# first input. Two inputs sampled 3 times each, all on one line.
x-request-id: req-a-0, req-a-1, req-a-2, req-b-0, req-b-1, req-b-2

# The same request, one line per input. Easier to read, and identical on the wire.
x-request-id: req-a-0, req-a-1, req-a-2      # first input
x-request-id: req-b-0, req-b-1, req-b-2      # second input
```

Rules:

- Blank entries are dropped, and a header that names nothing falls back to the body
  `rid`, then to a generated id.
- A batch accepts `batch_size` ids or `batch_size * n` ids; any other count is a 400
  that names the accepted counts.
- Ids must be unique within a request.
- Naming every sample yourself gives up the shared prefix, so the ids of one client
  request are no longer findable from a single value.

### Behaviour changes visible to clients

The engine sets no response header; the rid surfaces in the body as `meta_info.id`,
which the OpenAI layer copies into the response `id`. Non-streaming responses carry a
single top-level `id`, taken from the first sub-request, so a request that names
several rids still shows only the first. Streaming chunks each carry their own
sub-request's id, so chunks of different choices differ — that was already true, with
unrelated uuids.

| Case | Before | After |
|---|---|---|
| `n > 1`, header `R`, non-streaming | `id` was a random uuid | `R_0` |
| `n > 1`, header `R`, streaming | chunks carried unrelated uuids | chunks carry `R_0` … `R_{n-1}`, sharing the caller's prefix |
| `n > 1`, no header | random uuid | `<uuid>_0` |
| batch + `n > 1`, header `R` | random uuid | `R_0_0` (first input, first sample) |
| `n == 1`, any shape | — | unchanged |
| `/generate`, `n > 1` | the returned list held one unrelated uuid per sub-request | each element's id is derived from the caller's id |

## Accuracy Tests

Not applicable: no kernel or model forward code is touched.

## Speed Tests and Profiling

Not applicable. On the tokenizer-manager path the change is one f-string per
sub-request, and it removes work rather than adding it — `batch_size * (n - 1)`
`ReqState` objects and their `asyncio.Event`s are no longer allocated per request.

## Tests

| File | Cases |
|---|---|
| `test/registered/cpu/test_request_headers.py` | Header parsing: absent/blank, one value, blank entries dropped, comma list, repeated lines equal to one joined line, wire order preserved |
| `test/registered/unit/entrypoints/test_generate_rid_header.py` (new) | `/generate` honors the header; body rid survives without it; `x-override-rid` wins |
| `test/registered/unit/entrypoints/openai/test_serving_completions.py` | Header overrides the body rid; falls back to the body rid without a header |
| `test/registered/unit/entrypoints/openai/test_serving_embedding.py` | Batch expands one header rid; batch takes per-item rids from the header |
| `test/registered/unit/managers/test_io_struct.py` | Derived rid pairs with its own prompt; suffix only for dimensions that expand; caller rids stay prefixes; caller-named samples reordered; length rules; per-item `n` rejected; single request rejects a rid list; embedding batch expands one rid |
| `test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py` | Samples dispatched under the caller's rid; no state left behind; the same rid reusable by a later request; per-prompt warmup and samples in a batch |

The `/generate` wiring case and the state-reuse case were both confirmed to fail
before the change.

## Known issues, out of scope

Pre-existing, not introduced here, and worth separate PRs:

- **`video_data` / `audio_data` misalign for one prompt with several media and
  `n > 1`.** The list is repeated by `parallel_sample_num` without a length check, so
  each sample receives one medium instead of all of them. `image_data` in the same
  shape raises instead.
- **`_normalize_bootstrap_params` does not validate its list length**, so a
  gateway-injected `bootstrap_room` array of length `n` for a chat `n > 1` request
  silently degrades to every sample sharing `room[0]`.
- **Per-request `logprob` / `custom_logit_processor` lists are rejected when
  `n > 1`**, so those settings cannot vary across a sampled batch.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34082332177](https://github.com/sgl-project/sglang/actions/runs/34082332177)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34082331986](https://github.com/sgl-project/sglang/actions/runs/34082331986)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34082332175](https://github.com/sgl-project/sglang/actions/runs/34082332175)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->