### PR TITLE
[diffusion] Accept mesh benchmark artifacts

### DIFF
--- a/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/SKILL.md
+++ b/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/SKILL.md
@@ -107,7 +107,8 @@ synthetic warmup contract. Treat that as Eager fallback, not as a valid BCG
 measurement.
 
 A zero process exit is not sufficient evidence: every accepted row must also
-contain its requested perf dump and a generated image, video, or audio file.
+contain its requested perf dump and a generated image, video, audio, or 3D mesh
+file.
 The helper gives every cell a unique output name and rejects missing artifacts.
 
 On machines with a read-only Hugging Face cache, combine

--- a/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/benchmark-and-profile.md
+++ b/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/benchmark-and-profile.md
@@ -160,10 +160,10 @@ Eager/BCG/BCG/Eager at `lossless`, then the same sequence at `high`, while
 holding one GPU set and one isolated checkpoint cache. The high+BCG cells test
 whether the combination is actually supported; do not average them when the
 runtime rejects the combination or the helper detects a late quality-fusion
-mount. The helper also hashes every generated artifact, first requires the two
-Eager rows at each quality to agree, then rejects any BCG row whose hash differs
-from that Eager reference. Cleanup occurs only after all eight runs, including
-on failure or interruption:
+mount. The helper hashes every generated image, video, audio, or 3D mesh
+artifact. It first requires the two Eager rows at each quality to agree, then
+rejects any BCG row whose hash differs from that Eager reference. Cleanup occurs
+only after all eight runs, including on failure or interruption:
 
 ```bash
 MODEL_CACHE_ROOT=/path/to/task-owned/model-caches

--- a/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/scripts/bench_diffusion_denoise.py
+++ b/python/sglang/multimodal_gen/.claude/skills/sglang-diffusion-benchmark-profile/scripts/bench_diffusion_denoise.py
@@ -121,7 +121,16 @@ MODEL_WEIGHT_SUFFIXES = {
     ".pth",
     ".safetensors",
 }
-GENERATED_OUTPUT_SUFFIXES = {".jpeg", ".jpg", ".mp4", ".png", ".wav", ".webp"}
+GENERATED_OUTPUT_SUFFIXES = {
+    ".glb",
+    ".jpeg",
+    ".jpg",
+    ".mp4",
+    ".obj",
+    ".png",
+    ".wav",
+    ".webp",
+}
 NIGHTLY_PRESET_ORDER = (
     "flux",
     "flux2",

--- a/python/sglang/multimodal_gen/test/unit/test_diffusion_benchmark_skill.py
+++ b/python/sglang/multimodal_gen/test/unit/test_diffusion_benchmark_skill.py
@@ -464,6 +464,41 @@ class TestDiffusionBenchmarkSkill(unittest.TestCase):
                 result["missing_artifacts"], ["perf dump", "generated output"]
             )
 
+    def test_mesh_artifacts_are_accepted_and_hashed(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            temp_root = Path(tmpdir)
+            module = _load_benchmark_module(temp_root)
+            output_dir = temp_root / "outputs"
+            output_dir.mkdir()
+
+            def finish_run():
+                (output_dir / "hunyuan3d-shape_mesh-output.json").write_text(
+                    json.dumps({"total_duration_ms": 1000, "steps": []}),
+                    encoding="utf-8",
+                )
+                (output_dir / "hunyuan3d-shape-mesh-output.obj").write_bytes(
+                    b"v 0 0 0\n"
+                )
+                return 0
+
+            with patch.object(module.subprocess, "Popen") as popen:
+                popen.return_value.stdout = iter(())
+                popen.return_value.wait.side_effect = finish_run
+                result = module._run_benchmark_once_impl(
+                    "hunyuan3d-shape",
+                    "mesh-output",
+                    output_dir,
+                    warmup=False,
+                    cuda_visible_devices="0",
+                )
+
+            self.assertFalse(result["error"])
+            self.assertEqual(
+                result["output_artifacts"],
+                [str(output_dir / "hunyuan3d-shape-mesh-output.obj")],
+            )
+            self.assertEqual(len(result["output_sha256"]), 1)
+
     def test_high_bcg_rejects_quality_fusion_mounted_after_capture(self):
         with tempfile.TemporaryDirectory() as tmpdir:
             temp_root = Path(tmpdir)


### PR DESCRIPTION
## Summary

- accept `.obj` and `.glb` as generated artifacts in the diffusion benchmark helper
- hash mesh outputs with the same artifact-integrity checks used for image, video, and audio outputs
- document 3D mesh coverage in the benchmark skill and add a focused unit test

## Motivation

A native Hunyuan3D-2 shape benchmark on H100 completed successfully and produced both its perf dump and a 22.8 MB OBJ, but the helper reported a false failure because mesh suffixes were not in `GENERATED_OUTPUT_SUFFIXES`. This made valid Hunyuan3D rows unusable in eager/compile/BCG investigations.

## Validation

- `pytest -q python/sglang/multimodal_gen/test/unit/test_diffusion_benchmark_skill.py` (14 passed)
- targeted `pre-commit run --files ...` (all applicable hooks passed)
- real native-backend Hunyuan3D-2 H100 run accepted and hashed the generated OBJ

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33051887803](https://github.com/sgl-project/sglang/actions/runs/33051887803)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33058799428](https://github.com/sgl-project/sglang/actions/runs/33058799428)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33051887866](https://github.com/sgl-project/sglang/actions/runs/33051887866)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->