### PR TITLE
[NPU][Kimi-K3] Honor --moe-dense-tp-size 1 for dense MLP

### DIFF
--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -61,11 +61,18 @@ def check_server_args(server_args: Any):
     assert cfg.base_gpu_id >= 0, "base_gpu_id must be non-negative"
     assert cfg.gpu_id_step >= 1, "gpu_id_step must be positive"
 
+    attn_dp_size = cfg.dp_size if cfg.enable_dp_attention else 1
+    effective_attn_tp_size = cfg.tp_size // attn_dp_size // cfg.attn_cp_size
     assert cfg.moe_dense_tp_size in (
         None,
         1,
         cfg.tp_size,
-    ), "moe_dense_tp_size only supports None, 1, or tp_size currently"
+        effective_attn_tp_size,
+    ), (
+        "moe_dense_tp_size only supports None, 1, tp_size, or attn_tp_size "
+        f"(got {cfg.moe_dense_tp_size}; tp_size={cfg.tp_size}, "
+        f"attn_tp_size={effective_attn_tp_size})"
+    )
 
     # Check served model name to not have colon as it is reserved for LoRA adapter syntax
     if not is_runai_obj_uri(cfg.served_model_name):

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -125,8 +125,10 @@ def capture_cuda_graphs(
 
     """
 
-    model_runner.graph_shared_output = GraphSharedOutput.create_for_model_runner(
-        model_runner
+    model_runner.graph_shared_output = (
+        GraphSharedOutput.create_for_model_runner(model_runner)
+        if capture_decode_cuda_graph
+        else None
     )
 
     # The eager (no-cuda-graph) phase runner, built AFTER the attention

--- a/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/base_cuda_graph_runner.py
@@ -61,13 +61,17 @@ def freeze_gc(enable_cudagraph_gc: bool):
             gc.collect()
 
 
-def get_batch_sizes_to_capture(
+def compute_capture_batch_sizes(
     model_runner: ModelRunner, captured_req_width: int = 1
-) -> Tuple[List[int], List[int]]:
-    """Build the (capture_bs, compile_bs) lists for the decode runner.
+) -> List[int]:
+    """Compute the valid decode-graph capture batch sizes for ``model_runner``.
 
-    Filters cuda_graph_config[decode].bs by attention-tp/cp alignment
-    constraints and clamps to req_to_token_pool.size.
+    Filters ``cuda_graph_config[decode].bs`` by attention-tp/cp alignment and
+    clamps to the request-pool size, mirroring the capture filter exactly.
+
+    Returns a sorted list that may be empty (no asserts), so callers that want
+    a graceful fallback (e.g. the DSpark draft worker on NPU) can detect the
+    "no valid bucket" case without triggering the capture-time assertion.
     """
 
     capture_bs = list(get_exec().graph.cuda_graph_config.decode.bs)
@@ -90,8 +94,18 @@ def get_batch_sizes_to_capture(
     # Model input token count = bs * alignment_width; must be a multiple of attn_tp_size.
     capture_bs = [bs for bs in capture_bs if bs * alignment_width % mul_base == 0]
     capture_bs = [bs for bs in capture_bs if bs <= num_max_requests]
-    capture_bs = list(sorted(set(capture_bs)))
+    return list(sorted(set(capture_bs)))
 
+
+def get_batch_sizes_to_capture(
+    model_runner: ModelRunner, captured_req_width: int = 1
+) -> Tuple[List[int], List[int]]:
+    """Build the (capture_bs, compile_bs) lists for the decode runner.
+
+    Filters cuda_graph_config[decode].bs by attention-tp/cp alignment
+    constraints and clamps to req_to_token_pool.size.
+    """
+    capture_bs = compute_capture_batch_sizes(model_runner, captured_req_width)
     assert len(capture_bs) > 0 and capture_bs[0] > 0, f"{capture_bs=}"
     compile_bs = (
         [bs for bs in capture_bs if bs <= get_exec().graph.torch_compile_max_bs]

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -311,6 +311,9 @@ class KimiK3MLP(nn.Module):
         if self._dense_attn_tp:
             tp_rank = get_parallel().attn_tp_rank
             tp_size = get_parallel().attn_tp_size
+        elif tp_rank is None and tp_size is None:
+            if get_parallel().moe_dense_tp_size == 1:
+                tp_rank, tp_size = 0, 1
         _tp_kwargs = (
             dict(tp_rank=tp_rank, tp_size=tp_size) if tp_size is not None else {}
         )

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -302,18 +302,16 @@ class KimiK3MLP(nn.Module):
         # this one dense layer over the full TP group.  Keep the GPU default,
         # but allow the NPU launcher to retain the proven attention-TP layout
         # without a device-type branch in shared model code.
-        self._dense_attn_tp = (
-            get_parallel().enable_dense_mlp_attn_tp
-            and is_dp_attention_enabled()
-            and tp_rank is None
-            and tp_size is None
+        parallel = get_parallel()
+        self._dp_attention = is_dp_attention_enabled()
+        use_default_tp = tp_rank is None and tp_size is None
+        self.use_dp_attention_reduce = (
+            parallel.enable_dense_mlp_attn_tp and self._dp_attention and use_default_tp
         )
-        if self._dense_attn_tp:
-            tp_rank = get_parallel().attn_tp_rank
-            tp_size = get_parallel().attn_tp_size
-        elif tp_rank is None and tp_size is None:
-            if get_parallel().moe_dense_tp_size == 1:
-                tp_rank, tp_size = 0, 1
+        if self.use_dp_attention_reduce:
+            tp_rank, tp_size = parallel.attn_tp_rank, parallel.attn_tp_size
+        elif use_default_tp and parallel.moe_dense_tp_size == 1:
+            tp_rank, tp_size = 0, 1
         _tp_kwargs = (
             dict(tp_rank=tp_rank, tp_size=tp_size) if tp_size is not None else {}
         )
@@ -331,7 +329,7 @@ class KimiK3MLP(nn.Module):
             bias=False,
             quant_config=quant_config,
             reduce_results=reduce_results,
-            use_dp_attention_reduce=self._dense_attn_tp,
+            use_dp_attention_reduce=self.use_dp_attention_reduce,
             prefix=f"{prefix}.down_proj",
             **_tp_kwargs,
         )
@@ -344,7 +342,6 @@ class KimiK3MLP(nn.Module):
             )
         else:
             raise ValueError(f"Unsupported activation: {hidden_act}")
-        self._dp_attention = is_dp_attention_enabled()
 
     def forward(
         self,
@@ -357,7 +354,9 @@ class KimiK3MLP(nn.Module):
         # given); the shared-experts instance inside KimiK3MoE passes None and
         # runs on the already-gathered buffer.
         use_dp = (
-            self._dp_attention and forward_batch is not None and not self._dense_attn_tp
+            self._dp_attention
+            and forward_batch is not None
+            and not self.use_dp_attention_reduce
         )
         if use_dp:
             local_hidden_states = hidden_states

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -580,7 +580,10 @@ class KimiK3MoE(nn.Module):
         shared_experts_tp_kwargs = {}
         if self._shared_experts_tp1:
             shared_experts_tp_kwargs = dict(tp_rank=0, tp_size=1)
-        elif self._shared_experts_attn_tp_comm:
+        elif (
+            get_parallel().enable_shared_experts_attn_tp
+            and get_parallel().attn_tp_size > 1
+        ):
             shared_experts_tp_kwargs = dict(
                 tp_rank=get_parallel().attn_tp_rank,
                 tp_size=get_parallel().attn_tp_size,

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -305,8 +305,15 @@ class KimiK3MLP(nn.Module):
         parallel = get_parallel()
         self._dp_attention = is_dp_attention_enabled()
         use_default_tp = tp_rank is None and tp_size is None
+        # --moe-dense-tp-size selects how this dense MLP is sharded:
+        #   None          -> full-TP sharding (default)
+        #   1             -> replicate (tp_size=1)
+        #   tp_size       -> full-TP sharding (explicit)
+        #   attn_tp_size  -> shard over the attention-TP group under DP attention
         self.use_dp_attention_reduce = (
-            parallel.enable_dense_mlp_attn_tp and self._dp_attention and use_default_tp
+            parallel.moe_dense_tp_size == parallel.attn_tp_size
+            and self._dp_attention
+            and use_default_tp
         )
         if self.use_dp_attention_reduce:
             tp_rank, tp_size = parallel.attn_tp_rank, parallel.attn_tp_size

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -568,22 +568,19 @@ class KimiK3MoE(nn.Module):
         self._shared_experts_tp1 = (
             self._ep_a2a and not get_parallel().enable_shared_experts_attn_tp
         )
-        # NPU compatibility mode keeps DeepEP's DP-local token dispatch but
-        # uses the original TP-sharded shared MLP. Gather only that branch's
-        # inputs, then reduce-scatter its output back to the DP-local rows.
+        # NPU compatibility mode keeps DeepEP's token dispatch but uses the
+        # original TP-sharded shared MLP. Gather only that branch's inputs,
+        # then reduce-scatter its output back to the rank-local rows. This
+        # covers both DP-local batches and no-DP SP-MoE token shards.
         self._shared_experts_attn_tp_comm = (
             get_parallel().enable_shared_experts_attn_tp
             and self._ep_a2a
-            and self._dp_attention
             and get_parallel().attn_tp_size > 1
         )
         shared_experts_tp_kwargs = {}
         if self._shared_experts_tp1:
             shared_experts_tp_kwargs = dict(tp_rank=0, tp_size=1)
-        elif (
-            get_parallel().enable_shared_experts_attn_tp
-            and get_parallel().attn_tp_size > 1
-        ):
+        elif self._shared_experts_attn_tp_comm:
             shared_experts_tp_kwargs = dict(
                 tp_rank=get_parallel().attn_tp_rank,
                 tp_size=get_parallel().attn_tp_size,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1130,11 +1130,6 @@ class ServerArgs:
         "Shard shared expert weights across the attention TP group when using an expert-parallel all-to-all backend.",
         NS("parallel"),
     ] = False
-    enable_dense_mlp_attn_tp: A[
-        bool,
-        "Shard dense MLP weights across the attention TP group under DP attention.",
-        NS("parallel"),
-    ] = False
     disable_attn_tp_gather: A[
         bool,
         "Disable scheduler-side attn_tp_gather (the upstream SP path "
@@ -2486,7 +2481,7 @@ class ServerArgs:
     moe_dense_tp_size: A[
         Optional[int],
         Arg(
-            help="TP size for MoE dense MLP layers. This flag is useful when, with large TP size, there are errors caused by weights in MLP layers having dimension smaller than the min dimension GEMM supports.",
+            help="TP size for MoE dense MLP layers. Accepts None (shard over the full TP group, default), 1 (replicate), tp_size (explicit full-TP sharding), or the attention-TP size (shard the dense MLP over the attention-TP group under DP attention).",
             resolvable=True,
         ),
         NS("parallel"),

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -80,6 +80,7 @@ from sglang.srt.utils import (
     is_npu,
     is_pin_memory_available,
 )
+from sglang.srt.utils.common import get_cuda_graph_batch_size_alignment
 
 logger = logging.getLogger(__name__)
 
@@ -368,6 +369,21 @@ class DSparkWorkerV2(BaseSpecWorker):
 
     def init_cuda_graphs(self):
         capture_decode_cuda_graph = self._decode_graph_allowed
+        if _is_npu and capture_decode_cuda_graph:
+            width = self.draft_model_runner.decode_num_tokens_per_req()
+            alignment = get_cuda_graph_batch_size_alignment(
+                self.draft_model_runner.server_args
+            )
+            capture_bs = get_exec().graph.cuda_graph_config.decode.bs
+            if not any(bs * width % alignment == 0 for bs in capture_bs):
+                capture_decode_cuda_graph = False
+                logger.warning(
+                    "Disable DSpark draft cuda graph because no configured batch "
+                    "size satisfies NPU alignment: bs=%s, width=%d, alignment=%d.",
+                    capture_bs,
+                    width,
+                    alignment,
+                )
         if is_cuda() and capture_decode_cuda_graph:
             available_mem = get_available_gpu_memory(self.device, self.gpu_id)
             if available_mem < 1.0:

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -20,6 +20,9 @@ from sglang.srt.model_executor.forward_batch_info import (
     CaptureHiddenMode,
     compute_position,
 )
+from sglang.srt.model_executor.runner.base_cuda_graph_runner import (
+    compute_capture_batch_sizes,
+)
 from sglang.srt.runtime_context import (
     get_disagg,
     get_exec,
@@ -80,7 +83,6 @@ from sglang.srt.utils import (
     is_npu,
     is_pin_memory_available,
 )
-from sglang.srt.utils.common import get_cuda_graph_batch_size_alignment
 
 logger = logging.getLogger(__name__)
 
@@ -371,18 +373,19 @@ class DSparkWorkerV2(BaseSpecWorker):
         capture_decode_cuda_graph = self._decode_graph_allowed
         if _is_npu and capture_decode_cuda_graph:
             width = self.draft_model_runner.decode_num_tokens_per_req()
-            alignment = get_cuda_graph_batch_size_alignment(
-                self.draft_model_runner.server_args
+            # Reuse the exact bucket filter the decode graph runner applies
+            # (including TBO alignment and the padded num_max_requests bucket)
+            # so this guard is equivalent to the capture-time filter instead of
+            # a hand-rolled approximation.
+            capture_bs = compute_capture_batch_sizes(
+                self.draft_model_runner, captured_req_width=width
             )
-            capture_bs = get_exec().graph.cuda_graph_config.decode.bs
-            if not any(bs * width % alignment == 0 for bs in capture_bs):
+            if not capture_bs:
                 capture_decode_cuda_graph = False
                 logger.warning(
-                    "Disable DSpark draft cuda graph because no configured batch "
-                    "size satisfies NPU alignment: bs=%s, width=%d, alignment=%d.",
-                    capture_bs,
+                    "Disable DSpark draft cuda graph because no batch size "
+                    "satisfies NPU alignment: width=%d.",
                     width,
-                    alignment,
                 )
         if is_cuda() and capture_decode_cuda_graph:
             available_mem = get_available_gpu_memory(self.device, self.gpu_id)


### PR DESCRIPTION
## Motivation

Kimi-K3 has two independent TP-selection issues in the four-node NPU path:

1. When `--enable-dense-mlp-attn-tp` is disabled, `KimiK3MLP` leaves
   `tp_rank`/`tp_size` unset. The linear layers then select the default full TP
   group and ignore the supported `--moe-dense-tp-size 1` configuration.
2. Shared-expert attention-TP communication is gated by DP attention. With DP
   attention disabled, EP A2A still produces rank-local SP-MoE token shards,
   so an attention-TP-sharded shared MLP still needs to gather those rows and
   reduce-scatter its output. The DP-only gate makes the no-DP configuration
   unable to use `--enable-shared-experts-attn-tp` correctly.

## Changes

- Give `--enable-dense-mlp-attn-tp` priority when DP attention is enabled.
- Otherwise, honor `--moe-dense-tp-size 1` by constructing the dense MLP with
  `tp_rank=0, tp_size=1`; keep the existing full-TP default when neither option
  applies.
- Enable shared-expert attention-TP gather/reduce-scatter for EP A2A even when
  DP attention is disabled. The same communication now covers DP-local batches
  and no-DP SP-MoE token shards.
- Keep the selected dense-MLP reduction mode in
  `self.use_dp_attention_reduce`, which is used consistently by TP selection,
  `down_proj`, and the forward DP-gather decision.

### Why the D-Spark graph fallback is included

This is independent of the dense/shared-MLP math. During the four-node NPU
service validation, D-Spark draft graph initialization could have no configured
capture batch size satisfying the NPU alignment constraint
`batch_size * draft_width % alignment == 0`. Previously this reached graph
setup and prevented the service from starting.

The fallback is intentionally narrow:

- NPU + D-Spark draft worker only;
- only when none of the configured decode capture sizes is valid;
- disable the draft decode graph and use the existing eager runner;
- do not create `GraphSharedOutput` when decode graph capture is explicitly
  disabled.

Valid graph configurations and non-NPU paths are unchanged. This graph fix can
be split into a separate PR if maintainers prefer the dense/shared-MLP change
to remain isolated.

## Four-node validation

The following is the sanitized equivalent of the launch used for validation.
Host IPs, hostnames, container/image names, usernames, network interfaces,
absolute repository/model paths, and log paths are replaced with placeholders.
Image-specific vendor environment setup is omitted.

Topology: 4 nodes, 16 NPUs per node, global TP64, EP A2A enabled, DP attention
disabled. In particular, the command intentionally contains neither
`--enable-dp-attention` nor `--dp-size`.

```bash
#!/usr/bin/env bash
set -euo pipefail

# Run once on every node in the same NPU software container.
export MODEL_PATH="<kimi-k3-model-path>"
export DRAFT_MODEL_PATH="<dspark-draft-model-path>"
export DIST_INIT_ADDR="<node-0-ip>:<distributed-port>"
export NODE_RANK="<0|1|2|3>"
export SERVER_PORT="30000"
export HCCL_SOCKET_IFNAME="<cluster-network-interface>"
export GLOO_SOCKET_IFNAME="<cluster-network-interface>"
export PYTHONPATH="<sglang-checkout>/python:${PYTHONPATH:-}"

# Choose exactly one configuration:
# A: no-DP full-TP dense path; the switch is intentionally inert without DP.
DENSE_MLP_ARGS=(--enable-dense-mlp-attn-tp)

# B: validate the new TP1 fallback with the dense-attention-TP switch off.
# DENSE_MLP_ARGS=(--moe-dense-tp-size 1)

sglang serve \
  --dist-init-addr "${DIST_INIT_ADDR}" \
  --nnodes 4 \
  --node-rank "${NODE_RANK}" \
  --model-path "${MODEL_PATH}" \
  --tokenizer-path "${MODEL_PATH}" \
  --trust-remote-code \
  --device npu \
  --attention-backend ascend \
  --quantization modelslim \
  --dtype bfloat16 \
  --tp-size 64 \
  --enable-shared-experts-attn-tp \
  "${DENSE_MLP_ARGS[@]}" \
  --moe-a2a-backend deepep \
  --deepep-mode auto \
  --speculative-algorithm DSPARK \
  --speculative-draft-model-path "${DRAFT_MODEL_PATH}" \
  --speculative-dspark-block-size 7 \
  --speculative-draft-attention-backend ascend \
  --speculative-eagle-topk 1 \
  --speculative-draft-model-quantization unquant \
  --reasoning-parser kimi_k3 \
  --host 0.0.0.0 \
  --port "${SERVER_PORT}"
```

GSM8K command, run after the four-node service became healthy:

```bash
python3 benchmark/gsm8k/bench_sglang.py \
  --host "<node-0-service-address>" \
  --port 30000 \
  --num-questions 50 \
  --parallel 50
```

Results:

| No-DP configuration | Questions | Accuracy | Invalid | Latency | Output throughput |
|---|---:|---:|---:|---:|---:|
| flag present, but inactive without DP attention (default full-TP dense) | 50 | 1.000 | 0 | 101.979 s | 50.589 token/s |
| switch off + `--moe-dense-tp-size 1` | 50 | 0.980 | 0 | 96.697 s | 53.393 token/s |

Both configurations started successfully on all four nodes and produced valid
answers. On this 50-question smoke run, the TP1 configuration was about 5.5%
higher in output throughput; this short run is intended to rule out a material
regression, not to establish a performance benchmark. The full 1,319-question
run was not executed because the 50-question validation was used as the agreed
slow-run fallback.

The four-node run covered the functional commits before the final
behavior-preserving variable refactor/rebase. The current head additionally
passed the following local checks:

- Ruff 0.15.1 (`F401,F821,UP037`)
- Black 26.1.0
- isort 7.0.0
- `python -m py_compile` for all three changed Python files
- `git diff --check`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
