### PR TITLE
Fix DSV4 shared-fusion CPU unit test after the EP guard landed

### DIFF
--- a/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
+++ b/test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py
@@ -12,7 +12,7 @@ from sglang.srt.layers.moe.utils import (
 )
 from sglang.srt.models.deepseek_v4 import DeepseekV4ForCausalLM
 from sglang.srt.models.deepseek_v4_dspark import DeepseekV4ForCausalLMDSpark
-from sglang.srt.runtime_context import get_context, get_exec, get_flags
+from sglang.srt.runtime_context import get_context, get_exec, get_flags, get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -26,6 +26,12 @@ class TestDeepseekV4SharedExpertFusionPolicy(CustomTestCase):
     exists (``shared_experts_fusion_disable_reason``); the answer is installed
     on the ACTIVE moe flag, and the config bag keeps the user's intent.
     """
+
+    def setUp(self):
+        super().setUp()
+        cm = get_parallel().override(moe_ep_size=1)
+        cm.__enter__()
+        self.addCleanup(cm.__exit__, None, None, None)
 
     def _publish(self, enforce):
         override = get_context().override_server_args(


### PR DESCRIPTION
## Motivation

`test/registered/unit/models/test_deepseek_v4_shared_expert_fusion.py` fails in `base-a-test-cpu` with:

```
AssertionError: expert model parallel group is not initialized
```

#35505 added an EP guard to `DeepseekV4ForCausalLM.shared_experts_fusion_disable_reason`:

```python
if get_parallel().moe_ep_size > 1 and not uses_per_rank_fused_shared_slots():
```

`moe_ep_size` resolves through `get_moe_ep_group()`, which asserts when no MoE EP group is installed — as on a CPU runner. Before that commit the gate only read the quant config and an exec flag, so the test was fine.

Six of the seven tests in the class reach the gate, either directly or via `_install()` → `install_shared_experts_fusion_decision`. `run_unittest_files` invokes each file with `-f` (failfast), so only the first one gets reported.

## Modifications

Override `moe_ep_size=1` in `setUp`, stating a single-rank topology for every case in the class. With the override installed, `_v` returns it directly and the canonical getter is never called.

This is what `test/registered/unit/models/test_shared_experts_fusion_gates.py` already does for every other family's gate, for the same reason.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32924134249](https://github.com/sgl-project/sglang/actions/runs/32924134249)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32924134087](https://github.com/sgl-project/sglang/actions/runs/32924134087)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32924134334](https://github.com/sgl-project/sglang/actions/runs/32924134334)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->