### PR TITLE
Perf: Remove instances of torch.nonzero()

### DIFF
--- a/python/sglang/kernels/aot/tests/test_flash_attention.py
+++ b/python/sglang/kernels/aot/tests/test_flash_attention.py
@@ -75,7 +75,7 @@ def unpad_input(hidden_states, attention_mask, unused_mask=None):
     )
     seqlens_in_batch = all_masks.sum(dim=-1, dtype=torch.int32)
     used_seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
-    indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
+    indices = all_masks.flatten().nonzero(as_tuple=False).flatten()
     max_seqlen_in_batch = seqlens_in_batch.max().item()
     cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
     # TD [2022-03-04] We don't want to index with a bool mask, because Pytorch will expand the

--- a/python/sglang/kernels/ops/attention/flash_attn/cute/testing.py
+++ b/python/sglang/kernels/ops/attention/flash_attn/cute/testing.py
@@ -73,7 +73,7 @@ def unpad_input(hidden_states, attention_mask, unused_mask=None):
     used_seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
     in_fake_mode = active_fake_mode() is not None
     if not in_fake_mode:
-        indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
+        indices = all_masks.flatten().nonzero(as_tuple=False).flatten()
         max_seqlen_in_batch = seqlens_in_batch.max().item()
     else:
         # torch.nonzero and .item() are not supported in FakeTensorMode

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -2287,25 +2287,25 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
             )
 
         if local_embedding_layout is None:
-            text_source_ids = torch.nonzero(
+            text_source_ids = 
                 (text_pos >= row_start) & (text_pos < row_stop),
                 as_tuple=False,
-            ).view(-1)
+            .nonzero().view(-1)
             text_row_ids = text_pos.index_select(0, text_source_ids) - row_start
             img_global_ids = img_pos.index_select(
                 0,
-                torch.nonzero(
+                
                     (img_pos >= row_start) & (img_pos < row_stop),
                     as_tuple=False,
-                ).view(-1),
+                .nonzero().view(-1),
             )
             img_row_ids = img_global_ids - row_start
             audio_global_ids = audio_pos.index_select(
                 0,
-                torch.nonzero(
+                
                     (audio_pos >= row_start) & (audio_pos < row_stop),
                     as_tuple=False,
-                ).view(-1),
+                .nonzero().view(-1),
             )
             audio_row_ids = audio_global_ids - row_start
         else:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/denoise_loop.py
@@ -133,10 +133,10 @@ def _build_local_embedding_layout(
     row_stop = row_start + local_seq_len
 
     def local_ids(pos: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
-        source_ids = torch.nonzero(
+        source_ids = 
             (pos >= row_start) & (pos < row_stop),
             as_tuple=False,
-        ).view(-1)
+        .nonzero().view(-1)
         return source_ids.to(device), pos.index_select(0, source_ids).to(device)
 
     text_source_start = min(row_start, int(text_pos.shape[0]))
@@ -216,8 +216,8 @@ class MiniMaxH3DenoiseBranch:
         self.img_target_seq_idx = self.img_pos_dev[self.update_mask_dev]
         self.audio_target_seq_idx = self.audio_pos_dev[self.audio_update_mask_dev]
         self.audio_ref_seq_idx = self.audio_pos_dev[~self.audio_update_mask_dev]
-        self.cond_row_idx = torch.nonzero(~self.update_mask_dev).view(-1)
-        self.audio_ref_row_idx = torch.nonzero(~self.audio_update_mask_dev).view(-1)
+        self.cond_row_idx = ~self.update_mask_dev.nonzero().view(-1)
+        self.audio_ref_row_idx = ~self.audio_update_mask_dev.nonzero().view(-1)
         # rows that keep the video timestep each step: text, padding, and
         # video target rows — everything the three overwrite sets do not cover
         self.n_video_timestep_rows = (

--- a/python/sglang/multimodal_gen/test/unit/test_minimax_h3_denoise_loop.py
+++ b/python/sglang/multimodal_gen/test/unit/test_minimax_h3_denoise_loop.py
@@ -167,13 +167,13 @@ def test_local_text_layout_is_a_contiguous_prefix_per_ulysses_rank():
                 start = int(layout["text_source_start"])
                 stop = int(layout["text_source_stop"])
                 row_start = rank * (branch.seq_len // world_size)
-                expected = torch.nonzero(
+                expected = 
                     (torch.arange(text_len) >= row_start)
                     & (
                         torch.arange(text_len)
                         < row_start + branch.seq_len // world_size
                     )
-                ).view(-1)
+                .nonzero().view(-1)
                 assert expected.tolist() == list(range(start, stop))
 
 

--- a/python/sglang/srt/eplb/lplb_solver.py
+++ b/python/sglang/srt/eplb/lplb_solver.py
@@ -128,11 +128,11 @@ class LPLBSolver:
         # Separate single-copy vs replicated experts.
         # Stored as int64 so they can be used directly as index tensors in
         # _solve without per-call .long() casts (Tier 1 optimization).
-        self.log_single = torch.nonzero(logcnt == 1).flatten().to(torch.int64)
+        self.log_single = logcnt == 1.nonzero().flatten().to(torch.int64)
         self.phy_single = log2phy[self.log_single, 0].to(torch.int64)
-        self.log_replicated = torch.nonzero(logcnt > 1).flatten().to(torch.int64)
+        self.log_replicated = logcnt > 1.nonzero().flatten().to(torch.int64)
         self.phy_replicated = (
-            torch.nonzero(logcnt[phy2log] > 1).flatten().to(torch.int64)
+            logcnt[phy2log] > 1.nonzero().flatten().to(torch.int64)
         )
 
         self.num_single = len(self.log_single)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -1864,7 +1864,7 @@ class DeepseekV4AscendAttnBackend(
             n_draft, dtype=start_positions.dtype
         ).view(1, -1)
         boundary_mask = abs_positions % ratio == 0
-        indices = torch.nonzero(boundary_mask.flatten(), as_tuple=False).flatten()
+        indices = boundary_mask.flatten().nonzero(as_tuple=False).flatten()
 
         if indices.numel() == 0:
             return

--- a/python/sglang/srt/layers/logprob_processor.py
+++ b/python/sglang/srt/layers/logprob_processor.py
@@ -551,7 +551,7 @@ class InputLogprobProcessor:
             chunk_indices = global_indices - start_idx
             # Get the positions in the original array where chunk_mask is True
             # This is needed to correctly index into extend_input_logprob_token_ids_gpu
-            mask_indices = torch.nonzero(chunk_mask, as_tuple=True)[0]
+            mask_indices = chunk_mask.nonzero(as_tuple=True)[0]
 
             # Get the logits for this chunk. Each chunk must own its output:
             # writing through the shared graph logits buffer would alias

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -2797,7 +2797,7 @@ class MHATokenToKVPool(KVCache):
         if not (_is_cuda or _is_hip):
             row_offsets = torch.arange(loc_2d.shape[1], device=loc_2d.device)
             valid_mask = row_offsets[None, :] < commit_lens.to(torch.int64)[:, None]
-            valid_idx = torch.nonzero(valid_mask.reshape(-1), as_tuple=False).flatten()
+            valid_idx = valid_mask.reshape(-1).nonzero(as_tuple=False).flatten()
             if valid_idx.numel() == 0:
                 return
             self.set_kv_buffer(

--- a/test/registered/kernels/ops/attention/test_flash_attention_4.py
+++ b/test/registered/kernels/ops/attention/test_flash_attention_4.py
@@ -105,7 +105,7 @@ def unpad_input(hidden_states, attention_mask, unused_mask=None):
     )
     seqlens_in_batch = all_masks.sum(dim=-1, dtype=torch.int32)
     used_seqlens_in_batch = attention_mask.sum(dim=-1, dtype=torch.int32)
-    indices = torch.nonzero(all_masks.flatten(), as_tuple=False).flatten()
+    indices = all_masks.flatten().nonzero(as_tuple=False).flatten()
     max_seqlen_in_batch = seqlens_in_batch.max().item()
     cu_seqlens = F.pad(torch.cumsum(seqlens_in_batch, dim=0, dtype=torch.int32), (1, 0))
     # TD [2022-03-04] We don't want to index with a bool mask, because Pytorch will expand the

--- a/test/registered/kernels/ops/moe/test_moe_align_small_numel.py
+++ b/test/registered/kernels/ops/moe/test_moe_align_small_numel.py
@@ -43,7 +43,7 @@ def _reference(topk_ids, block_size, num_experts):
     offsets = torch.cumsum(padded, 0) - padded
     total = int(padded.sum())
 
-    non_empty = torch.nonzero(padded, as_tuple=True)[0]
+    non_empty = padded.nonzero(as_tuple=True)[0]
     expert_ids = torch.repeat_interleave(
         non_empty - 1, padded[non_empty] // block_size
     ).to(torch.int32)

--- a/test/registered/kv_canary/test_self_unit_perturb.py
+++ b/test/registered/kv_canary/test_self_unit_perturb.py
@@ -262,7 +262,7 @@ class TestReqToTokenPerturb(CustomTestCase):
 
         diff = pool.req_to_token != snapshot
         self.assertEqual(int(diff.sum().item()), 1)
-        rows, cols = torch.nonzero(diff, as_tuple=True)
+        rows, cols = diff.nonzero(as_tuple=True)
         row, col = int(rows[0].item()), int(cols[0].item())
         original = int(snapshot[row, col].item())
         replacement = int(pool.req_to_token[row, col].item())

--- a/test/registered/moe/test_cutedsl_moe.py
+++ b/test/registered/moe/test_cutedsl_moe.py
@@ -907,13 +907,13 @@ class TestCuteDslV1(unittest.TestCase):
                         ref_output, device=out.device, dtype=out.dtype
                     )
 
-                    positions = torch.nonzero(masked_m[topk_idx], as_tuple=False)
+                    positions = masked_m[topk_idx].nonzero(as_tuple=False)
                     rows, cols = positions[:, 0], positions[:, 1]
                     experts = topk_idx[rows, cols]
                     for i in range(num_experts):
                         mask = experts == i
                         if mask.any():
-                            idx = torch.nonzero(mask, as_tuple=False).squeeze(-1)
+                            idx = mask.nonzero(as_tuple=False).squeeze(-1)
                             r, c = rows[idx], cols[idx]
                             out_weighted[r] += out[i, : len(r), :] * routing_weights[
                                 r, c
@@ -1076,7 +1076,7 @@ class TestCuteDslV1(unittest.TestCase):
                 topk_idx.to(device),
             )
 
-            positions = torch.nonzero(masked_m[topk_idx], as_tuple=False)
+            positions = masked_m[topk_idx].nonzero(as_tuple=False)
             rows, cols = positions[:, 0], positions[:, 1]
             experts = topk_idx[rows, cols]
 
@@ -1087,7 +1087,7 @@ class TestCuteDslV1(unittest.TestCase):
                 for i in range(num_experts):
                     mask = experts == i
                     if mask.any():
-                        idx = torch.nonzero(mask, as_tuple=False).squeeze(-1)
+                        idx = mask.nonzero(as_tuple=False).squeeze(-1)
                         r, c = rows[idx], cols[idx]
                         out_weighted[r] += out[i, : len(r), :] * routing_weights[
                             r, c
@@ -1243,13 +1243,13 @@ class TestCuteDslV1(unittest.TestCase):
             )
 
             out_weighted = torch.zeros_like(ref, device=device)
-            positions = torch.nonzero(masked_m[topk_idx], as_tuple=False)
+            positions = masked_m[topk_idx].nonzero(as_tuple=False)
             rows, cols = positions[:, 0], positions[:, 1]
             experts = topk_idx[rows, cols]
             for i in range(num_experts):
                 mask = experts == i
                 if mask.any():
-                    idx = torch.nonzero(mask, as_tuple=False).squeeze(-1)
+                    idx = mask.nonzero(as_tuple=False).squeeze(-1)
                     r, c = rows[idx], cols[idx]
                     out_weighted[r] += out[i, : len(r), :] * routing_weights[r, c].to(
                         device

--- a/test/registered/unit/models/test_locate_anything.py
+++ b/test/registered/unit/models/test_locate_anything.py
@@ -96,7 +96,7 @@ class TestBoxGrammarLogitProcessor(CustomTestCase):
         logits = torch.zeros(1, self.VOCAB)
         out = proc(logits, self._params(output_ids))
         # Allowed ids are those left finite after masking.
-        return set(torch.nonzero(torch.isfinite(out[0])).flatten().tolist())
+        return set(torch.isfinite(out[0]).nonzero().flatten().tolist())
 
     def test_no_box_open_is_untouched(self):
         proc = LocateAnythingBoxGrammarLogitProcessor()


### PR DESCRIPTION
Fixes #9889 by replacing torch.nonzero() with tensor.nonzero().

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33942874728](https://github.com/sgl-project/sglang/actions/runs/33942874728)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33942874628](https://github.com/sgl-project/sglang/actions/runs/33942874628)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33942874737](https://github.com/sgl-project/sglang/actions/runs/33942874737)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->