### PR TITLE
[docs] Document nightly-test-amd-rocm720.yml in write-sglang-test skill

### DIFF
--- a/.claude/skills/write-sglang-test/SKILL.md
+++ b/.claude/skills/write-sglang-test/SKILL.md
@@ -113,7 +113,7 @@ A per-commit suite name is **generated** from registration metadata as `{stage}-
 
 #### Nightly
 
-Nightly suites are listed in `NIGHTLY_SUITES` in [`test/run_suite.py`](../../../test/run_suite.py). They run via `nightly-test-nvidia.yml`, `nightly-test-amd.yml`, and `nightly-test-npu.yml`, not `pr-test.yml`.
+Nightly suites are listed in `NIGHTLY_SUITES` in [`test/run_suite.py`](../../../test/run_suite.py). They run via `nightly-test-nvidia.yml`, `nightly-test-amd.yml`, `nightly-test-amd-rocm720.yml`, and `nightly-test-npu.yml`, not `pr-test.yml`.
 
 CUDA nightly suites are named `nightly-test-{runner_config}` — one per machine type, holding everything that runs nightly on it. There is no per-purpose split (kernel / eval / perf / precision all share their machine's suite); `auto_partition` splits the work. Examples:
 
@@ -121,13 +121,15 @@ CUDA nightly suites are named `nightly-test-{runner_config}` — one per machine
 - `nightly-test-2-gpu-large` (CUDA)
 - `nightly-test-8-gpu-h200` (CUDA)
 - `nightly-test-4-gpu-gb300` (CUDA)
-- `nightly-amd` (AMD)
-- `nightly-amd-8-gpu-mi35x` (AMD)
+- `nightly-amd` (AMD, `nightly-test-amd.yml`, ROCm 7.0)
+- `nightly-amd-8-gpu-mi35x` (AMD, `nightly-test-amd.yml`, ROCm 7.0)
 - `nightly-1-npu-a3` (NPU)
 - `nightly-2-npu-a3` (NPU)
 - `nightly-4-npu-a3` (NPU)
 - `nightly-8-npu-a3` (NPU)
 - `nightly-16-npu-a3` (NPU)
+
+**`nightly-test-amd-rocm720.yml` (ROCm 7.2)** is a separate workflow from `nightly-test-amd.yml` (ROCm 7.0) and uses a different convention: instead of one shared per-machine suite, most models get their own dedicated job and suite(s), e.g. `nightly-amd-4-gpu-mi35x-minimax-m3-tp4` (accuracy) and `nightly-perf-4-gpu-mi35x-minimax-m3` (perf) for MiniMax-M3. The whole workflow runs as a `matrix.rocm_version` over `[rocm724, rocm720]` image flavors, so every job/suite name is exercised on both regardless of the `-rocm720` suffix on the job id. For a model job that has both an accuracy and a perf suite, the common pattern is to run accuracy first, then perf in the same job with `continue-on-error: true` on the perf step — so a throughput blip doesn't fail a job whose accuracy passed (see the GLM-5.2-FP8, GLM-5-MXFP4, Kimi-K3, and MiniMax-M3 jobs). New/replaced model jobs must also be added to (or removed from) the `job_select` dropdown and the `check-all-jobs`/`needs` list in the same file.
 
 > **Note**: Multimodal diffusion uses `python/sglang/multimodal_gen/test/run_suite.py`, not `test/run_suite.py`.
 


### PR DESCRIPTION
## Motivation

[#36142](https://github.com/sgl-project/sglang/pull/36142) (merged) replaced MiniMax-M2.5 with MiniMax-M3 perf coverage in `nightly-test-amd-rocm720.yml`, the ROCm 7.2 nightly workflow. While working on it, I noticed the `write-sglang-test` skill's Nightly section only documented `nightly-test-nvidia.yml`, `nightly-test-amd.yml`, and `nightly-test-npu.yml` — `nightly-test-amd-rocm720.yml` (ROCm 7.2) wasn't mentioned at all, despite being a separate workflow with a different suite-naming convention from `nightly-test-amd.yml` (ROCm 7.0).

## Modifications

**`.claude/skills/write-sglang-test/SKILL.md`**

- Added `nightly-test-amd-rocm720.yml` to the list of workflows that run nightly suites.
- Annotated the existing `nightly-amd` / `nightly-amd-8-gpu-mi35x` examples as belonging to `nightly-test-amd.yml` (ROCm 7.0), to disambiguate from the new entry.
- Added a paragraph documenting `nightly-test-amd-rocm720.yml`'s convention: dedicated per-model jobs/suites (e.g. `nightly-amd-4-gpu-mi35x-minimax-m3-tp4` for accuracy, `nightly-perf-4-gpu-mi35x-minimax-m3` for perf) instead of one shared per-machine suite, a `matrix.rocm_version` over `[rocm724, rocm720]` image flavors, the accuracy-then-perf-with-`continue-on-error: true` pattern used by several MI35x model jobs, and the reminder that new/removed model jobs must also update the `job_select` dropdown and `check-all-jobs`/`needs` list.

No code changes — this only updates agent-facing documentation (`.claude/skills/`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829296811](https://github.com/sgl-project/sglang/actions/runs/34829296811)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829296304](https://github.com/sgl-project/sglang/actions/runs/34829296304)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->