### PR TITLE
[NPU] Make Ascend fused top-k/top-p sampling capture-safe and dtype-correct

### DIFF
--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -642,6 +642,11 @@ def top_k_top_p_min_p_sampling_from_logits_ascend(
         use_fused_top_k_top_p = bool(torch.all((top_ks <= 1024) & (top_ks >= 1)))
 
     if use_fused_top_k_top_p:
+        # torch_npu.npu_top_k_top_p requires ``top_ps`` to share the logits
+        # dtype (e.g. DT_BFLOAT16); SamplingBatchInfo builds top_ps as float32,
+        # which the op rejects with AclNN_Parameter_Error (EZ1001, 161002).
+        # Cast to the logits dtype so the fused path works for every caller.
+        top_ps = top_ps.to(dtype=logits.dtype)
         logits_top_k_top_p = torch_npu.npu_top_k_top_p(logits, top_ps, top_ks)
         probs_top_k_top_p = logits_top_k_top_p.softmax(dim=-1)
 

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -612,6 +612,12 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
     return batch_next_token_ids
 
 
+def _ascend_sampling_stream_capturing() -> bool:
+    if not is_npu():
+        return False
+    return bool(torch.npu.is_current_stream_capturing())
+
+
 def top_k_top_p_min_p_sampling_from_logits_ascend(
     logits: torch.Tensor,
     top_ks: torch.Tensor,
@@ -625,10 +631,17 @@ def top_k_top_p_min_p_sampling_from_logits_ascend(
 
     Takes temperature-scaled logits as input (softmax is applied internally).
     """
-    # torch_npu.npu_top_k_top_p requires top_k value range in [1, 1024]
-    if hasattr(torch_npu, "npu_top_k_top_p") and torch.all(
-        (top_ks <= 1024) & (top_ks >= 1)
+    # torch_npu.npu_top_k_top_p requires top_k value range in [1, 1024].
+    # Reading the device predicate on the host is forbidden during graph capture,
+    # so capture the tensor-only fallback instead.
+    use_fused_top_k_top_p = False
+    if (
+        hasattr(torch_npu, "npu_top_k_top_p")
+        and not _ascend_sampling_stream_capturing()
     ):
+        use_fused_top_k_top_p = bool(torch.all((top_ks <= 1024) & (top_ks >= 1)))
+
+    if use_fused_top_k_top_p:
         logits_top_k_top_p = torch_npu.npu_top_k_top_p(logits, top_ps, top_ks)
         probs_top_k_top_p = logits_top_k_top_p.softmax(dim=-1)
 

--- a/test/registered/unit/sampling/test_ascend_sampler_capture_safety.py
+++ b/test/registered/unit/sampling/test_ascend_sampler_capture_safety.py
@@ -1,0 +1,109 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.layers import sampler
+
+
+def _sample(
+    *,
+    logits: torch.Tensor | None = None,
+    top_k: int = 2,
+) -> torch.Tensor:
+    logits = logits if logits is not None else torch.tensor([[4.0, 3.0, 2.0, 1.0]])
+    return sampler.top_k_top_p_min_p_sampling_from_logits_ascend(
+        logits=logits,
+        top_ks=torch.tensor([top_k], dtype=torch.int32),
+        top_ps=torch.tensor([0.9], dtype=torch.float32),
+        min_ps=torch.tensor([0.0], dtype=torch.float32),
+        need_min_p_sampling=False,
+        sampling_seed=None,
+        positions=torch.tensor([0], dtype=torch.int64),
+    )
+
+
+def test_capture_state_is_false_off_npu(monkeypatch) -> None:
+    monkeypatch.setattr(sampler, "is_npu", lambda: False)
+
+    assert sampler._ascend_sampling_stream_capturing() is False
+
+
+def test_capture_mode_avoids_host_guard_and_fused_kernel(monkeypatch) -> None:
+    fused_calls = []
+
+    def _fused(*args, **kwargs):
+        fused_calls.append((args, kwargs))
+        raise AssertionError("fused kernel must not run during graph capture")
+
+    def _forbidden_all(*args, **kwargs):
+        raise AssertionError("torch.all must not run during graph capture")
+
+    monkeypatch.setattr(
+        sampler,
+        "torch_npu",
+        SimpleNamespace(npu_top_k_top_p=_fused),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        sampler,
+        "_ascend_sampling_stream_capturing",
+        lambda: True,
+    )
+    monkeypatch.setattr(sampler.torch, "all", _forbidden_all)
+
+    output = _sample()
+
+    assert output.shape == (1,)
+    assert fused_calls == []
+
+
+def test_eager_eligible_top_k_uses_fused_kernel(monkeypatch) -> None:
+    fused_calls = []
+
+    def _fused(logits, top_ps, top_ks):
+        fused_calls.append((logits, top_ps, top_ks))
+        return logits
+
+    monkeypatch.setattr(
+        sampler,
+        "torch_npu",
+        SimpleNamespace(npu_top_k_top_p=_fused),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        sampler,
+        "_ascend_sampling_stream_capturing",
+        lambda: False,
+    )
+
+    output = _sample(top_k=2)
+
+    assert output.shape == (1,)
+    assert len(fused_calls) == 1
+
+
+def test_eager_out_of_range_top_k_uses_fallback(monkeypatch) -> None:
+    fused_calls = []
+
+    def _fused(*args, **kwargs):
+        fused_calls.append((args, kwargs))
+        raise AssertionError("out-of-range top_k must use the fallback")
+
+    monkeypatch.setattr(
+        sampler,
+        "torch_npu",
+        SimpleNamespace(npu_top_k_top_p=_fused),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        sampler,
+        "_ascend_sampling_stream_capturing",
+        lambda: False,
+    )
+
+    output = _sample(top_k=2048)
+
+    assert output.shape == (1,)
+    assert fused_calls == []

--- a/test/registered/unit/sampling/test_ascend_sampler_capture_safety.py
+++ b/test/registered/unit/sampling/test_ascend_sampler_capture_safety.py
@@ -78,10 +78,12 @@ def test_eager_eligible_top_k_uses_fused_kernel(monkeypatch) -> None:
         lambda: False,
     )
 
-    output = _sample(top_k=2)
+    logits = torch.tensor([[4.0, 3.0, 2.0, 1.0]], dtype=torch.bfloat16)
+    output = _sample(logits=logits, top_k=2)
 
     assert output.shape == (1,)
     assert len(fused_calls) == 1
+    assert fused_calls[0][1].dtype == logits.dtype
 
 
 def test_eager_out_of_range_top_k_uses_fallback(monkeypatch) -> None:

--- a/test/registered/unit/sampling/test_ascend_sampler_capture_safety.py
+++ b/test/registered/unit/sampling/test_ascend_sampler_capture_safety.py
@@ -1,10 +1,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
+import sys
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from sglang.srt.layers import sampler
+from sglang.test.ci.ci_register import register_npu_ci
+
+register_npu_ci(est_time=1, suite="base-a-test-1-npu-a2")
 
 
 def _sample(
@@ -109,3 +114,7 @@ def test_eager_out_of_range_top_k_uses_fallback(monkeypatch) -> None:
 
     assert output.shape == (1,)
     assert fused_calls == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

The Ascend sampling path guards the fused torch_npu.npu_top_k_top_p
kernel with a host-side read of a device predicate:
bool(torch.all((top_ks <= 1024) & (top_ks >= 1))). This has two
problems:

- Reading a device tensor on the host is forbidden during NPU graph
  capture, so neither the guard nor the fused kernel may run while
  capturing.
- The fused op requires top_ps to share the logits dtype (e.g.
  DT_BFLOAT16), but SamplingBatchInfo always builds top_ps as float32,
  so the eager fused path failed with AclNN_Parameter_Error
  (EZ1001, 161002).
## Modifications
- Add _ascend_sampling_stream_capturing() and gate the fused path on
  it: during capture, unconditionally take the tensor-only fallback
  without evaluating the host predicate; in eager mode, evaluate the
  top_k range check and dispatch to the fused kernel as before.
- Cast top_ps to the logits dtype right before the fused call so the
  op's homogeneous-dtype contract holds for every caller.
- Add mock-based unit tests (test_ascend_sampler_capture_safety.py)
  covering: the capture check returns False off NPU, capture mode
  never touches torch.all or the fused kernel, eager in-range top_k
  hits the fused kernel with dtype-aligned top_ps, and out-of-range
  top_k falls back.

## Accuracy Tests

NA

## Speed Tests and Profiling

NA
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32928948258](https://github.com/sgl-project/sglang/actions/runs/32928948258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32928948198](https://github.com/sgl-project/sglang/actions/runs/32928948198)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32928948188](https://github.com/sgl-project/sglang/actions/runs/32928948188)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->