### PR TITLE
fix(layernorm): keep GemmaRMSNorm weight-loader device-consistent under --cpu-offload-gb

### DIFF
--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -1076,7 +1076,7 @@ class GemmaRMSNorm(BaseFusedOp):
         assert param.size() == loaded_weight.size()
         param.data.copy_(loaded_weight)
         # Keep storage stable for CUDA graphs or fused paths that capture this buffer.
-        torch.add(param.data, 1.0, out=self.gemma_weight)
+        torch.add(param.data.to(self.gemma_weight.device, non_blocking=True), 1.0, out=self.gemma_weight)
 
     def _forward_impl(
         self,


### PR DESCRIPTION
## Problem

`--cpu-offload-gb` crashes while loading weights for models using `GemmaRMSNorm` (e.g. Qwen3.8-27B / `qwen3_5`):

```
RuntimeError: Expected all tensors to be on the same device, but found at least two devices, cuda:0 and cpu!
  File ".../layers/layernorm.py", in _weight_loader
    torch.add(param.data, 1.0, out=self.gemma_weight)
```

`GemmaRMSNorm` registers `gemma_weight` as a **non-persistent buffer** and precomputes `weight + 1` in its `_weight_loader`. The offloader moves the module's *parameters* to CPU but not its non-persistent buffers, so at load time `param.data` is on CPU while `self.gemma_weight` is still on CUDA, and the in-place `torch.add(..., out=...)` mixes devices.

## Fix

Run the add on the buffer's device by moving the (possibly offloaded) `param.data` there first:

```python
torch.add(param.data.to(self.gemma_weight.device, non_blocking=True), 1.0, out=self.gemma_weight)
```

For the non-offload path this is a no-op (`.to(same_device)` returns the same tensor); for the offloaded path it keeps `gemma_weight` correct and on-device so the forward hook works.

## Repro

`python -m sglang.launch_server --model-path <Qwen3.8-27B> --cpu-offload-gb 6 ...`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:warning: [Run #32979337813](https://github.com/sgl-project/sglang/actions/runs/32979337813)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:warning: [Run #32979337374](https://github.com/sgl-project/sglang/actions/runs/32979337374)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:warning: [Run #32979337553](https://github.com/sgl-project/sglang/actions/runs/32979337553)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->