### PR TITLE
fix(disagg): snapshot affected rooms before iterating outside the lock

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -1130,8 +1130,8 @@ class CommonKVManager(BaseKVManager):
                 del self.connection_pool[k]
             self.prefill_info_table.pop(failed_bootstrap_addr, None)
 
-            possible_affected_rooms = self.addr_to_rooms_tracker.get(
-                failed_bootstrap_addr, []
+            possible_affected_rooms = list(
+                self.addr_to_rooms_tracker.get(failed_bootstrap_addr, [])
             )
             self.addr_to_rooms_tracker.pop(failed_bootstrap_addr, None)
 


### PR DESCRIPTION
## Motivation

`CommonKVManager._handle_node_failure` takes the room set out of `addr_to_rooms_tracker` under `connection_lock`, then iterates it *after* the lock is released:

```python
with self.connection_lock:
    ...
    possible_affected_rooms = self.addr_to_rooms_tracker.get(failed_bootstrap_addr, [])
    self.addr_to_rooms_tracker.pop(failed_bootstrap_addr, None)

for endpoint in stale_endpoints:
    CommonKVReceiver.disconnect_endpoint(endpoint)

for room in possible_affected_rooms:      # live set, lock no longer held
    ...
```

`.get()` returns the live set, not a copy. The loop is safe only if no other thread can mutate that exact object — which holds when every mutator re-indexes the dict, because `addr_to_rooms_tracker` is a `defaultdict(set)` and the `pop` above means a later `tracker[addr]` builds a *fresh* set instead of resurrecting the popped one.

That assumption is not uniform across the backends:

| mutator | pattern | safe against the popped set? |
|---|---|---|
| `CommonKVReceiver.__init__` (`common/conn.py:1360`) | re-indexes | yes |
| `NixlKVReceiver.poll` (`nixl/conn.py:2942`) | re-indexes | yes |
| `MooncakeKVManager._on_heartbeat_success` (`mooncake/conn.py:2190`) | takes `.copy()` | yes |
| **`MoriKVManager._cleanup_room_tracking` (`mori/conn.py:577`)** | **caches the reference** | **no** |

Mori is the exception:

```python
rooms = self.addr_to_rooms_tracker.get(bootstrap_addr)
if rooms is not None:
    rooms.discard(bootstrap_room)      # mutates the object captured above
```

It holds the set across the `is not None` check and discards from what it captured, without `connection_lock`. If that reference was obtained before the `pop`, the discard lands on the same object `_handle_node_failure` is iterating, raising `RuntimeError: Set changed size during iteration`.

The consequence is disproportionate: `_handle_node_failure` is called *outside* the heartbeat loop's `try/except`, so the exception escapes the thread target. The heartbeat thread exits, and node-failure detection is silently disabled for the rest of the process's life with nothing logged.

### Reachability

**This is hardening, not a live bug.** Only `MooncakeKVManager` and `NixlKVManager` call `_start_heartbeat_checker_thread()`, so `_handle_node_failure` never runs in a mori process today, and mori's mutator does not exist in a mooncake or nixl one. The two halves currently cannot meet.

The fix is still worth making on the reader side:

- The safety of this loop currently depends on the access pattern of every present and future mutator, which is an invisible, unenforced invariant — mori already violates it.
- Wiring the heartbeat checker into mori is a one-line change that would silently make the race reachable.
- The failure mode is permanent, silent loss of failure detection, so the cost of being wrong is high and the cost of the guard is one `list()`.

## Modifications

Snapshot the set under the lock. One line; no other behavior change — the same rooms are visited, and the tracker entry is still popped.

`list()` on a built-in set is a complete fix rather than a narrowing: it completes without executing bytecode, so no other Python thread can interleave mid-iteration.

## Accuracy Tests

Not applicable — control-plane failure handling; no model output, kernel, or forward path is touched.

## Speed Tests and Profiling

Not applicable. One list construction on a node-failure path.

## Verification performed

Reproduced the interleaving against the real structures — a `defaultdict(set)` tracker, a reader doing get/pop under a lock then iterating outside it, and a mori-shaped mutator that caches the set by reference and discards without the lock — under `sys.setswitchinterval(1e-6)`:

| | RuntimeError |
|---|---|
| before | 20 / 300 trials |
| after (`list(...)`) | **0 / 300 trials** |

Separately confirmed that `list(a_set)` is atomic against concurrent mutation while an equivalent Python-level comprehension is not (0 vs 25 failures under the same conditions), which is why the snapshot closes the window rather than shrinking it.

The mutator/reachability table above was derived by inspecting each call site, not by eye.

`ruff 0.15.1 --select=F401,F821,UP037`, `black 26.1.0`, `isort 7.0.0` clean; `py_compile` passes.

Not exercised on a live PD deployment — reaching `_handle_node_failure` requires a prefill node to miss enough heartbeats on multi-GPU hardware.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — N/A: a deterministic test for this interleaving would be a timing-dependent sleep race; the reproduction above is described instead.
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: internal failure path.
- [x] Provide accuracy and speed benchmark results. — N/A, see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32871581769](https://github.com/sgl-project/sglang/actions/runs/32871581769)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32871581423](https://github.com/sgl-project/sglang/actions/runs/32871581423)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32871581708](https://github.com/sgl-project/sglang/actions/runs/32871581708)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->