### PR TITLE
fix: accept nullable strict field in tool definitions

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -745,8 +745,17 @@ class Function(BaseModel):
     description: Optional[str] = Field(default=None, examples=[None])
     name: str
     parameters: Optional[object] = None
-    strict: bool = False
+    # The OpenAI spec types ``strict`` as nullable (anyOf [boolean, "null"])
+    # so conforming clients may send ``"strict": null`` to mean "unset".
+    # Accept null and normalize it to False, matching the server's default.
+    strict: Optional[bool] = None
     defer_loading: Optional[bool] = None
+
+    @model_validator(mode="after")
+    def _normalize_strict(self) -> "Function":
+        if self.strict is None:
+            self.strict = False
+        return self
 
     @model_serializer(mode="wrap")
     def _serialize(self, handler):
@@ -1556,7 +1565,10 @@ class ResponseTool(BaseModel):
     name: Optional[str] = None
     description: Optional[str] = None
     parameters: Optional[Dict[str, Any]] = None
-    strict: bool = False
+    # The OpenAI spec types ``strict`` as nullable (anyOf [boolean, "null"])
+    # so conforming clients may send ``"strict": null`` to mean "unset".
+    # Accept null and normalize it to False, matching the server's default.
+    strict: Optional[bool] = None
     # Inner schemas for ``namespace`` tools.
     tools: Optional[List[Dict[str, Any]]] = None
 
@@ -1564,6 +1576,8 @@ class ResponseTool(BaseModel):
     def validate_function_tool(self) -> ResponseTool:
         if self.type == "function" and not self.name:
             raise ValueError("Function tools must include a name.")
+        if self.strict is None:
+            self.strict = False
         return self
 
 

--- a/test/registered/unit/entrypoints/openai/test_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_protocol.py
@@ -704,6 +704,22 @@ class TestFunctionDeferLoading(unittest.TestCase):
         self.assertEqual(data["strict"], False)
         self.assertNotIn("defer_loading", data)
 
+    def test_function_accepts_strict_null(self):
+        """The OpenAI spec types ``strict`` as nullable; ``"strict": null``
+        must be accepted and normalized to False (issue #36194)."""
+        f = Function.model_validate({"name": "foo", "strict": None})
+        self.assertEqual(f.strict, False)
+        data = f.model_dump()
+        self.assertEqual(data["strict"], False)
+
+        # Also via direct construction
+        f = Function(name="foo", strict=None)
+        self.assertEqual(f.strict, False)
+
+        # True is preserved
+        f = Function(name="foo", strict=True)
+        self.assertTrue(f.strict)
+
     def test_function_defer_loading_true_serialized(self):
         f = Function(name="foo", defer_loading=True)
         data = f.model_dump()

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -52,6 +52,25 @@ class ResponsesRequestTestCase(CustomTestCase):
         self.assertEqual(request.tools[0].name, "lookup")
         self.assertTrue(request.tools[0].strict)
 
+    def test_function_tool_accepts_strict_null(self):
+        """The OpenAI spec types ``strict`` as nullable; ``"strict": null``
+        must be accepted and normalized to False (issue #36194)."""
+        request = ResponsesRequest(
+            model="x",
+            input="ping",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "t1",
+                    "description": "d",
+                    "parameters": {"type": "object", "properties": {}},
+                    "strict": None,
+                }
+            ],
+            store=False,
+        )
+        self.assertFalse(request.tools[0].strict)
+
     def test_function_tool_requires_name(self):
         with self.assertRaises(ValueError):
             ResponsesRequest(


### PR DESCRIPTION
## Summary

Fixes #36194

The OpenAI spec types the `strict` field on function tools as nullable (`anyOf: [boolean, "null"]`). Official SDKs and gateways serialize `"strict": null` to express an unset value. SGLang previously declared `strict: bool = False` on both `Function` (chat completions) and `ResponseTool` (responses API), causing Pydantic to reject `"strict": null` with a 400 error before the request reached the model.

## Changes

- Changed `Function.strict` from `bool = False` to `Optional[bool] = None` with a `model_validator` that normalizes `None` to `False`.
- Changed `ResponseTool.strict` from `bool = False` to `Optional[bool] = None`, normalizing `None` to `False` in the existing `validate_function_tool` validator.
- Added unit tests for both endpoints verifying `"strict": null` is accepted and normalized to `False`.

## Behavior

- `"strict": null` -> accepted, treated as `False` (matching OpenAI spec and vLLM behavior)
- `"strict": true` -> preserved as `True`
- `"strict": false` -> preserved as `False`
- `"strict"` omitted -> defaults to `False`

The normalization to `False` ensures downstream code (function_call_parser, chat templates) and serialized output see the same shape as before, so existing behavior is fully preserved.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32760025925](https://github.com/sgl-project/sglang/actions/runs/32760025925)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32760025160](https://github.com/sgl-project/sglang/actions/runs/32760025160)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32760025763](https://github.com/sgl-project/sglang/actions/runs/32760025763)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->