### PR TITLE
[diffusion] Fuse Cosmos3 Nano T2I attention on Hopper

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/cosmos3video.py
@@ -66,6 +66,22 @@ def is_cosmos_layer(name: str, _module: object) -> bool:
     return is_module_list_entry_in(name, ("layers", "gen_layers"))
 
 
+def _can_enable_t1_fused_qk_norm_rope(
+    *,
+    is_blackwell: bool,
+    is_hopper: bool,
+    hidden_act: str,
+    tp_size: int,
+    sp_size: int,
+    is_compiled: bool,
+) -> bool:
+    if is_compiled:
+        return False
+    if is_blackwell:
+        return True
+    return is_hopper and hidden_act != "relu2" and tp_size == 1 and sp_size == 1
+
+
 # -----------------------------------------------------------------------------
 # mRoPE position ID computation (Qwen3VL-style)
 # -----------------------------------------------------------------------------
@@ -1602,12 +1618,17 @@ class Cosmos3OmniTransformer(CachableDiT, LayerwiseOffloadableModuleMixin):
 
         self._ensure_cache_dicts()
 
-        # The T=1 fused path is faster on Blackwell, but regresses the Hopper
-        # Cosmos3-Super two-GPU workload. Keep Hopper on the original split path.
-        enable_t1_fused_qk_norm_rope = (
-            T == 1
-            and current_platform.is_blackwell()
-            and not self._gen_layers_torch_compiled
+        # The T=1 fused path is faster on Blackwell. It also benefits the
+        # single-GPU Hopper Nano (SwiGLU) workload, while the Hopper
+        # Cosmos3-Super (dense MLP) multi-GPU workload remains on the split
+        # path because that shape regresses with the fusion.
+        enable_t1_fused_qk_norm_rope = T == 1 and _can_enable_t1_fused_qk_norm_rope(
+            is_blackwell=current_platform.is_blackwell(),
+            is_hopper=current_platform.is_hopper(),
+            hidden_act=self.hidden_act,
+            tp_size=get_tp_world_size(),
+            sp_size=get_sp_world_size(),
+            is_compiled=self._gen_layers_torch_compiled,
         )
 
         # Compute UND K/V cache for this cache_key if not already cached

--- a/python/sglang/multimodal_gen/test/unit/test_cosmos3.py
+++ b/python/sglang/multimodal_gen/test/unit/test_cosmos3.py
@@ -46,6 +46,7 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.scheduler_loader imp
 from sglang.multimodal_gen.runtime.loader.utils import get_param_names_mapping
 from sglang.multimodal_gen.runtime.models.dits.cosmos3video import (
     DomainAwareLinear,
+    _can_enable_t1_fused_qk_norm_rope,
     compute_mrope_position_ids_action,
     compute_mrope_position_ids_sound,
     compute_mrope_position_ids_vision,
@@ -89,6 +90,55 @@ def _cosmos3_server_args(config=None, batching_max_size=1):
         batching_max_size=batching_max_size,
         pipeline_config=config or Cosmos3Config(),
     )
+
+
+class TestCosmos3T1FusedQKNormRoPE(unittest.TestCase):
+    def _can_enable(
+        self,
+        *,
+        is_blackwell=False,
+        is_hopper=False,
+        hidden_act="silu",
+        tp_size=1,
+        sp_size=1,
+        is_compiled=False,
+    ):
+        return _can_enable_t1_fused_qk_norm_rope(
+            is_blackwell=is_blackwell,
+            is_hopper=is_hopper,
+            hidden_act=hidden_act,
+            tp_size=tp_size,
+            sp_size=sp_size,
+            is_compiled=is_compiled,
+        )
+
+    def test_blackwell_remains_enabled(self):
+        self.assertTrue(
+            self._can_enable(
+                is_blackwell=True,
+                hidden_act="relu2",
+                tp_size=2,
+                sp_size=2,
+            )
+        )
+
+    def test_hopper_swiglu_single_gpu_enabled(self):
+        self.assertTrue(self._can_enable(is_hopper=True))
+
+    def test_hopper_dense_mlp_disabled(self):
+        self.assertFalse(self._can_enable(is_hopper=True, hidden_act="relu2"))
+
+    def test_hopper_tensor_parallel_disabled(self):
+        self.assertFalse(self._can_enable(is_hopper=True, tp_size=2))
+
+    def test_hopper_sequence_parallel_disabled(self):
+        self.assertFalse(self._can_enable(is_hopper=True, sp_size=2))
+
+    def test_compiled_path_disabled(self):
+        self.assertFalse(self._can_enable(is_hopper=True, is_compiled=True))
+
+    def test_other_architecture_disabled(self):
+        self.assertFalse(self._can_enable())
 
 
 class TestCosmos3ParamNamesMapping(unittest.TestCase):


### PR DESCRIPTION
## Summary

- enable the existing fused QK normalization, mRoPE, and KV-pack kernel for Cosmos3-Nano T2I on single-GPU Hopper
- keep Blackwell behavior unchanged
- retain the split path for Cosmos3-Super dense MLP, Hopper TP/SP configurations, and torch.compile
- add focused unit coverage for every selection guard

## H100 validation

Hardware: NVIDIA H100 80GB HBM3, CUDA_VISIBLE_DEVICES=0. Native SGLang backend, Cosmos3-Nano T2I preset, 1024x1024x1, 35 steps, seed 42, lossless output, synchronized same-GPU ABBA.

| Metric | Baseline mean | Candidate mean | Change |
|---|---:|---:|---:|
| Denoise latency | 1818.63 ms | 1599.87 ms | -12.03% |
| End-to-end latency | 3055.53 ms | 2809.43 ms | -8.05% |
| Peak memory | 34244 MB | 34242 MB | stable |

All four ABBA outputs are byte-identical: SHA256 c93da30473d6b145615f86645730d391182d9fa845426e49de0623ae4cdd72a2. SSIM is 1.0 and PSNR is infinite.

A five-denoise-step torch profile shows GPU kernel time decreasing from 253.393 ms to 231.242 ms (-8.74%) and launches decreasing from 12,264 to 4,344 (-64.6%). The fused QKNorm + RoPE + KV-pack kernel is invoked 360 times in the candidate trace.

The branch is rebased onto main commit 7f27bf4708a. A fresh model smoke on 06694071c6 reports 1.600 s denoise latency and the same output hash; the intervening commits only add a CUDA 13.4 container and wheel ABI metadata, without changing diffusion code.

## Tests

- python -m pytest python/sglang/multimodal_gen/test/unit/test_cosmos3.py -q
  - 119 passed, 31 subtests passed
- python -m pytest test/registered/kernels/ops/diffusion/test_rope.py -q -k qknorm_rope_pack_kv
  - 2 passed
- selected-file Black pre-commit hook
- git diff --check
- python -m py_compile on both changed files

Related background: https://github.com/BBuf/how-to-optim-algorithm-in-cuda/issues/21

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33051882279](https://github.com/sgl-project/sglang/actions/runs/33051882279)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33058373303](https://github.com/sgl-project/sglang/actions/runs/33058373303)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33051882303](https://github.com/sgl-project/sglang/actions/runs/33051882303)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->