### PR TITLE
[LoRA] Preserve DeepSeek-V4 grouped wo_a semantics

### DIFF
--- a/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
+++ b/python/sglang/srt/layers/cp/cp_decode_attn_tp.py
@@ -126,6 +126,20 @@ class CpDecodeAttnTpContext:
 
     # ==================== Linear helpers ====================
 
+    def _unwrap_inactive_lora(self, linear_instance):
+        """Return the base linear, rejecting active LoRA during decode TP."""
+        from sglang.srt.lora.layers import BaseLayerWithLoRA
+
+        if not isinstance(linear_instance, BaseLayerWithLoRA):
+            return linear_instance
+        if linear_instance.lora_active:
+            raise RuntimeError(
+                "CP decode attention TP does not support active LoRA adapters. "
+                "The replicated LoRA buffers cannot be sliced safely with the "
+                "decode-TP base weights; disable CP decode attention TP or LoRA."
+            )
+        return linear_instance.base_layer
+
     def _get_linear_attrs(self, linear_instance) -> List[Tuple]:
         """Return (obj, attr_name, dim) list for a linear layer."""
         from sglang.srt.layers.linear import ColumnParallelLinear, RowParallelLinear
@@ -171,7 +185,8 @@ class CpDecodeAttnTpContext:
         row_parallel_decode_flags = []  # (RowParallelLinear, orig_flag) to restore
         orig_tp_q_head_num = None
         try:
-            for linear in modules:
+            for module in modules:
+                linear = self._unwrap_inactive_lora(module)
                 for obj, attr_name, dim in self._get_linear_attrs(linear):
                     self._activate(obj, attr_name, dim)
                     all_attrs.append((obj, attr_name))

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -93,8 +93,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
 
         source = self._get_sgemm_batch_info()
         is_capturing = (
-            source.seg_indptr.is_cuda
-            and torch.cuda.is_current_stream_capturing()
+            source.seg_indptr.is_cuda and torch.cuda.is_current_stream_capturing()
         )
         if getattr(self, "_grouped_sgemm_capture_state", False) != is_capturing:
             # Full CUDA-graph capture invokes the model for eager warmup before
@@ -162,8 +161,7 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         b_info = dataclasses.replace(
             source,
             weight_indices=(
-                source_weight_indices.unsqueeze(0) * num_groups
-                + group_ids.unsqueeze(1)
+                source_weight_indices.unsqueeze(0) * num_groups + group_ids.unsqueeze(1)
             ).reshape(-1),
             lora_ranks=source.lora_ranks.repeat_interleave(num_groups),
             scalings=source.scalings.repeat_interleave(num_groups),

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Optional, Tuple, Union
 
 import torch
@@ -26,6 +27,9 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
     # Supporting backends implement init_prefill_cuda_graph_batch_info() and
     # honor use_prefill_cuda_graph in prepare_lora_batch().
     supports_prefill_cuda_graph: bool = False
+    # Backends that honor the pruned_batch_info argument on both segmented
+    # GEMMs can opt into grouped projections whose rows repeat per token.
+    supports_repeated_sgemm_batch_info: bool = False
 
     def __init__(self, max_loras_per_batch: int, device: torch.device):
         self.max_loras_per_batch = max_loras_per_batch
@@ -51,6 +55,52 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         self.lm_head_batch_info = None
         self.lm_head_pass_batch_infos = None
         self._lm_head_pass_idx = None
+
+    def _get_sgemm_batch_info(self) -> LoRABatchInfo:
+        assert self.batch_info is not None, "LoRA batch metadata is not prepared"
+        return self.batch_info
+
+    def get_repeated_sgemm_batch_info(self, repeats: int) -> LoRABatchInfo:
+        """Repeat every logical token row while preserving adapter routing.
+
+        Grouped projections flatten ``[tokens, groups, hidden]`` to
+        ``[tokens * groups, hidden]`` in token-major order. Supporting
+        segmented-GEMM backends use this descriptor to route every expanded
+        group row to the same adapter as its source token.
+        """
+        if not self.supports_repeated_sgemm_batch_info:
+            raise RuntimeError(
+                f"LoRA backend {self.name!r} does not support repeated segmented-GEMM metadata"
+            )
+        if repeats <= 0:
+            raise ValueError(f"repeats must be positive, got {repeats}")
+
+        batch_info = self._get_sgemm_batch_info()
+        permutation = batch_info.permutation
+        if permutation is not None:
+            repeat_ids = torch.arange(
+                repeats,
+                device=permutation.device,
+                dtype=permutation.dtype,
+            )
+            permutation = (permutation.unsqueeze(-1) * repeats + repeat_ids).reshape(-1)
+
+        return dataclasses.replace(
+            batch_info,
+            seg_lens=(
+                None if batch_info.seg_lens is None else batch_info.seg_lens * repeats
+            ),
+            seg_indptr=batch_info.seg_indptr * repeats,
+            max_len=(
+                None if batch_info.max_len is None else batch_info.max_len * repeats
+            ),
+            permutation=permutation,
+            expected_tokens=(
+                None
+                if batch_info.expected_tokens is None
+                else batch_info.expected_tokens * repeats
+            ),
+        )
 
     def run_lora_a_embedding(
         self,

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -1,3 +1,4 @@
+import dataclasses
 from typing import Optional, Tuple, Union
 
 import torch
@@ -26,6 +27,9 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
     # Supporting backends implement init_prefill_cuda_graph_batch_info() and
     # honor use_prefill_cuda_graph in prepare_lora_batch().
     supports_prefill_cuda_graph: bool = False
+    # Supporting segmented-GEMM backends can apply grouped projections with
+    # group-major routing metadata supplied to both the A and B kernels.
+    supports_grouped_sgemm_batch_info: bool = False
 
     def __init__(self, max_loras_per_batch: int, device: torch.device):
         self.max_loras_per_batch = max_loras_per_batch
@@ -42,6 +46,8 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         # Request/token caps for serving a batch from the static metadata.
         self.prefill_cuda_graph_max_bs: int | None = None
         self.prefill_cuda_graph_max_tokens: int | None = None
+        self._grouped_sgemm_batch_info_cache = {}
+        self._grouped_sgemm_capture_state = False
 
     def reset_batch_state(self):
         """Idle-forward counterpart of prepare_lora_batch(): clears all
@@ -51,6 +57,120 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         self.lm_head_batch_info = None
         self.lm_head_pass_batch_infos = None
         self._lm_head_pass_idx = None
+        self._reset_grouped_sgemm_batch_info()
+
+    def _reset_grouped_sgemm_batch_info(self):
+        # prepare_lora_batch() calls this once per logical forward. During
+        # CUDA-graph capture, the first grouped layer records the metadata
+        # transforms and later layers reuse their outputs.
+        self._grouped_sgemm_batch_info_cache = {}
+        self._grouped_sgemm_capture_state = False
+
+    def _get_sgemm_batch_info(self) -> LoRABatchInfo:
+        assert self.batch_info is not None, "LoRA batch metadata is not prepared"
+        return self.batch_info
+
+    def get_grouped_sgemm_batch_infos(
+        self, num_groups: int, num_tokens: int
+    ) -> tuple[LoRABatchInfo, LoRABatchInfo]:
+        """Build group-major segmented-GEMM metadata for grouped projections.
+
+        The A pass reuses each token's adapter for every group. The B pass
+        routes to the composite ``adapter * num_groups + group`` weight. Whole
+        token segments are repeated per group, so the backend's original
+        maximum segment length remains unchanged.
+        """
+        if not self.supports_grouped_sgemm_batch_info:
+            raise RuntimeError(
+                f"LoRA backend {self.name!r} does not support grouped "
+                "segmented-GEMM metadata"
+            )
+        if num_groups <= 0 or num_tokens <= 0:
+            raise ValueError(
+                "grouped segmented-GEMM dimensions must be positive, got "
+                f"groups={num_groups}, tokens={num_tokens}"
+            )
+
+        source = self._get_sgemm_batch_info()
+        is_capturing = (
+            source.seg_indptr.is_cuda
+            and torch.cuda.is_current_stream_capturing()
+        )
+        if getattr(self, "_grouped_sgemm_capture_state", False) != is_capturing:
+            # Full CUDA-graph capture invokes the model for eager warmup before
+            # recording it. Rebuild on the eager/capture transition so the
+            # metadata transforms themselves are captured exactly once.
+            self._grouped_sgemm_batch_info_cache = {}
+            self._grouped_sgemm_capture_state = is_capturing
+        key = (id(source), num_groups, num_tokens)
+        cache = getattr(self, "_grouped_sgemm_batch_info_cache", None)
+        if cache is None:
+            cache = self._grouped_sgemm_batch_info_cache = {}
+        if key in cache:
+            return cache[key]
+
+        # CUDA-graph descriptors use fixed-size padded buffers. Include every
+        # allocated slot so captured tensor shapes stay static; padded
+        # zero-length segments remain no-ops.
+        num_segments = (
+            source.weight_indices.shape[0]
+            if source.use_cuda_graph
+            else source.num_segments
+        )
+        if num_segments is None:
+            raise RuntimeError("grouped LoRA batch metadata has no segment count")
+
+        device = source.seg_indptr.device
+        index_dtype = source.weight_indices.dtype
+        group_ids = torch.arange(num_groups, dtype=index_dtype, device=device)
+        token_offsets = group_ids * num_tokens
+        source_starts = source.seg_indptr[:num_segments]
+        segment_starts = (
+            source_starts.unsqueeze(0) + token_offsets.unsqueeze(1)
+        ).reshape(-1)
+        segment_end = source.seg_indptr[:1] + num_tokens * num_groups
+        seg_indptr = torch.cat((segment_starts, segment_end))
+
+        permutation = None
+        if source.permutation is not None:
+            permutation = (
+                source.permutation[:num_tokens].unsqueeze(0)
+                + token_offsets.unsqueeze(1)
+            ).reshape(-1)
+        seg_lens = None
+        if source.seg_lens is not None:
+            seg_lens = source.seg_lens[:num_segments].repeat(num_groups)
+
+        common = {
+            "bs": source.bs * num_groups,
+            "num_segments": num_segments * num_groups,
+            "seg_indptr": seg_indptr,
+            "max_len": source.max_len,
+            "seg_lens": seg_lens,
+            "permutation": permutation,
+            "expected_tokens": num_tokens * num_groups,
+            "req_seg_indptr": None,
+            "req_weight_indices": None,
+            "moe_lora_info": None,
+        }
+        source_weight_indices = source.weight_indices[:num_segments]
+        a_info = dataclasses.replace(
+            source,
+            weight_indices=source_weight_indices.repeat(num_groups),
+            **common,
+        )
+        b_info = dataclasses.replace(
+            source,
+            weight_indices=(
+                source_weight_indices.unsqueeze(0) * num_groups
+                + group_ids.unsqueeze(1)
+            ).reshape(-1),
+            lora_ranks=source.lora_ranks.repeat_interleave(num_groups),
+            scalings=source.scalings.repeat_interleave(num_groups),
+            **common,
+        )
+        cache[key] = (a_info, b_info)
+        return a_info, b_info
 
     def run_lora_a_embedding(
         self,

--- a/python/sglang/srt/lora/backend/base_backend.py
+++ b/python/sglang/srt/lora/backend/base_backend.py
@@ -1,4 +1,3 @@
-import dataclasses
 from typing import Optional, Tuple, Union
 
 import torch
@@ -27,9 +26,6 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
     # Supporting backends implement init_prefill_cuda_graph_batch_info() and
     # honor use_prefill_cuda_graph in prepare_lora_batch().
     supports_prefill_cuda_graph: bool = False
-    # Backends that honor the pruned_batch_info argument on both segmented
-    # GEMMs can opt into grouped projections whose rows repeat per token.
-    supports_repeated_sgemm_batch_info: bool = False
 
     def __init__(self, max_loras_per_batch: int, device: torch.device):
         self.max_loras_per_batch = max_loras_per_batch
@@ -55,52 +51,6 @@ class BaseLoRABackend(LoRABackendLmHeadMixing):
         self.lm_head_batch_info = None
         self.lm_head_pass_batch_infos = None
         self._lm_head_pass_idx = None
-
-    def _get_sgemm_batch_info(self) -> LoRABatchInfo:
-        assert self.batch_info is not None, "LoRA batch metadata is not prepared"
-        return self.batch_info
-
-    def get_repeated_sgemm_batch_info(self, repeats: int) -> LoRABatchInfo:
-        """Repeat every logical token row while preserving adapter routing.
-
-        Grouped projections flatten ``[tokens, groups, hidden]`` to
-        ``[tokens * groups, hidden]`` in token-major order. Supporting
-        segmented-GEMM backends use this descriptor to route every expanded
-        group row to the same adapter as its source token.
-        """
-        if not self.supports_repeated_sgemm_batch_info:
-            raise RuntimeError(
-                f"LoRA backend {self.name!r} does not support repeated segmented-GEMM metadata"
-            )
-        if repeats <= 0:
-            raise ValueError(f"repeats must be positive, got {repeats}")
-
-        batch_info = self._get_sgemm_batch_info()
-        permutation = batch_info.permutation
-        if permutation is not None:
-            repeat_ids = torch.arange(
-                repeats,
-                device=permutation.device,
-                dtype=permutation.dtype,
-            )
-            permutation = (permutation.unsqueeze(-1) * repeats + repeat_ids).reshape(-1)
-
-        return dataclasses.replace(
-            batch_info,
-            seg_lens=(
-                None if batch_info.seg_lens is None else batch_info.seg_lens * repeats
-            ),
-            seg_indptr=batch_info.seg_indptr * repeats,
-            max_len=(
-                None if batch_info.max_len is None else batch_info.max_len * repeats
-            ),
-            permutation=permutation,
-            expected_tokens=(
-                None
-                if batch_info.expected_tokens is None
-                else batch_info.expected_tokens * repeats
-            ),
-        )
 
     def run_lora_a_embedding(
         self,

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -34,6 +34,7 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
 
     name = "csgmv"
     supports_prefill_cuda_graph = True
+    supports_grouped_sgemm_batch_info = True
 
     def __init__(
         self,
@@ -275,6 +276,7 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
         use_cuda_graph: bool,
         use_prefill_cuda_graph: bool = False,
     ):
+        self._reset_grouped_sgemm_batch_info()
         chunk_size = self._determine_chunk_size(forward_batch)
 
         permutation, weight_indices_reordered = ChunkedSgmvLoRABackend._get_permutation(

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -34,6 +34,7 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
 
     name = "csgmv"
     supports_prefill_cuda_graph = True
+    supports_repeated_sgemm_batch_info = True
 
     def __init__(
         self,

--- a/python/sglang/srt/lora/backend/chunked_backend.py
+++ b/python/sglang/srt/lora/backend/chunked_backend.py
@@ -34,7 +34,6 @@ class ChunkedSgmvLoRABackend(BaseLoRABackend):
 
     name = "csgmv"
     supports_prefill_cuda_graph = True
-    supports_repeated_sgemm_batch_info = True
 
     def __init__(
         self,

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -26,6 +26,7 @@ PREFILL_CUDA_GRAPH_LORA_SEGMENTS = 32
 class TritonLoRABackend(BaseLoRABackend):
     name = "triton"
     supports_prefill_cuda_graph = True
+    supports_grouped_sgemm_batch_info = True
 
     def __init__(
         self,
@@ -70,6 +71,9 @@ class TritonLoRABackend(BaseLoRABackend):
             "sglang/srt/lora/layers.py forwards."
         )
         return self.sgemm_batch_info or self.batch_info
+
+    def _get_sgemm_batch_info(self) -> LoRABatchInfo:
+        return self._sgemm_info()
 
     def run_lora_a_sgemm(
         self,
@@ -273,6 +277,7 @@ class TritonLoRABackend(BaseLoRABackend):
         use_cuda_graph: bool,
         use_prefill_cuda_graph: bool = False,
     ):
+        self._reset_grouped_sgemm_batch_info()
         # Use pinned memory to avoid synchronizations during host-to-device transfer
         weight_indices_tensor = torch.tensor(
             weight_indices, dtype=torch.int32, pin_memory=True, device="cpu"

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -26,6 +26,7 @@ PREFILL_CUDA_GRAPH_LORA_SEGMENTS = 32
 class TritonLoRABackend(BaseLoRABackend):
     name = "triton"
     supports_prefill_cuda_graph = True
+    supports_repeated_sgemm_batch_info = True
 
     def __init__(
         self,
@@ -70,6 +71,9 @@ class TritonLoRABackend(BaseLoRABackend):
             "sglang/srt/lora/layers.py forwards."
         )
         return self.sgemm_batch_info or self.batch_info
+
+    def _get_sgemm_batch_info(self) -> LoRABatchInfo:
+        return self._sgemm_info()
 
     def run_lora_a_sgemm(
         self,

--- a/python/sglang/srt/lora/backend/triton_backend.py
+++ b/python/sglang/srt/lora/backend/triton_backend.py
@@ -26,7 +26,6 @@ PREFILL_CUDA_GRAPH_LORA_SEGMENTS = 32
 class TritonLoRABackend(BaseLoRABackend):
     name = "triton"
     supports_prefill_cuda_graph = True
-    supports_repeated_sgemm_batch_info = True
 
     def __init__(
         self,
@@ -71,9 +70,6 @@ class TritonLoRABackend(BaseLoRABackend):
             "sglang/srt/lora/layers.py forwards."
         )
         return self.sgemm_batch_info or self.batch_info
-
-    def _get_sgemm_batch_info(self) -> LoRABatchInfo:
-        return self._sgemm_info()
 
     def run_lora_a_sgemm(
         self,

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -488,9 +488,8 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         """Apply a flattened LoRA matrix as independent grouped projections.
 
         DeepSeek-V4 ``wo_a`` stores ``G`` independent ``[R, D]`` matrices as
-        one column-parallel ``[G * R, D]`` weight. The generic LoRA wrapper
-        computes all output groups for every input group, so retain only the
-        matching input/output-group diagonal.
+        one column-parallel ``[G * R, D]`` weight. Apply each group's matching
+        B slice independently so off-diagonal group products are never built.
         """
         if not self.lora_active:
             return base_output
@@ -500,7 +499,7 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
                 "base_output=[tokens,groups,output]"
             )
 
-        num_tokens, num_groups, input_dim = x.shape
+        num_tokens, num_groups, _ = x.shape
         if base_output.shape[:2] != (num_tokens, num_groups):
             raise RuntimeError(
                 "grouped LoRA base/input prefix mismatch: "
@@ -514,48 +513,46 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
                 f"group_output={group_output_dim}"
             )
 
-        batch_info = self.lora_backend.get_repeated_sgemm_batch_info(num_groups)
-        expected_tokens = num_tokens * num_groups
+        batch_info = self.lora_backend.batch_info
         if (
             batch_info.expected_tokens is not None
-            and batch_info.expected_tokens != expected_tokens
+            and batch_info.expected_tokens != num_tokens
         ):
             raise RuntimeError(
                 "grouped LoRA batch/input token mismatch: "
-                f"metadata={batch_info.expected_tokens}, input={expected_tokens}"
+                f"metadata={batch_info.expected_tokens}, input={num_tokens}"
             )
 
-        flat_input = x.reshape(expected_tokens, input_dim)
-        lora_a_output = self.lora_backend.run_lora_a_sgemm(
-            flat_input,
-            self.A_buffer,
-            pruned_batch_info=batch_info,
+        # Preserve the backend's original token segmentation and chunk size.
+        # Expanding every token row by G also expands csgmv's BLOCK_M and can
+        # exceed the device shared-memory limit. Running each group through
+        # the same segmented kernels computes only the G diagonal projections
+        # instead of materializing and discarding a G-by-G output.
+        group_output_offset = self.output_offset.new_tensor([0, group_output_dim])
+        group_output_offset_cpu = self.output_offset_cpu.new_tensor(
+            [0, group_output_dim]
         )
-        lora_output = self.lora_backend.run_lora_b_sgemm(
-            x=lora_a_output,
-            weights=self.B_buffer,
-            output_offset=self.output_offset,
-            output_offset_cpu=self.output_offset_cpu,
-            pruned_batch_info=batch_info,
-        )
-        expected_shape = (
-            expected_tokens,
-            num_groups * group_output_dim,
-        )
-        if tuple(lora_output.shape) != expected_shape:
-            raise RuntimeError(
-                "grouped LoRA kernel output mismatch: "
-                f"got {tuple(lora_output.shape)}, expected {expected_shape}"
+        group_outputs = []
+        for group_id in range(num_groups):
+            group_input = x[:, group_id, :].contiguous()
+            group_lora_a = self.lora_backend.run_lora_a_sgemm(
+                group_input,
+                self.A_buffer,
+            )
+            b_start = group_id * group_output_dim
+            group_lora_b = self.B_buffer[
+                :, b_start : b_start + group_output_dim, :
+            ].contiguous()
+            group_outputs.append(
+                self.lora_backend.run_lora_b_sgemm(
+                    x=group_lora_a,
+                    weights=group_lora_b,
+                    output_offset=group_output_offset,
+                    output_offset_cpu=group_output_offset_cpu,
+                )
             )
 
-        lora_output = lora_output.view(
-            num_tokens,
-            num_groups,
-            num_groups,
-            group_output_dim,
-        )
-        group_ids = torch.arange(num_groups, device=x.device)
-        return base_output + lora_output[:, group_ids, group_ids, :]
+        return base_output + torch.stack(group_outputs, dim=1)
 
     def forward(self, input_: torch.Tensor):
         # duplicate the logic in ColumnParallelLinear

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -488,8 +488,9 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         """Apply a flattened LoRA matrix as independent grouped projections.
 
         DeepSeek-V4 ``wo_a`` stores ``G`` independent ``[R, D]`` matrices as
-        one column-parallel ``[G * R, D]`` weight. Apply each group's matching
-        B slice independently so off-diagonal group products are never built.
+        one column-parallel ``[G * R, D]`` weight. Route the flattened grouped
+        input through matching composite adapter/group B weights so
+        off-diagonal group products are never built.
         """
         if not self.lora_active:
             return base_output
@@ -523,36 +524,44 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
                 f"metadata={batch_info.expected_tokens}, input={num_tokens}"
             )
 
-        # Preserve the backend's original token segmentation and chunk size.
-        # Expanding every token row by G also expands csgmv's BLOCK_M and can
-        # exceed the device shared-memory limit. Running each group through
-        # the same segmented kernels computes only the G diagonal projections
-        # instead of materializing and discarding a G-by-G output.
+        a_info, b_info = self.lora_backend.get_grouped_sgemm_batch_infos(
+            num_groups, num_tokens
+        )
+        flat_input = x.transpose(0, 1).contiguous().view(num_tokens * num_groups, -1)
+        lora_a_output = self.lora_backend.run_lora_a_sgemm(
+            flat_input,
+            self.A_buffer,
+            pruned_batch_info=a_info,
+        )
+
+        num_adapters, _, lora_rank = self.B_buffer.shape
+        grouped_b = self.B_buffer.view(
+            num_adapters,
+            num_groups,
+            group_output_dim,
+            lora_rank,
+        ).reshape(num_adapters * num_groups, group_output_dim, lora_rank)
         group_output_offset = self.output_offset.new_tensor([0, group_output_dim])
         group_output_offset_cpu = self.output_offset_cpu.new_tensor(
             [0, group_output_dim]
         )
-        group_outputs = []
-        for group_id in range(num_groups):
-            group_input = x[:, group_id, :].contiguous()
-            group_lora_a = self.lora_backend.run_lora_a_sgemm(
-                group_input,
-                self.A_buffer,
-            )
-            b_start = group_id * group_output_dim
-            group_lora_b = self.B_buffer[
-                :, b_start : b_start + group_output_dim, :
-            ].contiguous()
-            group_outputs.append(
-                self.lora_backend.run_lora_b_sgemm(
-                    x=group_lora_a,
-                    weights=group_lora_b,
-                    output_offset=group_output_offset,
-                    output_offset_cpu=group_output_offset_cpu,
-                )
+        lora_output = self.lora_backend.run_lora_b_sgemm(
+            x=lora_a_output,
+            weights=grouped_b,
+            output_offset=group_output_offset,
+            output_offset_cpu=group_output_offset_cpu,
+            pruned_batch_info=b_info,
+        )
+        expected_shape = (num_tokens * num_groups, group_output_dim)
+        if tuple(lora_output.shape) != expected_shape:
+            raise RuntimeError(
+                "grouped LoRA kernel output mismatch: "
+                f"got {tuple(lora_output.shape)}, expected {expected_shape}"
             )
 
-        return base_output + torch.stack(group_outputs, dim=1)
+        return base_output + lora_output.view(
+            num_groups, num_tokens, group_output_dim
+        ).transpose(0, 1)
 
     def forward(self, input_: torch.Tensor):
         # duplicate the logic in ColumnParallelLinear

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -461,6 +461,9 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
             device="cpu",
             pin_memory=True,
         )
+        self._grouped_output_dim = None
+        self._grouped_output_offset = None
+        self._grouped_output_offset_cpu = None
 
     def set_lora_info(
         self,
@@ -481,6 +484,31 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
             base_output=base_output,
         )
         return lora_output
+
+    def _get_grouped_output_offsets(
+        self, group_output_dim: int
+    ) -> tuple[torch.Tensor, torch.Tensor]:
+        if getattr(self, "_grouped_output_dim", None) != group_output_dim:
+            is_capturing = (
+                self.output_offset.is_cuda
+                and torch.cuda.is_current_stream_capturing()
+            )
+            if is_capturing:
+                raise RuntimeError(
+                    "grouped LoRA output offsets must be initialized during "
+                    "CUDA-graph warmup"
+                )
+            self._grouped_output_dim = group_output_dim
+            self._grouped_output_offset = self.output_offset.new_tensor(
+                [0, group_output_dim]
+            )
+            self._grouped_output_offset_cpu = torch.tensor(
+                [0, group_output_dim],
+                dtype=self.output_offset_cpu.dtype,
+                device="cpu",
+                pin_memory=self.output_offset_cpu.is_pinned(),
+            )
+        return self._grouped_output_offset, self._grouped_output_offset_cpu
 
     def apply_grouped_lora(
         self, base_output: torch.Tensor, x: torch.Tensor
@@ -541,9 +569,8 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
             group_output_dim,
             lora_rank,
         ).reshape(num_adapters * num_groups, group_output_dim, lora_rank)
-        group_output_offset = self.output_offset.new_tensor([0, group_output_dim])
-        group_output_offset_cpu = self.output_offset_cpu.new_tensor(
-            [0, group_output_dim]
+        group_output_offset, group_output_offset_cpu = (
+            self._get_grouped_output_offsets(group_output_dim)
         )
         lora_output = self.lora_backend.run_lora_b_sgemm(
             x=lora_a_output,

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -490,8 +490,7 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
     ) -> tuple[torch.Tensor, torch.Tensor]:
         if getattr(self, "_grouped_output_dim", None) != group_output_dim:
             is_capturing = (
-                self.output_offset.is_cuda
-                and torch.cuda.is_current_stream_capturing()
+                self.output_offset.is_cuda and torch.cuda.is_current_stream_capturing()
             )
             if is_capturing:
                 raise RuntimeError(
@@ -569,8 +568,8 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
             group_output_dim,
             lora_rank,
         ).reshape(num_adapters * num_groups, group_output_dim, lora_rank)
-        group_output_offset, group_output_offset_cpu = (
-            self._get_grouped_output_offsets(group_output_dim)
+        group_output_offset, group_output_offset_cpu = self._get_grouped_output_offsets(
+            group_output_dim
         )
         lora_output = self.lora_backend.run_lora_b_sgemm(
             x=lora_a_output,

--- a/python/sglang/srt/lora/layers.py
+++ b/python/sglang/srt/lora/layers.py
@@ -482,6 +482,81 @@ class ColumnParallelLinearWithLoRA(BaseLayerWithLoRA):
         )
         return lora_output
 
+    def apply_grouped_lora(
+        self, base_output: torch.Tensor, x: torch.Tensor
+    ) -> torch.Tensor:
+        """Apply a flattened LoRA matrix as independent grouped projections.
+
+        DeepSeek-V4 ``wo_a`` stores ``G`` independent ``[R, D]`` matrices as
+        one column-parallel ``[G * R, D]`` weight. The generic LoRA wrapper
+        computes all output groups for every input group, so retain only the
+        matching input/output-group diagonal.
+        """
+        if not self.lora_active:
+            return base_output
+        if x.ndim != 3 or base_output.ndim != 3:
+            raise RuntimeError(
+                "grouped LoRA expects x=[tokens,groups,input] and "
+                "base_output=[tokens,groups,output]"
+            )
+
+        num_tokens, num_groups, input_dim = x.shape
+        if base_output.shape[:2] != (num_tokens, num_groups):
+            raise RuntimeError(
+                "grouped LoRA base/input prefix mismatch: "
+                f"x={tuple(x.shape)}, base={tuple(base_output.shape)}"
+            )
+        group_output_dim = base_output.shape[-1]
+        if self.B_buffer.shape[-2] != num_groups * group_output_dim:
+            raise RuntimeError(
+                "grouped LoRA B/output mismatch: "
+                f"B={tuple(self.B_buffer.shape)}, groups={num_groups}, "
+                f"group_output={group_output_dim}"
+            )
+
+        batch_info = self.lora_backend.get_repeated_sgemm_batch_info(num_groups)
+        expected_tokens = num_tokens * num_groups
+        if (
+            batch_info.expected_tokens is not None
+            and batch_info.expected_tokens != expected_tokens
+        ):
+            raise RuntimeError(
+                "grouped LoRA batch/input token mismatch: "
+                f"metadata={batch_info.expected_tokens}, input={expected_tokens}"
+            )
+
+        flat_input = x.reshape(expected_tokens, input_dim)
+        lora_a_output = self.lora_backend.run_lora_a_sgemm(
+            flat_input,
+            self.A_buffer,
+            pruned_batch_info=batch_info,
+        )
+        lora_output = self.lora_backend.run_lora_b_sgemm(
+            x=lora_a_output,
+            weights=self.B_buffer,
+            output_offset=self.output_offset,
+            output_offset_cpu=self.output_offset_cpu,
+            pruned_batch_info=batch_info,
+        )
+        expected_shape = (
+            expected_tokens,
+            num_groups * group_output_dim,
+        )
+        if tuple(lora_output.shape) != expected_shape:
+            raise RuntimeError(
+                "grouped LoRA kernel output mismatch: "
+                f"got {tuple(lora_output.shape)}, expected {expected_shape}"
+            )
+
+        lora_output = lora_output.view(
+            num_tokens,
+            num_groups,
+            num_groups,
+            group_output_dim,
+        )
+        group_ids = torch.arange(num_groups, device=x.device)
+        return base_output + lora_output[:, group_ids, group_ids, :]
+
     def forward(self, input_: torch.Tensor):
         # duplicate the logic in ColumnParallelLinear
         bias = self.base_layer.bias if not self.base_layer.skip_bias_add else None

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1695,6 +1695,8 @@ class MQALayer(MqaAttentionBase):
             )
 
         o = o.view(o.shape[0], self.n_local_groups, -1)
+        wo_a_input = o
+        wo_a_base = getattr(self.wo_a, "base_layer", self.wo_a)
 
         if _FP8_WO_A_GEMM:
             import deep_gemm
@@ -1721,13 +1723,13 @@ class MQALayer(MqaAttentionBase):
             deep_gemm.fp8_einsum(
                 "bhr,hdr->bhd",
                 (o_fp8, o_s),
-                (self.wo_a.weight.view(G, R, D), self.wo_a.weight_scale_inv.data),
+                (wo_a_base.weight.view(G, R, D), wo_a_base.weight_scale_inv.data),
                 output,
                 recipe=recipe,
             )
             o = output
         else:
-            wo_a_weight = getattr(self.wo_a, "weight", None)
+            wo_a_weight = getattr(wo_a_base, "weight", None)
             if wo_a_weight is not None:
                 wo_a = wo_a_weight.view(self.n_local_groups, self.o_lora_rank, -1)
                 o = _apply_wo_a_bf16_matmul(
@@ -1736,10 +1738,13 @@ class MQALayer(MqaAttentionBase):
             else:
                 o = _apply_gguf_grouped_wo_a(
                     o,
-                    self.wo_a.qweight,
-                    self.wo_a.qweight_type.weight_type,
+                    wo_a_base.qweight,
+                    wo_a_base.qweight_type.weight_type,
                     self.o_lora_rank,
                 )
+
+        if hasattr(self.wo_a, "apply_grouped_lora"):
+            o = self.wo_a.apply_grouped_lora(o, wo_a_input)
 
         o, _ = self.wo_b(o.flatten(1))
         if self.attn_tp_size > 1 and self.attn_tp_size < get_parallel().tp_size:

--- a/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
+++ b/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
@@ -2,9 +2,13 @@ import pytest
 import torch
 from torch import nn
 
+from sglang.srt.layers.cp.cp_decode_attn_tp import CpDecodeAttnTpContext
 from sglang.srt.lora.backend.base_backend import BaseLoRABackend
 from sglang.srt.lora.layers import ColumnParallelLinearWithLoRA
 from sglang.srt.lora.utils import LoRABatchInfo
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
 
 def _batch_info(*, permutation=None):
@@ -65,6 +69,7 @@ class _TorchSegmentedBackend(BaseLoRABackend):
 def _layer(backend, lora_a, lora_b):
     layer = object.__new__(ColumnParallelLinearWithLoRA)
     nn.Module.__init__(layer)
+    layer.base_layer = nn.Linear(lora_a.shape[-1], lora_b.shape[-2], bias=False)
     layer.set_lora = True
     layer.A_buffer = lora_a
     layer.B_buffer = lora_b
@@ -137,3 +142,19 @@ def test_grouped_wo_a_rejects_backend_without_repeated_metadata():
             torch.randn(3, groups, 5),
             torch.randn(3, groups, 4),
         )
+
+
+def test_cp_decode_tp_rejects_active_lora_and_unwraps_inactive_wrapper():
+    backend = _TorchSegmentedBackend(_batch_info())
+    layer = _layer(
+        backend,
+        torch.randn(2, 3, 4),
+        torch.randn(2, 10, 3),
+    )
+    context = object.__new__(CpDecodeAttnTpContext)
+
+    with pytest.raises(RuntimeError, match="does not support active LoRA"):
+        context._unwrap_inactive_lora(layer)
+
+    backend.batch_info = None
+    assert context._unwrap_inactive_lora(layer) is layer.base_layer

--- a/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
+++ b/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
@@ -29,16 +29,11 @@ def _batch_info(*, permutation=None):
 
 class _TorchSegmentedBackend(BaseLoRABackend):
     name = "test"
-    supports_repeated_sgemm_batch_info = True
 
-    def __init__(self, batch_info, *, supports_repeated=True):
+    def __init__(self, batch_info):
         self.batch_info = batch_info
-        self.supports_repeated_sgemm_batch_info = supports_repeated
-        self.repeated_batch_info = None
-
-    def get_repeated_sgemm_batch_info(self, repeats):
-        self.repeated_batch_info = super().get_repeated_sgemm_batch_info(repeats)
-        return self.repeated_batch_info
+        self.a_input_shapes = []
+        self.b_weight_shapes = []
 
     def _adapter_per_row(self, batch_info, num_rows):
         adapters = torch.empty(num_rows, dtype=torch.long)
@@ -54,16 +49,16 @@ class _TorchSegmentedBackend(BaseLoRABackend):
             adapters[physical_rows] = batch_info.weight_indices[segment].long()
         return adapters
 
-    def run_lora_a_sgemm(self, x, weights, pruned_batch_info):
-        assert pruned_batch_info is self.repeated_batch_info
-        adapters = self._adapter_per_row(pruned_batch_info, x.shape[0])
+    def run_lora_a_sgemm(self, x, weights, **_kwargs):
+        self.a_input_shapes.append(tuple(x.shape))
+        adapters = self._adapter_per_row(self.batch_info, x.shape[0])
         return torch.bmm(x.unsqueeze(1), weights[adapters].transpose(1, 2)).squeeze(1)
 
-    def run_lora_b_sgemm(self, x, weights, pruned_batch_info, **_kwargs):
-        assert pruned_batch_info is self.repeated_batch_info
-        adapters = self._adapter_per_row(pruned_batch_info, x.shape[0])
+    def run_lora_b_sgemm(self, x, weights, **_kwargs):
+        self.b_weight_shapes.append(tuple(weights.shape))
+        adapters = self._adapter_per_row(self.batch_info, x.shape[0])
         output = torch.bmm(x.unsqueeze(1), weights[adapters].transpose(1, 2)).squeeze(1)
-        return output * pruned_batch_info.scalings[adapters].unsqueeze(1)
+        return output * self.batch_info.scalings[adapters].unsqueeze(1)
 
 
 def _layer(backend, lora_a, lora_b):
@@ -99,10 +94,10 @@ def test_grouped_wo_a_lora_selects_matching_group_diagonal():
     torch.testing.assert_close(output, expected)
 
 
-def test_grouped_batch_metadata_repeats_segments_and_permutation():
+def test_grouped_wo_a_preserves_backend_segments_and_chunk_size():
     info = _batch_info(permutation=torch.tensor([2, 0, 1], dtype=torch.int32))
     backend = _TorchSegmentedBackend(info)
-    groups = 2
+    groups = 4
     layer = _layer(
         backend,
         torch.randn(2, 3, 4),
@@ -114,30 +109,23 @@ def test_grouped_batch_metadata_repeats_segments_and_permutation():
         torch.randn(3, groups, 4),
     )
 
-    repeated = backend.repeated_batch_info
-    torch.testing.assert_close(
-        repeated.seg_indptr, torch.tensor([0, 2, 6], dtype=torch.int32)
-    )
-    torch.testing.assert_close(
-        repeated.seg_lens, torch.tensor([2, 4], dtype=torch.int32)
-    )
-    torch.testing.assert_close(
-        repeated.permutation,
-        torch.tensor([4, 5, 0, 1, 2, 3], dtype=torch.int32),
-    )
-    assert repeated.expected_tokens == 6
+    assert backend.batch_info is info
+    assert info.max_len == 2
+    torch.testing.assert_close(info.seg_indptr, torch.tensor([0, 1, 3]))
+    assert backend.a_input_shapes == [(3, 4)] * groups
+    assert backend.b_weight_shapes == [(2, 5, 3)] * groups
 
 
-def test_grouped_wo_a_rejects_backend_without_repeated_metadata():
+def test_grouped_wo_a_rejects_incompatible_b_layout():
     groups = 2
-    backend = _TorchSegmentedBackend(_batch_info(), supports_repeated=False)
+    backend = _TorchSegmentedBackend(_batch_info())
     layer = _layer(
         backend,
         torch.randn(1, 3, 4),
-        torch.randn(1, groups * 5, 3),
+        torch.randn(1, groups * 5 + 1, 3),
     )
 
-    with pytest.raises(RuntimeError, match="does not support repeated"):
+    with pytest.raises(RuntimeError, match="B/output mismatch"):
         layer.apply_grouped_lora(
             torch.randn(3, groups, 5),
             torch.randn(3, groups, 4),

--- a/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
+++ b/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
@@ -111,7 +111,9 @@ def test_grouped_wo_a_preserves_backend_segments_and_chunk_size():
 
     assert backend.batch_info is info
     assert info.max_len == 2
-    torch.testing.assert_close(info.seg_indptr, torch.tensor([0, 1, 3]))
+    torch.testing.assert_close(
+        info.seg_indptr, torch.tensor([0, 1, 3], dtype=torch.int32)
+    )
     assert backend.a_input_shapes == [(3, 4)] * groups
     assert backend.b_weight_shapes == [(2, 5, 3)] * groups
 

--- a/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
+++ b/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
@@ -1,0 +1,139 @@
+import pytest
+import torch
+from torch import nn
+
+from sglang.srt.lora.backend.base_backend import BaseLoRABackend
+from sglang.srt.lora.layers import ColumnParallelLinearWithLoRA
+from sglang.srt.lora.utils import LoRABatchInfo
+
+
+def _batch_info(*, permutation=None):
+    return LoRABatchInfo(
+        use_cuda_graph=False,
+        bs=2,
+        num_segments=2,
+        seg_indptr=torch.tensor([0, 1, 3], dtype=torch.int32),
+        weight_indices=torch.tensor([0, 1], dtype=torch.int32),
+        lora_ranks=torch.tensor([3, 3], dtype=torch.int32),
+        scalings=torch.tensor([1.0, 1.0]),
+        max_len=2,
+        seg_lens=torch.tensor([1, 2], dtype=torch.int32),
+        permutation=permutation,
+        expected_tokens=3,
+    )
+
+
+class _TorchSegmentedBackend(BaseLoRABackend):
+    name = "test"
+    supports_repeated_sgemm_batch_info = True
+
+    def __init__(self, batch_info, *, supports_repeated=True):
+        self.batch_info = batch_info
+        self.supports_repeated_sgemm_batch_info = supports_repeated
+        self.repeated_batch_info = None
+
+    def get_repeated_sgemm_batch_info(self, repeats):
+        self.repeated_batch_info = super().get_repeated_sgemm_batch_info(repeats)
+        return self.repeated_batch_info
+
+    def _adapter_per_row(self, batch_info, num_rows):
+        adapters = torch.empty(num_rows, dtype=torch.long)
+        permutation = batch_info.permutation
+        for segment in range(batch_info.num_segments):
+            start = int(batch_info.seg_indptr[segment])
+            end = int(batch_info.seg_indptr[segment + 1])
+            physical_rows = (
+                torch.arange(start, end)
+                if permutation is None
+                else permutation[start:end].long()
+            )
+            adapters[physical_rows] = batch_info.weight_indices[segment].long()
+        return adapters
+
+    def run_lora_a_sgemm(self, x, weights, pruned_batch_info):
+        assert pruned_batch_info is self.repeated_batch_info
+        adapters = self._adapter_per_row(pruned_batch_info, x.shape[0])
+        return torch.bmm(x.unsqueeze(1), weights[adapters].transpose(1, 2)).squeeze(1)
+
+    def run_lora_b_sgemm(self, x, weights, pruned_batch_info, **_kwargs):
+        assert pruned_batch_info is self.repeated_batch_info
+        adapters = self._adapter_per_row(pruned_batch_info, x.shape[0])
+        output = torch.bmm(x.unsqueeze(1), weights[adapters].transpose(1, 2)).squeeze(1)
+        return output * pruned_batch_info.scalings[adapters].unsqueeze(1)
+
+
+def _layer(backend, lora_a, lora_b):
+    layer = object.__new__(ColumnParallelLinearWithLoRA)
+    nn.Module.__init__(layer)
+    layer.set_lora = True
+    layer.A_buffer = lora_a
+    layer.B_buffer = lora_b
+    layer.lora_backend = backend
+    layer.output_offset = torch.tensor([0, lora_b.shape[-2]], dtype=torch.int32)
+    layer.output_offset_cpu = layer.output_offset
+    return layer
+
+
+def test_grouped_wo_a_lora_selects_matching_group_diagonal():
+    torch.manual_seed(0)
+    tokens, groups, input_dim, output_dim, rank = 3, 4, 5, 2, 3
+    x = torch.randn(tokens, groups, input_dim)
+    base_output = torch.randn(tokens, groups, output_dim)
+    lora_a = torch.randn(2, rank, input_dim)
+    lora_b = torch.randn(2, groups * output_dim, rank)
+    backend = _TorchSegmentedBackend(_batch_info())
+    layer = _layer(backend, lora_a, lora_b)
+
+    output = layer.apply_grouped_lora(base_output, x)
+
+    adapter_per_token = torch.tensor([0, 1, 1])
+    delta_weight = torch.bmm(lora_b, lora_a).view(2, groups, output_dim, input_dim)
+    expected = base_output + torch.einsum(
+        "tgd,tgrd->tgr", x, delta_weight[adapter_per_token]
+    )
+    torch.testing.assert_close(output, expected)
+
+
+def test_grouped_batch_metadata_repeats_segments_and_permutation():
+    info = _batch_info(permutation=torch.tensor([2, 0, 1], dtype=torch.int32))
+    backend = _TorchSegmentedBackend(info)
+    groups = 2
+    layer = _layer(
+        backend,
+        torch.randn(2, 3, 4),
+        torch.randn(2, groups * 5, 3),
+    )
+
+    layer.apply_grouped_lora(
+        torch.randn(3, groups, 5),
+        torch.randn(3, groups, 4),
+    )
+
+    repeated = backend.repeated_batch_info
+    torch.testing.assert_close(
+        repeated.seg_indptr, torch.tensor([0, 2, 6], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        repeated.seg_lens, torch.tensor([2, 4], dtype=torch.int32)
+    )
+    torch.testing.assert_close(
+        repeated.permutation,
+        torch.tensor([4, 5, 0, 1, 2, 3], dtype=torch.int32),
+    )
+    assert repeated.expected_tokens == 6
+
+
+def test_grouped_wo_a_rejects_backend_without_repeated_metadata():
+    groups = 2
+    backend = _TorchSegmentedBackend(_batch_info(), supports_repeated=False)
+    layer = _layer(
+        backend,
+        torch.randn(1, 3, 4),
+        torch.randn(1, groups * 5, 3),
+    )
+
+    with pytest.raises(RuntimeError, match="does not support repeated"):
+        layer.apply_grouped_lora(
+            torch.randn(3, groups, 5),
+            torch.randn(3, groups, 4),
+        )

--- a/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
+++ b/test/registered/unit/lora/test_deepseek_v4_grouped_wo_a.py
@@ -29,11 +29,15 @@ def _batch_info(*, permutation=None):
 
 class _TorchSegmentedBackend(BaseLoRABackend):
     name = "test"
+    supports_grouped_sgemm_batch_info = True
 
     def __init__(self, batch_info):
         self.batch_info = batch_info
+        self._grouped_sgemm_batch_info_cache = {}
         self.a_input_shapes = []
         self.b_weight_shapes = []
+        self.a_batch_infos = []
+        self.b_batch_infos = []
 
     def _adapter_per_row(self, batch_info, num_rows):
         adapters = torch.empty(num_rows, dtype=torch.long)
@@ -49,16 +53,20 @@ class _TorchSegmentedBackend(BaseLoRABackend):
             adapters[physical_rows] = batch_info.weight_indices[segment].long()
         return adapters
 
-    def run_lora_a_sgemm(self, x, weights, **_kwargs):
+    def run_lora_a_sgemm(self, x, weights, pruned_batch_info=None, **_kwargs):
         self.a_input_shapes.append(tuple(x.shape))
-        adapters = self._adapter_per_row(self.batch_info, x.shape[0])
+        batch_info = pruned_batch_info or self.batch_info
+        self.a_batch_infos.append(batch_info)
+        adapters = self._adapter_per_row(batch_info, x.shape[0])
         return torch.bmm(x.unsqueeze(1), weights[adapters].transpose(1, 2)).squeeze(1)
 
-    def run_lora_b_sgemm(self, x, weights, **_kwargs):
+    def run_lora_b_sgemm(self, x, weights, pruned_batch_info=None, **_kwargs):
         self.b_weight_shapes.append(tuple(weights.shape))
-        adapters = self._adapter_per_row(self.batch_info, x.shape[0])
+        batch_info = pruned_batch_info or self.batch_info
+        self.b_batch_infos.append(batch_info)
+        adapters = self._adapter_per_row(batch_info, x.shape[0])
         output = torch.bmm(x.unsqueeze(1), weights[adapters].transpose(1, 2)).squeeze(1)
-        return output * self.batch_info.scalings[adapters].unsqueeze(1)
+        return output * batch_info.scalings[adapters].unsqueeze(1)
 
 
 def _layer(backend, lora_a, lora_b):
@@ -114,8 +122,29 @@ def test_grouped_wo_a_preserves_backend_segments_and_chunk_size():
     torch.testing.assert_close(
         info.seg_indptr, torch.tensor([0, 1, 3], dtype=torch.int32)
     )
-    assert backend.a_input_shapes == [(3, 4)] * groups
-    assert backend.b_weight_shapes == [(2, 5, 3)] * groups
+    assert backend.a_input_shapes == [(12, 4)]
+    assert backend.b_weight_shapes == [(8, 5, 3)]
+
+    a_info = backend.a_batch_infos[0]
+    b_info = backend.b_batch_infos[0]
+    assert a_info.max_len == b_info.max_len == 2
+    assert a_info.expected_tokens == b_info.expected_tokens == 12
+    torch.testing.assert_close(
+        a_info.seg_indptr,
+        torch.tensor([0, 1, 3, 4, 6, 7, 9, 10, 12], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        a_info.permutation,
+        torch.tensor([2, 0, 1, 5, 3, 4, 8, 6, 7, 11, 9, 10], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        a_info.weight_indices,
+        torch.tensor([0, 1, 0, 1, 0, 1, 0, 1], dtype=torch.int32),
+    )
+    torch.testing.assert_close(
+        b_info.weight_indices,
+        torch.tensor([0, 4, 1, 5, 2, 6, 3, 7], dtype=torch.int32),
+    )
 
 
 def test_grouped_wo_a_rejects_incompatible_b_layout():


### PR DESCRIPTION
## Problem

DeepSeek-V4 `wo_a` is a grouped projection: `G` independent `[R, D]`
matrices are stored in one flattened column-parallel weight. Each input group
must receive only the LoRA delta from its matching output group.

The generic column-parallel LoRA path instead treats the flattened weight as
one dense projection. That introduces cross-group terms and changes the model
operator. It also hides the base-layer attributes used by the native V4
forward.

CP decode attention TP introduces another layout transition: it slices the
replicated base weights for decode while loaded LoRA buffers remain in the
prefill layout. Silently unwrapping an active adapter there would be incorrect.

## Fix

- Unwrap the base `wo_a` layer for the native BF16, FP8, and GGUF projection.
- Add a backend contract that constructs group-major segmented-GEMM metadata
  for one LoRA A and one LoRA B dispatch.
- Route A with the original adapter index repeated per group, and route B with
  a composite adapter/group index, so only the matching group diagonal is
  materialized.
- Preserve the backend's original segment `max_len`; group count must not
  change kernel tuning or chunk size.
- Cache grouped metadata once per logical forward and rebuild it on the
  eager-to-CUDA-graph capture transition so all metadata transforms are
  captured safely.
- Initialize constant grouped output offsets during eager warmup and fail
  closed if capture begins before initialization.
- Enable the csgmv and Triton backends, which both honor explicit segmented
  metadata for A and B.
- Reject unsupported backends, incompatible grouped layouts, and active LoRA
  under CP decode attention TP. Inactive wrappers are safely unwrapped and use
  the existing base-weight slice/restore path.

This computes the required diagonal directly. It does not allocate a `G x G`
intermediate and does not issue a separate A/B kernel pair per group.

The target registration and V4 dimensions are in #36578, which should merge
after this execution support. The matching trainer implementation is
radixark/miles#2771.

## Validation

- Four focused CPU contract tests pass, including exact grouped algebra,
  routing/permutation metadata, incompatible layouts, and the CP contract.
- TP=2 H200 kernel qualification passed for both csgmv and Triton with:
  - 8,192-token prefill and 8-token decode;
  - two adapters with nontrivial token routing;
  - four local groups per TP rank;
  - CUDA-graph capture after eager warmup and replay after changing adapter
    routing.
- Production output matched an independently assembled group-major kernel path
  bit-for-bit on both ranks and both backends.
- Maximum absolute error versus the grouped-diagonal PyTorch BF16 reference was
  0.03125 for prefill and 0.015625 for decode.
- The diagonal path avoided 192 MiB/rank of off-diagonal B output at 8,192
  tokens (64 MiB instead of 256 MiB).
- Median production/reference latency ratios, using five samples of 20
  iterations, were:
  - csgmv: 0.999--1.001x prefill, 1.115--1.136x decode;
  - Triton: 1.003x prefill, 1.032--1.090x decode.
- Inactive CP decode TP succeeded; active LoRA failed closed as intended.
- Black and diff checks pass.

GPU qualification also caught two problems in the earlier prototype: repeated
metadata inflated csgmv's `max_len` from 128 to 512 and exceeded H200 shared
memory, while a later implementation allocated grouped offsets during CUDA
capture. The submitted path preserves `max_len` and initializes the offsets in
eager warmup.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33131282727](https://github.com/sgl-project/sglang/actions/runs/33131282727)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33131282590](https://github.com/sgl-project/sglang/actions/runs/33131282590)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33131282712](https://github.com/sgl-project/sglang/actions/runs/33131282712)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->