### PR TITLE
fix(openai): accept nullable strict in function tools

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -745,7 +745,7 @@ class Function(BaseModel):
     description: Optional[str] = Field(default=None, examples=[None])
     name: str
     parameters: Optional[object] = None
-    strict: bool = False
+    strict: Optional[bool] = False
     defer_loading: Optional[bool] = None
 
     @model_serializer(mode="wrap")
@@ -1556,7 +1556,7 @@ class ResponseTool(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = None
-    strict: bool = False
+    strict: Optional[bool] = False
     # Inner schemas for ``namespace`` tools.
     tools: Optional[List[Dict[str, Any]]] = None
 

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -704,6 +704,20 @@ class TestFunctionDeferLoading(unittest.TestCase):
         self.assertEqual(data["strict"], False)
         self.assertNotIn("defer_loading", data)
 
+    def test_chat_function_tool_accepts_nullable_strict(self):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "Call the tool"}],
+            tools=[
+                {
+                    "type": "function",
+                    "function": {"name": "lookup", "strict": None},
+                }
+            ],
+        )
+
+        self.assertIsNone(request.tools[0].function.strict)
+
     def test_function_defer_loading_true_serialized(self):
         f = Function(name="foo", defer_loading=True)
         data = f.model_dump()

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -52,6 +52,22 @@ class ResponsesRequestTestCase(CustomTestCase):
         self.assertEqual(request.tools[0].name, "lookup")
         self.assertTrue(request.tools[0].strict)
 
+    def test_function_tool_accepts_nullable_strict(self):
+        request = ResponsesRequest(
+            model="x",
+            input="call the tool",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "lookup",
+                    "strict": None,
+                }
+            ],
+            store=False,
+        )
+
+        self.assertIsNone(request.tools[0].strict)
+
     def test_function_tool_requires_name(self):
         with self.assertRaises(ValueError):
             ResponsesRequest(


### PR DESCRIPTION
## Motivation

The OpenAI function-tool schema allows `strict` to be either a boolean or `null`. Official SDKs and gateways can therefore serialize `"strict": null`, but SGLang currently rejects that payload during Pydantic validation with HTTP 400 on both `/v1/chat/completions` and `/v1/responses`.

Fixes #36194.

## Modifications

- Allow nullable `strict` values in the nested Chat Completions `Function` model.
- Allow nullable `strict` values in the flat Responses API `ResponseTool` model.
- Preserve the existing `False` default when the field is omitted.
- Add regression coverage for both endpoint request shapes.

## Tests

- `isort --check-only` on all modified files
- `ruff check --select F401,F821,UP037` on all modified files
- `black --check` on all modified files
- `python scripts/lint/check_registered_tests.py`
- Targeted Pydantic protocol validation: nullable Chat tool, nullable Responses tool, and unchanged omitted-field defaults (3/3 passed)

## Accuracy Tests

Not applicable. This changes request validation only and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This change is outside the inference path.

## Checklist

- [x] Format the modified code according to the repository hooks.
- [x] Add unit tests for both affected API request schemas.
- [x] Documentation is not needed because this aligns validation with the existing OpenAI wire contract.
- [x] Accuracy and speed benchmarks are not applicable to a request-schema fix.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32813248194](https://github.com/sgl-project/sglang/actions/runs/32813248194)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32813248004](https://github.com/sgl-project/sglang/actions/runs/32813248004)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32813248215](https://github.com/sgl-project/sglang/actions/runs/32813248215)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->