### PR TITLE
scheduler: cap finished-request emissions per pass (SGLANG_OPT_STREAM_FINISH_BUDGET)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -640,6 +640,11 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
+
+    # Cap finished-request final emissions per pass (0 = unlimited) so a
+    # completion wave's payload assembly spreads over a few passes; KV release
+    # and abort semantics are unchanged, only the finish event is delayed.
+    SGLANG_OPT_STREAM_FINISH_BUDGET = EnvInt(64)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Deferred decode-side KV release: on abort, hold an in-flight request's KV
     # pages/slot until the prefill acks the transfer drained, or the timeout

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -640,10 +640,6 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
-
-    # Cap finished-request final emissions per pass (0 = unlimited) so a
-    # completion wave's payload assembly spreads over a few passes; KV release
-    # and abort semantics are unchanged, only the finish event is delayed.
     SGLANG_OPT_STREAM_FINISH_BUDGET = EnvInt(64)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Deferred decode-side KV release: on abort, hold an in-flight request's KV

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4168,6 +4168,11 @@ class Scheduler(
         # Flush any health-check signal deferred while the engine was busy.
         self.maybe_send_health_check_signal()
 
+        # Drain finish outputs deferred by SGLANG_OPT_STREAM_FINISH_BUDGET so
+        # clients are not left waiting when traffic stops right after a wave.
+        if self.output_streamer._deferred_finished:
+            self.output_streamer.stream_output([], False)
+
         if not self.is_fully_idle():
             return
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -4168,8 +4168,6 @@ class Scheduler(
         # Flush any health-check signal deferred while the engine was busy.
         self.maybe_send_health_check_signal()
 
-        # Drain finish outputs deferred by SGLANG_OPT_STREAM_FINISH_BUDGET so
-        # clients are not left waiting when traffic stops right after a wave.
         if self.output_streamer._deferred_finished:
             self.output_streamer.stream_output([], False)
 

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from dataclasses import dataclass, field
 from typing import (
     TYPE_CHECKING,
@@ -41,6 +42,7 @@ logger = logging.getLogger(__name__)
 
 
 DEFAULT_FORCE_STREAM_INTERVAL = envs.SGLANG_FORCE_STREAM_INTERVAL.get()
+STREAM_FINISH_BUDGET = envs.SGLANG_OPT_STREAM_FINISH_BUDGET.get()
 
 
 @dataclass(kw_only=True, slots=True)
@@ -60,6 +62,9 @@ class SchedulerOutputStreamer:
     # detokenizer. None otherwise. (Rust-specific state lives in RustServer.)
     rust_server: Optional[RustServer] = None
     _test_stream_output_count: int = 0
+    # Emissions deferred by SGLANG_OPT_STREAM_FINISH_BUDGET; drained FIFO.
+    _deferred_finished: deque = field(default_factory=deque)
+    _deferred_rids: set = field(default_factory=set)
 
     def __post_init__(self) -> None:
         if self.has_additional_customized_info and self.rust_server is not None:
@@ -144,17 +149,33 @@ class SchedulerOutputStreamer:
         skip_req: Optional[Req] = None,
         is_idle_batch: bool = False,
     ):
+        finish_budget = STREAM_FINISH_BUDGET
+        drained: List[Req] = []
+        if self._deferred_finished:
+            n_drain = len(self._deferred_finished)
+            if finish_budget > 0:
+                n_drain = min(n_drain, finish_budget)
+            for _ in range(n_drain):
+                req = self._deferred_finished.popleft()
+                self._deferred_rids.discard(req.rid)
+                if not req.finished_output:
+                    drained.append(req)
+            return_logprob = return_logprob or any(
+                req.return_logprob for req in drained
+            )
+
+        all_reqs = drained + reqs if drained else reqs
         return_hidden_states = any(
-            req.return_hidden_states for req in reqs if req is not skip_req
+            req.return_hidden_states for req in all_reqs if req is not skip_req
         )
         return_routed_experts = any(
-            req.return_routed_experts for req in reqs if req is not skip_req
+            req.return_routed_experts for req in all_reqs if req is not skip_req
         )
         return_indexer_topk = any(
-            req.return_indexer_topk for req in reqs if req is not skip_req
+            req.return_indexer_topk for req in all_reqs if req is not skip_req
         )
         return_sampling_mask = any(
-            req.return_sampling_mask for req in reqs if req is not skip_req
+            req.return_sampling_mask for req in all_reqs if req is not skip_req
         )
 
         acc = _GenerationStreamAccumulator(
@@ -171,13 +192,27 @@ class SchedulerOutputStreamer:
             rust_server_mode=self.rust_server is not None,
             current_weight_version=get_serving().weight_version,
         )
-        for req in reqs:
+        emitted_finished = 0
+        drained_ids = {id(req) for req in drained}
+        for req in all_reqs:
             if req is skip_req:
                 continue
             if req.finished() and req.finished_output:
                 # With the overlap schedule, a request will try to output twice and hit this line twice
                 # because of the one additional delayed token. This "continue" prevented the dummy output.
                 continue
+            if (
+                finish_budget > 0
+                and req.finished()
+                and emitted_finished >= finish_budget
+                and id(req) not in drained_ids
+            ):
+                if req.rid not in self._deferred_rids:
+                    self._deferred_rids.add(req.rid)
+                    self._deferred_finished.append(req)
+                continue
+            if req.finished():
+                emitted_finished += 1
 
             acc.accept(req=req)
             self._maybe_log_time_stats(req=req)

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -62,7 +62,6 @@ class SchedulerOutputStreamer:
     # detokenizer. None otherwise. (Rust-specific state lives in RustServer.)
     rust_server: Optional[RustServer] = None
     _test_stream_output_count: int = 0
-    # Emissions deferred by SGLANG_OPT_STREAM_FINISH_BUDGET; drained FIFO.
     _deferred_finished: deque = field(default_factory=deque)
     _deferred_rids: set = field(default_factory=set)
 

--- a/test/registered/unit/managers/test_stream_finish_budget.py
+++ b/test/registered/unit/managers/test_stream_finish_budget.py
@@ -1,0 +1,139 @@
+"""Unit tests for SGLANG_OPT_STREAM_FINISH_BUDGET: a completion wave's finished
+outputs are spread over multiple stream_output passes, each request emitted
+exactly once, streaming (unfinished) requests unaffected."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.scheduler_components import output_streamer as os_mod
+from sglang.srt.managers.scheduler_components.output_streamer import (
+    SchedulerOutputStreamer,
+)
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _StubAccumulator:
+    """Stands in for _GenerationStreamAccumulator: records accepted reqs and
+    mirrors the finished_output bookkeeping accept() performs."""
+
+    instances = []
+
+    def __init__(self, **kwargs):
+        self.accepted = []
+        _StubAccumulator.instances.append(self)
+
+    def accept(self, *, req):
+        if req.finished():
+            req.finished_output = True
+        self.accepted.append(req.rid)
+
+    def to_payload(self, *, dp_rank, is_idle_batch):
+        return None
+
+
+def _req(rid, finished):
+    return SimpleNamespace(
+        rid=rid,
+        finished=lambda f=finished: f,
+        finished_output=False,
+        return_logprob=False,
+        return_hidden_states=False,
+        return_routed_experts=False,
+        return_indexer_topk=False,
+        return_sampling_mask=False,
+    )
+
+
+def _streamer():
+    return SchedulerOutputStreamer(
+        send_to_detokenizer=MagicMock(),
+        tree_cache=MagicMock(),
+        ps=MagicMock(attn_tp_rank=1),
+        server_args=MagicMock(),
+        is_generation=True,
+        spec_algorithm=SpeculativeAlgorithm.NONE,
+        disaggregation_mode=DisaggregationMode.NULL,
+        enable_hicache_storage=lambda: False,
+    )
+
+
+class TestStreamFinishBudget(CustomTestCase):
+    def _run_wave(self, budget, n_finished=10, n_streaming=3):
+        finished = [_req(f"f{i}", True) for i in range(n_finished)]
+        streaming = [_req(f"s{i}", False) for i in range(n_streaming)]
+        streamer = _streamer()
+        accepted_per_pass = []
+        with (
+            patch.object(os_mod, "_GenerationStreamAccumulator", _StubAccumulator),
+            patch.object(os_mod, "STREAM_FINISH_BUDGET", budget),
+            patch.object(os_mod, "get_serving", MagicMock()),
+        ):
+            _StubAccumulator.instances = []
+            streamer._stream_output_generation(finished + streaming, False)
+            accepted_per_pass.append(_StubAccumulator.instances[-1].accepted)
+            for _ in range(6):
+                if not streamer._deferred_finished:
+                    break
+                streamer._stream_output_generation(streaming, False)
+                accepted_per_pass.append(_StubAccumulator.instances[-1].accepted)
+        return finished, streaming, streamer, accepted_per_pass
+
+    def test_budget_disabled_emits_all_at_once(self):
+        finished, streaming, streamer, passes = self._run_wave(budget=0)
+        self.assertEqual(len(passes), 1)
+        self.assertEqual(
+            passes[0], [r.rid for r in finished] + [r.rid for r in streaming]
+        )
+        self.assertEqual(len(streamer._deferred_finished), 0)
+
+    def test_wave_spread_over_passes_each_emitted_once(self):
+        finished, streaming, streamer, passes = self._run_wave(budget=4)
+        finished_emitted = [
+            rid for p in passes for rid in p if rid.startswith("f")
+        ]
+        self.assertEqual(sorted(finished_emitted), sorted(r.rid for r in finished))
+        self.assertEqual(len(finished_emitted), len(set(finished_emitted)))
+        for p in passes:
+            self.assertLessEqual(sum(rid.startswith("f") for rid in p), 4)
+        # 10 finished at budget 4 -> 3 passes carry finished outputs.
+        self.assertEqual(len(passes), 3)
+        self.assertEqual(len(streamer._deferred_finished), 0)
+        self.assertEqual(len(streamer._deferred_rids), 0)
+        self.assertTrue(all(r.finished_output for r in finished))
+
+    def test_streaming_reqs_never_deferred(self):
+        _, streaming, _, passes = self._run_wave(budget=2)
+        self.assertEqual(
+            [rid for rid in passes[0] if rid.startswith("s")],
+            [r.rid for r in streaming],
+        )
+
+    def test_overlap_duplicate_not_double_deferred(self):
+        finished = [_req(f"f{i}", True) for i in range(5)]
+        streamer = _streamer()
+        with (
+            patch.object(os_mod, "_GenerationStreamAccumulator", _StubAccumulator),
+            patch.object(os_mod, "STREAM_FINISH_BUDGET", 2),
+            patch.object(os_mod, "get_serving", MagicMock()),
+        ):
+            _StubAccumulator.instances = []
+            streamer._stream_output_generation(finished, False)
+            # Overlap can re-present the same finished reqs on the next pass.
+            streamer._stream_output_generation(finished, False)
+            while streamer._deferred_finished:
+                streamer._stream_output_generation([], False)
+            emitted = [
+                rid for acc in _StubAccumulator.instances for rid in acc.accepted
+            ]
+        self.assertEqual(sorted(emitted), sorted(r.rid for r in finished))
+        self.assertEqual(len(emitted), len(set(emitted)))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_stream_finish_budget.py
+++ b/test/registered/unit/managers/test_stream_finish_budget.py
@@ -101,7 +101,6 @@ class TestStreamFinishBudget(CustomTestCase):
         self.assertEqual(len(finished_emitted), len(set(finished_emitted)))
         for p in passes:
             self.assertLessEqual(sum(rid.startswith("f") for rid in p), 4)
-        # 10 finished at budget 4 -> 3 passes carry finished outputs.
         self.assertEqual(len(passes), 3)
         self.assertEqual(len(streamer._deferred_finished), 0)
         self.assertEqual(len(streamer._deferred_rids), 0)
@@ -124,7 +123,6 @@ class TestStreamFinishBudget(CustomTestCase):
         ):
             _StubAccumulator.instances = []
             streamer._stream_output_generation(finished, False)
-            # Overlap can re-present the same finished reqs on the next pass.
             streamer._stream_output_generation(finished, False)
             while streamer._deferred_finished:
                 streamer._stream_output_generation([], False)


### PR DESCRIPTION
A completion wave assembles every finished request's final payload (logprob slicing, payload lists) in one scheduler pass, stalling decode for the surviving requests. `SGLANG_OPT_STREAM_FINISH_BUDGET` (default 64) defers the excess finished requests to subsequent passes, and the scheduler's idle path drains any leftovers so clients are never left waiting when traffic stops right after a wave. KV release and abort semantics are unchanged — only the finish event is delayed. `0` disables the cap.

Measured as part of a scheduler-CPU series on an internal multi-turn RL rolling benchmark (1x GB300): this + a scheduler GC-interval policy (#36366) were worth ~+6% output throughput together. Unit test included.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32896565831](https://github.com/sgl-project/sglang/actions/runs/32896565831)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32896565418](https://github.com/sgl-project/sglang/actions/runs/32896565418)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32896565837](https://github.com/sgl-project/sglang/actions/runs/32896565837)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->