### PR TITLE
fix(qsa): allow trtllm sparse decode on SM120/SM121

### DIFF
--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -53,9 +53,9 @@ def _resolve_trtllm_sparse_decode():
     at decode row counts; the trtllm-gen decode kernel over a page-aligned
     scratch measures ~35% faster for the gather+attention pair.
     """
-    from sglang.srt.utils import is_sm100_supported
+    from sglang.srt.utils import is_sm100_supported, is_sm120_supported
 
-    if not is_sm100_supported():
+    if not (is_sm100_supported() or is_sm120_supported()):
         return None
     try:
         from flashinfer.decode import trtllm_batch_decode_with_kv_cache


### PR DESCRIPTION
_resolve_trtllm_sparse_decode gated the flashinfer trtllm sparse decode path on is_sm100_supported, so SM12x fell through to the flash-attn cute varlen interface, which fails to compile for these GPUs and crashes the scheduler at the first decode (or during decode CUDA graph capture).

Widen the gate with the existing is_sm120_supported helper (capability major 12, so both SM120 and SM121 qualify).

Validated on GB10 (SM121, DGX Spark pair, TP=2): kernel level with the PR #36556 shape (q=[1,24,256], kv=[2051,2,256], max_abs_diff 4.7e-4, CUDA graph replay ok) and end to end serving of
RadixArk/Qwen3.8-Flash-Next-NVFP4.

Fixes #36558, sibling of #36556 (SM120 / RTX 5090).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33010808088](https://github.com/sgl-project/sglang/actions/runs/33010808088)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33010807902](https://github.com/sgl-project/sglang/actions/runs/33010807902)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33010807920](https://github.com/sgl-project/sglang/actions/runs/33010807920)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->