### PR TITLE
fix(lora): stop rebuilding the MoE align JIT module on every miss

### DIFF
--- a/python/sglang/kernels/ops/moe/virtual_experts.py
+++ b/python/sglang/kernels/ops/moe/virtual_experts.py
@@ -3,6 +3,7 @@ LoRA Virtual Experts Triton Ops.
 """
 
 import functools
+import logging
 from typing import Any
 
 import torch
@@ -10,8 +11,13 @@ import triton
 import triton.language as tl
 
 from sglang.kernels.ops.moe.moe_align import (
+    _jit_moe_align_module,
+)
+from sglang.kernels.ops.moe.moe_align import (
     moe_align_block_size as jit_moe_align_block_size,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @triton.jit
@@ -484,6 +490,9 @@ def _align_block_size_torch(
     return sorted_token_ids, expert_ids, total_padded_tokens
 
 
+_jit_align_block_size_unavailable = False
+
+
 def _align_block_size_large(
     topk_ids: torch.Tensor,
     block_size: int,
@@ -492,10 +501,26 @@ def _align_block_size_large(
     """Dispatch to the CUDA JIT kernel when available, otherwise fall back to
     the pure-PyTorch torch.compile path (needed on AMD/ROCm or when the JIT
     module fails to load)."""
-    try:
-        return _align_block_size_jit(topk_ids, block_size, num_experts)
-    except Exception:
-        return _align_block_size_torch(topk_ids, block_size, num_experts)
+    global _jit_align_block_size_unavailable
+
+    if not _jit_align_block_size_unavailable:
+        module_loaded = False
+        try:
+            # Loading is cached only on success, so a platform that cannot build
+            # the module at all would rebuild it once per call and never finish a
+            # forward pass. Runtime errors stay retryable.
+            _jit_moe_align_module(topk_ids.dtype)
+            module_loaded = True
+            return _align_block_size_jit(topk_ids, block_size, num_experts)
+        except Exception:
+            if not module_loaded:
+                logger.warning(
+                    "moe_align_block_size JIT module unavailable; using the "
+                    "pure-PyTorch alignment fallback for the rest of this process.",
+                    exc_info=True,
+                )
+                _jit_align_block_size_unavailable = True
+    return _align_block_size_torch(topk_ids, block_size, num_experts)
 
 
 def _merged_experts_fused_moe_lora_add_fake(


### PR DESCRIPTION
## Problem

`_align_block_size_large` already falls back to the pure-PyTorch alignment path when the `moe_align_block_size` JIT module cannot be loaded, and its docstring calls that path out as the one needed on AMD/ROCm. The failure is not remembered, though, and a failed build leaves nothing cached, so the next call rebuilds from scratch.

On a platform where the module cannot build at all, every call therefore spawns a fresh ninja compile that runs for tens of seconds and fails again. MoE LoRA with virtual experts reaches this function on each expert layer, so a forward pass never finishes and the scheduler watchdog kills the process:

```
Scheduler watchdog timeout (self.watchdog_timeout=300, self.soft=False)
    build_ninja (tvm_ffi/cpp/extension.py:533)
    load_jit (sglang/jit_kernel/utils/compile.py:271)
    _align_block_size_jit (sglang/kernels/ops/moe/virtual_experts.py:373)
    _align_block_size_large (sglang/kernels/ops/moe/virtual_experts.py:494)
```

The fallback itself works; it is simply never reached a second time.

## Change

Latch a module-level flag the first time the JIT module fails to load, and log one warning, so later calls go straight to the fallback instead of rebuilding. The latch is set only when loading the module fails; a kernel that loads and then raises still falls back for that call and stays retryable.

## Validation

MI350X (`gfx950`), ROCm 7.2, Qwen3-30B-A3B served with a rank-32 shared-outer MoE LoRA adapter, `lora_use_virtual_experts=True`, `moe_runner_backend=triton`:

- Before: the first prefill never returns. A new ninja process appears on every poll and the run ends at the 300s watchdog.
- After: the request set completes, with a single `moe_align_block_size JIT module unavailable; using the pure-PyTorch alignment fallback` warning and correct output.
- Injecting a load failure latches after one attempt and stops calling the loader; injecting a post-load runtime failure falls back for that call without latching.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32920134921](https://github.com/sgl-project/sglang/actions/runs/32920134921)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32920134845](https://github.com/sgl-project/sglang/actions/runs/32920134845)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32920134939](https://github.com/sgl-project/sglang/actions/runs/32920134939)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->