### PR TITLE
[Model] Add Qwen3.5 sequence classification support

### DIFF
--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -527,6 +527,7 @@ def handle_model_specific_adjustments(server_args: Any):
         "Qwen3_5MoeForConditionalGeneration",
         "InternS2PreviewForConditionalGeneration",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForSequenceClassification",
     ]:
         # The quantization/moe_runner_backend resolution moved to the
         # override registry (arg_groups/overrides.py:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1600,6 +1600,7 @@ def _nemotron_h_overrides(server_args: Any, hf_config: Any) -> dict:
     "InternS2PreviewForConditionalGeneration",
     "InternS2MobiusForConditionalGeneration",
     "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5ForSequenceClassification",
 )
 def _qwen3_5_hybrid_overrides(server_args: Any, hf_config: Any) -> dict:
     cfg = resolving_view(server_args)
@@ -1658,6 +1659,7 @@ def _qwen3vl_overrides(server_args: Any, hf_config: Any) -> dict:
     "Qwen3_5MoeForConditionalGeneration",
     "InternS2PreviewForConditionalGeneration",
     "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5ForSequenceClassification",
 )
 def _qwen3_moe_family_overrides(server_args: Any, hf_config: Any) -> dict:
     cfg = resolving_view(server_args)
@@ -1789,6 +1791,7 @@ _MAMBA_RADIX_CACHE_ARCHS = frozenset(
         "InternS2PreviewForConditionalGeneration",
         "InternS2MobiusForConditionalGeneration",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForSequenceClassification",
         # Text-only entries of the same hybrid stack (models/qwen3_5_text.py);
         # Qwen3.8-2.4T-A95B ships as Qwen3_5MoeForCausalLM.
         "Qwen3_5MoeForCausalLM",
@@ -1812,6 +1815,7 @@ _MAMBA_EXTRA_BUFFER_ARCHS = frozenset(
     {
         "KimiLinearForCausalLM",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForSequenceClassification",
         "Qwen3_5MoeForConditionalGeneration",
         # Text-only entries of the same hybrid stack (models/qwen3_5_text.py);
         # Qwen3.8-2.4T-A95B ships as Qwen3_5MoeForCausalLM.
@@ -2257,6 +2261,7 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
         "Qwen3_5MoeForConditionalGeneration",
         "InternS2PreviewForConditionalGeneration",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForSequenceClassification",
         "NemotronHForCausalLM",
         "NemotronHPuzzleForCausalLM",
     }

--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -246,6 +246,7 @@ def handle_encoder_disaggregation(server_args: Any):
         "Qwen2_5_VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForSequenceClassification",
         "Qwen3_5MoeForConditionalGeneration",
         "InternS2PreviewForConditionalGeneration",
         "Qwen3OmniMoeForConditionalGeneration",

--- a/python/sglang/srt/configs/embedding_model_spec.py
+++ b/python/sglang/srt/configs/embedding_model_spec.py
@@ -146,6 +146,7 @@ _CLASSIFICATION_ARCHITECTURES = {
     "LlamaForSequenceClassificationWithNormal_Weights",
     "Qwen2ForSequenceClassification",
     "Qwen3ForSequenceClassification",
+    "Qwen3_5ForSequenceClassification",
     "XLMRobertaForSequenceClassification",
 }
 
@@ -291,7 +292,9 @@ def resolve_embedding_model_spec(
             tokenizer_special_tokens="model_default",
             supports_dimensions=False,
             supports_token_embeddings=False,
-            supports_multimodal=False,
+            supports_multimodal=(
+                "Qwen3_5ForSequenceClassification" in architecture_set
+            ),
             requires_embedding_flag=False,
             auto_enable_embedding=False,
             bidirectional_attention=False,

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -151,6 +151,7 @@ def is_dspark_draft(config) -> bool:
 def is_qwen3_5(config) -> bool:
     return _hf_arch(config) in (
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForSequenceClassification",
         "Qwen3_5MoeForConditionalGeneration",
         "Qwen3_5ForCausalLM",
         "Qwen3_5MoeForCausalLM",
@@ -1867,6 +1868,7 @@ def is_generation_model(model_architectures: List[str], is_embedding: bool = Fal
         or "Qwen3ForRewardModel" in model_architectures
         or "Qwen2ForSequenceClassification" in model_architectures
         or "Qwen3ForSequenceClassification" in model_architectures
+        or "Qwen3_5ForSequenceClassification" in model_architectures
         or "Qwen3Model" in model_architectures
         or "CLIPModel" in model_architectures
         or "BertModel" in model_architectures
@@ -1925,6 +1927,7 @@ multimodal_model_archs = [
     "Qwen3VLForConditionalGeneration",
     "Qwen3VLMoeForConditionalGeneration",
     "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5ForSequenceClassification",
     "Qwen3_5MoeForConditionalGeneration",
     "InternS2PreviewForConditionalGeneration",
     "InternS2MobiusForConditionalGeneration",
@@ -1986,6 +1989,7 @@ multimodal_breakable_cuda_graph_supported_model_archs = [
     "InternS2MobiusForConditionalGeneration",
     "PaddleOCRVLForConditionalGeneration",
     "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5ForSequenceClassification",
     "Qwen3_5MoeForConditionalGeneration",
     "MuseGlimmerForConditionalGeneration",
     "KimiK3ForConditionalGeneration",

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -201,6 +201,7 @@ def _can_skip_pre_embed_feature_move(data_embedding_func: DataEmbeddingFunc) -> 
         "Qwen3VLForConditionalGeneration",
         "Qwen3VLMoeForConditionalGeneration",
         "Qwen3_5ForConditionalGeneration",
+        "Qwen3_5ForSequenceClassification",
         "Qwen3_5MoeForConditionalGeneration",
         "KimiK25ForConditionalGeneration",
         "KimiK3ForConditionalGeneration",

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -66,6 +66,7 @@ from sglang.srt.layers.parameter import (
     BlockQuantScaleParameter,
     PerTensorScaleParameter,
 )
+from sglang.srt.layers.pooler import Pooler, PoolingType, score_and_pool
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.layers.radix_attention import RadixAttention
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
@@ -2099,8 +2100,15 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         language_model_cls=Qwen3_5ForCausalLM,
+        create_lm_head: bool = True,
     ):
-        super().__init__(config, quant_config, prefix, language_model_cls)
+        super().__init__(
+            config,
+            quant_config,
+            prefix,
+            language_model_cls,
+            create_lm_head=create_lm_head,
+        )
 
         rope_config = getattr(self.config, "rope_parameters", None) or getattr(
             self.config, "rope_scaling", {}
@@ -2246,6 +2254,65 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
                     weight_loader(param_lm_head, loaded_weight)
             loaded_params.add(name)
         return loaded_params
+
+
+class Qwen3_5ForSequenceClassification(Qwen3_5ForConditionalGeneration):
+    """Multimodal Qwen3.5 with a sequence-classification score head.
+
+    The head is applied to the raw last-token hidden state. In particular, it
+    must not reuse the L2-normalized embedding returned by the base Qwen3-VL
+    pooler.
+    """
+
+    def __init__(
+        self,
+        config: Qwen3_5Config,
+        quant_config: Optional[QuantizationConfig] = None,
+        prefix: str = "",
+    ) -> None:
+        num_labels = config.num_labels
+        problem_type = getattr(config, "problem_type", None)
+        super().__init__(config, quant_config, prefix, create_lm_head=False)
+
+        self.num_labels = num_labels
+        self.problem_type = problem_type
+        self.score = nn.Linear(
+            config.text_config.hidden_size,
+            num_labels,
+            bias=False,
+        )
+        self.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=False)
+
+    def _pool_hidden_states(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ):
+        return score_and_pool(
+            self.score,
+            self.pooler,
+            hidden_states,
+            forward_batch,
+            input_ids,
+        )
+
+    def get_embed_and_head(self):
+        embed = self.model.embed_tokens.weight if self.pp_group.is_first_rank else None
+        return embed, None
+
+    def set_embed_and_head(self, embed, head):
+        # The score head is independent from token embeddings and must never be
+        # replaced by the generation lm_head sharing path.
+        super().set_embed_and_head(embed, None)
+
+    def load_weights(self, weights: Iterable[Tuple[str, torch.Tensor]]):
+        filtered_weights = (
+            (name, weight)
+            for name, weight in weights
+            if not name.startswith("lm_head.")
+        )
+        return super().load_weights(filtered_weights)
 
 
 class Qwen3_5MoeForConditionalGeneration(Qwen3VLForConditionalGeneration):
@@ -2676,6 +2743,7 @@ for _entry_class in (
     Qwen3_5ForCausalLM,
     Qwen3_5MoeForCausalLM,
     Qwen3_5ForConditionalGeneration,
+    Qwen3_5ForSequenceClassification,
     Qwen3_5MoeForConditionalGeneration,
 ):
     _entry_class.shared_experts_fusion_disable_reason = staticmethod(
@@ -2683,4 +2751,8 @@ for _entry_class in (
     )
 
 
-EntryClass = [Qwen3_5MoeForConditionalGeneration, Qwen3_5ForConditionalGeneration]
+EntryClass = [
+    Qwen3_5MoeForConditionalGeneration,
+    Qwen3_5ForConditionalGeneration,
+    Qwen3_5ForSequenceClassification,
+]

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1286,6 +1286,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
         quant_config: Optional[QuantizationConfig] = None,
         prefix: str = "",
         language_model_cls=Qwen3LLMModel,
+        create_lm_head: bool = True,
     ) -> None:
         super().__init__()
         self.pp_group = get_pp_group()
@@ -1327,7 +1328,9 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 quant_config=quant_config,
                 prefix=add_prefix("model.language_model", prefix),
             )
-            if self.pp_group.is_last_rank:
+            if not create_lm_head:
+                self.lm_head = None
+            elif self.pp_group.is_last_rank:
                 if (
                     self.pp_group.world_size == 1
                     and self.config.tie_word_embeddings
@@ -1461,6 +1464,19 @@ class Qwen3VLForConditionalGeneration(nn.Module):
     def should_apply_lora(self, module_name: str) -> bool:
         return bool(self._lora_pattern.match(module_name))
 
+    def _pool_hidden_states(
+        self,
+        input_ids: torch.Tensor,
+        hidden_states: torch.Tensor,
+        forward_batch: ForwardBatch,
+    ):
+        """Pool model outputs for embedding-style requests.
+
+        Subclasses with a task-specific head can override this hook without
+        duplicating the multimodal forward path.
+        """
+        return self.pooler(hidden_states, forward_batch)
+
     @torch.no_grad()
     def forward(
         self,
@@ -1526,7 +1542,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                     aux_hidden_states,
                 )
             else:
-                return self.pooler(hidden_states, forward_batch)
+                return self._pool_hidden_states(input_ids, hidden_states, forward_batch)
         else:
             return hidden_states
 

--- a/python/sglang/srt/multimodal/processors/qwen_vl.py
+++ b/python/sglang/srt/multimodal/processors/qwen_vl.py
@@ -25,6 +25,7 @@ from sglang.srt.models.qwen2_5_vl import Qwen2_5_VLForConditionalGeneration
 from sglang.srt.models.qwen2_vl import Qwen2VLForConditionalGeneration
 from sglang.srt.models.qwen3_5 import (
     Qwen3_5ForConditionalGeneration,
+    Qwen3_5ForSequenceClassification,
     Qwen3_5MoeForConditionalGeneration,
 )
 from sglang.srt.models.qwen3_5_mtp import Qwen3_5ForCausalLMMTP
@@ -295,6 +296,7 @@ class QwenVLImageProcessor(SGLangBaseProcessor):
         Qwen3VLForConditionalGeneration,
         Qwen3VLMoeForConditionalGeneration,
         Qwen3_5ForConditionalGeneration,
+        Qwen3_5ForSequenceClassification,
         Qwen3_5MoeForConditionalGeneration,
         Qwen3_5ForCausalLMMTP,
         InternS2PreviewForConditionalGeneration,

--- a/test/registered/unit/configs/test_embedding_model_spec.py
+++ b/test/registered/unit/configs/test_embedding_model_spec.py
@@ -107,6 +107,18 @@ class TestEmbeddingModelSpec(unittest.TestCase):
         self.assertFalse(spec.safe_disable_kv_cache)
         self.assertEqual(spec.bcg_prefill_policy, BCGPrefillPolicy.DEFAULT)
 
+    def test_qwen3_5_classification_preserves_multimodal_capability(self):
+        spec = resolve_embedding_model_spec(
+            ["Qwen3_5ForSequenceClassification"],
+            is_embedding_requested=True,
+            is_embedding_gemma=False,
+        )
+
+        self.assertEqual(spec.task, EmbeddingTask.CLASSIFY)
+        self.assertEqual(spec.execution, EmbeddingExecution.CLASSIFICATION)
+        self.assertFalse(spec.normalize)
+        self.assertTrue(spec.supports_multimodal)
+
     def test_unknown_generation_model_has_no_embedding_contract_without_intent(self):
         spec = resolve_embedding_model_spec(
             ["Qwen3ForCausalLM"],

--- a/test/registered/unit/models/test_qwen3_5_sequence_classification.py
+++ b/test/registered/unit/models/test_qwen3_5_sequence_classification.py
@@ -1,0 +1,89 @@
+"""Unit tests for native Qwen3.5 sequence-classification support."""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from sglang.srt.configs.embedding_model_spec import (
+    EmbeddingExecution,
+    EmbeddingTask,
+    resolve_embedding_model_spec,
+)
+from sglang.srt.configs.model_config import is_generation_model
+from sglang.srt.layers.pooler import Pooler, PoolingType
+from sglang.srt.models.qwen3_5 import Qwen3_5ForSequenceClassification
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class TestQwen3_5ForSequenceClassification(CustomTestCase):
+    def test_registry_resolves_native_class(self):
+        from sglang.srt.models.registry import ModelRegistry
+
+        model_cls, resolved_arch = ModelRegistry.resolve_model_cls(
+            "Qwen3_5ForSequenceClassification"
+        )
+
+        self.assertIs(model_cls, Qwen3_5ForSequenceClassification)
+        self.assertEqual(resolved_arch, "Qwen3_5ForSequenceClassification")
+
+    def test_architecture_is_multimodal_classification(self):
+        architectures = ["Qwen3_5ForSequenceClassification"]
+
+        self.assertFalse(is_generation_model(architectures))
+        spec = resolve_embedding_model_spec(
+            architectures,
+            is_embedding_requested=True,
+            is_embedding_gemma=False,
+        )
+        self.assertEqual(spec.task, EmbeddingTask.CLASSIFY)
+        self.assertEqual(spec.execution, EmbeddingExecution.CLASSIFICATION)
+        self.assertFalse(spec.normalize)
+        self.assertTrue(spec.supports_multimodal)
+
+    def test_score_head_uses_raw_last_token_hidden_state(self):
+        model = Qwen3_5ForSequenceClassification.__new__(
+            Qwen3_5ForSequenceClassification
+        )
+        nn.Module.__init__(model)
+        model.score = nn.Linear(2, 1, bias=False)
+        model.score.weight.data.copy_(torch.tensor([[2.0, -1.0]]))
+        model.pooler = Pooler(pooling_type=PoolingType.LAST, normalize=False)
+
+        hidden_states = torch.tensor(
+            [
+                [1.0, 1.0],
+                [3.0, 4.0],
+                [2.0, 2.0],
+                [6.0, 8.0],
+            ]
+        )
+        forward_batch = SimpleNamespace(
+            extend_seq_lens=torch.tensor([2, 2]),
+            extend_seq_lens_cpu=[2, 2],
+            multi_item_delimiter_indices=None,
+            return_pooled_hidden_states=True,
+            is_prefill_only=True,
+            dimensions=None,
+        )
+
+        output = model._pool_hidden_states(
+            torch.arange(4), hidden_states, forward_batch
+        )
+
+        raw_last_tokens = hidden_states[torch.tensor([1, 3])]
+        torch.testing.assert_close(output.embeddings, model.score(raw_last_tokens))
+        torch.testing.assert_close(output.pooled_hidden_states, raw_last_tokens)
+
+        normalized_scores = model.score(
+            nn.functional.normalize(raw_last_tokens, p=2, dim=-1)
+        )
+        self.assertFalse(torch.allclose(output.embeddings, normalized_scores))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -357,6 +357,7 @@ class TestQwen3_5Gate(_FusionGateCase):
             qwen3_5.Qwen3_5ForCausalLM,
             qwen3_5.Qwen3_5MoeForCausalLM,
             qwen3_5.Qwen3_5ForConditionalGeneration,
+            qwen3_5.Qwen3_5ForSequenceClassification,
             qwen3_5.Qwen3_5MoeForConditionalGeneration,
         ):
             self.assertTrue(


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

SGLang supports Qwen3.5 generation and pooled embeddings, but it does not currently provide a native Qwen3.5 sequence-classification model implementation.

This is required by Qwen3.5 reward models whose checkpoints contain a sequence-level score head, for example:

```text
score.weight: [1, 2560]
problem_type: regression
num_labels: 1
```

The expected reward inference path is:

```text
Qwen3.5 backbone
→ raw LAST-token hidden state
→ score head
→ scalar reward
```

The existing Qwen3.5 embedding path applies L2 normalization to the pooled hidden state. While this is appropriate for embedding models, applying a reward head to that normalized representation changes the reward scale.

For sequence classification and reward inference, the score head must instead operate on the raw pooled hidden state.

This PR adds a dedicated `Qwen3_5ForSequenceClassification` implementation without changing existing Qwen3.5 generation or embedding behavior.

## Modifications

### Model implementation

- Add native `Qwen3_5ForSequenceClassification`.
- Reuse the existing multimodal Qwen3.5 backbone.
- Add a bias-free classification head:

  ```text
  Linear(text_hidden_size, num_labels, bias=False)
  ```

- Pool the raw LAST-token hidden state with:

  ```text
  PoolingType.LAST
  normalize=False
  ```

- Apply the score head through the existing `score_and_pool` infrastructure.
- Return raw logits/rewards without applying softmax.
- Skip loading generation-only `lm_head` weights for classification checkpoints.

### Shared Qwen3-VL integration

- Add an optional `create_lm_head` constructor argument while preserving `True` as the default.
- Add an overridable `_pool_hidden_states` hook to the shared multimodal forward path.
- Keep the existing normalized embedding pooler as the default implementation.
- Let the sequence-classification subclass override only the task-specific pooling/scoring step.
- Avoid constructing an unused vocabulary-sized generation head for classification models.

The defaults preserve existing Qwen3-VL and Qwen3.5 generation behavior.

### Runtime and model registration

Register `Qwen3_5ForSequenceClassification` in the existing Qwen3.5 capability paths:

- model registry
- classification model specification
- Qwen3.5 architecture detection
- non-generation model detection
- multimodal model support
- multimodal processor routing
- hybrid/Mamba runtime overrides
- Mamba radix-cache support
- CUDA graph capability lists
- multimodal scheduling
- shared-expert fusion gating

The classification model is exposed through SGLang's existing pooled-output serving mode.

### Tests

Add unit coverage for:

- native model-registry resolution
- classification task and execution-mode resolution
- preservation of multimodal capability
- LAST-token pooling
- use of the raw hidden state rather than an L2-normalized embedding
- score-head output
- shared-expert fusion gating

## Accuracy Tests

### Static checks

The following checks passed:

```bash
python -m compileall -q \
  python/sglang/srt/models/qwen3_5.py \
  python/sglang/srt/models/qwen3_vl.py \
  test/registered/unit/models/test_qwen3_5_sequence_classification.py

git diff --check
```

### Unit tests

Executed on an NVIDIA H800 environment:

```bash
python -m pytest -q \
  test/registered/unit/configs/test_embedding_model_spec.py \
  test/registered/unit/models/test_qwen3_5_sequence_classification.py \
  test/registered/unit/models/test_shared_experts_fusion_gates.py
```

Result:

```text
38 passed, 5 warnings, 2 subtests passed
```

The warnings were dependency deprecation/configuration warnings and did not indicate test failures.

### End-to-end reward validation

The implementation was validated with a BF16 Qwen3.5 4B regression reward checkpoint trained with ms-swift.

Relevant checkpoint properties:

```text
hidden_size: 2560
score.weight: [1, 2560]
problem_type: regression
num_labels: 1
```

The validation checkpoint stores:

```text
architectures = ["Qwen3_5ForConditionalGeneration"]
```

despite containing a regression `score.weight` head. For validation, the architecture was therefore explicitly overridden:

```bash
--json-model-override-args \
'{"architectures":["Qwen3_5ForSequenceClassification"]}'
```

This PR intentionally does not automatically reinterpret ordinary `Qwen3_5ForConditionalGeneration` checkpoints as reward models, because doing so could change normal generation behavior.

The exact 18-token input used for the SGLang/ms-swift comparison was:

```text
[
  248045, 846, 198, 9419, 11, 18553, 5941, 25899, 13,
  248046, 198, 248045, 74455, 198, 248068, 271, 248069, 271
]
```

Results:

```text
Input tokens:     18
SGLang reward:   -1.4296875
ms-swift reward: -1.4296875
Absolute error:   0.0
```

A separate comparison with Hugging Face used the same six raw-text token IDs:

```text
SGLang reward:    -1.484375
Hugging Face:     -1.4921875
Absolute error:    0.0078125
```

The remaining difference is one BF16 quantization step and is within the expected BF16 tolerance.

### Template alignment

The initial difference between SGLang and ms-swift raw-string requests was traced to preprocessing rather than model computation.

ms-swift converts a raw input string into a user message and applies the Qwen3.5 chat template with:

```text
add_generation_prompt=True
enable_thinking=False
```

This produces 18 tokens, while the plain SGLang string request contains six tokens.

When SGLang receives the same 18 token IDs, the reward matches ms-swift exactly:

```text
-1.4296875
```

This PR does not globally add ms-swift-specific template processing to `/v1/embeddings`. Callers remain responsible for applying preprocessing consistent with model training.

### Validation limitations

- Text reward inference was validated end to end.
- The multimodal model and processor paths are registered, but image/video reward inputs have not yet been validated end to end.
- The ms-swift validation checkpoint uses non-standard architecture metadata, so it requires the explicit architecture override shown above.

## Speed Tests and Profiling

No formal speed benchmark was collected for this PR.

This change does not introduce new CUDA kernels, attention implementations, or generation hot-path changes. It reuses the existing Qwen3.5 multimodal backbone and pooled-output infrastructure.

For sequence-classification requests, the generation `lm_head` is not constructed. The only task-specific operation added after pooling is a small linear score head.

The H800 end-to-end validation used Triton attention and linear-attention backends because the validation environment retained an older preinstalled SGLang kernel stack. Performance with the current fully matched main-branch dependency stack remains to be benchmarked.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (N/A: this PR uses the existing pooled-output API and adds no new public API or CLI option.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Accuracy results are provided above; speed benchmarking is not applicable to a new-kernel comparison because this PR adds no new kernel or attention implementation.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33238211852](https://github.com/sgl-project/sglang/actions/runs/33238211852)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33238211707](https://github.com/sgl-project/sglang/actions/runs/33238211707)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33238211802](https://github.com/sgl-project/sglang/actions/runs/33238211802)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->