### PR TITLE
[Tool Call] Fix DeepSeekV32Detector streaming corrupting tool-call arguments

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -13,7 +13,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
-from sglang.srt.function_call.utils import _find_common_prefix, _partial_json_loads
+from sglang.srt.function_call.utils import _partial_json_loads
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +75,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
         self.bot_token = "<｜DSML｜function_calls>"
         self.eot_token = "</｜DSML｜function_calls>"
         self.invoke_end_token = "</｜DSML｜invoke>"
+        self.parameter_end_token = "</｜DSML｜parameter>"
         self.parameter_regex = r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*?)</｜DSML｜parameter>'
         self.partial_parameter_regex = (
             r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*)$'
@@ -112,6 +113,54 @@ class DeepSeekV32Detector(BaseFormatDetector):
             return name, "", True
         return name, m.group("body"), bool(m.group("end"))
 
+    @staticmethod
+    def _strip_partial_tag_suffix(text: str, tag: str) -> str:
+        """Drop a trailing fragment of `text` that is the start of `tag`.
+
+        `str.rstrip` cannot do this: it takes a character SET, so the previous
+        `rstrip("oke")` also ate a value ending in "note", leaving "not".
+        """
+        for n in range(min(len(tag), len(text)), 0, -1):
+            if text.endswith(tag[:n]):
+                return text[:-n]
+        return text
+
+    def _direct_json_body(self, invoke_content: str, allow_partial: bool):
+        """Format 2: the invoke body IS the arguments object, verbatim.
+        Returns None when the body is not in that format.
+
+        The partial closing tag is trimmed BEFORE whitespace is stripped. The
+        other order is off by a byte: the tag's leading "<" shields the
+        whitespace in front of it from strip(), so that whitespace is streamed
+        and then vanishes once the tag completes.
+        """
+        text = invoke_content
+        if allow_partial:
+            text = self._strip_partial_tag_suffix(text, self.invoke_end_token)
+        text = text.strip()
+        if text.startswith("{") and (allow_partial or text.endswith("}")):
+            return text
+        return None
+
+    def _complete_parameters(self, invoke_content: str) -> tuple[dict, int]:
+        """Parameters whose closing tag has arrived, and the offset past the
+        last one. These are settled: their serialised form cannot change."""
+        parameters = {}
+        last_match_end = 0
+        for match in re.finditer(self.parameter_regex, invoke_content, re.DOTALL):
+            name, param_type, value = match.group(1), match.group(2), match.group(3)
+            value = value.strip()
+            if param_type == "true":  # string type
+                parameters[name] = value
+            else:
+                # Try to parse as JSON for other types
+                try:
+                    parameters[name] = json.loads(value)
+                except (json.JSONDecodeError, ValueError):
+                    parameters[name] = value
+            last_match_end = match.end()
+        return parameters, last_match_end
+
     def _parse_parameters_from_xml(
         self, invoke_content: str, allow_partial: bool = False
     ) -> str:
@@ -121,49 +170,26 @@ class DeepSeekV32Detector(BaseFormatDetector):
         Supports two formats:
         1. XML parameter tags: <｜DSML｜parameter name="..." string="...">value</｜DSML｜parameter>
         2. Direct JSON: { "key": "value" }
+
+        NOTE: the `allow_partial=True` result must not be streamed. A parameter
+        still arriving can serialise as a structure on one chunk and as a
+        quote-escaped string on the next, so consecutive results are not
+        prefixes of each other. Use `_streamable_prefix` for that.
         """
         # First, try to parse as direct JSON (new format)
-        invoke_content_stripped = invoke_content.strip()
-        if invoke_content_stripped.startswith("{"):
-            if allow_partial:
-                # Remove incomplete invoke end call prefix in case they are captured by param
-                for token in reversed(self.prefix_invoke_end_call):
-                    invoke_content_stripped = invoke_content_stripped.rstrip(token)
-                return invoke_content_stripped
-            elif invoke_content_stripped.endswith("}"):
-                return invoke_content_stripped
+        body = self._direct_json_body(invoke_content, allow_partial)
+        if body is not None:
+            return body
 
         # Fall back to XML parameter tag parsing (original format)
-        parameters = {}
-        # Find all complete parameter matches
-        param_matches = list(
-            re.finditer(self.parameter_regex, invoke_content, re.DOTALL)
-        )
-
-        last_match_end = 0
-        for match in param_matches:
-            param_name = match.group(1)
-            param_type = match.group(2)
-            param_value = match.group(3)
-            last_match_end = match.end()
-
-            # Convert value based on type
-            if param_type == "true":  # string type
-                parameters[param_name] = param_value.strip()
-            else:
-                # Try to parse as JSON for other types
-                try:
-                    parameters[param_name] = json.loads(param_value.strip())
-                except (json.JSONDecodeError, ValueError):
-                    parameters[param_name] = param_value.strip()
+        parameters, last_match_end = self._complete_parameters(invoke_content)
 
         # If allowed, try to parse a partial parameter at the end
         if allow_partial:
-            remaining_content = invoke_content[last_match_end:]
-
-            # Remove incomplete parameter_end_call prefix in case they are captured by param
-            for token in reversed(self.prefix_parameter_end_call):
-                remaining_content = remaining_content.rstrip(token)
+            # Remove an incomplete closing tag in case it was captured by param
+            remaining_content = self._strip_partial_tag_suffix(
+                invoke_content[last_match_end:], self.parameter_end_token
+            )
 
             # Match start of a parameter tag + value (potentially incomplete)
             # Regex: <tag name="..." string="...">VALUE... (no end tag)
@@ -184,6 +210,48 @@ class DeepSeekV32Detector(BaseFormatDetector):
                         parameters[param_name] = param_value.strip()
 
         return json.dumps(parameters, ensure_ascii=False)
+
+    def _streamable_prefix(self, invoke_content: str) -> str:
+        """The longest prefix of the final arguments JSON that cannot change.
+
+        Every byte returned here is handed to the client and can never be
+        recalled, so this is deliberately conservative:
+
+        * a parameter whose closing tag has arrived is settled — include it;
+        * a non-string parameter still arriving is not settled: whether its
+          value ends up structural (`_partial_json_loads` succeeded) or a
+          quote-escaped string (the fallback) is only decided once the whole
+          value is in hand, and the two differ from the value's first byte.
+          Stop before it;
+        * a string parameter is safe — `json.dumps` escapes character by
+          character, so its serialisation only grows by appending. Stream its
+          content, minus the closing quote.
+        """
+        body = self._direct_json_body(invoke_content, allow_partial=True)
+        if body is not None:
+            return body
+
+        parameters, last_match_end = self._complete_parameters(invoke_content)
+        # Drop the closing brace: more parameters may still follow.
+        prefix = json.dumps(parameters, ensure_ascii=False)[:-1]
+
+        remaining_content = self._strip_partial_tag_suffix(
+            invoke_content[last_match_end:], self.parameter_end_token
+        )
+        partial_match = re.search(
+            self.partial_parameter_regex, remaining_content, re.DOTALL
+        )
+        if (
+            partial_match
+            and partial_match.group(2) == "true"
+            and (param_value := partial_match.group(3))
+        ):
+            key = json.dumps(partial_match.group(1), ensure_ascii=False)
+            value = json.dumps(param_value.strip(), ensure_ascii=False)
+            # ", " and ": " are json.dumps' default separators; value[:-1] drops
+            # the closing quote, because the content can still grow.
+            prefix += f"{', ' if parameters else ''}{key}: {value[:-1]}"
+        return prefix
 
     def detect_and_parse(self, text: str, tools: list[Tool]) -> StreamingParseResult:
         """
@@ -307,28 +375,33 @@ class DeepSeekV32Detector(BaseFormatDetector):
                     )
                     self.current_tool_name_sent = True
 
-                # 2. Parse current parameters (partial or complete)
-                current_params = self._parse_parameters_from_xml(
-                    invoke_content, allow_partial=not is_tool_end
-                )
+                # 2. Parse current parameters. While the invoke is still open,
+                #    take only the part that is provably final. Diffing two
+                #    partial serialisations is not sound: a parameter flips
+                #    between structural and quote-escaped-string form as it
+                #    arrives, so their common prefix need not be a prefix of the
+                #    finished arguments.
+                if is_tool_end:
+                    current_params = self._parse_parameters_from_xml(invoke_content)
+                else:
+                    current_params = self._streamable_prefix(invoke_content)
 
                 # 3. Calculate and send incremental arguments
-                sent_len = len(self.streamed_args_for_tool[self.current_tool_id])
-                prev_params = self.prev_tool_call_arr[self.current_tool_id].get(
-                    "arguments"
-                )
+                sent = self.streamed_args_for_tool[self.current_tool_id]
 
                 argument_diff = None
-
-                if is_tool_end:
-                    # If complete, send everything remaining
-                    argument_diff = current_params[sent_len:]
-                elif prev_params is not None:
-                    # If partial, send stable prefix diff
-                    if current_params != prev_params:
-                        prefix = _find_common_prefix(current_params, prev_params)
-                        if len(prefix) > sent_len:
-                            argument_diff = prefix[sent_len:]
+                if current_params.startswith(sent):
+                    argument_diff = current_params[len(sent) :] or None
+                else:
+                    # Bytes already streamed cannot be recalled; all that is
+                    # left is to stop making it worse and be loud about it.
+                    logger.warning(
+                        "deepseekv32: streamed tool arguments diverged from the "
+                        "parsed value (%d chars streamed, %d parsed); dropping "
+                        "this delta rather than emitting invalid JSON",
+                        len(sent),
+                        len(current_params),
+                    )
 
                 if argument_diff:
                     all_calls.append(

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -1,5 +1,6 @@
 """Unit tests for DeepSeekV4Detector DSML streaming — no server, no model loading."""
 
+import json
 from unittest.mock import patch
 
 from sglang.srt.entrypoints.openai.protocol import Function, Tool
@@ -121,6 +122,140 @@ class TestDeepSeekV4Streaming(CustomTestCase):
         # No half-formed call: the failure can land between a tool's name and its
         # arguments, so an argument-less named call must not reach the client.
         self.assertEqual(first.calls, [])
+
+
+def _tasks_call(tasks_literal: str, notes: str = "see the plan") -> str:
+    """A create_tasks call: an array-of-objects parameter (string="false") plus a
+    string one. The array is the largest delimiter surface a tool argument has,
+    which is where the streaming corruption showed up."""
+    return _wrapped(
+        _invoke(
+            "create_tasks",
+            _param("tasks", "false", tasks_literal)
+            + "\n"
+            + _param("notes", "true", notes),
+        )
+    )
+
+
+_TASKS = (
+    '[{"id": "T1", "title": "Review the template", '
+    '"description": "He said \\"no problem\\", but check the delimiters.", '
+    '"dependencies": [], "priority": "high", "estimated_minutes": 120}, '
+    '{"id": "T2", "title": "压测吞吐与首 token 延迟", '
+    '"description": "在预发环境对比两套引擎。", '
+    '"dependencies": ["T1"], "priority": "medium", "estimated_minutes": 240}]'
+)
+
+# How the model plausibly gets the INNER json slightly wrong. Nothing constrains
+# a parameter's interior — the structural tag pins the DSML tags and the function
+# name — so these are ordinary outputs, and they are what used to make the
+# serialisation change shape between chunks.
+ARGUMENT_FIXTURES = {
+    "well_formed": _tasks_call(_TASKS),
+    "trailing_comma": _tasks_call(_TASKS[:-1] + ",]"),
+    "unescaped_quote": _tasks_call(_TASKS.replace("压测吞吐", '压测"吞吐"')),
+    "single_quoted_key": _tasks_call(_TASKS.replace('"priority"', "'priority'")),
+    "value_ends_in_tag_letters": _tasks_call(_TASKS, notes="please read the note"),
+}
+
+
+def _chunkings(text):
+    """Real chunk boundaries are token boundaries; the parser has to be correct at
+    all of them, so sweep rather than sample."""
+    yield "per_char", [text[i : i + 1] for i in range(len(text))]
+    for n in (2, 3, 5, 7, 11, 16, 32, 64):
+        yield f"fixed_{n}", [text[i : i + n] for i in range(0, len(text), n)]
+
+
+class TestDeepSeekV4StreamingArguments(CustomTestCase):
+    """Streaming must never hand the client argument bytes it then contradicts.
+
+    parse_streaming_increment() rebuilds the whole arguments string on every
+    chunk. It used to emit common_prefix(current, previous)[sent_len:] and then
+    current[sent_len:] on the closing tag, which assumes every byte already sent
+    is still a prefix of the finished serialisation. A non-string parameter
+    breaks that: it serialises as a structure while _partial_json_loads succeeds
+    and as a quote-escaped string when it falls back, so the closing-tag slice
+    started at a stale offset and dropped a run out of the middle.
+    """
+
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="create_tasks",
+                    description="Create a task plan",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "tasks": {"type": "array", "items": {"type": "object"}},
+                            "notes": {"type": "string"},
+                        },
+                        "required": ["tasks"],
+                    },
+                ),
+            )
+        ]
+
+    def _stream_arguments(self, chunks):
+        """Reassemble arguments the way an OpenAI client does, and count deltas."""
+        detector = DeepSeekV4Detector()
+        arguments, deltas = "", 0
+        for chunk in chunks:
+            for call in detector.parse_streaming_increment(chunk, self.tools).calls:
+                if call.parameters:
+                    arguments += call.parameters
+                    deltas += 1
+        return arguments, deltas
+
+    def test_streamed_arguments_match_non_streaming(self):
+        for name, text in ARGUMENT_FIXTURES.items():
+            expected = DeepSeekV4Detector().detect_and_parse(text, self.tools).calls
+            self.assertEqual(len(expected), 1, name)
+            for label, chunks in _chunkings(text):
+                with self.subTest(fixture=name, chunking=label):
+                    arguments, _ = self._stream_arguments(chunks)
+                    self.assertEqual(
+                        json.loads(arguments), json.loads(expected[0].parameters)
+                    )
+
+    def test_streamed_arguments_are_always_a_prefix_of_the_final_value(self):
+        """The model can stop anywhere and a delta cannot be recalled, so at every
+        truncation point what has been streamed must still be a prefix of what the
+        finished stream produces."""
+        for name, text in ARGUMENT_FIXTURES.items():
+            final, _ = self._stream_arguments([text])
+            for cut in range(1, len(text), 3):
+                partial, _ = self._stream_arguments(
+                    [text[:cut][i : i + 4] for i in range(0, cut, 4)]
+                )
+                with self.subTest(fixture=name, cut=cut):
+                    self.assertTrue(final.startswith(partial), partial[-80:])
+
+    def test_string_parameter_arguments_still_stream_incrementally(self):
+        """Holding back the unsettled tail must not degrade into one final chunk:
+        a string parameter is prefix-stable and has to keep flowing (#11888)."""
+        value = "paragraph " * 300
+        text = _wrapped(_invoke("create_tasks", _param("notes", "true", value)))
+        arguments, deltas = self._stream_arguments(
+            [text[i : i + 8] for i in range(0, len(text), 8)]
+        )
+
+        self.assertEqual(json.loads(arguments)["notes"], value.strip())
+        self.assertGreater(deltas, 10)
+
+    def test_partial_tag_suffix_trim_does_not_eat_value_characters(self):
+        """str.rstrip takes a character set, not a suffix: rstrip("oke") turned a
+        value ending in "note" into "not"."""
+        trim = DeepSeekV4Detector()._strip_partial_tag_suffix
+        end = f"</{DSML}parameter>"
+
+        self.assertEqual(trim("read the note", end), "read the note")
+        self.assertEqual(trim("value", end), "value")
+        self.assertEqual(trim("value</", end), "value")
+        self.assertEqual(trim(f"value</{DSML}par", end), "value")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

With `--tool-call-parser deepseekv32` (or `deepseekv4`, which subclasses the same
detector) in **streaming** mode, `function.arguments` intermittently arrives as
invalid JSON with a run of bytes missing out of the middle. Measured on
DeepSeek-V4 over 433 calls through a production gateway:

| request shape | calls | malformed | rate |
|---|---|---|---|
| `stream=false` | 80 | 0 | 0.0% |
| `stream=true` | 80 | 4 | 5.0% |
| `stream=true`, `temperature=0.7` | 81 | 3 | 3.7% |
| `stream=true`, ~30k-token prompt | 80 | 2 | 2.5% |
| `stream=true`, `tool_choice` pinned to the function | 64 | 3 | 4.7% |

Same weights, same prompts — only `stream` matters. Per tool it concentrates
where the arguments are biggest: 13.8% of calls to a planner tool whose argument
is a nested array of objects, 0% on a single-string search tool. Pinning
`tool_choice`, which puts the grammar backend in the loop, does not help, because
the arguments string the client receives is not generated by the model at all —
the detector builds it out of the DSML tags.

A representative broken payload, with the seam visible mid-string:

```
…"description": "…并据此调优"medium", "estimated_minutes": …
                          ^ jumps from mid-description into the next key's tail
```

plus stray `\"` escapes stranded inside an otherwise structural blob.

## Root cause

`parse_streaming_increment()` re-serialises the whole arguments object on every
chunk and emits `common_prefix(current, previous)[sent_len:]`, then
`current_params[sent_len:]` once the closing tag arrives. That is sound only if
**every byte already emitted is still a prefix of the finished serialisation**,
and it is not: a parameter has two possible serialised shapes, and which one you
get depends on how much of it has arrived.

```python
# complete value
try:    parameters[name] = json.loads(value.strip())
except: parameters[name] = value.strip()                      # -> one JSON string

# partial value
try:    parameters[name] = _partial_json_loads(value, Allow.ALL)[0]
except: parameters[name] = value.strip()                      # -> one JSON string
```

The structural shape `{"tasks": [{…}]}` and the string shape
`{"tasks": "[{\"…\"}]"}` diverge from the first byte of the value and have
different lengths. When the fallback fires at a different moment than it did on
the previous chunk, `sent_len` no longer indexes the same string, so the
closing-tag slice starts too far in and drops exactly the bytes that were
over-sent.

The trigger is the model writing *slightly* invalid JSON inside a parameter,
which nothing constrains — the structural tag pins the DSML tags and the function
name, not the parameter interior. A trailing comma, an unescaped quote or a
single-quoted key is enough.

## Modifications

**Stop emitting bytes that can still change**, rather than trying to reconcile
two partial serialisations after the fact. `_streamable_prefix()` returns the
longest prefix of the final arguments JSON that is settled:

- a parameter whose closing tag has arrived is settled — include it;
- the parameter still arriving is **not** settled when it is a non-string type,
  because its shape is only decided once the whole value is in hand — stop before
  its value;
- when it is a string type the shape **is** known: `json.dumps` escapes character
  by character, so the serialisation only grows by appending. Stream its content,
  minus the closing quote.

The emit is then `current[len(sent):]` guarded by `current.startswith(sent)`,
which logs a warning rather than corrupting the payload if the invariant is ever
broken again.

**Argument streaming is preserved.** This deliberately does not buffer everything
until the closing tag — string parameters keep flowing incrementally, so it does
not reintroduce #11888. A 3000-char string parameter still arrives in 154 deltas.

Also replaces the two `rstrip()` tail trims. `str.rstrip` takes a character set,
not a suffix, so `rstrip("oke")` ate any trailing run of `o`, `k` and `e` — a
parameter value ending in `note` came back as `not`.
`_strip_partial_tag_suffix()` matches a real prefix of the closing tag, and runs
*before* whitespace is stripped, because the other order lets the tag's leading
`<` shield whitespace that then gets streamed and later vanishes when the tag
completes (an off-by-one-byte prefix violation).

`_direct_json_body()` and `_complete_parameters()` are extraction, not new
behaviour: they exist so `_streamable_prefix()` and `_parse_parameters_from_xml()`
cannot drift apart. `_parse_parameters_from_xml()`'s own behaviour is unchanged;
it now has no caller inside the class and is kept for subclasses, with a
docstring note that its partial result is not prefix-safe.

### Deliberately out of scope

- **Invalid inner JSON is still coerced into a string.** When the model's own JSON
  does not parse, both paths store the blob as one JSON string, so the client
  gets syntactically valid JSON whose array-typed parameter is a string. This PR
  makes streaming and non-streaming *agree*; it does not change what they agree
  on, which is a separate decision.
- **A direct-JSON body that opens `{` and never closes** still yields
  `arguments: "{}"`. Changing that changes what a client receives on that path.
- **Direct-JSON bodies stream the model's own whitespace** while the
  non-streaming path re-serialises compactly via `parse_base_json`. Both parse to
  the same value.

## Accuracy Tests

Not applicable — no model output changes; this is a serialisation-path fix.
Verified separately that the same 433-call probe that produced the table above
returns **0/433 malformed** against a patched engine, with reasoning parsing,
tool calling, streaming framing and prefix caching all unchanged.

## Speed Tests and Profiling

No measurable effect. Per chunk the work is the same regex scan plus one
`json.dumps` of the settled parameters; the code being replaced did a
`json.dumps` plus a `_find_common_prefix` over the whole string. Nothing new runs
per token, and non-string parameters now serialise *less* often, not more.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Tests

Added to `test/registered/unit/function_call/test_deepseekv4_detector.py`, the
file that already covers this detector's streaming behaviour: 5 fixtures x 9
chunk boundary sets (per-char and 8 fixed widths), asserting that streamed
arguments parse and equal the non-streaming result, and that at **every**
truncation point the bytes streamed so far are a prefix of what the finished
stream produces — the invariant the old code assumed but did not hold to. Plus a
guard that a long string parameter still arrives in many deltas, and a unit test
for the `rstrip` fix.

```
before this change:  480 failed, 9 passed
after:               10 passed, 970 subtests passed
```

Run without a GPU:

```bash
python3 -m pytest -q test/registered/unit/function_call/test_deepseekv4_detector.py
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32864233420](https://github.com/sgl-project/sglang/actions/runs/32864233420)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32864232953](https://github.com/sgl-project/sglang/actions/runs/32864232953)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32864233177](https://github.com/sgl-project/sglang/actions/runs/32864233177)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->