### PR TITLE
[Sepc]Dflash2 tree drafting

### DIFF
--- a/python/sglang/kernels/ops/speculative/dflash.py
+++ b/python/sglang/kernels/ops/speculative/dflash.py
@@ -314,3 +314,159 @@ def selector_walk_triton(
         num_warps=1,
     )
     return tokens, q_rows
+
+
+@triton.jit
+def _lane(vector, lanes, index):
+    """Read one lane out of a register-resident per-beam vector."""
+    return tl.sum(tl.where(lanes == index, vector, vector * 0), axis=0)
+
+
+@triton.jit
+def _beam_first_max(tile, flat_index, limit):
+    """(value, flattened index) of the first maximum of a [WIDTH, top_k] tile.
+
+    `flat_index` is `beam * top_k + candidate`, so ties resolve beam-major. That
+    convention is load bearing: the torch reference flattens the same way, and a
+    tie broken the other way picks a different subtree.
+    """
+    best = tl.max(tl.max(tile, axis=1), axis=0)
+    picked = tl.min(tl.min(tl.where(tile == best, flat_index, limit), axis=1), axis=0)
+    return best, picked
+
+
+@triton.jit
+def _selector_beam_walk_kernel(
+    scores_ptr,
+    candidate_ptr,
+    anchor_ptr,
+    tokens_ptr,
+    parents_ptr,
+    slots: tl.constexpr,
+    top_k: tl.constexpr,
+    width: tl.constexpr,
+    WIDTH: tl.constexpr,
+):
+    """One program per request: the beams' carried state -- candidate index, path
+    log-prob, tree node index -- is WIDTH scalars in registers, so the depth-to-depth
+    dependency stays inside one launch exactly like the single-path walk above.
+
+    WIDTH is `next_power_of_2(width)` because `tl.arange` demands a power of two.
+    Padded lanes hold -inf and can never win a slot; that is the same mechanism that
+    folds the first depth (where only beam 0 is live) into the shared loop body.
+    """
+    row = tl.program_id(0)
+    lanes = tl.arange(0, WIDTH)
+    successors = tl.arange(0, top_k)
+    flat_index = lanes[:, None] * top_k + successors[None, :]
+    limit: tl.constexpr = WIDTH * top_k
+    nodes: tl.constexpr = 1 + slots * width
+    neg_inf = float("-inf")
+    live = lanes < width
+
+    tl.store(tokens_ptr + row * nodes, tl.load(anchor_ptr + row))
+    tl.store(parents_ptr + row * nodes, -1)
+
+    state = tl.zeros((WIDTH,), dtype=tl.int32)
+    node = tl.zeros((WIDTH,), dtype=tl.int32)
+    cum = tl.where(lanes == 0, 0.0, neg_inf)
+
+    for slot in range(slots):
+        base = 1 + slot * width
+        candidate_row = candidate_ptr + (row * slots + slot) * top_k
+        # Gather the WIDTH transition rows the beams currently sit on.
+        rows_base = ((row * slots + slot) * top_k + state[:, None]) * top_k
+        transitions = tl.load(
+            scores_ptr + rows_base + successors[None, :],
+            mask=live[:, None],
+            other=0.0,
+        ).to(tl.float32)
+        # log_softmax along the successor axis, one independent row per beam: a row
+        # is the conditional distribution given its predecessor, and only that
+        # normalization makes the depth-wise sums comparable across rows.
+        shifted = transitions - tl.max(transitions, axis=1)[:, None]
+        log_probs = shifted - tl.log(tl.sum(tl.exp(shifted), axis=1))[:, None]
+        scored = tl.where(live[:, None], cum[:, None] + log_probs, neg_inf)
+
+        # The spine takes slot 0: beam 0's own best child, parent pinned to beam 0.
+        # Restricting to beam 0 rather than ranking the whole pool is what keeps the
+        # spine chain equal to the single-path greedy walk, hence the tree a superset
+        # of it. cum[0] is a constant across the row, so it cannot move the argmax.
+        spine_value, spine = _beam_first_max(
+            tl.where(lanes[:, None] == 0, scored, neg_inf), flat_index, limit
+        )
+        tl.store(
+            tokens_ptr + row * nodes + base,
+            tl.load(candidate_row + spine),
+        )
+        tl.store(parents_ptr + row * nodes + base, _lane(node, lanes, 0))
+        next_state = tl.where(lanes == 0, spine.to(tl.int32), 0)
+        next_node = tl.where(lanes == 0, base, 0)
+        next_cum = tl.where(lanes == 0, spine_value, neg_inf)
+
+        # Struck from the pool, so the width picks are distinct (beam, candidate)
+        # pairs -- which is what makes same-parent sibling tokens distinct.
+        remaining = tl.where(flat_index == spine, neg_inf, scored)
+        for beam in range(1, width):
+            value, picked = _beam_first_max(remaining, flat_index, limit)
+            picked_beam = picked // top_k
+            picked_candidate = picked % top_k
+            tl.store(
+                tokens_ptr + row * nodes + base + beam,
+                tl.load(candidate_row + picked_candidate),
+            )
+            # Parents come from the previous depth, so they are always < base: the
+            # BFS order every downstream ancestor-closure scan relies on.
+            tl.store(
+                parents_ptr + row * nodes + base + beam,
+                _lane(node, lanes, picked_beam),
+            )
+            next_state = tl.where(
+                lanes == beam, picked_candidate.to(tl.int32), next_state
+            )
+            next_node = tl.where(lanes == beam, base + beam, next_node)
+            next_cum = tl.where(lanes == beam, value, next_cum)
+            remaining = tl.where(flat_index == picked, neg_inf, remaining)
+
+        state = next_state
+        node = next_node
+        cum = next_cum
+
+
+def selector_beam_walk_triton(
+    *,
+    candidate_ids,
+    scores,
+    anchor_token_ids,
+    beam_width,
+):
+    batch, slots, top_k = candidate_ids.shape
+    width = int(beam_width)
+    if width < 1:
+        raise ValueError(f"DFLASH beam walk needs beam_width >= 1, got {width}.")
+    if width > top_k:
+        raise ValueError(
+            f"DFLASH beam walk beam_width {width} exceeds top_k {top_k}: the first "
+            "depth only has top_k candidates, so a wider beam cannot be filled."
+        )
+    num_nodes = 1 + slots * width
+    tokens = torch.empty((batch, num_nodes), dtype=torch.int64, device=scores.device)
+    parents = torch.empty((batch, num_nodes), dtype=torch.int64, device=scores.device)
+    padded = triton.next_power_of_2(width)
+    _selector_beam_walk_kernel[(batch,)](
+        scores.contiguous(),
+        candidate_ids.contiguous(),
+        anchor_token_ids.contiguous(),
+        tokens,
+        parents,
+        slots=slots,
+        top_k=top_k,
+        width=width,
+        WIDTH=padded,
+        # The whole tile is at most WIDTH * top_k <= 256 registers, same as the
+        # single-path walk above: one warp, no cross-warp reduction.
+        num_warps=1,
+    )
+    return tokens, parents
+
+

--- a/python/sglang/kernels/ops/speculative/dflash.py
+++ b/python/sglang/kernels/ops/speculative/dflash.py
@@ -352,7 +352,7 @@ def _selector_beam_walk_kernel(
     dependency stays inside one launch exactly like the single-path walk above.
 
     WIDTH is `next_power_of_2(width)` because `tl.arange` demands a power of two.
-    Padded lanes hold -inf and can never win a slot; that is the same mechanism that
+    Padded lanes hold -inf and can never win a beam; that is the same mechanism that
     folds the first depth (where only beam 0 is live) into the shared loop body.
     """
     row = tl.program_id(0)
@@ -388,10 +388,11 @@ def _selector_beam_walk_kernel(
         log_probs = shifted - tl.log(tl.sum(tl.exp(shifted), axis=1))[:, None]
         scored = tl.where(live[:, None], cum[:, None] + log_probs, neg_inf)
 
-        # The spine takes slot 0: beam 0's own best child, parent pinned to beam 0.
-        # Restricting to beam 0 rather than ranking the whole pool is what keeps the
-        # spine chain equal to the single-path greedy walk, hence the tree a superset
-        # of it. cum[0] is a constant across the row, so it cannot move the argmax.
+        # The depth's first node (`base`) is the spine: beam 0's own best child, with
+        # its parent pinned to beam 0. Restricting to beam 0 rather than ranking the
+        # whole pool is what keeps the spine chain equal to the single-path greedy
+        # walk, hence the tree a superset of it. cum[0] is a constant across the row,
+        # so it cannot move the argmax.
         spine_value, spine = _beam_first_max(
             tl.where(lanes[:, None] == 0, scored, neg_inf), flat_index, limit
         )
@@ -468,5 +469,86 @@ def selector_beam_walk_triton(
         num_warps=1,
     )
     return tokens, parents
+
+
+@triton.jit
+def _dflash_tree_full_mask_kernel(
+    ancestor_ptr,
+    mask_indptr_ptr,
+    seq_lens_ptr,
+    out_ptr,
+    nodes,
+    PREFIX_BLOCK: tl.constexpr,
+    NODES: tl.constexpr,
+):
+    """One program per (request, node): writes that node's whole attention row.
+
+    Row layout is `seq_len` prefix cells (a draft node sees the entire committed
+    prefix) followed by the node's `nodes`-wide ancestor closure. The prefix span
+    is why this cannot be a fixed-shape store: it is read from device memory, so
+    the host never learns the committed length.
+    """
+    request = tl.program_id(0)
+    node = tl.program_id(1)
+    prefix = tl.load(seq_lens_ptr + request).to(tl.int64)
+    base = tl.load(mask_indptr_ptr + request).to(tl.int64) + node * (prefix + nodes)
+
+    allow = tl.full((PREFIX_BLOCK,), 1, dtype=out_ptr.dtype.element_ty)
+    for start in range(0, prefix, PREFIX_BLOCK):
+        cols = start + tl.arange(0, PREFIX_BLOCK)
+        tl.store(out_ptr + base + cols, allow, mask=cols < prefix)
+
+    lanes = tl.arange(0, NODES)
+    lane_mask = lanes < nodes
+    closure = tl.load(
+        ancestor_ptr + (request * nodes + node) * nodes + lanes,
+        mask=lane_mask,
+        other=0,
+    )
+    tl.store(
+        out_ptr + base + prefix + lanes,
+        closure.to(out_ptr.dtype.element_ty),
+        mask=lane_mask,
+    )
+
+
+def write_dflash_tree_full_mask(
+    *,
+    ancestor_mask: torch.Tensor,
+    mask_indptr: torch.Tensor,
+    seq_lens: torch.Tensor,
+    out: torch.Tensor,
+) -> torch.Tensor:
+    """Write the flat FULL_MASK for a DFLASH beam tree into `out`, in place.
+
+    `out` is normally the attention backend's own verify-mask buffer, so verify
+    reads the mask where the kernel left it and nothing is copied. `mask_indptr`
+    must come from `fill_verify_mask_indptr` -- the writer and the reader share
+    that one formula on purpose.
+
+    Every cell of every live row is written, prefix included: the buffer is reused
+    across steps and a request's rows move as its prefix grows, so last step's
+    closure bits land inside this step's prefix span. Returns `out` for the caller
+    to hand to `custom_mask`.
+    """
+    batch, nodes, nodes_again = ancestor_mask.shape
+    if nodes != nodes_again:
+        raise ValueError(
+            f"ancestor_mask must be [bs, N, N], got {tuple(ancestor_mask.shape)}."
+        )
+    if mask_indptr.shape[0] < batch:
+        raise ValueError(
+            f"mask_indptr holds {mask_indptr.shape[0]} entries for {batch} requests."
+        )
+    _dflash_tree_full_mask_kernel[(batch, nodes)](
+        ancestor_mask.contiguous(),
+        mask_indptr,
+        seq_lens,
+        out,
+        nodes=nodes,
+        PREFIX_BLOCK=1024,
+        NODES=triton.next_power_of_2(nodes),
+    )
+    return out
 
 

--- a/python/sglang/kernels/ops/speculative/dflash.py
+++ b/python/sglang/kernels/ops/speculative/dflash.py
@@ -258,8 +258,7 @@ def _selector_walk_kernel(
     slots: tl.constexpr,
     top_k: tl.constexpr,
 ):
-    """One program per request: a slot's K scores stay in registers and the walk is a
-    loop, so the slot-to-slot dependency costs nothing instead of one kernel each."""
+    """Walk one request's candidate slots in a single program."""
     row = tl.program_id(0)
     offsets = tl.arange(0, top_k)
     temperature = tl.load(temperatures_ptr + row)
@@ -318,18 +317,13 @@ def selector_walk_triton(
 
 @triton.jit
 def _lane(vector, lanes, index):
-    """Read one lane out of a register-resident per-beam vector."""
+    """Read one lane from a register-resident beam vector."""
     return tl.sum(tl.where(lanes == index, vector, vector * 0), axis=0)
 
 
 @triton.jit
 def _beam_first_max(tile, flat_index, limit):
-    """(value, flattened index) of the first maximum of a [WIDTH, top_k] tile.
-
-    `flat_index` is `beam * top_k + candidate`, so ties resolve beam-major. That
-    convention is load bearing: the torch reference flattens the same way, and a
-    tie broken the other way picks a different subtree.
-    """
+    """Return the first maximum using beam-major flattened indices."""
     best = tl.max(tl.max(tile, axis=1), axis=0)
     picked = tl.min(tl.min(tl.where(tile == best, flat_index, limit), axis=1), axis=0)
     return best, picked
@@ -342,19 +336,13 @@ def _selector_beam_walk_kernel(
     anchor_ptr,
     tokens_ptr,
     parents_ptr,
+    cums_ptr,
     slots: tl.constexpr,
     top_k: tl.constexpr,
     width: tl.constexpr,
     WIDTH: tl.constexpr,
 ):
-    """One program per request: the beams' carried state -- candidate index, path
-    log-prob, tree node index -- is WIDTH scalars in registers, so the depth-to-depth
-    dependency stays inside one launch exactly like the single-path walk above.
-
-    WIDTH is `next_power_of_2(width)` because `tl.arange` demands a power of two.
-    Padded lanes hold -inf and can never win a beam; that is the same mechanism that
-    folds the first depth (where only beam 0 is live) into the shared loop body.
-    """
+    """Build a BFS-ordered beam tree and store cumulative scores."""
     row = tl.program_id(0)
     lanes = tl.arange(0, WIDTH)
     successors = tl.arange(0, top_k)
@@ -366,6 +354,7 @@ def _selector_beam_walk_kernel(
 
     tl.store(tokens_ptr + row * nodes, tl.load(anchor_ptr + row))
     tl.store(parents_ptr + row * nodes, -1)
+    tl.store(cums_ptr + row * nodes, 0.0)
 
     state = tl.zeros((WIDTH,), dtype=tl.int32)
     node = tl.zeros((WIDTH,), dtype=tl.int32)
@@ -374,25 +363,17 @@ def _selector_beam_walk_kernel(
     for slot in range(slots):
         base = 1 + slot * width
         candidate_row = candidate_ptr + (row * slots + slot) * top_k
-        # Gather the WIDTH transition rows the beams currently sit on.
         rows_base = ((row * slots + slot) * top_k + state[:, None]) * top_k
         transitions = tl.load(
             scores_ptr + rows_base + successors[None, :],
             mask=live[:, None],
             other=0.0,
         ).to(tl.float32)
-        # log_softmax along the successor axis, one independent row per beam: a row
-        # is the conditional distribution given its predecessor, and only that
-        # normalization makes the depth-wise sums comparable across rows.
         shifted = transitions - tl.max(transitions, axis=1)[:, None]
         log_probs = shifted - tl.log(tl.sum(tl.exp(shifted), axis=1))[:, None]
         scored = tl.where(live[:, None], cum[:, None] + log_probs, neg_inf)
 
-        # The depth's first node (`base`) is the spine: beam 0's own best child, with
-        # its parent pinned to beam 0. Restricting to beam 0 rather than ranking the
-        # whole pool is what keeps the spine chain equal to the single-path greedy
-        # walk, hence the tree a superset of it. cum[0] is a constant across the row,
-        # so it cannot move the argmax.
+        # Keep beam 0 on the greedy spine so width 1 remains the chain.
         spine_value, spine = _beam_first_max(
             tl.where(lanes[:, None] == 0, scored, neg_inf), flat_index, limit
         )
@@ -401,12 +382,12 @@ def _selector_beam_walk_kernel(
             tl.load(candidate_row + spine),
         )
         tl.store(parents_ptr + row * nodes + base, _lane(node, lanes, 0))
+        tl.store(cums_ptr + row * nodes + base, spine_value)
         next_state = tl.where(lanes == 0, spine.to(tl.int32), 0)
         next_node = tl.where(lanes == 0, base, 0)
         next_cum = tl.where(lanes == 0, spine_value, neg_inf)
 
-        # Struck from the pool, so the width picks are distinct (beam, candidate)
-        # pairs -- which is what makes same-parent sibling tokens distinct.
+        # Remove each pick so sibling pairs remain distinct.
         remaining = tl.where(flat_index == spine, neg_inf, scored)
         for beam in range(1, width):
             value, picked = _beam_first_max(remaining, flat_index, limit)
@@ -416,12 +397,12 @@ def _selector_beam_walk_kernel(
                 tokens_ptr + row * nodes + base + beam,
                 tl.load(candidate_row + picked_candidate),
             )
-            # Parents come from the previous depth, so they are always < base: the
-            # BFS order every downstream ancestor-closure scan relies on.
+            # BFS numbering keeps every parent before its children.
             tl.store(
                 parents_ptr + row * nodes + base + beam,
                 _lane(node, lanes, picked_beam),
             )
+            tl.store(cums_ptr + row * nodes + base + beam, value)
             next_state = tl.where(
                 lanes == beam, picked_candidate.to(tl.int32), next_state
             )
@@ -434,12 +415,87 @@ def _selector_beam_walk_kernel(
         cum = next_cum
 
 
+@triton.jit
+def _dflash_tree_prune_by_cum_kernel(
+    tokens_ptr,
+    parents_ptr,
+    cums_ptr,
+    out_tokens_ptr,
+    out_parents_ptr,
+    num_nodes: tl.constexpr,
+    max_num_nodes: tl.constexpr,
+    NODES: tl.constexpr,
+):
+    """Keep the anchor and top cumulative-score nodes, preserving BFS order.
+
+    The kernel operates on the built tree without a sort or scratch buffer.
+
+    Ranking counts better rivals, renumbering is order-preserving, and parent remapping
+    uses a register reduction. Cumulative log-probability keeps every kept node's
+    ancestors in the selection.
+
+    NaNs are normalized to `-inf` and stores are masked to keep the output in bounds.
+    """
+    row = tl.program_id(0)
+    idx = tl.arange(0, NODES)
+    valid = idx < num_nodes
+    cum = tl.load(cums_ptr + row * num_nodes + idx, mask=valid, other=float("-inf"))
+    cum = tl.where(cum != cum, float("-inf"), cum)
+
+    rival = valid & (idx > 0)
+    better = (cum[None, :] > cum[:, None]) | (
+        (cum[None, :] == cum[:, None]) & (idx[None, :] < idx[:, None])
+    )
+    rank = tl.sum((better & rival[None, :]).to(tl.int32), axis=1)
+    keep = (idx == 0) | (rival & (rank < max_num_nodes - 1))
+    new = tl.cumsum(keep.to(tl.int32), axis=0) - 1
+
+    tokens = tl.load(tokens_ptr + row * num_nodes + idx, mask=valid, other=0)
+    parents = tl.load(parents_ptr + row * num_nodes + idx, mask=valid, other=0)
+    new_parent = tl.sum(
+        tl.where(parents[:, None] == idx[None, :], new[None, :], 0), axis=1
+    )
+    stored = keep & (new < max_num_nodes)
+    tl.store(out_tokens_ptr + row * max_num_nodes + new, tokens, mask=stored)
+    tl.store(
+        out_parents_ptr + row * max_num_nodes + new,
+        tl.where(idx == 0, -1, new_parent),
+        mask=stored,
+    )
+
+
+_MAX_PRUNE_NODES = 256
+
+
+def _validate_max_num_nodes(*, max_num_nodes, num_nodes: int) -> None:
+    """Validate the optional prune cap for both implementations."""
+    if max_num_nodes is None:
+        return
+    cap = int(max_num_nodes)
+    if cap < 1:
+        raise ValueError(f"DFLASH tree prune needs max_num_nodes >= 1, got {cap}.")
+    if cap > num_nodes:
+        raise ValueError(
+            f"DFLASH tree prune max_num_nodes {cap} exceeds the {num_nodes} nodes the "
+            "beam walk builds: pruning only removes nodes, so it cannot reach a "
+            "larger tree. Raise beam_width instead."
+        )
+    if cap == num_nodes:
+        return
+    if num_nodes > _MAX_PRUNE_NODES:
+        raise ValueError(
+            f"DFLASH tree prune ranks {num_nodes} built nodes with an N x N tile, "
+            f"above the {_MAX_PRUNE_NODES} limit. Lower beam_width or block_size."
+        )
+
+
 def selector_beam_walk_triton(
     *,
     candidate_ids,
     scores,
     anchor_token_ids,
     beam_width,
+    max_num_nodes=None,
 ):
     batch, slots, top_k = candidate_ids.shape
     width = int(beam_width)
@@ -451,8 +507,10 @@ def selector_beam_walk_triton(
             "depth only has top_k candidates, so a wider beam cannot be filled."
         )
     num_nodes = 1 + slots * width
+    _validate_max_num_nodes(max_num_nodes=max_num_nodes, num_nodes=num_nodes)
     tokens = torch.empty((batch, num_nodes), dtype=torch.int64, device=scores.device)
     parents = torch.empty((batch, num_nodes), dtype=torch.int64, device=scores.device)
+    cums = torch.empty((batch, num_nodes), dtype=torch.float32, device=scores.device)
     padded = triton.next_power_of_2(width)
     _selector_beam_walk_kernel[(batch,)](
         scores.contiguous(),
@@ -460,15 +518,33 @@ def selector_beam_walk_triton(
         anchor_token_ids.contiguous(),
         tokens,
         parents,
+        cums,
         slots=slots,
         top_k=top_k,
         width=width,
         WIDTH=padded,
-        # The whole tile is at most WIDTH * top_k <= 256 registers, same as the
-        # single-path walk above: one warp, no cross-warp reduction.
         num_warps=1,
     )
-    return tokens, parents
+    if max_num_nodes is None or num_nodes <= int(max_num_nodes):
+        return tokens, parents
+
+    cap = int(max_num_nodes)
+    out_tokens = torch.empty((batch, cap), dtype=torch.int64, device=scores.device)
+    out_parents = torch.empty((batch, cap), dtype=torch.int64, device=scores.device)
+    _dflash_tree_prune_by_cum_kernel[(batch,)](
+        tokens,
+        parents,
+        cums,
+        out_tokens,
+        out_parents,
+        num_nodes=num_nodes,
+        max_num_nodes=cap,
+        NODES=triton.next_power_of_2(num_nodes),
+        # The rank and parent-remap tiles are NODES x NODES, so unlike the walk this
+        # one wants threads rather than registers.
+        num_warps=4,
+    )
+    return out_tokens, out_parents
 
 
 @triton.jit
@@ -550,5 +626,3 @@ def write_dflash_tree_full_mask(
         NODES=triton.next_power_of_2(nodes),
     )
     return out
-
-

--- a/python/sglang/srt/arg_groups/fields/spec.py
+++ b/python/sglang/srt/arg_groups/fields/spec.py
@@ -71,7 +71,11 @@ class Spec:
     ] = None
     speculative_dflash_block_size: A[
         Optional[int],
-        "DFLASH only. Block size (verify window length). Alias of --speculative-num-draft-tokens for DFLASH.",
+        "DFLASH only. Draft block width. Alias of --speculative-num-draft-tokens when --speculative-dflash-tree-width is 1. Omit to infer it from the draft checkpoint block_size.",
+    ] = None
+    speculative_dflash_tree_width: A[
+        Optional[int],
+        "DFLASH only. Beam width kept at every draft depth (1 = single-path chain). The verify window is 1 + (block_size - 1) * tree_width. Must not exceed the draft checkpoint selector_top_k. Use this instead of --speculative-eagle-topk, which is EAGLE-only.",
     ] = None
     speculative_dspark_block_size: A[
         Optional[int],

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -502,7 +502,8 @@ def _resolve_dflash_block_size(
     server_args: ServerArgs, *, tree_width: int, draft_config
 ) -> int:
     """The draft block width, from (in order) the explicit flag, the
-    --speculative-num-draft-tokens alias, the draft checkpoint, or a hardcoded default."""
+    --speculative-num-draft-tokens alias, the draft checkpoint, or a hardcoded default.
+    """
     cfg = resolving_view(server_args)
     explicit = cfg.speculative_dflash_block_size
     alias = cfg.speculative_num_draft_tokens
@@ -595,12 +596,41 @@ def _resolve_dflash_widths(server_args: ServerArgs) -> None:
         speculative_eagle_topk=tree_width,
     )
 
+    _log_dflash_widths(tree_width=tree_width, block_size=block_size)
+
+
+def _log_dflash_widths(*, tree_width: int, block_size: int) -> None:
+    """Record the resolved verify shape so a run can be reconstructed from its log.
+
+    Only for tree runs; at width 1 these are the values every DFLASH launch has always
+    had, so logging them would be noise. `SGLANG_DFLASH_FORCE_TREE_VERIFY` has to be
+    part of the condition rather than the width alone: it is the one switch that
+    decouples the verify *shape* from the resolved widths (it sends a width-1 run down
+    the tree path, leaving tree_width at 1), so gating on `tree_width > 1` would leave
+    that configuration indistinguishable from a plain chain run in the log.
+    """
+    from sglang.srt.environ import envs
+
+    force_tree_verify = envs.SGLANG_DFLASH_FORCE_TREE_VERIFY.get()
+    if tree_width <= 1 and not force_tree_verify:
+        return
+
+    logger.info(
+        "DFLASH tree verify: tree_width=%d, block_size=%d, verify_width=%d, "
+        "force_tree_verify=%s",
+        tree_width,
+        block_size,
+        1 + (block_size - 1) * tree_width,
+        force_tree_verify,
+    )
+
 
 def _validate_dflash_tree_selector(
     *, draft_config, tree_width: int, block_size: int
 ) -> None:
     """The tree is a beam over the candidate selector's transition lattice, so the checkpoint
-    must have a selector and the beam cannot be wider than the lattice's candidate axis."""
+    must have a selector and the beam cannot be wider than the lattice's candidate axis.
+    """
     if not draft_config.selector_rank or not draft_config.selector_top_k:
         raise ValueError(
             f"{_DFLASH_TREE_WIDTH_FLAG} > 1 requires a DFlash 2 draft checkpoint with a "
@@ -709,7 +739,6 @@ def _validate_dflash_tree_admission(server_args: ServerArgs) -> None:
             f"{_DFLASH_TREE_WIDTH_FLAG}={tree_width}. Use SGLANG_SIMULATE_ACC_TOKEN_MODE=fixed "
             "or unset SGLANG_SIMULATE_ACC_LEN."
         )
-
 
 
 def _target_checkpoint_bundles_dspark_draft(server_args: ServerArgs) -> bool:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -229,92 +229,20 @@ def _handle_dflash(server_args: ServerArgs) -> None:
             speculative_num_steps=1,
         )
 
-    if cfg.speculative_eagle_topk is None:
-        declare_resolution(
-            server_args,
-            "_handle_dflash",
-            speculative_eagle_topk=1,
-        )
-    elif int(cfg.speculative_eagle_topk) != 1:
-        logger.warning(
-            "DFLASH only supports speculative_eagle_topk == 1; overriding speculative_eagle_topk=%s to 1.",
-            cfg.speculative_eagle_topk,
-        )
-        declare_resolution(
-            server_args,
-            "_handle_dflash",
-            speculative_eagle_topk=1,
-        )
-
-    if cfg.speculative_dflash_block_size is not None:
-        if int(cfg.speculative_dflash_block_size) <= 0:
-            raise ValueError(
-                "DFLASH requires --speculative-dflash-block-size to be positive, "
-                f"got {cfg.speculative_dflash_block_size}."
-            )
-        if cfg.speculative_num_draft_tokens is not None and int(
-            cfg.speculative_num_draft_tokens
-        ) != int(cfg.speculative_dflash_block_size):
-            raise ValueError(
-                "Both --speculative-num-draft-tokens and --speculative-dflash-block-size are set "
-                "but they differ. For DFLASH they must match. "
-                f"speculative_num_draft_tokens={cfg.speculative_num_draft_tokens}, "
-                f"speculative_dflash_block_size={cfg.speculative_dflash_block_size}."
-            )
-        declare_resolution(
-            server_args,
-            "_handle_dflash",
-            speculative_num_draft_tokens=int(cfg.speculative_dflash_block_size),
-        )
-
-    if cfg.speculative_num_draft_tokens is None:
-        from sglang.srt.speculative.dflash_utils import (
-            parse_dflash_draft_config,
-        )
-
-        model_override_args = json.loads(cfg.json_model_override_args)
-        inferred_block_size = None
-        try:
-            from sglang.srt.utils.hf_transformers_utils import get_config
-
-            draft_hf_config = get_config(
-                cfg.speculative_draft_model_path,
-                trust_remote_code=cfg.trust_remote_code,
-                revision=cfg.speculative_draft_model_revision,
-                model_override_args=model_override_args,
-            )
-            inferred_block_size = parse_dflash_draft_config(
-                draft_hf_config=draft_hf_config
-            ).resolve_block_size(default=None)
-        except Exception as e:
-            logger.warning(
-                "Failed to infer DFLASH block_size from draft model config; "
-                "defaulting speculative_num_draft_tokens to 16. Error: %s",
-                e,
-            )
-
-        if inferred_block_size is None:
-            inferred_block_size = 16
-            logger.warning(
-                "speculative_num_draft_tokens is not set; defaulting to %d for DFLASH.",
-                inferred_block_size,
-            )
-        declare_resolution(
-            server_args,
-            "_handle_dflash",
-            speculative_num_draft_tokens=inferred_block_size,
-        )
+    _resolve_dflash_widths(server_args)
 
     if cfg.speculative_draft_window_size is not None:
-        draft_tokens = int(cfg.speculative_num_draft_tokens)
-        if cfg.speculative_draft_window_size < draft_tokens:
+        block_size = int(cfg.speculative_dflash_block_size)
+        if cfg.speculative_draft_window_size < block_size:
             raise ValueError(
                 "--speculative-draft-window-size must be >= "
-                "--speculative-num-draft-tokens (block_size). "
-                f"window_size={cfg.speculative_draft_window_size}, block_size={draft_tokens}."
+                "--speculative-dflash-block-size (the draft block width). "
+                f"window_size={cfg.speculative_draft_window_size}, block_size={block_size}."
             )
 
     _resolve_dflash_draft_attention_backend(server_args)
+
+    _validate_dflash_tree_admission(server_args)
 
     if cfg.max_running_requests is None:
         declare_resolution(
@@ -490,6 +418,298 @@ def _handle_uno(server_args: ServerArgs) -> None:
             "UNO requires FA3 for both prefill and decode attention; "
             f"got prefill={prefill_backend!r}, decode={decode_backend!r}."
         )
+
+
+# Target attention backends that can express a *tree*-shaped TARGET_VERIFY: they either
+# consume `spec_info.custom_mask` + `mask_indptr` directly (triton, flashinfer) or rebuild a
+# compacted page table from it (fa3 cascade attention). Deliberately a positive list, not the
+# complement of `_DFLASH_VERIFY_SKIP_CUSTOM_MASK_BACKENDS` -- that set means "can express a
+# *linear* verify with its built-in causal path, so skip building a mask", and it contains
+# exactly the mask-capable backends, so complementing it would reject triton (the SM100
+# default for hybrid-GDN models).
+_DFLASH_TREE_VERIFY_BACKENDS = ("flashinfer", "triton", "fa3")
+
+# Backends that silently compute a causal chain over a tree layout instead of raising: their
+# metadata is scalar-uniform with no per-node visibility, so a wrong answer is the failure mode.
+_DFLASH_TREE_SILENTLY_WRONG_BACKENDS = ("trtllm_mha",)
+
+_DFLASH_TREE_WIDTH_FLAG = "--speculative-dflash-tree-width"
+
+
+def _load_dflash_draft_config(server_args: ServerArgs, *, required: bool):
+    """Parse `dflash_config` out of the draft checkpoint, or return None if unreadable.
+
+    `required=True` raises instead of returning None: tree-width admission validates
+    `tree_width <= selector_top_k` and "checkpoint has a selector" from this config and
+    lives only here (the worker does not re-check), so a swallowed read would turn both
+    checks into silent passes.
+    """
+    from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
+    from sglang.srt.utils.hf_transformers_utils import get_config
+
+    cfg = resolving_view(server_args)
+    try:
+        draft_hf_config = get_config(
+            cfg.speculative_draft_model_path,
+            trust_remote_code=cfg.trust_remote_code,
+            revision=cfg.speculative_draft_model_revision,
+            model_override_args=json.loads(cfg.json_model_override_args),
+        )
+        return parse_dflash_draft_config(draft_hf_config=draft_hf_config)
+    except Exception as e:
+        if required:
+            raise ValueError(
+                f"{_DFLASH_TREE_WIDTH_FLAG} > 1 requires reading dflash_config from the draft "
+                f"checkpoint at {cfg.speculative_draft_model_path!r} to validate the "
+                "beam width against selector_top_k, but the config could not be parsed. "
+                f"Fix the draft checkpoint or drop {_DFLASH_TREE_WIDTH_FLAG}. Error: {e}"
+            ) from e
+        logger.warning(
+            "Failed to read DFLASH dflash_config from the draft model config; "
+            "block_size falls back to the built-in default. Error: %s",
+            e,
+        )
+        return None
+
+
+def _resolve_dflash_tree_width(server_args: ServerArgs) -> int:
+    """The beam width kept per draft depth. 1 reproduces today's single-path chain."""
+    cfg = resolving_view(server_args)
+    if cfg.speculative_eagle_topk is not None:
+        raise ValueError(
+            "--speculative-eagle-topk is EAGLE-only and has no meaning for DFLASH, which "
+            "drafts a whole block in parallel rather than expanding one token at a time. "
+            f"Use {_DFLASH_TREE_WIDTH_FLAG} to widen the DFLASH draft tree instead. Got "
+            f"--speculative-eagle-topk={cfg.speculative_eagle_topk}."
+        )
+
+    if cfg.speculative_dflash_tree_width is None:
+        return 1
+
+    tree_width = int(cfg.speculative_dflash_tree_width)
+    if tree_width < 1:
+        raise ValueError(
+            f"{_DFLASH_TREE_WIDTH_FLAG} must be >= 1 (1 = single-path chain), "
+            f"got {tree_width}."
+        )
+    return tree_width
+
+
+_DFLASH_DEFAULT_BLOCK_SIZE = 16
+
+
+def _resolve_dflash_block_size(
+    server_args: ServerArgs, *, tree_width: int, draft_config
+) -> int:
+    """The draft block width, from (in order) the explicit flag, the
+    --speculative-num-draft-tokens alias, the draft checkpoint, or a hardcoded default."""
+    cfg = resolving_view(server_args)
+    explicit = cfg.speculative_dflash_block_size
+    alias = cfg.speculative_num_draft_tokens
+
+    if alias is not None and tree_width > 1:
+        raise ValueError(
+            "--speculative-num-draft-tokens is the *verify* window width, and with "
+            f"{_DFLASH_TREE_WIDTH_FLAG} > 1 DFLASH derives it as "
+            "1 + (block_size - 1) * tree_width, so setting it directly is ambiguous. "
+            "Pass the draft block width as --speculative-dflash-block-size instead. Got "
+            f"--speculative-num-draft-tokens={alias}, "
+            f"{_DFLASH_TREE_WIDTH_FLAG}={tree_width}."
+        )
+
+    if explicit is not None:
+        if int(explicit) <= 0:
+            raise ValueError(
+                "DFLASH requires --speculative-dflash-block-size to be positive, "
+                f"got {explicit}."
+            )
+        if alias is not None and int(alias) != int(explicit):
+            raise ValueError(
+                "Both --speculative-num-draft-tokens and --speculative-dflash-block-size are set "
+                "but they differ. At tree width 1 they mean the same thing and must match. "
+                f"speculative_num_draft_tokens={alias}, "
+                f"speculative_dflash_block_size={explicit}."
+            )
+        return int(explicit)
+
+    if alias is not None:
+        return int(alias)
+
+    inferred = (
+        None if draft_config is None else draft_config.resolve_block_size(default=None)
+    )
+    if inferred is None:
+        logger.warning(
+            "DFLASH block_size is not set and could not be inferred from the draft "
+            "checkpoint; defaulting to %d.",
+            _DFLASH_DEFAULT_BLOCK_SIZE,
+        )
+        return _DFLASH_DEFAULT_BLOCK_SIZE
+    return int(inferred)
+
+
+def _resolve_dflash_widths(server_args: ServerArgs) -> None:
+    """Split the one width DFLASH used to carry into three, and declare them.
+
+    Post-conditions, relied on by the worker and by generic KV / scheduler accounting:
+
+      speculative_dflash_block_size  = block_size  (draft block width, never None)
+      speculative_num_draft_tokens   = 1 + (block_size - 1) * tree_width  (verify width)
+      speculative_eagle_topk         = tree_width
+
+    `speculative_eagle_topk` is not a user-facing knob for DFLASH (it is rejected above); it
+    is reused as the carrier for "is this verify a tree" because two correctness-critical
+    gates already read it -- `conv_window_dedup_enabled` (dense conv windows, which tree
+    ancestors need) and the GDN backend's tree-kernel dispatch.
+    """
+    cfg = resolving_view(server_args)
+    tree_width = _resolve_dflash_tree_width(server_args)
+
+    # W > 1 must read the draft config to validate the beam against selector_top_k; W == 1
+    # only needs it when block_size has no explicit source, so the common single-path launch
+    # keeps its current (config-free) startup path.
+    needs_config = tree_width > 1 or (
+        cfg.speculative_dflash_block_size is None
+        and cfg.speculative_num_draft_tokens is None
+    )
+    draft_config = (
+        _load_dflash_draft_config(server_args, required=tree_width > 1)
+        if needs_config
+        else None
+    )
+
+    block_size = _resolve_dflash_block_size(
+        server_args, tree_width=tree_width, draft_config=draft_config
+    )
+
+    if tree_width > 1:
+        _validate_dflash_tree_selector(
+            draft_config=draft_config, tree_width=tree_width, block_size=block_size
+        )
+
+    declare_resolution(
+        server_args,
+        "_handle_dflash",
+        speculative_dflash_block_size=block_size,
+        speculative_num_draft_tokens=1 + (block_size - 1) * tree_width,
+        speculative_eagle_topk=tree_width,
+    )
+
+
+def _validate_dflash_tree_selector(
+    *, draft_config, tree_width: int, block_size: int
+) -> None:
+    """The tree is a beam over the candidate selector's transition lattice, so the checkpoint
+    must have a selector and the beam cannot be wider than the lattice's candidate axis."""
+    if not draft_config.selector_rank or not draft_config.selector_top_k:
+        raise ValueError(
+            f"{_DFLASH_TREE_WIDTH_FLAG} > 1 requires a DFlash 2 draft checkpoint with a "
+            "candidate selector (dflash_config.selector_rank / selector_top_k); the tree is "
+            "built from the selector's transition lattice. This checkpoint has "
+            f"selector_rank={draft_config.selector_rank}, "
+            f"selector_top_k={draft_config.selector_top_k}."
+        )
+    if tree_width > int(draft_config.selector_top_k):
+        raise ValueError(
+            f"{_DFLASH_TREE_WIDTH_FLAG} must be <= the draft checkpoint's "
+            f"dflash_config.selector_top_k ({draft_config.selector_top_k}): draft depth 1 has "
+            "only selector_top_k candidates under the root, so a wider beam cannot fill the "
+            f"fixed tree shape. Got {_DFLASH_TREE_WIDTH_FLAG}={tree_width}."
+        )
+    if block_size < 2:
+        raise ValueError(
+            f"{_DFLASH_TREE_WIDTH_FLAG} > 1 needs at least one drafted depth, i.e. "
+            f"--speculative-dflash-block-size >= 2, got {block_size}."
+        )
+
+
+def _dflash_effective_target_backends(server_args: ServerArgs) -> dict[str, str]:
+    """The target-side attention backends that a DFLASH verify forward can land on."""
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    view = resolved_view(server_args)
+    candidates = {
+        "--attention-backend": view.attention_backend,
+        "--prefill-attention-backend": view.prefill_attention_backend,
+        "--decode-attention-backend": view.decode_attention_backend,
+    }
+    return {flag: name for flag, name in candidates.items() if name is not None}
+
+
+def _validate_dflash_tree_backends(server_args: ServerArgs, *, tree_width: int) -> None:
+    from sglang.srt.arg_groups.overrides import resolved_view
+
+    for flag, backend in _dflash_effective_target_backends(server_args).items():
+        if backend in _DFLASH_TREE_VERIFY_BACKENDS:
+            continue
+        if backend in _DFLASH_TREE_SILENTLY_WRONG_BACKENDS:
+            raise ValueError(
+                f"{flag}={backend!r} cannot verify a tree-shaped DFLASH draft: it has no "
+                "custom-mask path and its attention metadata carries no per-node visibility, "
+                "so it would silently verify the tree as a causal chain and return wrong "
+                f"tokens rather than failing. Use one of {_DFLASH_TREE_VERIFY_BACKENDS} with "
+                f"{_DFLASH_TREE_WIDTH_FLAG}={tree_width}."
+            )
+        raise ValueError(
+            f"{_DFLASH_TREE_WIDTH_FLAG} > 1 needs a target attention backend that consumes a "
+            f"custom tree mask; only {_DFLASH_TREE_VERIFY_BACKENDS} do. Got {flag}={backend!r}."
+        )
+
+    # DFLASH cannot borrow EAGLE's page-tree gate: that check lives in the EAGLE branch of
+    # this hook, and DFLASH dispatches to _handle_dflash instead, so it never runs here.
+    page_size = int(resolved_view(server_args).page_size)
+    if page_size > 1:
+        raise ValueError(
+            f"{_DFLASH_TREE_WIDTH_FLAG} > 1 is only implemented at --page-size 1; a paged "
+            "tree verify needs the two-pass cascade draft-decode that DFLASH does not "
+            f"implement. Got --page-size {page_size}."
+        )
+
+
+def _validate_dflash_tree_admission(server_args: ServerArgs) -> None:
+    """Reject configurations that are structurally incompatible with a tree-shaped verify.
+
+    Only reached with tree_width > 1; every branch raises rather than degrading, because a
+    silent fallback to chain verify would look like "the tree bought us nothing" in the
+    acceptance-length measurement this feature exists to produce.
+    """
+    cfg = resolving_view(server_args)
+    tree_width = int(cfg.speculative_eagle_topk)
+    if tree_width <= 1:
+        return
+
+    _validate_dflash_tree_backends(server_args, tree_width=tree_width)
+
+    if cfg.enable_linear_replayssm_spec:
+        raise ValueError(
+            "--enable-linear-replayssm-spec is structurally incompatible with "
+            f"{_DFLASH_TREE_WIDTH_FLAG} > 1: it skips the per-step intermediate SSM states a "
+            "tree needs to restart each node from its parent, and its chunked verify kernel "
+            "uses a strictly-lower causal mask. Drop one of the two. (This is not caught by "
+            "the flag's own topk check, which runs before the speculative hook assigns topk.)"
+        )
+
+    if not (cfg.disable_cuda_graph or cfg.disable_decode_cuda_graph):
+        raise ValueError(
+            f"{_DFLASH_TREE_WIDTH_FLAG} > 1 requires --disable-decode-cuda-graph for now: the "
+            "captured DFLASH verify buffers carry neither the tree custom mask nor the "
+            "retrieve_* tree links, and a zero-initialized retrieve_parent_token replays as a "
+            "star-shaped tree without warning."
+        )
+
+    from sglang.srt.environ import envs
+
+    if (
+        envs.SGLANG_SIMULATE_ACC_LEN.get() > 0
+        and envs.SGLANG_SIMULATE_ACC_TOKEN_MODE.get() == "real-draft-token"
+    ):
+        raise ValueError(
+            "SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token forces an accept length along a "
+            f"linear chain and cannot address tree nodes, so it is invalid with "
+            f"{_DFLASH_TREE_WIDTH_FLAG}={tree_width}. Use SGLANG_SIMULATE_ACC_TOKEN_MODE=fixed "
+            "or unset SGLANG_SIMULATE_ACC_LEN."
+        )
+
 
 
 def _target_checkpoint_bundles_dspark_draft(server_args: ServerArgs) -> bool:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -719,14 +719,6 @@ def _validate_dflash_tree_admission(server_args: ServerArgs) -> None:
             "the flag's own topk check, which runs before the speculative hook assigns topk.)"
         )
 
-    if not (cfg.disable_cuda_graph or cfg.disable_decode_cuda_graph):
-        raise ValueError(
-            f"{_DFLASH_TREE_WIDTH_FLAG} > 1 requires --disable-decode-cuda-graph for now: the "
-            "captured DFLASH verify buffers carry neither the tree custom mask nor the "
-            "retrieve_* tree links, and a zero-initialized retrieve_parent_token replays as a "
-            "star-shaped tree without warning."
-        )
-
     from sglang.srt.environ import envs
 
     if (

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -420,30 +420,17 @@ def _handle_uno(server_args: ServerArgs) -> None:
         )
 
 
-# Target attention backends that can express a *tree*-shaped TARGET_VERIFY: they either
-# consume `spec_info.custom_mask` + `mask_indptr` directly (triton, flashinfer) or rebuild a
-# compacted page table from it (fa3 cascade attention). Deliberately a positive list, not the
-# complement of `_DFLASH_VERIFY_SKIP_CUSTOM_MASK_BACKENDS` -- that set means "can express a
-# *linear* verify with its built-in causal path, so skip building a mask", and it contains
-# exactly the mask-capable backends, so complementing it would reject triton (the SM100
-# default for hybrid-GDN models).
+# Backends that support tree-shaped TARGET_VERIFY.
 _DFLASH_TREE_VERIFY_BACKENDS = ("flashinfer", "triton", "fa3")
 
-# Backends that silently compute a causal chain over a tree layout instead of raising: their
-# metadata is scalar-uniform with no per-node visibility, so a wrong answer is the failure mode.
+# Backends that would silently treat a tree as a causal chain.
 _DFLASH_TREE_SILENTLY_WRONG_BACKENDS = ("trtllm_mha",)
 
 _DFLASH_TREE_WIDTH_FLAG = "--speculative-dflash-tree-width"
 
 
 def _load_dflash_draft_config(server_args: ServerArgs, *, required: bool):
-    """Parse `dflash_config` out of the draft checkpoint, or return None if unreadable.
-
-    `required=True` raises instead of returning None: tree-width admission validates
-    `tree_width <= selector_top_k` and "checkpoint has a selector" from this config and
-    lives only here (the worker does not re-check), so a swallowed read would turn both
-    checks into silent passes.
-    """
+    """Parse `dflash_config`; raise when tree admission requires it."""
     from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
     from sglang.srt.utils.hf_transformers_utils import get_config
 
@@ -473,7 +460,7 @@ def _load_dflash_draft_config(server_args: ServerArgs, *, required: bool):
 
 
 def _resolve_dflash_tree_width(server_args: ServerArgs) -> int:
-    """The beam width kept per draft depth. 1 reproduces today's single-path chain."""
+    """Return the beam width kept at each draft depth."""
     cfg = resolving_view(server_args)
     if cfg.speculative_eagle_topk is not None:
         raise ValueError(
@@ -501,9 +488,7 @@ _DFLASH_DEFAULT_BLOCK_SIZE = 16
 def _resolve_dflash_block_size(
     server_args: ServerArgs, *, tree_width: int, draft_config
 ) -> int:
-    """The draft block width, from (in order) the explicit flag, the
-    --speculative-num-draft-tokens alias, the draft checkpoint, or a hardcoded default.
-    """
+    """Resolve the draft block width from flags, checkpoint config, or the default."""
     cfg = resolving_view(server_args)
     explicit = cfg.speculative_dflash_block_size
     alias = cfg.speculative_num_draft_tokens
@@ -550,25 +535,10 @@ def _resolve_dflash_block_size(
 
 
 def _resolve_dflash_widths(server_args: ServerArgs) -> None:
-    """Split the one width DFLASH used to carry into three, and declare them.
-
-    Post-conditions, relied on by the worker and by generic KV / scheduler accounting:
-
-      speculative_dflash_block_size  = block_size  (draft block width, never None)
-      speculative_num_draft_tokens   = 1 + (block_size - 1) * tree_width  (verify width)
-      speculative_eagle_topk         = tree_width
-
-    `speculative_eagle_topk` is not a user-facing knob for DFLASH (it is rejected above); it
-    is reused as the carrier for "is this verify a tree" because two correctness-critical
-    gates already read it -- `conv_window_dedup_enabled` (dense conv windows, which tree
-    ancestors need) and the GDN backend's tree-kernel dispatch.
-    """
+    """Resolve and publish DFLASH block, verify, and tree widths."""
     cfg = resolving_view(server_args)
     tree_width = _resolve_dflash_tree_width(server_args)
 
-    # W > 1 must read the draft config to validate the beam against selector_top_k; W == 1
-    # only needs it when block_size has no explicit source, so the common single-path launch
-    # keeps its current (config-free) startup path.
     needs_config = tree_width > 1 or (
         cfg.speculative_dflash_block_size is None
         and cfg.speculative_num_draft_tokens is None
@@ -588,27 +558,40 @@ def _resolve_dflash_widths(server_args: ServerArgs) -> None:
             draft_config=draft_config, tree_width=tree_width, block_size=block_size
         )
 
+    verify_width = _resolve_dflash_verify_width(
+        tree_width=tree_width, block_size=block_size
+    )
     declare_resolution(
         server_args,
         "_handle_dflash",
         speculative_dflash_block_size=block_size,
-        speculative_num_draft_tokens=1 + (block_size - 1) * tree_width,
+        speculative_num_draft_tokens=verify_width,
         speculative_eagle_topk=tree_width,
     )
 
-    _log_dflash_widths(tree_width=tree_width, block_size=block_size)
+    _log_dflash_widths(
+        tree_width=tree_width, block_size=block_size, verify_width=verify_width
+    )
 
 
-def _log_dflash_widths(*, tree_width: int, block_size: int) -> None:
-    """Record the resolved verify shape so a run can be reconstructed from its log.
+def _resolve_dflash_verify_width(*, tree_width: int, block_size: int) -> int:
+    """Resolve the target verify node count after applying the optional cap."""
+    from sglang.srt.environ import envs
 
-    Only for tree runs; at width 1 these are the values every DFLASH launch has always
-    had, so logging them would be noise. `SGLANG_DFLASH_FORCE_TREE_VERIFY` has to be
-    part of the condition rather than the width alone: it is the one switch that
-    decouples the verify *shape* from the resolved widths (it sends a width-1 run down
-    the tree path, leaving tree_width at 1), so gating on `tree_width > 1` would leave
-    that configuration indistinguishable from a plain chain run in the log.
-    """
+    full_width = 1 + (block_size - 1) * tree_width
+    max_num_nodes = int(envs.SGLANG_DFLASH_MAX_NUM_NODES.get())
+    if max_num_nodes == 0:
+        return full_width
+    if max_num_nodes < block_size:
+        raise ValueError(
+            "SGLANG_DFLASH_MAX_NUM_NODES must be at least the DFLASH block size "
+            f"({block_size}), got {max_num_nodes}."
+        )
+    return min(full_width, max_num_nodes)
+
+
+def _log_dflash_widths(*, tree_width: int, block_size: int, verify_width: int) -> None:
+    """Log resolved widths for tree verification runs."""
     from sglang.srt.environ import envs
 
     force_tree_verify = envs.SGLANG_DFLASH_FORCE_TREE_VERIFY.get()
@@ -617,9 +600,10 @@ def _log_dflash_widths(*, tree_width: int, block_size: int) -> None:
 
     logger.info(
         "DFLASH tree verify: tree_width=%d, block_size=%d, verify_width=%d, "
-        "force_tree_verify=%s",
+        "full_width=%d, force_tree_verify=%s",
         tree_width,
         block_size,
+        verify_width,
         1 + (block_size - 1) * tree_width,
         force_tree_verify,
     )
@@ -628,9 +612,7 @@ def _log_dflash_widths(*, tree_width: int, block_size: int) -> None:
 def _validate_dflash_tree_selector(
     *, draft_config, tree_width: int, block_size: int
 ) -> None:
-    """The tree is a beam over the candidate selector's transition lattice, so the checkpoint
-    must have a selector and the beam cannot be wider than the lattice's candidate axis.
-    """
+    """Validate the selector and dimensions needed by tree drafting."""
     if not draft_config.selector_rank or not draft_config.selector_top_k:
         raise ValueError(
             f"{_DFLASH_TREE_WIDTH_FLAG} > 1 requires a DFlash 2 draft checkpoint with a "

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1254,6 +1254,13 @@ class Envs:
     # is the equivalence gate for the tree wiring: same prompts, same tokens. No
     # effect at width > 1, which always takes the tree path.
     SGLANG_DFLASH_FORCE_TREE_VERIFY = EnvBool(False)
+    # Cap on the DFLASH draft-tree node count: the beam is still built at
+    # tree_width per depth, then pruned to the best `max_num_nodes` nodes by
+    # cumulative log-prob, and the target verifies that many. 0 = no cap, i.e.
+    # verify_width stays 1 + (block_size - 1) * tree_width. Must be >= block_size
+    # (the spine is what the draft forward writes) and <= 256 (the prune kernel
+    # ranks all nodes in registers).
+    SGLANG_DFLASH_MAX_NUM_NODES = EnvInt(0)
     SGLANG_RAGGED_VERIFY_MODE = EnvStr("static")
     SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE = EnvBool(False)
     # Skip draft_extend while adaptive spec is at steps=0 (drafting disabled).

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1249,6 +1249,11 @@ class Envs:
     SGLANG_OPT_FUSED_KDA_VERIFY = EnvBool(False)
     # A/B: keep the DFLASH draft greedy head eager (not folded in-graph).
     SGLANG_DFLASH_EAGER_DRAFT_SAMPLER = EnvBool(False)
+    # Route DFLASH tree width 1 through the tree verify path instead of the chain
+    # path it is otherwise dispatched to. The width-1 tree *is* the chain, so this
+    # is the equivalence gate for the tree wiring: same prompts, same tokens. No
+    # effect at width > 1, which always takes the tree path.
+    SGLANG_DFLASH_FORCE_TREE_VERIFY = EnvBool(False)
     SGLANG_RAGGED_VERIFY_MODE = EnvStr("static")
     SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE = EnvBool(False)
     # Skip draft_extend while adaptive spec is at steps=0 (drafting disabled).

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -22,7 +22,11 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
-from sglang.srt.layers.attention.verify_mask import VerifyMask, maybe_create_verify_mask
+from sglang.srt.layers.attention.verify_mask import (
+    VerifyMask,
+    fill_verify_mask_indptr,
+    maybe_create_verify_mask,
+)
 from sglang.srt.layers.dcp import (
     cp_lse_ag_out_rs_mha,
     create_triton_kv_indices_for_dcp_triton,
@@ -588,16 +592,22 @@ class TritonAttnBackend(AttentionBackend):
         custom_mask = (
             self._verify_mask.buffer if self._verify_mask is not None else None
         )
-        if (
-            spec_info is not None
-            and getattr(spec_info, "custom_mask", None) is not None
-        ):
-            custom_mask[: spec_info.custom_mask.shape[0]] = spec_info.custom_mask
-        else:
+        live_mask = (
+            getattr(spec_info, "custom_mask", None) if spec_info is not None else None
+        )
+        if live_mask is None:
             custom_mask = None
-        seq_mask_len = num_draft_tokens * (seq_lens + num_draft_tokens)
-        mask_indptr = self.mask_indptr[: bs + 1]
-        mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
+        elif live_mask.data_ptr() != custom_mask.data_ptr():
+            # A draft stage that owns no buffer built its mask elsewhere; stage it.
+            # One that wrote straight into this buffer (DFLASH tree, EAGLE with
+            # tree_mask_buf) would otherwise copy the buffer onto itself.
+            custom_mask[: live_mask.shape[0]] = live_mask
+        mask_indptr = fill_verify_mask_indptr(
+            mask_indptr=self.mask_indptr,
+            seq_lens=seq_lens,
+            num_draft_tokens=num_draft_tokens,
+            bs=bs,
+        )
         return (
             qo_indptr,
             kv_indptr,
@@ -931,12 +941,12 @@ class TritonAttnBackend(AttentionBackend):
                 )
 
             custom_mask = spec_info.custom_mask
-            seq_mask_len = num_draft_tokens * (
-                forward_batch.seq_lens + num_draft_tokens
+            mask_indptr = fill_verify_mask_indptr(
+                mask_indptr=self.mask_indptr,
+                seq_lens=forward_batch.seq_lens,
+                num_draft_tokens=num_draft_tokens,
+                bs=bs,
             )
-            mask_indptr = self.mask_indptr
-            mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len[:bs], dim=0)
-            mask_indptr = mask_indptr[: bs + 1]
             max_extend_len = num_draft_tokens
             num_kv_splits = None
             attn_logits = None

--- a/python/sglang/srt/layers/attention/verify_mask.py
+++ b/python/sglang/srt/layers/attention/verify_mask.py
@@ -26,6 +26,31 @@ def tree_mask_numel(
     return bs * per_req
 
 
+def fill_verify_mask_indptr(
+    *,
+    mask_indptr: torch.Tensor,
+    seq_lens: torch.Tensor,
+    num_draft_tokens: int,
+    bs: int,
+) -> torch.Tensor:
+    """Flat FULL_MASK start offset of each request, into ``mask_indptr[: bs + 1]``.
+
+    Each request owns ``num_draft_tokens`` rows of ``seq_len + num_draft_tokens``
+    cells. Whoever *writes* the mask and whoever *reads* it must agree cell for cell,
+    and a formula duplicated at the two ends is the bug that produces wrong tokens
+    rather than a crash -- so producers and the triton/flashinfer readers share this.
+    (``FlashAttentionBackend`` still derives its own equivalent from
+    ``speculative_num_draft_tokens``; it does not consume ``mask_indptr``.)
+
+    Stays on device -- ``seq_lens`` is the committed prefix, which the host does
+    not know without a sync. ``mask_indptr[0]`` is left alone: every caller's
+    buffer is zero-initialized and request 0 starts at 0.
+    """
+    seq_mask_len = num_draft_tokens * (seq_lens[:bs] + num_draft_tokens)
+    mask_indptr[1 : bs + 1] = torch.cumsum(seq_mask_len, dim=0)
+    return mask_indptr[: bs + 1]
+
+
 class VerifyMask(msgspec.Struct, frozen=True):
     """The target-verify mask.
 

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -366,7 +366,14 @@ def compute_spec_logprobs(
 
     if accept_index is not None:
         max_accept = accept_index.shape[1]
-        flat_accept_idx = accept_index.long().reshape(-1)
+        # Clamped, not raw: accept_index pads with -1 past each request's accepted run,
+        # and a negative index would wrap to the last row of logits and the last entry
+        # of predict. The wrapped logprob is never read (callers slice each row to the
+        # accept length), but the token id it produces feeds the vocabulary gather
+        # below, and the verify kernel only writes predict at the nodes it visits --
+        # so that slot can hold anything and the gather goes out of bounds. Reading
+        # row 0 instead keeps the same unread garbage in bounds.
+        flat_accept_idx = accept_index.long().reshape(-1).clamp(min=0)
         gathered_logits = next_token_logits[flat_accept_idx]
         accepted_token_ids = predict[flat_accept_idx]
     else:

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1566,6 +1566,12 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 draft_token=None,
                 positions=None,
                 draft_token_num=self.captured_req_width,
+                # Mirror the live verify input's shape family. Tree width > 1 currently
+                # requires --disable-decode-cuda-graph, so this stays 1 in practice; passing
+                # it through means enabling graph capture later fails loudly (block_size is
+                # missing) instead of replaying a zero-initialized star-shaped tree.
+                topk=get_spec().speculative_eagle_topk or 1,
+                block_size=get_spec().speculative_dflash_block_size,
                 custom_mask=(
                     None
                     if (self.model_runner.is_draft_worker or not build_custom_mask)

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -1557,8 +1557,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 resolve_dflash_verify_mask_policy,
             )
 
-            # Avoid enabling custom-mask modes during graph capture for backends that
-            # can express DFLASH verify via their built-in causal path.
+            # A chain verify is causal, so backends with a built-in causal path capture
+            # without a custom mask; a tree needs one (see the policy helper).
             _, build_custom_mask = resolve_dflash_verify_mask_policy(
                 self.model_runner.attn_backend
             )
@@ -1566,10 +1566,9 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 draft_token=None,
                 positions=None,
                 draft_token_num=self.captured_req_width,
-                # Mirror the live verify input's shape family. Tree width > 1 currently
-                # requires --disable-decode-cuda-graph, so this stays 1 in practice; passing
-                # it through means enabling graph capture later fails loudly (block_size is
-                # missing) instead of replaying a zero-initialized star-shaped tree.
+                # Mirror the live verify input's shape family: the tree width decides the
+                # per-node visibility the mask encodes, so capturing with the wrong one
+                # would freeze the wrong tree shape into the graph.
                 topk=get_spec().speculative_eagle_topk or 1,
                 block_size=get_spec().speculative_dflash_block_size,
                 custom_mask=(

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -12,6 +12,7 @@ import torch.nn.functional as F
 from torch import nn
 
 from sglang.kernels.ops.speculative.dflash import (
+    _validate_max_num_nodes,
     selector_beam_walk_triton,
     selector_walk_triton,
 )
@@ -944,17 +945,32 @@ def _follow_maps(maps, initial_indices, edges: int):
 
 
 def _first_max_index(values: torch.Tensor) -> torch.Tensor:
-    """Index of the first maximum along the last axis.
-
-    `torch.argmax` does not promise the first occurrence and the triton walk
-    deliberately does (`tl.min(tl.where(scores == best, offsets, limit))`). Beam
-    selection compares across a flattened axis where exact ties are constructible,
-    so the reference has to spell out the same rule.
-    """
+    """Return the first maximum along the last axis."""
     limit = values.shape[-1]
     best = values.max(dim=-1, keepdim=True).values
     offsets = torch.arange(limit, device=values.device)
     return torch.where(values == best, offsets, limit).min(dim=-1).values
+
+
+def _prune_by_cum_torch(
+    *,
+    node_tokens: torch.Tensor,
+    node_parents: torch.Tensor,
+    node_cums: torch.Tensor,
+    max_num_nodes: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Reference implementation for cumulative-score pruning."""
+    bs, num_nodes = node_cums.shape
+    cap = int(max_num_nodes)
+    order = node_cums.sort(dim=1, descending=True, stable=True).indices
+    kept = order[:, :cap].sort(dim=1).values
+    tokens = node_tokens.gather(1, kept)
+
+    renumber = torch.zeros((bs, num_nodes), dtype=torch.int64, device=kept.device)
+    renumber.scatter_(1, kept, torch.arange(cap, device=kept.device).expand(bs, cap))
+    parents = renumber.gather(1, node_parents.gather(1, kept).clamp(min=0))
+    parents[:, 0] = -1
+    return tokens, parents
 
 
 def _beam_walk_torch(
@@ -963,32 +979,28 @@ def _beam_walk_torch(
     scores: torch.Tensor,
     anchor_token_ids: torch.Tensor,
     beam_width: int,
+    max_num_nodes: Optional[int] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
-    """Device-agnostic reference for the fixed-width draft tree; see `beam_walk`.
-
-    Mirrors the triton kernel step for step -- beam_width-1 rounds of masked argmax
-    rather than `torch.topk`, and the same `flat = m * top_k + c` flattening -- so
-    the two resolve ties identically and can be compared elementwise.
-    """
+    """Device-agnostic reference for the fixed-width draft tree."""
     bs, slots, top_k = candidate_ids.shape
     width = int(beam_width)
     device = candidate_ids.device
-    node_tokens = torch.empty((bs, 1 + slots * width), dtype=torch.int64, device=device)
+    num_nodes = 1 + slots * width
+    _validate_max_num_nodes(max_num_nodes=max_num_nodes, num_nodes=num_nodes)
+    node_tokens = torch.empty((bs, num_nodes), dtype=torch.int64, device=device)
     node_parents = torch.empty_like(node_tokens)
     node_tokens[:, 0] = anchor_token_ids
     node_parents[:, 0] = -1
+    prune = max_num_nodes is not None and num_nodes > int(max_num_nodes)
+    node_cums = (
+        torch.zeros((bs, num_nodes), dtype=torch.float32, device=device)
+        if prune
+        else None
+    )
 
-    # Per-row over the successor axis: a row is the conditional distribution given
-    # its predecessor, and only that normalization makes the depth-wise sums
-    # comparable across rows. Rows are independent, so normalizing all top_k of them
-    # here and gathering width of them below matches the kernel's gather-then-
-    # normalize order elementwise.
     log_probs = torch.log_softmax(scores.float(), dim=-1)
 
     rows = torch.arange(bs, device=device)
-    # cum = -inf everywhere but beam 0 folds the first depth into the same loop
-    # body: only beam 0 can score, so the top-width is taken over that one row's
-    # top_k candidates and every parent is the root.
     state = torch.zeros((bs, width), dtype=torch.int64, device=device)
     cum = torch.full((bs, width), float("-inf"), dtype=torch.float32, device=device)
     cum[:, 0] = 0.0
@@ -1003,17 +1015,11 @@ def _beam_walk_torch(
 
         beam_index = torch.zeros((bs, width), dtype=torch.int64, device=device)
         candidate_index = torch.empty((bs, width), dtype=torch.int64, device=device)
-        # The spine: beam 0's own best child, parent pinned to beam 0 (`beam_index`
-        # keeps its zero init). Reads `transitions[:, 0]` where the kernel reads its
-        # `cum`-added row; the two argmaxes agree because `cum[:, 0]` is a constant
-        # across the row, and staying independent of the accumulated score is what
-        # keeps the spine chain equal to `sample_path`'s greedy walk.
+        # Keep beam 0 on the greedy spine so width 1 remains the chain.
         candidate_index[:, 0] = _first_max_index(transitions[:, 0, :])
 
         remaining = flat.clone()
-        # Struck from the pool, so the width picks are distinct (beam, candidate)
-        # pairs -- which is what makes same-parent sibling tokens distinct. The
-        # spine's flat index is just its candidate index, since its beam is 0.
+        # Remove each pick so sibling pairs remain distinct.
         remaining[rows, candidate_index[:, 0]] = float("-inf")
         for beam in range(1, width):
             picked = _first_max_index(remaining)
@@ -1024,16 +1030,23 @@ def _beam_walk_torch(
         node_tokens[:, base : base + width] = candidate_ids[:, slot].gather(
             1, candidate_index
         )
-        # Parents come from the previous depth, so they are always < base: the BFS
-        # order every downstream ancestor-closure scan relies on.
+        # BFS numbering keeps every parent before its children.
         node_parents[:, base : base + width] = node.gather(1, beam_index)
 
-        # Read `flat`, not `remaining`, whose picks have been overwritten with -inf.
         cum = flat.gather(1, beam_index * top_k + candidate_index)
+        if node_cums is not None:
+            node_cums[:, base : base + width] = cum
         state = candidate_index
         node = torch.arange(base, base + width, device=device).expand(bs, width)
 
-    return node_tokens, node_parents
+    if node_cums is None:
+        return node_tokens, node_parents
+    return _prune_by_cum_torch(
+        node_tokens=node_tokens,
+        node_parents=node_parents,
+        node_cums=node_cums,
+        max_num_nodes=int(max_num_nodes),
+    )
 
 
 class CandidateSelector(nn.Module):
@@ -1164,6 +1177,7 @@ class CandidateSelector(nn.Module):
         scores: torch.Tensor,
         anchor_token_ids: torch.Tensor,
         beam_width: int,
+        max_num_nodes: Optional[int] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Expand the lattice into a fixed-width tree: [bs, 1 + slots * beam_width]
         BFS-ordered `(node_tokens, node_parents)`, root inclusive at index 0.
@@ -1177,6 +1191,13 @@ class CandidateSelector(nn.Module):
         `beam_width == 1` reproduces `sample_path`'s greedy output, but the worker
         keeps calling `sample_path` there -- this path is the tree's regression gate,
         not its chain implementation.
+
+        `max_num_nodes` caps the emitted node count: the walk still builds
+        `1 + slots * beam_width` nodes, then the anchor plus the best
+        `max_num_nodes - 1` by `cum` are kept and renumbered, so the return is
+        `[bs, min(max_num_nodes, 1 + slots * beam_width)]`. `None` is today's
+        behaviour, unpruned. The cap is a config-time constant rather than anything
+        read off a device tensor, which is what keeps the emitted shape static.
         """
         if beam_width > self.top_k:
             raise ValueError(
@@ -1190,12 +1211,14 @@ class CandidateSelector(nn.Module):
                 scores=scores,
                 anchor_token_ids=anchor_token_ids,
                 beam_width=beam_width,
+                max_num_nodes=max_num_nodes,
             )
         return _beam_walk_torch(
             candidate_ids=candidate_ids,
             scores=scores,
             anchor_token_ids=anchor_token_ids,
             beam_width=beam_width,
+            max_num_nodes=max_num_nodes,
         )
 
 

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -11,7 +11,10 @@ import torch
 import torch.nn.functional as F
 from torch import nn
 
-from sglang.kernels.ops.speculative.dflash import selector_walk_triton
+from sglang.kernels.ops.speculative.dflash import (
+    selector_beam_walk_triton,
+    selector_walk_triton,
+)
 from sglang.srt.configs.laguna import normalize_gating
 from sglang.srt.distributed.communication_op import tensor_model_parallel_all_gather
 from sglang.srt.layers.activation import SiluAndMul
@@ -940,6 +943,96 @@ def _follow_maps(maps, initial_indices, edges: int):
     return torch.stack(path, dim=1)
 
 
+def _first_max_index(values: torch.Tensor) -> torch.Tensor:
+    """Index of the first maximum along the last axis.
+
+    `torch.argmax` does not promise the first occurrence and the triton walk
+    deliberately does (`tl.min(tl.where(scores == best, offsets, limit))`). Beam
+    selection compares across a flattened axis where exact ties are constructible,
+    so the reference has to spell out the same rule.
+    """
+    limit = values.shape[-1]
+    best = values.max(dim=-1, keepdim=True).values
+    offsets = torch.arange(limit, device=values.device)
+    return torch.where(values == best, offsets, limit).min(dim=-1).values
+
+
+def _beam_walk_torch(
+    *,
+    candidate_ids: torch.Tensor,
+    scores: torch.Tensor,
+    anchor_token_ids: torch.Tensor,
+    beam_width: int,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Device-agnostic reference for the fixed-width draft tree; see `beam_walk`.
+
+    Mirrors the triton kernel step for step -- beam_width-1 rounds of masked argmax
+    rather than `torch.topk`, and the same `flat = m * top_k + c` flattening -- so
+    the two resolve ties identically and can be compared elementwise.
+    """
+    bs, slots, top_k = candidate_ids.shape
+    width = int(beam_width)
+    device = candidate_ids.device
+    node_tokens = torch.empty((bs, 1 + slots * width), dtype=torch.int64, device=device)
+    node_parents = torch.empty_like(node_tokens)
+    node_tokens[:, 0] = anchor_token_ids
+    node_parents[:, 0] = -1
+
+    # Per-row over the successor axis: a row is the conditional distribution given
+    # its predecessor, and only that normalization makes the depth-wise sums
+    # comparable across rows. Rows are independent, so normalizing all top_k of them
+    # here and gathering width of them below matches the kernel's gather-then-
+    # normalize order elementwise.
+    log_probs = torch.log_softmax(scores.float(), dim=-1)
+
+    rows = torch.arange(bs, device=device)
+    # cum = -inf everywhere but beam 0 folds the first depth into the same loop
+    # body: only beam 0 can score, so the top-width is taken over that one row's
+    # top_k candidates and every parent is the root.
+    state = torch.zeros((bs, width), dtype=torch.int64, device=device)
+    cum = torch.full((bs, width), float("-inf"), dtype=torch.float32, device=device)
+    cum[:, 0] = 0.0
+    node = torch.zeros((bs, width), dtype=torch.int64, device=device)
+
+    for slot in range(slots):
+        base = 1 + slot * width
+        transitions = log_probs[:, slot].gather(
+            1, state[:, :, None].expand(bs, width, top_k)
+        )
+        flat = (cum[:, :, None] + transitions).reshape(bs, width * top_k)
+
+        beam_index = torch.zeros((bs, width), dtype=torch.int64, device=device)
+        candidate_index = torch.empty((bs, width), dtype=torch.int64, device=device)
+        # The spine: beam 0's own best child, parent pinned to beam 0. Reads the row
+        # rather than `flat` so it stays independent of the accumulated score, which
+        # is what keeps the spine chain equal to `sample_path`'s greedy walk.
+        candidate_index[:, 0] = _first_max_index(transitions[:, 0, :])
+
+        remaining = flat.clone()
+        # Struck from the pool, so the width picks are distinct (beam, candidate)
+        # pairs -- which is what makes same-parent sibling tokens distinct.
+        remaining[rows, candidate_index[:, 0]] = float("-inf")
+        for beam in range(1, width):
+            picked = _first_max_index(remaining)
+            beam_index[:, beam] = torch.div(picked, top_k, rounding_mode="floor")
+            candidate_index[:, beam] = picked % top_k
+            remaining[rows, picked] = float("-inf")
+
+        node_tokens[:, base : base + width] = candidate_ids[:, slot].gather(
+            1, candidate_index
+        )
+        # Parents come from the previous depth, so they are always < base: the BFS
+        # order every downstream ancestor-closure scan relies on.
+        node_parents[:, base : base + width] = node.gather(1, beam_index)
+
+        # Read `flat`, not `remaining`, whose picks have been overwritten with -inf.
+        cum = flat.gather(1, beam_index * top_k + candidate_index)
+        state = candidate_index
+        node = torch.arange(base, base + width, device=device).expand(bs, width)
+
+    return node_tokens, node_parents
+
+
 class CandidateSelector(nn.Module):
     """Scores the K x K transitions between adjacent proposal slots, then walks them.
 
@@ -1060,6 +1153,47 @@ class CandidateSelector(nn.Module):
             greedy_mask[:, None, None], F.one_hot(path_indices, top_k).float(), q_rows
         )
         return tokens, q_rows
+
+    def beam_walk(
+        self,
+        *,
+        candidate_ids: torch.Tensor,
+        scores: torch.Tensor,
+        anchor_token_ids: torch.Tensor,
+        beam_width: int,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Expand the lattice into a fixed-width tree: [bs, 1 + slots * beam_width]
+        BFS-ordered `(node_tokens, node_parents)`, root inclusive at index 0.
+
+        Greedy only -- no `q`, so it cannot feed a rejection-sampling accept. Each
+        depth keeps `beam_width` nodes: index 0 is the spine (the previous depth's
+        spine child with the best transition, which makes the spine chain equal to
+        `sample_path`'s greedy walk and the tree a superset of it), the rest are the
+        top of the flattened `beam_width * top_k` pool with the spine struck out.
+
+        `beam_width == 1` reproduces `sample_path`'s greedy output, but the worker
+        keeps calling `sample_path` there -- this path is the tree's regression gate,
+        not its chain implementation.
+        """
+        if beam_width > self.top_k:
+            raise ValueError(
+                f"DFlash2 beam width {beam_width} exceeds the checkpoint's "
+                f"selector_top_k {self.top_k}: the first depth only has "
+                "selector_top_k candidates, so a wider beam cannot be filled."
+            )
+        if scores.is_cuda:
+            return selector_beam_walk_triton(
+                candidate_ids=candidate_ids,
+                scores=scores,
+                anchor_token_ids=anchor_token_ids,
+                beam_width=beam_width,
+            )
+        return _beam_walk_torch(
+            candidate_ids=candidate_ids,
+            scores=scores,
+            anchor_token_ids=anchor_token_ids,
+            beam_width=beam_width,
+        )
 
 
 class DFlash2DraftModel(DFlashDraftModel):

--- a/python/sglang/srt/models/dflash.py
+++ b/python/sglang/srt/models/dflash.py
@@ -1003,14 +1003,17 @@ def _beam_walk_torch(
 
         beam_index = torch.zeros((bs, width), dtype=torch.int64, device=device)
         candidate_index = torch.empty((bs, width), dtype=torch.int64, device=device)
-        # The spine: beam 0's own best child, parent pinned to beam 0. Reads the row
-        # rather than `flat` so it stays independent of the accumulated score, which
-        # is what keeps the spine chain equal to `sample_path`'s greedy walk.
+        # The spine: beam 0's own best child, parent pinned to beam 0 (`beam_index`
+        # keeps its zero init). Reads `transitions[:, 0]` where the kernel reads its
+        # `cum`-added row; the two argmaxes agree because `cum[:, 0]` is a constant
+        # across the row, and staying independent of the accumulated score is what
+        # keeps the spine chain equal to `sample_path`'s greedy walk.
         candidate_index[:, 0] = _first_max_index(transitions[:, 0, :])
 
         remaining = flat.clone()
         # Struck from the pool, so the width picks are distinct (beam, candidate)
-        # pairs -- which is what makes same-parent sibling tokens distinct.
+        # pairs -- which is what makes same-parent sibling tokens distinct. The
+        # spine's flat index is just its candidate index, since its beam is 0.
         remaining[rows, candidate_index[:, 0]] = float("-inf")
         for beam in range(1, width):
             picked = _first_max_index(remaining)

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -34,12 +34,26 @@ class DFlashVerifyInput(SpecInput):
     draft_token: torch.Tensor
     positions: torch.Tensor
     draft_token_num: int
-    # Kept for compatibility with attention backends that gate tree metadata by `topk > 1`.
-    # DFLASH verify is linear (non-tree), so this is always 1.
-    topk: int = 1
+    # Beam width kept per draft depth: 1 = linear chain, > 1 = tree verify. Required (no
+    # default) so every construction site states which shape it is building -- attention
+    # backends gate tree metadata on `topk > 1` and a forgotten site would silently verify a
+    # tree as a chain. DSPARK reuses this class and always passes 1.
+    topk: int
+    # Longest root-to-leaf chain, i.e. the DFLASH draft block width. Bounds `accept_index`,
+    # whose outer accept loop silently truncates the accepted path if it is too narrow.
+    # Defaults to `draft_token_num`, which is exact for any chain (topk == 1); tree callers
+    # must pass it, since there the verify width 1 + (block_size - 1) * topk is wider.
+    block_size: Optional[int] = None
     # Custom attention "allow mask" for TARGET_VERIFY in backends that require it.
     # Semantics follow SGLang speculative conventions: True means the (q, k) pair is allowed.
     custom_mask: torch.Tensor | None = None
+    # Left-child / right-sibling encoding of the draft tree, plus the flat node index, in the
+    # layout `reconstruct_indices_from_tree_mask` writes and `verify_tree_greedy` walks. None
+    # for chain verify. Declared here rather than alongside their producer because the GDN
+    # backend reads `spec_info.retrieve_next_token` as a bare attribute as soon as topk > 1.
+    retrieve_index: Optional[torch.Tensor] = None
+    retrieve_next_token: Optional[torch.Tensor] = None
+    retrieve_next_sibling: Optional[torch.Tensor] = None
     capture_hidden_mode: CaptureHiddenMode = CaptureHiddenMode.FULL
 
     # Shape info for padding (e.g., DP attention / CUDA graph).
@@ -55,6 +69,28 @@ class DFlashVerifyInput(SpecInput):
         if self.num_tokens_per_req == -1:
             self.num_tokens_per_req = int(self.draft_token_num)
         self.num_tokens_for_logprob_per_req = int(self.draft_token_num)
+        if self.block_size is None:
+            if self.topk > 1:
+                raise ValueError(
+                    "DFlashVerifyInput with topk > 1 must pass block_size: the verify width "
+                    "1 + (block_size - 1) * topk no longer equals the longest root-to-leaf "
+                    f"chain, so accept_index cannot be sized from draft_token_num. Got "
+                    f"topk={self.topk}, draft_token_num={self.draft_token_num}."
+                )
+            self.block_size = int(self.draft_token_num)
+
+    @property
+    def max_tree_depth(self) -> int:
+        # Longest root-to-leaf chain, NOT the node count: a fixed-width beam over the
+        # selector lattice keeps W nodes per depth but every path is still block_size long.
+        return int(self.block_size)
+
+    @property
+    def tree_topk(self) -> int:
+        # Per-parent fanout. The beam picks its W nodes per depth globally across parents, so
+        # a parent can end up with anywhere from 0 to W children: irregular, hence -1. topk
+        # == 1 keeps reporting 1 so the chain path's callers see today's value.
+        return -1 if self.topk > 1 else int(self.topk)
 
     def prepare_for_verify(
         self,

--- a/python/sglang/srt/speculative/dflash_info.py
+++ b/python/sglang/srt/speculative/dflash_info.py
@@ -34,23 +34,14 @@ class DFlashVerifyInput(SpecInput):
     draft_token: torch.Tensor
     positions: torch.Tensor
     draft_token_num: int
-    # Beam width kept per draft depth: 1 = linear chain, > 1 = tree verify. Required (no
-    # default) so every construction site states which shape it is building -- attention
-    # backends gate tree metadata on `topk > 1` and a forgotten site would silently verify a
-    # tree as a chain. DSPARK reuses this class and always passes 1.
+    # 1 is a chain; values greater than 1 select tree verification. DSPARK passes 1.
     topk: int
-    # Longest root-to-leaf chain, i.e. the DFLASH draft block width. Bounds `accept_index`,
-    # whose outer accept loop silently truncates the accepted path if it is too narrow.
-    # Defaults to `draft_token_num`, which is exact for any chain (topk == 1); tree callers
-    # must pass it, since there the verify width 1 + (block_size - 1) * topk is wider.
+    # Longest root-to-leaf chain, used to size accept bookkeeping.
     block_size: Optional[int] = None
     # Custom attention "allow mask" for TARGET_VERIFY in backends that require it.
     # Semantics follow SGLang speculative conventions: True means the (q, k) pair is allowed.
     custom_mask: torch.Tensor | None = None
-    # Left-child / right-sibling encoding of the draft tree, plus the flat node index, in the
-    # layout `reconstruct_indices_from_tree_mask` writes and `verify_tree_greedy` walks. None
-    # for chain verify. Declared here rather than alongside their producer because the GDN
-    # backend reads `spec_info.retrieve_next_token` as a bare attribute as soon as topk > 1.
+    # Left-child/right-sibling links and flat node indices for tree verification.
     retrieve_index: Optional[torch.Tensor] = None
     retrieve_next_token: Optional[torch.Tensor] = None
     retrieve_next_sibling: Optional[torch.Tensor] = None

--- a/python/sglang/srt/speculative/dflash_tree.py
+++ b/python/sglang/srt/speculative/dflash_tree.py
@@ -1,0 +1,123 @@
+"""Verify metadata for a DFLASH beam tree.
+
+The beam walk (`models/dflash.py::_beam_walk_torch` and its triton twin) emits the
+minimal representation of the tree: `node_tokens` and `node_parents`, both
+`[bs, num_nodes]`, in BFS order so that `node_parents[i] < i`. Target verify needs
+more than that, and this module derives all of it.
+
+Two different masks are involved and they must not be confused:
+
+- the **QLEN** mask, `[bs, N, N]` bool, is the ancestor closure over draft nodes
+  alone. `reconstruct_indices_from_tree_mask` consumes exactly this; the committed
+  prefix reaches it only through `prefix_lens`, which the kernel adds to the
+  per-node depth to produce absolute positions.
+- the **FULL_MASK**, a flat bool buffer, is what the attention backends consume.
+  Its trailing `N x N` block per request *is* the QLEN mask, preceded by the
+  request's committed prefix columns.
+
+Spelling: the sgl_kernel op schema says `retrive_*`. This module keeps that
+spelling on values that go straight into the op, matching the boundary
+`eagle_utils.py::verify_tree_greedy_func` already draws, while
+`DFlashVerifyInput` keeps the correct `retrieve_*` on its fields.
+"""
+
+from __future__ import annotations
+
+import torch
+from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
+
+
+def build_ancestor_mask(*, node_parents: torch.Tensor, max_depth: int) -> torch.Tensor:
+    """`[bs, N, N]` bool ancestor closure, `mask[b, i, j] = j is an ancestor of i`.
+
+    The diagonal is set (a node counts as its own ancestor) and column 0 is set on
+    every row, because the root is an ancestor of everything.
+
+    Walks parent pointers `max_depth` times rather than scanning the `N` nodes in
+    order. `max_depth` is the deepest layer index -- `gamma = block_size - 1` -- so
+    the iteration count is independent of the beam width, and a width sweep does
+    not pay a growing number of kernel launches. Clamping a spent chain to node 0
+    is harmless precisely because the root bit is already set on every row.
+    """
+    batch_size, num_nodes = node_parents.shape
+    device = node_parents.device
+
+    mask = torch.zeros(
+        (batch_size, num_nodes, num_nodes), dtype=torch.bool, device=device
+    )
+    cursor = (
+        torch.arange(num_nodes, device=device)
+        .unsqueeze(0)
+        .expand(batch_size, num_nodes)
+        .contiguous()
+    )
+    mask.scatter_(2, cursor.unsqueeze(2), True)
+    for _ in range(int(max_depth)):
+        cursor = node_parents.gather(1, cursor).clamp(min=0)
+        mask.scatter_(2, cursor.unsqueeze(2), True)
+    return mask
+
+
+def build_dflash_tree_meta(
+    *, ancestor_mask: torch.Tensor, prefix_lens: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """`(positions, retrive_index, retrive_next_token, retrive_next_sibling)`.
+
+    Derived from the mask rather than from `node_parents` directly, so a
+    mis-built mask shows up as links that disagree with the parents instead of
+    staying invisible until attention silently reads the wrong keys.
+
+    Returned in the kernel's own argument order. `positions` is flat `[bs * N]`;
+    the three link tensors are `[bs, N]`. All four are int64, which the CUDA
+    kernel requires -- it casts the pointers without checking.
+    """
+    batch_size, num_nodes, _ = ancestor_mask.shape
+    device = ancestor_mask.device
+    if prefix_lens.dtype != torch.int64:
+        raise ValueError(
+            "DFLASH tree meta requires int64 prefix_lens (the CUDA kernel casts "
+            f"the pointer unchecked), got {prefix_lens.dtype}."
+        )
+
+    positions = torch.empty((batch_size * num_nodes,), dtype=torch.int64, device=device)
+    # -1 is the "no such link" sentinel; the kernel leaves absent links untouched.
+    links = torch.full((3, batch_size, num_nodes), -1, dtype=torch.int64, device=device)
+    retrive_index, retrive_next_token, retrive_next_sibling = links
+
+    reconstruct_indices_from_tree_mask(
+        ancestor_mask.contiguous(),
+        prefix_lens,
+        positions,
+        retrive_index,
+        retrive_next_token,
+        retrive_next_sibling,
+        batch_size,
+        num_nodes,
+    )
+    return positions, retrive_index, retrive_next_token, retrive_next_sibling
+
+
+def build_full_tree_mask(
+    *, ancestor_mask: torch.Tensor, prefix_lens_cpu: torch.Tensor
+) -> torch.Tensor:
+    """The flat bool mask the attention backends consume.
+
+    Per request: `N` rows of width `prefix + N`, the leading `prefix` columns all
+    True (every draft node sees the whole committed prefix) and the trailing block
+    the request's ancestor closure. Requests are concatenated, so the total is
+    `sum(prefix) * N + N**2 * bs` -- the same formula
+    `DFlashVerifyInput.generate_attn_arg_prefill` uses to size its padding.
+
+    Takes the prefix lengths on the host because the row widths are Python-level
+    loop bounds; passing the device copy would force a sync every step. These must
+    be the *committed* lengths, not the temporarily verify-extended ones.
+    """
+    batch_size, num_nodes, _ = ancestor_mask.shape
+    device = ancestor_mask.device
+    rows = []
+    for request, prefix_len in enumerate(prefix_lens_cpu.tolist()):
+        prefix = torch.ones(
+            (num_nodes, int(prefix_len)), dtype=torch.bool, device=device
+        )
+        rows.append(torch.cat([prefix, ancestor_mask[request]], dim=1).flatten())
+    return torch.cat(rows)

--- a/python/sglang/srt/speculative/dflash_tree.py
+++ b/python/sglang/srt/speculative/dflash_tree.py
@@ -13,7 +13,9 @@ Two different masks are involved and they must not be confused:
   per-node depth to produce absolute positions.
 - the **FULL_MASK**, a flat bool buffer, is what the attention backends consume.
   Its trailing `N x N` block per request *is* the QLEN mask, preceded by the
-  request's committed prefix columns.
+  request's committed prefix columns. It is written on device, straight into the
+  backend's own buffer, by `write_dflash_tree_full_mask` -- the row widths depend
+  on the committed prefix, and reading that on the host would cost a sync per step.
 
 Spelling: the sgl_kernel op schema says `retrive_*`. This module keeps that
 spelling on values that go straight into the op, matching the boundary
@@ -95,29 +97,3 @@ def build_dflash_tree_meta(
         num_nodes,
     )
     return positions, retrive_index, retrive_next_token, retrive_next_sibling
-
-
-def build_full_tree_mask(
-    *, ancestor_mask: torch.Tensor, prefix_lens_cpu: torch.Tensor
-) -> torch.Tensor:
-    """The flat bool mask the attention backends consume.
-
-    Per request: `N` rows of width `prefix + N`, the leading `prefix` columns all
-    True (every draft node sees the whole committed prefix) and the trailing block
-    the request's ancestor closure. Requests are concatenated, so the total is
-    `sum(prefix) * N + N**2 * bs` -- the same formula
-    `DFlashVerifyInput.generate_attn_arg_prefill` uses to size its padding.
-
-    Takes the prefix lengths on the host because the row widths are Python-level
-    loop bounds; passing the device copy would force a sync every step. These must
-    be the *committed* lengths, not the temporarily verify-extended ones.
-    """
-    batch_size, num_nodes, _ = ancestor_mask.shape
-    device = ancestor_mask.device
-    rows = []
-    for request, prefix_len in enumerate(prefix_lens_cpu.tolist()):
-        prefix = torch.ones(
-            (num_nodes, int(prefix_len)), dtype=torch.bool, device=device
-        )
-        rows.append(torch.cat([prefix, ancestor_mask[request]], dim=1).flatten())
-    return torch.cat(rows)

--- a/python/sglang/srt/speculative/dflash_tree.py
+++ b/python/sglang/srt/speculative/dflash_tree.py
@@ -1,26 +1,17 @@
-"""Verify metadata for a DFLASH beam tree.
+"""Build target-verify metadata for a DFLASH beam tree.
 
-The beam walk (`models/dflash.py::_beam_walk_torch` and its triton twin) emits the
-minimal representation of the tree: `node_tokens` and `node_parents`, both
-`[bs, num_nodes]`, in BFS order so that `node_parents[i] < i`. Target verify needs
-more than that, and this module derives all of it.
-
-Two different masks are involved and they must not be confused:
+Two masks are involved:
 
 - the **QLEN** mask, `[bs, N, N]` bool, is the ancestor closure over draft nodes
   alone. `reconstruct_indices_from_tree_mask` consumes exactly this; the committed
   prefix reaches it only through `prefix_lens`, which the kernel adds to the
   per-node depth to produce absolute positions.
 - the **FULL_MASK**, a flat bool buffer, is what the attention backends consume.
-  Its trailing `N x N` block per request *is* the QLEN mask, preceded by the
-  request's committed prefix columns. It is written on device, straight into the
-  backend's own buffer, by `write_dflash_tree_full_mask` -- the row widths depend
-  on the committed prefix, and reading that on the host would cost a sync per step.
+  Its trailing `N x N` block per request is the QLEN mask, preceded by the
+  request's committed-prefix columns.
 
-Spelling: the sgl_kernel op schema says `retrive_*`. This module keeps that
-spelling on values that go straight into the op, matching the boundary
-`eagle_utils.py::verify_tree_greedy_func` already draws, while
-`DFlashVerifyInput` keeps the correct `retrieve_*` on its fields.
+The sgl_kernel op schema spells its link arguments `retrive_*`; values passed to
+that op keep the spelling while `DFlashVerifyInput` uses `retrieve_*`.
 """
 
 from __future__ import annotations
@@ -30,17 +21,7 @@ from sgl_kernel.speculative import reconstruct_indices_from_tree_mask
 
 
 def build_ancestor_mask(*, node_parents: torch.Tensor, max_depth: int) -> torch.Tensor:
-    """`[bs, N, N]` bool ancestor closure, `mask[b, i, j] = j is an ancestor of i`.
-
-    The diagonal is set (a node counts as its own ancestor) and column 0 is set on
-    every row, because the root is an ancestor of everything.
-
-    Walks parent pointers `max_depth` times rather than scanning the `N` nodes in
-    order. `max_depth` is the deepest layer index -- `gamma = block_size - 1` -- so
-    the iteration count is independent of the beam width, and a width sweep does
-    not pay a growing number of kernel launches. Clamping a spent chain to node 0
-    is harmless precisely because the root bit is already set on every row.
-    """
+    """Return `[bs, N, N]` ancestor closure for BFS-ordered parent links."""
     batch_size, num_nodes = node_parents.shape
     device = node_parents.device
 
@@ -63,16 +44,7 @@ def build_ancestor_mask(*, node_parents: torch.Tensor, max_depth: int) -> torch.
 def build_dflash_tree_meta(
     *, ancestor_mask: torch.Tensor, prefix_lens: torch.Tensor
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-    """`(positions, retrive_index, retrive_next_token, retrive_next_sibling)`.
-
-    Derived from the mask rather than from `node_parents` directly, so a
-    mis-built mask shows up as links that disagree with the parents instead of
-    staying invisible until attention silently reads the wrong keys.
-
-    Returned in the kernel's own argument order. `positions` is flat `[bs * N]`;
-    the three link tensors are `[bs, N]`. All four are int64, which the CUDA
-    kernel requires -- it casts the pointers without checking.
-    """
+    """Derive kernel links and positions from an ancestor mask."""
     batch_size, num_nodes, _ = ancestor_mask.shape
     device = ancestor_mask.device
     if prefix_lens.dtype != torch.int64:
@@ -82,7 +54,6 @@ def build_dflash_tree_meta(
         )
 
     positions = torch.empty((batch_size * num_nodes,), dtype=torch.int64, device=device)
-    # -1 is the "no such link" sentinel; the kernel leaves absent links untouched.
     links = torch.full((3, batch_size, num_nodes), -1, dtype=torch.int64, device=device)
     retrive_index, retrive_next_token, retrive_next_sibling = links
 

--- a/python/sglang/srt/speculative/dflash_tree_verify.py
+++ b/python/sglang/srt/speculative/dflash_tree_verify.py
@@ -1,0 +1,216 @@
+"""The DFLASH decode steps that differ between chain verify and tree verify.
+
+Tree width 1 keeps the chain path in `DFlashWorkerV2.forward_batch_generation`
+byte-for-byte, so everything here runs only when the beam is wider -- or when
+`SGLANG_DFLASH_FORCE_TREE_VERIFY` routes width 1 through here, which is how the
+two paths are shown to agree (a width-1 beam *is* the chain).
+
+Stateless on purpose: the worker hands each step the values it needs and assigns
+the results back, so the fork points inside that long method stay readable as
+`if tree: x = f(...)`.
+
+Two width conventions meet here and must not be swapped:
+
+- `verify_width` (`N = 1 + (block_size - 1) * tree_width`) is the node count --
+  the verify forward's per-request token count, and the width of `candidates`,
+  `predict`, `cache_loc_2d` and the ancestor mask.
+- `block_size` is the longest root-to-leaf chain, hence the width of
+  `accept_index` and of everything derived from it (`out_tokens`, the scheduler's
+  output stride). The accepted run is a path, never wider than the tree is deep.
+"""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+
+from sglang.kernels.ops.speculative.eagle import fill_bonus_tokens_func
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.speculative.dflash_info import DFlashVerifyInput
+from sglang.srt.speculative.dflash_tree import (
+    build_ancestor_mask,
+    build_dflash_tree_meta,
+    build_full_tree_mask,
+)
+from sglang.srt.speculative.eagle_utils import verify_tree_greedy_func
+from sglang.srt.speculative.spec_utils import move_accept_tokens_to_target_kvcache
+
+
+class TreeAccept(msgspec.Struct):
+    """What the greedy tree accept produces, in the worker's own vocabulary.
+
+    `out_tokens` / `commit_lens` / `bonus_tokens` carry exactly what the chain
+    path's `_commit_accept` returns, so the shared tail (KV writeback, seq-len
+    advance, result assembly) does not have to branch. `accept_index` and
+    `predict` are additionally exposed because the tree needs them for the steps
+    a chain gets for free: hidden-state compaction, logprobs, mamba step index.
+    """
+
+    out_tokens: torch.Tensor
+    commit_lens: torch.Tensor
+    bonus_tokens: torch.Tensor
+    accept_index: torch.Tensor
+    predict: torch.Tensor
+
+
+def build_tree_verify_input(
+    *,
+    node_tokens: torch.Tensor,
+    node_parents: torch.Tensor,
+    block_size: int,
+    tree_width: int,
+    prefix_lens: torch.Tensor,
+    prefix_lens_cpu: torch.Tensor,
+) -> DFlashVerifyInput:
+    """The verify input for a beam tree: mask, tree links, depth-based positions.
+
+    `prefix_lens` must be the *committed* lengths on both sides. The device copy
+    feeds the kernel that turns per-node depth into an absolute position; the host
+    copy feeds the per-request row widths of the flat attention mask. Passing the
+    verify-extended lengths would shift every position by one block and widen
+    every mask row past what the backend allocated.
+    """
+    ancestor_mask = build_ancestor_mask(
+        node_parents=node_parents, max_depth=block_size - 1
+    )
+    positions, retrive_index, retrive_next_token, retrive_next_sibling = (
+        build_dflash_tree_meta(ancestor_mask=ancestor_mask, prefix_lens=prefix_lens)
+    )
+    return DFlashVerifyInput(
+        draft_token=node_tokens.reshape(-1),
+        positions=positions,
+        draft_token_num=int(node_parents.shape[1]),
+        topk=tree_width,
+        block_size=block_size,
+        custom_mask=build_full_tree_mask(
+            ancestor_mask=ancestor_mask, prefix_lens_cpu=prefix_lens_cpu
+        ),
+        retrieve_index=retrive_index,
+        retrieve_next_token=retrive_next_token,
+        retrieve_next_sibling=retrive_next_sibling,
+        capture_hidden_mode=CaptureHiddenMode.FULL,
+    )
+
+
+def accept_tree_greedy(
+    *,
+    verify_input: DFlashVerifyInput,
+    next_token_logits: torch.Tensor,
+    bs: int,
+) -> TreeAccept:
+    """Walk the tree greedily and lay the accepted path out like a chain.
+
+    Pure tensor work, so it is checkable against the chain accept without a model:
+    at width 1 the tree *is* the chain and the two must return the same tokens.
+    The KV that the accepted path implies is moved separately, by
+    `move_accepted_target_kv` -- keep the two adjacent at the call site.
+
+    `out_tokens` is gathered through `accept_index` rather than shifted left, which
+    is the same "drafts shifted by one, bonus last" run the chain produces:
+    `predict[node]` is the target's continuation *after* that node.
+    """
+    num_nodes = int(verify_input.draft_token_num)
+    device = next_token_logits.device
+
+    target_predict = torch.argmax(next_token_logits, dim=-1).view(bs, num_nodes)
+    # Zero-initialized, not empty: `compute_spec_logprobs` gathers through the whole
+    # accept_index including its -1 pad, and -1 indexes predict[-1] rather than
+    # raising. An uninitialized slot there is a garbage token id and the logprob
+    # gather walks off the vocabulary. Only the accepted prefix is ever read, so any
+    # in-range value would do; 0 is what EAGLE relies on for the same reason.
+    predict = torch.zeros((bs * num_nodes,), dtype=torch.int32, device=device)
+    # -1 marks "no node accepted at this depth"; the kernel fills the prefix only.
+    accept_index = torch.full(
+        (bs, verify_input.max_tree_depth), -1, dtype=torch.int32, device=device
+    )
+    num_correct_drafts = torch.empty((bs,), dtype=torch.int32, device=device)
+    verify_tree_greedy_func(
+        predicts=predict,  # mutable
+        accept_index=accept_index,  # mutable
+        accept_token_num=num_correct_drafts,  # mutable
+        candidates=verify_input.draft_token.view(bs, num_nodes),
+        retrieve_index=verify_input.retrieve_index,
+        retrieve_next_token=verify_input.retrieve_next_token,
+        retrieve_next_sibling=verify_input.retrieve_next_sibling,
+        target_predict=target_predict,
+        topk=verify_input.tree_topk,
+    )
+
+    # Padded entries clamp to node 0; they land past commit_lens and are never read.
+    out_tokens = predict[accept_index.to(torch.int64).clamp(min=0)]
+    commit_lens = num_correct_drafts + 1
+    bonus_tokens = torch.empty((bs,), dtype=torch.int32, device=device)
+    fill_bonus_tokens_func(
+        out_tokens,
+        commit_lens,
+        bonus_tokens,  # mutable
+        # Stride of out_tokens, i.e. accept_index's width, NOT the node count.
+        accept_index.shape[1],
+        bs,
+    )
+    return TreeAccept(
+        out_tokens=out_tokens,
+        commit_lens=commit_lens,
+        bonus_tokens=bonus_tokens,
+        accept_index=accept_index,
+        predict=predict,
+    )
+
+
+def move_accepted_target_kv(
+    *,
+    batch: ScheduleBatch,
+    accepted: TreeAccept,
+    token_to_kv_pool_allocator,
+) -> None:
+    """Copy the accepted nodes' target KV down onto the contiguous front slots.
+
+    The r-th accepted token is node `accept_index[i, r]`, but the next round reads
+    position `prefix + r`, which `req_to_token` maps to the r-th *slot*. Chain
+    verify has those coincide, which is why DFLASH has never needed this step; a
+    tree does not, and skipping it leaves the target reading a sibling's KV.
+    """
+    move_accept_tokens_to_target_kvcache(
+        batch,
+        accepted.accept_index,
+        accepted.commit_lens - 1,
+        token_to_kv_pool_allocator,
+    )
+
+
+def compact_hidden_to_commit_layout(
+    *,
+    target_hidden: torch.Tensor,
+    accept_index: torch.Tensor,
+    bs: int,
+    verify_width: int,
+) -> torch.Tensor:
+    """Move the accepted path's hidden rows to the front of each node block.
+
+    This is what lets the draft-KV writeback stay untouched: it commits row `r`
+    of request `i` into `cache_loc_2d[i, r]`, and after this gather row `r` holds
+    the node accepted at depth `r`. Without it the tree would write node `r`'s
+    features into depth `r`'s slot -- a silent mismatch that width 1 cannot show,
+    because there the accepted nodes already are the first rows.
+    """
+    from sglang.srt.speculative.eagle_worker_common import compact_accept_to_front
+
+    return compact_accept_to_front(
+        target_hidden, accept_index, bs, num_draft_tokens=verify_width
+    )
+
+
+def commit_positions(
+    *, prefix_lens: torch.Tensor, verify_width: int
+) -> torch.Tensor:
+    """Positions for the compacted commit layout, `[bs * verify_width]`.
+
+    Not the same tensor the verify forward used: there a node's position is
+    `prefix + depth(node)`, ordered by node. Here row `r` is whichever node was
+    accepted at depth `r`, so its position is `prefix + r` no matter which node it
+    was, and the layout is a plain chain again. Rows past the accepted run get
+    positions that are never committed.
+    """
+    offsets = torch.arange(verify_width, device=prefix_lens.device)
+    return (prefix_lens.unsqueeze(1) + offsets).reshape(-1)

--- a/python/sglang/srt/speculative/dflash_tree_verify.py
+++ b/python/sglang/srt/speculative/dflash_tree_verify.py
@@ -24,14 +24,15 @@ from __future__ import annotations
 import msgspec
 import torch
 
+from sglang.kernels.ops.speculative.dflash import write_dflash_tree_full_mask
 from sglang.kernels.ops.speculative.eagle import fill_bonus_tokens_func
+from sglang.srt.layers.attention.verify_mask import fill_verify_mask_indptr
 from sglang.srt.managers.schedule_batch import ScheduleBatch
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_tree import (
     build_ancestor_mask,
     build_dflash_tree_meta,
-    build_full_tree_mask,
 )
 from sglang.srt.speculative.eagle_utils import verify_tree_greedy_func
 from sglang.srt.speculative.spec_utils import move_accept_tokens_to_target_kvcache
@@ -61,15 +62,20 @@ def build_tree_verify_input(
     block_size: int,
     tree_width: int,
     prefix_lens: torch.Tensor,
-    prefix_lens_cpu: torch.Tensor,
+    mask_buffer: torch.Tensor,
+    mask_indptr: torch.Tensor,
 ) -> DFlashVerifyInput:
     """The verify input for a beam tree: mask, tree links, depth-based positions.
 
-    `prefix_lens` must be the *committed* lengths on both sides. The device copy
-    feeds the kernel that turns per-node depth into an absolute position; the host
-    copy feeds the per-request row widths of the flat attention mask. Passing the
-    verify-extended lengths would shift every position by one block and widen
-    every mask row past what the backend allocated.
+    `prefix_lens` must be the *committed* lengths: they turn per-node depth into an
+    absolute position and set the per-request row widths of the flat attention mask.
+    Passing the verify-extended lengths would shift every position by one block and
+    widen every mask row past what the backend allocated.
+
+    Everything here stays on device. `mask_buffer` is the backend's own verify-mask
+    buffer, so the mask is written where verify will read it, and `mask_indptr`
+    is scratch for the shared row-offset formula. The host never learns a committed
+    length, which is what keeps the decode step free of a device-to-host sync.
     """
     ancestor_mask = build_ancestor_mask(
         node_parents=node_parents, max_depth=block_size - 1
@@ -77,15 +83,25 @@ def build_tree_verify_input(
     positions, retrive_index, retrive_next_token, retrive_next_sibling = (
         build_dflash_tree_meta(ancestor_mask=ancestor_mask, prefix_lens=prefix_lens)
     )
+    num_nodes = int(node_parents.shape[1])
+    custom_mask = write_dflash_tree_full_mask(
+        ancestor_mask=ancestor_mask,
+        mask_indptr=fill_verify_mask_indptr(
+            mask_indptr=mask_indptr,
+            seq_lens=prefix_lens,
+            num_draft_tokens=num_nodes,
+            bs=int(node_parents.shape[0]),
+        ),
+        seq_lens=prefix_lens,
+        out=mask_buffer,
+    )
     return DFlashVerifyInput(
         draft_token=node_tokens.reshape(-1),
         positions=positions,
-        draft_token_num=int(node_parents.shape[1]),
+        draft_token_num=num_nodes,
         topk=tree_width,
         block_size=block_size,
-        custom_mask=build_full_tree_mask(
-            ancestor_mask=ancestor_mask, prefix_lens_cpu=prefix_lens_cpu
-        ),
+        custom_mask=custom_mask,
         retrieve_index=retrive_index,
         retrieve_next_token=retrive_next_token,
         retrieve_next_sibling=retrive_next_sibling,

--- a/python/sglang/srt/speculative/dflash_tree_verify.py
+++ b/python/sglang/srt/speculative/dflash_tree_verify.py
@@ -1,13 +1,6 @@
-"""The DFLASH decode steps that differ between chain verify and tree verify.
+"""Decode steps shared by DFLASH chain and tree verification.
 
-Tree width 1 keeps the chain path in `DFlashWorkerV2.forward_batch_generation`
-byte-for-byte, so everything here runs only when the beam is wider -- or when
-`SGLANG_DFLASH_FORCE_TREE_VERIFY` routes width 1 through here, which is how the
-two paths are shown to agree (a width-1 beam *is* the chain).
-
-Stateless on purpose: the worker hands each step the values it needs and assigns
-the results back, so the fork points inside that long method stay readable as
-`if tree: x = f(...)`.
+The helpers are stateless so the worker's branch points remain small.
 
 Two width conventions meet here and must not be swapped:
 
@@ -39,14 +32,7 @@ from sglang.srt.speculative.spec_utils import move_accept_tokens_to_target_kvcac
 
 
 class TreeAccept(msgspec.Struct):
-    """What the greedy tree accept produces, in the worker's own vocabulary.
-
-    `out_tokens` / `commit_lens` / `bonus_tokens` carry exactly what the chain
-    path's `_commit_accept` returns, so the shared tail (KV writeback, seq-len
-    advance, result assembly) does not have to branch. `accept_index` and
-    `predict` are additionally exposed because the tree needs them for the steps
-    a chain gets for free: hidden-state compaction, logprobs, mamba step index.
-    """
+    """Results of greedy tree acceptance."""
 
     out_tokens: torch.Tensor
     commit_lens: torch.Tensor
@@ -65,18 +51,7 @@ def build_tree_verify_input(
     mask_buffer: torch.Tensor,
     mask_indptr: torch.Tensor,
 ) -> DFlashVerifyInput:
-    """The verify input for a beam tree: mask, tree links, depth-based positions.
-
-    `prefix_lens` must be the *committed* lengths: they turn per-node depth into an
-    absolute position and set the per-request row widths of the flat attention mask.
-    Passing the verify-extended lengths would shift every position by one block and
-    widen every mask row past what the backend allocated.
-
-    Everything here stays on device. `mask_buffer` is the backend's own verify-mask
-    buffer, so the mask is written where verify will read it, and `mask_indptr`
-    is scratch for the shared row-offset formula. The host never learns a committed
-    length, which is what keeps the decode step free of a device-to-host sync.
-    """
+    """Build tree links, positions, and the device-side verify mask."""
     ancestor_mask = build_ancestor_mask(
         node_parents=node_parents, max_depth=block_size - 1
     )
@@ -115,36 +90,21 @@ def accept_tree_greedy(
     next_token_logits: torch.Tensor,
     bs: int,
 ) -> TreeAccept:
-    """Walk the tree greedily and lay the accepted path out like a chain.
-
-    Pure tensor work, so it is checkable against the chain accept without a model:
-    at width 1 the tree *is* the chain and the two must return the same tokens.
-    The KV that the accepted path implies is moved separately, by
-    `move_accepted_target_kv` -- keep the two adjacent at the call site.
-
-    `out_tokens` is gathered through `accept_index` rather than shifted left, which
-    is the same "drafts shifted by one, bonus last" run the chain produces:
-    `predict[node]` is the target's continuation *after* that node.
-    """
+    """Greedily accept a tree and lay the result out like a chain."""
     num_nodes = int(verify_input.draft_token_num)
     device = next_token_logits.device
 
     target_predict = torch.argmax(next_token_logits, dim=-1).view(bs, num_nodes)
-    # Zero-initialized, not empty: `compute_spec_logprobs` gathers through the whole
-    # accept_index including its -1 pad, and -1 indexes predict[-1] rather than
-    # raising. An uninitialized slot there is a garbage token id and the logprob
-    # gather walks off the vocabulary. Only the accepted prefix is ever read, so any
-    # in-range value would do; 0 is what EAGLE relies on for the same reason.
+    # Padded accept indices can still reach predict during logprob gathering.
     predict = torch.zeros((bs * num_nodes,), dtype=torch.int32, device=device)
-    # -1 marks "no node accepted at this depth"; the kernel fills the prefix only.
     accept_index = torch.full(
         (bs, verify_input.max_tree_depth), -1, dtype=torch.int32, device=device
     )
     num_correct_drafts = torch.empty((bs,), dtype=torch.int32, device=device)
     verify_tree_greedy_func(
-        predicts=predict,  # mutable
-        accept_index=accept_index,  # mutable
-        accept_token_num=num_correct_drafts,  # mutable
+        predicts=predict,
+        accept_index=accept_index,
+        accept_token_num=num_correct_drafts,
         candidates=verify_input.draft_token.view(bs, num_nodes),
         retrieve_index=verify_input.retrieve_index,
         retrieve_next_token=verify_input.retrieve_next_token,
@@ -153,15 +113,14 @@ def accept_tree_greedy(
         topk=verify_input.tree_topk,
     )
 
-    # Padded entries clamp to node 0; they land past commit_lens and are never read.
+    # Keep padded gathers in range.
     out_tokens = predict[accept_index.to(torch.int64).clamp(min=0)]
     commit_lens = num_correct_drafts + 1
     bonus_tokens = torch.empty((bs,), dtype=torch.int32, device=device)
     fill_bonus_tokens_func(
         out_tokens,
         commit_lens,
-        bonus_tokens,  # mutable
-        # Stride of out_tokens, i.e. accept_index's width, NOT the node count.
+        bonus_tokens,
         accept_index.shape[1],
         bs,
     )
@@ -180,13 +139,7 @@ def move_accepted_target_kv(
     accepted: TreeAccept,
     token_to_kv_pool_allocator,
 ) -> None:
-    """Copy the accepted nodes' target KV down onto the contiguous front slots.
-
-    The r-th accepted token is node `accept_index[i, r]`, but the next round reads
-    position `prefix + r`, which `req_to_token` maps to the r-th *slot*. Chain
-    verify has those coincide, which is why DFLASH has never needed this step; a
-    tree does not, and skipping it leaves the target reading a sibling's KV.
-    """
+    """Move accepted tree-node KV to the contiguous commit slots."""
     move_accept_tokens_to_target_kvcache(
         batch,
         accepted.accept_index,
@@ -202,14 +155,7 @@ def compact_hidden_to_commit_layout(
     bs: int,
     verify_width: int,
 ) -> torch.Tensor:
-    """Move the accepted path's hidden rows to the front of each node block.
-
-    This is what lets the draft-KV writeback stay untouched: it commits row `r`
-    of request `i` into `cache_loc_2d[i, r]`, and after this gather row `r` holds
-    the node accepted at depth `r`. Without it the tree would write node `r`'s
-    features into depth `r`'s slot -- a silent mismatch that width 1 cannot show,
-    because there the accepted nodes already are the first rows.
-    """
+    """Compact accepted hidden rows into the chain commit layout."""
     from sglang.srt.speculative.eagle_worker_common import compact_accept_to_front
 
     return compact_accept_to_front(
@@ -220,13 +166,6 @@ def compact_hidden_to_commit_layout(
 def commit_positions(
     *, prefix_lens: torch.Tensor, verify_width: int
 ) -> torch.Tensor:
-    """Positions for the compacted commit layout, `[bs * verify_width]`.
-
-    Not the same tensor the verify forward used: there a node's position is
-    `prefix + depth(node)`, ordered by node. Here row `r` is whichever node was
-    accepted at depth `r`, so its position is `prefix + r` no matter which node it
-    was, and the layout is a plain chain again. Rows past the accepted run get
-    positions that are never committed.
-    """
+    """Return positions for the compacted chain commit layout."""
     offsets = torch.arange(verify_width, device=prefix_lens.device)
     return (prefix_lens.unsqueeze(1) + offsets).reshape(-1)

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -196,6 +196,13 @@ def scale_kv_cell_size_per_token_for_dflash(
 
 
 def resolve_dflash_verify_mask_policy(attn_backend: Any) -> tuple[str, bool]:
+    """Resolve the target's full-attention backend and whether verify needs a tree mask.
+
+    A chain draft is causal, so backends with a built-in causal verify path skip the mask.
+    A tree is not: siblings must not see each other, which only the mask can express. The
+    backend does not need re-checking here -- `_validate_dflash_tree_admission` already
+    rejected tree width > 1 on any target backend that cannot consume one.
+    """
     backend = attn_backend
     for _ in range(4):
         full_backend = getattr(backend, "full_attn_backend", None)
@@ -203,6 +210,8 @@ def resolve_dflash_verify_mask_policy(attn_backend: Any) -> tuple[str, bool]:
             break
         backend = full_backend
     backend_name = type(backend).__name__
+    if dflash_tree_verify_active():
+        return backend_name, True
     return backend_name, (backend_name not in _DFLASH_VERIFY_SKIP_CUSTOM_MASK_BACKENDS)
 
 

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -1090,17 +1090,13 @@ def build_dflash_verify_target_probs(
 
 
 def dflash_tree_verify_active() -> bool:
-    """Whether DFLASH verifies a tree-shaped draft rather than a chain this run.
-
-    The one predicate both the request-admission check and `DFlashWorkerV2` read, so
-    a request cannot be admitted on the chain's terms and then verified as a tree.
-    Keyed on the DFLASH-only flag, so DSPARK (which shares the request validation
-    hook and carries its own `speculative_eagle_topk`) never trips it.
-    """
+    """Whether the current DFLASH run uses tree verification."""
     from sglang.srt.environ import envs
     from sglang.srt.runtime_context import get_spec
 
     tree_width = get_spec().speculative_dflash_tree_width
+    if get_spec().speculative_algorithm != "DFLASH":
+        return False
     return bool(
         (tree_width is not None and int(tree_width) > 1)
         or envs.SGLANG_DFLASH_FORCE_TREE_VERIFY.get()
@@ -1112,11 +1108,6 @@ def validate_dflash_request(req: Req, enable_overlap: bool) -> Optional[str]:
         return "DFLASH speculative decoding does not support return_hidden_states yet."
 
     if req.sampling_params.top_k > 1 and dflash_tree_verify_active():
-        # Greedy-only by construction: the beam walk that builds the tree emits no q,
-        # so no rejection-sampling accept can read it. Rejected rather than silently
-        # served greedily, which would misreport the acceptance length this feature is
-        # being measured on. `top_k > 1` is the per-request mirror of the batch-level
-        # `is_all_greedy`; temperature 0 normalizes to top_k == 1.
         return (
             "DFLASH tree drafting supports greedy decoding only (temperature 0), but "
             f"this request samples (top_k={req.sampling_params.top_k}). Send "

--- a/python/sglang/srt/speculative/dflash_utils.py
+++ b/python/sglang/srt/speculative/dflash_utils.py
@@ -1080,9 +1080,39 @@ def build_dflash_verify_target_probs(
     return target_probs.view(bs, draft_token_num, -1).contiguous()
 
 
+def dflash_tree_verify_active() -> bool:
+    """Whether DFLASH verifies a tree-shaped draft rather than a chain this run.
+
+    The one predicate both the request-admission check and `DFlashWorkerV2` read, so
+    a request cannot be admitted on the chain's terms and then verified as a tree.
+    Keyed on the DFLASH-only flag, so DSPARK (which shares the request validation
+    hook and carries its own `speculative_eagle_topk`) never trips it.
+    """
+    from sglang.srt.environ import envs
+    from sglang.srt.runtime_context import get_spec
+
+    tree_width = get_spec().speculative_dflash_tree_width
+    return bool(
+        (tree_width is not None and int(tree_width) > 1)
+        or envs.SGLANG_DFLASH_FORCE_TREE_VERIFY.get()
+    )
+
+
 def validate_dflash_request(req: Req, enable_overlap: bool) -> Optional[str]:
     if enable_overlap and req.return_hidden_states:
         return "DFLASH speculative decoding does not support return_hidden_states yet."
+
+    if req.sampling_params.top_k > 1 and dflash_tree_verify_active():
+        # Greedy-only by construction: the beam walk that builds the tree emits no q,
+        # so no rejection-sampling accept can read it. Rejected rather than silently
+        # served greedily, which would misreport the acceptance length this feature is
+        # being measured on. `top_k > 1` is the per-request mirror of the batch-level
+        # `is_all_greedy`; temperature 0 normalizes to top_k == 1.
+        return (
+            "DFLASH tree drafting supports greedy decoding only (temperature 0), but "
+            f"this request samples (top_k={req.sampling_params.top_k}). Send "
+            "temperature 0, or serve with --speculative-dflash-tree-width 1 to sample."
+        )
 
     return None
 

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -343,10 +343,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_config = parse_dflash_draft_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config
         )
-        # ServerArgs (_resolve_dflash_widths) resolves three widths and guarantees all are
-        # set: block_size is the draft block width and the longest root-to-leaf chain,
-        # verify_width = 1 + (block_size - 1) * tree_width is what the target verifies in one
-        # forward, and tree_width is the per-depth beam width (1 = today's chain).
         self.block_size = int(get_spec().speculative_dflash_block_size)
         self.tree_width = int(get_spec().speculative_eagle_topk)
         self.verify_width = int(get_spec().speculative_num_draft_tokens)
@@ -361,10 +357,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 draft_config.block_size,
             )
         self.draft_model.set_block_size(self.block_size)
-        # Tree verify is the path for a wider beam; width 1 keeps the chain path it has
-        # always used. The env override routes width 1 through the tree too, which is
-        # how the two are shown to agree -- a width-1 beam is the chain, so the tokens
-        # must match. It is a debug switch, not a serving mode.
+        # The env override also routes width 1 through tree verification.
         self._use_tree_verify = dflash_tree_verify_active()
         if self._use_tree_verify and self.selector is None:
             raise ValueError(
@@ -375,16 +368,13 @@ class DFlashWorkerV2(BaseSpecWorker):
                 "without SGLANG_DFLASH_FORCE_TREE_VERIFY."
             )
         if self._use_tree_verify and SIMULATE_ACC_LEN > 0:
-            # Both simulate modes rewrite chain-shaped accept bookkeeping in place; on a
-            # tree they would address nodes as if they were depths.
+            # Simulated acceptance uses chain-shaped bookkeeping.
             raise ValueError(
                 "SGLANG_SIMULATE_ACC_LEN cannot be combined with DFLASH tree verify "
                 f"(got {SIMULATE_ACC_LEN}): the forced accept path is a linear chain and "
                 "cannot address tree nodes. Unset it, or run chain verify."
             )
-        # The per-request output stride the scheduler slices results with. Stays block_size,
-        # not verify_width: the committed block is the accepted chain plus its bonus, which is
-        # at most block_size long however wide the tree is.
+        # Scheduler output remains the accepted chain plus its bonus.
         self.speculative_num_draft_tokens = int(self.block_size)
 
         self._mask_token = draft_config.mask_token
@@ -432,8 +422,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_block_end_buf: Optional[torch.Tensor] = None  # [cap_bs]
         self._selector_sample: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
         self._draft_seq_lens_cpu_buf: Optional[torch.Tensor] = None  # [cap_bs] on CPU
-        # Tree verify only: scratch for the flat mask's per-request row offsets, and
-        # the mask itself for the case where the backend owns no captured buffer.
+        # Tree verify mask scratch and fallback buffer.
         self._tree_mask_indptr: Optional[torch.Tensor] = None  # [cap_bs + 1]
         self._tree_mask_buf: Optional[torch.Tensor] = None
         self._draft_block_spec_info = make_draft_block_spec_info(
@@ -457,9 +446,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         supports_gpu_triton = is_cuda() or is_hip()
         self._use_triton_prepare_block = supports_gpu_triton
         self._use_triton_accept_bonus = supports_gpu_triton
-        # The legacy compact-rebuild path host-syncs twice per step (masked
-        # gather's implicit nonzero D2H + lengths.max().item()); keep it only
-        # for platforms without GPU triton.
+        # Keep the host-syncing path for platforms without GPU Triton.
         self._use_triton_compact_rebuild = supports_gpu_triton
         self._accept_bonus_buffer_cap: int = 0
         self._accept_bonus_buffer_slot: int = 0
@@ -471,15 +458,10 @@ class DFlashWorkerV2(BaseSpecWorker):
 
     @property
     def draft_worker(self):
-        # DFLASH drives the draft model through a plain TpModelWorker: the
-        # draft KV is materialized from target hidden states, so there is no
-        # EagleDraftWorkerBase draft/draft_extend split to wrap it in.
         return self._draft_worker
 
     @property
     def spec_v2_attn_backends(self) -> tuple:
-        # Every attn backend a spec_v2 forward touches; consumed by
-        # decide_needs_cpu_seq_lens to gate the seq_lens_cpu D2H.
         return (
             self._target_worker.model_runner.attn_backend,
             self.draft_model_runner.attn_backend,
@@ -491,11 +473,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         req_to_token_pool=None,
         token_to_kv_pool_allocator=None,
     ):
-        # Without draft windowing, the draft worker aliases the target
-        # request->token mapping and allocation state. With draft windowing
-        # enabled, the draft worker keeps a private compact req->token table
-        # over the same global KV index space, so radix-cache/prefix-hit KV
-        # remains reusable while draft attention sees only the recent window.
         self._draft_worker.alloc_memory_pool(
             memory_pool_config=memory_pool_config,
             req_to_token_pool=(
@@ -532,7 +509,6 @@ class DFlashWorkerV2(BaseSpecWorker):
                     available_mem,
                 )
         if capture_decode_cuda_graph:
-            # Must run before capture so the draft graph folds the head in.
             self._draft_sampler = self._maybe_build_draft_sampler()
             assert not (self._use_tree_verify and self._draft_sampler is not None), (
                 "DFLASH tree verify reads the selector's transition lattice, which the "
@@ -668,8 +644,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         if envs.SGLANG_DFLASH_EAGER_DRAFT_SAMPLER.get():
             return _eager("SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1")
         if self._use_tree_verify:
-            # The folded head samples one path; the beam needs the [bs, gamma, K, K]
-            # transition lattice, which only the eager selector returns.
             return _eager("tree verify")
         if self.block_size <= 1:
             return _eager("block_size<=1")
@@ -710,7 +684,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         tp_group = get_tp_group()
         if not hasattr(lm_head, "shard_indices"):
             if tp_group.world_size != 1:
-                # No shard metadata to recover per-rank vocab offsets from.
                 return _eager("tp>1 without shard_indices")
             num_org = int(lm_head.weight.shape[0])
             org_vocab_start = 0
@@ -866,31 +839,9 @@ class DFlashWorkerV2(BaseSpecWorker):
     def _tree_mask_buffer(
         self, *, bs: int, target_kv_bound: Optional[torch.Tensor]
     ) -> torch.Tensor:
-        """Where this step's flat verify mask goes.
-
-        Preferably the target backend's own buffer, so verify reads the mask in place
-        and nothing is copied. Two conditions before we may write into it: it has to be
-        a FULL_MASK buffer (a QLEN_ONLY one is `N * N` per request while this writer
-        needs `N * (prefix + N)`) and it has to be sized for this batch at this verify
-        width. Both are checked because neither implies the other and neither raises on
-        its own -- the kernel would write past the buffer and corrupt what follows.
-        `FlashInferAttnBackend` allocates no such buffer at all, and
-        `FlashAttentionBackend` allocates a QLEN_ONLY one at topk 1, so this is a live
-        path rather than a rare fallback.
-
-        Otherwise keep our own and grow it. `target_kv_bound` must be a host-side upper
-        bound on the *committed target* lengths (None = use the context-length bound):
-        over-sizing is harmless, since the row offsets are computed exactly on device
-        and the tail is never read, but under-sizing is an out-of-bounds write. A
-        draft-local view of the lengths does not qualify -- under a compact draft cache
-        it is the window size, which does not dominate the target prefix.
-        """
+        """Return a backend-owned or fallback full-mask buffer."""
         width = int(self.verify_width)
         model_runner = self._target_worker.model_runner
-        # The bound on any committed prefix, and therefore on the row width this writes.
-        # Read from the model rather than from `attn_backend.max_context_len` (which the
-        # hybrid wrapper leaves None when its child has none): what matters is what the
-        # prefixes can actually reach, not what the buffer was sized against.
         max_context_len = int(model_runner.model_config.context_len)
         verify_mask = model_runner.attn_backend.verify_mask
         if (
@@ -909,9 +860,6 @@ class DFlashWorkerV2(BaseSpecWorker):
         )
         held = 0 if self._tree_mask_buf is None else self._tree_mask_buf.numel()
         if held < need:
-            # Doubling, like the draft block buffers above: the bound grows by the accept
-            # length every step, so an exactly-sized allocation would reallocate a
-            # possibly-huge buffer on every step of the hot path.
             self._tree_mask_buf = torch.empty(
                 (max(need, 2 * held),), dtype=torch.bool, device=self.device
             )
@@ -1268,6 +1216,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             scores=scores,
             anchor_token_ids=anchor_token_ids,
             beam_width=self.tree_width,
+            max_num_nodes=self.verify_width,
         )
 
     def _selector_sampling_accept(
@@ -2014,11 +1963,25 @@ class DFlashWorkerV2(BaseSpecWorker):
             # path derives gamma from block_size and reads chain-shaped retrieve_* links, so
             # on a tree it miscomputes silently instead of failing. Callers that build
             # batches directly (tests, bench scripts) bypass request admission and land here.
-            raise ValueError(
-                "DFLASH tree verify supports greedy sampling only, but this batch has "
-                "non-greedy requests (top_k > 1). Serve with "
-                "--speculative-dflash-tree-width 1 for sampling, or send temperature 0."
-            )
+            #
+            # An already-rejected request still reaches this forward: set_finish_with_abort
+            # truncates origin_input_ids to one token to skip the long prefill rather than
+            # dropping the request, and leaves sampling_params non-greedy. Raising on it
+            # would turn a request-level 400 into SIGQUIT for the whole scheduler, so only
+            # a live non-greedy request should trigger this guard.
+            live_sampling = [
+                req
+                for req in batch.reqs
+                if req.sampling_params.top_k > 1
+                and req.to_finish is None
+                and not req.finished()
+            ]
+            if live_sampling:
+                raise ValueError(
+                    "DFLASH tree verify supports greedy sampling only, but this batch has "
+                    "non-greedy requests (top_k > 1). Serve with "
+                    "--speculative-dflash-tree-width 1 for sampling, or send temperature 0."
+                )
         if sampling_info is None or sampling_info.is_all_greedy:
             return
 

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -20,6 +20,7 @@ from sglang.srt.configs.hybrid_arch import mambaish_config
 from sglang.srt.distributed import get_tp_group
 from sglang.srt.distributed.parallel_state_wrapper import ParallelState
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.verify_mask import TreeMaskMode, tree_mask_numel
 from sglang.srt.layers.logits_processor import should_apply_lm_head_quant_method
 from sglang.srt.layers.logprob_processor import compute_spec_logprobs
 from sglang.srt.lora.layers import unwrap_lora_layer
@@ -431,6 +432,10 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_block_end_buf: Optional[torch.Tensor] = None  # [cap_bs]
         self._selector_sample: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
         self._draft_seq_lens_cpu_buf: Optional[torch.Tensor] = None  # [cap_bs] on CPU
+        # Tree verify only: scratch for the flat mask's per-request row offsets, and
+        # the mask itself for the case where the backend owns no captured buffer.
+        self._tree_mask_indptr: Optional[torch.Tensor] = None  # [cap_bs + 1]
+        self._tree_mask_buf: Optional[torch.Tensor] = None
         self._draft_block_spec_info = make_draft_block_spec_info(
             draft_token_num=int(self.block_size), device=self.device
         )
@@ -529,6 +534,10 @@ class DFlashWorkerV2(BaseSpecWorker):
         if capture_decode_cuda_graph:
             # Must run before capture so the draft graph folds the head in.
             self._draft_sampler = self._maybe_build_draft_sampler()
+            assert not (self._use_tree_verify and self._draft_sampler is not None), (
+                "DFLASH tree verify reads the selector's transition lattice, which the "
+                "folded draft head does not produce."
+            )
             if self._draft_sampler is not None:
                 self.draft_model_runner.capture_tail_hooks.append(
                     make_draft_sampler_capture_hook(self._draft_sampler)
@@ -658,6 +667,10 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         if envs.SGLANG_DFLASH_EAGER_DRAFT_SAMPLER.get():
             return _eager("SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1")
+        if self._use_tree_verify:
+            # The folded head samples one path; the beam needs the [bs, gamma, K, K]
+            # transition lattice, which only the eager selector returns.
+            return _eager("tree verify")
         if self.block_size <= 1:
             return _eager("block_size<=1")
         target_model = self._target_worker.model_runner.model
@@ -844,6 +857,65 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_seq_lens_cpu_buf = torch.empty(
             (new_cap,), dtype=torch.int32, device="cpu"
         )
+        # Zeros, not empty: `fill_verify_mask_indptr` writes [1 : bs + 1] and relies on
+        # entry 0 already being the offset of request 0, which is always 0.
+        self._tree_mask_indptr = torch.zeros(
+            (new_cap + 1,), dtype=torch.int64, device=device
+        )
+
+    def _tree_mask_buffer(
+        self, *, bs: int, target_kv_bound: Optional[torch.Tensor]
+    ) -> torch.Tensor:
+        """Where this step's flat verify mask goes.
+
+        Preferably the target backend's own buffer, so verify reads the mask in place
+        and nothing is copied. Two conditions before we may write into it: it has to be
+        a FULL_MASK buffer (a QLEN_ONLY one is `N * N` per request while this writer
+        needs `N * (prefix + N)`) and it has to be sized for this batch at this verify
+        width. Both are checked because neither implies the other and neither raises on
+        its own -- the kernel would write past the buffer and corrupt what follows.
+        `FlashInferAttnBackend` allocates no such buffer at all, and
+        `FlashAttentionBackend` allocates a QLEN_ONLY one at topk 1, so this is a live
+        path rather than a rare fallback.
+
+        Otherwise keep our own and grow it. `target_kv_bound` must be a host-side upper
+        bound on the *committed target* lengths (None = use the context-length bound):
+        over-sizing is harmless, since the row offsets are computed exactly on device
+        and the tail is never read, but under-sizing is an out-of-bounds write. A
+        draft-local view of the lengths does not qualify -- under a compact draft cache
+        it is the window size, which does not dominate the target prefix.
+        """
+        width = int(self.verify_width)
+        model_runner = self._target_worker.model_runner
+        # The bound on any committed prefix, and therefore on the row width this writes.
+        # Read from the model rather than from `attn_backend.max_context_len` (which the
+        # hybrid wrapper leaves None when its child has none): what matters is what the
+        # prefixes can actually reach, not what the buffer was sized against.
+        max_context_len = int(model_runner.model_config.context_len)
+        verify_mask = model_runner.attn_backend.verify_mask
+        if (
+            verify_mask is not None
+            and verify_mask.mode == TreeMaskMode.FULL_MASK
+            and verify_mask.fits(bs)
+            and verify_mask.buffer.numel()
+            >= tree_mask_numel(TreeMaskMode.FULL_MASK, bs, width, max_context_len)
+        ):
+            return verify_mask.buffer
+
+        need = (
+            width * bs * (max_context_len + width)
+            if target_kv_bound is None
+            else width * int((target_kv_bound[:bs] + width).sum())
+        )
+        held = 0 if self._tree_mask_buf is None else self._tree_mask_buf.numel()
+        if held < need:
+            # Doubling, like the draft block buffers above: the bound grows by the accept
+            # length every step, so an exactly-sized allocation would reallocate a
+            # possibly-huge buffer on every step of the hot path.
+            self._tree_mask_buf = torch.empty(
+                (max(need, 2 * held),), dtype=torch.bool, device=self.device
+            )
+        return self._tree_mask_buf
 
     def __getattr__(self, name):
         # Delegate anything not implemented yet to the target worker. Guard
@@ -2277,16 +2349,6 @@ class DFlashWorkerV2(BaseSpecWorker):
 
         folded = self._draft_sampler is not None and draft_out.can_run_graph
         if self._use_tree_verify:
-            if folded:
-                # The in-graph selector emits one sampled path plus its candidate/q
-                # rows, not the [bs, gamma, K, K] transition lattice the beam walks.
-                raise RuntimeError(
-                    "DFLASH tree verify needs the eager selector to reach the "
-                    "transition lattice, but the draft sampler is folded into the "
-                    "draft cuda graph. "
-                    "Launch with --disable-decode-cuda-graph (required anyway for tree "
-                    "width > 1) or SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1."
-                )
             node_tokens, node_parents = self._propose_selector_tree(
                 draft_logits_output=draft_logits_output,
                 bs=bs,
@@ -2329,22 +2391,27 @@ class DFlashWorkerV2(BaseSpecWorker):
         # --- 2) Target verify.
         if self._use_tree_verify:
             draft_tokens = node_tokens
-            # Committed lengths on both sides: the device copy becomes absolute
-            # positions, the host copy sets the mask's per-request row widths. Read
-            # before the verify-extended override further down.
+            # Committed lengths, device-side only: they become both the absolute
+            # positions and the mask's per-request row widths. Read before the
+            # verify-extended override further down.
             verify_input = build_tree_verify_input(
                 node_tokens=node_tokens,
                 node_parents=node_parents,
                 block_size=block_size,
                 tree_width=self.tree_width,
                 prefix_lens=prefix_lens,
-                prefix_lens_cpu=(
-                    batch.seq_lens_cpu
-                    if batch.seq_lens_cpu is not None
-                    # GPU-only backends keep no host copy; the tree path is eager, so
-                    # one sync per step here is cheaper than carrying a mirror buffer.
-                    else prefix_lens.to("cpu")
+                mask_buffer=self._tree_mask_buffer(
+                    bs=bs,
+                    # Sizing bound only, and it must dominate the committed target
+                    # lengths -- `seq_lens_cpu` above cannot be reused, since under a
+                    # compact draft cache it holds the draft-local window instead.
+                    target_kv_bound=(
+                        batch.seq_lens_cpu
+                        if batch.seq_lens_cpu is not None
+                        else draft_input.nxt_kv_lens_cpu
+                    ),
                 ),
+                mask_indptr=self._tree_mask_indptr[: bs + 1],
             )
             # Must stay ahead of the target verify launch below.
             grammar_tree = (

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -49,6 +49,13 @@ from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+from sglang.srt.speculative.dflash_tree_verify import (
+    accept_tree_greedy,
+    build_tree_verify_input,
+    commit_positions,
+    compact_hidden_to_commit_layout,
+    move_accepted_target_kv,
+)
 from sglang.srt.speculative.dflash_utils import (
     _get_or_create_chain_verify_buffers,
     apply_dflash_simulated_acceptance,
@@ -56,6 +63,7 @@ from sglang.srt.speculative.dflash_utils import (
     can_dflash_use_fused_qkv_proj,
     compute_dflash_correct_drafts_and_bonus,
     compute_dflash_sampling_correct_drafts_and_bonus,
+    dflash_tree_verify_active,
     is_dense_head_weight,
     is_dflash_sampling_verify_available,
     parse_dflash_draft_config,
@@ -77,6 +85,7 @@ from sglang.srt.speculative.spec_utils import (
     GrammarTree,
     assign_req_to_token_pool_func,
     build_grammar_vocab_mask,
+    verify_commit_step_indices,
 )
 from sglang.srt.utils import is_cuda, is_hip, is_npu
 
@@ -351,15 +360,26 @@ class DFlashWorkerV2(BaseSpecWorker):
                 draft_config.block_size,
             )
         self.draft_model.set_block_size(self.block_size)
-        if self.tree_width > 1:
-            # Phase A resolves the config surface only. Without the beam walk and the tree
-            # metadata the verify forward would still consume chain-shaped kernels, silently
-            # producing chain acceptance lengths under a tree-shaped config -- exactly the
-            # measurement error this feature exists to avoid.
-            raise NotImplementedError(
-                "--speculative-dflash-tree-width > 1 is not wired into the verify path yet "
-                f"(got {self.tree_width}). The config surface resolves, but tree drafting "
-                "still needs the beam walk and tree metadata; run with tree width 1."
+        # Tree verify is the path for a wider beam; width 1 keeps the chain path it has
+        # always used. The env override routes width 1 through the tree too, which is
+        # how the two are shown to agree -- a width-1 beam is the chain, so the tokens
+        # must match. It is a debug switch, not a serving mode.
+        self._use_tree_verify = dflash_tree_verify_active()
+        if self._use_tree_verify and self.selector is None:
+            raise ValueError(
+                "DFLASH tree verify needs a DFlash 2 draft checkpoint with a "
+                "candidate selector: the tree is a beam over the selector's transition "
+                "lattice, and this checkpoint has none. Run with "
+                "--speculative-dflash-tree-width 1 and "
+                "without SGLANG_DFLASH_FORCE_TREE_VERIFY."
+            )
+        if self._use_tree_verify and SIMULATE_ACC_LEN > 0:
+            # Both simulate modes rewrite chain-shaped accept bookkeeping in place; on a
+            # tree they would address nodes as if they were depths.
+            raise ValueError(
+                "SGLANG_SIMULATE_ACC_LEN cannot be combined with DFLASH tree verify "
+                f"(got {SIMULATE_ACC_LEN}): the forced accept path is a linear chain and "
+                "cannot address tree nodes. Unset it, or run chain verify."
             )
         # The per-request output stride the scheduler slices results with. Stays block_size,
         # not verify_width: the committed block is the accepted chain plus its bonus, which is
@@ -1146,6 +1166,38 @@ class DFlashWorkerV2(BaseSpecWorker):
             self._selector_sample = (candidate_ids, q_rows)
         return tokens.view(bs, num_pred)
 
+    def _propose_selector_tree(
+        self,
+        *,
+        draft_logits_output,
+        bs: int,
+        lm_head,
+        anchor_token_ids: torch.Tensor,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        """`(node_tokens, node_parents)`, both `[bs, verify_width]` in BFS order.
+
+        Same lattice `_propose_selector_block` builds; the beam expands it into a
+        fixed-width tree instead of collapsing it to one path. Greedy only -- the
+        beam walk carries no `q`, so there is nothing for a sampling accept to read.
+        """
+        draft_model = self.draft_model
+        if draft_model.lm_head is None:
+            draft_model.lm_head = lm_head
+
+        draft_hidden = draft_logits_output.hidden_states
+        if draft_hidden is None:
+            raise RuntimeError("DFLASH selector draft returned no hidden states.")
+        draft_hidden = draft_hidden.view(bs, int(self.block_size), -1)
+        candidate_ids, scores = _selector_lattice(
+            draft_model, draft_hidden[:, 1:, :], anchor_token_ids
+        )
+        return self.selector.beam_walk(
+            candidate_ids=candidate_ids,
+            scores=scores,
+            anchor_token_ids=anchor_token_ids,
+            beam_width=self.tree_width,
+        )
+
     def _selector_sampling_accept(
         self,
         *,
@@ -1677,18 +1729,45 @@ class DFlashWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         seq_lens_pre_verify: torch.Tensor,
         commit_lens: torch.Tensor,
+        accept_index: Optional[torch.Tensor] = None,
     ) -> None:
         """Commit Mamba intermediate states for accepted verify steps.
 
         During TARGET_VERIFY, Mamba kernels run with `disable_state_update=True` and
         cache per-step intermediate states. After acceptance, we need to commit the
         state corresponding to each request's last accepted step.
+
+        The step index is a *node* index into the verify window, which is what the
+        per-step cache is keyed by. On a chain that equals the accept length minus
+        one; on a tree it does not, so the tree branch resolves it through
+        `accept_index` (and likewise for the interval-crossing track step).
         """
         if not self._need_mamba_verify_commit:
             return
         attn_backend = self.target_worker.model_runner.attn_backend
 
+        if accept_index is not None:
+            last_correct_step_indices, mamba_steps_to_track = (
+                verify_commit_step_indices(
+                    batch=batch,
+                    accept_index=accept_index,
+                    accept_lens=commit_lens,
+                    draft_token_num=int(self.verify_width),
+                )
+            )
+            model_runner = self.target_worker.model_runner
+            if hasattr(attn_backend, "update_mamba_state_after_mtp_verify"):
+                attn_backend.update_mamba_state_after_mtp_verify(
+                    last_correct_step_indices=last_correct_step_indices,
+                    mamba_track_indices=batch.mamba_track_indices,
+                    mamba_steps_to_track=mamba_steps_to_track,
+                    model=model_runner.model,
+                    req_pool_indices=batch.req_pool_indices[: commit_lens.shape[0]],
+                )
+            return
+
         last_correct_step_indices = commit_lens.to(torch.int64) - 1
+
         mamba_steps_to_track = None
 
         if batch.mamba_track_indices is not None:
@@ -1857,6 +1936,17 @@ class DFlashWorkerV2(BaseSpecWorker):
 
     def _validate_phase1_sampling_support(self, batch: ScheduleBatch) -> None:
         sampling_info = batch.sampling_info
+        if self._use_tree_verify and not _is_all_greedy(sampling_info):
+            # Backstop for the per-request rejection in the scheduler: the accept dispatch
+            # below reaches `_selector_sampling_accept` before the greedy branch, and that
+            # path derives gamma from block_size and reads chain-shaped retrieve_* links, so
+            # on a tree it miscomputes silently instead of failing. Callers that build
+            # batches directly (tests, bench scripts) bypass request admission and land here.
+            raise ValueError(
+                "DFLASH tree verify supports greedy sampling only, but this batch has "
+                "non-greedy requests (top_k > 1). Serve with "
+                "--speculative-dflash-tree-width 1 for sampling, or send temperature 0."
+            )
         if sampling_info is None or sampling_info.is_all_greedy:
             return
 
@@ -2102,6 +2192,23 @@ class DFlashWorkerV2(BaseSpecWorker):
         positions = positions_2d.reshape(-1)
         verify_out_cache_loc = verify_out_cache_loc_2d.reshape(-1)
 
+        # The target verifies `verify_width` nodes, so it needs that many slots; the
+        # draft forward keeps writing the block-wide prefix of the same region (both
+        # come from req_to_token at [prefix, prefix + width), so the first block_size
+        # slots are the same ones the chain path would use).
+        verify_token_num = self.verify_width if self._use_tree_verify else block_size
+        tree_cache_loc_2d = None
+        if self._use_tree_verify:
+            tree_cache_loc_2d = assign_extend_cache_locs_func(
+                req_pool_indices=batch.req_pool_indices,
+                req_to_token=self.model_runner.req_to_token_pool.req_to_token,
+                start_offset=prefix_lens,
+                end_offset=prefix_lens + self.verify_width,
+                batch_size=bs,
+                draft_token_num=self.verify_width,
+                device=device,
+            ).view(bs, self.verify_width)
+
         seq_lens_cpu = self._draft_seq_lens_cpu_buf[:bs]
         if self.use_compact_draft_cache:
             # Rebuild the draft-local sliding-window view from committed target state.
@@ -2169,7 +2276,24 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_logits_output = draft_out.logits_output
 
         folded = self._draft_sampler is not None and draft_out.can_run_graph
-        if folded:
+        if self._use_tree_verify:
+            if folded:
+                # The in-graph selector emits one sampled path plus its candidate/q
+                # rows, not the [bs, gamma, K, K] transition lattice the beam walks.
+                raise RuntimeError(
+                    "DFLASH tree verify needs the eager selector to reach the "
+                    "transition lattice, but the draft sampler is folded into the "
+                    "draft cuda graph. "
+                    "Launch with --disable-decode-cuda-graph (required anyway for tree "
+                    "width > 1) or SGLANG_DFLASH_EAGER_DRAFT_SAMPLER=1."
+                )
+            node_tokens, node_parents = self._propose_selector_tree(
+                draft_logits_output=draft_logits_output,
+                bs=bs,
+                lm_head=lm_head,
+                anchor_token_ids=block_ids[:, 0],
+            )
+        elif folded:
             draft_next = self._draft_sampler.out[
                 : bs * (int(self.block_size) - 1)
             ].view(bs, int(self.block_size) - 1)
@@ -2202,31 +2326,67 @@ class DFlashWorkerV2(BaseSpecWorker):
                 lm_head=lm_head,
             ).view(bs, int(self.block_size) - 1)
 
-        draft_tokens = self._draft_block_tokens_buf[:bs]
-        draft_tokens[:, 0].copy_(block_ids[:, 0])
-        draft_tokens[:, 1:].copy_(draft_next)
-
-        # Must stay ahead of the target verify launch below.
-        grammar_tree = (
-            GrammarTree.from_linear_chain(draft_tokens) if batch.has_grammar else None
-        )
-
         # --- 2) Target verify.
-        # TARGET_VERIFY uses standard causal masking; custom masks are unnecessary here.
-        custom_mask = None
+        if self._use_tree_verify:
+            draft_tokens = node_tokens
+            # Committed lengths on both sides: the device copy becomes absolute
+            # positions, the host copy sets the mask's per-request row widths. Read
+            # before the verify-extended override further down.
+            verify_input = build_tree_verify_input(
+                node_tokens=node_tokens,
+                node_parents=node_parents,
+                block_size=block_size,
+                tree_width=self.tree_width,
+                prefix_lens=prefix_lens,
+                prefix_lens_cpu=(
+                    batch.seq_lens_cpu
+                    if batch.seq_lens_cpu is not None
+                    # GPU-only backends keep no host copy; the tree path is eager, so
+                    # one sync per step here is cheaper than carrying a mirror buffer.
+                    else prefix_lens.to("cpu")
+                ),
+            )
+            # Must stay ahead of the target verify launch below.
+            grammar_tree = (
+                GrammarTree.from_device(
+                    verify_input.retrieve_next_token,
+                    verify_input.retrieve_next_sibling,
+                    verify_input.draft_token.view(bs, verify_token_num),
+                )
+                if batch.has_grammar
+                else None
+            )
+        else:
+            draft_tokens = self._draft_block_tokens_buf[:bs]
+            draft_tokens[:, 0].copy_(block_ids[:, 0])
+            draft_tokens[:, 1:].copy_(draft_next)
 
-        verify_input_ids = draft_tokens.reshape(-1)
-        verify_input = DFlashVerifyInput(
-            draft_token=verify_input_ids,
-            positions=positions,
-            draft_token_num=int(self.block_size),
-            topk=self.tree_width,
-            block_size=int(self.block_size),
-            custom_mask=custom_mask,
-            capture_hidden_mode=CaptureHiddenMode.FULL,
+            # Must stay ahead of the target verify launch below.
+            grammar_tree = (
+                GrammarTree.from_linear_chain(draft_tokens)
+                if batch.has_grammar
+                else None
+            )
+
+            # TARGET_VERIFY uses standard causal masking; custom masks are unnecessary.
+            custom_mask = None
+
+            verify_input_ids = draft_tokens.reshape(-1)
+            verify_input = DFlashVerifyInput(
+                draft_token=verify_input_ids,
+                positions=positions,
+                draft_token_num=int(self.block_size),
+                topk=self.tree_width,
+                block_size=int(self.block_size),
+                custom_mask=custom_mask,
+                capture_hidden_mode=CaptureHiddenMode.FULL,
+            )
+
+        batch.out_cache_loc = (
+            tree_cache_loc_2d.reshape(-1)
+            if self._use_tree_verify
+            else verify_out_cache_loc
         )
-
-        batch.out_cache_loc = verify_out_cache_loc
         sampling_info = batch.sampling_info
 
         seq_lens_pre_verify = (
@@ -2235,8 +2395,8 @@ class DFlashWorkerV2(BaseSpecWorker):
         seq_lens_cpu_backup = batch.seq_lens_cpu
         seq_lens_sum_backup = batch.seq_lens_sum
         if seq_lens_cpu_backup is not None:
-            # Verify host bound = committed prefix + one verify block (matches draft).
-            verify_host_seq_lens = seq_lens_cpu_backup + block_size
+            # Verify host bound = committed prefix + the verify window (matches draft).
+            verify_host_seq_lens = seq_lens_cpu_backup + verify_token_num
             batch.seq_lens_cpu = verify_host_seq_lens
             batch.seq_lens_sum = int(verify_host_seq_lens.sum())
         elif draft_input.nxt_kv_lens_cpu is not None:
@@ -2272,7 +2432,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             apply_dflash_verify_logits_adjustments(
                 next_token_logits=logits_output.next_token_logits,
                 sampling_info=sampling_info,
-                draft_token_num=int(self.block_size),
+                draft_token_num=verify_token_num,
             )
 
         # Constrain every chain position before accept picks from it.
@@ -2280,21 +2440,40 @@ class DFlashWorkerV2(BaseSpecWorker):
             grammar_mask.apply(logits_output.next_token_logits)
 
         candidates = draft_tokens
-        (
-            accept_len,
-            commit_lens,
-            bonus,
-            out_tokens,
-            new_seq_lens,
-            target_predict,
-        ) = self._accept_block(
-            candidates=candidates,
-            next_token_logits=logits_output.next_token_logits,
-            sampling_info=sampling_info,
-            draft_input=draft_input,
-            prefix_lens=prefix_lens,
-            bs=bs,
-        )
+        tree_accept = None
+        if self._use_tree_verify:
+            tree_accept = accept_tree_greedy(
+                verify_input=verify_input,
+                next_token_logits=logits_output.next_token_logits,
+                bs=bs,
+            )
+            move_accepted_target_kv(
+                batch=batch,
+                accepted=tree_accept,
+                token_to_kv_pool_allocator=self.model_runner.token_to_kv_pool_allocator,
+            )
+            out_tokens = tree_accept.out_tokens
+            commit_lens = tree_accept.commit_lens
+            bonus = tree_accept.bonus_tokens
+            accept_len = commit_lens - 1
+            new_seq_lens = None
+            target_predict = None
+        else:
+            (
+                accept_len,
+                commit_lens,
+                bonus,
+                out_tokens,
+                new_seq_lens,
+                target_predict,
+            ) = self._accept_block(
+                candidates=candidates,
+                next_token_logits=logits_output.next_token_logits,
+                sampling_info=sampling_info,
+                draft_input=draft_input,
+                prefix_lens=prefix_lens,
+                bs=bs,
+            )
 
         if SIMULATE_ACC_LEN > 0:
             if SIMULATE_ACC_TOKEN_MODE not in ("fixed", "real-draft-token"):
@@ -2325,12 +2504,22 @@ class DFlashWorkerV2(BaseSpecWorker):
             new_seq_lens = None
 
         if batch.return_logprob:
-            compute_spec_logprobs(
-                batch,
-                logits_output,
-                out_tokens.reshape(-1),
-                chain_stride=block_size,
-            )
+            if tree_accept is not None:
+                # The accepted run is scattered across nodes, so the chain branch's
+                # identity gather does not hold; index the logits by accept_index.
+                compute_spec_logprobs(
+                    batch,
+                    logits_output,
+                    tree_accept.predict,
+                    accept_index=tree_accept.accept_index,
+                )
+            else:
+                compute_spec_logprobs(
+                    batch,
+                    logits_output,
+                    out_tokens.reshape(-1),
+                    chain_stride=block_size,
+                )
 
         if self._need_mamba_verify_commit:
             assert seq_lens_pre_verify is not None
@@ -2338,6 +2527,9 @@ class DFlashWorkerV2(BaseSpecWorker):
                 batch=batch,
                 seq_lens_pre_verify=seq_lens_pre_verify,
                 commit_lens=commit_lens,
+                accept_index=(
+                    tree_accept.accept_index if tree_accept is not None else None
+                ),
             )
 
         if new_seq_lens is None:
@@ -2351,13 +2543,32 @@ class DFlashWorkerV2(BaseSpecWorker):
             raise RuntimeError(
                 "DFLASH verify requires target hidden states, but got None."
             )
-        hidden = hidden.view(bs, int(self.block_size), -1)
+        if tree_accept is not None:
+            # Row r of each request becomes the node accepted at depth r, which is what
+            # makes the prefix-valid write below correct without touching it: it commits
+            # row r into cache_loc_2d[i, r], the slot req_to_token maps position
+            # prefix + r to. Positions follow the same compacted layout, so they are the
+            # plain chain again rather than the per-node depths verify ran with.
+            hidden = compact_hidden_to_commit_layout(
+                target_hidden=hidden,
+                accept_index=tree_accept.accept_index,
+                bs=bs,
+                verify_width=verify_token_num,
+            )
+            commit_cache_loc_2d = tree_cache_loc_2d
+            commit_positions_flat = commit_positions(
+                prefix_lens=prefix_lens, verify_width=verify_token_num
+            )
+        else:
+            commit_cache_loc_2d = verify_out_cache_loc_2d
+            commit_positions_flat = positions
+        hidden = hidden.view(bs, verify_token_num, -1)
 
         self._append_target_hidden_to_draft_kv_by_loc(
             target_hidden=hidden.reshape(-1, hidden.shape[-1]),
-            cache_loc=verify_out_cache_loc,
-            cache_loc_2d=verify_out_cache_loc_2d,
-            positions=positions,
+            cache_loc=commit_cache_loc_2d.reshape(-1),
+            cache_loc_2d=commit_cache_loc_2d,
+            positions=commit_positions_flat,
             commit_lens=commit_lens,
         )
 

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -333,23 +333,37 @@ class DFlashWorkerV2(BaseSpecWorker):
         draft_config = parse_dflash_draft_config(
             draft_hf_config=self.draft_model_runner.model_config.hf_config
         )
-        if get_spec().speculative_num_draft_tokens is None:
-            # Should not happen (ServerArgs should have inferred it), but keep a fallback.
-            self.block_size = int(draft_config.resolve_block_size(default=16))
-        else:
-            self.block_size = int(get_spec().speculative_num_draft_tokens)
-            model_block_size = draft_config.block_size
-            if model_block_size is None:
-                model_block_size = getattr(self.draft_model, "block_size", None)
-            if model_block_size is not None and int(model_block_size) != int(
-                self.block_size
-            ):
-                logger.warning(
-                    "DFLASH block size mismatch: using speculative_num_draft_tokens=%s but draft config block_size=%s.",
-                    self.block_size,
-                    model_block_size,
-                )
+        # ServerArgs (_resolve_dflash_widths) resolves three widths and guarantees all are
+        # set: block_size is the draft block width and the longest root-to-leaf chain,
+        # verify_width = 1 + (block_size - 1) * tree_width is what the target verifies in one
+        # forward, and tree_width is the per-depth beam width (1 = today's chain).
+        self.block_size = int(get_spec().speculative_dflash_block_size)
+        self.tree_width = int(get_spec().speculative_eagle_topk)
+        self.verify_width = int(get_spec().speculative_num_draft_tokens)
+        if (
+            draft_config.block_size is not None
+            and int(draft_config.block_size) != self.block_size
+        ):
+            logger.warning(
+                "DFLASH block size mismatch: using speculative_dflash_block_size=%s but draft "
+                "config block_size=%s.",
+                self.block_size,
+                draft_config.block_size,
+            )
         self.draft_model.set_block_size(self.block_size)
+        if self.tree_width > 1:
+            # Phase A resolves the config surface only. Without the beam walk and the tree
+            # metadata the verify forward would still consume chain-shaped kernels, silently
+            # producing chain acceptance lengths under a tree-shaped config -- exactly the
+            # measurement error this feature exists to avoid.
+            raise NotImplementedError(
+                "--speculative-dflash-tree-width > 1 is not wired into the verify path yet "
+                f"(got {self.tree_width}). The config surface resolves, but tree drafting "
+                "still needs the beam walk and tree metadata; run with tree width 1."
+            )
+        # The per-request output stride the scheduler slices results with. Stays block_size,
+        # not verify_width: the committed block is the accepted chain plus its bonus, which is
+        # at most block_size long however wide the tree is.
         self.speculative_num_draft_tokens = int(self.block_size)
 
         self._mask_token = draft_config.mask_token
@@ -2206,6 +2220,8 @@ class DFlashWorkerV2(BaseSpecWorker):
             draft_token=verify_input_ids,
             positions=positions,
             draft_token_num=int(self.block_size),
+            topk=self.tree_width,
+            block_size=int(self.block_size),
             custom_mask=custom_mask,
             capture_hidden_mode=CaptureHiddenMode.FULL,
         )

--- a/python/sglang/srt/speculative/draft_worker_common.py
+++ b/python/sglang/srt/speculative/draft_worker_common.py
@@ -130,8 +130,7 @@ def make_draft_block_spec_info(
         draft_token=torch.empty((0,), dtype=torch.long, device=device),
         positions=torch.empty((0,), dtype=torch.int64, device=device),
         draft_token_num=int(draft_token_num),
-        # Draft-side shape placeholder: the draft forward is always the block-wide chain,
-        # never the tree, whatever the verify-side beam width is.
+        # Draft forward remains a block-wide chain.
         topk=1,
         custom_mask=None,
         capture_hidden_mode=CaptureHiddenMode.NULL,

--- a/python/sglang/srt/speculative/draft_worker_common.py
+++ b/python/sglang/srt/speculative/draft_worker_common.py
@@ -130,6 +130,9 @@ def make_draft_block_spec_info(
         draft_token=torch.empty((0,), dtype=torch.long, device=device),
         positions=torch.empty((0,), dtype=torch.int64, device=device),
         draft_token_num=int(draft_token_num),
+        # Draft-side shape placeholder: the draft forward is always the block-wide chain,
+        # never the tree, whatever the verify-side beam width is.
+        topk=1,
         custom_mask=None,
         capture_hidden_mode=CaptureHiddenMode.NULL,
     )

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -211,8 +211,7 @@ class TargetVerifyExecutor:
                 (num_dummy_tokens,), dtype=torch.int64, device=device
             ),
             draft_token_num=self.verify_num_draft_tokens,
-            # DSPARK verify is always the linear gamma+1 chain (it asserts eagle_topk in
-            # {None, 1}); only DFLASH's selector tree widens this.
+            # DSPARK verify is always a chain.
             topk=1,
             custom_mask=None,
             capture_hidden_mode=CaptureHiddenMode.FULL,
@@ -260,7 +259,7 @@ class TargetVerifyExecutor:
             draft_token=verify_ids_2d.reshape(-1),
             positions=positions_2d.reshape(-1),
             draft_token_num=verify_w,
-            # DSPARK verify is always the linear gamma+1 chain; see the idle-dummy note above.
+            # DSPARK verify is always a chain.
             topk=1,
             custom_mask=None,
             capture_hidden_mode=CaptureHiddenMode.FULL,
@@ -374,7 +373,7 @@ class TargetVerifyExecutor:
             draft_token=ragged_window.verify_ids,
             positions=ragged_window.positions,
             draft_token_num=self.verify_num_draft_tokens,
-            # DSPARK verify is always the linear gamma+1 chain; see the idle-dummy note above.
+            # DSPARK verify is always a chain.
             topk=1,
             custom_mask=None,
             capture_hidden_mode=CaptureHiddenMode.FULL,

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -211,6 +211,9 @@ class TargetVerifyExecutor:
                 (num_dummy_tokens,), dtype=torch.int64, device=device
             ),
             draft_token_num=self.verify_num_draft_tokens,
+            # DSPARK verify is always the linear gamma+1 chain (it asserts eagle_topk in
+            # {None, 1}); only DFLASH's selector tree widens this.
+            topk=1,
             custom_mask=None,
             capture_hidden_mode=CaptureHiddenMode.FULL,
             ragged_verify_layout=idle_layout,
@@ -257,6 +260,8 @@ class TargetVerifyExecutor:
             draft_token=verify_ids_2d.reshape(-1),
             positions=positions_2d.reshape(-1),
             draft_token_num=verify_w,
+            # DSPARK verify is always the linear gamma+1 chain; see the idle-dummy note above.
+            topk=1,
             custom_mask=None,
             capture_hidden_mode=CaptureHiddenMode.FULL,
             live_seq_lens_cpu=batch.seq_lens_cpu,
@@ -369,6 +374,8 @@ class TargetVerifyExecutor:
             draft_token=ragged_window.verify_ids,
             positions=ragged_window.positions,
             draft_token_num=self.verify_num_draft_tokens,
+            # DSPARK verify is always the linear gamma+1 chain; see the idle-dummy note above.
+            topk=1,
             custom_mask=None,
             capture_hidden_mode=CaptureHiddenMode.FULL,
             ragged_verify_layout=layout,

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -422,11 +422,11 @@ def _finalize_accept_tree_path(
     move_accept_tokens_to_target_kvcache(
         batch, accept_index, accept_lens - 1, token_to_kv_pool_allocator
     )
-    predict = _compact_accept_to_front(
+    predict = compact_accept_to_front(
         predict, accept_index, bs, num_draft_tokens=num_draft_tokens
     )
     if logits_output.hidden_states is not None:
-        logits_output.hidden_states = _compact_accept_to_front(
+        logits_output.hidden_states = compact_accept_to_front(
             logits_output.hidden_states,
             accept_index,
             bs,
@@ -435,7 +435,7 @@ def _finalize_accept_tree_path(
     return predict
 
 
-def _compact_accept_to_front(
+def compact_accept_to_front(
     x: torch.Tensor,
     accept_index: torch.Tensor,
     bs: int,

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -283,11 +283,7 @@ class SpeculativeAlgorithm(Enum):
         if self.is_dspark() and is_draft_worker:
             return num_draft_tokens - 1
         if self.is_dflash() and is_draft_worker:
-            # DFLASH drafts one block-wide chain however wide the verify tree is: the beam
-            # expands the draft's transition lattice, it does not widen the draft forward. So
-            # the draft worker's fixed-length forward stays block_size, while
-            # `num_draft_tokens` (the target's verify width) grows to
-            # 1 + (block_size - 1) * tree_width.
+            # Draft forward width stays block_size; verify width may be larger.
             return int(get_spec_config().speculative_dflash_block_size)
         return num_draft_tokens
 
@@ -494,8 +490,7 @@ def create_dummy_verify_input(
             draft_token=None,
             positions=None,
             draft_token_num=spec.speculative_num_draft_tokens,
-            # Must mirror the live verify input: the GDN backend picks its tree kernel from
-            # topk, so a dummy pinned to 1 while server_args says W would diverge silently.
+            # Match live topk so graph capture selects the same verify kernel.
             topk=spec.speculative_eagle_topk or 1,
             block_size=spec.speculative_dflash_block_size,
             custom_mask=None,

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -282,6 +282,13 @@ class SpeculativeAlgorithm(Enum):
         # Here, we expose this interface to allow the other use cases.
         if self.is_dspark() and is_draft_worker:
             return num_draft_tokens - 1
+        if self.is_dflash() and is_draft_worker:
+            # DFLASH drafts one block-wide chain however wide the verify tree is: the beam
+            # expands the draft's transition lattice, it does not widen the draft forward. So
+            # the draft worker's fixed-length forward stays block_size, while
+            # `num_draft_tokens` (the target's verify width) grows to
+            # 1 + (block_size - 1) * tree_width.
+            return int(get_spec_config().speculative_dflash_block_size)
         return num_draft_tokens
 
     def get_num_tokens_per_bs_for_target_verify(
@@ -487,6 +494,10 @@ def create_dummy_verify_input(
             draft_token=None,
             positions=None,
             draft_token_num=spec.speculative_num_draft_tokens,
+            # Must mirror the live verify input: the GDN backend picks its tree kernel from
+            # topk, so a dummy pinned to 1 while server_args says W would diverge silently.
+            topk=spec.speculative_eagle_topk or 1,
+            block_size=spec.speculative_dflash_block_size,
             custom_mask=None,
             capture_hidden_mode=(
                 CaptureHiddenMode.NULL if is_draft_worker else CaptureHiddenMode.FULL

--- a/python/sglang/srt/speculative/spec_utils.py
+++ b/python/sglang/srt/speculative/spec_utils.py
@@ -793,7 +793,7 @@ def prepare_mamba_track_for_verify(batch: ScheduleBatch) -> None:
     batch.mamba_track_seqlens = None
 
 
-def _verify_commit_step_indices(
+def verify_commit_step_indices(
     *,
     batch: ScheduleBatch,
     accept_index: torch.Tensor,
@@ -887,7 +887,7 @@ def commit_mamba_states_after_verify(
 
         spec_state = req_pool.get_speculative_mamba2_params_all_layers()
         state_batch_indices = req_pool.get_mamba_indices(batch.req_pool_indices)
-        last_correct_step_indices, mamba_steps_to_track = _verify_commit_step_indices(
+        last_correct_step_indices, mamba_steps_to_track = verify_commit_step_indices(
             batch=batch,
             accept_index=accept_index,
             accept_lens=accept_lens,
@@ -923,7 +923,7 @@ def commit_mamba_states_after_verify(
         bs = accept_lens.shape[0]
         state_batch_indices = req_pool.get_mamba_indices(batch.req_pool_indices)
         replay_indices = batch.req_pool_indices
-        last_correct_step_indices, mamba_steps_to_track = _verify_commit_step_indices(
+        last_correct_step_indices, mamba_steps_to_track = verify_commit_step_indices(
             batch=batch,
             accept_index=accept_index,
             accept_lens=accept_lens,
@@ -1044,7 +1044,7 @@ def commit_mamba_states_after_verify(
     bs = accept_lens.shape[0]
     # `accept_lens` already includes the bonus token (drafts + 1 per req).
     if not batch.forward_mode.is_idle() and accept_index.numel() > 0:
-        last_correct_step_indices, mamba_steps_to_track = _verify_commit_step_indices(
+        last_correct_step_indices, mamba_steps_to_track = verify_commit_step_indices(
             batch=batch,
             accept_index=accept_index,
             accept_lens=accept_lens,

--- a/test/manual/spec/bench_dflash_beam_walk_agreement.py
+++ b/test/manual/spec/bench_dflash_beam_walk_agreement.py
@@ -1,0 +1,69 @@
+"""Where the triton beam walk stops agreeing with the torch reference.
+
+The CI test (`test/registered/unit/spec/test_dflash_logits.py`) asserts elementwise
+equality on well-separated scores, which is the only regime where equality is a
+legitimate claim: the two implementations normalize with different reduction orders,
+so once the gaps in the flattened pool approach fp32 noise either one may pick a
+different node, and one different pick makes every deeper depth diverge.
+
+This script measures where that boundary sits. Run it after touching either
+implementation; it asserts nothing, it prints a table.
+
+    python3 test/manual/spec/bench_dflash_beam_walk_agreement.py
+"""
+
+import torch
+
+from sglang.kernels.ops.speculative.dflash import selector_beam_walk_triton
+from sglang.srt.models.dflash import _beam_walk_torch
+
+SLOTS = 7
+TOP_K = 16
+BATCH = 128
+SEEDS = 10
+WIDTHS = (2, 4, 8)
+# randn * 3 is the order of magnitude a trained selector's lattice actually spans;
+# the smaller scales exist to locate the failure boundary, not to model anything.
+SCALES = (3.0, 1e-2, 1e-4, 1e-6)
+
+
+def diverging_rows(*, scale: float, seed: int, beam_width: int) -> int:
+    generator = torch.Generator().manual_seed(seed)
+    scores = torch.randn(BATCH, SLOTS, TOP_K, TOP_K, generator=generator) * scale
+    candidate_ids = torch.randint(0, 5000, (BATCH, SLOTS, TOP_K), generator=generator)
+    anchor = torch.randint(0, 5000, (BATCH,), generator=generator)
+
+    expected = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=anchor,
+        beam_width=beam_width,
+    )
+    actual = selector_beam_walk_triton(
+        candidate_ids=candidate_ids.cuda(),
+        scores=scores.cuda(),
+        anchor_token_ids=anchor.cuda(),
+        beam_width=beam_width,
+    )
+    differs = (actual[0].cpu() != expected[0]).any(dim=1)
+    differs |= (actual[1].cpu() != expected[1]).any(dim=1)
+    return int(differs.sum())
+
+
+def main() -> None:
+    if not torch.cuda.is_available():
+        raise SystemExit("needs a GPU")
+    print(f"{'score scale':>12}  {'rows':>6}  {'diverging':>9}  {'share':>7}")
+    for scale in SCALES:
+        rows = diverged = 0
+        for seed in range(SEEDS):
+            for beam_width in WIDTHS:
+                diverged += diverging_rows(
+                    scale=scale, seed=seed, beam_width=beam_width
+                )
+                rows += BATCH
+        print(f"{scale:>12g}  {rows:>6}  {diverged:>9}  {100 * diverged / rows:>6.2f}%")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/spec/compare_dflash_tree_tokens.py
+++ b/test/manual/spec/compare_dflash_tree_tokens.py
@@ -1,0 +1,166 @@
+"""Does DFLASH tree verify emit the same tokens as the chain it degenerates to?
+
+At tree width 1 the beam keeps one node per depth, which is the chain DFLASH has
+always drafted, so the two paths must produce identical token ids. That equality is
+the gate for the whole tree wiring: positions, the custom mask, the tree links and
+the accept all have a width-1 answer that is already known to be right.
+
+Run the server twice and diff the dumps:
+
+    ./run_dflash2_tree.sh baseline &                       # chain path
+    python3 test/manual/spec/compare_dflash_tree_tokens.py --out /tmp/chain.json
+    ./run_dflash2_tree.sh force-tree &                     # tree path, width 1
+    python3 test/manual/spec/compare_dflash_tree_tokens.py --out /tmp/tree.json
+    python3 test/manual/spec/compare_dflash_tree_tokens.py \
+        --compare /tmp/chain.json /tmp/tree.json
+
+Requests go out one at a time so the batch is always size 1: batch composition
+changes matmul reduction order, and that difference alone would swamp the signal.
+
+`--concurrency 4` exists but is **not** a gate. Measured 2026-08-24: the same server
+compared against itself at concurrency 4 diverges on 2 of 8 prompts, at the same
+token indices and the same logprob magnitudes (~1e-2) as a chain-vs-tree comparison
+does. Which requests share a step depends on arrival timing, so the batch differs
+between runs and nothing about the tree can be concluded from it. Keep it for smoke
+value only.
+
+Asserts nothing. It prints, and a divergence needs reading rather than a red mark:
+attaching a custom mask switches the attention kernel to its masked path, so a
+handful of near-tie argmax flips is a different finding from a wiring bug. The
+logprob diff separates them -- structural errors are not subtle.
+"""
+
+import argparse
+import json
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+# Deterministic, varied enough to reach different accept lengths, short enough that
+# a full pass is a couple of minutes on one GPU.
+PROMPTS = [
+    "Explain in three sentences why speculative decoding speeds up inference.",
+    "Write a Python function that returns the n-th Fibonacci number.",
+    "What is 17 * 23? Show the steps.",
+    "List four differences between a linked list and an array.",
+    "Summarize the plot of Hamlet in one paragraph.",
+    "Translate to French: The weather is unusually warm for October.",
+    "Name the first five prime numbers and explain what makes a number prime.",
+    "Describe what a KV cache stores during autoregressive decoding.",
+]
+
+
+def _generate(port: int, prompt: str, max_new_tokens: int) -> dict:
+    response = requests.post(
+        f"http://127.0.0.1:{port}/generate",
+        json={
+            "text": prompt,
+            "sampling_params": {"temperature": 0, "max_new_tokens": max_new_tokens},
+            # The only way to get token ids back; also gives the logprobs the
+            # divergence triage needs.
+            "return_logprob": True,
+        },
+        timeout=900,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    logprobs = payload["meta_info"]["output_token_logprobs"]
+    return {
+        "prompt": prompt,
+        "ids": [entry[1] for entry in logprobs],
+        "logprobs": [entry[0] for entry in logprobs],
+        "accept_length": payload["meta_info"].get("spec_accept_length"),
+        "text": payload["text"],
+    }
+
+
+def collect(*, port: int, max_new_tokens: int, concurrency: int) -> list:
+    if concurrency == 1:
+        return [_generate(port, prompt, max_new_tokens) for prompt in PROMPTS]
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        return list(
+            pool.map(lambda prompt: _generate(port, prompt, max_new_tokens), PROMPTS)
+        )
+
+
+def compare(chain: list, tree: list) -> bool:
+    """Print a per-prompt verdict; return whether every token matched."""
+    all_equal = True
+    for baseline, candidate in zip(chain, tree):
+        ids_a, ids_b = baseline["ids"], candidate["ids"]
+        shared = min(len(ids_a), len(ids_b))
+        first_diff = next(
+            (i for i in range(shared) if ids_a[i] != ids_b[i]),
+            None if len(ids_a) == len(ids_b) else shared,
+        )
+        # Over the shared prefix only: past a divergence the sequences are different
+        # continuations and the logprob gap stops meaning anything.
+        compared = shared if first_diff is None else first_diff
+        max_logprob_diff = max(
+            (
+                abs(baseline["logprobs"][i] - candidate["logprobs"][i])
+                for i in range(compared)
+            ),
+            default=0.0,
+        )
+        verdict = "same" if first_diff is None else f"DIVERGES at token {first_diff}"
+        print(
+            f"[{verdict}] len={len(ids_a)}/{len(ids_b)} "
+            f"accept_len={baseline['accept_length']}/{candidate['accept_length']} "
+            f"max|dlogprob|={max_logprob_diff:.2e}  {baseline['prompt'][:44]!r}"
+        )
+        if first_diff is not None:
+            all_equal = False
+            lo, hi = max(0, first_diff - 3), first_diff + 3
+            print(f"    chain ids[{lo}:{hi}] = {ids_a[lo:hi]}")
+            print(f"    tree  ids[{lo}:{hi}] = {ids_b[lo:hi]}")
+    print("\nALL TOKENS IDENTICAL" if all_equal else "\nDIVERGENCE FOUND")
+    if not all_equal:
+        print(
+            "Triage: max|dlogprob| above ~1e-3 with a structural pattern means the "
+            "wiring is wrong (check positions -> custom_mask -> accept_index[:, 0] == "
+            "bs_idx * N -> retrieve_* links, in that order). Values below that, at a "
+            "near-tie argmax, are the masked attention kernel's own numerics."
+        )
+    return all_equal
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port", type=int, default=30000)
+    parser.add_argument("--max-new-tokens", type=int, default=96)
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=1,
+        help="1 keeps the batch at size 1; >1 cross-checks with a fixed batch.",
+    )
+    parser.add_argument("--out", help="Write this run's dump here.")
+    parser.add_argument(
+        "--compare", nargs=2, metavar=("CHAIN", "TREE"), help="Diff two dumps."
+    )
+    args = parser.parse_args()
+
+    if args.compare:
+        with open(args.compare[0]) as chain_file, open(args.compare[1]) as tree_file:
+            compare(json.load(chain_file), json.load(tree_file))
+        return
+
+    dump = collect(
+        port=args.port,
+        max_new_tokens=args.max_new_tokens,
+        concurrency=args.concurrency,
+    )
+    for record in dump:
+        print(
+            f"{len(record['ids']):4d} tokens  accept_len={record['accept_length']}  "
+            f"{record['prompt'][:56]!r}"
+        )
+    if args.out:
+        with open(args.out, "w") as out_file:
+            json.dump(dump, out_file)
+        print(f"\nwrote {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/manual/spec/compare_dflash_tree_tokens.py
+++ b/test/manual/spec/compare_dflash_tree_tokens.py
@@ -17,6 +17,16 @@ Run the server twice and diff the dumps:
 Requests go out one at a time so the batch is always size 1: batch composition
 changes matmul reduction order, and that difference alone would swamp the signal.
 
+`--temperature > 0` repurposes the same comparison for a second question: whether the
+*chain* path's sampling accept (`_selector_sampling_accept`, a different kernel from
+the greedy `accept_tree_greedy`) still behaves after the tree wiring landed. There the
+two dumps come from two *commits* at width 1, not from two paths of one build. Token
+equality is only meaningful if both servers ran with the same `--random-seed`: DFLASH
+draws its accept coins with `torch.rand` on the default generator and never reads a
+request's `sampling_seed`, so the request-level seed does nothing here. A whole-suffix
+mismatch starting at one token is more likely RNG-stream misalignment than a numerical
+bug -- read the accept lengths at that step before concluding anything.
+
 `--concurrency 4` exists but is **not** a gate. Measured 2026-08-24: the same server
 compared against itself at concurrency 4 diverges on 2 of 8 prompts, at the same
 token indices and the same logprob magnitudes (~1e-2) as a chain-vs-tree comparison
@@ -50,12 +60,17 @@ PROMPTS = [
 ]
 
 
-def _generate(port: int, prompt: str, max_new_tokens: int) -> dict:
+def _generate(
+    port: int, prompt: str, max_new_tokens: int, temperature: float = 0.0
+) -> dict:
     response = requests.post(
         f"http://127.0.0.1:{port}/generate",
         json={
             "text": prompt,
-            "sampling_params": {"temperature": 0, "max_new_tokens": max_new_tokens},
+            "sampling_params": {
+                "temperature": temperature,
+                "max_new_tokens": max_new_tokens,
+            },
             # The only way to get token ids back; also gives the logprobs the
             # divergence triage needs.
             "return_logprob": True,
@@ -74,12 +89,19 @@ def _generate(port: int, prompt: str, max_new_tokens: int) -> dict:
     }
 
 
-def collect(*, port: int, max_new_tokens: int, concurrency: int) -> list:
+def collect(
+    *, port: int, max_new_tokens: int, concurrency: int, temperature: float = 0.0
+) -> list:
     if concurrency == 1:
-        return [_generate(port, prompt, max_new_tokens) for prompt in PROMPTS]
+        return [
+            _generate(port, prompt, max_new_tokens, temperature) for prompt in PROMPTS
+        ]
     with ThreadPoolExecutor(max_workers=concurrency) as pool:
         return list(
-            pool.map(lambda prompt: _generate(port, prompt, max_new_tokens), PROMPTS)
+            pool.map(
+                lambda prompt: _generate(port, prompt, max_new_tokens, temperature),
+                PROMPTS,
+            )
         )
 
 
@@ -137,6 +159,17 @@ def main() -> None:
     )
     parser.add_argument("--out", help="Write this run's dump here.")
     parser.add_argument(
+        "--temperature",
+        type=float,
+        default=0.0,
+        help=(
+            "0 compares the greedy accept path. >0 compares the sampling accept path "
+            "instead, which is a different kernel; reproducibility then rests on the "
+            "server's --random-seed, not on any per-request seed (DFLASH draws its "
+            "accept coins from the default generator and ignores sampling_seed)."
+        ),
+    )
+    parser.add_argument(
         "--compare", nargs=2, metavar=("CHAIN", "TREE"), help="Diff two dumps."
     )
     args = parser.parse_args()
@@ -150,6 +183,7 @@ def main() -> None:
         port=args.port,
         max_new_tokens=args.max_new_tokens,
         concurrency=args.concurrency,
+        temperature=args.temperature,
     )
     for record in dump:
         print(

--- a/test/manual/spec/compare_dflash_tree_tokens.py
+++ b/test/manual/spec/compare_dflash_tree_tokens.py
@@ -1,9 +1,4 @@
-"""Does DFLASH tree verify emit the same tokens as the chain it degenerates to?
-
-At tree width 1 the beam keeps one node per depth, which is the chain DFLASH has
-always drafted, so the two paths must produce identical token ids. That equality is
-the gate for the whole tree wiring: positions, the custom mask, the tree links and
-the accept all have a width-1 answer that is already known to be right.
+"""Compare DFLASH chain and width-one tree verification.
 
 Run the server twice and diff the dumps:
 
@@ -14,30 +9,8 @@ Run the server twice and diff the dumps:
     python3 test/manual/spec/compare_dflash_tree_tokens.py \
         --compare /tmp/chain.json /tmp/tree.json
 
-Requests go out one at a time so the batch is always size 1: batch composition
-changes matmul reduction order, and that difference alone would swamp the signal.
-
-`--temperature > 0` repurposes the same comparison for a second question: whether the
-*chain* path's sampling accept (`_selector_sampling_accept`, a different kernel from
-the greedy `accept_tree_greedy`) still behaves after the tree wiring landed. There the
-two dumps come from two *commits* at width 1, not from two paths of one build. Token
-equality is only meaningful if both servers ran with the same `--random-seed`: DFLASH
-draws its accept coins with `torch.rand` on the default generator and never reads a
-request's `sampling_seed`, so the request-level seed does nothing here. A whole-suffix
-mismatch starting at one token is more likely RNG-stream misalignment than a numerical
-bug -- read the accept lengths at that step before concluding anything.
-
-`--concurrency 4` exists but is **not** a gate. Measured 2026-08-24: the same server
-compared against itself at concurrency 4 diverges on 2 of 8 prompts, at the same
-token indices and the same logprob magnitudes (~1e-2) as a chain-vs-tree comparison
-does. Which requests share a step depends on arrival timing, so the batch differs
-between runs and nothing about the tree can be concluded from it. Keep it for smoke
-value only.
-
-Asserts nothing. It prints, and a divergence needs reading rather than a red mark:
-attaching a custom mask switches the attention kernel to its masked path, so a
-handful of near-tie argmax flips is a different finding from a wiring bug. The
-logprob diff separates them -- structural errors are not subtle.
+Requests default to batch size 1 because batch composition changes reduction order.
+The script prints diagnostics rather than asserting equality.
 """
 
 import argparse
@@ -46,8 +19,6 @@ from concurrent.futures import ThreadPoolExecutor
 
 import requests
 
-# Deterministic, varied enough to reach different accept lengths, short enough that
-# a full pass is a couple of minutes on one GPU.
 PROMPTS = [
     "Explain in three sentences why speculative decoding speeds up inference.",
     "Write a Python function that returns the n-th Fibonacci number.",
@@ -71,8 +42,6 @@ def _generate(
                 "temperature": temperature,
                 "max_new_tokens": max_new_tokens,
             },
-            # The only way to get token ids back; also gives the logprobs the
-            # divergence triage needs.
             "return_logprob": True,
         },
         timeout=900,
@@ -115,8 +84,6 @@ def compare(chain: list, tree: list) -> bool:
             (i for i in range(shared) if ids_a[i] != ids_b[i]),
             None if len(ids_a) == len(ids_b) else shared,
         )
-        # Over the shared prefix only: past a divergence the sequences are different
-        # continuations and the logprob gap stops meaning anything.
         compared = shared if first_diff is None else first_diff
         max_logprob_diff = max(
             (

--- a/test/registered/unit/spec/test_dflash_extra_buffer_lazy.py
+++ b/test/registered/unit/spec/test_dflash_extra_buffer_lazy.py
@@ -97,6 +97,7 @@ class TestDflashVerifyRunsMambaTrackHook(CustomTestCase):
             draft_token=torch.tensor([1, 2, 3, 4], dtype=torch.long),
             positions=torch.tensor([0, 1, 2, 3], dtype=torch.long),
             draft_token_num=4,
+            topk=1,
         )
 
     def _run(self, forward_mode):

--- a/test/registered/unit/spec/test_dflash_logits.py
+++ b/test/registered/unit/spec/test_dflash_logits.py
@@ -7,6 +7,7 @@ import torch
 from sglang.srt.models.dflash import (
     CandidateSelector,
     DFlash2DraftModel,
+    _validate_max_num_nodes,
     _beam_walk_torch,
     _grouped_conv,
 )
@@ -15,7 +16,7 @@ from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 
 register_cpu_ci(est_time=38, suite="base-a-test-cpu")
 # The triton beam walk needs a device; the rest of this file needs no kernel.
-register_cuda_ci(est_time=3, stage="base-b", runner_config="1-gpu-small")
+register_cuda_ci(est_time=4, stage="base-b", runner_config="1-gpu-small")
 
 
 def test_dflash_unary_logit_transform():
@@ -76,8 +77,7 @@ def test_selector_greedy_row_walk_is_deterministic_in_a_mixed_batch():
 
 
 def test_selector_rejects_a_quantized_target_lm_head():
-    """The candidate matmuls read the lm_head weight directly, so a packed or
-    absent weight would be read as if it were dense."""
+    """Candidate scoring requires a dense target lm_head."""
     model = SimpleNamespace(
         lm_head=SimpleNamespace(weight=torch.empty(8, 4, dtype=torch.int8)),
         candidate_selector=SimpleNamespace(top_k=4),
@@ -254,6 +254,7 @@ def test_worker_folds_a_gate_admitted_quantized_selector_head(monkeypatch):
         ps=SimpleNamespace(tp_rank=0),
         draft_model=SimpleNamespace(lm_head=None),
         device="cpu",
+        _use_tree_verify=False,
         _selector_sampling_enabled=True,
         _target_worker=SimpleNamespace(
             model_runner=SimpleNamespace(model=SimpleNamespace(lm_head=quant_head))
@@ -283,6 +284,7 @@ def test_worker_warns_once_when_selector_sampling_is_disabled(monkeypatch):
     )
     worker = SimpleNamespace(
         selector=object(),
+        _use_tree_verify=False,
         _selector_sampling_enabled=False,
         _warned_sampling_fallback=False,
         ps=SimpleNamespace(tp_rank=0),
@@ -407,19 +409,11 @@ def test_selector_accept_uses_greedy_fallback_without_staged_sample(monkeypatch)
 
 
 def _lattice(*, bs, slots, top_k, seed=0, spread=8.0):
-    """A lattice whose scores are well separated, so index selection is stable.
-
-    Beam picks compare fp32 sums across a flattened axis; the triton kernel and the
-    torch reference normalize with different reduction orders and differ by ~1e-7.
-    Integer-valued scores keep every comparison gap far above that, which is what
-    makes elementwise equality a non-flaky assertion.
-    """
+    """Build a lattice with score gaps large enough for exact comparisons."""
     generator = torch.Generator().manual_seed(seed)
     scores = torch.randint(
         -5, 6, (bs, slots, top_k, top_k), generator=generator
     ).float()
-    # Distinct ids per slot, so "same-parent siblings differ" is about the walk
-    # rather than about the candidate set happening to repeat a token.
     candidate_ids = (
         torch.arange(slots * top_k).view(1, slots, top_k).expand(bs, slots, top_k)
     )
@@ -429,8 +423,7 @@ def _lattice(*, bs, slots, top_k, seed=0, spread=8.0):
 
 @pytest.mark.parametrize("slots,top_k", [(3, 4), (7, 16)])
 def test_beam_width_one_reproduces_the_greedy_chain(slots, top_k):
-    """Width 1 is the regression gate for every later phase: the tree must degenerate
-    to the chain `sample_path` already produces, root included at index 0."""
+    """Width 1 must reproduce the existing greedy chain."""
     bs = 3
     candidate_ids, scores, anchor = _lattice(bs=bs, slots=slots, top_k=top_k)
     selector = CandidateSelector(
@@ -460,9 +453,7 @@ def test_beam_width_one_reproduces_the_greedy_chain(slots, top_k):
 @pytest.mark.parametrize("beam_width", [1, 2, 3, 4])
 @pytest.mark.parametrize("slots,top_k", [(3, 4), (7, 16)])
 def test_tree_is_fixed_width_and_bfs_ordered(beam_width, slots, top_k):
-    """`parent < index` is the precondition for the single-pass ancestor closure and
-    for `reconstruct_indices_from_tree_mask`; the fixed node count is what keeps the
-    verify window a constant length. Width 3 also covers the padded-lane path."""
+    """Tree nodes are fixed-width and BFS ordered."""
     bs = 2
     candidate_ids, scores, anchor = _lattice(bs=bs, slots=slots, top_k=top_k)
     tokens, parents = _beam_walk_torch(
@@ -477,7 +468,6 @@ def test_tree_is_fixed_width_and_bfs_ordered(beam_width, slots, top_k):
     assert parents.shape == (bs, num_nodes)
     assert torch.equal(parents[:, 0], torch.full((bs,), -1))
     assert (parents[:, 1:] < torch.arange(1, num_nodes)).all()
-    # Every parent lives on the depth immediately above.
     for slot in range(slots):
         base = 1 + slot * beam_width
         block = parents[:, base : base + beam_width]
@@ -487,10 +477,7 @@ def test_tree_is_fixed_width_and_bfs_ordered(beam_width, slots, top_k):
 
 
 def test_spine_is_independent_of_the_beam_width():
-    """The spine is beam 0's own argmax chain and never reads the accumulated score,
-    so one lattice must yield one spine at every width. Miscomputing `cum`,
-    normalizing on the wrong axis, or shuffling the beam order all break this while
-    leaving the shape invariants intact."""
+    """The greedy spine must be independent of beam width."""
     slots, top_k = 7, 16
     candidate_ids, scores, anchor = _lattice(bs=2, slots=slots, top_k=top_k, seed=3)
 
@@ -509,12 +496,7 @@ def test_spine_is_independent_of_the_beam_width():
 
 
 def test_same_parent_siblings_carry_distinct_tokens():
-    """`verify_tree_greedy` sweeps a sibling chain and takes the first match, so a
-    repeated token under one parent could send the walk into another subtree and stop
-    earlier -- which would break "tree acceptance >= chain acceptance". Distinctness
-    holds structurally because the width picks are distinct (beam, candidate) pairs;
-    switching to per-state dedup, or letting predecessors share candidate numbering,
-    loses it."""
+    """Siblings selected under one parent must carry distinct tokens."""
     slots, top_k, beam_width = 7, 16, 4
     candidate_ids, scores, anchor = _lattice(bs=3, slots=slots, top_k=top_k, seed=5)
     tokens, parents = _beam_walk_torch(
@@ -536,11 +518,7 @@ def test_same_parent_siblings_carry_distinct_tokens():
 
 
 def test_rows_are_normalized_before_the_scores_accumulate():
-    """Two predecessors with identical conditional distributions but rows offset by a
-    constant must compete equally: a logit row is only defined up to a per-row
-    additive constant, so accumulating raw scores lets the offset alone decide which
-    subtree eats the budget. Here the +10 row would take both free slots and starve
-    node 2 into a dead end."""
+    """Row offsets must not affect beam competition."""
     beam_width = top_k = 3
     scores = torch.zeros(1, 2, top_k, top_k)
     scores[0, 1, 0] = torch.tensor([0.0, -1.0, -2.0])
@@ -560,10 +538,7 @@ def test_rows_are_normalized_before_the_scores_accumulate():
 
 
 def test_exact_ties_break_beam_major():
-    """Flattening the pool as `beam * top_k + candidate` is a convention the torch
-    reference and the triton kernel have to share; c-major would pick a different
-    parent on a tie. Within-row ties are reproducible in both (equal inputs give equal
-    `log_softmax` outputs), so this pins the flattening without relying on luck."""
+    """Exact ties must use beam-major flattening."""
     beam_width = top_k = 2
     scores = torch.zeros(1, 2, top_k, top_k)
     candidate_ids = torch.arange(2 * top_k).view(1, 2, top_k)
@@ -582,9 +557,7 @@ def test_exact_ties_break_beam_major():
 
 
 def test_beam_walk_rejects_a_width_above_the_candidate_count():
-    """Depth 1 only has top_k candidates, so a wider beam cannot fill a fixed width;
-    the resolved server args promise this never happens, and the walk says so rather
-    than silently emitting duplicates."""
+    """Reject a beam wider than the candidate axis."""
     selector = CandidateSelector(hidden_size=4, vocab_size=64, state_rank=2, top_k=4)
     candidate_ids, scores, anchor = _lattice(bs=1, slots=3, top_k=4)
     with pytest.raises(ValueError, match="selector_top_k"):
@@ -599,9 +572,7 @@ def test_beam_walk_rejects_a_width_above_the_candidate_count():
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="triton needs a GPU")
 @pytest.mark.parametrize("beam_width", [1, 2, 3, 4, 8])
 def test_triton_beam_walk_matches_the_reference(beam_width):
-    """The kernel's first-max and register reductions are new code with no other
-    oracle. Separated scores keep every comparison gap far above fp32 noise, so
-    elementwise equality is meaningful; cross-row ties are explicitly not promised."""
+    """The Triton walk must match the device-agnostic reference."""
     slots, top_k = 7, 16
     candidate_ids, scores, anchor = _lattice(bs=4, slots=slots, top_k=top_k, seed=11)
     selector = CandidateSelector(
@@ -623,6 +594,198 @@ def test_triton_beam_walk_matches_the_reference(beam_width):
 
     assert torch.equal(actual[0].cpu(), expected[0])
     assert torch.equal(actual[1].cpu(), expected[1])
+
+
+def _root_path(*, tokens, parents, node):
+    """Token sequence from the root down to `node`, root first."""
+    path = []
+    while node != -1:
+        path.append(int(tokens[node]))
+        node = int(parents[node])
+    return path[::-1]
+
+
+# scores drawn from {0, -SPLIT}: fp32 log_softmax returns exactly 0.0 and -SPLIT
+# there (the other candidate's mass underflows fp32 eps), so every `cum` is an exact
+# multiple of -SPLIT and both the ranking and its ties are hand-derivable.
+_SPLIT = 40.0
+
+
+def _two_slot_lattice():
+    """slots=2, top_k=2; at beam_width=2 the walk builds 5 nodes with known `cum`.
+
+    Hand-derived: node 1 and node 3 have cum 0, node 2 and node 4 have cum -SPLIT, so
+    ranking by (-cum, index) over the non-anchor nodes gives 1, 3, 2, 4.
+    """
+    scores = torch.tensor(
+        [[[0.0, -_SPLIT], [0.0, -_SPLIT]], [[0.0, -_SPLIT], [0.0, -_SPLIT]]]
+    )[None]
+    return torch.arange(4).view(1, 2, 2), scores, torch.tensor([9001])
+
+
+@pytest.mark.parametrize(
+    "max_num_nodes,tokens,parents",
+    [
+        (2, [9001, 0], [-1, 0]),
+        (3, [9001, 0, 2], [-1, 0, 1]),
+        (4, [9001, 0, 1, 2], [-1, 0, 0, 1]),
+    ],
+)
+def test_prune_keeps_the_best_cum_nodes(max_num_nodes, tokens, parents):
+    """Keep the expected cumulative-score nodes and remap their parents."""
+    candidate_ids, scores, anchor = _two_slot_lattice()
+    actual = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=anchor,
+        beam_width=2,
+        max_num_nodes=max_num_nodes,
+    )
+    assert actual[0][0].tolist() == tokens
+    assert actual[1][0].tolist() == parents
+
+
+_CAPS = [1, 2, 8, 15, 30]
+
+
+def _caps_for(built):
+    """The sweep at one built size: fixed points plus both sides of the boundary."""
+    return sorted({cap for cap in _CAPS if cap <= built} | {built - 1, built})
+
+
+@pytest.mark.parametrize("beam_width", [1, 2, 4, 8])
+def test_prune_emits_a_bfs_ordered_tree_at_every_cap(beam_width):
+    """Pruned trees must remain BFS ordered."""
+    slots, top_k = 7, 16
+    built = 1 + slots * beam_width
+    candidate_ids, scores, anchor = _lattice(bs=3, slots=slots, top_k=top_k, seed=5)
+    for max_num_nodes in _caps_for(built):
+        tokens, parents = _beam_walk_torch(
+            candidate_ids=candidate_ids,
+            scores=scores,
+            anchor_token_ids=anchor,
+            beam_width=beam_width,
+            max_num_nodes=max_num_nodes,
+        )
+        assert tokens.shape == (3, max_num_nodes)
+        assert parents.shape == (3, max_num_nodes)
+        assert (parents[:, 0] == -1).all()
+        ceiling = torch.arange(1, max_num_nodes)
+        assert (parents[:, 1:] < ceiling).all()
+        assert (parents[:, 1:] >= 0).all()
+
+
+@pytest.mark.parametrize("beam_width", [2, 4, 8])
+def test_prune_preserves_every_surviving_root_path(beam_width):
+    """Pruning may remove paths but must not rewrite survivors."""
+    slots, top_k = 7, 16
+    built = 1 + slots * beam_width
+    candidate_ids, scores, anchor = _lattice(bs=2, slots=slots, top_k=top_k, seed=7)
+    full_tokens, full_parents = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=anchor,
+        beam_width=beam_width,
+    )
+    paths = [
+        {
+            tuple(
+                _root_path(
+                    tokens=full_tokens[row], parents=full_parents[row], node=node
+                )
+            )
+            for node in range(built)
+        }
+        for row in range(full_tokens.shape[0])
+    ]
+    for max_num_nodes in _caps_for(built):
+        tokens, parents = _beam_walk_torch(
+            candidate_ids=candidate_ids,
+            scores=scores,
+            anchor_token_ids=anchor,
+            beam_width=beam_width,
+            max_num_nodes=max_num_nodes,
+        )
+        for row in range(tokens.shape[0]):
+            for node in range(max_num_nodes):
+                path = tuple(
+                    _root_path(tokens=tokens[row], parents=parents[row], node=node)
+                )
+                assert path in paths[row]
+
+
+def test_prune_breaks_cum_ties_towards_the_lower_node_index():
+    """Equal cumulative scores must break ties by lower node index."""
+    slots, top_k, bs = 7, 16, 2
+    candidate_ids, _, anchor = _lattice(bs=bs, slots=slots, top_k=top_k)
+    uniform = torch.zeros(bs, slots, top_k, top_k)
+    for beam_width in (2, 4, 8):
+        built = 1 + slots * beam_width
+        full = _beam_walk_torch(
+            candidate_ids=candidate_ids,
+            scores=uniform,
+            anchor_token_ids=anchor,
+            beam_width=beam_width,
+        )
+        for max_num_nodes in (5, 15, 30):
+            if max_num_nodes >= built:
+                continue
+            actual = _beam_walk_torch(
+                candidate_ids=candidate_ids,
+                scores=uniform,
+                anchor_token_ids=anchor,
+                beam_width=beam_width,
+                max_num_nodes=max_num_nodes,
+            )
+            assert torch.equal(actual[0], full[0][:, :max_num_nodes])
+            assert torch.equal(actual[1], full[1][:, :max_num_nodes])
+
+
+def test_prune_rejects_a_cap_outside_the_built_node_count():
+    """Reject caps that do not describe a subset of the built tree."""
+    candidate_ids, scores, anchor = _lattice(bs=1, slots=7, top_k=16)
+    for bad in (0, 1 + 7 * 4 + 1):
+        with pytest.raises(ValueError, match="max_num_nodes"):
+            _beam_walk_torch(
+                candidate_ids=candidate_ids,
+                scores=scores,
+                anchor_token_ids=anchor,
+                beam_width=4,
+                max_num_nodes=bad,
+            )
+
+
+def test_prune_allows_an_uncapped_tree_above_kernel_limit():
+    _validate_max_num_nodes(max_num_nodes=257, num_nodes=257)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="triton needs a GPU")
+@pytest.mark.parametrize("beam_width", [1, 2, 4, 8])
+def test_triton_prune_matches_the_reference(beam_width):
+    """The Triton prune must match the independent torch reference."""
+    slots, top_k = 7, 16
+    built = 1 + slots * beam_width
+    candidate_ids, scores, anchor = _lattice(bs=4, slots=slots, top_k=top_k, seed=11)
+    selector = CandidateSelector(
+        hidden_size=4, vocab_size=slots * top_k, state_rank=2, top_k=top_k
+    )
+    for max_num_nodes in _caps_for(built):
+        expected = _beam_walk_torch(
+            candidate_ids=candidate_ids,
+            scores=scores,
+            anchor_token_ids=anchor,
+            beam_width=beam_width,
+            max_num_nodes=max_num_nodes,
+        )
+        actual = selector.beam_walk(
+            candidate_ids=candidate_ids.cuda(),
+            scores=scores.cuda(),
+            anchor_token_ids=anchor.cuda(),
+            beam_width=beam_width,
+            max_num_nodes=max_num_nodes,
+        )
+        assert torch.equal(actual[0].cpu(), expected[0])
+        assert torch.equal(actual[1].cpu(), expected[1])
 
 
 def test_grouped_conv_supports_runtime_block_sizes():
@@ -654,6 +817,59 @@ def test_grouped_conv_supports_runtime_block_sizes():
                     value += coefficient * hidden_3d[batch, position - tap]
                 expected[batch * block_size + position] = value.flatten()
         torch.testing.assert_close(actual, expected)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="triton needs a GPU")
+def test_prune_kernel_bounds_its_writes_on_non_finite_cums():
+    """A NaN `cum` compares false against everything, so without the normalization
+    every node ranks 0, `keep` is all-true, and the compaction pushes up to `num_nodes`
+    elements into a `max_num_nodes`-wide row -- an out-of-bounds write, silent memory
+    corruption rather than a wrong answer. Mapping NaN to -inf instead makes
+    `better[i, j]` reduce to `j < i`, so exactly `max_num_nodes` nodes survive.
+
+    Driven at the kernel rather than through `beam_walk`, because the walk cannot
+    produce a tree at all from a NaN lattice: `_first_max_index` returns its
+    out-of-range sentinel there.
+
+    The output buffers are flat with `guard` sentinel elements past the end, because
+    the kernel derives each row's offset from `max_num_nodes` itself -- padding the
+    rows instead would put row `r + 1`'s legitimate writes inside row `r`'s padding
+    and detect nothing."""
+    import triton
+
+    from sglang.kernels.ops.speculative.dflash import _dflash_tree_prune_by_cum_kernel
+
+    bs, num_nodes, cap, guard = 3, 57, 15, 8
+    sentinel = -12345
+    tokens = torch.arange(bs * num_nodes, device="cuda").view(bs, num_nodes)
+    parents = torch.zeros(bs, num_nodes, dtype=torch.int64, device="cuda")
+    parents[:, 0] = -1
+    cums = torch.full((bs, num_nodes), float("nan"), device="cuda")
+    out_tokens = torch.full(
+        (bs * cap + guard,), sentinel, dtype=torch.int64, device="cuda"
+    )
+    out_parents = torch.full_like(out_tokens, sentinel)
+
+    _dflash_tree_prune_by_cum_kernel[(bs,)](
+        tokens,
+        parents,
+        cums,
+        out_tokens,
+        out_parents,
+        num_nodes=num_nodes,
+        max_num_nodes=cap,
+        NODES=triton.next_power_of_2(num_nodes),
+        num_warps=4,
+    )
+
+    assert (out_tokens[bs * cap :] == sentinel).all()
+    assert (out_parents[bs * cap :] == sentinel).all()
+    # All-equal cum degenerates to the BFS prefix, exactly `cap` nodes per row.
+    assert torch.equal(out_tokens[: bs * cap].view(bs, cap), tokens[:, :cap])
+    for row in range(bs):
+        assert out_parents[row * cap : (row + 1) * cap].tolist() == [-1] + [0] * (
+            cap - 1
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_dflash_logits.py
+++ b/test/registered/unit/spec/test_dflash_logits.py
@@ -7,12 +7,15 @@ import torch
 from sglang.srt.models.dflash import (
     CandidateSelector,
     DFlash2DraftModel,
+    _beam_walk_torch,
     _grouped_conv,
 )
 from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
-from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 
 register_cpu_ci(est_time=38, suite="base-a-test-cpu")
+# The triton beam walk needs a device; the rest of this file needs no kernel.
+register_cuda_ci(est_time=3, stage="base-b", runner_config="1-gpu-small")
 
 
 def test_dflash_unary_logit_transform():
@@ -401,6 +404,225 @@ def test_selector_accept_uses_greedy_fallback_without_staged_sample(monkeypatch)
     assert out_tokens.tolist() == [[7, 0]]
     assert target_predict.tolist() == [[1, 0]]
     assert sync_sites == [worker_mod.SpecTpSyncSite.DFLASH_ACCEPT_GREEDY]
+
+
+def _lattice(*, bs, slots, top_k, seed=0, spread=8.0):
+    """A lattice whose scores are well separated, so index selection is stable.
+
+    Beam picks compare fp32 sums across a flattened axis; the triton kernel and the
+    torch reference normalize with different reduction orders and differ by ~1e-7.
+    Integer-valued scores keep every comparison gap far above that, which is what
+    makes elementwise equality a non-flaky assertion.
+    """
+    generator = torch.Generator().manual_seed(seed)
+    scores = torch.randint(
+        -5, 6, (bs, slots, top_k, top_k), generator=generator
+    ).float()
+    # Distinct ids per slot, so "same-parent siblings differ" is about the walk
+    # rather than about the candidate set happening to repeat a token.
+    candidate_ids = (
+        torch.arange(slots * top_k).view(1, slots, top_k).expand(bs, slots, top_k)
+    )
+    anchor = torch.arange(bs) + 9001
+    return candidate_ids.contiguous(), scores * spread, anchor
+
+
+@pytest.mark.parametrize("slots,top_k", [(3, 4), (7, 16)])
+def test_beam_width_one_reproduces_the_greedy_chain(slots, top_k):
+    """Width 1 is the regression gate for every later phase: the tree must degenerate
+    to the chain `sample_path` already produces, root included at index 0."""
+    bs = 3
+    candidate_ids, scores, anchor = _lattice(bs=bs, slots=slots, top_k=top_k)
+    selector = CandidateSelector(
+        hidden_size=4, vocab_size=64, state_rank=2, top_k=top_k
+    )
+
+    chain, _ = selector.sample_path(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        uniforms=torch.zeros(bs, slots),
+        temperatures=torch.ones(bs),
+        greedy_mask=torch.ones(bs, dtype=torch.bool),
+    )
+    tokens, parents = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=anchor,
+        beam_width=1,
+    )
+
+    assert torch.equal(tokens[:, 0], anchor)
+    assert torch.equal(tokens[:, 1:], chain)
+    expected_parents = torch.cat([torch.tensor([-1]), torch.arange(slots)])
+    assert torch.equal(parents, expected_parents.expand(bs, slots + 1))
+
+
+@pytest.mark.parametrize("beam_width", [1, 2, 3, 4])
+@pytest.mark.parametrize("slots,top_k", [(3, 4), (7, 16)])
+def test_tree_is_fixed_width_and_bfs_ordered(beam_width, slots, top_k):
+    """`parent < index` is the precondition for the single-pass ancestor closure and
+    for `reconstruct_indices_from_tree_mask`; the fixed node count is what keeps the
+    verify window a constant length. Width 3 also covers the padded-lane path."""
+    bs = 2
+    candidate_ids, scores, anchor = _lattice(bs=bs, slots=slots, top_k=top_k)
+    tokens, parents = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=anchor,
+        beam_width=beam_width,
+    )
+
+    num_nodes = 1 + slots * beam_width
+    assert tokens.shape == (bs, num_nodes)
+    assert parents.shape == (bs, num_nodes)
+    assert torch.equal(parents[:, 0], torch.full((bs,), -1))
+    assert (parents[:, 1:] < torch.arange(1, num_nodes)).all()
+    # Every parent lives on the depth immediately above.
+    for slot in range(slots):
+        base = 1 + slot * beam_width
+        block = parents[:, base : base + beam_width]
+        lower = 1 + (slot - 1) * beam_width if slot else 0
+        assert (block >= lower).all()
+        assert (block < base).all()
+
+
+def test_spine_is_independent_of_the_beam_width():
+    """The spine is beam 0's own argmax chain and never reads the accumulated score,
+    so one lattice must yield one spine at every width. Miscomputing `cum`,
+    normalizing on the wrong axis, or shuffling the beam order all break this while
+    leaving the shape invariants intact."""
+    slots, top_k = 7, 16
+    candidate_ids, scores, anchor = _lattice(bs=2, slots=slots, top_k=top_k, seed=3)
+
+    spines = []
+    for beam_width in (1, 2, 4, 8):
+        tokens, _ = _beam_walk_torch(
+            candidate_ids=candidate_ids,
+            scores=scores,
+            anchor_token_ids=anchor,
+            beam_width=beam_width,
+        )
+        spines.append(tokens[:, [1 + slot * beam_width for slot in range(slots)]])
+
+    for spine in spines[1:]:
+        assert torch.equal(spine, spines[0])
+
+
+def test_same_parent_siblings_carry_distinct_tokens():
+    """`verify_tree_greedy` sweeps a sibling chain and takes the first match, so a
+    repeated token under one parent could send the walk into another subtree and stop
+    earlier -- which would break "tree acceptance >= chain acceptance". Distinctness
+    holds structurally because the width picks are distinct (beam, candidate) pairs;
+    switching to per-state dedup, or letting predecessors share candidate numbering,
+    loses it."""
+    slots, top_k, beam_width = 7, 16, 4
+    candidate_ids, scores, anchor = _lattice(bs=3, slots=slots, top_k=top_k, seed=5)
+    tokens, parents = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=anchor,
+        beam_width=beam_width,
+    )
+
+    for row in range(tokens.shape[0]):
+        for slot in range(slots):
+            base = 1 + slot * beam_width
+            groups = {}
+            for beam in range(beam_width):
+                parent = int(parents[row, base + beam])
+                groups.setdefault(parent, []).append(int(tokens[row, base + beam]))
+            for siblings in groups.values():
+                assert len(siblings) == len(set(siblings))
+
+
+def test_rows_are_normalized_before_the_scores_accumulate():
+    """Two predecessors with identical conditional distributions but rows offset by a
+    constant must compete equally: a logit row is only defined up to a per-row
+    additive constant, so accumulating raw scores lets the offset alone decide which
+    subtree eats the budget. Here the +10 row would take both free slots and starve
+    node 2 into a dead end."""
+    beam_width = top_k = 3
+    scores = torch.zeros(1, 2, top_k, top_k)
+    scores[0, 1, 0] = torch.tensor([0.0, -1.0, -2.0])
+    scores[0, 1, 1] = torch.tensor([0.0, -1.0, -2.0])
+    scores[0, 1, 2] = torch.tensor([10.0, 9.0, 8.0])
+    candidate_ids = torch.arange(2 * top_k).view(1, 2, top_k)
+
+    _, parents = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=torch.tensor([7]),
+        beam_width=beam_width,
+    )
+
+    # Depth 1 is nodes 1..3; every one of them must have kept a child.
+    assert sorted(int(p) for p in parents[0, 1 + beam_width :]) == [1, 2, 3]
+
+
+def test_exact_ties_break_beam_major():
+    """Flattening the pool as `beam * top_k + candidate` is a convention the torch
+    reference and the triton kernel have to share; c-major would pick a different
+    parent on a tie. Within-row ties are reproducible in both (equal inputs give equal
+    `log_softmax` outputs), so this pins the flattening without relying on luck."""
+    beam_width = top_k = 2
+    scores = torch.zeros(1, 2, top_k, top_k)
+    candidate_ids = torch.arange(2 * top_k).view(1, 2, top_k)
+
+    _, parents = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=torch.tensor([7]),
+        beam_width=beam_width,
+    )
+
+    # Depth 2 is nodes 3 and 4. Node 3 is the spine, under node 1. Every remaining
+    # pool entry ties, so beam-major hands node 4 to beam 0 -- node 1, not node 2.
+    assert parents[0, 3] == 1
+    assert parents[0, 4] == 1
+
+
+def test_beam_walk_rejects_a_width_above_the_candidate_count():
+    """Depth 1 only has top_k candidates, so a wider beam cannot fill a fixed width;
+    the resolved server args promise this never happens, and the walk says so rather
+    than silently emitting duplicates."""
+    selector = CandidateSelector(hidden_size=4, vocab_size=64, state_rank=2, top_k=4)
+    candidate_ids, scores, anchor = _lattice(bs=1, slots=3, top_k=4)
+    with pytest.raises(ValueError, match="selector_top_k"):
+        selector.beam_walk(
+            candidate_ids=candidate_ids,
+            scores=scores,
+            anchor_token_ids=anchor,
+            beam_width=8,
+        )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="triton needs a GPU")
+@pytest.mark.parametrize("beam_width", [1, 2, 3, 4, 8])
+def test_triton_beam_walk_matches_the_reference(beam_width):
+    """The kernel's first-max and register reductions are new code with no other
+    oracle. Separated scores keep every comparison gap far above fp32 noise, so
+    elementwise equality is meaningful; cross-row ties are explicitly not promised."""
+    slots, top_k = 7, 16
+    candidate_ids, scores, anchor = _lattice(bs=4, slots=slots, top_k=top_k, seed=11)
+    selector = CandidateSelector(
+        hidden_size=4, vocab_size=slots * top_k, state_rank=2, top_k=top_k
+    )
+
+    expected = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=anchor,
+        beam_width=beam_width,
+    )
+    actual = selector.beam_walk(
+        candidate_ids=candidate_ids.cuda(),
+        scores=scores.cuda(),
+        anchor_token_ids=anchor.cuda(),
+        beam_width=beam_width,
+    )
+
+    assert torch.equal(actual[0].cpu(), expected[0])
+    assert torch.equal(actual[1].cpu(), expected[1])
 
 
 def test_grouped_conv_supports_runtime_block_sizes():

--- a/test/registered/unit/spec/test_dflash_tree.py
+++ b/test/registered/unit/spec/test_dflash_tree.py
@@ -1,0 +1,230 @@
+"""Verify metadata for a DFLASH beam tree.
+
+The mask is the fragile part: attention reads it, and the accept kernel's links are
+derived from it, so a transposed or off-by-one closure is silently wrong rather than
+loud. These tests pin it from both ends -- structural invariants on the mask itself,
+and an independent host-side derivation of the links that has to agree with both the
+parents we started from and the device kernel we ship.
+"""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.srt.models.dflash import _beam_walk_torch
+from sglang.srt.speculative.dflash_tree import (
+    build_ancestor_mask,
+    build_dflash_tree_meta,
+    build_full_tree_mask,
+)
+
+# The NGRAM path's own host-side reimplementation of the device kernel. Independent
+# of everything here -- different author, different algorithm, and live code rather
+# than a test fixture (ngram_worker.py:455 uses it on the grammar path).
+from sglang.srt.speculative.ngram_worker import _derive_tree_links
+from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+# Only the real-kernel comparison needs a device; the mask algebra does not.
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+
+# block_size 8 is what the DFlash 2 checkpoint resolves to, so gamma is 7.
+GAMMA = 7
+PREFIX_LENS = torch.tensor([13, 5], dtype=torch.int64)
+
+
+def _beam_tree(*, width, slots=GAMMA, top_k=16, seed=0):
+    """`node_parents` from the real beam walk, at production shapes."""
+    batch_size = PREFIX_LENS.numel()
+    generator = torch.Generator().manual_seed(seed)
+    scores = torch.randint(
+        -5, 6, (batch_size, slots, top_k, top_k), generator=generator
+    ).float()
+    candidate_ids = (
+        torch.arange(slots * top_k)
+        .view(1, slots, top_k)
+        .expand(batch_size, slots, top_k)
+        .contiguous()
+    )
+    _, parents = _beam_walk_torch(
+        candidate_ids=candidate_ids,
+        scores=scores,
+        anchor_token_ids=torch.arange(batch_size) + 9001,
+        beam_width=width,
+    )
+    return parents
+
+
+def _expected_depths(*, num_nodes, width):
+    """Node 0 is the root; node `i` sits on layer `(i - 1) // width + 1`."""
+    return torch.cat(
+        [torch.zeros(1, dtype=torch.int64), torch.arange(num_nodes - 1) // width + 1]
+    )
+
+
+def _parents_from_links(*, next_token, next_sibling, num_nodes):
+    """Invert the first-child / next-sibling encoding back to a parent array."""
+    parents = [-1] * num_nodes
+    for node in range(num_nodes):
+        child = int(next_token[node])
+        while child != -1:
+            parents[child] = node
+            child = int(next_sibling[child])
+    return torch.tensor(parents, dtype=torch.int64)
+
+
+def test_width_one_closure_is_lower_triangular():
+    """W=1 degenerates to a chain, and the chain's closure is exactly what causal
+    masking already allows -- the regression gate for every later width."""
+    parents = _beam_tree(width=1)
+    batch_size, num_nodes = parents.shape
+    assert num_nodes == 1 + GAMMA
+
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+
+    causal = torch.tril(torch.ones(num_nodes, num_nodes, dtype=torch.bool))
+    assert torch.equal(mask, causal.expand(batch_size, num_nodes, num_nodes))
+
+
+@pytest.mark.parametrize("width", [1, 2, 4, 8])
+def test_closure_row_counts_give_the_layer_index(width):
+    """The kernel reads depth off the row population count, so a row holding one bit
+    too many or too few shifts that node's position -- and with it its RoPE and its
+    KV slot. Also pins that the root is an ancestor of every node."""
+    parents = _beam_tree(width=width)
+    batch_size, num_nodes = parents.shape
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+
+    depths = mask.sum(dim=-1) - 1
+    expected = _expected_depths(num_nodes=num_nodes, width=width)
+    assert torch.equal(depths, expected.expand(batch_size, num_nodes))
+    # The tree is exactly gamma deep: no shallower (a layer went missing) and no
+    # deeper (the closure leaked across layers).
+    assert int(depths.max()) == GAMMA
+    assert mask[:, :, 0].all()
+
+
+def test_closure_handles_dead_ends_and_uneven_fanout():
+    """The beam picks its width globally across parents, so a parent can end up with
+    no children at all. A hand-built tree covers the shapes a fixed-width lattice
+    cannot produce on demand -- node 1 is a dead end and node 3 is an only child."""
+    parents = torch.tensor([[-1, 0, 0, 2, 2, 3]], dtype=torch.int64)
+
+    mask = build_ancestor_mask(node_parents=parents, max_depth=3)
+
+    expected = torch.tensor(
+        [
+            [1, 0, 0, 0, 0, 0],
+            [1, 1, 0, 0, 0, 0],
+            [1, 0, 1, 0, 0, 0],
+            [1, 0, 1, 1, 0, 0],
+            [1, 0, 1, 0, 1, 0],
+            [1, 0, 1, 1, 0, 1],
+        ],
+        dtype=torch.bool,
+    )
+    assert torch.equal(mask[0], expected)
+
+
+@pytest.mark.parametrize("width", [1, 2, 4, 8])
+def test_full_mask_numel_matches_the_verify_sizing_formula(width):
+    """`DFlashVerifyInput.generate_attn_arg_prefill` pads the mask up to
+    `sum(prefix) * N + N**2 * bs`. If this producer disagrees, the pad path either
+    silently appends True columns or the backend reads past the rows it owns."""
+    parents = _beam_tree(width=width)
+    batch_size, num_nodes = parents.shape
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+
+    full = build_full_tree_mask(ancestor_mask=mask, prefix_lens_cpu=PREFIX_LENS)
+
+    expected = int(PREFIX_LENS.sum()) * num_nodes + num_nodes**2 * batch_size
+    assert full.numel() == expected
+
+
+def test_width_one_full_mask_is_exactly_causal():
+    """The mathematical precondition for keeping W=1 on the tree code path: the mask
+    we hand attention must permit exactly what running with no mask permits. If the
+    numbers still move at W=1, that isolates it to the backend's masked kernel path
+    rather than to this construction."""
+    parents = _beam_tree(width=1)
+    num_nodes = parents.shape[1]
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+
+    full = build_full_tree_mask(ancestor_mask=mask, prefix_lens_cpu=PREFIX_LENS)
+
+    causal = torch.tril(torch.ones(num_nodes, num_nodes, dtype=torch.bool))
+    expected = torch.cat(
+        [
+            torch.cat(
+                [torch.ones(num_nodes, int(prefix), dtype=torch.bool), causal], dim=1
+            ).flatten()
+            for prefix in PREFIX_LENS.tolist()
+        ]
+    )
+    assert torch.equal(full, expected)
+
+
+@pytest.mark.parametrize("width", [1, 2, 4, 8])
+def test_links_derived_from_the_mask_recover_the_parents(width):
+    """The round trip that makes the mask self-checking: parents -> mask -> links ->
+    parents. Transposing the mask, dropping the diagonal, or breaking the BFS order
+    the beam walk promises all break it."""
+    parents = _beam_tree(width=width)
+    batch_size, num_nodes = parents.shape
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+
+    next_token, next_sibling = _derive_tree_links(mask.numpy(), batch_size, num_nodes)
+
+    for request in range(batch_size):
+        recovered = _parents_from_links(
+            next_token=next_token[request],
+            next_sibling=next_sibling[request],
+            num_nodes=num_nodes,
+        )
+        assert torch.equal(recovered, parents[request])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="the kernel needs a device")
+@pytest.mark.parametrize("width", [1, 2, 4, 8])
+def test_kernel_meta_matches_the_host_derivation(width):
+    """The shipped path is the device kernel, and its only other oracle is NGRAM's
+    host reimplementation. `positions` has no host oracle at all, so it is checked
+    against the depths the mask itself carries, offset by the committed prefix."""
+    parents = _beam_tree(width=width)
+    batch_size, num_nodes = parents.shape
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+
+    positions, retrive_index, next_token, next_sibling = build_dflash_tree_meta(
+        ancestor_mask=mask.cuda(), prefix_lens=PREFIX_LENS.cuda()
+    )
+
+    expected_token, expected_sibling = _derive_tree_links(
+        mask.numpy(), batch_size, num_nodes
+    )
+    assert torch.equal(next_token.cpu(), expected_token)
+    assert torch.equal(next_sibling.cpu(), expected_sibling)
+    # The accept kernel indexes `predicts` through this, so anything but the flat
+    # identity would send the target's tokens to the wrong nodes.
+    assert torch.equal(
+        retrive_index.cpu(), torch.arange(batch_size * num_nodes).view(batch_size, -1)
+    )
+
+    depths = _expected_depths(num_nodes=num_nodes, width=width)
+    expected_positions = (PREFIX_LENS[:, None] + depths).flatten()
+    assert torch.equal(positions.cpu(), expected_positions)
+
+
+def test_tree_meta_rejects_narrow_prefix_lens():
+    """The CUDA kernel casts `verified_seq_len` to int64 without checking, so an
+    int32 `seq_lens` would be read as garbage positions instead of failing."""
+    parents = _beam_tree(width=2)
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+    with pytest.raises(ValueError, match="int64"):
+        build_dflash_tree_meta(
+            ancestor_mask=mask, prefix_lens=PREFIX_LENS.to(torch.int32)
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/spec/test_dflash_tree.py
+++ b/test/registered/unit/spec/test_dflash_tree.py
@@ -12,11 +12,12 @@ import sys
 import pytest
 import torch
 
+from sglang.kernels.ops.speculative.dflash import write_dflash_tree_full_mask
+from sglang.srt.layers.attention.verify_mask import fill_verify_mask_indptr
 from sglang.srt.models.dflash import _beam_walk_torch
 from sglang.srt.speculative.dflash_tree import (
     build_ancestor_mask,
     build_dflash_tree_meta,
-    build_full_tree_mask,
 )
 
 # The NGRAM path's own host-side reimplementation of the device kernel. Independent
@@ -32,6 +33,28 @@ register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
 # block_size 8 is what the DFlash 2 checkpoint resolves to, so gamma is 7.
 GAMMA = 7
 PREFIX_LENS = torch.tensor([13, 5], dtype=torch.int64)
+# Same batch shape, but long enough to make the kernel's prefix loop run several
+# times and end on a partial tile (PREFIX_BLOCK is 1024). A prefix that fits in one
+# tile would leave the loop's tail mask untested, and the tail is where a mask bug
+# spills into the next request's rows.
+LONG_PREFIX_LENS = torch.tensor([13, 2049], dtype=torch.int64)
+
+
+def _full_mask_reference(*, ancestor_mask, prefix_lens):
+    """Host derivation of the flat FULL_MASK the backends read.
+
+    Per request: `N` rows of `prefix + N` cells, the leading `prefix` all True (a
+    draft node sees the whole committed prefix) and the trailing block the request's
+    ancestor closure; requests concatenated. This is what the shipped kernel writes
+    on device, kept here as an independent oracle -- it is deliberately the naive
+    per-request python loop, which is what the kernel replaced.
+    """
+    num_nodes = ancestor_mask.shape[1]
+    rows = []
+    for request, prefix_len in enumerate(prefix_lens.tolist()):
+        prefix = torch.ones((num_nodes, int(prefix_len)), dtype=torch.bool)
+        rows.append(torch.cat([prefix, ancestor_mask[request].cpu()], dim=1).flatten())
+    return torch.cat(rows)
 
 
 def _beam_tree(*, width, slots=GAMMA, top_k=16, seed=0):
@@ -128,30 +151,42 @@ def test_closure_handles_dead_ends_and_uneven_fanout():
 
 
 @pytest.mark.parametrize("width", [1, 2, 4, 8])
-def test_full_mask_numel_matches_the_verify_sizing_formula(width):
-    """`DFlashVerifyInput.generate_attn_arg_prefill` pads the mask up to
-    `sum(prefix) * N + N**2 * bs`. If this producer disagrees, the pad path either
-    silently appends True columns or the backend reads past the rows it owns."""
+def test_row_offsets_and_layout_agree_on_the_total_size(width):
+    """Three descriptions of the same layout have to land on the same total.
+
+    `fill_verify_mask_indptr` is what the writer and the attention backend index with,
+    `_full_mask_reference` is the row-by-row layout, and
+    `DFlashVerifyInput.generate_attn_arg_prefill` sizes its padding from the closed form
+    `sum(prefix) * N + N**2 * bs`. Any one of the three drifting is a mask written where
+    the reader does not look, which is silently wrong tokens rather than an error.
+    """
     parents = _beam_tree(width=width)
     batch_size, num_nodes = parents.shape
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
 
-    full = build_full_tree_mask(ancestor_mask=mask, prefix_lens_cpu=PREFIX_LENS)
+    reference = _full_mask_reference(ancestor_mask=mask, prefix_lens=PREFIX_LENS)
+    indptr = fill_verify_mask_indptr(
+        mask_indptr=torch.zeros((batch_size + 1,), dtype=torch.int64),
+        seq_lens=PREFIX_LENS,
+        num_draft_tokens=num_nodes,
+        bs=batch_size,
+    )
 
-    expected = int(PREFIX_LENS.sum()) * num_nodes + num_nodes**2 * batch_size
-    assert full.numel() == expected
+    closed_form = int(PREFIX_LENS.sum()) * num_nodes + num_nodes**2 * batch_size
+    assert int(indptr[batch_size]) == closed_form
+    assert reference.numel() == closed_form
 
 
-def test_width_one_full_mask_is_exactly_causal():
+def test_width_one_mask_row_is_exactly_causal():
     """The mathematical precondition for keeping W=1 on the tree code path: the mask
     we hand attention must permit exactly what running with no mask permits. If the
     numbers still move at W=1, that isolates it to the backend's masked kernel path
-    rather than to this construction."""
+    rather than to the closure and layout pinned here."""
     parents = _beam_tree(width=1)
     num_nodes = parents.shape[1]
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
 
-    full = build_full_tree_mask(ancestor_mask=mask, prefix_lens_cpu=PREFIX_LENS)
+    full = _full_mask_reference(ancestor_mask=mask, prefix_lens=PREFIX_LENS)
 
     causal = torch.tril(torch.ones(num_nodes, num_nodes, dtype=torch.bool))
     expected = torch.cat(
@@ -224,6 +259,52 @@ def test_tree_meta_rejects_narrow_prefix_lens():
         build_dflash_tree_meta(
             ancestor_mask=mask, prefix_lens=PREFIX_LENS.to(torch.int32)
         )
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="the kernel needs a device")
+@pytest.mark.parametrize("width", [1, 4])
+@pytest.mark.parametrize("poison", [False, True])
+@pytest.mark.parametrize("dtype", [torch.bool, torch.uint8])
+def test_mask_kernel_rewrites_every_live_cell(width, poison, dtype):
+    """The shipped writer against the host oracle, in both buffer dtypes it meets.
+
+    The buffer is reused across decode steps and arrives holding the previous step's
+    bits, at different offsets, because a request's rows move as its prefix grows. So
+    every live cell has to be rewritten: `poison=True` catches a writer that skips
+    closure zeros, `poison=False` one that skips the all-True prefix span -- the
+    tempting "the prefix never changes" shortcut, which is wrong for exactly that
+    reason. `dtype` covers both buffers in production: the triton backend's captured
+    mask is uint8, the worker's own fallback is bool.
+    """
+    parents = _beam_tree(width=width)
+    batch_size, num_nodes = parents.shape
+    prefix_lens = LONG_PREFIX_LENS
+    ancestor_mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA).cuda()
+
+    expected = _full_mask_reference(
+        ancestor_mask=ancestor_mask, prefix_lens=prefix_lens
+    )
+    # Deliberately larger than needed, like the backend's captured buffer.
+    buffer = torch.full(
+        (expected.numel() + 4096,), poison, dtype=dtype, device="cuda"
+    )
+
+    written = write_dflash_tree_full_mask(
+        ancestor_mask=ancestor_mask,
+        mask_indptr=fill_verify_mask_indptr(
+            mask_indptr=torch.zeros(
+                (batch_size + 1,), dtype=torch.int64, device="cuda"
+            ),
+            seq_lens=prefix_lens.cuda(),
+            num_draft_tokens=num_nodes,
+            bs=batch_size,
+        ),
+        seq_lens=prefix_lens.cuda(),
+        out=buffer,
+    )
+
+    assert written.data_ptr() == buffer.data_ptr(), "must write in place"
+    assert torch.equal(written[: expected.numel()].cpu().bool(), expected)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_dflash_tree.py
+++ b/test/registered/unit/spec/test_dflash_tree.py
@@ -1,11 +1,4 @@
-"""Verify metadata for a DFLASH beam tree.
-
-The mask is the fragile part: attention reads it, and the accept kernel's links are
-derived from it, so a transposed or off-by-one closure is silently wrong rather than
-loud. These tests pin it from both ends -- structural invariants on the mask itself,
-and an independent host-side derivation of the links that has to agree with both the
-parents we started from and the device kernel we ship.
-"""
+"""Test DFLASH beam-tree masks and verification metadata."""
 
 import sys
 
@@ -20,9 +13,7 @@ from sglang.srt.speculative.dflash_tree import (
     build_dflash_tree_meta,
 )
 
-# The NGRAM path's own host-side reimplementation of the device kernel. Independent
-# of everything here -- different author, different algorithm, and live code rather
-# than a test fixture (ngram_worker.py:455 uses it on the grammar path).
+# Reuse the live NGRAM host implementation as an independent link oracle.
 from sglang.srt.speculative.ngram_worker import _derive_tree_links
 from sglang.test.ci.ci_register import register_cpu_ci, register_cuda_ci
 
@@ -30,25 +21,13 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 # Only the real-kernel comparison needs a device; the mask algebra does not.
 register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
 
-# block_size 8 is what the DFlash 2 checkpoint resolves to, so gamma is 7.
 GAMMA = 7
 PREFIX_LENS = torch.tensor([13, 5], dtype=torch.int64)
-# Same batch shape, but long enough to make the kernel's prefix loop run several
-# times and end on a partial tile (PREFIX_BLOCK is 1024). A prefix that fits in one
-# tile would leave the loop's tail mask untested, and the tail is where a mask bug
-# spills into the next request's rows.
 LONG_PREFIX_LENS = torch.tensor([13, 2049], dtype=torch.int64)
 
 
 def _full_mask_reference(*, ancestor_mask, prefix_lens):
-    """Host derivation of the flat FULL_MASK the backends read.
-
-    Per request: `N` rows of `prefix + N` cells, the leading `prefix` all True (a
-    draft node sees the whole committed prefix) and the trailing block the request's
-    ancestor closure; requests concatenated. This is what the shipped kernel writes
-    on device, kept here as an independent oracle -- it is deliberately the naive
-    per-request python loop, which is what the kernel replaced.
-    """
+    """Reference implementation of the flat full mask."""
     num_nodes = ancestor_mask.shape[1]
     rows = []
     for request, prefix_len in enumerate(prefix_lens.tolist()):
@@ -57,8 +36,8 @@ def _full_mask_reference(*, ancestor_mask, prefix_lens):
     return torch.cat(rows)
 
 
-def _beam_tree(*, width, slots=GAMMA, top_k=16, seed=0):
-    """`node_parents` from the real beam walk, at production shapes."""
+def _beam_tree(*, width, slots=GAMMA, top_k=16, seed=0, max_num_nodes=None):
+    """Return parents from the production-shaped beam walk."""
     batch_size = PREFIX_LENS.numel()
     generator = torch.Generator().manual_seed(seed)
     scores = torch.randint(
@@ -75,19 +54,20 @@ def _beam_tree(*, width, slots=GAMMA, top_k=16, seed=0):
         scores=scores,
         anchor_token_ids=torch.arange(batch_size) + 9001,
         beam_width=width,
+        max_num_nodes=max_num_nodes,
     )
     return parents
 
 
 def _expected_depths(*, num_nodes, width):
-    """Node 0 is the root; node `i` sits on layer `(i - 1) // width + 1`."""
+    """Return BFS layer indices."""
     return torch.cat(
         [torch.zeros(1, dtype=torch.int64), torch.arange(num_nodes - 1) // width + 1]
     )
 
 
 def _parents_from_links(*, next_token, next_sibling, num_nodes):
-    """Invert the first-child / next-sibling encoding back to a parent array."""
+    """Invert first-child/next-sibling links to parent indices."""
     parents = [-1] * num_nodes
     for node in range(num_nodes):
         child = int(next_token[node])
@@ -98,8 +78,7 @@ def _parents_from_links(*, next_token, next_sibling, num_nodes):
 
 
 def test_width_one_closure_is_lower_triangular():
-    """W=1 degenerates to a chain, and the chain's closure is exactly what causal
-    masking already allows -- the regression gate for every later width."""
+    """Width 1 must produce the causal chain mask."""
     parents = _beam_tree(width=1)
     batch_size, num_nodes = parents.shape
     assert num_nodes == 1 + GAMMA
@@ -112,9 +91,7 @@ def test_width_one_closure_is_lower_triangular():
 
 @pytest.mark.parametrize("width", [1, 2, 4, 8])
 def test_closure_row_counts_give_the_layer_index(width):
-    """The kernel reads depth off the row population count, so a row holding one bit
-    too many or too few shifts that node's position -- and with it its RoPE and its
-    KV slot. Also pins that the root is an ancestor of every node."""
+    """Closure row counts must recover each node's layer."""
     parents = _beam_tree(width=width)
     batch_size, num_nodes = parents.shape
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
@@ -122,16 +99,12 @@ def test_closure_row_counts_give_the_layer_index(width):
     depths = mask.sum(dim=-1) - 1
     expected = _expected_depths(num_nodes=num_nodes, width=width)
     assert torch.equal(depths, expected.expand(batch_size, num_nodes))
-    # The tree is exactly gamma deep: no shallower (a layer went missing) and no
-    # deeper (the closure leaked across layers).
     assert int(depths.max()) == GAMMA
     assert mask[:, :, 0].all()
 
 
 def test_closure_handles_dead_ends_and_uneven_fanout():
-    """The beam picks its width globally across parents, so a parent can end up with
-    no children at all. A hand-built tree covers the shapes a fixed-width lattice
-    cannot produce on demand -- node 1 is a dead end and node 3 is an only child."""
+    """Closure must handle dead ends and uneven fanout."""
     parents = torch.tensor([[-1, 0, 0, 2, 2, 3]], dtype=torch.int64)
 
     mask = build_ancestor_mask(node_parents=parents, max_depth=3)
@@ -152,14 +125,7 @@ def test_closure_handles_dead_ends_and_uneven_fanout():
 
 @pytest.mark.parametrize("width", [1, 2, 4, 8])
 def test_row_offsets_and_layout_agree_on_the_total_size(width):
-    """Three descriptions of the same layout have to land on the same total.
-
-    `fill_verify_mask_indptr` is what the writer and the attention backend index with,
-    `_full_mask_reference` is the row-by-row layout, and
-    `DFlashVerifyInput.generate_attn_arg_prefill` sizes its padding from the closed form
-    `sum(prefix) * N + N**2 * bs`. Any one of the three drifting is a mask written where
-    the reader does not look, which is silently wrong tokens rather than an error.
-    """
+    """Row offsets and full-mask size must agree."""
     parents = _beam_tree(width=width)
     batch_size, num_nodes = parents.shape
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
@@ -178,10 +144,7 @@ def test_row_offsets_and_layout_agree_on_the_total_size(width):
 
 
 def test_width_one_mask_row_is_exactly_causal():
-    """The mathematical precondition for keeping W=1 on the tree code path: the mask
-    we hand attention must permit exactly what running with no mask permits. If the
-    numbers still move at W=1, that isolates it to the backend's masked kernel path
-    rather than to the closure and layout pinned here."""
+    """Width 1 full mask must be exactly causal."""
     parents = _beam_tree(width=1)
     num_nodes = parents.shape[1]
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
@@ -202,9 +165,7 @@ def test_width_one_mask_row_is_exactly_causal():
 
 @pytest.mark.parametrize("width", [1, 2, 4, 8])
 def test_links_derived_from_the_mask_recover_the_parents(width):
-    """The round trip that makes the mask self-checking: parents -> mask -> links ->
-    parents. Transposing the mask, dropping the diagonal, or breaking the BFS order
-    the beam walk promises all break it."""
+    """Mask-derived links must recover the original parents."""
     parents = _beam_tree(width=width)
     batch_size, num_nodes = parents.shape
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
@@ -220,12 +181,37 @@ def test_links_derived_from_the_mask_recover_the_parents(width):
         assert torch.equal(recovered, parents[request])
 
 
+@pytest.mark.parametrize("width,max_num_nodes", [(8, 15), (8, 30), (16, 30)])
+def test_links_derived_from_the_mask_recover_a_pruned_tree(width, max_num_nodes):
+    """Mask-derived links must also recover pruned trees."""
+    parents = _beam_tree(width=width, max_num_nodes=max_num_nodes)
+    batch_size, num_nodes = parents.shape
+    assert num_nodes == max_num_nodes
+
+    child_counts = torch.zeros(num_nodes, dtype=torch.int64)
+    child_counts.scatter_add_(
+        0, parents[0, 1:].clamp(min=0), torch.ones(num_nodes - 1, dtype=torch.int64)
+    )
+    interior = child_counts[: num_nodes - 1]
+    assert (interior == 0).any(), "expected a parent the prune left childless"
+    assert (interior > 0).any() and int(interior.max()) < width
+
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+    next_token, next_sibling = _derive_tree_links(mask.numpy(), batch_size, num_nodes)
+
+    for request in range(batch_size):
+        recovered = _parents_from_links(
+            next_token=next_token[request],
+            next_sibling=next_sibling[request],
+            num_nodes=num_nodes,
+        )
+        assert torch.equal(recovered, parents[request])
+
+
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="the kernel needs a device")
 @pytest.mark.parametrize("width", [1, 2, 4, 8])
 def test_kernel_meta_matches_the_host_derivation(width):
-    """The shipped path is the device kernel, and its only other oracle is NGRAM's
-    host reimplementation. `positions` has no host oracle at all, so it is checked
-    against the depths the mask itself carries, offset by the committed prefix."""
+    """Device metadata must match host links and mask depths."""
     parents = _beam_tree(width=width)
     batch_size, num_nodes = parents.shape
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
@@ -239,8 +225,6 @@ def test_kernel_meta_matches_the_host_derivation(width):
     )
     assert torch.equal(next_token.cpu(), expected_token)
     assert torch.equal(next_sibling.cpu(), expected_sibling)
-    # The accept kernel indexes `predicts` through this, so anything but the flat
-    # identity would send the target's tokens to the wrong nodes.
     assert torch.equal(
         retrive_index.cpu(), torch.arange(batch_size * num_nodes).view(batch_size, -1)
     )
@@ -250,9 +234,28 @@ def test_kernel_meta_matches_the_host_derivation(width):
     assert torch.equal(positions.cpu(), expected_positions)
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="the kernel needs a device")
+@pytest.mark.parametrize("width,max_num_nodes", [(8, 15), (8, 30), (16, 30)])
+def test_kernel_positions_follow_the_closure_on_a_pruned_tree(width, max_num_nodes):
+    """Pruned node positions must follow mask-derived depths."""
+    parents = _beam_tree(width=width, max_num_nodes=max_num_nodes)
+    mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
+
+    positions, *_ = build_dflash_tree_meta(
+        ancestor_mask=mask.cuda(), prefix_lens=PREFIX_LENS.cuda()
+    )
+
+    depths = mask.sum(dim=2) - 1
+    assert int(depths.max()) < GAMMA + 1
+    assert not torch.equal(
+        depths[0], _expected_depths(num_nodes=max_num_nodes, width=width)
+    )
+    expected_positions = (PREFIX_LENS[:, None] + depths).flatten()
+    assert torch.equal(positions.cpu(), expected_positions)
+
+
 def test_tree_meta_rejects_narrow_prefix_lens():
-    """The CUDA kernel casts `verified_seq_len` to int64 without checking, so an
-    int32 `seq_lens` would be read as garbage positions instead of failing."""
+    """Reject prefix lengths with the wrong dtype for the CUDA kernel."""
     parents = _beam_tree(width=2)
     mask = build_ancestor_mask(node_parents=parents, max_depth=GAMMA)
     with pytest.raises(ValueError, match="int64"):
@@ -266,16 +269,7 @@ def test_tree_meta_rejects_narrow_prefix_lens():
 @pytest.mark.parametrize("poison", [False, True])
 @pytest.mark.parametrize("dtype", [torch.bool, torch.uint8])
 def test_mask_kernel_rewrites_every_live_cell(width, poison, dtype):
-    """The shipped writer against the host oracle, in both buffer dtypes it meets.
-
-    The buffer is reused across decode steps and arrives holding the previous step's
-    bits, at different offsets, because a request's rows move as its prefix grows. So
-    every live cell has to be rewritten: `poison=True` catches a writer that skips
-    closure zeros, `poison=False` one that skips the all-True prefix span -- the
-    tempting "the prefix never changes" shortcut, which is wrong for exactly that
-    reason. `dtype` covers both buffers in production: the triton backend's captured
-    mask is uint8, the worker's own fallback is bool.
-    """
+    """The device mask writer must rewrite every live cell."""
     parents = _beam_tree(width=width)
     batch_size, num_nodes = parents.shape
     prefix_lens = LONG_PREFIX_LENS
@@ -284,10 +278,7 @@ def test_mask_kernel_rewrites_every_live_cell(width, poison, dtype):
     expected = _full_mask_reference(
         ancestor_mask=ancestor_mask, prefix_lens=prefix_lens
     )
-    # Deliberately larger than needed, like the backend's captured buffer.
-    buffer = torch.full(
-        (expected.numel() + 4096,), poison, dtype=dtype, device="cuda"
-    )
+    buffer = torch.full((expected.numel() + 4096,), poison, dtype=dtype, device="cuda")
 
     written = write_dflash_tree_full_mask(
         ancestor_mask=ancestor_mask,

--- a/test/registered/unit/spec/test_dflash_tree_sampling_admission.py
+++ b/test/registered/unit/spec/test_dflash_tree_sampling_admission.py
@@ -1,0 +1,121 @@
+"""Who gets turned away when DFLASH verifies a tree instead of a chain.
+
+The tree is built by a beam walk over the candidate selector's transition lattice, and
+that walk emits no per-edge `q`. Every rejection-sampling accept in the repo needs one,
+so a tree run can only serve greedy requests. Two independent checks enforce that, and
+this file covers both plus the cases they must *not* catch:
+
+- `validate_dflash_request` (request admission, `dflash_utils.py`) -- the user-facing
+  arm. Rejecting here aborts one request with a readable message and leaves the server
+  serving.
+- `DFlashWorkerV2._validate_phase1_sampling_support` (batch entry) -- the backstop for
+  callers that build batches directly (unit tests, bench scripts) and never pass through
+  admission. Raising here is loud by design: the accept dispatch downstream derives gamma
+  from `block_size` and reads chain-shaped retrieve links, so on a tree it would
+  miscompute silently rather than fail.
+
+Both read one predicate, `dflash_tree_verify_active()`, so a request cannot be admitted
+on the chain's terms and then verified as a tree.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.environ import envs
+from sglang.srt.speculative.dflash_utils import validate_dflash_request
+from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+# `dflash_tree_verify_active` imports this lazily inside the function body, so patching
+# the definition site is what takes effect.
+_GET_SPEC = "sglang.srt.runtime_context.get_spec"
+
+# `SamplingParams.normalize` maps `temperature < eps` to `top_k = 1` and leaves an
+# unset top_k at TOP_K_ALL (1 << 30), which is why the admission check reads top_k
+# rather than temperature: it is the one field that is already normalized.
+_GREEDY_TOP_K = 1
+_SAMPLING_TOP_K = 1 << 30
+
+
+def _req(*, top_k: int):
+    return SimpleNamespace(
+        sampling_params=SimpleNamespace(top_k=top_k),
+        return_hidden_states=False,
+    )
+
+
+def _spec(*, tree_width):
+    return mock.patch(
+        _GET_SPEC,
+        return_value=SimpleNamespace(speculative_dflash_tree_width=tree_width),
+    )
+
+
+class TestDflashTreeRejectsSampling(CustomTestCase):
+    def test_sampling_request_rejected_on_a_tree(self):
+        with _spec(tree_width=4):
+            error = validate_dflash_request(
+                _req(top_k=_SAMPLING_TOP_K), enable_overlap=False
+            )
+
+        self.assertIsNotNone(error)
+        # Both escapes must be stated: one for the caller who wants this request served,
+        # one for the operator who wants the whole server to sample.
+        self.assertIn("temperature 0", error)
+        self.assertIn("--speculative-dflash-tree-width 1", error)
+
+    def test_batch_entry_backstops_a_non_greedy_batch(self):
+        # Reached only by callers that bypass request admission. Without this the batch
+        # would flow into an accept path that reads chain-shaped links off a tree.
+        worker = SimpleNamespace(_use_tree_verify=True)
+        batch = SimpleNamespace(sampling_info=SimpleNamespace(is_all_greedy=False))
+
+        with self.assertRaises(ValueError) as caught:
+            DFlashWorkerV2._validate_phase1_sampling_support(worker, batch)
+
+        self.assertIn("greedy", str(caught.exception))
+
+
+class TestDflashTreeAdmitsWhatItMust(CustomTestCase):
+    """The three shapes the rejection must not swallow."""
+
+    def test_greedy_request_admitted_on_a_tree(self):
+        # Guards the choice of `top_k` as the judgement: keyed on temperature instead,
+        # a temperature-0 request (normalized to temperature 1.0, top_k 1) reads as
+        # sampling and every greedy request on a tree run would be rejected.
+        with _spec(tree_width=4):
+            self.assertIsNone(
+                validate_dflash_request(_req(top_k=_GREEDY_TOP_K), enable_overlap=False)
+            )
+
+    def test_sampling_request_admitted_on_the_chain(self):
+        # DFLASH has always served sampling requests through `_selector_sampling_accept`.
+        # Only the tree lacks the per-edge q, so a predicate broadened to "is this
+        # DFLASH" would silently drop a capability that exists today.
+        with _spec(tree_width=1):
+            self.assertIsNone(
+                validate_dflash_request(
+                    _req(top_k=_SAMPLING_TOP_K), enable_overlap=False
+                )
+            )
+
+    def test_forced_tree_verify_rejects_sampling_at_width_one(self):
+        # SGLANG_DFLASH_FORCE_TREE_VERIFY is the one way the verify *shape* decouples
+        # from the resolved widths: tree_width stays 1 while the run verifies a tree. If
+        # the env drops out of the predicate, this configuration serves sampling requests
+        # through the greedy tree accept and silently ignores temperature and top_p.
+        with _spec(tree_width=1):
+            with envs.SGLANG_DFLASH_FORCE_TREE_VERIFY.override(True):
+                error = validate_dflash_request(
+                    _req(top_k=_SAMPLING_TOP_K), enable_overlap=False
+                )
+
+        self.assertIsNotNone(error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_tree_sampling_admission.py
+++ b/test/registered/unit/spec/test_dflash_tree_sampling_admission.py
@@ -1,22 +1,4 @@
-"""Who gets turned away when DFLASH verifies a tree instead of a chain.
-
-The tree is built by a beam walk over the candidate selector's transition lattice, and
-that walk emits no per-edge `q`. Every rejection-sampling accept in the repo needs one,
-so a tree run can only serve greedy requests. Two independent checks enforce that, and
-this file covers both plus the cases they must *not* catch:
-
-- `validate_dflash_request` (request admission, `dflash_utils.py`) -- the user-facing
-  arm. Rejecting here aborts one request with a readable message and leaves the server
-  serving.
-- `DFlashWorkerV2._validate_phase1_sampling_support` (batch entry) -- the backstop for
-  callers that build batches directly (unit tests, bench scripts) and never pass through
-  admission. Raising here is loud by design: the accept dispatch downstream derives gamma
-  from `block_size` and reads chain-shaped retrieve links, so on a tree it would
-  miscompute silently rather than fail.
-
-Both read one predicate, `dflash_tree_verify_active()`, so a request cannot be admitted
-on the chain's terms and then verified as a tree.
-"""
+"""Test DFLASH tree sampling admission."""
 
 import unittest
 from types import SimpleNamespace
@@ -41,17 +23,33 @@ _GREEDY_TOP_K = 1
 _SAMPLING_TOP_K = 1 << 30
 
 
-def _req(*, top_k: int):
+def _req(*, top_k: int, aborted: bool = False):
     return SimpleNamespace(
         sampling_params=SimpleNamespace(top_k=top_k),
         return_hidden_states=False,
+        # What `set_finish_with_abort` leaves behind: a rejected request still carries its
+        # original sampling_params into one forward pass.
+        to_finish=object() if aborted else None,
+        finished=lambda: False,
     )
 
 
-def _spec(*, tree_width):
+def _batch(*reqs):
+    return SimpleNamespace(
+        reqs=list(reqs),
+        sampling_info=SimpleNamespace(
+            is_all_greedy=all(r.sampling_params.top_k <= 1 for r in reqs)
+        ),
+    )
+
+
+def _spec(*, tree_width, algorithm="DFLASH"):
     return mock.patch(
         _GET_SPEC,
-        return_value=SimpleNamespace(speculative_dflash_tree_width=tree_width),
+        return_value=SimpleNamespace(
+            speculative_algorithm=algorithm,
+            speculative_dflash_tree_width=tree_width,
+        ),
     )
 
 
@@ -63,39 +61,58 @@ class TestDflashTreeRejectsSampling(CustomTestCase):
             )
 
         self.assertIsNotNone(error)
-        # Both escapes must be stated: one for the caller who wants this request served,
-        # one for the operator who wants the whole server to sample.
         self.assertIn("temperature 0", error)
         self.assertIn("--speculative-dflash-tree-width 1", error)
 
     def test_batch_entry_backstops_a_non_greedy_batch(self):
-        # Reached only by callers that bypass request admission. Without this the batch
-        # would flow into an accept path that reads chain-shaped links off a tree.
         worker = SimpleNamespace(_use_tree_verify=True)
-        batch = SimpleNamespace(sampling_info=SimpleNamespace(is_all_greedy=False))
+        batch = _batch(_req(top_k=_SAMPLING_TOP_K))
 
         with self.assertRaises(ValueError) as caught:
             DFlashWorkerV2._validate_phase1_sampling_support(worker, batch)
 
         self.assertIn("greedy", str(caught.exception))
 
+    def test_an_aborted_sampling_request_does_not_kill_the_worker(self):
+        """A rejected request must not take the scheduler down with it.
+
+        `validate_dflash_request` rejects a sampling request, but `set_finish_with_abort`
+        keeps it runnable -- it shortens origin_input_ids to one token instead of dropping
+        the request, and its sampling_params stay non-greedy. Raising here runs inside
+        `run_batch`, so it would turn a request-level 400 into a scheduler SIGQUIT.
+        """
+        # A tree worker always has a selector (tree width > 1 requires a DFlash 2
+        # checkpoint). The selector-enabled path handles the batch after the aborted
+        # request is exempted from the tree admission backstop.
+        worker = SimpleNamespace(
+            _use_tree_verify=True, selector=object(), _selector_sampling_enabled=True
+        )
+        batch = _batch(_req(top_k=_SAMPLING_TOP_K, aborted=True))
+
+        DFlashWorkerV2._validate_phase1_sampling_support(worker, batch)
+
+    def test_a_live_sampling_request_beside_an_aborted_one_still_raises(self):
+        # The abort exemption is per request, not "any abort disarms the check".
+        worker = SimpleNamespace(_use_tree_verify=True)
+        batch = _batch(
+            _req(top_k=_SAMPLING_TOP_K, aborted=True),
+            _req(top_k=_SAMPLING_TOP_K),
+        )
+
+        with self.assertRaises(ValueError):
+            DFlashWorkerV2._validate_phase1_sampling_support(worker, batch)
+
 
 class TestDflashTreeAdmitsWhatItMust(CustomTestCase):
-    """The three shapes the rejection must not swallow."""
+    """Cases that tree admission must not reject."""
 
     def test_greedy_request_admitted_on_a_tree(self):
-        # Guards the choice of `top_k` as the judgement: keyed on temperature instead,
-        # a temperature-0 request (normalized to temperature 1.0, top_k 1) reads as
-        # sampling and every greedy request on a tree run would be rejected.
         with _spec(tree_width=4):
             self.assertIsNone(
                 validate_dflash_request(_req(top_k=_GREEDY_TOP_K), enable_overlap=False)
             )
 
     def test_sampling_request_admitted_on_the_chain(self):
-        # DFLASH has always served sampling requests through `_selector_sampling_accept`.
-        # Only the tree lacks the per-edge q, so a predicate broadened to "is this
-        # DFLASH" would silently drop a capability that exists today.
         with _spec(tree_width=1):
             self.assertIsNone(
                 validate_dflash_request(
@@ -104,10 +121,6 @@ class TestDflashTreeAdmitsWhatItMust(CustomTestCase):
             )
 
     def test_forced_tree_verify_rejects_sampling_at_width_one(self):
-        # SGLANG_DFLASH_FORCE_TREE_VERIFY is the one way the verify *shape* decouples
-        # from the resolved widths: tree_width stays 1 while the run verifies a tree. If
-        # the env drops out of the predicate, this configuration serves sampling requests
-        # through the greedy tree accept and silently ignores temperature and top_p.
         with _spec(tree_width=1):
             with envs.SGLANG_DFLASH_FORCE_TREE_VERIFY.override(True):
                 error = validate_dflash_request(
@@ -115,6 +128,15 @@ class TestDflashTreeAdmitsWhatItMust(CustomTestCase):
                 )
 
         self.assertIsNotNone(error)
+
+    def test_force_tree_verify_is_ignored_by_dspark(self):
+        with _spec(tree_width=1, algorithm="DSPARK"):
+            with envs.SGLANG_DFLASH_FORCE_TREE_VERIFY.override(True):
+                self.assertIsNone(
+                    validate_dflash_request(
+                        _req(top_k=_SAMPLING_TOP_K), enable_overlap=False
+                    )
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/spec/test_dflash_tree_verify.py
+++ b/test/registered/unit/spec/test_dflash_tree_verify.py
@@ -1,0 +1,325 @@
+"""Wiring checks for DFLASH tree verify, one layer below the server.
+
+The gate this file exists to hold is the width-1 equivalence: a width-1 beam *is*
+the chain DFLASH has always drafted, so the tree accept must return the same
+tokens as the chain accept for the same inputs. The end-to-end version of that
+check needs two server launches; this one runs on tensors and can stay in CI.
+
+The rest covers what width 1 structurally cannot: the two places where the tree's
+"r-th accepted token" and "node r" diverge, both of which fail silently (wrong
+mamba state, wrong draft KV) rather than raising.
+"""
+
+import sys
+
+import pytest
+import torch
+
+from sglang.srt.speculative.dflash_tree_verify import (
+    accept_tree_greedy,
+    build_tree_verify_input,
+    commit_positions,
+    compact_hidden_to_commit_layout,
+)
+from sglang.srt.speculative.dflash_utils import (
+    compute_dflash_correct_drafts_and_bonus,
+)
+from sglang.srt.speculative.dflash_worker_v2 import _commit_accept
+from sglang.srt.speculative.spec_utils import verify_commit_step_indices
+from sglang.test.ci.ci_register import register_cuda_ci
+
+# `verify_tree_greedy` and the tree-meta kernel are CUDA-only in this build, and the
+# equivalence claim is about the shipped kernels, not a reimplementation of them.
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="the verify kernels need a device"
+)
+
+# block_size 8 is what the DFlash 2 checkpoint resolves to.
+BLOCK_SIZE = 8
+PREFIX_LENS = torch.tensor([13, 5], dtype=torch.int64)
+
+
+def _chain_parents(*, bs, block_size):
+    """`node_parents` for a width-1 beam: node i hangs off node i-1."""
+    parents = torch.arange(-1, block_size - 1, dtype=torch.int64)
+    return parents.unsqueeze(0).expand(bs, block_size).contiguous()
+
+
+def _logits_from_predictions(target_predict):
+    """One-hot logits, so `argmax` inside the accept returns `target_predict`."""
+    bs, width = target_predict.shape
+    logits = torch.zeros((bs * width, 4096), dtype=torch.float32)
+    logits.scatter_(1, target_predict.reshape(-1, 1).to(torch.int64), 1.0)
+    return logits.cuda()
+
+
+def _equivalence_case():
+    """Three requests covering the accept-length boundaries: partial, none, all.
+
+    The chain rule is `candidates[:, 1:] == target_predict[:, :-1]` consecutively,
+    so each row is built by choosing where that equality first breaks.
+    """
+    candidates = torch.tensor(
+        [
+            [100, 101, 102, 103, 999, 105, 106, 107],
+            [200, 777, 202, 203, 204, 205, 206, 207],
+            [300, 301, 302, 303, 304, 305, 306, 307],
+        ],
+        dtype=torch.int64,
+    )
+    target_predict = torch.tensor(
+        [
+            [101, 102, 103, 888, 700, 701, 702, 703],
+            [201, 800, 801, 802, 803, 804, 805, 806],
+            [301, 302, 303, 304, 305, 306, 307, 308],
+        ],
+        dtype=torch.int64,
+    )
+    return candidates, target_predict
+
+
+def test_width_one_tree_accept_matches_the_chain():
+    """The gate. A width-1 beam is the chain, so both accepts must commit the same
+    run: same length, same tokens, same bonus (the next block's anchor). Breaks on a
+    transposed mask, an off-by-one in the link derivation, a wrong `out_tokens`
+    stride, or a bonus read at the wrong offset."""
+    candidates, target_predict = _equivalence_case()
+    bs = candidates.shape[0]
+    prefix_lens = torch.tensor([13, 5, 21], dtype=torch.int64)
+
+    chain_len, chain_bonus = compute_dflash_correct_drafts_and_bonus(
+        candidates=candidates.cuda(), target_predict=target_predict.cuda()
+    )
+    chain_out, chain_commit = _commit_accept(candidates.cuda(), chain_len, chain_bonus)
+    # Guards the fixture itself: if every row accepted the same amount the
+    # comparison below would pass without discriminating anything.
+    assert chain_commit.cpu().tolist() == [4, 1, 8]
+
+    verify_input = build_tree_verify_input(
+        node_tokens=candidates.cuda(),
+        node_parents=_chain_parents(bs=bs, block_size=BLOCK_SIZE).cuda(),
+        block_size=BLOCK_SIZE,
+        tree_width=1,
+        prefix_lens=prefix_lens.cuda(),
+        prefix_lens_cpu=prefix_lens,
+    )
+    accepted = accept_tree_greedy(
+        verify_input=verify_input,
+        next_token_logits=_logits_from_predictions(target_predict),
+        bs=bs,
+    )
+
+    assert torch.equal(accepted.commit_lens.cpu(), chain_commit.cpu())
+    assert torch.equal(
+        accepted.bonus_tokens.cpu().to(torch.int64), chain_bonus.cpu().to(torch.int64)
+    )
+    for request, length in enumerate(chain_commit.cpu().tolist()):
+        assert torch.equal(
+            accepted.out_tokens[request, :length].cpu().to(torch.int64),
+            chain_out[request, :length].cpu(),
+        ), f"request {request} committed a different run"
+
+
+def test_width_one_accept_index_is_the_identity_chain():
+    """The first diagnostic to reach for when the gate above goes red: on a chain the
+    accepted nodes must be node 0, 1, 2, ... of each request's own block, so
+    `accept_index` is `bs_idx * N + arange`. A tree-shaped bug shows up here before it
+    shows up in the tokens."""
+    candidates, target_predict = _equivalence_case()
+    bs = candidates.shape[0]
+    prefix_lens = torch.tensor([13, 5, 21], dtype=torch.int64)
+
+    verify_input = build_tree_verify_input(
+        node_tokens=candidates.cuda(),
+        node_parents=_chain_parents(bs=bs, block_size=BLOCK_SIZE).cuda(),
+        block_size=BLOCK_SIZE,
+        tree_width=1,
+        prefix_lens=prefix_lens.cuda(),
+        prefix_lens_cpu=prefix_lens,
+    )
+    accepted = accept_tree_greedy(
+        verify_input=verify_input,
+        next_token_logits=_logits_from_predictions(target_predict),
+        bs=bs,
+    )
+
+    accept_index = accepted.accept_index.cpu()
+    for request, length in enumerate(accepted.commit_lens.cpu().tolist()):
+        expected = request * BLOCK_SIZE + torch.arange(length, dtype=torch.int32)
+        assert torch.equal(accept_index[request, :length], expected)
+        assert (accept_index[request, length:] == -1).all()
+
+
+def test_predict_stays_in_vocabulary_where_accept_index_pads():
+    """`compute_spec_logprobs` gathers through the whole `accept_index`, pad included,
+    and -1 resolves to `predict[-1]` instead of raising. So every slot of `predict`
+    must hold a valid token id even where no node was accepted -- an uninitialized
+    buffer here is a device-side assert in the logprob gather, and only for requests
+    that accept fewer tokens than the tree is deep. Turns red if `predict` goes back
+    to `torch.empty`."""
+    candidates, target_predict = _equivalence_case()
+    bs = candidates.shape[0]
+    prefix_lens = torch.tensor([13, 5, 21], dtype=torch.int64)
+    logits = _logits_from_predictions(target_predict)
+
+    verify_input = build_tree_verify_input(
+        node_tokens=candidates.cuda(),
+        node_parents=_chain_parents(bs=bs, block_size=BLOCK_SIZE).cuda(),
+        block_size=BLOCK_SIZE,
+        tree_width=1,
+        prefix_lens=prefix_lens.cuda(),
+        prefix_lens_cpu=prefix_lens,
+    )
+    accepted = accept_tree_greedy(
+        verify_input=verify_input, next_token_logits=logits, bs=bs
+    )
+
+    # The fixture's second request accepts 1 of 8, so the pad is populated.
+    assert (accepted.accept_index == -1).any()
+    padded_reads = accepted.predict[accepted.accept_index.to(torch.int64).reshape(-1)]
+    assert int(padded_reads.min()) >= 0
+    assert int(padded_reads.max()) < logits.shape[-1]
+
+
+# --- What width 1 cannot cover: the two places node index != accepted depth. ---
+
+# A width-2 beam over block_size 8: 15 nodes, depth d holds nodes 2d-1 and 2d.
+TREE_WIDTH = 2
+VERIFY_WIDTH = 1 + (BLOCK_SIZE - 1) * TREE_WIDTH
+# root -> node 2 -> node 4: an accepted path that leaves the spine, so no node index
+# equals its depth. -1 pads the depths past the accepted run.
+OFF_SPINE_ACCEPT = [0, 2, 4] + [-1] * (BLOCK_SIZE - 3)
+
+
+def _off_spine_accept_index(*, bs):
+    row = torch.tensor(OFF_SPINE_ACCEPT, dtype=torch.int32)
+    offsets = torch.arange(bs, dtype=torch.int32) * VERIFY_WIDTH
+    # Flat node ids, per request, with the -1 pad preserved.
+    return torch.where(row.unsqueeze(0) < 0, row.unsqueeze(0), row + offsets[:, None])
+
+
+def _fixed_width_parents(*, block_size, tree_width):
+    """A valid fixed-width tree: depth 1 hangs off the root, and each deeper depth
+    spreads its `tree_width` nodes over the previous depth's nodes round-robin. BFS
+    ordered, so `node_parents[i] < i`, which is what the beam walk promises."""
+    parents = [-1]
+    for depth in range(1, block_size):
+        prev_first = 1 + (depth - 2) * tree_width if depth >= 2 else 0
+        prev_count = tree_width if depth >= 2 else 1
+        parents.extend(prev_first + slot % prev_count for slot in range(tree_width))
+    return torch.tensor(parents, dtype=torch.int64)
+
+
+class _StubBatch:
+    """The two fields `verify_commit_step_indices` reads. A real ScheduleBatch would
+    drag a memory pool and an allocator into a test about index arithmetic."""
+
+    def __init__(self, seq_lens):
+        self.seq_lens = seq_lens
+        self.mamba_track_indices = None
+
+
+def test_mamba_step_index_follows_the_node_not_the_depth():
+    """`intermediate_ssm` is keyed by node index over the verify window, so the state
+    to commit is the last accepted *node* -- 4 here, not 2. Turns red if the tree path
+    ever falls back to the chain's `commit_lens - 1`, which is the shape of this bug
+    that neither a width-1 run nor a crash would reveal."""
+    bs = 2
+    accept_index = _off_spine_accept_index(bs=bs).cuda()
+    commit_lens = torch.full((bs,), 3, dtype=torch.int32, device="cuda")
+
+    last_step, track_step = verify_commit_step_indices(
+        batch=_StubBatch(seq_lens=torch.tensor([13, 5], device="cuda")),
+        accept_index=accept_index,
+        accept_lens=commit_lens,
+        draft_token_num=VERIFY_WIDTH,
+    )
+
+    assert last_step.cpu().tolist() == [4, 4]
+    # The chain formula would have said 2; that it disagrees is the whole point.
+    assert last_step.cpu().tolist() != (commit_lens.cpu() - 1).tolist()
+    assert track_step is None  # tracking off -> no interval-crossing step
+
+
+def test_commit_layout_gathers_source_rows_and_chain_positions():
+    """The draft-KV writeback commits row r into `cache_loc_2d[i, r]` and never looks
+    at `accept_index`, so the gather has to happen on the *rows*: after compaction row
+    r must be the node accepted at depth r. Positions follow the compacted layout, so
+    they are `prefix + r` -- the per-node depths verify ran with would mis-rope every
+    off-spine node."""
+    bs = 2
+    accept_index = _off_spine_accept_index(bs=bs).cuda()
+    # Row content encodes its own flat node id, so a wrong gather is readable.
+    hidden = (
+        torch.arange(bs * VERIFY_WIDTH, dtype=torch.float32)
+        .unsqueeze(1)
+        .expand(bs * VERIFY_WIDTH, 8)
+        .contiguous()
+        .cuda()
+    )
+
+    compacted = compact_hidden_to_commit_layout(
+        target_hidden=hidden,
+        accept_index=accept_index,
+        bs=bs,
+        verify_width=VERIFY_WIDTH,
+    ).view(bs, VERIFY_WIDTH, 8)
+
+    for request in range(bs):
+        for depth, node in enumerate(OFF_SPINE_ACCEPT[:3]):
+            expected = request * VERIFY_WIDTH + node
+            assert compacted[request, depth, 0].item() == expected, (
+                f"depth {depth} of request {request} holds row "
+                f"{compacted[request, depth, 0].item()}, not node {expected}"
+            )
+
+    positions = commit_positions(
+        prefix_lens=PREFIX_LENS.cuda(), verify_width=VERIFY_WIDTH
+    ).view(bs, VERIFY_WIDTH)
+    for request, prefix in enumerate(PREFIX_LENS.tolist()):
+        assert torch.equal(
+            positions[request].cpu(),
+            prefix + torch.arange(VERIFY_WIDTH, dtype=torch.int64),
+        )
+
+
+def test_tree_meta_links_match_the_beam_parents():
+    """Cross-check that the links the accept walks come from the parents the beam
+    emitted, at a width the gate above cannot reach. `test_dflash_tree.py` pins the
+    mask algebra; this pins that `build_tree_verify_input` hands the kernel the same
+    tree rather than a transposed or stale one."""
+    bs = 2
+    node_parents = (
+        _fixed_width_parents(block_size=BLOCK_SIZE, tree_width=TREE_WIDTH)
+        .unsqueeze(0)
+        .expand(bs, -1)
+        .contiguous()
+    )
+    assert node_parents.shape[1] == VERIFY_WIDTH
+
+    verify_input = build_tree_verify_input(
+        node_tokens=torch.arange(bs * VERIFY_WIDTH, dtype=torch.int64)
+        .view(bs, VERIFY_WIDTH)
+        .cuda(),
+        node_parents=node_parents.cuda(),
+        block_size=BLOCK_SIZE,
+        tree_width=TREE_WIDTH,
+        prefix_lens=PREFIX_LENS.cuda(),
+        prefix_lens_cpu=PREFIX_LENS,
+    )
+
+    recovered = [-1] * VERIFY_WIDTH
+    next_token = verify_input.retrieve_next_token[0].cpu().tolist()
+    next_sibling = verify_input.retrieve_next_sibling[0].cpu().tolist()
+    for node in range(VERIFY_WIDTH):
+        child = next_token[node]
+        while child != -1:
+            recovered[child] = node
+            child = next_sibling[child]
+    assert recovered == node_parents[0].tolist()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/spec/test_dflash_tree_verify.py
+++ b/test/registered/unit/spec/test_dflash_tree_verify.py
@@ -47,6 +47,25 @@ def _chain_parents(*, bs, block_size):
     return parents.unsqueeze(0).expand(bs, block_size).contiguous()
 
 
+def _mask_scratch(*, prefix_lens, num_nodes):
+    """The buffers `build_tree_verify_input` writes the flat mask into.
+
+    Production passes the attention backend's own captured buffer so verify reads the
+    mask in place; a test only needs something at least as large, because the row
+    offsets are computed on device from `prefix_lens` either way.
+    """
+    return {
+        "mask_buffer": torch.zeros(
+            num_nodes * int((prefix_lens + num_nodes).sum()),
+            dtype=torch.bool,
+            device="cuda",
+        ),
+        "mask_indptr": torch.zeros(
+            prefix_lens.numel() + 1, dtype=torch.int64, device="cuda"
+        ),
+    }
+
+
 def _logits_from_predictions(target_predict):
     """One-hot logits, so `argmax` inside the accept returns `target_predict`."""
     bs, width = target_predict.shape
@@ -103,7 +122,7 @@ def test_width_one_tree_accept_matches_the_chain():
         block_size=BLOCK_SIZE,
         tree_width=1,
         prefix_lens=prefix_lens.cuda(),
-        prefix_lens_cpu=prefix_lens,
+        **_mask_scratch(prefix_lens=prefix_lens, num_nodes=BLOCK_SIZE),
     )
     accepted = accept_tree_greedy(
         verify_input=verify_input,
@@ -137,7 +156,7 @@ def test_width_one_accept_index_is_the_identity_chain():
         block_size=BLOCK_SIZE,
         tree_width=1,
         prefix_lens=prefix_lens.cuda(),
-        prefix_lens_cpu=prefix_lens,
+        **_mask_scratch(prefix_lens=prefix_lens, num_nodes=BLOCK_SIZE),
     )
     accepted = accept_tree_greedy(
         verify_input=verify_input,
@@ -170,7 +189,7 @@ def test_predict_stays_in_vocabulary_where_accept_index_pads():
         block_size=BLOCK_SIZE,
         tree_width=1,
         prefix_lens=prefix_lens.cuda(),
-        prefix_lens_cpu=prefix_lens,
+        **_mask_scratch(prefix_lens=prefix_lens, num_nodes=BLOCK_SIZE),
     )
     accepted = accept_tree_greedy(
         verify_input=verify_input, next_token_logits=logits, bs=bs
@@ -307,7 +326,7 @@ def test_tree_meta_links_match_the_beam_parents():
         block_size=BLOCK_SIZE,
         tree_width=TREE_WIDTH,
         prefix_lens=PREFIX_LENS.cuda(),
-        prefix_lens_cpu=PREFIX_LENS,
+        **_mask_scratch(prefix_lens=PREFIX_LENS, num_nodes=VERIFY_WIDTH),
     )
 
     recovered = [-1] * VERIFY_WIDTH

--- a/test/registered/unit/spec/test_dflash_tree_verify.py
+++ b/test/registered/unit/spec/test_dflash_tree_verify.py
@@ -1,14 +1,4 @@
-"""Wiring checks for DFLASH tree verify, one layer below the server.
-
-The gate this file exists to hold is the width-1 equivalence: a width-1 beam *is*
-the chain DFLASH has always drafted, so the tree accept must return the same
-tokens as the chain accept for the same inputs. The end-to-end version of that
-check needs two server launches; this one runs on tensors and can stay in CI.
-
-The rest covers what width 1 structurally cannot: the two places where the tree's
-"r-th accepted token" and "node r" diverge, both of which fail silently (wrong
-mamba state, wrong draft KV) rather than raising.
-"""
+"""Test DFLASH tree verification wiring and chain equivalence."""
 
 import sys
 
@@ -28,15 +18,13 @@ from sglang.srt.speculative.dflash_worker_v2 import _commit_accept
 from sglang.srt.speculative.spec_utils import verify_commit_step_indices
 from sglang.test.ci.ci_register import register_cuda_ci
 
-# `verify_tree_greedy` and the tree-meta kernel are CUDA-only in this build, and the
-# equivalence claim is about the shipped kernels, not a reimplementation of them.
+# These tests cover CUDA-only verification kernels.
 register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
 
 pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(), reason="the verify kernels need a device"
 )
 
-# block_size 8 is what the DFlash 2 checkpoint resolves to.
 BLOCK_SIZE = 8
 PREFIX_LENS = torch.tensor([13, 5], dtype=torch.int64)
 
@@ -48,12 +36,7 @@ def _chain_parents(*, bs, block_size):
 
 
 def _mask_scratch(*, prefix_lens, num_nodes):
-    """The buffers `build_tree_verify_input` writes the flat mask into.
-
-    Production passes the attention backend's own captured buffer so verify reads the
-    mask in place; a test only needs something at least as large, because the row
-    offsets are computed on device from `prefix_lens` either way.
-    """
+    """Return test buffers for the device-side full mask writer."""
     return {
         "mask_buffer": torch.zeros(
             num_nodes * int((prefix_lens + num_nodes).sum()),
@@ -75,11 +58,7 @@ def _logits_from_predictions(target_predict):
 
 
 def _equivalence_case():
-    """Three requests covering the accept-length boundaries: partial, none, all.
-
-    The chain rule is `candidates[:, 1:] == target_predict[:, :-1]` consecutively,
-    so each row is built by choosing where that equality first breaks.
-    """
+    """Return partial, empty, and full acceptance cases."""
     candidates = torch.tensor(
         [
             [100, 101, 102, 103, 999, 105, 106, 107],
@@ -100,10 +79,7 @@ def _equivalence_case():
 
 
 def test_width_one_tree_accept_matches_the_chain():
-    """The gate. A width-1 beam is the chain, so both accepts must commit the same
-    run: same length, same tokens, same bonus (the next block's anchor). Breaks on a
-    transposed mask, an off-by-one in the link derivation, a wrong `out_tokens`
-    stride, or a bonus read at the wrong offset."""
+    """Width-one tree acceptance must match chain acceptance."""
     candidates, target_predict = _equivalence_case()
     bs = candidates.shape[0]
     prefix_lens = torch.tensor([13, 5, 21], dtype=torch.int64)
@@ -112,8 +88,6 @@ def test_width_one_tree_accept_matches_the_chain():
         candidates=candidates.cuda(), target_predict=target_predict.cuda()
     )
     chain_out, chain_commit = _commit_accept(candidates.cuda(), chain_len, chain_bonus)
-    # Guards the fixture itself: if every row accepted the same amount the
-    # comparison below would pass without discriminating anything.
     assert chain_commit.cpu().tolist() == [4, 1, 8]
 
     verify_input = build_tree_verify_input(
@@ -142,10 +116,7 @@ def test_width_one_tree_accept_matches_the_chain():
 
 
 def test_width_one_accept_index_is_the_identity_chain():
-    """The first diagnostic to reach for when the gate above goes red: on a chain the
-    accepted nodes must be node 0, 1, 2, ... of each request's own block, so
-    `accept_index` is `bs_idx * N + arange`. A tree-shaped bug shows up here before it
-    shows up in the tokens."""
+    """Width-one accept indices must be the identity chain."""
     candidates, target_predict = _equivalence_case()
     bs = candidates.shape[0]
     prefix_lens = torch.tensor([13, 5, 21], dtype=torch.int64)
@@ -172,12 +143,7 @@ def test_width_one_accept_index_is_the_identity_chain():
 
 
 def test_predict_stays_in_vocabulary_where_accept_index_pads():
-    """`compute_spec_logprobs` gathers through the whole `accept_index`, pad included,
-    and -1 resolves to `predict[-1]` instead of raising. So every slot of `predict`
-    must hold a valid token id even where no node was accepted -- an uninitialized
-    buffer here is a device-side assert in the logprob gather, and only for requests
-    that accept fewer tokens than the tree is deep. Turns red if `predict` goes back
-    to `torch.empty`."""
+    """Padded accept indices must gather valid prediction tokens."""
     candidates, target_predict = _equivalence_case()
     bs = candidates.shape[0]
     prefix_lens = torch.tensor([13, 5, 21], dtype=torch.int64)
@@ -195,20 +161,15 @@ def test_predict_stays_in_vocabulary_where_accept_index_pads():
         verify_input=verify_input, next_token_logits=logits, bs=bs
     )
 
-    # The fixture's second request accepts 1 of 8, so the pad is populated.
     assert (accepted.accept_index == -1).any()
     padded_reads = accepted.predict[accepted.accept_index.to(torch.int64).reshape(-1)]
     assert int(padded_reads.min()) >= 0
     assert int(padded_reads.max()) < logits.shape[-1]
 
 
-# --- What width 1 cannot cover: the two places node index != accepted depth. ---
-
-# A width-2 beam over block_size 8: 15 nodes, depth d holds nodes 2d-1 and 2d.
+# An off-spine accepted path exercises node/depth differences.
 TREE_WIDTH = 2
 VERIFY_WIDTH = 1 + (BLOCK_SIZE - 1) * TREE_WIDTH
-# root -> node 2 -> node 4: an accepted path that leaves the spine, so no node index
-# equals its depth. -1 pads the depths past the accepted run.
 OFF_SPINE_ACCEPT = [0, 2, 4] + [-1] * (BLOCK_SIZE - 3)
 
 
@@ -220,9 +181,7 @@ def _off_spine_accept_index(*, bs):
 
 
 def _fixed_width_parents(*, block_size, tree_width):
-    """A valid fixed-width tree: depth 1 hangs off the root, and each deeper depth
-    spreads its `tree_width` nodes over the previous depth's nodes round-robin. BFS
-    ordered, so `node_parents[i] < i`, which is what the beam walk promises."""
+    """Build a valid BFS-ordered fixed-width tree."""
     parents = [-1]
     for depth in range(1, block_size):
         prev_first = 1 + (depth - 2) * tree_width if depth >= 2 else 0
@@ -232,8 +191,7 @@ def _fixed_width_parents(*, block_size, tree_width):
 
 
 class _StubBatch:
-    """The two fields `verify_commit_step_indices` reads. A real ScheduleBatch would
-    drag a memory pool and an allocator into a test about index arithmetic."""
+    """Minimal batch stub for verify commit-index arithmetic."""
 
     def __init__(self, seq_lens):
         self.seq_lens = seq_lens
@@ -241,10 +199,7 @@ class _StubBatch:
 
 
 def test_mamba_step_index_follows_the_node_not_the_depth():
-    """`intermediate_ssm` is keyed by node index over the verify window, so the state
-    to commit is the last accepted *node* -- 4 here, not 2. Turns red if the tree path
-    ever falls back to the chain's `commit_lens - 1`, which is the shape of this bug
-    that neither a width-1 run nor a crash would reveal."""
+    """Mamba commit index must follow the last accepted node."""
     bs = 2
     accept_index = _off_spine_accept_index(bs=bs).cuda()
     commit_lens = torch.full((bs,), 3, dtype=torch.int32, device="cuda")
@@ -257,20 +212,14 @@ def test_mamba_step_index_follows_the_node_not_the_depth():
     )
 
     assert last_step.cpu().tolist() == [4, 4]
-    # The chain formula would have said 2; that it disagrees is the whole point.
     assert last_step.cpu().tolist() != (commit_lens.cpu() - 1).tolist()
     assert track_step is None  # tracking off -> no interval-crossing step
 
 
 def test_commit_layout_gathers_source_rows_and_chain_positions():
-    """The draft-KV writeback commits row r into `cache_loc_2d[i, r]` and never looks
-    at `accept_index`, so the gather has to happen on the *rows*: after compaction row
-    r must be the node accepted at depth r. Positions follow the compacted layout, so
-    they are `prefix + r` -- the per-node depths verify ran with would mis-rope every
-    off-spine node."""
+    """Compaction must map accepted nodes to chain slots and positions."""
     bs = 2
     accept_index = _off_spine_accept_index(bs=bs).cuda()
-    # Row content encodes its own flat node id, so a wrong gather is readable.
     hidden = (
         torch.arange(bs * VERIFY_WIDTH, dtype=torch.float32)
         .unsqueeze(1)
@@ -305,10 +254,7 @@ def test_commit_layout_gathers_source_rows_and_chain_positions():
 
 
 def test_tree_meta_links_match_the_beam_parents():
-    """Cross-check that the links the accept walks come from the parents the beam
-    emitted, at a width the gate above cannot reach. `test_dflash_tree.py` pins the
-    mask algebra; this pins that `build_tree_verify_input` hands the kernel the same
-    tree rather than a transposed or stale one."""
+    """Tree metadata links must match beam parents."""
     bs = 2
     node_parents = (
         _fixed_width_parents(block_size=BLOCK_SIZE, tree_width=TREE_WIDTH)

--- a/test/registered/unit/spec/test_dflash_tree_width_args.py
+++ b/test/registered/unit/spec/test_dflash_tree_width_args.py
@@ -1,0 +1,297 @@
+"""ServerArgs-level tests for DFLASH tree drafting (phase A: config surface only).
+
+What these lock down: DFLASH used to carry one width (`speculative_num_draft_tokens`) that
+served as both the draft block width and the target's verify width. Tree drafting splits it
+into three -- block width, verify width `1 + (block_size - 1) * tree_width`, and the per-depth
+beam width parked in `speculative_eagle_topk`. Tree width 1 must resolve byte-identically to
+the pre-split behaviour, since that equality is the regression gate for every later phase.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.arg_groups.overrides import resolved_view
+from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.environ import envs
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+_HOOK = "sglang.srt.arg_groups.speculative_hook"
+
+
+def _draft_config(block_size=8, selector_rank=64, selector_top_k=16):
+    """Stand-in for the parsed `dflash_config` of a DFlash 2 draft checkpoint."""
+    return SimpleNamespace(
+        block_size=block_size,
+        selector_rank=selector_rank,
+        selector_top_k=selector_top_k,
+        resolve_block_size=lambda default=None: (
+            block_size if block_size is not None else default
+        ),
+    )
+
+
+def _make_args(**overrides) -> ServerArgs:
+    # model_path="dummy" short-circuits ServerArgs.__post_init__; the hook is invoked
+    # directly, same as the other unit/spec ServerArgs tests.
+    args = ServerArgs(model_path="dummy")
+    args.speculative_algorithm = "DFLASH"
+    args.speculative_draft_model_path = "dummy-draft"
+    args.device = "cuda"
+    args.get_model_config = lambda: SimpleNamespace(
+        hf_config=SimpleNamespace(
+            architectures=["Qwen3NextForCausalLM"],
+            get_text_config=lambda: SimpleNamespace(),
+        )
+    )
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+def _resolve(args: ServerArgs, draft_config=None, *, readable=True):
+    """Run the speculative hook with every draft-checkpoint read stubbed out, and return the
+    resolved view.
+
+    The hook declares its decisions instead of writing fields, so the record still holds the
+    raw input afterwards; `resolved_view` is what answers with the resolution result.
+
+    Two independent reads have to go: `_resolve_speculative_algorithm_alias` calls
+    `get_config` on the draft path unconditionally (to sniff Gemma4 assistant drafts), and
+    DFLASH's own width resolution parses `dflash_config`. Left real, both would hit the HF
+    hub for a nonexistent repo.
+    """
+
+    def fake_load(server_args, *, required):
+        return draft_config if draft_config is not None else _draft_config()
+
+    hf_get_config = mock.patch(
+        "sglang.srt.utils.hf_transformers_utils.get_config",
+        return_value=SimpleNamespace(architectures=["DFlash2DraftModel"]),
+    )
+    if readable:
+        dflash_read = mock.patch(f"{_HOOK}._load_dflash_draft_config", fake_load)
+    else:
+        # Break the parse one level down, inside the real `_load_dflash_draft_config`, so its
+        # own required/optional branching is what the test exercises. A malformed
+        # `dflash_config` is the realistic failure -- an unreadable draft path would already
+        # have failed in the algorithm-alias sniff before DFLASH's hook runs.
+        dflash_read = mock.patch(
+            "sglang.srt.speculative.dflash_utils.parse_dflash_draft_config",
+            side_effect=ValueError("malformed dflash_config"),
+        )
+    with hf_get_config, dflash_read:
+        handle_speculative_decoding(args)
+    return resolved_view(args)
+
+
+def _tree_args(*, tree_width=2, **overrides) -> ServerArgs:
+    """A tree-width configuration that passes every admission check, so a test can flip
+    exactly one field and attribute the resulting error to that field."""
+    defaults = dict(
+        speculative_dflash_tree_width=tree_width,
+        speculative_dflash_block_size=8,
+        attention_backend="triton",
+        page_size=1,
+        disable_decode_cuda_graph=True,
+    )
+    defaults.update(overrides)
+    return _make_args(**defaults)
+
+
+class TestDflashChainWidthUnchanged(CustomTestCase):
+    """Tree width 1 (the default) must resolve exactly as DFLASH did before the split."""
+
+    def test_num_draft_tokens_alias_still_sets_block_size(self):
+        # The pre-split launch path: --speculative-num-draft-tokens 8 means block width 8.
+        args = _resolve(_make_args(speculative_num_draft_tokens=8))
+
+        self.assertEqual(args.speculative_dflash_block_size, 8)
+        self.assertEqual(args.speculative_num_draft_tokens, 8)
+        self.assertEqual(args.speculative_eagle_topk, 1)
+
+    def test_explicit_block_size_alone_resolves(self):
+        args = _resolve(_make_args(speculative_dflash_block_size=8))
+
+        self.assertEqual(args.speculative_dflash_block_size, 8)
+        self.assertEqual(args.speculative_num_draft_tokens, 8)
+        self.assertEqual(args.speculative_eagle_topk, 1)
+
+    def test_block_size_inferred_from_draft_checkpoint(self):
+        args = _resolve(_make_args(), _draft_config(block_size=5))
+
+        self.assertEqual(args.speculative_dflash_block_size, 5)
+        self.assertEqual(args.speculative_num_draft_tokens, 5)
+
+    def test_matching_alias_and_explicit_block_size_agree(self):
+        args = _resolve(
+            _make_args(speculative_num_draft_tokens=8, speculative_dflash_block_size=8)
+        )
+
+        self.assertEqual(args.speculative_dflash_block_size, 8)
+        self.assertEqual(args.speculative_num_draft_tokens, 8)
+
+    def test_conflicting_alias_and_explicit_block_size_raise(self):
+        with self.assertRaisesRegex(ValueError, "must match"):
+            _resolve(
+                _make_args(
+                    speculative_num_draft_tokens=4, speculative_dflash_block_size=8
+                )
+            )
+
+    def test_unreadable_draft_config_falls_back_to_default_block_size(self):
+        # Chain width tolerates an unreadable checkpoint (it only needs a block width);
+        # tree width does not, which is asserted separately below.
+        args = _resolve(_make_args(), readable=False)
+
+        self.assertEqual(args.speculative_dflash_block_size, 16)
+        self.assertEqual(args.speculative_num_draft_tokens, 16)
+
+
+class TestDflashTreeWidthDerivation(CustomTestCase):
+    def test_verify_width_grows_with_tree_width(self):
+        for tree_width, verify_width in ((1, 8), (2, 15), (4, 29), (8, 57)):
+            with self.subTest(tree_width=tree_width):
+                args = _resolve(_tree_args(tree_width=tree_width))
+
+                self.assertEqual(args.speculative_dflash_block_size, 8)
+                self.assertEqual(args.speculative_num_draft_tokens, verify_width)
+                self.assertEqual(args.speculative_eagle_topk, tree_width)
+
+    def test_non_power_of_two_block_size(self):
+        # gamma = 4 -> 1 + 4 * 2. Guards against a derivation that assumes a power of two.
+        args = _resolve(_tree_args(tree_width=2, speculative_dflash_block_size=5))
+
+        self.assertEqual(args.speculative_num_draft_tokens, 9)
+
+    def test_num_steps_stays_one(self):
+        # Widening the verify window must not leak into num_steps: accept_index is sized from
+        # max_tree_depth, and generic accounting still assumes DFLASH takes one step.
+        args = _resolve(_tree_args(tree_width=4))
+
+        self.assertEqual(args.speculative_num_steps, 1)
+
+
+class TestDflashTreeWidthRejections(CustomTestCase):
+    def test_eagle_topk_is_rejected(self):
+        # Even the value DFLASH used to force (1): the flag has no DFLASH meaning at all, so
+        # accepting it would leave two ways to spell the width.
+        for topk in (1, 4):
+            with self.subTest(topk=topk):
+                with self.assertRaisesRegex(ValueError, "dflash-tree-width"):
+                    _resolve(_make_args(speculative_eagle_topk=topk))
+
+    def test_num_draft_tokens_rejected_with_a_wide_tree(self):
+        with self.assertRaisesRegex(ValueError, "speculative-dflash-block-size"):
+            _resolve(_tree_args(tree_width=2, speculative_num_draft_tokens=15))
+
+    def test_zero_tree_width_rejected(self):
+        with self.assertRaisesRegex(ValueError, "must be >= 1"):
+            _resolve(_tree_args(tree_width=0))
+
+    def test_tree_width_above_selector_top_k_rejected(self):
+        with self.assertRaisesRegex(ValueError, "selector_top_k"):
+            _resolve(_tree_args(tree_width=8), _draft_config(selector_top_k=4))
+
+    def test_checkpoint_without_selector_rejected(self):
+        with self.assertRaisesRegex(ValueError, "candidate selector"):
+            _resolve(
+                _tree_args(tree_width=2),
+                _draft_config(selector_rank=0, selector_top_k=0),
+            )
+
+    def test_unreadable_draft_config_rejected_with_a_wide_tree(self):
+        # The selector checks live only in the hook, so a swallowed read would turn both of
+        # them into silent passes.
+        with self.assertRaisesRegex(ValueError, "selector_top_k"):
+            _resolve(_tree_args(tree_width=2), readable=False)
+
+
+class TestDflashTreeAdmissionChecks(CustomTestCase):
+    """The W>1 gates. DFLASH cannot borrow EAGLE's `_PAGE_TREE_SPEC_BACKENDS` check (that one
+    lives in the EAGLE branch of the hook), so every one of these is load-bearing."""
+
+    def test_mask_capable_backends_are_accepted(self):
+        # The whitelist direction guard: triton is the SM100 default for hybrid-GDN models, so
+        # a whitelist written as the complement of the skip-custom-mask set would reject the
+        # one backend this feature actually runs on.
+        for backend in ("triton", "flashinfer", "fa3"):
+            with self.subTest(backend=backend):
+                args = _resolve(_tree_args(attention_backend=backend))
+
+                self.assertEqual(args.speculative_eagle_topk, 2)
+
+    def test_trtllm_mha_rejected_as_silently_wrong(self):
+        with self.assertRaisesRegex(ValueError, "silently"):
+            _resolve(_tree_args(attention_backend="trtllm_mha"))
+
+    def test_mask_incapable_backend_rejected(self):
+        with self.assertRaisesRegex(ValueError, "custom tree mask"):
+            _resolve(_tree_args(attention_backend="aiter"))
+
+    def test_prefill_and_decode_backend_slots_are_checked(self):
+        # A tree verify lands on whichever slot the forward resolves to, so an incompatible
+        # override in either slot has to be caught even when --attention-backend is fine.
+        for slot in ("prefill_attention_backend", "decode_attention_backend"):
+            with self.subTest(slot=slot):
+                with self.assertRaisesRegex(ValueError, "silently"):
+                    _resolve(_tree_args(**{slot: "trtllm_mha"}))
+
+    def test_paged_kv_rejected(self):
+        with self.assertRaisesRegex(ValueError, "page-size"):
+            _resolve(_tree_args(page_size=16))
+
+    def test_replayssm_spec_rejected(self):
+        # Its own topk guard runs in _handle_linear_attn_backend, before the speculative hook
+        # assigns topk, so it sees None and lets this through.
+        with self.assertRaisesRegex(ValueError, "replayssm-spec"):
+            _resolve(_tree_args(enable_linear_replayssm_spec=True))
+
+    def test_decode_cuda_graph_must_be_disabled(self):
+        with self.assertRaisesRegex(ValueError, "disable-decode-cuda-graph"):
+            _resolve(_tree_args(disable_decode_cuda_graph=False))
+
+    def test_disable_cuda_graph_also_satisfies_the_graph_gate(self):
+        args = _resolve(
+            _tree_args(disable_decode_cuda_graph=False, disable_cuda_graph=True)
+        )
+
+        self.assertEqual(args.speculative_eagle_topk, 2)
+
+    def test_simulated_real_draft_tokens_rejected(self):
+        with envs.SGLANG_SIMULATE_ACC_LEN.override(
+            3.0
+        ), envs.SGLANG_SIMULATE_ACC_TOKEN_MODE.override("real-draft-token"):
+            with self.assertRaisesRegex(ValueError, "real-draft-token"):
+                _resolve(_tree_args())
+
+    def test_simulated_fixed_tokens_allowed(self):
+        with envs.SGLANG_SIMULATE_ACC_LEN.override(
+            3.0
+        ), envs.SGLANG_SIMULATE_ACC_TOKEN_MODE.override("fixed"):
+            args = _resolve(_tree_args())
+
+        self.assertEqual(args.speculative_eagle_topk, 2)
+
+    def test_chain_width_is_exempt_from_every_gate(self):
+        # The gates must not regress the single-path launch: today's DFLASH runs with decode
+        # cuda graph on, and may run on a backend that cannot express a tree.
+        args = _resolve(
+            _make_args(
+                speculative_num_draft_tokens=8,
+                attention_backend="trtllm_mha",
+                page_size=16,
+                disable_decode_cuda_graph=False,
+            )
+        )
+
+        self.assertEqual(args.speculative_eagle_topk, 1)
+        self.assertEqual(args.speculative_num_draft_tokens, 8)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_tree_width_args.py
+++ b/test/registered/unit/spec/test_dflash_tree_width_args.py
@@ -174,6 +174,33 @@ class TestDflashTreeWidthDerivation(CustomTestCase):
 
         self.assertEqual(args.speculative_num_steps, 1)
 
+    def test_node_cap_becomes_the_verify_width(self):
+        # The cap reaches serving only by landing in speculative_num_draft_tokens: every
+        # captured shape, KV reservation and mask allocation downstream is sized off that
+        # field. Parked anywhere else it would resolve fine and then verify the unpruned
+        # node count, i.e. the prune would silently not happen.
+        for tree_width, verify_width in ((2, 15), (4, 15), (8, 15), (16, 15)):
+            with self.subTest(tree_width=tree_width):
+                with envs.SGLANG_DFLASH_MAX_NUM_NODES.override(15):
+                    args = _resolve(_tree_args(tree_width=tree_width))
+
+                self.assertEqual(args.speculative_num_draft_tokens, verify_width)
+                # The cap narrows the verify window, not the beam: the tree is still built
+                # at tree_width per depth and only then pruned.
+                self.assertEqual(args.speculative_eagle_topk, tree_width)
+                self.assertEqual(args.speculative_dflash_block_size, 8)
+
+    def test_node_cap_at_or_above_the_full_beam_is_a_no_op(self):
+        # Sweeping one cap across several widths relies on this: at 1 + gamma * W <= cap the
+        # run has to be the unpruned run, not an error. 29 is exactly the full beam at W=4,
+        # so it also pins the boundary rather than only the interior.
+        for tree_width, cap, verify_width in ((2, 30, 15), (4, 29, 29), (4, 60, 29)):
+            with self.subTest(tree_width=tree_width, cap=cap):
+                with envs.SGLANG_DFLASH_MAX_NUM_NODES.override(cap):
+                    args = _resolve(_tree_args(tree_width=tree_width))
+
+                self.assertEqual(args.speculative_num_draft_tokens, verify_width)
+
 
 class TestDflashTreeWidthRejections(CustomTestCase):
     def test_eagle_topk_is_rejected(self):
@@ -191,6 +218,20 @@ class TestDflashTreeWidthRejections(CustomTestCase):
     def test_zero_tree_width_rejected(self):
         with self.assertRaisesRegex(ValueError, "must be >= 1"):
             _resolve(_tree_args(tree_width=0))
+
+    def test_node_cap_below_the_block_size_rejected(self):
+        # The draft forward writes the block-wide prefix of the same
+        # [prefix, prefix + verify_width) region the tree occupies, so a cap under the spine
+        # length under-sizes that region -- an out-of-bounds write at first decode rather
+        # than a smaller tree. Caught at startup because the shapes are captured before any
+        # step runs.
+        for cap in (1, 7):
+            with self.subTest(cap=cap):
+                with envs.SGLANG_DFLASH_MAX_NUM_NODES.override(cap):
+                    with self.assertRaisesRegex(
+                        ValueError, "SGLANG_DFLASH_MAX_NUM_NODES"
+                    ):
+                        _resolve(_tree_args(tree_width=4))
 
     def test_tree_width_above_selector_top_k_rejected(self):
         with self.assertRaisesRegex(ValueError, "selector_top_k"):

--- a/test/registered/unit/spec/test_dflash_tree_width_args.py
+++ b/test/registered/unit/spec/test_dflash_tree_width_args.py
@@ -97,7 +97,6 @@ def _tree_args(*, tree_width=2, **overrides) -> ServerArgs:
         speculative_dflash_block_size=8,
         attention_backend="triton",
         page_size=1,
-        disable_decode_cuda_graph=True,
     )
     defaults.update(overrides)
     return _make_args(**defaults)
@@ -251,16 +250,15 @@ class TestDflashTreeAdmissionChecks(CustomTestCase):
         with self.assertRaisesRegex(ValueError, "replayssm-spec"):
             _resolve(_tree_args(enable_linear_replayssm_spec=True))
 
-    def test_decode_cuda_graph_must_be_disabled(self):
-        with self.assertRaisesRegex(ValueError, "disable-decode-cuda-graph"):
-            _resolve(_tree_args(disable_decode_cuda_graph=False))
+    def test_decode_cuda_graph_is_allowed(self):
+        # The verify graph now captures with the tree mask enabled, so a wide tree no
+        # longer has to opt out of the decode graph. Re-adding a gate here would silently
+        # cost the ~2x the graph buys back.
+        args = _resolve(_tree_args(tree_width=4))
 
-    def test_disable_cuda_graph_also_satisfies_the_graph_gate(self):
-        args = _resolve(
-            _tree_args(disable_decode_cuda_graph=False, disable_cuda_graph=True)
-        )
-
-        self.assertEqual(args.speculative_eagle_topk, 2)
+        self.assertFalse(args.disable_decode_cuda_graph)
+        self.assertFalse(args.disable_cuda_graph)
+        self.assertEqual(args.speculative_eagle_topk, 4)
 
     def test_simulated_real_draft_tokens_rejected(self):
         with envs.SGLANG_SIMULATE_ACC_LEN.override(

--- a/test/registered/unit/spec/test_dflash_verify_mask_policy.py
+++ b/test/registered/unit/spec/test_dflash_verify_mask_policy.py
@@ -1,0 +1,148 @@
+"""Whether a captured DFLASH verify graph carries the tree mask.
+
+`resolve_dflash_verify_mask_policy` answers one question at cuda-graph capture time:
+does `spec_info.custom_mask` get a buffer? The answer is frozen into the graph -- for
+`TritonAttnBackend` it becomes the `USE_CUSTOM_MASK` `tl.constexpr`, so a wrong answer
+cannot be corrected at replay. Getting it wrong on a tree is silent: the runtime still
+builds and copies the mask every step, and the graph verifies a 29-node tree as a plain
+causal sequence. That was measured as 8/8 diverged completions before the tree branch
+below existed, which is why it is worth a test of its own.
+
+The chain direction is equally load-bearing in the other direction: chain verify is
+genuinely causal, and re-enabling the mask for it would give up the backend's cheaper
+built-in path for nothing.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.srt.speculative.dflash_utils import resolve_dflash_verify_mask_policy
+from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+# `dflash_tree_verify_active` imports `get_spec` lazily inside the function body, so
+# patching the definition site is what takes effect.
+_GET_SPEC = "sglang.srt.runtime_context.get_spec"
+
+
+def _spec(*, tree_width):
+    return mock.patch(
+        _GET_SPEC,
+        return_value=SimpleNamespace(speculative_dflash_tree_width=tree_width),
+    )
+
+
+class TritonAttnBackend:
+    """Name-matched stand-in: the policy keys on the resolved class name, and importing
+    the real backend drags in triton plus a device."""
+
+    full_attn_backend = None
+
+
+class AiterAttnBackend:
+    """Any backend outside the chain skip set -- it has no built-in causal verify."""
+
+    full_attn_backend = None
+
+
+class _Hybrid:
+    """Shape of `HybridLinearAttnBackend`: the tree's mask channel is the full-attention
+    child, not the composite the model runner holds."""
+
+    def __init__(self, child):
+        self.full_attn_backend = child
+
+
+class TestChainSkipsTheMask(CustomTestCase):
+    def test_backend_with_a_builtin_causal_path_skips_the_mask(self):
+        with _spec(tree_width=1):
+            name, build_custom_mask = resolve_dflash_verify_mask_policy(
+                TritonAttnBackend()
+            )
+
+        self.assertEqual(name, "TritonAttnBackend")
+        self.assertFalse(build_custom_mask)
+
+    def test_backend_without_one_still_gets_the_mask(self):
+        with _spec(tree_width=1):
+            _, build_custom_mask = resolve_dflash_verify_mask_policy(AiterAttnBackend())
+
+        self.assertTrue(build_custom_mask)
+
+
+class TestTreeAlwaysTakesTheMask(CustomTestCase):
+    def test_skip_set_does_not_apply_to_a_tree(self):
+        # The regression: siblings must not see each other, and only the mask says so.
+        with _spec(tree_width=4):
+            name, build_custom_mask = resolve_dflash_verify_mask_policy(
+                TritonAttnBackend()
+            )
+
+        self.assertEqual(name, "TritonAttnBackend")
+        self.assertTrue(build_custom_mask)
+
+    def test_tree_width_one_is_still_a_chain(self):
+        # Width 1 is the equivalence gate for every phase of this feature: it must keep
+        # resolving byte-identically to the pre-tree behaviour.
+        with _spec(tree_width=1):
+            _, build_custom_mask = resolve_dflash_verify_mask_policy(TritonAttnBackend())
+
+        self.assertFalse(build_custom_mask)
+
+
+class TestCompositeBackendIsUnwrapped(CustomTestCase):
+    def test_hybrid_target_resolves_to_its_full_attention_child(self):
+        # The bench target (Qwen3.8 GDN + GQA) hands the runner a composite. Answering
+        # for the composite's own class name would miss the skip set both ways.
+        backend = _Hybrid(_Hybrid(TritonAttnBackend()))
+
+        with _spec(tree_width=4):
+            name, build_custom_mask = resolve_dflash_verify_mask_policy(backend)
+
+        self.assertEqual(name, "TritonAttnBackend")
+        self.assertTrue(build_custom_mask)
+
+
+class TestTreeKeepsTheSelectorEager(CustomTestCase):
+    """The other half of getting a tree into the graph: the draft head must stay out.
+
+    Folding it in would give the beam one sampled path instead of the `[bs, gamma, K, K]`
+    transition lattice it walks. This used to be a per-step `RuntimeError`; the graph is
+    on by default now, so it has to be decided once, before capture.
+    """
+
+    def test_tree_verify_refuses_to_fold_the_draft_head(self):
+        worker = SimpleNamespace(
+            _use_tree_verify=True,
+            ps=SimpleNamespace(tp_rank=0),
+            block_size=8,
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SGLANG_DFLASH_EAGER_DRAFT_SAMPLER": "0"}, clear=False
+        ):
+            self.assertIsNone(DFlashWorkerV2._maybe_build_draft_sampler(worker))
+
+    def test_chain_still_reaches_the_folding_checks(self):
+        # Guards the placement of the tree branch: if it were unconditional, the chain
+        # would lose the folded head too. Reaching the target-lm_head lookup (and failing
+        # on this stub) is the proof that it did not short-circuit.
+        worker = SimpleNamespace(
+            _use_tree_verify=False,
+            ps=SimpleNamespace(tp_rank=0),
+            block_size=8,
+        )
+
+        with mock.patch.dict(
+            "os.environ", {"SGLANG_DFLASH_EAGER_DRAFT_SAMPLER": "0"}, clear=False
+        ):
+            with self.assertRaises(AttributeError):
+                DFlashWorkerV2._maybe_build_draft_sampler(worker)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_dflash_verify_mask_policy.py
+++ b/test/registered/unit/spec/test_dflash_verify_mask_policy.py
@@ -32,7 +32,10 @@ _GET_SPEC = "sglang.srt.runtime_context.get_spec"
 def _spec(*, tree_width):
     return mock.patch(
         _GET_SPEC,
-        return_value=SimpleNamespace(speculative_dflash_tree_width=tree_width),
+        return_value=SimpleNamespace(
+            speculative_algorithm="DFLASH",
+            speculative_dflash_tree_width=tree_width,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

This PR extends DFLASH from single-path drafting to selector-based beam-tree drafting.
The selector already computes top-K candidates and transition scores for every draft
position; tree drafting retains multiple candidates instead of collapsing them to one
path.

The target verifies the tree with an ancestor mask, then the accepted path is compacted
back into the existing chain-shaped acceptance and KV-cache bookkeeping. A node budget
limits verification cost independently from the per-depth beam width. Nodes are selected
by cumulative selector log-probability while preserving ancestor closure. This is a
serving heuristic, not a claim that selector scores exactly optimize target acceptance.

Tree verification currently supports greedy decoding only. The default `W=1` chain path
and chain sampling behavior remain unchanged unless tree verification is explicitly
enabled.

## Configuration

| name | meaning | value in the runs below |
|---|---|---|
| `block_size` | draft forward positions, anchor included | 8 |
| `gamma = block_size - 1` | maximum tree depth | 7 |
| `W` (`--speculative-dflash-tree-width`) | beam width per draft depth | 1 / 2 / 4 / 8 / 16 |
| `max_num_nodes` (`SGLANG_DFLASH_MAX_NUM_NODES`) | node budget; `0` means unbounded | 0 / 12 / 15 / 30 / 60 |
| `N` (`speculative_num_draft_tokens`) | nodes submitted to verify | `full_width` when cap is 0, otherwise `min(full_width, max_num_nodes)` |
| `K` (`selector_top_k`) | selector candidates per position | 16 |

Configuration constraints:

- `W=1` keeps the existing chain path by default.
- `W>1` requires `W <= K`, `page_size=1`, and a tree-capable target attention backend (`flashinfer`, `triton`, or `fa3`).
- Tree verification supports greedy decoding only. Sampling requests are rejected while tree verification is active; chain sampling remains supported.
- `SGLANG_DFLASH_MAX_NUM_NODES` must be `0` or at least `block_size`. A positive cap at or above `full_width` is a no-op.
- `SGLANG_DFLASH_FORCE_TREE_VERIFY` is a debug-only switch for routing `W=1` through the tree path.

## Implementation

- **Width plumbing**: draft, verify, and beam widths use independent values, with buffers and CUDA-graph shapes sized from the appropriate width.
- **Beam walk**: builds a BFS-ordered beam over the selector lattice and retains the greedy spine.
- **Tree verification**: derives ancestor masks, positions, and retrieve links, then compacts the accepted path back to chain-shaped scheduler and KV-cache state.
- **CUDA graph support**: writes the flat verify mask on device into the backend-owned buffer, removing the per-step blocking host copy.
- **Node pruning**: ranks cumulative scores with a Triton kernel and has an independent torch reference implementation.

## Correctness

**Width-one equivalence.** Compared with the pre-PR chain path using identical flags and
concurrency 1: 768 generated tokens were identical, per-request accept lengths matched,
and `max|delta logprob| = 0.0`. The on-device mask rewrite was also byte-identical on
`W=4`, forced tree verification at `W=1`, and the chain path.

The registered tests cover beam construction, ancestor closure, pruned-tree metadata,
tree acceptance and compaction, width/node-budget resolution, sampling admission, mask
writing, pruning tie behavior, bounds, non-finite cumulative scores, and Triton-vs-torch
reference agreement.

**Known correctness gap.** `W>1` has not yet been validated against an autoregressive
baseline. Some W>1 runs differ from the W=1 chain in log probabilities by up to roughly
`7e-2`; this may be caused by reduction-order changes from the wider verify batch, but it
has not been formally attributed. W>1 AR output parity should be checked before merge.

## Performance

Measured on 1x NVIDIA GB200 (device reports `CF-NG-GBZZ2-O-L`, compute capability 10.0,
188729 MiB), with Qwen3.8-27B + DFlash2 draft (GDN + GQA target), `block_size=8`,
decode CUDA graph enabled, bs=1, greedy, ShareGPT prompts (32 x 512 output tokens),
seed 42.

Environment: Python 3.12.13, PyTorch 2.13.0+cu130, CUDA runtime 13.0, CUDA toolkit
13.2, NVIDIA driver 580.159.03, SGLang commit `7b13998137`.

| W | `max_num_nodes` | N | accept len | mean TPOT | output tok/s |
|---|---:|---:|---:|---:|---:|
| 1 (chain path) | - | 8 | 3.67 | 3.73 ms | 255.9 |
| 8 | 12 | 12 | 4.31 | **3.52 ms** | **269.6** |
| 2 | 15 | 15 | 4.28 | 3.64 ms | 261.6 |
| 4 | 15 | 15 | 4.38 | 3.56 ms | 267.1 |
| 8 | 15 | 15 | 4.42 | **3.52 ms** | 269.5 |
| 16 | 15 | 15 | 4.42 | 3.53 ms | 268.6 |
| 4 | 30 | 29 | 4.55 | 3.89 ms | 244.6 |
| 8 | 30 | 30 | 4.59 | 3.89 ms | 245.3 |
| 16 | 30 | 30 | 4.63 | 3.87 ms | 246.4 |
| 8 | 60 | 57 | 4.88 | 4.83 ms | 199.0 |
| 16 | 60 | 60 | 4.92 | 4.92 ms | 195.4 |
| 16 | 0 (unbounded) | 113 | 5.24 | 6.54 ms | 147.8 |

The best measured point is `W=8`, `max_num_nodes=15`: `-5.6%` TPOT and `+5.3%`
output tok/s versus the chain. Larger trees improve accept length but are slower; at
the same `N=15`, `W=8/16` outperform `W=2` on accept length (4.42 vs. 4.28).

For a 100-step torch profile at `W=16`, `N=15`, bs=4, and 8192-token contexts, the
device-side mask rewrite reduced inter-kernel gaps from 5.5 to 0 per step, removed the
1.03 blocking `Device -> Pageable` copies per step, and reduced GPU idle from 15.1% to
4.0%.

## Limitations

- W>1 autoregressive output parity has not been measured yet.
- Tree verification is greedy-only and currently requires the listed attention backends and `page_size=1`.
- Accept length is workload-dependent; the benchmark rows are not general model-quality claims.
- Dense convolution-window and full tree-mask memory costs are not included in the reported accounting.
- NPU and AMX W>1 paths have not been exercised.

## Checklist

- [x] Format code according to [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update repository documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). The configuration and limitations are documented above, but the formal docs pages still need the new flags.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34126806808](https://github.com/sgl-project/sglang/actions/runs/34126806808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34126806479](https://github.com/sgl-project/sglang/actions/runs/34126806479)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34126806779](https://github.com/sgl-project/sglang/actions/runs/34126806779)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->