### PR TITLE
Return prefill batch to waiting queue when real KV alloc misses (#34676)

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -275,6 +275,7 @@ from sglang.srt.managers.utils import (
     validate_input_length,
 )
 from sglang.srt.mem_cache import kv_cache_builder
+from sglang.srt.mem_cache.allocation import PrefillOOMError
 from sglang.srt.mem_cache.common import (
     maybe_cache_unfinished_req,
     release_kv_cache,
@@ -3508,7 +3509,30 @@ class Scheduler(
                 self.tree_cache.ready_to_load_host_cache()
             )
 
-        new_batch.prepare_for_extend()
+        try:
+            new_batch.prepare_for_extend()
+        except PrefillOOMError as e:
+            # can_run_list was admitted against an estimate of available
+            # KV-cache capacity that the real allocation found wrong.
+            # alloc_for_extend() already released the req slots it took, so
+            # return the requests to the waiting queue and skip this round
+            # rather than letting the error escape and kill the scheduler
+            # process. Decode has an equivalent retraction path; this is
+            # prefill's. See sgl-project/sglang#34676.
+            logger.warning(
+                f"Prefill allocation missed after admission for "
+                f"{len(can_run_list)} request(s); returning them to the "
+                f"waiting queue. {e}"
+            )
+            if (
+                self.chunked_req is not None
+                and self.chunked_req is adder.new_chunked_req
+            ):
+                self.chunked_req = None
+            for req in can_run_list:
+                self._add_request_to_queue(req)
+            running_batch.batch_is_full = True
+            return None, running_batch
 
         if self.tp_worker.model_runner.prefill_aware_swa:
             for req in can_run_list:

--- a/python/sglang/srt/mem_cache/allocation.py
+++ b/python/sglang/srt/mem_cache/allocation.py
@@ -51,6 +51,15 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class PrefillOOMError(RuntimeError):
+    """Real KV-cache allocation missed for an already-admitted prefill batch.
+
+    Typed so the scheduler can catch this specifically and return the batch
+    to the waiting queue, rather than the exception escaping its event loop
+    and killing the process. See sgl-project/sglang#34676.
+    """
+
+
 def write_cache_indices(
     out_cache_loc: torch.Tensor,
     req_pool_indices_tensor: torch.Tensor,
@@ -305,6 +314,11 @@ def alloc_for_extend(
     prefix_lens_device = prefix_lens_cpu.to(batch.device, non_blocking=True)
     extend_lens_device = extend_lens_cpu.to(batch.device, non_blocking=True)
 
+    # Slots this call allocates are ours to release if the KV allocation
+    # below fails; slots a request already held (a chunked-prefill
+    # continuation) belong to that request's own lifecycle.
+    newly_pooled_reqs = [r for r in batch.reqs if r.req_pool_idx is None]
+
     # Allocate req slots (raises RuntimeError if the pool is exhausted)
     req_pool_indices = alloc_req_slots(
         batch.req_to_token_pool, batch.reqs, batch.tree_cache
@@ -312,37 +326,45 @@ def alloc_for_extend(
     req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
     req_pool_indices_device = req_pool_indices_cpu.to(batch.device, non_blocking=True)
 
-    # Allocate KV cache (throws exception on failure)
+    # PrefillAdder admits requests against an estimate of available capacity;
+    # the real allocation here can still miss. Free the req slots taken just
+    # above (otherwise each miss leaks one) and raise a typed error so the
+    # scheduler can requeue instead of dying. See sgl-project/sglang#34676.
     alloc_page_size = _alloc_page_size(batch)
-    if reuse_kv is not None and any(reuse_kv):
-        out_cache_loc = _alloc_extend_loc_with_kv_reuse(
-            batch,
-            reuse_kv,
-            req_pool_indices_cpu,
-            prefix_lens_cpu,
-            extend_lens_cpu,
-            req_pool_indices_device,
-            alloc_page_size,
-        )
-    elif alloc_page_size == 1:
-        out_cache_loc = alloc_token_slots(batch.tree_cache, batch.extend_num_tokens)
-    else:
-        # Paged allocation - build last_loc
-        last_loc = [
-            (t[-1:] if len(t) > 0 else torch.full((1,), -1, device=batch.device))
-            for t in prefix_tensors
-        ]
-        out_cache_loc = alloc_paged_token_slots_extend(
-            tree_cache=batch.tree_cache,
-            prefix_lens=prefix_lens_device,
-            prefix_lens_cpu=prefix_lens_cpu,
-            seq_lens=batch.seq_lens,
-            seq_lens_cpu=batch.seq_lens_cpu,
-            last_loc=torch.cat(last_loc),
-            extend_num_tokens=batch.extend_num_tokens,
-            req_pool_indices=req_pool_indices_device,
-            batch=batch,
-        )
+    try:
+        if reuse_kv is not None and any(reuse_kv):
+            out_cache_loc = _alloc_extend_loc_with_kv_reuse(
+                batch,
+                reuse_kv,
+                req_pool_indices_cpu,
+                prefix_lens_cpu,
+                extend_lens_cpu,
+                req_pool_indices_device,
+                alloc_page_size,
+            )
+        elif alloc_page_size == 1:
+            out_cache_loc = alloc_token_slots(batch.tree_cache, batch.extend_num_tokens)
+        else:
+            # Paged allocation - build last_loc
+            last_loc = [
+                (t[-1:] if len(t) > 0 else torch.full((1,), -1, device=batch.device))
+                for t in prefix_tensors
+            ]
+            out_cache_loc = alloc_paged_token_slots_extend(
+                tree_cache=batch.tree_cache,
+                prefix_lens=prefix_lens_device,
+                prefix_lens_cpu=prefix_lens_cpu,
+                seq_lens=batch.seq_lens,
+                seq_lens_cpu=batch.seq_lens_cpu,
+                last_loc=torch.cat(last_loc),
+                extend_num_tokens=batch.extend_num_tokens,
+                req_pool_indices=req_pool_indices_device,
+                batch=batch,
+            )
+    except RuntimeError as e:
+        for req in newly_pooled_reqs:
+            batch.req_to_token_pool.free(req)
+        raise PrefillOOMError(str(e)) from e
 
     # Write to req_to_token_pool
     write_cache_indices(

--- a/test/registered/unit/managers/test_prefill_alloc_oom_requeue.py
+++ b/test/registered/unit/managers/test_prefill_alloc_oom_requeue.py
@@ -1,0 +1,333 @@
+"""Regression tests for sgl-project/sglang#34676.
+
+"Hybrid Mamba prefill allocation failure kills scheduler instead of
+returning request to waiting queue."
+
+PrefillAdder admits requests against an *estimate* of available KV-cache
+capacity; the real allocation happens later in
+ScheduleBatch.prepare_for_extend() -> alloc_for_extend(). When it misses
+(concurrent decode-side eviction, DCP-owned pages, or hybrid Mamba state
+made the estimate wrong), two things must hold:
+
+1. alloc_for_extend() must free the req-pool slots it handed out for this
+   batch and raise the typed PrefillOOMError, not a bare RuntimeError
+   (TestAllocForExtendOOMContract).
+2. Scheduler._get_new_batch_prefill_raw() must catch it, return the admitted
+   requests to the waiting queue, and report "no batch this round" -- not
+   let the exception escape its event loop, where run_scheduler_process()
+   treats it as fatal and kills the whole process tree
+   (TestSchedulerRecoversFromPrefillOOM).
+
+Decode already has a retraction path for the equivalent situation; these
+tests pin down prefill's.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+maybe_stub_sgl_kernel()
+
+import sglang.srt.managers.scheduler as scheduler_mod
+from sglang.srt.managers.schedule_policy import AddReqResult
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.mem_cache.allocation import PrefillOOMError, alloc_for_extend
+from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
+
+
+class _FakeReq:
+    """Minimal stand-in for sglang.srt.managers.schedule_batch.Req."""
+
+    def __init__(self, prefix_len: int):
+        self.prefix_indices = torch.empty(prefix_len, dtype=torch.int64)
+        self.dllm_incomplete_ids = None
+        self.req_pool_idx = None
+        self.kv = None
+
+
+class _FakeAllocator:
+    """Stands in for the real TokenToKVPoolAllocator.
+
+    Deliberately a plain object (not a MagicMock): MagicMock auto-creates
+    any attribute you ask for, so `hasattr(allocator, "c128_attn_allocator")`
+    would silently be True and divert alloc_for_extend() down the DSV4
+    branch. A plain object keeps hasattr() honest.
+    """
+
+    def __init__(self, page_size: int, *, oom_on_extend: bool):
+        self.page_size = page_size
+        self._oom_on_extend = oom_on_extend
+
+    def available_size(self) -> int:
+        # Real capacity looks fine; the shortfall only shows up on the real
+        # alloc_extend() call -- mirrors PrefillAdder's admission estimate
+        # being wrong in the reported crash.
+        return 10**9
+
+    def alloc_extend(self, *args, **kwargs):
+        if self._oom_on_extend:
+            return None
+        return torch.arange(4, dtype=torch.int64)
+
+
+class _FakeTreeCache:
+    def __init__(self, allocator: _FakeAllocator):
+        self.token_to_kv_pool_allocator = allocator
+        self.page_size = allocator.page_size
+
+    def is_chunk_cache(self) -> bool:
+        return False
+
+    def evict(self, params) -> None:
+        pass
+
+    def available_and_evictable_str(self) -> str:
+        return "fake-tree-cache-state"
+
+    def pretty_print(self) -> None:
+        pass
+
+
+class _FakeReqToTokenPool:
+    """Deliberately *not* a HybridReqToTokenPool instance -- keeps
+    alloc_req_slots() on the plain (non-mamba) path.
+
+    Mirrors the real ReqToTokenPool alloc()/free() contract closely enough
+    to observe alloc_for_extend()'s failure-path cleanup: alloc() stamps
+    req.req_pool_idx on each request, free() clears it back to None.
+    """
+
+    device = "cpu"
+
+    def __init__(self, num_slots: int = 1, max_context_len: int = 64):
+        self.req_to_token = torch.zeros((num_slots, max_context_len), dtype=torch.int64)
+        self._next_idx = 0
+
+    def alloc(self, reqs):
+        for r in reqs:
+            if r.req_pool_idx is None:
+                r.req_pool_idx = self._next_idx
+                self._next_idx += 1
+        return [r.req_pool_idx for r in reqs]
+
+    def free(self, req):
+        assert req.req_pool_idx is not None, "request must have req_pool_idx"
+        req.req_pool_idx = None
+
+    def write(self, indices, values):
+        self.req_to_token[indices] = values
+
+
+class _FakeBatch:
+    def __init__(self, allocator: _FakeAllocator):
+        req = _FakeReq(prefix_len=0)
+        self.reqs = [req]
+        self.prefix_lens = [0]
+        self.extend_lens = [4]
+        self.extend_num_tokens = 4
+        self.device = "cpu"
+        self.seq_lens = torch.tensor([4], dtype=torch.int64)
+        self.seq_lens_cpu = torch.tensor([4], dtype=torch.int64)
+        self.tree_cache = _FakeTreeCache(allocator)
+        self.req_to_token_pool = _FakeReqToTokenPool()
+        self.token_to_kv_pool_allocator = allocator
+
+    def is_dllm(self) -> bool:
+        return False
+
+    def maybe_evict_swa(self) -> None:
+        pass
+
+
+class TestAllocForExtendOOMContract(CustomTestCase):
+    """Layer 1: the allocation-side contract of the #34676 fix."""
+
+    def setUp(self):
+        # torch_native keeps write_cache_indices() off the triton kernel path,
+        # so this CPU-CI test doesn't need a GPU driver.
+        set_global_server_args_for_scheduler(
+            ServerArgs(model_path="dummy", attention_backend="torch_native")
+        )
+
+    def test_oom_raises_typed_error_and_frees_req_slot(self):
+        # page_size > 1 routes through alloc_paged_token_slots_extend(), the
+        # exact function behind the reported "Prefill out of memory" error.
+        allocator = _FakeAllocator(page_size=16, oom_on_extend=True)
+        batch = _FakeBatch(allocator)
+        req = batch.reqs[0]
+
+        with self.assertRaises(PrefillOOMError):
+            alloc_for_extend(batch)
+
+        # The req-pool slot handed out earlier in the same call must be freed
+        # on failure -- otherwise every miss leaks one slot, a slow-drain
+        # crash of its own (same family as sgl-project/sglang#21404/#16067).
+        self.assertIsNone(req.req_pool_idx)
+
+    def test_preexisting_req_slot_is_not_freed_on_oom(self):
+        # A chunked-prefill continuation arrives already holding a slot; the
+        # failure path may only free slots *this* call allocated.
+        allocator = _FakeAllocator(page_size=16, oom_on_extend=True)
+        batch = _FakeBatch(allocator)
+        req = batch.reqs[0]
+        req.req_pool_idx = 7  # pre-existing slot, not ours to free
+
+        with self.assertRaises(PrefillOOMError):
+            alloc_for_extend(batch)
+
+        self.assertEqual(req.req_pool_idx, 7)
+
+    def test_success_path_unaffected(self):
+        # Guard against the fixture silently no-op'ing: the same fakes must
+        # complete a real allocation when the allocator does not miss.
+        allocator = _FakeAllocator(page_size=16, oom_on_extend=False)
+        batch = _FakeBatch(allocator)
+        out_cache_loc, _, _ = alloc_for_extend(batch)
+        self.assertEqual(out_cache_loc.numel(), 4)
+        self.assertIsNotNone(batch.reqs[0].req_pool_idx)
+
+
+def _scheduler_for_prefill_raw(*, waiting_reqs) -> Scheduler:
+    """Scheduler.__new__ with exactly the attributes
+    _get_new_batch_prefill_raw() touches before/around prepare_for_extend().
+    Follows the pattern of test_scheduler_chunked_req_gate.py."""
+    s = Scheduler.__new__(Scheduler)
+    s.grammar_manager = MagicMock(has_waiting_grammars=MagicMock(return_value=False))
+    s.enable_hierarchical_cache = False
+    s.server_args = MagicMock(enable_flexkv=False, prefill_max_requests=None)
+    s.enable_priority_preemption = False
+    s.is_hybrid_swa = False
+    s.chunked_req = None
+    s.waiting_queue = list(waiting_reqs)
+    s.min_free_slots_delayer = None
+    s.get_num_allocatable_reqs = MagicMock(return_value=64)
+    s.policy = MagicMock()
+    s.chunked_prefill_size = 8192
+    s.enable_dynamic_chunking = False
+    s.page_size = 16
+    s.tree_cache = MagicMock()
+    s.token_to_kv_pool_allocator = MagicMock()
+    s.new_token_ratio_tracker = SimpleNamespace(current=1.0)
+    s.max_prefill_tokens = 8192
+    s.is_mixed_chunk = False
+    s.priority_scheduling_preemption_threshold = 0
+    s.max_prefill_bs = 0
+    s.max_running_requests = 64
+    s.dllm_config = None
+    s.enable_lora = False
+    # Plain namespace: getattr(pool, "mamba_allocator", None) must be None,
+    # and a MagicMock would fabricate one.
+    s.req_to_token_pool = SimpleNamespace(available_size=lambda: 64)
+    s.disaggregation_mode = scheduler_mod.DisaggregationMode.NULL
+    s.enable_hicache_storage = False
+    s.truncation_align_size = None
+    s.enable_priority_scheduling = False
+    s.load_inquirer = MagicMock()
+    s.model_config = MagicMock()
+    s.enable_overlap = False
+    s.spec_algorithm = MagicMock()
+    s.tp_worker = MagicMock()
+    # Requeue must really land in waiting_queue so the test can observe it.
+    s._add_request_to_queue = lambda req: s.waiting_queue.append(req)
+    return s
+
+
+class TestSchedulerRecoversFromPrefillOOM(CustomTestCase):
+    """Layer 2: the scheduler-side recovery of the #34676 fix.
+
+    Drives the real Scheduler._get_new_batch_prefill_raw() with an adder
+    that admits one request and a batch whose prepare_for_extend() raises
+    PrefillOOMError. On pre-fix code the exception escapes this method (and
+    would kill the scheduler process); post-fix it must be absorbed: the
+    admitted request goes back to the waiting queue and no batch is
+    scheduled this round.
+    """
+
+    def test_prefill_oom_requeues_and_returns_no_batch(self):
+        req = MagicMock(name="admitted_req")
+        s = _scheduler_for_prefill_raw(waiting_reqs=[req])
+
+        fake_adder = MagicMock()
+        fake_adder.can_run_list = [req]
+        fake_adder.preempt_list = []
+        fake_adder.new_chunked_req = None
+        fake_adder.add_one_req = MagicMock(return_value=AddReqResult.CONTINUE)
+
+        fake_batch = MagicMock(name="new_batch")
+        fake_batch.prepare_for_extend.side_effect = PrefillOOMError(
+            "Prefill out of memory (injected)"
+        )
+        fake_schedule_batch_cls = MagicMock()
+        fake_schedule_batch_cls.init_new.return_value = fake_batch
+
+        running_batch = MagicMock()
+        running_batch.batch_is_full = False
+        running_batch.reqs = []
+
+        with patch.object(
+            scheduler_mod, "PrefillAdder", MagicMock(return_value=fake_adder)
+        ), patch.object(scheduler_mod, "ScheduleBatch", fake_schedule_batch_cls):
+            # Pre-fix code re-raises PrefillOOMError here and this call blows
+            # up -- exactly the process-killing escape from #34676.
+            result, returned_running = Scheduler._get_new_batch_prefill_raw(
+                s, prefill_delayer_single_pass=None, running_batch=running_batch
+            )
+
+        # The batch really was attempted (guards against the test passing
+        # because the method bailed out before prepare_for_extend()).
+        fake_batch.prepare_for_extend.assert_called_once()
+        # No batch this round; the running batch flows back unchanged.
+        self.assertIsNone(result)
+        self.assertIs(returned_running, running_batch)
+        # The admitted request is back in the waiting queue, not dropped.
+        self.assertIn(req, s.waiting_queue)
+        # And the scheduler stops re-admitting into the same full pool this
+        # round instead of hot-looping the failure.
+        self.assertTrue(running_batch.batch_is_full)
+
+    def test_prefill_success_still_schedules_batch(self):
+        # Symmetric guard against over-catching: when prepare_for_extend()
+        # succeeds, the method must still produce the batch.
+        req = MagicMock(name="admitted_req")
+        s = _scheduler_for_prefill_raw(waiting_reqs=[req])
+
+        fake_adder = MagicMock()
+        fake_adder.can_run_list = [req]
+        fake_adder.preempt_list = []
+        fake_adder.new_chunked_req = None
+        fake_adder.add_one_req = MagicMock(return_value=AddReqResult.CONTINUE)
+
+        fake_batch = MagicMock(name="new_batch")
+        fake_schedule_batch_cls = MagicMock()
+        fake_schedule_batch_cls.init_new.return_value = fake_batch
+
+        running_batch = MagicMock()
+        running_batch.batch_is_full = False
+        running_batch.reqs = []
+        running_batch.is_empty = MagicMock(return_value=True)
+
+        with patch.object(
+            scheduler_mod, "PrefillAdder", MagicMock(return_value=fake_adder)
+        ), patch.object(
+            scheduler_mod, "ScheduleBatch", fake_schedule_batch_cls
+        ), patch.object(
+            scheduler_mod, "PrefillStats", MagicMock()
+        ):
+            result, _ = Scheduler._get_new_batch_prefill_raw(
+                s, prefill_delayer_single_pass=None, running_batch=running_batch
+            )
+
+        fake_batch.prepare_for_extend.assert_called_once()
+        self.assertIs(result, fake_batch)
+        self.assertNotIn(req, s.waiting_queue)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Fixes #34676.

`PrefillAdder` admits requests against an *estimate* of available KV-cache capacity (`allocator.available_size()` + `tree_cache.*_evictable_size()`). The real allocation happens later, in `prepare_for_extend()` -> `alloc_for_extend()`, where it can still miss — concurrent decode-side eviction, DCP-owned pages, or hybrid Mamba state can all make the admission estimate wrong.

Today that miss raises a bare `RuntimeError` from `alloc_paged_token_slots_extend()`:

```
RuntimeError: Prefill out of memory. Try to lower your batch size.
Try to allocate 8192 tokens.
Available full tokens: 8070656 (full_available_size=7936 + full_evictable_size_=8062720)
Available mamba: 760 (available_size=57 + component_evictable_size_=703)
```

Nothing between there and the scheduler's event loop catches it, so it propagates out of `event_loop_normal()` / `event_loop_overlap()` and `run_scheduler_process()` treats it as fatal — the supervisor then `SIGQUIT`s the whole process tree. A single allocation miss takes down every scheduler rank, with no host OOM, CUDA Xid, or Docker OOM kill involved.

Decode already has a retraction path for the equivalent situation. Prefill had none.

## Modifications

**`mem_cache/allocation.py`**
- Add `PrefillOOMError(RuntimeError)` so the failure is distinguishable from unrelated `RuntimeError`s.
- Wrap the KV-cache allocation in `alloc_for_extend()`. On a miss, free the req-pool slots allocated by *this* call before re-raising as `PrefillOOMError`. Slots a request already held (a chunked-prefill continuation) are left alone — those belong to that request's own lifecycle. Without this, every miss also leaks a req-pool slot, which is a slow-drain failure of its own (cf. #21404, #16067).

**`managers/scheduler.py`**
- `_get_new_batch_prefill_raw()` catches `PrefillOOMError`, returns the admitted requests to the waiting queue via `_add_request_to_queue()`, sets `running_batch.batch_is_full = True` so the round doesn't hot-loop the same failure, and reports no batch this round.

Capacity pressure now degrades to "retry next round" instead of killing the server.

## Tests

New `test/registered/unit/managers/test_prefill_alloc_oom_requeue.py` (CPU-only, `register_cpu_ci`), 5 cases across both layers:

- `TestAllocForExtendOOMContract` — typed error is raised; the req-pool slot allocated in the failing call is freed; a pre-existing slot is *not* freed; the success path is unaffected.
- `TestSchedulerRecoversFromPrefillOOM` — drives the real `Scheduler._get_new_batch_prefill_raw()`: on `PrefillOOMError` the request lands back in `waiting_queue` and no batch is returned; symmetrically, a successful `prepare_for_extend()` still yields the batch (guards against over-catching).

### Verification note

The behavioural runs were done inside `lmsysorg/sglang:kimi-k3` (overlay commit `c6ad1f26`), where all 5 pass with the patch applied and the OOM cases fail without it. Against current `main` I have verified that the patch applies cleanly and that both modified modules compile and import, but I have not been able to execute the suite on a `main`-based environment. `allocation.py` differs between the two revisions (`c4_attn_allocator` / `dsv4_state_lens` / `backup_state` vs `c128_attn_allocator`), so the fakes may need adjusting for `main` — flagging explicitly rather than implying a green run I didn't do. Happy to iterate if CI disagrees.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).
- [ ] Work with maintainers to merge your PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015Vq7PhXv6vzWUyNTy9E3BM

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32950077909](https://github.com/sgl-project/sglang/actions/runs/32950077909)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32950077753](https://github.com/sgl-project/sglang/actions/runs/32950077753)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32950077963](https://github.com/sgl-project/sglang/actions/runs/32950077963)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->