### PR TITLE
fix(metrics): handle missing CPU sequence lengths

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -320,8 +320,12 @@ class SchedulerMetricsReporter:
             for req in batch.decoding_reqs or []:
                 decode_kv.add(req.seqlen)
         elif batch.forward_mode.is_decode():
-            for sl in batch.seq_lens_cpu:
-                decode_kv.add(int(sl))
+            if batch.seq_lens_cpu is not None:
+                for seq_len in batch.seq_lens_cpu:
+                    decode_kv.add(int(seq_len))
+            else:
+                for req in batch.reqs:
+                    decode_kv.add(req.seqlen)
 
         return ScheduledRequestMetrics(
             num_prefill_requests=num_prefill_requests,

--- a/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
+++ b/python/sglang/srt/managers/scheduler_components/metrics_reporter.py
@@ -324,6 +324,7 @@ class SchedulerMetricsReporter:
                 for seq_len in batch.seq_lens_cpu:
                     decode_kv.add(int(seq_len))
             else:
+                # Requests hold post-step lengths here; the mirror may hold pre-step lengths.
                 for req in batch.reqs:
                     decode_kv.add(req.seqlen)
 

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -197,6 +197,23 @@ class TestForwardPassMetrics(unittest.TestCase):
         self.assertEqual(metrics.queued_requests.num_prefill_requests, 1)
         self.assertEqual(metrics.queued_requests.num_decode_requests, 1)
 
+    def test_emit_decode_batch_without_cpu_seq_lens(self):
+        decode_reqs = [_FakeReq(8, output_len=3), _FakeReq(13, output_len=5)]
+        batch = self._make_batch(reqs=decode_reqs, seq_lens_cpu=None)
+
+        with patch(
+            "sglang.srt.managers.scheduler_components.metrics_reporter.time.monotonic",
+            return_value=101.0,
+        ):
+            self.reporter._emit_forward_pass_metrics(batch)
+
+        metrics = self.scheduler._fpm_publisher.metrics[0]
+        self.assertEqual(metrics.scheduled_requests.num_decode_requests, 2)
+        self.assertEqual(
+            metrics.scheduled_requests.sum_decode_kv_tokens,
+            sum(req.seqlen for req in decode_reqs),
+        )
+
     def test_emit_uses_device_timer_gpu_time(self):
         self.scheduler._fpm_uses_device_timer = True
         self.scheduler._fpm_gpu_time_acc = 0.042

--- a/test/registered/unit/observability/test_forward_pass_metrics.py
+++ b/test/registered/unit/observability/test_forward_pass_metrics.py
@@ -198,6 +198,7 @@ class TestForwardPassMetrics(unittest.TestCase):
         self.assertEqual(metrics.queued_requests.num_decode_requests, 1)
 
     def test_emit_decode_batch_without_cpu_seq_lens(self):
+        """Decode metrics emit when a speculative backend omits CPU sequence lengths."""
         decode_reqs = [_FakeReq(8, output_len=3), _FakeReq(13, output_len=5)]
         batch = self._make_batch(reqs=decode_reqs, seq_lens_cpu=None)
 
@@ -207,12 +208,15 @@ class TestForwardPassMetrics(unittest.TestCase):
         ):
             self.reporter._emit_forward_pass_metrics(batch)
 
+        self.assertEqual(len(self.scheduler._fpm_publisher.metrics), 1)
         metrics = self.scheduler._fpm_publisher.metrics[0]
+        self.assertEqual(metrics.scheduled_requests.num_prefill_requests, 0)
         self.assertEqual(metrics.scheduled_requests.num_decode_requests, 2)
         self.assertEqual(
             metrics.scheduled_requests.sum_decode_kv_tokens,
             sum(req.seqlen for req in decode_reqs),
         )
+        self.assertAlmostEqual(metrics.scheduled_requests.var_decode_kv_tokens, 12.25)
 
     def test_emit_uses_device_timer_gpu_time(self):
         self.scheduler._fpm_uses_device_timer = True


### PR DESCRIPTION
## Summary

Prevent forward-pass metrics from crashing speculative decode when the optional `ScheduleBatch.seq_lens_cpu` mirror is absent. The metrics reporter now uses `Req.seqlen` as a sync-free fallback, which preserves decode metrics without forcing a device synchronization.

## Changes

- Guard access to `ScheduleBatch.seq_lens_cpu` in `SchedulerMetricsReporter._build_scheduled_request_metrics`.
- Collect the decode request count, total KV tokens, and KV token variance from `Req.seqlen` when the CPU mirror is unavailable.
- Add `test_emit_decode_batch_without_cpu_seq_lens` to cover `seq_lens_cpu=None` and verify the emitted request count and token total.

## Test Plan

- Added a regression test for decode batches where `ScheduleBatch.seq_lens_cpu` is `None`.
- Passed Python bytecode compilation for the changed source and test files.
- Passed `git diff --check`.
- Passed the repository's configured `ruff` checks for the changed files.
- The focused `pytest` test was not run locally because `sgl-deep-ep==0.1.2` does not provide a macOS ARM wheel. Run the regression test in Linux CI.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33025747008](https://github.com/sgl-project/sglang/actions/runs/33025747008)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33025746810](https://github.com/sgl-project/sglang/actions/runs/33025746810)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33025746858](https://github.com/sgl-project/sglang/actions/runs/33025746858)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->