### PR TITLE
fix: detect WSL2 and reject cuda_ipc transport with actionable error

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -96,6 +96,7 @@ from sglang.srt.utils.common import (
     is_sm100_or_sm110_supported,
     is_sm100_supported,
     is_sm120_supported,
+    is_wsl,
     is_xpu,
     json_list_type,
     nullable_str,
@@ -8624,6 +8625,12 @@ class ServerArgs:
             if self.nnodes != 1:
                 raise ValueError(
                     "--mm-feature-transport=cuda_ipc only supports a single node."
+                )
+            if is_wsl():
+                raise ValueError(
+                    "--mm-feature-transport=cuda_ipc is not supported on WSL2 "
+                    "(cudaIpcOpenMemHandle is unavailable). Use "
+                    "--mm-feature-transport=cpu instead."
                 )
 
             pool_budget_mb = envs.SGLANG_MM_FEATURE_CACHE_MB.get()

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -869,6 +869,22 @@ def is_mnnvl_fabric_device() -> bool:
 
 
 @lru_cache(maxsize=1)
+def is_wsl() -> bool:
+    """Whether the process is running under Windows Subsystem for Linux v2.
+
+    CUDA IPC (cudaIpcOpenMemHandle / cudaIpcGetMemHandle) is unsupported on
+    WSL2, so callers that auto-select or validate ``cuda_ipc`` transport use
+    this to fall back to ``cpu`` or emit an actionable error.
+    """
+    try:
+        with open("/proc/version", "r") as f:
+            version_info = f.read()
+    except OSError:
+        return False
+    return "microsoft" in version_info.lower() or "wsl" in version_info.lower()
+
+
+@lru_cache(maxsize=1)
 def is_habana_available() -> bool:
     return find_spec("habana_frameworks") is not None
 

--- a/test/registered/unit/utils/test_common.py
+++ b/test/registered/unit/utils/test_common.py
@@ -1,5 +1,6 @@
 import unittest
 from array import array
+from unittest import mock as unittest_mock  # noqa: F401
 
 import torch
 
@@ -7,6 +8,7 @@ from sglang.srt.utils.common import (
     flatten_arrays_to_int64_tensor,
     get_device_sm_nvidia_smi,
     get_nvidia_driver_version_str,
+    is_wsl,
 )
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -142,6 +144,48 @@ class TestGetDeviceSmNvidiaSmi(CustomTestCase):
             self.assertEqual(get_device_sm_nvidia_smi(), (0, 0))
         finally:
             subprocess.run = original
+
+
+class TestIsWsl(unittest.TestCase):
+    """Tests for the WSL2 detection helper (issue #35385)."""
+
+    def test_returns_bool(self):
+        result = is_wsl()
+        self.assertIsInstance(result, bool)
+
+    def test_detects_wsl_kernel_string(self):
+        import sglang.srt.utils.common as common
+
+        with unittest_mock.patch(
+            "builtins.open",
+            unittest_mock.mock_open(
+                read_data="Linux version 6.6.87.2-microsoft-standard-WSL2"
+            ),
+        ):
+            common.is_wsl.cache_clear()
+            self.assertTrue(common.is_wsl())
+            common.is_wsl.cache_clear()
+
+    def test_returns_false_on_non_wsl_kernel(self):
+        import sglang.srt.utils.common as common
+
+        with unittest_mock.patch(
+            "builtins.open",
+            unittest_mock.mock_open(
+                read_data="Linux version 6.8.0-1014-aws"
+            ),
+        ):
+            common.is_wsl.cache_clear()
+            self.assertFalse(common.is_wsl())
+            common.is_wsl.cache_clear()
+
+    def test_returns_false_when_proc_version_missing(self):
+        import sglang.srt.utils.common as common
+
+        with unittest_mock.patch("builtins.open", side_effect=OSError):
+            common.is_wsl.cache_clear()
+            self.assertFalse(common.is_wsl())
+            common.is_wsl.cache_clear()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Fixes #35385

On WSL2, CUDA IPC (`cudaIpcOpenMemHandle` / `cudaIpcGetMemHandle`) is unsupported, but if `--mm-feature-transport=cuda_ipc` is explicitly requested the server crashes on the first multimodal request with a cryptic `CUDA error: invalid resource handle` traceback that does not mention the flag or the workaround.

## Changes

- Added `is_wsl()` helper in `python/sglang/srt/utils/common.py` that checks `/proc/version` for the `microsoft` / `wsl` kernel identifier.
- Added a WSL2 validation check in `_handle_multimodal_feature_transport` (`python/sglang/srt/server_args.py`) that raises a `ValueError` with an actionable message pointing to `--mm-feature-transport=cpu` when `cuda_ipc` is requested on WSL2.
- Added unit tests for `is_wsl()` covering WSL2 detection, non-WSL kernel, and missing `/proc/version`.

## Behavior

When a user on WSL2 passes `--mm-feature-transport=cuda_ipc` (or the deprecated `--keep-mm-feature-on-device` / `SGLANG_USE_CUDA_IPC_TRANSPORT=1`), they now get:

```
ValueError: --mm-feature-transport=cuda_ipc is not supported on WSL2
(cudaIpcOpenMemHandle is unavailable). Use --mm-feature-transport=cpu instead.
```

instead of a scheduler crash on the first request.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32762582162](https://github.com/sgl-project/sglang/actions/runs/32762582162)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32762581699](https://github.com/sgl-project/sglang/actions/runs/32762581699)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32762581610](https://github.com/sgl-project/sglang/actions/runs/32762581610)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->