### PR TITLE
[AMD][CI] Fix shared-KV verify tests for multi-head GQA

### DIFF
--- a/test/registered/attention/test_verify_shared_kv.py
+++ b/test/registered/attention/test_verify_shared_kv.py
@@ -29,6 +29,7 @@ def _build_inputs(
     h_q,
     head_dim,
     v_head_dim,
+    h_kv=1,
     cache_dtype=torch.bfloat16,
 ):
     device = "cuda"
@@ -43,10 +44,10 @@ def _build_inputs(
         return torch.randn(*shape, dtype=dtype, device=device, generator=generator)
 
     q = randn(num_extend_tokens, h_q, head_dim)
-    k = randn(num_extend_tokens, 1, head_dim)
-    v = randn(num_extend_tokens, 1, v_head_dim)
-    k_buffer = randn(total_prefix, 1, head_dim).to(cache_dtype)
-    v_buffer = randn(total_prefix, 1, v_head_dim).to(cache_dtype)
+    k = randn(num_extend_tokens, h_kv, head_dim)
+    v = randn(num_extend_tokens, h_kv, v_head_dim)
+    k_buffer = randn(total_prefix, h_kv, head_dim).to(cache_dtype)
+    v_buffer = randn(total_prefix, h_kv, v_head_dim).to(cache_dtype)
     qo_indptr = torch.arange(
         0, num_extend_tokens + 1, l_ext, dtype=torch.int32, device=device
     )
@@ -63,6 +64,8 @@ class TestVerifySharedKV(CustomTestCase):
         head_dim,
         v_head_dim,
         h_q=4,
+        h_kv=1,
+        is_causal=True,
         cache_dtype=torch.bfloat16,
         k_scale=1.0,
         v_scale=1.0,
@@ -74,6 +77,7 @@ class TestVerifySharedKV(CustomTestCase):
             prefix_lens=[512, 2048],
             l_ext=l_ext,
             h_q=h_q,
+            h_kv=h_kv,
             head_dim=head_dim,
             v_head_dim=v_head_dim,
             cache_dtype=cache_dtype,
@@ -95,7 +99,7 @@ class TestVerifySharedKV(CustomTestCase):
             kv_indptr,
             kv_indices,
             None,
-            True,
+            is_causal,
             None,
             l_ext,
             k_scale,
@@ -113,7 +117,7 @@ class TestVerifySharedKV(CustomTestCase):
             kv_indptr,
             kv_indices,
             None,
-            True,
+            is_causal,
             None,
             l_ext,
             k_scale,
@@ -158,18 +162,25 @@ class TestVerifySharedKV(CustomTestCase):
     def test_kimi_k3_absorbed_mla_shape(self):
         self._run_parity(head_dim=576, v_head_dim=512)
 
-    def test_rejects_multiple_local_kv_heads(self):
-        inputs = list(
-            _build_inputs(
-                prefix_lens=[512],
-                l_ext=4,
-                h_q=4,
-                head_dim=256,
-                v_head_dim=256,
-            )
+    def test_kimi_k3_dspark_gqa_shape(self):
+        self._run_parity(
+            head_dim=64,
+            v_head_dim=64,
+            h_q=8,
+            h_kv=2,
+            is_causal=False,
+            l_ext=7,
         )
-        for index in (1, 2, 3, 4):
-            inputs[index] = inputs[index].expand(-1, 2, -1).contiguous()
+
+    def test_rejects_non_power_of_two_kv_group(self):
+        inputs = _build_inputs(
+            prefix_lens=[512],
+            l_ext=4,
+            h_q=6,
+            h_kv=2,
+            head_dim=256,
+            v_head_dim=256,
+        )
         q, k, v, k_buffer, v_buffer, qo_indptr, kv_indptr, kv_indices = inputs
         output = torch.empty_like(q)
         self.assertFalse(


### PR DESCRIPTION
## Motivation

`TestVerifySharedKV.test_rejects_multiple_local_kv_heads` has kept `stage-b-test-1-gpu-small-amd-mi35x` red since #35499 landed ([failing ROCm 7.2.4 job](https://github.com/sgl-project/sglang/actions/runs/32725797196/job/97426719260)).

The test expects `h_q=4, h_kv=2` to be rejected. However, #35499 added support for multiple local KV heads when `h_q / h_kv` is a power of two. This shape has a group size of 2, so `verify_shared_kv_fwd` correctly returns `True` and the assertion is stale.

## Modifications

- Generalize the shared-KV input builder and parity helper to cover multiple KV heads and causal/non-causal attention.
- Add kernel-vs-baseline parity coverage for the Kimi-K3 DSpark GQA shape (`h_q=8`, `h_kv=2`, `head_dim=64`, `l_ext=7`, non-causal).
- Preserve rejection coverage with an actually unsupported non-power-of-two KV group (`h_q=6`, `h_kv=2`, group size 3).

This is a test-only change; no kernel or dispatch code is modified.

## Accuracy Tests

Targeted [ROCm 7.2.4 MI35x CI](https://github.com/sgl-project/sglang/actions/runs/32827106519) passed.
<img width="1887" height="1431" alt="image" src="https://github.com/user-attachments/assets/a5533914-1173-4734-9d41-28848b7ce8a0" />

## Speed Tests and Profiling

Not applicable. This change does not affect inference performance.

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation update is not applicable for this test-only change.
- [x] Accuracy and speed benchmarks are not applicable for this test-only change.
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32827096139](https://github.com/sgl-project/sglang/actions/runs/32827096139)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32827095878](https://github.com/sgl-project/sglang/actions/runs/32827095878)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32827096138](https://github.com/sgl-project/sglang/actions/runs/32827096138)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->