### PR TITLE
Reject torch_native attention backend + speculative decoding at startup

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2969,6 +2969,10 @@ class ServerArgs:
             )
             self.cuda_graph_config.decode.backend = Backend.DISABLED
             self.cuda_graph_config.prefill.backend = Backend.DISABLED
+            assert self.speculative_algorithm is None, (
+                "Speculative decoding is currently not supported with the "
+                "torch_native attention backend"
+            )
 
         if self.attention_backend == "flex_attention":
             logger.warning(

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.configs.model_config import AttentionArch
 from sglang.srt.layers.cp.base import is_cp_enabled, is_interleave
 from sglang.srt.model_executor.cuda_graph_config import (
     Backend,
@@ -1099,6 +1100,34 @@ class TestCutedslMoeMaxNumTokens(CustomTestCase):
             cuda_graph_max_bs=64,
         )
         self.assertEqual(args.cutedsl_moe_max_num_tokens(), 512)
+
+
+class TestTorchNativeAttentionBackendSpeculativeRejected(CustomTestCase):
+    """torch_native's SDPA extend path doesn't populate/consult spec_info for
+    TARGET_VERIFY batches, so speculative decoding must be rejected up front
+    (mirrors the existing flex_attention + speculative_algorithm check)."""
+
+    def _args(self, *, speculative_algorithm):
+        server_args = ServerArgs(model_path="dummy")
+        server_args.attention_backend = "torch_native"
+        server_args.speculative_algorithm = speculative_algorithm
+        server_args.get_model_config = lambda: SimpleNamespace(
+            attention_arch=AttentionArch.MHA,
+            is_encoder_decoder=False,
+            hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+        )
+        server_args.cuda_graph_config = CudaGraphConfig()
+        return server_args
+
+    def test_torch_native_rejects_speculative_decoding(self):
+        server_args = self._args(speculative_algorithm="NGRAM")
+        with self.assertRaisesRegex(AssertionError, "torch_native attention backend"):
+            server_args._handle_attention_backend_compatibility()
+
+    def test_torch_native_allows_non_speculative(self):
+        server_args = self._args(speculative_algorithm=None)
+        server_args._handle_attention_backend_compatibility()
+        self.assertEqual(server_args.cuda_graph_config.decode.backend, Backend.DISABLED)
 
 
 class TestSamplingBackendTokenOracleEnvGate(CustomTestCase):


### PR DESCRIPTION
## Why not a duplicate

Searched open/merged PRs referencing #36352, `torch_native`, and `ngram`/speculative decoding — none found addressing this.

## Root cause

`TorchNativeAttnBackend._run_sdpa_forward_extend` (`torch_native_backend.py`) never consults `forward_batch.spec_info`, unlike the flashinfer/triton backends, which use `spec_info.generate_attn_arg_prefill(...)` for verify batches. Meanwhile, no speculative worker (NGRAM's `_prepare_for_speculative_decoding`, or the shared EAGLE/dflash/standalone `prepare_for_verify`) populates `batch.prefix_lens`/`batch.extend_lens` before switching to `ForwardMode.TARGET_VERIFY`. Since `ForwardBatch.init_new` derives `extend_prefix_lens`/`extend_seq_lens` from those fields for any non-decode/idle forward mode, they stay `None` for TARGET_VERIFY batches — so `torch_native`'s `assert seq_lens.shape[0] == extend_prefix_lens.shape[0]` crashes with `AttributeError: 'NoneType' object has no attribute 'shape'`.

This isn't NGRAM-specific — any speculative algorithm combined with `--attention-backend torch_native` hits the same crash, matching how `flex_attention` is already fully blocked from speculative decoding (not partially).

## Fix

Mirrors the existing `flex_attention` + `speculative_algorithm` assertion in `ServerArgs._handle_attention_backend_compatibility` (`server_args.py`), so `--attention-backend torch_native` + `--speculative-algorithm ...` fails fast at arg-parsing time with a clear message, instead of crashing opaquely during warmup.

## Tests

Added `TestTorchNativeAttentionBackendSpeculativeRejected` to `test/registered/unit/server_args/test_server_args.py`:
- `test_torch_native_rejects_speculative_decoding` — asserts the new validation fires.
- `test_torch_native_allows_non_speculative` — regression check that plain `torch_native` (no speculative decoding) still works and still disables CUDA graphs as before.

```
python -m pytest test/registered/unit/server_args/test_server_args.py -v
```
Result: **79 passed** (77 pre-existing + 2 new), no regressions.

## AI assistance disclosure

This change was implemented with Claude Code (root-caused by reading `torch_native_backend.py`, `ngram_worker.py`, `eagle_utils.py`, and `forward_batch_info.py`, not just the issue report). I reviewed every changed line and ran the test command above myself.

Fixes #36352

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->