### PR TITLE
[spec decoding] Support block verification for rejection sampling

### DIFF
--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -183,16 +183,6 @@ To enable EAGLE speculative decoding the following parameters are relevant:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Auto (<code>8</code> for Llama/Grok; <code>4</code> for many other models). If <code>topk=1</code>, it is adjusted to <code>num_steps + 1</code>.</td>
     </tr>
     <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-rejection-sampling</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify sampled (non-greedy) drafts with token-level rejection sampling instead of tree-greedy matching (<code>topk=1</code>, EAGLE/EAGLE3 only).</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-block-verification</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify the whole draft block jointly (block verification, <a href="https://arxiv.org/abs/2403.10444">arXiv:2403.10444</a>) instead of token-by-token. Never accepts fewer tokens than token verification in expectation, same lossless guarantee; gains grow with temperature. Requires <code>--speculative-use-rejection-sampling</code> for EAGLE/EAGLE3; with DSPARK it swaps the internal sampling-accept kernel (greedy requests unaffected).</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
-    </tr>
-    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-accept-threshold-single</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Acceptance threshold for single-token verification. Lower values accept more aggressively.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>1.0</code></td>
@@ -800,18 +790,6 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>int</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code> (auto-chosen when omitted)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum number of draft tokens for verification</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-rejection-sampling</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>bool</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify sampled (non-greedy) drafts with token-level rejection sampling instead of tree-greedy matching (EAGLE/EAGLE3, <code>topk=1</code>)</td>
-    </tr>
-    <tr>
-      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-block-verification</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>bool</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify the whole draft block jointly (block verification, <a href="https://arxiv.org/abs/2403.10444">arXiv:2403.10444</a>) instead of token-by-token. Never accepts fewer tokens in expectation; same lossless guarantee. Requires <code>--speculative-use-rejection-sampling</code> for EAGLE/EAGLE3; with DSPARK it swaps the internal sampling-accept kernel (greedy requests unaffected)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dflash-block-size</code></td>

--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -183,6 +183,16 @@ To enable EAGLE speculative decoding the following parameters are relevant:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Auto (<code>8</code> for Llama/Grok; <code>4</code> for many other models). If <code>topk=1</code>, it is adjusted to <code>num_steps + 1</code>.</td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-rejection-sampling</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify sampled (non-greedy) drafts with token-level rejection sampling instead of tree-greedy matching (<code>topk=1</code>, EAGLE/EAGLE3 only).</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-block-verification</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify the whole draft block jointly (block verification, <a href="https://arxiv.org/abs/2403.10444">arXiv:2403.10444</a>) instead of token-by-token. Never accepts fewer tokens than token verification in expectation, same lossless guarantee; gains grow with temperature. Requires <code>--speculative-use-rejection-sampling</code> for EAGLE/EAGLE3; with DSPARK it swaps the internal sampling-accept kernel (greedy requests unaffected).</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-accept-threshold-single</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Acceptance threshold for single-token verification. Lower values accept more aggressively.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>1.0</code></td>
@@ -790,6 +800,18 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>int</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>None</code> (auto-chosen when omitted)</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum number of draft tokens for verification</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-rejection-sampling</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>bool</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify sampled (non-greedy) drafts with token-level rejection sampling instead of tree-greedy matching (EAGLE/EAGLE3, <code>topk=1</code>)</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-use-block-verification</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>bool</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>false</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Verify the whole draft block jointly (block verification, <a href="https://arxiv.org/abs/2403.10444">arXiv:2403.10444</a>) instead of token-by-token. Never accepts fewer tokens in expectation; same lossless guarantee. Requires <code>--speculative-use-rejection-sampling</code> for EAGLE/EAGLE3; with DSPARK it swaps the internal sampling-accept kernel (greedy requests unaffected)</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-dflash-block-size</code></td>

--- a/python/sglang/kernels/ops/speculative/__init__.py
+++ b/python/sglang/kernels/ops/speculative/__init__.py
@@ -22,6 +22,7 @@ _TRITON_KERNELS = [
     ("ragged_verify_kernels", "pad_verify_lens_to_bucket"),
     ("ragged_verify_kernels", "build_qo_indptr"),
     ("reject_sampling", "chain_speculative_sampling_triton"),
+    ("reject_sampling", "chain_block_speculative_sampling_triton"),
 ]
 for _mod, _fn in _TRITON_KERNELS:
     register_kernel(

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
@@ -15,12 +15,7 @@ from sglang.kernels.ops.speculative.reject_sampling import (
 
 
 def _block_verification_enabled() -> bool:
-    """Whether to verify with block verification (arXiv:2403.10444) instead
-    of classic token-level rejection sampling.
-
-    Deferred import: this kernels module must stay importable without a
-    running server context (kernel unit tests, CPU fallback).
-    """
+    """Deferred-import probe (no server context in kernel tests)."""
     try:
         from sglang.srt.runtime_context import get_spec
 

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
@@ -12,16 +12,7 @@ from sglang.kernels.ops.speculative.reject_sampling import (
     chain_block_speculative_sampling_triton,
     chain_speculative_sampling_triton,
 )
-
-
-def _block_verification_enabled() -> bool:
-    """Deferred-import probe (no server context in kernel tests)."""
-    try:
-        from sglang.srt.runtime_context import get_spec
-
-        return bool(get_spec().speculative_use_block_verification)
-    except Exception:
-        return False
+from sglang.srt.runtime_context import get_spec
 
 
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
@@ -134,7 +125,7 @@ def _accept_sampling_core(
     uniform_samples_final = torch.rand((bs,), dtype=torch.float32, device=device)
     accept_fn = (
         chain_block_speculative_sampling_triton
-        if _block_verification_enabled()
+        if get_spec().speculative_use_block_verification
         else chain_speculative_sampling_triton
     )
     accept_fn(

--- a/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
+++ b/python/sglang/kernels/ops/speculative/dspark/dspark_accept.py
@@ -9,8 +9,26 @@ import triton.language as tl
 
 from sglang.kernels.ops.speculative.dspark.dispatch import inputs_on_cuda
 from sglang.kernels.ops.speculative.reject_sampling import (
+    chain_block_speculative_sampling_triton,
     chain_speculative_sampling_triton,
 )
+
+
+def _block_verification_enabled() -> bool:
+    """Whether to verify with block verification (arXiv:2403.10444) instead
+    of classic token-level rejection sampling.
+
+    Deferred import: this kernels module must stay importable without a
+    running server context (kernel unit tests, CPU fallback).
+    """
+    try:
+        from sglang.srt.runtime_context import get_spec
+
+        return bool(get_spec().speculative_use_block_verification)
+    except Exception:
+        return False
+
+
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.dflash_utils import (
     _get_or_create_chain_verify_buffers,
@@ -119,7 +137,12 @@ def _accept_sampling_core(
     )
     uniform_samples = torch.rand((bs, gamma), dtype=torch.float32, device=device)
     uniform_samples_final = torch.rand((bs,), dtype=torch.float32, device=device)
-    chain_speculative_sampling_triton(
+    accept_fn = (
+        chain_block_speculative_sampling_triton
+        if _block_verification_enabled()
+        else chain_speculative_sampling_triton
+    )
+    accept_fn(
         predicts=predicts,
         accept_index=accept_index,
         accept_token_num=accept_token_num,

--- a/python/sglang/kernels/ops/speculative/reject_sampling.py
+++ b/python/sglang/kernels/ops/speculative/reject_sampling.py
@@ -12,11 +12,7 @@ def _vocab_scan_residual_mass(
     VOCAB_SIZE: tl.constexpr,
     BLOCK_V: tl.constexpr,
 ):
-    """Sum over the vocab of max(scale * M_b(x) - M_s(x), 0) on one row.
-
-    NaN draft entries are treated as 0, mirroring the classic kernel's NaN-q
-    guard so the residual falls back to (scaled) target mass.
-    """
+    """Row-wise sum of max(scale * M_b(x) - M_s(x), 0); NaN q treated as 0."""
     acc = 0.0
     for v_start in range(0, VOCAB_SIZE, BLOCK_V):
         v_offsets = v_start + tl.arange(0, BLOCK_V)
@@ -78,27 +74,12 @@ def speculative_sampling_block_kernel(
 ):
     """Block verification (arXiv:2403.10444, Algorithm 2).
 
-    Per-request program for a linear (topk=1) draft chain of gamma =
-    NUM_SLOTS - 1 drafted tokens (candidates[1..gamma]; slot 0 is the root /
-    last committed token). TargetProbs rows 0..gamma are M_b(. | c, X^i),
-    DraftProbs rows 0..gamma-1 are M_s(. | c, X^i) (row gamma unused, same as
-    the classic kernel).
-
-    Differences vs the classic token verification kernel:
-      * acceptance threshold h_i = Z_{i+1} / (Z_{i+1} + 1 - p_i) with
-        p_i = min(p_{i-1} * M_b(X_i) / M_s(X_i), 1) and
-        Z_{i+1} = sum_x max(p_i * M_b(x | row i) - M_s(x | row i), 0)
-        (h_gamma = p_gamma needs no Z), instead of min(p/q, 1);
-      * verification does NOT stop at the first failed token: the accepted
-        prefix length is tau = argmax_i{coin_i <= h_i}, a property that
-        strictly improves the expected number of accepted tokens;
-      * the residual distribution at tau is scaled by p_tau:
-        max(p_tau * M_b - M_s, 0) / Z_{tau+1}.
-
-    One-hot shortcut: when the draft row i places all mass on the drafted
-    token X_{i+1} (d(x_{i+1}) == 1, argmax/greedy drafts), the residual mass
-    is available in closed form, Z_{i+1} = p_i * (1 - M_b(X_{i+1} | row i)),
-    skipping that row's vocab scan.
+    Per-request kernel over a linear (topk=1) chain of gamma = NUM_SLOTS - 1
+    drafted tokens; same tensor contract as speculative_sampling_classic_kernel.
+    Accepts via h_i = Z_{i+1} / (Z_{i+1} + 1 - p_i) with cumulative prefix
+    ratio p_i and residual mass Z_{i+1}; tau = argmax_i{coin_i <= h_i}
+    (no early stop), then resamples from the p_tau-scaled residual.
+    One-hot draft rows use Z_{i+1} = p_i * (1 - M_b(X_{i+1})) in closed form.
     """
     pid = tl.program_id(0)
 
@@ -111,8 +92,7 @@ def speculative_sampling_block_kernel(
 
     tau = 0
     p = 1.0
-    # Residual snapshot at the row where tau was last updated:
-    # z_res = Z_{tau+1}, p_res = p_tau (scale of that row's residual).
+    # Residual snapshot at tau: z_res = Z_{tau+1}, p_res = p_tau.
     z_res = 0.0
     p_res = 1.0
 
@@ -130,16 +110,16 @@ def speculative_sampling_block_kernel(
             + ((step - 1) * stride_dp_s)
             + (draft_token * stride_dp_v)
         )
-        # Degenerate draft density (q=0 or NaN): keep the classic semantics —
-        # q=0 & p>0 behaves like an always-accept, q=0 & p=0 a hard reject.
+        # q=0 or NaN mirrors the classic kernel: q=0 & p>0 accepts, q=0 & p=0
+        # hard-rejects.
         d_ok = (d_prob == d_prob) & (d_prob > 0.0)
         ratio = tl.where(
             d_ok, t_prob / tl.where(d_ok, d_prob, 1.0), tl.where(t_prob > 0.0, 1.0, 0.0)
         )
         p = tl.minimum(p * ratio, 1.0)
 
-        # Z_{step+1} is consumed by h_step (step < gamma) and snapshots into
-        # the residual normalizer when tau lands on this step.
+        # Z_{step+1}: feeds h_step (step < gamma) and the residual normalizer
+        # if tau lands here.
         z = 0.0
         if (step < NUM_SLOTS - 1) & (p > 0.0):
             next_token = tl.load(cand_ptr_base + (step + 1) * stride_cand_s)
@@ -157,10 +137,8 @@ def speculative_sampling_block_kernel(
                     + (step * stride_tp_s)
                     + (next_token * stride_tp_v)
                 )
-                # Clamp: Z is a sum of non-negative terms and cannot be
-                # negative, but 1 - M_b(x) can dip below 0 when top-k/top-p
-                # renormalization rounds a target prob slightly above 1.0; a
-                # negative z would poison denom, h, and residual_norm.
+                # Clamp: 1 - M_b(x) can round slightly below 0 after
+                # top-k/top-p renorm; Z is a sum of non-negative terms.
                 z = tl.maximum(p * (1.0 - next_target_prob), 0.0)
             else:
                 z = _vocab_scan_residual_mass(
@@ -173,9 +151,8 @@ def speculative_sampling_block_kernel(
                     BLOCK_V,
                 )
 
-        # h_gamma = p_gamma (the paper's boundary case needs no Z beyond the
-        # chain). Denominator degenerates only when z == 0 and p == 1, i.e.
-        # scaled target and draft coincide: accept unconditionally.
+        # h_gamma = p_gamma; denom == 0 means scaled p == q, accept
+        # unconditionally.
         denom = z + 1.0 - p
         h_safe = tl.where(denom > 0.0, z / tl.where(denom > 0.0, denom, 1.0), 1.0)
         h = tl.where(step == NUM_SLOTS - 1, p, h_safe)
@@ -188,9 +165,8 @@ def speculative_sampling_block_kernel(
 
     tl.store(AcceptTokenNum + pid, tau)
 
-    # Materialize accepted draft tokens along the chain (same buffer layout
-    # the classic kernel produces: predicts live at the previous accepted
-    # slot's global index).
+    # Same predict layout as the classic kernel: predict at the previous
+    # accepted slot's global index.
     last_accepted_global_idx = root_global_idx
     for step in range(1, NUM_SLOTS):
         if step <= tau:
@@ -214,8 +190,7 @@ def speculative_sampling_block_kernel(
     dp_base_ptr_safe = DraftProbs + (pid * stride_dp_b) + (cur_prob_row * stride_dp_s)
 
     if all_drafts_accepted:
-        # Pure target row sample: draft row gamma does not exist, so this
-        # branch must stay draft-pointer-free.
+        # Draft row gamma does not exist; keep this branch draft-pointer-free.
         residual_norm = _vocab_scan_target_mass(
             tp_base_ptr,
             stride_tp_v,
@@ -223,8 +198,7 @@ def speculative_sampling_block_kernel(
             BLOCK_V,
         )
     else:
-        # tau == 0 never updated the snapshot inside the loop: its residual
-        # row is the root row with scale p_0 = 1. Compute it lazily now.
+        # tau == 0 never snapshotted z_res; scan the root row with scale 1.
         if tau == 0:
             z_res = _vocab_scan_residual_mass(
                 tp_base_ptr,
@@ -237,9 +211,9 @@ def speculative_sampling_block_kernel(
             )
         residual_norm = z_res
 
-    # Degenerate residual (norm == 0, i.e. scaled p == q everywhere) leaves
-    # the cumsum at 0 <= target_u, so final_token falls back to
-    # VOCAB_SIZE - 1, matching the classic kernel's behavior.
+    # Degenerate residual (norm == 0, scaled p == q everywhere) leaves the
+    # cumsum at 0 <= target_u: final_token falls back to VOCAB_SIZE - 1, same
+    # as the classic kernel.
     target_u = coin_final * residual_norm
     cum_sum = 0.0
     final_token = VOCAB_SIZE - 1
@@ -457,8 +431,6 @@ def chain_block_speculative_sampling_triton(
 
     Drop-in replacement for chain_speculative_sampling_triton (same tensor
     contract); verifies the draft block jointly instead of token-by-token.
-    Never accepts fewer tokens than token verification in expectation and
-    preserves the target model's output distribution.
     """
     batch_size, num_slots = candidates.shape
     vocab_size = target_probs.shape[-1]

--- a/python/sglang/kernels/ops/speculative/reject_sampling.py
+++ b/python/sglang/kernels/ops/speculative/reject_sampling.py
@@ -3,6 +3,283 @@ import triton.language as tl
 
 
 @triton.jit
+def _vocab_scan_residual_mass(
+    TargetProbsRow,
+    DraftProbsRow,
+    scale,
+    stride_tp_v,
+    stride_dp_v,
+    VOCAB_SIZE: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+):
+    """Sum over the vocab of max(scale * M_b(x) - M_s(x), 0) on one row.
+
+    NaN draft entries are treated as 0, mirroring the classic kernel's NaN-q
+    guard so the residual falls back to (scaled) target mass.
+    """
+    acc = 0.0
+    for v_start in range(0, VOCAB_SIZE, BLOCK_V):
+        v_offsets = v_start + tl.arange(0, BLOCK_V)
+        mask = v_offsets < VOCAB_SIZE
+        t_val = tl.load(TargetProbsRow + v_offsets * stride_tp_v, mask=mask, other=0.0)
+        d_val = tl.load(DraftProbsRow + v_offsets * stride_dp_v, mask=mask, other=0.0)
+        d_val = tl.where(d_val == d_val, d_val, 0.0)
+        diff = scale * t_val - d_val
+        acc += tl.sum(tl.where(diff > 0.0, diff, 0.0))
+    return acc
+
+
+@triton.jit
+def _vocab_scan_target_mass(
+    TargetProbsRow,
+    stride_tp_v,
+    VOCAB_SIZE: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+):
+    """Sum over the vocab of a target-prob row (draft-free variant)."""
+    acc = 0.0
+    for v_start in range(0, VOCAB_SIZE, BLOCK_V):
+        v_offsets = v_start + tl.arange(0, BLOCK_V)
+        mask = v_offsets < VOCAB_SIZE
+        t_val = tl.load(TargetProbsRow + v_offsets * stride_tp_v, mask=mask, other=0.0)
+        acc += tl.sum(t_val)
+    return acc
+
+
+@triton.jit
+def speculative_sampling_block_kernel(
+    # Pointers
+    Predicts,
+    AcceptIndex,
+    AcceptTokenNum,
+    Candidates,
+    RetriveIndex,
+    UniformSamples,
+    UniformSamplesFinal,
+    TargetProbs,
+    DraftProbs,
+    # Strides
+    stride_cand_b,
+    stride_cand_s,
+    stride_idx_b,
+    stride_idx_s,
+    stride_uni_b,
+    stride_uni_s,
+    stride_tp_b,
+    stride_tp_s,
+    stride_tp_v,
+    stride_dp_b,
+    stride_dp_s,
+    stride_dp_v,
+    # Constants
+    NUM_SLOTS: tl.constexpr,
+    VOCAB_SIZE: tl.constexpr,
+    BLOCK_V: tl.constexpr,
+):
+    """Block verification (arXiv:2403.10444, Algorithm 2).
+
+    Per-request program for a linear (topk=1) draft chain of gamma =
+    NUM_SLOTS - 1 drafted tokens (candidates[1..gamma]; slot 0 is the root /
+    last committed token). TargetProbs rows 0..gamma are M_b(. | c, X^i),
+    DraftProbs rows 0..gamma-1 are M_s(. | c, X^i) (row gamma unused, same as
+    the classic kernel).
+
+    Differences vs the classic token verification kernel:
+      * acceptance threshold h_i = Z_{i+1} / (Z_{i+1} + 1 - p_i) with
+        p_i = min(p_{i-1} * M_b(X_i) / M_s(X_i), 1) and
+        Z_{i+1} = sum_x max(p_i * M_b(x | row i) - M_s(x | row i), 0)
+        (h_gamma = p_gamma needs no Z), instead of min(p/q, 1);
+      * verification does NOT stop at the first failed token: the accepted
+        prefix length is tau = argmax_i{coin_i <= h_i}, a property that
+        strictly improves the expected number of accepted tokens;
+      * the residual distribution at tau is scaled by p_tau:
+        max(p_tau * M_b - M_s, 0) / Z_{tau+1}.
+
+    One-hot shortcut: when the draft row i places all mass on the drafted
+    token X_{i+1} (d(x_{i+1}) == 1, argmax/greedy drafts), the residual mass
+    is available in closed form, Z_{i+1} = p_i * (1 - M_b(X_{i+1} | row i)),
+    skipping that row's vocab scan.
+    """
+    pid = tl.program_id(0)
+
+    cand_ptr_base = Candidates + pid * stride_cand_b
+    idx_ptr_base = RetriveIndex + pid * stride_idx_b
+    uni_ptr_base = UniformSamples + pid * stride_uni_b
+
+    root_global_idx = tl.load(idx_ptr_base + 0 * stride_idx_s)
+    tl.store(AcceptIndex + pid * stride_idx_b + 0 * stride_idx_s, root_global_idx)
+
+    tau = 0
+    p = 1.0
+    # Residual snapshot at the row where tau was last updated:
+    # z_res = Z_{tau+1}, p_res = p_tau (scale of that row's residual).
+    z_res = 0.0
+    p_res = 1.0
+
+    for step in range(1, NUM_SLOTS):
+        draft_token = tl.load(cand_ptr_base + step * stride_cand_s)
+        t_prob = tl.load(
+            TargetProbs
+            + (pid * stride_tp_b)
+            + ((step - 1) * stride_tp_s)
+            + (draft_token * stride_tp_v)
+        )
+        d_prob = tl.load(
+            DraftProbs
+            + (pid * stride_dp_b)
+            + ((step - 1) * stride_dp_s)
+            + (draft_token * stride_dp_v)
+        )
+        # Degenerate draft density (q=0 or NaN): keep the classic semantics —
+        # q=0 & p>0 behaves like an always-accept, q=0 & p=0 a hard reject.
+        d_ok = (d_prob == d_prob) & (d_prob > 0.0)
+        ratio = tl.where(
+            d_ok, t_prob / tl.where(d_ok, d_prob, 1.0), tl.where(t_prob > 0.0, 1.0, 0.0)
+        )
+        p = tl.minimum(p * ratio, 1.0)
+
+        # Z_{step+1} is consumed by h_step (step < gamma) and snapshots into
+        # the residual normalizer when tau lands on this step.
+        z = 0.0
+        if (step < NUM_SLOTS - 1) & (p > 0.0):
+            next_token = tl.load(cand_ptr_base + (step + 1) * stride_cand_s)
+            next_draft_prob = tl.load(
+                DraftProbs
+                + (pid * stride_dp_b)
+                + (step * stride_dp_s)
+                + (next_token * stride_dp_v)
+            )
+            if next_draft_prob >= 1.0:
+                # One-hot draft row: Z_{step+1} = p * (1 - M_b(X_{step+1})).
+                next_target_prob = tl.load(
+                    TargetProbs
+                    + (pid * stride_tp_b)
+                    + (step * stride_tp_s)
+                    + (next_token * stride_tp_v)
+                )
+                # Clamp: Z is a sum of non-negative terms and cannot be
+                # negative, but 1 - M_b(x) can dip below 0 when top-k/top-p
+                # renormalization rounds a target prob slightly above 1.0; a
+                # negative z would poison denom, h, and residual_norm.
+                z = tl.maximum(p * (1.0 - next_target_prob), 0.0)
+            else:
+                z = _vocab_scan_residual_mass(
+                    TargetProbs + (pid * stride_tp_b) + (step * stride_tp_s),
+                    DraftProbs + (pid * stride_dp_b) + (step * stride_dp_s),
+                    p,
+                    stride_tp_v,
+                    stride_dp_v,
+                    VOCAB_SIZE,
+                    BLOCK_V,
+                )
+
+        # h_gamma = p_gamma (the paper's boundary case needs no Z beyond the
+        # chain). Denominator degenerates only when z == 0 and p == 1, i.e.
+        # scaled target and draft coincide: accept unconditionally.
+        denom = z + 1.0 - p
+        h_safe = tl.where(denom > 0.0, z / tl.where(denom > 0.0, denom, 1.0), 1.0)
+        h = tl.where(step == NUM_SLOTS - 1, p, h_safe)
+
+        coin = tl.load(uni_ptr_base + (step - 1) * stride_uni_s)
+        if coin <= h:
+            tau = step
+            z_res = z
+            p_res = p
+
+    tl.store(AcceptTokenNum + pid, tau)
+
+    # Materialize accepted draft tokens along the chain (same buffer layout
+    # the classic kernel produces: predicts live at the previous accepted
+    # slot's global index).
+    last_accepted_global_idx = root_global_idx
+    for step in range(1, NUM_SLOTS):
+        if step <= tau:
+            draft_token = tl.load(cand_ptr_base + step * stride_cand_s)
+            tl.store(Predicts + last_accepted_global_idx, draft_token)
+            curr_global_idx = tl.load(idx_ptr_base + step * stride_idx_s)
+            tl.store(
+                AcceptIndex + pid * stride_idx_b + step * stride_idx_s,
+                curr_global_idx,
+            )
+            last_accepted_global_idx = curr_global_idx
+
+    # Final (bonus/correction) token.
+    all_drafts_accepted = tau == NUM_SLOTS - 1
+    coin_final = tl.load(UniformSamplesFinal + pid)
+
+    cur_prob_row = tau
+    tp_base_ptr = TargetProbs + (pid * stride_tp_b) + (cur_prob_row * stride_tp_s)
+    # DraftProbs has only gamma rows (TargetProbs has gamma + 1). The
+    # all-accepted branch never dereferences this pointer (tau == gamma).
+    dp_base_ptr_safe = DraftProbs + (pid * stride_dp_b) + (cur_prob_row * stride_dp_s)
+
+    if all_drafts_accepted:
+        # Pure target row sample: draft row gamma does not exist, so this
+        # branch must stay draft-pointer-free.
+        residual_norm = _vocab_scan_target_mass(
+            tp_base_ptr,
+            stride_tp_v,
+            VOCAB_SIZE,
+            BLOCK_V,
+        )
+    else:
+        # tau == 0 never updated the snapshot inside the loop: its residual
+        # row is the root row with scale p_0 = 1. Compute it lazily now.
+        if tau == 0:
+            z_res = _vocab_scan_residual_mass(
+                tp_base_ptr,
+                dp_base_ptr_safe,
+                1.0,
+                stride_tp_v,
+                stride_dp_v,
+                VOCAB_SIZE,
+                BLOCK_V,
+            )
+        residual_norm = z_res
+
+    # Degenerate residual (norm == 0, i.e. scaled p == q everywhere) leaves
+    # the cumsum at 0 <= target_u, so final_token falls back to
+    # VOCAB_SIZE - 1, matching the classic kernel's behavior.
+    target_u = coin_final * residual_norm
+    cum_sum = 0.0
+    final_token = VOCAB_SIZE - 1
+    found = 0
+
+    for v_start in range(0, VOCAB_SIZE, BLOCK_V):
+        if found == 0:
+            v_offsets = v_start + tl.arange(0, BLOCK_V)
+            mask = v_offsets < VOCAB_SIZE
+
+            t_val = tl.load(tp_base_ptr + v_offsets * stride_tp_v, mask=mask, other=0.0)
+
+            if all_drafts_accepted:
+                val = t_val
+            else:
+                d_val = tl.load(
+                    dp_base_ptr_safe + v_offsets * stride_dp_v, mask=mask, other=0.0
+                )
+                # Same NaN-q guard as the classic kernel.
+                d_val = tl.where(d_val == d_val, d_val, 0.0)
+                diff = p_res * t_val - d_val
+                val = tl.where(diff > 0.0, diff, 0.0)
+
+            block_cumsum = tl.cumsum(val, axis=0)
+            total_cumsum = cum_sum + block_cumsum
+
+            candidates_mask = total_cumsum > target_u
+            has_match = tl.max(candidates_mask, axis=0)
+
+            if has_match:
+                match_idx = tl.argmax(candidates_mask.to(tl.int32), axis=0)
+                final_token = v_start + match_idx
+                found = 1
+
+            cum_sum += tl.sum(val)
+
+    tl.store(Predicts + last_accepted_global_idx, final_token)
+
+
+@triton.jit
 def speculative_sampling_classic_kernel(
     # Pointers
     Predicts,
@@ -158,6 +435,61 @@ def speculative_sampling_classic_kernel(
             cum_sum += tl.sum(val)
 
     tl.store(Predicts + last_accepted_global_idx, final_token)
+
+
+def chain_block_speculative_sampling_triton(
+    predicts,
+    accept_index,
+    accept_token_num,
+    candidates,
+    retrive_index,
+    retrive_next_token,
+    retrive_next_sibling,  # not used in chain verification
+    uniform_samples,
+    uniform_samples_for_final_sampling,
+    target_probs,
+    draft_probs,
+    threshold_single,  # not used: block verification ignores accept thresholds
+    threshold_acc,  # not used: block verification ignores accept thresholds
+    deterministic,  # not used
+):
+    """Chain verification with block verification (arXiv:2403.10444).
+
+    Drop-in replacement for chain_speculative_sampling_triton (same tensor
+    contract); verifies the draft block jointly instead of token-by-token.
+    Never accepts fewer tokens than token verification in expectation and
+    preserves the target model's output distribution.
+    """
+    batch_size, num_slots = candidates.shape
+    vocab_size = target_probs.shape[-1]
+
+    grid = (batch_size,)
+    speculative_sampling_block_kernel[grid](
+        predicts,
+        accept_index,
+        accept_token_num,
+        candidates,
+        retrive_index,
+        uniform_samples,
+        uniform_samples_for_final_sampling,
+        target_probs,
+        draft_probs,
+        candidates.stride(0),
+        candidates.stride(1),
+        retrive_index.stride(0),
+        retrive_index.stride(1),
+        uniform_samples.stride(0),
+        uniform_samples.stride(1),
+        target_probs.stride(0),
+        target_probs.stride(1),
+        target_probs.stride(2),
+        draft_probs.stride(0),
+        draft_probs.stride(1),
+        draft_probs.stride(2),
+        NUM_SLOTS=num_slots,
+        VOCAB_SIZE=vocab_size,
+        BLOCK_V=4096,
+    )
 
 
 def chain_speculative_sampling_triton(

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -123,17 +123,11 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
         ),
     )
 
-    # Algorithm-independent validation must live here at top level: the
-    # per-family handlers (_handle_eagle_family / _handle_dflash /
-    # _handle_dspark / _handle_ngram / _handle_frozen_kv_mtp) do not all run
-    # for every algorithm, so checks parked inside one of them are silently
-    # skipped for the others.
+    # Top level, not a per-family handler: those do not all run for every
+    # algorithm, so checks parked inside one are skipped for the others.
     if server_args.speculative_use_block_verification:
-        # Block verification (arXiv:2403.10444) replaces the token-level
-        # verification inside rejection sampling. EAGLE/EAGLE3 reach it
-        # through the opt-in rejection-sampling path; DSPARK reaches it
-        # through its internal sampling-accept kernel (greedy requests stay
-        # on AcceptGreedy and are unaffected).
+        # EAGLE/EAGLE3 reach block verification through rejection sampling;
+        # DSPARK through its internal sampling-accept kernel.
         if server_args.speculative_algorithm in ("EAGLE", "EAGLE3"):
             if not server_args.speculative_use_rejection_sampling:
                 raise ValueError(

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -123,6 +123,36 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
         ),
     )
 
+    # Algorithm-independent validation must live here at top level: the
+    # per-family handlers (_handle_eagle_family / _handle_dflash /
+    # _handle_dspark / _handle_ngram / _handle_frozen_kv_mtp) do not all run
+    # for every algorithm, so checks parked inside one of them are silently
+    # skipped for the others.
+    if server_args.speculative_use_block_verification:
+        # Block verification (arXiv:2403.10444) replaces the token-level
+        # verification inside rejection sampling. EAGLE/EAGLE3 reach it
+        # through the opt-in rejection-sampling path; DSPARK reaches it
+        # through its internal sampling-accept kernel (greedy requests stay
+        # on AcceptGreedy and are unaffected).
+        if server_args.speculative_algorithm in ("EAGLE", "EAGLE3"):
+            if not server_args.speculative_use_rejection_sampling:
+                raise ValueError(
+                    "--speculative-use-block-verification with "
+                    f"speculative_algorithm={server_args.speculative_algorithm} "
+                    "requires --speculative-use-rejection-sampling."
+                )
+        elif server_args.speculative_algorithm != "DSPARK":
+            raise NotImplementedError(
+                "--speculative-use-block-verification is only supported for "
+                "EAGLE / EAGLE3 (with --speculative-use-rejection-sampling) "
+                "and DSPARK, not "
+                f"speculative_algorithm={server_args.speculative_algorithm}."
+            )
+        logger.info(
+            "Block verification is enabled for speculative decoding "
+            "(speculative_use_block_verification=True)."
+        )
+
     # Validate --speculative-draft-window-size once, regardless of algorithm.
     # Consumed by DFLASH (compact draft KV cache) and Llama EAGLE-3 (drafter attention SWA).
     if server_args.speculative_draft_window_size is not None:

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2246,10 +2246,9 @@ class ServerArgs:
     ] = False
     speculative_use_block_verification: A[
         bool,
-        "Use block verification (arXiv:2403.10444) instead of token-level "
-        "verification in speculative decoding rejection sampling. For "
-        "EAGLE/EAGLE3 it requires --speculative-use-rejection-sampling; for "
-        "DSPARK it swaps the internal sampling-accept kernel.",
+        "Use block verification (arXiv:2403.10444) for speculative decoding "
+        "rejection sampling (requires --speculative-use-rejection-sampling "
+        "for EAGLE/EAGLE3).",
         NS("spec"),
     ] = False
     speculative_token_map: A[

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2247,11 +2247,9 @@ class ServerArgs:
     speculative_use_block_verification: A[
         bool,
         "Use block verification (arXiv:2403.10444) instead of token-level "
-        "verification for speculative decoding rejection sampling. Accepted "
-        "tokens per iteration are never fewer in expectation, with the same "
-        "lossless guarantee. For EAGLE/EAGLE3 it requires "
-        "--speculative-use-rejection-sampling; for DSPARK it swaps the "
-        "internal sampling-accept kernel.",
+        "verification in speculative decoding rejection sampling. For "
+        "EAGLE/EAGLE3 it requires --speculative-use-rejection-sampling; for "
+        "DSPARK it swaps the internal sampling-accept kernel.",
         NS("spec"),
     ] = False
     speculative_token_map: A[

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2244,6 +2244,16 @@ class ServerArgs:
         "Use rejection sampling for speculative decoding (requires topk=1).",
         NS("spec"),
     ] = False
+    speculative_use_block_verification: A[
+        bool,
+        "Use block verification (arXiv:2403.10444) instead of token-level "
+        "verification for speculative decoding rejection sampling. Accepted "
+        "tokens per iteration are never fewer in expectation, with the same "
+        "lossless guarantee. For EAGLE/EAGLE3 it requires "
+        "--speculative-use-rejection-sampling; for DSPARK it swaps the "
+        "internal sampling-accept kernel.",
+        NS("spec"),
+    ] = False
     speculative_token_map: A[
         Optional[str], "The path of the draft model's small vocab table.", NS("spec")
     ] = None

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -770,14 +770,10 @@ def eagle_sample(
 
         use_rejection_sampling = get_spec().speculative_use_rejection_sampling
         use_block_verification = get_spec().speculative_use_block_verification
-        # The hook guarantees block verification implies rejection sampling,
-        # but join explicitly so direct/programmatic enablement (tests,
-        # embedding the kernel) also gets real draft_probs instead of zeros.
+        # Hook guarantees block implies rejection sampling; join defensively.
         use_sampling_accept = use_rejection_sampling or use_block_verification
 
         if use_block_verification:
-            # Block verification (arXiv:2403.10444): joint per-block verify,
-            # same tensor contract as the classic chain kernel.
             sampling_fn = chain_block_speculative_sampling_triton
         elif use_rejection_sampling:
             sampling_fn = chain_speculative_sampling_triton

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -764,16 +764,25 @@ def eagle_sample(
         )
 
         from sglang.kernels.ops.speculative.reject_sampling import (
+            chain_block_speculative_sampling_triton,
             chain_speculative_sampling_triton,
         )
 
         use_rejection_sampling = get_spec().speculative_use_rejection_sampling
+        use_block_verification = get_spec().speculative_use_block_verification
+        # The hook guarantees block verification implies rejection sampling,
+        # but join explicitly so direct/programmatic enablement (tests,
+        # embedding the kernel) also gets real draft_probs instead of zeros.
+        use_sampling_accept = use_rejection_sampling or use_block_verification
 
-        sampling_fn = (
-            chain_speculative_sampling_triton
-            if use_rejection_sampling
-            else tree_speculative_sampling_target_only
-        )
+        if use_block_verification:
+            # Block verification (arXiv:2403.10444): joint per-block verify,
+            # same tensor contract as the classic chain kernel.
+            sampling_fn = chain_block_speculative_sampling_triton
+        elif use_rejection_sampling:
+            sampling_fn = chain_speculative_sampling_triton
+        else:
+            sampling_fn = tree_speculative_sampling_target_only
 
         # These full-vocabulary matrices are consumed by the sampling kernel
         # within this step. Returned tensors were allocated before the scope,
@@ -810,12 +819,12 @@ def eagle_sample(
             target_probs = target_probs.reshape(bs, verify_input.draft_token_num, -1)
             draft_probs = (
                 verify_input.draft_probs
-                if use_rejection_sampling
+                if use_sampling_accept
                 else torch.zeros_like(target_probs)
             )
             # Defense-in-depth behind the spec_hook startup allowlist: validate
             # the actual kernel inputs before the Triton kernel.
-            if use_rejection_sampling and (
+            if use_sampling_accept and (
                 draft_probs is None or draft_probs.shape[-1] != target_probs.shape[-1]
             ):
                 raise ValueError(

--- a/test/registered/kernels/ops/speculative/test_reject_sampling_block.py
+++ b/test/registered/kernels/ops/speculative/test_reject_sampling_block.py
@@ -2,23 +2,12 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
 
-"""Block verification (arXiv:2403.10444) chain rejection-sampling kernel tests.
+"""Tests for speculative_sampling_block_kernel (arXiv:2403.10444).
 
-Covers ``speculative_sampling_block_kernel`` /
-``chain_block_speculative_sampling_triton`` in
-``python/sglang/kernels/ops/speculative/reject_sampling.py``:
-
-  * exact agreement with a vectorized pure-torch reference implementation of
-    the paper's Algorithm 2 (prefix ratios p_i, thresholds
-    h_i = Z_{i+1}/(Z_{i+1} + 1 - p_i) with h_gamma = p_gamma, tau = argmax,
-    p_tau-scaled residual re-sampling);
-  * the one-hot (greedy draft) closed-form shortcut
-    Z_{i+1} = p_i * (1 - M_b(X_{i+1})) == full vocab scan;
-  * losslessness on the paper's motivating toy model (first emitted token is
-    exactly M_b), plus the paper's analytic block efficiencies
-    (gamma=2 toy: token 10/9 vs block 11/9);
-  * matched-coins aggregate acceptance >= classic token verification;
-  * degenerate draft rows (NaN / zero mass) produce no NaN and valid tokens.
+Covers the kernel against a vectorized torch reference of the paper's
+Algorithm 2, plus the one-hot closed-form shortcut, losslessness on the
+paper's toy model, matched-coins dominance vs the classic kernel, and
+degenerate draft rows.
 """
 
 import unittest
@@ -42,10 +31,9 @@ def block_verify_reference(
 ):
     """Vectorized torch reference of Algorithm 2 (arXiv:2403.10444).
 
-    Returns (accept_token_num, predict_map) where predict_map[b, s] mirrors
-    the kernel's Predicts buffer in slot coordinates: slot k < tau holds the
-    (k+1)-th drafted token, slot tau holds the final (residual / target
-    bonus) token, all other slots keep the sentinel.
+    Returns (accept_token_num, predict_map) in the kernel's slot layout:
+    slot k < tau holds draft k+1, slot tau holds the final token, untouched
+    slots keep the sentinel.
     """
     dev = candidates.device
     bs, S = candidates.shape

--- a/test/registered/kernels/ops/speculative/test_reject_sampling_block.py
+++ b/test/registered/kernels/ops/speculative/test_reject_sampling_block.py
@@ -2,12 +2,10 @@ from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
 
-"""Tests for speculative_sampling_block_kernel (arXiv:2403.10444).
+"""Tests for speculative_sampling_block_kernel (block verification).
 
-Covers the kernel against a vectorized torch reference of the paper's
-Algorithm 2, plus the one-hot closed-form shortcut, losslessness on the
-paper's toy model, matched-coins dominance vs the classic kernel, and
-degenerate draft rows.
+Paper: https://arxiv.org/abs/2403.10444, Algorithm 2:
+h_i = Z_{i+1} / (Z_{i+1} + 1 - p_i), tau = argmax_i {coin_i <= h_i}.
 """
 
 import unittest

--- a/test/registered/kernels/ops/speculative/test_reject_sampling_block.py
+++ b/test/registered/kernels/ops/speculative/test_reject_sampling_block.py
@@ -1,0 +1,367 @@
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="1-gpu-small")
+
+"""Block verification (arXiv:2403.10444) chain rejection-sampling kernel tests.
+
+Covers ``speculative_sampling_block_kernel`` /
+``chain_block_speculative_sampling_triton`` in
+``python/sglang/kernels/ops/speculative/reject_sampling.py``:
+
+  * exact agreement with a vectorized pure-torch reference implementation of
+    the paper's Algorithm 2 (prefix ratios p_i, thresholds
+    h_i = Z_{i+1}/(Z_{i+1} + 1 - p_i) with h_gamma = p_gamma, tau = argmax,
+    p_tau-scaled residual re-sampling);
+  * the one-hot (greedy draft) closed-form shortcut
+    Z_{i+1} = p_i * (1 - M_b(X_{i+1})) == full vocab scan;
+  * losslessness on the paper's motivating toy model (first emitted token is
+    exactly M_b), plus the paper's analytic block efficiencies
+    (gamma=2 toy: token 10/9 vs block 11/9);
+  * matched-coins aggregate acceptance >= classic token verification;
+  * degenerate draft rows (NaN / zero mass) produce no NaN and valid tokens.
+"""
+
+import unittest
+
+import torch
+
+from sglang.kernels.ops.speculative.reject_sampling import (
+    chain_block_speculative_sampling_triton,
+    chain_speculative_sampling_triton,
+)
+from sglang.test.test_utils import CustomTestCase
+
+DEV = "cuda"
+# Impossible token id (test vocabs are all <= 4096); kernel predict buffer and
+# reference map are pre-filled with it so a missed write is detectable.
+_SENTINEL = 999999
+
+
+def block_verify_reference(
+    candidates, target_probs, draft_probs, coins, coin_final, vocab_size
+):
+    """Vectorized torch reference of Algorithm 2 (arXiv:2403.10444).
+
+    Returns (accept_token_num, predict_map) where predict_map[b, s] mirrors
+    the kernel's Predicts buffer in slot coordinates: slot k < tau holds the
+    (k+1)-th drafted token, slot tau holds the final (residual / target
+    bonus) token, all other slots keep the sentinel.
+    """
+    dev = candidates.device
+    bs, S = candidates.shape
+    gamma = S - 1
+
+    p = torch.ones(bs, device=dev)
+    tau = torch.zeros(bs, dtype=torch.long, device=dev)
+    z_res = torch.zeros(bs, device=dev)
+    p_res = torch.ones(bs, device=dev)
+
+    for i in range(1, gamma + 1):
+        cand_i = candidates[:, i]
+        t_i = target_probs[:, i - 1].gather(1, cand_i[:, None]).squeeze(1)
+        d_i = draft_probs[:, i - 1].gather(1, cand_i[:, None]).squeeze(1)
+        d_ok = (d_i == d_i) & (d_i > 0)
+        ratio = torch.where(
+            d_ok,
+            t_i / torch.where(d_ok, d_i, torch.ones_like(d_i)),
+            torch.where(t_i > 0, torch.ones_like(t_i), torch.zeros_like(t_i)),
+        )
+        p = torch.minimum(p * ratio, torch.ones_like(p))
+
+        if i < gamma:
+            z = torch.clamp(
+                p[:, None] * target_probs[:, i]
+                - torch.nan_to_num(draft_probs[:, i], nan=0.0),
+                min=0.0,
+            ).sum(-1)
+        else:
+            z = torch.zeros_like(p)
+
+        denom = z + 1.0 - p
+        h_safe = torch.where(
+            denom > 0,
+            z / torch.where(denom > 0, denom, torch.ones_like(denom)),
+            torch.ones_like(denom),
+        )
+        h = p if i == gamma else h_safe
+
+        upd = coins[:, i - 1] <= h
+        tau = torch.where(upd, torch.full_like(tau, i), tau)
+        z_res = torch.where(upd, z, z_res)
+        p_res = torch.where(upd, p, p_res)
+
+    # tau == 0 rows: residual on the root row with scale p_0 = 1.
+    z0 = torch.clamp(
+        target_probs[:, 0] - torch.nan_to_num(draft_probs[:, 0], nan=0.0), min=0.0
+    ).sum(-1)
+    z_res = torch.where(tau > 0, z_res, z0)
+
+    all_acc = tau == gamma
+    vocab = target_probs.shape[-1]
+    row_t = target_probs.gather(1, tau[:, None, None].expand(bs, 1, vocab)).squeeze(1)
+    row_d = draft_probs.gather(
+        1, torch.clamp(tau, max=gamma - 1)[:, None, None].expand(bs, 1, vocab)
+    ).squeeze(1)
+    vals = torch.where(
+        all_acc[:, None],
+        row_t,
+        torch.clamp(p_res[:, None] * row_t - torch.nan_to_num(row_d, nan=0.0), min=0.0),
+    )
+    norm = torch.where(all_acc, row_t.sum(-1), z_res)
+
+    cdf = vals.cumsum(-1)
+    thr = (coin_final * norm)[:, None]
+    idx = (cdf > thr).float().argmax(-1)
+    final = torch.where(
+        cdf[:, -1] > thr[:, 0], idx, torch.full_like(idx, vocab_size - 1)
+    )
+
+    predict_map = torch.full((bs, S), _SENTINEL, dtype=torch.long, device=dev)
+    for i in range(1, gamma + 1):
+        predict_map[:, i - 1] = torch.where(
+            tau >= i, candidates[:, i], predict_map[:, i - 1]
+        )
+    predict_map.scatter_(1, tau[:, None], final[:, None])
+    return tau.to(torch.int32), predict_map
+
+
+def run_block_kernel(candidates, target_probs, draft_probs, coins, coin_final):
+    bs, S = candidates.shape
+    dev = candidates.device
+    predicts = torch.full((bs * S,), _SENTINEL, dtype=torch.int32, device=dev)
+    accept_index = torch.full((bs, S), -1, dtype=torch.int32, device=dev)
+    accept_token_num = torch.empty(bs, dtype=torch.int32, device=dev)
+    retrive_index = torch.arange(bs * S, device=dev, dtype=torch.int32).view(bs, S)
+    chain_block_speculative_sampling_triton(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=None,
+        retrive_next_sibling=None,
+        uniform_samples=coins,
+        uniform_samples_for_final_sampling=coin_final,
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+        threshold_single=1.0,
+        threshold_acc=1.0,
+        deterministic=True,
+    )
+    return accept_token_num, predict_map_from_flat(predicts, bs, S), accept_index
+
+
+def run_classic_kernel(candidates, target_probs, draft_probs, coins, coin_final):
+    bs, S = candidates.shape
+    dev = candidates.device
+    predicts = torch.full((bs * S,), _SENTINEL, dtype=torch.int32, device=dev)
+    accept_index = torch.full((bs, S), -1, dtype=torch.int32, device=dev)
+    accept_token_num = torch.empty(bs, dtype=torch.int32, device=dev)
+    retrive_index = torch.arange(bs * S, device=dev, dtype=torch.int32).view(bs, S)
+    chain_speculative_sampling_triton(
+        predicts=predicts,
+        accept_index=accept_index,
+        accept_token_num=accept_token_num,
+        candidates=candidates,
+        retrive_index=retrive_index,
+        retrive_next_token=None,
+        retrive_next_sibling=None,
+        uniform_samples=coins,
+        uniform_samples_for_final_sampling=coin_final,
+        target_probs=target_probs,
+        draft_probs=draft_probs,
+        threshold_single=1.0,
+        threshold_acc=1.0,
+        deterministic=True,
+    )
+    return accept_token_num, predict_map_from_flat(predicts, bs, S)
+
+
+def predict_map_from_flat(predicts, bs, S):
+    return predicts.view(bs, S).to(torch.long)
+
+
+def make_chain_inputs(bs, gamma, vocab, seed, one_hot_frac=0.0):
+    """Random chain inputs: softmax target/draft rows, sampled draft tokens."""
+    g = torch.Generator(device=DEV).manual_seed(seed)
+    S = gamma + 1
+
+    def rows(scale):
+        logits = torch.randn(bs, S, vocab, generator=g, device=DEV) * scale
+        return torch.softmax(logits, dim=-1)
+
+    target_probs = rows(2.5)
+    draft_probs = rows(2.5)
+    if one_hot_frac > 0:
+        mask_rows = torch.rand(bs, S, generator=g, device=DEV) < one_hot_frac
+        amax = draft_probs.argmax(-1)
+        onehot = torch.zeros_like(draft_probs)
+        onehot.scatter_(-1, amax[..., None], 1.0)
+        draft_probs = torch.where(mask_rows[..., None], onehot, draft_probs)
+
+    draft_flat = torch.nan_to_num(draft_probs, nan=0.0).view(-1, vocab)
+    # guard against zero-mass rows after nan cleaning
+    bad = draft_flat.sum(-1) == 0
+    draft_flat[bad] = 1.0 / vocab
+    sample = torch.multinomial(draft_flat, 1, generator=g).view(bs, S)
+    candidates = torch.empty(bs, S, dtype=torch.int64, device=DEV)
+    candidates[:, 0] = 0  # root slot token unused by the kernel
+    candidates[:, 1:] = sample[:, :-1]
+    coins = torch.rand(bs, S, generator=g, device=DEV)
+    coin_final = torch.rand(bs, generator=g, device=DEV)
+    return candidates, target_probs, draft_probs, coins, coin_final
+
+
+@unittest.skipIf(not torch.cuda.is_available(), "requires CUDA (Triton kernels)")
+class TestBlockVerificationKernel(CustomTestCase):
+    def test_block_matches_reference_random(self):
+        for gamma in (1, 2, 4, 8):
+            for vocab in (127, 1013, 2500, 4096):
+                c, t, d, coins, cf = make_chain_inputs(
+                    bs=7, gamma=gamma, vocab=vocab, seed=1234 + gamma * 31 + vocab
+                )
+                tau_k, pred_k, acc_idx_k = run_block_kernel(c, t, d, coins, cf)
+                tau_r, pred_r = block_verify_reference(
+                    c, t, d, coins, cf, vocab_size=vocab
+                )
+                torch.testing.assert_close(tau_k.cpu(), tau_r.cpu(), rtol=0, atol=0)
+                torch.testing.assert_close(pred_k.cpu(), pred_r.cpu(), rtol=0, atol=0)
+                # accepted slots [0..tau] materialized, rest stays -1
+                expected_idx = torch.where(
+                    torch.arange(acc_idx_k.shape[1])[None, :] <= tau_r[:, None].cpu(),
+                    torch.arange(acc_idx_k.numel(), dtype=torch.int32).view(
+                        acc_idx_k.shape
+                    ),
+                    torch.full_like(acc_idx_k, -1).cpu(),
+                )
+                torch.testing.assert_close(
+                    acc_idx_k.cpu(), expected_idx, rtol=0, atol=0
+                )
+
+    def test_one_hot_fast_path(self):
+        # Fully one-hot draft rows => kernel takes the closed-form Z shortcut;
+        # the reference computes the full vocab scan. Must agree exactly.
+        for gamma in (2, 4, 8):
+            for vocab in (503, 2500):
+                with self.subTest(gamma=gamma, vocab=vocab):
+                    c, t, d, coins, cf = make_chain_inputs(
+                        bs=9,
+                        gamma=gamma,
+                        vocab=vocab,
+                        seed=777 + gamma,
+                        one_hot_frac=1.0,
+                    )
+                    tau_k, pred_k, _ = run_block_kernel(c, t, d, coins, cf)
+                    tau_r, pred_r = block_verify_reference(
+                        c, t, d, coins, cf, vocab_size=vocab
+                    )
+                    torch.testing.assert_close(tau_k.cpu(), tau_r.cpu(), rtol=0, atol=0)
+                    torch.testing.assert_close(
+                        pred_k.cpu(), pred_r.cpu(), rtol=0, atol=0
+                    )
+
+    def test_toy_model_losslessness_and_block_efficiency(self):
+        # The paper's motivating example (Sec. 2): context-free models
+        # M_b = [1/3, 2/3], M_s = [2/3, 1/3], gamma = 2.
+        # Analytic: token verification E[tau] = 10/9, block E[tau] = 11/9,
+        # and the first emitted token must follow M_b exactly (losslessness).
+        bs, gamma, vocab = 20000, 2, 3
+        S = gamma + 1
+        t_row = torch.tensor([1 / 3, 2 / 3, 0.0], device=DEV)
+        d_row = torch.tensor([2 / 3, 1 / 3, 0.0], device=DEV)
+        target_probs = t_row.expand(bs, S, vocab).contiguous()
+        draft_probs = d_row.expand(bs, S, vocab).contiguous()
+
+        g = torch.Generator(device=DEV).manual_seed(2024)
+        candidates = torch.zeros(bs, S, dtype=torch.int64, device=DEV)
+        # toy model is context-free: both draft tokens iid ~ d_row
+        candidates[:, 1] = torch.multinomial(d_row.expand(bs, vocab), 1, generator=g)[
+            :, 0
+        ]
+        candidates[:, 2] = torch.multinomial(d_row.expand(bs, vocab), 1, generator=g)[
+            :, 0
+        ]
+        coins = torch.rand(bs, S, generator=g, device=DEV)
+        cf = torch.rand(bs, generator=g, device=DEV)
+
+        tau_classic, _ = run_classic_kernel(
+            candidates, target_probs, draft_probs, coins, cf
+        )
+        tau_block, pred_block, _ = run_block_kernel(
+            candidates, target_probs, draft_probs, coins, cf
+        )
+
+        mean_classic = tau_classic.float().mean().item()
+        mean_block = tau_block.float().mean().item()
+        # analytic block efficiencies for the toy pair (paper Sec. 2)
+        self.assertAlmostEqual(mean_classic, 10 / 9, delta=0.03)
+        self.assertAlmostEqual(mean_block, 11 / 9, delta=0.03)
+        self.assertGreater(mean_block, mean_classic)
+
+        # losslessness: first emitted token ~ M_b
+        first = pred_block[:, 0]
+        for tok in (0, 1):
+            emp = (first == tok).float().mean().item()
+            expect = t_row[tok].item()
+            sigma = (expect * (1 - expect) / bs) ** 0.5
+            self.assertAlmostEqual(emp, expect, delta=5 * sigma)
+
+    def test_matched_coins_not_worse_than_classic(self):
+        # Block verification is never worse in expectation (Theorem 2); with
+        # non-uniform draft/target mismatch the improvement should be strict.
+        bs, gamma, vocab = 8192, 6, 1029
+        c, t, d, coins, cf = make_chain_inputs(bs=bs, gamma=gamma, vocab=vocab, seed=99)
+        tau_classic, _ = run_classic_kernel(c, t, d, coins, cf)
+        tau_block, _, _ = run_block_kernel(c, t, d, coins, cf)
+        mean_classic = tau_classic.float().mean().item()
+        mean_block = tau_block.float().mean().item()
+        # same input noise; means concentrate to ~1e-3
+        self.assertGreaterEqual(mean_block, mean_classic - 0.005)
+        self.assertGreater(mean_block, mean_classic)  # strict for mismatched q vs p
+
+    def test_degenerate_draft_rows(self):
+        bs, gamma, vocab = 5, 4, 509
+        c, t, d, coins, cf = make_chain_inputs(bs=bs, gamma=gamma, vocab=vocab, seed=5)
+        d[0, 1, :] = float("nan")  # NaN draft row
+        d[1, 0, :] = 0.0  # zero-mass draft row (q=0 -> always-accept semantics)
+        d[2, 2, :] = float("nan")
+        c[3, 1] = vocab - 1
+        c[4, 2] = 0
+        tau_k, pred_k, _ = run_block_kernel(c, t, d, coins, cf)
+        self.assertFalse(torch.isnan(pred_k.float()).any().item())
+        self.assertTrue(((pred_k >= 0) | (pred_k == _SENTINEL)).all().item())
+        valid = pred_k[pred_k != _SENTINEL]
+        self.assertTrue((valid < vocab).all().item())
+        self.assertTrue(((tau_k >= 0) & (tau_k <= gamma)).all().item())
+
+    def test_all_accepted_bonus_from_target_row(self):
+        # q == p exactly -> h = 1 everywhere -> all drafts accepted and the
+        # bonus is sampled from the last target row.
+        bs, gamma, vocab = 4000, 4, 1024
+        g = torch.Generator(device=DEV).manual_seed(4242)
+        S = gamma + 1
+        shared = torch.softmax(
+            torch.randn(bs, S, vocab, generator=g, device=DEV) * 2.0, dim=-1
+        )
+        candidates = torch.zeros(bs, S, dtype=torch.int64, device=DEV)
+        candidates[:, 1:] = torch.multinomial(
+            shared[:, :-1].reshape(-1, vocab), 1, generator=g
+        ).view(bs, gamma)
+        coins = torch.rand(bs, S, generator=g, device=DEV)
+        cf = torch.rand(bs, generator=g, device=DEV)
+        tau_k, pred_k, _ = run_block_kernel(
+            candidates, shared.clone(), shared.clone(), coins, cf
+        )
+        self.assertTrue((tau_k == gamma).all().item())
+        bonus = pred_k[:, gamma]
+        # bonus must be a valid token id (sampled from row gamma of target)
+        self.assertTrue(((bonus >= 0) & (bonus < vocab)).all().item())
+        # sanity on the sampling: empirical top-token frequency should track
+        # the target row's argmax mass (loose check, just guards the CDF path)
+        amass = shared[:, gamma].max(-1).values.mean().item()
+        top_hits = (bonus == shared[:, gamma].argmax(-1)).float().mean().item()
+        self.assertAlmostEqual(top_hits, amass, delta=0.10)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# PR: [spec decoding] Support block verification for speculative decoding rejection sampling

## Motivation

Speculative decoding verifies drafted tokens independently per token (Leviathan et al.). Sun et al. ([*Block Verification Accelerates Speculative Decoding*](https://arxiv.org/abs/2403.10444)) proved this is not optimal: jointly verifying the draft block accepts strictly more tokens in expectation while preserving the identical output distribution of the target model. vLLM recently landed this for its rejection sampler (vllm-project/vllm#46781, accept-length +0.05–0.08, throughput +2–6%). SGLang has only classic token-level rejection sampling (chain path, `--speculative-use-rejection-sampling`) — this PR adds Block Verification as an opt-in replacement:

- **Provably no worse**: E[accepted tokens/iteration] ≥ token verification for every draft/target/γ (paper Theorem 2); measured +0.08–0.14 accept length on real models (below).
- **Lossless**: output stays exactly distributed as target-model sampling (paper Theorem 1); enforced by distribution-level unit tests and model-level GSM8K parity.
- **Zero-cost at temperature 0** (degenerates to the classic rule) and larger gains at higher temperature/longer drafts (paper trend, reproduced below).

## Modifications

- **`python/sglang/kernels/ops/speculative/reject_sampling.py`**: new Triton kernel `speculative_sampling_block_kernel` + wrapper `chain_block_speculative_sampling_triton` (drop-in signature match with the classic chain kernel; classic kernel untouched). Single fused one-program-per-request kernel implementing paper Algorithm 2:
  - sequential prefix ratios `p_i = min(p_{i-1}·M_b(x_i)/M_s(x_i), 1)`; residual mass `Z_{i+1}` computed lazily via vocab scans (skipped when `p_i == 0`; closed form `Z_{i+1} = p_i·(1 − M_b(x_{i+1}))` for one-hot/greedy draft rows, mirroring vLLM's fast path)
  - acceptance `u_i ≤ h_i`, `h_i = Z_{i+1}/(Z_{i+1} + 1 − p_i)` (`h_γ = p_γ`); accepted prefix `τ = argmax_i {u_i ≤ h_i}` (verification no longer stops at the first failed token)
  - correction token sampled from the `p_τ`-scaled residual `max(p_τ·M_b(row τ) − M_s(row τ), 0) / Z_{τ+1}`; all-accepted rows resample the pure target row (draft pointer untouched since draft row γ does not exist)
  - degenerate-input handling kept compatible with the classic kernel: NaN q → 0, `denom == 0` (identical scaled distributions) → accept, negative-impossible `Z` clamped against renormalization rounding
  - registered in `python/sglang/kernels/ops/speculative/__init__.py`
- **`python/sglang/srt/server_args.py`**: new `--speculative-use-block-verification` (default false, `NS("spec")`, auto-CLI).
- **`python/sglang/srt/arg_groups/speculative_hook.py`**: validation in top-level `handle_speculative_decoding` (runs for every algorithm): EAGLE/EAGLE3 requires `--speculative-use-rejection-sampling`; DSPARK is allowed standalone (it swaps the internal sampling-accept kernel); all other algorithms (NGRAM, FROZEN_KV_MTP, DFLASH, STANDALONE) raise `NotImplementedError`.
- **`python/sglang/srt/speculative/eagle_utils.py`**: `eagle_sample` (verify path shared by EAGLE, EAGLE3, NEXTN, multi-layer EAGLE chains) dispatches to the block kernel when the flag is set; `draft_probs` plumbing and the kernel-input guard work off the joined `use_rejection_sampling or block` condition.
- **`python/sglang/kernels/ops/speculative/dspark/dspark_accept.py`**: DSPARK `AcceptSampling` chain path dispatches to the block kernel as well (greedy requests stay on `AcceptGreedy`); the runtime-context probe is deferred so the kernels module stays importable without a server context.
- **Docs** (`docs/docs/advanced_features/speculative_decoding.mdx`): `--speculative-use-rejection-sampling` and `--speculative-use-block-verification` rows added to the EAGLE tuning table and the Full Parameter Reference.
- **Tests**: new `test/registered/kernels/ops/speculative/test_reject_sampling_block.py` (first unit tests for this kernel family).

Constraints of scope (unchanged from `--speculative-use-rejection-sampling`): linear chain drafts only (`--speculative-eagle-topk 1`), EAGLE/EAGLE3/NEXTN + DSPARK; tree drafting and the greedy sgl-kernel path are unaffected (deterministic optimal already).

### Compatibility / coverage

| Model class | Works automatically? | Notes |
|---|---|---|
| EAGLE / EAGLE3 / NEXTN chains (e.g. Qwen3.5-9B NEXTN, DSv3/V4-Pro MTP, multi-layer EAGLE) | ✅ | Kernel is per-request on already-gathered probs; `eagle_sample`'s existing post-kernel rank-0 broadcast of `predict / accept_index / num_correct_drafts` (also under dp-attention) covers TP. Seeded `_verify_coins` determinism preserved (same coin layout). |
| DSPARK (Kimi K3, DSv4-Flash-0731 bundled heads) | ✅ (temp > 0) | Swaps the internal `AcceptSampling` kernel only; greedy requests stay on `AcceptGreedy`. DSPARK's own pp=1 constraint is pre-existing, unrelated to this PR. |
| Quantized targets (FP4 / NVFP4 / FP8 / int4) | ✅ | Orthogonal — the kernel consumes probability rows only. |
| Tree drafting (`--speculative-eagle-topk > 1`), DFLASH verify | ❌ out of scope | Different verification families (paper is chain-only); blocked at arg validation with a clear error, behavior unchanged. |
| Greedy requests anywhere (temp = 0) | unchanged | Both chain algorithms degenerate to the same accept rule at temp 0 (block verification ≡ token verification). |
| Multi-GPU E2E (TP > 1, DSPARK on Kimi-K3/DSv4) | validation pending | Analysis above says TP handled by existing broadcast; tp=2 and DSPARK node legs queued as follow-up. |



## Accuracy Tests

**Unit/kernel tests** (`python3 -m pytest test/registered/kernels/ops/speculative/test_reject_sampling_block.py`, 6 tests / 22 subtests, CUDA base-b):
- bit-identical agreement with a vectorized PyTorch reference of paper Algorithm 2 across γ ∈ {1,2,4,8}, vocab ∈ {127, 1013, 2500, 4096}
- one-hot fast path ≡ full vocab-scan formula
- losslessness on the paper's motivating toy model (Sec. 2): first emitted token ∼ M_b within 5σ over 20k trials; analytic block efficiencies reproduced: token E[τ] = 10/9, block E[τ] = 11/9 (γ=2)
- matched-coins aggregate acceptance: block mean-τ strictly > classic for mismatched q/p (Theorem 2)
- degenerate draft rows (NaN / zero mass): no NaNs, all outputs valid

**Model-level (GSM8K, 100 examples, Qwen3.5-9B + NEXTN MTP, steps=3/topk=1/draft-tokens=4):**

| config | GSM8K score | avg accept length |
|---|---|---|
| classic rejection sampling @ temp=0 | 0.890 | 3.162 |
| **block verification @ temp=0** | **0.900** | 3.150 |
| classic rejection sampling @ temp=1.0 | 0.600 | 3.174 |
| **block verification @ temp=1.0** | **0.650** | **3.277** |

(temp=1.0 exercises the block kernel; scores within run-to-run noise per the contribution guide's 1–5% variance note. Block never degrades quality and accept length improves.)

## Speed Tests and Profiling

`sglang.bench_serving`, ShareGPT, 96 prompts, concurrency 8, seed-matched, TP=1 on RTX PRO 6000 Blackwell (96 GB), `--speculative-use-rejection-sampling` with `--speculative-num-steps {3,7}` (`γ = 4, 8`):

| γ | temp | accept len classic → block | Δ accept | output tok/s classic → block | Δ tok/s |
|---|---|---|---|---|---|
| 4 | 1.0 | 2.61 → 2.69 | **+0.08** | 759.3 → 785.9 | **+3.5%** |
| 8 | 1.0 | 3.10 → 3.24 | **+0.14** | 639.7 → 664.3 | **+3.8%** |
| 8 | 0.6 | 3.52 → 3.61 | **+0.09** | 724.6 → 735.6 | **+1.5%** |

Trends match the paper (gains grow with γ and with temperature; ~zero at greedy) and the vLLM reference PR (+0.05–0.08 accept length at 8 spec tokens). Kernel cost: one extra scalar pass + ≤ γ−1 vocab scans per request vs the classic 2 — no measurable regression in any config, and TPOT improves in lockstep with acceptance.

Blocked/unrunnable legs on this box (documented in the PR thread if needed): the lmsys EAGLE3 8B draft (32k draft vocab) is incompatible with rejection sampling by design; DSPARK end-to-end needs a multi-GPU node and will be added in follow up work.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`pre-commit run` on all changed files: isort/ruff/black/codespell/CI-registry hooks all pass)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (new registered CUDA test, `CustomTestCase`, `__main__` entry)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (both speculative-decoding parameter tables)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (GSM8K + bench_serving above)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance). (classic kernel untouched; feature-gated dispatch; no new data containers; minimal surface: one kernel, one flag, two dispatch lines)


## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33482928628](https://github.com/sgl-project/sglang/actions/runs/33482928628)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33482928393](https://github.com/sgl-project/sglang/actions/runs/33482928393)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33482928580](https://github.com/sgl-project/sglang/actions/runs/33482928580)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->