### PR TITLE
[Kimi-K3] Enable fused KDA decode for TP4

### DIFF
--- a/python/sglang/kernels/jit/csrc/attention/kda_fused_decode.cuh
+++ b/python/sglang/kernels/jit/csrc/attention/kda_fused_decode.cuh
@@ -388,7 +388,8 @@ template <
     int kTmaStages = kNumChunks,
     bool kUsePDL = false>
 // Shapes below use K3's per-TP-rank sizing (linear_attn_config: num_heads=96 over
-// TP={8,16,32} -> H=HV={12,6,3} local heads; head_dim=128 -> kDimK=kDimV=128; kSeg = H*128;
+// TP={4,8,16,32} -> H=HV={24,12,6,3} local heads; head_dim=128 ->
+// kDimK=kDimV=128; kSeg = H*128;
 // short_conv_kernel_size=4 -> kKernelWidth=4, kConvStateWidth=3). B is the live
 // (post-padding, under kUseStaticDecodeLayout) decode batch size; slots is the
 // recurrent-state / conv-cache pool capacity, addressed by ssm_state_indices, not B.
@@ -881,7 +882,7 @@ __global__ __launch_bounds__(kThreads, 2) void kda_decode_fusion_many_heads_kern
 }
 
 // K3 decode configuration of the many-heads kernel: onorm fused, static
-// H = HV in {3, 6, 12} layout with a (B, HV) grid, onorm params preloaded, next state
+// H = HV in {3, 6, 12, 24} layout with a (B, HV) grid, onorm params preloaded, next state
 // chunk prefetched, active onorm reduction, conv cache updated in place,
 // beta sigmoid in-kernel. Both forget-gate variants are compiled (softplus
 // and lower-bounded sigmoid) and selected at launch from the model config.
@@ -948,7 +949,8 @@ struct KdaFusedDecodeKernel {
     using namespace host;
 
     const int64_t kH = A_log.shape()[0];
-    RuntimeCheck(kH == 3 || kH == 6 || kH == 12, "KDA fused decode supports local head counts 3, 6, or 12, got ", kH);
+    RuntimeCheck(kH == 3 || kH == 6 || kH == 12 || kH == 24,
+                 "KDA fused decode supports local head counts 3, 6, 12, or 24, got ", kH);
     const int64_t kSeg = kH * 128;  // q, k and v segment width
 
     auto B_ = SymbolicSize{"batch"};
@@ -1014,7 +1016,8 @@ struct KdaFusedDecodeKernel {
     }
     auto kernel = kH == 3 ? select_kda_fused_decode_k3_kernel<3, kUsePDL>(use_lower_bound, tma_stages)
                           : (kH == 6 ? select_kda_fused_decode_k3_kernel<6, kUsePDL>(use_lower_bound, tma_stages)
-                                     : select_kda_fused_decode_k3_kernel<12, kUsePDL>(use_lower_bound, tma_stages));
+                                     : (kH == 12 ? select_kda_fused_decode_k3_kernel<12, kUsePDL>(use_lower_bound, tma_stages)
+                                                 : select_kda_fused_decode_k3_kernel<24, kUsePDL>(use_lower_bound, tma_stages)));
     const int smem_stages = tma_stages == 0 ? 2 : tma_stages;
     const size_t smem_bytes = static_cast<size_t>(smem_stages) * kChunkV * kDimK * sizeof(float);
     host::RuntimeDeviceCheck(

--- a/python/sglang/kernels/ops/attention/kda_fused_decode.py
+++ b/python/sglang/kernels/ops/attention/kda_fused_decode.py
@@ -11,8 +11,8 @@ Kernel body vendored from the NVIDIA x Moonshot Kimi K3 optimization package
 (see csrc/attention/kda_fused_decode.cuh for provenance and the list of
 integration patches). Specialized for the K3 KDA decode regime:
 K = V = 128, kernel width 4, no lower bound, T = 1 per request.
-The JIT currently instantiates local head counts H = HV in {12, 6, 3}
-(TP8, TP16, and TP32).
+The JIT instantiates local head counts H = HV in {24, 12, 6, 3}
+(TP4, TP8, TP16, and TP32).
 
 The model must hand off the output-norm gate (attempt-and-verify stash on the
 attention layer, see kimi_k3.py), and a covered() check gates supported inputs.
@@ -35,7 +35,7 @@ from sglang.kernels.jit.utils import (
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
-_SUPPORTED_HEADS = {3, 6, 12}
+_SUPPORTED_HEADS = {3, 6, 12, 24}
 _CONV_STATE_W = 3  # kernel width 4 -> 3 cached tokens
 
 

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -1730,14 +1730,16 @@ class KimiK3DeltaAttention(nn.Module):
         w = layer.conv_weights
         if _is_npu:
             return
-        seg = 12 * 128  # compiled for H = HV = 12 heads of 128 (TP8)
+        local_heads = self.local_num_heads
+        seg = local_heads * 128
         if (
-            w is None
+            local_heads not in (12, 24)
+            or w is None
             or w.ndim != 2
             or w.shape != (3 * seg, 4)
             or w.dtype != torch.float32
             or layer.A_log is None
-            or layer.A_log.numel() != 12
+            or layer.A_log.numel() != local_heads
             or layer.A_log.dtype != torch.float32
             or layer.dt_bias is None
             or tuple(layer.dt_bias.shape) != (seg,)
@@ -1764,7 +1766,7 @@ class KimiK3DeltaAttention(nn.Module):
             wt[:, seg : 2 * seg].contiguous(),
             wt[:, 2 * seg :].contiguous(),
             conv_bias,
-            layer.A_log.detach().reshape(-1),  # view; kernel wants [12]
+            layer.A_log.detach().reshape(-1),
             self.o_norm.weight.data.float().contiguous(),
             float(self.o_norm.eps),
         )

--- a/test/registered/kernels/benchmark/attention/bench_kimi_k3_kda_fused_decode_tp4.py
+++ b/test/registered/kernels/benchmark/attention/bench_kimi_k3_kda_fused_decode_tp4.py
@@ -1,0 +1,356 @@
+"""Benchmark the full Kimi K3 KDA decode boundary at TP4/TP8 shapes.
+
+The baseline is the production unfused chain:
+
+    causal_conv1d_update -> Triton packed KDA -> sigmoid-gated RMSNorm
+
+The candidate is ``kda_fused_decode``. The benchmark records raw balanced
+samples for both eager launch and CUDA graph replay. Run each order in at
+least three fresh processes:
+
+    python bench_kimi_k3_kda_fused_decode_tp4.py --first baseline
+    python bench_kimi_k3_kda_fused_decode_tp4.py --first candidate
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+import subprocess
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+import torch
+from sglang.kernels.ops.attention.fla.fused_norm_gate import rms_norm_gated
+from sglang.kernels.ops.attention.kda_fused_decode import kda_fused_decode
+from sglang.kernels.ops.mamba.causal_conv1d_triton import causal_conv1d_update
+from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
+
+_D = 128
+_LOWER_BOUND = -5.0
+_EPS = 1e-6
+
+
+@dataclass
+class Inputs:
+    mixed_qkv: torch.Tensor
+    a: torch.Tensor
+    b: torch.Tensor
+    onorm_g: torch.Tensor
+    conv_states: torch.Tensor
+    ssm_states: torch.Tensor
+    cache_indices: torch.Tensor
+    conv_weight: torch.Tensor
+    conv_weight_t_q: torch.Tensor
+    conv_weight_t_k: torch.Tensor
+    conv_weight_t_v: torch.Tensor
+    conv_bias: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    onorm_weight: torch.Tensor
+
+
+def make_inputs(heads: int, batch: int, seed: int) -> Inputs:
+    generator = torch.Generator(device="cuda").manual_seed(seed)
+    seg = heads * _D
+    conv_dim = 3 * seg
+    slots = batch + 8
+
+    def randn(*shape, dtype=torch.bfloat16, scale=0.1):
+        return (
+            torch.randn(
+                *shape,
+                dtype=dtype,
+                device="cuda",
+                generator=generator,
+            )
+            * scale
+        )
+
+    conv_weight = randn(
+        conv_dim, 4, dtype=torch.float32, scale=0.05
+    ).contiguous()
+    conv_weight_t = conv_weight.t().contiguous()
+    return Inputs(
+        mixed_qkv=randn(batch, conv_dim).contiguous(),
+        a=randn(batch, seg).contiguous(),
+        b=randn(batch, heads).contiguous(),
+        onorm_g=randn(batch, seg).contiguous(),
+        conv_states=randn(slots, 3, conv_dim).contiguous(),
+        ssm_states=randn(
+            slots, heads, _D, _D, dtype=torch.float32, scale=0.01
+        ).contiguous(),
+        cache_indices=torch.randperm(
+            slots, device="cuda", generator=generator
+        )[:batch]
+        .to(torch.int32)
+        .contiguous(),
+        conv_weight=conv_weight,
+        conv_weight_t_q=conv_weight_t[:, :seg].contiguous(),
+        conv_weight_t_k=conv_weight_t[:, seg : 2 * seg].contiguous(),
+        conv_weight_t_v=conv_weight_t[:, 2 * seg :].contiguous(),
+        conv_bias=randn(conv_dim, dtype=torch.float32, scale=0.01).contiguous(),
+        a_log=randn(heads, dtype=torch.float32).contiguous(),
+        dt_bias=randn(seg, dtype=torch.float32).contiguous(),
+        onorm_weight=(
+            1.0 + randn(_D, dtype=torch.float32, scale=0.1)
+        ).contiguous(),
+    )
+
+
+def clone_inputs(inputs: Inputs) -> Inputs:
+    values = vars(inputs).copy()
+    values["conv_states"] = inputs.conv_states.clone()
+    values["ssm_states"] = inputs.ssm_states.clone()
+    return Inputs(**values)
+
+
+def baseline(inputs: Inputs) -> torch.Tensor:
+    heads = inputs.ssm_states.shape[-3]
+    qkv = causal_conv1d_update(
+        inputs.mixed_qkv,
+        inputs.conv_states.transpose(-1, -2),
+        inputs.conv_weight,
+        inputs.conv_bias,
+        activation="silu",
+        conv_state_indices=inputs.cache_indices,
+    )
+    out = TritonKDAKernel().packed_decode(
+        qkv,
+        inputs.a,
+        inputs.b,
+        A_log=inputs.a_log,
+        dt_bias=inputs.dt_bias,
+        scale=_D**-0.5,
+        ssm_states=inputs.ssm_states,
+        cache_indices=inputs.cache_indices,
+        num_v_heads=heads,
+        head_v_dim=_D,
+        lower_bound=_LOWER_BOUND,
+    )
+    return rms_norm_gated(
+        x=out,
+        g=inputs.onorm_g.view(1, -1, heads, _D),
+        weight=inputs.onorm_weight,
+        bias=None,
+        activation="sigmoid",
+        eps=_EPS,
+    )
+
+
+def candidate(inputs: Inputs) -> torch.Tensor:
+    return kda_fused_decode(
+        inputs.mixed_qkv,
+        inputs.a,
+        inputs.b,
+        inputs.conv_states,
+        inputs.conv_weight_t_q,
+        inputs.conv_weight_t_k,
+        inputs.conv_weight_t_v,
+        inputs.conv_bias,
+        inputs.a_log,
+        inputs.dt_bias,
+        inputs.onorm_g,
+        inputs.onorm_weight,
+        inputs.ssm_states,
+        inputs.cache_indices,
+        scale=_D**-0.5,
+        onorm_eps=_EPS,
+        lower_bound=_LOWER_BOUND,
+    )
+
+
+def correctness(source: Inputs) -> dict[str, float]:
+    baseline_inputs = clone_inputs(source)
+    candidate_inputs = clone_inputs(source)
+    baseline_out = baseline(baseline_inputs)
+    candidate_out = candidate(candidate_inputs)
+    torch.cuda.synchronize()
+    return {
+        "output_max_abs": float(
+            (baseline_out.float() - candidate_out.float()).abs().max()
+        ),
+        "state_max_abs": float(
+            (baseline_inputs.ssm_states - candidate_inputs.ssm_states).abs().max()
+        ),
+        "conv_max_abs": float(
+            (
+                baseline_inputs.conv_states.float()
+                - candidate_inputs.conv_states.float()
+            )
+            .abs()
+            .max()
+        ),
+    }
+
+
+def graph_replay(fn):
+    fn()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        fn()
+    return graph.replay
+
+
+def time_sample(fn, iterations: int) -> dict[str, float]:
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    wall_start = time.perf_counter_ns()
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    end.synchronize()
+    wall_end = time.perf_counter_ns()
+    return {
+        "gpu_us": start.elapsed_time(end) * 1000.0 / iterations,
+        "wall_us": (wall_end - wall_start) / 1000.0 / iterations,
+    }
+
+
+def benchmark_cell(
+    heads: int,
+    batch: int,
+    mode: str,
+    first: str,
+    samples: int,
+    iterations: int,
+    seed: int,
+) -> dict:
+    source = make_inputs(heads, batch, seed)
+    errors = correctness(source)
+    baseline_inputs = clone_inputs(source)
+    candidate_inputs = clone_inputs(source)
+
+    def baseline_fn():
+        return baseline(baseline_inputs)
+
+    def candidate_fn():
+        return candidate(candidate_inputs)
+
+    for _ in range(5):
+        baseline_fn()
+        candidate_fn()
+    torch.cuda.synchronize()
+
+    if mode == "graph":
+        baseline_fn = graph_replay(baseline_fn)
+        candidate_fn = graph_replay(candidate_fn)
+
+    timings = {"baseline": [], "candidate": []}
+    initial_order = (
+        ("baseline", "candidate")
+        if first == "baseline"
+        else ("candidate", "baseline")
+    )
+    functions = {"baseline": baseline_fn, "candidate": candidate_fn}
+    for sample in range(samples):
+        order = initial_order if sample % 2 == 0 else initial_order[::-1]
+        for provider in order:
+            timings[provider].append(time_sample(functions[provider], iterations))
+
+    def med(provider: str, metric: str) -> float:
+        return statistics.median(x[metric] for x in timings[provider])
+
+    baseline_gpu = med("baseline", "gpu_us")
+    candidate_gpu = med("candidate", "gpu_us")
+    result = {
+        "heads": heads,
+        "batch": batch,
+        "mode": mode,
+        "first": first,
+        "samples": samples,
+        "iterations": iterations,
+        "correctness": errors,
+        "raw": timings,
+        "median": {
+            "baseline_gpu_us": baseline_gpu,
+            "candidate_gpu_us": candidate_gpu,
+            "saved_gpu_us": baseline_gpu - candidate_gpu,
+            "saved_gpu_percent": 100.0
+            * (baseline_gpu - candidate_gpu)
+            / baseline_gpu,
+            "baseline_wall_us": med("baseline", "wall_us"),
+            "candidate_wall_us": med("candidate", "wall_us"),
+        },
+    }
+    torch.cuda.empty_cache()
+    return result
+
+
+def git_sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], text=True
+    ).strip()
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--heads", type=int, default=24, choices=(12, 24))
+    parser.add_argument("--batches", default="1,8,32,64,128")
+    parser.add_argument("--modes", default="eager,graph")
+    parser.add_argument("--first", choices=("baseline", "candidate"), required=True)
+    parser.add_argument("--samples", type=int, default=10)
+    parser.add_argument("--iterations", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=32541)
+    parser.add_argument("--output", type=Path)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if torch.cuda.get_device_capability()[0] < 10:
+        raise RuntimeError("The fused KDA decode kernel requires Blackwell")
+
+    batches = [int(value) for value in args.batches.split(",")]
+    modes = args.modes.split(",")
+    result = {
+        "metadata": {
+            "git_sha": git_sha(),
+            "torch": torch.__version__,
+            "torch_cuda": torch.version.cuda,
+            "device": torch.cuda.get_device_name(),
+            "capability": torch.cuda.get_device_capability(),
+            "command": vars(args) | {"output": str(args.output)},
+        },
+        "cells": [],
+    }
+    for mode in modes:
+        for batch in batches:
+            cell = benchmark_cell(
+                args.heads,
+                batch,
+                mode,
+                args.first,
+                args.samples,
+                args.iterations,
+                args.seed + batch,
+            )
+            result["cells"].append(cell)
+            median = cell["median"]
+            print(
+                f"H={args.heads} B={batch} {mode}: "
+                f"{median['baseline_gpu_us']:.3f} -> "
+                f"{median['candidate_gpu_us']:.3f} us, "
+                f"save {median['saved_gpu_us']:.3f} us "
+                f"({median['saved_gpu_percent']:.2f}%)",
+                flush=True,
+            )
+
+    payload = json.dumps(result, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        temporary = args.output.with_suffix(args.output.suffix + ".tmp")
+        temporary.write_text(payload + "\n")
+        temporary.replace(args.output)
+    print(payload)
+
+
+if __name__ == "__main__":
+    main()

--- a/test/registered/kernels/ops/attention/test_kimi_k3_kda_fused_decode_tp4.py
+++ b/test/registered/kernels/ops/attention/test_kimi_k3_kda_fused_decode_tp4.py
@@ -1,0 +1,322 @@
+"""Kimi K3 fused KDA decode coverage for TP8 and TP4 head shards."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+import torch
+from sglang.kernels.ops.attention.fla.fused_norm_gate import rms_norm_gated
+from sglang.kernels.ops.attention.kda_fused_decode import (
+    covered,
+    kda_fused_decode,
+)
+from sglang.kernels.ops.mamba.causal_conv1d_triton import causal_conv1d_update
+from sglang.srt.layers.attention.linear.kernels.kda_triton import TritonKDAKernel
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=90, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+_D = 128
+_LOWER_BOUND = -5.0
+_EPS = 1e-6
+
+
+@dataclass
+class Inputs:
+    mixed_qkv: torch.Tensor
+    a: torch.Tensor
+    b: torch.Tensor
+    onorm_g: torch.Tensor
+    conv_states: torch.Tensor
+    ssm_states: torch.Tensor
+    cache_indices: torch.Tensor
+    conv_weight: torch.Tensor
+    conv_weight_t_q: torch.Tensor
+    conv_weight_t_k: torch.Tensor
+    conv_weight_t_v: torch.Tensor
+    conv_bias: torch.Tensor
+    a_log: torch.Tensor
+    dt_bias: torch.Tensor
+    onorm_weight: torch.Tensor
+
+
+def _strided_zeros(shape, stride, *, dtype):
+    storage_size = 1 + sum((size - 1) * step for size, step in zip(shape, stride))
+    storage = torch.zeros(storage_size, dtype=dtype, device="cuda")
+    return torch.as_strided(storage, shape, stride)
+
+
+def _make_inputs(
+    heads: int,
+    batch: int,
+    *,
+    strided_state: bool,
+    cache_indices: torch.Tensor | None = None,
+    seed: int = 32541,
+) -> Inputs:
+    generator = torch.Generator(device="cuda").manual_seed(seed + heads + batch)
+    seg = heads * _D
+    conv_dim = 3 * seg
+    slots = batch + 5
+
+    def randn(*shape, dtype=torch.bfloat16, scale=0.1):
+        return (
+            torch.randn(
+                *shape,
+                dtype=dtype,
+                device="cuda",
+                generator=generator,
+            )
+            * scale
+        )
+
+    if strided_state:
+        conv_stride = (3 * conv_dim + 256, conv_dim, 1)
+        conv_states = _strided_zeros(
+            (slots, 3, conv_dim), conv_stride, dtype=torch.bfloat16
+        )
+        ssm_stride = (heads * _D * _D + 256, _D * _D, _D, 1)
+        ssm_states = _strided_zeros(
+            (slots, heads, _D, _D), ssm_stride, dtype=torch.float32
+        )
+        conv_states.copy_(randn(slots, 3, conv_dim))
+        ssm_states.copy_(
+            randn(slots, heads, _D, _D, dtype=torch.float32, scale=0.01)
+        )
+    else:
+        conv_states = randn(slots, 3, conv_dim).contiguous()
+        ssm_states = randn(
+            slots, heads, _D, _D, dtype=torch.float32, scale=0.01
+        ).contiguous()
+
+    if cache_indices is None:
+        cache_indices = torch.randperm(
+            slots, device="cuda", generator=generator, dtype=torch.int64
+        )[:batch].to(torch.int32)
+
+    conv_weight = randn(
+        conv_dim, 4, dtype=torch.float32, scale=0.05
+    ).contiguous()
+    conv_weight_t = conv_weight.t().contiguous()
+    return Inputs(
+        mixed_qkv=randn(batch, conv_dim).contiguous(),
+        a=randn(batch, seg).contiguous(),
+        b=randn(batch, heads).contiguous(),
+        onorm_g=randn(batch, seg).contiguous(),
+        conv_states=conv_states,
+        ssm_states=ssm_states,
+        cache_indices=cache_indices.contiguous(),
+        conv_weight=conv_weight,
+        conv_weight_t_q=conv_weight_t[:, :seg].contiguous(),
+        conv_weight_t_k=conv_weight_t[:, seg : 2 * seg].contiguous(),
+        conv_weight_t_v=conv_weight_t[:, 2 * seg :].contiguous(),
+        conv_bias=randn(conv_dim, dtype=torch.float32, scale=0.01).contiguous(),
+        a_log=randn(heads, dtype=torch.float32).contiguous(),
+        dt_bias=randn(seg, dtype=torch.float32).contiguous(),
+        onorm_weight=(
+            1.0 + randn(_D, dtype=torch.float32, scale=0.1)
+        ).contiguous(),
+    )
+
+
+def _clone_state_view(tensor: torch.Tensor) -> torch.Tensor:
+    clone = torch.empty_strided(
+        tensor.shape, tensor.stride(), dtype=tensor.dtype, device=tensor.device
+    )
+    clone.copy_(tensor)
+    return clone
+
+
+def _clone_inputs(inputs: Inputs) -> Inputs:
+    values = vars(inputs).copy()
+    values["conv_states"] = _clone_state_view(inputs.conv_states)
+    values["ssm_states"] = _clone_state_view(inputs.ssm_states)
+    return Inputs(**values)
+
+
+def _reference(inputs: Inputs) -> torch.Tensor:
+    heads = inputs.ssm_states.shape[-3]
+    qkv = causal_conv1d_update(
+        inputs.mixed_qkv,
+        inputs.conv_states.transpose(-1, -2),
+        inputs.conv_weight,
+        inputs.conv_bias,
+        activation="silu",
+        conv_state_indices=inputs.cache_indices,
+    )
+    out = TritonKDAKernel().packed_decode(
+        qkv,
+        inputs.a,
+        inputs.b,
+        A_log=inputs.a_log,
+        dt_bias=inputs.dt_bias,
+        scale=_D**-0.5,
+        ssm_states=inputs.ssm_states,
+        cache_indices=inputs.cache_indices,
+        num_v_heads=heads,
+        head_v_dim=_D,
+        lower_bound=_LOWER_BOUND,
+    )
+    return rms_norm_gated(
+        x=out,
+        g=inputs.onorm_g.view(1, -1, heads, _D),
+        weight=inputs.onorm_weight,
+        bias=None,
+        activation="sigmoid",
+        eps=_EPS,
+    )
+
+
+def _candidate(inputs: Inputs) -> torch.Tensor:
+    return kda_fused_decode(
+        inputs.mixed_qkv,
+        inputs.a,
+        inputs.b,
+        inputs.conv_states,
+        inputs.conv_weight_t_q,
+        inputs.conv_weight_t_k,
+        inputs.conv_weight_t_v,
+        inputs.conv_bias,
+        inputs.a_log,
+        inputs.dt_bias,
+        inputs.onorm_g,
+        inputs.onorm_weight,
+        inputs.ssm_states,
+        inputs.cache_indices,
+        scale=_D**-0.5,
+        onorm_eps=_EPS,
+        lower_bound=_LOWER_BOUND,
+    )
+
+
+def _assert_matches(reference: Inputs, candidate: Inputs) -> None:
+    reference_out = _reference(reference)
+    candidate_out = _candidate(candidate)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        candidate_out.float(), reference_out.float(), rtol=1e-2, atol=2e-3
+    )
+    torch.testing.assert_close(
+        candidate.ssm_states,
+        reference.ssm_states,
+        rtol=1e-4,
+        atol=5e-5,
+    )
+    torch.testing.assert_close(
+        candidate.conv_states.float(),
+        reference.conv_states.float(),
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("heads", [12, 24])
+@pytest.mark.parametrize("strided_state", [False, True])
+@torch.inference_mode()
+def test_fused_decode_matches_full_chain(heads: int, strided_state: bool) -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required.")
+    if torch.cuda.get_device_capability()[0] < 10:
+        pytest.skip("The fused KDA decode kernel requires Blackwell.")
+
+    source = _make_inputs(heads, 8, strided_state=strided_state)
+    reference = _clone_inputs(source)
+    candidate = _clone_inputs(source)
+    assert covered(
+        candidate.mixed_qkv,
+        candidate.a,
+        candidate.b,
+        candidate.conv_states,
+        candidate.ssm_states,
+        candidate.cache_indices,
+        candidate.onorm_g,
+    )
+    _assert_matches(reference, candidate)
+
+
+@torch.inference_mode()
+def test_tp4_padded_slots_are_zero_and_do_not_mutate_state() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required.")
+
+    indices = torch.tensor([4, -1, 1, -1], dtype=torch.int32, device="cuda")
+    inputs = _make_inputs(
+        24,
+        4,
+        strided_state=True,
+        cache_indices=indices,
+        seed=32607,
+    )
+    conv_before = inputs.conv_states.clone()
+    state_before = inputs.ssm_states.clone()
+    out = _candidate(inputs)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(out[:, [1, 3]], torch.zeros_like(out[:, [1, 3]]))
+    untouched = torch.tensor([0, 2, 3, 5, 6, 7, 8], device="cuda")
+    torch.testing.assert_close(
+        inputs.ssm_states[untouched], state_before[untouched], rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        inputs.conv_states[untouched].float(),
+        conv_before[untouched].float(),
+        rtol=0,
+        atol=0,
+    )
+
+
+@torch.inference_mode()
+def test_tp4_changing_input_cuda_graph_replay() -> None:
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA is required.")
+
+    captured = _make_inputs(24, 8, strided_state=True, seed=400)
+    _candidate(captured)
+    torch.cuda.synchronize()
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out = _candidate(captured)
+
+    changed = _make_inputs(24, 8, strided_state=True, seed=401)
+    reference = _clone_inputs(changed)
+    for name in (
+        "mixed_qkv",
+        "a",
+        "b",
+        "onorm_g",
+        "conv_states",
+        "ssm_states",
+        "cache_indices",
+        "conv_weight",
+        "conv_weight_t_q",
+        "conv_weight_t_k",
+        "conv_weight_t_v",
+        "conv_bias",
+        "a_log",
+        "dt_bias",
+        "onorm_weight",
+    ):
+        getattr(captured, name).copy_(getattr(changed, name))
+
+    graph.replay()
+    reference_out = _reference(reference)
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        graph_out.float(), reference_out.float(), rtol=1e-2, atol=2e-3
+    )
+    torch.testing.assert_close(
+        captured.ssm_states,
+        reference.ssm_states,
+        rtol=1e-4,
+        atol=5e-5,
+    )
+    torch.testing.assert_close(
+        captured.conv_states.float(),
+        reference.conv_states.float(),
+        rtol=0,
+        atol=0,
+    )

--- a/test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py
+++ b/test/registered/unit/mem_cache/test_kda_fused_decode_strided_state.py
@@ -125,6 +125,33 @@ def _addressing_samples(heads: int):
 
 
 class TestKdaFusedDecodeStridedState(unittest.TestCase):
+    def test_covered_accepts_tp4_heads_and_rejects_other_head_counts(self):
+        def make_args(heads: int):
+            seg = heads * _K
+            mixed_qkv = torch.zeros((2, 3 * seg), dtype=torch.bfloat16)
+            a = torch.zeros((2, seg), dtype=torch.bfloat16)
+            b = torch.zeros((2, heads), dtype=torch.bfloat16)
+            conv_states = torch.zeros(
+                (_SLOTS, _CONV_STATE_W, 3 * seg), dtype=torch.bfloat16
+            )
+            ssm_states = torch.zeros(
+                (_SLOTS, heads, _V, _K), dtype=torch.float32
+            )
+            cache_indices = torch.zeros((2,), dtype=torch.int32)
+            onorm_g = torch.zeros((2, seg), dtype=torch.bfloat16)
+            return (
+                mixed_qkv,
+                a,
+                b,
+                conv_states,
+                ssm_states,
+                cache_indices,
+                onorm_g,
+            )
+
+        self.assertTrue(covered(*make_args(24)))
+        self.assertFalse(covered(*make_args(16)))
+
     def test_covered_accepts_envelope_strided_and_rejects_noncontiguous_inner(self):
         for heads in _KDA_HEADS:
             with self.subTest(kda_heads=heads):


### PR DESCRIPTION
## Summary

Enable the fused KDA decode kernel for the Kimi-K3 TP4 geometry with 24 local heads.

The fused path combines short convolution, recurrent KDA state update, and gated RMSNorm. Previously H=24 fell back to the separate kernel chain because the fused kernel's dispatch and launch geometry did not accept this head count.

AS-IS

```text
mixed_qkv + recurrent state
  -> causal convolution update
  -> Triton packed KDA state update
  -> gated RMSNorm
```

PR

```text
mixed_qkv + recurrent state + gate inputs
  -> one fused KDA decode kernel
  -> output + updated convolution and recurrent state
```

## Performance

Measured on one NVIDIA GB200 with BF16 activations, FP32 recurrent state, H=24, and K=V=128. CUDA-graph results are the conservative attribution because they remove Python and launch gaps from the three-call baseline.

| Batch | Baseline | Fused | Saving |
| ---: | ---: | ---: | ---: |
| 1 | 12.355 us | 8.256 us | 4.099 us, 33.18% |
| 8 | 16.601 us | 10.270 us | 6.331 us, 38.14% |
| 32 | 23.074 us | 18.734 us | 4.340 us, 18.81% |
| 64 | 49.526 us | 40.792 us | 8.734 us, 17.64% |
| 128 | 89.364 us | 80.033 us | 9.330 us, 10.44% |

Every measured graph cell saves at least 10% and 3 us per layer. At batch 1, multiplying 4.099 us by 69 KDA layers gives a 0.283 ms/token upper-bound projection, not measured TPOT.

No request-level serving speedup is claimed.

## Validation

- Six focused current-main GPU tests passed on one NVIDIA GB200 at commit `1e01a8684`: H12/H24 with dense and envelope-strided FP32 state, padded-slot safety, and changing-input CUDA-graph replay.
- Covers eager and CUDA-graph execution, dense and envelope-strided FP32 state, K3's safe lower-bound gate, and sigmoid output gate.
- `git diff --check` and touched-file Python byte-compilation passed.

## Related PRs

- Parent Kimi-K3 integration: #32541
- Kimi-K3 follow-up tracker: #32607
- Direct-final Query publication: #33069
- Replicated-Q storage ownership: #36294 (supersedes the temporary #33070 draft)
- KDA temporal-state copy-on-write: #33072
- Fused NVIDIA KDA prefill staging: #33073
- Generic lazy-compaction scheduler fix: #33060

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32829650160](https://github.com/sgl-project/sglang/actions/runs/32829650160)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32829649979](https://github.com/sgl-project/sglang/actions/runs/32829649979)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32829650018](https://github.com/sgl-project/sglang/actions/runs/32829650018)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->