### PR TITLE
[Spec] Enable draft-extend CUDA graph on FlashAttention (fa3) via backend capability

### DIFF
--- a/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
+++ b/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
@@ -925,6 +925,12 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
 
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        # FlashAttentionBackend declares support, but the musa draft-extend
+        # graph path has not been validated; keep the pre-capability behavior
+        # (eager draft-extend).
+        return False
+
 
 class MusaFlashAttentionMultiStepBackend(FlashAttentionMultiStepBackend):
 

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -113,6 +113,16 @@ class AttentionBackend(ABC):
         :py:meth:`init_forward_metadata_out_graph` call."""
         return False
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        """True when this backend supports capture under the EAGLE worker's
+        draft-extend (DRAFT_EXTEND_V2) CUDA graph runner.
+
+        Metadata is still rebuilt eagerly via
+        :py:meth:`init_forward_metadata_out_graph` before every replay, so this
+        only requires the backend's DRAFT_EXTEND_V2 kernels to be capturable
+        against the static buffers from :py:meth:`init_cuda_graph_state`."""
+        return False
+
     # Opt out only when this backend never reads seq_lens_cpu / seq_lens_sum.
     needs_cpu_seq_lens: bool = True
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -2264,6 +2264,9 @@ class DeepseekV4AttnBackend(
         )
         return swa_page_indices, swa_topk_lengths
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
     def __init__(

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -3425,6 +3425,9 @@ class DeepseekSparseAttnBackend(
             num_splits=num_splits,
         )
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class DeepseekSparseAttnMultiStepBackend:
 

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -136,8 +136,10 @@ class FlashAttentionBackend(AttentionBackend):
             - It will spawn num_steps FlashAttentionBackend for the draft worker
 
     Note about CUDA Graph:
-    - We only support CUDA Graph for Decode (Normal Decode and Draft Decode) and Target Verify.
-    - We don't support CUDA Graph for Extend and Draft Extend.
+    - We only support CUDA Graph for Decode (Normal Decode and Draft Decode), Target Verify,
+      and single-layer EAGLE Draft Extend (DRAFT_EXTEND_V2; guarded off for sliding-window
+      KV pools, see supports_draft_extend_cuda_graph).
+    - We don't support CUDA Graph for Extend.
     - When server init, init_cuda_graph_state will be called first and then init_cuda_graph_capture will be called.
     - For each forward batch, init_replay_cuda_graph will be called first and then replay the graph.
     """
@@ -453,6 +455,12 @@ class FlashAttentionBackend(AttentionBackend):
             not self.use_sliding_window_kv_pool
             or self.token_to_kv_pool.full_to_swa_index_mapping is not None
         )
+
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        # SWA models translate out_cache_loc into the sliding-window pool when
+        # rebuilding draft-extend metadata; that combination has not been
+        # exercised under the draft-extend graph runner, so keep it eager.
+        return not self.use_sliding_window_kv_pool
 
     def init_forward_metadata_out_graph(
         self,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1491,6 +1491,9 @@ class FlashInferAttnBackend(AttentionBackend):
 
         raise ValueError(f"Unknown dispatch reason: {self.dispatch_reason}")
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class FlashInferIndicesUpdaterDecode:
     def __init__(self, model_runner: ModelRunner, attn_backend: FlashInferAttnBackend):

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -562,6 +562,9 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
                 )
             return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class FlashMLAMultiStepDraftBackend:
     # Read by decide_needs_cpu_seq_lens (getattr defaults missing flags to True).

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1948,6 +1948,9 @@ class TritonAttnBackend(AttentionBackend):
         )
         return o
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class TritonMultiStepDraftBackend:
     """

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -1532,6 +1532,9 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 o_sf_scale=1.0,
             )
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class TRTLLMMLAMultiStepDraftBackend(FlashInferMLAMultiStepDraftBackend):
     """Multi-step draft backend for TRT-LLM MLA used by EAGLE."""

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -591,18 +591,31 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
-        # Snapshot built -- the forward is done reading the shared pool. Publish
-        # a read-done event the scheduler's WAR barrier waits on (draft extend
-        # is the EAGLE-family last shared-read phase; last write wins the mailbox).
-        read_done = self.device_module.Event()
-        read_done.record()
-        self.model_runner.shared_read_done_event = read_done
+        # Publish a read-done event the scheduler's WAR barrier waits on before
+        # its next shared-buffer write (draft extend is the EAGLE-family last
+        # shared-read phase; last write wins the mailbox). Backends that rebuild
+        # replay metadata inside the captured graph re-read req_to_token during
+        # replay itself, so their event must be recorded after the replay
+        # launch; all other backends retain the legacy early publication and
+        # its scheduler overlap.
+        publish_read_done_after_replay = (
+            self.draft_extend_attn_backend.draft_extend_metadata_captured_in_graph()
+        )
+        if not publish_read_done_after_replay:
+            read_done = self.device_module.Event()
+            read_done.record()
+            self.model_runner.shared_read_done_event = read_done
 
         self.raw_bs = raw_bs
         self.bs = bs
         shape_key = self._make_graph_key(bs)
         with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
             out = self._replay_graph(shape_key, forward_batch)
+
+        if publish_read_done_after_replay:
+            read_done = self.device_module.Event()
+            read_done.record()
+            self.model_runner.shared_read_done_event = read_done
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -17,14 +17,7 @@ from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner i
 )
 from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import NPUGraphRunner
 from sglang.srt.kv_canary.runner.canary_manager import context_tuple
-from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
 from sglang.srt.layers.attention.index_topk_share import IndexTopKShareState
-from sglang.srt.layers.attention.tokenspeed_mla_backend import TokenspeedMLABackend
-from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
-from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
-from sglang.srt.layers.attention.trtllm_mla_backend import (
-    TRTLLMMLABackend,
-)
 from sglang.srt.layers.moe.utils import (
     draft_model_build_scope,
     speculative_moe_a2a_backend_context,
@@ -421,42 +414,16 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 self.draft_attn_backend, AiterMultiStepDraftBackend
             ) or isinstance(self.draft_extend_attn_backend, DeepseekV4HipRadixBackend)
 
-        graph_supported_backend_types = [
-            TritonAttnBackend,
-            TRTLLMMLABackend,
-            TRTLLMHAAttnBackend,
-            TokenspeedMLABackend,
-            FlashInferAttnBackend,
-        ]
-        if _is_cuda or _is_musa:
-            # DSA is CUDA-only; import lazily so non-CUDA builds don't pull in
-            # deep_gemm and the rest of the sparse-attention stack at import time.
-            from sglang.srt.layers.attention.dsa_backend import (
-                DeepseekSparseAttnBackend,
-            )
-
-            graph_supported_backend_types.append(DeepseekSparseAttnBackend)
-            from sglang.srt.layers.attention.deepseek_v4_backend import (
-                DeepseekV4AttnBackend,
-            )
-
-            graph_supported_backend_types.append(DeepseekV4AttnBackend)
-        if _is_cuda:
-            # FlashMLA is CUDA-only; import lazily so CPU builds don't pull
-            # sgl_kernel.flash_mla at import time.
-            from sglang.srt.layers.attention.flashmla_backend import FlashMLABackend
-
-            graph_supported_backend_types.append(FlashMLABackend)
-
-        graph_supported_backend = isinstance(
-            self.draft_extend_attn_backend,
-            tuple(graph_supported_backend_types),
+        # Backends declare draft-extend graph support by overriding
+        # AttentionBackend.supports_draft_extend_cuda_graph().
+        graph_supported_backend = (
+            self.draft_extend_attn_backend is not None
+            and self.draft_extend_attn_backend.supports_draft_extend_cuda_graph()
         )
         supports_cuda_draft_extend_graph = (
             _is_cuda or _is_musa
         ) and graph_supported_backend
         # Capture extend
-        # TODO: support draft extend cuda graph for more attention backends
         if (
             self.draft_extend_attn_backend
             and not envs.SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH.get()

--- a/test/registered/unit/spec/test_draft_extend_graph_capability.py
+++ b/test/registered/unit/spec/test_draft_extend_graph_capability.py
@@ -1,0 +1,51 @@
+"""Pin tests for the draft-extend CUDA-graph backend capability.
+
+``eagle_worker_v2`` gates draft-extend graph capture on
+``AttentionBackend.supports_draft_extend_cuda_graph()``. It used to be an
+isinstance allowlist that omitted ``FlashAttentionBackend`` even though fa3's
+DRAFT_EXTEND_V2 graph machinery exists and is unit-tested (see
+``test/registered/attention/unittests/dense/test_fa3.py``). Pins: the
+FlashAttention backend declares support (fa3/fa4 EAGLE draft-extend runs under
+CUDA graph), support implies the in-graph metadata rebuild the WAR read-done
+publication relies on, and the sliding-window-pool combination stays on the
+eager path.
+"""
+
+import unittest
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestDraftExtendGraphCapability(CustomTestCase):
+    def test_flashattention_declares_support(self):
+        backend = object.__new__(FlashAttentionBackend)
+        backend.use_sliding_window_kv_pool = False
+        self.assertTrue(backend.supports_draft_extend_cuda_graph())
+        # Backends that never declared support keep the eager default.
+        base = object.__new__(AttentionBackend)
+        self.assertFalse(base.supports_draft_extend_cuda_graph())
+
+    def test_support_implies_in_graph_metadata_rebuild(self):
+        # The draft-extend graph runner keys its WAR read-done publication on
+        # draft_extend_metadata_captured_in_graph(): FA rebuilds metadata inside
+        # the captured graph (re-reading req_to_token at replay time), so
+        # whenever it declares graph support it must also declare the in-graph
+        # rebuild -- otherwise the scheduler's next-batch shared-buffer writes
+        # could race the replay's reads.
+        backend = object.__new__(FlashAttentionBackend)
+        backend.use_sliding_window_kv_pool = False
+        self.assertTrue(backend.draft_extend_metadata_captured_in_graph())
+
+    def test_swa_pool_stays_eager(self):
+        backend = object.__new__(FlashAttentionBackend)
+        backend.use_sliding_window_kv_pool = True
+        self.assertFalse(backend.supports_draft_extend_cuda_graph())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`eagle_worker_v2._capture_cuda_graphs` gated draft-extend CUDA-graph capture on an
isinstance allowlist, tagged `TODO: support draft extend cuda graph for more attention
backends`. `FlashAttentionBackend` was not in it, so single-layer EAGLE on fa3 — the
default MHA spec backend on Hopper — replays the draft-extend phase eagerly and pays a
per-decode-step host launch cost, even though:

- fa3's DRAFT_EXTEND_V2 graph machinery already exists and is unit-tested
  (`test/registered/attention/unittests/dense/test_fa3.py`,
  `runner_cuda_graph_fa3_eagle_draft_extend_v2_*` cases), and
- the multi-layer EAGLE runner already consumes it in graph mode
  (`draft_extend_metadata_captured_in_graph()`,
  `multi_layer_eagle_draft_extend_cuda_graph_runner.py`).

Draft-extend is the same phase #35126 optimizes on the host side; capturing it closes
the gap for fa3 instead of leaving the whole phase eager.

## Modifications

Follow the backend-declaration pattern (#35059, #29232) instead of growing the
allowlist (#29413 added DSA to it; #35672 is doing the same dance for HIP DSA):

- `base_attn_backend.py`: new capability
  `AttentionBackend.supports_draft_extend_cuda_graph()` (default `False`). Metadata is
  still rebuilt eagerly via `init_forward_metadata_out_graph` before every replay, so
  the capability only requires the backend's DRAFT_EXTEND_V2 kernels to be capturable
  against the static buffers from `init_cuda_graph_state`.
- `eagle_worker_v2.py`: replace the isinstance allowlist (and the lazy imports it
  needed) with the capability query. The `_is_cuda/_is_musa` platform gate and the HIP
  path (`supports_hip_draft_extend_graph`) are unchanged.
- Declare `True` on every backend the allowlist named: `TritonAttnBackend`,
  `TRTLLMMLABackend` (inherited by `TokenspeedMLABackend`), `FlashInferAttnBackend`
  (inherited by `TRTLLMHAAttnBackend`), `DeepseekSparseAttnBackend`,
  `DeepseekV4AttnBackend`, `FlashMLABackend`.
- `FlashAttentionBackend` (fa3/fa4): declare `True`, guarded to eager when
  `use_sliding_window_kv_pool` — the SWA out_cache_loc translation has not been
  exercised under the draft-extend graph runner, so SWA models keep today's behavior.
- `eagle_draft_extend_cuda_graph_runner.py`: when the backend rebuilds its
  draft-extend replay metadata inside the captured graph
  (`draft_extend_metadata_captured_in_graph()`, true for fa3), publish the
  scheduler's WAR read-done event after the replay launch instead of before it.
  Such backends re-read `req_to_token` during replay, so the pre-replay
  publication would let the next batch's `req_to_token` writes race the
  replay's reads under the overlap scheduler. Eager-metadata backends keep the
  pre-replay publication and their scheduler overlap unchanged.
- `MusaFlashAttentionBackend`: pin `False`. It inherits from `FlashAttentionBackend`
  but was never allowlisted, and musa maps the draft-extend runner onto a different
  graph runner class; preserve pre-change behavior.
- Three pin tests (`test/registered/unit/spec/test_draft_extend_graph_capability.py`):
  FlashAttention declares support (and the base default stays `False`), declared
  support implies the in-graph metadata rebuild that the post-replay WAR
  publication keys on, and the SWA pool combination stays eager.

No behavior change for any backend other than CUDA `FlashAttentionBackend` without a
sliding-window pool. `SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH=1` remains the escape
hatch and was used as the control arm below.

## Accuracy Tests

H100 (sm90, CUDA 12.6), `meta-llama/Llama-3.1-8B-Instruct` +
`lmsys/sglang-EAGLE3-LLaMA3.1-Instruct-8B`, EAGLE3 topk=1, steps=5, draft-tokens=6,
fa3, bf16. Arms differ only in `SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH`.

gsm8k (few-shot, `sglang.test.few_shot_gsm8k`, parallel 64; measured at 77723491f5):

| arm | 400q accuracy | avg_spec_accept_length |
|---|---|---|
| draft-extend graph (this PR) | 0.797 | 1.736 |
| eager draft-extend (control) | 0.795 | 1.729 |

A 62-request greedy corpus (batch 1–32, output 16–512, varied prefill) is
bitwise-identical across arms in the controlled sequential phases; the only diverging
requests sit in the concurrent phases and match the same-arm rerun noise (dynamic
batch composition), with accept-length deltas inside the same-arm noise band as well.

## Speed Tests

`sglang.bench_serving`, random dataset 512 in / 256 out, greedy. Same-GPU A/B
(graph vs eager on the identical device; measured at 77723491f5):

| metric | concurrency 1 | concurrency 16 |
|---|---|---|
| output tok/s, graph | 237.8 | 2476.1 |
| output tok/s, eager | 237.7 | 2469.7 |
| median TPOT ms, graph | 4.28 | 5.37 |
| median TPOT ms, eager | 4.29 | 5.39 |

Capture cost: +1.2 s startup, +0.20 GB for the draft-extend graphs at
`max_running_requests=64`. The win is per-step host launch elimination, so it grows
with host-side load and smaller TPOT budgets; on this 8B/H100 config it is a small
(0–1%) throughput gain, on par or better in every pairing across repeats, with the
per-pairing delta inside run-to-run noise at this scale.

## Checklist

- [x] Format your code with pre-commit.
- [x] Add unit tests as outlined in the PR description.
- [x] Update documentation / docstrings as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32847912066](https://github.com/sgl-project/sglang/actions/runs/32847912066)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32847911932](https://github.com/sgl-project/sglang/actions/runs/32847911932)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32847912254](https://github.com/sgl-project/sglang/actions/runs/32847912254)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->