### PR TITLE
fix(BCG dp): align prefill CUDA graph capture sizes to attn_tp_size under DP attention

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -73,6 +73,7 @@ from sglang.srt.speculative.decoupled_spec_io import DecoupledSpecIpcConfig
 from sglang.srt.utils.common import (
     LORA_TARGET_ALL_MODULES,
     SUPPORTED_LORA_TARGET_MODULES,
+    ceil_align,
     configure_media_url_security,
     get_device,
     get_device_memory_capacity,
@@ -4747,6 +4748,7 @@ class ServerArgs:
         disable_kimi_k3_symm_mem(self)
         self._apply_cuda_graph_compatibility()
         self._apply_deepep_adjustments()
+        self._apply_dp_attn_capture_alignment()
         self._apply_cuda_graph_disaggregation_roles()
         self._validate_cuda_graph_config()
         # Warn on the final resolved config (not inside the compat cascade —
@@ -4781,6 +4783,36 @@ class ServerArgs:
                 )
                 self.cuda_graph_config.prefill.bs = aligned
                 self.cuda_graph_config.prefill.max_bs = aligned[-1]
+
+    def _apply_dp_attn_capture_alignment(self):
+        """Align prefill CUDA graph capture sizes to attn_tp_size."""
+        view = self._resolved()
+        if not view.enable_dp_attention:
+            return
+
+        attn_dp_size = self.dp_size if view.enable_dp_attention else 1
+        if attn_dp_size == 0:
+            return
+        attn_tp_size = self.tp_size // attn_dp_size
+        if attn_tp_size <= 1:
+            return
+
+        bs = self.cuda_graph_config.prefill.bs
+        if bs is None:
+            max_bs = self.cuda_graph_config.prefill.max_bs or 2048
+            bs = self._generate_prefill_cuda_graph_batch_sizes(max_bs)
+        aligned = sorted({ceil_align(b, attn_tp_size) for b in bs})
+        if aligned != sorted(bs):
+            logger.info(
+                "Prefill CUDA graph with DP attention (attn_tp_size=%d) "
+                "requires bucket sizes divisible by %d; aligning %s -> %s.",
+                attn_tp_size,
+                attn_tp_size,
+                sorted(bs),
+                aligned,
+            )
+            self.cuda_graph_config.prefill.bs = aligned
+            self.cuda_graph_config.prefill.max_bs = aligned[-1]
 
     def _parse_cuda_graph_config(self):
         """Resolve cuda_graph_config from explicit JSON, per-phase


### PR DESCRIPTION
## Why

- Commit `429f6b6d15` removed the "DP attention" disable rule from `_disable_breakable_cudagraph_if_incompatible`, allowing breakable prefill CUDA graph to run with DP attention.
- The prefill CUDA graph capture path (`capture_prepare`) does not align `num_tokens` to `attn_tp_size`, unlike the eager path (`prepare_mlp_sync_batch`) which applies `ceil_align`.
- When `attn_tp_size > 1`, the DP gather path (`_dp_gather_via_all_gather`) calls `reduce_scatter_tensor` on the `attn_tp_group`, which requires the per-rank token count to be divisible by `attn_tp_size`. Default capture bucket sizes `4, 12, 20, 28` violate this constraint, causing:
  ```
  ValueError: input tensor must be the same size as output size times world size
  ```

## How

- Add `_apply_dp_attn_capture_alignment` method in `ServerArgs` that runs after `_apply_deepep_adjustments` in `_handle_cuda_graph_config`.
- When `enable_dp_attention` is `True` and `attn_tp_size > 1`, it aligns prefill CUDA graph capture bucket sizes to multiples of `attn_tp_size` using `ceil_align`, mirroring the existing alignment in the eager path.

## Test plan

- [ ] Launch server with `--tp-size 32 --enable-dp-attention --dp-size 2 --quantization w8a8_int8 --attention-backend fa3 --trust-remote-code` and verify prefill CUDA graph capture completes without `reduce_scatter_tensor` `ValueError`
- [ ] Verify GSM8K accuracy with score threshold 0.50 using 200 examples

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32806929060](https://github.com/sgl-project/sglang/actions/runs/32806929060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32806928743](https://github.com/sgl-project/sglang/actions/runs/32806928743)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32806928971](https://github.com/sgl-project/sglang/actions/runs/32806928971)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->