### PR TITLE
[DeepSeek-V4] Seed EP topology in shared-expert fusion test

### DIFF
--- a/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
+++ b/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
@@ -12,7 +12,7 @@ from sglang.srt.layers.moe.utils import (
 )
 from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
 from sglang.srt.models.deepseek_v4_dspark import DeepseekV4ForCausalLMDSpark
-from sglang.srt.runtime_context import get_context, get_exec, get_flags
+from sglang.srt.runtime_context import get_context, get_exec, get_flags, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -26,6 +26,13 @@ class TestDeepseekV4SharedExpertFusionPolicy(CustomTestCase):
     exists (``shared_experts_fusion_disable_reason``); the answer is installed
     on the ACTIVE moe flag, and the config bag keeps the user's intent.
     """
+
+    def setUp(self):
+        # The fusion gate reads live EP topology, but this unit test does not
+        # initialize distributed process groups.
+        parallel_override = get_parallel().override(moe_ep_size=1)
+        parallel_override.__enter__()
+        self.addCleanup(parallel_override.__exit__, None, None, None)
 
     def _publish(self, enforce):
         override = get_context().override_server_args(


### PR DESCRIPTION
## Motivation

PR #35505 made the DeepSeek-V4 shared-expert fusion gate consult the live MoE expert-parallel topology. The existing CPU unit test publishes configuration but does not initialize distributed process groups or provide a topology override, so it fails with:

```
AssertionError: expert model parallel group is not initialized
```

This is visible in [PR #35791's base-A CPU job](https://github.com/sgl-project/sglang/actions/runs/32911287489/job/98005974375) and reproduces directly on current `main`.

## Modification

Seed the single-rank topology assumed by `TestDeepseekV4SharedExpertFusionPolicy` with a scoped `get_parallel().override(moe_ep_size=1)`.

The override is automatically restored through `addCleanup`. Production behavior remains unchanged and still fails loudly when live topology is read before distributed initialization.

## Tests

- Before the patch, the targeted test fails with the uninitialized `_MOE_EP` assertion.
- `python test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py -f` — 7 passed.
- Targeted pre-commit hooks — passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #32923781002](https://github.com/sgl-project/sglang/actions/runs/32923781002)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32923813636](https://github.com/sgl-project/sglang/actions/runs/32923813636)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32923780943](https://github.com/sgl-project/sglang/actions/runs/32923780943)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->