### PR TITLE
[diffusion] feat: support out-of-tree platforms and hook plugins

### DIFF
--- a/docs/docs/hardware-platforms/plugin.mdx
+++ b/docs/docs/hardware-platforms/plugin.mdx
@@ -43,6 +43,8 @@ The framework provides two plugin types, both discovered via Python's standard `
 - **Zero configuration**: Plugins are automatically discovered after `pip install`, no sglang code changes required.
 - **Environment variable control**: `SGLANG_PLATFORM` selects or validates the active platform plugin; `SGLANG_PLUGINS` (comma-separated) controls which general plugins to load.
 
+The diffusion engine mirrors both plugin types under its own entry point groups (`sglang.multimodal_gen.platforms` and `sglang.multimodal_gen.plugins`) — see [Diffusion Engine Plugins](#diffusion-engine-plugins) below.
+
 ### Current Scope & Future Direction
 
 The plugin system currently targets **out-of-tree (OOT) hardware platforms** — enabling new devices to integrate with SGLang without any changes to the main repository. The main-repo hardware paths (CUDA, ROCm, NPU, XPU, etc.) continue to use the existing `is_cuda()`/`is_npu()`/… utility functions.
@@ -821,6 +823,142 @@ Target paths use fully-qualified dotted notation. Both formats are supported:
 
 ---
 
+## Diffusion Engine Plugins
+
+The diffusion engine (`sglang-diffusion`, package `sglang.multimodal_gen`) has its own platform hierarchy and its own process tree, so it exposes a parallel pair of entry point groups. The discovery machinery and the hook registry are shared with SRT — only the group names and the selection env vars differ.
+
+<table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
+  <colgroup>
+    <col style={{width: "25%"}} />
+    <col style={{width: "37.5%"}} />
+    <col style={{width: "37.5%"}} />
+  </colgroup>
+  <thead>
+    <tr>
+      <th>Plugin Type</th>
+      <th>Entry Point Group</th>
+      <th>Callable</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Diffusion Platform Plugin</strong></td>
+      <td><code>sglang.multimodal_gen.platforms</code></td>
+      <td><code>activate() -&gt; str | None</code> returning the qualname of a <code>sglang.multimodal_gen.runtime.platforms.interface.Platform</code> subclass, or <code>None</code> when the hardware is absent</td>
+    </tr>
+    <tr>
+      <td><strong>Diffusion General Plugin</strong></td>
+      <td><code>sglang.multimodal_gen.plugins</code></td>
+      <td><code>register() -&gt; None</code> registering hooks on the shared <code>HookRegistry</code></td>
+    </tr>
+  </tbody>
+</table>
+
+### Environment Variables
+
+<table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
+  <colgroup>
+    <col style={{width: "50%"}} />
+    <col style={{width: "50%"}} />
+  </colgroup>
+  <thead>
+    <tr>
+      <th>Variable</th>
+      <th>Description</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>SGLANG_DIFFUSION_PLATFORM</code></td>
+      <td>Select the diffusion platform plugin by entry_point name. Same semantics as <code>SGLANG_PLATFORM</code>: front-loading filter (only the named plugin is imported), and general plugins from unselected platform dists are skipped. Required when several plugins would activate.</td>
+    </tr>
+    <tr>
+      <td><code>SGLANG_DIFFUSION_PLUGINS</code></td>
+      <td>Comma-separated whitelist of diffusion general plugin names. Unset loads all discovered ones. <code>SGLANG_PLUGINS</code> does not gate this group.</td>
+    </tr>
+    <tr>
+      <td><code>SGLANG_DIFFUSION_PLATFORM_OVERRIDE</code></td>
+      <td>Escape hatch that bypasses detection and plugins: a built-in short name (<code>cpu</code>, <code>cuda</code>, <code>rocm</code>, <code>mps</code>, <code>npu</code>, <code>musa</code>, <code>xpu</code>) or an explicit <code>module.Class</code> / <code>module:Class</code> qualname.</td>
+    </tr>
+  </tbody>
+</table>
+
+### Platform Resolution Order
+
+```
+SGLANG_DIFFUSION_PLATFORM_OVERRIDE set → use it (short name or qualname), no discovery
+  │
+SGLANG_DIFFUSION_PLATFORM set (front-loading filter):
+  ├─ name not in entry_points          → RuntimeError
+  ├─ activate() returns a qualname      → use it
+  └─ activate() returns None / raises   → RuntimeError
+  │
+SGLANG_DIFFUSION_PLATFORM unset (activate every discovered plugin):
+  ├─ 1 activated  → use it
+  ├─ N activated  → RuntimeError (must set SGLANG_DIFFUSION_PLATFORM)
+  └─ 0 activated  → built-in chain: mps → xpu → rocm → cuda → npu → musa → cpu
+```
+
+The resolved qualname is loaded through `_load_platform_class()`, which rejects anything that is not a `Platform` subclass.
+
+### Plugin Load Point
+
+`load_diffusion_plugins()` runs from `sglang/multimodal_gen/__init__.py`, before the package binds `PipelineConfig`, `SamplingParams` and `DiffGenerator`. Every diffusion process imports that package — including workers spawned by the multiproc executor — so no explicit call site is needed. It is idempotent per process.
+
+Two consequences for plugin authors:
+
+- `register()` must not do `from sglang.multimodal_gen import <top-level name>`: those names are not bound yet, and the resulting `ImportError` is swallowed into a log line that silently disables the plugin. Importing *submodules* is fine, and hook targets are dotted strings resolved later.
+- Because SRT's `load_plugins()` and `load_diffusion_plugins()` share one process-global `HookRegistry`, a target patched by whichever loader ran first is not patched again. `apply_hooks()` logs a warning naming the plugin sources of any hook that arrives too late.
+
+### Quick Start
+
+```python
+# my_diffusion_plugin/__init__.py
+from sglang.srt.plugins.hook_registry import HookRegistry, HookType
+
+
+def activate() -> str | None:
+    """Platform plugin: return the Platform qualname when the device is present."""
+    import torch
+
+    if not torch.foo.is_available():
+        return None
+    return "my_diffusion_plugin.platform.MyDiffusionPlatform"
+
+
+def _after_build(result, *args, **kwargs):
+    return result
+
+
+def register() -> None:
+    """General plugin: register hooks."""
+    HookRegistry.register(
+        "sglang.multimodal_gen.runtime.pipelines_core.build_pipeline",
+        _after_build,
+        HookType.AFTER,
+    )
+```
+
+```toml
+# pyproject.toml
+[project.entry-points."sglang.multimodal_gen.platforms"]
+mydev = "my_diffusion_plugin:activate"
+
+[project.entry-points."sglang.multimodal_gen.plugins"]
+mydev_hooks = "my_diffusion_plugin:register"
+```
+
+### Out-of-Tree Platform Requirements
+
+An out-of-tree diffusion platform subclasses `Platform` and sets `_enum = PlatformEnum.OOT`, which makes `is_out_of_tree()` true. Two dispatch points consult it:
+
+- `CustomOp.dispatch_forward()` routes to `forward_oot()` before the in-tree `is_hip()` / `is_npu()` / `is_xpu()` / `is_musa()` branches, so a vendor torch build that also answers those predicates still lands on the OOT implementation.
+- `GroupCoordinator` asks the platform for `get_device_communicator_cls()` (validated as a `DeviceCommunicatorBase` subclass); in-tree platforms keep the CUDA-alike / CPU split.
+
+Out-of-tree *models and pipelines* are a separate, lighter mechanism — see [Support New Diffusion Models](/docs/sglang-diffusion/support_new_models) for `register_pipeline()`, `ModelRegistry.register_model()` and `SGLANG_EXTERNAL_MODEL_PACKAGE`.
+
+---
+
 ## File Reference
 
 <table style={{width: "100%", borderCollapse: "collapse", tableLayout: "fixed"}}>
@@ -854,6 +992,14 @@ Target paths use fully-qualified dotted notation. Both formats are supported:
     <tr>
       <td><code>sglang/srt/plugins/hook_registry.py</code></td>
       <td><code>HookRegistry</code>, <code>HookType</code>, <code>plugin_hook</code> decorator</td>
+    </tr>
+    <tr>
+      <td><code>sglang/multimodal_gen/plugins/__init__.py</code></td>
+      <td><code>load_diffusion_plugins()</code> + <code>discover_diffusion_plugins()</code> (diffusion entry point groups)</td>
+    </tr>
+    <tr>
+      <td><code>sglang/multimodal_gen/runtime/platforms/__init__.py</code></td>
+      <td>Diffusion <code>current_platform</code> lazy singleton + platform plugin discovery</td>
     </tr>
   </tbody>
 </table>

--- a/docs/docs/sglang-diffusion/environment_variables.mdx
+++ b/docs/docs/sglang-diffusion/environment_variables.mdx
@@ -24,6 +24,21 @@ description: "Configure SGLang diffusion behavior with environment variables."
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Installed package that registers out-of-tree diffusion pipelines and component models. The package is imported once in every process.</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DIFFUSION_PLATFORM</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>not set</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Select an out-of-tree platform plugin by entry_point name (group <code>sglang.multimodal_gen.platforms</code>). Only the named plugin is imported; required when several installed plugins would activate. See <a href="/docs/hardware-platforms/plugin">Plugin System</a>.</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DIFFUSION_PLUGINS</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>not set</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Comma-separated whitelist of diffusion general plugin names (group <code>sglang.multimodal_gen.plugins</code>). Unset loads every discovered plugin.</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DIFFUSION_PLATFORM_OVERRIDE</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>not set</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Force a platform, bypassing detection and plugins: a built-in short name (<code>cpu</code>, <code>cuda</code>, <code>rocm</code>, <code>mps</code>, <code>npu</code>, <code>musa</code>, <code>xpu</code>) or an explicit <code>module.Class</code> qualname.</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>SGLANG_DIFFUSION_TARGET_DEVICE</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>cuda</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Target device for inference (<code>cuda</code>, <code>rocm</code>, <code>xpu</code>, <code>npu</code>, <code>musa</code>, <code>mps</code>, <code>cpu</code>)</td>

--- a/python/sglang/multimodal_gen/__init__.py
+++ b/python/sglang/multimodal_gen/__init__.py
@@ -1,4 +1,12 @@
 # Copied and adapted from: https://github.com/hao-ai-lab/FastVideo
+from sglang.multimodal_gen.plugins import load_diffusion_plugins
+
+# Load diffusion plugins before importing anything else from this package: hooks
+# must be applied before the runtime binds module-level state, and before the
+# platform singleton resolves. Every diffusion process imports this package,
+# including spawned workers, so this covers them too.
+load_diffusion_plugins()
+
 from sglang.multimodal_gen.configs.pipeline_configs import PipelineConfig
 from sglang.multimodal_gen.configs.sample import SamplingParams
 from sglang.multimodal_gen.runtime.entrypoints.diffusion_generator import DiffGenerator

--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -26,7 +26,6 @@ if TYPE_CHECKING:
     SGLANG_DIFFUSION_DISABLE_LORA_MERGE_CACHE: bool = False
     SGLANG_DIFFUSION_WORKER_MULTIPROC_METHOD: str = "fork"
     SGLANG_DIFFUSION_TARGET_DEVICE: str = "cuda"
-    SGLANG_DIFFUSION_PLATFORM_OVERRIDE: str = ""
     SGLANG_EXTERNAL_MODEL_PACKAGE: str = ""
     MAX_JOBS: str | None = None
     NVCC_THREADS: str | None = None
@@ -219,11 +218,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "SGLANG_DIFFUSION_WORKER_MULTIPROC_METHOD": _lazy_str(
         "SGLANG_DIFFUSION_WORKER_MULTIPROC_METHOD", "fork"
     ),
-    # Internal per-worker platform override used by disaggregated role launch.
-    # Empty means normal platform auto-detection.
-    "SGLANG_DIFFUSION_PLATFORM_OVERRIDE": _lazy_str(
-        "SGLANG_DIFFUSION_PLATFORM_OVERRIDE", ""
-    ),
+    # NOTE: the diffusion plugin selectors (SGLANG_DIFFUSION_PLATFORM,
+    # SGLANG_DIFFUSION_PLUGINS, SGLANG_DIFFUSION_PLATFORM_OVERRIDE) live in
+    # sglang.srt.environ, next to their SRT counterparts: the platform resolver
+    # and the plugin loader must read them without importing this module.
     # Import an installed package that registers out-of-tree diffusion models
     # and pipelines. This is shared with the SRT model plugin mechanism.
     "SGLANG_EXTERNAL_MODEL_PACKAGE": _lazy_str("SGLANG_EXTERNAL_MODEL_PACKAGE", ""),

--- a/python/sglang/multimodal_gen/plugins/__init__.py
+++ b/python/sglang/multimodal_gen/plugins/__init__.py
@@ -1,0 +1,136 @@
+"""
+Plugin framework for sglang-diffusion (``sglang.multimodal_gen``).
+
+Reuses the discovery machinery of :mod:`sglang.srt.plugins` for the diffusion
+engine, with diffusion-specific entry point groups and env vars. Two entry
+point groups are supported:
+
+1. Platform plugins (``sglang.multimodal_gen.platforms``): a callable
+   ``activate() -> str | None`` returning the qualname of a
+   :class:`sglang.multimodal_gen.runtime.platforms.interface.Platform`
+   subclass, or ``None`` when the hardware is not present.
+2. General plugins (``sglang.multimodal_gen.plugins``): a callable
+   ``register() -> None`` that registers hooks on the shared
+   :class:`sglang.srt.plugins.hook_registry.HookRegistry`.
+
+Selection env vars:
+- ``SGLANG_DIFFUSION_PLATFORM``: platform plugin (entry point) name.
+- ``SGLANG_DIFFUSION_PLUGINS``: comma-separated plugin name whitelist.
+
+NOTE: this module must not import anything from
+``sglang.multimodal_gen.runtime`` at module scope. It is loaded from the
+package ``__init__`` before any hook is applied, and pulling in the runtime
+here would resolve ``current_platform`` too early.
+
+PLUGIN AUTHORS - partial initialization constraint: ``load_diffusion_plugins()``
+runs from ``sglang/multimodal_gen/__init__.py`` *before* ``PipelineConfig``,
+``SamplingParams`` and ``DiffGenerator`` are bound on the package. A
+``register()`` body must therefore not do
+``from sglang.multimodal_gen import <top-level name>``: it raises ImportError,
+which this loader swallows into a log line, silently disabling the plugin.
+Register hooks by dotted-string target instead; importing *submodules*
+(``sglang.multimodal_gen.configs.sample``, ...) is fine.
+"""
+
+import logging
+from collections.abc import Callable
+from typing import Any
+
+from sglang.srt.environ import envs
+from sglang.srt.plugins import excluded_dists_for, load_plugins_by_group
+from sglang.srt.plugins.hook_registry import (
+    HookRegistry,
+    HookSource,
+    _current_plugin_source,
+)
+
+logger = logging.getLogger(__name__)
+
+# Entry point group names
+DIFFUSION_PLATFORM_PLUGINS_GROUP = "sglang.multimodal_gen.platforms"
+DIFFUSION_GENERAL_PLUGINS_GROUP = "sglang.multimodal_gen.plugins"
+
+# Guard against multiple loads in the same process
+_plugins_loaded = False
+
+
+def discover_diffusion_plugins(
+    group: str,
+    excluded_dists: set[str] | None = None,
+) -> dict[str, tuple[Callable[[], Any], str | None]]:
+    """
+    Discover and import diffusion plugins registered under ``group``.
+
+    Delegates to :func:`sglang.srt.plugins.load_plugins_by_group` with the
+    diffusion whitelist env var, so both engines share one discovery
+    implementation.
+    """
+    return load_plugins_by_group(
+        group,
+        excluded_dists=excluded_dists,
+        whitelist_env=envs.SGLANG_DIFFUSION_PLUGINS,
+    )
+
+
+def _get_excluded_dists() -> set[str]:
+    """Dist names to skip when ``SGLANG_DIFFUSION_PLATFORM`` is set.
+
+    Returns dist names that provide a diffusion platform plugin but are NOT
+    the one selected by ``SGLANG_DIFFUSION_PLATFORM``. This prevents
+    unselected platform packages from registering hooks that pull their
+    hardware dependencies.
+    """
+    return excluded_dists_for(
+        DIFFUSION_PLATFORM_PLUGINS_GROUP,
+        envs.SGLANG_DIFFUSION_PLATFORM.get(),
+    )
+
+
+def load_diffusion_plugins() -> None:
+    """
+    Load and execute all diffusion general plugins, then apply their hooks.
+
+    Idempotent - safe to call multiple times. Plugins are functions whose side
+    effects (registering hooks, replacing classes, etc.) are the desired
+    behavior; return values are ignored.
+
+    This is called from ``sglang/multimodal_gen/__init__.py`` so that it runs
+    in every diffusion process, including spawned workers.
+    """
+    global _plugins_loaded
+    if _plugins_loaded:
+        return
+    _plugins_loaded = True
+
+    plugins: dict[str, tuple[Callable[[], Any], str | None]] = {}
+    try:
+        plugins = discover_diffusion_plugins(
+            DIFFUSION_GENERAL_PLUGINS_GROUP,
+            excluded_dists=_get_excluded_dists(),
+        )
+    except Exception:
+        # This runs from ``sglang/multimodal_gen/__init__.py``, so letting a
+        # discovery error escape would make ``import sglang.multimodal_gen``
+        # fail outright (e.g. a malformed third-party ``*.dist-info`` breaking
+        # ``importlib.metadata.entry_points()``).
+        logger.exception(
+            "Diffusion plugin discovery failed; continuing without plugins"
+        )
+
+    for name, (func, dist_name) in plugins.items():
+        source = HookSource(plugin_name=name, dist_name=dist_name)
+        token = _current_plugin_source.set(source)
+        try:
+            func()
+            logger.info("Executed diffusion plugin: %s", name)
+        except Exception:
+            logger.exception("Failed to execute diffusion plugin: %s", name)
+        finally:
+            _current_plugin_source.reset(token)
+
+    # Apply all registered hooks. HookRegistry is process-global and shared
+    # with sglang.srt.plugins: its ``_patched`` set spans both loaders, so a
+    # target already patched by whichever loader ran first is skipped here
+    # (apply_hooks logs a warning naming the dropped hook sources). Hooks
+    # registered on targets nobody patched yet are applied normally.
+    HookRegistry.apply_hooks()

--- a/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/group_coordinator.py
@@ -8,6 +8,7 @@
 # Copyright 2023 The vLLM team.
 # Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
 import pickle
+import pkgutil
 from collections import namedtuple
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass
@@ -50,6 +51,35 @@ def get_local_torch_device() -> torch.device:
     """Return the torch device for the current rank."""
 
     return current_platform.get_local_torch_device()
+
+
+def _resolve_device_communicator_cls() -> type[DeviceCommunicatorBase]:
+    """Pick the device communicator class for the active platform.
+
+    Out-of-tree platforms are asked for their own class through
+    ``Platform.get_device_communicator_cls()``; in-tree platforms keep the
+    existing CUDA-alike / CPU split (MPS included, whose base-class default
+    must not be used).
+    """
+    if current_platform.is_cuda_alike():
+        from sglang.multimodal_gen.runtime.distributed.device_communicators.cuda_communicator import (
+            CudaCommunicator,
+        )
+
+        return CudaCommunicator
+
+    if current_platform.is_out_of_tree():
+        qualname = current_platform.get_device_communicator_cls()
+        cls = pkgutil.resolve_name(qualname)
+        if not isinstance(cls, type) or not issubclass(cls, DeviceCommunicatorBase):
+            raise TypeError(
+                f"Expected a DeviceCommunicatorBase subclass, got {type(cls)}: "
+                f"{qualname}"
+            )
+        return cls
+
+    # For MPS and CPU, use the CPU communicator
+    return CpuCommunicator
 
 
 def _get_unique_name(name: str) -> str:
@@ -204,25 +234,13 @@ class GroupCoordinator:
         self.device_communicator: DeviceCommunicatorBase = None  # type: ignore
         if use_device_communicator and self.world_size > 1:
             # Platform-aware device communicator selection
-            if current_platform.is_cuda_alike():
-                from sglang.multimodal_gen.runtime.distributed.device_communicators.cuda_communicator import (
-                    CudaCommunicator,
-                )
-
-                self.device_communicator = CudaCommunicator(
-                    cpu_group=self.cpu_group,
-                    device=self.device,
-                    device_group=self.device_group,
-                    unique_name=self.unique_name,
-                )
-            else:
-                # For MPS and CPU, use the CPU communicator
-                self.device_communicator = CpuCommunicator(
-                    cpu_group=self.cpu_group,
-                    device=self.device,
-                    device_group=self.device_group,
-                    unique_name=self.unique_name,
-                )
+            communicator_cls = _resolve_device_communicator_cls()
+            self.device_communicator = communicator_cls(
+                cpu_group=self.cpu_group,
+                device=self.device,
+                device_group=self.device_group,
+                unique_name=self.unique_name,
+            )
 
         self.mq_broadcaster = None
         self.srt_custom_allreduce = None

--- a/python/sglang/multimodal_gen/runtime/layers/custom_op.py
+++ b/python/sglang/multimodal_gen/runtime/layers/custom_op.py
@@ -71,6 +71,11 @@ class CustomOp(nn.Module):
     def dispatch_forward(self) -> Callable:
         if _is_cuda:
             return self.forward_cuda
+        # Out-of-tree platforms are checked before the in-tree predicates: a
+        # vendor torch build can expose torch.xpu / torch.npu and report them
+        # available, so those branches would otherwise steal the dispatch.
+        elif current_platform.is_out_of_tree():
+            return self.forward_oot
         elif current_platform.is_hip():
             return self.forward_hip
         elif current_platform.is_npu():

--- a/python/sglang/multimodal_gen/runtime/platforms/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/__init__.py
@@ -3,8 +3,14 @@
 # SPDX-License-Identifier: Apache-2.0
 # Adapted from vllm: https://github.com/vllm-project/vllm/blob/v0.7.3/vllm/platforms/__init__.py
 
-import os
+import pkgutil
 import traceback
+from importlib.metadata import entry_points
+
+from sglang.multimodal_gen.plugins import (
+    DIFFUSION_PLATFORM_PLUGINS_GROUP,
+    discover_diffusion_plugins,
+)
 
 # imported by other files, do not remove
 from sglang.multimodal_gen.runtime.platforms.interface import (  # noqa: F401
@@ -13,9 +19,19 @@ from sglang.multimodal_gen.runtime.platforms.interface import (  # noqa: F401
     PlatformEnum,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import resolve_obj_by_qualname
+from sglang.srt.environ import envs
 
 logger = init_logger(__name__)
+
+_BUILTIN_PLATFORM_QUALNAMES = {
+    "cpu": "sglang.multimodal_gen.runtime.platforms.cpu.CpuPlatform",
+    "cuda": "sglang.multimodal_gen.runtime.platforms.cuda.CudaPlatform",
+    "rocm": "sglang.multimodal_gen.runtime.platforms.rocm.RocmPlatform",
+    "mps": "sglang.multimodal_gen.runtime.platforms.mps.MpsPlatform",
+    "npu": "sglang.multimodal_gen.runtime.platforms.npu.NPUPlatformBase",
+    "musa": "sglang.multimodal_gen.runtime.platforms.musa.MusaPlatform",
+    "xpu": "sglang.multimodal_gen.runtime.platforms.xpu.XpuPlatform",
+}
 
 
 def cuda_platform_plugin() -> str | None:
@@ -192,25 +208,38 @@ builtin_platform_plugins = {
 
 
 def resolve_current_platform_cls_qualname() -> str:
-    forced_platform = os.environ.get("SGLANG_DIFFUSION_PLATFORM_OVERRIDE", "").strip()
-    if forced_platform:
-        forced_map = {
-            "cpu": "sglang.multimodal_gen.runtime.platforms.cpu.CpuPlatform",
-            "cuda": "sglang.multimodal_gen.runtime.platforms.cuda.CudaPlatform",
-            "rocm": "sglang.multimodal_gen.runtime.platforms.rocm.RocmPlatform",
-            "mps": "sglang.multimodal_gen.runtime.platforms.mps.MpsPlatform",
-            "npu": "sglang.multimodal_gen.runtime.platforms.npu.NPUPlatformBase",
-            "musa": "sglang.multimodal_gen.runtime.platforms.musa.MusaPlatform",
-        }
-        qualname = forced_map.get(forced_platform.lower())
-        if qualname is None:
-            raise ValueError(
-                f"Unsupported SGLANG_DIFFUSION_PLATFORM_OVERRIDE={forced_platform!r}"
-            )
-        return qualname
+    """Resolve the qualname of the platform class to instantiate.
 
-    # TODO(will): if we need to support other platforms, we should consider if
-    # vLLM's plugin architecture is suitable for our needs.
+    Resolution order:
+
+    1. ``SGLANG_DIFFUSION_PLATFORM_OVERRIDE`` — a built-in short name
+       (``cpu``, ``cuda``, ...) or an explicit ``module.Class`` /
+       ``module:Class`` qualname. Bypasses detection and plugins entirely.
+    2. ``SGLANG_DIFFUSION_PLATFORM`` set — front-loading filter over the
+       ``sglang.multimodal_gen.platforms`` entry point group: only the named
+       plugin is imported and activated. Name not found, or ``activate()``
+       returning None, is an error.
+    3. ``SGLANG_DIFFUSION_PLATFORM`` unset — import and activate every
+       discovered plugin. Exactly one activated wins, several is an error, none
+       falls through to the built-in detection chain below.
+    """
+    forced_platform = envs.SGLANG_DIFFUSION_PLATFORM_OVERRIDE.get().strip()
+    if forced_platform:
+        qualname = _BUILTIN_PLATFORM_QUALNAMES.get(forced_platform.lower())
+        if qualname is not None:
+            return qualname
+        # Not a short name: accept an explicit out-of-tree platform qualname.
+        if "." in forced_platform or ":" in forced_platform:
+            return forced_platform
+        raise ValueError(
+            f"Unsupported SGLANG_DIFFUSION_PLATFORM_OVERRIDE={forced_platform!r}. "
+            f"Use one of {sorted(_BUILTIN_PLATFORM_QUALNAMES)} or a "
+            f"'module.Class' qualname."
+        )
+
+    platform_cls_qualname = _resolve_platform_plugin_qualname()
+    if platform_cls_qualname is not None:
+        return platform_cls_qualname
 
     # Try MPS first on macOS
     platform_cls_qualname = mps_platform_plugin()
@@ -250,6 +279,79 @@ def resolve_current_platform_cls_qualname() -> str:
     raise RuntimeError("No platform plugin found. Please check your " "installation.")
 
 
+def _resolve_platform_plugin_qualname() -> str | None:
+    """Resolve an out-of-tree platform from the entry point group.
+
+    Returns None when no plugin claims the machine, so the caller can fall back
+    to the built-in detection chain.
+    """
+    selected = envs.SGLANG_DIFFUSION_PLATFORM.get().strip()
+
+    if selected:
+        # Front-loading filter: only the selected plugin is imported, so the
+        # other vendors' modules never pull their hardware dependencies.
+        ep_map = {
+            ep.name: ep for ep in entry_points(group=DIFFUSION_PLATFORM_PLUGINS_GROUP)
+        }
+        if selected not in ep_map:
+            available = ", ".join(f"'{name}'" for name in ep_map) if ep_map else "none"
+            raise RuntimeError(
+                f"SGLANG_DIFFUSION_PLATFORM={selected!r} not found in discovered "
+                f"diffusion platform plugins (available: {available}). Install the "
+                f"plugin with 'pip install -e' to register its entry_points."
+            )
+        try:
+            result = ep_map[selected].load()()
+        except Exception as e:
+            logger.exception(
+                "Failed to activate diffusion platform plugin: %s", selected
+            )
+            raise RuntimeError(
+                f"Diffusion platform plugin {selected!r} failed to activate: {e}"
+            ) from e
+        if result is None:
+            raise RuntimeError(
+                f"Diffusion platform plugin {selected!r} is installed but activate() "
+                f"returned None (hardware not available on this machine?)."
+            )
+        logger.info("OOT diffusion platform activated: %s -> %s", selected, result)
+        return result
+
+    # Auto-discover: activate every plugin and expect at most one to claim the
+    # machine. An activation error only disables that plugin.
+    activated: dict[str, str] = {}
+    for name, (activate, _dist) in discover_diffusion_plugins(
+        DIFFUSION_PLATFORM_PLUGINS_GROUP
+    ).items():
+        try:
+            result = activate()
+        except Exception:
+            logger.exception("Failed to activate diffusion platform plugin: %s", name)
+            continue
+        if result is not None:
+            activated[name] = result
+            logger.info("OOT diffusion platform activated: %s -> %s", name, result)
+
+    if not activated:
+        return None
+    if len(activated) == 1:
+        return next(iter(activated.values()))
+
+    names_str = ", ".join(f"'{name}'" for name in activated)
+    raise RuntimeError(
+        f"Multiple diffusion platform plugins activated: {names_str}. "
+        f"Set SGLANG_DIFFUSION_PLATFORM to select one."
+    )
+
+
+def _load_platform_class(qualname: str) -> type[Platform]:
+    """Load a Platform subclass from ``module.Class`` or ``module:Class``."""
+    cls = pkgutil.resolve_name(qualname)
+    if not isinstance(cls, type) or not issubclass(cls, Platform):
+        raise TypeError(f"Expected a Platform subclass, got {type(cls)}: {qualname}")
+    return cls
+
+
 _current_platform: Platform | None = None
 _init_trace: str = ""
 
@@ -266,7 +368,7 @@ def __getattr__(name: str):
         global _current_platform
         if _current_platform is None:
             platform_cls_qualname = resolve_current_platform_cls_qualname()
-            _current_platform = resolve_obj_by_qualname(platform_cls_qualname)()
+            _current_platform = _load_platform_class(platform_cls_qualname)()
             global _init_trace
             _init_trace = "".join(traceback.format_stack())
         return _current_platform

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_plugins.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_plugins.py
@@ -1,0 +1,372 @@
+"""
+Unit tests for the sglang-diffusion plugin framework.
+
+Run:
+  python -m pytest python/sglang/multimodal_gen/test/unit/test_diffusion_plugins.py -v
+"""
+
+import ast
+import contextlib
+import os
+import pathlib
+import subprocess
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import MagicMock, patch
+
+import sglang
+import sglang.multimodal_gen
+import sglang.multimodal_gen.plugins as diffusion_plugins
+from sglang.multimodal_gen.plugins import (
+    _get_excluded_dists,
+    discover_diffusion_plugins,
+    load_diffusion_plugins,
+)
+from sglang.srt.environ import envs
+from sglang.srt.plugins.hook_registry import (
+    HookRegistry,
+    HookType,
+    _current_plugin_source,
+)
+
+FAKE_TARGET_MODULE = "fake_diffusion_hook_target"
+
+# Discovery lives in sglang.srt.plugins now, so entry_points must be patched
+# where it is actually called.
+SRT_ENTRY_POINTS = "sglang.srt.plugins.entry_points"
+
+
+def _make_ep(name, dist_name=None, load_fn=None, load_raises=False):
+    """Build a mock importlib.metadata.EntryPoint."""
+    ep = MagicMock()
+    ep.name = name
+    ep.value = f"fake_module:{name}"
+    ep.dist = MagicMock()
+    ep.dist.name = dist_name or f"{name}-dist"
+    if load_raises:
+        ep.load.side_effect = RuntimeError("boom on load")
+    else:
+        ep.load.return_value = load_fn if load_fn is not None else MagicMock()
+    return ep
+
+
+class _DiffusionPluginTestCase(unittest.TestCase):
+    """Shared setup: env overrides, plugin-load flag and registry isolation."""
+
+    def setUp(self):
+        self._stack = contextlib.ExitStack()
+        self.addCleanup(self._stack.close)
+
+        # Save/restore the process-global registry contents instead of
+        # resetting it: a real installed plugin may own entries here.
+        saved_hooks = {
+            target: list(hooks) for target, hooks in HookRegistry._hooks.items()
+        }
+        saved_patched = set(HookRegistry._patched)
+        saved_applied = dict(HookRegistry._applied)
+        self.addCleanup(
+            self._restore_registry, saved_hooks, saved_patched, saved_applied
+        )
+        HookRegistry._hooks.clear()
+        HookRegistry._patched.clear()
+        HookRegistry._applied.clear()
+
+        diffusion_plugins._plugins_loaded = False
+        self.addCleanup(setattr, diffusion_plugins, "_plugins_loaded", False)
+
+    @staticmethod
+    def _restore_registry(saved_hooks, saved_patched, saved_applied):
+        HookRegistry._hooks.clear()
+        HookRegistry._hooks.update(saved_hooks)
+        HookRegistry._patched.clear()
+        HookRegistry._patched.update(saved_patched)
+        HookRegistry._applied.clear()
+        HookRegistry._applied.update(saved_applied)
+
+    def set_envs(self, platform="", plugins=""):
+        """Override the real diffusion env descriptors for this test."""
+        self._stack.enter_context(envs.SGLANG_DIFFUSION_PLATFORM.override(platform))
+        self._stack.enter_context(envs.SGLANG_DIFFUSION_PLUGINS.override(plugins))
+
+
+class TestDiffusionPluginLoading(_DiffusionPluginTestCase):
+    def tearDown(self):
+        sys.modules.pop(FAKE_TARGET_MODULE, None)
+
+    def test_load_is_idempotent_and_applies_hooks(self):
+        self.set_envs()
+        with patch(SRT_ENTRY_POINTS, return_value=[]), patch(
+            "sglang.multimodal_gen.plugins.HookRegistry"
+        ) as mock_registry:
+            load_diffusion_plugins()
+            self.assertEqual(mock_registry.apply_hooks.call_count, 1)
+            load_diffusion_plugins()
+            self.assertEqual(mock_registry.apply_hooks.call_count, 1)
+
+    def test_plugin_exception_is_isolated(self):
+        calls = []
+
+        def bad():
+            calls.append("bad")
+            raise RuntimeError("plugin blew up")
+
+        def good():
+            calls.append("good")
+
+        eps = [_make_ep("bad", load_fn=bad), _make_ep("good", load_fn=good)]
+        self.set_envs()
+        with patch(SRT_ENTRY_POINTS, return_value=eps), patch(
+            "sglang.multimodal_gen.plugins.HookRegistry"
+        ):
+            load_diffusion_plugins()
+
+        self.assertEqual(calls, ["bad", "good"])
+
+    def test_plugin_source_contextvar_is_reset(self):
+        eps = [_make_ep("noop", load_fn=lambda: None)]
+        self.set_envs()
+        with patch(SRT_ENTRY_POINTS, return_value=eps), patch(
+            "sglang.multimodal_gen.plugins.HookRegistry"
+        ):
+            load_diffusion_plugins()
+
+        self.assertIsNone(_current_plugin_source.get())
+
+    def test_whitelist_filters_by_entry_point_name(self):
+        eps = [_make_ep("a"), _make_ep("b")]
+        self.set_envs(plugins="b")
+        with patch(SRT_ENTRY_POINTS, return_value=eps):
+            found = discover_diffusion_plugins("any.group")
+
+        self.assertEqual(list(found), ["b"])
+
+    def test_srt_whitelist_does_not_filter_diffusion_plugins(self):
+        """SGLANG_PLUGINS must not gate the diffusion group."""
+        eps = [_make_ep("a"), _make_ep("b")]
+        self.set_envs()
+        self._stack.enter_context(envs.SGLANG_PLUGINS.override("b"))
+        with patch(SRT_ENTRY_POINTS, return_value=eps):
+            found = discover_diffusion_plugins("any.group")
+
+        self.assertEqual(sorted(found), ["a", "b"])
+
+    def test_excluded_dist_is_never_loaded(self):
+        ep_a = _make_ep("a", dist_name="a-dist")
+        ep_b = _make_ep("b", dist_name="b-dist")
+        self.set_envs()
+        with patch(SRT_ENTRY_POINTS, return_value=[ep_a, ep_b]):
+            found = discover_diffusion_plugins("any.group", excluded_dists={"a-dist"})
+
+        self.assertEqual(list(found), ["b"])
+        ep_a.load.assert_not_called()
+        ep_b.load.assert_called_once()
+
+    def test_entry_point_load_failure_is_isolated(self):
+        ep_bad = _make_ep("bad", load_raises=True)
+        ep_ok = _make_ep("ok")
+        self.set_envs()
+        with patch(SRT_ENTRY_POINTS, return_value=[ep_bad, ep_ok]):
+            found = discover_diffusion_plugins("any.group")
+
+        self.assertEqual(list(found), ["ok"])
+
+    def test_get_excluded_dists_returns_other_platform_dists(self):
+        eps = [
+            _make_ep("klx", dist_name="klx-dist"),
+            _make_ep("other", dist_name="other-dist"),
+        ]
+        self.set_envs(platform="klx")
+        with patch(SRT_ENTRY_POINTS, return_value=eps):
+            self.assertEqual(_get_excluded_dists(), {"other-dist"})
+
+    def test_get_excluded_dists_empty_when_platform_unset(self):
+        self.set_envs(platform="")
+        with patch(SRT_ENTRY_POINTS) as mock_eps:
+            self.assertEqual(_get_excluded_dists(), set())
+            mock_eps.assert_not_called()
+
+    def test_discovery_failure_does_not_break_import(self):
+        """Discovery is called from the package __init__: it must never raise."""
+        self.set_envs()
+        with patch(
+            "sglang.multimodal_gen.plugins.discover_diffusion_plugins",
+            side_effect=RuntimeError("entry_points blew up"),
+        ), patch("sglang.multimodal_gen.plugins.HookRegistry") as mock_registry:
+            with self.assertLogs("sglang.multimodal_gen.plugins", level="ERROR") as cm:
+                load_diffusion_plugins()
+
+        self.assertTrue(any("discovery failed" in msg for msg in cm.output))
+        self.assertEqual(mock_registry.apply_hooks.call_count, 1)
+
+    def test_registered_hook_is_actually_applied(self):
+        target_mod = types.ModuleType(FAKE_TARGET_MODULE)
+
+        def double(x):
+            return x * 2
+
+        target_mod.double = double
+        sys.modules[FAKE_TARGET_MODULE] = target_mod
+
+        def plugin():
+            def around(original_fn, *args, **kwargs):
+                return original_fn(*args, **kwargs) + 1
+
+            HookRegistry.register(
+                f"{FAKE_TARGET_MODULE}.double", around, HookType.AROUND
+            )
+
+        eps = [_make_ep("hooky", load_fn=plugin)]
+        self.set_envs()
+        with patch(SRT_ENTRY_POINTS, return_value=eps):
+            load_diffusion_plugins()
+
+        self.assertEqual(target_mod.double(3), 7)
+
+
+class TestPackageLoadPoint(unittest.TestCase):
+    """The package __init__ must load plugins before importing the runtime."""
+
+    def _package_dir(self) -> pathlib.Path:
+        return pathlib.Path(sglang.multimodal_gen.__file__).parent
+
+    def test_load_call_precedes_other_diffusion_imports(self):
+        tree = ast.parse((self._package_dir() / "__init__.py").read_text())
+        call_index = None
+        first_other_import_index = None
+        for index, node in enumerate(tree.body):
+            if (
+                isinstance(node, ast.Expr)
+                and isinstance(node.value, ast.Call)
+                and getattr(node.value.func, "id", None) == "load_diffusion_plugins"
+            ):
+                call_index = index
+            elif isinstance(node, ast.ImportFrom):
+                module = node.module or ""
+                if (
+                    module.startswith("sglang.multimodal_gen")
+                    and module != "sglang.multimodal_gen.plugins"
+                    and first_other_import_index is None
+                ):
+                    first_other_import_index = index
+        self.assertIsNotNone(call_index, "load_diffusion_plugins() call not found")
+        self.assertIsNotNone(
+            first_other_import_index, "no other sglang.multimodal_gen import found"
+        )
+        self.assertLess(call_index, first_other_import_index)
+
+    def test_plugins_module_does_not_import_runtime_at_module_scope(self):
+        tree = ast.parse((self._package_dir() / "plugins" / "__init__.py").read_text())
+        imported: list[str] = []
+        for node in tree.body:
+            if isinstance(node, ast.Import):
+                imported.extend(alias.name for alias in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                imported.append(node.module or "")
+        for name in imported:
+            self.assertFalse(
+                name.startswith("sglang.multimodal_gen.runtime"),
+                f"plugins module must not import {name} at module scope",
+            )
+
+
+PLUGIN_MODULE_NAME = "fake_diffusion_plugin_pkg"
+PLUGIN_MODULE_TEMPLATE = '''\
+"""Throwaway diffusion plugin used by the fresh-process test."""
+
+import pathlib
+
+MARKER = pathlib.Path({marker!r})
+
+
+def target():
+    return "original"
+
+
+def _after(result, *args, **kwargs):
+    return result + "+hooked"
+
+
+def register():
+    from sglang.srt.plugins.hook_registry import HookRegistry, HookType
+
+    HookRegistry.register("{module}.target", _after, HookType.AFTER)
+    MARKER.write_text("register-ran")
+'''
+
+CHILD_CODE = """\
+import sys
+
+import sglang.multimodal_gen  # noqa: F401  (the only trigger)
+import sglang.multimodal_gen.plugins as p
+
+assert p._plugins_loaded, "package __init__ did not load plugins"
+assert "{module}" in sys.modules, "plugin module was never imported by the loader"
+
+import {module}
+
+print("HOOK_RESULT:" + {module}.target())
+"""
+
+
+class TestFreshProcessPluginLoading(unittest.TestCase):
+    """A brand-new interpreter must discover, run and APPLY plugin hooks.
+
+    The plugin is materialized as a throwaway installed-looking distribution
+    (module file + ``*.dist-info`` with ``entry_points.txt``) in a temp dir put
+    first on the child's PYTHONPATH, so importlib.metadata discovers it. The
+    parent never imports that module (asserted below), so both the marker file
+    and the hooked return value can only come from the child.
+    """
+
+    def _write_plugin_dist(self, root: pathlib.Path, marker: pathlib.Path) -> None:
+        (root / f"{PLUGIN_MODULE_NAME}.py").write_text(
+            PLUGIN_MODULE_TEMPLATE.format(marker=str(marker), module=PLUGIN_MODULE_NAME)
+        )
+        dist_info = root / "fake_diffusion_plugin-0.0.1.dist-info"
+        dist_info.mkdir()
+        (dist_info / "METADATA").write_text(
+            "Metadata-Version: 2.1\nName: fake-diffusion-plugin\nVersion: 0.0.1\n"
+        )
+        (dist_info / "entry_points.txt").write_text(
+            f"[{diffusion_plugins.DIFFUSION_GENERAL_PLUGINS_GROUP}]\n"
+            f"fake_diffusion = {PLUGIN_MODULE_NAME}:register\n"
+        )
+
+    def test_importing_package_loads_and_applies_plugins_in_a_fresh_process(self):
+        repo_python = pathlib.Path(sglang.__file__).parents[1]
+        self.assertNotIn(
+            PLUGIN_MODULE_NAME, sys.modules, "parent must not know the fake plugin"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = pathlib.Path(tmp)
+            marker = tmp_path / "register_ran.txt"
+            self._write_plugin_dist(tmp_path, marker)
+            self.assertFalse(marker.exists())
+
+            env = dict(os.environ)
+            env["PYTHONPATH"] = os.pathsep.join(
+                [str(tmp_path), str(repo_python), env.get("PYTHONPATH", "")]
+            ).strip(os.pathsep)
+            # Do not let an inherited whitelist filter the fake plugin out.
+            env["SGLANG_DIFFUSION_PLUGINS"] = ""
+            env["SGLANG_DIFFUSION_PLATFORM"] = ""
+            proc = subprocess.run(
+                [sys.executable, "-c", CHILD_CODE.format(module=PLUGIN_MODULE_NAME)],
+                capture_output=True,
+                text=True,
+                timeout=300,
+                env=env,
+            )
+
+            self.assertEqual(proc.returncode, 0, msg=proc.stderr[-3000:])
+            # register() ran inside the child ...
+            self.assertTrue(marker.exists(), msg=proc.stderr[-3000:])
+            self.assertEqual(marker.read_text(), "register-ran")
+            # ... and its hook was actually APPLIED, not merely registered.
+            self.assertIn("HOOK_RESULT:original+hooked", proc.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_oot_platform.py
+++ b/python/sglang/multimodal_gen/test/unit/test_oot_platform.py
@@ -1,0 +1,384 @@
+"""
+Unit tests for out-of-tree (OOT) diffusion platform discovery.
+
+Run:
+  python -m pytest python/sglang/multimodal_gen/test/unit/test_oot_platform.py -v
+
+NOTE: never import sglang.multimodal_gen.runtime.platforms.cuda here - it runs
+NVML at import time and crashes on non-NVIDIA machines. The same holds for the
+cuda device communicator.
+"""
+
+import contextlib
+import os
+import unittest
+from unittest.mock import MagicMock, patch
+
+from sglang.multimodal_gen.runtime import platforms as platforms_mod
+from sglang.multimodal_gen.runtime.distributed.device_communicators.base_device_communicator import (
+    DeviceCommunicatorBase,
+)
+from sglang.multimodal_gen.runtime.platforms.interface import Platform, PlatformEnum
+from sglang.srt.environ import envs
+
+CPU_QUALNAME = "sglang.multimodal_gen.runtime.platforms.cpu.CpuPlatform"
+XPU_QUALNAME = "sglang.multimodal_gen.runtime.platforms.xpu.XpuPlatform"
+PLATFORMS = "sglang.multimodal_gen.runtime.platforms"
+
+
+class FakeOOTPlatform(Platform):
+    _enum = PlatformEnum.OOT
+    device_name = "fake_oot"
+    device_type = "fake_oot"
+    dispatch_key = "CPU"
+
+
+FAKE_OOT_QUALNAME = f"{__name__}.FakeOOTPlatform"
+
+
+def _override(value: str):
+    """Patch SGLANG_DIFFUSION_PLATFORM_OVERRIDE ('' means unset).
+
+    Deliberately patches os.environ directly rather than using
+    ``EnvField.override``: this pins that the descriptor reads os.environ at
+    call time, so plain env patching keeps working after the switch from
+    ``os.environ.get`` to ``envs.SGLANG_DIFFUSION_PLATFORM_OVERRIDE.get()``.
+    """
+    return patch.dict(
+        os.environ, {"SGLANG_DIFFUSION_PLATFORM_OVERRIDE": value}, clear=False
+    )
+
+
+def _make_platform_ep(name, activate_result=None, raises=False):
+    ep = MagicMock()
+    ep.name = name
+    ep.dist = MagicMock()
+    ep.dist.name = f"{name}-dist"
+
+    def activate():
+        if raises:
+            raise RuntimeError("activate blew up")
+        return activate_result
+
+    ep.load.return_value = activate
+    return ep
+
+
+class _PlatformTestBase(unittest.TestCase):
+    """Saves/restores the lazily-initialized platform singleton.
+
+    Required because an installed OOT plugin may pre-seed _current_platform in
+    this environment.
+    """
+
+    def setUp(self):
+        self._saved_platform = platforms_mod._current_platform
+        platforms_mod._current_platform = None
+        self._stack = contextlib.ExitStack()
+        self.addCleanup(self._stack.close)
+
+    def tearDown(self):
+        platforms_mod._current_platform = self._saved_platform
+
+    def select_platform(self, name: str) -> None:
+        """Set SGLANG_DIFFUSION_PLATFORM for the duration of the test."""
+        self._stack.enter_context(envs.SGLANG_DIFFUSION_PLATFORM.override(name))
+
+    def resolve(self) -> str:
+        return platforms_mod.resolve_current_platform_cls_qualname()
+
+
+class TestOverrideEnvVar(_PlatformTestBase):
+    def test_short_name_cpu(self):
+        with _override("cpu"):
+            self.assertEqual(self.resolve(), CPU_QUALNAME)
+
+    def test_short_name_xpu_is_supported(self):
+        with _override("xpu"):
+            self.assertEqual(self.resolve(), XPU_QUALNAME)
+
+    def test_dotted_value_is_taken_as_qualname(self):
+        with _override(FAKE_OOT_QUALNAME):
+            self.assertEqual(self.resolve(), FAKE_OOT_QUALNAME)
+
+    def test_unknown_short_name_raises_value_error(self):
+        with _override("nosuchplatform"):
+            with self.assertRaises(ValueError):
+                self.resolve()
+
+    def test_env_descriptor_reads_os_environ(self):
+        with _override("cpu"):
+            self.assertEqual(envs.SGLANG_DIFFUSION_PLATFORM_OVERRIDE.get(), "cpu")
+
+
+class TestSelectedPlatformPlugin(_PlatformTestBase):
+    def test_selected_plugin_is_used(self):
+        ep = _make_platform_ep("fakeoot", activate_result=FAKE_OOT_QUALNAME)
+        self.select_platform("fakeoot")
+        with _override(""), patch(f"{PLATFORMS}.entry_points", return_value=[ep]):
+            self.assertEqual(self.resolve(), FAKE_OOT_QUALNAME)
+
+    def test_selected_plugin_not_installed_raises(self):
+        ep = _make_platform_ep("other", activate_result=FAKE_OOT_QUALNAME)
+        self.select_platform("missing")
+        with _override(""), patch(f"{PLATFORMS}.entry_points", return_value=[ep]):
+            with self.assertRaises(RuntimeError) as ctx:
+                self.resolve()
+        self.assertIn("'other'", str(ctx.exception))
+
+    def test_selected_plugin_returning_none_raises(self):
+        ep = _make_platform_ep("fakeoot", activate_result=None)
+        self.select_platform("fakeoot")
+        with _override(""), patch(f"{PLATFORMS}.entry_points", return_value=[ep]):
+            with self.assertRaises(RuntimeError):
+                self.resolve()
+
+    def test_unselected_plugin_is_never_loaded(self):
+        """Level-2 front-loading filter: only the selected ep is imported."""
+        selected = _make_platform_ep("fakeoot", activate_result=FAKE_OOT_QUALNAME)
+        unselected = _make_platform_ep("otheroot", activate_result=CPU_QUALNAME)
+        self.select_platform("fakeoot")
+        with _override(""), patch(
+            f"{PLATFORMS}.entry_points", return_value=[selected, unselected]
+        ):
+            self.assertEqual(self.resolve(), FAKE_OOT_QUALNAME)
+        selected.load.assert_called_once()
+        unselected.load.assert_not_called()
+
+    def test_selected_plugin_activate_raising_is_logged_and_reraised(self):
+        ep = _make_platform_ep("fakeoot", raises=True)
+        self.select_platform("fakeoot")
+        with _override(""), patch(f"{PLATFORMS}.entry_points", return_value=[ep]):
+            with self.assertLogs(PLATFORMS, level="ERROR") as cm:
+                with self.assertRaises(RuntimeError) as ctx:
+                    self.resolve()
+        self.assertIn("activate blew up", str(ctx.exception))
+        self.assertTrue(any("fakeoot" in msg for msg in cm.output))
+
+
+class TestPlatformAutoDiscovery(_PlatformTestBase):
+    def _run(self, discovered):
+        self.select_platform("")
+        with _override(""), patch(
+            f"{PLATFORMS}.discover_diffusion_plugins", return_value=discovered
+        ):
+            return self.resolve()
+
+    def test_single_activated_plugin_wins(self):
+        discovered = {"fakeoot": (lambda: FAKE_OOT_QUALNAME, "fake-dist")}
+        self.assertEqual(self._run(discovered), FAKE_OOT_QUALNAME)
+
+    def test_multiple_activated_plugins_raise(self):
+        discovered = {
+            "a": (lambda: FAKE_OOT_QUALNAME, "a-dist"),
+            "b": (lambda: CPU_QUALNAME, "b-dist"),
+        }
+        with self.assertRaises(RuntimeError) as ctx:
+            self._run(discovered)
+        self.assertIn("SGLANG_DIFFUSION_PLATFORM", str(ctx.exception))
+
+    def test_activation_error_is_isolated(self):
+        def boom():
+            raise RuntimeError("no hardware")
+
+        discovered = {
+            "bad": (boom, "bad-dist"),
+            "good": (lambda: FAKE_OOT_QUALNAME, "good-dist"),
+        }
+        self.assertEqual(self._run(discovered), FAKE_OOT_QUALNAME)
+
+    def test_no_plugin_falls_back_to_builtin_chain(self):
+        self.select_platform("")
+        with _override(""), patch(
+            f"{PLATFORMS}.discover_diffusion_plugins", return_value={}
+        ), patch(
+            f"{PLATFORMS}.mps_platform_plugin", return_value=None
+        ) as mock_mps, patch(
+            f"{PLATFORMS}.xpu_platform_plugin", return_value=None
+        ), patch(
+            f"{PLATFORMS}.rocm_platform_plugin", return_value=None
+        ), patch(
+            f"{PLATFORMS}.cuda_platform_plugin", return_value=None
+        ), patch(
+            f"{PLATFORMS}.npu_platform_plugin", return_value=None
+        ), patch(
+            f"{PLATFORMS}.musa_platform_plugin", return_value=None
+        ), patch(
+            f"{PLATFORMS}.cpu_platform_plugin", return_value=CPU_QUALNAME
+        ):
+            self.assertEqual(self.resolve(), CPU_QUALNAME)
+            mock_mps.assert_called_once()
+
+
+class TestLoadPlatformClass(_PlatformTestBase):
+    def test_accepts_platform_subclass(self):
+        self.assertIs(
+            platforms_mod._load_platform_class(FAKE_OOT_QUALNAME), FakeOOTPlatform
+        )
+
+    def test_accepts_colon_separated_form(self):
+        module, _, name = FAKE_OOT_QUALNAME.rpartition(".")
+        self.assertIs(
+            platforms_mod._load_platform_class(f"{module}:{name}"), FakeOOTPlatform
+        )
+
+    def test_rejects_non_platform_type(self):
+        with self.assertRaises(TypeError):
+            platforms_mod._load_platform_class("builtins.dict")
+
+    def test_rejects_non_type(self):
+        with self.assertRaises(TypeError):
+            platforms_mod._load_platform_class("os.getcwd")
+
+    def test_rejects_dotless_value(self):
+        with self.assertRaises(TypeError):
+            platforms_mod._load_platform_class("os")
+
+    def test_current_platform_goes_through_load_platform_class(self):
+        with patch.object(
+            platforms_mod,
+            "resolve_current_platform_cls_qualname",
+            return_value=FAKE_OOT_QUALNAME,
+        ):
+            self.assertIsInstance(platforms_mod.current_platform, FakeOOTPlatform)
+
+    def test_current_platform_rejects_non_platform_qualname(self):
+        platforms_mod._current_platform = None
+        with patch.object(
+            platforms_mod,
+            "resolve_current_platform_cls_qualname",
+            return_value="builtins.dict",
+        ):
+            with self.assertRaises(TypeError):
+                platforms_mod.current_platform
+
+
+class FakeCommunicator(DeviceCommunicatorBase):
+    """Stand-in device communicator class for OOT platform tests.
+
+    The base __init__ needs an initialized process group, so it is bypassed;
+    these tests only assert on class identity.
+    """
+
+    def __init__(self, cpu_group=None, device=None, device_group=None, unique_name=""):
+        self.unique_name = unique_name
+
+
+class NotACommunicator:
+    """Resolvable but not a DeviceCommunicatorBase subclass."""
+
+
+class OOTCommPlatform(FakeOOTPlatform):
+    @classmethod
+    def get_device_communicator_cls(cls) -> str:
+        return f"{__name__}.FakeCommunicator"
+
+
+class OOTBadCommPlatform(FakeOOTPlatform):
+    @classmethod
+    def get_device_communicator_cls(cls) -> str:
+        return f"{__name__}.NotACommunicator"
+
+
+class OOTPlatformClaimingEveryDevice(FakeOOTPlatform):
+    """OOT platform that also answers True to the in-tree predicates.
+
+    Pins the mandated dispatch order in CustomOp.dispatch_forward: if the OOT
+    branch were moved after the hip/npu/xpu/musa branches, dispatch would pick
+    one of those instead of forward_oot.
+    """
+
+    def is_hip(self) -> bool:
+        return True
+
+    def is_npu(self) -> bool:
+        return True
+
+    def is_xpu(self) -> bool:
+        return True
+
+    def is_musa(self) -> bool:
+        return True
+
+
+class TestCustomOpOOTDispatch(unittest.TestCase):
+    def test_out_of_tree_platform_dispatches_to_forward_oot(self):
+        from sglang.multimodal_gen.runtime.layers import custom_op as custom_op_mod
+
+        class MyOp(custom_op_mod.CustomOp):
+            def forward_native(self, x):
+                return "native"
+
+            def forward_cuda(self, x):
+                return "cuda"
+
+            def forward_oot(self, x):
+                return "oot"
+
+            def forward_npu(self, x):
+                return "npu"
+
+            def forward_xpu(self, x):
+                return "xpu"
+
+        with patch.object(custom_op_mod, "_is_cuda", False), patch.object(
+            custom_op_mod, "current_platform", OOTPlatformClaimingEveryDevice()
+        ):
+            op = MyOp()
+        self.assertEqual(op(1), "oot")
+
+    def test_cuda_platform_still_dispatches_to_forward_cuda(self):
+        from sglang.multimodal_gen.runtime.layers import custom_op as custom_op_mod
+
+        class MyOp(custom_op_mod.CustomOp):
+            def forward_native(self, x):
+                return "native"
+
+            def forward_cuda(self, x):
+                return "cuda"
+
+        with patch.object(custom_op_mod, "_is_cuda", True):
+            op = MyOp()
+        self.assertEqual(op(1), "cuda")
+
+
+class TestDeviceCommunicatorSelection(unittest.TestCase):
+    def test_out_of_tree_platform_uses_platform_hook(self):
+        from sglang.multimodal_gen.runtime.distributed import group_coordinator as gc
+
+        with patch.object(gc, "current_platform", OOTCommPlatform()):
+            self.assertIs(gc._resolve_device_communicator_cls(), FakeCommunicator)
+
+    def test_out_of_tree_non_communicator_raises(self):
+        from sglang.multimodal_gen.runtime.distributed import group_coordinator as gc
+
+        with patch.object(gc, "current_platform", OOTBadCommPlatform()):
+            with self.assertRaises(TypeError) as ctx:
+                gc._resolve_device_communicator_cls()
+        self.assertIn("NotACommunicator", str(ctx.exception))
+
+    def test_cpu_platform_keeps_cpu_communicator(self):
+        from sglang.multimodal_gen.runtime.distributed import group_coordinator as gc
+        from sglang.multimodal_gen.runtime.distributed.device_communicators.cpu_communicator import (
+            CpuCommunicator,
+        )
+        from sglang.multimodal_gen.runtime.platforms.cpu import CpuPlatform
+
+        with patch.object(gc, "current_platform", CpuPlatform()):
+            self.assertIs(gc._resolve_device_communicator_cls(), CpuCommunicator)
+
+    def test_mps_platform_keeps_cpu_communicator(self):
+        from sglang.multimodal_gen.runtime.distributed import group_coordinator as gc
+        from sglang.multimodal_gen.runtime.distributed.device_communicators.cpu_communicator import (
+            CpuCommunicator,
+        )
+        from sglang.multimodal_gen.runtime.platforms.mps import MpsPlatform
+
+        # MpsPlatform.get_device_communicator_cls() returns the *base* class,
+        # but the in-tree path must keep giving MPS the CPU communicator.
+        with patch.object(gc, "current_platform", MpsPlatform()):
+            self.assertIs(gc._resolve_device_communicator_cls(), CpuCommunicator)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1511,6 +1511,9 @@ class Envs:
     # ===================================================================
     SGLANG_PLATFORM = EnvStr("")
     SGLANG_PLUGINS = EnvStr("")
+    SGLANG_DIFFUSION_PLATFORM = EnvStr("")
+    SGLANG_DIFFUSION_PLUGINS = EnvStr("")
+    SGLANG_DIFFUSION_PLATFORM_OVERRIDE = EnvStr("")
 
     # ===================================================================
     # KV-Canary and Token-Oracle (testing only)

--- a/python/sglang/srt/plugins/__init__.py
+++ b/python/sglang/srt/plugins/__init__.py
@@ -8,6 +8,9 @@ Supports two types of plugins via setuptools entry_points:
 Plugins are discovered automatically when installed via pip.
 - Platform plugins: use ``SGLANG_PLATFORM`` to select when multiple are installed.
 - General plugins: use ``SGLANG_PLUGINS`` (comma-separated) to restrict which are loaded.
+
+The diffusion engine reuses this discovery machinery under its own entry point
+groups and env vars; see :mod:`sglang.multimodal_gen.plugins`.
 """
 
 import logging
@@ -15,7 +18,7 @@ from collections.abc import Callable
 from importlib.metadata import entry_points
 from typing import Any
 
-from sglang.srt.environ import envs
+from sglang.srt.environ import EnvField, envs
 from sglang.srt.plugins.hook_registry import (
     HookRegistry,
     HookSource,
@@ -35,6 +38,7 @@ _plugins_loaded = False
 def load_plugins_by_group(
     group: str,
     excluded_dists: set[str] | None = None,
+    whitelist_env: EnvField | None = None,
 ) -> dict[str, tuple[Callable[[], Any], str | None]]:
     """
     Discover and load plugins registered under the given entry point group.
@@ -44,13 +48,19 @@ def load_plugins_by_group(
         excluded_dists: Distribution names to skip. Plugins from these
             distributions are never ``ep.load()``-ed (avoids importing
             their modules and pulling hardware-specific dependencies).
+        whitelist_env: Env field holding the comma-separated name whitelist.
+            Defaults to ``SGLANG_PLUGINS``; the diffusion loader passes
+            ``SGLANG_DIFFUSION_PLUGINS`` so the two engines do not gate each
+            other's plugins.
 
     Returns:
         Dictionary mapping plugin name to ``(callable, dist_name)``.
     """
-    # SGLANG_PLUGINS whitelist (comma-separated plugin names)
+    # Name whitelist (comma-separated plugin names)
+    if whitelist_env is None:
+        whitelist_env = envs.SGLANG_PLUGINS
     allowed_set: set[str] | None = None
-    allowed_str = envs.SGLANG_PLUGINS.get()
+    allowed_str = whitelist_env.get()
     if allowed_str:
         allowed_set = {x.strip() for x in allowed_str.split(",") if x.strip()}
 
@@ -66,12 +76,12 @@ def load_plugins_by_group(
     plugins: dict[str, tuple[Callable[[], Any], str | None]] = {}
     for ep in discovered:
         if allowed_set is not None and ep.name not in allowed_set:
-            logger.info("Skipping plugin %s (not in SGLANG_PLUGINS)", ep.name)
+            logger.info("Skipping plugin %s (not in %s)", ep.name, whitelist_env.name)
             continue
         dist_name = ep.dist.name if ep.dist else None
         if excluded_dists and dist_name in excluded_dists:
             logger.info(
-                "Skipping plugin %s (dist %s excluded by SGLANG_PLATFORM)",
+                "Skipping plugin %s (dist %s excluded by platform selection)",
                 ep.name,
                 dist_name,
             )
@@ -86,6 +96,19 @@ def load_plugins_by_group(
     return plugins
 
 
+def excluded_dists_for(group: str, selected: str) -> set[str]:
+    """Dist names providing a platform plugin in ``group`` other than ``selected``.
+
+    Skipping those dists keeps an unselected platform package from registering
+    hooks that import its hardware dependencies. An empty ``selected`` (env var
+    unset) excludes nothing and, importantly, does not enumerate entry points.
+    """
+    if not selected:
+        return set()
+    platform_eps = entry_points(group=group)
+    return {ep.dist.name for ep in platform_eps if ep.dist and ep.name != selected}
+
+
 def _get_excluded_dists() -> set[str]:
     """Compute dist names to skip when ``SGLANG_PLATFORM`` is set.
 
@@ -93,11 +116,7 @@ def _get_excluded_dists() -> set[str]:
     selected by ``SGLANG_PLATFORM``.  This prevents unselected platform
     packages from registering hooks that pull their hardware dependencies.
     """
-    selected = envs.SGLANG_PLATFORM.get()
-    if not selected:
-        return set()
-    platform_eps = entry_points(group=PLATFORM_PLUGINS_GROUP)
-    return {ep.dist.name for ep in platform_eps if ep.dist and ep.name != selected}
+    return excluded_dists_for(PLATFORM_PLUGINS_GROUP, envs.SGLANG_PLATFORM.get())
 
 
 def load_plugins():

--- a/python/sglang/srt/plugins/hook_registry.py
+++ b/python/sglang/srt/plugins/hook_registry.py
@@ -79,6 +79,11 @@ class HookRegistry:
         list
     )
     _patched: set[str] = set()
+    # target -> number of hooks already applied to it. Two loaders share this
+    # registry (sglang.srt.plugins and sglang.multimodal_gen.plugins), so hooks
+    # can be registered after their target was patched by the earlier loader;
+    # this is what lets apply_hooks() report them instead of dropping silently.
+    _applied: dict[str, int] = {}
 
     @classmethod
     def register(
@@ -154,14 +159,30 @@ class HookRegistry:
         subsequent method-level hooks (AROUND, BEFORE, AFTER) on child
         attributes resolve against the *replaced* class rather than the
         original.
+
+        Hooks registered on a target that a previous apply_hooks() call already
+        patched cannot be applied any more; they are reported with their plugin
+        source rather than dropped silently.
         """
         sorted_items = sorted(cls._hooks.items(), key=cls._target_sort_key)
         for target, hooks in sorted_items:
             if target in cls._patched:
+                late = hooks[cls._applied.get(target, len(hooks)) :]
+                if late:
+                    sources = sorted({_format_source(src) for _, _, src in late})
+                    logger.warning(
+                        "%d hook(s) on '%s' were registered after it was already "
+                        "patched and are NOT applied (from: %s). Register them "
+                        "before the loader that patched this target runs.",
+                        len(late),
+                        target,
+                        ", ".join(sources),
+                    )
                 continue
             try:
                 cls._apply_target(target, hooks)
                 cls._patched.add(target)
+                cls._applied[target] = len(hooks)
             except Exception:
                 logger.exception("Failed to apply hooks to %s", target)
 
@@ -317,6 +338,7 @@ class HookRegistry:
         """Reset all hooks and patches. Primarily for testing."""
         cls._hooks.clear()
         cls._patched.clear()
+        cls._applied.clear()
 
 
 def _propagate_patch(original: object, wrapped: object, source_module: object) -> int:

--- a/test/registered/unit/plugins/test_hook_registry.py
+++ b/test/registered/unit/plugins/test_hook_registry.py
@@ -12,7 +12,12 @@ import sys
 import types
 import uuid
 
-from sglang.srt.plugins.hook_registry import HookRegistry, HookType, plugin_hook
+from sglang.srt.plugins.hook_registry import (
+    HookRegistry,
+    HookSource,
+    HookType,
+    plugin_hook,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -440,6 +445,35 @@ class TestEdgeCases(_HookTestCase):
 
         mod.orig(1)
         self.assertEqual(call_count[0], 1)
+
+    def test_hook_registered_after_apply_is_reported(self):
+        """A second loader's late hook cannot be applied; it must not be silent."""
+
+        def orig(x):
+            return x
+
+        mod, name = _make_module(orig=orig)
+
+        def first(fn, x):
+            return fn(x) + 1
+
+        def late(fn, x):
+            return fn(x) + 100
+
+        HookRegistry.register(f"{name}.orig", first, HookType.AROUND)
+        HookRegistry.apply_hooks()
+
+        HookRegistry.register(
+            f"{name}.orig",
+            late,
+            HookType.AROUND,
+            source=HookSource(plugin_name="late_plugin", dist_name="late-dist"),
+        )
+        with self.assertLogs("sglang.srt.plugins.hook_registry", level="WARNING") as cm:
+            HookRegistry.apply_hooks()
+
+        self.assertEqual(mod.orig(0), 1)  # late hook was NOT applied
+        self.assertTrue(any("late_plugin" in message for message in cm.output))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

SGLang already lets an out-of-tree hardware vendor plug into the SRT engine without touching the main repo: `sglang.srt.platforms` for the platform, `sglang.srt.plugins` for hooks, both discovered through setuptools entry points. `sglang.multimodal_gen` (sglang-diffusion) has no such door. It resolves its platform through a hard-coded detection chain and a short-name-only `SGLANG_DIFFUSION_PLATFORM_OVERRIDE`, so a vendor adapting the diffusion engine has to either patch the tree or inject monkeypatches from a `.pth` file at interpreter startup — the latter being what out-of-tree adapters do today, with all the import-ordering fragility that implies.

#35713 added out-of-tree *models and pipelines* (`register_pipeline()`, `ModelRegistry.register_model()`, `SGLANG_EXTERNAL_MODEL_PACKAGE`). This PR covers the other half: out-of-tree *platforms and runtime hooks* for the diffusion engine, reusing the SRT plugin machinery rather than duplicating it.

## Modifications

**New entry point groups** (`python/sglang/multimodal_gen/plugins/__init__.py`)

- `sglang.multimodal_gen.platforms` — `activate() -> str | None`, returning the qualname of a `multimodal_gen.runtime.platforms.interface.Platform` subclass, or `None` when the hardware is absent.
- `sglang.multimodal_gen.plugins` — `register() -> None`, registering hooks on the existing process-global `HookRegistry`.

Discovery delegates to `sglang.srt.plugins.load_plugins_by_group()`, so both engines share one implementation.

**Env vars** (`python/sglang/srt/environ.py`, declared next to `SGLANG_PLATFORM` / `SGLANG_PLUGINS`)

- `SGLANG_DIFFUSION_PLATFORM` — select the platform plugin by entry point name; front-loading filter, so only the selected plugin is imported and other vendors' hardware deps are never pulled. General plugins from unselected platform dists are skipped as well.
- `SGLANG_DIFFUSION_PLUGINS` — comma-separated whitelist for the diffusion general-plugin group. `SGLANG_PLUGINS` deliberately does not gate it.
- `SGLANG_DIFFUSION_PLATFORM_OVERRIDE` — moved here from `multimodal_gen/envs.py` (the platform resolver must read it without importing that module). It now also accepts an explicit `module.Class` / `module:Class` qualname and the previously missing `xpu` short name; the old short names behave exactly as before.

**Platform resolution** (`multimodal_gen/runtime/platforms/__init__.py`)

    OVERRIDE set                → use it (short name or qualname), no discovery
    SGLANG_DIFFUSION_PLATFORM   → only that plugin is imported/activated;
                                  unknown name, activate() -> None, or a raising
                                  activate() is a RuntimeError
    unset                       → activate all discovered plugins:
                                  1 → use it, N → RuntimeError,
                                  0 → existing built-in chain
                                      (mps → xpu → rocm → cuda → npu → musa → cpu)

The resolved qualname now goes through `_load_platform_class()`, which rejects anything that is not a `Platform` subclass instead of instantiating it blindly.

**Load point** (`multimodal_gen/__init__.py`)

`load_diffusion_plugins()` runs before the package binds `PipelineConfig` / `SamplingParams` / `DiffGenerator`, so hooks are applied before the runtime captures module-level state and before the platform singleton resolves. Every diffusion process imports this package, including workers spawned by the multiproc executor, so there is no explicit call site to maintain. It is idempotent per process, and discovery failures are logged rather than allowed to break `import sglang.multimodal_gen`.

**Out-of-tree dispatch points**

- `CustomOp.dispatch_forward()` routes `is_out_of_tree()` platforms to `forward_oot` *before* the `is_hip()` / `is_npu()` / `is_xpu()` / `is_musa()` branches: a vendor torch build can answer those predicates too, and would otherwise steal the dispatch. `forward_oot` already existed but was unreachable.
- `GroupCoordinator` gains `_resolve_device_communicator_cls()`; out-of-tree platforms are asked for `get_device_communicator_cls()` (validated as a `DeviceCommunicatorBase` subclass), while in-tree platforms keep the current CUDA-alike / CPU split, MPS included.

**Shared plumbing** (`sglang/srt/plugins/`)

- `load_plugins_by_group()` takes an optional `whitelist_env`; `excluded_dists_for()` is factored out of `_get_excluded_dists()`. SRT behavior is unchanged.
- `HookRegistry` tracks how many hooks it has applied per target. With two loaders sharing one registry, hooks registered after their target was patched can no longer be applied; they are now reported with their plugin source instead of being dropped silently.

**Docs**

- `docs/docs/hardware-platforms/plugin.mdx`: new "Diffusion Engine Plugins" section — entry point groups, env vars, resolution order, load point, plugin-author constraints, quick start, OOT platform requirements, plus a pointer to #35713's model/pipeline mechanism.
- `docs/docs/sglang-diffusion/environment_variables.mdx`: the three env vars.

No in-tree platform changes behavior: with no plugin installed and no env var set, resolution falls through to the same detection chain, and every new branch is gated on `is_out_of_tree()`, which no in-tree platform returns true for.

## Accuracy Tests

N/A — no kernel, model forward or numerics change. The only forward-path edit is a dispatch branch that is reachable only for platforms with `PlatformEnum.OOT`, so in-tree CUDA/ROCm/NPU/XPU/MUSA/CPU/MPS dispatch is bit-identical.

## Speed Tests and Profiling

N/A — the added work is entry point enumeration once per process at import time; the steady-state inference path is untouched.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

### Tests

- `python/sglang/multimodal_gen/test/unit/test_diffusion_plugins.py` (new, 14 cases): loader idempotence, per-plugin exception isolation, whitelist and excluded-dist filtering, `SGLANG_PLUGINS` not leaking into the diffusion group, discovery failure not breaking package import, the load point preceding other package imports, the plugins module not importing the runtime at module scope, and a fresh-interpreter test that materializes a throwaway `*.dist-info` so a real entry point is discovered, executed and its hook actually applied.
- `python/sglang/multimodal_gen/test/unit/test_oot_platform.py` (new, 27 cases): override forms, selected-plugin paths including "unselected plugin is never imported", auto-discovery 0/1/N, `_load_platform_class()` validation, `forward_oot` dispatch precedence, and device communicator selection for OOT / CPU / MPS.
- `test/registered/unit/plugins/test_hook_registry.py`: one case for the late-registration warning.
- Existing `test/registered/unit/plugins/` and `test/registered/unit/platforms/` pass unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32844031557](https://github.com/sgl-project/sglang/actions/runs/32844031557)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32844031439](https://github.com/sgl-project/sglang/actions/runs/32844031439)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32844031517](https://github.com/sgl-project/sglang/actions/runs/32844031517)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->