### PR TITLE
 [kernel] Optimize MiniMax sparse KV page lookups

### DIFF
--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/flash_with_topk_idx.py
@@ -158,7 +158,12 @@ def _decode_score_kernel(
                 mask=prefetch_mask,
                 other=0,
             ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots
+        # Same wrap as `(slots + max_slots) % max_slots` over
+        # [-max_slots, 2 * max_slots), without a runtime integer modulo: GPUs
+        # have no integer div/mod, so the modulo expands into a reciprocal
+        # sequence on every lane of this vector.
+        slots = tl.where(slots < 0, slots + max_slots, slots)
+        slots = tl.where(slots >= max_slots, slots - max_slots, slots)
         # load K as (head_dim, BLOCK_SIZE_N) via indirect addressing
         k_off = (
             slots[None, :] * stride_k_s
@@ -373,7 +378,12 @@ def _decode_score_attn_kernel(
             mask=pos_mask,
             other=0,
         ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots  # safety against negative
+        # Same wrap as `(slots + max_slots) % max_slots` over
+        # [-max_slots, 2 * max_slots), without a runtime integer modulo: GPUs
+        # have no integer div/mod, so the modulo expands into a reciprocal
+        # sequence on every lane of this vector.
+        slots = tl.where(slots < 0, slots + max_slots, slots)
+        slots = tl.where(slots >= max_slots, slots - max_slots, slots)
         # load K as (head_dim, BLOCK_SIZE_N) via indirect addressing
         k_off = (
             slots[None, :] * stride_k_s

--- a/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/decode/topk_sparse.py
@@ -13,6 +13,10 @@ from ..common.utils import (
     unit_scale,
 )
 
+# Shortest per-page run worth taking the paged slot resolution for. Below this
+# the [PAGE_RUNS, PAGE_SPAN] reshape costs more than the gather it replaces.
+MIN_PAGE_SPAN = 16
+
 
 @triton.heuristics(
     {
@@ -89,6 +93,9 @@ def _gqa_share_sparse_decode_kernel(
     NUM_TOPK_CHUNKS: tl.constexpr,
     HAS_SINK: tl.constexpr,
     IS_FP8: tl.constexpr,
+    PAGED_KV: tl.constexpr,
+    PAGE_SPAN: tl.constexpr,  # consecutive slots per run
+    PAGE_RUNS: tl.constexpr,  # runs per block (PAGE_SPAN * PAGE_RUNS == BLOCK_SIZE_N)
 ):
     # decode program ids: split-K over the topk dimension to give every SM
     # something to do at small batch. pid(0) folds (batch, chunk) together so
@@ -168,12 +175,46 @@ def _gqa_share_sparse_decode_kernel(
         # resolve slots for this block via req_to_token
         pos = c + off_n
         pos_mask = pos < seq_len
-        slots = tl.load(
-            req_to_token_ptr + sid * stride_r2t_b + pos,
-            mask=pos_mask,
-            other=0,
-        ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots  # safety against negative
+        if PAGED_KV:
+            # A block starts at a multiple of block_size, so whenever page and
+            # block sizes divide one another the block covers PAGE_RUNS whole,
+            # page-aligned runs of PAGE_SPAN consecutive slots. One lookup per
+            # run then replaces the BLOCK_SIZE_N-entry index gather.
+            if PAGE_RUNS == 1:
+                # page_size >= block size: the whole block is one page.
+                base_slot = tl.load(
+                    req_to_token_ptr + sid * stride_r2t_b + c,
+                    mask=c < seq_len,
+                    other=0,
+                ).to(tl.int64)
+                base_slot = tl.where(base_slot < 0, base_slot + max_slots, base_slot)
+                slots = base_slot + off_n.to(tl.int64)
+            else:
+                # page_size < block size: one lookup per page.
+                off_p = tl.arange(0, PAGE_RUNS)
+                run_pos = c + off_p * PAGE_SPAN
+                bases = tl.load(
+                    req_to_token_ptr + sid * stride_r2t_b + run_pos,
+                    mask=run_pos < seq_len,
+                    other=0,
+                ).to(tl.int64)
+                bases = tl.where(bases < 0, bases + max_slots, bases)
+                slots = tl.reshape(
+                    bases[:, None] + tl.arange(0, PAGE_SPAN).to(tl.int64)[None, :],
+                    BLOCK_SIZE_N,
+                )
+        else:
+            slots = tl.load(
+                req_to_token_ptr + sid * stride_r2t_b + pos,
+                mask=pos_mask,
+                other=0,
+            ).to(tl.int64)
+            # Same wrap as `(slots + max_slots) % max_slots` over
+            # [-max_slots, 2 * max_slots), without a runtime integer modulo:
+            # GPUs have no integer div/mod, so the modulo expands into a
+            # reciprocal sequence on every lane of this vector.
+            slots = tl.where(slots < 0, slots + max_slots, slots)
+            slots = tl.where(slots >= max_slots, slots - max_slots, slots)
         # load K as (head_dim, BLOCK_SIZE_N) via indirect addressing
         k_off = (
             slots[None, :] * stride_k_s
@@ -321,7 +362,19 @@ def flash_decode_with_gqa_share_sparse(
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    page_size: int = 1,
 ) -> torch.Tensor:
+    """Sparse GQA decode over the selected blocks of the paged main KV cache.
+
+    ``page_size`` is the KV pool's allocation granularity -- the pool hands out
+    ``page_size`` *contiguous* slots per page, which is what makes this work
+    (the MSA path relies on the same contract). When it and
+    ``block_size`` divide one another a selected block covers whole,
+    page-aligned runs of consecutive slots, so the inner loop resolves it with
+    one ``req_to_token`` lookup per run instead of a ``block_size``-entry
+    gather. Any other page size (and the default 1) keeps the gather, so the
+    argument is always safe to pass; the two paths are bit-identical.
+    """
     triton.set_allocator(robust_allocator)
     is_fp8 = check_sparse_kv_fp8(q, k_cache, v_cache, label="decode")
     k_scale = unit_scale(k_scale)
@@ -334,6 +387,18 @@ def flash_decode_with_gqa_share_sparse(
     assert (
         triton.next_power_of_2(block_size) == block_size
     ), f"block_size must be a power of 2, but got {block_size}"
+    # A block starts at a multiple of block_size, so its slots are consecutive
+    # within page-aligned runs exactly when page and block sizes divide one
+    # another -- either direction:
+    #     page >= block  ->  1 run of block_size      (one scalar lookup)
+    #     page <  block  ->  block/page runs of page  (one lookup per page)
+    page_span = min(page_size, block_size)
+    paged_kv = (
+        (page_size % block_size == 0 or block_size % page_size == 0)
+        and max_slots % page_size == 0
+        and page_span >= MIN_PAGE_SPAN
+    )
+    page_runs = block_size // page_span if paged_kv else 1
     # assert slot_ids.max() < max_slots, f"get slot_ids {slot_ids}, but kv_cache shape is {kv_cache.shape}"
     max_kv_len = req_to_token.shape[1]
     # gqa
@@ -420,6 +485,9 @@ def flash_decode_with_gqa_share_sparse(
         BLOCK_SIZE_N=block_size,
         NUM_TOPK_CHUNKS=NUM_TOPK_CHUNKS,
         IS_FP8=is_fp8,
+        PAGED_KV=paged_kv,
+        PAGE_SPAN=page_span,
+        PAGE_RUNS=page_runs,
     )
     # merge partials into chunk 0
     merge_grid = (batch_size, num_q_heads)

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/flash_with_topk_idx.py
@@ -204,7 +204,12 @@ def _flash_attn_fwd_with_block_score_kernel(
             mask=pos_mask,
             other=0,
         ).to(tl.int64)
-        slots = (slots + max_slots) % max_slots  # safety against negative
+        # Same wrap as `(slots + max_slots) % max_slots` over
+        # [-max_slots, 2 * max_slots), without a runtime integer modulo: GPUs
+        # have no integer div/mod, so the modulo expands into a reciprocal
+        # sequence on every lane of this vector.
+        slots = tl.where(slots < 0, slots + max_slots, slots)
+        slots = tl.where(slots >= max_slots, slots - max_slots, slots)
         # k shape: [BLOCK_SIZE_KD, BLOCK_SIZE_K] (transposed for tl.dot)
         k = tl.load(
             k_cache_ptr

--- a/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
+++ b/python/sglang/kernels/ops/attention/minimax_sparse/prefill/topk_sparse.py
@@ -14,6 +14,10 @@ from ..common.utils import (
     unit_scale,
 )
 
+# Shortest per-page run worth taking the paged slot resolution for. Below this
+# the [PAGE_RUNS, PAGE_SPAN] reshape costs more than the gather it replaces.
+MIN_PAGE_SPAN = 16
+
 
 @triton.heuristics(
     {
@@ -106,6 +110,9 @@ def _gqa_share_sparse_fwd_kernel(
     HAS_SINK: tl.constexpr,
     USE_TMA: tl.constexpr,
     IS_FP8: tl.constexpr,
+    PAGED_KV: tl.constexpr,
+    PAGE_SPAN: tl.constexpr,  # consecutive slots per run
+    PAGE_RUNS: tl.constexpr,  # runs per block (PAGE_SPAN * PAGE_RUNS == BLOCK_SIZE_K)
 ):
     sm_scale_log2e = sm_scale * 1.4426950409
     # get batch id and head id
@@ -194,12 +201,48 @@ def _gqa_share_sparse_fwd_kernel(
             # paged load K via req_to_token: pos -> slot -> k_cache
             pos = c + off_n
             pos_mask = pos < seq_len
-            slots = tl.load(
-                req_to_token_ptr + sid * stride_r2t_b + pos,
-                mask=pos_mask,
-                other=0,
-            ).to(tl.int64)
-            slots = (slots + max_slots) % max_slots  # safety against negative
+            if PAGED_KV:
+                # A block starts at a multiple of block_size, so whenever page and
+                # block sizes divide one another the block covers PAGE_RUNS whole,
+                # page-aligned runs of PAGE_SPAN consecutive slots. One lookup per
+                # run then replaces the BLOCK_SIZE_K-entry index gather.
+                if PAGE_RUNS == 1:
+                    # page_size >= block size: the whole block is one page.
+                    base_slot = tl.load(
+                        req_to_token_ptr + sid * stride_r2t_b + c,
+                        mask=c < seq_len,
+                        other=0,
+                    ).to(tl.int64)
+                    base_slot = tl.where(
+                        base_slot < 0, base_slot + max_slots, base_slot
+                    )
+                    slots = base_slot + off_n.to(tl.int64)
+                else:
+                    # page_size < block size: one lookup per page.
+                    off_p = tl.arange(0, PAGE_RUNS)
+                    run_pos = c + off_p * PAGE_SPAN
+                    bases = tl.load(
+                        req_to_token_ptr + sid * stride_r2t_b + run_pos,
+                        mask=run_pos < seq_len,
+                        other=0,
+                    ).to(tl.int64)
+                    bases = tl.where(bases < 0, bases + max_slots, bases)
+                    slots = tl.reshape(
+                        bases[:, None] + tl.arange(0, PAGE_SPAN).to(tl.int64)[None, :],
+                        BLOCK_SIZE_K,
+                    )
+            else:
+                slots = tl.load(
+                    req_to_token_ptr + sid * stride_r2t_b + pos,
+                    mask=pos_mask,
+                    other=0,
+                ).to(tl.int64)
+                # Same wrap as `(slots + max_slots) % max_slots` over
+                # [-max_slots, 2 * max_slots), without a runtime integer modulo:
+                # GPUs have no integer div/mod, so the modulo expands into a
+                # reciprocal sequence on every lane of this vector.
+                slots = tl.where(slots < 0, slots + max_slots, slots)
+                slots = tl.where(slots >= max_slots, slots - max_slots, slots)
             # k shape: [BLOCK_SIZE_KD, BLOCK_SIZE_K] (transposed for tl.dot)
             k = tl.load(
                 k_cache_ptr
@@ -289,7 +332,19 @@ def flash_prefill_with_gqa_share_sparse(
     q_scale: Optional[float] = None,
     k_scale: Optional[float] = None,
     v_scale: Optional[float] = None,
+    page_size: int = 1,
 ) -> torch.Tensor:
+    """Sparse GQA attention over the selected blocks of the paged main KV cache.
+
+    ``page_size`` is the KV pool's allocation granularity -- the pool hands out
+    ``page_size`` *contiguous* slots per page, which is what makes this work
+    (the MSA path relies on the same contract). When it and
+    ``block_size_k`` divide one another a selected block covers whole,
+    page-aligned runs of consecutive slots, so the inner loop resolves it with
+    one ``req_to_token`` lookup per run instead of a ``block_size_k``-entry
+    gather. Any other page size (and the default 1) keeps the gather, so the
+    argument is always safe to pass; the two paths are bit-identical.
+    """
     triton.set_allocator(robust_allocator)
     is_fp8 = check_sparse_kv_fp8(q, k_cache, v_cache, label="prefill")
     k_scale = unit_scale(k_scale)
@@ -302,6 +357,18 @@ def flash_prefill_with_gqa_share_sparse(
     _, num_v_heads, v_head_dim = v_cache.shape
     batch_size = cu_seqlens.shape[0] - 1
     topk = topk_idx.shape[-1]
+    # A block starts at a multiple of block_size_k, so its slots are consecutive
+    # within page-aligned runs exactly when page and block sizes divide one
+    # another -- either direction:
+    #     page >= block  ->  1 run of block_size_k    (one scalar lookup)
+    #     page <  block  ->  block/page runs of page  (one lookup per page)
+    page_span = min(page_size, block_size_k)
+    paged_kv = (
+        (page_size % block_size_k == 0 or block_size_k % page_size == 0)
+        and max_slots % page_size == 0
+        and page_span >= MIN_PAGE_SPAN
+    )
+    page_runs = block_size_k // page_span if paged_kv else 1
     assert topk_idx.shape[0] == num_k_heads
     # gqa
     assert num_k_heads == num_v_heads
@@ -377,5 +444,8 @@ def flash_prefill_with_gqa_share_sparse(
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         USE_TMA=use_tma,
         IS_FP8=is_fp8,
+        PAGED_KV=paged_kv,
+        PAGE_SPAN=page_span,
+        PAGE_RUNS=page_runs,
     )
     return o

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -888,6 +888,17 @@ def _minimax_m3_overrides(server_args: Any, hf_config: Any) -> dict:
     if is_hip():
         if server_args.is_attention_backend_not_set():
             overrides["attention_backend"] = "triton"
+        if (
+            server_args.page_size is None
+            and overrides.get("attention_backend", server_args.attention_backend)
+            == "triton"
+        ):
+            overrides["page_size"] = 128
+            logger.info(
+                "MiniMax-M3 on ROCm: page_size=128 to match the sparse block "
+                "size, so the Triton sparse kernels resolve a selected block "
+                "with one req_to_token lookup per page."
+            )
         if server_args.moe_runner_backend == "auto" and quant_resolved == "mxfp8":
             overrides["moe_runner_backend"] = "triton"
         if not envs.USE_ROCM_AITER_ROPE_BACKEND.is_set():
@@ -932,8 +943,16 @@ def _minimax_m3_overrides(server_args: Any, hf_config: Any) -> dict:
         page_resolved = server_args.page_size
         # fa4 (fmha_sm100) and trtllm_mha both allow the page_size == 128
         # sparse block MSA needs (trtllm_mha via trtllm-gen's dynamic
-        # tokens-per-page kernels).
-        if page_resolved is None and backend_resolved in ("fa4", "trtllm_mha"):
+        # tokens-per-page kernels), and triton serves any page size. Matching
+        # the page to the sparse block also lets the Triton step-3 kernels
+        # resolve a selected block with one req_to_token lookup per page
+        # instead of a per-token gather, which is what runs whenever MSA is
+        # unavailable.
+        if page_resolved is None and backend_resolved in (
+            "fa4",
+            "trtllm_mha",
+            "triton",
+        ):
             overrides["page_size"] = 128
             page_resolved = 128
         if server_args.moe_runner_backend == "auto" and quant_resolved == "mxfp8":
@@ -952,11 +971,12 @@ def _minimax_m3_overrides(server_args: Any, hf_config: Any) -> dict:
         if server_args.is_attention_backend_not_set():
             overrides["attention_backend"] = "fa3"
         page_resolved = server_args.page_size
-        if (
-            page_resolved is None
-            and overrides.get("attention_backend", server_args.attention_backend)
-            == "fa3"
-        ):
+        # fa3 allows the 128-token page, and triton serves any page size; both
+        # want it matched to the sparse block size so the Triton step-3 kernels
+        # resolve a selected block with one req_to_token lookup per page.
+        if page_resolved is None and overrides.get(
+            "attention_backend", server_args.attention_backend
+        ) in ("fa3", "triton"):
             overrides["page_size"] = 128
             page_resolved = 128
         logger.info(
@@ -964,6 +984,15 @@ def _minimax_m3_overrides(server_args: Any, hf_config: Any) -> dict:
             f"{overrides.get('attention_backend', server_args.attention_backend)}, page_size={page_resolved} "
             "(MSA is SM100-only; sparse attention runs on the Triton path)."
         )
+    elif (
+        server_args.page_size is None
+        and overrides.get("attention_backend", server_args.attention_backend)
+        == "triton"
+    ):
+        # Pre-Hopper CUDA has no arch default for the dense backend, but an
+        # explicit --attention-backend triton runs the same Triton sparse path,
+        # which wants the KV page matched to the sparse block size.
+        overrides["page_size"] = 128
 
     # fp8 attention GEMMs have no opt-in flag: m3_fp8_attn_gemm_enabled
     # (server_args.py) derives the mode from kv_cache_dtype (fp8_e4m3) +

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -1420,6 +1420,7 @@ class MiniMaxSparseAttnBackend(AttentionBackend):
                 self.local_blocks,
                 score_type=self.score_type,
                 disable_index_value=disable_value,
+                page_size=self.page_size,
                 use_msa=self.use_msa,
                 seqlens_cpu=forward_batch.extend_seq_lens_cpu,
                 q_scale=layer.q_scale_float,

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/minimax_sparse.py
@@ -62,6 +62,7 @@ def minimax_sparse_prefill(
     idx_sm_scale: Optional[float] = None,
     score_type: str = "max",
     disable_index_value: bool = False,
+    page_size: int = 1,
     use_msa: bool = False,
     cu_seqblocks_q: Optional[torch.Tensor] = None,
     max_seqblock_q: Optional[int] = None,
@@ -81,6 +82,12 @@ def minimax_sparse_prefill(
     kernels. Supplying them avoids recomputing the same block layout twice.
     ``seqlens_cpu`` (host copy of ``torch.diff(cu_seqlens)``) is forwarded to
     ``get_cu_seqblocks`` to avoid a per-layer device sync when it recomputes.
+
+    ``page_size`` is the KV pool's allocation granularity; the step-3 kernel uses
+    it to resolve a selected block with one ``req_to_token`` lookup per
+    page-aligned run instead of a per-token gather. It falls back to the gather
+    for page sizes that do not divide (or are not divided by) ``block_size_k``,
+    so it is always safe to pass.
     """
     if cu_seqblocks_q is None or max_seqblock_q is None or all_seqblock_q is None:
         cu_seqblocks_q, max_seqblock_q, all_seqblock_q, _, _, _ = get_cu_seqblocks(
@@ -169,6 +176,7 @@ def minimax_sparse_prefill(
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                page_size=page_size,
             )
     else:
         o = flash_prefill_with_gqa_share_sparse(
@@ -191,6 +199,7 @@ def minimax_sparse_prefill(
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            page_size=page_size,
         )
     return idx_o, o
 
@@ -309,6 +318,7 @@ def minimax_sparse_decode(
                     q_scale=q_scale,
                     k_scale=k_scale,
                     v_scale=v_scale,
+                    page_size=page_size,
                 )
         else:
             o = flash_decode_with_gqa_share_sparse(
@@ -325,5 +335,6 @@ def minimax_sparse_decode(
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                page_size=page_size,
             )
     return idx_o, o

--- a/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa_paged.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa_paged.py
@@ -1,0 +1,372 @@
+"""Paged slot resolution in the step-3 sparse kernels vs the per-token gather.
+
+``flash_{prefill,decode}_with_gqa_share_sparse`` take a ``page_size``. When it
+and the sparse block size divide one another, a selected block covers whole
+page-aligned runs of consecutive slots, so the kernel resolves it with one
+``req_to_token`` lookup per run instead of a ``block_size``-entry gather. The
+math is untouched, so the two paths must agree element for element -- and they
+share one autotune cache entry (``page_size`` reaches the kernel as a constexpr,
+which is not part of the autotune key), so there is no config race to make the
+comparison approximate.
+
+Every fallback condition is covered alongside the fast path: production sends
+whatever ``--page-size`` the pool was built with straight through here, and the
+kernel decides on its own which way to resolve.
+"""
+
+import argparse
+
+import pytest
+import torch
+from triton.testing import do_bench
+
+from sglang.kernels.ops.attention.minimax_sparse.common.utils import get_cu_seqblocks
+from sglang.kernels.ops.attention.minimax_sparse.decode import topk_sparse as decode_mod
+from sglang.kernels.ops.attention.minimax_sparse.decode.topk_sparse import (
+    flash_decode_with_gqa_share_sparse,
+)
+from sglang.kernels.ops.attention.minimax_sparse.prefill import (
+    topk_sparse as prefill_mod,
+)
+from sglang.kernels.ops.attention.minimax_sparse.prefill.topk_sparse import (
+    flash_prefill_with_gqa_share_sparse,
+)
+
+DEVICE = "cuda"
+NUM_Q_HEADS = 16
+NUM_KV_HEADS = 1
+HEAD_DIM = 128
+DTYPE = torch.bfloat16
+CONTEXT_LEN = 4096
+
+# page_size -> does the fast path engage at block_size 128?
+PAGE_CASES = [
+    pytest.param(128, True, id="page128_eq_block"),
+    pytest.param(256, True, id="page256_gt_block"),
+    pytest.param(64, True, id="page64_two_runs"),
+    pytest.param(16, True, id="page16_min_span"),
+    pytest.param(8, False, id="page8_below_min_span"),
+    pytest.param(48, False, id="page48_indivisible"),
+    pytest.param(1, False, id="page1_per_token_gather"),
+]
+
+
+def build_page_table(batch_size, context_len, page_size, device):
+    """Tokens contiguous within a page, pages scattered across the pool.
+
+    This is how sglang's paged allocator lays a request out, and it is what the
+    fast path relies on: consecutive positions inside one page are consecutive
+    slots, while nothing is guaranteed across pages.
+    """
+    pages_per_req = (context_len + page_size - 1) // page_size
+    total_pages = batch_size * pages_per_req
+    max_slots = total_pages * page_size
+    perm = torch.randperm(total_pages, device=device)
+    within = torch.arange(context_len, device=device) % page_size
+    page_of_tok = torch.arange(context_len, device=device) // page_size
+    phys_page = perm.view(batch_size, pages_per_req)[:, page_of_tok]
+    return (phys_page * page_size + within).to(torch.int32), max_slots
+
+
+def _randn(*shape, generator):
+    return torch.randn(*shape, dtype=DTYPE, device=DEVICE, generator=generator)
+
+
+def _topk_idx(rows, num_blocks, topk, generator):
+    u = torch.rand(NUM_KV_HEADS, rows, topk, device=DEVICE, generator=generator)
+    return (u * num_blocks).to(torch.int32).clamp_(max=num_blocks - 1)
+
+
+def _causal_topk_idx(abs_pos, topk, block_size, generator):
+    """Selections a query may legally attend to: its own block or an earlier one.
+
+    A row whose every selection lay in the future would softmax over an all-masked
+    row and produce NaN, which is never ``torch.equal`` to itself and would mask a
+    real divergence.
+    """
+    rows = abs_pos.numel()
+    u = torch.rand(NUM_KV_HEADS, rows, topk, device=DEVICE, generator=generator)
+    highest = ((abs_pos + block_size) // block_size).to(torch.float32)
+    return (u * highest.view(1, rows, 1)).to(torch.int32)
+
+
+def build_decode_inputs(
+    batch_size, page_size, block_size, topk, generator, context_len=CONTEXT_LEN
+):
+    req_to_token, max_slots = build_page_table(
+        batch_size, context_len, page_size, DEVICE
+    )
+    num_blocks = (context_len + block_size - 1) // block_size
+    return dict(
+        q=_randn(batch_size, NUM_Q_HEADS, HEAD_DIM, generator=generator),
+        sink=None,
+        k_cache=_randn(max_slots, NUM_KV_HEADS, HEAD_DIM, generator=generator),
+        v_cache=_randn(max_slots, NUM_KV_HEADS, HEAD_DIM, generator=generator),
+        req_to_token=req_to_token,
+        seq_lens=torch.full(
+            (batch_size,), context_len, dtype=torch.int32, device=DEVICE
+        ),
+        slot_ids=torch.arange(batch_size, dtype=torch.int64, device=DEVICE),
+        block_size=block_size,
+        topk_idx=_topk_idx(batch_size, num_blocks, topk, generator),
+    )
+
+
+def build_prefill_inputs(
+    batch_size,
+    page_size,
+    block_size,
+    topk,
+    chunk_len,
+    generator,
+    context_len=CONTEXT_LEN,
+):
+    req_to_token, max_slots = build_page_table(
+        batch_size, context_len, page_size, DEVICE
+    )
+    cu_seqlens = torch.arange(
+        0, (batch_size + 1) * chunk_len, chunk_len, dtype=torch.int32, device=DEVICE
+    )
+    cu_seqblocks_q, max_seqblock_q, _, _, _, _ = get_cu_seqblocks(
+        cu_seqlens, chunk_len, 1, block_size
+    )
+    # block_size_q is 1, so one row per query token: the chunk sits at the end of
+    # the context, after a prefix of CONTEXT_LEN - chunk_len tokens.
+    abs_pos = (torch.arange(chunk_len, device=DEVICE) + context_len - chunk_len).repeat(
+        batch_size
+    )
+    assert abs_pos.numel() == int(cu_seqblocks_q[-1].item())
+    return dict(
+        q=_randn(batch_size * chunk_len, NUM_Q_HEADS, HEAD_DIM, generator=generator),
+        k_cache=_randn(max_slots, NUM_KV_HEADS, HEAD_DIM, generator=generator),
+        v_cache=_randn(max_slots, NUM_KV_HEADS, HEAD_DIM, generator=generator),
+        sink=None,
+        req_to_token=req_to_token,
+        slot_ids=torch.arange(batch_size, dtype=torch.int64, device=DEVICE),
+        topk_idx=_causal_topk_idx(abs_pos, topk, block_size, generator),
+        block_size_q=1,
+        block_size_k=block_size,
+        cu_seqlens=cu_seqlens,
+        seq_lens=torch.full(
+            (batch_size,), context_len, dtype=torch.int32, device=DEVICE
+        ),
+        prefix_lens=torch.full(
+            (batch_size,), context_len - chunk_len, dtype=torch.int32, device=DEVICE
+        ),
+        max_seqlen_q=chunk_len,
+        cu_seqblocks_q=cu_seqblocks_q,
+        max_seqblock_q=max_seqblock_q,
+    )
+
+
+def _assert_equal(o_gather, o_paged, what, page_size):
+    diff = (o_gather.float() - o_paged.float()).abs()
+    assert torch.equal(o_gather, o_paged), (
+        f"paged {what} diverged at page_size={page_size}: "
+        f"{int((diff > 0).sum())} of {diff.numel()} elements, max {diff.max().item()}"
+    )
+
+
+@pytest.mark.parametrize("page_size,fast_path", PAGE_CASES)
+@pytest.mark.parametrize("batch_size", [1, 4, 32])
+def test_decode_paged_is_bit_identical(page_size, fast_path, batch_size):
+    gen = torch.Generator(device=DEVICE).manual_seed(0)
+    kwargs = build_decode_inputs(
+        batch_size, page_size=page_size, block_size=128, topk=16, generator=gen
+    )
+    o_gather = flash_decode_with_gqa_share_sparse(**kwargs, page_size=1)
+    o_paged = flash_decode_with_gqa_share_sparse(**kwargs, page_size=page_size)
+    _assert_equal(o_gather, o_paged, "decode", page_size)
+
+
+@pytest.mark.parametrize("page_size,fast_path", PAGE_CASES)
+@pytest.mark.parametrize("batch_size", [1, 2])
+def test_prefill_paged_is_bit_identical(page_size, fast_path, batch_size):
+    gen = torch.Generator(device=DEVICE).manual_seed(0)
+    kwargs = build_prefill_inputs(
+        batch_size,
+        page_size=page_size,
+        block_size=128,
+        topk=16,
+        chunk_len=512,
+        generator=gen,
+    )
+    o_gather = flash_prefill_with_gqa_share_sparse(**kwargs, page_size=1)
+    o_paged = flash_prefill_with_gqa_share_sparse(**kwargs, page_size=page_size)
+    _assert_equal(o_gather, o_paged, "prefill", page_size)
+
+
+@pytest.mark.parametrize("block_size", [16, 32, 64, 128])
+def test_decode_paged_across_block_sizes(block_size):
+    """page_size 128 held fixed while block_size varies.
+
+    Every one of these divides 128, so all take the fast path -- block == page
+    resolves in one lookup, block < page in one lookup per run.
+    """
+    gen = torch.Generator(device=DEVICE).manual_seed(0)
+    kwargs = build_decode_inputs(
+        2, page_size=128, block_size=block_size, topk=16, generator=gen
+    )
+    o_gather = flash_decode_with_gqa_share_sparse(**kwargs, page_size=1)
+    o_paged = flash_decode_with_gqa_share_sparse(**kwargs, page_size=128)
+    _assert_equal(o_gather, o_paged, "decode", 128)
+
+
+def test_min_page_span_agrees_across_phases():
+    """Prefill and decode must stop taking the fast path at the same width."""
+    assert decode_mod.MIN_PAGE_SPAN == prefill_mod.MIN_PAGE_SPAN
+
+
+# ===== Benchmark =====
+#
+# Run with ``python test_sparse_gqa_paged.py --bench``: the same kernel call on a
+# page_size 1 pool (per-token gather) and on a page_size 128 pool (fast path),
+# each pool built the way the allocator would build it.
+#
+# The gain is the lookup elimination, not KV locality -- measured on H200, a
+# page 128 layout forced through the gather path landed within noise of page 1.
+#
+# Decode is timed as a cuda graph replay, which is both how production runs it
+# and the only way the number means anything: an eager launch costs ~85us on
+# H200 (host-side, it moves with machine load) and buries the kernel under
+# dispatch. Prefill runs eager, as it does in production.
+
+BENCH_PAGE_SIZE = 128
+BENCH_BLOCK_SIZE = 128
+# Long enough that a topk still selects distinct blocks: a topk past
+# context_len / block_size would clamp into repeats and read a cache-warm block
+# over and over, which flatters both paths.
+BENCH_CONTEXT_LEN = 65536
+# topk counts BLOCKS, not tokens -- each selects BENCH_BLOCK_SIZE tokens. Past
+# 32 blocks (4096 tokens) the attention is not sparse enough to be worth
+# serving, so the table stops there.
+BENCH_TOPKS = (16, 32)
+
+
+def _bench_eager_ms(fn):
+    # First call resolves the autotune config; keep it out of the timed region.
+    fn()
+    torch.cuda.synchronize()
+    return do_bench(fn, warmup=25, rep=100, return_mode="median")
+
+
+def _bench_graph_ms(fn):
+    # Autotune and the TMA descriptor allocation have to settle on a side stream
+    # before capture; capturing them would bake a tuning launch into the graph.
+    warmup = torch.cuda.Stream()
+    warmup.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(warmup):
+        for _ in range(5):
+            fn()
+    torch.cuda.current_stream().wait_stream(warmup)
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fn()
+    torch.cuda.synchronize()
+    ms = do_bench(graph.replay, warmup=25, rep=100, return_mode="median")
+    del graph
+    return ms
+
+
+def _bench_variants(kernel, build_inputs, bench_ms):
+    """Latency at page_size 1 and at BENCH_PAGE_SIZE.
+
+    One pool is built, timed and freed before the next -- at the largest batch
+    the two do not fit side by side. Each build reseeds, so the two variants see
+    identical q/k/v/topk_idx and differ only in the slot layout.
+    """
+    times = []
+    for page_size in (1, BENCH_PAGE_SIZE):
+        gen = torch.Generator(device=DEVICE).manual_seed(0)
+        kwargs = build_inputs(page_size=page_size, generator=gen)
+        times.append(
+            bench_ms(lambda: kernel(**kwargs, page_size=page_size))  # noqa: F821
+        )
+        del kwargs
+        torch.cuda.empty_cache()
+    return tuple(times)
+
+
+def _print_header(what, how, label_width):
+    print(
+        f"\n{what} [{how}] (context_len={BENCH_CONTEXT_LEN}, "
+        f"block_size={BENCH_BLOCK_SIZE}, page_size={BENCH_PAGE_SIZE})"
+    )
+    print(
+        f"{'topk counts BLOCKS of ' + str(BENCH_BLOCK_SIZE) + ' tokens; ':<{label_width}}"
+        "kv tok = tokens attended per query row"
+    )
+    print(
+        f"{'':<{label_width}}  {'kv tok':>7}  {'ctx %':>6}  {'page1':>10}"
+        f"  {'page128':>10}  {'speedup':>9}"
+    )
+
+
+def _print_row(label, topk, times, label_width):
+    t_page1, t_paged = times
+    kv_tokens = topk * BENCH_BLOCK_SIZE
+    print(
+        f"{label:<{label_width}}  {kv_tokens:>7}  "
+        f"{100 * kv_tokens / BENCH_CONTEXT_LEN:>5.1f}%  {t_page1 * 1e3:>9.1f}u"
+        f"  {t_paged * 1e3:>9.1f}u  {t_page1 / t_paged:>8.2f}x"
+    )
+
+
+def bench_decode():
+    label_width = 32
+    _print_header("decode", "cuda graph replay", label_width)
+    for batch_size in (1, 8, 32, 64, 128):
+        for topk in BENCH_TOPKS:
+            times = _bench_variants(
+                flash_decode_with_gqa_share_sparse,
+                lambda page_size, generator, bs=batch_size, tk=topk: build_decode_inputs(
+                    bs,
+                    page_size=page_size,
+                    block_size=BENCH_BLOCK_SIZE,
+                    topk=tk,
+                    generator=generator,
+                    context_len=BENCH_CONTEXT_LEN,
+                ),
+                _bench_graph_ms,
+            )
+            _print_row(f"bs={batch_size:<4} topk={topk:<4}", topk, times, label_width)
+
+
+def bench_prefill():
+    label_width = 32
+    _print_header("prefill", "eager", label_width)
+    for batch_size in (1, 2):
+        for chunk_len in (512, 2048):
+            for topk in BENCH_TOPKS:
+                times = _bench_variants(
+                    flash_prefill_with_gqa_share_sparse,
+                    lambda page_size, generator, bs=batch_size, cl=chunk_len, tk=topk: build_prefill_inputs(
+                        bs,
+                        page_size=page_size,
+                        block_size=BENCH_BLOCK_SIZE,
+                        topk=tk,
+                        chunk_len=cl,
+                        generator=generator,
+                        context_len=BENCH_CONTEXT_LEN,
+                    ),
+                    _bench_eager_ms,
+                )
+                _print_row(
+                    f"bs={batch_size:<4} chunk={chunk_len:<5} topk={topk:<4}",
+                    topk,
+                    times,
+                    label_width,
+                )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--bench", action="store_true", help="benchmark instead of test"
+    )
+    args, rest = parser.parse_known_args()
+    if not args.bench:
+        raise SystemExit(pytest.main([__file__, "-v", *rest]))
+    print(torch.cuda.get_device_name(0))
+    bench_decode()
+    bench_prefill()


### PR DESCRIPTION
## Motivation

<!-- Describe the purpose and goals of this pull request. -->
In the Triton sparse-attention path, every selected KV block was resolved with a full per-token req_to_token gather plus an integer modulo, even though the KV pool already hands out contiguous slots per page — so the block's addresses could be derived from one lookup per page instead.

## Modifications

<!-- Detail the changes made in this pull request. -->


- Paged slot resolution in the Triton sparse kernels (decode/topk_sparse.py, prefill/topk_sparse.py): adds PAGED_KV / PAGE_SPAN / PAGE_RUNS constexprs. When page and block size divide one another, a selected block covers whole page-aligned runs of consecutive slots, so the kernel loads one base slot per run and adds an offset range, replacing the BLOCK_SIZE_N-entry gather.
 
- Falls back safely: if the sizes don't divide, max_slots % page_size != 0, or the run is shorter than MIN_PAGE_SPAN = 16 (where the reshape costs more than the gather), it keeps the old gather. The two paths are bit-identical, so page_size is always safe to pass.
 
- Drops the expensive integer modulo: (slots + max_slots) % max_slots becomes two tl.where clamps in all four kernels. GPUs have no integer div/mod, so that modulo expanded into a reciprocal sequence on every lane.

- Defaults page_size=128 for MiniMax-M3 whenever the Triton path is used (arg_groups/overrides.py): now added for ROCm, SM90 (fa3 + explicit triton), pre-SM100 CUDA, and pre-Hopper with explicit --attention-backend triton — matching the KV page to the sparse block size so the optimization actually kicks in.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

I have validated the output remains consistent in page size 1 and 128.

```
python python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa_paged.py
```

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

benchmark script:

```
python python/sglang/srt/layers/attention/minimax_sparse_ops/tests/test_sparse_gqa_paged.py --bench
```

- Prefill (eager, as in production)

| config | kv tok | ctx % | page1 | page128 | speedup |
|---|---:|---:|---:|---:|---:|
| bs=1 chunk=512 topk=16 | 2048 | 3.1% | 105.0us | 92.4us | 1.14x |
| bs=1 chunk=512 topk=32 | 4096 | 6.2% | 192.0us | 167.6us | 1.15x |
| bs=1 chunk=2048 topk=16 | 2048 | 3.1% | 374.6us | 323.8us | 1.16x |
| bs=1 chunk=2048 topk=32 | 4096 | 6.2% | 720.9us | 619.1us | 1.16x |
| bs=2 chunk=512 topk=16 | 2048 | 3.1% | 198.8us | 174.5us | 1.14x |
| bs=2 chunk=512 topk=32 | 4096 | 6.2% | 374.0us | 324.4us | 1.15x |
| bs=2 chunk=2048 topk=16 | 2048 | 3.1% | 742.0us | 640.3us | 1.16x |
| bs=2 chunk=2048 topk=32 | 4096 | 6.2% | 1441.0us | 1242.2us | 1.16x |

- Decode (timed as CUDA graph replay)

| config | kv tok | ctx % | page1 | page128 | speedup |
|---|---:|---:|---:|---:|---:|
| bs=1 topk=16 | 2048 | 3.1% | 13.2us | 12.8us | 1.03x |
| bs=1 topk=32 | 4096 | 6.2% | 14.0us | 13.3us | 1.05x |
| bs=8 topk=16 | 2048 | 3.1% | 15.5us | 14.8us | 1.05x |
| bs=8 topk=32 | 4096 | 6.2% | 19.3us | 18.4us | 1.05x |
| bs=32 topk=16 | 2048 | 3.1% | 26.0us | 25.9us | 1.01x |
| bs=32 topk=32 | 4096 | 6.2% | 37.0us | 36.1us | 1.02x |
| bs=64 topk=16 | 2048 | 3.1% | 37.3us | 36.6us | 1.02x |
| bs=64 topk=32 | 4096 | 6.2% | 55.2us | 54.0us | 1.02x |
| bs=128 topk=16 | 2048 | 3.1% | 53.9us | 52.9us | 1.02x |
| bs=128 topk=32 | 4096 | 6.2% | 86.0us | 83.7us | 1.03x |


## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32822047692](https://github.com/sgl-project/sglang/actions/runs/32822047692)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32822047348](https://github.com/sgl-project/sglang/actions/runs/32822047348)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32822048322](https://github.com/sgl-project/sglang/actions/runs/32822048322)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->