### PR TITLE
[Gateway] Preserve rid and secure control-plane credentials

### DIFF
--- a/sgl-model-gateway/README.md
+++ b/sgl-model-gateway/README.md
@@ -907,6 +907,11 @@ The gateway supports role-based access control (RBAC) for control plane APIs (wo
 
 Both methods can be used together. Requests are authenticated in order: API key → JWT token.
 
+For a single service-account key, `CONTROL_PLANE_API_KEYS` is an equivalent
+environment-variable default when `--control-plane-api-keys` is absent. This
+keeps a secret out of a process argument list; an explicit CLI flag overrides
+the environment value.
+
 #### Roles
 
 | Role | Access |

--- a/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
+++ b/sgl-model-gateway/bindings/python/src/sglang_router/router_args.py
@@ -912,8 +912,13 @@ class RouterArgs:
             f"--{prefix}control-plane-api-keys",
             type=str,
             nargs="*",
-            default=[],
+            default=(
+                [os.environ["CONTROL_PLANE_API_KEYS"]]
+                if os.environ.get("CONTROL_PLANE_API_KEYS")
+                else []
+            ),
             help="API keys for control plane authentication. Format: 'id:name:role:key' where role is 'admin' or 'user'. "
+            "The CONTROL_PLANE_API_KEYS environment variable supplies one key when the flag is absent. "
             "Example: --control-plane-api-keys 'key1:Service Account:admin:secret123' 'key2:Read Only:user:secret456'",
         )
         auth_group.add_argument(

--- a/sgl-model-gateway/bindings/python/tests/test_pyo3_binding.py
+++ b/sgl-model-gateway/bindings/python/tests/test_pyo3_binding.py
@@ -267,6 +267,19 @@ class TestBuildControlPlaneAuthConfig:
 
 
 class TestParseControlPlaneApiKeys:
+    def test_environment_default_is_used_only_without_cli_keys(self, monkeypatch):
+        from sglang_router.launch_router import parse_router_args
+
+        monkeypatch.setenv(
+            "CONTROL_PLANE_API_KEYS", "env:Gateway:admin:environment-value"
+        )
+        assert parse_router_args([]).control_plane_api_keys == [
+            ("env", "Gateway", "environment-value", "admin")
+        ]
+        assert parse_router_args(
+            ["--control-plane-api-keys", "cli:Gateway:user:cli-value"]
+        ).control_plane_api_keys == [("cli", "Gateway", "cli-value", "user")]
+
     def test_valid(self):
         result = RouterArgs._parse_control_plane_api_keys(
             ["k1:Service Account:admin:secret123", "k2:Read Only:user:secret456"]

--- a/sgl-model-gateway/src/routers/mod.rs
+++ b/sgl-model-gateway/src/routers/mod.rs
@@ -98,6 +98,22 @@ pub trait RouterTrait: Send + Sync + Debug {
         model_id: Option<&str>,
     ) -> Response;
 
+    /// Route a chat completion while preserving SGLang's optional request ID.
+    ///
+    /// The public OpenAI request type intentionally does not model SGLang's
+    /// `rid` extension. Routers that cannot forward extensions retain the
+    /// ordinary OpenAI behavior through this default implementation.
+    async fn route_chat_with_sglang_rid(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &ChatCompletionRequest,
+        model_id: Option<&str>,
+        sglang_rid: Option<&str>,
+    ) -> Response {
+        let _ = sglang_rid;
+        self.route_chat(headers, body, model_id).await
+    }
+
     /// Route a completion request
     async fn route_completion(
         &self,

--- a/sgl-model-gateway/src/routers/openai/router.rs
+++ b/sgl-model-gateway/src/routers/openai/router.rs
@@ -474,6 +474,17 @@ impl crate::routers::RouterTrait for OpenAIRouter {
         body: &ChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
+        self.route_chat_with_sglang_rid(headers, body, model_id, None)
+            .await
+    }
+
+    async fn route_chat_with_sglang_rid(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &ChatCompletionRequest,
+        model_id: Option<&str>,
+        sglang_rid: Option<&str>,
+    ) -> Response {
         let start = Instant::now();
         let model = model_id.unwrap_or(body.model.as_str());
         let streaming = body.stream;
@@ -534,6 +545,10 @@ impl crate::routers::RouterTrait for OpenAIRouter {
                 metrics_labels::ERROR_VALIDATION,
             );
             return error_responses::bad_request(format!("Provider transform error: {}", e));
+        }
+
+        if let Some(rid) = sglang_rid {
+            payload["rid"] = Value::String(rid.to_owned());
         }
 
         let mut ctx = RequestContext::for_chat(

--- a/sgl-model-gateway/src/routers/router_manager.rs
+++ b/sgl-model-gateway/src/routers/router_manager.rs
@@ -530,6 +530,17 @@ impl RouterTrait for RouterManager {
         body: &ChatCompletionRequest,
         model_id: Option<&str>,
     ) -> Response {
+        self.route_chat_with_sglang_rid(headers, body, model_id, None)
+            .await
+    }
+
+    async fn route_chat_with_sglang_rid(
+        &self,
+        headers: Option<&HeaderMap>,
+        body: &ChatCompletionRequest,
+        model_id: Option<&str>,
+        sglang_rid: Option<&str>,
+    ) -> Response {
         // In IGW mode, resolve model_id and fail fast if not resolvable
         // In non-IGW mode, pass through to router (router handles validation)
         let effective_model_id = if self.enable_igw {
@@ -548,7 +559,12 @@ impl RouterTrait for RouterManager {
 
         if let Some(router) = router {
             router
-                .route_chat(headers, body, effective_model_id.as_deref().or(model_id))
+                .route_chat_with_sglang_rid(
+                    headers,
+                    body,
+                    effective_model_id.as_deref().or(model_id),
+                    sglang_rid,
+                )
                 .await
         } else {
             (

--- a/sgl-model-gateway/src/server.rs
+++ b/sgl-model-gateway/src/server.rs
@@ -21,6 +21,7 @@ use smg_mesh::{
 };
 use tokio::{signal, spawn};
 use tracing::{debug, error, info, warn, Level};
+use validator::Validate;
 use wfaas::LoggingSubscriber;
 
 use crate::{
@@ -75,6 +76,26 @@ pub struct AppState {
     pub router_manager: Option<Arc<RouterManager>>,
     pub mesh_handler: Option<Arc<MeshServerHandler>>,
     pub mesh_sync_manager: Option<Arc<MeshSyncManager>>,
+}
+
+/// Validated OpenAI chat input with the SGLang-only request ID retained.
+///
+/// `ChatCompletionRequest` intentionally models the public OpenAI schema, so
+/// its serde round-trip discards SGLang's `rid` extension. The gateway needs
+/// that ID to preserve a caller's ability to cancel the exact worker request.
+#[derive(Deserialize, validator::Validate)]
+struct ChatCompletionRequestWithSglangRid {
+    #[serde(flatten)]
+    #[validate(nested)]
+    request: ChatCompletionRequest,
+    #[serde(default)]
+    rid: Option<String>,
+}
+
+impl crate::protocols::validated::Normalizable for ChatCompletionRequestWithSglangRid {
+    fn normalize(&mut self) {
+        self.request.normalize();
+    }
 }
 
 async fn parse_function_call(
@@ -184,11 +205,16 @@ async fn generate(
 async fn v1_chat_completions(
     State(state): State<Arc<AppState>>,
     headers: http::HeaderMap,
-    ValidatedJson(body): ValidatedJson<ChatCompletionRequest>,
+    ValidatedJson(body): ValidatedJson<ChatCompletionRequestWithSglangRid>,
 ) -> Response {
     state
         .router
-        .route_chat(Some(&headers), &body, Some(&body.model))
+        .route_chat_with_sglang_rid(
+            Some(&headers),
+            &body.request,
+            Some(&body.request.model),
+            body.rid.as_deref(),
+        )
         .await
 }
 

--- a/sgl-model-gateway/tests/routing/test_openai_routing.rs
+++ b/sgl-model-gateway/tests/routing/test_openai_routing.rs
@@ -4,7 +4,7 @@ use std::{
     collections::HashMap,
     sync::{
         atomic::{AtomicUsize, Ordering},
-        Arc,
+        Arc, Mutex,
     },
 };
 
@@ -679,6 +679,57 @@ async fn test_openai_router_chat_completion_with_mock() {
     assert_eq!(chat_response["object"], "chat.completion");
     assert_eq!(chat_response["model"], "gpt-3.5-turbo");
     assert!(!chat_response["choices"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_openai_router_forwards_sglang_rid_to_external_worker() {
+    let received_payload = Arc::new(Mutex::new(None));
+    let handler_payload = Arc::clone(&received_payload);
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(move |Json(payload): Json<serde_json::Value>| {
+            let handler_payload = Arc::clone(&handler_payload);
+            async move {
+                *handler_payload.lock().unwrap() = Some(payload);
+                Json(json!({
+                    "id": "chatcmpl-rid",
+                    "object": "chat.completion",
+                    "created": 0,
+                    "model": "gpt-3.5-turbo",
+                    "choices": [],
+                    "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
+                }))
+            }
+        }),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    let ctx = crate::common::test_app::create_test_app_context().await;
+    crate::common::test_app::register_external_worker(&ctx, &format!("http://{address}"), None);
+    let router = OpenAIRouter::new(&ctx).await.unwrap();
+
+    let response = router
+        .route_chat_with_sglang_rid(
+            None,
+            &create_minimal_chat_request(),
+            None,
+            Some("nbe-cutoff-request-id"),
+        )
+        .await;
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert_eq!(
+        received_payload
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|payload| payload.get("rid"))
+            .and_then(serde_json::Value::as_str),
+        Some("nbe-cutoff-request-id")
+    );
+    server.abort();
 }
 
 /// Test full E2E flow with Axum server


### PR DESCRIPTION
## Motivation
SGLang Model Gateway forwards typed OpenAI chat requests through the Python sglang_router launcher. The launcher previously dropped a caller-provided SGLang rid, preventing downstream workers from receiving request-cancellation identity. It also accepted control-plane API keys only through argv, which makes a secret visible in a process argument list.

## Changes
- preserve an optional top-level rid through typed chat deserialization, router-manager dispatch, and the OpenAI worker payload
- permit CONTROL_PLANE_API_KEYS as the Python launcher one-key default when --control-plane-api-keys is absent; an explicit CLI flag overrides it
- document the environment default so containerized gateways can receive the control key from a protected env file
- add routing and parser regressions

## Validation
- PROTOC=/opt/homebrew/bin/protoc cargo check --manifest-path sgl-model-gateway/Cargo.toml
- exact rid-forwarding regression
- routing suite: 93 passed; one Redis integration test remains blocked locally because redis-server is absent
- direct Python parser check: environment default and explicit CLI override

The AMD cascade is currently skipped because the maintainer-controlled CI gate was not activated; no opened code or test job has failed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32783547024](https://github.com/sgl-project/sglang/actions/runs/32783547024)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32783546735](https://github.com/sgl-project/sglang/actions/runs/32783546735)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->