### PR TITLE
[Docs][Cookbook] AMD DeepSeek-V4 FP8 cells are missing SGLANG_DSV4_FP4_EXPERTS=0 and cannot load on a cold cache

### DIFF
--- a/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
+++ b/docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx
@@ -2235,6 +2235,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi300x", variant: "flash", quant: "fp8", strategy: "low-latency", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton",
         "AITER_BF16_FP8_MOE_BOUND=0",
@@ -2262,6 +2263,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi300x", variant: "flash", quant: "fp8", strategy: "balanced", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_DP_USE_GATHERV=1",
         "SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton",
@@ -2294,6 +2296,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi300x", variant: "flash", quant: "fp8", strategy: "high-throughput", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_DP_USE_GATHERV=1",
         "SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton",
@@ -2514,6 +2517,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi355x", variant: "flash", quant: "fp8", strategy: "low-latency", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton",
         "AITER_BF16_FP8_MOE_BOUND=0",
@@ -2542,6 +2546,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi355x", variant: "flash", quant: "fp8", strategy: "balanced", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_SHARED_EXPERT_TP1=1",
         "SGLANG_DP_SHARED_EXPERT_LOCAL=1",
@@ -2577,6 +2582,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi355x", variant: "flash", quant: "fp8", strategy: "high-throughput", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_SHARED_EXPERT_TP1=1",
         "SGLANG_DP_SHARED_EXPERT_LOCAL=1",
@@ -2714,6 +2720,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi355x", variant: "pro", quant: "fp8", strategy: "low-latency", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton",
         "AITER_BF16_FP8_MOE_BOUND=0",
@@ -2742,6 +2749,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi355x", variant: "pro", quant: "fp8", strategy: "balanced", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_SHARED_EXPERT_TP1=1",
         "SGLANG_DP_SHARED_EXPERT_LOCAL=1",
@@ -2777,6 +2785,7 @@ sgl-eval run aime25 \\
       match: { hw: "mi355x", variant: "pro", quant: "fp8", strategy: "high-throughput", nodes: "single" },
       verified: true,
       env: [
+        "SGLANG_DSV4_FP4_EXPERTS=0",
         "SGLANG_USE_ROCM700A=0",
         "SGLANG_SHARED_EXPERT_TP1=1",
         "SGLANG_DP_SHARED_EXPERT_LOCAL=1",


### PR DESCRIPTION
Scope: one file, nine added lines, all in `docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx`. No code, no test, no workflow.

## Motivation

All nine AMD DeepSeek-V4 **FP8** cookbook cells name an FP8 checkpoint but omit `SGLANG_DSV4_FP4_EXPERTS=0`, the env var that tells the loader the routed experts are FP8 rather than mxfp4-packed:

| Cell | had it before |
|---|---|
| `mi300x \| flash \| fp8` — low-latency, balanced, high-throughput | no |
| `mi355x \| flash \| fp8` — low-latency, balanced, high-throughput | no |
| `mi355x \| pro \| fp8` — low-latency, balanced, high-throughput | no |
| `h200 \| flash \| fp8` and `h200 \| pro \| fp8` (6 cells) | **yes** |

All nine are marked `verified: true`. Every other FP8 DSV4 config in the repo sets the var — the MI35x nightly tests (`test_deepseek_v4_flash_fp8.py`, `..._fp8_tbo.py`, `test_deepseek_v4_pro_fp8.py`), the disaggregation tests, `kv_canary/consts.py`, the manual `test/manual/dsv4/` suite, the NPU perf tests, and `scripts/ci/slurm/launch_mi355x.sh`, which derives it from `PRECISION`. The AMD cookbook cells are the only FP8 DSV4 configuration in the tree that leaves it unset.

**Why this is latent rather than obviously broken.** `SGLANG_DSV4_FP4_EXPERTS` defaults to `True`:

```1280:1281:python/sglang/srt/environ.py
    # Set False when using FP4-to-FP8 converted DeepSeek V4 checkpoint.
    SGLANG_DSV4_FP4_EXPERTS = EnvBool(True)
```

`ModelConfig` falls back to auto-detection when it is unset:

```395:409:python/sglang/srt/configs/model_config.py
        if is_deepseek_v4(self.hf_config):
            self.is_fp4_experts = envs.SGLANG_DSV4_FP4_EXPERTS.get()
            if (
                not envs.SGLANG_DSV4_FP4_EXPERTS.is_set()
                or envs.SGLANG_DSV4_FP4_DEQUANT.is_set()
            ):
                from sglang.srt.configs.deepseek_v4 import try_detect_fp4_experts

                detected = try_detect_fp4_experts(self.model_path)
                if detected is not None:
                    self.is_fp4_experts = detected
```

But `try_detect_fp4_experts` reads the safetensors header out of the **local HF cache** and returns `None` when the repo is not cached — its own docstring says "None when the header isn't readable (HF slug not cached yet, etc.). Caller falls back to user default." `find_local_repo_dir` returns `None` for an uncached slug, so on a fresh host detection is skipped and the `True` default wins. The FP8 checkpoint is then read at mxfp4 shapes.

That is why these cells can be marked verified and still be broken: they work on a machine that already has the weights and fail on a new one, which is exactly the machine a reader following the cookbook is on.

## Modifications

Added `"SGLANG_DSV4_FP4_EXPERTS=0"` to the `env` list of the nine AMD FP8 cells, matching what the H200 FP8 cells already do. Nothing else changed — no flag, no other env var, no `verified` value, and no FP4 cell.

Setting it explicitly also removes the cold/warm cache dependence, so the recipe behaves identically on any host instead of depending on whether the checkpoint happens to be cached.

## Accuracy Tests

Observed on 8 x MI300X running the `mi300x | flash | fp8 | low-latency | single` cell verbatim on a cold HF cache — [run 32914407497](https://github.com/sgl-project/sglang/actions/runs/32914407497), from the CI job added in #36396. The log contains no `Auto-detected DSV4 routed-expert layout` line, confirming detection returned `None`, and then all eight ranks crash during weight load:

```
File "/sglang-checkout/python/sglang/srt/layers/moe/fused_moe_triton/layer.py", line 703, in _load_w13
    expert_data.copy_(loaded_weight)
RuntimeError: The size of tensor a (2048) must match the size of tensor b (4096) at non-singleton dimension 1
```

The factor of two is the mxfp4 packing: two 4-bit experts per byte against FP8's one. Other ranks report the same mismatch at their own shard shapes (128 vs 256, 128 vs 32). The server then exits with code -9 and never serves a request.

Static validation:

- `pre-commit run --files docs/src/snippets/configs/deepseek-ai/deepseek-v4.jsx` — all hooks pass
- re-audited every cell in the file by parsing it: all 15 FP8 cells now carry the var, and no non-FP8 cell was touched
- the diff is nine added lines, one per cell
- the Mintlify preview build renders it: the deployed page carries 21 occurrences of `SGLANG_DSV4_FP4_EXPERTS` against production's 12, a delta of exactly the nine patched cells

Not verified: I could not re-run the MI355X Flash/Pro FP8 cells, so those six are fixed by the same reasoning rather than by observation. The reasoning is checkpoint-level, not architecture-level — the MI35x nightly tests set the same var against the same checkpoints and pass — but if an AMD reviewer wants to confirm one MI355X cell before merging, that seems worth doing.

Worth a follow-up conversation separately: `try_detect_fp4_experts` silently falling back to a default that hard-crashes at weight load is a poor failure mode. Loading an FP8 checkpoint at mxfp4 shapes is detectable at config time, and a clear error naming the env var would be better than a shape mismatch eight stack frames into the MoE weight loader. This PR does not attempt that.

## Speed Tests and Profiling

No performance impact; this makes the recipes load at all on a fresh host.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests <!-- N/A: cookbook config data -->
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results <!-- crash repro provided above; no perf change -->
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829299271](https://github.com/sgl-project/sglang/actions/runs/34829299271)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829298608](https://github.com/sgl-project/sglang/actions/runs/34829298608)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->