### PR TITLE
[Bugfix] Abort streaming-session requests on client disconnect (#36475)

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -226,6 +226,10 @@ class ReqState:
 
     # For performance metrics
     time_stats: APIServerReqTimeStats
+
+    # HTTP request handle, for client-disconnect probing of streaming
+    # sessions (see _await_session_ready_for_new_turn).
+    request: Optional[fastapi.Request] = None
     last_completion_tokens: int = 1
     ttft_observed: bool = False
 
@@ -581,6 +585,15 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
     def init_running_status(self):
         # Request states
         self.rid_to_state: Dict[str, ReqState] = {}
+        # Streaming-session bookkeeping for client-disconnect aborts dispatched
+        # from _discard_pending_req_states. Maps the aborted rid to its session
+        # id and the session id to the settle event a follow-up request on the
+        # same session waits on (see _await_session_disconnect_settled).
+        self.disconnect_aborted_rid_to_session: Dict[str, str] = {}
+        self.session_settle_events: Dict[str, asyncio.Event] = {}
+        # session_id -> rid of the most recently dispatched request on that
+        # streaming session (validated against rid_to_state on use).
+        self.session_inflight_rids: Dict[str, str] = {}
         self.event_loop = None
         self.asyncio_tasks = set()
 
@@ -815,6 +828,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     state = self.rid_to_state[obj.rid]
                     if obj.return_prompt_token_ids:
                         state.prompt_token_ids = list(tokenized_obj.input_ids)
+                    if obj.is_single:
+                        session_id = self._get_session_params_id(obj.session_params)
+                        if session_id:
+                            await self._await_session_ready_for_new_turn(session_id)
+                            self.session_inflight_rids[session_id] = obj.rid
                     self._send_one_request(tokenized_obj)
                     async for response in self._wait_one_response(obj, request):
                         yield response
@@ -2186,6 +2204,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Known race: /health_generate pops its rid as soon as ANY message bumps last_receive_tstamp.
                 if rid.startswith(HEALTH_CHECK_RID_PREFIX):
                     continue
+                if recv_obj.finished_reasons[i]:
+                    self._mark_session_settled_for_rid(rid)
                 logger.error(
                     f"Received output for {rid=} but the state was deleted in TokenizerManager."
                 )
@@ -2443,6 +2463,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     )
 
                 del self.rid_to_state[rid]
+                self._mark_session_settled_for_rid(rid)
 
                 # Mark ongoing LoRA request as finished.
                 if self.enable_lora and state.obj.lora_path:
@@ -3166,6 +3187,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # disconnects, amplified by prefix / abort_all fan-out.
         state = self.rid_to_state.get(recv_obj.rid)
         if state is None:
+            self._mark_session_settled_for_rid(recv_obj.rid)
             logger.info(
                 "Abort request for rid=%s not found in rid_to_state; "
                 "likely already finished/removed.",
@@ -3410,6 +3432,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 raise ValueError(f"Duplicate request ID detected: {rid}")
             time_stats = APIServerReqTimeStats(disagg_mode=self.disaggregation_mode)
             state = ReqState([], False, asyncio.Event(), sub_obj, time_stats)
+            state.request = request
             self.rid_to_state[rid] = state
             if self.enable_trace:
                 time_stats.init_trace_ctx(rid, bootstrap_room, external_trace_header)
@@ -3427,7 +3450,107 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         else:
             rids = obj.rid
         for rid in rids:
-            self.rid_to_state.pop(rid, None)
+            state = self.rid_to_state.pop(rid, None)
+            if (
+                state is not None
+                and not state.finished
+                and not getattr(obj, "background", False)
+            ):
+                # Torn down before completion: almost always a client
+                # disconnect. The request can still be live on the scheduler,
+                # and once its state is gone here the delayed background abort
+                # from create_abort_task is a no-op (abort_request
+                # early-returns for unknown rids). Abort it now so its KV is
+                # released promptly and streaming sessions roll back to the
+                # last committed turn, instead of decoding to max_new_tokens
+                # as a zombie whose output is later committed into the
+                # session (or racing the next turn's pre-abort and leaking
+                # pool memory, cf. #36475).
+                self._dispatch_to_scheduler(
+                    AbortReq(rid=rid, abort_message="Client disconnected")
+                )
+                session_id = self._get_session_params_id(
+                    getattr(state.obj, "session_params", None)
+                )
+                if session_id:
+                    self._register_session_settle_event(session_id, rid)
+
+    @staticmethod
+    def _get_session_params_id(session_params):
+        """session_params is a dict on GenerateReqInput and a SessionReqParam
+        object once tokenized; accept both."""
+        if session_params is None:
+            return None
+        if isinstance(session_params, dict):
+            return session_params.get("id")
+        return getattr(session_params, "id", None)
+
+    def _register_session_settle_event(self, session_id: str, rid: str):
+        """Track rid -> session and arm a fresh settle event for the session."""
+        self.disconnect_aborted_rid_to_session[rid] = session_id
+        event = self.session_settle_events.get(session_id)
+        if event is None or event.is_set():
+            self.session_settle_events[session_id] = asyncio.Event()
+
+    async def _await_session_ready_for_new_turn(self, session_id):
+        """Make sure the previous turn on a streaming session is retired
+        before dispatching a new one.
+
+        If the previous turn's client disconnected mid-stream, abort that
+        request and wait until the scheduler retires it, so the new request is
+        admitted against the rolled-back session state (mirroring the
+        explicit /abort_request behavior) instead of being pre-aborted by
+        SessionController.create_req while the old request is still in flight.
+        """
+        if not session_id:
+            return
+        inflight_rid = self.session_inflight_rids.get(session_id)
+        if inflight_rid is not None:
+            state = self.rid_to_state.get(inflight_rid)
+            if (
+                state is not None
+                and state.request is not None
+                and not getattr(state.obj, "background", False)
+                and await state.request.is_disconnected()
+            ):
+                self._register_session_settle_event(session_id, inflight_rid)
+                self.abort_request(inflight_rid)
+            # If the state is already gone, the disconnect teardown path has
+            # dispatched the abort and armed the event itself.
+        await self._await_session_disconnect_settled(session_id)
+
+    def _mark_session_settled_for_rid(self, rid: str):
+        """Signal that a client-disconnect-aborted request has settled."""
+        session_id = self.disconnect_aborted_rid_to_session.pop(rid, None)
+        if session_id is None:
+            return
+        event = self.session_settle_events.get(session_id)
+        if event is not None:
+            event.set()
+
+    async def _await_session_disconnect_settled(self, session_id):
+        """Wait until a just-disconnected streaming session settles.
+
+        A client disconnect aborts the in-flight request, but the scheduler
+        retires it only after its current forward pass completes. A follow-up
+        request racing into that window is pre-aborted by
+        SessionController.create_req ("Streaming session already has an
+        active request"). Waiting for the aborted request's final output lets
+        the new request run against the rolled-back session state, matching
+        the explicit /abort_request behavior.
+        """
+        if not session_id:
+            return
+        event = self.session_settle_events.get(session_id)
+        if event is None or event.is_set():
+            return
+        try:
+            await asyncio.wait_for(event.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            logger.warning(
+                "Timed out waiting for disconnected session %s to settle",
+                session_id,
+            )
 
     def _should_dispatch_to_encoder(
         self, obj: Union[GenerateReqInput, EmbeddingReqInput]

--- a/python/sglang/test/kits/streaming_session_kit.py
+++ b/python/sglang/test/kits/streaming_session_kit.py
@@ -10,13 +10,16 @@ the fixture only launches the server; the kit owns the `test_*` methods.
 """
 
 import asyncio
+import json
 import time
 
+import aiohttp
 import requests
 
 from sglang.test.server_fixtures.streaming_session_fixture import (
     _abort_repro_run_all,
     _concurrent_logprob_run,
+    _make_token_sized_ids,
     _stress_run_all,
 )
 
@@ -439,4 +442,127 @@ class AbortLeakReproKitMixin:
             health.status_code,
             200,
             "Server unhealthy after abort-heavy streaming session cleanup.",
+        )
+
+
+async def _client_disconnect_turn(
+    http: aiohttp.ClientSession,
+    base_url: str,
+    input_ids: list,
+    session_id: str,
+    gen_len: int,
+    disconnect_after_chunks: int = 0,
+) -> dict:
+    """Stream one session turn; optionally drop the connection mid-stream.
+
+    Returns the last received meta_info."""
+    payload = {
+        "input_ids": input_ids,
+        "session_params": {"id": session_id, "rid": None},
+        "sampling_params": {
+            "temperature": 0,
+            "max_new_tokens": gen_len,
+            "ignore_eos": True,
+            "skip_special_tokens": False,
+        },
+        "stream": True,
+    }
+    last_meta: dict = {}
+    chunks = 0
+    async with http.post(base_url + "/generate", json=payload) as resp:
+        assert resp.status == 200, await resp.text()
+        async for raw_line in resp.content:
+            line = raw_line.decode("utf-8", errors="replace").strip()
+            if not line.startswith("data:"):
+                continue
+            data = line[len("data:") :].strip()
+            if data == "[DONE]":
+                continue
+            item = json.loads(data)
+            if item.get("meta_info") is not None:
+                last_meta = item["meta_info"]
+            chunks += 1
+            if disconnect_after_chunks and chunks >= disconnect_after_chunks:
+                # Exiting the context with the body unread closes the
+                # connection: a mid-turn client disconnect.
+                return last_meta
+    return last_meta
+
+
+async def _client_disconnect_run(base_url: str, tokenizer) -> None:
+    """Repro for #36475: disconnect mid-turn, immediately send the next turn.
+
+    The next turn must be admitted against the last completed turn (rollback
+    semantics, like an explicit /abort_request), not silently corrupted."""
+    timeout = aiohttp.ClientTimeout(total=120)
+    async with aiohttp.ClientSession(timeout=timeout) as http:
+        async with http.post(
+            base_url + "/open_session",
+            json={"capacity_of_str_len": 10_000_000, "streaming": True},
+        ) as resp:
+            assert resp.status == 200, await resp.text()
+            session_id = await resp.json()
+
+        turn_ids = [
+            _make_token_sized_ids(
+                tokenizer, prefix=f"[disconnect repro turn{i}]", min_tokens=n
+            )
+            for i, n in enumerate((512, 64, 64))
+        ]
+        # The session controller strips a leading BOS from appended turns.
+        bos = getattr(tokenizer, "bos_token_id", None)
+        for ids in turn_ids:
+            if bos is not None and ids and ids[0] == bos:
+                ids.pop(0)
+        turn0_ids, turn1_ids, turn2_ids = turn_ids
+        gen_len = 48
+
+        turn0_meta = await _client_disconnect_turn(
+            http, base_url, turn0_ids, session_id, gen_len
+        )
+        turn0_total = turn0_meta["prompt_tokens"] + turn0_meta["completion_tokens"]
+
+        # Turn 1: disconnect after the first streamed chunk.
+        turn1_meta = await _client_disconnect_turn(
+            http, base_url, turn1_ids, session_id, gen_len, disconnect_after_chunks=1
+        )
+        assert turn1_meta["prompt_tokens"] == turn0_total + len(
+            turn1_ids
+        ), f"turn1 lost inherited context: {turn1_meta}"
+
+        # Turn 2 must run against the rolled-back session (last completed
+        # turn = turn 0), not be pre-aborted with a one-token context.
+        turn2_meta = await _client_disconnect_turn(
+            http, base_url, turn2_ids, session_id, gen_len
+        )
+        expected = turn0_total + len(turn2_ids)
+        assert turn2_meta.get("prompt_tokens") == expected, (
+            "turn2 after mid-turn client disconnect lost session context: "
+            f"expected prompt_tokens={expected}, got {turn2_meta}"
+        )
+        finish_type = (turn2_meta.get("finish_reason") or {}).get("type")
+        assert finish_type != "abort", (
+            "turn2 after mid-turn client disconnect was pre-aborted: " f"{turn2_meta}"
+        )
+
+
+class ClientDisconnectKitMixin:
+    """Client disconnects mid-turn (issue #36475)."""
+
+    def test_client_disconnect_next_turn_rolls_back(self) -> None:
+        requests.post(self.base_url + "/flush_cache")
+
+        asyncio.run(_client_disconnect_run(self.base_url, self.tokenizer))
+
+        time.sleep(5)
+        self.assertIsNone(
+            self.process.poll(),
+            "Server crashed during client-disconnect streaming session repro.",
+        )
+
+        health = requests.get(self.base_url + "/health", timeout=10)
+        self.assertEqual(
+            health.status_code,
+            200,
+            "Server unhealthy after client-disconnect streaming session repro.",
         )

--- a/test/registered/sessions/test_streaming_session.py
+++ b/test/registered/sessions/test_streaming_session.py
@@ -10,6 +10,7 @@ import unittest
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.streaming_session_kit import (
     AbortLeakReproKitMixin,
+    ClientDisconnectKitMixin,
     StreamingSessionKitMixin,
 )
 from sglang.test.server_fixtures.streaming_session_fixture import (
@@ -60,6 +61,12 @@ class TestStreamingSessionEagleV2RetractLargePage(TestStreamingSession):
         ("SGLANG_TEST_RETRACT", True),
         ("SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN", True),
     ]
+
+
+class TestStreamingSessionClientDisconnect(
+    StreamingSessionServerBase, ClientDisconnectKitMixin
+):
+    """Client disconnects mid-turn; the next turn must roll back cleanly."""
 
 
 class TestStreamingSessionAbortLeakRepro(


### PR DESCRIPTION
## [Bugfix] Abort streaming-session requests on client disconnect

Fixes #36475

### Problem

With `--enable-streaming-session`, a client that disconnects mid-turn (e.g. a "stop generating" button) corrupts the session for the immediately-following request, and the abandoned turn becomes a zombie:

1. The next request on the same session is pre-aborted by `SessionController.create_req` ("Streaming session already has an active request") and returns a one-token context (`prompt_tokens=1, cached_tokens=0`) - the exact symptom in #36475 (100% repro).
2. The disconnected request keeps decoding to `max_new_tokens` server-side and its output is silently committed into the session context, so a later turn sees tokens the client never received.
3. On slower GPUs (decode ≳ 2s), the delayed abort lands mid-decode and races the follow-up turn's detach, leaking the interrupted turn's KV - the idle pool invariant check then kills the scheduler (ValueError -> SIGQUIT, 5/5 in the issue report).

### Root cause

On disconnect, the async generator in `TokenizerManager.generate_request` is torn down and `_discard_pending_req_states` deletes the rid state immediately (`abort_request` then early-returns for unknown rids). The 2-second delayed abort from `create_abort_task` therefore never fires: nothing aborts the in-flight request, and the session stays in `_inflight=True` for the whole 2s window.

### Fix

1. **Abort at teardown.** When the generator is torn down before completion, dispatch `AbortReq` for dispatched-but-unfinished, non-background requests.
2. **Wait for settle before dispatching the next turn on the same session.** A follow-up request on a streaming session first checks whether the previous turn's client is gone (probe the previous request's HTTP connection; if its state is already deleted, the teardown path has dispatched the abort), and if so waits - event-driven, 5s-bounded - until the aborted request is retired on the scheduler before dispatching.
3. New `ClientDisconnectKitMixin` regression test: disconnect after the first SSE chunk, immediately send the next turn, assert it runs against the last completed turn and the server stays healthy.

### Why this design

**Why abort at teardown instead of fixing the 2s-delayed abort?** The delayed abort cannot be made reliable without keeping the rid state alive: once the generator is torn down the state is deleted, and `abort_request` must early-return for unknown rids (finished requests). Teardown is the single point where we know both (a) the client is gone and (b) the request may still be running.

**Why point 2 is needed - the abort alone is not enough.** The abort is asynchronous: the scheduler retires an aborted *running* request only after its in-flight forward pass completes (~10-30ms). In the issue's repro the follow-up request is dispatched just ~2.4ms after the abort dispatch - well inside that window - so `SessionController.create_req` still sees `_inflight=True` and pre-aborts it. I verified this experimentally: with only the teardown abort (point 1), the repro still failed 5/5 (one-token pre-abort); with point 2 added, it passes 5/5. The explicit `/abort_request` path never hits this race only because it is a synchronous HTTP call - the client sends the next turn after the abort returns, by which time the request has retired. Point 2 reproduces exactly that ordering for the disconnect case, making disconnect and explicit abort behave identically (rollback to the last committed turn).

**Why the proactive `is_disconnected()` probe?** Server-side disconnect detection lags the client by a few milliseconds, so the follow-up's pre-dispatch check can run *before* the teardown has registered its settle event (a ~1ms window that was hit consistently in testing). Probing the previous turn's HTTP connection closes that gap: if the previous owner's socket is already gone, we dispatch the abort ourselves and arm the event, then wait on the same event. A genuinely concurrent double-submit (previous client still connected) is unaffected: no probe hit, no wait, the existing "already has an active request" rejection still applies.

### Validation

Qwen2.5-0.5B-Instruct, single RTX 5090, triton backend, `--disable-cuda-graph`, repro script from the issue. Verified on both the released sglang 0.5.18 (PyPI) and current `main` with this patch applied:

| scenario | before | after |
|---|---|---|
| disconnect -> immediate next turn | `prompt_tokens=1, cached=0` (10/10) | `prompt_tokens=624` rollback, 5/5, exit 0 |
| explicit `/abort_request` control | pass | pass (unchanged) |
| normal multi-turn (no disconnect) | pass | pass - correct inheritance chain 512->624->736 |
| zombie decode after disconnect | decodes to `max_new_tokens`, output committed into session | aborted immediately ("Session KV released" in scheduler log) |
| server health after repro | 200 (fast GPU); SIGQUIT on slow GPU | 200, all runs, no invariant-check failures |

Note: the scheduler-crash variant requires the delayed abort to land mid-decode (needs decode ≳ 2s) and did not reproduce on the fast test GPU even before the patch; the mechanism analysis is in #36475. This patch removes the race window by aborting at disconnect time.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33003592174](https://github.com/sgl-project/sglang/actions/runs/33003592174)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33003591993](https://github.com/sgl-project/sglang/actions/runs/33003591993)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33003592171](https://github.com/sgl-project/sglang/actions/runs/33003592171)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->