### PR TITLE
[AMD][CI] Add DeepSeek-V4-Flash FP8 accuracy coverage on MI30x

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -59,11 +59,9 @@ on:
           # 8-GPU Grok2 (MI30x + MI35x)
           - nightly-8-gpu-grok2-rocm720
           - nightly-8-gpu-mi35x-grok2-rocm720
-          # 8-GPU DeepSeek-V3.x (MI30x)
-          - nightly-8-gpu-deepseek-v31-rocm720
+          # 8-GPU DeepSeek-V3.2 (MI30x)
           - nightly-8-gpu-deepseek-v32-rocm720
           - nightly-8-gpu-deepseek-v32-mtp-rocm720
-          - nightly-8-gpu-deepseek-v3-kv-fp8-rocm720
           # 8-GPU DeepSeek-V3.2 (MI35x)
           - nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720
           - nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp-rocm720
@@ -854,59 +852,12 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU DeepSeek-V3.x (MI30x)
+  # 8-GPU DeepSeek-V3.2 (MI30x)
+  #
+  # V3-0324 and V3.1 are no longer scheduled here: V3.2 covers the same MI30x
+  # paths (aiter MLA, EAGLE MTP, multithread weight load) on a current
+  # checkpoint, and DeepSeek-R1/V4 carry the MI35x side.
   # ==============================================================================
-
-  nightly-8-gpu-deepseek-v31-rocm720:
-    name: ${{ format('nightly-8-gpu-deepseek-v31 ({0}, linux-mi300-8gpu-sglang)', matrix.rocm_version) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
-    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v31-rocm720,'))
-    runs-on: linux-mi300-8gpu-sglang
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Setup docker (${{ matrix.rocm_version }})
-        run: |
-          touch github_summary.md
-          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-          ENABLE_CACHE_HOST: "1"
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
-
-      - name: Accuracy Test ROCm 7.2 (8-GPU DeepSeek-V3.1)
-        timeout-minutes: 120
-        run: |
-          > github_summary.md  # Clear summary file
-          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-            -e SGLANG_USE_AITER=1 \
-            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-deepseek-v31 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
-          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
-          exit ${TEST_EXIT_CODE:-0}
-
-      - name: Performance Test ROCm 7.2 (8-GPU DeepSeek-V3.1)
-        timeout-minutes: 300
-        continue-on-error: true
-        run: |
-          > github_summary.md  # Clear summary file
-          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-            -e SGLANG_USE_ROCM700A=1 \
-            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-deepseek-v31 --nightly --timeout-per-file 18000 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
-          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
-          exit ${TEST_EXIT_CODE:-0}
 
   nightly-8-gpu-deepseek-v32-rocm720:
     name: ${{ format('nightly-8-gpu-deepseek-v32 ({0}, linux-mi300-8gpu-sglang)', matrix.rocm_version) }}
@@ -1003,44 +954,6 @@ jobs:
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
             -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
             python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-deepseek-v32-mtp --nightly --timeout-per-file 7200 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
-          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
-          exit ${TEST_EXIT_CODE:-0}
-
-  nightly-8-gpu-deepseek-v3-kv-fp8-rocm720:
-    name: ${{ format('nightly-8-gpu-deepseek-v3-kv-fp8 ({0}, linux-mi300-8gpu-sglang)', matrix.rocm_version) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
-    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v3-kv-fp8-rocm720,'))
-    runs-on: linux-mi300-8gpu-sglang
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Setup docker (${{ matrix.rocm_version }})
-        run: |
-          touch github_summary.md
-          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-          ENABLE_CACHE_HOST: "1"
-
-      - name: Install dependencies
-        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
-
-      - name: DeepSeek-V3 KV FP8 Test ROCm 7.2 (8-GPU Basic + MTP)
-        timeout-minutes: 120
-        run: |
-          > github_summary.md  # Clear summary file
-          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-amd-8-gpu-deepseek-v3-kv-fp8 --nightly --timeout-per-file 3600 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
@@ -2346,11 +2259,9 @@ jobs:
       # 8-GPU Grok2 (MI30x + MI35x)
       - nightly-8-gpu-grok2-rocm720
       - nightly-8-gpu-mi35x-grok2-rocm720
-      # 8-GPU DeepSeek-V3.x (MI30x)
-      - nightly-8-gpu-deepseek-v31-rocm720
+      # 8-GPU DeepSeek-V3.2 (MI30x)
       - nightly-8-gpu-deepseek-v32-rocm720
       - nightly-8-gpu-deepseek-v32-mtp-rocm720
-      - nightly-8-gpu-deepseek-v3-kv-fp8-rocm720
       # 8-GPU DeepSeek-V3.2 (MI35x)
       - nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720
       - nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp-rocm720

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1384,9 +1384,10 @@ jobs:
   # below carry the perf numbers, and there is no gfx942 DSV4 baseline to
   # regress against until this job is green.
   #
-  # Deliberately absent from check-all-jobs: #36390 reports DSV4-Flash FP8
-  # output degrading with context length on MI300X, so this is expected red
-  # until that is fixed. Add it to the needs list once it passes.
+  # Deliberately absent from check-all-jobs for its first landing: the cookbook
+  # marks this recipe verified on MI300X but #36390 reports DSV4-Flash FP8
+  # degrading with context length there, and no CI run has ever settled which
+  # holds. Add it to the needs list once it has passed.
   # ==============================================================================
 
   nightly-8-gpu-deepseek-v4-flash-rocm720:
@@ -2327,7 +2328,7 @@ jobs:
       - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-tp4-rocm720
       - nightly-8-gpu-mi35x-deepseek-r1-hicache-rocm720
       # 8-GPU DeepSeek-V4 (MI35x). The MI30x nightly-8-gpu-deepseek-v4-flash job
-      # is excluded on purpose while #36390 is open; see its section comment.
+      # is excluded on purpose for its first landing; see its section comment.
       - nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-mtp-rocm720

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -73,7 +73,9 @@ on:
           - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-ar-fusion-rocm720
           - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-tp4-rocm720
           - nightly-8-gpu-mi35x-deepseek-r1-hicache-rocm720
-          # 8-GPU DeepSeek-V4 (MI35x only)
+          # 8-GPU DeepSeek-V4-Flash (MI30x)
+          - nightly-8-gpu-deepseek-v4-flash-rocm720
+          # 8-GPU DeepSeek-V4 (MI35x)
           - nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720
           - nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720
           - nightly-8-gpu-mi35x-deepseek-v4-pro-mtp-rocm720
@@ -1376,7 +1378,58 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
   # ==============================================================================
-  # 8-GPU DeepSeek-V4 (MI35x only)
+  # 8-GPU DeepSeek-V4-Flash (MI30x)
+  #
+  # Accuracy only. This is the first DSV4 coverage on gfx942; the MI35x jobs
+  # below carry the perf numbers, and there is no gfx942 DSV4 baseline to
+  # regress against until this job is green.
+  #
+  # Deliberately absent from check-all-jobs: #36390 reports DSV4-Flash FP8
+  # output degrading with context length on MI300X, so this is expected red
+  # until that is fixed. Add it to the needs list once it passes.
+  # ==============================================================================
+
+  nightly-8-gpu-deepseek-v4-flash-rocm720:
+    name: ${{ format('nightly-8-gpu-deepseek-v4-flash ({0}, linux-mi300-8gpu-sglang)', matrix.rocm_version) }}
+    strategy:
+      fail-fast: false
+      matrix:
+        rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-deepseek-v4-flash-rocm720,'))
+    runs-on: linux-mi300-8gpu-sglang
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Setup docker (${{ matrix.rocm_version }})
+        run: |
+          touch github_summary.md
+          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+
+      - name: Accuracy Test ROCm 7.2 (8-GPU DeepSeek-V4-Flash FP8)
+        timeout-minutes: 180
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-amd-accuracy-8-gpu-deepseek-v4-flash --nightly --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  # ==============================================================================
+  # 8-GPU DeepSeek-V4 (MI35x)
   # ==============================================================================
 
   nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720:
@@ -2273,7 +2326,8 @@ jobs:
       - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-ar-fusion-rocm720
       - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-tp4-rocm720
       - nightly-8-gpu-mi35x-deepseek-r1-hicache-rocm720
-      # 8-GPU DeepSeek-V4 (MI35x only)
+      # 8-GPU DeepSeek-V4 (MI35x). The MI30x nightly-8-gpu-deepseek-v4-flash job
+      # is excluded on purpose while #36390 is open; see its section comment.
       - nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-mtp-rocm720

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1380,14 +1380,9 @@ jobs:
   # ==============================================================================
   # 8-GPU DeepSeek-V4-Flash (MI30x)
   #
-  # Accuracy only. This is the first DSV4 coverage on gfx942; the MI35x jobs
-  # below carry the perf numbers, and there is no gfx942 DSV4 baseline to
-  # regress against until this job is green.
-  #
-  # Deliberately absent from check-all-jobs for its first landing: the cookbook
-  # marks this recipe verified on MI300X but #36390 reports DSV4-Flash FP8
-  # degrading with context length there, and no CI run has ever settled which
-  # holds. Add it to the needs list once it has passed.
+  # Accuracy only: the MI35x jobs below carry the DSV4 perf numbers, and gfx942
+  # has no DSV4 perf baseline to regress against yet. Runs the cookbook's
+  # MI300X Flash FP8 low-latency cell, so it also covers MLA + KV-FP8 on gfx942.
   # ==============================================================================
 
   nightly-8-gpu-deepseek-v4-flash-rocm720:
@@ -2327,8 +2322,9 @@ jobs:
       - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-ar-fusion-rocm720
       - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-tp4-rocm720
       - nightly-8-gpu-mi35x-deepseek-r1-hicache-rocm720
-      # 8-GPU DeepSeek-V4 (MI35x). The MI30x nightly-8-gpu-deepseek-v4-flash job
-      # is excluded on purpose for its first landing; see its section comment.
+      # 8-GPU DeepSeek-V4-Flash (MI30x)
+      - nightly-8-gpu-deepseek-v4-flash-rocm720
+      # 8-GPU DeepSeek-V4 (MI35x)
       - nightly-8-gpu-mi35x-deepseek-v4-flash-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-rocm720
       - nightly-8-gpu-mi35x-deepseek-v4-pro-mtp-rocm720

--- a/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
@@ -13,12 +13,16 @@ The cell as published could not load this checkpoint; the fix is in the
 cookbook PR and is the SGLANG_DSV4_FP4_EXPERTS entry below.
 
 Accuracy only: gfx942 has no DSV4 perf baseline to regress against yet, and the
-MI35x suite already carries the 8k/1k throughput numbers. The GSM8K threshold
-matches the MI35x FP8 test so the two architectures are comparable on the same
-eval.
+MI35x suite already carries the 8k/1k throughput numbers.
 
 Unlike the MI35x FP8 test this recipe also runs `--kv-cache-dtype fp8_e4m3` and
-EAGLE, so it is the gfx942 MLA + KV-FP8 signal as well.
+EAGLE, so it is the gfx942 MLA + KV-FP8 signal as well. That extra quantization
+is also why the threshold below is 0.90 rather than the 0.91 the MI35x FP8 test
+uses: measured 0.9174 and 0.9257 here, a spread wide enough that 0.91 would sit
+only ~2 sd off the mean and fail a good build roughly one night in forty. 0.90
+keeps ~2 points of headroom and still catches every regression worth gating on
+-- the failure modes this guards against (see #36390) collapse output entirely
+rather than shaving a point.
 
 Registry: nightly-amd-accuracy-8-gpu-deepseek-v4-flash suite
 """
@@ -128,7 +132,7 @@ class TestDeepseekV4FlashFp8Mi30x(CustomTestCase):
                 f"### test_gsm8k (deepseek-v4-flash-fp8, mi30x)\n"
                 f'{metrics["accuracy"]=:.3f}\n'
             )
-            self.assertGreater(metrics["accuracy"], 0.91)
+            self.assertGreater(metrics["accuracy"], 0.90)
 
 
 if __name__ == "__main__":

--- a/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
@@ -9,6 +9,9 @@ MI300X strategies it is the only TP-only one (balanced and high-throughput add
 DP attention and the prefill delayer), so it is the narrowest cell that still
 covers the gfx942 serving path. Keep this in sync with that cell.
 
+The cell as published could not load this checkpoint; the fix is in the
+cookbook PR and is the SGLANG_DSV4_FP4_EXPERTS entry below.
+
 Accuracy only: gfx942 has no DSV4 perf baseline to regress against yet, and the
 MI35x suite already carries the 8k/1k throughput numbers. The GSM8K threshold
 matches the MI35x FP8 test so the two architectures are comparable on the same
@@ -47,6 +50,12 @@ DEEPSEEK_V4_FP8_MODEL_PATH = os.environ.get(
 SERVER_LAUNCH_TIMEOUT = 3600
 
 ENV_VARS = {
+    # The routed experts of this checkpoint are FP8, not mxfp4-packed. The env
+    # default is mxfp4 and the auto-detect fallback reads the safetensors header
+    # from the local HF cache, so it returns None on a runner that has not pulled
+    # the weights yet and the wrong default wins -- weight load then dies on a
+    # factor-of-2 shape mismatch. Set it rather than depend on cache state.
+    "SGLANG_DSV4_FP4_EXPERTS": "0",
     "SGLANG_USE_ROCM700A": "0",
     "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
     "AITER_BF16_FP8_MOE_BOUND": "0",

--- a/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
@@ -2,19 +2,20 @@
 
 GSM8K few-shot accuracy for DeepSeek-V4-Flash FP8 on MI30x (gfx942) ROCm 7.2.
 
+The launch config is the cookbook's MI300X Flash FP8 low-latency single-node
+recipe, verbatim -- the one the docs tell users to run, marked `verified: true`
+in docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx. Of the three published
+MI300X strategies it is the only TP-only one (balanced and high-throughput add
+DP attention and the prefill delayer), so it is the narrowest cell that still
+covers the gfx942 serving path. Keep this in sync with that cell.
+
 Accuracy only: gfx942 has no DSV4 perf baseline to regress against yet, and the
 MI35x suite already carries the 8k/1k throughput numbers. The GSM8K threshold
-matches the MI35x FP8 test so the two architectures are directly comparable on
-the same eval.
+matches the MI35x FP8 test so the two architectures are comparable on the same
+eval.
 
-The launch config below is the gfx942 one from #36390, which is the only
-DSV4-Flash FP8 configuration observed to serve on 8x MI300X. It differs from the
-MI35x test in three places, each forced by gfx942:
-
-- ``aiter`` attention and DSA backends rather than ``dsv4``.
-- ``SGLANG_OPT_SWIGLU_CLAMP_FUSION=0``: the fusion dispatches a CUDA-only kernel.
-- ``--moe-runner-backend triton``: the aiter fused MoE returns different logprobs
-  for identical greedy requests on gfx942.
+Unlike the MI35x FP8 test this recipe also runs `--kv-cache-dtype fp8_e4m3` and
+EAGLE, so it is the gfx942 MLA + KV-FP8 signal as well.
 
 Registry: nightly-amd-accuracy-8-gpu-deepseek-v4-flash suite
 """
@@ -46,11 +47,9 @@ DEEPSEEK_V4_FP8_MODEL_PATH = os.environ.get(
 SERVER_LAUNCH_TIMEOUT = 3600
 
 ENV_VARS = {
-    "SGLANG_DEFAULT_THINKING": "1",
-    "SGLANG_DSV4_REASONING_EFFORT": "max",
-    "SGLANG_DSV4_FP4_EXPERTS": "false",
-    "SGLANG_USE_AITER": "1",
-    "SGLANG_OPT_SWIGLU_CLAMP_FUSION": "0",
+    "SGLANG_USE_ROCM700A": "0",
+    "SGLANG_HACK_FLASHMLA_BACKEND": "unified_kv_triton",
+    "AITER_BF16_FP8_MOE_BOUND": "0",
 }
 
 
@@ -68,26 +67,26 @@ class TestDeepseekV4FlashFp8Mi30x(CustomTestCase):
             "--tp",
             "8",
             "--attention-backend",
-            "aiter",
-            "--dsa-prefill-backend",
-            "aiter",
-            "--dsa-decode-backend",
-            "aiter",
-            "--moe-runner-backend",
-            "triton",
-            "--disable-radix-cache",
-            "--disable-cuda-graph",
-            "--max-running-requests",
+            "dsv4",
+            "--page-size",
             "256",
             "--mem-fraction-static",
-            "0.75",
+            "0.90",
+            "--swa-full-tokens-ratio",
+            "0.1",
+            "--disable-shared-experts-fusion",
+            "--kv-cache-dtype",
+            "fp8_e4m3",
             "--chunked-prefill-size",
             "8192",
-            "--disable-shared-experts-fusion",
-            "--tool-call-parser",
-            "deepseekv4",
-            "--reasoning-parser",
-            "deepseek-v4",
+            "--speculative-algorithm",
+            "EAGLE",
+            "--speculative-num-steps",
+            "3",
+            "--speculative-eagle-topk",
+            "1",
+            "--speculative-num-draft-tokens",
+            "4",
         ]
 
         cls.process = popen_launch_server(

--- a/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
+++ b/test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py
@@ -1,0 +1,127 @@
+"""MI30x DeepSeek-V4-Flash FP8 Accuracy Test (8-GPU)
+
+GSM8K few-shot accuracy for DeepSeek-V4-Flash FP8 on MI30x (gfx942) ROCm 7.2.
+
+Accuracy only: gfx942 has no DSV4 perf baseline to regress against yet, and the
+MI35x suite already carries the 8k/1k throughput numbers. The GSM8K threshold
+matches the MI35x FP8 test so the two architectures are directly comparable on
+the same eval.
+
+The launch config below is the gfx942 one from #36390, which is the only
+DSV4-Flash FP8 configuration observed to serve on 8x MI300X. It differs from the
+MI35x test in three places, each forced by gfx942:
+
+- ``aiter`` attention and DSA backends rather than ``dsv4``.
+- ``SGLANG_OPT_SWIGLU_CLAMP_FUSION=0``: the fusion dispatches a CUDA-only kernel.
+- ``--moe-runner-backend triton``: the aiter fused MoE returns different logprobs
+  for identical greedy requests on gfx942.
+
+Registry: nightly-amd-accuracy-8-gpu-deepseek-v4-flash suite
+"""
+
+import os
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.utils import kill_process_tree
+from sglang.test.ci.ci_register import register_amd_ci
+from sglang.test.few_shot_gsm8k import run_eval as run_eval_few_shot_gsm8k
+from sglang.test.test_utils import (
+    DEFAULT_URL_FOR_TEST,
+    CustomTestCase,
+    is_in_ci,
+    popen_launch_server,
+    write_github_step_summary,
+)
+
+register_amd_ci(
+    est_time=5400,
+    suite="nightly-amd-accuracy-8-gpu-deepseek-v4-flash",
+    nightly=True,
+)
+
+DEEPSEEK_V4_FP8_MODEL_PATH = os.environ.get(
+    "DEEPSEEK_V4_FP8_MODEL_PATH", "sgl-project/DeepSeek-V4-Flash-FP8"
+)
+SERVER_LAUNCH_TIMEOUT = 3600
+
+ENV_VARS = {
+    "SGLANG_DEFAULT_THINKING": "1",
+    "SGLANG_DSV4_REASONING_EFFORT": "max",
+    "SGLANG_DSV4_FP4_EXPERTS": "false",
+    "SGLANG_USE_AITER": "1",
+    "SGLANG_OPT_SWIGLU_CLAMP_FUSION": "0",
+}
+
+
+class TestDeepseekV4FlashFp8Mi30x(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.model = DEEPSEEK_V4_FP8_MODEL_PATH
+        cls.base_url = DEFAULT_URL_FOR_TEST
+
+        env = os.environ.copy()
+        env.update(ENV_VARS)
+
+        other_args = [
+            "--trust-remote-code",
+            "--tp",
+            "8",
+            "--attention-backend",
+            "aiter",
+            "--dsa-prefill-backend",
+            "aiter",
+            "--dsa-decode-backend",
+            "aiter",
+            "--moe-runner-backend",
+            "triton",
+            "--disable-radix-cache",
+            "--disable-cuda-graph",
+            "--max-running-requests",
+            "256",
+            "--mem-fraction-static",
+            "0.75",
+            "--chunked-prefill-size",
+            "8192",
+            "--disable-shared-experts-fusion",
+            "--tool-call-parser",
+            "deepseekv4",
+            "--reasoning-parser",
+            "deepseek-v4",
+        ]
+
+        cls.process = popen_launch_server(
+            cls.model,
+            cls.base_url,
+            timeout=SERVER_LAUNCH_TIMEOUT,
+            other_args=other_args,
+            env=env,
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        kill_process_tree(cls.process.pid)
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            num_shots=8,
+            data_path=None,
+            num_questions=1319,
+            parallel=1319,
+            max_new_tokens=512,
+            host="http://127.0.0.1",
+            port=int(self.base_url.split(":")[-1]),
+        )
+        metrics = run_eval_few_shot_gsm8k(args)
+        print(f"{metrics=}")
+
+        if is_in_ci():
+            write_github_step_summary(
+                f"### test_gsm8k (deepseek-v4-flash-fp8, mi30x)\n"
+                f'{metrics["accuracy"]=:.3f}\n'
+            )
+            self.assertGreater(metrics["accuracy"], 0.91)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/run_suite.py
+++ b/test/run_suite.py
@@ -147,6 +147,7 @@ NIGHTLY_SUITES = {
         "nightly-amd-4-gpu",
         "nightly-amd-8-gpu",
         "nightly-amd-vlm",
+        "nightly-amd-accuracy-8-gpu-deepseek-v4-flash",
         "nightly-amd-8-gpu-mi35x-deepseek-v4-flash",
         # MI35x 8-GPU suite (different model configs)
         "nightly-amd-8-gpu-mi35x",


### PR DESCRIPTION
MI30x only. The V3.x drop was split out of #36388, which now carries only its MI35x half.

## Motivation

DeepSeek-V4 has no gfx942 coverage: every DSV4 job in the repo runs on `linux-mi35x-gpu-8`, and this workflow's V4 section was literally commented `MI35x only`. Meanwhile the cookbook publishes three `verified: true` MI300X Flash FP8 cells, so the docs call MI300X a supported DSV4 target while CI has never once run DSV4 there.

Separately, `nightly-8-gpu-deepseek-v31` and `nightly-8-gpu-deepseek-v3-kv-fp8` do not test what their names say — both serve `deepseek-ai/DeepSeek-V3-0324` for accuracy, and only the v31 perf step serves V3.1. Every MI30x path they exercise (aiter MLA, EAGLE MTP, `enable_multithread_load`, bs=1 `send_one`) is covered by the retained V3.2 jobs on a current checkpoint.

Together this is one trade: stop paying 32 GPU-h/night for two jobs on a superseded checkpoint, and spend a fraction of it on the model with no gfx942 signal at all.

## Modifications

**1. New job `nightly-8-gpu-deepseek-v4-flash` on `linux-mi300-8gpu-sglang`**, running the new `test/registered/amd/test_deepseek_v4_flash_fp8_mi30x.py` via the new `nightly-amd-accuracy-8-gpu-deepseek-v4-flash` suite.

The launch config is the cookbook's `mi300x | flash | fp8 | low-latency | single` cell verbatim — the only TP-only MI300X strategy published, so the narrowest cell that still covers the gfx942 serving path. Accuracy only: gfx942 has no DSV4 perf baseline to regress against, and the MI35x jobs carry the throughput numbers. GSM8K uses the same 8-shot / 1319-question eval as the MI35x FP8 test, with a `> 0.90` floor. Blocking in `check-all-jobs`.

**Depends on #36405**: the cell as published omits `SGLANG_DSV4_FP4_EXPERTS=0` and cannot load its own checkpoint on a cold cache. The test sets it, and the set-equality check below is stated against the cell as fixed there.

**2. Dropped `nightly-8-gpu-deepseek-v31-rocm720` and `nightly-8-gpu-deepseek-v3-kv-fp8-rocm720`**, with their `job_select` options and `check-all-jobs` needs. All four test files stay registered, so the three suites remain reachable from `workflow_dispatch` — the same outcome #34761 documented for `nightly-amd-accuracy-8-gpu-grok1-fp8`.

MLA + KV-FP8 on gfx942 stays gated rather than lost: the cookbook recipe runs `--kv-cache-dtype fp8_e4m3` and the new job blocks, so dropping the V3 KV-FP8 job leaves no gap, on a current model instead of V3-0324. The ROCm 7.0 nightly still schedules both dropped jobs and is untouched here.

**On #36390.** That issue reports DSV4-Flash FP8 degrading with context length on MI300X. It runs `--attention-backend aiter` with `--dsa-{prefill,decode}-backend aiter`; this recipe runs `--attention-backend dsv4`. The pass below does not contradict the report — it localizes it to the aiter path, which no CI job covers on any architecture. A follow-up job for that path is a reasonable next step and is not attempted here.

## Accuracy Tests

Two runs on 8x MI300X, both dispatched with `rocm_version=rocm720` and `continue_on_error=false` so a failure is loud, both green:

| Run | GSM8K | invalid |
|---|---|---|
| [32918680921](https://github.com/sgl-project/sglang/actions/runs/32918680921) | 0.9174 | 0.000 |
| [33023346555](https://github.com/sgl-project/sglang/actions/runs/33023346555) | 0.9257 | 0.000 |

For reference, the MI35x DSV4-Flash suite spans 0.9189–0.9310 (mean 0.9251) over its last three nightlies, so MI300X sits inside the same band.

**On the 0.90 floor.** The first revision used 0.91, inherited from the MI35x FP8 test for comparability, on one observation. The second run showed the two MI300X values span 0.83 points — wider than the MI35x per-test run-to-run sd of ~0.0019, which is expected given this recipe adds KV-FP8 and EAGLE. At that spread 0.91 sits ~2 sd below the mean, about one spurious failure per forty nights on a job that blocks `check-all-jobs`; 0.90 is >3.5 sd out under either sd estimate. It does not weaken the gate in any way that matters — the failure modes this exists to catch (see #36390) collapse output entirely rather than costing a point of GSM8K. Comparability with MI35x is preserved in the measured numbers rather than in a shared threshold.

Static validation:

- `pre-commit` passes, including `check for duplicate workflow job names`, `validate registered test CI registries` and `check yaml`
- the test's env and flags are set-equal to the cookbook cell as fixed by #36405 (checked by parsing both files)
- job set delta against `main` is exactly `-nightly-8-gpu-deepseek-v31-rocm720`, `-nightly-8-gpu-deepseek-v3-kv-fp8-rocm720`, `+nightly-8-gpu-deepseek-v4-flash-rocm720` (46 jobs to 45); no dangling `job_select` option or `check-all-jobs` need, and no removed job referenced anywhere in the repo
- the new suite resolves to exactly the one new file, and the dropped jobs' three suites still resolve to their test files
- trial-merged with #36388: no conflict
- the diff is MI30x-only; every MI35x job is byte-identical to `main`

## Speed Tests and Profiling

Measured from [run 32757901075](https://github.com/sgl-project/sglang/actions/runs/32757901075), summed over both image flavors: dropping `nightly-8-gpu-deepseek-v31` frees 17.4 GPU-h/night and `nightly-8-gpu-deepseek-v3-kv-fp8` frees 14.7. The new job is a single 8-GPU accuracy step that took 42 min on its first run. Net reduction, and 2 fewer 8-GPU MI30x job slots.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation <!-- N/A -->
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33026136250](https://github.com/sgl-project/sglang/actions/runs/33026136250)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33026136082](https://github.com/sgl-project/sglang/actions/runs/33026136082)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33026135973](https://github.com/sgl-project/sglang/actions/runs/33026135973)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->