### PR TITLE
docs: point the Qwen3.8-Flash-Next cookbook at model support PR #36497

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next.mdx
@@ -23,15 +23,15 @@ pip install -U uv
 uv venv --python 3.12 && source .venv/bin/activate
 
 # Qwen3.8-Flash-Next model support:
-# https://github.com/sgl-project/sglang/pull/<PR-NUMBER>
+# https://github.com/sgl-project/sglang/pull/36497
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-git fetch origin pull/<PR-NUMBER>/head && git checkout FETCH_HEAD
+git fetch origin pull/36497/head && git checkout FETCH_HEAD
 uv pip install -e python
 ```
 
 <Note>
-`<PR-NUMBER>` is a placeholder — substitute the number of the SGLang PR that adds Qwen3.8-Flash-Next model support. Once that PR is in a release, `uv pip install sglang` is enough and this whole step goes away.
+Model support lands in [#36497](https://github.com/sgl-project/sglang/pull/36497). Once it is in a release, `uv pip install sglang` is enough and this whole step goes away.
 </Note>
 
 Then run the **Python** output of the command panel below in that environment.


### PR DESCRIPTION
Replaces the `<PR-NUMBER>` placeholder in the Qwen3.8-Flash-Next source-install step with #36497, the PR that adds model support.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32970319484](https://github.com/sgl-project/sglang/actions/runs/32970319484)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32970319142](https://github.com/sgl-project/sglang/actions/runs/32970319142)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->