### PR TITLE
[CI] Cut repeated tokenizer loads, serial subprocesses and a double scan

### DIFF
--- a/test/registered/bench_fn/test_benchmark_datasets_api.py
+++ b/test/registered/bench_fn/test_benchmark_datasets_api.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import base64
+import functools
 import io
 import json
 import pickle
@@ -59,8 +60,56 @@ from sglang.benchmark.serving import (
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cpu_ci(est_time=40, suite="base-a-test-cpu")
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
 register_cpu_ci(est_time=46, suite="base-c-test-cpu")
+
+
+_BENCH_SERVING_CLI_CASES = {
+    "help": ["--help"],
+    "invalid_distribution": [
+        "--dataset-name",
+        "generated-shared-prefix",
+        "--gsp-group-distribution",
+        "invalid_name",
+    ],
+    "flush_cache_timeout": ["--flush-cache-timeout", "inf"],
+    "zipf_without_alpha": [
+        "--dataset-name",
+        "generated-shared-prefix",
+        "--gsp-group-distribution",
+        "zipf",
+        "--ready-check-timeout-sec",
+        "0",
+    ],
+    "uniform_with_alpha": [
+        "--dataset-name",
+        "generated-shared-prefix",
+        "--gsp-group-distribution",
+        "uniform",
+        "--gsp-zipf-alpha",
+        "1.0",
+        "--ready-check-timeout-sec",
+        "0",
+    ],
+}
+
+
+@functools.lru_cache(maxsize=1)
+def _bench_serving_cli_results():
+    def run(args):
+        return subprocess.run(
+            [sys.executable, "-m", "sglang.benchmark.serving", *args],
+            capture_output=True,
+            text=True,
+            timeout=180,
+        )
+
+    with ThreadPoolExecutor(max_workers=len(_BENCH_SERVING_CLI_CASES)) as pool:
+        futures = {
+            name: pool.submit(run, args)
+            for name, args in _BENCH_SERVING_CLI_CASES.items()
+        }
+    return {name: future.result() for name, future in futures.items()}
 
 
 class _DummyTokenTensor:
@@ -1363,12 +1412,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
         # Subprocess-driven coverage of the live CLI: --help advertises both
         # flags with the rank-based Zipf formula and the alpha constraint,
         # and argparse rejects an unknown distribution choice.
-        help_res = subprocess.run(
-            [sys.executable, "-m", "sglang.benchmark.serving", "--help"],
-            capture_output=True,
-            text=True,
-            timeout=90,
-        )
+        help_res = _bench_serving_cli_results()["help"]
         self.assertEqual(help_res.returncode, 0, help_res.stderr)
         out = help_res.stdout
         # Both new flags appear.
@@ -1380,37 +1424,13 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
         self.assertIn("finite float", out)
 
         # Argparse rejects unknown distribution choice.
-        bad_choice_res = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "sglang.benchmark.serving",
-                "--dataset-name",
-                "generated-shared-prefix",
-                "--gsp-group-distribution",
-                "invalid_name",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=90,
-        )
+        bad_choice_res = _bench_serving_cli_results()["invalid_distribution"]
         self.assertNotEqual(bad_choice_res.returncode, 0)
         self.assertIn("invalid choice", (bad_choice_res.stderr + bad_choice_res.stdout))
 
     def test_serving_benchmark_cli_rejects_invalid_flush_cache_timeout(self):
         """Invalid timeouts fail before the benchmark contacts a server or hangs."""
-        res = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "sglang.benchmark.serving",
-                "--flush-cache-timeout",
-                "inf",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=90,
-        )
+        res = _bench_serving_cli_results()["flush_cache_timeout"]
         self.assertEqual(res.returncode, 2, res.stderr)
         self.assertIn("expected a finite float > 0", res.stderr)
 
@@ -1423,22 +1443,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
         # Malformed CLI combinations (zipf with no alpha) must fail at
         # argparse time so users see the GSP-flag error directly, not a
         # downstream connection or model-fetch failure.
-        res = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "sglang.benchmark.serving",
-                "--dataset-name",
-                "generated-shared-prefix",
-                "--gsp-group-distribution",
-                "zipf",
-                "--ready-check-timeout-sec",
-                "0",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=90,
-        )
+        res = _bench_serving_cli_results()["zipf_without_alpha"]
         # parser.error() exits with code 2 (argparse convention).
         self.assertEqual(res.returncode, 2, res.stderr)
         stderr = res.stderr + res.stdout
@@ -1458,24 +1463,7 @@ class TestBenchmarkDatasetsAPI(CustomTestCase):
     def test_bench_serving_cli_rejects_uniform_with_alpha_before_server(self):
         # The complementary malformation: uniform distribution with an
         # explicit alpha value. Must also fail at argparse time.
-        res = subprocess.run(
-            [
-                sys.executable,
-                "-m",
-                "sglang.benchmark.serving",
-                "--dataset-name",
-                "generated-shared-prefix",
-                "--gsp-group-distribution",
-                "uniform",
-                "--gsp-zipf-alpha",
-                "1.0",
-                "--ready-check-timeout-sec",
-                "0",
-            ],
-            capture_output=True,
-            text=True,
-            timeout=90,
-        )
+        res = _bench_serving_cli_results()["uniform_with_alpha"]
         self.assertEqual(res.returncode, 2, res.stderr)
         stderr = res.stderr + res.stdout
         self.assertIn("--gsp-group-distribution", stderr)

--- a/test/registered/kernels/ops/diffusion/test_import_surface.py
+++ b/test/registered/kernels/ops/diffusion/test_import_surface.py
@@ -14,6 +14,7 @@ resolve them with ``importlib``/``ast`` without importing torch backends.
 """
 
 import ast
+import functools
 import importlib
 import pathlib
 import subprocess
@@ -25,7 +26,7 @@ from sglang.kernels.ops.diffusion import _EXPORTS, _SPECS
 from sglang.kernels.registry import registry
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+register_cpu_ci(est_time=25, suite="base-a-test-cpu")
 
 PACKAGE = "sglang.kernels.ops.diffusion"
 _PACKAGE_DIR = pathlib.Path(importlib.import_module(PACKAGE).__file__ or "").parent
@@ -74,6 +75,52 @@ def _module_defines(module_path: str) -> set[str]:
     return names
 
 
+@functools.lru_cache(maxsize=None)
+def _scan_root(root: str) -> tuple[frozenset[str], tuple[str, ...]]:
+    unexported: set[str] = set()
+    offenders: list[str] = []
+    root_dir = _REPO_ROOT / root
+    if not root_dir.exists():
+        return frozenset(), ()
+
+    for path in root_dir.rglob("*.py"):
+        rel = path.relative_to(_REPO_ROOT).as_posix()
+        if rel.startswith("python/sglang/kernels/ops/diffusion/"):
+            continue
+        try:
+            source = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            continue
+        if PACKAGE not in source:
+            continue
+        try:
+            tree = ast.parse(source)
+        except SyntaxError:
+            continue
+        allowlisted = rel in _DEEP_IMPORT_ALLOWLIST
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                if node.module == PACKAGE:
+                    unexported.update(
+                        a.name
+                        for a in node.names
+                        if a.name not in _EXPORTS and not a.name.startswith("_")
+                    )
+                elif (
+                    not allowlisted
+                    and node.module
+                    and node.module.startswith(f"{PACKAGE}.")
+                ):
+                    offenders.append(f"{rel}:{node.lineno} imports {node.module}")
+            elif isinstance(node, ast.Import) and not allowlisted:
+                offenders.extend(
+                    f"{rel}:{node.lineno} imports {a.name}"
+                    for a in node.names
+                    if a.name.startswith(f"{PACKAGE}.")
+                )
+    return frozenset(unexported), tuple(offenders)
+
+
 def test_every_export_resolves_to_a_real_symbol():
     missing = [
         f"{symbol} -> {module}"
@@ -92,26 +139,9 @@ def test_every_symbol_imported_from_the_facade_is_exported():
     or code path runs, on the platform that has the backend.  Enumerating the
     call sites catches it here instead.
     """
-    unexported = set()
+    unexported: set[str] = set()
     for root in ("python/sglang", "test", "benchmark"):
-        root_dir = _REPO_ROOT / root
-        if not root_dir.exists():
-            continue
-        for path in root_dir.rglob("*.py"):
-            rel = path.relative_to(_REPO_ROOT).as_posix()
-            if rel.startswith("python/sglang/kernels/ops/diffusion/"):
-                continue
-            try:
-                tree = ast.parse(path.read_text(encoding="utf-8"))
-            except (SyntaxError, UnicodeDecodeError):
-                continue
-            for node in ast.walk(tree):
-                if isinstance(node, ast.ImportFrom) and node.module == PACKAGE:
-                    unexported.update(
-                        a.name
-                        for a in node.names
-                        if a.name not in _EXPORTS and not a.name.startswith("_")
-                    )
+        unexported.update(_scan_root(root)[0])
     assert not unexported, f"imported but not in _EXPORTS: {sorted(unexported)}"
 
 
@@ -174,34 +204,10 @@ def test_importing_the_package_does_not_import_any_leaf_module():
 
 @pytest.mark.parametrize("root", ["python/sglang", "test", "benchmark"])
 def test_runtime_code_imports_only_through_the_facade(root):
-    root_dir = _REPO_ROOT / root
-    if not root_dir.exists():  # source checkouts only
+    if not (_REPO_ROOT / root).exists():  # source checkouts only
         pytest.skip(f"{root} not present in this install")
 
-    offenders = []
-    for path in root_dir.rglob("*.py"):
-        rel = path.relative_to(_REPO_ROOT).as_posix()
-        if rel.startswith("python/sglang/kernels/ops/diffusion/"):
-            continue  # intra-package imports are the point of the subpackages
-        if rel in _DEEP_IMPORT_ALLOWLIST:
-            continue
-        try:
-            tree = ast.parse(path.read_text(encoding="utf-8"))
-        except (SyntaxError, UnicodeDecodeError):
-            continue
-        for node in ast.walk(tree):
-            if (
-                isinstance(node, ast.ImportFrom)
-                and node.module
-                and node.module.startswith(f"{PACKAGE}.")
-            ):
-                offenders.append(f"{rel}:{node.lineno} imports {node.module}")
-            elif isinstance(node, ast.Import):
-                offenders.extend(
-                    f"{rel}:{node.lineno} imports {a.name}"
-                    for a in node.names
-                    if a.name.startswith(f"{PACKAGE}.")
-                )
+    offenders = _scan_root(root)[1]
     assert not offenders, (
         "import from sglang.kernels.ops.diffusion instead of a submodule:\n  "
         + "\n  ".join(offenders)

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -1,3 +1,4 @@
+import functools
 import json
 import unittest
 import warnings
@@ -33,8 +34,15 @@ from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
 register_cpu_ci(est_time=70, suite="base-c-test-cpu")
+
+
+@functools.lru_cache(maxsize=None)
+def _shared_tokenizer(path: str):
+    from sglang.srt.utils.hf_transformers_utils import get_tokenizer
+
+    return get_tokenizer(path)
 
 
 class TestInklingDetector(unittest.TestCase):
@@ -1599,9 +1607,7 @@ class TestDeepSeekV32Detector(unittest.TestCase):
             ),
         ]
         self.detector = DeepSeekV32Detector()
-        from sglang.srt.utils.hf_transformers_utils import get_tokenizer
-
-        self.tokenizer = get_tokenizer("deepseek-ai/DeepSeek-V3.2")
+        self.tokenizer = _shared_tokenizer("deepseek-ai/DeepSeek-V3.2")
         self.interval = 1
 
     def test_detect_and_parse_xml_format(self):
@@ -2049,9 +2055,7 @@ class TestDeepSeekV4Detector(unittest.TestCase):
             ),
         ]
         self.detector = DeepSeekV4Detector()
-        from sglang.srt.utils.hf_transformers_utils import get_tokenizer
-
-        self.tokenizer = get_tokenizer("deepseek-ai/DeepSeek-V3.2")
+        self.tokenizer = _shared_tokenizer("deepseek-ai/DeepSeek-V3.2")
         self.interval = 1
 
     def test_detect_and_parse_xml_format(self):


### PR DESCRIPTION
## Motivation

Follow-up to the shard-7 timeout on [run 32786070189](https://github.com/sgl-project/sglang/actions/runs/32786070189). Sweeping every CPU test over 30s turned up three expensive files whose cost is **not** the package-AST-scan pattern the sibling PRs address — each has a different root cause, and each is fixable without touching an assertion.

Calibration used throughout: CI runs each file as its own `python3 <file>` subprocess and times the whole thing, so ~10s of every CI number below is fixed floor (interpreter + `import torch` + `import sglang`). The mode across all 444 files in a real shard is exactly 10s.

## Modifications

### `unit/function_call/test_function_call_parser.py` — CI 57s

`TestDeepSeekV32Detector.setUp` and `TestDeepSeekV4Detector.setUp` each call `get_tokenizer("deepseek-ai/DeepSeek-V3.2")`, so a real HF tokenizer is constructed **15 times per run for the same model**. `get_tokenizer` does no caching. Measured in isolation: 2.6s per call online, 0.77s with `HF_HUB_OFFLINE=1` — so ~0.75s is parsing DeepSeek's large `tokenizer.json` and ~1.9s is hub round-trips. Locally the file spends 45.92s wall against only 14.67s user: **~30s blocked on network**.

Only 6 of the 15 tests touch `self.tokenizer` at all, and only through `.encode()` / `.decode()` — read-only, safe to share. Wrapped in `functools.lru_cache`.

Worth noting beyond the speed: this removes 15 HF hub round-trips per CI run, which is a flakiness surface as much as a slow one.

### `bench_fn/test_benchmark_datasets_api.py` — CI 67s

Four tests launch five sequential `python -m sglang.benchmark.serving` subprocesses to exercise the live CLI. Each launch costs 4.68s, of which ~2.5s is top-level `import sglang` (transformers → sklearn, torchvision) and ~1s is `disaggregation.utils` → `model_config` → quantization. 21.45s of the file's 22.2s of test time is those five launches.

They are independent and their assertions are untouched, so they now run concurrently behind an `lru_cache`d helper. Measured `sequential 23.72s → parallel-5 5.21s`, stdout byte-identical across modes. Peak child RSS goes 635MB → ~3.2GB for five concurrent, comfortable on the runner.

### `kernels/ops/diffusion/test_import_surface.py` — CI 63s

This one **is** a package scan — it walks all 5,479 `.py` files and `ast.parse`s them, and it does so **twice**, once for `test_every_symbol_imported_from_the_facade_is_exported` and once for `test_runtime_code_imports_only_through_the_facade`. 15.16s of its 17.94s of test time is parsing the repo two times over.

Replaced with a single `lru_cache`d pass per root that collects both results, plus a substring prefilter on the package name. Measured: 5,478 files parsed today vs **65** with the prefilter; one full pass 8.48s → 0.45s.

The 2.69s subprocess test is irreducible — a fresh interpreter importing `sglang` is exactly what it asserts.

## Results

| file | before | after | |
|---|---:|---:|---:|
| `unit/function_call/test_function_call_parser.py` | 45.92s | 3.14s | 226 tests, OK both |
| `kernels/ops/diffusion/test_import_surface.py` | 21.12s | 7.61s | 9 passed both |
| `bench_fn/test_benchmark_datasets_api.py` | 26.88s | 10.96s | 45 passed + 6 subtests both |

Equivalence for `test_import_surface` was proven by running both algorithms and diffing raw hits: 280 facade-import names identical, 8 deep-import hits identical (all 8 are the four allowlisted files).

## `est_time` corrections

All three were mis-registered, which is what misleads the shard partitioner. Updated to the post-patch estimates:

| file | was | now |
|---|---:|---:|
| `kernels/ops/diffusion/test_import_surface.py` | 4 | 25 |
| `bench_fn/test_benchmark_datasets_api.py` | 40 | 30 |
| `unit/function_call/test_function_call_parser.py` | 15 | 20 |

Two of these also carry `base-c-test-cpu` registrations (46 and 70). I have no base-c wall times to correct them from, so they are left alone — but the same causes apply there, especially the 15 tokenizer loads, so they are worth a look from someone with that data.

## For reviewers — two judgment calls

1. **The `test_import_surface` prefilter rests on a weaker argument than the sibling PR's.** `from a . b import c` is legal Python with whitespace around the dots, which a substring gate would miss. black normalizes it and no such file exists in the tree today — but that is true-now, not true-by-construction. **Dropping the prefilter and keeping only the shared cached pass still halves the scan (15.16s → ~8.5s)** with no such caveat, if you prefer that trade.
2. **`test_benchmark_datasets_api`**: after this change, running a single CLI test under `-k` launches all five subprocesses rather than one.

## Not changed: `unit/spec/test_dflash_logits.py`

Investigated as part of the same sweep and deliberately left alone. Its 32s (against `est_time=1`, the worst ratio in the fleet) is cold CPU Inductor compilation of the three `@torch.compile(dynamic=True)` functions in `models/dflash.py`. A cold compile of a comparably sized function measures 6.51s with subsequent dynamic shapes at 0.00s; two cold compiles at CI single-core speed plus the 10s floor reproduces 32s. The only lever is running those two tests eagerly, which would delete the compiled-path coverage both docstrings explicitly claim — with `dynamic=True` the guard behavior *is* the thing under test. It needs an `est_time` fix (1 → 35), not a code change; sent separately so it can be merged independently.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32797290471](https://github.com/sgl-project/sglang/actions/runs/32797290471)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32797290285](https://github.com/sgl-project/sglang/actions/runs/32797290285)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32797290428](https://github.com/sgl-project/sglang/actions/runs/32797290428)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->