### PR TITLE
[diffusion] prefer cuDNN SDPA for Wan 1.3B on SM120

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/wanvideo.py
@@ -120,3 +120,4 @@ class WanVideoConfig(DiTConfig):
     arch_config: DiTArchConfig = field(default_factory=WanVideoArchConfig)
 
     prefix: str = "Wan"
+    prefer_cudnn_sdpa_on_sm120: bool = False

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -196,6 +196,15 @@ class WanI2V480PConfig(WanT2V480PConfig, WanI2VCommonConfig):
 
 
 @dataclass
+class Wan2_1_Fun_1_3B_InP_Config(WanI2V480PConfig):
+    """Configuration for the Wan2.1 Fun InP 1.3B checkpoint."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.dit_config.prefer_cudnn_sdpa_on_sm120 = True
+
+
+@dataclass
 class WanI2V720PConfig(WanI2V480PConfig):
     """Base configuration for Wan I2V 14B 720P pipeline architecture."""
 

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -221,6 +221,10 @@ class FastWan2_1_T2V_480P_Config(WanT2V480PConfig):
         default_factory=lambda: [1000, 757, 522]
     )
 
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.dit_config.prefer_cudnn_sdpa_on_sm120 = True
+
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(
             dit_layerwise_offload_modes=("memory",),

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/wan.py
@@ -125,6 +125,15 @@ class WanT2V480PConfig(PipelineConfig):
 
 
 @dataclass
+class Wan2_1_T2V_1_3B_Config(WanT2V480PConfig):
+    """Configuration for the Wan2.1 T2V 1.3B checkpoint."""
+
+    def __post_init__(self) -> None:
+        super().__post_init__()
+        self.dit_config.prefer_cudnn_sdpa_on_sm120 = True
+
+
+@dataclass
 class TurboWanT2V480PConfig(WanT2V480PConfig):
     """Base configuration for Wan T2V 1.3B pipeline architecture."""
 

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -109,6 +109,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.wan import (
     TurboWanI2V720Config,
     TurboWanT2V1_3B480PConfig,
     TurboWanT2V480PConfig,
+    Wan2_1_T2V_1_3B_Config,
     Wan2_2_I2V_A14B_Config,
     Wan2_2_T2V_A14B_Config,
     Wan2_2_TI2V_5B_Config,
@@ -829,10 +830,14 @@ def _register_configs():
     # Wan
     register_configs(
         sampling_param_cls=WanT2V_1_3B_SamplingParams,
-        pipeline_config_cls=WanT2V480PConfig,
+        pipeline_config_cls=Wan2_1_T2V_1_3B_Config,
         hf_model_paths=[
             "Wan-AI/Wan2.1-T2V-1.3B-Diffusers",
         ],
+    )
+    register_configs(
+        sampling_param_cls=WanT2V_1_3B_SamplingParams,
+        pipeline_config_cls=WanT2V480PConfig,
         model_detectors=[lambda hf_id: "wanpipeline" in hf_id.lower()],
     )
     register_configs(

--- a/python/sglang/multimodal_gen/registry.py
+++ b/python/sglang/multimodal_gen/registry.py
@@ -109,6 +109,7 @@ from sglang.multimodal_gen.configs.pipeline_configs.wan import (
     TurboWanI2V720Config,
     TurboWanT2V1_3B480PConfig,
     TurboWanT2V480PConfig,
+    Wan2_1_Fun_1_3B_InP_Config,
     Wan2_1_T2V_1_3B_Config,
     Wan2_2_I2V_A14B_Config,
     Wan2_2_T2V_A14B_Config,
@@ -886,7 +887,7 @@ def _register_configs():
     )
     register_configs(
         sampling_param_cls=Wan2_1_Fun_1_3B_InP_SamplingParams,
-        pipeline_config_cls=WanI2V480PConfig,
+        pipeline_config_cls=Wan2_1_Fun_1_3B_InP_Config,
         hf_model_paths=[
             "weizhou03/Wan2.1-Fun-1.3B-InP-Diffusers",
         ],

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -24,6 +24,9 @@ from sglang.multimodal_gen.runtime.distributed import (
     get_tp_world_size,
     sequence_model_parallel_all_gather,
 )
+from sglang.multimodal_gen.runtime.distributed.parallel_state import (
+    get_ring_parallel_world_size,
+)
 from sglang.multimodal_gen.runtime.layers.attention import (
     MinimalA2AAttnOp,
     UlyssesAttention_VSA,
@@ -88,6 +91,7 @@ def _wan_default_attention_backend(
         config.prefer_cudnn_sdpa_on_sm120
         and current_platform.is_sm120()
         and not enable_torch_compile
+        and get_ring_parallel_world_size() == 1
     ):
         return AttentionBackendEnum.TORCH_CUDNN_SDPA
     return None

--- a/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/wanvideo.py
@@ -76,6 +76,23 @@ if USE_AITER:
     from aiter.ops.rope import rope_cached_2c_fwd_inplace
 
 
+def _wan_default_attention_backend(
+    config: WanVideoConfig,
+    *,
+    enable_torch_compile: bool = False,
+) -> AttentionBackendEnum | None:
+    """Return a model-owned backend preference without overriding the CLI."""
+    # Composing the SM120 cuDNN preference with torch.compile did not improve
+    # end-to-end latency and missed the video worst-frame quality gate.
+    if (
+        config.prefer_cudnn_sdpa_on_sm120
+        and current_platform.is_sm120()
+        and not enable_torch_compile
+    ):
+        return AttentionBackendEnum.TORCH_CUDNN_SDPA
+    return None
+
+
 class WanImageEmbedding(torch.nn.Module):
     def __init__(self, in_features: int, out_features: int):
         super().__init__()
@@ -147,6 +164,7 @@ class WanSelfAttention(nn.Module):
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         is_cross_attention: bool = False,
         quant_config: QuantizationConfig | None = None,
+        default_attention_backend: AttentionBackendEnum | None = None,
     ) -> None:
         assert dim % num_heads == 0
         super().__init__()
@@ -201,6 +219,7 @@ class WanSelfAttention(nn.Module):
             softmax_scale=None,
             causal=False,
             supported_attention_backends=supported_attention_backends,
+            default_attention_backend=default_attention_backend,
             skip_sequence_parallel=is_cross_attention,
             is_cross_attention=is_cross_attention,
             quant_config=quant_config,
@@ -262,6 +281,7 @@ class WanI2VCrossAttention(WanSelfAttention):
         prefix: str = "",
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
         quant_config: QuantizationConfig | None = None,
+        default_attention_backend: AttentionBackendEnum | None = None,
     ) -> None:
         super().__init__(
             dim,
@@ -270,6 +290,7 @@ class WanI2VCrossAttention(WanSelfAttention):
             qk_norm,
             eps,
             supported_attention_backends=supported_attention_backends,
+            default_attention_backend=default_attention_backend,
             is_cross_attention=True,
             quant_config=quant_config,
         )
@@ -401,6 +422,7 @@ class WanTransformerBlock(nn.Module):
         attention_type: str = "original",
         sla_topk: float = 0.1,
         quant_config: QuantizationConfig | None = None,
+        default_attention_backend: AttentionBackendEnum | None = None,
     ):
         super().__init__()
 
@@ -466,6 +488,7 @@ class WanTransformerBlock(nn.Module):
                 head_size=dim // num_heads,
                 causal=False,
                 supported_attention_backends=self_attn_backends,
+                default_attention_backend=default_attention_backend,
                 prefix=add_prefix("attn1", prefix),
                 quant_config=quant_config,
                 is_cross_attention=False,
@@ -507,6 +530,7 @@ class WanTransformerBlock(nn.Module):
                 eps=eps,
                 prefix=add_prefix("attn2", prefix),
                 supported_attention_backends=cross_attn_backends,
+                default_attention_backend=default_attention_backend,
                 quant_config=quant_config,
             )
         else:
@@ -518,6 +542,7 @@ class WanTransformerBlock(nn.Module):
                 eps=eps,
                 prefix=add_prefix("attn2", prefix),
                 supported_attention_backends=cross_attn_backends,
+                default_attention_backend=default_attention_backend,
                 quant_config=quant_config,
             )
         self.cross_attn_residual_norm = ScaleResidualLayerNormScaleShift(
@@ -684,6 +709,7 @@ class WanTransformerBlock_VSA(nn.Module):
         attention_type: str = "original",
         sla_topk: float = 0.0,
         quant_config: QuantizationConfig | None = None,
+        default_attention_backend: AttentionBackendEnum | None = None,
     ):
         super().__init__()
 
@@ -777,6 +803,7 @@ class WanTransformerBlock_VSA(nn.Module):
                 eps=eps,
                 prefix=add_prefix("attn2", prefix),
                 supported_attention_backends=cross_attn_backends,
+                default_attention_backend=default_attention_backend,
                 quant_config=quant_config,
             )
         else:
@@ -788,6 +815,7 @@ class WanTransformerBlock_VSA(nn.Module):
                 eps=eps,
                 prefix=add_prefix("attn2", prefix),
                 supported_attention_backends=cross_attn_backends,
+                default_attention_backend=default_attention_backend,
                 quant_config=quant_config,
             )
         self.cross_attn_residual_norm = ScaleResidualLayerNormScaleShift(
@@ -961,7 +989,12 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
         )
 
         # 3. Transformer blocks
-        attn_backend = get_global_server_args().attention_backend
+        server_args = get_global_server_args()
+        attn_backend = server_args.attention_backend
+        default_attention_backend = _wan_default_attention_backend(
+            config,
+            enable_torch_compile=server_args.enable_torch_compile,
+        )
         transformer_block = (
             WanTransformerBlock_VSA
             if (attn_backend and attn_backend.lower() == "video_sparse_attn")
@@ -979,6 +1012,7 @@ class WanTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
                     config.added_kv_proj_dim,
                     self._supported_attention_backends
                     | {AttentionBackendEnum.VIDEO_SPARSE_ATTN},
+                    default_attention_backend=default_attention_backend,
                     prefix=f"blocks.{i}",
                     attention_type=config.attention_type,
                     sla_topk=config.sla_topk,

--- a/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
@@ -59,8 +59,9 @@ class TestWanAttentionBackendRole(unittest.TestCase):
             AttentionBackendEnum.TORCH_CUDNN_SDPA,
         )
 
+    @patch(f"{_WAN}.get_ring_parallel_world_size", return_value=1)
     @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
-    def test_fastwan_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
+    def test_fastwan_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120, _mock_ring):
         config = FastWan2_1_T2V_480P_Config()
 
         self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
@@ -69,8 +70,9 @@ class TestWanAttentionBackendRole(unittest.TestCase):
             AttentionBackendEnum.TORCH_CUDNN_SDPA,
         )
 
+    @patch(f"{_WAN}.get_ring_parallel_world_size", return_value=1)
     @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
-    def test_wan21_1_3b_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
+    def test_wan21_1_3b_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120, _mock_ring):
         config = Wan2_1_T2V_1_3B_Config()
 
         self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
@@ -79,8 +81,11 @@ class TestWanAttentionBackendRole(unittest.TestCase):
             AttentionBackendEnum.TORCH_CUDNN_SDPA,
         )
 
+    @patch(f"{_WAN}.get_ring_parallel_world_size", return_value=1)
     @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
-    def test_wan21_fun_1_3b_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
+    def test_wan21_fun_1_3b_prefers_cudnn_sdpa_on_sm120(
+        self, _mock_is_sm120, _mock_ring
+    ):
         config = Wan2_1_Fun_1_3B_InP_Config()
 
         self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
@@ -105,6 +110,13 @@ class TestWanAttentionBackendRole(unittest.TestCase):
                 enable_torch_compile=True,
             )
         )
+
+    @patch(f"{_WAN}.get_ring_parallel_world_size", return_value=2)
+    @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
+    def test_fastwan_keeps_ring_backend_on_sm120(self, _mock_is_sm120, _mock_ring):
+        config = FastWan2_1_T2V_480P_Config()
+
+        self.assertIsNone(_wan_default_attention_backend(config.dit_config))
 
     @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
     def test_regular_wan_keeps_platform_default_on_sm120(self, _mock_is_sm120):

--- a/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
@@ -5,6 +5,7 @@ from torch import nn
 
 from sglang.multimodal_gen.configs.pipeline_configs.wan import (
     FastWan2_1_T2V_480P_Config,
+    Wan2_1_T2V_1_3B_Config,
     WanT2V480PConfig,
 )
 from sglang.multimodal_gen.runtime.models.dits.wanvideo import (
@@ -60,6 +61,16 @@ class TestWanAttentionBackendRole(unittest.TestCase):
     @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
     def test_fastwan_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
         config = FastWan2_1_T2V_480P_Config()
+
+        self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
+        self.assertEqual(
+            _wan_default_attention_backend(config.dit_config),
+            AttentionBackendEnum.TORCH_CUDNN_SDPA,
+        )
+
+    @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
+    def test_wan21_1_3b_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
+        config = Wan2_1_T2V_1_3B_Config()
 
         self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
         self.assertEqual(

--- a/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
@@ -5,6 +5,7 @@ from torch import nn
 
 from sglang.multimodal_gen.configs.pipeline_configs.wan import (
     FastWan2_1_T2V_480P_Config,
+    Wan2_1_Fun_1_3B_InP_Config,
     Wan2_1_T2V_1_3B_Config,
     WanT2V480PConfig,
 )
@@ -71,6 +72,16 @@ class TestWanAttentionBackendRole(unittest.TestCase):
     @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
     def test_wan21_1_3b_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
         config = Wan2_1_T2V_1_3B_Config()
+
+        self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
+        self.assertEqual(
+            _wan_default_attention_backend(config.dit_config),
+            AttentionBackendEnum.TORCH_CUDNN_SDPA,
+        )
+
+    @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
+    def test_wan21_fun_1_3b_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
+        config = Wan2_1_Fun_1_3B_InP_Config()
 
         self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
         self.assertEqual(

--- a/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_wan_attention_backend.py
@@ -3,7 +3,14 @@ from unittest.mock import patch
 
 from torch import nn
 
-from sglang.multimodal_gen.runtime.models.dits.wanvideo import WanSelfAttention
+from sglang.multimodal_gen.configs.pipeline_configs.wan import (
+    FastWan2_1_T2V_480P_Config,
+    WanT2V480PConfig,
+)
+from sglang.multimodal_gen.runtime.models.dits.wanvideo import (
+    WanSelfAttention,
+    _wan_default_attention_backend,
+)
 from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 
 _WAN = "sglang.multimodal_gen.runtime.models.dits.wanvideo"
@@ -30,6 +37,59 @@ class TestWanAttentionBackendRole(unittest.TestCase):
 
         self.assertTrue(usp_attention.call_args.kwargs["is_cross_attention"])
         self.assertTrue(usp_attention.call_args.kwargs["skip_sequence_parallel"])
+
+    def test_default_backend_is_forwarded_to_usp(self):
+        with (
+            patch(f"{_WAN}.ColumnParallelLinear", return_value=nn.Identity()),
+            patch(f"{_WAN}.RowParallelLinear", return_value=nn.Identity()),
+            patch(f"{_WAN}.get_tp_world_size", return_value=1),
+            patch(f"{_WAN}.USPAttention") as usp_attention,
+        ):
+            WanSelfAttention(
+                dim=128,
+                num_heads=1,
+                qk_norm=False,
+                default_attention_backend=AttentionBackendEnum.TORCH_CUDNN_SDPA,
+            )
+
+        self.assertEqual(
+            usp_attention.call_args.kwargs["default_attention_backend"],
+            AttentionBackendEnum.TORCH_CUDNN_SDPA,
+        )
+
+    @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
+    def test_fastwan_prefers_cudnn_sdpa_on_sm120(self, _mock_is_sm120):
+        config = FastWan2_1_T2V_480P_Config()
+
+        self.assertTrue(config.dit_config.prefer_cudnn_sdpa_on_sm120)
+        self.assertEqual(
+            _wan_default_attention_backend(config.dit_config),
+            AttentionBackendEnum.TORCH_CUDNN_SDPA,
+        )
+
+    @patch(f"{_WAN}.current_platform.is_sm120", return_value=False)
+    def test_fastwan_keeps_platform_default_outside_sm120(self, _mock_is_sm120):
+        config = FastWan2_1_T2V_480P_Config()
+
+        self.assertIsNone(_wan_default_attention_backend(config.dit_config))
+
+    @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
+    def test_fastwan_keeps_compile_backend_on_sm120(self, _mock_is_sm120):
+        config = FastWan2_1_T2V_480P_Config()
+
+        self.assertIsNone(
+            _wan_default_attention_backend(
+                config.dit_config,
+                enable_torch_compile=True,
+            )
+        )
+
+    @patch(f"{_WAN}.current_platform.is_sm120", return_value=True)
+    def test_regular_wan_keeps_platform_default_on_sm120(self, _mock_is_sm120):
+        config = WanT2V480PConfig()
+
+        self.assertFalse(config.dit_config.prefer_cudnn_sdpa_on_sm120)
+        self.assertIsNone(_wan_default_attention_backend(config.dit_config))
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_wan_pipeline_config.py
+++ b/python/sglang/multimodal_gen/test/unit/test_wan_pipeline_config.py
@@ -1,8 +1,13 @@
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
-from sglang.multimodal_gen.configs.pipeline_configs.wan import WanT2V480PConfig
+from sglang.multimodal_gen.configs.pipeline_configs.wan import (
+    Wan2_1_T2V_1_3B_Config,
+    WanT2V480PConfig,
+)
+from sglang.multimodal_gen.registry import _get_config_info
 
 
 def test_wan_prompt_embed_accessors_return_transformer_tensor():
@@ -17,3 +22,25 @@ def test_wan_prompt_embed_accessors_return_transformer_tensor():
 
     assert config.get_pos_prompt_embeds(batch) is prompt_embeds
     assert config.get_neg_prompt_embeds(batch) is negative_prompt_embeds
+
+
+def test_wan21_1_3b_exact_path_uses_checkpoint_specific_config():
+    _get_config_info.cache_clear()
+
+    info = _get_config_info("Wan-AI/Wan2.1-T2V-1.3B-Diffusers")
+
+    assert info is not None
+    assert info.pipeline_config_cls is Wan2_1_T2V_1_3B_Config
+
+
+def test_unregistered_wan_pipeline_keeps_generic_config():
+    _get_config_info.cache_clear()
+    with patch(
+        "sglang.multimodal_gen.registry.maybe_download_model_index",
+        return_value={"_class_name": "WanPipeline"},
+    ):
+        info = _get_config_info("example-org/unregistered-wan-checkpoint")
+    _get_config_info.cache_clear()
+
+    assert info is not None
+    assert info.pipeline_config_cls is WanT2V480PConfig

--- a/python/sglang/multimodal_gen/test/unit/test_wan_pipeline_config.py
+++ b/python/sglang/multimodal_gen/test/unit/test_wan_pipeline_config.py
@@ -4,6 +4,7 @@ from unittest.mock import patch
 import torch
 
 from sglang.multimodal_gen.configs.pipeline_configs.wan import (
+    Wan2_1_Fun_1_3B_InP_Config,
     Wan2_1_T2V_1_3B_Config,
     WanT2V480PConfig,
 )
@@ -31,6 +32,15 @@ def test_wan21_1_3b_exact_path_uses_checkpoint_specific_config():
 
     assert info is not None
     assert info.pipeline_config_cls is Wan2_1_T2V_1_3B_Config
+
+
+def test_wan21_fun_1_3b_exact_path_uses_checkpoint_specific_config():
+    _get_config_info.cache_clear()
+
+    info = _get_config_info("weizhou03/Wan2.1-Fun-1.3B-InP-Diffusers")
+
+    assert info is not None
+    assert info.pipeline_config_cls is Wan2_1_Fun_1_3B_InP_Config
 
 
 def test_unregistered_wan_pipeline_keeps_generic_config():


### PR DESCRIPTION
## Summary

- prefer the existing `torch_cudnn_sdpa` backend for verified Wan 2.1 T2V 1.3B eager inference on SM120
- cover the original Wan2.1 T2V, Wan2.1 Fun InP, and FastWan 2.1 1.3B configs
- preserve selector precedence and keep existing defaults for compile, ring attention, generic Wan checkpoints, non-SM120 platforms, and explicit overrides

## Why

Native SGLang traces and paired Nsight Compute reports show that Torch Flash SDPA is a dominant Wan 1.3B transformer cost on RTX PRO 6000 Blackwell Server Edition. At the two production self-attention shapes, cuDNN raises occupancy from 8.33% to 18.74% and reduces register pressure from 255 to 168 registers/thread.

| Model shape | Metric | Torch Flash SDPA | cuDNN SDPA |
|---|---|---:|---:|
| `[1,12,24960,128]` | CUDA-event median | 11.159 ms | 10.078 ms |
|  | NCU duration | 14.62 ms | 12.61 ms |
|  | Compute throughput | 73.66% | 85.42% |
| `[1,12,32760,128]` | CUDA-event median | 18.510 ms | 17.733 ms |
|  | NCU duration | 24.24 ms | 21.90 ms |
|  | Compute throughput | 76.34% | 84.49% |
| `[1,12,31584,128]` | CUDA-event median | 16.838 ms | 16.257 ms |
|  | NCU duration | 22.03 ms | 19.91 ms |
|  | Compute throughput | 78.22% | 86.54% |

## Real-model benchmarks

- Commit: `bede6bc37c5d9638099ebb948d93b9e2a7799f10`
- GPU: 1x RTX PRO 6000 Blackwell Server Edition (SM120), BF16
- Native SGLang backend with synchronized stage timing and two fresh-server eager runs per variant

| Model / request | Variant | Denoise mean | E2E mean | Peak reserved |
|---|---|---:|---:|---:|
| FastWan2.1, 832x480x61, 3 steps | Baseline eager | 1687.736 ms | 3806.657 ms | 34,206 MB |
|  | Patched eager | 1584.821 ms | 3702.568 ms | 34,206 MB |
|  | Improvement | **-6.098%** | **-2.734%** | unchanged |
| Wan2.1, 832x480x81, 50 steps | Baseline eager | 86.5105 s | 89.5394 s | 14,426 MB |
|  | Patched eager | 83.9983 s | 87.0260 s | 14,426 MB |
|  | Improvement | **-2.904%** | **-2.807%** | unchanged |
| Wan2.1 Fun InP, 832x480x81, 50 steps | Baseline eager | 81.2084 s | 86.3882 s | 15,542 MB |
|  | Patched eager | 78.9800 s | 84.1590 s | 15,542 MB |
|  | Improvement | **-2.744%** | **-2.581%** | unchanged |

This corresponds to +6.494%/+2.811% denoise/E2E throughput for FastWan, +2.991%/+2.888% for Wan2.1 T2V, and +2.822%/+2.649% for Wan2.1 Fun InP.

## Correctness and scope

- patched eager A/B outputs are deterministic and byte-identical to explicit-cuDNN A/B for both checkpoints
- FastWan, all 61 frames versus eager baseline:
  - PSNR 31.96 dB mean / 30.88 dB worst
  - SSIM 0.9385 mean / 0.9206 worst
- Wan2.1, all 81 frames versus eager baseline:
  - PSNR 38.92 dB mean / 36.04 dB worst
  - SSIM 0.97496 mean / 0.97146 worst
- Wan2.1 `quality=high` retains 38.68 dB mean / 35.75 dB worst PSNR and 0.97321 mean / 0.96659 worst SSIM; first/middle/last-frame inspection passed
- Wan2.1 Fun InP, all 81 frames versus eager baseline:
  - PSNR 44.90 dB mean / 42.41 dB worst
  - SSIM 0.98825 mean / 0.98372 worst
- Wan2.1 Fun InP `quality=high` retains 44.90 dB mean / 42.39 dB worst PSNR and 0.98823 mean / 0.98370 worst SSIM; first/middle/last-frame inspection passed
- direct Flash/cuDNN attention comparisons retain 66.21 dB, 65.95 dB, and 66.60 dB tensor PSNR at the three production shapes
- compile intentionally keeps Torch SDPA; patched FastWan and Wan2.1 T2V compile artifacts are byte-identical to their baselines (Wan2.1 Fun InP compile timed out during first Inductor autotune)
- the exact Wan2.1 mapping is separate from the generic `WanPipeline` detector, so unregistered Wan checkpoints do not inherit this preference

## Tests

- `13 passed`: changed Wan backend and pipeline-config unit tests, including SM120/non-SM120, compile, ring exclusion, forwarding, exact registry mappings, and generic Wan fallback
- full pre-commit run on all changed files passed
- native real-model eager A/B, high-quality, and compile validation passed on SM120

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #32985858730](https://github.com/sgl-project/sglang/actions/runs/32985858730)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->