### PR TITLE
fix(server_args): reject speculative decoding with torch_native attention backend

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6343,6 +6343,14 @@ class ServerArgs:
                 self.speculative_algorithm is None
             ), "Speculative decoding is currently not supported with Flex Attention backend"
 
+        if (
+            attention_backend == "torch_native"
+            and self.speculative_algorithm is not None
+        ):
+            raise ValueError(
+                "Speculative decoding is currently not supported with torch_native attention backend"
+            )
+
         # Whisper's encoder token padding conflicts with prefix caching.
         # Only disable for Whisper; other encoder-decoder models (e.g., mllama) use radix cache.
         if (

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -25,6 +25,7 @@ from sglang.srt.model_executor.cuda_graph_config import (
     CudaGraphConfig,
     Phase,
     PhaseConfig,
+    default_cuda_graph_config,
 )
 from sglang.srt.server_args import PortArgs, ServerArgs, prepare_server_args
 from sglang.srt.server_args_config_parser import ConfigArgumentMerger
@@ -885,6 +886,53 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
 
         self.assertEqual(args.page_size, 1)  # dual-apply retired: pristine
         self.assertEqual(resolved_view(args).page_size, 128)
+
+
+class TestNgramTorchNativeIncompatible(CustomTestCase):
+    """NGRAM speculative decoding does not work with the torch_native attention
+    backend and should fail early during argument validation instead of crashing
+    in the warmup path."""
+
+    def _make_args(
+        self, attention_backend="torch_native", speculative_algorithm="NGRAM"
+    ):
+        args = ServerArgs(model_path="dummy")
+        args.attention_backend = attention_backend
+        args.speculative_algorithm = speculative_algorithm
+        args.cuda_graph_config = default_cuda_graph_config()
+        # Short-circuit get_model_config(): the compatibility handler only needs
+        # a few hf_config flags, not a real checkpoint.
+        args.model_config = MagicMock()
+        args.model_config.hf_config.dual_chunk_attention_config = None
+        args.model_config.is_encoder_decoder = False
+        return args
+
+    @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=False)
+    @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
+    def test_ngram_with_torch_native_raises(self, _mock_mla, _mock_sm100):
+        args = self._make_args()
+        with self.assertRaisesRegex(
+            ValueError,
+            "Speculative decoding is currently not supported with torch_native attention backend",
+        ):
+            args._handle_attention_backend_compatibility()
+
+    @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=False)
+    @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
+    def test_eagle_with_torch_native_raises(self, _mock_mla, _mock_sm100):
+        args = self._make_args(speculative_algorithm="EAGLE")
+        with self.assertRaisesRegex(
+            ValueError,
+            "Speculative decoding is currently not supported with torch_native attention backend",
+        ):
+            args._handle_attention_backend_compatibility()
+
+    @patch("sglang.srt.arg_groups.overrides.is_sm100_supported", return_value=False)
+    @patch("sglang.srt.server_args.ServerArgs.use_mla_backend", return_value=False)
+    def test_no_speculative_with_torch_native_allowed(self, _mock_mla, _mock_sm100):
+        args = self._make_args(speculative_algorithm=None)
+        # Should not raise; the assertion is simply reaching this point.
+        args._handle_attention_backend_compatibility()
 
 
 class TestContextParallelServerArgs(CustomTestCase):


### PR DESCRIPTION
## Bug

SGLang accepted `--speculative-algorithm NGRAM` together with `--attention-backend torch_native`, started loading the model, and then crashed during startup warmup with an opaque scheduler traceback:

```text
AttributeError: 'NoneType' object has no attribute 'shape'
```

The [attention-backend support matrix](https://github.com/sgl-project/sglang/blob/e9c9df6a52925af7a5908eea51f91c5dd5f01a00/docs/docs/advanced_features/attention_backend.mdx#L34-L39) already marks speculative decoding as unsupported for torch_native, so the missing validation is the real bug.

## Fix

Mirror the existing `flex_attention` check in `_handle_attention_backend_compatibility` and reject any speculative algorithm when `attention_backend == "torch_native"`:

```text
Speculative decoding is currently not supported with torch_native attention backend
```

This fails fast before model loading, instead of crashing in the warmup path.

## Tests

Added `TestNgramTorchNativeIncompatible` in `test/registered/unit/server_args/test_server_args.py`:

- `test_ngram_with_torch_native_raises`
- `test_eagle_with_torch_native_raises`
- `test_no_speculative_with_torch_native_allowed`

All 154 tests in `test_server_args.py` pass locally.

Fixes #36352.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32936735575](https://github.com/sgl-project/sglang/actions/runs/32936735575)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32936735310](https://github.com/sgl-project/sglang/actions/runs/32936735310)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32936735454](https://github.com/sgl-project/sglang/actions/runs/32936735454)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->