### PR TITLE
trace: propagate W3C trace context through Mooncake PD boundary

### DIFF
--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -8,7 +8,7 @@ import struct
 import threading
 import time
 from collections import defaultdict
-from typing import List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2259,6 +2259,7 @@ class MooncakeFailureExceptionMixin:
 
 
 class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
+    supports_external_trace_header = True
 
     def __init__(
         self,

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2268,6 +2268,7 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         dest_tp_ranks: List[int],
         pp_rank: int,
         req_has_disagg_prefill_dp_rank: bool = False,
+        external_trace_header: Optional[Dict[str, str]] = None,
     ):
         super().__init__(
             mgr,
@@ -2279,7 +2280,7 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         )
         self.conclude_state = None
         self.init_time = time.time()
-        self._init_trace_ctx()
+        self._init_trace_ctx(external_trace_header)
 
     @mooncake_trace_func(MooncakeRequestStage.MOONCAKE_SEND)
     def send(
@@ -2338,13 +2339,14 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         else:
             return self.conclude_state
 
-    def _init_trace_ctx(self):
+    def _init_trace_ctx(self, external_trace_header: Optional[Dict[str, str]] = None):
         if self.kv_mgr.enable_trace:
             self.trace_ctx = TraceReqContext(
                 rid=str(hex(self.bootstrap_room)),
                 bootstrap_room=self.bootstrap_room,
                 role="Sender",
                 module_name="mooncake",
+                external_trace_header=external_trace_header,
             )
             if not self.trace_ctx.tracing_enable:
                 self.trace_ctx = TraceNullContext()

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -20,6 +20,7 @@ Life cycle of a request in the prefill server
 from __future__ import annotations
 
 import hashlib
+import inspect
 import logging
 from array import array
 from collections import deque
@@ -319,24 +320,19 @@ class PrefillBootstrapQueue:
             pp_rank=self.pp_rank,
             req_has_disagg_prefill_dp_rank=req.disagg_prefill_dp_rank is not None,
         )
-        # Propagate trace context to KV sender so Mooncake transfer spans
-        # link to the parent request's trace (W3C traceparent).
-        import inspect as _inspect
+        # Link Mooncake transfer spans to the parent request's W3C trace.
+        if "external_trace_header" in inspect.signature(
+            kv_sender_class.__init__
+        ).parameters:
+            trace_ctx = getattr(req.time_stats, "trace_ctx", None)
+            if getattr(trace_ctx, "tracing_enable", False):
+                root = getattr(trace_ctx, "root_span_context", None)
+                if root is not None:
+                    carrier: Dict[str, str] = {}
+                    from opentelemetry import propagate
 
-        if (
-            "external_trace_header"
-            in _inspect.signature(kv_sender_class.__init__).parameters
-        ):
-            _trace_carrier: Dict[str, str] = {}
-            _trace_ctx = getattr(
-                getattr(req.time_stats, "trace_ctx", None), "root_span_context", None
-            )
-            if _trace_ctx is not None:
-                from opentelemetry import propagate
-
-                propagate.inject(_trace_carrier, _trace_ctx)
-            if _trace_carrier:
-                _sender_kwargs["external_trace_header"] = _trace_carrier
+                    propagate.inject(carrier, root)
+                    _sender_kwargs["external_trace_header"] = carrier
         req.disagg_kv_sender = kv_sender_class(**_sender_kwargs)
         self._process_req(req)
         req.pending_bootstrap = True

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -311,7 +311,7 @@ class PrefillBootstrapQueue:
 
         dest_tp_ranks = [self.tp_rank]
 
-        req.disagg_kv_sender = kv_sender_class(
+        _sender_kwargs = dict(
             mgr=self.kv_manager,
             bootstrap_addr=f"{req.bootstrap_host}:{self.bootstrap_port}",
             bootstrap_room=req.bootstrap_room,
@@ -319,6 +319,18 @@ class PrefillBootstrapQueue:
             pp_rank=self.pp_rank,
             req_has_disagg_prefill_dp_rank=req.disagg_prefill_dp_rank is not None,
         )
+        # Propagate trace context to KV sender so Mooncake transfer spans
+        # link to the parent request's trace (W3C traceparent).
+        import inspect as _inspect
+        if "external_trace_header" in _inspect.signature(kv_sender_class.__init__).parameters:
+            _trace_carrier: Dict[str, str] = {}
+            _trace_ctx = getattr(getattr(req.time_stats, "trace_ctx", None), "root_span_context", None)
+            if _trace_ctx is not None:
+                from opentelemetry import propagate
+                propagate.inject(_trace_carrier, _trace_ctx)
+            if _trace_carrier:
+                _sender_kwargs["external_trace_header"] = _trace_carrier
+        req.disagg_kv_sender = kv_sender_class(**_sender_kwargs)
         self._process_req(req)
         req.pending_bootstrap = True
         return True

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -20,7 +20,6 @@ Life cycle of a request in the prefill server
 from __future__ import annotations
 
 import hashlib
-import inspect
 import logging
 from array import array
 from collections import deque
@@ -321,9 +320,7 @@ class PrefillBootstrapQueue:
             req_has_disagg_prefill_dp_rank=req.disagg_prefill_dp_rank is not None,
         )
         # Link Mooncake transfer spans to the parent request's W3C trace.
-        if "external_trace_header" in inspect.signature(
-            kv_sender_class.__init__
-        ).parameters:
+        if getattr(kv_sender_class, "supports_external_trace_header", False):
             trace_ctx = getattr(req.time_stats, "trace_ctx", None)
             if getattr(trace_ctx, "tracing_enable", False):
                 root = getattr(trace_ctx, "root_span_context", None)

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -24,7 +24,7 @@ import logging
 from array import array
 from collections import deque
 from http import HTTPStatus
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 import torch
@@ -322,11 +322,18 @@ class PrefillBootstrapQueue:
         # Propagate trace context to KV sender so Mooncake transfer spans
         # link to the parent request's trace (W3C traceparent).
         import inspect as _inspect
-        if "external_trace_header" in _inspect.signature(kv_sender_class.__init__).parameters:
+
+        if (
+            "external_trace_header"
+            in _inspect.signature(kv_sender_class.__init__).parameters
+        ):
             _trace_carrier: Dict[str, str] = {}
-            _trace_ctx = getattr(getattr(req.time_stats, "trace_ctx", None), "root_span_context", None)
+            _trace_ctx = getattr(
+                getattr(req.time_stats, "trace_ctx", None), "root_span_context", None
+            )
             if _trace_ctx is not None:
                 from opentelemetry import propagate
+
                 propagate.inject(_trace_carrier, _trace_ctx)
             if _trace_carrier:
                 _sender_kwargs["external_trace_header"] = _trace_carrier


### PR DESCRIPTION
## Problem

PR #23755 added Mooncake KV transfer tracing but deliberately did not propagate the request's trace context (W3C `traceparent`) across the PD disaggregation boundary. The `MooncakeKVSender` creates a new `TraceReqContext` with no link to the parent request's trace, so prefiller/decoder transfer spans appear as **separate traces** in Jaeger instead of joining the router's root span.

## Root Cause

`MooncakeKVSender._init_trace_ctx` (in `disaggregation/mooncake/conn.py`) creates:
```python
TraceReqContext(rid=..., bootstrap_room=..., role="Sender", module_name="mooncake")
```
without passing `external_trace_header`. `TraceReqContext` already supports `external_trace_header` (used in `trace_req_start` to extract the parent context via `_trace_context_propagator.extract`), but the Mooncake sender never passes it.

## Fix

Two small changes:

### 1. `disaggregation/mooncake/conn.py`
`MooncakeKVSender.__init__` accepts `external_trace_header` and passes it to `_init_trace_ctx`, which forwards it to `TraceReqContext`. The extracted W3C context becomes the parent of the transfer spans.

### 2. `disaggregation/prefill.py`
Before creating the KV sender, inject the request's `root_span_context` (which survives pickle serialization via `__getstate__`) into a W3C carrier and pass it as `external_trace_header`. Uses `inspect` to conditionally pass only to senders that accept it (`FakeKVSender` and other backends remain unaffected).

## Result

End-to-end traces join from router to prefiller HTTP to Mooncake KV transfer to decoder, with all stages visible as child spans of a single trace in Jaeger/OTLP collectors.

A joined trace shows 28-29 spans per request including:
- `prefill_waiting` (queue wait)
- `prefill_forward` (prefill compute)
- `prefill_transfer_kv_cache` (Mooncake KV transfer)
- `mooncake_send` / `mooncake_recv` (transfer slices)
- `decode_bootstrap` / `decode_prepare`

## Testing

Tested on a 3P4D GLM-5.2 NVFP4 cluster with Mooncake RDMA transfer backend and `sgl-model-gateway` router (with `--enable-trace --otlp-traces-endpoint`):
- Router injects `traceparent` header into HTTP requests to prefillers (verified via `tcpdump`)
- Prefiller extracts `traceparent` and creates child span (verified via debug log)
- Mooncake sender now links to parent trace (verified: joined traces with matching 128-bit trace IDs in Jaeger)
- `FakeKVSender` and non-Mooncake backends unaffected (inspect guards the kwarg)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32919649947](https://github.com/sgl-project/sglang/actions/runs/32919649947)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32919649588](https://github.com/sgl-project/sglang/actions/runs/32919649588)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32919649642](https://github.com/sgl-project/sglang/actions/runs/32919649642)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->