### PR TITLE
feat(server): support API keys from environment

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1255,8 +1255,12 @@ class Envs:
     SGLANG_ENCODER_DP_WORKER_MAX_INFLIGHT = EnvInt(64)
 
     # ===================================================================
-    # Native gRPC server
+    # HTTP authentication and native gRPC server
     # ===================================================================
+    # Server authentication credentials. Keep these fields secret so they are
+    # never included in scheduler environment snapshots.
+    SGLANG_API_KEY = EnvStr(None, secret=True)
+    SGLANG_ADMIN_API_KEY = EnvStr(None, secret=True)
     # Native gRPC server. SGLANG_GRPC_PORT is the env fallback for the
     # --grpc-port CLI flag; setting either enables the native server alongside
     # HTTP. The worker-threads knob stays env-only (internal tuning, no CLI

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1414,12 +1414,12 @@ class ServerArgs:
     # -------------------------------------------------------------------------
     api_key: A[
         Optional[str],
-        "Set API key of the server. It is also used in the OpenAI API compatible server.",
+        "Set API key of the server. It is also used in the OpenAI API compatible server. Falls back to SGLANG_API_KEY when omitted.",
         NS("serving"),
     ] = None
     admin_api_key: A[
         Optional[str],
-        "Set admin API key for sensitive management endpoints (e.g. /clear_hicache_storage_backend). When set, admin endpoints require this key and do NOT accept --api-key.",
+        "Set admin API key for sensitive management endpoints (e.g. /clear_hicache_storage_backend). When set, admin endpoints require this key and do NOT accept --api-key. Falls back to SGLANG_ADMIN_API_KEY when omitted.",
         NS("serving"),
     ] = None
     served_model_name: A[
@@ -3809,6 +3809,7 @@ class ServerArgs:
         handle_mega_moe(self)
         self._handle_return_hidden_states_mode()
         self._handle_media_url_security()
+        self._handle_api_key_env()
         self._handle_hicache_ratio_default()
         self._validate_prefill_decode_interval()
 
@@ -4004,6 +4005,18 @@ class ServerArgs:
                 "_handle_return_hidden_states_mode",
                 enable_return_hidden_states=True,
             )
+
+    def _handle_api_key_env(self):
+        resolved = {}
+        if self.api_key is None and (api_key := envs.SGLANG_API_KEY.get()) is not None:
+            resolved["api_key"] = api_key
+        if (
+            self.admin_api_key is None
+            and (admin_api_key := envs.SGLANG_ADMIN_API_KEY.get()) is not None
+        ):
+            resolved["admin_api_key"] = admin_api_key
+        if resolved:
+            self._declare("_handle_api_key_env", **resolved)
 
     def _handle_model_capability_adjustments(self):
         if parse_connector_type(self.model_path) == ConnectorType.INSTANCE:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -18,7 +18,7 @@ from sglang.srt.entrypoints.sidecar import (
     build_sidecar_endpoint,
     start_sidecar,
 )
-from sglang.srt.environ import envs
+from sglang.srt.environ import envs, exportable_env_vars
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -43,6 +43,37 @@ _mock_device.start()
 
 
 class TestPrepareServerArgs(CustomTestCase):
+    def test_api_keys_fall_back_to_secret_environment_variables(self):
+        args = ServerArgs(model_path="dummy")
+        with (
+            envs.SGLANG_API_KEY.override("user-secret"),
+            envs.SGLANG_ADMIN_API_KEY.override("admin-secret"),
+        ):
+            args.resolve_once()
+            self.assertEqual(args.api_key, "user-secret")
+            self.assertEqual(args.admin_api_key, "admin-secret")
+            self.assertNotIn("SGLANG_API_KEY", exportable_env_vars())
+            self.assertNotIn("SGLANG_ADMIN_API_KEY", exportable_env_vars())
+
+    def test_api_key_cli_values_take_precedence_over_environment(self):
+        args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--api-key",
+                "cli-user",
+                "--admin-api-key",
+                "cli-admin",
+            ]
+        )
+        with (
+            envs.SGLANG_API_KEY.override("env-user"),
+            envs.SGLANG_ADMIN_API_KEY.override("env-admin"),
+        ):
+            args.resolve_once()
+        self.assertEqual(args.api_key, "cli-user")
+        self.assertEqual(args.admin_api_key, "cli-admin")
+
     def test_enable_w4a4_mxfp4_megamoe_sets_deepgemm_env(self):
         deepgemm_env = {
             "DG_USE_FP4_ACTS": "0",


### PR DESCRIPTION
## Motivation

Passing `--api-key` or `--admin-api-key` leaves the credential visible in the process command line for the lifetime of the server. Deployments should be able to provide these credentials through environment variables instead.

I searched open PRs by issue number, `SGLANG_API_KEY`, and API-key environment fallback keywords. I did not find an existing implementation.

Closes #36346.

## Modifications

- Add `SGLANG_API_KEY` and `SGLANG_ADMIN_API_KEY` as secret environment fields.
- Use those variables when the corresponding CLI argument is omitted; explicit CLI values keep precedence.
- Exclude both credentials from exported scheduler environment snapshots.
- Update CLI help and add regression coverage for fallback, precedence, and secret filtering.

## Accuracy Tests

Not applicable; this change does not affect model outputs.

Focused server-argument tests:

```text
2 passed in 5.73s
```

Validation:

```text
black: 3 files unchanged
ruff: all checks passed
pre-commit file hooks: passed
registered-test lint scripts: passed
python compileall: passed
git diff --check: passed
```

## Speed Tests and Profiling

Not applicable; the environment fallback runs once during server argument resolution.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

AI assistance was used for implementation suggestions and test preparation. I reviewed and understand every change and will maintain the contribution and address reviewer feedback.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32877972909](https://github.com/sgl-project/sglang/actions/runs/32877972909)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32877972856](https://github.com/sgl-project/sglang/actions/runs/32877972856)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32877973119](https://github.com/sgl-project/sglang/actions/runs/32877973119)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->