### PR TITLE
[Bugfix] Validate chunked_prefill_size >= alignment for deterministic inference (#36344)

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -98,6 +98,7 @@ from sglang.srt.utils.common import (
     is_sm100_supported,
     is_sm120_supported,
     is_xpu,
+    get_int_env_var,
     json_list_type,
     nullable_str,
     parse_connector_type,
@@ -10011,6 +10012,36 @@ class ServerArgs:
             assert (
                 cfg.chunked_prefill_size % cfg.page_size == 0
             ), "chunked_prefill_size must be divisible by page_size"
+
+            # Deterministic inference requires chunked_prefill_size >= the
+            # prefill truncation alignment (default 4096 for triton and
+            # flashinfer).  When chunked_prefill_size is smaller than the
+            # alignment, PrefillAdder always returns OTHER (trunc_len <
+            # truncation_align_size), causing the request to be retried
+            # indefinitely and the server to hang (issue #36344).
+            if cfg.enable_deterministic_inference:
+                prefill_backend = self.get_attention_backends()[0]
+                if prefill_backend == "flashinfer":
+                    align_env = "SGLANG_FLASHINFER_PREFILL_SPLIT_TILE_SIZE"
+                    align_default = 4096
+                elif prefill_backend == "triton":
+                    align_env = "SGLANG_TRITON_PREFILL_TRUNCATION_ALIGN_SIZE"
+                    align_default = 4096
+                else:
+                    align_env = None
+
+                if align_env is not None:
+                    align_size = get_int_env_var(align_env, align_default)
+                    assert cfg.chunked_prefill_size >= align_size, (
+                        "--chunked-prefill-size must be >= the deterministic "
+                        f"inference prefill alignment size ({align_size}, "
+                        f"controlled by {align_env}) when "
+                        "--enable-deterministic-inference is set. A smaller "
+                        "chunked prefill size causes indefinite request retries "
+                        "and server hang. "
+                        f"Got chunked_prefill_size={cfg.chunked_prefill_size}, "
+                        f"alignment={align_size}."
+                    )
 
         # Check pdmux
         if cfg.enable_pdmux:

--- a/test/registered/unit/server_args/test_deterministic_chunked_prefill.py
+++ b/test/registered/unit/server_args/test_deterministic_chunked_prefill.py
@@ -1,0 +1,77 @@
+"""Unit tests for deterministic inference chunked-prefill alignment validation (#36344).
+
+Validates that ``check_server_args`` rejects configs where
+``chunked_prefill_size`` is smaller than the prefill truncation alignment
+when ``--enable-deterministic-inference`` is set, which causes indefinite
+request retries and server hang.
+"""
+import unittest
+
+from sglang.srt.server_args import ServerArgs
+
+
+class TestDeterministicChunkedPrefillValidation(unittest.TestCase):
+    """Verify the chunked_prefill_size >= alignment invariant."""
+
+    BASE_KWARGS = dict(
+        model_path="dummy",
+        served_model_name="dummy",
+        page_size=1,
+    )
+
+    def test_chunked_lt_align_rejected_triton(self):
+        """chunked_prefill_size < alignment + deterministic + triton -> reject."""
+        args = ServerArgs(
+            enable_deterministic_inference=True,
+            chunked_prefill_size=128,
+            attention_backend="triton",
+            **self.BASE_KWARGS,
+        )
+        with self.assertRaises(AssertionError) as ctx:
+            args.check_server_args()
+        self.assertIn("alignment", str(ctx.exception))
+
+    def test_chunked_lt_align_rejected_flashinfer(self):
+        """chunked_prefill_size < alignment + deterministic + flashinfer -> reject."""
+        args = ServerArgs(
+            enable_deterministic_inference=True,
+            chunked_prefill_size=128,
+            attention_backend="flashinfer",
+            **self.BASE_KWARGS,
+        )
+        with self.assertRaises(AssertionError) as ctx:
+            args.check_server_args()
+        self.assertIn("alignment", str(ctx.exception))
+
+    def test_chunked_eq_align_accepted(self):
+        """chunked_prefill_size == alignment must pass."""
+        args = ServerArgs(
+            enable_deterministic_inference=True,
+            chunked_prefill_size=4096,
+            attention_backend="triton",
+            **self.BASE_KWARGS,
+        )
+        args.check_server_args()
+
+    def test_chunked_gt_align_accepted(self):
+        """chunked_prefill_size > alignment must pass."""
+        args = ServerArgs(
+            enable_deterministic_inference=True,
+            chunked_prefill_size=8192,
+            attention_backend="triton",
+            **self.BASE_KWARGS,
+        )
+        args.check_server_args()
+
+    def test_no_deterministic_unaffected(self):
+        """Without deterministic inference, small chunked_prefill_size is fine."""
+        args = ServerArgs(
+            chunked_prefill_size=128,
+            attention_backend="triton",
+            **self.BASE_KWARGS,
+        )
+        args.check_server_args()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Thanks for pointing this out — I just noticed PR #36417 by @maithilijoshi20 was opened earlier today and addresses the same issue with the same approach.

Closing this as a duplicate. Will defer to #36417.

(For reference, both PRs add the same assertion in `check_server_args()` to reject `chunked_prefill_size < alignment` when deterministic inference is enabled.)