### PR TITLE
[AMD][DI][CI] 10.5/N Add DeepSeek-R1-0528 FP8 HiCache 1P1D nightly recipe

### DIFF
--- a/scripts/ci/slurm/launch_mi355x.sh
+++ b/scripts/ci/slurm/launch_mi355x.sh
@@ -144,6 +144,13 @@ emit("MAXTOK", rt.get("max_total_tokens", ""))
 emit("CHUNK", rt["chunked_prefill_size"])
 # swa is DSV4-specific; emit empty when a model omits it so the flag is dropped.
 emit("SWA", rt.get("swa_full_tokens_ratio", ""))
+# --disable-radix-cache used to be hardcoded into both role strings. The default
+# reproduces that, so every recipe that omits the key keeps its argv byte-identical.
+# A HiCache recipe MUST set `disable_radix_cache: false`: server_args
+# _handle_cache_compatibility raises on enable-hierarchical-cache + disable-radix-cache.
+# Only the prefill role is affected in practice -- the PD hook force-disables the
+# radix cache on a decode server anyway unless --disaggregation-decode-enable-radix-cache.
+emit("NORADIX", 1 if rt.get("disable_radix_cache", True) else 0)
 # 1 when the recipe carries a `model:` block (env + server_args written to
 # model_flags.sh); 0 for the DSV4 recipes, which keep the hardcoded DSV4 path.
 emit("HAS_MODEL", 1 if r.get("model") else 0)
@@ -427,6 +434,10 @@ KV_FLAG=""
 PREFILL_TAIL="$PREFILL_DPEP$EXTRA_COMMON$(sp "$WECOMMON")$(sp "$PEXTRA")"
 DECODE_TAIL="$DECODE_DPEP$EXTRA_COMMON$(sp "$WECOMMON")$(sp "$DEXTRA")"
 echo "prefill tail:${PREFILL_TAIL:-<none>} | decode tail:${DECODE_TAIL:-<none>} (pep=$PEP pdp=$PDP dep=$DEP ddp=$DDP mtp=$MTP_ENABLED)"
+# Carries its own leading space so that with the default (NORADIX=1) the role
+# strings below render exactly as the previous hardcoded text.
+RADIX_FLAG=""
+[[ "$NORADIX" == "1" ]] && RADIX_FLAG=" --disable-radix-cache"
 
 if [[ "$HAS_MODEL" == "1" ]]; then
     # Generic path (e.g. Kimi): attention + swa from the recipe, model parsers /
@@ -439,12 +450,12 @@ if [[ "$HAS_MODEL" == "1" ]]; then
     [[ -n "$DATTN" ]] && ATTN_FLAGS="$ATTN_FLAGS --decode-attention-backend $DATTN"
     SWA_FLAG=""
     [[ -n "$SWA" ]] && SWA_FLAG=" --swa-full-tokens-ratio $SWA"
-    PREFILL_COMMON_FLAGS="--trust-remote-code --tp $PTP --disable-radix-cache \
+    PREFILL_COMMON_FLAGS="--trust-remote-code --tp $PTP$RADIX_FLAG \
 $ATTN_FLAGS --max-running-requests $PMAXREQ --page-size $PAGE \
 --mem-fraction-static $PMEMFRAC$SWA_FLAG \
 --chunked-prefill-size $PCHUNK \
 --disaggregation-transfer-backend $XFER --disaggregation-ib-device $IB$KV_FLAG$PREFILL_TAIL"
-    DECODE_COMMON_FLAGS="--trust-remote-code --tp $DTP --disable-radix-cache \
+    DECODE_COMMON_FLAGS="--trust-remote-code --tp $DTP$RADIX_FLAG \
 $ATTN_FLAGS --max-running-requests $DMAXREQ --page-size $PAGE \
 --mem-fraction-static $DMEMFRAC$SWA_FLAG \
 --chunked-prefill-size $CHUNK \
@@ -452,13 +463,13 @@ $ATTN_FLAGS --max-running-requests $DMAXREQ --page-size $PAGE \
 else
     # DSV4 path: for EP<=8 recipes (PTP==DTP, no wide_ep) both role strings equal
     # the pre-Kimi launcher's COMMON_FLAGS exactly.
-    PREFILL_COMMON_FLAGS="--trust-remote-code --tp $PTP --disable-radix-cache \
+    PREFILL_COMMON_FLAGS="--trust-remote-code --tp $PTP$RADIX_FLAG \
 --attention-backend $ATTN --max-running-requests $PMAXREQ --page-size $PAGE \
 --mem-fraction-static $PMEMFRAC --swa-full-tokens-ratio $SWA \
 --chunked-prefill-size $PCHUNK --disable-shared-experts-fusion \
 --tool-call-parser deepseekv4 --reasoning-parser deepseek-v4 \
 --disaggregation-transfer-backend $XFER --disaggregation-ib-device $IB$KV_FLAG$PREFILL_TAIL"
-    DECODE_COMMON_FLAGS="--trust-remote-code --tp $DTP --disable-radix-cache \
+    DECODE_COMMON_FLAGS="--trust-remote-code --tp $DTP$RADIX_FLAG \
 --attention-backend $ATTN --max-running-requests $DMAXREQ --page-size $PAGE \
 --mem-fraction-static $DMEMFRAC --swa-full-tokens-ratio $SWA \
 --chunked-prefill-size $CHUNK --disable-shared-experts-fusion \

--- a/scripts/ci/slurm/nightly-configs.yaml
+++ b/scripts/ci/slurm/nightly-configs.yaml
@@ -357,6 +357,35 @@ kimik26-fp8-mi355x-mtp-sglang:
         - conc-list: [1, 8, 16, 32, 64, 128, 256]
           config_file: scripts/ci/slurm/recipes/mi355x-fp8/kimik26/1k1k/1p1d-mtp.yaml
 
+# DeepSeek-R1-0528 (native FP8) 2-node 1P1D with HiCache (L1 GPU radix + L2 host
+# pinned + L3 file) on the PREFILL role. This is the disaggregated counterpart of
+# the single-instance registered test
+# test/registered/amd/test_deepseek_r1_hicache_mi35x.py (#26395 / #26478); the DI
+# CI had no hierarchical-cache coverage at all before this leg. R1 is used
+# because it is the model HiCache is known-good on for MI35x.
+#
+# The recipe sets runtime.disable_radix_cache: false -- HiCache L1 *is* the radix
+# cache, and --disable-radix-cache was previously hardcoded for every role.
+#
+# The perf sweep uses --dataset-name random (no cross-request prefix sharing), so
+# this leg's throughput reflects HiCache overhead rather than benefit; the GSM8K
+# hard-gate is the signal that matters here.
+dsr1-fp8-mi355x-hicache-sglang:
+  model: deepseek-ai/DeepSeek-R1-0528
+  model-prefix: dsr1
+  model_path: /it-share/model_coverage/models--deepseek-ai--DeepSeek-R1-0528
+  runner: mi355x
+  precision: fp8
+  framework: sglang
+  multinode: true
+  disagg: true
+  seq-len-configs:
+    - isl: 1024
+      osl: 1024
+      search-space:
+        - conc-list: [1, 8, 16, 32, 64, 128, 256]
+          config_file: scripts/ci/slurm/recipes/mi355x-fp8/dsr1/1k1k/1p1d-hicache.yaml
+
 # AMD 4-node disaggregation with narrow-prefill EP8 + WIDE-decode EP16 (Oren's
 # 2P1D config: two single-node prefill engines EP8 that the router fans across +
 # one decode engine EP16 spanning 2 nodes; 4 nodes total). Runs on the `mi355x`

--- a/scripts/ci/slurm/recipes/mi355x-fp8/dsr1/1k1k/1p1d-hicache.yaml
+++ b/scripts/ci/slurm/recipes/mi355x-fp8/dsr1/1k1k/1p1d-hicache.yaml
@@ -1,0 +1,155 @@
+# MI355X DeepSeek-R1-0528 (native FP8) 2-node 1P1D disaggregation recipe with
+# HiCache (hierarchical KV cache) enabled on the PREFILL role.
+#
+# This is the disaggregated counterpart of the single-instance registered test
+# test/registered/amd/test_deepseek_r1_hicache_mi35x.py (added in #26395, moved
+# to the nightly suite in #26478). The HiCache flag set below is that test's,
+# with two deliberate deviations called out under `wide_ep` and `runtime`.
+#
+# WHY PREFILL ONLY:
+#   * A PD decode server never prefills, so a prefix cache there has no work.
+#   * AMD's own guidance for MI355X + MORI is prefill-only ("HiCache is not
+#     recommended on the decode role with MORI").
+#   * It is not expressible anyway: arg_groups/pd_disaggregation_hook.py forces
+#     disable_radix_cache=True on a decode server unless
+#     --disaggregation-decode-enable-radix-cache is passed, and
+#     server_args._handle_cache_compatibility then raises on
+#     enable-hierarchical-cache + disable-radix-cache.
+#   The prefill KV sender is HiCache-aware: disaggregation/prefill.py computes
+#   the early-send boundary as len(prefix_indices) - host_hit_length, so decode
+#   still receives the full KV range including L2/L3 cache hits.
+#
+# NOTE ON THE PERF NUMBERS: the sweep runs --dataset-name random, which samples
+# distinct ShareGPT conversations per request, so there is ~zero cross-request
+# prefix reuse. This leg therefore measures HiCache OVERHEAD, not benefit, and
+# is expected to sit at or slightly below the non-HiCache legs. Its value is the
+# correctness gate: does HiCache-in-PD break R1 generation. The 8-shot GSM8K
+# prefix in the accuracy gate is the only part that exercises prefix reuse.
+#
+# Consumed by:
+#   * scripts/ci/slurm/process_result.py reads `resources` and
+#     `backend.sglang_config` (TP/EP/DP + worker counts) for the summary table.
+#   * scripts/ci/slurm/launch_mi355x.sh reads `runtime` and `bench`.
+
+resources:
+  prefill_workers: 1
+  decode_workers: 1
+
+backend:
+  sglang_config:
+    prefill:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+    decode:
+      tensor-parallel-size: 8
+      expert-parallel-size: 1
+      data-parallel-size: 1
+
+# Model-specific docker env + sglang server args (generic launcher path; keeps
+# R1 off the hardcoded DeepSeek-V4 parser branch in launch_mi355x.sh). The three
+# env vars are the ROCm DSR1-0528 requirements carried over from #26395:
+#   SGLANG_USE_AITER=1                  -> aiter prefill/decode path
+#   ROCM_QUICK_REDUCE_QUANTIZATION=NONE -> keep allreduce fp16/bf16
+#   SGLANG_AITER_FP8_PREFILL_ATTN=0     -> the FP8 prefill kernel
+#                                          (flash_attn_varlen_func) is
+#                                          incompatible with DSR1-0528 at
+#                                          page_size=64
+model:
+  env:
+    SGLANG_USE_AITER: 1
+    ROCM_QUICK_REDUCE_QUANTIZATION: NONE
+    SGLANG_AITER_FP8_PREFILL_ATTN: 0
+    SAFETENSORS_FAST_GPU: 1
+  server_args:
+    - --context-length
+    - 65536
+    - --max-prefill-tokens
+    - 32768
+    - --watchdog-timeout
+    - 1200
+    - --enable-metrics
+    - --enable-cache-report
+    # Anything containing a space or a quote MUST live here rather than in
+    # wide_ep.*_extra_flags: server_args is shlex-quoted into a bash array and
+    # expanded as "${MODEL_SERVER_ARGS[@]}", whereas the extra_flags strings are
+    # word-split by the entry script.
+    - --model-loader-extra-config
+    - '{"enable_multithread_load": true, "num_threads": 64}'
+
+runtime:
+  image: lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260820
+  attention_backend: aiter
+  # RoCE HCAs MORI uses for cross-node KV transfer.
+  ib_devices: rdma0,rdma1,rdma2,rdma3
+  prefill_port: 30025
+  decode_port: 30026
+  prefill_bootstrap_port: 8998
+  decode_bootstrap_port: 9001
+  lb_port: 8000
+  mem_fraction_static: 0.85
+  # DEVIATION FROM THE OTHER MI355X RECIPES (which all use 256): 64 matches the
+  # registered DSR1 HiCache test, the only known-green R1+HiCache config on this
+  # hardware, and pairs with SGLANG_AITER_FP8_PREFILL_ATTN=0 above. It also
+  # drops the MORI KV transfer granularity 4x versus every previously validated
+  # recipe -- this is the first thing to A/B if the leg is slow or flaky.
+  page_size: 64
+  max_running_requests: 256
+  chunked_prefill_size: 32768
+  # swa_full_tokens_ratio intentionally omitted: R1 has no SWA, and the generic
+  # launcher branch drops --swa-full-tokens-ratio when the key is absent.
+  #
+  # Required for HiCache: --disable-radix-cache is otherwise hardcoded into both
+  # role flag strings, and hicache + disable-radix-cache is a hard ValueError.
+  # HiCache L1 *is* the radix cache. Only the prefill role is affected in
+  # practice (see the WHY PREFILL ONLY note above).
+  disable_radix_cache: false
+  wide_ep:
+    # Applies to both roles; PD requires a matching KV dtype on each side.
+    kv_cache_dtype: fp8_e4m3
+    # Mirrors the registered test. Leaves GPU headroom for the L2 staging path.
+    prefill_mem_fraction_static: 0.6
+    # Every token here must be space- and quote-free (see the server_args note).
+    #
+    # DEVIATION: the registered test uses --hicache-ratio 2. A ratio is relative
+    # to the DEVICE pool, which in this PD layout is far larger than in that
+    # single-instance test -- ratio 2 would ask for well over 1 TB of pinned
+    # host memory across the 8 ranks and trip the "Not enough host memory
+    # available" ValueError in memory_pool_host.py. --hicache-size is an
+    # absolute per-rank GB budget and overrides the ratio.
+    prefill_extra_flags: "--enable-hierarchical-cache --hicache-size 64 --hicache-io-backend kernel --hicache-mem-layout page_first --hicache-write-policy write_through --hicache-storage-backend file --hicache-storage-prefetch-policy best_effort"
+    prefill_extra_env:
+      # L3 tier. /tmp is the container's overlayfs on node-local NVMe and is
+      # reclaimed by `docker run --rm`. It must NOT be /host_home: that Weka
+      # share is 24 GB total and holds every leg's logs.
+      SGLANG_HICACHE_FILE_BACKEND_STORAGE_DIR: /tmp/hicache-l3
+      # The file evictor is OFF unless one of these is set, and write_through
+      # over a full sweep writes on the order of 70 GB. Setting them also makes
+      # rank 0 the sole storage owner, collapsing the 8-way write amplification
+      # that MLA models otherwise incur (all ranks share one filename).
+      SGLANG_HICACHE_FILE_BACKEND_MAX_SIZE: 64G
+      SGLANG_HICACHE_FILE_BACKEND_MIN_FREE_SPACE: 512G
+      SGLANG_HICACHE_FILE_BACKEND_ENABLE_METADATA_CACHE: 1
+
+bench:
+  # bench_serving --max-concurrency sweep; one result JSON per concurrency.
+  concurrencies: [1, 8, 16, 32, 64, 128, 256]
+  num_prompts_factor: 4      # num-prompts = concurrency * factor
+  random_range_ratio: 1.0
+
+  # Correctness gate run through the PD path before the perf sweep
+  # (full GSM8K, 8-shot, accuracy > 0.93). A regression here fails the nightly
+  # even when throughput looks fine ("fast but wrong").
+  #
+  # method is deliberately left at the default few_shot: the run_eval branch
+  # does not pass --api and would drive R1 through the chat template, where the
+  # reasoning preamble gets truncated at --max-tokens and GSM8K collapses to ~0.
+  accuracy:
+    enabled: true
+    num_shots: 8
+    num_questions: 1319    # full GSM8K test set
+    # Threshold matches the registered DSR1-0528 tests. Measured 0.959 on the
+    # first 2-node validation run of this recipe (g29 prefill / g53 decode,
+    # image v0.5.17-rocm720-mi35x-20260820, Invalid 0.000), so ~2.9 points of
+    # headroom.
+    threshold: 0.93


### PR DESCRIPTION
# PR Description

## Motivation

Add an AMD MI355X DI/CI nightly recipe for DeepSeek-R1-0528 (FP8) 2-node 1P1D with HiCache (L1+L2+L3), so the nightly covers hierarchical KV caching — it has none today (`grep -ri hicache scripts/ci/slurm/` is empty).

HiCache is exercised today only by the single-instance registered test `test_deepseek_r1_hicache_mi35x.py` (#26395 / #26478), never through a PD topology. R1 is used because it is the model HiCache is known-good on for MI35x.

## What's New

### New Recipe

1 new recipe under `scripts/ci/slurm/recipes/mi355x-fp8/dsr1/1k1k/`:

| Recipe | Topology | HiCache |
|----------|----------|----------|
| `1p1d-hicache.yaml` | TP8 1P1D | L1+L2+L3 (file), prefill role |

Plus one matching block in `nightly-configs.yaml` (`dsr1-fp8-mi355x-hicache-sglang`).

HiCache sits on the prefill role only: the PD hook force-disables the radix cache on a decode server, and `_handle_cache_compatibility` then raises on `hicache + disable-radix`. A PD decode server never prefills, so a prefix cache there has no work.

## Launcher Change

`--disable-radix-cache` was hardcoded into both role flag strings, and HiCache L1 is the radix cache — so no recipe could enable HiCache.

It becomes `runtime.disable_radix_cache`, defaulting to `true`.

Verified byte-identical: all 34 existing recipes rendered through both the old and new launcher; the `PREFILL/DECODE_COMMON_FLAGS` diff is empty.

## Runtime Image

`lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260820`

## Validation

2-node run (g29 prefill / g53 decode):

- Both roles boot
- HiCache L1+L2+L3 initialize
- GSM8K 0.959 (full 1319, 8-shot) vs the 0.93 gate
- 7/7 concurrency points
- 0 GPU memory access faults

> Note: the sweep uses `--dataset-name random` (no cross-request prefix sharing), so this leg measures HiCache overhead rather than benefit — the accuracy gate is the signal.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32790242281](https://github.com/sgl-project/sglang/actions/runs/32790242281)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32790242069](https://github.com/sgl-project/sglang/actions/runs/32790242069)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32790242215](https://github.com/sgl-project/sglang/actions/runs/32790242215)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->