### PR TITLE
[AMD] Support gfx942 in TileLang DSV4 indexer

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -1492,6 +1492,14 @@ def tilelang_fp8_paged_mqa_logits(
     _ = deep_gemm_metadata
     batch_size, _, num_heads, head_dim = q_fp8.shape
     block_size = kvcache_fp8.shape[1]
+    if q_fp8.dtype != FP8_DTYPE:
+        assert _is_fp8_fnuz and q_fp8.dtype == torch.float8_e4m3fn, (
+            f"Unsupported mixed FP8 formats: query={q_fp8.dtype}, "
+            f"kernel={FP8_DTYPE}"
+        )
+        # Support E4M3FNUZ on gfx942.
+        q_fp8 = q_fp8.view(torch.uint8).view(FP8_DTYPE)
+        weight = weight * 2.0
     assert head_dim == 128, "TODO"
     assert block_size == 64, "TODO"
     assert q_fp8.shape == (batch_size, 1, num_heads, head_dim)


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
On the ROCm 7.0 MI300X image, the Aiter indexer is unavailable due to a Triton version incompatibility. The TileLang indexer previously failed because the query uses E4M3FN while the kernel expects E4M3FNUZ.
To run DeepSeek-V4-Flash on this image, enable the TileLang indexer in the existing launch command:
```bash
export SGLANG_OPT_USE_TILELANG_INDEXER=1
```

## Modifications

<!-- Detail the changes made in this pull request. -->
Add gfx942 support to the TileLang DSV4 indexer by reinterpreting the E4M3FN query as E4M3FNUZ and scaling the corresponding weights by 2 to preserve the original values.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->
launch server:
```
SGLANG_OPT_USE_TILELANG_INDEXER=1 \
SGLANG_USE_ROCM700A=0 \
SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
AITER_BF16_FP8_MOE_BOUND=0 \
sglang serve \
  --trust-remote-code \
  --model-path /data/models/DeepSeek-V4-Flash-FP8 \
  --tp 8 \
  --attention-backend dsv4 \
  --page-size 256 \
  --mem-fraction-static 0.90 \
  --swa-full-tokens-ratio 0.1 \
  --disable-shared-experts-fusion \
  --kv-cache-dtype fp8_e4m3 \
  --chunked-prefill-size 8192 \
  --host 0.0.0.0 \
  --port 30000
```
GSM8K accuracy: 0.945

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33005471119](https://github.com/sgl-project/sglang/actions/runs/33005471119)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33005470803](https://github.com/sgl-project/sglang/actions/runs/33005470803)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33005471075](https://github.com/sgl-project/sglang/actions/runs/33005471075)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->