### PR TITLE
fix: clear VLM embedding cache on flush_cache

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -967,7 +967,7 @@ async def classify_request(obj: EmbeddingReqInput, request: Request):
 @app.api_route("/flush_cache", methods=["GET", "POST"])
 @auth_level(AuthLevel.ADMIN_OPTIONAL)
 async def flush_cache(timeout: float = Query(0.0, ge=0.0)):
-    """Flush the radix cache."""
+    """Flush runtime caches, including multimodal embeddings."""
     ret = await _global_state.tokenizer_manager.flush_cache(timeout_s=timeout)
     if ret.success:
         content = (

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -113,6 +113,7 @@ from sglang.srt.layers.quantization.fp8_utils import initialize_fp8_gemm_config
 from sglang.srt.layers.quantization.unquant import initialize_bf16_gemm_config
 from sglang.srt.lora.lora_drainer import LoRADrainer
 from sglang.srt.lora.lora_overlap_loader import LoRAOverlapLoader
+from sglang.srt.managers import mm_schedule
 from sglang.srt.managers.disagg_service import maybe_create_ascend_config_store
 from sglang.srt.managers.hisparse_coordinator import HiSparseCoordinator
 from sglang.srt.managers.io_struct import (
@@ -4386,7 +4387,7 @@ class Scheduler(
         return DetachHiCacheStorageReqOutput(success=False, message=msg)
 
     def flush_cache(self, empty_cache: bool = True):
-        """Flush memory pools (e.g., KV cache, Mamba cache) and optionally empty device allocator cache."""
+        """Flush runtime caches and optionally empty the device allocator cache."""
         if self.is_fully_idle():
             self.cur_batch_for_debug = None
             self.last_batch = None
@@ -4399,6 +4400,12 @@ class Scheduler(
 
             if self.draft_worker:
                 self.draft_worker.clear_cache_pool()
+
+            # Drop cached embeddings so weight updates cannot reuse stale encoder
+            # outputs. Do this before trimming the allocator so colocated workloads
+            # can reclaim the memory.
+            if mm_schedule.embedding_cache is not None:
+                mm_schedule.embedding_cache.clear()
 
             if empty_cache:
                 current_platform.empty_cache()

--- a/test/registered/unit/managers/test_scheduler_flush_cache.py
+++ b/test/registered/unit/managers/test_scheduler_flush_cache.py
@@ -29,6 +29,23 @@ class TestSchedulerFlushCache(unittest.TestCase):
         )
         return scheduler
 
+    def _new_flushable_scheduler(self) -> Scheduler:
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.is_fully_idle = MagicMock(return_value=True)
+        scheduler.cur_batch_for_debug = object()
+        scheduler.last_batch = object()
+        scheduler.tree_cache = MagicMock()
+        scheduler.req_to_token_pool = MagicMock()
+        scheduler.token_to_kv_pool_allocator = MagicMock()
+        scheduler.grammar_manager = MagicMock()
+        scheduler.metrics_reporter = MagicMock()
+        scheduler.metrics_reporter.is_stats_logging_rank = False
+        scheduler.draft_worker = None
+        scheduler.waiting_queue = []
+        scheduler.running_batch = MagicMock()
+        scheduler.running_batch.reqs = []
+        return scheduler
+
     def test_immediate_flush_no_timeout(self):
         """No timeout → flush immediately regardless of idle state."""
         scheduler = self._new_scheduler()
@@ -121,6 +138,28 @@ class TestSchedulerFlushCache(unittest.TestCase):
 
         self.assertIsNotNone(scheduler.flush_wrapper._pending)
         scheduler.ipc_channels.send_to_tokenizer.send_output.assert_not_called()
+
+    def test_successful_flush_clears_mm_embedding_cache_before_allocator(self):
+        scheduler = self._new_flushable_scheduler()
+        embedding_cache = MagicMock()
+        call_order = []
+        embedding_cache.clear.side_effect = lambda: call_order.append("mm_cache")
+
+        with (
+            patch(
+                "sglang.srt.managers.scheduler.mm_schedule.embedding_cache",
+                embedding_cache,
+            ),
+            patch(
+                "sglang.srt.managers.scheduler.current_platform.empty_cache",
+                side_effect=lambda: call_order.append("allocator"),
+            ),
+        ):
+            success = scheduler.flush_cache()
+
+        self.assertTrue(success)
+        self.assertEqual(call_order, ["mm_cache", "allocator"])
+        embedding_cache.clear.assert_called_once_with()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

The scheduler-side VLM embedding cache controlled by `SGLANG_VLM_CACHE_SIZE_MB` was not cleared by `flush_cache()`.

As a result, cached embedding tensors remained referenced even after `current_platform.empty_cache()` was called. This could:

- prevent colocated workloads from reclaiming the memory when switching from rollout to training;
- reuse stale multimodal encoder outputs after model weights are updated.

## Modifications

- Clear `mm_schedule.embedding_cache` during a successful, fully-idle scheduler flush.
- Clear embedding references before trimming the device allocator cache.
- Update the `/flush_cache` docstring to reflect that runtime caches include multimodal embeddings.
- Add a unit test verifying that the embedding cache is cleared before the allocator cache.

## Accuracy Tests

No model forward or kernel logic is changed.

- `test/registered/unit/managers/test_scheduler_flush_cache.py`: 8 passed.
- Targeted pre-commit checks: passed.

## Speed Tests and Profiling

Not applicable. The new logic only runs during an explicit cache flush and does not affect the inference hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32948260388](https://github.com/sgl-project/sglang/actions/runs/32948260388)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32948260207](https://github.com/sgl-project/sglang/actions/runs/32948260207)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32948260281](https://github.com/sgl-project/sglang/actions/runs/32948260281)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->