### PR TITLE
[Kernel] Selectively dequantize FP8 KV for BF16 DSA prefill

### DIFF
--- a/benchmark/kernels/attention/benchmark_dsa_selective_kv_dequant.py
+++ b/benchmark/kernels/attention/benchmark_dsa_selective_kv_dequant.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Probe selective FP8 KV dequantization for BF16 DSA sparse prefill.
+
+This benchmark compares the production candidate against both the current
+path and a framework ``torch.unique`` oracle:
+
+* current full-prefix paged dequantization;
+* selective dequantization without deduplication;
+* allocation-free full-prefix dequantization (to separate allocator effects);
+* ``torch.unique`` physical-slot deduplication oracle;
+* dense-epoch/prefix-scan physical-slot deduplication candidate;
+* isolated and combined selected-row dequantization timings.
+
+The JSON/CSV output retains isolated stages so an apparent end-to-end win can
+be rejected if it comes only from avoiding a framework allocation.
+"""
+
+import argparse
+import csv
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import torch
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_module(name: str, relative_path: str):
+    path = _REPO_ROOT / relative_path
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot load {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+_dequant_module = _load_module(
+    "dsa_dequant_k_cache",
+    "python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py",
+)
+_case_module = _load_module(
+    "dsa_selective_kv_benchmark_utils",
+    "benchmark/kernels/attention/dsa_selective_kv_benchmark_utils.py",
+)
+_selective_runtime_module = _load_module(
+    "dsa_selective_kv_runtime",
+    "python/sglang/srt/layers/attention/dsa/selective_kv_dequant.py",
+)
+_selective_kernel_module = _load_module(
+    "dsa_selective_kv_kernel",
+    "python/sglang/kernels/ops/attention/dsa/selective_kv_dequant.py",
+)
+
+dequantize_k_cache_paged = _dequant_module.dequantize_k_cache_paged
+SyntheticDSACase = _case_module.SyntheticDSACase
+build_benchmark_record = _case_module.build_benchmark_record
+make_synthetic_dsa_indices = _case_module.make_synthetic_dsa_indices
+SelectiveKVWorkspace = _selective_runtime_module.SelectiveKVWorkspace
+prepare_dense_epoch_selection = _selective_runtime_module.prepare_dense_epoch_selection
+deduplicate_kv_slots_dense_epoch = (
+    _selective_kernel_module.deduplicate_kv_slots_dense_epoch
+)
+
+DIM_QUANT = 656
+DEFAULT_CASES = (
+    SyntheticDSACase(8192, 1, 2048, 1.0, seed=101),
+    SyntheticDSACase(32768, 4, 2048, 0.50, seed=102),
+    SyntheticDSACase(65536, 16, 2048, 0.125, seed=103),
+    SyntheticDSACase(
+        65536,
+        16,
+        2048,
+        0.125,
+        physical_unique_ratio=0.50,
+        seed=104,
+    ),
+)
+
+
+def build_quantized_kv_pool(pool_tokens: int, device: torch.device) -> torch.Tensor:
+    generator = torch.Generator(device=device)
+    generator.manual_seed(7)
+    nope = (
+        torch.randn(pool_tokens, 512, generator=generator, device=device) * 0.25
+    ).to(torch.float8_e4m3fn)
+    scales = (
+        torch.rand(pool_tokens, 4, generator=generator, device=device) * 0.05 + 1e-3
+    ).to(torch.float32)
+    rope = torch.randn(pool_tokens, 64, generator=generator, device=device).to(
+        torch.bfloat16
+    )
+
+    raw = torch.empty(pool_tokens, DIM_QUANT, dtype=torch.uint8, device=device)
+    raw[:, :512] = nope.view(torch.uint8)
+    raw[:, 512:528] = scales.view(torch.uint8)
+    raw[:, 528:] = rope.view(torch.uint8)
+    return raw.view(torch.float8_e4m3fn).view(pool_tokens, 1, DIM_QUANT)
+
+
+def bench_us(fn, *, warmup: int, iterations: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    start = torch.cuda.Event(enable_timing=True)
+    end = torch.cuda.Event(enable_timing=True)
+    start.record()
+    for _ in range(iterations):
+        fn()
+    end.record()
+    torch.cuda.synchronize()
+    return start.elapsed_time(end) * 1000.0 / iterations
+
+
+def _dedup_remap(
+    page_table: torch.Tensor, flat_topk: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    physical_occurrences = page_table[flat_topk.long()]
+    physical_slots, inverse = torch.unique(
+        physical_occurrences.reshape(-1), sorted=True, return_inverse=True
+    )
+    return physical_slots, inverse.to(torch.int32).reshape(flat_topk.shape)
+
+
+def run_case(
+    case: SyntheticDSACase,
+    pool: torch.Tensor,
+    *,
+    warmup: int,
+    iterations: int,
+    git_sha: str,
+) -> dict:
+    cpu_inputs = make_synthetic_dsa_indices(case)
+    page_table = cpu_inputs.page_table_1_flattened.to(pool.device)
+    flat_topk = cpu_inputs.flat_topk_indices.to(pool.device)
+    physical_occurrences = page_table[flat_topk.long()]
+    physical_slots, remapped = _dedup_remap(page_table, flat_topk)
+    workspace = SelectiveKVWorkspace(pool.device)
+    dense_selection = prepare_dense_epoch_selection(
+        page_table,
+        flat_topk,
+        num_pool_rows=pool.shape[0],
+        workspace=workspace,
+        deduplicate_fn=deduplicate_kv_slots_dense_epoch,
+    )
+    full_out = torch.empty(
+        (page_table.numel(), 1, 576), dtype=torch.bfloat16, device=pool.device
+    )
+    no_dedup_out = torch.empty(
+        (physical_occurrences.numel(), 1, 576),
+        dtype=torch.bfloat16,
+        device=pool.device,
+    )
+    dense_out = workspace.get_bf16(dense_selection.capacity)
+
+    # Validate both selective variants against exactly the rows read from the
+    # current full-prefix BF16 workspace.
+    full = dequantize_k_cache_paged(pool, page_table)
+    expected = full.view(case.prefix_rows, -1)[flat_topk.long()]
+    no_dedup = dequantize_k_cache_paged(pool, physical_occurrences.reshape(-1))
+    no_dedup = no_dedup.view(*flat_topk.shape, -1)
+    selected = dequantize_k_cache_paged(pool, physical_slots).view(
+        physical_slots.numel(), -1
+    )
+    reconstructed = selected[remapped.long()]
+    dense_selected = dequantize_k_cache_paged(
+        pool,
+        dense_selection.selected_physical_slots,
+        out=dense_out,
+        num_valid_rows=dense_selection.num_unique,
+    ).view(dense_selection.capacity, -1)
+    dense_reconstructed = dense_selected[dense_selection.remapped_topk.long()]
+    torch.testing.assert_close(no_dedup, expected, rtol=0, atol=0)
+    torch.testing.assert_close(reconstructed, expected, rtol=0, atol=0)
+    torch.testing.assert_close(dense_reconstructed, expected, rtol=0, atol=0)
+    assert int(dense_selection.num_unique.item()) == physical_slots.numel()
+    torch.testing.assert_close(
+        dense_selection.selected_physical_slots[: physical_slots.numel()],
+        physical_slots.to(torch.int32),
+    )
+    del (
+        full,
+        expected,
+        no_dedup,
+        selected,
+        reconstructed,
+        dense_selected,
+        dense_reconstructed,
+    )
+
+    def full_dequant():
+        return dequantize_k_cache_paged(pool, page_table)
+
+    def full_dequant_cached():
+        return dequantize_k_cache_paged(pool, page_table, out=full_out)
+
+    def selective_no_dedup():
+        return dequantize_k_cache_paged(
+            pool, physical_occurrences.reshape(-1), out=no_dedup_out
+        )
+
+    def oracle_dedup_remap():
+        return _dedup_remap(page_table, flat_topk)
+
+    def dense_dedup_remap():
+        return prepare_dense_epoch_selection(
+            page_table,
+            flat_topk,
+            num_pool_rows=pool.shape[0],
+            workspace=workspace,
+            deduplicate_fn=deduplicate_kv_slots_dense_epoch,
+        )
+
+    def oracle_selected_dequant():
+        return dequantize_k_cache_paged(pool, physical_slots)
+
+    def dense_selected_dequant():
+        return dequantize_k_cache_paged(
+            pool,
+            dense_selection.selected_physical_slots,
+            out=dense_out,
+            num_valid_rows=dense_selection.num_unique,
+        )
+
+    def oracle_selective_total():
+        selected_slots, selected_remap = _dedup_remap(page_table, flat_topk)
+        return dequantize_k_cache_paged(pool, selected_slots), selected_remap
+
+    def dense_selective_total():
+        selection = prepare_dense_epoch_selection(
+            page_table,
+            flat_topk,
+            num_pool_rows=pool.shape[0],
+            workspace=workspace,
+            deduplicate_fn=deduplicate_kv_slots_dense_epoch,
+        )
+        return (
+            dequantize_k_cache_paged(
+                pool,
+                selection.selected_physical_slots,
+                out=dense_out,
+                num_valid_rows=selection.num_unique,
+            ),
+            selection.remapped_topk,
+        )
+
+    timings = {
+        "full_dequant_us": bench_us(full_dequant, warmup=warmup, iterations=iterations),
+        "full_dequant_cached_us": bench_us(
+            full_dequant_cached, warmup=warmup, iterations=iterations
+        ),
+        "selective_no_dedup_us": bench_us(
+            selective_no_dedup, warmup=warmup, iterations=iterations
+        ),
+        "oracle_dedup_remap_us": bench_us(
+            oracle_dedup_remap, warmup=warmup, iterations=iterations
+        ),
+        "dense_dedup_remap_us": bench_us(
+            dense_dedup_remap, warmup=warmup, iterations=iterations
+        ),
+        "oracle_selected_dequant_us": bench_us(
+            oracle_selected_dequant, warmup=warmup, iterations=iterations
+        ),
+        "dense_selected_dequant_us": bench_us(
+            dense_selected_dequant, warmup=warmup, iterations=iterations
+        ),
+        "oracle_selective_total_us": bench_us(
+            oracle_selective_total, warmup=warmup, iterations=iterations
+        ),
+        "dense_selective_total_us": bench_us(
+            dense_selective_total, warmup=warmup, iterations=iterations
+        ),
+    }
+    return build_benchmark_record(
+        case=case,
+        inputs=cpu_inputs,
+        timings_us=timings,
+        device_name=torch.cuda.get_device_name(pool.device),
+        git_sha=git_sha,
+        pool_rows=pool.shape[0],
+    )
+
+
+def _git_sha() -> str:
+    return subprocess.check_output(
+        ["git", "rev-parse", "HEAD"], cwd=_REPO_ROOT, text=True
+    ).strip()
+
+
+def _write_artifacts(records: list[dict], output_dir: Path) -> None:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "dsa_selective_kv_dequant.json"
+    csv_path = output_dir / "dsa_selective_kv_dequant.csv"
+    json_path.write_text(json.dumps(records, indent=2) + "\n")
+    with csv_path.open("w", newline="") as csv_file:
+        writer = csv.DictWriter(
+            csv_file, fieldnames=_case_module.BENCHMARK_RESULT_COLUMNS
+        )
+        writer.writeheader()
+        writer.writerows(records)
+    print(f"wrote {json_path}")
+    print(f"wrote {csv_path}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--warmup", type=int, default=20)
+    parser.add_argument("--iterations", type=int, default=100)
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument(
+        "--case-index",
+        type=int,
+        action="append",
+        help="run only the selected zero-based DEFAULT_CASES entry; repeatable",
+    )
+    args = parser.parse_args()
+
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is unavailable; this benchmark requires one SM90 GPU")
+    device = torch.device(args.device)
+    major, minor = torch.cuda.get_device_capability(device)
+    if major != 9:
+        raise SystemExit(
+            f"this DSA benchmark targets SM90/H20; got compute capability {major}.{minor}"
+        )
+    if args.warmup < 1 or args.iterations < 1:
+        raise SystemExit("--warmup and --iterations must both be positive")
+
+    cases = DEFAULT_CASES
+    if args.case_index is not None:
+        invalid = [index for index in args.case_index if not 0 <= index < len(cases)]
+        if invalid:
+            raise SystemExit(
+                f"--case-index must be in [0, {len(cases) - 1}], got {invalid}"
+            )
+        cases = tuple(DEFAULT_CASES[index] for index in args.case_index)
+
+    torch.cuda.set_device(device)
+    max_prefix = max(case.prefix_rows for case in cases)
+    pool = build_quantized_kv_pool(max_prefix, device)
+    git_sha = _git_sha()
+    records = []
+    for case in cases:
+        record = run_case(
+            case,
+            pool,
+            warmup=args.warmup,
+            iterations=args.iterations,
+            git_sha=git_sha,
+        )
+        records.append(record)
+        print(json.dumps(record, sort_keys=False))
+
+    if args.output_dir is not None:
+        _write_artifacts(records, args.output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/attention/dsa_selective_kv_benchmark_utils.py
+++ b/benchmark/kernels/attention/dsa_selective_kv_benchmark_utils.py
@@ -1,0 +1,198 @@
+from dataclasses import dataclass
+from typing import Mapping
+
+import torch
+
+KV_BYTES_PER_ROW = 656
+BF16_BYTES_PER_ROW = 576 * 2
+DENSE_SCAN_BLOCK_SIZE = 256
+
+TIMING_COLUMNS = (
+    "full_dequant_us",
+    "full_dequant_cached_us",
+    "selective_no_dedup_us",
+    "oracle_dedup_remap_us",
+    "dense_dedup_remap_us",
+    "oracle_selected_dequant_us",
+    "dense_selected_dequant_us",
+    "oracle_selective_total_us",
+    "dense_selective_total_us",
+)
+
+BENCHMARK_RESULT_COLUMNS = (
+    "device_name",
+    "git_sha",
+    "prefix_rows",
+    "query_tokens",
+    "topk",
+    "requested_logical_unique_ratio",
+    "requested_physical_unique_ratio",
+    "valid_topk_entries",
+    "logical_unique_rows",
+    "physical_unique_rows",
+    "logical_unique_ratio",
+    "physical_unique_ratio",
+    "pool_rows",
+    "selection_capacity_rows",
+    "full_kv_traffic_bytes",
+    "active_selective_kv_traffic_bytes",
+    "full_bf16_workspace_bytes",
+    "fixed_selective_bf16_workspace_bytes",
+    "dense_metadata_workspace_bytes",
+    "estimated_dense_metadata_traffic_bytes",
+    *TIMING_COLUMNS,
+    "dense_speedup_vs_current",
+    "dense_speedup_vs_cached_full",
+)
+
+
+@dataclass(frozen=True)
+class SyntheticDSACase:
+    prefix_rows: int
+    query_tokens: int
+    topk: int
+    unique_ratio: float
+    physical_unique_ratio: float = 1.0
+    seed: int = 0
+
+    def __post_init__(self) -> None:
+        for name in ("prefix_rows", "query_tokens", "topk"):
+            value = getattr(self, name)
+            if not isinstance(value, int) or isinstance(value, bool) or value <= 0:
+                raise ValueError(f"{name} must be a positive integer, got {value!r}")
+        for name in ("unique_ratio", "physical_unique_ratio"):
+            value = getattr(self, name)
+            if not 0.0 < value <= 1.0:
+                raise ValueError(f"{name} must be in (0, 1], got {value!r}")
+
+
+@dataclass(frozen=True)
+class SyntheticDSAInputs:
+    page_table_1_flattened: torch.Tensor
+    flat_topk_indices: torch.Tensor
+    logical_unique_rows: int
+    physical_unique_rows: int
+
+
+def make_synthetic_dsa_indices(case: SyntheticDSACase) -> SyntheticDSAInputs:
+    """Create deterministic DSA index geometry without requiring CUDA.
+
+    ``unique_ratio`` controls duplicate logical top-k occurrences.  The
+    independent ``physical_unique_ratio`` aliases selected logical positions in
+    the page table, modeling radix-prefix sharing between requests.
+    """
+    occurrences = case.query_tokens * case.topk
+    logical_unique_rows = min(
+        case.prefix_rows,
+        occurrences,
+        max(1, round(occurrences * case.unique_ratio)),
+    )
+    physical_unique_rows = min(
+        logical_unique_rows,
+        max(1, round(logical_unique_rows * case.physical_unique_ratio)),
+    )
+
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(case.seed)
+    selected_logical = torch.randperm(
+        case.prefix_rows, generator=generator, dtype=torch.int64
+    )[:logical_unique_rows]
+
+    # Repeat every selected row before shuffling, which guarantees that the
+    # generated tensor has exactly logical_unique_rows distinct values.
+    occurrence_indices = torch.arange(occurrences, dtype=torch.int64)
+    topk_flat = selected_logical[occurrence_indices % logical_unique_rows]
+    topk_flat = topk_flat[
+        torch.randperm(occurrences, generator=generator, dtype=torch.int64)
+    ]
+
+    # Unselected logical positions remain one-to-one.  Only selected positions
+    # are deliberately aliased, so the reported physical ratio describes the
+    # rows attention can actually read.
+    page_table = torch.arange(case.prefix_rows, dtype=torch.int32)
+    physical_ids = torch.arange(physical_unique_rows, dtype=torch.int32)
+    alias_assignment = physical_ids[
+        torch.arange(logical_unique_rows, dtype=torch.int64) % physical_unique_rows
+    ]
+    page_table[selected_logical] = alias_assignment
+
+    return SyntheticDSAInputs(
+        page_table_1_flattened=page_table,
+        flat_topk_indices=topk_flat.to(torch.int32).reshape(
+            case.query_tokens, case.topk
+        ),
+        logical_unique_rows=logical_unique_rows,
+        physical_unique_rows=physical_unique_rows,
+    )
+
+
+def build_benchmark_record(
+    *,
+    case: SyntheticDSACase,
+    inputs: SyntheticDSAInputs,
+    timings_us: Mapping[str, float],
+    device_name: str,
+    git_sha: str,
+    pool_rows: int,
+) -> dict:
+    """Return a stable row suitable for both JSON and CSV serialization."""
+    missing = [column for column in TIMING_COLUMNS if column not in timings_us]
+    if missing:
+        raise ValueError(f"missing timing columns: {missing}")
+    for column in TIMING_COLUMNS:
+        value = timings_us[column]
+        if value < 0:
+            raise ValueError(f"{column} must be non-negative, got {value}")
+    dense_selective_total_us = float(timings_us["dense_selective_total_us"])
+    if dense_selective_total_us == 0:
+        raise ValueError("dense_selective_total_us must be positive")
+    if not isinstance(pool_rows, int) or isinstance(pool_rows, bool) or pool_rows <= 0:
+        raise ValueError(f"pool_rows must be a positive integer, got {pool_rows!r}")
+
+    valid_entries = case.query_tokens * case.topk
+    selection_capacity = min(case.prefix_rows, valid_entries)
+    num_scan_blocks = (pool_rows + DENSE_SCAN_BLOCK_SIZE - 1) // DENSE_SCAN_BLOCK_SIZE
+    record = {
+        "device_name": device_name,
+        "git_sha": git_sha,
+        "prefix_rows": case.prefix_rows,
+        "query_tokens": case.query_tokens,
+        "topk": case.topk,
+        "requested_logical_unique_ratio": case.unique_ratio,
+        "requested_physical_unique_ratio": case.physical_unique_ratio,
+        "valid_topk_entries": valid_entries,
+        "logical_unique_rows": inputs.logical_unique_rows,
+        "physical_unique_rows": inputs.physical_unique_rows,
+        "logical_unique_ratio": inputs.logical_unique_rows / valid_entries,
+        "physical_unique_ratio": inputs.physical_unique_rows / valid_entries,
+        "pool_rows": pool_rows,
+        "selection_capacity_rows": selection_capacity,
+        "full_kv_traffic_bytes": case.prefix_rows
+        * (KV_BYTES_PER_ROW + BF16_BYTES_PER_ROW),
+        "active_selective_kv_traffic_bytes": inputs.physical_unique_rows
+        * (KV_BYTES_PER_ROW + BF16_BYTES_PER_ROW),
+        "full_bf16_workspace_bytes": case.prefix_rows * BF16_BYTES_PER_ROW,
+        "fixed_selective_bf16_workspace_bytes": selection_capacity * BF16_BYTES_PER_ROW,
+        # int64 slot_epoch + int32 slot_to_compact + selected physical IDs +
+        # remapped occurrences + block offsets + int64 epoch + int32 count.
+        "dense_metadata_workspace_bytes": pool_rows * (8 + 4)
+        + selection_capacity * 4
+        + valid_entries * 4
+        + num_scan_blocks * 4
+        + 8
+        + 4,
+        # Two full int64 epoch scans plus a conservative charge for block
+        # prefix-scan traffic and compact-row publication.
+        "estimated_dense_metadata_traffic_bytes": pool_rows * 2 * 8
+        + num_scan_blocks * 12
+        + inputs.physical_unique_rows * 12,
+    }
+    record.update({column: float(timings_us[column]) for column in TIMING_COLUMNS})
+    record["dense_speedup_vs_current"] = (
+        float(timings_us["full_dequant_us"]) / dense_selective_total_us
+    )
+    record["dense_speedup_vs_cached_full"] = (
+        float(timings_us["full_dequant_cached_us"]) / dense_selective_total_us
+    )
+    assert tuple(record) == BENCHMARK_RESULT_COLUMNS
+    return record

--- a/python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py
@@ -4,6 +4,25 @@ import torch
 import triton
 import triton.language as tl
 
+# A device-side active-row count is deliberately not copied to the host: that
+# would make the selective path uncapturable by CUDA Graphs.  Bound the launch
+# to a small multiple of the GPU's SM count and let each program consume a
+# strided sequence of valid rows instead of materializing one masked program
+# per row of the conservative workspace capacity.
+_DEVICE_EXTENT_CTA_ROWS_PER_SM = 16
+
+
+def _device_extent_grid_rows(capacity: int, sm_count: Optional[int] = None) -> int:
+    if capacity <= 0:
+        raise ValueError(f"capacity must be positive, got {capacity}")
+    if sm_count is None:
+        sm_count = torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).multi_processor_count
+    if sm_count <= 0:
+        raise ValueError(f"sm_count must be positive, got {sm_count}")
+    return min(capacity, sm_count * _DEVICE_EXTENT_CTA_ROWS_PER_SM)
+
 
 def dequantize_k_cache(quant_k_cache):
     return _dequantize_k_cache_fast_wrapped(quant_k_cache)
@@ -171,12 +190,22 @@ def dequantize_k_cache_paged(
     quant_k_cache: torch.Tensor,
     page_table_1_flattened: torch.Tensor,
     group_size: int = 128,
+    out: Optional[torch.Tensor] = None,
+    num_valid_rows: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """
     De-quantize the k-cache with paged layout
     Args:
         quant_k_cache: [total_num_tokens, 1, dim_quant] or [num_blocks, block_size, 1, dim_quant], the quantized k-cache in paged layout
         page_table_1_flattened: [num_tokens], the flattened page_table_1 with the page indices in each requests concatenated together
+        out: optional preallocated contiguous BF16 destination with shape
+            [num_tokens, 1, dim_nope + dim_rope]. Without ``num_valid_rows``
+            the kernel overwrites every element. With it, only the valid
+            compact prefix is overwritten and the ignored tail may stay dirty.
+        num_valid_rows: optional one-element int32 device tensor. When set,
+            only rows ``[0, num_valid_rows)`` are read/written even though the
+            page table and output keep a fixed capacity. This avoids a host
+            sync when a device-side dedup kernel determines the active extent.
     Returns:
         output: [num_tokens, 1, dim_nope + dim_rope], the de-quantized k-cache
     """
@@ -194,10 +223,46 @@ def dequantize_k_cache_paged(
     dim_rope = 64
     num_tiles = dim_nope // group_size  # 512 // 128 = 4
 
-    output = torch.empty(
-        (num_tokens, 1, dim_nope + dim_rope),
-        dtype=torch.bfloat16,
-        device=quant_k_cache.device,
+    expected_shape = (num_tokens, 1, dim_nope + dim_rope)
+    if out is None:
+        output = torch.empty(
+            expected_shape,
+            dtype=torch.bfloat16,
+            device=quant_k_cache.device,
+        )
+    else:
+        if out.shape != expected_shape:
+            raise ValueError(
+                f"out shape must be {expected_shape}, got {tuple(out.shape)}"
+            )
+        if out.dtype != torch.bfloat16:
+            raise ValueError(f"out dtype must be torch.bfloat16, got {out.dtype}")
+        if out.device != quant_k_cache.device:
+            raise ValueError(
+                "out device must match quant_k_cache: "
+                f"{out.device} != {quant_k_cache.device}"
+            )
+        if not out.is_contiguous():
+            raise ValueError("out must be contiguous")
+        output = out
+
+    if num_valid_rows is not None:
+        if num_valid_rows.dtype != torch.int32:
+            raise ValueError(
+                f"num_valid_rows dtype must be torch.int32, got {num_valid_rows.dtype}"
+            )
+        if num_valid_rows.numel() != 1:
+            raise ValueError("num_valid_rows must contain exactly one element")
+        if num_valid_rows.device != quant_k_cache.device:
+            raise ValueError(
+                "num_valid_rows device must match quant_k_cache: "
+                f"{num_valid_rows.device} != {quant_k_cache.device}"
+            )
+        if not num_valid_rows.is_contiguous():
+            raise ValueError("num_valid_rows must be contiguous")
+
+    valid_rows_ptr = (
+        num_valid_rows if num_valid_rows is not None else page_table_1_flattened
     )
 
     # cdiv(512 + 64, 128) = 5
@@ -214,12 +279,46 @@ def dequantize_k_cache_paged(
     # [:, 528:]
     input_rope = quant_k_cache[:, dim_nope + num_tiles * 4 :].view(torch.bfloat16)
 
+    if num_valid_rows is not None:
+        if quant_k_cache.device.type == "cuda":
+            grid_rows = _device_extent_grid_rows(
+                num_tokens,
+                torch.cuda.get_device_properties(
+                    quant_k_cache.device
+                ).multi_processor_count,
+            )
+        else:
+            # CPU unit tests replace the Triton launcher with a contract stub.
+            # Preserve that test seam without querying unavailable CUDA state.
+            grid_rows = num_tokens
+        _dequantize_k_cache_paged_device_extent_kernel[
+            (grid_rows, num_blocks_per_token)
+        ](
+            output,
+            input_nope_q,
+            input_nope_s,
+            input_rope,
+            page_table_1_flattened,
+            num_valid_rows,
+            output.stride(0),
+            input_nope_q.stride(0),
+            input_nope_s.stride(0),
+            input_rope.stride(0),
+            NUM_NOPE_BLOCKS=num_tiles,
+            GROUP_SIZE=group_size,
+            DIM_NOPE=dim_nope,
+            DIM_ROPE=dim_rope,
+            GRID_ROWS=grid_rows,
+        )
+        return output
+
     _dequantize_k_cache_paged_kernel[(num_tokens, num_blocks_per_token)](
         output,
         input_nope_q,
         input_nope_s,
         input_rope,
         page_table_1_flattened,
+        valid_rows_ptr,
         output.stride(0),
         input_nope_q.stride(0),
         input_nope_s.stride(0),
@@ -228,9 +327,65 @@ def dequantize_k_cache_paged(
         GROUP_SIZE=group_size,
         DIM_NOPE=dim_nope,
         DIM_ROPE=dim_rope,
+        HAS_VALID_ROWS=num_valid_rows is not None,
     )
 
     return output
+
+
+@triton.jit
+def _dequantize_k_cache_paged_device_extent_kernel(
+    output_ptr,
+    input_nope_q_ptr,
+    input_nope_s_ptr,
+    input_rope_ptr,
+    page_table_1_ptr,
+    num_valid_rows_ptr,
+    output_stride_0: int,
+    input_nope_q_stride_0: int,
+    input_nope_s_stride_0: int,
+    input_rope_stride_0: int,
+    NUM_NOPE_BLOCKS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    DIM_NOPE: tl.constexpr,
+    DIM_ROPE: tl.constexpr,
+    GRID_ROWS: tl.constexpr,
+):
+    """Gather/dequantize a device-sized prefix with a bounded static grid.
+
+    ``num_valid_rows`` remains on device for CUDA Graph replay.  Each program
+    owns one feature block and walks rows separated by ``GRID_ROWS``; therefore
+    launch work depends on SM count rather than the worst-case output capacity.
+    """
+    token_id = tl.program_id(0)
+    raw_block_id = tl.program_id(1)
+    num_valid_rows = tl.load(num_valid_rows_ptr)
+
+    while token_id < num_valid_rows:
+        token_id_paged = tl.load(page_table_1_ptr + token_id).to(tl.int32)
+
+        if raw_block_id < NUM_NOPE_BLOCKS:
+            offs_q = raw_block_id * GROUP_SIZE + tl.arange(0, GROUP_SIZE)
+            mask = offs_q < DIM_NOPE
+            ptr_q = input_nope_q_ptr + token_id_paged * input_nope_q_stride_0 + offs_q
+            ptr_s = (
+                input_nope_s_ptr + token_id_paged * input_nope_s_stride_0 + raw_block_id
+            )
+            y_q = tl.load(ptr_q, mask=mask, other=0.0).to(tl.float32)
+            y_s = tl.load(ptr_s)
+            y = (y_q * y_s).to(output_ptr.dtype.element_ty)
+            dst_ptr = output_ptr + token_id * output_stride_0 + offs_q
+            tl.store(dst_ptr, y, mask=mask)
+        else:
+            rope_block_id = raw_block_id - NUM_NOPE_BLOCKS
+            offs = rope_block_id * GROUP_SIZE + tl.arange(0, GROUP_SIZE)
+            mask = offs < DIM_ROPE
+            src_ptr = input_rope_ptr + token_id_paged * input_rope_stride_0 + offs
+            dst_ptr = output_ptr + token_id * output_stride_0 + DIM_NOPE + offs
+            data = tl.load(src_ptr, mask=mask).to(tl.bfloat16)
+            tl.store(dst_ptr, data, mask=mask)
+
+        token_id += GRID_ROWS
 
 
 @triton.jit
@@ -240,6 +395,7 @@ def _dequantize_k_cache_paged_kernel(
     input_nope_s_ptr,
     input_rope_ptr,
     page_table_1_ptr,
+    num_valid_rows_ptr,
     output_stride_0: int,
     input_nope_q_stride_0: int,
     input_nope_s_stride_0: int,
@@ -248,9 +404,18 @@ def _dequantize_k_cache_paged_kernel(
     GROUP_SIZE: tl.constexpr,
     DIM_NOPE: tl.constexpr,
     DIM_ROPE: tl.constexpr,
+    HAS_VALID_ROWS: tl.constexpr,
 ):
     token_id = tl.program_id(0)
-    token_id_paged = tl.load(page_table_1_ptr + token_id).to(tl.int32)
+    if HAS_VALID_ROWS:
+        token_is_valid = token_id < tl.load(num_valid_rows_ptr)
+    else:
+        token_is_valid = True
+    token_id_paged = tl.load(
+        page_table_1_ptr + token_id,
+        mask=token_is_valid,
+        other=0,
+    ).to(tl.int32)
     raw_block_id = tl.program_id(1)
 
     if raw_block_id < NUM_NOPE_BLOCKS:
@@ -258,7 +423,7 @@ def _dequantize_k_cache_paged_kernel(
         effective_block_id = raw_block_id
 
         offs_q = effective_block_id * GROUP_SIZE + tl.arange(0, GROUP_SIZE)
-        mask = offs_q < DIM_NOPE
+        mask = (offs_q < DIM_NOPE) & token_is_valid
         ptr_q = input_nope_q_ptr + token_id_paged * input_nope_q_stride_0 + offs_q
         ptr_s = (
             input_nope_s_ptr
@@ -267,7 +432,7 @@ def _dequantize_k_cache_paged_kernel(
         )
 
         y_q = tl.load(ptr_q, mask=mask, other=0.0).to(tl.float32)
-        y_s = tl.load(ptr_s)
+        y_s = tl.load(ptr_s, mask=token_is_valid, other=0.0)
 
         y = (y_q * y_s).to(output_ptr.dtype.element_ty)
 
@@ -278,7 +443,7 @@ def _dequantize_k_cache_paged_kernel(
         effective_block_id = raw_block_id - NUM_NOPE_BLOCKS
 
         offs = effective_block_id * GROUP_SIZE + tl.arange(0, GROUP_SIZE)
-        mask = offs < DIM_ROPE
+        mask = (offs < DIM_ROPE) & token_is_valid
 
         src_ptr = input_rope_ptr + token_id_paged * input_rope_stride_0 + offs
         dst_ptr = output_ptr + token_id * output_stride_0 + DIM_NOPE + offs

--- a/python/sglang/kernels/ops/attention/dsa/selective_kv_dequant.py
+++ b/python/sglang/kernels/ops/attention/dsa/selective_kv_dequant.py
@@ -1,0 +1,293 @@
+import torch
+import triton
+import triton.language as tl
+
+_BLOCK_SIZE = 256
+
+
+@triton.jit
+def _begin_dense_epoch_kernel(epoch_ptr, num_unique_ptr):
+    current_epoch = tl.load(epoch_ptr)
+    tl.store(epoch_ptr, current_epoch + 1)
+    tl.store(num_unique_ptr, 0)
+
+
+@triton.jit
+def _mark_selected_slots_kernel(
+    page_table_ptr,
+    flat_topk_ptr,
+    slot_epoch_ptr,
+    epoch_ptr,
+    num_occurrences,
+    page_table_len,
+    num_pool_rows,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < num_occurrences
+    logical = tl.load(flat_topk_ptr + offsets, mask=in_bounds, other=-1).to(tl.int32)
+    valid_logical = in_bounds & (logical >= 0) & (logical < page_table_len)
+    physical = tl.load(
+        page_table_ptr + logical,
+        mask=valid_logical,
+        other=0,
+    ).to(tl.int32)
+    valid_physical = valid_logical & (physical >= 0) & (physical < num_pool_rows)
+    current_epoch = tl.load(epoch_ptr)
+    # Duplicate occurrences may race here, but atomic exchange makes the
+    # generation publication formally ordered; every writer publishes the
+    # same int64 value.
+    tl.atomic_xchg(
+        slot_epoch_ptr + physical,
+        current_epoch,
+        mask=valid_physical,
+    )
+
+
+@triton.jit
+def _local_scan_selected_slots_kernel(
+    slot_epoch_ptr,
+    slot_to_compact_ptr,
+    block_offsets_ptr,
+    epoch_ptr,
+    num_pool_rows,
+    BLOCK_SIZE: tl.constexpr,
+):
+    physical = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    in_bounds = physical < num_pool_rows
+    current_epoch = tl.load(epoch_ptr)
+    selected = in_bounds & (
+        tl.load(slot_epoch_ptr + physical, mask=in_bounds, other=-1) == current_epoch
+    )
+    selected_i32 = selected.to(tl.int32)
+    local_rank = tl.cumsum(selected_i32, axis=0) - 1
+    tl.store(
+        slot_to_compact_ptr + physical,
+        local_rank,
+        mask=selected,
+    )
+    block_count = tl.sum(selected_i32, axis=0)
+    tl.store(block_offsets_ptr + tl.program_id(0), block_count)
+
+
+@triton.jit
+def _scan_block_counts_kernel(
+    block_offsets_ptr,
+    num_unique_ptr,
+    num_blocks,
+    SCAN_SIZE: tl.constexpr,
+):
+    block = tl.arange(0, SCAN_SIZE)
+    in_bounds = block < num_blocks
+    counts = tl.load(block_offsets_ptr + block, mask=in_bounds, other=0).to(tl.int32)
+    exclusive_offsets = tl.cumsum(counts, axis=0) - counts
+    tl.store(block_offsets_ptr + block, exclusive_offsets, mask=in_bounds)
+    tl.store(num_unique_ptr, tl.sum(counts, axis=0))
+
+
+@triton.jit
+def _finalize_compact_rows_kernel(
+    slot_epoch_ptr,
+    slot_to_compact_ptr,
+    selected_physical_slots_ptr,
+    block_offsets_ptr,
+    epoch_ptr,
+    num_pool_rows,
+    selection_capacity,
+    BLOCK_SIZE: tl.constexpr,
+):
+    block_id = tl.program_id(0)
+    physical = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    in_bounds = physical < num_pool_rows
+    current_epoch = tl.load(epoch_ptr)
+    selected = in_bounds & (
+        tl.load(slot_epoch_ptr + physical, mask=in_bounds, other=-1) == current_epoch
+    )
+    local_rank = tl.load(
+        slot_to_compact_ptr + physical,
+        mask=selected,
+        other=0,
+    ).to(tl.int32)
+    block_offset = tl.load(block_offsets_ptr + block_id).to(tl.int32)
+    compact = local_rank + block_offset
+    within_capacity = selected & (compact < selection_capacity)
+    tl.store(slot_to_compact_ptr + physical, compact, mask=within_capacity)
+    tl.store(
+        selected_physical_slots_ptr + compact,
+        physical,
+        mask=within_capacity,
+    )
+
+
+@triton.jit
+def _remap_topk_kernel(
+    page_table_ptr,
+    flat_topk_ptr,
+    slot_to_compact_ptr,
+    remapped_topk_ptr,
+    num_occurrences,
+    page_table_len,
+    num_pool_rows,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < num_occurrences
+    logical = tl.load(flat_topk_ptr + offsets, mask=in_bounds, other=-1).to(tl.int32)
+    valid_logical = in_bounds & (logical >= 0) & (logical < page_table_len)
+    physical = tl.load(
+        page_table_ptr + logical,
+        mask=valid_logical,
+        other=0,
+    ).to(tl.int32)
+    valid_physical = valid_logical & (physical >= 0) & (physical < num_pool_rows)
+    compact = tl.load(
+        slot_to_compact_ptr + physical,
+        mask=valid_physical,
+        other=-1,
+    ).to(tl.int32)
+    remapped = tl.where(valid_physical, compact, -1)
+    tl.store(remapped_topk_ptr + offsets, remapped, mask=in_bounds)
+
+
+def _require_cuda_int_tensor(
+    name: str,
+    tensor: torch.Tensor,
+    dtype: torch.dtype,
+) -> None:
+    if tensor.device.type != "cuda":
+        raise ValueError(f"{name} must be a CUDA tensor, got {tensor.device}")
+    if tensor.dtype != dtype:
+        raise ValueError(f"{name} dtype must be {dtype}, got {tensor.dtype}")
+    if not tensor.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+def deduplicate_kv_slots_dense_epoch(
+    page_table_1_flattened: torch.Tensor,
+    flat_topk_indices: torch.Tensor,
+    *,
+    slot_epoch: torch.Tensor,
+    slot_to_compact: torch.Tensor,
+    selected_physical_slots: torch.Tensor,
+    remapped_topk: torch.Tensor,
+    block_offsets: torch.Tensor,
+    epoch: torch.Tensor,
+    num_unique: torch.Tensor,
+    num_pool_rows: int,
+    selection_capacity: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Deduplicate physical DSA KV slots with persistent generation tables.
+
+    The six launch phases are ordered on the current CUDA stream:
+
+    1. advance the int64 generation and reset ``num_unique``;
+    2. mark every valid physical slot;
+    3. prefix-scan each 256-slot block;
+    4. prefix-scan the block counts;
+    5. publish deterministic physical-slot-sorted compact rows;
+    6. remap every logical top-k occurrence to its compact row.
+
+    No device value is converted to Python, so the wrapper introduces no host
+    synchronization and can be replayed inside a CUDA Graph after buffers have
+    been allocated.
+    """
+    _require_cuda_int_tensor(
+        "page_table_1_flattened", page_table_1_flattened, torch.int32
+    )
+    _require_cuda_int_tensor("flat_topk_indices", flat_topk_indices, torch.int32)
+    _require_cuda_int_tensor("slot_epoch", slot_epoch, torch.int64)
+    _require_cuda_int_tensor("slot_to_compact", slot_to_compact, torch.int32)
+    _require_cuda_int_tensor(
+        "selected_physical_slots", selected_physical_slots, torch.int32
+    )
+    _require_cuda_int_tensor("remapped_topk", remapped_topk, torch.int32)
+    _require_cuda_int_tensor("block_offsets", block_offsets, torch.int32)
+    _require_cuda_int_tensor("epoch", epoch, torch.int64)
+    _require_cuda_int_tensor("num_unique", num_unique, torch.int32)
+
+    if page_table_1_flattened.ndim != 1:
+        raise ValueError("page_table_1_flattened must be one-dimensional")
+    if remapped_topk.shape != flat_topk_indices.shape:
+        raise ValueError(
+            "remapped_topk shape must match flat_topk_indices: "
+            f"{tuple(remapped_topk.shape)} != {tuple(flat_topk_indices.shape)}"
+        )
+    if epoch.numel() != 1 or num_unique.numel() != 1:
+        raise ValueError("epoch and num_unique must each contain one element")
+    if num_pool_rows <= 0 or num_pool_rows > slot_epoch.numel():
+        raise ValueError(
+            f"num_pool_rows must be in [1, {slot_epoch.numel()}], got {num_pool_rows}"
+        )
+    if slot_to_compact.numel() < num_pool_rows:
+        raise ValueError("slot_to_compact is smaller than num_pool_rows")
+
+    required_capacity = min(page_table_1_flattened.numel(), flat_topk_indices.numel())
+    if selection_capacity < required_capacity:
+        raise ValueError(
+            "selection_capacity must cover the conservative unique-row bound: "
+            f"{selection_capacity} < {required_capacity}"
+        )
+    if selection_capacity > selected_physical_slots.numel():
+        raise ValueError(
+            "selected_physical_slots is smaller than selection_capacity: "
+            f"{selected_physical_slots.numel()} < {selection_capacity}"
+        )
+
+    num_occurrences = flat_topk_indices.numel()
+    num_scan_blocks = triton.cdiv(num_pool_rows, _BLOCK_SIZE)
+    if block_offsets.numel() < num_scan_blocks:
+        raise ValueError(
+            "block_offsets is smaller than the dense scan grid: "
+            f"{block_offsets.numel()} < {num_scan_blocks}"
+        )
+    scan_size = triton.next_power_of_2(num_scan_blocks)
+    _begin_dense_epoch_kernel[(1,)](epoch, num_unique)
+    _mark_selected_slots_kernel[(triton.cdiv(num_occurrences, _BLOCK_SIZE),)](
+        page_table_1_flattened,
+        flat_topk_indices,
+        slot_epoch,
+        epoch,
+        num_occurrences,
+        page_table_1_flattened.numel(),
+        num_pool_rows,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    _local_scan_selected_slots_kernel[(num_scan_blocks,)](
+        slot_epoch,
+        slot_to_compact,
+        block_offsets,
+        epoch,
+        num_pool_rows,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    _scan_block_counts_kernel[(1,)](
+        block_offsets,
+        num_unique,
+        num_scan_blocks,
+        SCAN_SIZE=scan_size,
+    )
+    _finalize_compact_rows_kernel[(num_scan_blocks,)](
+        slot_epoch,
+        slot_to_compact,
+        selected_physical_slots,
+        block_offsets,
+        epoch,
+        num_pool_rows,
+        selection_capacity,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    _remap_topk_kernel[(triton.cdiv(num_occurrences, _BLOCK_SIZE),)](
+        page_table_1_flattened,
+        flat_topk_indices,
+        slot_to_compact,
+        remapped_topk,
+        num_occurrences,
+        page_table_1_flattened.numel(),
+        num_pool_rows,
+        BLOCK_SIZE=_BLOCK_SIZE,
+    )
+    return (
+        selected_physical_slots[:selection_capacity],
+        remapped_topk,
+        num_unique,
+    )

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1399,6 +1399,17 @@ class Envs:
     SGLANG_ENABLE_PCG_DSV2_DUAL_STREAM = EnvBool(False)
     SGLANG_DSA_TOPK_BROADCAST = EnvBool(False)
     SGLANG_DISABLE_DSA_INDEXER_FUSION = EnvBool(False)
+    # Experimental BF16 FlashMLA sparse-prefill probe: gather/dequantize one
+    # physical FP8 KV row per top-k occurrence instead of materializing the
+    # whole prefix.  This intentionally does not deduplicate overlapping top-k
+    # rows; it is default-off and exists to measure the attainable selective
+    # bandwidth benefit before promoting the fixed-workspace dedup kernel.
+    SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_NO_DEDUP = EnvBool(False)
+    # Experimental follow-up to the no-dedup probe. A persistent dense epoch
+    # map deduplicates physical KV slots, prefix-scans them into a fixed BF16
+    # workspace, and remaps sparse indices without reading num_unique on the
+    # host. Default OFF until SM90 numerical, Nsight and E2E gates pass.
+    SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_DENSE_EPOCH = EnvBool(False)
     # Opt-in perf path for --dsa-prefill-backend flashmla_sparse_q8: fuse the
     # absorbed q bmm with the nope/rope concat + fp8 cast so q is written
     # directly in fp8 ("born fp8") and the standalone concat-cast kernel

--- a/python/sglang/srt/layers/attention/dsa/selective_kv_dequant.py
+++ b/python/sglang/srt/layers/attention/dsa/selective_kv_dequant.py
@@ -1,0 +1,773 @@
+from dataclasses import dataclass
+from typing import Literal
+
+import torch
+
+# DeepSeek DSA FP8 KV rows use 512 E4M3 values, four float32 group scales,
+# and 64 BF16 RoPE values: 512 + 4 * 4 + 64 * 2 = 656 bytes.  The BF16
+# FlashMLA workspace expands the 512 + 64 values to 576 * 2 = 1152 bytes.
+KV_BYTES_PER_ROW = 656
+KV_DEQUANTIZED_BYTES_PER_ROW = 576 * 2
+INDEX_BYTES = torch.tensor([], dtype=torch.int32).element_size()
+DENSE_DEDUP_BLOCK_SIZE = 256
+# A 1xH20 crossover sweep with a 65,536-row pool measured the dense-epoch
+# path at 0.28x, 0.53x, 0.80x, and 1.07x of cached full dequant for 8K, 16K,
+# 24K, and 32K prefixes.  The first material win was 1.31x at 40K.  The byte
+# model below cannot represent the fixed six-kernel launch/scan floor, so keep
+# the experimental path fail-closed below that measured boundary.
+DENSE_EPOCH_MIN_PREFIX_ROWS = 40 * 1024
+
+
+def _validate_extent(name: str, value: int) -> None:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise ValueError(f"{name} must be a non-negative integer, got {value!r}")
+
+
+def _capacity_bucket(extent: int) -> int:
+    return 0 if extent == 0 else 1 << (extent - 1).bit_length()
+
+
+@dataclass(frozen=True)
+class DenseEpochDedupBuffers:
+    slot_epoch: torch.Tensor
+    slot_to_compact: torch.Tensor
+    selected_physical_slots: torch.Tensor
+    remapped_topk: torch.Tensor
+    block_offsets: torch.Tensor
+    epoch: torch.Tensor
+    num_unique: torch.Tensor
+
+
+@dataclass(frozen=True)
+class DenseEpochSelection:
+    selected_physical_slots: torch.Tensor
+    remapped_topk: torch.Tensor
+    num_unique: torch.Tensor
+    capacity: int
+
+
+SelectiveKVMode = Literal["off", "no_dedup", "dense_epoch"]
+
+
+@dataclass(frozen=True)
+class SelectiveKVDequantResult:
+    kv_cache: torch.Tensor
+    remapped_topk: torch.Tensor
+    mode: SelectiveKVMode
+
+
+def resolve_selective_kv_mode(
+    no_dedup_enabled: bool,
+    dense_epoch_enabled: bool,
+) -> SelectiveKVMode:
+    """Resolve the two temporary experiment gates to one explicit mode."""
+    if no_dedup_enabled and dense_epoch_enabled:
+        raise ValueError(
+            "SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_NO_DEDUP and "
+            "SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_DENSE_EPOCH are mutually exclusive"
+        )
+    if dense_epoch_enabled:
+        return "dense_epoch"
+    if no_dedup_enabled:
+        return "no_dedup"
+    return "off"
+
+
+class SelectiveKVWorkspace:
+    """Grow-only buffers for selective DSA prefill preparation.
+
+    Calls on one attention backend execute serially on the same CUDA stream.
+    Reusing bucketed storage therefore gives stable addresses for repeated or
+    smaller shapes without retaining per-layer outputs.
+    """
+
+    def __init__(self, device: torch.device):
+        self.device = torch.device(device)
+        self._bf16: torch.Tensor | None = None
+        self._physical_slots: torch.Tensor | None = None
+        self._remapped_topk: torch.Tensor | None = None
+        self._slot_epoch: torch.Tensor | None = None
+        self._slot_to_compact: torch.Tensor | None = None
+        self._selected_physical_slots: torch.Tensor | None = None
+        self._dedup_remapped_topk: torch.Tensor | None = None
+        self._block_offsets: torch.Tensor | None = None
+        self._epoch: torch.Tensor | None = None
+        self._num_unique: torch.Tensor | None = None
+
+    @property
+    def bf16_capacity(self) -> int:
+        return 0 if self._bf16 is None else self._bf16.shape[0]
+
+    @property
+    def occurrence_capacity(self) -> int:
+        return 0 if self._physical_slots is None else self._physical_slots.shape[0]
+
+    def get_bf16(self, num_rows: int) -> torch.Tensor:
+        _validate_extent("num_rows", num_rows)
+        if num_rows > self.bf16_capacity:
+            self._bf16 = torch.empty(
+                (_capacity_bucket(num_rows), 1, 576),
+                dtype=torch.bfloat16,
+                device=self.device,
+            )
+        if self._bf16 is None:
+            return torch.empty((0, 1, 576), dtype=torch.bfloat16, device=self.device)
+        return self._bf16[:num_rows]
+
+    def get_occurrence_metadata(
+        self, num_occurrences: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        _validate_extent("num_occurrences", num_occurrences)
+        if num_occurrences > self.occurrence_capacity:
+            capacity = _capacity_bucket(num_occurrences)
+            self._physical_slots = torch.empty(
+                capacity, dtype=torch.int32, device=self.device
+            )
+            self._remapped_topk = torch.empty(
+                capacity, dtype=torch.int32, device=self.device
+            )
+        if self._physical_slots is None:
+            empty = torch.empty(0, dtype=torch.int32, device=self.device)
+            return empty, empty.clone()
+        return (
+            self._physical_slots[:num_occurrences],
+            self._remapped_topk[:num_occurrences],
+        )
+
+    def get_dense_dedup_buffers(
+        self,
+        num_pool_rows: int,
+        selection_capacity: int,
+        num_occurrences: int,
+    ) -> DenseEpochDedupBuffers:
+        for name, value in (
+            ("num_pool_rows", num_pool_rows),
+            ("selection_capacity", selection_capacity),
+            ("num_occurrences", num_occurrences),
+        ):
+            _validate_extent(name, value)
+        if selection_capacity > num_pool_rows:
+            raise ValueError(
+                "selection_capacity cannot exceed num_pool_rows: "
+                f"{selection_capacity} > {num_pool_rows}"
+            )
+
+        current_pool_capacity = (
+            0 if self._slot_epoch is None else self._slot_epoch.shape[0]
+        )
+        if num_pool_rows > current_pool_capacity:
+            pool_capacity = _capacity_bucket(num_pool_rows)
+            self._slot_epoch = torch.full(
+                (pool_capacity,), -1, dtype=torch.int64, device=self.device
+            )
+            self._slot_to_compact = torch.empty(
+                pool_capacity, dtype=torch.int32, device=self.device
+            )
+
+        num_scan_blocks = (
+            num_pool_rows + DENSE_DEDUP_BLOCK_SIZE - 1
+        ) // DENSE_DEDUP_BLOCK_SIZE
+        current_block_capacity = (
+            0 if self._block_offsets is None else self._block_offsets.shape[0]
+        )
+        if num_scan_blocks > current_block_capacity:
+            self._block_offsets = torch.empty(
+                _capacity_bucket(num_scan_blocks),
+                dtype=torch.int32,
+                device=self.device,
+            )
+
+        current_selection_capacity = (
+            0
+            if self._selected_physical_slots is None
+            else self._selected_physical_slots.shape[0]
+        )
+        if selection_capacity > current_selection_capacity:
+            selected_capacity = _capacity_bucket(selection_capacity)
+            self._selected_physical_slots = torch.empty(
+                selected_capacity, dtype=torch.int32, device=self.device
+            )
+
+        current_occurrence_capacity = (
+            0
+            if self._dedup_remapped_topk is None
+            else self._dedup_remapped_topk.shape[0]
+        )
+        if num_occurrences > current_occurrence_capacity:
+            occurrence_capacity = _capacity_bucket(num_occurrences)
+            self._dedup_remapped_topk = torch.empty(
+                occurrence_capacity, dtype=torch.int32, device=self.device
+            )
+
+        if self._epoch is None:
+            self._epoch = torch.zeros(1, dtype=torch.int64, device=self.device)
+            self._num_unique = torch.zeros(1, dtype=torch.int32, device=self.device)
+
+        # Zero-sized calls are not useful in production, but returning valid
+        # empty tensors keeps the workspace contract total and easy to test.
+        if self._slot_epoch is None:
+            self._slot_epoch = torch.empty(0, dtype=torch.int64, device=self.device)
+            self._slot_to_compact = torch.empty(
+                0, dtype=torch.int32, device=self.device
+            )
+        if self._selected_physical_slots is None:
+            self._selected_physical_slots = torch.empty(
+                0, dtype=torch.int32, device=self.device
+            )
+        if self._dedup_remapped_topk is None:
+            self._dedup_remapped_topk = torch.empty(
+                0, dtype=torch.int32, device=self.device
+            )
+        if self._block_offsets is None:
+            self._block_offsets = torch.empty(0, dtype=torch.int32, device=self.device)
+
+        return DenseEpochDedupBuffers(
+            slot_epoch=self._slot_epoch,
+            slot_to_compact=self._slot_to_compact,
+            selected_physical_slots=self._selected_physical_slots,
+            remapped_topk=self._dedup_remapped_topk,
+            block_offsets=self._block_offsets,
+            epoch=self._epoch,
+            num_unique=self._num_unique,
+        )
+
+
+@dataclass(frozen=True)
+class SelectiveKVRemap:
+    """CPU oracle for the DSA logical -> physical -> compact mapping."""
+
+    physical_slots: torch.Tensor
+    remapped_topk: torch.Tensor
+    num_valid: int
+    num_unique: int
+
+
+@dataclass(frozen=True)
+class NoDedupSelectiveKVRemap:
+    """Fixed-shape selective mapping used by the no-dedup GPU probe."""
+
+    physical_slots: torch.Tensor
+    remapped_topk: torch.Tensor
+
+
+@dataclass(frozen=True)
+class SelectiveKVTrafficEstimate:
+    """Byte model used to gate the selective path conservatively."""
+
+    full_kv_bytes: int
+    selective_kv_bytes: int
+    metadata_bytes: int
+    full_workspace_bytes: int
+    selective_workspace_bytes: int
+
+    @property
+    def selective_total_bytes(self) -> int:
+        return self.selective_kv_bytes + self.metadata_bytes
+
+
+def prepare_dense_epoch_selection(
+    page_table_1_flattened: torch.Tensor,
+    flat_topk_indices: torch.Tensor,
+    *,
+    num_pool_rows: int,
+    workspace: SelectiveKVWorkspace,
+    deduplicate_fn=None,
+) -> DenseEpochSelection:
+    """Prepare fixed-capacity compact DSA indices without reading device state.
+
+    ``deduplicate_fn`` is injectable only so the standalone kernel test can
+    load this orchestration module without importing the complete SGLang
+    package. Production callers use the real kernel by default.
+    """
+    if deduplicate_fn is None:
+        from sglang.kernels.ops.attention.dsa.selective_kv_dequant import (
+            deduplicate_kv_slots_dense_epoch,
+        )
+
+        deduplicate_fn = deduplicate_kv_slots_dense_epoch
+
+    capacity = min(page_table_1_flattened.numel(), flat_topk_indices.numel())
+    buffers = workspace.get_dense_dedup_buffers(
+        num_pool_rows=num_pool_rows,
+        selection_capacity=capacity,
+        num_occurrences=flat_topk_indices.numel(),
+    )
+    selected_physical_slots = buffers.selected_physical_slots[:capacity]
+    remapped_topk = buffers.remapped_topk[: flat_topk_indices.numel()].view_as(
+        flat_topk_indices
+    )
+    selected_physical_slots, remapped_topk, num_unique = deduplicate_fn(
+        page_table_1_flattened,
+        flat_topk_indices,
+        slot_epoch=buffers.slot_epoch,
+        slot_to_compact=buffers.slot_to_compact,
+        selected_physical_slots=selected_physical_slots,
+        remapped_topk=remapped_topk,
+        block_offsets=buffers.block_offsets,
+        epoch=buffers.epoch,
+        num_unique=buffers.num_unique,
+        num_pool_rows=num_pool_rows,
+        selection_capacity=capacity,
+    )
+    return DenseEpochSelection(
+        selected_physical_slots=selected_physical_slots,
+        remapped_topk=remapped_topk,
+        num_unique=num_unique,
+        capacity=capacity,
+    )
+
+
+def dequantize_dsa_prefix_kv_selective(
+    quant_k_cache: torch.Tensor,
+    page_table_1_flattened: torch.Tensor,
+    flat_topk_indices: torch.Tensor,
+    *,
+    num_pool_rows: int,
+    mode: SelectiveKVMode,
+    workspace: SelectiveKVWorkspace,
+    dequantize_fn=None,
+    deduplicate_fn=None,
+) -> SelectiveKVDequantResult:
+    """Prepare BF16 prefix KV for FlashMLA with an opt-in selective path.
+
+    The shape-only traffic gate runs before either experimental path.  It
+    intentionally assumes every top-k occurrence is unique, so enabling an
+    experiment cannot make a clearly dense workload pay the dedup overhead.
+    ``dense_epoch`` keeps the data-dependent active row count on device;
+    ``no_dedup`` dequantizes every occurrence because padding entries need not
+    form a contiguous suffix.
+    """
+    if mode not in ("off", "no_dedup", "dense_epoch"):
+        raise ValueError(f"unsupported selective KV mode: {mode!r}")
+    if dequantize_fn is None:
+        from sglang.kernels.ops.attention.dsa.dequant_k_cache import (
+            dequantize_k_cache_paged,
+        )
+
+        dequantize_fn = dequantize_k_cache_paged
+
+    def full_dequantize() -> SelectiveKVDequantResult:
+        return SelectiveKVDequantResult(
+            kv_cache=dequantize_fn(quant_k_cache, page_table_1_flattened),
+            remapped_topk=flat_topk_indices,
+            mode="off",
+        )
+
+    if mode == "off":
+        return full_dequantize()
+    if flat_topk_indices.ndim != 2:
+        raise ValueError(
+            "flat_topk_indices must have shape (query_tokens, topk), got "
+            f"{tuple(flat_topk_indices.shape)}"
+        )
+
+    query_tokens, topk = flat_topk_indices.shape
+    if mode == "dense_epoch":
+        use_selective = should_use_dense_epoch_kv_dequant(
+            prefix_rows=page_table_1_flattened.numel(),
+            query_tokens=query_tokens,
+            topk=topk,
+            num_pool_rows=num_pool_rows,
+        )
+    else:
+        use_selective = should_use_selective_kv_dequant(
+            prefix_rows=page_table_1_flattened.numel(),
+            query_tokens=query_tokens,
+            topk=topk,
+        )
+    if not use_selective:
+        return full_dequantize()
+
+    if mode == "no_dedup":
+        physical_slots, remapped_topk = workspace.get_occurrence_metadata(
+            flat_topk_indices.numel()
+        )
+        remapped_topk = remapped_topk.view_as(flat_topk_indices)
+        selection = build_selective_kv_no_dedup(
+            page_table_1_flattened,
+            flat_topk_indices,
+            physical_slots_out=physical_slots,
+            remapped_topk_out=remapped_topk,
+        )
+        out = workspace.get_bf16(selection.physical_slots.numel())
+        return SelectiveKVDequantResult(
+            kv_cache=dequantize_fn(
+                quant_k_cache,
+                selection.physical_slots,
+                out=out,
+            ),
+            remapped_topk=selection.remapped_topk,
+            mode="no_dedup",
+        )
+
+    selection = prepare_dense_epoch_selection(
+        page_table_1_flattened,
+        flat_topk_indices,
+        num_pool_rows=num_pool_rows,
+        workspace=workspace,
+        deduplicate_fn=deduplicate_fn,
+    )
+    out = workspace.get_bf16(selection.capacity)
+    return SelectiveKVDequantResult(
+        kv_cache=dequantize_fn(
+            quant_k_cache,
+            selection.selected_physical_slots,
+            out=out,
+            num_valid_rows=selection.num_unique,
+        ),
+        remapped_topk=selection.remapped_topk,
+        mode="dense_epoch",
+    )
+
+
+def _require_index_tensor(name: str, tensor: torch.Tensor) -> None:
+    if tensor.dtype not in (torch.int32, torch.int64):
+        raise TypeError(
+            f"{name} must be an integer index tensor (int32 or int64), "
+            f"got {tensor.dtype}"
+        )
+    if tensor.device.type != "cpu":
+        raise ValueError(f"{name} must be on CPU for the reference implementation")
+
+
+def build_selective_kv_remap_reference(
+    page_table_1_flattened: torch.Tensor,
+    flat_topk_indices: torch.Tensor,
+) -> SelectiveKVRemap:
+    """Build a stable physical-slot deduplication oracle on CPU.
+
+    ``flat_topk_indices`` contains indices into ``page_table_1_flattened``
+    after the DSA request-local offsets have been applied.  The returned
+    indices address a compact list of unique *physical* KV-cache slots.  This
+    distinction is important when different requests share radix-cache rows.
+
+    The first appearance of a physical slot determines its compact index.  A
+    production GPU kernel does not need to preserve this order, but using a
+    deterministic oracle makes exact remap tests and benchmark debugging much
+    easier.
+    """
+    _require_index_tensor("page_table_1_flattened", page_table_1_flattened)
+    _require_index_tensor("flat_topk_indices", flat_topk_indices)
+    if page_table_1_flattened.ndim != 1:
+        raise ValueError(
+            "page_table_1_flattened must be one-dimensional, got "
+            f"shape={tuple(page_table_1_flattened.shape)}"
+        )
+
+    flat_indices = flat_topk_indices.reshape(-1)
+    if flat_indices.numel() and int(flat_indices.min().item()) < -1:
+        raise ValueError("flat_topk_indices contains an index smaller than -1")
+
+    valid = flat_indices >= 0
+    valid_indices = flat_indices[valid]
+    if valid_indices.numel():
+        max_index = int(valid_indices.max().item())
+        if max_index >= page_table_1_flattened.numel():
+            raise ValueError(
+                "flat_topk_indices contains an index outside "
+                f"page_table_1_flattened: {max_index} >= "
+                f"{page_table_1_flattened.numel()}"
+            )
+
+    remapped_flat = torch.full(
+        flat_indices.shape,
+        -1,
+        dtype=torch.int32,
+        device=flat_topk_indices.device,
+    )
+    compact_by_physical_slot = {}
+    selected_physical_slots = []
+
+    for position, logical_index in enumerate(flat_indices.tolist()):
+        if logical_index == -1:
+            continue
+        physical_slot = int(page_table_1_flattened[logical_index].item())
+        if physical_slot < 0:
+            raise ValueError(
+                "page_table_1_flattened contains a negative physical KV slot "
+                f"at logical index {logical_index}: {physical_slot}"
+            )
+        compact_index = compact_by_physical_slot.get(physical_slot)
+        if compact_index is None:
+            compact_index = len(selected_physical_slots)
+            compact_by_physical_slot[physical_slot] = compact_index
+            selected_physical_slots.append(physical_slot)
+        remapped_flat[position] = compact_index
+
+    physical_slots = torch.tensor(
+        selected_physical_slots,
+        dtype=page_table_1_flattened.dtype,
+        device=page_table_1_flattened.device,
+    )
+    return SelectiveKVRemap(
+        physical_slots=physical_slots,
+        remapped_topk=remapped_flat.reshape(flat_topk_indices.shape),
+        num_valid=int(valid.sum().item()),
+        num_unique=len(selected_physical_slots),
+    )
+
+
+def build_selective_kv_no_dedup(
+    page_table_1_flattened: torch.Tensor,
+    flat_topk_indices: torch.Tensor,
+    *,
+    physical_slots_out: torch.Tensor | None = None,
+    remapped_topk_out: torch.Tensor | None = None,
+) -> NoDedupSelectiveKVRemap:
+    """Build a fixed-shape selective mapping without deduplicating rows.
+
+    This is the first GPU performance probe, not the final production policy.
+    It performs no data-dependent compaction: every top-k occurrence owns one
+    output row, while ``-1`` entries retain their sentinel and gather physical
+    row zero as an ignored landing value.  Consequently tensor shapes and
+    addresses depend only on the input shapes and are suitable for measuring
+    capture behavior without a host synchronization.
+    """
+    if page_table_1_flattened.dtype not in (torch.int32, torch.int64):
+        raise TypeError(
+            "page_table_1_flattened must be an integer index tensor "
+            f"(int32 or int64), got {page_table_1_flattened.dtype}"
+        )
+    if flat_topk_indices.dtype not in (torch.int32, torch.int64):
+        raise TypeError(
+            "flat_topk_indices must be an integer index tensor "
+            f"(int32 or int64), got {flat_topk_indices.dtype}"
+        )
+    if page_table_1_flattened.device != flat_topk_indices.device:
+        raise ValueError(
+            "page_table_1_flattened and flat_topk_indices must be on the same device"
+        )
+    if page_table_1_flattened.ndim != 1:
+        raise ValueError(
+            "page_table_1_flattened must be one-dimensional, got "
+            f"shape={tuple(page_table_1_flattened.shape)}"
+        )
+    if (physical_slots_out is None) != (remapped_topk_out is None):
+        raise ValueError(
+            "physical_slots_out and remapped_topk_out must be provided together"
+        )
+
+    flat_indices = flat_topk_indices.reshape(-1)
+    valid = flat_indices >= 0
+    if page_table_1_flattened.numel() == 0:
+        # An empty prefix is not a production selective-dequant case.  Support
+        # the all-padding CPU oracle edge without manufacturing an invalid
+        # physical row; reject any real index explicitly.
+        if flat_indices.device.type != "cpu" or bool(valid.any().item()):
+            raise ValueError(
+                "non-padding top-k indices require a non-empty "
+                "page_table_1_flattened"
+            )
+        return NoDedupSelectiveKVRemap(
+            physical_slots=page_table_1_flattened.new_empty((0,)),
+            remapped_topk=torch.full_like(flat_topk_indices, -1, dtype=torch.int32),
+        )
+
+    if physical_slots_out is None:
+        safe_logical_indices = flat_indices.clamp_min(0)
+        physical_slots = page_table_1_flattened[safe_logical_indices.long()]
+        occurrence_rows = torch.arange(
+            flat_indices.numel(), device=flat_indices.device, dtype=torch.int32
+        )
+        remapped = torch.where(
+            valid,
+            occurrence_rows,
+            torch.full_like(occurrence_rows, -1),
+        )
+    else:
+        if page_table_1_flattened.dtype != torch.int32:
+            raise TypeError(
+                "preallocated no-dedup metadata requires an int32 page table"
+            )
+        if physical_slots_out.shape != flat_indices.shape:
+            raise ValueError(
+                "physical_slots_out shape must match flattened top-k: "
+                f"{tuple(physical_slots_out.shape)} != {tuple(flat_indices.shape)}"
+            )
+        if remapped_topk_out.shape != flat_topk_indices.shape:
+            raise ValueError(
+                "remapped_topk_out shape must match top-k: "
+                f"{tuple(remapped_topk_out.shape)} != "
+                f"{tuple(flat_topk_indices.shape)}"
+            )
+        for name, tensor in (
+            ("physical_slots_out", physical_slots_out),
+            ("remapped_topk_out", remapped_topk_out),
+        ):
+            if tensor.device != flat_topk_indices.device:
+                raise ValueError(f"{name} must be on the top-k device")
+            if tensor.dtype != torch.int32 or not tensor.is_contiguous():
+                raise ValueError(f"{name} must be contiguous int32")
+
+        physical_slots = physical_slots_out
+        remapped = remapped_topk_out.reshape(-1)
+        # Reuse the remap destination as the safe logical-index staging
+        # buffer, then overwrite it with compact occurrence rows.
+        torch.clamp(flat_indices, min=0, out=remapped)
+        torch.index_select(
+            page_table_1_flattened,
+            0,
+            remapped,
+            out=physical_slots,
+        )
+        torch.arange(
+            flat_indices.numel(),
+            device=flat_indices.device,
+            dtype=torch.int32,
+            out=remapped,
+        )
+        remapped.masked_fill_(~valid, -1)
+    return NoDedupSelectiveKVRemap(
+        physical_slots=physical_slots,
+        remapped_topk=remapped.reshape(flat_topk_indices.shape),
+    )
+
+
+def estimate_selective_kv_traffic(
+    *,
+    prefix_rows: int,
+    valid_topk_entries: int,
+    unique_rows: int,
+) -> SelectiveKVTrafficEstimate:
+    """Estimate compulsory byte traffic before kernel-specific profiling.
+
+    Metadata uses a transparent lower-order approximation per valid entry:
+    read the logical top-k index, read its physical page-table entry, and write
+    the compact index.  Each unique row also records one physical key and one
+    compact value.  H20 measurements will replace or calibrate this model; it
+    intentionally does not pretend to predict cache-line or atomic traffic.
+    """
+    for name, value in (
+        ("prefix_rows", prefix_rows),
+        ("valid_topk_entries", valid_topk_entries),
+        ("unique_rows", unique_rows),
+    ):
+        _validate_extent(name, value)
+    if unique_rows > valid_topk_entries:
+        raise ValueError(
+            "unique_rows cannot exceed valid_topk_entries: "
+            f"{unique_rows} > {valid_topk_entries}"
+        )
+    if unique_rows > prefix_rows:
+        raise ValueError(
+            f"unique_rows cannot exceed prefix_rows: {unique_rows} > {prefix_rows}"
+        )
+
+    row_traffic = KV_BYTES_PER_ROW + KV_DEQUANTIZED_BYTES_PER_ROW
+    metadata_bytes = valid_topk_entries * (3 * INDEX_BYTES) + unique_rows * (
+        2 * INDEX_BYTES
+    )
+    return SelectiveKVTrafficEstimate(
+        full_kv_bytes=prefix_rows * row_traffic,
+        selective_kv_bytes=unique_rows * row_traffic,
+        metadata_bytes=metadata_bytes,
+        full_workspace_bytes=prefix_rows * KV_DEQUANTIZED_BYTES_PER_ROW,
+        selective_workspace_bytes=unique_rows * KV_DEQUANTIZED_BYTES_PER_ROW,
+    )
+
+
+def should_use_selective_kv_dequant(
+    *,
+    prefix_rows: int,
+    query_tokens: int,
+    topk: int,
+    safety_factor: float = 1.25,
+) -> bool:
+    """Return a conservative host-side pre-dedup decision.
+
+    Without measuring overlap, ``query_tokens * topk`` is the maximum number
+    of valid occurrences and ``min(prefix_rows, occurrences)`` is the maximum
+    unique-row count.  The path is selected only if it still wins under that
+    pessimistic bound.  A later device-side policy may use an observed unique
+    ratio, but must retain this function as the fail-closed fallback.
+    """
+    if prefix_rows <= 0 or query_tokens <= 0 or topk <= 0:
+        return False
+    if safety_factor < 1.0:
+        raise ValueError(f"safety_factor must be >= 1.0, got {safety_factor}")
+
+    valid_upper_bound = query_tokens * topk
+    unique_upper_bound = min(prefix_rows, valid_upper_bound)
+    estimate = estimate_selective_kv_traffic(
+        prefix_rows=prefix_rows,
+        valid_topk_entries=valid_upper_bound,
+        unique_rows=unique_upper_bound,
+    )
+    return estimate.selective_total_bytes * safety_factor < estimate.full_kv_bytes
+
+
+def should_use_dense_epoch_kv_dequant(
+    *,
+    prefix_rows: int,
+    query_tokens: int,
+    topk: int,
+    num_pool_rows: int,
+    safety_factor: float = 1.25,
+) -> bool:
+    """Fail-closed byte gate including the persistent dense-table scan.
+
+    The local-scan and finalize phases each read the int64 epoch table once.
+    This upper-bound model also charges block scan/readback traffic and compact
+    mapping publication. It deliberately double-counts some per-occurrence
+    metadata already present in ``estimate_selective_kv_traffic``: the gate is
+    a conservative pre-profile safeguard, not a throughput predictor.
+    """
+    if not isinstance(num_pool_rows, int) or isinstance(num_pool_rows, bool):
+        raise ValueError(
+            f"num_pool_rows must be a positive integer, got {num_pool_rows!r}"
+        )
+    if num_pool_rows <= 0:
+        raise ValueError(
+            f"num_pool_rows must be a positive integer, got {num_pool_rows!r}"
+        )
+    if prefix_rows <= 0 or query_tokens <= 0 or topk <= 0:
+        return False
+    if prefix_rows < DENSE_EPOCH_MIN_PREFIX_ROWS:
+        return False
+    if safety_factor < 1.0:
+        raise ValueError(f"safety_factor must be >= 1.0, got {safety_factor}")
+
+    valid_upper_bound = query_tokens * topk
+    unique_upper_bound = min(prefix_rows, valid_upper_bound, num_pool_rows)
+    estimate = estimate_selective_kv_traffic(
+        prefix_rows=prefix_rows,
+        valid_topk_entries=valid_upper_bound,
+        unique_rows=unique_upper_bound,
+    )
+    num_scan_blocks = (
+        num_pool_rows + DENSE_DEDUP_BLOCK_SIZE - 1
+    ) // DENSE_DEDUP_BLOCK_SIZE
+    dense_scan_bytes = (
+        2 * num_pool_rows * 8 + num_scan_blocks * 12 + unique_upper_bound * 12
+    )
+    selective_bytes = estimate.selective_total_bytes + dense_scan_bytes
+    return selective_bytes * safety_factor < estimate.full_kv_bytes
+
+
+def maybe_build_selective_kv_no_dedup(
+    page_table_1_flattened: torch.Tensor,
+    flat_topk_indices: torch.Tensor,
+    *,
+    enabled: bool,
+    safety_factor: float = 1.25,
+) -> NoDedupSelectiveKVRemap | None:
+    """Plan the opt-in no-dedup probe without inspecting device data."""
+    if not enabled:
+        return None
+    if flat_topk_indices.ndim != 2:
+        raise ValueError(
+            "flat_topk_indices must have shape (query_tokens, topk), got "
+            f"{tuple(flat_topk_indices.shape)}"
+        )
+    query_tokens, topk = flat_topk_indices.shape
+    if not should_use_selective_kv_dequant(
+        prefix_rows=page_table_1_flattened.numel(),
+        query_tokens=query_tokens,
+        topk=topk,
+        safety_factor=safety_factor,
+    ):
+        return None
+    return build_selective_kv_no_dedup(
+        page_table_1_flattened,
+        flat_topk_indices,
+    )

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -51,6 +51,11 @@ from sglang.srt.layers.attention.dsa.dsa_topk_backend import (
     DSATopKBackend,
     TopkTransformMethod,
 )
+from sglang.srt.layers.attention.dsa.selective_kv_dequant import (
+    SelectiveKVWorkspace,
+    dequantize_dsa_prefix_kv_selective,
+    resolve_selective_kv_mode,
+)
 from sglang.srt.layers.attention.dsa.utils import (
     can_dsa_prefill_cp_round_robin_split,
     compute_dsa_seqlens,
@@ -321,6 +326,13 @@ class DeepseekSparseAttnBackend(
             model_runner.token_to_kv_pool.dsa_kv_cache_store_fp8
         )
         self.dsa_index_topk = get_dsa_index_topk(model_runner.model_config.hf_config)
+        self._selective_kv_mode = resolve_selective_kv_mode(
+            envs.SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_NO_DEDUP.get(),
+            envs.SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_DENSE_EPOCH.get(),
+        )
+        # The object itself owns no storage. Buffers are allocated lazily only
+        # when an experimental path passes its conservative shape gate.
+        self._selective_kv_workspace = SelectiveKVWorkspace(self.device)
         self.max_context_len = model_runner.model_config.context_len
         self.num_q_heads = (
             model_runner.model_config.num_attention_heads // get_parallel().attn_tp_size
@@ -2112,9 +2124,23 @@ class DeepseekSparseAttnBackend(
                         self.forward_metadata.page_table_1_flattened
                     )
                     assert page_table_1_flattened is not None
-                    kv_cache = dequantize_k_cache_paged(
-                        kv_cache, page_table_1_flattened
-                    )
+                    if self._selective_kv_mode == "off":
+                        # Preserve the established default path without
+                        # result-wrapper or workspace overhead.
+                        kv_cache = dequantize_k_cache_paged(
+                            kv_cache, page_table_1_flattened
+                        )
+                    else:
+                        selective_result = dequantize_dsa_prefix_kv_selective(
+                            kv_cache,
+                            page_table_1_flattened,
+                            page_table_1,
+                            num_pool_rows=kv_cache.numel() // kv_cache.shape[-1],
+                            mode=self._selective_kv_mode,
+                            workspace=self._selective_kv_workspace,
+                        )
+                        kv_cache = selective_result.kv_cache
+                        page_table_1 = selective_result.remapped_topk
                 else:
                     kv_cache = _cat([k, k_rope], dim=-1)
 

--- a/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
+++ b/python/sglang/test/kits/attention_unittest/attention_methods/dsa_attention.py
@@ -1069,7 +1069,7 @@ def run_dsa_sparse_attention_case(
     index_topk: int = DSA_SPARSE_INDEX_TOPK,
     index_pattern: str = "trailing",
     loc_layout: str = "shuffled_pages",
-) -> None:
+) -> DSASparseAttentionFixture:
     fixture = build_dsa_sparse_attention_fixture(
         testcase,
         case,
@@ -1089,6 +1089,7 @@ def run_dsa_sparse_attention_case(
     atol = DSA_SPARSE_FP8_ATOL if fp8_kv_cache else DSA_SPARSE_ATOL
     rtol = DSA_SPARSE_FP8_RTOL if fp8_kv_cache else DSA_SPARSE_RTOL
     torch.testing.assert_close(actual, expected, atol=atol, rtol=rtol)
+    return fixture
 
 
 # ---------------------------------------------------------------------------
@@ -1384,7 +1385,7 @@ def run_dsa_sparse_fp8_prefill_case(
     case: DSAAttentionCase,
     *,
     dsa_prefill_backend: str = "flashmla_auto",
-) -> None:
+) -> DSASparseAttentionFixture:
     """FP8-KV-cache prefill. With `flashmla_sparse` + EXTEND + non-empty
     prefix, `get_topk_transform_method` returns `RAGGED` (the only path
     that exercises `dequantize_k_cache_paged` + the
@@ -1400,7 +1401,7 @@ def run_dsa_sparse_fp8_prefill_case(
         )
     if not case.forward_mode.is_extend_without_speculative():
         raise ValueError("run_dsa_sparse_fp8_prefill_case expects an EXTEND case.")
-    run_dsa_sparse_attention_case(
+    return run_dsa_sparse_attention_case(
         testcase,
         case,
         dsa_prefill_backend=dsa_prefill_backend,

--- a/test/registered/attention/unittests/dsa/test_dsa.py
+++ b/test/registered/attention/unittests/dsa/test_dsa.py
@@ -1,7 +1,9 @@
 import unittest
+from unittest import mock
 
 import torch
 
+from sglang.srt.environ import envs
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.dsa_attention import (
@@ -302,6 +304,30 @@ class TestDSAAttentionBackendCorrectness(CustomTestCase):
                     else self.FP8_PREFILL_PAGED_CASE
                 )
                 run_dsa_sparse_fp8_prefill_case(self, case, dsa_prefill_backend=impl)
+
+    def test_sparse_fp8_prefill_dense_epoch_selective_kv(self):
+        # This is the full integration gate for #36338: FP8 DSA cache,
+        # RAGGED logical top-k, physical-slot dedup/remap, device-side active
+        # extent, BF16 FlashMLA sparse prefill, and the independent attention
+        # reference all run through the real backend.
+        # The standard correctness fixture intentionally uses a small prefix.
+        # Policy crossover is covered separately with H20-calibrated unit and
+        # benchmark cases; force only the policy decision here so this test
+        # exercises the real backend wiring without allocating a 40K fixture.
+        policy = (
+            "sglang.srt.layers.attention.dsa.selective_kv_dequant."
+            "should_use_dense_epoch_kv_dequant"
+        )
+        with envs.SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_DENSE_EPOCH.override(
+            True
+        ), mock.patch(policy, return_value=True):
+            fixture = run_dsa_sparse_fp8_prefill_case(
+                self,
+                self.FP8_PREFILL_RAGGED_CASE,
+                dsa_prefill_backend="flashmla_sparse",
+            )
+        self.assertEqual(fixture.backend._selective_kv_mode, "dense_epoch")
+        self.assertGreater(fixture.backend._selective_kv_workspace.bf16_capacity, 0)
 
     def test_sparse_fp8_decode_cases(self):
         for impl in DSA_DECODE_IMPL_VARIANTS:

--- a/test/registered/kernels/ops/attention/test_dsa_selective_kv_dedup.py
+++ b/test/registered/kernels/ops/attention/test_dsa_selective_kv_dedup.py
@@ -1,0 +1,277 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+_ROOT = Path(__file__).resolve().parents[5]
+_MODULE_PATH = _ROOT / "python/sglang/kernels/ops/attention/dsa/selective_kv_dequant.py"
+_RUNTIME_MODULE_PATH = (
+    _ROOT / "python/sglang/srt/layers/attention/dsa/selective_kv_dequant.py"
+)
+
+
+def _load_kernel_module():
+    assert _MODULE_PATH.exists(), "dense epoch dedup kernel module is not implemented"
+    spec = importlib.util.spec_from_file_location(
+        "dsa_selective_kv_dequant_kernel", _MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert hasattr(module, "deduplicate_kv_slots_dense_epoch")
+    return module
+
+
+def _load_runtime_module():
+    spec = importlib.util.spec_from_file_location(
+        "dsa_selective_kv_dequant_runtime", _RUNTIME_MODULE_PATH
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert hasattr(module, "prepare_dense_epoch_selection")
+    return module
+
+
+def _cuda_available():
+    return torch.cuda.is_available()
+
+
+def _run_case(page_table_values, topk_values, pool_rows=None, state=None):
+    module = _load_kernel_module()
+    device = torch.device("cuda")
+    page_table = torch.tensor(page_table_values, dtype=torch.int32, device=device)
+    topk = torch.tensor(topk_values, dtype=torch.int32, device=device)
+    if pool_rows is None:
+        pool_rows = max(page_table_values) + 1
+    selection_capacity = min(page_table.numel(), topk.numel())
+
+    if state is None:
+        state = {
+            "slot_epoch": torch.full(
+                (pool_rows,), -1, dtype=torch.int64, device=device
+            ),
+            "slot_to_compact": torch.empty(pool_rows, dtype=torch.int32, device=device),
+            "selected": torch.empty(
+                selection_capacity, dtype=torch.int32, device=device
+            ),
+            "remapped": torch.empty_like(topk),
+            "block_offsets": torch.empty(
+                (pool_rows + 255) // 256,
+                dtype=torch.int32,
+                device=device,
+            ),
+            "epoch": torch.zeros(1, dtype=torch.int64, device=device),
+            "num_unique": torch.zeros(1, dtype=torch.int32, device=device),
+        }
+
+    selected, remapped, num_unique = module.deduplicate_kv_slots_dense_epoch(
+        page_table,
+        topk,
+        slot_epoch=state["slot_epoch"],
+        slot_to_compact=state["slot_to_compact"],
+        selected_physical_slots=state["selected"],
+        remapped_topk=state["remapped"],
+        block_offsets=state["block_offsets"],
+        epoch=state["epoch"],
+        num_unique=state["num_unique"],
+        num_pool_rows=pool_rows,
+        selection_capacity=selection_capacity,
+    )
+    torch.cuda.synchronize()
+    return state, selected, remapped, num_unique
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA is required")
+def test_dense_epoch_dedup_reconstructs_physical_slots_and_padding():
+    _, selected, remapped, num_unique = _run_case(
+        [7, 3, 7, 9, 5],
+        [[0, 1, -1], [2, 3, 1]],
+        pool_rows=16,
+    )
+
+    unique_count = int(num_unique.item())
+    assert unique_count == 3
+    torch.testing.assert_close(
+        selected[:unique_count].cpu(),
+        torch.tensor([3, 7, 9], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        remapped.cpu()[0, 2], torch.tensor(-1, dtype=torch.int32)
+    )
+    valid = remapped >= 0
+    reconstructed = selected[:unique_count][remapped[valid].long()]
+    expected = torch.tensor([7, 3, 7, 9, 3], dtype=torch.int32, device="cuda")
+    torch.testing.assert_close(reconstructed, expected)
+    assert torch.unique(selected[:unique_count]).numel() == unique_count
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA is required")
+def test_dense_epoch_dedup_reuses_state_without_stale_slot_leakage():
+    state, _, _, first_count = _run_case([2, 4, 6, 8], [[0, 1, 2, 3]], pool_rows=16)
+    first_epoch = int(state["epoch"].item())
+    assert int(first_count.item()) == 4
+
+    # Reuse every persistent tensor but select only slots 4 and 8.  Epoch tags
+    # from physical slots 2 and 6 must not enter the new compact set.
+    state["selected"] = torch.empty(3, dtype=torch.int32, device="cuda")
+    state["remapped"] = torch.empty((1, 3), dtype=torch.int32, device="cuda")
+    state, selected, remapped, second_count = _run_case(
+        [2, 4, 6, 8], [[1, 3, 1]], pool_rows=16, state=state
+    )
+
+    assert int(state["epoch"].item()) == first_epoch + 1
+    assert int(second_count.item()) == 2
+    assert set(selected[:2].cpu().tolist()) == {4, 8}
+    reconstructed = selected[:2][remapped.reshape(-1).long()]
+    torch.testing.assert_close(
+        reconstructed,
+        torch.tensor([4, 8, 4], dtype=torch.int32, device="cuda"),
+    )
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA is required")
+def test_dense_epoch_dedup_prefix_scan_crosses_256_slot_boundaries():
+    physical = [0, 255, 256, 257, 511, 512, 599]
+    _, selected, remapped, num_unique = _run_case(
+        physical,
+        [[6, 1, 2, 4, 0, 5, 3, 2, 6]],
+        pool_rows=600,
+    )
+
+    count = int(num_unique.item())
+    assert count == len(physical)
+    torch.testing.assert_close(
+        selected[:count].cpu(), torch.tensor(physical, dtype=torch.int32)
+    )
+    reconstructed = selected[:count][remapped.reshape(-1).long()]
+    torch.testing.assert_close(
+        reconstructed,
+        torch.tensor(
+            [599, 255, 256, 511, 0, 512, 257, 256, 599],
+            dtype=torch.int32,
+            device="cuda",
+        ),
+    )
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA is required")
+def test_dense_epoch_dedup_cuda_graph_replays_with_new_indices():
+    module = _load_kernel_module()
+    device = torch.device("cuda")
+    page_table = torch.tensor([1, 3, 5, 7], dtype=torch.int32, device=device)
+    topk = torch.tensor([[0, 1, 0, 1]], dtype=torch.int32, device=device)
+    slot_epoch = torch.full((8,), -1, dtype=torch.int64, device=device)
+    slot_to_compact = torch.empty(8, dtype=torch.int32, device=device)
+    selected = torch.empty(4, dtype=torch.int32, device=device)
+    remapped = torch.empty_like(topk)
+    block_offsets = torch.empty(1, dtype=torch.int32, device=device)
+    epoch = torch.zeros(1, dtype=torch.int64, device=device)
+    num_unique = torch.zeros(1, dtype=torch.int32, device=device)
+
+    def launch():
+        return module.deduplicate_kv_slots_dense_epoch(
+            page_table,
+            topk,
+            slot_epoch=slot_epoch,
+            slot_to_compact=slot_to_compact,
+            selected_physical_slots=selected,
+            remapped_topk=remapped,
+            block_offsets=block_offsets,
+            epoch=epoch,
+            num_unique=num_unique,
+            num_pool_rows=8,
+            selection_capacity=4,
+        )
+
+    launch()  # JIT before capture.
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+
+    topk.copy_(torch.tensor([[2, 3, 2, 3]], dtype=torch.int32, device=device))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    count = int(num_unique.item())
+    assert count == 2
+    reconstructed = selected[:count][remapped.reshape(-1).long()]
+    torch.testing.assert_close(
+        reconstructed,
+        torch.tensor([5, 7, 5, 7], dtype=torch.int32, device=device),
+    )
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA is required")
+def test_no_dedup_preallocated_metadata_cuda_graph_replay():
+    runtime = _load_runtime_module()
+    device = torch.device("cuda")
+    page_table = torch.tensor([11, 13, 17, 19], dtype=torch.int32, device=device)
+    topk = torch.tensor([[0, -1, 2, 0]], dtype=torch.int32, device=device)
+    workspace = runtime.SelectiveKVWorkspace(device)
+    physical, remapped = workspace.get_occurrence_metadata(topk.numel())
+    remapped = remapped.view_as(topk)
+
+    def launch():
+        return runtime.build_selective_kv_no_dedup(
+            page_table,
+            topk,
+            physical_slots_out=physical,
+            remapped_topk_out=remapped,
+        )
+
+    launch()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        launch()
+
+    topk.copy_(torch.tensor([[3, 1, -1, 2]], dtype=torch.int32, device=device))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    torch.testing.assert_close(
+        physical,
+        torch.tensor([19, 13, 11, 17], dtype=torch.int32, device=device),
+    )
+    torch.testing.assert_close(
+        remapped,
+        torch.tensor([[0, 1, -1, 3]], dtype=torch.int32, device=device),
+    )
+
+
+@pytest.mark.skipif(not _cuda_available(), reason="CUDA is required")
+def test_runtime_selection_plan_uses_workspace_capacity_without_host_compaction():
+    runtime = _load_runtime_module()
+    workspace = runtime.SelectiveKVWorkspace(torch.device("cuda"))
+    page_table = torch.tensor([7, 3, 7, 9, 5], dtype=torch.int32, device="cuda")
+    topk = torch.tensor([[0, 1, -1], [2, 3, 1]], dtype=torch.int32, device="cuda")
+
+    plan = runtime.prepare_dense_epoch_selection(
+        page_table,
+        topk,
+        num_pool_rows=16,
+        workspace=workspace,
+        deduplicate_fn=_load_kernel_module().deduplicate_kv_slots_dense_epoch,
+    )
+    torch.cuda.synchronize()
+
+    assert plan.capacity == 5
+    assert plan.selected_physical_slots.shape == (5,)
+    assert plan.remapped_topk.shape == topk.shape
+    assert plan.num_unique.shape == (1,)
+    count = int(plan.num_unique.item())
+    assert count == 3
+    reconstructed = plan.selected_physical_slots[:count][
+        plan.remapped_topk[plan.remapped_topk >= 0].long()
+    ]
+    torch.testing.assert_close(
+        reconstructed,
+        torch.tensor([7, 3, 7, 9, 3], dtype=torch.int32, device="cuda"),
+    )

--- a/test/registered/kernels/ops/attention/test_dsa_selective_kv_dequant_fp8.py
+++ b/test/registered/kernels/ops/attention/test_dsa_selective_kv_dequant_fp8.py
@@ -1,0 +1,178 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+_ROOT = Path(__file__).resolve().parents[5]
+_DEQUANT_PATH = _ROOT / "python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py"
+_DEDUP_PATH = _ROOT / "python/sglang/kernels/ops/attention/dsa/selective_kv_dequant.py"
+_RUNTIME_PATH = _ROOT / "python/sglang/srt/layers/attention/dsa/selective_kv_dequant.py"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _sm89_or_newer_available() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability() >= (8, 9)
+
+
+pytestmark = pytest.mark.skipif(
+    not _sm89_or_newer_available(),
+    reason="the DSA FP8 Triton kernel requires compute capability 8.9 or newer",
+)
+
+
+def _build_quantized_kv_pool(pool_rows: int) -> torch.Tensor:
+    generator = torch.Generator(device="cuda")
+    generator.manual_seed(20260826)
+    nope = (torch.randn(pool_rows, 512, generator=generator, device="cuda") * 0.25).to(
+        torch.float8_e4m3fn
+    )
+    scales = (
+        torch.rand(pool_rows, 4, generator=generator, device="cuda") * 0.05 + 1e-3
+    ).to(torch.float32)
+    rope = torch.randn(pool_rows, 64, generator=generator, device="cuda").to(
+        torch.bfloat16
+    )
+
+    # Reproduce the exact 656-byte DSA cache row:
+    # [512 fp8 nope | 4 fp32 scales | 64 bf16 rope].
+    raw = torch.empty(pool_rows, 656, dtype=torch.uint8, device="cuda")
+    raw[:, :512] = nope.view(torch.uint8)
+    raw[:, 512:528] = scales.view(torch.uint8)
+    raw[:, 528:] = rope.view(torch.uint8)
+    return raw.view(torch.float8_e4m3fn).view(pool_rows, 1, 656)
+
+
+def _load_implementations():
+    dequant = _load_module("dsa_dequant_fp8_test", _DEQUANT_PATH)
+    dedup = _load_module("dsa_selective_dedup_fp8_test", _DEDUP_PATH)
+    runtime = _load_module("dsa_selective_runtime_fp8_test", _RUNTIME_PATH)
+    return dequant, dedup, runtime
+
+
+def _expected_topk_rows(full_kv: torch.Tensor, topk: torch.Tensor) -> torch.Tensor:
+    valid = topk >= 0
+    return full_kv.view(full_kv.shape[0], -1)[topk[valid].long()]
+
+
+def test_device_extent_dequant_grid_is_bounded_by_sm_count():
+    dequant, _, _ = _load_implementations()
+
+    # The CUDA Graph-safe path cannot size its launch from the device scalar
+    # ``num_valid_rows``.  It should nevertheless cap the resident work grid
+    # instead of launching one masked program for every capacity row.
+    assert dequant._device_extent_grid_rows(32_768, sm_count=78) == 1_248
+    assert dequant._device_extent_grid_rows(512, sm_count=78) == 512
+
+
+def test_dense_selective_fp8_dequant_matches_full_prefix_with_physical_aliases():
+    dequant, dedup, runtime = _load_implementations()
+    pool = _build_quantized_kv_pool(32)
+    # Logical prefix rows 0 and 2 intentionally alias physical KV slot 7.
+    page_table = torch.tensor(
+        [7, 3, 7, 9, 5, 11, 13, 15], dtype=torch.int32, device="cuda"
+    )
+    topk = torch.tensor([[0, 1, -1, 2], [3, 0, 4, 1]], dtype=torch.int32, device="cuda")
+    workspace = runtime.SelectiveKVWorkspace(torch.device("cuda"))
+
+    full = dequant.dequantize_k_cache_paged(pool, page_table)
+    selection = runtime.prepare_dense_epoch_selection(
+        page_table,
+        topk,
+        num_pool_rows=pool.shape[0],
+        workspace=workspace,
+        deduplicate_fn=dedup.deduplicate_kv_slots_dense_epoch,
+    )
+    selected = dequant.dequantize_k_cache_paged(
+        pool,
+        selection.selected_physical_slots,
+        out=workspace.get_bf16(selection.capacity),
+        num_valid_rows=selection.num_unique,
+    )
+    torch.cuda.synchronize()
+
+    valid = selection.remapped_topk >= 0
+    actual = selected.view(selection.capacity, -1)[
+        selection.remapped_topk[valid].long()
+    ]
+    torch.testing.assert_close(
+        actual,
+        _expected_topk_rows(full, topk),
+        rtol=0,
+        atol=0,
+    )
+    assert int(selection.num_unique.item()) == 4
+    torch.testing.assert_close(
+        selection.selected_physical_slots[:4].cpu(),
+        torch.tensor([3, 5, 7, 9], dtype=torch.int32),
+    )
+
+
+def test_dense_selective_fp8_dequant_combined_cuda_graph_replay():
+    dequant, dedup, runtime = _load_implementations()
+    pool = _build_quantized_kv_pool(32)
+    page_table = torch.tensor(
+        [2, 4, 6, 8, 10, 12, 14, 16], dtype=torch.int32, device="cuda"
+    )
+    topk = torch.tensor([[0, 1, 0, 1]], dtype=torch.int32, device="cuda")
+    workspace = runtime.SelectiveKVWorkspace(torch.device("cuda"))
+
+    # Allocate and JIT every persistent buffer before capture.
+    initial = runtime.prepare_dense_epoch_selection(
+        page_table,
+        topk,
+        num_pool_rows=pool.shape[0],
+        workspace=workspace,
+        deduplicate_fn=dedup.deduplicate_kv_slots_dense_epoch,
+    )
+    out = workspace.get_bf16(initial.capacity)
+
+    def launch():
+        selection = runtime.prepare_dense_epoch_selection(
+            page_table,
+            topk,
+            num_pool_rows=pool.shape[0],
+            workspace=workspace,
+            deduplicate_fn=dedup.deduplicate_kv_slots_dense_epoch,
+        )
+        result = dequant.dequantize_k_cache_paged(
+            pool,
+            selection.selected_physical_slots,
+            out=out,
+            num_valid_rows=selection.num_unique,
+        )
+        return selection, result
+
+    launch()
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured_selection, captured_out = launch()
+
+    topk.copy_(torch.tensor([[2, 3, 4, 2]], dtype=torch.int32, device="cuda"))
+    graph.replay()
+    torch.cuda.synchronize()
+
+    full = dequant.dequantize_k_cache_paged(pool, page_table)
+    valid = captured_selection.remapped_topk >= 0
+    actual = captured_out.view(captured_selection.capacity, -1)[
+        captured_selection.remapped_topk[valid].long()
+    ]
+    torch.testing.assert_close(
+        actual,
+        _expected_topk_rows(full, topk),
+        rtol=0,
+        atol=0,
+    )
+    assert int(captured_selection.num_unique.item()) == 3

--- a/test/registered/unit/layers/attention/test_dsa_dequant_output_buffer.py
+++ b/test/registered/unit/layers/attention/test_dsa_dequant_output_buffer.py
@@ -1,0 +1,143 @@
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_ROOT = Path(__file__).resolve().parents[5]
+_MODULE_PATH = _ROOT / "python/sglang/kernels/ops/attention/dsa/dequant_k_cache.py"
+
+
+class _KernelStub:
+    def __init__(self, function):
+        self.function = function
+        self.calls = []
+
+    def __getitem__(self, _grid):
+        # Wrapper tests exercise allocation/validation/address contracts.  The
+        # actual Triton math is covered by the SM90 kernel test and H20 gate.
+        def launch(*args, **kwargs):
+            self.calls.append((args, kwargs))
+
+        return launch
+
+
+def _load_dequant_wrapper_without_triton_runtime():
+    triton = types.ModuleType("triton")
+    triton.jit = lambda function: _KernelStub(function)
+    triton.cdiv = (
+        lambda numerator, denominator: (numerator + denominator - 1) // denominator
+    )
+    language = types.ModuleType("triton.language")
+    language.constexpr = object()
+    triton.language = language
+
+    previous_triton = sys.modules.get("triton")
+    previous_language = sys.modules.get("triton.language")
+    sys.modules["triton"] = triton
+    sys.modules["triton.language"] = language
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "dsa_dequant_wrapper", _MODULE_PATH
+        )
+        assert spec is not None and spec.loader is not None
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        if previous_triton is None:
+            sys.modules.pop("triton", None)
+        else:
+            sys.modules["triton"] = previous_triton
+        if previous_language is None:
+            sys.modules.pop("triton.language", None)
+        else:
+            sys.modules["triton.language"] = previous_language
+
+
+_MODULE = _load_dequant_wrapper_without_triton_runtime()
+
+
+def _inputs(num_pool_rows=4, num_selected_rows=2):
+    pool = torch.empty(
+        (num_pool_rows, 1, 656),
+        dtype=torch.float8_e4m3fn,
+    )
+    page_table = torch.arange(num_selected_rows, dtype=torch.int32)
+    return pool, page_table
+
+
+def test_paged_dequant_returns_the_exact_preallocated_output_buffer():
+    pool, page_table = _inputs()
+    out = torch.empty((2, 1, 576), dtype=torch.bfloat16)
+
+    result = _MODULE.dequantize_k_cache_paged(pool, page_table, out=out)
+
+    assert result is out
+    assert result.data_ptr() == out.data_ptr()
+
+
+@pytest.mark.parametrize(
+    ("out", "match"),
+    [
+        (torch.empty((3, 1, 576), dtype=torch.bfloat16), "shape"),
+        (torch.empty((2, 1, 576), dtype=torch.float16), "dtype"),
+        (torch.empty((2, 1, 1152), dtype=torch.bfloat16)[:, :, ::2], "contiguous"),
+    ],
+)
+def test_paged_dequant_rejects_incompatible_output_buffers(out, match):
+    pool, page_table = _inputs()
+
+    with pytest.raises(ValueError, match=match):
+        _MODULE.dequantize_k_cache_paged(pool, page_table, out=out)
+
+
+def test_paged_dequant_allocates_when_output_buffer_is_omitted():
+    pool, page_table = _inputs()
+
+    result = _MODULE.dequantize_k_cache_paged(pool, page_table)
+
+    assert result.shape == (2, 1, 576)
+    assert result.dtype == torch.bfloat16
+    assert result.is_contiguous()
+
+
+def test_paged_dequant_accepts_device_valid_row_count_without_host_slicing():
+    pool, page_table = _inputs(num_selected_rows=4)
+    out = torch.empty((4, 1, 576), dtype=torch.bfloat16)
+    num_valid_rows = torch.tensor([2], dtype=torch.int32)
+
+    result = _MODULE.dequantize_k_cache_paged(
+        pool,
+        page_table,
+        out=out,
+        num_valid_rows=num_valid_rows,
+    )
+
+    assert result is out
+    _, launch_kwargs = _MODULE._dequantize_k_cache_paged_device_extent_kernel.calls[-1]
+    assert launch_kwargs["GRID_ROWS"] == page_table.numel()
+
+
+@pytest.mark.parametrize(
+    ("num_valid_rows", "match"),
+    [
+        (torch.tensor([1], dtype=torch.int64), "dtype"),
+        (torch.tensor([1, 2], dtype=torch.int32), "one element"),
+    ],
+)
+def test_paged_dequant_rejects_invalid_device_valid_row_count(num_valid_rows, match):
+    pool, page_table = _inputs()
+
+    with pytest.raises(ValueError, match=match):
+        _MODULE.dequantize_k_cache_paged(
+            pool,
+            page_table,
+            num_valid_rows=num_valid_rows,
+        )

--- a/test/registered/unit/layers/attention/test_dsa_selective_kv_benchmark_utils.py
+++ b/test/registered/unit/layers/attention/test_dsa_selective_kv_benchmark_utils.py
@@ -1,0 +1,153 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_ROOT = Path(__file__).resolve().parents[5]
+_MODULE_PATH = _ROOT / "benchmark/kernels/attention/dsa_selective_kv_benchmark_utils.py"
+_SPEC = importlib.util.spec_from_file_location(
+    "dsa_selective_kv_benchmark_utils", _MODULE_PATH
+)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+BENCHMARK_RESULT_COLUMNS = _MODULE.BENCHMARK_RESULT_COLUMNS
+SyntheticDSACase = _MODULE.SyntheticDSACase
+build_benchmark_record = _MODULE.build_benchmark_record
+make_synthetic_dsa_indices = _MODULE.make_synthetic_dsa_indices
+
+
+def test_synthetic_case_is_deterministic_and_has_requested_shape():
+    case = SyntheticDSACase(
+        prefix_rows=4096,
+        query_tokens=8,
+        topk=128,
+        unique_ratio=0.25,
+        seed=17,
+    )
+
+    first = make_synthetic_dsa_indices(case)
+    second = make_synthetic_dsa_indices(case)
+
+    assert first.flat_topk_indices.shape == (8, 128)
+    assert first.page_table_1_flattened.shape == (4096,)
+    assert first.flat_topk_indices.dtype == torch.int32
+    assert first.page_table_1_flattened.dtype == torch.int32
+    torch.testing.assert_close(first.flat_topk_indices, second.flat_topk_indices)
+    torch.testing.assert_close(
+        first.page_table_1_flattened, second.page_table_1_flattened
+    )
+
+
+@pytest.mark.parametrize("unique_ratio", [0.125, 0.5, 1.0])
+def test_synthetic_case_controls_logical_unique_ratio(unique_ratio):
+    case = SyntheticDSACase(
+        prefix_rows=8192,
+        query_tokens=8,
+        topk=128,
+        unique_ratio=unique_ratio,
+        seed=23,
+    )
+
+    inputs = make_synthetic_dsa_indices(case)
+
+    valid_entries = case.query_tokens * case.topk
+    expected_unique = round(valid_entries * unique_ratio)
+    assert torch.unique(inputs.flat_topk_indices).numel() == expected_unique
+    assert inputs.logical_unique_rows == expected_unique
+
+
+def test_synthetic_case_can_model_cross_request_physical_aliasing():
+    case = SyntheticDSACase(
+        prefix_rows=1024,
+        query_tokens=4,
+        topk=128,
+        unique_ratio=1.0,
+        physical_unique_ratio=0.5,
+        seed=29,
+    )
+
+    inputs = make_synthetic_dsa_indices(case)
+    logical = torch.unique(inputs.flat_topk_indices)
+    physical = torch.unique(inputs.page_table_1_flattened[logical.long()])
+
+    assert logical.numel() == 512
+    assert physical.numel() == 256
+    assert inputs.physical_unique_rows == 256
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("prefix_rows", 0),
+        ("query_tokens", 0),
+        ("topk", 0),
+        ("unique_ratio", 0.0),
+        ("unique_ratio", 1.1),
+        ("physical_unique_ratio", 0.0),
+        ("physical_unique_ratio", 1.1),
+    ],
+)
+def test_synthetic_case_rejects_invalid_geometry(field, value):
+    kwargs = dict(
+        prefix_rows=1024,
+        query_tokens=4,
+        topk=128,
+        unique_ratio=0.5,
+        physical_unique_ratio=1.0,
+    )
+    kwargs[field] = value
+    with pytest.raises(ValueError, match=field):
+        SyntheticDSACase(**kwargs)
+
+
+def test_benchmark_record_has_stable_json_csv_schema():
+    case = SyntheticDSACase(
+        prefix_rows=4096,
+        query_tokens=8,
+        topk=128,
+        unique_ratio=0.25,
+        seed=31,
+    )
+    inputs = make_synthetic_dsa_indices(case)
+    timings = {
+        "full_dequant_us": 100.0,
+        "full_dequant_cached_us": 90.0,
+        "selective_no_dedup_us": 80.0,
+        "oracle_dedup_remap_us": 10.0,
+        "dense_dedup_remap_us": 8.0,
+        "oracle_selected_dequant_us": 20.0,
+        "dense_selected_dequant_us": 22.0,
+        "oracle_selective_total_us": 30.0,
+        "dense_selective_total_us": 32.0,
+    }
+
+    record = build_benchmark_record(
+        case=case,
+        inputs=inputs,
+        timings_us=timings,
+        device_name="NVIDIA H20",
+        git_sha="deadbeef",
+        pool_rows=8192,
+    )
+
+    assert tuple(record) == BENCHMARK_RESULT_COLUMNS
+    assert record["dense_speedup_vs_current"] == pytest.approx(100.0 / 32.0)
+    assert record["dense_speedup_vs_cached_full"] == pytest.approx(90.0 / 32.0)
+    assert record["logical_unique_ratio"] == pytest.approx(0.25)
+    assert record["pool_rows"] == 8192
+    assert record["selection_capacity_rows"] == 1024
+    assert record["full_kv_traffic_bytes"] == 4096 * (656 + 576 * 2)
+    assert record["active_selective_kv_traffic_bytes"] == 256 * (656 + 576 * 2)
+    assert record["full_bf16_workspace_bytes"] == 4096 * 576 * 2
+    assert record["fixed_selective_bf16_workspace_bytes"] == 1024 * 576 * 2
+    assert record["dense_metadata_workspace_bytes"] > 8192 * (8 + 4)
+    assert record["estimated_dense_metadata_traffic_bytes"] > 8192 * 2 * 8
+    assert record["device_name"] == "NVIDIA H20"
+    assert record["git_sha"] == "deadbeef"

--- a/test/registered/unit/layers/attention/test_dsa_selective_kv_dequant.py
+++ b/test/registered/unit/layers/attention/test_dsa_selective_kv_dequant.py
@@ -1,0 +1,594 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+# Keep this CPU contract test independent of SGLang's package-level CUDA/Triton
+# imports.  That lets contributors validate the index semantics before renting
+# a GPU machine or installing the complete runtime environment.
+_ROOT = Path(__file__).resolve().parents[5]
+_MODULE_PATH = _ROOT / "python/sglang/srt/layers/attention/dsa/selective_kv_dequant.py"
+_SPEC = importlib.util.spec_from_file_location("selective_kv_dequant", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+_ENV_PATH = _ROOT / "python/sglang/srt/environ.py"
+_ENV_SPEC = importlib.util.spec_from_file_location("sglang_environ", _ENV_PATH)
+assert _ENV_SPEC is not None and _ENV_SPEC.loader is not None
+_ENV_MODULE = importlib.util.module_from_spec(_ENV_SPEC)
+_ENV_SPEC.loader.exec_module(_ENV_MODULE)
+
+KV_BYTES_PER_ROW = _MODULE.KV_BYTES_PER_ROW
+KV_DEQUANTIZED_BYTES_PER_ROW = _MODULE.KV_DEQUANTIZED_BYTES_PER_ROW
+build_selective_kv_remap_reference = _MODULE.build_selective_kv_remap_reference
+estimate_selective_kv_traffic = _MODULE.estimate_selective_kv_traffic
+should_use_selective_kv_dequant = _MODULE.should_use_selective_kv_dequant
+
+
+def should_use_dense_epoch_kv_dequant(*args, **kwargs):
+    implementation = getattr(_MODULE, "should_use_dense_epoch_kv_dequant", None)
+    assert (
+        implementation is not None
+    ), "should_use_dense_epoch_kv_dequant is not implemented"
+    return implementation(*args, **kwargs)
+
+
+def build_selective_kv_no_dedup(*args, **kwargs):
+    implementation = getattr(_MODULE, "build_selective_kv_no_dedup", None)
+    assert implementation is not None, "build_selective_kv_no_dedup is not implemented"
+    return implementation(*args, **kwargs)
+
+
+def maybe_build_selective_kv_no_dedup(*args, **kwargs):
+    implementation = getattr(_MODULE, "maybe_build_selective_kv_no_dedup", None)
+    assert (
+        implementation is not None
+    ), "maybe_build_selective_kv_no_dedup is not implemented"
+    return implementation(*args, **kwargs)
+
+
+def dequantize_dsa_prefix_kv_selective(*args, **kwargs):
+    implementation = getattr(_MODULE, "dequantize_dsa_prefix_kv_selective", None)
+    assert (
+        implementation is not None
+    ), "dequantize_dsa_prefix_kv_selective is not implemented"
+    return implementation(*args, **kwargs)
+
+
+def resolve_selective_kv_mode(*args, **kwargs):
+    implementation = getattr(_MODULE, "resolve_selective_kv_mode", None)
+    assert implementation is not None, "resolve_selective_kv_mode is not implemented"
+    return implementation(*args, **kwargs)
+
+
+def _i32(values):
+    return torch.tensor(values, dtype=torch.int32)
+
+
+def test_reference_remap_preserves_first_physical_occurrence_order():
+    page_table = _i32([40, 41, 42, 43])
+    topk = _i32([[2, 0], [3, 1]])
+
+    result = build_selective_kv_remap_reference(page_table, topk)
+
+    torch.testing.assert_close(result.physical_slots, _i32([42, 40, 43, 41]))
+    torch.testing.assert_close(result.remapped_topk, _i32([[0, 1], [2, 3]]))
+    assert result.num_unique == 4
+
+
+def test_reference_remap_deduplicates_within_and_across_queries():
+    page_table = _i32([10, 11, 12, 13])
+    topk = _i32([[1, 1, 3], [3, 1, 3]])
+
+    result = build_selective_kv_remap_reference(page_table, topk)
+
+    torch.testing.assert_close(result.physical_slots, _i32([11, 13]))
+    torch.testing.assert_close(result.remapped_topk, _i32([[0, 0, 1], [1, 0, 1]]))
+    assert result.num_valid == 6
+    assert result.num_unique == 2
+
+
+def test_reference_remap_deduplicates_physical_aliases_across_requests():
+    # Flat logical rows 0 and 3 belong to different requests, but radix-prefix
+    # sharing makes them refer to the same physical KV-cache slot.
+    page_table = _i32([70, 71, 80, 70, 81])
+    topk = _i32([[0, 1], [3, 4]])
+
+    result = build_selective_kv_remap_reference(page_table, topk)
+
+    torch.testing.assert_close(result.physical_slots, _i32([70, 71, 81]))
+    torch.testing.assert_close(result.remapped_topk, _i32([[0, 1], [0, 2]]))
+
+
+def test_no_dedup_remap_keeps_one_physical_row_per_valid_occurrence():
+    page_table = _i32([70, 71, 80, 70, 81])
+    topk = _i32([[0, 1], [3, 4]])
+
+    result = build_selective_kv_no_dedup(page_table, topk)
+
+    # Physical slot 70 is deliberately repeated.  This prototype measures the
+    # selective upper bound without paying any dedup metadata cost.
+    torch.testing.assert_close(result.physical_slots, _i32([70, 71, 70, 81]))
+    torch.testing.assert_close(result.remapped_topk, _i32([[0, 1], [2, 3]]))
+
+
+def test_no_dedup_remap_preserves_padding_without_compacting_shape():
+    page_table = _i32([20, 21, 22])
+    topk = _i32([[2, -1], [0, -1]])
+
+    result = build_selective_kv_no_dedup(page_table, topk)
+
+    # Padding occurrences use physical row 0 as a safe, ignored landing row;
+    # FlashMLA still receives -1 for those positions.
+    torch.testing.assert_close(result.physical_slots, _i32([22, 20, 20, 20]))
+    torch.testing.assert_close(result.remapped_topk, _i32([[0, -1], [2, -1]]))
+
+
+def test_no_dedup_remap_handles_all_padding_without_a_page_table():
+    result = build_selective_kv_no_dedup(_i32([]), _i32([[-1, -1]]))
+
+    assert result.physical_slots.shape == (0,)
+    torch.testing.assert_close(result.remapped_topk, _i32([[-1, -1]]))
+
+
+def test_no_dedup_probe_planner_requires_gate_and_conservative_profitability():
+    page_table = torch.arange(4096, dtype=torch.int32)
+    profitable_topk = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+
+    assert (
+        maybe_build_selective_kv_no_dedup(page_table, profitable_topk, enabled=False)
+        is None
+    )
+    selected = maybe_build_selective_kv_no_dedup(
+        page_table, profitable_topk, enabled=True
+    )
+    assert selected is not None
+    torch.testing.assert_close(selected.physical_slots, profitable_topk.reshape(-1))
+
+    # Q*K reaches the full prefix, so the probe must retain the current path
+    # instead of betting on overlap it does not deduplicate yet.
+    unprofitable_topk = torch.arange(4096, dtype=torch.int32).reshape(32, 128)
+    assert (
+        maybe_build_selective_kv_no_dedup(page_table, unprofitable_topk, enabled=True)
+        is None
+    )
+
+
+def test_selective_workspace_reuses_addresses_and_grows_by_capacity_bucket():
+    workspace_type = getattr(_MODULE, "SelectiveKVWorkspace", None)
+    assert workspace_type is not None, "SelectiveKVWorkspace is not implemented"
+    workspace = workspace_type(torch.device("cpu"))
+
+    first = workspace.get_bf16(7)
+    first_ptr = first.data_ptr()
+    smaller = workspace.get_bf16(3)
+
+    assert first.shape == (7, 1, 576)
+    assert first.dtype == torch.bfloat16
+    assert smaller.shape == (3, 1, 576)
+    assert smaller.data_ptr() == first_ptr
+    assert workspace.bf16_capacity == 8
+
+    grown = workspace.get_bf16(9)
+    assert grown.shape == (9, 1, 576)
+    assert workspace.bf16_capacity == 16
+
+
+def test_selective_workspace_reuses_fixed_shape_occurrence_metadata():
+    workspace_type = getattr(_MODULE, "SelectiveKVWorkspace", None)
+    assert workspace_type is not None, "SelectiveKVWorkspace is not implemented"
+    workspace = workspace_type(torch.device("cpu"))
+
+    physical, remapped = workspace.get_occurrence_metadata(5)
+    physical_ptr = physical.data_ptr()
+    remapped_ptr = remapped.data_ptr()
+    physical_small, remapped_small = workspace.get_occurrence_metadata(2)
+
+    assert physical.dtype == torch.int32
+    assert remapped.dtype == torch.int32
+    assert physical.shape == remapped.shape == (5,)
+    assert physical_small.data_ptr() == physical_ptr
+    assert remapped_small.data_ptr() == remapped_ptr
+    assert workspace.occurrence_capacity == 8
+
+
+def test_selective_workspace_allocates_generation_safe_dense_dedup_state():
+    workspace_type = getattr(_MODULE, "SelectiveKVWorkspace", None)
+    assert workspace_type is not None, "SelectiveKVWorkspace is not implemented"
+    workspace = workspace_type(torch.device("cpu"))
+
+    buffers = workspace.get_dense_dedup_buffers(
+        num_pool_rows=9,
+        selection_capacity=5,
+        num_occurrences=7,
+    )
+
+    assert buffers.slot_epoch.shape == (16,)
+    assert buffers.slot_to_compact.shape == (16,)
+    assert buffers.selected_physical_slots.shape == (8,)
+    assert buffers.remapped_topk.shape == (8,)
+    assert buffers.block_offsets.shape == (1,)
+    assert buffers.epoch.shape == (1,)
+    assert buffers.num_unique.shape == (1,)
+    # A 64-bit generation prevents a long-lived CUDA Graph service from ever
+    # aliasing a stale int32 epoch after wraparound.
+    assert buffers.slot_epoch.dtype == torch.int64
+    assert buffers.slot_to_compact.dtype == torch.int32
+    assert buffers.selected_physical_slots.dtype == torch.int32
+    assert buffers.remapped_topk.dtype == torch.int32
+    assert buffers.block_offsets.dtype == torch.int32
+    assert buffers.epoch.dtype == torch.int64
+    assert buffers.epoch.item() == 0
+    assert buffers.num_unique.item() == 0
+    assert torch.all(buffers.slot_epoch == -1)
+
+
+def test_selective_workspace_reuses_dense_dedup_state_for_smaller_shapes():
+    workspace_type = getattr(_MODULE, "SelectiveKVWorkspace", None)
+    assert workspace_type is not None, "SelectiveKVWorkspace is not implemented"
+    workspace = workspace_type(torch.device("cpu"))
+    large = workspace.get_dense_dedup_buffers(16, 8, 8)
+    pointers = tuple(
+        tensor.data_ptr()
+        for tensor in (
+            large.slot_epoch,
+            large.slot_to_compact,
+            large.selected_physical_slots,
+            large.remapped_topk,
+            large.block_offsets,
+            large.epoch,
+            large.num_unique,
+        )
+    )
+
+    small = workspace.get_dense_dedup_buffers(7, 3, 4)
+
+    assert small.slot_epoch.shape == (16,)
+    assert small.slot_to_compact.shape == (16,)
+    assert small.selected_physical_slots.shape == (8,)
+    assert small.remapped_topk.shape == (8,)
+    assert pointers == tuple(
+        tensor.data_ptr()
+        for tensor in (
+            small.slot_epoch,
+            small.slot_to_compact,
+            small.selected_physical_slots,
+            small.remapped_topk,
+            small.block_offsets,
+            small.epoch,
+            small.num_unique,
+        )
+    )
+
+
+@pytest.mark.parametrize("num_rows", [-1, 1.5, True])
+def test_selective_workspace_rejects_invalid_extents(num_rows):
+    workspace_type = getattr(_MODULE, "SelectiveKVWorkspace", None)
+    assert workspace_type is not None, "SelectiveKVWorkspace is not implemented"
+    workspace = workspace_type(torch.device("cpu"))
+
+    with pytest.raises(ValueError, match="non-negative integer"):
+        workspace.get_bf16(num_rows)
+
+
+def test_reference_remap_preserves_minus_one_and_handles_empty_selection():
+    page_table = _i32([20, 21])
+
+    mixed = build_selective_kv_remap_reference(page_table, _i32([[1, -1], [-1, 0]]))
+    torch.testing.assert_close(mixed.physical_slots, _i32([21, 20]))
+    torch.testing.assert_close(mixed.remapped_topk, _i32([[0, -1], [-1, 1]]))
+
+    empty = build_selective_kv_remap_reference(page_table, _i32([[-1, -1]]))
+    assert empty.physical_slots.shape == (0,)
+    torch.testing.assert_close(empty.remapped_topk, _i32([[-1, -1]]))
+    assert empty.num_valid == 0
+    assert empty.num_unique == 0
+
+
+@pytest.mark.parametrize(
+    ("topk", "match"),
+    [
+        ([[-2]], "smaller than -1"),
+        ([[2]], "outside page_table_1_flattened"),
+    ],
+)
+def test_reference_remap_rejects_invalid_logical_indices(topk, match):
+    with pytest.raises(ValueError, match=match):
+        build_selective_kv_remap_reference(_i32([5, 6]), _i32(topk))
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.int16])
+def test_reference_remap_rejects_non_index_dtypes(dtype):
+    with pytest.raises(TypeError, match="integer index tensor"):
+        build_selective_kv_remap_reference(
+            torch.tensor([5, 6], dtype=dtype), _i32([[0]])
+        )
+
+
+def test_traffic_model_accounts_for_full_selective_and_peak_workspace_bytes():
+    estimate = estimate_selective_kv_traffic(
+        prefix_rows=10_000,
+        valid_topk_entries=4_096,
+        unique_rows=1_024,
+    )
+
+    assert estimate.full_kv_bytes == 10_000 * (
+        KV_BYTES_PER_ROW + KV_DEQUANTIZED_BYTES_PER_ROW
+    )
+    assert estimate.selective_kv_bytes == 1_024 * (
+        KV_BYTES_PER_ROW + KV_DEQUANTIZED_BYTES_PER_ROW
+    )
+    assert estimate.full_workspace_bytes == 10_000 * KV_DEQUANTIZED_BYTES_PER_ROW
+    assert estimate.selective_workspace_bytes == (1_024 * KV_DEQUANTIZED_BYTES_PER_ROW)
+    assert estimate.metadata_bytes > 0
+    assert estimate.selective_total_bytes == (
+        estimate.selective_kv_bytes + estimate.metadata_bytes
+    )
+
+
+def test_traffic_model_rejects_impossible_geometry():
+    with pytest.raises(ValueError, match="unique_rows.*valid_topk_entries"):
+        estimate_selective_kv_traffic(
+            prefix_rows=100, valid_topk_entries=4, unique_rows=5
+        )
+    with pytest.raises(ValueError, match="unique_rows.*prefix_rows"):
+        estimate_selective_kv_traffic(
+            prefix_rows=4, valid_topk_entries=5, unique_rows=5
+        )
+
+
+def test_conservative_policy_uses_occurrence_upper_bound_without_overlap_guess():
+    # 128 selected occurrences out of a long prefix is profitable even if all
+    # occurrences are unique.
+    assert should_use_selective_kv_dequant(
+        prefix_rows=16_384,
+        query_tokens=1,
+        topk=128,
+        safety_factor=1.25,
+    )
+
+    # When Q*K covers the full prefix, the conservative policy refuses to
+    # assume overlap that has not been measured yet.
+    assert not should_use_selective_kv_dequant(
+        prefix_rows=1_024,
+        query_tokens=8,
+        topk=128,
+        safety_factor=1.0,
+    )
+
+
+@pytest.mark.parametrize(
+    ("prefix_rows", "query_tokens", "topk"),
+    [(0, 1, 128), (128, 0, 128), (128, 1, 0)],
+)
+def test_conservative_policy_rejects_empty_work(prefix_rows, query_tokens, topk):
+    assert not should_use_selective_kv_dequant(
+        prefix_rows=prefix_rows,
+        query_tokens=query_tokens,
+        topk=topk,
+    )
+
+
+def test_dense_epoch_policy_accounts_for_full_pool_scan():
+    # H20 crossover measurements show that the fixed multi-kernel scan and
+    # launch cost dominates short prefixes even when the byte model predicts
+    # a saving. Fail closed below the measured profitable region.
+    assert not should_use_dense_epoch_kv_dequant(
+        prefix_rows=8192,
+        query_tokens=1,
+        topk=128,
+        num_pool_rows=8192,
+    )
+    assert not should_use_dense_epoch_kv_dequant(
+        prefix_rows=32768,
+        query_tokens=4,
+        topk=2048,
+        num_pool_rows=65536,
+    )
+    assert should_use_dense_epoch_kv_dequant(
+        prefix_rows=40960,
+        query_tokens=5,
+        topk=2048,
+        num_pool_rows=65536,
+    )
+    # Two int64 epoch-table scans over a much larger persistent pool erase the
+    # bytes saved from this small logical prefix, so fail closed.
+    assert not should_use_dense_epoch_kv_dequant(
+        prefix_rows=8192,
+        query_tokens=1,
+        topk=128,
+        num_pool_rows=1_000_000,
+    )
+
+
+def test_dense_epoch_policy_rejects_pool_smaller_than_prefix_physical_extent():
+    with pytest.raises(ValueError, match="num_pool_rows"):
+        should_use_dense_epoch_kv_dequant(
+            prefix_rows=8192,
+            query_tokens=1,
+            topk=128,
+            num_pool_rows=0,
+        )
+
+
+def test_no_dedup_probe_env_gate_defaults_off_and_can_be_enabled():
+    field = getattr(
+        _ENV_MODULE.envs,
+        "SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_NO_DEDUP",
+        None,
+    )
+    assert field is not None, "selective no-dedup probe env gate is not registered"
+    field.clear()
+    try:
+        assert field.get() is False
+        with field.override(True):
+            assert field.get() is True
+        assert field.get() is False
+    finally:
+        field.clear()
+
+
+def test_dense_epoch_probe_env_gate_defaults_off_and_can_be_enabled():
+    field = getattr(
+        _ENV_MODULE.envs,
+        "SGLANG_EXPERIMENTAL_DSA_SELECTIVE_KV_DENSE_EPOCH",
+        None,
+    )
+    assert field is not None, "selective dense-epoch probe env gate is not registered"
+    field.clear()
+    try:
+        assert field.get() is False
+        with field.override(True):
+            assert field.get() is True
+        assert field.get() is False
+    finally:
+        field.clear()
+
+
+def test_prefix_orchestrator_preserves_full_dequant_fallback():
+    quant_kv = torch.empty((32, 1, 656), dtype=torch.uint8)
+    page_table = torch.arange(32, dtype=torch.int32)
+    topk = _i32([[0, 1]])
+    workspace = _MODULE.SelectiveKVWorkspace(torch.device("cpu"))
+    calls = []
+
+    def fake_dequant(quant, selected, **kwargs):
+        calls.append((selected, kwargs))
+        return torch.full((selected.numel(), 1, 576), 7, dtype=torch.bfloat16)
+
+    result = dequantize_dsa_prefix_kv_selective(
+        quant_kv,
+        page_table,
+        topk,
+        num_pool_rows=32,
+        mode="off",
+        workspace=workspace,
+        dequantize_fn=fake_dequant,
+    )
+
+    assert result.mode == "off"
+    assert result.remapped_topk is topk
+    assert calls == [(page_table, {})]
+    assert workspace.bf16_capacity == 0
+
+
+def test_prefix_orchestrator_no_dedup_does_not_treat_padding_as_prefix():
+    quant_kv = torch.empty((4096, 1, 656), dtype=torch.uint8)
+    page_table = torch.arange(4096, dtype=torch.int32)
+    topk = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    topk[0, 3] = -1
+    topk[0, -1] = 200
+    workspace = _MODULE.SelectiveKVWorkspace(torch.device("cpu"))
+    calls = []
+
+    def fake_dequant(quant, selected, **kwargs):
+        calls.append((selected, kwargs.copy()))
+        out = kwargs["out"]
+        out.fill_(3)
+        return out
+
+    result = dequantize_dsa_prefix_kv_selective(
+        quant_kv,
+        page_table,
+        topk,
+        num_pool_rows=4096,
+        mode="no_dedup",
+        workspace=workspace,
+        dequantize_fn=fake_dequant,
+    )
+
+    assert result.mode == "no_dedup"
+    assert result.remapped_topk[0, 3] == -1
+    assert result.remapped_topk[0, -1] == 127
+    assert calls[0][1].keys() == {"out"}
+    assert "num_valid_rows" not in calls[0][1]
+    assert calls[0][0][3] == 0  # ignored landing row for the padding occurrence
+    physical_buffer, remap_buffer = workspace.get_occurrence_metadata(128)
+    assert calls[0][0].data_ptr() == physical_buffer.data_ptr()
+    assert result.remapped_topk.data_ptr() == remap_buffer.data_ptr()
+
+
+def test_prefix_orchestrator_dense_epoch_uses_device_compact_extent():
+    quant_kv = torch.empty((40960, 1, 656), dtype=torch.uint8)
+    page_table = torch.arange(40960, dtype=torch.int32)
+    topk = torch.arange(128, dtype=torch.int32).reshape(1, 128)
+    workspace = _MODULE.SelectiveKVWorkspace(torch.device("cpu"))
+    calls = []
+
+    def fake_dedup(
+        page_table_1_flattened,
+        flat_topk_indices,
+        *,
+        selected_physical_slots,
+        remapped_topk,
+        num_unique,
+        **kwargs,
+    ):
+        selected_physical_slots[:2].copy_(_i32([11, 29]))
+        remapped_topk.copy_(
+            (torch.arange(flat_topk_indices.numel(), dtype=torch.int32) % 2).reshape_as(
+                flat_topk_indices
+            )
+        )
+        num_unique.fill_(2)
+        return selected_physical_slots, remapped_topk, num_unique
+
+    def fake_dequant(quant, selected, **kwargs):
+        calls.append((selected, kwargs.copy()))
+        out = kwargs["out"]
+        out.fill_(5)
+        return out
+
+    result = dequantize_dsa_prefix_kv_selective(
+        quant_kv,
+        page_table,
+        topk,
+        num_pool_rows=40960,
+        mode="dense_epoch",
+        workspace=workspace,
+        dequantize_fn=fake_dequant,
+        deduplicate_fn=fake_dedup,
+    )
+
+    assert result.mode == "dense_epoch"
+    assert result.remapped_topk.shape == topk.shape
+    assert calls[0][0].shape == (128,)
+    assert calls[0][1]["num_valid_rows"].item() == 2
+    assert calls[0][1]["out"].shape == (128, 1, 576)
+
+
+def test_prefix_orchestrator_rejects_conflicting_or_unknown_modes():
+    quant_kv = torch.empty((1, 1, 656), dtype=torch.uint8)
+    page_table = _i32([0])
+    topk = _i32([[0]])
+    workspace = _MODULE.SelectiveKVWorkspace(torch.device("cpu"))
+
+    with pytest.raises(ValueError, match="unsupported selective KV mode"):
+        dequantize_dsa_prefix_kv_selective(
+            quant_kv,
+            page_table,
+            topk,
+            num_pool_rows=1,
+            mode="both",
+            workspace=workspace,
+            dequantize_fn=lambda *args, **kwargs: None,
+        )
+
+
+@pytest.mark.parametrize(
+    ("no_dedup", "dense_epoch", "expected"),
+    [(False, False, "off"), (True, False, "no_dedup"), (False, True, "dense_epoch")],
+)
+def test_resolve_selective_kv_mode(no_dedup, dense_epoch, expected):
+    assert resolve_selective_kv_mode(no_dedup, dense_epoch) == expected
+
+
+def test_resolve_selective_kv_mode_rejects_two_experiments_at_once():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        resolve_selective_kv_mode(True, True)


### PR DESCRIPTION
## Motivation

When FP8 DSA KV cache is consumed by the BF16 `flashmla_sparse` prefill path, SGLang currently dequantizes the complete flattened prefix. DSA only attends to selected top-k positions, and selections from a prefill chunk can overlap, so full-prefix BF16 staging wastes memory traffic and workspace for long contexts.

Closes #36338.

## What this draft implements

- Maps logical DSA top-k positions through the page table to physical KV slots.
- Deduplicates physical slots with a persistent epoch table and deterministic device-side compaction.
- Remaps top-k indices to a compact BF16 buffer.
- Extends paged FP8 KV dequantization with reusable output and a device-side valid-row extent, avoiding a host synchronization on `num_unique`.
- Bounds the CUDA Graph-safe dequant launch by SM count and consumes device-sized active rows with a grid-stride loop instead of launching one masked program per workspace-capacity row.
- Reuses grow-only metadata/BF16 buffers and covers CUDA Graph capture/replay.
- Preserves the existing full-prefix path by default. Both experimental modes are opt-in.
- Adds a conservative H20-calibrated crossover gate so short-prefix regressions fall back to full dequantization.
- Adds reproducible JSON/CSV shape benchmarks.

## H20 results

GPU: 1x NVIDIA H20, SM90, 97,871 MiB, 78 SMs  
Dtype: FP8 E4M3 KV input, BF16 compact output  
Metric: uninstrumented CUDA-event operator-path latency

Final long-prefix measurements use 50 warmups and 500 measured iterations:

| Prefix rows | Query tokens | Top-k | Physical unique rows | Cached full dequant | Dense selective total | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 65,536 | 16 | 2,048 | 4,096 | 224.59 us | 104.41 us | 2.151x |
| 65,536 | 16 | 2,048 | 2,048 | 224.66 us | 99.23 us | 2.264x |

For the 4,096-unique-row case, replacing the capacity-sized masked launch with the SM-bounded device-extent kernel reduced isolated selected-row dequantization from 100.94 us to 28.33 us (3.56x).

Earlier crossover measurements showed that the complete selective pipeline is not profitable for short prefixes: approximately 0.28x/0.53x/0.80x/1.07x at 8K/16K/24K/32K prefix rows and 1.31x/1.58x/1.90x at 40K/48K/56K. The current experimental policy therefore fails closed below 40K and retains the conservative byte-traffic/pool-scan check above it.

CUDA allocator peak increment for the 65,536-row / 16-query case decreased from 75,497,472 bytes for full BF16 staging to 38,799,360 bytes for selective workspace plus metadata, a 48.6% reduction. The fixed CUDA-Graph-safe BF16 output capacity decreased from 65,536 to 32,768 rows; the measured physical union contained 4,096 rows.

Nsight Systems 2025.1.1 identified the original capacity-masked paged FP8 dequantization as 79.1% of captured GPU kernel time. After the follow-up, `_dequantize_k_cache_paged_device_extent_kernel` averaged 8.586 us under tracing. Nsight tracing perturbs this multi-launch microbenchmark, so speedups above are from uninstrumented CUDA-event measurements. Nsight Compute hardware counters were unavailable because the rental host disables performance-counter access for both container users and container root.

The repository's separate native Q8KV8 benchmark was also run on this H20. Its FP8 attention-only path was 1.57-1.69x faster than Q16 BF16 FlashMLA over the five official shapes. That is not directly comparable to the staging-only measurements above: this draft specifically optimizes configurations that retain BF16 sparse attention while storing KV in FP8; native Q8KV8 remains an explicit SM90-only prefill backend.

These are operator/backend-path results, not end-to-end model claims.

## Validation

- `67 passed` on H20 across the five focused kernel/unit files, covering metadata, physical alias dedup/remap, exact FP8-to-BF16 reconstruction, wrapper contracts, and combined CUDA Graph replay.
- `1 passed` on H20 through the real DSA backend: FP8 KV cache -> ragged top-k -> selective physical compaction/dequantization -> BF16 FlashMLA sparse prefill -> independent attention reference.
- `2 passed` for native Q8KV8 real-kernel parity and repeated-launch stability, used only as a scope/baseline check.
- Black 26.1.0, isort 7.0.0, Ruff 0.15.1, registered-test validation, `py_compile`, wrapper contract validation, and `git diff --check` pass.
- The latest upstream lint workflow passed before the device-extent follow-up; the amended commit will trigger it again.

## Draft limitations / promotion gates

- No end-to-end DeepSeek DSA TTFT, prefill latency, throughput, or real-workload top-k overlap distribution yet.
- The available full-model fixture uses TP8 and reports about 80.4 GiB peak-before-load per GPU, so one H20 cannot supply the full-model gate. A reduced-layer TP integration can run on fewer GPUs, while an original-model result needs 8x96GB-class GPUs.
- Nsight Compute DRAM/occupancy counters require a host that permits GPU performance-counter access.
- The 40K floor and 16x-SM launch bound are deliberately conservative H20-calibrated heuristics. They should be replaced or generalized with a cross-device/shape cost model before default enablement.
- The feature remains default-off until real-model evidence and maintainer feedback justify promotion.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32938324700](https://github.com/sgl-project/sglang/actions/runs/32938324700)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32938324446](https://github.com/sgl-project/sglang/actions/runs/32938324446)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32938324711](https://github.com/sgl-project/sglang/actions/runs/32938324711)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
