### PR TITLE
test(perf): add AMD score API latency bounds

### DIFF
--- a/test/registered/perf/test_bench_serving_1gpu_part2.py
+++ b/test/registered/perf/test_bench_serving_1gpu_part2.py
@@ -94,8 +94,12 @@ class TestBenchServing1GPUPart2(CustomTestCase):
             )
 
         self.assertEqual(res["successful_requests"], res["total_requests"])
-        self.assertLess(res["avg_latency_ms"], 48)
-        self.assertLess(res["p95_latency_ms"], 50)
+        if is_in_amd_ci():
+            self.assertLess(res["avg_latency_ms"], 55)
+            self.assertLess(res["p95_latency_ms"], 60)
+        else:
+            self.assertLess(res["avg_latency_ms"], 48)
+            self.assertLess(res["p95_latency_ms"], 50)
         self.assertGreater(res["throughput"], 20)
 
     def test_score_api_batch_scaling(self):


### PR DESCRIPTION


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32807887267](https://github.com/sgl-project/sglang/actions/runs/32807887267)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32807887086](https://github.com/sgl-project/sglang/actions/runs/32807887086)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32807887245](https://github.com/sgl-project/sglang/actions/runs/32807887245)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->