### PR TITLE
[HiSparse] Fix layer indexing and enable prefetch under PP

### DIFF
--- a/docs/docs/advanced_features/hisparse_guide.mdx
+++ b/docs/docs/advanced_features/hisparse_guide.mdx
@@ -122,7 +122,7 @@ Example: `--hisparse-config='{"top_k": 2048, "device_buffer_size": 6144, "host_t
 
 When a model reuses one anchor layer's top-k selection across a run of subsequent "skip" layers (DSA `index_topk_freq` / `index_topk_pattern`; native in GLM-5.2 as IndexShare), the working set of every skip layer is known the moment the anchor's index is computed. HiSparse exploits this automatically: the anchor's swap-in kernel records its miss plan (which host slots go to which device-buffer slots), and each skip layer replays that plan with a copy-only kernel issued ahead on a side stream, so the skip layers' host→device IO overlaps the intervening layers' compute instead of sitting on the decode critical path. The replay kernel uses a small fixed grid to keep its SM footprint low while overlapped.
 
-The prefetch is enabled automatically for eligible models (no pipeline parallelism, no speculative decoding) and can be turned off for A/B comparison with `SGLANG_DISABLE_HISPARSE_PREFETCH=1`.
+The prefetch is enabled automatically for eligible models (no speculative decoding) and can be turned off for A/B comparison with `SGLANG_DISABLE_HISPARSE_PREFETCH=1`. It works under pipeline parallelism, with one caveat: a PP stage whose first attention layer is a skip layer has no anchor of its own to prefetch from, so that stage falls back to synchronous swap-in. Use `SGLANG_PP_LAYER_PARTITION` to split on anchor layers if you hit this.
 
 ## Deployment
 

--- a/python/sglang/srt/managers/hisparse_coordinator.py
+++ b/python/sglang/srt/managers/hisparse_coordinator.py
@@ -48,14 +48,17 @@ class HiSparseTokenStats(NamedTuple):
 def resolve_shared_index_layers(
     *,
     hf_text_config,
-    pp_size: int,
     is_speculative: bool,
 ) -> Optional[List[bool]]:
     """Per-layer "reuses the previous layer's top-k index" pattern, or None.
 
     Mirrors DeepseekV2AttentionMLA's skip_topk derivation (index_topk_pattern /
     index_topk_freq / cli_factor); None when the model has no sharing or the
-    prefetch cannot run (PP, speculative decoding, kill-switch).
+    prefetch cannot run (speculative decoding, kill-switch).
+
+    The returned pattern is model-global; under pipeline parallelism the
+    coordinator slices it to the KV pool's layer range (see
+    `HiSparseCoordinator._init_shared_index_prefetch`).
     """
     if not is_deepseek_dsa(hf_text_config):
         return None
@@ -67,11 +70,10 @@ def resolve_shared_index_layers(
         pattern = [dsa_layer_skips_topk(hf_text_config, i) for i in range(num_layers)]
     if not any(pattern):
         return None
-    if pp_size != 1 or is_speculative:
+    if is_speculative:
         logger.warning(
-            "HiSparse shared-index prefetch is unsupported under pipeline "
-            "parallelism / speculative decoding; falling back to synchronous "
-            "swap-in."
+            "HiSparse shared-index prefetch is unsupported under speculative "
+            "decoding; falling back to synchronous swap-in."
         )
         return None
     if envs.SGLANG_DISABLE_HISPARSE_PREFETCH.get():
@@ -81,6 +83,45 @@ def resolve_shared_index_layers(
         )
         return None
     return pattern
+
+
+def _localize_shared_index_layers(
+    pattern: List[bool], *, start_layer: int, layer_num: int
+) -> Optional[List[bool]]:
+    """Cut the model-global skip pattern down to one rank's KV pool layers.
+
+    Returns None (-> synchronous swap-in) when the pattern cannot be mapped:
+
+    - It does not cover ``[start_layer, start_layer + layer_num)``, i.e. the
+      attention-layer count differs from num_hidden_layers (Longcat doubles it).
+    - The stage's first layer is a skip layer. The model itself can carry the
+      top-k index across a pipeline boundary (deepseek_v2 forwards
+      `topk_indices` via PPProxyTensors), but the anchor's *miss plan* lives in
+      this rank's device memory and cannot, so the stage has nothing to replay.
+      Avoidable with an anchor-aligned split via SGLANG_PP_LAYER_PARTITION.
+    """
+    end_layer = start_layer + layer_num
+    if len(pattern) < end_layer:
+        logger.warning(
+            "HiSparse shared-index prefetch disabled: pattern length %d does "
+            "not cover KV pool layers [%d, %d); using synchronous swap-in.",
+            len(pattern),
+            start_layer,
+            end_layer,
+        )
+        return None
+    local = pattern[start_layer:end_layer]
+    if local[0]:
+        logger.warning(
+            "HiSparse shared-index prefetch disabled: this stage starts on "
+            "layer %d, a shared-index (skip) layer, so its anchor's miss plan "
+            "lives on the previous rank and cannot be replayed here. Use "
+            "SGLANG_PP_LAYER_PARTITION to split on an anchor layer. Falling "
+            "back to synchronous swap-in.",
+            start_layer,
+        )
+        return None
+    return local
 
 
 def _build_prefetch_groups(
@@ -217,6 +258,11 @@ class HiSparseCoordinator:
 
         # initialize data structures for swap-in kernel
         layer_num = self.mem_pool_device.layer_num
+        # Under pipeline parallelism the device/host KV pools only hold this
+        # rank's slice, so every per-layer structure below is indexed 0..layer_num,
+        # while callers hand us the model-global `layer.layer_id`. Subtract the
+        # pool's start_layer to convert, same convention as memory_pool.py.
+        self.start_layer = self.mem_pool_device.start_layer
         self.req_device_buffer_tokens = torch.full(
             (layer_num, max_num_req_slots, self.padded_buffer_size),
             -1,
@@ -270,17 +316,17 @@ class HiSparseCoordinator:
     ) -> None:
         """Set up the plan-then-IO prefetch for shared-index (IndexShare) models:
         the anchor's kernel records its miss plan and skip layers replay it on
-        `prefetch_stream`, overlapping their IO with the intervening compute."""
-        if shared_index_layers is not None and len(shared_index_layers) != layer_num:
-            # Attention-layer count differs from num_hidden_layers (e.g. Longcat
-            # doubles it): pattern would be misindexed, fall back to synchronous.
-            logger.warning(
-                "HiSparse shared-index prefetch disabled: pattern length %d != "
-                "KV pool layer_num %d; using synchronous swap-in.",
-                len(shared_index_layers),
-                layer_num,
+        `prefetch_stream`, overlapping their IO with the intervening compute.
+
+        `shared_index_layers` is model-global; slice it to this rank's KV pool
+        range so the pattern (and the groups built from it) is pool-local.
+        """
+        if shared_index_layers is not None:
+            shared_index_layers = _localize_shared_index_layers(
+                shared_index_layers,
+                start_layer=self.start_layer,
+                layer_num=layer_num,
             )
-            shared_index_layers = None
         self._is_shared_index_layer = list(shared_index_layers or [False] * layer_num)
         self.enable_prefetch = any(self._is_shared_index_layer)
         self._prefetch_groups, self._prefetch_slot = _build_prefetch_groups(
@@ -939,10 +985,12 @@ class HiSparseCoordinator:
         req_pool_indices: torch.Tensor,
         compressed_seq_lens: torch.Tensor,
         top_k_result: torch.Tensor,
-        layer_id: int,
+        local_layer_id: int,
         record_plan: bool = False,
     ) -> torch.Tensor:
         """Run the full plan+IO swap-in kernel for one layer; return its slot table.
+
+        `local_layer_id` is pool-local (see `self.start_layer`).
 
         record_plan (set on the anchor of a shared-index group) also records the
         miss plan into self._miss_{src,dst,count} for the skip layers to replay.
@@ -966,15 +1014,15 @@ class HiSparseCoordinator:
         )
         swap_in_fn(
             top_k_tokens=top_k_result,
-            device_buffer_tokens=self.req_device_buffer_tokens[layer_id],
+            device_buffer_tokens=self.req_device_buffer_tokens[local_layer_id],
             host_cache_locs=self.req_to_host_pool,
-            device_buffer_locs=self.req_device_buffer_token_locs[layer_id],
-            host_cache=self.mem_pool_host.kv_buffer[layer_id],
-            device_buffer=self.mem_pool_device.kv_buffer[layer_id],
+            device_buffer_locs=self.req_device_buffer_token_locs[local_layer_id],
+            host_cache=self.mem_pool_host.kv_buffer[local_layer_id],
+            device_buffer=self.mem_pool_device.kv_buffer[local_layer_id],
             top_k_device_locs=top_k_indices,
             req_pool_indices=req_pool_indices,
             seq_lens=compressed_seq_lens,
-            lru_slots=self.lru_slots[layer_id],
+            lru_slots=self.lru_slots[local_layer_id],
             item_size_bytes=self.item_size_bytes,
             num_top_k=self.top_k,
             hot_buffer_size=self.device_buffer_size,
@@ -986,16 +1034,19 @@ class HiSparseCoordinator:
         )
         return top_k_indices
 
-    def _run_copy_only_kernel(self, num_reqs: int, skip_layer: int) -> None:
+    def _run_copy_only_kernel(self, num_reqs: int, local_skip_layer: int) -> None:
         """Replay the anchor's recorded miss plan into a skip layer's buffers
-        (IO-only; the anchor's slot table stays valid -- lockstep layout)."""
+        (IO-only; the anchor's slot table stays valid -- lockstep layout).
+
+        `local_skip_layer` is pool-local (see `self.start_layer`).
+        """
         copy_cache_planned_mla(
             miss_src=self._miss_src[:num_reqs],
             miss_dst=self._miss_dst[:num_reqs],
             miss_count=self._miss_count[:num_reqs],
             num_real_reqs=self.num_real_reqs,
-            host_cache=self.mem_pool_host.kv_buffer[skip_layer],
-            device_buffer=self.mem_pool_device.kv_buffer[skip_layer],
+            host_cache=self.mem_pool_host.kv_buffer[local_skip_layer],
+            device_buffer=self.mem_pool_device.kv_buffer[local_skip_layer],
             item_size_bytes=self.item_size_bytes,
             num_blocks=self._prefetch_copy_blocks,
             is_dsv4_layout=self.is_dsv4_hisparse,
@@ -1011,30 +1062,34 @@ class HiSparseCoordinator:
     ) -> torch.Tensor:
         """Swap selected top-k tokens into device memory and return their indices.
 
+        `layer_id` is the model-global layer id; every per-layer structure here
+        is pool-local, so convert through `self.start_layer` first.
+
         With prefetch enabled, anchors swap in synchronously (recording the miss
         plan) and prefetch their skip layers' copies; skip layers just wait.
         """
+        local_layer_id = layer_id - self.start_layer
         if not self.enable_prefetch:
             return self._run_swap_in_kernel(
-                req_pool_indices, compressed_seq_lens, top_k_result, layer_id
+                req_pool_indices, compressed_seq_lens, top_k_result, local_layer_id
             )
 
         num_reqs = req_pool_indices.size(0)
-        if self._is_shared_index_layer[layer_id]:
+        if self._is_shared_index_layer[local_layer_id]:
             # Skip layer: wait for its prefetched copy; the anchor's slot table
             # applies (shared index + lockstep buffers).
-            slot = self._prefetch_slot[layer_id]
+            slot = self._prefetch_slot[local_layer_id]
             self._prefetch_events[slot].wait(device_module.current_stream())
             return self.top_k_device_locs_buffer[:num_reqs]
 
         # Anchor: swap in synchronously (recording the plan), then prefetch the
         # skip layers' copies on the side stream.
-        group = self._prefetch_groups.get(layer_id)
+        group = self._prefetch_groups.get(local_layer_id)
         anchor_locs = self._run_swap_in_kernel(
             req_pool_indices,
             compressed_seq_lens,
             top_k_result,
-            layer_id,
+            local_layer_id,
             record_plan=group is not None,
         )
         if group:

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -895,7 +895,6 @@ class ModelRunner:
             swap_in_block_size=hisparse_cfg.swap_in_block_size,
             shared_index_layers=resolve_shared_index_layers(
                 hf_text_config=self.model_config.hf_text_config,
-                pp_size=self.ps.pp_size,
                 is_speculative=self.spec_algorithm.is_speculative(),
             ),
         )

--- a/test/registered/unit/managers/test_hisparse_shared_index_localize.py
+++ b/test/registered/unit/managers/test_hisparse_shared_index_localize.py
@@ -1,0 +1,68 @@
+"""Unit tests for HiSparse's model-global -> pool-local skip-pattern slicing.
+
+`resolve_shared_index_layers` returns a pattern indexed by model-global layer
+id, but every per-layer structure in `HiSparseCoordinator` is sized to this
+rank's KV pool slice. `_localize_shared_index_layers` bridges the two, and must
+bail out (-> synchronous swap-in) rather than mis-index when the mapping does
+not hold.
+"""
+
+import unittest
+
+from sglang.srt.managers.hisparse_coordinator import _localize_shared_index_layers
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+# Anchor / skip / anchor / skip ... as produced by index_topk_freq=2.
+ALTERNATING = [False, True] * 4
+
+
+class TestLocalizeSharedIndexLayers(unittest.TestCase):
+    def test_single_stage_is_identity(self):
+        """pp_size=1: start_layer=0 and the whole pattern is this rank's slice."""
+        self.assertEqual(
+            _localize_shared_index_layers(ALTERNATING, start_layer=0, layer_num=8),
+            ALTERNATING,
+        )
+
+    def test_later_pp_stage_is_sliced(self):
+        """A stage starting at layer 4 gets pattern[4:8], not pattern[0:4].
+
+        The slice must be offset by start_layer: returning the head of the
+        pattern would make the coordinator treat the wrong layers as anchors.
+        """
+        pattern = [False, True, True, False, False, True, False, False]
+        self.assertEqual(
+            _localize_shared_index_layers(pattern, start_layer=4, layer_num=4),
+            [False, True, False, False],
+        )
+
+    def test_stage_starting_on_skip_layer_disables_prefetch(self):
+        """A stage whose first layer is a skip layer has no local anchor.
+
+        The anchor's miss plan lives in the previous rank's device memory, so
+        there is nothing to replay here. Must return None (synchronous swap-in)
+        instead of a pattern whose layer 0 is a skip layer -- that would make
+        `_build_prefetch_groups` assert.
+        """
+        self.assertIsNone(
+            _localize_shared_index_layers(ALTERNATING, start_layer=1, layer_num=4)
+        )
+
+    def test_pattern_shorter_than_pool_range_disables_prefetch(self):
+        """Attention-layer count != num_hidden_layers (e.g. Longcat doubles it).
+
+        The pattern cannot cover the pool's layer range, so slicing it would
+        silently drop layers; fall back to synchronous swap-in.
+        """
+        self.assertIsNone(
+            _localize_shared_index_layers([False, True], start_layer=0, layer_num=8)
+        )
+        self.assertIsNone(
+            _localize_shared_index_layers(ALTERNATING, start_layer=4, layer_num=8)
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION

## Motivation

`HiSparseCoordinator` sizes every per-layer structure to **this rank's KV pool slice**
(`mem_pool_device.layer_num`), but `swap_in_selected_pages()` is called from the attention
backend with the **model-global** `layer.layer_id`. With `pp_size == 1` the two coincide, so
the bug was invisible; under pipeline parallelism they differ by the pool's `start_layer` and
every later PP stage indexes out of range.

The pre-existing `pp_size != 1` guard only disabled the *shared-index prefetch*. The
**synchronous** swap-in path was mis-indexed as well, so HiSparse + PP crashed the decode
instance at startup — see the captured traceback below. This makes HiSparse unusable with
pipeline parallelism, which on GPUs without NVLink (SM120 / PCIe) is exactly the topology
that gives the largest KV pool.

## Modifications

- `hisparse_coordinator.py`
  - Store `self.start_layer = self.mem_pool_device.start_layer` and convert once at the single
    public entry point: `local_layer_id = layer_id - self.start_layer`. Internal helpers are
    renamed (`local_layer_id`, `local_skip_layer`) so the pool-local boundary is explicit;
    all per-layer lookups (`req_device_buffer_tokens`, `req_device_buffer_token_locs`,
    `lru_slots`, both pools' `kv_buffer`) now use the local id — same convention already used
    throughout `memory_pool.py`.
  - New pure helper `_localize_shared_index_layers(pattern, *, start_layer, layer_num)` slices
    the model-global skip pattern down to this rank's layer range, and returns `None`
    (→ synchronous swap-in) when the mapping cannot hold:
    - the pattern does not cover `[start_layer, start_layer + layer_num)` (e.g. Longcat sets
      `num_attention_layers = num_hidden_layers * 2`);
    - the stage's first layer is a *skip* layer — the model can carry `topk_indices` across a
      PP boundary via `PPProxyTensors`, but the anchor's device-side **miss plan** cannot, so
      there is nothing to replay on this rank. Avoidable with an anchor-aligned
      `SGLANG_PP_LAYER_PARTITION`.
  - `resolve_shared_index_layers()` drops the `pp_size` kwarg; only speculative decoding still
    disables the prefetch.
- `model_runner.py` — drop the now-unused `pp_size=` argument (one line).
- New CPU unit test `test/registered/unit/managers/test_hisparse_shared_index_localize.py`.
- `docs/.../hisparse_guide.mdx` — the prefetch section no longer claims PP is unsupported;
  documents the skip-layer-boundary caveat instead.

## Accuracy Tests

Run inside `sglang:v0.5.18` (torch 2.13.0+cu130, Python 3.12.3) with the patch mounted,
8× RTX PRO 6000 (SM120):

```
$ python3 -m pytest test/registered/unit/managers/test_hisparse_shared_index_localize.py -v
test_later_pp_stage_is_sliced                        PASSED [ 25%]
test_pattern_shorter_than_pool_range_disables_prefetch PASSED [ 50%]
test_single_stage_is_identity                        PASSED [ 75%]
test_stage_starting_on_skip_layer_disables_prefetch  PASSED [100%]
======================= 4 passed, 15 warnings in 19.94s ========================

$ python3 -m pytest test/registered/unit/managers/test_hisparse_unit.py -v
9 passed, 2 skipped, 15 warnings in 22.65s
```

(The 2 skips are the `page_size == 1` cases, skipped by the test itself on this config.)

### End-to-end: HiSparse + TP4/PP2 before vs. after

GLM-5.2-NVFP4, 2-node PD disaggregation, decode instance `--tp-size 4 --pp-size 2`,
`SGLANG_PP_LAYER_PARTITION=38,40`, `--enable-hisparse
--hisparse-config '{"top_k":2048,"device_buffer_size":4096,"host_to_device_ratio":10}'`.

**Without this patch (stock v0.5.18)** — the decode instance never reaches serving state.
PP stage 1 owns model layers 38..77 while its per-layer tensors are sized 40:

```
[PP1 TP0] HiSparse shared-index prefetch is unsupported under pipeline parallelism /
          speculative decoding; falling back to synchronous swap-in.
...
[PP1 TP0] Scheduler hit an exception: Traceback (most recent call last):
  File ".../managers/scheduler.py", line 1006, in init_model_worker
    self.init_all_cuda_graphs()
  File ".../model_executor/runner/base_runner.py", line 247, in warmup
    self._flashinfer_autotune(buffers=buffers, batch_size=batch_size)
  ...
  File ".../layers/attention/dsa_backend.py", line 2259, in forward_decode
    page_table_1 = self.hisparse_coordinator.swap_in_selected_pages(
  File ".../managers/hisparse_coordinator.py", line 1018, in swap_in_selected_pages
    return self._run_swap_in_kernel(
  File ".../managers/hisparse_coordinator.py", line 969, in _run_swap_in_kernel
    device_buffer_tokens=self.req_device_buffer_tokens[layer_id],
                         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^
IndexError: index 40 is out of bounds for dimension 0 with size 40

[..] Received sigquit from a child process. It usually means the child failed.
```

All four PP1 TP ranks fail identically. Note the crash happens on the **synchronous** path,
after the old guard already disabled the prefetch — lifting the guard alone would not have
been enough.

**With this patch** — boots clean, prefetch active on both stages, no
`shared-index prefetch disabled` warning:

```
[PP0 TP0] HiSparse: shared-index prefetch (plan-then-IO) enabled;  9 anchor group(s), 27 skip layer(s) of 38 total.
[PP1 TP0] HiSparse: shared-index prefetch (plan-then-IO) enabled; 10 anchor group(s), 30 skip layer(s) of 40 total.
[PP0 TP0] max_total_num_tokens=442432, ... max_running_requests=57
[PP1 TP0] max_total_num_tokens=442432, ...
The server is fired up and ready to roll!
```

## Speed Tests and Profiling

Same hardware/model/image, patch applied to both configurations. Workload:
`prompt_tokens=32000` (byte-identical prompt, verified server-side), `max_new_tokens=1500`,
`ignore_eos=true`, 57 in-flight requests held constant, 900 s window, `sglang_router` in PD
mode, prefill instance identical across runs.

| Decode config | `max_total_num_tokens` | client goodput | D-side state |
|---|---|---|---|
| TP8 / PP1 (BS 54) | 238,720 | 180 tok/s | GPU KV usage 0.94 — saturated |
| TP4 / PP2 (BS 57) | **442,432** (1.85×) | **285 tok/s** (1.58×) | GPU KV usage 0.54, `#queue-req`≈0 — not saturated |


**TP4/PP2 delivers 1.58× the decode goodput of TP8/PP1 with 1.85× the KV pool**, and that
1.58× is a *lower bound*: TP8/PP1 was pinned at its `max_running_requests` with 94 % of the
GPU KV pool in use, whereas TP4/PP2 still had ~46 % of its (much larger) pool free and an
empty queue — the prefill side, not decode, was the limit at this offered load.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32853700051](https://github.com/sgl-project/sglang/actions/runs/32853700051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32853699810](https://github.com/sgl-project/sglang/actions/runs/32853699810)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32853700471](https://github.com/sgl-project/sglang/actions/runs/32853700471)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->