### PR TITLE
fix(constrained): require output after reasoning

### DIFF
--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -440,6 +440,9 @@ def create_grammar_backend(
             reasoning_parser,
             tokenizer,
             enable_strict_thinking=get_serving().enable_strict_thinking,
+            model_eos_token_ids=(
+                sorted(eos_token_ids) if eos_token_ids is not None else None
+            ),
         )
 
     return grammar_backend

--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -40,6 +40,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
         grammar: Optional[BaseGrammarObject],
         think_end_ids: List[int],
         think_excluded_token_ids: Optional[List[int]] = None,
+        model_eos_token_ids: Optional[List[int]] = None,
         max_think_tokens: int = -1,
         enable_token_filter: bool = False,
         token_filter_fn=None,
@@ -52,6 +53,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
         self.think_end_ids = tuple(think_end_ids)
         self._think_end_matcher = TokenSequenceMatcher(self.think_end_ids)
         self.think_excluded_token_ids = think_excluded_token_ids
+        self.model_eos_token_ids = model_eos_token_ids
         self.max_think_tokens = max_think_tokens
         self.enable_token_filter = enable_token_filter
         self.token_filter_fn = token_filter_fn
@@ -143,9 +145,18 @@ class ReasonerGrammarObject(BaseGrammarObject):
             < self.max_think_tokens
         )
 
-    def _do_token_filter(self, vocab_mask, token_ids, idx, is_allowed=True):
+    def _do_token_filter(
+        self,
+        vocab_mask,
+        token_ids,
+        idx,
+        is_allowed=True,
+        reset_vocab_mask=True,
+    ):
         if self.token_filter_fn is not None:
-            self.token_filter_fn(vocab_mask, token_ids, idx, is_allowed)
+            self.token_filter_fn(
+                vocab_mask, token_ids, idx, is_allowed, reset_vocab_mask
+            )
 
     def fill_vocab_mask(self, vocab_mask: torch.Tensor, idx: int) -> None:
         if self._is_thinking():
@@ -167,8 +178,22 @@ class ReasonerGrammarObject(BaseGrammarObject):
                     is_allowed=True,
                 )
             return
-        if self._is_generation() and self.grammar is not None:
-            self.grammar.fill_vocab_mask(vocab_mask, idx)
+        if self._is_generation():
+            if self.grammar is not None:
+                self.grammar.fill_vocab_mask(vocab_mask, idx)
+            # Prevent a successful response with reasoning but no answer/tool call.
+            if (
+                self.enable_token_filter
+                and self.tokens_after_end == 0
+                and self.model_eos_token_ids
+            ):
+                self._do_token_filter(
+                    vocab_mask,
+                    self.model_eos_token_ids,
+                    idx,
+                    is_allowed=False,
+                    reset_vocab_mask=self.grammar is None,
+                )
 
     def allocate_vocab_mask(self, vocab_size, batch_size, device):
         if self.grammar is not None:
@@ -195,6 +220,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
             grammar=self.grammar.copy() if self.grammar is not None else None,
             think_end_ids=self.think_end_ids,
             think_excluded_token_ids=self.think_excluded_token_ids,
+            model_eos_token_ids=self.model_eos_token_ids,
             max_think_tokens=self.max_think_tokens,
             enable_token_filter=self.enable_token_filter,
             token_filter_fn=self.token_filter_fn,
@@ -247,6 +273,7 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
         reasoning_parser: ReasoningParser,
         tokenizer: Union[PreTrainedTokenizer, PreTrainedTokenizerFast],
         enable_strict_thinking: bool = False,
+        model_eos_token_ids: Optional[List[int]] = None,
     ):
         super().__init__()
         self.grammar_backend = grammar_backend
@@ -260,12 +287,15 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
             )
         self.think_end_ids = think_end_ids
         self._enable_strict_thinking = enable_strict_thinking
+        self.model_eos_token_ids = model_eos_token_ids
         self.think_excluded_token_ids = self._get_think_excluded_token_ids(
             reasoning_parser, tokenizer
         )
         self.max_think_tokens = envs.SGLANG_MAX_THINK_TOKENS.get()
         self.enable_token_filter = self.enable_strict_thinking and (
-            self.think_excluded_token_ids is not None or self.max_think_tokens >= 0
+            self.think_excluded_token_ids is not None
+            or self.model_eos_token_ids is not None
+            or self.max_think_tokens >= 0
         )
         if (
             self.enable_token_filter
@@ -308,6 +338,7 @@ class ReasonerGrammarBackend(BaseGrammarBackend):
             grammar=grammar,
             think_end_ids=self.think_end_ids,
             think_excluded_token_ids=self.think_excluded_token_ids,
+            model_eos_token_ids=self.model_eos_token_ids,
             max_think_tokens=self.max_think_tokens,
             enable_token_filter=self.enable_token_filter,
             token_filter_fn=self._token_filter_fn,

--- a/python/sglang/srt/constrained/reasoner_grammar_backend.py
+++ b/python/sglang/srt/constrained/reasoner_grammar_backend.py
@@ -184,6 +184,7 @@ class ReasonerGrammarObject(BaseGrammarObject):
             # Prevent a successful response with reasoning but no answer/tool call.
             if (
                 self.enable_token_filter
+                and self.tokens_in_think >= 0
                 and self.tokens_after_end == 0
                 and self.model_eos_token_ids
             ):

--- a/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+++ b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
@@ -79,6 +79,7 @@ class TestReasonerGrammarObject(unittest.TestCase):
             grammar=None,
             think_end_ids=[7],
             think_excluded_token_ids=[3, 5],
+            model_eos_token_ids=[9],
             max_think_tokens=2,
             enable_token_filter=True,
             token_filter_fn=set_token_filter_torch,
@@ -118,6 +119,35 @@ class TestReasonerGrammarObject(unittest.TestCase):
         self.assertEqual(mask.shape, (2, 2))
         self.assertIs(obj.move_vocab_mask(mask, "cpu"), mask)
         self.assertIsNotNone(obj.apply_vocab_mask)
+
+    def test_eos_blocked_until_first_post_reasoning_token(self):
+        obj = self._make_strict_object()
+        obj.maybe_init_reasoning(True)
+        obj.accept_token(10)
+        obj.accept_token(7)
+        mask = obj.allocate_vocab_mask(64, 1, "cpu")
+
+        obj.fill_vocab_mask(mask, 0)
+
+        self.assertEqual(_allowed_token_ids(mask, [8, 9, 10]), [8, 10])
+
+        obj.accept_token(8)
+        mask.zero_()
+        obj.fill_vocab_mask(mask, 0)
+        self.assertTrue(torch.all(mask == 0))
+
+    def test_rollback_restores_post_reasoning_eos_guard(self):
+        obj = self._make_strict_object()
+        obj.maybe_init_reasoning(True)
+        obj.accept_token(7)
+        obj.accept_token(8)
+        obj.rollback(1)
+        mask = obj.allocate_vocab_mask(64, 1, "cpu")
+
+        obj.fill_vocab_mask(mask, 0)
+
+        self.assertEqual(obj.tokens_after_end, 0)
+        self.assertEqual(_allowed_token_ids(mask, [8, 9, 10]), [8, 10])
 
     def test_budget_exhaustion_walks_multi_token_end(self):
         obj = ReasonerGrammarObject(
@@ -176,6 +206,7 @@ class TestReasonerGrammarBackend(unittest.TestCase):
             self._make_parser(),
             self._make_tokenizer(),
             enable_strict_thinking=True,
+            model_eos_token_ids=[9],
         )
 
         obj = reasoner.init_strict_reasoning_grammar(reasoning=True)
@@ -184,6 +215,7 @@ class TestReasonerGrammarBackend(unittest.TestCase):
         self.assertTrue(obj.enable_token_filter)
         self.assertEqual(obj.max_think_tokens, 2)
         self.assertEqual(obj.think_excluded_token_ids, [3, 4])
+        self.assertEqual(obj.model_eos_token_ids, [9])
 
     def test_kimi_k3_excluded_tokens_spare_the_xtml_control_tokens(self):
         """Kimi K3 bans bare channel names, never the marker-composing tokens.
@@ -506,6 +538,31 @@ class TestReasonerGrammarObjectFillVocabMask(unittest.TestCase):
         obj.fill_vocab_mask(mask, 0)
 
         inner_grammar.fill_vocab_mask.assert_called_once_with(mask, 0)
+
+    def test_post_reasoning_eos_guard_composes_with_inner_grammar(self):
+        inner_grammar = MagicMock()
+        inner_grammar.allocate_vocab_mask.side_effect = lambda vs, bs, d: torch.zeros(
+            (bs, (vs + 31) // 32), dtype=torch.int32
+        )
+        inner_grammar.fill_vocab_mask.side_effect = lambda mask, idx: (
+            set_token_filter_torch(mask, [8], idx, is_allowed=False)
+        )
+        obj = ReasonerGrammarObject(
+            grammar=inner_grammar,
+            think_end_ids=[7],
+            think_excluded_token_ids=[3, 5],
+            model_eos_token_ids=[9],
+            max_think_tokens=-1,
+            enable_token_filter=True,
+            token_filter_fn=set_token_filter_torch,
+        )
+        obj.maybe_init_reasoning(True)
+        obj.accept_token(7)
+        mask = obj.allocate_vocab_mask(64, 1, "cpu")
+
+        obj.fill_vocab_mask(mask, 0)
+
+        self.assertEqual(_allowed_token_ids(mask, [7, 8, 9, 10]), [7, 10])
 
     def test_non_strict_thinking_is_noop(self):
         inner_grammar = MagicMock()

--- a/test/registered/unit/constrained/test_reasoner_grammar_backend.py
+++ b/test/registered/unit/constrained/test_reasoner_grammar_backend.py
@@ -149,6 +149,15 @@ class TestReasonerGrammarObject(unittest.TestCase):
         self.assertEqual(obj.tokens_after_end, 0)
         self.assertEqual(_allowed_token_ids(mask, [8, 9, 10]), [8, 10])
 
+    def test_non_reasoning_request_does_not_block_eos(self):
+        obj = self._make_strict_object()
+        obj.maybe_init_reasoning(False)
+        mask = obj.allocate_vocab_mask(64, 1, "cpu")
+
+        obj.fill_vocab_mask(mask, 0)
+
+        self.assertTrue(torch.all(mask == 0))
+
     def test_budget_exhaustion_walks_multi_token_end(self):
         obj = ReasonerGrammarObject(
             grammar=None,


### PR DESCRIPTION
## Motivation

Reasoning models can select EOS immediately after emitting their think-end sequence. The OpenAI response then contains reasoning but no `content` or `tool_calls`, while reporting `finish_reason=stop`.

This was reproduced with Kimi K2.7 Code in both streaming and non-streaming modes. The raw terminal sequence was `</think><|im_end|>`. One streaming run reproduced at 1/8 requests with zero content/tool calls and 1,750 completion tokens.

`ReasonerGrammarObject` already tracks the exact boundary as `tokens_after_end == 0`, but the model EOS IDs passed to `create_grammar_backend()` were not available to that state machine.

## Modifications

- Pass model-configured EOS token IDs into `ReasonerGrammarBackend`.
- Under `--enable-strict-thinking`, mask model EOS for exactly the first sampling step after the think-end sequence.
- Lift the mask after one answer or tool token is accepted.
- Compose the EOS exclusion with an existing output grammar rather than replacing its mask.
- Preserve behavior through copy and rollback for speculative decoding.
- Leave requests that did not enter reasoning unchanged.

## Accuracy

The behavior is opt-in under `--enable-strict-thinking`. It only changes the invalid boundary where the model would otherwise terminate with reasoning but no answer/tool call. No benchmark results yet; this is a draft pending quality evaluation.

## Speed

No expected measurable impact. The additional token filter is applied for one sampling step per reasoning response.

## Tests

Added unit coverage for:

- EOS suppression immediately after reasoning.
- Mask release after the first post-reasoning token.
- Rollback restoration.
- Composition with an inner output grammar.
- EOS propagation from the backend.
- Unchanged non-reasoning requests.

Validation completed:

- Full pre-commit checks on changed files.
- Python syntax compilation.
- Focused behavior test in an SGLang v0.5.14 runtime.
- v0.5.14 ordered backport apply check.

The full unit module could not be executed locally because the checkout does not have a compatible SGLang test environment; draft CI is expected to run it.

## Checklist

- [x] Format code with pre-commit
- [x] Add unit tests
- [ ] Run accuracy benchmarks
- [ ] Run full upstream CI

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32740275265](https://github.com/sgl-project/sglang/actions/runs/32740275265)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32740274779](https://github.com/sgl-project/sglang/actions/runs/32740274779)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32740275251](https://github.com/sgl-project/sglang/actions/runs/32740275251)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->