### PR TITLE
[Fix][Spec] TRTLLM-MHA draft-extend graph replay races req_to_token writes; defer WAR read-done via a dedicated capability

### DIFF
--- a/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
+++ b/python/sglang/srt/hardware_backend/musa/attention/flashattention_backend.py
@@ -925,6 +925,12 @@ class MusaFlashAttentionBackend(FlashAttentionBackend):
 
         return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        # FlashAttentionBackend declares support, but the musa draft-extend
+        # graph path has not been validated; keep the pre-capability behavior
+        # (eager draft-extend).
+        return False
+
 
 class MusaFlashAttentionMultiStepBackend(FlashAttentionMultiStepBackend):
 

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -113,6 +113,16 @@ class AttentionBackend(ABC):
         :py:meth:`init_forward_metadata_out_graph` call."""
         return False
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        """True when this backend supports capture under the EAGLE worker's
+        draft-extend (DRAFT_EXTEND_V2) CUDA graph runner.
+
+        Metadata is still rebuilt eagerly via
+        :py:meth:`init_forward_metadata_out_graph` before every replay, so this
+        only requires the backend's DRAFT_EXTEND_V2 kernels to be capturable
+        against the static buffers from :py:meth:`init_cuda_graph_state`."""
+        return False
+
     # Opt out only when this backend never reads seq_lens_cpu / seq_lens_sum.
     needs_cpu_seq_lens: bool = True
 

--- a/python/sglang/srt/layers/attention/base_attn_backend.py
+++ b/python/sglang/srt/layers/attention/base_attn_backend.py
@@ -123,6 +123,21 @@ class AttentionBackend(ABC):
         against the static buffers from :py:meth:`init_cuda_graph_state`."""
         return False
 
+    def draft_extend_rereads_shared_state_in_graph(self) -> bool:
+        """True when this backend's captured DRAFT_EXTEND_V2 graph re-reads
+        scheduler-shared state (req_to_token) while replaying, so the
+        draft-extend graph runner must record its WAR read-done event after
+        the replay launch instead of before it.
+
+        An in-graph metadata rebuild re-reads req_to_token by construction,
+        hence the default mirrors
+        :py:meth:`draft_extend_metadata_captured_in_graph`. Backends whose
+        recorded capture re-reads shared state without satisfying that
+        method's full-rebuild contract (its consumers skip the eager
+        :py:meth:`init_forward_metadata_out_graph` call and gate multi-layer
+        single-graph draft modes on it) must override this method alone."""
+        return self.draft_extend_metadata_captured_in_graph()
+
     # Opt out only when this backend never reads seq_lens_cpu / seq_lens_sum.
     needs_cpu_seq_lens: bool = True
 

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -2264,6 +2264,9 @@ class DeepseekV4AttnBackend(
         )
         return swa_page_indices, swa_topk_lengths
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class DeepseekV4MultiStepBackend(DeepseekV4AttnBackend):
     def __init__(

--- a/python/sglang/srt/layers/attention/dots_hybrid_backend.py
+++ b/python/sglang/srt/layers/attention/dots_hybrid_backend.py
@@ -162,6 +162,9 @@ class DotsSWAMLAAttnBackend(AttentionBackend):
     def draft_extend_metadata_captured_in_graph(self) -> bool:
         return self.backend.draft_extend_metadata_captured_in_graph()
 
+    def draft_extend_rereads_shared_state_in_graph(self) -> bool:
+        return self.backend.draft_extend_rereads_shared_state_in_graph()
+
     def selected_backend(self, forward_batch: ForwardBatch) -> AttentionBackend:
         return (
             self.backend._select_backend(forward_batch.forward_mode)

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -3425,6 +3425,9 @@ class DeepseekSparseAttnBackend(
             num_splits=num_splits,
         )
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class DeepseekSparseAttnMultiStepBackend:
 

--- a/python/sglang/srt/layers/attention/flashattention_backend.py
+++ b/python/sglang/srt/layers/attention/flashattention_backend.py
@@ -136,8 +136,10 @@ class FlashAttentionBackend(AttentionBackend):
             - It will spawn num_steps FlashAttentionBackend for the draft worker
 
     Note about CUDA Graph:
-    - We only support CUDA Graph for Decode (Normal Decode and Draft Decode) and Target Verify.
-    - We don't support CUDA Graph for Extend and Draft Extend.
+    - We only support CUDA Graph for Decode (Normal Decode and Draft Decode), Target Verify,
+      and single-layer EAGLE Draft Extend (DRAFT_EXTEND_V2; guarded off for sliding-window
+      KV pools, see supports_draft_extend_cuda_graph).
+    - We don't support CUDA Graph for Extend.
     - When server init, init_cuda_graph_state will be called first and then init_cuda_graph_capture will be called.
     - For each forward batch, init_replay_cuda_graph will be called first and then replay the graph.
     """
@@ -453,6 +455,12 @@ class FlashAttentionBackend(AttentionBackend):
             not self.use_sliding_window_kv_pool
             or self.token_to_kv_pool.full_to_swa_index_mapping is not None
         )
+
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        # SWA models translate out_cache_loc into the sliding-window pool when
+        # rebuilding draft-extend metadata; that combination has not been
+        # exercised under the draft-extend graph runner, so keep it eager.
+        return not self.use_sliding_window_kv_pool
 
     def init_forward_metadata_out_graph(
         self,

--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -1491,6 +1491,9 @@ class FlashInferAttnBackend(AttentionBackend):
 
         raise ValueError(f"Unknown dispatch reason: {self.dispatch_reason}")
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class FlashInferIndicesUpdaterDecode:
     def __init__(self, model_runner: ModelRunner, attn_backend: FlashInferAttnBackend):

--- a/python/sglang/srt/layers/attention/flashmla_backend.py
+++ b/python/sglang/srt/layers/attention/flashmla_backend.py
@@ -562,6 +562,9 @@ class FlashMLABackend(FlashInferMLAAttnBackend):
                 )
             return o.view(-1, layer.tp_q_head_num * layer.v_head_dim)
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class FlashMLAMultiStepDraftBackend:
     # Read by decide_needs_cpu_seq_lens (getattr defaults missing flags to True).

--- a/python/sglang/srt/layers/attention/linear/inkling_sconv_backend.py
+++ b/python/sglang/srt/layers/attention/linear/inkling_sconv_backend.py
@@ -611,3 +611,6 @@ class InklingShortConvHybridAttnBackend(ShortConvHybridAttnBackend):
 
     def draft_extend_metadata_captured_in_graph(self) -> bool:
         return self.full_attn_backend.draft_extend_metadata_captured_in_graph()
+
+    def draft_extend_rereads_shared_state_in_graph(self) -> bool:
+        return self.full_attn_backend.draft_extend_rereads_shared_state_in_graph()

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -1948,6 +1948,9 @@ class TritonAttnBackend(AttentionBackend):
         )
         return o
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class TritonMultiStepDraftBackend:
     """

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -942,6 +942,17 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             out_cache_loc=forward_batch.out_cache_loc,
         )
 
+    def draft_extend_rereads_shared_state_in_graph(self) -> bool:
+        # init_forward_metadata_in_graph is recorded into the draft-extend
+        # capture (_apply_cuda_graph_metadata ->
+        # update_trtllm_mha_graph_metadata), so every replay re-reads
+        # req_to_token on device. That rebuild does not satisfy
+        # draft_extend_metadata_captured_in_graph()'s contract (replay still
+        # needs the eager init_forward_metadata_out_graph call to rebind
+        # forward_metadata per step, so multi-layer single-graph draft modes
+        # must stay gated off); declare only the WAR read-done deferral.
+        return True
+
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize the metadata for a forward pass."""
 

--- a/python/sglang/srt/layers/attention/trtllm_mla_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mla_backend.py
@@ -1532,6 +1532,9 @@ class TRTLLMMLABackend(FlashInferMLAAttnBackend):
                 o_sf_scale=1.0,
             )
 
+    def supports_draft_extend_cuda_graph(self) -> bool:
+        return True
+
 
 class TRTLLMMLAMultiStepDraftBackend(FlashInferMLAMultiStepDraftBackend):
     """Multi-step draft backend for TRT-LLM MLA used by EAGLE."""

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -591,18 +591,31 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
-        # Snapshot built -- the forward is done reading the shared pool. Publish
-        # a read-done event the scheduler's WAR barrier waits on (draft extend
-        # is the EAGLE-family last shared-read phase; last write wins the mailbox).
-        read_done = self.device_module.Event()
-        read_done.record()
-        self.model_runner.shared_read_done_event = read_done
+        # Publish a read-done event the scheduler's WAR barrier waits on before
+        # its next shared-buffer write (draft extend is the EAGLE-family last
+        # shared-read phase; last write wins the mailbox). Backends that rebuild
+        # replay metadata inside the captured graph re-read req_to_token during
+        # replay itself, so their event must be recorded after the replay
+        # launch; all other backends retain the legacy early publication and
+        # its scheduler overlap.
+        publish_read_done_after_replay = (
+            self.draft_extend_attn_backend.draft_extend_metadata_captured_in_graph()
+        )
+        if not publish_read_done_after_replay:
+            read_done = self.device_module.Event()
+            read_done.record()
+            self.model_runner.shared_read_done_event = read_done
 
         self.raw_bs = raw_bs
         self.bs = bs
         shape_key = self._make_graph_key(bs)
         with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
             out = self._replay_graph(shape_key, forward_batch)
+
+        if publish_read_done_after_replay:
+            read_done = self.device_module.Event()
+            read_done.record()
+            self.model_runner.shared_read_done_event = read_done
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],

--- a/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
+++ b/python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py
@@ -74,6 +74,15 @@ class EagleDraftExtendInputBuffers(ForwardInputBuffers):
     dsa_seed_topk_capture: Optional[torch.Tensor] = None
 
 
+def read_done_publishes_after_replay(draft_extend_attn_backend) -> bool:
+    """Position of the scheduler WAR read-done record relative to the replay
+    launch: after it when the backend's captured draft-extend graph re-reads
+    scheduler-shared state (req_to_token) during replay itself, before it
+    otherwise (keeping the legacy scheduler overlap). Module-level so tests
+    can pin the runner's ordering decision against the backend capability."""
+    return draft_extend_attn_backend.draft_extend_rereads_shared_state_in_graph()
+
+
 class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
     """EAGLE draft-extend cuda-graph runner.
 
@@ -467,6 +476,30 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
                     post_warmup_hook=post_warmup_hook,
                 )
 
+    def _publish_read_done(self):
+        read_done = self.device_module.Event()
+        read_done.record()
+        self.model_runner.shared_read_done_event = read_done
+
+    def _replay_and_publish_read_done(self, shape_key, forward_batch):
+        """Launch the captured graph and publish the read-done event the
+        scheduler's WAR barrier waits on before its next shared-buffer write
+        (draft extend is the EAGLE-family last shared-read phase; last write
+        wins the mailbox). Backends whose captured graph re-reads req_to_token
+        during replay itself (an in-graph metadata rebuild, or a recorded
+        kernel gathering from the shared table) must have their event recorded
+        after the replay launch; all other backends retain the legacy early
+        publication and its scheduler overlap. This method owns that ordering;
+        tests pin it via spies."""
+        publish_after = read_done_publishes_after_replay(self.draft_extend_attn_backend)
+        if not publish_after:
+            self._publish_read_done()
+        with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
+            out = self._replay_graph(shape_key, forward_batch)
+        if publish_after:
+            self._publish_read_done()
+        return out
+
     def execute(self, forward_batch: ForwardBatch):
         assert forward_batch.out_cache_loc is not None
         self.deepep_adapter.replay()
@@ -591,31 +624,10 @@ class EAGLEDraftExtendCudaGraphRunner(DecodeCudaGraphRunner):
         )
         self.draft_extend_attn_backend.init_forward_metadata_out_graph(fb_view)
 
-        # Publish a read-done event the scheduler's WAR barrier waits on before
-        # its next shared-buffer write (draft extend is the EAGLE-family last
-        # shared-read phase; last write wins the mailbox). Backends that rebuild
-        # replay metadata inside the captured graph re-read req_to_token during
-        # replay itself, so their event must be recorded after the replay
-        # launch; all other backends retain the legacy early publication and
-        # its scheduler overlap.
-        publish_read_done_after_replay = (
-            self.draft_extend_attn_backend.draft_extend_metadata_captured_in_graph()
-        )
-        if not publish_read_done_after_replay:
-            read_done = self.device_module.Event()
-            read_done.record()
-            self.model_runner.shared_read_done_event = read_done
-
         self.raw_bs = raw_bs
         self.bs = bs
         shape_key = self._make_graph_key(bs)
-        with device_timer_ctx(self.model_runner.device_timer, "eagle_draft_extend"):
-            out = self._replay_graph(shape_key, forward_batch)
-
-        if publish_read_done_after_replay:
-            read_done = self.device_module.Event()
-            read_done.record()
-            self.model_runner.shared_read_done_event = read_done
+        out = self._replay_and_publish_read_done(shape_key, forward_batch)
 
         out = LogitsProcessorOutput(
             next_token_logits=out.next_token_logits[:num_tokens],

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -17,14 +17,7 @@ from sglang.srt.hardware_backend.npu.graph_runner.eagle_draft_npu_graph_runner i
 )
 from sglang.srt.hardware_backend.npu.graph_runner.npu_graph_runner import NPUGraphRunner
 from sglang.srt.kv_canary.runner.canary_manager import context_tuple
-from sglang.srt.layers.attention.flashinfer_backend import FlashInferAttnBackend
 from sglang.srt.layers.attention.index_topk_share import IndexTopKShareState
-from sglang.srt.layers.attention.tokenspeed_mla_backend import TokenspeedMLABackend
-from sglang.srt.layers.attention.triton_backend import TritonAttnBackend
-from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
-from sglang.srt.layers.attention.trtllm_mla_backend import (
-    TRTLLMMLABackend,
-)
 from sglang.srt.layers.moe.utils import (
     draft_model_build_scope,
     speculative_moe_a2a_backend_context,
@@ -421,42 +414,16 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 self.draft_attn_backend, AiterMultiStepDraftBackend
             ) or isinstance(self.draft_extend_attn_backend, DeepseekV4HipRadixBackend)
 
-        graph_supported_backend_types = [
-            TritonAttnBackend,
-            TRTLLMMLABackend,
-            TRTLLMHAAttnBackend,
-            TokenspeedMLABackend,
-            FlashInferAttnBackend,
-        ]
-        if _is_cuda or _is_musa:
-            # DSA is CUDA-only; import lazily so non-CUDA builds don't pull in
-            # deep_gemm and the rest of the sparse-attention stack at import time.
-            from sglang.srt.layers.attention.dsa_backend import (
-                DeepseekSparseAttnBackend,
-            )
-
-            graph_supported_backend_types.append(DeepseekSparseAttnBackend)
-            from sglang.srt.layers.attention.deepseek_v4_backend import (
-                DeepseekV4AttnBackend,
-            )
-
-            graph_supported_backend_types.append(DeepseekV4AttnBackend)
-        if _is_cuda:
-            # FlashMLA is CUDA-only; import lazily so CPU builds don't pull
-            # sgl_kernel.flash_mla at import time.
-            from sglang.srt.layers.attention.flashmla_backend import FlashMLABackend
-
-            graph_supported_backend_types.append(FlashMLABackend)
-
-        graph_supported_backend = isinstance(
-            self.draft_extend_attn_backend,
-            tuple(graph_supported_backend_types),
+        # Backends declare draft-extend graph support by overriding
+        # AttentionBackend.supports_draft_extend_cuda_graph().
+        graph_supported_backend = (
+            self.draft_extend_attn_backend is not None
+            and self.draft_extend_attn_backend.supports_draft_extend_cuda_graph()
         )
         supports_cuda_draft_extend_graph = (
             _is_cuda or _is_musa
         ) and graph_supported_backend
         # Capture extend
-        # TODO: support draft extend cuda graph for more attention backends
         if (
             self.draft_extend_attn_backend
             and not envs.SGLANG_DISABLE_DRAFT_EXTEND_CUDA_GRAPH.get()

--- a/test/registered/unit/spec/test_draft_extend_graph_capability.py
+++ b/test/registered/unit/spec/test_draft_extend_graph_capability.py
@@ -1,0 +1,51 @@
+"""Pin tests for the draft-extend CUDA-graph backend capability.
+
+``eagle_worker_v2`` gates draft-extend graph capture on
+``AttentionBackend.supports_draft_extend_cuda_graph()``. It used to be an
+isinstance allowlist that omitted ``FlashAttentionBackend`` even though fa3's
+DRAFT_EXTEND_V2 graph machinery exists and is unit-tested (see
+``test/registered/attention/unittests/dense/test_fa3.py``). Pins: the
+FlashAttention backend declares support (fa3/fa4 EAGLE draft-extend runs under
+CUDA graph), support implies the in-graph metadata rebuild the WAR read-done
+publication relies on, and the sliding-window-pool combination stays on the
+eager path.
+"""
+
+import unittest
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.flashattention_backend import FlashAttentionBackend
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=2, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestDraftExtendGraphCapability(CustomTestCase):
+    def test_flashattention_declares_support(self):
+        backend = object.__new__(FlashAttentionBackend)
+        backend.use_sliding_window_kv_pool = False
+        self.assertTrue(backend.supports_draft_extend_cuda_graph())
+        # Backends that never declared support keep the eager default.
+        base = object.__new__(AttentionBackend)
+        self.assertFalse(base.supports_draft_extend_cuda_graph())
+
+    def test_support_implies_in_graph_metadata_rebuild(self):
+        # The draft-extend graph runner keys its WAR read-done publication on
+        # draft_extend_metadata_captured_in_graph(): FA rebuilds metadata inside
+        # the captured graph (re-reading req_to_token at replay time), so
+        # whenever it declares graph support it must also declare the in-graph
+        # rebuild -- otherwise the scheduler's next-batch shared-buffer writes
+        # could race the replay's reads.
+        backend = object.__new__(FlashAttentionBackend)
+        backend.use_sliding_window_kv_pool = False
+        self.assertTrue(backend.draft_extend_metadata_captured_in_graph())
+
+    def test_swa_pool_stays_eager(self):
+        backend = object.__new__(FlashAttentionBackend)
+        backend.use_sliding_window_kv_pool = True
+        self.assertFalse(backend.supports_draft_extend_cuda_graph())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_draft_extend_graph_capability.py
+++ b/test/registered/unit/spec/test_draft_extend_graph_capability.py
@@ -32,6 +32,7 @@ class TestDraftExtendGraphCapability(CustomTestCase):
 
     def test_support_implies_in_graph_metadata_rebuild(self):
         # The draft-extend graph runner keys its WAR read-done publication on
+        # draft_extend_rereads_shared_state_in_graph(), whose default mirrors
         # draft_extend_metadata_captured_in_graph(): FA rebuilds metadata inside
         # the captured graph (re-reading req_to_token at replay time), so
         # whenever it declares graph support it must also declare the in-graph

--- a/test/registered/unit/spec/test_trtllm_mha_draft_extend_war_read_done.py
+++ b/test/registered/unit/spec/test_trtllm_mha_draft_extend_war_read_done.py
@@ -1,0 +1,258 @@
+"""TRTLLM-MHA draft-extend WAR read-done capability and ordering pins.
+
+The EAGLE draft-extend CUDA-graph runner publishes
+``model_runner.shared_read_done_event`` -- the event the scheduler WAR barrier
+(``Scheduler._apply_war_barrier``) waits on before its next shared-buffer
+write (e.g. ``assign_req_to_token_pool_func`` in ``mem_cache/allocation.py``).
+TRTLLM-MHA records its draft-extend metadata rebuild INTO the captured graph
+(``init_forward_metadata_in_graph`` -> ``_apply_cuda_graph_metadata`` ->
+``update_trtllm_mha_graph_metadata``), so every replay re-reads
+``req_to_token`` on device. Publishing the read-done event before the replay
+launch therefore lets the scheduler race its next-batch ``req_to_token``
+writes against the replay reads: silently wrong page tables, no error. The
+runner keys the publication position on
+``AttentionBackend.draft_extend_rereads_shared_state_in_graph()``.
+
+Pins, on a real graph capture of the backend recorded metadata rebuild:
+  1. the premise: replay re-reads ``req_to_token`` (no capture-time snapshot);
+  2. the capability decoupling: rereads-shared-state is True while
+     ``draft_extend_metadata_captured_in_graph()`` stays False (that one lets
+     runners skip the eager out-graph rebuild and gates multi-layer
+     single-graph draft modes -- TRTLLM-MHA satisfies neither);
+  3. the ordering: with a deterministically widened race window, the pre-fix
+     early publication reproduces the corruption, and the post-replay
+     publication the capability selects keeps the snapshot intact.
+"""
+
+import unittest
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
+from sglang.srt.layers.attention.trtllm_mha_backend import TRTLLMHAAttnBackend
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative.eagle_draft_extend_cuda_graph_runner import (
+    EAGLEDraftExtendCudaGraphRunner,
+    read_done_publishes_after_replay,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+
+BS = 4
+POOL_SIZE = 8
+PAGE_SIZE = 32
+MAX_NUM_PAGES = 16
+MAX_CTX = MAX_NUM_PAGES * PAGE_SIZE
+NUM_TOKENS_PER_REQ = 4
+
+
+def _page_aligned_table(page_base: int, device) -> torch.Tensor:
+    """req_to_token whose row r maps page p to page id page_base + r*MAX + p."""
+    rows = []
+    for r in range(POOL_SIZE):
+        pages = page_base + r * MAX_NUM_PAGES + torch.arange(MAX_NUM_PAGES)
+        rows.append(torch.repeat_interleave(pages * PAGE_SIZE, PAGE_SIZE))
+    return torch.stack(rows).to(dtype=torch.int32, device=device)
+
+
+def _expected_page_table(page_base: int, req_pool_indices, device) -> torch.Tensor:
+    cols = torch.arange(MAX_NUM_PAGES, device=device, dtype=torch.int32)
+    base = page_base + req_pool_indices.to(torch.int32) * MAX_NUM_PAGES
+    return base[:, None] + cols[None, :]
+
+
+class _StubCapturedBackend(AttentionBackend):
+    def draft_extend_metadata_captured_in_graph(self) -> bool:
+        return True
+
+
+class TestTRTLLMMHADraftExtendWARReadDone(CustomTestCase):
+    def _make_backend(self, device):
+        # Skeleton instance: only the state the draft-extend graph metadata
+        # path touches, mirroring init_cuda_graph_state allocations.
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        backend.device = device
+        backend.page_size = PAGE_SIZE
+        backend.max_num_pages = MAX_NUM_PAGES
+        backend._swa_kv_pool = None
+        backend._swa_full_to_swa_mapping = None
+        backend.use_sliding_window_kv_pool = False
+        backend.expand_encoder_only_verify = False
+        backend.speculative_step_id = 0
+        backend.forward_metadata = None
+        backend.req_to_token = _page_aligned_table(0, device)
+        backend.draft_extend_metadata = {
+            "cache_seqlens": torch.zeros(BS, dtype=torch.int32, device=device),
+            "cu_seqlens_q": torch.zeros(BS + 1, dtype=torch.int32, device=device),
+            "cu_seqlens_k": torch.zeros(BS + 1, dtype=torch.int32, device=device),
+            "page_table": torch.zeros(
+                BS, MAX_NUM_PAGES, dtype=torch.int32, device=device
+            ),
+            "swa_page_table": None,
+        }
+        return backend
+
+    def _capture(self, device):
+        """Capture the backend recorded draft-extend metadata rebuild, exactly
+        as EAGLEDraftExtendCudaGraphRunner captures init_forward_metadata_in_graph."""
+        backend = self._make_backend(device)
+        req_pool_indices = torch.tensor([5, 2, 7, 0], dtype=torch.int64, device=device)
+        fb = SimpleNamespace(
+            batch_size=BS,
+            req_pool_indices=req_pool_indices,
+            # All pages live so the kernel rewrites every column.
+            seq_lens=torch.full((BS,), MAX_CTX, dtype=torch.int64, device=device),
+            forward_mode=ForwardMode.DRAFT_EXTEND_V2,
+            spec_info=SimpleNamespace(num_tokens_per_req=NUM_TOKENS_PER_REQ),
+            out_cache_loc=None,
+        )
+        backend._build_cuda_graph_metadata(
+            BS,
+            BS * NUM_TOKENS_PER_REQ,
+            ForwardMode.DRAFT_EXTEND_V2,
+            fb.spec_info,
+            device,
+        )
+        # Warm up the triton JIT outside capture.
+        backend.init_forward_metadata_in_graph(fb)
+        torch.cuda.synchronize()
+        graph = torch.cuda.CUDAGraph()
+        with torch.cuda.graph(graph):
+            backend.init_forward_metadata_in_graph(fb)
+        torch.cuda.synchronize()
+        return backend, graph, req_pool_indices
+
+    def _page_table(self, backend) -> torch.Tensor:
+        return backend.draft_extend_metadata[BS].page_table
+
+    def test_replay_rereads_req_to_token(self):
+        """The captured rebuild gathers from req_to_token at replay time."""
+        device = torch.device("cuda")
+        backend, graph, req_pool_indices = self._capture(device)
+        backend.req_to_token.copy_(_page_aligned_table(1000, device))
+        graph.replay()
+        torch.cuda.synchronize()
+        torch.testing.assert_close(
+            self._page_table(backend),
+            _expected_page_table(1000, req_pool_indices, device),
+            msg="replay did not re-read req_to_token; re-audit "
+            "draft_extend_rereads_shared_state_in_graph before changing it",
+        )
+
+    def test_capability_decoupled_from_captured_in_graph(self):
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        # WAR deferral: the captured graph re-reads shared state at replay.
+        self.assertTrue(backend.draft_extend_rereads_shared_state_in_graph())
+        # Unchanged: replay still needs the eager out-graph rebind, and
+        # multi-layer single-graph draft modes must stay gated off.
+        self.assertFalse(backend.draft_extend_metadata_captured_in_graph())
+
+    def test_base_default_mirrors_captured_in_graph(self):
+        base = object.__new__(AttentionBackend)
+        self.assertFalse(base.draft_extend_rereads_shared_state_in_graph())
+        stub = object.__new__(_StubCapturedBackend)
+        self.assertTrue(stub.draft_extend_rereads_shared_state_in_graph())
+
+    def _run_publication_protocol(self, publish_after_replay: bool) -> bool:
+        """Emulate the runner/scheduler WAR protocol around one replay.
+
+        The writer stream is the scheduler: it waits on the published
+        read-done event, then overwrites req_to_token -- exactly what
+        Scheduler._apply_war_barrier permits. The pre-fix early publication
+        PERMITS the write to land before the replay's reads; that permitted
+        interleaving is constructed deterministically (writer_done fence)
+        instead of racing free-running streams. Returns True when the replay
+        observed the pre-write snapshot (correct), False when it observed the
+        writer mutation (silent corruption).
+        """
+        device = torch.device("cuda")
+        backend, graph, req_pool_indices = self._capture(device)
+        mutated = _page_aligned_table(1000, device)
+        forward_stream = torch.cuda.Stream()
+        writer_stream = torch.cuda.Stream()
+        read_done = torch.cuda.Event()
+        writer_done = torch.cuda.Event()
+        torch.cuda.synchronize()
+        if publish_after_replay:
+            # Fixed protocol: the read-done record lands after the replay on
+            # the same stream, so the waiting writer cannot precede the reads.
+            with torch.cuda.stream(forward_stream):
+                graph.replay()
+                read_done.record()
+            with torch.cuda.stream(writer_stream):
+                writer_stream.wait_event(read_done)
+                backend.req_to_token.copy_(mutated)
+        else:
+            # Pre-fix protocol: the event is already recorded when the writer
+            # waits on it, so the write may land before the replay's reads.
+            with torch.cuda.stream(forward_stream):
+                read_done.record()
+            with torch.cuda.stream(writer_stream):
+                writer_stream.wait_event(read_done)
+                backend.req_to_token.copy_(mutated)
+                writer_done.record()
+            with torch.cuda.stream(forward_stream):
+                forward_stream.wait_event(writer_done)
+                graph.replay()
+        torch.cuda.synchronize()
+        snapshot = _expected_page_table(0, req_pool_indices, device)
+        return bool(torch.equal(self._page_table(backend), snapshot))
+
+    def test_early_publication_reproduces_the_race(self):
+        """Pre-fix ordering: the scheduler write beats the replay reads."""
+        self.assertFalse(self._run_publication_protocol(publish_after_replay=False))
+
+    def test_capability_selected_ordering_is_safe(self):
+        """The ordering the runner actually derives for this backend
+        (read_done_publishes_after_replay, the production predicate) keeps the
+        replay reading the snapshot; regressing either the capability or the
+        runner predicate makes this test observe the corruption again."""
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        publish_after_replay = read_done_publishes_after_replay(backend)
+        self.assertTrue(
+            self._run_publication_protocol(publish_after_replay=publish_after_replay)
+        )
+
+    def _spy_replay_sequence(self, backend) -> list:
+        """Drive the production replay/publication sequence with spies and
+        return the observed call order."""
+        calls = []
+        recorded = []
+
+        class _SpyEvent:
+            def record(self):
+                calls.append("record")
+                recorded.append(self)
+
+        runner = object.__new__(EAGLEDraftExtendCudaGraphRunner)
+        runner.device_module = SimpleNamespace(Event=_SpyEvent)
+        runner.model_runner = SimpleNamespace(
+            device_timer=None, shared_read_done_event=None
+        )
+        runner.draft_extend_attn_backend = backend
+        runner._replay_graph = lambda shape_key, forward_batch: calls.append("replay")
+        runner._replay_and_publish_read_done(None, None)
+        # The published event must be the one this phase recorded.
+        self.assertEqual(len(recorded), 1)
+        self.assertIs(runner.model_runner.shared_read_done_event, recorded[0])
+        return calls
+
+    def test_production_sequence_defers_record_for_trtllm_mha(self):
+        """The runner's own replay/publication method must record the WAR
+        read-done event after the replay launch for TRTLLM-MHA (its captured
+        graph re-reads req_to_token during replay)."""
+        backend = object.__new__(TRTLLMHAAttnBackend)
+        self.assertEqual(self._spy_replay_sequence(backend), ["replay", "record"])
+
+    def test_production_sequence_keeps_early_record_for_eager_backends(self):
+        """Backends without in-graph shared-state re-reads keep the legacy
+        early publication (scheduler overlap)."""
+        backend = object.__new__(AttentionBackend)
+        self.assertEqual(self._spy_replay_sequence(backend), ["record", "replay"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

TRTLLM-MHA silently reads a torn `req_to_token` during EAGLE draft-extend CUDA-graph replay under the (default) overlap scheduler: a write-after-read race that produces wrong page tables — wrong attention inputs — with no error.

Mechanism (all references on this branch):

1. **The captured draft-extend graph re-reads `req_to_token` at replay time.** `TRTLLMHAAttnBackend.init_forward_metadata_in_graph` (`python/sglang/srt/layers/attention/trtllm_mha_backend.py:935`) is recorded into the captured graph and runs `_apply_cuda_graph_metadata` -> `update_trtllm_mha_graph_metadata(..., req_to_token=self.req_to_token, ...)` (`trtllm_mha_backend.py:769`): every replay gathers the page table from the shared `req_to_token` on device.
2. **But the runner used to publish the WAR read-done event before the replay launch.** The draft-extend graph runner keyed the publication position on `draft_extend_metadata_captured_in_graph()`, which TRTLLM-MHA (correctly, see below) leaves `False` — so the event was recorded before `_replay_graph` (see `EAGLEDraftExtendCudaGraphRunner._replay_and_publish_read_done`, `python/sglang/srt/speculative/eagle_draft_extend_cuda_graph_runner.py:484`, which now owns this ordering).
3. **The scheduler only fences its next shared-buffer write on that event.** `Scheduler._apply_war_barrier` (`python/sglang/srt/managers/scheduler.py:1751-1760`) waits on `shared_read_done_event`, then the next batch overwrites `req_to_token` (`assign_req_to_token_pool_func`, `python/sglang/srt/mem_cache/allocation.py:698`) — while the replay may still be reading it.

## Modifications

`draft_extend_metadata_captured_in_graph()` cannot simply be flipped to `True` for TRTLLM-MHA: its contract is "the in-graph rebuild is complete, a runner may skip the eager `init_forward_metadata_out_graph` call", and it also gates multi-layer single-graph draft modes (`multi_layer_eagle_worker_v2.py:405`, `multi_layer_eagle_draft_extend_cuda_graph_runner.py:175`). TRTLLM-MHA does not satisfy that contract (each replay still needs the eager out-graph `forward_metadata` rebind), so flipping it would be an unsafe drive-by.

Instead, decouple the two concerns:

- **New capability** `AttentionBackend.draft_extend_rereads_shared_state_in_graph()` (`base_attn_backend.py:126`): "my captured draft-extend graph re-reads scheduler-shared state (`req_to_token`) during replay". Default mirrors `draft_extend_metadata_captured_in_graph()` — an in-graph full metadata rebuild re-reads `req_to_token` by construction — so no existing backend changes behavior.
- **The draft-extend runner keys its read-done publication position on the new capability**: `read_done_publishes_after_replay()` (`eagle_draft_extend_cuda_graph_runner.py:77`) decides, and `_replay_and_publish_read_done()` (`eagle_draft_extend_cuda_graph_runner.py:484`) owns the replay/record sequence — record after the replay launch when the capability is `True`, keep the legacy early publication (and its scheduler overlap) otherwise. Both are seams the added tests pin (predicate binding + call-order spies).
- **TRTLLM-MHA overrides only the new capability to `True`** (`trtllm_mha_backend.py:945`); `draft_extend_metadata_captured_in_graph()` and all its consumers are untouched.
- Wrapper backends that already delegate the old capability (`dots_hybrid_backend.py`, `linear/inkling_sconv_backend.py`) delegate the new one alongside.

Backend coverage audit: of the backends eligible for the draft-extend graph runner, only FlashAttention (covered by the default mirror) and TRTLLM-MHA (this override) rebuild metadata inside the captured graph; the others build draft-extend metadata eagerly out-of-graph, so their early publication remains correct (e.g. DeepseekV4 rebuilds draft-extend metadata in `init_forward_metadata_out_graph`; its in-graph body reads only runner-owned static buffers).

## Evidence / reproduction

Unit-level GPU reproduction (honest scope: not an end-to-end server repro — in production the corruption window depends on scheduler timing; the test constructs the protocol-permitted interleaving deterministically). `test/registered/unit/spec/test_trtllm_mha_draft_extend_war_read_done.py` captures the backend's recorded draft-extend metadata rebuild exactly as the runner does, then:

- pins the premise: replay re-reads `req_to_token` (mutating the table between capture and replay changes the replayed page table);
- **demonstrates the corruption** under the pre-fix event ordering: once the read-done event is published before the replay launch, the protocol permits a writer that (like the scheduler) waits on the event and then overwrites `req_to_token` to land before the replay's reads; the test realizes that permitted interleaving deterministically (event-fenced, no free-running race) and the replayed page table is silently wrong;
- shows the ordering the runner actually derives (via the production predicate `read_done_publishes_after_replay`, extracted as a module-level seam) preserves the snapshot — the test fails again if either the backend capability or the runner predicate regresses;
- pins the decoupling: `draft_extend_rereads_shared_state_in_graph()` is `True` while `draft_extend_metadata_captured_in_graph()` stays `False`, and the base default mirrors the old method.

Test runs on this branch (B200):

| state | result |
| --- | --- |
| pre-fix (TRTLLM-MHA override removed) | 2 failed (decoupling pin + ordering test observes the corruption), 3 passed (premise pins) |
| runner-predicate regression (deferral keyed on the old method again) | 1 failed (ordering test observes the corruption), 4 passed |
| post-fix | 5 passed (plus 3 passed stacked-base pins in `test_draft_extend_graph_capability.py`) |

## Relationship to the FlashAttention draft-extend graph PR

Stacked on the FlashAttention draft-extend CUDA-graph PR (#36324), whose commit is the first commit of this branch: that PR introduces the read-done deferral mechanism keyed on `draft_extend_metadata_captured_in_graph()`; this PR generalizes the key to a dedicated capability (the old method conflates "may skip eager rebuild / multi-layer eligible" with "re-reads shared state in graph", which diverge exactly for TRTLLM-MHA) and applies it to TRTLLM-MHA. The two merge cleanly in either order: if that PR merges first, this one rebases to its single top commit; if this PR merges first, that one becomes a no-op.

## Checklist

- [x] Format your code with `pre-commit run --all-files` (changed files pass).
- [x] Add unit tests (`test/registered/unit/spec/test_trtllm_mha_draft_extend_war_read_done.py`, registered for CUDA CI).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32858729469](https://github.com/sgl-project/sglang/actions/runs/32858729469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32858728693](https://github.com/sgl-project/sglang/actions/runs/32858728693)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32858731322](https://github.com/sgl-project/sglang/actions/runs/32858731322)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->