### PR TITLE
[Fix] server args: allow canonical option overridden by DeprecatedAliasStoreAction in --config

### DIFF
--- a/python/sglang/srt/utils/server_args_config_parser.py
+++ b/python/sglang/srt/utils/server_args_config_parser.py
@@ -31,12 +31,21 @@ class ConfigArgumentMerger:
                 for action in parser._actions
                 if isinstance(action, argparse._StoreTrueAction)
             ]
+            # A canonical option and its deprecated alias share `dest`; the
+            # canonical `_StoreAction` / `_StoreTrueAction` must not be shadowed
+            # by an unsupported alias at the same dest.
+            supported_dests = {
+                a.dest
+                for a in parser._actions
+                if isinstance(a, (argparse._StoreTrueAction, argparse._StoreAction))
+            }
             self.unsupported_actions = {
                 a.dest: a
                 for a in parser._actions
                 if a.option_strings
                 and not isinstance(a, argparse._StoreTrueAction)
                 and not isinstance(a, argparse._StoreAction)
+                and a.dest not in supported_dests
                 and "--config" not in a.option_strings
                 and "--help" not in a.option_strings
                 and "-h" not in a.option_strings

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -261,6 +261,31 @@ class TestPrepareServerArgs(CustomTestCase):
         finally:
             os.unlink(config_file)
 
+    def test_config_accepts_canonical_option_shadowed_by_deprecated_alias(self):
+        # Regression for #36326: a DeprecatedAliasStoreAction sharing `dest`
+        # with a canonical `_StoreAction` must not cause --config to reject
+        # the canonical key.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".yaml", delete=False) as f:
+            f.write("mamba-radix-cache-strategy: no_buffer\n")
+            config_file = f.name
+
+        try:
+            parser = server_args_module.argparse.ArgumentParser()
+            ServerArgs.add_cli_args(parser)
+            merged = ConfigArgumentMerger(parser).merge_config_with_args(
+                [
+                    "--config",
+                    config_file,
+                    "--model-path",
+                    DEFAULT_SMALL_MODEL_NAME_FOR_TEST_QWEN,
+                ]
+            )
+            parsed = parser.parse_args(merged)
+
+            self.assertEqual(parsed.mamba_radix_cache_strategy, "no_buffer")
+        finally:
+            os.unlink(config_file)
+
 
 class TestMmEncoderDataParallelLogging(CustomTestCase):
     def test_logs_when_encoder_dp_has_no_parallelism(self):


### PR DESCRIPTION
**Motivation**

When a canonical option (e.g. `--mamba-radix-cache-strategy`) shares its `dest` with a `DeprecatedAliasStoreAction` (`--mamba-scheduler-strategy` → same `dest="mamba_radix_cache_strategy"`), `ConfigArgumentMerger` traps the alias in `unsupported_actions`, keyed by `dest`. That entry shadows the canonical `_StoreAction` at the same `dest`, so passing `mamba-radix-cache-strategy: no_buffer` through `--config file.yaml` raises `ValueError: Unsupported config option 'mamba_radix_cache_strategy' with action 'DeprecatedAliasStoreAction'` even though the option is fully supported on the CLI. Reported in #36326.

**Modifications**

In `ConfigArgumentMerger.__init__`, precompute the set of `dest`s already served by a canonical `_StoreAction` / `_StoreTrueAction`, and exclude those `dest`s when building `unsupported_actions`. This preserves the "truly unsupported action" guard for other custom `argparse.Action` subclasses while letting the canonical option flow through `--config` normally.

Adds `test_config_accepts_canonical_option_shadowed_by_deprecated_alias` in `test/registered/unit/server_args/test_server_args.py` — a black-box regression that constructs a real `ServerArgs`-populated parser, feeds `mamba-radix-cache-strategy: no_buffer` via `--config`, and asserts `parsed.mamba_radix_cache_strategy == "no_buffer"`.

Closes #36326.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33231281412](https://github.com/sgl-project/sglang/actions/runs/33231281412)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33231281283](https://github.com/sgl-project/sglang/actions/runs/33231281283)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33231281406](https://github.com/sgl-project/sglang/actions/runs/33231281406)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->