### PR TITLE
perf: fuse static FP8 quantization into FlashInfer allreduce

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -166,11 +166,15 @@ def _fused_rmsnorm_fp8_per_token_quant(
 FUSE_ALLREDUCE_MAX_BATCH_SIZE = 2048
 
 
+def is_flashinfer_allreduce_fusion_arch_supported() -> bool:
+    return _is_sm90_supported or _is_sm100_supported
+
+
 def apply_flashinfer_allreduce_fusion(batch_size: int):
     return (
         # NOTE: flashinfer 0.6.1 caused performance regression on sm100 for allreduce fusion
         # Ref: https://github.com/sgl-project/sglang/issues/17237
-        (_is_sm90_supported or _is_sm100_supported)
+        is_flashinfer_allreduce_fusion_arch_supported()
         and _is_flashinfer_available
         and not is_dp_attention_enabled()
         and get_exec().comm.flashinfer_allreduce_fusion_backend is not None
@@ -462,6 +466,7 @@ class LayerCommunicator:
         force_layernorm_before_dp_gather: bool = False,
         enable_fused_ar_quant: bool = False,
         fused_ar_quant_keep_bf16: bool = False,
+        fused_ar_quant_linear: Optional[torch.nn.Module] = None,
     ):
         self.layer_scatter_modes = layer_scatter_modes
         self.input_layernorm = input_layernorm
@@ -472,6 +477,7 @@ class LayerCommunicator:
         self.force_layernorm_before_dp_gather = force_layernorm_before_dp_gather
         self.enable_fused_ar_quant = enable_fused_ar_quant
         self.fused_ar_quant_keep_bf16 = fused_ar_quant_keep_bf16
+        self.fused_ar_quant_linear = fused_ar_quant_linear
 
         self._context = CommunicateContext.init_new()
         self._context.force_layernorm_before_dp_gather = (
@@ -571,6 +577,7 @@ class LayerCommunicator:
         quant_format: str = "",
         post_residual_addition: Optional[torch.Tensor] = None,
     ):
+        static_fp8_scale = None
         if get_attn_tp_context().input_scattered:
             hidden_states, residual = self._tp_reduce_scatter(
                 hidden_states,
@@ -606,6 +613,37 @@ class LayerCommunicator:
                             use_attn_tp_group=False,
                             keep_bf16=self.fused_ar_quant_keep_bf16,
                         )
+                    elif (
+                        self.enable_fused_ar_quant
+                        and self.fused_ar_quant_linear is not None
+                        and hasattr(
+                            self.input_layernorm,
+                            "forward_with_allreduce_fusion_static_fp8_quant",
+                        )
+                    ):
+                        quant_result = self.input_layernorm.forward_with_allreduce_fusion_static_fp8_quant(
+                            hidden_states,
+                            residual,
+                            self.fused_ar_quant_linear,
+                            use_attn_tp_group=False,
+                            keep_bf16=self.fused_ar_quant_keep_bf16,
+                        )
+                        if quant_result is not None:
+                            quant_hidden_states, quant_residual = quant_result
+                            # The static scale is replicated model state, not a
+                            # token-major activation. Keep it out of a possible
+                            # scattered-to-full all-gather and restore it after
+                            # the token tensors have crossed the boundary.
+                            if self.fused_ar_quant_keep_bf16:
+                                bf16_out, fp8_out, static_fp8_scale = (
+                                    quant_hidden_states
+                                )
+                                quant_hidden_states = (bf16_out, fp8_out)
+                            else:
+                                quant_hidden_states, static_fp8_scale = (
+                                    quant_hidden_states
+                                )
+                            quant_result = (quant_hidden_states, quant_residual)
                     if quant_result is not None:
                         hidden_states, residual = quant_result
                     else:
@@ -734,6 +772,12 @@ class LayerCommunicator:
             forward_batch=forward_batch,
             context=self._context,
         )
+        if static_fp8_scale is not None:
+            if self.fused_ar_quant_keep_bf16:
+                bf16_out, fp8_out = hidden_states
+                hidden_states = (bf16_out, fp8_out, static_fp8_scale)
+            else:
+                hidden_states = (hidden_states, static_fp8_scale)
         if self.qkv_latent_func is not None:
             attn_inputs = AttentionInputs(
                 hidden_states, forward_batch, self.qkv_latent_func

--- a/python/sglang/srt/layers/flashinfer_comm_fusion.py
+++ b/python/sglang/srt/layers/flashinfer_comm_fusion.py
@@ -647,6 +647,16 @@ def _get_workspace_manager(use_attn_tp_group: bool) -> FlashInferWorkspaceManage
     return manager
 
 
+def _get_workspace_parallel_info(use_attn_tp_group: bool):
+    """Return the live world size, rank, and coordinator for a workspace."""
+    parallel = get_parallel()
+    if use_attn_tp_group:
+        return parallel.attn_tp_size, parallel.attn_tp_rank, get_attn_tp_group()
+    if parallel.moe_ep_size > 1:
+        return parallel.moe_ep_size, parallel.moe_ep_rank, get_moe_ep_group()
+    return parallel.moe_tp_size, parallel.moe_tp_rank, get_moe_tp_group()
+
+
 def _sync_allreduce_unavailable_across_tp():
     """Synchronize _flashinfer_allreduce_unavailable across all TP ranks.
 
@@ -694,19 +704,7 @@ def ensure_workspace_initialized(
     if not is_flashinfer_available() or _flashinfer_comm is None:
         return False
 
-    if use_attn_tp_group:
-        world_size = get_parallel().attn_tp_size
-        rank = get_parallel().attn_tp_rank
-        coordinator = get_attn_tp_group()
-    else:
-        if get_parallel().moe_ep_size > 1:
-            world_size = get_parallel().moe_ep_size
-            rank = get_parallel().moe_ep_rank
-            coordinator = get_moe_ep_group()
-        else:
-            world_size = get_parallel().moe_tp_size
-            rank = get_parallel().moe_tp_rank
-            coordinator = get_moe_tp_group()
+    world_size, rank, coordinator = _get_workspace_parallel_info(use_attn_tp_group)
 
     # Always pass the coordinator's groups: flashinfer >=0.6.10 reads the
     # rendezvous group from `group=...` (falling back to WORLD when None),
@@ -872,6 +870,167 @@ def flashinfer_allreduce_residual_rmsnorm(
     _flashinfer_comm.allreduce_fusion(**kwargs)
 
     return norm_out, residual_out
+
+
+def fake_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+    input_tensor: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale_factor: torch.Tensor,
+    eps: float = 1e-6,
+    max_token_num: int = 2048,
+    use_oneshot: Optional[bool] = None,
+    trigger_completion_at_end: bool = False,
+    fp32_acc: bool = False,
+    use_attn_tp_group: bool = True,
+    keep_bf16: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    quant_out = torch.empty_like(input_tensor, dtype=torch.float8_e4m3fn)
+    residual_out = torch.empty_like(residual)
+    norm_out = (
+        torch.empty_like(input_tensor) if keep_bf16 else input_tensor.new_empty((0,))
+    )
+    return quant_out, residual_out, norm_out
+
+
+@register_custom_op(
+    mutates_args=["input_tensor", "residual", "weight"],
+    fake_impl=fake_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant,
+)
+def _flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+    input_tensor: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale_factor: torch.Tensor,
+    eps: float = 1e-6,
+    max_token_num: int = 2048,
+    use_oneshot: Optional[bool] = None,
+    trigger_completion_at_end: bool = False,
+    fp32_acc: bool = False,
+    use_attn_tp_group: bool = True,
+    keep_bf16: bool = False,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Launch the preflighted static-FP8 allreduce fusion custom op."""
+    pattern_name = (
+        "kARResidualRMSNormOutFP8Quant" if keep_bf16 else "kARResidualRMSNormFP8Quant"
+    )
+    workspace = _get_workspace_manager(use_attn_tp_group).workspace
+    assert workspace is not None
+    patterns = _flashinfer_comm.AllReduceFusionPattern
+
+    quant_out = torch.empty_like(input_tensor, dtype=torch.float8_e4m3fn)
+    residual_out = torch.empty_like(residual)
+    norm_out = (
+        torch.empty_like(input_tensor) if keep_bf16 else input_tensor.new_empty((0,))
+    )
+    kwargs = dict(
+        input=input_tensor,
+        workspace=workspace,
+        pattern=getattr(patterns, pattern_name),
+        launch_with_pdl=True,
+        residual_out=residual_out,
+        norm_out=norm_out if keep_bf16 else None,
+        quant_out=quant_out,
+        scale_factor=scale_factor,
+        residual_in=residual,
+        rms_gamma=weight,
+        rms_eps=eps,
+        weight_bias=0.0,
+        use_oneshot=use_oneshot,
+        fp32_acc=fp32_acc,
+    )
+    if _flashinfer_allreduce_supports_trigger_completion:
+        kwargs["trigger_completion_at_end"] = trigger_completion_at_end
+    _flashinfer_comm.allreduce_fusion(**kwargs)
+    return quant_out, residual_out, norm_out
+
+
+def try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+    input_tensor: torch.Tensor,
+    residual: torch.Tensor,
+    weight: torch.Tensor,
+    scale_factor: torch.Tensor,
+    eps: float = 1e-6,
+    max_token_num: int = 2048,
+    use_oneshot: Optional[bool] = None,
+    trigger_completion_at_end: bool = False,
+    fp32_acc: bool = False,
+    use_attn_tp_group: bool = True,
+    keep_bf16: bool = False,
+):
+    """Preflight the optional pattern before entering its collective custom op."""
+    if _flashinfer_allreduce_unavailable or _flashinfer_comm is None:
+        return None, None, None
+
+    pattern_name = (
+        "kARResidualRMSNormOutFP8Quant" if keep_bf16 else "kARResidualRMSNormFP8Quant"
+    )
+    patterns = getattr(_flashinfer_comm, "AllReduceFusionPattern", None)
+    if patterns is None or not hasattr(patterns, pattern_name):
+        return None, None, None
+
+    parallel = get_parallel()
+    world_size = (
+        parallel.attn_tp_size
+        if use_attn_tp_group
+        else parallel.moe_ep_size if parallel.moe_ep_size > 1 else parallel.moe_tp_size
+    )
+    if world_size <= 1 or input_tensor.shape[0] > max_token_num:
+        return None, None, None
+    if (
+        input_tensor.dim() != 2
+        or residual.shape != input_tensor.shape
+        or weight.shape != (input_tensor.shape[-1],)
+        or scale_factor.numel() != 1
+        or scale_factor.dtype != torch.float32
+        or scale_factor.device != input_tensor.device
+        or not input_tensor.is_contiguous()
+        or not residual.is_contiguous()
+        or not weight.is_contiguous()
+    ):
+        return None, None, None
+
+    manager = _get_workspace_manager(use_attn_tp_group)
+    if torch.compiler.is_compiling():
+        _, _, coordinator = _get_workspace_parallel_info(use_attn_tp_group)
+        expected_group = (coordinator.device_group, coordinator.cpu_group)
+        if (
+            not manager.initialized
+            or manager.workspace is None
+            or manager.world_size != world_size
+            or manager.group != expected_group
+            or manager.max_token_num is None
+            or manager.hidden_dim is None
+            or manager.dtype is None
+            or input_tensor.shape[0] > manager.max_token_num
+            or input_tensor.shape[-1] > manager.hidden_dim
+            or input_tensor.dtype != manager.dtype
+        ):
+            return None, None, None
+    elif not ensure_workspace_initialized(
+        max_token_num=max_token_num,
+        hidden_dim=input_tensor.shape[-1],
+        use_fp32_lamport=(input_tensor.dtype == torch.float32),
+        dtype=input_tensor.dtype,
+        token_num=input_tensor.shape[0],
+        use_oneshot=use_oneshot,
+        use_attn_tp_group=use_attn_tp_group,
+    ):
+        return None, None, None
+
+    return _flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+        input_tensor,
+        residual,
+        weight,
+        scale_factor,
+        eps,
+        max_token_num,
+        use_oneshot,
+        trigger_completion_at_end,
+        fp32_acc,
+        use_attn_tp_group,
+        keep_bf16,
+    )
 
 
 def can_use_flashinfer_allreduce(

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -380,10 +380,10 @@ def _fp8_static_input_scale(linear) -> Optional[torch.Tensor]:
     an FP8 linear using static per-tensor activation scaling that can consume a
     pre-quantized ``(fp8, scale)`` input; otherwise ``None``.
 
-    Recognizes both the native ``Fp8LinearMethod`` (non block/mxfp8/marlin) and
-    the compressed-tensors W8A8-FP8 scheme with a static per-tensor input scale
-    (e.g. RedHatAI ``*-FP8`` checkpoints). The flashinfer fused kernel only
-    supports per-tensor quant, hence the ``numel() == 1`` requirement.
+    Recognizes native and ModelOpt FP8 linears (excluding block/mxfp8/marlin)
+    plus the compressed-tensors W8A8-FP8 scheme with a static per-tensor input
+    scale. The FlashInfer fused kernel only supports per-tensor quant, hence the
+    ``numel() == 1`` requirement.
     """
     if linear is None:
         return None
@@ -398,6 +398,46 @@ def _fp8_static_input_scale(linear) -> Optional[torch.Tensor]:
     return input_scale
 
 
+def _forward_with_allreduce_fusion_static_fp8_quant(
+    norm_module,
+    x: torch.Tensor,
+    residual: Optional[torch.Tensor],
+    weight: torch.Tensor,
+    quant_linear,
+    use_attn_tp_group: bool,
+    keep_bf16: bool,
+):
+    if residual is None:
+        return None
+    scale = _fp8_static_input_scale(quant_linear)
+    if scale is None:
+        return None
+
+    from sglang.srt.layers.flashinfer_comm_fusion import (
+        try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant,
+    )
+
+    max_token_num = 2048
+    if not torch.compiler.is_compiling():
+        max_token_num = max(x.shape[0], max_token_num)
+    quant_out, residual_out, norm_out = (
+        try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+            x,
+            residual,
+            weight,
+            scale,
+            eps=norm_module.variance_epsilon,
+            max_token_num=max_token_num,
+            use_attn_tp_group=use_attn_tp_group,
+            keep_bf16=keep_bf16,
+        )
+    )
+    if quant_out is None:
+        return None
+    hidden_states = (norm_out, quant_out, scale) if keep_bf16 else (quant_out, scale)
+    return hidden_states, residual_out
+
+
 def _is_static_per_tensor_fp8_linear(quant_method, linear) -> bool:
     try:
         from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
@@ -409,6 +449,14 @@ def _is_static_per_tensor_fp8_linear(quant_method, linear) -> bool:
             or getattr(quant_method, "use_mxfp8", False)
             or getattr(quant_method, "use_marlin", False)
         )
+    try:
+        from sglang.srt.layers.quantization.modelopt_quant import (
+            ModelOptFp8LinearMethod,
+        )
+    except ImportError:
+        ModelOptFp8LinearMethod = ()
+    if isinstance(quant_method, ModelOptFp8LinearMethod):
+        return not getattr(quant_method, "use_marlin", False)
     try:
         from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
             CompressedTensorsLinearMethod,
@@ -911,6 +959,24 @@ class RMSNorm(BaseFusedOp):
             self, x, residual, self.weight, group_size, use_attn_tp_group, keep_bf16
         )
 
+    def forward_with_allreduce_fusion_static_fp8_quant(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        quant_linear: nn.Module,
+        use_attn_tp_group: bool = True,
+        keep_bf16: bool = False,
+    ):
+        return _forward_with_allreduce_fusion_static_fp8_quant(
+            self,
+            x,
+            residual,
+            self.weight,
+            quant_linear,
+            use_attn_tp_group,
+            keep_bf16,
+        )
+
     def forward_with_per_tensor_quant_fusion(
         self,
         x: torch.Tensor,
@@ -1263,6 +1329,24 @@ class GemmaRMSNorm(BaseFusedOp):
             residual,
             self.gemma_weight,
             group_size,
+            use_attn_tp_group,
+            keep_bf16,
+        )
+
+    def forward_with_allreduce_fusion_static_fp8_quant(
+        self,
+        x: torch.Tensor,
+        residual: Optional[torch.Tensor],
+        quant_linear: nn.Module,
+        use_attn_tp_group: bool = True,
+        keep_bf16: bool = False,
+    ):
+        return _forward_with_allreduce_fusion_static_fp8_quant(
+            self,
+            x,
+            residual,
+            self.gemma_weight,
+            quant_linear,
             use_attn_tp_group,
             keep_bf16,
         )

--- a/python/sglang/srt/layers/quantization/fp8_utils.py
+++ b/python/sglang/srt/layers/quantization/fp8_utils.py
@@ -1770,12 +1770,18 @@ def apply_fp8_linear_bmm_flashinfer(
     weight_scale: torch.Tensor,
     input_scale: torch.Tensor,
     bias: Optional[torch.Tensor] = None,
+    output_dtype: Optional[torch.dtype] = None,
 ) -> torch.Tensor:
     """Per-tensor static fp8 linear via flashinfer bmm_fp8 (SM90 and newer)."""
     output_shape = [*input.shape[:-1], weight.shape[1]]
     input_2d = input.view(-1, input.shape[-1])
-    qinput, x_scale = static_quant_fp8(input_2d, input_scale, repeat_scale=False)
-    output = flashinfer_bmm_fp8(qinput, weight, x_scale, weight_scale, input.dtype)
+    if input_2d.dtype == torch.float8_e4m3fn:
+        qinput, x_scale = input_2d, input_scale
+        output_dtype = output_dtype or torch.bfloat16
+    else:
+        qinput, x_scale = static_quant_fp8(input_2d, input_scale, repeat_scale=False)
+        output_dtype = output_dtype or input.dtype
+    output = flashinfer_bmm_fp8(qinput, weight, x_scale, weight_scale, output_dtype)
     if bias is not None:
         output = output + bias
     return output.view(*output_shape)

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
 import regex as re
 import torch
@@ -604,10 +604,54 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
     def apply(
         self,
         layer: torch.nn.Module,
-        x: torch.Tensor,
+        x: Union[
+            torch.Tensor,
+            Tuple[torch.Tensor, torch.Tensor],
+            Tuple[torch.Tensor, torch.Tensor, torch.dtype],
+        ],
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Applies FP8 linear transformation."""
+        input_scale = layer.input_scale if not self.use_marlin else None
+        output_dtype = None
+        input_prequantized = isinstance(x, tuple)
+        if isinstance(x, tuple):
+            if self.use_marlin:
+                raise TypeError("FP8 Marlin cannot consume pre-quantized input")
+            if len(x) not in (2, 3):
+                raise ValueError(
+                    "Pre-quantized FP8 input must be (input, scale[, output_dtype])"
+                )
+            prequantized = x
+            x, input_scale = prequantized[:2]
+            output_dtype = (
+                prequantized[2] if len(prequantized) == 3 else layer.orig_dtype
+            )
+            if not isinstance(x, torch.Tensor) or x.dtype != torch.float8_e4m3fn:
+                raise TypeError(
+                    "Pre-quantized input must contain an FP8 tensor (E4M3FN)"
+                )
+            if input_scale is not layer.input_scale:
+                raise ValueError(
+                    "Pre-quantized input must reuse the layer's input_scale"
+                )
+            if input_scale.numel() != 1 or input_scale.device != x.device:
+                raise ValueError(
+                    "Pre-quantized input scale must be a scalar on the input device"
+                )
+            if output_dtype != layer.orig_dtype:
+                raise ValueError(
+                    "Pre-quantized input must preserve the layer's original dtype"
+                )
+        if (
+            not input_prequantized
+            and isinstance(x, torch.Tensor)
+            and x.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+        ):
+            raise TypeError(
+                "Pre-quantized FP8 input requires the (input, scale[, dtype]) "
+                "tuple contract"
+            )
         if self.use_marlin:
             return torch.ops.sglang.apply_fp8_marlin_linear(
                 input=x,
@@ -624,6 +668,7 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
             and x.dim() == 2
             and x.shape[0] == 1
             and hasattr(layer, "sm120_gemv_alpha")
+            and (not input_prequantized or output_dtype == torch.bfloat16)
         ):
             from sglang.kernels.ops.gemm.sm120_fp8_gemv import (
                 sm120_fp8_gemv,
@@ -634,25 +679,34 @@ class ModelOptFp8LinearMethod(LinearMethodBase):
             # buffer, so .t() recovers the row-major weight the GEMV streams.
             w = layer.weight.t()
             if use_sm120_fp8_gemv(1, w.shape[0], w.shape[1]) and w.is_contiguous():
-                from sglang.kernels.ops.quantization.fp8_kernel import static_quant_fp8
+                if input_prequantized:
+                    qinput = x
+                else:
+                    from sglang.kernels.ops.quantization.fp8_kernel import (
+                        static_quant_fp8,
+                    )
 
-                qinput, _ = static_quant_fp8(x, layer.input_scale, repeat_scale=False)
+                    qinput, _ = static_quant_fp8(
+                        x, layer.input_scale, repeat_scale=False
+                    )
                 return sm120_fp8_gemv(qinput, w, layer.sm120_gemv_alpha)
         if layer.use_flashinfer_bmm:
             return apply_fp8_linear_bmm_flashinfer(
                 input=x,
                 weight=layer.weight,
                 weight_scale=layer.weight_scale,
-                input_scale=layer.input_scale,
+                input_scale=input_scale,
                 bias=bias,
+                output_dtype=output_dtype,
             )
         return apply_fp8_linear(
             input=x,
             weight=layer.weight,
             weight_scale=layer.weight_scale,
-            input_scale=layer.input_scale,
+            input_scale=input_scale,
             bias=bias,
             cutlass_fp8_supported=self.cutlass_fp8_supported,
+            pre_quant_output_dtype=output_dtype,
         )
 
 

--- a/python/sglang/srt/models/interns2_mobius.py
+++ b/python/sglang/srt/models/interns2_mobius.py
@@ -506,10 +506,9 @@ class InternS2MobiusLinearDecoderLayer(_InternS2MobiusDecoderMixin, nn.Module):
         self.post_attention_layernorm = GemmaRMSNorm(
             config.hidden_size, eps=config.rms_norm_eps
         )
-        enable_fused_ar_quant = (
-            _enable_qwen35_fused_ar_quant()
-            and _linear_accepts_fp8_tuple(self.linear_attn.in_proj_qkvz)
-        )
+        enable_fused_ar_quant = _enable_qwen35_fused_ar_quant(
+            allow_cuda=False
+        ) and _linear_accepts_fp8_tuple(self.linear_attn.in_proj_qkvz)
         self.layer_communicator = LayerCommunicator(
             layer_scatter_modes=self.layer_scatter_modes,
             input_layernorm=self.input_layernorm,
@@ -641,9 +640,9 @@ class InternS2MobiusAttentionDecoderLayer(
         )
         self.q_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
         self.k_norm = GemmaRMSNorm(self.head_dim, eps=config.rms_norm_eps)
-        enable_fused_ar_quant = (
-            _enable_qwen35_fused_ar_quant() and _linear_accepts_fp8_tuple(self.qkv_proj)
-        )
+        enable_fused_ar_quant = _enable_qwen35_fused_ar_quant(
+            allow_cuda=False
+        ) and _linear_accepts_fp8_tuple(self.qkv_proj)
         self.layer_communicator = LayerCommunicator(
             layer_scatter_modes=self.layer_scatter_modes,
             input_layernorm=self.input_layernorm,

--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -43,13 +43,21 @@ from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
 from sglang.srt.layers.attention.mamba.mamba import mamba_v2_sharded_weight_loader
-from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
+from sglang.srt.layers.communicator import (
+    LayerCommunicator,
+    LayerScatterModes,
+    is_flashinfer_allreduce_fusion_arch_supported,
+)
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
 
 # Layers - Others
-from sglang.srt.layers.layernorm import GemmaRMSNorm
+from sglang.srt.layers.layernorm import (
+    GemmaRMSNorm,
+    _fp8_static_input_scale,
+    _is_static_per_tensor_fp8_linear,
+)
 
 # Layers - Linear
 from sglang.srt.layers.linear import (
@@ -97,6 +105,7 @@ from sglang.srt.models.utils import (
     fused_qk_gemma_rmsnorm_with_gate,
 )
 from sglang.srt.runtime_context import (
+    get_context,
     get_exec,
     get_forward,
     get_parallel,
@@ -235,38 +244,51 @@ if _is_cpu:
     )
 
 
-@lru_cache(maxsize=1)
-def _enable_qwen35_fused_ar_quant() -> bool:
-    """Gate the fused AR+RMSNorm+per-group-FP8-quant path for Qwen3.5.
+def _enable_qwen35_fused_ar_quant(*, allow_cuda: bool = True) -> bool:
+    """Gate the platform's fused allreduce + RMSNorm + FP8-quant path.
 
-    The single-kernel backend is ROCm/aiter/gfx95-only. The model gate stays
-    tied to ROCm/aiter so non-gfx95 HIP can keep the existing 2-kernel fallback
-    behavior for tuple handoff when this branch is used. It replaces the
-    existing ``--enable-aiter-allreduce-fusion`` 3-kernel path
-    (AR → RMSNorm → per-group quant) with either a single fused kernel (when
-    the fully-fused variant is eligible) or a 2-kernel path
-    (fused AR+RMSNorm + separate per-group quant) that still saves one
-    kernel launch vs. baseline. The LayerCommunicator gracefully falls back
-    to ``forward_with_allreduce_fusion`` (plain AR+RMSNorm) when the fused
-    quant helper returns ``None``, so turning this on never regresses the
-    AR+RMSNorm fusion itself.
-
-    Opt-out: set ``SGLANG_DISABLE_FUSED_AR_QUANT=1`` to fall back to the
-    unmodified AR+RMSNorm fusion path.
+    ROCm uses AITER per-group quantization; CUDA uses FlashInfer static
+    per-tensor quantization when ``allow_cuda`` is true. Importing models can
+    keep their existing ROCm-only behavior by passing ``allow_cuda=False``.
+    ``SGLANG_DISABLE_FUSED_AR_QUANT=1`` disables both backends.
     """
-    if not _use_aiter:
-        return False
     if get_bool_env_var("SGLANG_DISABLE_FUSED_AR_QUANT", default="false"):
         return False
-    return bool(get_exec().comm.enable_aiter_allreduce_fusion)
+    if _use_aiter:
+        return bool(get_exec().comm.enable_aiter_allreduce_fusion)
+    if (
+        not allow_cuda
+        or not _is_cuda
+        or not is_flashinfer_allreduce_fusion_arch_supported()
+    ):
+        return False
+    if not get_context().is_config_namespace_published("exec"):
+        return False
+    return get_exec().comm.flashinfer_allreduce_fusion_backend is not None
 
 
 def _linear_accepts_fp8_tuple(linear: nn.Module) -> bool:
     quant_method = getattr(linear, "quant_method", None)
-    return quant_method.__class__.__name__ == "Fp8LinearMethod" and (
-        getattr(quant_method, "block_quant", False)
-        or getattr(quant_method, "use_mxfp8", False)
-    )
+    if _use_aiter:
+        return quant_method.__class__.__name__ == "Fp8LinearMethod" and (
+            getattr(quant_method, "block_quant", False)
+            or getattr(quant_method, "use_mxfp8", False)
+        )
+    return _fp8_static_input_scale(linear) is not None
+
+
+def _enable_fused_ar_quant_for_linear(linear: nn.Module) -> bool:
+    if not _enable_qwen35_fused_ar_quant():
+        return False
+    if _use_aiter:
+        return _linear_accepts_fp8_tuple(linear)
+    quant_method = getattr(linear, "quant_method", None)
+    return _is_static_per_tensor_fp8_linear(quant_method, linear)
+
+
+def _prequantized_input_for_linear(fp8, scale, linear: nn.Module):
+    orig_dtype = getattr(linear, "orig_dtype", None)
+    return (fp8, scale, orig_dtype) if orig_dtype is not None else (fp8, scale)
 
 
 def _select_fused_ar_input_for_linear(hidden_states, linear: nn.Module):
@@ -275,10 +297,10 @@ def _select_fused_ar_input_for_linear(hidden_states, linear: nn.Module):
     if len(hidden_states) == 3:
         hs_bf16, hs_fp8, hs_scale = hidden_states
         if _linear_accepts_fp8_tuple(linear):
-            return (hs_fp8, hs_scale)
+            return _prequantized_input_for_linear(hs_fp8, hs_scale, linear)
         return hs_bf16
     if len(hidden_states) == 2 and _linear_accepts_fp8_tuple(linear):
-        return hidden_states
+        return _prequantized_input_for_linear(*hidden_states, linear)
     raise TypeError(
         f"{linear.__class__.__name__} cannot consume fused AR quant tuple input"
     )
@@ -642,13 +664,12 @@ class Qwen3_5GatedDeltaNet(nn.Module):
         return query, key, value, z, b, a
 
     def _forward_input_proj(self, hidden_states: torch.Tensor):
-        # AMD/aiter fused AR+RMSNorm+per-group-quant path ships a
+        # Fused AR+RMSNorm+quant paths ship a
         # ``(bf16, fp8, scale)`` 3-tuple so the FP8 ``in_proj_qkvz`` can
         # consume ``(fp8, scale)`` (skipping its internal quant) while the
-        # bf16 ``in_proj_ba`` consumes the unquantized bf16. Non-aiter runs skip
-        # the tuple branch and keep the original control flow below unchanged.
-        if _use_aiter and isinstance(hidden_states, tuple):
-            return self._forward_input_proj_fused_quant_amd(hidden_states)
+        # bf16 ``in_proj_ba`` consumes the unquantized bf16.
+        if isinstance(hidden_states, tuple):
+            return self._forward_input_proj_fused_quant(hidden_states)
 
         if (
             _is_cpu
@@ -686,8 +707,8 @@ class Qwen3_5GatedDeltaNet(nn.Module):
             projected_states_ba, _ = self.in_proj_ba(hidden_states)
         return projected_states_qkvz, projected_states_ba
 
-    def _forward_input_proj_fused_quant_amd(self, hidden_states):
-        """AMD-only variant for the fused AR+RMSNorm+per-group-quant path.
+    def _forward_input_proj_fused_quant(self, hidden_states):
+        """Consume the dual output from a fused AR+RMSNorm+quant path.
 
         ``hidden_states`` is a ``(bf16, fp8, scale)`` 3-tuple produced by the
         upstream fused kernel. FP8 ``in_proj_qkvz`` takes ``(fp8, scale)``
@@ -929,9 +950,8 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
         # GDN layers need both bf16 (for the small in_proj_ba gating
         # projection) and a quantized tuple only when in_proj_qkvz can consume
         # it. Otherwise, stay on the plain AR+RMSNorm path.
-        enable_fused_ar_quant = (
-            _enable_qwen35_fused_ar_quant()
-            and _linear_accepts_fp8_tuple(self.linear_attn.in_proj_qkvz)
+        enable_fused_ar_quant = _enable_fused_ar_quant_for_linear(
+            self.linear_attn.in_proj_qkvz
         )
         self.layer_communicator = _layer_communicator_class(config, is_nextn)(
             layer_scatter_modes=self.layer_scatter_modes,
@@ -941,6 +961,9 @@ class Qwen3_5LinearDecoderLayer(nn.Module):
             is_last_layer=(layer_id == config.num_hidden_layers - 1),
             enable_fused_ar_quant=enable_fused_ar_quant,
             fused_ar_quant_keep_bf16=enable_fused_ar_quant,
+            fused_ar_quant_linear=(
+                self.linear_attn.in_proj_qkvz if enable_fused_ar_quant else None
+            ),
         )
 
     def forward(
@@ -1172,9 +1195,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
         # Standard attention layers benefit from a fused quant epilogue only
         # when qkv_proj can consume the returned quantized tuple.
-        enable_fused_ar_quant = (
-            _enable_qwen35_fused_ar_quant() and _linear_accepts_fp8_tuple(self.qkv_proj)
-        )
+        enable_fused_ar_quant = _enable_fused_ar_quant_for_linear(self.qkv_proj)
         self.layer_communicator = _layer_communicator_class(config, is_nextn)(
             layer_scatter_modes=self.layer_scatter_modes,
             input_layernorm=self.input_layernorm,
@@ -1183,6 +1204,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             is_last_layer=(layer_id == config.num_hidden_layers - 1),
             enable_fused_ar_quant=enable_fused_ar_quant,
             fused_ar_quant_keep_bf16=False,
+            fused_ar_quant_linear=self.qkv_proj if enable_fused_ar_quant else None,
         )
 
         self.alt_stream = alt_stream
@@ -1224,6 +1246,10 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
 
     def forward_prepare_cuda_fused(self, positions, hidden_states):
         """Fused QK GemmaRMSNorm + NeoX RoPE + gate deinterleave."""
+        if isinstance(hidden_states, tuple):
+            hidden_states = _select_fused_ar_input_for_linear(
+                hidden_states, self.qkv_proj
+            )
         qkv, _ = self.qkv_proj(hidden_states)
         if self.attn_output_gate:
             q_gate, k, v = qkv.split(
@@ -1246,14 +1272,14 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             has_gate=self.attn_output_gate,
             mrope_axis_map=(self.rotary_emb.axis_map if positions.dim() == 2 else None),
         )
-        seq_len = hidden_states.shape[0]
+        seq_len = qkv.shape[0]
         q = q_out.view(seq_len, -1)
         k = k_out.view(seq_len, -1)
         gate = gate_out.view(seq_len, -1) if gate_out is not None else None
         return q, k, v, gate
 
     def forward_prepare_native(self, positions, hidden_states):
-        if _use_aiter and isinstance(hidden_states, tuple):
+        if isinstance(hidden_states, tuple):
             hidden_states = _select_fused_ar_input_for_linear(
                 hidden_states, self.qkv_proj
             )
@@ -1276,7 +1302,7 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         return q, k, v, gate
 
     def forward_prepare_fused_gate(self, positions, hidden_states):
-        if _use_aiter and isinstance(hidden_states, tuple):
+        if isinstance(hidden_states, tuple):
             hidden_states = _select_fused_ar_input_for_linear(
                 hidden_states, self.qkv_proj
             )

--- a/test/registered/unit/layers/quantization/test_fp8_blockwise_linear_backends.py
+++ b/test/registered/unit/layers/quantization/test_fp8_blockwise_linear_backends.py
@@ -13,7 +13,10 @@ import torch
 from sglang.srt.layers.quantization import fp8_utils
 from sglang.srt.layers.quantization.fp8 import Fp8Config
 from sglang.srt.layers.quantization.fp8_utils import Fp8GemmRunnerBackend
-from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp8Config
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptFp8Config,
+    ModelOptFp8LinearMethod,
+)
 from sglang.srt.utils import get_device_sm
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.layer_ut_utils import (
@@ -134,6 +137,144 @@ class _LinearBackendCheck(CustomTestCase):
                     # atol covers single-element UE8M0 scale-rounding outliers
                     # (deep_gemm); a wrong kernel/layout fails by orders more.
                     assert_output_close(self, out, ref, rtol=5e-2, atol=1e-1)
+
+
+class TestModelOptFp8PrequantizedDispatch(unittest.TestCase):
+    @staticmethod
+    def _make_method():
+        method = object.__new__(ModelOptFp8LinearMethod)
+        method.use_marlin = False
+        method.use_sm120_gemv = False
+        method.cutlass_fp8_supported = True
+        return method
+
+    def test_three_item_tuple_preserves_output_dtype(self):
+        method = self._make_method()
+        scale = torch.ones(1)
+        layer = mock.Mock(
+            use_flashinfer_bmm=False,
+            weight=torch.empty((8, 8), dtype=torch.float8_e4m3fn),
+            weight_scale=torch.ones(1),
+            input_scale=scale,
+            orig_dtype=torch.float16,
+        )
+        qx = torch.empty((2, 8), dtype=torch.float8_e4m3fn)
+        expected = torch.empty((2, 8), dtype=torch.float16)
+
+        with mock.patch(
+            "sglang.srt.layers.quantization.modelopt_quant.apply_fp8_linear",
+            return_value=expected,
+        ) as apply_fp8:
+            actual = method.apply(layer, (qx, scale, torch.float16))
+
+        self.assertIs(actual, expected)
+        self.assertEqual(
+            apply_fp8.call_args.kwargs["pre_quant_output_dtype"], torch.float16
+        )
+
+    def test_prequantized_m1_keeps_sm120_gemv_fast_path(self):
+        method = self._make_method()
+        method.use_sm120_gemv = True
+        scale = torch.ones(1)
+        # ModelOpt stores a [K, N] view whose transpose recovers contiguous [N, K].
+        weight_nk = torch.empty((16, 512), dtype=torch.float8_e4m3fn)
+        layer = mock.Mock(
+            use_flashinfer_bmm=False,
+            weight=weight_nk.t(),
+            weight_scale=torch.ones(1),
+            input_scale=scale,
+            orig_dtype=torch.bfloat16,
+            sm120_gemv_alpha=torch.ones(1),
+        )
+        qx = torch.empty((1, 512), dtype=torch.float8_e4m3fn)
+        expected = torch.empty((1, 16), dtype=torch.bfloat16)
+
+        with (
+            mock.patch(
+                "sglang.kernels.ops.gemm.sm120_fp8_gemv.use_sm120_fp8_gemv",
+                return_value=True,
+            ),
+            mock.patch(
+                "sglang.kernels.ops.gemm.sm120_fp8_gemv.sm120_fp8_gemv",
+                return_value=expected,
+            ) as gemv,
+            mock.patch(
+                "sglang.srt.layers.quantization.modelopt_quant.apply_fp8_linear",
+                side_effect=AssertionError("generic FP8 GEMM should not run"),
+            ),
+        ):
+            actual = method.apply(layer, (qx, scale, torch.bfloat16))
+
+        self.assertIs(actual, expected)
+        gemv.assert_called_once()
+        self.assertIs(gemv.call_args.args[0], qx)
+        self.assertEqual(gemv.call_args.args[1].data_ptr(), weight_nk.data_ptr())
+        self.assertEqual(gemv.call_args.args[1].shape, weight_nk.shape)
+        self.assertIs(gemv.call_args.args[2], layer.sm120_gemv_alpha)
+
+    def test_prequantized_tuple_rejects_another_layers_scale(self):
+        method = self._make_method()
+        layer_scale = torch.ones(1)
+        layer = mock.Mock(
+            use_flashinfer_bmm=False,
+            input_scale=layer_scale,
+            orig_dtype=torch.bfloat16,
+        )
+        qx = torch.empty((2, 8), dtype=torch.float8_e4m3fn)
+
+        with self.assertRaisesRegex(ValueError, "layer's input_scale"):
+            method.apply(layer, (qx, layer_scale.clone(), torch.bfloat16))
+
+    def test_prequantized_tuple_rejects_non_fp8_payload(self):
+        method = self._make_method()
+        scale = torch.ones(1)
+        layer = mock.Mock(
+            use_flashinfer_bmm=False,
+            input_scale=scale,
+            orig_dtype=torch.bfloat16,
+        )
+
+        with self.assertRaisesRegex(TypeError, "FP8 tensor"):
+            method.apply(layer, (torch.empty((2, 8), dtype=torch.bfloat16), scale))
+
+    def test_prequantized_tuple_rejects_e4m3fnuz_payload(self):
+        method = self._make_method()
+        scale = torch.ones(1)
+        layer = mock.Mock(
+            use_flashinfer_bmm=False,
+            input_scale=scale,
+            orig_dtype=torch.bfloat16,
+        )
+        qx = torch.empty((2, 8), dtype=torch.float8_e4m3fnuz)
+
+        with self.assertRaisesRegex(TypeError, "E4M3FN"):
+            method.apply(layer, (qx, scale))
+
+    def test_prequantized_tuple_rejects_wrong_output_dtype(self):
+        method = self._make_method()
+        scale = torch.ones(1)
+        layer = mock.Mock(
+            use_flashinfer_bmm=False,
+            input_scale=scale,
+            orig_dtype=torch.bfloat16,
+        )
+        qx = torch.empty((2, 8), dtype=torch.float8_e4m3fn)
+
+        with self.assertRaisesRegex(ValueError, "original dtype"):
+            method.apply(layer, (qx, scale, torch.float16))
+
+    def test_bare_fp8_input_is_not_a_prequantized_contract(self):
+        method = self._make_method()
+        layer = mock.Mock(
+            use_flashinfer_bmm=False,
+            input_scale=torch.ones(1),
+            orig_dtype=torch.bfloat16,
+        )
+        for dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz):
+            with self.subTest(dtype=dtype):
+                qx = torch.empty((2, 8), dtype=dtype)
+                with self.assertRaisesRegex(TypeError, "tuple contract"):
+                    method.apply(layer, qx)
 
 
 @unittest.skipIf(get_device_sm() < 90, "FP8 GEMM backends require SM90+")
@@ -264,6 +405,51 @@ class TestModeloptFp8PerTensorLinear(_LinearBackendCheck):
 
     def test_auto(self):
         self._check_backend("auto", ["auto"], PER_TENSOR_SHAPES, self._build_layer)
+
+    def test_prequantized_input_skips_static_quant(self):
+        layer, _ = self._build_layer(512, 512)
+        layer.quant_method.process_weights_after_loading(layer)
+        # Exercise the generic scaled-mm/CUTLASS route here. The FlashInfer BMM
+        # helper has its own dispatch test; separating them makes a failure
+        # identify which consumer mishandled the pre-quantized activation.
+        layer.use_flashinfer_bmm = False
+        x = torch.randn((8, 512), device="cuda", dtype=torch.bfloat16) / 10
+        qx, scale = fp8_utils.static_quant_fp8(x, layer.input_scale, repeat_scale=False)
+        expected, _ = layer(x)
+
+        with mock.patch.object(
+            fp8_utils,
+            "static_quant_fp8",
+            side_effect=AssertionError("pre-quantized input was quantized again"),
+        ):
+            actual, _ = layer((qx, scale))
+
+        torch.testing.assert_close(actual, expected, rtol=5e-2, atol=1e-1)
+
+    def test_prequantized_flashinfer_bmm_dispatch(self):
+        qx = torch.zeros((8, 512), device="cuda", dtype=torch.float8_e4m3fn)
+        weight = torch.zeros((512, 512), device="cuda", dtype=torch.float8_e4m3fn)
+        input_scale = torch.ones(1, device="cuda")
+        weight_scale = torch.ones(1, device="cuda")
+        expected = torch.zeros((8, 512), device="cuda", dtype=torch.bfloat16)
+
+        with (
+            mock.patch.object(
+                fp8_utils,
+                "static_quant_fp8",
+                side_effect=AssertionError("pre-quantized input was quantized again"),
+            ),
+            mock.patch.object(
+                fp8_utils, "flashinfer_bmm_fp8", return_value=expected
+            ) as bmm,
+        ):
+            actual = fp8_utils.apply_fp8_linear_bmm_flashinfer(
+                qx, weight, weight_scale, input_scale
+            )
+
+        torch.testing.assert_close(actual, expected)
+        self.assertEqual(bmm.call_args.args[0].data_ptr(), qx.data_ptr())
+        self.assertEqual(bmm.call_args.args[-1], torch.bfloat16)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_flashinfer_comm_fusion.py
+++ b/test/registered/unit/layers/test_flashinfer_comm_fusion.py
@@ -5,6 +5,7 @@ from unittest.mock import MagicMock, patch
 import torch
 
 from sglang.srt.layers import flashinfer_comm_fusion as fusion
+from sglang.srt.layers import layernorm
 from sglang.srt.runtime_context import get_parallel, override_platform
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
@@ -28,6 +29,8 @@ class _FakeFlashInferComm:
     class AllReduceFusionPattern:
         kAllReduce = object()
         kARResidualRMSNorm = object()
+        kARResidualRMSNormFP8Quant = object()
+        kARResidualRMSNormOutFP8Quant = object()
 
     def __init__(self):
         self.calls = []
@@ -47,6 +50,8 @@ class _FakeFlashInferComm:
         output=None,
         residual_out=None,
         norm_out=None,
+        quant_out=None,
+        scale_factor=None,
         residual_in=None,
         rms_gamma=None,
         rms_eps=None,
@@ -59,9 +64,6 @@ class _FakeFlashInferComm:
             output.copy_(allreduced)
             return output
 
-        if pattern is not self.AllReduceFusionPattern.kARResidualRMSNorm:
-            raise ValueError(f"Unexpected pattern: {pattern}")
-
         allreduced = input * workspace.world_size
         expected_residual = allreduced + residual_in
         variance = expected_residual.to(torch.float32).pow(2).mean(dim=-1, keepdim=True)
@@ -71,7 +73,17 @@ class _FakeFlashInferComm:
             * rms_gamma.to(torch.float32)
         ).to(input.dtype)
         residual_out.copy_(expected_residual)
-        norm_out.copy_(expected_norm)
+        if pattern is self.AllReduceFusionPattern.kARResidualRMSNorm:
+            norm_out.copy_(expected_norm)
+        elif pattern in (
+            self.AllReduceFusionPattern.kARResidualRMSNormFP8Quant,
+            self.AllReduceFusionPattern.kARResidualRMSNormOutFP8Quant,
+        ):
+            quant_out.copy_((expected_norm / scale_factor).to(quant_out.dtype))
+            if norm_out is not None:
+                norm_out.copy_(expected_norm)
+        else:
+            raise ValueError(f"Unexpected pattern: {pattern}")
 
 
 def _torch_allreduce_residual_rmsnorm_baseline(
@@ -180,6 +192,58 @@ class TestFlashInferCommFusion(CustomTestCase):
                         with self.assertRaises(ValueError):
                             fusion._resolve_backend(*args)
 
+    def test_static_fp8_fusion_sizes_workspace_for_long_prefill(self):
+        token_count = 2049
+        x = torch.zeros(token_count, 8)
+        residual = torch.zeros_like(x)
+        weight = torch.ones(8)
+        scale = torch.ones(1)
+        quant_out = torch.zeros_like(x, dtype=torch.float8_e4m3fn)
+        norm_out = torch.zeros_like(x)
+        norm = type("Norm", (), {"variance_epsilon": 1e-6})()
+
+        with (
+            patch.object(layernorm, "_fp8_static_input_scale", return_value=scale),
+            patch.object(
+                fusion,
+                "try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant",
+                return_value=(quant_out, residual, norm_out),
+            ) as fused_op,
+        ):
+            result = layernorm._forward_with_allreduce_fusion_static_fp8_quant(
+                norm,
+                x,
+                residual,
+                weight,
+                quant_linear=object(),
+                use_attn_tp_group=False,
+                keep_bf16=True,
+            )
+
+        self.assertIsNotNone(result)
+        self.assertEqual(fused_op.call_args.kwargs["max_token_num"], token_count)
+
+        with (
+            patch.object(torch.compiler, "is_compiling", return_value=True),
+            patch.object(layernorm, "_fp8_static_input_scale", return_value=scale),
+            patch.object(
+                fusion,
+                "try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant",
+                return_value=(quant_out, residual, norm_out),
+            ) as compiled_fused_op,
+        ):
+            layernorm._forward_with_allreduce_fusion_static_fp8_quant(
+                norm,
+                x,
+                residual,
+                weight,
+                quant_linear=object(),
+                use_attn_tp_group=False,
+                keep_bf16=True,
+            )
+
+        self.assertEqual(compiled_fused_op.call_args.kwargs["max_token_num"], 2048)
+
     def test_allreduce_fusion_backends_match_torch_baseline(self):
         fake_comm = _FakeFlashInferComm()
         original_comm = fusion._flashinfer_comm
@@ -248,6 +312,145 @@ class TestFlashInferCommFusion(CustomTestCase):
             else:
                 buffers[manager_key] = original_manager
             fusion._flashinfer_allreduce_unavailable = original_unavailable
+
+    def test_static_fp8_quant_patterns_match_baseline(self):
+        if not torch.cuda.is_available():
+            self.skipTest("FlashInfer allreduce custom op is CUDA-only")
+
+        fake_comm = _FakeFlashInferComm()
+        manager = fusion.FlashInferWorkspaceManager()
+        manager.workspace = _FakeWorkspace("trtllm", 2)
+        manager.initialized = True
+        from sglang.srt.runtime_context import get_resources
+
+        buffers = get_resources().buffers
+        manager_key = "flashinfer_fusion_moe_tp_workspace"
+        old_manager = buffers.get(manager_key)
+        old_comm = fusion._flashinfer_comm
+        try:
+            buffers[manager_key] = manager
+            fusion._flashinfer_comm = fake_comm
+            x = torch.randn(4, 8, device="cuda", dtype=torch.bfloat16)
+            residual = torch.randn_like(x)
+            weight = torch.randn(8, device="cuda", dtype=torch.bfloat16)
+            scale = torch.tensor(0.02, device="cuda")
+            expected_norm, expected_residual = (
+                _torch_allreduce_residual_rmsnorm_baseline(x, residual, weight, 2, 1e-6)
+            )
+
+            with (
+                patch.object(fusion, "is_flashinfer_available", return_value=True),
+                get_parallel().override(moe_tp_size=2, moe_ep_size=1),
+                patch.object(fusion, "ensure_workspace_initialized", return_value=True),
+            ):
+                for keep_bf16 in (False, True):
+                    quant, residual_out, norm = (
+                        fusion.try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+                            x,
+                            residual,
+                            weight,
+                            scale,
+                            keep_bf16=keep_bf16,
+                            use_attn_tp_group=False,
+                        )
+                    )
+                    torch.testing.assert_close(residual_out, expected_residual)
+                    torch.testing.assert_close(
+                        quant.float(),
+                        (expected_norm / scale).to(torch.float8_e4m3fn).float(),
+                    )
+                    self.assertEqual(norm.numel() > 0, keep_bf16)
+                    if keep_bf16:
+                        torch.testing.assert_close(norm, expected_norm)
+        finally:
+            fusion._flashinfer_comm = old_comm
+            if old_manager is None:
+                buffers.pop(manager_key, None)
+            else:
+                buffers[manager_key] = old_manager
+
+    def test_static_fp8_compile_path_respects_workspace_allocation(self):
+        manager = fusion.FlashInferWorkspaceManager()
+        manager.workspace = _FakeWorkspace("trtllm", 2)
+        manager.initialized = True
+        manager.world_size = 2
+        manager.group = ("device_group", "cpu_group")
+        manager.max_token_num = 8
+        manager.hidden_dim = 16
+        manager.dtype = torch.bfloat16
+
+        from sglang.srt.runtime_context import get_resources
+
+        buffers = get_resources().buffers
+        manager_key = "flashinfer_fusion_attn_tp_workspace"
+        old_manager = buffers.get(manager_key)
+        old_comm = fusion._flashinfer_comm
+        launch = MagicMock(return_value=(object(), object(), object()))
+        try:
+            buffers[manager_key] = manager
+            fusion._flashinfer_comm = _FakeFlashInferComm()
+            with (
+                get_parallel().override(attn_tp_size=2, attn_tp_rank=0),
+                patch.object(torch.compiler, "is_compiling", return_value=True),
+                patch.object(
+                    fusion,
+                    "get_attn_tp_group",
+                    return_value=MagicMock(
+                        device_group="device_group", cpu_group="cpu_group"
+                    ),
+                ),
+                patch.object(
+                    fusion,
+                    "_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant",
+                    launch,
+                ),
+            ):
+                for shape, dtype in (
+                    ((9, 16), torch.bfloat16),
+                    ((8, 17), torch.bfloat16),
+                    ((8, 16), torch.float32),
+                ):
+                    with self.subTest(shape=shape, dtype=dtype):
+                        x = torch.randn(shape, dtype=dtype)
+                        result = fusion.try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+                            x,
+                            torch.randn_like(x),
+                            torch.randn(shape[-1], dtype=dtype),
+                            torch.ones(1, dtype=torch.float32),
+                            use_attn_tp_group=True,
+                        )
+                        self.assertEqual(result, (None, None, None))
+
+                manager.group = ("other_device_group", "other_cpu_group")
+                x = torch.randn((8, 16), dtype=torch.bfloat16)
+                result = (
+                    fusion.try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+                        x,
+                        torch.randn_like(x),
+                        torch.randn(16, dtype=torch.bfloat16),
+                        torch.ones(1, dtype=torch.float32),
+                        use_attn_tp_group=True,
+                    )
+                )
+                self.assertEqual(result, (None, None, None))
+
+                manager.group = ("device_group", "cpu_group")
+                with patch.object(fusion, "_flashinfer_allreduce_unavailable", True):
+                    result = fusion.try_flashinfer_allreduce_residual_rmsnorm_static_fp8_quant(
+                        x,
+                        torch.randn_like(x),
+                        torch.randn(16, dtype=torch.bfloat16),
+                        torch.ones(1, dtype=torch.float32),
+                        use_attn_tp_group=True,
+                    )
+                    self.assertEqual(result, (None, None, None))
+                launch.assert_not_called()
+        finally:
+            fusion._flashinfer_comm = old_comm
+            if old_manager is None:
+                buffers.pop(manager_key, None)
+            else:
+                buffers[manager_key] = old_manager
 
 
 _GROUP_KEY = ("device_group", "cpu_group")
@@ -484,9 +687,12 @@ class TestTagGroupsForFlashInferAllReduceOnly(CustomTestCase):
     def _tag(self, *, attn_tp, moe_ep, moe_tp):
         from sglang.srt.distributed import parallel_state as ps
 
-        with patch.object(ps, "_ENABLE_FLASHINFER_ALLREDUCE_ONLY", True), patch.object(
-            ps, "_ATTN_TP", attn_tp
-        ), patch.object(ps, "_MOE_EP", moe_ep), patch.object(ps, "_MOE_TP", moe_tp):
+        with (
+            patch.object(ps, "_ENABLE_FLASHINFER_ALLREDUCE_ONLY", True),
+            patch.object(ps, "_ATTN_TP", attn_tp),
+            patch.object(ps, "_MOE_EP", moe_ep),
+            patch.object(ps, "_MOE_TP", moe_tp),
+        ):
             ps._tag_groups_for_flashinfer_allreduce_only()
 
     def test_hybrid_ep_tp_tags_only_the_ep_group(self):

--- a/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
+++ b/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
@@ -2,6 +2,8 @@ import types
 import unittest
 from unittest.mock import patch
 
+import torch
+
 from sglang.srt.layers import communicator as comm
 from sglang.srt.layers.communicator import LayerCommunicator, ScatterMode
 from sglang.srt.runtime_context import get_parallel
@@ -59,6 +61,65 @@ class TestFuseMlpAllReduceGate(CustomTestCase):
 
     def test_pure_ep_still_fuses(self):
         self.assertTrue(self._should_fuse(moe_ep_size=4, moe_tp_size=1))
+
+
+class TestStaticFp8ScaleHandoff(CustomTestCase):
+    def test_scattered_gather_keeps_static_scale_scalar(self):
+        scale = torch.ones(1, dtype=torch.float32)
+        quant = torch.zeros(2, 8, dtype=torch.float8_e4m3fn)
+        bf16 = torch.zeros(2, 8, dtype=torch.bfloat16)
+        residual_out = torch.zeros(2, 8, dtype=torch.bfloat16)
+
+        class _Norm:
+            def forward_with_allreduce_fusion(self, *args, **kwargs):
+                raise AssertionError("static-FP8 path should be selected")
+
+            def forward_with_allreduce_fusion_static_fp8_quant(
+                self, *args, keep_bf16, **kwargs
+            ):
+                hidden_states = (bf16, quant, scale) if keep_bf16 else (quant, scale)
+                return hidden_states, residual_out
+
+        def _gather_every_tuple_element(hidden_states, **kwargs):
+            if isinstance(hidden_states, tuple):
+                return tuple(torch.cat((item, item), dim=0) for item in hidden_states)
+            return torch.cat((hidden_states, hidden_states), dim=0)
+
+        for keep_bf16 in (False, True):
+            with self.subTest(keep_bf16=keep_bf16):
+                layer = types.SimpleNamespace(
+                    enable_fused_ar_quant=True,
+                    fused_ar_quant_linear=object(),
+                    fused_ar_quant_keep_bf16=keep_bf16,
+                    input_layernorm=_Norm(),
+                    _communicate_simple_fn=_gather_every_tuple_element,
+                    _context=object(),
+                    qkv_latent_func=None,
+                )
+                hidden_states = torch.zeros(2, 8, dtype=torch.bfloat16)
+                hidden_states._sglang_needs_allreduce_fusion = True
+                with (
+                    patch.object(comm, "_use_aiter", False),
+                    patch.object(
+                        comm, "apply_flashinfer_allreduce_fusion", return_value=True
+                    ),
+                    patch.object(
+                        comm,
+                        "get_attn_tp_context",
+                        return_value=types.SimpleNamespace(input_scattered=False),
+                    ),
+                ):
+                    result, _ = LayerCommunicator.prepare_attn(
+                        layer,
+                        hidden_states,
+                        torch.zeros_like(hidden_states),
+                        types.SimpleNamespace(),
+                    )
+
+                self.assertIs(result[-1], scale)
+                self.assertEqual(result[-1].numel(), 1)
+                for token_tensor in result[:-1]:
+                    self.assertEqual(token_tensor.shape[0], 4)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_qwen3_5_fused_ar_quant.py
+++ b/test/registered/unit/models/test_qwen3_5_fused_ar_quant.py
@@ -1,0 +1,245 @@
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.models import qwen3_5
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=15, stage="base-b", runner_config="1-gpu-small")
+
+
+class _Linear:
+    quant_method = object()
+
+
+class _ModelOptFp8LinearMethod:
+    use_marlin = False
+
+
+class _RecordingLinear:
+    def __init__(self, quant_method):
+        self.quant_method = quant_method
+        self.input = None
+
+    def __call__(self, hidden_states):
+        self.input = hidden_states
+        return hidden_states, None
+
+
+def test_cuda_modelopt_fp8_tuple_reuses_existing_handoff():
+    bf16 = torch.randn(2, 8)
+    fp8 = torch.zeros(2, 8, dtype=torch.float8_e4m3fn)
+    scale = torch.ones(1)
+    linear = _Linear()
+    linear.quant_method = _ModelOptFp8LinearMethod()
+
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(qwen3_5, "_fp8_static_input_scale", return_value=scale),
+    ):
+        assert qwen3_5._linear_accepts_fp8_tuple(linear)
+        dual_result = qwen3_5._select_fused_ar_input_for_linear(
+            (bf16, fp8, scale), linear
+        )
+        quant_result = qwen3_5._select_fused_ar_input_for_linear((fp8, scale), linear)
+        assert dual_result[0] is fp8 and dual_result[1] is scale
+        assert quant_result[0] is fp8 and quant_result[1] is scale
+
+
+def test_gdn_routes_dual_output_to_quantized_and_bf16_projections():
+    bf16 = torch.randn(2, 8)
+    fp8 = torch.zeros(2, 8, dtype=torch.float8_e4m3fn)
+    scale = torch.ones(1)
+    gdn = type("GDN", (), {})()
+    gdn.in_proj_qkvz = _RecordingLinear(_ModelOptFp8LinearMethod())
+    gdn.in_proj_ba = _RecordingLinear(object())
+    gdn.alt_stream = None
+
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(qwen3_5, "check_cuda_graph_backend", return_value=False),
+        patch.object(qwen3_5, "_fp8_static_input_scale", return_value=scale),
+    ):
+        qkvz, ba = qwen3_5.Qwen3_5GatedDeltaNet._forward_input_proj_fused_quant(
+            gdn, (bf16, fp8, scale)
+        )
+
+    assert gdn.in_proj_qkvz.input[0] is fp8
+    assert gdn.in_proj_qkvz.input[1] is scale
+    assert gdn.in_proj_ba.input is bf16
+    assert qkvz is gdn.in_proj_qkvz.input
+    assert ba is bf16
+
+
+def test_cuda_non_modelopt_fp8_method_does_not_accept_tuple():
+    linear = _Linear()
+    linear.quant_method = type("Fp8LinearMethod", (), {"block_quant": False})()
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(qwen3_5, "_fp8_static_input_scale", return_value=None),
+    ):
+        assert not qwen3_5._linear_accepts_fp8_tuple(linear)
+
+
+def test_cuda_tuple_gate_matches_static_per_tensor_fp8_producer():
+    linear = _Linear()
+    scale = torch.ones(1)
+
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(
+            qwen3_5, "_fp8_static_input_scale", return_value=scale, create=True
+        ),
+    ):
+        assert qwen3_5._linear_accepts_fp8_tuple(linear)
+
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(
+            qwen3_5, "_fp8_static_input_scale", return_value=None, create=True
+        ),
+    ):
+        assert not qwen3_5._linear_accepts_fp8_tuple(linear)
+
+
+def test_communicator_gate_uses_quant_method_before_scale_is_scalarized():
+    linear = _Linear()
+    linear.input_scale = torch.ones(2)
+
+    with (
+        patch.object(qwen3_5, "_enable_qwen35_fused_ar_quant", return_value=True),
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(
+            qwen3_5, "_is_static_per_tensor_fp8_linear", return_value=True, create=True
+        ),
+        patch.object(qwen3_5, "_fp8_static_input_scale", return_value=None),
+    ):
+        assert qwen3_5._enable_fused_ar_quant_for_linear(linear)
+        assert not qwen3_5._linear_accepts_fp8_tuple(linear)
+
+
+def test_rocm_communicator_gate_matches_per_group_tuple_consumer():
+    linear = _Linear()
+    linear.quant_method = type(
+        "Fp8LinearMethod", (), {"block_quant": False, "use_mxfp8": False}
+    )()
+
+    with (
+        patch.object(qwen3_5, "_enable_qwen35_fused_ar_quant", return_value=True),
+        patch.object(qwen3_5, "_use_aiter", True),
+        patch.object(qwen3_5, "_is_static_per_tensor_fp8_linear", return_value=True),
+    ):
+        assert not qwen3_5._enable_fused_ar_quant_for_linear(linear)
+        linear.quant_method.block_quant = True
+        assert qwen3_5._enable_fused_ar_quant_for_linear(linear)
+
+
+def test_cuda_prequantized_handoff_preserves_linear_output_dtype():
+    fp8 = torch.zeros(2, 8, dtype=torch.float8_e4m3fn)
+    scale = torch.ones(1)
+    linear = _Linear()
+    linear.orig_dtype = torch.float16
+
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(qwen3_5, "_fp8_static_input_scale", return_value=scale),
+    ):
+        selected = qwen3_5._select_fused_ar_input_for_linear((fp8, scale), linear)
+
+    assert len(selected) == 3
+    assert selected[0] is fp8 and selected[1] is scale
+    assert selected[2] is torch.float16
+
+
+def test_shared_gate_can_keep_importing_models_rocm_only():
+    context = type(
+        "Context",
+        (),
+        {"is_config_namespace_published": lambda self, name: True},
+    )()
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(qwen3_5, "_is_cuda", True),
+        patch.object(
+            qwen3_5,
+            "is_flashinfer_allreduce_fusion_arch_supported",
+            return_value=True,
+            create=True,
+        ),
+        patch.object(qwen3_5, "get_context", return_value=context),
+        patch.object(
+            qwen3_5,
+            "get_exec",
+            return_value=type(
+                "Exec",
+                (),
+                {
+                    "comm": type(
+                        "Comm",
+                        (),
+                        {"flashinfer_allreduce_fusion_backend": "trtllm"},
+                    )()
+                },
+            )(),
+        ),
+    ):
+        assert qwen3_5._enable_qwen35_fused_ar_quant()
+        assert not qwen3_5._enable_qwen35_fused_ar_quant(allow_cuda=False)
+
+
+def test_cuda_gate_fails_closed_before_exec_config_is_published():
+    context = type(
+        "Context",
+        (),
+        {"is_config_namespace_published": lambda self, name: False},
+    )()
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(qwen3_5, "_is_cuda", True),
+        patch.object(
+            qwen3_5,
+            "is_flashinfer_allreduce_fusion_arch_supported",
+            return_value=True,
+            create=True,
+        ),
+        patch.object(qwen3_5, "get_context", return_value=context),
+        patch.object(
+            qwen3_5,
+            "get_exec",
+            side_effect=ValueError("config namespace 'exec' not published"),
+        ) as get_exec,
+    ):
+        assert not qwen3_5._enable_qwen35_fused_ar_quant()
+        get_exec.assert_not_called()
+
+
+def test_cuda_gate_rejects_unsupported_flashinfer_allreduce_arch():
+    context = type(
+        "Context",
+        (),
+        {"is_config_namespace_published": lambda self, name: True},
+    )()
+    with (
+        patch.object(qwen3_5, "_use_aiter", False),
+        patch.object(qwen3_5, "_is_cuda", True),
+        patch.object(
+            qwen3_5,
+            "is_flashinfer_allreduce_fusion_arch_supported",
+            return_value=False,
+            create=True,
+        ),
+        patch.object(qwen3_5, "get_context", return_value=context),
+    ):
+        assert not qwen3_5._enable_qwen35_fused_ar_quant()
+
+
+def test_amd_tuple_predicate_remains_per_group_only():
+    linear = _Linear()
+    with patch.object(qwen3_5, "_use_aiter", True):
+        assert not qwen3_5._linear_accepts_fp8_tuple(linear)
+
+    linear.quant_method = type(
+        "Fp8LinearMethod", (), {"block_quant": True, "use_mxfp8": False}
+    )()
+    with patch.object(qwen3_5, "_use_aiter", True):
+        assert qwen3_5._linear_accepts_fp8_tuple(linear)


### PR DESCRIPTION
## Summary

- integrate FlashInfer `kARResidualRMSNormFP8Quant` and `kARResidualRMSNormOutFP8Quant` into Qwen3.5's SM90/SM100 layer-boundary path
- hand the fused FP8 activation, exact layer-owned static scale, and original output dtype directly to compatible native, ModelOpt, and compressed-tensors FP8 linears
- preserve BF16 for GDN's second projection and keep the replicated scalar scale outside token all-gathers
- fail closed to the existing path before collective launch for unsupported methods, shapes, dtypes, architectures, workspaces, or process groups

Refs #31504 (Step 3).

## Runtime flow

```mermaid
flowchart TD
    A["Qwen3.5 decoder construction"] --> B{"static per-tensor FP8 consumer + SM90/SM100 FlashInfer AR"}
    B -->|eligible| C["LayerCommunicator records exact consumer"]
    B -->|unsupported| D["Existing split path"]
    C --> E{"scale / shape / workspace / exact-group preflight"}
    E -->|pass on every rank| F["AR + residual + RMSNorm + static FP8 quant"]
    E -->|fallback before collective| D
    F --> G{"BF16 side output required?"}
    G -->|full attention| H["FP8 + scalar scale"]
    G -->|GDN| I["BF16 + FP8 + scalar scale"]
    H --> J["FP8 linear skips standalone quant"]
    I --> J
    D --> K["AR + RMSNorm, then _static_quant_fp8"]
```

Construction checks quant-method capability before checkpoint post-processing; execution rechecks the loaded scalar scale. Compiled execution additionally requires a preinitialized workspace with matching capacity, dtype, world size, and exact device/CPU process-group identity. A synchronized initialization failure disables the path on every TP rank.

## Scope

- collective architectures: SM90 and SM100, matching SGLang's existing FlashInfer allreduce gate
- model wiring: Qwen3.5 standard attention and GDN layer-boundary projections
- quant consumers: static per-tensor native FP8, ModelOpt FP8, and compressed-tensors W8A8 FP8
- out of scope: block/dynamic FP8, Marlin activation handling, SM120 allreduce, DP-attention/wide-EP producer fusion, and non-Qwen3.5 model wiring

Production diff: `+450/-78` across seven files. Test diff: `+706/-8` across four focused files.

## Validation

Head: `71b5af4cc000c043a98476560dbed8b967251c9c`

- exact-source no-GPU suite: `44 passed, 18 skipped, 19 subtests passed`
- Ruff `F401/F821/UP037`, isort, Black, compileall, and `git diff --check`: passed
- 2x H20 TP2: quant-only and BF16+FP8 modes at rows 1/8/32/128; eager, `torch.compile(fullgraph=True)`, CUDA Graph capture, and changed-input replay passed; FP8 bytes, scale, BF16 side output, and residual matched the split reference
- TP2 interleaved Graph operator geomean: **1.108x dual-output**, **1.124x quant-only**

## Qwen3.5-397B TP4 E2E

Model: `nvidia/Qwen3.5-397B-A17B-NVFP4-V2`; 4x H20 96GB with NV18 links; TP4, `modelopt_mixed`, Marlin FP4 GEMM/MoE, CUDA Graph max BS 32, radix cache disabled.

The matrix used four independent server lifetimes in A1/B1/B2/A2 order. Both sides used identical code, model, arguments, caches, and two common H20 environment overlays; baseline alone set `SGLANG_DISABLE_FUSED_AR_QUANT=1`. Values below are the medians of the two baseline and two candidate lifetimes.

| ISL / OSL | concurrency | output throughput | median ITL | interpretation |
|---|---:|---:|---:|---|
| 128 / 256 | 1 | **+1.27%** | **+1.29%** | decode-bound win |
| 1024 / 1024 | 1 | **+1.29%** | **+1.33%** | decode-bound win |
| 8192 / 256 | 1 | **+0.85%** | **+1.32%** | long-prefill dilution |
| all three | 8 | -0.28% geomean | mixed | neutral within repeat drift |
| all three | 32 | +0.23% geomean | mixed | neutral within repeat drift |

All four fixed-prompt correctness runs completed 32/32 requests. Every one of the nine performance points completed its exact requested count and exact per-request input/output token lengths with no errors. Baseline and candidate both reported `max_total_num_tokens=1,060,469` and 14.70GB available scheduler memory.

The issue's 1.5-2.5% estimate assumes a 4-5ms step. On H20, baseline C1 median ITL is about 6.74ms; the observed 86-88us reduction is consistent with the issue's 60-120us/step cost model and yields about 1.3%.

## Profiler attribution

Separate four-rank Torch Profiler traces recorded 64 server steps. Every rank produced the same counts:

| family | baseline | candidate |
|---|---:|---:|
| pattern 1: AR + residual + RMSNorm | 7616 | 3840 |
| `_static_quant_fp8` | 15360 | 11584 |
| pattern 2: quant-only fused | 0 | 960 |
| pattern 4: BF16+FP8 fused | 0 | 2816 |

The candidate therefore replaces exactly `3776 = 59 eligible layers x 64 steps` split collective/quant pairs. The checkpoint has 15 full-attention and 45 GDN layers; all 15 attention layers use pattern 2, 44 GDN layers use pattern 4, and the first layer has no preceding residual collective. Static-quant accounting closes exactly: baseline `15360/64 = 240` sites/step; candidate `11584/64 + 3776/64 = 240`.

Marlin MoE is the largest recorded kernel family (~35% of GPU kernel time), explaining why a roughly 1.11x target-boundary speedup becomes a low-concurrency ~1.3% E2E result and is diluted at larger batches.

This rental image did not provide `nsys` or `ncu`, so this PR makes no measured HBM-transaction, L2, register, or occupancy claim.

## Runtime overlay disclosure

The real-model run placed the exact PR commit beneath two identical baseline/candidate environment fixes:

- `ca759ecd19`: use cuDNN for a FlashInfer FP8 BMM that independently crashes through cuBLAS on this H20 image
- `4e961049e3`: the two-line TVM FFI tuple NVCC fix from upstream PR #35733

These overlays do not change the A/B variable, but are disclosed so the E2E tree is reproducible rather than described as a bare one-commit checkout.

<!-- pr-states:start -->
---
### CI States

<!-- pr-states:end -->
