### PR TITLE
[Bugfix] Reject corpus removal during pending async load (#36500)

### DIFF
--- a/python/sglang/srt/speculative/external_corpus_manager.py
+++ b/python/sglang/srt/speculative/external_corpus_manager.py
@@ -83,11 +83,24 @@ class ExternalCorpusManager:
         thread.start()
         return None  # response sent later by check_pending_load
 
-    # FIXME(kpham-sgl): remove a corpus during a pending load is an undefined behaviour
-    # and should be explicitly prevented.
     def remove(
         self, recv_req: RemoveExternalCorpusReqInput
     ) -> RemoveExternalCorpusReqOutput:
+        # Reject removal while a load for the same corpus_id is in progress.
+        # Otherwise the remove returns success but the background thread still
+        # commits the corpus when it finishes (issue #36500).
+        if (
+            self._pending_load is not None
+            and self._pending_load[0].corpus_id == recv_req.corpus_id
+        ):
+            return RemoveExternalCorpusReqOutput(
+                success=False,
+                message=(
+                    f"Cannot remove corpus '{recv_req.corpus_id}' while it "
+                    "is still being loaded. Wait for the load to complete "
+                    "or cancel it first."
+                ),
+            )
         try:
             self._worker.remove_external_corpus(recv_req.corpus_id)
             return RemoveExternalCorpusReqOutput(

--- a/test/registered/unit/speculative/test_external_corpus_remove.py
+++ b/test/registered/unit/speculative/test_external_corpus_remove.py
@@ -1,0 +1,94 @@
+"""Unit tests for ExternalCorpusManager corpus removal during pending load (#36500).
+
+Validates that removing a corpus while it is being asynchronously loaded is
+rejected, and that removal after load completes works as expected.
+"""
+import time
+import unittest
+
+from sglang.srt.managers.io_struct import (
+    AddExternalCorpusReqInput,
+    ListExternalCorporaReqInput,
+    RemoveExternalCorpusReqInput,
+)
+from sglang.srt.speculative.external_corpus_manager import ExternalCorpusManager
+
+
+class _FakeWorker:
+    def __init__(self):
+        self._corpora = {}
+
+    def add_external_corpus(self, corpus_id, token_chunks):
+        time.sleep(0.5)
+        return len(token_chunks)
+
+    def remove_external_corpus(self, corpus_id):
+        self._corpora.pop(corpus_id, None)
+
+    def list_external_corpora(self):
+        return dict(self._corpora)
+
+    def commit_corpus_load(self, corpus_id, count):
+        self._corpora[corpus_id] = count
+
+
+class _FakeResponseCapture:
+    def __init__(self):
+        self.responses = []
+
+    def __call__(self, output, recv_req):
+        self.responses.append((output, recv_req))
+
+
+class TestRemoveDuringPendingLoad(unittest.TestCase):
+    def test_remove_during_pending_load_rejected(self):
+        worker = _FakeWorker()
+        mgr = ExternalCorpusManager(worker, _FakeResponseCapture())
+        mgr.add(AddExternalCorpusReqInput(
+            corpus_id="test_corpus",
+            token_chunks=[[1, 2, 3, 4, 5]],
+        ))
+
+        result = mgr.remove(RemoveExternalCorpusReqInput(corpus_id="test_corpus"))
+        self.assertFalse(result.success)
+        self.assertIn("still being loaded", result.message)
+
+    def test_corpus_committed_after_load(self):
+        worker = _FakeWorker()
+        mgr = ExternalCorpusManager(worker, _FakeResponseCapture())
+        mgr.add(AddExternalCorpusReqInput(
+            corpus_id="test_corpus",
+            token_chunks=[[1, 2, 3, 4, 5]],
+        ))
+        time.sleep(1.0)
+        mgr.check_pending_load()
+        result = mgr.list(ListExternalCorporaReqInput())
+        self.assertIn("test_corpus", result.corpus_token_counts)
+
+    def test_remove_after_load_succeeds(self):
+        worker = _FakeWorker()
+        mgr = ExternalCorpusManager(worker, _FakeResponseCapture())
+        mgr.add(AddExternalCorpusReqInput(
+            corpus_id="test_corpus",
+            token_chunks=[[1, 2, 3, 4, 5]],
+        ))
+        time.sleep(1.0)
+        mgr.check_pending_load()
+        result = mgr.remove(RemoveExternalCorpusReqInput(corpus_id="test_corpus"))
+        self.assertTrue(result.success)
+        listed = mgr.list(ListExternalCorporaReqInput())
+        self.assertNotIn("test_corpus", listed.corpus_token_counts)
+
+    def test_remove_different_corpus_during_load_succeeds(self):
+        worker = _FakeWorker()
+        mgr = ExternalCorpusManager(worker, _FakeResponseCapture())
+        mgr.add(AddExternalCorpusReqInput(
+            corpus_id="corpus_a",
+            token_chunks=[[10, 20, 30]],
+        ))
+        result = mgr.remove(RemoveExternalCorpusReqInput(corpus_id="corpus_b"))
+        self.assertTrue(result.success)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

When an external NGRAM corpus is being loaded asynchronously through `/add_external_corpus`, calling `/remove_external_corpus` for the same corpus ID returns `success=true`. However, the remove neither cancels the pending load nor rejects the request. When the background load finishes, the corpus is committed normally and becomes visible through `/list_external_corpora` (issue #36500).

The existing `# FIXME(kpham-sgl)` comment in `ExternalCorpusManager.remove()` already flags this as undefined behaviour.

## Fix

Reject the remove request when a load for the same `corpus_id` is still pending, returning `success=false` with a message to wait for the load to complete:

```python
def remove(self, recv_req):
    if (
        self._pending_load is not None
        and self._pending_load[0].corpus_id == recv_req.corpus_id
    ):
        return RemoveExternalCorpusReqOutput(
            success=False,
            message="Cannot remove corpus ... while it is still being loaded. ...",
        )
    # ... existing remove logic
```

This matches option 2 from the issue's expected behaviour section ("Reject the remove request with an explicit pending/conflict response"). Removing a **different** corpus during a pending load is unaffected.

## Tests

Added unit tests in `test/registered/unit/speculative/test_external_corpus_remove.py` covering:

- Remove during pending load → rejected ✅
- Corpus committed after load completes → present in list ✅
- Remove after load completes → succeeds ✅
- Corpus gone after post-load remove → confirmed ✅
- Remove of a different corpus during pending load → succeeds ✅

Closes #36500

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32982453758](https://github.com/sgl-project/sglang/actions/runs/32982453758)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32982453350](https://github.com/sgl-project/sglang/actions/runs/32982453350)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32982453567](https://github.com/sgl-project/sglang/actions/runs/32982453567)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->