### PR TITLE
[CI] Stop the config ratchets re-parsing the package on every scan

### DIFF
--- a/test/registered/unit/server_args/test_model_config_reads_resolved_input.py
+++ b/test/registered/unit/server_args/test_model_config_reads_resolved_input.py
@@ -13,6 +13,7 @@ one field that is deliberately read before resolution touches it.
 """
 
 import ast
+import functools
 import pathlib
 import unittest
 
@@ -51,6 +52,24 @@ _STALE_FROM_THE_REGISTRIES = frozenset(
 )
 
 
+@functools.lru_cache(maxsize=None)
+def _parsed(path):
+    return ast.parse(path.read_text(encoding="utf-8-sig"))
+
+
+@functools.lru_cache(maxsize=None)
+def _declared_resolution_fields(path):
+    fields = set()
+    for node in ast.walk(_parsed(path)):
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "declare_resolution"
+        ):
+            fields |= {kw.arg for kw in node.keywords if kw.arg}
+    return frozenset(fields)
+
+
 def _registry_declared_fields():
     """What the live registries and passes declare.
 
@@ -79,7 +98,7 @@ def _registry_collection_is_after_the_build():
     collection above this handler's own `get_model_config()` call does not move
     it above the configuration another handler already cached.
     """
-    tree = ast.parse((_SRT / "server_args.py").read_text(encoding="utf-8-sig"))
+    tree = _parsed(_SRT / "server_args.py")
     handler = next(
         node
         for node in ast.walk(tree)
@@ -129,7 +148,7 @@ def _server_args_names(tree, path):
 def _constructor_reads():
     """Fields `ModelConfig.from_server_args` takes off the record."""
     path = _SRT / "configs/model_config.py"
-    tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+    tree = _parsed(path)
     constructor = next(
         node
         for node in ast.walk(tree)
@@ -177,7 +196,7 @@ def _late_resolution_fields():
         path = _SRT / name
         if not path.exists():
             continue
-        tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+        tree = _parsed(path)
         for node in ast.walk(tree):
             if not isinstance(node, ast.Call):
                 continue
@@ -205,7 +224,7 @@ def _hook_declarations(dispatch, source_module):
     `test_every_opaque_callback_is_still_late`.
     """
     imported = {}
-    for node in ast.walk(ast.parse(source_module.read_text(encoding="utf-8-sig"))):
+    for node in ast.walk(_parsed(source_module)):
         if isinstance(node, ast.ImportFrom) and node.module:
             for alias in node.names:
                 imported[alias.asname or alias.name] = node.module
@@ -225,22 +244,14 @@ def _hook_declarations(dispatch, source_module):
         path = _SRT / (module[len("sglang.srt.") :].replace(".", "/") + ".py")
         if not path.exists():
             continue
-        for inner in ast.walk(ast.parse(path.read_text(encoding="utf-8-sig"))):
-            if (
-                isinstance(inner, ast.Call)
-                and isinstance(inner.func, ast.Name)
-                and inner.func.id == "declare_resolution"
-            ):
-                for keyword in inner.keywords:
-                    if keyword.arg:
-                        out[keyword.arg] = max(out.get(keyword.arg, 0), node.lineno)
+        for field in _declared_resolution_fields(path):
+            out[field] = max(out.get(field, 0), node.lineno)
     return out
 
 
 def _pipeline():
     """(ordered steps, {step: methods it reaches}) for the resolution dispatch."""
-    source = (_SRT / "server_args.py").read_text(encoding="utf-8-sig")
-    tree = ast.parse(source)
+    tree = _parsed(_SRT / "server_args.py")
     record = next(
         node
         for node in tree.body
@@ -305,7 +316,7 @@ def _opaque_callback_positions(dispatch, source_module):
     it.
     """
     imported = {}
-    for node in ast.walk(ast.parse(source_module.read_text(encoding="utf-8-sig"))):
+    for node in ast.walk(_parsed(source_module)):
         if isinstance(node, ast.ImportFrom) and node.module:
             for alias in node.names:
                 imported[alias.asname or alias.name] = node.module
@@ -349,7 +360,7 @@ def _opaque_callback_positions(dispatch, source_module):
         path = _SRT / (module[len("sglang.srt.") :].replace(".", "/") + ".py")
         if not path.exists():
             continue
-        for spelling in callbacks_in(ast.parse(path.read_text(encoding="utf-8-sig"))):
+        for spelling in callbacks_in(_parsed(path)):
             positions[spelling] = min(positions.get(spelling, 10**9), node.lineno)
     return positions
 
@@ -392,7 +403,7 @@ def _declaration_positions():
 
     source_module = _SRT / "server_args.py"
     imported = {}
-    for node in ast.walk(ast.parse(source_module.read_text(encoding="utf-8-sig"))):
+    for node in ast.walk(_parsed(source_module)):
         if isinstance(node, ast.ImportFrom) and node.module:
             for alias in node.names:
                 imported[alias.asname or alias.name] = node.module
@@ -405,15 +416,7 @@ def _declaration_positions():
         path = _SRT / (module[len("sglang.srt.") :].replace(".", "/") + ".py")
         if not path.exists():
             return frozenset()
-        fields = set()
-        for node in ast.walk(ast.parse(path.read_text(encoding="utf-8-sig"))):
-            if (
-                isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Name)
-                and node.func.id == "declare_resolution"
-            ):
-                fields |= {kw.arg for kw in node.keywords if kw.arg}
-        return frozenset(fields)
+        return _declared_resolution_fields(path)
 
     declared_at = {}
     for index, step in enumerate(steps):

--- a/test/registered/unit/server_args/test_resolution_reads_no_bag.py
+++ b/test/registered/unit/server_args/test_resolution_reads_no_bag.py
@@ -28,6 +28,7 @@ It is a ratchet, not a proof.
 """
 
 import ast
+import functools
 import inspect
 import pathlib
 import unittest
@@ -114,6 +115,7 @@ def _registry_functions():
     return functions
 
 
+@functools.lru_cache(maxsize=None)
 def _registered_entries():
     """Entries the import map cannot reach: passes and override providers.
 
@@ -138,13 +140,17 @@ def _registered_entries():
     # from the source. The entry carries the *defining* file: `_reaches_a_bag`
     # walks functions in the entry's file, so a call-site key walks nothing.
     by_value = set()
-    trees = {}
-    for path in sorted(_SRT.rglob("*.py")):
+    sources = {
+        path: path.read_text(encoding="utf-8-sig")
+        for path in sorted(_SRT.rglob("*.py"))
+    }
+    for path, source in sources.items():
+        if "run_post_process_pass" not in source:
+            continue
         try:
-            trees[path] = ast.parse(path.read_text(encoding="utf-8-sig"))
+            tree = ast.parse(source)
         except SyntaxError:
             continue
-    for path, tree in trees.items():
         for node in ast.walk(tree):
             if (
                 isinstance(node, ast.Call)
@@ -154,6 +160,14 @@ def _registered_entries():
                 and isinstance(node.args[1], ast.Name)
             ):
                 by_value.add(node.args[1].id)
+    trees = {}
+    for path, source in sources.items():
+        if not any(name in source for name in by_value):
+            continue
+        try:
+            trees[path] = ast.parse(source)
+        except SyntaxError:
+            continue
     for name in sorted(by_value):
         defined_in = [
             path
@@ -173,14 +187,19 @@ def _registered_entries():
     return entries
 
 
-def _reaches_a_bag(path, entry):
-    """Does `entry` in `path` reach a bag accessor, following calls in-module?"""
+@functools.lru_cache(maxsize=None)
+def _functions_in(path):
     tree = ast.parse(path.read_text(encoding="utf-8-sig"))
-    functions = {
+    return {
         node.name: node
         for node in ast.walk(tree)
         if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
     }
+
+
+def _reaches_a_bag(path, entry):
+    """Does `entry` in `path` reach a bag accessor, following calls in-module?"""
+    functions = _functions_in(path)
     seen = set()
 
     def walk(name):

--- a/test/registered/unit/test_chain_read_ratchet.py
+++ b/test/registered/unit/test_chain_read_ratchet.py
@@ -47,8 +47,11 @@ def _declared_by_keyword():
     """Fields named as a keyword at a declaration site."""
     written = set()
     for path in sorted(_SRT.rglob("*.py")):
+        source = path.read_text(encoding="utf-8-sig")
+        if not any(declarer in source for declarer in _DECLARERS):
+            continue
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+            tree = ast.parse(source)
         except SyntaxError:
             raise AssertionError(f"unparsable module in the census: {path}")
         for node in ast.walk(tree):
@@ -293,8 +296,11 @@ def _subtrees_with_their_own_record():
         rel = path.relative_to(_PACKAGE).as_posix()
         if rel.startswith("srt/") or "/" not in rel:
             continue
+        source = path.read_text(encoding="utf-8-sig")
+        if "ServerArgs" not in source:
+            continue
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+            tree = ast.parse(source)
         except SyntaxError:
             continue
         if any(
@@ -333,8 +339,11 @@ def _chain_reads(written):
             under_srt = rel[len("srt/") :]
             if path.name in _OWNERS or under_srt.startswith(_OWNERS[-1]):
                 continue
+        source = path.read_text(encoding="utf-8-sig")
+        if "server_args" not in source:
+            continue
         try:
-            tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+            tree = ast.parse(source)
         except SyntaxError:
             raise AssertionError(f"unparsable module in the census: {rel}")
         if (

--- a/test/registered/unit/test_global_config_read_ratchet.py
+++ b/test/registered/unit/test_global_config_read_ratchet.py
@@ -498,8 +498,11 @@ def _field_reads():
         rel = path.relative_to(_PACKAGE_ROOT).as_posix()
         if rel.startswith(_SLOT_OWNERS):
             continue
+        source = path.read_text()
+        if "get_server_args" not in source:
+            continue
         try:
-            tree = ast.parse(path.read_text())
+            tree = ast.parse(source)
         except SyntaxError:
             continue
         module_direct, module_alias = _collect(rel, tree)
@@ -551,8 +554,11 @@ class TestConfiguredSizeCallSites(CustomTestCase):
             rel = path.relative_to(_PACKAGE_ROOT).as_posix()
             if rel.startswith(_SLOT_OWNERS):
                 continue
+            source = path.read_text()
+            if "configured_" not in source:
+                continue
             try:
-                tree = ast.parse(path.read_text())
+                tree = ast.parse(source)
             except SyntaxError:
                 continue
             for node in ast.walk(tree):
@@ -588,8 +594,11 @@ class TestNoRenamedAccessorImports(CustomTestCase):
         offenders = []
         for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
             rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+            source = path.read_text()
+            if "get_server_args" not in source and "configured_" not in source:
+                continue
             try:
-                tree = ast.parse(path.read_text())
+                tree = ast.parse(source)
             except SyntaxError:
                 continue
             for node in ast.walk(tree):

--- a/test/registered/unit/test_launch_path_reads_configured_sizes.py
+++ b/test/registered/unit/test_launch_path_reads_configured_sizes.py
@@ -8,6 +8,7 @@ reaches, because nothing short of booting a server runs the launcher.
 """
 
 import ast
+import functools
 import pathlib
 import unittest
 
@@ -82,6 +83,7 @@ def _multiprocessing_names(tree):
     return modules, constructors
 
 
+@functools.lru_cache(maxsize=None)
 def _configured_accessors() -> frozenset:
     """The `configured_*_size()` names `runtime_context` exports.
 
@@ -217,10 +219,13 @@ def _launch_paths():
     nothing, which no derivation can reach.
     """
     seen = {}
+    sizes = frozenset(_LIVE_SHADOWED) | _configured_accessors()
     for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
         source = path.read_text()
         # Every spawn shape below names Process, ProcessPoolExecutor or Popen.
         if not any(name in source for name in ("Process", "Popen", "spawn")):
+            continue
+        if not any(name in source for name in sizes):
             continue
         try:
             tree = ast.parse(source)

--- a/test/registered/unit/test_publish_precedes_bag_reads.py
+++ b/test/registered/unit/test_publish_precedes_bag_reads.py
@@ -397,6 +397,9 @@ def _publishing_functions():
         rel = path.relative_to(_PACKAGE_ROOT).as_posix()
         if rel in _PUBLISH_HOMES:
             continue
+        source = path.read_text(encoding="utf-8-sig")
+        if not any(name in source for name in _PUBLISH_NAMES):
+            continue
         mod = _module(rel)
         if mod is None or not mod.publishers:
             continue

--- a/test/registered/unit/test_server_args_namespaces.py
+++ b/test/registered/unit/test_server_args_namespaces.py
@@ -81,8 +81,11 @@ class TestServerArgsNamespaces(CustomTestCase):
         for path in sorted(srt.rglob("*.py")):
             if path.name == "runtime_context.py":
                 continue
+            source = path.read_text(encoding="utf-8-sig")
+            if "runtime_context" not in source:
+                continue
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+                tree = ast.parse(source)
             except SyntaxError:
                 self.fail(f"unparsable module in the census: {path}")
             bindings = collections.defaultdict(set)
@@ -155,8 +158,11 @@ class TestServerArgsNamespaces(CustomTestCase):
         sites = 0
         disagreements = []
         for path in sorted(srt.rglob("*.py")):
+            source = path.read_text(encoding="utf-8-sig")
+            if not any(name in source for name in accessors):
+                continue
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+                tree = ast.parse(source)
             except SyntaxError:
                 self.fail(f"unparsable module in the census: {path}")
             for node in ast.walk(tree):

--- a/test/registered/unit/test_supplied_instance_exposure_ratchet.py
+++ b/test/registered/unit/test_supplied_instance_exposure_ratchet.py
@@ -682,8 +682,11 @@ class TestSuppliedInstanceExposure(CustomTestCase):
         root = _PACKAGE_ROOT
         for path in sorted(root.rglob("*.py")):
             rel = path.relative_to(root).as_posix()
+            source = path.read_text(encoding="utf-8-sig")
+            if "_late_resolution" not in source:
+                continue
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+                tree = ast.parse(source)
             except SyntaxError:
                 self.fail(f"unparsable module in the census: {rel}")
             for node in ast.walk(tree):
@@ -734,6 +737,8 @@ class TestSuppliedInstanceExposure(CustomTestCase):
                             written |= _expanded_override_keys(rel, tree, node, kw)
         return written
 
+    _READS_CACHE = None
+
     def _supplied_instance_reads(self) -> set:
         """Three spellings of the same read: ``server_args.field`` off the
         parameter, ``getattr(server_args, "field", default)`` with a literal
@@ -746,13 +751,18 @@ class TestSuppliedInstanceExposure(CustomTestCase):
         census still does not count -- but those reads are gone for every
         resolution-written field and ``test_chain_read_ratchet.py`` holds them
         at zero, so the gap is no longer where the risk is."""
+        if TestSuppliedInstanceExposure._READS_CACHE is not None:
+            return TestSuppliedInstanceExposure._READS_CACHE
         pairs = set()
         for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
             rel = path.relative_to(_PACKAGE_ROOT).as_posix()
             if rel.startswith(_OWNERS):
                 continue
+            source = path.read_text(encoding="utf-8-sig")
+            if "server_args" not in source:
+                continue
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+                tree = ast.parse(source)
             except SyntaxError:
                 # A silently dropped module shrinks `found` and reads as
                 # intentional surface shrinkage under the bidirectional pin.
@@ -818,6 +828,7 @@ class TestSuppliedInstanceExposure(CustomTestCase):
                         and node.value.value.id == "self"
                     ):
                         pairs.add((rel, node.attr))
+        TestSuppliedInstanceExposure._READS_CACHE = pairs
         return pairs
 
     @staticmethod
@@ -826,8 +837,13 @@ class TestSuppliedInstanceExposure(CustomTestCase):
         written = set()
         for path in sorted(_PACKAGE_ROOT.rglob("*.py")):
             rel = path.relative_to(_PACKAGE_ROOT).as_posix()
+            source = path.read_text(encoding="utf-8-sig")
+            if "record_config_updates" not in source and not (
+                "get_context" in source and "override" in source
+            ):
+                continue
             try:
-                tree = ast.parse(path.read_text(encoding="utf-8-sig"))
+                tree = ast.parse(source)
             except SyntaxError:
                 raise AssertionError(f"unparsable module in the census: {rel}")
             for node in ast.walk(tree):


### PR DESCRIPTION
## Motivation

Shard 7 of `base-a-test-cpu` timed out at 15 minutes on [run 32786070189](https://github.com/sgl-project/sglang/actions/runs/32786070189). Investigating it turned up a family-wide pattern rather than one bad file: the config / runtime-context ratchets each walk the whole `python/sglang` package (3,467 files, 1.31 MB of AST) and several walk it more than once, or re-parse the same module hundreds of times.

Measured on the runner, these eight files cost **507s per CPU run** — roughly one shard's entire budget, spent re-parsing the same tree:

| file | CI |
|---|---:|
| `test_global_config_read_ratchet.py` | 99s |
| `test_chain_read_ratchet.py` | 84s |
| `test_supplied_instance_exposure_ratchet.py` | 69s |
| `server_args/test_model_config_reads_resolved_input.py` | 64s |
| `test_publish_precedes_bag_reads.py` | 61s |
| `server_args/test_resolution_reads_no_bag.py` | 58s |
| `test_launch_path_reads_configured_sizes.py` | 40s |
| `test_server_args_namespaces.py` | 32s |

For calibration: `ast.parse` over the package is 2.75s warm / 7.04s cold, while `read_text` of every file is 0.085s. The parse is the cost, so any guard has to sit before it.

## Modifications

Two mechanisms, no assertion or exemption list touched anywhere.

**Source prefilter.** Every one of these scans matches an AST node by a *literal identifier* — `func.id == "get_server_args"`, `ClassDef.name == "ServerArgs"`, `func.attr in _DECLARERS`, a parameter named `server_args`. An identifier cannot appear in the AST without appearing verbatim in the source text, so a file whose text lacks the token provably contributes nothing and does not need parsing. One `if "<token>" not in source: continue` before `ast.parse`.

Token selectivity over the real tree: `get_server_args` 27/3467 · `configured_` 41/3467 · `_late_resolution` 4/3467 · `ServerArgs` 330/3467 · `server_args` 599/3467.

**Memoization.** Several scans re-parse the same file repeatedly: `_hook_declared_fields` ran **1,968 times**, `runtime_context.py` (1,777 lines) was parsed **559 times** in one test, `server_args.py` (10,745 lines, 24ms/parse) at six separate sites, and `_registered_entries()` ran once per test method over all 1,664 `srt` files. These become `lru_cache`. No tightness question arises — the inputs are identical by construction. Verified there are no `id()`/`is` comparisons on AST nodes and no tree mutation, so sharing parsed trees is safe.

Deliberately **not** tightened to `".server_args"`: `model_runner . server_args . pp_size` is legal Python and a dotted-substring filter would miss it.

## Results

| file | before | after | |
|---|---:|---:|---:|
| `server_args/test_model_config_reads_resolved_input.py` | 9.69s | 0.34s | 28.8x |
| `server_args/test_resolution_reads_no_bag.py` | 13.63s | 0.56s | 24.5x |
| `test_global_config_read_ratchet.py` | 22.42s | 1.52s | 14.7x |
| `test_supplied_instance_exposure_ratchet.py` | 14.96s | 2.02s | 7.4x |
| `test_publish_precedes_bag_reads.py` | 14.98s | 2.13s | 7.0x |
| `test_chain_read_ratchet.py` | 21.33s | 4.37s | 4.9x |
| `test_launch_path_reads_configured_sizes.py` | 8.00s | 2.84s | 2.8x |
| `test_server_args_namespaces.py` | 6.69s | 3.96s | 1.7x |

Local scan time 111.7s → 17.7s. **This does not map onto the CI numbers directly** — a large fixed slice of each CI figure is interpreter startup plus `import torch` / `import sglang` (~10s per file on the runner), which none of this touches. The saving is the scan portion only.

Side effect worth noting: `test_resolution_reads_no_bag` was holding 1,664 parsed trees simultaneously at ~860 MB RSS. It now holds a handful.

## Verification

Every change is proven equivalent, not assumed. Two harnesses, both against the real package:

**Identical-output assertions** — original and patched scan loaded side by side, outputs compared:

```
_field_reads()                      12.116s ->  0.445s  x27.25  identical: True
configured-size call sites           5.406s ->  0.489s  x11.05  identical: True (n=41)
import-rename offenders              6.785s ->  0.534s  x12.71  identical: True
_supplied_instance_reads()           4.918s ->  1.337s          identical: True (n=344)
_override_written_fields()           3.297s ->  0.419s  x 7.87  identical: True (n=23)
_late_resolution_written_fields()    3.056s ->  0.127s  x24.05  identical: True (n=6)
_declared_by_keyword()               2.930s ->  0.139s  x21.14  identical: True (n=118)
_subtrees_with_their_own_record()    2.926s ->  0.573s  x 5.11  identical: True
_chain_reads(<479 SA fields>)       12.288s ->  3.097s  x 3.97  identical: True (n=95)
ALL EQUIVALENCE ASSERTIONS PASSED
```

**Negative control** — the important one. The package is copied, ten synthetic offender modules are injected covering every spelling each predicate knows (bare and module-qualified calls, the `getattr` form, function-local alias, alias-of-alias, module-level alias, `self._sa` parking, `import ... as` renames, borrowed `model_runner.server_args.field`, parked `self.args = scheduler.server_args`, `get_context().override()`, `record_config_updates()`, a second `ServerArgs` subtree) — **including the whitespace-around-the-dot spellings** `ctx . get_server_args() .pp_size` and `model_runner . server_args . pp_size` — and both versions are run against it:

```
_field_reads(): direct              3 vs 3   identical: True
_field_reads(): alias               4 vs 4   identical: True
configured-size call sites         43 vs 43  identical: True
import-rename offenders             3 vs 3   identical: True
_supplied_instance_reads()        347 vs 347 identical: True
_override_written_fields()         25 vs 25  identical: True
_late_resolution_written_fields()   7 vs 7   identical: True
_declared_by_keyword()            121 vs 121 identical: True
_subtrees_with_their_own_record()   2 vs 2   identical: True
_chain_reads(<all SA fields>)      99 vs 99  identical: True
NEGATIVE CONTROL PASSED
```

`_chain_reads` is exercised with a superset written set (all 479 `ServerArgs` field names) so the predicate fires 95 times instead of 1.

`test_server_args_namespaces.py` keeps `sites` at exactly 1990, so its `> 1500` vacuousness guard is untouched.

## For reviewers — three judgment calls

1. **The parseability census narrows.** Five of these scans currently double as "every module in the tree parses" (`raise AssertionError` / `self.fail` on `SyntaxError`). Prefiltering scopes that to token-matching files. The census-integrity argument is intact — a file lacking the token provably contributes nothing — and `test_server_args_namespaces.py` independently parses every `srt` file. What narrows is coverage of `benchmark/`, `lang/`, `multimodal_gen/`, which only `_chain_reads` reached. Dropping just the `_chain_reads` hunk preserves it; that file then lands at ~15s instead of 4.4s.
2. **The `_READS_CACHE` memo** in `test_supplied_instance_exposure_ratchet.py` is a caching change rather than a pure guard. Dropping it lands that file at 3.36s instead of 2.02s.
3. **`_registered_entries()`** now returns a cached `set`. Both current callers only read it; a future in-place mutation would poison the cache.

## Note on `test_chain_read_ratchet.py`

That test is **red on `main` today**, before this PR: both of its cases error with `AssertionError: non-literal key in _minicpm_sala_overrides`, from `arg_groups/overrides.py` (added by #30360). The census aborts before `_chain_reads` ever runs, so the scan is currently dead code and the ratchet is not guarding anything. #36178 fixes that. This PR does not change the outcome either way — `FAILED (errors=2)` before and after — and the before/after timings for that file were taken with an identical neutralization of that one raise applied to both sides, so the comparison is apples-to-apples.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32797284034](https://github.com/sgl-project/sglang/actions/runs/32797284034)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32797283857](https://github.com/sgl-project/sglang/actions/runs/32797283857)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32797283965](https://github.com/sgl-project/sglang/actions/runs/32797283965)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->