### PR TITLE
[diffusion] prefer cuDNN SDPA for FastHunyuan on SM120

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/hunyuanvideo.py
@@ -158,3 +158,4 @@ class HunyuanVideoConfig(DiTConfig):
     arch_config: DiTArchConfig = field(default_factory=HunyuanVideoArchConfig)
 
     prefix: str = "Hunyuan"
+    prefer_cudnn_sdpa_on_sm120: bool = False

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py
@@ -164,6 +164,10 @@ class FastHunyuanConfig(HunyuanConfig):
     # No need to re-specify guidance_scale or embedded_cfg_scale as they
     # already have the desired values from HunyuanConfig
 
+    def __post_init__(self):
+        super().__post_init__()
+        self.dit_config.prefer_cudnn_sdpa_on_sm120 = True
+
     def get_model_deployment_config(self) -> ModelDeploymentConfig:
         return ModelDeploymentConfig(
             keep_resident_min_available_gb=60,

--- a/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py
@@ -72,6 +72,7 @@ from sglang.multimodal_gen.runtime.platforms import (
     AttentionBackendEnum,
     current_platform,
 )
+from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 
 logger = init_logger(__name__)
@@ -79,6 +80,22 @@ logger = init_logger(__name__)
 _HUNYUAN_QKV_PACK = BitExactFusionGate("HunyuanVideo QKV RoPE pack", per_signature=True)
 _HUNYUAN_QKV_PACK_SIGS = _HUNYUAN_QKV_PACK.verified_sigs
 assert _HUNYUAN_QKV_PACK_SIGS is not None
+
+
+def _hunyuan_default_attention_backend(
+    config: HunyuanVideoConfig,
+    *,
+    enable_torch_compile: bool = False,
+) -> AttentionBackendEnum | None:
+    """Return a model-owned backend preference without overriding the CLI."""
+    if (
+        config.prefer_cudnn_sdpa_on_sm120
+        and current_platform.is_sm120()
+        and not enable_torch_compile
+        and get_ring_parallel_world_size() == 1
+    ):
+        return AttentionBackendEnum.TORCH_CUDNN_SDPA
+    return None
 
 
 def _hunyuan_qknorm(
@@ -242,6 +259,7 @@ class MMDoubleStreamBlock(nn.Module):
         mlp_ratio: float,
         dtype: torch.dtype | None = None,
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
+        default_attention_backend: AttentionBackendEnum | None = None,
         prefix: str = "",
         quant_config: QuantizationConfig | None = None,
     ):
@@ -362,6 +380,7 @@ class MMDoubleStreamBlock(nn.Module):
             head_size=head_dim,
             causal=False,
             supported_attention_backends=supported_attention_backends,
+            default_attention_backend=default_attention_backend,
             prefix=f"{prefix}.attn",
         )
         mark_hunyuan_qknorm_site(self)
@@ -492,6 +511,7 @@ class MMSingleStreamBlock(nn.Module):
         mlp_ratio: float = 4.0,
         dtype: torch.dtype | None = None,
         supported_attention_backends: set[AttentionBackendEnum] | None = None,
+        default_attention_backend: AttentionBackendEnum | None = None,
         prefix: str = "",
         quant_config: QuantizationConfig | None = None,
     ):
@@ -560,6 +580,7 @@ class MMSingleStreamBlock(nn.Module):
             head_size=head_dim,
             causal=False,
             supported_attention_backends=supported_attention_backends,
+            default_attention_backend=default_attention_backend,
             prefix=f"{prefix}.attn",
         )
         mark_hunyuan_qknorm_site(self)
@@ -736,6 +757,12 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
             else None
         )
 
+        server_args = get_global_server_args()
+        default_attention_backend = _hunyuan_default_attention_backend(
+            config,
+            enable_torch_compile=server_args.enable_torch_compile,
+        )
+
         # Double blocks
         self.double_blocks = nn.ModuleList(
             [
@@ -745,6 +772,7 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
                     mlp_ratio=config.mlp_ratio,
                     dtype=config.dtype,
                     supported_attention_backends=self._supported_attention_backends,
+                    default_attention_backend=default_attention_backend,
                     prefix=f"{config.prefix}.double_blocks.{i}",
                     quant_config=quant_config,
                 )
@@ -761,6 +789,7 @@ class HunyuanVideoTransformer3DModel(CachableDiT, LayerwiseOffloadableModuleMixi
                     mlp_ratio=config.mlp_ratio,
                     dtype=config.dtype,
                     supported_attention_backends=self._supported_attention_backends,
+                    default_attention_backend=default_attention_backend,
                     prefix=f"{config.prefix}.single_blocks.{i + config.num_layers}",
                     quant_config=quant_config,
                 )

--- a/python/sglang/multimodal_gen/test/unit/test_hunyuan_attention_backend.py
+++ b/python/sglang/multimodal_gen/test/unit/test_hunyuan_attention_backend.py
@@ -1,0 +1,95 @@
+from contextlib import ExitStack
+from unittest.mock import patch
+
+from torch import nn
+
+from sglang.multimodal_gen.configs.pipeline_configs.hunyuan import (
+    FastHunyuanConfig,
+    HunyuanConfig,
+)
+from sglang.multimodal_gen.runtime.models.dits.hunyuanvideo import (
+    MMSingleStreamBlock,
+    _hunyuan_default_attention_backend,
+)
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
+
+_HUNYUAN = "sglang.multimodal_gen.runtime.models.dits.hunyuanvideo"
+
+
+@patch(f"{_HUNYUAN}.get_ring_parallel_world_size", return_value=1)
+@patch(f"{_HUNYUAN}.current_platform.is_sm120", return_value=True)
+def test_fasthunyuan_prefers_cudnn_sdpa_on_sm120(_mock_is_sm120, _mock_ring):
+    config = FastHunyuanConfig()
+
+    assert config.dit_config.prefer_cudnn_sdpa_on_sm120
+    assert (
+        _hunyuan_default_attention_backend(config.dit_config)
+        is AttentionBackendEnum.TORCH_CUDNN_SDPA
+    )
+
+
+@patch(f"{_HUNYUAN}.get_ring_parallel_world_size", return_value=1)
+@patch(f"{_HUNYUAN}.current_platform.is_sm120", return_value=False)
+def test_fasthunyuan_keeps_default_outside_sm120(_mock_is_sm120, _mock_ring):
+    config = FastHunyuanConfig()
+
+    assert _hunyuan_default_attention_backend(config.dit_config) is None
+
+
+@patch(f"{_HUNYUAN}.get_ring_parallel_world_size", return_value=1)
+@patch(f"{_HUNYUAN}.current_platform.is_sm120", return_value=True)
+def test_fasthunyuan_keeps_compile_backend_on_sm120(_mock_is_sm120, _mock_ring):
+    config = FastHunyuanConfig()
+
+    assert (
+        _hunyuan_default_attention_backend(
+            config.dit_config,
+            enable_torch_compile=True,
+        )
+        is None
+    )
+
+
+@patch(f"{_HUNYUAN}.get_ring_parallel_world_size", return_value=2)
+@patch(f"{_HUNYUAN}.current_platform.is_sm120", return_value=True)
+def test_fasthunyuan_keeps_ring_backend_on_sm120(_mock_is_sm120, _mock_ring):
+    config = FastHunyuanConfig()
+
+    assert _hunyuan_default_attention_backend(config.dit_config) is None
+
+
+@patch(f"{_HUNYUAN}.get_ring_parallel_world_size", return_value=1)
+@patch(f"{_HUNYUAN}.current_platform.is_sm120", return_value=True)
+def test_regular_hunyuan_keeps_platform_default_on_sm120(_mock_is_sm120, _mock_ring):
+    config = HunyuanConfig()
+
+    assert not config.dit_config.prefer_cudnn_sdpa_on_sm120
+    assert _hunyuan_default_attention_backend(config.dit_config) is None
+
+
+def test_default_backend_is_forwarded_to_usp():
+    module_names = (
+        "MergedColumnParallelLinear",
+        "MixedRowParallelLinear",
+        "RMSNorm",
+        "LayerNormScaleShift",
+        "MulAdd",
+        "ModulateProjection",
+    )
+    with ExitStack() as stack:
+        for name in module_names:
+            stack.enter_context(patch(f"{_HUNYUAN}.{name}", return_value=nn.Identity()))
+        stack.enter_context(patch(f"{_HUNYUAN}.get_tp_world_size", return_value=1))
+        usp = stack.enter_context(
+            patch(f"{_HUNYUAN}.USPAttention", return_value=nn.Identity())
+        )
+        MMSingleStreamBlock(
+            hidden_size=128,
+            num_attention_heads=1,
+            default_attention_backend=AttentionBackendEnum.TORCH_CUDNN_SDPA,
+        )
+
+    assert (
+        usp.call_args.kwargs["default_attention_backend"]
+        is AttentionBackendEnum.TORCH_CUDNN_SDPA
+    )


### PR DESCRIPTION
## Summary

- prefer cuDNN SDPA for FastHunyuan's double- and single-stream DiT attention on SM120 in eager mode
- keep compile, ring attention, regular Hunyuan checkpoints, non-SM120 platforms, and explicit backend choices unchanged
- add focused coverage for backend eligibility and propagation into `USPAttention`

## RTX PRO 6000 Blackwell validation

Native SGLang, `FastVideo/FastHunyuan-diffusers`, 832x480, 61 frames, 6 steps, seed 42, BF16, one GPU:

| Mode | Denoise | E2E | Peak reserved |
|---|---:|---:|---:|
| baseline eager A/B mean | 14.3977 s | 19.5667 s | 36,968 MB |
| patched eager A/B mean | 14.0212 s | 19.1925 s | 36,968 MB |
| baseline quality-high | 14.2167 s | 19.3856 s | 37,076 MB |
| patched quality-high | 13.8687 s | 19.0324 s | 37,076 MB |

The eager candidate reduces denoise latency by 2.615% and E2E latency by 1.912%. Across all 61 frames against baseline eager, it retains 0.97979 mean / 0.97385 worst-frame SSIM and 44.63 dB mean / 43.60 dB worst-frame PSNR. Start, middle, and end frame inspection found no visible semantic regression. The preset compile path timed out during its first Inductor max-autotune run, and this patch leaves compile backend selection unchanged.

At the production `[1,24,24968,128]` BF16 attention shape, CUDA-event median falls from 21.6193 to 20.6921 ms. NCU kernel duration falls from 28.32 to 25.58 ms, compute throughput rises from 76.41% to 84.61%, achieved occupancy rises from 8.33% to 18.74%, and registers/thread fall from 255 to 168 with no spill.

## Tests

- `pytest -q python/sglang/multimodal_gen/test/unit/test_hunyuan_attention_backend.py python/sglang/multimodal_gen/test/unit/test_hunyuan_config.py` (8 passed)
- `pre-commit run --files python/sglang/multimodal_gen/configs/models/dits/hunyuanvideo.py python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan.py python/sglang/multimodal_gen/runtime/models/dits/hunyuanvideo.py python/sglang/multimodal_gen/test/unit/test_hunyuan_attention_backend.py`
