### PR TITLE
test: cover multi-stream scheduling helpers

### DIFF
--- a/test/registered/unit/utils/test_multi_stream_utils.py
+++ b/test/registered/unit/utils/test_multi_stream_utils.py
@@ -1,5 +1,6 @@
 """CPU-only tests for multi-stream scheduling helpers."""
 
+import unittest
 from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import Mock, patch
@@ -105,3 +106,7 @@ class TestMaybeExecuteInParallel(CustomTestCase):
                 "done.wait",
             ],
         )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/utils/test_multi_stream_utils.py
+++ b/test/registered/unit/utils/test_multi_stream_utils.py
@@ -1,0 +1,107 @@
+"""CPU-only tests for multi-stream scheduling helpers."""
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+from sglang.srt.utils import multi_stream_utils
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class _Event:
+    def __init__(self, name: str, calls: list[object]):
+        self.name = name
+        self.calls = calls
+
+    def record(self):
+        self.calls.append(f"{self.name}.record")
+
+    def wait(self):
+        self.calls.append(f"{self.name}.wait")
+
+
+class TestMultiStreamContext(CustomTestCase):
+    def test_forward_context_helpers_delegate_to_runtime_context(self):
+        scoped = object()
+        forward = Mock(multi_stream=True)
+        forward.scoped.return_value = scoped
+
+        with patch.object(multi_stream_utils, "get_forward", return_value=forward):
+            multi_stream_utils.set_do_multi_stream(False)
+
+            self.assertTrue(multi_stream_utils.do_multi_stream())
+            self.assertIs(multi_stream_utils.with_multi_stream(True), scoped)
+
+        forward.set.assert_called_once_with("multi_stream", False)
+        forward.scoped.assert_called_once_with(multi_stream=True)
+
+
+class TestMaybeExecuteInParallel(CustomTestCase):
+    def test_falls_back_to_ordered_execution_without_aux_stream(self):
+        calls: list[object] = []
+        events = [_Event("start", calls), _Event("done", calls)]
+        forward = SimpleNamespace(multi_stream=True)
+
+        def fn0():
+            calls.append("fn0")
+            return "left"
+
+        def fn1():
+            calls.append("fn1")
+            return "right"
+
+        with patch.object(multi_stream_utils, "get_forward", return_value=forward):
+            result = multi_stream_utils.maybe_execute_in_parallel(
+                fn0, fn1, events, aux_stream=None
+            )
+
+        self.assertEqual(result, ("left", "right"))
+        self.assertEqual(calls, ["fn0", "fn1"])
+
+    def test_uses_event_ordering_when_multi_stream_is_enabled(self):
+        calls: list[object] = []
+        events = [_Event("start", calls), _Event("done", calls)]
+        aux_stream = object()
+        forward = SimpleNamespace(multi_stream=True)
+
+        @contextmanager
+        def fake_stream(stream):
+            calls.append(("stream.enter", stream))
+            yield
+            calls.append(("stream.exit", stream))
+
+        def fn0():
+            calls.append("fn0")
+            return "left"
+
+        def fn1():
+            calls.append("fn1")
+            return "right"
+
+        with (
+            patch.object(multi_stream_utils, "get_forward", return_value=forward),
+            patch.object(
+                multi_stream_utils.torch.cuda, "stream", side_effect=fake_stream
+            ),
+        ):
+            result = multi_stream_utils.maybe_execute_in_parallel(
+                fn0, fn1, events, aux_stream=aux_stream
+            )
+
+        self.assertEqual(result, ("left", "right"))
+        self.assertEqual(
+            calls,
+            [
+                "start.record",
+                "fn0",
+                ("stream.enter", aux_stream),
+                "start.wait",
+                "fn1",
+                "done.record",
+                ("stream.exit", aux_stream),
+                "done.wait",
+            ],
+        )


### PR DESCRIPTION
## Summary
- add CPU-only coverage for multi-stream runtime-context helpers
- exercise sequential fallback when no auxiliary stream is available
- verify mocked CUDA event and auxiliary-stream ordering for the parallel path

## Validation
- Windows isolated-module run: 3 passed (GitHub's Linux CPU job remains the authoritative full-import check)
- `ruff check test/registered/unit/utils/test_multi_stream_utils.py`
- `ruff format --check test/registered/unit/utils/test_multi_stream_utils.py`

Closes #20865

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32810108434](https://github.com/sgl-project/sglang/actions/runs/32810108434)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32810108111](https://github.com/sgl-project/sglang/actions/runs/32810108111)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32810108122](https://github.com/sgl-project/sglang/actions/runs/32810108122)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->