### PR TITLE
Fix deterministic chunked prefill starvation

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1569,6 +1569,18 @@ class Scheduler(
             get_int_env_var(env_var, default_size) if env_var else None
         )
 
+        if (
+            self.truncation_align_size is not None
+            and self.chunked_prefill_size is not None
+            and self.chunked_prefill_size < self.truncation_align_size
+        ):
+            raise ValueError(
+                "chunked_prefill_size must be at least the deterministic prefill "
+                f"alignment size ({self.truncation_align_size}) for the "
+                f"{prefill_backend} attention backend; got "
+                f"chunked_prefill_size={self.chunked_prefill_size}."
+            )
+
     def init_request_dispatcher(self):
         self._request_dispatcher = TypeBasedDispatcher(
             [

--- a/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
+++ b/test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py
@@ -1,7 +1,9 @@
 import logging
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
+import sglang.srt.managers.scheduler as scheduler_module
 from sglang.srt.environ import envs
 from sglang.srt.managers.scheduler import Scheduler
 from sglang.srt.runtime_context import get_parallel
@@ -121,6 +123,58 @@ class TestSchedulerInitReqMaxNewTokens(unittest.TestCase):
                     scheduler = self._new_scheduler()
                     req = self._new_req(max_new_tokens=64)
                     self.assertEqual(self._init_and_check(scheduler, req), 64)
+
+    def test_deterministic_chunked_prefill_requires_alignment_sized_chunk(self):
+        """Reject a configuration that would otherwise requeue every chunk.
+
+        A 129-token request with a 128-token chunk never becomes runnable when
+        deterministic Triton prefill requires 4096-token-aligned truncation.
+        Failing during scheduler initialization avoids starving that request.
+        """
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.chunked_prefill_size = 128
+        deterministic = SimpleNamespace(enable_deterministic_inference=True)
+
+        with (
+            patch.object(
+                scheduler_module,
+                "get_exec",
+                return_value=SimpleNamespace(deterministic=deterministic),
+            ),
+            patch.object(
+                scheduler_module,
+                "attention_backends",
+                return_value=("triton", "triton"),
+            ),
+            patch.object(scheduler_module, "get_int_env_var", return_value=4096),
+        ):
+            with self.assertRaisesRegex(
+                ValueError,
+                "chunked_prefill_size must be at least the deterministic prefill",
+            ):
+                scheduler.init_deterministic_inference_config()
+
+    def test_deterministic_chunked_prefill_accepts_alignment_sized_chunk(self):
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.chunked_prefill_size = 4096
+        deterministic = SimpleNamespace(enable_deterministic_inference=True)
+
+        with (
+            patch.object(
+                scheduler_module,
+                "get_exec",
+                return_value=SimpleNamespace(deterministic=deterministic),
+            ),
+            patch.object(
+                scheduler_module,
+                "attention_backends",
+                return_value=("triton", "triton"),
+            ),
+            patch.object(scheduler_module, "get_int_env_var", return_value=4096),
+        ):
+            scheduler.init_deterministic_inference_config()
+
+        self.assertEqual(scheduler.truncation_align_size, 4096)
 
     def test_context_rule_binds_tighter_than_limit(self):
         max_req_len, input_len = 32, 20


### PR DESCRIPTION
## Motivation

Fixes #36344. With deterministic inference and Triton attention, a chunked-prefill size smaller than the deterministic truncation alignment can permanently requeue a request. For example, a 129-token request with `--chunked-prefill-size 128` and the default 4096-token alignment never makes admission progress.

## Modifications

- Validate deterministic prefill configuration during scheduler initialization.
- Raise a clear `ValueError` when `chunked_prefill_size` is smaller than the selected prefill backend's deterministic alignment, rather than accepting a configuration that can starve requests indefinitely.
- Add regression tests for the failing Triton boundary (`128 < 4096`) and the valid equality boundary (`4096 == 4096`).

## Accuracy Tests

Not applicable. This change rejects an invalid scheduler configuration before any model forward pass and does not modify inference kernels or model outputs.

## Speed Tests and Profiling

Not applicable. The validation runs once during scheduler initialization; it has no request-path overhead.

## Verification

- `pytest test/registered/unit/managers/test_prefill_adder.py test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py -q`
  - 36 passed, 554 subtests passed
- `ruff check test/registered/unit/managers/test_scheduler_init_req_max_new_tokens.py`
  - passed
- `git diff --check`
  - passed

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — N/A: configuration validation and error message are self-contained.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). — N/A; see above.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32922976511](https://github.com/sgl-project/sglang/actions/runs/32922976511)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32922976083](https://github.com/sgl-project/sglang/actions/runs/32922976083)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32922976195](https://github.com/sgl-project/sglang/actions/runs/32922976195)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->