### PR TITLE
[LoRA] Add DeepSeek-V4 attention targets and disambiguate DSA wq_b

### DIFF
--- a/python/sglang/srt/lora/lora_manager.py
+++ b/python/sglang/srt/lora/lora_manager.py
@@ -43,6 +43,7 @@ from sglang.srt.lora.utils import (
     auto_detect_lora_target_modules,
     get_normalized_target_modules,
     get_target_module_name,
+    matches_lora_target,
     warn_if_adapter_targets_embeddings,
 )
 from sglang.srt.managers.io_struct import LoRAUpdateOutput
@@ -666,7 +667,9 @@ class LoRAManager:
             )
             target_modules = self.target_modules
         elif target_modules:
-            self.target_modules = get_normalized_target_modules(target_modules)
+            self.target_modules = get_normalized_target_modules(
+                target_modules, base_model=self.base_model
+            )
         else:
             self.target_modules = set()
 
@@ -710,7 +713,7 @@ class LoRAManager:
                 )
 
             adapter_target_modules = get_normalized_target_modules(
-                config.target_modules
+                config.target_modules, base_model=self.base_model
             )
 
             if target_modules is not None:
@@ -980,11 +983,7 @@ class LoRAManager:
                 continue
 
             # The module should be converted if it is included in target_names
-            parts = module_name.split(".")
-            if (
-                parts[-1] in self.target_modules
-                or ".".join(parts[-2:]) in self.target_modules
-            ):
+            if matches_lora_target(module_name, self.target_modules):
                 layer_id = get_layer_id(module_name)
                 if layer_id is None:
                     continue

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -149,6 +149,7 @@ class LoRAMemoryPool:
         enable_lora_overlap_loading: bool = False,
     ):
         self.base_hf_config: AutoConfig = base_hf_config
+        self.base_model = base_model
         self.num_layer: int = base_hf_config.num_hidden_layers
         self.max_loras_per_batch: int = max_loras_per_batch
         self.dtype: torch.dtype = dtype
@@ -248,7 +249,9 @@ class LoRAMemoryPool:
                 return False
             if config.lora_added_tokens_size > self.lora_added_tokens_size:
                 return False
-            target_module_names = get_normalized_target_modules(config.target_modules)
+            target_module_names = get_normalized_target_modules(
+                config.target_modules, base_model=self.base_model
+            )
             if "all" in target_module_names:
                 return True
             return target_module_names.issubset(self.target_modules)

--- a/python/sglang/srt/lora/mem_pool.py
+++ b/python/sglang/srt/lora/mem_pool.py
@@ -942,6 +942,41 @@ class LoRAMemoryPool:
                 target_module: None for target_module in self.B_buffer
             }
 
+            def add_per_expert_weight(
+                buffer: Dict[
+                    str, Optional[Union[torch.Tensor, Dict[int, torch.Tensor]]]
+                ],
+                cache_keys: Dict[str, Optional[Union[str, Dict[int, str]]]],
+                target_module: str,
+                expert_id: int,
+                name: str,
+                weights: torch.Tensor,
+            ) -> None:
+                """Stage one factor without disturbing the opposite factor.
+
+                Shared-outer MoE adapters intentionally mix layouts: one LoRA
+                factor is a packed 3D tensor while the opposite factor is a
+                dictionary of per-expert 2D tensors. Therefore A and B must be
+                initialized independently.
+                """
+                factor_weights = buffer[target_module]
+                factor_cache_keys = cache_keys[target_module]
+                if factor_weights is None:
+                    factor_weights = {}
+                    buffer[target_module] = factor_weights
+                if factor_cache_keys is None:
+                    factor_cache_keys = {}
+                    cache_keys[target_module] = factor_cache_keys
+                if not isinstance(factor_weights, dict) or not isinstance(
+                    factor_cache_keys, dict
+                ):
+                    raise ValueError(
+                        f"LoRA target '{target_module}' mixes packed and "
+                        f"per-expert weights for the same factor: '{name}'."
+                    )
+                factor_weights[expert_id] = weights
+                factor_cache_keys[expert_id] = name
+
             for name, weights in layer_weights.items():
                 target_module = get_target_module_name(name, self.target_modules)
 
@@ -958,18 +993,25 @@ class LoRAMemoryPool:
                     # packed 3D weights and named per-expert 2D weights.
                     target_module = shared_moe_target
                     if expert_match:
-                        if temp_A_buffer[target_module] is None:
-                            temp_A_buffer[target_module] = {}
-                            temp_B_buffer[target_module] = {}
-                            temp_A_cache_keys[target_module] = {}
-                            temp_B_cache_keys[target_module] = {}
                         expert_id = int(expert_match.group(1))
                         if "lora_A" in name:
-                            temp_A_buffer[target_module][expert_id] = weights
-                            temp_A_cache_keys[target_module][expert_id] = name
+                            add_per_expert_weight(
+                                temp_A_buffer,
+                                temp_A_cache_keys,
+                                target_module,
+                                expert_id,
+                                name,
+                                weights,
+                            )
                         else:
-                            temp_B_buffer[target_module][expert_id] = weights
-                            temp_B_cache_keys[target_module][expert_id] = name
+                            add_per_expert_weight(
+                                temp_B_buffer,
+                                temp_B_cache_keys,
+                                target_module,
+                                expert_id,
+                                name,
+                                weights,
+                            )
                     elif "lora_A" in name:
                         temp_A_buffer[target_module] = weights
                         temp_A_cache_keys[target_module] = name
@@ -979,19 +1021,25 @@ class LoRAMemoryPool:
                 elif expert_match:
                     # Per-expert MoE weight — 2D tensors, one per expert
                     target_module = target_module + "_moe"
-                    if temp_A_buffer[target_module] is None:
-                        temp_A_buffer[target_module] = {}
-                        temp_B_buffer[target_module] = {}
-                        temp_A_cache_keys[target_module] = {}
-                        temp_B_cache_keys[target_module] = {}
-
                     expert_id = int(expert_match.group(1))
                     if "lora_A" in name:
-                        temp_A_buffer[target_module][expert_id] = weights
-                        temp_A_cache_keys[target_module][expert_id] = name
+                        add_per_expert_weight(
+                            temp_A_buffer,
+                            temp_A_cache_keys,
+                            target_module,
+                            expert_id,
+                            name,
+                            weights,
+                        )
                     else:
-                        temp_B_buffer[target_module][expert_id] = weights
-                        temp_B_cache_keys[target_module][expert_id] = name
+                        add_per_expert_weight(
+                            temp_B_buffer,
+                            temp_B_cache_keys,
+                            target_module,
+                            expert_id,
+                            name,
+                            weights,
+                        )
                 elif "experts" in name and weights.dim() == 3:
                     # Shared outer MoE weight — 3D tensor [expert_dim, rank, hidden]
                     target_module = target_module + "_moe"

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -221,6 +221,19 @@ def get_default_hidden_dim(
             config.kv_lora_rank,
             config.num_attention_heads * (config.qk_nope_head_dim + config.v_head_dim),
         )
+    elif module_name == "wq_a":
+        return config.hidden_size, config.q_lora_rank
+    elif module_name == "wq_b":
+        return config.q_lora_rank, config.num_attention_heads * config.head_dim
+    elif module_name == "wkv":
+        return config.hidden_size, config.head_dim
+    elif module_name == "wo_a":
+        return (
+            config.num_attention_heads * config.head_dim // config.o_groups,
+            config.o_groups * config.o_lora_rank,
+        )
+    elif module_name == "wo_b":
+        return config.o_groups * config.o_lora_rank, config.hidden_size
     elif module_name in DSA_INDEXER_LORA_NAMES:
         from sglang.srt.configs.model_config import (
             get_dsa_index_head_dim,
@@ -260,6 +273,7 @@ def get_default_hidden_dim(
 
 def get_normalized_target_modules(
     target_modules: Union[str, Iterable[str]],
+    base_model: Optional[torch.nn.Module] = None,
 ) -> set[str]:
     """
     Mapping a list of target module name to names of the normalized LoRA weights.
@@ -295,20 +309,44 @@ def get_normalized_target_modules(
         "unembed_tokens": "lm_head",
         "q_a_proj": "fused_qkv_a_proj_with_mqa",
         "kv_a_proj_with_mqa": "fused_qkv_a_proj_with_mqa",
-        # DSA indexer projections are qualified with their parent module name
-        # because the bare leaf names collide with unrelated modules in other
-        # models (e.g. DeepSeek-V4 attention `wq_b`, Pixtral vision `wk`).
-        "wq_b": "indexer.wq_b",
-        "wk": "indexer.wk",
-        "weights_proj": "indexer.weights_proj",
     }
 
     result = set()
     for name in target_modules:
+        parent_qualified_name = ".".join(name.split(".")[-2:])
+        if parent_qualified_name in DSA_INDEXER_LORA_NAMES:
+            result.add(parent_qualified_name)
+            continue
+
         base_name = name.split(".")[-1]
+        dsa_name = f"indexer.{base_name}"
+        if dsa_name in DSA_INDEXER_LORA_NAMES:
+            # PR #29874 accepted PEFT's bare DSA leaves. Preserve that
+            # behavior for DSA-only models, but resolve the same leaf to the
+            # main projection when the loaded model actually owns one (for
+            # example DeepSeek-V4 self_attn.wq_b). A DSA adapter on such a
+            # model must use the unambiguous parent-qualified name.
+            has_main_projection = base_model is not None and any(
+                module_name.split(".")[-1] == base_name
+                and ".".join(module_name.split(".")[-2:]) != dsa_name
+                for module_name, _module in base_model.named_modules()
+            )
+            result.add(base_name if has_main_projection else dsa_name)
+            continue
+
         normalized_name = params_mapping.get(base_name, base_name)
         result.add(normalized_name)
     return result
+
+
+def matches_lora_target(module_name: str, target_modules: Set[str]) -> bool:
+    """Match a concrete module path without aliasing a DSA child to its parent leaf."""
+    parts = module_name.split(".")
+    leaf_name = parts[-1]
+    parent_qualified_name = ".".join(parts[-2:])
+    if parent_qualified_name in DSA_INDEXER_LORA_NAMES:
+        return parent_qualified_name in target_modules
+    return leaf_name in target_modules or parent_qualified_name in target_modules
 
 
 def get_stacked_multiply(
@@ -344,6 +382,11 @@ def get_target_module_name(full_module_name: str, target_modules: Set[str]) -> s
     """
     best = None
     for target_module in target_modules:
+        if (
+            target_module in {name.split(".")[-1] for name in DSA_INDEXER_LORA_NAMES}
+            and f".indexer.{target_module}" in f".{full_module_name}"
+        ):
+            continue
         if target_module in full_module_name:
             if best is None or len(target_module) > len(best):
                 best = target_module
@@ -362,6 +405,7 @@ ROW_PARALLELISM_LINEAR_LORA_NAMES = [
     "down_proj_moe",
     "down_proj_shared_moe",
     "wo_ud",
+    "wo_b",
 ]
 DSA_INDEXER_LORA_NAMES = frozenset(
     {"indexer.wq_b", "indexer.wk", "indexer.weights_proj"}
@@ -370,6 +414,8 @@ REPLICATED_LINEAR_LORA_NAMES = [
     "fused_qkv_a_proj_with_mqa",
     "fc1_latent_proj",
     "fc2_latent_proj",
+    "wq_a",
+    "wkv",
     *DSA_INDEXER_LORA_NAMES,
 ]
 # Attention-projection LoRA modules shard on the attention-TP group, which
@@ -388,6 +434,9 @@ ATTN_TP_LORA_MODULE_NAMES = frozenset(
         "wo_ud",
         "in_proj",
         "in_proj_qkvz",
+        "wq_b",
+        "wo_a",
+        "wo_b",
     }
 )
 
@@ -412,6 +461,11 @@ _KNOWN_LORA_TARGET_MODULES = frozenset(
         "fused_qkv_a_proj_with_mqa",
         "q_b_proj",
         "kv_b_proj",
+        "wq_a",
+        "wq_b",
+        "wkv",
+        "wo_a",
+        "wo_b",
     }
     | DSA_INDEXER_LORA_NAMES
 )
@@ -458,7 +512,7 @@ def auto_detect_lora_target_modules(model: "torch.nn.Module") -> set:
             else:
                 raw_names.add(leaf_name)
 
-    normalized = get_normalized_target_modules(raw_names)
+    normalized = get_normalized_target_modules(raw_names, base_model=model)
     result = normalized & _KNOWN_LORA_TARGET_MODULES
 
     # Allow models to declare additional LoRA-compatible modules that

--- a/python/sglang/srt/lora/utils.py
+++ b/python/sglang/srt/lora/utils.py
@@ -184,9 +184,12 @@ def get_default_hidden_dim(
         )
     elif module_name == "gate_up_proj":
         inter = config.intermediate_size
+        deepseek_v4_shared = getattr(config, "model_type", None) == "deepseek_v4"
         first_k = getattr(config, "first_k_dense_replace", None)
         moe_freq = getattr(config, "moe_layer_freq", 1)
-        if first_k is not None and layer_idx >= first_k and layer_idx % moe_freq == 0:
+        if deepseek_v4_shared or (
+            first_k is not None and layer_idx >= first_k and layer_idx % moe_freq == 0
+        ):
             moe_inter = getattr(config, "moe_intermediate_size", None)
             n_shared = getattr(config, "n_shared_experts", None)
             if moe_inter is not None and n_shared is not None:
@@ -194,9 +197,12 @@ def get_default_hidden_dim(
         return config.hidden_size, inter * 2
     elif module_name == "down_proj":
         inter = config.intermediate_size
+        deepseek_v4_shared = getattr(config, "model_type", None) == "deepseek_v4"
         first_k = getattr(config, "first_k_dense_replace", None)
         moe_freq = getattr(config, "moe_layer_freq", 1)
-        if first_k is not None and layer_idx >= first_k and layer_idx % moe_freq == 0:
+        if deepseek_v4_shared or (
+            first_k is not None and layer_idx >= first_k and layer_idx % moe_freq == 0
+        ):
             moe_inter = getattr(config, "moe_intermediate_size", None)
             n_shared = getattr(config, "n_shared_experts", None)
             if moe_inter is not None and n_shared is not None:

--- a/test/registered/unit/lora/test_deepseek_v4_lora_utils.py
+++ b/test/registered/unit/lora/test_deepseek_v4_lora_utils.py
@@ -8,6 +8,9 @@ from sglang.srt.lora.utils import (
     get_normalized_target_modules,
     matches_lora_target,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 class _NamedModel:

--- a/test/registered/unit/lora/test_deepseek_v4_lora_utils.py
+++ b/test/registered/unit/lora/test_deepseek_v4_lora_utils.py
@@ -23,7 +23,11 @@ class _NamedModel:
 
 def _v4_config():
     return SimpleNamespace(
+        model_type="deepseek_v4",
         hidden_size=4096,
+        intermediate_size=18432,
+        moe_intermediate_size=2048,
+        n_shared_experts=1,
         num_attention_heads=64,
         head_dim=512,
         q_lora_rank=1024,
@@ -45,6 +49,14 @@ def test_deepseek_v4_attention_dimensions_and_parallelism():
     assert {"wq_a", "wkv"} <= set(REPLICATED_LINEAR_LORA_NAMES)
     assert "wo_b" in ROW_PARALLELISM_LINEAR_LORA_NAMES
     assert {"wq_b", "wo_a", "wo_b"} <= ATTN_TP_LORA_MODULE_NAMES
+
+
+def test_deepseek_v4_shared_expert_dimensions():
+    config = _v4_config()
+    base_model = object()
+
+    assert get_hidden_dim("gate_up_proj", config, base_model, 0) == (4096, 4096)
+    assert get_hidden_dim("down_proj", config, base_model, 0) == (2048, 4096)
 
 
 def test_wq_b_normalization_preserves_dsa_only_adapters():

--- a/test/registered/unit/lora/test_deepseek_v4_lora_utils.py
+++ b/test/registered/unit/lora/test_deepseek_v4_lora_utils.py
@@ -1,0 +1,73 @@
+from types import SimpleNamespace
+
+from sglang.srt.lora.utils import (
+    ATTN_TP_LORA_MODULE_NAMES,
+    REPLICATED_LINEAR_LORA_NAMES,
+    ROW_PARALLELISM_LINEAR_LORA_NAMES,
+    get_hidden_dim,
+    get_normalized_target_modules,
+    matches_lora_target,
+)
+
+
+class _NamedModel:
+    def __init__(self, names):
+        self._names = names
+
+    def named_modules(self):
+        return [(name, object()) for name in self._names]
+
+
+def _v4_config():
+    return SimpleNamespace(
+        hidden_size=4096,
+        num_attention_heads=64,
+        head_dim=512,
+        q_lora_rank=1024,
+        o_groups=8,
+        o_lora_rank=1024,
+    )
+
+
+def test_deepseek_v4_attention_dimensions_and_parallelism():
+    config = _v4_config()
+    base_model = object()
+
+    assert get_hidden_dim("wq_a", config, base_model, 0) == (4096, 1024)
+    assert get_hidden_dim("wq_b", config, base_model, 0) == (1024, 32768)
+    assert get_hidden_dim("wkv", config, base_model, 0) == (4096, 512)
+    assert get_hidden_dim("wo_a", config, base_model, 0) == (4096, 8192)
+    assert get_hidden_dim("wo_b", config, base_model, 0) == (8192, 4096)
+
+    assert {"wq_a", "wkv"} <= set(REPLICATED_LINEAR_LORA_NAMES)
+    assert "wo_b" in ROW_PARALLELISM_LINEAR_LORA_NAMES
+    assert {"wq_b", "wo_a", "wo_b"} <= ATTN_TP_LORA_MODULE_NAMES
+
+
+def test_wq_b_normalization_preserves_dsa_only_adapters():
+    dsa_only = _NamedModel(["model.layers.0.self_attn.indexer.wq_b"])
+
+    assert get_normalized_target_modules(["wq_b"]) == {"indexer.wq_b"}
+    assert get_normalized_target_modules(["wq_b"], base_model=dsa_only) == {
+        "indexer.wq_b"
+    }
+
+
+def test_wq_b_normalization_disambiguates_deepseek_v4_paths():
+    v4 = _NamedModel(
+        [
+            "model.layers.0.self_attn.wq_b",
+            "model.layers.0.self_attn.indexer.wq_b",
+        ]
+    )
+
+    assert get_normalized_target_modules(["wq_b"], base_model=v4) == {"wq_b"}
+    assert get_normalized_target_modules(["indexer.wq_b"], base_model=v4) == {
+        "indexer.wq_b"
+    }
+
+    assert matches_lora_target("model.layers.0.self_attn.wq_b", {"wq_b"})
+    assert not matches_lora_target("model.layers.0.self_attn.indexer.wq_b", {"wq_b"})
+    assert matches_lora_target(
+        "model.layers.0.self_attn.indexer.wq_b", {"indexer.wq_b"}
+    )

--- a/test/registered/unit/lora/test_mem_pool_ep_unit.py
+++ b/test/registered/unit/lora/test_mem_pool_ep_unit.py
@@ -879,6 +879,95 @@ class TestSharedMoeProductionLoad(unittest.TestCase):
                     torch.count_nonzero(pool.B_buffer[f"gate_up_proj{suffix}"][0]), 0
                 )
 
+    def test_mixed_packed_outer_and_per_expert_factors_load_independently(self):
+        for suffix, expert_path in (
+            ("_shared_moe", "shared_experts"),
+            ("_moe", "experts"),
+        ):
+            with self.subTest(suffix=suffix):
+                pool = _make_pool(
+                    num_experts_global=2,
+                    moe_ep_size=1,
+                    moe_ep_rank=0,
+                    moe_use_local_expert_ids=False,
+                )
+                pool.num_layer = 1
+                pool.max_lora_rank = 2
+                pool.target_modules = {"gate_up_proj", "down_proj"}
+                pool.experts_shared_outer_loras = True
+                pool.strict_loading = True
+                pool.lora_added_tokens_size = 0
+                pool.pin_memory_available = False
+                pool.enable_lora_overlap_loading = False
+                pool.base_model = object()
+                pool.A_buffer = {
+                    f"gate_up_proj{suffix}": [torch.zeros(1, 1, 4, 5)],
+                    f"down_proj{suffix}": [torch.zeros(1, 2, 2, 3)],
+                }
+                pool.B_buffer = {
+                    f"gate_up_proj{suffix}": [torch.zeros(1, 2, 6, 2)],
+                    f"down_proj{suffix}": [torch.zeros(1, 1, 5, 2)],
+                }
+                pool.embedding_A_buffer = {}
+                pool.embedding_B_buffer = {}
+                pool.lm_head_A_buffer = {}
+                pool.lm_head_B_buffer = {}
+                pool.new_embeddings_buffer = {}
+
+                gate_a = torch.arange(20, dtype=torch.float32).reshape(1, 4, 5)
+                gate_b = torch.arange(24, dtype=torch.float32).reshape(2, 6, 2)
+                down_a = torch.arange(12, dtype=torch.float32).reshape(2, 2, 3)
+                down_b = torch.arange(10, dtype=torch.float32).reshape(1, 5, 2)
+                weights = {
+                    f"model.layers.0.mlp.{expert_path}.gate_up_proj.lora_A.weight": gate_a,
+                    f"model.layers.0.mlp.{expert_path}.down_proj.lora_B.weight": down_b,
+                }
+                for expert_id in range(2):
+                    weights[
+                        f"model.layers.0.mlp.{expert_path}.{expert_id}.gate_up_proj.lora_B.weight"
+                    ] = gate_b[expert_id]
+                    weights[
+                        f"model.layers.0.mlp.{expert_path}.{expert_id}.down_proj.lora_A.weight"
+                    ] = down_a[expert_id]
+
+                adapter = types.SimpleNamespace(
+                    config=types.SimpleNamespace(r=2),
+                    scaling=2.5,
+                    layers=[types.SimpleNamespace(weights=weights, pinned_weights={})],
+                    embedding_layers={},
+                    added_tokens_embeddings={},
+                )
+                module = (
+                    _FakeSharedMoeLayer()
+                    if suffix == "_shared_moe"
+                    else _FakeRoutedMoeLayer()
+                )
+
+                _load_lora_weight_to_buffer(
+                    pool,
+                    uid="mixed-layout",
+                    buffer_id=0,
+                    lora_adapter=adapter,
+                    lora_modules=[{"experts": module}],
+                    lora_embed_tokens_module=None,
+                    lora_lm_head_module=None,
+                )
+
+                torch.testing.assert_close(
+                    pool.A_buffer[f"gate_up_proj{suffix}"][0][0, 0], gate_a[0]
+                )
+                torch.testing.assert_close(
+                    pool.B_buffer[f"gate_up_proj{suffix}"][0][0],
+                    gate_b * adapter.scaling,
+                )
+                torch.testing.assert_close(
+                    pool.A_buffer[f"down_proj{suffix}"][0][0], down_a
+                )
+                torch.testing.assert_close(
+                    pool.B_buffer[f"down_proj{suffix}"][0][0, 0],
+                    down_b[0] * adapter.scaling,
+                )
+
 
 class TestModuleLevelHelpers(unittest.TestCase):
     """`_get_moe_ep_context` / `_moe_runner_keeps_global_expert_ids`


### PR DESCRIPTION
> **Depends on #36579.** Grouped `wo_a` execution must land before this PR makes that module targetable.

## Problem

PR #29874 correctly introduced parent-qualified DSA indexer targets and normalized bare `wq_b` to `indexer.wq_b`. DeepSeek-V4 contains both that nested indexer projection and a distinct main-attention `wq_b`. The global alias therefore makes the main projection impossible to target with its normal PEFT leaf name, and simple suffix matching can wrap the indexer when only the main projection was requested.

The other V4 attention projections also lacked exact LoRA dimensions and parallelism classifications.

Two additional loader problems appear with a real all-linear V4 adapter:

- V4 configs do not use `first_k_dense_replace`, so the generic fallback sizes shared-expert gate/up/down buffers from `intermediate_size` instead of `moe_intermediate_size * n_shared_experts`.
- Shared-outer MoE adapters intentionally combine a packed 3D factor with per-expert 2D tensors for the opposite factor. The loader initialized A and B staging dictionaries together, which could overwrite an already-packed factor or dereference the still-uninitialized opposite factor.

## Fix

- Normalize DSA-colliding leaves with awareness of the loaded model:
  - bare `wq_b` resolves to the main projection when the model owns one;
  - explicit `indexer.wq_b` remains the DSA target;
  - DSA-only models preserve the behavior added by #29874.
- Match indexer children by their qualified parent+leaf name so a main `wq_b` target cannot wrap them.
- Use the same model-aware normalization for CLI targets, adapter configs, auto-detection, and memory-pool compatibility checks.
- Add exact V4 dimensions for `wq_a`, `wq_b`, `wkv`, `wo_a`, and `wo_b`, together with their replicated, row-parallel, and attention-TP ownership.
- Size V4 shared-expert gate/up/down buffers from the shared MoE geometry.
- Stage each MoE LoRA factor independently, preserving valid packed/per-expert mixed layouts for both routed and shared experts and rejecting incompatible same-factor layouts.

## Validation

- Model-free tests cover exact V4 attention geometry, main/indexer `wq_b` disambiguation, DSA-only compatibility, exact target matching, shared-expert dimensions, and both routed/shared packed-outer layouts.
- Focused CPU suite: 44 passed, 6 subtests passed.
- Repository-pinned Ruff 0.15.1, Black 26.1.0, isort 7.0.0, and diff checks pass.
- A current-main integration with #36579 started the real V4-Flash model at TP8/DP8 and loaded a 33,841-tensor all-linear adapter covering `wq_a`, `wq_b`, `wkv`, `wo_a`, `wo_b`, and MoE gate/up/down targets.
- The adapter loaded, ran on all eight ranks, unloaded, restored bitwise-stable base outputs on every rank, reloaded, and reproduced bitwise-stable adapter outputs on every rank. The adapter changed the measured outputs on all eight ranks.

Grouped `wo_a` execution and the active-LoRA CP decode-TP guard are in #36579. The matching trainer implementation is radixark/miles#2771.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33136696293](https://github.com/sgl-project/sglang/actions/runs/33136696293)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33136696200](https://github.com/sgl-project/sglang/actions/runs/33136696200)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33136696271](https://github.com/sgl-project/sglang/actions/runs/33136696271)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->