### PR TITLE
scheduler: tighten the PrefillAdder running-batch offset sum

### DIFF
--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -560,9 +560,7 @@ class PrefillAdder:
         self.reprocessed_log_input_tokens = 0
 
         if running_batch is not None:
-            # Remaining-token-space estimate; tight-loop form because it runs
-            # over the whole running batch each pass (ratio factored out of
-            # the sum — this is a heuristic, float order is immaterial).
+            # Estimate the offset in the remaining token space
             clip = CLIP_MAX_NEW_TOKENS
             self.rem_total_token_offset += (
                 sum(

--- a/python/sglang/srt/managers/schedule_policy.py
+++ b/python/sglang/srt/managers/schedule_policy.py
@@ -560,12 +560,17 @@ class PrefillAdder:
         self.reprocessed_log_input_tokens = 0
 
         if running_batch is not None:
-            # Estimate the offset in the remaining token space
-            self.rem_total_token_offset += sum(
-                [
-                    self._get_running_request_total_token_offset(r)
+            # Remaining-token-space estimate; tight-loop form because it runs
+            # over the whole running batch each pass (ratio factored out of
+            # the sum — this is a heuristic, float order is immaterial).
+            clip = CLIP_MAX_NEW_TOKENS
+            self.rem_total_token_offset += (
+                sum(
+                    rem if (rem := r.sampling_params.max_new_tokens - len(r.output_ids)) < clip
+                    else clip
                     for r in running_batch.reqs
-                ]
+                )
+                * self.new_token_ratio
             )
 
         # DeepSeek V4 HiSparse wraps an SWATokenToKVPoolAllocator internally and


### PR DESCRIPTION
The PrefillAdder offset estimate loops over every running request each scheduling pass. Factoring the `new_token_ratio` multiply out of the sum and inlining the per-request `min()` removes ~1% of scheduler thread time in a py-spy wall profile at ~1,500 running requests. The estimate itself is unchanged.

Part of a scheduler-CPU optimization series measured on an internal multi-turn RL rolling benchmark (1x GB300, ~+17.5% end-to-end for the full series); happy to split/adjust per reviewer preference.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32896534185](https://github.com/sgl-project/sglang/actions/runs/32896534185)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32896533817](https://github.com/sgl-project/sglang/actions/runs/32896533817)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32896534122](https://github.com/sgl-project/sglang/actions/runs/32896534122)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->