### PR TITLE
fix(hicache): isolate overlapping NIXL path registrations

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/nixl_registry.py
@@ -51,6 +51,11 @@ class NixlRegistry:
         # from a single monotonic counter.
         self._obj_devid_lock = threading.Lock()
         self._obj_devid_next = 1
+        # Path-mode FILE registrations are also keyed by caller-supplied
+        # devId, so overlapping backup and prefetch registrations need
+        # disjoint ranges as well.
+        self._file_devid_lock = threading.Lock()
+        self._file_devid_next = 1
         self.path_mode = mem_type == "FILE" and self._probe_path_mode()
         if mem_type == "FILE" and self.path_mode:
             logger.info("HiCacheNixl: path-mode FILE registration active.")
@@ -130,6 +135,12 @@ class NixlRegistry:
         except Exception:
             return True
 
+    def _allocate_file_dev_ids(self, count: int) -> range:
+        with self._file_devid_lock:
+            base = self._file_devid_next
+            self._file_devid_next += count
+        return range(base, base + count)
+
     @contextmanager
     def storage(self, buffers, keys, direction):
         """Open + register the storage side; deregister and close fds on exit.
@@ -148,8 +159,10 @@ class NixlRegistry:
                 if self.file_manager.use_direct_io:
                     parts.append("direct")
                 spec = ",".join(parts)
+                dev_ids = self._allocate_file_dev_ids(len(keys))
                 tuples = [
-                    (0, sizes[i], i + 1, f"{spec}:{keys[i]}") for i in range(len(keys))
+                    (0, sizes[i], dev_id, f"{spec}:{keys[i]}")
+                    for i, dev_id in enumerate(dev_ids)
                 ]
                 with self._registered(tuples, "FILE") as reg:
                     if reg is None:

--- a/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
@@ -11,6 +11,7 @@ import subprocess
 import tempfile
 import time
 import unittest
+from contextlib import contextmanager
 
 import torch
 
@@ -331,6 +332,60 @@ class TestNixlUnified(CustomTestCase):
             fds_before,
             "fd leak after register_memory failure mid-storage",
         )
+
+    def test_path_mode_dev_ids_are_disjoint_across_overlapping_contexts(self):
+        registry = self.hicache.registry
+        if not registry.path_mode:
+            self.skipTest("installed NIXL does not support path-mode FILE registration")
+
+        captured = []
+        original_registered = registry._registered
+
+        class _FakeRegistration:
+            def trim(self):
+                return self
+
+        @contextmanager
+        def capture_registered(items, mem_type):
+            captured.append([item[2] for item in items])
+            yield _FakeRegistration()
+
+        registry._registered = capture_registered
+        try:
+            with registry.storage([(0, 64), (0, 64)], ["first-a", "first-b"], "WRITE"):
+                with registry.storage(
+                    [(0, 64), (0, 64)], ["second-a", "second-b"], "WRITE"
+                ):
+                    pass
+        finally:
+            registry._registered = original_registered
+
+        self.assertEqual(len(captured), 2)
+        self.assertEqual(len(captured[0]), len(set(captured[0])))
+        self.assertEqual(len(captured[1]), len(set(captured[1])))
+        self.assertTrue(set(captured[0]).isdisjoint(captured[1]))
+
+    def test_overlapping_path_mode_registrations_succeed(self):
+        registry = self.hicache.registry
+        if not registry.path_mode:
+            self.skipTest("installed NIXL does not support path-mode FILE registration")
+
+        first_paths = [
+            os.path.join(self.test_dir, "first-a"),
+            os.path.join(self.test_dir, "first-b"),
+        ]
+        second_paths = [
+            os.path.join(self.test_dir, "second-a"),
+            os.path.join(self.test_dir, "second-b"),
+        ]
+
+        # Keep the first registration active while opening the second one.
+        # Newer NIXL rejects active devId collisions; older supported versions
+        # accept them but cannot unambiguously associate both paths with one ID.
+        with registry.storage([(0, 64), (0, 64)], first_paths, "WRITE") as first:
+            self.assertIsNotNone(first)
+            with registry.storage([(0, 64), (0, 64)], second_paths, "WRITE") as second:
+                self.assertIsNotNone(second)
 
     def _assert_host_addrs_pre_registered(
         self, is_zero_copy_mode: bool, hicache: HiCacheNixl = None


### PR DESCRIPTION
## Motivation

NIXL path-mode FILE registrations are keyed by caller-supplied `devId`. SGLang currently assigns `1..N` independently inside every `NixlRegistry.storage()` call.

HiCache backup and prefetch use separate threads, so their storage contexts can overlap. Two different FILE registrations can then present the same device IDs while the first registration is still active. NIXL 1.3.2 and newer reject the duplicate active IDs. The NIXL 1.3.0 version currently pinned by SGLang CI accepts them, but path lookup and cleanup are ambiguous because both registrations use the same IDs.

Device IDs therefore need to be unique across simultaneously active storage contexts, including on the older supported NIXL release that does not reject the collision.

## Modification

- Add a locked monotonic device-ID allocator for path-mode FILE registrations, following the existing OBJ allocation pattern without changing the OBJ path.
- Add a deterministic cross-version regression that models overlapping backup/prefetch registration lifetimes and verifies disjoint ID ranges.
- Add a real nested path-mode registration test for the supported backend integration.

Legacy fd-mode FILE registration is unchanged.

## Validation

- Negative control on unmodified upstream: the device-ID invariant regression fails because both storage contexts start at IDs `[1, 2]`.
- Patched targeted regressions: `2 passed`.
- Complete NIXL HiCache storage unit file: `23 passed, 1 skipped` (backend-dependent OBJ fixture).

This changes registration metadata only; it does not alter cache keys, file layout, transfer sizes, or inference kernels.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #32985580018](https://github.com/sgl-project/sglang/actions/runs/32985580018)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #32985580012](https://github.com/sgl-project/sglang/actions/runs/32985580012)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->