### PR TITLE
fix(offloader): pass tie_weights=False in functional_call for tied-param modules under --cpu-offload-gb

### DIFF
--- a/python/sglang/srt/utils/offloader.py
+++ b/python/sglang/srt/utils/offloader.py
@@ -145,7 +145,7 @@ class OffloaderV1(BaseOffloader):
                     k: v.to(device, non_blocking=True)
                     for k, v in module.state_dict().items()
                 }
-                output = functional_call(module, device_state, args=args, kwargs=kwargs)
+                output = functional_call(module, device_state, args=args, kwargs=kwargs, tie_weights=False)
                 module.forward = forward
                 return output
 
@@ -266,7 +266,7 @@ def _hook_module_forward_raw(module, on_forward_end, get_parameter_and_buffer_di
     def forward(*args, **kwargs):
         module.forward = original_forward
         output = functional_call(
-            module, get_parameter_and_buffer_dicts(), args=args, kwargs=kwargs
+            module, get_parameter_and_buffer_dicts(), args=args, kwargs=kwargs, tie_weights=False
         )
         on_forward_end()
         module.forward = forward


### PR DESCRIPTION
## Problem

`--cpu-offload-gb` crashes during the offloaded module's forward on models that have **tied parameters**. Concretely, serving Qwen3.8-27B (Qwen3-Next / `qwen3_5`, GatedDeltaNet) with cpu-offload fails with:

```
ValueError: functional_call got multiple values for keys ['linear_attn.A_log', 'linear_attn.attn.A_log'], which are tied. Consider using tie_weights=False
```

GatedDeltaNet exposes the same `A_log` parameter under two tied names. `OffloaderV1`/`OffloaderV2`'s forward hook rebuilds the module state via `functional_call(...)`, which defaults to `tie_weights=True` and rejects the tied keys.

## Fix

Pass `tie_weights=False` to both `functional_call(...)` sites in `offloader.py` (V1 and V2). This is safe: the offloader supplies the full parameter/buffer dict itself, so torch does not need to re-tie.

## Repro

`python -m sglang.launch_server --model-path <Qwen3.8-27B> --cpu-offload-gb 6 ...` (any hybrid GatedDeltaNet model with tied `A_log`).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #33068663087](https://github.com/sgl-project/sglang/actions/runs/33068663087)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #33068662631](https://github.com/sgl-project/sglang/actions/runs/33068662631)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #33068663031](https://github.com/sgl-project/sglang/actions/runs/33068663031)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->