### PR TITLE
[Bugfix] Initialize one_batch runtime configs in load_model

### DIFF
--- a/python/sglang/benchmark/one_batch.py
+++ b/python/sglang/benchmark/one_batch.py
@@ -298,6 +298,9 @@ class BenchArgs:
 
 def load_model(server_args, port_args, gpu_id, tp_rank):
     suppress_other_loggers()
+    initialize_moe_config(server_args)
+    initialize_fp8_gemm_config(server_args)
+    initialize_fp4_gemm_config(server_args)
     rank_print = print if tp_rank == 0 else lambda *args, **kwargs: None
     moe_ep_rank = tp_rank // (server_args.tp_size // server_args.ep_size)
 
@@ -881,10 +884,6 @@ def latency_test(
     gpu_id,
     tp_rank,
 ):
-    initialize_moe_config(server_args)
-    initialize_fp8_gemm_config(server_args)
-    initialize_fp4_gemm_config(server_args)
-
     # Set CPU affinity
     if get_bool_env_var("SGLANG_SET_CPU_AFFINITY"):
         set_gpu_proc_affinity(

--- a/test/registered/unit/bench/test_one_batch_runtime_config.py
+++ b/test/registered/unit/bench/test_one_batch_runtime_config.py
@@ -1,0 +1,85 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.benchmark import one_batch
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def test_load_model_initializes_runtime_configs_before_model(monkeypatch):
+    events = []
+
+    monkeypatch.setattr(one_batch, "suppress_other_loggers", lambda: None)
+    monkeypatch.setattr(
+        one_batch,
+        "initialize_moe_config",
+        lambda server_args: events.append("moe"),
+    )
+    monkeypatch.setattr(
+        one_batch,
+        "initialize_fp8_gemm_config",
+        lambda server_args: events.append("fp8"),
+    )
+    monkeypatch.setattr(
+        one_batch,
+        "initialize_fp4_gemm_config",
+        lambda server_args: events.append("fp4"),
+    )
+    monkeypatch.setattr(
+        one_batch.ModelConfig,
+        "from_server_args",
+        lambda server_args: object(),
+    )
+    monkeypatch.setattr(
+        one_batch,
+        "compute_dp_attention_world_info",
+        lambda *args: (0, 1, 0, 1),
+    )
+    monkeypatch.setattr(one_batch, "ParallelState", lambda **kwargs: object())
+    monkeypatch.setattr(one_batch, "use_mlx", lambda: False)
+    monkeypatch.setattr(one_batch, "get_tokenizer", lambda *args, **kwargs: "tokenizer")
+
+    class FakeModelRunner:
+        max_total_num_tokens = 1
+
+        def __init__(self, **kwargs):
+            assert events == ["moe", "fp8", "fp4"]
+
+        def alloc_memory_pool(self):
+            pass
+
+        def init_attention_backends(self):
+            pass
+
+        def init_cuda_graphs(self):
+            pass
+
+    monkeypatch.setattr(one_batch, "ModelRunner", FakeModelRunner)
+
+    server_args = SimpleNamespace(
+        tp_size=1,
+        ep_size=1,
+        dp_size=1,
+        enable_dp_attention=False,
+        attn_cp_size=1,
+        dcp_size=1,
+        moe_dp_size=1,
+        mem_fraction_static=0.8,
+        is_startup_weight_load_overlap=False,
+        tokenizer_path="tokenizer",
+        tokenizer_mode="auto",
+        trust_remote_code=False,
+    )
+    port_args = SimpleNamespace(nccl_port=12345)
+
+    _, tokenizer = one_batch.load_model(server_args, port_args, gpu_id=0, tp_rank=0)
+
+    assert tokenizer == "tokenizer"
+    assert events == ["moe", "fp8", "fp4"]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

`one_batch` runtime configuration must be initialized before `ModelRunner` is constructed. The latency path on current `main` already does this, but `correctness_test` and direct callers of `load_model` still bypass the MoE, FP8, and FP4 initializers.

This leaves those paths with default process-global backend settings even when the corresponding `ServerArgs` values select another backend.

Fixes #36395.

## Modifications

- Move `initialize_moe_config`, `initialize_fp8_gemm_config`, and `initialize_fp4_gemm_config` from `latency_test` into the shared `load_model` entry point.
- Add a CPU regression test that verifies all three initializers run before `ModelRunner` construction.

The regular latency path still initializes each configuration once, while correctness and direct `load_model` paths now receive the same behavior.

## Accuracy Tests

The regression harness was run against the current baseline and the patch on an RTX 5090 host:

```text
baseline: exit 1, events=['model_config', 'model_runner']
patched:  exit 0, events=['moe', 'fp8', 'fp4', 'model_config', 'model_runner']
```

This change only moves configuration initialization ahead of model construction; it does not change model math.

## Speed Tests and Profiling

Not applicable. The same three initialization calls are executed once per latency worker as before.

## Validation

- All pre-commit hooks passed for the changed files.
- The repository's registered-test validation passed.
- `git diff --check` passed.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change needed.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (No model-math or hot-path change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32930984341](https://github.com/sgl-project/sglang/actions/runs/32930984341)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32930984179](https://github.com/sgl-project/sglang/actions/runs/32930984179)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32930984567](https://github.com/sgl-project/sglang/actions/runs/32930984567)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->