### PR TITLE
[openai][bench] Keep buffered decode steps observable so tool-call runs report real ITL/TPOT

### DIFF
--- a/python/sglang/benchmark/serving.py
+++ b/python/sglang/benchmark/serving.py
@@ -448,6 +448,18 @@ async def async_request_openai_chat_completions(
         # These will override defaults if present
         payload.update(request_func_input.extra_request_body)
 
+        # Ask the server to report per-chunk usage so TTFT/ITL can be derived from
+        # the token counter instead of from visible text. Without this a step
+        # whose text the reasoning / tool-call parser buffered is invisible to the
+        # client and gets charged to TTFT.
+        step_usage_chunks = getattr(args, "stream_step_usage_chunks", "off")
+        if step_usage_chunks != "off" and payload.get("stream"):
+            stream_options = dict(payload.get("stream_options") or {})
+            stream_options.setdefault("include_usage", True)
+            stream_options.setdefault("continuous_usage_stats", True)
+            stream_options.setdefault("step_usage_chunks", step_usage_chunks)
+            payload["stream_options"] = stream_options
+
         # hack to accommodate different LoRA conventions between SGLang and vLLM.
         if request_func_input.lora_name:
             payload["model"] = request_func_input.lora_name
@@ -500,6 +512,7 @@ async def async_request_openai_chat_completions(
                             _extract_cache_from_sglext(response_json, output)
                     else:
                         # Streaming response
+                        last_counted_tokens = 0
                         async for chunk_bytes in response.content:
                             chunk_bytes = chunk_bytes.strip()
                             if not chunk_bytes:
@@ -513,21 +526,52 @@ async def async_request_openai_chat_completions(
                                 data = json.loads(chunk)
                                 # Check for usage info in final chunks. OpenAI-compatible
                                 # servers may emit usage-only chunks with choices=[].
-                                output_len = (data.get("usage") or {}).get(
-                                    "completion_tokens", output_len
+                                usage_tokens = (data.get("usage") or {}).get(
+                                    "completion_tokens"
                                 )
+                                if usage_tokens is not None:
+                                    output_len = usage_tokens
 
                                 if getattr(args, "cache_report", False):
                                     _extract_cache_from_sglext(data, output)
 
                                 choices = data.get("choices") or []
-                                if not choices:
-                                    continue
 
                                 # Reasoning models stream thoughts via
                                 # `reasoning_content`; count them like content.
-                                delta = choices[0].get("delta") or {}
+                                delta = (
+                                    (choices[0].get("delta") or {}) if choices else {}
+                                )
                                 content = _combine_openai_chat_content(delta)
+
+                                # Prefer the server-reported token counter when it
+                                # is available: it also covers tokens the parsers
+                                # buffered or turned into structured tool_calls,
+                                # neither of which shows up as visible text.
+                                if usage_tokens is not None and (
+                                    usage_tokens > last_counted_tokens
+                                ):
+                                    timestamp = time.perf_counter()
+                                    num_new_tokens = usage_tokens - last_counted_tokens
+                                    if ttft == 0.0:
+                                        ttft = timestamp - st
+                                        output.ttft = ttft
+                                        num_new_tokens -= 1
+                                    if num_new_tokens > 0:
+                                        adjusted_itl = (
+                                            timestamp - most_recent_timestamp
+                                        ) / num_new_tokens
+                                        output.itl.extend(
+                                            [adjusted_itl] * num_new_tokens
+                                        )
+                                    last_counted_tokens = usage_tokens
+                                    most_recent_timestamp = timestamp
+                                    if content:
+                                        generated_text += content
+                                    continue
+
+                                if not choices:
+                                    continue
 
                                 if content:
                                     timestamp = time.perf_counter()
@@ -1133,7 +1177,9 @@ def calculate_metrics(
                 total_input_vision += input_requests[i].vision_prompt_len
             if output_len > 1:
                 tpots.append((outputs[i].latency - outputs[i].ttft) / (output_len - 1))
-            if use_retokenized_itl:
+            if use_retokenized_itl and len(outputs[i].text_chunks) == len(
+                outputs[i].itl
+            ):
                 for k, itl in enumerate(outputs[i].itl):
                     num_tokens = len(
                         tokenizer.encode(
@@ -1142,6 +1188,10 @@ def calculate_metrics(
                     )
                     adjusted_itl = itl / num_tokens
                     retokenized_itls.extend([adjusted_itl] * num_tokens)
+            elif use_retokenized_itl:
+                # The usage-driven path already spreads each chunk over the
+                # tokens the server counted, so there is nothing to re-tokenize.
+                retokenized_itls.extend(outputs[i].itl)
             else:
                 itls += outputs[i].itl
             ttfts.append(outputs[i].ttft)
@@ -2406,6 +2456,18 @@ def cli_main():
         "--disable-stream",
         action="store_true",
         help="Disable streaming mode.",
+    )
+    parser.add_argument(
+        "--stream-step-usage-chunks",
+        type=str,
+        default="off",
+        choices=["off", "first_token", "all"],
+        help="Request stream_options.step_usage_chunks so the server reports "
+        "decode steps whose text the reasoning / tool-call parser buffered. "
+        "Without it those tokens are invisible to the client and get charged to "
+        "TTFT, which distorts TTFT/ITL/TPOT. 'first_token' fixes TTFT, 'all' "
+        "also gives a correct ITL distribution. Requires a server that supports "
+        "the option (older servers ignore it).",
     )
     parser.add_argument(
         "--return-logprob",

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -214,6 +214,18 @@ class UsageInfo(BaseModel):
 class StreamOptions(BaseModel):
     include_usage: Optional[bool] = False
     continuous_usage_stats: Optional[bool] = False
+    # When a decode step's text is fully absorbed by the reasoning / tool-call
+    # parser buffers, no chunk is emitted even though the tokens are already
+    # counted in usage, so clients attribute them to TTFT and over-report decode
+    # speed. Emit an empty-delta chunk carrying usage instead:
+    #   "off"         - never (default, matches the previous behavior)
+    #   "first_token" - only before the first delta-carrying chunk, which is
+    #                   enough for an accurate TTFT and average decode speed
+    #   "all"         - on every buffered step, for a true ITL distribution at
+    #                   the cost of roughly doubling the chunk count
+    # Requires continuous_usage_stats, since the chunk is only useful for its
+    # usage payload.
+    step_usage_chunks: Optional[Literal["off", "first_token", "all"]] = "off"
 
 
 class JsonSchemaResponseFormat(BaseModel):

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -732,6 +732,7 @@ class OpenAIServingChat(OpenAIServingBase):
         prompt_tokens: Dict[int, int],
         reasoning_tokens: Dict[int, int],
         completion_tokens: Dict[int, int],
+        first_delta_seen: Optional[Dict[int, bool]] = None,
     ) -> AsyncGenerator[str, None]:
         """Generate SSE chunks for streaming content."""
         offset = stream_offsets.get(index, 0)
@@ -745,6 +746,13 @@ class OpenAIServingChat(OpenAIServingBase):
         # tool-call, or content) so they aren't dropped when a parser is active
         # nor duplicated across chunks; flush any leftover at the end.
         remaining_logprobs = choice_logprobs
+        # Track whether this generation step produced any SSE chunk. The
+        # reasoning / tool-call parsers may swallow a step's text while they
+        # buffer a partial marker, which makes the stream stop looking
+        # per-step and breaks client-side TTFT/ITL measurement. When the
+        # client opted in via stream_options.step_usage_chunks we emit an
+        # empty-delta usage chunk instead, so the step stays observable.
+        step_emitted = False
 
         # Handle reasoning content
         if self.reasoning_parser and request.separate_reasoning:
@@ -776,6 +784,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     usage=usage,
                 )
                 remaining_logprobs = None
+                step_emitted = True
 
         # Handle tool calls
         if self._tool_call_parsing_active(request):
@@ -791,6 +800,7 @@ class OpenAIServingChat(OpenAIServingBase):
             ):
                 if chunk:
                     yield chunk
+                    step_emitted = True
 
             # Send any remaining tool call arguments when generation finishes
             if finish_reason_type is not None and index in parser_dict:
@@ -800,6 +810,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 )
                 if remaining_chunk:
                     yield remaining_chunk
+                    step_emitted = True
 
         else:
             # Regular content
@@ -823,6 +834,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     usage=usage,
                 )
                 remaining_logprobs = None
+                step_emitted = True
 
         # Flush logprobs still unattached this step — only when a parser is
         # active, since _process_tool_call_stream may consume the delta and emit
@@ -849,6 +861,46 @@ class OpenAIServingChat(OpenAIServingBase):
                 logprobs=remaining_logprobs,
                 usage=usage,
             )
+            step_emitted = True
+
+        if step_emitted:
+            if first_delta_seen is not None:
+                first_delta_seen[index] = True
+            return
+
+        # Nothing was emitted this step: the reasoning / tool-call parser
+        # swallowed the text while buffering a partial marker. Those tokens
+        # already count in usage, so without a chunk here the client charges
+        # them to TTFT, which shrinks the decode window and inflates the
+        # reported decode speed. Opt-in per request via
+        # stream_options.step_usage_chunks, and only meaningful when the client
+        # also asked for per-chunk usage.
+        if not continuous_usage_stats:
+            return
+        step_usage_chunks = (
+            request.stream_options.step_usage_chunks
+            if request.stream_options
+            else "off"
+        )
+        if step_usage_chunks == "off":
+            return
+        if step_usage_chunks == "first_token" and (
+            first_delta_seen is None or first_delta_seen.get(index, False)
+        ):
+            return
+
+        yield build_sse_content(
+            chunk_id=content["meta_info"]["id"],
+            created=int(time.time()),
+            model=request.model,
+            index=index,
+            usage=UsageProcessor.calculate_token_usage(
+                prompt_tokens=prompt_tokens.get(index, 0),
+                reasoning_tokens=reasoning_tokens.get(index, 0),
+                completion_tokens=completion_tokens.get(index, 0),
+                cached_tokens=self._continuous_usage_cached_details(content),
+            ).model_dump(),
+        )
 
     def _tool_call_parsing_active(self, request: ChatCompletionRequest) -> bool:
         """Whether this request's output runs through the tool-call parser.
@@ -1557,6 +1609,9 @@ class OpenAIServingChat(OpenAIServingBase):
         n_prev_tokens = {}
         has_tool_calls = {}
         finish_reasons = {}
+        # Per-choice: has any delta-carrying chunk been sent yet? Used to keep
+        # the usage heartbeat limited to the pre-first-token window.
+        first_delta_seen = {}
 
         # Usage tracking
         prompt_tokens = {}
@@ -1671,6 +1726,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     prompt_tokens=prompt_tokens,
                     reasoning_tokens=reasoning_tokens,
                     completion_tokens=completion_tokens,
+                    first_delta_seen=first_delta_seen,
                 ):
                     yield chunk
 

--- a/test/registered/unit/bench/test_serving_step_usage_chunks.py
+++ b/test/registered/unit/bench/test_serving_step_usage_chunks.py
@@ -1,0 +1,194 @@
+"""Unit tests for the usage-driven TTFT/ITL accounting in the chat bench client.
+
+A decode step whose text the reasoning / tool-call parser buffered produces no
+visible delta, and tokens turned into structured `tool_calls` never show up as
+text either. Driving TTFT/ITL from `usage.completion_tokens` keeps those tokens
+accounted for; without it the run reports ITL 0 and a token count that comes from
+`max_tokens` rather than from the server.
+"""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+import asyncio
+import json
+import unittest
+from argparse import Namespace
+from typing import List
+
+import sglang.benchmark.serving as bench
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=8, suite="base-a-test-cpu")
+
+_API_URL = "http://127.0.0.1:30000/v1/chat/completions"
+
+
+def _chunk(delta=None, usage_tokens=None, finish_reason=None):
+    payload = {
+        "id": "chatcmpl-test",
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": delta or {}, "finish_reason": finish_reason}],
+    }
+    if usage_tokens is not None:
+        payload["usage"] = {"prompt_tokens": 5, "completion_tokens": usage_tokens}
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+class _FakeContent:
+    def __init__(self, lines: List[str]):
+        self._lines = lines
+
+    def __aiter__(self):
+        async def gen():
+            for line in self._lines:
+                yield line.encode()
+
+        return gen()
+
+
+class _FakeResponse:
+    def __init__(self, lines: List[str], status: int = 200):
+        self.status = status
+        self.reason = "OK"
+        self.content = _FakeContent(lines)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Captures the payload and replays a canned SSE stream."""
+
+    def __init__(self, lines: List[str], captured: dict):
+        self._lines = lines
+        self._captured = captured
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    def post(self, url=None, json=None, headers=None):
+        self._captured["url"] = url
+        self._captured["payload"] = json
+        return _FakeResponse(self._lines)
+
+
+def _run(lines: List[str], step_usage_chunks: str = "all", output_len: int = 200):
+    captured = {}
+    saved_args = getattr(bench, "args", None)
+    saved_session = bench._create_bench_client_session
+    bench.args = Namespace(
+        disable_stream=False,
+        disable_ignore_eos=True,
+        cache_report=False,
+        print_requests=False,
+        stream_step_usage_chunks=step_usage_chunks,
+    )
+    bench._create_bench_client_session = lambda: _FakeSession(lines, captured)
+    try:
+        request_input = bench.RequestFuncInput(
+            prompt="hi",
+            api_url=_API_URL,
+            prompt_len=5,
+            output_len=output_len,
+            model="test-model",
+            lora_name=None,
+            image_data=None,
+            extra_request_body={},
+        )
+        output = asyncio.run(bench.async_request_openai_chat_completions(request_input))
+    finally:
+        bench._create_bench_client_session = saved_session
+        if saved_args is None:
+            del bench.args
+        else:
+            bench.args = saved_args
+    return output, captured
+
+
+class TestStreamOptionsInjection(CustomTestCase):
+    def test_off_does_not_touch_payload(self):
+        _, captured = _run([_chunk(usage_tokens=1), "data: [DONE]\n\n"], "off")
+        self.assertNotIn("stream_options", captured["payload"])
+
+    def test_all_requests_usage_chunks(self):
+        _, captured = _run([_chunk(usage_tokens=1), "data: [DONE]\n\n"], "all")
+        self.assertEqual(
+            captured["payload"]["stream_options"],
+            {
+                "include_usage": True,
+                "continuous_usage_stats": True,
+                "step_usage_chunks": "all",
+            },
+        )
+
+
+class TestUsageDrivenAccounting(CustomTestCase):
+    def test_buffered_steps_are_counted(self):
+        """Empty-delta usage chunks contribute tokens, TTFT and ITL samples."""
+        lines = [
+            _chunk(delta={"role": "assistant", "content": ""}),
+            _chunk(delta={"content": "\n"}, usage_tokens=1),
+            # Parser buffered these steps: no visible delta, usage keeps moving.
+            _chunk(usage_tokens=4),
+            _chunk(usage_tokens=7),
+            _chunk(delta={"tool_calls": [{"index": 0}]}, usage_tokens=10),
+            _chunk(finish_reason="tool_calls", usage_tokens=10),
+            "data: [DONE]\n\n",
+        ]
+        output, _ = _run(lines)
+        self.assertTrue(output.success)
+        self.assertEqual(output.output_len, 10)
+        self.assertGreater(output.ttft, 0.0)
+        # 10 tokens: the first sets TTFT, the other 9 become ITL samples.
+        self.assertEqual(len(output.itl), 9)
+
+    def test_tool_call_only_stream_is_not_empty(self):
+        """A pure tool-call answer used to yield zero ITL samples."""
+        lines = [
+            _chunk(delta={"role": "assistant", "content": ""}),
+            _chunk(delta={"tool_calls": [{"index": 0}]}, usage_tokens=1),
+            _chunk(delta={"tool_calls": [{"index": 0}]}, usage_tokens=3),
+            _chunk(finish_reason="tool_calls", usage_tokens=3),
+            "data: [DONE]\n\n",
+        ]
+        output, _ = _run(lines)
+        self.assertEqual(output.output_len, 3)
+        self.assertEqual(len(output.itl), 2)
+
+    def test_output_len_not_taken_from_max_tokens(self):
+        """The reported token count comes from usage, not from the request."""
+        lines = [
+            _chunk(delta={"content": "a"}, usage_tokens=1),
+            _chunk(delta={"content": "b"}, usage_tokens=2),
+            "data: [DONE]\n\n",
+        ]
+        output, _ = _run(lines, output_len=999)
+        self.assertEqual(output.output_len, 2)
+
+    def test_falls_back_to_content_when_server_sends_no_usage(self):
+        """Servers without per-chunk usage keep the previous behavior."""
+        lines = [
+            _chunk(delta={"role": "assistant", "content": ""}),
+            _chunk(delta={"content": "a"}),
+            _chunk(delta={"content": "b"}),
+            _chunk(delta={"content": "c"}),
+            "data: [DONE]\n\n",
+        ]
+        output, _ = _run(lines, "off", output_len=7)
+        self.assertEqual(output.generated_text, "abc")
+        self.assertEqual(len(output.itl), 2)
+        # No usage anywhere: output_len stays at the requested value.
+        self.assertEqual(output.output_len, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/entrypoints/openai/test_stream_step_usage_chunks.py
+++ b/test/registered/unit/entrypoints/openai/test_stream_step_usage_chunks.py
@@ -1,0 +1,358 @@
+"""Unit tests for `stream_options.step_usage_chunks` — no server, no model loading.
+
+Streaming chat only emits an SSE chunk when a parser hands back visible text.
+While the reasoning / tool-call parser buffers a partial marker it swallows the
+step's text, so those tokens are already counted in usage but the client sees no
+chunk and charges them to TTFT, which shrinks the decode window and inflates the
+reported decode speed. `stream_options.step_usage_chunks` (off/first_token/all,
+default off) makes such a step observable by emitting an empty-delta chunk that
+carries usage.
+
+The tests drive `OpenAIServingChat._generate_stream_content` directly with stubs
+for the tokenizer manager and the parsers.
+"""
+
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()  # must precede any import that pulls in sgl_kernel
+
+import asyncio
+import json
+import unittest
+
+from sglang.srt.entrypoints.openai.protocol import ChatCompletionRequest, StreamOptions
+from sglang.srt.entrypoints.openai.serving_chat import OpenAIServingChat
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_CHUNK_ID = "chatcmpl-test"
+_PROMPT_TOKENS = 7
+_COMPLETION_TOKENS = 3
+# tool_choice defaults are derived from tools: without tools it becomes "none",
+# which would keep _generate_stream_content off the tool-call branch entirely.
+_TOOLS = [
+    {
+        "type": "function",
+        "function": {"name": "get_weather", "parameters": {"type": "object"}},
+    }
+]
+
+
+class _FakeServerArgs:
+    incremental_streaming_output = False
+    stream_response_default_include_usage = False
+    enable_cache_report = False
+
+
+class _FakeTokenizerManager:
+    def __init__(self, contents=()):
+        self.server_args = _FakeServerArgs()
+        self._contents = contents
+
+    async def generate_request(self, adapted_request, raw_request):
+        for content in self._contents:
+            yield content
+
+    def create_abort_task(self, adapted_request):
+        return None
+
+
+class _StubServingChat:
+    """Only the attributes and collaborators `_generate_stream_content` touches.
+
+    `tool_emits=None` means the tool-call parser buffered the whole step and
+    emitted nothing; otherwise it is the chunk the parser hands back this step.
+    `reasoning_text` / `remaining_delta` stand in for the reasoning parser's two
+    return values, and `unstreamed_args` for the tool-call arguments flushed when
+    generation finishes.
+    """
+
+    def __init__(
+        self,
+        tool_emits=None,
+        reasoning_parser=None,
+        tool_call_parser="dsml",
+        reasoning_text=None,
+        remaining_delta="",
+        unstreamed_args=None,
+        contents=(),
+    ):
+        self.tokenizer_manager = _FakeTokenizerManager(contents)
+        self.reasoning_parser = reasoning_parser
+        self.tool_call_parser = tool_call_parser
+        self._tool_emits = tool_emits
+        self._reasoning_text = reasoning_text
+        self._remaining_delta = remaining_delta
+        self._unstreamed_args = unstreamed_args
+
+    def _effective_tools(self, request):
+        return [{"type": "function"}]
+
+    def _tool_call_parsing_active(self, request):
+        return OpenAIServingChat._tool_call_parsing_active(self, request)
+
+    def _continuous_usage_cached_details(self, content):
+        return None
+
+    def _check_for_unstreamed_tool_args(self, parser, content, request, index):
+        return self._unstreamed_args
+
+    def _process_reasoning_stream(
+        self, index, delta, reasoning_parser_dict, content, request, finish_reason_type
+    ):
+        return self._reasoning_text, self._remaining_delta
+
+    async def _process_tool_call_stream(
+        self,
+        index,
+        delta,
+        parser_dict,
+        content,
+        request,
+        has_tool_calls,
+        continuous_usage_stats,
+        flush=False,
+    ):
+        if self._tool_emits is not None:
+            yield self._tool_emits
+
+
+def _make_request(step_usage_chunks=None, continuous_usage_stats=True):
+    stream_options = StreamOptions(
+        include_usage=True,
+        continuous_usage_stats=continuous_usage_stats,
+    )
+    if step_usage_chunks is not None:
+        stream_options.step_usage_chunks = step_usage_chunks
+    return ChatCompletionRequest(
+        model="test-model",
+        messages=[{"role": "user", "content": "hi"}],
+        tools=_TOOLS,
+        stream=True,
+        stream_options=stream_options,
+    )
+
+
+async def _collect(
+    stub,
+    request,
+    first_delta_seen,
+    continuous_usage_stats=True,
+    choice_logprobs=None,
+    finish_reason_type=None,
+    parser_dict=None,
+):
+    """Run one decode step and return the SSE chunks it produced."""
+    content = {"text": "<|tool_call_start|>", "meta_info": {"id": _CHUNK_ID}}
+    chunks = []
+    async for chunk in OpenAIServingChat._generate_stream_content(
+        stub,
+        content=content,
+        index=0,
+        request=request,
+        stream_offsets={},
+        reasoning_parser_dict={},
+        parser_dict={0: object()} if parser_dict is None else parser_dict,
+        has_tool_calls={},
+        choice_logprobs=choice_logprobs,
+        finish_reason_type=finish_reason_type,
+        continuous_usage_stats=continuous_usage_stats,
+        prompt_tokens={0: _PROMPT_TOKENS},
+        reasoning_tokens={0: 0},
+        completion_tokens={0: _COMPLETION_TOKENS},
+        first_delta_seen=first_delta_seen,
+    ):
+        chunks.append(chunk)
+    return chunks
+
+
+def _parse(chunk):
+    prefix, _, payload = chunk.partition("data: ")
+    assert prefix == "", f"unexpected SSE prefix: {chunk!r}"
+    return json.loads(payload)
+
+
+class TestStreamOptionsStepUsageChunks(CustomTestCase):
+    """Protocol layer: the value contract of step_usage_chunks."""
+
+    def test_default_is_off(self):
+        self.assertEqual(StreamOptions().step_usage_chunks, "off")
+
+    def test_accepts_documented_values(self):
+        for value in ("off", "first_token", "all"):
+            self.assertEqual(
+                StreamOptions(step_usage_chunks=value).step_usage_chunks, value
+            )
+
+    def test_rejects_unknown_value(self):
+        with self.assertRaises(ValueError):
+            StreamOptions(step_usage_chunks="sometimes")
+
+    def test_reachable_through_request(self):
+        request = _make_request("first_token")
+        self.assertEqual(request.stream_options.step_usage_chunks, "first_token")
+
+
+class TestBufferedStepUsageChunk(CustomTestCase):
+    """Steps whose text the parser buffered (no chunk emitted)."""
+
+    def test_off_emits_nothing(self):
+        chunks = asyncio.run(_collect(_StubServingChat(), _make_request("off"), {}))
+        self.assertEqual(chunks, [])
+
+    def test_missing_stream_options_emits_nothing(self):
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=_TOOLS,
+            stream=True,
+        )
+        chunks = asyncio.run(_collect(_StubServingChat(), request, {}))
+        self.assertEqual(chunks, [])
+
+    def test_first_token_emits_usage_only_chunk(self):
+        chunks = asyncio.run(
+            _collect(_StubServingChat(), _make_request("first_token"), {})
+        )
+        self.assertEqual(len(chunks), 1)
+
+        data = _parse(chunks[0])
+        self.assertEqual(data["id"], _CHUNK_ID)
+        self.assertEqual(data["object"], "chat.completion.chunk")
+        self.assertEqual(data["usage"]["prompt_tokens"], _PROMPT_TOKENS)
+        self.assertEqual(data["usage"]["completion_tokens"], _COMPLETION_TOKENS)
+
+        delta = data["choices"][0]["delta"]
+        self.assertIsNone(delta.get("content"))
+        self.assertIsNone(delta.get("reasoning_content"))
+        self.assertIsNone(data["choices"][0]["finish_reason"])
+
+    def test_first_token_stops_after_first_delta(self):
+        chunks = asyncio.run(
+            _collect(_StubServingChat(), _make_request("first_token"), {0: True})
+        )
+        self.assertEqual(chunks, [])
+
+    def test_all_emits_after_first_delta(self):
+        chunks = asyncio.run(
+            _collect(_StubServingChat(), _make_request("all"), {0: True})
+        )
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(
+            _parse(chunks[0])["usage"]["completion_tokens"], _COMPLETION_TOKENS
+        )
+
+    def test_requires_continuous_usage_stats(self):
+        request = _make_request("all", continuous_usage_stats=False)
+        chunks = asyncio.run(
+            _collect(_StubServingChat(), request, {}, continuous_usage_stats=False)
+        )
+        self.assertEqual(chunks, [])
+
+
+class TestVisibleStepNotAffected(CustomTestCase):
+    """Steps with visible output must behave exactly as before."""
+
+    def test_visible_chunk_passes_through_without_extra_chunk(self):
+        stub = _StubServingChat(tool_emits='data: {"choices": []}\n\n')
+        chunks = asyncio.run(_collect(stub, _make_request("all"), {}))
+        self.assertEqual(chunks, ['data: {"choices": []}\n\n'])
+
+    def test_visible_chunk_marks_first_delta_seen(self):
+        stub = _StubServingChat(tool_emits='data: {"choices": []}\n\n')
+        first_delta_seen = {}
+        asyncio.run(_collect(stub, _make_request("first_token"), first_delta_seen))
+        self.assertTrue(first_delta_seen[0])
+
+
+class TestStepEmittedOnEveryEmitPath(CustomTestCase):
+    """Every emit path must mark the step, otherwise a usage chunk is added."""
+
+    def test_reasoning_chunk_counts_as_emitted(self):
+        stub = _StubServingChat(
+            reasoning_parser="deepseek-r1",
+            tool_call_parser=None,
+            reasoning_text="thinking...",
+        )
+        first_delta_seen = {}
+        chunks = asyncio.run(
+            _collect(stub, _make_request("first_token"), first_delta_seen)
+        )
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(
+            _parse(chunks[0])["choices"][0]["delta"]["reasoning_content"],
+            "thinking...",
+        )
+        self.assertTrue(first_delta_seen[0])
+
+    def test_regular_content_chunk_counts_as_emitted(self):
+        stub = _StubServingChat(tool_call_parser=None)
+        first_delta_seen = {}
+        chunks = asyncio.run(
+            _collect(stub, _make_request("first_token"), first_delta_seen)
+        )
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(
+            _parse(chunks[0])["choices"][0]["delta"]["content"], "<|tool_call_start|>"
+        )
+        self.assertTrue(first_delta_seen[0])
+
+    def test_unstreamed_tool_args_counts_as_emitted(self):
+        tail = 'data: {"choices": [{"index": 0}]}\n\n'
+        stub = _StubServingChat(unstreamed_args=tail)
+        first_delta_seen = {}
+        chunks = asyncio.run(
+            _collect(
+                stub,
+                _make_request("first_token"),
+                first_delta_seen,
+                finish_reason_type="stop",
+            )
+        )
+        self.assertEqual(chunks, [tail])
+        self.assertTrue(first_delta_seen[0])
+
+    def test_logprobs_flush_counts_as_emitted(self):
+        stub = _StubServingChat()
+        first_delta_seen = {}
+        chunks = asyncio.run(
+            _collect(
+                stub,
+                _make_request("first_token"),
+                first_delta_seen,
+                choice_logprobs={"content": []},
+            )
+        )
+        self.assertEqual(len(chunks), 1)
+        self.assertEqual(_parse(chunks[0])["choices"][0]["logprobs"], {"content": []})
+        self.assertTrue(first_delta_seen[0])
+
+
+class TestStreamStateInit(CustomTestCase):
+    """first_delta_seen initialization in _generate_chat_stream."""
+
+    def test_first_delta_seen_initialized_per_stream(self):
+        stub = _StubServingChat(contents=())
+        request = ChatCompletionRequest(
+            model="test-model",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=_TOOLS,
+            stream=True,
+            stream_options=StreamOptions(include_usage=False),
+        )
+
+        async def run():
+            chunks = []
+            async for chunk in OpenAIServingChat._generate_chat_stream(
+                stub, adapted_request=None, request=request, raw_request=None
+            ):
+                chunks.append(chunk)
+            return chunks
+
+        self.assertEqual(asyncio.run(run()), ["data: [DONE]\n\n"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Streaming chat only emits an SSE chunk when a parser hands back visible text. While the reasoning / tool-call parser buffers a partial marker it swallows the step's text, and tokens it turns into structured `tool_calls` never appear as text at all. Those tokens are already counted in `usage`, but the client receives no chunk, so `bench_serving` cannot place them in time.

On a DeepSeek-V4 server started with `--tool-call-parser deepseekv4` this makes three reported numbers wrong:

- `ITL` gets no samples at all and is printed as `0.00 ms`.
- `Total generated tokens` falls back to the requested `max_tokens`, so it is decoupled from what the model actually produced.
- `TPOT` divides the real decode window by that inflated token count and reports a decode speed several times higher than reality.

The gap is directly observable. Per-chunk timestamps of a single streamed request with `continuous_usage_stats` enabled show `usage.completion_tokens` jumping from 1 to 17 with no chunk in between:

```
     t_ms  chunk                  usage.completion_tokens
    435.8  content[2c]                   1
    619.4  tool_calls                   17     <- 16 tokens, no chunk emitted
    801.8  tool_calls                   31
```

## Modifications

Server (`entrypoints/openai/protocol.py`, `entrypoints/openai/serving_chat.py`): add `stream_options.step_usage_chunks` with values `off` / `first_token` / `all` (default `off`). When a decode step emits no chunk and the client asked for `continuous_usage_stats`, send an empty-delta chunk carrying usage so the step stays observable. `first_token` only covers the window before the first delta (enough for a correct TTFT); `all` covers every buffered step (needed for a correct ITL distribution, roughly doubles the chunk count). All emit paths (reasoning delta, tool-call delta, flushed tool-call arguments, regular content, standalone logprobs) mark the step as emitted, so a visible step never gets an extra chunk.

Client (`benchmark/serving.py`): for `sglang-oai-chat`, prefer the server-reported `usage.completion_tokens` when present — the first increment sets TTFT and later increments are spread over the tokens they cover, the same way the `/generate` backend already does. Streams without per-chunk usage keep the previous content-driven path. New flag `--stream-step-usage-chunks {off,first_token,all}` requests the option (default `off`, no `stream_options` injected). Also fixes an `IndexError` in the retokenized-ITL path, which indexed `text_chunks` by ITL position — with usage-driven accounting `itl` has one entry per token while `text_chunks` has one per visible chunk.

Default behavior is unchanged for both server and client.

## Accuracy Tests

No change to model outputs — the change only adds an SSE chunk that carries usage and no delta, plus client-side metric accounting.

Unit tests:

```
test/registered/unit/entrypoints/openai/test_stream_step_usage_chunks.py   17 passed
test/registered/unit/bench/test_serving_step_usage_chunks.py                6 passed
test/registered/unit/entrypoints/openai/test_serving_chat.py
test/registered/unit/entrypoints/openai/test_protocol.py       156 passed, 82 subtests
```

The server-side tests cover the protocol contract (default `off`, accepted values, rejection of unknown values, propagation from the request), the heartbeat behavior (`off` / `first_token` / `all`, missing `stream_options`, `continuous_usage_stats` required, chunk shape and usage counters) and that every emit path marks the step. The client tests cover `stream_options` injection, usage-driven TTFT/ITL accounting including tool-call-only streams, `output_len` no longer defaulting to `max_tokens`, and the fallback for servers without per-chunk usage.

## Speed Tests and Profiling

Server: DeepSeek-V4-Flash-FP8, `--tool-call-parser deepseekv4`, `--reasoning-parser deepseek-v4`, EAGLE speculative decoding, TP4 DP4. Workload: 32 prompts that force one `execute_bash` tool call, concurrency 8, `--sharegpt-output-len 200`. Same server, same dataset for every run.

### Before (main, `c2223996d`)

```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     32
Benchmark duration (s):                  28.64
Total input tokens:                      1580
Total input text tokens:                 1580
Total generated tokens:                  6400
Total generated tokens (retokenized):    32
Request throughput (req/s):              1.12
Input token throughput (tok/s):          55.17
Output token throughput (tok/s):         223.49
Peak output token throughput (tok/s):    5.00
Peak concurrent requests:                12
Total token throughput (tok/s):          278.66
Concurrency:                             7.31
Accept length:                           2.66
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   6538.22
Median E2E Latency (ms):                 7441.71
P90 E2E Latency (ms):                    9187.89
P95 E2E Latency (ms):                    9444.90
P99 E2E Latency (ms):                    9686.20
---------------Time to First Token----------------
Mean TTFT (ms):                          1386.02
Median TTFT (ms):                        1371.10
P90 TTFT (ms):                           2338.84
P95 TTFT (ms):                           2593.85
P99 TTFT (ms):                           2875.35
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          25.89
Median TPOT (ms):                        30.05
P90 TPOT (ms):                           37.62
P95 TPOT (ms):                           39.65
P99 TPOT (ms):                           40.92
---------------Inter-Token Latency----------------
Mean ITL (ms):                           0.00
Median ITL (ms):                         0.00
P90 ITL (ms):                            0.00
P95 ITL (ms):                            0.00
P99 ITL (ms):                            0.00
Max ITL (ms):                            0.00
==================================================
```

### After (this PR, `--stream-step-usage-chunks all`)

```
============ Serving Benchmark Result ============
Backend:                                 sglang-oai-chat
Traffic request rate:                    inf
Max request concurrency:                 8
Successful requests:                     32
Benchmark duration (s):                  34.34
Total input tokens:                      1580
Total input text tokens:                 1580
Total generated tokens:                  1843
Total generated tokens (retokenized):    32
Request throughput (req/s):              0.93
Input token throughput (tok/s):          46.01
Output token throughput (tok/s):         53.66
Peak output token throughput (tok/s):    150.00
Peak concurrent requests:                14
Total token throughput (tok/s):          99.67
Concurrency:                             6.82
Accept length:                           2.64
----------------End-to-End Latency----------------
Mean E2E Latency (ms):                   7316.45
Median E2E Latency (ms):                 7014.01
P90 E2E Latency (ms):                    9064.14
P95 E2E Latency (ms):                    9465.56
P99 E2E Latency (ms):                    10093.37
---------------Time to First Token----------------
Mean TTFT (ms):                          1180.48
Median TTFT (ms):                        1074.90
P90 TTFT (ms):                           2051.89
P95 TTFT (ms):                           2833.23
P99 TTFT (ms):                           3091.79
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          108.17
Median TPOT (ms):                        113.04
P90 TPOT (ms):                           128.33
P95 TPOT (ms):                           129.88
P99 TPOT (ms):                           131.89
---------------Inter-Token Latency----------------
Mean ITL (ms):                           108.42
Median ITL (ms):                         107.05
P90 ITL (ms):                            161.04
P95 ITL (ms):                            165.16
P99 ITL (ms):                            288.25
Max ITL (ms):                            426.33
==================================================
```

### Which numbers were wrong

- `ITL`, all percentiles: `0.00` -> `108.42 / 107.05 / 161.04 / 165.16 / 288.25 / 426.33 ms`
- `Mean TPOT`: `25.89` -> `108.17 ms`, i.e. reported decode speed `38.6` -> `9.2 tok/s`
- `Total generated tokens`: `6400` (= 32 x 200 `max_tokens`) -> `1843` (server usage)
- `Output token throughput` / `Peak`: `223.49 / 5.00` -> `53.66 / 150.00 tok/s`. Before, the aggregate was inflated by the fake token count while the peak was near zero because almost no visible token landed in a per-second bucket.

`TTFT`, `E2E Latency` and `Accept length` are unaffected on this deployment: this model emits one visible character before the DSML marker, so the buffering starts after the first token. On deployments where the first tokens are markers the same mechanism inflates TTFT.

### Repeatability and cross-check

Three runs each, same server and dataset:

- before: TPOT `25.89 / 28.05 / 25.50 ms`, ITL all `0.00`, tokens all `6400`
- after: TPOT `108.17 / 116.54 / 92.37 ms`, ITL `108.42 / 117.37 / 92.71 ms`, tokens `1843 / 1957 / 1840`
- anchor, same prompts without `tools` so the tool-call parser is not used: TPOT `93.37 / 109.83 ms`, ITL `96.17 / 110.96 ms`

After the fix the tool-call run agrees with the no-tool anchor; before the fix it looked ~4x faster than the anchor.

Changing only `--sharegpt-output-len` from 200 to 400, while the model stops on EOS well before either limit so generation is identical:

- before: `Total generated tokens 6400 -> 12800`, `Mean TPOT 25.89 -> 14.27 ms`, reported decode speed `38.6 -> 70.1 tok/s`
- after: `Total generated tokens 1843 -> 1843`, `Mean TPOT 108.17 -> 97.76 ms`, reported decode speed `9.2 -> 10.2 tok/s` (shared-machine noise)

Before the fix the reported decode speed is a function of the requested `max_tokens` rather than a measurement of the server.

## Known limitation: the Rust router strips `stream_options` extensions

When the request goes through the official Rust router (`sglang-router`, built from `sgl-model-gateway/`), the new option never reaches the server. The router deserializes the body into a typed `ChatCompletionRequest` (`sgl-model-gateway/src/server.rs`, `ValidatedJson<ChatCompletionRequest>`) and re-serializes it before forwarding (`src/routers/http/pd_router.rs`, `serde_json::to_value(shared_request.as_ref())`), so any field the struct does not model is dropped. The types come from the pinned `openai-protocol = "=1.0.0"` crate, whose `StreamOptions` only carries `include_usage`.

This is not specific to this PR — upstream's own `continuous_usage_stats`, and even top-level fields such as `rid`, are dropped the same way. Measured on a PD deployment (1 prefill + 1 decode), identical request each time:

```
entry point                                sse_chunks  usage_bearing_chunks  rid kept
sglang-router (Rust, protocol 1.0.0)                8                     1  no
--mini-lb (Python MiniLoadBalancer)                21                    19  yes
direct to the decode server                        23                    21  yes
```

A fix has been proposed upstream in the gateway's protocol crate (https://github.com/smg-project/smg/pull/2339): a catch-all for unmodelled `stream_options` keys, mirroring the one `ChatCompletionRequest` already has. With a gateway built from that branch the same request carries 19 usage-bearing chunks and `Median ITL` becomes `3.62 ms` against a `4.71 ms` mean TPOT, instead of `0.43 ms`. Until a release carrying it is picked up here, benchmark with `--mini-lb` or against the server directly.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33034308769](https://github.com/sgl-project/sglang/actions/runs/33034308769)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33034308727](https://github.com/sgl-project/sglang/actions/runs/33034308727)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33034308705](https://github.com/sgl-project/sglang/actions/runs/33034308705)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->