### PR TITLE
[Bugfix] Select JIT cudaMemcpyBatchAsync ABI at runtime

### DIFF
--- a/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
@@ -9,41 +9,16 @@
 namespace sglang {
 
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12080
-#if CUDA_VERSION >= 13000
-using CudaMemcpyBatchPtr = const void*;
-using CudaMemcpyBatchAsyncFn = cudaError_t (*)(
-    CudaMemcpyBatchPtr*,
-    CudaMemcpyBatchPtr*,
-    const size_t*,
-    size_t,
-    cudaMemcpyAttributes*,
-    size_t*,
-    size_t,
-    cudaStream_t);
-#else
 using CudaMemcpyBatchPtr = void*;
-using CudaMemcpyBatchAsyncFn = cudaError_t (*)(
-    CudaMemcpyBatchPtr*,
-    CudaMemcpyBatchPtr*,
-    size_t*,
-    size_t,
-    cudaMemcpyAttributes*,
-    size_t*,
-    size_t,
-    size_t*,
-    cudaStream_t);
-#endif
 
-inline auto get_cuda_memcpy_batch_async() -> CudaMemcpyBatchAsyncFn {
-  static CudaMemcpyBatchAsyncFn cuda_memcpy_batch_async = []() {
-    void* symbol = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
-    return reinterpret_cast<CudaMemcpyBatchAsyncFn>(symbol);
-  }();
+inline auto get_cuda_memcpy_batch_async() -> void* {
+  static void* cuda_memcpy_batch_async = dlsym(RTLD_DEFAULT, "cudaMemcpyBatchAsync");
   return cuda_memcpy_batch_async;
 }
 
 inline auto call_cuda_memcpy_batch_async(
-    CudaMemcpyBatchAsyncFn copy_fn,
+    void* copy_fn,
+    bool use_v13_signature,
     CudaMemcpyBatchPtr* dsts,
     CudaMemcpyBatchPtr* srcs,
     size_t* sizes,
@@ -52,12 +27,18 @@ inline auto call_cuda_memcpy_batch_async(
     size_t* attrs_idxs,
     size_t num_attrs,
     cudaStream_t stream) -> cudaError_t {
-#if CUDA_VERSION >= 13000
-  return copy_fn(dsts, srcs, sizes, count, attrs, attrs_idxs, num_attrs, stream);
-#else
+  if (use_v13_signature) {
+    using FnV13 = cudaError_t (*)(
+        void* const*, const void* const*, const size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, cudaStream_t);
+    auto fn = reinterpret_cast<FnV13>(copy_fn);
+    return fn(dsts, srcs, sizes, count, attrs, attrs_idxs, num_attrs, stream);
+  }
+
+  using FnV12 =
+      cudaError_t (*)(void**, void**, size_t*, size_t, cudaMemcpyAttributes*, size_t*, size_t, size_t*, cudaStream_t);
+  auto fn = reinterpret_cast<FnV12>(copy_fn);
   size_t fail_idx = std::numeric_limits<size_t>::max();
-  return copy_fn(dsts, srcs, sizes, count, attrs, attrs_idxs, num_attrs, &fail_idx, stream);
-#endif
+  return fn(dsts, srcs, sizes, count, attrs, attrs_idxs, num_attrs, &fail_idx, stream);
 }
 #endif
 
@@ -119,6 +100,15 @@ inline bool try_copy_page_first_pages_batch(
     return false;
   }
 
+  // CUDA 13 removed failIdx from cudaMemcpyBatchAsync. Select the ABI from
+  // the loaded runtime rather than the toolkit that compiled this JIT kernel.
+  static int runtime_version = 0;
+  static const cudaError_t runtime_version_err = cudaRuntimeGetVersion(&runtime_version);
+  if (runtime_version_err != cudaSuccess) {
+    return false;
+  }
+  static const bool use_v13_signature = runtime_version >= 13000;
+
   const size_t num_copies = static_cast<size_t>(src_ptrs.size()) * static_cast<size_t>(num_pages);
   batch_srcs.clear();
   batch_dsts.clear();
@@ -166,6 +156,7 @@ inline bool try_copy_page_first_pages_batch(
 
   cudaError_t err = call_cuda_memcpy_batch_async(
       copy_fn,
+      use_v13_signature,
       batch_dsts.data(),
       batch_srcs.data(),
       batch_sizes.data(),

--- a/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
+++ b/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
@@ -95,7 +95,7 @@ def _assert_pages_equal(host_ref, device_ref, host_pages, device_pages) -> None:
         )
 
 
-def _run_mha(element_dim: int, page_count: int) -> None:
+def _run_mha(element_dim: int, page_count: int, num_layers: int = NUM_LAYERS) -> None:
     pool_size = PAGE_SIZE * (page_count + 8)
     device_pool = MHATokenToKVPool(
         size=pool_size,
@@ -103,7 +103,7 @@ def _run_mha(element_dim: int, page_count: int) -> None:
         head_num=element_dim // 128,
         head_dim=128,
         dtype=torch.bfloat16,
-        layer_num=NUM_LAYERS,
+        layer_num=num_layers,
         device=DEVICE,
         enable_memory_saver=False,
     )
@@ -116,7 +116,7 @@ def _run_mha(element_dim: int, page_count: int) -> None:
     # page_first + kernel staged write-back JIT path must be enabled.
     assert host_pool.can_use_write_back_jit
 
-    for layer_id in range(NUM_LAYERS):
+    for layer_id in range(num_layers):
         _fill_with_offset(device_pool.k_buffer[layer_id], layer_id)
         _fill_with_offset(device_pool.v_buffer[layer_id], layer_id + 100)
 
@@ -133,7 +133,7 @@ def _run_mha(element_dim: int, page_count: int) -> None:
     )
     torch.cuda.synchronize()
 
-    for layer_id in range(NUM_LAYERS):
+    for layer_id in range(num_layers):
         _assert_pages_equal(
             host_pool.k_data_refs[layer_id],
             device_pool.k_buffer[layer_id],
@@ -150,20 +150,20 @@ def _run_mha(element_dim: int, page_count: int) -> None:
     # Load path (prefix-cache hit): exercises the hicache.cuh load matchers.
     if not host_pool.can_use_jit:
         return
-    for layer_id in range(NUM_LAYERS):
+    for layer_id in range(num_layers):
         device_pool.k_buffer[layer_id].zero_()
         device_pool.v_buffer[layer_id].zero_()
 
     load_pages = torch.arange(1, 1 + page_count, device=DEVICE, dtype=torch.int64)
     load_indices = _token_indices_for_pages(load_pages)
     host_indices_device = host_indices.to(DEVICE)
-    for layer_id in range(NUM_LAYERS):
+    for layer_id in range(num_layers):
         host_pool.load_to_device_per_layer(
             device_pool, host_indices_device, load_indices, layer_id, "kernel"
         )
     torch.cuda.synchronize()
 
-    for layer_id in range(NUM_LAYERS):
+    for layer_id in range(num_layers):
         _assert_pages_equal(
             host_pool.k_data_refs[layer_id],
             device_pool.k_buffer[layer_id],
@@ -247,6 +247,12 @@ def _run_mla(element_dim: int, page_count: int) -> None:
 @pytest.mark.parametrize("page_count", PAGE_COUNTS)
 def test_page_first_staged_write_back_mha(element_dim: int, page_count: int) -> None:
     _run_mha(element_dim, page_count)
+
+
+def test_page_first_staged_write_back_mha_batch_copy() -> None:
+    # Sixteen layers at this shape reach the 128 KiB threshold that selects
+    # cudaMemcpyBatchAsync instead of the per-page fallback.
+    _run_mha(element_dim=256, page_count=1, num_layers=16)
 
 
 @pytest.mark.parametrize("element_dim", MLA_ELEMENT_DIMS)


### PR DESCRIPTION
## Motivation

Fixes #36302.

The JIT HiCache write-back path resolves `cudaMemcpyBatchAsync` from the loaded CUDA runtime, but previously selected its function-pointer signature from the compile-time `CUDA_VERSION`. In a mixed-toolchain process, that can pass the CUDA 12.8 `failIdx` argument where CUDA 13 expects the stream and segfault on the first batched write-back.

## Modifications

- Resolve `cudaMemcpyBatchAsync` as an untyped symbol.
- Cache `cudaRuntimeGetVersion()` and select the CUDA 12.8 or CUDA 13 call signature from the loaded runtime version.
- Add a HiCache regression case with 16 layers and 256 elements per layer. Its 128 KiB page span reaches the batch-copy threshold instead of exercising the per-page fallback.

## Accuracy Tests

On an RTX 5090 with CUDA runtime 13.0, the patched JIT kernel was rebuilt in an isolated cache and passed 20 repeated MHA staged write-backs. Each run copied three pages for K and V across 16 layers through the 128 KiB `cudaMemcpyBatchAsync` path; all outputs matched the source tensors exactly (`rtol=0`, `atol=0`).

Validation:

- Focused RTX 5090 JIT correctness harness: passed
- `git diff --check`: passed
- Pre-commit formatting, ruff, codespell, clang-format, and repository lint checks for the changed files: passed
- `check_no_bare_pytest_main.py`: passed
- `check_registered_tests.py`: passed

## Speed Tests and Profiling

No hot-path runtime-version query is added: `cudaRuntimeGetVersion()` and the resulting ABI choice are cached in function-local statics. The copy implementation and fallback threshold are unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing behavior or API change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32938027523](https://github.com/sgl-project/sglang/actions/runs/32938027523)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32938027253](https://github.com/sgl-project/sglang/actions/runs/32938027253)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32938027510](https://github.com/sgl-project/sglang/actions/runs/32938027510)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->