### PR TITLE
docs(cookbook): add GB10 (DGX Spark) MXFP4 cells for Ling-3.0-flash

### DIFF
--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
@@ -166,6 +166,34 @@ export const benchmarks = [
   },
 
   // ====================================================================
+  // GB10 + MXFP4 (TP1, DGX Spark sm121)
+  // ====================================================================
+  {
+    match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "low-latency", spec: "dspark", nodes: "single" },
+    sglang_version: "PR #33561 @ 2f85329efe",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 2172.03, tpot_ms: 9.48, tokens_per_sec_per_gpu: 580 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 71292.20, tpot_ms: 38.09, tokens_per_sec_per_gpu: 1157 },
+    ],
+    accuracy: { gsm8k_pct: null },
+    notes: "Full GSM8K run in progress on GB10; single-chip memory ceiling makes c=16 prefill the bottleneck.",
+  },
+  {
+    match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "high-throughput", spec: "off", nodes: "single" },
+    sglang_version: "PR #33561 @ 2f85329efe",
+    speed: [
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
+        ttft_ms: 2068.91, tpot_ms: 25.76, tokens_per_sec_per_gpu: 324 },
+      { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
+        ttft_ms: 21649.69, tpot_ms: 106.51, tokens_per_sec_per_gpu: 1129 },
+    ],
+    accuracy: { gsm8k_pct: 100 },
+    notes: "gsm8k_pct from a deterministic 20-question window (full run pending); stop rate 100%.",
+  },
+
+  // ====================================================================
   // GB300 + BF16 (TP4)
   // ====================================================================
   // TODO: both cells are `verified: true` (gated on the final head) but the GSM8K

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
@@ -177,8 +177,8 @@ export const benchmarks = [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
         ttft_ms: 71292.20, tpot_ms: 38.09, tokens_per_sec_per_gpu: 1157 },
     ],
-    accuracy: { gsm8k_pct: null },
-    notes: "Full GSM8K run in progress on GB10; single-chip memory ceiling makes c=16 prefill the bottleneck.",
+    accuracy: { gsm8k_pct: 96.36 },
+    notes: "Full GSM8K stop rate 99.55%; single-chip memory ceiling makes c=16 prefill the bottleneck.",
   },
   {
     match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "high-throughput", spec: "off", nodes: "single" },

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
@@ -169,7 +169,7 @@ export const benchmarks = [
   // GB10 + MXFP4 (TP1, DGX Spark sm121)
   // ====================================================================
   {
-    match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "low-latency", spec: "dspark", nodes: "single" },
+    match: { hw: "dgx-spark", variant: "default", quant: "mxfp4", strategy: "low-latency", spec: "dspark", nodes: "single" },
     sglang_version: "PR #33561 @ 2f85329efe",
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },
@@ -181,7 +181,7 @@ export const benchmarks = [
     notes: "Full GSM8K stop rate 99.55%; single-chip memory ceiling makes c=16 prefill the bottleneck.",
   },
   {
-    match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "high-throughput", spec: "off", nodes: "single" },
+    match: { hw: "dgx-spark", variant: "default", quant: "mxfp4", strategy: "high-throughput", spec: "off", nodes: "single" },
     sglang_version: "PR #33561 @ 2f85329efe",
     speed: [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 1 },

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-flash-benchmarks.jsx
@@ -189,8 +189,8 @@ export const benchmarks = [
       { workload: { dataset: "random", isl: 8192, osl: 1024, max_concurrency: 16 },
         ttft_ms: 21649.69, tpot_ms: 106.51, tokens_per_sec_per_gpu: 1129 },
     ],
-    accuracy: { gsm8k_pct: 100 },
-    notes: "gsm8k_pct from a deterministic 20-question window (full run pending); stop rate 100%.",
+    accuracy: { gsm8k_pct: 96.82 },
+    notes: "Full GSM8K stop rate 99.62%.",
   },
 
   // ====================================================================

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-flash.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-flash.jsx
@@ -1,7 +1,7 @@
 export const config = {
   modelName: "Ling-3.0-flash",
 
-  supportedHardware: ["h20-3e", "h200", "h800", "h100", "b200", "gb300", "gb10"],
+  supportedHardware: ["h20-3e", "h200", "h800", "h100", "b200", "gb300", "dgx-spark"],
   groupHardware: false,
 
   variants: [{ id: "default", label: "Ling-3.0-flash" }],
@@ -46,7 +46,7 @@ export const config = {
     "h100": "lmsysorg/sglang:dev-Ling-3.0-flash",
     "b200": "lmsysorg/sglang:dev-Ling-3.0-flash",
     "gb300": "lmsysorg/sglang:dev-Ling-3.0-flash",
-    "gb10": "lmsysorg/sglang:latest",
+    "dgx-spark": "lmsysorg/sglang:dev-Ling-3.0-flash",
   },
 
   dockerHostNetworkWhen: (_sel, { flags }) =>
@@ -376,7 +376,7 @@ sgl-eval run gsm8k \\
       ],
     },
     {
-      match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "low-latency", spec: "dspark", nodes: "single" },
+      match: { hw: "dgx-spark", variant: "default", quant: "mxfp4", strategy: "low-latency", spec: "dspark", nodes: "single" },
       verified: true,
       flags: [
         "--model-path {{MODEL_NAME}}",
@@ -582,7 +582,7 @@ sgl-eval run gsm8k \\
       ],
     },
     {
-      match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "high-throughput", spec: "off", nodes: "single" },
+      match: { hw: "dgx-spark", variant: "default", quant: "mxfp4", strategy: "high-throughput", spec: "off", nodes: "single" },
       verified: true,
       flags: [
         "--model-path {{MODEL_NAME}}",

--- a/docs/src/snippets/configs/inclusionAI/ling-3.0-flash.jsx
+++ b/docs/src/snippets/configs/inclusionAI/ling-3.0-flash.jsx
@@ -1,7 +1,7 @@
 export const config = {
   modelName: "Ling-3.0-flash",
 
-  supportedHardware: ["h20-3e", "h200", "h800", "h100", "b200", "gb300"],
+  supportedHardware: ["h20-3e", "h200", "h800", "h100", "b200", "gb300", "gb10"],
   groupHardware: false,
 
   variants: [{ id: "default", label: "Ling-3.0-flash" }],
@@ -46,6 +46,7 @@ export const config = {
     "h100": "lmsysorg/sglang:dev-Ling-3.0-flash",
     "b200": "lmsysorg/sglang:dev-Ling-3.0-flash",
     "gb300": "lmsysorg/sglang:dev-Ling-3.0-flash",
+    "gb10": "lmsysorg/sglang:latest",
   },
 
   dockerHostNetworkWhen: (_sel, { flags }) =>
@@ -375,6 +376,19 @@ sgl-eval run gsm8k \\
       ],
     },
     {
+      match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "low-latency", spec: "dspark", nodes: "single" },
+      verified: true,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--tp 1",
+        "--moe-runner-backend flashinfer_mxfp4",
+        ...DSPARK_FLAGS,
+        "--mem-fraction-static 0.85",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
       match: { hw: "h20-3e", variant: "default", quant: "bf16", strategy: "high-throughput", spec: "off", nodes: "single" },
       verified: false,
       flags: [
@@ -560,6 +574,20 @@ sgl-eval run gsm8k \\
         "--tp 2",
         "--moe-runner-backend flashinfer_mxfp4",
         "--fp8-gemm-backend triton",
+        "--mem-fraction-static 0.85",
+        "--tool-call-parser ling3",
+        "--reasoning-parser ling3",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "gb10", variant: "default", quant: "mxfp4", strategy: "high-throughput", spec: "off", nodes: "single" },
+      verified: true,
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--tp 1",
+        "--moe-runner-backend flashinfer_mxfp4",
         "--mem-fraction-static 0.85",
         "--tool-call-parser ling3",
         "--reasoning-parser ling3",


### PR DESCRIPTION
Adds GB10 (DGX Spark, sm121) as a hardware option for the Ling-3.0-flash cookbook, MXFP4 quant, TP1 on the single chip:

- **low-latency + DSPARK** (external draft, `--moe-runner-backend flashinfer_mxfp4`)
- **high-throughput + spec off**

All numbers measured on a real GB10 box with the #33561 head (`2f85329efe`, includes the SwigluStep clamp fix required for correct output on the SM12x CUTLASS path):

| cell | c | TTFT ms | TPOT ms | tok/s |
|---|---|---|---|---|
| dspark | 1 | 2172 | 9.48 | 580 |
| dspark | 16 | 71292 | 38.09 | 1157 |
| off | 1 | 2069 | 25.76 | 324 |
| off | 16 | 21650 | 106.51 | 1129 |

DSPARK decode is ~2.7x faster than greedy at bs=1 on GB10. The spec-off cell's GSM8K is 100% on a deterministic 20-question window; full 1319-question GSM8K runs for both cells are in flight and the dspark accuracy field will be updated when they land.

Verified: `mint validate` passes; local `mint dev` renders both cells (config + benchmark table) under hw=gb10.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33037260605](https://github.com/sgl-project/sglang/actions/runs/33037260605)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33037260462](https://github.com/sgl-project/sglang/actions/runs/33037260462)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->