### PR TITLE
state_capturer: pin the exact host-cache size via mmap + cudaHostRegister

### DIFF
--- a/python/sglang/srt/state_capturer/base.py
+++ b/python/sglang/srt/state_capturer/base.py
@@ -5,6 +5,10 @@ from typing import Optional
 import torch
 
 from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.pool_host.common import (
+    ALLOC_MEMORY_FUNCS,
+    HostTensorAllocator,
+)
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 logger = logging.getLogger(__name__)
@@ -52,13 +56,18 @@ class BaseDeviceCache:
 
 
 class BaseHostCache:
-    def __init__(self, num_tokens: int, num_layers: int, topk_size: int, name: str):
-        self.buffer = torch.zeros(
+    def __init__(
+        self, num_tokens: int, num_layers: int, topk_size: int, name: str, device: str
+    ):
+        alloc = ALLOC_MEMORY_FUNCS[device]
+        self.buffer = alloc(
             (num_tokens, num_layers, topk_size),
             dtype=torch.int32,
             device="cpu",
             pin_memory=True,
+            allocator=HostTensorAllocator(),
         )
+        self.buffer.zero_()
         self.num_tokens = num_tokens
         self.num_layers = num_layers
         self.topk_size = topk_size
@@ -115,7 +124,9 @@ class BaseTopkCapturer:
         self.num_layers = num_layers
         self.topk_size = topk_size
 
-        self.host_cache = BaseHostCache(num_tokens, num_layers, topk_size, name=name)
+        self.host_cache = BaseHostCache(
+            num_tokens, num_layers, topk_size, name=name, device=device
+        )
         self.device_cache = BaseDeviceCache(
             max_batch_size,
             num_layers,


### PR DESCRIPTION
BaseHostCache sizes its buffer by the KV pool's token capacity, and torch's caching host allocator rounds pinned blocks up to the next power of two — on DeepSeek-V4 at 21M pool tokens the 20.4 GiB request pinned 32 GiB per rank (verified by intercepting the underlying `cudaHostAlloc`, which was exactly 2^35 bytes), i.e. 46 GB of dead host memory per 4-GPU GB300 node for `--use-rollout-routing-replay`. Allocate through the same mmap + cudaHostRegister path the HiCache host pools use (`pool_host.common.ALLOC_MEMORY_FUNCS`), which pins exactly the requested size; npu/musa keep the plain `pin_memory=True` path via the existing dispatch.

Verified on GB300: exact nbytes (zero rounding), `is_pinned()` true, zero-init preserved, D2H/H2D roundtrip intact, `torch.cuda.host_memory_stats()` shows zero caching-host-allocator segments.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33426573312](https://github.com/sgl-project/sglang/actions/runs/33426573312)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33426572697](https://github.com/sgl-project/sglang/actions/runs/33426572697)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33426572928](https://github.com/sgl-project/sglang/actions/runs/33426572928)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->