### PR TITLE
[Spec][DSA] Add --speculative-dsa-topk-backend

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1458,7 +1458,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--dsa-topk-backend`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the DSA indexer top-k backend. The `torch` backend currently requires `SGLANG_DSA_FUSE_TOPK=false`.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the DSA indexer top-k backend for the target model. The `torch` backend currently requires `SGLANG_DSA_FUSE_TOPK=false`.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`sgl-kernel`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code></td>
     </tr>
@@ -1607,6 +1607,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Attention backend for speculative decoding drafting.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Same as attention backend options</td>
+    </tr>
+        <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-dsa-topk-backend`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Choose the DSA indexer top-k backend for speculative draft workers. The `torch` backend currently requires `SGLANG_DSA_FUSE_TOPK=false`.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`sgl-kernel`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>sgl-kernel</code>, <code>torch</code>, <code>flashinfer</code></td>
     </tr>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-moe-runner-backend`</td>

--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -203,6 +203,11 @@ To enable EAGLE speculative decoding the following parameters are relevant:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code> (same as target)</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dsa-topk-backend</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Select the DSA indexer top-k backend for speculative draft workers independently of <code>--dsa-topk-backend</code>. Options are <code>sgl-kernel</code>, <code>torch</code>, and <code>flashinfer</code>; <code>torch</code> requires <code>SGLANG_DSA_FUSE_TOPK=false</code>.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>sgl-kernel</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-model-quantization</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Quantization method for the draft model. Use <code>"unquant"</code> to force no quantization even when the target model is quantized.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Same as target model</td>
@@ -408,6 +413,8 @@ python3 -m sglang.launch_server \
     --cuda-graph-max-bs-decode 8 \
     --log-level warning
 ```
+
+For DSA-based MTP, draft workers default to the `sgl-kernel` top-k backend. Use `--speculative-dsa-topk-backend` to override the draft independently of `--dsa-topk-backend` for the target model.
 
 **Send a request:**
 
@@ -825,6 +832,12 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>str</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Override attention backend for the draft model</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dsa-topk-backend</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>str</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>sgl-kernel</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>DSA indexer top-k backend for speculative draft workers, independent of <code>--dsa-topk-backend</code> (<code>sgl-kernel</code>, <code>torch</code>, or <code>flashinfer</code>)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-moe-runner-backend</code></td>

--- a/docs/docs/references/environment_variables.mdx
+++ b/docs/docs/references/environment_variables.mdx
@@ -523,12 +523,12 @@ SGLang supports various environment variables that can be used to configure its 
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSA_TOPK_FLASHINFER_DETERMINISTIC</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Use deterministic FlashInfer topk kernels when <code>--dsa-topk-backend=flashinfer</code>.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Use deterministic FlashInfer topk kernels when either <code>--dsa-topk-backend=flashinfer</code> or <code>--speculative-dsa-topk-backend=flashinfer</code>.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DSA_TOPK_FLASHINFER_TIE_BREAK</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Tie-break mode for FlashInfer DSA topk when <code>--dsa-topk-backend=flashinfer</code>: unset disables explicit tie-breaking, <code>small</code> prefers the smaller candidate index for equal scores, and <code>large</code> prefers the larger candidate index for equal scores. Setting this variable makes FlashInfer use deterministic topk.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Tie-break mode for FlashInfer DSA topk when either <code>--dsa-topk-backend=flashinfer</code> or <code>--speculative-dsa-topk-backend=flashinfer</code>: unset disables explicit tie-breaking, <code>small</code> prefers the smaller candidate index for equal scores, and <code>large</code> prefers the larger candidate index for equal scores. Setting this variable makes FlashInfer use deterministic topk.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>unset</code></td>
     </tr>
     <tr>

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -560,9 +560,7 @@ class DeepseekV4AttnBackend(
         self.enable_deepseek_v4_fp4_indexer: bool = (
             model_runner.server_args.enable_deepseek_v4_fp4_indexer
         )
-        self.dsa_topk_backend: DSATopKBackend = DSATopKBackend(
-            model_runner.server_args.dsa_topk_backend
-        )
+        self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.resolve(model_runner)
         self.dsv4_prefill_backend: str = getattr(
             model_runner.server_args, "dsv4_prefill_backend", "auto"
         )

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -1,11 +1,15 @@
 from __future__ import annotations
 
 from enum import Enum, IntEnum, auto
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple
 
 import torch
 
 from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_exec, get_spec
+
+if TYPE_CHECKING:
+    from sglang.srt.model_executor.model_runner import ModelRunner
 
 _FLASHINFER_TIE_BREAK_VALUES = {
     "small": 1,
@@ -24,6 +28,17 @@ class DSATopKBackend(Enum):
     SGL_KERNEL = "sgl-kernel"
     TORCH = "torch"
     FLASHINFER = "flashinfer"
+
+    @classmethod
+    def resolve(cls, model_runner: ModelRunner) -> DSATopKBackend:
+        """Resolve the DSA top-k backend for one model runner.
+
+        ``--dsa-topk-backend`` selects the target backend, while
+        ``--speculative-dsa-topk-backend`` independently selects the draft.
+        """
+        if model_runner.is_draft_worker:
+            return cls(get_spec().speculative_dsa_topk_backend)
+        return cls(get_exec().kernel.dsa_topk_backend)
 
     def is_sgl_kernel(self) -> bool:
         return self == DSATopKBackend.SGL_KERNEL

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -340,9 +340,7 @@ class DeepseekSparseAttnBackend(
         self.supports_mha_one_shot: bool = True
         self.dsa_prefill_impl: _DSA_IMPL_T = get_exec().kernel.dsa_prefill_backend
         self.dsa_decode_impl: _DSA_IMPL_T = get_exec().kernel.dsa_decode_backend
-        self.dsa_topk_backend: DSATopKBackend = DSATopKBackend(
-            model_runner.server_args.dsa_topk_backend
-        )
+        self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.resolve(model_runner)
         if self.num_q_heads <= 64:
             self.flashmla_kv_num_q_heads = 64
         elif self.num_q_heads <= 128:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1888,7 +1888,7 @@ class ServerArgs:
     dsa_topk_backend: A[
         str,
         Arg(
-            help="DSA indexer top-k backend. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            help="DSA indexer top-k backend for the target model. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
             choices=DSA_TOPK_BACKEND_CHOICES,
         ),
         NS("exec.kernel"),
@@ -2252,6 +2252,14 @@ class ServerArgs:
         "Attention backend for speculative decoding drafting.",
         NS("spec"),
     ] = None
+    speculative_dsa_topk_backend: A[
+        str,
+        Arg(
+            help="DSA indexer top-k backend for speculative draft workers. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            choices=DSA_TOPK_BACKEND_CHOICES,
+        ),
+        NS("spec"),
+    ] = "sgl-kernel"
     speculative_draft_kv_cache_dtype: A[
         Optional[str],
         Arg(

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
@@ -298,6 +298,7 @@ class DSAMockModelRunner(ModelRunner):
         self.prefill_attention_backend_str = case.backend
         self.decode_attention_backend_str = case.backend
         self.draft_attention_backend = None
+        self.is_draft_worker = False
         # For TARGET_VERIFY / DRAFT_EXTEND, the DSA backend uses
         # `self.speculative_num_draft_tokens` to size `seqlens_expanded`
         # (`dsa_backend.py:482-486,510-515`). When zero, deep_gemm's

--- a/test/registered/kernels/ops/attention/test_dsa_indexer.py
+++ b/test/registered/kernels/ops/attention/test_dsa_indexer.py
@@ -180,6 +180,7 @@ class MockModelRunner:
         self.config = {**DEFAULT_CONFIG, **(config or {})}
         self.dtype = self.config["dtype"]
         self.kv_cache_dtype = self.config["kv_cache_dtype"]
+        self.is_draft_worker = False
         self.is_hybrid_swa = False
 
         # Model configuration


### PR DESCRIPTION
## Motivation
@humansand

- **Scope:** Split DSA indexer top-k selection between the target model and
  speculative draft workers.
- `--dsa-topk-backend` currently reaches both roles because target and draft
  runners share one `ServerArgs`. A target override such as `flashinfer`
  therefore also changes repeated MTP draft top-k.
- Add `--speculative-dsa-topk-backend`, defaulting to `sgl-kernel`, so the
  draft stays on the usual fast path unless it is explicitly overridden.
- Default launches are unchanged. To use the same non-default backend for both
  roles, pass both selectors.

## Modifications

- Keep `--dsa-topk-backend` as the target-model selector.
- Add `--speculative-dsa-topk-backend` for speculative draft workers with the
  same `sgl-kernel`, `torch`, and `flashinfer` choices and a
  `sgl-kernel` default.
- Resolve the backend per runner from the post-publish config namespaces:
  - target: `exec.kernel.dsa_topk_backend`;
  - draft: `spec.speculative_dsa_topk_backend`.
- Use the common resolver in both `DeepseekSparseAttnBackend` (DSA/GLM) and
  `DeepseekV4AttnBackend` without mutating the shared `ServerArgs`.
- Make the existing DSA test runners explicit target workers so their mocks
  satisfy the same role contract as production `ModelRunner`.
- Document the independent selector in the server-argument and speculative
  decoding references, including the DSA MTP path and FlashInfer environment
  switches.
- **Compatibility:** Existing launches that set only
  `--dsa-topk-backend=<non-default>` now apply that override only to the
  target. Pass the new flag as well to restore the previous target/draft
  pairing.
- **Non-goals:** No kernel implementation changes. `SGLANG_DSA_FUSE_TOPK`,
  `SGLANG_OPT_USE_TOPK_V2`, and the FlashInfer deterministic/tie-break
  settings remain process-wide. Selecting `torch` for either role still
  requires `SGLANG_DSA_FUSE_TOPK=false`, which disables fused top-k for both
  roles.

## Accuracy Tests

Tested commits and environment:

- PR: `e06cd057c3cb319970a283aafb3e23facbf7f559`
- Base: `99c02d71b170673f97676f097fc928de38d847e0`
- C2 bare devbox with 8 x NVIDIA B300 SXM6 AC allocated; tests were constrained
  to GPU 0 with `CUDA_VISIBLE_DEVICES=0`
- Image:
  `lmsysorg/sglang:nightly-dev-cu13-20260825-1ec20fd2`
  (linux/amd64 digest
  `sha256:65376f9f5c317da614be2d6e2c683d8c4d7964cf8fa63f663a1cd058929598ca`)
- NVIDIA driver `590.48.01`; CUDA `13.0.3`; Python `3.12.3`;
  PyTorch `2.13.0+cu130`; Triton `3.7.1`
- Exact PR and base sources were downloaded from GitHub codeload tarballs for
  the SHAs above and selected with `PYTHONPATH`.

Existing DSA and DeepSeek-V4 attention unit suites on the PR:

```bash
cd /sgl-workspace/sglang-pr36313
export PYTHONPATH=/sgl-workspace/sglang-pr36313/python
export CUDA_VISIBLE_DEVICES=0
python3 -m pytest -q -ra \
  test/registered/attention/unittests/dsa/test_dsa.py \
  test/registered/attention/unittests/dsv4/test_deepseek_v4.py
```

```text
32 passed, 23 skipped, 21 warnings, 73 subtests passed in 15.24s
```

The skips are capability-gated on SM 10.3: FA3 is limited to SM 9.x, the image
does not contain a matching TileLang B300 template, TensorRT-LLM covers SM
10.0 rather than SM 10.3 here, AITER is AMD-only, and the remaining cases are
unsupported FP8/backend combinations.

Existing DSA metadata/transform and DeepSeek-V4 indexer unit suites on the PR:

```bash
cd /sgl-workspace/sglang-pr36313
export PYTHONPATH=/sgl-workspace/sglang-pr36313/python
export CUDA_VISIBLE_DEVICES=0
python3 -m pytest -q -ra \
  test/registered/kernels/ops/attention/test_dsa_metadata.py \
  test/registered/kernels/ops/attention/test_dsa_transform_index.py \
  test/registered/kernels/ops/attention/test_dsv4_indexer_quant.py \
  test/registered/unit/layers/test_dsv4_nonpaged_indexer.py
```

```text
41 passed, 15 warnings, 18 subtests passed in 37.91s
```

Direct selector smoke against the resolved runtime namespaces:

```python
from types import SimpleNamespace

from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
    DSATopKBackend as Backend,
)
from sglang.srt.runtime_context import get_context

target = SimpleNamespace(is_draft_worker=False)
draft = SimpleNamespace(is_draft_worker=True)

override = get_context().override_server_args(dsa_topk_backend="flashinfer")
server_args = override.install()
assert Backend.resolve(target) is Backend.FLASHINFER
assert Backend.resolve(draft) is Backend.SGL_KERNEL
assert server_args.speculative_dsa_topk_backend == "sgl-kernel"
override.restore()

override = get_context().override_server_args(
    dsa_topk_backend="sgl-kernel",
    speculative_dsa_topk_backend="torch",
)
override.install()
assert Backend.resolve(target) is Backend.SGL_KERNEL
assert Backend.resolve(draft) is Backend.TORCH
print("target/draft DSA top-k selection: PASS")
```

```text
target/draft DSA top-k selection: PASS
```

Controlled PR/base comparison of the attention and B300 indexer suites, using
the same node, image, GPU, and command:

```bash
cd /sgl-workspace/sglang-pr36313
PYTHONPATH=/sgl-workspace/sglang-pr36313/python CUDA_VISIBLE_DEVICES=0 \
  python3 -m pytest -q -ra \
    test/registered/attention/unittests/dsa/test_dsa.py \
    test/registered/attention/unittests/dsv4/test_deepseek_v4.py \
    test/registered/kernels/ops/attention/test_dsa_indexer.py
```

```text
2 failed, 42 passed, 23 skipped, 21 warnings, 106 subtests passed in 224.45s
```

```bash
cd /sgl-workspace/sglang-pr36313-base
PYTHONPATH=/sgl-workspace/sglang-pr36313-base/python CUDA_VISIBLE_DEVICES=0 \
  python3 -m pytest -q -ra \
    test/registered/attention/unittests/dsa/test_dsa.py \
    test/registered/attention/unittests/dsv4/test_deepseek_v4.py \
    test/registered/kernels/ops/attention/test_dsa_indexer.py
```

```text
2 failed, 42 passed, 23 skipped, 21 warnings, 106 subtests passed in 17.77s
```

Both commits fail the same two B300-only cases:

```text
FAILED test/registered/kernels/ops/attention/test_dsa_indexer.py::TestDSAIndexer::test_forward_decode_mode
FAILED test/registered/kernels/ops/attention/test_dsa_indexer.py::TestDSAIndexer::test_forward_extend_mode
AttributeError: 'MockModelRunner' object has no attribute 'max_running_requests'
```

The failing workspace allocation reads
`model_runner.max_running_requests`; the unchanged upstream mock does not
define that field. The identical base and PR outcomes bound this as a
pre-existing B300 test-mock limitation rather than a regression from this
change. The wall times are not a performance comparison because the second run
used warm JIT/caches.

No new standalone test cases are included; validation uses the existing DSA
suites plus the direct selector smoke above.

Static validation:

```bash
pre-commit run --files \
  docs/docs/advanced_features/server_arguments.mdx \
  docs/docs/advanced_features/speculative_decoding.mdx \
  docs/docs/references/environment_variables.mdx \
  python/sglang/srt/layers/attention/deepseek_v4_backend.py \
  python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py \
  python/sglang/srt/layers/attention/dsa_backend.py \
  python/sglang/srt/server_args.py \
  python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py \
  test/registered/kernels/ops/attention/test_dsa_indexer.py
```

```text
check for broken symlinks..............................(no files to check)Skipped
detect destroyed symlinks..................................................Passed
trim trailing whitespace...................................................Passed
fix end of files...........................................................Passed
check yaml.............................................(no files to check)Skipped
check toml.............................................(no files to check)Skipped
check python ast...........................................................Passed
check for added large files................................................Passed
check for merge conflicts..................................................Passed
check that scripts with shebangs are executable............................Passed
detect private key.........................................................Passed
debug statements (python)..................................................Passed
don't commit to branch.....................................................Passed
isort......................................................................Passed
ruff (legacy alias)........................................................Passed
black-jupyter..............................................................Passed
codespell..................................................................Passed
clang-format...........................................(no files to check)Skipped
nbstripout.............................................(no files to check)Skipped
forbid docs_new/ (renamed to docs/)....................(no files to check)Skipped
check chinese characters in multimodal_gen.............(no files to check)Skipped
sort CI_PERMISSIONS.json...............................(no files to check)Skipped
check for duplicate workflow job names.................(no files to check)Skipped
check rust-ext cache key prefix defaults match.........(no files to check)Skipped
reject bare pytest.main calls in __main__ blocks...........................Passed
unit tests for lint checkers...........................(no files to check)Skipped
validate registered test CI registries.....................................Passed
reject CI-registered tests inside the sglang package.......................Passed
rustfmt sgl-model-gateway (nightly)....................(no files to check)Skipped
rustfmt experimental/sgl-router........................(no files to check)Skipped
clippy rust/ workspace (auto-fix)......................(no files to check)Skipped
rustfmt rust/ workspace................................(no files to check)Skipped
```

```bash
python3 -m compileall -q \
  python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py \
  python/sglang/srt/layers/attention/dsa_backend.py \
  python/sglang/srt/layers/attention/deepseek_v4_backend.py \
  python/sglang/srt/server_args.py \
  python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py \
  test/registered/kernels/ops/attention/test_dsa_indexer.py
git diff --check upstream/main..HEAD
```

```text
# Both commands exited 0 with no output.
```

## Speed Tests and Profiling

- Not run. This PR changes backend selection configuration, not a kernel
  implementation, and makes no quantitative speedup claim.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32886603742](https://github.com/sgl-project/sglang/actions/runs/32886603742)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32886603233](https://github.com/sgl-project/sglang/actions/runs/32886603233)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32886603588](https://github.com/sgl-project/sglang/actions/runs/32886603588)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->