### PR TITLE
fix(hicache): bound NIXL hybrid bounce transfers

### DIFF
--- a/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
+++ b/python/sglang/srt/mem_cache/storage/nixl/hicache_nixl.py
@@ -2,8 +2,8 @@ import logging
 import os
 import time
 import uuid
-from dataclasses import dataclass
-from typing import Any, List, Optional
+from dataclasses import dataclass, replace
+from typing import Any, Iterator, List, Optional
 
 import torch
 
@@ -580,6 +580,39 @@ class HiCacheNixl(HiCacheStorage):
         key_strs = self._get_component_keys(keys, transfer.name)
         return host_pool, key_strs, host_buffers, page_offsets, 1
 
+    def _iter_bounded_pool_transfers(
+        self, transfer: PoolTransfer
+    ) -> Iterator[PoolTransfer]:
+        """Split bounce-backed hybrid I/O to the registered buffer capacity.
+
+        Zero-copy pools can describe the complete transfer directly. Bounce-backed
+        pools reuse a fixed ``STORAGE_BATCH_SIZE`` staging area, so each yielded
+        descriptor must fit that area. ``host_indices`` contains ``page_size``
+        entries per logical storage key and is sliced on the same page boundary.
+
+        Leave malformed transfers intact so ``_prepare_pool_transfer`` rejects the
+        complete operation before any partial I/O is issued.
+        """
+        ctx = self._hybrid_pool_ctx.get(transfer.name)
+        keys = transfer.keys or []
+        if ctx is None or ctx.is_zero_copy or len(keys) <= STORAGE_BATCH_SIZE:
+            yield transfer
+            return
+
+        host_indices = transfer.host_indices
+        page_size = getattr(ctx.host_pool, "page_size", 1) or 1
+        if host_indices is None or host_indices.numel() != len(keys) * page_size:
+            yield transfer
+            return
+
+        for start in range(0, len(keys), STORAGE_BATCH_SIZE):
+            end = min(start + STORAGE_BATCH_SIZE, len(keys))
+            yield replace(
+                transfer,
+                keys=keys[start:end],
+                host_indices=host_indices[start * page_size : end * page_size],
+            )
+
     def _alloc_registered(
         self,
         page_numel: int,
@@ -943,6 +976,43 @@ class HiCacheNixl(HiCacheStorage):
             for i in range(0, len(results), key_multiplier)
         ]
 
+    def _normalize_pool_transfer_results(
+        self,
+        raw_results: List[bool],
+        expected_components: int,
+        expected_pages: int,
+        key_multiplier: int,
+        pool_name: PoolName,
+    ) -> List[bool]:
+        """Validate component results and return a contiguous page prefix."""
+        if len(raw_results) != expected_components:
+            logger.error(
+                "HiCacheNixl: hybrid pool %s result length mismatch: "
+                "expected %s components, got %s",
+                pool_name,
+                expected_components,
+                len(raw_results),
+            )
+            return [False] * expected_pages
+
+        page_results = [
+            bool(result) for result in self._page_results(raw_results, key_multiplier)
+        ]
+        if len(page_results) != expected_pages:
+            logger.error(
+                "HiCacheNixl: hybrid pool %s page result length mismatch: "
+                "expected %s pages, got %s",
+                pool_name,
+                expected_pages,
+                len(page_results),
+            )
+            return [False] * expected_pages
+
+        if False in page_results:
+            first_failure = page_results.index(False)
+            page_results[first_failure:] = [False] * (expected_pages - first_failure)
+        return page_results
+
     def batch_get_v2(
         self,
         transfers: List[PoolTransfer],
@@ -950,35 +1020,51 @@ class HiCacheNixl(HiCacheStorage):
     ) -> dict[str, List[bool]]:
         results: dict[str, List[bool]] = {}
         for transfer in transfers:
-            host_pool, key_strs, host_buffers, page_offsets, key_multiplier = (
-                self._prepare_pool_transfer(transfer, for_write=False)
-            )
-            if host_pool is None or not key_strs:
-                results[transfer.name] = [False] * len(transfer.keys or [])
-                continue
+            pool_results: List[bool] = []
+            total_pages = len(transfer.keys or [])
+            for bounded in self._iter_bounded_pool_transfers(transfer):
+                host_pool, key_strs, host_buffers, page_offsets, key_multiplier = (
+                    self._prepare_pool_transfer(bounded, for_write=False)
+                )
+                batch_pages = len(bounded.keys or [])
+                if host_pool is None or not key_strs:
+                    pool_results.extend([False] * batch_pages)
+                    break
 
-            start_time = time.perf_counter()
-            transfer_results = self._batch_xfer(
-                key_strs, key_strs, host_buffers, "READ"
-            )
-            elapsed_ms = (time.perf_counter() - start_time) * 1000
-            self._log_xfer_stats(
-                f"batch_get_v2[{transfer.name}]",
-                len(transfer.keys or []),
-                transfer.host_indices,
-                [size for _, size in host_buffers],
-                elapsed_ms,
-            )
-            ctx = self._hybrid_pool_ctx[transfer.name]
-            page_results = self._page_results(transfer_results, key_multiplier)
-            if not ctx.is_zero_copy:
-                for ok, page_offset, data_page in zip(
-                    page_results, page_offsets, ctx.bounce_get
-                ):
-                    if not ok:
-                        break
-                    host_pool.set_from_flat_data_page(page_offset, data_page)
-            results[transfer.name] = page_results
+                start_time = time.perf_counter()
+                transfer_results = self._batch_xfer(
+                    key_strs, key_strs, host_buffers, "READ"
+                )
+                elapsed_ms = (time.perf_counter() - start_time) * 1000
+                self._log_xfer_stats(
+                    f"batch_get_v2[{transfer.name}]",
+                    batch_pages,
+                    bounded.host_indices,
+                    [size for _, size in host_buffers],
+                    elapsed_ms,
+                )
+                ctx = self._hybrid_pool_ctx[transfer.name]
+                page_results = self._normalize_pool_transfer_results(
+                    transfer_results,
+                    len(key_strs),
+                    batch_pages,
+                    key_multiplier,
+                    transfer.name,
+                )
+                if not ctx.is_zero_copy:
+                    for ok, page_offset, data_page in zip(
+                        page_results, page_offsets, ctx.bounce_get
+                    ):
+                        if not ok:
+                            break
+                        host_pool.set_from_flat_data_page(page_offset, data_page)
+                pool_results.extend(page_results)
+                if len(page_results) != batch_pages or not all(page_results):
+                    break
+
+            if len(pool_results) < total_pages:
+                pool_results.extend([False] * (total_pages - len(pool_results)))
+            results[transfer.name] = pool_results
         return results
 
     def batch_set_v2(
@@ -988,26 +1074,41 @@ class HiCacheNixl(HiCacheStorage):
     ) -> dict[str, List[bool]]:
         results: dict[str, List[bool]] = {}
         for transfer in transfers:
-            _, key_strs, host_buffers, _, key_multiplier = self._prepare_pool_transfer(
-                transfer, for_write=True
-            )
-            if not key_strs:
-                results[transfer.name] = [False] * len(transfer.keys or [])
-                continue
+            pool_results: List[bool] = []
+            total_pages = len(transfer.keys or [])
+            for bounded in self._iter_bounded_pool_transfers(transfer):
+                _, key_strs, host_buffers, _, key_multiplier = (
+                    self._prepare_pool_transfer(bounded, for_write=True)
+                )
+                batch_pages = len(bounded.keys or [])
+                if not key_strs:
+                    pool_results.extend([False] * batch_pages)
+                    break
 
-            start_time = time.perf_counter()
-            transfer_results = self._batch_xfer(
-                key_strs, key_strs, host_buffers, "WRITE"
-            )
-            elapsed_ms = (time.perf_counter() - start_time) * 1000
-            self._log_xfer_stats(
-                f"batch_set_v2[{transfer.name}]",
-                len(transfer.keys or []),
-                transfer.host_indices,
-                [size for _, size in host_buffers],
-                elapsed_ms,
-            )
-            results[transfer.name] = self._page_results(
-                transfer_results, key_multiplier
-            )
+                start_time = time.perf_counter()
+                transfer_results = self._batch_xfer(
+                    key_strs, key_strs, host_buffers, "WRITE"
+                )
+                elapsed_ms = (time.perf_counter() - start_time) * 1000
+                self._log_xfer_stats(
+                    f"batch_set_v2[{transfer.name}]",
+                    batch_pages,
+                    bounded.host_indices,
+                    [size for _, size in host_buffers],
+                    elapsed_ms,
+                )
+                page_results = self._normalize_pool_transfer_results(
+                    transfer_results,
+                    len(key_strs),
+                    batch_pages,
+                    key_multiplier,
+                    transfer.name,
+                )
+                pool_results.extend(page_results)
+                if len(page_results) != batch_pages or not all(page_results):
+                    break
+
+            if len(pool_results) < total_pages:
+                pool_results.extend([False] * (total_pages - len(pool_results)))
+            results[transfer.name] = pool_results
         return results

--- a/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
+++ b/test/registered/unit/mem_cache/test_hicache_nixl_storage.py
@@ -15,6 +15,7 @@ import unittest
 import torch
 
 from sglang.srt.mem_cache.hicache_storage import (
+    STORAGE_BATCH_SIZE,
     HiCacheStorageConfig,
     PoolName,
     PoolTransfer,
@@ -641,6 +642,317 @@ class TestNixlUnified(CustomTestCase):
 
         self.assertEqual(results[PoolName.MAMBA], [True])
         self.assertTrue(torch.all(pool.get_data_page(0) == 3))
+
+    def test_batch_set_v2_chunks_large_bounce_backed_draft_pool(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        page_size = 2
+        pool = MockHybridPool(
+            num_pages=page_count, page_size=page_size, expose_zero_copy=False
+        )
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append((len(key_strs), direction))
+            self.assertLessEqual(len(host_buffers), STORAGE_BATCH_SIZE)
+            return [True] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=[f"p{i}" for i in range(page_count)],
+                    host_indices=torch.arange(
+                        page_count * page_size, dtype=torch.int64
+                    ),
+                )
+            ]
+        )
+
+        self.assertEqual(results[PoolName.DRAFT], [True] * page_count)
+        self.assertEqual(
+            calls,
+            [(STORAGE_BATCH_SIZE, "WRITE"), (2, "WRITE")],
+        )
+
+    def test_batch_get_v2_chunks_large_bounce_backed_draft_pool(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        page_size = 2
+        pool = MockHybridPool(
+            num_pages=page_count, page_size=page_size, expose_zero_copy=False
+        )
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append((len(key_strs), direction))
+            ctx = self.hicache._hybrid_pool_ctx[PoolName.DRAFT]
+            fill_value = 7 if len(calls) == 1 else 9
+            ctx.bounce_get[: len(host_buffers)].fill_(fill_value)
+            return [True] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_get_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=[f"p{i}" for i in range(page_count)],
+                    host_indices=torch.arange(
+                        page_count * page_size, dtype=torch.int64
+                    ),
+                )
+            ]
+        )
+
+        self.assertEqual(results[PoolName.DRAFT], [True] * page_count)
+        self.assertEqual(
+            calls,
+            [(STORAGE_BATCH_SIZE, "READ"), (2, "READ")],
+        )
+        self.assertTrue(torch.all(pool.get_data_page(0) == 7))
+        self.assertTrue(
+            torch.all(pool.get_data_page((STORAGE_BATCH_SIZE - 1) * page_size) == 7)
+        )
+        self.assertTrue(
+            torch.all(pool.get_data_page(STORAGE_BATCH_SIZE * page_size) == 9)
+        )
+        self.assertTrue(
+            torch.all(pool.get_data_page((page_count - 1) * page_size) == 9)
+        )
+
+    def test_batch_set_v2_leaves_large_zero_copy_pool_unbatched(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        pool = MockHybridPool(num_pages=page_count, expose_zero_copy=True)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append((len(key_strs), len(host_buffers), direction))
+            return [True] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=[f"p{i}" for i in range(page_count)],
+                    host_indices=torch.arange(page_count, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(results[PoolName.DRAFT], [True] * page_count)
+        self.assertEqual(calls, [(page_count * 2, page_count * 2, "WRITE")])
+
+    def test_batch_set_v2_rejects_malformed_large_transfer_before_io(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        page_size = 2
+        pool = MockHybridPool(
+            num_pages=page_count, page_size=page_size, expose_zero_copy=False
+        )
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append(direction)
+            return [True] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=[f"p{i}" for i in range(page_count)],
+                    host_indices=torch.arange(page_count, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(results[PoolName.DRAFT], [False] * page_count)
+        self.assertEqual(calls, [])
+
+    def test_batch_get_v2_normalizes_non_prefix_bounce_results(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        pool = MockHybridPool(num_pages=page_count, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append(direction)
+            ctx = self.hicache._hybrid_pool_ctx[PoolName.DRAFT]
+            ctx.bounce_get[: len(host_buffers)].fill_(5)
+            return [True, False] + [True] * (len(key_strs) - 2)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_get_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=[f"p{i}" for i in range(page_count)],
+                    host_indices=torch.arange(page_count, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(results[PoolName.DRAFT], [True] + [False] * (page_count - 1))
+        self.assertEqual(calls, ["READ"])
+        self.assertTrue(torch.all(pool.get_data_page(0) == 5))
+        self.assertTrue(torch.all(pool.get_data_page(1) == 0))
+        self.assertTrue(torch.all(pool.get_data_page(page_count - 1) == 0))
+
+    def test_batch_get_v2_preserves_prefix_when_later_chunk_fails(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        pool = MockHybridPool(num_pages=page_count, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append((len(key_strs), direction))
+            ctx = self.hicache._hybrid_pool_ctx[PoolName.DRAFT]
+            ctx.bounce_get[: len(host_buffers)].fill_(len(calls) + 6)
+            return [len(calls) == 1] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_get_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=[f"p{i}" for i in range(page_count)],
+                    host_indices=torch.arange(page_count, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(
+            results[PoolName.DRAFT],
+            [True] * STORAGE_BATCH_SIZE + [False, False],
+        )
+        self.assertEqual(
+            calls,
+            [(STORAGE_BATCH_SIZE, "READ"), (2, "READ")],
+        )
+        self.assertTrue(torch.all(pool.get_data_page(0) == 7))
+        self.assertTrue(torch.all(pool.get_data_page(STORAGE_BATCH_SIZE - 1) == 7))
+        self.assertTrue(torch.all(pool.get_data_page(STORAGE_BATCH_SIZE) == 0))
+        self.assertTrue(torch.all(pool.get_data_page(page_count - 1) == 0))
+
+    def test_batch_set_v2_preserves_prefix_when_later_chunk_fails(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        pool = MockHybridPool(num_pages=page_count, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+        calls = []
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            calls.append((len(key_strs), direction))
+            return [len(calls) == 1] * len(key_strs)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=[f"p{i}" for i in range(page_count)],
+                    host_indices=torch.arange(page_count, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(
+            results[PoolName.DRAFT],
+            [True] * STORAGE_BATCH_SIZE + [False, False],
+        )
+        self.assertEqual(
+            calls,
+            [(STORAGE_BATCH_SIZE, "WRITE"), (2, "WRITE")],
+        )
+
+    def test_batch_set_v2_rejects_malformed_result_lengths(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        pool = MockHybridPool(num_pages=page_count, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+        transfer = PoolTransfer(
+            name=PoolName.DRAFT,
+            keys=[f"p{i}" for i in range(page_count)],
+            host_indices=torch.arange(page_count, dtype=torch.int64),
+        )
+
+        for result_delta in (-1, 1):
+            calls = []
+
+            def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+                calls.append(direction)
+                return [True] * (len(key_strs) + result_delta)
+
+            with self.subTest(result_delta=result_delta):
+                self.hicache._batch_xfer = fake_batch_xfer
+                results = self.hicache.batch_set_v2([transfer])
+                self.assertEqual(results[PoolName.DRAFT], [False] * page_count)
+                self.assertEqual(calls, ["WRITE"])
+
+    def test_batch_get_v2_rejects_incomplete_zero_copy_component_results(self):
+        page_count = 2
+        pool = MockHybridPool(num_pages=page_count, expose_zero_copy=True)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+
+        def fake_batch_xfer(keys, key_strs, host_buffers, direction):
+            return [True] * (len(key_strs) - 1)
+
+        self.hicache._batch_xfer = fake_batch_xfer
+        results = self.hicache.batch_get_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=["p0", "p1"],
+                    host_indices=torch.arange(page_count, dtype=torch.int64),
+                )
+            ]
+        )
+
+        self.assertEqual(results[PoolName.DRAFT], [False, False])
+
+    def test_batch_set_get_v2_large_bounce_pool_round_trip(self):
+        page_count = STORAGE_BATCH_SIZE + 2
+        pool = MockHybridPool(num_pages=page_count, expose_zero_copy=False)
+        self.hicache.register_mem_host_pool_v2(pool, PoolName.DRAFT)
+        keys = [f"round-trip-{i}" for i in range(page_count)]
+        host_indices = torch.arange(page_count, dtype=torch.int64)
+
+        for i in range(page_count):
+            pool.temporal_buffer[i].fill_(i % 251)
+            pool.conv_buffer[0][i].fill_((i + 1) % 251)
+        expected = [pool.get_data_page(i).clone() for i in range(page_count)]
+
+        set_results = self.hicache.batch_set_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=keys,
+                    host_indices=host_indices,
+                )
+            ]
+        )
+        self.assertEqual(set_results[PoolName.DRAFT], [True] * page_count)
+
+        pool.temporal_buffer.zero_()
+        pool.conv_buffer[0].zero_()
+        get_results = self.hicache.batch_get_v2(
+            [
+                PoolTransfer(
+                    name=PoolName.DRAFT,
+                    keys=keys,
+                    host_indices=host_indices,
+                )
+            ]
+        )
+
+        self.assertEqual(get_results[PoolName.DRAFT], [True] * page_count)
+        for i in range(page_count):
+            self.assertTrue(torch.equal(pool.get_data_page(i), expected[i]))
 
     def test_batch_set_get_v2_distinguishes_same_key_by_pool_name(self):
         mamba_pool = MockHybridPool(expose_zero_copy=False)


### PR DESCRIPTION
## Motivation

`HiCacheNixl` pre-registers `STORAGE_BATCH_SIZE` staging slots for each hybrid pool that cannot expose an aligned zero-copy buffer. The v2 API can receive a larger logical sidecar transfer, but currently passes it to `_prepare_pool_transfer()` as one operation. That operation is rejected when it exceeds the fixed staging capacity, so sufficiently long DFlash draft, Mamba/GDN, or other bounce-backed hybrid state cannot be written to or restored from NIXL.

The target-KV v1 path is already batched by the controller. Hybrid v2 sidecar transfers are submitted whole and need equivalent bounding inside the NIXL backend.

## Modification

- Split only bounce-backed v2 transfers into `STORAGE_BATCH_SIZE` logical-page chunks.
- Slice `host_indices` by the host pool's `page_size`, keeping keys, logical pages, staging slots, and result entries aligned.
- Copy each read chunk back before reusing its staging buffer.
- Validate physical result cardinality, normalize logical results to a contiguous success prefix, stop after the first failed or malformed chunk, and pad the unattempted suffix with `False`.
- Leave zero-copy hybrid transfers unbatched.
- Reject malformed oversized transfer shapes before issuing partial I/O.

No cache keys, persistent file layout, transfer payload format, controller API, or inference kernel changes.

## Validation

- Upstream base: `f8cc1f9525c3a0bf3b14480cc76eccb79db1b4ea`.
- Tested candidate: `e5b4a8efeade7ed21060cb968518d93f6984f2ba`.
- Negative control on unmodified upstream: large bounce-backed v2 read and write tests fail because all 130 pages are rejected against the 128-page staging area; the large zero-copy control passes.
- Focused new tests: `10 passed`, plus two malformed-length subtests.
- Complete NIXL HiCache storage unit file: `31 passed, 1 skipped`, plus two subtests.
- The integration regression writes and restores 130 distinct draft-pool pages through the real installed NIXL POSIX backend across the 128/2 chunk boundary.

Commands used with the worktree source forced into the installed test environment:

```bash
PYTHONPATH="$PWD/python" SGLANG_CACHE_DIR=/tmp/sglang-nixl-bounce-green-cache \
  /opt/sglang/.venv/bin/python -m pytest -q \
  test/registered/unit/mem_cache/test_hicache_nixl_storage.py \
  -k 'large_bounce or large_zero_copy or malformed_large or non_prefix or later_chunk or malformed_result or incomplete_zero_copy' \
  --tb=short

PYTHONPATH="$PWD/python" SGLANG_CACHE_DIR=/tmp/sglang-nixl-bounce-green-cache \
  /opt/sglang/.venv/bin/python -m pytest -q \
  test/registered/unit/mem_cache/test_hicache_nixl_storage.py --tb=short
```

The live Pennyroyal service was not modified or restarted while preparing this change.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32988601294](https://github.com/sgl-project/sglang/actions/runs/32988601294)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32988600968](https://github.com/sgl-project/sglang/actions/runs/32988600968)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32988601140](https://github.com/sgl-project/sglang/actions/runs/32988601140)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->