### PR TITLE
[Kimi-K3] Fix deferred preprocessing grids under vision DP

### DIFF
--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -3339,6 +3339,8 @@ class KimiK3ForConditionalGeneration(nn.Module):
                 for backend, indices in deferred_by_backend.items():
                     group_items = [selected_items[index] for index in indices]
                     group_configs = [deferred[index] for index in indices]
+                    # ``indices`` is rank-local; grid_thws_host is global.
+                    global_indices = [image_indices[index] for index in indices]
                     first_config = group_configs[0]
                     if backend == "gpu":
                         from sglang.srt.multimodal.processors.kimi_k25 import (
@@ -3361,7 +3363,7 @@ class KimiK3ForConditionalGeneration(nn.Module):
                                 x, first_config.transparent_bg_config
                             ),
                         )
-                        expected_grids = grid_thws_host[indices]
+                        expected_grids = grid_thws_host[global_indices]
                         if not torch.equal(produced_grids.cpu(), expected_grids):
                             raise ValueError(
                                 "Kimi-K3 deferred GPU preprocessing produced wrong grids"
@@ -3380,7 +3382,8 @@ class KimiK3ForConditionalGeneration(nn.Module):
                         )
 
                     patch_counts = [
-                        int(grid_thws_host[index].prod().item()) for index in indices
+                        int(grid_thws_host[index].prod().item())
+                        for index in global_indices
                     ]
                     if sum(patch_counts) != pixel_values.shape[0]:
                         raise ValueError(

--- a/test/registered/unit/models/test_kimi_k3_vision.py
+++ b/test/registered/unit/models/test_kimi_k3_vision.py
@@ -503,6 +503,7 @@ def test_kimi_k3_encoder_dp_defers_feature_materialization(monkeypatch):
 
 
 def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
+    """A vision-DP owner uses each assigned image's global grid."""
     from unittest.mock import patch as mock_patch
 
     from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
@@ -531,13 +532,15 @@ def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
             "pad_height": 0,
         },
     )
+    grids = [[1, 1, 1], [1, 1, 2]]
+    patch_counts = [grid[0] * grid[1] * grid[2] for grid in grids]
     items = [
         MultimodalDataItem(
             modality=Modality.IMAGE,
             offsets=[(index, index)],
             feature=torch.full((3, 2, 2), index, dtype=torch.uint8),
             model_specific_data={
-                "image_grid_thw": torch.tensor([[1, 1, 1]]),
+                "image_grid_thw": torch.tensor([grids[index]]),
                 DEFERRED_PREPROCESSING_KEY: deferred_config,
             },
         )
@@ -546,8 +549,12 @@ def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
     calls = []
 
     def fake_preprocess(images, resize_configs, *args, **kwargs):
-        calls.append([int(image[0, 0, 0]) for image in images])
-        return torch.tensor([[float(calls[-1][0]), 0.0]]), torch.tensor([[1, 1, 1]])
+        ids = [int(image[0, 0, 0]) for image in images]
+        calls.append(ids)
+        pixel_values = torch.cat(
+            [torch.full((patch_counts[i], 2), float(i)) for i in ids]
+        )
+        return pixel_values, torch.tensor([grids[i] for i in ids])
 
     # Configured TP size (the IPC consumer count) comes from the published
     # bags; the live topology is forced through the context's own override.
@@ -566,7 +573,8 @@ def test_kimi_k3_preprocesses_only_dp_owner_images(monkeypatch):
 
     assert calls == [[1]]
     assert one.dtype == torch.float32
-    assert one.tolist() == [[1.0, 0.0]]
+    assert one.shape == (2, 2)
+    assert (one == 1.0).all()
 
 
 def test_kimi_k3_scheduler_leaves_feature_placement_to_dp_owner():


### PR DESCRIPTION
## Summary

Backport the Kimi-K3 deferred GPU preprocessing fix to `release/v0.5.18`.

## Root cause

With vision-DP enabled, `load_local_pixel_values(image_indices)` receives global image indices but builds `selected_items` as a rank-local shard. The deferred backend loop then used its local `indices` to index `grid_thws_host`, which is global. When a rank owned a non-prefix image and the images had different NaViT grids, the produced grids and patch-count split were compared against the wrong image, raising:

```text
ValueError: Kimi-K3 deferred GPU preprocessing produced wrong grids
```

## Fix

Translate the backend-group local positions through `image_indices` before reading global grid metadata. Use the mapped indices for both GPU grid validation and feature patch-count splitting.

## Validation

- `pre-commit run --files python/sglang/srt/models/kimi_k3.py test/registered/unit/models/test_kimi_k3_vision.py` passed.
- Updated regression test uses a non-prefix DP owner (`image_indices=[1]`) and distinct grids (`[1,1,1]` vs `[1,1,2]`), covering both grid validation and patch splitting.
- Local pytest collection was blocked by the macOS PyTorch installation missing `torch.cuda.memory._cuda_beginAllocateCurrentThreadToPool`; NVIDIA CI should run the registered Kimi-K3 test.

The same fix is already present on current `main` as #35305; this PR backports it to the v0.5.18 release branch that contains the reported crash.

Fixes #36018

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32807733355](https://github.com/sgl-project/sglang/actions/runs/32807733355)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32807994441](https://github.com/sgl-project/sglang/actions/runs/32807994441)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32807733354](https://github.com/sgl-project/sglang/actions/runs/32807733354)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->