### PR TITLE
fix(server): reject torch native speculative decoding

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6448,6 +6448,20 @@ class ServerArgs:
                 disable_radix_cache=True,
             )
 
+        self._validate_speculative_attention_backends()
+
+    def _validate_speculative_attention_backends(self):
+        if self.speculative_algorithm is None:
+            return
+
+        prefill_backend, decode_backend = self._resolved_attention_backends()
+        if "torch_native" in (prefill_backend, decode_backend):
+            raise ValueError(
+                "Speculative decoding is currently not supported with the "
+                "torch_native attention backend. Choose a different attention "
+                "backend or disable speculative decoding."
+            )
+
     def _handle_mxfp8_kv_cache_compatibility(self):
         """MXFP8 KV cache uses operands available only on SM100+ (Blackwell)."""
         if self.kv_cache_dtype != "mxfp8":

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -887,6 +887,70 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
         self.assertEqual(resolved_view(args).page_size, 128)
 
 
+class TestSpeculativeAttentionBackendValidation(CustomTestCase):
+    @patch("sglang.srt.server_args.ServerArgs.get_model_config")
+    @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
+    def test_attention_backend_handler_runs_validation(
+        self, _mock_mla, mock_get_model_config
+    ):
+        args = ServerArgs(
+            model_path="dummy",
+            attention_backend="torch_native",
+            speculative_algorithm="NGRAM",
+        )
+        model_config = MagicMock()
+        model_config.hf_config.dual_chunk_attention_config = None
+        mock_get_model_config.return_value = model_config
+        args.cuda_graph_config = CudaGraphConfig()
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Speculative decoding is currently not supported with the "
+            "torch_native attention backend",
+        ):
+            args._handle_attention_backend_compatibility()
+
+    def test_torch_native_rejects_speculative_decoding(self):
+        for backend_args in (
+            {"attention_backend": "torch_native"},
+            {
+                "attention_backend": "triton",
+                "prefill_attention_backend": "torch_native",
+            },
+            {
+                "attention_backend": "triton",
+                "decode_attention_backend": "torch_native",
+            },
+        ):
+            with self.subTest(backend_args=backend_args):
+                args = ServerArgs(
+                    model_path="dummy",
+                    speculative_algorithm="NGRAM",
+                    **backend_args,
+                )
+
+                with self.assertRaisesRegex(
+                    ValueError,
+                    "Speculative decoding is currently not supported with the "
+                    "torch_native attention backend",
+                ):
+                    args._validate_speculative_attention_backends()
+
+    def test_torch_native_without_speculative_decoding_is_allowed(self):
+        args = ServerArgs(model_path="dummy", attention_backend="torch_native")
+
+        args._validate_speculative_attention_backends()
+
+    def test_speculative_decoding_with_supported_backend_is_allowed(self):
+        args = ServerArgs(
+            model_path="dummy",
+            attention_backend="triton",
+            speculative_algorithm="NGRAM",
+        )
+
+        args._validate_speculative_attention_backends()
+
+
 class TestContextParallelServerArgs(CustomTestCase):
     def setUp(self):
         self.parser = server_args_module.argparse.ArgumentParser()


### PR DESCRIPTION
## Motivation

Fixes #36352.

The attention-backend support matrix marks speculative decoding as unsupported for Torch Native, but the server currently accepts the combination, loads the model, reports startup complete, and then crashes during warmup with an `extend_prefix_lens` `AttributeError`.

Rejecting the unsupported configuration during argument resolution gives users an actionable error before the model worker starts.

## Modifications

- Validate the resolved prefill and decode attention backends when speculative decoding is enabled.
- Reject `torch_native` for both the combined backend flag and split prefill/decode backend flags.
- Preserve the valid cases: Torch Native without speculative decoding, and speculative decoding with supported attention backends.
- Add regression tests for the validation helper and its integration into attention-backend resolution.

## Accuracy Tests

N/A. This change only rejects a configuration that is already documented as unsupported; it does not change model outputs.

Focused validation:

```text
6 passed in 5.91s
```

The six cases cover the integrated handler, combined/prefill/decode `torch_native` configurations, and two valid controls.

## Speed Tests and Profiling

N/A. There is no inference-path change. The validation prevents an unsupported configuration from spending time on model startup before failing.

Additional checks:

- Standard pre-commit formatting, AST, Ruff, Black, isort, codespell, and repository checks passed.
- The three Windows-incompatible `python3` system hooks were run directly with `python` and passed.
- `python -m compileall` passed.
- `git diff --check` passed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is already accurate: the support matrix marks Torch Native speculative decoding as unsupported.
- [x] Accuracy and speed tests are not applicable because no supported inference path changes.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

AI assisted with implementation suggestions and test preparation. I reviewed and understood every change and accept responsibility for maintaining the code and addressing reviewer feedback.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32880008535](https://github.com/sgl-project/sglang/actions/runs/32880008535)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32880008314](https://github.com/sgl-project/sglang/actions/runs/32880008314)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32880008652](https://github.com/sgl-project/sglang/actions/runs/32880008652)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->