### PR TITLE
Require exactly one generation input type

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -404,15 +404,13 @@ class GenerateReqInput:
 
     def _validate_inputs(self):
         """Validate that the input configuration is valid."""
-        if (
-            self.text is None and self.input_ids is None and self.input_embeds is None
-        ) or (
-            self.text is not None
-            and self.input_ids is not None
-            and self.input_embeds is not None
-        ):
+        num_inputs = sum(
+            value is not None
+            for value in (self.text, self.input_ids, self.input_embeds)
+        )
+        if num_inputs != 1:
             raise ValueError(
-                "Either text, input_ids or input_embeds should be provided."
+                "Exactly one of text, input_ids, or input_embeds should be provided."
             )
         if (
             self.return_flat_raw_top_logprobs

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -1075,17 +1075,22 @@ class TestGenerateReqInputNormalization(CustomTestCase):
 
     def test_error_cases(self):
         """Test various error cases."""
-        # Test when neither text, input_ids, nor input_embeds is provided
-        with self.assertRaises(ValueError):
-            req = GenerateReqInput()
-            req.normalize_batch_and_arguments()
-
-        # Test when all of text, input_ids, and input_embeds are provided
-        with self.assertRaises(ValueError):
-            req = GenerateReqInput(
-                text="Hello", input_ids=[1, 2, 3], input_embeds=[[0.1, 0.2]]
-            )
-            req.normalize_batch_and_arguments()
+        invalid_inputs = (
+            {},
+            {"text": "Hello", "input_ids": [1, 2, 3]},
+            {"text": "Hello", "input_embeds": [[0.1, 0.2]]},
+            {"input_ids": [1, 2, 3], "input_embeds": [[0.1, 0.2]]},
+            {
+                "text": "Hello",
+                "input_ids": [1, 2, 3],
+                "input_embeds": [[0.1, 0.2]],
+            },
+        )
+        for inputs in invalid_inputs:
+            with self.subTest(inputs=inputs), self.assertRaisesRegex(
+                ValueError, "Exactly one"
+            ):
+                GenerateReqInput(**inputs).normalize_batch_and_arguments()
 
     def test_data_parallel_rank_alias_maps_to_routed_dp_rank(self):
         req = GenerateReqInput(text="Hello", sampling_params={}, data_parallel_rank=2)


### PR DESCRIPTION
## Motivation

`GenerateReqInput` currently rejects requests only when none or all three of `text`, `input_ids`, and `input_embeds` are provided. As a result, requests containing any two input types are accepted even though the inputs are alternatives, leaving downstream code to apply ambiguous precedence.

## Modifications

- Require exactly one of `text`, `input_ids`, or `input_embeds`.
- Add unit coverage for every invalid combination: zero inputs, each pair, and all three inputs.

## Accuracy Tests

Not applicable; this change only validates request arguments.

## Speed Tests and Profiling

Not applicable; this change does not affect inference execution.

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [unit testing guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to the [documentation guide](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Follow the SGLang [code style guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

Tested with:

```
python -m pytest test/registered/unit/managers/test_io_struct.py
```

Result: 47 passed, 2 skipped.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32840282074](https://github.com/sgl-project/sglang/actions/runs/32840282074)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32840281871](https://github.com/sgl-project/sglang/actions/runs/32840281871)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32840282085](https://github.com/sgl-project/sglang/actions/runs/32840282085)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->