### PR TITLE
[diffusion] acceleration: add SeaCache algorithm

### DIFF
--- a/python/sglang/multimodal_gen/configs/sample/sampling_params.py
+++ b/python/sglang/multimodal_gen/configs/sample/sampling_params.py
@@ -238,6 +238,10 @@ class SamplingParams:
     # request; see DenoisingStage._maybe_override_attention_backend.
     attention_backend_override: str | None = None
 
+    # SeaCache parameters
+    enable_seacache: bool = False
+    seacache_params: Any = None  # SeaCacheParams
+
     # Spectrum parameters
     enable_spectrum: bool = False
     spectrum_params: Any = None  # SpectrumParams
@@ -374,6 +378,16 @@ class SamplingParams:
             from sglang.multimodal_gen.configs.sample.spectrum import SpectrumParams
 
             self.spectrum_params = SpectrumParams()
+
+        if self.enable_seacache and isinstance(self.seacache_params, dict):
+            from sglang.multimodal_gen.configs.sample.seacache import SeaCacheParams
+
+            self.seacache_params = SeaCacheParams(**self.seacache_params)
+
+        if self.enable_seacache and self.seacache_params is None:
+            from sglang.multimodal_gen.configs.sample.seacache import SeaCacheParams
+
+            self.seacache_params = SeaCacheParams()
 
     def build_request_extra(self) -> dict[str, Any]:
         """Return optional request-scoped extras for downstream pipeline stages."""
@@ -595,6 +609,14 @@ class SamplingParams:
         if self.enable_teacache and self.enable_spectrum:
             raise ValueError(
                 "enable_teacache and enable_spectrum are mutually exclusive; enable only one."
+            )
+        if self.enable_seacache and self.enable_teacache:
+            raise ValueError(
+                "enable_seacache and enable_teacache are mutually exclusive; enable only one."
+            )
+        if self.enable_seacache and self.enable_spectrum:
+            raise ValueError(
+                "enable_seacache and enable_spectrum are mutually exclusive; enable only one."
             )
 
         RLRolloutArgs.validate_sampling_params(self)
@@ -939,6 +961,25 @@ class SamplingParams:
         add_argument(
             "--attention-backend-override",
             type=str,
+        )
+        add_argument(
+            "--enable-seacache",
+            action="store_true",
+        )
+        add_argument(
+            "--seacache-thresh",
+            "--seacache_thresh",
+            dest="seacache_thresh",
+            type=float,
+            help="SeaCache refresh threshold; larger skips more steps (0 never skips).",
+        )
+        add_argument(
+            "--seacache-norm-mode",
+            "--seacache_norm_mode",
+            dest="seacache_norm_mode",
+            type=str,
+            choices=["mean", "peak", "none"],
+            help="SeaCache filter gain normalization; 'none' reproduces the paper ablation.",
         )
         add_argument(
             "--enable-spectrum",
@@ -1450,6 +1491,26 @@ class SamplingParams:
         }
         if isinstance(cli_args.get("seed"), list) and len(cli_args["seed"]) == 1:
             cli_args["seed"] = cli_args["seed"][0]
+
+        seacache_overrides = {}
+        seacache_flag_map = {
+            "thresh": "seacache_thresh",
+            "norm_mode": "seacache_norm_mode",
+        }
+        for field_name, arg_name in seacache_flag_map.items():
+            if hasattr(args, arg_name) and getattr(args, arg_name) is not None:
+                seacache_overrides[field_name] = getattr(args, arg_name)
+        if seacache_overrides:
+            if not cli_args.get("enable_seacache", False):
+                logger.info(
+                    "SeaCache override flags were provided without --enable-seacache; "
+                    "auto-enabling SeaCache caching."
+                )
+                cli_args["enable_seacache"] = True
+            existing_seacache_params = cli_args.get("seacache_params")
+            if isinstance(existing_seacache_params, dict):
+                seacache_overrides = {**existing_seacache_params, **seacache_overrides}
+            cli_args["seacache_params"] = seacache_overrides
 
         spectrum_overrides = {}
         spectrum_flag_map = {

--- a/python/sglang/multimodal_gen/configs/sample/seacache.py
+++ b/python/sglang/multimodal_gen/configs/sample/seacache.py
@@ -1,0 +1,59 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from sglang.multimodal_gen.configs.sample.sampling_params import CacheParams
+
+_NORM_MODES = ("mean", "peak", "none")
+
+
+@dataclass
+class SeaCacheParams(CacheParams):
+    """
+    Parameters for [SeaCache](https://arxiv.org/abs/2602.18993) spectral-evolution-aware
+    caching.
+
+    SeaCache reuses TeaCache's accumulate-and-refresh rule but measures the
+    step-to-step distance after a timestep-dependent Wiener filter, so the metric
+    tracks content change rather than noise. It needs no per-checkpoint fitted
+    coefficients: `thresh` is the only value worth tuning.
+
+    Attributes:
+        cache_type: (`str`, defaults to `seacache`):
+            A string labeling these parameters as belonging to seacache.
+        thresh (`float`, defaults to `0.3`):
+            Refresh threshold (paper: delta). The filtered relative-L1 distance is
+            accumulated across steps and the denoiser is re-run once the sum reaches
+            `thresh`. Larger values skip more steps.
+        norm_mode (`str`, defaults to `mean`):
+            Filter gain normalization. `mean` gives the filter unit mean gain over the
+            spectrum, which is what makes distances comparable across timesteps and is
+            the only mode any official call site uses. `peak` normalizes the maximum
+            gain to 1 instead; `none` disables normalization and reproduces the
+            paper's *w/o norm* ablation, which it reports as worse.
+
+    CFG branches: SeaCache keeps independent state per classifier-free-guidance
+    branch. Passing a negative prompt turns on two forwards per step and both branches
+    accumulate separately.
+    """
+
+    cache_type: str = "seacache"
+    thresh: float = 0.3
+    norm_mode: str = "mean"
+
+    def __post_init__(self) -> None:
+        if (
+            isinstance(self.thresh, bool)
+            or not isinstance(self.thresh, (int, float))
+            or not math.isfinite(self.thresh)
+        ):
+            raise ValueError("SeaCache thresh must be a finite number.")
+        if self.thresh < 0:
+            raise ValueError("SeaCache thresh must be non-negative.")
+        if self.norm_mode not in _NORM_MODES:
+            raise ValueError(
+                f"SeaCache norm_mode must be one of {_NORM_MODES}, "
+                f"got {self.norm_mode!r}."
+            )

--- a/python/sglang/multimodal_gen/runtime/cache/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/cache/__init__.py
@@ -6,6 +6,7 @@ This module provides various caching strategies to accelerate
 diffusion transformer (DiT) inference:
 
 - TeaCache: Temporal similarity-based caching for diffusion models
+- SeaCache: Spectral-evolution-aware step skipping via a timestep-dependent filter
 - Spectrum: Chebyshev spectral feature forecasting for step skipping
 - cache-dit integration: Block-level caching with DBCache and TaylorSeer
 
@@ -17,6 +18,7 @@ from sglang.multimodal_gen.runtime.cache.cache_dit_integration import (
     enable_cache_on_transformer,
     get_scm_mask,
 )
+from sglang.multimodal_gen.runtime.cache.seacache import SeaCache, apply_sea_filter
 from sglang.multimodal_gen.runtime.cache.spectrum import SpectrumMixin
 from sglang.multimodal_gen.runtime.cache.teacache import TeaCacheContext, TeaCacheMixin
 
@@ -24,6 +26,9 @@ __all__ = [
     # TeaCache (always available)
     "TeaCacheContext",
     "TeaCacheMixin",
+    # SeaCache (always available)
+    "SeaCache",
+    "apply_sea_filter",
     # Spectrum (always available)
     "SpectrumMixin",
     # cache-dit integration (lazy-loaded, requires cache-dit package)

--- a/python/sglang/multimodal_gen/runtime/cache/seacache.py
+++ b/python/sglang/multimodal_gen/runtime/cache/seacache.py
@@ -1,0 +1,325 @@
+# SPDX-License-Identifier: Apache-2.0
+"""
+SeaCache: spectral-evolution-aware step caching for diffusion transformers.
+
+SeaCache reuses TeaCache's accumulate-and-refresh schedule -- accumulate a
+relative-L1 distance between the timestep-modulated inputs of consecutive steps,
+re-run the transformer blocks once the sum reaches a threshold, and otherwise add
+back the cached block-stack residual -- but measures that distance after a
+timestep-dependent Wiener filter instead of on the raw feature.
+
+Diffusion builds low-frequency structure early and refines high-frequency detail
+late, so the optimal linear denoiser's frequency response widens as sampling
+proceeds. Filtering the decision feature with that response makes the distance
+track content change rather than stochastic noise, which yields a schedule that
+concentrates refreshes on the early steps that matter. Unlike TeaCache there are
+no per-checkpoint fitted coefficients.
+
+Reference: SeaCache, Chung et al., CVPR 2026 (https://arxiv.org/abs/2602.18993),
+official implementation at https://github.com/jiwoogit/SeaCache.
+"""
+
+from __future__ import annotations
+
+import msgspec
+import torch
+
+from sglang.multimodal_gen.configs.sample.seacache import SeaCacheParams
+from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+logger = init_logger(__name__)
+
+# Keeps the flow-matching endpoints off the degenerate a=0 / b=0 filters. FLUX's
+# first sigma is exactly 1.0, so this clamp is reached on every run.
+_SIGMA_CLAMP = 1e-6
+
+# Regularizes the power-law signal spectrum at DC. Without it Sx(0) is infinite;
+# with it Sx(0) = 1/eps, which makes the DC gain 1/a -- finite, and large enough
+# that mean normalization still leaves a low-pass shape.
+_SPECTRUM_EPS = 1e-16
+
+_REL_L1_EPS = 1e-16
+
+# Exponent beta of the assumed power-law signal spectrum S(f) ~ |f|^-beta. The paper
+# fixes it per modality rather than tuning it: 2 for images, 3 for video.
+_POWER_EXP_IMAGE = 2.0
+
+
+def ab_from_sigma(sigma: float) -> tuple[float, float]:
+    """Flow-matching mixture coefficients: x_t = a * x_0 + b * noise."""
+    clamped = max(_SIGMA_CLAMP, min(1.0 - _SIGMA_CLAMP, float(sigma)))
+    return 1.0 - clamped, clamped
+
+
+def sea_filter_response(
+    *,
+    shape: torch.Size | tuple[int, ...],
+    dims: tuple[int, ...],
+    a: float,
+    b: float,
+    power_exp: float,
+    norm_mode: str,
+    device: torch.device,
+) -> torch.Tensor:
+    """Separable Wiener gain broadcast over `shape`, one 1-D factor per filtered axis."""
+    response = None
+    for axis in dims:
+        freq = torch.fft.fftfreq(shape[axis], device=device, dtype=torch.float32).abs()
+        signal_power = 1.0 / (freq**power_exp + _SPECTRUM_EPS)
+        gain = (a * signal_power) / (a * a * signal_power + b * b + _SPECTRUM_EPS)
+        view = [1] * len(shape)
+        view[axis] = gain.shape[0]
+        gain = gain.reshape(view)
+        response = gain if response is None else response * gain
+
+    if norm_mode == "mean":
+        return response / response.mean()
+    if norm_mode == "peak":
+        return response / response.amax()
+    return response
+
+
+def apply_sea_filter(
+    x: torch.Tensor,
+    *,
+    a: float,
+    b: float,
+    power_exp: float = 2.0,
+    norm_mode: str = "mean",
+    dims: tuple[int, ...] = (-2, -3),
+) -> torch.Tensor:
+    """Filter `x` along `dims` with the SEA response, in fp32, returning `x.dtype`."""
+    x32 = x.contiguous().to(torch.float32)
+    response = sea_filter_response(
+        shape=x32.shape,
+        dims=dims,
+        a=a,
+        b=b,
+        power_exp=power_exp,
+        norm_mode=norm_mode,
+        device=x32.device,
+    )
+    spectrum = torch.fft.fftn(x32, dim=dims)
+    return torch.fft.ifftn(spectrum * response, dim=dims).real.to(x.dtype)
+
+
+def rel_l1(current: torch.Tensor, previous: torch.Tensor) -> float:
+    """Relative L1 distance, normalized by the previous step's magnitude.
+
+    Reduced in fp32 rather than the bf16 input dtype the reference uses: a
+    bf16-rounded ratio accumulated over tens of steps drifts by a few percent
+    against a threshold of order 0.3.
+    """
+    numerator = (current - previous).abs().float().mean()
+    denominator = previous.abs().float().mean() + _REL_L1_EPS
+    return float(numerator / denominator)
+
+
+class _BranchState(msgspec.Struct):
+    previous_modulated_input: torch.Tensor | None = None
+    previous_residual: torch.Tensor | None = None
+    accumulated_rel_l1_distance: float = 0.0
+    real_steps: int = 0
+    skipped_steps: int = 0
+
+
+class _StepContext(msgspec.Struct):
+    params: SeaCacheParams
+    step: int
+    num_steps: int
+    sigmas: torch.Tensor
+    is_cfg_negative: bool
+    debug: bool
+
+
+class SeaCache:
+    """Per-DiT SeaCache state and skip decision.
+
+    Held by `CachableDiT` and driven by the model's forward, which supplies the
+    block-0 modulated input and the latent grid shape.
+    """
+
+    # Models whose forward is entered once per CFG branch, so each branch needs
+    # its own accumulator. FLUX.1-dev is single-branch by default (embedded
+    # guidance, no negative prompt) but becomes two-branch with --negative-prompt.
+    _CFG_SUPPORTED_PREFIXES = frozenset({"flux"})
+
+    def __init__(self, *, prefix: str) -> None:
+        self.supports_cfg_cache = prefix.lower() in self._CFG_SUPPORTED_PREFIXES
+        self._branches: dict[bool, _BranchState] = {}
+        self.reset()
+
+    def reset(self) -> None:
+        self._branches = {False: _BranchState(), True: _BranchState()}
+
+    def should_run_blocks(
+        self, *, modulated_inp: torch.Tensor, grid_hw: tuple[int, int]
+    ) -> bool:
+        context = self._resolve()
+        if context is None:
+            return True
+
+        if context.step == 0 and not context.is_cfg_negative:
+            self.reset()
+
+        state = self._branch_state(context)
+        should_run = self._decide(
+            context=context, state=state, modulated_inp=modulated_inp, grid_hw=grid_hw
+        )
+
+        if should_run:
+            state.real_steps += 1
+        else:
+            state.skipped_steps += 1
+        if context.step == context.num_steps - 1:
+            self._log_summary(context=context, state=state)
+        return should_run
+
+    def record_residual(
+        self, *, hidden_states: torch.Tensor, original_hidden_states: torch.Tensor
+    ) -> None:
+        context = self._resolve()
+        if context is None:
+            return
+        self._branch_state(context).previous_residual = (
+            hidden_states - original_hidden_states
+        )
+
+    def retrieve(self, *, hidden_states: torch.Tensor) -> torch.Tensor:
+        context = self._resolve()
+        return hidden_states + self._branch_state(context).previous_residual
+
+    def _branch_state(self, context: _StepContext) -> _BranchState:
+        if self.supports_cfg_cache:
+            return self._branches[context.is_cfg_negative]
+        return self._branches[False]
+
+    def _decide(
+        self,
+        *,
+        context: _StepContext,
+        state: _BranchState,
+        modulated_inp: torch.Tensor,
+        grid_hw: tuple[int, int],
+    ) -> bool:
+        # The reference stores the unfiltered feature on force-computed steps and
+        # the filtered one elsewhere, so the first gated distance compares across
+        # representations. Kept as-is: this is the schedule the published FLUX
+        # numbers come from.
+        last_step = context.num_steps - 1
+        if (
+            context.step == 0
+            or context.step == last_step
+            or state.previous_modulated_input is None
+        ):
+            state.accumulated_rel_l1_distance = 0.0
+            state.previous_modulated_input = modulated_inp
+            return True
+
+        a, b = ab_from_sigma(float(context.sigmas[context.step]))
+        height, width = grid_hw
+        filtered = apply_sea_filter(
+            modulated_inp.reshape(modulated_inp.shape[0], height, width, -1),
+            a=a,
+            b=b,
+            power_exp=_POWER_EXP_IMAGE,
+            norm_mode=context.params.norm_mode,
+        ).reshape(modulated_inp.shape)
+
+        distance = state.accumulated_rel_l1_distance + rel_l1(
+            filtered, state.previous_modulated_input
+        )
+        # Ranks must agree: the blocks contain collectives, so one rank skipping
+        # while another computes deadlocks. Syncing the accumulator rather than
+        # the boolean keeps the two branches' state in lockstep too.
+        state.accumulated_rel_l1_distance = _sync_distance(
+            distance, device=modulated_inp.device
+        )
+        state.previous_modulated_input = filtered
+
+        should_run = state.accumulated_rel_l1_distance >= context.params.thresh
+        if should_run:
+            state.accumulated_rel_l1_distance = 0.0
+        return should_run
+
+    def _resolve(self) -> _StepContext | None:
+        from sglang.multimodal_gen.runtime.managers.forward_context import (
+            get_forward_context,
+        )
+        from sglang.multimodal_gen.runtime.server_args import get_global_server_args
+
+        forward_context = get_forward_context()
+        batch = forward_context.forward_batch
+        if (
+            batch is None
+            or not batch.enable_seacache
+            or batch.seacache_params is None
+            # Warmup and breakable-CUDA-graph capture both issue several forwards
+            # under one timestep index and carry a truncated step count.
+            or batch.is_warmup
+        ):
+            return None
+
+        if batch.progressive_mode != "fullres":
+            logger.warning_once(
+                "SeaCache is disabled for progressive resolution: the latent shape "
+                "changes between stages and step indices can be revisited."
+            )
+            return None
+
+        if get_global_server_args().enable_breakable_cuda_graph:
+            logger.warning_once(
+                "SeaCache is disabled under --enable-breakable-cuda-graph: a replayed "
+                "graph freezes the skip decision taken at capture time."
+            )
+            return None
+
+        if batch.did_sp_shard_latents:
+            raise RuntimeError(
+                "SeaCache is not compatible with sequence parallelism: its filter "
+                "needs the full 2-D latent grid, but each rank holds a contiguous "
+                "slice of rows. Drop --ulysses-degree / --ring-degree, or use "
+                "--tp-size to spend the extra GPUs on tensor parallelism instead."
+            )
+
+        return _StepContext(
+            params=batch.seacache_params,
+            step=forward_context.current_timestep,
+            num_steps=batch.num_inference_steps,
+            sigmas=batch.scheduler.sigmas,
+            is_cfg_negative=batch.is_cfg_negative,
+            debug=batch.debug,
+        )
+
+    def _log_summary(self, *, context: _StepContext, state: _BranchState) -> None:
+        if not context.debug:
+            return
+        total = state.real_steps + state.skipped_steps
+        if total == 0:
+            return
+        branch = "negative" if context.is_cfg_negative else "positive"
+        logger.info(
+            "[SeaCache] %s branch: %d/%d steps refreshed (refresh ratio %.2f), "
+            "thresh=%.3f",
+            branch,
+            state.real_steps,
+            total,
+            state.real_steps / total,
+            context.params.thresh,
+        )
+
+
+def _sync_distance(distance: float, *, device: torch.device) -> float:
+    from sglang.multimodal_gen.runtime.distributed import (
+        get_tp_group,
+        model_parallel_is_initialized,
+    )
+
+    if not model_parallel_is_initialized():
+        return distance
+    group = get_tp_group()
+    if group.world_size == 1:
+        return distance
+    buffer = torch.tensor([distance], dtype=torch.float64, device=device)
+    group.broadcast(buffer, src=0)
+    return float(buffer[0])

--- a/python/sglang/multimodal_gen/runtime/disaggregation/scheduler_mixin.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/scheduler_mixin.py
@@ -108,12 +108,12 @@ _EXCLUDE_FIELDS = frozenset(
 )
 
 # SamplingParams fields that are reconstructed locally or not JSON-safe.
+# teacache_params carries callables; the rest cross as plain data.
 _SAMPLING_PARAMS_EXCLUDE_FIELDS = frozenset(
     {
         "data_type",
         "supported_resolutions",
         "teacache_params",
-        "seacache_params",
     }
 )
 
@@ -127,6 +127,8 @@ def _is_tensor_like(value) -> bool:
 
 
 def _to_json_serializable(value):
+    if dataclasses.is_dataclass(value) and not isinstance(value, type):
+        return dataclasses.asdict(value)
     if isinstance(value, (torch.Tensor, np.ndarray)):
         return value.tolist()
     if isinstance(value, np.generic):
@@ -1311,7 +1313,9 @@ class SchedulerDisaggMixin:
             with self._disagg_trace_dispatch(req):
                 self.worker.execute_forward([req])
 
-    def _build_disagg_req(self: Scheduler, scalar_fields: dict, tensors: dict) -> Req:
+    def _build_disagg_req(
+        self: Scheduler | None, scalar_fields: dict, tensors: dict
+    ) -> Req:
         """Reconstruct a Req from transfer scalar fields and loaded GPU tensors.
 
         Initializes all dataclass field defaults first, then overlays
@@ -1328,14 +1332,25 @@ class SchedulerDisaggMixin:
                 object.__setattr__(req, f.name, f.default)
             elif f.default_factory is not dataclasses.MISSING:
                 object.__setattr__(req, f.name, f.default_factory())
-        # Ensure sampling_params is not None so __getattr__ delegation works
-        object.__setattr__(req, "sampling_params", SamplingParams())
+        # Model subclass, not the base: only fields differing from the
+        # subclass defaults are transferred. self is None in unit tests.
+        if self is not None:
+            from sglang.multimodal_gen.runtime.warmup_request_builder import (
+                get_model_sampling_defaults,
+            )
+
+            base_sampling_params = get_model_sampling_defaults(self.server_args)
+        else:
+            base_sampling_params = SamplingParams()
+        object.__setattr__(req, "sampling_params", base_sampling_params)
         # Restore _extra_* prefixed fields into req.extra dict
         extra_keys = [k for k in scalar_fields if k.startswith("_extra_")]
         for key in extra_keys:
             req.extra[key[len("_extra_") :]] = scalar_fields.pop(key)
         for key, value in scalar_fields.items():
             setattr(req, key, value)
+        # Re-finalize so cache-param dicts get rehydrated.
+        req.sampling_params.__post_init__()
         # Set tensor fields
         for key, value in tensors.items():
             setattr(req, key, value)

--- a/python/sglang/multimodal_gen/runtime/disaggregation/scheduler_mixin.py
+++ b/python/sglang/multimodal_gen/runtime/disaggregation/scheduler_mixin.py
@@ -113,6 +113,7 @@ _SAMPLING_PARAMS_EXCLUDE_FIELDS = frozenset(
         "data_type",
         "supported_resolutions",
         "teacache_params",
+        "seacache_params",
     }
 )
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/base.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/base.py
@@ -8,6 +8,7 @@ import torch
 from torch import nn
 
 from sglang.multimodal_gen.configs.models.dits.base import DiTArchConfig, DiTConfig
+from sglang.multimodal_gen.runtime.cache.seacache import SeaCache
 
 # NOTE: SpectrumMixin lives in runtime.cache.spectrum
 from sglang.multimodal_gen.runtime.cache.spectrum import SpectrumMixin
@@ -117,7 +118,8 @@ class CachableDiT(SpectrumMixin, TeaCacheMixin, BaseDiT):
     Base class for DiT models that support inference-time cache accelerators.
 
     Inherits ``SpectrumMixin`` (Chebyshev step skipping) and ``TeaCacheMixin``
-    (temporal L1 similarity caching) plus ``BaseDiT`` core functionality.
+    (temporal L1 similarity caching) plus ``BaseDiT`` core functionality, and holds
+    a ``SeaCache`` collaborator (spectral-evolution-aware step skipping).
 
     """
 
@@ -135,6 +137,7 @@ class CachableDiT(SpectrumMixin, TeaCacheMixin, BaseDiT):
         super().__init__(config, **kwargs)
         self._init_spectrum_state()
         self._init_teacache_state()
+        self.seacache = SeaCache(prefix=config.prefix)
 
     @classmethod
     def get_nunchaku_quant_rules(cls) -> dict[str, dict[str, Any]]:

--- a/python/sglang/multimodal_gen/runtime/models/dits/flux.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/flux.py
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import torch
 import torch.nn as nn
@@ -90,7 +90,11 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload im
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.models.dits.common import get_qkv_projections
 from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+
+if TYPE_CHECKING:
+    from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 
 logger = init_logger(__name__)  # pylint: disable=invalid-name
 
@@ -1241,6 +1245,34 @@ class FluxTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
             "single_transformer_blocks",
         ]
 
+    def _seacache_should_run_blocks(
+        self,
+        *,
+        hidden_states: torch.Tensor,
+        temb: torch.Tensor,
+        forward_batch: "Req",
+    ) -> bool:
+        """Ask SeaCache whether the transformer blocks must run this step."""
+        # Block 0's first adaLN modulation is SeaCache's decision feature. Recomputing
+        # it here costs one LayerNorm + one 3072->18432 projection; the block recomputes
+        # its own copy when it runs.
+        modulated_inp = self.transformer_blocks[0].norm1(hidden_states, emb=temb)[0]
+        # hidden_states holds image tokens only -- text stays in encoder_hidden_states
+        # and is concatenated inside the blocks -- so the cached residual covers the
+        # whole stream that norm_out/proj_out consume.
+        vae_scale_factor = (
+            get_global_server_args().pipeline_config.vae_config.arch_config.vae_scale_factor
+        )
+        patched = vae_scale_factor * 2
+        grid_hw = (
+            int(forward_batch.height) // patched,
+            int(forward_batch.width) // patched,
+        )
+        assert grid_hw[0] * grid_hw[1] == int(forward_batch.raw_latent_shape[1])
+        return self.seacache.should_run_blocks(
+            modulated_inp=modulated_inp, grid_hw=grid_hw
+        )
+
     def forward(
         self,
         hidden_states: torch.Tensor,
@@ -1347,10 +1379,18 @@ class FluxTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
 
         forward_batch = get_forward_context().forward_batch
         spectrum_enabled = forward_batch is not None and forward_batch.enable_spectrum
-        run_transformer_blocks = (
-            self.begin_spectrum_step() if spectrum_enabled else True
-        )
+        seacache_enabled = forward_batch is not None and forward_batch.enable_seacache
+        run_transformer_blocks = True
+        if spectrum_enabled:
+            run_transformer_blocks = self.begin_spectrum_step()
+        elif seacache_enabled:
+            run_transformer_blocks = self._seacache_should_run_blocks(
+                hidden_states=hidden_states, temb=temb, forward_batch=forward_batch
+            )
         if run_transformer_blocks:
+            # SeaCache caches the delta across the block stack, so snapshot the
+            # entry value; norm_out/proj_out below stay outside the cached span.
+            original_hidden_states = hidden_states.clone() if seacache_enabled else None
             for block in self.transformer_blocks:
                 encoder_hidden_states, hidden_states = block(
                     hidden_states=hidden_states,
@@ -1371,9 +1411,16 @@ class FluxTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
                 )
             if spectrum_enabled:
                 self.spectrum_record_features(hidden_states)
+            elif seacache_enabled:
+                self.seacache.record_residual(
+                    hidden_states=hidden_states,
+                    original_hidden_states=original_hidden_states,
+                )
         else:
             if spectrum_enabled:
                 hidden_states = self.spectrum_predict_features(hidden_states)
+            elif seacache_enabled:
+                hidden_states = self.seacache.retrieve(hidden_states=hidden_states)
 
         hidden_states = self.norm_out(hidden_states, temb)
 

--- a/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/weights_updater.py
@@ -57,6 +57,7 @@ from sglang.multimodal_gen.runtime.loader.weight_utils import (
 from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload import (
     is_layerwise_offloaded_module,
 )
+from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
 from sglang.multimodal_gen.runtime.pipelines.diffusers_pipeline import DiffusersPipeline
 from sglang.multimodal_gen.runtime.pipelines_core.lora.pipeline import (
     LoRAPipeline,
@@ -417,6 +418,8 @@ class WeightsUpdater:
             for _, module in modules_to_update:
                 if isinstance(module, TeaCacheMixin):
                     module.reset_teacache_state()
+                if isinstance(module, CachableDiT):
+                    module.seacache.reset()
 
         logger.info(message)
         return success, message

--- a/python/sglang/multimodal_gen/test/unit/test_sampling_params.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sampling_params.py
@@ -122,6 +122,23 @@ class TestSamplingParamsValidate(unittest.TestCase):
             with self.assertRaises(ValueError):
                 SpectrumParams(**kwargs)
 
+    def test_seacache_is_mutually_exclusive_with_the_other_step_caches(self):
+        with self.assertRaisesRegex(
+            ValueError, r"enable_seacache and enable_teacache are mutually exclusive"
+        ):
+            SamplingParams(enable_seacache=True, enable_teacache=True)
+        with self.assertRaisesRegex(
+            ValueError, r"enable_seacache and enable_spectrum are mutually exclusive"
+        ):
+            SamplingParams(enable_seacache=True, enable_spectrum=True)
+
+    def test_seacache_dict_is_validated_when_sampling_params_constructs_it(self):
+        with self.assertRaisesRegex(ValueError, "norm_mode"):
+            SamplingParams(
+                enable_seacache=True,
+                seacache_params={"norm_mode": "lowpass"},
+            )
+
     def test_spectrum_dict_is_validated_when_sampling_params_constructs_it(self):
         with self.assertRaisesRegex(ValueError, "history_size"):
             SamplingParams(
@@ -370,6 +387,29 @@ class TestSamplingParamsCliArgs(unittest.TestCase):
                 "tau_num_steps": 42,
             },
         )
+
+    def test_get_cli_args_maps_seacache_prefixed_flags(self):
+        kwargs = self._parse_cli_kwargs(
+            [
+                "--enable-seacache",
+                "--seacache-thresh",
+                "0.6",
+                "--seacache-norm-mode",
+                "none",
+            ]
+        )
+
+        self.assertTrue(kwargs["enable_seacache"])
+        self.assertEqual(
+            kwargs["seacache_params"],
+            {"thresh": 0.6, "norm_mode": "none"},
+        )
+
+    def test_seacache_override_flag_implicitly_enables_the_cache(self):
+        kwargs = self._parse_cli_kwargs(["--seacache-thresh", "0.215"])
+
+        self.assertTrue(kwargs["enable_seacache"])
+        self.assertEqual(kwargs["seacache_params"], {"thresh": 0.215})
 
     def test_qwen_image_cli_path_preserves_model_defaults(self):
         params = self._make_qwen_image_params([])

--- a/python/sglang/multimodal_gen/test/unit/test_seacache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_seacache.py
@@ -3,6 +3,7 @@
 
 import contextlib
 import dataclasses
+import json
 import unittest
 from types import SimpleNamespace
 from unittest.mock import patch
@@ -17,6 +18,12 @@ from sglang.multimodal_gen.runtime.cache.seacache import (
     apply_sea_filter,
     sea_filter_response,
 )
+from sglang.multimodal_gen.runtime.disaggregation.scheduler_mixin import (
+    SchedulerDisaggMixin,
+    extract_transfer_fields,
+)
+from sglang.multimodal_gen.runtime.disaggregation.transport.codec import pack_tensors
+from sglang.multimodal_gen.runtime.pipelines_core import Req
 
 _GRID = (8, 8)
 _CHANNELS = 4
@@ -332,6 +339,53 @@ class TestSeaCacheParamsValidation(unittest.TestCase):
         for name in ("enable_seacache", "seacache_params"):
             with self.subTest(field=name):
                 self.assertFalse(fields[name].metadata.get("batch_sig_exclude"))
+
+
+class TestSeaCacheDisaggTransfer(unittest.TestCase):
+    """Dropped params at the disagg hop silently disable SeaCache."""
+
+    @staticmethod
+    def _scheduler():
+        # Resolves FluxSamplingParams via the registry, no model files.
+        return SimpleNamespace(
+            server_args=SimpleNamespace(
+                pipeline_class_name="ComfyUIFluxPipeline",
+                model_path="/nonexistent",
+                backend="auto",
+                model_id=None,
+            )
+        )
+
+    def test_non_default_threshold_round_trips(self) -> None:
+        req = Req(
+            request_id="seacache-disagg",
+            prompt="x",
+            sampling_params=SamplingParams(
+                enable_seacache=True,
+                seacache_params=SeaCacheParams(thresh=0.42, norm_mode="peak"),
+            ),
+        )
+
+        _, scalar_fields = extract_transfer_fields(req)
+        # pack_tensors is the RDMA metadata frame's json path
+        metadata_bytes, _ = pack_tensors({}, scalar_fields)
+        decoded = json.loads(metadata_bytes.decode("utf-8"))["scalar_fields"]
+        rebuilt = SchedulerDisaggMixin._build_disagg_req(
+            self._scheduler(), dict(decoded), {}
+        )
+
+        self.assertIsInstance(rebuilt.seacache_params, SeaCacheParams)
+        self.assertEqual(rebuilt.seacache_params.thresh, 0.42)
+        self.assertEqual(rebuilt.seacache_params.norm_mode, "peak")
+
+    def test_model_subclass_defaults_are_reconstructed(self) -> None:
+        """num_inference_steps equals the subclass default, so it is never
+        transferred."""
+        rebuilt = SchedulerDisaggMixin._build_disagg_req(
+            self._scheduler(), {"request_id": "t", "prompt": "x"}, {}
+        )
+
+        self.assertEqual(rebuilt.num_inference_steps, 50)
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_seacache.py
+++ b/python/sglang/multimodal_gen/test/unit/test_seacache.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for runtime/cache/seacache."""
+
+import contextlib
+import dataclasses
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.multimodal_gen.configs.sample.sampling_params import SamplingParams
+from sglang.multimodal_gen.configs.sample.seacache import SeaCacheParams
+from sglang.multimodal_gen.runtime.cache.seacache import (
+    SeaCache,
+    ab_from_sigma,
+    apply_sea_filter,
+    sea_filter_response,
+)
+
+_GRID = (8, 8)
+_CHANNELS = 4
+_TOKENS = _GRID[0] * _GRID[1]
+
+
+def _linspace_sigmas(num_steps: int) -> torch.Tensor:
+    """Descending sigmas with the terminal zero a flow-matching scheduler appends."""
+    return torch.cat([torch.linspace(1.0, 1.0 / num_steps, num_steps), torch.zeros(1)])
+
+
+def _fake_batch(**overrides):
+    batch = SimpleNamespace(
+        enable_seacache=True,
+        seacache_params=SeaCacheParams(),
+        is_warmup=False,
+        progressive_mode="fullres",
+        did_sp_shard_latents=False,
+        is_cfg_negative=False,
+        debug=False,
+        num_inference_steps=6,
+        scheduler=SimpleNamespace(sigmas=_linspace_sigmas(6)),
+    )
+    for key, value in overrides.items():
+        setattr(batch, key, value)
+    return batch
+
+
+@contextlib.contextmanager
+def _forward_context(*, batch, step):
+    context = SimpleNamespace(current_timestep=step, forward_batch=batch)
+    server_args = SimpleNamespace(enable_breakable_cuda_graph=False)
+    with (
+        patch(
+            "sglang.multimodal_gen.runtime.managers.forward_context.get_forward_context",
+            return_value=context,
+        ),
+        patch(
+            "sglang.multimodal_gen.runtime.server_args.get_global_server_args",
+            return_value=server_args,
+        ),
+    ):
+        yield
+
+
+def _run_trajectory(cache, *, batch, features):
+    """Drive one full denoising trajectory; return (decisions, accumulator history)."""
+    decisions = []
+    accumulators = []
+    for step, feature in enumerate(features):
+        with _forward_context(batch=batch, step=step):
+            ran = cache.should_run_blocks(modulated_inp=feature, grid_hw=_GRID)
+            if ran:
+                cache.record_residual(
+                    hidden_states=feature + 1.0, original_hidden_states=feature
+                )
+        decisions.append(ran)
+        branch = cache._branches[batch.is_cfg_negative]
+        accumulators.append(branch.accumulated_rel_l1_distance)
+    return decisions, accumulators
+
+
+def _constant_features(num_steps: int) -> list[torch.Tensor]:
+    torch.manual_seed(0)
+    feature = torch.randn(1, _TOKENS, _CHANNELS)
+    return [feature.clone() for _ in range(num_steps)]
+
+
+class TestSeaFilter(unittest.TestCase):
+    def test_normalization_pins_the_filter_gain(self) -> None:
+        """Mean mode gives unit mean gain, peak mode unit maximum gain."""
+        for sigma in (0.9, 0.5, 0.1):
+            a, b = ab_from_sigma(sigma)
+            mean_response = sea_filter_response(
+                shape=(1, 32, 32, 1),
+                dims=(-2, -3),
+                a=a,
+                b=b,
+                power_exp=2.0,
+                norm_mode="mean",
+                device=torch.device("cpu"),
+            )
+            self.assertAlmostEqual(mean_response.mean().item(), 1.0, places=5)
+            peak_response = sea_filter_response(
+                shape=(1, 32, 32, 1),
+                dims=(-2, -3),
+                a=a,
+                b=b,
+                power_exp=2.0,
+                norm_mode="peak",
+                device=torch.device("cpu"),
+            )
+            self.assertAlmostEqual(peak_response.amax().item(), 1.0, places=5)
+
+    def test_passband_widens_as_the_signal_coefficient_grows(self) -> None:
+        """Spectral evolution: later steps must retain more high-frequency energy.
+
+        This is the property the method rests on, and the only guard against an
+        inverted filter (swapped a/b, or the complementary 1-SEA response).
+        """
+        size = 32
+        freq = torch.fft.fftfreq(size).abs()
+        radius = (freq.reshape(-1, 1) ** 2 + freq.reshape(1, -1) ** 2).sqrt()
+        high = radius > 0.25
+
+        gains = []
+        for sigma in (0.95, 0.8, 0.6, 0.4, 0.2, 0.05):
+            a, b = ab_from_sigma(sigma)
+            response = sea_filter_response(
+                shape=(1, size, size, 1),
+                dims=(-2, -3),
+                a=a,
+                b=b,
+                power_exp=2.0,
+                norm_mode="mean",
+                device=torch.device("cpu"),
+            ).squeeze()
+            gains.append((response[high].mean() / response.mean()).item())
+
+        self.assertEqual(gains, sorted(gains))
+        self.assertLess(gains[0], gains[-1])
+
+    def test_terminal_sigma_stays_finite(self) -> None:
+        """FLUX's first sigma is exactly 1.0, which without clamping gives a=0."""
+        a, b = ab_from_sigma(1.0)
+        self.assertGreater(a, 0.0)
+        filtered = apply_sea_filter(torch.randn(1, 16, 16, 4), a=a, b=b)
+        self.assertTrue(torch.isfinite(filtered).all())
+
+
+class TestSeaCacheSchedule(unittest.TestCase):
+    def test_zero_threshold_never_skips(self) -> None:
+        """thresh=0 must reduce to the uncached trajectory; it is the A/B control."""
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch(seacache_params=SeaCacheParams(thresh=0.0))
+        decisions, _ = _run_trajectory(
+            cache, batch=batch, features=_constant_features(6)
+        )
+        self.assertEqual(decisions, [True] * 6)
+
+    def test_large_threshold_skips_every_interior_step(self) -> None:
+        """First and last step always refresh; everything between is skippable."""
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch(seacache_params=SeaCacheParams(thresh=1e9))
+        decisions, _ = _run_trajectory(
+            cache, batch=batch, features=_constant_features(6)
+        )
+        self.assertEqual(decisions, [True, False, False, False, False, True])
+
+    def test_accumulator_grows_on_skip_and_clears_on_refresh(self) -> None:
+        """The accumulated distance is what makes consecutive skips progressively
+        harder; resetting it on a skip would uncap the skip run."""
+        num_steps = 20
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch(
+            seacache_params=SeaCacheParams(thresh=0.3),
+            num_inference_steps=num_steps,
+            scheduler=SimpleNamespace(sigmas=_linspace_sigmas(num_steps)),
+        )
+        decisions, accumulators = _run_trajectory(
+            cache, batch=batch, features=_constant_features(num_steps)
+        )
+        interior = decisions[1:-1]
+        self.assertIn(False, interior, "no skip: threshold too low for this schedule")
+        self.assertIn(
+            True, interior, "no refresh: threshold too high for this schedule"
+        )
+        for step in range(1, len(decisions)):
+            if decisions[step]:
+                self.assertEqual(accumulators[step], 0.0)
+            else:
+                self.assertGreater(accumulators[step], accumulators[step - 1])
+
+    def test_retrieve_adds_the_cached_residual(self) -> None:
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch(seacache_params=SeaCacheParams(thresh=1e9))
+        features = _constant_features(6)
+        with _forward_context(batch=batch, step=0):
+            cache.should_run_blocks(modulated_inp=features[0], grid_hw=_GRID)
+            cache.record_residual(
+                hidden_states=features[0] + 3.0, original_hidden_states=features[0]
+            )
+        with _forward_context(batch=batch, step=1):
+            self.assertFalse(
+                cache.should_run_blocks(modulated_inp=features[1], grid_hw=_GRID)
+            )
+            retrieved = cache.retrieve(hidden_states=features[1])
+        torch.testing.assert_close(retrieved, features[1] + 3.0)
+
+    def test_second_trajectory_starts_clean(self) -> None:
+        """State must not leak across generations on a reused module."""
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch(seacache_params=SeaCacheParams(thresh=1e9))
+        first, _ = _run_trajectory(cache, batch=batch, features=_constant_features(6))
+        second, _ = _run_trajectory(cache, batch=batch, features=_constant_features(6))
+        self.assertEqual(first, second)
+
+    def test_cfg_branches_accumulate_independently(self) -> None:
+        """A shared accumulator would let the negative branch trigger positive
+        refreshes, which is how counter-parity implementations get this wrong."""
+        cache = SeaCache(prefix="flux")
+        params = SeaCacheParams(thresh=1e9)
+        positive = _fake_batch(seacache_params=params, is_cfg_negative=False)
+        negative = _fake_batch(seacache_params=params, is_cfg_negative=True)
+        features = _constant_features(6)
+
+        for step in range(6):
+            for batch in (positive, negative):
+                with _forward_context(batch=batch, step=step):
+                    ran = cache.should_run_blocks(
+                        modulated_inp=features[step], grid_hw=_GRID
+                    )
+                    if ran:
+                        cache.record_residual(
+                            hidden_states=features[step] + 1.0,
+                            original_hidden_states=features[step],
+                        )
+
+        for is_negative in (False, True):
+            branch = cache._branches[is_negative]
+            self.assertEqual(branch.real_steps, 2, f"negative={is_negative}")
+            self.assertEqual(branch.skipped_steps, 4, f"negative={is_negative}")
+
+    def test_single_branch_model_shares_one_accumulator(self) -> None:
+        """Models outside _CFG_SUPPORTED_PREFIXES must not touch negative state."""
+        cache = SeaCache(prefix="qwenimage")
+        self.assertFalse(cache.supports_cfg_cache)
+        batch = _fake_batch(
+            seacache_params=SeaCacheParams(thresh=1e9), is_cfg_negative=True
+        )
+        _run_trajectory(cache, batch=batch, features=_constant_features(6))
+        self.assertEqual(cache._branches[True].real_steps, 0)
+        self.assertGreater(cache._branches[False].real_steps, 0)
+
+
+class TestSeaCacheBailOuts(unittest.TestCase):
+    def test_warmup_request_leaves_state_untouched(self) -> None:
+        """Warmup and CUDA-graph capture issue several forwards under one timestep
+        and carry a truncated step count, so they must not advance the schedule."""
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch(is_warmup=True, num_inference_steps=1)
+        decisions, _ = _run_trajectory(
+            cache, batch=batch, features=_constant_features(4)
+        )
+        self.assertEqual(decisions, [True] * 4)
+        branch = cache._branches[False]
+        self.assertIsNone(branch.previous_modulated_input)
+        self.assertIsNone(branch.previous_residual)
+        self.assertEqual(branch.real_steps, 0)
+
+    def test_disabled_request_runs_every_step(self) -> None:
+        cache = SeaCache(prefix="flux")
+        for batch in (
+            _fake_batch(enable_seacache=False),
+            _fake_batch(seacache_params=None),
+            _fake_batch(progressive_mode="dct"),
+        ):
+            decisions, _ = _run_trajectory(
+                cache, batch=batch, features=_constant_features(4)
+            )
+            self.assertEqual(decisions, [True] * 4)
+
+    def test_sequence_parallel_shard_is_rejected(self) -> None:
+        """Each rank holds a row slice, so the 2-D filter would silently see a
+        sub-image instead of the latent grid."""
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch(did_sp_shard_latents=True)
+        with _forward_context(batch=batch, step=0):
+            with self.assertRaisesRegex(RuntimeError, "sequence parallelism"):
+                cache.should_run_blocks(
+                    modulated_inp=_constant_features(1)[0], grid_hw=_GRID
+                )
+
+    def test_breakable_cuda_graph_disables_the_gate(self) -> None:
+        """A replayed graph freezes whichever branch was taken at capture time."""
+        cache = SeaCache(prefix="flux")
+        batch = _fake_batch()
+        context = SimpleNamespace(current_timestep=0, forward_batch=batch)
+        server_args = SimpleNamespace(enable_breakable_cuda_graph=True)
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.managers.forward_context.get_forward_context",
+                return_value=context,
+            ),
+            patch(
+                "sglang.multimodal_gen.runtime.server_args.get_global_server_args",
+                return_value=server_args,
+            ),
+        ):
+            self.assertTrue(
+                cache.should_run_blocks(
+                    modulated_inp=_constant_features(1)[0], grid_hw=_GRID
+                )
+            )
+
+
+class TestSeaCacheParamsValidation(unittest.TestCase):
+    def test_invalid_controls_are_rejected(self) -> None:
+        for kwargs in (
+            {"thresh": -0.1},
+            {"thresh": float("nan")},
+            {"thresh": float("inf")},
+            {"norm_mode": "lowpass"},
+        ):
+            with self.subTest(**kwargs):
+                with self.assertRaises(ValueError):
+                    SeaCacheParams(**kwargs)
+
+    def test_cache_fields_stay_in_batch_signature(self) -> None:
+        """batch_sig_exclude would let requests with different cache settings share
+        a dynamic batch, which changes generated output."""
+        fields = {field.name: field for field in dataclasses.fields(SamplingParams)}
+        for name in ("enable_seacache", "seacache_params"):
+            with self.subTest(field=name):
+                self.assertFalse(fields[name].metadata.get("batch_sig_exclude"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds SeaCache ([CVPR 2026](https://arxiv.org/abs/2602.18993), [official code](https://github.com/jiwoogit/SeaCache)) as a fourth diffusion cache strategy, wired into the FLUX.1-dev DiT.

SeaCache keeps TeaCache's accumulate-and-refresh rule but measures the step-to-step distance *after* a timestep-dependent Wiener filter, so the metric tracks content change instead of noise. It needs no per-checkpoint fitted coefficients — one threshold controls the whole trade-off.

```bash
sglang generate --model-path black-forest-labs/FLUX.1-dev \
  --prompt "..." --enable-seacache --seacache-thresh 0.3
```

On FLUX.1-dev at 1024x1024 / 50 steps, `--seacache-thresh 0.3` cuts denoise time **56.5%** (6572 ms -> 2859 ms) at 28.96 dB PSNR against the uncached output.

## How it works

Diffusion establishes low-frequency structure early and refines high-frequency detail later, so the band the denoiser is working on moves as sampling proceeds. Per step, SeaCache builds the Wiener response of the optimal linear denoiser at the current noise level, applies it to the timestep-modulated input of transformer block 0, and accumulates the relative L1 distance between consecutive filtered features. Below the threshold the block stack is skipped and the cached residual is added back; at or above it the blocks run and the accumulator resets. First and last step always run.

## Performance

`compare_perf.py`, FLUX.1-dev, 1024x1024, 50 steps, seed 42, 1x H100, `quality=lossless`, `--warmup-mode request`, `SGLANG_DIFFUSION_SYNC_STAGE_PROFILING=1`, `--backend sglang` pinned.

| Config | DenoisingStage | vs baseline | E2E | vs baseline |
| --- | --- | --- | --- | --- |
| baseline | 6572 ms | - | 6858 ms | - |
| `--seacache-thresh 0.215` | 3755 ms | -42.9% | 4044 ms | -41.0% |
| `--seacache-thresh 0.30` | 2859 ms | -56.5% | 3152 ms | -54.0% |
| `--seacache-thresh 0.60` | 1775 ms | -73.0% | 2061 ms | -69.9% |

Peak reserved VRAM grows 28540 -> 28592 MB (+52 MB: one cached residual plus transient FFT buffers).

## Quality, and how it compares to the other step caches

25 DrawBench-style prompts, 1024x1024, 50 steps, seed 42, metrics against the uncached run of the same prompt and seed:

| Config           | Denoise | Refresh | PSNR  | SSIM  | LPIPS | Peak MB |
| ------------------| ---------| ---------| -------| -------| -------| ---------|
| baseline         | 6606 ms | 1.00    | -     | -     | -     | 28540   |
| seacache 0.215   | 3550 ms | 0.53    | 31.97 | 0.947 | 0.043 | 28592   |
| seacache 0.30    | 2839 ms | 0.42    | 28.96 | 0.917 | 0.071 | 28592   |
| seacache 0.60    | 1793 ms | 0.26    | 22.77 | 0.828 | 0.182 | 28592   |

### vs TeaCache: SeaCache wins decisively

At matched refresh ratio. Each SeaCache threshold was tuned so its measured refresh ratio lands on the corresponding TeaCache operating point:

| Refresh  | TeaCache PSNR | SeaCache PSNR | Delta        | TeaCache LPIPS | SeaCache LPIPS |
| --------------------------------| ---------------| ---------------| --------------| ----------------| ----------------|
| 0.52                   | 21.65         | 31.47         | **+9.82 dB** | 0.172          | 0.046          |
| 0.38                   | 19.08         | 27.78         | **+8.69 dB** | 0.262          | 0.087          |
| 0.30                   | 17.77         | 24.82         | **+7.05 dB** | 0.313          | 0.139          |


### Why: the schedules differ in shape, not just in rate

Refresh pattern for one prompt over 50 steps (`R` = blocks ran, `.` = skipped):

```
teacache 0.25    RR.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R.R   gaps {1,2}
teacache 0.80    R...R....R....R....R....R....R....R....R...R...R.R   gaps {2,4,5}
seacache 0.215   RRRRRRRRRR.R.R.R.RR.R..R..R..R..R..R..R..R..R.R.RR   gaps {1,2,3}
seacache 0.60    RRR.R.R..R...R....R.....R......R......R......R...R   gaps {1..7}
```

TeaCache degenerates to a near-fixed stride, spending half its budget on late steps. SeaCache front-loads (17 of its 27 refreshes fall in the first half) and its gaps widen monotonically. Early steps set image structure, which is why the same refresh budget buys ~10 dB more.

### vs cache-dit: SeaCache wins at every point

| Refresh     | SeaCache                      | cache-dit                  | dPSNR              | SeaCache better on |
| -------------| -------------------------------| ----------------------------| --------------------| --------------------|
| 0.45 / 0.42 | `thresh 0.30`, 2839 ms, 28.96 | `rdt 0.08`, 3099 ms, 27.07 | **+1.90** +/- 0.30 | 22/25 prompts      |
| 0.34        | `thresh 0.42`, 2283 ms, 25.98 | `rdt 0.16`, 2357 ms, 23.48 | **+2.50** +/- 0.33 | 24/25 prompts      |
| 0.31        | `thresh 0.47`, 2170 ms, 25.09 | `rdt 0.24`, 2186 ms, 21.68 | **+3.42** +/- 0.38 | 25/25 prompts      |
| 0.30        | `thresh 0.52`, 2039 ms, 24.82 | `rdt 0.55`, 2103 ms, 21.61 | **+3.21** +/- 0.35 | 25/25 prompts      |

### vs Spectrum: the curves cross

| Refresh | SeaCache (`thresh`) | Spectrum (`flex_window`) | Latency   | PSNR: Sea / Spec | Ahead                            |
| ---------| ---------------------| --------------------------| -----------| ------------------| ----------------------------------|
| 0.36    | `0.385`, 2455 ms    | `0.25`, 2475 ms          | Sea -0.8% | 26.76 / 25.10    | SeaCache +1.67 dB, 24/25 prompts |
| 0.32    | `0.47`, 2170 ms     | `0.40`, 2203 ms          | Sea -1.5% | 25.09 / 24.78    | SeaCache +0.32 dB         |
| 0.28    | `0.54`, 1925 ms     | default `0.75`, 1935 ms  | Sea -0.5% | 24.71 / 24.78    | Spectrum +0.06 dB         |
| 0.20    | `0.89`, 1398 ms     | `3.0`, 1386 ms           | Sea +0.9% | 20.39 / 22.92    | Spectrum +2.53 dB, 23/25 prompts |

The curves cross between refresh 0.28 and 0.32, near 1950-2150 ms of denoise time. SeaCache wins the higher-fidelity half and loses the aggressive end decisively: at refresh 0.20 Spectrum is 2.53 dB better on 23 of 25 prompts. Its advantages are:

- **About 5 GB less peak VRAM at every setting** (28592 vs 33820-33856 MB).
  Spectrum keeps a feature history for its Chebyshev fit; SeaCache keeps one
  residual per CFG branch.
- **Better quality above ~2150 ms**, by up to 1.67 dB.
- **One monotone knob**, versus tuning `window_size` / `flex_window` / warmup
  together.
- **No calibration**, unlike TeaCache's per-checkpoint polynomial.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33601103878](https://github.com/sgl-project/sglang/actions/runs/33601103878)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33601103833](https://github.com/sgl-project/sglang/actions/runs/33601103833)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33601104045](https://github.com/sgl-project/sglang/actions/runs/33601104045)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->