### PR TITLE
scheduler: periodic manual GC replaces automatic gen2 collection

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -640,10 +640,6 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
-
-    # Manual full GC every N seconds instead of automatic collection, whose
-    # gen2 passes pause the scheduler 100-350ms at large live sets (0 = stock
-    # automatic GC).
     SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S = EnvFloat(600)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Deferred decode-side KV release: on abort, hold an in-flight request's KV

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -640,6 +640,11 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
+
+    # Manual full GC every N seconds instead of automatic collection, whose
+    # gen2 passes pause the scheduler 100-350ms at large live sets (0 = stock
+    # automatic GC).
+    SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S = EnvFloat(600)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Deferred decode-side KV release: on abort, hold an in-flight request's KV
     # pages/slot until the prefill acks the transfer drained, or the timeout

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1323,6 +1323,15 @@ class Scheduler(
         if envs.SGLANG_LOG_GC.get():
             configure_gc_logger()
 
+        self.init_gc_policy()
+
+    def init_gc_policy(self):
+        from sglang.srt.managers.scheduler_components.gc_policy import (
+            SchedulerGcPolicy,
+        )
+
+        self.gc_policy = SchedulerGcPolicy()
+
     def init_disaggregation(self):
         self.mm_receiver = None
         self.disagg_prefill_bootstrap_queue = None
@@ -1793,6 +1802,7 @@ class Scheduler(
 
             # Update last_batch
             self.last_batch = batch
+            self.gc_policy.maybe_run()
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.invariant_checker.self_check_during_busy()
 
@@ -1867,6 +1877,8 @@ class Scheduler(
 
             # Update last_batch
             self.last_batch = batch
+
+            self.gc_policy.maybe_run()
 
             if envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY.get():
                 self.invariant_checker.self_check_during_busy()

--- a/python/sglang/srt/managers/scheduler_components/gc_policy.py
+++ b/python/sglang/srt/managers/scheduler_components/gc_policy.py
@@ -1,0 +1,67 @@
+"""Scheduler GC policy: periodic manual collects instead of automatic GC.
+
+At large live sets (batch ~1500, 65k-token outputs) CPython's automatic gen2
+collections become 100-350ms stop-the-world pauses every few decode steps.
+With SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S > 0: one collect + gc.freeze
+of startup objects on activation, automatic GC disabled, then one full
+collect per interval at a loop boundary. Refcounting still reclaims acyclic
+per-request state immediately; the periodic pass handles cycles. Caveat: a
+startup-era object that is cyclic and dies later leaks (rare, small).
+"""
+
+from __future__ import annotations
+
+import gc
+import logging
+import time
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+
+class SchedulerGcPolicy:
+    def __init__(self) -> None:
+        self.interval_s: float = (
+            envs.SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S.get() or 0.0
+        )
+        self._activated = False
+        self._next_collect_ts = 0.0
+
+    @property
+    def enabled(self) -> bool:
+        return self.interval_s > 0.0
+
+    def _activate(self, now: float) -> None:
+        gc.collect()
+        gc.freeze()
+        gc.disable()
+        self._activated = True
+        self._next_collect_ts = now + self.interval_s
+        logger.info(
+            "SchedulerGcPolicy active: automatic GC disabled, %d startup objects "
+            "frozen, manual collect every %.1fs.",
+            gc.get_freeze_count(),
+            self.interval_s,
+        )
+
+    def maybe_run(self) -> None:
+        """Cheap per-iteration hook: activates on first call, then runs one
+        full collection whenever the interval elapsed."""
+        if not self.enabled:
+            return
+        now = time.monotonic()
+        if not self._activated:
+            self._activate(now)
+            return
+        if now < self._next_collect_ts:
+            return
+        start = time.perf_counter()
+        unreachable = gc.collect()
+        elapsed = time.perf_counter() - start
+        self._next_collect_ts = now + self.interval_s
+        logger.debug(
+            "SchedulerGcPolicy collect: %.1fms, %d unreachable objects.",
+            elapsed * 1e3,
+            unreachable,
+        )

--- a/test/registered/unit/managers/test_scheduler_gc_policy.py
+++ b/test/registered/unit/managers/test_scheduler_gc_policy.py
@@ -1,0 +1,69 @@
+"""Unit tests for SchedulerGcPolicy (SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S)."""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.scheduler_components.gc_policy import SchedulerGcPolicy
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+GC_POLICY_MOD = "sglang.srt.managers.scheduler_components.gc_policy"
+
+
+class TestSchedulerGcPolicy(CustomTestCase):
+    def test_enabled_by_default(self):
+        policy = SchedulerGcPolicy()
+        self.assertTrue(policy.enabled)
+
+    def test_disabled_at_zero(self):
+        with envs.SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S.override(0.0):
+            policy = SchedulerGcPolicy()
+        self.assertFalse(policy.enabled)
+        with patch(f"{GC_POLICY_MOD}.gc") as mock_gc:
+            policy.maybe_run()
+        mock_gc.collect.assert_not_called()
+        mock_gc.disable.assert_not_called()
+
+    def test_activation_and_interval(self):
+        with envs.SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S.override(30.0):
+            policy = SchedulerGcPolicy()
+        self.assertTrue(policy.enabled)
+
+        clock = [1000.0]
+        with (
+            patch(f"{GC_POLICY_MOD}.gc") as mock_gc,
+            patch(f"{GC_POLICY_MOD}.time") as mock_time,
+        ):
+            mock_time.monotonic.side_effect = lambda: clock[0]
+            mock_time.perf_counter.side_effect = lambda: clock[0]
+            mock_gc.collect.return_value = 0
+            mock_gc.get_freeze_count.return_value = 123
+
+            # First call activates: collect + freeze survivors + disable auto GC.
+            policy.maybe_run()
+            self.assertEqual(mock_gc.collect.call_count, 1)
+            mock_gc.freeze.assert_called_once()
+            mock_gc.disable.assert_called_once()
+
+            # Within the interval: no collection.
+            clock[0] += 29.0
+            policy.maybe_run()
+            self.assertEqual(mock_gc.collect.call_count, 1)
+
+            # Interval elapsed: one manual collect, no re-freeze.
+            clock[0] += 2.0
+            policy.maybe_run()
+            self.assertEqual(mock_gc.collect.call_count, 2)
+            mock_gc.freeze.assert_called_once()
+
+            # Next interval boundary.
+            clock[0] += 30.5
+            policy.maybe_run()
+            self.assertEqual(mock_gc.collect.call_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_scheduler_gc_policy.py
+++ b/test/registered/unit/managers/test_scheduler_gc_policy.py
@@ -42,24 +42,20 @@ class TestSchedulerGcPolicy(CustomTestCase):
             mock_gc.collect.return_value = 0
             mock_gc.get_freeze_count.return_value = 123
 
-            # First call activates: collect + freeze survivors + disable auto GC.
             policy.maybe_run()
             self.assertEqual(mock_gc.collect.call_count, 1)
             mock_gc.freeze.assert_called_once()
             mock_gc.disable.assert_called_once()
 
-            # Within the interval: no collection.
             clock[0] += 29.0
             policy.maybe_run()
             self.assertEqual(mock_gc.collect.call_count, 1)
 
-            # Interval elapsed: one manual collect, no re-freeze.
             clock[0] += 2.0
             policy.maybe_run()
             self.assertEqual(mock_gc.collect.call_count, 2)
             mock_gc.freeze.assert_called_once()
 
-            # Next interval boundary.
             clock[0] += 30.5
             policy.maybe_run()
             self.assertEqual(mock_gc.collect.call_count, 3)


### PR DESCRIPTION
CPython's automatic gen2 GC pauses the scheduler thread 100-350ms every few decode steps once the live set reaches ~1,500 requests. This adds `SGLANG_OPT_SCHEDULER_GC_COLLECT_INTERVAL_S` (default 600s): the scheduler disables automatic collection, freezes startup objects, and runs one manual `gc.collect()` per interval instead. `0` restores stock automatic GC.

Measured as part of a scheduler-CPU series on an internal multi-turn RL rolling benchmark (1x GB300): this + a finish-emission budget were worth ~+6% output throughput together. Unit test included. Env-var section placement is flexible — happy to move it wherever maintainers prefer.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32896497742](https://github.com/sgl-project/sglang/actions/runs/32896497742)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32896497446](https://github.com/sgl-project/sglang/actions/runs/32896497446)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32896497808](https://github.com/sgl-project/sglang/actions/runs/32896497808)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->