### PR TITLE
fix(platform_stubs): import importlib submodules explicitly

### DIFF
--- a/python/sglang/_platform_stubs.py
+++ b/python/sglang/_platform_stubs.py
@@ -10,7 +10,8 @@ just work. Triton is also stubbed because it is unavailable on macOS.
 from __future__ import annotations
 
 import functools
-import importlib
+import importlib.machinery
+import importlib.util
 import platform
 import sys
 import types


### PR DESCRIPTION
## Motivation

`python/sglang/_platform_stubs.py` does a bare `import importlib` but then
uses `importlib.util.find_spec()` in `install_platform_stubs()` and
`importlib.machinery.ModuleSpec()` in `_MockModule.__init__`.

`import importlib` does not bind those submodules. They only resolve if
something else in the process has already imported them, which used to be
the case incidentally during interpreter start-up. On Python 3.14 that is no
longer true, so on a machine where the stub path runs (macOS/MPS, or any
build without triton installed) `import sglang` fails with:

```
  File ".../sglang/_platform_stubs.py", line 391, in install_platform_stubs
    if "triton" not in sys.modules and importlib.util.find_spec("triton") is None:
                                       ^^^^^^^^^^^^^^
AttributeError: module 'importlib' has no attribute 'util'
```

## Modifications

Import the two submodules explicitly instead of the package.

## Checklist

- [x] Minimal change, no behaviour change on Python versions where the
      submodules happened to already be loaded.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32765762155](https://github.com/sgl-project/sglang/actions/runs/32765762155)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32765761708](https://github.com/sgl-project/sglang/actions/runs/32765761708)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32765762175](https://github.com/sgl-project/sglang/actions/runs/32765762175)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->