### PR TITLE
[Fix] Clamp tombstoned v2p entries in the fused decode-metadata kernel

### DIFF
--- a/python/sglang/kernels/ops/attention/metadata.py
+++ b/python/sglang/kernels/ops/attention/metadata.py
@@ -263,6 +263,9 @@ def _fused_metadata_kernel_general(
     # still needs in virtual space. Masked so padded lanes never index the table.
     if v2p_ptr is not None:
         page_table_val = tl.load(v2p_ptr + page_table_val, mask=mask, other=0)
+        # A freed page is tombstoned to -1 in v2p; clamp to the slot-0 sink so
+        # replayed metadata never indexes the KV pool at a negative page.
+        page_table_val = tl.maximum(page_table_val, 0)
     page_table_val = page_table_val * PAGE_MULT
 
     # Store to page_table
@@ -283,6 +286,9 @@ def _fused_metadata_kernel_general(
             other=0,
             cache_modifier=".cg",
         )
+        # Same tombstone clamp for the unified SWA v2p; out-of-window pages of
+        # a live request are tombstoned once freed. No-op for the legacy map.
+        swa_slot = tl.maximum(swa_slot, 0)
         if page_size == 1 or SWA_MAPPING_IS_V2P:
             swa_val = swa_slot
         else:

--- a/test/registered/kernels/ops/attention/test_fused_metadata_v2p_tombstone.py
+++ b/test/registered/kernels/ops/attention/test_fused_metadata_v2p_tombstone.py
@@ -1,0 +1,95 @@
+"""A -1 (tombstoned) virtual_to_physical entry must never reach the page tables
+the fused decode-metadata kernel builds: a negative page index sent to an
+attention kernel is a k_buffer[-1]-class illegal access under captured graph
+replay. Tombstones must land on the reserved slot-0 sink instead."""
+
+import torch
+import triton
+
+from sglang.kernels.ops.attention.metadata import _fused_metadata_kernel_general
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+PAGE_SIZE = 128
+SHIFT = 7
+BLOCK_COLS = 128
+
+
+def test_v2p_tombstones_clamped_to_sink():
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+
+    # Request 0: 9 live pages, the first 5 outside the sliding window and
+    # SWA-tombstoned. Request 1: 2 live pages, fully in-window.
+    seq_lens = torch.tensor([1152, 256], dtype=torch.int64, device=device)
+    bs = 2
+    max_seq_pages = int((int(seq_lens.max()) + PAGE_SIZE - 1) // PAGE_SIZE)
+
+    req_to_token = torch.zeros(
+        (bs, max_seq_pages * PAGE_SIZE), dtype=torch.int64, device=device
+    )
+    for i in range(bs):
+        pages = int((int(seq_lens[i]) + PAGE_SIZE - 1) // PAGE_SIZE)
+        for p in range(pages):
+            full_page = i * 16 + p
+            req_to_token[i, p * PAGE_SIZE : (p + 1) * PAGE_SIZE] = torch.arange(
+                full_page * PAGE_SIZE, (full_page + 1) * PAGE_SIZE, device=device
+            )
+    req_pool_indices = torch.tensor([0, 1], dtype=torch.int64, device=device)
+
+    num_pool_pages = 64
+    v2p_full = torch.arange(num_pool_pages, dtype=torch.int32, device=device)
+    v2p_full[0] = -1
+    swa_v2p = torch.arange(num_pool_pages, dtype=torch.int32, device=device)
+    swa_v2p[:5] = -1  # request 0's out-of-window prefix pages
+
+    cache_seqlens = torch.zeros(bs, dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.zeros(bs + 1, dtype=torch.int32, device=device)
+    page_table = torch.zeros((bs, max_seq_pages), dtype=torch.int32, device=device)
+    swa_page_table = torch.zeros((bs, max_seq_pages), dtype=torch.int32, device=device)
+
+    grid = (bs, triton.cdiv(max_seq_pages, BLOCK_COLS))
+    _fused_metadata_kernel_general[grid](
+        seq_lens,
+        seq_lens.stride(0),
+        req_to_token,
+        req_to_token.stride(0),
+        req_to_token.stride(1),
+        req_pool_indices,
+        req_pool_indices.stride(0),
+        cache_seqlens,
+        cache_seqlens.stride(0),
+        cu_seqlens_k,
+        cu_seqlens_k.stride(0),
+        page_table,
+        page_table.stride(0),
+        page_table.stride(1),
+        swa_page_table,
+        swa_page_table.stride(0),
+        swa_page_table.stride(1),
+        swa_v2p,
+        0,
+        bs,
+        max_seq_pages,
+        PAGE_SIZE,
+        0,
+        True,
+        SHIFT,
+        BLOCK_COLS=BLOCK_COLS,
+        v2p_ptr=v2p_full,
+        PAGE_MULT=1,
+        SWA_MAPPING_IS_V2P=True,
+        num_warps=4,
+        num_stages=3,
+    )
+    torch.cuda.synchronize()
+
+    for i in range(bs):
+        live = int((int(cache_seqlens[i]) + PAGE_SIZE - 1) // PAGE_SIZE)
+        assert (page_table[i, :live] >= 0).all(), page_table[i, :live].tolist()
+        assert (swa_page_table[i, :live] >= 0).all(), swa_page_table[i, :live].tolist()
+    # In-window pages must keep their real translation, not get clamped away.
+    assert swa_page_table[0, 5:9].tolist() == [5, 6, 7, 8]
+    assert page_table[1, :2].tolist() == [16, 17]


### PR DESCRIPTION
## Motivation

When a hybrid-SWA model (e.g. Inkling) runs with the unified radix tree, SWA
pages that slide out of the window are freed and tombstoned to -1 in
`virtual_to_physical`. The fused decode-metadata kernel loads that table raw,
so from then on every decode step writes -1 page indices into
`swa_page_table` (and `page_table` for a tombstoned full page). Any consumer
that touches such an entry indexes the KV pool at a negative page: an illegal
memory access that, under decode CUDA-graph replay, wedges the context rather
than failing cleanly.

Today's decode kernels happen to stay inside the window and never read those
entries, but nothing enforces that: the metadata kernel's contract only bounds
consumers by `cache_seqlens`, which includes the tombstoned region, and recent
evict-floor fixes (#35286, #35396) show the invariant is fragile. #35933
already clamped every host-side full-to-SWA translation for exactly this
reason; the in-kernel unified-pool branch is the one site it missed.

## Modifications

- `kernels/ops/attention/metadata.py`: `tl.maximum(..., 0)` after both raw v2p
  loads, routing tombstones to the reserved slot-0 sink (same semantics as the
  host-side clamps; no-op for legacy mappings and non-unified pools).
- New regression test `test_fused_metadata_v2p_tombstone.py`
  (`base-b-kernel-unit`, 1-gpu-large + 4-gpu-b200): tombstoned v2p tables must
  produce no negative page-table entries, while in-window pages keep their
  real translation.

## Accuracy Tests

Only -1 (invalid) entries change; valid translations are bit-identical, pinned
by the test. Verified on GB200: test fails on main, passes with the fix.

## Speed Tests and Profiling

Two register ops in a metadata kernel; no measurable impact.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32955595712](https://github.com/sgl-project/sglang/actions/runs/32955595712)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32955595688](https://github.com/sgl-project/sglang/actions/runs/32955595688)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32955595626](https://github.com/sgl-project/sglang/actions/runs/32955595626)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->