### PR TITLE
[Kernel] Bound the EAGLE tree ancestor walk and stop when the ancestor is missing

### DIFF
--- a/python/sglang/kernels/aot/csrc/speculative/eagle_utils.cu
+++ b/python/sglang/kernels/aot/csrc/speculative/eagle_utils.cu
@@ -31,6 +31,19 @@ typedef enum { FULL_MASK = 0, QLEN_ONLY = 1, QLEN_ONLY_BITPACKING = 2 } TreeMask
 // tree_mask [draft_token*(seq_len[0]+draft_token) | draft_token*(seq_len[1]+draft_token) | ..] =
 // [sum(verified_seq_len)*draft_token+bs*draft_token*draft_token] positions [bs * draft_token] retrive_index [b,
 // draft_token] retrive_next_token [b, draft_token] retrive_next_sibling [b, draft_token]
+// selected_index holds draft_token_num - 1 entries per request. Searching any further reads the
+// next request's row, or past the tensor for the last request. Mirrors find_parent_node in
+// csrc/cpu/spec.cpp, which returns -1 for a token that was not selected.
+__device__ __forceinline__ int find_selected_position(
+    const int64_t* selected_index, int sel_off, int sel_stride, int64_t token_idx) {
+  for (int p = 0; p < sel_stride; ++p) {
+    if (selected_index[sel_off + p] == token_idx) {
+      return p;
+    }
+  }
+  return -1;
+}
+
 __global__ void build_tree_efficient(
     int64_t* parent_list,
     int64_t* selected_index,
@@ -78,18 +91,15 @@ __global__ void build_tree_efficient(
       int parent_position = 0;
       if (parent_tb_idx > 0) {
         int parent_token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
-        for (; parent_position < draft_token_num; ++parent_position) {
-          if (selected_index[bid * (draft_token_num - 1) + parent_position] == parent_token_idx) {
-            ++parent_position;
-            break;
-          }
+        const int found = find_selected_position(
+            selected_index, bid * (draft_token_num - 1), draft_token_num - 1, parent_token_idx);
+        if (found < 0) {
+          printf(
+              "WARNING: invalid eagle tree!!! Detected a token with no parent token selected. "
+              "Please check if the logprob has nan. The token will be ignored to keep proceeding.\n");
+          continue;
         }
-      }
-      if (parent_position == draft_token_num) {
-        printf(
-            "WARNING: invalid eagle tree!!! Detected a token with no parent token selected. "
-            "Please check if the logprob has nan. The token will be ignored to keep proceeding.\n");
-        continue;
+        parent_position = found + 1;
       }
 
       if (retrive_next_token[bid * draft_token_num + parent_position] == -1) {
@@ -113,14 +123,8 @@ __global__ void build_tree_efficient(
       }
 
       int token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
-      // selected_index has draft_token_num - 1 entries per request
-      int found = -1;
-      for (int p = 0; p < draft_token_num - 1; ++p) {
-        if (selected_index[bid * (draft_token_num - 1) + p] == token_idx) {
-          found = p;
-          break;
-        }
-      }
+      const int found = find_selected_position(
+          selected_index, bid * (draft_token_num - 1), draft_token_num - 1, token_idx);
       if (found < 0) {
         printf(
             "WARNING: invalid eagle tree!!! Detected a token whose ancestor was not selected. "
@@ -176,18 +180,15 @@ __global__ void build_tree_efficient_partial_packed(
       int parent_position = 0;
       if (parent_tb_idx > 0) {
         int parent_token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
-        for (; parent_position < draft_token_num; ++parent_position) {
-          if (selected_index[bid * (draft_token_num - 1) + parent_position] == parent_token_idx) {
-            ++parent_position;
-            break;
-          }
+        const int found = find_selected_position(
+            selected_index, bid * (draft_token_num - 1), draft_token_num - 1, parent_token_idx);
+        if (found < 0) {
+          printf(
+              "WARNING: invalid eagle tree!!! Detected a token with no parent token selected. "
+              "Please check if the logprob has nan. The token will be ignored to keep proceeding.\n");
+          continue;
         }
-      }
-      if (parent_position == draft_token_num) {
-        printf(
-            "WARNING: invalid eagle tree!!! Detected a token with no parent token selected. "
-            "Please check if the logprob has nan. The token will be ignored to keep proceeding.\n");
-        continue;
+        parent_position = found + 1;
       }
 
       if (retrive_next_token[bid * draft_token_num + parent_position] == -1) {
@@ -201,7 +202,8 @@ __global__ void build_tree_efficient_partial_packed(
     retrive_index[bid * draft_token_num] = bid * draft_token_num;
   } else {
     int cur_position = tid - 1;
-    while (true) {
+    // a malformed tree can loop back on itself and never reach the root
+    while (position < depth) {
       position += 1;
       int byte_idx = (cur_position + 1) / 8;
       int bit_idx = (cur_position + 1) % 8;
@@ -212,11 +214,15 @@ __global__ void build_tree_efficient_partial_packed(
       }
 
       int token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
-      for (cur_position = 0; cur_position < draft_token_num; ++cur_position) {
-        if (selected_index[bid * (draft_token_num - 1) + cur_position] == token_idx) {
-          break;
-        }
+      const int found = find_selected_position(
+          selected_index, bid * (draft_token_num - 1), draft_token_num - 1, token_idx);
+      if (found < 0) {
+        printf(
+            "WARNING: invalid eagle tree!!! Detected a token whose ancestor was not selected. "
+            "Please check if the logprob has nan. The walk stops here to keep proceeding.\n");
+        break;
       }
+      cur_position = found;
     }
     positions[bid * draft_token_num + tid] = position + seq_len;
   }

--- a/python/sglang/kernels/aot/csrc/speculative/eagle_utils.cu
+++ b/python/sglang/kernels/aot/csrc/speculative/eagle_utils.cu
@@ -103,7 +103,8 @@ __global__ void build_tree_efficient(
     retrive_index[bid * draft_token_num] = bid * draft_token_num;
   } else {
     int cur_position = tid - 1;
-    while (true) {
+    // a malformed tree can loop back on itself and never reach the root
+    while (position < depth) {
       position += 1;
       tree_mask[token_tree_idx + cur_position] = true;
       int parent_tb_idx = selected_index[bid * (draft_token_num - 1) + cur_position] / topk;
@@ -112,11 +113,21 @@ __global__ void build_tree_efficient(
       }
 
       int token_idx = parent_list[bid * (topk * (depth - 1) + 1) + parent_tb_idx];
-      for (cur_position = 0; cur_position < draft_token_num; ++cur_position) {
-        if (selected_index[bid * (draft_token_num - 1) + cur_position] == token_idx) {
+      // selected_index has draft_token_num - 1 entries per request
+      int found = -1;
+      for (int p = 0; p < draft_token_num - 1; ++p) {
+        if (selected_index[bid * (draft_token_num - 1) + p] == token_idx) {
+          found = p;
           break;
         }
       }
+      if (found < 0) {
+        printf(
+            "WARNING: invalid eagle tree!!! Detected a token whose ancestor was not selected. "
+            "Please check if the logprob has nan. The walk stops here to keep proceeding.\n");
+        break;
+      }
+      cur_position = found;
     }
     positions[bid * draft_token_num + tid] = position + seq_len;
   }

--- a/test/registered/spec/utils/test_build_eagle_tree_malformed.py
+++ b/test/registered/spec/utils/test_build_eagle_tree_malformed.py
@@ -1,9 +1,24 @@
-"""Malformed-tree handling in build_tree_kernel_efficient.
+"""build_tree_kernel_efficient on malformed trees, across all three mask modes.
 
-The reference walk mirrors csrc/cpu/spec.cpp, which stops both on an ancestor
-that was never selected and on a chain that loops.
+The reference mirrors csrc/cpu/spec.cpp, which is the implementation this kernel is being
+brought in line with: the parent lookup searches only the draft_token_num - 1 entries
+selected_index holds per request, a token whose parent was not selected is skipped, and the
+root-ward walk is bounded by depth.
+
+All three mask layouts encode the same logical [bs][token][ancestor] matrix, so the reference
+builds that once and encodes it per layout:
+
+  QLEN_ONLY             row of draft_token_num bools per token
+  FULL_MASK             row of verified_seq_len + draft_token_num bools; the leading
+                        verified_seq_len entries belong to the caller and are not compared
+  QLEN_ONLY_BITPACKING  num_bytes_per_item bytes per token, bit k of the item is column k
+
+Every case compares positions, tree_mask, retrieve_index, retrieve_next_token and
+retrieve_next_sibling. Checking positions and the mask alone leaves the retrieval tree, which
+is what a missing parent actually corrupts, without an oracle.
 """
 
+import itertools
 import unittest
 
 import torch
@@ -11,122 +26,222 @@ import torch
 from sglang.srt.speculative.eagle_utils import TreeMaskMode
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
-register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
-register_amd_ci(est_time=2, suite="stage-b-test-1-gpu-small-amd")
+register_cuda_ci(est_time=4, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=4, suite="stage-b-test-1-gpu-small-amd")
 
 TOPK = 2
 NUM_STEPS = 3
 DRAFT_TOKEN_NUM = 4
 BS = 2
 
-# an entry below topk is the root and ends the walk; two requests, so the
-# per-request offset in the ancestor search is exercised
+# an entry below topk ends the walk at the root; two requests, so the per-request offset in the
+# lookup is exercised rather than assumed
 SELECTED = torch.tensor([[4, 2, 0], [2, 4, 0]], dtype=torch.int64)
 SEQ_LENS = torch.tensor([7, 11], dtype=torch.int64)
 
-PARENT_VALID = torch.tensor(
-    [[0, 0, 2, 0, 0], [0, 4, 0, 0, 0]], dtype=torch.int64
-)  # chains that reach the root
-# 99 is never selected
-PARENT_ABSENT = torch.tensor(
-    [[0, 99, 99, 99, 99], [0, 99, 99, 99, 99]], dtype=torch.int64
-)
-# node 1 is its own ancestor
-PARENT_LOOPS = torch.tensor([[0, 2, 2, 0, 0], [0, 4, 4, 0, 0]], dtype=torch.int64)
+CASES = {
+    # chains that reach the root
+    "valid_chain": torch.tensor([[0, 0, 2, 0, 0], [0, 4, 0, 0, 0]], dtype=torch.int64),
+    # the direct parent of a token is a value selected_index never holds
+    "missing_direct_parent": torch.tensor(
+        [[0, 99, 2, 0, 0], [0, 99, 0, 0, 0]], dtype=torch.int64
+    ),
+    # every lookup misses, so the search runs to the end of the row on every step
+    "missing_ancestor": torch.tensor(
+        [[0, 99, 99, 99, 99], [0, 99, 99, 99, 99]], dtype=torch.int64
+    ),
+    # a node is its own ancestor, so an unbounded walk never reaches the root
+    "cyclic_ancestor": torch.tensor(
+        [[0, 2, 2, 0, 0], [0, 4, 4, 0, 0]], dtype=torch.int64
+    ),
+    # a chain exactly depth long: the bound must not cut a walk that is still valid
+    "max_valid_depth": torch.tensor(
+        [[0, 0, 4, 2, 0], [0, 0, 2, 4, 0]], dtype=torch.int64
+    ),
+}
+
+# Request 0's parent is absent from its own row but present as request 1's first entry. A search
+# that runs one element too far reads request 1's row and can match there. The outputs cannot see
+# it -- the extra step makes a match indistinguishable from not-found -- so this case exists for
+# a memory checker rather than for its assertions.
+# 6 is absent from request 0's row, is request 1's first entry, and 6 // topk stays inside
+# parent_list, so the case probes the row overrun and not the separate question of an
+# out-of-range parent_tb_idx, which this kernel does not validate and this PR does not claim to.
+CROSS_ROW_SELECTED = torch.tensor([[4, 2, 0], [6, 4, 0]], dtype=torch.int64)
+CROSS_ROW_PARENT = torch.tensor([[0, 6, 4, 0, 0], [0, 0, 6, 4, 0]], dtype=torch.int64)
+
+MODES = [TreeMaskMode.FULL_MASK, TreeMaskMode.QLEN_ONLY, TreeMaskMode.QLEN_ONLY_BITPACKING]
+MODE_NAMES = {
+    TreeMaskMode.FULL_MASK: "FULL_MASK",
+    TreeMaskMode.QLEN_ONLY: "QLEN_ONLY",
+    TreeMaskMode.QLEN_ONLY_BITPACKING: "QLEN_ONLY_BITPACKING",
+}
 
 
-def _ref(parent_list, selected_index, seq_lens):
-    """positions[] and the QLEN_ONLY mask, as the CPU backend computes them."""
-    positions = []
-    mask = torch.zeros(
-        BS * DRAFT_TOKEN_NUM * DRAFT_TOKEN_NUM, dtype=torch.bool
-    ).reshape(BS, DRAFT_TOKEN_NUM, DRAFT_TOKEN_NUM)
+def _bytes_per_item(draft_token_num):
+    if draft_token_num > 16:
+        return 4
+    if draft_token_num > 8:
+        return 2
+    return 1
+
+
+def _reference(parent_list, selected_index, seq_lens):
+    """The logical outputs: positions, an [bs][token][column] matrix, and the retrieval tree."""
+    sel_stride = DRAFT_TOKEN_NUM - 1
+    positions = torch.zeros(BS * DRAFT_TOKEN_NUM, dtype=torch.int64)
+    retrieve_index = torch.full((BS, DRAFT_TOKEN_NUM), -1, dtype=torch.int64)
+    retrieve_next_token = torch.full((BS, DRAFT_TOKEN_NUM), -1, dtype=torch.int64)
+    retrieve_next_sibling = torch.full((BS, DRAFT_TOKEN_NUM), -1, dtype=torch.int64)
+    matrix = torch.zeros(BS, DRAFT_TOKEN_NUM, DRAFT_TOKEN_NUM, dtype=torch.bool)
+
+    def find(sel, token_idx):
+        for p in range(sel_stride):
+            if sel[p] == token_idx:
+                return p
+        return -1
+
     for bid in range(BS):
         sel = selected_index[bid].tolist()
         par = parent_list[bid].tolist()
         seq_len = int(seq_lens[bid])
+
+        # the retrieval tree, built by tid == 0 walking i downward
+        for i in range(DRAFT_TOKEN_NUM - 1, 0, -1):
+            retrieve_index[bid][i] = bid * DRAFT_TOKEN_NUM + i
+            parent_tb_idx = sel[i - 1] // TOPK
+            parent_position = 0
+            if parent_tb_idx > 0:
+                found = find(sel, par[parent_tb_idx])
+                if found < 0:
+                    continue  # the token is skipped, as on CPU
+                parent_position = found + 1
+            if retrieve_next_token[bid][parent_position] == -1:
+                retrieve_next_token[bid][parent_position] = i
+            else:
+                origin = int(retrieve_next_token[bid][parent_position])
+                retrieve_next_token[bid][parent_position] = i
+                retrieve_next_sibling[bid][i] = origin
+        retrieve_index[bid][0] = bid * DRAFT_TOKEN_NUM
+
+        # one root-ward walk per token, which fills that token's mask row and its position
         for tid in range(DRAFT_TOKEN_NUM):
-            mask[bid][tid][0] = True  # every token attends to the root
+            matrix[bid][tid][0] = True
             if tid == 0:
-                positions.append(seq_len)
+                positions[bid * DRAFT_TOKEN_NUM] = seq_len
                 continue
             position, cur = 0, tid - 1
             while position < NUM_STEPS:
                 position += 1
-                mask[bid][tid][cur + 1] = True
+                matrix[bid][tid][cur + 1] = True
                 if sel[cur] // TOPK == 0:
                     break
-                token_idx = par[sel[cur] // TOPK]
-                found = -1
-                for p in range(DRAFT_TOKEN_NUM - 1):
-                    if sel[p] == token_idx:
-                        found = p
-                        break
+                found = find(sel, par[sel[cur] // TOPK])
                 if found < 0:
                     break
                 cur = found
-            positions.append(position + seq_len)
-    return torch.tensor(positions, dtype=torch.int64), mask.flatten()
+            positions[bid * DRAFT_TOKEN_NUM + tid] = position + seq_len
+
+    return positions, matrix, retrieve_index, retrieve_next_token, retrieve_next_sibling
 
 
-def _run_cuda(parent_list, selected_index, seq_lens):
+def _decode_mask(raw, matrix_shape, seq_lens, mode):
+    """The kernel's mask buffer, decoded back to the logical [bs][token][column] matrix."""
+    bs, n, _ = matrix_shape
+    out = torch.zeros(bs, n, n, dtype=torch.bool)
+    if mode == TreeMaskMode.QLEN_ONLY:
+        return raw.reshape(bs, n, n).clone()
+    if mode == TreeMaskMode.FULL_MASK:
+        off = 0
+        for bid in range(bs):
+            seq_len = int(seq_lens[bid])
+            row = seq_len + n
+            for tid in range(n):
+                base = off + row * tid + seq_len
+                out[bid][tid] = raw[base : base + n]
+            off += row * n
+        return out
+    nbytes = _bytes_per_item(n)
+    for bid in range(bs):
+        for tid in range(n):
+            item = raw[(bid * n + tid) * nbytes : (bid * n + tid + 1) * nbytes]
+            for col in range(n):
+                out[bid][tid][col] = bool(int(item[col // 8]) >> (col % 8) & 1)
+    return out
+
+
+def _run(parent_list, selected_index, seq_lens, mode, op=None):
+    op = op or torch.ops.sgl_kernel.build_tree_kernel_efficient
     device = "cuda"
-    tree_mask = torch.full(
-        (BS * DRAFT_TOKEN_NUM * DRAFT_TOKEN_NUM,),
-        True,
-        dtype=torch.bool,
-        device=device,
-    )
-    positions = torch.zeros(BS * DRAFT_TOKEN_NUM, dtype=torch.int64, device=device)
-    retrieve_buf = torch.full(
-        (3, BS, DRAFT_TOKEN_NUM), -1, dtype=torch.int64, device=device
-    )
-    retrieve_index, retrieve_next_token, retrieve_next_sibling = retrieve_buf
-    torch.ops.sgl_kernel.build_tree_kernel_efficient(
+    n = DRAFT_TOKEN_NUM
+    if mode == TreeMaskMode.QLEN_ONLY:
+        mask = torch.zeros(BS * n * n, dtype=torch.bool, device=device)
+    elif mode == TreeMaskMode.FULL_MASK:
+        total = sum((int(s) + n) * n for s in seq_lens)
+        mask = torch.zeros(total, dtype=torch.bool, device=device)
+    else:
+        mask = torch.zeros(BS * n * _bytes_per_item(n), dtype=torch.uint8, device=device)
+
+    positions = torch.zeros(BS * n, dtype=torch.int64, device=device)
+    buf = torch.full((3, BS, n), -1, dtype=torch.int64, device=device)
+    ri, rnt, rns = buf
+    op(
         parent_list.to(device),
         selected_index.to(device),
         seq_lens.to(device),
-        tree_mask,
+        mask,
         positions,
-        retrieve_index,
-        retrieve_next_token,
-        retrieve_next_sibling,
+        ri,
+        rnt,
+        rns,
         TOPK,
         NUM_STEPS,
-        DRAFT_TOKEN_NUM,
-        TreeMaskMode.QLEN_ONLY,
+        n,
+        int(mode),
     )
     torch.cuda.synchronize()
-    return positions.cpu(), tree_mask.cpu()
+    return positions.cpu(), mask.cpu(), ri.cpu(), rnt.cpu(), rns.cpu()
 
 
 @unittest.skipUnless(torch.cuda.is_available(), "needs a CUDA device")
 class TestBuildEagleTreeMalformed(unittest.TestCase):
-    def _check(self, parent_list):
-        got_pos, got_mask = _run_cuda(parent_list, SELECTED, SEQ_LENS)
-        want_pos, want_mask = _ref(parent_list, SELECTED, SEQ_LENS)
-        self.assertTrue(
-            torch.equal(got_pos, want_pos),
-            f"positions {got_pos.tolist()} != reference {want_pos.tolist()}",
+    def _check(self, name, parent_list, selected_index, mode, op=None):
+        got_pos, got_raw, got_ri, got_rnt, got_rns = _run(
+            parent_list, selected_index, SEQ_LENS, mode, op
         )
-        # an unbounded walk writes past its own row, which positions alone cannot see
-        self.assertTrue(
-            torch.equal(got_mask, want_mask),
-            "tree_mask differs from the reference at "
-            f"{(got_mask != want_mask).nonzero().flatten().tolist()}",
+        want_pos, want_matrix, want_ri, want_rnt, want_rns = _reference(
+            parent_list, selected_index, SEQ_LENS
         )
+        got_matrix = _decode_mask(got_raw, want_matrix.shape, SEQ_LENS, mode)
+        tag = f"{name}/{MODE_NAMES[mode]}"
+        for label, got, want in (
+            ("positions", got_pos, want_pos),
+            ("tree_mask", got_matrix, want_matrix),
+            ("retrieve_index", got_ri, want_ri),
+            ("retrieve_next_token", got_rnt, want_rnt),
+            ("retrieve_next_sibling", got_rns, want_rns),
+        ):
+            self.assertTrue(
+                torch.equal(got, want),
+                f"{tag}: {label}\n  got  {got.tolist()}\n  want {want.tolist()}",
+            )
 
-    def test_valid_chain(self):
-        """The bound must not change a tree that was already well formed."""
-        self._check(PARENT_VALID)
+    def test_matrix(self):
+        for (name, parents), mode in itertools.product(CASES.items(), MODES):
+            with self.subTest(case=name, mode=MODE_NAMES[mode]):
+                self._check(name, parents, SELECTED, mode)
 
-    def test_absent_ancestor(self):
-        """An ancestor that was never selected stops the walk, as on CPU."""
-        self._check(PARENT_ABSENT)
+    def test_cross_row_lookup(self):
+        """A lookup that runs past its row can reach the next request's first entry.
 
-    def test_looping_ancestor_chain(self):
-        """A chain that never reaches the root stops at the depth bound."""
-        self._check(PARENT_LOOPS)
+        The assertions here cannot see that read; they exist so the case is covered by the
+        oracle as well. Run this file under compute-sanitizer to see the read itself.
+        """
+        for mode in MODES:
+            with self.subTest(mode=MODE_NAMES[mode]):
+                self._check(
+                    "cross_row", CROSS_ROW_PARENT, CROSS_ROW_SELECTED, mode
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/spec/utils/test_build_eagle_tree_malformed.py
+++ b/test/registered/spec/utils/test_build_eagle_tree_malformed.py
@@ -1,0 +1,133 @@
+"""Malformed-tree handling in build_tree_kernel_efficient.
+
+The reference walk mirrors csrc/cpu/spec.cpp, which stops both on an ancestor
+that was never selected and on a chain that loops.
+"""
+
+import unittest
+
+import torch
+
+from sglang.srt.speculative.eagle_utils import TreeMaskMode
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=2, suite="stage-b-test-1-gpu-small-amd")
+
+TOPK = 2
+NUM_STEPS = 3
+DRAFT_TOKEN_NUM = 4
+BS = 2
+
+# an entry below topk is the root and ends the walk; two requests, so the
+# per-request offset in the ancestor search is exercised
+SELECTED = torch.tensor([[4, 2, 0], [2, 4, 0]], dtype=torch.int64)
+SEQ_LENS = torch.tensor([7, 11], dtype=torch.int64)
+
+PARENT_VALID = torch.tensor(
+    [[0, 0, 2, 0, 0], [0, 4, 0, 0, 0]], dtype=torch.int64
+)  # chains that reach the root
+# 99 is never selected
+PARENT_ABSENT = torch.tensor(
+    [[0, 99, 99, 99, 99], [0, 99, 99, 99, 99]], dtype=torch.int64
+)
+# node 1 is its own ancestor
+PARENT_LOOPS = torch.tensor([[0, 2, 2, 0, 0], [0, 4, 4, 0, 0]], dtype=torch.int64)
+
+
+def _ref(parent_list, selected_index, seq_lens):
+    """positions[] and the QLEN_ONLY mask, as the CPU backend computes them."""
+    positions = []
+    mask = torch.zeros(
+        BS * DRAFT_TOKEN_NUM * DRAFT_TOKEN_NUM, dtype=torch.bool
+    ).reshape(BS, DRAFT_TOKEN_NUM, DRAFT_TOKEN_NUM)
+    for bid in range(BS):
+        sel = selected_index[bid].tolist()
+        par = parent_list[bid].tolist()
+        seq_len = int(seq_lens[bid])
+        for tid in range(DRAFT_TOKEN_NUM):
+            mask[bid][tid][0] = True  # every token attends to the root
+            if tid == 0:
+                positions.append(seq_len)
+                continue
+            position, cur = 0, tid - 1
+            while position < NUM_STEPS:
+                position += 1
+                mask[bid][tid][cur + 1] = True
+                if sel[cur] // TOPK == 0:
+                    break
+                token_idx = par[sel[cur] // TOPK]
+                found = -1
+                for p in range(DRAFT_TOKEN_NUM - 1):
+                    if sel[p] == token_idx:
+                        found = p
+                        break
+                if found < 0:
+                    break
+                cur = found
+            positions.append(position + seq_len)
+    return torch.tensor(positions, dtype=torch.int64), mask.flatten()
+
+
+def _run_cuda(parent_list, selected_index, seq_lens):
+    device = "cuda"
+    tree_mask = torch.full(
+        (BS * DRAFT_TOKEN_NUM * DRAFT_TOKEN_NUM,),
+        True,
+        dtype=torch.bool,
+        device=device,
+    )
+    positions = torch.zeros(BS * DRAFT_TOKEN_NUM, dtype=torch.int64, device=device)
+    retrieve_buf = torch.full(
+        (3, BS, DRAFT_TOKEN_NUM), -1, dtype=torch.int64, device=device
+    )
+    retrieve_index, retrieve_next_token, retrieve_next_sibling = retrieve_buf
+    torch.ops.sgl_kernel.build_tree_kernel_efficient(
+        parent_list.to(device),
+        selected_index.to(device),
+        seq_lens.to(device),
+        tree_mask,
+        positions,
+        retrieve_index,
+        retrieve_next_token,
+        retrieve_next_sibling,
+        TOPK,
+        NUM_STEPS,
+        DRAFT_TOKEN_NUM,
+        TreeMaskMode.QLEN_ONLY,
+    )
+    torch.cuda.synchronize()
+    return positions.cpu(), tree_mask.cpu()
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "needs a CUDA device")
+class TestBuildEagleTreeMalformed(unittest.TestCase):
+    def _check(self, parent_list):
+        got_pos, got_mask = _run_cuda(parent_list, SELECTED, SEQ_LENS)
+        want_pos, want_mask = _ref(parent_list, SELECTED, SEQ_LENS)
+        self.assertTrue(
+            torch.equal(got_pos, want_pos),
+            f"positions {got_pos.tolist()} != reference {want_pos.tolist()}",
+        )
+        # an unbounded walk writes past its own row, which positions alone cannot see
+        self.assertTrue(
+            torch.equal(got_mask, want_mask),
+            "tree_mask differs from the reference at "
+            f"{(got_mask != want_mask).nonzero().flatten().tolist()}",
+        )
+
+    def test_valid_chain(self):
+        """The bound must not change a tree that was already well formed."""
+        self._check(PARENT_VALID)
+
+    def test_absent_ancestor(self):
+        """An ancestor that was never selected stops the walk, as on CPU."""
+        self._check(PARENT_ABSENT)
+
+    def test_looping_ancestor_chain(self):
+        """A chain that never reaches the root stops at the depth bound."""
+        self._check(PARENT_LOOPS)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`build_tree_efficient` and `build_tree_efficient_partial_packed` search `selected_index` while building the retrieval links and each draft token's mask row. Each request has `draft_token_num - 1` selected entries, but the four parent and ancestor lookups currently scan `draft_token_num` entries. If the requested parent is absent, the last lookup reads the next request's row, or past the tensor for the final request.

The ancestor walks are also unbounded. A cyclic chain can therefore keep the kernel from returning. The CPU and Triton implementations already limit the search to one request's selected row and bound the walk by `depth`.

This is not only an arbitrary-input case. #7477 reports the existing missing-parent warning, and the reporter later found NaNs in the EAGLE logits. This PR does not address the source of those NaNs. It makes the CUDA tree builder stop safely when it receives a malformed tree.

## Modifications

- Add `find_selected_position`, a small device helper that searches one request's valid `selected_index` row and returns `-1` when the token is absent.
- Use the helper for the retrieval-tree and ancestor lookups in both CUDA builders.
- Skip an invalid retrieval link or stop the current ancestor walk when a lookup fails, matching the CPU behavior.
- Bound the ordinary and bit-packed ancestor walks by `depth`.
- Add regression coverage for all three tree-mask modes.

The tree verification and sampling kernels are unchanged.

## Accuracy Tests

`test/registered/spec/utils/test_build_eagle_tree_malformed.py` builds a CPU-style reference and compares `positions`, `tree_mask`, `retrive_index`, `retrive_next_token`, and `retrive_next_sibling`.

The test covers six cases in `FULL_MASK`, `QLEN_ONLY`, and `QLEN_ONLY_BITPACKING`:

- well-formed chain
- missing direct parent
- missing ancestor
- cyclic ancestor
- chain exactly `depth` steps long
- lookup that would otherwise cross into the next request's row

Hardware: NVIDIA RTX A6000 (`sm_86`), CUDA 12.9.

All 18 case/mode combinations pass with this change. Before the change, the cyclic `QLEN_ONLY_BITPACKING` case does not return within 60 seconds. With the bound, it returns and matches the reference.

`compute-sanitizer --tool memcheck` reports 0 errors for the registered test matrix after the change.

PyTorch's caching allocator can place the one-row overread inside a larger allocation, so the operator-level sanitizer run is not sufficient to demonstrate the old read. I also checked the search with an exact-sized `cudaMalloc` buffer. Before the change, memcheck reports an invalid 8-byte global read immediately past the 24-byte allocation. After correcting the search bound, it reports no error.

## Speed Tests and Profiling

No throughput benchmark was run. On a valid tree, this remains the same linear lookup, now shared by the four call sites, plus one `position < depth` comparison per ancestor. A valid walk already reaches the root in at most `depth` steps.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). Not applicable; this change has no user-facing interface or configuration change.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

Please trigger the registered CUDA and ROCm jobs for the updated commit.

Signed-off-by: thc1006 <84045975+thc1006@users.noreply.github.com>
