### PR TITLE
[AMD][CI] Run the Wan2.2 FP8-MLA diffusion nightly suite and skip MiniMax-H3 on ROCm

### DIFF
--- a/.github/workflows/nightly-test-amd.yml
+++ b/.github/workflows/nightly-test-amd.yml
@@ -89,6 +89,7 @@ on:
           - nightly-8-gpu-minimax-m27
           # Diffusion (MI30x)
           - nightly-1-gpu-zimage-turbo
+          - nightly-8-gpu-wan22-fp8-mla
       job_filter:
         description: 'Or type comma-separated job names (overrides dropdown if non-empty)'
         required: false
@@ -1913,6 +1914,50 @@ jobs:
           if-no-files-found: ignore
           retention-days: 30
 
+  nightly-8-gpu-wan22-fp8-mla:
+    name: nightly-8-gpu-wan22-fp8-mla (rocm700, linux-mi300-8gpu-sglang)
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-wan22-fp8-mla,'))
+    runs-on: linux-mi300-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh diffusion
+
+      - name: Wan2.2 FP8 MLA Diffusion Test (1-GPU + 8-GPU)
+        timeout-minutes: 150
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            -e SGLANG_DIFFUSION_ARTIFACT_DIR="/sglang-checkout/diffusion-failures" \
+            python3 run_suite.py --hw amd --suite nightly-amd-fp8-mla-diffusion --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+      - name: Upload diffusion failure artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wan22-fp8-mla-failures
+          path: diffusion-failures/
+          if-no-files-found: ignore
+          retention-days: 7
+
   check-all-jobs:
     if: always() && (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch')
     needs:
@@ -1975,6 +2020,7 @@ jobs:
       - nightly-8-gpu-minimax-m27
       # Diffusion (MI30x)
       - nightly-1-gpu-zimage-turbo
+      # - nightly-8-gpu-wan22-fp8-mla  # excluded: newly enabled suite with no green history yet
     runs-on: ubuntu-latest
     steps:
       - name: Check if any job failed

--- a/python/sglang/multimodal_gen/test/server/gpu_cases.py
+++ b/python/sglang/multimodal_gen/test/server/gpu_cases.py
@@ -1088,6 +1088,18 @@ if not current_platform.is_hip():
 ONE_GPU_CASES += ONE_GPU_MODELOPT_FP8_CASES
 TWO_GPU_CASES = _with_default_num_gpus(TWO_GPU_CASES, 2)
 
+# MiniMax-H3's full-loop denoise stage accepts CUDA, MPS, and Ascend NPU only and
+# raises RuntimeError on every other platform, so every H3 case fails within
+# seconds of the first request on ROCm. Keying off the model path rather than the
+# case ids covers H3 cases added later. Remove this block once the stage grows a
+# HIP path.
+if current_platform.is_hip():
+    TWO_GPU_CASES = [
+        case
+        for case in TWO_GPU_CASES
+        if case.server_args.model_path != "MiniMaxAI/MiniMax-H3"
+    ]
+
 
 ONE_GPU_5090_PERF_CASE_IDS = frozenset(
     {

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -139,6 +139,7 @@ NIGHTLY_SUITES = {
         "nightly-amd-kernel-1-gpu",
         "nightly-amd-1-gpu-mi35x",
         "nightly-amd-1-gpu-zimage-turbo",
+        "nightly-amd-fp8-mla-diffusion",
         "nightly-amd-2-gpu-mi35x-deepseek-r1-mxfp4-tp2",
         "nightly-amd-8-gpu-mi35x-deepseek-r1-mxfp4-tp4",
         "nightly-amd-accuracy-8-gpu-mi35x-kimi-k3",


### PR DESCRIPTION
## Motivation

While comparing AMD's nightly diffusion coverage against NVIDIA's, two problems turned up.

**AMD's only video-diffusion test has never run.** `test/registered/amd/test_wan22_fp8_mla.py` registers `suite="nightly-amd-fp8-mla-diffusion"` with `nightly=True` and `est_time=3600`, covering four Wan2.2-T2V-A14B FP8-MLA cases (1-GPU and 8-GPU, torch-compile on and off). That suite name is not in `NIGHTLY_SUITES[HWBackend.AMD]` and no workflow dispatches it, so the file is dead code. It went unnoticed because `HWBackend.AMD` is absent from `_SUITE_CHECKED_BACKENDS` in `test/run_suite.py`, so `validate_all_suites` never rejects an AMD registration pointing at a non-existent suite; `run_suite.py` only prints `Warning: Unknown suite ...` if someone happens to ask for it by name. That left AMD nightly with exactly one diffusion job — Z-Image-Turbo text-to-image on a single MI300 — and no video diffusion at all.

**Both MiniMax-H3 cases fail on every scheduled ROCm run.** `MiniMaxH3DenoisingStage._run_full_loop` accepts CUDA, MPS, and Ascend NPU and raises `RuntimeError: MiniMax H3 full-loop denoise requires CUDA, MPS, or Ascend NPU` on anything else, so `minimax_h3_t2va_2gpu_h100` and `minimax_h3_ref2va_video_audio_2gpu_h100` fail seconds into the first request on MI300. Both shards of `multimodal-gen-test-2-gpu-amd` have been red in every recent scheduled run of the ROCm 7.0 shadow (daily) and ROCm 7.2 (every 12 hours), for example runs [32758110155](https://github.com/sgl-project/sglang/actions/runs/32758110155) and [32725797196](https://github.com/sgl-project/sglang/actions/runs/32725797196).

## Modifications

- `test/run_suite.py`: add `nightly-amd-fp8-mla-diffusion` to `NIGHTLY_SUITES[HWBackend.AMD]` so the suite is recognized rather than warned about.
- `.github/workflows/nightly-test-amd.yml`: add a `nightly-8-gpu-wan22-fp8-mla` job on `linux-mi300-8gpu-sglang` (8 GPUs are required by two of the four cases) and add it to the `job_select` dropdown. It is deliberately **left out of `check-all-jobs`** — this suite has never executed, so it should not gate the nightly until it has a green history. Moving that one line into the `needs` list is all it takes to make it gating later.
- `python/sglang/multimodal_gen/test/server/gpu_cases.py`: drop MiniMax-H3 cases from `TWO_GPU_CASES` under `current_platform.is_hip()`, matching the existing `is_hip()` guards in the same file. The filter keys off `server_args.model_path` rather than case ids so H3 cases added later are covered without another patch.

NVIDIA is unaffected. `diffusion_case_parser` reads the case lists statically and `_extract_case_ids` returns `None` for anything that is not a literal list, so the guarded reassignment is ignored exactly like the existing `TWO_GPU_CASES = _with_default_num_gpus(...)` line. I confirmed `collect_diffusion_suites` still reports all 27 two-GPU cases including both H3 ids, so the NVIDIA partition plan and `diffusion-coverage-check` are unchanged. AMD partitions at runtime from the imported list (it passes `--total-partitions` with no `--partition-plan-json`), so its planning and execution stay consistent with each other.

I added the new job to the ROCm 7.0 nightly only. Mirroring it into `nightly-test-amd-rocm720.yml` makes sense once it has run green a few times, rather than committing two nightlies' worth of 8-GPU MI300 time to a suite with no history.

## Accuracy Tests

No model or kernel forward code is touched. The Wan2.2 FP8-MLA cases assert non-empty output only (`run_perf_check`, `run_consistency_check`, `run_models_api_check`, and `run_t2v_input_reference_check` are all `False` in the test file).

## Speed Tests and Profiling

Not applicable. The new job adds roughly one hour of `linux-mi300-8gpu-sglang` time per night; the H3 exclusion returns the two 2-GPU shards to useful signal and stops burning MI300 time on a guaranteed failure.

## Not addressed here

Two further ROCm-specific failures keep `multimodal-gen-test-2-gpu-amd` red and need owners. Both reproduce on ROCm 7.0 and 7.2 and are real bugs rather than test-matrix problems, so I did not paper over them:

1. `test_diffusion_bcg_tp2_zimage_turbo.py` hangs until the 900 s subprocess timeout. The RCCL watchdog trips on `HIP error: operation not permitted on an event last recorded in a capturing stream` (`hipErrorCapturedEvent`) — the breakable-CUDA-graph path records an event inside a graph capture that `ProcessGroupNCCL::WorkNCCL::finishedGPUExecutionInternal` then queries.
2. `test_disagg_server.py::TestDisaggZImage1Rank` and `::TestDisaggZImageTracing` error with `TypeError: unsupported operand type(s) for //: 'NoneType' and 'int'` at `configs/pipeline_configs/zimage.py:438`, where `batch.height` reaches `get_freqs_cis` as `None`. `TestDisaggZImage2RankDenoiser` passes, and all NVIDIA 2-GPU shards pass, so height/width propagation to the denoiser looks broken only on the 1-rank ROCm path.

Separately, the orphaned-suite problem is wider than diffusion: 39 distinct AMD-registered suites are dispatched by no workflow and are missing from `run_suite.py`'s lists, mostly superseded model configs under `test/registered/amd/perf/` and `test/registered/amd/accuracy/`. A ratchet check for that belongs in its own PR rather than this one.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32907047906](https://github.com/sgl-project/sglang/actions/runs/32907047906)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32907047419](https://github.com/sgl-project/sglang/actions/runs/32907047419)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32907047573](https://github.com/sgl-project/sglang/actions/runs/32907047573)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->