### PR TITLE
[CI] Register test_dflash_logits at its real cost

### DIFF
--- a/test/registered/unit/spec/test_dflash_logits.py
+++ b/test/registered/unit/spec/test_dflash_logits.py
@@ -12,7 +12,7 @@ from sglang.srt.models.dflash import (
 from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
 from sglang.test.ci.ci_register import register_cpu_ci
 
-register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_cpu_ci(est_time=35, suite="base-a-test-cpu")
 
 
 def test_dflash_unary_logit_transform():


### PR DESCRIPTION
## Motivation

`test/registered/unit/spec/test_dflash_logits.py` is registered at `est_time=1` and actually takes **32s** on `base-a-test-cpu` — a 32x underestimate, the worst ratio of any CPU test in the suite. The shard partitioner (`scripts/ci/utils/compute_partitions.py`) uses this number when the live per-file estimate from `sglang-ci-stats` is missing, so a 1s registration lets it pack a shard as if this file were free.

This surfaced while investigating the shard-7 timeout on [run 32786070189](https://github.com/sgl-project/sglang/actions/runs/32786070189).

## Modifications

`est_time` 1 → 35. No code change, deliberately.

## Why there is no code change

The cost is cold CPU Inductor compilation, not anything the test does wrong. `python/sglang/srt/models/dflash.py` has three `@torch.compile(dynamic=True, backend=get_compiler_backend(), disable=_is_npu)` functions — `_grouped_conv` (line 347), `_score_edges` (789), `_follow_maps` (814) — and `get_compiler_backend()` returns `"inductor"` on the CPU lane (`utils/common.py:1020`). Two tests drive them:

- `test_grouped_conv_supports_runtime_block_sizes` → `_grouped_conv`
- `test_selector_greedy_row_walk_is_deterministic_in_a_mixed_batch` → `sample_path` → the non-CUDA branch → `_follow_maps`

Quantified in a clean process with no sglang import: a cold CPU Inductor compile of a comparably sized function is **6.51s**, and subsequent dynamic shapes are **0.00s**. Two cold compiles at CI single-core speed (~2.5-3x slower than the measurement box), on top of the ~10s per-file interpreter + import floor, reproduces the observed 32s. Sibling spec tests that do not compile land at 19-21s.

Two optimizations were measured and rejected:

- **Lazy-importing the triton kernel.** `sglang.srt.models.dflash` eagerly does `from sglang.kernels.ops.speculative.dflash import selector_walk_triton`, which does a bare unguarded `import triton`. But `sglang.srt.layers.linear` already pulls in 60 `sglang.kernels.*` modules; adding the speculative one takes the count to 61. No win.
- **Shrinking the block-size loop.** The extra sizes cost 0.00s — the compile is cold exactly once.

The only remaining lever is running those two tests eagerly (`torch._dynamo.disable` / `.__wrapped__`), which would remove ~20s but delete the compiled-path coverage both docstrings explicitly claim ("must follow whatever block size the worker resolved", "one captured graph serves greedy and sampling batches alike"). With `dynamic=True`, the dynamic-shape guard behaviour *is* the thing under test. Not worth trading.

So the right fix is to tell the partitioner the truth and leave the test alone.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32797293529](https://github.com/sgl-project/sglang/actions/runs/32797293529)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32797293120](https://github.com/sgl-project/sglang/actions/runs/32797293120)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32797293124](https://github.com/sgl-project/sglang/actions/runs/32797293124)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->