### PR TITLE
[CI] Stop run_suite from stalling after every result is reported

### DIFF
--- a/python/sglang/test/ci/ci_utils.py
+++ b/python/sglang/test/ci/ci_utils.py
@@ -104,7 +104,12 @@ def run_with_timeout(
     def _target_func():
         ret_value.append(func(*args, **(kwargs or {})))
 
-    t = threading.Thread(target=_target_func)
+    # daemon=True: on timeout the worker is abandoned while still blocked on
+    # its child. A non-daemon worker would keep the interpreter alive at
+    # shutdown, so a child that survives kill_process_tree (e.g. stuck in
+    # D-state on a wedged GPU) would stall the runner indefinitely after every
+    # result had already been reported.
+    t = threading.Thread(target=_target_func, daemon=True, name="ci-file-runner")
     t.start()
     t.join(timeout=timeout)
     if t.is_alive():

--- a/test/registered/unit/utils/test_ci_runner_exit.py
+++ b/test/registered/unit/utils/test_ci_runner_exit.py
@@ -1,0 +1,107 @@
+# Copyright 2023-2024 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Tests that the CI suite runner cannot stall after results are reported.
+
+A ROCm 7.2.4 job stayed alive for 34 minutes after its suite had already
+printed `Ran 2 tests ... OK`, producing no further output until the runner was
+reclaimed. A suite that has reported every result must exit, and a leftover
+worker must never be able to hold the interpreter open.
+"""
+
+import subprocess
+import sys
+import threading
+import unittest
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.ci.ci_utils import run_with_timeout
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=15, suite="base-a-test-cpu")
+
+# Mirrors the tail of run_suite.main(): a worker that will never finish, a
+# result line already written, then the exit path under test.
+_EXIT_SCRIPT = """
+import os, sys, threading
+threading.Thread(target=threading.Event().wait, daemon=False).start()
+print("summary line")
+{exit_stmt}
+"""
+
+_HANG_BUDGET_S = 5.0
+
+
+class TestRunWithTimeout(CustomTestCase):
+    def setUp(self):
+        self._release = threading.Event()
+
+    def tearDown(self):
+        # Let any worker abandoned by a timeout finish, so it does not leak
+        # into the rest of this process.
+        self._release.set()
+
+    def test_returns_value_when_within_budget(self):
+        self.assertEqual(run_with_timeout(lambda: 7, timeout=10), 7)
+
+    def test_timed_out_worker_is_daemonized(self):
+        """A worker abandoned on timeout must not outrank interpreter shutdown.
+
+        The runner kills the child and moves on, but a child stuck in D-state
+        on a wedged GPU keeps the worker blocked forever. As a non-daemon
+        thread it would then hang the whole suite at exit.
+        """
+        with self.assertRaises(TimeoutError):
+            run_with_timeout(self._release.wait, timeout=0.2)
+
+        workers = [t for t in threading.enumerate() if t.name == "ci-file-runner"]
+        self.assertEqual(len(workers), 1, "expected exactly one abandoned worker")
+        self.assertTrue(workers[0].daemon, "abandoned worker must be a daemon")
+
+
+class TestSuiteRunnerExitPath(CustomTestCase):
+    def _run_exit_script(self, exit_stmt: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, "-c", _EXIT_SCRIPT.format(exit_stmt=exit_stmt)],
+            capture_output=True,
+            text=True,
+            timeout=_HANG_BUDGET_S,
+        )
+
+    def test_hard_exit_terminates_and_keeps_output(self):
+        proc = self._run_exit_script(
+            "sys.stdout.flush(); sys.stderr.flush(); os._exit(0)"
+        )
+        self.assertEqual(proc.returncode, 0)
+        # os._exit bypasses Python's own flush, so the explicit flush above is
+        # the only thing keeping the summary out of the void.
+        self.assertIn("summary line", proc.stdout)
+
+    def test_hard_exit_reports_failure_as_255(self):
+        proc = self._run_exit_script(
+            "sys.stdout.flush(); sys.stderr.flush(); os._exit(-1 & 0xFF)"
+        )
+        self.assertEqual(proc.returncode, 255)
+
+    def test_sys_exit_would_hang(self):
+        """Guards the guard: proves the leftover worker really does block exit.
+
+        Without this, the tests above would still pass if a stuck thread had
+        never been able to stall shutdown in the first place.
+        """
+        with self.assertRaises(subprocess.TimeoutExpired):
+            self._run_exit_script("sys.exit(0)")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -503,7 +503,18 @@ def main():
             )
 
     exit_code = run_a_suite(args)
-    sys.exit(exit_code)
+
+    # run_a_suite has already printed every per-file result, the summary and
+    # the TIMINGS block, so nothing after this point is worth blocking on.
+    # sys.exit would unwind into interpreter shutdown, which joins lingering
+    # threads and reaps child processes -- either can wedge behind a test
+    # process that refuses to die and burn the rest of the job's budget with
+    # no further output, which reads as an infra hang rather than a finished
+    # suite. os._exit skips that, so flush the streams it won't.
+    sys.stdout.flush()
+    sys.stderr.flush()
+    # & 0xFF matches what sys.exit() reported: 0 stays 0, -1 becomes 255.
+    os._exit(exit_code & 0xFF)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`stage-b-test-2-gpu-large-amd (rocm724, linux-mi300-2gpu-sglang, 1)` in pr-test-amd-rocm720 run [32792996490](https://github.com/sgl-project/sglang/actions/runs/32792996490) ([job](https://github.com/sgl-project/sglang/actions/runs/32792996490/job/97638346505)) printed a clean pass:

```
Ran 2 tests in 440.651s

OK
```

at 05:06:50 UTC, then emitted nothing for the next 34 minutes until the runner was reclaimed at 05:41:07. No `End (i/N)` line, no summary, and no TIMINGS block ever followed.

A suite whose results are all reported has no reason to still be running. Because the stall produced no output, it was bucketed with three genuinely unrelated jobs that lost runner communication in the same 30-second window, and the whole group was written off as runner infrastructure noise. Left to run out, this shape consumes the file's entire `--timeout-per-file` budget (5400 s here, for a file whose tests take 440 s) and then reports `TIMEOUT`, which reads as "the tests are slow" rather than "the tests passed and the process would not exit".

## Modifications

Two paths could hold the runner open after the work was done:

- `run_with_timeout` abandons its worker on timeout while that worker is still blocked in the child's `wait()`. As a non-daemon thread it kept the interpreter alive at shutdown, so a child that survives `kill_process_tree` (for example stuck in D-state on a wedged GPU) stalled the runner indefinitely, after every result had already been printed.
- `main()` exited via `sys.exit`, unwinding into interpreter shutdown, which joins lingering threads and reaps child processes. Either can wedge behind a test process that refuses to die.

So the worker is daemonized and named, and `main()` exits deterministically once the exit code is known, flushing the streams `os._exit` will not. Exit statuses are unchanged: `0` stays `0`, and `-1` still surfaces as `255`.

Scope note: this bounds the damage and makes the failure fast and diagnosable. It does not claim to fix whatever kept that particular child from exiting after `OK` — with this in place, that case reports a real timeout against its own file instead of silently draining the job, which is what makes it debuggable in the first place.

## Accuracy Tests

Not applicable; no model or kernel code is touched.

## Speed Tests and Profiling

No inference path is affected. CI-side the effect is strictly positive: a suite that has reported all of its results can no longer occupy a runner.

New coverage in `test/registered/unit/utils/test_ci_runner_exit.py` (`base-a-test-cpu`) asserts both directions rather than just the happy path:

- a worker abandoned on timeout is a daemon, and the normal path still returns its value
- the exit path terminates promptly and keeps its buffered output
- a stuck non-daemon thread really does block `sys.exit`, so the promptness checks are not vacuous
- without the explicit flush, `os._exit` would drop the summary — covering the one regression this change could introduce

Verified locally against the modified module on a bare interpreter (that sandbox had no GPU or torch, so the ROCm job itself was not reproduced there):

```
PASS: returns value within budget
PASS: raises TimeoutError
PASS: exactly one abandoned worker (found 1)
PASS: abandoned worker is daemon
PASS: hard exit terminates (rc=0)
PASS: hard exit keeps buffered output 'summary line\n'
PASS: failure maps to 255 (rc=255)
PASS: sys.exit hangs (bug is real)
PASS: unflushed hard exit loses output (flush is load-bearing)
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (black, isort, and ruff with the repo's `F401,F821,UP037` selection all clean.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; CI harness only.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829117101](https://github.com/sgl-project/sglang/actions/runs/34829117101)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829116698](https://github.com/sgl-project/sglang/actions/runs/34829116698)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829116809](https://github.com/sgl-project/sglang/actions/runs/34829116809)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->