### PR TITLE
[AMD][CI] Restore MiniMax-M2.5 4-GPU MI35x nightly job

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -96,6 +96,8 @@ on:
           - nightly-8-gpu-mi35x-glm52-fp8-rocm720
           # 8-GPU GLM-5-MXFP4 (MI35x only)
           - nightly-8-gpu-mi35x-glm5-mxfp4-rocm720
+          # 4-GPU MiniMax-M2.5 (MI35x)
+          - nightly-4-gpu-mi35x-minimax-m25-rocm720
           # 4-GPU MiniMax-M3 MXFP8 (MI35x accuracy + performance)
           - nightly-4-gpu-mi35x-minimax-m3-rocm720
           # 8-GPU MiniMax-M2.7 (MI30x only)
@@ -2162,6 +2164,50 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
+  # 4-GPU MiniMax-M2.5 (MI35x)
+  # ==============================================================================
+
+  nightly-4-gpu-mi35x-minimax-m25-rocm720:
+    name: ${{ format('nightly-4-gpu-mi35x-minimax-m25 ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-4-gpu-mi35x-minimax-m25-rocm720,'))
+    runs-on: linux-mi35x-gpu-8
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker (${{ matrix.rocm_version }})
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+
+      - name: Accuracy Test MI35x ROCm 7.2 (4-GPU MiniMax-M2.5)
+        timeout-minutes: 120
+        run: |
+          > github_summary.md
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_USE_AITER=1 \
+            -e SGLANG_USE_AITER_UNIFIED_ATTN=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-4-gpu-mi35x-minimax-m25-tp4 --nightly --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  # ==============================================================================
   # 4-GPU MiniMax-M3 MXFP8 (MI35x accuracy + performance)
   # ==============================================================================
 
@@ -2383,6 +2429,8 @@ jobs:
       - nightly-8-gpu-mi35x-glm52-fp8-rocm720
       # 8-GPU GLM-5-MXFP4 (MI35x only)
       - nightly-8-gpu-mi35x-glm5-mxfp4-rocm720
+      # 4-GPU MiniMax-M2.5 (MI35x)
+      - nightly-4-gpu-mi35x-minimax-m25-rocm720
       # 4-GPU MiniMax-M3 MXFP8 (MI35x accuracy + performance)
       - nightly-4-gpu-mi35x-minimax-m3-rocm720
       # 8-GPU MiniMax-M2.7 (MI30x only)


### PR DESCRIPTION
## Motivation

[#36142](https://github.com/sgl-project/sglang/pull/36142) removed the `nightly-4-gpu-mi35x-minimax-m25-rocm720` job from the ROCm 7.2 nightly workflow, giving its MI35x slot to MiniMax-M3 (accuracy + perf). This restores the MiniMax-M2.5 job so both models get nightly MI35x coverage again, each in its own job.

## Modifications

**`.github/workflows/nightly-test-amd-rocm720.yml`**

- Re-added the `nightly-4-gpu-mi35x-minimax-m25-rocm720` job, its `job_select` dropdown entry, and its `check-all-jobs` `needs` entry, placed back in their original position (immediately before the MiniMax-M3 job).
- The restored job body is byte-for-byte identical to the version removed in #36142 — same accuracy suite (`nightly-amd-4-gpu-mi35x-minimax-m25-tp4`), same `aiter` + `aiter_unified_attn` env vars, same 120-minute timeout. That suite's test file (`test/registered/amd/accuracy/mi35x/test_minimax_m25_tp4_eval_mi35x.py`) was never deleted, so no test code changes are needed.
- Runs across the workflow's existing `rocm724` + `rocm720` matrix, same as every other job in the file.

## Accuracy Tests

No model, kernel, or runtime code is touched. This only re-registers an existing, previously-passing nightly job.

## Speed Tests and Profiling

Not applicable — no perf-affecting code changed.

Verified locally: the workflow YAML parses, the restored job block diffs byte-identical against the pre-#36142 version, and the referenced accuracy suite/test file are still present on `main`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32910672890](https://github.com/sgl-project/sglang/actions/runs/32910672890)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32910672380](https://github.com/sgl-project/sglang/actions/runs/32910672380)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->