### PR TITLE
feat(qwen4): stream PLE embeddings from NVMe

### DIFF
--- a/.github/workflows/pr-test-rust-exts.yml
+++ b/.github/workflows/pr-test-rust-exts.yml
@@ -1,19 +1,20 @@
 name: PR Test (Rust extensions)
 
-# In-crate checks for the Rust extensions bundled with the `sglang` wheel
-# (rust/sglang-mm). The pyo3 bindings themselves are exercised by the Python
-# unit suite (base-a-test-cpu), which builds the extensions from source; this
-# job covers the pure-Rust core, exactly as sglang-server links it, plus lints.
+# In-crate checks for the Rust extensions bundled with the `sglang` wheel.
+# The pyo3 bindings themselves are exercised by the Python unit suite
+# (base-a-test-cpu), which builds the extensions from source; these jobs cover
+# the pure-Rust cores and their native tests, plus lints.
 #
-# Scoped to sglang-mm on purpose: sglang-server and sglang-grpc have no
-# in-crate test suite yet, so a `rust/**` trigger would spawn a job that does
-# not actually cover the changed crate. Widen the paths together with the job.
+# Scoped to crates with in-crate test suites on purpose: sglang-server and
+# sglang-grpc have none yet, so a `rust/**` trigger would spawn jobs that do not
+# actually cover the changed crate. Widen the paths together with the jobs.
 
 on:
   push:
     branches: [ main ]
     paths:
       - "rust/sglang-mm/**"
+      - "rust/sglang-storage/**"
       - "rust/Cargo.toml"
       - ".github/workflows/pr-test-rust-exts.yml"
   pull_request:
@@ -21,6 +22,7 @@ on:
     types: [opened, synchronize, reopened, labeled]
     paths:
       - "rust/sglang-mm/**"
+      - "rust/sglang-storage/**"
       - "rust/Cargo.toml"
       - ".github/workflows/pr-test-rust-exts.yml"
   workflow_dispatch:
@@ -68,3 +70,30 @@ jobs:
       # implementations and results are required to be identical.
       - name: cargo test (parallel shape)
         run: cargo test --features parallel
+
+  sglang-storage-unit:
+    if: |
+      github.event_name != 'pull_request' ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-ci')) ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-ci')
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    defaults:
+      run:
+        working-directory: rust/sglang-storage
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: cargo clippy (all targets)
+        run: |
+          rustup component add clippy
+          cargo clippy --all-targets -- -D warnings
+
+      - name: cargo test
+        run: cargo test

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -963,6 +963,7 @@
               "docs/advanced_features/deterministic_inference",
               "docs/advanced_features/observability",
               "docs/advanced_features/model_loading",
+              "docs/advanced_features/qwen4_ple_nvme",
               "docs/advanced_features/object_storage",
               "docs/advanced_features/checkpoint_engine",
               "docs/advanced_features/sglang_for_rl"

--- a/docs/docs/advanced_features/qwen4_ple_nvme.mdx
+++ b/docs/docs/advanced_features/qwen4_ple_nvme.mdx
@@ -1,0 +1,101 @@
+---
+title: "Qwen3.8 Flash Next NVMe PLE streaming"
+description: "Serve Qwen3.8 Flash Next on memory-constrained NVIDIA systems by reading sparse PLE rows from local NVMe."
+---
+
+Qwen3.8 Flash Next includes a large PLE n-gram embedding table. SGLang can keep
+that table in its original sharded safetensors files and read only the rows used
+by each forward pass. The remaining model weights stay on the GPU.
+
+This path is intended for a single NVIDIA GPU with local NVMe storage. It
+currently supports tensor parallel size 1 and an FP8 E4M3 PLE table.
+
+## Prerequisites
+
+- Linux on an NVIDIA CUDA system
+- A local model snapshot that contains `model.safetensors.index.json` and all
+  referenced safetensors files
+- A filesystem that supports `O_DIRECT`
+- The `io_uring_setup`, `io_uring_enter`, and `io_uring_register` system calls
+
+<Warning>
+  Docker's default seccomp profile may block `io_uring`. Add the three syscalls
+  above to the container's seccomp allowlist. SGLang reports an actionable
+  `Operation not permitted` error when the profile blocks ring creation.
+</Warning>
+
+## Start the server
+
+Set `MODEL_PATH` to the local snapshot for
+`RadixArk/Qwen3.8-Flash-Next-NVFP4`:
+
+```bash
+export MODEL_PATH=/models/Qwen3.8-Flash-Next-NVFP4
+export SGLANG_QWEN4_PLE_NVME_PATH="$MODEL_PATH"
+export SGLANG_QWEN4_PLE_NVME_BACKEND=io_uring
+export SGLANG_QWEN4_PLE_NVME_QUEUE_DEPTH=512
+
+python -m sglang.launch_server \
+  --model-path "$MODEL_PATH" \
+  --quantization modelopt_fp4 \
+  --fp4-gemm-backend flashinfer_cutlass \
+  --page-size 64 \
+  --mamba-radix-cache-strategy extra_buffer \
+  --mamba-track-interval 64 \
+  --chunked-prefill-size 512 \
+  --max-running-requests 1 \
+  --context-length 32768 \
+  --mem-fraction-static 0.84 \
+  --speculative-algorithm NEXTN \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --cuda-graph-backend-decode disabled \
+  --cuda-graph-backend-prefill disabled
+```
+
+The NVMe gather starts before the decoder layer immediately preceding PLE. The
+reader performs the host I/O on a background thread, then copies the selected
+FP8 rows through pinned memory and converts them to BF16 on the GPU.
+
+## Configuration
+
+| Environment variable | Default | Description |
+| --- | --- | --- |
+| `SGLANG_QWEN4_PLE_NVME_PATH` | empty | Local snapshot path. An empty value keeps the normal resident embedding. |
+| `SGLANG_QWEN4_PLE_NVME_BACKEND` | `io_uring` | Row reader. Use `mmap` only for correctness checks or filesystems without `O_DIRECT`. |
+| `SGLANG_QWEN4_PLE_NVME_QUEUE_DEPTH` | `512` | Maximum in-flight reads in the persistent ring. |
+| `SGLANG_QWEN4_PLE_NVME_MAX_BATCH_PAGES` | `4096` | Number of aligned page buffers allocated by the native reader. Larger requests are chunked. |
+| `SGLANG_QWEN4_PLE_NVME_CACHE_PAGES` | `0` | Application-level LRU page count. Zero relies on direct reads without retaining pages. |
+| `SGLANG_QWEN4_PLE_NVME_LOG_INTERVAL` | `1000` | Emit aggregate row-read timing every N gathers. Zero disables timing logs. |
+
+The native reader is bundled in the SGLang wheel as a Rust extension. Source
+installs build it through SGLang's Rust extension loader on first use.
+
+## Verify the endpoint
+
+```bash
+curl http://127.0.0.1:30000/v1/models
+```
+
+During startup, the log reports the PLE table size, file count, and row count.
+After the configured log interval, it also reports aggregate read latency.
+
+## Troubleshooting
+
+### `Operation not permitted` when creating the reader
+
+The process cannot call `io_uring_setup`. Update the container seccomp profile
+to allow the three `io_uring` syscalls listed in the prerequisites.
+
+### `Invalid argument` from a direct read
+
+The checkpoint filesystem does not satisfy `O_DIRECT` alignment or support.
+Move the snapshot to a local NVMe filesystem, or set
+`SGLANG_QWEN4_PLE_NVME_BACKEND=mmap` for a correctness test.
+
+### Snapshot or shard validation errors
+
+Keep the index and all referenced shard files in one local snapshot directory.
+The reader validates contiguous PLE shard indices, tensor dimensions, dtype,
+and the model-config row count before serving requests.

--- a/python/sglang/kernels/ops/attention/qsa_decode.py
+++ b/python/sglang/kernels/ops/attention/qsa_decode.py
@@ -1,0 +1,150 @@
+"""Triton decode kernel for Qwen sparse grouped-query attention."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _sparse_gqa_decode_kernel(
+    q,
+    k_cache,
+    v_cache,
+    token_slots,
+    out,
+    scale,
+    topk,
+    sq_m: tl.constexpr,
+    sq_h: tl.constexpr,
+    sq_d: tl.constexpr,
+    sk_n: tl.constexpr,
+    sk_h: tl.constexpr,
+    sk_d: tl.constexpr,
+    sv_n: tl.constexpr,
+    sv_h: tl.constexpr,
+    sv_d: tl.constexpr,
+    ss_m: tl.constexpr,
+    ss_n: tl.constexpr,
+    so_m: tl.constexpr,
+    so_h: tl.constexpr,
+    so_d: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+):
+    row = tl.program_id(0)
+    kv_head = tl.program_id(1)
+    query_heads = kv_head * GROUP_SIZE + tl.arange(0, BLOCK_M)
+    dimensions = tl.arange(0, HEAD_DIM)
+    query = tl.load(
+        q + row * sq_m + query_heads[:, None] * sq_h + dimensions[None, :] * sq_d,
+        mask=(tl.arange(0, BLOCK_M) < GROUP_SIZE)[:, None],
+        other=0.0,
+    )
+    query = (query * scale * 1.4426950408889634).to(query.dtype)
+
+    maximum = tl.full([BLOCK_M], -float("inf"), tl.float32)
+    normalizer = tl.zeros([BLOCK_M], tl.float32)
+    accumulator = tl.zeros([BLOCK_M, HEAD_DIM], tl.float32)
+    columns = tl.arange(0, BLOCK_N)
+    for start in range(0, topk, BLOCK_N):
+        positions = start + columns
+        slots = tl.load(
+            token_slots + row * ss_m + positions * ss_n,
+            mask=positions < topk,
+            other=-1,
+        )
+        valid = (positions < topk) & (slots >= 0)
+        keys = tl.load(
+            k_cache
+            + slots[None, :] * sk_n
+            + kv_head * sk_h
+            + dimensions[:, None] * sk_d,
+            mask=valid[None, :],
+            other=0.0,
+        )
+        values = tl.load(
+            v_cache
+            + slots[:, None] * sv_n
+            + kv_head * sv_h
+            + dimensions[None, :] * sv_d,
+            mask=valid[:, None],
+            other=0.0,
+        )
+        scores = tl.where(valid[None, :], tl.dot(query, keys), -float("inf"))
+        next_maximum = tl.maximum(maximum, tl.max(scores, axis=1))
+        correction = tl.math.exp2(maximum - next_maximum)
+        probabilities = tl.math.exp2(scores - next_maximum[:, None])
+        accumulator = tl.dot(
+            probabilities.to(values.dtype),
+            values,
+            accumulator * correction[:, None],
+        )
+        normalizer = normalizer * correction + tl.sum(probabilities, axis=1)
+        maximum = next_maximum
+
+    result = accumulator / normalizer[:, None]
+    tl.store(
+        out + row * so_m + query_heads[:, None] * so_h + dimensions[None, :] * so_d,
+        result,
+        mask=(tl.arange(0, BLOCK_M) < GROUP_SIZE)[:, None],
+    )
+
+
+def sparse_gqa_decode_physical_triton(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    token_slots: torch.Tensor,
+    softmax_scale: float,
+) -> torch.Tensor:
+    """Run sparse GQA decode directly over physical KV-cache slots."""
+    if not all(tensor.is_cuda for tensor in (q, k_cache, v_cache, token_slots)):
+        raise ValueError("the sparse GQA Triton decode path requires CUDA tensors")
+    if q.ndim != 3 or k_cache.ndim != 3 or v_cache.ndim != 3:
+        raise ValueError("Q, K, and V must be rank-3 tensors")
+    if token_slots.ndim != 2 or token_slots.shape[0] != q.shape[0]:
+        raise ValueError("token_slots must have shape [batch, selected_tokens]")
+    if q.shape[-1] != k_cache.shape[-1] or q.shape[-1] != v_cache.shape[-1]:
+        raise ValueError("Q, K, and V head dimensions must match")
+    if q.shape[1] % k_cache.shape[1] != 0:
+        raise ValueError("query heads must be divisible by KV heads")
+
+    rows, query_heads, head_dim = q.shape
+    kv_heads = k_cache.shape[1]
+    group_size = query_heads // kv_heads
+    block_m = max(16, triton.next_power_of_2(group_size))
+    output = torch.empty_like(q)
+    _sparse_gqa_decode_kernel[(rows, kv_heads)](
+        q,
+        k_cache,
+        v_cache,
+        token_slots,
+        output,
+        softmax_scale,
+        token_slots.shape[1],
+        q.stride(0),
+        q.stride(1),
+        q.stride(2),
+        k_cache.stride(0),
+        k_cache.stride(1),
+        k_cache.stride(2),
+        v_cache.stride(0),
+        v_cache.stride(1),
+        v_cache.stride(2),
+        token_slots.stride(0),
+        token_slots.stride(1),
+        output.stride(0),
+        output.stride(1),
+        output.stride(2),
+        GROUP_SIZE=group_size,
+        BLOCK_M=block_m,
+        BLOCK_N=32,
+        HEAD_DIM=head_dim,
+        num_warps=8,
+        num_stages=2,
+    )
+    return output

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -294,6 +294,14 @@ class Envs:
     # Bitwise-exact, shape-guarded Qwen4 PLE decode fusion. Unsupported inputs
     # and phases fall back to the original implementation.
     SGLANG_ENABLE_QWEN4_PLE_FUSION = EnvBool(True)
+    # Stream Qwen4's PLE n-gram table from a local safetensors snapshot instead
+    # of allocating it in host or device memory. An empty path disables it.
+    SGLANG_QWEN4_PLE_NVME_PATH = EnvStr("")
+    SGLANG_QWEN4_PLE_NVME_BACKEND = EnvStr("io_uring")
+    SGLANG_QWEN4_PLE_NVME_QUEUE_DEPTH = EnvInt(512)
+    SGLANG_QWEN4_PLE_NVME_MAX_BATCH_PAGES = EnvInt(4096)
+    SGLANG_QWEN4_PLE_NVME_CACHE_PAGES = EnvInt(0)
+    SGLANG_QWEN4_PLE_NVME_LOG_INTERVAL = EnvInt(1000)
     # Select the FP8 (deep_gemm) tokenwise QSA indexer; only the BF16 reference
     # path is ported, so setting this fails loudly instead of degrading.
     SGLANG_QWEN_DSA_USE_FP8_INDEXER = EnvBool(False)

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -16,6 +16,9 @@ import msgspec
 import torch
 import torch.nn.functional as F
 
+from sglang.kernels.ops.attention.qsa_decode import (
+    sparse_gqa_decode_physical_triton,
+)
 from sglang.srt.layers.attention.base_attn_backend import AttentionBackend
 from sglang.srt.layers.attention.qsa.config import (
     QSA_VARIANT_COMPRESSED,
@@ -78,9 +81,7 @@ def _resolve_flash_attn_varlen_func():
     except ImportError:
         pass
     try:
-        from flash_attn.cute.interface import (
-            flash_attn_varlen_func as cute_varlen_func,
-        )
+        from flash_attn.cute.interface import flash_attn_varlen_func as cute_varlen_func
 
         def flash_attn_varlen_func(*args, **kwargs):
             output = cute_varlen_func(*args, **kwargs)
@@ -93,7 +94,6 @@ def _resolve_flash_attn_varlen_func():
             "QSA decode requires flash_attn (FA2) or flash-attn-4 "
             "(FA4 cute) for its packed varlen fallback."
         ) from exc
-
 
 
 class QwenSparseAttnMetadata(msgspec.Struct, frozen=True):
@@ -257,8 +257,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             return
         if int(getattr(spec_info, "topk", 1) or 1) != 1:
             raise NotImplementedError(
-                "Qwen QSA target verification supports only "
-                "speculative_eagle_topk=1"
+                "Qwen QSA target verification supports only " "speculative_eagle_topk=1"
             )
         draft_tokens = int(getattr(spec_info, "draft_token_num", 0) or 0)
         if draft_tokens > self.compress_ratio:
@@ -288,9 +287,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
             return max(1, int(sequence_lengths.max()))
         spec_info = forward_batch.spec_info
-        draft_window = (
-            int(spec_info.draft_token_num) if spec_info is not None else 0
-        )
+        draft_window = int(spec_info.draft_token_num) if spec_info is not None else 0
         return max(1, int(seq_lens_cpu.max()) + draft_window)
 
     @staticmethod
@@ -378,9 +375,7 @@ class QwenSparseAttnBackend(AttentionBackend):
                     extend_lengths = torch.cat(
                         [
                             extend_lengths,
-                            torch.zeros(
-                                bs - extend_lengths.numel(), dtype=torch.int32
-                            ),
+                            torch.zeros(bs - extend_lengths.numel(), dtype=torch.int32),
                         ]
                     )
             else:
@@ -414,9 +409,7 @@ class QwenSparseAttnBackend(AttentionBackend):
                 torch.full((int(extend_len),), prefix_len, dtype=torch.int32)
             )
         row_lengths = (
-            torch.cat(row_lengths)
-            if row_lengths
-            else torch.empty(0, dtype=torch.int32)
+            torch.cat(row_lengths) if row_lengths else torch.empty(0, dtype=torch.int32)
         )
         row_prefix_lengths = (
             torch.cat(row_prefix_lengths)
@@ -429,12 +422,8 @@ class QwenSparseAttnBackend(AttentionBackend):
                 "QSA CUDA graph speculative layout has inconsistent token count: "
                 f"capacity={num_tokens}, actual={actual_rows}"
             )
-        repeats = extend_lengths.to(
-            device=req_pool_indices.device, dtype=torch.long
-        )
-        row_req_pool_indices = torch.repeat_interleave(
-            req_pool_indices[:bs], repeats
-        )
+        repeats = extend_lengths.to(device=req_pool_indices.device, dtype=torch.long)
+        row_req_pool_indices = torch.repeat_interleave(req_pool_indices[:bs], repeats)
         # Draft-extend graphs always execute the captured static token shape,
         # while a replay can contain fewer accepted tokens.  The runner packs
         # real rows first and zero-fills the tail, so give those tail rows safe
@@ -542,9 +531,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             # member sits chunk-locally at (block * ratio - prefix).
             member_rows = torch.where(
                 valid,
-                row_token_starts[rows]
-                + blocks * compress_ratio
-                - prefix_lens[rows],
+                row_token_starts[rows] + blocks * compress_ratio - prefix_lens[rows],
                 torch.zeros_like(blocks),
             )
         return write_locs, group_end_positions, rows, member_rows
@@ -609,10 +596,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             self.device = forward_batch.seq_lens.device
         if not self.max_context_len:
             self.max_context_len = self.req_to_token.shape[1]
-        if (
-            forward_batch.forward_mode.is_idle()
-            or forward_batch.seq_lens.numel() == 0
-        ):
+        if forward_batch.forward_mode.is_idle() or forward_batch.seq_lens.numel() == 0:
             # DP attention runs IDLE dummy forwards on ranks without work, and
             # the MTP multi-step wrapper forwards them as zero-row DECODE
             # steps.  Model layers skip attention for these batches, but
@@ -620,9 +604,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             # of falling into the extend/decode paths on empty tensors.
             return self._empty_metadata(forward_batch)
         original_mode = getattr(forward_batch, "_original_forward_mode", None)
-        if original_mode is not None and self._is_speculative_paged_mode(
-            original_mode
-        ):
+        if original_mode is not None and self._is_speculative_paged_mode(original_mode):
             # DP MAX_LEN pseudo-extend rewrites the mode to EXTEND with
             # extend_seq_lens == 1 per request, which loses the per-request
             # draft fan-out of target_verify/draft_extend.  Refuse to guess
@@ -632,9 +614,7 @@ class QwenSparseAttnBackend(AttentionBackend):
                 f"speculative mode {original_mode}: token rows would be "
                 "mis-mapped to requests"
             )
-        speculative_paged = self._is_speculative_paged_mode(
-            forward_batch.forward_mode
-        )
+        speculative_paged = self._is_speculative_paged_mode(forward_batch.forward_mode)
         if speculative_paged:
             logical_positions = forward_batch.positions
             if logical_positions.ndim == 2:
@@ -690,9 +670,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             else:
                 extend_seq_lens = forward_batch.extend_seq_lens
                 if extend_seq_lens is None:
-                    raise ValueError(
-                        "QSA extend metadata requires extend_seq_lens"
-                    )
+                    raise ValueError("QSA extend metadata requires extend_seq_lens")
                 token_to_batch_idx = torch.repeat_interleave(
                     torch.arange(
                         batch_size,
@@ -912,8 +890,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             max_bs, dtype=torch.int32, device=self.device
         )
         self._graph_extend_lens_pin = [
-            torch.zeros(max_bs, dtype=torch.int32, pin_memory=True)
-            for _ in range(2)
+            torch.zeros(max_bs, dtype=torch.int32, pin_memory=True) for _ in range(2)
         ]
         self._extend_lens_pin_idx = 0
 
@@ -1064,9 +1041,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
         else:
             metadata.sequence_lengths.copy_(seq_lens[:bs].to(torch.int32))
-            metadata.row_req_pool_indices.copy_(
-                req_pool_indices[:bs].to(torch.int32)
-            )
+            metadata.row_req_pool_indices.copy_(req_pool_indices[:bs].to(torch.int32))
             metadata.indexer_metadata.graph_prefix_lengths.copy_(
                 (seq_lens[:bs] - 1).clamp_min(0).to(torch.int32)
             )
@@ -1228,8 +1203,7 @@ class QwenSparseAttnBackend(AttentionBackend):
         row_width_pages = self.req_to_token.shape[1] // full_page
         num_pages = min(max_pages, row_width_pages)
         table = (
-            self.req_to_token[req_indices, : num_pages * full_page : full_page]
-            .long()
+            self.req_to_token[req_indices, : num_pages * full_page : full_page].long()
             // full_page
         ).clamp_min(0)
         page_table[:, :num_pages].copy_(table.to(torch.int32))
@@ -1531,7 +1505,6 @@ class QwenSparseAttnBackend(AttentionBackend):
             self._fa2_scratch[key] = buffers
         return buffers[0][:capacity], buffers[1][:capacity]
 
-
     def _get_trtllm_sparse_tables(self, batch, pages_per_row, page, device):
         key = (batch, pages_per_row, device)
         cached = self._trtllm_sparse_tables.get(key)
@@ -1541,9 +1514,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             block_tables = (
                 torch.arange(batch, dtype=torch.int32, device=device)[:, None]
                 * pages_per_row
-                + torch.arange(pages_per_row, dtype=torch.int32, device=device)[
-                    None, :
-                ]
+                + torch.arange(pages_per_row, dtype=torch.int32, device=device)[None, :]
             ).contiguous()
             cached = (cu, block_tables)
             self._trtllm_sparse_tables[key] = cached
@@ -1582,9 +1553,7 @@ class QwenSparseAttnBackend(AttentionBackend):
         cu_strided, block_tables = self._get_trtllm_sparse_tables(
             batch, pages_per_row, page, device
         )
-        capacity_rows = (
-            self._cuda_graph_max_tokens if metadata.is_cuda_graph else batch
-        )
+        capacity_rows = self._cuda_graph_max_tokens if metadata.is_cuda_graph else batch
         packed_k, packed_v = self._get_fa2_scratch(
             max(capacity_rows, batch) * stride,
             k_buffer.shape[1],
@@ -1687,6 +1656,13 @@ class QwenSparseAttnBackend(AttentionBackend):
                 topk_indices,
                 trtllm_decode,
             )
+
+        if torch.cuda.get_device_capability(q.device) == (12, 1):
+            slots = self._logical_to_physical(topk_indices, metadata)
+            output = sparse_gqa_decode_physical_triton(
+                q, k_buffer, v_buffer, slots, layer.scaling
+            )
+            return output.reshape(q.shape[0], -1)
 
         flash_attn_varlen_func = _resolve_flash_attn_varlen_func()
         batch, topk = topk_indices.shape
@@ -1812,9 +1788,7 @@ class QwenSparseMultiStepDraftBackend:
             .reshape(steps, -1)[step]
         )
 
-    def _make_step_forward_batch(
-        self, forward_batch, step: int, num_padding: int = 0
-    ):
+    def _make_step_forward_batch(self, forward_batch, step: int, num_padding: int = 0):
         step_forward_batch = copy(forward_batch)
         step_forward_batch.forward_mode = ForwardMode.DECODE
         step_forward_batch.seq_lens = (forward_batch.seq_lens + step + 1).to(
@@ -1841,9 +1815,7 @@ class QwenSparseMultiStepDraftBackend:
                 )
                 step_forward_batch.seq_lens_cpu[-num_padding:] = 1
         step_forward_batch.batch_size = int(step_forward_batch.seq_lens.numel())
-        step_forward_batch.out_cache_loc = self._step_out_cache_loc(
-            forward_batch, step
-        )
+        step_forward_batch.out_cache_loc = self._step_out_cache_loc(forward_batch, step)
         return step_forward_batch
 
     def set_mtp_shared_sparse_indices(self, state) -> None:
@@ -1860,9 +1832,7 @@ class QwenSparseMultiStepDraftBackend:
         for backend in self.attn_backends:
             backend.init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_out_graph(
-        self, forward_batch, in_capture: bool = False
-    ):
+    def init_forward_metadata_out_graph(self, forward_batch, in_capture: bool = False):
         if in_capture:
             for step, backend in enumerate(self.attn_backends):
                 # Every capture row is synthetic.  Keep its sequence length

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -60,6 +60,10 @@ from sglang.srt.models.qwen3_5 import (
     Qwen3_5LinearDecoderLayer,
 )
 from sglang.srt.models.qwen3_vl import Qwen3VLForConditionalGeneration
+from sglang.srt.models.qwen4_ple_nvme import (
+    NVMePLEEmbedding,
+    is_nvme_ple_embedding,
+)
 from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils import logger
 
@@ -488,21 +492,32 @@ class Qwen4ExpNGramEmbedding(nn.Module):
             and get_attention_dp_size() > 1
             and not self.use_attn_tp_ngram
         )
-        self.ngram_embedding = VocabParallelEmbedding(
-            padded_vocab_size,
-            self.head_dim_per_ngram,
-            params_dtype=(
-                torch.float8_e4m3fn
-                if (quant_config is not None and quant_config.get_name() == "fp8")
-                or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
-                else torch.bfloat16
-            ),
-            output_dtype=torch.bfloat16,
-            use_attn_tp_group=self.use_attn_tp_ngram,
-        )
-        self.ngram_embedding.register_buffer(
-            "weight_scale", torch.ones(1, dtype=torch.bfloat16), persistent=True
-        )
+        nvme_snapshot = envs.SGLANG_QWEN4_PLE_NVME_PATH.get()
+        if nvme_snapshot:
+            if get_parallel().tp_size != 1:
+                raise NotImplementedError("Qwen4 NVMe PLE currently supports TP1 only")
+            self.ngram_embedding = NVMePLEEmbedding(
+                nvme_snapshot,
+                num_embeddings=padded_vocab_size,
+                embedding_dim=self.head_dim_per_ngram,
+                expected_shards=int(config.split_ngram_parts),
+            )
+        else:
+            self.ngram_embedding = VocabParallelEmbedding(
+                padded_vocab_size,
+                self.head_dim_per_ngram,
+                params_dtype=(
+                    torch.float8_e4m3fn
+                    if (quant_config is not None and quant_config.get_name() == "fp8")
+                    or getattr(config, "ple_embedding_dtype", None) == "float8_e4m3fn"
+                    else torch.bfloat16
+                ),
+                output_dtype=torch.bfloat16,
+                use_attn_tp_group=self.use_attn_tp_ngram,
+            )
+            self.ngram_embedding.register_buffer(
+                "weight_scale", torch.ones(1, dtype=torch.bfloat16), persistent=True
+            )
 
     @classmethod
     def _splitmix64(cls, x: int) -> int:
@@ -891,7 +906,9 @@ class Qwen4ExpPLELayer(nn.Module):
             ple_layer_index=ple_layer_index,
             quant_config=quant_config,
         )
-        if config.ple_offload_embedding:
+        if config.ple_offload_embedding and not is_nvme_ple_embedding(
+            self.ple_embedding.ngram_embedding
+        ):
             self.ple_embedding.ngram_embedding = Qwen4ExpPinnedHostEmbedding(
                 self.ple_embedding.ngram_embedding
             )
@@ -942,7 +959,10 @@ class Qwen4ExpPLELayer(nn.Module):
         )
         nn.init.zeros_(self.conv1d.weight)
         self._prefetch_stream = (
-            torch.cuda.Stream() if config.ple_offload_embedding else None
+            torch.cuda.Stream()
+            if config.ple_offload_embedding
+            or is_nvme_ple_embedding(self.ple_embedding.ngram_embedding)
+            else None
         )
         self._graph_prefetch_buffers = {}
         self._eager_prefetch_buffer = None
@@ -1135,18 +1155,39 @@ class Qwen4ExpPLELayer(nn.Module):
         offloaded_embedding = self.ple_embedding.ngram_embedding
 
         stream = self._prefetch_stream
-        stream.wait_stream(torch.cuda.current_stream())
-        lookup_ids.record_stream(stream)
-        with torch.cuda.stream(stream):
-            offloaded_embedding.gather(lookup_ids, out=output_view)
-        self._prefetch_state = prefetched, semantic_tokens, physical_tokens
+        pending_nvme = None
+        if is_nvme_ple_embedding(offloaded_embedding):
+            pending_nvme = offloaded_embedding.start_gather(lookup_ids)
+        else:
+            stream.wait_stream(torch.cuda.current_stream())
+            lookup_ids.record_stream(stream)
+            with torch.cuda.stream(stream):
+                offloaded_embedding.gather(lookup_ids, out=output_view)
+        self._prefetch_state = (
+            prefetched,
+            semantic_tokens,
+            physical_tokens,
+            pending_nvme,
+        )
 
     def _consume_prefetched_embeddings(
         self, forward_batch: ForwardBatch
     ) -> torch.Tensor:
         if self._prefetch_state is None:
             raise RuntimeError("PLE prefetch state is missing")
-        embeddings, semantic_tokens, physical_tokens = self._prefetch_state
+        embeddings, semantic_tokens, physical_tokens, pending_nvme = (
+            self._prefetch_state
+        )
+        if pending_nvme is not None:
+            output_view = embeddings.view(
+                embeddings.shape[0], self.ple_embedding.ngram_heads, -1
+            )
+            self.ple_embedding.ngram_embedding.finish_gather(
+                pending_nvme,
+                embeddings.device,
+                out=output_view,
+                stream=self._prefetch_stream,
+            )
         torch.cuda.current_stream().wait_stream(self._prefetch_stream)
         embeddings = self.ple_embedding.ngram_embedding.reduce(embeddings)
         embeddings = embeddings * self.ple_embedding.ngram_embedding.weight_scale
@@ -1874,6 +1915,9 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
             if ple_mod is None:
                 return False
             emb = ple_mod.ngram_embedding
+            if is_nvme_ple_embedding(emb):
+                loaded_shard_params.add(f"{mod_prefix}.ngram_embedding.weight")
+                return True
             if (
                 loaded_weight.dtype == torch.float8_e4m3fn
                 and emb.weight.dtype != torch.float8_e4m3fn

--- a/python/sglang/srt/models/qwen4_ple_nvme.py
+++ b/python/sglang/srt/models/qwen4_ple_nvme.py
@@ -1,0 +1,626 @@
+"""NVMe-backed Qwen4 PLE embeddings.
+
+Qwen4's PLE table is a large, row-sharded FP8 matrix. This module parses the
+safetensors headers without loading the tensors, reads only selected rows, and
+overlaps those reads with the decoder layer immediately before PLE.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import errno
+import json
+import logging
+import math
+import mmap
+import os
+import re
+import struct
+import time
+from collections import OrderedDict
+from collections.abc import Sequence
+from concurrent.futures import Future, ThreadPoolExecutor
+from contextlib import nullcontext
+from itertools import pairwise
+from pathlib import Path
+from typing import Any, Protocol
+
+import msgspec
+import torch
+from torch import nn
+
+from sglang.srt.environ import envs
+from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph import (
+    eager_on_graph,
+    is_in_breakable_cuda_graph,
+)
+
+logger = logging.getLogger(__name__)
+
+_PLE_SHARD_PATTERN = re.compile(
+    r"^(?P<prefix>.+\.ngram_embedding)\.shard_(?P<index>\d+)\.weight$"
+)
+_DTYPE_BYTES = {
+    "BOOL": 1,
+    "U8": 1,
+    "I8": 1,
+    "F8_E4M3": 1,
+    "F8_E5M2": 1,
+    "I16": 2,
+    "U16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "I32": 4,
+    "U32": 4,
+    "F32": 4,
+    "I64": 8,
+    "U64": 8,
+    "F64": 8,
+}
+_MAX_HEADER_BYTES = 128 * 1024 * 1024
+
+
+class TensorRecord(msgspec.Struct, frozen=True):
+    path: Path
+    name: str
+    dtype: str
+    shape: tuple[int, ...]
+    offset: int
+    nbytes: int
+
+    @property
+    def itemsize(self) -> int:
+        return _DTYPE_BYTES[self.dtype]
+
+    @property
+    def row_bytes(self) -> int:
+        if len(self.shape) != 2:
+            raise ValueError(f"{self.name} is not a matrix: {self.shape}")
+        return self.shape[1] * self.itemsize
+
+
+class RowLocation(msgspec.Struct, frozen=True):
+    path: Path
+    offset: int
+    nbytes: int
+
+
+class PLEShard(msgspec.Struct, frozen=True):
+    index: int
+    row_start: int
+    row_end: int
+    tensor: TensorRecord
+
+
+def _read_safetensors_header(path: Path) -> dict[str, TensorRecord]:
+    with path.open("rb") as handle:
+        length_bytes = handle.read(8)
+        if len(length_bytes) != 8:
+            raise ValueError(f"truncated safetensors length in {path}")
+        (header_length,) = struct.unpack("<Q", length_bytes)
+        if header_length <= 0 or header_length > _MAX_HEADER_BYTES:
+            raise ValueError(
+                f"invalid safetensors header length {header_length} in {path}"
+            )
+        header_bytes = handle.read(header_length)
+        if len(header_bytes) != header_length:
+            raise ValueError(f"truncated safetensors header in {path}")
+
+    try:
+        header = json.loads(header_bytes)
+    except json.JSONDecodeError as error:
+        raise ValueError(f"invalid safetensors JSON in {path}") from error
+
+    data_start = 8 + header_length
+    records = {}
+    for name, metadata in header.items():
+        if name == "__metadata__":
+            continue
+        try:
+            dtype = str(metadata["dtype"])
+            shape = tuple(int(value) for value in metadata["shape"])
+            relative_start, relative_end = (
+                int(value) for value in metadata["data_offsets"]
+            )
+        except (KeyError, TypeError, ValueError) as error:
+            raise ValueError(
+                f"invalid metadata for tensor {name!r} in {path}"
+            ) from error
+        if dtype not in _DTYPE_BYTES:
+            raise ValueError(f"unsupported dtype {dtype!r} for {name!r}")
+        if any(dimension < 0 for dimension in shape):
+            raise ValueError(f"negative tensor shape for {name!r}: {shape}")
+        if relative_start < 0 or relative_end < relative_start:
+            raise ValueError(f"invalid data offsets for {name!r}")
+        expected_bytes = math.prod(shape) * _DTYPE_BYTES[dtype]
+        actual_bytes = relative_end - relative_start
+        if actual_bytes != expected_bytes:
+            raise ValueError(
+                f"size mismatch for {name!r}: {actual_bytes} != {expected_bytes}"
+            )
+        records[name] = TensorRecord(
+            path=path,
+            name=name,
+            dtype=dtype,
+            shape=shape,
+            offset=data_start + relative_start,
+            nbytes=actual_bytes,
+        )
+    return records
+
+
+class PLEManifest(msgspec.Struct, frozen=True):
+    prefix: str
+    dtype: str
+    embedding_dim: int
+    total_rows: int
+    shard_size: int
+    shards: tuple[PLEShard, ...]
+
+    @classmethod
+    def from_snapshot(
+        cls, snapshot: str | Path, *, expected_shards: int | None = None
+    ) -> PLEManifest:
+        snapshot_path = Path(snapshot)
+        index_path = snapshot_path / "model.safetensors.index.json"
+        with index_path.open() as handle:
+            weight_map = json.load(handle)["weight_map"]
+
+        matched = []
+        for name, filename in weight_map.items():
+            match = _PLE_SHARD_PATTERN.match(name)
+            if match:
+                matched.append(
+                    (name, match.group("prefix"), int(match.group("index")), filename)
+                )
+        if not matched:
+            raise ValueError(f"no sharded PLE embedding found in {index_path}")
+
+        prefixes = {prefix for _, prefix, _, _ in matched}
+        if len(prefixes) != 1:
+            raise ValueError(f"expected one PLE table, found {sorted(prefixes)}")
+        prefix = prefixes.pop()
+        matched.sort(key=lambda item: item[2])
+        indices = [index for _, _, index, _ in matched]
+        if indices != list(range(len(indices))):
+            raise ValueError(f"PLE shard indices are not contiguous: {indices}")
+        if expected_shards is not None and len(matched) != expected_shards:
+            raise ValueError(
+                f"expected {expected_shards} PLE shards, found {len(matched)}"
+            )
+
+        header_cache: dict[Path, dict[str, TensorRecord]] = {}
+        records = []
+        for name, _, shard_index, filename in matched:
+            path = snapshot_path / filename
+            header = header_cache.setdefault(path, _read_safetensors_header(path))
+            try:
+                record = header[name]
+            except KeyError as error:
+                raise ValueError(f"{name!r} is absent from {path}") from error
+            if len(record.shape) != 2:
+                raise ValueError(f"PLE shard {name!r} is not a matrix")
+            records.append((shard_index, record))
+
+        dtypes = {record.dtype for _, record in records}
+        dimensions = {record.shape[1] for _, record in records}
+        if len(dtypes) != 1 or len(dimensions) != 1:
+            raise ValueError(
+                f"inconsistent PLE shards: dtypes={dtypes}, dimensions={dimensions}"
+            )
+        shard_size = max(record.shape[0] for _, record in records)
+        shards = tuple(
+            PLEShard(
+                index=shard_index,
+                row_start=shard_index * shard_size,
+                row_end=shard_index * shard_size + record.shape[0],
+                tensor=record,
+            )
+            for shard_index, record in records
+        )
+        for previous, current in pairwise(shards):
+            if previous.row_end != current.row_start:
+                raise ValueError(
+                    "only the final PLE shard may be short; "
+                    f"shards {previous.index} and {current.index} are discontinuous"
+                )
+        return cls(
+            prefix=prefix,
+            dtype=records[0][1].dtype,
+            embedding_dim=records[0][1].shape[1],
+            total_rows=shards[-1].row_end,
+            shard_size=shard_size,
+            shards=shards,
+        )
+
+    @property
+    def row_bytes(self) -> int:
+        return self.shards[0].tensor.row_bytes
+
+    def locate(self, row_id: int) -> RowLocation:
+        if row_id < 0 or row_id >= self.total_rows:
+            raise IndexError(f"PLE row {row_id} is outside [0, {self.total_rows})")
+        shard = self.shards[row_id // self.shard_size]
+        if row_id >= shard.row_end:
+            raise IndexError(f"PLE row {row_id} is not materialized")
+        local_row = row_id - shard.row_start
+        return RowLocation(
+            path=shard.tensor.path,
+            offset=shard.tensor.offset + local_row * shard.tensor.row_bytes,
+            nbytes=shard.tensor.row_bytes,
+        )
+
+    def summary(self) -> dict[str, int | str]:
+        return {
+            "prefix": self.prefix,
+            "dtype": self.dtype,
+            "embedding_dim": self.embedding_dim,
+            "row_bytes": self.row_bytes,
+            "total_rows": self.total_rows,
+            "shards": len(self.shards),
+            "tensor_bytes": sum(shard.tensor.nbytes for shard in self.shards),
+            "files": len({shard.tensor.path for shard in self.shards}),
+        }
+
+
+class RowReader(Protocol):
+    def read_rows(self, row_ids: Sequence[int]) -> list[bytes]: ...
+
+    def close(self) -> None: ...
+
+
+class MMapRowReader:
+    """Portable correctness/debug backend backed by the page cache."""
+
+    def __init__(self, manifest: PLEManifest) -> None:
+        self.manifest = manifest
+        self._files: dict[Path, Any] = {}
+        self._maps: dict[Path, mmap.mmap] = {}
+
+    def _mapping(self, path: Path) -> mmap.mmap:
+        mapping = self._maps.get(path)
+        if mapping is None:
+            handle = path.open("rb")
+            mapping = mmap.mmap(handle.fileno(), 0, access=mmap.ACCESS_READ)
+            self._files[path] = handle
+            self._maps[path] = mapping
+        return mapping
+
+    def read_rows(self, row_ids: Sequence[int]) -> list[bytes]:
+        output = []
+        for row_id in row_ids:
+            location = self.manifest.locate(row_id)
+            mapping = self._mapping(location.path)
+            output.append(mapping[location.offset : location.offset + location.nbytes])
+        return output
+
+    def close(self) -> None:
+        for mapping in self._maps.values():
+            mapping.close()
+        for handle in self._files.values():
+            handle.close()
+        self._maps.clear()
+        self._files.clear()
+
+
+class IoUringPageRowReader:
+    """Read aligned pages through SGLang's persistent native io_uring reader."""
+
+    def __init__(
+        self,
+        manifest: PLEManifest,
+        *,
+        queue_depth: int,
+        max_batch: int,
+        cache_pages: int,
+        page_size: int = 4096,
+    ) -> None:
+        if not hasattr(os, "O_DIRECT"):
+            raise OSError("O_DIRECT is unavailable on this platform")
+        if cache_pages < 0:
+            raise ValueError("cache_pages cannot be negative")
+        from sglang.srt.rust_extensions import load_rust_extension
+
+        IoUringReader = load_rust_extension(
+            "sglang.srt.rust_extensions._storage"
+        ).IoUringReader
+
+        self.manifest = manifest
+        self.page_size = page_size
+        self.max_batch = max_batch
+        self.cache_pages = cache_pages
+        try:
+            self._ring = IoUringReader(queue_depth, max_batch, page_size)
+        except OSError as error:
+            if error.errno == errno.EPERM:
+                raise OSError(
+                    errno.EPERM,
+                    "io_uring is blocked; allow io_uring_setup, io_uring_enter, "
+                    "and io_uring_register in the container seccomp profile",
+                ) from error
+            raise
+        self._fds: dict[Path, int] = {}
+        self._cache: OrderedDict[tuple[Path, int], bytes] = OrderedDict()
+
+    def _fd(self, path: Path) -> int:
+        descriptor = self._fds.get(path)
+        if descriptor is None:
+            descriptor = os.open(path, os.O_RDONLY | os.O_DIRECT)
+            self._fds[path] = descriptor
+        return descriptor
+
+    def _page_keys(self, location: RowLocation) -> tuple[tuple[Path, int], ...]:
+        first = location.offset // self.page_size * self.page_size
+        last_byte = location.offset + location.nbytes - 1
+        last = last_byte // self.page_size * self.page_size
+        return tuple(
+            (location.path, offset)
+            for offset in range(first, last + self.page_size, self.page_size)
+        )
+
+    def _load_pages(
+        self, keys: Sequence[tuple[Path, int]]
+    ) -> dict[tuple[Path, int], bytes]:
+        pages = {}
+        misses = []
+        for key in dict.fromkeys(keys):
+            page = self._cache.get(key)
+            if page is None:
+                misses.append(key)
+            else:
+                self._cache.move_to_end(key)
+                pages[key] = page
+        for start in range(0, len(misses), self.max_batch):
+            chunk = misses[start : start + self.max_batch]
+            loaded = self._ring.read_pages(
+                [self._fd(path) for path, _ in chunk],
+                [offset for _, offset in chunk],
+            )
+            for key, page in zip(chunk, loaded, strict=True):
+                pages[key] = page
+                if self.cache_pages:
+                    self._cache[key] = page
+                    self._cache.move_to_end(key)
+                    while len(self._cache) > self.cache_pages:
+                        self._cache.popitem(last=False)
+        return pages
+
+    def read_rows(self, row_ids: Sequence[int]) -> list[bytes]:
+        locations = [self.manifest.locate(row_id) for row_id in row_ids]
+        location_keys = [self._page_keys(location) for location in locations]
+        pages = self._load_pages([key for keys in location_keys for key in keys])
+
+        output = []
+        for location, keys in zip(locations, location_keys, strict=True):
+            remaining = location.nbytes
+            cursor = location.offset
+            parts = []
+            for key in keys:
+                page_offset = key[1]
+                within_page = cursor - page_offset
+                available = min(remaining, len(pages[key]) - within_page)
+                if available <= 0:
+                    raise OSError(
+                        f"io_uring page does not cover {location.path}:{cursor}"
+                    )
+                parts.append(pages[key][within_page : within_page + available])
+                cursor += available
+                remaining -= available
+            if remaining:
+                raise OSError(f"incomplete row read: {remaining} bytes remain")
+            output.append(b"".join(parts))
+        return output
+
+    def close(self) -> None:
+        for descriptor in self._fds.values():
+            os.close(descriptor)
+        self._fds.clear()
+        self._cache.clear()
+
+
+class PendingGather:
+    """Mutable bridge updated by breakable CUDA-graph replay."""
+
+    def __init__(
+        self, future: Future[list[bytes]], input_shape: tuple[int, ...]
+    ) -> None:
+        self.future = future
+        self.input_shape = input_shape
+
+
+def _capture_start_gather(embedding: Any, input_ids: torch.Tensor) -> PendingGather:
+    future: Future[list[bytes]] = Future()
+    future.set_result([])
+    return PendingGather(future, tuple(input_ids.shape))
+
+
+def _capture_finish_gather(
+    embedding: Any,
+    pending: PendingGather,
+    device: torch.device,
+    out: torch.Tensor | None = None,
+    stream: torch.cuda.Stream | None = None,
+) -> torch.Tensor:
+    expected_shape = (*pending.input_shape, embedding.embedding_dim)
+    output = (
+        out if out is not None else embedding.allocate_output(expected_shape, device)
+    )
+    output.zero_()
+    return output
+
+
+class NVMePLEEmbedding(nn.Module):
+    """TP1 Qwen4 PLE embedding backed by sparse reads from a local snapshot."""
+
+    def __init__(
+        self,
+        snapshot: str | Path,
+        *,
+        num_embeddings: int,
+        embedding_dim: int,
+        expected_shards: int | None = None,
+    ) -> None:
+        super().__init__()
+        self.manifest = PLEManifest.from_snapshot(
+            snapshot, expected_shards=expected_shards
+        )
+        if self.manifest.total_rows != num_embeddings:
+            raise ValueError(
+                "PLE snapshot row count does not match the model config: "
+                f"{self.manifest.total_rows} != {num_embeddings}"
+            )
+        if self.manifest.embedding_dim != embedding_dim:
+            raise ValueError(
+                "PLE snapshot dimension does not match the model config: "
+                f"{self.manifest.embedding_dim} != {embedding_dim}"
+            )
+        if self.manifest.dtype != "F8_E4M3":
+            raise ValueError(
+                f"the NVMe PLE path requires FP8 E4M3 rows, got {self.manifest.dtype}"
+            )
+
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        self.tp_size = 1
+        self.register_buffer(
+            "weight_scale", torch.ones(1, dtype=torch.bfloat16), persistent=True
+        )
+        self._reader = self._create_reader()
+        self._io_executor = ThreadPoolExecutor(
+            max_workers=1, thread_name_prefix="ple-prefetch"
+        )
+        self._stage: torch.Tensor | None = None
+        self._stage_event: torch.cuda.Event | None = None
+        self._calls = 0
+        self._rows = 0
+        self._read_seconds = 0.0
+        summary = self.manifest.summary()
+        logger.info(
+            "Qwen4 PLE NVMe table: %.2f GiB across %d files (%d rows)",
+            int(summary["tensor_bytes"]) / (1024**3),
+            summary["files"],
+            self.manifest.total_rows,
+        )
+
+    def _create_reader(self) -> RowReader:
+        backend = envs.SGLANG_QWEN4_PLE_NVME_BACKEND.get()
+        if backend == "mmap":
+            return MMapRowReader(self.manifest)
+        if backend == "io_uring":
+            return IoUringPageRowReader(
+                self.manifest,
+                queue_depth=envs.SGLANG_QWEN4_PLE_NVME_QUEUE_DEPTH.get(),
+                max_batch=envs.SGLANG_QWEN4_PLE_NVME_MAX_BATCH_PAGES.get(),
+                cache_pages=envs.SGLANG_QWEN4_PLE_NVME_CACHE_PAGES.get(),
+            )
+        raise ValueError(f"unsupported SGLANG_QWEN4_PLE_NVME_BACKEND={backend!r}")
+
+    def _stage_buffer(self, nbytes: int) -> torch.Tensor:
+        if self._stage_event is not None:
+            self._stage_event.synchronize()
+        if self._stage is None or self._stage.numel() < nbytes:
+            self._stage = torch.empty(
+                nbytes, dtype=torch.uint8, device="cpu", pin_memory=True
+            )
+        return self._stage[:nbytes]
+
+    def allocate_output(
+        self, shape: Sequence[int], device: torch.device
+    ) -> torch.Tensor:
+        return torch.empty(tuple(shape), dtype=torch.bfloat16, device=device)
+
+    def gather(
+        self, input_ids: torch.Tensor, out: torch.Tensor | None = None
+    ) -> torch.Tensor:
+        return self.finish_gather(
+            self.start_gather(input_ids), input_ids.device, out=out
+        )
+
+    @eager_on_graph(True, capture_stub=_capture_start_gather)
+    def start_gather(self, input_ids: torch.Tensor) -> PendingGather:
+        row_ids = (
+            input_ids.detach().reshape(-1).to(device="cpu", dtype=torch.int64).tolist()
+        )
+        return PendingGather(
+            self._io_executor.submit(self._timed_read_rows, row_ids),
+            tuple(input_ids.shape),
+        )
+
+    def _timed_read_rows(self, row_ids: list[int]) -> list[bytes]:
+        started = time.perf_counter()
+        rows = self._reader.read_rows(row_ids)
+        self._calls += 1
+        self._rows += len(row_ids)
+        self._read_seconds += time.perf_counter() - started
+        interval = envs.SGLANG_QWEN4_PLE_NVME_LOG_INTERVAL.get()
+        if interval > 0 and self._calls % interval == 0:
+            logger.info(
+                "Qwen4 PLE NVMe: calls=%d rows=%d mean_read_ms=%.3f",
+                self._calls,
+                self._rows,
+                self._read_seconds / self._calls * 1000,
+            )
+        return rows
+
+    @eager_on_graph(True, capture_stub=_capture_finish_gather)
+    def finish_gather(
+        self,
+        pending: PendingGather,
+        device: torch.device,
+        out: torch.Tensor | None = None,
+        stream: torch.cuda.Stream | None = None,
+    ) -> torch.Tensor:
+        rows = pending.future.result()
+        expected_shape = (*pending.input_shape, self.embedding_dim)
+        output = (
+            out if out is not None else self.allocate_output(expected_shape, device)
+        )
+        if (
+            tuple(output.shape) != expected_shape
+            or output.dtype != torch.bfloat16
+            or output.device != device
+        ):
+            raise ValueError("invalid NVMe PLE output buffer")
+
+        raw = b"".join(rows)
+        expected_bytes = math.prod(pending.input_shape) * self.embedding_dim
+        if len(raw) != expected_bytes:
+            raise OSError(
+                f"NVMe PLE read returned {len(raw)} bytes; expected {expected_bytes}"
+            )
+        if raw:
+            stage = self._stage_buffer(len(raw))
+            ctypes.memmove(stage.data_ptr(), raw, len(raw))
+            stream_context = (
+                torch.cuda.stream(stream) if stream is not None else nullcontext()
+            )
+            with stream_context:
+                device_bytes = stage.to(device=device, non_blocking=True)
+                decoded = device_bytes.view(torch.float8_e4m3fn).to(torch.bfloat16)
+                output.copy_(decoded.view(expected_shape))
+                if self._stage_event is None:
+                    self._stage_event = torch.cuda.Event()
+                self._stage_event.record()
+            if is_in_breakable_cuda_graph():
+                self._stage_event.synchronize()
+        return output
+
+    def reduce(self, output: torch.Tensor) -> torch.Tensor:
+        return output
+
+    def forward(self, input_ids: torch.Tensor) -> torch.Tensor:
+        return self.gather(input_ids)
+
+    def close(self) -> None:
+        self._io_executor.shutdown()
+        self._reader.close()
+
+    def extra_repr(self) -> str:
+        return (
+            f"num_embeddings={self.num_embeddings}, "
+            f"embedding_dim={self.embedding_dim}, backend={type(self._reader).__name__}"
+        )
+
+
+def is_nvme_ple_embedding(module: Any) -> bool:
+    return isinstance(module, NVMePLEEmbedding)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1636,7 +1636,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tokio",
  "tower-service",
  "tracing",
@@ -1870,6 +1870,17 @@ name = "interpolator"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71dd52191aae121e8611f1e8dc3e324dd0dd1dee1e6dd91d10ee07a3cfb4d9d8"
+
+[[package]]
+name = "io-uring"
+version = "0.7.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64d8ca234d152948ceaede1f419b6a83983a5ecccaac05fb337a809c96d3aa6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+]
 
 [[package]]
 name = "ipnet"
@@ -2943,7 +2954,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.3",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "thiserror",
  "tokio",
  "tracing",
@@ -2981,7 +2992,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.5",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3731,6 +3742,15 @@ dependencies = [
  "tracing-appender",
  "tracing-subscriber",
  "uuid",
+]
+
+[[package]]
+name = "sglang-storage"
+version = "0.1.0"
+dependencies = [
+ "io-uring",
+ "libc",
+ "pyo3",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -3,7 +3,8 @@ resolver = "3"
 members = [
     "sglang-grpc",
     "sglang-mm",
-    "sglang-server"
+    "sglang-server",
+    "sglang-storage",
 ]
 
 [workspace.package]
@@ -18,6 +19,8 @@ license = "Apache-2.0"
 async-stream = "0.3"
 bytes = "1"
 futures = "0.3"
+io-uring = "0.7"
+libc = "0.2"
 pyo3 = { version = "0.29.0", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/sglang-storage/Cargo.toml
+++ b/rust/sglang-storage/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "sglang-storage"
+description = "Native storage primitives for SGLang"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+
+[package.metadata.sglang]
+python-module = "sglang.srt.rust_extensions._storage"
+debug = false
+
+[lib]
+name = "sglang_storage_core"
+crate-type = ["cdylib"]
+
+[dependencies]
+pyo3 = { workspace = true }
+
+[target.'cfg(target_os = "linux")'.dependencies]
+io-uring = { workspace = true }
+libc = { workspace = true }
+
+[features]
+default = ["pyo3/extension-module"]

--- a/rust/sglang-storage/src/io_uring_reader.rs
+++ b/rust/sglang-storage/src/io_uring_reader.rs
@@ -1,0 +1,285 @@
+use std::io;
+use std::os::fd::RawFd;
+use std::ptr::NonNull;
+use std::sync::Mutex;
+
+use io_uring::{IoUring, opcode, types};
+use pyo3::exceptions::{PyOSError, PyValueError};
+use pyo3::prelude::*;
+use pyo3::types::PyBytes;
+
+fn to_py_os_error(error: io::Error) -> PyErr {
+    match error.raw_os_error() {
+        Some(code) => PyOSError::new_err((code, error.to_string())),
+        None => PyOSError::new_err(error.to_string()),
+    }
+}
+
+struct AlignedBuffer {
+    ptr: NonNull<u8>,
+    len: usize,
+}
+
+// The allocation is exclusively accessed while ReaderState's mutex is held.
+unsafe impl Send for AlignedBuffer {}
+
+impl AlignedBuffer {
+    fn new(len: usize, alignment: usize) -> io::Result<Self> {
+        if len == 0 || !alignment.is_power_of_two() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "buffer length must be positive and alignment must be a power of two",
+            ));
+        }
+        let mut raw = std::ptr::null_mut();
+        // SAFETY: posix_memalign initializes `raw` on success. Its allocation
+        // is owned by this type and released exactly once in Drop.
+        let result = unsafe { libc::posix_memalign(&mut raw, alignment, len) };
+        if result != 0 {
+            return Err(io::Error::from_raw_os_error(result));
+        }
+        let ptr = NonNull::new(raw.cast::<u8>())
+            .ok_or_else(|| io::Error::other("posix_memalign returned a null pointer"))?;
+        Ok(Self { ptr, len })
+    }
+
+    fn page_ptr(&self, index: usize, page_size: usize) -> *mut u8 {
+        debug_assert!((index + 1) * page_size <= self.len);
+        // SAFETY: the caller bounds `index` by max_batch and the allocation is
+        // max_batch * page_size bytes.
+        unsafe { self.ptr.as_ptr().add(index * page_size) }
+    }
+
+    fn page(&self, index: usize, page_size: usize, read_size: usize) -> &[u8] {
+        debug_assert!(read_size <= page_size);
+        // SAFETY: the kernel has completed the read before this view is made,
+        // and the mutex prevents another read from mutating the allocation.
+        unsafe { std::slice::from_raw_parts(self.page_ptr(index, page_size), read_size) }
+    }
+}
+
+impl Drop for AlignedBuffer {
+    fn drop(&mut self) {
+        // SAFETY: ptr came from posix_memalign and has not been freed.
+        unsafe { libc::free(self.ptr.as_ptr().cast()) };
+    }
+}
+
+struct ReaderState {
+    ring: IoUring,
+    buffer: AlignedBuffer,
+}
+
+impl ReaderState {
+    fn read_pages(
+        &mut self,
+        file_descriptors: &[RawFd],
+        offsets: &[u64],
+        queue_depth: usize,
+        max_batch: usize,
+        page_size: usize,
+    ) -> io::Result<Vec<Vec<u8>>> {
+        if file_descriptors.len() != offsets.len() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "file descriptor and offset counts differ",
+            ));
+        }
+        if offsets.len() > max_batch {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!(
+                    "read has {} pages but max_batch is {max_batch}",
+                    offsets.len()
+                ),
+            ));
+        }
+
+        let count = offsets.len();
+        let mut read_sizes = vec![0_i32; count];
+        for base in (0..count).step_by(queue_depth) {
+            let batch = (count - base).min(queue_depth);
+            {
+                let mut submission = self.ring.submission();
+                for local in 0..batch {
+                    let index = base + local;
+                    let entry = opcode::Read::new(
+                        types::Fd(file_descriptors[index]),
+                        self.buffer.page_ptr(index, page_size),
+                        page_size as u32,
+                    )
+                    .offset(offsets[index])
+                    .build()
+                    .user_data((index + 1) as u64);
+                    // SAFETY: every read points into the persistent aligned
+                    // allocation, and all entries complete before reuse.
+                    unsafe { submission.push(&entry) }.map_err(|_| {
+                        io::Error::new(io::ErrorKind::WouldBlock, "io_uring queue is full")
+                    })?;
+                }
+            }
+
+            self.ring.submit_and_wait(batch)?;
+            let mut completion = self.ring.completion();
+            let mut first_error = None;
+            for _ in 0..batch {
+                let entry = completion.next().ok_or_else(|| {
+                    io::Error::new(io::ErrorKind::UnexpectedEof, "missing io_uring completion")
+                })?;
+                let user_data = entry.user_data();
+                if user_data == 0 || user_data > count as u64 {
+                    first_error.get_or_insert_with(|| {
+                        io::Error::other("invalid io_uring completion user_data")
+                    });
+                    continue;
+                }
+                let result = entry.result();
+                if result < 0 {
+                    first_error.get_or_insert_with(|| io::Error::from_raw_os_error(-result));
+                } else {
+                    read_sizes[user_data as usize - 1] = result;
+                }
+            }
+            if let Some(error) = first_error {
+                return Err(error);
+            }
+        }
+
+        read_sizes
+            .into_iter()
+            .enumerate()
+            .map(|(index, read_size)| {
+                if read_size <= 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::UnexpectedEof,
+                        format!("short io_uring read at offset {}", offsets[index]),
+                    ));
+                }
+                Ok(self
+                    .buffer
+                    .page(index, page_size, read_size as usize)
+                    .to_vec())
+            })
+            .collect()
+    }
+}
+
+#[pyclass]
+pub(crate) struct IoUringReader {
+    queue_depth: usize,
+    max_batch: usize,
+    page_size: usize,
+    state: Mutex<ReaderState>,
+}
+
+#[pymethods]
+impl IoUringReader {
+    #[new]
+    #[pyo3(signature = (queue_depth=512, max_batch=4096, page_size=4096))]
+    fn new(queue_depth: usize, max_batch: usize, page_size: usize) -> PyResult<Self> {
+        if queue_depth == 0 || max_batch == 0 {
+            return Err(PyValueError::new_err(
+                "queue_depth and max_batch must be positive",
+            ));
+        }
+        if !page_size.is_power_of_two() {
+            return Err(PyValueError::new_err(
+                "page_size must be a positive power of two",
+            ));
+        }
+        if page_size > u32::MAX as usize {
+            return Err(PyValueError::new_err("page_size exceeds u32"));
+        }
+        let buffer_len = max_batch
+            .checked_mul(page_size)
+            .ok_or_else(|| PyValueError::new_err("buffer size overflows usize"))?;
+        let ring = IoUring::new(
+            queue_depth
+                .try_into()
+                .map_err(|_| PyValueError::new_err("queue_depth exceeds u32"))?,
+        )
+        .map_err(to_py_os_error)?;
+        let buffer = AlignedBuffer::new(buffer_len, page_size).map_err(to_py_os_error)?;
+        Ok(Self {
+            queue_depth,
+            max_batch,
+            page_size,
+            state: Mutex::new(ReaderState { ring, buffer }),
+        })
+    }
+
+    fn read_pages(
+        &self,
+        py: Python<'_>,
+        file_descriptors: Vec<RawFd>,
+        offsets: Vec<u64>,
+    ) -> PyResult<Vec<Py<PyBytes>>> {
+        let pages = py
+            .detach(|| {
+                let mut state = self
+                    .state
+                    .lock()
+                    .map_err(|_| io::Error::other("io_uring reader lock is poisoned"))?;
+                state.read_pages(
+                    &file_descriptors,
+                    &offsets,
+                    self.queue_depth,
+                    self.max_batch,
+                    self.page_size,
+                )
+            })
+            .map_err(to_py_os_error)?;
+        Ok(pages
+            .into_iter()
+            .map(|page| PyBytes::new(py, &page).unbind())
+            .collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, OpenOptions};
+    use std::io::Write;
+    use std::os::fd::AsRawFd;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    use super::{AlignedBuffer, IoUring, ReaderState};
+
+    #[test]
+    fn reads_multiple_pages_in_submission_batches() {
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path =
+            std::env::temp_dir().join(format!("sglang-storage-{}-{nonce}.bin", std::process::id()));
+        let mut file = OpenOptions::new()
+            .create_new(true)
+            .read(true)
+            .write(true)
+            .open(&path)
+            .unwrap();
+        file.write_all(&vec![0x31; 4096]).unwrap();
+        file.write_all(&vec![0x72; 4096]).unwrap();
+        file.sync_all().unwrap();
+
+        let mut state = ReaderState {
+            ring: IoUring::new(1).unwrap(),
+            buffer: AlignedBuffer::new(8192, 4096).unwrap(),
+        };
+        let pages = state
+            .read_pages(
+                &[file.as_raw_fd(), file.as_raw_fd()],
+                &[0, 4096],
+                1,
+                2,
+                4096,
+            )
+            .unwrap();
+        assert_eq!(pages[0], vec![0x31; 4096]);
+        assert_eq!(pages[1], vec![0x72; 4096]);
+
+        drop(file);
+        fs::remove_file(path).unwrap();
+    }
+}

--- a/rust/sglang-storage/src/lib.rs
+++ b/rust/sglang-storage/src/lib.rs
@@ -1,0 +1,13 @@
+//! Native storage helpers used by the Python serving runtime.
+
+#[cfg(target_os = "linux")]
+mod io_uring_reader;
+
+use pyo3::prelude::*;
+
+#[pymodule]
+fn _storage(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    #[cfg(target_os = "linux")]
+    m.add_class::<io_uring_reader::IoUringReader>()?;
+    Ok(())
+}

--- a/test/registered/unit/layers/attention/test_qsa_decode_kernel.py
+++ b/test/registered/unit/layers/attention/test_qsa_decode_kernel.py
@@ -1,0 +1,54 @@
+import math
+import unittest
+
+import torch
+
+from sglang.kernels.ops.attention.qsa_decode import (
+    sparse_gqa_decode_physical_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cuda_ci(est_time=10, stage="base-b", runner_config="1-gpu-small")
+
+
+class TestSparseGQADecodeKernel(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        if not torch.cuda.is_available():
+            raise unittest.SkipTest("CUDA is unavailable")
+
+    def test_matches_grouped_query_reference(self):
+        torch.manual_seed(7)
+        device = torch.device("cuda")
+        batch, cache_tokens, topk = 4, 4096, 2051
+        q_heads, kv_heads, head_dim = 24, 2, 256
+        q = torch.randn(batch, q_heads, head_dim, dtype=torch.bfloat16, device=device)
+        k = torch.randn(
+            cache_tokens, kv_heads, head_dim, dtype=torch.bfloat16, device=device
+        )
+        v = torch.randn_like(k)
+        slots = torch.randint(0, cache_tokens, (batch, topk), device=device)
+        slots[:, -13:] = -1
+        scale = 1 / math.sqrt(head_dim)
+
+        actual = sparse_gqa_decode_physical_triton(q, k, v, slots, scale)
+        valid = slots >= 0
+        safe_slots = slots.clamp_min(0)
+        selected_k = k[safe_slots]
+        selected_v = v[safe_slots]
+        group_size = q_heads // kv_heads
+        q_grouped = q.view(batch, kv_heads, group_size, head_dim).float()
+        scores = torch.einsum("bkgd,btkd->bkgt", q_grouped, selected_k.float())
+        scores = scores.mul(scale).masked_fill(~valid[:, None, None, :], -torch.inf)
+        probabilities = torch.softmax(scores, dim=-1)
+        expected = torch.einsum(
+            "bkgt,btkd->bkgd", probabilities, selected_v.float()
+        ).to(q.dtype)
+        expected = expected.reshape_as(q)
+
+        torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-3)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_qwen4_ple_nvme.py
+++ b/test/registered/unit/models/test_qwen4_ple_nvme.py
@@ -1,0 +1,96 @@
+import json
+import struct
+import tempfile
+import unittest
+from pathlib import Path
+
+from sglang.srt.models.qwen4_ple_nvme import (
+    IoUringPageRowReader,
+    MMapRowReader,
+    PLEManifest,
+    RowLocation,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _write_safetensors(
+    path: Path, tensors: dict[str, tuple[str, tuple[int, ...], bytes]]
+):
+    header = {}
+    payload = bytearray()
+    for name, (dtype, shape, data) in tensors.items():
+        start = len(payload)
+        payload.extend(data)
+        header[name] = {
+            "dtype": dtype,
+            "shape": list(shape),
+            "data_offsets": [start, len(payload)],
+        }
+    encoded = json.dumps(header, separators=(",", ":")).encode()
+    path.write_bytes(struct.pack("<Q", len(encoded)) + encoded + payload)
+
+
+class TestQwen4PLENvmeManifest(CustomTestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.snapshot = Path(self.temp.name)
+        prefix = "model.layers.2.ple.ple_embedding.ngram_embedding"
+        self.names = [f"{prefix}.shard_{index}.weight" for index in range(2)]
+        _write_safetensors(
+            self.snapshot / "model-00001-of-00002.safetensors",
+            {self.names[0]: ("F8_E4M3", (2, 4), bytes(range(8)))},
+        )
+        _write_safetensors(
+            self.snapshot / "model-00002-of-00002.safetensors",
+            {self.names[1]: ("F8_E4M3", (1, 4), bytes(range(8, 12)))},
+        )
+        index = {
+            "metadata": {},
+            "weight_map": {
+                self.names[0]: "model-00001-of-00002.safetensors",
+                self.names[1]: "model-00002-of-00002.safetensors",
+            },
+        }
+        (self.snapshot / "model.safetensors.index.json").write_text(json.dumps(index))
+
+    def tearDown(self):
+        self.temp.cleanup()
+
+    def test_maps_global_rows_to_exact_safetensors_ranges(self):
+        manifest = PLEManifest.from_snapshot(self.snapshot, expected_shards=2)
+        self.assertEqual(manifest.dtype, "F8_E4M3")
+        self.assertEqual(manifest.embedding_dim, 4)
+        self.assertEqual(manifest.total_rows, 3)
+        self.assertEqual(manifest.row_bytes, 4)
+
+        reader = MMapRowReader(manifest)
+        self.addCleanup(reader.close)
+        self.assertEqual(
+            reader.read_rows([2, 0, 1]),
+            [bytes(range(8, 12)), bytes(range(4)), bytes(range(4, 8))],
+        )
+
+    def test_rejects_noncontiguous_shards(self):
+        index_path = self.snapshot / "model.safetensors.index.json"
+        index = json.loads(index_path.read_text())
+        second = index["weight_map"].pop(self.names[1])
+        index["weight_map"][self.names[1].replace("shard_1", "shard_2")] = second
+        index_path.write_text(json.dumps(index))
+        with self.assertRaisesRegex(ValueError, "not contiguous"):
+            PLEManifest.from_snapshot(self.snapshot)
+
+    def test_enumerates_every_page_spanned_by_a_row(self):
+        reader = object.__new__(IoUringPageRowReader)
+        reader.page_size = 4096
+        path = self.snapshot / "model-00001-of-00002.safetensors"
+        self.assertEqual(
+            reader._page_keys(RowLocation(path=path, offset=100, nbytes=9000)),
+            ((path, 0), (path, 4096), (path, 8192)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/storage/test_io_uring_reader.py
+++ b/test/registered/unit/storage/test_io_uring_reader.py
@@ -1,0 +1,37 @@
+import errno
+import os
+import tempfile
+import unittest
+
+from sglang.srt.rust_extensions import load_rust_extension
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+class TestIoUringReader(CustomTestCase):
+    def test_reads_pages_through_python_binding(self):
+        try:
+            reader_type = load_rust_extension(
+                "sglang.srt.rust_extensions._storage"
+            ).IoUringReader
+            reader = reader_type(1, 2, 4096)
+        except OSError as error:
+            if error.errno in (errno.ENOSYS, errno.EPERM):
+                raise unittest.SkipTest(f"io_uring is unavailable: {error}") from error
+            raise
+
+        with tempfile.NamedTemporaryFile() as file:
+            file.write(bytes([0x15]) * 4096)
+            file.write(bytes([0xA6]) * 4096)
+            file.flush()
+            os.fsync(file.fileno())
+            pages = reader.read_pages([file.fileno(), file.fileno()], [0, 4096])
+
+        self.assertEqual(pages[0], bytes([0x15]) * 4096)
+        self.assertEqual(pages[1], bytes([0xA6]) * 4096)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Stack

This PR is stacked on #36497 and targets its `qwen4-main-squashed` branch. It should be rebased onto `main` after that PR lands.

## Motivation

The Qwen3.8 Flash Next NVFP4 checkpoint contains a 47.68 GiB FP8 PLE n-gram embedding table. On a 128 GiB unified-memory system such as DGX Spark, keeping that table resident prevents the rest of the model, Mamba state, and KV cache from fitting comfortably.

PLE selects a small number of rows per forward, so the full table does not need to be resident. This change leaves the table in its original sharded safetensors files and reads only the selected rows from local NVMe.

## Modifications

- Add a bundled Linux Rust extension with a persistent `io_uring`, page-aligned storage, bounded submission batches, GIL-free reads, and preserved OS error codes.
- Parse and validate sharded PLE safetensors metadata without loading the table.
- Add `io_uring` and `mmap` row readers, optional page caching, pinned staging memory, asynchronous H2D conversion, and overlap with the decoder layer before PLE.
- Skip loading resident PLE shard weights when NVMe streaming is enabled. The initial path is intentionally TP1 and FP8 E4M3 only.
- Add a correctness-first Triton sparse GQA decode fallback for SM121, used only when the preferred TRT-LLM sparse path is unavailable.
- Add native, CPU, and GPU unit tests plus a deployment guide and a crate-scoped Rust CI job.

The feature is opt-in through `SGLANG_QWEN4_PLE_NVME_PATH`; existing model loading is unchanged when it is unset.

## Accuracy Tests

- The manifest and `mmap` tests cover sharded row mapping and malformed shard layouts.
- The Python binding test reads multiple pages through a queue-depth-one ring.
- Against `RadixArk/Qwen3.8-Flash-Next-NVFP4` revision `7b719225242aacd3dbd3f9407468c2ee9a9d2594`, rows at the first shard, a shard boundary, and the final shard matched `safetensors.safe_open` byte for byte through the Rust reader. Sixteen additional random rows also matched.
- The SM121 sparse GQA kernel matches a float32 grouped-query reference for the model shape: 24 Q heads, 2 KV heads, head dimension 256, and 2,051 selected positions. Maximum absolute error was 0.0009765625 and mean absolute error was 0.0000765.
- The exact branch served the full checkpoint through the Rust reader and completed a deterministic OpenAI-compatible chat-completion smoke test.

Completed locally:

```text
cargo test -p sglang-storage                                           1 passed
cargo clippy --workspace -- -D warnings                                passed
pytest test_qwen4_ple_nvme.py test_io_uring_reader.py                   4 passed
pytest test_qsa_decode_kernel.py                                        1 passed
pre-commit on all changed files                                         passed
mint validate                                                           passed
mint broken-links --check-anchors --check-redirects                     passed
```

## Speed Tests and Profiling

Hardware: NVIDIA DGX Spark GB10, SM121, internal Samsung NVMe, TP1, concurrency one.

The Rust reader measured 0.208 ms p50, 0.627 ms p95, and 0.944 ms p99 for 16 random logical PLE rows over 1,000 iterations while another storage-heavy workload was active. The sparse GQA kernel measured 0.0978 ms mean over 100 iterations at batch size one.

The exact branch was then run end to end with `RadixArk/Qwen3.8-Flash-Next-NVFP4`, BF16 KV cache, a 32K context, eager execution, and the checkpoint's built-in NEXTN head using three speculative steps, top-k one, and four draft tokens. Each domain contains ten held-out prompts with 512 output tokens per request:

| Domain | Input tokens | Output tokens | Duration | Output tok/s | Accept length | Median TTFT | Median TPOT |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| Chat | 8,162 | 5,120 | 217.72 s | 23.52 | 2.51 | 939.78 ms | 39.88 ms |
| STEM | 2,892 | 5,120 | 215.26 s | 23.78 | 2.54 | 462.02 ms | 38.11 ms |
| Math | 1,379 | 5,120 | 189.82 s | 26.97 | 2.69 | 310.90 ms | 36.76 ms |
| Code | 6,456 | 5,120 | 222.49 s | 23.01 | 2.68 | 801.03 ms | 41.48 ms |
| **Overall** | **18,889** | **20,480** | **845.30 s** | **24.23** | **2.60** | **469.02 ms** | **39.06 ms** |

All 40 requests completed without an API error, restart, or OOM. Overall TTFT is the median across all requests; overall TPOT is the mean of the four domain medians. After 7,000 logged gathers, the Rust reader had selected 703,568 rows at 4.475 ms mean read time across mixed prefill and speculative verification batches.

The target weights loaded in 466.10 seconds and occupied 80.06 GiB. The integrated NEXTN pass loaded in another 90.20 seconds. Target, draft, Mamba, and KV pools left 18.31 GiB available, with 447,040 KV-cache tokens allocated.
\n
## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33088727474](https://github.com/sgl-project/sglang/actions/runs/33088727474)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33088725886](https://github.com/sgl-project/sglang/actions/runs/33088725886)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33088726382](https://github.com/sgl-project/sglang/actions/runs/33088726382)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
