### PR TITLE
Avoid sampling-mask synchronization in decode

### DIFF
--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -116,10 +116,12 @@ class LogitsProcessorOutput:
         List[Union[List[float], torch.Tensor]]
     ] = None
     next_token_token_ids_logprobs_idx: Optional[List] = None
-    # Sparse top-k/top-p/min-p support ids and selected-token logprob after
-    # truncation/renormalization. Only populated when requested.
-    next_token_sampling_mask_idx: Optional[List[Optional[List[int]]]] = None
-    next_token_sampling_logprobs: Optional[List[Optional[float]]] = None
+    # Sparse top-k/top-p/min-p support and selected-token logprob after
+    # truncation/renormalization. Kept as padded device tensors until result
+    # processing so sampling does not block on GPU-to-CPU conversion.
+    next_token_sampling_mask_idx: Optional[torch.Tensor] = None
+    next_token_sampling_mask_len: Optional[torch.Tensor] = None
+    next_token_sampling_logprobs: Optional[torch.Tensor] = None
 
     ## Part 3: Prefill-only. This part will be assigned in python/sglang/srt/layers/logits_processor.py::LogitsProcessor
     # The logprobs of input tokens.        shape: [#token]

--- a/python/sglang/srt/layers/sampler.py
+++ b/python/sglang/srt/layers/sampler.py
@@ -334,18 +334,16 @@ class Sampler(nn.Module):
         sampling_info: SamplingBatchInfo,
         batch_next_token_ids: torch.Tensor,
     ) -> None:
-        tokens = batch_next_token_ids.to(torch.int32).cpu().tolist()
-        masks = []
-        logprobs = []
-        for i, should_return in enumerate(sampling_info.return_sampling_masks or []):
-            if should_return:
-                masks.append([int(tokens[i])])
-                logprobs.append(0.0)
-            else:
-                masks.append(None)
-                logprobs.append(None)
-        logits_output.next_token_sampling_mask_idx = masks
-        logits_output.next_token_sampling_logprobs = logprobs
+        batch_size = batch_next_token_ids.shape[0]
+        logits_output.next_token_sampling_mask_idx = batch_next_token_ids.to(
+            torch.int32
+        ).view(batch_size, 1)
+        logits_output.next_token_sampling_mask_len = torch.ones(
+            batch_size, dtype=torch.int32, device=batch_next_token_ids.device
+        )
+        logits_output.next_token_sampling_logprobs = torch.zeros(
+            batch_size, dtype=torch.float32, device=batch_next_token_ids.device
+        )
 
     def _attach_sampling_mask_to_output(
         self,
@@ -357,15 +355,11 @@ class Sampler(nn.Module):
         ],
     ) -> None:
         probs_idx, probs_sort, keep_mask, probs = sampling_mask_data
-        return_sampling_masks = sampling_info.return_sampling_masks or []
-        if not return_sampling_masks:
-            logits_output.next_token_sampling_mask_idx = []
-            logits_output.next_token_sampling_logprobs = []
-            return
 
         sampled_tokens = batch_next_token_ids.view(-1, 1)
         sampled_matches_all = probs_idx == sampled_tokens
         sampled_in_idx = sampled_matches_all.any(dim=-1)
+        sampled_in_support = (sampled_matches_all & keep_mask).any(dim=-1)
 
         # The sampler is the source of truth for the rollout action space. If a
         # backend/numeric edge chooses a token just outside the reconstructed
@@ -377,41 +371,44 @@ class Sampler(nn.Module):
             effective_keep_mask, probs_sort, torch.zeros_like(probs_sort)
         ).sum(dim=-1)
         support_mass = support_mass + torch.where(
-            sampled_in_idx, torch.zeros_like(selected_raw_probs), selected_raw_probs
+            sampled_in_idx,
+            torch.zeros_like(selected_raw_probs),
+            selected_raw_probs,
         )
         selected_logprobs = torch.log(
             selected_raw_probs.float()
             / support_mass.float().clamp_min(torch.finfo(torch.float32).tiny)
         )
 
-        flat_rows, flat_cols = effective_keep_mask.nonzero(as_tuple=True)
-        flat_ids = probs_idx[flat_rows, flat_cols].to(torch.int32)
-        mask_lengths = effective_keep_mask.sum(dim=-1, dtype=torch.int32)
+        keep_lengths = keep_mask.sum(dim=-1, dtype=torch.int32)
+        missing = ~sampled_in_support
 
-        flat_ids_cpu = flat_ids.cpu().tolist()
-        mask_lengths_cpu = mask_lengths.cpu().tolist()
-        sampled_in_idx_cpu = sampled_in_idx.cpu().tolist()
-        sampled_tokens_cpu = batch_next_token_ids.to(torch.int32).cpu().tolist()
-        selected_logprobs_cpu = selected_logprobs.cpu().tolist()
+        # keep_mask is a prefix because candidates are probability-sorted and
+        # top-k/top-p/min-p each retain a prefix. Keep a guard column for a
+        # sampled token that backend numerics place just outside that prefix.
+        # This fixed-size scatter avoids nonzero(), whose dynamic output size
+        # synchronizes CUDA with the host.
+        candidate_count = probs_idx.shape[1]
+        packed_ids = torch.zeros(
+            (probs.shape[0], candidate_count + 1),
+            dtype=torch.int32,
+            device=probs.device,
+        )
+        packed_ids[:, :candidate_count] = probs_idx.to(torch.int32)
+        append_values = torch.where(
+            missing,
+            batch_next_token_ids.to(torch.int32),
+            torch.zeros_like(batch_next_token_ids, dtype=torch.int32),
+        )
+        packed_ids.scatter_(
+            1, keep_lengths.to(torch.long).view(-1, 1), append_values.view(-1, 1)
+        )
 
-        masks = []
-        logprobs = []
-        cursor = 0
-        for i, should_return in enumerate(return_sampling_masks):
-            mask_len = int(mask_lengths_cpu[i])
-            row_ids = flat_ids_cpu[cursor : cursor + mask_len]
-            cursor += mask_len
-            if not sampled_in_idx_cpu[i]:
-                row_ids.append(int(sampled_tokens_cpu[i]))
-            if should_return:
-                masks.append(row_ids)
-                logprobs.append(float(selected_logprobs_cpu[i]))
-            else:
-                masks.append(None)
-                logprobs.append(None)
-
-        logits_output.next_token_sampling_mask_idx = masks
-        logits_output.next_token_sampling_logprobs = logprobs
+        logits_output.next_token_sampling_mask_idx = packed_ids
+        logits_output.next_token_sampling_mask_len = keep_lengths + missing.to(
+            torch.int32
+        )
+        logits_output.next_token_sampling_logprobs = selected_logprobs
 
     def _sample_from_logprobs(
         self,

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -1063,10 +1063,15 @@ class SchedulerBatchResultProcessor:
     ) -> None:
         """Attach sparse sampling support metadata to the return values."""
         mask = output.next_token_sampling_mask_idx
+        mask_len = output.next_token_sampling_mask_len
         logprobs = output.next_token_sampling_logprobs
-        req.output_token_sampling_mask.append(None if mask is None else mask[i])
+        if mask is None or mask_len is None:
+            req.output_token_sampling_mask.append(None)
+        else:
+            length = int(mask_len[i].item())
+            req.output_token_sampling_mask.append(mask[i, :length].cpu().tolist())
         req.output_token_sampling_logprobs.append(
-            None if logprobs is None else logprobs[i]
+            None if logprobs is None else float(logprobs[i].item())
         )
 
     def _handle_finish_state_updated_req(

--- a/python/sglang/srt/managers/utils.py
+++ b/python/sglang/srt/managers/utils.py
@@ -147,6 +147,15 @@ class GenerationBatchResult:
                     _async_d2h(v) if torch.is_tensor(v) else v
                     for v in self.logits_output.next_token_token_ids_logprobs_val
                 ]
+        if self.logits_output is not None:
+            for field in (
+                "next_token_sampling_mask_idx",
+                "next_token_sampling_mask_len",
+                "next_token_sampling_logprobs",
+            ):
+                value = getattr(self.logits_output, field)
+                if value is not None:
+                    setattr(self.logits_output, field, _async_d2h(value))
         if return_hidden_states and self.logits_output.hidden_states is not None:
             self.logits_output.hidden_states = _async_d2h(
                 self.logits_output.hidden_states
@@ -250,6 +259,7 @@ def get_logprob_dict_from_result(result: GenerationBatchResult) -> dict:
         "next_token_token_ids_logprobs_val": result.logits_output.next_token_token_ids_logprobs_val,
         "next_token_token_ids_logprobs_idx": result.logits_output.next_token_token_ids_logprobs_idx,
         "next_token_sampling_mask_idx": result.logits_output.next_token_sampling_mask_idx,
+        "next_token_sampling_mask_len": result.logits_output.next_token_sampling_mask_len,
         "next_token_sampling_logprobs": result.logits_output.next_token_sampling_logprobs,
         "input_token_logprobs": result.logits_output.input_token_logprobs,
         "input_top_logprobs_val": result.logits_output.input_top_logprobs_val,
@@ -276,6 +286,7 @@ def get_logprob_from_pp_outputs(
             "next_token_token_ids_logprobs_idx"
         ],
         next_token_sampling_mask_idx=next_pp_outputs["next_token_sampling_mask_idx"],
+        next_token_sampling_mask_len=next_pp_outputs["next_token_sampling_mask_len"],
         next_token_sampling_logprobs=next_pp_outputs["next_token_sampling_logprobs"],
         input_token_logprobs=next_pp_outputs["input_token_logprobs"],
         input_top_logprobs_val=next_pp_outputs["input_top_logprobs_val"],

--- a/test/registered/unit/sampling/test_sampling_mask.py
+++ b/test/registered/unit/sampling/test_sampling_mask.py
@@ -1,0 +1,113 @@
+"""Unit tests for tensor-backed sampling-mask packing and result copying."""
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=10, suite="stage-b-test-1-gpu-small-amd")
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.layers.sampler import Sampler
+from sglang.srt.managers.utils import GenerationBatchResult
+
+
+def test_sampling_mask_is_packed_as_tensors():
+    probs = torch.tensor(
+        [
+            [0.4, 0.3, 0.2, 0.1],
+            [0.1, 0.2, 0.3, 0.4],
+        ],
+        dtype=torch.float32,
+        device="cuda",
+    )
+    sampling_info = SimpleNamespace(
+        sampling_mask_max_top_k=3,
+        top_ks=torch.tensor([3, 2], dtype=torch.int32, device="cuda"),
+        top_ps=torch.tensor([0.6, 1.0], dtype=torch.float32, device="cuda"),
+        min_ps=torch.zeros(2, dtype=torch.float32, device="cuda"),
+        need_min_p_sampling=False,
+    )
+    sampled_tokens = torch.tensor([1, 0], dtype=torch.int64, device="cuda")
+    output = LogitsProcessorOutput(next_token_logits=None)
+
+    sampling_mask_data = Sampler._compute_sampling_mask_from_probs(
+        None, probs, sampling_info
+    )
+    Sampler._attach_sampling_mask_to_output(
+        None,
+        output,
+        sampling_info,
+        sampled_tokens,
+        sampling_mask_data,
+    )
+
+    assert isinstance(output.next_token_sampling_mask_idx, torch.Tensor)
+    assert isinstance(output.next_token_sampling_mask_len, torch.Tensor)
+    assert isinstance(output.next_token_sampling_logprobs, torch.Tensor)
+    assert output.next_token_sampling_mask_idx.is_cuda
+    assert output.next_token_sampling_mask_len.is_cuda
+    assert output.next_token_sampling_logprobs.is_cuda
+    assert output.next_token_sampling_mask_len.tolist() == [2, 3]
+    assert output.next_token_sampling_mask_idx[0, :2].tolist() == [0, 1]
+    # Token 0 is outside the second row's reconstructed top-2 support, so it is
+    # appended after the retained candidates without materializing on the host.
+    assert output.next_token_sampling_mask_idx[1, :3].tolist() == [3, 2, 0]
+    assert output.next_token_sampling_logprobs.tolist() == pytest.approx(
+        [
+            torch.log(torch.tensor(0.3 / 0.7)).item(),
+            torch.log(torch.tensor(0.1 / 0.8)).item(),
+        ]
+    )
+
+
+def test_greedy_sampling_mask_is_tensor_backed():
+    sampled_tokens = torch.tensor([4, 7], dtype=torch.int64, device="cuda")
+    output = LogitsProcessorOutput(next_token_logits=None)
+
+    Sampler._attach_greedy_sampling_mask_to_output(
+        None,
+        output,
+        SimpleNamespace(),
+        sampled_tokens,
+    )
+
+    assert output.next_token_sampling_mask_idx.tolist() == [[4], [7]]
+    assert output.next_token_sampling_mask_len.tolist() == [1, 1]
+    assert output.next_token_sampling_logprobs.tolist() == [0.0, 0.0]
+
+
+def test_sampling_mask_uses_generation_result_copy_stream():
+    output = LogitsProcessorOutput(
+        next_token_logits=None,
+        next_token_sampling_mask_idx=torch.tensor(
+            [[3, 2, 0]], dtype=torch.int32, device="cuda"
+        ),
+        next_token_sampling_mask_len=torch.tensor(
+            [3], dtype=torch.int32, device="cuda"
+        ),
+        next_token_sampling_logprobs=torch.tensor(
+            [-0.5], dtype=torch.float32, device="cuda"
+        ),
+    )
+    result = GenerationBatchResult(
+        logits_output=output,
+        next_token_ids=torch.tensor([0], dtype=torch.int64, device="cuda"),
+        copy_done=torch.cuda.Event(),
+    )
+
+    copy_stream = torch.cuda.Stream()
+    copy_stream.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(copy_stream):
+        result.copy_to_cpu(return_logprob=False, return_hidden_states=False)
+    result.copy_done.synchronize()
+
+    assert result.logits_output.next_token_sampling_mask_idx.device.type == "cpu"
+    assert result.logits_output.next_token_sampling_mask_len.device.type == "cpu"
+    assert result.logits_output.next_token_sampling_logprobs.device.type == "cpu"
+    assert result.logits_output.next_token_sampling_mask_idx.tolist() == [[3, 2, 0]]
+    assert result.logits_output.next_token_sampling_mask_len.tolist() == [3]
+    assert result.logits_output.next_token_sampling_logprobs.tolist() == [-0.5]


### PR DESCRIPTION
return_sampling_mask currently turns GPU tensors into variable-length Python lists inside Sampler.forward. Those host reads synchronize the GPU and block decode before the scheduler can launch the next iteration.

This keeps the reconstructed support in padded tensors, copies it through the existing asynchronous result-copy stream, and builds the public Python lists during result processing. It preserves the current support reconstruction, sampled-token fallback, and returned logprob calculation.

## Summary

- Pack support token IDs, per-row lengths, and selected-token logprobs as tensors.
- Copy those tensors with the existing GenerationBatchResult copy stream.
- Materialize variable-length lists during scheduler result processing.
- Carry mask lengths through pipeline-parallel result transport.

## Verification

- Compared the old and new materialization algorithms across 2,000 randomized top-k/top-p/min-p cases; mask IDs and logprobs matched exactly.
- Ran Python compilation, Black, isort, focused Ruff checks, and git diff checks.
- Verified that this branch merges without conflict with #36173.
- Added CUDA and AMD unit coverage for tensor packing, greedy masks, sampled-token fallback, and asynchronous CPU copying.

The CUDA tests could not be executed in the local workspace because it has no active GPU/Triton driver.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #32992961263](https://github.com/sgl-project/sglang/actions/runs/32992961263)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32992956042](https://github.com/sgl-project/sglang/actions/runs/32992956042)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32992957810](https://github.com/sgl-project/sglang/actions/runs/32992957810)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->