### PR TITLE
[environ] Make callable env defaults traceable under torch.compile

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -42,6 +42,13 @@ class EnvField:
 
     def __init__(self, default: Any, secret: bool = False):
         self.default = default
+        # get() is traced by Dynamo (models read envs in their forwards), which
+        # cannot trace `callable()`. Moving the check out of get() is not enough:
+        # Dynamo mis-models an lru_cache default as a bound method carrying `self`
+        # at the *attribute load*, so calling it fails too. functools.partial is safe.
+        self._default_factory = (
+            functools.partial(default) if callable(default) else None
+        )
         # NOTE: environ can only accept str values, so we need a flag to indicate
         # whether the env var is explicitly set to None.
         self._set_to_none = False
@@ -57,7 +64,9 @@ class EnvField:
     def _resolve_default(self) -> Any:
         # Support a callable default for lazily/platform-computed defaults
         # (e.g. EnvBool(_default_hip)); evaluated only when the env is unset.
-        return self.default() if callable(self.default) else self.default
+        if self._default_factory is None:
+            return self.default
+        return self._default_factory()
 
     def get(self) -> Any:
         value = os.getenv(self.name)

--- a/test/registered/unit/test_environ.py
+++ b/test/registered/unit/test_environ.py
@@ -1,5 +1,6 @@
 """Unit tests for sglang.srt.environ: EnvField semantics and the deprecated-env registry."""
 
+import functools
 import os
 import re
 import subprocess
@@ -8,7 +9,7 @@ import unittest
 import warnings
 from contextlib import ExitStack
 
-from sglang.srt.environ import _DEPRECATED_ENVS, _DeprecatedEnv, envs
+from sglang.srt.environ import _DEPRECATED_ENVS, EnvBool, _DeprecatedEnv, envs
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=15, suite="base-a-test-cpu")
@@ -97,6 +98,29 @@ class TestEnvField(unittest.TestCase):
             warnings.simplefilter("always")
             self.assertIs(envs.SGLANG_TEST_RETRACT.get(), False)
         self.assertIn("Invalid value", str(caught[0].message))
+
+    def test_callable_default_traces_under_torch_compile(self):
+        # get() runs inside compiled model forwards, so resolving a callable
+        # default must stay traceable. lru_cache specifically: Dynamo models
+        # such a function loaded from an instance attribute as a bound method
+        # carrying `self`. A plain function default traces fine either way.
+        import torch
+
+        @functools.lru_cache(maxsize=1)
+        def default_factory():
+            return True
+
+        field = EnvBool(default_factory)
+        # Envs turns off _allow_set_name after its body, so a field built out
+        # here never gets a name from __set_name__.
+        field.name = "SGLANG_TEST_CALLABLE_DEFAULT"
+        field.clear()
+
+        @torch.compile(fullgraph=True, backend="eager", dynamic=False)
+        def probe(x):
+            return x + 1 if field.get() else x - 1
+
+        self.assertEqual(probe(torch.zeros(())).item(), 1.0)
 
 
 class TestDeprecatedEnvRegistry(unittest.TestCase):


### PR DESCRIPTION
## Problem

Capturing the prefill CUDA graph on `tc_piecewise` dies during the compile pass:

```
RuntimeError: Capture prefill CUDA graph failed: Failed to trace builtin operator `callable`
  Developer debug context: builtin callable [<class '...WrapperUserMethodVariable'>]
from user code:
  deepseek_v4.py  _run_moe_ffn_dp_sync   envs.SGLANG_DP_USE_REDUCE_SCATTER.get()
  environ.py:60   _resolve_default       self.default() if callable(self.default) else self.default
```

`tc_piecewise` compiles the model forward, and DeepSeek-V4 reads
`SGLANG_DP_USE_REDUCE_SCATTER` from inside its MoE forward. That field's default is
`_default_hip`, an `lru_cache`-wrapped function, and `get()` reaches `_resolve_default()`
whenever the variable is unset.

Deterministic, not flaky. The read sits **first** in an `and` chain, ahead of the parallelism
guards that would otherwise short-circuit it, and `_run_moe_ffn_dp_sync` is called
unconditionally from the decoder layer — plain TP hits it too. What hides the bug is having
the variable *set*, which is why recipes that export it never saw this.

## Root cause

Not the `callable()` builtin as such. Dynamo mis-models an `lru_cache`-wrapped function **at
the attribute load**: `self.default` yields a `WrapperUserMethodVariable` that already carries
`self`. Both things you can then do with it fail:

```python
fn = instance.f          # attribute load only
callable(fn)             # Dynamo does not know how to trace builtin operator `callable`
fn()                     # TypeError: Too many positional arguments: got 1, expected 0
```

So removing the `callable()` call alone does not fix it, and neither does adding indirection —
passing the factory as an argument, through a `staticmethod`, or through another object
attribute all still fail with the `TypeError`. I measured each.

## Fix

Bind the callable default once in `__init__` as a `functools.partial` and reach it through
that. `partial` objects are modelled correctly, and moving the `callable()` test to
construction keeps it out of the traced region.

Resolution stays lazy, so `environ.py` remains importable without torch — the reason these
defaults are callables. Verified side by side against the unpatched module: loading
`environ.py` by path leaves `torch` out of `sys.modules` before and after.

## Verified

Real module, `SGLANG_DP_USE_REDUCE_SCATTER` unset — same file, same test, only `environ.py`
swapped:

| | `fullgraph=True` compile |
|---|---|
| before | FAIL at `environ.py:60` |
| after | PASS |

End to end on MI355X x8, GSM8K 200q with the variable unset: unpatched reproduces the error
above at capture; patched runs to completion at 0.975 accuracy.

## Tests

One test added to `test/registered/unit/test_environ.py`, compiling a `get()` on a field whose
default is `lru_cache`-wrapped under `fullgraph=True`. A plain-function default traces fine
even without the fix, so the test uses the `lru_cache` case specifically. It fails on the
unpatched module.

## Still open

`get()`'s invalid-value branch calls `warnings.warn`, which Dynamo cannot trace under
`fullgraph=True` (gb0007) — and the `reorderable_logging_functions` workaround the error
suggests fails with a bare `AssertionError`. A compiled read of a set-but-**unparseable** env
var therefore still cannot compile. Narrower hole, and fixing it means deciding where that
warning should go instead, so I left it out.
