### PR TITLE
fix(attention): defer Hopper FA3 for unresolved EAGLE topk

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6308,8 +6308,13 @@ class ServerArgs:
         if not use_mla_backend:
             # MHA architecture
 
-            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(
-                resolved_view(self)
+            if (
+                is_hopper_with_cuda_12_3()
+                and is_no_spec_infer_or_topk_one(resolved_view(self))
+                and (
+                    cfg.speculative_algorithm is None
+                    or cfg.speculative_eagle_topk is not None
+                )
             ):
                 # Note: flashinfer 0.6.1 caused performance regression on Hopper attention kernel
                 # Before the kernel is fixed, we choose fa3 as the default backend on Hopper MHA

--- a/test/registered/unit/server_args/test_hopper_eagle_attention_backend.py
+++ b/test/registered/unit/server_args/test_hopper_eagle_attention_backend.py
@@ -1,0 +1,49 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import sglang.srt.server_args as server_args_module
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestHopperEagleAttentionBackend(unittest.TestCase):
+    def test_unresolved_eagle_topk_skips_fa3(self):
+        model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+            has_asymmetric_kv=False,
+            has_attention_sinks=False,
+        )
+
+        with patch.multiple(
+            server_args_module,
+            current_platform=SimpleNamespace(is_out_of_tree=lambda: False),
+            is_hopper_with_cuda_12_3=MagicMock(return_value=True),
+            is_sm100_supported=MagicMock(return_value=False),
+            is_hip=MagicMock(return_value=False),
+            is_mps=MagicMock(return_value=False),
+            is_flashinfer_available=MagicMock(return_value=True),
+        ):
+            cases = (
+                ("no_spec", None, None, "fa3"),
+                ("eagle_topk_one", "EAGLE", 1, "fa3"),
+                ("eagle_auto_pending", "EAGLE", None, "flashinfer"),
+                ("eagle_topk_four", "EAGLE", 4, "flashinfer"),
+            )
+            for name, algorithm, topk, expected in cases:
+                with self.subTest(name=name):
+                    args = ServerArgs(
+                        model_path="dummy",
+                        speculative_algorithm=algorithm,
+                        speculative_eagle_topk=topk,
+                        page_size=1,
+                    )
+                    self.assertEqual(
+                        args._get_default_attn_backend(False, model_config), expected
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #36554.

## Motivation

On Hopper, the default attention backend is selected before EAGLE auto-parameters are filled. An unresolved `speculative_eagle_topk=None` is therefore treated like no speculative decoding and selects FA3. Resolution later fills `(num_steps, topk, num_draft_tokens) = (5, 4, 8)`, while explicitly passing those same values selects FlashInfer.

This is reachable through the normal EAGLE CLI path when the user leaves the EAGLE parameters at their defaults.

## Changes

- Defer Hopper's FA3 default while speculative decoding is enabled and `speculative_eagle_topk` is still unresolved.
- Preserve FA3 for non-speculative decoding and resolved EAGLE `topk=1`.
- Add focused CPU-CI coverage for no spec, `topk=1`, unresolved EAGLE topk, and `topk=4`.

The condition mirrors the existing SM100 resolution guard immediately below it.

## Validation

Validated from upstream `main` at `e7e78940168f3ba65c762a6f82fd8bc5b6ee04e3` on RTX 5090 GPU 0 (physical SM120, Torch `2.13.0+cu130`):

- Baseline with deterministic SM90 capability: auto `(5, 4, 8)` selected FA3, explicit `(5, 4, 8)` selected FlashInfer.
- Patched code with the same SM90 capability: both paths selected FlashInfer.
- Patched code on native SM120: both paths selected FlashInfer (non-regression check).
- `python -m pytest test/registered/unit/server_args/test_hopper_eagle_attention_backend.py -q` — 1 passed.
- Ruff (`F401`, `F821`, `UP037`), isort, Black, `py_compile`, and `git diff --check` passed.

The 5090 cannot natively execute the Hopper-only branch; the SM90 result above validates configuration resolution rather than Hopper kernel execution.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33009379726](https://github.com/sgl-project/sglang/actions/runs/33009379726)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33009379425](https://github.com/sgl-project/sglang/actions/runs/33009379425)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33009379551](https://github.com/sgl-project/sglang/actions/runs/33009379551)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->