### PR TITLE
[CI] Stop the resolution ratchets re-parsing the whole package

### DIFF
--- a/test/registered/unit/server_args/test_resolution_is_reproducible.py
+++ b/test/registered/unit/server_args/test_resolution_is_reproducible.py
@@ -689,13 +689,14 @@ class TestForksResolveFirst(CustomTestCase):
                 continue
             try:
                 source = path.read_text(encoding="utf-8-sig")
+                if "Process" not in source:
+                    continue
                 tree = ast.parse(source)
             except (SyntaxError, UnicodeDecodeError):
                 continue
             for node in ast.walk(tree):
                 if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
                     continue
-                body = ast.get_source_segment(source, node) or ""
                 forks = [
                     call
                     for call in ast.walk(node)
@@ -714,6 +715,7 @@ class TestForksResolveFirst(CustomTestCase):
                 ]
                 if not forks:
                     continue
+                body = ast.get_source_segment(source, node) or ""
                 examined += 1
                 # `spawn` starts a fresh interpreter, so the child may probe.
                 if 'get_context("spawn")' in body or "'spawn'" in body:
@@ -939,7 +941,10 @@ class TestTheResolutionSeamHasOneCaller(CustomTestCase):
         callers = []
         for path in sorted(package_root.rglob("*.py")):
             try:
-                tree = ast.parse(path.read_text())
+                source = path.read_text()
+                if "_run_resolution_pipeline" not in source:
+                    continue
+                tree = ast.parse(source)
             except SyntaxError:
                 continue
             # The full (class, function, ...) scope chain, so the assertion can
@@ -988,7 +993,10 @@ class TestTheResolutionSeamHasOneCaller(CustomTestCase):
         callers = []
         for path in sorted(package_root.rglob("*.py")):
             try:
-                tree = ast.parse(path.read_text())
+                source = path.read_text()
+                if "resolve_once" not in source:
+                    continue
+                tree = ast.parse(source)
             except SyntaxError:
                 continue
             for node in ast.walk(tree):


### PR DESCRIPTION
## Motivation

`test/registered/unit/server_args/test_resolution_is_reproducible.py` takes **359s** on `base-a-test-cpu` — 41% of shard 7, whose "Run test" step timed out at 15 minutes on [run 32786070189](https://github.com/sgl-project/sglang/actions/runs/32786070189). The next slowest file in that shard is 32s. Shard 7 came in at 881s against a 900s budget while the other nine shards landed between 356s and 652s.

From the `[CI Test Method]` timestamps in that job's log, the 359s splits as:

| window | duration | what ran |
|---|---:|---|
| 22:46:23 → 22:47:13 | 49.7s | interpreter + import + `TestACopyStaysResolved` |
| 22:47:13 → 22:50:58 | **225.1s** | `test_every_fork_of_a_record_has_a_resolved_one` |
| 22:50:58 → 22:51:24 | 25.7s | `TestProgramsResolveBeforeReadingResolution` + `TestResolutionIsReproducible` |
| 22:51:24 → 22:51:59 | 35.8s | `test_only_the_gate_runs_the_pipeline` |
| 22:51:59 → 22:52:20 | 20.6s | `test_the_gate_is_reached_from_the_launcher_and_from_publish` |

The reproducibility assertions the file is named for are cheap. The cost is in the package scans, and three of them do work they discard.

## Modifications

**`test_every_fork_of_a_record_has_a_resolved_one`** called `ast.get_source_segment(source, node)` on every function definition *before* checking whether that function forks — 28,817 calls to serve 13 fork sites. `get_source_segment` re-splits the entire file on every call, so a 10k-line file with 300 functions pays ~3M line-copies. `body` is only read inside the `if not forks` branch, so it moves under the guard.

**All three scans** match an AST node by a literal name (`Process`, `_run_resolution_pipeline`, `resolve_once`). A file whose text does not contain that name cannot contribute a match, so it does not need parsing at all — one substring check before `ast.parse`. The filter is exactly as tight as the AST match it guards: both require the name verbatim.

No assertion, exemption list, or expected-value set changes.

## Speed Tests and Profiling

Per-test, local (`--durations`):

| test | before | after | |
|---|---:|---:|---:|
| `test_only_the_gate_runs_the_pipeline` | 10.32s | 0.25s | 41x |
| `test_the_gate_is_reached_from_the_launcher_and_from_publish` | 5.66s | 0.18s | 31x |
| `test_every_fork_of_a_record_has_a_resolved_one` | 14.49s | 1.86s | 7.8x |
| **file total** | **49.4s** | **20.5s** | 2.4x |

Isolating the fork scan and running the three variants side by side over the real package, asserting identical output:

```
   current:  13.88s   examined=13  offenders=0
     hoist:   4.64s   examined=13  offenders=0
 prefilter:   1.66s   examined=13  offenders=0
all variants agree exactly: (13, [])
```

The two gate scans assert exact expected caller lists, so they are their own equivalence check — a prefilter that hid a caller would fail them. Both pass.

Local wall time does not translate directly to the CI runner (the 49.4s local vs 359s CI gap is wider than runner speed alone explains), so the exact CI saving needs a run here to confirm.

## Not addressed

Two scans in this file keep a full parse because no equally tight prefilter exists: `test_no_bare_replace_of_a_record_outside_the_helper` matches `replace(`, which `str.replace` makes non-selective, and `test_every_program_that_builds_a_record_resolves_it` has no single distinctive token. A prefilter that does not select is a ratchet silently disabled, so neither got one.

Two related findings from the same investigation, both left for follow-ups:

1. **The partition estimate for this file is stale.** `compute_partitions.py` pulls live per-file estimates from `sglang-ci-stats`; the pinned model has this file at **53s** against an actual 359s, because its fit window is 7 days / 16 runs and the file went 375 → 1058 lines on 2026-08-23 (#35907). Files missing from that table fall back to in-source `est_time` — `test_chain_read_ratchet.py` falls back to 5 against an actual 84s, `test_model_config_reads_resolved_input.py` to 5 against 64s.
2. **`_RestoresProcessState` overrides `_callTestMethod`** and calls `unittest.TestCase._callTestMethod` directly, bypassing `CustomTestCase` — so the 10 tests in `TestResolutionIsReproducible` and `TestACopyStaysResolved` get neither the `[CI Test Method]` marker nor the retry wrapper every other registered test has.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32789584006](https://github.com/sgl-project/sglang/actions/runs/32789584006)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32789583841](https://github.com/sgl-project/sglang/actions/runs/32789583841)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32789583973](https://github.com/sgl-project/sglang/actions/runs/32789583973)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->