### PR TITLE
[CPU] Raise mem-fraction-static 0.1->0.2 in intel_amx backend a/b

### DIFF
--- a/test/registered/cpu/test_intel_amx_attention_backend_a.py
+++ b/test/registered/cpu/test_intel_amx_attention_backend_a.py
@@ -34,7 +34,7 @@ class TestIntelAMXAttnBackend(CustomTestCase):
         return DEFAULT_MLA_MODEL_NAME_FOR_TEST
 
     @intel_amx_benchmark(
-        extra_args=["--batch-size", "4", "--mem-fraction-static", "0.1"],
+        extra_args=["--batch-size", "4", "--mem-fraction-static", "0.2"],
         min_throughput=40,
     )
     def test_latency_default_model(self):
@@ -84,7 +84,7 @@ class TestDPAttention(CustomTestCase):
             "--attention-backend",
             "intel_amx",
             "--mem-fraction-static",
-            "0.1",
+            "0.2",
             "--disable-overlap-schedule",
             "--tp",
             "2",

--- a/test/registered/cpu/test_intel_amx_attention_backend_b.py
+++ b/test/registered/cpu/test_intel_amx_attention_backend_b.py
@@ -20,14 +20,14 @@ register_cpu_ci(est_time=47, suite="base-b-test-cpu")
 class TestIntelAMXAttnBackendQuant(CustomTestCase):
 
     @intel_amx_benchmark(
-        extra_args=["--batch-size", "4", "--mem-fraction-static", "0.1"],
+        extra_args=["--batch-size", "4", "--mem-fraction-static", "0.2"],
         min_throughput=150,
     )
     def test_latency_fp8_qwen(self):
         return DEFAULT_MODEL_NAME_FOR_TEST_QWEN_FP8
 
     @intel_amx_benchmark(
-        extra_args=["--batch-size", "4", "--mem-fraction-static", "0.1"],
+        extra_args=["--batch-size", "4", "--mem-fraction-static", "0.2"],
         min_throughput=50,
     )
     def test_latency_fp8_moe_model(self):


### PR DESCRIPTION
  ## Problem

  `test_intel_amx_attention_backend_a` / `_b` flakily fail with:

  > ValueError: Loaded weights leave no GPU memory for the KV cache under --mem-fraction-static=0.1

  Passing one day, failing the next, with no relevant code change.

  ## Root cause

  The KV-cache configurator computes `slack = pre_model_load_memory * (1 - mem_fraction_static)`
  and `rest_memory = available_now - slack`, then raises if `rest_memory <= 0`.
  `pre_model_load_memory` and `available_now` are sampled at **different moments**
  (before load vs. at configure). With `0.1`, slack is 90% of pre, leaving only
  ~10% headroom (~23GB on a 234GB NUMA node).

  Under the new dual-socket parallel CPU CI (two socket-pinned containers loading
  models simultaneously), a peer container's allocation transiently drops
  `available_now` below `0.9*pre` in that window -> `rest_memory` goes negative
  -> raise. It's a timing race on available memory, not a code regression.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32804624754](https://github.com/sgl-project/sglang/actions/runs/32804624754)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32817580621](https://github.com/sgl-project/sglang/actions/runs/32817580621)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #32804624952](https://github.com/sgl-project/sglang/actions/runs/32804624952)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->