### PR TITLE
[Bugfix] Return the longest partial in _ends_with_partial_token

### DIFF
--- a/python/sglang/srt/function_call/base_format_detector.py
+++ b/python/sglang/srt/function_call/base_format_detector.py
@@ -117,7 +117,12 @@ class BaseFormatDetector(ABC):
         For some format, the bot_token is not a token in model's vocabulary, such as
         `[TOOL_CALLS] [` in Mistral.
         """
-        for i in range(1, min(len(buffer) + 1, len(bot_token))):
+        # Scan longest suffix first: when a bot_token repeats its own prefix
+        # (e.g. `<|action_start|> <|plugin|>`, `<|start|>assistant<|channel|>...`),
+        # a shorter suffix of the buffer can also be a prefix of the bot_token, so
+        # returning the first (shortest) match would hold back too few characters
+        # and leak part of the partial token into the normal text stream.
+        for i in range(min(len(buffer), len(bot_token) - 1), 0, -1):
             if bot_token.startswith(buffer[-i:]):
                 return i
         return 0

--- a/test/registered/unit/function_call/test_base_format_detector.py
+++ b/test/registered/unit/function_call/test_base_format_detector.py
@@ -1,0 +1,45 @@
+"""Unit tests for BaseFormatDetector._ends_with_partial_token — no server, no model."""
+
+from sglang.srt.function_call.qwen25_detector import Qwen25Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestEndsWithPartialToken(CustomTestCase):
+    def setUp(self):
+        # _ends_with_partial_token is defined on BaseFormatDetector and takes the
+        # bot_token as an argument, so any concrete detector exercises it.
+        self.detector = Qwen25Detector()
+
+    def _partial(self, buffer, bot_token):
+        return self.detector._ends_with_partial_token(buffer, bot_token)
+
+    def test_returns_longest_partial_for_repeating_prefix_tokens(self):
+        # These real bot_tokens repeat "<" internally, so a *shorter* trailing
+        # suffix of the buffer is also a prefix of the token. The helper must
+        # return the LONGEST partial (the whole trailing partial token), not the
+        # shortest, otherwise callers hold back too few characters and leak most
+        # of the partial token into the normal-text stream.
+        cases = [
+            ("<|action_start|> <|plugin|>", "<|action_start|> <", 18),
+            ("<|action_start|> <|plugin|>", "<|action_start|> <|", 19),
+            ("<|start|>assistant<|channel|>commentary", "<|start|>assistant<", 19),
+            ("<|start|>assistant<|channel|>commentary", "<|start|>assistant<|", 20),
+        ]
+        for bot_token, partial, expected in cases:
+            self.assertEqual(
+                self._partial("some normal text " + partial, bot_token),
+                expected,
+                msg=f"bot_token={bot_token!r} partial={partial!r}",
+            )
+
+    def test_simple_tokens(self):
+        # Tokens without an internal border are unaffected.
+        self.assertEqual(self._partial("hi <tool_ca", "<tool_call>"), 8)
+        self.assertEqual(self._partial("body <tool_call", "<tool_call>\n"), 10)
+
+    def test_no_partial_returns_zero(self):
+        self.assertEqual(self._partial("just some normal text", "<tool_call>"), 0)
+        self.assertEqual(self._partial("", "<tool_call>"), 0)


### PR DESCRIPTION
## Motivation

`BaseFormatDetector._ends_with_partial_token(buffer, bot_token)` is documented to *"Return the length of the partial bot_token"* — the number of trailing characters of `buffer` that are a prefix of `bot_token`, so streaming callers can hold them back. It scans suffixes **shortest-first** and returns the first match:

```python
for i in range(1, min(len(buffer) + 1, len(bot_token))):
    if bot_token.startswith(buffer[-i:]):
        return i
```

When a `bot_token` repeats its own prefix, a **shorter** trailing suffix of the buffer can also be a prefix of the token and shadows the real (longer) partial. This happens with real markers:

- `<|action_start|> <|plugin|>` (apertus) — buffer ending in `<|action_start|> <` returns **1** (matching the leading `<`) instead of **18**.
- `<|start|>assistant<|channel|>commentary` (gpt-oss) — buffer ending in `<|start|>assistant<` returns **1** instead of **19**.

Callers use the value as a hold-back length:

```python
partial_len = self._ends_with_partial_token(current_text, self.bot_token)
if partial_len:
    safe_text = current_text[:-partial_len]   # emitted as normal text
    self._buffer = current_text[-partial_len:] # held back
```

So under-reporting emits most of a partial tool-call start token into the **normal-text stream** and corrupts the subsequent tool-call parse.

## Modifications

Scan suffixes **longest-first** and return the first (longest) match, so the whole partial token is held back. Tokens without an internal border match exactly one length, so their behavior is unchanged.

```python
for i in range(min(len(buffer), len(bot_token) - 1), 0, -1):
    if bot_token.startswith(buffer[-i:]):
        return i
```

Adds `test/registered/unit/function_call/test_base_format_detector.py` covering the repeating-prefix tokens, ordinary tokens, and the no-partial case. `ruff` / `black` / `isort` clean.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#format-your-code-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#run-and-add-unit-tests).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35130230127](https://github.com/sgl-project/sglang/actions/runs/35130230127)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35130229784](https://github.com/sgl-project/sglang/actions/runs/35130229784)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35130229998](https://github.com/sgl-project/sglang/actions/runs/35130229998)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->