### PR TITLE
[Kernel] Declare the PyTorch ABI dependency in sglang-kernel wheels

### DIFF
--- a/python/sglang/kernels/aot/pyproject.toml
+++ b/python/sglang/kernels/aot/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 requires = [
   "scikit-build-core>=0.10",
-  "torch>=2.8.0",
+  "torch==2.13.0",
   "wheel",
 ]
 build-backend = "scikit_build_core.build"
@@ -21,7 +21,7 @@ classifiers = [
   "License :: OSI Approved :: Apache Software License",
   "Environment :: GPU :: NVIDIA CUDA"
 ]
-dependencies = []
+dependencies = ["torch==2.13.0"]
 
 [project.urls]
 "Homepage" = "https://github.com/sgl-project/sglang/tree/main/python/sglang/kernels/aot"


### PR DESCRIPTION
## Motivation

`sglang-kernel` contains native extensions compiled against a specific PyTorch C++ ABI, but its wheel metadata currently does not declare a runtime dependency on PyTorch.

This allows package resolvers to install incompatible combinations. For example, `sglang-kernel==0.4.6.post1`, which is built against PyTorch 2.13.0, can be installed alongside PyTorch 2.11.0. Importing `sgl_kernel` then fails with an unresolved PyTorch symbol.

The build-system requirement is also currently `torch>=2.8.0`, so an isolated source build could select a different PyTorch ABI from the version documented and used by the CUDA release workflow.

Fixes #36462.

## Modifications

Update `python/sglang/kernels/aot/pyproject.toml` to:

- require `torch==2.13.0` in the isolated build environment;
- add `torch==2.13.0` to the generated package runtime dependencies.

This matches the PyTorch version currently documented in the AOT kernel README, installed by the CUDA kernel build container, and required by the main SGLang Python package.

The exact public-version requirement remains compatible with CUDA local versions such as `torch==2.13.0+cu129` and `torch==2.13.0+cu130`.

This change is limited to the CUDA package configuration. CPU, ROCm, and MUSA use separate build configurations and should declare their respective ABI requirements independently.

## Accuracy Tests

Not applicable. This change only affects package dependency metadata and does not modify kernels, model execution, or numerical results.

Metadata validation:

```text
Name: sglang-kernel
Version: 0.4.6.post1
Requires-Python: >=3.10
Requires-Dist: torch==2.13.0
```

PEP 440 requirement validation:

```text
2.13.0: True
2.13.0+cu130: True
2.13.0+cu129: True
2.11.0+cu130: False
2.14.0: False
```

`git diff --check` also passes. A complete CUDA wheel build was not run locally because it requires the project's CUDA kernel build environment.

## Speed Tests and Profiling

Not applicable. This change does not affect runtime code or kernel performance.

## Checklist

- [x] Format the change according to the project style.
- [x] Validate the generated package metadata; no runtime unit test is applicable.
- [x] Confirm that no documentation update is required; the existing AOT README already specifies PyTorch 2.13.0.
- [x] Confirm that accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32945430169](https://github.com/sgl-project/sglang/actions/runs/32945430169)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32945429867](https://github.com/sgl-project/sglang/actions/runs/32945429867)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32945430055](https://github.com/sgl-project/sglang/actions/runs/32945430055)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->