### PR TITLE
Fix string-valued numeric constraints in tool schemas

### DIFF
--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -68,6 +68,24 @@ _PREFIX_RULES: Tuple[Tuple[Tuple[str, ...], str], ...] = (
     (("dict",), "object"),
 )
 
+_INTEGER_JSON_SCHEMA_KEYWORDS = (
+    "maxContains",
+    "maxItems",
+    "maxLength",
+    "maxProperties",
+    "minContains",
+    "minItems",
+    "minLength",
+    "minProperties",
+)
+_NUMBER_JSON_SCHEMA_KEYWORDS = (
+    "exclusiveMaximum",
+    "exclusiveMinimum",
+    "maximum",
+    "minimum",
+    "multipleOf",
+)
+
 
 def _matches_type_prefix(base: str, prefixes: Tuple[str, ...]) -> bool:
     for p in prefixes:
@@ -110,16 +128,30 @@ def _normalize_type_list(raw_items: List[Any]) -> List[Any]:
     return normalized_items
 
 
+def _normalize_numeric_constraint(raw: Any, *, integer: bool) -> Any:
+    if not isinstance(raw, str):
+        return raw
+    try:
+        parsed = orjson.loads(raw)
+    except orjson.JSONDecodeError:
+        return raw
+    if isinstance(parsed, bool):
+        return raw
+    if integer:
+        return parsed if isinstance(parsed, int) else raw
+    return parsed if isinstance(parsed, (int, float)) else raw
+
+
 def normalize_json_schema_types(schema: Any) -> None:
     """
-    Walk a JSON Schema in place and rewrite non-standard ``"type"`` values
-    (e.g. ``"varchar"``, ``"enum"``, ``"int"``) to their standard JSON Schema
-    equivalents.
+    Walk a JSON Schema in place and normalize common generator output:
+    non-standard ``"type"`` values (e.g. ``"varchar"``, ``"enum"``, ``"int"``)
+    and numeric constraint values serialized as JSON strings.
 
     Acts as a compatibility layer for tool ``parameters`` schemas exported
     from database / ORM tooling, which often uses DB type names rather than
-    JSON Schema types. Unknown types are left untouched so that downstream
-    validation can still surface genuine errors.
+    JSON Schema types. Unknown types and non-numeric constraints are left
+    untouched so that downstream validation can still surface genuine errors.
 
     Mutates the input dict in place; the rewritten schema is also what gets
     rendered into the model prompt, so e.g. a user-supplied ``"varchar"``
@@ -139,6 +171,13 @@ def normalize_json_schema_types(schema: Any) -> None:
             schema["type"] = _normalize_single_type(t)
         elif isinstance(t, list):
             schema["type"] = _normalize_type_list(t)
+
+    for key in _INTEGER_JSON_SCHEMA_KEYWORDS:
+        if key in schema:
+            schema[key] = _normalize_numeric_constraint(schema[key], integer=True)
+    for key in _NUMBER_JSON_SCHEMA_KEYWORDS:
+        if key in schema:
+            schema[key] = _normalize_numeric_constraint(schema[key], integer=False)
 
     for key in (
         "properties",

--- a/test/registered/unit/function_call/test_normalize_json_schema_types.py
+++ b/test/registered/unit/function_call/test_normalize_json_schema_types.py
@@ -59,6 +59,50 @@ class TestNormalizeJsonSchemaTypes(CustomTestCase):
         self.assertEqual(props["ratio"]["type"], "number")
         self._assert_accepts(schema)
 
+    def test_string_encoded_numeric_constraints(self):
+        schema = {
+            "type": "object",
+            "properties": {
+                "count": {
+                    "type": "integer",
+                    "minimum": "1",
+                    "maximum": "10.5",
+                },
+                "label": {"type": "string", "minLength": "2"},
+                "values": {
+                    "type": "array",
+                    "maxItems": "3",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "score": {"type": "number", "multipleOf": "0.25"}
+                        },
+                    },
+                },
+            },
+        }
+        normalize_json_schema_types(schema)
+        properties = schema["properties"]
+        self.assertEqual(properties["count"]["minimum"], 1)
+        self.assertEqual(properties["count"]["maximum"], 10.5)
+        self.assertEqual(properties["label"]["minLength"], 2)
+        self.assertEqual(properties["values"]["maxItems"], 3)
+        self.assertEqual(
+            properties["values"]["items"]["properties"]["score"]["multipleOf"],
+            0.25,
+        )
+        self._assert_accepts(schema)
+
+    def test_invalid_numeric_constraints_remain_invalid(self):
+        values = ("many", "1.5", "true", {}, [])
+        for value in values:
+            with self.subTest(value=value):
+                schema = {"type": "array", "maxItems": value}
+                normalize_json_schema_types(schema)
+                self.assertEqual(schema["maxItems"], value)
+                with self.assertRaises(SchemaError):
+                    self._assert_accepts(schema)
+
     def test_prefix_matched_numeric_types(self):
         schema = {
             "type": "object",


### PR DESCRIPTION
## Summary

- Normalize parseable string-valued numeric constraints in tool JSON schemas before strict validation.
- Keep malformed values and incompatible types unchanged so `Draft202012Validator.check_schema` still rejects them.
- Add focused positive and negative regression coverage.

## Motivation

Numeric JSON Schema constraints are canonically numbers, but real OpenAI-compatible traffic sometimes encodes them as strings. vLLM tolerates these schemas, while SGLang currently rejects them before inference.

In a privacy-safe replay of requests that had previously failed schema validation, 102 requests failed persistently because of string-valued numeric constraints: `minimum` (44), `maximum` (23), `maxItems` (33: 9 direct and 24 nested), and `minLength` (2). No prompt text or private schema values are included in this PR.

A minimized synthetic example is:

```json
{
  "type": "object",
  "properties": {
    "count": {"type": "integer", "minimum": "1", "maximum": "10"},
    "tags": {"type": "array", "maxItems": "3"},
    "name": {"type": "string", "minLength": "1"}
  }
}
```

## Behavior

This is narrow compatibility normalization before strict validation, not a relaxation of arbitrary schema types:

- integer-only constraints accept only strings that decode to JSON integers (excluding booleans);
- number constraints accept strings that decode to JSON integers or floats (excluding booleans);
- nonnumeric strings, booleans, objects, and arrays remain unchanged and fail strict validation;
- decimal strings remain invalid for integer-only constraints.

## Tests

- Focused test file: 25 passed, including 5 parameterized subtests
- New targeted cases: 2 passed, including 5 parameterized subtests
- `ruff`, `isort --check-only`, `black --check`, `py_compile`, and `git diff --check`
- With `max_tokens=1` to isolate schema acceptance, unpatched v0.5.17 still rejected 102 of the 231 prior HTTP 400 requests for the numeric constraints counted above. Patched v0.5.17 accepted the same 231-request cohort: 231 HTTP 200 responses, 0 HTTP 400 responses.
- A standalone synthetic request containing string-valued `minimum`, `maximum`, `maxItems`, and `minLength` constraints returned HTTP 200 on patched v0.5.17.

## Compatibility risk

Low and intentionally scoped. Schemas that previously returned HTTP 400 solely because a recognized numeric constraint was a parseable string will now be accepted. Malformed constraints remain rejected by the existing strict validator.
