### PR TITLE
[CP][AMD] Add runtime TP/CP switching for MLA

### DIFF
--- a/benchmark/dynamic_parallel/README.md
+++ b/benchmark/dynamic_parallel/README.md
@@ -15,7 +15,8 @@ python -m sglang.benchmark.dynamic_parallel \
   --prefix-hit-ratios 0,0.5,0.9 \
   --output-length 32 \
   --repeats 3 \
-  --mode-server-args-json '{"dcp":"--dcp-comm-backend a2a"}' \
+  --mode-server-args-json '{"dcp":"--dcp-comm-backend a2a","dynamic":"--dynamic-attn-parallel-min-prefill-tokens 8192"}' \
+  --server-env-json '{"SGLANG_JIT_DEEPGEMM_PRECOMPILE":"0","SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK":"32768","MORI_SHMEM_HEAP_SIZE":"16G"}' \
   --strict-parity \
   --result-file dynamic_parallel.jsonl
 ```
@@ -34,4 +35,18 @@ Useful ROCm overrides:
 ```
 
 The `dynamic` mode expects the runtime selector flags implemented by this
-feature branch. `--dynamic-include-dcp` additionally enables decode DCP.
+feature branch. Dynamic prefill remains TP unless
+`--dynamic-attn-parallel-min-prefill-tokens` is supplied through the dynamic
+mode's server arguments; choose it from a measured crossover grid.
+`--dynamic-include-dcp` additionally enables decode DCP over replicated KV,
+which preserves the CP prefill path. Compact striped KV is an
+explicit experiment; add `--dynamic-striped-min-context 8192` to assign prompts
+at or above that length to the striped pool. The harness also disables radix
+cache for this opt-in path because cross-residency eviction accounting is not
+yet supported. Striped prefill currently uses the full-prefix DCP assembly path
+and should be benchmarked separately.
+
+For MLA CP with MoRI, set
+`SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK >= --chunked-prefill-size`.
+Large values also need a larger `MORI_SHMEM_HEAP_SIZE`; 16 GiB is sufficient
+for the 32K-token example above on MI355X.

--- a/benchmark/dynamic_parallel/README.md
+++ b/benchmark/dynamic_parallel/README.md
@@ -1,0 +1,37 @@
+# Dynamic attention-parallel benchmark
+
+This benchmark compares TP, prefill CP, DCP, and runtime-selected execution on
+the same deterministic request grid. It records latency, cache hits, selected
+mode metrics, generated token IDs, and output-token logprobs in JSONL.
+
+Run it from the repository root:
+
+```bash
+python -m sglang.benchmark.dynamic_parallel \
+  --model-path deepseek-ai/DeepSeek-V3.1 \
+  --modes tp,prefill_cp,dcp,dynamic \
+  --batch-sizes 1,8,32 \
+  --input-lengths 1024,4096,16384,32768 \
+  --prefix-hit-ratios 0,0.5,0.9 \
+  --output-length 32 \
+  --repeats 3 \
+  --mode-server-args-json '{"dcp":"--dcp-comm-backend a2a"}' \
+  --strict-parity \
+  --result-file dynamic_parallel.jsonl
+```
+
+Each grid point flushes the cache. For nonzero prefix-hit ratios, the driver
+first primes the exact shared prefix, then submits one batched `/generate`
+request. Put `tp` first when comparing several modes so later records receive a
+parity result against the matching TP record.
+
+Useful ROCm overrides:
+
+```bash
+--attention-backend aiter \
+--server-env-json '{"SGLANG_JIT_DEEPGEMM_PRECOMPILE":"0"}' \
+--extra-server-args '--page-size 1 --disable-piecewise-cuda-graph'
+```
+
+The `dynamic` mode expects the runtime selector flags implemented by this
+feature branch. `--dynamic-include-dcp` additionally enables decode DCP.

--- a/python/sglang/benchmark/dynamic_parallel.py
+++ b/python/sglang/benchmark/dynamic_parallel.py
@@ -122,6 +122,7 @@ def build_mode_server_args(
     cp_size: int,
     dcp_size: int,
     dynamic_include_dcp: bool,
+    dynamic_striped_min_context: int | None = None,
 ) -> list[str]:
     """Return only the mode-specific server arguments."""
 
@@ -151,6 +152,12 @@ def build_mode_server_args(
                 "--disable-overlap-schedule",
                 "--no-dcp-replicate-q-proj",
             ]
+            if dynamic_striped_min_context is not None:
+                args += [
+                    "--dynamic-attn-parallel-striped-min-context",
+                    str(dynamic_striped_min_context),
+                    "--disable-radix-cache",
+                ]
         return args
     raise AssertionError(f"unhandled deployment mode: {mode}")
 
@@ -378,6 +385,7 @@ def _build_server_command(args, mode: DeploymentMode) -> list[str]:
         cp_size=args.cp_size,
         dcp_size=args.dcp_size,
         dynamic_include_dcp=args.dynamic_include_dcp,
+        dynamic_striped_min_context=args.dynamic_striped_min_context,
     )
     command += shlex.split(args.extra_server_args)
     mode_args = args.mode_server_args.get(mode.value, "")
@@ -576,6 +584,15 @@ def parse_args(argv: Sequence[str] | None = None):
     parser.add_argument("--logprob-tolerance", type=float, default=0.1)
     parser.add_argument("--strict-parity", action="store_true")
     parser.add_argument("--dynamic-include-dcp", action="store_true")
+    parser.add_argument(
+        "--dynamic-striped-min-context",
+        type=int,
+        default=None,
+        help=(
+            "Opt in to compact striped KV residency at this prompt length. "
+            "The default keeps replicated KV so prefill can use CP before decode DCP."
+        ),
+    )
     parser.add_argument("--launch-module", default="sglang.launch_server")
     parser.add_argument("--extra-server-args", default="")
     parser.add_argument(
@@ -597,6 +614,11 @@ def parse_args(argv: Sequence[str] | None = None):
     }
     if args.output_length <= 0 or args.repeats <= 0:
         parser.error("--output-length and --repeats must be positive")
+    if (
+        args.dynamic_striped_min_context is not None
+        and args.dynamic_striped_min_context <= 0
+    ):
+        parser.error("--dynamic-striped-min-context must be positive")
     if args.tp_size % args.cp_size != 0 or args.tp_size % args.dcp_size != 0:
         parser.error("--cp-size and --dcp-size must divide --tp-size")
     if args.modes[0] is not DeploymentMode.TP and len(args.modes) > 1:

--- a/python/sglang/benchmark/dynamic_parallel.py
+++ b/python/sglang/benchmark/dynamic_parallel.py
@@ -1,0 +1,612 @@
+"""Benchmark TP/CP/DCP execution modes on an identical request grid.
+
+The driver launches one SGLang server per mode, runs deterministic batched
+``/generate`` requests, and writes JSON records that can be compared across
+deployments.  It deliberately uses token IDs instead of text so input lengths
+and shared-prefix ratios are exact.
+
+Example:
+
+.. code-block:: bash
+
+    python -m sglang.benchmark.dynamic_parallel \
+      --model-path deepseek-ai/DeepSeek-V3.1 \
+      --modes tp,prefill_cp,dcp,dynamic \
+      --batch-sizes 1,8,32 \
+      --input-lengths 1024,4096,16384,32768 \
+      --prefix-hit-ratios 0,0.5,0.9 \
+      --output-length 32 \
+      --result-file dynamic_parallel.jsonl
+
+This is an experiment harness, not a CI benchmark.  Large DeepSeek checkpoints
+need a machine with enough accelerators for the requested TP size.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import shlex
+import subprocess
+import sys
+import time
+from collections.abc import Iterable, Sequence
+from dataclasses import asdict, dataclass
+from enum import Enum
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import requests
+from typing_extensions import Self
+
+
+class DeploymentMode(str, Enum):
+    TP = "tp"
+    PREFILL_CP = "prefill_cp"
+    DCP = "dcp"
+    DYNAMIC = "dynamic"
+
+
+@dataclass(frozen=True)
+class GridCase:
+    batch_size: int
+    input_length: int
+    output_length: int
+    prefix_hit_ratio: float
+    repeat: int
+
+    @property
+    def key(self) -> str:
+        return (
+            f"bs={self.batch_size}/in={self.input_length}/out={self.output_length}/"
+            f"prefix={self.prefix_hit_ratio:.6f}/repeat={self.repeat}"
+        )
+
+
+@dataclass
+class RunRecord:
+    mode: str
+    case: dict[str, Any]
+    case_key: str
+    wall_latency_s: float
+    cached_tokens: list[int]
+    prompt_tokens: list[int]
+    completion_tokens: list[int]
+    output_ids: list[list[int]]
+    output_logprobs: list[list[float]]
+    mode_metrics_before: dict[str, float]
+    mode_metrics_after: dict[str, float]
+    server_info: dict[str, Any]
+    parity: dict[str, Any] | None = None
+
+
+def _csv_ints(value: str) -> tuple[int, ...]:
+    values = tuple(int(item.strip()) for item in value.split(",") if item.strip())
+    if not values or any(item <= 0 for item in values):
+        raise argparse.ArgumentTypeError("expected comma-separated positive integers")
+    return values
+
+
+def _csv_floats(value: str) -> tuple[float, ...]:
+    values = tuple(float(item.strip()) for item in value.split(",") if item.strip())
+    if not values or any(item < 0.0 or item >= 1.0 for item in values):
+        raise argparse.ArgumentTypeError(
+            "expected comma-separated ratios in the range [0, 1)"
+        )
+    return values
+
+
+def _csv_modes(value: str) -> tuple[DeploymentMode, ...]:
+    try:
+        modes = tuple(
+            DeploymentMode(item.strip()) for item in value.split(",") if item.strip()
+        )
+    except ValueError as exc:
+        valid = ", ".join(mode.value for mode in DeploymentMode)
+        raise argparse.ArgumentTypeError(
+            f"unknown mode; expected one of: {valid}"
+        ) from exc
+    if not modes:
+        raise argparse.ArgumentTypeError("at least one mode is required")
+    if len(set(modes)) != len(modes):
+        raise argparse.ArgumentTypeError("modes must not contain duplicates")
+    return modes
+
+
+def build_mode_server_args(
+    mode: DeploymentMode,
+    *,
+    cp_size: int,
+    dcp_size: int,
+    dynamic_include_dcp: bool,
+) -> list[str]:
+    """Return only the mode-specific server arguments."""
+
+    cp_args = [
+        "--enable-prefill-cp",
+        "--cp-strategy",
+        "zigzag",
+        "--attention-context-parallel-size",
+        str(cp_size),
+        "--enable-cp-decode-attn-tp",
+    ]
+    if mode is DeploymentMode.TP:
+        return []
+    if mode is DeploymentMode.PREFILL_CP:
+        return cp_args
+    if mode is DeploymentMode.DCP:
+        return ["--dcp-size", str(dcp_size)]
+    if mode is DeploymentMode.DYNAMIC:
+        args = [*cp_args, "--enable-dynamic-attn-parallel"]
+        if dynamic_include_dcp:
+            args += [
+                "--dcp-size",
+                str(dcp_size),
+                "--dynamic-attn-parallel-enable-dcp",
+                "--page-size",
+                "1",
+                "--disable-overlap-schedule",
+                "--no-dcp-replicate-q-proj",
+            ]
+        return args
+    raise AssertionError(f"unhandled deployment mode: {mode}")
+
+
+def build_inputs(
+    *,
+    batch_size: int,
+    input_length: int,
+    prefix_hit_ratio: float,
+    seed: int,
+    token_id_low: int,
+    token_id_high: int,
+) -> tuple[list[int], list[list[int]]]:
+    """Build exact-length inputs with a deterministic shared prefix."""
+
+    if batch_size <= 0 or input_length <= 0:
+        raise ValueError("batch_size and input_length must be positive")
+    if not 0.0 <= prefix_hit_ratio < 1.0:
+        raise ValueError("prefix_hit_ratio must be in [0, 1)")
+    if token_id_low < 0 or token_id_high <= token_id_low:
+        raise ValueError("invalid token ID range")
+
+    prefix_length = math.floor(input_length * prefix_hit_ratio)
+    rng = np.random.default_rng(seed)
+    shared_prefix = rng.integers(
+        token_id_low, token_id_high, size=prefix_length, dtype=np.int64
+    ).tolist()
+    suffix_length = input_length - prefix_length
+    inputs = []
+    for _ in range(batch_size):
+        suffix = rng.integers(
+            token_id_low, token_id_high, size=suffix_length, dtype=np.int64
+        ).tolist()
+        inputs.append([*shared_prefix, *suffix])
+    return shared_prefix, inputs
+
+
+def _normalize_batch_response(payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, dict):
+        return [payload]
+    if isinstance(payload, list) and all(isinstance(item, dict) for item in payload):
+        return payload
+    raise RuntimeError(f"unexpected /generate response shape: {type(payload).__name__}")
+
+
+def _extract_logprobs(meta_info: dict[str, Any]) -> list[float]:
+    values = meta_info.get("output_token_logprobs") or []
+    result = []
+    for value in values:
+        if isinstance(value, (list, tuple)):
+            result.append(float(value[0]))
+        elif isinstance(value, dict):
+            result.append(float(value.get("logprob", float("nan"))))
+        else:
+            result.append(float(value))
+    return result
+
+
+def _extract_cache_tokens(meta_info: dict[str, Any]) -> int:
+    details = meta_info.get("cached_tokens_details") or {}
+    if details:
+        return int(
+            sum(int(details.get(tier) or 0) for tier in ("device", "host", "storage"))
+        )
+    return int(meta_info.get("cached_tokens") or 0)
+
+
+def _parse_prometheus_metrics(text: str) -> dict[str, float]:
+    """Extract only dynamic-parallel metrics from Prometheus text."""
+
+    result: dict[str, float] = {}
+    for line in text.splitlines():
+        if not line or line.startswith("#"):
+            continue
+        name, separator, raw_value = line.rpartition(" ")
+        if not separator or "dynamic_attn_parallel" not in name:
+            continue
+        try:
+            result[name] = float(raw_value)
+        except ValueError:
+            continue
+    return result
+
+
+class ServerProcess:
+    def __init__(
+        self,
+        *,
+        command: Sequence[str],
+        base_url: str,
+        log_file: Path,
+        launch_timeout_s: int,
+        env: dict[str, str],
+    ):
+        self.command = list(command)
+        self.base_url = base_url
+        self.log_file = log_file
+        self.launch_timeout_s = launch_timeout_s
+        self.env = env
+        self.process: subprocess.Popen | None = None
+        self._log_handle = None
+
+    def __enter__(self) -> Self:
+        self.log_file.parent.mkdir(parents=True, exist_ok=True)
+        self._log_handle = self.log_file.open("w")
+        self.process = subprocess.Popen(
+            self.command,
+            stdout=self._log_handle,
+            stderr=subprocess.STDOUT,
+            env=self.env,
+        )
+        deadline = time.monotonic() + self.launch_timeout_s
+        while time.monotonic() < deadline:
+            if self.process.poll() is not None:
+                raise RuntimeError(
+                    f"server exited with code {self.process.returncode}; "
+                    f"see {self.log_file}"
+                )
+            try:
+                response = requests.get(f"{self.base_url}/health", timeout=5)
+                if response.status_code == 200:
+                    return self
+            except requests.RequestException:
+                pass
+            time.sleep(2)
+        raise TimeoutError(
+            f"server was not healthy within {self.launch_timeout_s}s; "
+            f"see {self.log_file}"
+        )
+
+    def __exit__(self, exc_type, exc, traceback):
+        if self.process is not None:
+            from sglang.srt.utils import kill_process_tree
+
+            kill_process_tree(self.process.pid)
+            self.process = None
+        if self._log_handle is not None:
+            self._log_handle.close()
+            self._log_handle = None
+
+    def flush_cache(self):
+        response = requests.post(
+            f"{self.base_url}/flush_cache",
+            params={"timeout": 60},
+            timeout=90,
+        )
+        response.raise_for_status()
+
+    def server_info(self) -> dict[str, Any]:
+        response = requests.get(f"{self.base_url}/server_info", timeout=30)
+        response.raise_for_status()
+        info = response.json()
+        keep = (
+            "max_total_num_tokens",
+            "max_req_len",
+            "tp_size",
+            "dp_size",
+            "dcp_size",
+            "attn_cp_size",
+        )
+        return {key: info[key] for key in keep if key in info}
+
+    def mode_metrics(self) -> dict[str, float]:
+        try:
+            response = requests.get(f"{self.base_url}/metrics", timeout=30)
+            response.raise_for_status()
+        except requests.RequestException:
+            return {}
+        return _parse_prometheus_metrics(response.text)
+
+    def generate(
+        self,
+        *,
+        input_ids: list[int] | list[list[int]],
+        output_length: int,
+        return_logprob: bool,
+        timeout_s: int,
+    ) -> tuple[float, list[dict[str, Any]]]:
+        payload = {
+            "input_ids": input_ids,
+            "sampling_params": {
+                "temperature": 0,
+                "max_new_tokens": output_length,
+                "ignore_eos": True,
+            },
+            "return_logprob": return_logprob,
+            "top_logprobs_num": 0,
+            "logprob_start_len": -1,
+            "return_prompt_token_ids": False,
+        }
+        start = time.perf_counter()
+        response = requests.post(
+            f"{self.base_url}/generate", json=payload, timeout=timeout_s
+        )
+        latency = time.perf_counter() - start
+        response.raise_for_status()
+        return latency, _normalize_batch_response(response.json())
+
+
+def _build_server_command(args, mode: DeploymentMode) -> list[str]:
+    command = [
+        sys.executable,
+        "-m",
+        args.launch_module,
+        "--model-path",
+        args.model_path,
+        "--host",
+        "127.0.0.1",
+        "--port",
+        str(args.port),
+        "--tp-size",
+        str(args.tp_size),
+        "--attention-backend",
+        args.attention_backend,
+        "--mem-fraction-static",
+        str(args.mem_fraction_static),
+        "--random-seed",
+        str(args.seed),
+        "--enable-cache-report",
+        "--enable-metrics",
+        "--trust-remote-code",
+    ]
+    command += build_mode_server_args(
+        mode,
+        cp_size=args.cp_size,
+        dcp_size=args.dcp_size,
+        dynamic_include_dcp=args.dynamic_include_dcp,
+    )
+    command += shlex.split(args.extra_server_args)
+    mode_args = args.mode_server_args.get(mode.value, "")
+    command += shlex.split(mode_args)
+    return command
+
+
+def _run_case(
+    server: ServerProcess,
+    *,
+    mode: DeploymentMode,
+    case: GridCase,
+    args,
+) -> RunRecord:
+    shared_prefix, inputs = build_inputs(
+        batch_size=case.batch_size,
+        input_length=case.input_length,
+        prefix_hit_ratio=case.prefix_hit_ratio,
+        seed=args.seed + case.repeat,
+        token_id_low=args.token_id_low,
+        token_id_high=args.token_id_high,
+    )
+    server.flush_cache()
+    if shared_prefix:
+        server.generate(
+            input_ids=shared_prefix,
+            output_length=1,
+            return_logprob=False,
+            timeout_s=args.request_timeout_s,
+        )
+
+    metrics_before = server.mode_metrics()
+    latency, outputs = server.generate(
+        input_ids=inputs,
+        output_length=case.output_length,
+        return_logprob=True,
+        timeout_s=args.request_timeout_s,
+    )
+    metrics_after = server.mode_metrics()
+
+    output_ids: list[list[int]] = []
+    output_logprobs: list[list[float]] = []
+    cached_tokens: list[int] = []
+    prompt_tokens: list[int] = []
+    completion_tokens: list[int] = []
+    for output in outputs:
+        meta = output.get("meta_info") or {}
+        output_ids.append([int(token_id) for token_id in output.get("output_ids", [])])
+        output_logprobs.append(_extract_logprobs(meta))
+        cached_tokens.append(_extract_cache_tokens(meta))
+        prompt_tokens.append(int(meta.get("prompt_tokens") or 0))
+        completion_tokens.append(int(meta.get("completion_tokens") or 0))
+
+    return RunRecord(
+        mode=mode.value,
+        case=asdict(case),
+        case_key=case.key,
+        wall_latency_s=latency,
+        cached_tokens=cached_tokens,
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        output_ids=output_ids,
+        output_logprobs=output_logprobs,
+        mode_metrics_before=metrics_before,
+        mode_metrics_after=metrics_after,
+        server_info=server.server_info(),
+    )
+
+
+def compare_with_tp(
+    baseline: RunRecord, candidate: RunRecord, *, logprob_tolerance: float
+) -> dict[str, Any]:
+    if baseline.case_key != candidate.case_key:
+        raise ValueError("cannot compare records from different grid cases")
+    exact_output_match = baseline.output_ids == candidate.output_ids
+    max_logprob_delta = 0.0
+    comparable_values = 0
+    shape_match = len(baseline.output_logprobs) == len(candidate.output_logprobs)
+    if shape_match:
+        for baseline_row, candidate_row in zip(
+            baseline.output_logprobs, candidate.output_logprobs
+        ):
+            if len(baseline_row) != len(candidate_row):
+                shape_match = False
+                continue
+            for baseline_value, candidate_value in zip(baseline_row, candidate_row):
+                if math.isnan(baseline_value) or math.isnan(candidate_value):
+                    continue
+                comparable_values += 1
+                max_logprob_delta = max(
+                    max_logprob_delta, abs(baseline_value - candidate_value)
+                )
+    return {
+        "baseline_mode": DeploymentMode.TP.value,
+        "exact_output_match": exact_output_match,
+        "logprob_shape_match": shape_match,
+        "comparable_logprobs": comparable_values,
+        "max_logprob_delta": max_logprob_delta,
+        "logprob_tolerance": logprob_tolerance,
+        "passed": (
+            exact_output_match
+            and shape_match
+            and comparable_values > 0
+            and max_logprob_delta <= logprob_tolerance
+        ),
+    }
+
+
+def _iter_cases(args) -> Iterable[GridCase]:
+    for repeat in range(args.repeats):
+        for batch_size in args.batch_sizes:
+            for input_length in args.input_lengths:
+                for prefix_hit_ratio in args.prefix_hit_ratios:
+                    yield GridCase(
+                        batch_size=batch_size,
+                        input_length=input_length,
+                        output_length=args.output_length,
+                        prefix_hit_ratio=prefix_hit_ratio,
+                        repeat=repeat,
+                    )
+
+
+def run(args) -> int:
+    result_path = Path(args.result_file)
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    log_dir = Path(args.log_dir)
+    baseline_records: dict[str, RunRecord] = {}
+    failed_parity = False
+
+    for mode in args.modes:
+        command = _build_server_command(args, mode)
+        print(f"[{mode.value}] launching: {shlex.join(command)}", flush=True)
+        env = os.environ.copy()
+        env.update(args.server_env)
+        with ServerProcess(
+            command=command,
+            base_url=f"http://127.0.0.1:{args.port}",
+            log_file=log_dir / f"{mode.value}.log",
+            launch_timeout_s=args.launch_timeout_s,
+            env=env,
+        ) as server:
+            for case in _iter_cases(args):
+                record = _run_case(server, mode=mode, case=case, args=args)
+                if mode is DeploymentMode.TP:
+                    baseline_records[case.key] = record
+                elif case.key in baseline_records:
+                    record.parity = compare_with_tp(
+                        baseline_records[case.key],
+                        record,
+                        logprob_tolerance=args.logprob_tolerance,
+                    )
+                    failed_parity = failed_parity or not record.parity["passed"]
+                with result_path.open("a") as output_file:
+                    output_file.write(json.dumps(asdict(record), sort_keys=True) + "\n")
+                print(
+                    f"[{mode.value}] {case.key}: {record.wall_latency_s:.6f}s"
+                    + (
+                        f", parity={record.parity['passed']}"
+                        if record.parity is not None
+                        else ""
+                    ),
+                    flush=True,
+                )
+
+    if args.strict_parity and failed_parity:
+        return 2
+    return 0
+
+
+def parse_args(argv: Sequence[str] | None = None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-path", required=True)
+    parser.add_argument(
+        "--modes",
+        type=_csv_modes,
+        default=(DeploymentMode.TP, DeploymentMode.PREFILL_CP),
+    )
+    parser.add_argument("--batch-sizes", type=_csv_ints, default=(1, 8, 32))
+    parser.add_argument("--input-lengths", type=_csv_ints, default=(1024, 4096, 16384))
+    parser.add_argument(
+        "--prefix-hit-ratios", type=_csv_floats, default=(0.0, 0.5, 0.9)
+    )
+    parser.add_argument("--output-length", type=int, default=32)
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--tp-size", type=int, default=8)
+    parser.add_argument("--cp-size", type=int, default=8)
+    parser.add_argument("--dcp-size", type=int, default=8)
+    parser.add_argument("--attention-backend", default="aiter")
+    parser.add_argument("--mem-fraction-static", type=float, default=0.88)
+    parser.add_argument("--port", type=int, default=30000)
+    parser.add_argument("--seed", type=int, default=1)
+    parser.add_argument("--token-id-low", type=int, default=100)
+    parser.add_argument("--token-id-high", type=int, default=10000)
+    parser.add_argument("--launch-timeout-s", type=int, default=2400)
+    parser.add_argument("--request-timeout-s", type=int, default=7200)
+    parser.add_argument("--logprob-tolerance", type=float, default=0.1)
+    parser.add_argument("--strict-parity", action="store_true")
+    parser.add_argument("--dynamic-include-dcp", action="store_true")
+    parser.add_argument("--launch-module", default="sglang.launch_server")
+    parser.add_argument("--extra-server-args", default="")
+    parser.add_argument(
+        "--mode-server-args-json",
+        default="{}",
+        help='Per-mode extra args, e.g. \'{"dcp": "--dcp-comm-backend a2a"}\'.',
+    )
+    parser.add_argument(
+        "--server-env-json",
+        default="{}",
+        help="Environment variables merged into the server process environment.",
+    )
+    parser.add_argument("--result-file", default="dynamic_parallel.jsonl")
+    parser.add_argument("--log-dir", default="dynamic_parallel_logs")
+    args = parser.parse_args(argv)
+    args.mode_server_args = json.loads(args.mode_server_args_json)
+    args.server_env = {
+        str(key): str(value) for key, value in json.loads(args.server_env_json).items()
+    }
+    if args.output_length <= 0 or args.repeats <= 0:
+        parser.error("--output-length and --repeats must be positive")
+    if args.tp_size % args.cp_size != 0 or args.tp_size % args.dcp_size != 0:
+        parser.error("--cp-size and --dcp-size must divide --tp-size")
+    if args.modes[0] is not DeploymentMode.TP and len(args.modes) > 1:
+        parser.error("put 'tp' first when running multiple modes for parity comparison")
+    return args
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    return run(parse_args(argv))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -26,6 +26,20 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.kernels.ops.kvcache.kv_indices import (
+    get_num_kv_index_blocks_flashmla,
+    get_num_page_per_block_flashmla,
+)
+from sglang.srt.utils import is_hip
+
+# tl.constexpr, not a plain float: a @triton.jit body cannot read a non-constexpr
+# global. Use _LOG2E.value where the host side needs the number.
+_LOG2E = tl.constexpr(1.4426950408889634)
+
+# waves_per_eu keeps more wavefronts resident on the tiny grids these DCP
+# kernels launch; matrix_instr_nonkdim matches the convention in verify_splitkv.
+_AMD_LAUNCH_KWARGS = {"waves_per_eu": 4, "matrix_instr_nonkdim": 16} if is_hip() else {}
+
 
 # ---------------------------------------------------------------------------
 # KV-index build (PR #25090, Triton/MHA): per-rank local KV indices.
@@ -87,6 +101,7 @@ def create_mla_kv_page_table_for_dcp(
     PHYSICAL_PAGE_SIZE: tl.constexpr,
     DCP_SIZE: tl.constexpr,
     DCP_RANK: tl.constexpr,
+    KV_LOC_SCALE: tl.constexpr,
     PAGES_PER_BLOCK: tl.constexpr,
 ):
     req = tl.program_id(0)
@@ -102,7 +117,7 @@ def create_mla_kv_page_table_for_dcp(
         mask=mask,
         other=0,
     )
-    physical_pages = virtual_locs // DCP_SIZE // PHYSICAL_PAGE_SIZE
+    physical_pages = virtual_locs // KV_LOC_SCALE // PHYSICAL_PAGE_SIZE
     tl.store(
         block_kv_indices_ptr + req * block_table_stride + page_offsets,
         physical_pages,
@@ -664,3 +679,577 @@ def _lse_weighted_combine_cpu(
 
     combined = (partial_outputs * weights.unsqueeze(-1)).sum(dim=0)
     return combined
+
+
+# ---------------------------------------------------------------------------
+# aiter MLA DCP: page-table build, KV page packing, and the split-KV reduce.
+# ---------------------------------------------------------------------------
+
+
+def build_dcp_page_table(
+    req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    local_kv_lens: torch.Tensor,
+    bs: int,
+    max_pages: int,
+    page_size: int,
+    dcp_size: int,
+    dcp_rank: int,
+    kv_loc_scale: Optional[int] = None,
+    out: Optional[torch.Tensor] = None,
+):
+    """Build this rank's PAGE table for aiter's ``mla_decode_fwd``.
+
+    Args:
+        req_to_token:     [max_reqs, max_context_len] virtual token locations
+        req_pool_indices: [B] row of req_to_token per request
+        local_kv_lens:    [B] this rank's shard length per request, in TOKENS
+                          (the kernel's ``seqused_k``); the table itself is
+                          indexed in PAGES
+        bs:               number of requests
+        max_pages:        columns to allocate, i.e. the per-graph page bound
+        page_size:        PHYSICAL page size; the allocator's virtual page is
+                          ``page_size * dcp_size``
+        dcp_size:         DCP world size
+        dcp_rank:         this rank
+        out:              [B, max_pages] int32 to fill, allocated if None
+
+    Returns:
+        [B, max_pages] int32 page table (``out`` when provided)
+    """
+    if out is None:
+        out = torch.zeros(bs, max_pages, dtype=torch.int32, device=req_to_token.device)
+    if max_pages == 0:
+        return out
+    pages_per_block = get_num_page_per_block_flashmla(page_size)
+    kv_loc_scale = dcp_size if kv_loc_scale is None else kv_loc_scale
+    create_mla_kv_page_table_for_dcp[
+        (bs, get_num_kv_index_blocks_flashmla(max_pages, page_size))
+    ](
+        req_to_token,
+        req_pool_indices,
+        local_kv_lens,
+        out,
+        req_to_token.stride(0),
+        out.stride(0),
+        PHYSICAL_PAGE_SIZE=page_size,
+        DCP_SIZE=dcp_size,
+        DCP_RANK=dcp_rank,
+        KV_LOC_SCALE=kv_loc_scale,
+        PAGES_PER_BLOCK=pages_per_block,
+    )
+    return out
+
+
+@triton.jit
+def _pack_dcp_kv_pages_kernel(
+    src_ptr,  # [n_src, 1, D] assembled dcp_kv_buffer
+    dst_ptr,  # [n_pages * PAGE, 1, D] paged staging buffer
+    src_idx_ptr,  # [total] dcp_kv_indices: sequence position -> src row
+    dst_idx_ptr,  # [total] sequence position -> padded/paged dst row
+    D: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    row = tl.program_id(0)
+    src = tl.load(src_idx_ptr + row).to(tl.int64)
+    dst = tl.load(dst_idx_ptr + row).to(tl.int64)
+    offs = tl.arange(0, BLOCK)
+    mask = offs < D
+    tl.store(
+        dst_ptr + dst * D + offs,
+        tl.load(src_ptr + src * D + offs, mask=mask),
+        mask=mask,
+    )
+
+
+def pack_dcp_kv_into_pages(
+    kv_buffer: torch.Tensor,
+    kv_indptr: torch.Tensor,
+    kv_indices: torch.Tensor,
+    bs: int,
+    page_size: int,
+):
+    """Repack the assembled ``dcp_kv_buffer`` into pages for ``mla_prefill_fwd``.
+
+    Args:
+        kv_buffer:  [total_tokens, 1, D] the all-gathered full-sequence latent KV
+        kv_indptr:  [bs + 1] per-request boundaries into ``kv_indices``
+        kv_indices: [total_tokens] sequence position -> row of ``kv_buffer``
+        bs:         number of requests
+        page_size:  staging page size (``_DCP_PREFILL_PAGE_SIZE``, independent of
+                    the KV pool's --page-size)
+
+    Returns:
+        paged_kv:     [n_pages, page_size, 1, D] page-aligned per request
+        block_tables: [bs, max_pages] int32
+    """
+    total, _, dim = kv_buffer.shape[0], kv_buffer.shape[1], kv_buffer.shape[-1]
+    device = kv_buffer.device
+    lens = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int64)
+    pages = (lens + page_size - 1) // page_size
+    page_start = torch.cumsum(pages, dim=0) - pages
+    # sequence position -> row in the padded buffer
+    shift = page_start * page_size - kv_indptr[:bs].to(torch.int64)
+    n_tokens = int(kv_indptr[bs].item())
+    dst_idx = torch.repeat_interleave(shift, lens) + torch.arange(
+        n_tokens, device=device, dtype=torch.int64
+    )
+
+    n_pages = int(pages.sum().item())
+    # zeros, not empty: the kernel reads the whole last page of a sequence and masks
+    # by seqused_k, so uninitialized tail rows could feed NaNs into the QK GEMM.
+    paged = torch.zeros(
+        (n_pages * page_size, 1, dim), dtype=kv_buffer.dtype, device=device
+    )
+    if n_tokens > 0:
+        _pack_dcp_kv_pages_kernel[(n_tokens,)](
+            kv_buffer,
+            paged,
+            kv_indices,
+            dst_idx,
+            D=dim,
+            BLOCK=triton.next_power_of_2(dim),
+        )
+    max_pages = int(pages.max().item()) if bs > 0 else 0
+    block_tables = page_start[:, None] + torch.arange(
+        max_pages, device=device, dtype=torch.int64
+    )
+    return paged.view(-1, page_size, 1, dim), block_tables.to(torch.int32)
+
+
+@triton.jit
+def _dcp_reduce_kv_segments_kernel(
+    out_ptr,  # [num_tokens, num_query_heads, KV_LORA_RANK]
+    lse_ptr,  # [num_tokens, num_query_heads] (base-2)
+    segm_output_ptr,  # [num_tokens, num_query_heads, NUM_SEGMENTS, KV_LORA_RANK]
+    segm_max_ptr,  # [num_tokens, num_query_heads, NUM_SEGMENTS]
+    segm_expsum_ptr,  # [num_tokens, num_query_heads, NUM_SEGMENTS]
+    seq_lens_ptr,  # [num_tokens] local (this-rank shard) kv length per token
+    num_query_heads: tl.constexpr,
+    out_stride0: tl.int64,
+    out_stride1: tl.int64,
+    lse_stride0: tl.int64,
+    TILE_SIZE: tl.constexpr,
+    KV_LORA_RANK: tl.constexpr,
+    NUM_SEGMENTS_PER_SEQ: tl.constexpr,
+):
+    tok = tl.program_id(0)
+    head = tl.program_id(1)
+
+    seq_len = tl.load(seq_lens_ptr + tok)
+
+    # A rank owns no committed KV for a request whose prefix is shorter than the
+    # rank index, so an all-zero shard length is a normal input here (the planner
+    # clamps local_kv_lens to min 0, not min 1). Emit the identity element of the
+    # LSE merge -- out = 0 with lse = -inf, which dcp_lse_combine_base2 and
+    # cp_lse_ag_out_rs_mla both weight to zero.
+    #
+    # This has to be an early return, not a mask on the result: with seq_len 0
+    # tiles_per_segment below is 0, so act_num_segments divides by zero, and the
+    # NaNs that follow cannot be cleaned up downstream -- the merge zeroes the
+    # WEIGHT via nan_to_num, but NaN * 0 is still NaN, so a single empty shard
+    # poisons the merged output of an otherwise healthy batch.
+    if seq_len == 0:
+        tl.store(
+            out_ptr
+            + tok * out_stride0
+            + head * out_stride1
+            + tl.arange(0, KV_LORA_RANK),
+            tl.zeros([KV_LORA_RANK], dtype=out_ptr.type.element_ty),
+        )
+        tl.store(lse_ptr + tok * lse_stride0 + head, float("-inf"))
+        return
+
+    # aiter picks the same segment count regardless of seq_len; only the first
+    # act_num_segments hold valid data (the rest of the empty() buffer is garbage).
+    tiles_per_segment = tl.cdiv(seq_len, NUM_SEGMENTS_PER_SEQ * TILE_SIZE)
+    act_num_segments = tl.cdiv(seq_len, tiles_per_segment * TILE_SIZE)
+    segm_mask = tl.arange(0, NUM_SEGMENTS_PER_SEQ) < act_num_segments
+
+    seg_off = (
+        tok.to(tl.int64) * (num_query_heads * NUM_SEGMENTS_PER_SEQ)
+        + head * NUM_SEGMENTS_PER_SEQ
+        + tl.arange(0, NUM_SEGMENTS_PER_SEQ)
+    )
+    segm_max = tl.load(segm_max_ptr + seg_off, mask=segm_mask, other=float("-inf"))
+    overall_max = tl.max(segm_max)
+
+    segm_expsum = tl.load(segm_expsum_ptr + seg_off, mask=segm_mask, other=0.0)
+    segm_expsum = segm_expsum * tl.math.exp2(segm_max - overall_max)
+    overall_expsum = tl.sum(segm_expsum)
+
+    out_off = (
+        tok.to(tl.int64) * (num_query_heads * NUM_SEGMENTS_PER_SEQ * KV_LORA_RANK)
+        + head * (NUM_SEGMENTS_PER_SEQ * KV_LORA_RANK)
+        + tl.arange(0, NUM_SEGMENTS_PER_SEQ)[:, None] * KV_LORA_RANK
+        + tl.arange(0, KV_LORA_RANK)[None, :]
+    )
+    segm_output = tl.load(segm_output_ptr + out_off, mask=segm_mask[:, None], other=0.0)
+    segm_output = segm_output * tl.math.exp2(segm_max - overall_max)[:, None]
+    acc = tl.sum(segm_output, axis=0)
+    acc = tl.where(overall_expsum == 0.0, 0.0, acc / overall_expsum)
+
+    # base-2 LSE, matching correct_attn_out / cp_lse_ag_out_rs_mla.
+    lse = tl.where(
+        overall_expsum == 0.0, float("-inf"), overall_max + tl.log2(overall_expsum)
+    )
+
+    tl.store(
+        out_ptr + tok * out_stride0 + head * out_stride1 + tl.arange(0, KV_LORA_RANK),
+        acc.to(out_ptr.type.element_ty),
+    )
+    tl.store(lse_ptr + tok * lse_stride0 + head, lse)
+
+
+def dcp_reduce_kv_segments(
+    segm_output: torch.Tensor,
+    segm_max: torch.Tensor,
+    segm_expsum: torch.Tensor,
+    seq_lens: torch.Tensor,
+    tile_size: int,
+    out_dtype: torch.dtype,
+):
+    """Reduce ``mla_decode_fwd(skip_reduce=True)`` partials to (out, base-2 lse).
+
+    Args:
+        segm_output: [num_tokens, H, NUM_SEGMENTS, KV_LORA_RANK] unnormalized
+                     per-segment output
+        segm_max:    [num_tokens, H, NUM_SEGMENTS] per-segment score max
+        segm_expsum: [num_tokens, H, NUM_SEGMENTS] per-segment softmax denominator
+        seq_lens:    [num_tokens] this rank's shard length per token; 0 is legal
+                     and yields the merge identity (out 0, lse -inf)
+        tile_size:   kernel TILE_SIZE (== the paged block_size handed to
+                     mla_decode_fwd), which sets how segments were sized
+        out_dtype:   dtype of the returned output
+
+    Returns:
+        out: [num_tokens, H, KV_LORA_RANK] in ``out_dtype``
+        lse: [num_tokens, H] float32, base-2
+
+    The segments are a split-KV device INSIDE one rank, not the cross-rank DCP
+    shards -- see the section header above. aiter's own reduce writes only the
+    merged output, so this one exists to additionally emit the LSE that the
+    cross-rank merge needs as a weight.
+    """
+    num_tokens, num_heads, num_segments, kv_lora_rank = segm_output.shape
+    out = torch.empty(
+        num_tokens, num_heads, kv_lora_rank, dtype=out_dtype, device=segm_output.device
+    )
+    lse = torch.empty(
+        num_tokens, num_heads, dtype=torch.float32, device=segm_output.device
+    )
+    _dcp_reduce_kv_segments_kernel[(num_tokens, num_heads)](
+        out,
+        lse,
+        segm_output,
+        segm_max,
+        segm_expsum,
+        seq_lens,
+        num_query_heads=num_heads,
+        out_stride0=out.stride(0),
+        out_stride1=out.stride(1),
+        lse_stride0=lse.stride(0),
+        TILE_SIZE=tile_size,
+        KV_LORA_RANK=kv_lora_rank,
+        NUM_SEGMENTS_PER_SEQ=num_segments,
+    )
+    return out, lse
+
+
+@triton.jit
+def _dense_causal_mla_window_kernel(
+    q_ptr,  # [bs * q_len, H, NOPE + PE]
+    k_ptr,  # [bs * q_len, 1, NOPE + PE] latent KV; v aliases its first NOPE cols
+    out_ptr,  # [bs * q_len, H, NOPE]
+    lse_ptr,  # [bs * q_len, H] fp32, base-2
+    scaling,
+    q_stride_t: tl.int64,
+    q_stride_h: tl.int64,
+    k_stride_t: tl.int64,
+    out_stride_t: tl.int64,
+    out_stride_h: tl.int64,
+    lse_stride_t: tl.int64,
+    lse_stride_h: tl.int64,
+    Q_LEN: tl.constexpr,
+    L_EXT: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    BLOCK_NOPE: tl.constexpr,
+    PE_DIM: tl.constexpr,
+    BLOCK_PE: tl.constexpr,
+):
+    """Dense causal attention over one request's in-hand window, one program
+    per (request, head).
+
+    The latent KV is read once as nope+rope: the rope half only feeds the QK
+    dot, and the nope half is BOTH the QK nope term and V (the MLA absorb
+    form), so there is no separate V load.
+    """
+    b = tl.program_id(0).to(tl.int64)
+    h = tl.program_id(1).to(tl.int64)
+
+    offs_l = tl.arange(0, L_EXT)
+    mask_l = offs_l < Q_LEN
+    offs_n = tl.arange(0, BLOCK_NOPE)
+    mask_n = offs_n < NOPE_DIM
+    offs_p = tl.arange(0, BLOCK_PE)
+    mask_p = offs_p < PE_DIM
+
+    # Window position i of request b is row b * Q_LEN + i.
+    row = b * Q_LEN + offs_l
+
+    q_nope = tl.load(
+        q_ptr + row[:, None] * q_stride_t + h * q_stride_h + offs_n[None, :],
+        mask=mask_l[:, None] & mask_n[None, :],
+        other=0.0,
+    )
+    q_rope = tl.load(
+        q_ptr + row[:, None] * q_stride_t + h * q_stride_h + NOPE_DIM + offs_p[None, :],
+        mask=mask_l[:, None] & mask_p[None, :],
+        other=0.0,
+    )
+    k_nope = tl.load(
+        k_ptr + row[:, None] * k_stride_t + offs_n[None, :],
+        mask=mask_l[:, None] & mask_n[None, :],
+        other=0.0,
+    )
+    k_rope = tl.load(
+        k_ptr + row[:, None] * k_stride_t + NOPE_DIM + offs_p[None, :],
+        mask=mask_l[:, None] & mask_p[None, :],
+        other=0.0,
+    )
+
+    # scores[i, j] = q_i . k_j, split nope + rope so nothing is padded (both
+    # halves are powers of two for MLA).
+    #
+    # tl.dot, NOT an elementwise mul-reduce over [L_EXT, L_EXT, D]: that form
+    # reads better and verify_mla uses it for the same block, but its live set
+    # grows as L_EXT^2 * D and spills hard once L_EXT passes 8. Measured on
+    # gfx950 at bs 64: 78 us at q_len 8 but 1925 us at q_len 16, against 233 us
+    # for the torch version. tl.dot is flat across the same range.
+    qk = tl.dot(q_nope, tl.trans(k_nope), out_dtype=tl.float32)
+    qk += tl.dot(q_rope, tl.trans(k_rope), out_dtype=tl.float32)
+    qk *= scaling
+
+    # Causal within the window: query i sees key j iff j <= i.
+    causal = (offs_l[None, :] <= offs_l[:, None]) & mask_l[None, :] & mask_l[:, None]
+    qk = tl.where(causal, qk, float("-inf"))
+
+    m = tl.max(qk, 1)
+    p = tl.exp(qk - m[:, None])
+    denom = tl.sum(p, 1)
+    # PV in fp32. Casting p down to bf16 for an MFMA dot is the usual trick, but
+    # it costs real accuracy at short prefixes here (max_abs over the unit-test
+    # grid rises 1.95e-3 -> 2.91e-3 at prefix 0), eating most of the margin the
+    # tolerance tiers were calibrated with. The window is a handful of rows, so
+    # the slower fp32 path is affordable.
+    acc = tl.dot(p, k_nope.to(tl.float32), out_dtype=tl.float32) / denom[:, None]
+
+    tl.store(
+        out_ptr + row[:, None] * out_stride_t + h * out_stride_h + offs_n[None, :],
+        acc.to(out_ptr.dtype.element_ty),
+        mask=mask_l[:, None] & mask_n[None, :],
+    )
+    # Natural-log LSE rebased to base-2, which is what the DCP merges consume.
+    tl.store(
+        lse_ptr + row * lse_stride_t + h * lse_stride_h,
+        (m + tl.log(denom)) * _LOG2E,
+        mask=mask_l,
+    )
+
+
+def dense_causal_mla_attn_base2(
+    q: torch.Tensor,
+    k_window: torch.Tensor,
+    scaling: float,
+    bs: int,
+    q_len: int,
+    kv_lora_rank: int,
+):
+    """Dense causal MLA attention over one in-hand ``q_len``-token window.
+
+    Args:
+        q:            [bs * q_len, num_heads, kv_lora_rank + qk_rope_head_dim]
+        k_window:     [bs * q_len, 1, kv_lora_rank + qk_rope_head_dim] latent KV
+                      of the window tokens, in query order; ``v`` is its first
+                      ``kv_lora_rank`` columns (MLA absorb form), not a separate
+                      tensor
+        scaling:      softmax scale
+        bs:           number of requests
+        q_len:        window length per request (``gamma + 1``)
+        kv_lora_rank: nope width, i.e. where the rope half starts
+
+    Returns:
+        out: [bs * q_len, num_heads, kv_lora_rank] float32
+        lse: [bs * q_len, num_heads] float32, base-2
+    """
+    n_rows, num_heads, head_dim = q.shape
+    pe_dim = head_dim - kv_lora_rank
+    out = torch.empty(
+        (n_rows, num_heads, kv_lora_rank), dtype=torch.float32, device=q.device
+    )
+    lse = torch.empty((n_rows, num_heads), dtype=torch.float32, device=q.device)
+    if n_rows == 0:
+        return out, lse
+
+    k2 = k_window.view(n_rows, -1)
+    _dense_causal_mla_window_kernel[(bs, num_heads)](
+        q,
+        k2,
+        out,
+        lse,
+        scaling,
+        q.stride(0),
+        q.stride(1),
+        k2.stride(0),
+        out.stride(0),
+        out.stride(1),
+        lse.stride(0),
+        lse.stride(1),
+        Q_LEN=q_len,
+        # tl.dot needs at least 16 rows/cols; rows past q_len are masked off.
+        L_EXT=max(16, triton.next_power_of_2(q_len)),
+        NOPE_DIM=kv_lora_rank,
+        BLOCK_NOPE=triton.next_power_of_2(kv_lora_rank),
+        PE_DIM=pe_dim,
+        BLOCK_PE=triton.next_power_of_2(pe_dim),
+        **_AMD_LAUNCH_KWARGS,
+    )
+    return out, lse
+
+
+@triton.jit
+def _dcp_lse_combine_pair_kernel(
+    out_ptr,  # [tokens, heads, DIM]
+    out_lse_ptr,  # [tokens, heads] fp32, base-2
+    a_out_ptr,
+    a_lse_ptr,
+    b_out_ptr,
+    b_lse_ptr,
+    out_stride_t: tl.int64,
+    out_stride_h: tl.int64,
+    a_out_stride_t: tl.int64,
+    a_out_stride_h: tl.int64,
+    b_out_stride_t: tl.int64,
+    b_out_stride_h: tl.int64,
+    out_lse_stride_t: tl.int64,
+    out_lse_stride_h: tl.int64,
+    a_lse_stride_t: tl.int64,
+    a_lse_stride_h: tl.int64,
+    b_lse_stride_t: tl.int64,
+    b_lse_stride_h: tl.int64,
+    DIM: tl.constexpr,
+    BLOCK_DIM: tl.constexpr,
+):
+    """Merge two partial attentions over DISJOINT key sets, given base-2 LSEs.
+
+    Grid: (tokens, heads), one program per output row.
+    """
+    tok = tl.program_id(0).to(tl.int64)
+    head = tl.program_id(1).to(tl.int64)
+
+    lse_a = tl.load(a_lse_ptr + tok * a_lse_stride_t + head * a_lse_stride_h).to(
+        tl.float32
+    )
+    lse_b = tl.load(b_lse_ptr + tok * b_lse_stride_t + head * b_lse_stride_h).to(
+        tl.float32
+    )
+    # A partial that saw no keys carries -inf. Fold NaN and +inf in with it
+    # rather than letting either reach the weights.
+    lse_a = tl.where((lse_a != lse_a) | (lse_a == float("inf")), float("-inf"), lse_a)
+    lse_b = tl.where((lse_b != lse_b) | (lse_b == float("inf")), float("-inf"), lse_b)
+
+    m = tl.maximum(lse_a, lse_b)
+    # Both partials empty: m is -inf and (-inf) - (-inf) would be NaN. Re-centre
+    # on 0 so both weights come out exp2(-inf) == 0, and let the guards below
+    # turn that into out 0 / lse -inf. The two comparable kernels in this repo
+    # (merge_state_kernel, _dcp_lse_combine_kernel) both return NaN here.
+    m_safe = tl.where(m == float("-inf"), 0.0, m)
+    w_a = tl.math.exp2(lse_a - m_safe)
+    w_b = tl.math.exp2(lse_b - m_safe)
+    denom = w_a + w_b
+
+    offs = tl.arange(0, BLOCK_DIM)
+    mask = offs < DIM
+    o_a = tl.load(
+        a_out_ptr + tok * a_out_stride_t + head * a_out_stride_h + offs,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    o_b = tl.load(
+        b_out_ptr + tok * b_out_stride_t + head * b_out_stride_h + offs,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    acc = o_a * w_a + o_b * w_b
+    # Guard the divisor as well as the result: both branches of a tl.where are
+    # evaluated, so dividing by a zero denominator would still produce NaN.
+    acc = tl.where(denom == 0.0, 0.0, acc / tl.where(denom == 0.0, 1.0, denom))
+
+    tl.store(
+        out_ptr + tok * out_stride_t + head * out_stride_h + offs,
+        acc.to(out_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    lse = tl.where(denom == 0.0, float("-inf"), m_safe + tl.log2(denom))
+    tl.store(out_lse_ptr + tok * out_lse_stride_t + head * out_lse_stride_h, lse)
+
+
+def dcp_lse_combine_base2(
+    out_a: torch.Tensor,
+    lse_a: torch.Tensor,
+    out_b: torch.Tensor,
+    lse_b: torch.Tensor,
+    out_dtype: torch.dtype,
+):
+    """Merge two partial attentions over DISJOINT key sets, given base-2 LSEs.
+
+    Args:
+        out_a:     [tokens, heads, dim] first partial's output
+        lse_a:     [tokens, heads] its base-2 LSE; ``-inf`` means it saw no keys
+                   (what dcp_reduce_kv_segments writes for an empty shard), and
+                   weights it to 0
+        out_b:     [tokens, heads, dim] second partial's output
+        lse_b:     [tokens, heads] its base-2 LSE
+        out_dtype: dtype of the returned output
+
+    Returns:
+        out: [tokens, heads, dim] in ``out_dtype``; 0 where both partials are
+             empty, rather than NaN
+        lse: [tokens, heads] float32, base-2; ``-inf`` where both are empty
+
+    This is the two-input case of ``dcp_lse_combine_triton`` above. It is a
+    separate kernel because that one takes a stacked ``[N, B, H, D]`` tensor,
+    so reusing it here would mean a ``torch.stack`` copy of both partials on
+    every call.
+    """
+    n_tokens, n_heads, dim = out_a.shape
+    out = torch.empty((n_tokens, n_heads, dim), dtype=out_dtype, device=out_a.device)
+    lse = torch.empty((n_tokens, n_heads), dtype=torch.float32, device=out_a.device)
+    if n_tokens == 0:
+        return out, lse
+
+    _dcp_lse_combine_pair_kernel[(n_tokens, n_heads)](
+        out,
+        lse,
+        out_a,
+        lse_a,
+        out_b,
+        lse_b,
+        out.stride(0),
+        out.stride(1),
+        out_a.stride(0),
+        out_a.stride(1),
+        out_b.stride(0),
+        out_b.stride(1),
+        lse.stride(0),
+        lse.stride(1),
+        lse_a.stride(0),
+        lse_a.stride(1),
+        lse_b.stride(0),
+        lse_b.stride(1),
+        DIM=dim,
+        BLOCK_DIM=triton.next_power_of_2(dim),
+        **_AMD_LAUNCH_KWARGS,
+    )
+    return out, lse

--- a/python/sglang/kernels/ops/kvcache/mla_buffer.py
+++ b/python/sglang/kernels/ops/kvcache/mla_buffer.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.jit.utils import is_arch_support_pdl
+from sglang.srt.attn_parallel import kv_storage_dcp_size
 from sglang.srt.runtime_context import get_parallel
 
 
@@ -92,6 +93,8 @@ def set_mla_kv_buffer_triton(
     loc: torch.Tensor,
     cache_k_nope: torch.Tensor,
     cache_k_rope: torch.Tensor,
+    dcp_world_size: int | None = None,
+    dcp_rank: int | None = None,
 ):
     """Dispatch MLA paged-KV scatter writes to the fastest available path.
 
@@ -124,13 +127,18 @@ def set_mla_kv_buffer_triton(
     )
 
     n_loc = loc.numel()
+    parallel = get_parallel()
+    storage_dcp_size = (
+        kv_storage_dcp_size(parallel) if dcp_world_size is None else dcp_world_size
+    )
+    storage_dcp_rank = parallel.attn_dcp_rank if dcp_rank is None else dcp_rank
     nope_bytes = cache_k_nope.shape[-1] * cache_k_nope.element_size()
     rope_bytes = cache_k_rope.shape[-1] * cache_k_rope.element_size()
     if (
         n_loc >= _TMA_BULK_STORE_MIN_LOCS
         and is_arch_support_pdl()
         and can_use_set_mla_kv_buffer(nope_bytes, rope_bytes)
-        and not get_parallel().dcp_enabled
+        and storage_dcp_size == 1
     ):
         jit_set_mla_kv_buffer(kv_buffer, loc, cache_k_nope, cache_k_rope)
         return
@@ -157,8 +165,8 @@ def set_mla_kv_buffer_triton(
         nope_dim,
         rope_dim,
         BLOCK=BLOCK,
-        DCP_RANK=get_parallel().attn_dcp_rank,
-        DCP_WORLD_SIZE=get_parallel().attn_dcp_size,
+        DCP_RANK=(storage_dcp_rank if storage_dcp_size > 1 else 0),
+        DCP_WORLD_SIZE=storage_dcp_size,
         **pdl_kwargs,
     )
 

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -576,6 +576,34 @@ def _kimi_k3_overrides(server_args: Any, hf_config: Any) -> dict:
             overrides["speculative_attention_mode"] = "decode"
 
         prefill_backend, decode_backend = attention_backends_of(server_args)
+        if decode_backend == "aiter":
+            # ag_rs merges the per-rank partials by default; --dcp-comm-backend
+            # a2a avoids its grouped self-P2P RCCL path (sgl-project/sglang#32831).
+            # Either prefill backend is KV-compatible: both write the same latent KV.
+            prefill_ab = "triton" if prefill_backend == "triton" else "aiter"
+            dcp_comm = (
+                server_args.dcp_comm_backend
+                if server_args.dcp_comm_backend in ("a2a", "fi_a2a")
+                else "ag_rs"
+            )
+            logger.info(
+                "Kimi-K3 DCP uses aiter MLA decode: "
+                f"prefill={prefill_backend!r} -> {prefill_ab!r}, "
+                f"decode={decode_backend!r} -> 'aiter' (dcp_comm_backend -> {dcp_comm!r})."
+            )
+            overrides.update(
+                prefill_attention_backend=prefill_ab,
+                decode_attention_backend="aiter",
+                dcp_comm_backend=dcp_comm,
+            )
+            # ag_rs needs the head-dim Q all-gather; a2a/fi_a2a project locally.
+            if server_args.dcp_replicate_q_proj is None:
+                overrides["dcp_replicate_q_proj"] = dcp_comm in ("a2a", "fi_a2a")
+            if server_args.page_size is None:
+                # The decode KV tile is the paged block size, and under DCP the
+                # allocator's page is page_size * dcp_size. 32 measured fastest.
+                overrides["page_size"] = 32
+            return overrides
         if decode_backend == "cutedsl_mla" or decode_backend is None:
             _require_kimi_k3_cutedsl_dcp_support()
             logger.info(
@@ -808,10 +836,16 @@ def _deepseek_family_overrides(server_args: Any, hf_config: Any) -> dict:
             overrides["enable_dp_attention"] = True
             # TODO(kpham-sgl) Supports moe_dense_tp_size != 1.
             overrides["moe_dense_tp_size"] = 1
-            overrides["moe_a2a_backend"] = "deepep"
+            # DeepEP is CUDA-only. Mori implements the same all-to-all contract
+            # for ROCm and keeps routed-expert ownership unchanged across CP/TP
+            # batches.
+            overrides["moe_a2a_backend"] = "mori" if is_hip() else "deepep"
             overrides["ep_size"] = server_args.tp_size
             logger.warning(
-                "For MLA CP, we have the following restrictions: moe_dense_tp_size == 1, moe_a2a_backend == deepep, ep_size == tp_size, batch_size == 1"
+                "For MLA CP, we have the following restrictions: "
+                "moe_dense_tp_size == 1, "
+                f"moe_a2a_backend == {overrides['moe_a2a_backend']}, "
+                "ep_size == tp_size, batch_size == 1"
             )
             # FIXME(kpham-sgl): Keep attn_tp_size == 1 under MLA CP.
             # DSACPLayerCommunicator does not all-reduce attention-TP

--- a/python/sglang/srt/attn_parallel.py
+++ b/python/sglang/srt/attn_parallel.py
@@ -1,0 +1,155 @@
+"""Batch-level attention-parallel mode selection.
+
+The module intentionally has no model, scheduler, or CP-package imports so it
+can be used by both ``ScheduleBatch`` and ``ForwardBatch`` without cycles.
+Process groups and weight residency remain static; only the execution axis is
+selected per finalized batch.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from enum import IntEnum
+from typing import Any
+
+
+class AttnParallelMode(IntEnum):
+    """Attention execution mode stamped once on a scheduler batch."""
+
+    TP = 0
+    CP = 1
+    DCP = 2
+
+    @property
+    def is_cp(self) -> bool:
+        return self is AttnParallelMode.CP
+
+    @property
+    def is_dcp(self) -> bool:
+        return self is AttnParallelMode.DCP
+
+
+class KvResidency(IntEnum):
+    """Physical MLA KV placement for a request or server-level PoC."""
+
+    REPLICATED = 0
+    STRIPED = 1
+    TRANSITIONING = 2
+
+
+@dataclass(frozen=True)
+class AttnParallelDecision:
+    mode: AttnParallelMode
+    veto_reason: str | None = None
+
+
+def resolve_kv_residency(
+    parallel: Any, forward_batch: Any | None = None
+) -> KvResidency:
+    if forward_batch is not None:
+        residency = getattr(forward_batch, "kv_residency", None)
+        if residency is not None:
+            return KvResidency(residency)
+    if bool(getattr(parallel, "dynamic_attn_parallel_enable_dcp", False)):
+        # Functional dynamic-DCP PoC: retain a complete local KV view so TP can
+        # be selected on the next batch without an online all-gather.
+        return KvResidency.REPLICATED
+    if bool(getattr(parallel, "dcp_enabled", False)):
+        return KvResidency.STRIPED
+    return KvResidency.REPLICATED
+
+
+def kv_storage_dcp_size(parallel: Any, forward_batch: Any | None = None) -> int:
+    return (
+        int(getattr(parallel, "attn_dcp_size", 1))
+        if resolve_kv_residency(parallel, forward_batch) is KvResidency.STRIPED
+        else 1
+    )
+
+
+def strategy_min_tokens(strategy: str | None, cp_size: int) -> tuple[int, int]:
+    """Return ``(batch_floor, per_request_floor)`` for a CP layout."""
+
+    if strategy == "zigzag":
+        return 2 * cp_size, 2 * cp_size
+    if strategy == "interleave":
+        return cp_size, 1
+    return 0, 0
+
+
+def select_attn_parallel_mode(
+    *,
+    forward_mode: Any,
+    extend_seq_lens: Sequence[int] | None,
+    num_tokens: int,
+    strategy: str | None,
+    cp_size: int,
+    min_prefill_tokens: int | None = None,
+    allow_mixed: bool = False,
+    enable_decode_dcp: bool = False,
+    dcp_size: int = 1,
+    decode_seq_lens: Sequence[int] | None = None,
+    min_decode_context: int = 8192,
+    kv_residency: KvResidency | None = None,
+) -> AttnParallelDecision:
+    """Select TP or prefill CP from immutable, rank-consistent batch facts."""
+
+    mode_name = getattr(forward_mode, "name", str(forward_mode))
+    if mode_name == "DECODE":
+        if not enable_decode_dcp or dcp_size <= 1:
+            if kv_residency is KvResidency.STRIPED:
+                return AttnParallelDecision(AttnParallelMode.DCP)
+            return AttnParallelDecision(AttnParallelMode.TP, "dcp_disabled")
+        if kv_residency is KvResidency.STRIPED:
+            return AttnParallelDecision(AttnParallelMode.DCP)
+        max_context = max(
+            (int(length) for length in (decode_seq_lens or ())), default=0
+        )
+        if max_context < min_decode_context:
+            return AttnParallelDecision(AttnParallelMode.TP, "short_context")
+        return AttnParallelDecision(AttnParallelMode.DCP)
+
+    if kv_residency is KvResidency.STRIPED:
+        # Compact KV is not a complete local prefix, so the current CP-v2
+        # paged-attention path cannot consume it directly. The Aiter DCP
+        # prefill path assembles the full prefix while keeping TP heads.
+        return AttnParallelDecision(AttnParallelMode.TP, "striped_prefill")
+
+    if cp_size <= 1 or strategy not in ("zigzag", "interleave"):
+        return AttnParallelDecision(AttnParallelMode.TP, "disabled")
+
+    is_cp_extend = bool(
+        getattr(forward_mode, "is_context_parallel_extend", lambda: False)()
+    )
+    if not is_cp_extend:
+        return AttnParallelDecision(AttnParallelMode.TP, "not_extend")
+    if mode_name == "MIXED" and not allow_mixed:
+        return AttnParallelDecision(AttnParallelMode.TP, "mixed")
+    if bool(getattr(forward_mode, "is_target_verify", lambda: False)()) or bool(
+        getattr(forward_mode, "is_draft_extend_v2", lambda: False)()
+    ):
+        return AttnParallelDecision(AttnParallelMode.TP, "speculative")
+
+    lengths = (
+        [int(length) for length in extend_seq_lens]
+        if extend_seq_lens is not None
+        else None
+    )
+    logical_tokens = sum(lengths) if lengths is not None else int(num_tokens)
+    batch_floor, request_floor = strategy_min_tokens(strategy, cp_size)
+    if logical_tokens < batch_floor:
+        return AttnParallelDecision(AttnParallelMode.TP, "too_few_tokens")
+
+    threshold = max(batch_floor, int(min_prefill_tokens or batch_floor))
+    if logical_tokens < threshold:
+        return AttnParallelDecision(AttnParallelMode.TP, "below_threshold")
+
+    if (
+        strategy == "zigzag"
+        and lengths is not None
+        and any(length < request_floor for length in lengths)
+    ):
+        return AttnParallelDecision(AttnParallelMode.TP, "short_request")
+
+    return AttnParallelDecision(AttnParallelMode.CP)

--- a/python/sglang/srt/batch_overlap/two_batch_overlap.py
+++ b/python/sglang/srt/batch_overlap/two_batch_overlap.py
@@ -740,6 +740,8 @@ class TboForwardBatchPreparer:
             "can_run_dp_breakable_cuda_graph",
             "dp_padding_mode",
             "global_forward_mode",
+            "attn_parallel_mode",
+            "kv_residency",
             "is_prefill_only",
             "spec_algorithm",
             "capture_hidden_mode",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1192,7 +1192,11 @@ class ModelConfig:
         total_num_kv_heads = self.get_total_num_kv_heads()
         if self.is_draft_model:
             dcp_size = 1
-        kv_tensor_parallel_size = tensor_parallel_size // dcp_size
+        # Runtime attention-TP can be carved from a replicated prefill-CP
+        # topology, where configured attn_tp_size is 1 while effective decode
+        # TP/DCP is larger. MLA has one latent KV head, so clamp the static
+        # divisor instead of producing a zero-width group.
+        kv_tensor_parallel_size = max(1, tensor_parallel_size // dcp_size)
         return max(1, total_num_kv_heads // kv_tensor_parallel_size)
 
     def get_swa_num_kv_heads(self, tensor_parallel_size) -> int:

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -822,6 +822,9 @@ class Envs:
     # the SHUFFLE KV layout that enables pa_decode_gluon for full-attn
     # decode without runtime permutes.
     SGLANG_AITER_KV_CACHE_LAYOUT = EnvStr("nhd")
+    # fp8 kv-cache under aiter MLA DCP. Validated for Kimi-K3 on gfx950 only,
+    # so it stays opt-in rather than becoming the default.
+    SGLANG_EXPERIMENTAL_AITER_DCP_FP8 = EnvBool(False)
     SGLANG_ROCM_FUSED_DECODE_MLA = EnvBool(False)
     SGLANG_ROCM_DISABLE_LINEARQUANT = EnvBool(False)
     USE_ROCM_AITER_ROPE_BACKEND = EnvStr("0")

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -350,7 +350,10 @@ class AiterAttnBackend(AttentionBackend):
 
             # Under DCP, Q is all-gathered, so this operates on the gathered
             # head count num_head * dcp_world_size. No-op otherwise.
-            _gathered_num_head = self.num_head * self.dcp_world_size
+            _dcp_local_num_head = self.num_head
+            if get_parallel().dynamic_attn_parallel_enable_dcp:
+                _dcp_local_num_head //= get_parallel().attn_cp_size
+            _gathered_num_head = _dcp_local_num_head * self.dcp_world_size
             self.mla_kernel_num_head_padded = (
                 16 if _gathered_num_head < 16 else _gathered_num_head
             )
@@ -515,8 +518,13 @@ class AiterAttnBackend(AttentionBackend):
         )
 
     def make_mla_prefill_ps_meta_data_buffer(
-        self, batch_size: int, max_qlen: int, qlen_granularity: int
+        self,
+        batch_size: int,
+        max_qlen: int,
+        qlen_granularity: int,
+        num_head_k: Optional[int] = None,
     ):
+        num_head_k = self.num_kv_head if num_head_k is None else num_head_k
         (
             (work_meta_data_size, work_meta_data_type),
             (work_indptr_size, work_indptr_type),
@@ -526,7 +534,7 @@ class AiterAttnBackend(AttentionBackend):
             (reduce_partial_map_size, reduce_partial_map_type),
         ) = get_ps_metadata_info_v1(
             batch_size=batch_size,
-            num_head_k=self.num_kv_head,
+            num_head_k=num_head_k,
             max_qlen=max_qlen,
             qlen_granularity=qlen_granularity,
         )
@@ -570,9 +578,13 @@ class AiterAttnBackend(AttentionBackend):
         reduce_final_map: torch.Tensor,
         reduce_partial_map: torch.Tensor,
         is_causal: bool = True,
+        num_head: Optional[int] = None,
+        num_kv_head: Optional[int] = None,
     ):
-        gqa_ratio = self.num_head // self.num_kv_head
-        num_heads_k = self.num_kv_head
+        num_head = self.num_head if num_head is None else num_head
+        num_kv_head = self.num_kv_head if num_kv_head is None else num_kv_head
+        gqa_ratio = num_head // num_kv_head
+        num_heads_k = num_kv_head
         tile_q = 256
         qhead_granularity = gqa_ratio
         qlen_granularity = tile_q // qhead_granularity
@@ -1779,9 +1791,19 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map = None
                 fp8_prefill_kv_indices = None
 
-                if _use_fp8_prefill_attn and not runtime_attn_tp:
+                if _use_fp8_prefill_attn:
                     tile_q = 256
-                    qlen_granularity = tile_q // (self.num_head // self.num_kv_head)
+                    metadata_num_head = self.num_head
+                    metadata_num_kv_head = self.num_kv_head
+                    if runtime_attn_tp:
+                        runtime_tp_size = get_parallel().attn_cp_size
+                        metadata_num_head //= runtime_tp_size
+                        metadata_num_kv_head = max(
+                            1, metadata_num_kv_head // runtime_tp_size
+                        )
+                    qlen_granularity = tile_q // (
+                        metadata_num_head // metadata_num_kv_head
+                    )
                     (
                         work_metadata,
                         work_indptr,
@@ -1790,7 +1812,10 @@ class AiterAttnBackend(AttentionBackend):
                         reduce_final_map,
                         reduce_partial_map,
                     ) = self.make_mla_prefill_ps_meta_data_buffer(
-                        bs, max_q_len, qlen_granularity
+                        bs,
+                        max_q_len,
+                        qlen_granularity,
+                        num_head_k=metadata_num_kv_head,
                     )
 
                     self.make_mla_prefill_ps_meta_data(
@@ -1804,6 +1829,8 @@ class AiterAttnBackend(AttentionBackend):
                         reduce_final_map,
                         reduce_partial_map,
                         is_causal=True,
+                        num_head=metadata_num_head,
+                        num_kv_head=metadata_num_kv_head,
                     )
 
                     total_s = forward_batch.seq_lens_sum
@@ -1943,7 +1970,7 @@ class AiterAttnBackend(AttentionBackend):
             self.page_size,
             self.dcp_world_size,
             get_parallel().attn_dcp_rank,
-            kv_loc_scale=kv_storage_dcp_size(get_parallel()),
+            kv_loc_scale=self.token_to_kv_pool.active_storage_dcp_size(),
             out=out,
         )
         return block_table, local_kv_lens
@@ -2149,6 +2176,13 @@ class AiterAttnBackend(AttentionBackend):
             if attn_parallel_mode is None
             else AttnParallelMode(attn_parallel_mode) is AttnParallelMode.DCP
         )
+        from sglang.srt.layers.cp.cp_decode_attn_tp import (
+            get_cp_decode_attn_tp_ctx,
+        )
+
+        runtime_attn_tp = (
+            get_cp_decode_attn_tp_ctx().is_enabled and not dcp_batch_active
+        )
 
         num_kv_splits = None
         # num_kv_splits_indptr = None
@@ -2290,7 +2324,11 @@ class AiterAttnBackend(AttentionBackend):
 
                 # DCP decode builds its own block-table metadata in
                 # forward_decode, so the persist metadata is unused here.
-                if _use_mla_ps_kernel and dcp_cp_world_size == 1:
+                if (
+                    _use_mla_ps_kernel
+                    and not runtime_attn_tp
+                    and dcp_cp_world_size == 1
+                ):
                     num_kv_splits = self.max_split_per_batch
 
                     self.make_mla_meta_data(

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -28,7 +28,12 @@ from sglang.kernels.ops.kvcache.aiter_unified_attention import (
     scatter_ragged_to_page_table_kernel,
     scatter_req_to_token_to_page_table_kernel,
 )
+from sglang.srt.attn_parallel import AttnParallelMode, kv_storage_dcp_size
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.cp.base import CPAttentionBackendKind, get_cp_strategy
+from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.layers.dcp import update_local_kv_lens_for_dcp
+from sglang.srt.layers.dcp.planner import plan_dcp_decode_metadata
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
@@ -130,13 +135,41 @@ class ForwardMetadata:
     swa_page_table: Optional[torch.Tensor] = None
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: Optional[torch.Tensor] = None
+    mla_cp_metadata: Optional[AiterMlaCPMetadata] = None
+    # dcp_g_kv_indptr keeps the GLOBAL per-request kv_indptr so that it can
+    # mask on global positions g(j)=j*W+r. See mla_decode_fwd(cp_world_size,...).
+    dcp_g_kv_indptr: Optional[torch.Tensor] = None
+    dcp_cp_world_size: int = 1
+    dcp_cp_rank: int = 0
+    # Per-rank PAGE table + shard length (tokens) for the Triton DCP decode,
+    # built once per forward instead of per layer. See build_dcp_page_table.
+    dcp_block_table: Optional[torch.Tensor] = None
+    dcp_local_kv_lens: Optional[torch.Tensor] = None
+    # Stage A flattens the window to one row per query token, so it needs its
+    # own arange cu_seqlens_q; qo_indptr stays the per-request boundaries.
+    dcp_verify_qo_indptr: Optional[torch.Tensor] = None
+
+
+@dataclass
+class AiterMlaCPLaunchMetadata:
+    kv_indptr: torch.Tensor
+    kv_indices: torch.Tensor
+    kv_last_page_len: torch.Tensor
+
+
+@dataclass
+class AiterMlaCPMetadata:
+    prev: AiterMlaCPLaunchMetadata
+    next: AiterMlaCPLaunchMetadata
 
 
 _AITER_PARTITION_SIZE_ROCM = 256
 
+# Staging page size for the DCP extend path, independent of --page-size
+_DCP_PREFILL_PAGE_SIZE = 64
+
 
 class AiterAttnBackend(AttentionBackend):
-
     # kv_indptr/qo_indptr are preallocated at (req pool + 1); an extend batch
     # can never carry more seqs than the pool.
     extend_dummy_seqs_capped_by_req_pool: bool = True
@@ -300,10 +333,13 @@ class AiterAttnBackend(AttentionBackend):
         self.forward_metadata: ForwardMetadata = None
 
         if self.use_mla:
+            self.dcp_world_size = get_parallel().attn_dcp_size
+            # The DCP decode kernel tiles the query heads, so it serves any
+            # local head count; the check below is for the non-DCP path only.
             _valid_heads = self.num_head in (4, 8) or (
                 self.num_head % 16 == 0 and 16 <= self.num_head <= 128
             )
-            assert _valid_heads, (
+            assert self.dcp_world_size > 1 or _valid_heads, (
                 f"Aiter MLA supports num_head of 4, 8, or multiples of 16 "
                 f"in [16, 128].\n"
                 f"Provided {self.num_head} number of heads.\n"
@@ -312,17 +348,24 @@ class AiterAttnBackend(AttentionBackend):
             self.num_head_padded = 16 if self.num_head < 16 else self.num_head
             self.head_repeat_factor = 16 // self.num_head if self.num_head < 16 else 1
 
+            # Under DCP, Q is all-gathered, so this operates on the gathered
+            # head count num_head * dcp_world_size. No-op otherwise.
+            _gathered_num_head = self.num_head * self.dcp_world_size
+            self.mla_kernel_num_head_padded = (
+                16 if _gathered_num_head < 16 else _gathered_num_head
+            )
+
             self.enable_dp_attention = is_dp_attention_enabled()
             self.qo_indptr_ = torch.zeros(
                 (max_bs + 1,), dtype=torch.int32, device=model_runner.device
             )
             global _use_mla_ps_kernel, fast_mode, intra_batch_mode
 
-            # current mla_decode_fwd only support fake-nps in self.num_head == 16
+            # current mla_decode_fwd only support fake-nps in num_head == 16
             # so all num_head size does not use qh16 kernel to simulate
             # it should not use fake-nps (fast_mode = False, intra_batch_mode = True)
-            # it will cause gpu-fault or accuracy issue
-            if self.num_head in (32, 64, 128):
+            # it will cause gpu-fault or accuracy issue.
+            if self.mla_kernel_num_head_padded in (32, 64, 128):
                 fast_mode = True
                 intra_batch_mode = False
 
@@ -332,8 +375,9 @@ class AiterAttnBackend(AttentionBackend):
             # for non-fp8 kv_cache on tp8, use non-persist kernel to avoid performance degradation
             # head_num=16 (tp8 perf issue), head_num=128 (unsupported, like tp1 or --enable-dp-attention with tp8-dp8)
             if (
-                self.num_head_padded == 16 or self.num_head_padded == 128
-            ) and self.kv_cache_dtype is not fp8_dtype:
+                self.mla_kernel_num_head_padded in (16, 128)
+                and self.kv_cache_dtype is not fp8_dtype
+            ):
                 _use_mla_ps_kernel = False
                 fast_mode = False
                 intra_batch_mode = False
@@ -361,7 +405,9 @@ class AiterAttnBackend(AttentionBackend):
         return "fp8_e4m3"
 
     def make_mla_decode_meta_data_buffer(self, max_seqlen_qo, batch_size):
-        nhead = self.num_head_padded
+        # Under DCP this is the gathered head count (num_head * dcp_world_size);
+        # equals num_head_padded when DCP is off.
+        nhead = self.mla_kernel_num_head_padded
         dtype = self.kv_cache_dtype
 
         if self.enable_dp_attention:
@@ -444,11 +490,12 @@ class AiterAttnBackend(AttentionBackend):
         page_size = self.page_size
         dtype = self.kv_cache_dtype
 
+        # For dcp, kv_indptr here is already localized to this rank's shard
         meta = get_mla_metadata_v1(
             qo_indptr,
             kv_indptr,
             kv_last_page_len,
-            self.num_head_padded // nhead_kv,
+            self.mla_kernel_num_head_padded // nhead_kv,
             nhead_kv,
             False,
             work_metadata,
@@ -736,6 +783,77 @@ class AiterAttnBackend(AttentionBackend):
             )
         return self._kv_indices_scratch[:required_tokens]
 
+    def _uses_runtime_attn_tp(self, forward_batch: ForwardBatch) -> bool:
+        if not self.use_mla:
+            return False
+        from sglang.srt.layers.cp.cp_decode_attn_tp import (
+            get_cp_decode_attn_tp_ctx,
+        )
+
+        return get_cp_decode_attn_tp_ctx().should_use_attn_tp(forward_batch)
+
+    def _is_dcp_batch(self, forward_batch: ForwardBatch) -> bool:
+        from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla import (
+            is_dcp_mla_attention_phase,
+        )
+
+        return self.use_mla and is_dcp_mla_attention_phase(forward_batch)
+
+    def _activate_kv_residency(self, forward_batch: ForwardBatch) -> None:
+        allocator = getattr(self.token_to_kv_pool, "residency_allocator", None)
+        residency = getattr(forward_batch, "kv_residency", None)
+        if allocator is not None and residency is not None:
+            allocator.set_active_residency(residency)
+
+    def _build_mla_cp_launch_metadata(
+        self,
+        req_pool_indices: torch.Tensor,
+        kv_lens: torch.Tensor,
+        kv_lens_sum: int,
+    ) -> AiterMlaCPLaunchMetadata:
+        """Build token-level paged-MLA metadata for one zigzag half."""
+
+        bs = req_pool_indices.shape[0]
+        kv_indptr = torch.zeros(bs + 1, dtype=torch.int32, device=kv_lens.device)
+        kv_indptr[1:] = torch.cumsum(kv_lens, dim=0)
+        kv_indices = torch.empty(
+            kv_lens_sum, dtype=torch.int32, device=req_pool_indices.device
+        )
+        create_flashinfer_kv_indices_triton[(bs,)](
+            self.req_to_token,
+            req_pool_indices,
+            kv_lens,
+            kv_indptr,
+            None,
+            kv_indices,
+            self.req_to_token.stride(0),
+        )
+        return AiterMlaCPLaunchMetadata(
+            kv_indptr=kv_indptr,
+            kv_indices=kv_indices,
+            # The MLA pool is flattened to one latent row per token for this
+            # kernel, independent of the scheduler's allocation page size.
+            kv_last_page_len=torch.ones(
+                bs, dtype=torch.int32, device=req_pool_indices.device
+            ),
+        )
+
+    def _build_mla_cp_metadata(self, forward_batch) -> AiterMlaCPMetadata:
+        cp_metadata = forward_batch.attn_cp_metadata
+        if cp_metadata is None:
+            raise RuntimeError("Aiter MLA CP requires attn_cp_metadata")
+        prev = self._build_mla_cp_launch_metadata(
+            forward_batch.req_pool_indices,
+            cp_metadata.kv_len_prev_tensor,
+            sum(cp_metadata.kv_len_prev_list),
+        )
+        next_ = self._build_mla_cp_launch_metadata(
+            forward_batch.req_pool_indices,
+            cp_metadata.kv_len_next_tensor,
+            sum(cp_metadata.kv_len_next_list),
+        )
+        return AiterMlaCPMetadata(prev=prev, next=next_)
+
     def _set_uniform_qo_indptr(
         self, bs: int, tokens_per_req: int, device: torch.device
     ) -> torch.Tensor:
@@ -761,6 +879,7 @@ class AiterAttnBackend(AttentionBackend):
         q: torch.Tensor,
         k_buffer_flat: torch.Tensor,
         layer,
+        return_lse: bool = False,
         **kwargs,
     ):
         """Wrap mla_decode_fwd with head-dimension padding for num_head < 16.
@@ -769,22 +888,261 @@ class AiterAttnBackend(AttentionBackend):
         repeat-interleaved to reach num_head_padded (16) before the kernel
         call, and the corresponding output columns are sliced back afterward.
         q / o must already be shaped (..., num_head, head_dim).
+
+        When ``return_lse`` is set (DCP case), also returns the
+        per-(token, head) log-sum-exp so the caller can merge partial outputs
+        across dcp ranks.
         """
-        if self.head_repeat_factor > 1:
-            q_in = q.repeat_interleave(self.head_repeat_factor, dim=1)
+        # Padding follows this call's actual head count, not self.num_head: under
+        # DCP the gathered layer usually already has >= 16 heads.
+        n_heads = layer.tp_q_head_num
+        repeat_factor = (16 // n_heads) if n_heads < 16 else 1
+        if repeat_factor > 1:
+            q_in = q.repeat_interleave(repeat_factor, dim=1)
             o = q.new_empty(
-                (q.shape[0], self.num_head_padded, layer.v_head_dim),
+                (q.shape[0], n_heads * repeat_factor, layer.v_head_dim),
                 dtype=self.input_dtype,
             )
+            # Only ask for the (out, lse) tuple under DCP, so the non-DCP path
+            # stays agnostic to the installed aiter's signature.
+            if return_lse:
+                _, lse = mla_decode_fwd(
+                    q_in, k_buffer_flat, o, return_lse=True, **kwargs
+                )
+                return o[:, ::repeat_factor, :], lse[:, ::repeat_factor]
             mla_decode_fwd(q_in, k_buffer_flat, o, **kwargs)
-            return o[:, :: self.head_repeat_factor, :]
+            return o[:, ::repeat_factor, :]
         else:
             o = q.new_empty(
-                (q.shape[0], layer.tp_q_head_num, layer.v_head_dim),
+                (q.shape[0], n_heads, layer.v_head_dim),
                 dtype=self.input_dtype,
             )
+            if return_lse:
+                _, lse = mla_decode_fwd(q, k_buffer_flat, o, return_lse=True, **kwargs)
+                return o, lse
             mla_decode_fwd(q, k_buffer_flat, o, **kwargs)
             return o
+
+    def _dcp_graph_max_local_kv_len(self) -> int:
+        """Static upper bound on this rank's shard, ceil(max_context_len / W).
+
+        Used as ``max_seqlen_kv`` under cuda graph so every buffer shape is fixed.
+        """
+        w = max(self.dcp_world_size, 1)
+        return (self.max_context_len + w - 1) // w
+
+    def _mla_decode_fwd_dcp(self, q, k_buffer, layer, k_descale):
+        """DCP decode over this rank's round-robin KV shard -> (out, base-2 lse).
+
+        NOTE ``mla_decode_fwd`` is Triton, not Gluon, on gfx950: it only picks
+        its Gluon path under IS_DEVICE_ARCH_GFX12.
+        """
+        return self._mla_decode_fwd_dcp_triton(q, k_buffer, layer, k_descale)
+
+    def _mla_decode_fwd_dcp_triton(self, q, k_buffer, layer, k_descale):
+        """DCP decode on aiter's Triton MLA kernel -> (out, base-2 lse).
+
+        At q_len == 1 every shard entry is a past token, so no causal masking is
+        needed and this rank simply attends its whole shard.
+        """
+        from aiter.ops.triton.attention.mla import mla_decode_fwd
+
+        from sglang.kernels.ops.attention.dcp_kernels import (
+            dcp_reduce_kv_segments,
+        )
+
+        fm = self.forward_metadata
+        # kv_indptr and the PAGE table were localized to this rank's shard by
+        # _plan_dcp_decode_metadata, once per forward rather than per layer.
+        kv_indptr = fm.kv_indptr
+        bs = kv_indptr.shape[0] - 1
+        num_heads = layer.tp_q_head_num  # gathered heads = num_local_heads * dcp
+        kv_lora_rank = layer.v_head_dim
+        qk_rope_head_dim = layer.qk_head_dim - kv_lora_rank
+
+        seqused_k = fm.dcp_local_kv_lens
+        block_tables = fm.dcp_block_table
+        # .item() is illegal under capture, and a per-step max would vary
+        # NUM_SEGMENTS between capture and replay. Pin a static per-graph bound;
+        # per-token correctness still comes from seqused_k inside the kernel.
+        if fm.run_graph:
+            max_local = self._dcp_graph_max_local_kv_len()
+        else:
+            max_local = int(seqused_k.max().item())
+
+        # cu_seqlens_q for decode is [0, 1, ..., bs] (1 query token per request),
+        # which is exactly the MLA qo_indptr already built in the metadata.
+        cu_seqlens_q = fm.qo_indptr[: bs + 1]
+        q3 = q.view(bs, num_heads, layer.qk_head_dim)
+        kv_buffer = k_buffer.view(-1, self.page_size, 1, layer.qk_head_dim)
+        out = q.new_empty((bs, num_heads, kv_lora_rank), dtype=self.input_dtype)
+
+        segm_output, segm_max, segm_expsum = mla_decode_fwd(
+            q3,
+            kv_buffer,
+            out,
+            cu_seqlens_q,
+            seqused_k,
+            max_local,
+            block_tables,
+            layer.scaling,
+            kv_lora_rank,
+            qk_rope_head_dim,
+            True,  # causal
+            k_descale,
+            k_descale,
+            skip_reduce=True,
+        )
+        # segment-reduce the shard partials to (out_local, lse2_local) [base-2].
+        return dcp_reduce_kv_segments(
+            segm_output,
+            segm_max,
+            segm_expsum,
+            seqused_k,
+            self.page_size,
+            self.input_dtype,
+        )
+
+    def _mla_verify_fwd_dcp(self, q, k_window, layer, k_descale):
+        """DCP target-verify."""
+        return self._mla_verify_fwd_dcp_triton(q, k_window, layer, k_descale)
+
+    def _mla_verify_fwd_dcp_triton(self, q, k_window, layer, k_descale):
+        """DCP target-verify, split at the window boundary -> (out, base-2 lse).
+
+        Splitting there avoids the one thing mla_decode_fwd cannot do under DCP:
+        mask on the GLOBAL position g(j) = j * W + r rather than the local index.
+
+        * stage A, the committed shard: every entry precedes every window token,
+          so flattening to single-token rows degenerates the mask to "attend the
+          whole shard" and no global masking is needed.
+        * stage B, the in-hand window: dense and unsharded, plain causal attention.
+
+        Stage B runs on ONE rank only, so the cross-rank merge counts it once.
+        """
+        from aiter.ops.triton.attention.mla import mla_decode_fwd
+
+        from sglang.kernels.ops.attention.dcp_kernels import (
+            dcp_reduce_kv_segments,
+        )
+
+        fm = self.forward_metadata
+        q_len = fm.max_q_len
+        num_heads = layer.tp_q_head_num  # gathered heads = num_local_heads * dcp
+        kv_lora_rank = layer.v_head_dim
+        qk_rope_head_dim = layer.qk_head_dim - kv_lora_rank
+
+        # Both were expanded to one row per window token when the metadata was
+        # planned, so the shard lengths and page table are already per-row.
+        seqused_k = fm.dcp_local_kv_lens
+        n_rows = seqused_k.shape[0]
+        bs = n_rows // q_len
+
+        # Static bound for the same reason as the decode path: NUM_SEGMENTS must
+        # not vary between capture and replay.
+        if fm.run_graph:
+            max_local = self._dcp_graph_max_local_kv_len()
+        else:
+            max_local = int(seqused_k.max().item())
+
+        k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        out_a = q.new_empty((n_rows, num_heads, kv_lora_rank), dtype=self.input_dtype)
+        segm_output, segm_max, segm_expsum = mla_decode_fwd(
+            q.view(n_rows, num_heads, layer.qk_head_dim),
+            k_buffer.view(-1, self.page_size, 1, layer.qk_head_dim),
+            out_a,
+            fm.dcp_verify_qo_indptr[: n_rows + 1],
+            seqused_k,
+            max_local,
+            fm.dcp_block_table,
+            layer.scaling,
+            kv_lora_rank,
+            qk_rope_head_dim,
+            True,  # causal (degenerate at num_tokens_per_seq == 1)
+            k_descale,
+            k_descale,
+            skip_reduce=True,
+        )
+        out_a, lse_a = dcp_reduce_kv_segments(
+            segm_output,
+            segm_max,
+            segm_expsum,
+            seqused_k,
+            self.page_size,
+            self.input_dtype,
+        )
+
+        if fm.dcp_cp_rank != 0:
+            return out_a, lse_a
+
+        from sglang.kernels.ops.attention.dcp_kernels import (
+            dcp_lse_combine_base2,
+            dense_causal_mla_attn_base2,
+        )
+
+        out_b, lse_b = dense_causal_mla_attn_base2(
+            q, k_window, layer.scaling, bs, q_len, kv_lora_rank
+        )
+        return dcp_lse_combine_base2(out_a, lse_a, out_b, lse_b, self.input_dtype)
+
+    def _mla_prefill_fwd_dcp(self, q, layer, k_descale, forward_batch):
+        """DCP prefill (extend) on aiter's Triton absorb-prefill kernel."""
+        return self._mla_prefill_fwd_dcp_triton(q, layer, k_descale, forward_batch)
+
+    def _mla_prefill_fwd_dcp_triton(self, q, layer, k_descale, forward_batch):
+        """DCP prefill (extend) on aiter's MLA absorb-prefill kernel.
+
+        Reads the full sequence from ``attn_dcp_metadata.dcp_kv_buffer``, which
+        the model layer assembles, because the sharded local cache does not hold
+        it. Q is NOT gathered here: each rank attends the full KV with its own
+        local heads, so there is no cross-rank merge.
+        """
+        from aiter.ops.triton.attention.mla import mla_prefill_fwd
+
+        from sglang.kernels.ops.attention.dcp_kernels import (
+            pack_dcp_kv_into_pages,
+        )
+
+        dcp_meta = forward_batch.attn_dcp_metadata
+        kv_buffer = dcp_meta.dcp_kv_buffer  # [seq_lens_sum, 1, qk_head_dim]
+        kv_indptr = dcp_meta.dcp_kv_indptr  # [bs + 1] full-seq boundaries
+        kv_indices = dcp_meta.dcp_kv_indices  # indices into dcp_kv_buffer
+        bs = kv_indptr.shape[0] - 1
+        num_heads = layer.tp_q_head_num
+        kv_lora_rank = layer.v_head_dim
+        qk_rope_head_dim = layer.qk_head_dim - kv_lora_rank
+
+        # The .item() below is a GPU->CPU sync, fine because this path is
+        # uncapturable anyway (pack_dcp_kv_into_pages allocates per batch). Do NOT
+        # guard it with ForwardMetadata.run_graph: that defaults True on prefill
+        # metadata and says nothing about capture state.
+        seqused_k = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32)
+        max_kv = int(seqused_k.max().item())
+        # The KV tile is the paged block size, so block_size 1 collapses each
+        # tile to one token. Need to repack here.
+        paged_kv, block_tables = pack_dcp_kv_into_pages(
+            kv_buffer, kv_indptr, kv_indices, bs, _DCP_PREFILL_PAGE_SIZE
+        )
+
+        out = q.new_empty(
+            (q.shape[0], num_heads * kv_lora_rank), dtype=self.input_dtype
+        )
+        mla_prefill_fwd(
+            q.view(-1, num_heads, layer.qk_head_dim),
+            paged_kv,
+            out.view(-1, num_heads, kv_lora_rank),
+            self.forward_metadata.qo_indptr,  # extend query-token boundaries
+            seqused_k,
+            max_kv,
+            block_tables,
+            layer.scaling,
+            kv_lora_rank,
+            qk_rope_head_dim,
+            True,  # causal
+            k_descale,
+            k_descale,
+        )
+        return out
 
     def mla_fp8_prefill_attn(
         self,
@@ -868,6 +1226,7 @@ class AiterAttnBackend(AttentionBackend):
         forward_batch: ForwardBatch,
         in_capture: bool = False,
     ):
+        self._activate_kv_residency(forward_batch)
         seq_lens_cpu = (
             forward_batch.seq_lens.cpu() if in_capture else forward_batch.seq_lens_cpu
         )
@@ -886,6 +1245,7 @@ class AiterAttnBackend(AttentionBackend):
             spec_info=forward_batch.spec_info,
             seq_lens_cpu=seq_lens_cpu,
             verify_tokens_per_req=verify_tokens_per_req,
+            attn_parallel_mode=forward_batch.attn_parallel_mode,
         )
 
         # Refill the SWA write-target buffer from the live out_cache_loc and
@@ -905,7 +1265,10 @@ class AiterAttnBackend(AttentionBackend):
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init auxiliary variables for aiter attention backend."""
 
+        self._activate_kv_residency(forward_batch)
         bs = forward_batch.batch_size
+        runtime_attn_tp = self._uses_runtime_attn_tp(forward_batch)
+        dcp_batch_active = self._is_dcp_batch(forward_batch)
         kv_indptr = self.kv_indptr
         spec_info = forward_batch.spec_info
         qo_indptr = None
@@ -929,6 +1292,34 @@ class AiterAttnBackend(AttentionBackend):
             )
         max_kv_len = forward_batch.seq_lens_cpu.max().item()
 
+        if self.use_mla and is_cp_v2_active(forward_batch):
+            cp_metadata = forward_batch.attn_cp_metadata
+            mla_cp_metadata = self._build_mla_cp_metadata(forward_batch)
+            self.forward_metadata = ForwardMetadata(
+                kv_indptr=mla_cp_metadata.prev.kv_indptr,
+                kv_indices=mla_cp_metadata.prev.kv_indices,
+                qo_indptr=cp_metadata.cu_seqlens_q_prev_tensor,
+                kv_last_page_len=mla_cp_metadata.prev.kv_last_page_len,
+                max_q_len=max(
+                    cp_metadata.max_seqlen_q_prev,
+                    cp_metadata.max_seqlen_q_next,
+                ),
+                max_kv_len=max(
+                    max(cp_metadata.kv_len_prev_list),
+                    max(cp_metadata.kv_len_next_list),
+                ),
+                run_graph=False,
+                mla_cp_metadata=mla_cp_metadata,
+            )
+            return
+
+        # dcp metadata
+        dcp_g_kv_indptr = None
+        dcp_cp_world_size = 1
+        dcp_cp_rank = 0
+        dcp_block_table = None
+        dcp_local_kv_lens = None
+        dcp_verify_qo_indptr = None
         if forward_batch.forward_mode.is_decode_or_idle():
             if spec_info is None or forward_batch.forward_mode.is_idle():
                 kv_indptr[1 : bs + 1] = torch.cumsum(forward_batch.seq_lens, dim=0)
@@ -947,6 +1338,33 @@ class AiterAttnBackend(AttentionBackend):
                         kv_indices,
                         self.req_to_token.stride(0),
                     )
+
+                    if (
+                        self.use_mla
+                        and dcp_batch_active
+                        and not forward_batch.forward_mode.is_idle()
+                    ):
+                        dcp_g_kv_indptr = kv_indptr.clone()
+                        dcp_cp_world_size = get_parallel().attn_dcp_size
+                        dcp_cp_rank = get_parallel().attn_dcp_rank
+                        kv_lens = forward_batch.seq_lens[:bs].to(torch.int32).clone()
+                        self._plan_dcp_decode_metadata(
+                            kv_indptr,
+                            kv_indices,
+                            kv_lens,
+                            forward_batch.seq_lens_cpu,
+                            bs,
+                        )
+                        (
+                            dcp_block_table,
+                            dcp_local_kv_lens,
+                        ) = self._build_dcp_decode_page_table(
+                            kv_indptr,
+                            forward_batch.req_pool_indices,
+                            bs,
+                            (max_kv_len + self.dcp_world_size - 1)
+                            // self.dcp_world_size,
+                        )
                 else:
                     max_q_len = 1
                     page_size = self.page_size
@@ -1003,7 +1421,13 @@ class AiterAttnBackend(AttentionBackend):
                 kv_last_page_len = self.kv_last_page_len[:bs]
                 max_q_len = 1
 
-                if _use_mla_ps_kernel:
+                # DCP decode runs the aiter MLA kernel (builds its own block-table
+                # metadata in forward_decode), so skip the persist metadata.
+                if (
+                    _use_mla_ps_kernel
+                    and not runtime_attn_tp
+                    and dcp_cp_world_size == 1
+                ):
                     (
                         work_metadata,
                         work_indptr,
@@ -1048,6 +1472,11 @@ class AiterAttnBackend(AttentionBackend):
                 run_graph=False,
                 swa_page_table=swa_page_table,
                 swa_out_cache_loc=swa_out_cache_loc,
+                dcp_g_kv_indptr=dcp_g_kv_indptr,
+                dcp_cp_world_size=dcp_cp_world_size,
+                dcp_cp_rank=dcp_cp_rank,
+                dcp_block_table=dcp_block_table,
+                dcp_local_kv_lens=dcp_local_kv_lens,
             )
 
         elif forward_batch.forward_mode.is_draft_extend_v2():
@@ -1140,9 +1569,16 @@ class AiterAttnBackend(AttentionBackend):
         elif forward_batch.forward_mode.is_target_verify():
             if self.use_mla:
                 draft_num = spec_info.draft_token_num
-                kv_lens = forward_batch.seq_lens + draft_num
-                kv_lens_sum = forward_batch.seq_lens_sum + draft_num * bs
                 device = forward_batch.seq_lens.device
+                # Prefix and window are attended as two stages, so plan the
+                # shard over the COMMITTED length only or the window is counted twice.
+                verify_dcp = self.use_mla and dcp_batch_active
+                if verify_dcp:
+                    kv_lens = forward_batch.seq_lens.to(torch.int32).clone()
+                    kv_lens_sum = forward_batch.seq_lens_sum
+                else:
+                    kv_lens = forward_batch.seq_lens + draft_num
+                    kv_lens_sum = forward_batch.seq_lens_sum + draft_num * bs
 
                 qo_indptr = self.qo_indptr[: bs + 1]
                 qo_indptr[: bs + 1] = torch.arange(
@@ -1168,8 +1604,33 @@ class AiterAttnBackend(AttentionBackend):
                     self.req_to_token.stride(0),
                 )
 
+                if verify_dcp:
+                    dcp_g_kv_indptr = kv_indptr.clone()
+                    dcp_cp_world_size = get_parallel().attn_dcp_size
+                    dcp_cp_rank = get_parallel().attn_dcp_rank
+                    # seq_lens_cpu is NOT usable: the DSPARK verify path pre-adds
+                    # the window to it, so the shard would be draft_num too long.
+                    self._plan_dcp_decode_metadata(
+                        kv_indptr,
+                        kv_indices,
+                        kv_lens,
+                        None,
+                        bs,
+                    )
+                    (
+                        dcp_block_table,
+                        dcp_local_kv_lens,
+                        dcp_verify_qo_indptr,
+                    ) = self._build_dcp_verify_page_table(
+                        kv_indptr,
+                        forward_batch.req_pool_indices,
+                        bs,
+                        draft_num,
+                        (max_kv_len + self.dcp_world_size - 1) // self.dcp_world_size,
+                    )
+
                 # if self.kv_cache_dtype == fp8_dtype:
-                if _use_mla_ps_kernel:
+                if _use_mla_ps_kernel and not verify_dcp:
                     max_seqlen_qo = draft_num
                     (
                         work_metadata,
@@ -1214,6 +1675,12 @@ class AiterAttnBackend(AttentionBackend):
                     reduce_partial_map=reduce_partial_map,
                     num_kv_splits=num_kv_splits,
                     run_graph=False,
+                    dcp_g_kv_indptr=dcp_g_kv_indptr,
+                    dcp_cp_world_size=dcp_cp_world_size,
+                    dcp_cp_rank=dcp_cp_rank,
+                    dcp_block_table=dcp_block_table,
+                    dcp_local_kv_lens=dcp_local_kv_lens,
+                    dcp_verify_qo_indptr=dcp_verify_qo_indptr,
                 )
             else:
                 draft_num = forward_batch.input_ids.shape[0] // bs
@@ -1312,7 +1779,7 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map = None
                 fp8_prefill_kv_indices = None
 
-                if _use_fp8_prefill_attn:
+                if _use_fp8_prefill_attn and not runtime_attn_tp:
                     tile_q = 256
                     qlen_granularity = tile_q // (self.num_head // self.num_kv_head)
                     (
@@ -1390,6 +1857,130 @@ class AiterAttnBackend(AttentionBackend):
                     swa_out_cache_loc=swa_out_cache_loc,
                 )
 
+    def _dcp_graph_local_len_bounds(self, bs: int) -> tuple[int, int]:
+        """Static (max, total) shard-length bounds for a cuda-graph batch."""
+        max_local = self._dcp_graph_max_local_kv_len()
+        return max_local, bs * max_local
+
+    def _plan_dcp_decode_metadata(
+        self,
+        kv_indptr: torch.Tensor,
+        kv_indices: torch.Tensor,
+        kv_lens_gpu: torch.Tensor,
+        seq_lens_cpu: Optional[torch.Tensor],
+        bs: int,
+        static_local_len_bounds: Optional[tuple[int, int]] = None,
+    ):
+        """Localize kv_indptr / kv_indices to this rank's DCP shard, in place.
+
+        Sized from ``seq_lens_cpu`` when available, else from
+        ``static_local_len_bounds``; both avoid a per-step GPU->CPU sync.
+        """
+        if static_local_len_bounds is not None:
+            plan_dcp_decode_metadata(
+                kv_lens_gpu,
+                kv_indptr,
+                kv_indices,
+                init_metadata_replay=False,
+                fast_decode_kwargs={},
+                bs=bs,
+                static_local_len_bounds=static_local_len_bounds,
+            )
+        elif seq_lens_cpu is not None:
+            kv_len_arr_cpu = seq_lens_cpu[:bs].to(torch.int32).clone()
+            update_local_kv_lens_for_dcp(kv_len_arr_cpu)
+            plan_dcp_decode_metadata(
+                kv_lens_gpu,
+                kv_indptr,
+                kv_indices,
+                init_metadata_replay=True,
+                fast_decode_kwargs={"kv_len_arr_cpu": kv_len_arr_cpu},
+                bs=bs,
+            )
+        else:
+            plan_dcp_decode_metadata(
+                kv_lens_gpu,
+                kv_indptr,
+                kv_indices,
+                init_metadata_replay=False,
+                fast_decode_kwargs={},
+                bs=bs,
+            )
+
+    def _build_dcp_decode_page_table(
+        self,
+        kv_indptr: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        bs: int,
+        max_local_kv_len: int,
+        out: Optional[torch.Tensor] = None,
+        out_lens: Optional[torch.Tensor] = None,
+    ):
+        """Per-rank page table + shard lengths for the Triton DCP decode.
+
+        Built once per forward, not per layer. ``kv_indptr`` must already be
+        localized by ``_plan_dcp_decode_metadata``. On the cuda-graph path the
+        caller's buffers are filled in place: this runs OUT of the graph, so a
+        fresh tensor would be invisible to the captured kernels.
+        """
+        from sglang.kernels.ops.attention.dcp_kernels import (
+            build_dcp_page_table,
+        )
+
+        lens = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32)
+        if out_lens is not None:
+            out_lens.copy_(lens)
+            local_kv_lens = out_lens
+        else:
+            local_kv_lens = lens
+        max_pages = (max_local_kv_len + self.page_size - 1) // self.page_size
+        block_table = build_dcp_page_table(
+            self.req_to_token,
+            req_pool_indices,
+            local_kv_lens,
+            bs,
+            max_pages,
+            self.page_size,
+            self.dcp_world_size,
+            get_parallel().attn_dcp_rank,
+            kv_loc_scale=kv_storage_dcp_size(get_parallel()),
+            out=out,
+        )
+        return block_table, local_kv_lens
+
+    def _build_dcp_verify_page_table(
+        self,
+        kv_indptr: torch.Tensor,
+        req_pool_indices: torch.Tensor,
+        bs: int,
+        q_len: int,
+        max_local_kv_len: int,
+        out: Optional[torch.Tensor] = None,
+        out_lens: Optional[torch.Tensor] = None,
+        qo_indptr: Optional[torch.Tensor] = None,
+    ):
+        """Per-ROW page table, shard lengths and cu_seqlens_q for verify stage A.
+
+        Stage A flattens the window into ``bs * q_len`` single-token rows (see
+        _mla_verify_fwd_dcp_triton). Rows of one request share its shard, so the
+        decode table just repeats ``q_len`` times, once per forward.
+        """
+        block_table, local_kv_lens = self._build_dcp_decode_page_table(
+            kv_indptr, req_pool_indices, bs, max_local_kv_len
+        )
+        n_rows = bs * q_len
+        if out is None:
+            out = block_table.new_empty((n_rows, block_table.shape[1]))
+        out.view(bs, q_len, -1).copy_(block_table.unsqueeze(1).expand(bs, q_len, -1))
+        if out_lens is None:
+            out_lens = local_kv_lens.new_empty((n_rows,))
+        out_lens.view(bs, q_len).copy_(local_kv_lens.unsqueeze(1).expand(bs, q_len))
+        if qo_indptr is None:
+            qo_indptr = torch.arange(
+                n_rows + 1, dtype=torch.int32, device=kv_indptr.device
+            )
+        return out, out_lens, qo_indptr
+
     def init_cuda_graph_state(
         self,
         max_bs: int,
@@ -1417,6 +2008,36 @@ class AiterAttnBackend(AttentionBackend):
         self.cuda_graph_kv_last_page_len = torch.ones(
             max_bs, dtype=torch.int32, device=self.device
         )
+        if self.use_mla and get_parallel().dcp_enabled:
+            self.cuda_graph_dcp_g_kv_indptr = torch.zeros(
+                (max_bs + 1,), dtype=torch.int32, device=self.device
+            )
+            # Capture-stable page table, filled out-of-graph. Width is the
+            # worst-case local shard, ceil(ctx_len / W) pages.
+            max_local_pages = (
+                self._dcp_graph_max_local_kv_len() + self.page_size - 1
+            ) // self.page_size
+            self.cuda_graph_dcp_block_table = torch.zeros(
+                (max_bs, max_local_pages), dtype=torch.int32, device=self.device
+            )
+            self.cuda_graph_dcp_local_kv_lens = torch.zeros(
+                (max_bs,), dtype=torch.int32, device=self.device
+            )
+            if self.num_draft_tokens:
+                # Target-verify flattens the window into single-token rows, so it
+                # needs max_bs * num_draft_tokens of them, not max_bs.
+                n_verify_rows = max_bs * self.num_draft_tokens
+                self.cuda_graph_dcp_verify_block_table = torch.zeros(
+                    (n_verify_rows, max_local_pages),
+                    dtype=torch.int32,
+                    device=self.device,
+                )
+                self.cuda_graph_dcp_verify_local_kv_lens = torch.zeros(
+                    (n_verify_rows,), dtype=torch.int32, device=self.device
+                )
+                self.cuda_graph_dcp_verify_qo_indptr = torch.arange(
+                    n_verify_rows + 1, dtype=torch.int32, device=self.device
+                )
         if kv_indices_buf is None:
             max_num_blocks_per_seq = (
                 self.max_context_len + self.page_size - 1
@@ -1521,7 +2142,13 @@ class AiterAttnBackend(AttentionBackend):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
         verify_tokens_per_req: Optional[int],
+        attn_parallel_mode: Optional[AttnParallelMode],
     ):
+        dcp_batch_active = (
+            get_parallel().dcp_enabled
+            if attn_parallel_mode is None
+            else AttnParallelMode(attn_parallel_mode) is AttnParallelMode.DCP
+        )
 
         num_kv_splits = None
         # num_kv_splits_indptr = None
@@ -1533,6 +2160,14 @@ class AiterAttnBackend(AttentionBackend):
         reduce_indptr = None
         reduce_final_map = None
         reduce_partial_map = None
+
+        # DCP metadata which will be populated for MLA decode when dcp enabled
+        dcp_g_kv_indptr = None
+        dcp_cp_world_size = 1
+        dcp_cp_rank = 0
+        dcp_block_table = None
+        dcp_local_kv_lens = None
+        dcp_verify_qo_indptr = None
 
         swa_page_table = None
         max_kv_len = (
@@ -1567,6 +2202,33 @@ class AiterAttnBackend(AttentionBackend):
                         kv_indices,
                         self.req_to_token.stride(0),
                     )
+
+                    if self.use_mla and dcp_batch_active and not forward_mode.is_idle():
+                        self.cuda_graph_dcp_g_kv_indptr[: bs + 1] = kv_indptr
+                        dcp_g_kv_indptr = self.cuda_graph_dcp_g_kv_indptr[: bs + 1]
+                        dcp_cp_world_size = get_parallel().attn_dcp_size
+                        dcp_cp_rank = get_parallel().attn_dcp_rank
+                        kv_lens = seq_lens[:bs].to(torch.int32).clone()
+                        self._plan_dcp_decode_metadata(
+                            kv_indptr,
+                            kv_indices,
+                            kv_lens,
+                            seq_lens_cpu,
+                            bs,
+                        )
+                        # Runs out-of-graph, so filling the capture-stable page
+                        # table buffer here is legal.
+                        (
+                            dcp_block_table,
+                            dcp_local_kv_lens,
+                        ) = self._build_dcp_decode_page_table(
+                            kv_indptr,
+                            req_pool_indices,
+                            bs,
+                            self._dcp_graph_max_local_kv_len(),
+                            out=self.cuda_graph_dcp_block_table[:bs],
+                            out_lens=self.cuda_graph_dcp_local_kv_lens[:bs],
+                        )
                 else:
                     max_q_len = 1
                     kv_indices = self.cuda_graph_page_table
@@ -1626,7 +2288,9 @@ class AiterAttnBackend(AttentionBackend):
                 kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
                 max_q_len = 1
 
-                if _use_mla_ps_kernel:
+                # DCP decode builds its own block-table metadata in
+                # forward_decode, so the persist metadata is unused here.
+                if _use_mla_ps_kernel and dcp_cp_world_size == 1:
                     num_kv_splits = self.max_split_per_batch
 
                     self.make_mla_meta_data(
@@ -1668,6 +2332,11 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map=reduce_partial_map,
                 num_kv_splits=num_kv_splits,
                 swa_page_table=swa_page_table,
+                dcp_g_kv_indptr=dcp_g_kv_indptr,
+                dcp_cp_world_size=dcp_cp_world_size,
+                dcp_cp_rank=dcp_cp_rank,
+                dcp_block_table=dcp_block_table,
+                dcp_local_kv_lens=dcp_local_kv_lens,
                 # num_kv_splits_indptr=num_kv_splits_indptr,
             )
 
@@ -1687,7 +2356,10 @@ class AiterAttnBackend(AttentionBackend):
                 dtype=torch.int32,
                 device=self.device,
             )
-            if self.use_mla:
+            # Prefix and window are attended as two stages, so plan the shard
+            # over the COMMITTED length only or the window is counted twice.
+            verify_dcp = self.use_mla and dcp_batch_active
+            if self.use_mla and not verify_dcp:
                 kv_lens = seq_lens + self.num_draft_tokens
             else:
                 kv_lens = seq_lens
@@ -1717,9 +2389,41 @@ class AiterAttnBackend(AttentionBackend):
             )
             kv_last_page_len = self.cuda_graph_kv_last_page_len[:bs]
 
+            if verify_dcp:
+                self.cuda_graph_dcp_g_kv_indptr[: bs + 1] = kv_indptr
+                dcp_g_kv_indptr = self.cuda_graph_dcp_g_kv_indptr[: bs + 1]
+                dcp_cp_world_size = get_parallel().attn_dcp_size
+                dcp_cp_rank = get_parallel().attn_dcp_rank
+                # seq_lens_cpu is NOT usable (the DSPARK verify path pre-adds the
+                # window), and exact device sizing costs two syncs per replay, so
+                # size from the static per-graph bounds instead.
+                self._plan_dcp_decode_metadata(
+                    kv_indptr,
+                    kv_indices,
+                    seq_lens[:bs].to(torch.int32).clone(),
+                    None,
+                    bs,
+                    static_local_len_bounds=self._dcp_graph_local_len_bounds(bs),
+                )
+                n_rows = bs * self.num_draft_tokens
+                (
+                    dcp_block_table,
+                    dcp_local_kv_lens,
+                    dcp_verify_qo_indptr,
+                ) = self._build_dcp_verify_page_table(
+                    kv_indptr,
+                    req_pool_indices,
+                    bs,
+                    self.num_draft_tokens,
+                    self._dcp_graph_max_local_kv_len(),
+                    out=self.cuda_graph_dcp_verify_block_table[:n_rows],
+                    out_lens=self.cuda_graph_dcp_verify_local_kv_lens[:n_rows],
+                    qo_indptr=self.cuda_graph_dcp_verify_qo_indptr[: n_rows + 1],
+                )
+
             if self.use_mla:
                 max_q_len = self.num_draft_tokens
-                if _use_mla_ps_kernel:
+                if _use_mla_ps_kernel and not verify_dcp:
                     num_kv_splits = self.max_split_per_batch
 
                     self.make_mla_meta_data(
@@ -1760,6 +2464,12 @@ class AiterAttnBackend(AttentionBackend):
                     reduce_final_map=reduce_final_map,
                     reduce_partial_map=reduce_partial_map,
                     num_kv_splits=num_kv_splits,
+                    dcp_g_kv_indptr=dcp_g_kv_indptr,
+                    dcp_cp_world_size=dcp_cp_world_size,
+                    dcp_cp_rank=dcp_cp_rank,
+                    dcp_block_table=dcp_block_table,
+                    dcp_local_kv_lens=dcp_local_kv_lens,
+                    dcp_verify_qo_indptr=dcp_verify_qo_indptr,
                 )
             else:
                 max_q_len = verify_tokens_per_req
@@ -1912,6 +2622,68 @@ class AiterAttnBackend(AttentionBackend):
             and layer.qk_head_dim == layer.v_head_dim
         )
 
+    def _forward_mla_cp(
+        self,
+        q: torch.Tensor,
+        layer: RadixAttention,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        metadata = self.forward_metadata.mla_cp_metadata
+        if metadata is None:
+            raise RuntimeError("Aiter MLA CP metadata was not initialized")
+        cp_metadata = forward_batch.attn_cp_metadata
+        cp_strategy = get_cp_strategy()
+        if cp_metadata is None or cp_strategy is None:
+            raise RuntimeError("Aiter MLA CP requires an active CP strategy")
+
+        k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id).view(
+            -1, 1, 1, layer.qk_head_dim
+        )
+
+        def _mla_cp_attn(
+            q_chunk,
+            cu_seqlens_q_cp,
+            cache_seqlens_cp,
+            max_seqlen_q_cp,
+        ):
+            if cache_seqlens_cp.data_ptr() == cp_metadata.kv_len_prev_tensor.data_ptr():
+                launch = metadata.prev
+            elif (
+                cache_seqlens_cp.data_ptr() == cp_metadata.kv_len_next_tensor.data_ptr()
+            ):
+                launch = metadata.next
+            else:
+                raise RuntimeError("Unknown zigzag KV-length tensor for Aiter MLA CP")
+
+            q_chunk = q_chunk.contiguous().view(
+                -1, layer.tp_q_head_num, layer.qk_head_dim
+            )
+            output = q_chunk.new_empty(
+                (q_chunk.shape[0], layer.tp_q_head_num, layer.v_head_dim),
+                dtype=self.input_dtype,
+            )
+            mla_prefill_fwd(
+                q_chunk,
+                k_buffer,
+                output,
+                cu_seqlens_q_cp,
+                launch.kv_indptr,
+                launch.kv_indices,
+                launch.kv_last_page_len,
+                max_seqlen_q_cp,
+                layer.scaling,
+                layer.logit_cap,
+            )
+            return output
+
+        return cp_strategy.run_attention(
+            q,
+            forward_batch,
+            self.device,
+            _mla_cp_attn,
+            attention_backend=CPAttentionBackendKind.AITER,
+        )
+
     def forward_extend(
         self,
         q: torch.Tensor,
@@ -1923,6 +2695,9 @@ class AiterAttnBackend(AttentionBackend):
         sinks=None,
     ):
         self.logits_soft_cap = layer.logit_cap
+        cp_v2_active = is_cp_v2_active(forward_batch)
+        runtime_attn_tp = self._uses_runtime_attn_tp(forward_batch)
+        striped_kv_residency = kv_storage_dcp_size(get_parallel(), forward_batch) > 1
 
         cache_loc = (
             forward_batch.out_cache_loc
@@ -1939,10 +2714,21 @@ class AiterAttnBackend(AttentionBackend):
         if k is not None:
             assert v is not None
             if save_kv_cache:
+                if self.use_mla and cp_v2_active:
+                    cp_strategy = get_cp_strategy()
+                    if cp_strategy is None:
+                        raise RuntimeError("Aiter MLA CP requires an active strategy")
+                    kv_lora_rank = v.shape[-1]
+                    cp_strategy.materialize_full_mla_kv(
+                        forward_batch,
+                        layer,
+                        v,
+                        k[..., kv_lora_rank:],
+                    )
                 # 5D pool cannot be reshaped to the 4D paged view used by
                 # launch_reshape_and_cache_flash; always route through
                 # set_kv_buffer which dispatches to the SHUFFLE 5D writer.
-                if self.kv_cache_is_vectorized_5d:
+                elif self.kv_cache_is_vectorized_5d:
                     self.token_to_kv_pool.set_kv_buffer(
                         layer,
                         KVWriteLoc(cache_loc, self.forward_metadata.swa_out_cache_loc),
@@ -1985,7 +2771,20 @@ class AiterAttnBackend(AttentionBackend):
                         v_scale=v_descale,
                     )
                 elif self.use_mla:
-                    self.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
+                    if get_parallel().dcp_enabled:
+                        # set_mla_kv_buffer owner-filters AND shards internally,
+                        # so pass the RAW loc and the full k: pre-dividing would
+                        # double-apply the filter. (set_kv_buffer's MLA path
+                        # filters without dividing, so it is wrong here.)
+                        kv_lora_rank = v.shape[-1]
+                        self.token_to_kv_pool.set_mla_kv_buffer(
+                            layer,
+                            cache_loc,
+                            k[..., :kv_lora_rank],
+                            k[..., kv_lora_rank:],
+                        )
+                    else:
+                        self.token_to_kv_pool.set_kv_buffer(layer, cache_loc, k, v)
                 elif self._use_fused_fp8_kv_write(layer):
                     # FP8: fuse bf16->fp8 cast + paged write in one kernel.
                     k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(
@@ -2024,6 +2823,15 @@ class AiterAttnBackend(AttentionBackend):
             V_Buffer = self.token_to_kv_pool.get_value_buffer(layer.layer_id)
             kv_lora_rank = V_Buffer.shape[-1]
             qk_rope_head_dim = K_Buffer.shape[-1] - kv_lora_rank
+
+            if (
+                forward_batch.forward_mode.is_target_verify()
+                and self.forward_metadata.dcp_cp_world_size > 1
+            ):
+                # Two-stage DCP verify, dispatched before the dims below: the
+                # model layer hands us the window's k/v, not a full-sequence k.
+                return self._mla_verify_fwd_dcp(q, k, layer, k_descale)
+
             qk_nope_head_dim = k.shape[-1] - qk_rope_head_dim
             assert len(q.shape) == 3
             assert len(k.shape) == 3
@@ -2034,8 +2842,16 @@ class AiterAttnBackend(AttentionBackend):
                 and not forward_batch.forward_mode.is_target_verify()
                 and not forward_batch.forward_mode.is_draft_extend_v2()
             ):
+                if cp_v2_active:
+                    return self._forward_mla_cp(q, layer, forward_batch)
+                if striped_kv_residency:
+                    # DCP absorb-prefill over the assembled full-seq KV
+                    # (dcp_kv_buffer), since the local cache is round-robin sharded.
+                    return self._mla_prefill_fwd_dcp(q, layer, k_descale, forward_batch)
                 extend_no_prefix = not any(forward_batch.extend_prefix_lens_cpu)
-                if kv_indices.shape[0] == 0 or extend_no_prefix:
+                if (
+                    kv_indices.shape[0] == 0 or extend_no_prefix
+                ) and not runtime_attn_tp:
                     if _use_fp8_prefill_attn:
                         output = self.mla_fp8_prefill_attn(
                             q,
@@ -2524,6 +3340,7 @@ class AiterAttnBackend(AttentionBackend):
         save_kv_cache=True,
         sinks=None,
     ):
+        runtime_attn_tp = self._uses_runtime_attn_tp(forward_batch)
         q = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)
 
         k_descale = None
@@ -2608,6 +3425,11 @@ class AiterAttnBackend(AttentionBackend):
         if self.use_mla:
             k_buffer = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
 
+            if self.forward_metadata.dcp_cp_world_size > 1:
+                # DCP decode over this rank's KV shard, returning (out, base-2
+                # lse) for the cross-rank merge.
+                return self._mla_decode_fwd_dcp(q, k_buffer, layer, k_descale)
+
             work_metadata = self.forward_metadata.work_metadata
             work_indptr = self.forward_metadata.work_indptr
             work_info_set = self.forward_metadata.work_info_set
@@ -2637,7 +3459,7 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map=reduce_partial_map,
                 q_scale=k_descale,
                 kv_scale=k_descale,
-                intra_batch_mode=intra_batch_mode,
+                intra_batch_mode=(True if runtime_attn_tp else intra_batch_mode),
                 num_kv_splits=num_kv_splits,
             )
         else:

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -221,8 +221,23 @@ class TritonAttnBackend(AttentionBackend):
             self.use_mla,
             self.use_verify_splitkv,
         )
-        self.dcp_size = get_parallel().attn_dcp_size
-        self.dcp_rank = get_parallel().attn_dcp_rank
+        # The DSPARK draft's KV never passes through _set_kv_buffer: dspark_kv_inject
+        # writes it with draft_model.write_target_hidden_kv() at the RAW cache_loc,
+        # so it is skipped by both the `loc // dcp_size` shard transform and the
+        # dcp_kv_mask owner filter and every rank ends up with a FULL copy. Running
+        # the DCP attention paths over a replicated pool is not just wasteful, it is
+        # wrong: _forward_extend_dcp merges the per-rank partials as if they covered
+        # disjoint keys, which inflates the prefix LSE by log(W) and over-weights the
+        # committed prefix against the in-hand window by a factor of W. A replicated
+        # pool is exactly the non-DCP case, so drive these paths with dcp_size = 1.
+        spec_alg = model_runner.spec_algorithm
+        self.is_dspark_draft = model_runner.is_draft_worker and spec_alg.is_dspark()
+        if self.is_dspark_draft:
+            self.dcp_size = 1
+            self.dcp_rank = 0
+        else:
+            self.dcp_size = get_parallel().attn_dcp_size
+            self.dcp_rank = get_parallel().attn_dcp_rank
         self.num_head = (
             model_runner.model_config.get_max_num_attention_heads()
             // get_parallel().attn_tp_size
@@ -1285,6 +1300,22 @@ class TritonAttnBackend(AttentionBackend):
         # dcp_size) through the masked path so each rank only stores the tokens
         # it owns. Non-DCP keeps the original write loc and plain set_kv_buffer.
         if self.dcp_size > 1:
+            if self.use_mla:
+                # The MLA pool's set_kv_buffer owner-filters by `loc % dcp_size`
+                # but never divides, and the hybrid pool drops `dcp_kv_mask` on
+                # its MLA branch, so the pre-divided loc below would have the
+                # owner filter applied twice. The set_mla_kv_buffer kernel is
+                # DCP-aware end to end (owner filter AND `loc // dcp_size`), so
+                # hand it the RAW virtual loc and the latent split into
+                # nope/rope.
+                kv_lora_rank = v.shape[-1]
+                self.token_to_kv_pool.set_mla_kv_buffer(
+                    layer,
+                    forward_batch.out_cache_loc,
+                    k[..., :kv_lora_rank],
+                    k[..., kv_lora_rank:],
+                )
+                return
             loc = forward_batch.out_cache_loc // self.dcp_size
             if (
                 forward_batch.positions is not None
@@ -1553,8 +1584,14 @@ class TritonAttnBackend(AttentionBackend):
         )
 
         # Select the replicated K/V heads matching this rank's Q shard.
+        # MLA is excluded: the absorbed path carries a single latent head, and
+        # the MHA companion an MLA model prefills with carries this rank's OWN
+        # heads (tp_k_head_num == tp_q_head_num), not a DCP-replicated set. K3
+        # at tp8/dcp8 has 12 of them, so slicing would leave 1-2 K/V heads
+        # against 12 Q heads -- silently wrong, and only on the zero-prefix
+        # batches that take the MHA path (gsm8k 200 at dcp8: 0.985 -> 0.535).
         if k.numel() > 0:
-            if layer.tp_k_head_num > 1:
+            if layer.tp_k_head_num > 1 and not self.use_mla:
                 kv_head_start = (
                     group.rank_in_group * layer.tp_k_head_num // group.world_size
                 )

--- a/python/sglang/srt/layers/cp/base.py
+++ b/python/sglang/srt/layers/cp/base.py
@@ -50,8 +50,7 @@ class ContextParallelStrategyKind(IntEnum):
         if value == "interleave":
             return cls.INTERLEAVE
         raise ValueError(
-            f"Unknown cp_strategy={value!r}; expected one of "
-            "{'zigzag', 'interleave'}"
+            f"Unknown cp_strategy={value!r}; expected one of {{'zigzag', 'interleave'}}"
         )
 
     @property
@@ -69,6 +68,7 @@ class CPAttentionBackendKind(IntEnum):
     FLASH_ATTENTION = 0
     DSA = 1
     TRTLLM_MHA = 2
+    AITER = 3
 
     @classmethod
     def from_string(cls, value: str) -> CPAttentionBackendKind:
@@ -78,9 +78,11 @@ class CPAttentionBackendKind(IntEnum):
             return cls.DSA
         if value == "trtllm_mha":
             return cls.TRTLLM_MHA
+        if value == "aiter":
+            return cls.AITER
         raise ValueError(
             f"Unsupported attention_backend={value!r} for CP strategy; expected one "
-            "of {'fa3', 'fa4', 'flashinfer', 'dsa', 'trtllm_mha'}"
+            "of {'fa3', 'fa4', 'flashinfer', 'dsa', 'trtllm_mha', 'aiter'}"
         )
 
 

--- a/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
+++ b/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
@@ -27,6 +27,8 @@ if TYPE_CHECKING:
 # equivalent to a normal TP-layout GEMM. Any model not on this list must not use
 # CP decode attention TP. Single arch-string source of truth for the whitelist.
 CP_DECODE_ATTN_TP_SUPPORTED_ARCHS: Tuple[str, ...] = (
+    # DeepSeek V3 / R1 (DeepseekV2 attention implementation)
+    "DeepseekV3ForCausalLM",
     # DeepSeek-V4
     "DeepseekV4ForCausalLM",
     "DeepseekV4ForCausalLMNextN",
@@ -70,14 +72,21 @@ class CpDecodeAttnTpContext:
         return self.decode_tp_size is not None and self.decode_tp_size > 1
 
     def set_decode_attn_tp(self, forward_batch: ForwardBatch):
+        self.use_decode_attn_tp = self.should_use_attn_tp(forward_batch)
+
+    def should_use_attn_tp(self, forward_batch: ForwardBatch) -> bool:
         if not self.is_enabled:
-            self.use_decode_attn_tp = False
-            return
+            return False
+        forward_mode = getattr(forward_batch, "forward_mode", None)
+        if forward_mode is not None and (
+            forward_mode.is_target_verify() or forward_mode.is_draft_extend_v2()
+        ):
+            return False
         # Skip during prefill context parallel (needs all heads); apply on every
         # other forward, which includes decode.
-        self.use_decode_attn_tp = not is_cp_v2_active(
+        return not is_cp_v2_active(forward_batch) and not dsa_use_prefill_cp(
             forward_batch
-        ) and not dsa_use_prefill_cp(forward_batch)
+        )
 
     def _slice(self, tensor: torch.Tensor, dim: int) -> torch.Tensor:
         assert dim in (0, 1)
@@ -151,15 +160,15 @@ class CpDecodeAttnTpContext:
         forward_batch: ForwardBatch,
         modules: list,
         tensor_attrs: List[Tuple] = None,
-        radix_attn: Optional[RadixAttention] = None,
+        radix_attn: Optional[RadixAttention | List[RadixAttention]] = None,
     ):
         """Activate decode attention TP for the duration of the block.
 
         Args:
             modules: Linear layers (ColumnParallel/RowParallel) to slice.
             tensor_attrs: (obj, attr_name, dim) tuples for absorbed weights.
-            radix_attn: RadixAttention instance whose tp_q_head_num should be
-                overridden to match the sliced head count during decode TP.
+            radix_attn: RadixAttention instance(s) whose tp_q_head_num should
+                be overridden to match the sliced head count during runtime TP.
         """
         self.set_decode_attn_tp(forward_batch)
         if not self.use_decode_attn_tp:
@@ -169,7 +178,7 @@ class CpDecodeAttnTpContext:
         all_attrs = []  # (obj, attr_name) pairs to restore
         size_overrides = []  # (linear, size_attr, orig_size)
         row_parallel_decode_flags = []  # (RowParallelLinear, orig_flag) to restore
-        orig_tp_q_head_num = None
+        radix_attn_overrides = []
         try:
             for linear in modules:
                 for obj, attr_name, dim in self._get_linear_attrs(linear):
@@ -199,12 +208,17 @@ class CpDecodeAttnTpContext:
                     all_attrs.append((obj, attr_name))
 
             if radix_attn is not None:
-                orig_tp_q_head_num = radix_attn.tp_q_head_num
-                radix_attn.tp_q_head_num = orig_tp_q_head_num // self.decode_tp_size
+                radix_attns = (
+                    radix_attn if isinstance(radix_attn, list) else [radix_attn]
+                )
+                for attn in radix_attns:
+                    orig_tp_q_head_num = attn.tp_q_head_num
+                    radix_attn_overrides.append((attn, orig_tp_q_head_num))
+                    attn.tp_q_head_num = orig_tp_q_head_num // self.decode_tp_size
             yield
         finally:
-            if radix_attn is not None and orig_tp_q_head_num is not None:
-                radix_attn.tp_q_head_num = orig_tp_q_head_num
+            for attn, orig_tp_q_head_num in reversed(radix_attn_overrides):
+                attn.tp_q_head_num = orig_tp_q_head_num
             for linear, orig_flag in reversed(row_parallel_decode_flags):
                 linear.use_decode_attn_tp = orig_flag
             for linear, size_attr, orig_size in reversed(size_overrides):

--- a/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
+++ b/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
@@ -15,6 +15,7 @@ import torch
 from sglang.srt.layers.attention.dsa.utils import dsa_use_prefill_cp
 from sglang.srt.layers.cp.utils import is_cp_v2_active
 from sglang.srt.layers.radix_attention import RadixAttention
+from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
 from sglang.srt.runtime_context import get_parallel
 
 logger = logging.getLogger(__name__)
@@ -84,8 +85,10 @@ class CpDecodeAttnTpContext:
             return False
         # Skip during prefill context parallel (needs all heads); apply on every
         # other forward, which includes decode.
-        return not is_cp_v2_active(forward_batch) and not dsa_use_prefill_cp(
-            forward_batch
+        return (
+            not is_cp_v2_active(forward_batch)
+            and not mla_use_prefill_cp(forward_batch)
+            and not dsa_use_prefill_cp(forward_batch)
         )
 
     def _slice(self, tensor: torch.Tensor, dim: int) -> torch.Tensor:
@@ -93,6 +96,71 @@ class CpDecodeAttnTpContext:
         chunk = tensor.shape[dim] // self.decode_tp_size
         sliced = tensor.narrow(dim, self.decode_tp_rank * chunk, chunk)
         return sliced if dim == 0 else sliced.contiguous()
+
+    @staticmethod
+    def _is_aiter_bpreshuffled_weight(obj, tensor: torch.Tensor) -> bool:
+        quant_method = getattr(obj, "quant_method", None)
+        if quant_method is None:
+            return False
+        try:
+            from sglang.srt.layers.quantization.fp8_utils import (
+                _use_aiter_bpreshuffle_gfx95,
+                aiter_w8a8_block_fp8_linear,
+                use_aiter_triton_gemm_w8a8_tuned_gfx950,
+            )
+        except ImportError:
+            return False
+        if (
+            not _use_aiter_bpreshuffle_gfx95
+            or getattr(quant_method, "w8a8_block_fp8_linear", None)
+            is not aiter_w8a8_block_fp8_linear
+        ):
+            return False
+        n, k = tensor.shape[-2:]
+        return not use_aiter_triton_gemm_w8a8_tuned_gfx950(n, k)
+
+    @staticmethod
+    def _unshuffle_aiter_weight(tensor: torch.Tensor) -> torch.Tensor:
+        """Invert ``aiter.ops.shuffle.shuffle_weight(..., (16, 16))``."""
+
+        n, k = tensor.shape[-2:]
+        n_lane = 16
+        k_block = 32
+        k_lane = 16 // tensor.element_size()
+        if n % n_lane != 0 or k % k_block != 0:
+            raise RuntimeError(
+                "Aiter pre-shuffled weight requires N divisible by 16 and "
+                f"K divisible by 32, got shape {(n, k)}"
+            )
+        return (
+            tensor.view(
+                -1, n // n_lane, k // k_block, k_block // k_lane, n_lane, k_lane
+            )
+            .permute(0, 1, 4, 2, 3, 5)
+            .contiguous()
+            .view_as(tensor)
+        )
+
+    def _slice_attr(
+        self,
+        obj,
+        attr_name: str,
+        tensor: torch.Tensor,
+        dim: int,
+    ) -> torch.Tensor:
+        if attr_name == "weight":
+            source_is_shuffled = self._is_aiter_bpreshuffled_weight(obj, tensor)
+            logical = (
+                self._unshuffle_aiter_weight(tensor) if source_is_shuffled else tensor
+            )
+            logical_slice = self._slice(logical, dim)
+            target_is_shuffled = self._is_aiter_bpreshuffled_weight(obj, logical_slice)
+            if target_is_shuffled:
+                from aiter.ops.shuffle import shuffle_weight
+
+                return shuffle_weight(logical_slice, (16, 16))
+            return logical_slice
+        return self._slice(tensor, dim)
 
     # ==================== Unified activate/restore ====================
 
@@ -115,7 +183,7 @@ class CpDecodeAttnTpContext:
         cache_key = (id(obj), attr_name)
         cache = self._slice_cache.get(cache_key)
         if cache is None:
-            cache = (raw, self._slice(raw, dim), is_param)
+            cache = (raw, self._slice_attr(obj, attr_name, raw, dim), is_param)
             self._slice_cache[cache_key] = cache
 
         if cache[2]:
@@ -212,13 +280,29 @@ class CpDecodeAttnTpContext:
                     radix_attn if isinstance(radix_attn, list) else [radix_attn]
                 )
                 for attn in radix_attns:
-                    orig_tp_q_head_num = attn.tp_q_head_num
-                    radix_attn_overrides.append((attn, orig_tp_q_head_num))
-                    attn.tp_q_head_num = orig_tp_q_head_num // self.decode_tp_size
+                    for attr_name in (
+                        "tp_q_head_num",
+                        "tp_k_head_num",
+                        "tp_v_head_num",
+                    ):
+                        orig_head_num = getattr(attn, attr_name)
+                        if orig_head_num % self.decode_tp_size != 0:
+                            if orig_head_num == 1:
+                                continue
+                            raise RuntimeError(
+                                f"{attr_name}={orig_head_num} is not divisible by "
+                                f"runtime attention TP size {self.decode_tp_size}"
+                            )
+                        radix_attn_overrides.append((attn, attr_name, orig_head_num))
+                        setattr(
+                            attn,
+                            attr_name,
+                            orig_head_num // self.decode_tp_size,
+                        )
             yield
         finally:
-            for attn, orig_tp_q_head_num in reversed(radix_attn_overrides):
-                attn.tp_q_head_num = orig_tp_q_head_num
+            for attn, attr_name, orig_head_num in reversed(radix_attn_overrides):
+                setattr(attn, attr_name, orig_head_num)
             for linear, orig_flag in reversed(row_parallel_decode_flags):
                 linear.use_decode_attn_tp = orig_flag
             for linear, size_attr, orig_size in reversed(size_overrides):

--- a/python/sglang/srt/layers/cp/interleave.py
+++ b/python/sglang/srt/layers/cp/interleave.py
@@ -64,6 +64,8 @@ class InterleaveCPStrategy(ContextParallelStrategy):
     def can_apply(self, num_tokens: int, forward_batch) -> bool:
         if not forward_batch.forward_mode.is_context_parallel_extend():
             return False
+        if getattr(forward_batch.forward_mode, "name", None) == "MIXED":
+            return False
         cp_size = self.cp_size
         seq_len = sum(forward_batch.extend_seq_lens_cpu)
         return seq_len > 0 and seq_len >= cp_size and cp_size > 1

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -17,6 +17,7 @@
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Optional, Tuple
 
+from sglang.srt.attn_parallel import AttnParallelMode
 from sglang.srt.layers.cp.base import (
     BaseContextParallelMetadata,
     ContextParallelStrategy,
@@ -137,7 +138,16 @@ def enable_cp_v2() -> bool:
 
 
 def is_cp_v2_active(forward_batch) -> bool:
-    """Return whether the current forward batch is running through CP-v2."""
+    """Return whether the current forward batch is running through CP-v2.
+
+    Scheduler-produced batches carry an immutable decision.  The legacy
+    derivation remains for isolated unit tests and worker-created batches that
+    do not pass through the scheduler.
+    """
+    stamped_mode = getattr(forward_batch, "attn_parallel_mode", None)
+    if stamped_mode is not None:
+        return AttnParallelMode(stamped_mode).is_cp
+
     if not enable_cp_v2():
         return False
     forward_mode = getattr(forward_batch, "forward_mode", None)
@@ -183,8 +193,14 @@ def prepare_cp_forward(forward_batch) -> None:
             sum(forward_batch.attn_cp_metadata.per_rank_actual_token)
         )
 
-    if getattr(forward_batch, "out_cache_loc", None) is not None:
-        forward_batch.out_cache_loc = forward_batch.out_cache_loc[:num_tokens]
+    out_cache_loc = getattr(forward_batch, "out_cache_loc", None)
+    if out_cache_loc is not None and out_cache_loc.shape[0] != num_tokens:
+        if out_cache_loc.shape[0] < num_tokens:
+            raise RuntimeError(
+                "CP-v2 received fewer cache locations than logical tokens: "
+                f"cache_locs={out_cache_loc.shape[0]}, tokens={num_tokens}"
+            )
+        forward_batch.out_cache_loc = out_cache_loc[:num_tokens]
 
 
 def cp_split_before_forward(

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -112,6 +112,8 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         forward_mode = getattr(forward_batch, "forward_mode", None)
         if forward_mode is not None and not forward_mode.is_context_parallel_extend():
             return False
+        if getattr(forward_mode, "name", None) == "MIXED":
+            return False
 
         extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
         if extend_lens is None:
@@ -338,6 +340,7 @@ class ZigzagCPStrategy(ContextParallelStrategy):
         return [
             CPAttentionBackendKind.FLASH_ATTENTION,
             CPAttentionBackendKind.TRTLLM_MHA,
+            CPAttentionBackendKind.AITER,
         ]
 
     def run_attention(

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -275,21 +275,24 @@ def all_gather_kv_cache_for_mla_extend(
     k_nope,
     k_pe,
 ):
-    cache_k_nope, cache_k_rope = token_to_kv_pool.get_mla_kv_buffer(
-        attn_mqa,
-        dcp_local_prefix_kv_indices,
-    )
-    extend_prefix_lens_cpu = torch.tensor(extend_prefix_lens_cpu)
-    # all gather kv cache into forward_batch.attn_dcp_metadata.dcp_kv_buffer
-    gathered_kv = all_gather_kv_cache_for_dcp(
-        cache_k_nope,
-        cache_k_rope,
-        extend_prefix_lens_cpu,
-        prefix_starts_cpu=torch.zeros_like(extend_prefix_lens_cpu),
-    )
-    dcp_kv_buffer[:dcp_extend_prefix_lens_sum] = gathered_kv
+    # Skip the all-gather when there is no cached prefix: an empty one launches
+    # a 0-sized kernel (HIP invalid configuration). The copy below still runs.
+    if dcp_extend_prefix_lens_sum > 0:
+        cache_k_nope, cache_k_rope = token_to_kv_pool.get_mla_kv_buffer(
+            attn_mqa,
+            dcp_local_prefix_kv_indices,
+        )
+        extend_prefix_lens_cpu = torch.tensor(extend_prefix_lens_cpu)
+        # all gather kv cache into forward_batch.attn_dcp_metadata.dcp_kv_buffer
+        gathered_kv = all_gather_kv_cache_for_dcp(
+            cache_k_nope,
+            cache_k_rope,
+            extend_prefix_lens_cpu,
+            prefix_starts_cpu=torch.zeros_like(extend_prefix_lens_cpu),
+        )
+        dcp_kv_buffer[:dcp_extend_prefix_lens_sum] = gathered_kv
 
-    # copy local kv cache into forward_batch.attn_dcp_metadata.dcp_kv_buffer
+    # copy local (in-hand) new-token kv cache into dcp_kv_buffer
     dcp_kv_buffer[
         dcp_extend_prefix_lens_sum:,
         ...,

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -292,6 +292,20 @@ def all_gather_kv_cache_for_mla_extend(
         )
         dcp_kv_buffer[:dcp_extend_prefix_lens_sum] = gathered_kv
 
+    # Model-runner warmup and DP-attention sync may pad the in-hand Q/K/V token
+    # dimension beyond the logical extend lengths used to size this metadata.
+    # Copy only the leading logical rows; any extra rows are trailing padding
+    # and do not belong to a request.
+    extend_token_count = dcp_kv_buffer.shape[0] - dcp_extend_prefix_lens_sum
+    if k_nope.shape[0] < extend_token_count or k_pe.shape[0] < extend_token_count:
+        raise RuntimeError(
+            "DCP prefill metadata expects more extend tokens than the model produced: "
+            f"expected={extend_token_count}, k_nope={k_nope.shape[0]}, "
+            f"k_pe={k_pe.shape[0]}"
+        )
+    k_nope = k_nope[:extend_token_count]
+    k_pe = k_pe[:extend_token_count]
+
     # copy local (in-hand) new-token kv cache into dcp_kv_buffer
     dcp_kv_buffer[
         dcp_extend_prefix_lens_sum:,

--- a/python/sglang/srt/layers/dcp/planner.py
+++ b/python/sglang/srt/layers/dcp/planner.py
@@ -139,13 +139,19 @@ def plan_dcp_decode_metadata(
     init_metadata_replay: bool,
     fast_decode_kwargs: dict,
     bs: int,
+    static_local_len_bounds: Optional[tuple[int, int]] = None,
 ):
     parallel = get_parallel()
     local_kv_lens = kv_lens.clone()
     update_local_kv_lens_for_dcp(local_kv_lens)
     local_kv_lens.clamp_(min=0)
 
-    if not init_metadata_replay:
+    if static_local_len_bounds is not None:
+        # (max, total) upper bounds for callers that can afford neither a
+        # GPU->CPU sync nor a CPU length array (cuda-graph target-verify).
+        # Over-estimating only sizes a grid and over-allocates a tail nobody reads.
+        max_local_len, total_local_len = static_local_len_bounds
+    elif not init_metadata_replay:
         max_local_len = (
             int(local_kv_lens.max().item()) if local_kv_lens.numel() > 0 else 0
         )

--- a/python/sglang/srt/layers/dcp/planner.py
+++ b/python/sglang/srt/layers/dcp/planner.py
@@ -63,6 +63,8 @@ def prepare_decode_context_parallel_metadata(
     extend_cu_prefix_lens[1:] = torch.cumsum(extend_prefix_lens, dim=0)
     extend_cu_prefix_lens = extend_cu_prefix_lens[:-1]
     extend_prefix_lens_sum = sum([i for i in extend_prefix_lens_cpu])
+    effective_seq_lens = extend_prefix_lens + extend_seq_lens
+    effective_seq_lens_sum = extend_prefix_lens_sum + int(extend_seq_lens.sum().item())
 
     dcp_prefix_kv_indices = torch.empty(
         sum(extend_prefix_lens_cpu),
@@ -83,10 +85,10 @@ def prepare_decode_context_parallel_metadata(
         dtype=torch.int32,
         device=get_device().device,
     )
-    dcp_kv_indptr[1:] = seq_lens.cumsum(dim=0)
+    dcp_kv_indptr[1:] = effective_seq_lens.cumsum(dim=0)
     dcp_kv_indptr = dcp_kv_indptr[: (len(seq_lens) + 1)]
     dcp_kv_indices = torch.zeros(
-        seq_lens_sum,
+        effective_seq_lens_sum,
         dtype=torch.int32,
         device=get_device().device,
     )
@@ -116,7 +118,7 @@ def prepare_decode_context_parallel_metadata(
     )
     dcp_kv_buffer = torch.empty(
         (
-            seq_lens_sum,
+            effective_seq_lens_sum,
             *kv_buffer_shape[1:],
         ),
         dtype=kv_cache_dtype,

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -5,6 +5,7 @@ from typing import Callable, List
 import torch
 import torch.nn.functional as F
 
+from sglang.srt.attn_parallel import AttnParallelMode
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     use_symmetric_memory,
 )
@@ -77,11 +78,24 @@ def is_mla_prefill_cp_enabled() -> bool:
     return get_parallel().enable_prefill_context_parallel and uses_mla_backend()
 
 
+def _batch_selects_cp(forward_batch) -> bool:
+    from sglang.srt.environ import envs
+
+    # CP-v1 predates scheduler batch stamps and derives applicability from its
+    # own metadata. Dynamic switching requires CP-v2, where the stamp is
+    # authoritative and must prevent a TP batch from falling back into CP-v1.
+    if not envs.SGLANG_ENABLE_CP_V2.get():
+        return True
+    stamped_mode = getattr(forward_batch, "attn_parallel_mode", None)
+    return stamped_mode is None or AttnParallelMode(stamped_mode) is AttnParallelMode.CP
+
+
 def mla_use_prefill_cp(forward_batch, mla_enable_prefill_cp=None):
     if mla_enable_prefill_cp is None:
         mla_enable_prefill_cp = is_mla_prefill_cp_enabled()
     return (
         forward_batch.attn_cp_metadata is not None
+        and _batch_selects_cp(forward_batch)
         and mla_enable_prefill_cp
         and forward_batch.forward_mode.is_context_parallel_extend()
     )
@@ -97,6 +111,7 @@ def can_cp_split(seq_len: int, cp_size: int, forward_batch):
     if not (
         cur_cp_seq_len != 0
         and cp_size > 1
+        and _batch_selects_cp(forward_batch)
         # prepare_context_parallel_metadata hard-codes bs_per_cp_group = 1;
         # guard explicitly to avoid silent mis-partitioning under continuous batching.
         and forward_batch.forward_mode.is_context_parallel_extend()

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -79,6 +79,7 @@ import msgspec
 import numpy as np
 import torch
 
+from sglang.srt.attn_parallel import AttnParallelMode, KvResidency
 from sglang.srt.constrained.base_grammar_backend import BaseGrammarObject
 from sglang.srt.disaggregation.base import BaseKVSender
 from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
@@ -943,6 +944,8 @@ class Req(ReqDllmMixin):
             ) + lora_id  # lora_id is concatenated to the extra key
 
         self.extra_key = extra_key
+        self.kv_residency: Optional[KvResidency] = None
+        self.kv_layout_tagged = False
         self.cache_salt = cache_salt or None
         self.lora_id = lora_id
         self.routing_key = routing_key
@@ -2138,6 +2141,11 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # === Config / flags crossing to ForwardBatch (by-value) ===
     forward_mode: ForwardMode = None
     global_forward_mode: Optional[ForwardMode] = None
+    # Stamped once after the scheduler finalizes this batch. Geometry-changing
+    # operations invalidate it back to None.
+    attn_parallel_mode: Optional[AttnParallelMode] = None
+    attn_parallel_veto_reason: Optional[str] = None
+    kv_residency: Optional[KvResidency] = None
 
     # For DP attention
     is_extend_in_batch: bool = False
@@ -2220,6 +2228,13 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         return_logprob = any(req.return_logprob for req in reqs)
 
         return_hidden_states_mode = get_batch_return_hidden_states_mode(reqs)
+        residencies = {
+            KvResidency(req.kv_residency)
+            for req in reqs
+            if req.kv_residency is not None
+        }
+        if len(residencies) > 1:
+            raise RuntimeError("A ScheduleBatch cannot mix KV residencies")
 
         batch = cls(
             reqs=reqs,
@@ -2241,6 +2256,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                 model_config.vocab_size,
             ),
             dllm_config=dllm_config,
+            kv_residency=(next(iter(residencies)) if residencies else None),
         )
         return batch
 
@@ -2386,6 +2402,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_extend(self):
         self.forward_mode = ForwardMode.EXTEND
+        self.attn_parallel_mode = None
+        self.attn_parallel_veto_reason = None
 
         if self.is_dllm():
             # For DLLM, we use a separate forward mode
@@ -2772,6 +2790,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def mix_with_running(self, running_batch: ScheduleBatch):
         self.forward_mode = ForwardMode.MIXED
+        self.attn_parallel_mode = None
+        self.attn_parallel_veto_reason = None
         running_bs = running_batch.batch_size()
 
         for req in running_batch.reqs:
@@ -2965,6 +2985,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_idle(self):
         self.forward_mode = ForwardMode.IDLE
+        self.attn_parallel_mode = None
+        self.attn_parallel_veto_reason = None
         self.input_ids = torch.empty(0, dtype=torch.int64, device=self.device)
         self.seq_lens = torch.empty(0, dtype=torch.int64, device=self.device)
         self.seq_lens_cpu = torch.empty(0, dtype=torch.int64)
@@ -3074,6 +3096,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
     def prepare_for_decode(self):
         self.forward_mode = ForwardMode.DECODE
+        self.attn_parallel_mode = None
+        self.attn_parallel_veto_reason = None
         # Decode embeds the last output token via embed_tokens; clear the stale
         # prefill-time tensor so it doesn't leak into ForwardBatch.
         self.input_embeds = None
@@ -3182,6 +3206,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.reqs = []
             self.return_hidden_states = False
             self.return_hidden_states_mode = CaptureHiddenMode.NULL
+            self.attn_parallel_mode = None
+            self.attn_parallel_veto_reason = None
             return
 
         if len(keep_indices) == len(self.reqs):
@@ -3208,6 +3234,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.out_cache_loc = None
         # Sum is recomputed lazily by ForwardBatch.init_new.
         self.seq_lens_sum = None
+        self.attn_parallel_mode = None
+        self.attn_parallel_veto_reason = None
 
         if self.input_ids is not None:
             self.input_ids = self.input_ids[keep_indices_device]
@@ -3246,6 +3274,14 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             )
 
     def merge_batch(self, other: ScheduleBatch):
+        if (
+            self.kv_residency is not None
+            and other.kv_residency is not None
+            and self.kv_residency != other.kv_residency
+        ):
+            raise RuntimeError("Cannot merge batches with different KV residencies")
+        if self.kv_residency is None:
+            self.kv_residency = other.kv_residency
         # Penalizer orchestrator must be merged before Batch.reqs is merged. This is because
         # orchestrator.merge() depends on Batch.reqs during preparation of each penalizers, so it
         # needs to be called with pre-merged Batch.reqs.
@@ -3266,6 +3302,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.out_cache_loc = None
         # Sum is recomputed lazily by ForwardBatch.init_new.
         self.seq_lens_sum = None
+        self.attn_parallel_mode = None
+        self.attn_parallel_veto_reason = None
         # Cat only when both sides hold a real token tensor; otherwise drop to
         # None and let resolve_forward_inputs rebuild from the merged
         # req_pool_indices. Mismatch arises e.g. with spec_v1, which keeps its
@@ -3325,6 +3363,9 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             req_pool_indices=self.req_pool_indices,
             model_config=self.model_config,
             forward_mode=self.forward_mode,
+            attn_parallel_mode=self.attn_parallel_mode,
+            attn_parallel_veto_reason=self.attn_parallel_veto_reason,
+            kv_residency=self.kv_residency,
             out_cache_loc=self.out_cache_loc,
             return_logprob=self.return_logprob,
             has_grammar=self.has_grammar,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3143,6 +3143,14 @@ class Scheduler(
             kv_residency=batch.kv_residency,
         )
         if (
+            self.server_args.enable_dynamic_attn_parallel
+            and self.server_args.dynamic_attn_parallel_min_prefill_tokens is None
+            and decision.mode is AttnParallelMode.CP
+        ):
+            decision = AttnParallelDecision(
+                AttnParallelMode.TP, "prefill_threshold_unset"
+            )
+        if (
             not self.server_args.enable_dynamic_attn_parallel
             and self.ps.attn_dcp_size > 1
             and (
@@ -3159,9 +3167,12 @@ class Scheduler(
             return
         if self.server_args.dynamic_attn_parallel_enable_dcp:
             prompt_len = len(req.full_untruncated_fill_ids or req.origin_input_ids)
+            striped_threshold = (
+                self.server_args.dynamic_attn_parallel_striped_min_context
+            )
             req.kv_residency = (
                 KvResidency.STRIPED
-                if prompt_len >= self.server_args.dynamic_attn_parallel_dcp_min_context
+                if striped_threshold is not None and prompt_len >= striped_threshold
                 else KvResidency.REPLICATED
             )
             if not req.kv_layout_tagged:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -59,6 +59,14 @@ import torch
 import torch.distributed
 from torch.distributed import barrier
 
+from sglang.srt.attn_parallel import (
+    AttnParallelDecision,
+    AttnParallelMode,
+    KvResidency,
+    kv_storage_dcp_size,
+    select_attn_parallel_mode,
+)
+
 if TYPE_CHECKING:
     from torch.cuda import Stream as CudaStream
 
@@ -106,6 +114,7 @@ from sglang.srt.dllm.mixin.scheduler import SchedulerDllmMixin
 from sglang.srt.environ import envs, exportable_env_vars
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
+from sglang.srt.layers.cp.base import get_cp_strategy
 from sglang.srt.layers.dp_attention import compute_dp_attention_world_info
 from sglang.srt.layers.moe import initialize_moe_config
 from sglang.srt.layers.quantization.fp4_utils import initialize_fp4_gemm_config
@@ -2114,7 +2123,7 @@ class Scheduler(
             full_tokens_per_layer=self.full_tokens_per_layer,
             swa_tokens_per_layer=self.swa_tokens_per_layer,
             max_total_num_tokens=self.max_total_num_tokens
-            * get_parallel().attn_dcp_size,
+            * kv_storage_dcp_size(get_parallel()),
             get_last_batch=lambda: self.last_batch,
             get_running_batch=lambda: self.running_batch,
         )
@@ -2263,7 +2272,7 @@ class Scheduler(
             min(
                 max_new_tokens,
                 self.max_req_len - input_len - 1,
-                self.max_total_num_tokens * get_parallel().attn_dcp_size
+                self.max_total_num_tokens * kv_storage_dcp_size(get_parallel())
                 - paged_input_len
                 - self.page_size
                 - 1,
@@ -3093,6 +3102,82 @@ class Scheduler(
         # todo hisparse, maybe other info to contain for the new batch
         return batch
 
+    def _stamp_attn_parallel_mode(self, batch: ScheduleBatch) -> None:
+        strategy = get_cp_strategy() if envs.SGLANG_ENABLE_CP_V2.get() else None
+        decision = select_attn_parallel_mode(
+            forward_mode=batch.forward_mode,
+            extend_seq_lens=(
+                batch.extend_lens
+                if not batch.forward_mode.is_decode_or_idle()
+                else None
+            ),
+            num_tokens=int(batch.extend_num_tokens or 0),
+            strategy=(strategy.name if strategy is not None else None),
+            cp_size=self.ps.attn_cp_size,
+            min_prefill_tokens=(
+                self.server_args.dynamic_attn_parallel_min_prefill_tokens
+                if self.server_args.enable_dynamic_attn_parallel
+                else None
+            ),
+            allow_mixed=self.server_args.dynamic_attn_parallel_allow_mixed,
+            enable_decode_dcp=(
+                self.ps.attn_dcp_size > 1
+                and (
+                    not self.server_args.enable_dynamic_attn_parallel
+                    or self.server_args.dynamic_attn_parallel_enable_dcp
+                )
+            ),
+            dcp_size=self.ps.attn_dcp_size,
+            decode_seq_lens=(
+                batch.seq_lens_cpu.tolist()
+                if batch.forward_mode.is_decode()
+                and batch.seq_lens_cpu is not None
+                and hasattr(batch.seq_lens_cpu, "tolist")
+                else batch.seq_lens_cpu if batch.forward_mode.is_decode() else None
+            ),
+            min_decode_context=(
+                self.server_args.dynamic_attn_parallel_dcp_min_context
+                if self.server_args.enable_dynamic_attn_parallel
+                else 1
+            ),
+            kv_residency=batch.kv_residency,
+        )
+        if (
+            not self.server_args.enable_dynamic_attn_parallel
+            and self.ps.attn_dcp_size > 1
+            and (
+                batch.forward_mode.is_target_verify()
+                or batch.forward_mode.is_draft_extend_v2()
+            )
+        ):
+            decision = AttnParallelDecision(AttnParallelMode.DCP)
+        batch.attn_parallel_mode = decision.mode
+        batch.attn_parallel_veto_reason = decision.veto_reason
+
+    def _ensure_req_kv_residency(self, req: Req) -> None:
+        if req.kv_residency is not None:
+            return
+        if self.server_args.dynamic_attn_parallel_enable_dcp:
+            prompt_len = len(req.full_untruncated_fill_ids or req.origin_input_ids)
+            req.kv_residency = (
+                KvResidency.STRIPED
+                if prompt_len >= self.server_args.dynamic_attn_parallel_dcp_min_context
+                else KvResidency.REPLICATED
+            )
+            if not req.kv_layout_tagged:
+                layout_tag = (
+                    f"|sglang-kv:{req.kv_residency.name.lower()}:"
+                    f"dcp{self.ps.attn_dcp_size}:epoch0"
+                )
+                req.extra_key = (req.extra_key or "") + layout_tag
+                req.kv_layout_tagged = True
+        else:
+            req.kv_residency = (
+                KvResidency.STRIPED
+                if self.ps.attn_dcp_size > 1
+                else KvResidency.REPLICATED
+            )
+
     @scheduler_nvtx_method("scheduler.get_next_batch_to_run")
     def get_next_batch_to_run(
         self, running_batch: ScheduleBatch, last_batch: Optional[ScheduleBatch]
@@ -3202,6 +3287,8 @@ class Scheduler(
             # Before merging the new batch into running batch:
             # 1. All new batches are none -> need_mlp_sync remains true (sync is needed for decode batch).
             # 2. All new batches are some (prefill / idle) -> we do not need prepare mlp sync one more time.
+            if new_batch is not None and new_batch.attn_parallel_mode is None:
+                self._stamp_attn_parallel_mode(new_batch)
             new_batch = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(new_batch)
             need_mlp_sync = new_batch is None
 
@@ -3216,6 +3303,11 @@ class Scheduler(
             else:
                 ret = None
 
+        # Stamp before the DP-attention sync so the existing all-gather can
+        # apply a rank-wide veto without introducing a new collective.
+        if ret is not None and ret.attn_parallel_mode is None:
+            self._stamp_attn_parallel_mode(ret)
+
         # Handle DP attention and log stats
         ret = self.dp_attn_adapter.maybe_prepare_mlp_sync_batch(
             ret, need_sync=need_mlp_sync
@@ -3228,6 +3320,17 @@ class Scheduler(
         )
 
         if ret:
+            if ret.attn_parallel_mode is None:
+                self._stamp_attn_parallel_mode(ret)
+            if (
+                self.server_args.enable_dynamic_attn_parallel
+                and self.metrics_collector is not None
+            ):
+                self.metrics_collector.increment_dynamic_attn_parallel_batch(
+                    mode=ret.attn_parallel_mode.name.lower(),
+                    veto_reason=ret.attn_parallel_veto_reason,
+                    vote_mismatch=ret.attn_parallel_veto_reason == "rank_veto",
+                )
             set_schedule_time_batch(ret)
             if self.enable_fpm:
                 ret.fpm_start_time = self._fpm_batch_t0
@@ -3289,6 +3392,18 @@ class Scheduler(
         ) and self.chunked_req is None:
             return None, running_batch
 
+        for running_req in running_batch.reqs:
+            self._ensure_req_kv_residency(running_req)
+        if running_batch.reqs and running_batch.kv_residency is None:
+            running_batch.kv_residency = running_batch.reqs[0].kv_residency
+        if self.chunked_req is not None:
+            self._ensure_req_kv_residency(self.chunked_req)
+
+        target_kv_residency = (
+            running_batch.kv_residency
+            if not running_batch.is_empty()
+            else self.chunked_req.kv_residency if self.chunked_req is not None else None
+        )
         running_bs = len(running_batch.reqs)
         # Skipped during a chunked prefill: that pass must proceed regardless.
         if (
@@ -3314,8 +3429,19 @@ class Scheduler(
             running_batch.batch_is_full = True
             return None, running_batch
 
+        # Residency is part of the radix namespace, so stamp it before LPM or
+        # any prefix-sensitive policy inspects the waiting queue.
+        for waiting_req in self.waiting_queue:
+            self._ensure_req_kv_residency(waiting_req)
+
         # Get priority queue
         self.policy.calc_priority(self.waiting_queue, running_batch)
+        if target_kv_residency is None and self.waiting_queue:
+            target_kv_residency = self.waiting_queue[0].kv_residency
+        if target_kv_residency is not None and hasattr(
+            self.token_to_kv_pool_allocator, "set_active_residency"
+        ):
+            self.token_to_kv_pool_allocator.set_active_residency(target_kv_residency)
 
         if TEST_RETRACT and running_bs > TEST_RETRACT_NO_PREFILL_BS:
             # If we are testing retraction and the running batch size exceeds
@@ -3340,7 +3466,11 @@ class Scheduler(
             prefill_tile_block_m = 64  # Fallback for non-Triton backends
 
         adder = PrefillAdder(
-            self.page_size,
+            (
+                self.token_to_kv_pool_allocator.page_size
+                if self.server_args.dynamic_attn_parallel_enable_dcp
+                else self.page_size
+            ),
             self.tree_cache,
             self.token_to_kv_pool_allocator,
             running_batch,
@@ -3381,6 +3511,11 @@ class Scheduler(
         # Get requests from the waiting queue to a new prefill batch
         for req in self.waiting_queue:
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
+                continue
+            self._ensure_req_kv_residency(req)
+            if target_kv_residency is None:
+                target_kv_residency = req.kv_residency
+            if req.kv_residency != target_kv_residency:
                 continue
 
             running_bs = len(running_batch.reqs)

--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Optional
 
 import torch
 
+from sglang.srt.attn_parallel import AttnParallelMode
 from sglang.srt.batch_overlap.two_batch_overlap import TboDPAttentionPreparer
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.distributed.parallel_state import get_tp_group
@@ -89,6 +90,7 @@ class MLPSyncBatchInfo:
     is_extend_in_batch: bool
     local_can_run_tbo: bool
     local_forward_mode: int
+    local_attn_parallel_mode: int
 
     # some gathered elements
     tp0_info_cpu: torch.Tensor = None
@@ -96,6 +98,8 @@ class MLPSyncBatchInfo:
     global_num_tokens_for_logprob: list[int] = None
     tbo_split_seq_index: torch.Tensor = None
     global_forward_mode: int = None
+    attn_parallel_mode: int = None
+    attn_parallel_vote_mismatch: bool = False
     dp_cooperation_info: Optional[DPCooperationInfo] = None
 
     def _get_local_tensor(self, device, dtype=torch.int64) -> torch.Tensor:
@@ -108,6 +112,7 @@ class MLPSyncBatchInfo:
                 int(self.local_can_run_tbo),
                 self.local_forward_mode,
                 int(self.can_run_prefill_cuda_graph),
+                self.local_attn_parallel_mode,
             ],
             device=device,
             dtype=dtype,
@@ -123,6 +128,7 @@ class MLPSyncBatchInfo:
                 1,  # local_can_run_tbo
                 ForwardMode.IDLE.value,  # local_forward_mode
                 0,  # can_run_prefill_cuda_graph
+                AttnParallelMode.DCP.value,  # permissive idle-rank sentinel
             ],
             device=device,
             dtype=dtype,
@@ -194,6 +200,18 @@ class MLPSyncBatchInfo:
         self.can_run_decode_cuda_graph = bool(tp0_info_cpu[:, 2].min())
         self.is_extend_in_batch = bool(tp0_info_cpu[:, 3].max())
         self.can_run_prefill_cuda_graph = bool(tp0_info_cpu[:, 6].min())
+        active_modes = tp0_info_cpu[tp0_info_cpu[:, 5] != ForwardMode.IDLE.value, 7]
+        if active_modes.numel() == 0:
+            self.attn_parallel_mode = self.local_attn_parallel_mode
+            self.attn_parallel_vote_mismatch = False
+        else:
+            first_mode = int(active_modes[0])
+            self.attn_parallel_vote_mismatch = bool((active_modes != first_mode).any())
+            self.attn_parallel_mode = (
+                AttnParallelMode.TP.value
+                if self.attn_parallel_vote_mismatch
+                else first_mode
+            )
         if _ENABLE_METRICS_DP_ATTENTION:
             self.dp_cooperation_info = DPCooperationInfo.create(
                 tp0_info_cpu[:, 5].tolist()
@@ -223,6 +241,12 @@ def _update_gather_batch(
     # Check forward mode for cuda graph
     batch.can_run_dp_cuda_graph = mlp_sync_info.can_run_decode_cuda_graph
     batch.can_run_dp_breakable_cuda_graph = mlp_sync_info.can_run_prefill_cuda_graph
+    batch.attn_parallel_mode = AttnParallelMode(mlp_sync_info.attn_parallel_mode)
+    if (
+        mlp_sync_info.attn_parallel_vote_mismatch
+        and batch.attn_parallel_mode is AttnParallelMode.TP
+    ):
+        batch.attn_parallel_veto_reason = "rank_veto"
 
 
 def prepare_mlp_sync_batch_raw(
@@ -341,7 +365,13 @@ def prepare_mlp_sync_batch_raw(
         is_extend_in_batch=is_extend_in_batch,
         local_can_run_tbo=local_can_run_tbo,
         local_forward_mode=local_forward_mode,
+        local_attn_parallel_mode=(
+            int(local_batch.attn_parallel_mode)
+            if local_batch is not None and local_batch.attn_parallel_mode is not None
+            else AttnParallelMode.DCP.value
+        ),
     )
+    mlp_sync_info.attn_parallel_mode = mlp_sync_info.local_attn_parallel_mode
 
     if not skip_all_gather:
         mlp_sync_info.all_gather(

--- a/python/sglang/srt/managers/scheduler_components/pool_stats_observer.py
+++ b/python/sglang/srt/managers/scheduler_components/pool_stats_observer.py
@@ -214,10 +214,20 @@ class SchedulerPoolStatsObserver:
         return pool_stats
 
     def _get_token_info(self) -> PoolStats:
-        available_size = self.token_to_kv_pool_allocator.available_size()
-        evictable_size = self.tree_cache.evictable_size()
-        num_used = self.max_total_num_tokens - (available_size + evictable_size)
-        token_usage = num_used / self.max_total_num_tokens
+        allocator = self.token_to_kv_pool_allocator
+        if hasattr(allocator, "total_available_size"):
+            # Residency-aware pools have independent capacities. Report the
+            # active namespace conservatively; striped mode currently requires
+            # radix cache off, so no cross-namespace evictable pages exist.
+            capacity = allocator.size
+            available_size = allocator.available_size()
+            evictable_size = 0
+        else:
+            capacity = self.max_total_num_tokens
+            available_size = allocator.available_size()
+            evictable_size = self.tree_cache.evictable_size()
+        num_used = capacity - (available_size + evictable_size)
+        token_usage = num_used / capacity
         return PoolStats(
             full_num_used=num_used,
             full_token_usage=token_usage,

--- a/python/sglang/srt/managers/tp_worker.py
+++ b/python/sglang/srt/managers/tp_worker.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
 
+from sglang.srt.attn_parallel import kv_storage_dcp_size
 from sglang.srt.distributed import get_pp_group, get_world_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
@@ -56,6 +57,7 @@ from sglang.srt.runtime_context import (
     get_device,
     get_exec,
     get_model,
+    get_parallel,
     get_schedule,
     get_serving,
     get_spec,
@@ -417,7 +419,8 @@ class TpModelWorker(BaseTpWorker):
         assert self.model_runner.max_running_requests > 0, "max_running_request is zero"
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens * self.ps.attn_dcp_size
+            self.model_runner.effective_max_total_num_tokens
+            * kv_storage_dcp_size(get_parallel())
             - 1,
         )
         assert max_req_len > 0, "Memory pool size is too small"
@@ -532,7 +535,8 @@ class TpModelWorker(BaseTpWorker):
     def get_worker_info(self):
         max_req_len = min(
             self.model_config.context_len - 1,
-            self.model_runner.effective_max_total_num_tokens * self.ps.attn_dcp_size
+            self.model_runner.effective_max_total_num_tokens
+            * kv_storage_dcp_size(get_parallel())
             - 1,
         )
         return (

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -13,6 +13,7 @@ from sglang.kernels.ops.memory.common import (
     get_last_loc_triton_safe,
     write_req_to_token_pool_triton,
 )
+from sglang.srt.attn_parallel import KvResidency
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
     maybe_write_dsv4_decode,
     maybe_write_dsv4_extend,
@@ -49,6 +50,15 @@ if TYPE_CHECKING:
     from sglang.srt.managers.schedule_batch import Req, ScheduleBatch
 
 logger = logging.getLogger(__name__)
+
+
+def _activate_batch_residency(batch: ScheduleBatch) -> None:
+    allocator = batch.tree_cache.token_to_kv_pool_allocator
+    if not hasattr(allocator, "set_active_residency"):
+        return
+    if batch.kv_residency is None:
+        raise RuntimeError("Residency-aware allocation requires a stamped batch")
+    allocator.set_active_residency(KvResidency(batch.kv_residency))
 
 
 def write_cache_indices(
@@ -288,6 +298,8 @@ def alloc_for_extend(
     (the last is the host/CPU mirror). ``alloc_req_slots`` raises ``RuntimeError``
     if the pool can't satisfy the batch (fail-loud — see its docstring).
     """
+    _activate_batch_residency(batch)
+
     # free out-of-window swa tokens
     batch.maybe_evict_swa()
 
@@ -525,6 +537,7 @@ def alloc_for_decode(batch: ScheduleBatch, token_per_req: int) -> torch.Tensor:
         out_cache_loc: allocated cache locations
     """
 
+    _activate_batch_residency(batch)
     batch.maybe_evict_swa()
 
     seq_lens_gpu = batch.seq_lens

--- a/python/sglang/srt/mem_cache/allocation_sizing.py
+++ b/python/sglang/srt/mem_cache/allocation_sizing.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from sglang.srt.attn_parallel import kv_storage_dcp_size
 from sglang.srt.runtime_context import (
     get_parallel,
     get_schedule,
@@ -11,7 +12,7 @@ from sglang.srt.runtime_context import (
 def get_alloc_page_size() -> int:
     # Mirrors _build_token_to_kv_pool_allocator's DCP branch; the platform
     # allocators that skip it page smaller, so this is an upper bound for them.
-    return get_schedule().page_size * get_parallel().attn_dcp_size
+    return get_schedule().page_size * kv_storage_dcp_size(get_parallel())
 
 
 def get_alloc_len_per_decode() -> int:

--- a/python/sglang/srt/mem_cache/allocator/__init__.py
+++ b/python/sglang/srt/mem_cache/allocator/__init__.py
@@ -5,11 +5,15 @@ from sglang.srt.mem_cache.allocator.paged import (
     PagedTokenToKVPoolAllocator,
     alloc_extend_naive,
 )
+from sglang.srt.mem_cache.allocator.residency import (
+    ResidencyAwarePagedTokenToKVPoolAllocator,
+)
 from sglang.srt.mem_cache.allocator.token import TokenToKVPoolAllocator
 
 __all__ = [
     "BaseTokenToKVPoolAllocator",
     "PagedTokenToKVPoolAllocator",
+    "ResidencyAwarePagedTokenToKVPoolAllocator",
     "TokenToKVPoolAllocator",
     "alloc_extend_naive",
 ]

--- a/python/sglang/srt/mem_cache/allocator/residency.py
+++ b/python/sglang/srt/mem_cache/allocator/residency.py
@@ -1,0 +1,217 @@
+"""Paged allocator with disjoint replicated and DCP-striped KV regions."""
+
+from __future__ import annotations
+
+import torch
+
+from sglang.srt.attn_parallel import KvResidency
+from sglang.srt.mem_cache.allocator.base import BaseTokenToKVPoolAllocator
+from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
+
+
+class ResidencyAwarePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
+    """Partition one physical MLA pool into two residency namespaces.
+
+    Replicated locs directly address the first physical region. Striped locs
+    use widened virtual IDs whose division by ``dcp_size`` addresses the second
+    region. Both allocators expose the same logical page size, so one radix tree
+    can safely hold entries from both namespaces when ``extra_key`` carries the
+    residency tag.
+    """
+
+    def __init__(
+        self,
+        *,
+        physical_size: int,
+        physical_page_size: int,
+        dcp_size: int,
+        replicated_fraction: float,
+        dtype: torch.dtype,
+        device: str,
+        kvcache,
+        need_sort: bool,
+    ):
+        if dcp_size <= 1:
+            raise ValueError("residency-aware allocator requires dcp_size > 1")
+        if not 0.0 < replicated_fraction < 1.0:
+            raise ValueError("replicated_fraction must be in (0, 1)")
+
+        logical_page_size = physical_page_size * dcp_size
+        replicated_size = (
+            int(physical_size * replicated_fraction) // logical_page_size
+        ) * logical_page_size
+        striped_physical_size = (
+            (physical_size - replicated_size) // physical_page_size
+        ) * physical_page_size
+        if (
+            replicated_size < logical_page_size
+            or striped_physical_size < physical_page_size
+        ):
+            raise ValueError("KV pool is too small for both residency regions")
+
+        super().__init__(
+            size=replicated_size + striped_physical_size * dcp_size,
+            page_size=logical_page_size,
+            dtype=dtype,
+            device=device,
+            kvcache=kvcache,
+            need_sort=need_sort,
+        )
+        self.dcp_size = dcp_size
+        self.physical_page_size = physical_page_size
+        self.logical_page_size = logical_page_size
+        self.physical_size = replicated_size + striped_physical_size
+        self.replicated_size = replicated_size
+        self.striped_physical_size = striped_physical_size
+        self.active_residency = KvResidency.REPLICATED
+
+        self.replicated = PagedTokenToKVPoolAllocator(
+            size=replicated_size,
+            page_size=logical_page_size,
+            dtype=dtype,
+            device=device,
+            kvcache=kvcache,
+            need_sort=need_sort,
+        )
+        self.striped = PagedTokenToKVPoolAllocator(
+            size=striped_physical_size * dcp_size,
+            page_size=logical_page_size,
+            dtype=dtype,
+            device=device,
+            kvcache=kvcache,
+            need_sort=need_sort,
+        )
+
+        # Paged allocator page IDs become physical addresses after loc/dcp.
+        # Offset the striped IDs past the replicated physical region.
+        striped_page_offset = replicated_size // physical_page_size
+        striped_pages = striped_physical_size // physical_page_size
+        self.striped.free_pages = torch.arange(
+            striped_page_offset + 1,
+            striped_page_offset + striped_pages + 1,
+            dtype=torch.int64,
+            device=device,
+        )
+        self.striped.release_pages = torch.empty(0, dtype=torch.int64, device=device)
+        self.striped_virtual_start = (striped_page_offset + 1) * logical_page_size
+        self.num_pages = replicated_size // logical_page_size + striped_pages
+        self.set_active_residency(KvResidency.REPLICATED)
+
+    def set_active_residency(self, residency: KvResidency) -> None:
+        residency = KvResidency(residency)
+        if residency is KvResidency.TRANSITIONING:
+            raise RuntimeError("cannot allocate while KV residency is transitioning")
+        self.active_residency = residency
+        if hasattr(self, "replicated"):
+            self.size = self._active.size
+            self.page_size = self._active.page_size
+
+    @property
+    def _active(self) -> PagedTokenToKVPoolAllocator:
+        return (
+            self.striped
+            if self.active_residency is KvResidency.STRIPED
+            else self.replicated
+        )
+
+    @property
+    def free_pages(self):
+        return torch.cat((self.replicated.free_pages, self.striped.free_pages))
+
+    @free_pages.setter
+    def free_pages(self, _value):
+        # BaseTokenToKVPoolAllocator initializes this before child allocators.
+        pass
+
+    @property
+    def release_pages(self):
+        return torch.cat((self.replicated.release_pages, self.striped.release_pages))
+
+    @release_pages.setter
+    def release_pages(self, _value):
+        pass
+
+    def available_size(self):
+        return self._active.available_size()
+
+    def total_available_size(self):
+        return self.replicated.available_size() + self.striped.available_size()
+
+    def get_kvcache(self):
+        return self._kvcache
+
+    def alloc(self, need_size: int):
+        return self._active.alloc(need_size)
+
+    def alloc_extend(self, *args, **kwargs):
+        return self._active.alloc_extend(*args, **kwargs)
+
+    def alloc_decode(self, *args, **kwargs):
+        return self._active.alloc_decode(*args, **kwargs)
+
+    def _split_indices(self, indices: torch.Tensor):
+        replicated_mask = indices < self.striped_virtual_start
+        return indices[replicated_mask], indices[~replicated_mask]
+
+    def free(self, free_index: torch.Tensor):
+        replicated, striped = self._split_indices(free_index)
+        self.replicated.free(replicated)
+        self.striped.free(striped)
+
+    def free_segment(self, free_index: torch.Tensor, *, start_pos: int):
+        replicated, striped = self._split_indices(free_index)
+        if replicated.numel():
+            self.replicated.free_segment(replicated, start_pos=start_pos)
+        if striped.numel():
+            self.striped.free_segment(striped, start_pos=start_pos)
+
+    def free_segments(self, segments):
+        for free_index, start_pos in segments:
+            self.free_segment(free_index, start_pos=start_pos)
+
+    def free_group_begin(self):
+        self.replicated.free_group_begin()
+        self.striped.free_group_begin()
+
+    def free_group_end(self):
+        self.replicated.free_group_end()
+        self.striped.free_group_end()
+
+    def merge_and_sort_free(self):
+        self.replicated.merge_and_sort_free()
+        self.striped.merge_and_sort_free()
+
+    def clear(self):
+        self.replicated.clear()
+        self.striped.clear()
+        striped_page_offset = self.replicated_size // self.physical_page_size
+        striped_pages = self.striped_physical_size // self.physical_page_size
+        self.striped.free_pages = torch.arange(
+            striped_page_offset + 1,
+            striped_page_offset + striped_pages + 1,
+            dtype=torch.int64,
+            device=self.device,
+        )
+
+    def translate_kv_indices_for_transfer(self, kv_indices: torch.Tensor):
+        replicated, striped = self._split_indices(kv_indices)
+        if replicated.numel() == 0:
+            return striped // self.dcp_size
+        if striped.numel() == 0:
+            return replicated
+        # Mixed transfers preserve request order; callers should split by
+        # residency before transfer rather than concatenate two address spaces.
+        raise RuntimeError("mixed-residency KV transfer is not supported")
+
+    def get_cpu_copy(self, indices, mamba_indices=None):
+        return self._kvcache.get_cpu_copy(indices, mamba_indices=mamba_indices)
+
+    def load_cpu_copy(self, kv_cache_cpu, indices, mamba_indices=None):
+        return self._kvcache.load_cpu_copy(
+            kv_cache_cpu, indices, mamba_indices=mamba_indices
+        )
+
+    def resize(self, config) -> None:
+        raise NotImplementedError(
+            "runtime resize is not supported for residency-aware KV allocation"
+        )

--- a/python/sglang/srt/mem_cache/allocator/residency.py
+++ b/python/sglang/srt/mem_cache/allocator/residency.py
@@ -43,14 +43,13 @@ class ResidencyAwarePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         striped_physical_size = (
             (physical_size - replicated_size) // physical_page_size
         ) * physical_page_size
-        if (
-            replicated_size < logical_page_size
-            or striped_physical_size < physical_page_size
-        ):
+        striped_pages = striped_physical_size // physical_page_size - (dcp_size - 1)
+        striped_usable_physical_size = striped_pages * physical_page_size
+        if replicated_size < logical_page_size or striped_pages < 1:
             raise ValueError("KV pool is too small for both residency regions")
 
         super().__init__(
-            size=replicated_size + striped_physical_size * dcp_size,
+            size=replicated_size + striped_usable_physical_size * dcp_size,
             page_size=logical_page_size,
             dtype=dtype,
             device=device,
@@ -60,9 +59,11 @@ class ResidencyAwarePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         self.dcp_size = dcp_size
         self.physical_page_size = physical_page_size
         self.logical_page_size = logical_page_size
-        self.physical_size = replicated_size + striped_physical_size
+        self.physical_size = physical_size
         self.replicated_size = replicated_size
-        self.striped_physical_size = striped_physical_size
+        self.striped_physical_size = striped_usable_physical_size
+        self.striped_page_start = replicated_size // physical_page_size + dcp_size
+        self.striped_pages = striped_pages
         self.active_residency = KvResidency.REPLICATED
 
         self.replicated = PagedTokenToKVPoolAllocator(
@@ -74,7 +75,7 @@ class ResidencyAwarePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             need_sort=need_sort,
         )
         self.striped = PagedTokenToKVPoolAllocator(
-            size=striped_physical_size * dcp_size,
+            size=striped_usable_physical_size * dcp_size,
             page_size=logical_page_size,
             dtype=dtype,
             device=device,
@@ -84,16 +85,14 @@ class ResidencyAwarePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
 
         # Paged allocator page IDs become physical addresses after loc/dcp.
         # Offset the striped IDs past the replicated physical region.
-        striped_page_offset = replicated_size // physical_page_size
-        striped_pages = striped_physical_size // physical_page_size
         self.striped.free_pages = torch.arange(
-            striped_page_offset + 1,
-            striped_page_offset + striped_pages + 1,
+            self.striped_page_start,
+            self.striped_page_start + self.striped_pages,
             dtype=torch.int64,
             device=device,
         )
         self.striped.release_pages = torch.empty(0, dtype=torch.int64, device=device)
-        self.striped_virtual_start = (striped_page_offset + 1) * logical_page_size
+        self.striped_virtual_start = self.striped_page_start * logical_page_size
         self.num_pages = replicated_size // logical_page_size + striped_pages
         self.set_active_residency(KvResidency.REPLICATED)
 
@@ -166,8 +165,7 @@ class ResidencyAwarePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
             self.striped.free_segment(striped, start_pos=start_pos)
 
     def free_segments(self, segments):
-        for free_index, start_pos in segments:
-            self.free_segment(free_index, start_pos=start_pos)
+        super().free_segments(segments)
 
     def free_group_begin(self):
         self.replicated.free_group_begin()
@@ -184,14 +182,16 @@ class ResidencyAwarePagedTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def clear(self):
         self.replicated.clear()
         self.striped.clear()
-        striped_page_offset = self.replicated_size // self.physical_page_size
-        striped_pages = self.striped_physical_size // self.physical_page_size
         self.striped.free_pages = torch.arange(
-            striped_page_offset + 1,
-            striped_page_offset + striped_pages + 1,
+            self.striped_page_start,
+            self.striped_page_start + self.striped_pages,
             dtype=torch.int64,
             device=self.device,
         )
+        self.striped.release_pages = torch.empty(
+            0, dtype=torch.int64, device=self.device
+        )
+        self.set_active_residency(KvResidency.REPLICATED)
 
     def translate_kv_indices_for_transfer(self, kv_indices: torch.Tensor):
         replicated, striped = self._split_indices(kv_indices)

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1775,7 +1775,11 @@ class KVCacheConfigurator:
                             need_sort=need_sort,
                         )
                     else:
-                        if get_parallel().dynamic_attn_parallel_enable_dcp:
+                        if (
+                            get_parallel().dynamic_attn_parallel_enable_dcp
+                            and get_parallel().dynamic_attn_parallel_striped_min_context
+                            is not None
+                        ):
                             token_to_kv_pool_allocator = ResidencyAwarePagedTokenToKVPoolAllocator(
                                 physical_size=sizes.max_total_num_tokens,
                                 physical_page_size=get_schedule().page_size,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 import msgspec
 import torch
 
+from sglang.srt.attn_parallel import kv_storage_dcp_size
 from sglang.srt.configs.hybrid_arch import (
     hybrid_gdn_config,
     kimi_linear_config,
@@ -35,6 +36,7 @@ from sglang.srt.mem_cache.allocation_sizing import get_req_to_token_extra_contex
 from sglang.srt.mem_cache.allocator import (
     BaseTokenToKVPoolAllocator,
     PagedTokenToKVPoolAllocator,
+    ResidencyAwarePagedTokenToKVPoolAllocator,
     TokenToKVPoolAllocator,
 )
 from sglang.srt.mem_cache.allocator.hisparse import (
@@ -1773,15 +1775,32 @@ class KVCacheConfigurator:
                             need_sort=need_sort,
                         )
                     else:
-                        token_to_kv_pool_allocator = PagedTokenToKVPoolAllocator(
-                            sizes.max_total_num_tokens * get_parallel().attn_dcp_size,
-                            page_size=get_schedule().page_size
-                            * get_parallel().attn_dcp_size,
-                            dtype=self.kv_cache_dtype,
-                            device=self.device,
-                            kvcache=token_to_kv_pool,
-                            need_sort=need_sort,
-                        )
+                        if get_parallel().dynamic_attn_parallel_enable_dcp:
+                            token_to_kv_pool_allocator = ResidencyAwarePagedTokenToKVPoolAllocator(
+                                physical_size=sizes.max_total_num_tokens,
+                                physical_page_size=get_schedule().page_size,
+                                dcp_size=get_parallel().attn_dcp_size,
+                                replicated_fraction=(
+                                    get_parallel().dynamic_attn_parallel_replicated_kv_fraction
+                                ),
+                                dtype=self.kv_cache_dtype,
+                                device=self.device,
+                                kvcache=token_to_kv_pool,
+                                need_sort=need_sort,
+                            )
+                            token_to_kv_pool.residency_allocator = (
+                                token_to_kv_pool_allocator
+                            )
+                        else:
+                            loc_scale = kv_storage_dcp_size(get_parallel())
+                            token_to_kv_pool_allocator = PagedTokenToKVPoolAllocator(
+                                sizes.max_total_num_tokens * loc_scale,
+                                page_size=get_schedule().page_size * loc_scale,
+                                dtype=self.kv_cache_dtype,
+                                device=self.device,
+                                kvcache=token_to_kv_pool,
+                                need_sort=need_sort,
+                            )
 
             if get_memory().enable_hisparse and is_dsv4_model:
                 assert self.is_hybrid_swa, "DeepSeek V4 HiSparse requires SWA mode."

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -49,6 +49,7 @@ from sglang.kernels.ops.kvcache.cache_move import (
 )
 from sglang.kernels.ops.kvcache.kvcache import can_use_store_cache, store_cache
 from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype, is_fp8_fnuz
+from sglang.srt.attn_parallel import KvResidency, kv_storage_dcp_size
 from sglang.srt.configs.mamba_utils import BaseLinearStateParams
 from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
 from sglang.srt.environ import envs
@@ -4149,6 +4150,16 @@ class MLATokenToKVPool(KVCache):
     def get_kv_buffer(self, layer_id: int):
         return self.get_key_buffer(layer_id), self.get_value_buffer(layer_id)
 
+    def _active_storage_dcp_size(self) -> int:
+        allocator = getattr(self, "residency_allocator", None)
+        if allocator is not None:
+            return (
+                allocator.dcp_size
+                if allocator.active_residency is KvResidency.STRIPED
+                else 1
+            )
+        return kv_storage_dcp_size(get_parallel())
+
     def set_kv_buffer(
         self,
         layer: RadixAttention,
@@ -4158,17 +4169,24 @@ class MLATokenToKVPool(KVCache):
         layer_id_override: Optional[int] = None,
     ):
         loc, _, _ = unwrap_write_loc(loc_info)
-        maybe_detect_oob(loc, 0, self.size + self.page_size, "set_kv_buffer (MLA)")
         layer_id = (
             layer_id_override if layer_id_override is not None else layer.layer_id
         )
         assert not self.dsa_kv_cache_store_fp8
         parallel = get_parallel()
-        if parallel.dcp_enabled:
-            valid_mask = loc % parallel.attn_dcp_size == parallel.attn_dcp_rank
+        storage_dcp_size = self._active_storage_dcp_size()
+        maybe_detect_oob(
+            loc,
+            0,
+            (self.size + self.page_size) * storage_dcp_size,
+            "set_kv_buffer (MLA)",
+        )
+        if storage_dcp_size > 1:
+            valid_mask = loc % storage_dcp_size == parallel.attn_dcp_rank
             if not valid_mask.all():
                 loc = loc[valid_mask]
                 cache_k = cache_k[valid_mask]
+            loc = loc // storage_dcp_size
         if cache_k.dtype != self.dtype:
             cache_k = cache_k.to(self.dtype)
 
@@ -4185,8 +4203,11 @@ class MLATokenToKVPool(KVCache):
         loc: torch.Tensor,
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
+        storage_dcp_size: int,
     ) -> None:
         if _is_hip and self.use_dsa and self.dtype == fp8_dtype:
+            if storage_dcp_size > 1:
+                raise RuntimeError("ROCm FP8 MLA KV write does not support striped DCP")
             # HIP FP8 path uses raw MLA KV layout (nope + rope) without per-block scales.
             # Fuse BF16/FP16 -> FP8 cast with paged KV write.
             set_mla_kv_buffer_triton_fp8_quant(
@@ -4212,6 +4233,8 @@ class MLATokenToKVPool(KVCache):
                 loc,
                 cache_k_nope_fp8,
                 cache_k_rope_fp8,
+                dcp_world_size=storage_dcp_size,
+                dcp_rank=get_parallel().attn_dcp_rank,
             )
         else:
             if cache_k_nope.dtype != self.dtype:
@@ -4226,6 +4249,8 @@ class MLATokenToKVPool(KVCache):
                 loc,
                 cache_k_nope,
                 cache_k_rope,
+                dcp_world_size=storage_dcp_size,
+                dcp_rank=get_parallel().attn_dcp_rank,
             )
 
     def set_mla_kv_buffer(
@@ -4236,11 +4261,11 @@ class MLATokenToKVPool(KVCache):
         cache_k_rope: torch.Tensor,
         layer_id_override: Optional[int] = None,
     ):
-        # loc is widened under DCP; the kernel divides by the world size itself.
+        storage_dcp_size = self._active_storage_dcp_size()
         maybe_detect_oob(
             loc,
             0,
-            (self.size + self.page_size) * get_parallel().attn_dcp_size,
+            (self.size + self.page_size) * storage_dcp_size,
             "set_mla_kv_buffer (MLA)",
         )
         layer_id = (
@@ -4251,6 +4276,7 @@ class MLATokenToKVPool(KVCache):
             loc,
             cache_k_nope,
             cache_k_rope,
+            storage_dcp_size,
         )
 
     def get_mla_kv_buffer(
@@ -4278,7 +4304,8 @@ class MLATokenToKVPool(KVCache):
 
     def move_kv_cache(self, tgt_loc: torch.Tensor, src_loc: torch.Tensor):
         """Relocate accepted-token combined MLA KV (latent + rope) per layer."""
-        size_limit = self.size + self.page_size
+        storage_dcp_size = self._active_storage_dcp_size()
+        size_limit = (self.size + self.page_size) * storage_dcp_size
         maybe_detect_oob(tgt_loc, 0, size_limit, "move_kv_cache tgt_loc")
         maybe_detect_oob(src_loc, 0, size_limit, "move_kv_cache src_loc")
 
@@ -4287,6 +4314,17 @@ class MLATokenToKVPool(KVCache):
 
         tgt_loc_flat = tgt_loc.view(-1).long()
         src_loc_flat = src_loc.view(-1).long()
+        if storage_dcp_size > 1:
+            rank = get_parallel().attn_dcp_rank
+            tgt_owner = tgt_loc_flat % storage_dcp_size == rank
+            src_owner = src_loc_flat % storage_dcp_size == rank
+            if not torch.equal(tgt_owner, src_owner):
+                raise RuntimeError(
+                    "DCP KV relocation changed token ownership between source "
+                    "and destination"
+                )
+            tgt_loc_flat = tgt_loc_flat[tgt_owner] // storage_dcp_size
+            src_loc_flat = src_loc_flat[src_owner] // storage_dcp_size
         for kv_cache in self.kv_buffer:
             kv_cache[tgt_loc_flat] = kv_cache[src_loc_flat]
 

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4160,6 +4160,9 @@ class MLATokenToKVPool(KVCache):
             )
         return kv_storage_dcp_size(get_parallel())
 
+    def active_storage_dcp_size(self) -> int:
+        return self._active_storage_dcp_size()
+
     def set_kv_buffer(
         self,
         layer: RadixAttention,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -37,6 +37,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Set, Tuple, Un
 import torch
 
 from sglang.kernels.ops.attention.position import compute_position_triton
+from sglang.srt.attn_parallel import AttnParallelMode, KvResidency
 from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.environ import envs
 from sglang.srt.kv_canary.req_to_expected_token_ids_manager import (
@@ -449,6 +450,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     can_run_dp_cuda_graph: bool = False
     can_run_dp_breakable_cuda_graph: bool = False
     global_forward_mode: Optional[ForwardMode] = None
+    attn_parallel_mode: Optional[AttnParallelMode] = None
+    kv_residency: Optional[KvResidency] = None
 
     # For two-batch overlap
     tbo_split_seq_index: Optional[int] = None
@@ -791,6 +794,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             can_run_dp_cuda_graph=batch.can_run_dp_cuda_graph,
             can_run_dp_breakable_cuda_graph=batch.can_run_dp_breakable_cuda_graph,
             global_forward_mode=batch.global_forward_mode,
+            attn_parallel_mode=(
+                batch.attn_parallel_mode
+                if batch.attn_parallel_mode is not None
+                else AttnParallelMode.TP
+            ),
+            kv_residency=batch.kv_residency,
             is_prefill_only=batch.is_prefill_only,
             spec_algorithm=batch.spec_algorithm,
             capture_hidden_mode=capture_hidden_mode,
@@ -1729,6 +1738,8 @@ def build_inner_fb_view(
         batch_size=bs,
         forward_mode=forward_mode,
         actual_forward_mode=forward_batch.forward_mode,
+        attn_parallel_mode=forward_batch.attn_parallel_mode,
+        kv_residency=forward_batch.kv_residency,
         input_ids=getattr(forward_batch, "input_ids", None),
         positions=getattr(forward_batch, "positions", None),
         req_pool_indices=forward_batch.req_pool_indices,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -204,6 +204,8 @@ def build_replay_fb_view(
             else buffers.mamba_track_indices[:bs]
         ),
         spec_info=forward_batch.spec_info,
+        attn_parallel_mode=forward_batch.attn_parallel_mode,
+        kv_residency=forward_batch.kv_residency,
     )
 
 
@@ -1131,29 +1133,38 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         dsa_variants = (
             ["dense", "sparse"] if getattr(self, "dsa_dual_graph", False) else [None]
         )
-        attn_parallel_variants = (
-            [
+        dynamic_dcp = getattr(
+            self.model_runner.server_args,
+            "enable_dynamic_attn_parallel",
+            False,
+        ) and getattr(
+            self.model_runner.server_args,
+            "dynamic_attn_parallel_enable_dcp",
+            False,
+        )
+        if dynamic_dcp:
+            attn_parallel_variants = [
                 (AttnParallelMode.TP, KvResidency.REPLICATED),
                 (AttnParallelMode.DCP, KvResidency.REPLICATED),
-                (AttnParallelMode.DCP, KvResidency.STRIPED),
             ]
-            if getattr(
-                self.model_runner.server_args,
-                "enable_dynamic_attn_parallel",
-                False,
-            )
-            and getattr(
-                self.model_runner.server_args,
-                "dynamic_attn_parallel_enable_dcp",
-                False,
-            )
-            else [
+            if (
+                getattr(
+                    self.model_runner.server_args,
+                    "dynamic_attn_parallel_striped_min_context",
+                    None,
+                )
+                is not None
+            ):
+                attn_parallel_variants.append(
+                    (AttnParallelMode.DCP, KvResidency.STRIPED)
+                )
+        else:
+            attn_parallel_variants = [
                 (
                     self._resolve_attn_parallel_mode(),
                     self._resolve_kv_residency(),
                 )
             ]
-        )
         for bs in capture_range:
             if get_parallel().tp_rank == 0:
                 avail_mem = get_available_gpu_memory(
@@ -1193,6 +1204,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         _set_capture_dsa_variant(None)
         self._capture_attn_parallel_mode = None
         self._capture_kv_residency = None
+        allocator = self.model_runner.token_to_kv_pool_allocator
+        if hasattr(allocator, "set_active_residency"):
+            allocator.set_active_residency(KvResidency.REPLICATED)
 
     def capture_one_shape(
         self,

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -36,6 +36,11 @@ import torch
 import tqdm
 from torch.profiler import ProfilerActivity, profile
 
+from sglang.srt.attn_parallel import (
+    AttnParallelMode,
+    KvResidency,
+    resolve_kv_residency,
+)
 from sglang.srt.compilation import torch_compile_decoration
 from sglang.srt.compilation.torch_compile_decoration import set_torch_compile_config
 from sglang.srt.distributed.parallel_state import (
@@ -542,14 +547,46 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         return torch.int64
 
     def _make_graph_key(
-        self, size, stream_idx=None, variant_label=None, dsa_variant=None
+        self,
+        size,
+        stream_idx=None,
+        variant_label=None,
+        dsa_variant=None,
+        attn_parallel_mode=None,
+        kv_residency=None,
     ):
         return ShapeKey(
             size=size,
             stream_idx=stream_idx,
             variant_label=variant_label,
             dsa_variant=dsa_variant,
+            attn_parallel_mode=(
+                int(attn_parallel_mode) if attn_parallel_mode is not None else None
+            ),
+            kv_residency=(int(kv_residency) if kv_residency is not None else None),
         )
+
+    def _resolve_attn_parallel_mode(
+        self, forward_batch: Optional[ForwardBatch] = None
+    ) -> AttnParallelMode:
+        if forward_batch is not None and forward_batch.attn_parallel_mode is not None:
+            return AttnParallelMode(forward_batch.attn_parallel_mode)
+        capture_mode = getattr(self, "_capture_attn_parallel_mode", None)
+        if capture_mode is not None:
+            return AttnParallelMode(capture_mode)
+        return (
+            AttnParallelMode.DCP if get_parallel().dcp_enabled else AttnParallelMode.TP
+        )
+
+    def _resolve_kv_residency(
+        self, forward_batch: Optional[ForwardBatch] = None
+    ) -> KvResidency:
+        if forward_batch is not None and forward_batch.kv_residency is not None:
+            return KvResidency(forward_batch.kv_residency)
+        capture_residency = getattr(self, "_capture_kv_residency", None)
+        if capture_residency is not None:
+            return KvResidency(capture_residency)
+        return resolve_kv_residency(get_parallel())
 
     def _capture_graph_size(self, *, bs: int, num_tokens: int) -> int:
         return num_tokens if self.ragged_verify_mode else bs
@@ -685,6 +722,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             cuda_graph_bs,
             stream_idx=get_current_stream_idx() if self.enable_pdmux else None,
             variant_label=self._resolve_lora_variant(forward_batch),
+            dsa_variant=self._resolve_dsa_variant(forward_batch),
+            attn_parallel_mode=self._resolve_attn_parallel_mode(forward_batch),
+            kv_residency=self._resolve_kv_residency(forward_batch),
         )
 
         is_bs_supported = (
@@ -983,6 +1023,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             capture_hidden_mode=self.capture_hidden_mode,
             num_token_non_padded=buffers.num_token_non_padded,
             global_forward_mode=self.capture_forward_mode,
+            attn_parallel_mode=self._resolve_attn_parallel_mode(),
+            kv_residency=self._resolve_kv_residency(),
             lora_ids=lora_ids,
             rids_int=rids_int,
             bootstrap_room_ids_int=bootstrap_room_ids_int,
@@ -1089,6 +1131,29 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         dsa_variants = (
             ["dense", "sparse"] if getattr(self, "dsa_dual_graph", False) else [None]
         )
+        attn_parallel_variants = (
+            [
+                (AttnParallelMode.TP, KvResidency.REPLICATED),
+                (AttnParallelMode.DCP, KvResidency.REPLICATED),
+                (AttnParallelMode.DCP, KvResidency.STRIPED),
+            ]
+            if getattr(
+                self.model_runner.server_args,
+                "enable_dynamic_attn_parallel",
+                False,
+            )
+            and getattr(
+                self.model_runner.server_args,
+                "dynamic_attn_parallel_enable_dcp",
+                False,
+            )
+            else [
+                (
+                    self._resolve_attn_parallel_mode(),
+                    self._resolve_kv_residency(),
+                )
+            ]
+        )
         for bs in capture_range:
             if get_parallel().tp_rank == 0:
                 avail_mem = get_available_gpu_memory(
@@ -1104,21 +1169,30 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 _set_capture_lora_variant(variant_label)
                 for dsa_variant in dsa_variants:
                     _set_capture_dsa_variant(dsa_variant)
-                    with torch_compile_decoration.patch_model(
-                        self.model_runner.model,
-                        bs in self.compile_bs,
-                        num_tokens=bs * self.captured_req_width,
-                        tp_group=self.model_runner.tp_group,
-                    ) as forward:
-                        if dsa_variant is None:
-                            self.capture_one_shape(
-                                bs, forward, stream_idx, variant_label
-                            )
-                        else:
-                            self.capture_one_shape(
-                                bs, forward, stream_idx, variant_label, dsa_variant
-                            )
+                    for attn_parallel_mode, kv_residency in attn_parallel_variants:
+                        self._capture_attn_parallel_mode = attn_parallel_mode
+                        self._capture_kv_residency = kv_residency
+                        with torch_compile_decoration.patch_model(
+                            self.model_runner.model,
+                            bs in self.compile_bs,
+                            num_tokens=bs * self.captured_req_width,
+                            tp_group=self.model_runner.tp_group,
+                        ) as forward:
+                            if dsa_variant is None:
+                                self.capture_one_shape(
+                                    bs, forward, stream_idx, variant_label
+                                )
+                            else:
+                                self.capture_one_shape(
+                                    bs,
+                                    forward,
+                                    stream_idx,
+                                    variant_label,
+                                    dsa_variant,
+                                )
         _set_capture_dsa_variant(None)
+        self._capture_attn_parallel_mode = None
+        self._capture_kv_residency = None
 
     def capture_one_shape(
         self,
@@ -1216,6 +1290,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     stream_idx,
                     variant_label,
                     dsa_variant,
+                    self._resolve_attn_parallel_mode(forward_batch),
+                    self._resolve_kv_residency(forward_batch),
                 )
                 post_warmup_hook = getattr(
                     self.model_runner.attn_backend,
@@ -1287,7 +1363,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             dsa_variant = self._resolve_dsa_variant(forward_batch)
             stream_idx = get_current_stream_idx() if self.enable_pdmux else None
             self._replay_graph_key = self._make_graph_key(
-                graph_size_key, stream_idx, variant_label, dsa_variant
+                graph_size_key,
+                stream_idx,
+                variant_label,
+                dsa_variant,
+                self._resolve_attn_parallel_mode(forward_batch),
+                self._resolve_kv_residency(forward_batch),
             )
             return
 
@@ -1380,7 +1461,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         dsa_variant = self._resolve_dsa_variant(forward_batch)
         stream_idx = get_current_stream_idx() if self.enable_pdmux else None
         self._replay_graph_key = self._make_graph_key(
-            graph_size_key, stream_idx, variant_label, dsa_variant
+            graph_size_key,
+            stream_idx,
+            variant_label,
+            dsa_variant,
+            self._resolve_attn_parallel_mode(forward_batch),
+            self._resolve_kv_residency(forward_batch),
         )
 
     def _ragged_graph_num_tokens(self, total_verify_tokens: int) -> int:

--- a/python/sglang/srt/model_executor/runner/eager_runner.py
+++ b/python/sglang/srt/model_executor/runner/eager_runner.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, Any, Tuple, Union
 
 import torch
 
+from sglang.srt.attn_parallel import kv_storage_dcp_size
 from sglang.srt.dllm.config import DllmConfig
 from sglang.srt.environ import envs
 from sglang.srt.layers.cp.utils import (
@@ -281,10 +282,15 @@ class EagerRunner(BaseRunner):
             or cp_v2_active
             or forward_batch.forward_mode.is_target_verify()
         ):
-            if model_runner.ps.attn_dcp_size > 1 and hasattr(
-                model_runner.model, "prepare_context_parallel_metadata_for_dcp"
+            if (
+                kv_storage_dcp_size(get_parallel(), forward_batch) > 1
+                and hasattr(
+                    model_runner.model, "prepare_context_parallel_metadata_for_dcp"
+                )
+                and forward_batch.extend_prefix_lens is not None
+                and not forward_batch.forward_mode.is_target_verify()
             ):
-                # prepare kv cache buffer for dcp to gather kv cache
+                # prepare kv cache buffer for dcp to gather kv cache. Skip for target verify
                 forward_batch.attn_dcp_metadata = (
                     model_runner.model.prepare_context_parallel_metadata_for_dcp(
                         forward_batch.seq_lens,

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1570,6 +1570,8 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
             num_token_non_padded=num_token_non_padded,
             num_token_non_padded_cpu=forward_batch.num_token_non_padded_cpu,
             global_forward_mode=pcg_global_forward_mode,
+            attn_parallel_mode=forward_batch.attn_parallel_mode,
+            kv_residency=forward_batch.kv_residency,
             lora_ids=forward_batch.lora_ids,
             sampling_info=forward_batch.sampling_info,
             mm_inputs=forward_batch.mm_inputs,

--- a/python/sglang/srt/model_executor/runner/shape_key.py
+++ b/python/sglang/srt/model_executor/runner/shape_key.py
@@ -33,9 +33,14 @@ class ShapeKey:
     dsa_variant: DSA decode dual-graph variant ("dense" / "sparse"), or None
         when DSA dual-graph capture is not enabled. Composes with variant_label
         so LoRA and DSA variants can be captured independently.
+    attn_parallel_mode: batch-level TP/CP/DCP mode. Dynamic decode captures TP
+        and DCP separately because collectives and KV page tables differ.
+    kv_residency: replicated or striped KV address-space variant.
     """
 
     size: int
     stream_idx: Optional[int] = None
     variant_label: Optional[str] = None
     dsa_variant: Optional[str] = None
+    attn_parallel_mode: Optional[int] = None
+    kv_residency: Optional[int] = None

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -11,7 +11,7 @@ from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods
     AttnForwardMethod,
 )
 from sglang.srt.models.deepseek_common.utils import _is_hip
-from sglang.srt.runtime_context import get_exec
+from sglang.srt.runtime_context import get_exec, get_parallel
 from sglang.srt.utils import is_sm100_or_sm110_supported, use_intel_amx_backend
 
 MHA_ONE_SHOT_SUPPORTED_BACKENDS = ["fa3", "flashinfer", "flashmla"]
@@ -184,12 +184,27 @@ def handle_attention_tokenspeed_mla(attn, forward_batch):
 
 
 def handle_attention_aiter(attn, forward_batch):
+    # CP-v2 shards model inputs at the runner boundary and needs the absorbed
+    # MLA path so Aiter can gather the latent KV and apply zigzag causality.
+    if mla_use_prefill_cp(forward_batch):
+        return AttnForwardMethod.MLA
+    # Under a CP topology, non-CP batches slice the replicated absorbed-MLA
+    # weights into an effective TP layout. The expanded MHA path still owns
+    # full-head KV weights and cannot consume that sliced query.
+    from sglang.srt.layers.cp.cp_decode_attn_tp import get_cp_decode_attn_tp_ctx
+
+    if get_cp_decode_attn_tp_ctx().should_use_attn_tp(forward_batch):
+        return AttnForwardMethod.MLA
     # During PCG/BCG capture on ROCm, aiter fp8 MLA prefill has no capture
     # kernels; route through the MHA path (radix_attention swaps attn_mqa for
     # its attn_mha companion) so capture/replay use valid head/dim metadata.
     if is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph():
         return AttnForwardMethod.MHA
     if forward_batch.forward_mode.is_extend_without_speculative():
+        # MHA's concat kernel assumes a power-of-2 local head count, which K3
+        # (12 at tp8) violates; absorbed MLA also matches the DCP KV layout.
+        if get_parallel().dcp_enabled:
+            return AttnForwardMethod.MLA
         return AttnForwardMethod.MHA
     else:
         return AttnForwardMethod.MLA

--- a/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
+++ b/python/sglang/srt/models/deepseek_common/attention_backend_handler.py
@@ -1,3 +1,4 @@
+from sglang.srt.attn_parallel import kv_storage_dcp_size
 from sglang.srt.layers.attention.tbo_backend import TboAttnBackend
 from sglang.srt.layers.utils.cp_utils import mla_use_prefill_cp
 from sglang.srt.model_executor.forward_context import get_attn_backend
@@ -194,6 +195,11 @@ def handle_attention_aiter(attn, forward_batch):
     from sglang.srt.layers.cp.cp_decode_attn_tp import get_cp_decode_attn_tp_ctx
 
     if get_cp_decode_attn_tp_ctx().should_use_attn_tp(forward_batch):
+        if (
+            forward_batch.forward_mode.is_extend_without_speculative()
+            and kv_storage_dcp_size(get_parallel(), forward_batch) == 1
+        ):
+            return AttnForwardMethod.MHA
         return AttnForwardMethod.MLA
     # During PCG/BCG capture on ROCm, aiter fp8 MLA prefill has no capture
     # kernels; route through the MHA path (radix_attention swaps attn_mqa for

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -11,6 +11,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
     per_tensor_quant_mla_fp8,
     per_token_group_quant_mla_deep_gemm_masked_fp8,
 )
+from sglang.srt.attn_parallel import AttnParallelMode
 from sglang.srt.compilation.compilation_config import register_split_op
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
@@ -94,11 +95,33 @@ def _select_local_dcp_heads_for_autotune(
 
 
 def is_dcp_mla_decode_phase(forward_batch: ForwardBatch) -> bool:
-    if not get_parallel().dcp_enabled:
+    stamped_mode = getattr(forward_batch, "attn_parallel_mode", None)
+    if stamped_mode is not None:
+        if AttnParallelMode(stamped_mode) is not AttnParallelMode.DCP:
+            return False
+    elif not get_parallel().dcp_enabled:
         return False
     return (
         forward_batch.forward_mode.is_decode()
         or forward_batch.forward_mode.is_target_verify()
+    )
+
+
+def is_dcp_mla_attention_phase(forward_batch: ForwardBatch) -> bool:
+    if is_dcp_mla_decode_phase(forward_batch):
+        return True
+    stamped_mode = getattr(forward_batch, "attn_parallel_mode", None)
+    if (
+        stamped_mode is not None
+        and AttnParallelMode(stamped_mode) is AttnParallelMode.DCP
+    ):
+        return forward_batch.forward_mode.is_draft_extend_v2()
+    # Static DCP supports draft-extend-v2. Dynamically stamped speculative
+    # batches remain TP until a separate residency/graph policy is validated.
+    return (
+        getattr(forward_batch, "attn_parallel_mode", None) is None
+        and get_parallel().dcp_enabled
+        and forward_batch.forward_mode.is_draft_extend_v2()
     )
 
 

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -548,19 +548,25 @@ class DeepseekMLARocmForwardMixin:
 
         # The fused rope+cache-write kernel writes at the virtual out_cache_loc,
         # which is wrong under DCP, so force the standalone rope there.
-        force_rope_for_aiter_dcp_decode = (
-            is_dcp_mla_attention_phase(forward_batch)
-            and (
-                forward_batch.forward_mode.is_decode()
-                or forward_batch.forward_mode.is_target_verify()
-                or forward_batch.forward_mode.is_draft_extend_v2()
+        striped_kv_residency = kv_storage_dcp_size(get_parallel(), forward_batch) > 1
+        force_rope_for_aiter_dcp = (
+            (
+                striped_kv_residency
+                or (
+                    is_dcp_mla_attention_phase(forward_batch)
+                    and (
+                        forward_batch.forward_mode.is_decode()
+                        or forward_batch.forward_mode.is_target_verify()
+                        or forward_batch.forward_mode.is_draft_extend_v2()
+                    )
+                )
             )
             and _use_aiter_gfx95
             and self.current_attention_backend
             not in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS
         )
         if self.rotary_emb is not None and (
-            force_rope_for_aiter_dcp_decode
+            force_rope_for_aiter_dcp
             or (
                 (not fuse_rope_for_trtllm_mla)
                 and (not self._skip_rope_for_dsa_tilelang_fused())
@@ -604,7 +610,6 @@ class DeepseekMLARocmForwardMixin:
 
         # all_gather q_pe, q_nope_out,take tp8 as an example， q_pe [B, H, ROPE_DIM], q_nope_out [B, H, NOPE_DIM] gathered to [B, H * dcp_world_size, ROPE_DIM] [B, H * dcp_world_size, NOPE_DIM] for decode batch, and all gather k_pe, k_nope for extend batch.
         dcp_decode_active = is_dcp_mla_decode_phase(forward_batch)
-        striped_kv_residency = kv_storage_dcp_size(get_parallel(), forward_batch) > 1
         if (dcp_decode_active or striped_kv_residency) and not cp_v2_active:
             if dcp_decode_active:
                 if not q_replicate_active:
@@ -800,8 +805,10 @@ class DeepseekMLARocmForwardMixin:
                 **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
             )
         else:
-            if self._skip_rope_for_aiter_fused_mla() and not is_cp_v2_active(
-                forward_batch
+            if (
+                self._skip_rope_for_aiter_fused_mla()
+                and not is_cp_v2_active(forward_batch)
+                and kv_storage_dcp_size(get_parallel(), forward_batch) == 1
             ):
                 q, _, _, k = _fused_rope_cat_and_cache(
                     self,

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla_rocm.py
@@ -18,6 +18,7 @@ from sglang.kernels.ops.quantization.fp8_kernel import (
     fp8_dtype,
     per_token_group_quant_mla_deep_gemm_masked_fp8,
 )
+from sglang.srt.attn_parallel import kv_storage_dcp_size
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.attention.dsa.utils import dsa_use_prefill_cp
@@ -49,6 +50,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.model_executor.forward_context import get_token_to_kv_pool
 from sglang.srt.models.deepseek_common.attention_forward_methods.forward_mla import (
     _select_local_dcp_heads_for_autotune,
+    is_dcp_mla_attention_phase,
     is_dcp_mla_decode_phase,
     is_mla_dcp_lse_base_on_e,
     should_defer_dsa_cp_kv_gather,
@@ -318,7 +320,6 @@ def _fused_rope_cat_and_cache(
 
 
 class DeepseekMLARocmForwardMixin:
-
     def forward_absorb_rocm_prepare(
         self: DeepseekV2AttentionMLA,
         positions: torch.Tensor,
@@ -542,17 +543,35 @@ class DeepseekMLARocmForwardMixin:
             elif is_kv_b_lora_active(self):
                 q_nope_out = apply_kv_b_lora_q_correction(self, q_nope, q_nope_out)
 
+        cp_v2_active = is_cp_v2_active(forward_batch)
         fuse_rope_for_trtllm_mla = self._fuse_rope_for_trtllm_mla(forward_batch)
-        if (
-            self.rotary_emb is not None
-            and (not fuse_rope_for_trtllm_mla)
-            and (not self._skip_rope_for_dsa_tilelang_fused())
-            and (not self._skip_rope_for_aiter_fused_mla())
+
+        # The fused rope+cache-write kernel writes at the virtual out_cache_loc,
+        # which is wrong under DCP, so force the standalone rope there.
+        force_rope_for_aiter_dcp_decode = (
+            is_dcp_mla_attention_phase(forward_batch)
             and (
-                not _use_aiter
-                or not _is_gfx95_supported
-                or self.use_dsa
-                or self.current_attention_backend == "triton"
+                forward_batch.forward_mode.is_decode()
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend_v2()
+            )
+            and _use_aiter_gfx95
+            and self.current_attention_backend
+            not in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS
+        )
+        if self.rotary_emb is not None and (
+            force_rope_for_aiter_dcp_decode
+            or (
+                (not fuse_rope_for_trtllm_mla)
+                and (not self._skip_rope_for_dsa_tilelang_fused())
+                and (not self._skip_rope_for_aiter_fused_mla() or cp_v2_active)
+                and (
+                    not _use_aiter
+                    or not _is_gfx95_supported
+                    or self.use_dsa
+                    or self.current_attention_backend == "triton"
+                    or cp_v2_active
+                )
             )
         ):
             q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
@@ -573,7 +592,7 @@ class DeepseekMLARocmForwardMixin:
                 k_nope,
                 k_pe,
             )
-        elif mla_prefill_cp and not is_cp_v2_active(forward_batch):
+        elif mla_prefill_cp and not cp_v2_active:
             # CP-v1 gathers the latent here; CP-v2 gathers it in the attention
             # backend via the strategy (materialize_full_mla_kv).
             k_nope, k_pe = self.rebuild_cp_kv_cache(
@@ -584,26 +603,33 @@ class DeepseekMLARocmForwardMixin:
             )
 
         # all_gather q_pe, q_nope_out,take tp8 as an example， q_pe [B, H, ROPE_DIM], q_nope_out [B, H, NOPE_DIM] gathered to [B, H * dcp_world_size, ROPE_DIM] [B, H * dcp_world_size, NOPE_DIM] for decode batch, and all gather k_pe, k_nope for extend batch.
-        if get_parallel().dcp_enabled:
-            if is_dcp_mla_decode_phase(forward_batch):
+        dcp_decode_active = is_dcp_mla_decode_phase(forward_batch)
+        striped_kv_residency = kv_storage_dcp_size(get_parallel(), forward_batch) > 1
+        if (dcp_decode_active or striped_kv_residency) and not cp_v2_active:
+            if dcp_decode_active:
                 if not q_replicate_active:
                     q_nope_out, q_pe = all_gather_q_for_mla_decode(
                         q_nope_out=q_nope_out,
                         q_pe=q_pe,
                     )
             elif forward_batch.forward_mode.is_extend():
-                # for extend, gather kv
-                all_gather_kv_cache_for_mla_extend(
-                    get_token_to_kv_pool(),
-                    self.attn_mqa,
-                    forward_batch.extend_prefix_lens_cpu,
-                    forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
-                    forward_batch.attn_dcp_metadata.dcp_extend_prefix_lens_sum,
-                    forward_batch.attn_dcp_metadata.dcp_kv_buffer,
-                    self.kv_lora_rank,
-                    k_nope,
-                    k_pe,
-                )
+                # Assemble the full sequence into dcp_kv_buffer, which the
+                # backend attends over instead of the sharded local cache.
+                if (
+                    forward_batch.attn_dcp_metadata is not None
+                    and forward_batch.attn_dcp_metadata.dcp_kv_buffer is not None
+                ):
+                    all_gather_kv_cache_for_mla_extend(
+                        get_token_to_kv_pool(),
+                        self.attn_mqa,
+                        forward_batch.extend_prefix_lens_cpu,
+                        forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
+                        forward_batch.attn_dcp_metadata.dcp_extend_prefix_lens_sum,
+                        forward_batch.attn_dcp_metadata.dcp_kv_buffer,
+                        self.kv_lora_rank,
+                        k_nope,
+                        k_pe,
+                    )
             else:
                 logger.warning(
                     f"not supported forward_mode {forward_batch.forward_mode}"
@@ -734,8 +760,49 @@ class DeepseekMLARocmForwardMixin:
                             else {}
                         ),
                     )
+        elif (
+            _use_aiter
+            and (
+                forward_batch.forward_mode.is_decode()
+                or forward_batch.forward_mode.is_target_verify()
+                or forward_batch.forward_mode.is_draft_extend_v2()
+            )
+            and is_dcp_mla_attention_phase(forward_batch)
+        ):
+            # aiter DCP decode over this rank's KV shard, returning (out, lse)
+            # for the cross-rank merge below. Cannot use is_dcp_mla_decode_phase():
+            # that helper omits draft-extend-v2, which needs the same treatment.
+            q = torch.cat([q_nope_out, q_pe], dim=-1)
+            if llama_4_scaling is not None:
+                q *= llama_4_scaling
+            # set_mla_kv_buffer owner-filters and shards internally, so pass the
+            # RAW loc: pre-dividing here would double-apply the filter.
+            get_token_to_kv_pool().set_mla_kv_buffer(
+                self.attn_mqa,
+                forward_batch.out_cache_loc,
+                k_nope,
+                k_pe,
+            )
+            # Decode reads its KV back from the shard; target-verify cannot,
+            # since the window it must attend densely is split across ranks.
+            if forward_batch.forward_mode.is_target_verify():
+                k_window = torch.cat([k_nope, k_pe], dim=-1)
+                v_window = k_nope
+            else:
+                k_window = None
+                v_window = None
+            attn_output, lse = self.attn_mqa_for_dcp_decode(
+                q,
+                k_window,
+                v_window,
+                forward_batch,
+                save_kv_cache=False,
+                **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
+            )
         else:
-            if self._skip_rope_for_aiter_fused_mla():
+            if self._skip_rope_for_aiter_fused_mla() and not is_cp_v2_active(
+                forward_batch
+            ):
                 q, _, _, k = _fused_rope_cat_and_cache(
                     self,
                     q_nope_out,
@@ -878,4 +945,8 @@ class DeepseekMLARocmForwardMixin:
         when running aiter-backend MLA on gfx95 (i.e., the `else` branch in
         forward_absorb_rocm_core that calls fused_qk_rope_cat_and_cache_mla).
         """
-        return _use_aiter_gfx95 and self.current_attention_backend == "aiter"
+        return (
+            _use_aiter_gfx95
+            and self.current_attention_backend == "aiter"
+            and self.rotary_emb is not None
+        )

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1980,13 +1980,13 @@ class DeepseekV2AttentionMLA(
             (self, "w_scale_k", 0),
             (self, "w_scale_v", 0),
         ]
-        radix_attns = [self.attn_mqa]
+        radix_attns = [self.attn_mqa, self.attn_mha]
         if hasattr(self, "attn_mqa_for_dcp_decode"):
             radix_attns.append(self.attn_mqa_for_dcp_decode)
         ctx = get_cp_decode_attn_tp_ctx()
         with ctx.maybe_use_decode_attn_tp(
             forward_batch,
-            [self.q_b_proj, self.o_proj],
+            [self.q_b_proj, self.kv_b_proj, self.o_proj],
             tensor_attrs=tensor_attrs,
             radix_attn=radix_attns,
         ):

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -1980,12 +1980,15 @@ class DeepseekV2AttentionMLA(
             (self, "w_scale_k", 0),
             (self, "w_scale_v", 0),
         ]
+        radix_attns = [self.attn_mqa]
+        if hasattr(self, "attn_mqa_for_dcp_decode"):
+            radix_attns.append(self.attn_mqa_for_dcp_decode)
         ctx = get_cp_decode_attn_tp_ctx()
         with ctx.maybe_use_decode_attn_tp(
             forward_batch,
             [self.q_b_proj, self.o_proj],
             tensor_attrs=tensor_attrs,
-            radix_attn=self.attn_mqa,
+            radix_attn=radix_attns,
         ):
             if ctx.use_decode_attn_tp:
                 orig_num_local_heads = self.num_local_heads

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -301,6 +301,21 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
             labelnames=labels.keys(),
             multiprocess_mode="mostrecent",
         )
+        self.dynamic_attn_parallel_batches_total = Counter(
+            name="sglang:dynamic_attn_parallel_batches_total",
+            documentation="Finalized scheduler batches by attention-parallel mode.",
+            labelnames=[*labels.keys(), "mode"],
+        )
+        self.dynamic_attn_parallel_veto_total = Counter(
+            name="sglang:dynamic_attn_parallel_veto_total",
+            documentation="Batches that did not select CP, grouped by stable reason.",
+            labelnames=[*labels.keys(), "reason"],
+        )
+        self.dynamic_attn_parallel_vote_mismatch_total = Counter(
+            name="sglang:dynamic_attn_parallel_vote_mismatch_total",
+            documentation="Batches whose local CP votes differed across ranks.",
+            labelnames=labels.keys(),
+        )
         self.decode_sum_seq_lens = Gauge(
             name="sglang:decode_sum_seq_lens",
             documentation="The sum of all sequence lengths in decode.",
@@ -1235,6 +1250,17 @@ class SchedulerMetricsCollector(_StatLoggerDIMixin):
     def increment_decode_cuda_graph_pass(self, value: bool) -> None:
         mode = "decode_cuda_graph" if value else "decode_none"
         self.cuda_graph_passes_total.labels(**self.labels, mode=mode).inc(1)
+
+    def increment_dynamic_attn_parallel_batch(
+        self, *, mode: str, veto_reason: Optional[str], vote_mismatch: bool = False
+    ) -> None:
+        self.dynamic_attn_parallel_batches_total.labels(**self.labels, mode=mode).inc(1)
+        if veto_reason is not None:
+            self.dynamic_attn_parallel_veto_total.labels(
+                **self.labels, reason=veto_reason
+            ).inc(1)
+        if vote_mismatch:
+            self.dynamic_attn_parallel_vote_mismatch_total.labels(**self.labels).inc(1)
 
     def increment_prefill_cuda_graph_pass(self, value: bool) -> None:
         mode = "prefill_cuda_graph" if value else "prefill_none"

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1173,6 +1173,43 @@ class ServerArgs:
         ),
         NS("parallel"),
     ] = None
+    enable_dynamic_attn_parallel: A[
+        bool,
+        "Stamp one deterministic attention-parallel mode on each finalized batch. "
+        "Prefill batches choose TP or CP; decode remains TP unless the experimental "
+        "DCP option is enabled.",
+        NS("parallel"),
+    ] = False
+    dynamic_attn_parallel_min_prefill_tokens: A[
+        Optional[int],
+        "Minimum total uncached prefill tokens required to select CP. The default "
+        "is the selected strategy's correctness floor.",
+        NS("parallel"),
+    ] = None
+    dynamic_attn_parallel_allow_mixed: A[
+        bool,
+        "Allow CP on MIXED prefill/decode batches. Disabled by default because "
+        "the CP-v2 layouts do not support mixed token semantics.",
+        NS("parallel"),
+    ] = False
+    dynamic_attn_parallel_enable_dcp: A[
+        bool,
+        "Experimental: allow the batch selector to choose decode DCP when the "
+        "configured KV residency supports it.",
+        NS("parallel"),
+    ] = False
+    dynamic_attn_parallel_dcp_min_context: A[
+        int,
+        "Minimum maximum sequence length in a decode batch before dynamic DCP "
+        "engages.",
+        NS("parallel"),
+    ] = 8192
+    dynamic_attn_parallel_replicated_kv_fraction: A[
+        float,
+        "Fraction of the physical MLA KV pool reserved for TP-readable replicated "
+        "residency; the remainder backs compact DCP-striped residency.",
+        NS("parallel"),
+    ] = 0.5
     # Split DSA GPU KV/indexer cache layers across CP ranks.
     enable_dsa_cache_layer_split: A[
         bool,
@@ -4235,6 +4272,34 @@ class ServerArgs:
                     f"got --dcp-comm-backend={self.dcp_comm_backend}."
                 )
 
+        # Resolve the decode backend the way the model overrides do: gating on
+        # self.attention_backend alone misses --decode-attention-backend aiter.
+        if self.dcp_size > 1 and is_hip():
+            from sglang.srt.arg_groups.overrides import attention_backends_of
+
+            _, decode_backend = attention_backends_of(self)
+            if decode_backend == "aiter":
+                self._validate_aiter_mla_dcp()
+
+    def _validate_aiter_mla_dcp(self):
+        """Validate aiter MLA decode-context-parallel (--dcp-size > 1)."""
+        from sglang.srt.configs.model_config import AttentionArch
+
+        model_config = self.get_model_config()
+        if model_config.attention_arch != AttentionArch.MLA:
+            return
+
+        if "fp8" in (self.kv_cache_dtype or "") and not (
+            envs.SGLANG_EXPERIMENTAL_AITER_DCP_FP8.get()
+        ):
+            raise ValueError(
+                "aiter MLA decode context parallel (--dcp-size > 1) defaults to "
+                "bf16 kv-cache. fp8 kv-cache has been validated for Kimi-K3 on "
+                "gfx950 only (gsm8k within the run-to-run band of bf16, KV pool "
+                "exactly 2x); it stays opt-in pending broader coverage. Set "
+                "SGLANG_EXPERIMENTAL_AITER_DCP_FP8=1 to enable it."
+            )
+
     def _handle_load_balance_method(self):
         if self.disaggregation_mode not in ("null", "prefill", "decode"):
             raise ValueError(
@@ -6968,6 +7033,29 @@ class ServerArgs:
             raise ValueError(
                 "--cp-strategy must be set when --enable-prefill-cp is enabled."
             )
+        if self.enable_dynamic_attn_parallel and not self.enable_prefill_cp:
+            raise ValueError(
+                "--enable-dynamic-attn-parallel requires --enable-prefill-cp."
+            )
+        if (
+            self.dynamic_attn_parallel_min_prefill_tokens is not None
+            and self.dynamic_attn_parallel_min_prefill_tokens <= 0
+        ):
+            raise ValueError(
+                "--dynamic-attn-parallel-min-prefill-tokens must be positive."
+            )
+        if self.dynamic_attn_parallel_enable_dcp and self.dcp_size <= 1:
+            raise ValueError(
+                "--dynamic-attn-parallel-enable-dcp requires --dcp-size > 1."
+            )
+        if self.dynamic_attn_parallel_dcp_min_context <= 0:
+            raise ValueError(
+                "--dynamic-attn-parallel-dcp-min-context must be positive."
+            )
+        if not (0.0 < self.dynamic_attn_parallel_replicated_kv_fraction < 1.0):
+            raise ValueError(
+                "--dynamic-attn-parallel-replicated-kv-fraction must be in (0, 1)."
+            )
 
         if (
             self.enable_prefill_context_parallel
@@ -6983,7 +7071,82 @@ class ServerArgs:
             )
 
         view = self._resolved()
+        prefill_backend, _ = self._resolved_attention_backends()
+        if (
+            is_hip()
+            and self.enable_prefill_cp
+            and prefill_backend == "aiter"
+            and self.use_mla_backend()
+        ):
+            if self.cp_strategy != "zigzag":
+                raise ValueError(
+                    "Aiter MLA prefill CP currently supports --cp-strategy "
+                    "zigzag only."
+                )
+            if self.kv_cache_dtype not in ("auto", "bf16", "bfloat16"):
+                raise ValueError(
+                    "Aiter MLA prefill CP currently requires BF16 KV cache; "
+                    f"got --kv-cache-dtype={self.kv_cache_dtype}."
+                )
+            if view.page_size != 1:
+                raise ValueError(
+                    "Aiter MLA prefill CP currently requires --page-size 1."
+                )
+            attn_tp_size = self.tp_size // self.dp_size // view.attn_cp_size
+            local_heads = self.get_model_config().num_attention_heads // attn_tp_size
+            if local_heads not in (16, 128):
+                raise ValueError(
+                    "Aiter MLA prefill CP requires 16 or 128 local query heads; "
+                    f"got {local_heads}."
+                )
+        if self.dynamic_attn_parallel_enable_dcp:
+            from sglang.srt.configs.model_config import AttentionArch
+
+            if self.get_model_config().attention_arch != AttentionArch.MLA:
+                raise ValueError("Dynamic TP/DCP currently supports MLA models only.")
+            if view.attn_cp_size != self.dcp_size:
+                raise ValueError(
+                    "Dynamic TP/DCP requires attn_cp_size == dcp_size so runtime "
+                    "attention-TP slices align with DCP ranks."
+                )
+            if not self.enable_cp_decode_attn_tp:
+                raise ValueError("Dynamic TP/DCP requires --enable-cp-decode-attn-tp.")
+            if view.page_size != 1:
+                raise ValueError(
+                    "The replicated-KV dynamic DCP PoC requires --page-size 1."
+                )
+            if self.dcp_replicate_q_proj:
+                raise ValueError(
+                    "Dynamic TP/DCP is incompatible with --dcp-replicate-q-proj."
+                )
+            if self.speculative_algorithm not in (None, "NONE"):
+                raise ValueError(
+                    "Dynamic TP/DCP does not yet support speculative decoding."
+                )
+            if not self.disable_overlap_schedule:
+                raise ValueError(
+                    "Residency-aware dynamic TP/DCP currently requires "
+                    "--disable-overlap-schedule."
+                )
+            if self.enable_hierarchical_cache:
+                raise ValueError(
+                    "Residency-aware dynamic TP/DCP does not yet support HiCache; "
+                    "its host pools need the same per-layout address translation."
+                )
         if view.attn_cp_size > 1:
+            if self.cp_strategy is not None:
+                from sglang.srt.attn_parallel import strategy_min_tokens
+
+                strategy_floor, _ = strategy_min_tokens(
+                    self.cp_strategy, view.attn_cp_size
+                )
+                configured_floor = self.dynamic_attn_parallel_min_prefill_tokens
+                if configured_floor is not None and configured_floor < strategy_floor:
+                    raise ValueError(
+                        "--dynamic-attn-parallel-min-prefill-tokens cannot be "
+                        f"smaller than the {self.cp_strategy} correctness floor "
+                        f"({strategy_floor})."
+                    )
             # The tp_size is the world size, not the real tensor parallel size
             assert (
                 self.tp_size % view.attn_cp_size == 0

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1182,8 +1182,8 @@ class ServerArgs:
     ] = False
     dynamic_attn_parallel_min_prefill_tokens: A[
         Optional[int],
-        "Minimum total uncached prefill tokens required to select CP. The default "
-        "is the selected strategy's correctness floor.",
+        "Minimum total uncached prefill tokens required to select CP. If unset, "
+        "dynamic prefill remains TP; set this from a measured crossover grid.",
         NS("parallel"),
     ] = None
     dynamic_attn_parallel_allow_mixed: A[
@@ -1204,10 +1204,18 @@ class ServerArgs:
         "engages.",
         NS("parallel"),
     ] = 8192
+    dynamic_attn_parallel_striped_min_context: A[
+        Optional[int],
+        "Opt in to compact striped KV residency for requests whose prompt length "
+        "meets this threshold. By default dynamic DCP reads rank-local shards from "
+        "replicated KV so prefill can still use CP without a layout conversion.",
+        NS("parallel"),
+    ] = None
     dynamic_attn_parallel_replicated_kv_fraction: A[
         float,
         "Fraction of the physical MLA KV pool reserved for TP-readable replicated "
-        "residency; the remainder backs compact DCP-striped residency.",
+        "residency when striped residency is explicitly enabled; the remainder "
+        "backs compact DCP-striped residency.",
         NS("parallel"),
     ] = 0.5
     # Split DSA GPU KV/indexer cache layers across CP ranks.
@@ -7037,6 +7045,10 @@ class ServerArgs:
             raise ValueError(
                 "--enable-dynamic-attn-parallel requires --enable-prefill-cp."
             )
+        if self.enable_dynamic_attn_parallel and not envs.SGLANG_ENABLE_CP_V2.get():
+            raise ValueError(
+                "--enable-dynamic-attn-parallel requires the CP-v2 runtime."
+            )
         if (
             self.dynamic_attn_parallel_min_prefill_tokens is not None
             and self.dynamic_attn_parallel_min_prefill_tokens <= 0
@@ -7051,6 +7063,13 @@ class ServerArgs:
         if self.dynamic_attn_parallel_dcp_min_context <= 0:
             raise ValueError(
                 "--dynamic-attn-parallel-dcp-min-context must be positive."
+            )
+        if (
+            self.dynamic_attn_parallel_striped_min_context is not None
+            and self.dynamic_attn_parallel_striped_min_context <= 0
+        ):
+            raise ValueError(
+                "--dynamic-attn-parallel-striped-min-context must be positive."
             )
         if not (0.0 < self.dynamic_attn_parallel_replicated_kv_fraction < 1.0):
             raise ValueError(
@@ -7132,6 +7151,22 @@ class ServerArgs:
                 raise ValueError(
                     "Residency-aware dynamic TP/DCP does not yet support HiCache; "
                     "its host pools need the same per-layout address translation."
+                )
+            if (
+                self.dynamic_attn_parallel_striped_min_context is not None
+                and not self.disable_radix_cache
+            ):
+                raise ValueError(
+                    "Striped dynamic TP/DCP currently requires "
+                    "--disable-radix-cache because eviction accounting is "
+                    "residency-specific."
+                )
+            if (
+                self.dynamic_attn_parallel_striped_min_context is not None
+                and self.disaggregation_mode != "null"
+            ):
+                raise ValueError(
+                    "Striped dynamic TP/DCP does not support PD disaggregation."
                 )
         if view.attn_cp_size > 1:
             if self.cp_strategy is not None:

--- a/test/registered/amd/test_dcp_mla_unit.py
+++ b/test/registered/amd/test_dcp_mla_unit.py
@@ -1,0 +1,392 @@
+"""Numeric validation of the two-stage DCP target-verify decomposition.
+
+Under DCP the aiter backend drives aiter's ``mla_decode_fwd`` over each
+rank's round-robin KV shard: it tiles the query heads, so it serves any
+gathered head count (Kimi-K3 has 96 at tp8 dcp8). Its own causal mask is
+``seq_offset < (seq_len - num_tokens_per_seq) + query_pos + 1`` where
+``seq_offset`` is the LOCAL shard index, which is wrong under round-robin
+sharding for ``q_len > 1``. Target-verify is therefore split in two:
+
+  stage A  mla_decode_fwd over the committed shard, with the ``bs x q_len`` window
+           flattened to ``bs*q_len`` single-token rows so ``num_tokens_per_seq
+           == 1`` and the mask degenerates to "attend the whole local shard"
+           (every committed token precedes every window token, so no masking is
+           needed there)
+  stage B  dense causal attention over the in-hand ``q_len`` window, folded into
+           rank 0 only so the cross-rank merge counts it exactly once
+  merge    base-2 LSE merge across ranks, i.e. what ``cp_lse_ag_out_rs_mla``
+           does in ``forward_mla``
+
+This test runs the REAL aiter kernel and the REAL reduce/combine helpers against
+an fp32 full-attention reference. What it guards, none of which any other test
+covers:
+
+* the ``ALL_DECODE = num_tokens_per_seq == 1`` mask degeneration in aiter. An
+  aiter bump that changes it makes stage A attend the wrong keys and produces
+  *silently* wrong output -- no crash, just a slow drift in speculative accept
+  length that is easy to misread as draft-quality noise.
+* the LSE log base. ``dense_causal_mla_attn_base2`` rebases its natural-log
+  ``logsumexp`` with ``_LOG2E`` because the aiter reduce and sglang's
+  ``correct_attn_out`` both work in base-2. Dropping that factor, or swapping
+  ``exp2`` for ``exp`` in ``dcp_lse_combine_base2``, silently reweights the merge.
+* the empty-shard path (``prefix_len < dcp_size``, so some ranks own nothing and
+  must contribute ``lse = -inf`` rather than poisoning the merge with NaN).
+* the gathered head counts K3 actually runs (96 at tp8 dcp8), which the kernel
+  serves by tiling the query heads; 128 is kept alongside as a control.
+
+Error must also not grow with the shard count: a sharding or merge fault shows
+up as error rising with W, which is what ``test_error_does_not_grow_with_w``
+pins down.
+"""
+
+import itertools
+import math
+import unittest
+
+import torch
+
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_amd_ci(est_time=300, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+KV_LORA_RANK = 512
+QK_ROPE = 64
+D = KV_LORA_RANK + QK_ROPE
+PAGE = 32
+DTYPE = torch.bfloat16
+DEV = "cuda"
+
+# Tolerance is tiered by prefix length. A single flat bound does not work: the
+# bf16-vs-fp32 baseline error falls ~10x across the grid (2.4e-3 at prefix 7
+# down to 2.6e-4 at prefix 1000, as the softmax mass spreads over more keys),
+# so a bound loose enough for the short-prefix tiers is blind at the long ones.
+# Each tier is ~2.5x its measured worst case over the whole (W, q_len, H) grid.
+#
+# Calibrated against three injected faults -- LSE base left un-rebased, stage B
+# dropped entirely, empty-shard `-inf` replaced by 0 -- with these results for
+# the hardest configuration in each tier:
+#
+#   prefix     baseline    tol      LSE-base fault   stage-B fault
+#   0          2.0e-3      5e-3     (not observable) 1.20
+#   1          2.1e-3      5e-3     8.0e-2           0.97
+#   7          2.4e-3      6e-3     3.8e-2           0.21
+#   100        6.0e-4      1.5e-3   3.6e-3           1.6e-2
+#   1000       2.6e-4      1e-3     4.3e-4  <-- see below
+#
+# Two deliberate blind spots, both inherent rather than sloppy:
+#  * prefix 0: no rank owns committed KV, so the cross-stage merge is degenerate
+#    and the LSE base cannot affect the result there by construction.
+#  * prefix 1000: the fault signal (4.3e-4) sits only 1.65x above the baseline
+#    (2.6e-4), too close to separate without making the tier fragile to
+#    legitimate kernel rounding changes. This tier therefore guards shape /
+#    NaN / multi-page-shard behaviour, not numerics; prefix 1, 7 and 100 carry
+#    the numeric guard with 16-24x margin.
+MAX_ABS_TOL_BY_PREFIX = {0: 5e-3, 1: 5e-3, 7: 6e-3, 100: 1.5e-3, 1000: 1e-3}
+
+PREFIX_LENS = [0, 1, 7, 100, 1000]
+WORLD_SIZES = [1, 2, 4, 8]
+Q_LENS = [2, 8]
+HEAD_COUNTS = [96, 128]
+
+
+def _aiter_mla_available() -> bool:
+    if not is_hip() or not torch.cuda.is_available():
+        return False
+    try:
+        from aiter.ops.triton.attention.mla import mla_decode_fwd  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _reference(q, k_prefix, k_window, bs, q_len, scaling):
+    """fp32 full attention: query token i sees all of prefix + window[: i + 1]."""
+    qf = q.view(bs, q_len, -1, D).float()
+    outs = []
+    for b in range(bs):
+        keys = torch.cat([k_prefix[b].float(), k_window[b].float()], dim=0)
+        n_prefix = k_prefix[b].shape[0]
+        scores = torch.einsum("ihd,jd->hij", qf[b], keys) * scaling
+        j = torch.arange(keys.shape[0], device=DEV)
+        i = torch.arange(q_len, device=DEV)
+        allowed = j[None, :] <= (n_prefix + i)[:, None]
+        scores = scores.masked_fill(~allowed[None], float("-inf"))
+        p = torch.softmax(scores, dim=-1)
+        outs.append(torch.einsum("hij,jd->ihd", p, keys[:, :KV_LORA_RANK]))
+    return torch.stack(outs).reshape(bs * q_len, -1, KV_LORA_RANK)
+
+
+def _stage_a(q, shard, shard_lens, bs, q_len, num_heads, scaling):
+    """mla_decode_fwd over one rank's committed shard, flattened to bs*q_len rows."""
+    from aiter.ops.triton.attention.mla import mla_decode_fwd
+
+    from sglang.kernels.ops.attention.dcp_kernels import dcp_reduce_kv_segments
+
+    n_rows = bs * q_len
+    max_local = int(shard_lens.max().item())
+    if max_local == 0:
+        # mla_decode_fwd cannot be launched with a zero-length shard (it would
+        # get a zero-page block table), so stand in for it with the identity
+        # element of the merge. NOTE this stands in for the KERNEL only -- it
+        # deliberately does not assert anything about dcp_reduce_kv_segments, whose
+        # own empty-shard contract is covered by
+        # TestDcpReduceKvSegmentsEmptyShard below.
+        return (
+            torch.zeros(n_rows, num_heads, KV_LORA_RANK, dtype=DTYPE, device=DEV),
+            torch.full((n_rows, num_heads), float("-inf"), device=DEV),
+        )
+
+    max_pages = (max_local + PAGE - 1) // PAGE
+    # Per-request paged shard buffer; the tail page is zero-padded because the kernel
+    # reads the whole last page and masks it by seqused_k.
+    paged = torch.zeros(bs * max_pages, PAGE, 1, D, dtype=DTYPE, device=DEV)
+    block_tables = torch.zeros(bs, max_pages, dtype=torch.int32, device=DEV)
+    for b in range(bs):
+        n = int(shard_lens[b].item())
+        if n:
+            paged.view(bs, max_pages * PAGE, 1, D)[b, :n] = shard[b][:n].unsqueeze(1)
+        block_tables[b] = torch.arange(max_pages, device=DEV) + b * max_pages
+
+    seqused = shard_lens.repeat_interleave(q_len).to(torch.int32)
+    out = torch.empty(n_rows, num_heads, KV_LORA_RANK, dtype=DTYPE, device=DEV)
+    segm_o, segm_m, segm_e = mla_decode_fwd(
+        q.view(n_rows, num_heads, D),
+        paged,
+        out,
+        torch.arange(n_rows + 1, dtype=torch.int32, device=DEV),
+        seqused,
+        max_local,
+        block_tables.repeat_interleave(q_len, dim=0),
+        scaling,
+        KV_LORA_RANK,
+        QK_ROPE,
+        True,
+        None,
+        None,
+        skip_reduce=True,
+    )
+    return dcp_reduce_kv_segments(segm_o, segm_m, segm_e, seqused, PAGE, DTYPE)
+
+
+def _merge_ranks(outs, lses):
+    """Base-2 LSE merge across ranks == cp_lse_ag_out_rs_mla / correct_attn_out."""
+    lse_all = torch.stack(lses)
+    m = lse_all.max(dim=0).values
+    w = torch.nan_to_num(torch.exp2(lse_all - m), nan=0.0, posinf=0.0, neginf=0.0)
+    num = sum(o.float() * w[r].unsqueeze(-1) for r, o in enumerate(outs))
+    return num / w.sum(dim=0).clamp_min(1e-38).unsqueeze(-1)
+
+
+def _run_config(bs, q_len, num_heads, prefix_len, world_size):
+    """Return (max_abs_err, has_nan) for one simulated DCP group."""
+    from sglang.kernels.ops.attention.dcp_kernels import (
+        dcp_lse_combine_base2,
+        dense_causal_mla_attn_base2,
+    )
+
+    torch.manual_seed(0)
+    scaling = 1.0 / math.sqrt(D)
+    q = torch.randn(bs * q_len, num_heads, D, dtype=DTYPE, device=DEV) * 0.3
+    k_prefix = torch.randn(bs, prefix_len, D, dtype=DTYPE, device=DEV) * 0.3
+    k_window = torch.randn(bs, q_len, D, dtype=DTYPE, device=DEV) * 0.3
+
+    outs, lses = [], []
+    for rank in range(world_size):
+        # Round-robin owner rule: rank r holds committed positions p % W == r.
+        idx = (
+            torch.arange(rank, prefix_len, world_size, device=DEV)
+            if prefix_len > rank
+            else torch.empty(0, dtype=torch.long, device=DEV)
+        )
+        shard = k_prefix[:, idx, :]
+        shard_lens = torch.full((bs,), idx.numel(), dtype=torch.int32, device=DEV)
+        out_r, lse_r = _stage_a(q, shard, shard_lens, bs, q_len, num_heads, scaling)
+        if rank == 0:
+            out_b, lse_b = dense_causal_mla_attn_base2(
+                q,
+                k_window.reshape(bs * q_len, 1, D),
+                scaling,
+                bs,
+                q_len,
+                KV_LORA_RANK,
+            )
+            out_r, lse_r = dcp_lse_combine_base2(out_r, lse_r, out_b, lse_b, DTYPE)
+        outs.append(out_r)
+        lses.append(lse_r)
+
+    got = _merge_ranks(outs, lses)
+    ref = _reference(q, k_prefix, k_window, bs, q_len, scaling)
+    return (got - ref).abs().max().item(), bool(torch.isnan(got).any())
+
+
+@unittest.skipUnless(
+    _aiter_mla_available(), "requires ROCm + aiter with the MLA decode kernel"
+)
+class TestDcpVerifyDecomposition(CustomTestCase):
+    def test_matches_full_attention_reference(self):
+        """Two-stage verify == fp32 full attention, across the DCP grid."""
+        for prefix_len, world_size, q_len, num_heads in itertools.product(
+            PREFIX_LENS, WORLD_SIZES, Q_LENS, HEAD_COUNTS
+        ):
+            tol = MAX_ABS_TOL_BY_PREFIX[prefix_len]
+            with self.subTest(
+                prefix_len=prefix_len, W=world_size, q_len=q_len, H=num_heads
+            ):
+                err, has_nan = _run_config(4, q_len, num_heads, prefix_len, world_size)
+                self.assertFalse(has_nan, "NaN in the merged attention output")
+                self.assertTrue(math.isfinite(err), f"non-finite error: {err}")
+                self.assertLess(err, tol, f"max_abs {err:.6f} exceeds {tol:.1e}")
+
+    def test_error_does_not_grow_with_w(self):
+        """Sharding must not degrade accuracy as the DCP group grows.
+
+        A correct decomposition is W-independent: each rank attends a disjoint
+        key subset and the LSE merge is exact. A sharding or merge fault instead
+        degrades progressively with W, so the trend is a sharper signal than any
+        single absolute error.
+        """
+        for prefix_len, q_len in itertools.product([7, 100, 1000], Q_LENS):
+            with self.subTest(prefix_len=prefix_len, q_len=q_len):
+                base, _ = _run_config(4, q_len, 96, prefix_len, 1)
+                for world_size in (2, 4, 8):
+                    err, _ = _run_config(4, q_len, 96, prefix_len, world_size)
+                    # Absolute floor absorbs bf16 jitter when `base` is tiny.
+                    self.assertLessEqual(
+                        err,
+                        max(base * 2.0, 5e-4),
+                        f"W={world_size} error {err:.6f} exceeds the W=1 "
+                        f"baseline {base:.6f}; sharding is degrading accuracy",
+                    )
+
+
+@unittest.skipUnless(
+    _aiter_mla_available(), "requires ROCm + aiter with the MLA decode kernel"
+)
+class TestDcpReduceKvSegmentsEmptyShard(CustomTestCase):
+    """dcp_reduce_kv_segments's contract for a rank that owns no committed KV.
+
+    A rank owns nothing for a request whose prefix is shorter than its rank
+    index, and the planner clamps local_kv_lens to min 0, so a zero-length row
+    is a normal input. The reduce must emit the identity element of the LSE
+    merge -- out 0, lse -inf -- which dcp_lse_combine_base2 and cp_lse_ag_out_rs_mla
+    both weight to zero.
+
+    Regression: the reduce used to compute act_num_segments as
+    ``cdiv(seq_len, cdiv(seq_len, N*T) * T)``, which divides by zero at
+    seq_len 0. The resulting garbage segment mask produced lse NaN instead of
+    -inf, and the NaN survived the merge -- nan_to_num zeroes the WEIGHT, but
+    NaN * 0 is still NaN, so one empty shard poisoned the merged output of an
+    otherwise healthy batch.
+
+    The grid in TestDcpVerifyDecomposition cannot reach this: every request
+    there shares one prefix_len, so a rank's shard lengths are uniform and the
+    all-empty case short-circuits before the kernel runs. The mixed case below
+    is the one that occurs in practice -- a short prompt batched with a long one.
+    """
+
+    def _reduce(self, shard_lens):
+        from sglang.kernels.ops.attention.dcp_kernels import dcp_reduce_kv_segments
+
+        torch.manual_seed(0)
+        n_rows, heads, segments = len(shard_lens), 2, 4
+        # normal_(), not zeros: aiter hands the reduce an empty() buffer whose
+        # inactive segments hold garbage, and the masking is what this guards.
+        shape = (n_rows, heads, segments)
+        segm_o = torch.empty(*shape, KV_LORA_RANK, device=DEV).normal_(0, 1.0)
+        segm_m = torch.empty(*shape, device=DEV).normal_(0, 1.0)
+        segm_e = torch.empty(*shape, device=DEV).normal_(0, 1.0).abs()
+        lens = torch.tensor(shard_lens, dtype=torch.int32, device=DEV)
+        return dcp_reduce_kv_segments(segm_o, segm_m, segm_e, lens, PAGE, DTYPE)
+
+    def test_mixed_batch_empty_rows_are_the_merge_identity(self):
+        shard_lens = [64, 0, 8, 0]
+        out, lse = self._reduce(shard_lens)
+        for row, n in enumerate(shard_lens):
+            with self.subTest(row=row, shard_len=n):
+                self.assertTrue(
+                    torch.isfinite(out[row].float()).all(), "non-finite output"
+                )
+                if n == 0:
+                    self.assertTrue((out[row] == 0).all(), "empty shard must emit 0")
+                    self.assertTrue(
+                        torch.isneginf(lse[row]).all(), "empty shard must emit -inf"
+                    )
+                else:
+                    self.assertTrue(
+                        torch.isfinite(lse[row]).all(),
+                        "a non-empty row must not be disturbed by an empty neighbour",
+                    )
+
+    def test_empty_shard_does_not_poison_the_merge(self):
+        """The end that actually matters: a NaN here corrupts real output."""
+        from sglang.kernels.ops.attention.dcp_kernels import dcp_lse_combine_base2
+
+        out_a, lse_a = self._reduce([16, 0])
+        out_b = torch.ones(2, 2, KV_LORA_RANK, device=DEV)
+        lse_b = torch.zeros(2, 2, device=DEV)
+        merged, _ = dcp_lse_combine_base2(out_a, lse_a, out_b, lse_b, torch.float32)
+        self.assertTrue(torch.isfinite(merged).all(), "empty shard poisoned the merge")
+        # Row 1's stage A saw no keys, so the merge must return stage B untouched.
+        torch.testing.assert_close(merged[1], out_b[1].float())
+
+    def test_merge_of_two_empty_partials(self):
+        """Both sides empty: the merge weights sum to zero.
+
+        Neither of the two comparable kernels survives this -- merge_state_kernel
+        computes `-inf - (-inf)` and `_dcp_lse_combine_kernel` divides `0 / 0`,
+        both NaN. Reachable at prefix 0, where no rank owns committed KV and a
+        non-rank-0 partial has no window to fold in either.
+        """
+        from sglang.kernels.ops.attention.dcp_kernels import dcp_lse_combine_base2
+
+        out_a, lse_a = self._reduce([0, 0])
+        merged, lse = dcp_lse_combine_base2(
+            out_a, lse_a, out_a.clone(), lse_a.clone(), torch.float32
+        )
+        self.assertTrue(torch.isfinite(merged).all(), "all-empty merge produced NaN")
+        self.assertTrue((merged == 0).all(), "all-empty merge must emit 0")
+        self.assertTrue(torch.isneginf(lse).all(), "all-empty merge must emit -inf")
+
+
+@unittest.skipUnless(
+    _aiter_mla_available(), "requires ROCm for the DCP page-table kernel"
+)
+class TestDcpPageTableResidency(CustomTestCase):
+    def test_replicated_and_striped_loc_mapping(self):
+        from sglang.kernels.ops.attention.dcp_kernels import build_dcp_page_table
+
+        req_to_token = torch.arange(16, dtype=torch.int64, device=DEV).view(1, -1)
+        req_pool_indices = torch.tensor([0], dtype=torch.int64, device=DEV)
+        local_lens = torch.tensor([4], dtype=torch.int32, device=DEV)
+
+        replicated = build_dcp_page_table(
+            req_to_token,
+            req_pool_indices,
+            local_lens,
+            bs=1,
+            max_pages=4,
+            page_size=1,
+            dcp_size=2,
+            dcp_rank=1,
+            kv_loc_scale=1,
+        )
+        striped = build_dcp_page_table(
+            req_to_token,
+            req_pool_indices,
+            local_lens,
+            bs=1,
+            max_pages=4,
+            page_size=1,
+            dcp_size=2,
+            dcp_rank=1,
+            kv_loc_scale=2,
+        )
+
+        self.assertEqual(replicated[0].tolist(), [1, 3, 5, 7])
+        self.assertEqual(striped[0].tolist(), [0, 1, 2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/amd/test_mla_cp_aiter_parity.py
+++ b/test/registered/amd/test_mla_cp_aiter_parity.py
@@ -1,0 +1,114 @@
+"""Aiter absorbed-MLA prefill parity for the CP zigzag geometry."""
+
+import unittest
+
+import torch
+
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_amd_ci(est_time=120, suite="stage-b-test-1-gpu-small-amd-mi35x")
+
+KV_LORA_RANK = 512
+ROPE_DIM = 64
+HEAD_DIM = KV_LORA_RANK + ROPE_DIM
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+
+def _aiter_mla_available():
+    if not is_hip() or not torch.cuda.is_available():
+        return False
+    try:
+        from aiter.mla import mla_prefill_fwd  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def _run_mla(q, kv, q_len, kv_len, num_heads, scaling):
+    from aiter.mla import mla_prefill_fwd
+
+    output = torch.empty(q_len, num_heads, KV_LORA_RANK, dtype=DTYPE, device=DEVICE)
+    mla_prefill_fwd(
+        q.contiguous(),
+        kv.view(-1, 1, 1, HEAD_DIM),
+        output,
+        torch.tensor([0, q_len], dtype=torch.int32, device=DEVICE),
+        torch.tensor([0, kv_len], dtype=torch.int32, device=DEVICE),
+        torch.arange(kv_len, dtype=torch.int32, device=DEVICE),
+        torch.ones(1, dtype=torch.int32, device=DEVICE),
+        q_len,
+        scaling,
+        0.0,
+    )
+    return output
+
+
+@unittest.skipUnless(_aiter_mla_available(), "requires ROCm + aiter MLA prefill")
+class TestAiterMlaPrefillCPParity(CustomTestCase):
+    def test_zigzag_halves_match_full_prefill(self):
+        torch.manual_seed(7)
+        prefix_len = 8
+        extend_len = 64
+        cp_size = 2
+        block_count = 2 * cp_size
+        block_len = extend_len // block_count
+        scaling = HEAD_DIM**-0.5
+
+        for num_heads in (16, 128):
+            with self.subTest(num_heads=num_heads):
+                kv = (
+                    torch.randn(
+                        prefix_len + extend_len,
+                        1,
+                        HEAD_DIM,
+                        dtype=DTYPE,
+                        device=DEVICE,
+                    )
+                    * 0.2
+                )
+                q = (
+                    torch.randn(
+                        extend_len,
+                        num_heads,
+                        HEAD_DIM,
+                        dtype=DTYPE,
+                        device=DEVICE,
+                    )
+                    * 0.2
+                )
+                reference = _run_mla(
+                    q,
+                    kv,
+                    q_len=extend_len,
+                    kv_len=prefix_len + extend_len,
+                    num_heads=num_heads,
+                    scaling=scaling,
+                )
+
+                for rank in range(cp_size):
+                    block_ids = (rank, block_count - rank - 1)
+                    for block_id in block_ids:
+                        start = block_id * block_len
+                        end = start + block_len
+                        kv_len = prefix_len + end
+                        actual = _run_mla(
+                            q[start:end],
+                            kv,
+                            q_len=block_len,
+                            kv_len=kv_len,
+                            num_heads=num_heads,
+                            scaling=scaling,
+                        )
+                        torch.testing.assert_close(
+                            actual.float(),
+                            reference[start:end].float(),
+                            atol=6e-3,
+                            rtol=2e-3,
+                        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/cp/test_attn_parallel_mode.py
+++ b/test/registered/cp/test_attn_parallel_mode.py
@@ -13,6 +13,7 @@ from sglang.srt.attn_parallel import (
 )
 from sglang.srt.layers.cp.base import init_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active, prepare_cp_forward
+from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.managers.scheduler_components.dp_attn import MLPSyncBatchInfo
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.model_executor.runner.shape_key import ShapeKey
@@ -91,6 +92,41 @@ class TestAttnParallelModeSelector(unittest.TestCase):
         )
         self.assertEqual(decision.mode, AttnParallelMode.TP)
         self.assertEqual(decision.veto_reason, "below_threshold")
+
+    def test_dynamic_scheduler_keeps_tp_when_prefill_threshold_is_unset(self):
+        scheduler = object.__new__(Scheduler)
+        scheduler.server_args = SimpleNamespace(
+            enable_dynamic_attn_parallel=True,
+            dynamic_attn_parallel_min_prefill_tokens=None,
+            dynamic_attn_parallel_allow_mixed=False,
+            dynamic_attn_parallel_enable_dcp=False,
+            dynamic_attn_parallel_dcp_min_context=8192,
+        )
+        scheduler.ps = SimpleNamespace(attn_cp_size=8, attn_dcp_size=1)
+        batch = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            extend_lens=[512],
+            extend_num_tokens=512,
+            seq_lens_cpu=torch.tensor([512]),
+            kv_residency=KvResidency.REPLICATED,
+            attn_parallel_mode=None,
+            attn_parallel_veto_reason=None,
+        )
+
+        with (
+            patch(
+                "sglang.srt.managers.scheduler.get_cp_strategy",
+                return_value=SimpleNamespace(name="zigzag"),
+            ),
+            patch(
+                "sglang.srt.managers.scheduler.envs.SGLANG_ENABLE_CP_V2.get",
+                return_value=True,
+            ),
+        ):
+            scheduler._stamp_attn_parallel_mode(batch)
+
+        self.assertEqual(batch.attn_parallel_mode, AttnParallelMode.TP)
+        self.assertEqual(batch.attn_parallel_veto_reason, "prefill_threshold_unset")
 
     def test_decode_selects_dcp_only_above_context_threshold(self):
         short = select_attn_parallel_mode(

--- a/test/registered/cp/test_attn_parallel_mode.py
+++ b/test/registered/cp/test_attn_parallel_mode.py
@@ -1,0 +1,231 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.attn_parallel import (
+    AttnParallelMode,
+    KvResidency,
+    kv_storage_dcp_size,
+    resolve_kv_residency,
+    select_attn_parallel_mode,
+)
+from sglang.srt.layers.cp.base import init_cp_strategy
+from sglang.srt.layers.cp.utils import is_cp_v2_active, prepare_cp_forward
+from sglang.srt.managers.scheduler_components.dp_attn import MLPSyncBatchInfo
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.model_executor.runner.shape_key import ShapeKey
+from sglang.srt.runtime_context import get_parallel
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _Mode:
+    def __init__(
+        self,
+        name,
+        *,
+        cp_extend=False,
+        target_verify=False,
+        draft_extend_v2=False,
+    ):
+        self.name = name
+        self._cp_extend = cp_extend
+        self._target_verify = target_verify
+        self._draft_extend_v2 = draft_extend_v2
+
+    def is_context_parallel_extend(self):
+        return self._cp_extend
+
+    def is_target_verify(self):
+        return self._target_verify
+
+    def is_draft_extend_v2(self):
+        return self._draft_extend_v2
+
+
+class TestAttnParallelModeSelector(unittest.TestCase):
+    def test_zigzag_selects_cp_at_floor(self):
+        decision = select_attn_parallel_mode(
+            forward_mode=_Mode("EXTEND", cp_extend=True),
+            extend_seq_lens=[16, 32],
+            num_tokens=48,
+            strategy="zigzag",
+            cp_size=8,
+        )
+        self.assertEqual(decision.mode, AttnParallelMode.CP)
+        self.assertIsNone(decision.veto_reason)
+
+    def test_mixed_is_vetoed_for_interleave(self):
+        decision = select_attn_parallel_mode(
+            forward_mode=_Mode("MIXED", cp_extend=True),
+            extend_seq_lens=[128, 1],
+            num_tokens=129,
+            strategy="interleave",
+            cp_size=8,
+        )
+        self.assertEqual(decision.mode, AttnParallelMode.TP)
+        self.assertEqual(decision.veto_reason, "mixed")
+
+    def test_prefix_hit_short_request_vetoes_zigzag(self):
+        decision = select_attn_parallel_mode(
+            forward_mode=_Mode("EXTEND", cp_extend=True),
+            extend_seq_lens=[256, 8],
+            num_tokens=264,
+            strategy="zigzag",
+            cp_size=8,
+        )
+        self.assertEqual(decision.mode, AttnParallelMode.TP)
+        self.assertEqual(decision.veto_reason, "short_request")
+
+    def test_policy_threshold_is_separate_from_layout_floor(self):
+        decision = select_attn_parallel_mode(
+            forward_mode=_Mode("EXTEND", cp_extend=True),
+            extend_seq_lens=[32],
+            num_tokens=32,
+            strategy="zigzag",
+            cp_size=8,
+            min_prefill_tokens=64,
+        )
+        self.assertEqual(decision.mode, AttnParallelMode.TP)
+        self.assertEqual(decision.veto_reason, "below_threshold")
+
+    def test_decode_selects_dcp_only_above_context_threshold(self):
+        short = select_attn_parallel_mode(
+            forward_mode=_Mode("DECODE"),
+            extend_seq_lens=None,
+            num_tokens=0,
+            strategy="zigzag",
+            cp_size=8,
+            enable_decode_dcp=True,
+            dcp_size=8,
+            decode_seq_lens=[4096, 8191],
+            min_decode_context=8192,
+        )
+        long = select_attn_parallel_mode(
+            forward_mode=_Mode("DECODE"),
+            extend_seq_lens=None,
+            num_tokens=0,
+            strategy="zigzag",
+            cp_size=8,
+            enable_decode_dcp=True,
+            dcp_size=8,
+            decode_seq_lens=[4096, 8192],
+            min_decode_context=8192,
+        )
+        self.assertEqual(short.mode, AttnParallelMode.TP)
+        self.assertEqual(short.veto_reason, "short_context")
+        self.assertEqual(long.mode, AttnParallelMode.DCP)
+
+    def test_striped_prefill_uses_full_prefix_assembly_path(self):
+        decision = select_attn_parallel_mode(
+            forward_mode=_Mode("EXTEND", cp_extend=True),
+            extend_seq_lens=[32768],
+            num_tokens=32768,
+            strategy="zigzag",
+            cp_size=8,
+            enable_decode_dcp=True,
+            dcp_size=8,
+            kv_residency=KvResidency.STRIPED,
+        )
+        self.assertEqual(decision.mode, AttnParallelMode.TP)
+        self.assertEqual(decision.veto_reason, "striped_prefill")
+
+    def test_stamped_mode_is_authoritative(self):
+        self.assertTrue(
+            is_cp_v2_active(SimpleNamespace(attn_parallel_mode=AttnParallelMode.CP))
+        )
+        self.assertFalse(
+            is_cp_v2_active(SimpleNamespace(attn_parallel_mode=AttnParallelMode.TP))
+        )
+
+    def test_replicated_dynamic_dcp_uses_unscaled_loc_space(self):
+        parallel = SimpleNamespace(
+            dcp_enabled=True,
+            attn_dcp_size=8,
+            dynamic_attn_parallel_enable_dcp=True,
+        )
+        self.assertEqual(resolve_kv_residency(parallel), KvResidency.REPLICATED)
+        self.assertEqual(kv_storage_dcp_size(parallel), 1)
+
+        parallel.dynamic_attn_parallel_enable_dcp = False
+        self.assertEqual(resolve_kv_residency(parallel), KvResidency.STRIPED)
+        self.assertEqual(kv_storage_dcp_size(parallel), 8)
+
+    def test_decode_graph_key_separates_tp_and_dcp(self):
+        tp_key = ShapeKey(size=8, attn_parallel_mode=AttnParallelMode.TP.value)
+        dcp_key = ShapeKey(size=8, attn_parallel_mode=AttnParallelMode.DCP.value)
+        self.assertNotEqual(tp_key, dcp_key)
+
+    def test_mlp_sync_uses_permissive_idle_vote(self):
+        info = MLPSyncBatchInfo(
+            dp_size=2,
+            tp_size=1,
+            cp_size=1,
+            num_tokens=32,
+            num_tokens_for_logprob=1,
+            can_run_decode_cuda_graph=False,
+            can_run_prefill_cuda_graph=False,
+            is_extend_in_batch=True,
+            local_can_run_tbo=False,
+            local_forward_mode=1,
+            local_attn_parallel_mode=AttnParallelMode.TP.value,
+        )
+        local = info._get_local_tensor("cpu")
+        fallback = info._get_fallback_tensor("cpu")
+        self.assertEqual(local.numel(), 8)
+        self.assertEqual(fallback.numel(), 8)
+        self.assertEqual(int(fallback[-1]), AttnParallelMode.DCP.value)
+        self.assertEqual(local.dtype, torch.int64)
+
+    def test_cp_metadata_and_cache_locations_survive_mode_flip(self):
+        init_cp_strategy(
+            SimpleNamespace(
+                enable_prefill_cp=True,
+                cp_strategy="zigzag",
+                attn_cp_size=2,
+            )
+        )
+        forward_batch = SimpleNamespace(
+            attn_parallel_mode=AttnParallelMode.CP,
+            input_ids=torch.arange(32),
+            forward_mode=ForwardMode.EXTEND,
+            extend_seq_lens_cpu=[32],
+            seq_lens_cpu=torch.tensor([32], dtype=torch.int32),
+            attn_cp_metadata=None,
+            global_num_tokens_cpu=None,
+            out_cache_loc=torch.arange(40),
+        )
+
+        try:
+            with (
+                get_parallel().override(attn_cp_rank=0, attn_cp_size=2),
+                patch(
+                    "sglang.srt.layers.cp.padding.get_cp_padding_align_size",
+                    return_value=4,
+                ),
+            ):
+                prepare_cp_forward(forward_batch)
+                metadata = forward_batch.attn_cp_metadata
+                cache_locations = forward_batch.out_cache_loc
+                prepare_cp_forward(forward_batch)
+
+                self.assertIs(forward_batch.attn_cp_metadata, metadata)
+                self.assertIs(forward_batch.out_cache_loc, cache_locations)
+                self.assertEqual(cache_locations.tolist(), list(range(32)))
+
+                forward_batch.attn_parallel_mode = AttnParallelMode.TP
+                self.assertFalse(is_cp_v2_active(forward_batch))
+                self.assertIs(forward_batch.attn_cp_metadata, metadata)
+                self.assertIs(forward_batch.out_cache_loc, cache_locations)
+
+                forward_batch.attn_parallel_mode = AttnParallelMode.CP
+                self.assertTrue(is_cp_v2_active(forward_batch))
+        finally:
+            init_cp_strategy(SimpleNamespace(enable_prefill_cp=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -22,10 +22,12 @@ import torch
 from sglang.srt import runtime_context as rc
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
+from sglang.srt.layers.dcp.comm import all_gather_kv_cache_for_mla_extend
 from sglang.srt.layers.dcp.layout import (
     filter_dcp_local_chunk_kv_indices,
     get_dcp_lens,
 )
+from sglang.srt.layers.dcp.planner import prepare_decode_context_parallel_metadata
 from sglang.srt.layers.linear import QKVParallelLinear
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
 from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
@@ -142,6 +144,65 @@ class TestFilterDcpLocalChunkKvIndices(CustomTestCase):
 
 
 class TestGetDcpLens(CustomTestCase):
+    def test_mla_prefill_ignores_padded_in_hand_kv_rows(self):
+        k_nope = torch.arange(16, dtype=torch.float32).view(8, 1, 2)
+        k_pe = (torch.arange(8, dtype=torch.float32) + 100).view(8, 1, 1)
+        dcp_kv_buffer = torch.empty((7, 1, 3), dtype=torch.float32)
+
+        all_gather_kv_cache_for_mla_extend(
+            token_to_kv_pool=None,
+            attn_mqa=None,
+            extend_prefix_lens_cpu=[0],
+            dcp_local_prefix_kv_indices=torch.empty(0, dtype=torch.int64),
+            dcp_extend_prefix_lens_sum=0,
+            dcp_kv_buffer=dcp_kv_buffer,
+            kv_lora_rank=2,
+            k_nope=k_nope,
+            k_pe=k_pe,
+        )
+
+        self.assertTrue(torch.equal(dcp_kv_buffer[..., :2], k_nope[:7]))
+        self.assertTrue(torch.equal(dcp_kv_buffer[..., 2:], k_pe[:7]))
+
+    def test_prefill_metadata_uses_prefix_plus_extend_not_stale_seq_sum(self):
+        class FakeKernel:
+            def __getitem__(self, _grid):
+                return lambda *_args, **_kwargs: None
+
+        parallel = SimpleNamespace(dcp_enabled=True, dcp_size=8, dcp_rank=0)
+        device = SimpleNamespace(device=torch.device("cpu"))
+        with (
+            patch(
+                "sglang.srt.layers.dcp.planner.get_parallel",
+                return_value=parallel,
+            ),
+            patch(
+                "sglang.srt.layers.dcp.planner.get_device",
+                return_value=device,
+            ),
+            patch(
+                "sglang.srt.layers.dcp.planner.create_dcp_kv_indices",
+                FakeKernel(),
+            ),
+        ):
+            metadata = prepare_decode_context_parallel_metadata(
+                seq_lens=torch.tensor([7], dtype=torch.int32),
+                extend_prefix_lens=torch.tensor([0], dtype=torch.int32),
+                extend_prefix_lens_cpu=[0],
+                extend_seq_lens=torch.tensor([8], dtype=torch.int32),
+                req_pool_indices=torch.tensor([0]),
+                req_to_token=torch.zeros((1, 16), dtype=torch.int32),
+                seq_lens_sum=7,
+                kv_buffer_shape=torch.Size([16, 1, 576]),
+                kv_cache_dtype=torch.bfloat16,
+                kv_cache_device=torch.device("cpu"),
+                create_chunked_prefix_cache_kv_indices_fn=FakeKernel(),
+            )
+
+        self.assertEqual(metadata.dcp_kv_indptr.tolist(), [0, 8])
+        self.assertEqual(metadata.dcp_kv_indices.numel(), 8)
+        self.assertEqual(metadata.dcp_kv_buffer.shape[0], 8)
+
     def test_start_none_matches_owner_count(self):
         for n in DCP_SIZES:
             for rank in range(n):

--- a/test/registered/dcp/test_dcp_layout_unit.py
+++ b/test/registered/dcp/test_dcp_layout_unit.py
@@ -29,7 +29,7 @@ from sglang.srt.layers.dcp.layout import (
 from sglang.srt.layers.linear import QKVParallelLinear
 from sglang.srt.mem_cache.allocator.paged import PagedTokenToKVPoolAllocator
 from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
-from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool, MLATokenToKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -191,6 +191,82 @@ class TestGetDcpLens(CustomTestCase):
         lens = torch.tensor(LENS, dtype=torch.int32)
         self.assertTrue(torch.equal(get_dcp_lens(lens, 1, 0), lens))
 
+    @staticmethod
+    def _fake_mla_pool(size=8):
+        pool = object.__new__(MLATokenToKVPool)
+        pool.size = size
+        pool.page_size = 1
+        pool.start_layer = 0
+        pool.layer_transfer_counter = None
+        pool.dtype = torch.float32
+        pool.store_dtype = torch.float32
+        pool.dsa_kv_cache_store_fp8 = False
+        pool.kv_buffer = [torch.zeros(size, 1, dtype=torch.float32)]
+        return pool
+
+    def test_mla_generic_write_translates_striped_locs(self):
+        pool = self._fake_mla_pool()
+        parallel = SimpleNamespace(
+            dcp_enabled=True,
+            attn_dcp_size=2,
+            attn_dcp_rank=1,
+            dynamic_attn_parallel_enable_dcp=False,
+        )
+        with patch(
+            "sglang.srt.mem_cache.memory_pool.get_parallel",
+            return_value=parallel,
+        ):
+            pool.set_kv_buffer(
+                SimpleNamespace(layer_id=0),
+                torch.tensor([1, 3, 5]),
+                torch.tensor([[10.0], [20.0], [30.0]]),
+                None,
+            )
+        self.assertEqual(pool.kv_buffer[0][:3, 0].tolist(), [10.0, 20.0, 30.0])
+
+    def test_mla_generic_write_keeps_replicated_locs(self):
+        pool = self._fake_mla_pool()
+        parallel = SimpleNamespace(
+            dcp_enabled=True,
+            attn_dcp_size=2,
+            attn_dcp_rank=1,
+            dynamic_attn_parallel_enable_dcp=True,
+        )
+        with patch(
+            "sglang.srt.mem_cache.memory_pool.get_parallel",
+            return_value=parallel,
+        ):
+            pool.set_kv_buffer(
+                SimpleNamespace(layer_id=0),
+                torch.tensor([1, 3, 5]),
+                torch.tensor([[10.0], [20.0], [30.0]]),
+                None,
+            )
+        self.assertEqual(
+            pool.kv_buffer[0][[1, 3, 5], 0].tolist(),
+            [10.0, 20.0, 30.0],
+        )
+
+    def test_mla_move_translates_striped_locs(self):
+        pool = self._fake_mla_pool()
+        pool.kv_buffer[0][0, 0] = 10
+        pool.kv_buffer[0][1, 0] = 20
+        parallel = SimpleNamespace(
+            dcp_enabled=True,
+            attn_dcp_size=2,
+            attn_dcp_rank=1,
+            dynamic_attn_parallel_enable_dcp=False,
+        )
+        with patch(
+            "sglang.srt.mem_cache.memory_pool.get_parallel",
+            return_value=parallel,
+        ):
+            pool.move_kv_cache(
+                tgt_loc=torch.tensor([5, 7]),
+                src_loc=torch.tensor([1, 3]),
+            )
+        self.assertEqual(pool.kv_buffer[0][[2, 3], 0].tolist(), [10.0, 20.0])
+
     def test_gqa_current_chunk_selects_kv_for_the_global_dcp_head_layout(self):
         """A local Q shard must not restart GQA mapping at KV head zero."""
 
@@ -207,6 +283,9 @@ class TestGetDcpLens(CustomTestCase):
 
         group = FakeDcpGroup()
         backend = TritonAttnBackend.__new__(TritonAttnBackend)
+        # GQA, not MLA: the K/V heads reaching the kernel are the DCP-replicated
+        # set, so this rank has to pick the slice its Q shard maps to.
+        backend.use_mla = False
         backend.forward_metadata = SimpleNamespace(
             custom_mask=None,
             kv_indptr=torch.zeros(2, dtype=torch.int32),
@@ -395,6 +474,7 @@ class TestGetDcpLens(CustomTestCase):
             disaggregation_mode="null",
             page_size=physical_page_size,
             enable_hisparse=False,
+            dynamic_attn_parallel_enable_dcp=False,
         )
         override.install()
         self.addCleanup(override.restore)
@@ -412,7 +492,10 @@ class TestGetDcpLens(CustomTestCase):
             with patch(
                 "sglang.srt.mem_cache.kv_cache_configurator.current_platform.is_out_of_tree",
                 return_value=False,
-            ), rc.get_parallel().override(attn_dcp_size=dcp_size):
+            ), rc.get_parallel().override(
+                attn_dcp_size=dcp_size,
+                dcp_enabled=dcp_size > 1,
+            ):
                 allocators[dcp_size] = (
                     KVCacheConfigurator._build_token_to_kv_pool_allocator(
                         configurator,

--- a/test/registered/kernels/benchmark/attention/bench_dcp_verify_helpers.py
+++ b/test/registered/kernels/benchmark/attention/bench_dcp_verify_helpers.py
@@ -1,0 +1,156 @@
+"""Benchmark: the two DCP target-verify helpers, Triton vs torch.
+
+Both run on the speculative target-verify path only, and only on dcp_rank 0:
+
+* stage B  -- ``dense_causal_mla_attn_base2``: dense causal attention over the
+  in-hand ``gamma + 1`` window, returning ``(out, base-2 lse)``.
+* the merge -- ``dcp_lse_combine_base2``: folds stage B into stage A (the rank's
+  committed KV shard) over disjoint key sets.
+
+Both were torch before; the ``torch`` provider below is the implementation they
+replaced, kept here so the swap stays measurable. The merge in particular was
+~10 elementwise launches, which is what a single Triton program should win back
+at these shapes.
+
+``extend_attention`` is a third provider for stage B only: the generic
+``extend_attention_fwd(is_causal=True, skip_prefix=True, lse_extend=...)``
+computes the same thing and would have needed no new kernel, so its cost is
+worth having on record. It turned out to be both slower here (it carries the
+whole paged-prefix machinery) and not the drop-in it looks like -- ``k_buffer``,
+``v_buffer``, ``kv_indices``, ``k_scale`` and ``v_scale`` must all be non-None
+even with ``skip_prefix=True``.
+
+Shapes are Kimi-K3 at tp8 dcp8: 96 gathered heads, kv_lora_rank 512,
+qk_rope_head_dim 64, bf16.
+"""
+
+import math
+
+import torch
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.ops.attention.dcp_kernels import (
+    dcp_lse_combine_base2,
+    dense_causal_mla_attn_base2,
+)
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=10, stage="jit-kernel-benchmark", runner_config="amd")
+
+KV_LORA_RANK = 512
+QK_ROPE = 64
+D = KV_LORA_RANK + QK_ROPE
+NUM_HEADS = 96  # K3 gathered heads at tp8 dcp8
+DTYPE = torch.bfloat16
+DEV = "cuda"
+
+_LOG2E = 1.4426950408889634
+
+
+def _torch_dense_causal(q, k_window, scaling, bs, q_len, kv_lora_rank):
+    """The torch stage B this kernel replaced."""
+    num_heads = q.shape[1]
+    qb = q.view(bs, q_len, num_heads, -1)
+    kb = k_window.view(bs, q_len, -1)
+    scores = torch.einsum("bihd,bjd->bhij", qb, kb).float() * scaling
+    causal = torch.ones(q_len, q_len, dtype=torch.bool, device=q.device).tril()
+    scores = scores.masked_fill(~causal, float("-inf"))
+    lse_e = torch.logsumexp(scores, dim=-1)
+    probs = torch.exp(scores - lse_e.unsqueeze(-1))
+    vb = kb[..., :kv_lora_rank].float()
+    out = torch.einsum("bhij,bjd->bihd", probs, vb)
+    return (
+        out.reshape(bs * q_len, num_heads, kv_lora_rank),
+        (lse_e * _LOG2E).permute(0, 2, 1).reshape(bs * q_len, num_heads),
+    )
+
+
+def _torch_lse_combine(out_a, lse_a, out_b, lse_b, out_dtype):
+    """The torch merge this kernel replaced (~10 elementwise launches)."""
+    m = torch.maximum(lse_a, lse_b)
+    w_a = torch.nan_to_num(torch.exp2(lse_a - m), nan=0.0, posinf=0.0, neginf=0.0)
+    w_b = torch.nan_to_num(torch.exp2(lse_b - m), nan=0.0, posinf=0.0, neginf=0.0)
+    denom = w_a + w_b
+    out = out_a.float() * w_a.unsqueeze(-1) + out_b.float() * w_b.unsqueeze(-1)
+    out = out / denom.clamp_min(torch.finfo(torch.float32).tiny).unsqueeze(-1)
+    lse = torch.where(denom == 0.0, float("-inf"), m + torch.log2(denom))
+    return out.to(out_dtype), lse
+
+
+def _extend_attention_dense_causal(q, k_window, scaling, bs, q_len, kv_lora_rank):
+    """Same stage B through the generic extend kernel, for comparison."""
+    from sglang.kernels.ops.attention.extend_attention import extend_attention_fwd
+
+    n_rows = bs * q_len
+    k2 = k_window.view(n_rows, 1, D)
+    v2 = k2[..., :kv_lora_rank]
+    out = torch.empty(n_rows, q.shape[1], kv_lora_rank, dtype=q.dtype, device=q.device)
+    lse = torch.empty(n_rows, q.shape[1], dtype=torch.float32, device=q.device)
+    qo_indptr = torch.arange(0, n_rows + 1, q_len, dtype=torch.int32, device=q.device)
+    zeros = torch.zeros(bs + 1, dtype=torch.int32, device=q.device)
+    extend_attention_fwd(
+        q,
+        k2,
+        v2,
+        out,
+        # k_buffer/v_buffer are never read (skip_prefix=True, kv_indptr all
+        # zeros) but cannot be None: extend_attention_fwd extracts their strides
+        # unconditionally. So it is not quite the drop-in it looks like.
+        k2,
+        v2,
+        qo_indptr,
+        zeros,  # kv_indptr: no committed prefix
+        torch.zeros(1, dtype=torch.int32, device=q.device),  # kv_indices
+        None,  # custom_mask
+        True,  # is_causal
+        None,  # mask_indptr
+        q_len,  # max_len_extend
+        1.0,  # k_scale -- also cannot be None, it is applied unconditionally
+        1.0,  # v_scale
+        sm_scale=scaling,
+        skip_prefix=True,
+        lse_extend=lse,
+    )
+    return out, lse * _LOG2E
+
+
+@marker.parametrize("q_len", [2, 4, 8, 16], [2, 8])
+@marker.parametrize("bs", [1, 8, 32, 64], [1, 32])
+@marker.benchmark("impl", ["triton", "torch"])
+def benchmark_lse_combine(bs: int, q_len: int, impl: str):
+    n_rows = bs * q_len
+    out_a = torch.randn(n_rows, NUM_HEADS, KV_LORA_RANK, dtype=DTYPE, device=DEV)
+    out_b = torch.randn(n_rows, NUM_HEADS, KV_LORA_RANK, dtype=DTYPE, device=DEV)
+    lse_a = torch.randn(n_rows, NUM_HEADS, dtype=torch.float32, device=DEV)
+    lse_b = torch.randn(n_rows, NUM_HEADS, dtype=torch.float32, device=DEV)
+    fn = dcp_lse_combine_base2 if impl == "triton" else _torch_lse_combine
+    return marker.do_bench(
+        fn,
+        input_args=(out_a, lse_a, out_b, lse_b, DTYPE),
+        memory_args=(out_a, out_b),
+    )
+
+
+@marker.parametrize("q_len", [2, 4, 8, 16], [2, 8])
+@marker.parametrize("bs", [1, 8, 32, 64], [1, 32])
+@marker.benchmark("impl", ["triton", "torch", "extend_attention"])
+def benchmark_dense_causal(bs: int, q_len: int, impl: str):
+    n_rows = bs * q_len
+    q = torch.randn(n_rows, NUM_HEADS, D, dtype=DTYPE, device=DEV) * 0.3
+    k_window = torch.randn(n_rows, 1, D, dtype=DTYPE, device=DEV) * 0.3
+    scaling = 1.0 / math.sqrt(D)
+    fn = {
+        "triton": dense_causal_mla_attn_base2,
+        "torch": _torch_dense_causal,
+        "extend_attention": _extend_attention_dense_causal,
+    }[impl]
+    return marker.do_bench(
+        fn,
+        input_args=(q, k_window, scaling, bs, q_len, KV_LORA_RANK),
+        memory_args=(q, k_window),
+    )
+
+
+if __name__ == "__main__":
+    benchmark_lse_combine.run()
+    benchmark_dense_causal.run()

--- a/test/registered/unit/mem_cache/test_residency_allocator.py
+++ b/test/registered/unit/mem_cache/test_residency_allocator.py
@@ -1,0 +1,96 @@
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.attn_parallel import KvResidency
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.mem_cache.allocator.residency import (
+    ResidencyAwarePagedTokenToKVPoolAllocator,
+)
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestResidencyAwareAllocator(CustomTestCase):
+    def _allocator(self):
+        return ResidencyAwarePagedTokenToKVPoolAllocator(
+            physical_size=128,
+            physical_page_size=1,
+            dcp_size=4,
+            replicated_fraction=0.5,
+            dtype=torch.bfloat16,
+            device="cpu",
+            kvcache=object(),
+            need_sort=False,
+        )
+
+    def test_regions_map_to_disjoint_physical_rows(self):
+        allocator = self._allocator()
+        initial_available = allocator.total_available_size()
+
+        allocator.set_active_residency(KvResidency.REPLICATED)
+        replicated = allocator.alloc(allocator.page_size)
+        allocator.set_active_residency(KvResidency.STRIPED)
+        striped = allocator.alloc(allocator.page_size)
+
+        self.assertTrue((replicated < allocator.striped_virtual_start).all())
+        self.assertTrue((striped >= allocator.striped_virtual_start).all())
+        replicated_physical = set(replicated.tolist())
+        striped_physical = set((striped // allocator.dcp_size).tolist())
+        self.assertTrue(replicated_physical.isdisjoint(striped_physical))
+
+        allocator.free(torch.cat((replicated, striped)))
+        self.assertEqual(allocator.total_available_size(), initial_available)
+
+    def test_transitioning_residency_cannot_allocate(self):
+        allocator = self._allocator()
+        with self.assertRaises(RuntimeError):
+            allocator.set_active_residency(KvResidency.TRANSITIONING)
+
+
+class TestResidencyLayoutTag(CustomTestCase):
+    def test_scheduler_stamps_sticky_layout_namespace(self):
+        scheduler = object.__new__(Scheduler)
+        scheduler.server_args = SimpleNamespace(
+            dynamic_attn_parallel_enable_dcp=True,
+            dynamic_attn_parallel_dcp_min_context=8,
+        )
+        scheduler.ps = SimpleNamespace(attn_dcp_size=4)
+        req = SimpleNamespace(
+            kv_residency=None,
+            kv_layout_tagged=False,
+            full_untruncated_fill_ids=list(range(16)),
+            origin_input_ids=list(range(16)),
+            extra_key="tenant",
+        )
+
+        scheduler._ensure_req_kv_residency(req)
+        first_key = req.extra_key
+        self.assertEqual(req.kv_residency, KvResidency.STRIPED)
+        self.assertIn("striped:dcp4:epoch0", first_key)
+
+        req.full_untruncated_fill_ids = [1]
+        scheduler._ensure_req_kv_residency(req)
+        self.assertEqual(req.kv_residency, KvResidency.STRIPED)
+        self.assertEqual(req.extra_key, first_key)
+
+    def test_radix_keys_reject_cross_layout_match(self):
+        tokens = torch.arange(8).tolist()
+        from array import array
+
+        replicated = RadixKey(
+            array("q", tokens), extra_key="tenant|sglang-kv:replicated:dcp4:epoch0"
+        )
+        striped = RadixKey(
+            array("q", tokens), extra_key="tenant|sglang-kv:striped:dcp4:epoch0"
+        )
+        with self.assertRaises(ValueError):
+            replicated.match(striped)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_residency_allocator.py
+++ b/test/registered/unit/mem_cache/test_residency_allocator.py
@@ -5,6 +5,9 @@ import torch
 
 from sglang.srt.attn_parallel import KvResidency
 from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.pool_stats_observer import (
+    SchedulerPoolStatsObserver,
+)
 from sglang.srt.mem_cache.allocator.residency import (
     ResidencyAwarePagedTokenToKVPoolAllocator,
 )
@@ -46,10 +49,70 @@ class TestResidencyAwareAllocator(CustomTestCase):
         allocator.free(torch.cat((replicated, striped)))
         self.assertEqual(allocator.total_available_size(), initial_available)
 
+    def test_last_replicated_page_does_not_alias_first_striped_page(self):
+        allocator = self._allocator()
+        allocator.set_active_residency(KvResidency.REPLICATED)
+        replicated_pages = []
+        while allocator.available_size():
+            replicated_pages.append(allocator.alloc(allocator.page_size))
+        last_replicated = replicated_pages[-1]
+
+        allocator.set_active_residency(KvResidency.STRIPED)
+        first_striped = allocator.alloc(allocator.page_size)
+
+        replicated_physical = set(last_replicated.tolist())
+        striped_physical = set((first_striped // allocator.dcp_size).tolist())
+        self.assertTrue(replicated_physical.isdisjoint(striped_physical))
+
+    def test_free_segments_deduplicates_shared_boundary_page(self):
+        allocator = self._allocator()
+        calls = []
+        allocator.free_segment = lambda indices, *, start_pos: calls.append(
+            (indices.clone(), start_pos)
+        )
+
+        allocator.free_segments(
+            [
+                (torch.tensor([4, 5, 6]), 0),
+                (torch.tensor([7, 8, 9]), 3),
+            ]
+        )
+
+        self.assertEqual([len(indices) for indices, _ in calls], [3, 2])
+        self.assertEqual([start for _, start in calls], [0, 4])
+
     def test_transitioning_residency_cannot_allocate(self):
         allocator = self._allocator()
         with self.assertRaises(RuntimeError):
             allocator.set_active_residency(KvResidency.TRANSITIONING)
+
+    def test_pool_stats_use_active_residency_capacity(self):
+        allocator = self._allocator()
+        observer = SchedulerPoolStatsObserver(
+            tree_cache=SimpleNamespace(evictable_size=lambda: 0),
+            token_to_kv_pool_allocator=allocator,
+            req_to_token_pool=SimpleNamespace(),
+            session_controller=SimpleNamespace(sessions={}),
+            hisparse_coordinator=None,
+            is_hybrid_swa=False,
+            is_hybrid_ssm=False,
+            enable_hisparse=False,
+            full_tokens_per_layer=None,
+            swa_tokens_per_layer=None,
+            max_total_num_tokens=allocator.physical_size,
+            get_last_batch=lambda: None,
+            get_running_batch=lambda: None,
+        )
+
+        stats = observer._get_token_info()
+        self.assertEqual(stats.full_num_used, 0)
+        self.assertEqual(stats.full_token_usage, 0.0)
+
+        allocator.set_active_residency(KvResidency.STRIPED)
+        allocator.alloc(allocator.page_size)
+        stats = observer._get_token_info()
+        self.assertEqual(stats.full_num_used, allocator.page_size)
+        self.assertGreater(stats.full_token_usage, 0.0)
 
 
 class TestResidencyLayoutTag(CustomTestCase):
@@ -58,6 +121,7 @@ class TestResidencyLayoutTag(CustomTestCase):
         scheduler.server_args = SimpleNamespace(
             dynamic_attn_parallel_enable_dcp=True,
             dynamic_attn_parallel_dcp_min_context=8,
+            dynamic_attn_parallel_striped_min_context=8,
         )
         scheduler.ps = SimpleNamespace(attn_dcp_size=4)
         req = SimpleNamespace(
@@ -77,6 +141,27 @@ class TestResidencyLayoutTag(CustomTestCase):
         scheduler._ensure_req_kv_residency(req)
         self.assertEqual(req.kv_residency, KvResidency.STRIPED)
         self.assertEqual(req.extra_key, first_key)
+
+    def test_scheduler_defaults_dynamic_dcp_to_replicated_residency(self):
+        scheduler = object.__new__(Scheduler)
+        scheduler.server_args = SimpleNamespace(
+            dynamic_attn_parallel_enable_dcp=True,
+            dynamic_attn_parallel_dcp_min_context=8,
+            dynamic_attn_parallel_striped_min_context=None,
+        )
+        scheduler.ps = SimpleNamespace(attn_dcp_size=4)
+        req = SimpleNamespace(
+            kv_residency=None,
+            kv_layout_tagged=False,
+            full_untruncated_fill_ids=list(range(16)),
+            origin_input_ids=list(range(16)),
+            extra_key=None,
+        )
+
+        scheduler._ensure_req_kv_residency(req)
+
+        self.assertEqual(req.kv_residency, KvResidency.REPLICATED)
+        self.assertIn("replicated:dcp4:epoch0", req.extra_key)
 
     def test_radix_keys_reject_cross_layout_match(self):
         tokens = torch.arange(8).tolist()

--- a/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/runner/test_decode_cuda_graph_runner.py
@@ -28,9 +28,13 @@ import unittest
 from types import SimpleNamespace
 from unittest import mock
 
+import torch
+
+from sglang.srt.attn_parallel import AttnParallelMode, KvResidency
 from sglang.srt.model_executor.runner import decode_cuda_graph_runner as mod
 from sglang.srt.model_executor.runner.decode_cuda_graph_runner import (
     DecodeCudaGraphRunner,
+    build_replay_fb_view,
 )
 from sglang.srt.utils import profile_utils as putils
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -50,6 +54,44 @@ def _make_fake_self(capture_bs):
         DecodeCudaGraphRunner._graph_batch_capture_active.__get__(fake_self)
     )
     return fake_self
+
+
+class TestReplayForwardBatchView(CustomTestCase):
+    def test_preserves_dynamic_attention_mode_and_residency(self):
+        mode = SimpleNamespace()
+        forward_batch = SimpleNamespace(
+            forward_mode=mode,
+            seq_lens_sum=1,
+            seq_lens_cpu=torch.tensor([1]),
+            out_cache_loc=torch.tensor([1]),
+            out_cache_loc_dsv4=None,
+            spec_info=None,
+            attn_parallel_mode=AttnParallelMode.DCP,
+            kv_residency=KvResidency.STRIPED,
+        )
+        buffers = SimpleNamespace(
+            input_ids=torch.tensor([1]),
+            positions=torch.tensor([0]),
+            req_pool_indices=torch.tensor([0]),
+            seq_lens=torch.tensor([1]),
+            seq_lens_cpu=torch.tensor([1]),
+            encoder_lens=None,
+            mamba_track_indices=None,
+        )
+
+        replay = build_replay_fb_view(
+            forward_batch=forward_batch,
+            buffers=buffers,
+            bs=1,
+            raw_bs=1,
+            num_tokens=1,
+            seq_len_fill_value=1,
+            capture_forward_mode=mode,
+            is_encoder_decoder=False,
+        )
+
+        self.assertEqual(replay.attn_parallel_mode, AttnParallelMode.DCP)
+        self.assertEqual(replay.kv_residency, KvResidency.STRIPED)
 
 
 class TestInitProfileBatchMode(CustomTestCase):

--- a/test/registered/unit/models/test_aiter_mla_cp.py
+++ b/test/registered/unit/models/test_aiter_mla_cp.py
@@ -17,6 +17,7 @@ from sglang.srt.layers.cp.cp_decode_attn_tp import (
     CpDecodeAttnTpContext,
 )
 from sglang.srt.layers.cp.zigzag import ZigzagCPStrategy
+from sglang.srt.layers.utils.cp_utils import can_cp_split, mla_use_prefill_cp
 from sglang.srt.models.deepseek_common.attention_backend_handler import (
     handle_attention_aiter,
 )
@@ -26,6 +27,25 @@ from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+def _shuffle_weight_reference(x: torch.Tensor) -> torch.Tensor:
+    n_lane = 16
+    k_block = 32
+    k_lane = 16 // x.element_size()
+    return (
+        x.view(
+            -1,
+            x.shape[-2] // n_lane,
+            n_lane,
+            x.shape[-1] // k_block,
+            k_block // k_lane,
+            k_lane,
+        )
+        .permute(0, 1, 3, 4, 2, 5)
+        .contiguous()
+        .view_as(x)
+    )
 
 
 class _FakeTokenPool:
@@ -56,6 +76,55 @@ class _FakeCPStrategy:
 
 
 class TestAiterMlaContextParallel(unittest.TestCase):
+    def test_legacy_cp_helpers_honor_runtime_tp_stamp(self):
+        forward_mode = SimpleNamespace(is_context_parallel_extend=lambda: True)
+        batch = SimpleNamespace(
+            attn_parallel_mode=AttnParallelMode.TP,
+            attn_cp_metadata=object(),
+            forward_mode=forward_mode,
+            extend_seq_lens_cpu=[32],
+        )
+        with (
+            patch(
+                "sglang.srt.layers.utils.cp_utils.is_prefill_context_parallel_enabled",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.environ.envs.SGLANG_ENABLE_CP_V2.get",
+                return_value=True,
+            ),
+        ):
+            self.assertFalse(can_cp_split(32, 8, batch))
+            self.assertFalse(mla_use_prefill_cp(batch, mla_enable_prefill_cp=True))
+
+        batch.attn_parallel_mode = AttnParallelMode.CP
+        with (
+            patch(
+                "sglang.srt.layers.utils.cp_utils.is_prefill_context_parallel_enabled",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.environ.envs.SGLANG_ENABLE_CP_V2.get",
+                return_value=True,
+            ),
+        ):
+            self.assertTrue(can_cp_split(32, 8, batch))
+            self.assertTrue(mla_use_prefill_cp(batch, mla_enable_prefill_cp=True))
+
+        batch.attn_parallel_mode = AttnParallelMode.TP
+        with (
+            patch(
+                "sglang.srt.layers.utils.cp_utils.is_prefill_context_parallel_enabled",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.environ.envs.SGLANG_ENABLE_CP_V2.get",
+                return_value=False,
+            ),
+        ):
+            self.assertTrue(can_cp_split(32, 8, batch))
+            self.assertTrue(mla_use_prefill_cp(batch, mla_enable_prefill_cp=True))
+
     def test_dcp_backend_dispatch_reads_batch_stamp(self):
         backend = object.__new__(AiterAttnBackend)
         backend.use_mla = True
@@ -81,6 +150,34 @@ class TestAiterMlaContextParallel(unittest.TestCase):
             )
         )
 
+    def test_dcp_page_table_uses_active_residency_scale(self):
+        backend = object.__new__(AiterAttnBackend)
+        backend.req_to_token = torch.zeros((1, 8), dtype=torch.int64)
+        backend.page_size = 1
+        backend.dcp_world_size = 8
+        backend.token_to_kv_pool = SimpleNamespace(active_storage_dcp_size=lambda: 8)
+        expected = torch.zeros((1, 1), dtype=torch.int32)
+
+        with (
+            patch(
+                "sglang.kernels.ops.attention.dcp_kernels.build_dcp_page_table",
+                return_value=expected,
+            ) as build,
+            patch(
+                "sglang.srt.layers.attention.aiter_backend.get_parallel",
+                return_value=SimpleNamespace(attn_dcp_rank=0),
+            ),
+        ):
+            table, _ = backend._build_dcp_decode_page_table(
+                kv_indptr=torch.tensor([0, 1], dtype=torch.int32),
+                req_pool_indices=torch.tensor([0]),
+                bs=1,
+                max_local_kv_len=1,
+            )
+
+        self.assertIs(table, expected)
+        self.assertEqual(build.call_args.kwargs["kv_loc_scale"], 8)
+
     def test_deepseek_v3_runtime_tp_is_enabled(self):
         self.assertIn("DeepseekV3ForCausalLM", CP_DECODE_ATTN_TP_SUPPORTED_ARCHS)
 
@@ -91,9 +188,15 @@ class TestAiterMlaContextParallel(unittest.TestCase):
             is_target_verify=lambda: False,
             is_draft_extend_v2=lambda: False,
         )
-        with patch(
-            "sglang.srt.layers.cp.cp_decode_attn_tp.dsa_use_prefill_cp",
-            return_value=False,
+        with (
+            patch(
+                "sglang.srt.layers.cp.cp_decode_attn_tp.dsa_use_prefill_cp",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.layers.cp.cp_decode_attn_tp.mla_use_prefill_cp",
+                return_value=False,
+            ),
         ):
             self.assertTrue(
                 ctx.should_use_attn_tp(
@@ -141,13 +244,122 @@ class TestAiterMlaContextParallel(unittest.TestCase):
         "sglang.srt.layers.cp.cp_decode_attn_tp.get_cp_decode_attn_tp_ctx",
         return_value=SimpleNamespace(should_use_attn_tp=lambda _batch: True),
     )
-    def test_aiter_dispatches_runtime_tp_prefill_to_mla(
-        self, _mock_runtime_tp, _mock_cp
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_backend_handler.kv_storage_dcp_size",
+        return_value=1,
+    )
+    def test_aiter_dispatches_runtime_tp_prefill_to_mha(
+        self, _mock_storage_dcp_size, _mock_runtime_tp, _mock_cp
     ):
         method = handle_attention_aiter(
-            SimpleNamespace(), SimpleNamespace(forward_mode=SimpleNamespace())
+            SimpleNamespace(),
+            SimpleNamespace(
+                forward_mode=SimpleNamespace(is_extend_without_speculative=lambda: True)
+            ),
         )
-        self.assertEqual(method, AttnForwardMethod.MLA)
+        self.assertEqual(method, AttnForwardMethod.MHA)
+
+    def test_runtime_tp_slices_mha_heads_and_preserves_mqa_kv_heads(self):
+        ctx = object.__new__(CpDecodeAttnTpContext)
+        ctx.decode_tp_rank = 0
+        ctx.decode_tp_size = 8
+        ctx.use_decode_attn_tp = False
+        ctx._slice_cache = {}
+        forward_mode = SimpleNamespace(
+            is_target_verify=lambda: False,
+            is_draft_extend_v2=lambda: False,
+        )
+        forward_batch = SimpleNamespace(forward_mode=forward_mode)
+        mha = SimpleNamespace(
+            tp_q_head_num=128,
+            tp_k_head_num=128,
+            tp_v_head_num=128,
+        )
+        mqa = SimpleNamespace(
+            tp_q_head_num=128,
+            tp_k_head_num=1,
+            tp_v_head_num=1,
+        )
+
+        with (
+            patch(
+                "sglang.srt.layers.cp.cp_decode_attn_tp.is_cp_v2_active",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.layers.cp.cp_decode_attn_tp.dsa_use_prefill_cp",
+                return_value=False,
+            ),
+            patch(
+                "sglang.srt.layers.cp.cp_decode_attn_tp.mla_use_prefill_cp",
+                return_value=False,
+            ),
+            ctx.maybe_use_decode_attn_tp(
+                forward_batch,
+                modules=[],
+                radix_attn=[mha, mqa],
+            ),
+        ):
+            self.assertEqual(
+                (mha.tp_q_head_num, mha.tp_k_head_num, mha.tp_v_head_num),
+                (16, 16, 16),
+            )
+            self.assertEqual(
+                (mqa.tp_q_head_num, mqa.tp_k_head_num, mqa.tp_v_head_num),
+                (16, 1, 1),
+            )
+
+        self.assertEqual(
+            (mha.tp_q_head_num, mha.tp_k_head_num, mha.tp_v_head_num),
+            (128, 128, 128),
+        )
+        self.assertEqual(
+            (mqa.tp_q_head_num, mqa.tp_k_head_num, mqa.tp_v_head_num),
+            (128, 1, 1),
+        )
+
+    def test_runtime_tp_slices_aiter_preshuffled_row_weight_logically(self):
+        logical = torch.arange(32 * 64, dtype=torch.float32).view(32, 64)
+        shuffled = _shuffle_weight_reference(logical)
+        ctx = object.__new__(CpDecodeAttnTpContext)
+        ctx.decode_tp_rank = 1
+        ctx.decode_tp_size = 2
+
+        with patch.object(
+            ctx,
+            "_is_aiter_bpreshuffled_weight",
+            return_value=True,
+        ):
+            sliced = ctx._slice_attr(
+                SimpleNamespace(),
+                "weight",
+                shuffled,
+                dim=1,
+            )
+
+        actual = ctx._unshuffle_aiter_weight(sliced)
+        self.assertTrue(torch.equal(actual, logical[:, 32:]))
+
+    def test_runtime_tp_converts_full_preshuffle_to_local_triton_layout(self):
+        logical = torch.arange(64 * 64, dtype=torch.float32).view(64, 64)
+        shuffled = _shuffle_weight_reference(logical)
+        ctx = object.__new__(CpDecodeAttnTpContext)
+        ctx.decode_tp_rank = 0
+        ctx.decode_tp_size = 2
+
+        with patch.object(
+            ctx,
+            "_is_aiter_bpreshuffled_weight",
+            side_effect=(True, False),
+        ):
+            sliced = ctx._slice_attr(
+                SimpleNamespace(),
+                "weight",
+                shuffled,
+                dim=0,
+            )
+
+        self.assertTrue(torch.equal(sliced, logical[:32]))
 
     def test_mla_cp_forward_dispatches_both_zigzag_halves(self):
         backend = object.__new__(AiterAttnBackend)

--- a/test/registered/unit/models/test_aiter_mla_cp.py
+++ b/test/registered/unit/models/test_aiter_mla_cp.py
@@ -1,0 +1,231 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.attn_parallel import AttnParallelMode
+from sglang.srt.layers.attention.aiter_backend import (
+    AiterAttnBackend,
+    AiterMlaCPLaunchMetadata,
+    AiterMlaCPMetadata,
+    ForwardMetadata,
+)
+from sglang.srt.layers.cp.base import CPAttentionBackendKind
+from sglang.srt.layers.cp.cp_decode_attn_tp import (
+    CP_DECODE_ATTN_TP_SUPPORTED_ARCHS,
+    CpDecodeAttnTpContext,
+)
+from sglang.srt.layers.cp.zigzag import ZigzagCPStrategy
+from sglang.srt.models.deepseek_common.attention_backend_handler import (
+    handle_attention_aiter,
+)
+from sglang.srt.models.deepseek_common.attention_forward_methods.forward_methods import (
+    AttnForwardMethod,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _FakeTokenPool:
+    def __init__(self, head_dim):
+        self.buffer = torch.zeros(8, head_dim)
+
+    def get_key_buffer(self, _layer_id):
+        return self.buffer
+
+
+class _FakeCPStrategy:
+    def run_attention(self, q, forward_batch, _device, attn_fn, *, attention_backend):
+        assert attention_backend is CPAttentionBackendKind.AITER
+        metadata = forward_batch.attn_cp_metadata
+        prev = attn_fn(
+            q[:2],
+            torch.tensor([0, 2], dtype=torch.int32),
+            metadata.kv_len_prev_tensor,
+            2,
+        )
+        next_ = attn_fn(
+            q[2:],
+            torch.tensor([0, 2], dtype=torch.int32),
+            metadata.kv_len_next_tensor,
+            2,
+        )
+        return torch.cat([prev, next_], dim=0)
+
+
+class TestAiterMlaContextParallel(unittest.TestCase):
+    def test_dcp_backend_dispatch_reads_batch_stamp(self):
+        backend = object.__new__(AiterAttnBackend)
+        backend.use_mla = True
+        mode = SimpleNamespace(
+            is_decode=lambda: True,
+            is_target_verify=lambda: False,
+            is_draft_extend_v2=lambda: False,
+        )
+        self.assertFalse(
+            backend._is_dcp_batch(
+                SimpleNamespace(
+                    forward_mode=mode,
+                    attn_parallel_mode=AttnParallelMode.TP,
+                )
+            )
+        )
+        self.assertTrue(
+            backend._is_dcp_batch(
+                SimpleNamespace(
+                    forward_mode=mode,
+                    attn_parallel_mode=AttnParallelMode.DCP,
+                )
+            )
+        )
+
+    def test_deepseek_v3_runtime_tp_is_enabled(self):
+        self.assertIn("DeepseekV3ForCausalLM", CP_DECODE_ATTN_TP_SUPPORTED_ARCHS)
+
+        ctx = object.__new__(CpDecodeAttnTpContext)
+        ctx.decode_tp_rank = 0
+        ctx.decode_tp_size = 8
+        forward_mode = SimpleNamespace(
+            is_target_verify=lambda: False,
+            is_draft_extend_v2=lambda: False,
+        )
+        with patch(
+            "sglang.srt.layers.cp.cp_decode_attn_tp.dsa_use_prefill_cp",
+            return_value=False,
+        ):
+            self.assertTrue(
+                ctx.should_use_attn_tp(
+                    SimpleNamespace(
+                        forward_mode=forward_mode,
+                        attn_parallel_mode=0,
+                    )
+                )
+            )
+            self.assertFalse(
+                ctx.should_use_attn_tp(
+                    SimpleNamespace(
+                        forward_mode=forward_mode,
+                        attn_parallel_mode=1,
+                    )
+                )
+            )
+
+    def test_aiter_is_supported_by_zigzag_strategy(self):
+        self.assertEqual(
+            CPAttentionBackendKind.from_string("aiter"),
+            CPAttentionBackendKind.AITER,
+        )
+        strategy = object.__new__(ZigzagCPStrategy)
+        self.assertIn(
+            CPAttentionBackendKind.AITER,
+            strategy.get_supported_attention_backend(),
+        )
+
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_backend_handler.mla_use_prefill_cp",
+        return_value=True,
+    )
+    def test_aiter_dispatches_cp_prefill_to_mla(self, _mock_cp):
+        method = handle_attention_aiter(
+            SimpleNamespace(), SimpleNamespace(forward_mode=SimpleNamespace())
+        )
+        self.assertEqual(method, AttnForwardMethod.MLA)
+
+    @patch(
+        "sglang.srt.models.deepseek_common.attention_backend_handler.mla_use_prefill_cp",
+        return_value=False,
+    )
+    @patch(
+        "sglang.srt.layers.cp.cp_decode_attn_tp.get_cp_decode_attn_tp_ctx",
+        return_value=SimpleNamespace(should_use_attn_tp=lambda _batch: True),
+    )
+    def test_aiter_dispatches_runtime_tp_prefill_to_mla(
+        self, _mock_runtime_tp, _mock_cp
+    ):
+        method = handle_attention_aiter(
+            SimpleNamespace(), SimpleNamespace(forward_mode=SimpleNamespace())
+        )
+        self.assertEqual(method, AttnForwardMethod.MLA)
+
+    def test_mla_cp_forward_dispatches_both_zigzag_halves(self):
+        backend = object.__new__(AiterAttnBackend)
+        backend.input_dtype = torch.bfloat16
+        backend.device = torch.device("cpu")
+        backend.token_to_kv_pool = _FakeTokenPool(head_dim=6)
+
+        prev_lens = torch.tensor([2], dtype=torch.int32)
+        next_lens = torch.tensor([3], dtype=torch.int32)
+        prev = AiterMlaCPLaunchMetadata(
+            kv_indptr=torch.tensor([0, 2], dtype=torch.int32),
+            kv_indices=torch.tensor([0, 1], dtype=torch.int32),
+            kv_last_page_len=torch.ones(1, dtype=torch.int32),
+        )
+        next_ = AiterMlaCPLaunchMetadata(
+            kv_indptr=torch.tensor([0, 3], dtype=torch.int32),
+            kv_indices=torch.tensor([0, 1, 2], dtype=torch.int32),
+            kv_last_page_len=torch.ones(1, dtype=torch.int32),
+        )
+        backend.forward_metadata = ForwardMetadata(
+            kv_indptr=prev.kv_indptr,
+            kv_indices=prev.kv_indices,
+            qo_indptr=torch.tensor([0, 2], dtype=torch.int32),
+            kv_last_page_len=prev.kv_last_page_len,
+            max_q_len=2,
+            max_kv_len=3,
+            mla_cp_metadata=AiterMlaCPMetadata(prev=prev, next=next_),
+        )
+        forward_batch = SimpleNamespace(
+            attn_cp_metadata=SimpleNamespace(
+                kv_len_prev_tensor=prev_lens,
+                kv_len_next_tensor=next_lens,
+            )
+        )
+        layer = SimpleNamespace(
+            layer_id=0,
+            tp_q_head_num=2,
+            qk_head_dim=6,
+            v_head_dim=4,
+            scaling=0.5,
+            logit_cap=0.0,
+        )
+        q = torch.zeros(4, 2, 6)
+        launches = []
+
+        def fake_mla_prefill(
+            _q,
+            _k,
+            output,
+            _qo_indptr,
+            _kv_indptr,
+            kv_indices,
+            _last_page_len,
+            _max_q_len,
+            _scaling,
+            _logit_cap,
+        ):
+            launches.append(kv_indices.clone())
+            output.fill_(float(len(launches)))
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.aiter_backend.get_cp_strategy",
+                return_value=_FakeCPStrategy(),
+            ),
+            patch(
+                "sglang.srt.layers.attention.aiter_backend.mla_prefill_fwd",
+                side_effect=fake_mla_prefill,
+                create=True,
+            ),
+        ):
+            output = backend._forward_mla_cp(q, layer, forward_batch)
+
+        self.assertEqual(output.shape, (4, 2, 4))
+        self.assertTrue(torch.equal(output[:2], torch.ones_like(output[:2])))
+        self.assertTrue(torch.equal(output[2:], torch.full_like(output[2:], 2)))
+        self.assertEqual([indices.numel() for indices in launches], [2, 3])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_dynamic_parallel_benchmark.py
+++ b/test/registered/unit/test_dynamic_parallel_benchmark.py
@@ -82,6 +82,18 @@ class TestDynamicParallelBenchmark(unittest.TestCase):
         self.assertIn("--enable-dynamic-attn-parallel", dynamic_args)
         self.assertIn("--dynamic-attn-parallel-enable-dcp", dynamic_args)
         self.assertIn("--dcp-size", dynamic_args)
+        self.assertNotIn("--dynamic-attn-parallel-striped-min-context", dynamic_args)
+
+        striped_args = build_mode_server_args(
+            DeploymentMode.DYNAMIC,
+            cp_size=8,
+            dcp_size=8,
+            dynamic_include_dcp=True,
+            dynamic_striped_min_context=8192,
+        )
+        self.assertIn("--dynamic-attn-parallel-striped-min-context", striped_args)
+        self.assertIn("8192", striped_args)
+        self.assertIn("--disable-radix-cache", striped_args)
 
     def test_parity_comparison_reports_logprob_delta(self):
         baseline = _record(DeploymentMode.TP.value)

--- a/test/registered/unit/test_dynamic_parallel_benchmark.py
+++ b/test/registered/unit/test_dynamic_parallel_benchmark.py
@@ -1,0 +1,125 @@
+import unittest
+
+from sglang.benchmark.dynamic_parallel import (
+    DeploymentMode,
+    GridCase,
+    RunRecord,
+    build_inputs,
+    build_mode_server_args,
+    compare_with_tp,
+    parse_args,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _record(mode: str, *, output_ids=None, logprobs=None):
+    case = GridCase(
+        batch_size=2,
+        input_length=32,
+        output_length=2,
+        prefix_hit_ratio=0.5,
+        repeat=0,
+    )
+    return RunRecord(
+        mode=mode,
+        case={},
+        case_key=case.key,
+        wall_latency_s=0.1,
+        cached_tokens=[16, 16],
+        prompt_tokens=[32, 32],
+        completion_tokens=[2, 2],
+        output_ids=output_ids or [[1, 2], [3, 4]],
+        output_logprobs=logprobs or [[-0.1, -0.2], [-0.3, -0.4]],
+        mode_metrics_before={},
+        mode_metrics_after={},
+        server_info={},
+    )
+
+
+class TestDynamicParallelBenchmark(unittest.TestCase):
+    def test_build_inputs_has_exact_shared_prefix(self):
+        prefix, inputs = build_inputs(
+            batch_size=4,
+            input_length=100,
+            prefix_hit_ratio=0.75,
+            seed=7,
+            token_id_low=100,
+            token_id_high=200,
+        )
+
+        self.assertEqual(len(prefix), 75)
+        self.assertEqual([len(row) for row in inputs], [100] * 4)
+        self.assertTrue(all(row[:75] == prefix for row in inputs))
+        self.assertGreater(len({tuple(row[75:]) for row in inputs}), 1)
+
+    def test_mode_specific_server_args(self):
+        self.assertEqual(
+            build_mode_server_args(
+                DeploymentMode.TP,
+                cp_size=8,
+                dcp_size=8,
+                dynamic_include_dcp=False,
+            ),
+            [],
+        )
+        cp_args = build_mode_server_args(
+            DeploymentMode.PREFILL_CP,
+            cp_size=8,
+            dcp_size=8,
+            dynamic_include_dcp=False,
+        )
+        self.assertIn("--enable-prefill-cp", cp_args)
+        self.assertIn("--enable-cp-decode-attn-tp", cp_args)
+
+        dynamic_args = build_mode_server_args(
+            DeploymentMode.DYNAMIC,
+            cp_size=8,
+            dcp_size=8,
+            dynamic_include_dcp=True,
+        )
+        self.assertIn("--enable-dynamic-attn-parallel", dynamic_args)
+        self.assertIn("--dynamic-attn-parallel-enable-dcp", dynamic_args)
+        self.assertIn("--dcp-size", dynamic_args)
+
+    def test_parity_comparison_reports_logprob_delta(self):
+        baseline = _record(DeploymentMode.TP.value)
+        candidate = _record(
+            DeploymentMode.PREFILL_CP.value,
+            logprobs=[[-0.11, -0.19], [-0.31, -0.39]],
+        )
+
+        result = compare_with_tp(baseline, candidate, logprob_tolerance=0.02)
+
+        self.assertTrue(result["exact_output_match"])
+        self.assertTrue(result["logprob_shape_match"])
+        self.assertAlmostEqual(result["max_logprob_delta"], 0.01)
+        self.assertTrue(result["passed"])
+
+    def test_parity_fails_on_output_mismatch(self):
+        baseline = _record(DeploymentMode.TP.value)
+        candidate = _record(
+            DeploymentMode.DCP.value,
+            output_ids=[[1, 9], [3, 4]],
+        )
+
+        result = compare_with_tp(baseline, candidate, logprob_tolerance=0.1)
+
+        self.assertFalse(result["exact_output_match"])
+        self.assertFalse(result["passed"])
+
+    def test_parse_args_requires_tp_first_for_comparison(self):
+        with self.assertRaises(SystemExit):
+            parse_args(
+                [
+                    "--model-path",
+                    "model",
+                    "--modes",
+                    "prefill_cp,tp",
+                ]
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- stamp one rank-consistent attention-parallel mode per scheduler batch so a collocated MLA engine can select prefill TP/CP and decode TP/DCP without rebuilding process groups
- add ROCm Aiter MLA prefill-CP and decode-DCP support, including runtime-TP weight-layout conversion, residency-aware page tables, and separate TP/DCP decode graph variants
- keep replicated KV as the safe dynamic-DCP default; make prefill CP thresholds and compact striped residency explicit, benchmark-driven opt-ins
- add deterministic length/prefix benchmarking, mode metrics, layout safety checks, and regression coverage for the failures found by real MI355X runs

This draft incorporates and adapts the Aiter DCP work from #34432 and #34438 onto current `main`, while replacing deprecated parallel-state accessors and layering the runtime mode selector on top.

## Validated behavior and defaults
- dynamic prefill remains TP unless `--dynamic-attn-parallel-min-prefill-tokens` is explicitly set from a measured crossover grid
- dynamic decode DCP defaults to replicated KV, allowing long prefill to stay on CP and avoiding an online layout conversion
- compact striped KV is opt-in through `--dynamic-attn-parallel-striped-min-context`; it currently requires `--disable-radix-cache` and does not support PD disaggregation
- TP, CP, DCP, replicated/striped residency, and decode graph choices are batch-stamped and visible through Prometheus counters on every rank

## MI355X correctness validation
All runs used `lmsysorg/sglang-rocm:v0.5.18-rocm724-mi35x-20260823` on 8×MI355X.

- compact DeepSeek-V3 control, runtime TP: 4/4 generated IDs exact, max output-logprob delta `0.0632`
- compact static CP vs dynamic CP: exact IDs, max delta `0.0603`; 512-token prefix hit also passes strict parity
- compact static DCP vs dynamic DCP: exact IDs, max delta `0.0589`; 512-token prefix hit also passes strict parity
- batch size 8: static CP and dynamic CP produce exact IDs for cold and 50%-prefix-hit cases; max inter-mode delta `0.114`
- decode graphs: separate TP/replicated and DCP/replicated variants capture and replay successfully; eager and graph runs produce exact IDs for short TP and long DCP requests
- opt-in striped residency: eager prefill + DCP decode passes after validating physical-region separation, padded warmup KV handling, page-table scaling, and allocator free invariants
- full DeepSeek-V3-0324:
  - static CP vs dynamic CP: exact IDs, max delta `0.0755`
  - static DCP vs dynamic replicated-DCP: exact IDs, max delta `0.1309`
  - mode metrics confirm TP for short batches, CP for configured prefill batches, and DCP for long decode batches on all 8 ranks
- full DeepSeek-R1-0528 smoke: 1K CP prefill and 16K CP-prefill + DCP-decode both complete successfully with the expected per-rank mode counters

Random-token full-model prompts often have ~1% top-token probability, so exact TP-vs-CP argmax can flip from normal FP8/collective numerical variation. The correctness comparisons above therefore use topology-matched static CP/DCP controls; dynamic and static modes agree exactly on generated IDs.

## MI355X performance findings
Steady-state full DeepSeek-V3-0324, batch size 1, no prefix hit, output length 1, `--chunked-prefill-size 4096`:

- 512: TP `0.1182s`, CP `0.1214s` (`+2.7%`)
- 1K: TP `0.1154s`, CP `0.1183s` (`+2.6%`)
- 2K: TP `0.1157s`, CP `0.1192s` (`+3.0%`)
- 4K: TP `0.1656s`, CP `0.1757s` (`+6.1%`)
- 8K: TP `0.3374s`, CP `0.4008s` (`+18.8%`)
- 16K: TP `0.7071s`, CP `1.0142s` (`+43.4%`)

No prefill-CP crossover was observed on this MI355X setup, so the PR no longer guesses a default CP threshold. At batch size 8, CP was also slower for a cold 1K batch and approximately tied for a 50% prefix hit.

Striped prefill is substantially slower because it assembles the full prefix before attention (1K/50% prefix: `7.68s` dynamic striped vs `0.117s` static DCP; full 16K: `21.55s` striped vs `9.80s` replicated CP→DCP). This is why striped residency is explicit rather than the default.

## Current safety limits
- MLA-only; CP-v2 and `--page-size 1` are required
- overlap scheduling, speculative decoding, and HiCache are rejected for dynamic TP/DCP
- BF16 KV is required for Aiter MLA prefill CP
- striped residency additionally requires radix cache off and no PD disaggregation; replicated residency remains the production-oriented path in this draft

## Test plan
- [x] repository pre-commit hooks
- [x] targeted scheduler/CP/DCP/cache/graph suite: 101 tests, 128 subtests passed
- [x] real MI355X Aiter DCP numeric suite and Aiter prefill-CP parity
- [x] compact end-to-end TP/CP/DCP parity, prefix-hit reuse, batch-size 8, and dual decode graphs
- [x] full DeepSeek-V3-0324 static-control parity and full DeepSeek-R1-0528 dynamic smoke
- [x] MI355X 512–16K prefill crossover grid (no CP crossover observed)
- [ ] split this prototype into smaller reviewable PRs after the runtime contract is agreed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32730639411](https://github.com/sgl-project/sglang/actions/runs/32730639411)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32730639127](https://github.com/sgl-project/sglang/actions/runs/32730639127)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32730639513](https://github.com/sgl-project/sglang/actions/runs/32730639513)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->