### PR TITLE
[DO NOT MERGE] test mooncake-transfer-engine from test.pypi

### DIFF
--- a/scripts/ci/cuda/ci_install_dependency.sh
+++ b/scripts/ci/cuda/ci_install_dependency.sh
@@ -691,7 +691,7 @@ stabilize_flashinfer_jit_paths() {
 }
 
 install_extra_deps() {
-    MOONCAKE_VERSION="0.3.12.post1"
+    MOONCAKE_VERSION="0.3.14.dev20260825"
     NIXL_VERSION="1.3.0"
     # shellcheck source=scripts/ci/utils/sgl_eval_ref.sh
     source "${SCRIPT_DIR}/../utils/sgl_eval_ref.sh"
@@ -711,11 +711,16 @@ install_extra_deps() {
     # files that the live variant's RECORD still references, so we force a
     # reinstall to restore them — pip would otherwise see "already satisfied"
     # and skip.
+    # TEST ONLY: pull the pre-release mooncake wheel from test.pypi (not on prod
+    # PyPI yet). Kept as a dedicated install so --index-strategy unsafe-best-match
+    # can't pull the other bundled packages below from test.pypi. Revert before merge.
+    MOONCAKE_EXTRA_INDEX="--extra-index-url https://test.pypi.org/simple/"
     if pip show ${MOONCAKE_STALE_PKG} >/dev/null 2>&1; then
         $PIP_UNINSTALL_CMD ${MOONCAKE_STALE_PKG} $PIP_UNINSTALL_SUFFIX || true
-        $PIP_CMD install ${MOONCAKE_PKG} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
+        $PIP_CMD install ${MOONCAKE_PKG} ${MOONCAKE_EXTRA_INDEX} --force-reinstall --no-deps $PIP_INSTALL_SUFFIX
     fi
-    $PIP_CMD install ${MOONCAKE_PKG} ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
+    $PIP_CMD install ${MOONCAKE_PKG} ${MOONCAKE_EXTRA_INDEX} $PIP_INSTALL_SUFFIX
+    $PIP_CMD install ${EXTRA_NVIDIA_SPECS} py-spy scipy huggingface_hub[hf_xet] pytest $PIP_INSTALL_SUFFIX
 
     NIXL_INSTALLED=$(pip show nixl 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")
     NIXL_BIN_INSTALLED=$(pip show "${NIXL_BIN_NAME}" 2>/dev/null | grep "^Version:" | awk '{print $2}' || echo "")


### PR DESCRIPTION
## Motivation

Validate the upcoming **Mooncake 0.3.13 release line** through sglang **CI** before it lands on prod PyPI. This points the CI dependency install at the latest pre-release build on **test.pypi**.

- Package under test: https://test.pypi.org/project/mooncake-transfer-engine/#files
- Pinned version: `0.3.14.dev20260825` (both `mooncake-transfer-engine` and `mooncake-transfer-engine-cuda13` variants are published there)
- Release context: tag `v0.3.13-rc1` on [kvcache-ai/Mooncake `release/v0.3.13`](https://github.com/kvcache-ai/Mooncake/tree/release/v0.3.13)

## Modifications

`scripts/ci/cuda/ci_install_dependency.sh` (`install_extra_deps`):
- Bump `MOONCAKE_VERSION` → `0.3.14.dev20260825`
- Add `--extra-index-url https://test.pypi.org/simple/` to the mooncake installs
- Split the mooncake install off from the other bundled deps (`py-spy scipy huggingface_hub[hf_xet] pytest`) so `uv`'s `--index-strategy unsafe-best-match` can't pull those from test.pypi

Follows the same bump pattern as #32302.

> [!NOTE]
> **Test/validation PR — do not merge as-is.** Before merge, remove the `--extra-index-url https://test.pypi.org/simple/` and pin the final `0.3.13` release once it is on prod PyPI.

## Checklist

- [ ] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/references/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/references/contribution_guide.html#running-unit-tests-adding-tests).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32957056546](https://github.com/sgl-project/sglang/actions/runs/32957056546)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32957056302](https://github.com/sgl-project/sglang/actions/runs/32957056302)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32957056543](https://github.com/sgl-project/sglang/actions/runs/32957056543)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->