### PR TITLE
[Performance] Tune FlashInfer EXTEND for DP prefill

### DIFF
--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -426,10 +426,12 @@ class BaseRunner(ABC):
             capture_forward_mode = ForwardMode.TARGET_VERIFY
             num_tokens_per_req = mr.decode_num_tokens_per_req()
         if extend_num_tokens_per_req is not None:
-            assert (
-                capture_forward_mode == ForwardMode.EXTEND
-                and not mr.spec_algorithm.is_speculative()
-            ), "extend_num_tokens_per_req requires a non-speculative EXTEND dummy"
+            assert capture_forward_mode == ForwardMode.EXTEND and (
+                not mr.spec_algorithm.is_speculative() or _is_pd_prefill_target
+            ), (
+                "extend_num_tokens_per_req requires an ordinary or PD-prefill "
+                "target EXTEND dummy"
+            )
             num_tokens_per_req = extend_num_tokens_per_req
 
         num_tokens = batch_size * num_tokens_per_req

--- a/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
+++ b/python/sglang/srt/model_executor/runner/flashinfer_autotune.py
@@ -26,6 +26,7 @@ import torch
 from sglang.srt.environ import envs
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.srt.runtime_context import (
+    get_disagg,
     get_exec,
     get_model,
     get_spec,
@@ -261,19 +262,24 @@ def maybe_flashinfer_autotune_extend(
     if not envs.SGLANG_FLASHINFER_AUTOTUNE_EXTEND.get():
         return
     mr = runner.model_runner
-    # max_prefill_tokens is a per-scheduler (per dp-rank) budget, and warmup
-    # runs on all dp ranks at once, so the gathered dummy already reaches the
-    # worst-case serving gather. Do not divide by dp_size.
-    num_tokens = mr.server_args.max_prefill_tokens
+    # Prefer the per-rank scheduler buffer while preserving the legacy ceiling
+    # when chunked prefill is disabled.
+    num_tokens = (
+        mr.server_args.max_prefill_buffer_tokens() or mr.server_args.max_prefill_tokens
+    )
     if num_tokens <= (decode_num_tokens or 0):
         return  # decode-shaped autotune already covered these buckets
-    if not mr.is_generation or mr.spec_algorithm.is_speculative():
-        # _dummy_run forces TARGET_VERIFY shapes for speculative runners;
-        # extend-bucket autotune for spec configs is a follow-up.
+    is_pd_prefill_target = (
+        get_disagg().disaggregation_mode == "prefill" and not mr.is_draft_worker
+    )
+    if not mr.is_generation or (
+        mr.spec_algorithm.is_speculative() and not is_pd_prefill_target
+    ):
+        # Ordinary speculative runners force TARGET_VERIFY; PD prefill targets
+        # have no draft-side state and preserve the requested EXTEND mode.
         return
-    if mr.model_config.is_multimodal:
-        # The dummy runs mm_inputs=None, which multimodal prefill paths iterate.
-        return
+    # Multimodal generation wrappers can still run this text-only EXTEND dummy;
+    # an incompatible model should fail the explicit opt-in visibly.
 
     if mr.attn_backend.extend_dummy_seqs_capped_by_req_pool:
         pool_size = mr.req_to_token_pool.size

--- a/test/registered/unit/model_executor/runner/test_flashinfer_autotune.py
+++ b/test/registered/unit/model_executor/runner/test_flashinfer_autotune.py
@@ -1,0 +1,94 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import pytest
+
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sglang.srt.model_executor.runner import base_runner, flashinfer_autotune
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+@pytest.mark.parametrize(
+    "mode,error",
+    [
+        ("prefill", "_dummy_run needs a static buffer"),
+        ("decode", "ordinary or PD-prefill target EXTEND dummy"),
+    ],
+)
+def test_packed_speculative_extend_is_limited_to_pd_prefill_target(mode, error):
+    runner = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            is_draft_worker=False,
+            spec_algorithm=SimpleNamespace(is_speculative=lambda: True),
+            decode_num_tokens_per_req=lambda: 6,
+        )
+    )
+    with (
+        patch.object(
+            base_runner,
+            "get_disagg",
+            return_value=SimpleNamespace(disaggregation_mode=mode),
+        ),
+        patch.object(
+            base_runner,
+            "get_server_return_hidden_states_mode",
+            return_value=CaptureHiddenMode.NULL,
+        ),
+        pytest.raises(AssertionError, match=error),
+    ):
+        base_runner.BaseRunner._dummy_run(
+            runner,
+            batch_size=1,
+            buffers=None,
+            forward_mode_override=ForwardMode.EXTEND,
+            extend_num_tokens_per_req=1,
+        )
+
+
+def test_chunked_prefill_disabled_uses_legacy_token_ceiling():
+    model_runner = SimpleNamespace(
+        server_args=SimpleNamespace(
+            max_prefill_buffer_tokens=Mock(return_value=0),
+            max_prefill_tokens=32768,
+        ),
+        is_generation=True,
+        is_draft_worker=False,
+        spec_algorithm=SimpleNamespace(is_speculative=lambda: False),
+        attn_backend=SimpleNamespace(extend_dummy_seqs_capped_by_req_pool=False),
+        canary_manager=None,
+    )
+    runner = SimpleNamespace(
+        model_runner=model_runner,
+        _alloc_dummy_decode_buffers=Mock(return_value=object()),
+        _dummy_run=Mock(),
+    )
+    with (
+        patch.object(
+            flashinfer_autotune.envs.SGLANG_FLASHINFER_AUTOTUNE_EXTEND,
+            "get",
+            return_value=True,
+        ),
+        patch.object(
+            flashinfer_autotune,
+            "get_disagg",
+            return_value=SimpleNamespace(disaggregation_mode="prefill"),
+        ),
+        patch.object(flashinfer_autotune, "run_flashinfer_autotune_forward"),
+        patch.object(flashinfer_autotune.torch.cuda, "empty_cache"),
+    ):
+        flashinfer_autotune.maybe_flashinfer_autotune_extend(
+            runner, decode_num_tokens=128
+        )
+
+    runner._alloc_dummy_decode_buffers.assert_called_once_with(
+        32768,
+        num_tokens_per_req=1,
+        allocate_logits_buffer=False,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

The explicit FlashInfer EXTEND autotune warmup used `max_prefill_tokens`, which remains the global DP token budget in a DP-attention prefill worker. With a global/local chunk size of `32768/8192`, each rank therefore warmed an unrepresentative 32768-token shape instead of its production 8192-token scheduler buffer. The path also skipped speculative PD prefill targets and text-only serving through multimodal generation wrappers, leaving the production FlashInfer MoE EXTEND bucket untuned.

## Modifications

- Size the EXTEND dummy from `max_prefill_buffer_tokens()`, matching the largest buffer one scheduler rank can submit, and fall back to the legacy `max_prefill_tokens` ceiling when chunked prefill is disabled.
- Allow a non-draft PD prefill target to retain the explicitly requested EXTEND mode while preserving the existing skip for ordinary speculative runners.
- Permit the corresponding packed EXTEND shape in `BaseRunner._dummy_run` for a speculative PD prefill target; ordinary speculative targets remain rejected.
- Allow text-only EXTEND warmup for multimodal generation wrappers instead of silently skipping the model.

The feature remains opt-in through `SGLANG_FLASHINFER_AUTOTUNE_EXTEND`.

## Accuracy Tests

A production-shaped, non-simulated GSM8K run completed successfully on Qwen3.5-397B-A17B-NVFP4 with speculative decoding, FlashInfer attention, the packed PD-prefill EXTEND contract, and EXTEND autotune enabled: job `3178955`, 200 examples, score `0.985`, mean accepted length `4.4966`, acceptance rate `0.6994`, CUDA graph request fraction `1.0`, zero retracts, and zero error markers.

Two focused CPU regression tests cover the review findings: packed speculative EXTEND is accepted only for a PD prefill target, and disabling chunked prefill falls back to `max_prefill_tokens` instead of silently skipping the explicit autotune opt-in.

## Speed Tests and Profiling

The matched A/B used Qwen3.5-397B-A17B-NVFP4 on GB300, one DEP4 prefill worker plus one DEP4 decode worker, RadixCache enabled, HiCache disabled, OSL 1, global/local chunk size `32768/8192`, FlashInfer A2A plus CuteDSL MoE, Breakable CUDA Graph, and the same frozen request manifest. Jobs `3177457` and `3177572` had identical source, backend, topology, cache work, request stream, rank load, and 36/36 cohort contracts; the only runtime difference was enabling `SGLANG_FLASHINFER_AUTOTUNE_EXTEND=1`. All four prefill ranks logged and completed the extra EXTEND autotune pass at 8192 tokens.

| Total concurrency | Before TPS/chip | After TPS/chip | Change |
|---:|---:|---:|---:|
| 4 | 25,369.772 | 26,682.219 | +5.173% |
| 8 | 29,105.925 | 30,543.648 | +4.940% |
| 16 | 30,974.960 | 33,070.931 | +6.767% |
| 32 | 32,138.435 | 34,139.581 | +6.227% |
| 64 | 32,204.009 | 34,346.322 | +6.652% |

At the stable saturation points, C32 and C64 had wave CVs of `0.262%` and `0.322%`. The C128 cell measured `32,093.066 -> 33,268.215 TPS/chip` (`+3.662%`) but is intentionally excluded from the performance claim because its candidate wave CV was `3.954%`, above the preregistered `1%` gate, due to one shared execution stall.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32793242211](https://github.com/sgl-project/sglang/actions/runs/32793242211)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32793241797](https://github.com/sgl-project/sglang/actions/runs/32793241797)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32793242177](https://github.com/sgl-project/sglang/actions/runs/32793242177)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->