### PR TITLE
[Test] Unified radix cache tests write markers into the pool, not a copy

### DIFF
--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -3963,10 +3963,11 @@ class UnifiedRadixCacheSuite:
     def _fill_full_kv(self, allocator, indices, marker):
         kv_pool = self._get_full_kv_pool(allocator)
         layer_id = kv_pool.start_layer
-        k_buf = kv_pool.get_key_buffer(layer_id)
-        v_buf = kv_pool.get_value_buffer(layer_id)
-        k_buf[indices].fill_(marker)
-        v_buf[indices].fill_(marker + 1)
+        # Assign through __setitem__: `buf[indices]` is an advanced-index copy,
+        # so `.fill_()` on it leaves the pool untouched and every bytes-match
+        # assertion downstream compares zeros to zeros.
+        kv_pool.get_key_buffer(layer_id)[indices] = marker
+        kv_pool.get_value_buffer(layer_id)[indices] = marker + 1
 
     def _snapshot_full_kv(self, allocator, indices):
         kv_pool = self._get_full_kv_pool(allocator)
@@ -3981,9 +3982,10 @@ class UnifiedRadixCacheSuite:
             return
         mamba_indices = indices.reshape(-1)
         mamba_cache = req_to_token_pool.mamba_pool.mamba_cache
-        mamba_cache.temporal[:, mamba_indices].fill_(marker)
+        # See _fill_full_kv: assign, never fill_ an advanced-index copy.
+        mamba_cache.temporal[:, mamba_indices] = marker
         for offset, conv_buf in enumerate(mamba_cache.conv, start=1):
-            conv_buf[:, mamba_indices].fill_(marker + offset)
+            conv_buf[:, mamba_indices] = marker + offset
 
     def _snapshot_mamba_state(self, req_to_token_pool, indices):
         mamba_indices = indices.reshape(-1)


### PR DESCRIPTION
## Problem

Two helpers in the unified radix cache unit suite write their marker into a
*copy* of the pool, not the pool:

```python
k_buf[indices].fill_(marker)          # advanced indexing -> new tensor
mamba_cache.temporal[:, mamba_indices].fill_(marker)
```

`buf[indices]` with a tensor index is advanced indexing, which returns a fresh
tensor; `.fill_()` mutates that temporary and the pool keeps its zeros.

Every downstream assertion of the form "the loaded bytes equal the producer's"
is therefore comparing zeros to zeros — `test_hicache_load_back_restores_data`,
`test_hicache_l3_prefetch_roundtrip`, `test_buffer_only_read_path_roundtrip`
and the SWA data checks all pass unconditionally. A load-back that restored the
wrong slot, or restored nothing at all, would not turn any of them red.

Reproduced standalone:

```
>>> t = torch.zeros(3, 8); t[:, torch.tensor([1, 2])].fill_(5); t.sum()
tensor(0.)
```

## Fix

Assign through `__setitem__`, which is an in-place `index_put_`.

## Verification

H200, `-k 'buffer or hicache'` over the whole config matrix: **418 passed, 403
skipped, 0 failed** — identical to before the fix, so the now-live comparisons
hold on current `main`. The point is that they can fail from here on.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32921455790](https://github.com/sgl-project/sglang/actions/runs/32921455790)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32922623099](https://github.com/sgl-project/sglang/actions/runs/32922623099)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32921455764](https://github.com/sgl-project/sglang/actions/runs/32921455764)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->