### PR TITLE
[CPU] Fix rotary_embedding_cpu fake for in-place layouts

### DIFF
--- a/python/sglang/srt/model_executor/cpu_graph_runner.py
+++ b/python/sglang/srt/model_executor/cpu_graph_runner.py
@@ -282,9 +282,9 @@ def register_fake_ops(tp_size: int):
 
     @register_cpu_compile_fake("rotary_embedding_cpu")
     def _(positions, query, key, head_size, cos_sin_cache, is_neox):
-        # TODO: the kernel aliases query/key for 2D and 4D but allocates for 3D,
-        # which no schema expresses; an accurate fake needs it to pick one
-        return torch.empty_like(query), torch.empty_like(key)
+        if query.ndim == 3:
+            return torch.empty_like(query), torch.empty_like(key)
+        return query, key
 
     @register_cpu_compile_fake("apply_rotary_pos_emb_cpu")
     def _(query, key, cos, sin):


### PR DESCRIPTION
Fixes regression caused by

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

On CPU with `--enable-torch-compile`, graph capture fails for any model with a fused QKV projection:

```
assert_size_stride(buf6, (32, 4096), (4096, 1), 'torch.ops.sgl_kernel.rotary_embedding_cpu.default')
AssertionError: expected size 32==32, stride 6144==4096 at dim=0
Error in op: torch.ops.sgl_kernel.rotary_embedding_cpu.default
```

The fake (meta) kernel for `rotary_embedding_cpu` claimed the kernel always
allocates its outputs:

```python
return torch.empty_like(query), torch.empty_like(key)
```

However the kernel rotates 2D and 4D layouts in place and hands back
the very tensors it was given, allocating only for 3D
(`python/sglang/kernels/aot/csrc/cpu/rope.cpp`):

```cpp
at::Tensor query_out = (input_dim != 3) ? query : at::empty(query.sizes(), query.options());
```

Introduced by [CPU] Add support for Gemma4 on Xeon (#22498), which replaced a layout-dependent fake with an unconditional one.

## Modifications

<!-- Detail the changes made in this pull request. -->

Make the fake mirror the kernel's own `input_dim != 3` test.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

Not measured - it's a correctness change

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

Not measured - it's a correctness change

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32935948986](https://github.com/sgl-project/sglang/actions/runs/32935948986)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #32937262150](https://github.com/sgl-project/sglang/actions/runs/32937262150)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32935948993](https://github.com/sgl-project/sglang/actions/runs/32935948993)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->