### PR TITLE
[Model] Add SKT A.X-K2 and ModelOpt NVFP4 support

### DIFF
--- a/python/sglang/kernels/jit/utils/compile/toolchain.py
+++ b/python/sglang/kernels/jit/utils/compile/toolchain.py
@@ -160,7 +160,16 @@ def base_link_flags(*, with_device: bool) -> List[str]:
         return flags
     if is_hip_runtime():
         return flags + [f"-L{rocm_home()}/lib", "-lamdhip64"]
-    return flags + [f"-L{cuda_home()}/lib64", "-lcudart"]
+    cuda_root = pathlib.Path(cuda_home())
+    cuda_lib = cuda_root / "lib64"
+    if not cuda_lib.is_dir():
+        cuda_lib = cuda_root / "lib"
+    cudart_link = "-lcudart"
+    if not (cuda_lib / "libcudart.so").exists():
+        versioned = sorted(cuda_lib.glob("libcudart.so.*"))
+        if versioned:
+            cudart_link = f"-l:{versioned[-1].name}"
+    return flags + [f"-L{cuda_lib}", cudart_link]
 
 
 def compilers() -> Tuple[str, str]:

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1927,6 +1927,7 @@ _DEEPSEEK_FAMILY_ARCHS = frozenset(
     {
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
+        "AXK2ForCausalLM",
         "KimiK25ForConditionalGeneration",
         "MistralLarge3ForCausalLM",
         "PixtralForConditionalGeneration",

--- a/python/sglang/srt/configs/__init__.py
+++ b/python/sglang/srt/configs/__init__.py
@@ -1,4 +1,5 @@
 from sglang.srt.configs.afmoe import AfmoeConfig
+from sglang.srt.configs.axk2 import AXK2Config
 from sglang.srt.configs.bailing_hybrid import BailingHybridConfig
 from sglang.srt.configs.chatglm import ChatGLMConfig
 from sglang.srt.configs.cohere2_moe import Cohere2MoeConfig
@@ -68,6 +69,7 @@ from sglang.srt.configs.unlimited_ocr import UnlimitedVLConfig
 from sglang.srt.configs.zaya import ZayaConfig
 
 __all__ = [
+    "AXK2Config",
     "AfmoeConfig",
     "BailingHybridConfig",
     "ExaoneConfig",

--- a/python/sglang/srt/configs/axk2.py
+++ b/python/sglang/srt/configs/axk2.py
@@ -1,0 +1,65 @@
+"""Configuration for SKT A.X-K2 models."""
+
+from typing import Any
+
+from transformers.configuration_utils import PretrainedConfig
+
+
+class AXK2Config(PretrainedConfig):
+    """DeepSeek-V3-style MLA/MoE config with A.X-K2 gating attributes."""
+
+    model_type = "axk2"
+    keys_to_ignore_at_inference = ["past_key_values"]
+    # The dense shortcut does not implement this architecture's fused
+    # query/output-gate projection, so prefill must stay on native MLA.
+    supports_mha_one_shot = False
+
+    def __init__(
+        self,
+        vocab_size: int = 163840,
+        hidden_size: int = 7168,
+        intermediate_size: int = 18432,
+        moe_intermediate_size: int = 2048,
+        num_hidden_layers: int = 61,
+        num_attention_heads: int = 64,
+        num_key_value_heads: int | None = None,
+        n_shared_experts: int | None = 1,
+        n_routed_experts: int | None = 256,
+        num_experts_per_tok: int = 8,
+        first_k_dense_replace: int = 1,
+        moe_layer_freq: int = 1,
+        q_lora_rank: int | None = 1536,
+        kv_lora_rank: int = 512,
+        qk_nope_head_dim: int = 128,
+        qk_rope_head_dim: int = 64,
+        v_head_dim: int = 128,
+        rms_norm_eps: float = 1e-6,
+        rope_theta: float = 1_000_000.0,
+        rope_scaling: dict[str, Any] | None = None,
+        rope_parameters: dict[str, Any] | None = None,
+        gated_norm: bool = True,
+        gated_norm_rank: int = 16,
+        attention_output_gate: bool = True,
+        attn_gate_fused: bool = True,
+        index_n_heads: int | None = None,
+        index_head_dim: int | None = None,
+        index_topk: int | None = None,
+        use_cache: bool = True,
+        **kwargs,
+    ):
+        for name, value in vars().items():
+            if name not in {"self", "kwargs", "num_key_value_heads", "rope_parameters"}:
+                setattr(self, name, value)
+        self.num_key_value_heads = num_key_value_heads or num_attention_heads
+        self.rope_parameters = (
+            rope_parameters
+            or rope_scaling
+            or {"rope_type": "default", "rope_theta": rope_theta}
+        )
+        if index_n_heads is not None:
+            self.index_n_heads = index_n_heads
+        if index_head_dim is not None:
+            self.index_head_dim = index_head_dim
+        if index_topk is not None:
+            self.index_topk = index_topk
+        super().__init__(**kwargs)

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -126,6 +126,7 @@ def is_deepseek_dsa(config) -> bool:
             "LongcatFlashForCausalLMNextN",
             "Dots3NoteForCausalLM",
             "Dots3NoteForCausalLMNextN",
+            "AXK2ForCausalLM",
         )
         and _hf_attr(config, "index_topk") is not None
     )
@@ -906,6 +907,7 @@ class ModelConfig:
             or "DeepseekV32ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLM" in self.hf_config.architectures
             or "DeepseekV3ForCausalLMNextN" in self.hf_config.architectures
+            or "AXK2ForCausalLM" in self.hf_config.architectures
             or "Glm4MoeLiteForCausalLM" in self.hf_config.architectures
             or "Glm4MoeLiteForCausalLMNextN" in self.hf_config.architectures
             or "GlmMoeDsaForCausalLM" in self.hf_config.architectures

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -102,7 +102,7 @@ if _use_aiter and not _use_aiter_preshuffle:
 if _is_cuda:
     try:
         import deep_gemm
-    except ImportError as e:
+    except (ImportError, AssertionError) as e:
         deep_gemm = e
 
 if _use_aiter:

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -337,7 +337,13 @@ class DeepseekSparseAttnBackend(
         self.req_to_token = model_runner.req_to_token_pool.req_to_token
 
         self.use_mha: bool = False
-        self.supports_mha_one_shot: bool = True
+        # Architectures with projection semantics not implemented by the dense
+        # shortcut can opt out while all existing configs retain the default.
+        self.supports_mha_one_shot: bool = getattr(
+            model_runner.model_config.hf_config,
+            "supports_mha_one_shot",
+            True,
+        )
         self.dsa_prefill_impl: _DSA_IMPL_T = get_exec().kernel.dsa_prefill_backend
         self.dsa_decode_impl: _DSA_IMPL_T = get_exec().kernel.dsa_decode_backend
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend(

--- a/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
+++ b/python/sglang/srt/layers/deep_gemm_wrapper/configurer.py
@@ -26,7 +26,11 @@ def _compute_enable_deep_gemm():
 
     try:
         import deep_gemm  # noqa: F401
-    except ImportError:
+    # Some DeepGEMM wheels locate CUDA during import and can raise an
+    # AssertionError when the CUDA toolkit is not installed locally.  Treat
+    # that the same as an unavailable optional dependency so SGLang can use
+    # its non-DeepGEMM kernels.
+    except (ImportError, AssertionError):
         return False
 
     return envs.SGLANG_ENABLE_JIT_DEEPGEMM.get()

--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -627,6 +627,38 @@ class FusedMoE(torch.nn.Module):
         tp_rank: int,
         is_bias: bool = False,
     ):
+        quant_method = self.quant_method
+        if isinstance(quant_method, KTEPWrapperMethod):
+            quant_method = quant_method.gpu_method
+        if isinstance(
+            quant_method, ModelOptNvFp4FusedMoEMethod
+        ) and loaded_weight.dtype in (
+            torch.uint8,
+            torch.int8,
+        ):
+            # ModelOpt serializes NVFP4 expert tensors in the exact physical
+            # [output, packed-input] layout of w13_weight.  Do not route
+            # through the generic padded helper: that helper is for logical
+            # BF16 layouts and can transpose/reinterpret the packed axis.
+            assert shard_id in {"w1", "w3"}
+            target_shard_size = expert_data.shape[shard_dim] // 2
+            # Converted FP8 shared experts can have a smaller intermediate
+            # size than routed experts.  Their int8 MXFP4 payload therefore
+            # needs its source-derived TP slice copied into the leading,
+            # zero-padded part of the routed-expert slot.
+            shard_size = (
+                target_shard_size
+                if loaded_weight.dtype == torch.uint8
+                else loaded_weight.shape[shard_dim] // self.moe_tp_size
+            )
+            if not self.use_presharded_weights:
+                loaded_weight = loaded_weight.narrow(
+                    shard_dim, shard_size * tp_rank, shard_size
+                )
+            start = 0 if shard_id == "w1" else target_shard_size
+            expert_data.narrow(shard_dim, start, shard_size).copy_(loaded_weight)
+            return
+
         # Index the loaded weight for tp sharding.
         # gate_up_proj: "MergedColumnParallel", so tp sharding on output_dim
         assert shard_id in {"w1", "w3", "w13"}
@@ -720,6 +752,30 @@ class FusedMoE(torch.nn.Module):
             loaded_weight: The weight tensor to load from
             tp_rank: The tensor parallel rank
         """
+        quant_method = self.quant_method
+        if isinstance(quant_method, KTEPWrapperMethod):
+            quant_method = quant_method.gpu_method
+        if isinstance(
+            quant_method, ModelOptNvFp4FusedMoEMethod
+        ) and loaded_weight.dtype in (
+            torch.uint8,
+            torch.int8,
+        ):
+            if not self.use_presharded_weights:
+                # The physical NVFP4 buffer can be more finely partitioned
+                # than the logical MoE TP group (packed inputs halve the
+                # stored width).  Its target dimension is authoritative.
+                loaded_size = (
+                    expert_data.shape[shard_dim]
+                    if loaded_weight.dtype == torch.uint8
+                    else loaded_weight.shape[shard_dim] // self.moe_tp_size
+                )
+                loaded_weight = loaded_weight.narrow(
+                    shard_dim, loaded_size * tp_rank, loaded_size
+                )
+            expert_data.copy_(loaded_weight)
+            return
+
         if not isinstance(expert_data, torch.Tensor) or not isinstance(
             loaded_weight, torch.Tensor
         ):
@@ -798,11 +854,18 @@ class FusedMoE(torch.nn.Module):
         shard_dim: int,
         tp_rank: int,
     ) -> bool:
+        quant_method = self.quant_method
+        if isinstance(quant_method, KTEPWrapperMethod):
+            quant_method = quant_method.gpu_method
         if (
             not self._has_fused_shared
             or expert_id < self._num_local_routed
             or self.quant_config is None
-            or not getattr(self.quant_config, "is_fp4_experts", False)
+            # ModelConfig's architecture-specific FP4-expert flag is not set
+            # for every mixed ModelOpt checkpoint.  The installed fused MoE
+            # method is the authoritative signal that the destination is
+            # NVFP4.
+            or not isinstance(quant_method, ModelOptNvFp4FusedMoEMethod)
             or shard_id not in ("w1", "w2", "w3")
         ):
             return False
@@ -812,16 +875,20 @@ class FusedMoE(torch.nn.Module):
             and "scale" not in weight_name
             and loaded_weight.dtype == torch.float8_e4m3fn
         )
-        is_scale = "weight_scale_inv" in weight_name and loaded_weight.dtype in (
-            torch.float8_e8m0fnu,
-            torch.float32,
-        )
+        # ModelOpt checkpoints use ``weight_scale`` for the FP8 shared
+        # experts, while the MXFP4 destination stores
+        # ``weight_scale_inv``.  Accept both source spellings so the pair is
+        # converted together instead of trying to copy the original 7168-wide
+        # FP8 tensor into the packed FP4 buffer.
+        is_scale = (
+            "weight_scale_inv" in weight_name or "weight_scale" in weight_name
+        ) and loaded_weight.dtype in (torch.float8_e8m0fnu, torch.float32)
         if not is_weight and not is_scale:
             return False
 
         weight_param = self.w2_weight if shard_id == "w2" else self.w13_weight
         scale_param = (
-            self.w2_weight_scale_inv if shard_id == "w2" else self.w13_weight_scale_inv
+            self.w2_weight_scale if shard_id == "w2" else self.w13_weight_scale
         )
         if param is not weight_param and param is not scale_param:
             return False
@@ -849,13 +916,39 @@ class FusedMoE(torch.nn.Module):
 
         weight_block_size = getattr(self.quant_config, "weight_block_size", None)
         if weight_block_size is None:
-            raise ValueError(
-                "Loading FP8 shared expert weights into FP4 fused MoE weights "
-                "requires block-FP8 weight_block_size."
+            # Some mixed checkpoints store FP8 shared experts with one scalar
+            # scale per projection rather than block-FP8 scales. Dequantize
+            # that source before generating the destination's grouped MXFP4
+            # payload.
+            from sglang.srt.layers.quantization.mxfp4_tensor import (
+                MXFP4QuantizeUtil,
             )
-        fp4_weight, fp4_scale = quantize_block_fp8_weight_to_mxfp4(
-            fp8_weight, fp8_scale, weight_block_size
-        )
+
+            fp8_dequant = (
+                fp8_weight.to(torch.float32) * fp8_scale.to(torch.float32)
+            ).to(torch.bfloat16)
+            fp4_quant, fp4_scale_raw = MXFP4QuantizeUtil.quantize(
+                fp8_dequant, block_size=self.quant_config.group_size
+            )
+            fp4_weight = fp4_quant.contiguous().view(torch.int8)
+            fp4_scale = (
+                fp4_scale_raw.view(
+                    *fp8_dequant.shape[:-1],
+                    fp8_dequant.shape[-1] // self.quant_config.group_size,
+                )
+                .contiguous()
+                .view(torch.float8_e8m0fnu)
+            )
+        else:
+            fp4_weight, fp4_scale = quantize_block_fp8_weight_to_mxfp4(
+                fp8_weight,
+                fp8_scale,
+                weight_block_size,
+                # Match the serialized NVFP4 destination's group scale layout
+                # (16 for this checkpoint), rather than the helper's generic
+                # MXFP4 default of 32.
+                mxfp4_block_size=self.quant_config.group_size,
+            )
 
         weight_data = weight_param.data[expert_id]
         scale_data = scale_param.data[expert_id]
@@ -1149,7 +1242,17 @@ class FusedMoE(torch.nn.Module):
         # should be whatever dimension intermediate_size is
         is_transposed = getattr(param, "is_transposed", False)
         shard_dim = SHARD_ID_TO_SHARDED_DIM[shard_id]
-        if self.use_triton_kernels:
+        # Serialized ModelOpt NVFP4 tensors are already stored in the
+        # physical [output, packed-input] layout used by their runtime
+        # buffers.  Unlike BF16/Triton MoE weights they must not have the
+        # shard dimension flipped here: w1/w3 slice dim 0 and w2 slices dim
+        # 1.  Flipping it makes the native 2048x3584 gate/up tensor copy as
+        # a 7168-wide source into the 3584-wide packed target.
+        # ``method`` is the unwrapped GPU method (``self.quant_method`` can
+        # be a KTEP wrapper), so use it for the serialized-NVFP4 check.
+        if self.use_triton_kernels and not isinstance(
+            method, ModelOptNvFp4FusedMoEMethod
+        ):
             is_transposed = True
         if is_transposed:
             shard_dim = int(not shard_dim)
@@ -1215,7 +1318,12 @@ class FusedMoE(torch.nn.Module):
                 else "weight_scale" in weight_name
             ) or "input_scale" in weight_name
 
-            if per_tensor_conditions:
+            # ModelOpt NVFP4 exports ``weight_scale_2`` as a scalar.  Treat
+            # any scalar here as a per-expert tensor scale as well: the
+            # checkpoint's projection-name mapping may have converted it to
+            # ``w13_weight_scale_2`` before this branch.  Sending a scalar to
+            # the sharded group-scale loader would index a nonexistent dim.
+            if per_tensor_conditions or loaded_weight.ndim == 0:
                 self._load_per_tensor_weight_scale(
                     shard_id=shard_id,
                     param=param,

--- a/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/deepep.py
@@ -57,7 +57,10 @@ try:
         )
 
     use_deepep = True
-except ImportError:
+except (ImportError, AssertionError):
+    # DeepEP may raise AssertionError during optional JIT initialization when
+    # a CUDA toolkit is absent.  Degrade to the available dispatcher instead
+    # of preventing all model modules from being imported.
     use_deepep = False
 
 from enum import Enum, IntEnum, auto

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -923,6 +923,28 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return self.quantized_layers[candidate]["quant_algo"].upper()
 
         proj_name = prefix.rsplit(".", 1)[-1]
+        # DeepSeek MLPs fuse checkpoint ``gate_proj`` and ``up_proj`` into
+        # one runtime ``gate_up_proj``.  ModelOpt exports the two source
+        # names even when it does not include a packed_modules_mapping, so
+        # infer the fused method when (and only when) both agree.
+        if proj_name == "gate_up_proj":
+            algos = set()
+            base = prefix.rsplit(".", 1)[0]
+            for base_candidate in self._quantized_layer_prefix_candidates(base):
+                for shard_name in ("gate_proj", "up_proj"):
+                    shard_prefix = f"{base_candidate}.{shard_name}"
+                    if shard_prefix in self.quantized_layers:
+                        algos.add(
+                            self.quantized_layers[shard_prefix]["quant_algo"].upper()
+                        )
+            if len(algos) == 1:
+                return algos.pop()
+            if len(algos) > 1:
+                raise ValueError(
+                    f"Mixed quant_algo within fused layer {prefix}: {algos}. "
+                    "gate_proj and up_proj must use the same quantization."
+                )
+
         if self.packed_modules_mapping and proj_name in self.packed_modules_mapping:
             algos = set()
             base = prefix.rsplit(".", 1)[0]

--- a/python/sglang/srt/layers/quantization/mxfp4_tensor.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_tensor.py
@@ -71,7 +71,7 @@ class MXFP4QuantizeUtil:
         input_q = cast_fp4(input)
         input_q = fuse_uint4_to_uint8(input_q)
         e8m0_scale = (e8m0_scale + 127).to(torch.uint8)
-        return cls(original_shape, original_dtype, input_q), e8m0_scale
+        return input_q, e8m0_scale
 
     @classmethod
     def dequantize(cls, quantized_data, dtype: torch.dtype, scale, block_sizes):

--- a/python/sglang/srt/models/axk2.py
+++ b/python/sglang/srt/models/axk2.py
@@ -1,0 +1,176 @@
+"""Native SGLang execution path for SKT A.X-K2.
+
+AXK2 is a DeepSeek-v3.2 MLA/DSA MoE model, but its released checkpoints add
+two non-optional operations: low-rank gated RMSNorm and a fused query/output
+gate.  This module reuses SGLang's optimized MLA/DSA and MoE path while
+inserting those checkpoint-compatible operations.
+"""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.layernorm import RMSNorm
+from sglang.srt.layers.linear import (
+    ColumnParallelLinear,
+    ReplicatedLinear,
+    RowParallelLinear,
+)
+from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA, DeepseekV32ForCausalLM
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.utils import add_prefix
+
+
+class _RecordingRMSNorm(RMSNorm):
+    """RMSNorm retaining the pre-normalized q-LoRA latent for AXK2's gate."""
+
+    def forward(self, x, *args, **kwargs):
+        self.axk2_pre_norm = x
+        return super().forward(x, *args, **kwargs)
+
+
+class AXK2GatedRMSNorm(torch.nn.Module):
+    """RMSNorm followed by ``sigmoid(W_up(silu(W_down(y))))``."""
+
+    def __init__(self, hidden_size, eps, rank, prefix):
+        super().__init__()
+        self.norm = RMSNorm(hidden_size, eps=eps)
+        # Rank-16 gates remain BF16 in the released checkpoint.
+        self.W_down = ReplicatedLinear(
+            hidden_size, rank, bias=False, quant_config=None, prefix=f"{prefix}.W_down"
+        )
+        self.W_up = ReplicatedLinear(
+            rank, hidden_size, bias=False, quant_config=None, prefix=f"{prefix}.W_up"
+        )
+
+    def _gate(self, y):
+        down, _ = self.W_down(y)
+        up, _ = self.W_up(F.silu(down.float()).to(y.dtype))
+        return (y.float() * torch.sigmoid(up.float())).to(y.dtype)
+
+    def forward(self, x, residual=None, *args, **kwargs):
+        result = self.norm(x, residual, *args, **kwargs)
+        if residual is None:
+            return self._gate(result)
+        y, new_residual = result
+        return self._gate(y), new_residual
+
+
+class _GatedOProj(RowParallelLinear):
+    """Applies AXK2's per-head gate immediately before ``o_proj``."""
+
+    axk2_gate = None
+
+    def forward(self, x):
+        gate = self.axk2_gate
+        if gate is not None:
+            x = (x.float() * torch.sigmoid(gate.float())).to(x.dtype)
+        return super().forward(x)
+
+
+class AXK2Attention(DeepseekV2AttentionMLA):
+    """DeepSeek MLA with the fused AXK2 ``q_b_proj`` query/output gate."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        config = kwargs["config"]
+        prefix = kwargs["prefix"]
+        quant_config = kwargs.get("quant_config")
+        attn_tp_rank = get_parallel().attn_tp_rank
+        attn_tp_size = get_parallel().attn_tp_size
+
+        self.q_a_layernorm = _RecordingRMSNorm(
+            self.q_lora_rank, eps=config.rms_norm_eps
+        )
+        # Checkpoint layout: [q_lora post-norm | q_lora pre-norm] ->
+        # per-head [query | output-gate]. It must remain fused: its FP8 block
+        # scales cross the q/gate boundary.
+        self.q_b_proj = ColumnParallelLinear(
+            2 * self.q_lora_rank,
+            self.num_heads * (self.qk_head_dim + self.v_head_dim),
+            bias=False,
+            quant_config=self._get_q_b_proj_quant_config(quant_config),
+            prefix=add_prefix("q_b_proj", prefix),
+            tp_rank=attn_tp_rank,
+            tp_size=attn_tp_size,
+        )
+        self.o_proj = _GatedOProj(
+            self.num_heads * self.v_head_dim,
+            self.hidden_size,
+            bias=False,
+            quant_config=quant_config,
+            reduce_results=False,
+            prefix=add_prefix("o_proj", prefix),
+            tp_rank=attn_tp_rank,
+            tp_size=attn_tp_size,
+        )
+
+    def q_b_proj_forward(self, q_lora):
+        q_pre_norm = self.q_a_layernorm.axk2_pre_norm
+        q_and_gate = self.q_b_proj(torch.cat((q_lora, q_pre_norm), dim=-1))[0]
+        q_and_gate = q_and_gate.view(
+            -1, self.num_local_heads, self.qk_head_dim + self.v_head_dim
+        )
+        query, gate = torch.split(
+            q_and_gate, (self.qk_head_dim, self.v_head_dim), dim=-1
+        )
+        self.o_proj.axk2_gate = gate.reshape(gate.shape[0], -1)
+        return query
+
+
+class AXK2ForCausalLM(DeepseekV32ForCausalLM):
+    """A.X-K2 inference model using SGLang's MLA/DSA and MoE kernels."""
+
+    fused_shared_experts_architecture = "AXK2ForCausalLM"
+
+    def __init__(self, config, quant_config=None, prefix=""):
+        super().__init__(config, quant_config, prefix)
+        for layer_id in range(self.model.start_layer, self.model.end_layer):
+            layer = self.model.layers[layer_id]
+            old_attn = layer.self_attn
+            attn_prefix = add_prefix("self_attn", f"model.layers.{layer_id}")
+            layer.self_attn = AXK2Attention(
+                config=config,
+                hidden_size=config.hidden_size,
+                num_heads=config.num_attention_heads,
+                qk_nope_head_dim=config.qk_nope_head_dim,
+                qk_rope_head_dim=config.qk_rope_head_dim,
+                v_head_dim=config.v_head_dim,
+                q_lora_rank=config.q_lora_rank,
+                kv_lora_rank=config.kv_lora_rank,
+                rope_theta=old_attn.rope_theta,
+                rope_scaling=config.rope_parameters,
+                max_position_embeddings=config.max_position_embeddings,
+                quant_config=quant_config,
+                layer_id=layer_id,
+                reduce_results=False,
+                prefix=attn_prefix,
+                alt_stream=self.model.alt_stream,
+                dsa_enable_prefill_cp=self.model.dsa_enable_prefill_cp,
+                mla_enable_prefill_cp=self.model.mla_enable_prefill_cp,
+            )
+            layer.input_layernorm = AXK2GatedRMSNorm(
+                config.hidden_size,
+                config.rms_norm_eps,
+                config.gated_norm_rank,
+                add_prefix("input_layernorm", f"model.layers.{layer_id}"),
+            )
+            if layer.is_layer_sparse:
+                layer.post_attention_layernorm = AXK2GatedRMSNorm(
+                    config.hidden_size,
+                    config.rms_norm_eps,
+                    config.gated_norm_rank,
+                    add_prefix("post_attention_layernorm", f"model.layers.{layer_id}"),
+                )
+            # The communicator caches these module references during layer construction.
+            layer.layer_communicator.input_layernorm = layer.input_layernorm
+            layer.layer_communicator.post_attention_layernorm = (
+                layer.post_attention_layernorm
+            )
+            layer.layer_communicator.qkv_latent_func = (
+                layer.self_attn.prepare_qkv_latent
+            )
+
+
+EntryClass = AXK2ForCausalLM

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha.py
@@ -159,9 +159,10 @@ class DeepseekMHAForwardMixin:
 
             if self.use_dsa:
                 q_lora = self.q_a_layernorm(q)
-                q = self.q_b_proj(q_lora)[0].view(
-                    -1, self.num_local_heads, self.qk_head_dim
-                )
+                # Keep the projection behind the model hook so architectures
+                # with fused or otherwise specialized q_b projections can
+                # override it without branching in the common attention path.
+                q = self.q_b_proj_forward(q_lora)
                 if self.should_run_indexer():
                     forward_dsa_indexer_for_mha(
                         self.indexer,
@@ -173,7 +174,7 @@ class DeepseekMHAForwardMixin:
                     )
             else:
                 q = self.q_a_layernorm(q)
-                q = self.q_b_proj(q)[0].view(-1, self.num_local_heads, self.qk_head_dim)
+                q = self.q_b_proj_forward(q)
 
         else:
             q = self.q_proj(hidden_states)[0].view(

--- a/python/sglang/srt/utils/hf_transformers/common.py
+++ b/python/sglang/srt/utils/hf_transformers/common.py
@@ -23,6 +23,7 @@ from huggingface_hub import snapshot_download
 
 from sglang.srt.configs import (
     AfmoeConfig,
+    AXK2Config,
     BailingHybridConfig,
     ChatGLMConfig,
     DbrxConfig,
@@ -91,6 +92,7 @@ from transformers import PretrainedConfig
 _CONFIG_REGISTRY: Dict[str, Type[PretrainedConfig]] = {
     cls.model_type: cls
     for cls in [
+        AXK2Config,
         AfmoeConfig,
         BailingHybridConfig,
         ChatGLMConfig,


### PR DESCRIPTION

## Motivation

This PR adds native SGLang support for the SKT A.X-K2 model and its ModelOpt mixed NVFP4/FP8 checkpoint.

The released checkpoints use a DeepSeek-V3.2-style MLA/DSA/MoE architecture with additional model-specific operations, including gated RMSNorm and a fused `q_b` query/output-gate projection.

The NVFP4 checkpoint also requires mixed-precision expert loading that preserves the serialized packed layout and handles FP8 shared experts.

The shared runtime, attention, and quantization changes are selected by model capabilities and checkpoint metadata rather than model-name-specific branches, preserving the existing behavior for other models.

## Modifications

- Add `AXK2Config`, model registration, and `AXK2ForCausalLM`.
- Implement the A.X-K2 gated RMSNorm and fused `q_b` projection/output-gate behavior on top of the existing DeepSeek-V3.2 MLA, DSA, and MoE paths.
- Add a model-overridable `q_b_proj_forward` hook to the common MHA forward path while retaining the existing implementation as the default.
- Add a generic `supports_mha_one_shot` model capability:
  - existing models default to `true`;
  - A.X-K2 disables the one-shot dense shortcut because it does not preserve the fused projection semantics.
- Extend ModelOpt mixed-precision checkpoint loading to:
  - infer fused `gate_up_proj` quantization from its source projections;
  - preserve the physical packed NVFP4 expert layout across tensor parallel ranks;
  - handle different routed and shared expert dimensions;
  - load scalar per-projection FP8 shared-expert scales;
  - convert FP8 shared experts to grouped MXFP4 with group size 16.
- Add pip-installed CUDA toolkit library-directory and versioned `libcudart` fallbacks.
- Gracefully fall back when optional DeepGEMM or DeepEP initialization is unavailable in the active CUDA environment.

Compatibility notes:

- Existing model configurations retain the current MHA one-shot behavior.
- The default `q_b` projection hook performs the existing projection operation.
- The new quantized loading paths are selected through ModelOpt quantization metadata and weight formats, not through A.X-K2-specific checks in common code.

## Accuracy Tests

Validation environment:

- 8x NVIDIA B300 SXM6
- Tensor parallel size: 4 per model
- BF16 KV cache
- FlashMLA sparse prefill
- TRT-LLM DSA decode
- CUDA graphs disabled for correctness isolation

Models:

- `skt/A.X-K2`
- `skt/A.X-K2-NVFP4`

Representative serving command:

```bash
MODEL=/path/to/A.X-K2
MOE_BACKEND=triton

# For A.X-K2-NVFP4:
# MODEL=/path/to/A.X-K2-NVFP4
# MOE_BACKEND=flashinfer_cutlass

SGLANG_ENABLE_JIT_DEEPGEMM=0 \
SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD=0 \
sglang serve "$MODEL" \
  --chat-template "$MODEL/chat_template.jinja" \
  --tensor-parallel-size 4 \
  --expert-parallel-size 1 \
  --page-size 64 \
  --kv-cache-dtype bfloat16 \
  --disable-custom-all-reduce \
  --attention-backend dsa \
  --dsa-prefill-backend flashmla_sparse \
  --dsa-decode-backend trtllm \
  --moe-runner-backend "$MOE_BACKEND" \
  --flashinfer-mxfp4-moe-precision bf16 \
  --disable-flashinfer-autotune \
  --disable-cuda-graph \
  --disable-shared-experts-fusion \
  --skip-server-warmup \
  --reasoning-parser deepseek-v3
```

Example request:

```json
{
  "messages": [
    {
      "role": "user",
      "content": "What is Sparse Attention? Answer in one concise sentence."
    }
  ],
  "temperature": 0,
  "max_tokens": 64,
  "chat_template_kwargs": {
    "enable_thinking": false
  }
}
```

End-to-end results:

| Checkpoint | Loading | `/health` | Chat completion |
| --- | --- | --- | --- |
| `skt/A.X-K2` | All 346 shards loaded | HTTP 200 | HTTP 200, 38 completion tokens, `stop` |
| `skt/A.X-K2-NVFP4` | All 346 shards loaded | HTTP 200 | HTTP 200, 18 completion tokens, `stop` |

Example A.X-K2 output:

> Sparse attention is a technique that reduces the computational cost of
> standard attention by limiting each token to attend only to a strategically
> selected subset of other tokens, rather than all tokens in the sequence.

Example A.X-K2-NVFP4 output:

> Sparse attention is a method of attention mechanism where attention is
> distributed over multiple sparse points.

Numerical comparisons against the reference Transformers implementation:

- Fused `q_b` projection:
  - cosine similarity: `0.999991`
- Layer-1 expert gate/up/down computation:
  - cosine similarity: `0.999989`
- Router validation:
  - selected expert sets and routing weights matched for `64/64` tokens

The dense A.X-K2 forward path was also cross-checked against the official Transformers implementation through the numerical comparisons above.

Additional checks:

- Full `pre-commit run --all-files` passed.
- Black check passed on all changed Python files.
- isort check passed.
- Ruff `F401`, `F821`, and `UP037` checks passed.
- Python compilation passed for all changed files.
- `git diff --check` passed.
- Checkpoint configuration loading passed for both released checkpoints.
- CUDA MXFP4 packing smoke test passed.

These results are functional and numerical correctness checks rather than a standardized downstream-task accuracy benchmark.

## Speed Tests and Profiling

Not measured. This PR focuses on model correctness and checkpoint compatibility and does not claim an inference performance improvement.

CUDA graphs, FlashInfer autotuning, and server warmup were disabled during the validation, so the validation runs should not be interpreted as performance benchmarks.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
  - Full `pre-commit run --all-files` passed, including the Rust formatting and Clippy hooks.
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
  - Full-checkpoint end-to-end, numerical equivalence, and CUDA packing checks were performed, but no registered unit test was added.
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
  - No documentation update is included yet.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
  - Functional and numerical accuracy results are provided above; standardized accuracy and speed benchmarks are pending.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32860449696](https://github.com/sgl-project/sglang/actions/runs/32860449696)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32860450076](https://github.com/sgl-project/sglang/actions/runs/32860450076)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32860450108](https://github.com/sgl-project/sglang/actions/runs/32860450108)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->