### PR TITLE
[Fix] Honor metrics content negotiation in gRPC sidecar

### DIFF
--- a/python/sglang/srt/entrypoints/grpc_server.py
+++ b/python/sglang/srt/entrypoints/grpc_server.py
@@ -23,6 +23,14 @@ from sglang.srt.utils.common import get_bool_env_var
 logger = logging.getLogger(__name__)
 
 
+def _encode_metrics(registry, accept_header):
+    """Encode metrics using the same content negotiation as HTTP mode."""
+    from prometheus_client.exposition import choose_encoder
+
+    encoder, content_type = choose_encoder(accept_header)
+    return encoder(registry), content_type
+
+
 async def _start_sidecar_server(host: str, port: int, app):
     """Start the aiohttp sidecar and return the runner for cleanup."""
     runner = web.AppRunner(app)
@@ -43,19 +51,17 @@ def _add_metrics_routes(app):
         CollectorRegistry,
         multiprocess,
     )
-    from prometheus_client.openmetrics.exposition import (
-        CONTENT_TYPE_LATEST,
-        generate_latest,
-    )
 
     async def metrics_handler(request):
         try:
             registry = CollectorRegistry()
             multiprocess.MultiProcessCollector(registry)
-            data = generate_latest(registry)
+            data, content_type = _encode_metrics(
+                registry, request.headers.get("Accept")
+            )
             return web.Response(
                 body=data,
-                headers={"Content-Type": CONTENT_TYPE_LATEST},
+                headers={"Content-Type": content_type},
             )
         except Exception:
             logger.exception("Failed to generate Prometheus metrics")

--- a/test/registered/unit/entrypoints/test_grpc_server.py
+++ b/test/registered/unit/entrypoints/test_grpc_server.py
@@ -1,0 +1,39 @@
+"""Unit tests for the gRPC HTTP sidecar."""
+
+import unittest
+
+from prometheus_client import CollectorRegistry, Gauge
+
+from sglang.srt.entrypoints.grpc_server import _encode_metrics
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestGrpcMetricsSerialization(CustomTestCase):
+    def test_colon_delimited_metric_name_is_preserved(self):
+        registry = CollectorRegistry()
+        Gauge(
+            "sglang:num_running_reqs",
+            "The number of running requests.",
+            registry=registry,
+        ).set(1)
+
+        accept_headers = (
+            "*/*",
+            "application/openmetrics-text; version=1.0.0; escaping=allow-utf-8",
+        )
+        for accept_header in accept_headers:
+            with self.subTest(accept_header=accept_header):
+                data, _ = _encode_metrics(registry, accept_header)
+                output = data.decode("utf-8")
+
+                self.assertIn("# HELP sglang:num_running_reqs ", output)
+                self.assertIn("# TYPE sglang:num_running_reqs gauge", output)
+                self.assertIn("\nsglang:num_running_reqs 1.0\n", output)
+                self.assertNotIn("sglang_num_running_reqs", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [Fix] Honor metrics content negotiation in gRPC sidecar

## Motivation

SGLang exposes metrics differently depending on the server mode. The regular HTTP metrics endpoint uses `prometheus-client` content negotiation, while the gRPC metrics sidecar always used the OpenMetrics encoder and ignored the request's `Accept` header.

With affected `prometheus-client` versions, the hardcoded OpenMetrics path can expose a colon-delimited sample name differently from the regular HTTP endpoint:

```text
# HELP sglang:num_running_reqs ...
# TYPE sglang:num_running_reqs gauge
sglang_num_running_reqs 1
```

As a result, Prometheus may ingest `sglang_num_running_reqs` from a gRPC deployment instead of the `sglang:num_running_reqs` series exposed by an HTTP deployment. Existing Grafana dashboards and alerts that query the colon-delimited name can then return no data after switching server modes. Strict OpenMetrics parsers may also reject the response because the `HELP` and `TYPE` metadata names do not match the sample name.

This change makes the gRPC sidecar use the same content-negotiation behavior as SGLang's regular HTTP metrics endpoint. The underlying `prometheus-client` behavior is tracked in [prometheus/client_python#1177](https://github.com/prometheus/client_python/issues/1177).

## Modifications

- Use `prometheus_client.exposition.choose_encoder` to select the metrics encoder from the request's `Accept` header.
- Return the content type associated with the selected encoder.
- Align the gRPC sidecar's response format and metric-name encoding with SGLang's normal HTTP metrics behavior for the same scrape request.
- Add a CPU unit test covering Prometheus text negotiation with `Accept: */*`, OpenMetrics negotiation with `escaping=allow-utf-8`, and preservation of colon-delimited metric names.

## Accuracy Tests

Not applicable. This change does not affect model execution or outputs.

Unit test:

```bash
PYTHONPATH="$PWD/python" python3 \
  test/registered/unit/entrypoints/test_grpc_server.py
```

Result:

```text
Ran 1 test in 0.000s

OK
```

Formatting and lint checks:

```bash
pre-commit run --files \
  python/sglang/srt/entrypoints/grpc_server.py \
  test/registered/unit/entrypoints/test_grpc_server.py
```

All applicable pre-commit hooks passed.

## Speed Tests and Profiling

Not applicable. This change only affects metrics response serialization and is not on the inference path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is needed for this internal behavior fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable because model outputs and inference performance are unaffected.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32845419962](https://github.com/sgl-project/sglang/actions/runs/32845419962)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32845419589](https://github.com/sgl-project/sglang/actions/runs/32845419589)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32845419753](https://github.com/sgl-project/sglang/actions/runs/32845419753)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->