### PR TITLE
[CP V1 Deprecation 5/5] Update prefill CP documentation

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
@@ -432,25 +432,25 @@ For production deployments (RBG / LWS-based, DeepEP EP parallelism), see [multi_
 
 #### 4.2.5 DSA Long-Sequence Context Parallel and PP/CP
 
-SGLang provides two context parallel (CP) modes for long-sequence workloads, controlled with `--dsa-prefill-cp-mode`.
+SGLang provides two context parallel (CP) layouts for long-sequence workloads. Enable prefill CP with `--enable-prefill-cp` and select the layout with `--cp-strategy`.
 
-**In-sequence splitting** (`--dsa-prefill-cp-mode in-seq-split`): Each CP rank handles a uniform shard of the sequence; KV cache is gathered via all-gather. Batch size is restricted to 1 during prefill. See [PR #12065](https://github.com/sgl-project/sglang/pull/12065).
+**Zigzag** (`--cp-strategy zigzag`): Splits each sequence into `2 * cp_size` blocks and assigns each rank one early and one late block to balance causal-attention work. KV cache is restored to logical token order after the rank-local work.
 
 ```bash Command
-# In-seq splitting mode — EP + DP, batch size 1
+# Zigzag — EP + DP
 python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp \
   --tp 8 --ep 8 --dp 2 --enable-dp-attention \
-  --enable-dsa-prefill-context-parallel --attn-cp-size 4 \
-  --dsa-prefill-cp-mode in-seq-split --max-running-requests 32
+  --enable-prefill-cp --attn-cp-size 4 \
+  --cp-strategy zigzag --max-running-requests 32
 ```
 
-**Round-robin splitting** (`--dsa-prefill-cp-mode round-robin-split`, default): Distributes tokens by `token_idx % cp_size`. Supports fused MoE, FP8 KV cache, and multi-batch prefill. Cannot be combined with DP attention. See [PR #13959](https://github.com/sgl-project/sglang/pull/13959).
+**Interleave** (`--cp-strategy interleave`): Distributes tokens by `token_idx % cp_size`. It supports fused MoE, FP8 KV cache, and multi-batch prefill. It cannot be combined with DP attention.
 
 ```bash Command
-# Round-robin splitting — FusedMoE + CP8
+# Interleave — FusedMoE + CP8
 python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp \
-  --tp 8 --enable-dsa-prefill-context-parallel --attn-cp-size 8 \
-  --dsa-prefill-cp-mode round-robin-split --max-running-requests 32
+  --tp 8 --enable-prefill-cp --attn-cp-size 8 \
+  --cp-strategy interleave --max-running-requests 32
 ```
 
 **PP + CP (multi-node):** Combines Pipeline Parallelism and Context Parallelism for cross-node scaling. The production-optimized configurations below have been verified on Hopper:
@@ -499,8 +499,8 @@ sglang_args=$(echo serve \
   --attention-backend dsa \
   --dsa-prefill-backend flashmla_sparse \
   --dsa-decode-backend flashmla_sparse \
-  --enable-dsa-prefill-context-parallel \
-  --dsa-prefill-cp-mode round-robin-split \
+  --enable-prefill-cp \
+  --cp-strategy interleave \
   --cuda-graph-max-bs-decode 128 \
   --max-running-requests 128 \
   --trust-remote-code --host "0.0.0.0" --port 30000 \
@@ -529,20 +529,20 @@ dp_config=" \
 "
 
 cp_config=" \
-  --enable-dsa-prefill-context-parallel \
+  --enable-prefill-cp \
 "
 
 if [ "$dp" -eq 1 ]; then
 
 cp_config=" \
   $cp_config \
-  --dsa-prefill-cp-mode round-robin-split \
+  --cp-strategy interleave \
 "
 
 else
 cp_config=" \
   $cp_config \
-  --dsa-prefill-cp-mode in-seq-split \
+  --cp-strategy zigzag \
 "
 fi
 

--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V3_2.mdx
@@ -432,19 +432,13 @@ For production deployments (RBG / LWS-based, DeepEP EP parallelism), see [multi_
 
 #### 4.2.5 DSA Long-Sequence Context Parallel and PP/CP
 
-SGLang provides two context parallel (CP) layouts for long-sequence workloads. Enable prefill CP with `--enable-prefill-cp` and select the layout with `--cp-strategy`.
+Enable prefill context parallelism (CP) on CUDA with `--enable-prefill-cp --cp-strategy interleave` for long-sequence workloads.
 
-**Zigzag** (`--cp-strategy zigzag`): Splits each sequence into `2 * cp_size` blocks and assigns each rank one early and one late block to balance causal-attention work. KV cache is restored to logical token order after the rank-local work.
+<Warning>
+Zigzag prefill CP (`--cp-strategy zigzag`) is temporarily unavailable for DeepSeek V3.2, GLM-5, GLM-5.1, GLM-5.2, and GLM-5.3. Use `interleave` for these models and keep `--dp 1`; interleave DSA CP does not support `--dp` greater than 1.
+</Warning>
 
-```bash Command
-# Zigzag — EP + DP
-python -m sglang.launch_server --model deepseek-ai/DeepSeek-V3.2-Exp \
-  --tp 8 --ep 8 --dp 2 --enable-dp-attention \
-  --enable-prefill-cp --attn-cp-size 4 \
-  --cp-strategy zigzag --max-running-requests 32
-```
-
-**Interleave** (`--cp-strategy interleave`): Distributes tokens by `token_idx % cp_size`. It supports fused MoE, FP8 KV cache, and multi-batch prefill. It cannot be combined with DP attention.
+**Interleave** (`--cp-strategy interleave`): Distributes tokens by `token_idx % cp_size`. It supports fused MoE, FP8 KV cache, and multi-batch prefill.
 
 ```bash Command
 # Interleave — FusedMoE + CP8
@@ -518,33 +512,18 @@ sglang "${sglang_args[@]}" 2>&1 | tee $LOG_DIR/$RANK.log
 
 **fp8 KV + CP + PP**
 
-With FP8 KV, we can have less memory footprint. This can be combined with various parallel schemes:
+FP8 KV reduces the memory footprint. For DeepSeek V3.2, combine it with interleave CP and PP while keeping `--dp 1`:
 
 ```shell Command
 # verified in Hopper platform
-dp=1
-
 dp_config=" \
   --dp 1 --enable-dp-attention \
 "
 
 cp_config=" \
   --enable-prefill-cp \
-"
-
-if [ "$dp" -eq 1 ]; then
-
-cp_config=" \
-  $cp_config \
   --cp-strategy interleave \
 "
-
-else
-cp_config=" \
-  $cp_config \
-  --cp-strategy zigzag \
-"
-fi
 
 # see discussion : https://github.com/sgl-project/sglang/pull/12065
 sglang_args=$(echo serve \

--- a/docs/cookbook/autoregressive/GLM/GLM-5.1.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.1.mdx
@@ -100,6 +100,9 @@ import { GLM51Deployment } from '/src/snippets/autoregressive/glm-51-deployment.
 - **B300 and GB300**: NVFP4 is the recommended deployment path. Use `nvidia/GLM-5.1-NVFP4` with `--quantization modelopt_fp4`. Use `tp=8` on B300 and `tp=4` on GB300. The CUDA 13 image variant is required for B300 and GB300.
 - **AMD GPUs**: BF16 and FP8 checkpoints run on MI300X/MI325X/MI355X at tp=8. On MI355X (gfx950), the MXFP4 checkpoint `amd/GLM-5.1-MXFP4` is also supported at tp=4 with `--kv-cache-dtype fp8_e4m3`. All AMD paths pass `--dsa-prefill-backend tilelang --dsa-decode-backend tilelang`, `--chunked-prefill-size 131072`, and `--watchdog-timeout 1200` (20 minutes for weight loading). FP8 uses approximately half the memory of BF16 (~89 GB/GPU vs ~175 GB/GPU). EAGLE speculative decoding is supported on AMD GPUs: MI300X/MI325X (gfx942) and MI355X (gfx950), but it **requires `--disable-custom-all-reduce`** — the aiter custom all-reduce kernel deadlocks during EAGLE verify at high concurrency, so without this flag the server will hang.
 - For other configuration tips (MTP, DSA kernel, Context Parallel, HiSparse, NVFP4, Index Cache), see the [DeepSeek-V3.2 cookbook page](../DeepSeek/DeepSeek-V3_2). GLM-5.1 and DeepSeek-V3.2 share the same model structure, so the optimization techniques are common.
+
+- **Prefill CP on CUDA**: Zigzag (`--cp-strategy zigzag`) is temporarily unavailable for GLM-5.1. Use `--enable-prefill-cp --cp-strategy interleave` with `--dp 1`.
+
 - Use `--json-model-override-args '{"index_topk_pattern": "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSSFSFFFSFSSSFSFFSFFSSS"}'` to enable the [IndexCache](https://github.com/THUDM/IndexCache) method for GLM-5.1. This can improve serving efficiency with only a small accuracy loss. If you are running rigorous accuracy evaluations, do not enable this feature.
 
 ## 4. Model Invocation

--- a/docs/cookbook/autoregressive/GLM/GLM-5.2.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.2.mdx
@@ -254,6 +254,10 @@ For the full setup (streaming, tool-use, count_tokens, persisting env in `~/.cla
 
 ### 3.5 Context Parallelism
 
+<Warning>
+Zigzag prefill CP (`--cp-strategy zigzag`) is temporarily unavailable for GLM-5.2. For prefill CP on CUDA, use `interleave` with `--dp 1` as shown below.
+</Warning>
+
 Prefill context parallelism can help with reduction of TTFT under long context. To enable prefill context parallelism for GLM 5.2, please append the following arguments:
 ```bash
 --attn-cp-size 8 \

--- a/docs/cookbook/autoregressive/GLM/GLM-5.3.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.3.mdx
@@ -242,6 +242,10 @@ For the full setup (streaming, tool-use, count_tokens, persisting env in `~/.cla
 
 ### 3.5 Context Parallelism
 
+<Warning>
+Zigzag prefill CP (`--cp-strategy zigzag`) is temporarily unavailable for GLM-5.3. For prefill CP on CUDA, use `interleave` with `--dp 1` as shown below.
+</Warning>
+
 Prefill context parallelism can help with reduction of TTFT under long context. To enable prefill context parallelism for GLM 5.3, please append the following arguments:
 ```bash
 --attn-cp-size 8 \

--- a/docs/cookbook/autoregressive/GLM/GLM-5.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.mdx
@@ -93,6 +93,9 @@ import { GLM5Deployment } from '/src/snippets/autoregressive/glm-5-deployment.js
 
 - **AMD GPUs**: Use `--dsa-prefill-backend tilelang --dsa-decode-backend tilelang` for the DSA attention backend. Add `--chunked-prefill-size 131072` and `--watchdog-timeout 1200` (20 minutes for weight loading). EAGLE speculative decoding is not currently supported on AMD for GLM-5.
 - For other configuration tips (MTP, DSA kernel, Context Parallel, HiSparse, NVFP4, Index Cache), see the [DeepSeek-V3.2 cookbook page](../DeepSeek/DeepSeek-V3_2). GLM-5 and DeepSeek-V3.2 share the same model structure, so the optimization techniques are common.
+
+- **Prefill CP on CUDA**: Zigzag (`--cp-strategy zigzag`) is temporarily unavailable for GLM-5. Use `--enable-prefill-cp --cp-strategy interleave` with `--dp 1`.
+
 - Use `--json-model-override-args '{"index_topk_pattern": "FFSFSSSFSSFFFSSSFFFSFSSSSSSFFSFFSFFSSFFFFFFSFFFFFSFFSSSSSSFSFFFSFSSSFSFFSFFSSS"}'` for GLM-5-FP8 if you want to enable the [IndexCache](https://github.com/THUDM/IndexCache) method. This feature is supported through [this PR](https://github.com/sgl-project/sglang/pull/21405) and introduces only a small accuracy loss. However, if you are running rigorous accuracy evaluations, it is not recommended to enable this feature.
 
 ## 4. Model Invocation

--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -2819,7 +2819,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--cp-strategy`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Sharding strategy for prefill CP. <code>zigzag</code> is the former <code>in-seq-split</code> mode; <code>interleave</code> is the former <code>round-robin-split</code> mode.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Sharding strategy for prefill CP. <code>zigzag</code> assigns each rank one early and one late sequence block; <code>interleave</code> assigns token indices modulo the CP size.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>zigzag</code>, <code>interleave</code></td>
     </tr>
@@ -2882,42 +2882,6 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Disable scheduler-side attn_tp_gather (the upstream SP path that pads num_tokens to attn_tp_size and pre-allocates a gathered buffer). Use for models that manage SP scatter/gather at the model level (e.g., perform their own all_gather/reduce_scatter inside attention) and do not consume the upstream gathered_buffer. Without this, the cuda graph runner pads num_tokens to attn_tp_size, which can cause kernel autotuners to select wrong-sized variants at small batches.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-dsa-prefill-context-parallel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --enable-prefill-cp instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>—</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-nsa-prefill-context-parallel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --enable-prefill-cp instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>—</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-prefill-context-parallel`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --enable-prefill-cp instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>—</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: str</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--dsa-prefill-cp-mode`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --cp-strategy &#123;zigzag,interleave&#125; instead. 'in-seq-split' maps to 'zigzag'; 'round-robin-split' maps to 'interleave'.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`round-robin-split`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>in-seq-split</code>, <code>round-robin-split</code></td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--nsa-prefill-cp-mode`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --cp-strategy instead.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Auto</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>in-seq-split</code>, <code>round-robin-split</code></td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--prefill-cp-mode`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>[Deprecated] Use --cp-strategy &#123;zigzag,interleave&#125; instead. 'in-seq-split' maps to 'zigzag'.</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`in-seq-split`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>in-seq-split</code></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-fused-moe-sum-all-reduce`</td>

--- a/python/sglang/srt/arg_groups/fields/parallel.py
+++ b/python/sglang/srt/arg_groups/fields/parallel.py
@@ -152,7 +152,7 @@ class Parallel:
     cp_strategy: A[
         Optional[str],
         Arg(
-            help="Sharding strategy for prefill CP. 'zigzag' is the former in-seq-split mode; 'interleave' is the former round-robin-split mode.",
+            help="Sharding strategy for prefill CP. 'zigzag' assigns each rank one early and one late sequence block; 'interleave' assigns token indices modulo the CP size.",
             choices=("zigzag", "interleave"),
         ),
     ] = None


### PR DESCRIPTION
## Summary

- update the generic DeepSeek V3.2 cookbook to use `--enable-prefill-cp` with `--cp-strategy {zigzag,interleave}`
- replace v1-era in-sequence/round-robin descriptions with the canonical layouts
- remove generic CLI aliases that no longer exist from the server-argument reference
- remove the two stale Ascend NPU compatibility alias entries, whose CLI definitions were removed by merged #38293
- keep the CLI help text and generated reference wording aligned

## Review follow-up

- Commit `9ca43af000`: document the temporary zigzag prefill CP restriction for DeepSeek V3.2 and GLM-5/5.1/5.2/5.3 in their cookbook pages.
- Use interleave with DP=1; remove the unsupported DeepSeek zigzag command and the FP8 KV script's zigzag branch.
- Documentation only; no runtime, AMD/NPU implementation, or test changes.
- Changed-file pre-commit, `bash -n` for DeepSeek shell examples, `mint validate`, and `mint broken-links` passed.

## Stack

1. #36222 — switch CP tests from v1 to v2
2. #36223 — remove CP v1 server-argument compatibility
3. #36228 — remove generic CP v1 runtime
4. #36229 — canonicalize API names
5. **this PR** — update documentation

## AMD/NPU preservation

No AMD/NPU implementation, registered test, or Ascend NPU documentation file changes in this PR. The protected ROCm/HIP files and AMD/NPU test trees are byte-identical to the parent PR.

## Previous rebase and verification (2026-09-08)

- PR #36229 is merged. Rebased directly onto latest main `ed183d45acfb0f6d1a2b1cd6b6a34a579e1a3ad7`; head `06f0f25e00ff8afd9e7bd9214377cf4f32392134`.
- PR base is now `main`. Only the single documentation/help commit remains (3 files, +16/-52).
- Rebase completed without conflicts; the entire patch has the same stable patch ID as before the rebase.
- Changed-file pre-commit checks passed.
- `mint validate`: passed; `mint broken-links`: no broken links found.
- Runtime/GPU tests were not rerun for this documentation-only rebase.

## Historical verification (before this rebase)

- `pre-commit run --files <changed files>`
- focused CLI metadata and context-parallel server-argument tests: 14 passed, 5 subtests passed
- full server-argument suite: 158 passed; 2 local baseline/environment failures reproduced unchanged on the parent commit (macOS backend fallback and unavailable `uvloop`)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34289522643](https://github.com/sgl-project/sglang/actions/runs/34289522643)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34289522519](https://github.com/sgl-project/sglang/actions/runs/34289522519)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34289522612](https://github.com/sgl-project/sglang/actions/runs/34289522612)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->