### PR TITLE
fix(qsa): support SM120/SM121 sparse decode paths

### DIFF
--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -53,9 +53,9 @@ def _resolve_trtllm_sparse_decode():
     at decode row counts; the trtllm-gen decode kernel over a page-aligned
     scratch measures ~35% faster for the gather+attention pair.
     """
-    from sglang.srt.utils import is_sm100_supported
+    from sglang.srt.utils import is_sm100_supported, is_sm120_supported
 
-    if not is_sm100_supported():
+    if not (is_sm100_supported() or is_sm120_supported()):
         return None
     try:
         from flashinfer.decode import trtllm_batch_decode_with_kv_cache
@@ -68,9 +68,17 @@ def _resolve_trtllm_sparse_decode():
 def _resolve_flash_attn_varlen_func():
     """The dense varlen kernel behind the packed sparse-decode fallback.
 
-    Classic flash_attn (FA2, Ampere/Hopper) is preferred when installed;
-    flash-attn-4's cute interface serves the same call shape on Blackwell.
+    SM120 uses SGLang's architecture-owned FA4 dispatcher. Other platforms
+    prefer classic flash_attn (FA2) before flash-attn-4's cute interface.
     """
+    from sglang.srt.utils import is_sm120_supported
+
+    if is_sm120_supported():
+        from sglang.kernels.ops.attention.flash_attention_v4 import (
+            flash_attn_varlen_func,
+        )
+
+        return flash_attn_varlen_func
     try:
         from flash_attn import flash_attn_varlen_func
 

--- a/test/registered/kernels/test_qsa.py
+++ b/test/registered/kernels/test_qsa.py
@@ -1,5 +1,5 @@
 import sys
-from types import SimpleNamespace
+from types import ModuleType, SimpleNamespace
 
 import pytest
 import torch
@@ -42,6 +42,62 @@ COMPRESS_RATIO = 4
 TOKEN_TOPK = 2048
 BLOCK_TOPK = TOKEN_TOPK // COMPRESS_RATIO
 FINAL_TOPK = TOKEN_TOPK + COMPRESS_RATIO - 1
+
+
+def test_qsa_trtllm_sparse_decode_is_enabled_on_sm120(monkeypatch):
+    resolver = qsa_backend_module._resolve_trtllm_sparse_decode
+    resolver.cache_clear()
+
+    trtllm_decode_func = object()
+    flashinfer_decode = ModuleType("flashinfer.decode")
+    flashinfer_decode.trtllm_batch_decode_with_kv_cache = trtllm_decode_func
+
+    monkeypatch.setattr("sglang.srt.utils.is_sm100_supported", lambda: False)
+    monkeypatch.setattr("sglang.srt.utils.is_sm120_supported", lambda: True)
+    monkeypatch.setitem(sys.modules, flashinfer_decode.__name__, flashinfer_decode)
+
+    try:
+        assert resolver() is trtllm_decode_func
+    finally:
+        resolver.cache_clear()
+
+
+def test_qsa_varlen_fallback_uses_sglang_fa4_on_sm120(monkeypatch):
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+
+    sglang_varlen_func = object()
+    classic_varlen_func = object()
+    sglang_fa4 = ModuleType("sglang.kernels.ops.attention.flash_attention_v4")
+    sglang_fa4.flash_attn_varlen_func = sglang_varlen_func
+    classic_fa = ModuleType("flash_attn")
+    classic_fa.flash_attn_varlen_func = classic_varlen_func
+
+    monkeypatch.setattr("sglang.srt.utils.is_sm120_supported", lambda: True)
+    monkeypatch.setitem(sys.modules, sglang_fa4.__name__, sglang_fa4)
+    monkeypatch.setitem(sys.modules, classic_fa.__name__, classic_fa)
+
+    try:
+        assert resolver() is sglang_varlen_func
+    finally:
+        resolver.cache_clear()
+
+
+def test_qsa_varlen_fallback_keeps_classic_fa_preference_off_sm120(monkeypatch):
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+
+    classic_varlen_func = object()
+    classic_fa = ModuleType("flash_attn")
+    classic_fa.flash_attn_varlen_func = classic_varlen_func
+
+    monkeypatch.setattr("sglang.srt.utils.is_sm120_supported", lambda: False)
+    monkeypatch.setitem(sys.modules, classic_fa.__name__, classic_fa)
+
+    try:
+        assert resolver() is classic_varlen_func
+    finally:
+        resolver.cache_clear()
 
 
 def test_qwen4_exp_indexer_config_is_read_from_text_config():


### PR DESCRIPTION
## Title

fix(qsa): support SM120/SM121 sparse decode paths

## Description

This is a stacked fix for #36531 on top of #36497. The PR base should be `qwen4-main-squashed`.

## Summary

- enable the existing FlashInfer TRTLLM sparse-decode path on SM120 and SM121
- use SGLang's architecture-owned FA4 dispatcher as the fallback for devices matched by the existing major-12 capability gate
- preserve the existing FA2-first fallback order on non-SM12x GPUs
- add focused resolver tests for the SM12x fast path, SM12x fallback, and non-SM12x behavior

## Why

On SM120, `_resolve_trtllm_sparse_decode()` rejected the architecture even though FlashInfer 0.6.17 supports this QSA decode shape. The code then fell through to the pip `flash_attn.cute.interface` implementation, which fails during warmup for the packed QSA varlen shape.

On SM120 and SM121, the normal path now uses TRTLLM decode. If FlashInfer is unavailable, devices matched by the existing major-12 capability gate use SGLang's architecture-owned FA4 dispatcher instead of the incompatible pip implementation.

The TRTLLM path has been validated on both SM120 and SM121. The SGLang FA4 fallback was directly validated on SM120.

Fixes #36531.
Fixes #36558.

## Validation

- `pytest -q test/registered/kernels/test_qsa.py -k 'qsa_trtllm_sparse_decode_is_enabled_on_sm120 or qsa_varlen_fallback'`
  - `3 passed, 52 deselected`
- RTX 5090 (SM120), CUDA 13.0, PyTorch 2.13.0, QSA shape
  `q=[1,24,256]`, `kv=[2051,2,256]`
  - reproduced the pip FA4 failure as `CUDADialectError`; the generated kernel requested 131072 bytes of shared memory while the GPU allows 101376 bytes
  - FlashInfer 0.6.17 TRTLLM path matched the PyTorch reference (`max_abs_diff=7.18e-4`) and passed CUDA Graph replay
  - SGLang SM120 FA4 fallback matched the PyTorch reference (`max_abs_diff=4.44e-4`) and passed CUDA Graph replay
- `git diff --check`
- `python -m compileall` on the changed source and test files
- Ruff `F821,UP037` checks on the changed source and test files
- Community validation on SM121 (GB10, 2x DGX Spark, TP=2):
  - FlashInfer TRTLLM output matched the PyTorch reference (`max_abs_diff=4.70e-4`)
  - CUDA Graph replay passed
  - Qwen3.8-Flash-Next loaded, captured NEXTN decode graphs, and served end to end
  - See https://github.com/sgl-project/sglang/pull/36556#issuecomment-5430954780

The full Qwen3.8-Flash-Next server was not launched on this 32 GiB GPU; the failure and both replacement paths were validated directly with the model's packed sparse-decode kernel shape.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33005601878](https://github.com/sgl-project/sglang/actions/runs/33005601878)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33005601538](https://github.com/sgl-project/sglang/actions/runs/33005601538)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33005601802](https://github.com/sgl-project/sglang/actions/runs/33005601802)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->