### PR TITLE
ROCm: charge the aiter paged-decode workspace against the KV pool instead of a flat mem-fraction haircut

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -79,6 +79,12 @@ from sglang.srt.layers.attention.aiter_utils import (
     forward_decode_vectorized_5d,
     forward_extend_vectorized_5d,
 )
+from sglang.srt.layers.attention.aiter_workspace import (
+    AITER_PARTITION_SIZE_ROCM as _AITER_PARTITION_SIZE_ROCM,
+)
+from sglang.srt.layers.attention.aiter_workspace import (
+    aiter_attn_workspace_bytes,
+)
 from sglang.srt.mem_cache.memory_pool import KVWriteLoc
 from sglang.srt.mem_cache.swa_memory_pool import SWAKVPool
 from sglang.srt.utils import get_bool_env_var
@@ -130,9 +136,6 @@ class ForwardMetadata:
     swa_page_table: Optional[torch.Tensor] = None
     # full->SWA translated out_cache_loc (SWA KV-store write target)
     swa_out_cache_loc: Optional[torch.Tensor] = None
-
-
-_AITER_PARTITION_SIZE_ROCM = 256
 
 
 class AiterAttnBackend(AttentionBackend):
@@ -279,13 +282,14 @@ class AiterAttnBackend(AttentionBackend):
             self.max_context_len + _AITER_PARTITION_SIZE_ROCM - 1
         ) // _AITER_PARTITION_SIZE_ROCM
 
-        nbyes_per_qo_elem = torch.finfo(torch.float32).bits // 8
-
         if not (self.use_mla or self.use_triton_unified_attention):
             self.workspace_buffer = torch.empty(
-                (max_bs * self.num_head * self.max_num_partitions * self.head_dim)
-                * nbyes_per_qo_elem
-                + 2 * (max_bs * self.num_head * self.max_num_partitions) * 4,
+                aiter_attn_workspace_bytes(
+                    max_num_reqs=max_bs,
+                    num_head=self.num_head,
+                    head_dim=self.head_dim,
+                    context_len=self.max_context_len,
+                ),
                 dtype=torch.uint8,
                 device=self.device,
             )

--- a/python/sglang/srt/layers/attention/aiter_workspace.py
+++ b/python/sglang/srt/layers/attention/aiter_workspace.py
@@ -1,0 +1,37 @@
+# Copyright 2023-2026 SGLang Team
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""Size of the AITER paged-decode split workspace.
+
+The buffer is allocated by ``AiterAttnBackend`` *after* the KV pool exists, so
+``KVCacheConfigurator`` has to charge it against the pool budget. Both callers
+share this formula rather than inlining it at the ``torch.empty``: the charge
+and the allocation must be the same number, and any gap between them is lost
+memory, linear in the gap.
+"""
+
+AITER_PARTITION_SIZE_ROCM = 256
+
+_FP32_BYTES = 4
+
+
+def aiter_attn_workspace_bytes(
+    *, max_num_reqs: int, num_head: int, head_dim: int, context_len: int
+) -> int:
+    """Bytes of ``AiterAttnBackend.workspace_buffer``: fp32 partial outputs plus
+    the two fp32 (max_logit, exp_sum) reduction planes, one set per partition."""
+    num_partitions = (
+        context_len + AITER_PARTITION_SIZE_ROCM - 1
+    ) // AITER_PARTITION_SIZE_ROCM
+    per_partition = max_num_reqs * num_head * num_partitions
+    return per_partition * head_dim * _FP32_BYTES + 2 * per_partition * _FP32_BYTES

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -27,6 +27,9 @@ from sglang.srt.configs.model_config import (
 from sglang.srt.distributed.parallel_state import get_world_group
 from sglang.srt.distributed.utils import get_pp_indices
 from sglang.srt.environ import envs
+from sglang.srt.layers.attention.aiter_workspace import (
+    aiter_attn_workspace_bytes,
+)
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
     get_kv_cache_quant_method,
     resolve_kv_cache_quant,
@@ -1873,6 +1876,35 @@ class KVCacheConfigurator:
 
         return int(rest_memory * (1 << 30))  # return in bytes
 
+    def _aiter_workspace_bytes(self, max_num_reqs: int) -> int:
+        """Bytes ``AiterAttnBackend`` will allocate for its paged-decode split
+        workspace, or 0 when it allocates none.
+
+        The buffer is created after the KV pool, is fp32 and linear in context
+        length (tens of GB at long context), and no generic reserve covers it.
+        Charging it here rather than against ``mem_fraction_static`` is what
+        keeps the number exact: it is sized from ``req_to_token_pool.size``,
+        i.e. the ``max_num_reqs`` resolved just above, which arg resolution
+        cannot know because it is derived from the pool being sized.
+        """
+        prefill_backend, decode_backend = self.server_args.get_attention_backends()
+        if "aiter" not in (prefill_backend, decode_backend):
+            return 0
+        # Mirrors the three skips at the backend's own `torch.empty`.
+        if (
+            self.use_mla_backend
+            or self.is_hybrid_swa
+            or envs.SGLANG_USE_AITER_UNIFIED_ATTN.get()
+        ):
+            return 0
+        return aiter_attn_workspace_bytes(
+            max_num_reqs=max_num_reqs,
+            num_head=self.model_config.num_attention_heads
+            // get_parallel().attn_tp_size,
+            head_dim=self.model_config.head_dim,
+            context_len=self.model_config.context_len,
+        )
+
     def _calculate_mamba_ratio(self) -> int:
         if get_memory().disable_radix_cache:
             return 1
@@ -2001,6 +2033,17 @@ class KVCacheConfigurator:
         config.max_running_requests = self.resolve_max_num_reqs(
             config.max_total_num_tokens
         )
+        workspace_bytes = self._aiter_workspace_bytes(config.max_running_requests)
+        if workspace_bytes:
+            # Second pass: the workspace is sized from the request count, which
+            # is itself derived from the first pass's capacity. Re-solving once
+            # with the charge applied is what makes the reserve equal the later
+            # allocation -- an estimate here would over- or under-shoot by its
+            # full size, and the buffer is tens of GB at long context.
+            config = self.config_from_budget(available_bytes - workspace_bytes)
+            config.max_running_requests = self.resolve_max_num_reqs(
+                config.max_total_num_tokens
+            )
         configurator = create_memory_pool_configurator(self)
         config = configurator.finalize_with_max_running_requests(config)
         config.mem_fraction_static = get_schedule().mem_fraction_static

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6414,14 +6414,6 @@ class ServerArgs:
 
         run_post_process_pass(self, _fa4_page_constraint)
 
-        # AMD platforms backends
-        if resolved_view(self).attention_backend == "aiter":
-            if model_config.context_len > 8192:
-                self._declare(
-                    "_handle_attention_backend_compatibility",
-                    mem_fraction_static=self.mem_fraction_static * 0.85,
-                )
-
         # Other platforms backends
         run_post_process_pass(self, _attention_backend_platform_fallbacks)
 


### PR DESCRIPTION
# Charge the AITER paged-decode workspace against the KV-pool budget

`AiterAttnBackend` allocates an fp32 paged-decode split workspace
(`self.workspace_buffer`) in its constructor — i.e. *after* the KV pool has
already been sized and allocated. The buffer is linear in context length and
gets large fast: at TP8, 8 q-heads/rank, head_dim 128 and a 128k context it is
4.06 GiB, and 48.50 GiB at 256k with 16 heads and head_dim 192. Nothing in
`KVCacheConfigurator` accounted for it, so the shortfall was papered over in
`ServerArgs._handle_attention_backend_compatibility` with a flat
`mem_fraction_static *= 0.85` applied whenever the aiter backend was selected
with `context_len > 8192`. That fraction is not the workspace size and has no
relationship to it: it over-reserves on short-context or narrow-head configs
and under-reserves at very long context, and every byte of the gap is memory
that is neither KV cache nor workspace — it is simply lost.

This PR replaces the guess with the number. The size formula moves into a new
`python/sglang/srt/layers/attention/aiter_workspace.py` as
`aiter_attn_workspace_bytes()`; `aiter_backend.py` calls it at its
`torch.empty`, and `KVCacheConfigurator._resolve_memory_pool_config` calls it
to subtract exactly that many bytes from the KV budget. The flat 0.85 haircut
is deleted.

The charge needs a second resolve pass, not an estimate. The workspace is sized
from `req_to_token_pool.size`, which is the resolved `max_running_requests` —
itself derived from the pool capacity being solved for. So the resolve computes
capacity once, derives the request count, computes the charge, and re-solves
once with the charge applied. An estimate at this point would miss by the full
size of the buffer in either direction, which at long context is tens of GB.

**The load-bearing property: the charge and the allocation are the same
number.** `aiter_attn_workspace_bytes` has exactly two call sites —

- the charge: `mem_cache/kv_cache_configurator.py`, in `_aiter_workspace_bytes`
- the allocation: `layers/attention/aiter_backend.py`, at the
  `self.workspace_buffer = torch.empty(...)`

— and the formula is not inlined anywhere else (`grep -rn
aiter_attn_workspace_bytes python/` returns the definition, two imports, and
those two calls; the previous inlined expression and its
`nbyes_per_qo_elem` local are gone). The four arguments correspond 1:1:

| argument | allocation site | charge site |
|---|---|---|
| `max_num_reqs` | `model_runner.req_to_token_pool.size` | `config.max_running_requests` |
| `num_head` | `model_config.num_attention_heads // get_parallel().attn_tp_size` | same expression |
| `head_dim` | `model_config.head_dim` | same |
| `context_len` | `model_config.context_len` | same |

`req_to_token_pool.size` *is* `max_running_requests`: every pool class is
constructed with `size=max_num_reqs`, and that `max_num_reqs` is the config's
`max_running_requests` (`DecodeReqToTokenPool` inflates only its backing tensor
by `pre_alloc_size`, not its `.size`). `finalize_with_max_running_requests` is
a no-op on the base configurator and does not revise the request count.

The three skip conditions are mirrored too: `_aiter_workspace_bytes` returns 0
for MLA (`use_mla_backend` is defined as `attention_arch == AttentionArch.MLA`,
the backend's own `use_mla`), for hybrid SWA, and when
`SGLANG_USE_AITER_UNIFIED_ATTN` is set — the same three cases in which the
backend allocates nothing.

Extracting the formula is byte-exact against the expression it replaces;
spot-checked over `(max_num_reqs, num_head, head_dim, context_len)` =
`(2048,8,128,131072)`, `(1,1,1,1)`, `(512,4,64,80000)`,
`(4096,16,192,262144)`, `(2048,8,128,8192)`, all identical.

No-op off ROCm and off the aiter backend: `_aiter_workspace_bytes` returns 0
unless `"aiter"` is one of the resolved prefill/decode backends, and the
second resolve pass is guarded on a non-zero charge, so the CUDA path resolves
its pool in exactly one pass as before. The new module has no imports at all.

## Performance
Measured on 8x MI350X (gfx950), MiniMax-M3-MXFP8, TP8, 80k input / 600 output.
Two bench reps per boot; the warm (second) rep is reported and the two agreed
within 0.1%. Noise floor is +/-0.4%. Tables are the harness output verbatim,
trimmed to the first five columns. Baseline is `aiter-base-AITER`.
**Baseline (`aiter-base-AITER`)**

```
Input lens: [80000]. Output lens: [600]. Cache hit rate: 90.0%.
|   batch size |   input len |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) |
|--------------|-------------|---------------|----------------------------|-----------------------------|
|            1 |       80000 |         10.71 |                     192890 |                       58.29 |
|            2 |       80000 |         11.34 |                     199011 |                      113.9  |
|            4 |       80000 |         12.84 |                     199154 |                      213.72 |
|            8 |       80000 |         15.73 |                     199661 |                      383.26 |
|           16 |       80000 |         21.63 |                     198820 |                      631.81 |
|           32 |       80000 |         32.62 |                     198998 |                      972.12 |
```
**With this PR**

```
Input lens: [80000]. Output lens: [600]. Cache hit rate: 90.0%.
|   batch size |   input len |   latency (s) |   input throughput (tok/s) |   output throughput (tok/s) |
|--------------|-------------|---------------|----------------------------|-----------------------------|
|            1 |       80000 |         10.71 |                     192348 |                       58.29 |
|            2 |       80000 |         11.34 |                     197417 |                      113.98 |
|            4 |       80000 |         12.82 |                     198268 |                      214.08 |
|            8 |       80000 |         15.74 |                     197959 |                      383.89 |
|           16 |       80000 |         21.63 |                     198297 |                      632.71 |
|           32 |       80000 |         32.57 |                     198587 |                      975.78 |
```
Output throughput +0.00%..+0.38%; input throughput -0.85%..-0.21%.

## This is not a throughput PR

Output throughput is flat (+0.0%..+0.4%, inside the +/-0.4% noise floor) and input
throughput moves -0.9%..-0.2%. The change is about the reserve being *correct*,
not faster, and the honest summary is that it buys no measurable throughput.

What it does change, measured with `--attention-backend aiter` on **both** sides
(the only configuration where this code runs at all -- under `triton` the aiter
workspace is never allocated and the PR is inert):

| | max_total_num_tokens | max_running_requests |
|---|---|---|
| `upstream/main` | 3207280 | 2048 |
| this PR | 3223815 | 2048 |

**+16535 tokens (+0.5%).** Small, and that is the point: `main` applies a
flat `mem_fraction_static *= 0.85` haircut whenever the aiter backend is used with
context > 8192, which is a guess. This replaces it with the actual byte count the
backend will allocate, so `--mem-fraction-static` means what it says and the pool
is sized from the real number rather than from a margin.

## The load-bearing property

`aiter_attn_workspace_bytes` has **exactly two call sites** -- the charge in
`kv_cache_configurator.py` and the allocation in `aiter_backend.py` -- and no
inlined duplicate of the formula. Any gap between the charge and the allocation is
dead memory, linear in the gap, which is why the formula is shared rather than
repeated.

The arguments correspond: the allocation passes `req_to_token_pool.size`, the
charge passes `config.max_running_requests`, and these are equal because every
pool class is constructed with `size=max_num_reqs` (`DecodeReqToTokenPool` inflates
only its backing tensor, not its `.size`).

Two caveats stated rather than papered over. First, the charge comes from resolve
pass 1 and the allocation from pass 2; if the re-solve lowered
`max_running_requests` the reserve would exceed the allocation by that difference.
It does not in this regime (`resolve_max_num_reqs` saturates at its 2048 floor, and
both passes agree above ~4096 tokens at 80k context), and where it could differ the
error is a bounded **over**-reserve, never an under-reserve, so it cannot OOM.
Second, a hybrid-SWA model routed to the unified SWA pool would be charged 0 while
the backend still allocates, because the charge skips on `is_hybrid_swa` while the
backend skips on `use_sliding_window_kv_pool`. Not reachable for MiniMax-M3, but it
is the one case where the two sides disagree in the unsafe direction.

## Accuracy

gsm8k **97.27% vs a 97.07% baseline (+0.20 pp)**, `truncated_rate` 1.56% (identical
to baseline), `error_rate` 0.00%. Expected -- this changes only how much memory is
reserved, not any computation.
## Reproduction

Server (identical on both sides):

```bash
SGLANG_USE_AITER=1 \
AITER_CONFIG_FMOE=/path/to/minimax_m3_mxfp8_tuned_fmoe.csv \
SGLANG_FORCE_MXFP8_BLOCK_CONVERT_DENSE=1 \
python3 -m sglang.launch_server \
  --model-path /path/to/MiniMax-M3-MXFP8 \
  --trust-remote-code --tp 8 --quantization mxfp8 \
  --moe-runner-backend aiter --fp8-gemm-backend auto \
  --enable-aiter-allreduce-fusion --attention-backend triton \
  --dtype bfloat16 --chunked-prefill-size 8192 --mem-fraction-static 0.80 \
  --host 0.0.0.0 --port 30000
```

Benchmark:

```bash
python3 -m sglang.benchmark.one_batch_server \
  --model None --base-url http://127.0.0.1:30000 \
  --output-len 600 --skip-warmup \
  --batch-size 1 2 4 8 16 32 \
  --input-len 80000 --show-report --cache-hit-rate 0.9
```

Accuracy gate:

```bash
sgl-eval run gsm8k --base-url http://127.0.0.1:30000/v1 \
  --num-examples 512 --num-threads 64 \
  --max-tokens 2048 --temperature 0 --seed 0
```

Two bench reps per boot, warm rep reported; noise floor +/-0.4%, established by a separate PR measuring flat under a config where its code cannot fire.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->