### PR TITLE
[NPU][AFD] Attention-FFN Disaggregation Experimental, adopt from #10900

### DIFF
--- a/python/sglang/srt/afd/afd_model.py
+++ b/python/sglang/srt/afd/afd_model.py
@@ -1,0 +1,29 @@
+# AF disaggregation model
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==========
+
+import torch
+from torch import nn
+
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+
+
+class AFDProxyAttention(nn.Module):
+    def forward(
+        self,
+        positions: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+        return hidden_states

--- a/python/sglang/srt/afd/afd_type.py
+++ b/python/sglang/srt/afd/afd_type.py
@@ -1,0 +1,40 @@
+# AF disaggregation type
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==========
+
+from enum import Enum
+from typing import Optional
+
+
+class AFDRole(Enum):
+    AFD_ROLE_ATTN = "attn"
+    AFD_ROLE_FFN = "ffn"
+
+    def __str__(self):
+        return self.value
+
+
+def get_afd_role() -> Optional[AFDRole]:
+    from sglang.srt.runtime_context import get_disagg
+
+    afd_role = get_disagg().afd_role
+    return afd_role
+
+
+def afd_is_attn():
+    return get_afd_role() == AFDRole.AFD_ROLE_ATTN
+
+
+def afd_is_ffn():
+    return get_afd_role() == AFDRole.AFD_ROLE_FFN

--- a/python/sglang/srt/distributed/bootstrap.py
+++ b/python/sglang/srt/distributed/bootstrap.py
@@ -14,6 +14,7 @@ from sglang.srt.distributed import (
     get_tp_group,
     get_world_group,
     init_distributed_environment,
+    initialize_local_group,
     initialize_model_parallel,
     set_custom_all_reduce,
     set_flashinfer_allreduce_only,
@@ -28,6 +29,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.dp_attention import initialize_dp_attention
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
+    get_disagg,
     get_exec,
     get_parallel,
 )
@@ -269,6 +271,12 @@ def _init_parallel_groups(
         max_world_size=server_args.max_ep_size,
     )
     _tag_groups_for_flashinfer_allreduce_only()
+    if get_disagg().afd_role is not None:
+        initialize_local_group(
+            nnodes=server_args.nnodes,
+            pp_size=pp_size,
+            tp_size=tp_size,
+        )
     initialize_dp_attention(
         server_args=server_args,
         model_config=model_config,

--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -2040,6 +2040,14 @@ def get_moe_tp_group() -> GroupCoordinator:
     return _MOE_TP
 
 
+_LOCAL_GROUP: Optional[GroupCoordinator] = None
+
+
+def get_local_group() -> GroupCoordinator:
+    assert _LOCAL_GROUP is not None, "local group is not initialized"
+    return _LOCAL_GROUP
+
+
 # kept for backward compatibility
 get_tensor_model_parallel_group = get_tp_group
 
@@ -2698,6 +2706,29 @@ def initialize_model_parallel(
     )
 
 
+def initialize_local_group(
+    nnodes: int,
+    pp_size: int,
+    tp_size: int,
+) -> None:
+    total = tp_size * pp_size
+    n_per_node = total // nnodes
+
+    groups = []
+    for i in range(nnodes):
+        groups.append(list(range(i * n_per_node, (i + 1) * n_per_node)))
+
+    global _LOCAL_GROUP
+    assert _LOCAL_GROUP is None, "local group is already initialized"
+
+    _LOCAL_GROUP = init_model_parallel_group(
+        groups,
+        get_world_group().local_rank,
+        torch.distributed.get_backend(get_world_group().device_group),
+        group_name="local",
+    )
+
+
 def create_custom_parallel_group(
     group_ranks: List[int], backend: str = "gloo"
 ) -> Optional[torch.distributed.ProcessGroup]:
@@ -2944,6 +2975,11 @@ def destroy_model_parallel():
     if _MOE_TP:
         _MOE_TP.destroy()
     _MOE_TP = None
+
+    global _LOCAL_GROUP
+    if _LOCAL_GROUP:
+        _LOCAL_GROUP.destroy()
+    _LOCAL_GROUP = None
 
     global _ATTN_CP
     global _ATTN_CP_OVERLAP

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -63,6 +63,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import ORJSONResponse, Response, StreamingResponse
 from fastapi.routing import APIRoute
 
+from sglang.srt.afd.afd_type import AFDRole
 from sglang.srt.configs.embedding_model_spec import resolved_embedding_plan
 from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.disaggregation.utils import FAKE_BOOTSTRAP_HOST, DisaggregationMode
@@ -2391,7 +2392,17 @@ def _wait_and_warmup(
             get_exec().moe.ep_join_mode,
         )
 
-    if not get_serving().skip_server_warmup and not skip_elastic_joiner_warmup:
+    # No work request arrives at the FFN side, so warmup is unnecessary (and
+    # would fail there): skip it for the AFD FFN role.
+    skip_afd_ffn_warmup = get_disagg().afd_role == AFDRole.AFD_ROLE_FFN
+    if skip_afd_ffn_warmup:
+        logger.debug("[AFD] Skipping server warmup for the FFN role.")
+
+    if (
+        not get_serving().skip_server_warmup
+        and not skip_elastic_joiner_warmup
+        and not skip_afd_ffn_warmup
+    ):
         if not execute_warmup_func(server_args):
             return
     else:

--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -20,6 +20,7 @@ from typing import Callable, Dict, Optional, Tuple, Union
 
 import torch
 
+from sglang.srt.afd.afd_type import AFDRole, get_afd_role
 from sglang.srt.distributed import (
     attention_tensor_model_parallel_all_reduce,
     attention_tensor_model_parallel_quant_all_reduce,
@@ -388,6 +389,7 @@ class LayerScatterModes:
             if (
                 # Token dispatch/combine will be handled outside of LayerCommunicator for these modes.
                 not get_moe_a2a_backend().is_none()
+                or get_afd_role()
                 or should_use_flashinfer_cutlass_moe_fp4_allgather()
                 or enable_dwdp()
             ):
@@ -468,6 +470,7 @@ class LayerCommunicator:
         self.force_layernorm_before_dp_gather = force_layernorm_before_dp_gather
         self.enable_fused_ar_quant = enable_fused_ar_quant
         self.fused_ar_quant_keep_bf16 = fused_ar_quant_keep_bf16
+        self.afd_role = get_afd_role()
 
         self._context = CommunicateContext.init_new()
         self._context.force_layernorm_before_dp_gather = (
@@ -567,6 +570,9 @@ class LayerCommunicator:
         quant_format: str = "",
         post_residual_addition: Optional[torch.Tensor] = None,
     ):
+        if self.afd_role == AFDRole.AFD_ROLE_FFN:
+            return hidden_states, residual
+
         if get_attn_tp_context().input_scattered:
             hidden_states, residual = self._tp_reduce_scatter(
                 hidden_states,
@@ -763,6 +769,9 @@ class LayerCommunicator:
         forward_batch: ForwardBatch,
         cache=None,
     ):
+        if self.afd_role == AFDRole.AFD_ROLE_FFN:
+            return hidden_states, residual
+
         if cache is not None:
             self._context.cache = cache
 
@@ -780,6 +789,9 @@ class LayerCommunicator:
         residual: torch.Tensor,
         forward_batch: ForwardBatch,
     ):
+        if self.afd_role == AFDRole.AFD_ROLE_FFN:
+            return hidden_states, residual
+
         return self._communicate_summable_tensor_pair_fn(
             hidden_states=hidden_states,
             residual=residual,
@@ -789,6 +801,9 @@ class LayerCommunicator:
         )
 
     def should_use_reduce_scatter(self, forward_batch: ForwardBatch):
+        if self.afd_role is not None:
+            return False
+
         if not self.allow_reduce_scatter:
             return False
         if (
@@ -809,6 +824,9 @@ class LayerCommunicator:
     def should_fuse_mlp_allreduce_with_next_layer(
         self, forward_batch: ForwardBatch
     ) -> bool:
+        if self.afd_role is not None:
+            return False
+
         # When MOE_FULL is active (moe_cp allgather), fusion must be disabled because
         # the fusion path skips postprocess_layer which contains the moe_cp scatter.
         # Without scatter, hidden_states remain at MOE_FULL size while residual is at

--- a/python/sglang/srt/layers/moe/ep_moe/layer.py
+++ b/python/sglang/srt/layers/moe/ep_moe/layer.py
@@ -6,6 +6,8 @@ from typing import TYPE_CHECKING, Any, Dict, Optional
 import torch
 
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
+from sglang.srt.afd.afd_type import AFDRole, get_afd_role
+from sglang.srt.distributed.parallel_state import GroupCoordinator
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.dp_attention import (
@@ -25,6 +27,7 @@ from sglang.srt.layers.moe.token_dispatcher.deepep import (
     DeepEPLLCombineInput,
     DeepEPNormalCombineInput,
 )
+from sglang.srt.layers.moe.token_dispatcher.stepmesh import StepMeshATTN, StepMeshFFN
 from sglang.srt.layers.moe.topk import (
     StandardTopKOutput,
     TopKOutput,
@@ -33,6 +36,7 @@ from sglang.srt.layers.moe.topk import (
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config, W4AFp8MoEMethod
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
     eager_on_graph,
 )
@@ -349,7 +353,159 @@ class DeepEPMoE(FusedMoE):
         )
 
 
+class AFDDispatcher(object):
+    def __init__(
+        self,
+        layer_id: int,
+        group: GroupCoordinator,
+    ):
+        from sglang.srt.runtime_context import get_disagg
+
+        backend = get_disagg().afd_transfer_backend
+        assert backend == "stepmesh", f"{backend} is not supperted"
+
+        self.attn = StepMeshATTN(layer_id, group)
+        self.ffn = StepMeshFFN(layer_id, group)
+
+    def attn_send(self, p: PPProxyTensors):
+        return self.attn.send(p)
+
+    def attn_recv(self):
+        return self.attn.recv()
+
+    def ffn_send(self, x: torch.Tensor):
+        return self.ffn.send(x)
+
+    def ffn_recv(self):
+        return self.ffn.recv()
+
+
+class AFDATTNMoE(torch.nn.Module):
+    def __init__(
+        self,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        layer_id: int,
+        num_fused_shared_experts: int = 0,
+        params_dtype: Optional[torch.dtype] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        activation: str = "silu",
+        routed_scaling_factor: Optional[float] = None,
+        gemm1_alpha: Optional[float] = None,
+        gemm1_clamp_limit: Optional[float] = None,
+        with_bias: bool = False,
+        **kwargs,
+    ):
+        super().__init__()
+
+        from sglang.srt.distributed.parallel_state import get_local_group
+
+        self.afd_dispatcher = AFDDispatcher(
+            layer_id,
+            group=get_local_group(),
+        )
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        topk_output: TopKOutput,
+        forward_batch: ForwardBatch,
+    ):
+        p = PPProxyTensors(
+            {
+                "hidden_states": hidden_states,
+                "topk_weights": topk_output.topk_weights,
+                "topk_ids": topk_output.topk_ids,
+                "router_logits": topk_output.router_logits,
+                "forward_batch": forward_batch,
+            }
+        )
+
+        self.attn_send(p)
+        return self.attn_recv()
+
+    def attn_send(self, p: PPProxyTensors):
+        return self.afd_dispatcher.attn_send(p)
+
+    def attn_recv(self):
+        return self.afd_dispatcher.attn_recv()
+
+
+class AFDFFNMoE(FusedMoE):
+    """
+    MoE Expert Parallel Impl for AFD
+    """
+
+    def __init__(
+        self,
+        num_experts: int,
+        top_k: int,
+        hidden_size: int,
+        intermediate_size: int,
+        layer_id: int,
+        num_fused_shared_experts: int = 0,
+        params_dtype: Optional[torch.dtype] = None,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+        activation: str = "silu",
+        routed_scaling_factor: Optional[float] = None,
+        gemm1_alpha: Optional[float] = None,
+        gemm1_clamp_limit: Optional[float] = None,
+        with_bias: bool = False,
+        **kwargs,
+    ):
+        super().__init__(
+            num_experts=num_experts,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
+            num_fused_shared_experts=num_fused_shared_experts,
+            layer_id=layer_id,
+            top_k=top_k,
+            params_dtype=params_dtype,
+            quant_config=quant_config,
+            prefix=prefix,
+            activation=activation,
+            routed_scaling_factor=routed_scaling_factor,
+            gemm1_alpha=gemm1_alpha,
+            gemm1_clamp_limit=gemm1_clamp_limit,
+            with_bias=with_bias,
+            **kwargs,
+        )
+
+        from sglang.srt.distributed.parallel_state import get_local_group
+
+        self.afd_dispatcher = AFDDispatcher(
+            layer_id,
+            group=get_local_group(),
+        )
+
+    def forward(self, hidden_states: torch.Tensor, topk_output: TopKOutput):
+        hidden_states, topk_output = self.ffn_recv()
+
+        output = super().forward(hidden_states, topk_output)
+
+        self.ffn_send(output)
+
+        return hidden_states
+
+    def ffn_send(self, x: torch.Tensor):
+        return self.afd_dispatcher.ffn_send(x)
+
+    def ffn_recv(self):
+        return self.afd_dispatcher.ffn_recv()
+
+
 def get_moe_impl_class(quant_config: Optional[QuantizationConfig]):
+    afd_role = get_afd_role()
+    if afd_role is not None:
+        if afd_role == AFDRole.AFD_ROLE_ATTN:
+            return AFDATTNMoE
+        else:
+            return AFDFFNMoE
+
     # [TODO] kk, temporary solution
     if (
         get_moe_a2a_backend().is_mori()

--- a/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/__init__.py
@@ -52,6 +52,7 @@ from sglang.srt.layers.moe.token_dispatcher.standard import (
     StandardDispatcher,
     StandardDispatchOutput,
 )
+from sglang.srt.layers.moe.token_dispatcher.stepmesh import StepMeshATTN, StepMeshFFN
 
 __all__ = [
     "BaseDispatcher",
@@ -90,4 +91,6 @@ __all__ = [
     "AscendTPDispatcher",
     "AscendTPDispatchOutput",
     "AscendTPCombineInput",
+    "StepMeshATTN",
+    "StepMeshFFN",
 ]

--- a/python/sglang/srt/layers/moe/token_dispatcher/stepmesh.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/stepmesh.py
@@ -1,0 +1,449 @@
+import json
+import logging
+import os
+import time
+
+import torch
+import zmq
+
+from sglang.srt.afd.afd_type import afd_is_attn, get_afd_role
+from sglang.srt.distributed.parallel_state import (
+    GroupCoordinator,
+    inplace_all_reduce,
+)
+from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
+
+logger = logging.getLogger(__name__)
+
+dtype_map = [
+    torch.float16,  # torch.half
+    torch.float32,  # torch.float
+    torch.float64,  # torch.double
+    torch.bfloat16,  # Brain floating point
+    torch.complex32,
+    torch.complex64,
+    torch.complex128,
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,  # torch.int
+    torch.int64,  # torch.long
+    torch.bool,
+    torch.quint8,  # Quantized unsigned int8
+    torch.qint8,  # Quantized int8
+    torch.qint32,  # Quantized int32
+    torch.quint4x2,  # 4-bit quantized (packed)
+    torch.quint2x4,  # 2-bit quantized (packed)
+]
+
+push_cache = None
+initialized = False
+fserver = None
+global_tokens_num = None
+
+
+def stepmesh_scheduler():
+    os.environ["DMLC_ROLE"] = "scheduler"
+
+    import fserver_lib as f
+
+    f.init()
+
+    # let the scheduler to sleep forever
+    while True:
+        time.sleep(30 * 24 * 3600)
+
+
+def env_def(env, v):
+    if os.environ.get(env) == None:
+        os.environ[env] = v
+
+
+def start_stepmesh_scheduler(world: GroupCoordinator):
+    if os.environ["DMLC_ROLE"] != "server":
+        return
+
+    if world.rank_in_group != 0:
+        return
+
+    if os.environ.get("STEPMESH_SCHEDULER_STARTED") == "1":
+        return
+
+    os.environ["STEPMESH_SCHEDULER_STARTED"] = "1"
+
+    import multiprocessing
+
+    p = multiprocessing.Process(target=stepmesh_scheduler)
+    p.daemon = True
+    p.start()
+
+
+def stepmesh_config(world: GroupCoordinator, local_group: GroupCoordinator):
+    rank = world.rank_in_group
+    local_size = local_group.world_size
+
+    node_rank = rank // local_size
+
+    # Users do not care about these:
+    env_def("DMLC_GROUP_SIZE", f"{local_size}")
+    env_def("DMLC_NODE_RANK", f"{node_rank}")
+    env_def("STEPMESH_GPU", f"{torch.cuda.current_device()}")
+    env_def("DMLC_ENABLE_RDMA", "ibverbs")
+
+
+def att_ffn_exchange_conf(world: GroupCoordinator, local_group: GroupCoordinator):
+    from sglang.srt.runtime_context import get_disagg
+
+    rank = world.rank_in_group
+
+    nodes_n = world.world_size // local_group.world_size
+
+    addr = get_disagg().afd_ffn_addr
+    ffn_ip, port = addr.split(":")
+
+    port = int(port) + 10
+
+    if rank > 0:
+        x = torch.tensor([0])
+        # wait that rank0 connects to the peer(attn or ffn)
+        x = world.all_gather(x)
+    else:
+        context = zmq.Context()
+
+        if afd_is_attn():
+            assert nodes_n == 1, "Only support one attention node"
+
+            socket = context.socket(zmq.REQ)
+            socket.connect(f"tcp://{ffn_ip}:{port}")
+
+            msg = {"attn_nodes_n": nodes_n, "scheduler_ip": ffn_ip}
+
+            socket.send_string(json.dumps(msg))
+            reply = socket.recv_string()
+
+            reply = json.loads(reply)
+
+            peer_nodes_n = reply["ffn_nodes_n"]
+        else:
+            assert nodes_n == 1, "Only support one FFN node"
+
+            socket = context.socket(zmq.REP)
+            socket.bind(f"tcp://*:{port}")
+
+            msg = socket.recv_string()
+
+            msg = json.loads(msg)
+            peer_nodes_n = msg["attn_nodes_n"]
+            ffn_ip = msg["scheduler_ip"]
+
+            reply = {"ffn_nodes_n": nodes_n}
+
+            socket.send_string(json.dumps(reply))
+
+        x = torch.tensor([peer_nodes_n])
+        x = world.all_gather(x)
+
+    peer_nodes_n = x[0]
+
+    if afd_is_attn():
+        os.environ["DMLC_NUM_WORKER"] = f"{nodes_n}"
+        os.environ["DMLC_NUM_SERVER"] = f"{peer_nodes_n}"
+        os.environ["DMLC_ROLE"] = "worker"
+    else:
+        os.environ["DMLC_NUM_WORKER"] = f"{peer_nodes_n}"
+        os.environ["DMLC_NUM_SERVER"] = f"{nodes_n}"
+        os.environ["DMLC_ROLE"] = "server"
+
+    os.environ["DMLC_PS_ROOT_URI"] = ffn_ip
+    env_def("DMLC_PS_ROOT_PORT", "8123")
+
+
+def stepmesh_init(local_group: GroupCoordinator):
+    global initialized
+
+    if initialized:
+        return
+
+    initialized = True
+
+    from sglang.srt.distributed import get_world_group
+
+    world = get_world_group()
+
+    global push_cache
+    push_cache = PushTensorCache(world.rank_in_group)
+
+    att_ffn_exchange_conf(world, local_group)
+    stepmesh_config(world, local_group)
+
+    import fserver_lib as f
+
+    start_stepmesh_scheduler(world)
+
+    logger.info("stepmesh for %s init..." % get_afd_role())
+    f.init()
+    logger.info("stepmesh for %s init done." % get_afd_role())
+
+    global fserver
+    fserver = f
+
+
+class StepMeshTensorCache:
+    def __init__(self):
+        self.push = []
+        self.pull = []
+
+        self.push_keys = []
+        self.pull_keys = []
+        self.shape = None
+
+        self.h = None
+
+
+class PushTensorCache:
+    def __init__(self, rank):
+        self.cache = {}
+        self.key = rank << 24
+
+    def copy(self, p: PPProxyTensors):
+        x = p["hidden_states"]
+        topk_weights = p["topk_weights"]
+        topk_ids = p["topk_ids"]
+        router_logits = p["router_logits"]
+
+        free = self.cache.get(x.shape)
+        if free == None:
+            self.cache[x.shape] = []
+            free = self.cache[x.shape]
+
+        if x.shape[0] == 0:
+            l = []
+            for t in [x, topk_weights, topk_ids, router_logits]:
+                l.append(t.shape[1])
+                l.append(dtype_map.index(t.dtype))
+
+            y = torch.tensor(l)
+
+        if len(free) == 0:
+            t = StepMeshTensorCache()
+            t.shape = x.shape
+            t.dtype = x.dtype
+            t.device = x.device
+
+            if x.shape[0] == 0:
+                x = torch.empty(y.shape[0], dtype=torch.int)
+                t.push.append(x)
+                t.pull = [torch.empty_like(x)]
+
+            else:
+                t.push.append(torch.empty_like(x))
+                t.push.append(torch.empty_like(topk_weights))
+                t.push.append(torch.empty_like(topk_ids))
+                t.push.append(torch.empty_like(router_logits))
+
+                t.pull = [torch.empty_like(x)]
+
+            t.push_keys = range(self.key, self.key + len(t.push))
+            self.key += len(t.push)
+            t.pull_keys = range(self.key, self.key + len(t.pull))
+            self.key += len(t.pull)
+
+        else:
+            t = free.pop(0)
+
+        if len(t.push) > 2:
+            t.push[0].copy_(x)
+            t.push[1].copy_(topk_weights)
+            t.push[2].copy_(topk_ids)
+            t.push[3].copy_(router_logits)
+        else:
+            t.push[0].copy_(y)
+
+        return t
+
+    def put(self, t):
+        self.cache[t.shape].append(t)
+
+
+class FFNSendCache:
+    def __init__(self):
+        self.free_tensors = {}
+        self.inflight = []
+
+    def copy(self, x: torch.Tensor):
+        if len(self.inflight) > 100:
+            t = self.inflight.pop(0)
+            self.free_tensors[t.shape].append(t)
+
+        free = self.free_tensors.get(x.shape)
+        if free == None:
+            self.free_tensors[x.shape] = []
+            free = self.free_tensors[x.shape]
+
+        if len(free) == 0:
+            t = torch.empty_like(x)
+        else:
+            t = free.pop(0)
+
+        t.copy_(x)
+
+        self.inflight.append(t)
+
+        return t
+
+
+ffn_cache = FFNSendCache()
+
+
+class StepMeshATTN:
+    def __init__(
+        self,
+        layer_id: int,
+        group: GroupCoordinator,
+    ):
+        stepmesh_init(group)
+
+        self.waits = []
+        self.f = fserver
+        self.layer_id = layer_id
+
+    def send(self, p: PPProxyTensors):
+
+        t = push_cache.copy(p)
+
+        h = self.f.push_pull(t.push, t.push_keys, t.pull, t.pull_keys)
+
+        t.h = h
+
+        self.waits.append(t)
+
+    def recv(self):
+        t = self.waits.pop(0)
+
+        self.f.wait(t.h)
+
+        push_cache.put(t)
+
+        if t.shape[0] == 0:
+            return torch.empty(0, t.shape[1], dtype=t.dtype, device=t.device)
+
+        return t.pull[0].clone()
+
+
+def all_gathter_global_tokens(x: torch.Tensor, layer_id: int, group: GroupCoordinator):
+    global global_tokens_num
+    if layer_id > 0:
+        return global_tokens_num
+
+    tensor = torch.tensor([x.shape[0]], dtype=torch.int, device=x.device)
+
+    tensor = group.all_gather(tensor, dim=0)
+
+    global_tokens_num = tensor.tolist()
+
+    return global_tokens_num
+
+
+class FFNCTX:
+    def __init__(self):
+        self.id = None
+        self.token_n = 0
+        self.token_s = 0
+        self.token_e = 0
+        self.zero_x = None
+
+
+def all_gather_partial(ctx: FFNCTX, x: torch.Tensor, group: GroupCoordinator):
+    dim = x.shape[1]
+
+    t = torch.zeros(ctx.token_n, dim, device=x.device, dtype=x.dtype)
+    t[ctx.token_s : ctx.token_e] = x
+
+    inplace_all_reduce(t, group_name=group.unique_name)
+
+    return t
+
+
+class StepMeshFFN:
+    def __init__(
+        self,
+        layer_id: int,
+        group: GroupCoordinator,
+    ):
+        stepmesh_init(group)
+
+        self.layer_id = layer_id
+        self.comms = []
+        self.peek_tensor = None
+
+        self.f = fserver
+
+        self.group = group
+
+    def send(self, x: torch.Tensor):
+        x = self.group.all_reduce(x)
+
+        ctx = self.comms.pop(0)
+
+        if ctx.zero_x == None:
+            x = x[ctx.token_s : ctx.token_e]
+
+            t = ffn_cache.copy(x)
+        else:
+            t = ffn_cache.copy(ctx.zero_x)
+
+        self.f.respond([t], ctx.id, True)
+
+    def recv(self):
+        batches = self.f.get_batch()
+        if len(batches) == 0:
+            return None
+
+        from sglang.srt.layers.moe.topk import StandardTopKOutput
+
+        ctx = FFNCTX()
+        ctx.id = batches[0][0]
+
+        self.comms.append(ctx)
+
+        # attn send tensor(0, dim)
+        if len(batches[0][1]) == 1:
+            x = batches[0][1][0]
+            ctx.zero_x = x
+            y = x.tolist()
+
+            ts = []
+
+            for i in range(0, 4):
+                dim = y.pop(0)
+                dtype = dtype_map[y.pop(0)]
+                ts.append(torch.empty(0, dim, device=x.device, dtype=dtype))
+
+            x, topk_weights, topk_idx, router_logits = ts
+
+        else:
+            x, topk_weights, topk_idx, router_logits = batches[0][1]
+
+        g_tokens = all_gathter_global_tokens(x, self.layer_id, self.group)
+
+        ctx.token_s = sum(g_tokens[0 : self.group.rank_in_group])
+        ctx.token_e = sum(g_tokens[0 : self.group.rank_in_group + 1])
+
+        if set(g_tokens) == 1:  # tokens number is eq
+            x = self.group.all_gather(x, dim=0)
+            topk_weights = self.group.all_gather(topk_weights, dim=0)
+            topk_idx = self.group.all_gather(topk_idx, dim=0)
+            router_logits = self.group.all_gather(router_logits, dim=0)
+        else:
+            tk = sum(g_tokens)
+
+            ctx.token_n = tk
+
+            x = all_gather_partial(ctx, x, self.group)
+            topk_weights = all_gather_partial(ctx, topk_weights, self.group)
+            topk_idx = all_gather_partial(ctx, topk_idx, self.group)
+            router_logits = all_gather_partial(ctx, router_logits, self.group)
+
+        topk_output = StandardTopKOutput(topk_weights, topk_idx, router_logits)
+
+        return x, topk_output

--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -2305,6 +2305,13 @@ class DumperControlReqOutput(BaseReq, kw_only=True):
     error: str = ""
 
 
+class AFSyncReq(BaseReq, kw_only=True):
+    """Sync request from the AFD ATTN scheduler to the FFN scheduler:
+    notifies the FFN side to run one model forward pass."""
+
+    pass
+
+
 # The following request types are either defined in other files,
 # or not subclasses of BaseReq/BaseBatchReq, so we skip the check for them.
 _IGNORE_REQ_TYPES_CHECK = (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -56,6 +56,7 @@ import psutil  # isort: skip
 import setproctitle
 import torch
 import torch.distributed
+import zmq
 from torch.distributed import barrier
 
 if TYPE_CHECKING:
@@ -67,6 +68,7 @@ try:
     )
 except ImportError:
     initialize_mamba_selective_state_update_backend = None
+from sglang.srt.afd.afd_type import AFDRole, get_afd_role
 from sglang.srt.configs.model_config import (
     ModelConfig,
     ModelImpl,
@@ -119,6 +121,7 @@ from sglang.srt.managers.io_struct import (
     ActiveRanksOutput,
     AddExternalCorpusReqInput,
     AddExternalCorpusReqOutput,
+    AFSyncReq,
     AttachHiCacheStorageReqInput,
     AttachHiCacheStorageReqOutput,
     BatchTokenizedEmbeddingReqInput,
@@ -326,6 +329,7 @@ from sglang.srt.utils.hf_transformers_utils import (
     resolve_image_processor_backend,
 )
 from sglang.srt.utils.msgspec_utils import msgspec_to_builtins
+from sglang.srt.utils.network import get_zmq_socket
 from sglang.srt.utils.numa_utils import get_numa_node_if_available, numa_bind_to_node
 from sglang.srt.utils.nvtx_utils import scheduler_nvtx_method
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
@@ -498,6 +502,7 @@ class Scheduler(
 
         # Init inter-process communication
         self.init_ipc_channels(port_args)
+        self.init_afd(port_args)
         self.init_idle_sleeper()
 
         # Init ZBAL, switch allocator should before any torch alloc action
@@ -782,6 +787,33 @@ class Scheduler(
         except Exception as e:
             logger.warning("load snapshot writer init failed: %s", e)
 
+    def init_afd(self, port_args: PortArgs):
+        # Init afd config
+        self.afd_role = get_afd_role()
+        self.afd_send_to_ffn = None
+        self.afd_recv_from_attn = None
+        self.afd_ffn_running = False
+        if self.afd_role is None:
+            return
+
+        if self.model_config.hf_config.architectures[0] not in ["Qwen3MoeForCausalLM"]:
+            logging.warning("AFD is not supported for the target model, disabled.")
+            self.afd_role = None
+            return
+
+        # Init the Attn-to-FFN control socket. It is only active at tp_rank 0,
+        # and other ranks get the requests by broadcasting.
+        if self.ps.tp_rank == 0:
+            context = zmq.Context(1)
+            if self.afd_role == AFDRole.AFD_ROLE_ATTN:
+                self.afd_send_to_ffn = get_zmq_socket(
+                    context, zmq.PUSH, port_args.afd_ipc_name, False
+                )
+            elif self.afd_role == AFDRole.AFD_ROLE_FFN:
+                self.afd_recv_from_attn = get_zmq_socket(
+                    context, zmq.PULL, port_args.afd_ipc_name, True
+                )
+
     def init_idle_sleeper(self) -> None:
         if (
             self.ps.pp_rank == 0
@@ -789,11 +821,14 @@ class Scheduler(
             and self.ps.attn_cp_rank == 0
             and get_device().sleep_on_idle
         ):
+            sockets = [
+                self.ipc_channels.recv_from_tokenizer,
+                self.ipc_channels.recv_from_rpc,
+            ]
+            if self.afd_recv_from_attn is not None:
+                sockets.append(self.afd_recv_from_attn)
             self.idle_sleeper = IdleSleeper(
-                sockets=[
-                    self.ipc_channels.recv_from_tokenizer,
-                    self.ipc_channels.recv_from_rpc,
-                ],
+                sockets=sockets,
             )
         else:
             self.idle_sleeper = None
@@ -1654,6 +1689,7 @@ class Scheduler(
                     ListExternalCorporaReqInput,
                     self.list_external_corpora,
                 ),
+                (AFSyncReq, self.handle_afd_sync),
             ]
         )
 
@@ -1772,6 +1808,8 @@ class Scheduler(
 
             # Launch the current batch
             if batch:
+                self._afd_send_req_to_ffn(AFSyncReq())
+
                 result = self.run_batch(batch)
                 self.process_batch_result(batch, result)
             else:
@@ -1783,6 +1821,30 @@ class Scheduler(
             self.last_batch = batch
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.invariant_checker.self_check_during_busy()
+
+    def _afd_send_req_to_ffn(self, req):
+        if (
+            self.afd_role == AFDRole.AFD_ROLE_ATTN
+            and self.ps.pp_rank == 0
+            and self.ps.tp_rank == 0
+        ):
+            self.afd_send_to_ffn.send_pyobj(req)
+
+    @DynamicGradMode()
+    def event_loop_afd_ffn_normal(self):
+        """A normal scheduler loop for afd ffn."""
+        while True:
+            if self.gracefully_exit:
+                break
+
+            self.afd_ffn_running = False
+            recv_reqs = self.request_receiver.recv_requests()
+            self.process_input_requests(recv_reqs)
+
+            if self.afd_ffn_running:
+                self.tp_worker.model_runner.afd_forward_ffn()
+            else:
+                self.maybe_sleep_on_idle()
 
     @DynamicGradMode()
     def event_loop_overlap(self):
@@ -2064,6 +2126,8 @@ class Scheduler(
             stream_output=lambda *a, **kw: self.output_streamer.stream_output(*a, **kw),
             get_last_batch=lambda: self.last_batch,
             scripted_scheduler_hook=self.scripted_scheduler_hook,
+            afd_send_to_ffn=self.afd_send_to_ffn,
+            afd_recv_from_attn=self.afd_recv_from_attn,
         )
 
     def init_dp_attn_adapter(self) -> None:
@@ -5008,6 +5072,10 @@ class Scheduler(
         self.ipc_channels.send_to_detokenizer.send_output(recv_req, recv_req)
         return None
 
+    def handle_afd_sync(self, recv_req: AFSyncReq):
+        self.afd_ffn_running = True
+        return None
+
     def handle_shutdown(self, recv_req: ShutdownReq):
         # Break the event loop; the finally in run_scheduler_process releases resources.
         self.gracefully_exit = True
@@ -5048,6 +5116,13 @@ class Scheduler(
 
 
 def dispatch_event_loop(scheduler: Scheduler):
+    if scheduler.afd_role is not None:
+        if scheduler.afd_role == AFDRole.AFD_ROLE_FFN:
+            scheduler.event_loop_afd_ffn_normal()
+        else:
+            scheduler.event_loop_normal()
+        return
+
     # The live PP property asserts before torch.distributed init (MLX stub).
     disaggregation_mode: DisaggregationMode = scheduler.disaggregation_mode
     if disaggregation_mode == DisaggregationMode.NULL:

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -66,6 +66,10 @@ class SchedulerRequestReceiver:
     stream_output: Callable[..., None]
     get_last_batch: Callable[[], Any]
     scripted_scheduler_hook: Optional[ScriptedSchedulerHook] = None
+    # AFD (Attention-FFN disaggregation) control channel, only active at
+    # tp_rank 0: ATTN forwards control requests to FFN, FFN receives them.
+    afd_send_to_ffn: Optional[zmq.Socket] = None
+    afd_recv_from_attn: Optional[zmq.Socket] = None
 
     def recv_limit_reached(self, num_recv_reqs: int) -> bool:
         if self.max_recv_per_poll < 0:
@@ -132,6 +136,31 @@ class SchedulerRequestReceiver:
                     except zmq.ZMQError:
                         break
                     recv_reqs.append(recv_rpc)
+
+                if self.ps.tp_rank == 0:
+                    if self.afd_send_to_ffn is not None:
+                        # AFD ATTN: forward control reqs to the FFN scheduler.
+                        for req in recv_reqs:
+                            if not isinstance(
+                                req,
+                                (
+                                    TokenizedGenerateReqInput,
+                                    TokenizedEmbeddingReqInput,
+                                    BatchTokenizedGenerateReqInput,
+                                    BatchTokenizedEmbeddingReqInput,
+                                ),
+                            ):
+                                self.afd_send_to_ffn.send_pyobj(req)
+                    elif self.afd_recv_from_attn is not None:
+                        # AFD FFN: drain the control reqs forwarded by ATTN.
+                        while True:
+                            try:
+                                recv_afd = self.afd_recv_from_attn.recv_pyobj(
+                                    zmq.NOBLOCK
+                                )
+                            except zmq.ZMQError:
+                                break
+                            recv_reqs.append(recv_afd)
             else:
                 recv_reqs = None
         else:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1526,6 +1526,25 @@ class ModelRunner:
         forward_batch.split_index = next_split_index
         return ret
 
+    def afd_forward_ffn(self):
+        from sglang.srt.afd.afd_type import AFDRole
+
+        assert self.server_args.afd_role == AFDRole.AFD_ROLE_FFN
+
+        # forward_batch fields like input_ids are needed in forwarding
+        placeholder = torch.zeros(0).to(self.device, non_blocking=True)
+        forward_batch = ForwardBatch(
+            forward_mode=0,
+            batch_size=0,
+            input_ids=placeholder,
+            req_pool_indices=placeholder,
+            seq_lens=placeholder,
+            out_cache_loc=placeholder,
+            seq_lens_sum=0,
+        )
+
+        self.model.forward(forward_batch.input_ids, None, forward_batch)
+
     def forward(
         self,
         forward_batch: ForwardBatch,

--- a/python/sglang/srt/models/qwen2_moe.py
+++ b/python/sglang/srt/models/qwen2_moe.py
@@ -28,6 +28,7 @@ from torch import nn
 from transformers import PretrainedConfig
 
 from sglang.kernels.ops.elementwise.elementwise import fused_gate_sigmoid_mul_add
+from sglang.srt.afd.afd_type import afd_is_ffn
 from sglang.srt.batch_overlap.two_batch_overlap import model_forward_maybe_tbo
 from sglang.srt.distributed import (
     get_pp_group,
@@ -943,7 +944,8 @@ class Qwen2MoeModel(nn.Module):
         self.moe_dp_size = get_parallel().moe_dp_size
         self.attn_cp_size = get_parallel().attn_cp_size
 
-        if self.pp_group.is_first_rank:
+        # AFD: always skip embed for ffn
+        if not afd_is_ffn() and self.pp_group.is_first_rank:
             self.embed_tokens = VocabParallelEmbedding(
                 config.vocab_size,
                 config.hidden_size,

--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -25,6 +25,8 @@ import torch
 from torch import nn
 from transformers import PretrainedConfig
 
+from sglang.srt.afd.afd_model import AFDProxyAttention
+from sglang.srt.afd.afd_type import afd_is_attn, afd_is_ffn, get_afd_role
 from sglang.srt.distributed import (
     get_pp_group,
     moe_expert_parallel_all_reduce,
@@ -48,7 +50,7 @@ from sglang.srt.layers.moe import (
 )
 from sglang.srt.layers.moe.ep_moe.layer import get_moe_impl_class
 from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
-from sglang.srt.layers.moe.topk import TopK
+from sglang.srt.layers.moe.topk import StandardTopKOutput, TopK
 from sglang.srt.layers.moe.utils import (
     RoutingMethodType,
     filter_moe_weight_param_global_expert,
@@ -291,13 +293,16 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
             self.num_experts = (
                 config.num_experts + get_exec().moe.ep_num_redundant_experts
             )
-            self.top_k = config.num_experts_per_tok
+        self.top_k = config.num_experts_per_tok
 
     def forward(
         self,
         hidden_states: torch.Tensor,
         forward_batch: Optional[ForwardBatch] = None,
     ) -> torch.Tensor:
+
+        if get_afd_role() is not None:
+            return self.forward_afd(hidden_states, forward_batch)
 
         if (
             not is_deepep_class_backend()
@@ -316,6 +321,37 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
                 name, x, self.experts.num_local_experts
             )
         ]
+
+    def forward_afd(
+        self,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ) -> torch.Tensor:
+
+        if afd_is_ffn():
+            self.experts(hidden_states, None)
+            return hidden_states
+
+        num_tokens, hidden_dim = hidden_states.shape
+        hidden_states = hidden_states.view(-1, hidden_dim)
+
+        # router_logits: (num_tokens, n_experts)
+        router_logits, _ = self.gate(hidden_states)
+
+        if num_tokens == 0:
+            topk_ids = torch.full(
+                (0, self.top_k), -1, dtype=torch.int, device=hidden_states.device
+            )
+            topk_weights = torch.empty(
+                (0, self.top_k), dtype=torch.float32, device=hidden_states.device
+            )
+
+            topk_output = StandardTopKOutput(topk_weights, topk_ids, router_logits)
+        else:
+            topk_output = self.topk(hidden_states, router_logits)
+
+        final_hidden_states = self.experts(hidden_states, topk_output, forward_batch)
+        return final_hidden_states
 
     def forward_normal(
         self,
@@ -733,24 +769,29 @@ class Qwen3MoeDecoderLayer(nn.Module):
         dual_chunk_attention_config = getattr(
             config, "dual_chunk_attention_config", None
         )
-        self.self_attn = Qwen3MoeAttention(
-            hidden_size=self.hidden_size,
-            num_heads=config.num_attention_heads,
-            num_kv_heads=config.num_key_value_heads,
-            layer_id=layer_id,
-            start_layer=start_layer,
-            rope_theta=rope_theta,
-            rope_scaling=rope_scaling,
-            max_position_embeddings=max_position_embeddings,
-            head_dim=head_dim,
-            rms_norm_eps=rms_norm_eps,
-            attention_bias=attention_bias,
-            config=config,
-            quant_config=quant_config,
-            prefix=add_prefix("self_attn", prefix),
-            dual_chunk_attention_config=dual_chunk_attention_config,
-            alt_stream=alt_stream,
-        )
+
+        # AFD: the FFN role skips attention entirely; install a placeholder.
+        if afd_is_ffn():
+            self.self_attn = AFDProxyAttention()
+        else:
+            self.self_attn = Qwen3MoeAttention(
+                hidden_size=self.hidden_size,
+                num_heads=config.num_attention_heads,
+                num_kv_heads=config.num_key_value_heads,
+                layer_id=layer_id,
+                start_layer=start_layer,
+                rope_theta=rope_theta,
+                rope_scaling=rope_scaling,
+                max_position_embeddings=max_position_embeddings,
+                head_dim=head_dim,
+                rms_norm_eps=rms_norm_eps,
+                attention_bias=attention_bias,
+                config=config,
+                quant_config=quant_config,
+                prefix=add_prefix("self_attn", prefix),
+                dual_chunk_attention_config=dual_chunk_attention_config,
+                alt_stream=alt_stream,
+            )
 
         self.layer_id = layer_id
 
@@ -1017,6 +1058,9 @@ class Qwen3MoeForCausalLM(nn.Module):
         if self.capture_aux_hidden_states:
             hidden_states, aux_hidden_states = hidden_states
 
+        if afd_is_ffn():
+            return hidden_states
+
         if self.pp_group.is_last_rank:
             logits_output = self.logits_processor(
                 input_ids, hidden_states, self.lm_head, forward_batch, aux_hidden_states
@@ -1111,21 +1155,27 @@ class Qwen3MoeForCausalLM(nn.Module):
     def load_weights(
         self, weights: Iterable[Tuple[str, torch.Tensor]], is_mtp: bool = False
     ):
-        stacked_params_mapping = [
-            # (param_name, shard_name, shard_id)
-            ("qkv_proj", "q_proj", "q"),
-            ("qkv_proj", "k_proj", "k"),
-            ("qkv_proj", "v_proj", "v"),
-            ("gate_up_proj", "gate_proj", 0),
-            ("gate_up_proj", "up_proj", 1),
-        ]
+        if afd_is_ffn():
+            stacked_params_mapping = []
+        else:
+            stacked_params_mapping = [
+                # (param_name, shard_name, shard_id)
+                ("qkv_proj", "q_proj", "q"),
+                ("qkv_proj", "k_proj", "k"),
+                ("qkv_proj", "v_proj", "v"),
+                ("gate_up_proj", "gate_proj", 0),
+                ("gate_up_proj", "up_proj", 1),
+            ]
 
-        expert_params_mapping = FusedMoE.make_expert_params_mapping(
-            ckpt_gate_proj_name="gate_proj",
-            ckpt_down_proj_name="down_proj",
-            ckpt_up_proj_name="up_proj",
-            num_experts=self.config.num_experts,
-        )
+        if afd_is_attn():
+            expert_params_mapping = []
+        else:
+            expert_params_mapping = FusedMoE.make_expert_params_mapping(
+                ckpt_gate_proj_name="gate_proj",
+                ckpt_down_proj_name="down_proj",
+                ckpt_up_proj_name="up_proj",
+                num_experts=self.config.num_experts,
+            )
 
         # Pre-define `params_dict` to avoid repeated expensive traversal of model parameters.
         params_dict = dict(self.named_parameters())

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -33,6 +33,7 @@ import uuid
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from sglang.kernels.ops.kv_canary.consts import RealKvHashMode
+from sglang.srt.afd.afd_type import AFDRole
 from sglang.srt.arg_groups.arg_utils import NS, A, Arg, add_cli_args_from_dataclass
 from sglang.srt.arg_groups.argparse_actions import (
     DeprecatedAction,
@@ -3238,6 +3239,29 @@ class ServerArgs:
     ] = 0
 
     # -------------------------------------------------------------------------
+    # Attention-FFN disaggregation (AFD)
+    # -------------------------------------------------------------------------
+    afd_role: A[
+        Optional[AFDRole],
+        Arg(
+            help="AFD role, i.e., `attn` or `ffn`.",
+            choices=list(AFDRole),
+            type_parser=AFDRole,
+        ),
+        NS("disagg"),
+    ] = None
+    afd_transfer_backend: A[
+        Literal["stepmesh"],
+        Arg(help="Backend for AFD."),
+        NS("disagg"),
+    ] = "stepmesh"
+    afd_ffn_addr: A[
+        Optional[str],
+        "The host address (ip:port) for FFN (e.g., `192.168.0.2:25000`).",
+        NS("disagg"),
+    ] = None
+
+    # -------------------------------------------------------------------------
     # Encode prefill disaggregation
     # -------------------------------------------------------------------------
     encoder_only: A[
@@ -3827,6 +3851,9 @@ class ServerArgs:
         # Validate PD disaggregation flags before CUDA graph config.
         self._handle_pd_disaggregation()
 
+        # Validate Attention-FFN disaggregation (AFD) flags.
+        self._handle_afd_validation()
+
         # Normalize deprecated CP aliases before validations or model-specific
         # defaults inspect enable_prefill_cp/cp_strategy.
         self._handle_legacy_cp_arguments()
@@ -4190,6 +4217,31 @@ class ServerArgs:
         )
 
         handle_pd_disaggregation(self)
+
+    def _handle_afd_validation(self):
+        if self.afd_role is None:
+            return
+
+        # Either not compatible or temporarily unsupported.
+        assert self.disable_cuda_graph, "Cuda graph is not supported for AFD."
+        assert (
+            self.disable_overlap_schedule
+        ), "Overlap schedule is not supported for AFD."
+
+        assert self.nnodes == 1, "Multi-node distribution is not supported for AFD."
+        assert (
+            self.disaggregation_mode == "null"
+        ), "Disaggregation mode is not supported for AFD."
+        assert self.pp_size == 1, "PP is not supported for AFD."
+        if self.tp_size > 1:
+            assert (
+                self.enable_dp_attention
+            ), "DP attention must be enabled if tp_size > 1 for AFD"
+
+        assert self.moe_a2a_backend == "none", "MoE A2A is not compatible with AFD."
+        assert (
+            not self.enable_two_batch_overlap
+        ), "Two batch overlap is not compatible with AFD."
 
     def _handle_dcp_validation(self):
         if self.dcp_size < 1:
@@ -10576,6 +10628,9 @@ class PortArgs:
     # empty when IPC mode derives the address from instance_id).
     load_collector_ipc_name: str = ""
 
+    # The ipc endpoint for Attn-to-FFN scheduler sync (AFD only)
+    afd_ipc_name: Optional[str] = None
+
     # Stable token shared by all processes in one server instance, used to
     # derive the /dev/shm path for load snapshots.
     instance_id: str = ""
@@ -10599,6 +10654,20 @@ class PortArgs:
             )
 
         instance_id = uuid.uuid4().hex[:12]
+
+        # always use TCP for AFD
+        afd_ipc_name = None
+        if server_args.afd_role is not None:
+            assert (
+                server_args.afd_ffn_addr is not None
+            ), "Please provide --afd-ffn-addr for AFD"
+            try:
+                afd_ffn_addr = NetworkAddress.parse(server_args.afd_ffn_addr)
+            except ValueError:
+                raise ValueError(
+                    "Please provide --afd-ffn-addr as host:port of FFN node"
+                )
+            afd_ipc_name = afd_ffn_addr.to_tcp()
 
         decoupled_spec_ipc_config = None
         if server_args.decoupled_spec_role != "null":
@@ -10629,6 +10698,7 @@ class PortArgs:
                 metrics_ipc_name=f"ipc://{tempfile.NamedTemporaryFile(delete=False).name}",
                 tokenizer_worker_ipc_name=tokenizer_worker_ipc_name,
                 decoupled_spec_ipc_config=decoupled_spec_ipc_config,
+                afd_ipc_name=afd_ipc_name,
                 instance_id=instance_id,
             )
         else:
@@ -10720,5 +10790,6 @@ class PortArgs:
                 load_collector_ipc_name=NetworkAddress(
                     dist_init_host, load_collector_port
                 ).to_tcp(),
+                afd_ipc_name=afd_ipc_name,
                 instance_id=instance_id,
             )


### PR DESCRIPTION
Separates attention and FFN/expert layers onto distinct sets of GPUs (Qwen3-MoE only, StepMesh transfer backend). Adapted to the current tree: config reads go through the RuntimeContext disagg bag instead of the removed global_server_args_dict, server args use the A[..., NS()] dataclass CLI derivation, and the Attn->FFN control channel hooks into SchedulerRequestReceiver / TypeBasedDispatcher.

- afd/: AFDRole helpers and AFDProxyAttention placeholder
- token_dispatcher/stepmesh.py: StepMeshATTN/FFN communication layer
- server_args.py: --afd-role/--afd-transfer-backend/--afd-ffn-addr, compatibility validation, PortArgs.afd_ipc_name (TCP)
- parallel_state.py: local group (per-node ranks) init/destroy, wired in distributed/bootstrap.py for AFD runs
- scheduler.py: AFD event loop for FFN, AFSyncReq work sync, control request forwarding at tp_rank 0
- ep_moe/layer.py: AFDATTNMoE / AFDFFNMoE via get_moe_impl_class
- qwen3_moe.py / qwen2_moe.py: forward_afd, role-based weight loading, FFN-side attention/embed skipping; communicator.py short-circuits
- http_server.py: skip warmup for the FFN role

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32804139826](https://github.com/sgl-project/sglang/actions/runs/32804139826)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32804139640](https://github.com/sgl-project/sglang/actions/runs/32804139640)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32804139889](https://github.com/sgl-project/sglang/actions/runs/32804139889)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->