### PR TITLE
[CI] Fix stale tool_call_parser key in Spark2.5 detector test

### DIFF
--- a/test/registered/unit/function_call/test_spark25_detector.py
+++ b/test/registered/unit/function_call/test_spark25_detector.py
@@ -149,7 +149,7 @@ class TestSpark25DetectorDetectAndParse(CustomTestCase):
         self.assertFalse(self.detector.supports_structural_tag())
         self.assertTrue(self.detector.parses_required_natively())
         self.assertIs(
-            FunctionCallParser(self.tools, "spark").get_structure_constraint(
+            FunctionCallParser(self.tools, "spark25").get_structure_constraint(
                 "required"
             ),
             None,


### PR DESCRIPTION
## Summary

Fixes the stale `"spark"` parser key missed by the rename in #36416

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32945144760](https://github.com/sgl-project/sglang/actions/runs/32945144760)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32945144325](https://github.com/sgl-project/sglang/actions/runs/32945144325)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32945144632](https://github.com/sgl-project/sglang/actions/runs/32945144632)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->