### PR TITLE
scheduler: three per-pass CPU micro-cuts from a py-spy wall profile

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3660,8 +3660,6 @@ class Scheduler(
         batch.prepare_for_decode()
         return batch
 
-    # ScheduleBatch field names, resolved once: fields() reflection is on
-    # the per-pass critical path.
     _schedule_batch_field_names: tuple[str, ...] | None = None
 
     def record_batch_in_overlap(self, batch: ScheduleBatch):

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3660,6 +3660,10 @@ class Scheduler(
         batch.prepare_for_decode()
         return batch
 
+    # ScheduleBatch field names, resolved once: fields() reflection is on
+    # the per-pass critical path.
+    _schedule_batch_field_names: tuple[str, ...] | None = None
+
     def record_batch_in_overlap(self, batch: ScheduleBatch):
         # FIXME(lsyin): hacky way to keep a reference to avoid GPU tensors being freed by torch GC
         # NOTE: More Reliable: record all tensors into the forward stream
@@ -3667,9 +3671,11 @@ class Scheduler(
         #       - for all non-future tensors (produced only by schedule stream),
         #       we shall keep its reference not being release during all the forwarding pass
         # Snapshot all fields: spec V2 rebinds seq_lens / spec_info mid-forward.
-        attr_snapshot = [
-            getattr(batch, f.name, None) for f in dataclasses.fields(batch)
-        ]
+        names = Scheduler._schedule_batch_field_names
+        if names is None:
+            names = tuple(f.name for f in dataclasses.fields(batch))
+            Scheduler._schedule_batch_field_names = names
+        attr_snapshot = [getattr(batch, name, None) for name in names]
         self.batch_record_ct = (self.batch_record_ct + 1) % 2
         # List (not tuple) so that workers can register additional refs via
         # GenerationBatchResult.extra_keep_alive_refs after forward returns.

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1169,8 +1169,6 @@ class SchedulerBatchResultProcessor:
 
             req.time_stats.set_completion_time()
 
-        # Gated at the call site: per-request call overhead alone is
-        # measurable at large batches.
         if logits_output is not None and logits_output.customized_info is not None:
             self._maybe_collect_customized_info(i, req, logits_output)
 

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -332,7 +332,11 @@ class SchedulerBatchResultProcessor:
                         if get_memory().enable_hisparse:
                             self.hisparse_coordinator.admit_request_into_staging(req)
 
-                    self._maybe_collect_customized_info(i, req, logits_output)
+                    if (
+                        logits_output is not None
+                        and logits_output.customized_info is not None
+                    ):
+                        self._maybe_collect_customized_info(i, req, logits_output)
 
                     if batch.return_logprob:
                         logprob_pt = self._apply_prefill_logprobs(
@@ -1165,7 +1169,10 @@ class SchedulerBatchResultProcessor:
 
             req.time_stats.set_completion_time()
 
-        self._maybe_collect_customized_info(i, req, logits_output)
+        # Gated at the call site: per-request call overhead alone is
+        # measurable at large batches.
+        if logits_output is not None and logits_output.customized_info is not None:
+            self._maybe_collect_customized_info(i, req, logits_output)
 
     def _maybe_update_reasoning_tokens(
         self,

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -144,7 +144,6 @@ class SchedulerOutputStreamer:
         skip_req: Optional[Req] = None,
         is_idle_batch: bool = False,
     ):
-        # One fused scan instead of four any() passes over the running batch.
         return_hidden_states = False
         return_routed_experts = False
         return_indexer_topk = False

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -144,18 +144,22 @@ class SchedulerOutputStreamer:
         skip_req: Optional[Req] = None,
         is_idle_batch: bool = False,
     ):
-        return_hidden_states = any(
-            req.return_hidden_states for req in reqs if req is not skip_req
-        )
-        return_routed_experts = any(
-            req.return_routed_experts for req in reqs if req is not skip_req
-        )
-        return_indexer_topk = any(
-            req.return_indexer_topk for req in reqs if req is not skip_req
-        )
-        return_sampling_mask = any(
-            req.return_sampling_mask for req in reqs if req is not skip_req
-        )
+        # One fused scan instead of four any() passes over the running batch.
+        return_hidden_states = False
+        return_routed_experts = False
+        return_indexer_topk = False
+        return_sampling_mask = False
+        for req in reqs:
+            if req is skip_req:
+                continue
+            if req.return_hidden_states:
+                return_hidden_states = True
+            if req.return_routed_experts:
+                return_routed_experts = True
+            if req.return_indexer_topk:
+                return_indexer_topk = True
+            if req.return_sampling_mask:
+                return_sampling_mask = True
 
         acc = _GenerationStreamAccumulator(
             return_logprob=return_logprob,


### PR DESCRIPTION
Three small scheduler-thread cuts found in a py-spy wall profile at ~1,500-request batches (the scheduler thread was ~99% busy):

- `_stream_output_generation`: fuse the four `any()` flag scans over the batch into one pass (~2.1% of thread time).
- `_maybe_collect_customized_info`: gate at the call sites on `logits_output.customized_info is not None` — the per-request call overhead alone is measurable (~1.4%).
- `record_batch_in_overlap`: cache `ScheduleBatch` field names once instead of `dataclasses.fields()` reflection per pass (~1.0%).

No behavior change. Part of a scheduler-CPU series measured on an internal multi-turn RL rolling benchmark (1x GB300).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32896525222](https://github.com/sgl-project/sglang/actions/runs/32896525222)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32896524777](https://github.com/sgl-project/sglang/actions/runs/32896524777)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32896525060](https://github.com/sgl-project/sglang/actions/runs/32896525060)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->