### PR TITLE
[compile][Spec] Let the EAGLE target keep its prefill CUDA graph on tc_piecewise

### DIFF
--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -21,10 +21,6 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.model_executor.forward_batch_info import (
-    CaptureHiddenMode,
-    get_server_return_hidden_states_mode,
-)
 from sglang.srt.model_executor.graph_memory_usage import (
     merge_graph_memory_usage,
     merge_graph_time_usage,
@@ -321,24 +317,6 @@ def capture_prefill_graph(
     # init_lm_head so graphs capture the final embedding weights.
     if model_runner.is_draft_worker and not force_for_draft_worker:
         return result(None)
-
-    # Skip prefill CG for EAGLE target on tc_piecewise when the fixed server
-    # capture ceiling is below FULL. EAGLE target prefill requests FULL, so a
-    # NULL or LAST graph is dead; capturing it can perturb FP4/TRTLLM-MoE
-    # state and corrupt decode replay (see #28386 and #28870). BCG and FullCG
-    # capture FULL for EAGLE targets in PrefillCudaGraphRunner.__init__, so
-    # they do not need this skip.
-    if (
-        model_runner.spec_algorithm.is_eagle()
-        and not model_runner.is_draft_worker
-        and get_server_return_hidden_states_mode() < CaptureHiddenMode.FULL
-        and check_cuda_graph_backend(Phase.PREFILL, Backend.TC_PIECEWISE)
-    ):
-        logger.info(
-            "Disable prefill CUDA graph for EAGLE target on tc_piecewise "
-            "to avoid FP4/MoE decode-replay corruption (#28386)."
-        )
-        return result(eager_runner)
 
     if (
         model_runner.lora_manager is not None

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -311,22 +311,13 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
 
         # --- capture modes --------------------------------------------
         self.capture_forward_mode = ForwardMode.EXTEND
-        # Hidden-state capture mode cases:
-        # - Breakable EAGLE draft: LAST.
-        # - EAGLE target: FULL.
-        # - Return-hidden-states or DFLASH: FULL.
-        # - Otherwise: NULL.
+        # EAGLE prefill asks for FULL on the target (it feeds the draft) and
+        # LAST on the draft, regardless of the prefill backend: a graph captured
+        # below the requested mode is rejected on every replay.
         is_eagle = model_runner.spec_algorithm.is_eagle()
-        is_breakable_eagle_draft = (
-            self.prefill_backend_name == Backend.BREAKABLE
-            and is_eagle
-            and model_runner.is_draft_worker
-        )
-        if is_breakable_eagle_draft:
+        if is_eagle and model_runner.is_draft_worker:
             self.capture_hidden_mode = CaptureHiddenMode.LAST
-        elif (is_eagle and not model_runner.is_draft_worker) or (
-            model_runner.spec_algorithm.is_dflash_family()
-        ):
+        elif is_eagle or model_runner.spec_algorithm.is_dflash_family():
             self.capture_hidden_mode = CaptureHiddenMode.FULL
         else:
             self.capture_hidden_mode = self.return_hidden_states_mode

--- a/test/registered/models_e2e/test_inkling_small_nvfp4.py
+++ b/test/registered/models_e2e/test_inkling_small_nvfp4.py
@@ -149,12 +149,10 @@ class TestInklingSmallNvfp4DsparkDeterministic(CustomTestCase):
     prefix restored from the radix cache that does not reproduce a fresh
     prefill -- rather than the float noise a loose threshold would hide.
 
-    DSPARK drives the decode loop because the spec-side mamba/sconv save is
-    otherwise unreachable: that gate lives in PrefillCudaGraphRunner, and EAGLE
-    targets disable the prefill graph outright (#28386), so the MTP class in
-    test_unified_radix_cache_kl_hybrid_bitexact.py never reaches it. Reverting
-    #34043 reads 1.10e-01 on prefill_cache_hit here and exactly 0 without
-    speculation.
+    DSPARK drives the decode loop because the spec-side mamba/sconv save gate
+    lives in PrefillCudaGraphRunner, and this is the configuration that
+    exercises it here. Reverting #34043 reads 1.10e-01 on prefill_cache_hit
+    here and exactly 0 without speculation.
 
     Runs its own server: the accuracy case above has to stay on the production
     numerics, so it cannot share this one.

--- a/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
+++ b/test/registered/unit/model_executor/test_prefill_cuda_graph_runner.py
@@ -22,7 +22,7 @@ from sglang.srt.model_executor.runner.prefill_cuda_graph_runner import (
     PrefillCudaGraphRunner,
 )
 from sglang.srt.model_executor.runner.shape_key import ShapeKey
-from sglang.srt.runtime_context import get_context
+from sglang.srt.runtime_context import get_context, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -152,29 +152,63 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
 
         self.assertIs(capture.runner, prefill_runner)
 
-    def test_eagle_target_tc_piecewise_skips_last_mode_capture(self):
+    def test_eagle_target_tc_piecewise_still_captures_prefill_graph(self):
+        """The EAGLE target now captures FULL on tc_piecewise too, so a
+        sub-FULL server ceiling leaves no dead graph behind and the capture must
+        not fall back to eager."""
         eager_runner = object()
-        # The server-side hidden-state ceiling and graph config are bag leaves.
+        prefill_runner = object()
+        # Bag leaves; the hidden-state ceiling is held below FULL on purpose.
         override = get_context().override_server_args(
+            enable_lora=False,
             enable_return_hidden_states=True,
             return_hidden_states_mode="last",
             cuda_graph_config=SimpleNamespace(
-                prefill=SimpleNamespace(backend=Backend.TC_PIECEWISE)
+                prefill=SimpleNamespace(bs=[1], backend=Backend.TC_PIECEWISE)
             ),
         )
         override.install()
         self.addCleanup(override.restore)
         model_runner = SimpleNamespace(
+            device="cuda",
+            gpu_id=0,
             is_draft_worker=False,
+            lora_manager=None,
             spec_algorithm=SimpleNamespace(is_eagle=lambda: True),
+            server_args=SimpleNamespace(),
+            model=SimpleNamespace(),
+            model_config=SimpleNamespace(context_len=8192, num_hidden_layers=1),
+            req_to_token_pool=SimpleNamespace(size=1),
         )
+        language_model = SimpleNamespace(layers=[object()])
 
-        capture = capture_prefill_graph(
-            model_runner=model_runner,
-            eager_runner=eager_runner,
-        )
+        with (
+            patch.object(graph_setup, "check_cuda_graph_backend", return_value=False),
+            patch.object(
+                graph_setup, "resolve_language_model", return_value=language_model
+            ),
+            patch.object(
+                graph_setup,
+                "compute_attention_and_moe_layers",
+                return_value=([object()], [], [], [], []),
+            ),
+            patch.object(
+                graph_setup,
+                "get_available_gpu_memory",
+                side_effect=[10.0, 9.5],
+            ),
+            patch.object(
+                graph_setup,
+                "PrefillCudaGraphRunner",
+                return_value=prefill_runner,
+            ),
+        ):
+            capture = capture_prefill_graph(
+                model_runner=model_runner,
+                eager_runner=eager_runner,
+            )
 
-        self.assertIs(capture.runner, eager_runner)
+        self.assertIs(capture.runner, prefill_runner)
 
     def test_pp_proxy_output_is_trimmed_to_raw_prefill_tokens(self):
         runner = PrefillCudaGraphRunner.__new__(PrefillCudaGraphRunner)
@@ -472,6 +506,81 @@ class TestPrefillCudaGraphRunnerChunkedPrefix(CustomTestCase):
         )
         forward_batch.extend_prefix_lens_cpu = [9, 1]
         self.assertFalse(runner.can_run_graph(forward_batch))
+
+
+class _StopInit(Exception):
+    """Ends __init__ right after the capture-mode block, before buffers."""
+
+
+class TestPrefillCudaGraphRunnerCaptureHiddenMode(CustomTestCase):
+    """The hidden-state capture mode PrefillCudaGraphRunner.__init__ pins.
+
+    EAGLE prefill requests FULL on the target and LAST on the draft; a graph
+    captured below the requested mode is rejected by can_run_graph on every
+    replay, so the mode must not depend on the prefill backend.
+    """
+
+    @staticmethod
+    def _eagle_capture_hidden_mode(*, is_draft_worker):
+        model_runner = SimpleNamespace(
+            device="cpu",
+            gpu_id=0,
+            is_draft_worker=is_draft_worker,
+            is_generation=True,
+            lora_manager=None,
+            spec_algorithm=SimpleNamespace(
+                is_eagle=lambda: True,
+                is_dflash_family=lambda: False,
+            ),
+            server_args=SimpleNamespace(tp_size=1, enable_pdmux=False),
+            model=SimpleNamespace(),
+            model_config=SimpleNamespace(is_multimodal=False),
+            req_to_token_pool=SimpleNamespace(size=8),
+        )
+
+        captured = {}
+
+        def stop(self):
+            captured["runner"] = self
+            raise _StopInit
+
+        with (
+            get_parallel().override(attn_tp_size=1, attn_tp_rank=0),
+            patch.object(PrefillCudaGraphRunner, "_is_mamba_track_enabled", stop),
+        ):
+            try:
+                PrefillCudaGraphRunner(model_runner)
+            except _StopInit:
+                pass
+
+        return captured["runner"].capture_hidden_mode
+
+    def _install_config(self, backend):
+        override = get_context().override_server_args(
+            cuda_graph_config=SimpleNamespace(
+                prefill=SimpleNamespace(bs=[4], backend=backend)
+            ),
+        )
+        override.install()
+        self.addCleanup(override.restore)
+
+    def test_eagle_target_captures_full_on_every_backend(self):
+        for backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE, Backend.FULL):
+            with self.subTest(backend=backend):
+                self._install_config(backend)
+                self.assertEqual(
+                    self._eagle_capture_hidden_mode(is_draft_worker=False),
+                    CaptureHiddenMode.FULL,
+                )
+
+    def test_eagle_draft_worker_captures_last_on_every_backend(self):
+        for backend in (Backend.TC_PIECEWISE, Backend.BREAKABLE):
+            with self.subTest(backend=backend):
+                self._install_config(backend)
+                self.assertEqual(
+                    self._eagle_capture_hidden_mode(is_draft_worker=True),
+                    CaptureHiddenMode.LAST,
+                )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`cuda_graph_setup.py` skips the prefill CUDA graph entirely for an EAGLE target on
`tc_piecewise`, so the target always falls back to eager prefill.

The skip was added because the runner used to capture `LAST`/`NULL` for the EAGLE
target on non-breakable backends, and a graph captured below the requested mode is
rejected on every replay. `main` has since changed the runner to capture `FULL` for
the EAGLE target regardless of backend, so the reason for the skip is gone -- but
the skip is still there, and it runs first, so that new branch is never reached.

One gap remains on the draft side: `LAST` is still conditioned on
`prefill_backend_name == BREAKABLE`, so an EAGLE draft on `tc_piecewise` captures
`NULL` and every replay is rejected.

## Modifications

- Remove the EAGLE-target skip in `cuda_graph_setup.py`.
- Drop the `BREAKABLE` condition on the draft's `LAST` capture mode: EAGLE prefill
  asks for `FULL` on the target and `LAST` on the draft regardless of backend.

Replaces the unit test asserting the old skip behaviour with tests covering both
workers across backends.

## Accuracy Tests

DeepSeek-V4 on MI355X, gsm8k 200 questions / 5-shot, EAGLE MTP
(`speculative_num_steps=2`, `eagle_topk=1`, `num_draft_tokens=3`), TP8:

| config | accuracy |
| --- | --- |
| prefill graph disabled | 0.970 |
| tc_piecewise | 0.970 - 0.975 |

Also verified under DP8 + EP8: 0.965 with and without the prefill graph.

## Benchmarking and Profiling

TP8 with EAGLE MTP, gsm8k 200 questions:

| config | latency |
| --- | --- |
| prefill graph disabled | 12.2 s |
| tc_piecewise | 11.3 s |

DP8 + EP8 with EAGLE MTP:

| config | latency | accuracy |
| --- | --- | --- |
| prefill graph disabled | 22.5 s | 0.965 |
| tc_piecewise | 15.6 s | 0.965 |

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-files).
- [x] Update documentation / docstrings / example tutorials as needed, according to [Writing Documentation](https://docs.sglang.ai/developer_guide/contribution_guide.html#writing-documentation-running-docs-ci).
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed, according to [Benchmark and Profiling](https://docs.sglang.ai/developer_guide/benchmark_and_profiling.html) and [Accuracy Results](https://docs.sglang.ai/developer_guide/accuracy_evaluation.html).
- [x] For reviewers: If you haven't made any contributions to this PR and are only assisting with merging the main branch, please remove yourself as a co-author when merging the PR.
- [x] Please feel free to join our Slack channel at https://slack.sglang.ai to discuss your PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33409178913](https://github.com/sgl-project/sglang/actions/runs/33409178913)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33409178690](https://github.com/sgl-project/sglang/actions/runs/33409178690)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33409178741](https://github.com/sgl-project/sglang/actions/runs/33409178741)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->