### PR TITLE
[Fix] Prevent rank divergence in multimodal input broadcast

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -91,6 +91,14 @@ class BaseReq(msgspec.Struct, tag=True, kw_only=True, array_like=True):
         return msgspec_struct_pydantic_core_schema(cls, handler)
 
 
+class MMInputsProcessMode(Enum):
+    """Scheduler MM processing protocol selected before TP request broadcast."""
+
+    NONE = 0
+    LOCAL = 1
+    BROADCAST = 2
+
+
 class BaseBatchReq(msgspec.Struct, tag=True, kw_only=True, array_like=True):
     """Base for batched IPC payloads."""
 
@@ -1068,6 +1076,10 @@ class TokenizedGenerateReqInput(BaseReq, kw_only=True):
     # Cache namespace used to isolate otherwise-identical prefixes.
     cache_salt: Optional[str] = None
 
+    # Must remain the final field: these request DTOs use array-like msgpack
+    # encoding, so appending preserves the wire indices of existing fields.
+    mm_inputs_process_mode: MMInputsProcessMode = MMInputsProcessMode.NONE
+
     def wrap_pickle_fields(self):
         self.time_stats = wrap_as_pickle(self.time_stats)
 
@@ -1353,6 +1365,9 @@ class TokenizedEmbeddingReqInput(BaseReq, kw_only=True):
     # For observability
     # Pickled Optional[Union[APIServerReqTimeStats, DPControllerReqTimeStats]]
     time_stats: Optional[PickleWrapper] = None
+
+    # Must remain the final field; see TokenizedGenerateReqInput above.
+    mm_inputs_process_mode: MMInputsProcessMode = MMInputsProcessMode.NONE
 
     def wrap_pickle_fields(self):
         self.time_stats = wrap_as_pickle(self.time_stats)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -153,6 +153,7 @@ from sglang.srt.managers.io_struct import (
     LoadLoRAAdapterReqInput,
     LoadLoRAAdapterReqOutput,
     MMInputsProcessError,
+    MMInputsProcessMode,
     OpenSessionReqInput,
     PauseGenerationReqInput,
     ProfileReq,
@@ -387,12 +388,6 @@ STEP_MAX_US = 2_000_000
 # spins on_idle without sleeping. Bounds the O(queue) get_loads for both the
 # DP-balancing writer and the router-facing socket.
 LOAD_STALL_REFRESH_S = 0.05
-
-
-@dataclasses.dataclass(frozen=True)
-class _MultimodalInputBroadcast:
-    inputs: Optional[MultimodalInputs] = None
-    error: Optional[str] = None
 
 
 class _MultimodalInputProcessingError(RuntimeError):
@@ -2529,102 +2524,17 @@ class Scheduler(
         if req.sampling_params.min_new_tokens > req.sampling_params.max_new_tokens:
             req.sampling_params.min_new_tokens = req.sampling_params.max_new_tokens
 
-    def _process_and_broadcast_mm_inputs(
-        self,
-        raw_mm_inputs,
-    ):
-        """Materialize MultimodalInputs once on the entry rank and broadcast to others.
-
-        Entry rank:
-        - constructs MultimodalInputs.from_processor_output() once
-        - broadcasts to other ranks in self.cpu_group (if world_size > 1)
-
-        Non-entry ranks:
-        - receive the object via broadcast (if world_size > 1)
-        - otherwise (single-rank / no group) fall back to local from_processor_output
-
-        Returns:
-            MultimodalInputs | None
-
-        Raises:
-            _MultimodalInputProcessingError: The entry rank could not build the
-                request's multimodal inputs. The same error is broadcast to all
-                ranks before it is raised.
-        """
-        if raw_mm_inputs is None:
+    def _get_multimodal_inputs(self, mm_inputs, mode: MMInputsProcessMode):
+        if mode is MMInputsProcessMode.NONE:
             return None
-
-        group_world_size = 1
-        try:
-            if (
-                torch.distributed.is_available()
-                and torch.distributed.is_initialized()
-                and self.dp_tp_cpu_group is not None
-            ):
-                group_world_size = torch.distributed.get_world_size(
-                    group=self.dp_tp_cpu_group
-                )
-        except Exception as e:
-            logger.warning(
-                f"Failed to get world size in mm_inputs handling with {e}, fallback to 1."
-            )
-
-        # In case tp size > 1, all the Scheduler TP ranks runs the duplicated computing
-        # process in CPU which occupies the main thread CPU cycle. This computing logic
-        # merely needs to be run on TP0 and be broadcast to other TP ranks.
-        # Since the Scheduler is single-threaded, any large CPU cost will impact
-        # handling of other messages. For example, CPU hits 99.9% can significantly
-        # increase the CUDA kernel launch time.
-        result = None
-        if self.dp_tp_group.rank_in_group == 0:
-            try:
-                result = _MultimodalInputBroadcast(
-                    inputs=MultimodalInputs.from_processor_output(raw_mm_inputs)
-                )
-            except Exception as error:
-                result = _MultimodalInputBroadcast(
-                    error=(
-                        "Multimodal input processing failed on the TP entry rank: "
-                        f"{type(error).__name__}: {error}"
-                    )
-                )
-
-            # Broadcast either the prepared inputs or the request-local error.
-            if group_world_size > 1:
-                obj_list = [result]
-                torch.distributed.broadcast_object_list(
-                    obj_list,
-                    src=self.dp_tp_group.first_rank,
-                    group=self.dp_tp_cpu_group,
-                )
-                result = obj_list[0]
-        else:
-            # Non-entry ranks: receive if group size > 1; otherwise materialize locally.
-            if group_world_size > 1:
-                obj_list = [None]
-                torch.distributed.broadcast_object_list(
-                    obj_list,
-                    src=self.dp_tp_group.first_rank,
-                    group=self.dp_tp_cpu_group,
-                )
-                result = obj_list[0]
-            else:
-                result = _MultimodalInputBroadcast(
-                    inputs=MultimodalInputs.from_processor_output(raw_mm_inputs)
-                )
-
-        if result.error is not None:
-            raise _MultimodalInputProcessingError(result.error)
-        return result.inputs
-
-    def _get_multimodal_inputs(self, mm_inputs):
         if isinstance(mm_inputs, MMInputsProcessError):
             raise _MultimodalInputProcessingError(mm_inputs.message)
         if isinstance(mm_inputs, MultimodalInputs):
             return mm_inputs
-
-        if get_mm().enable_broadcast_mm_inputs_process:
-            return self._process_and_broadcast_mm_inputs(mm_inputs)
+        if mode is MMInputsProcessMode.BROADCAST:
+            raise _MultimodalInputProcessingError(
+                "Multimodal broadcast protocol completed without a result"
+            )
         return MultimodalInputs.from_processor_output(mm_inputs)
 
     @staticmethod
@@ -2934,9 +2844,10 @@ class Scheduler(
             return
 
         # Handle multimodal inputs
-        if recv_req.mm_inputs is not None:
+        mm_mode = recv_req.mm_inputs_process_mode
+        if mm_mode is not MMInputsProcessMode.NONE:
             try:
-                image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs)
+                image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs, mm_mode)
             except _MultimodalInputProcessingError as error:
                 req.set_finish_with_abort(
                     str(error),
@@ -3313,9 +3224,10 @@ class Scheduler(
             return
 
         # Handle multimodal inputs
-        if recv_req.mm_inputs is not None:
+        mm_mode = recv_req.mm_inputs_process_mode
+        if mm_mode is not MMInputsProcessMode.NONE:
             try:
-                image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs)
+                image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs, mm_mode)
             except _MultimodalInputProcessingError as error:
                 req.set_finish_with_abort(
                     str(error),

--- a/python/sglang/srt/managers/scheduler_components/request_receiver.py
+++ b/python/sglang/srt/managers/scheduler_components/request_receiver.py
@@ -23,6 +23,7 @@ from sglang.srt.managers.io_struct import (
     BatchTokenizedEmbeddingReqInput,
     BatchTokenizedGenerateReqInput,
     MMInputsProcessError,
+    MMInputsProcessMode,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     sock_recv,
@@ -32,12 +33,18 @@ from sglang.srt.managers.mm_utils import (
     has_shm_features,
     unwrap_shm_features,
 )
+from sglang.srt.managers.schedule_batch import MultimodalInputs
 from sglang.srt.observability.scheduler_stage_metrics import (
     SCHEDULER_STAGE_RECV_REQUESTS,
     SchedulerStageMetricsRecorder,
     scheduler_stage_method,
 )
-from sglang.srt.runtime_context import get_disagg, get_parallel, is_ep_scale_joiner
+from sglang.srt.runtime_context import (
+    get_disagg,
+    get_mm,
+    get_parallel,
+    is_ep_scale_joiner,
+)
 from sglang.srt.utils import (
     broadcast_pyobj,
     point_to_point_pyobj,
@@ -102,6 +109,7 @@ class SchedulerRequestReceiver:
         if self.input_blocker is not None:
             recv_reqs = self.input_blocker.handle(recv_reqs)
 
+        self._set_mm_process_mode(recv_reqs)
         recv_reqs = self._broadcast_reqs_across_ranks(recv_reqs)
 
         if self.ps.pp_rank == 0:
@@ -109,9 +117,57 @@ class SchedulerRequestReceiver:
 
         recv_reqs = self._apply_mm_receiver(recv_reqs)
 
+        # EPD's waiting path can refill ``mm_inputs`` after the initial
+        # request fanout. Only requests that were synchronized as NONE may
+        # transition here; never overwrite an entry-rank BROADCAST decision
+        # from rank-local post-fanout state.
+        # This re-stamp is safe only while every MM receiver backend returns
+        # rank-symmetric refill status and shapes. New backends must preserve
+        # that invariant or scheduler ranks can diverge again.
+        self._set_mm_process_mode(recv_reqs, only_if_none=True)
+
         self._finalize_shm_features(recv_reqs)
+        self._materialize_broadcast_mm_inputs(recv_reqs)
 
         return recv_reqs
+
+    def _set_mm_process_mode(
+        self, recv_reqs: Optional[List], *, only_if_none: bool = False
+    ) -> None:
+        """Stamp the source-selected MM processing mode onto each work request.
+
+        The request payload is subsequently broadcast to TP peers.  Keeping
+        this mode in the payload prevents any scheduler rank from deriving
+        collective participation from its local MM object state.
+        """
+        if not recv_reqs:
+            return
+
+        for req in recv_reqs:
+            if isinstance(req, (TokenizedGenerateReqInput, TokenizedEmbeddingReqInput)):
+                if (
+                    only_if_none
+                    and req.mm_inputs_process_mode is not MMInputsProcessMode.NONE
+                ):
+                    continue
+                if isinstance(req.mm_inputs, (MultimodalInputs, MMInputsProcessError)):
+                    # A PP predecessor has already prepared a shared result.
+                    mode = MMInputsProcessMode.LOCAL
+                elif req.mm_inputs is None:
+                    mode = MMInputsProcessMode.NONE
+                elif get_mm().mm_feature_transport == "cuda_vmm":
+                    # CUDA-VMM has its own local materialization protocol; do
+                    # not serialize GPU-backed inputs through Gloo.
+                    mode = MMInputsProcessMode.LOCAL
+                elif get_mm().enable_broadcast_mm_inputs_process:
+                    mode = MMInputsProcessMode.BROADCAST
+                else:
+                    mode = MMInputsProcessMode.LOCAL
+                req.mm_inputs_process_mode = mode
+            elif isinstance(
+                req, (BatchTokenizedGenerateReqInput, BatchTokenizedEmbeddingReqInput)
+            ):
+                self._set_mm_process_mode(req.batch, only_if_none=only_if_none)
 
     def _pull_raw_reqs(self) -> Optional[List]:
         if self.ps.pp_rank == 0:
@@ -167,8 +223,8 @@ class SchedulerRequestReceiver:
             if self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0:
                 work_reqs, control_reqs = self._split_work_and_control_reqs(recv_reqs)
             else:
-                work_reqs = None
-                control_reqs = None
+                work_reqs = []
+                control_reqs = []
 
             work_reqs = attn_cp_tp_broadcast_pyobj(work_reqs)
 
@@ -291,6 +347,81 @@ class SchedulerRequestReceiver:
             if failed[index].item():
                 discard_shm_features(req)
                 req.mm_inputs = error
+
+    def _materialize_broadcast_mm_inputs(self, recv_reqs: Optional[List]) -> None:
+        """Run the ordered root-only MM protocol after request fanout.
+
+        Every rank receives the same request list, so iterating its work items
+        in order gives the follow-up collectives an identical schedule.  The
+        result is written back before handlers run, leaving handlers entirely
+        collective-free.
+        """
+        if not recv_reqs:
+            return
+
+        for req in self._iter_tokenized_reqs(recv_reqs):
+            if req.mm_inputs_process_mode is MMInputsProcessMode.BROADCAST:
+                result, error_message = self._broadcast_mm_inputs_result(req)
+                req.mm_inputs = (
+                    MMInputsProcessError(error_message)
+                    if error_message is not None
+                    else result
+                )
+                # A following PP stage must not repeat the large result fanout.
+                req.mm_inputs_process_mode = MMInputsProcessMode.LOCAL
+
+    @staticmethod
+    def _iter_tokenized_reqs(recv_reqs: List):
+        for req in recv_reqs:
+            if isinstance(req, (TokenizedGenerateReqInput, TokenizedEmbeddingReqInput)):
+                yield req
+            elif isinstance(
+                req, (BatchTokenizedGenerateReqInput, BatchTokenizedEmbeddingReqInput)
+            ):
+                yield from req
+
+    @staticmethod
+    def _materialize_mm_envelope(req):
+        try:
+            if has_shm_features([req]):
+                unwrap_shm_features(req)
+            mm_inputs = req.mm_inputs
+            result = (
+                mm_inputs
+                if isinstance(mm_inputs, (MultimodalInputs, MMInputsProcessError))
+                else MultimodalInputs.from_processor_output(mm_inputs)
+            )
+            return result, None
+        except Exception as exc:
+            # This runs only on the collective source. Preserve the concise
+            # envelope shared with peers, but retain the full traceback locally
+            # for server-side diagnosis.
+            logger.exception(
+                "Failed to materialize broadcast multimodal inputs on entry rank"
+            )
+            return (
+                None,
+                "Failed to process multimodal inputs on entry rank: "
+                f"{type(exc).__name__}: {exc}",
+            )
+
+    def _broadcast_mm_inputs_result(self, req):
+        """Fan out one materialized result using the request fanout topology."""
+        if get_parallel().enable_dp_attention:
+            is_source = self.ps.attn_tp_rank == 0 and self.ps.attn_cp_rank == 0
+            envelopes = [self._materialize_mm_envelope(req)] if is_source else []
+            return attn_cp_tp_broadcast_pyobj(envelopes)[0]
+
+        is_source = self.tp_group.rank == self.tp_group.ranks[0]
+        envelope = self._materialize_mm_envelope(req) if is_source else None
+        if self.ps.tp_size != 1:
+            envelope = broadcast_pyobj(
+                envelope,
+                self.tp_group.rank,
+                self.tp_cpu_group,
+                src=self.tp_group.ranks[0],
+            )
+        return envelope
 
     def _split_work_and_control_reqs(self, recv_reqs: List):
         work_reqs = [

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -12,6 +12,7 @@ import torch
 from sglang.srt.managers.io_struct import (
     EmbeddingReqInput,
     GenerateReqInput,
+    MMInputsProcessMode,
     TokenizedEmbeddingReqInput,
     TokenizedGenerateReqInput,
     msgpack_decode,
@@ -68,6 +69,69 @@ class TestTokenizedReqInputMsgpack(unittest.TestCase):
                 ]
             ),
             "Rust may omit only a defaulted suffix of the Python wire schema",
+        )
+
+    def test_mm_process_mode_is_appended_to_array_like_request_dtos(self):
+        self.assertEqual(
+            TokenizedGenerateReqInput.__struct_fields__[-1], "mm_inputs_process_mode"
+        )
+        self.assertEqual(
+            TokenizedEmbeddingReqInput.__struct_fields__[-1], "mm_inputs_process_mode"
+        )
+        self.assertEqual(
+            [(member.name, member.value) for member in MMInputsProcessMode],
+            [("NONE", 0), ("LOCAL", 1), ("BROADCAST", 2)],
+        )
+
+    def test_mm_process_mode_msgpack_round_trip_and_old_array_default(self):
+        generate_req = TokenizedGenerateReqInput(
+            input_text="",
+            input_ids=array("q", [1]),
+            input_embeds=None,
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            return_logprob=False,
+            logprob_start_len=0,
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            stream=False,
+            mm_inputs_process_mode=MMInputsProcessMode.BROADCAST,
+        )
+        decoded_generate = self._round_trip(generate_req)
+        self.assertIs(
+            decoded_generate.mm_inputs_process_mode, MMInputsProcessMode.BROADCAST
+        )
+
+        # The old wire format is the same tagged array without the newly
+        # appended tail field. msgspec must apply the DTO default on decode.
+        old_generate_wire = msgspec.msgpack.decode(msgpack_encode(generate_req))
+        old_generate_wire.pop()
+        decoded_old_generate = msgpack_decode(msgspec.msgpack.encode(old_generate_wire))
+        self.assertIs(
+            decoded_old_generate.mm_inputs_process_mode, MMInputsProcessMode.NONE
+        )
+
+        embedding_req = TokenizedEmbeddingReqInput(
+            input_text="",
+            input_ids=array("q", [1]),
+            mm_inputs=None,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            mm_inputs_process_mode=MMInputsProcessMode.BROADCAST,
+        )
+        decoded_embedding = self._round_trip(embedding_req)
+        self.assertIs(
+            decoded_embedding.mm_inputs_process_mode, MMInputsProcessMode.BROADCAST
+        )
+
+        old_embedding_wire = msgspec.msgpack.decode(msgpack_encode(embedding_req))
+        old_embedding_wire.pop()
+        decoded_old_embedding = msgpack_decode(
+            msgspec.msgpack.encode(old_embedding_wire)
+        )
+        self.assertIs(
+            decoded_old_embedding.mm_inputs_process_mode, MMInputsProcessMode.NONE
         )
 
     def _make_mm_inputs(self, device="cpu"):

--- a/test/registered/unit/managers/test_mm_broadcast_protocol.py
+++ b/test/registered/unit/managers/test_mm_broadcast_protocol.py
@@ -1,0 +1,724 @@
+import multiprocessing
+import os
+import queue
+import tempfile
+import unittest
+from array import array
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import call, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.distributed import communication_op  # noqa: E402
+from sglang.srt.managers import scheduler as scheduler_module  # noqa: E402
+from sglang.srt.managers.io_struct import (  # noqa: E402
+    MMInputsProcessError,
+    MMInputsProcessMode,
+    TokenizedGenerateReqInput,
+)
+from sglang.srt.managers.scheduler_components import (  # noqa: E402
+    request_receiver as receiver_module,
+)
+from sglang.srt.sampling.sampling_params import SamplingParams  # noqa: E402
+
+register_cpu_ci(est_time=50, suite="base-a-test-cpu")
+
+
+class _Request:
+    def __init__(self, mm_inputs, mode=MMInputsProcessMode.NONE):
+        self.mm_inputs = mm_inputs
+        self.mm_inputs_process_mode = mode
+
+
+class _EmbeddingRequest(_Request):
+    pass
+
+
+class _BatchRequest:
+    def __init__(self, batch):
+        self.batch = batch
+
+    def __iter__(self):
+        return iter(self.batch)
+
+
+class _EmbeddingBatchRequest(_BatchRequest):
+    pass
+
+
+def _group(name, rank=0, ranks=(0, 1)):
+    return SimpleNamespace(
+        name=name, rank=rank, ranks=list(ranks), world_size=len(ranks)
+    )
+
+
+def _receiver(*, tp_rank=0, attn_tp_rank=0, attn_cp_rank=0):
+    receiver = object.__new__(receiver_module.SchedulerRequestReceiver)
+    object.__setattr__(
+        receiver,
+        "ps",
+        SimpleNamespace(
+            tp_size=2,
+            attn_tp_size=2,
+            attn_cp_size=2,
+            attn_tp_rank=attn_tp_rank,
+            attn_cp_rank=attn_cp_rank,
+        ),
+    )
+    object.__setattr__(receiver, "tp_group", _group("tp", rank=tp_rank))
+    object.__setattr__(receiver, "tp_cpu_group", "tp-cpu")
+    object.__setattr__(receiver, "attn_tp_group", _group("attn-tp", rank=attn_tp_rank))
+    object.__setattr__(receiver, "attn_tp_cpu_group", f"attn-tp-cp{attn_cp_rank}")
+    object.__setattr__(receiver, "attn_cp_group", _group("attn-cp", rank=attn_cp_rank))
+    object.__setattr__(receiver, "attn_cp_cpu_group", f"attn-cp-tp{attn_tp_rank}")
+    return receiver
+
+
+def _run_gloo_mm_broadcast_regression(rank, world_size, init_method, result_queue):
+    """Exercise the real TP collective; this function must remain spawn-picklable."""
+    import torch.distributed as dist
+
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=8),
+    )
+    try:
+        receiver = _receiver(tp_rank=rank)
+        object.__setattr__(receiver, "tp_cpu_group", dist.group.WORLD)
+        request = _Request(
+            "rank-0-raw-mm-input" if rank == 0 else None,
+            MMInputsProcessMode.BROADCAST,
+        )
+        with (
+            patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+            patch.object(
+                receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+            ),
+            patch.object(
+                receiver_module,
+                "get_parallel",
+                return_value=SimpleNamespace(enable_dp_attention=False),
+            ),
+            patch.object(receiver_module, "unwrap_shm_features"),
+            patch.object(
+                receiver_module.MultimodalInputs,
+                "from_processor_output",
+                side_effect=lambda raw: scheduler_module.MultimodalInputs(
+                    mm_items=[{"materialized_from": raw}]
+                ),
+            ),
+        ):
+            receiver._set_mm_process_mode([request], only_if_none=True)
+            receiver._materialize_broadcast_mm_inputs([request])
+
+        gathered = [None] * world_size
+        dist.all_gather_object(gathered, request.mm_inputs.mm_items)
+        if rank == 0:
+            result_queue.put(("ok", gathered))
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_gloo_mm_broadcast_regression_with_watchdog(
+    world_size, init_method, result_queue
+):
+    """Contain a broken collective schedule so the parent test cannot hang."""
+    import torch.multiprocessing as torch_mp
+
+    try:
+        torch_mp.spawn(
+            _run_gloo_mm_broadcast_regression,
+            args=(world_size, init_method, result_queue),
+            nprocs=world_size,
+            join=True,
+        )
+    except BaseException as exc:
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+def _run_gloo_dp_attention_mm_broadcast_regression(
+    rank, world_size, init_method, result_queue
+):
+    """Exercise the shared TP-then-CP fanout with real TP2 x CP2 Gloo groups."""
+    import torch.distributed as dist
+
+    dist.init_process_group(
+        backend="gloo",
+        init_method=init_method,
+        rank=rank,
+        world_size=world_size,
+        timeout=timedelta(seconds=8),
+    )
+    try:
+        # All ranks create the same orthogonal subgroups in the same order.
+        cp_groups = [dist.new_group([0, 2]), dist.new_group([1, 3])]
+        tp_groups = [dist.new_group([0, 1]), dist.new_group([2, 3])]
+        tp_rank, cp_rank = rank % 2, rank // 2
+        receiver = _receiver(tp_rank=rank, attn_tp_rank=tp_rank, attn_cp_rank=cp_rank)
+        object.__setattr__(receiver, "attn_cp_cpu_group", cp_groups[tp_rank])
+        object.__setattr__(receiver, "attn_tp_cpu_group", tp_groups[cp_rank])
+        object.__setattr__(
+            receiver, "attn_cp_group", _group("cp", rank, (tp_rank, tp_rank + 2))
+        )
+        object.__setattr__(
+            receiver,
+            "attn_tp_group",
+            _group("tp", rank, (cp_rank * 2, cp_rank * 2 + 1)),
+        )
+
+        request = _Request(
+            "rank-0-raw-mm-input" if rank == 0 else None,
+            MMInputsProcessMode.BROADCAST,
+        )
+        trace = []
+        original_broadcast = communication_op.broadcast_pyobj
+
+        def traced_broadcast(data, group_rank, group, src):
+            trace.append(
+                ("cp" if group is cp_groups[tp_rank] else "tp", group_rank, src)
+            )
+            return original_broadcast(data, group_rank, group, src)
+
+        with (
+            patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+            patch.object(
+                receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+            ),
+            patch.object(
+                receiver_module,
+                "get_parallel",
+                return_value=SimpleNamespace(
+                    enable_dp_attention=True,
+                    enable_dp_attention_local_control_broadcast=True,
+                ),
+            ),
+            patch.object(receiver_module, "unwrap_shm_features"),
+            patch.object(
+                receiver_module.MultimodalInputs,
+                "from_processor_output",
+                side_effect=lambda raw: scheduler_module.MultimodalInputs(
+                    mm_items=[{"materialized_from": raw}]
+                ),
+            ),
+            patch.object(
+                communication_op, "broadcast_pyobj", side_effect=traced_broadcast
+            ),
+            patch.object(
+                communication_op,
+                "get_attn_tp_group",
+                return_value=SimpleNamespace(
+                    rank=rank,
+                    ranks=receiver.attn_tp_group.ranks,
+                    world_size=2,
+                    cpu_group=tp_groups[cp_rank],
+                ),
+            ),
+            patch.object(
+                communication_op,
+                "get_attn_cp_group",
+                return_value=SimpleNamespace(
+                    rank=rank,
+                    ranks=receiver.attn_cp_group.ranks,
+                    world_size=2,
+                    cpu_group=cp_groups[tp_rank],
+                ),
+            ),
+        ):
+            requests = receiver._broadcast_reqs_across_ranks(
+                [request] if rank == 0 else None
+            )
+            request = requests[0]
+            if rank != 0:
+                request.mm_inputs = None
+            receiver._materialize_broadcast_mm_inputs(requests)
+
+        gathered = [None] * world_size
+        dist.all_gather_object(gathered, (request.mm_inputs.mm_items, trace))
+        if rank == 0:
+            result_queue.put(("ok", gathered))
+    finally:
+        dist.destroy_process_group()
+
+
+def _run_gloo_dp_attention_mm_broadcast_regression_with_watchdog(
+    world_size, init_method, result_queue
+):
+    """Contain a broken CP/TP collective schedule so the parent cannot hang."""
+    import torch.multiprocessing as torch_mp
+
+    try:
+        torch_mp.spawn(
+            _run_gloo_dp_attention_mm_broadcast_regression,
+            args=(world_size, init_method, result_queue),
+            nprocs=world_size,
+            join=True,
+        )
+    except BaseException as exc:
+        result_queue.put(("error", f"{type(exc).__name__}: {exc}"))
+
+
+class TestMmBroadcastProtocol(unittest.TestCase):
+    def test_tp2_gloo_ordered_protocol_materializes_root_raw_input_on_all_ranks(self):
+        """A local ``None`` peer must still join the root's ordered MM broadcast.
+
+        The outer process is a watchdog for the historical mismatched-collective
+        regression; Gloo's own short timeout supplies a useful child-side error.
+        """
+        fd, store_path = tempfile.mkstemp(prefix="sglang-mm-broadcast-")
+        os.close(fd)
+        os.unlink(store_path)
+        result_queue = multiprocessing.get_context("spawn").Queue()
+        watchdog = multiprocessing.get_context("spawn").Process(
+            target=_run_gloo_mm_broadcast_regression_with_watchdog,
+            args=(2, f"file://{store_path}", result_queue),
+        )
+        try:
+            watchdog.start()
+            # Spawn imports the scheduler in both watchdog and workers before
+            # Gloo's separate 8-second collective timeout begins.
+            watchdog.join(timeout=60)
+            if watchdog.is_alive():
+                watchdog.terminate()
+                watchdog.join(timeout=5)
+                self.fail("2-process Gloo MM broadcast exceeded its watchdog timeout")
+            self.assertEqual(watchdog.exitcode, 0)
+            try:
+                status, payload = result_queue.get(timeout=2)
+            except queue.Empty:
+                self.fail("2-process Gloo MM broadcast produced no result")
+            self.assertEqual(status, "ok", payload)
+            self.assertEqual(
+                payload,
+                [
+                    [{"materialized_from": "rank-0-raw-mm-input"}],
+                    [{"materialized_from": "rank-0-raw-mm-input"}],
+                ],
+            )
+        finally:
+            if watchdog.is_alive():
+                watchdog.terminate()
+                watchdog.join(timeout=5)
+            result_queue.close()
+            result_queue.join_thread()
+            if os.path.exists(store_path):
+                os.unlink(store_path)
+
+    def test_dp_attention_tp2_cp2_gloo_shared_fanout_completes(self):
+        """Real TP2 x CP2 groups must fan out one envelope without a hang.
+
+        The shared helper distributes the root envelope along TP, then CP.
+        Empty non-root envelopes keep every collective source serializable.
+        """
+        fd, store_path = tempfile.mkstemp(prefix="sglang-mm-dp-attn-broadcast-")
+        os.close(fd)
+        os.unlink(store_path)
+        result_queue = multiprocessing.get_context("spawn").Queue()
+        watchdog = multiprocessing.get_context("spawn").Process(
+            target=_run_gloo_dp_attention_mm_broadcast_regression_with_watchdog,
+            args=(4, f"file://{store_path}", result_queue),
+        )
+        try:
+            watchdog.start()
+            watchdog.join(timeout=60)
+            if watchdog.is_alive():
+                watchdog.terminate()
+                watchdog.join(timeout=5)
+                self.fail("TP2 x CP2 Gloo MM fanout exceeded its watchdog timeout")
+            self.assertEqual(watchdog.exitcode, 0)
+            try:
+                status, payload = result_queue.get(timeout=2)
+            except queue.Empty:
+                self.fail("TP2 x CP2 Gloo MM fanout produced no result")
+            self.assertEqual(status, "ok", payload)
+            self.assertEqual(
+                [mm_items for mm_items, _ in payload],
+                [[{"materialized_from": "rank-0-raw-mm-input"}]] * 4,
+            )
+            self.assertEqual(
+                [trace for _, trace in payload],
+                [
+                    [("tp", 0, 0), ("cp", 0, 0)] * 3,
+                    [("tp", 1, 0), ("cp", 1, 1)] * 3,
+                    [("tp", 2, 2), ("cp", 2, 0)] * 3,
+                    [("tp", 3, 2), ("cp", 3, 1)] * 3,
+                ],
+            )
+        finally:
+            if watchdog.is_alive():
+                watchdog.terminate()
+                watchdog.join(timeout=5)
+            result_queue.close()
+            result_queue.join_thread()
+            if os.path.exists(store_path):
+                os.unlink(store_path)
+
+    def test_source_stamps_shared_modes_for_generate_embedding_and_batches(self):
+        receiver = object.__new__(receiver_module.SchedulerRequestReceiver)
+        image = _Request(object())
+        text = _Request(None)
+        embedding = _EmbeddingRequest(object())
+        batch = _BatchRequest([image])
+        embedding_batch = _EmbeddingBatchRequest([embedding])
+
+        with (
+            patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+            patch.object(
+                receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+            ),
+            patch.object(
+                receiver_module, "BatchTokenizedGenerateReqInput", _BatchRequest
+            ),
+            patch.object(
+                receiver_module,
+                "BatchTokenizedEmbeddingReqInput",
+                _EmbeddingBatchRequest,
+            ),
+            patch.object(
+                receiver_module,
+                "get_mm",
+                return_value=SimpleNamespace(
+                    enable_broadcast_mm_inputs_process=True,
+                    mm_feature_transport="cpu",
+                ),
+            ),
+        ):
+            receiver._set_mm_process_mode([text, batch, embedding_batch])
+
+        self.assertIs(text.mm_inputs_process_mode, MMInputsProcessMode.NONE)
+        self.assertIs(image.mm_inputs_process_mode, MMInputsProcessMode.BROADCAST)
+        self.assertIs(embedding.mm_inputs_process_mode, MMInputsProcessMode.BROADCAST)
+
+    def test_cuda_vmm_uses_local_mode_even_when_broadcast_is_enabled(self):
+        receiver = object.__new__(receiver_module.SchedulerRequestReceiver)
+        request = _Request(object())
+        with (
+            patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+            patch.object(
+                receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+            ),
+            patch.object(
+                receiver_module,
+                "get_mm",
+                return_value=SimpleNamespace(
+                    enable_broadcast_mm_inputs_process=True,
+                    mm_feature_transport="cuda_vmm",
+                ),
+            ),
+        ):
+            receiver._set_mm_process_mode([request])
+        self.assertIs(request.mm_inputs_process_mode, MMInputsProcessMode.LOCAL)
+
+    def test_mixed_work_list_uses_one_ordered_collective_per_broadcast_item(self):
+        receiver = _receiver()
+        first = _Request("first", MMInputsProcessMode.BROADCAST)
+        text = _Request(None)
+        local = _Request("local", MMInputsProcessMode.LOCAL)
+        second = _EmbeddingRequest("second", MMInputsProcessMode.BROADCAST)
+        requests = [first, text, _BatchRequest([local, second])]
+        outputs = [
+            scheduler_module.MultimodalInputs(mm_items=[]),
+            scheduler_module.MultimodalInputs(mm_items=[]),
+        ]
+        with (
+            patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+            patch.object(
+                receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+            ),
+            patch.object(
+                receiver_module, "BatchTokenizedGenerateReqInput", _BatchRequest
+            ),
+            patch.object(
+                receiver_module,
+                "BatchTokenizedEmbeddingReqInput",
+                _EmbeddingBatchRequest,
+            ),
+            patch.object(
+                receiver_module,
+                "get_parallel",
+                return_value=SimpleNamespace(enable_dp_attention=False),
+            ),
+            patch.object(
+                receiver_module.MultimodalInputs,
+                "from_processor_output",
+                side_effect=outputs,
+            ) as materialize,
+            patch.object(
+                receiver_module,
+                "broadcast_pyobj",
+                side_effect=lambda data, *args, **kwargs: data,
+            ) as broadcast,
+        ):
+            receiver._materialize_broadcast_mm_inputs(requests)
+
+        self.assertEqual(materialize.call_args_list, [call("first"), call("second")])
+        self.assertEqual(broadcast.call_count, 2)
+        self.assertIs(first.mm_inputs, outputs[0])
+        self.assertIs(second.mm_inputs, outputs[1])
+        self.assertEqual(local.mm_inputs, "local")
+
+    def test_epd_waiting_success_refill_recomputes_mode_before_protocol(self):
+        class WaitingReceiver:
+            def __init__(self, refilled_mm_inputs):
+                self.refilled_mm_inputs = refilled_mm_inputs
+
+            def process_waiting_requests(self, requests):
+                for request in requests:
+                    request.mm_inputs = self.refilled_mm_inputs
+                return requests, []
+
+        for backend in ("zmq_to_scheduler", "mooncake"):
+            with self.subTest(backend=backend):
+                receivers = [_receiver(tp_rank=rank) for rank in range(2)]
+                requests = [_Request(None), _Request(None)]
+                raw_refill = object()
+                for receiver in receivers:
+                    receiver.ps.pp_rank = 0
+                    object.__setattr__(
+                        receiver, "mm_receiver", WaitingReceiver(raw_refill)
+                    )
+                    object.__setattr__(
+                        receiver, "stream_output", lambda *args, **kwargs: None
+                    )
+
+                with (
+                    patch.object(
+                        receiver_module, "TokenizedGenerateReqInput", _Request
+                    ),
+                    patch.object(
+                        receiver_module,
+                        "TokenizedEmbeddingReqInput",
+                        _EmbeddingRequest,
+                    ),
+                    patch.object(
+                        receiver_module,
+                        "get_disagg",
+                        return_value=SimpleNamespace(
+                            language_only=True,
+                            encoder_transfer_backend=backend,
+                        ),
+                    ),
+                    patch.object(
+                        receiver_module,
+                        "get_mm",
+                        return_value=SimpleNamespace(
+                            enable_broadcast_mm_inputs_process=True,
+                            mm_feature_transport="cpu",
+                        ),
+                    ),
+                ):
+                    for receiver, request in zip(receivers, requests):
+                        receiver._set_mm_process_mode([request])
+                        self.assertIs(
+                            request.mm_inputs_process_mode,
+                            MMInputsProcessMode.NONE,
+                        )
+                        refilled = receiver._apply_mm_receiver([request])
+                        receiver._set_mm_process_mode(refilled, only_if_none=True)
+
+                self.assertTrue(
+                    all(
+                        request.mm_inputs_process_mode is MMInputsProcessMode.BROADCAST
+                        for request in requests
+                    )
+                )
+
+    def test_dp_attention_reuses_request_fanout_with_empty_peer_envelopes(self):
+        output = scheduler_module.MultimodalInputs(mm_items=[])
+        envelope = (output, None)
+        for tp_rank, cp_rank in ((0, 0), (0, 1), (1, 0), (1, 1)):
+            with self.subTest(tp_rank=tp_rank, cp_rank=cp_rank):
+                receiver = _receiver(attn_tp_rank=tp_rank, attn_cp_rank=cp_rank)
+                request = _Request("image", MMInputsProcessMode.BROADCAST)
+                with (
+                    patch.object(
+                        receiver_module, "TokenizedGenerateReqInput", _Request
+                    ),
+                    patch.object(
+                        receiver_module,
+                        "get_parallel",
+                        return_value=SimpleNamespace(enable_dp_attention=True),
+                    ),
+                    patch.object(
+                        receiver_module.MultimodalInputs,
+                        "from_processor_output",
+                        return_value=output,
+                    ) as materialize,
+                    patch.object(
+                        receiver_module,
+                        "attn_cp_tp_broadcast_pyobj",
+                        return_value=[envelope],
+                    ) as broadcast,
+                ):
+                    receiver._materialize_broadcast_mm_inputs([request])
+                is_source = tp_rank == 0 and cp_rank == 0
+                broadcast.assert_called_once_with([envelope] if is_source else [])
+                self.assertEqual(materialize.call_count, int(is_source))
+                self.assertIs(request.mm_inputs, output)
+
+    def test_root_error_becomes_consistent_abort_sentinel(self):
+        receiver = _receiver()
+        request = _Request("bad", MMInputsProcessMode.BROADCAST)
+        with self.assertLogs(receiver_module.logger, level="ERROR") as logs:
+            with (
+                patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+                patch.object(
+                    receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+                ),
+                patch.object(
+                    receiver_module,
+                    "get_parallel",
+                    return_value=SimpleNamespace(enable_dp_attention=False),
+                ),
+                patch.object(
+                    receiver_module.MultimodalInputs,
+                    "from_processor_output",
+                    side_effect=ValueError("bad image"),
+                ),
+                patch.object(
+                    receiver_module,
+                    "broadcast_pyobj",
+                    side_effect=lambda data, *args, **kwargs: data,
+                ) as broadcast,
+            ):
+                receiver._materialize_broadcast_mm_inputs([request])
+
+        self.assertEqual(broadcast.call_count, 1)
+        self.assertIn(
+            "Failed to materialize broadcast multimodal inputs on entry rank",
+            logs.output[0],
+        )
+        self.assertIn("ValueError: bad image", logs.output[0])
+        self.assertIsInstance(request.mm_inputs, MMInputsProcessError)
+        self.assertIs(request.mm_inputs_process_mode, MMInputsProcessMode.LOCAL)
+        self.assertIn("ValueError: bad image", request.mm_inputs.message)
+        scheduler = object.__new__(scheduler_module.Scheduler)
+        with self.assertRaisesRegex(
+            scheduler_module._MultimodalInputProcessingError, "ValueError: bad image"
+        ):
+            scheduler._get_multimodal_inputs(
+                request.mm_inputs, MMInputsProcessMode.LOCAL
+            )
+
+    def test_peer_consumes_ordered_error_envelope_without_materializing(self):
+        receiver = _receiver(tp_rank=1)
+        request = _Request(None, MMInputsProcessMode.BROADCAST)
+        envelope = (None, "Failed to process multimodal inputs on entry rank: bad")
+        with self.assertNoLogs(receiver_module.logger, level="ERROR"):
+            with (
+                patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+                patch.object(
+                    receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+                ),
+                patch.object(
+                    receiver_module,
+                    "get_parallel",
+                    return_value=SimpleNamespace(enable_dp_attention=False),
+                ),
+                patch.object(
+                    receiver_module.MultimodalInputs, "from_processor_output"
+                ) as materialize,
+                patch.object(receiver_module, "broadcast_pyobj", return_value=envelope),
+            ):
+                receiver._materialize_broadcast_mm_inputs([request])
+
+        materialize.assert_not_called()
+        self.assertIsInstance(request.mm_inputs, MMInputsProcessError)
+        self.assertIs(request.mm_inputs_process_mode, MMInputsProcessMode.LOCAL)
+        self.assertEqual(request.mm_inputs.message, envelope[1])
+
+    def test_shm_unwrap_failure_is_sent_as_an_ordered_error_envelope(self):
+        receiver = _receiver()
+        request = _Request("shm", MMInputsProcessMode.BROADCAST)
+        with (
+            patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+            patch.object(
+                receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+            ),
+            patch.object(
+                receiver_module,
+                "get_parallel",
+                return_value=SimpleNamespace(enable_dp_attention=False),
+            ),
+            patch.object(
+                receiver_module, "unwrap_shm_features", side_effect=OSError("shm gone")
+            ),
+            patch.object(receiver_module, "has_shm_features", return_value=True),
+            patch.object(
+                receiver_module.MultimodalInputs, "from_processor_output"
+            ) as materialize,
+            patch.object(
+                receiver_module,
+                "broadcast_pyobj",
+                side_effect=lambda data, *args, **kwargs: data,
+            ),
+        ):
+            receiver._materialize_broadcast_mm_inputs([request])
+
+        materialize.assert_not_called()
+        self.assertIsInstance(request.mm_inputs, MMInputsProcessError)
+        self.assertIn("OSError: shm gone", request.mm_inputs.message)
+
+    def test_pp_downstream_preserves_error_sentinel_without_shm_access(self):
+        receiver = _receiver()
+        object.__setattr__(
+            receiver, "model_config", SimpleNamespace(is_multimodal=True)
+        )
+        sentinel = MMInputsProcessError("upstream failure")
+        request = TokenizedGenerateReqInput(
+            input_text="",
+            input_ids=array("q", [1]),
+            input_embeds=None,
+            mm_inputs=sentinel,
+            token_type_ids=None,
+            sampling_params=SamplingParams(),
+            return_logprob=False,
+            logprob_start_len=0,
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            stream=False,
+            mm_inputs_process_mode=MMInputsProcessMode.BROADCAST,
+        )
+        with patch.object(receiver_module, "broadcast_pyobj") as broadcast:
+            receiver._set_mm_process_mode([request])
+            receiver._finalize_shm_features([request])
+            receiver._materialize_broadcast_mm_inputs([request])
+
+        self.assertIs(request.mm_inputs, sentinel)
+        self.assertIs(request.mm_inputs_process_mode, MMInputsProcessMode.LOCAL)
+        broadcast.assert_not_called()
+
+    def test_pp_downstream_preserves_prepared_mm_inputs_without_rebroadcasting(self):
+        receiver = _receiver()
+        prepared = scheduler_module.MultimodalInputs(mm_items=[])
+        request = _Request(prepared, MMInputsProcessMode.BROADCAST)
+        with (
+            patch.object(receiver_module, "TokenizedGenerateReqInput", _Request),
+            patch.object(
+                receiver_module, "TokenizedEmbeddingReqInput", _EmbeddingRequest
+            ),
+            patch.object(receiver_module, "broadcast_pyobj") as broadcast,
+        ):
+            receiver._set_mm_process_mode([request])
+            receiver._materialize_broadcast_mm_inputs([request])
+
+        self.assertIs(request.mm_inputs_process_mode, MMInputsProcessMode.LOCAL)
+        self.assertIs(request.mm_inputs, prepared)
+        broadcast.assert_not_called()
+
+    def test_text_requests_add_no_mm_collective(self):
+        receiver = _receiver()
+        text = _Request(None, MMInputsProcessMode.NONE)
+        with patch.object(receiver_module, "broadcast_pyobj") as broadcast:
+            receiver._materialize_broadcast_mm_inputs([text])
+        broadcast.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_mm_shm_error_consensus.py
+++ b/test/registered/unit/managers/test_mm_shm_error_consensus.py
@@ -17,6 +17,7 @@ maybe_stub_sgl_kernel()
 from sglang.srt.managers.io_struct import (  # noqa: E402
     BatchTokenizedEmbeddingReqInput,
     MMInputsProcessError,
+    MMInputsProcessMode,
     TokenizedEmbeddingReqInput,
 )
 from sglang.srt.managers.mm_utils import ShmPointerMMData  # noqa: E402
@@ -133,9 +134,15 @@ def _run_consensus_rank(rank: int, world_size: int, init_file: str) -> None:
     )
     try:
         req = _request(_failed_pointer() if rank == 1 else _successful_pointer())
+        req.mm_inputs_process_mode = MMInputsProcessMode.BROADCAST
         parallel = SimpleNamespace(enable_dp_attention=False)
         receiver = _receiver(tp_size=world_size)
         object.__setattr__(receiver, "tp_cpu_group", torch.distributed.group.WORLD)
+        object.__setattr__(
+            receiver,
+            "tp_group",
+            SimpleNamespace(rank=rank, ranks=list(range(world_size))),
+        )
         with (
             patch(
                 "sglang.srt.managers.mm_utils._get_is_default_transport",
@@ -151,8 +158,11 @@ def _run_consensus_rank(rank: int, world_size: int, init_file: str) -> None:
             ),
         ):
             receiver._finalize_shm_features([req])
+            receiver._materialize_broadcast_mm_inputs([req])
         if not isinstance(req.mm_inputs, MMInputsProcessError):
             raise AssertionError(f"rank {rank} did not receive the VLM request error")
+        if req.mm_inputs_process_mode is not MMInputsProcessMode.LOCAL:
+            raise AssertionError(f"rank {rank} did not finish the MM protocol")
     finally:
         torch.distributed.destroy_process_group()
 
@@ -239,7 +249,9 @@ class TestShmRequestFailureConsensus(unittest.TestCase):
 
         self.assertIsInstance(req.mm_inputs, MMInputsProcessError)
         with self.assertRaises(_MultimodalInputProcessingError):
-            Scheduler._get_multimodal_inputs(object.__new__(Scheduler), req.mm_inputs)
+            Scheduler._get_multimodal_inputs(
+                object.__new__(Scheduler), req.mm_inputs, MMInputsProcessMode.LOCAL
+            )
 
     def test_peer_failure_rejects_the_local_request(self):
         req = _request(torch.zeros(1))

--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -853,9 +853,6 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
                 return_value=materialized,
             ) as build_inputs,
             patch.object(
-                scheduler, "_process_and_broadcast_mm_inputs"
-            ) as cpu_broadcast,
-            patch.object(
                 scheduler_module, "is_health_check_generate_req", return_value=False
             ),
         ):
@@ -864,7 +861,6 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
         build_inputs.assert_called_once_with(raw_inputs)
         self.assertIs(request.mm_inputs, materialized)
         scheduler._request_dispatcher.assert_called_once_with(request)
-        cpu_broadcast.assert_not_called()
 
     def test_materializes_batched_inputs_before_dispatch(self):
         from sglang.srt.managers import scheduler as scheduler_module
@@ -923,96 +919,21 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
         scheduler._request_dispatcher.assert_called_once_with(request)
 
     def test_already_materialized_inputs_are_reused(self):
+        from sglang.srt.managers.io_struct import MMInputsProcessMode
         from sglang.srt.managers.schedule_batch import MultimodalInputs
         from sglang.srt.managers.scheduler import Scheduler
 
         scheduler = object.__new__(Scheduler)
         mm_inputs = MultimodalInputs(mm_items=[])
 
-        with patch.object(
-            scheduler, "_process_and_broadcast_mm_inputs"
-        ) as process_and_broadcast:
-            self.assertIs(scheduler._get_multimodal_inputs(mm_inputs), mm_inputs)
-
-        process_and_broadcast.assert_not_called()
-
-    def test_broadcast_mm_inputs_sends_entry_rank_processing_error(self):
-        from sglang.srt.managers import scheduler as scheduler_module
-
-        scheduler = object.__new__(scheduler_module.Scheduler)
-        scheduler.dp_tp_group = SimpleNamespace(rank_in_group=0, first_rank=0)
-        scheduler.dp_tp_cpu_group = object()
-
-        with (
-            patch.object(
-                scheduler_module.MultimodalInputs,
-                "from_processor_output",
-                side_effect=ValueError("bad image"),
-            ),
-            patch.object(
-                scheduler_module.torch.distributed, "is_available", return_value=True
-            ),
-            patch.object(
-                scheduler_module.torch.distributed,
-                "is_initialized",
-                return_value=True,
-            ),
-            patch.object(
-                scheduler_module.torch.distributed, "get_world_size", return_value=2
-            ),
-            patch.object(
-                scheduler_module.torch.distributed, "broadcast_object_list"
-            ) as broadcast,
-            self.assertRaisesRegex(
-                scheduler_module._MultimodalInputProcessingError,
-                "ValueError: bad image",
-            ),
-        ):
-            scheduler._process_and_broadcast_mm_inputs(object())
-
-        payload = broadcast.call_args.args[0][0]
-        self.assertIn("ValueError: bad image", payload.error)
-
-    def test_broadcast_mm_inputs_peer_rank_receives_processing_error(self):
-        from sglang.srt.managers import scheduler as scheduler_module
-
-        scheduler = object.__new__(scheduler_module.Scheduler)
-        scheduler.dp_tp_group = SimpleNamespace(rank_in_group=1, first_rank=0)
-        scheduler.dp_tp_cpu_group = object()
-
-        def receive_error(obj_list, **_kwargs):
-            obj_list[0] = scheduler_module._MultimodalInputBroadcast(error="bad image")
-
-        with (
-            patch.object(
-                scheduler_module.MultimodalInputs, "from_processor_output"
-            ) as materialize,
-            patch.object(
-                scheduler_module.torch.distributed, "is_available", return_value=True
-            ),
-            patch.object(
-                scheduler_module.torch.distributed,
-                "is_initialized",
-                return_value=True,
-            ),
-            patch.object(
-                scheduler_module.torch.distributed, "get_world_size", return_value=2
-            ),
-            patch.object(
-                scheduler_module.torch.distributed,
-                "broadcast_object_list",
-                side_effect=receive_error,
-            ),
-            self.assertRaisesRegex(
-                scheduler_module._MultimodalInputProcessingError, "bad image"
-            ),
-        ):
-            scheduler._process_and_broadcast_mm_inputs(object())
-
-        materialize.assert_not_called()
+        self.assertIs(
+            scheduler._get_multimodal_inputs(mm_inputs, MMInputsProcessMode.LOCAL),
+            mm_inputs,
+        )
 
     def test_embedding_request_aborts_broadcast_processing_error(self):
         from sglang.srt.managers import scheduler as scheduler_module
+        from sglang.srt.managers.io_struct import MMInputsProcessMode
 
         scheduler = object.__new__(scheduler_module.Scheduler)
         scheduler.tokenizer = object()
@@ -1038,6 +959,7 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
             return_pooled_hidden_states=False,
             multi_item_delimiter_indices=None,
             mm_inputs=object(),
+            mm_inputs_process_mode=MMInputsProcessMode.LOCAL,
         )
 
         with patch.object(scheduler_module, "Req", return_value=req):


### PR DESCRIPTION
# [Fix] synchronize multimodal input broadcast across scheduler ranks

## Motivation

The old code decided whether to broadcast from each rank's local `mm_inputs`.
If rank states differed, ranks entered different collective sequences.

The visible failure may surface later as:

```text
Watchdog caught collective operation timeout:
WorkNCCL(... OpType=ALLREDUCE ...)
```

The timed-out AllReduce is the symptom; the earlier rank-divergent broadcast
schedule is the root cause.

## Modifications

```mermaid
flowchart TD
    A["Before: each rank checks its local mm_inputs"] --> B["Rank 0 enters the multimodal broadcast"]
    A --> C["Rank 1 skips it and continues"]
    B --> D["Collective order diverges<br/>and the process group hangs"]
    C --> D

    D --> E["After: entry rank selects<br/>NONE / LOCAL / BROADCAST"]
    E --> F["The request and mode are broadcast to all ranks"]
    F --> G["All ranks follow the same collective schedule"]
    G --> H["Entry rank broadcasts the result or error"]
    H --> I["All ranks continue or abort consistently"]
```

- Stamp the processing mode before broadcasting the request to scheduler ranks.
- Materialize `BROADCAST` inputs once in the request receiver, before handlers
  can exit early; reuse the existing TP-then-CP broadcast helper.
- Preserve upstream shared-memory failure consensus and request-local HTTP 500
  handling.
- Propagate entry-rank failures as a shared error envelope and retain the full
  traceback in server logs.
- Prepared PP inputs and CUDA-VMM inputs bypass this CPU broadcast path.
- Append a defaulted trailing mode field. `msgspec` defaults missing values and
  ignores extra trailing values; mixed-version rolling upgrades remain unsupported.

Text-only requests use `NONE` and add no multimodal collective.

## Accuracy Tests

Not applicable. This change does not modify model computation or outputs.

## Speed Tests and Profiling

Not applicable. This PR makes no performance claim, and text-only requests add
no collective.

## Tests

- Two-rank Gloo ordered-broadcast test with a watchdog.
- Four-process TP2 x CP2 Gloo test covering request fanout and TP-then-CP result broadcast.
- Entry-rank error broadcast without peer-side reprocessing.
- Generate and embedding request round trips; a missing mode defaults to `NONE`.
- PP, shared-memory, CUDA-VMM, batch, and text-only paths.

Validated at `ade7a7a5dacc8209d7fb538600d12dfc2f78aef1` (based on
`c8207e32b63800ca21eb928fad2b6cc009490bd2`):

- CPU/distributed selection: 69 passed, 2 skipped; includes real Gloo process groups.
- CUDA wire/feature-transport selection on H20-3e: 51 passed, covering the CPU-skipped CUDA cases.
- Repository pre-push hooks and `git diff --check`: passed.
- Validation covers the protocol and transport tests above; a full VLM/EPD server
  replay is not included.

## Checklist

- [x] Format the changed Python files and pass the relevant lint checks.
- [x] Add focused unit and distributed regression tests.
- [x] No documentation update is required for this internal protocol fix.
- [x] Accuracy and speed results are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34081575611](https://github.com/sgl-project/sglang/actions/runs/34081575611)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34081575503](https://github.com/sgl-project/sglang/actions/runs/34081575503)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34081575582](https://github.com/sgl-project/sglang/actions/runs/34081575582)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
