### PR TITLE
 [NPU][Quant] Fix ModelSlim W8A8 loading for Qwen3.8-27B-W8A8: resolve fused in_proj_qkvz scheme, quantize vision encoder, flatten 3-D inputs in NPU W8A8 kernels

### DIFF
--- a/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
+++ b/python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
@@ -96,9 +96,11 @@ class NPUW8A8Int8LinearMethod(_NPULinearMethodBase):
         from sglang.srt.layers.linear import RowParallelLinear
 
         original_dtype = x.dtype
+        original_shape = x.shape
+        x_2d = x.reshape(-1, original_shape[-1]) if x.ndim > 2 else x
         if original_dtype != torch.int8:
-            x = torch.ops.npu.npu_quantize(
-                x,
+            x_2d = torch.ops.npu.npu_quantize(
+                x_2d,
                 layer.aclnn_input_scale_reciprocal,
                 layer.aclnn_input_offset,
                 torch.qint8,
@@ -111,13 +113,16 @@ class NPUW8A8Int8LinearMethod(_NPULinearMethodBase):
             quant_bias = None
         else:
             quant_bias = layer.quant_bias
-        return torch.ops.npu.npu_quant_matmul(
-            x,
+        out = torch.ops.npu.npu_quant_matmul(
+            x_2d,
             layer.weight,
             layer.deq_scale,
             bias=quant_bias,
             output_dtype=original_dtype,
         )
+        if x.ndim > 2:
+            out = out.reshape(*original_shape[:-1], -1)
+        return out
 
 
 class NPUW8A8Int8DynamicLinearMethod(_NPULinearMethodBase):
@@ -142,10 +147,23 @@ class NPUW8A8Int8DynamicLinearMethod(_NPULinearMethodBase):
             """dynamic_scale is calculated in malprolog kernel"""
             original_dtype = torch.bfloat16
             quant_out, dynamic_scale = x
-        else:
-            original_dtype = x.dtype
-            quant_out, dynamic_scale = torch.ops.npu.npu_dynamic_quant(x)
-        return torch.ops.npu.npu_quant_matmul(
+            return torch.ops.npu.npu_quant_matmul(
+                quant_out,
+                layer.weight,
+                layer.weight_scale,
+                pertoken_scale=dynamic_scale.flatten(),
+                bias=bias,
+                output_dtype=original_dtype,
+            )
+
+        # The vision encoder feeds linears a 3-D (seq, 1, hidden) layout that
+        # the NPU quant ops only accept flattened to 2-D.  Fold the leading
+        # batch dims into m for the quantized GEMM, then restore the layout.
+        original_dtype = x.dtype
+        original_shape = x.shape
+        x_2d = x.reshape(-1, original_shape[-1]) if x.ndim > 2 else x
+        quant_out, dynamic_scale = torch.ops.npu.npu_dynamic_quant(x_2d)
+        out = torch.ops.npu.npu_quant_matmul(
             quant_out,
             layer.weight,
             layer.weight_scale,
@@ -153,6 +171,9 @@ class NPUW8A8Int8DynamicLinearMethod(_NPULinearMethodBase):
             bias=bias,
             output_dtype=original_dtype,
         )
+        if x.ndim > 2:
+            out = out.reshape(*original_shape[:-1], -1)
+        return out
 
 
 class NPUMXFP8LinearMethod(_NPULinearMethodBase):

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -281,9 +281,20 @@ class ModelSlimConfig(QuantizationConfig):
             prefix_in_quant_config = prefix
             proj_name = prefix.split(".")[-1]
             if proj_name in packed_modules_mapping_subset:
-                prefix_in_quant_config = prefix.replace(
+                component = prefix.replace(
                     proj_name, packed_modules_mapping_subset[proj_name][0]
                 )
+                # Redirect to the unfused component name only when the
+                # checkpoint actually stores it that way (e.g. Qwen3.8-27B,
+                # whose fused in_proj_qkvz Linear must read the unfused
+                # in_proj_qkv / in_proj_z scheme entries).  Qwen3-Next-80B
+                # instead stores the fused name directly, so keep the original
+                # prefix and let it resolve against the fused entry -- a
+                # blanket redirect here would miss it and silently fall back
+                # to an unquantized Linear (then KeyError on weight_offset).
+                resolved_component = self._resolve_quant_prefix(component)
+                if (resolved_component + ".weight") in self.quant_description:
+                    prefix_in_quant_config = resolved_component
             prefix_in_quant_config = self._resolve_quant_prefix(prefix_in_quant_config)
             if self.is_layer_skipped(
                 prefix, packed_modules_mapping_subset

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -209,18 +209,31 @@ class ModelSlimConfig(QuantizationConfig):
         Kimi-K3's upstream model uses ``mlp`` internally while its ModelSlim
         checkpoint retains the Hugging Face ``block_sparse_moe`` hierarchy.
         Some multimodal checkpoints also keep the outer ``language_model``
-        prefix.  Resolve those layout-only differences at the quantization
-        boundary.
+        prefix, and Qwen3.5-GDN fuses the per-projection ``in_proj_*`` linears
+        on the model side while the checkpoint keeps the unfused names.
+        Resolve those layout-only differences at the quantization boundary.
         """
         candidates = [prefix]
         if ".mlp." in prefix:
             candidates.append(prefix.replace(".mlp.", ".block_sparse_moe."))
 
+        # Fused GDN projections (in_proj_qkvz = in_proj_qkv + in_proj_z,
+        # in_proj_ba = in_proj_b + in_proj_a): the checkpoint records the
+        # unfused per-projection schemes.
+        for fused, unfused in (
+            (".in_proj_qkvz", (".in_proj_qkv", ".in_proj_z")),
+            (".in_proj_ba", (".in_proj_b", ".in_proj_a")),
+        ):
+            if fused in prefix:
+                candidates.extend(prefix.replace(fused, u) for u in unfused)
+
         for candidate in list(candidates):
             if candidate.startswith("language_model."):
                 candidates.append(candidate.removeprefix("language_model."))
-            else:
-                candidates.append(f"language_model.{candidate}")
+            elif candidate.startswith("model.visual."):
+                candidates.append(candidate.removeprefix("model."))
+            elif candidate.startswith("visual."):
+                candidates.append(f"model.{candidate}")
 
         return list(dict.fromkeys(candidates))
 

--- a/python/sglang/srt/layers/quantization/modelslim/modelslim.py
+++ b/python/sglang/srt/layers/quantization/modelslim/modelslim.py
@@ -209,28 +209,20 @@ class ModelSlimConfig(QuantizationConfig):
         Kimi-K3's upstream model uses ``mlp`` internally while its ModelSlim
         checkpoint retains the Hugging Face ``block_sparse_moe`` hierarchy.
         Some multimodal checkpoints also keep the outer ``language_model``
-        prefix, and Qwen3.5-GDN fuses the per-projection ``in_proj_*`` linears
-        on the model side while the checkpoint keeps the unfused names.
-        Resolve those layout-only differences at the quantization boundary.
+        prefix.  Resolve those layout-only differences at the quantization
+        boundary.
         """
         candidates = [prefix]
         if ".mlp." in prefix:
             candidates.append(prefix.replace(".mlp.", ".block_sparse_moe."))
 
-        # Fused GDN projections (in_proj_qkvz = in_proj_qkv + in_proj_z,
-        # in_proj_ba = in_proj_b + in_proj_a): the checkpoint records the
-        # unfused per-projection schemes.
-        for fused, unfused in (
-            (".in_proj_qkvz", (".in_proj_qkv", ".in_proj_z")),
-            (".in_proj_ba", (".in_proj_b", ".in_proj_a")),
-        ):
-            if fused in prefix:
-                candidates.extend(prefix.replace(fused, u) for u in unfused)
-
         for candidate in list(candidates):
             if candidate.startswith("language_model."):
                 candidates.append(candidate.removeprefix("language_model."))
-            elif candidate.startswith("model.visual."):
+            else:
+                candidates.append(f"language_model.{candidate}")
+
+            if candidate.startswith("model.visual."):
                 candidates.append(candidate.removeprefix("model."))
             elif candidate.startswith("visual."):
                 candidates.append(f"model.{candidate}")

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -198,6 +198,8 @@ def _get_quantization_config(
                         "q_a_proj",
                         "kv_a_proj_with_mqa",
                     ],
+                    "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+                    "in_proj_ba": ["in_proj_b", "in_proj_a"],
                     "index_qkv_proj": ["index_q_proj", "index_k_proj"],
                 },
             }

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -1307,9 +1307,7 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 # ModelSlim checkpoints quantize the vision tower as well, so
                 # forward the config for those.
                 quant_config=(
-                    quant_config
-                    if isinstance(quant_config, ModelSlimConfig)
-                    else None
+                    quant_config if isinstance(quant_config, ModelSlimConfig) else None
                 ),
                 norm_eps=getattr(config, "rms_norm_eps", 1e-6),
                 prefix=add_prefix("model.visual", prefix),

--- a/python/sglang/srt/models/qwen3_vl.py
+++ b/python/sglang/srt/models/qwen3_vl.py
@@ -45,6 +45,7 @@ from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
 from sglang.srt.layers.logits_processor import LogitsProcessor
 from sglang.srt.layers.pooler import Pooler, PoolingType
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
 from sglang.srt.layers.rotary_embedding import get_rope
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import (
@@ -1303,7 +1304,13 @@ class Qwen3VLForConditionalGeneration(nn.Module):
                 config.vision_config,
                 # NOTE: Qwen3-VL vision encoder currently supports BitsAndBytes 4-bit quantization.
                 # Other quantization methods (e.g., GPTQ, AWQ) are untested and may not be supported.
-                quant_config=None,
+                # ModelSlim checkpoints quantize the vision tower as well, so
+                # forward the config for those.
+                quant_config=(
+                    quant_config
+                    if isinstance(quant_config, ModelSlimConfig)
+                    else None
+                ),
                 norm_eps=getattr(config, "rms_norm_eps", 1e-6),
                 prefix=add_prefix("model.visual", prefix),
                 use_data_parallel=self.use_data_parallel,


### PR DESCRIPTION
Summary
ModelSlim W8A8_DYNAMIC checkpoints of Qwen3.5 (GDN hybrid, e.g. Qwen3.8-27B-w8a8) load incorrectly on Ascend NPU: the fused linear-attention projections and the whole vision tower silently fall back to unquantized loading
(int8 weights copied raw into bf16 params → garbage output, with only not found in params_dict warnings), and once quantized, the first vision-tower matmul crashes the server at warmup with an ACL parameter error.
Three independent bugs are fixed:
1. Unresolved fused-GDN scheme — the model side fuses in_proj_qkv + in_proj_z into in_proj_qkvz (and in_proj_b + in_proj_a into in_proj_ba) while the ModelSlim checkpoint records the unfused per-projection names.
   ModelSlimConfig._quant_prefix_candidates() now maps the fused names onto their shards, so in_proj_qkvz resolves to W8A8_DYNAMIC instead of falling through to UnquantizedLinearMethod (48 layers × missing
   weight_scale/weight_offset).
2. Vision encoder forced unquantized — Qwen3VLForConditionalGeneration hardcoded quant_config=None for Qwen3VLMoeVisionModel, but ModelSlim checkpoints quantize the vision tower (attn.qkv/attn.proj/mlp.linear_fc1 are
   W8A8_DYNAMIC). The config is now forwarded when isinstance(quant_config, ModelSlimConfig) (same gating as kimi_vl_moonvit.py); GPTQ/AWQ/BitsAndBytes paths keep quant_config=None exactly as before.
3. NPU W8A8 kernels reject 3-D input — the vision tower feeds linears (seq, 1, hidden) activations (x.unsqueeze(1) in Qwen3VLMoeVisionModel.forward); the bf16 path broadcasts fine but
   npu_dynamic_quant/npu_quantize/npu_quant_matmul only accept 2-D (ACL error 161002). Both NPUW8A8Int8LinearMethod and NPUW8A8Int8DynamicLinearMethod.apply now flatten leading batch dims into m for the NPU ops and restore
   the layout afterwards. 2-D inputs (all language-model layers) are byte-identical.

Changes
python/sglang/srt/layers/quantization/modelslim/modelslim.py
_quant_prefix_candidates(): add fused-GDN candidates (in_proj_qkvz → in_proj_qkv/in_proj_z, in_proj_ba → in_proj_b/in_proj_a) and model.visual. ↔ visual. prefix variants.
python/sglang/srt/models/qwen3_vl.py
Forward quant_config to Qwen3VLMoeVisionModel when it is a ModelSlimConfig.
python/sglang/srt/hardware_backend/npu/quantization/linear_method_npu.py
Flatten 3-D inputs to 2-D in both W8A8 apply() methods and restore shape on output.
Total: +54 / −13 lines across 3 files.

Functional verification
Real TP=1 server run on Ascend NPU with Qwen3.8-27B-w8a8 (--quantization modelslim):
- 0 Unsupported Linear modelslim scheme warnings (was 48), 0 not found in params_dict (was 208+)
- Server starts and passes warmup (quantized vision-tower forward)
- Text generation correct (1+1=? → 2); multimodal request correctly describes the test image (objects and colors)
- Radix cache hits observed

<details>
<summary>Accuracy</summary>
bf16
<img width="972" height="571" alt="image" src="https://github.com/user-attachments/assets/e67ce759-4dca-4a23-badf-eece45716b41" />
w8a8
<img width="1087" height="632" alt="image" src="https://github.com/user-attachments/assets/a49dfed6-41aa-4ff8-a1f7-f174fdcf4aa1" />
</details>

<details>
<summary>Performance (性能测试)</summary>
bf16
<img width="496" height="796" alt="image" src="https://github.com/user-attachments/assets/3ea0a45f-f83f-4142-af57-abae08d10a2d" />
w8a8
<img width="492" height="794" alt="image" src="https://github.com/user-attachments/assets/98e25e76-5db8-41ea-bdbe-720f7b257d90" />
</details>

Scope
Only the modelslim quantization path changes behavior; 2-D linear paths (all language-model layers) are byte-identical. The kernel change also benefits compressed-tensors W8A8 int8 on NPU, which shares
NPUW8A8Int8DynamicLinearMethod. Other quantization methods (GPTQ/AWQ/FP8/MXFP4/bnb) are untouched.

Fixes #36423 
<!-- pr-states:start -->
---
### CI States
Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33526223270](https://github.com/sgl-project/sglang/actions/runs/33526223270)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33526223118](https://github.com/sgl-project/sglang/actions/runs/33526223118)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33526223232](https://github.com/sgl-project/sglang/actions/runs/33526223232)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
