### PR TITLE
Fix the R3 dp-capture layout corruption and the DSV4 fusion auto-enable deadlock

### DIFF
--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1960,7 +1960,13 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
     {
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
-        "DeepseekV4ForCausalLM",
+        # DeepseekV4ForCausalLM is deliberately absent: with EP + the NextN draft
+        # runner, the fusion workspace creation barriers inside cuda-graph capture
+        # against the capture loop's own barrier -- rank killed by the NCCL
+        # watchdog at 10 min, peers die on gloo "connection closed by peer"
+        # (miles test_session_server_multi_role/test_deepseekv4, 2/2 rounds).
+        # v0.5.16 never auto-enabled DSV4; an explicit
+        # --flashinfer-allreduce-fusion-backend still opts in.
         "GptOssForCausalLM",
         "GlmMoeDsaForCausalLM",
         "Glm4MoeForCausalLM",

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1960,13 +1960,8 @@ _FLASHINFER_ALLREDUCE_FUSION_ARCHS = frozenset(
     {
         "DeepseekV3ForCausalLM",
         "DeepseekV32ForCausalLM",
-        # DeepseekV4ForCausalLM is deliberately absent: with EP + the NextN draft
-        # runner, the fusion workspace creation barriers inside cuda-graph capture
-        # against the capture loop's own barrier -- rank killed by the NCCL
-        # watchdog at 10 min, peers die on gloo "connection closed by peer"
-        # (miles test_session_server_multi_role/test_deepseekv4, 2/2 rounds).
-        # v0.5.16 never auto-enabled DSV4; an explicit
-        # --flashinfer-allreduce-fusion-backend still opts in.
+        # DeepseekV4 is absent on purpose: under EP + NextN its workspace
+        # creation barriers against the cuda-graph capture loop's own barrier.
         "GptOssForCausalLM",
         "GlmMoeDsaForCausalLM",
         "Glm4MoeForCausalLM",

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -436,21 +436,11 @@ def get_dp_local_slice_cpu(
     can_run_graph: bool,
     cuda_graph_batch: Optional[int],
 ) -> Tuple[int, int]:
-    # CPU (start, length) slice for this rank's REAL rows in the dp-gathered
-    # buffer, no D2H sync. Layouts (verified against the buffer's zero-routing
-    # regions on a dp2 devbox):
-    #   graph replay (decode or piecewise prefill): uniform segments strided by
-    #     the replayed graph's padded per-rank size -- cuda_graph_batch, which
-    #     ModelRunnerOutput.graph_num_tokens now carries from the runner that
-    #     ran THIS forward. max(global_num_tokens) is NOT the stride there: a
-    #     prefill graph pads 300 real tokens to a 320-token capture size.
-    #   eager: packed by global_num_tokens (under eager MAX_LEN the entries are
-    #     already uniform, so the sum degenerates to rank * max).
-    # The length is the rank's REAL count (original_*): the rows and
-    # out_cache_loc entries past it belong to graph padding -- every pad row
-    # holds the routing of a zero hidden state, and scattering them through the
-    # pad out_cache_loc entries overwrote live tokens' captured rows with that
-    # single row (the R3 repeated-row corruption).
+    # CPU (start, length) slice for this rank's real rows, no D2H sync. A graph
+    # forward strides by the replayed graph's padded size, not by
+    # max(global_num_tokens): a prefill graph pads 300 tokens to a 320 capture.
+    # The length excludes that padding -- every pad row holds the routing of a
+    # zero hidden state, and its out_cache_loc entry points at a live token.
     global_num_tokens = forward_batch.global_num_tokens_cpu
     dp_rank = get_attention_dp_rank()
     if can_run_graph:

--- a/python/sglang/srt/layers/dp_attention.py
+++ b/python/sglang/srt/layers/dp_attention.py
@@ -436,16 +436,31 @@ def get_dp_local_slice_cpu(
     can_run_graph: bool,
     cuda_graph_batch: Optional[int],
 ) -> Tuple[int, int]:
-    # CPU (start, length) slice for DP-local data in a rank-padded buffer.
-    # Returns Python ints (no D2H sync) and handles the cuda-graph-padded layout.
+    # CPU (start, length) slice for this rank's REAL rows in the dp-gathered
+    # buffer, no D2H sync. Layouts (verified against the buffer's zero-routing
+    # regions on a dp2 devbox):
+    #   graph replay (decode or piecewise prefill): uniform segments strided by
+    #     the replayed graph's padded per-rank size -- cuda_graph_batch, which
+    #     ModelRunnerOutput.graph_num_tokens now carries from the runner that
+    #     ran THIS forward. max(global_num_tokens) is NOT the stride there: a
+    #     prefill graph pads 300 real tokens to a 320-token capture size.
+    #   eager: packed by global_num_tokens (under eager MAX_LEN the entries are
+    #     already uniform, so the sum degenerates to rank * max).
+    # The length is the rank's REAL count (original_*): the rows and
+    # out_cache_loc entries past it belong to graph padding -- every pad row
+    # holds the routing of a zero hidden state, and scattering them through the
+    # pad out_cache_loc entries overwrote live tokens' captured rows with that
+    # single row (the R3 repeated-row corruption).
     global_num_tokens = forward_batch.global_num_tokens_cpu
     dp_rank = get_attention_dp_rank()
-    local_num_tokens = global_num_tokens[dp_rank]
     if can_run_graph:
+        assert cuda_graph_batch is not None, "graph forward without its size"
         local_start_pos = dp_rank * cuda_graph_batch
     else:
         local_start_pos = sum(global_num_tokens[:dp_rank])
-    return local_start_pos, local_num_tokens
+    original = forward_batch.original_global_num_tokens_cpu
+    counts = original if original is not None else global_num_tokens
+    return local_start_pos, counts[dp_rank]
 
 
 from sglang.kernels.ops.memory.memcpy_triton import memcpy_triton

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1907,11 +1907,9 @@ def capture_routed_experts_if_allowed(
     Routing all backends through here keeps the draft-side opt-out from being
     bypassed by an inlined capturer call.
 
-    Rows at or past ``num_token_non_padded`` still hold whatever the router left
-    there; ``_post_process_topk_ids`` masks them only further down, and on ROCm it
-    masks them to 0, a valid expert id. Capture runs ahead of both, so mask a copy
-    here: replay consumers skip -1 rows, and treating a padded row as a real
-    selection makes a whole padded region replay one stale routing row.
+    Capture runs ahead of every padded-region mask in ``_post_process_topk_ids``
+    (and ROCm's masks to 0, a valid expert id), so mask a copy here: replay skips
+    -1 rows but reads a padded one as a real selection.
     """
     if not topk_config.allow_routed_experts_capture:
         return

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -265,10 +265,8 @@ def _prefill_cuda_graph_allows_context_parallel(
 class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]
     can_run_graph: bool
-    # Per-rank padded token count of the cuda graph this forward replayed
-    # (None for eager). The dp-gathered buffer is strided by it, so the state
-    # capturer needs the value from THIS forward's runner, not whichever
-    # runner ran last.
+    # Per-rank padded size of the graph this forward replayed (None for eager);
+    # the dp-gathered buffer is strided by it.
     graph_num_tokens: Optional[int] = None
     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
     routed_experts_output: Optional[TopkCaptureOutput] = None
@@ -1647,10 +1645,8 @@ class ModelRunner:
         # pass the actual number of tokens per DP rank in CUDA graph, not the batch
         # size — the width is captured_req_width.
 
-        # The runner that ran THIS forward reports its padded per-rank size;
-        # reading self.decode_cuda_graph_runner.bs here instead gave the state
-        # capturer another graph's (or an unset) stride on prefill-graph
-        # forwards.
+        # From the runner that ran this forward: the decode runner's own bs is
+        # another graph's stride once a prefill graph replays.
         cuda_graph_num_tokens = output.graph_num_tokens
 
         if (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -265,6 +265,11 @@ def _prefill_cuda_graph_allows_context_parallel(
 class ModelRunnerOutput:
     logits_output: Union[LogitsProcessorOutput, PPProxyTensors]
     can_run_graph: bool
+    # Per-rank padded token count of the cuda graph this forward replayed
+    # (None for eager). The dp-gathered buffer is strided by it, so the state
+    # capturer needs the value from THIS forward's runner, not whichever
+    # runner ran last.
+    graph_num_tokens: Optional[int] = None
     expert_distribution_metrics: Optional[ExpertDistributionMetrics] = None
     routed_experts_output: Optional[TopkCaptureOutput] = None
     indexer_topk_output: Optional[TopkCaptureOutput] = None
@@ -1642,10 +1647,11 @@ class ModelRunner:
         # pass the actual number of tokens per DP rank in CUDA graph, not the batch
         # size — the width is captured_req_width.
 
-        cuda_graph_num_tokens = None
-        runner = self.decode_cuda_graph_runner
-        if getattr(runner, "bs", None):
-            cuda_graph_num_tokens = runner.bs * runner.captured_req_width
+        # The runner that ran THIS forward reports its padded per-rank size;
+        # reading self.decode_cuda_graph_runner.bs here instead gave the state
+        # capturer another graph's (or an unset) stride on prefill-graph
+        # forwards.
+        cuda_graph_num_tokens = output.graph_num_tokens
 
         if (
             not self.is_draft_worker
@@ -1760,13 +1766,20 @@ class ModelRunner:
                 self.hisparse_coordinator.wait_for_pending_backup()
                 self.hisparse_coordinator.num_real_reqs.fill_(forward_batch.batch_size)
 
+            graph_num_tokens = None
+
             # Replay cuda graph if applicable
             if can_run_graph:
                 ret = self.decode_cuda_graph_runner.execute(
                     forward_batch,
                     pp_proxy_tensors=pp_proxy_tensors,
                 )
-                return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
+                return ModelRunnerOutput(
+                    logits_output=ret,
+                    can_run_graph=can_run_graph,
+                    graph_num_tokens=self.decode_cuda_graph_runner.bs
+                    * self.decode_cuda_graph_runner.captured_req_width,
+                )
 
             # DP / MLP-sync padding + attn-tp normalization. Only the decode
             # cuda-graph path above pre-pads its static buffers and returns
@@ -1815,6 +1828,7 @@ class ModelRunner:
                         forward_batch, **kwargs
                     )
                 can_run_graph = True
+                graph_num_tokens = self.prefill_cuda_graph_runner.last_replay_num_tokens
             else:
                 # Eager: decode / extend / idle dispatched inside the runner.
                 ret = self.eager_runner.execute(
@@ -1827,7 +1841,11 @@ class ModelRunner:
             ):
                 forward_batch.post_forward_mlp_sync_batch(ret)
 
-            return ModelRunnerOutput(logits_output=ret, can_run_graph=can_run_graph)
+            return ModelRunnerOutput(
+                logits_output=ret,
+                can_run_graph=can_run_graph,
+                graph_num_tokens=graph_num_tokens,
+            )
 
     def _preprocess_logits(
         self, logits_output: LogitsProcessorOutput, sampling_info: SamplingBatchInfo

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1778,8 +1778,7 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         with self.backend.replay_session():
             static_forward_batch = self.load_batch(forward_batch, **kwargs)
             static_num_tokens = len(static_forward_batch.input_ids)
-            # The dp-gathered buffer this replay uses is strided by the static
-            # (padded) local size; the state capturer reads it via
+            # Stride of the dp-gathered buffer for this replay; surfaced through
             # ModelRunnerOutput.graph_num_tokens.
             self.last_replay_num_tokens = static_num_tokens
             raw_num_tokens = self.raw_num_tokens

--- a/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/prefill_cuda_graph_runner.py
@@ -1778,6 +1778,10 @@ class PrefillCudaGraphRunner(BaseCudaGraphRunner):
         with self.backend.replay_session():
             static_forward_batch = self.load_batch(forward_batch, **kwargs)
             static_num_tokens = len(static_forward_batch.input_ids)
+            # The dp-gathered buffer this replay uses is strided by the static
+            # (padded) local size; the state capturer reads it via
+            # ModelRunnerOutput.graph_num_tokens.
+            self.last_replay_num_tokens = static_num_tokens
             raw_num_tokens = self.raw_num_tokens
             shape_key = self._shape_key(static_num_tokens, forward_batch)
             # The only variants this runner records are chunked-prefix ones.

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1437,9 +1437,8 @@ class MQALayer(MqaAttentionBase):
         )
 
         tp_slice, q_padded, q_out = slice(None), None, None
-        # attn_tp_size, not tp_size: MqaAttentionBase only sets the attention-TP
-        # pair, and the padded/local head counts this block indexes with
-        # (padded_num_heads, n_local_heads) are both derived from it.
+        # attn_tp_size: the head counts indexed below derive from it, and
+        # MqaAttentionBase never sets tp_size.
         if self.attn_tp_size > 1:
             # Only [0:n_local_heads] is written below. Uninitialized padded TP
             # heads inject NaN into attention on gfx942 (fnuz), so zero-init

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1437,7 +1437,10 @@ class MQALayer(MqaAttentionBase):
         )
 
         tp_slice, q_padded, q_out = slice(None), None, None
-        if self.tp_size > 1:
+        # attn_tp_size, not tp_size: MqaAttentionBase only sets the attention-TP
+        # pair, and the padded/local head counts this block indexes with
+        # (padded_num_heads, n_local_heads) are both derived from it.
+        if self.attn_tp_size > 1:
             # Only [0:n_local_heads] is written below. Uninitialized padded TP
             # heads inject NaN into attention on gfx942 (fnuz), so zero-init
             # there; other archs tolerate new_empty and skip the per-forward

--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -178,10 +178,10 @@ class BaseTopkCapturer:
         if no_copy_to_cpu:
             # Clone before the next overlapping forward reuses these buffers.
             return TopkCaptureOutput(
-                out_cache_loc=forward_batch.out_cache_loc.clone(),
+                out_cache_loc=forward_batch.out_cache_loc[: slice_gpu.shape[0]].clone(),
                 topk=slice_gpu.clone(),
                 host_cache=self.host_cache,
             )
-        out_cache_loc_cpu = forward_batch.out_cache_loc.cpu()
+        out_cache_loc_cpu = forward_batch.out_cache_loc[: slice_gpu.shape[0]].cpu()
         self.host_cache.buffer[out_cache_loc_cpu] = slice_gpu.cpu()
         return None


### PR DESCRIPTION
Two fixes for the miles CI failures on the v0.5.18 bump, both diagnosed and
validated on devboxes running the CI image.

## 1. capture: slice the dp-gathered buffer by the layout this forward used

The R3 replay corruption (one routing row repeated across a contiguous token
block; 104 zero-overlap mismatches vs threshold 82). Three stacked defects in
the state capturer's CPU-side layout reconstruction under dp attention:

- stride read from `decode_cuda_graph_runner.bs` regardless of which runner ran
  (piecewise-graph prefill -> stale stride, or TypeError on None);
- `max(global_num_tokens)` is not the prefill-graph stride (300 real tokens
  replay as a 320-token capture size);
- slice and `out_cache_loc` ran to the padded length: pad rows hold the routing
  of a zero hidden state (one deterministic row), pad `out_cache_loc` entries
  point at other tokens' live slots -> each padded scatter overwrites a block
  of live rows with that single row. Its value `[179, 161, 51, 198, 30, 3,
  192, 213]` is bit-identical across forwards, matching the row repeated 67x
  in the CI log.

Fix: the runner that ran the forward reports its padded per-rank size via
`ModelRunnerOutput.graph_num_tokens`; the slice strides by it under graphs and
by the packed sum otherwise; length and `out_cache_loc` are trimmed to the
rank's real count.

Before/after on a dp2/tp2 devbox, same 24 deterministic generations: unfixed
crashes on the first dp>0 graph forward; stride-only fix leaves 20-68-row
blocks of the zero-input row; with this change that row is absent (longest
repeat: 9 rows inside a temperature-0 decode loop, i.e. legitimate text
repetition).

## 2. args: drop DeepseekV4 from the FlashInfer allreduce-fusion auto-enable

v0.5.18 added DSV4 to the auto-enable list. Under EP + the NextN draft runner
the fusion workspace creation barriers inside cuda-graph capture against the
capture loop's own barrier; the NCCL watchdog kills the stuck rank after 10
minutes and the peers die on gloo connection-closed-by-peer
(`test_session_server_multi_role/test_deepseekv4`, reproduced on both CI
rounds; v0.5.16, which does not list DSV4, passes). Restores the v0.5.16
default; explicit `--flashinfer-allreduce-fusion-backend` still opts in.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33029009381](https://github.com/sgl-project/sglang/actions/runs/33029009381)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33029009255](https://github.com/sgl-project/sglang/actions/runs/33029009255)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33029009619](https://github.com/sgl-project/sglang/actions/runs/33029009619)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->