### PR TITLE
[AMD] ci: resolve the nightly image tag with git ls-remote instead of fetching tags

### DIFF
--- a/scripts/ci/amd/amd_ci_latest_release_tag.py
+++ b/scripts/ci/amd/amd_ci_latest_release_tag.py
@@ -28,7 +28,21 @@ REF_PREFIX = "refs/tags/"
 
 
 def load_parse_version_tuple():
-    """Import the shared PEP 440 tag ordering by path, without running its CLI."""
+    """Import the shared PEP 440 tag ordering by path, without running its CLI.
+
+    Returns None when the release helper is not in this checkout. That happens on
+    branches from before #35196 moved it under scripts/release/, where it is
+    still at python/tools/get_version_tag.py -- picking a tag without the shared
+    ordering risks naming an image the nightly never published, so callers are
+    left with their default instead.
+    """
+    if not VERSION_HELPER_PATH.is_file():
+        print(
+            f"WARNING: {VERSION_HELPER_PATH} is missing, so release tags cannot "
+            "be ordered the way the nightly image was published",
+            file=sys.stderr,
+        )
+        return None
     spec = importlib.util.spec_from_file_location(
         "get_version_tag", VERSION_HELPER_PATH
     )
@@ -75,19 +89,23 @@ def list_local_tags() -> list:
 
 def get_latest_release_tag(remote: str = "origin") -> str:
     """Return the highest release tag, or "" so callers can keep a default."""
+    parse_version_tuple = load_parse_version_tuple()
+    if parse_version_tuple is None:
+        return ""
     tags = list_remote_tags(remote) or list_local_tags()
     if not tags:
+        print(
+            f"WARNING: no {TAG_PATTERN} tags on {remote} or in the local clone",
+            file=sys.stderr,
+        )
         return ""
-    return sorted(tags, key=load_parse_version_tuple(), reverse=True)[0]
+    return sorted(tags, key=parse_version_tuple, reverse=True)[0]
 
 
 def main() -> None:
     tag = get_latest_release_tag()
     if not tag:
-        print(
-            f"ERROR: no {TAG_PATTERN} tags found on origin or in the local clone",
-            file=sys.stderr,
-        )
+        print("ERROR: could not resolve a release tag", file=sys.stderr)
         sys.exit(1)
     print(tag)
 

--- a/scripts/ci/amd/amd_ci_latest_release_tag.py
+++ b/scripts/ci/amd/amd_ci_latest_release_tag.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Print the highest sglang release tag, read off the remote.
+
+The AMD container scripts need this only to spell the nightly image name
+(`rocm/sgl-dev:v0.5.17-rocm720-mi30x-<date>`), so they need the tag *name* and
+nothing the tag points at. `git ls-remote` transfers refs and no objects, which
+keeps that cheap on the depth-1 checkout `actions/checkout` leaves behind.
+
+Do not go back to `git fetch --tags origin`: on a depth-1 checkout that pulls
+tag objects and the history behind them, which no later step in these jobs
+reads, and which grew into minutes per job once a nightly had every AMD job
+fetching at once.
+
+Ordering comes from scripts/release/get_version_tag.py instead of being
+reimplemented here, so this picks the same tag the nightly release workflow
+published the image under, including stable and post releases sorting above rc.
+"""
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+VERSION_HELPER_PATH = REPO_ROOT / "scripts" / "release" / "get_version_tag.py"
+TAG_PATTERN = "v*.*.*"
+REF_PREFIX = "refs/tags/"
+
+
+def load_parse_version_tuple():
+    """Import the shared PEP 440 tag ordering by path, without running its CLI."""
+    spec = importlib.util.spec_from_file_location(
+        "get_version_tag", VERSION_HELPER_PATH
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.parse_version_tuple
+
+
+def run_git(*args: str) -> str:
+    """Run a git command, returning stripped stdout, or "" if it failed."""
+    try:
+        result = subprocess.run(["git", *args], capture_output=True, text=True)
+    except OSError as exc:
+        print(f"WARNING: failed to run 'git {' '.join(args)}': {exc}", file=sys.stderr)
+        return ""
+    if result.returncode != 0:
+        print(
+            f"WARNING: git {' '.join(args)} failed "
+            f"(exit {result.returncode}): {result.stderr.strip()}",
+            file=sys.stderr,
+        )
+        return ""
+    return result.stdout.strip()
+
+
+def list_remote_tags(remote: str = "origin") -> list:
+    """Return version tag names on `remote`, or [] if it cannot be reached.
+
+    `--refs` drops the peeled `<tag>^{}` lines that annotated tags also emit.
+    """
+    raw = run_git("ls-remote", "--tags", "--refs", remote, TAG_PATTERN)
+    tags = []
+    for line in raw.splitlines():
+        _, _, ref = line.partition("\t")
+        if ref.startswith(REF_PREFIX):
+            tags.append(ref[len(REF_PREFIX) :])
+    return tags
+
+
+def list_local_tags() -> list:
+    """Return version tag names already in the local ref store."""
+    return run_git("tag", "--list", TAG_PATTERN).splitlines()
+
+
+def get_latest_release_tag(remote: str = "origin") -> str:
+    """Return the highest release tag, or "" so callers can keep a default."""
+    tags = list_remote_tags(remote) or list_local_tags()
+    if not tags:
+        return ""
+    return sorted(tags, key=load_parse_version_tuple(), reverse=True)[0]
+
+
+def main() -> None:
+    tag = get_latest_release_tag()
+    if not tag:
+        print(
+            f"ERROR: no {TAG_PATTERN} tags found on origin or in the local clone",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    print(tag)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/amd/amd_ci_start_container.sh
+++ b/scripts/ci/amd/amd_ci_start_container.sh
@@ -4,18 +4,16 @@ set -euo pipefail
 # Get version from git tags
 SGLANG_VERSION="v0.5.5"   # Default version, will be overridden if git tags are found
 
-# Fetch tags from origin to ensure we have the latest
-if git fetch --tags origin; then
-  # Use the shared helper so stable/post releases sort above rc tags.
-  VERSION_FROM_TAG=$(python3 scripts/release/get_version_tag.py --tag-only || true)
-  if [ -n "$VERSION_FROM_TAG" ]; then
-    SGLANG_VERSION="$VERSION_FROM_TAG"
-    echo "Using SGLang version from git tags: $SGLANG_VERSION"
-  else
-    echo "Warning: No version tags found; using default $SGLANG_VERSION" >&2
-  fi
+# Read the tag name off the remote. The helper still sorts stable/post releases
+# above rc tags, and explains why this must not go back to fetching tag objects
+# into the checkout.
+TAG_LOOKUP_START=$SECONDS
+VERSION_FROM_TAG=$(python3 scripts/ci/amd/amd_ci_latest_release_tag.py || true)
+if [ -n "$VERSION_FROM_TAG" ]; then
+  SGLANG_VERSION="$VERSION_FROM_TAG"
+  echo "Using SGLang version from git tags: $SGLANG_VERSION (resolved in $(( SECONDS - TAG_LOOKUP_START ))s)"
 else
-  echo "Warning: Failed to fetch tags from origin; using default $SGLANG_VERSION" >&2
+  echo "Warning: No version tags resolved; using default $SGLANG_VERSION" >&2
 fi
 
 

--- a/scripts/ci/amd/amd_ci_start_container_disagg.sh
+++ b/scripts/ci/amd/amd_ci_start_container_disagg.sh
@@ -4,18 +4,16 @@ set -euo pipefail
 # Get version from git tags
 SGLANG_VERSION="v0.5.5"   # Default version, will be overridden if git tags are found
 
-# Fetch tags from origin to ensure we have the latest
-if git fetch --tags origin; then
-  # Use the shared helper so stable/post releases sort above rc tags.
-  VERSION_FROM_TAG=$(python3 scripts/release/get_version_tag.py --tag-only || true)
-  if [ -n "$VERSION_FROM_TAG" ]; then
-    SGLANG_VERSION="$VERSION_FROM_TAG"
-    echo "Using SGLang version from git tags: $SGLANG_VERSION"
-  else
-    echo "Warning: No version tags found; using default $SGLANG_VERSION" >&2
-  fi
+# Read the tag name off the remote. The helper still sorts stable/post releases
+# above rc tags, and explains why this must not go back to fetching tag objects
+# into the checkout.
+TAG_LOOKUP_START=$SECONDS
+VERSION_FROM_TAG=$(python3 scripts/ci/amd/amd_ci_latest_release_tag.py || true)
+if [ -n "$VERSION_FROM_TAG" ]; then
+  SGLANG_VERSION="$VERSION_FROM_TAG"
+  echo "Using SGLang version from git tags: $SGLANG_VERSION (resolved in $(( SECONDS - TAG_LOOKUP_START ))s)"
 else
-  echo "Warning: Failed to fetch tags from origin; using default $SGLANG_VERSION" >&2
+  echo "Warning: No version tags resolved; using default $SGLANG_VERSION" >&2
 fi
 
 

--- a/test/registered/unit/tools/test_amd_ci_latest_release_tag.py
+++ b/test/registered/unit/tools/test_amd_ci_latest_release_tag.py
@@ -79,6 +79,17 @@ class TestAmdCiLatestReleaseTag(CustomTestCase):
         ):
             self.assertEqual(self.helper.get_latest_release_tag(), "")
 
+    def test_missing_release_helper_yields_empty_instead_of_a_traceback(self):
+        # Branches from before #35196 keep the ordering helper at
+        # python/tools/get_version_tag.py, so a cherry-pick of this script onto
+        # one of them finds nothing at VERSION_HELPER_PATH. Guessing an order
+        # there could name an image the nightly never published.
+        with patch.object(
+            self.helper, "VERSION_HELPER_PATH", Path("/nonexistent/get_version_tag.py")
+        ):
+            self.assertIsNone(self.helper.load_parse_version_tuple())
+            self.assertEqual(self.helper.get_latest_release_tag(), "")
+
     def test_failed_git_invocation_is_reported_but_not_fatal(self):
         failed = Mock(returncode=128, stdout="", stderr="no such remote")
 

--- a/test/registered/unit/tools/test_amd_ci_latest_release_tag.py
+++ b/test/registered/unit/tools/test_amd_ci_latest_release_tag.py
@@ -1,0 +1,108 @@
+"""Unit tests for scripts/ci/amd/amd_ci_latest_release_tag.py
+
+The AMD container scripts resolve the nightly image tag by reading tag *names*
+off the remote with `git ls-remote`, never by fetching tag objects into the
+depth-1 CI checkout. These tests pin both halves of that: the helper's own
+behavior, and the fact that the two container scripts still call it.
+"""
+
+import importlib.util
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+REPO_ROOT = Path(__file__).resolve().parents[4]
+HELPER_PATH = REPO_ROOT / "scripts/ci/amd/amd_ci_latest_release_tag.py"
+CONTAINER_SCRIPTS = [
+    REPO_ROOT / "scripts/ci/amd/amd_ci_start_container.sh",
+    REPO_ROOT / "scripts/ci/amd/amd_ci_start_container_disagg.sh",
+]
+
+
+class TestAmdCiLatestReleaseTag(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        spec = importlib.util.spec_from_file_location(
+            "amd_ci_latest_release_tag", HELPER_PATH
+        )
+        cls.helper = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(cls.helper)
+
+    def test_remote_tags_are_listed_without_transferring_objects(self):
+        ls_remote_output = (
+            "aaa\trefs/tags/v0.5.9\n"
+            "bbb\trefs/tags/v0.5.10\n"
+            "ccc\trefs/heads/main\n"
+        )
+
+        with patch.object(
+            self.helper, "run_git", return_value=ls_remote_output
+        ) as run_git:
+            tags = self.helper.list_remote_tags()
+
+        # ls-remote is what keeps this from pulling tag objects into the depth-1
+        # CI checkout, and --refs is what keeps an annotated tag from also
+        # yielding a peeled `<tag>^{}` entry.
+        run_git.assert_called_once_with(
+            "ls-remote", "--tags", "--refs", "origin", "v*.*.*"
+        )
+        self.assertEqual(tags, ["v0.5.9", "v0.5.10"])
+
+    def test_tag_ordering_matches_the_shared_release_helper(self):
+        # The image tag only resolves if this picks the same tag the nightly
+        # release workflow published under, so stable/post must sort above rc.
+        with patch.object(
+            self.helper,
+            "list_remote_tags",
+            return_value=["v0.5.10rc0", "v0.5.9", "v0.5.10.post1", "v0.5.10"],
+        ):
+            self.assertEqual(self.helper.get_latest_release_tag(), "v0.5.10.post1")
+
+    def test_unreachable_remote_falls_back_to_local_tags(self):
+        with (
+            patch.object(self.helper, "list_remote_tags", return_value=[]),
+            patch.object(
+                self.helper, "list_local_tags", return_value=["v0.5.8", "v0.5.9"]
+            ),
+        ):
+            self.assertEqual(self.helper.get_latest_release_tag(), "v0.5.9")
+
+    def test_no_tags_anywhere_yields_empty_so_callers_keep_their_default(self):
+        with (
+            patch.object(self.helper, "list_remote_tags", return_value=[]),
+            patch.object(self.helper, "list_local_tags", return_value=[]),
+        ):
+            self.assertEqual(self.helper.get_latest_release_tag(), "")
+
+    def test_failed_git_invocation_is_reported_but_not_fatal(self):
+        failed = Mock(returncode=128, stdout="", stderr="no such remote")
+
+        with patch.object(self.helper.subprocess, "run", return_value=failed):
+            self.assertEqual(self.helper.run_git("ls-remote"), "")
+
+    def test_container_scripts_resolve_the_tag_without_fetching_tags(self):
+        for path in CONTAINER_SCRIPTS:
+            with self.subTest(script=path.name):
+                lines = path.read_text().splitlines()
+                self.assertTrue(
+                    any("amd_ci_latest_release_tag.py" in line for line in lines),
+                    f"{path.name} no longer resolves the image tag through the "
+                    "helper, so it is back to whatever the tag lookup was before",
+                )
+                self.assertEqual(
+                    [line.strip() for line in lines if "fetch --tags" in line],
+                    [],
+                    f"{path.name} fetches tags into the depth-1 CI checkout: that "
+                    "transfers ~170MB of objects no later step reads, and still "
+                    "cannot make `git describe` work from a single-commit HEAD; "
+                    "read the tag name off the remote instead",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Both AMD container-start scripts ran `git fetch --tags origin` for one reason: to learn the name of the latest release tag so they could spell the nightly image, `rocm/sgl-dev:v0.5.18-rocm720-mi30x-<date>`. They need the tag *name* and nothing the tag points at, but the fetch pulls every tag object and the history behind it into a checkout that `actions/checkout` created at depth 1. That is the single most expensive thing these scripts do before the image pull, and every AMD job pays it — a nightly runs ~90 of them concurrently against the same remote.

This is the tag-lookup half of #34487, split out on its own as requested. The image-tarball cache measured in that PR is not included here; the benchmark came out negative for it.

## Modifications

- add `scripts/ci/amd/amd_ci_latest_release_tag.py`, which lists tag names with `git ls-remote --tags --refs origin 'v*.*.*'` and picks the highest. Tag ordering is imported from `scripts/release/get_version_tag.py` rather than reimplemented, so this resolves to the same tag the nightly release workflow published the image under (stable and post above rc). If the remote is unreachable it falls back to local tags; if it cannot order tags at all it returns nothing so the caller keeps its hard-coded default.
- point `amd_ci_start_container.sh` and `amd_ci_start_container_disagg.sh` at that helper. Both scripts carried a byte-identical copy of the old block and have been changed in lockstep by every prior fix to it (#23644, #35196), so leaving one behind on the fetch would have half-solved the problem and invited drift.
- log how long the lookup took next to the resolved version, so the nightly logs stay measurable without a separate probe.
- add `test/registered/unit/tools/test_amd_ci_latest_release_tag.py`, covering the helper plus a guard that neither container script goes back to fetching tags.

No workflow YAML changes, and the flags both scripts accept are unchanged, so a workflow file from any ref still drives a checkout from any other ref. The helper and its caller always travel together in the same checkout.

`scripts/release/get_version_tag.py` is untouched: it is what setuptools-scm invokes via `git_describe_command` in six pyprojects, and nothing here needs it to change.

## Accuracy Tests

N/A — CI setup plumbing, no model or kernel code.

## Speed Tests and Profiling

Measured on a fresh `git clone --depth 1`, which is what `actions/checkout@v4` leaves the AMD jobs (1 commit, no tags, shallow):

| Step | Wall time | `.git` size after |
|---|---:|---:|
| depth-1 clone | 47s | 33MB |
| `git ls-remote --tags --refs origin 'v*.*.*'` | **1s** | 33MB (unchanged) |
| `git fetch --tags origin` | **29s** | **201MB** |

So the fetch transferred ~168MB of objects to answer a question `ls-remote` answers in one round trip and 150 lines of output. The 29s above is a well-provisioned VM with a fast link to GitHub; a second run against `release/v0.5.18` took **125s**, in line with the 136s median measured on the AMD runners in #34487, where the worst `ls-remote` lookup across all those runs was 20s.

The end-to-end helper on a depth-1 checkout with no local tags returns in **0.29s**:

```
$ python3 scripts/ci/amd/amd_ci_latest_release_tag.py
v0.5.18
```

**The dropped fetch changes no version that anything downstream reads.** `get_version_tag.py` in describe mode — the mode setuptools-scm actually calls — fails identically before and after the fetch, because a single-commit HEAD has no common ancestor with any release tag:

```
# depth-1 checkout, no tags fetched
$ python3 scripts/release/get_version_tag.py
WARNING: No version tags (v*.*.*) found in repo
ERROR: Could not determine version from git tags. ... exit 1

# same checkout, after `git fetch --tags origin` brought in all 150 tags
$ python3 scripts/release/get_version_tag.py
WARNING: No common ancestor between v0.5.18 and HEAD. Is this a shallow clone?
ERROR: Could not determine version from git tags. ... exit 1
```

Either way setuptools-scm falls back to the same tagless dev version. The only thing the fetch enabled was `--tag-only` printing `v0.5.18`, which is exactly what the new helper returns.

## Branch coverage

These scripts do not only run on `main`. `amd-aiter-scout.yml` drives all four AMD workflows at `ref: amd/aiter-ci`, the PR workflows check out `inputs.pr_head_sha`, and release branches get cherry-picks. Because `git ls-remote` asks the *remote* for its refs, the answer does not depend on which ref is checked out, and none of the AMD workflows override `repository:` or `token:` — so `origin` is always `sgl-project/sglang`. Old and new paths were compared on a depth-1 clone of each branch:

| Branch checked out | `ls-remote` helper | `fetch --tags` + old helper | Agree |
|---|---|---|---|
| `main` | `v0.5.18` (1s) | `v0.5.18` (35s) | yes |
| `amd/aiter-ci` (aiter scout) | `v0.5.18` (0s) | `v0.5.18` (14s) | yes |
| `release/v0.5.18` | `v0.5.18` (0s) | `v0.5.18` (125s) | yes |
| `release/v0.5.17` | degrades to default | n/a — pre-#35196 layout | — |

Note this resolves the newest release tag on every branch, including release branches, exactly as the fetch did; picking a branch-scoped version was never the behavior and is not changed here.

That last row is a gap the branch sweep found and this PR now handles. `release/v0.5.17` predates #35196, so its ordering helper is still at `python/tools/get_version_tag.py`; loading it from the new path raised `FileNotFoundError`, and the caller's `|| true` turned that into a bare traceback. The helper now reports the missing file and returns no tag, so the caller keeps its default the way it did before:

```
$ python3 scripts/ci/amd/amd_ci_latest_release_tag.py   # on release/v0.5.17
WARNING: .../scripts/release/get_version_tag.py is missing, so release tags
cannot be ordered the way the nightly image was published
ERROR: could not resolve a release tag

$ # through the caller's block, under `set -euo pipefail`
Warning: No version tags resolved; using default v0.5.5      (exit 0)
```

It deliberately does not guess an order in that case: without the shared helper, `v0.5.10rc0` sorts above `v0.5.10` under `strverscmp`, which is the bug #35196's helper exists to avoid, and that would name an image the nightly never published.

`nightly-test-amd-miles-rocm720.yml` passes `--custom-image`, so it discards the resolved tag entirely — it was paying the full fetch for a value it never used, and now pays ~1s. Skipping the lookup outright for `--custom-image` would mean reordering the argument parsing that builds the default base tags, which is not worth the churn for a second.

## Verification

Fallback and failure paths, exercised on a depth-1 shallow checkout:

| Condition | Result |
|---|---|
| remote reachable, no local tags | `v0.5.18` in 0.29s |
| remote unreachable, local tags present | warns, falls back to local tags, shared ordering |
| remote unreachable, no tags at all | warns, empty stdout, exit 1 |
| ordering helper missing from the checkout | warns with the path, empty stdout, exit 1 |
| the caller's bash block on either of those | `Warning: No version tags resolved; using default v0.5.5`, exit 0 under `set -euo pipefail` |

Also run:

- 7/7 unit tests in the new file, including a negative check that the anti-regression guard really fails when `git fetch --tags` is reintroduced into either script;
- `scripts/lint/check_registered_tests.py` and `check_no_bare_pytest_main.py`;
- `bash -n` on both container scripts;
- `pre-commit` on all four files.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — n/a, no user-facing surface
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829113888](https://github.com/sgl-project/sglang/actions/runs/34829113888)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829113577](https://github.com/sgl-project/sglang/actions/runs/34829113577)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829113943](https://github.com/sgl-project/sglang/actions/runs/34829113943)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->