### PR TITLE
[AMD] Fix int32 seqused_k overflow in aiter draft-extend attention

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -2379,7 +2379,14 @@ class AiterAttnBackend(AttentionBackend):
                     if swa_page_table is not None:
                         pt = swa_page_table
                 kv_indptr = self.forward_metadata.kv_indptr
-                seqused_k = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32)
+                # seqused_k MUST be int64 (kv_indptr is int32, so the diff is
+                # int32 and has to be widened). unified_attention derives the
+                # per-tile KV addresses from this dtype: with an int32
+                # seqused_k the whole K/V offset chain stays 32-bit and wraps
+                # once a per-layer KV buffer reaches 2 GiB, silently returning
+                # NaN. The verify (seq_lens + max_q_len) and decode
+                # (seq_lens) call sites pass int64 for the same reason.
+                seqused_k = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int64)
                 unified_attention(
                     q=q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                     k=k_cache.view(


### PR DESCRIPTION
Co-authored-by: chuyeh <chuyeh@amd.com>

## Motivation

### Where the regression came from

The bug was introduced by #30105 (`eec794bce0`, merged 2026-08-22), which routed EAGLE-v2 draft-extend through `unified_attention` on the AITER backend instead of the occupancy-starved `mha_batch_prefill_func` FMHA. The new path is gated by `SGLANG_AITER_UNIFIED_DRAFT_EXTEND`, which defaults to `True`, so every AITER + EAGLE deployment picked it up on upgrade with no opt-in.

The new call site builds `seqused_k` from the KV indptr and casts it to **int32**:

```python
seqused_k = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32)
```

The two pre-existing `unified_attention` call sites in the same file both pass **int64** — target-verify passes `forward_batch.seq_lens + max_q_len` and decode passes `forward_batch.seq_lens`, and `seq_lens` is int64. The draft-extend site is the only int32 one.

That dtype is load-bearing. `unified_attention` propagates it into the per-tile K/V address chain (`seq_len` feeds `tiles_per_segment`, which feeds the `seq_offset` used to index the block table and the KV cache), so with an int32 `seqused_k` the whole offset computation stays 32-bit and wraps once a per-layer KV buffer reaches 2 GiB. The kernel then silently returns NaN — no assert, no error, just corrupted attention output.

Because only the draft model's attention is corrupted, the failure is quiet: the target model still produces correct text, but the draft proposals never match, so speculative decoding degenerates to `accept len: 1.00, accept rate: 0.00` and collapses to plain autoregressive decoding (~2.4x TPOT regression). Nothing in the logs points at attention.

### Why raising `--max-running-requests` from 4 to 128 hides it

This was first hit on Qwen3.5-397B-A17B-MXFP4 (MI355X, TP2, EAGLE, fp8 KV, page 16), where the same server script failed at `--max-running-requests 4` and was fine at `128`. That looked like a batch-size bug, but the request count is incidental — it only changes the bug's actual trigger, which is the **KV pool size**.

Qwen3.5 is a hybrid model, so its mamba state cache is sized by `max_running_requests`, and whatever the mamba cache does not take is handed to the KV pool. Dropping from 128 to 4 slots frees ~27.8 GB, which grows `max_total_num_tokens` by ~3.9 M tokens and pushes the draft model's single-layer KV buffer over 2 GiB:

| `--max-running-requests` | mamba cache | `max_total_num_tokens` | draft per-layer K buffer | draft-extend attention |
|---|---|---|---|---|
| 128 | 28.95 GB | 6,486,768 | 1.55 GiB (under 2^31 B) | OK, accept len 2.94 |
| 4 | 1.13 GB | 10,429,968 | 2.49 GiB (over 2^31 B) | NaN, accept len 1.00 |

At 256 B/token for that buffer, the threshold is exactly `2^31 / 256 = 8,388,608` tokens, which a direct bisect on `--max-total-tokens` confirms (8,380,416 works, 8,404,992 fails — see Accuracy Tests). So `--max-running-requests 128` "fixes" it only by shrinking the KV pool back under 2 GiB; any configuration that grows a per-layer KV buffer to 2 GiB hits the same bug, including large `--max-running-requests` on a bigger GPU or a higher `--mem-fraction-static`.

## Modifications

- `python/sglang/srt/layers/attention/aiter_backend.py`: in the DRAFT_EXTEND_V2 `unified_attention` branch of `forward_extend`, widen `seqused_k` to `torch.int64` instead of `torch.int32` (`kv_indptr` is int32, so the indptr difference is int32 and must be widened explicitly). Added a comment recording the invariant and why the other two call sites already pass int64.

This is a one-line dtype change; no behavioral change below the 2 GiB threshold, and no change to the legacy `mha_batch_prefill_func` path.

## Accuracy Tests

Qwen3.5-397B-A17B-MXFP4, MI355X x2 (TP2), EAGLE `--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`, `--kv-cache-dtype fp8_e4m3 --page-size 16 --disable-radix-cache --max-running-requests 4`, `SGLANG_USE_AITER_UNIFIED_ATTN=1`. Workload: random ISL 4096 / OSL 256, concurrency 4, 16 prompts. The KV pool size was pinned with `--max-total-tokens` to bracket the 2 GiB boundary.

| `max_total_num_tokens` | draft per-layer KV buffer | `SGLANG_AITER_UNIFIED_DRAFT_EXTEND` | accept len before | accept len after |
|---|---|---|---|---|
| 8,380,416 | 2.000 GiB (just under 2^31 B) | 1 | 3.59 | 3.59 |
| 8,404,992 | 2.004 GiB (just over 2^31 B) | 1 | **1.03** | **3.53** |
| 8,404,992 | 2.004 GiB | 0 (legacy FMHA path) | 3.51 | 3.51 |

Greedy generation was already correct on the broken configuration (`"The capital of France is Paris."`), because only the draft model's attention was corrupted; it remains correct after the fix.

Isolated kernel check on the draft layer's shapes (16 q heads / 1 kv head / head_dim 256, fp8 KV, q_len 4, kv_len 4096, bs 4), max absolute error against an fp32 torch reference:

| KV cache allocation | `seqused_k` dtype | max abs error |
|---|---|---|
| 1.6 GiB | int32 | 1.0e-4 |
| 2.0 GiB (2^31 B) | int32 | **NaN** |
| 2.0 GiB (2^31 B) | int64 | 1.0e-4 |
| 2.87 GiB (block offsets up to 2.46e9) | int64 | 1.0e-4 |

The int32 failure is reproducible and depends only on the KV cache size, not on which pages the batch actually touches. Arguably `unified_attention` should not let an index dtype affect correctness at all; this is worth fixing in AITER as well, but SGLang should pass int64 here regardless, to match its other two call sites.

## Benchmarking and Profiling

Same server/workload as above, on the affected configuration (`--max-total-tokens 8404992`):

| Metric | Before (broken) | After (fix) | Legacy FMHA path (env=0) |
|---|---|---|---|
| Mean accept len | 1.03 | 3.53 | 3.51 |
| Median E2E latency (ms) | 3871.34 | 1592.91 | 1605.30 |
| Mean TTFT (ms) | 552.31 | 293.27 | 293.90 |
| Mean TPOT (ms) | 12.99 | 5.45 | 5.53 |

The fix restores the unified draft-extend path to full speculative throughput, and it stays slightly ahead of the legacy FMHA path (TPOT 5.45 ms vs 5.53 ms), which is the speedup PR #30105 was after.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review Process

1. Ping Merge Oncalls to start the PR flow. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - `/tag-run-ci-label`, `/rerun-failed-ci`, `/tag-and-rerun-ci`
4. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #32992585868](https://github.com/sgl-project/sglang/actions/runs/32992585868)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #32992585713](https://github.com/sgl-project/sglang/actions/runs/32992585713)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #32992585831](https://github.com/sgl-project/sglang/actions/runs/32992585831)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->