### PR TITLE
Triton attention: wider decode KV tile on ROCm and a 2D-grid kv_indices fill

### DIFF
--- a/python/sglang/kernels/ops/attention/decode_attention.py
+++ b/python/sglang/kernels/ops/attention/decode_attention.py
@@ -654,11 +654,19 @@ def _fwd_grouped_kernel_stage1(
             qpe = tl.load(
                 Q + off_qpe, mask=(mask_h[:, None]) & (mask_dpe[None, :]), other=0.0
             )
+        offs_n = split_kv_start + tl.arange(0, BLOCK_N)
+        kv_loc_next = tl.load(
+            kv_indices + cur_batch_kv_start_idx + offs_n,
+            mask=offs_n < split_kv_end,
+            other=0,
+        )
         for start_n in tl.range(split_kv_start, split_kv_end, BLOCK_N):
             offs_n = start_n + tl.arange(0, BLOCK_N)
-            kv_loc = tl.load(
-                kv_indices + cur_batch_kv_start_idx + offs_n,
-                mask=offs_n < split_kv_end,
+            kv_loc = kv_loc_next
+            offs_n_next = offs_n + BLOCK_N
+            kv_loc_next = tl.load(
+                kv_indices + cur_batch_kv_start_idx + offs_n_next,
+                mask=offs_n_next < split_kv_end,
                 other=0,
             )
             # Page-aware KV address math (see _fwd_kernel_stage1).
@@ -799,8 +807,8 @@ def _decode_grouped_att_m_fwd(
     Lv = v_buffer.shape[-1]
 
     # [TODO] work around shmem limit on MI3xx
-    if _is_hip and Lk >= 576:
-        BLOCK = 16
+    if _is_hip:
+        BLOCK = 16 if Lk >= 576 else (64 if Lk <= 128 else 32)
 
     if Lk == 576:
         BLOCK_DMODEL = 512
@@ -830,7 +838,7 @@ def _decode_grouped_att_m_fwd(
         # https://rocm.docs.amd.com/en/docs-6.2.0/how-to/llm-fine-tuning-optimization/optimizing-triton-kernel.html
         # https://github.com/triton-lang/triton/blob/main/third_party/amd/backend/compiler.py
         extra_kargs = {"waves_per_eu": 1, "matrix_instr_nonkdim": 16, "kpack": 2}
-        num_stages = 1
+        num_stages = 2 if Lk <= 128 else 1
 
     if tune_mla:
         # num_warps reorders the fp32 accumulation, so whoever declined the batch-wide

--- a/python/sglang/kernels/ops/kvcache/kv_indices.py
+++ b/python/sglang/kernels/ops/kvcache/kv_indices.py
@@ -5,6 +5,11 @@ _FLASHMLA_CREATE_KV_BLOCK_SIZE = 4096
 FLASHMLA_CREATE_KV_BLOCK_SIZE_TRITON = tl.constexpr(_FLASHMLA_CREATE_KV_BLOCK_SIZE)
 
 
+# Tokens copied per CTA when the caller opts into a 2D grid (axis 1 spans the
+# sequence). Must be a multiple of the 512-token vector width below.
+KV_INDICES_CTA_SPAN = 4096
+
+
 @triton.jit
 def create_flashinfer_kv_indices_triton(
     req_to_token_ptr,  # [max_batch, max_context_len]
@@ -14,6 +19,7 @@ def create_flashinfer_kv_indices_triton(
     kv_start_idx,
     kv_indices_ptr,
     req_to_token_ptr_stride: tl.constexpr,
+    ONE_CTA_PER_SPAN: tl.constexpr = False,
 ):
     BLOCK_SIZE: tl.constexpr = 512
     pid = tl.program_id(axis=0)
@@ -29,19 +35,42 @@ def create_flashinfer_kv_indices_triton(
         kv_end = kv_start
     kv_end += tl.load(page_kernel_lens_ptr + pid).to(tl.int32)
 
-    num_loop = tl.cdiv(kv_end - kv_start, BLOCK_SIZE)
-    for i in range(num_loop):
-        # index into req_to_token_ptr needs to be int64
-        offset = tl.arange(0, BLOCK_SIZE).to(tl.int64) + i * BLOCK_SIZE
-        mask = offset < kv_end - kv_start
-        data = tl.load(
-            req_to_token_ptr
-            + req_pool_index * req_to_token_ptr_stride
-            + kv_start
-            + offset,
-            mask=mask,
-        )
-        tl.store(kv_indices_ptr + kv_indices_offset + offset, data, mask=mask)
+    if ONE_CTA_PER_SPAN:
+        # 2D grid: axis 1 CTAs each copy one 4096-token span of this request.
+        # Grid axis 1 is sized for the max context (graph-safe static grid);
+        # CTAs past this sequence's span count exit at the guard.
+        SPAN: tl.constexpr = 4096
+        span = tl.program_id(axis=1)
+        span_start = span * SPAN
+        seq_len = kv_end - kv_start
+        if span_start < seq_len:
+            for j in range(SPAN // BLOCK_SIZE):
+                offset = (
+                    tl.arange(0, BLOCK_SIZE).to(tl.int64) + span_start + j * BLOCK_SIZE
+                )
+                mask = offset < seq_len
+                data = tl.load(
+                    req_to_token_ptr
+                    + req_pool_index * req_to_token_ptr_stride
+                    + kv_start
+                    + offset,
+                    mask=mask,
+                )
+                tl.store(kv_indices_ptr + kv_indices_offset + offset, data, mask=mask)
+    else:
+        num_loop = tl.cdiv(kv_end - kv_start, BLOCK_SIZE)
+        for i in range(num_loop):
+            # index into req_to_token_ptr needs to be int64
+            offset = tl.arange(0, BLOCK_SIZE).to(tl.int64) + i * BLOCK_SIZE
+            mask = offset < kv_end - kv_start
+            data = tl.load(
+                req_to_token_ptr
+                + req_pool_index * req_to_token_ptr_stride
+                + kv_start
+                + offset,
+                mask=mask,
+            )
+            tl.store(kv_indices_ptr + kv_indices_offset + offset, data, mask=mask)
 
 
 @triton.jit

--- a/python/sglang/srt/layers/attention/triton_backend.py
+++ b/python/sglang/srt/layers/attention/triton_backend.py
@@ -8,6 +8,7 @@ import triton
 
 from sglang.kernels.ops.attention.metadata import get_num_kv_splits_triton
 from sglang.kernels.ops.kvcache.kv_indices import (
+    KV_INDICES_CTA_SPAN,
     create_flashinfer_kv_indices_triton,
 )
 from sglang.srt.configs.hybrid_arch import mambaish_config
@@ -449,7 +450,11 @@ class TritonAttnBackend(AttentionBackend):
     ) -> torch.Tensor:
         kv_indptr = self.kv_indptr[: bs + 1]
         kv_indptr[1:] = torch.cumsum(seq_lens, dim=0)
-        create_flashinfer_kv_indices_triton[(bs,)](
+        # 2D grid: one CTA per 4096-token span instead of one CTA looping the
+        # whole sequence. Axis 1 is sized for max context so the grid is static
+        # under graph capture; out-of-range CTAs exit at the kernel guard.
+        num_spans = triton.cdiv(self.max_context_len, KV_INDICES_CTA_SPAN)
+        create_flashinfer_kv_indices_triton[(bs, num_spans)](
             self.req_to_token,
             req_pool_indices,
             seq_lens,
@@ -457,6 +462,7 @@ class TritonAttnBackend(AttentionBackend):
             None,
             kv_indices,
             self.req_to_token.stride(0),
+            ONE_CTA_PER_SPAN=True,
         )
         return kv_indptr
 


### PR DESCRIPTION
# Triton attention: wider decode KV tile on ROCm and a 2D-grid kv_indices fill

Two independent, generic wins on the Triton attention backend — they help any model that runs on it, not just MiniMax-M3. First, the grouped decode-attention kernel (`_decode_grouped_att_m_fwd`) gets a KV tile of 64 instead of 32 and `num_stages` 2 instead of 1 on ROCm, for head dims `Lk <= 128` only; the larger head dims (288, 576) already sit at the MI3xx shmem ceiling, so they keep the existing tile and single stage. The same kernel now hoists the `kv_indices` load for the next KV tile one iteration ahead, so the index fetch overlaps the current tile's MMA. Second, `create_flashinfer_kv_indices_triton` gains an opt-in `ONE_CTA_PER_SPAN` mode that launches one CTA per 4096-token span (`KV_INDICES_CTA_SPAN`) instead of one CTA looping the whole sequence, so a long-context index fill gets parallelism along the sequence and not only across the batch. Grid axis 1 is sized from max context so the grid stays static under CUDA-graph capture, and CTAs past a given sequence's span count exit at the kernel's guard. Only the Triton backend's `_fill_kv_indptr_and_indices` opts in — every other call site of the kernel keeps the 1D grid through the default `ONE_CTA_PER_SPAN=False`.

## Performance
Measured on 8x MI350X (gfx950), MiniMax-M3-MXFP8, TP8, 80k input / 600 output.
Two bench reps per boot; the warm (second) rep is reported and the two agreed
within 0.1%. Noise floor is +/-0.4%. Tables are the harness output verbatim,
trimmed to the first five columns. Baseline is `upstream/main`.
**Baseline (`upstream/main`)**

```
Input lens: [80000]. Output lens: [600]. Cache hit rate: 90.0%.
|   batch size |   input len |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) |
|--------------|-------------|---------------|----------------------------|-----------------------------|
|            1 |       80000 |         11.26 |                     187984 |                       55.35 |
|            2 |       80000 |         11.88 |                     191222 |                      108.68 |
|            4 |       80000 |         13.39 |                     192965 |                      204.62 |
|            8 |       80000 |         16.27 |                     193687 |                      370.13 |
|           16 |       80000 |         22.2  |                     193188 |                      616.28 |
|           32 |       80000 |         33.78 |                     193245 |                      934.92 |
```
**With this PR**

```
Input lens: [80000]. Output lens: [600]. Cache hit rate: 90.0%.
|   batch size |   input len |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) |
|--------------|-------------|---------------|----------------------------|-----------------------------|
|            1 |       80000 |         10.83 |                     187663 |                       57.65 |
|            2 |       80000 |         11.43 |                     191929 |                      113.2  |
|            4 |       80000 |         12.95 |                     193258 |                      212.47 |
|            8 |       80000 |         15.81 |                     193638 |                      383.74 |
|           16 |       80000 |         21.69 |                     193948 |                      635.98 |
|           32 |       80000 |         32.83 |                     194308 |                      977.01 |
```
Output throughput +3.20%..+4.50%; input throughput -0.17%..+0.55%.

## Accuracy
gsm8k, 512 examples, `max_tokens 2048`, `temperature 0`, `seed 0`, against the
same server boot as the perf run.
**Baseline**

```
== gsm8k ==
512 examples (single-shot)  |  109.0s  |  1338 tok/s  |  146K tokens

* score           =  97.07%
  stop_rate       =  98.44%
  truncated_rate  =  1.56%  [warn: hitting max_tokens]
  error_rate      =  0.00%
```
**With this PR**

```
== gsm8k ==
512 examples (single-shot)  |  107.6s  |  1362 tok/s  |  146K tokens

* score           =  97.27%
  stop_rate       =  98.24%
  truncated_rate  =  1.76%  [warn: hitting max_tokens]
  error_rate      =  0.00%
```

## Note on the launch command

`--moe-runner-backend aiter` is **not honoured on current `main`** for mxfp8. Arg resolution logs:

```
mxfp8 quantization supports only cutlass, deep_gemm, flashinfer_trtllm,
flashinfer_trtllm_routed, triton backends. Overriding 'aiter'.
```

and falls back to **triton**. Both sides of this A/B therefore ran the Triton MoE runner, so the comparison is apples-to-apples and the deltas stand — but `AITER_CONFIG_FMOE` is inert under this configuration and the aiter MoE path is *not* what was measured. The flag is kept in the command above only because it matches the invocation actually used; anyone reproducing will get triton and should see the same numbers.
