### PR TITLE
[AMD][CI] Stabilize PyTorch sampling backend test on ROCm

### DIFF
--- a/test/registered/sampling/test_pytorch_sampling_backend.py
+++ b/test/registered/sampling/test_pytorch_sampling_backend.py
@@ -28,7 +28,13 @@ class TestPyTorchSamplingBackend(CustomTestCase):
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=["--sampling-backend", "pytorch", "--disable-radix-cache"],
+            other_args=[
+                "--sampling-backend",
+                "pytorch",
+                "--disable-radix-cache",
+                "--max-running-requests",
+                "64",
+            ],
         )
 
     @classmethod

--- a/test/registered/sampling/test_pytorch_sampling_backend.py
+++ b/test/registered/sampling/test_pytorch_sampling_backend.py
@@ -3,7 +3,7 @@ from types import SimpleNamespace
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
+from sglang.srt.utils import is_hip, kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.run_eval import run_eval
 from sglang.test.test_utils import (
@@ -24,17 +24,15 @@ class TestPyTorchSamplingBackend(CustomTestCase):
     def setUpClass(cls):
         cls.model = DEFAULT_MODEL_NAME_FOR_TEST
         cls.base_url = DEFAULT_URL_FOR_TEST
+        other_args = ["--sampling-backend", "pytorch", "--disable-radix-cache"]
+        if is_hip():
+            other_args.extend(["--max-running-requests", "64"])
+
         cls.process = popen_launch_server(
             cls.model,
             cls.base_url,
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
-            other_args=[
-                "--sampling-backend",
-                "pytorch",
-                "--disable-radix-cache",
-                "--max-running-requests",
-                "64",
-            ],
+            other_args=other_args,
         )
 
     @classmethod


### PR DESCRIPTION
## Motivation

`test_pytorch_sampling_backend` can abort on ROCm 7.2.4 with `HSA_STATUS_ERROR_OUT_OF_RESOURCES`.

The server auto-resolves `max_running_requests=4029`. AITER sizes its attention workspace from that request-pool capacity, allocating about 32 GiB even though this test drives only 32 client threads.

Failing job: https://github.com/sgl-project/sglang/actions/runs/32725797196/job/97426719822

## Modifications

On HIP/ROCm, cap this test server at 64 running requests; leave CUDA/NVIDIA on the existing auto-derived limit.

The cap is gated by `is_hip()`, so CUDA/NVIDIA receives exactly the original test arguments. On ROCm, it does not change sampling coverage: MMLU uses 32 client threads and the greedy case uses a batch of 10. In the validation run, overlap bookkeeping peaked at 34 running requests (35 including the newly admitted requests), and the queue stayed at 0, so the cap leaves headroom without throttling the workload.

## Accuracy Tests
`test_pytorch_sampling_backend.py` passed on ROCm 7.2.4 / MI300 in [shard 8](https://github.com/sgl-project/sglang/actions/runs/32832826471/job/97755198396)
<img width="1605" height="1107" alt="image" src="https://github.com/user-attachments/assets/0ec590c5-b2e2-4b2b-bbf1-eb149a07dedc" />


## Speed Tests and Profiling

No performance change is intended. The target test completed in 97 s in the CI harness.

## Checklist

- [x] Format and static checks pass (Python compile, Ruff, Black, isort, `git diff --check`).
- [x] Existing test coverage is preserved.
- [x] No documentation update is required.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32973593002](https://github.com/sgl-project/sglang/actions/runs/32973593002)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32973592839](https://github.com/sgl-project/sglang/actions/runs/32973592839)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32973593041](https://github.com/sgl-project/sglang/actions/runs/32973593041)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->