### PR TITLE
[Sampling] Defer sampling-mask materialization off the decode hot path

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -100,8 +100,7 @@ class SamplingMaskOutput:
 
     batch_indices: torch.Tensor
     batch_size: torch.Tensor
-    token_ids: Optional[torch.Tensor]
-    support_bits: Optional[torch.Tensor]
+    token_ids: torch.Tensor
     lengths: torch.Tensor
     selected_logprobs: torch.Tensor
     valid: torch.Tensor
@@ -109,18 +108,28 @@ class SamplingMaskOutput:
     def map_device_tensors(self, fn) -> None:
         self.batch_indices = fn(self.batch_indices)
         self.batch_size = fn(self.batch_size)
-        if self.token_ids is not None:
-            self.token_ids = fn(self.token_ids)
-        if self.support_bits is not None:
-            self.support_bits = fn(self.support_bits)
+        self.token_ids = fn(self.token_ids)
         self.lengths = fn(self.lengths)
         self.selected_logprobs = fn(self.selected_logprobs)
         self.valid = fn(self.valid)
 
     def materialize(self) -> Tuple[List[Optional[List[int]]], List[Optional[float]]]:
         """Convert copied tensors into batch-aligned Python values."""
-        batch_indices = self.batch_indices.cpu().tolist()
-        valid = self.valid.cpu().tolist()
+        batch_indices = self.batch_indices.tolist()
+        lengths = self.lengths.tolist()
+        packed_width = self.token_ids.shape[1]
+        overflow_rows = [
+            batch_row
+            for batch_row, length in zip(batch_indices, lengths)
+            if length > packed_width
+        ]
+        if overflow_rows:
+            raise RuntimeError(
+                "Captured sampling support exceeds its packed token storage "
+                f"for batch rows {overflow_rows}."
+            )
+
+        valid = self.valid.tolist()
         invalid_rows = [
             batch_row
             for batch_row, is_valid in zip(batch_indices, valid)
@@ -132,38 +141,15 @@ class SamplingMaskOutput:
                 f"for batch rows {invalid_rows}."
             )
 
-        lengths = self.lengths.cpu().tolist()
-        selected_logprobs = self.selected_logprobs.cpu().tolist()
-        batch_size = int(self.batch_size.cpu().item())
+        selected_logprobs = self.selected_logprobs.tolist()
+        batch_size = int(self.batch_size.item())
         masks: List[Optional[List[int]]] = [None] * batch_size
         logprobs: List[Optional[float]] = [None] * batch_size
 
-        if self.support_bits is not None:
-            support_bits = self.support_bits.cpu().tolist()
-            row_token_ids = []
-            for row_bytes, length in zip(support_bits, lengths):
-                token_ids = []
-                for byte_index, byte_value in enumerate(row_bytes):
-                    while byte_value:
-                        bit_index = (byte_value & -byte_value).bit_length() - 1
-                        token_ids.append(byte_index * 8 + bit_index)
-                        byte_value &= byte_value - 1
-                if len(token_ids) != length:
-                    raise RuntimeError(
-                        "Captured sampling support length does not match its bitset."
-                    )
-                row_token_ids.append(token_ids)
-        else:
-            assert self.token_ids is not None
-            token_ids = self.token_ids.cpu()
-            packed_width = token_ids.shape[1]
-            row_token_ids = []
-            for row, length in enumerate(lengths):
-                if not 0 <= length <= packed_width:
-                    raise RuntimeError(
-                        "Captured sampling support exceeds its packed token storage."
-                    )
-                row_token_ids.append(token_ids[row, :length].tolist())
+        token_ids = self.token_ids
+        row_token_ids = [
+            token_ids[row, :length].tolist() for row, length in enumerate(lengths)
+        ]
 
         for row, batch_index in enumerate(batch_indices):
             masks[batch_index] = row_token_ids[row]

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -95,6 +95,83 @@ def autotune_dummy_run_mode(*, run_lm_head: bool):
 
 
 @dataclasses.dataclass
+class SamplingMaskOutput:
+    """Tensor-backed sampling support for rows that requested it."""
+
+    batch_indices: torch.Tensor
+    batch_size: torch.Tensor
+    token_ids: Optional[torch.Tensor]
+    support_bits: Optional[torch.Tensor]
+    lengths: torch.Tensor
+    selected_logprobs: torch.Tensor
+    valid: torch.Tensor
+
+    def map_device_tensors(self, fn) -> None:
+        self.batch_indices = fn(self.batch_indices)
+        self.batch_size = fn(self.batch_size)
+        if self.token_ids is not None:
+            self.token_ids = fn(self.token_ids)
+        if self.support_bits is not None:
+            self.support_bits = fn(self.support_bits)
+        self.lengths = fn(self.lengths)
+        self.selected_logprobs = fn(self.selected_logprobs)
+        self.valid = fn(self.valid)
+
+    def materialize(self) -> Tuple[List[Optional[List[int]]], List[Optional[float]]]:
+        """Convert copied tensors into batch-aligned Python values."""
+        batch_indices = self.batch_indices.cpu().tolist()
+        valid = self.valid.cpu().tolist()
+        invalid_rows = [
+            batch_row
+            for batch_row, is_valid in zip(batch_indices, valid)
+            if not is_valid
+        ]
+        if invalid_rows:
+            raise RuntimeError(
+                "Sampled token is outside captured positive sampling support "
+                f"for batch rows {invalid_rows}."
+            )
+
+        lengths = self.lengths.cpu().tolist()
+        selected_logprobs = self.selected_logprobs.cpu().tolist()
+        batch_size = int(self.batch_size.cpu().item())
+        masks: List[Optional[List[int]]] = [None] * batch_size
+        logprobs: List[Optional[float]] = [None] * batch_size
+
+        if self.support_bits is not None:
+            support_bits = self.support_bits.cpu().tolist()
+            row_token_ids = []
+            for row_bytes, length in zip(support_bits, lengths):
+                token_ids = []
+                for byte_index, byte_value in enumerate(row_bytes):
+                    while byte_value:
+                        bit_index = (byte_value & -byte_value).bit_length() - 1
+                        token_ids.append(byte_index * 8 + bit_index)
+                        byte_value &= byte_value - 1
+                if len(token_ids) != length:
+                    raise RuntimeError(
+                        "Captured sampling support length does not match its bitset."
+                    )
+                row_token_ids.append(token_ids)
+        else:
+            assert self.token_ids is not None
+            token_ids = self.token_ids.cpu()
+            packed_width = token_ids.shape[1]
+            row_token_ids = []
+            for row, length in enumerate(lengths):
+                if not 0 <= length <= packed_width:
+                    raise RuntimeError(
+                        "Captured sampling support exceeds its packed token storage."
+                    )
+                row_token_ids.append(token_ids[row, :length].tolist())
+
+        for row, batch_index in enumerate(batch_indices):
+            masks[batch_index] = row_token_ids[row]
+            logprobs[batch_index] = float(selected_logprobs[row])
+        return masks, logprobs
+
+
+@dataclasses.dataclass
 class LogitsProcessorOutput:
     ## Part 1: This part will be assigned in python/sglang/srt/layers/logits_processor.py::LogitsProcessor
     # The logits of the next tokens.       shape: [#seq, vocab_size]
@@ -116,10 +193,18 @@ class LogitsProcessorOutput:
         List[Union[List[float], torch.Tensor]]
     ] = None
     next_token_token_ids_logprobs_idx: Optional[List] = None
-    # Sparse top-k/top-p/min-p support ids and selected-token logprob after
-    # truncation/renormalization. Only populated when requested.
-    next_token_sampling_mask_idx: Optional[List[Optional[List[int]]]] = None
-    next_token_sampling_logprobs: Optional[List[Optional[float]]] = None
+    # Sparse top-k/top-p/min-p support and selected-token logprob after
+    # truncation/renormalization. SamplingMaskOutput stays tensor-backed until
+    # the scheduler processes the completed result. The legacy fields hold the
+    # final batch-aligned values after materialization.
+    sampling_mask_output: Optional[SamplingMaskOutput] = None
+    next_token_sampling_mask_idx: Optional[
+        Union[torch.Tensor, List[Optional[List[int]]]]
+    ] = None
+    next_token_sampling_mask_len: Optional[torch.Tensor] = None
+    next_token_sampling_logprobs: Optional[
+        Union[torch.Tensor, List[Optional[float]]]
+    ] = None
 
     ## Part 3: Prefill-only. This part will be assigned in python/sglang/srt/layers/logits_processor.py::LogitsProcessor
     # The logprobs of input tokens.        shape: [#token]

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -1,6 +1,6 @@
 import logging
 from functools import partial
-from typing import Callable, Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, NamedTuple, Optional, Tuple
 
 import torch
 import torch.distributed as dist
@@ -68,6 +68,14 @@ _CUSTOM_SAMPLER_FACTORIES: Dict[str, Callable[[], "Sampler"]] = {}
 _BUILT_IN_SAMPLING_BACKENDS = {"flashinfer", "pytorch", "ascend"}
 
 
+class _SamplingMaskCapture(NamedTuple):
+    """Actual post-filter sampling weights and their token mapping."""
+
+    weights: torch.Tensor
+    token_ids: Optional[torch.Tensor]
+    selected_weight: Optional[torch.Tensor]
+
+
 class Sampler(nn.Module):
     def __init__(self):
         super().__init__()
@@ -126,6 +134,7 @@ class Sampler(nn.Module):
         # Preprocess logits (custom processors and NaN handling)
         logits = self._preprocess_logits(logits, sampling_info)
         return_sampling_mask = any(sampling_info.return_sampling_masks or [])
+        sampling_mask_capture = None
 
         if sampling_info.is_all_greedy:
             if _use_aiter and not _disable_aiter_greedy_sample:
@@ -135,10 +144,6 @@ class Sampler(nn.Module):
                 _aiter_greedy_sample(batch_next_token_ids, logits)
             else:
                 batch_next_token_ids = torch.argmax(logits, -1)
-            if return_sampling_mask:
-                self._attach_greedy_sampling_mask_to_output(
-                    logits_output, sampling_info, batch_next_token_ids
-                )
             if return_logprob:
                 original_logprobs = logprobs = torch.nn.functional.log_softmax(
                     logits, dim=-1
@@ -211,19 +216,13 @@ class Sampler(nn.Module):
                 logits[:] = torch.softmax(logits, dim=-1)
                 probs = logits
 
-                batch_next_token_ids = self._sample_from_probs(
-                    probs, sampling_info, positions, simple_sampling_case
+                batch_next_token_ids, sampling_mask_capture = self._sample_from_probs(
+                    probs,
+                    sampling_info,
+                    positions,
+                    simple_sampling_case,
+                    return_sampling_mask=return_sampling_mask,
                 )
-                if return_sampling_mask:
-                    sampling_mask_data = self._compute_sampling_mask_from_probs(
-                        probs, sampling_info
-                    )
-                    self._attach_sampling_mask_to_output(
-                        logits_output,
-                        sampling_info,
-                        batch_next_token_ids,
-                        sampling_mask_data,
-                    )
                 if return_logprob and not SGLANG_RETURN_ORIGINAL_LOGPROB:
                     logprobs = (
                         logprobs_via_logsoftmax_kernel
@@ -245,6 +244,25 @@ class Sampler(nn.Module):
 
         self._sync_token_ids_across_tp(batch_next_token_ids, sampling_info)
 
+        if return_sampling_mask:
+            if sampling_info.is_all_greedy:
+                self._attach_greedy_sampling_mask_to_output(
+                    logits_output, sampling_info, batch_next_token_ids
+                )
+            else:
+                assert sampling_mask_capture is not None
+                if SYNC_TOKEN_IDS_ACROSS_TP or sampling_info.grammars:
+                    # Token synchronization can replace the producer-selected token.
+                    sampling_mask_capture = sampling_mask_capture._replace(
+                        selected_weight=None
+                    )
+                self._attach_sampling_mask_to_output(
+                    logits_output,
+                    sampling_info,
+                    batch_next_token_ids,
+                    sampling_mask_capture,
+                )
+
         return batch_next_token_ids
 
     def _sample_from_probs(
@@ -253,18 +271,31 @@ class Sampler(nn.Module):
         sampling_info: SamplingBatchInfo,
         positions: torch.Tensor,
         simple_sampling_case: bool,
-    ) -> torch.Tensor:
+        *,
+        return_sampling_mask: bool = False,
+    ) -> Tuple[torch.Tensor, Optional[_SamplingMaskCapture]]:
         """Sample from probability distribution (after softmax).
 
         Used for standard sampling with flashinfer/pytorch backends.
         Handles both simple (direct multinomial) and complex (top-k/top-p/min-p) cases.
+        Capture work is performed only when return_sampling_mask is enabled.
         """
+        sampling_mask_capture = None
         if simple_sampling_case:
             batch_next_token_ids = sampling_from_probs_torch(
                 probs,
                 sampling_seed=sampling_info.sampling_seed,
                 positions=positions,
             )
+            if return_sampling_mask:
+                selected_weight = torch.gather(
+                    probs, 1, batch_next_token_ids.long().view(-1, 1)
+                ).squeeze(1)
+                sampling_mask_capture = _SamplingMaskCapture(
+                    weights=probs,
+                    token_ids=None,
+                    selected_weight=selected_weight,
+                )
         else:
             backend = get_exec().kernel.sampling_backend
             if backend == "flashinfer":
@@ -277,6 +308,23 @@ class Sampler(nn.Module):
                     batch_next_token_ids = min_p_sampling_from_probs(
                         probs, sampling_info.min_ps
                     )
+                    if return_sampling_mask:
+                        min_p_thresholds = (
+                            probs.max(dim=-1).values * sampling_info.min_ps
+                        )
+                        filtered_probs = probs.masked_fill(
+                            probs < min_p_thresholds.view(-1, 1), 0
+                        )
+                        selected_weight = torch.gather(
+                            filtered_probs,
+                            1,
+                            batch_next_token_ids.long().view(-1, 1),
+                        ).squeeze(1)
+                        sampling_mask_capture = _SamplingMaskCapture(
+                            weights=filtered_probs,
+                            token_ids=None,
+                            selected_weight=selected_weight,
+                        )
                 else:
                     batch_next_token_ids = top_k_top_p_sampling_from_probs(
                         probs.contiguous(),
@@ -284,9 +332,31 @@ class Sampler(nn.Module):
                         sampling_info.top_ps,
                         filter_apply_order="joint",
                     )
+                    if return_sampling_mask:
+                        filtered_probs = probs
+                        if sampling_info.need_top_k_sampling:
+                            filtered_probs = top_k_renorm_prob(
+                                probs, sampling_info.top_ks
+                            )
+                        if sampling_info.need_top_p_sampling:
+                            top_p_probs = top_p_renorm_prob(probs, sampling_info.top_ps)
+                            if filtered_probs is probs:
+                                filtered_probs = top_p_probs
+                            else:
+                                filtered_probs.masked_fill_(top_p_probs <= 0, 0)
+                        selected_weight = torch.gather(
+                            filtered_probs,
+                            1,
+                            batch_next_token_ids.long().view(-1, 1),
+                        ).squeeze(1)
+                        sampling_mask_capture = _SamplingMaskCapture(
+                            weights=filtered_probs,
+                            token_ids=None,
+                            selected_weight=selected_weight,
+                        )
             elif backend == "pytorch":
                 # A slower fallback implementation with torch native operations.
-                batch_next_token_ids = top_k_top_p_min_p_sampling_from_probs_torch(
+                sample_result = top_k_top_p_min_p_sampling_from_probs_torch(
                     probs,
                     sampling_info.top_ks,
                     sampling_info.top_ps,
@@ -294,39 +364,25 @@ class Sampler(nn.Module):
                     sampling_info.need_min_p_sampling,
                     sampling_info.sampling_seed,
                     positions,
+                    return_filtered_probs=return_sampling_mask,
                 )
+                if return_sampling_mask:
+                    (
+                        batch_next_token_ids,
+                        filtered_probs,
+                        token_ids,
+                        selected_weight,
+                    ) = sample_result
+                    sampling_mask_capture = _SamplingMaskCapture(
+                        weights=filtered_probs,
+                        token_ids=token_ids,
+                        selected_weight=selected_weight,
+                    )
+                else:
+                    batch_next_token_ids = sample_result
             else:
                 raise ValueError(f"Invalid sampling backend: {backend}")
-        return batch_next_token_ids
-
-    def _compute_sampling_mask_from_probs(
-        self, probs: torch.Tensor, sampling_info: SamplingBatchInfo
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
-        """Return sorted token ids, sorted probs, keep mask, and raw probs."""
-        vocab_size = probs.shape[-1]
-        max_top_k = sampling_info.sampling_mask_max_top_k
-        if 0 < max_top_k < vocab_size:
-            probs_sort, probs_idx = torch.topk(
-                probs,
-                k=max_top_k,
-                dim=-1,
-                largest=True,
-                sorted=True,
-            )
-            positions = torch.arange(max_top_k, device=probs.device).view(1, -1)
-        else:
-            probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
-            positions = torch.arange(vocab_size, device=probs.device).view(1, -1)
-        probs_sum = torch.cumsum(probs_sort, dim=-1)
-
-        keep_mask = positions < sampling_info.top_ks.view(-1, 1)
-        keep_mask &= (probs_sum - probs_sort) <= sampling_info.top_ps.view(-1, 1)
-
-        if sampling_info.need_min_p_sampling:
-            min_p_thresholds = probs_sort[:, 0] * sampling_info.min_ps
-            keep_mask &= probs_sort >= min_p_thresholds.view(-1, 1)
-
-        return probs_idx, probs_sort, keep_mask, probs
+        return batch_next_token_ids, sampling_mask_capture
 
     def _attach_greedy_sampling_mask_to_output(
         self,
@@ -352,63 +408,94 @@ class Sampler(nn.Module):
         logits_output: LogitsProcessorOutput,
         sampling_info: SamplingBatchInfo,
         batch_next_token_ids: torch.Tensor,
-        sampling_mask_data: Tuple[
-            torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor
-        ],
+        sampling_mask_capture: _SamplingMaskCapture,
     ) -> None:
-        probs_idx, probs_sort, keep_mask, probs = sampling_mask_data
         return_sampling_masks = sampling_info.return_sampling_masks or []
         if not return_sampling_masks:
             logits_output.next_token_sampling_mask_idx = []
             logits_output.next_token_sampling_logprobs = []
             return
 
-        sampled_tokens = batch_next_token_ids.view(-1, 1)
-        sampled_matches_all = probs_idx == sampled_tokens
-        sampled_in_idx = sampled_matches_all.any(dim=-1)
-
-        # The sampler is the source of truth for the rollout action space. If a
-        # backend/numeric edge chooses a token just outside the reconstructed
-        # prefix, include that sampled token so training can replay a support
-        # that contained the rollout action.
-        effective_keep_mask = keep_mask | sampled_matches_all
-        selected_raw_probs = torch.gather(probs, 1, sampled_tokens).squeeze(1)
-        support_mass = torch.where(
-            effective_keep_mask, probs_sort, torch.zeros_like(probs_sort)
-        ).sum(dim=-1)
-        support_mass = support_mass + torch.where(
-            sampled_in_idx, torch.zeros_like(selected_raw_probs), selected_raw_probs
+        requested_rows_list = [
+            i for i, should_return in enumerate(return_sampling_masks) if should_return
+        ]
+        requested_rows = torch.tensor(
+            requested_rows_list,
+            device=sampling_mask_capture.weights.device,
+            dtype=torch.long,
         )
-        selected_logprobs = torch.log(
-            selected_raw_probs.float()
-            / support_mass.float().clamp_min(torch.finfo(torch.float32).tiny)
+        weights = sampling_mask_capture.weights.index_select(0, requested_rows)
+        token_ids = sampling_mask_capture.token_ids
+        if token_ids is not None:
+            token_ids = token_ids.index_select(0, requested_rows)
+        selected_weight = sampling_mask_capture.selected_weight
+        if selected_weight is not None:
+            selected_weight = selected_weight.index_select(0, requested_rows)
+        sampled_tokens = batch_next_token_ids.index_select(0, requested_rows).view(
+            -1, 1
         )
+        if token_ids is None:
+            support_token_ids = (
+                torch.arange(
+                    weights.shape[-1], device=weights.device, dtype=torch.int32
+                )
+                .view(1, -1)
+                .expand_as(weights)
+            )
+            selected_from_weights = torch.gather(
+                weights, 1, sampled_tokens.long()
+            ).squeeze(1)
+            sampled_in_capture = selected_from_weights > 0
+        else:
+            sampled_matches = token_ids == sampled_tokens.to(token_ids.dtype)
+            sampled_in_capture = sampled_matches.any(dim=-1)
+            selected_positions = sampled_matches.to(torch.int32).argmax(
+                dim=-1, keepdim=True
+            )
+            selected_from_weights = torch.gather(
+                weights, 1, selected_positions
+            ).squeeze(1)
+            support_token_ids = token_ids
 
-        flat_rows, flat_cols = effective_keep_mask.nonzero(as_tuple=True)
-        flat_ids = probs_idx[flat_rows, flat_cols].to(torch.int32)
-        mask_lengths = effective_keep_mask.sum(dim=-1, dtype=torch.int32)
+        if selected_weight is None:
+            selected_weight = selected_from_weights
+
+        support = weights > 0
+        support_mass = torch.where(support, weights, torch.zeros_like(weights)).sum(
+            dim=-1, dtype=torch.float32
+        )
+        selected_weight = selected_weight.float()
+        selected_logprobs = torch.log(selected_weight / support_mass)
+        valid = (
+            sampled_in_capture
+            & (selected_weight > 0)
+            & (support_mass > 0)
+            & torch.isfinite(selected_logprobs)
+        )
+        if not bool(torch.all(valid).item()):
+            invalid_rows = (~valid).nonzero(as_tuple=True)[0].cpu().tolist()
+            raise RuntimeError(
+                "Sampled token is outside captured positive sampling support "
+                f"for batch rows {invalid_rows}."
+            )
+
+        flat_rows, flat_cols = support.nonzero(as_tuple=True)
+        flat_ids = support_token_ids[flat_rows, flat_cols].to(torch.int32)
+        mask_lengths = support.sum(dim=-1, dtype=torch.int32)
 
         flat_ids_cpu = flat_ids.cpu().tolist()
         mask_lengths_cpu = mask_lengths.cpu().tolist()
-        sampled_in_idx_cpu = sampled_in_idx.cpu().tolist()
-        sampled_tokens_cpu = batch_next_token_ids.to(torch.int32).cpu().tolist()
         selected_logprobs_cpu = selected_logprobs.cpu().tolist()
 
-        masks = []
-        logprobs = []
+        masks = [None] * len(return_sampling_masks)
+        logprobs = [None] * len(return_sampling_masks)
         cursor = 0
-        for i, should_return in enumerate(return_sampling_masks):
-            mask_len = int(mask_lengths_cpu[i])
+        for capture_row, batch_row in enumerate(requested_rows_list):
+            mask_len = int(mask_lengths_cpu[capture_row])
             row_ids = flat_ids_cpu[cursor : cursor + mask_len]
             cursor += mask_len
-            if not sampled_in_idx_cpu[i]:
-                row_ids.append(int(sampled_tokens_cpu[i]))
-            if should_return:
-                masks.append(row_ids)
-                logprobs.append(float(selected_logprobs_cpu[i]))
-            else:
-                masks.append(None)
-                logprobs.append(None)
+            masks[batch_row] = row_ids
+            logprobs[batch_row] = float(selected_logprobs_cpu[capture_row])
 
         logits_output.next_token_sampling_mask_idx = masks
         logits_output.next_token_sampling_logprobs = logprobs
@@ -572,11 +659,17 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
     need_min_p_sampling: bool,
     sampling_seed: Optional[torch.Tensor],
     positions: torch.Tensor,
+    *,
+    return_filtered_probs: bool = False,
 ):
     """
     A top-k, top-p and min-p sampling implementation with native pytorch operations.
     When sampling_seed is not None, deterministic inference will be enabled, it will sample
     with the sampling_seed of each request.
+
+    By default, returns only sampled token IDs. With return_filtered_probs=True,
+    also returns the actual filtered weights, their token-ID permutation, and
+    the selected weights.
     """
     probs_sort, probs_idx = probs.sort(dim=-1, descending=True)
     probs_sum = torch.cumsum(probs_sort, dim=-1)
@@ -601,14 +694,20 @@ def top_k_top_p_min_p_sampling_from_probs_torch(
         # apply log to get logprobs. Therefore, we cannot use log_softmax directly.
         # For now, we use log to the modified probs to get logprobs, but for numerical
         # stability, we'd better come up with a solution to use log_softmax.
-        logprobs = probs_sort.to(torch.float64)  # Using float64 for numerical stability
-        del probs_sort
+        logprobs = probs_sort.to(torch.float64, copy=return_filtered_probs)
+        if not return_filtered_probs:
+            del probs_sort
         logprobs.log_()
         sampled_index = multinomial_with_seed(logprobs, sampling_seed, positions)
+
+    if return_filtered_probs:
+        selected_weight = torch.gather(probs_sort, 1, sampled_index).view(-1)
 
     # int32 range is enough to represent the token ids
     probs_idx = probs_idx.to(torch.int32)
     batch_next_token_ids = torch.gather(probs_idx, dim=1, index=sampled_index).view(-1)
+    if return_filtered_probs:
+        return batch_next_token_ids, probs_sort, probs_idx, selected_weight
     return batch_next_token_ids
 
 

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -69,6 +69,7 @@ SYNC_TOKEN_IDS_ACROSS_TP = get_bool_env_var("SYNC_TOKEN_IDS_ACROSS_TP")
 SGLANG_RETURN_ORIGINAL_LOGPROB = get_bool_env_var("SGLANG_RETURN_ORIGINAL_LOGPROB")
 _CUSTOM_SAMPLER_FACTORIES: Dict[str, Callable[[], "Sampler"]] = {}
 _BUILT_IN_SAMPLING_BACKENDS = {"flashinfer", "pytorch", "ascend"}
+SAMPLING_MASK_TIE_BUFFER = 128
 
 
 class _SamplingMaskCapture(NamedTuple):
@@ -413,7 +414,6 @@ class Sampler(nn.Module):
                 device=batch_next_token_ids.device,
             ),
             token_ids=token_ids.view(-1, 1),
-            support_bits=None,
             lengths=torch.ones(
                 num_requested, dtype=torch.int32, device=batch_next_token_ids.device
             ),
@@ -487,42 +487,28 @@ class Sampler(nn.Module):
         )
         mask_lengths = support.sum(dim=-1, dtype=torch.int32)
 
+        max_top_k = getattr(sampling_info, "sampling_mask_max_top_k", weights.shape[-1])
+        packed_width = min(
+            max_top_k + SAMPLING_MASK_TIE_BUFFER,
+            weights.shape[-1],
+        )
+        _, packed_positions = torch.topk(weights, k=packed_width, dim=-1)
         if token_ids is None:
-            padding = (-support.shape[-1]) % 8
-            if padding:
-                support = torch.cat(
-                    (
-                        support,
-                        torch.zeros(
-                            (support.shape[0], padding),
-                            dtype=torch.bool,
-                            device=support.device,
-                        ),
-                    ),
-                    dim=-1,
-                )
-            bit_weights = (
-                1 << torch.arange(8, device=support.device, dtype=torch.int16)
-            ).view(1, 1, 8)
-            support_bits = (
-                (support.view(support.shape[0], -1, 8).to(torch.int16) * bit_weights)
-                .sum(dim=-1, dtype=torch.int16)
-                .to(torch.uint8)
-            )
-            packed_token_ids = None
+            packed_token_ids = packed_positions.to(torch.int32)
         else:
-            packed_width = min(
-                getattr(
-                    sampling_info,
-                    "sampling_mask_max_top_k",
-                    token_ids.shape[-1],
-                ),
-                token_ids.shape[-1],
+            packed_token_ids = torch.gather(token_ids, 1, packed_positions).to(
+                torch.int32
             )
-            packed_token_ids = token_ids[:, :packed_width].contiguous()
-            support_bits = None
-            valid &= mask_lengths <= packed_width
+        packed_token_ids = packed_token_ids.contiguous()
+        sampled_in_packed_support = (
+            packed_token_ids == sampled_tokens.to(torch.int32)
+        ).any(dim=-1)
+        valid &= sampled_in_packed_support
 
+        # The fixed-width tensor avoids the synchronization required by
+        # nonzero(), while leaving room for FlashInfer's cutoff-tie semantics.
+        # Materialization rejects the unbounded overflow case instead of
+        # silently returning incomplete support.
         logits_output.sampling_mask_output = SamplingMaskOutput(
             batch_indices=requested_rows,
             batch_size=torch.tensor(
@@ -531,7 +517,6 @@ class Sampler(nn.Module):
                 device=weights.device,
             ),
             token_ids=packed_token_ids,
-            support_bits=support_bits,
             lengths=mask_lengths,
             selected_logprobs=selected_logprobs,
             valid=valid,

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -11,7 +11,10 @@ from sglang.srt.distributed import get_tp_group
 from sglang.srt.layers.dp_attention import (
     is_dp_attention_enabled,
 )
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.logits_processor import (
+    LogitsProcessorOutput,
+    SamplingMaskOutput,
+)
 from sglang.srt.layers.logprob_processor import (
     OutputLogprobProcessor,
 )
@@ -390,18 +393,37 @@ class Sampler(nn.Module):
         sampling_info: SamplingBatchInfo,
         batch_next_token_ids: torch.Tensor,
     ) -> None:
-        tokens = batch_next_token_ids.to(torch.int32).cpu().tolist()
-        masks = []
-        logprobs = []
-        for i, should_return in enumerate(sampling_info.return_sampling_masks or []):
-            if should_return:
-                masks.append([int(tokens[i])])
-                logprobs.append(0.0)
-            else:
-                masks.append(None)
-                logprobs.append(None)
-        logits_output.next_token_sampling_mask_idx = masks
-        logits_output.next_token_sampling_logprobs = logprobs
+        return_sampling_masks = sampling_info.return_sampling_masks or []
+        requested_rows = torch.tensor(
+            [
+                i
+                for i, should_return in enumerate(return_sampling_masks)
+                if should_return
+            ],
+            device=batch_next_token_ids.device,
+            dtype=torch.long,
+        )
+        token_ids = batch_next_token_ids.index_select(0, requested_rows).to(torch.int32)
+        num_requested = requested_rows.numel()
+        logits_output.sampling_mask_output = SamplingMaskOutput(
+            batch_indices=requested_rows,
+            batch_size=torch.tensor(
+                len(return_sampling_masks),
+                dtype=torch.int32,
+                device=batch_next_token_ids.device,
+            ),
+            token_ids=token_ids.view(-1, 1),
+            support_bits=None,
+            lengths=torch.ones(
+                num_requested, dtype=torch.int32, device=batch_next_token_ids.device
+            ),
+            selected_logprobs=torch.zeros(
+                num_requested, dtype=torch.float32, device=batch_next_token_ids.device
+            ),
+            valid=torch.ones(
+                num_requested, dtype=torch.bool, device=batch_next_token_ids.device
+            ),
+        )
 
     def _attach_sampling_mask_to_output(
         self,
@@ -412,8 +434,7 @@ class Sampler(nn.Module):
     ) -> None:
         return_sampling_masks = sampling_info.return_sampling_masks or []
         if not return_sampling_masks:
-            logits_output.next_token_sampling_mask_idx = []
-            logits_output.next_token_sampling_logprobs = []
+            logits_output.sampling_mask_output = None
             return
 
         requested_rows_list = [
@@ -435,13 +456,6 @@ class Sampler(nn.Module):
             -1, 1
         )
         if token_ids is None:
-            support_token_ids = (
-                torch.arange(
-                    weights.shape[-1], device=weights.device, dtype=torch.int32
-                )
-                .view(1, -1)
-                .expand_as(weights)
-            )
             selected_from_weights = torch.gather(
                 weights, 1, sampled_tokens.long()
             ).squeeze(1)
@@ -455,7 +469,6 @@ class Sampler(nn.Module):
             selected_from_weights = torch.gather(
                 weights, 1, selected_positions
             ).squeeze(1)
-            support_token_ids = token_ids
 
         if selected_weight is None:
             selected_weight = selected_from_weights
@@ -472,33 +485,57 @@ class Sampler(nn.Module):
             & (support_mass > 0)
             & torch.isfinite(selected_logprobs)
         )
-        if not bool(torch.all(valid).item()):
-            invalid_rows = (~valid).nonzero(as_tuple=True)[0].cpu().tolist()
-            raise RuntimeError(
-                "Sampled token is outside captured positive sampling support "
-                f"for batch rows {invalid_rows}."
-            )
-
-        flat_rows, flat_cols = support.nonzero(as_tuple=True)
-        flat_ids = support_token_ids[flat_rows, flat_cols].to(torch.int32)
         mask_lengths = support.sum(dim=-1, dtype=torch.int32)
 
-        flat_ids_cpu = flat_ids.cpu().tolist()
-        mask_lengths_cpu = mask_lengths.cpu().tolist()
-        selected_logprobs_cpu = selected_logprobs.cpu().tolist()
+        if token_ids is None:
+            padding = (-support.shape[-1]) % 8
+            if padding:
+                support = torch.cat(
+                    (
+                        support,
+                        torch.zeros(
+                            (support.shape[0], padding),
+                            dtype=torch.bool,
+                            device=support.device,
+                        ),
+                    ),
+                    dim=-1,
+                )
+            bit_weights = (
+                1 << torch.arange(8, device=support.device, dtype=torch.int16)
+            ).view(1, 1, 8)
+            support_bits = (
+                (support.view(support.shape[0], -1, 8).to(torch.int16) * bit_weights)
+                .sum(dim=-1, dtype=torch.int16)
+                .to(torch.uint8)
+            )
+            packed_token_ids = None
+        else:
+            packed_width = min(
+                getattr(
+                    sampling_info,
+                    "sampling_mask_max_top_k",
+                    token_ids.shape[-1],
+                ),
+                token_ids.shape[-1],
+            )
+            packed_token_ids = token_ids[:, :packed_width].contiguous()
+            support_bits = None
+            valid &= mask_lengths <= packed_width
 
-        masks = [None] * len(return_sampling_masks)
-        logprobs = [None] * len(return_sampling_masks)
-        cursor = 0
-        for capture_row, batch_row in enumerate(requested_rows_list):
-            mask_len = int(mask_lengths_cpu[capture_row])
-            row_ids = flat_ids_cpu[cursor : cursor + mask_len]
-            cursor += mask_len
-            masks[batch_row] = row_ids
-            logprobs[batch_row] = float(selected_logprobs_cpu[capture_row])
-
-        logits_output.next_token_sampling_mask_idx = masks
-        logits_output.next_token_sampling_logprobs = logprobs
+        logits_output.sampling_mask_output = SamplingMaskOutput(
+            batch_indices=requested_rows,
+            batch_size=torch.tensor(
+                len(return_sampling_masks),
+                dtype=torch.int32,
+                device=weights.device,
+            ),
+            token_ids=packed_token_ids,
+            support_bits=support_bits,
+            lengths=mask_lengths,
+            selected_logprobs=selected_logprobs,
+            valid=valid,
+        )
 
     def _sample_from_logprobs(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1062,6 +1062,14 @@ class SchedulerBatchResultProcessor:
         output: LogitsProcessorOutput,
     ) -> None:
         """Attach sparse sampling support metadata to the return values."""
+        if output.sampling_mask_output is not None:
+            (
+                output.next_token_sampling_mask_idx,
+                output.next_token_sampling_logprobs,
+            ) = output.sampling_mask_output.materialize()
+            output.next_token_sampling_mask_len = None
+            output.sampling_mask_output = None
+
         mask = output.next_token_sampling_mask_idx
         logprobs = output.next_token_sampling_logprobs
         req.output_token_sampling_mask.append(None if mask is None else mask[i])

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1027,11 +1027,15 @@ class SchedulerPPMixin:
             "next_token_ids": result.next_token_ids,
         }
 
-        if batch.return_logprob:
-            logprob_dict = get_logprob_dict_from_result(result)
+        has_sampling_mask_output = (
+            result.logits_output is not None
+            and result.logits_output.sampling_mask_output is not None
+        )
+        if batch.return_logprob or has_sampling_mask_output:
+            logits_output_dict = get_logprob_dict_from_result(result)
             tensor_dict = {
                 **tensor_dict,
-                **logprob_dict,
+                **logits_output_dict,
             }
         auxiliary_output = (
             result.logits_output.auxiliary_device_output
@@ -1157,7 +1161,10 @@ class SchedulerPPMixin:
         extend_input_len_per_req = None
         extend_logprob_start_len_per_req = None
 
-        if batch.return_logprob:
+        if (
+            batch.return_logprob
+            or pp_outputs.tensors.get("sampling_mask_batch_indices") is not None
+        ):
             (
                 logits_output,
                 extend_input_len_per_req,
@@ -1290,7 +1297,17 @@ class SchedulerPPMixin:
                     target, mb_metadata[next_mb_id], next_pp_outputs
                 )
                 d2h_event = self.device_module.Event()
-                d2h_event.record(self.device_module.current_stream())
+                if (
+                    batch_result.logits_output is not None
+                    and batch_result.logits_output.sampling_mask_output is not None
+                ):
+                    batch_result.copy_done = d2h_event
+                    batch_result.copy_to_cpu(
+                        return_logprob=target.return_logprob,
+                        return_hidden_states=False,
+                    )
+                else:
+                    d2h_event.record(self.device_module.current_stream())
 
         if send_first:
             send_output_work = _do_send()

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -270,9 +270,6 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
         "sampling_mask_token_ids": (
             None if sampling_mask_output is None else sampling_mask_output.token_ids
         ),
-        "sampling_mask_support_bits": (
-            None if sampling_mask_output is None else sampling_mask_output.support_bits
-        ),
         "sampling_mask_lengths": (
             None if sampling_mask_output is None else sampling_mask_output.lengths
         ),
@@ -301,7 +298,6 @@ def get_logprob_from_pp_outputs(
             batch_indices=next_pp_outputs["sampling_mask_batch_indices"],
             batch_size=next_pp_outputs["sampling_mask_batch_size"],
             token_ids=next_pp_outputs["sampling_mask_token_ids"],
-            support_bits=next_pp_outputs["sampling_mask_support_bits"],
             lengths=next_pp_outputs["sampling_mask_lengths"],
             selected_logprobs=next_pp_outputs["sampling_mask_selected_logprobs"],
             valid=next_pp_outputs["sampling_mask_valid"],

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -11,7 +11,10 @@ import torch
 
 from sglang.srt.constants import HEALTH_CHECK_RID_PREFIX
 from sglang.srt.eplb.expert_distribution import ExpertDistributionMetrics
-from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.logits_processor import (
+    LogitsProcessorOutput,
+    SamplingMaskOutput,
+)
 from sglang.srt.managers import io_struct
 from sglang.srt.managers.schedule_batch import Req
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
@@ -165,7 +168,13 @@ class GenerationBatchResult:
         # Sub-objects only declare their device fields; the single copy+safety
         # primitive (_async_d2h: pinned D2H + record_stream) is injected here so
         # all device->host copying and lifetime safety lives in one place.
+        sampling_mask_output = (
+            self.logits_output.sampling_mask_output
+            if self.logits_output is not None
+            else None
+        )
         for holder in (
+            sampling_mask_output,
             self.routed_experts_output,
             self.indexer_topk_output,
             self.expert_distribution_metrics,
@@ -240,6 +249,7 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
 
     logits_output = result.logits_output
     assert logits_output is not None
+    sampling_mask_output = logits_output.sampling_mask_output
 
     return {
         "extend_input_len_per_req": result.extend_input_len_per_req,
@@ -251,6 +261,29 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
         "next_token_token_ids_logprobs_idx": result.logits_output.next_token_token_ids_logprobs_idx,
         "next_token_sampling_mask_idx": result.logits_output.next_token_sampling_mask_idx,
         "next_token_sampling_logprobs": result.logits_output.next_token_sampling_logprobs,
+        "sampling_mask_batch_indices": (
+            None if sampling_mask_output is None else sampling_mask_output.batch_indices
+        ),
+        "sampling_mask_batch_size": (
+            None if sampling_mask_output is None else sampling_mask_output.batch_size
+        ),
+        "sampling_mask_token_ids": (
+            None if sampling_mask_output is None else sampling_mask_output.token_ids
+        ),
+        "sampling_mask_support_bits": (
+            None if sampling_mask_output is None else sampling_mask_output.support_bits
+        ),
+        "sampling_mask_lengths": (
+            None if sampling_mask_output is None else sampling_mask_output.lengths
+        ),
+        "sampling_mask_selected_logprobs": (
+            None
+            if sampling_mask_output is None
+            else sampling_mask_output.selected_logprobs
+        ),
+        "sampling_mask_valid": (
+            None if sampling_mask_output is None else sampling_mask_output.valid
+        ),
         "input_token_logprobs": result.logits_output.input_token_logprobs,
         "input_top_logprobs_val": result.logits_output.input_top_logprobs_val,
         "input_top_logprobs_idx": result.logits_output.input_top_logprobs_idx,
@@ -262,6 +295,17 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
 def get_logprob_from_pp_outputs(
     next_pp_outputs: PPProxyTensors,
 ) -> tuple[LogitsProcessorOutput, list[int], list[int]]:
+    sampling_mask_output = None
+    if next_pp_outputs["sampling_mask_batch_indices"] is not None:
+        sampling_mask_output = SamplingMaskOutput(
+            batch_indices=next_pp_outputs["sampling_mask_batch_indices"],
+            batch_size=next_pp_outputs["sampling_mask_batch_size"],
+            token_ids=next_pp_outputs["sampling_mask_token_ids"],
+            support_bits=next_pp_outputs["sampling_mask_support_bits"],
+            lengths=next_pp_outputs["sampling_mask_lengths"],
+            selected_logprobs=next_pp_outputs["sampling_mask_selected_logprobs"],
+            valid=next_pp_outputs["sampling_mask_valid"],
+        )
     logits_output = LogitsProcessorOutput(
         # Do not send logits and hidden states because they are large
         next_token_logits=None,
@@ -277,6 +321,7 @@ def get_logprob_from_pp_outputs(
         ],
         next_token_sampling_mask_idx=next_pp_outputs["next_token_sampling_mask_idx"],
         next_token_sampling_logprobs=next_pp_outputs["next_token_sampling_logprobs"],
+        sampling_mask_output=sampling_mask_output,
         input_token_logprobs=next_pp_outputs["input_token_logprobs"],
         input_top_logprobs_val=next_pp_outputs["input_top_logprobs_val"],
         input_top_logprobs_idx=next_pp_outputs["input_top_logprobs_idx"],

--- a/test/registered/sampling/test_sampling_mask.py
+++ b/test/registered/sampling/test_sampling_mask.py
@@ -19,6 +19,7 @@ register_amd_ci(est_time=320, suite="stage-b-test-1-gpu-small-amd")
 _MAX_NEW_TOKENS = 4
 _TOP_P = 0.99
 _TOP_K = 10
+_TOP_LOGPROBS_NUM = 128
 _SAMPLING_SEED = 1234
 _SERVER_ARGS = (
     "--mem-fraction-static",
@@ -79,6 +80,7 @@ class SamplingMaskTestMixin:
         self.assertEqual(len(sampling_masks), len(output_ids))
         for output_id, sampling_mask in zip(output_ids, sampling_masks):
             self.assertIn(output_id, sampling_mask)
+            self.assertEqual(len(sampling_mask), len(set(sampling_mask)))
         return sampling_masks
 
     def _assert_rejects_unbounded_sampling_mask(self, sampling_params):
@@ -88,6 +90,8 @@ class SamplingMaskTestMixin:
 
 
 class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
+    _sampling_backend = "flashinfer"
+
     @classmethod
     def setUpClass(cls):
         cls._launch_server()
@@ -102,12 +106,8 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
                 "ignore_eos": True,
             }
         )
-        # The mask keeps at most top_k tokens, plus possibly the actually
-        # sampled token when the sampling kernel picks one just outside the
-        # mask's topk reconstruction (fp cumsum divergence); see
-        # Sampler._attach_sampling_mask_to_output.
         for sampling_mask in top_p_sampling_masks:
-            self.assertLessEqual(len(sampling_mask), _TOP_K + 1)
+            self.assertGreater(len(sampling_mask), 0)
 
         top_k_sampling_masks = self._generate_sampling_masks(
             {
@@ -118,7 +118,7 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             }
         )
         for sampling_mask in top_k_sampling_masks:
-            self.assertIn(len(sampling_mask), (_TOP_K, _TOP_K + 1))
+            self.assertGreaterEqual(len(sampling_mask), _TOP_K)
 
         top_k_top_p_one_sampling_masks = self._generate_sampling_masks(
             {
@@ -130,15 +130,15 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
             }
         )
         for sampling_mask in top_k_top_p_one_sampling_masks:
-            self.assertIn(len(sampling_mask), (_TOP_K, _TOP_K + 1))
+            self.assertGreaterEqual(len(sampling_mask), _TOP_K)
 
     def test_sampling_mask_matches_topk_logprobs(self):
         """Check the returned mask and its renormalized logprobs.
 
-        We get the per-token full-vocab logprobs via ``return_logprob`` with
-        ``top_logprobs_num == top_k``, which covers every token the mask can
-        contain. With ``temperature=1.0`` these are the sampler's distribution,
-        so ``p = exp(logprob)`` are the exact probabilities. For each token, we check:
+        We get a wide prefix of full-vocab logprobs via ``return_logprob`` so
+        cutoff ties that extend beyond ``top_k`` are visible. With
+        ``temperature=1.0`` these are the sampler's distribution, so
+        ``p = exp(logprob)`` are the exact probabilities. For each token, we check:
 
         1. the returned mask matches the nucleus reconstructed from those probs,
         2. sampling_logprob == log(p[sampled] / sum(p[t] for t in mask)).
@@ -153,7 +153,7 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
                 "ignore_eos": True,
             },
             return_logprob=True,
-            top_logprobs_num=top_k,
+            top_logprobs_num=_TOP_LOGPROBS_NUM,
         )
         self.assertEqual(response.status_code, 200, response.text)
 
@@ -175,17 +175,25 @@ class TestSamplingMask(SamplingMaskTestMixin, CustomTestCase):
                 int(tid): math.exp(logprob) for logprob, tid, _ in step_top_logprobs
             }
 
-            reconstructed = []
             mass_before = 0.0
-            for logprob, tid, _ in step_top_logprobs:
-                if mass_before <= top_p:
-                    reconstructed.append(int(tid))
+            positional_support = []
+            for position, (logprob, tid, _) in enumerate(step_top_logprobs):
+                if position < top_k and mass_before <= top_p:
+                    positional_support.append((math.exp(logprob), int(tid)))
                 mass_before += math.exp(logprob)
-            if output_id not in reconstructed:
-                reconstructed.append(output_id)
-            # ``<= 1``: fp32 (server) and fp64 (here) cumsums may split on the
-            # single token straddling the top_p cut.
-            self.assertLessEqual(len(set(mask) ^ set(reconstructed)), 1)
+
+            if self._sampling_backend == "flashinfer":
+                # FlashInfer applies threshold filters, so cutoff ties survive.
+                cutoff = positional_support[-1][0]
+                reconstructed = {
+                    int(tid)
+                    for logprob, tid, _ in step_top_logprobs
+                    if math.exp(logprob) >= cutoff
+                }
+            else:
+                # PyTorch filters its sorted tensor by position.
+                reconstructed = {tid for _, tid in positional_support}
+            self.assertEqual(set(mask), reconstructed)
 
             support_mass = sum(probs[tid] for tid in mask)
             expected_logprob = math.log(probs[output_id] / support_mass)
@@ -278,6 +286,14 @@ class TestSamplingMaskDeterministic(SamplingMaskTestMixin, CustomTestCase):
             with_mask_output["output_ids"], without_mask_output["output_ids"]
         )
         self.assertEqual(with_mask_output["text"], without_mask_output["text"])
+
+
+class TestSamplingMaskPytorch(TestSamplingMask):
+    _sampling_backend = "pytorch"
+
+    @classmethod
+    def setUpClass(cls):
+        cls._launch_server(("--sampling-backend", "pytorch"))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/sampling/test_sampler_sampling_mask.py
+++ b/test/registered/unit/sampling/test_sampler_sampling_mask.py
@@ -1,0 +1,262 @@
+"""Focused tests for faithful sampling-mask capture."""
+
+import math
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.sampler import (
+    Sampler,
+    _SamplingMaskCapture,
+    top_k_top_p_min_p_sampling_from_probs_torch,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=90, stage="base-b", runner_config="1-gpu-small")
+
+
+def _pytorch_support_oracle(probs, top_k, top_p, min_p=0.0):
+    sorted_probs, sorted_ids = probs.sort(descending=True)
+    mass_before = sorted_probs.cumsum(dim=-1) - sorted_probs
+    positions = torch.arange(probs.numel(), device=probs.device)
+    keep = (positions < top_k) & (mass_before <= top_p)
+    keep &= sorted_probs >= sorted_probs[0] * min_p
+    return set(sorted_ids[keep].tolist())
+
+
+class TestSamplingMaskCapture(CustomTestCase):
+    def setUp(self):
+        self.sampler = Sampler.__new__(Sampler)
+        torch.nn.Module.__init__(self.sampler)
+
+    def _attach(self, weights, sampled_tokens, token_ids=None, selected_weight=None):
+        output = LogitsProcessorOutput(next_token_logits=None)
+        sampling_info = SimpleNamespace(return_sampling_masks=[True] * weights.shape[0])
+        self.sampler._attach_sampling_mask_to_output(
+            output,
+            sampling_info,
+            torch.tensor(sampled_tokens, device=weights.device),
+            _SamplingMaskCapture(weights, token_ids, selected_weight),
+        )
+        return output
+
+    def test_strict_positive_support_and_exact_selected_logprob(self):
+        weights = torch.tensor([[0.4, 0.3, 0.2, 0.0]], device="cuda")
+        output = self._attach(weights, sampled_tokens=[1])
+
+        self.assertEqual(set(output.next_token_sampling_mask_idx[0]), {0, 1, 2})
+        self.assertAlmostEqual(
+            output.next_token_sampling_logprobs[0], math.log(0.3 / 0.9), places=6
+        )
+
+    def test_token_permutation_maps_support_and_selected_weight(self):
+        weights = torch.tensor([[0.7, 0.3, 0.0]], device="cuda")
+        token_ids = torch.tensor([[3, 1, 2]], dtype=torch.int32, device="cuda")
+        output = self._attach(
+            weights,
+            sampled_tokens=[1],
+            token_ids=token_ids,
+            selected_weight=torch.tensor([0.3], device="cuda"),
+        )
+
+        self.assertEqual(set(output.next_token_sampling_mask_idx[0]), {1, 3})
+        self.assertAlmostEqual(
+            output.next_token_sampling_logprobs[0], math.log(0.3), places=6
+        )
+
+    def test_sampled_token_outside_support_is_invariant_failure(self):
+        weights = torch.tensor([[0.6, 0.4, 0.0]], device="cuda")
+        with self.assertRaisesRegex(RuntimeError, "outside captured positive"):
+            self._attach(weights, sampled_tokens=[2])
+
+    def test_only_requested_rows_are_materialized_and_validated(self):
+        output = LogitsProcessorOutput(next_token_logits=None)
+        sampling_info = SimpleNamespace(return_sampling_masks=[True, False])
+        self.sampler._attach_sampling_mask_to_output(
+            output,
+            sampling_info,
+            torch.tensor([0, 2], device="cuda"),
+            _SamplingMaskCapture(
+                weights=torch.tensor([[0.6, 0.4, 0.0], [0.0, 0.0, 0.0]], device="cuda"),
+                token_ids=None,
+                selected_weight=None,
+            ),
+        )
+
+        self.assertEqual(set(output.next_token_sampling_mask_idx[0]), {0, 1})
+        self.assertIsNone(output.next_token_sampling_mask_idx[1])
+        self.assertIsNone(output.next_token_sampling_logprobs[1])
+
+    def test_greedy_support_is_sampled_token_singleton(self):
+        output = LogitsProcessorOutput(next_token_logits=None)
+        self.sampler._attach_greedy_sampling_mask_to_output(
+            output,
+            SimpleNamespace(return_sampling_masks=[True, False, True]),
+            torch.tensor([4, 5, 6], device="cuda"),
+        )
+
+        self.assertEqual(output.next_token_sampling_mask_idx, [[4], None, [6]])
+        self.assertEqual(output.next_token_sampling_logprobs, [0.0, None, 0.0])
+
+    def test_pytorch_capture_matches_independent_oracle(self):
+        for top_k, top_p, min_p in ((4, 0.72, 0.0), (4, 1.0, 0.4)):
+            with self.subTest(top_k=top_k, top_p=top_p, min_p=min_p):
+                probs = torch.tensor([[0.40, 0.25, 0.15, 0.12, 0.08]], device="cuda")
+                sampled, filtered, token_ids, selected_weight = (
+                    top_k_top_p_min_p_sampling_from_probs_torch(
+                        probs,
+                        top_ks=torch.tensor([top_k], device="cuda"),
+                        top_ps=torch.tensor([top_p], device="cuda"),
+                        min_ps=torch.tensor([min_p], device="cuda"),
+                        need_min_p_sampling=min_p > 0,
+                        sampling_seed=None,
+                        positions=torch.tensor([0], device="cuda"),
+                        return_filtered_probs=True,
+                    )
+                )
+
+                actual_support = set(token_ids[filtered > 0].tolist())
+                expected_support = _pytorch_support_oracle(
+                    probs[0], top_k, top_p, min_p
+                )
+                self.assertEqual(actual_support, expected_support)
+                self.assertIn(int(sampled[0]), actual_support)
+                selected_position = (token_ids[0] == sampled[0]).nonzero()[0]
+                self.assertEqual(
+                    float(selected_weight[0]), float(filtered[0, selected_position])
+                )
+
+    def test_seeded_pytorch_capture_does_not_change_sample(self):
+        probs = torch.tensor([[0.40, 0.25, 0.15, 0.12, 0.08]], device="cuda")
+        args = dict(
+            probs=probs,
+            top_ks=torch.tensor([4], device="cuda"),
+            top_ps=torch.tensor([0.9], device="cuda"),
+            min_ps=torch.tensor([0.0], device="cuda"),
+            need_min_p_sampling=False,
+            sampling_seed=torch.tensor([1234], device="cuda"),
+            positions=torch.tensor([7], device="cuda"),
+        )
+
+        without_capture = top_k_top_p_min_p_sampling_from_probs_torch(**args)
+        with_capture, filtered, token_ids, selected_weight = (
+            top_k_top_p_min_p_sampling_from_probs_torch(
+                **args, return_filtered_probs=True
+            )
+        )
+
+        self.assertTrue(torch.equal(without_capture, with_capture))
+        self.assertGreater(int(torch.count_nonzero(filtered)), 0)
+        self.assertIn(int(with_capture[0]), token_ids[filtered > 0].tolist())
+        self.assertGreater(float(selected_weight[0]), 0)
+
+    def _flashinfer_sampling_info(self, *, top_k, top_p, min_p=0.0):
+        return SimpleNamespace(
+            sampling_seed=None,
+            need_top_k_sampling=top_k > 0,
+            need_top_p_sampling=top_p < 1.0,
+            need_min_p_sampling=min_p > 0,
+            top_ks=torch.tensor([top_k], device="cuda"),
+            top_ps=torch.tensor([top_p], device="cuda"),
+            min_ps=torch.tensor([min_p], device="cuda"),
+        )
+
+    def _sample_flashinfer(self, probs, sampling_info):
+        with patch(
+            "sglang.srt.layers.sampler.get_exec",
+            return_value=SimpleNamespace(
+                kernel=SimpleNamespace(sampling_backend="flashinfer")
+            ),
+        ):
+            return self.sampler._sample_from_probs(
+                probs,
+                sampling_info,
+                positions=torch.tensor([0], device="cuda"),
+                simple_sampling_case=False,
+                return_sampling_mask=True,
+            )
+
+    def test_flashinfer_joint_capture_matches_independent_oracle(self):
+        probs = torch.tensor([[0.40, 0.30, 0.20, 0.10]], device="cuda")
+        sampled, capture = self._sample_flashinfer(
+            probs, self._flashinfer_sampling_info(top_k=3, top_p=0.75)
+        )
+
+        actual_support = set((capture.weights[0] > 0).nonzero().view(-1).tolist())
+        self.assertEqual(actual_support, {0, 1, 2})
+        self.assertIn(int(sampled[0]), actual_support)
+        output = self._attach(
+            capture.weights, sampled.tolist(), selected_weight=capture.selected_weight
+        )
+        expected = math.log(
+            float(capture.selected_weight[0]) / float(capture.weights.sum())
+        )
+        self.assertAlmostEqual(
+            output.next_token_sampling_logprobs[0], expected, places=6
+        )
+
+    def test_flashinfer_min_p_capture_matches_sequential_oracle(self):
+        probs = torch.tensor([[0.50, 0.25, 0.15, 0.10]], device="cuda")
+        sampled, capture = self._sample_flashinfer(
+            probs, self._flashinfer_sampling_info(top_k=4, top_p=1.0, min_p=0.4)
+        )
+
+        actual_support = set((capture.weights[0] > 0).nonzero().view(-1).tolist())
+        self.assertEqual(actual_support, {0, 1})
+        self.assertIn(int(sampled[0]), actual_support)
+
+    def test_flashinfer_top_k_cutoff_ties_are_captured_faithfully(self):
+        probs = torch.tensor([[0.40, 0.20, 0.20, 0.20]], device="cuda")
+        sampled, capture = self._sample_flashinfer(
+            probs, self._flashinfer_sampling_info(top_k=2, top_p=1.0)
+        )
+
+        support = (capture.weights[0] > 0).nonzero().view(-1).tolist()
+        self.assertEqual(set(support), {0, 1, 2, 3})
+        self.assertGreater(len(support), 2)
+        self.assertIn(int(sampled[0]), support)
+
+    def test_capture_off_returns_no_data(self):
+        probs = torch.tensor([[0.40, 0.30, 0.20, 0.10]], device="cuda")
+        sampling_info = SimpleNamespace(
+            sampling_seed=torch.tensor([99], device="cuda"),
+            need_top_k_sampling=True,
+            need_top_p_sampling=True,
+            need_min_p_sampling=False,
+            top_ks=torch.tensor([3], device="cuda"),
+            top_ps=torch.tensor([0.9], device="cuda"),
+            min_ps=torch.tensor([0.0], device="cuda"),
+        )
+        with patch(
+            "sglang.srt.layers.sampler.get_exec",
+            return_value=SimpleNamespace(
+                kernel=SimpleNamespace(sampling_backend="pytorch")
+            ),
+        ):
+            without_mask, no_capture = self.sampler._sample_from_probs(
+                probs,
+                sampling_info,
+                positions=torch.tensor([3], device="cuda"),
+                simple_sampling_case=False,
+                return_sampling_mask=False,
+            )
+            with_mask, capture = self.sampler._sample_from_probs(
+                probs,
+                sampling_info,
+                positions=torch.tensor([3], device="cuda"),
+                simple_sampling_case=False,
+                return_sampling_mask=True,
+            )
+
+        self.assertIsNone(no_capture)
+        self.assertIsNotNone(capture)
+        self.assertTrue(torch.equal(without_mask, with_mask))
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()

--- a/test/registered/unit/sampling/test_sampler_sampling_mask.py
+++ b/test/registered/unit/sampling/test_sampler_sampling_mask.py
@@ -8,6 +8,7 @@ import torch
 
 from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.layers.sampler import (
+    SAMPLING_MASK_TIE_BUFFER,
     Sampler,
     _SamplingMaskCapture,
     top_k_top_p_min_p_sampling_from_probs_torch,
@@ -270,6 +271,46 @@ class TestSamplingMaskCapture(CustomTestCase):
         self.assertIsNone(no_capture)
         self.assertIsNotNone(capture)
         self.assertTrue(torch.equal(without_mask, with_mask))
+
+    def test_sampling_mask_reserves_space_for_cutoff_ties(self):
+        top_k = 2
+        capacity = top_k + SAMPLING_MASK_TIE_BUFFER
+        weights = torch.zeros((1, capacity + 2), device="cuda")
+        weights[0, :capacity] = 1.0
+        sampling_info = SimpleNamespace(
+            return_sampling_masks=[True], sampling_mask_max_top_k=top_k
+        )
+        output = LogitsProcessorOutput(next_token_logits=None)
+
+        self.sampler._attach_sampling_mask_to_output(
+            output,
+            sampling_info,
+            torch.tensor([capacity - 1], device="cuda"),
+            _SamplingMaskCapture(weights, None, None),
+        )
+
+        self.assertEqual(output.sampling_mask_output.token_ids.shape, (1, capacity))
+        masks, _ = output.sampling_mask_output.materialize()
+        self.assertEqual(set(masks[0]), set(range(capacity)))
+
+    def test_sampling_mask_rejects_tie_buffer_overflow(self):
+        top_k = 2
+        capacity = top_k + SAMPLING_MASK_TIE_BUFFER
+        weights = torch.ones((1, capacity + 1), device="cuda")
+        sampling_info = SimpleNamespace(
+            return_sampling_masks=[True], sampling_mask_max_top_k=top_k
+        )
+        output = LogitsProcessorOutput(next_token_logits=None)
+
+        self.sampler._attach_sampling_mask_to_output(
+            output,
+            sampling_info,
+            torch.tensor([0], device="cuda"),
+            _SamplingMaskCapture(weights, None, None),
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "exceeds its packed token storage"):
+            output.sampling_mask_output.materialize()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/sampling/test_sampler_sampling_mask.py
+++ b/test/registered/unit/sampling/test_sampler_sampling_mask.py
@@ -41,6 +41,10 @@ class TestSamplingMaskCapture(CustomTestCase):
             torch.tensor(sampled_tokens, device=weights.device),
             _SamplingMaskCapture(weights, token_ids, selected_weight),
         )
+        (
+            output.next_token_sampling_mask_idx,
+            output.next_token_sampling_logprobs,
+        ) = output.sampling_mask_output.materialize()
         return output
 
     def test_strict_positive_support_and_exact_selected_logprob(self):
@@ -85,6 +89,10 @@ class TestSamplingMaskCapture(CustomTestCase):
                 selected_weight=None,
             ),
         )
+        (
+            output.next_token_sampling_mask_idx,
+            output.next_token_sampling_logprobs,
+        ) = output.sampling_mask_output.materialize()
 
         self.assertEqual(set(output.next_token_sampling_mask_idx[0]), {0, 1})
         self.assertIsNone(output.next_token_sampling_mask_idx[1])
@@ -97,6 +105,10 @@ class TestSamplingMaskCapture(CustomTestCase):
             SimpleNamespace(return_sampling_masks=[True, False, True]),
             torch.tensor([4, 5, 6], device="cuda"),
         )
+        (
+            output.next_token_sampling_mask_idx,
+            output.next_token_sampling_logprobs,
+        ) = output.sampling_mask_output.materialize()
 
         self.assertEqual(output.next_token_sampling_mask_idx, [[4], None, [6]])
         self.assertEqual(output.next_token_sampling_logprobs, [0.0, None, 0.0])
@@ -218,6 +230,10 @@ class TestSamplingMaskCapture(CustomTestCase):
         self.assertEqual(set(support), {0, 1, 2, 3})
         self.assertGreater(len(support), 2)
         self.assertIn(int(sampled[0]), support)
+        output = self._attach(
+            capture.weights, sampled.tolist(), selected_weight=capture.selected_weight
+        )
+        self.assertEqual(set(output.next_token_sampling_mask_idx[0]), {0, 1, 2, 3})
 
     def test_capture_off_returns_no_data(self):
         probs = torch.tensor([[0.40, 0.30, 0.20, 0.10]], device="cuda")


### PR DESCRIPTION
This follows #35966. That change captures the actual filtered sampling support, but materializes the ragged support as CPU lists inside `Sampler.forward`. Determining the output size and copying it to the CPU synchronizes the GPU during every decode step for requests using `return_sampling_mask`.

This PR keeps that support tensor-backed through `GenerationBatchResult`. It packs token IDs into a bounded `top_k + 128` tensor, copies the tensor and its lengths on the existing asynchronous device-to-host stream, and creates the request-facing Python lists later in scheduler result processing. The extra capacity preserves FlashInfer cutoff ties, and overflow fails explicitly instead of silently truncating support.

Depends on #35966. The first commit in this draft is the current #35966 commit and will be dropped after that PR merges.

## Summary

- add a tensor-backed `SamplingMaskOutput` with delayed CPU materialization
- pack filtered support into bounded token-ID tensors without a decode-path host synchronization
- carry sampling-mask tensors through pipeline-parallel results and the existing asynchronous copy path
- add CUDA coverage for greedy, dense, sparse, tied-cutoff, and overflow cases

## Verification

- Qwen 3.5 35B, 32 rollout GPUs, routing replay and `--keep-sampling-mask`: [regression run](https://wandb.ai/harmonic/lean_sorry_closer_agent_qwen3_5_35B/runs/s97yyx5f)
- comparable steady-state decode samples: 1289 generated tokens/s per engine for this change versus 1299 for the [control](https://wandb.ai/harmonic/lean_sorry_closer_agent_qwen3_5_35B/runs/6808zvtx), a 0.8% difference
- mean forward occupancy: 81.1% for this change versus 79.8% for the control
- zero post-start retry or rollout-data failure lines observed
- `ruff` checks configured by the repository, `isort --check-only`, `black --check`, `compileall`, and `git diff --check` pass

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32982572641](https://github.com/sgl-project/sglang/actions/runs/32982572641)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32982571682](https://github.com/sgl-project/sglang/actions/runs/32982571682)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32982572024](https://github.com/sgl-project/sglang/actions/runs/32982572024)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->