### PR TITLE
[AMD] Add Kimi-K2.7-Code-MXFP4 to cookbook

### DIFF
--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
@@ -98,7 +98,7 @@ import { KimiK27CodeDeployment } from '/src/snippets/autoregressive/kimi-k27-cod
 - **Reasoning Parser**: Add `--reasoning-parser kimi_k2` to separate thinking and content in model outputs.
 - **Tool Call Parser**: Add `--tool-call-parser kimi_k2` for structured tool calls.
 - **AMD FP8 KV Cache**: On AMD platforms the generator adds `--kv-cache-dtype fp8_e4m3` by default and sets `--mem-fraction-static 0.8` to fit the INT4 weights plus KV cache. FP8 KV cache trades a small amount of accuracy for memory; omit the flag if you observe accuracy regressions on your workload.
-- **MXFP4 Checkpoint**: The [MXFP4 checkpoint](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4) is validated on MI350X/MI355X (TP=4) with the `rocm/sgl-dev:v0.5.16-rocm720-mi35x-20260804` image (ROCm 7.2). Select `MXFP4` in the Quantization control to target `amd/Kimi-K2.7-Code-MXFP4`. The MXFP4 quantization is auto-detected from the checkpoint, so no `--quantization` flag is required; the generator uses `--mem-fraction-static 0.765` and FP8 KV cache for MXFP4.
+- **MXFP4 Checkpoint**: The [MXFP4 checkpoint](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4) is validated on MI350X/MI355X (TP=4) with the `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260812` image (ROCm 7.2). Select `MXFP4` in the Quantization control to target `amd/Kimi-K2.7-Code-MXFP4`. The MXFP4 quantization is auto-detected from the checkpoint, so no `--quantization` flag is required; the generator emits the AITER/ROCm environment block plus `--attention-backend aiter`, `--mem-fraction-static 0.90`, FP8 KV cache, `--disable-radix-cache`, and `--enable-aiter-allreduce-fusion`. The reasoning and tool-call parsers are auto-detected, so they are not passed explicitly.
 
 ## 4. Model Invocation
 
@@ -504,18 +504,29 @@ sglang serve \
 
 For GB300, use `--tp 4`.
 
-Deploy the MXFP4 checkpoint on AMD MI350X/MI355X:
+Deploy the MXFP4 checkpoint on AMD MI350X/MI355X (reasoning and tool-call parsers are auto-detected from the checkpoint):
 
 ```shell Command
-SGLANG_USE_AITER=1 SGLANG_ROCM_FUSED_DECODE_MLA=0 \
+SGLANG_USE_AITER=1 \
+HIP_FORCE_DEV_KERNARG=1 \
+SGLANG_EXPERT_PARALLEL_SIZE=1 \
+SGLANG_USE_DYNAMIC_MXFP4_LINEAR=0 \
+TORCH_BLAS_PREFER_HIPBLASLT=1 \
+TENSILE_STREAMK_DYNAMIC_GRID=6 \
+AITER_QUICK_REDUCE_QUANTIZATION=INT4 \
+AITER_USE_FLYDSL_MOE_SORTING=1 \
+AITER_AR_1STAGE_MAX_KB=512 \
+AITER_MXFP4_INTERMEDIATE=1 \
+ROCM_QUICK_REDUCE_QUANTIZATION=INT4 \
 sglang serve \
   --model-path amd/Kimi-K2.7-Code-MXFP4 \
   --tp 4 \
-  --mem-fraction-static 0.765 \
   --trust-remote-code \
-  --reasoning-parser kimi_k2 \
-  --tool-call-parser kimi_k2 \
+  --attention-backend aiter \
+  --mem-fraction-static 0.90 \
   --kv-cache-dtype fp8_e4m3 \
+  --disable-radix-cache \
+  --enable-aiter-allreduce-fusion \
   --host 0.0.0.0 \
   --port 30000
 ```

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
@@ -533,7 +533,7 @@ sglang serve \
 
 ## 5. Benchmark
 
-### 5.1 Model Card Benchmarks (Official)
+### 5.1 Model Card Benchmarks
 
 The following results are from the official Kimi-K2.7-Code model card. They were evaluated with thinking mode enabled through Kimi Code CLI at `temperature=1.0`, `top_p=0.95`, and a 262,144-token context length unless otherwise stated.
 

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
@@ -533,6 +533,53 @@ sglang serve \
 
 ## 5. Benchmark
 
+### 5.1 Accuracy Benchmark
+
+**Test Environment:**
+
+- Hardware: 4× AMD MI355X
+- Model: `amd/Kimi-K2.7-Code-MXFP4` (MXFP4)
+- Tensor Parallelism: 4
+- Docker Image: `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260812` (ROCm 7.2)
+
+GSM8K accuracy of the MXFP4 checkpoint, measured on the deployed server across several client parallelism levels (2,000 questions each):
+
+```shell Command
+python3 benchmark/gsm8k/bench_sglang.py \
+  --num-questions 2000 \
+  --parallel <PARALLEL> \
+  --port 30000
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Parallel</th>
+      <th>GSM8K Accuracy</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>100</td>
+      <td>0.951</td>
+    </tr>
+    <tr>
+      <td>300</td>
+      <td>0.953</td>
+    </tr>
+    <tr>
+      <td>600</td>
+      <td>0.942</td>
+    </tr>
+    <tr>
+      <td>1200</td>
+      <td>0.950</td>
+    </tr>
+  </tbody>
+</table>
+
+#### Model Card Reference (Official)
+
 The following results are from the official Kimi-K2.7-Code model card. They were evaluated with thinking mode enabled through Kimi Code CLI at `temperature=1.0`, `top_p=0.95`, and a 262,144-token context length unless otherwise stated.
 
 <table>
@@ -580,6 +627,94 @@ The following results are from the official Kimi-K2.7-Code model card. They were
       <td>MCP Mark Verified</td>
       <td>72.8</td>
       <td>81.1</td>
+    </tr>
+  </tbody>
+</table>
+
+### 5.2 Speed Benchmark
+
+**Test Environment:**
+
+- Hardware: 4× AMD MI355X
+- Model: `amd/Kimi-K2.7-Code-MXFP4` (MXFP4)
+- Tensor Parallelism: 4
+- Docker Image: `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260812` (ROCm 7.2)
+
+We use SGLang's built-in `bench_serving` tool with the `random` dataset (input 8192, output 1024, range ratio 0.8). For each concurrency `C`, `--num-prompts` is set to `C × 5`.
+
+#### 5.2.1 Latency Benchmark
+
+```shell Command
+python3 -m sglang.bench_serving \
+  --backend sglang \
+  --model amd/Kimi-K2.7-Code-MXFP4 \
+  --dataset-name random \
+  --random-input-len 8192 \
+  --random-output-len 1024 \
+  --random-range-ratio 0.8 \
+  --max-concurrency <C> \
+  --num-prompts <C x 5> \
+  --host 0.0.0.0 \
+  --port 30000
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Concurrency</th>
+      <th>Output Throughput (tok/s)</th>
+      <th>Total Throughput (tok/s)</th>
+      <th>Mean TTFT (ms)</th>
+      <th>Median TTFT (ms)</th>
+      <th>Mean TPOT (ms)</th>
+      <th>Mean E2E Latency (ms)</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>4</td>
+      <td>416.22</td>
+      <td>3747.97</td>
+      <td>260.35</td>
+      <td>194.14</td>
+      <td>9.03</td>
+      <td>8720.79</td>
+    </tr>
+    <tr>
+      <td>8</td>
+      <td>670.88</td>
+      <td>6086.74</td>
+      <td>364.15</td>
+      <td>199.00</td>
+      <td>11.19</td>
+      <td>10687.52</td>
+    </tr>
+    <tr>
+      <td>16</td>
+      <td>963.47</td>
+      <td>8766.11</td>
+      <td>490.72</td>
+      <td>203.12</td>
+      <td>15.49</td>
+      <td>14680.68</td>
+    </tr>
+    <tr>
+      <td>32</td>
+      <td>1329.55</td>
+      <td>11857.47</td>
+      <td>775.37</td>
+      <td>215.45</td>
+      <td>22.61</td>
+      <td>21831.61</td>
+    </tr>
+    <tr>
+      <td>64</td>
+      <td>1740.46</td>
+      <td>15759.18</td>
+      <td>1343.98</td>
+      <td>300.81</td>
+      <td>34.41</td>
+      <td>33068.86</td>
     </tr>
   </tbody>
 </table>

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
@@ -533,52 +533,7 @@ sglang serve \
 
 ## 5. Benchmark
 
-### 5.1 Accuracy Benchmark
-
-**Test Environment:**
-
-- Hardware: 4× AMD MI355X
-- Model: `amd/Kimi-K2.7-Code-MXFP4` (MXFP4)
-- Tensor Parallelism: 4
-- Docker Image: `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260812` (ROCm 7.2)
-
-GSM8K accuracy of the MXFP4 checkpoint, measured on the deployed server across several client parallelism levels (2,000 questions each):
-
-```shell Command
-python3 benchmark/gsm8k/bench_sglang.py \
-  --num-questions 2000 \
-  --parallel <PARALLEL> \
-  --port 30000
-```
-
-<table>
-  <thead>
-    <tr>
-      <th>Parallel</th>
-      <th>GSM8K Accuracy</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>100</td>
-      <td>0.951</td>
-    </tr>
-    <tr>
-      <td>300</td>
-      <td>0.953</td>
-    </tr>
-    <tr>
-      <td>600</td>
-      <td>0.942</td>
-    </tr>
-    <tr>
-      <td>1200</td>
-      <td>0.950</td>
-    </tr>
-  </tbody>
-</table>
-
-#### Model Card Reference (Official)
+### 5.1 Model Card Benchmarks (Official)
 
 The following results are from the official Kimi-K2.7-Code model card. They were evaluated with thinking mode enabled through Kimi Code CLI at `temperature=1.0`, `top_p=0.95`, and a 262,144-token context length unless otherwise stated.
 
@@ -631,7 +586,7 @@ The following results are from the official Kimi-K2.7-Code model card. They were
   </tbody>
 </table>
 
-### 5.2 Speed Benchmark
+### 5.2 MXFP4 Benchmark
 
 **Test Environment:**
 
@@ -640,9 +595,47 @@ The following results are from the official Kimi-K2.7-Code model card. They were
 - Tensor Parallelism: 4
 - Docker Image: `rocm/sgl-dev:v0.5.17-rocm720-mi35x-20260812` (ROCm 7.2)
 
-We use SGLang's built-in `bench_serving` tool with the `random` dataset (input 8192, output 1024, range ratio 0.8). For each concurrency `C`, `--num-prompts` is set to `C × 5`.
+#### 5.2.1 Accuracy Benchmark
 
-#### 5.2.1 Latency Benchmark
+GSM8K accuracy of the MXFP4 checkpoint, measured on the deployed server across several client parallelism levels (2,000 questions each):
+
+```shell Command
+python3 benchmark/gsm8k/bench_sglang.py \
+  --num-questions 2000 \
+  --parallel <PARALLEL> \
+  --port 30000
+```
+
+<table>
+  <thead>
+    <tr>
+      <th>Parallel</th>
+      <th>GSM8K Accuracy</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>100</td>
+      <td>0.951</td>
+    </tr>
+    <tr>
+      <td>300</td>
+      <td>0.953</td>
+    </tr>
+    <tr>
+      <td>600</td>
+      <td>0.942</td>
+    </tr>
+    <tr>
+      <td>1200</td>
+      <td>0.950</td>
+    </tr>
+  </tbody>
+</table>
+
+#### 5.2.2 Latency Benchmark
+
+We use SGLang's built-in `bench_serving` tool with the `random` dataset (input 8192, output 1024, range ratio 0.8). For each concurrency `C`, `--num-prompts` is set to `C × 5`.
 
 ```shell Command
 python3 -m sglang.bench_serving \

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
@@ -67,6 +67,7 @@ metatags:
 **Available Models:**
 
 - **INT4 (native checkpoint)**: [moonshotai/Kimi-K2.7-Code](https://huggingface.co/moonshotai/Kimi-K2.7-Code)
+- **MXFP4**: [moonshotai/Kimi-K2.7-Code-MXFP4](https://huggingface.co/moonshotai/Kimi-K2.7-Code-MXFP4) — validated on AMD MI350X/MI355X.
 
 **License:** Modified MIT for the native checkpoint.
 
@@ -97,6 +98,7 @@ import { KimiK27CodeDeployment } from '/src/snippets/autoregressive/kimi-k27-cod
 - **Reasoning Parser**: Add `--reasoning-parser kimi_k2` to separate thinking and content in model outputs.
 - **Tool Call Parser**: Add `--tool-call-parser kimi_k2` for structured tool calls.
 - **AMD FP8 KV Cache**: On AMD platforms the generator adds `--kv-cache-dtype fp8_e4m3` by default and sets `--mem-fraction-static 0.8` to fit the INT4 weights plus KV cache. FP8 KV cache trades a small amount of accuracy for memory; omit the flag if you observe accuracy regressions on your workload.
+- **MXFP4 Checkpoint**: The [MXFP4 checkpoint](https://huggingface.co/moonshotai/Kimi-K2.7-Code-MXFP4) is validated on MI350X/MI355X (TP=4). Select `MXFP4` in the Quantization control to target `moonshotai/Kimi-K2.7-Code-MXFP4`. The MXFP4 quantization is auto-detected from the checkpoint, so no `--quantization` flag is required; the generator uses `--mem-fraction-static 0.765` and FP8 KV cache for MXFP4.
 
 ## 4. Model Invocation
 
@@ -501,6 +503,22 @@ sglang serve \
 ```
 
 For GB300, use `--tp 4`.
+
+Deploy the MXFP4 checkpoint on AMD MI350X/MI355X:
+
+```shell Command
+SGLANG_USE_AITER=1 SGLANG_ROCM_FUSED_DECODE_MLA=0 \
+sglang serve \
+  --model-path moonshotai/Kimi-K2.7-Code-MXFP4 \
+  --tp 4 \
+  --mem-fraction-static 0.765 \
+  --trust-remote-code \
+  --reasoning-parser kimi_k2 \
+  --tool-call-parser kimi_k2 \
+  --kv-cache-dtype fp8_e4m3 \
+  --host 0.0.0.0 \
+  --port 30000
+```
 
 ## 5. Benchmark
 

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
@@ -67,7 +67,7 @@ metatags:
 **Available Models:**
 
 - **INT4 (native checkpoint)**: [moonshotai/Kimi-K2.7-Code](https://huggingface.co/moonshotai/Kimi-K2.7-Code)
-- **MXFP4**: [moonshotai/Kimi-K2.7-Code-MXFP4](https://huggingface.co/moonshotai/Kimi-K2.7-Code-MXFP4) — validated on AMD MI350X/MI355X.
+- **MXFP4**: [amd/Kimi-K2.7-Code-MXFP4](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4) — validated on AMD MI350X/MI355X.
 
 **License:** Modified MIT for the native checkpoint.
 
@@ -98,7 +98,7 @@ import { KimiK27CodeDeployment } from '/src/snippets/autoregressive/kimi-k27-cod
 - **Reasoning Parser**: Add `--reasoning-parser kimi_k2` to separate thinking and content in model outputs.
 - **Tool Call Parser**: Add `--tool-call-parser kimi_k2` for structured tool calls.
 - **AMD FP8 KV Cache**: On AMD platforms the generator adds `--kv-cache-dtype fp8_e4m3` by default and sets `--mem-fraction-static 0.8` to fit the INT4 weights plus KV cache. FP8 KV cache trades a small amount of accuracy for memory; omit the flag if you observe accuracy regressions on your workload.
-- **MXFP4 Checkpoint**: The [MXFP4 checkpoint](https://huggingface.co/moonshotai/Kimi-K2.7-Code-MXFP4) is validated on MI350X/MI355X (TP=4). Select `MXFP4` in the Quantization control to target `moonshotai/Kimi-K2.7-Code-MXFP4`. The MXFP4 quantization is auto-detected from the checkpoint, so no `--quantization` flag is required; the generator uses `--mem-fraction-static 0.765` and FP8 KV cache for MXFP4.
+- **MXFP4 Checkpoint**: The [MXFP4 checkpoint](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4) is validated on MI350X/MI355X (TP=4). Select `MXFP4` in the Quantization control to target `amd/Kimi-K2.7-Code-MXFP4`. The MXFP4 quantization is auto-detected from the checkpoint, so no `--quantization` flag is required; the generator uses `--mem-fraction-static 0.765` and FP8 KV cache for MXFP4.
 
 ## 4. Model Invocation
 
@@ -509,7 +509,7 @@ Deploy the MXFP4 checkpoint on AMD MI350X/MI355X:
 ```shell Command
 SGLANG_USE_AITER=1 SGLANG_ROCM_FUSED_DECODE_MLA=0 \
 sglang serve \
-  --model-path moonshotai/Kimi-K2.7-Code-MXFP4 \
+  --model-path amd/Kimi-K2.7-Code-MXFP4 \
   --tp 4 \
   --mem-fraction-static 0.765 \
   --trust-remote-code \

--- a/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
+++ b/docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx
@@ -98,7 +98,7 @@ import { KimiK27CodeDeployment } from '/src/snippets/autoregressive/kimi-k27-cod
 - **Reasoning Parser**: Add `--reasoning-parser kimi_k2` to separate thinking and content in model outputs.
 - **Tool Call Parser**: Add `--tool-call-parser kimi_k2` for structured tool calls.
 - **AMD FP8 KV Cache**: On AMD platforms the generator adds `--kv-cache-dtype fp8_e4m3` by default and sets `--mem-fraction-static 0.8` to fit the INT4 weights plus KV cache. FP8 KV cache trades a small amount of accuracy for memory; omit the flag if you observe accuracy regressions on your workload.
-- **MXFP4 Checkpoint**: The [MXFP4 checkpoint](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4) is validated on MI350X/MI355X (TP=4). Select `MXFP4` in the Quantization control to target `amd/Kimi-K2.7-Code-MXFP4`. The MXFP4 quantization is auto-detected from the checkpoint, so no `--quantization` flag is required; the generator uses `--mem-fraction-static 0.765` and FP8 KV cache for MXFP4.
+- **MXFP4 Checkpoint**: The [MXFP4 checkpoint](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4) is validated on MI350X/MI355X (TP=4) with the `rocm/sgl-dev:v0.5.16-rocm720-mi35x-20260804` image (ROCm 7.2). Select `MXFP4` in the Quantization control to target `amd/Kimi-K2.7-Code-MXFP4`. The MXFP4 quantization is auto-detected from the checkpoint, so no `--quantization` flag is required; the generator uses `--mem-fraction-static 0.765` and FP8 KV cache for MXFP4.
 
 ## 4. Model Invocation
 

--- a/docs/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
+++ b/docs/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
@@ -128,7 +128,7 @@ export const KimiK27CodeDeployment = () => {
     const isMXFP4 = quantization === 'mxfp4';
     const hwConfig = modelConfigs[hardware];
     const tpValue = hwConfig.tp;
-    const modelName = isMXFP4 ? 'moonshotai/Kimi-K2.7-Code-MXFP4' : 'moonshotai/Kimi-K2.7-Code';
+    const modelName = isMXFP4 ? 'amd/Kimi-K2.7-Code-MXFP4' : 'moonshotai/Kimi-K2.7-Code';
 
     let cmd = '';
 

--- a/docs/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
+++ b/docs/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
@@ -14,6 +14,17 @@ export const KimiK27CodeDeployment = () => {
         { id: 'mi355x', label: 'MI355X', default: false },
       ],
     },
+    quantization: {
+      name: 'quantization',
+      title: 'Quantization',
+      getDynamicItems: (values) => {
+        const isMXFP4 = ['mi350x', 'mi355x'].includes(values.hardware);
+        return [
+          { id: 'int4', label: 'INT4', subtitle: 'Base checkpoint', default: !isMXFP4 },
+          { id: 'mxfp4', label: 'MXFP4', subtitle: 'AMD FP4', default: isMXFP4, disabled: !isMXFP4, disabledReason: !isMXFP4 ? 'MXFP4 only on AMD MI350X/MI355X' : '' },
+        ];
+      },
+    },
     reasoning: {
       name: 'reasoning',
       title: 'Reasoning Parser',
@@ -112,11 +123,12 @@ export const KimiK27CodeDeployment = () => {
   };
 
   const generateCommand = () => {
-    const { hardware, reasoning, toolcall, dpattention } = values;
+    const { hardware, quantization, reasoning, toolcall, dpattention } = values;
     const isAMD = hardware === 'mi300x' || hardware === 'mi325x' || hardware === 'mi350x' || hardware === 'mi355x';
+    const isMXFP4 = quantization === 'mxfp4';
     const hwConfig = modelConfigs[hardware];
     const tpValue = hwConfig.tp;
-    const modelName = 'moonshotai/Kimi-K2.7-Code';
+    const modelName = isMXFP4 ? 'moonshotai/Kimi-K2.7-Code-MXFP4' : 'moonshotai/Kimi-K2.7-Code';
 
     let cmd = '';
 
@@ -128,7 +140,7 @@ export const KimiK27CodeDeployment = () => {
     cmd += `  --model-path ${modelName}`;
     cmd += ` \\\n  --tp ${tpValue}`;
     if (isAMD) {
-      cmd += ' \\\n  --mem-fraction-static 0.8';
+      cmd += isMXFP4 ? ' \\\n  --mem-fraction-static 0.765' : ' \\\n  --mem-fraction-static 0.8';
     }
     cmd += ' \\\n  --trust-remote-code';
 

--- a/docs/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
+++ b/docs/src/snippets/autoregressive/kimi-k27-code-deployment.jsx
@@ -28,6 +28,7 @@ export const KimiK27CodeDeployment = () => {
     reasoning: {
       name: 'reasoning',
       title: 'Reasoning Parser',
+      condition: (values) => values.quantization !== 'mxfp4',
       items: [
         { id: 'disabled', label: 'Disabled', default: false },
         { id: 'enabled', label: 'Enabled', default: true },
@@ -36,6 +37,7 @@ export const KimiK27CodeDeployment = () => {
     toolcall: {
       name: 'toolcall',
       title: 'Tool Call Parser',
+      condition: (values) => values.quantization !== 'mxfp4',
       items: [
         { id: 'disabled', label: 'Disabled', default: false },
         { id: 'enabled', label: 'Enabled', default: true },
@@ -44,6 +46,7 @@ export const KimiK27CodeDeployment = () => {
     dpattention: {
       name: 'dpattention',
       title: 'DP Attention',
+      condition: (values) => values.quantization !== 'mxfp4',
       items: [
         { id: 'disabled', label: 'Disabled', subtitle: 'Low Latency', default: true },
         { id: 'enabled', label: 'Enabled', subtitle: 'High Throughput', default: false },
@@ -128,7 +131,38 @@ export const KimiK27CodeDeployment = () => {
     const isMXFP4 = quantization === 'mxfp4';
     const hwConfig = modelConfigs[hardware];
     const tpValue = hwConfig.tp;
-    const modelName = isMXFP4 ? 'amd/Kimi-K2.7-Code-MXFP4' : 'moonshotai/Kimi-K2.7-Code';
+
+    if (isMXFP4) {
+      const mxfp4Env = [
+        'SGLANG_USE_AITER=1',
+        'HIP_FORCE_DEV_KERNARG=1',
+        'SGLANG_EXPERT_PARALLEL_SIZE=1',
+        'SGLANG_USE_DYNAMIC_MXFP4_LINEAR=0',
+        'TORCH_BLAS_PREFER_HIPBLASLT=1',
+        'TENSILE_STREAMK_DYNAMIC_GRID=6',
+        'AITER_QUICK_REDUCE_QUANTIZATION=INT4',
+        'AITER_USE_FLYDSL_MOE_SORTING=1',
+        'AITER_AR_1STAGE_MAX_KB=512',
+        'AITER_MXFP4_INTERMEDIATE=1',
+        'ROCM_QUICK_REDUCE_QUANTIZATION=INT4',
+      ].join(' \\\n');
+      return (
+        mxfp4Env + ' \\\n' +
+        'sglang serve \\\n' +
+        '  --model-path amd/Kimi-K2.7-Code-MXFP4 \\\n' +
+        '  --tp 4 \\\n' +
+        '  --trust-remote-code \\\n' +
+        '  --attention-backend aiter \\\n' +
+        '  --mem-fraction-static 0.90 \\\n' +
+        '  --kv-cache-dtype fp8_e4m3 \\\n' +
+        '  --disable-radix-cache \\\n' +
+        '  --enable-aiter-allreduce-fusion \\\n' +
+        '  --host 0.0.0.0 \\\n' +
+        '  --port 30000'
+      );
+    }
+
+    const modelName = 'moonshotai/Kimi-K2.7-Code';
 
     let cmd = '';
 
@@ -140,7 +174,7 @@ export const KimiK27CodeDeployment = () => {
     cmd += `  --model-path ${modelName}`;
     cmd += ` \\\n  --tp ${tpValue}`;
     if (isAMD) {
-      cmd += isMXFP4 ? ' \\\n  --mem-fraction-static 0.765' : ' \\\n  --mem-fraction-static 0.8';
+      cmd += ' \\\n  --mem-fraction-static 0.8';
     }
     cmd += ' \\\n  --trust-remote-code';
 


### PR DESCRIPTION
<!-- Recommended PR title: [AMD] Add Kimi-K2.7-Code MXFP4 to cookbook -->

## Motivation

We enabled the **Kimi-K2.7-Code-MXFP4** checkpoint in SGLang and tested it on AMD **MI350X/MI355X** GPUs. The cookbook page for Kimi-K2.7-Code only showed the INT4 checkpoint, so users had no easy way to find or launch the MXFP4 version. This PR adds the MXFP4 checkpoint to the cookbook so people can deploy it with a ready-to-use command.

## Modifications

This is a documentation-only change. Two files are updated:

- **`docs/src/snippets/autoregressive/kimi-k27-code-deployment.jsx`** (the interactive command generator)
  - Added a new **Quantization** control with two choices: **INT4** (base checkpoint) and **MXFP4**.
  - MXFP4 is only selectable on **MI350X/MI355X**; on other GPUs it is greyed out with a short reason. This matches how the Kimi-K2.6 page handles its NVFP4 option.
  - When MXFP4 is selected, the generated command uses `--model-path amd/Kimi-K2.7-Code-MXFP4` and `--mem-fraction-static 0.765`. The INT4 command is unchanged.

- **`docs/cookbook/autoregressive/Moonshotai/Kimi-K2.7-Code.mdx`** (the page text)
  - Added the MXFP4 checkpoint to the **Available Models** list: [amd/Kimi-K2.7-Code-MXFP4](https://huggingface.co/amd/Kimi-K2.7-Code-MXFP4).
  - Added a short **Configuration Tips** note explaining that MXFP4 runs on MI350X/MI355X, uses TP=4, is auto-detected (no `--quantization` flag needed), uses FP8 KV cache, and validated with the `rocm/sgl-dev:v0.5.16-rocm720-mi35x-20260804` image.
  - Added an **MXFP4 deployment command** example for AMD.

The launch settings come from a real, validated MI355X server run: `--tp 4`, `--kv-cache-dtype fp8_e4m3`, `--mem-fraction-static 0.765`, ROCm aiter backend, with the MXFP4 format auto-detected from the checkpoint.

> **Note on `--kv-cache-dtype fp8_e4m3`:** this flag is carried over from the actual validated MI355X run and matches the existing AMD (INT4) path on this page, which already uses FP8 KV cache and documents the accuracy trade-off in Configuration Tips. It is not a new default introduced for all cells — it applies only to the AMD MXFP4 command.

## Verifications

<img width="673" height="775" alt="image" src="https://github.com/user-attachments/assets/bbcbcfc8-ae84-4502-aa29-af3012530724" />
<img width="685" height="760" alt="image" src="https://github.com/user-attachments/assets/1b4ef39f-6d7b-4dc6-a8b2-c057225f10e0" />
<img width="678" height="748" alt="image" src="https://github.com/user-attachments/assets/6a16d8c4-bc67-4c1a-b8f9-a5a5f98ddecd" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32820019880](https://github.com/sgl-project/sglang/actions/runs/32820019880)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32831875738](https://github.com/sgl-project/sglang/actions/runs/32831875738)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->