### PR TITLE
Fix HiCache startup with bare DSA MTP draft pools

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -712,8 +712,13 @@ def build_hybrid_mamba_stack(
 ) -> tuple[HostPoolGroup, HybridCacheController]:
     transfer_layer_num = len(full_layer_mapping | mamba_layer_mapping)
     mamba_allocator = params.req_to_token_pool.mamba_allocator
+    from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
+
+    # Hybrid draft runners wrap their attention KV in HybridLinearKVPool, but
+    # DSA draft workers (e.g. GLM-5.3-Flash NEXTN) are already bare KV pools.
     mtp_draft_device_pools = tuple(
-        pool.full_kv_pool for pool in params.mtp_draft_device_pools
+        pool.full_kv_pool if isinstance(pool, HybridLinearKVPool) else pool
+        for pool in params.mtp_draft_device_pools
     )
     kv_host_size, mamba_host_size = None, 0
     if get_memory().hicache_size > 0:


### PR DESCRIPTION
## Motivation

Enabling HiCache (`--enable-hierarchical-cache`) together with MTP speculative decoding crashed at startup:

```
AttributeError: 'DSATokenToKVPool' object has no attribute 'full_kv_pool'
```

`build_hybrid_mamba_stack` unconditionally read `.full_kv_pool` from every MTP draft pool, which only holds for `HybridLinearKVPool`-wrapped drafts (the case #34560-class fixes covered for the sidecar path). DSA draft workers (e.g. GLM-5.3-Flash NEXTN) hand in a bare `DSATokenToKVPool` — itself an MLA-family KV pool — so the unwrapping blows up. Target-only serving is unaffected (no draft pools), which is why HiCache appeared to work for non-speculative recipes.

## Modifications

One hunk in `build_hybrid_mamba_stack`: unwrap only `HybridLinearKVPool` wrappers, pass bare pools through — mirroring the existing isinstance guard in `build_full_draft_pools`.

## Tests

On 4x GB300, GLM-5.3-Flash (final weights), Low Latency cell (adaptive NEXTN 5/1/6, TP4/EP4) + `--enable-hierarchical-cache --hicache-size 32`:

- Startup passes pool assembly (the original crash point); L2 host pool initializes with packed MTP layers: `target_layers=11, draft_layers=1`, 3.5M tokens / 21.72 GB per rank.
- 3/3 chat probes correct with clean stops.
- GSM8K-20: 95% accuracy, 100% stop rate (matches the non-HiCache reference).

(Note: the validation serve also carries `--disable-shared-experts-fusion`; fusion-ON degenerates this model independently — root cause identified, separate fix in progress.)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32991877914](https://github.com/sgl-project/sglang/actions/runs/32991877914)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32991877687](https://github.com/sgl-project/sglang/actions/runs/32991877687)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32991877872](https://github.com/sgl-project/sglang/actions/runs/32991877872)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->