### PR TITLE
Support standard Content-Encoding for request decompression

### DIFF
--- a/python/sglang/srt/entrypoints/http_request_decompression.py
+++ b/python/sglang/srt/entrypoints/http_request_decompression.py
@@ -1,8 +1,8 @@
 """Pure-ASGI middleware that decompresses compressed request bodies.
 
-Gated on `SGLANG_ENABLE_REQUEST_DECOMPRESSION` and request header
-`x-body-compressed`, whose value names the method. For example, a caller that
-compressed the body with zstd sets the `x-body-compressed: zstd` header.
+Gated on `SGLANG_ENABLE_REQUEST_DECOMPRESSION` and a request compression
+header. Both the legacy `x-body-compressed` header and the standard
+`Content-Encoding` header are accepted; their value names the method.
 """
 
 import asyncio
@@ -28,14 +28,18 @@ def _rewrite_headers(headers, new_len):
     out = [
         (k, v)
         for (k, v) in headers
-        if k not in (b"content-length", b"x-body-compressed")
+        if k not in (
+            b"content-length",
+            b"x-body-compressed",
+            b"content-encoding",
+        )
     ]
     out.append((b"content-length", str(new_len).encode()))
     return out
 
 
 class RequestDecompressionMiddleware:
-    """Decompress request body per request header `x-body-compressed`."""
+    """Decompress request bodies tagged with a supported compression header."""
 
     def __init__(self, app):
         self.app = app
@@ -44,15 +48,21 @@ class RequestDecompressionMiddleware:
         # No-op passthrough for any request without the compression header.
         if scope["type"] != "http":
             return await self.app(scope, receive, send)
-        method = Headers(scope=scope).get("x-body-compressed")
+        headers = Headers(scope=scope)
+        method = headers.get("x-body-compressed")
+        if method is None:
+            method = headers.get("content-encoding")
         if method is None:
             return await self.app(scope, receive, send)
+        # Content-Encoding may contain a comma-separated chain. SGLang currently
+        # supports one request-body codec, so use the first value and normalize it.
+        method = method.split(",", 1)[0].strip().lower()
 
         # Fail loud on an unsupported compression method.
         decompress = _DECOMPRESSORS.get(method)
         if decompress is None:
             return await Response(
-                f"unsupported x-body-compressed {method!r}; "
+                f"unsupported request compression {method!r}; "
                 f"supported: {sorted(_DECOMPRESSORS)}",
                 status_code=400,
             )(scope, receive, send)

--- a/test/registered/cpu/test_request_decompression.py
+++ b/test/registered/cpu/test_request_decompression.py
@@ -67,6 +67,37 @@ class TestRequestDecompressionMiddleware(unittest.TestCase):
         self.assertEqual(seen["body"], PAYLOAD)
         self.assertEqual(sent, [])
 
+    def test_decompresses_standard_content_encoding_header(self):
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"content-encoding", b"zstd"),
+                (b"content-length", str(len(COMPRESSED)).encode()),
+            ],
+        }
+        seen, sent = _drive(scope, [(COMPRESSED, False)])
+        self.assertEqual(seen["body"], PAYLOAD)
+        self.assertEqual(sent, [])
+
+    def test_normalizes_content_encoding_and_strips_header(self):
+        scope = {
+            "type": "http",
+            "headers": [
+                (b"content-encoding", b" ZSTD, identity "),
+                (b"content-length", str(len(COMPRESSED)).encode()),
+                (b"content-type", b"application/json"),
+            ],
+        }
+        seen, _ = _drive(scope, [(COMPRESSED, False)])
+        self.assertEqual(seen["body"], PAYLOAD)
+        self.assertEqual(
+            seen["scope"]["headers"],
+            [
+                (b"content-type", b"application/json"),
+                (b"content-length", str(len(PAYLOAD)).encode()),
+            ],
+        )
+
     def test_strips_header_and_fixes_content_length(self):
         scope = {
             "type": "http",


### PR DESCRIPTION
## Motivation

SGLang's request decompression middleware currently only checks the legacy
x-body-compressed header. Clients that use the standard HTTP
Content-Encoding header, such as OpenAI Codex, send compressed request
bodies that are then passed to the JSON parser unchanged.

This results in errors such as:

JSON decode error: str is not valid UTF-8: surrogates not allowed

## Modifications

- Accept the standard Content-Encoding header in RequestDecompressionMiddleware.
- Preserve support for x-body-compressed.
- Normalize the compression token before lookup.
- Remove compression headers and update Content-Length after decompression.
- Add unit tests for standard header handling, normalization, and header rewriting.

The middleware remains gated by SGLANG_ENABLE_REQUEST_DECOMPRESSION; requests
without a supported compression header keep the existing behavior.

## Tests

- pytest -q test/registered/cpu/test_request_decompression.py (9 passed)
- Python compilation check passed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32959403249](https://github.com/sgl-project/sglang/actions/runs/32959403249)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32959403282](https://github.com/sgl-project/sglang/actions/runs/32959403282)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32959403230](https://github.com/sgl-project/sglang/actions/runs/32959403230)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->