### PR TITLE
Fix two logging calls that raise TypeError instead of logging

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,7 +35,7 @@ repos:
     hooks:
       - id: ruff
         args:
-          - --select=F401,F821,UP037
+          - --select=F401,F821,PLE1205,PLE1206,UP037
           - --fix
         files: ^(benchmark/|docs/|examples/|python/sglang/|sgl-model-gateway/py_*|test/)
         exclude: |

--- a/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/quick_all_reduce.py
@@ -176,10 +176,10 @@ class QuickAllReduce:
         regime_str = os.environ.get("ROCM_QUICK_REDUCE_QUANTIZATION", "NONE")
         if regime_str not in QuickReduceRegime.__members__:
             logger.warning(
-                "Custom quick allreduce:",
+                "Custom quick allreduce: "
                 f"Invalid quantization level: {regime_str}. "
                 "Supported levels: "
-                f"{list(QuickReduceRegime.__members__.keys())}",
+                f"{list(QuickReduceRegime.__members__.keys())}"
             )
             return
 

--- a/python/sglang/srt/hardware_backend/npu/utils.py
+++ b/python/sglang/srt/hardware_backend/npu/utils.py
@@ -30,7 +30,7 @@ def _call_once(fn: Callable):
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
         if getattr(fn, "_has_been_called", False):
-            logger.debug("Function {} has already been called.", fn.__name__)
+            logger.debug("Function %s has already been called.", fn.__name__)
             return
 
         fn._has_been_called = True


### PR DESCRIPTION
## Motivation

Two `logger` calls pass extra arguments to a format string that has no corresponding placeholder. Python's `logging` builds the final record with `msg % args`, so both raise:

```
TypeError: not all arguments converted during string formatting
```

This does **not** crash the process — `Handler.emit()` catches the exception and forwards it to `Handler.handleError()`. The practical effect is worse than a crash in one way: the intended message is silently dropped and replaced with a `--- Logging error ---` traceback, so the log line that was written to help the user diagnose something is the one line they never get to read.

### Why the first one matters in practice

`quick_all_reduce.py` is the more interesting of the two. The broken call is the warning emitted when a user sets an invalid `ROCM_QUICK_REDUCE_QUANTIZATION`:

```python
regime_str = os.environ.get("ROCM_QUICK_REDUCE_QUANTIZATION", "NONE")
if regime_str not in QuickReduceRegime.__members__:
    logger.warning(
        "Custom quick allreduce:",              # <-- stray comma
        f"Invalid quantization level: {regime_str}. "
        "Supported levels: "
        f"{list(QuickReduceRegime.__members__.keys())}",
    )
    return
```

The trailing comma after `"Custom quick allreduce:"` ends the format string and turns the rest of the message into a positional argument. So the exact message that would have told the user *which* quantization levels are valid is the one that fails to render. The function then `return`s and quick all-reduce stays disabled, with no usable signal about why.

Reproduction:

```python
import logging
logging.basicConfig(level=logging.WARNING)
logging.getLogger(__name__).warning(
    "Custom quick allreduce:",
    "Invalid quantization level: FP8. Supported levels: ['NONE', 'FP', 'INT8', 'INT6', 'INT4']",
)
```

```
--- Logging error ---
Traceback (most recent call last):
  File ".../logging/__init__.py", line 1163, in emit
    msg = self.format(record)
  ...
TypeError: not all arguments converted during string formatting
Message: 'Custom quick allreduce:'
Arguments: ('Invalid quantization level: FP8. Supported levels: [...]',)
```

The second, in `hardware_backend/npu/utils.py`, is the classic `str.format` / printf mix-up — stdlib `logging` uses `%`-style, not `{}`:

```python
logger.debug("Function {} has already been called.", fn.__name__)
```

## Modifications

- `quick_all_reduce.py`: removed the stray comma so the four string literals concatenate into one message, as was clearly intended.
- `hardware_backend/npu/utils.py`: `{}` → `%s`, keeping the lazy-formatting argument style (correct for `logging`, since the interpolation is skipped when the level is disabled).
- `.pre-commit-config.yaml`: added `PLE1205` (too many arguments for logging format string) and `PLE1206` (not enough arguments) to the existing ruff `--select` list.

On the lint rule: these two call sites are the **only** violations in the repository, so the rules are green as of this commit and introduce no new noise for other contributors — they just stop this class of bug from coming back. Happy to drop that part if you'd rather keep the `--select` list minimal.

Verified with `ruff check --select=PLE1205,PLE1206` over the paths covered by the hook's `files` pattern: 2 violations before, 0 after.

## Accuracy Tests

Not applicable — no change to model outputs, kernels, or forward code.

## Speed Tests and Profiling

Not applicable — logging call sites only. The `npu/utils.py` change keeps arguments lazily formatted, so there is no added cost when `DEBUG` is disabled.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — the added lint rules serve as the regression guard here.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — not user-facing.
- [ ] Provide accuracy and speed benchmark results. — not applicable, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32773680821](https://github.com/sgl-project/sglang/actions/runs/32773680821)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32773680695](https://github.com/sgl-project/sglang/actions/runs/32773680695)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32773680966](https://github.com/sgl-project/sglang/actions/runs/32773680966)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->