### PR TITLE
[AMD][Bugfix] Skip invalid fused MoE reduction for direct top-1 output

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -881,7 +881,9 @@ def _fused_moe_kernel_sequence(
                     routed_scaling_factor,
                 )
     elif _is_hip:
-        if _use_aiter:
+        if topk == 1 and routed_scaling_factor == 1.0 and not _use_intermediate:
+            pass  # we wrote directly into out_hidden_states
+        elif _use_aiter:
             moe_sum(
                 intermediate_cache3.view(*intermediate_cache3.shape),
                 out_hidden_states,


### PR DESCRIPTION
## Motivation

ROCm 7.2.4 [stage-b-test-1-gpu-small-amd (rocm724, linux-mi300-1gpu-sglang, 7)](https://github.com/sgl-project/sglang/actions/runs/32725797196/job/97426719871#logs) fails `TestFusedMOE.test_single_expert_routing` for `topk=1` and `routed_scaling_factor=1.0`.

In this path, the second GEMM writes directly to `out_hidden_states`, so `intermediate_cache3` is not populated. The HIP epilogue nevertheless reduces `intermediate_cache3` into the output, overwriting the valid result with uninitialized data. CUDA and XPU already skip the reduction under the same conditions.

## Modifications

Add the existing CUDA/XPU direct-output guard to the HIP epilogue. The change is limited to `topk == 1`, unit routed scaling, and the no-intermediate path. The existing `test_single_expert_routing` case already covers this exact configuration, so no test code is changed.

## Accuracy Tests
[`stage-b-test-1-gpu-small-amd` shard 7](https://github.com/sgl-project/sglang/actions/runs/32834713213/job/97761015318) passed on ROCm 7.2.4 / MI300
<img width="1835" height="1149" alt="image" src="https://github.com/user-attachments/assets/2346c118-3d74-4d69-b4f4-c5d23a772305" />


## Speed Tests and Profiling

No regression expected. The affected ROCm fast path now skips a reduction that is both unnecessary and invalid; all other paths are unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (Existing coverage exercises the failing configuration.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (The target regression passed; no performance-sensitive path is added.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32834676872](https://github.com/sgl-project/sglang/actions/runs/32834676872)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #32834676725](https://github.com/sgl-project/sglang/actions/runs/32834676725)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32834676879](https://github.com/sgl-project/sglang/actions/runs/32834676879)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
