### PR TITLE
scheduler: opt-in slow-pass stack dumps (SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS)

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -640,6 +640,11 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
+
+    # When > 0, dump all thread stacks whenever one scheduler pass exceeds
+    # this many ms. Rare-event thresholds only (>= ~100 ms): the dump volume
+    # of low thresholds wedges the run.
+    SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS = EnvFloat(0)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Deferred decode-side KV release: on abort, hold an in-flight request's KV
     # pages/slot until the prefill acks the transfer drained, or the timeout

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -640,10 +640,6 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
-
-    # When > 0, dump all thread stacks whenever one scheduler pass exceeds
-    # this many ms. Rare-event thresholds only (>= ~100 ms): the dump volume
-    # of low thresholds wedges the run.
     SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS = EnvFloat(0)
     SGLANG_DISAGGREGATION_BOOTSTRAP_ENTRY_CLEANUP_INTERVAL = EnvInt(120)
     # Deferred decode-side KV release: on abort, hold an in-flight request's KV

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1323,6 +1323,15 @@ class Scheduler(
         if envs.SGLANG_LOG_GC.get():
             configure_gc_logger()
 
+        self.init_slow_pass_tracer()
+
+    def init_slow_pass_tracer(self):
+        from sglang.srt.managers.scheduler_components.slow_pass_tracer import (
+            SlowPassTracer,
+        )
+
+        self.slow_pass_tracer = SlowPassTracer()
+
     def init_disaggregation(self):
         self.mm_receiver = None
         self.disagg_prefill_bootstrap_queue = None
@@ -1775,9 +1784,10 @@ class Scheduler(
                 continue
 
             # Get the next batch to run
-            plan = self.get_next_batch_to_run(
-                running_batch=self.running_batch, last_batch=self.last_batch
-            )
+            with self.slow_pass_tracer.trace("get_next_batch_to_run"):
+                plan = self.get_next_batch_to_run(
+                    running_batch=self.running_batch, last_batch=self.last_batch
+                )
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
             self.cur_batch_for_debug = batch
@@ -1785,7 +1795,8 @@ class Scheduler(
             # Launch the current batch
             if batch:
                 result = self.run_batch(batch)
-                self.process_batch_result(batch, result)
+                with self.slow_pass_tracer.trace("process_batch_result"):
+                    self.process_batch_result(batch, result)
             else:
                 # When the server is idle, do self-check and re-init some states.
                 self._sched_idled = True
@@ -1806,7 +1817,8 @@ class Scheduler(
         def pop_and_process():
             # Process the results of the last batch
             tmp_batch, tmp_result = self.result_queue.popleft()
-            self.process_batch_result(tmp_batch, tmp_result)
+            with self.slow_pass_tracer.trace("process_batch_result"):
+                self.process_batch_result(tmp_batch, tmp_result)
 
         while True:
             if self.gracefully_exit:
@@ -1819,9 +1831,10 @@ class Scheduler(
                 continue
 
             # Get the next batch to run
-            plan = self.get_next_batch_to_run(
-                running_batch=self.running_batch, last_batch=self.last_batch
-            )
+            with self.slow_pass_tracer.trace("get_next_batch_to_run"):
+                plan = self.get_next_batch_to_run(
+                    running_batch=self.running_batch, last_batch=self.last_batch
+                )
             self.running_batch = plan.running_batch
             batch = plan.batch_to_run
             self.cur_batch_for_debug = batch

--- a/python/sglang/srt/managers/scheduler_components/slow_pass_tracer.py
+++ b/python/sglang/srt/managers/scheduler_components/slow_pass_tracer.py
@@ -1,0 +1,53 @@
+"""Slow-pass stack dumps for scheduler stall attribution.
+
+When ``SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS`` > 0, wrapped scheduler passes arm
+a ``faulthandler`` watchdog: if the pass runs longer than the threshold, the
+watchdog dumps every python thread's stack (file:line) to stderr — i.e. into
+the scheduler's log — catching stalls that are invisible to torch profiler
+traces (pure-python holes) without external py-spy timing luck. A follow-up
+log line names the pass and its duration so dumps are attributable.
+"""
+
+from __future__ import annotations
+
+import faulthandler
+import logging
+import time
+from contextlib import contextmanager
+
+from sglang.srt.environ import envs
+
+logger = logging.getLogger(__name__)
+
+
+class SlowPassTracer:
+    def __init__(self) -> None:
+        ms = envs.SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS.get() or 0.0
+        self.timeout_s: float = ms / 1000.0 if ms > 0 else 0.0
+
+    @property
+    def enabled(self) -> bool:
+        return self.timeout_s > 0.0
+
+    @contextmanager
+    def trace(self, label: str):
+        if not self.enabled:
+            yield
+            return
+        start = time.perf_counter()
+        # One process-wide watchdog: the scheduler loop is the only user, and
+        # passes are wrapped non-overlapping, so re-arming per pass is safe.
+        faulthandler.dump_traceback_later(self.timeout_s, repeat=False, exit=False)
+        try:
+            yield
+        finally:
+            faulthandler.cancel_dump_traceback_later()
+            elapsed = time.perf_counter() - start
+            if elapsed >= self.timeout_s:
+                logger.warning(
+                    "slow scheduler pass: %s took %.1fms (>= %.1fms; thread "
+                    "stacks were dumped to stderr by the faulthandler watchdog)",
+                    label,
+                    elapsed * 1e3,
+                    self.timeout_s * 1e3,
+                )

--- a/python/sglang/srt/managers/scheduler_components/slow_pass_tracer.py
+++ b/python/sglang/srt/managers/scheduler_components/slow_pass_tracer.py
@@ -35,8 +35,6 @@ class SlowPassTracer:
             yield
             return
         start = time.perf_counter()
-        # One process-wide watchdog: the scheduler loop is the only user, and
-        # passes are wrapped non-overlapping, so re-arming per pass is safe.
         faulthandler.dump_traceback_later(self.timeout_s, repeat=False, exit=False)
         try:
             yield

--- a/test/registered/unit/managers/test_slow_pass_tracer.py
+++ b/test/registered/unit/managers/test_slow_pass_tracer.py
@@ -1,0 +1,69 @@
+"""Unit tests for SlowPassTracer (SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS)."""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.environ import envs
+from sglang.srt.managers.scheduler_components.slow_pass_tracer import SlowPassTracer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+TRACER_MOD = "sglang.srt.managers.scheduler_components.slow_pass_tracer"
+
+
+class TestSlowPassTracer(CustomTestCase):
+    def test_disabled_by_default_no_watchdog(self):
+        tracer = SlowPassTracer()
+        self.assertFalse(tracer.enabled)
+        with patch(f"{TRACER_MOD}.faulthandler") as mock_fh:
+            with tracer.trace("process_batch_result"):
+                pass
+        mock_fh.dump_traceback_later.assert_not_called()
+
+    def test_fast_pass_arms_and_cancels_without_warning(self):
+        with envs.SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS.override(100.0):
+            tracer = SlowPassTracer()
+        self.assertEqual(tracer.timeout_s, 0.1)
+        with (
+            patch(f"{TRACER_MOD}.faulthandler") as mock_fh,
+            patch(f"{TRACER_MOD}.logger") as mock_log,
+        ):
+            with tracer.trace("get_next_batch_to_run"):
+                pass
+        mock_fh.dump_traceback_later.assert_called_once_with(
+            0.1, repeat=False, exit=False
+        )
+        mock_fh.cancel_dump_traceback_later.assert_called_once()
+        mock_log.warning.assert_not_called()
+
+    def test_slow_pass_logs_attribution_line(self):
+        with envs.SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS.override(1.0):
+            tracer = SlowPassTracer()
+        clock = [0.0]
+        with (
+            patch(f"{TRACER_MOD}.faulthandler") as mock_fh,
+            patch(f"{TRACER_MOD}.logger") as mock_log,
+            patch(f"{TRACER_MOD}.time") as mock_time,
+        ):
+            mock_time.perf_counter.side_effect = lambda: clock[0]
+            with tracer.trace("process_batch_result"):
+                clock[0] += 0.35
+        mock_fh.cancel_dump_traceback_later.assert_called_once()
+        mock_log.warning.assert_called_once()
+        args = mock_log.warning.call_args[0]
+        self.assertIn("process_batch_result", args)
+
+    def test_cancel_runs_when_pass_raises(self):
+        with envs.SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS.override(50.0):
+            tracer = SlowPassTracer()
+        with patch(f"{TRACER_MOD}.faulthandler") as mock_fh:
+            with self.assertRaises(RuntimeError):
+                with tracer.trace("process_batch_result"):
+                    raise RuntimeError("boom")
+        mock_fh.cancel_dump_traceback_later.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Opt-in debug facility for attributing scheduler-thread stalls in production: when a single `get_next_batch_to_run` or `process_batch_result` call exceeds `SGLANG_DEBUG_SLOW_SCHEDULER_PASS_MS`, all thread stacks are dumped via `faulthandler`. Default off (0). Intended for rare-event thresholds (>= ~100 ms) — low thresholds produce enough dump volume to disturb the run, which the env comment warns about.

We used this to find and fix several scheduler CPU stalls (GC pauses, completion-wave payload assembly, allocator-free device syncs) on an internal RL rolling workload. Unit test included.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32896587606](https://github.com/sgl-project/sglang/actions/runs/32896587606)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32896587371](https://github.com/sgl-project/sglang/actions/runs/32896587371)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32896587612](https://github.com/sgl-project/sglang/actions/runs/32896587612)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->