### PR TITLE
feat: support temperature-scaled input logprobs

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -2242,6 +2242,7 @@ class MMReceiverBase(ABC):
             recv_req.sampling_params,
             return_logprob=recv_req.return_logprob,
             top_logprobs_num=recv_req.top_logprobs_num,
+            input_logprob_temperature=recv_req.input_logprob_temperature,
             token_ids_logprob=recv_req.token_ids_logprob,
             stream=recv_req.stream,
             lora_id=recv_req.lora_id,

--- a/python/sglang/srt/entrypoints/EngineBase.py
+++ b/python/sglang/srt/entrypoints/EngineBase.py
@@ -36,6 +36,8 @@ class EngineBase(ABC):
         rid: Optional[Union[List[str], str]] = None,
         priority: Optional[int] = None,
         session_id: Optional[str] = None,
+        *,
+        input_logprob_temperature: Optional[Union[List[float], float]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """Generate outputs based on given inputs."""
         pass

--- a/python/sglang/srt/entrypoints/engine.py
+++ b/python/sglang/srt/entrypoints/engine.py
@@ -411,6 +411,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
+        input_logprob_temperature: Optional[Union[List[float], float]] = None,
     ) -> Union[Dict, Iterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -432,6 +433,7 @@ class Engine(EngineScoreMixin, EngineBase):
             cache_salt=cache_salt,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
+            input_logprob_temperature=input_logprob_temperature,
             top_logprobs_num=top_logprobs_num,
             token_ids_logprob=token_ids_logprob,
             lora_path=lora_path,
@@ -524,6 +526,7 @@ class Engine(EngineScoreMixin, EngineBase):
         session_id: Optional[str] = None,
         *,
         cache_salt: Optional[Union[List[str], str]] = None,
+        input_logprob_temperature: Optional[Union[List[float], float]] = None,
     ) -> Union[Dict, AsyncIterator[Dict]]:
         """
         The arguments of this function is the same as `sglang/srt/managers/io_struct.py::GenerateReqInput`.
@@ -545,6 +548,7 @@ class Engine(EngineScoreMixin, EngineBase):
             cache_salt=cache_salt,
             return_logprob=return_logprob,
             logprob_start_len=logprob_start_len,
+            input_logprob_temperature=input_logprob_temperature,
             top_logprobs_num=top_logprobs_num,
             token_ids_logprob=token_ids_logprob,
             lora_path=lora_path,

--- a/python/sglang/srt/entrypoints/http_server_engine.py
+++ b/python/sglang/srt/entrypoints/http_server_engine.py
@@ -120,6 +120,8 @@ class HttpServerEngineAdapter(EngineBase):
         custom_logit_processor=None,
         priority=None,
         session_id=None,
+        *,
+        input_logprob_temperature=None,
     ):
         payload = {
             "text": prompt,
@@ -128,6 +130,7 @@ class HttpServerEngineAdapter(EngineBase):
             "image_data": image_data,
             "return_logprob": return_logprob,
             "logprob_start_len": logprob_start_len,
+            "input_logprob_temperature": input_logprob_temperature,
             "top_logprobs_num": top_logprobs_num,
             "token_ids_logprob": token_ids_logprob,
             "lora_path": lora_path,

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -166,6 +166,7 @@ class LogitsMetadata:
     top_logprobs_nums: Optional[List[int]] = None
     extend_input_logprob_token_ids_gpu: Optional[torch.Tensor] = None
     token_ids_logprobs: Optional[List[List[int]]] = None
+    input_logprob_temperatures: Optional[List[float]] = None
 
     # logits and logprobs post processing
     temperature: torch.Tensor = None
@@ -238,6 +239,7 @@ class LogitsMetadata:
             extend_logprob_pruned_lens_cpu=extend_logprob_pruned_lens_cpu,
             top_logprobs_nums=forward_batch.top_logprobs_nums,
             token_ids_logprobs=forward_batch.token_ids_logprobs,
+            input_logprob_temperatures=forward_batch.input_logprob_temperatures,
             extend_input_logprob_token_ids_gpu=forward_batch.extend_input_logprob_token_ids_gpu,
             is_prefill_only=forward_batch.is_prefill_only,
             global_num_tokens_gpu=forward_batch.global_num_tokens_gpu,
@@ -377,6 +379,7 @@ class LogitsProcessor(nn.Module):
             aux_pruned_states,
             sample_indices,
             input_logprob_indices,
+            input_logprob_temperatures,
             token_to_seq_idx,
         ) = self._get_pruned_states(
             hidden_states,
@@ -415,6 +418,7 @@ class LogitsProcessor(nn.Module):
             pruned_states=pruned_states,
             sample_indices=sample_indices,
             input_logprob_indices=input_logprob_indices,
+            input_logprob_temperatures=input_logprob_temperatures,
             token_to_seq_idx=token_to_seq_idx,
             lm_head=lm_head,
             get_logits_fn=self._get_logits,
@@ -439,6 +443,7 @@ class LogitsProcessor(nn.Module):
     ):
         pruned_states_before_norm: Optional[torch.Tensor] = None
         aux_pruned_states = None
+        input_logprob_temperatures = None
         token_to_seq_idx = []
 
         if (
@@ -507,6 +512,11 @@ class LogitsProcessor(nn.Module):
             sample_indices = []
             input_logprob_indices_pt = 0
             input_logprob_indices = []
+            temperature_values = logits_metadata.input_logprob_temperatures
+            scale_input_logprobs = temperature_values is not None and any(
+                temperature != 1.0 for temperature in temperature_values
+            )
+            input_logprob_temperature_values = []
             pt, pruned_states_list, pruned_states_before_norm_list = 0, [], []
             is_packed_aux_hidden_states = isinstance(aux_hidden_states, torch.Tensor)
             aux_pruned_states_lists = None
@@ -562,6 +572,11 @@ class LogitsProcessor(nn.Module):
                         for i in range(extend_len - extend_logprob_start_len)
                     ]
                 )
+                if scale_input_logprobs:
+                    input_logprob_temperature_values.extend(
+                        [temperature_values[idx]]
+                        * (extend_len - extend_logprob_start_len)
+                    )
                 input_logprob_indices_pt += extend_len - start_len
 
             pruned_states = torch.cat(pruned_states_list)
@@ -586,6 +601,12 @@ class LogitsProcessor(nn.Module):
                 dtype=torch.int64,
                 pin_memory=is_pin_memory_available(),
             ).to(pruned_states.device, non_blocking=True)
+            if scale_input_logprobs:
+                input_logprob_temperatures = torch.tensor(
+                    input_logprob_temperature_values,
+                    dtype=torch.float32,
+                    pin_memory=is_pin_memory_available(),
+                ).to(pruned_states.device, non_blocking=True)
 
         return (
             pruned_states,
@@ -593,6 +614,7 @@ class LogitsProcessor(nn.Module):
             aux_pruned_states,
             sample_indices,
             input_logprob_indices,
+            input_logprob_temperatures,
             token_to_seq_idx,
         )
 
@@ -950,6 +972,25 @@ class LogitsProcessor(nn.Module):
         sliced_hidden = hidden_states[multi_item_indices]
 
         sliced_logits = self._get_logits(sliced_hidden, lm_head, logits_metadata)
+        temperatures = logits_metadata.input_logprob_temperatures
+        if temperatures is not None and any(
+            temperature != 1.0 for temperature in temperatures
+        ):
+            row_temperatures = [
+                temperature
+                for temperature, delimiter_indices in zip(
+                    temperatures, multi_item_delimiter_indices
+                )
+                for _ in delimiter_indices
+            ]
+            sliced_logits = (
+                sliced_logits
+                / torch.tensor(
+                    row_temperatures,
+                    dtype=torch.float32,
+                    device=sliced_logits.device,
+                )[:, None]
+            )
         sliced_logprobs = torch.nn.functional.log_softmax(sliced_logits, dim=-1)
 
         # Initialize return values

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -462,6 +462,7 @@ class InputLogprobProcessor:
         pruned_states: torch.Tensor,
         sample_indices: Optional[torch.Tensor],
         input_logprob_indices: torch.Tensor,
+        input_logprob_temperatures: Optional[torch.Tensor],
         token_to_seq_idx: list[int],
         lm_head: VocabParallelEmbedding,
         get_logits_fn: Callable,
@@ -483,6 +484,7 @@ class InputLogprobProcessor:
             pruned_states,
             sample_indices,
             input_logprob_indices,
+            input_logprob_temperatures,
             token_to_seq_idx,
             lm_head,
             get_logits_fn,
@@ -495,6 +497,7 @@ class InputLogprobProcessor:
         pruned_states: torch.Tensor,
         sample_indices: torch.Tensor,
         input_logprob_indices: torch.Tensor,
+        input_logprob_temperatures: Optional[torch.Tensor],
         token_to_seq_idx: list[int],
         lm_head: VocabParallelEmbedding,
         get_logits_fn: Callable,
@@ -584,6 +587,10 @@ class InputLogprobProcessor:
             # Zero-logprob-row chunks still need the per-sequence bookkeeping below.
             chunk_logprobs = chunk_logits[chunk_indices]
             del chunk_logits
+            if input_logprob_temperatures is not None:
+                chunk_logprobs = (
+                    chunk_logprobs / input_logprob_temperatures[chunk_mask, None]
+                )
 
             # End at the last row inside the chunk; token_to_seq_idx[end_idx]
             # belongs to the next chunk and would emit its sequence twice.

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import copy
 import logging
+import math
 import pickle
 import uuid
 from array import array
@@ -216,6 +217,11 @@ class GenerateReqInput:
     # If return logprobs, the start location in the prompt for returning logprobs.
     # By default, this value is "-1", which means it will only return logprobs for output tokens.
     logprob_start_len: Optional[Union[List[int], int]] = None
+    # Temperature applied only when computing input-token logprobs. This is
+    # independent of sampling_params.temperature, which controls decoding.
+    input_logprob_temperature: Optional[Union[List[float], float]] = field(
+        default=None, kw_only=True
+    )
     # If return logprobs, the number of top logprobs to return at each position.
     top_logprobs_num: Optional[Union[List[int], int]] = None
     # If return logprobs, the token ids to return logprob for.
@@ -495,6 +501,9 @@ class GenerateReqInput:
             self.return_logprob = False
         if self.logprob_start_len is None:
             self.logprob_start_len = -1
+        if self.input_logprob_temperature is None:
+            self.input_logprob_temperature = 1.0
+        self._validate_input_logprob_temperatures([self.input_logprob_temperature])
         if self.top_logprobs_num is None:
             self.top_logprobs_num = 0
         if not self.token_ids_logprob:  # covers both None and []
@@ -708,6 +717,15 @@ class GenerateReqInput:
         self.logprob_start_len = normalize_param(
             self.logprob_start_len, -1, "logprob_start_len"
         )
+        self.input_logprob_temperature = normalize_param(
+            self.input_logprob_temperature, 1.0, "input_logprob_temperature"
+        )
+        if len(self.input_logprob_temperature) != num:
+            raise ValueError(
+                "The length of input_logprob_temperature should be equal to "
+                "the batch size."
+            )
+        self._validate_input_logprob_temperatures(self.input_logprob_temperature)
         self.top_logprobs_num = normalize_param(
             self.top_logprobs_num, 0, "top_logprobs_num"
         )
@@ -727,6 +745,19 @@ class GenerateReqInput:
         elif self.parallel_sample_num > 1:
             raise ValueError(
                 "Cannot use list token_ids_logprob with parallel_sample_num > 1"
+            )
+
+    @staticmethod
+    def _validate_input_logprob_temperatures(temperatures):
+        if any(
+            isinstance(temperature, bool)
+            or not isinstance(temperature, (int, float))
+            or not math.isfinite(temperature)
+            or temperature <= 0
+            for temperature in temperatures
+        ):
+            raise ValueError(
+                "input_logprob_temperature must contain positive finite numbers."
             )
 
     def _normalize_return_hidden_states(self, num):
@@ -872,6 +903,7 @@ class GenerateReqInput:
             sampling_params=self.sampling_params[i],
             return_logprob=self.return_logprob[i],
             logprob_start_len=self.logprob_start_len[i],
+            input_logprob_temperature=self.input_logprob_temperature[i],
             top_logprobs_num=self.top_logprobs_num[i],
             token_ids_logprob=self.token_ids_logprob[i],
             return_sampling_mask=self.return_sampling_mask[i],
@@ -963,6 +995,8 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     token_ids_logprob: Optional[List[int]]
     # Whether to stream output
     stream: bool
+    # Temperature applied only when computing input-token logprobs.
+    input_logprob_temperature: float = 1.0
     # Whether to return sparse output-token support from top-k/top-p/min-p sampling.
     return_sampling_mask: bool = False
     # Assemble prompt top logprobs as flat arrays scheduler-side (see

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -783,6 +783,7 @@ class MultimodalInputs:
 class ReqLogprob:
     top_logprobs_num: int
     token_ids_logprob: Optional[List[int]]
+    input_logprob_temperature: float = 1.0
     input_token_logprobs_val: Optional[List[float]] = None
     input_token_logprobs_idx: Optional[List[int]] = None
     input_top_logprobs_val: Optional[List[List[float]]] = None
@@ -866,6 +867,7 @@ class Req(ReqDllmMixin):
         multi_item_delimiter_indices: Optional[List[int]] = None,
         session_id: Optional[str] = None,
         cache_salt: Optional[str] = None,
+        input_logprob_temperature: float = 1.0,
     ):
         # Input and output info
         self.rid = rid
@@ -1059,6 +1061,7 @@ class Req(ReqDllmMixin):
         self.logprob = ReqLogprob(
             top_logprobs_num=top_logprobs_num,
             token_ids_logprob=token_ids_logprob,
+            input_logprob_temperature=input_logprob_temperature,
         )
         self.temp_scaled_logprobs = False
         self.top_p_normalized_logprobs = False

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -2459,6 +2459,7 @@ class Scheduler(
                 recv_req.sampling_params,
                 return_logprob=recv_req.return_logprob,
                 top_logprobs_num=recv_req.top_logprobs_num,
+                input_logprob_temperature=recv_req.input_logprob_temperature,
                 token_ids_logprob=recv_req.token_ids_logprob,
                 return_sampling_mask=recv_req.return_sampling_mask,
                 return_flat_raw_top_logprobs=recv_req.return_flat_raw_top_logprobs,

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1381,6 +1381,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 sampling_params=sampling_params,
                 return_logprob=obj.return_logprob,
                 logprob_start_len=obj.logprob_start_len,
+                input_logprob_temperature=obj.input_logprob_temperature,
                 top_logprobs_num=obj.top_logprobs_num,
                 token_ids_logprob=obj.token_ids_logprob,
                 return_sampling_mask=obj.return_sampling_mask,
@@ -2207,6 +2208,9 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     meta_info.update(scheduler_time_stats.convert_to_output_meta_info())
 
             if getattr(state.obj, "return_logprob", False):
+                meta_info["input_logprob_temperature"] = getattr(
+                    state.obj, "input_logprob_temperature", 1.0
+                )
                 self.convert_logprob_style(
                     meta_info,
                     state,

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -478,6 +478,8 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
     spec_info: Optional[SpecInput] = None
 
     # === Derived from ScheduleBatch.reqs ===
+    # For input logprobs
+    input_logprob_temperatures: Optional[List[float]] = None
     # For LoRA
     lora_ids: Optional[List[str]] = None
     # For dumper: request IDs for cross-step sequence tracking
@@ -799,6 +801,11 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             # Host-side metadata
             top_logprobs_nums=batch.top_logprobs_nums,
             token_ids_logprobs=batch.token_ids_logprobs,
+            input_logprob_temperatures=(
+                [req.logprob.input_logprob_temperature for req in batch.reqs]
+                if batch.return_logprob
+                else None
+            ),
             mm_inputs=batch.multimodal_inputs,
             encoder_cached=batch.encoder_cached,
             encoder_lens_cpu=batch.encoder_lens_cpu,

--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -301,6 +301,7 @@ class Session:
             stream=req.stream,
             return_logprob=req.return_logprob,
             top_logprobs_num=req.top_logprobs_num,
+            input_logprob_temperature=req.input_logprob_temperature,
             token_ids_logprob=req.token_ids_logprob,
             return_sampling_mask=req.return_sampling_mask,
             vocab_size=vocab_size,

--- a/test/registered/unit/layers/test_logprob_chunk_stitching.py
+++ b/test/registered/unit/layers/test_logprob_chunk_stitching.py
@@ -86,6 +86,7 @@ def _run(proc, batch, chunked, chunk_size):
         pruned_states=pruned_states,
         sample_indices=sample_indices,
         input_logprob_indices=input_logprob_indices,
+        input_logprob_temperatures=None,
         token_to_seq_idx=t2s,
         lm_head=None,
         get_logits_fn=get_logits_fn,

--- a/test/registered/unit/layers/test_logprob_fast_input.py
+++ b/test/registered/unit/layers/test_logprob_fast_input.py
@@ -12,10 +12,12 @@ from types import SimpleNamespace
 
 import torch
 
+from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.logprob_processor import (
     InputLogprobProcessor,
     compute_row_log_normalizer,
 )
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.logprob_test_utils import coverage_cases
 from sglang.test.test_utils import CustomTestCase
@@ -27,6 +29,7 @@ VOCAB = 11
 TOPK_CYCLE = [2, 0, 3]
 # [] is a valid probe set distinct from None (opt-out).
 TOKEN_IDS_CYCLE = [[0, 3], None, [1], []]
+TEMPERATURE_CYCLE = [0.5, 1.0, 2.0]
 # start == extend_len is the zero-logprob-row shape. Order determines the cyclic
 # width-3 heterogeneous coverage cases.
 SEQ_SPEC_MENU = ((1, 1), (3, 0), (4, 1), (5, 5), (6, 2))
@@ -66,6 +69,9 @@ def _build_batch(seq_specs, dtype, vocab=VOCAB):
         token_ids_logprobs=[
             TOKEN_IDS_CYCLE[i % len(TOKEN_IDS_CYCLE)] for i in range(len(seq_specs))
         ],
+        input_logprob_temperatures=[
+            TEMPERATURE_CYCLE[i % len(TEMPERATURE_CYCLE)] for i in range(len(seq_specs))
+        ],
     )
     return (
         torch.cat(pruned_rows),
@@ -85,10 +91,29 @@ def _run(proc, batch, fast, chunk_size):
     def get_logits_fn(states, lm_head, logits_metadata, **kwargs):
         return states
 
+    temperature_values = [
+        temperature
+        for temperature, pruned_len in zip(
+            metadata.input_logprob_temperatures,
+            metadata.extend_logprob_pruned_lens_cpu,
+        )
+        for _ in range(pruned_len)
+    ]
+    input_logprob_temperatures = (
+        torch.tensor(
+            temperature_values,
+            dtype=torch.float32,
+            device=pruned_states.device,
+        )
+        if any(temperature != 1.0 for temperature in temperature_values)
+        else None
+    )
+
     return proc.forward(
         pruned_states=pruned_states,
         sample_indices=sample_indices,
         input_logprob_indices=input_logprob_indices,
+        input_logprob_temperatures=input_logprob_temperatures,
         token_to_seq_idx=t2s,
         lm_head=None,
         get_logits_fn=get_logits_fn,
@@ -182,9 +207,21 @@ class TestFastInputLogprobs(CustomTestCase):
         for combo in coverage_cases(SEQ_SPEC_MENU, max_seqs=3):
             batch = _build_batch(list(combo), torch.bfloat16)
             pruned_states, _, input_logprob_indices, _, metadata = batch
-            truth = torch.log_softmax(pruned_states.double(), dim=-1)[
-                input_logprob_indices
-            ]
+            temperatures = torch.tensor(
+                [
+                    temperature
+                    for temperature, pruned_len in zip(
+                        metadata.input_logprob_temperatures,
+                        metadata.extend_logprob_pruned_lens_cpu,
+                    )
+                    for _ in range(pruned_len)
+                ],
+                dtype=torch.float64,
+            )
+            truth = torch.log_softmax(
+                pruned_states[input_logprob_indices].double() / temperatures[:, None],
+                dim=-1,
+            )
             for chunk_size in (None, 2, 5):
                 got, _ = _run(proc, batch, True, chunk_size)
                 label = f"specs={list(combo)} chunk={chunk_size}"
@@ -227,6 +264,51 @@ class TestFastInputLogprobs(CustomTestCase):
                 logprob.cpu(), expected.expand(4), rtol=1e-5, atol=1e-5
             )
 
+    def test_temperature_scales_input_logprobs_but_not_sampling_logits(self):
+        proc = InputLogprobProcessor()
+        batch = _build_batch([(3, 0)], torch.float32)
+        batch[-1].input_logprob_temperatures = [0.5]
+        result, sampled_logits = _run(proc, batch, False, None)
+
+        pruned_states, sample_indices, input_logprob_indices, _, metadata = batch
+        expected = torch.log_softmax(pruned_states[input_logprob_indices] / 0.5, dim=-1)
+        expected_token_logprobs = expected[
+            torch.arange(expected.shape[0]),
+            metadata.extend_input_logprob_token_ids_gpu,
+        ]
+        torch.testing.assert_close(result.token_logprobs, expected_token_logprobs)
+        torch.testing.assert_close(sampled_logits, pruned_states[sample_indices])
+
+    def test_mixed_request_temperatures_align_with_pruned_rows(self):
+        metadata = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            extend_return_logprob=True,
+            extend_seq_lens_cpu=[4, 5, 6],
+            extend_logprob_start_lens_cpu=[0, 5, 3],
+            input_logprob_temperatures=[0.5, 1.0, 2.0],
+        )
+        processor = LogitsProcessor.__new__(LogitsProcessor)
+        outputs = processor._get_pruned_states(
+            hidden_states=torch.arange(30).view(15, 2),
+            hidden_states_before_norm=None,
+            aux_hidden_states=None,
+            logits_metadata=metadata,
+        )
+        temperatures = outputs[-2]
+        torch.testing.assert_close(
+            temperatures,
+            torch.tensor([0.5, 0.5, 0.5, 0.5, 2.0, 2.0, 2.0]),
+        )
+
+        metadata.input_logprob_temperatures = [1.0, 1.0, 1.0]
+        outputs = processor._get_pruned_states(
+            hidden_states=torch.arange(30).view(15, 2),
+            hidden_states_before_norm=None,
+            aux_hidden_states=None,
+            logits_metadata=metadata,
+        )
+        self.assertIsNone(outputs[-2])
+
     def test_fast_path_emits_fp32_logprobs(self):
         # Chosen dtype policy: the fast path returns fp32 token logprobs
         # regardless of logits dtype (the normalizer is fp32, so fp32 is the
@@ -235,6 +317,7 @@ class TestFastInputLogprobs(CustomTestCase):
         # where the CUDA kernels never execute.
         proc = InputLogprobProcessor()
         batch = _build_batch([(4, 1), (3, 0)], torch.bfloat16)
+        batch[-1].input_logprob_temperatures = [1.0, 1.0]
         got, _ = _run(proc, batch, True, None)
         self.assertEqual(got.token_logprobs.dtype, torch.float32)
         ref, _ = _run(proc, batch, False, None)

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -917,12 +917,14 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             text="Hello",
             return_logprob=True,
             logprob_start_len=10,
+            input_logprob_temperature=0.7,
             top_logprobs_num=5,
             token_ids_logprob=[7, 8, 9],
         )
         req.normalize_batch_and_arguments()
         self.assertEqual(req.return_logprob, True)
         self.assertEqual(req.logprob_start_len, 10)
+        self.assertEqual(req.input_logprob_temperature, 0.7)
         self.assertEqual(req.top_logprobs_num, 5)
         self.assertEqual(req.token_ids_logprob, [7, 8, 9])
 
@@ -931,12 +933,14 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             text=["Hello", "World"],
             return_logprob=True,
             logprob_start_len=10,
+            input_logprob_temperature=0.7,
             top_logprobs_num=5,
             token_ids_logprob=[7, 8, 9],
         )
         req.normalize_batch_and_arguments()
         self.assertEqual(req.return_logprob, [True, True])
         self.assertEqual(req.logprob_start_len, [10, 10])
+        self.assertEqual(req.input_logprob_temperature, [0.7, 0.7])
         self.assertEqual(req.top_logprobs_num, [5, 5])
         self.assertEqual(req.token_ids_logprob, [[7, 8, 9], [7, 8, 9]])
 
@@ -945,6 +949,7 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             text=["Hello", "World"],
             return_logprob=[True, False],
             logprob_start_len=[10, 5],
+            input_logprob_temperature=[0.5, 2.0],
             top_logprobs_num=[5, 3],
             token_ids_logprob=[[7, 8, 9], [4, 5, 6]],
             return_hidden_states=[False, True],
@@ -952,9 +957,26 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         req.normalize_batch_and_arguments()
         self.assertEqual(req.return_logprob, [True, False])
         self.assertEqual(req.logprob_start_len, [10, 5])
+        self.assertEqual(req.input_logprob_temperature, [0.5, 2.0])
         self.assertEqual(req.top_logprobs_num, [5, 3])
         self.assertEqual(req.token_ids_logprob, [[7, 8, 9], [4, 5, 6]])
         self.assertEqual(req.return_hidden_states, [False, True])
+
+    def test_input_logprob_temperature_validation(self):
+        for temperature in (0, -1, float("inf"), float("nan"), True, "0.7"):
+            with self.subTest(temperature=temperature):
+                req = GenerateReqInput(
+                    text="Hello", input_logprob_temperature=temperature
+                )
+                with self.assertRaisesRegex(ValueError, "positive finite"):
+                    req.normalize_batch_and_arguments()
+
+        req = GenerateReqInput(
+            text=["Hello", "World"],
+            input_logprob_temperature=[0.7],
+        )
+        with self.assertRaisesRegex(ValueError, "batch size"):
+            req.normalize_batch_and_arguments()
 
     def test_custom_logit_processor_normalization(self):
         """Test normalization of custom_logit_processor."""
@@ -1019,6 +1041,7 @@ class TestGenerateReqInputNormalization(CustomTestCase):
             rid=["id1", "id2"],
             return_logprob=[True, False],
             logprob_start_len=[10, 5],
+            input_logprob_temperature=[0.5, 2.0],
             top_logprobs_num=[5, 3],
             token_ids_logprob=[[7, 8, 9], [4, 5, 6]],
             stream=True,
@@ -1039,6 +1062,7 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertEqual(item0.rid, "id1")
         self.assertEqual(item0.return_logprob, True)
         self.assertEqual(item0.logprob_start_len, 10)
+        self.assertEqual(item0.input_logprob_temperature, 0.5)
         self.assertEqual(item0.top_logprobs_num, 5)
         self.assertEqual(item0.token_ids_logprob, [7, 8, 9])
         self.assertEqual(item0.stream, True)

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -318,6 +318,24 @@ class TestRidToStateCleanupOnBatchOutput(CustomTestCase):
 
         self.assertIn(rid, tm.rid_to_state)
 
+    def test_batch_output_reports_input_logprob_temperature(self):
+        tm = _make_tokenizer_manager(self)
+        rid = "input_logprob_temperature_rid"
+        state = _make_req_state(rid)
+        state.obj.return_logprob = True
+        state.obj.input_logprob_temperature = 0.7
+        state.obj.top_logprobs_num = 0
+        state.obj.token_ids_logprob = None
+        state.obj.return_text_in_logprobs = False
+        tm.convert_logprob_style = Mock()
+        tm.rid_to_state[rid] = state
+
+        asyncio.run(tm._handle_batch_output(_make_batch_str_output(rid)))
+
+        self.assertEqual(
+            state.out_list[0]["meta_info"]["input_logprob_temperature"], 0.7
+        )
+
 
 class TestInitReqStateDuplicateDetection(CustomTestCase):
     """Test that _init_req_state raises ValueError for duplicate rids."""


### PR DESCRIPTION
## Motivation

SGLang currently computes teacher-forced input log-probabilities from `log_softmax(logits)` regardless of decoding temperature. That is the right default, but callers doing off-policy RL or distillation may need to score rollout tokens under the same temperature-scaled teacher distribution:

`q_T(y | x) = softmax(z(x) / T)_y`

Reusing `sampling_params.temperature` would conflate input scoring with decode sampling. A selected `q_1` log-probability also cannot be converted downstream into `q_T`, because the new normalizer depends on the full vocabulary logits.

This is needed by [THUDM/slime#2325](https://github.com/THUDM/slime/pull/2325).

## Modifications

- Add a first-class `input_logprob_temperature` option to `/generate` and the Engine API. It must be positive and finite and defaults to `1.0`.
- Apply the temperature only while computing input log-probabilities, including reference, fast, chunked-prefill, multi-item scoring, and heterogeneous-batch paths. Next-token sampling logits remain unchanged.
- Echo the applied value in response `meta_info`, allowing clients to detect older servers that silently ignore unknown JSON fields.
- Keep the default core path unchanged when every request uses `T = 1`: no temperature tensor is constructed and no division is performed.

## Accuracy Tests

CPU tests:

- `test/registered/unit/layers/test_logprob_fast_input.py`: 14 passed, 7 skipped (CUDA-only)
- `test/registered/unit/layers/test_logprob_chunk_stitching.py`: 2 passed
- `test/registered/unit/managers/test_io_struct.py`: 50 passed, 2 skipped
- `test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py`: 19 passed
- Direct Pydantic schema validation confirms that positive finite values are accepted and invalid values are rejected.
- `py_compile`, `git diff --check`, and all applicable changed-file pre-commit hooks pass.

The tests cover the explicit `q_T` calculation, preservation of raw next-token logits, mixed per-request temperatures, requests contributing zero input-logprob rows, fast/reference equivalence, and the all-unit fast path.

GPU accuracy tests were not run locally because the development host is macOS/CPU-only.

## Speed Tests and Profiling

Not run locally. For the default `T = 1` case, the logits-processing path performs neither a device transfer nor an elementwise division. A non-unit temperature adds one division over only the rows selected for input-logprob computation.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Document the request field and public API parameters in code.
- [x] Provide available accuracy and speed-impact evidence above; GPU benchmarking remains for CI/reviewer infrastructure.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32762667542](https://github.com/sgl-project/sglang/actions/runs/32762667542)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32762667371](https://github.com/sgl-project/sglang/actions/runs/32762667371)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32762667520](https://github.com/sgl-project/sglang/actions/runs/32762667520)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->