### PR TITLE
[Bugfix] Preserve streaming session ownership on rejected turns

### DIFF
--- a/python/sglang/srt/session/session_controller.py
+++ b/python/sglang/srt/session/session_controller.py
@@ -324,6 +324,11 @@ class Session:
 
         if abort:
             new_req.set_finish_with_abort(abort_message)
+            if self.streaming:
+                # A rejected overlapping turn never acquired the session.
+                # Keep scheduler-side pre-abort cleanup from releasing the
+                # request that still owns the streaming session.
+                new_req.session = None
         elif self.streaming:
             # req_nodes is NOT updated here — finish_req() handles it.
             self._inflight = True

--- a/test/registered/unit/mem_cache/test_session_token_share_unit.py
+++ b/test/registered/unit/mem_cache/test_session_token_share_unit.py
@@ -16,6 +16,7 @@ import unittest
 from array import array
 from types import SimpleNamespace
 
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.srt.session.session_controller import Session
 from sglang.test.test_utils import CustomTestCase
@@ -124,6 +125,29 @@ class TestSessionTokenShare(CustomTestCase):
         r4 = self._create("r4", [70])
         self.assertEqual(list(r4.origin_input_ids), in1 + out1 + [70])
         self.assertEqual(list(r4.full_untruncated_fill_ids), list(r4.origin_input_ids))
+
+    def test_overlapping_turn_does_not_release_active_request(self):
+        in1, out1 = list(range(400, 410)), [1, 2, 3]
+        r1 = self._create("r1", in1)
+        self._decode_and_finish(r1, out1)
+
+        # Turn 2 owns the session until it finishes or is explicitly aborted.
+        self._create("r2", [50, 51])
+        self.assertTrue(self.session._inflight)
+
+        # Rejecting an overlapping turn must not let scheduler-side pre-abort
+        # cleanup clear turn 2's ownership of the session.
+        with get_parallel().override(tp_size=1, tp_rank=0):
+            r3 = self._create("r3", [60])
+        self.assertIsNotNone(r3.to_finish)
+        self.assertIsNone(r3.session)
+        self.assertTrue(self.session._inflight)
+
+        # Once turn 2 is aborted, the next request resumes from the last
+        # committed turn; neither rejected attempt is retained.
+        self.session.abort_req()
+        r4 = self._create("r4", [70])
+        self.assertEqual(list(r4.origin_input_ids), in1 + out1 + [70])
 
     def test_first_turn_abort(self):
         self._create("r1", [1, 2, 3])


### PR DESCRIPTION
## Motivation

Streaming sessions use a session-wide `_inflight` flag to prevent overlapping turns. When an overlapping turn is rejected in `Session.create_req`, the returned pre-aborted request still points at the session even though it never acquired `_inflight`.

Later, `StreamingSession.find_active_slot` treats that request like an admitted request and calls `req.session.abort_req()`. This clears the flag owned by the previous live turn, so another turn can enter the same session and mutate the shared token arrays while the original request is still running.

This addresses the session-ownership invariant in #36475. It complements #35936, which handles aborting scheduler requests during HTTP cancellation; it does not duplicate that request-lifecycle change.

## Modifications

- Detach streaming requests that are pre-aborted during `Session.create_req` from the session.
- Preserve the active request's `_inflight` ownership when an overlapping turn is rejected.
- Add a regression test covering a completed turn, a live turn, an overlapping rejected turn, and the next valid turn.
- Verify that neither the live attempt nor the rejected attempt is added to committed session history.

Scheduler-side pre-aborts that occur after a request has been admitted remain attached to the session and continue to clear their own inflight state.

## Accuracy Tests

Not applicable; this change does not modify model outputs.

Validation:

- Baseline regression: failed because the rejected request still had a `Session` reference.
- Patched focused regression: 1 passed.
- `test_session_token_share_unit.py`: 5 passed.
- Pre-commit on the modified source and test: passed.
- `git diff --check`: passed.

## Speed Tests and Profiling

Not applicable; the change only runs on rejected session requests.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is needed for this bug fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable to the rejected-request path.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## AI usage disclosure

Assisted-by: AI assistant

AI assisted with implementation suggestions and test preparation. I reviewed and understood every change and accept responsibility for maintaining the code and addressing reviewer feedback.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32975051841](https://github.com/sgl-project/sglang/actions/runs/32975051841)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32975051470](https://github.com/sgl-project/sglang/actions/runs/32975051470)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32975051783](https://github.com/sgl-project/sglang/actions/runs/32975051783)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->