### PR TITLE
fix(openai): omit DSV4/DSV32 tools when tool_choice=none

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1288,7 +1288,16 @@ class OpenAIServingChat(OpenAIServingBase):
             if messages[0]["role"] != "system":
                 # insert an empty system prompt to help render tool system prompt
                 messages.insert(0, {"role": "system", "content": ""})
-            if request.tools:
+            if request.tool_choice == "none":
+                # tool_choice="none" disables tool use: strip tool schemas from
+                # both request-level and message-level tools so the DSV4/DSV32
+                # encoder does not render TOOLS_TEMPLATE into the system prompt.
+                # Without this, the model sees tool definitions and may emit DSML
+                # markup that the output parser (also disabled for "none") will
+                # not intercept, leaking raw DSML into message.content.
+                for message in messages:
+                    message.pop("tools", None)
+            elif request.tools:
                 messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
 
             # Default encoding (dsv4/dsv32)

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -1251,7 +1251,191 @@ class ServingChatTestCase(unittest.TestCase):
                     ],
                 )
 
+    def _setup_dsv_chat(self, chat_encoding_spec: str):
+        """Configure the mock for a DSV4/DSV32 encoding test."""
+        self.template_manager.chat_template_name = None
+        self.template_manager.jinja_template_content_format = "string"
+        self.tm.model_config.hf_config.architectures = [
+            "DeepseekV4ForCausalLM" if chat_encoding_spec == "dsv4"
+            else "DeepseekV3ForCausalLM"
+        ]
+        self.tm.model_config.hf_config.to_dict.return_value = {}
+        self.chat = OpenAIServingChat(self.tm, self.template_manager)
+        self.chat._dsv4_reasoning_effort_profile = "preview"
+        self.chat.tool_call_parser = None
+        self.chat.chat_encoding_spec = chat_encoding_spec
+        self.chat.default_chat_template_kwargs = {}
+
+    def test_dsv_encoders_omit_tools_when_tool_choice_is_none(self):
+        """DSV4/DSV32 encoders must not render tool schemas when tool_choice=none.
+
+        Both request-level tools and message-level tools (on system/developer
+        messages) must be stripped so the encoder does not render
+        TOOLS_TEMPLATE, which would cause the model to emit DSML markup
+        that the disabled output parser cannot intercept.
+        """
+        request_tool = {
+            "type": "function",
+            "function": {
+                "name": "request_tool",
+                "parameters": {"type": "object"},
+            },
+        }
+        message_tool = {
+            "type": "function",
+            "function": {
+                "name": "message_tool",
+                "parameters": {"type": "object"},
+            },
+        }
+
+        for chat_encoding_spec in ("dsv4", "dsv32"):
+            for message_role in ("system", "developer"):
+                with self.subTest(
+                    chat_encoding_spec=chat_encoding_spec, message_role=message_role
+                ):
+                    self._setup_dsv_chat(chat_encoding_spec)
+                    self.tm.tokenizer.encode.reset_mock()
+                    req = ChatCompletionRequest(
+                        model="x",
+                        messages=[
+                            {
+                                "role": message_role,
+                                "content": "Follow the request.",
+                                "tools": [message_tool],
+                            },
+                            {"role": "user", "content": "Answer directly."},
+                        ],
+                        tools=[request_tool],
+                        tool_choice="none",
+                    )
+
+                    self.chat._process_messages(req, is_multimodal=False)
+
+                    prompt = self.tm.tokenizer.encode.call_args.args[0]
+                    self.assertNotIn("## Tools", prompt)
+                    self.assertNotIn("request_tool", prompt)
+                    self.assertNotIn("message_tool", prompt)
+                    self.assertNotIn("<｜DSML｜tool_calls>", prompt)
+                    self.assertNotIn("<｜DSML｜function_calls>", prompt)
+                    # Original request should not be mutated
+                    self.assertEqual(req.tools[0].function.name, "request_tool")
+                    self.assertEqual(
+                        req.messages[0].tools[0].function.name, "message_tool"
+                    )
+
+    def test_dsv_encoders_keep_tools_when_tool_choice_is_auto(self):
+        """DSV4/DSV32 encoders must render tool schemas when tool_choice=auto."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "my_tool",
+                "parameters": {"type": "object"},
+            },
+        }
+
+        for chat_encoding_spec in ("dsv4", "dsv32"):
+            with self.subTest(chat_encoding_spec=chat_encoding_spec):
+                self._setup_dsv_chat(chat_encoding_spec)
+                self.tm.tokenizer.encode.reset_mock()
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "Use the tool."},
+                    ],
+                    tools=[tool],
+                    tool_choice="auto",
+                )
+
                 self.chat._process_messages(req, is_multimodal=False)
+
+                prompt = self.tm.tokenizer.encode.call_args.args[0]
+                self.assertIn("## Tools", prompt)
+                self.assertIn("my_tool", prompt)
+
+    def test_dsv_encoders_keep_tools_when_tool_choice_is_required(self):
+        """DSV4/DSV32 encoders must render tool schemas when tool_choice=required."""
+        tool = {
+            "type": "function",
+            "function": {
+                "name": "required_tool",
+                "parameters": {"type": "object"},
+            },
+        }
+
+        for chat_encoding_spec in ("dsv4", "dsv32"):
+            with self.subTest(chat_encoding_spec=chat_encoding_spec):
+                self._setup_dsv_chat(chat_encoding_spec)
+                self.tm.tokenizer.encode.reset_mock()
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "Use the tool."},
+                    ],
+                    tools=[tool],
+                    tool_choice="required",
+                )
+
+                self.chat._process_messages(req, is_multimodal=False)
+
+                prompt = self.tm.tokenizer.encode.call_args.args[0]
+                self.assertIn("## Tools", prompt)
+                self.assertIn("required_tool", prompt)
+
+    def test_dsv_encoders_none_without_tools_does_not_crash(self):
+        """tool_choice=none with no tools at all should work without error."""
+        for chat_encoding_spec in ("dsv4", "dsv32"):
+            with self.subTest(chat_encoding_spec=chat_encoding_spec):
+                self._setup_dsv_chat(chat_encoding_spec)
+                self.tm.tokenizer.encode.reset_mock()
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[
+                        {"role": "system", "content": "You are helpful."},
+                        {"role": "user", "content": "Hello."},
+                    ],
+                    tool_choice="none",
+                )
+
+                self.chat._process_messages(req, is_multimodal=False)
+
+                prompt = self.tm.tokenizer.encode.call_args.args[0]
+                self.assertNotIn("## Tools", prompt)
+
+    def test_dsv_encoders_none_with_only_message_tools_strips_them(self):
+        """tool_choice=none must strip message-level tools even without request-level tools."""
+        message_tool = {
+            "type": "function",
+            "function": {
+                "name": "message_only_tool",
+                "parameters": {"type": "object"},
+            },
+        }
+
+        for chat_encoding_spec in ("dsv4", "dsv32"):
+            with self.subTest(chat_encoding_spec=chat_encoding_spec):
+                self._setup_dsv_chat(chat_encoding_spec)
+                self.tm.tokenizer.encode.reset_mock()
+                req = ChatCompletionRequest(
+                    model="x",
+                    messages=[
+                        {
+                            "role": "system",
+                            "content": "You are helpful.",
+                            "tools": [message_tool],
+                        },
+                        {"role": "user", "content": "Hello."},
+                    ],
+                    tool_choice="none",
+                )
+
+                self.chat._process_messages(req, is_multimodal=False)
+
+                prompt = self.tm.tokenizer.encode.call_args.args[0]
+                self.assertNotIn("## Tools", prompt)
+                self.assertNotIn("message_only_tool", prompt)
 
     def test_stop_str_isolation_between_requests(self):
         """Test that stop strings from one request don't affect subsequent requests.


### PR DESCRIPTION
Closes #35736

## Motivation

When `tool_choice="none"`, the DSV4/DSV32 encoding path in `serving_chat.py` unconditionally injects tool schemas into the system message, causing the model to emit DSML tool-call markup that the output parser (disabled for "none") cannot intercept, leaking raw DSML into `message.content`.

## Reproduction

No model needed — the bug is in the encoding path. I verified it with a mock `OpenAIServingChat`:

```
dsv4  tool_choice=none:  Tools=True, DSML=True, tool_name=True  -> BUG: tools leaked
dsv32 tool_choice=none:  Tools=True, DSML=True, tool_name=True  -> BUG: tools leaked
```

## Modifications

In `serving_chat.py`, the DSV4/DSV32 encoding path now strips tool schemas from all messages when `tool_choice == "none"` before passing them to the encoder:

```python
if request.tool_choice == "none":
    for message in messages:
        message.pop("tools", None)
elif request.tools:
    messages[0]["tools"] = [tool.model_dump() for tool in request.tools]
```

This preserves existing behavior for `tool_choice="auto"` / `"required"`.

## Verification

After the fix:

```
dsv4  tool_choice=none:  Tools=False, DSML=False, tool_name=False  -> OK: no tools leaked
dsv4  tool_choice=auto:  Tools=True, tool_name=True              -> OK: tools present (correct)
```

Added two regression tests in `test_serving_chat.py`:
- `test_dsv_encoders_omit_tools_when_tool_choice_is_none`: verifies tools are stripped for both dsv4/dsv32 and system/developer message roles
- `test_dsv_encoders_keep_tools_when_tool_choice_is_auto`: verifies tools are still rendered for auto

## Relationship to #35738

PR #35738 by @junliu-mde implements the same fix but has been in draft state with failing CI since Aug 20. This PR is based on the latest main with clean regression tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32876896075](https://github.com/sgl-project/sglang/actions/runs/32876896075)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32876896088](https://github.com/sgl-project/sglang/actions/runs/32876896088)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32876896020](https://github.com/sgl-project/sglang/actions/runs/32876896020)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->