### PR TITLE
[Bugfix] Validate NGRAM capacity > max_trie_depth at startup (#36495)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -10004,6 +10004,25 @@ class ServerArgs:
                 not cfg.enable_mixed_chunk
             ), "enable_mixed_chunk is required for speculative decoding"
 
+            # NGRAM trie counts the root node against the configured capacity.
+            # When capacity == max_trie_depth, only depth-1 non-root nodes are
+            # available, but a suffix at maximum depth requires depth nodes. The
+            # first insertion then enters Trie::squeeze() with an empty LRU and
+            # crashes the native worker (issue #36495). Validate early.
+            if cfg.speculative_algorithm == "NGRAM":
+                assert (
+                    cfg.speculative_ngram_capacity
+                    > cfg.speculative_ngram_max_trie_depth
+                ), (
+                    "--speculative-ngram-capacity must be strictly greater than "
+                    "--speculative-ngram-max-trie-depth. The trie root node is "
+                    "counted against the capacity, so capacity <= max_trie_depth "
+                    "leaves insufficient nodes for a maximum-depth insertion and "
+                    "causes a crash in the native worker. "
+                    f"Got capacity={cfg.speculative_ngram_capacity}, "
+                    f"max_trie_depth={cfg.speculative_ngram_max_trie_depth}."
+                )
+
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).
         # Skip validation if disaggregation mode is decode.

--- a/test/registered/unit/server_args/test_ngram_capacity_validation.py
+++ b/test/registered/unit/server_args/test_ngram_capacity_validation.py
@@ -1,0 +1,73 @@
+"""Unit tests for NGRAM capacity > max_trie_depth validation (#36495).
+
+Validates that ``check_server_args`` rejects NGRAM speculative-decoding
+configs where ``speculative_ngram_capacity <= speculative_ngram_max_trie_depth``,
+which triggers a crash in the C++ ``Trie::squeeze`` during the first request.
+"""
+import unittest
+
+from sglang.srt.server_args import ServerArgs
+
+
+class TestNgramCapacityValidation(unittest.TestCase):
+    """Verify the NGRAM capacity-depth invariant in check_server_args."""
+
+    BASE_KWARGS = dict(
+        model_path="dummy",
+        served_model_name="dummy",
+        speculative_num_draft_tokens=4,
+        chunked_prefill_size=8192,
+        page_size=1,
+    )
+
+    def test_capacity_eq_depth_rejected(self):
+        """capacity == max_trie_depth must raise AssertionError."""
+        args = ServerArgs(
+            speculative_algorithm="NGRAM",
+            speculative_ngram_max_trie_depth=4,
+            speculative_ngram_capacity=4,
+            **self.BASE_KWARGS,
+        )
+        with self.assertRaises(AssertionError) as ctx:
+            args.check_server_args()
+        self.assertIn("capacity", str(ctx.exception))
+        self.assertIn("max_trie_depth", str(ctx.exception))
+
+    def test_capacity_lt_depth_rejected(self):
+        """capacity < max_trie_depth must raise AssertionError."""
+        args = ServerArgs(
+            speculative_algorithm="NGRAM",
+            speculative_ngram_max_trie_depth=10,
+            speculative_ngram_capacity=5,
+            **self.BASE_KWARGS,
+        )
+        with self.assertRaises(AssertionError) as ctx:
+            args.check_server_args()
+        self.assertIn("capacity", str(ctx.exception))
+
+    def test_capacity_gt_depth_accepted(self):
+        """capacity > max_trie_depth must pass validation."""
+        args = ServerArgs(
+            speculative_algorithm="NGRAM",
+            speculative_ngram_max_trie_depth=4,
+            speculative_ngram_capacity=8,
+            **self.BASE_KWARGS,
+        )
+        args.check_server_args()
+
+    def test_default_ngram_values_accepted(self):
+        """Default values (capacity=10M, depth=18) must pass."""
+        args = ServerArgs(
+            speculative_algorithm="NGRAM",
+            **self.BASE_KWARGS,
+        )
+        args.check_server_args()
+
+    def test_non_ngram_unaffected(self):
+        """Non-NGRAM configs must not be affected by the new check."""
+        args = ServerArgs(**self.BASE_KWARGS)
+        args.check_server_args()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

SGLang accepts an NGRAM speculative-decoding configuration where `speculative_ngram_capacity` is equal to (or less than) `speculative_ngram_max_trie_depth`. With both values set to `4`, the first ordinary generation request aborts the scheduler with `munmap_chunk(): invalid pointer` in the C++ `Trie::squeeze()` (issue #36495).

## Root Cause

The C++ NGRAM trie counts the root node against the configured `capacity`. When `capacity == max_trie_depth`, only `depth - 1` non-root nodes are available, but a suffix at maximum depth requires `depth` nodes. The first insertion enters `Trie::squeeze()` with an empty LRU and frees an invalid pointer.

Neither the CLI help nor the parameter documentation states that capacity must exceed max trie depth, and the server accepts the combination at startup.

## Fix

Add a startup validation in `ServerArgs.check_server_args()` to reject the invalid configuration **before** the native worker is created:

```python
if cfg.speculative_algorithm == "NGRAM":
    assert (
        cfg.speculative_ngram_capacity
        > cfg.speculative_ngram_max_trie_depth
    ), (
        "--speculative-ngram-capacity must be strictly greater than "
        "--speculative-ngram-max-trie-depth. ..."
    )
```

This matches the pattern used for other speculative-decoding validations in `check_server_args()`. The CLI flag keeps precedence; behavior is unchanged for valid configs.

## Tests

Added unit tests in `test/registered/unit/server_args/test_ngram_capacity_validation.py` covering:

- `capacity == max_trie_depth` → rejected ✅
- `capacity < max_trie_depth` → rejected ✅
- `capacity > max_trie_depth` → accepted ✅
- Default values (`capacity=10M`, `depth=18`) → accepted ✅
- Non-NGRAM configs → unaffected ✅

All tests pass on sglang 0.5.18.

Closes #36495

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32977128306](https://github.com/sgl-project/sglang/actions/runs/32977128306)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32977128244](https://github.com/sgl-project/sglang/actions/runs/32977128244)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32977128411](https://github.com/sgl-project/sglang/actions/runs/32977128411)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->