### PR TITLE
[AMD] Add ROCm MegaMoE path via AITER MegaMoEV2

### DIFF
--- a/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
+++ b/docs/cookbook/autoregressive/DeepSeek/DeepSeek-V4.mdx
@@ -325,7 +325,7 @@ HiCache and MegaMoE are **not** supported on RTX PRO 6000.
 - **Supported models** — **MI300X** supports DeepSeek-V4-Flash in FP8; **MI355X** supports DeepSeek-V4-Flash / Pro in both FP4 and FP8. All recipes run single-node.
 - **TP / DP setting** — both TP=4 and TP=8 are supported. At low concurrency we recommend **TP-only**; at high concurrency use **TP + DP**, which additionally needs `--dp 8 --enable-dp-attention --enable-prefill-delayer --prefill-delayer-max-delay-ms 5000`.
 - **MTP** — speculative decoding is supported; add `--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`.
-- **Kernels** — uses the Unified KV attention and the flydsl MoE.
+- **Kernels** — uses the Unified KV attention and the flydsl MoE. On MI355X, fused MegaMoE is available via `--moe-a2a-backend megamoe` (requires `SGLANG_USE_AITER=1` and AITER MegaMoEV2). Set `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK` to a power-of-two cap covering peak tokens per rank.
 
 **MegaMoE**
 
@@ -341,7 +341,7 @@ Two variants are exposed:
   Higher throughput with negligible accuracy drop (~89.5 GPQA on Pro).
 
 Notes:
-- The W4A8 / W4A4 variants above are **Blackwell-only** (B200 / B300 / GB200 / GB300). On **Hopper (SM90, H100 / H200)** use the all-FP8 MegaMoE path described below instead.
+- The W4A8 / W4A4 variants above are **Blackwell-only** (B200 / B300 / GB200 / GB300) via DeepGEMM. On **MI355X**, `--moe-a2a-backend megamoe` uses AITER FlyDSL MegaMoEV2 instead (see the AMD note). On **Hopper (SM90, H100 / H200)** use the all-FP8 MegaMoE path described below.
 - MegaMoE is **only wired into the `high-throughput` recipe** on Blackwell (per [sgl-project/sglang#26451](https://github.com/sgl-project/sglang/pull/26451)). The chip is hidden on `low-latency` and `balanced` — switch to `high-throughput` to expose it.
 - When running MegaMoE, don't set `--moe-runner-backend` manually.
 - Adjust `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK` based on your workload and memory usage. Setting higher number of tokens for MegaMoE requires more HBM space (recommended: 8320 for high-throughput).

--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -245,7 +245,7 @@ sgl-eval run aime25 \\
           // strategy for experimentation (docs recommend it on high-throughput).
           { id: "megamoe",           label: "MegaMoE",
             flags: ["--moe-a2a-backend megamoe"],
-            requiresHw: ["b200", "b300", "gb200", "gb300"] },
+            requiresHw: ["b200", "b300", "gb200", "gb300", "mi355x"] },
           { id: "flashinfer_mxfp4",  label: "FlashInfer (MXFP4)",
             flags: ["--moe-runner-backend flashinfer_mxfp4"] },
           { id: "marlin",            label: "Marlin (W4A16)",

--- a/python/sglang/srt/arg_groups/mega_moe_hook.py
+++ b/python/sglang/srt/arg_groups/mega_moe_hook.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 def handle_mega_moe(server_args: ServerArgs) -> None:
     handle_moe_runner_backend_alias(server_args)
     handle_w4a4_mxfp4_megamoe_env(server_args)
+    handle_rocm_megamoe(server_args)
 
 
 def handle_moe_runner_backend_alias(server_args: ServerArgs) -> None:
@@ -42,3 +43,33 @@ def handle_w4a4_mxfp4_megamoe_env(server_args: ServerArgs) -> None:
 
     os.environ["DG_USE_FP4_ACTS"] = "1"
     os.environ["DG_USE_MXF4_KIND"] = "1"
+
+
+def handle_rocm_megamoe(server_args: ServerArgs) -> None:
+    if server_args.moe_a2a_backend != "megamoe":
+        return
+
+    from sglang.srt.environ import envs
+    from sglang.srt.utils import is_hip
+
+    if not is_hip():
+        return
+
+    mtpr = envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get()
+    if mtpr <= 0 or (mtpr & (mtpr - 1)) != 0:
+        raise ValueError(
+            "MegaMoE on ROCm requires "
+            "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK to be a "
+            f"positive power of two (AITER MegaMoEV2 P2P wire format), got {mtpr}"
+        )
+    if not envs.SGLANG_USE_AITER.get():
+        raise ValueError(
+            "MegaMoE on ROCm requires SGLANG_USE_AITER=1 and an AITER build "
+            "that exports aiter.ops.flydsl.kernels.mega_moe.MegaMoEV2 "
+            "(ROCm/aiter#4439)."
+        )
+    logger.info(
+        "MegaMoE on ROCm: using AITER FlyDSL MegaMoEV2 (mtpr=%s, ep_size=%s).",
+        mtpr,
+        server_args.ep_size,
+    )

--- a/python/sglang/srt/arg_groups/mega_moe_hook.py
+++ b/python/sglang/srt/arg_groups/mega_moe_hook.py
@@ -68,6 +68,12 @@ def handle_rocm_megamoe(server_args: ServerArgs) -> None:
             "that exports aiter.ops.flydsl.kernels.mega_moe.MegaMoEV2 "
             "(ROCm/aiter#4439)."
         )
+    if os.environ.get("MORI_SHMEM_MODE", "").lower() == "isolation":
+        raise ValueError(
+            "MegaMoE on ROCm does not support MORI_SHMEM_MODE=ISOLATION. "
+            "MegaMoEV2 uses the pure symmetric-address API (shmem_ptr_p2p), "
+            "which requires static heap mode or MORI_SHMEM_MODE=VMM_HEAP."
+        )
     logger.info(
         "MegaMoE on ROCm: using AITER FlyDSL MegaMoEV2 (mtpr=%s, ep_size=%s).",
         mtpr,

--- a/python/sglang/srt/layers/moe/mega_moe.py
+++ b/python/sglang/srt/layers/moe/mega_moe.py
@@ -33,6 +33,15 @@ from sglang.srt.layers.moe.mega_moe_sm90 import (
 from sglang.srt.layers.moe.utils import get_moe_a2a_backend
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.models.deepseek_common.utils import _device_sm
+from sglang.srt.utils import is_hip
+
+_is_hip = is_hip()
+
+
+def _use_aiter_mega_moe() -> bool:
+    # HIP + megamoe always takes the AITER MegaMoEV2 path. Missing MegaMoEV2
+    # should fail at import/weight-build, not silently fall back to DeepGEMM.
+    return _is_hip and get_moe_a2a_backend().is_megamoe()
 
 if TYPE_CHECKING:
     from deep_gemm import SymmBuffer
@@ -83,7 +92,7 @@ def should_use_mega_moe(moe: DeepseekV2MoE, hidden_states: torch.Tensor) -> bool
         return False
     if not getattr(moe.experts, "_mega_moe_weights_built", False):
         return False
-    if _device_sm == 90:
+    if _device_sm == 90 and not _is_hip:
         if not is_sm90_fp8_mega_moe_available(moe.experts):
             return False
     if get_is_capture_mode():
@@ -142,6 +151,17 @@ def _run_mega_routed(
     input_ids_global: Optional[torch.Tensor],
     num_tokens: int,
 ) -> torch.Tensor:
+    if _use_aiter_mega_moe():
+        from sglang.srt.layers.moe.mega_moe_aiter import run_mega_moe_aiter_routed
+
+        return run_mega_moe_aiter_routed(
+            moe,
+            hidden_states,
+            forward_batch,
+            input_ids_global,
+            num_tokens,
+        )
+
     import deep_gemm
 
     from sglang.srt.distributed.parallel_state import get_moe_ep_group
@@ -296,12 +316,18 @@ def _transpose_mega_moe_sf_for_utccp(sf: torch.Tensor) -> torch.Tensor:
 
 
 def build_mega_moe_experts_weights(experts) -> None:
+    if getattr(experts, "_mega_moe_weights_built", False):
+        return
+
+    if _use_aiter_mega_moe():
+        from sglang.srt.layers.moe.mega_moe_aiter import build_mega_moe_aiter_weights
+
+        build_mega_moe_aiter_weights(experts)
+        return
+
     from deep_gemm import (
         transform_sf_into_required_layout,
     )
-
-    if getattr(experts, "_mega_moe_weights_built", False):
-        return
 
     w13 = experts.w13_weight.data
     w13_sf_fp32 = experts.w13_weight_scale_inv.data

--- a/python/sglang/srt/layers/moe/mega_moe_aiter.py
+++ b/python/sglang/srt/layers/moe/mega_moe_aiter.py
@@ -1,0 +1,296 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""ROCm MegaMoE via AITER FlyDSL MegaMoEV2.
+
+Ports ATOM's ``flydsl_mega_experts.py`` pattern into SGLang: dispatch, both
+grouped GEMMs, and combine run inside ``aiter.ops.flydsl.kernels.mega_moe.MegaMoEV2``
+(ROCm/aiter#4439). Selected when ``--moe-a2a-backend megamoe`` is set on HIP
+with ``SGLANG_USE_AITER=1``. NVIDIA Blackwell still uses DeepGEMM in
+``mega_moe.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.srt.distributed.parallel_state import get_moe_ep_group
+from sglang.srt.environ import envs
+from sglang.srt.layers.moe.utils import get_moe_a2a_backend
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.utils import is_hip
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.forward_batch_info import ForwardBatch
+    from sglang.srt.models.deepseek_v2 import DeepseekV2MoE
+
+logger = logging.getLogger(__name__)
+
+_is_hip = is_hip()
+_use_aiter = bool(envs.SGLANG_USE_AITER.get()) and _is_hip
+
+_MEGA_CACHE: dict = {}
+_MEGA_BUILD_LOGGED = False
+_MORI_SHMEM_READY = False
+
+
+def is_mega_moe_aiter_enabled() -> bool:
+    return _is_hip and _use_aiter and get_moe_a2a_backend().is_megamoe()
+
+
+def mega_moe_aiter_available() -> bool:
+    if not is_mega_moe_aiter_enabled():
+        return False
+    try:
+        from aiter.ops.flydsl.kernels.mega_moe import MegaMoEV2  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def get_mega_moe_mtpr() -> int:
+    return int(envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK.get())
+
+
+def _validate_mtpr(mtpr: int) -> None:
+    if mtpr <= 0 or (mtpr & (mtpr - 1)) != 0:
+        raise ValueError(
+            "MegaMoE on ROCm requires "
+            "SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK to be a "
+            f"positive power of two, got {mtpr}"
+        )
+
+
+def _ensure_mori_shmem(ep_group) -> tuple[int, int]:
+    """Initialize mori symmetric shmem once for MegaMoEV2 EP communication.
+
+    ATOM's MegaMoEV2 reads aiter's EP all2all manager (which constructs the
+    mori heap). SGLang does not initialize aiter parallel_state, so we bind
+    mori to SGLang's EP CPU group the same way ``moriep.py`` does, then try
+    the aiter manager if that package has already been set up.
+    """
+    global _MORI_SHMEM_READY
+
+    parallel = get_parallel()
+    rank = int(parallel.moe_ep_rank)
+    world_size = int(parallel.moe_ep_size)
+
+    if not _MORI_SHMEM_READY:
+        import mori
+
+        group_name = "mori"
+        cpu_group = ep_group.cpu_group
+        try:
+            torch._C._distributed_c10d._register_process_group(group_name, cpu_group)
+        except Exception as exc:
+            if "already registered" not in str(exc):
+                raise
+        else:
+            mori.shmem.shmem_torch_process_group_init(group_name)
+        _MORI_SHMEM_READY = True
+
+    try:
+        from aiter.dist.parallel_state import get_ep_group
+
+        # Load-bearing: constructing the all2all manager initializes mori's
+        # symmetric heap for MegaMoEV2 (see ATOM flydsl_mega_experts.py).
+        all2all = get_ep_group().device_communicator.all2all_manager
+        return int(all2all.rank), int(all2all.world_size)
+    except Exception:
+        return rank, world_size
+
+
+def build_mega_moe_aiter_weights(experts) -> None:
+    """Shuffle raw MXFP4 expert weights into MegaMoEV2 layout.
+
+    Must run on the pre-AITER-shuffle tensors (same contract as ATOM).
+    """
+    from aiter.ops.shuffle import shuffle_scale_a16w4, shuffle_weight_a16w4
+
+    if getattr(experts, "_mega_moe_weights_built", False):
+        return
+
+    w13 = experts.w13_weight.data
+    local_e = int(w13.shape[0])
+    if local_e != int(experts.num_local_experts):
+        raise RuntimeError(
+            "MegaMoE local weight width disagrees with the dispatch layout: "
+            f"weights={local_e}, dispatch={experts.num_local_experts}."
+        )
+
+    s1 = experts.w13_weight_scale_inv.data
+    w2 = experts.w2_weight.data
+    s2 = experts.w2_weight_scale_inv.data
+
+    experts._mega_w1 = shuffle_weight_a16w4(w13, 16, True).contiguous()
+    experts._mega_w1_scale = shuffle_scale_a16w4(
+        s1.reshape(local_e * s1.shape[1], s1.shape[2]), local_e, True
+    ).contiguous()
+    experts._mega_w2 = shuffle_weight_a16w4(w2, 16, False).contiguous()
+    experts._mega_w2_scale = shuffle_scale_a16w4(
+        s2.reshape(local_e * s2.shape[1], s2.shape[2]), local_e, False
+    ).contiguous()
+
+    experts._mega_moe_mtpr = get_mega_moe_mtpr()
+    experts._mega_moe_model_dim = int(experts.hidden_size)
+    experts._mega_moe_inter_dim = int(w13.shape[1] // 2)
+    experts._mega_moe_swiglu_limit = float(
+        getattr(experts.moe_runner_config, "swiglu_limit", None) or 0.0
+    )
+
+    global _MEGA_BUILD_LOGGED
+    if not _MEGA_BUILD_LOGGED:
+        _MEGA_BUILD_LOGGED = True
+        logger.info(
+            "[MegaMoE-ROCm] Prepared MegaMoEV2 weights: E=%d model_dim=%d "
+            "inter_dim=%d mtpr=%d swiglu_limit=%s",
+            local_e,
+            experts._mega_moe_model_dim,
+            experts._mega_moe_inter_dim,
+            experts._mega_moe_mtpr,
+            experts._mega_moe_swiglu_limit,
+        )
+
+    experts._mega_moe_weights_built = True
+
+
+def _get_or_build_mega_moe(
+    *,
+    rank: int,
+    world_size: int,
+    model_dim: int,
+    inter_dim: int,
+    experts: int,
+    topk: int,
+    mtpr: int,
+    swiglu_limit: float,
+    w1: torch.Tensor,
+    w1_scale: torch.Tensor,
+    w2: torch.Tensor,
+    w2_scale: torch.Tensor,
+    quant: str = "a8w4",
+):
+    from aiter.ops.flydsl.kernels.mega_moe import MegaMoEV2
+
+    key = (
+        rank,
+        world_size,
+        model_dim,
+        inter_dim,
+        experts,
+        topk,
+        quant,
+        mtpr,
+        swiglu_limit,
+    )
+    mega = _MEGA_CACHE.get(key)
+    if mega is None:
+        with torch.inference_mode(False), torch.no_grad():
+            mega = MegaMoEV2(
+                rank=rank,
+                world_size=world_size,
+                model_dim=model_dim,
+                inter_dim=inter_dim,
+                experts=experts,
+                topk=topk,
+                quant=quant,
+                w1=w1,
+                w1_scale=w1_scale,
+                w2=w2,
+                w2_scale=w2_scale,
+                max_tok_per_rank=mtpr,
+                swiglu_limit=swiglu_limit,
+            )
+        _MEGA_CACHE[key] = mega
+
+    mega._s1_w1 = w1.view(torch.uint8)
+    mega._s1_w1_scale = w1_scale.view(torch.uint8)
+    mega.w2 = w2
+    mega.w2_scale = w2_scale
+    return mega
+
+
+def run_mega_moe_aiter_routed(
+    moe: DeepseekV2MoE,
+    hidden_states: torch.Tensor,
+    forward_batch: Optional[ForwardBatch],
+    input_ids_global: Optional[torch.Tensor],
+    num_tokens: int,
+) -> torch.Tensor:
+    from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
+
+    experts = moe.experts
+    mtpr = int(getattr(experts, "_mega_moe_mtpr", get_mega_moe_mtpr()))
+    _validate_mtpr(mtpr)
+    if num_tokens > mtpr:
+        raise ValueError(
+            f"[MegaMoE-ROCm] num_tokens={num_tokens} exceeds mtpr={mtpr}; "
+            "raise SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK or "
+            "reduce batch size / cuda-graph max bs"
+        )
+
+    if num_tokens > 0:
+        router_logits = moe.gate(hidden_states, forward_batch=forward_batch)
+        topk_kwargs = {"input_ids": input_ids_global} if moe.is_hash else {}
+        topk_output = moe.topk(
+            hidden_states,
+            router_logits,
+            num_token_non_padded=(
+                forward_batch.num_token_non_padded
+                if forward_batch is not None
+                else None
+            ),
+            expert_location_dispatch_info=ExpertLocationDispatchInfo.init_new(
+                layer_id=moe.layer_id,
+            ),
+            **topk_kwargs,
+        )
+        topk_ids = topk_output.topk_ids.to(torch.int32).contiguous()
+        topk_weights = topk_output.topk_weights.to(torch.float32).contiguous()
+        topk = int(topk_ids.shape[1])
+    else:
+        topk = int(moe.config.num_experts_per_tok + moe.num_fused_shared_experts)
+        topk_ids = hidden_states.new_empty((0, topk), dtype=torch.int32)
+        topk_weights = hidden_states.new_empty((0, topk), dtype=torch.float32)
+
+    if not hasattr(experts, "_mega_w1"):
+        raise RuntimeError("MegaMoE-ROCm weights were not prepared")
+
+    rank, world_size = _ensure_mori_shmem(get_moe_ep_group())
+    mega = _get_or_build_mega_moe(
+        rank=rank,
+        world_size=world_size,
+        model_dim=int(getattr(experts, "_mega_moe_model_dim", experts.hidden_size)),
+        inter_dim=int(
+            getattr(experts, "_mega_moe_inter_dim", experts.w13_weight.shape[1] // 2)
+        ),
+        experts=int(experts.num_experts),
+        topk=topk,
+        mtpr=mtpr,
+        swiglu_limit=float(getattr(experts, "_mega_moe_swiglu_limit", 0.0)),
+        w1=experts._mega_w1,
+        w1_scale=experts._mega_w1_scale,
+        w2=experts._mega_w2,
+        w2_scale=experts._mega_w2_scale,
+    )
+
+    with torch.inference_mode(False), torch.no_grad():
+        y = mega.forward(hidden_states.contiguous(), topk_weights, topk_ids)
+
+    if not experts.should_fuse_routed_scaling_factor_in_topk:
+        y.mul_(moe.routed_scaling_factor)
+    return y

--- a/python/sglang/srt/layers/moe/mega_moe_aiter.py
+++ b/python/sglang/srt/layers/moe/mega_moe_aiter.py
@@ -45,6 +45,7 @@ _use_aiter = bool(envs.SGLANG_USE_AITER.get()) and _is_hip
 _MEGA_CACHE: dict = {}
 _MEGA_BUILD_LOGGED = False
 _MORI_SHMEM_READY = False
+_MEGA_RUNTIME_READY = False
 
 
 def is_mega_moe_aiter_enabled() -> bool:
@@ -76,12 +77,13 @@ def _validate_mtpr(mtpr: int) -> None:
 
 
 def _ensure_mori_shmem(ep_group) -> tuple[int, int]:
-    """Initialize mori symmetric shmem once for MegaMoEV2 EP communication.
+    """Initialize MegaMoEV2's process-global mori heap exactly once.
 
-    ATOM's MegaMoEV2 reads aiter's EP all2all manager (which constructs the
-    mori heap). SGLang does not initialize aiter parallel_state, so we bind
-    mori to SGLang's EP CPU group the same way ``moriep.py`` does, then try
-    the aiter manager if that package has already been set up.
+    MegaMoEV2 allocates through ``mori_shmem_create_tensor``, whose reference
+    harness registers the bootstrap group as ``default``.  Use SGLang's EP
+    Gloo group: unlike the device/RCCL WORLD group it supports the object
+    broadcast mori uses to distribute its unique id, and it remains correct
+    when EP is a proper subset of WORLD.
     """
     global _MORI_SHMEM_READY
 
@@ -91,27 +93,89 @@ def _ensure_mori_shmem(ep_group) -> tuple[int, int]:
 
     if not _MORI_SHMEM_READY:
         import mori
+        import torch._C._distributed_c10d as c10d
 
-        group_name = "mori"
-        cpu_group = ep_group.cpu_group
         try:
-            torch._C._distributed_c10d._register_process_group(group_name, cpu_group)
+            c10d._register_process_group("default", ep_group.cpu_group)
         except Exception as exc:
             if "already registered" not in str(exc):
                 raise
-        else:
-            mori.shmem.shmem_torch_process_group_init(group_name)
+
+        torch.distributed.barrier(group=ep_group.cpu_group)
+        mori.shmem.shmem_torch_process_group_init("default")
+        mori.shmem.shmem_barrier_all()
+        torch.distributed.barrier(group=ep_group.cpu_group)
         _MORI_SHMEM_READY = True
+        logger.info(
+            "MegaMoE-ROCm: initialized mori shmem heap 'default' on EP Gloo "
+            "group (rank=%s world=%s)",
+            rank,
+            world_size,
+        )
 
-    try:
-        from aiter.dist.parallel_state import get_ep_group
+    return rank, world_size
 
-        # Load-bearing: constructing the all2all manager initializes mori's
-        # symmetric heap for MegaMoEV2 (see ATOM flydsl_mega_experts.py).
-        all2all = get_ep_group().device_communicator.all2all_manager
-        return int(all2all.rank), int(all2all.world_size)
-    except Exception:
-        return rank, world_size
+
+def initialize_mega_moe_aiter_runtime(model) -> None:
+    """Collectively build and warm MegaMoEV2 before CUDA graph capture."""
+    global _MEGA_RUNTIME_READY
+
+    if not is_mega_moe_aiter_enabled() or _MEGA_RUNTIME_READY:
+        return
+
+    ep_group = get_moe_ep_group()
+    rank, world_size = _ensure_mori_shmem(ep_group)
+
+    moe = next(
+        (
+            module
+            for module in model.modules()
+            if hasattr(module, "experts")
+            and getattr(module.experts, "_mega_moe_weights_built", False)
+        ),
+        None,
+    )
+    if moe is None:
+        raise RuntimeError(
+            "MegaMoE-ROCm runtime initialization found no prepared MoE layer. "
+            "It must run after model weight loading and before graph capture."
+        )
+
+    experts = moe.experts
+    mtpr = int(getattr(experts, "_mega_moe_mtpr", get_mega_moe_mtpr()))
+    _validate_mtpr(mtpr)
+    topk = int(moe.config.num_experts_per_tok + moe.num_fused_shared_experts)
+
+    _get_or_build_mega_moe(
+        rank=rank,
+        world_size=world_size,
+        model_dim=int(getattr(experts, "_mega_moe_model_dim", experts.hidden_size)),
+        inter_dim=int(
+            getattr(experts, "_mega_moe_inter_dim", experts.w13_weight.shape[1] // 2)
+        ),
+        experts=int(experts.num_experts),
+        topk=topk,
+        mtpr=mtpr,
+        swiglu_limit=float(getattr(experts, "_mega_moe_swiglu_limit", 0.0)),
+        w1=experts._mega_w1,
+        w1_scale=experts._mega_w1_scale,
+        w2=experts._mega_w2,
+        w2_scale=experts._mega_w2_scale,
+    )
+
+    import mori
+
+    mori.shmem.shmem_barrier_all()
+    torch.distributed.barrier(group=ep_group.cpu_group)
+    _MEGA_RUNTIME_READY = True
+    logger.info(
+        "MegaMoE-ROCm runtime ready before graph capture "
+        "(rank=%s world=%s mtpr=%s topk=%s)",
+        rank,
+        world_size,
+        mtpr,
+        topk,
+    )
 
 
 def build_mega_moe_aiter_weights(experts) -> None:
@@ -269,8 +333,23 @@ def run_mega_moe_aiter_routed(
 
     if not hasattr(experts, "_mega_w1"):
         raise RuntimeError("MegaMoE-ROCm weights were not prepared")
+    if not _MEGA_RUNTIME_READY:
+        raise RuntimeError(
+            "MegaMoE-ROCm runtime was not initialized before forward. "
+            "BaseRunner.warmup() must run before eager execution or graph capture."
+        )
+    is_empty = hidden_states.shape[0] == 0
+    if is_empty:
+        # MegaMoEV2 is an EP collective: idle DP-attention ranks still must
+        # participate, but its config selector rejects zero tokens. Dispatch a
+        # zero-weight dummy token and discard its output after the collective.
+        hidden_states = hidden_states.new_zeros((1, hidden_states.shape[1]))
+        topk_weights = topk_weights.new_zeros((1, topk_weights.shape[1]))
+        topk_ids = topk_ids.new_zeros((1, topk_ids.shape[1]))
 
-    rank, world_size = _ensure_mori_shmem(get_moe_ep_group())
+    parallel = get_parallel()
+    rank = int(parallel.moe_ep_rank)
+    world_size = int(parallel.moe_ep_size)
     mega = _get_or_build_mega_moe(
         rank=rank,
         world_size=world_size,
@@ -291,6 +370,8 @@ def run_mega_moe_aiter_routed(
     with torch.inference_mode(False), torch.no_grad():
         y = mega.forward(hidden_states.contiguous(), topk_weights, topk_ids)
 
+    if is_empty:
+        return y[:0]
     if not experts.should_fuse_routed_scaling_factor_in_topk:
         y.mul_(moe.routed_scaling_factor)
     return y

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -2205,6 +2205,17 @@ def select_experts(
     # DeepSeek V2/V3/R1 series models use grouped_top_k
     # remove num_fused_shared_experts from grouped_topk/biased_grouped_topk
     num_routed_topk = top_k - num_fused_shared_experts
+    # On the per-rank shared-slot path the shared expert is appended afterwards by
+    # fused_append_remap_shared_experts_deepep, so the gate must not also emit a shared
+    # marker. Doing both costs one routed expert (K_routed = topk - num_fused_shared,
+    # so top-6 becomes top-5) and puts the marker at id num_experts, which the DeepEP
+    # remap shifts to one past the end of the expert space (384 -> 392 for 384 routed
+    # experts on EP8, where valid ids are 0..391).
+    num_fused_shared_experts_for_gate = (
+        0
+        if has_per_rank_fused_shared_slots(num_fused_shared_experts)
+        else num_fused_shared_experts
+    )
     if use_grouped_topk:
         assert topk_group is not None
         assert num_expert_group is not None
@@ -2261,7 +2272,7 @@ def select_experts(
                 topk=num_routed_topk if _use_aiter else top_k,
                 renormalize=renormalize,
                 scoring_func=scoring_func,
-                num_fused_shared_experts=num_fused_shared_experts,
+                num_fused_shared_experts=num_fused_shared_experts_for_gate,
                 routed_scaling_factor=routed_scaling_factor,
                 num_token_non_padded=num_token_non_padded,
                 expert_location_dispatch_info=expert_location_dispatch_info,
@@ -2324,7 +2335,7 @@ def select_experts(
                 renormalize=renormalize,
                 correction_bias=correction_bias,
                 scoring_func=scoring_func,
-                num_fused_shared_experts=num_fused_shared_experts,
+                num_fused_shared_experts=num_fused_shared_experts_for_gate,
                 routed_scaling_factor=routed_scaling_factor,
                 apply_routed_scaling_factor_on_output=apply_routed_scaling_factor_on_output,
                 **_fused_topk_kwargs,

--- a/python/sglang/srt/layers/moe/utils.py
+++ b/python/sglang/srt/layers/moe/utils.py
@@ -89,6 +89,7 @@ class MoeA2ABackend(Enum):
             MoeA2ABackend.MOONCAKE,
             MoeA2ABackend.NIXL,
             MoeA2ABackend.MORI,
+            MoeA2ABackend.MEGAMOE,
         )
 
 

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1432,6 +1432,17 @@ class Fp8MoEMethod(FusedMoEMethodBase):
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
         if _use_aiter and self.is_fp4_expert:
+            if get_moe_a2a_backend().is_megamoe():
+                from sglang.srt.layers.moe.mega_moe import (
+                    build_mega_moe_experts_weights,
+                )
+
+                # MegaMoEV2 needs the raw MXFP4 layout, not AITER fused_moe
+                # shuffle. Build fused MegaMoE weights and skip the standard
+                # FlyDSL shuffle path below.
+                build_mega_moe_experts_weights(layer)
+                return
+
             gu_intv = envs.SGLANG_USE_AITER_MOE_GU_ITLV.get()
             fp4_weight_dtype = _require_fp4_dtype()
 

--- a/python/sglang/srt/model_executor/runner/base_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_runner.py
@@ -244,6 +244,7 @@ class BaseRunner(ABC):
 
         self._pre_initialize_flashinfer_allreduce_workspace()
         self._pre_initialize_fi_a2a_workspace()
+        self._pre_initialize_rocm_mega_moe()
 
         if should_run_flashinfer_autotune(self.model_runner):
             buffers, batch_size = self._autotune_buffers()
@@ -297,6 +298,14 @@ class BaseRunner(ABC):
         from sglang.srt.layers.dcp import init_fi_a2a_workspace
 
         init_fi_a2a_workspace(get_parallel().dcp_group)
+
+    def _pre_initialize_rocm_mega_moe(self):
+        """Initialize Mori and construct MegaMoEV2 before graph capture."""
+        from sglang.srt.layers.moe.mega_moe_aiter import (
+            initialize_mega_moe_aiter_runtime,
+        )
+
+        initialize_mega_moe_aiter_runtime(self.model_runner.model)
 
     def _flashinfer_autotune(self, *, buffers, batch_size):
         """Run flashinfer autotune.

--- a/test/registered/amd/test_mega_moe_aiter_dispatch.py
+++ b/test/registered/amd/test_mega_moe_aiter_dispatch.py
@@ -1,0 +1,65 @@
+"""Unit tests for ROCm MegaMoE (AITER) dispatch wiring."""
+
+from __future__ import annotations
+
+import pytest
+
+
+def test_mega_moe_build_routes_to_aiter_on_rocm(monkeypatch):
+    monkeypatch.setattr("sglang.srt.layers.moe.mega_moe._is_hip", True)
+    monkeypatch.setattr(
+        "sglang.srt.layers.moe.mega_moe._use_aiter_mega_moe",
+        lambda: True,
+    )
+
+    called = {}
+
+    def fake_build(experts):
+        called["experts"] = experts
+        experts._mega_moe_weights_built = True
+
+    class Experts:
+        _mega_moe_weights_built = False
+
+    monkeypatch.setattr(
+        "sglang.srt.layers.moe.mega_moe_aiter.build_mega_moe_aiter_weights",
+        fake_build,
+    )
+
+    from sglang.srt.layers.moe.mega_moe import build_mega_moe_experts_weights
+
+    experts = Experts()
+    build_mega_moe_experts_weights(experts)
+    assert called["experts"] is experts
+
+
+def test_validate_mtpr_rejects_non_power_of_two():
+    from sglang.srt.layers.moe.mega_moe_aiter import _validate_mtpr
+
+    with pytest.raises(ValueError, match="power of two"):
+        _validate_mtpr(1000)
+
+
+def test_validate_mtpr_accepts_power_of_two():
+    from sglang.srt.layers.moe.mega_moe_aiter import _validate_mtpr
+
+    _validate_mtpr(1024)
+
+
+def test_is_mega_moe_aiter_enabled_requires_megamoe_backend(monkeypatch):
+    monkeypatch.setattr("sglang.srt.layers.moe.mega_moe_aiter._is_hip", True)
+    monkeypatch.setattr("sglang.srt.layers.moe.mega_moe_aiter._use_aiter", True)
+
+    class FakeBackend:
+        @staticmethod
+        def is_megamoe():
+            return False
+
+    monkeypatch.setattr(
+        "sglang.srt.layers.moe.mega_moe_aiter.get_moe_a2a_backend",
+        lambda: FakeBackend(),
+    )
+
+    from sglang.srt.layers.moe.mega_moe_aiter import is_mega_moe_aiter_enabled
+
+    assert is_mega_moe_aiter_enabled() is False

--- a/test/registered/amd/test_mega_moe_aiter_dispatch.py
+++ b/test/registered/amd/test_mega_moe_aiter_dispatch.py
@@ -2,7 +2,24 @@
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
+
 import pytest
+import torch
+
+
+@pytest.fixture(autouse=True)
+def reset_mega_moe_runtime_state():
+    import sglang.srt.layers.moe.mega_moe_aiter as mega
+
+    mega._MORI_SHMEM_READY = False
+    mega._MEGA_RUNTIME_READY = False
+    mega._MEGA_CACHE.clear()
+    yield
+    mega._MORI_SHMEM_READY = False
+    mega._MEGA_RUNTIME_READY = False
+    mega._MEGA_CACHE.clear()
 
 
 def test_mega_moe_build_routes_to_aiter_on_rocm(monkeypatch):
@@ -63,3 +80,198 @@ def test_is_mega_moe_aiter_enabled_requires_megamoe_backend(monkeypatch):
     from sglang.srt.layers.moe.mega_moe_aiter import is_mega_moe_aiter_enabled
 
     assert is_mega_moe_aiter_enabled() is False
+
+
+def test_mori_shmem_init_uses_default_name_and_ep_cpu_group(monkeypatch):
+    import sglang.srt.layers.moe.mega_moe_aiter as mega
+
+    mega._MORI_SHMEM_READY = False
+    calls = []
+    cpu_group = object()
+    ep_group = SimpleNamespace(cpu_group=cpu_group)
+
+    fake_shmem = SimpleNamespace(
+        shmem_torch_process_group_init=lambda name: calls.append(("init", name)),
+        shmem_barrier_all=lambda: calls.append(("shmem_barrier",)),
+    )
+    monkeypatch.setitem(sys.modules, "mori", SimpleNamespace(shmem=fake_shmem))
+    monkeypatch.setattr(
+        mega,
+        "get_parallel",
+        lambda: SimpleNamespace(moe_ep_rank=3, moe_ep_size=8),
+    )
+    monkeypatch.setattr(
+        torch._C._distributed_c10d,
+        "_register_process_group",
+        lambda name, group: calls.append(("register", name, group)),
+    )
+    monkeypatch.setattr(
+        torch.distributed,
+        "barrier",
+        lambda *, group: calls.append(("dist_barrier", group)),
+    )
+
+    assert mega._ensure_mori_shmem(ep_group) == (3, 8)
+    assert calls == [
+        ("register", "default", cpu_group),
+        ("dist_barrier", cpu_group),
+        ("init", "default"),
+        ("shmem_barrier",),
+        ("dist_barrier", cpu_group),
+    ]
+
+    calls.clear()
+    assert mega._ensure_mori_shmem(ep_group) == (3, 8)
+    assert calls == []
+
+
+def test_initialize_runtime_builds_operator_eagerly(monkeypatch):
+    import sglang.srt.layers.moe.mega_moe_aiter as mega
+
+    mega._MEGA_RUNTIME_READY = False
+    built = {}
+    cpu_group = object()
+    ep_group = SimpleNamespace(cpu_group=cpu_group)
+
+    experts = SimpleNamespace(
+        _mega_moe_weights_built=True,
+        _mega_moe_mtpr=4096,
+        _mega_moe_model_dim=7168,
+        _mega_moe_inter_dim=3072,
+        _mega_moe_swiglu_limit=10.0,
+        _mega_w1=object(),
+        _mega_w1_scale=object(),
+        _mega_w2=object(),
+        _mega_w2_scale=object(),
+        hidden_size=7168,
+        num_experts=392,
+        w13_weight=SimpleNamespace(shape=(49, 6144, 3584)),
+    )
+    moe = SimpleNamespace(
+        experts=experts,
+        config=SimpleNamespace(num_experts_per_tok=6),
+        num_fused_shared_experts=1,
+    )
+    model = SimpleNamespace(modules=lambda: iter([SimpleNamespace(), moe]))
+
+    monkeypatch.setattr(mega, "is_mega_moe_aiter_enabled", lambda: True)
+    monkeypatch.setattr(mega, "get_moe_ep_group", lambda: ep_group)
+    monkeypatch.setattr(mega, "_ensure_mori_shmem", lambda group: (2, 8))
+    monkeypatch.setattr(
+        mega, "_get_or_build_mega_moe", lambda **kwargs: built.update(kwargs)
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "mori",
+        SimpleNamespace(
+            shmem=SimpleNamespace(shmem_barrier_all=lambda: built.setdefault("barrier", True))
+        ),
+    )
+    monkeypatch.setattr(torch.distributed, "barrier", lambda *, group: None)
+
+    mega.initialize_mega_moe_aiter_runtime(model)
+
+    assert mega._MEGA_RUNTIME_READY is True
+    assert built["rank"] == 2
+    assert built["world_size"] == 8
+    assert built["experts"] == 392
+    assert built["topk"] == 7
+    assert built["mtpr"] == 4096
+    assert built["barrier"] is True
+
+
+def test_runtime_init_requires_prepared_weights(monkeypatch):
+    import sglang.srt.layers.moe.mega_moe_aiter as mega
+
+    mega._MEGA_RUNTIME_READY = False
+    monkeypatch.setattr(mega, "is_mega_moe_aiter_enabled", lambda: True)
+    monkeypatch.setattr(
+        mega, "get_moe_ep_group", lambda: SimpleNamespace(cpu_group=object())
+    )
+    monkeypatch.setattr(mega, "_ensure_mori_shmem", lambda group: (0, 8))
+
+    with pytest.raises(RuntimeError, match="no prepared MoE layer"):
+        mega.initialize_mega_moe_aiter_runtime(
+            SimpleNamespace(modules=lambda: iter([SimpleNamespace()]))
+        )
+
+
+def test_rocm_megamoe_rejects_mori_isolation_mode(monkeypatch):
+    from sglang.srt.arg_groups.mega_moe_hook import handle_rocm_megamoe
+    from sglang.srt.environ import envs
+
+    monkeypatch.setattr("sglang.srt.utils.is_hip", lambda: True)
+    monkeypatch.setattr(
+        envs.SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK,
+        "get",
+        lambda: 4096,
+    )
+    monkeypatch.setattr(envs.SGLANG_USE_AITER, "get", lambda: True)
+    monkeypatch.setenv("MORI_SHMEM_MODE", "ISOLATION")
+
+    with pytest.raises(ValueError, match="does not support MORI_SHMEM_MODE=ISOLATION"):
+        handle_rocm_megamoe(
+            SimpleNamespace(moe_a2a_backend="megamoe", ep_size=8)
+        )
+
+
+def test_empty_dp_attention_batch_participates_with_dummy_token(monkeypatch):
+    import sglang.srt.layers.moe.mega_moe_aiter as mega
+
+    mega._MEGA_RUNTIME_READY = True
+    forwarded = {}
+
+    class FakeMega:
+        def forward(self, hidden_states, topk_weights, topk_ids):
+            forwarded["shapes"] = (
+                hidden_states.shape,
+                topk_weights.shape,
+                topk_ids.shape,
+            )
+            assert torch.count_nonzero(topk_weights) == 0
+            return torch.zeros_like(hidden_states)
+
+    monkeypatch.setattr(
+        mega,
+        "_get_or_build_mega_moe",
+        lambda **kwargs: FakeMega(),
+    )
+    monkeypatch.setattr(
+        mega,
+        "get_parallel",
+        lambda: SimpleNamespace(moe_ep_rank=0, moe_ep_size=8),
+    )
+
+    hidden_states = torch.empty((0, 7168))
+    experts = SimpleNamespace(
+        _mega_w1=torch.empty(1),
+        _mega_w1_scale=torch.empty(1),
+        _mega_w2=torch.empty(1),
+        _mega_w2_scale=torch.empty(1),
+        _mega_moe_mtpr=4096,
+        _mega_moe_model_dim=7168,
+        _mega_moe_inter_dim=3072,
+        _mega_moe_swiglu_limit=10.0,
+        hidden_size=7168,
+        num_experts=392,
+        w13_weight=SimpleNamespace(shape=(49, 6144, 3584)),
+    )
+    moe = SimpleNamespace(
+        experts=experts,
+        config=SimpleNamespace(num_experts_per_tok=6),
+        num_fused_shared_experts=1,
+    )
+    output = mega.run_mega_moe_aiter_routed(
+        moe=moe,
+        hidden_states=hidden_states,
+        forward_batch=None,
+        input_ids_global=None,
+        num_tokens=0,
+    )
+
+    assert output.shape == hidden_states.shape
+    assert forwarded["shapes"] == (
+        torch.Size((1, 7168)),
+        torch.Size((1, 7)),
+        torch.Size((1, 7)),
+    )


### PR DESCRIPTION
## Summary

- Route `--moe-a2a-backend megamoe` on HIP/ROCm to AITER FlyDSL `MegaMoEV2` instead of DeepGEMM, so MI355X can use the same MegaMoE flag as Blackwell.
- Add `mega_moe_aiter.py` to build FP8 expert weights, initialize mori symmetric shmem on the EP Gloo group, and run the fused dispatch/GEMM/combine path.
- Initialize MegaMoE runtime during `BaseRunner.warmup()` before CUDA graph capture, handle idle DP-attention ranks with a zero-weight dummy token, and reject `MORI_SHMEM_MODE=ISOLATION`.
- Update DeepSeek-V4 docs/snippets to note ROCm MegaMoE support and add AMD unit tests for routing, mori init, runtime warmup, and empty-batch handling.

## Motivation

DeepSeek-V4 MegaMoE on Blackwell uses DeepGEMM. On ROCm/MI355X the equivalent fused path is AITER's `MegaMoEV2` (ROCm/aiter#4439). This PR wires that backend behind the existing `--moe-a2a-backend megamoe` flag when `SGLANG_USE_AITER=1`.

## Requirements

- HIP/ROCm with `SGLANG_USE_AITER=1`
- AITER build exporting `aiter.ops.flydsl.kernels.mega_moe.MegaMoEV2`
- `SGLANG_OPT_DEEPGEMM_MEGA_MOE_NUM_MAX_TOKENS_PER_RANK` set to a power of two (e.g. 4096)
- `MORI_SHMEM_MODE=VMM_HEAP` or static heap mode (isolation mode is unsupported)

## Test plan

- [x] `pytest test/registered/amd/test_mega_moe_aiter_dispatch.py` — routing, mori shmem init, runtime warmup, isolation-mode guard, empty DP-attention batch
- [ ] Manual: launch DeepSeek-V4-Pro on MI355X with `--moe-a2a-backend megamoe --ep-size 8 --enable-dp-attention` and verify server startup + decode throughput
- [ ] Manual: GSM8K accuracy smoke test with real MTP verification


Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32868984415](https://github.com/sgl-project/sglang/actions/runs/32868984415)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32868983458](https://github.com/sgl-project/sglang/actions/runs/32868983458)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32868985206](https://github.com/sgl-project/sglang/actions/runs/32868985206)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->