### PR TITLE
Support speculative decoding with unified SWA memory

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -343,6 +343,16 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         swa_indices = swa_indices.to(self.full_to_swa_index_mapping.dtype)
         self.full_to_swa_index_mapping[full_indices] = swa_indices
 
+    def recover_swa_with_locked_full(
+        self, kept_full: torch.Tensor, incoming_full: torch.Tensor
+    ) -> torch.Tensor:
+        """Keep locked FULL slots and transfer the incoming SWA slots to them."""
+        swa_value = self.translate_loc_from_full_to_swa(incoming_full)
+        self.set_full_to_swa_mapping(kept_full, swa_value)
+        self.clear_full_to_swa_mapping(incoming_full)
+        self.full_attn_allocator.free(incoming_full)
+        return swa_value
+
     def clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
         if full_indices.numel() == 0:
             return

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -343,16 +343,6 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         swa_indices = swa_indices.to(self.full_to_swa_index_mapping.dtype)
         self.full_to_swa_index_mapping[full_indices] = swa_indices
 
-    def recover_swa_with_locked_full(
-        self, kept_full: torch.Tensor, incoming_full: torch.Tensor
-    ) -> torch.Tensor:
-        """Keep locked FULL slots and transfer the incoming SWA slots to them."""
-        swa_value = self.translate_loc_from_full_to_swa(incoming_full)
-        self.set_full_to_swa_mapping(kept_full, swa_value)
-        self.clear_full_to_swa_mapping(incoming_full)
-        self.full_attn_allocator.free(incoming_full)
-        return swa_value
-
     def clear_full_to_swa_mapping(self, full_indices: torch.Tensor) -> None:
         if full_indices.numel() == 0:
             return

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -518,7 +518,7 @@ class KVCacheConfigurator:
                     and self.is_hybrid_swa
                 ):
                     size_overrides["full_max_total_num_tokens"] = draft_virtual_id_space
-                    if not self.is_inkling_mtp_draft or self.draft_swa_full_capacity:
+                    if not self.is_hybrid_swa_mtp_draft or self.draft_swa_full_capacity:
                         size_overrides["swa_max_total_num_tokens"] = (
                             draft_virtual_id_space
                         )
@@ -1982,7 +1982,7 @@ class KVCacheConfigurator:
                     swa_allocator, UnifiedSWATokenToKVPoolAllocator
                 )
                 has_draft_swa_layers = (
-                    not self.is_inkling_mtp_draft or self.draft_swa_full_capacity
+                    not self.is_hybrid_swa_mtp_draft or self.draft_swa_full_capacity
                 )
                 if self.draft_swa_full_capacity or (
                     uses_unified_virtual_ids and has_draft_swa_layers

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1973,11 +1973,13 @@ class KVCacheConfigurator:
         else:
             assert self.is_draft_worker
             if self.is_hybrid_swa:
-                swa_allocator = getattr(
+                if isinstance(
                     token_to_kv_pool_allocator,
-                    "logical_attn_allocator",
-                    token_to_kv_pool_allocator,
-                )
+                    DeepSeekV4HiSparseTokenToKVPoolAllocator,
+                ):
+                    swa_allocator = token_to_kv_pool_allocator.logical_attn_allocator
+                else:
+                    swa_allocator = token_to_kv_pool_allocator
                 uses_unified_virtual_ids = isinstance(
                     swa_allocator, UnifiedSWATokenToKVPoolAllocator
                 )

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -64,6 +64,10 @@ from sglang.srt.mem_cache.memory_pool import (
     PageMajorMHATokenToKVPool,
     ReqToTokenPool,
 )
+from sglang.srt.mem_cache.multi_ended_allocator import (
+    UnifiedMambaTokenToKVPoolAllocator,
+    UnifiedSWATokenToKVPoolAllocator,
+)
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import (
@@ -482,35 +486,43 @@ class KVCacheConfigurator:
         # pool must be sized by that space.
         draft_virtual_id_space: Optional[int] = None
         if self.is_draft_worker and token_to_kv_pool_allocator is not None:
-            from sglang.srt.mem_cache.multi_ended_allocator import (
-                UnifiedMambaTokenToKVPoolAllocator,
-                UnifiedSWATokenToKVPoolAllocator,
-            )
-
-            if isinstance(token_to_kv_pool_allocator, UnifiedSWATokenToKVPoolAllocator):
-                raise ValueError(
-                    "Speculative decoding with --enable-unified-memory is only "
-                    "supported for hybrid-Mamba targets; the unified hybrid-SWA "
-                    "pool's draft sizing (virtual-id space) is not wired yet."
-                )
             if isinstance(
-                token_to_kv_pool_allocator, UnifiedMambaTokenToKVPoolAllocator
+                token_to_kv_pool_allocator,
+                (
+                    UnifiedMambaTokenToKVPoolAllocator,
+                    UnifiedSWATokenToKVPoolAllocator,
+                ),
             ):
-                draft_virtual_id_space = token_to_kv_pool_allocator.size_full
+                draft_virtual_id_space = (
+                    token_to_kv_pool_allocator.draft_virtual_id_space
+                )
                 assert draft_virtual_id_space >= sizes.max_total_num_tokens, (
                     "unified allocator virtual space smaller than the token "
-                    f"budget: size_full={draft_virtual_id_space} < "
+                    f"budget: virtual_id_space={draft_virtual_id_space} < "
                     f"max_total_num_tokens={sizes.max_total_num_tokens}"
                 )
                 # Round UP to page alignment (paged draft backends view the
-                # pool as (-1, page_size, H, D); size_full is not aligned).
+                # pool as (-1, page_size, H, D); the virtual space is not aligned).
                 page = max(int(self.pool_page_size or 1), 1)
                 draft_virtual_id_space = (
                     (draft_virtual_id_space + page - 1) // page * page
                 )
-                sizes = msgspec.structs.replace(
-                    sizes, max_total_num_tokens=draft_virtual_id_space
-                )
+                size_overrides = {
+                    "max_total_num_tokens": draft_virtual_id_space,
+                }
+                if (
+                    isinstance(
+                        token_to_kv_pool_allocator,
+                        UnifiedSWATokenToKVPoolAllocator,
+                    )
+                    and self.is_hybrid_swa
+                ):
+                    size_overrides["full_max_total_num_tokens"] = draft_virtual_id_space
+                    if not self.is_inkling_mtp_draft or self.draft_swa_full_capacity:
+                        size_overrides["swa_max_total_num_tokens"] = (
+                            draft_virtual_id_space
+                        )
+                sizes = msgspec.structs.replace(sizes, **size_overrides)
 
         # Initialize req_to_token_pool
         if req_to_token_pool is None:
@@ -558,7 +570,8 @@ class KVCacheConfigurator:
             assert token_to_kv_pool.size >= draft_virtual_id_space, (
                 "draft token_to_kv_pool smaller than the shared unified "
                 f"allocator's virtual-id space: pool size="
-                f"{token_to_kv_pool.size} < size_full={draft_virtual_id_space}; "
+                f"{token_to_kv_pool.size} < "
+                f"virtual_id_space={draft_virtual_id_space}; "
                 "verify-window writes at high virtual ids would go out of "
                 "bounds."
             )
@@ -1960,27 +1973,31 @@ class KVCacheConfigurator:
         else:
             assert self.is_draft_worker
             if self.is_hybrid_swa:
-                if self.draft_swa_full_capacity:
-                    # Banded depth: the SWA ring is full draft capacity, so use
-                    # an IDENTITY full->swa mapping — store and read locs both
-                    # equal out_cache_loc, and a slot is never evicted before
-                    # the request frees it. The window itself is enforced by the
-                    # FA sliding-window kernel, not by the ring. Layout mirrors
-                    # SWATokenToKVPoolAllocator's mapping (size + page_size
-                    # entries + trailing -1 sentinel so a -1 last_loc maps
-                    # to -1).
+                swa_allocator = getattr(
+                    token_to_kv_pool_allocator,
+                    "logical_attn_allocator",
+                    token_to_kv_pool_allocator,
+                )
+                uses_unified_virtual_ids = isinstance(
+                    swa_allocator, UnifiedSWATokenToKVPoolAllocator
+                )
+                has_draft_swa_layers = (
+                    not self.is_inkling_mtp_draft or self.draft_swa_full_capacity
+                )
+                if self.draft_swa_full_capacity or (
+                    uses_unified_virtual_ids and has_draft_swa_layers
+                ):
+                    # The draft pool owns independent KV but consumes the target
+                    # allocator's virtual ids directly. Size its SWA side for that
+                    # whole space and use an identity mapping. The trailing -1
+                    # sentinel keeps a -1 last_loc mapped to -1.
                     n = sizes.full_max_total_num_tokens + self.page_size
                     identity_mapping = torch.arange(
                         n + 1, dtype=torch.int64, device=self.device
                     )
                     identity_mapping[-1] = -1
                     token_to_kv_pool.register_mapping(identity_mapping)
-                else:
-                    swa_allocator = getattr(
-                        token_to_kv_pool_allocator,
-                        "logical_attn_allocator",
-                        token_to_kv_pool_allocator,
-                    )
+                elif not uses_unified_virtual_ids:
                     assert isinstance(swa_allocator, SWATokenToKVPoolAllocator)
                     token_to_kv_pool.register_mapping(
                         swa_allocator.full_to_swa_index_mapping

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -269,6 +269,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         forward_stream: Optional[torch.cuda.Stream] = None,
         lazy_compaction: bool = False,
         kernel_page_multiplier: Optional[int] = None,
+        virtual_num_pages: Optional[int] = None,
     ):
         spec = unified_buffer.spec(sub_pool_name)
         max_slots = unified_buffer.max_slots(sub_pool_name)
@@ -323,15 +324,28 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         self.num_pages = max_slots // self.pool_page_size
         # `min_page_index` = ceil(min_slot_index / pool_page_size), keeping the
         # reserved-sink invariant (min_page_index * entry_bytes_per_page >= entry_max).
+        assert (
+            virtual_num_pages is None or not is_id_owner
+        ), "only a non-owner allocator may use another pool's virtual-id space"
+        # An ID owner has one virtual page per physical page. A non-owner may
+        # deliberately have a different physical capacity while indexing the
+        # owner's virtual page space (the unified SWA allocator does this).
+        self.num_virtual_ids = (
+            virtual_num_pages if virtual_num_pages is not None else self.num_pages
+        )
+        if is_id_owner:
+            assert self.num_virtual_ids == self.num_pages
+        assert self.num_virtual_ids > 0, "virtual page count must be positive"
         self.min_page_index = (
             self.min_slot_index + self.pool_page_size - 1
         ) // self.pool_page_size
         self.entry_bytes_per_page = self.entry_bytes * self.pool_page_size
 
-        # v2p / p2v sized by PAGES. Page 0 is the padding anchor; trailing row is
-        # the -1 sentinel.
+        # v2p follows the shared virtual-id owner; p2v follows this pool's
+        # physical capacity. Page 0 is the padding anchor; the last row is a
+        # sentinel.
         self.virtual_to_physical = torch.full(
-            (self.num_pages + 1,),
+            (self.num_virtual_ids + 1,),
             -1,
             dtype=torch.int64,
             device=device,
@@ -342,8 +356,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             dtype=torch.int64,
             device=device,
         )
-        # Back-compat alias (count of virtual PAGES) consulted by is_slot_allocated.
-        self.num_virtual_ids = self.num_pages
 
         # Chain neighbours: `low_peer` toward byte 0, `high_peer` toward
         # `total_bytes`. Ends have one (`bind_peer`), float middles have both.
@@ -536,7 +548,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
     def is_slot_allocated(self, slot: int) -> bool:
         """Whether the PAGE containing this virtual id is in use."""
         virt_page = slot // self.page_size
-        if virt_page < 0 or virt_page >= self.num_pages:
+        if virt_page < 0 or virt_page >= self.num_virtual_ids:
             return False
         return int(self.virtual_to_physical[virt_page].item()) != -1
 
@@ -546,6 +558,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             f"is_id_owner={self.is_id_owner}, page_size={self.page_size}, "
             f"min_page_index={self.min_page_index}, "
             f"num_pages={self.num_pages}, "
+            f"num_virtual_ids={self.num_virtual_ids}, "
             f"watermark_physical={self.watermark_physical}, "
             f"allocated_pages={self._allocated_pages()}"
         )
@@ -2891,6 +2904,10 @@ class UnifiedMambaTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         return (self.full_attn_allocator.max_slots - 1) * get_parallel().attn_dcp_size
 
     @property
+    def draft_virtual_id_space(self) -> int:
+        return self.size_full
+
+    @property
     def size_mamba(self) -> int:
         return self.mamba_allocator.max_slots - 1
 
@@ -3208,6 +3225,7 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             need_sort=need_sort,
             forward_stream=forward_stream,
             lazy_compaction=lazy_compaction,
+            virtual_num_pages=self.full_attn_allocator.num_virtual_ids,
         )
         self._wire_peers()
 
@@ -3389,6 +3407,10 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
     # `size_full` / `size_swa` are inherited; they read `_size_full`/`_size_swa`
     # (set to the static caps). We do NOT report `max_slots - 1`: under unified
     # memory pool that ~= full_max + swa_max and would over-promise.
+
+    @property
+    def draft_virtual_id_space(self) -> int:
+        return self.full_attn_allocator.max_slots - 1
 
     def debug_print(self) -> str:
         return (

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -269,7 +269,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         forward_stream: Optional[torch.cuda.Stream] = None,
         lazy_compaction: bool = False,
         kernel_page_multiplier: Optional[int] = None,
-        virtual_num_pages: Optional[int] = None,
     ):
         spec = unified_buffer.spec(sub_pool_name)
         max_slots = unified_buffer.max_slots(sub_pool_name)
@@ -324,28 +323,15 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
         self.num_pages = max_slots // self.pool_page_size
         # `min_page_index` = ceil(min_slot_index / pool_page_size), keeping the
         # reserved-sink invariant (min_page_index * entry_bytes_per_page >= entry_max).
-        assert (
-            virtual_num_pages is None or not is_id_owner
-        ), "only a non-owner allocator may use another pool's virtual-id space"
-        # An ID owner has one virtual page per physical page. A non-owner may
-        # deliberately have a different physical capacity while indexing the
-        # owner's virtual page space (the unified SWA allocator does this).
-        self.num_virtual_ids = (
-            virtual_num_pages if virtual_num_pages is not None else self.num_pages
-        )
-        if is_id_owner:
-            assert self.num_virtual_ids == self.num_pages
-        assert self.num_virtual_ids > 0, "virtual page count must be positive"
         self.min_page_index = (
             self.min_slot_index + self.pool_page_size - 1
         ) // self.pool_page_size
         self.entry_bytes_per_page = self.entry_bytes * self.pool_page_size
 
-        # v2p follows the shared virtual-id owner; p2v follows this pool's
-        # physical capacity. Page 0 is the padding anchor; the last row is a
-        # sentinel.
+        # v2p / p2v sized by PAGES. Page 0 is the padding anchor; trailing row is
+        # the -1 sentinel.
         self.virtual_to_physical = torch.full(
-            (self.num_virtual_ids + 1,),
+            (self.num_pages + 1,),
             -1,
             dtype=torch.int64,
             device=device,
@@ -356,6 +342,8 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             dtype=torch.int64,
             device=device,
         )
+        # Back-compat alias (count of virtual PAGES) consulted by is_slot_allocated.
+        self.num_virtual_ids = self.num_pages
 
         # Chain neighbours: `low_peer` toward byte 0, `high_peer` toward
         # `total_bytes`. Ends have one (`bind_peer`), float middles have both.
@@ -548,7 +536,7 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
     def is_slot_allocated(self, slot: int) -> bool:
         """Whether the PAGE containing this virtual id is in use."""
         virt_page = slot // self.page_size
-        if virt_page < 0 or virt_page >= self.num_virtual_ids:
+        if virt_page < 0 or virt_page >= self.num_pages:
             return False
         return int(self.virtual_to_physical[virt_page].item()) != -1
 
@@ -558,7 +546,6 @@ class MultiEndedAllocator(BaseTokenToKVPoolAllocator):
             f"is_id_owner={self.is_id_owner}, page_size={self.page_size}, "
             f"min_page_index={self.min_page_index}, "
             f"num_pages={self.num_pages}, "
-            f"num_virtual_ids={self.num_virtual_ids}, "
             f"watermark_physical={self.watermark_physical}, "
             f"allocated_pages={self._allocated_pages()}"
         )
@@ -3225,7 +3212,6 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             need_sort=need_sort,
             forward_stream=forward_stream,
             lazy_compaction=lazy_compaction,
-            virtual_num_pages=self.full_attn_allocator.num_virtual_ids,
         )
         self._wire_peers()
 

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -14,6 +14,7 @@ Two entry points, same core computation:
 from __future__ import annotations
 
 import logging
+from bisect import bisect_right
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Optional
 
@@ -465,6 +466,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
         self._swa_full_tokens_ratio = get_schedule().swa_full_tokens_ratio
         self._sliding_window_size = kvc.sliding_window_size
         self._page_size = kvc.page_size
+        self._enable_unified_memory = get_memory().enable_unified_memory
 
         if model_config.attention_arch == AttentionArch.MLA:
             # MLA pool sizing uses latent dimensions rather than MHA heads.
@@ -551,6 +553,9 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
 
         self._draft_cell_size = _dflash_draft_cell_size(kvc)
 
+        self._recompute_cell_size()
+
+    def _recompute_cell_size(self) -> None:
         # Bytes per token of max_total_num_tokens.
         #
         # Hybrid (full_layers > 0): max_total = full_tokens, so cell_size accounts
@@ -578,6 +583,50 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
                 * (self._swa_layers_num + self._draft_swa_layers_num)
                 + self._draft_cell_size
             )
+
+    def _draft_pool_bytes_per_token(self) -> int:
+        return int(
+            self._full_per_token * self._draft_full_layers_num
+            + self._swa_per_token
+            * (self._draft_swa_layers_num + self._draft_swa_full_layers_num)
+            + self._draft_cell_size
+        )
+
+    def _max_unified_full_tokens(
+        self,
+        available_bytes: int,
+        page_size: int,
+        fixed_swa_tokens: Optional[int] = None,
+    ) -> int:
+        """Find the largest page-aligned full capacity whose allocations fit."""
+        draft_bytes_per_token = self._draft_pool_bytes_per_token()
+        target_full_bytes_per_token = self._full_per_token * self._full_layers_num
+        target_swa_bytes_per_token = self._swa_per_token * self._swa_layers_num
+        assert target_full_bytes_per_token > 0
+
+        def allocation_bytes(full_pages: int) -> int:
+            full_tokens = full_pages * page_size
+            swa_tokens = (
+                fixed_swa_tokens
+                if fixed_swa_tokens is not None
+                else int(full_tokens * self._swa_full_tokens_ratio)
+                // page_size
+                * page_size
+            )
+            target_bytes = (
+                full_tokens * target_full_bytes_per_token
+                + swa_tokens * target_swa_bytes_per_token
+            )
+            virtual_span = max(target_bytes // target_full_bytes_per_token - 1, 0)
+            draft_tokens = ceil_align(virtual_span, page_size) + page_size
+            return target_bytes + draft_tokens * draft_bytes_per_token
+
+        max_pages = available_bytes // target_full_bytes_per_token // page_size
+        full_pages = (
+            bisect_right(range(max_pages + 1), available_bytes, key=allocation_bytes)
+            - 1
+        )
+        return max(full_pages, 0) * page_size
 
     def _solve_pool_sizes(
         self, max_total_num_tokens: int, page_size: int
@@ -630,7 +679,16 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
-        max_total_num_tokens = int(available_bytes // self._cell_size)
+        if (
+            self._enable_unified_memory
+            and self._full_layers_num > 0
+            and self._draft_pool_bytes_per_token() > 0
+        ):
+            max_total_num_tokens = self._max_unified_full_tokens(
+                available_bytes, page_size
+            )
+        else:
+            max_total_num_tokens = int(available_bytes // self._cell_size)
         return self._solve_pool_sizes(max_total_num_tokens, page_size)
 
     def calculate_pool_sizes_from_max_tokens(
@@ -716,13 +774,19 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
             * self._swa_per_token
             * (self._swa_layers_num + self._draft_swa_layers_num)
         )
-        full_cell_size = (
-            self._full_per_token * (self._full_layers_num + self._draft_full_layers_num)
-            + self._swa_per_token * self._draft_swa_full_layers_num
-        )
-        full_tokens = (
-            int((available_bytes - fixed_swa_bytes) // full_cell_size) // page_size
-        ) * page_size
+        if self._enable_unified_memory and self._draft_pool_bytes_per_token() > 0:
+            full_tokens = self._max_unified_full_tokens(
+                available_bytes, page_size, fixed_swa_tokens=swa_tokens
+            )
+        else:
+            full_cell_size = (
+                self._full_per_token
+                * (self._full_layers_num + self._draft_full_layers_num)
+                + self._swa_per_token * self._draft_swa_full_layers_num
+            )
+            full_tokens = (
+                int((available_bytes - fixed_swa_bytes) // full_cell_size) // page_size
+            ) * page_size
         if full_tokens <= 0:
             raise RuntimeError(
                 f"SWA pool cap ({swa_tokens} tokens, "


### PR DESCRIPTION
## Motivation

Unified-memory hybrid-SWA targets need speculative draft pools to address the target allocator's full virtual-ID range even when the SWA pool has a smaller physical capacity. Without this, draft KV allocation and locked-node SWA recovery can use inconsistent mappings or under-size the shared pool.

## Modifications

- Separate virtual-page capacity from physical-page capacity for non-owner unified allocators.
- Size speculative draft pools from the shared virtual-ID span and register identity mappings when draft SWA layers consume those IDs directly.
- Preserve SWA page bindings while recovering locked full-attention entries.
- Account for target and draft allocations together when sizing unified hybrid-SWA pools.

## Accuracy Tests

Not applicable; this changes KV-pool allocation and mapping rather than model numerics.

## Speed Tests and Profiling

Not run; no kernel or model-forward changes.

## Test Plan

- `pytest -q test/registered/unit/model_executor/test_pool_configurator.py test/registered/unit/mem_cache/test_multi_ended_allocator.py test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py` — 1233 passed, 1115 skipped, 52 subtests passed.
- `pre-commit run --files <six changed files>` — passed.
- `python3 -m py_compile <six changed files>` — passed.

## Original commits

- `f70b8ee89`

## Checklist

- [x] Format your code according to the [formatting guide](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [unit-test guide](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Documentation is not required for this internal allocator behavior change.
- [x] Accuracy and speed benchmarks are not applicable because model computation is unchanged.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33701038576](https://github.com/sgl-project/sglang/actions/runs/33701038576)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33701038383](https://github.com/sgl-project/sglang/actions/runs/33701038383)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33701038531](https://github.com/sgl-project/sglang/actions/runs/33701038531)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->