### PR TITLE
[Bugfix] Fix GemmaRMSNorm buffer handling in OffloaderV1

### DIFF
--- a/python/sglang/srt/utils/offloader.py
+++ b/python/sglang/srt/utils/offloader.py
@@ -135,6 +135,24 @@ class OffloaderV1(BaseOffloader):
             self._cpu_offload_bytes += p.data.numel() * p.data.element_size()
             offloaded_parameters = True
 
+        for _, submodule in module.named_modules():
+            if hasattr(submodule, "gemma_weight"):
+                weight = getattr(submodule, "weight", None)
+
+                if weight is not None and weight.device.type == "cpu":
+                    gemma_weight = submodule.gemma_weight
+
+                    cpu_buffer = torch.empty_strided(
+                        size=gemma_weight.size(),
+                        stride=gemma_weight.stride(),
+                        dtype=gemma_weight.dtype,
+                        layout=gemma_weight.layout,
+                        device="cpu",
+                        pin_memory=pin_memory,
+                    )
+                    cpu_buffer.copy_(gemma_weight)
+                    submodule.gemma_weight = cpu_buffer
+
         if offloaded_parameters:
             original_forward = module.forward
 
@@ -146,6 +164,9 @@ class OffloaderV1(BaseOffloader):
                     k: v.to(device, non_blocking=True)
                     for k, v in module.state_dict().items()
                 }
+                for name, buffer in module.named_buffers(remove_duplicate=False):
+                    if name.endswith("gemma_weight"):
+                        device_state[name] = buffer.to(device, non_blocking=True)
                 output = functional_call(module, device_state, args=args, kwargs=kwargs)
                 module.forward = forward
                 return output


### PR DESCRIPTION
## Motivation

`OffloaderV1` offloads `GemmaRMSNorm.weight` to CPU, but its non-persistent
`gemma_weight` buffer remains on CUDA.

This causes device mismatch errors during model loading and CUDA graph capture.

This issue has been reproduced on multiple Qwen3.x-based models using
`GemmaRMSNorm`, including Qwen3.6, Qwen3.8 27B, and Ornith.

## Modifications

- Move `gemma_weight` to pinned CPU memory when its corresponding weight is offloaded.
- Provide the GPU copy of `gemma_weight` to `functional_call` during forward.

## Accuracy Tests

Validated with a Qwen3.5-based Ornith model using CPU offload.

After the fix:

- model loading succeeds
- `gemma_weight` uses pinned CPU memory
- CUDA graph capture succeeds
- the service starts successfully
- generation requests can run

A targeted CUDA test also passed.

A separate tied-weight correctness issue in `OffloaderV1` is outside the scope of this PR.

## Speed Tests and Profiling

No dedicated benchmark was performed.

`gemma_weight` is a small RMSNorm buffer, so the additional transfer overhead is expected to be minimal.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32889438149](https://github.com/sgl-project/sglang/actions/runs/32889438149)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32889437527](https://github.com/sgl-project/sglang/actions/runs/32889437527)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32889437767](https://github.com/sgl-project/sglang/actions/runs/32889437767)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->