### PR TITLE
Release the weight-checker snapshot once compare passes

### DIFF
--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -8,6 +8,7 @@ import torch.distributed as dist
 from pydantic import BaseModel, ConfigDict
 
 from sglang.srt.managers.mm_utils import tensor_hash
+from sglang.srt.mem_cache.storage.mmap.mmap_allocator import alloc_mmap
 from sglang.srt.utils.weight_checker_comparator import (
     CHUNK_NUMEL,
     ComparableWeight,
@@ -87,6 +88,7 @@ class WeightChecker:
         self._get_model = get_model
         self._ps = ps
         self._snapshot_tensors = None
+        self._snapshot_arena = None
 
     def handle(
         self,
@@ -112,12 +114,29 @@ class WeightChecker:
             raise Exception(f"Unsupported {action=}")
 
     def _snapshot(self):
-        named_tensors = [
-            (name, param.data.detach().cpu()) for name, param in self._model_state()
-        ]
-        self._snapshot_tensors = dict(named_tensors)
+        # Back the snapshot with one mmap so releasing it returns the memory to
+        # the OS: the per-tensor copies are mostly below glibc's mmap threshold,
+        # and freeing arena chunks does not shrink RSS (Grace/64K pages: even
+        # malloc_trim reclaims nothing).
+        named_params = [(name, param.data) for name, param in self._model_state()]
+        align = 64
+        offsets, total = [], 0
+        for _, param in named_params:
+            offsets.append(total)
+            total += (param.nbytes + align - 1) // align * align
+        self._snapshot_arena = alloc_mmap((max(total, align),), torch.uint8)
+        snapshot_tensors = {}
+        for (name, param), offset in zip(named_params, offsets):
+            view = (
+                self._snapshot_arena[offset : offset + param.nbytes]
+                .view(param.dtype)
+                .view(param.shape)
+            )
+            view.copy_(param.detach())
+            snapshot_tensors[name] = view
+        self._snapshot_tensors = snapshot_tensors
         assert len(self._snapshot_tensors) == len(
-            named_tensors
+            named_params
         ), f"should not have duplicated tensor name"
 
     def _skip_compare_names(
@@ -155,6 +174,11 @@ class WeightChecker:
             ),
             allow_quant_error=allow_quant_error,
         )
+        # The snapshot is a host copy of every weight (tens of GB for a large
+        # model), only ever consumed here. Release it once the check passes --
+        # dropping the arena munmaps it; a failed compare keeps it for debugging.
+        self._snapshot_tensors = None
+        self._snapshot_arena = None
 
     def _compute_checksum(self, skip_tensor_list: Optional[List[str]] = None) -> Dict:
         torch.cuda.synchronize()

--- a/python/sglang/srt/utils/weight_checker.py
+++ b/python/sglang/srt/utils/weight_checker.py
@@ -114,12 +114,8 @@ class WeightChecker:
             raise Exception(f"Unsupported {action=}")
 
     def _snapshot(self):
-        # Back the snapshot with one mmap so releasing it returns the memory to
-        # the OS: the per-tensor copies are mostly below glibc's mmap threshold,
-        # and freeing arena chunks does not shrink RSS (Grace/64K pages: even
-        # malloc_trim reclaims nothing).
         named_params = [(name, param.data) for name, param in self._model_state()]
-        align = 64
+        align = 64  # torch CPU-allocator alignment
         offsets, total = [], 0
         for _, param in named_params:
             offsets.append(total)
@@ -174,9 +170,6 @@ class WeightChecker:
             ),
             allow_quant_error=allow_quant_error,
         )
-        # The snapshot is a host copy of every weight (tens of GB for a large
-        # model), only ever consumed here. Release it once the check passes --
-        # dropping the arena munmaps it; a failed compare keeps it for debugging.
         self._snapshot_tensors = None
         self._snapshot_arena = None
 

--- a/test/registered/unit/utils/test_weight_checker.py
+++ b/test/registered/unit/utils/test_weight_checker.py
@@ -573,6 +573,21 @@ class TestCompare(_WeightCheckerTestBase):
         self.checker._snapshot()
         self.checker._compare()  # no exception
 
+    def test_success_releases_snapshot(self):
+        self.checker._snapshot()
+        self.checker._compare()
+        self.assertIsNone(self.checker._snapshot_tensors)
+        self.assertIsNone(self.checker._snapshot_arena)
+        with self.assertRaises(AssertionError):
+            self.checker._compare()
+
+    def test_failure_keeps_snapshot(self):
+        self.checker._snapshot()
+        self.checker._reset_tensors()
+        with self.assertRaises(Exception):
+            self.checker._compare()
+        self.assertIsNotNone(self.checker._snapshot_tensors)
+
     def test_fails_after_reset_on_normal_param(self):
         self.checker._snapshot()
         self.checker._reset_tensors()


### PR DESCRIPTION
The snapshot is a host copy of every weight, and compare is its only consumer. Keeping it after a passed check holds weights-sized host memory for the process lifetime — 35 GB per TP8 rank on DeepSeek-V4-284B, observed idle for a full 10h RL run. A failed compare keeps the snapshot for debugging.

Evidence: on 8×GB300 colocated RL, `--check-weight-update-equal` fires snapshot/reset/compare exactly once at init; the retained snapshot then contributes 4×35 GB/node to the host budget at every trainer sleep, and the job cgroup's `memory.events` records boundary `oom_kill`s at the 898 GiB limit with the snapshot resident.

Semantics: a second compare without a fresh snapshot now raises, matching the existing `test_without_snapshot_raises` contract; two new unit tests pin release-on-success and keep-on-failure. Full `test_weight_checker.py` suite passes on GB300 (62 passed).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33426900003](https://github.com/sgl-project/sglang/actions/runs/33426900003)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33426899826](https://github.com/sgl-project/sglang/actions/runs/33426899826)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33426899896](https://github.com/sgl-project/sglang/actions/runs/33426899896)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->