### PR TITLE
Fix _is_compiling dynamo tracing: import torch instead of sys.modules lookup

### DIFF
--- a/python/sglang/srt/runtime_context.py
+++ b/python/sglang/srt/runtime_context.py
@@ -1265,9 +1265,12 @@ _RECORD_DUMP_REGISTERED = False
 def _is_compiling() -> bool:
     # Recording has Python side effects (set mutation, file I/O, atexit) that
     # must never run under tracing; torch.compiler.is_compiling() is dynamo's
-    # sanctioned probe. The lazy lookup keeps this module import-light.
-    torch = sys.modules.get("torch")
-    return torch is not None and torch.compiler.is_compiling()
+    # sanctioned probe. The function-level import keeps this module
+    # import-light; a sys.modules lookup here breaks fullgraph tracing (dynamo
+    # enumerates the dict, which other imports mutate mid-trace).
+    import torch
+
+    return torch.compiler.is_compiling()
 
 
 def _ensure_record_dump_registered() -> None:


### PR DESCRIPTION
## Motivation

`test_runtime_context_config_bags.py::TestRoleNamespaceEnforcement::test_record_mode_bag_read_traces_under_torch_compile` fails on main under torch 2.13 with:

```
InternalTorchDynamoError: RuntimeError: dictionary changed size during iteration
```

Root cause: `_is_compiling()` in `runtime_context.py` probed torch via `sys.modules.get("torch")`. Fullgraph-tracing that lookup makes dynamo build a variable tracker over the whole `sys.modules` dict — and dynamo's own lazily-imported internals (`torch._dynamo.symbolic_convert`, `triton.tools.tensor_descriptor`, ...) mutate the dict mid-enumeration.

**Why CI stays green while some machines fail:** the crash needs modules still unimported at trace time, so it is an import-order accident. Bisect points to 827552bc1d (#34496), which made `import sgl_kernel` lazy in `srt/utils/common.py` — before it, that eager import dragged in triton and most of torch at sglang-import time, leaving nothing to import mid-trace. Verified both ways: the test passes on unmodified main if `sgl_kernel` is pre-imported, and fails otherwise. Any environment where sgl_kernel/triton happens to load first (different wheel, different test ordering) hides the bug.

## Modifications

Replace the `sys.modules` lookup with a function-level `import torch`: dynamo traces import statements as constant module bindings, so no `sys.modules` dict is ever materialized, and the module stays import-light since nothing runs at module scope. This removes the import-order dependency entirely.

## Checklist

- Verified the traced form standalone under `torch.compile(fullgraph=True)`.
- `test_runtime_context_config_bags.py`: 19 passed, 8 subtests (previously 1 failed).
- `test_runtime_context.py`: 75 passed, 140 subtests.
- `test_global_config_read_ratchet.py` + `test_server_args_namespaces.py`: 10 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33022750575](https://github.com/sgl-project/sglang/actions/runs/33022750575)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33022750251](https://github.com/sgl-project/sglang/actions/runs/33022750251)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33022750664](https://github.com/sgl-project/sglang/actions/runs/33022750664)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->