### PR TITLE
[diffusion] advise the kernel ahead of the courier on mapped layers

### DIFF
--- a/python/sglang/multimodal_gen/envs.py
+++ b/python/sglang/multimodal_gen/envs.py
@@ -23,6 +23,7 @@ if TYPE_CHECKING:
     SGLANG_DIFFUSION_TRACE_FUNCTION: int = 0
     SGLANG_DIFFUSION_DISABLE_EARLY_VAE_DECODER_CAST: bool = False
     SGLANG_DIFFUSION_DISABLE_VAE_DECODER_STORE: bool = False
+    SGLANG_DIFFUSION_DISABLE_MAPPED_WILLNEED: bool = False
     SGLANG_DIFFUSION_DISABLE_LORA_MERGE_CACHE: bool = False
     SGLANG_DIFFUSION_WORKER_MULTIPROC_METHOD: str = "fork"
     SGLANG_DIFFUSION_TARGET_DEVICE: str = "cuda"
@@ -278,6 +279,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # memory instead of a file-backed cache mapping the page cache can drop.
     "SGLANG_DIFFUSION_DISABLE_VAE_DECODER_STORE": _lazy_bool(
         "SGLANG_DIFFUSION_DISABLE_VAE_DECODER_STORE"
+    ),
+    # Kill-switch: do not madvise(MADV_WILLNEED) mapped layers ahead of the
+    # courier; their pages arrive at fault-time readahead beats instead.
+    "SGLANG_DIFFUSION_DISABLE_MAPPED_WILLNEED": _lazy_bool(
+        "SGLANG_DIFFUSION_DISABLE_MAPPED_WILLNEED"
     ),
     # Kill-switch: keep LoRA-merged weights in anonymous host memory instead
     # of the file-backed LoRA merge cache.

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -1,6 +1,10 @@
 import bisect
+import ctypes
+import ctypes.util
+import os
 import queue
 import re
+import sys
 import threading
 from collections.abc import Mapping, Sequence
 from contextlib import nullcontext
@@ -191,6 +195,51 @@ def _install_host_gather_hooks(
 
     module.register_forward_pre_hook(_inputs_to_host, with_kwargs=True)
     module.register_forward_hook(_output_to_device)
+
+
+_MADV_WILLNEED = 3
+_libc = None
+if sys.platform == "linux":
+    try:
+        _libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+    except OSError:
+        _libc = None
+_PAGE = os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else 4096
+
+
+def advise_willneed(tensors) -> int:
+    """Ask the kernel to read these mapped tensors' pages ahead, in bulk.
+
+    The default readahead pipeline feeds the drive in read_ahead_kb-sized
+    beats (128 KB), which holds a fast NVMe to a quarter of its sequential
+    throughput on a host too small to cache the checkpoint. MADV_WILLNEED
+    schedules the whole range at once, so the disk read for the next layer
+    runs at drive speed while the current layer computes. Best-effort and
+    Linux-only: on any failure the normal fault path still works.
+    """
+    if _libc is None:
+        return 0
+    advised = 0
+    for tensor in tensors:
+        try:
+            storage = tensor.untyped_storage()
+            ptr = storage.data_ptr()
+            nbytes = storage.nbytes()
+        except Exception:
+            continue
+        if ptr == 0 or nbytes == 0:
+            continue
+        start = ptr & ~(_PAGE - 1)
+        length = (ptr + nbytes) - start
+        length = (length + _PAGE - 1) & ~(_PAGE - 1)
+        if (
+            _libc.madvise(
+                ctypes.c_void_p(start), ctypes.c_size_t(length), _MADV_WILLNEED
+            )
+            == 0
+        ):
+            advised += 1
+    return advised
 
 
 class MappedLayerCourier:
@@ -988,6 +1037,11 @@ class LayerwiseOffloadManager:
             if courier is not None and courier.submit(layer_idx):
                 self._courier_inflight.add(layer_idx)
                 ship_mapped = True
+                if not envs.SGLANG_DIFFUSION_DISABLE_MAPPED_WILLNEED:
+                    # Schedule the disk read for this layer's pages now, in
+                    # one bulk request, so it overlaps the previous layer's
+                    # compute instead of trickling in at fault-time beats.
+                    advise_willneed(self._mapped_cpu_weights[layer_idx].values())
 
         # create gpu buffer and load from CPU buffer
         gpu_buffers: Dict[torch.dtype, torch.Tensor] = {}

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/layerwise_offload.py
@@ -207,6 +207,29 @@ if sys.platform == "linux":
 _PAGE = os.sysconf("SC_PAGESIZE") if hasattr(os, "sysconf") else 4096
 
 
+_WILLNEED_MIN_AVAILABLE = 4 << 30  # bytes of MemAvailable required to advise
+
+
+def _willneed_headroom_ok(need_bytes: int) -> bool:
+    """Advised pages need somewhere to land, or the advice backfires.
+
+    Field-measured on a 32 GB host with MemAvailable at 0.29 GiB: pages read
+    ahead were evicted before the courier reached them, so every byte was
+    read twice and effective throughput fell to 0.67x of the unadvised run
+    (0.85 vs 1.27 GB/s). Only advise when the kernel has real headroom to
+    keep the window resident until it is consumed.
+    """
+    try:
+        with open("/proc/meminfo") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    available = int(line.split()[1]) * 1024
+                    return available >= max(_WILLNEED_MIN_AVAILABLE, 2 * need_bytes)
+    except (OSError, ValueError):
+        pass
+    return False
+
+
 def advise_willneed(tensors) -> int:
     """Ask the kernel to read these mapped tensors' pages ahead, in bulk.
 
@@ -215,9 +238,20 @@ def advise_willneed(tensors) -> int:
     throughput on a host too small to cache the checkpoint. MADV_WILLNEED
     schedules the whole range at once, so the disk read for the next layer
     runs at drive speed while the current layer computes. Best-effort and
-    Linux-only: on any failure the normal fault path still works.
+    Linux-only: on any failure the normal fault path still works — and on a
+    host with no free headroom the advice is withheld entirely, because a
+    window that cannot stay resident until consumed is read twice.
     """
     if _libc is None:
+        return 0
+    tensors = list(tensors)
+    need = 0
+    for tensor in tensors:
+        try:
+            need += tensor.untyped_storage().nbytes()
+        except Exception:
+            continue
+    if need == 0 or not _willneed_headroom_ok(need):
         return 0
     advised = 0
     for tensor in tensors:

--- a/python/sglang/multimodal_gen/test/unit/test_mapped_willneed.py
+++ b/python/sglang/multimodal_gen/test/unit/test_mapped_willneed.py
@@ -1,0 +1,65 @@
+"""advise_willneed hands the kernel page-aligned ranges and never raises.
+
+What matters: the madvise call receives a page-aligned start and a length
+that covers the tensor's storage, odd offsets round outward, and failures
+(no libc, bad pointers) degrade to zero advice instead of an exception.
+"""
+
+import pytest
+import torch
+
+from sglang.multimodal_gen.runtime.managers.memory_managers import (
+    layerwise_offload as lo,
+)
+
+
+class _RecordingLibc:
+    def __init__(self, ret=0):
+        self.calls = []
+        self.ret = ret
+
+    def madvise(self, addr, length, advice):
+        self.calls.append((addr.value, length.value, advice))
+        return self.ret
+
+
+@pytest.fixture()
+def libc(monkeypatch):
+    fake = _RecordingLibc()
+    monkeypatch.setattr(lo, "_libc", fake)
+    return fake
+
+
+def test_ranges_are_page_aligned_and_cover_the_storage(libc):
+    t = torch.zeros(1024, dtype=torch.float32)
+    advised = lo.advise_willneed([t])
+
+    assert advised == 1
+    ((addr, length, advice),) = libc.calls
+    page = lo._PAGE
+    assert advice == lo._MADV_WILLNEED
+    assert addr % page == 0
+    ptr = t.untyped_storage().data_ptr()
+    nbytes = t.untyped_storage().nbytes()
+    assert addr <= ptr
+    assert addr + length >= ptr + nbytes
+    assert length % page == 0
+
+
+def test_a_failing_madvise_counts_nothing(monkeypatch):
+    monkeypatch.setattr(lo, "_libc", _RecordingLibc(ret=-1))
+    assert lo.advise_willneed([torch.zeros(16)]) == 0
+
+
+def test_no_libc_is_a_quiet_noop(monkeypatch):
+    monkeypatch.setattr(lo, "_libc", None)
+    assert lo.advise_willneed([torch.zeros(16)]) == 0
+
+
+def test_empty_and_broken_tensors_are_skipped(libc):
+    class Broken:
+        def untyped_storage(self):
+            raise RuntimeError("no storage")
+
+    assert lo.advise_willneed([Broken(), torch.empty(0)]) == 0
+    assert libc.calls == []

--- a/python/sglang/multimodal_gen/test/unit/test_mapped_willneed.py
+++ b/python/sglang/multimodal_gen/test/unit/test_mapped_willneed.py
@@ -27,6 +27,7 @@ class _RecordingLibc:
 def libc(monkeypatch):
     fake = _RecordingLibc()
     monkeypatch.setattr(lo, "_libc", fake)
+    monkeypatch.setattr(lo, "_willneed_headroom_ok", lambda need: True)
     return fake
 
 
@@ -63,3 +64,30 @@ def test_empty_and_broken_tensors_are_skipped(libc):
 
     assert lo.advise_willneed([Broken(), torch.empty(0)]) == 0
     assert libc.calls == []
+
+
+def test_no_headroom_withholds_the_advice(monkeypatch):
+    fake = _RecordingLibc()
+    monkeypatch.setattr(lo, "_libc", fake)
+    monkeypatch.setattr(lo, "_willneed_headroom_ok", lambda need: False)
+    assert lo.advise_willneed([torch.zeros(1024)]) == 0
+    assert fake.calls == []
+
+
+def test_headroom_reads_memavailable(monkeypatch, tmp_path):
+    meminfo = tmp_path / "meminfo"
+
+    real_open = open
+
+    def fake_open(path, *a, **k):
+        if path == "/proc/meminfo":
+            return real_open(meminfo, *a, **k)
+        return real_open(path, *a, **k)
+
+    monkeypatch.setattr("builtins.open", fake_open)
+
+    meminfo.write_text("MemTotal: 32 kB\nMemAvailable: 16777216 kB\n")  # 16 GiB
+    assert lo._willneed_headroom_ok(1 << 30)
+
+    meminfo.write_text("MemTotal: 32 kB\nMemAvailable: 524288 kB\n")  # 0.5 GiB
+    assert not lo._willneed_headroom_ok(1 << 30)


### PR DESCRIPTION
## Summary

On a host too small to cache the checkpoint, every denoise step re-reads its weight sweep from disk — and the reads arrive at fault-time readahead beats (`read_ahead_kb`, default 128 KB), which holds a fast NVMe to a quarter of its sequential throughput. Field diagnosis on a real desktop (4090, 32 GB RAM, Samsung 990 Pro): **52.9 GB read per step, 38 s/step**, with major faults near zero — the kernel's sequential readahead turns them into minor faults, so the disk sets the denoise clock while staying invisible to the fault counters (`read_bytes` is the honest one).

When the courier takes a mapped layer, `madvise(MADV_WILLNEED)` now schedules the whole layer's pages in one bulk request, so the disk read for the next layer runs at drive speed while the current layer computes.

- Best-effort, Linux-only (WSL2 included): no libc, a failing call, or another platform falls back to the untouched fault path.
- Page-aligned ranges (start rounded down, length rounded up) per mapped storage.
- `SGLANG_DIFFUSION_DISABLE_MAPPED_WILLNEED` restores the old behavior.

Expected effect where it applies (physically small host): effective read throughput ~1.27 → 4-5 GB/s, i.e. the measured 38 s/step machine should land near ~15 s/step. This is invisible on hosts whose page cache holds the sweep (our capped-convention rigs) — a field verification round on the diagnosed machine is arranged. Unit tests cover alignment/coverage, failure, no-libc, and broken-tensor paths (78 passed together with the layerwise suite on the 5090-CI image).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Verification so far

- **No regression where the page cache holds the sweep** (the common case): turbo run on a 4090 rig with the advice active lands at den 35.6 s / dec 9.5 s vs the 33.7 / 9.5 baseline — within run variance, outputs normal. The advice is a no-op-cost hint when pages are already cached.
- Unit tests: 78 passed together with the layerwise suite on the 5090-CI image (alignment/coverage of the madvised ranges, failure, no-libc, broken-tensor paths).
- The win case (physically small host, disk-clocked) is being arranged on a memory-limited rig and on the originally diagnosed desktop.

## Field run on the target host class, and the fix it forced

A full field run on the diagnosed host class (4090, 32 GB RAM, 990 Pro; org-shared report) ran the advice for the whole request and landed **worse than the unadvised baseline**: effective read throughput 0.85 GB/s vs 1.27, a clean 0.67× that matches double-read arithmetic. The host's MemAvailable bottomed at **0.29 GiB** — pages advised ahead were evicted before the courier consumed them, so every byte was read twice. On a host that cannot keep the advised window resident, the advice is a tax on the very drive it tries to help. (The run was single-arm — no `DISABLE_MAPPED_WILLNEED=1` pair — but the sub-baseline throughput plus the eviction mechanism is enough to act on.)

The follow-up commit withholds the advice below `max(4 GiB, 2× window)` of MemAvailable: hosts with page-cache turnover room keep the bulk read; exhausted hosts fall back to the untouched fault path. This also sharpens the PR's honest envelope: the advice helps hosts whose page cache can hold a window in flight (the 40-64 GB middle band); a host oversubscribed on both anonymous memory and the sweep (32 GB + swap in use) needs fewer bytes — more RAM, resident layers, turbo — not faster prefetch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33053459091](https://github.com/sgl-project/sglang/actions/runs/33053459091)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33053458592](https://github.com/sgl-project/sglang/actions/runs/33053458592)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33053459130](https://github.com/sgl-project/sglang/actions/runs/33053459130)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->