### PR TITLE
Fix unified HiCache PP test import

### DIFF
--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_hicache_pp_kl.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_hicache_pp_kl.py
@@ -5,11 +5,12 @@ import unittest
 from types import SimpleNamespace
 from urllib.parse import urlparse
 
-from test_unified_radix_cache_kl_nightly import AccuracyTwoPassMixin
-
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
-from sglang.test.kits.unified_radix_cache_kit import UnifiedRadixTreeTestMixin
+from sglang.test.kits.unified_radix_cache_kit import (
+    AccuracyTwoPassMixin,
+    UnifiedRadixTreeTestMixin,
+)
 from sglang.test.kl_multiturn_utils import get_input_ids
 from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,


### PR DESCRIPTION
## Summary

- import `AccuracyTwoPassMixin` from the shared unified radix-cache test kit
- remove the stale import of the deleted `test_unified_radix_cache_kl_nightly` module

## Root cause

#36281 moved `AccuracyTwoPassMixin` into `sglang.test.kits.unified_radix_cache_kit` and deleted the nightly test module, but `test_unified_radix_cache_hicache_pp_kl.py` retained the old sibling import. The test therefore fails during collection with `ModuleNotFoundError`.

## Validation

- reproduced the exact `ModuleNotFoundError` on current `main`
- `python3 -m py_compile` on the repaired test and shared kit
- AST import-target check
- `ruff check` on the repaired test file

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32939441743](https://github.com/sgl-project/sglang/actions/runs/32939441743)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32939461727](https://github.com/sgl-project/sglang/actions/runs/32939461727)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32939441687](https://github.com/sgl-project/sglang/actions/runs/32939441687)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->