### PR TITLE
fix(gdn): normalize tracked conv state dtype

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -37,6 +37,20 @@ if is_cuda() or is_hip() or is_xpu():
 
 MAX_FUSED_QKV_SPLIT_DIM = 8192
 
+
+def _store_tracked_conv_states(
+    conv_states: torch.Tensor,
+    state_indices: torch.Tensor,
+    tracked_mixed_qkv: torch.Tensor,
+) -> None:
+    """Store a GDN conv snapshot in the cache's configured dtype.
+
+    The conv cache may intentionally use a dtype different from the runtime
+    activation dtype (for example, through SGLANG_MAMBA_CONV_DTYPE). Indexed
+    assignment does not perform this conversion, so normalize at this boundary.
+    """
+    conv_states[state_indices] = tracked_mixed_qkv.to(dtype=conv_states.dtype)
+
 if is_cuda():
     from sglang.srt.layers.attention.mamba.causal_conv1d import (
         causal_conv1d_fn as causal_conv1d_fn_cuda,
@@ -611,8 +625,10 @@ class GDNAttnBackend(MambaAttnBackendBase):
                 mixed_qkv_to_track = mixed_qkv[
                     :, forward_metadata.track_conv_indices
                 ].transpose(0, 1)
-                conv_states[forward_metadata.conv_states_mask_indices] = (
-                    mixed_qkv_to_track
+                _store_tracked_conv_states(
+                    conv_states,
+                    forward_metadata.conv_states_mask_indices,
+                    mixed_qkv_to_track,
                 )
 
             mixed_qkv = causal_conv1d_fn(

--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -51,6 +51,7 @@ def _store_tracked_conv_states(
     """
     conv_states[state_indices] = tracked_mixed_qkv.to(dtype=conv_states.dtype)
 
+
 if is_cuda():
     from sglang.srt.layers.attention.mamba.causal_conv1d import (
         causal_conv1d_fn as causal_conv1d_fn_cuda,

--- a/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
+++ b/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
@@ -78,6 +78,28 @@ def make_runner(
     )
 
 
+class TestGdnTrackedConvStateDtype(CustomTestCase):
+    def test_casts_snapshot_to_conv_cache_dtype(self):
+        conv_states = torch.zeros((2, 3, 4), dtype=torch.bfloat16)
+        tracked = torch.full((1, 3, 4), 1.5, dtype=torch.float16)
+
+        gdn_backend._store_tracked_conv_states(
+            conv_states, torch.tensor([1]), tracked
+        )
+
+        self.assertEqual(conv_states.dtype, torch.bfloat16)
+        torch.testing.assert_close(conv_states[1], tracked[0].to(torch.bfloat16))
+
+    def test_same_dtype_write_remains_exact(self):
+        conv_states = torch.zeros((1, 2, 3), dtype=torch.float16)
+        tracked = torch.arange(6, dtype=torch.float16).reshape(1, 2, 3)
+
+        gdn_backend._store_tracked_conv_states(
+            conv_states, torch.tensor([0]), tracked
+        )
+
+        torch.testing.assert_close(conv_states[0], tracked[0], rtol=0, atol=0)
+
 class TestFlashInferGDNPrefillBackendPolicy(CustomTestCase):
     def apply_policy(
         self,

--- a/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
+++ b/test/registered/unit/layers/attention/test_gdn_prefill_backend_policy.py
@@ -83,9 +83,7 @@ class TestGdnTrackedConvStateDtype(CustomTestCase):
         conv_states = torch.zeros((2, 3, 4), dtype=torch.bfloat16)
         tracked = torch.full((1, 3, 4), 1.5, dtype=torch.float16)
 
-        gdn_backend._store_tracked_conv_states(
-            conv_states, torch.tensor([1]), tracked
-        )
+        gdn_backend._store_tracked_conv_states(conv_states, torch.tensor([1]), tracked)
 
         self.assertEqual(conv_states.dtype, torch.bfloat16)
         torch.testing.assert_close(conv_states[1], tracked[0].to(torch.bfloat16))
@@ -94,11 +92,10 @@ class TestGdnTrackedConvStateDtype(CustomTestCase):
         conv_states = torch.zeros((1, 2, 3), dtype=torch.float16)
         tracked = torch.arange(6, dtype=torch.float16).reshape(1, 2, 3)
 
-        gdn_backend._store_tracked_conv_states(
-            conv_states, torch.tensor([0]), tracked
-        )
+        gdn_backend._store_tracked_conv_states(conv_states, torch.tensor([0]), tracked)
 
         torch.testing.assert_close(conv_states[0], tracked[0], rtol=0, atol=0)
+
 
 class TestFlashInferGDNPrefillBackendPolicy(CustomTestCase):
     def apply_policy(


### PR DESCRIPTION
## Summary
- normalize GDN tracked conv snapshots to the allocated conv-cache dtype before indexed assignment
- preserve `SGLANG_MAMBA_CONV_DTYPE` as the explicit cache-layout override
- avoid first-prefill dtype failures when activation dtype differs from the configured conv-state dtype

## Rationale
The cache dtype is intentionally configurable independently of activation and temporal-state dtypes. Indexed assignment does not perform the required conversion, so the snapshot boundary must normalize the tracked activation instead of changing global Mamba dtype policy.

## Tests
- CPU regression: FP16 tracked activations write safely into a BF16 conv cache
- CPU regression: same-dtype writes remain exact
- branch helper extracted and executed in local preflight for both paths

Closes #31719

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34213965264](https://github.com/sgl-project/sglang/actions/runs/34213965264)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34213964981](https://github.com/sgl-project/sglang/actions/runs/34213964981)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34213965348](https://github.com/sgl-project/sglang/actions/runs/34213965348)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->