### PR TITLE
[Bugfix] Restore disable_piecewise_cuda_graph Python kwarg

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1989,6 +1989,7 @@ class ServerArgs:
         NS("exec.graph"),
     ] = False
     disable_cuda_graph: A[bool, Arg(no_cli=True), NS("exec.graph")] = False
+    disable_piecewise_cuda_graph: A[bool, Arg(no_cli=True), NS("exec.graph")] = False
     disable_cuda_graph_padding: A[
         bool,
         "Disable cuda graph when padding is needed. Still uses cuda graph when padding is not needed.",
@@ -4853,6 +4854,8 @@ class ServerArgs:
         # ---- Legacy global flags (lowest precedence above defaults) ----
         if self.disable_cuda_graph:
             _set(Phase.DECODE, "backend", Backend.DISABLED)
+            _set(Phase.PREFILL, "backend", Backend.DISABLED)
+        if self.disable_piecewise_cuda_graph:
             _set(Phase.PREFILL, "backend", Backend.DISABLED)
 
         # ---- Boolean per-phase off-switches ----

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1669,6 +1669,35 @@ class TestPrefillOnlyDisableKvCache(unittest.TestCase):
 
 
 class TestCudaGraphConfigDataclassAccess(CustomTestCase):
+    def test_disable_piecewise_cuda_graph_python_kwarg_compatibility(self):
+        cases = [
+            (
+                {"disable_piecewise_cuda_graph": True},
+                Backend.DISABLED,
+            ),
+            (
+                {
+                    "disable_piecewise_cuda_graph": True,
+                    "cuda_graph_backend_prefill": Backend.BREAKABLE,
+                },
+                Backend.BREAKABLE,
+            ),
+            (
+                {
+                    "disable_piecewise_cuda_graph": True,
+                    "cuda_graph_config": {"prefill": {"backend": Backend.TC_PIECEWISE}},
+                },
+                Backend.TC_PIECEWISE,
+            ),
+        ]
+
+        for kwargs, expected in cases:
+            with self.subTest(kwargs=kwargs):
+                args = ServerArgs(model_path="dummy", **kwargs)
+                args._parse_cuda_graph_config()
+
+                self.assertEqual(args.cuda_graph_config.prefill.backend, expected)
+
     @patch(
         "sglang.srt.model_executor.runner_backend."
         "tc_piecewise_cuda_graph_backend.get_moe_a2a_backend"


### PR DESCRIPTION
## Motivation

Fixes #36478.

`--disable-piecewise-cuda-graph` still translates to the new prefill backend through argparse, but Python callers bypass argparse and fail while constructing `ServerArgs` because the legacy dataclass field was removed.

## Modifications

- Restore `disable_piecewise_cuda_graph` as a Python-only legacy `ServerArgs` field.
- Fold it into the prefill CUDA graph backend at the legacy precedence level, below canonical per-phase inputs and explicit `cuda_graph_config`.
- Add CPU unit coverage for the legacy mapping and both precedence levels.

## Accuracy Tests

Not applicable. This only restores argument compatibility and does not change model execution for canonical configurations.

## Speed Tests and Profiling

Not applicable.

## Tests

- Targeted compatibility test: passed.
- ServerArgs namespace, CLI metadata, mutation, and resolution guardrails: 40 passed, 11 subtests passed.
- RuntimeContext configuration tests: 36 passed, 8 subtests passed.
- Black 26.1.0, Ruff, registered-test lint, and `git diff --check`: passed.

## Checklist

- [x] Format the code with the repository-pinned Black version.
- [x] Add unit tests.
- [x] Documentation is unchanged because the existing CLI deprecation path remains the same.
- [x] Accuracy and speed tests are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32963666045](https://github.com/sgl-project/sglang/actions/runs/32963666045)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32963665871](https://github.com/sgl-project/sglang/actions/runs/32963665871)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32963665912](https://github.com/sgl-project/sglang/actions/runs/32963665912)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->