### PR TITLE
[diffusion] prefer cuDNN SDPA for Cosmos3-Edge video on SM120

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/cosmos3video.py
@@ -224,3 +224,4 @@ class Cosmos3VideoConfig(DiTConfig):
 
     arch_config: DiTArchConfig = field(default_factory=Cosmos3VideoArchConfig)
     prefix: str = "Cosmos3"
+    cudnn_sdpa_min_query_len_on_sm120: int | None = None

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/cosmos3.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/cosmos3.py
@@ -24,6 +24,9 @@ from sglang.multimodal_gen.configs.pipeline_configs.model_deployment_config impo
 )
 
 COSMOS3_EDGE_BACKBONE_TYPE = "cosmos3_edge_nemotron_dense"
+# On SM120, cuDNN SDPA wins for Edge video shapes at 4,725+ query tokens,
+# while the 1,344-token shape regresses and the 2,352-token shape is neutral.
+COSMOS3_EDGE_SM120_CUDNN_SDPA_MIN_QUERY_LEN = 4096
 
 
 @functools.lru_cache(maxsize=None)
@@ -145,6 +148,9 @@ class Cosmos3Config(PipelineConfig):
         if self.model_path:
             self.distilled_sigmas = get_distilled_sigmas(self.model_path)
             self.is_edge = is_edge_checkpoint(self.model_path)
+            self.dit_config.cudnn_sdpa_min_query_len_on_sm120 = (
+                COSMOS3_EDGE_SM120_CUDNN_SDPA_MIN_QUERY_LEN if self.is_edge else None
+            )
             if self.distilled_sigmas is not None:
                 self.scheduler_class_override = None
 

--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -13,6 +13,7 @@ from typing import Any
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.nn.attention import SDPBackend, sdpa_kernel
 
 from sglang.kernels.ops.diffusion import (
     can_use_fused_inplace_qknorm_rope,
@@ -28,6 +29,10 @@ from sglang.multimodal_gen.runtime.distributed import (
 )
 from sglang.multimodal_gen.runtime.layers.activation import SiluAndMul
 from sglang.multimodal_gen.runtime.layers.attention import USPAttention
+from sglang.multimodal_gen.runtime.layers.attention.selector import (
+    get_component_forced_attn_backend,
+    get_global_forced_attn_backend,
+)
 from sglang.multimodal_gen.runtime.layers.layernorm import (
     RMSNorm,
     apply_qk_norm,
@@ -55,7 +60,11 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload im
     LayerwiseOffloadableModuleMixin,
 )
 from sglang.multimodal_gen.runtime.models.dits.base import CachableDiT
-from sglang.multimodal_gen.runtime.platforms import current_platform
+from sglang.multimodal_gen.runtime.platforms import (
+    AttentionBackendEnum,
+    current_platform,
+)
+from sglang.multimodal_gen.runtime.server_args import get_global_server_args
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.srt.utils import add_prefix
 
@@ -64,6 +73,43 @@ logger = init_logger(__name__)
 
 def is_cosmos_layer(name: str, _module: object) -> bool:
     return is_module_list_entry_in(name, ("layers", "gen_layers"))
+
+
+def _resolve_cosmos3_cudnn_sdpa_min_query_len(
+    config: Cosmos3VideoConfig,
+    *,
+    is_sm120: bool,
+    attention_backend: str | None,
+    forced_attention_backend: AttentionBackendEnum | None,
+    enable_torch_compile: bool,
+    sp_size: int,
+) -> int | None:
+    min_query_len = config.cudnn_sdpa_min_query_len_on_sm120
+    if (
+        min_query_len is None
+        or not is_sm120
+        or attention_backend is not None
+        or forced_attention_backend is not None
+        or enable_torch_compile
+        or sp_size != 1
+    ):
+        return None
+    return min_query_len
+
+
+def _should_use_cosmos3_cudnn_sdpa(
+    query: torch.Tensor,
+    *,
+    min_query_len: int | None,
+    attention_backend: AttentionBackendEnum,
+) -> bool:
+    return (
+        min_query_len is not None
+        and query.shape[1] >= min_query_len
+        and not torch.compiler.is_compiling()
+        and attention_backend == AttentionBackendEnum.TORCH_SDPA
+        and query.device.type == "cuda"
+    )
 
 
 # -----------------------------------------------------------------------------
@@ -754,6 +800,7 @@ class Cosmos3CrossAttention(nn.Module):
         cos_sin_cache: torch.Tensor,
         rope_cache_positions: torch.Tensor,
         use_fused_qk_norm_rope: bool,
+        use_cudnn_sdpa: bool,
         round_norm_before_rope: bool = False,
     ) -> torch.Tensor:
         """Cross-attention from GEN to cached UND K/V.
@@ -764,6 +811,7 @@ class Cosmos3CrossAttention(nn.Module):
             v_und: [B, S_und, H_kv_local, D] UND values (replicated over SP)
             cos_sin_cache: [B*S_gen_local, D] local rows of [cos, sin]
             rope_cache_positions: identity row positions into cos_sin_cache
+            use_cudnn_sdpa: Whether to force cuDNN for this attention call
         """
         batch_size, seq_len_gen = hidden_states.shape[:2]
 
@@ -822,7 +870,11 @@ class Cosmos3CrossAttention(nn.Module):
                 rope_cache_positions,
                 round_norm_before_rope=round_norm_before_rope,
             )
-            out = self.attn.forward(q, packed_k, packed_v)
+            if use_cudnn_sdpa:
+                with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                    out = self.attn.forward(q, packed_k, packed_v)
+            else:
+                out = self.attn.forward(q, packed_k, packed_v)
         elif use_fused_qk_norm_rope:
             q, k = _apply_qwen3_qk_norm_rope(
                 q,
@@ -841,7 +893,13 @@ class Cosmos3CrossAttention(nn.Module):
         if not use_fused_kv_pack:
             # K/V = [UND prefix (replicated on SP ranks) | GEN suffix].
             # USPAttention applies the configured backend and SP collectives.
-            out = self.attn.forward_with_replicated_kv_prefix(q, k_und, v_und, k, v)
+            if use_cudnn_sdpa:
+                with sdpa_kernel(SDPBackend.CUDNN_ATTENTION):
+                    out = self.attn.forward_with_replicated_kv_prefix(
+                        q, k_und, v_und, k, v
+                    )
+            else:
+                out = self.attn.forward_with_replicated_kv_prefix(q, k_und, v_und, k, v)
         out = out.reshape(batch_size, seq_len_gen, -1)
         out, _ = self.to_out(out)
         return out
@@ -972,6 +1030,7 @@ class Cosmos3GenDecoderLayer(nn.Module):
         cos_sin_cache: torch.Tensor,
         rope_cache_positions: torch.Tensor,
         use_fused_qk_norm_rope: bool,
+        use_cudnn_sdpa: bool,
         round_norm_before_rope: bool = False,
         residual: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor]:
@@ -992,6 +1051,7 @@ class Cosmos3GenDecoderLayer(nn.Module):
             cos_sin_cache,
             rope_cache_positions,
             use_fused_qk_norm_rope,
+            use_cudnn_sdpa,
             round_norm_before_rope,
         )
 
@@ -1158,6 +1218,19 @@ class Cosmos3OmniTransformer(CachableDiT, LayerwiseOffloadableModuleMixin):
             logger.info(
                 f"Cosmos3 SP enabled: sp_size={self.sp_size}, sp_rank={self.sp_rank}"
             )
+
+        server_args = get_global_server_args()
+        forced_attention_backend = (
+            get_global_forced_attn_backend() or get_component_forced_attn_backend()
+        )
+        self.cudnn_sdpa_min_query_len = _resolve_cosmos3_cudnn_sdpa_min_query_len(
+            config,
+            is_sm120=current_platform.is_sm120(),
+            attention_backend=server_args.attention_backend,
+            forced_attention_backend=forced_attention_backend,
+            enable_torch_compile=server_args.enable_torch_compile,
+            sp_size=self.sp_size,
+        )
 
         # Language model (UND pathway)
         self.language_model = Cosmos3LanguageModel(
@@ -1680,6 +1753,11 @@ class Cosmos3OmniTransformer(CachableDiT, LayerwiseOffloadableModuleMixin):
                 pack_kv=True,
             )
         )
+        use_cudnn_sdpa = T > 1 and _should_use_cosmos3_cudnn_sdpa(
+            hidden_gen,
+            min_query_len=self.cudnn_sdpa_min_query_len,
+            attention_backend=self.gen_layers[0].cross_attention.attn.backend,
+        )
         for i, layer in enumerate(self.gen_layers):
             k_und, v_und = cached_kv_for_key[i]
             hidden_gen, residual = layer(
@@ -1689,6 +1767,7 @@ class Cosmos3OmniTransformer(CachableDiT, LayerwiseOffloadableModuleMixin):
                 cos_sin_gen,
                 gen_rope_cache_positions,
                 use_fused_qk_norm_rope,
+                use_cudnn_sdpa,
                 round_norm_before_rope,
                 residual=residual,
             )

--- a/python/sglang/multimodal_gen/test/unit/test_cosmos3.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cosmos3.py
@@ -55,7 +55,6 @@ from sglang.multimodal_gen.runtime.models.dits.cosmos3video import (
     compute_mrope_position_ids_sound,
     compute_mrope_position_ids_vision,
 )
-from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.cosmos3 import (
     Cosmos3DecodingStage,
     Cosmos3ImagePreprocessStage,
@@ -70,6 +69,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.c
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.cosmos3_guardrails import (
     is_cosmos_guardrail_available,
 )
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 
 
 def _apply(mapping_fn, key):

--- a/python/sglang/multimodal_gen/test/unit/test_cosmos3.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cosmos3.py
@@ -10,9 +10,13 @@ from unittest import mock
 import torch
 
 from sglang.multimodal_gen.configs.models.dits.cosmos3video import (
+    Cosmos3VideoConfig,
     _build_cosmos3_param_names_mapping,
 )
-from sglang.multimodal_gen.configs.pipeline_configs.cosmos3 import Cosmos3Config
+from sglang.multimodal_gen.configs.pipeline_configs.cosmos3 import (
+    COSMOS3_EDGE_SM120_CUDNN_SDPA_MIN_QUERY_LEN,
+    Cosmos3Config,
+)
 from sglang.multimodal_gen.configs.sample.cosmos3 import (
     COSMOS3_EDGE_SUPPORTED_RESOLUTIONS,
     Cosmos3SamplingParams,
@@ -45,10 +49,13 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.scheduler_loader imp
 from sglang.multimodal_gen.runtime.loader.utils import get_param_names_mapping
 from sglang.multimodal_gen.runtime.models.dits.cosmos3video import (
     DomainAwareLinear,
+    _resolve_cosmos3_cudnn_sdpa_min_query_len,
+    _should_use_cosmos3_cudnn_sdpa,
     compute_mrope_position_ids_action,
     compute_mrope_position_ids_sound,
     compute_mrope_position_ids_vision,
 )
+from sglang.multimodal_gen.runtime.platforms import AttentionBackendEnum
 from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.cosmos3 import (
     Cosmos3DecodingStage,
     Cosmos3ImagePreprocessStage,
@@ -291,6 +298,120 @@ class TestCosmos3AdjustNumFrames(unittest.TestCase):
     def test_minimum_video_frame_count(self):
         # 2 frames: (2-1)=1, 1//4=0, 0*4+1=1 → rounds to 1, but 1 is T2I — still valid
         self.assertEqual(self.cfg.adjust_num_frames(2), 1)
+
+
+class TestCosmos3EdgeSM120CudnnSDPA(unittest.TestCase):
+    def test_edge_checkpoint_sets_long_query_threshold(self):
+        cfg = Cosmos3Config()
+        cfg.model_path = "unused"
+        with (
+            mock.patch(
+                "sglang.multimodal_gen.configs.pipeline_configs.cosmos3."
+                "PipelineConfig.update_config_from_dict"
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.configs.pipeline_configs.cosmos3."
+                "get_distilled_sigmas",
+                return_value=None,
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.configs.pipeline_configs.cosmos3."
+                "is_edge_checkpoint",
+                return_value=True,
+            ),
+        ):
+            cfg.update_config_from_dict({})
+
+        self.assertEqual(
+            cfg.dit_config.cudnn_sdpa_min_query_len_on_sm120,
+            COSMOS3_EDGE_SM120_CUDNN_SDPA_MIN_QUERY_LEN,
+        )
+
+    def test_non_edge_checkpoint_leaves_threshold_disabled(self):
+        cfg = Cosmos3Config()
+        cfg.model_path = "unused"
+        with (
+            mock.patch(
+                "sglang.multimodal_gen.configs.pipeline_configs.cosmos3."
+                "PipelineConfig.update_config_from_dict"
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.configs.pipeline_configs.cosmos3."
+                "get_distilled_sigmas",
+                return_value=None,
+            ),
+            mock.patch(
+                "sglang.multimodal_gen.configs.pipeline_configs.cosmos3."
+                "is_edge_checkpoint",
+                return_value=False,
+            ),
+        ):
+            cfg.update_config_from_dict({})
+
+        self.assertIsNone(cfg.dit_config.cudnn_sdpa_min_query_len_on_sm120)
+
+    def test_runtime_gate_requires_default_eager_single_gpu_sm120(self):
+        cfg = Cosmos3VideoConfig(cudnn_sdpa_min_query_len_on_sm120=4096)
+        kwargs = {
+            "is_sm120": True,
+            "attention_backend": None,
+            "forced_attention_backend": None,
+            "enable_torch_compile": False,
+            "sp_size": 1,
+        }
+        self.assertEqual(_resolve_cosmos3_cudnn_sdpa_min_query_len(cfg, **kwargs), 4096)
+
+        disabled_overrides = (
+            {"is_sm120": False},
+            {"attention_backend": "torch_sdpa"},
+            {"forced_attention_backend": AttentionBackendEnum.TORCH_SDPA},
+            {"enable_torch_compile": True},
+            {"sp_size": 2},
+        )
+        for override in disabled_overrides:
+            with self.subTest(override=override):
+                self.assertIsNone(
+                    _resolve_cosmos3_cudnn_sdpa_min_query_len(
+                        cfg, **(kwargs | override)
+                    )
+                )
+
+    def test_only_long_cuda_torch_sdpa_queries_use_cudnn(self):
+        query = types.SimpleNamespace(
+            device=types.SimpleNamespace(type="cuda"), shape=(1, 4096, 16, 128)
+        )
+        kwargs = {
+            "min_query_len": 4096,
+            "attention_backend": AttentionBackendEnum.TORCH_SDPA,
+        }
+        with mock.patch.object(torch.compiler, "is_compiling", return_value=False):
+            self.assertTrue(_should_use_cosmos3_cudnn_sdpa(query, **kwargs))
+            query.shape = (1, 4095, 16, 128)
+            self.assertFalse(_should_use_cosmos3_cudnn_sdpa(query, **kwargs))
+            query.shape = (1, 8190, 16, 128)
+            query.device.type = "cpu"
+            self.assertFalse(_should_use_cosmos3_cudnn_sdpa(query, **kwargs))
+
+    def test_compilation_and_non_sdpa_backend_bypass_cudnn(self):
+        query = types.SimpleNamespace(
+            device=types.SimpleNamespace(type="cuda"), shape=(1, 8190, 16, 128)
+        )
+        with mock.patch.object(torch.compiler, "is_compiling", return_value=True):
+            self.assertFalse(
+                _should_use_cosmos3_cudnn_sdpa(
+                    query,
+                    min_query_len=4096,
+                    attention_backend=AttentionBackendEnum.TORCH_SDPA,
+                )
+            )
+        with mock.patch.object(torch.compiler, "is_compiling", return_value=False):
+            self.assertFalse(
+                _should_use_cosmos3_cudnn_sdpa(
+                    query,
+                    min_query_len=4096,
+                    attention_backend=AttentionBackendEnum.FA,
+                )
+            )
 
 
 class TestCosmos3SchedulerConfig(unittest.TestCase):


### PR DESCRIPTION
## Summary

- prefer cuDNN SDPA for long Cosmos3-Edge GEN cross-attention on SM120 while retaining the existing `USPAttention` abstraction
- limit the fast path to default-backend, eager, one-GPU video requests with at least 4,096 query tokens
- keep T2I, non-Edge Cosmos3, non-SM120, explicit attention backends, `torch.compile`, and sequence parallelism unchanged
- add focused coverage for checkpoint opt-in, runtime eligibility, backend compatibility, and shape/compile bypasses

## RTX PRO 6000 Blackwell validation

Native SGLang at `bede6bc37c5d9638099ebb948d93b9e2a7799f10`, `nvidia/Cosmos3-Edge`, BF16, one RTX PRO 6000 Blackwell Server Edition, 35 steps, request warmup, two measured runs:

| Preset | Baseline denoise | Patched denoise | Denoise delta | Baseline E2E | Patched E2E | E2E delta |
|---|---:|---:|---:|---:|---:|---:|
| T2V, 832x480x81 | 8.467977 s | 7.912366 s | -6.561% | 10.995700 s | 10.761708 s | -2.128% |
| I2V, 832x480x81 | 8.465489 s | 7.931959 s | -6.302% | 11.061884 s | 10.790479 s | -2.454% |

T2I remains on the original Torch SDPA path. Interleaved 640x640 T2I auto/control runs differ by 0.8%, within the observed run variance, and produce the same output hash. Candidate T2V and I2V A/B runs are byte-identical to their explicit-cuDNN controls.

The lossless baseline-to-candidate pixel comparisons are:

| Preset | SSIM | PSNR |
|---|---:|---:|
| T2I | 0.985251 | 34.748796 dB |
| T2V | 0.907081 | 25.155148 dB |
| I2V | 0.982283 | 38.785940 dB |

`quality=high` completes for T2I, T2V, and I2V. `--enable-torch-compile` also completes for T2I and T2V with this gate bypassed, preserving the existing compile path. BCG is not supported by these registered Cosmos3-Edge presets.

## Kernel evidence

For the production BF16 GQA shape Q `[1,16,8190,128]`, K/V `[1,8,8240,128]`, NCU reports 2.18 ms for the default `flash_fwd_kernel` and 1.98 ms for cuDNN. cuDNN lowers registers/thread from 255 to 168, raises achieved occupancy from 8.34% to 18.72%, and raises active warps/scheduler from 1.00 to 2.25.

A 10-warmup, 30-sample CUDA-event sweep brackets the 4,096-token threshold:

| Query tokens | cuDNN delta vs default |
|---:|---:|
| 1,344 | +13.941% |
| 2,352 | -0.483% |
| 4,725 | -5.694% |
| 6,300 | -6.221% |
| 8,190 | -7.524% |
| 8,400 | -4.874% |

The tested maximum absolute output difference is at most `0.000976562`, one BF16 quantization step.

## Tests

- `pytest -q python/sglang/multimodal_gen/test/unit/test_cosmos3.py python/sglang/multimodal_gen/test/unit/test_cuda_attention_backend.py` (112 passed, 36 subtests)
- `ruff format --check` and `ruff check` on all four touched files
- native end-to-end eager A/B, explicit-cuDNN control, `quality=high`, and compile smoke runs on RTX PRO 6000 Blackwell Server Edition

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33018468995](https://github.com/sgl-project/sglang/actions/runs/33018468995)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33018468877](https://github.com/sgl-project/sglang/actions/runs/33018468877)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33018469184](https://github.com/sgl-project/sglang/actions/runs/33018469184)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->