### PR TITLE
[Fix][DeepSeek V4] swa chunked prefill deadlock

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -938,6 +938,14 @@ class Req(ReqDllmMixin):
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
 
+        # Length of the previously scheduled extend chunk. Under the overlap
+        # scheduler that chunk is still in flight while the next one is being
+        # prepared, so its SWA slots must stay pinned. `maybe_evict_swa` needs
+        # the real length: the configured chunked_prefill_size is only an upper
+        # bound, and subtracting the bound instead of the actual length
+        # under-evicts and pins the SWA pool.
+        self.prev_extend_chunk_len = 0
+
         # For multi-http worker
         self.http_worker_ipc = http_worker_ipc
 
@@ -1757,6 +1765,7 @@ class Req(ReqDllmMixin):
         self.kv.kv_committed_len = 0
         self.extend_batch_idx = 0
         self.decode_batch_idx = 0
+        self.prev_extend_chunk_len = 0
 
         # When using input_embeds, we cannot easily mix the original input embeddings
         # with the newly generated output token IDs during re-prefill of retracted request.
@@ -2513,6 +2522,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             assert seq_len - pre_len == req.extend_range.length
 
             req.extend_batch_idx += 1
+            # Recorded after `alloc_for_extend` (which runs `maybe_evict_swa`),
+            # so during the next chunk's eviction this still holds the length of
+            # the chunk that is then in flight.
+            req.prev_extend_chunk_len = seq_len - pre_len
 
             # If input_embeds are available, store them
             if req.input_embeds is not None:
@@ -3527,11 +3540,17 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
                         if req.extend_batch_idx < 2:
                             continue
                         else:
-                            pre_len = (
-                                pre_len - get_schedule().chunked_prefill_size
-                                if get_schedule().chunked_prefill_size > 0
-                                else pre_len
-                            )
+                            # Hold back only the chunk that is actually still in
+                            # flight. `chunked_prefill_size` is just its upper
+                            # bound: when the previous chunk was shrunk (e.g. by
+                            # the SWA chunk cap) subtracting the bound evicts
+                            # nothing and keeps the pool pinned.
+                            in_flight_len = req.prev_extend_chunk_len
+                            if in_flight_len <= 0:
+                                in_flight_len = max(
+                                    get_schedule().chunked_prefill_size, 0
+                                )
+                            pre_len = pre_len - in_flight_len
                             self._evict_swa(req, pre_len)
                     else:
                         self._evict_swa(req, pre_len)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -276,6 +276,7 @@ from sglang.srt.managers.utils import (
 )
 from sglang.srt.mem_cache import kv_cache_builder
 from sglang.srt.mem_cache.common import (
+    free_swa_out_of_window_slots,
     maybe_cache_unfinished_req,
     release_kv_cache,
     retraction_discard,
@@ -3387,6 +3388,46 @@ class Scheduler(
 
         return NextBatchPlan(batch_to_run=ret, running_batch=running_batch)
 
+    def _evict_swa_before_chunked_admission(self, req: Req) -> None:
+        """Release the chunked request's out-of-window SWA slots before admission.
+
+        `ScheduleBatch.maybe_evict_swa` runs inside `alloc_for_extend`, i.e.
+        after the PrefillAdder has already sized the next chunk, so the slots it
+        is about to free are invisible to the SWA budget. On a small SWA pool
+        that livelocks: the chunked request pins the pool, `add_chunked_req` sees
+        `rem_swa_tokens <= page_size` and defers it, and with an empty running
+        batch nothing else will ever free a slot -- the server hangs with
+        `#running-req: 0` and a non-empty queue.
+
+        Freeing here is the same point in the iteration, only earlier, and holds
+        back the in-flight chunk plus its window exactly like maybe_evict_swa.
+        """
+        if not self.is_hybrid_swa or req.kv is None:
+            return
+        tree_cache = self.tree_cache
+        if not tree_cache.supports_swa() or not tree_cache.is_chunk_cache():
+            return
+
+        pre_len = len(req.prefix_indices)
+        if self.enable_overlap:
+            # The previous chunk is still running; its slots must stay pinned.
+            if req.extend_batch_idx < 2:
+                return
+            pre_len -= req.prev_extend_chunk_len or self.chunked_prefill_size
+        if pre_len <= 0:
+            return
+
+        free_swa_out_of_window_slots(
+            req,
+            pre_len,
+            sliding_window_size=tree_cache.sliding_window_size,
+            page_size=tree_cache.page_size,
+            req_to_token_pool=self.req_to_token_pool,
+            token_to_kv_pool_allocator=self.token_to_kv_pool_allocator,
+            is_chunk_cache=True,
+            retain_floor=tree_cache.swa_retain_floor(req),
+        )
+
     def _get_new_batch_prefill_raw(
         self,
         prefill_delayer_single_pass: Optional[PrefillDelayerSinglePassExecutor],
@@ -3485,6 +3526,7 @@ class Scheduler(
 
         if self.chunked_req is not None:
             self.chunked_req.init_next_round_input()
+            self._evict_swa_before_chunked_admission(self.chunked_req)
             self.chunked_req = adder.add_chunked_req(self.chunked_req)
 
         if self.enable_lora:

--- a/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
+++ b/test/registered/unit/mem_cache/test_swa_eviction_boundary.py
@@ -15,6 +15,7 @@ Tests use real tree/allocator/pool with mock Req/ScheduleBatch wrappers.
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
 import torch
 
@@ -25,6 +26,9 @@ from sglang.srt.mem_cache.common import free_swa_out_of_window_slots
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache
+from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.runtime_context import get_schedule
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
 from sglang.srt.utils import get_device
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
@@ -548,6 +552,62 @@ class TestSWAEvictionBoundary(unittest.TestCase):
                 req, is_insert=True, kv_len_to_handle=req._kv_committed_len
             )
             tree.sanity_check()
+
+    # -- Chunked prefill: hold back the real in-flight chunk, not the bound --
+
+    def test_chunk_cache_evicts_using_actual_in_flight_chunk_len(self):
+        """`maybe_evict_swa` must hold back only the chunk that is really in
+        flight. It used to subtract the configured `chunked_prefill_size`, which
+        is merely an upper bound: once SWA pressure shrinks a chunk, subtracting
+        the bound puts the frontier below what is already evicted, so nothing is
+        freed and the request keeps the SWA pool pinned. With an empty running
+        batch nothing else can free a slot, so the scheduler then spins forever
+        with `#running-req: 0` and a non-empty queue."""
+        page_size, window = 8, 16
+        configured_chunk, in_flight_chunk = 64, 16
+        pre_len = 80  # two committed chunks: 64 + 16
+
+        set_global_server_args_for_scheduler(
+            ServerArgs(model_path="dummy", chunked_prefill_size=configured_chunk)
+        )
+        self.assertEqual(get_schedule().chunked_prefill_size, configured_chunk)
+
+        tree, allocator, pool = _build_swa_tree(
+            page_size=page_size, sliding_window_size=window
+        )
+        kv = _swa_alloc(allocator, pre_len)
+        pool.write((0, slice(0, pre_len)), kv)
+
+        req = _make_req(0, list(range(pre_len)), 0, tree)
+        req.extend_batch_idx = 2
+        req.prev_extend_chunk_len = in_flight_chunk
+
+        chunk_cache = MagicMock()
+        chunk_cache.supports_swa.return_value = True
+        chunk_cache.is_chunk_cache.return_value = True
+        chunk_cache.sliding_window_size = window
+        chunk_cache.page_size = page_size
+        chunk_cache.swa_retain_floor.return_value = None
+
+        batch = SimpleNamespace(
+            tree_cache=chunk_cache,
+            req_to_token_pool=pool,
+            token_to_kv_pool_allocator=allocator,
+            reqs=[req],
+            prefix_lens=[pre_len],
+            enable_overlap=True,
+            forward_mode=ForwardMode.EXTEND,
+        )
+        batch._evict_swa = lambda r, p: ScheduleBatch._evict_swa(batch, r, p)
+
+        ScheduleBatch.maybe_evict_swa(batch)
+
+        # Everything older than the in-flight chunk and its window is freed.
+        expected = (pre_len - in_flight_chunk - window) // page_size * page_size
+        self.assertEqual(req.kv.swa_evicted_seqlen, expected)
+        # Subtracting the configured bound instead would have freed nothing.
+        self.assertGreater(expected, 0)
+        self.assertEqual((pre_len - configured_chunk - window) // page_size, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

On a hybrid-SWA model with the chunk cache, one long chunked prefill can pin the whole SWA pool and deadlock the scheduler. The process stays alive (`/health` 200, watchdog silent — the event loop is not blocked) but no forward pass ever runs again.

**Repro.** Any hybrid-SWA model whose SWA pool is smaller than two chunks. With DeepSeek-V4-Flash:

```
--tp 4 --chunked-prefill-size 8192 --page-size 256 \
--max-total-tokens 131072 --swa-full-tokens-ratio 0.1 --disable-radix-cache
```

`swa_tokens = 131072 * 0.1 = 13056`. Send a burst of long prompts (LongBench-v2 `short`, concurrency 16) to an **idle** server; it hangs within seconds on this line:

```
Prefill batch, #new-seq: 1, #new-token: 4608, swa token usage: 0.98,
#running-req: 0, #queue-req: 9
```

**Why.** `chunk0 = 8192`, then `chunk1 = 4608` (`rem_swa_tokens - page_size`, from `add_chunked_req`). `maybe_evict_swa` skips eviction while `req.extend_batch_idx < 2`, so both chunks stay pinned — `12800 / 13056 = 0.98`. On the next pass `rem_swa_tokens == page_size`, so `add_chunked_req` returns the request unscheduled; no forward pass means `maybe_evict_swa` — which runs inside `alloc_for_extend`, i.e. *after* admission — never runs, so nothing is freed. The request is starved by the slots it holds itself, and nothing external can help: queued requests fail the `_swa_budget_for_req >= rem_swa_tokens` gate, and retraction only covers the decode batch (`update_running_batch` returns early when it is empty), which the chunked request is not part of.

This is why it only bites a cold or bursting server: in steady state the running decodes hold the SWA pool and retraction keeps `rem_swa_tokens` recovering from an external source.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33350143515](https://github.com/sgl-project/sglang/actions/runs/33350143515)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33350143315](https://github.com/sgl-project/sglang/actions/runs/33350143315)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #33350143430](https://github.com/sgl-project/sglang/actions/runs/33350143430)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->