### PR TITLE
[Perf] Vectorize logit_bias construction in SamplingBatchInfo

### DIFF
--- a/python/sglang/srt/sampling/sampling_batch_info.py
+++ b/python/sglang/srt/sampling/sampling_batch_info.py
@@ -135,10 +135,26 @@ class SamplingBatchInfo:
         logit_bias = None
         if any(r.sampling_params.logit_bias is not None for r in reqs):
             logit_bias = torch.zeros(len(reqs), vocab_size, device=device)
+            # Preserve scalar-assignment conversion semantics before batching device writes.
+            value_cpu = torch.empty((), dtype=logit_bias.dtype, device="cpu")
+            canonical = {}
             for i, r in enumerate(reqs):
-                if r.sampling_params.logit_bias is not None:
-                    for key, value in r.sampling_params.logit_bias.items():
-                        logit_bias[i, int(key)] = value
+                bias = r.sampling_params.logit_bias
+                if not bias:
+                    continue
+                for key, value in bias.items():
+                    token_id = int(key)
+                    value_cpu[...] = value
+                    canonical[(i, token_id)] = value_cpu.item()
+
+            if canonical:
+                indices = torch.tensor(list(canonical.keys()), device=device)
+                logit_bias[
+                    indices[:, 0],
+                    indices[:, 1],
+                ] = torch.tensor(
+                    list(canonical.values()), dtype=logit_bias.dtype, device=device
+                )
 
         # Check if any request has custom logit processor
         has_custom_logit_processor = (

--- a/test/registered/unit/sampling/test_sampling_batch_info.py
+++ b/test/registered/unit/sampling/test_sampling_batch_info.py
@@ -599,17 +599,70 @@ class TestFromScheduleBatch(CustomTestCase):
         self.assertTrue(info.is_all_greedy)
 
     def test_logit_bias_construction(self):
-        """Test that logit_bias dict is converted to a tensor with correct values."""
+        """Test that logit_bias dicts are converted to a dense tensor."""
 
-        reqs = [self._make_req(logit_bias={"5": 2.0, "10": -1.0})]
+        reqs = [
+            self._make_req(logit_bias={"5": 2.0, "10": -1.0}),
+            self._make_req(),
+            self._make_req(logit_bias={"3": 1.5, "7": -0.5}),
+        ]
         batch = MagicMock()
         batch.reqs = reqs
         batch.device = DEVICE
         info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
         self.assertIsNotNone(info.logit_bias)
-        self.assertAlmostEqual(info.logit_bias[0, 5].item(), 2.0)
-        self.assertAlmostEqual(info.logit_bias[0, 10].item(), -1.0)
-        self.assertAlmostEqual(info.logit_bias[0, 0].item(), 0.0)
+        expected = torch.zeros(len(reqs), VOCAB_SIZE)
+        expected[0, 5] = 2.0
+        expected[0, 10] = -1.0
+        expected[2, 3] = 1.5
+        expected[2, 7] = -0.5
+        self.assertTrue(torch.equal(info.logit_bias, expected))
+
+    def test_logit_bias_duplicate_canonical_token_ids_last_write_wins(self):
+        """Test last-write-wins after integer token-ID canonicalization."""
+
+        reqs = [
+            self._make_req(logit_bias={"1": -1.0, "01": -2.0}),
+            self._make_req(logit_bias={"01": -2.0, "1": -1.0}),
+        ]
+        batch = MagicMock()
+        batch.reqs = reqs
+        batch.device = DEVICE
+        info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+        self.assertAlmostEqual(info.logit_bias[0, 1].item(), -2.0)
+        self.assertAlmostEqual(info.logit_bias[1, 1].item(), -1.0)
+
+    def test_logit_bias_value_conversion_matches_scalar_assignment(self):
+        """Test overflow and infinity behavior matches scalar tensor assignment."""
+
+        for value in [1e40, float("inf"), float("-inf")]:
+            expected = torch.zeros(1, VOCAB_SIZE)
+            batch = MagicMock()
+            batch.reqs = [self._make_req(logit_bias={"1": value})]
+            batch.device = DEVICE
+
+            try:
+                expected[0, 1] = value
+            except RuntimeError as expected_error:
+                with self.assertRaises(type(expected_error)):
+                    SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+            else:
+                info = SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
+                self.assertTrue(torch.equal(info.logit_bias, expected))
+
+    def test_logit_bias_key_conversion_precedes_value_conversion(self):
+        """Test malformed token IDs fail before value conversion."""
+
+        expected = torch.zeros(1, VOCAB_SIZE)
+        with self.assertRaises(ValueError):
+            expected[0, int("not-an-int")] = 1e40
+
+        batch = MagicMock()
+        batch.reqs = [self._make_req(logit_bias={"not-an-int": 1e40})]
+        batch.device = DEVICE
+
+        with self.assertRaises(ValueError):
+            SamplingBatchInfo.from_schedule_batch(batch, VOCAB_SIZE)
 
     def test_deterministic_seed(self):
         """Test that explicit seed=123 is kept and missing seed defaults to 42."""


### PR DESCRIPTION
## Motivation

`SamplingBatchInfo.from_schedule_batch` currently constructs the dense `logit_bias` tensor with nested Python loops:

```python
for i, r in enumerate(reqs):
    if r.sampling_params.logit_bias is not None:
        for key, value in r.sampling_params.logit_bias.items():
            logit_bias[i, int(key)] = value
```

When `logit_bias` is on CUDA, each assignment becomes a Python-driven scalar device write. The overhead grows with the total number of bias entries in a batch and can become significant for workloads that use many biased or suppressed tokens per request.

This PR keeps token/value processing on the CPU and performs a single bulk indexed device update instead.

The change is intentionally limited to `logit_bias` construction. It does not change sampling behavior, validation rules, or the `logit_bias` API.

## Modifications

- Canonicalize `(request row, token id)` entries on the CPU before constructing the dense CUDA tensor.
- Preserve the existing `int(key)` token-id conversion semantics.
- Preserve last-write-wins behavior when distinct string keys canonicalize to the same token id, for example `"1"` and `"01"`.
- Preserve the existing float32 scalar-assignment conversion behavior before batching device writes. In particular, finite values that overflow the destination dtype continue to raise instead of being silently converted to infinity.
- Materialize one index tensor and one value tensor, then apply the biases with one bulk indexed assignment instead of one CUDA scalar write per entry.
- Add focused unit tests covering dense construction, mixed biased/unbiased requests, duplicate canonical token ids, overflow/infinity behavior, and key/value conversion ordering.

No new configuration, model-specific path, or public API is introduced.

## Accuracy Tests

This change does not modify model forward computation or sampling semantics.

The focused `SamplingBatchInfo` unit tests verify behavioral parity for:

- requests with and without `logit_bias`
- multiple bias entries across multiple request rows
- duplicate canonical token ids with last-write-wins semantics
- finite float32 overflow behavior
- positive and negative infinity behavior
- token-id conversion preceding value conversion

Focused test command:

```bash
PYTHONPATH=python python -m pytest -q \
  test/registered/unit/sampling/test_sampling_batch_info.py
```

## Speed Tests and Profiling

Isolated microbenchmark on one NVIDIA H200.

Setup:

- dtype: `float32`
- vocab size: 51,865
- batch sizes: 1, 8, 16, 32
- bias entries per request: 1, 16, 90, 256
- bias dictionaries constructed outside the timed region
- 9 timed groups per arm per configuration
- old/new execution order alternated between groups
- host wall-clock timing with `torch.cuda.synchronize()` before and after each timed group, so Python, H2D, and CUDA launch overhead are included

The baseline is the current scalar-write implementation. The candidate is the CPU-canonicalization plus bulk indexed-write implementation.

| Batch | Entries / request | Baseline us/call | Candidate us/call | Speedup | Candidate delta |
|---:|---:|---:|---:|---:|---:|
| 1 | 1 | 23.037 | 60.967 | 0.378x | +164.65% |
| 1 | 16 | 217.068 | 103.626 | 2.095x | -52.26% |
| 1 | 90 | 1151.908 | 291.769 | 3.948x | -74.67% |
| 1 | 256 | 3256.896 | 713.083 | 4.567x | -78.11% |
| 8 | 1 | 113.299 | 79.064 | 1.433x | -30.22% |
| 8 | 16 | 1640.546 | 389.370 | 4.213x | -76.27% |
| 8 | 90 | 9147.981 | 1884.428 | 4.855x | -79.40% |
| 8 | 256 | 25877.317 | 5200.156 | 4.976x | -79.90% |
| 16 | 1 | 216.266 | 101.465 | 2.131x | -53.08% |
| 16 | 16 | 3266.072 | 717.444 | 4.552x | -78.03% |
| 16 | 90 | 18212.663 | 3700.017 | 4.922x | -79.68% |
| 16 | 256 | 51744.472 | 10454.653 | 4.949x | -79.80% |
| 32 | 1 | 422.329 | 145.594 | 2.901x | -65.53% |
| 32 | 16 | 6498.469 | 1371.204 | 4.739x | -78.90% |
| 32 | 90 | 36331.359 | 7394.912 | 4.913x | -79.65% |
| 32 | 256 | 103532.940 | 20948.615 | 4.942x | -79.77% |

For 90 bias entries per request, the candidate is approximately **3.9x to 4.9x faster** across batch sizes 1 to 32, reducing construction time by approximately **75% to 80%**.

The smallest case, batch size 1 with one bias entry, regresses from 23 us to 61 us, or approximately 38 us absolute. This PR intentionally does not add a special-case branch for that configuration. The bulk path becomes faster at batch size 1 with 16 entries, and is already faster at batch size 8 with one entry. Keeping one simple generic implementation avoids adding policy and branching for a small absolute singleton overhead.

These numbers measure `logit_bias` construction only and should not be interpreted as end-to-end inference speedups.

### End-to-end workload validation

As supplemental end-to-end validation, I tested the same semantics-preserving implementation through SGLang-Omni serving `openai/whisper-large-v3` on two NVIDIA H200 GPUs.

The workload used SeedTTS at concurrency 64 with 512 measured requests per arm. Each arm used a fresh server, and each GPU ran three paired rounds with counterbalanced baseline/candidate ordering. The Omni source and SGLang dependency were pinned; the candidate was the production implementation from this PR backported onto the pinned SGLang dependency so the only intended runtime delta was `logit_bias` construction.

Baseline profiling on this workload identified 5,189 small pageable host-to-device copies on the scheduler execution thread, totaling 21,480 bytes with a median and p95 transfer size of 4 bytes. Whisper large-v3 uses 88 suppressed tokens per request, and the trace repeatedly contained groups of 352 small transfers, matching four requests times 88 per-entry `logit_bias` writes. This provides a real workload execution signature for the scalar-write overhead targeted by this PR.

| GPU | Round | QPS change | Mean latency change | P95 change | P99 change |
|:---|---:|---:|---:|---:|---:|
| A | 1 | +1.61% | -1.88% | +8.65% | +28.93% |
| A | 2 | +5.94% | -5.86% | +14.58% | +9.26% |
| A | 3 | +0.83% | -2.48% | -11.54% | -11.17% |
| B | 1 | +5.84% | -5.61% | -6.25% | -17.32% |
| B | 2 | +0.84% | -0.82% | +0.84% | +11.24% |
| B | 3 | +7.94% | -6.72% | -13.85% | -12.95% |

Throughput improved in **6/6 paired rounds**, with a median paired QPS improvement of **3.73%**. Mean latency improved in **6/6 paired rounds**, with a median paired reduction of **4.05%**. P95 and P99 were mixed across server restarts and do not show a consistent directional improvement. WER was identical in every arm.

This end-to-end result is directionally positive and supports that the scalar-write pattern appears in a real serving workload, but it is intentionally not used as the primary speed claim because the service-level effect is modest and tail latency is noisy. The isolated `logit_bias` construction benchmark above remains the primary performance measurement.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No user-facing documentation change is needed for this internal implementation optimization.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32940072249](https://github.com/sgl-project/sglang/actions/runs/32940072249)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32940072121](https://github.com/sgl-project/sglang/actions/runs/32940072121)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32940072248](https://github.com/sgl-project/sglang/actions/runs/32940072248)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->