### PR TITLE
fix(mlx): prevent CPU/MPS device mismatch in FutureMap

### DIFF
--- a/python/sglang/srt/managers/overlap_utils.py
+++ b/python/sglang/srt/managers/overlap_utils.py
@@ -551,7 +551,8 @@ class FutureMap:
             self._lazy_init_forward_buf(payload)
         self._maybe_init_dsa_topk_indices_buf(payload)
         self.output_tokens_buf[indices] = payload.bonus_tokens.to(
-            self.output_tokens_buf.dtype
+            device=self.output_tokens_buf.device,
+            dtype=self.output_tokens_buf.dtype,
         )
 
         if self.need_topk:

--- a/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
+++ b/test/registered/unit/hardware_backend/mlx/test_attention_patching.py
@@ -8,6 +8,7 @@ from collections import deque
 from types import SimpleNamespace
 
 from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
@@ -47,6 +48,7 @@ if _HAS_MLX:
         SchedulerMlxOverlapMixin,
     )
     from sglang.srt.hardware_backend.mlx.tp_worker import MlxLaunch
+    from sglang.srt.managers.overlap_utils import FutureMap, RelayPayload
     from sglang.srt.managers.scheduler_components import (
         batch_result_processor as batch_result_processor_module,
     )
@@ -55,7 +57,9 @@ if _HAS_MLX:
     )
     from sglang.srt.managers.utils import GenerationBatchResult
     from sglang.srt.mem_cache.base_prefix_cache import InsertParams, InsertResult
+    from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
     from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 
 
 def _set_runner_cache_layout(
@@ -1095,7 +1099,35 @@ class TestMlxAuxiliaryStateRunnerCache(unittest.TestCase):
 
 
 @unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
+class TestMlxFutureMap(CustomTestCase):
+    def test_stash_matches_mps_buffer_device_and_dtype(self):
+        if not torch.backends.mps.is_available():
+            self.skipTest("requires PyTorch MPS")
+        pool = ReqToTokenPool(
+            size=4,
+            max_context_len=8,
+            device="mps",
+            enable_memory_saver=False,
+        )
+        future_map = FutureMap(
+            device=torch.device("mps"),
+            spec_algo=SpeculativeAlgorithm.NONE,
+            req_to_token_pool=pool,
+        )
+        indices = torch.tensor([1, 2], dtype=torch.int64, device="mps")
+        tokens = torch.tensor([17, 23], dtype=torch.int32, device="cpu")
+
+        future_map.stash(indices, RelayPayload(bonus_tokens=tokens))
+
+        stored = future_map.output_tokens_buf[indices]
+        self.assertEqual(stored.device.type, "mps")
+        self.assertEqual(stored.dtype, torch.int64)
+        self.assertEqual(stored.cpu().tolist(), [17, 23])
+
+
+@unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
 class TestMlxOverlapScheduler(unittest.TestCase):
+
     def test_finalize_pending_job_updates_scheduler_last_batch(self):
         token_ids = torch.tensor([7], dtype=torch.long)
         scheduler = FakeOverlapScheduler(token_ids)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at [https://slack.sglang.io](https://slack.sglang.io) to discuss further. -->

## Motivation

The MLX scheduler can return sampled token IDs as a CPU tensor while
`FutureMap.output_tokens_buf` resides on MPS. `FutureMap.stash()` previously
converted only the payload dtype, leaving the tensor on CPU before assigning it
to the MPS buffer. This caused generation to terminate with a device mismatch:

```text
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, mps:0 and cpu!
```

The relay should always match both the device and dtype of its destination
buffer before the indexed write.

## Modifications

- Convert relayed `bonus_tokens` to both `output_tokens_buf.device` and
  `output_tokens_buf.dtype` before storing them in `FutureMap`.
- Add an Apple MPS regression test whose source tokens are CPU `int32` and whose
  destination buffer is MPS `int64`.
- Verify the stored device, dtype, and token values so future changes cannot
  reintroduce a CPU-to-MPS assignment failure.

This preserves the existing destination-buffer contract for other devices; it
does not change token selection or model computation.

## Accuracy Tests

This change does not modify model weights, kernels, logits, sampling decisions,
or token values. It only moves already-selected token IDs to the destination
buffer's device and dtype.

Focused regression tests:

```bash
python test/registered/unit/hardware_backend/mlx/test_attention_patching.py -f
# Ran 38 tests: OK

python test/registered/unit/disaggregation/test_disaggregation_wire.py -f
# Ran 23 tests: OK
```

Real SGLang MLX serving smoke test:

- Hardware: Apple M5, macOS 26.2
- Runtime: PyTorch 2.13.0, MLX 0.32.1
- Model: `mlx-community/Qwen3-0.6B-4bit`
- Configuration: MLX backend, overlap scheduling enabled, radix cache enabled,
  `max_running_requests=4`, `context_length=2048`
- Workload: 4 concurrent requests repeated for 3 rounds; 12 total requests,
  each generating 32 tokens
- Result: 12/12 requests returned HTTP 200 with non-empty generations. Server
  logs confirmed a 4-request decode batch, and no CPU/MPS device mismatch
  occurred.

Formatting validation:

```bash
uvx pre-commit run --all-files
```

All Python and general repository hooks passed. 

## Speed Tests and Profiling

Not applicable. 

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32745793716](https://github.com/sgl-project/sglang/actions/runs/32745793716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32745793449](https://github.com/sgl-project/sglang/actions/runs/32745793449)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32745793639](https://github.com/sgl-project/sglang/actions/runs/32745793639)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->