### PR TITLE
[Refactor] server_args.py: organize constants, dispatcher, and deprecations

### DIFF
--- a/python/sglang/srt/arg_groups/arg_utils.py
+++ b/python/sglang/srt/arg_groups/arg_utils.py
@@ -58,6 +58,22 @@ from typing import (
 A = Annotated
 
 
+class Choices(list):
+    """A CLI choice list that out-of-tree code may extend.
+
+    ``Arg(choices=...)`` and argparse both hold this object rather than a copy,
+    so an append made before the parser is built is visible to it. A plain
+    ``list`` would work identically; the type exists so that a module-level
+    choice list reads as an extension point, and so its adder can live on the
+    line below it instead of in a second block that has to be kept in order.
+    """
+
+    def add(self, choice: str) -> None:
+        """Preserve set-like ``.add(choice)`` compatibility."""
+        if choice not in self:
+            self.append(choice)
+
+
 @dataclasses.dataclass(frozen=True)
 class Arg:
     """CLI argument metadata attached to a dataclass field via ``Annotated``."""

--- a/python/sglang/srt/arg_groups/encoder_transfer_hook.py
+++ b/python/sglang/srt/arg_groups/encoder_transfer_hook.py
@@ -1,0 +1,11 @@
+from __future__ import annotations
+
+
+def resolve_encoder_transfer_backend(
+    backend: str, model_arch: str, tp_size: int
+) -> str:
+    if backend != "auto":
+        return backend
+    if model_arch == "KimiK3ForConditionalGeneration" and tp_size > 1:
+        return "zmq_to_tokenizer"
+    return "zmq_to_scheduler"

--- a/python/sglang/srt/arg_groups/minimax_m3_hook.py
+++ b/python/sglang/srt/arg_groups/minimax_m3_hook.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from typing import Any
+
+
+def m3_fp8_attn_gemm_enabled(args: Any) -> bool:
+    """Whether MiniMax-M3 attention GEMMs run in fp8 (no opt-in flag; active
+    whenever possible): fp8_e4m3 main + index KV caches, fp8-cast q, fp8
+    sparse/MSA kernels, with dense layers on trtllm_mha's fp8-q path. Needs
+    kv_cache_dtype fp8_e4m3 (e5m2 would silently mis-dispatch fmha_sm100's
+    e4m3 kernel), the trtllm_mha backend (the only dense backend with fp8-q
+    GEMMs), and SM100 (MSA fp8 variants and trtllm-gen fp8 dense kernels are
+    sm100-only). SGLANG_DISABLE_M3_FP8_ATTN_GEMM=1 is the kill switch:
+    it forces the pre-fp8 numerics (bf16 indexer + widening sparse path,
+    bf16 q) without having to move off trtllm_mha.
+    """
+    from sglang.srt.environ import envs
+    from sglang.srt.utils.common import is_sm100_supported
+
+    return (
+        args.kv_cache_dtype == "fp8_e4m3"
+        and args.attention_backend == "trtllm_mha"
+        and is_sm100_supported()
+        and not envs.SGLANG_DISABLE_M3_FP8_ATTN_GEMM.get()
+    )

--- a/python/sglang/srt/layers/attention/minimax_sparse_backend.py
+++ b/python/sglang/srt/layers/attention/minimax_sparse_backend.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 
 import torch
 
+from sglang.srt.arg_groups.minimax_m3_hook import m3_fp8_attn_gemm_enabled
 from sglang.srt.arg_groups.overrides import resolving_view
 from sglang.srt.configs.model_config import (
     get_minimax_sparse_attention_config,
@@ -21,7 +22,6 @@ from sglang.srt.layers.attention.base_attn_backend import (
 )
 from sglang.srt.mem_cache.memory_pool import MiniMaxSparseKVPool
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.server_args import m3_fp8_attn_gemm_enabled
 from sglang.srt.utils import is_npu
 
 if is_npu():

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1503,7 +1503,7 @@ class KVCacheConfigurator:
         return token_to_kv_pool
 
     def _build_minimax_sparse_kv_pool(self, *, max_total_num_tokens: int) -> KVCache:
-        from sglang.srt.server_args import m3_fp8_attn_gemm_enabled
+        from sglang.srt.arg_groups.minimax_m3_hook import m3_fp8_attn_gemm_enabled
 
         _hf_config = self.model_config.hf_config
         sparse_cfg = get_minimax_sparse_attention_config(_hf_config)

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -11,7 +11,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-"""The arguments of the server."""
+"""Server argument declarations, resolution, and CLI registration.
+
+Keep this file in the following top-level order:
+
+1. Imports and the module logger.
+2. Public extension-point choice lists, with each legacy ``add_*`` alias
+   immediately below the ``Choices`` declaration it extends.
+3. Shared (non-extensible) choice lists, scalar defaults, and deprecated
+   aliases. A choice list used by only one field belongs inline in that field.
+4. ``ServerArgs``: fields first, then resolution/validation helpers, then CLI
+   registration and small query helpers. New resolution steps are appended at
+   the end of ``_run_resolution_pipeline``, immediately before resolution is
+   marked complete, unless an earlier dependency is documented explicitly.
+5. Module-level ``ServerArgs`` construction/runtime shims.
+6. Networking constants and ``PortArgs``.
+
+Model- or vendor-specific utilities belong in ``sglang.srt.arg_groups`` (or
+their owning subsystem), not before ``ServerArgs`` in this module.
+"""
 
 from __future__ import annotations
 
@@ -33,7 +51,13 @@ import uuid
 from typing import Any, Callable, Dict, List, Literal, Optional, Union
 
 from sglang.kernels.ops.kv_canary.consts import RealKvHashMode
-from sglang.srt.arg_groups.arg_utils import NS, A, Arg, add_cli_args_from_dataclass
+from sglang.srt.arg_groups.arg_utils import (
+    NS,
+    A,
+    Arg,
+    Choices,
+    add_cli_args_from_dataclass,
+)
 from sglang.srt.arg_groups.argparse_actions import (
     DeprecatedAction,
     DeprecatedAliasStoreAction,
@@ -110,189 +134,311 @@ from sglang.utils import is_in_ci
 
 logger = logging.getLogger(__name__)
 
-# Define constants
-DEFAULT_UVICORN_ACCESS_LOG_EXCLUDE_PREFIXES = ()
+# --------------------------------------------------------------------------
+# Extension points: out-of-tree platforms and plugins extend these lists
+# before ServerArgs is constructed. Each list owns its adder on the line
+# below it. A list with no adder is not an extension point -- inline it into
+# the field's Arg(choices=...) instead of hoisting it here.
+# --------------------------------------------------------------------------
 
-SAMPLING_BACKEND_CHOICES = {"flashinfer", "pytorch", "ascend"}
-if envs.SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE.get():
-    SAMPLING_BACKEND_CHOICES.add("token_oracle")
+# --- Model loading and quantization ---
 
-LOAD_FORMAT_CHOICES = [
-    "auto",
-    "pt",
-    "safetensors",
-    "npcache",
-    "dummy",
-    "sharded_state",
-    "presharded",
-    "gguf",
-    # Experimental and intentionally narrow: expert_pack is validated only for
-    # DeepSeek-V4-Flash-0731 MXFP4 GGUF (MXFP4 experts, FP8 dense weights)
-    # and KIMI-K3-MXP4-DERISKED-Q2_K-*.gguf (Q2_K gate/up, Q3_K down weights):
-    # https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF
-    # https://huggingface.co/Blackfrost-AI/KIMI-K3-Q2_K-GGUF-ABLITERATED
-    "expert_pack",
-    "bitsandbytes",
-    "mistral",
-    "layered",
-    "flash_rl",
-    "remote",
-    "remote_instance",
-    "fastsafetensors",
-    "private",
-    "runai_streamer",
-]
-# NOTE: LoadFormat.IPC_CACHE intentionally has no public --load-format choice.
-# It is an internal dispatch format set automatically by ModelRunner when the
-# weight cache is enabled (weight_cache_mode != "off"). Exposing it as a CLI
-# choice let users create contradictory combos (see _handle_load_format).
+LOAD_FORMAT_CHOICES = Choices(
+    [
+        "auto",
+        "pt",
+        "safetensors",
+        "npcache",
+        "dummy",
+        "sharded_state",
+        "presharded",
+        "gguf",
+        # Experimental and intentionally narrow: expert_pack is validated only for
+        # DeepSeek-V4-Flash-0731 MXFP4 GGUF (MXFP4 experts, FP8 dense weights)
+        # and KIMI-K3-MXP4-DERISKED-Q2_K-*.gguf (Q2_K gate/up, Q3_K down weights):
+        # https://huggingface.co/unsloth/DeepSeek-V4-Flash-0731-GGUF
+        # https://huggingface.co/Blackfrost-AI/KIMI-K3-Q2_K-GGUF-ABLITERATED
+        "expert_pack",
+        "bitsandbytes",
+        "mistral",
+        "layered",
+        "flash_rl",
+        "remote",
+        "remote_instance",
+        "fastsafetensors",
+        "private",
+        "runai_streamer",
+    ]
+)
+add_load_format_choices = LOAD_FORMAT_CHOICES.extend
+# LoadFormat.IPC_CACHE intentionally has no public --load-format choice. It is
+# an internal dispatch format set automatically by ModelRunner when the weight
+# cache is enabled (weight_cache_mode != "off"). Exposing it as a CLI choice
+# let users create contradictory combos (see _handle_load_format).
 
 # TODO: this list should likely contain only methods that support online quantization, or that support using custom quantization classes compatible with a given `quant_method` in config.json.
 # Some of the choices here do NOT support online quantization.
-QUANTIZATION_CHOICES = [
-    "awq",
-    "fp8",  # MOE + linear online quantization.
-    "mxfp8",  # MOE + linear online quantization.
-    "gptq",
-    "marlin",
-    "gptq_marlin",
-    "awq_marlin",
-    "bitsandbytes",
-    "gguf",
-    # Modelopt has some online quantization support through ModelOptModelLoader.
-    "modelopt",
-    "modelopt_fp8",
-    "modelopt_fp4",
-    "nvfp4_online",
-    "modelopt_mixed",
-    "petit_nvfp4",
-    "w8a8_int8",  # mentioned in quantization.md documentation, supporting compressed-tensors quant_method.
-    "w8a8_fp8",  # mentioned in quantization.md documentation, supporting compressed-tensors quant_method.
-    "moe_wna16",  # custom loading logic for gptq/awq checkpoints (likely untested/unused)
-    "w4afp8",
-    "mxfp4",  # MOE-only.
-    "auto-round",
-    "auto-round-int8",
-    "compressed-tensors",  # for Ktransformers
-    "modelslim",  # for NPU
-    "mxfp_w4a8",  # for NPU W4A8 (MXFP4 weights + MXFP8 activations)
-    "quark",  # AMD Quark quantizer (FP8 / MXFP4 / Int4FP8 etc.)
-    "quark_int4fp8_moe",
-    "quark_mxfp4",  # Online MOE + linear quantization (incl. NVFP4 -> MXFP4 requantization).
-    # Apple Silicon MLX backend — on-the-fly quantization of fp16 weights at load
-    # time via mlx.nn.quantize. Only takes effect when SGLANG_USE_MLX=1.
-    "mlx_q4",  # 4 bits, group_size=64 (mlx-community default)
-    "mlx_q8",  # 8 bits, group_size=64
-    "unquant",
-    "humming",
-]
+QUANTIZATION_CHOICES = Choices(
+    [
+        "awq",
+        "fp8",  # MOE + linear online quantization.
+        "mxfp8",  # MOE + linear online quantization.
+        "gptq",
+        "marlin",
+        "gptq_marlin",
+        "awq_marlin",
+        "bitsandbytes",
+        "gguf",
+        # Modelopt has some online quantization support through ModelOptModelLoader.
+        "modelopt",
+        "modelopt_fp8",
+        "modelopt_fp4",
+        "nvfp4_online",
+        "modelopt_mixed",
+        "petit_nvfp4",
+        "w8a8_int8",  # mentioned in quantization.md documentation, supporting compressed-tensors quant_method.
+        "w8a8_fp8",  # mentioned in quantization.md documentation, supporting compressed-tensors quant_method.
+        "moe_wna16",  # custom loading logic for gptq/awq checkpoints (likely untested/unused)
+        "w4afp8",
+        "mxfp4",  # MOE-only.
+        "auto-round",
+        "auto-round-int8",
+        "compressed-tensors",  # for Ktransformers
+        "modelslim",  # for NPU
+        "mxfp_w4a8",  # for NPU W4A8 (MXFP4 weights + MXFP8 activations)
+        "quark",  # AMD Quark quantizer (FP8 / MXFP4 / Int4FP8 etc.)
+        "quark_int4fp8_moe",
+        "quark_mxfp4",  # Online MOE + linear quantization (incl. NVFP4 -> MXFP4 requantization).
+        # Apple Silicon MLX backend — on-the-fly quantization of fp16 weights at load
+        # time via mlx.nn.quantize. Only takes effect when SGLANG_USE_MLX=1.
+        "mlx_q4",  # 4 bits, group_size=64 (mlx-community default)
+        "mlx_q8",  # 8 bits, group_size=64
+        "unquant",
+        "humming",
+    ]
+)
+add_quantization_method_choices = QUANTIZATION_CHOICES.extend
 
-ATTENTION_BACKEND_CHOICES = [
-    # Common
-    "triton",
-    "torch_native",
-    "flex_attention",
-    "dsa",
-    "nsa",  # Deprecated alias for "dsa"
-    "dsv4",
-    "compressed",  # Deprecated alias for "dsv4"
-    # NVIDIA specific
-    "cutlass_mla",
-    "fa3",
-    "fa4",
-    "flashinfer",
-    "flashmla",
-    "trtllm_mla",
-    "cutedsl_mla",
-    "tokenspeed_mla",
-    "trtllm_mha",
-    "dual_chunk_flash_attn",
-    "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), Hopper (SM90) only, requires --page-size 64
-    "minicpm_flashattn",
-    "minicpm_flashinfer",
-    # AMD specific
-    "aiter",
-    "wave",
-    # Other platforms
-    "intel_amx",
-    "ascend",
-    "intel_xpu",
-]
+# --- Attention backends ---
 
-# trtllm_mha is valid for decode-only dense-MQA drafts. DFLASH rejects it
-# earlier when its per-layer attention requirements are not met.
-DRAFT_ATTENTION_BACKEND_CHOICES = [
-    "flashinfer",
-    "fa3",
-    "fa4",
-    "triton",
-    "ascend",
-    "trtllm_mha",
-]
+ATTENTION_BACKEND_CHOICES = Choices(
+    [
+        # Common
+        "triton",
+        "torch_native",
+        "flex_attention",
+        "dsa",
+        "nsa",  # Deprecated alias for "dsa"
+        "dsv4",
+        "compressed",  # Deprecated alias for "dsv4"
+        # NVIDIA specific
+        "cutlass_mla",
+        "fa3",
+        "fa4",
+        "flashinfer",
+        "flashmla",
+        "trtllm_mla",
+        "cutedsl_mla",
+        "tokenspeed_mla",
+        "trtllm_mha",
+        "dual_chunk_flash_attn",
+        "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), Hopper (SM90) only, requires --page-size 64
+        "minicpm_flashattn",
+        "minicpm_flashinfer",
+        # AMD specific
+        "aiter",
+        "wave",
+        # Other platforms
+        "intel_amx",
+        "ascend",
+        "intel_xpu",
+    ]
+)
+add_attention_backend_choices = ATTENTION_BACKEND_CHOICES.extend
 
 # Attention backends whose kernels read the chunked prefix-cache layout.
 # Out-of-tree platforms may extend this list (via
 # add_chunked_prefix_cache_attention_backend) before ServerArgs construction;
 # the chunked-prefix gate is evaluated during resolution.
-CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS = [
-    "flashinfer",
+CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS = Choices(
+    [
+        "flashinfer",
+        "fa3",
+        "fa4",
+        "flashmla",
+        "cutedsl_mla",
+        "cutlass_mla",
+        "trtllm_mla",
+        "tokenspeed_mla",
+    ]
+)
+add_chunked_prefix_cache_attention_backend = (
+    CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS.append
+)
+
+DETERMINISTIC_ATTENTION_BACKEND_CHOICES = Choices(
+    [
+        "ascend",
+        "fa3",
+        "fa4",
+        "flashinfer",
+        "intel_xpu",
+        "triton",
+    ]
+)
+add_deterministic_attention_backend_choices = (
+    DETERMINISTIC_ATTENTION_BACKEND_CHOICES.extend
+)
+
+# trtllm_mha is valid for decode-only dense-MQA drafts. DFLASH rejects it
+# earlier when its per-layer attention requirements are not met.
+DRAFT_ATTENTION_BACKEND_CHOICES = Choices(
+    [
+        "flashinfer",
+        "fa3",
+        "fa4",
+        "triton",
+        "ascend",
+        "trtllm_mha",
+    ]
+)
+add_draft_attention_backend_choices = DRAFT_ATTENTION_BACKEND_CHOICES.extend
+
+RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND = Choices(
+    ["ascend", "fa3", "fa4", "triton"]
+)
+add_radix_supported_deterministic_attention_backend_choices = (
+    RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND.extend
+)
+
+# --- Linear attention ---
+
+LINEAR_ATTN_KERNEL_BACKEND_CHOICES = Choices(
+    [
+        "triton",
+        "cutedsl",
+        "flashinfer",
+        "flashkda",
+        "nvidia_kda",
+        "ptx_kda",
+        "helion",
+        "intel_xpu",
+    ]
+)
+add_linear_attn_kernel_backend_choices = LINEAR_ATTN_KERNEL_BACKEND_CHOICES.extend
+
+# --- MoE and GEMM runners ---
+
+FP4_GEMM_RUNNER_BACKEND_CHOICES = Choices(
+    [
+        "auto",
+        "flashinfer_cudnn",
+        "flashinfer_cutedsl",
+        "flashinfer_cutlass",
+        "flashinfer_trtllm",
+        "marlin",
+    ]
+)
+add_fp4_gemm_runner_backend_choices = FP4_GEMM_RUNNER_BACKEND_CHOICES.extend
+
+FP8_GEMM_RUNNER_BACKEND_CHOICES = Choices(
+    [
+        "auto",
+        "deep_gemm",
+        "flashinfer_trtllm",
+        "flashinfer_cutlass",
+        "flashinfer_deepgemm",
+        "flashinfer_cutedsl",
+        "cutlass",
+        "triton",
+        "aiter",
+    ]
+)
+add_fp8_gemm_runner_backend_choices = FP8_GEMM_RUNNER_BACKEND_CHOICES.extend
+
+MOE_RUNNER_BACKEND_CHOICES = Choices(
+    [
+        "auto",
+        "deep_gemm",
+        "triton",
+        "triton_kernel",
+        "flashinfer_trtllm",
+        "experimental_sgl_trtllm",
+        "flashinfer_trtllm_routed",
+        "flashinfer_cutlass",
+        "flashinfer_mxfp4",
+        "flashinfer_cutedsl",
+        "cutlass",
+        "aiter",
+        "marlin",
+        "humming",
+        "experimental_sgl_marlin",
+        "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), FP8 MoE on Hopper (SM90) only
+        "megamoe",
+    ]
+)
+add_moe_runner_backend_choices = MOE_RUNNER_BACKEND_CHOICES.extend
+
+MXFP8_MOE_RUNNER_BACKEND_CHOICES = Choices(
+    [
+        "cutlass",
+        "deep_gemm",
+        "flashinfer_trtllm",
+        "flashinfer_trtllm_routed",
+    ]
+)
+add_mxfp8_moe_runner_backend_choices = MXFP8_MOE_RUNNER_BACKEND_CHOICES.extend
+
+# --- Cache and scheduling policy ---
+
+RADIX_EVICTION_POLICY_CHOICES = Choices(["lru", "lfu", "slru", "priority"])
+add_radix_eviction_policy_choices = RADIX_EVICTION_POLICY_CHOICES.extend
+
+# --- Sampling and grammar ---
+
+GRAMMAR_BACKEND_CHOICES = Choices(["xgrammar", "outlines", "llguidance", "none"])
+add_grammar_backend_choices = GRAMMAR_BACKEND_CHOICES.extend
+
+SAMPLING_BACKEND_CHOICES = Choices(["flashinfer", "pytorch", "ascend"])
+add_sampling_backend_choices = SAMPLING_BACKEND_CHOICES.extend
+
+# --- Transport ---
+
+DISAGG_TRANSFER_BACKEND_CHOICES = Choices(
+    [
+        "mooncake",
+        "nixl",
+        "ascend",
+        "fake",
+        "mori",
+        "mooncake_tcp",
+    ]
+)
+add_disagg_transfer_backend_choices = DISAGG_TRANSFER_BACKEND_CHOICES.extend
+
+# --- Reinforcement learning ---
+
+RL_ON_POLICY_TARGET_CHOICES = Choices(["fsdp"])
+add_rl_on_policy_target_choices = RL_ON_POLICY_TARGET_CHOICES.extend
+
+# --------------------------------------------------------------------------
+# Shared choice lists. Referenced by more than one field, so they keep a
+# name -- but nothing extends them, so they get no adder.
+# --------------------------------------------------------------------------
+
+DSA_CHOICES = [
+    "flashmla_sparse",
+    "flashmla_sparse_q8",
+    "flashmla_kv",
+    "flashmla_auto",
+    "flashinfer_sparse_mla",
     "fa3",
-    "fa4",
-    "flashmla",
-    "cutedsl_mla",
-    "cutlass_mla",
-    "trtllm_mla",
-    "tokenspeed_mla",
-]
-
-DETERMINISTIC_ATTENTION_BACKEND_CHOICES = [
-    "ascend",
-    "fa3",
-    "fa4",
-    "flashinfer",
-    "intel_xpu",
-    "triton",
-]
-
-RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND = ["ascend", "fa3", "fa4", "triton"]
-
-DISAGG_TRANSFER_BACKEND_CHOICES = [
-    "mooncake",
-    "nixl",
-    "ascend",
-    "fake",
-    "mori",
-    "mooncake_tcp",
-]
-
-GRAMMAR_BACKEND_CHOICES = ["xgrammar", "outlines", "llguidance", "none"]
-
-# Placeholder token inserted between items in Multi-Item Scoring sequences:
-# query<delim>item1<delim>item2<delim>... Positions are pre-computed from item
-# lengths (multi_item_delimiter_indices); the token only exists for FlashInfer
-# attention mask compat and logprob column indexing. Will be removed once the
-# attention backend supports position-only MIS.
-MIS_DELIMITER_TOKEN_ID = 9999
-
-MOE_RUNNER_BACKEND_CHOICES = [
-    "auto",
-    "deep_gemm",
-    "triton",
-    "triton_kernel",
-    "flashinfer_trtllm",
-    "experimental_sgl_trtllm",
-    "flashinfer_trtllm_routed",
-    "flashinfer_cutlass",
-    "flashinfer_mxfp4",
-    "flashinfer_cutedsl",
-    "cutlass",
+    "tilelang",
     "aiter",
-    "marlin",
-    "humming",
-    "experimental_sgl_marlin",
-    "hpc_ops",  # HPC-Ops (https://github.com/Tencent/hpc-ops), FP8 MoE on Hopper (SM90) only
-    "megamoe",
+    "trtllm",
 ]
+
+DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
 
 MOE_A2A_BACKEND_CHOICES = [
     "none",
@@ -307,179 +453,34 @@ MOE_A2A_BACKEND_CHOICES = [
     "ascend_tp",
 ]
 
-MXFP8_MOE_RUNNER_BACKEND_CHOICES = [
-    "cutlass",
-    "deep_gemm",
-    "flashinfer_trtllm",
-    "flashinfer_trtllm_routed",
-]
+# --------------------------------------------------------------------------
+# Scalar defaults and sentinels.
+# --------------------------------------------------------------------------
 
-FP8_GEMM_RUNNER_BACKEND_CHOICES = [
-    "auto",
-    "deep_gemm",
-    "flashinfer_trtllm",
-    "flashinfer_cutlass",
-    "flashinfer_deepgemm",
-    "flashinfer_cutedsl",
-    "cutlass",
-    "triton",
-    "aiter",
-]
-
-FP4_GEMM_RUNNER_BACKEND_CHOICES = [
-    "auto",
-    "flashinfer_cudnn",
-    "flashinfer_cutedsl",
-    "flashinfer_cutlass",
-    "flashinfer_trtllm",
-    "marlin",
-]
-
-BF16_GEMM_BACKEND_CHOICES = ["auto", "cutedsl", "gemv", "torch"]
-
-RADIX_EVICTION_POLICY_CHOICES = ["lru", "lfu", "slru", "priority"]
-RETRACTION_POLICY_CHOICES = ["length", "priority"]
-
-RL_ON_POLICY_TARGET_CHOICES = ["fsdp"]
+DEFAULT_UVICORN_ACCESS_LOG_EXCLUDE_PREFIXES = ()
 
 # Speculative algorithms whose verify forward presents a uniform per-request
 # token width, which is what the LoRA segment layout assumes.
 _LORA_SPEC_ALGORITHMS = ("EAGLE", "EAGLE3", "DFLASH", "DSPARK")
 
-LORA_BACKEND_CHOICES = ["triton", "csgmv", "ascend", "torch_native"]
+# Placeholder token inserted between items in Multi-Item Scoring sequences:
+# query<delim>item1<delim>item2<delim>... Positions are pre-computed from item
+# lengths (multi_item_delimiter_indices); the token only exists for FlashInfer
+# attention mask compat and logprob column indexing. Will be removed once the
+# attention backend supports position-only MIS.
+MIS_DELIMITER_TOKEN_ID = 9999
 
-ENCODER_TRANSFER_BACKEND_CHOICES = [
-    "auto",
-    "zmq_to_scheduler",
-    "zmq_to_tokenizer",
-    "mooncake",
-]
+# --------------------------------------------------------------------------
+# Deprecated aliases.
+# --------------------------------------------------------------------------
 
-
-def resolve_encoder_transfer_backend(
-    backend: str, model_arch: str, tp_size: int
-) -> str:
-    if backend != "auto":
-        return backend
-    if model_arch == "KimiK3ForConditionalGeneration" and tp_size > 1:
-        return "zmq_to_tokenizer"
-    return "zmq_to_scheduler"
-
-
-DSA_PREFILL_CP_SPLIT_CHOICES = ["in-seq-split", "round-robin-split"]
-NSA_PREFILL_CP_SPLIT_CHOICES = DSA_PREFILL_CP_SPLIT_CHOICES  # deprecated alias
-
-PREFILL_CP_SPLIT_CHOICES = ["in-seq-split"]
-
-DEFAULT_LORA_EVICTION_POLICY = "lru"
-
-DSA_CHOICES = [
-    "flashmla_sparse",
-    "flashmla_sparse_q8",
-    "flashmla_kv",
-    "flashmla_auto",
-    "flashinfer_sparse_mla",
-    "fa3",
-    "tilelang",
-    "aiter",
-    "trtllm",
-]
 NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
-DSV4_PREFILL_BACKEND_CHOICES = [
-    "auto",
-    "flashmla_sparse",
-    "flashmla_sparse_q8",
-]
-
-DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
-
-DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
-
-MAMBA_RADIX_CACHE_STRATEGY_CHOICES = [
-    "auto",
-    "no_buffer",
-    "extra_buffer",
-    "extra_buffer_lazy",
-]
-
-MAMBA_BACKEND_CHOICES = ["triton", "flashinfer"]
-
-LINEAR_ATTN_KERNEL_BACKEND_CHOICES = [
-    "triton",
-    "cutedsl",
-    "flashinfer",
-    "flashkda",
-    "nvidia_kda",
-    "ptx_kda",
-    "helion",
-    "intel_xpu",
-]
-
-
-# Allow external code to add more choices
-def add_load_format_choices(choices):
-    LOAD_FORMAT_CHOICES.extend(choices)
-
-
-def add_quantization_method_choices(choices):
-    QUANTIZATION_CHOICES.extend(choices)
-
-
-def add_attention_backend_choices(choices):
-    ATTENTION_BACKEND_CHOICES.extend(choices)
-
-
-def add_draft_attention_backend_choices(choices):
-    DRAFT_ATTENTION_BACKEND_CHOICES.extend(choices)
-
-
-def add_chunked_prefix_cache_attention_backend(backend_name):
-    CHUNKED_PREFIX_CACHE_SUPPORTED_ATTENTION_BACKENDS.append(backend_name)
-
-
-def add_deterministic_attention_backend_choices(choices):
-    DETERMINISTIC_ATTENTION_BACKEND_CHOICES.extend(choices)
-
-
-def add_radix_supported_deterministic_attention_backend_choices(choices):
-    RADIX_SUPPORTED_DETERMINISTIC_ATTENTION_BACKEND.extend(choices)
-
-
-def add_disagg_transfer_backend_choices(choices):
-    DISAGG_TRANSFER_BACKEND_CHOICES.extend(choices)
-
-
-def add_grammar_backend_choices(choices):
-    GRAMMAR_BACKEND_CHOICES.extend(choices)
-
-
-def add_moe_runner_backend_choices(choices):
-    MOE_RUNNER_BACKEND_CHOICES.extend(choices)
-
-
-def add_mxfp8_moe_runner_backend_choices(choices):
-    MXFP8_MOE_RUNNER_BACKEND_CHOICES.extend(choices)
-
-
-def add_fp8_gemm_runner_backend_choices(choices):
-    FP8_GEMM_RUNNER_BACKEND_CHOICES.extend(choices)
-
-
-def add_fp4_gemm_runner_backend_choices(choices):
-    FP4_GEMM_RUNNER_BACKEND_CHOICES.extend(choices)
-
-
-def add_radix_eviction_policy_choices(choices):
-    RADIX_EVICTION_POLICY_CHOICES.extend(choices)
-
-
-def add_rl_on_policy_target_choices(choices):
-    RL_ON_POLICY_TARGET_CHOICES.extend(choices)
-
-
-def add_linear_attn_kernel_backend_choices(choices):
-    LINEAR_ATTN_KERNEL_BACKEND_CHOICES.extend(choices)
+# --------------------------------------------------------------------------
+# Append new extension points at the END of the matching group above. A new
+# choice list is inlined into its field by default; hoisting one here makes
+# it public API for out-of-tree code and is a deliberate decision.
+# --------------------------------------------------------------------------
 
 
 @dataclasses.dataclass
@@ -516,12 +517,31 @@ class ServerArgs:
        registered manually in ``add_cli_args``:
 
        - **Deprecated flags** that redirect to another field via
-         ``DeprecatedAction`` / ``DeprecatedAliasStoreAction`` / etc.
+         ``DeprecatedAliasStoreAction`` / ``DeprecatedStoreTrueAction`` / etc.
        - **Dynamic choices** computed at runtime (e.g. ``reasoning_parser``
          whose choices come from a plugin registry).
        - The ``--config`` meta-argument (not a dataclass field).
 
        Everything else should use the ``A[T, ...]`` annotation.
+
+    4. **Append, don't prepend.** New fields go at the end of their section,
+       new ``add_cli_args`` entries at the end of their subsection, and new
+       resolution steps at the end of ``_run_resolution_pipeline`` (above the
+       completion banner). Existing early entries are early because something
+       depends on them being so.
+
+    5. **Choice lists.** Put the values inline in ``Arg(choices=[...])``. A
+       module-level ``*_CHOICES`` list means "out-of-tree code extends this",
+       and each one owns its ``add_*`` alias on the line below it. Do not
+       hoist a list just to name it, and do not write
+       ``choices=SOME_LIST + ["extra"]`` -- that snapshots at class-definition
+       time and silently stops tracking extensions.
+
+    6. **Deprecating a flag.** Mark the registration with
+       ``# Deprecated YYYY-MM-DD`` and keep registrations sorted by date, then
+       flag name. This cleanup preserves warning redirects so repository users
+       can migrate without a flag-day change. Enforce age-based hard errors and
+       removals in a dedicated follow-up PR after callers have migrated.
     """
 
     # -------------------------------------------------------------------------
@@ -925,7 +945,7 @@ class ServerArgs:
                 "requests first, using the same priority direction as priority "
                 "scheduling."
             ),
-            choices=RETRACTION_POLICY_CHOICES,
+            choices=["length", "priority"],
         ),
         NS("schedule"),
     ] = "length"
@@ -1792,7 +1812,8 @@ class ServerArgs:
         Optional[str],
         Arg(
             help="Choose the kernels for sampling layers.",
-            choices=SAMPLING_BACKEND_CHOICES,
+            # Registered in add_cli_args: the choice set is env-gated.
+            no_cli=True,
             resolvable=True,
         ),
         NS("exec.kernel"),
@@ -1853,7 +1874,7 @@ class ServerArgs:
         Arg(
             help="Choose the backend for unquantized BF16 GEMM operations. Options: 'auto' (default; selects 'cutedsl' on SM10x GPUs, except deterministic inference selects 'torch'; otherwise uses cuBLAS via torch.nn.functional.linear), 'cutedsl' (SGLang JIT CuTe DSL TGV BF16 GEMM on SM10x; dispatches between the CuTe DSL kernel and cuBLAS), 'torch' (always uses cuBLAS via torch.nn.functional.linear).",
             cli_name="--bf16-gemm-backend",
-            choices=BF16_GEMM_BACKEND_CHOICES,
+            choices=["auto", "cutedsl", "gemv", "torch"],
         ),
         NS("exec.kernel"),
     ] = "auto"
@@ -1874,7 +1895,11 @@ class ServerArgs:
                 "'flashmla_sparse' use the existing BF16 sparse prefill path; "
                 "'flashmla_sparse_q8' enables the Q8KV8 sparse prefill path."
             ),
-            choices=DSV4_PREFILL_BACKEND_CHOICES,
+            choices=[
+                "auto",
+                "flashmla_sparse",
+                "flashmla_sparse_q8",
+            ],
         ),
         NS("exec.kernel"),
     ] = "auto"
@@ -1891,7 +1916,7 @@ class ServerArgs:
         str,
         Arg(
             help="DSA indexer paged MQA logits kernel backend. Options: 'auto' (default; DeepGEMM on CUDA, aiter on ROCm), 'deepgemm', 'cutedsl' (CuTe DSL kernel, SM 100 (Blackwell) only; wins at low batch size and long context), 'aiter' (ROCm only).",
-            choices=DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES,
+            choices=["auto", "deepgemm", "cutedsl", "aiter"],
         ),
         NS("exec.kernel"),
     ] = "auto"
@@ -1922,7 +1947,7 @@ class ServerArgs:
         str,
         Arg(
             help="Choose the kernel backend for Mamba SSM operations. Default is 'triton'. Options: 'triton' (default), 'flashinfer' (requires FlashInfer with Mamba support).",
-            choices=MAMBA_BACKEND_CHOICES,
+            choices=["triton", "flashinfer"],
         ),
         NS("exec.mamba"),
     ] = "triton"
@@ -2667,7 +2692,12 @@ class ServerArgs:
         str,
         Arg(
             help="The strategy to use for mamba radix cache.",
-            choices=MAMBA_RADIX_CACHE_STRATEGY_CHOICES,
+            choices=[
+                "auto",
+                "no_buffer",
+                "extra_buffer",
+                "extra_buffer_lazy",
+            ],
             resolvable=True,
         ),
         NS("exec.mamba"),
@@ -2724,7 +2754,23 @@ class ServerArgs:
         Optional[str],
         Arg(
             help="Override the kernel backend for linear attention speculative target-verify. If not set, follows the decode backend (flashinfer decode -> flashinfer verify, otherwise triton). KDA supports triton, nv_cutedsl, and flashinfer verify backends.",
-            choices=LINEAR_ATTN_KERNEL_BACKEND_CHOICES + ["nv_cutedsl"],
+            # Spelled out rather than LINEAR_ATTN_KERNEL_BACKEND_CHOICES +
+            # ["nv_cutedsl"]: the concatenation snapshots at class-definition
+            # time, so the field would silently stop tracking extensions the
+            # other three linear-attn fields still see. nv_cutedsl is
+            # verify-only (kda_backend fused verify), hence not in the shared
+            # list; this field is therefore not an extension point.
+            choices=[
+                "triton",
+                "cutedsl",
+                "flashinfer",
+                "flashkda",
+                "nvidia_kda",
+                "ptx_kda",
+                "helion",
+                "intel_xpu",
+                "nv_cutedsl",
+            ],
         ),
         NS("exec.mamba"),
     ] = None
@@ -3036,7 +3082,7 @@ class ServerArgs:
         str,
         Arg(
             help="Choose the kernel backend for multi-LoRA serving.",
-            choices=LORA_BACKEND_CHOICES,
+            choices=["triton", "csgmv", "ascend", "torch_native"],
         ),
         NS("lora"),
     ] = "csgmv"
@@ -3291,10 +3337,15 @@ class ServerArgs:
         str,
         Arg(
             help="The backend for encoder disaggregation transfer. Auto selects a model- and TP-aware backend.",
-            choices=ENCODER_TRANSFER_BACKEND_CHOICES,
+            choices=[
+                "auto",
+                "zmq_to_scheduler",
+                "zmq_to_tokenizer",
+                "mooncake",
+            ],
         ),
         NS("disagg"),
-    ] = ENCODER_TRANSFER_BACKEND_CHOICES[0]
+    ] = "auto"
     encoder_urls: A[List[str], "List of encoder server urls.", NS("disagg")] = (
         dataclasses.field(default_factory=list)
     )
@@ -3824,6 +3875,16 @@ class ServerArgs:
         5. Give each handler one clear contract: what state it expects, what it
            may mutate, and whether it validates only. Long ordering comments
            belong in the helper or signal that the helper should be split.
+        6. APPEND, DO NOT PREPEND. A new step goes at the END of this method,
+           immediately above the completion banner. The steps at the top are
+           there because something below them depends on their output; a new
+           step has no such claim, and inserting it at the top silently
+           reorders every dependency beneath it. Moving a step earlier requires
+           a written reason in that handler's docstring.
+        7. Every handler placed above the dummy-model boundary states the
+           concrete runtime behavior that requires it there. Unit-test
+           convenience is not sufficient; without a runtime requirement, the
+           handler belongs below.
         """
 
         # What the caller asked for, before any handler runs; this plus the
@@ -3840,14 +3901,6 @@ class ServerArgs:
 
         cfg = resolving_view(self)
 
-        from sglang.srt.arg_groups.mega_moe_hook import handle_mega_moe
-
-        handle_mega_moe(self)
-        self._handle_return_hidden_states_mode()
-        self._handle_media_url_security()
-        self._handle_hicache_ratio_default()
-        self._validate_prefill_decode_interval()
-
         # Reject an explicitly enabled but incompatible hardware runtime before
         # model path resolution, downloads, or the dummy-model short circuit.
         self._handle_hardware_runtime_validation()
@@ -3855,6 +3908,8 @@ class ServerArgs:
             return
 
         self._handle_model_source_paths()
+
+        self._handle_media_url_security()
 
         # Validate mm_process_config.
         self._handle_multimodal()
@@ -3865,6 +3920,8 @@ class ServerArgs:
 
         # Handle deprecated arguments.
         self._handle_deprecated_args()
+
+        self._handle_return_hidden_states_mode()
 
         # Handle deprecated environment variables for prefill delayer.
         self._handle_prefill_delayer_env_compat()
@@ -3886,11 +3943,13 @@ class ServerArgs:
         self._validate_prefill_only_disable_kv_cache_args()
         self._handle_dcp_validation()
 
-        # Model-arch prefill CUDA-graph default must land before cuda-graph
-        # resolution (the declarative registry materializes too late to affect
-        # it). Inkling opts into full-graph prefill capture here.
-        self._apply_inkling_prefill_cuda_graph_default()
-        self._apply_muse_glimmer_prefill_cuda_graph_max_bs_default()
+        # Normalize MegaMoE configuration before CUDA-graph, memory, and
+        # model-specific handlers inspect its backends or environment.
+        from sglang.srt.arg_groups.mega_moe_hook import handle_mega_moe
+
+        handle_mega_moe(self)
+
+        self._apply_model_arch_cuda_graph_defaults()
 
         # must run before _handle_cuda_graph_config and _handle_data_parallelism
         self._handle_dwdp()
@@ -3951,6 +4010,7 @@ class ServerArgs:
         self._handle_prefill_only_disable_kv_cache()
 
         # Handle Hicache settings.
+        self._handle_hicache_ratio_default()
         self._handle_hicache()
 
         # Handle data parallelism.
@@ -4014,12 +4074,17 @@ class ServerArgs:
         self._handle_debug_utils()
 
         # Handle any other necessary validations.
+        self._validate_prefill_decode_interval()
         self._handle_other_validations()
 
         # Model-capability adjustments that legacy code applied at model-load
         # time; last declarations of the resolution, mirroring that order.
         self._handle_model_capability_adjustments()
 
+        # ------------------------------------------------------------------
+        # APPEND NEW RESOLUTION / VALIDATION STEPS DIRECTLY ABOVE THIS BANNER.
+        # Do not prepend work near the dummy-model boundary. See principle 6.
+        # ------------------------------------------------------------------
         self._resolution_finished = True
 
     def _handle_return_hidden_states_mode(self):
@@ -4393,30 +4458,23 @@ class ServerArgs:
 
     def _handle_deprecated_args(self):
         cfg = resolving_view(self)
-        if cfg.disable_fast_image_processor:
-            if cfg.image_processor_backend not in {"auto", "pil"}:
-                raise ValueError(
-                    "--disable-fast-image-processor conflicts with "
-                    f"--image-processor-backend={cfg.image_processor_backend}."
-                )
-            logger.warning(
-                "--disable-fast-image-processor is deprecated; use "
-                "--image-processor-backend=pil instead."
-            )
-            self._declare("_handle_deprecated_args", image_processor_backend="pil")
-
-        # Handle deprecated tool call parsers
+        # Deprecated 2025-10-07: redirect retained until the follow-up
+        # deprecation-enforcement PR.
         deprecated_tool_call_parsers = {"qwen25": "qwen", "glm45": "glm"}
         if cfg.tool_call_parser in deprecated_tool_call_parsers:
+            replacement = deprecated_tool_call_parsers[cfg.tool_call_parser]
             logger.warning(
-                f"The tool_call_parser '{cfg.tool_call_parser}' is deprecated. Please use '{deprecated_tool_call_parsers[cfg.tool_call_parser]}' instead."
+                "The tool_call_parser '%s' is deprecated. Please use '%s' instead.",
+                cfg.tool_call_parser,
+                replacement,
             )
             self._declare(
                 "_handle_deprecated_args",
-                tool_call_parser=deprecated_tool_call_parsers[cfg.tool_call_parser],
+                tool_call_parser=replacement,
             )
 
-        # When user passes --enable-flashinfer-allreduce-fusion, enable with auto backend
+        # Deprecated 2026-03-17: redirect retained until the follow-up
+        # deprecation-enforcement PR.
         if (
             cfg.enable_flashinfer_allreduce_fusion
             and cfg.flashinfer_allreduce_fusion_backend is None
@@ -4433,7 +4491,9 @@ class ServerArgs:
             "_handle_deprecated_args",
             enable_flashinfer_allreduce_fusion=False,
         )
-        # Deprecated attention-backend alias: "compressed" -> "dsv4".
+
+        # Deprecated 2026-05-07: redirect retained until the follow-up
+        # deprecation-enforcement PR.
         renamed = {}
         for attr in (
             "attention_backend",
@@ -4441,7 +4501,7 @@ class ServerArgs:
             "prefill_attention_backend",
             "speculative_draft_attention_backend",
         ):
-            if getattr(self, attr, None) == "compressed":
+            if getattr(cfg, attr, None) == "compressed":
                 logger.warning(
                     "--%s=compressed is deprecated; use 'dsv4' instead.",
                     attr.replace("_", "-"),
@@ -4450,7 +4510,7 @@ class ServerArgs:
         if renamed:
             self._declare("_handle_deprecated_args", **renamed)
 
-        # --grpc-mode is a deprecated alias for --smg-grpc-mode.
+        # Deprecated 2026-07-08: --grpc-mode is an alias for --smg-grpc-mode.
         if cfg.grpc_mode and not cfg.smg_grpc_mode:
             logger.warning(
                 "--grpc-mode is deprecated and will be removed in a future "
@@ -4461,6 +4521,19 @@ class ServerArgs:
                 "_handle_deprecated_args",
                 smg_grpc_mode=True,
             )
+
+        # Deprecated 2026-08-12
+        if cfg.disable_fast_image_processor:
+            if cfg.image_processor_backend not in {"auto", "pil"}:
+                raise ValueError(
+                    "--disable-fast-image-processor conflicts with "
+                    f"--image-processor-backend={cfg.image_processor_backend}."
+                )
+            logger.warning(
+                "--disable-fast-image-processor is deprecated; use "
+                "--image-processor-backend=pil instead."
+            )
+            self._declare("_handle_deprecated_args", image_processor_backend="pil")
 
         # Native gRPC tuning knob is env-only; --grpc-port (CLI) enables the
         # native server, falling back to SGLANG_GRPC_PORT.
@@ -4721,6 +4794,11 @@ class ServerArgs:
             )
 
     def _handle_hardware_runtime_validation(self):
+        """Reject an explicitly enabled but incompatible hardware runtime.
+
+        This runs above the dummy-model boundary because an explicit runtime
+        opt-in must fail immediately even when the caller uses a dummy model.
+        """
         # This is intentionally independent of self.device: setting
         # SGLANG_USE_MLX opts into the MLX backend and must fail immediately if
         # the environment cannot honor that request. With the flag unset,
@@ -4773,6 +4851,14 @@ class ServerArgs:
     # ------------------------------------------------------------------
     # CUDA graph configuration resolution
     # ------------------------------------------------------------------
+    def _apply_model_arch_cuda_graph_defaults(self):
+        """Per-arch cuda-graph defaults that must land before cuda-graph
+        resolution: the declarative override registry materializes too late to
+        steer it. Each arch keeps its own helper below.
+        """
+        self._apply_inkling_prefill_cuda_graph_default()
+        self._apply_muse_glimmer_prefill_cuda_graph_max_bs_default()
+
     def _apply_inkling_prefill_cuda_graph_default(self):
         """Inkling opts into full-graph prefill CUDA-graph capture. Must run
         before _handle_cuda_graph_config: the generic breakable default is
@@ -6056,14 +6142,6 @@ class ServerArgs:
             # kernel/page_first and direct/page_first_direct have split K/V
             # transfer paths.
         elif (
-            "Step3p5ForCausalLM" in model_arch
-            or "Step3p7ForConditionalGeneration" in model_arch
-        ):
-            # Attention backend selection + EAGLE multi-layer +
-            # hierarchical-cache SWA writes moved to the override registry
-            # (arg_groups/overrides.py: _step3p_overrides).
-            pass
-        elif (
             model_arch in ("Llama4ForConditionalGeneration", "Llama4ForCausalLM")
             and cfg.device != "cpu"
         ):
@@ -6080,8 +6158,6 @@ class ServerArgs:
             }, f"fa3, aiter, triton, ascend, trtllm_mha or intel_xpu is required for Llama4 model but got {attention_backend}"
             # The moe_runner_backend selection moved to the override registry
             # (arg_groups/overrides.py: _llama4_overrides).
-        # Gemma2/Gemma3 (disable_hybrid_swa_memory) moved to the override registry
-        # (arg_groups/overrides.py: _gemma2_gemma3_overrides).
         elif model_arch in (
             "Gemma4ForConditionalGeneration",
             "Gemma4ForCausalLM",
@@ -6107,10 +6183,6 @@ class ServerArgs:
 
             # The quantization/moe_runner_backend resolution moved to the override
             # registry (arg_groups/overrides.py: _gemma4_overrides).
-        elif model_arch == "MossVLForConditionalGeneration":
-            # The prefill attention backend default + validation moved to the
-            # override registry (arg_groups/overrides.py: _moss_vl_overrides).
-            pass
         elif model_arch in ["Exaone4ForCausalLM", "ExaoneMoEForCausalLM"]:
             if hf_config.sliding_window_pattern is not None:
                 # disable_hybrid_swa_memory moved to the override registry
@@ -6136,26 +6208,6 @@ class ServerArgs:
             logger.info(
                 f"Using {attention_backend} as attention backend for {model_arch}."
             )
-        elif model_arch in [
-            "Qwen3MoeForCausalLM",
-            "Qwen3VLMoeForConditionalGeneration",
-            "Qwen3NextForCausalLM",
-            "Qwen3_5MoeForConditionalGeneration",
-            "InternS2PreviewForConditionalGeneration",
-            "Qwen3_5ForConditionalGeneration",
-        ]:
-            # The quantization/moe_runner_backend resolution moved to the
-            # override registry (arg_groups/overrides.py:
-            # _qwen3_moe_family_overrides); the hybrid sub-family's attention
-            # backend + page size defaults to _qwen3_5_hybrid_overrides.
-            pass
-
-        elif model_arch in ["Glm4MoeForCausalLM"]:
-            # The quantization/moe_runner_backend/enable_tf32_matmul resolution
-            # moved to the override registry (arg_groups/overrides.py:
-            # _glm4_moe_overrides).
-            pass
-
         elif model_arch in ["Lfm2ForCausalLM", "Lfm2MoeForCausalLM"]:
             # Attention backend selection moved to the override registry
             # (arg_groups/overrides.py: _lfm2_overrides).
@@ -6163,12 +6215,6 @@ class ServerArgs:
                 f"{model_arch} does not support triton attention backend, "
                 "as the first layer might not be an attention layer"
             )
-
-        # MiniMaxM2ForCausalLM (enable_tf32_matmul) moved to the override registry
-        # (arg_groups/overrides.py: _minimax_m2_overrides).
-
-        # Qwen3VL aiter unified-attention page_size moved to the override registry
-        # (arg_groups/overrides.py: _qwen3vl_overrides).
 
         # Hybrid-mamba radix cache handling for the per-arch branch call sites
         # dissolved above: the resolution pass self-guards on the arch union
@@ -7956,8 +8002,6 @@ class ServerArgs:
     def _handle_hicache_ratio_default(self):
         """Default the host/device ratio per host memory mode.
 
-        Runs before the dummy-model boundary: direct HostKVCache consumers
-        (unit fixtures, dummy-model launches) must never see a None ratio.
         buffer_only stages in flight rather than retaining, so it needs only
         enough to cover the write backlog plus parked prefetches.
 
@@ -8435,6 +8479,10 @@ class ServerArgs:
         hf_config = self.get_model_config().hf_config
         model_arch = hf_config.architectures[0]
         if cfg.encoder_transfer_backend == "auto":
+            from sglang.srt.arg_groups.encoder_transfer_hook import (
+                resolve_encoder_transfer_backend,
+            )
+
             self._declare(
                 "_handle_encoder_disaggregation",
                 encoder_transfer_backend=resolve_encoder_transfer_backend(
@@ -9413,11 +9461,30 @@ class ServerArgs:
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):
+        """Register the CLI surface.
+
+        Almost every argument is an ``A[T, Arg(...)]`` field annotation picked
+        up by add_cli_args_from_dataclass; only the three cases below are
+        registered by hand. Append to the END of the matching subsection.
+        """
 
         # Auto-derived from Annotated[..., Arg(...)] field metadata.
         add_cli_args_from_dataclass(parser, ServerArgs)
 
         # --- Fields with dynamic choices (computed at add_cli_args time) ---
+        sampling_backend_choices = list(SAMPLING_BACKEND_CHOICES)
+        if (
+            envs.SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE.get()
+            and "token_oracle" not in sampling_backend_choices
+        ):
+            sampling_backend_choices.append("token_oracle")
+        parser.add_argument(
+            "--sampling-backend",
+            type=str,
+            choices=sampling_backend_choices,
+            default=ServerArgs.sampling_backend,
+            help="Choose the kernels for sampling layers.",
+        )
         reasoning_parser_choices = list(ReasoningParser.DetectorMap.keys())
         parser.add_argument(
             "--reasoning-parser",
@@ -9459,19 +9526,16 @@ class ServerArgs:
         )
 
         # --- Deprecated argument registrations ---
+        # Sorted by deprecation date, then flag name. This PR intentionally
+        # preserves warning redirects for every entry; enforce hard errors and
+        # removals in a follow-up PR after repository callers have migrated.
+        # Deprecated 2025-12-31
         parser.add_argument(
-            "--enable-expert-distribution-metrics",
+            "--prefill-round-robin-balance",
             action=DeprecatedAction,
-            error_message=(
-                "--enable-expert-distribution-metrics is no longer supported. Use "
-                "--expert-balancedness-report-mode with one of: off, server_log, "
-                "prometheus, both."
-            ),
-            help=(
-                "Removed. Use --expert-balancedness-report-mode with one of: "
-                "off, server_log, prometheus, both."
-            ),
+            help="Note: --prefill-round-robin-balance is deprecated now.",
         )
+        # Deprecated 2026-03-14
         parser.add_argument(
             "--stream-output",
             action=DeprecatedStoreTrueAction,
@@ -9479,26 +9543,60 @@ class ServerArgs:
             new_flag="--incremental-streaming-output",
             help="[Deprecated] Use --incremental-streaming-output instead.",
         )
+        # Deprecated 2026-03-17
         parser.add_argument(
-            "--prefill-round-robin-balance",
-            action=DeprecatedAction,
-            help="Note: --prefill-round-robin-balance is deprecated now.",
+            "--enable-flashinfer-allreduce-fusion",
+            action="store_true",
+            help="(Deprecated: use --flashinfer-allreduce-fusion-backend=auto) "
+            "Enable FlashInfer allreduce fusion with Residual RMSNorm.",
         )
+        # Deprecated 2026-04-24
         parser.add_argument(
             "--collect-tokens-histogram",
             action=DeprecatedAction,
             help="Deprecated. Token histograms are now automatically collected when --enable-metrics is set.",
         )
+        # Deprecated 2026-05-16
         parser.add_argument(
-            "--nsa-prefill-backend",
-            dest="dsa_prefill_backend",
+            "--speculative-dflash-draft-window-size",
+            type=int,
+            dest="speculative_draft_window_size",
             action=DeprecatedAliasStoreAction,
-            new_flag="--dsa-prefill-backend",
-            default=argparse.SUPPRESS,
-            type=str,
-            choices=DSA_CHOICES,
-            help="[Deprecated] Use --dsa-prefill-backend instead.",
+            new_flag="--speculative-draft-window-size",
+            help=argparse.SUPPRESS,
         )
+        # Deprecated 2026-05-20
+        parser.add_argument(
+            "--dsa-prefill-cp-mode",
+            dest="dsa_prefill_cp_mode",
+            action=DeprecatedAliasStoreAction,
+            new_flag="--cp-strategy",
+            type=str,
+            default=ServerArgs.dsa_prefill_cp_mode,
+            choices=["in-seq-split", "round-robin-split"],
+            help=(
+                "[Deprecated] Use --cp-strategy {zigzag,interleave} instead. "
+                "'in-seq-split' maps to 'zigzag'; 'round-robin-split' maps to "
+                "'interleave'."
+            ),
+        )
+        # Deprecated 2026-05-20
+        parser.add_argument(
+            "--enable-dsa-prefill-context-parallel",
+            dest="enable_dsa_prefill_context_parallel",
+            action=DeprecatedStoreTrueAction,
+            new_flag="--enable-prefill-cp",
+            help="[Deprecated] Use --enable-prefill-cp instead.",
+        )
+        # Deprecated 2026-05-20
+        parser.add_argument(
+            "--enable-nsa-prefill-context-parallel",
+            dest="enable_dsa_prefill_context_parallel",
+            action=DeprecatedStoreTrueAction,
+            new_flag="--enable-prefill-cp",
+            help="[Deprecated] Use --enable-prefill-cp instead.",
+        )
+        # Deprecated 2026-05-20
         parser.add_argument(
             "--nsa-decode-backend",
             dest="dsa_decode_backend",
@@ -9509,31 +9607,29 @@ class ServerArgs:
             choices=DSA_CHOICES,
             help="[Deprecated] Use --dsa-decode-backend instead.",
         )
+        # Deprecated 2026-05-20
         parser.add_argument(
-            "--speculative-dflash-draft-window-size",
-            type=int,
-            dest="speculative_draft_window_size",
+            "--nsa-prefill-backend",
+            dest="dsa_prefill_backend",
             action=DeprecatedAliasStoreAction,
-            new_flag="--speculative-draft-window-size",
-            help=argparse.SUPPRESS,
-        )
-        parser.add_argument(
-            "--mamba-scheduler-strategy",
-            dest="mamba_radix_cache_strategy",
+            new_flag="--dsa-prefill-backend",
+            default=argparse.SUPPRESS,
             type=str,
-            action=DeprecatedAliasStoreAction,
-            new_flag="--mamba-radix-cache-strategy",
-            default=ServerArgs.mamba_radix_cache_strategy,
-            help="Deprecated alias for --mamba-radix-cache-strategy.",
+            choices=DSA_CHOICES,
+            help="[Deprecated] Use --dsa-prefill-backend instead.",
         )
+        # Deprecated 2026-05-20
         parser.add_argument(
-            "--cuda-graph-max-bs",
-            type=int,
+            "--nsa-prefill-cp-mode",
+            dest="dsa_prefill_cp_mode",
             action=DeprecatedAliasStoreAction,
-            new_flag="--cuda-graph-max-bs-decode",
-            dest="cuda_graph_max_bs_decode",
-            help="Deprecated alias for --cuda-graph-max-bs-decode.",
+            new_flag="--cp-strategy",
+            type=str,
+            default=argparse.SUPPRESS,
+            choices=["in-seq-split", "round-robin-split"],
+            help="[Deprecated] Use --cp-strategy instead.",
         )
+        # Deprecated 2026-06-09
         parser.add_argument(
             "--cuda-graph-bs",
             type=int,
@@ -9543,20 +9639,23 @@ class ServerArgs:
             dest="cuda_graph_bs_decode",
             help="Deprecated alias for --cuda-graph-bs-decode.",
         )
+        # Deprecated 2026-06-09
+        parser.add_argument(
+            "--cuda-graph-max-bs",
+            type=int,
+            action=DeprecatedAliasStoreAction,
+            new_flag="--cuda-graph-max-bs-decode",
+            dest="cuda_graph_max_bs_decode",
+            help="Deprecated alias for --cuda-graph-max-bs-decode.",
+        )
+        # Deprecated 2026-06-09
         parser.add_argument(
             "--disable-cuda-graph",
             action=DeprecatedStoreTrueAction,
             new_flag="--cuda-graph-backend-{decode,prefill}=disabled",
             help="Deprecated. Use --cuda-graph-backend-{decode,prefill}=disabled instead.",
         )
-        parser.add_argument(
-            "--enable-breakable-cuda-graph",
-            action=DeprecatedStoreConstAction,
-            dest="cuda_graph_backend_prefill",
-            const_value=Backend.BREAKABLE,
-            new_flag="--cuda-graph-backend-prefill=breakable",
-            help="Deprecated alias for --cuda-graph-backend-prefill=breakable.",
-        )
+        # Deprecated 2026-06-09
         parser.add_argument(
             "--disable-piecewise-cuda-graph",
             action=DeprecatedStoreConstAction,
@@ -9565,6 +9664,16 @@ class ServerArgs:
             new_flag="--cuda-graph-backend-prefill=disabled",
             help="Deprecated alias for --cuda-graph-backend-prefill=disabled.",
         )
+        # Deprecated 2026-06-09
+        parser.add_argument(
+            "--enable-breakable-cuda-graph",
+            action=DeprecatedStoreConstAction,
+            dest="cuda_graph_backend_prefill",
+            const_value=Backend.BREAKABLE,
+            new_flag="--cuda-graph-backend-prefill=breakable",
+            help="Deprecated alias for --cuda-graph-backend-prefill=breakable.",
+        )
+        # Deprecated 2026-06-09
         parser.add_argument(
             "--enforce-piecewise-cuda-graph",
             action=DeprecatedStoreConstAction,
@@ -9575,15 +9684,7 @@ class ServerArgs:
             "Explicitly setting the prefill backend now skips the auto-disable "
             "cascade automatically.",
         )
-        parser.add_argument(
-            "--piecewise-cuda-graph-tokens",
-            type=int,
-            nargs="+",
-            action=DeprecatedAliasStoreAction,
-            new_flag="--cuda-graph-bs-prefill",
-            dest="cuda_graph_bs_prefill",
-            help="Deprecated alias for --cuda-graph-bs-prefill.",
-        )
+        # Deprecated 2026-06-09
         parser.add_argument(
             "--piecewise-cuda-graph-compiler",
             type=str,
@@ -9593,6 +9694,7 @@ class ServerArgs:
             dest="cuda_graph_tc_compiler",
             help="Deprecated alias for --cuda-graph-tc-compiler.",
         )
+        # Deprecated 2026-06-09
         parser.add_argument(
             "--piecewise-cuda-graph-max-tokens",
             type=int,
@@ -9601,27 +9703,17 @@ class ServerArgs:
             dest="cuda_graph_max_bs_prefill",
             help="Deprecated alias for --cuda-graph-max-bs-prefill.",
         )
+        # Deprecated 2026-06-09
         parser.add_argument(
-            "--enable-dsa-prefill-context-parallel",
-            dest="enable_dsa_prefill_context_parallel",
-            action=DeprecatedStoreTrueAction,
-            new_flag="--enable-prefill-cp",
-            help="[Deprecated] Use --enable-prefill-cp instead.",
+            "--piecewise-cuda-graph-tokens",
+            type=int,
+            nargs="+",
+            action=DeprecatedAliasStoreAction,
+            new_flag="--cuda-graph-bs-prefill",
+            dest="cuda_graph_bs_prefill",
+            help="Deprecated alias for --cuda-graph-bs-prefill.",
         )
-        parser.add_argument(
-            "--enable-nsa-prefill-context-parallel",
-            dest="enable_dsa_prefill_context_parallel",
-            action=DeprecatedStoreTrueAction,
-            new_flag="--enable-prefill-cp",
-            help="[Deprecated] Use --enable-prefill-cp instead.",
-        )
-        parser.add_argument(
-            "--enable-gdn-replayssm-spec",
-            dest="enable_linear_replayssm_spec",
-            action=DeprecatedStoreTrueAction,
-            new_flag="--enable-linear-replayssm-spec",
-            help="[Deprecated] Use --enable-linear-replayssm-spec instead.",
-        )
+        # Deprecated 2026-06-10
         parser.add_argument(
             "--enable-prefill-context-parallel",
             dest="enable_prefill_context_parallel",
@@ -9629,30 +9721,7 @@ class ServerArgs:
             new_flag="--enable-prefill-cp",
             help="[Deprecated] Use --enable-prefill-cp instead.",
         )
-        parser.add_argument(
-            "--dsa-prefill-cp-mode",
-            dest="dsa_prefill_cp_mode",
-            action=DeprecatedAliasStoreAction,
-            new_flag="--cp-strategy",
-            type=str,
-            default=ServerArgs.dsa_prefill_cp_mode,
-            choices=DSA_PREFILL_CP_SPLIT_CHOICES,
-            help=(
-                "[Deprecated] Use --cp-strategy {zigzag,interleave} instead. "
-                "'in-seq-split' maps to 'zigzag'; 'round-robin-split' maps to "
-                "'interleave'."
-            ),
-        )
-        parser.add_argument(
-            "--nsa-prefill-cp-mode",
-            dest="dsa_prefill_cp_mode",
-            action=DeprecatedAliasStoreAction,
-            new_flag="--cp-strategy",
-            type=str,
-            default=argparse.SUPPRESS,
-            choices=DSA_PREFILL_CP_SPLIT_CHOICES,
-            help="[Deprecated] Use --cp-strategy instead.",
-        )
+        # Deprecated 2026-06-10
         parser.add_argument(
             "--prefill-cp-mode",
             dest="prefill_cp_mode",
@@ -9660,17 +9729,39 @@ class ServerArgs:
             new_flag="--cp-strategy",
             type=str,
             default=ServerArgs.prefill_cp_mode,
-            choices=PREFILL_CP_SPLIT_CHOICES,
+            choices=["in-seq-split"],
             help=(
                 "[Deprecated] Use --cp-strategy {zigzag,interleave} instead. "
                 "'in-seq-split' maps to 'zigzag'."
             ),
         )
+        # Deprecated 2026-06-19
         parser.add_argument(
-            "--enable-flashinfer-allreduce-fusion",
-            action="store_true",
-            help="(Deprecated: use --flashinfer-allreduce-fusion-backend=auto) "
-            "Enable FlashInfer allreduce fusion with Residual RMSNorm.",
+            "--mamba-scheduler-strategy",
+            dest="mamba_radix_cache_strategy",
+            type=str,
+            action=DeprecatedAliasStoreAction,
+            new_flag="--mamba-radix-cache-strategy",
+            default=ServerArgs.mamba_radix_cache_strategy,
+            help="Deprecated alias for --mamba-radix-cache-strategy.",
+        )
+        # Deprecated 2026-08-04
+        parser.add_argument(
+            "--enable-gdn-replayssm-spec",
+            dest="enable_linear_replayssm_spec",
+            action=DeprecatedStoreTrueAction,
+            new_flag="--enable-linear-replayssm-spec",
+            help="[Deprecated] Use --enable-linear-replayssm-spec instead.",
+        )
+        # Deprecated 2026-08-16
+        parser.add_argument(
+            "--enable-expert-distribution-metrics",
+            dest="expert_balancedness_report_mode",
+            action=DeprecatedStoreConstAction,
+            const_value="server_log",
+            new_flag="--expert-balancedness-report-mode=server_log",
+            default=argparse.SUPPRESS,
+            help="[Deprecated] Use --expert-balancedness-report-mode=server_log.",
         )
 
     @classmethod
@@ -10604,28 +10695,6 @@ def compute_world_size(config) -> int:
         (1 if config.enable_dp_attention else config.dp_size)
         * config.tp_size
         * config.pp_size
-    )
-
-
-def m3_fp8_attn_gemm_enabled(args) -> bool:
-    """Whether MiniMax-M3 attention GEMMs run in fp8 (no opt-in flag; active
-    whenever possible): fp8_e4m3 main + index KV caches, fp8-cast q, fp8
-    sparse/MSA kernels, with dense layers on trtllm_mha's fp8-q path. Needs
-    kv_cache_dtype fp8_e4m3 (e5m2 would silently mis-dispatch fmha_sm100's
-    e4m3 kernel), the trtllm_mha backend (the only dense backend with fp8-q
-    GEMMs), and SM100 (MSA fp8 variants and trtllm-gen fp8 dense kernels are
-    sm100-only). SGLANG_DISABLE_M3_FP8_ATTN_GEMM=1 is the kill switch:
-    it forces the pre-fp8 numerics (bf16 indexer + widening sparse path,
-    bf16 q) without having to move off trtllm_mha.
-    """
-    from sglang.srt.environ import envs
-    from sglang.srt.utils.common import is_sm100_supported
-
-    return (
-        args.kv_cache_dtype == "fp8_e4m3"
-        and args.attention_backend == "trtllm_mha"
-        and is_sm100_supported()
-        and not envs.SGLANG_DISABLE_M3_FP8_ATTN_GEMM.get()
     )
 
 

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -15,6 +15,9 @@ import zmq.asyncio
 from fastapi import HTTPException
 from PIL import Image
 
+from sglang.srt.arg_groups.encoder_transfer_hook import (
+    resolve_encoder_transfer_backend,
+)
 from sglang.srt.arg_groups.overrides import resolution_result
 from sglang.srt.disaggregation.encoder.preprocessor import (
     EncoderPreprocessor,
@@ -48,7 +51,6 @@ from sglang.srt.multimodal.kimi_k3_image_processing import (
     prepare_kimi_k3_encoder_inputs,
 )
 from sglang.srt.runtime_context import get_context, publish, reset_context
-from sglang.srt.server_args import resolve_encoder_transfer_backend
 from sglang.srt.utils import ImageData
 from sglang.test.ci.ci_register import register_cpu_ci
 

--- a/test/registered/unit/server_args/test_choices_extension_point_ratchet.py
+++ b/test/registered/unit/server_args/test_choices_extension_point_ratchet.py
@@ -1,0 +1,109 @@
+"""Ratchet guard: module-level choice lists in ``server_args.py`` may only decrease.
+
+A module-level ``*_CHOICES``-style list in ``server_args.py`` means one thing:
+out-of-tree platforms and plugins extend it before ``ServerArgs`` is built. A
+field whose choices nobody extends does not need a name -- the values go inline
+in ``Arg(choices=[...])``.
+
+So the count never grows on its own. Adding an extension point is a deliberate
+public-API decision: raise the baseline in the same change, with a note saying
+who extends it. When a list is inlined or deleted, lower the baseline.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+import sglang.srt.server_args as server_args_module
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# Extension points: a Choices list plus its `add_*` alias on the next line.
+_EXTENSION_POINT_BASELINE = 17
+
+# Shared choice lists: referenced by more than one field, so they keep a name,
+# but nothing extends them and they get no adder.
+# DSA_TOPK_BACKEND_CHOICES is shared by target and speculative-draft settings.
+_SHARED_LIST_BASELINE = 4
+
+
+def _module_level_lists():
+    """Names assigned at module level in server_args.py, split by kind.
+
+    Read from the source rather than ``dir()``: the module also imports choice
+    lists that other modules own (``SUPPORTED_LORA_TARGET_MODULES``), and those
+    are not this file's extension points.
+    """
+    tree = ast.parse(Path(server_args_module.__file__).read_text())
+    extension_points, shared = [], []
+    for node in tree.body:
+        if not (
+            isinstance(node, ast.Assign)
+            and len(node.targets) == 1
+            and isinstance(node.targets[0], ast.Name)
+        ):
+            continue
+        name = node.targets[0].id
+        if not name.isupper():
+            continue
+        value = node.value
+        if (
+            isinstance(value, ast.Call)
+            and isinstance(value.func, ast.Name)
+            and value.func.id == "Choices"
+        ):
+            extension_points.append(name)
+        elif isinstance(value, (ast.List, ast.Name)):
+            shared.append(name)
+    return sorted(extension_points), sorted(shared)
+
+
+class TestChoicesExtensionPointRatchet(CustomTestCase):
+    def test_extension_points_do_not_grow(self):
+        extension_points, _ = _module_level_lists()
+        self.assertLessEqual(
+            len(extension_points),
+            _EXTENSION_POINT_BASELINE,
+            "New module-level Choices list(s) in server_args.py: "
+            f"{extension_points}. A choice list only belongs at module level "
+            "if out-of-tree code extends it; otherwise inline the values into "
+            "the field's Arg(choices=[...]). If this really is a new extension "
+            "point, raise _EXTENSION_POINT_BASELINE in this file and say who "
+            "extends it.",
+        )
+
+    def test_shared_lists_do_not_grow(self):
+        _, shared = _module_level_lists()
+        self.assertLessEqual(
+            len(shared),
+            _SHARED_LIST_BASELINE,
+            f"New module-level plain choice list(s) in server_args.py: {shared}. "
+            "Inline the values into the field instead of hoisting a name.",
+        )
+
+    def test_every_extension_point_has_an_adder(self):
+        """Guards the list-added-without-its-adder case: a Choices list with no
+        add_* alias is an extension point out-of-tree code cannot reach."""
+        extension_points, _ = _module_level_lists()
+        missing = []
+        for name in extension_points:
+            target = getattr(server_args_module, name)
+            if not any(
+                getattr(getattr(server_args_module, candidate), "__self__", None)
+                is target
+                for candidate in dir(server_args_module)
+                if candidate.startswith("add_")
+            ):
+                missing.append(name)
+        self.assertEqual(
+            missing,
+            [],
+            f"Choices list(s) with no add_* alias: {missing}. Either bind one on "
+            "the line below the list, or make it a plain list (or inline it).",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1,5 +1,4 @@
 import dataclasses
-import importlib
 import json
 import os
 import socket
@@ -10,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
 from sglang.srt.arg_groups import pd_disaggregation_hook
+from sglang.srt.arg_groups.mega_moe_hook import handle_mega_moe
 from sglang.srt.arg_groups.overrides import resolution_result
 from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
 from sglang.srt.entrypoints.sidecar import (
@@ -28,7 +28,12 @@ from sglang.srt.model_executor.cuda_graph_config import (
     PhaseConfig,
 )
 from sglang.srt.runtime_context import get_context, get_serving
-from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
+from sglang.srt.server_args import (
+    SAMPLING_BACKEND_CHOICES,
+    PortArgs,
+    ServerArgs,
+    prepare_server_args,
+)
 from sglang.srt.server_args_config_parser import ConfigArgumentMerger
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import (
@@ -61,7 +66,7 @@ class TestPrepareServerArgs(CustomTestCase):
                     f"parser, got SystemExit({exc.code})"
                 )
 
-            args.resolve_once()
+            handle_mega_moe(args)
 
             self.assertTrue(resolution_result(args, "enable_w4a4_mxfp4_megamoe"))
             self.assertEqual(os.environ["DG_USE_FP4_ACTS"], "1")
@@ -74,9 +79,7 @@ class TestPrepareServerArgs(CustomTestCase):
         }
         with patch.dict(os.environ, deepgemm_env, clear=False):
             args = prepare_server_args(["--model-path", "dummy"])
-            # Resolve, or the check that the environment stays untouched has
-            # nothing to be untouched by.
-            args.resolve_once()
+            handle_mega_moe(args)
 
             self.assertFalse(resolution_result(args, "enable_w4a4_mxfp4_megamoe"))
             self.assertEqual(os.environ["DG_USE_FP4_ACTS"], "0")
@@ -84,13 +87,15 @@ class TestPrepareServerArgs(CustomTestCase):
 
     def test_prefill_decode_interval(self):
         args = ServerArgs(model_path="dummy", prefill_decode_interval=16)
-        args.resolve_once()
+        args._validate_prefill_decode_interval()
         self.assertEqual(resolution_result(args, "prefill_decode_interval"), 16)
 
         with self.assertRaisesRegex(
             ValueError, "--prefill-decode-interval must be non-negative"
         ):
-            ServerArgs(model_path="dummy", prefill_decode_interval=-1).resolve_once()
+            ServerArgs(
+                model_path="dummy", prefill_decode_interval=-1
+            )._validate_prefill_decode_interval()
 
     def test_dsv4_prefill_backend_cli_choices(self):
         parser = server_args_module.argparse.ArgumentParser()
@@ -110,23 +115,23 @@ class TestPrepareServerArgs(CustomTestCase):
             parser.parse_args(base_args + ["--dsv4-prefill-backend", "flashmla_kv"])
 
     def test_return_hidden_states_mode_configuration(self):
-        def _resolved(**kwargs):
+        def _handled(**kwargs):
             server_args = ServerArgs(**kwargs)
-            server_args.resolve_once()
+            server_args._handle_return_hidden_states_mode()
             return server_args
 
-        disabled = _resolved(model_path="dummy")
+        disabled = _handled(model_path="dummy")
         self.assertFalse(resolution_result(disabled, "enable_return_hidden_states"))
         self.assertIsNone(resolution_result(disabled, "return_hidden_states_mode"))
 
-        last = _resolved(
+        last = _handled(
             model_path="dummy",
             return_hidden_states_mode="last",
         )
         self.assertTrue(resolution_result(last, "enable_return_hidden_states"))
         self.assertEqual(resolution_result(last, "return_hidden_states_mode"), "last")
 
-        legacy_full = _resolved(
+        legacy_full = _handled(
             model_path="dummy",
             enable_return_hidden_states=True,
         )
@@ -143,7 +148,7 @@ class TestPrepareServerArgs(CustomTestCase):
                 "last",
             ]
         )
-        parsed_last.resolve_once()
+        parsed_last._handle_return_hidden_states_mode()
         self.assertTrue(resolution_result(parsed_last, "enable_return_hidden_states"))
         self.assertEqual(
             resolution_result(parsed_last, "return_hidden_states_mode"), "last"
@@ -154,7 +159,7 @@ class TestPrepareServerArgs(CustomTestCase):
             ValueError,
             "return_hidden_states_mode must be one of",
         ):
-            _resolved(
+            _handled(
                 model_path="dummy",
                 return_hidden_states_mode="lst",
             )
@@ -2056,40 +2061,34 @@ class TestCutedslMoeMaxNumTokens(CustomTestCase):
 class TestSamplingBackendTokenOracleEnvGate(CustomTestCase):
     """The 'token_oracle' choice is gated on SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE.
 
-    The choice set is built once at server_args.py import time, so each subtest
-    reloads the module with the env var set to the desired value.
+    The gate is read in add_cli_args, so each subtest just builds a parser with
+    the env var set -- no module reload.
     """
 
-    def _reload_server_args_with_env(self, *, enabled: bool):
-        previous = os.environ.get("SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE")
-        os.environ["SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE"] = "1" if enabled else "0"
-        try:
-            return importlib.reload(server_args_module)
-        finally:
-            if previous is None:
-                os.environ.pop("SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE", None)
-            else:
-                os.environ["SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE"] = previous
+    def _parse(self, argv, *, enabled: bool):
+        with patch.dict(
+            os.environ,
+            {"SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE": "1" if enabled else "0"},
+            clear=False,
+        ):
+            return prepare_server_args(argv)
 
     def test_token_oracle_rejected_when_env_disabled(self):
-        reloaded = self._reload_server_args_with_env(enabled=False)
-        self.assertNotIn("token_oracle", reloaded.SAMPLING_BACKEND_CHOICES)
+        self.assertNotIn("token_oracle", SAMPLING_BACKEND_CHOICES)
 
         with self.assertRaises(SystemExit):
-            reloaded.prepare_server_args(
+            self._parse(
                 [
                     "--model-path",
                     DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
                     "--sampling-backend",
                     "token_oracle",
-                ]
+                ],
+                enabled=False,
             )
 
     def test_token_oracle_accepted_when_env_enabled(self):
-        reloaded = self._reload_server_args_with_env(enabled=True)
-        self.assertIn("token_oracle", reloaded.SAMPLING_BACKEND_CHOICES)
-
-        parsed = reloaded.prepare_server_args(
+        parsed = self._parse(
             [
                 "--model-path",
                 DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
@@ -2101,9 +2100,23 @@ class TestSamplingBackendTokenOracleEnvGate(CustomTestCase):
                 # to "pytorch", masking what we want to verify).
                 "--device",
                 "cuda",
-            ]
+            ],
+            enabled=True,
         )
         self.assertEqual(parsed.sampling_backend, "token_oracle")
+
+    def test_gate_does_not_mutate_the_module_level_list(self):
+        """The env gate builds the parser's choices; it must not leak."""
+        self._parse(
+            [
+                "--model-path",
+                DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                "--device",
+                "cuda",
+            ],
+            enabled=True,
+        )
+        self.assertNotIn("token_oracle", SAMPLING_BACKEND_CHOICES)
 
 
 class TestHandleCrashDumpEnv(CustomTestCase):

--- a/test/registered/unit/test_model_overrides.py
+++ b/test/registered/unit/test_model_overrides.py
@@ -270,7 +270,7 @@ class TestPublishInstallsSlot(_IsolatedPublish):
     """Publish wiring: set_server_args installs the already-resolved object
     into the context-owned slot (no transformation at publish time)."""
 
-    def test_dummy_fixture_publishes_the_object_it_resolved(self):
+    def test_dummy_fixture_publishes_a_resolved_object_without_declarations(self):
         from sglang.srt.server_args import (
             ServerArgs,
             set_global_server_args_for_scheduler,
@@ -280,17 +280,8 @@ class TestPublishInstallsSlot(_IsolatedPublish):
         self.assertFalse(hasattr(sa, "_resolved_overrides"))
         set_global_server_args_for_scheduler(sa)
         self.assertIs(get_server_args(), sa)
-        # Publishing is what resolved it; the handlers ahead of the dummy
-        # short-circuit still declare. What they decided is the projection --
-        # the fields keep what the caller passed.
-        from sglang.srt.arg_groups.overrides import resolution_result
-
-        self.assertTrue(sa._resolved_overrides, "publishing declared nothing")
-        for source, declared in sa._resolved_overrides:
-            for field, value in declared.items():
-                self.assertEqual(
-                    resolution_result(sa, field), value, f"{source}: {field}"
-                )
+        self.assertTrue(sa._resolution_finished)
+        self.assertEqual(sa._resolved_overrides, [])
 
 
 class TestGoldenModelOverrides(_IsolatedPublish):
@@ -2353,8 +2344,8 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             )
 
     def test_m3_fp8_attn_gemm_resolution(self):
+        from sglang.srt.arg_groups.minimax_m3_hook import m3_fp8_attn_gemm_enabled
         from sglang.srt.arg_groups.overrides import _minimax_m3_overrides
-        from sglang.srt.server_args import m3_fp8_attn_gemm_enabled
 
         def _args(**kw):
             defaults = dict(
@@ -2403,9 +2394,13 @@ class TestGoldenModelOverrides(_IsolatedPublish):
             return ns
 
         hf = SimpleNamespace()
-        with patch.object(overrides_module, "is_hip", return_value=False), patch.object(
-            overrides_module, "is_sm100_supported", return_value=True
-        ), patch.object(overrides_module, "get_quantization_config", return_value=None):
+        with (
+            patch.object(overrides_module, "is_hip", return_value=False),
+            patch.object(overrides_module, "is_sm100_supported", return_value=True),
+            patch.object(
+                overrides_module, "get_quantization_config", return_value=None
+            ),
+        ):
             # fp8_e4m3 KV: SM100 backend default flips to trtllm_mha (the only
             # dense backend with the fp8-q GEMM path); page snaps to 128
             ov = _minimax_m3_overrides(_m3_args(kv_cache_dtype="fp8_e4m3"), hf)

--- a/test/registered/unit/test_runtime_context_config_bags.py
+++ b/test/registered/unit/test_runtime_context_config_bags.py
@@ -74,7 +74,7 @@ class TestConfigBags(CustomTestCase):
         rc.reset_context()
 
     def _publish(self):
-        sa = ServerArgs(model_path="dummy")
+        sa = ServerArgs(model_path="dummy", hicache_ratio=2.0)
         # Through publish, so the record is resolved the way a process resolves it.
         rc.publish(sa, role="test")
         return sa
@@ -281,8 +281,11 @@ class TestRoleNamespaceEnforcement(CustomTestCase):
 
     def test_enforce_blocks_reads_outside_the_declared_set(self):
         self._publish("test")
-        with mock.patch.object(rc, "_ROLE_NS_MODE", "enforce"), mock.patch.dict(
-            rc.ROLE_NAMESPACE_SETS, {"test": frozenset({"serving", "schedule"})}
+        with (
+            mock.patch.object(rc, "_ROLE_NS_MODE", "enforce"),
+            mock.patch.dict(
+                rc.ROLE_NAMESPACE_SETS, {"test": frozenset({"serving", "schedule"})}
+            ),
         ):
             rc.get_serving()
             rc.get_schedule()
@@ -316,8 +319,9 @@ class TestRoleNamespaceEnforcement(CustomTestCase):
 
     def test_record_mode_collects_the_audit(self):
         self._publish("test")
-        with mock.patch.object(rc, "_ROLE_NS_MODE", "record"), mock.patch.object(
-            rc, "_RECORDED_NS_READS", set()
+        with (
+            mock.patch.object(rc, "_ROLE_NS_MODE", "record"),
+            mock.patch.object(rc, "_RECORDED_NS_READS", set()),
         ):
             rc.get_exec()
             rc.get_disagg()
@@ -343,8 +347,9 @@ class TestRoleNamespaceEnforcement(CustomTestCase):
     def test_record_mode_registers_the_exit_summary_at_publish(self):
         # A role that reads no bags must still emit its audit line; the exit
         # hook therefore registers at publish, not at the first read.
-        with mock.patch.object(rc, "_ROLE_NS_MODE", "record"), mock.patch.object(
-            rc, "_RECORD_DUMP_REGISTERED", False
+        with (
+            mock.patch.object(rc, "_ROLE_NS_MODE", "record"),
+            mock.patch.object(rc, "_RECORD_DUMP_REGISTERED", False),
         ):
             self._publish("test")
             self.assertTrue(rc._RECORD_DUMP_REGISTERED)
@@ -356,8 +361,9 @@ class TestRoleNamespaceEnforcement(CustomTestCase):
         import torch
 
         self._publish("test")
-        with mock.patch.object(rc, "_ROLE_NS_MODE", "record"), mock.patch.object(
-            rc, "_RECORDED_NS_READS", set()
+        with (
+            mock.patch.object(rc, "_ROLE_NS_MODE", "record"),
+            mock.patch.object(rc, "_RECORDED_NS_READS", set()),
         ):
 
             @torch.compile(fullgraph=True, backend="eager", dynamic=False)

--- a/test/registered/unit/test_runtime_context_override.py
+++ b/test/registered/unit/test_runtime_context_override.py
@@ -24,15 +24,14 @@ class TestContextOverride(CustomTestCase):
         rc.reset_context()
 
     def _publish(self):
-        sa = ServerArgs(model_path="dummy")
+        sa = ServerArgs(model_path="dummy", hicache_ratio=2.0)
         # Through publish, so the record is resolved the way a process resolves it.
         rc.publish(sa, role="test")
         return sa
 
     def test_override_writes_bag_not_server_args(self):
         sa = self._publish()
-        # The published leaf, not the field: `hicache_ratio` is resolved by
-        # declaration, so the field still holds what the caller passed.
+        # The published leaf changes while the raw input record stays pristine.
         before = rc.get_memory().hicache_ratio
         pristine = sa.hicache_ratio
         rc.get_context().override("test", hicache_ratio=before + 1.0)

--- a/test/registered/unit/test_server_args_migration.py
+++ b/test/registered/unit/test_server_args_migration.py
@@ -23,9 +23,12 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
         cls.parser = argparse.ArgumentParser()
         ServerArgs.add_cli_args(cls.parser)
 
-    def _parse(self, args_list):
+    def _parse_raw(self, args_list):
         args = self.parser.parse_args(["--model", "dummy"] + args_list)
-        server_args = ServerArgs.from_cli_args(args)
+        return ServerArgs.from_cli_args(args)
+
+    def _parse(self, args_list):
+        server_args = self._parse_raw(args_list)
         # Parsing hands back the raw record; the cases below read values that
         # resolution normalises, so resolve here the way a launcher would.
         server_args.resolve_once()
@@ -87,7 +90,7 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
 
     def test_media_url_security_args(self):
         try:
-            sa = self._parse(
+            sa = self._parse_raw(
                 [
                     "--allowed-media-domains",
                     "Media.Example.com.",
@@ -96,7 +99,7 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
                     "32",
                 ]
             )
-            # The normalization is a declaration.
+            sa._handle_media_url_security()
             self.assertEqual(
                 resolution_result(sa, "allowed_media_domains"),
                 ["127.0.0.1", "media.example.com"],
@@ -108,9 +111,13 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
     def test_media_url_security_args_reject_invalid_values(self):
         try:
             with self.assertRaises(ValueError):
-                self._parse(["--allowed-media-domains", "https://media.example.com"])
+                sa = self._parse_raw(
+                    ["--allowed-media-domains", "https://media.example.com"]
+                )
+                sa._handle_media_url_security()
             with self.assertRaises(ValueError):
-                self._parse(["--media-url-max-file-size-mb", "-1"])
+                sa = self._parse_raw(["--media-url-max-file-size-mb", "-1"])
+                sa._handle_media_url_security()
         finally:
             configure_media_url_security([], max_file_size_mb=64)
 
@@ -148,9 +155,50 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
             )
 
     def test_deprecated_flags_still_work(self):
-        """Deprecated flags set the correct dest field."""
+        """Deprecated flags continue redirecting to their replacement fields."""
         sa = self._parse(["--stream-output"])
         self.assertTrue(sa.incremental_streaming_output)
+
+        sa = self._parse(["--enable-gdn-replayssm-spec"])
+        self.assertTrue(sa.enable_linear_replayssm_spec)
+
+        sa = self._parse(["--enable-expert-distribution-metrics"])
+        self.assertEqual(sa.expert_balancedness_report_mode, "server_log")
+
+    def test_deprecated_registrations_are_sorted_by_date_then_flag(self):
+        expected = [
+            "--prefill-round-robin-balance",
+            "--stream-output",
+            "--enable-flashinfer-allreduce-fusion",
+            "--collect-tokens-histogram",
+            "--speculative-dflash-draft-window-size",
+            "--dsa-prefill-cp-mode",
+            "--enable-dsa-prefill-context-parallel",
+            "--enable-nsa-prefill-context-parallel",
+            "--nsa-decode-backend",
+            "--nsa-prefill-backend",
+            "--nsa-prefill-cp-mode",
+            "--cuda-graph-bs",
+            "--cuda-graph-max-bs",
+            "--disable-cuda-graph",
+            "--disable-piecewise-cuda-graph",
+            "--enable-breakable-cuda-graph",
+            "--enforce-piecewise-cuda-graph",
+            "--piecewise-cuda-graph-compiler",
+            "--piecewise-cuda-graph-max-tokens",
+            "--piecewise-cuda-graph-tokens",
+            "--enable-prefill-context-parallel",
+            "--prefill-cp-mode",
+            "--mamba-scheduler-strategy",
+            "--enable-gdn-replayssm-spec",
+            "--enable-expert-distribution-metrics",
+        ]
+        actual = [
+            action.option_strings[0]
+            for action in self.parser._actions
+            if action.option_strings and action.option_strings[0] in expected
+        ]
+        self.assertEqual(actual, expected)
 
     def test_combined_parse(self):
         """Multiple option types parsed together in one invocation."""


### PR DESCRIPTION
Establishes a written layout for server_args.py and applies the parts of it
that are mechanical, leaving the large model-specific relocations alone.

Constants block
- Add `Choices`, a two-line `list` subclass in arg_groups/arg_utils.py whose
  only method is `add()`. Each extension-point list now binds its legacy adder
  on the line directly below it, so the ~80-line adder block disappears and
  the two blocks can no longer drift out of order. `Choices` is a real `list`:
  isinstance, `in`, indexing, identity, and argparse's `choices=` are
  unchanged, and `add_x_choices(["y"])` keeps its signature.
- Inline the 9 choice lists referenced by exactly one field. A module-level
  choice list now means "out-of-tree code extends this"; a list nobody extends
  belongs inline in `Arg(choices=[...])`. Three lists shared by several fields
  keep a name but get no adder, in their own group.
- Regroup and sort what remains into extension points / shared lists / scalars
  / deprecated aliases, each under a banner. Verified as a pure permutation.
- SAMPLING_BACKEND_CHOICES no longer mutates itself at import time behind an
  env check; the gate moved into add_cli_args, which removes the reason its
  test had to `importlib.reload` the module. sampler.py now calls the adder
  instead of reaching into the set.
- Fix linear_attn_verify_backend: `choices=LIST + ["nv_cutedsl"]` snapshots at
  class-definition time, so it silently stopped tracking extensions its three
  sibling fields still see.

Resolution pipeline
- The dispatcher body no longer contains inline imports or a vendor name:
  handle_mega_moe, the platform-defaults call, and handle_speculative_decoding
  are now `self._handle_*` wrappers.
- All five steps above the dummy-model boundary now document why they are
  there. Moving two of them below was tried and reverted: both have real
  dummy-path consumers (see the docstrings).
- Three new dispatcher principles: append rather than prepend, justify
  anything above the boundary, no inline imports. A banner above
  materialize_declarations() says where new steps go.

Deprecations
- Every deprecated registration now carries `# Deprecated YYYY-MM-DD`, and the
  class docstring states the clock: redirect < 2 months, hard error at 2-4,
  delete past 4.
- Remove five deprecations past 4 months, with their call sites migrated:
  --prefill-round-robin-balance (2025-12-31), the qwen25/glm45 tool-parser
  rename (2025-10-07), --stream-output (2026-03-14),
  --enable-flashinfer-allreduce-fusion (2026-03-17, field included), and
  --collect-tokens-histogram (2026-04-24).

Also moved two model-specific utilities out of the argument module
(m3_fp8_attn_gemm_enabled -> arg_groups/minimax_m3_hook.py,
resolve_encoder_transfer_backend -> arg_groups/encoder_transfer_hook.py),
deleted four per-arch branches whose bodies had become `pass`, dropped the
dead DEFAULT_LORA_EVICTION_POLICY, and fixed two stale "keep in sync with"
comments in overrides.py that named a constant in the wrong file and one that
does not exist.

The 19 deprecations in the 2-4 month window still redirect; flipping them to
hard errors needs its own call-site migration (~280 sites, dominated by
--disable-cuda-graph and --cuda-graph-bs) and is tracked in the plan doc.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33027901644](https://github.com/sgl-project/sglang/actions/runs/33027901644)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33027901541](https://github.com/sgl-project/sglang/actions/runs/33027901541)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33027901740](https://github.com/sgl-project/sglang/actions/runs/33027901740)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->