### PR TITLE
[CPU] Fix truncated KV prefix in intel_amx spec verify

### DIFF
--- a/python/sglang/srt/layers/attention/intel_amx_backend.py
+++ b/python/sglang/srt/layers/attention/intel_amx_backend.py
@@ -215,7 +215,6 @@ class IntelAMXAttnBackend(AttentionBackend):
         seq_lens, extend_seq_lens, extend_start_loc, tree_mask = self.extend_metadata
 
         _, max_extend_len = self.forward_metadata
-        seq_lens = forward_batch.seq_lens
         if seq_lens.dtype != torch.int64:
             seq_lens = seq_lens.to(torch.int64)
 
@@ -262,7 +261,6 @@ class IntelAMXAttnBackend(AttentionBackend):
             seq_lens = forward_batch.seq_lens
 
         q = q.reshape(-1, layer.tp_q_head_num * layer.qk_head_dim)
-        seq_lens = forward_batch.seq_lens
         if seq_lens.dtype != torch.int64:
             seq_lens = seq_lens.to(torch.int64)
 


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Speculative decoding on CPU with the `intel_amx` attention backend produces output the target model would never have generated, causing the accuracy to be significantly worsened.

Fixes regression caused by #24013 

## Modifications

<!-- Detail the changes made in this pull request. -->

`forward_extend` and `forward_decode` both resolved `seq_lens` from the per-forward
metadata, then overwrote it:

```python
seq_lens, extend_seq_lens, extend_start_loc, tree_mask = self.extend_metadata
...
seq_lens = forward_batch.seq_lens          # discards the resolved value
if seq_lens.dtype != torch.int64:
    seq_lens = seq_lens.to(torch.int64)
```

In `TARGET_VERIFY` mode `_build_extend_metadata` sets
`seq_lens = forward_batch.seq_lens + num_draft_tokens`, because `extend_attention_cpu`
derives the committed prefix by subtraction (`seq_len_prefix = seq_lens - extend_seq_lens`).
Overwritten, the kernel saw a prefix short by `num_draft_tokens`: the target scored every
draft token against a hole in its own context, and greedy verify accepted tokens its own
argmax would not have produced. `forward_decode` likewise discarded the expanded
per-candidate lengths used when `speculative_num_steps > 1`.

This deletes the two re-reads and keeps the int64 cast. Non-speculative extend is unaffected: there
`forward_batch.seq_lens` already equals prefix + extend.


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

GSM8K with greedy sampling:

| Target | Algorithm | steps/topk/draft | Baseline | Spec, before | Spec, after |
|---|---|---|---|---|---|
| MiMo-7B-RL | NEXTN | 1 / 1 / 2 | 0.792 | 0.010 | 0.792 |
| Llama-2-7b-chat-hf | EAGLE | 3 / 1 / 4 | 0.244 | 0.006 | 0.244 |

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Not measured - it's a correctness change

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32925792115](https://github.com/sgl-project/sglang/actions/runs/32925792115)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32937057026](https://github.com/sgl-project/sglang/actions/runs/32937057026)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32925792202](https://github.com/sgl-project/sglang/actions/runs/32925792202)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->