### PR TITLE
Register SGLang kernels in Pytroch dispatcher

### DIFF
--- a/python/sglang/kernels/ops/embeddings/vocab_parallel_embedding.py
+++ b/python/sglang/kernels/ops/embeddings/vocab_parallel_embedding.py
@@ -4,6 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.utils.custom_op import register_custom_op
+
 
 @triton.jit
 def _vocab_parallel_embedding_kernel(
@@ -53,6 +55,24 @@ def _vocab_parallel_embedding_kernel(
     tl.store(out_ptr + row * hidden_dim + cols, vals, mask=col_mask)
 
 
+def _vocab_parallel_embedding_fake(
+    input_: torch.Tensor,
+    weight: torch.Tensor,
+    org_vocab_start_index: int,
+    org_vocab_end_index: int,
+    num_org_vocab_padding: int,
+    added_vocab_start_index: int,
+    added_vocab_end_index: int,
+) -> torch.Tensor:
+    return torch.empty(
+        (*input_.shape, weight.shape[1]), dtype=weight.dtype, device=weight.device
+    )
+
+
+@register_custom_op(
+    op_name="vocab_parallel_embedding",
+    fake_impl=_vocab_parallel_embedding_fake,
+)
 def vocab_parallel_embedding(
     input_: torch.Tensor,
     weight: torch.Tensor,

--- a/python/sglang/kernels/ops/moe/moe_fused_gate.py
+++ b/python/sglang/kernels/ops/moe/moe_fused_gate.py
@@ -10,6 +10,7 @@ import triton.language as tl
 from sglang.kernel_api_logging import debug_kernel_api
 from sglang.kernels.jit.utils import cache_once, is_arch_support_pdl, load_jit
 from sglang.kernels.ops.moe import moe_route_radix
+from sglang.srt.utils.custom_op import register_custom_op
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
@@ -251,7 +252,30 @@ def _router_triton_kernel(
     tl.store(out_i_ptr, selected_idx, mask=store_mask)
 
 
+def _moe_fused_gate_fake(
+    scores: torch.Tensor,
+    bias: torch.Tensor,
+    topk: int,
+    scoring_func: str = "sigmoid",
+    num_fused_shared_experts: int = 0,
+    renormalize: bool = True,
+    routed_scaling_factor: float = 1.0,
+    apply_routed_scaling_factor_on_output: bool = False,
+    moe_softcapping: float = 0.0,
+    num_expert_group: int = 1,
+    topk_group: int = 1,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    num_rows = scores.shape[0]
+    weights = torch.empty(num_rows, topk, dtype=torch.float32, device=scores.device)
+    indices = torch.empty(num_rows, topk, dtype=torch.int32, device=scores.device)
+    return weights, indices
+
+
 @debug_kernel_api
+@register_custom_op(
+    op_name="moe_fused_gate",
+    fake_impl=_moe_fused_gate_fake,
+)
 def moe_fused_gate(
     scores: torch.Tensor,
     bias: torch.Tensor,

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -33,6 +33,7 @@ import torch
 import torch.nn.functional as F
 
 from sglang.srt.runtime_context import get_exec, get_lora, get_parallel
+from sglang.srt.utils.custom_op import register_custom_op
 
 try:
     from triton_kernels.matmul_ogs import GatherIndx, RoutingData, ScatterIndx
@@ -1378,6 +1379,10 @@ def _eplb_remap_enabled() -> bool:
     )
 
 
+@register_custom_op(
+    op_name="mask_topk_ids_padded_region",
+    mutates_args=["topk_ids"],
+)
 def _mask_topk_ids_padded_region(
     topk_ids: torch.Tensor,
     num_token_non_padded: Optional[torch.Tensor] = None,
@@ -1397,10 +1402,14 @@ def _mask_topk_ids_padded_region(
         topk_ids[indices >= num_token_non_padded, :] = fill_value
 
 
+@register_custom_op(
+    op_name="zero_topk_weights_padded_region",
+    mutates_args=["topk_weights"],
+)
 def _zero_topk_weights_padded_region(
     topk_weights: torch.Tensor,
     num_token_non_padded: Optional[torch.Tensor] = None,
-):
+) -> None:
     if num_token_non_padded is None:
         return
     if _can_fuse_padded_region(topk_weights):


### PR DESCRIPTION
## Motivation
Several GPU kernel launchers in SGLang are plain Python functions that call
Triton/JIT kernels directly. Because they never go through the PyTorch
dispatcher, they are invisible to tooling that keys off registered operators:
- **Profiler shape discovery** — with `record_shapes=True`, the PyTorch
  profiler only annotates `Input Dims` on operator-level (`cpu_op`) events
  (aten ops and registered custom ops). Kernels invoked outside the dispatcher
  show up (if at all) as bare device-kernel events with no shape metadata, so
  their input shapes cannot be recovered from a trace.
- **torch.compile** — un-registered launchers that perform JIT compilation /
  dynamic work are not safe to trace and have no fake (meta) implementation for
  shape/dtype propagation.
This PR registers four such leaf kernels as first-class custom ops under the
`sglang::` namespace using the existing `sglang.srt.utils.custom_op.register_custom_op`
machinery, so they appear by name **with input shapes** in profiler traces and
are torch.compile-safe. Schemas are declared honestly (accurate mutation
semantics and return types); no kernel behavior is changed.
## Modifications
Registered the following kernels (op body unchanged — the registered
implementation is the original launcher; the module-level name is rebound to the
dispatcher, so all existing call sites transparently dispatch through
`torch.ops.sglang.*`):
- `python/sglang/kernels/ops/embeddings/vocab_parallel_embedding.py`
  - `vocab_parallel_embedding` (functional). Added a `fake_impl` producing
    `(*input_.shape, weight.shape[1])` with `weight`'s dtype/device.
  - Schema: `(Tensor input_, Tensor weight, SymInt org_vocab_start_index, SymInt org_vocab_end_index, SymInt num_org_vocab_padding, SymInt added_vocab_start_index, SymInt added_vocab_end_index) -> Tensor`
- `python/sglang/kernels/ops/moe/moe_fused_gate.py`
  - `moe_fused_gate` (functional, tuple return). Registered as the inner
    decorator beneath `@debug_kernel_api` so the schema is inferred from the raw
    function (correct module globals); added a `fake_impl` returning
    `weights [M, topk] fp32` and `indices [M, topk] int32`.
  - Schema: `(Tensor scores, Tensor bias, SymInt topk, str scoring_func="sigmoid", SymInt num_fused_shared_experts=0, bool renormalize=True, float routed_scaling_factor=1.0, bool apply_routed_scaling_factor_on_output=False, float moe_softcapping=0.0, SymInt num_expert_group=1, SymInt topk_group=1) -> (Tensor, Tensor)`
- `python/sglang/srt/layers/moe/topk.py`
  - `_mask_topk_ids_padded_region` (in-place). `mutates_args=["topk_ids"]`,
    `-> None`.
    - Schema: `(Tensor(a0!) topk_ids, Tensor? num_token_non_padded=None, SymInt fill_value=-1) -> ()`
  - `_zero_topk_weights_padded_region` (in-place). Added the missing `-> None`
    return annotation (the function already returns `None`) and registered with
    `mutates_args=["topk_weights"]`.
    - Schema: `(Tensor(a0!) topk_weights, Tensor? num_token_non_padded=None) -> ()`
  - Promoted the `register_custom_op` import to module scope (it was previously
    imported only inside an `if _is_cuda` block).
Design notes:
- The two in-place ops are registered as `-> ()` (pure mutation, no return
  value). This is the honest schema and, importantly, avoids
  auto-functionalization producing a tuple + `getitem` that Inductor cannot
  lower — a functional op with a return value or a pure-mutation op with no
  return both compile cleanly; a "mutates an input and also returns it" op does
  not.

## Accuracy Tests
These are behavior-preserving registrations: the registered `op_func` is the
original kernel launcher, so numerics are unchanged.
- Validated all four schemas with `torch.library.infer_schema` (legal + honest:
  mutation markers on mutated tensors, correct return types).
- Verified fake-tensor shape/dtype propagation under `FakeTensorMode` (the exact
  path `torch.compile` uses), including the `num_token_non_padded=None` case.
- End-to-end serving smoke test with `zai-org/GLM-5.1-FP8` (TP=4, ROCm/MI355X):
  320/320 requests completed, 0 errors; outputs unaffected by the registration.
## Benchmarking and Profiling
Registration only adds a dispatcher hop on the kernel entry point, so it does
not affect steady-state throughput; the benefit is profiler/compiler
visibility. Verified on `zai-org/GLM-5.1-FP8` (TP=4, MI355X):
- CUDA-graph capture profiling (`--enable-profile-cuda-graph`,
  `SGLANG_GRAPH_BATCH_CAPTURE=1`) produced the expected per-batch-size decode
  traces.
- Runtime profiling (`/start_profile` with `record_shapes`) now shows the
  registered ops as named `sglang::` events **with input shapes**, e.g.:
  - `sglang::mask_topk_ids_padded_region` — `Input Dims [[401, 8], [], []]`
  - `sglang::zero_topk_weights_padded_region` — `Input Dims [[401, 9], []]`
  - `sglang::vocab_parallel_embedding` — `Input Dims [[401], [38720, 6144], ...]`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32881605552](https://github.com/sgl-project/sglang/actions/runs/32881605552)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32881605394](https://github.com/sgl-project/sglang/actions/runs/32881605394)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32881605709](https://github.com/sgl-project/sglang/actions/runs/32881605709)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->