### PR TITLE
moe: mask padded rows before capturing routed experts for R3

### DIFF
--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1900,19 +1900,31 @@ def capture_routed_experts_if_allowed(
     topk_config: TopKConfig,
     layer_id: Optional[int],
     topk_ids: torch.Tensor,
+    num_token_non_padded: Optional[torch.Tensor] = None,
 ) -> None:
     """Single capture site for every backend, gated by the per-config opt-out.
 
     Routing all backends through here keeps the draft-side opt-out from being
     bypassed by an inlined capturer call.
+
+    Rows at or past ``num_token_non_padded`` still hold whatever the router left
+    there; ``_post_process_topk_ids`` masks them only further down, and on ROCm it
+    masks them to 0, a valid expert id. Capture runs ahead of both, so mask a copy
+    here: replay consumers skip -1 rows, and treating a padded row as a real
+    selection makes a whole padded region replay one stale routing row.
     """
     if not topk_config.allow_routed_experts_capture:
         return
-    if (cap := get_global_experts_capturer()) is not None:
-        cap.capture(
-            layer_id=layer_id,
-            topk_indices=topk_ids,
-        )
+    cap = get_global_experts_capturer()
+    if cap is None:
+        return
+    if num_token_non_padded is not None:
+        topk_ids = topk_ids.clone()
+        _mask_topk_ids_padded_region(topk_ids, num_token_non_padded)
+    cap.capture(
+        layer_id=layer_id,
+        topk_indices=topk_ids,
+    )
 
 
 def _post_process_topk_ids(
@@ -1931,7 +1943,9 @@ def _post_process_topk_ids(
     fused_shared_experts_scaling_factor = (
         topk_config.fused_shared_experts_scaling_factor
     )
-    capture_routed_experts_if_allowed(topk_config, layer_id, topk_ids)
+    capture_routed_experts_if_allowed(
+        topk_config, layer_id, topk_ids, num_token_non_padded
+    )
     recorder_topk_ids = None
     if _is_cuda:
         # LP path: solve LP outside torch.compile (the solver contains an


### PR DESCRIPTION
## Problem

The R3 routed-experts capture runs at the top of `_post_process_topk_ids`, ahead
of every padded-region mask in that function. Rows at or past
`num_token_non_padded` therefore reach the capturer holding whatever the router
left in them, and the capturer writes `buffer[:batch]` without clearing, so those
rows carry a stale routing row from an earlier forward.

Replayed into training, a padded region comes back as one repeated row of real
expert ids. The R3 replay check counts each as a zero-overlap mismatch.

## Evidence

From a miles CI run (DeepSeek-V3.2-5layer, 8192-token batch,
`chunked_prefill_size=4096`):

- one replay row repeated **67 times** across contiguous tokens 4039-4053+, while
  the recomputed routing varied per token
- 104 mismatches against a threshold of 82
- the block starts at the chunked-prefill boundary

Same check on the pre-bump build: **171 replay rows, all 171 unique**, zero
repeats, and at most 9 mismatches per check.

## Why not just move the capture after the mask

The masks are per-branch and disagree on fill value: the CUDA path fills -1, the
ROCm path fills 0 -- a valid expert id that replay cannot tell from a real
selection. Masking a copy at the capture site gives replay -1 on both, and leaves
the tensor the MoE kernels consume untouched.

The NPU call site is left alone: `_mask_topk_ids_padded_region` is a no-op there,
so passing the count would only add a clone.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32918538859](https://github.com/sgl-project/sglang/actions/runs/32918538859)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32918538639](https://github.com/sgl-project/sglang/actions/runs/32918538639)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32918538816](https://github.com/sgl-project/sglang/actions/runs/32918538816)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->