### PR TITLE
perf: cache constant DP-attention fallback tensor across iterations

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/dp_attn.py
+++ b/python/sglang/srt/managers/scheduler_components/dp_attn.py
@@ -38,6 +38,8 @@ if TYPE_CHECKING:
 
 _ENABLE_METRICS_DP_ATTENTION = envs.SGLANG_ENABLE_METRICS_DP_ATTENTION.get()
 
+_FALLBACK_TENSOR_CACHE: dict = {}
+
 
 def _resolve_elastic_world_dp_size(
     dp_size: int,
@@ -114,19 +116,26 @@ class MLPSyncBatchInfo:
         )
 
     def _get_fallback_tensor(self, device, dtype=torch.int64) -> torch.Tensor:
-        return torch.tensor(
-            [
-                0,  # num_tokens
-                0,  # num_tokens_for_logprob
-                1,  # can_run_decode_cuda_graph
-                0,  # is_extend_in_batch
-                1,  # local_can_run_tbo
-                ForwardMode.IDLE.value,  # local_forward_mode
-                0,  # can_run_prefill_cuda_graph
-            ],
-            device=device,
-            dtype=dtype,
-        )
+        # Constant idle-batch row; cache per (device, dtype) to avoid a device
+        # alloc + H2D + implicit sync on every decode iteration.
+        cache_key = (str(device), dtype)
+        fallback = _FALLBACK_TENSOR_CACHE.get(cache_key)
+        if fallback is None:
+            fallback = torch.tensor(
+                [
+                    0,  # num_tokens
+                    0,  # num_tokens_for_logprob
+                    1,  # can_run_decode_cuda_graph
+                    0,  # is_extend_in_batch
+                    1,  # local_can_run_tbo
+                    ForwardMode.IDLE.value,  # local_forward_mode
+                    0,  # can_run_prefill_cuda_graph
+                ],
+                device=device,
+                dtype=dtype,
+            )
+            _FALLBACK_TENSOR_CACHE[cache_key] = fallback
+        return fallback
 
     def all_gather(
         self,


### PR DESCRIPTION
# perf: cache constant DP-attention fallback tensor across decode iterations

## Motivation

In the decode scheduler, `MLPSyncBatchInfo.all_gather()` runs once per decode
iteration to synchronize batch metadata across DP ranks. Inside it,
`_get_fallback_tensor()` returns a *constant* idle-batch row
(`[0, 0, 1, 0, 1, IDLE, 0]`), but the current code rebuilds that tensor from
scratch on every call:

```python
return torch.tensor([...], device=device, dtype=dtype)
```

`torch.tensor([...], device=device)` is not free on accelerator devices: each
call performs a device allocator allocation, a host-to-device copy, and an
implicit synchronization. Because `all_gather()` is on the decode hot path, this
constant-tensor construction executes on every step.

In a py-spy profile of the decode scheduler, `_get_fallback_tensor` alone
accounted for roughly **20% of the process CPU time** — spent producing the
exact same tensor every iteration.

## What this PR does

Cache the constant fallback tensor per `(device, dtype)` and reuse it:

- Add a module-level `_FALLBACK_TENSOR_CACHE`.
- `_get_fallback_tensor()` now does a cache lookup first and only builds the
  tensor on a miss.

The tensor is only ever *read* (it is copied into `global_info_tensor` /
`flat_info` / `tp_info`), never mutated in place, so sharing one instance is
safe. The existing `fallback_tensor.repeat(...)` aliasing behavior is unchanged
(`repeat()` always copies).

No behavioral change — this only removes redundant device-tensor construction
from the per-iteration path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32851618380](https://github.com/sgl-project/sglang/actions/runs/32851618380)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32851617904](https://github.com/sgl-project/sglang/actions/runs/32851617904)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32851618124](https://github.com/sgl-project/sglang/actions/runs/32851618124)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->