### PR TITLE
[Fix] Preserve SWA mappings during tree eviction

### DIFF
--- a/python/sglang/srt/mem_cache/allocator/hisparse.py
+++ b/python/sglang/srt/mem_cache/allocator/hisparse.py
@@ -371,6 +371,9 @@ class DeepSeekV4HiSparseTokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
     def free_swa(self, free_indices: torch.Tensor):
         self.logical_attn_allocator.free_swa(free_indices)
 
+    def free_swa_exact(self, full_indices: torch.Tensor) -> int:
+        return self.logical_attn_allocator.free_swa_exact(full_indices)
+
     def available_size(self) -> int:
         return min(
             self.logical_attn_allocator.available_size(),

--- a/python/sglang/srt/mem_cache/allocator/swa.py
+++ b/python/sglang/srt/mem_cache/allocator/swa.py
@@ -363,6 +363,44 @@ class SWATokenToKVPoolAllocator(BaseTokenToKVPoolAllocator):
         swa_indices = swa_indices[swa_indices > 0]
         self.clear_full_to_swa_mapping(mapping_indices)
 
+        self._free_swa_indices(swa_indices)
+
+    def free_swa_exact(self, full_indices: torch.Tensor) -> int:
+        """Free tree-owned SWA pages without widening the FULL-side lookup.
+
+        Radix nodes can own disjoint entries from the same FULL page while their
+        stored SWA values belong to distinct SWA pages. Expanding ``full_indices``
+        to whole FULL pages would therefore clear a neighboring node's mapping.
+
+        The exact entries must describe whole, uniquely owned SWA pages. Return
+        the token-equivalent physical capacity released so it can be checked
+        against the tree's eviction credit.
+        """
+        if full_indices.numel() == 0:
+            return 0
+
+        mapping_indices = full_indices.to(torch.int64)
+        swa_indices = self.full_to_swa_index_mapping[mapping_indices]
+        swa_indices = swa_indices[swa_indices > 0]
+
+        expected_tokens = full_indices.numel()
+        unique_pages = torch.unique(swa_indices // self.page_size)
+        freed_tokens = unique_pages.numel() * self.page_size
+        assert (
+            swa_indices.numel() == expected_tokens and freed_tokens == expected_tokens
+        ), (
+            "tree SWA free accounting mismatch: "
+            f"credited={expected_tokens}, mapped={swa_indices.numel()}, "
+            f"physically_freed={freed_tokens}"
+        )
+
+        self.clear_full_to_swa_mapping(mapping_indices)
+        self._free_swa_indices(swa_indices)
+        return freed_tokens
+
+    def _free_swa_indices(self, swa_indices: torch.Tensor) -> None:
+        """Release already-resolved SWA indices now or at free-group flush."""
+
         if not self.is_not_in_free_group:
             # Resolve ownership now. A cache action later in this group may
             # install a new mapping for the same full index.
@@ -518,6 +556,22 @@ class PureSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
             self.swa_attn_allocator.free(free_index[free_index > 0])
         else:
             self.free_group.append(self._copy_for_free_group(free_index))
+
+    def free_swa_exact(self, full_indices: torch.Tensor) -> int:
+        """Pure SWA uses an identity mapping, so exact FULL ids are SWA ids."""
+        if full_indices.numel() == 0:
+            return 0
+        swa_indices = full_indices[full_indices > 0]
+        expected_tokens = full_indices.numel()
+        freed_tokens = (
+            torch.unique(swa_indices // self.page_size).numel() * self.page_size
+        )
+        assert freed_tokens == expected_tokens, (
+            "tree SWA free accounting mismatch: "
+            f"credited={expected_tokens}, physically_freed={freed_tokens}"
+        )
+        self.free_swa(full_indices)
+        return freed_tokens
 
     def free_group_begin(self):
         self.is_not_in_free_group = False

--- a/python/sglang/srt/mem_cache/multi_ended_allocator.py
+++ b/python/sglang/srt/mem_cache/multi_ended_allocator.py
@@ -2478,6 +2478,24 @@ class UnifiedSWATokenToKVPoolAllocator(SWATokenToKVPoolAllocator):
         self.swa_attn_allocator.free(live)
         self.swa_attn_allocator.clear_inverse_history()
 
+    def free_swa_exact(self, full_indices: torch.Tensor) -> int:
+        """Shared-pool mapping is page-granular, so exact tree frees are
+        page-exact virtual-id frees."""
+        if full_indices is None or full_indices.numel() == 0:
+            return 0
+        v = full_indices.detach().to(torch.int64)
+        v_pages = torch.unique(v // self.page_size)
+        swa_v2p_pages = self.swa_attn_allocator.virtual_to_physical[v_pages]
+        live_pages = swa_v2p_pages[swa_v2p_pages > 0]
+        freed_tokens = live_pages.numel() * self.page_size
+        expected_tokens = full_indices.numel()
+        assert freed_tokens == expected_tokens, (
+            "tree SWA free accounting mismatch: "
+            f"credited={expected_tokens}, physically_freed={freed_tokens}"
+        )
+        self.free_swa(v)
+        return freed_tokens
+
     def set_full_to_swa_mapping(
         self, full_indices: torch.Tensor, swa_indices: torch.Tensor
     ) -> None:

--- a/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/swa_component.py
@@ -484,12 +484,16 @@ class SWAComponent(TreeComponent):
 
         # Device layer
         if EvictLayer.DEVICE in target and cd.value is not None:
-            # Pass full indices to free_swa so slots with no SWA pair are
-            # skipped. Freeing swa_value directly would double free those
-            # entries since they all map to the same sentinel slot.
-            device_frees[self.component_type].append(
-                node.component_data[BASE_COMPONENT_TYPE].value
+            # Pass the node's exact FULL indices. The Controller resolves only
+            # those mapping entries: widening to FULL pages can erase a sibling
+            # node's mapping when a radix split shares a boundary page.
+            full_value = node.component_data[BASE_COMPONENT_TYPE].value
+            assert full_value is not None and len(full_value) == len(cd.value), (
+                f"SWA/FULL eviction length mismatch on node {node.id}: "
+                f"swa={len(cd.value)}, full="
+                f"{None if full_value is None else len(full_value)}"
             )
+            device_frees[self.component_type].append(full_value)
             freed = len(cd.value)
             self.tree_core.component_evictable_size_[ct] -= freed
             cd.value = None
@@ -1128,7 +1132,7 @@ class SWAComponent(TreeComponent):
         alloc = self.cache.token_to_kv_pool_allocator
         if isinstance(action, FreeComponentDeviceSlot):
             for indices in action.indices:
-                alloc.free_swa(indices)
+                alloc.free_swa_exact(indices)
             return
         if isinstance(action, FreeComponentHostSlot):
             for host_indices in action.host_indices:

--- a/test/registered/unit/mem_cache/test_swa_unittest.py
+++ b/test/registered/unit/mem_cache/test_swa_unittest.py
@@ -742,6 +742,93 @@ class TestSWA(unittest.TestCase):
         self.assertEqual(freed_lens, [4, 1])
 
 
+class TestSWATreeFreeContract(CustomTestCase):
+    def test_exact_free_preserves_neighbor_mapping_on_shared_full_pages(self):
+        """A tree free must not clear another node's FULL-to-SWA entries.
+
+        This reproduces the observed 64-token discrepancy: node A touches two
+        FULL pages while owning one SWA page. Node B owns the complementary FULL
+        entries and nine SWA pages. Whole-FULL-page cleanup for A would erase one
+        of B's mappings, so B's later 576-token eviction would release only 512.
+        """
+        page_size = 64
+        for grouped in (False, True):
+            with self.subTest(grouped=grouped):
+                _, allocator, _ = _build_swa_tree(
+                    is_eagle=False,
+                    page_size=page_size,
+                    kv_size=12 * page_size,
+                    kv_size_swa=12 * page_size,
+                    sliding_window_size=page_size,
+                )
+                full_indices = _swa_alloc(allocator, 10 * page_size)
+                self.assertIsNotNone(full_indices)
+                swa_indices = allocator.translate_loc_from_full_to_swa(
+                    full_indices
+                ).clone()
+
+                node_a_full = torch.cat((full_indices[:32], full_indices[64:96]))
+                node_b_full = torch.cat(
+                    (
+                        full_indices[32:64],
+                        full_indices[96:128],
+                        full_indices[128:],
+                    )
+                )
+                node_a_swa = swa_indices[:page_size]
+                node_b_swa = swa_indices[page_size:]
+
+                allocator.clear_full_to_swa_mapping(full_indices)
+                allocator.set_full_to_swa_mapping(node_a_full, node_a_swa)
+                allocator.set_full_to_swa_mapping(node_b_full, node_b_swa)
+
+                available_before = allocator.swa_available_size()
+                if grouped:
+                    allocator.free_group_begin()
+                self.assertEqual(allocator.free_swa_exact(node_a_full), page_size)
+                torch.testing.assert_close(
+                    allocator.full_to_swa_index_mapping[node_b_full], node_b_swa
+                )
+                self.assertEqual(allocator.free_swa_exact(node_b_full), 9 * page_size)
+                if grouped:
+                    self.assertEqual(allocator.swa_available_size(), available_before)
+                    allocator.free_group_end()
+
+                self.assertEqual(
+                    allocator.swa_available_size() - available_before,
+                    10 * page_size,
+                )
+                self.assertTrue(
+                    torch.all(allocator.full_to_swa_index_mapping[full_indices] == 0)
+                )
+
+    def test_exact_free_rejects_missing_mapping_before_mutation(self):
+        page_size = 64
+        _, allocator, _ = _build_swa_tree(
+            is_eagle=False,
+            page_size=page_size,
+            kv_size=4 * page_size,
+            kv_size_swa=4 * page_size,
+            sliding_window_size=page_size,
+        )
+        full_indices = _swa_alloc(allocator, 2 * page_size)
+        self.assertIsNotNone(full_indices)
+        allocator.clear_full_to_swa_mapping(full_indices[:page_size])
+        mapping_before = allocator.full_to_swa_index_mapping[full_indices].clone()
+        available_before = allocator.swa_available_size()
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"credited=128.*physically_freed=64",
+        ):
+            allocator.free_swa_exact(full_indices)
+
+        self.assertEqual(allocator.swa_available_size(), available_before)
+        torch.testing.assert_close(
+            allocator.full_to_swa_index_mapping[full_indices], mapping_before
+        )
+
+
 # Optimization: SGLANG_OPT_SWA_SPLIT_LEAF_ON_INSERT.
 # Splits a freshly-inserted leaf at the (page-aligned) sliding-window
 # boundary so a future inc_lock_ref protects only ~sliding_window_size SWA

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -6459,13 +6459,14 @@ class TestUnifiedRadixCacheActionRouting(CustomTestCase):
             indices
         )
 
-    def test_apply_component_action_device_kv_swa_uses_free_swa(self):
+    def test_apply_component_action_device_kv_swa_uses_exact_free(self):
         cache = mock.MagicMock()
         indices = torch.tensor([4, 5])
         _component_with_cache(ComponentType.SWA, cache).apply_component_action(
             FreeComponentDeviceSlot([indices], component_type=ComponentType.SWA)
         )
-        cache.token_to_kv_pool_allocator.free_swa.assert_called_once_with(indices)
+        cache.token_to_kv_pool_allocator.free_swa_exact.assert_called_once_with(indices)
+        cache.token_to_kv_pool_allocator.free_swa.assert_not_called()
 
     def test_apply_component_action_device_kv_mamba_uses_mamba_allocator(self):
         cache = mock.MagicMock()


### PR DESCRIPTION
## Motivation

With `SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS=1`, unified-tree eviction credits the stored SWA value length but frees it through FULL indices. The regular allocator API expands those indices to whole FULL pages before clearing the FULL-to-SWA mapping.

Radix-split nodes can own disjoint entries on the same FULL boundary page. Evicting one node can therefore erase a neighboring node's mapping; that later eviction can credit 576 tokens while physically releasing only 512.

This contract is shared by the Python and Rust tree cores, so switching tree-core implementations does not provide a reliable workaround.

## Modifications

- Add a tree-specific exact SWA free path that resolves and clears only the supplied FULL mapping entries.
- Deduplicate resolved SWA pages and assert that mapped and physically freed capacity matches the tree eviction credit before mutation.
- Preserve the existing whole-page `free_swa` behavior for request-lifecycle cleanup.
- Route unified-tree SWA device-free actions through the exact path, including pure-SWA, unified-memory-pool, and HiSparse allocator variants.
- Add regression coverage for the shared-boundary-page sequence (64 tokens followed by 576 tokens), grouped frees, missing mappings, and action routing.

## Testing

- `python3.12 -m compileall` on all changed Python files
- `black --check` on all changed Python files
- `ruff check --select=F401,F821,UP037` on all changed Python files
- `git diff --check`
- Focused CPU allocator probe: legacy path reproduced 128/512; exact path released 64/576 and preserved the neighboring mapping in immediate and grouped modes

The full pytest module could not be collected in the local lightweight environment because the complete SGLang runtime dependency set is not installed; CI will run the registered unit tests.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33015948680](https://github.com/sgl-project/sglang/actions/runs/33015948680)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33015948269](https://github.com/sgl-project/sglang/actions/runs/33015948269)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33015948421](https://github.com/sgl-project/sglang/actions/runs/33015948421)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->