### PR TITLE
[PP] Batch independent chunks for small-chunk disaggregated prefill

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -813,6 +813,17 @@ class SchedulerDisaggregationPrefillMixin:
                         )
                         logprob_pt += num_input_logprobs
 
+                if (
+                    batch.requeue_chunked_reqs is not None
+                    and req in batch.requeue_chunked_reqs
+                ):
+                    assert not self.enable_overlap
+                    assert not req.pending_bootstrap
+                    maybe_cache_unfinished_req(req, self.tree_cache, chunked=True)
+                    self.send_kv_chunk(req, last_chunk=False)
+                    req.pp_batched_chunk_requeued = True
+                    self.waiting_queue.append(req)
+
                 # In non-overlap-mode, KV is sent in process_prefill_chunk
                 # Only send when req's sender is initialized
                 if self.enable_overlap and not req.pending_bootstrap:
@@ -1083,6 +1094,8 @@ class SchedulerDisaggregationPrefillMixin:
                 # In the context pipeline parallelism, after the last chunk, the current microbatch still track outdated chunked_req.
                 # We need to discard it.
                 chunked_req_to_exclude.add(last_batch.chunked_req)
+            if last_batch.requeue_chunked_reqs:
+                chunked_req_to_exclude.update(last_batch.requeue_chunked_reqs)
 
             last_bs = last_batch.batch_size()
             last_batch.filter_batch(chunked_req_to_exclude=list(chunked_req_to_exclude))

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -595,6 +595,9 @@ class Envs:
     # PP: skip output send/recv when the entire batch consists of non-final chunked prefill requests,
     # since process_batch_result_prefill discards next_token_ids for those anyway.
     SGLANG_PP_SKIP_PURE_CHUNKED_OUTPUT_COMM = EnvBool(False)
+    # PP disaggregated prefill: use chunked_prefill_size as the per-request
+    # limit and max_prefill_tokens as the aggregate batch budget.
+    SGLANG_PP_BATCH_INDEPENDENT_CHUNKS = EnvBool(False)
     SGLANG_NCCL_ALL_GATHER_IN_OVERLAP_SCHEDULER_SYNC_BATCH = EnvBool(False)
 
     # ===================================================================

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1036,6 +1036,9 @@ class Req(ReqDllmMixin):
         # it is chunked, and decrement whenever chunked request is
         # processed.
         self.inflight_middle_chunks = 0
+        # Batched PP middle chunks return to the waiting queue with their
+        # committed ChunkCache prefix and request-pool slot still intact.
+        self.pp_batched_chunk_requeued = False
 
         # For retraction
         self.is_retracted = False
@@ -1701,6 +1704,7 @@ class Req(ReqDllmMixin):
         self.temp_input_token_ids_logprobs_val = None
         self.temp_input_token_ids_logprobs_idx = None
         self.inflight_middle_chunks = 0
+        self.pp_batched_chunk_requeued = False
         self.mamba_pool_idx = None
         self.mamba_ping_pong_track_buffer = None
         self.mamba_next_track_idx = None
@@ -2069,6 +2073,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     chunked_req: Optional[Req] = None
     chunked_req_next_prompt_token: Optional[int] = None
     contains_last_prefill_chunk: bool = True
+    # Middle chunks to cache and requeue after this batch result is resolved.
+    requeue_chunked_reqs: Optional[List[Req]] = None
 
     # For DP attention
     inner_idle_batch: Optional[ScheduleBatch] = None

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -1083,6 +1083,7 @@ class PrefillAdder:
         cand_extend_input_len = len(req.full_untruncated_fill_ids) - len(
             req.prefix_indices
         )
+        chunk_tokens_limit = self._chunk_tokens_limit()
         paged_input = self.ceil_paged_tokens(cand_extend_input_len)
         # Shared Mamba pool: fold the new mamba state's shared-gap cost into the
         # budget gate so admission can't over-commit (0 for baseline / non-Mamba).
@@ -1169,8 +1170,8 @@ class PrefillAdder:
 
             self._add_dllm_req(req, 0)
         elif (
-            self.rem_chunk_tokens is None  # chunked prefill is disabled
-            or cand_extend_input_len <= self.rem_chunk_tokens  # it is the last chunk
+            chunk_tokens_limit is None  # chunked prefill is disabled
+            or cand_extend_input_len <= chunk_tokens_limit  # it is the last chunk
         ):
             if (
                 tile_stop := self._check_prefill_tile_budget(cand_extend_input_len)
@@ -1190,21 +1191,25 @@ class PrefillAdder:
                 mamba_gap_reserve=self._mamba_gap_budget_for_req(req),
             )
         else:
-            if self.rem_chunk_tokens <= 0:
+            if chunk_tokens_limit <= 0:
                 return AddReqResult.OTHER
 
             # Chunked prefill
-            trunc_len = self.rem_chunk_tokens
+            trunc_len = chunk_tokens_limit
 
             if (tile_stop := self._check_prefill_tile_budget(trunc_len)) is not None:
                 return tile_stop
 
-            assert len(req.prefix_indices) == 0
+            if self.per_request_chunk_size is None:
+                assert len(req.prefix_indices) == 0
             req.set_extend_range(
                 len(req.prefix_indices), len(req.prefix_indices) + trunc_len
             )
             self.can_run_list.append(req)
-            self.new_chunked_req = req
+            if self.per_request_chunk_size is None:
+                self.new_chunked_req = req
+            else:
+                self.new_chunked_reqs.append(req)
             self._update_prefill_budget(
                 0,
                 trunc_len,

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -527,6 +527,7 @@ class PrefillAdder:
         dllm_config: Optional[DllmConfig] = None,
         waiting_queue_len: int = 0,
         prefill_tile_block_m: int = 64,
+        per_request_chunk_size: Optional[int] = None,
     ):
         self.page_size = page_size
         self.prefill_tile_block_m = prefill_tile_block_m
@@ -536,6 +537,7 @@ class PrefillAdder:
         self.new_token_ratio = new_token_ratio
         self.rem_input_tokens = rem_input_tokens - num_mixed_decode_tokens
         self.rem_chunk_tokens = rem_chunk_tokens
+        self.per_request_chunk_size = per_request_chunk_size
         self.dllm_config = dllm_config
 
         if self.dllm_config is not None:
@@ -550,6 +552,7 @@ class PrefillAdder:
         self.can_run_list = []
         self.preempt_list = []
         self.new_chunked_req = None
+        self.new_chunked_reqs = []
         self.log_hit_tokens = 0
         self.reprocessed_log_hit_tokens = 0
         self.log_device_hit_tokens = 0
@@ -621,6 +624,13 @@ class PrefillAdder:
         # Snapshot of scheduler waiting_queue length at the start of this
         # prefill pass. Used by PrefillDelayer's queue-based trigger.
         self.waiting_queue_len = waiting_queue_len
+
+    def _chunk_tokens_limit(self) -> Optional[int]:
+        if self.rem_chunk_tokens is None:
+            return None
+        if self.per_request_chunk_size is None:
+            return self.rem_chunk_tokens
+        return min(self.rem_chunk_tokens, self.per_request_chunk_size)
 
     def _admitted_extend_lens(self) -> List[int]:
         return [int(getattr(req, "extend_input_len", 0)) for req in self.can_run_list]
@@ -1243,7 +1253,7 @@ class PrefillAdder:
         if total_tokens >= self.rem_total_tokens:
             return AddReqResult.NO_TOKEN
 
-        chunk_tokens_limit = self.rem_chunk_tokens
+        chunk_tokens_limit = self._chunk_tokens_limit()
         if self.is_hybrid_swa:
             # host-hit prefix is loaded back, not re-prefilled, so the SWA peak is
             # driven only by the freshly-prefilled tail (the loaded window is
@@ -1263,9 +1273,9 @@ class PrefillAdder:
                 swa_cap = self._swa_chunk_cap(
                     self._swa_new_tokens(req), req.swa_host_hit_length
                 )
-                if self.rem_chunk_tokens is None or swa_cap <= 0:
+                if chunk_tokens_limit is None or swa_cap <= 0:
                     return AddReqResult.NO_TOKEN
-                chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
+                chunk_tokens_limit = min(chunk_tokens_limit, swa_cap)
 
         if (
             self.rem_chunk_tokens is None
@@ -1299,9 +1309,9 @@ class PrefillAdder:
                     swa_cap = self._swa_chunk_cap(
                         self._swa_new_tokens(req), req.swa_host_hit_length
                     )
-                    if self.rem_chunk_tokens is None or swa_cap <= 0:
+                    if chunk_tokens_limit is None or swa_cap <= 0:
                         return AddReqResult.NO_TOKEN
-                    chunk_tokens_limit = min(self.rem_chunk_tokens, swa_cap)
+                    chunk_tokens_limit = min(chunk_tokens_limit, swa_cap)
 
             # Negotiate only after every KV-budget gate (a NO_TOKEN rank must
             # report not-prefillable via finalize()) and before init_load_back
@@ -1419,7 +1429,10 @@ class PrefillAdder:
                 )
 
                 self.can_run_list.append(req)
-                self.new_chunked_req = req
+                if self.per_request_chunk_size is None:
+                    self.new_chunked_req = req
+                else:
+                    self.new_chunked_reqs.append(req)
 
                 self._req_inc_lock_ref(req)
                 self._update_prefill_budget(

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3291,6 +3291,13 @@ class Scheduler(
 
         return NextBatchPlan(batch_to_run=ret, running_batch=running_batch)
 
+    def _init_waiting_req_next_round(self, req: Req) -> None:
+        """Initialize a waiting request without discarding batched-chunk progress."""
+        if self.pp_batch_independent_chunks and req.pp_batched_chunk_requeued:
+            req.init_next_round_input()
+        else:
+            req.init_next_round_input(self.tree_cache)
+
     def _get_new_batch_prefill_raw(
         self,
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor],
@@ -3439,7 +3446,10 @@ class Scheduler(
                 if loaded_tokens > 0:
                     req.storage_hit_length = loaded_tokens
 
-            req.init_next_round_input(self.tree_cache)
+            # ChunkCache has no searchable prefix tree. Re-matching a requeued
+            # middle chunk would replace its committed prefix with an empty one
+            # and restart the request from token zero.
+            self._init_waiting_req_next_round(req)
             if (
                 self.enable_hicache_storage
                 and self.server_args.hicache_host_memory_mode == "buffer_only"
@@ -3513,7 +3523,12 @@ class Scheduler(
             assert self.chunked_req is None
             self.chunked_req = adder.new_chunked_req
 
-        if self.chunked_req is not None:
+        batched_chunked_reqs = adder.new_chunked_reqs
+        if batched_chunked_reqs:
+            assert self.chunked_req is None
+            for req in batched_chunked_reqs:
+                req.inflight_middle_chunks += 1
+        elif self.chunked_req is not None:
             self.chunked_req.inflight_middle_chunks += 1
 
         set_time_batch(can_run_list, "set_forward_entry_time")
@@ -3530,9 +3545,16 @@ class Scheduler(
             chunked_req=self.chunked_req,
         )
 
-        new_batch.contains_last_prefill_chunk = (
-            self.chunked_req is None or len(can_run_list) != 1
-        )
+        new_batch.requeue_chunked_reqs = batched_chunked_reqs or None
+        if batched_chunked_reqs:
+            chunked_set = set(batched_chunked_reqs)
+            new_batch.contains_last_prefill_chunk = any(
+                req not in chunked_set for req in can_run_list
+            )
+        else:
+            new_batch.contains_last_prefill_chunk = (
+                self.chunked_req is None or len(can_run_list) != 1
+            )
 
         if self.enable_hierarchical_cache:
             # todo (zhiqiang): disable cuda graph execution if hicache loading triggered

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3306,6 +3306,32 @@ class Scheduler(
             and req.req_pool_idx is not None
         )
 
+    def _pp_order_waiting_queue_for_req_slots(
+        self, waiting_queue: List[Req], num_allocatable_reqs: int
+    ) -> List[Req]:
+        """Keep slotless requests from blocking slot-owning PP continuations."""
+        if not self.pp_batch_independent_chunks:
+            return waiting_queue
+
+        reusable_reqs = []
+        num_slotless_reqs = 0
+        num_slotless_before_last_reusable = 0
+        for req in waiting_queue:
+            if self._pp_batched_chunk_reuses_req_slot(req):
+                reusable_reqs.append(req)
+                num_slotless_before_last_reusable = num_slotless_reqs
+            elif req.req_pool_idx is None:
+                num_slotless_reqs += 1
+
+        if (
+            not reusable_reqs
+            or num_slotless_before_last_reusable <= num_allocatable_reqs
+        ):
+            return waiting_queue
+
+        reusable_set = set(reusable_reqs)
+        return reusable_reqs + [req for req in waiting_queue if req not in reusable_set]
+
     def _get_new_batch_prefill_raw(
         self,
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor],
@@ -3429,7 +3455,11 @@ class Scheduler(
         if mamba_allocator is not None:
             mamba_allocator.alloc_group_begin(len(self.waiting_queue))
         # Get requests from the waiting queue to a new prefill batch
-        for req in self.waiting_queue:
+        waiting_queue_to_schedule = self._pp_order_waiting_queue_for_req_slots(
+            self.waiting_queue,
+            num_allocatable_reqs=self.get_num_allocatable_reqs(running_bs),
+        )
+        for req in waiting_queue_to_schedule:
             if self.enable_lora and not self._can_schedule_lora_req(req, running_loras):
                 continue
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3298,6 +3298,14 @@ class Scheduler(
         else:
             req.init_next_round_input(self.tree_cache)
 
+    def _pp_batched_chunk_reuses_req_slot(self, req: Req) -> bool:
+        """Return whether a waiting PP continuation already owns its slot."""
+        return (
+            self.pp_batch_independent_chunks
+            and req.pp_batched_chunk_requeued
+            and req.req_pool_idx is not None
+        )
+
     def _get_new_batch_prefill_raw(
         self,
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor],
@@ -3322,10 +3330,14 @@ class Scheduler(
             return None, running_batch
 
         running_bs = len(running_batch.reqs)
+        has_reusable_pp_chunk = any(
+            self._pp_batched_chunk_reuses_req_slot(req) for req in self.waiting_queue
+        )
         # Skipped during a chunked prefill: that pass must proceed regardless.
         if (
             self.min_free_slots_delayer is not None
             and self.chunked_req is None
+            and not has_reusable_pp_chunk
             and self.min_free_slots_delayer.should_delay(
                 running_bs=running_bs,
                 num_allocatable_reqs=self.get_num_allocatable_reqs(running_bs),
@@ -3342,6 +3354,7 @@ class Scheduler(
             self.get_num_allocatable_reqs(running_bs) <= 0
             and self.chunked_req is None
             and not self.enable_priority_preemption
+            and not has_reusable_pp_chunk
         ):
             running_batch.batch_is_full = True
             return None, running_batch
@@ -3421,12 +3434,19 @@ class Scheduler(
                 continue
 
             running_bs = len(running_batch.reqs)
-            if len(adder.can_run_list) >= self.get_num_allocatable_reqs(running_bs):
+            reuses_req_slot = self._pp_batched_chunk_reuses_req_slot(req)
+            new_req_count = sum(r.req_pool_idx is None for r in adder.can_run_list)
+            if not reuses_req_slot and new_req_count >= self.get_num_allocatable_reqs(
+                running_bs
+            ):
                 running_batch.batch_is_full = True
-            if self.disaggregation_mode == DisaggregationMode.PREFILL:
+            if (
+                not reuses_req_slot
+                and self.disaggregation_mode == DisaggregationMode.PREFILL
+            ):
                 # In prefill mode, prealloc queue and transfer queue can also take memory,
                 # so we need to check if the available size for the actual available size.
-                if len(adder.can_run_list) >= self.req_to_token_pool.available_size():
+                if new_req_count >= self.req_to_token_pool.available_size():
                     running_batch.batch_is_full = True
 
             if running_batch.batch_is_full:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1198,6 +1198,31 @@ class Scheduler(
         self.is_mixed_chunk = (
             self.chunked_prefill_size is not None and get_schedule().enable_mixed_chunk
         )
+        self.pp_batch_independent_chunks = envs.SGLANG_PP_BATCH_INDEPENDENT_CHUNKS.get()
+        if self.pp_batch_independent_chunks:
+            if self.ps.pp_size <= 1 or get_disagg().disaggregation_mode != "prefill":
+                raise RuntimeError(
+                    "SGLANG_PP_BATCH_INDEPENDENT_CHUNKS requires PP "
+                    "disaggregated prefill"
+                )
+            if (
+                self.chunked_prefill_size is None
+                or self.max_prefill_tokens <= self.chunked_prefill_size
+            ):
+                raise RuntimeError(
+                    "SGLANG_PP_BATCH_INDEPENDENT_CHUNKS requires "
+                    "max_prefill_tokens > chunked_prefill_size"
+                )
+            if not self.server_args.disable_overlap_schedule:
+                raise RuntimeError(
+                    "SGLANG_PP_BATCH_INDEPENDENT_CHUNKS requires "
+                    "--disable-overlap-schedule"
+                )
+            if not self.tree_cache.is_chunk_cache():
+                raise RuntimeError(
+                    "SGLANG_PP_BATCH_INDEPENDENT_CHUNKS requires "
+                    "--disable-radix-cache"
+                )
 
         # Init the dynamic chunking predictor for PP
         self.enable_dynamic_chunking = (
@@ -3325,6 +3350,10 @@ class Scheduler(
 
         # Determine chunked_prefill_size for this batch
         chunked_prefill_size = self.chunked_prefill_size
+        per_request_chunk_size = None
+        if self.pp_batch_independent_chunks:
+            per_request_chunk_size = self.chunked_prefill_size
+            chunked_prefill_size = self.max_prefill_tokens
         if self.chunked_req is not None and self.enable_dynamic_chunking:
             history_len = len(self.chunked_req.prefix_indices)
             dynamic_size = self.predict_next_chunk_size(history_len)
@@ -3356,6 +3385,7 @@ class Scheduler(
             dllm_config=self.dllm_config,
             waiting_queue_len=len(self.waiting_queue),
             prefill_tile_block_m=prefill_tile_block_m,
+            per_request_chunk_size=per_request_chunk_size,
         )
 
         if self.chunked_req is not None:

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -464,6 +464,47 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(adder2.rem_chunk_tokens, 0)  # 3 - 3 = 0
         self.assertEqual(result3, AddReqResult.OTHER)
 
+    def test_per_request_chunk_cap_batches_independent_requests(self):
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            self.create_running_batch(),
+            rem_input_tokens=8192,
+            rem_chunk_tokens=4096,
+            per_request_chunk_size=2048,
+        )
+
+        reqs = []
+        for rid in ("req1", "req2"):
+            req = self.create_mock_req(rid, priority=0, max_new_tokens=1)
+            req.full_untruncated_fill_ids = list(range(8192))
+            req.last_node = MagicMock()
+            req.sampling_params.ignore_eos = False
+            req.set_extend_range = MagicMock(
+                side_effect=lambda start, end, req=req: setattr(
+                    req, "extend_range", Range(start, end)
+                )
+            )
+            reqs.append(req)
+
+        self.assertEqual(
+            adder.add_one_req(
+                reqs[0], has_chunked_req=False, truncation_align_size=None
+            ),
+            AddReqResult.CONTINUE,
+        )
+        self.assertEqual(
+            adder.add_one_req(
+                reqs[1], has_chunked_req=False, truncation_align_size=None
+            ),
+            AddReqResult.OTHER,
+        )
+
+        self.assertEqual(adder.can_run_list, reqs)
+        self.assertEqual(adder.new_chunked_reqs, reqs)
+        self.assertIsNone(adder.new_chunked_req)
+        self.assertEqual(adder.rem_chunk_tokens, 0)
+        self.assertEqual([req.extend_range.length for req in reqs], [2048, 2048])
+
     def _build_hybrid_swa_chunked_req(
         self,
         *,

--- a/test/registered/unit/managers/test_prefill_adder.py
+++ b/test/registered/unit/managers/test_prefill_adder.py
@@ -505,6 +505,52 @@ class TestPrefillAdder(CustomTestCase):
         self.assertEqual(adder.rem_chunk_tokens, 0)
         self.assertEqual([req.extend_range.length for req in reqs], [2048, 2048])
 
+    def test_per_request_chunk_cap_batches_ignore_eos_requests(self):
+        self.mock_tree_cache.disable = True
+        self.mock_token_allocator.available_size.return_value = 100_000
+        adder = self.create_adder(
+            self.create_running_batch(),
+            rem_input_tokens=8192,
+            rem_chunk_tokens=4096,
+            per_request_chunk_size=2048,
+        )
+
+        reqs = []
+        for rid in ("req1", "req2"):
+            req = self.create_mock_req(rid, priority=0, max_new_tokens=1)
+            req.origin_input_ids = list(range(8192))
+            req.prefix_indices = list(range(2048))
+            req.full_untruncated_fill_ids = list(range(8192))
+            req.sampling_params.ignore_eos = True
+            req.set_extend_range = MagicMock(
+                side_effect=lambda start, end, req=req: setattr(
+                    req, "extend_range", Range(start, end)
+                )
+            )
+            reqs.append(req)
+
+        self.assertEqual(
+            adder.add_one_req(
+                reqs[0], has_chunked_req=False, truncation_align_size=None
+            ),
+            AddReqResult.CONTINUE,
+        )
+        self.assertEqual(
+            adder.add_one_req(
+                reqs[1], has_chunked_req=False, truncation_align_size=None
+            ),
+            AddReqResult.OTHER,
+        )
+
+        self.assertEqual(adder.can_run_list, reqs)
+        self.assertEqual(adder.new_chunked_reqs, reqs)
+        self.assertIsNone(adder.new_chunked_req)
+        self.assertEqual(adder.rem_chunk_tokens, 0)
+        self.assertEqual(
+            [(req.extend_range.start, req.extend_range.end) for req in reqs],
+            [(2048, 4096), (2048, 4096)],
+        )
+
     def _build_hybrid_swa_chunked_req(
         self,
         *,

--- a/test/registered/unit/managers/test_scheduler_decision_batch_params.py
+++ b/test/registered/unit/managers/test_scheduler_decision_batch_params.py
@@ -82,6 +82,17 @@ class TestDecisionMethodsHaveNoHiddenBatchChannel(unittest.TestCase):
 
         req.init_next_round_input.assert_called_once_with()
 
+    def test_requeued_batched_chunk_reuses_request_pool_slot(self):
+        scheduler = SimpleNamespace(pp_batch_independent_chunks=True)
+        req = SimpleNamespace(
+            pp_batched_chunk_requeued=True,
+            req_pool_idx=7,
+        )
+
+        self.assertTrue(Scheduler._pp_batched_chunk_reuses_req_slot(scheduler, req))
+        req.req_pool_idx = None
+        self.assertFalse(Scheduler._pp_batched_chunk_reuses_req_slot(scheduler, req))
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/managers/test_scheduler_decision_batch_params.py
+++ b/test/registered/unit/managers/test_scheduler_decision_batch_params.py
@@ -1,5 +1,7 @@
 import inspect
 import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import maybe_stub_sgl_kernel
@@ -46,6 +48,39 @@ class TestDecisionMethodsHaveNoHiddenBatchChannel(unittest.TestCase):
                         "explicitly and return it via NextBatchPlan instead."
                     ),
                 )
+
+    def test_batched_middle_chunks_leave_previous_running_batch(self):
+        chunked_reqs = [
+            MagicMock(name="chunked_req_0"),
+            MagicMock(name="chunked_req_1"),
+        ]
+        last_batch = MagicMock()
+        last_batch.forward_mode.is_extend.return_value = True
+        last_batch.chunked_req = None
+        last_batch.requeue_chunked_reqs = chunked_reqs
+        last_batch.batch_size.side_effect = [2, 0]
+        running_batch = SimpleNamespace(batch_is_full=True)
+
+        SchedulerDisaggregationPrefillMixin.process_prefill_chunk(
+            SimpleNamespace(chunked_req=None),
+            last_batch=last_batch,
+            running_batch=running_batch,
+        )
+
+        excluded = last_batch.filter_batch.call_args.kwargs["chunked_req_to_exclude"]
+        self.assertEqual(set(excluded), set(chunked_reqs))
+        self.assertFalse(running_batch.batch_is_full)
+
+    def test_requeued_batched_chunk_keeps_committed_chunk_cache_prefix(self):
+        req = MagicMock(pp_batched_chunk_requeued=True)
+        scheduler = SimpleNamespace(
+            pp_batch_independent_chunks=True,
+            tree_cache=MagicMock(),
+        )
+
+        Scheduler._init_waiting_req_next_round(scheduler, req)
+
+        req.init_next_round_input.assert_called_once_with()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/managers/test_scheduler_decision_batch_params.py
+++ b/test/registered/unit/managers/test_scheduler_decision_batch_params.py
@@ -93,6 +93,44 @@ class TestDecisionMethodsHaveNoHiddenBatchChannel(unittest.TestCase):
         req.req_pool_idx = None
         self.assertFalse(Scheduler._pp_batched_chunk_reuses_req_slot(scheduler, req))
 
+    def test_requeued_chunks_bypass_slotless_requests_before_pool_saturation(self):
+        new_reqs = [
+            MagicMock(
+                rid=f"new-{i}",
+                pp_batched_chunk_requeued=False,
+                req_pool_idx=None,
+            )
+            for i in range(16)
+        ]
+        reusable_0 = MagicMock(
+            rid="reusable-0", pp_batched_chunk_requeued=True, req_pool_idx=3
+        )
+        reusable_1 = MagicMock(
+            rid="reusable-1", pp_batched_chunk_requeued=True, req_pool_idx=9
+        )
+        waiting_queue = new_reqs + [reusable_0, reusable_1]
+        scheduler = SimpleNamespace(pp_batch_independent_chunks=True)
+        scheduler._pp_batched_chunk_reuses_req_slot = (
+            lambda req: Scheduler._pp_batched_chunk_reuses_req_slot(scheduler, req)
+        )
+
+        for num_allocatable_reqs in (0, 1, 15):
+            with self.subTest(num_allocatable_reqs=num_allocatable_reqs):
+                ordered = Scheduler._pp_order_waiting_queue_for_req_slots(
+                    scheduler,
+                    waiting_queue,
+                    num_allocatable_reqs=num_allocatable_reqs,
+                )
+                self.assertEqual(ordered, [reusable_0, reusable_1] + new_reqs)
+
+        self.assertEqual(waiting_queue, new_reqs + [reusable_0, reusable_1])
+        self.assertIs(
+            Scheduler._pp_order_waiting_queue_for_req_slots(
+                scheduler, waiting_queue, num_allocatable_reqs=16
+            ),
+            waiting_queue,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

> **Scope correction:** This draft improves the case where each request is capped at a 2K chunk but the aggregate model-forward budget is increased to approximately 32K. It does **not** improve a model forward whose aggregate batch is fixed at 2K, so it is not a solution to the fixed-small-batch PP bubble problem. The corrected fixed-2K launch/control-overhead work is proposed separately in [#36248](https://github.com/sgl-project/sglang/pull/36248); the measurements below should be read only as an independent-chunk aggregation experiment.

In PP disaggregated prefill, `chunked_prefill_size` currently serves two different purposes: the per-request chunk boundary and the aggregate token budget of the entire forward batch. With `chunked_prefill_size=2048`, this limits every PP prefill forward to approximately 2K tokens even when many independent requests are waiting, so increasing client concurrency cannot recover GPU utilization and pipeline efficiency.

This PR separates those two limits for an opt-in PP disaggregated-prefill path: each request remains capped by `chunked_prefill_size`, while the batch can aggregate independent chunks up to `max_prefill_tokens`. For the evaluated 2K configuration, one forward can therefore combine up to approximately 16 independent chunks instead of launching one approximately 2K-token forward at a time.

## Modifications

This PR is organized as five dependency commits:

1. Add a per-request chunk limit to `PrefillAdder` and use `max_prefill_tokens` as the aggregate budget, allowing multiple independent middle chunks in one PP prefill batch.
2. Track, cache, transfer, and requeue all batched middle chunks without losing their committed ChunkCache progress.
3. Apply the same per-request chunk limit to the `ignore_eos` admission path so it cannot consume the aggregate budget as one request.
4. Let requeued middle chunks reuse the request-pool slots they already own when the pool is saturated.
5. Prioritize those slot-owning continuations whenever slotless requests would exhaust the remaining request slots before all continuations are visited, preventing both full-pool and partial-capacity head-of-line blocking.

The first item is the throughput mechanism. Items 2-5 are correctness and liveness requirements introduced by batching multiple independent middle chunks; they are not unrelated scheduler fixes. The new path is guarded by `SGLANG_PP_BATCH_INDEPENDENT_CHUNKS` and currently requires PP disaggregated prefill, `max_prefill_tokens > chunked_prefill_size`, overlap scheduling disabled, and ChunkCache (`--disable-radix-cache`). The default path is unchanged.

The patch intentionally excludes one-page tail merging, pure-middle-chunk PP output skipping, and 2K prefill BCG because their controlled peak contributions were small, inconsistent, or negative.

## Accuracy Tests

Matched GSM8K A/B used the same Qwen3.5 NVFP4 model, 4-GPU TP1 PP4 prefill, 4-GPU TP4 decode, and 2K per-request chunks. The protocol was 200 questions, five-shot chat, 128 threads, `temperature=0.6`, `top_p=0.95`, and `top_k=20`.

| Arm | Independent chunks | Aggregate budget | GSM8K score | Correct |
|---|---:|---:|---:|---:|
| Before | off | 2,048 | 0.980 | 196/200 |
| After | on | 33,792 | 0.995 | 199/200 |

Both runs completed 200/200 requests without errors, and their captured request payloads were byte-identical. Since the protocol uses stochastic sampling without a per-request seed, this is an accuracy non-regression result rather than an accuracy-improvement claim.

Scheduler correctness tests: **6/6 passed**. `git diff --check`, seven-file `py_compile`, and lint also passed.

## Speed Tests and Profiling

### Setup

| Field | Value |
|---|---|
| Model | `nvidia/Qwen3.5-397B-A17B-NVFP4-V2` |
| Precision | NVFP4 weights, FP8 KV cache |
| Prefill topology | 4 x GB300, TP1 PP4 |
| Decode topology | 4 x GB300, TP4 PP1 |
| Serving | Dynamo disaggregated prefill/decode with Mooncake transfer |
| Workload | random data, ISL=8192, OSL=1, request rate=inf |
| Concurrency | 16, 32, 64, 128, 256 |
| Requests per point | 10 x concurrency |
| Page size | 64 |
| Prefill settings | overlap disabled, radix cache disabled, dynamic chunking disabled, CUDA graph disabled, max running requests=128 |
| Before 2K | `chunked_prefill_size=2048`, aggregate budget=2048 |
| After 2K | `chunked_prefill_size=2048`, `max_prefill_tokens=33792`, aggregate FlashInfer dispatch budget=33792 |
| 32K reference | `chunked_prefill_size=max_prefill_tokens=32768` |
| Metric | aggregate input tokens/s |

The controlled five-point performance run used the final no-tail/no-output-skip ablation source with runtime semantics equivalent to this PR. After diagnosing the C256 result, a same-configuration C128/C256 follow-up changed only the partial-capacity queue-ordering rule and source identity. The five commits were then cleaned and transplanted onto current upstream `main`; the final main-based branch reran the targeted correctness and formatting tests but did not repeat the GB300 sweep. Every benchmark point completed all requests with exact 8192/1 lengths and zero non-empty errors.

### Baseline chunk-size sweep

| Chunk size | C16 | C32 | C64 | C128 | C256 | Peak concurrency | Peak input tok/s |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 2K | **30,507** | 30,318 | 30,093 | 29,873 | 29,690 | **C16** | **30,507** |
| 4K | 58,392 | **58,652** | 58,442 | 57,617 | 57,027 | **C32** | **58,652** |
| 8K | 113,512 | **114,642** | 114,614 | 113,200 | 113,069 | **C32** | **114,642** |
| 16K | 116,059 | 166,216 | 167,231 | **168,354** | 167,057 | **C128** | **168,354** |
| 32K | 88,803 | 139,336 | 176,180 | **177,586** | 177,273 | **C128** | **177,586** |

The original 2K peak reached only 17.18% of the 32K peak. Raising client concurrency from 16 to 256 reduced 2K throughput by 2.68%, confirming that the aggregate forward shape, rather than request supply, was the limiting factor.

### 2K before and after

| Concurrency | Original 2K | Batched 2K | Matched-concurrency speedup | 32K reference | Batched 2K / 32K |
|---:|---:|---:|---:|---:|---:|
| 16 | 30,507 | 60,417 | 1.98x | 88,803 | 68.04% |
| 32 | 30,318 | 84,924 | 2.80x | 139,336 | 60.95% |
| 64 | 30,093 | 135,633 | 4.51x | 176,180 | 76.99% |
| 128 | 29,873 | 170,652 | 5.71x | **177,586** | 96.10% |
| 256 | 29,690 | **171,489** | **5.78x** | 177,273 | **96.74%** |

Peak-to-peak, the final core path improves 2K throughput from 30,507 tok/s at C16 to 171,489 tok/s at C256: **5.621x / +462.12%**. It reaches **96.74%** of the matched-concurrency 32K reference while preserving a 2K per-request chunk boundary. C128 also remains non-regressed at 170,652 tok/s, and C256 is 0.49% above C128 rather than falling 20.53% below it.

The C256 follow-up directly isolates the partial-capacity queue-ordering change:

| C256 metric | Before partial-capacity fix | After | Change |
|---|---:|---:|---:|
| Input throughput | 133,843 tok/s | **171,489 tok/s** | **+28.13%** |
| Benchmark duration | 156.69 s | **122.29 s** | **-21.95%** |
| Mean TTFT | 15,196.7 ms | **11,718.7 ms** | **-22.89%** |
| P99 TTFT | 19,355.3 ms | **13,827.6 ms** | **-28.56%** |
| PP0 full 33,792-token batches | 472 / 897 (52.62%) | **614 / 640 (95.94%)** | **+43.32 pp** |
| Mean PP0 new tokens per batch | 23,445.5 | **32,860.6** | **+40.16%** |

Both C256 runs completed 2560/2560 requests with exact 8192/1 lengths and zero non-empty errors. Before the fix, a large waiting queue still produced repeated 2K multiples because a few newly available request slots were consumed by slotless requests before the scan reached slot-owning continuations. After the fix, the full-batch ratio rises to 95.94%, which explains the throughput recovery without changing the 2K per-request cap or any kernel.

An earlier batching-only prototype already reached 52,246 / 92,368 / 143,483 tok/s at C16/C32/C64, or 1.71x / 3.05x / 4.77x over the original 2K baseline, before request-slot saturation stopped C128. This isolates independent-chunk aggregation as the primary throughput mechanism; the slot reuse and queue-ordering commits make the new mechanism complete at C128/C256 rather than accelerating an individual GPU forward.

### Excluded micro-optimizations

These increments were measured in the controlled sweep before the final partial-capacity queue follow-up and are not combined with the new C256 result.

| Incremental change | C16 | C32 | C64 | C128 | C256 | Peak effect |
|---|---:|---:|---:|---:|---:|---:|
| One-page tail merge over core | +8.45% | -4.29% | -2.84% | +0.43% | +6.10% | +0.43% |
| Pure-middle output skip over tail | +3.58% | +8.10% | +2.33% | +0.72% | -2.01% | +0.72% |
| 2K prefill BCG | approximately -4% | approximately -4% | approximately -4% | not continued | not continued | negative |

Tail merging plus output skipping increased peak throughput from 168,421 to 170,363 tok/s, only +1.15% in one run, while showing inconsistent effects across concurrency. They are intentionally left out of this PR so the upstream patch contains only the dominant batching mechanism and its required correctness/liveness support.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
