### PR TITLE
[JIT Kernel] Migrate moe_sum from AOT to JIT

### DIFF
--- a/python/sglang/kernels/jit/csrc/moe/moe_sum.cuh
+++ b/python/sglang/kernels/jit/csrc/moe/moe_sum.cuh
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <algorithm>
+#include <climits>
+#include <cstdint>
+
+namespace sglang {
+
+/**
+ * \brief Sum the selected expert outputs for each token.
+ *
+ * \tparam T Element type.
+ * \tparam kTopK Number of expert outputs per token.
+ * \param out Output buffer with shape [num_tokens, hidden_size].
+ * \param input Input buffer with shape [num_tokens, kTopK, hidden_size].
+ * \param hidden_size Number of elements in each expert output.
+ */
+template <typename T, int kTopK>
+__global__ void moe_sum_kernel(T* __restrict__ out, const T* __restrict__ input, int32_t hidden_size) {
+  const int64_t token_idx = blockIdx.x;
+  for (int64_t idx = threadIdx.x; idx < hidden_size; idx += blockDim.x) {
+    T x = 0.0;
+#pragma unroll
+    for (int k = 0; k < kTopK; ++k) {
+      x += __ldg(&input[token_idx * kTopK * hidden_size + k * hidden_size + idx]);
+    }
+    out[token_idx * hidden_size + idx] = x;
+  }
+}
+
+/**
+ * \brief Validate tensors and launch the MoE sum kernel.
+ *
+ * \tparam T Element type: fp16_t, bf16_t, or fp32_t.
+ * \param input Input tensor [num_tokens, topk, hidden_size].
+ * \param output Output tensor [num_tokens, hidden_size].
+ */
+template <typename T>
+void moe_sum(tvm::ffi::TensorView input, tvm::ffi::TensorView output) {
+  using namespace host;
+  auto num_tokens = SymbolicSize{"num_tokens"};
+  auto topk = SymbolicSize{"topk"};
+  auto hidden_size = SymbolicSize{"hidden_size"};
+  auto device = SymbolicDevice{};
+  TensorMatcher({num_tokens, topk, hidden_size}).with_dtype<T>().template with_device<kDLCUDA>(device).verify(input);
+  TensorMatcher({num_tokens, hidden_size}).with_dtype<T>().template with_device<kDLCUDA>(device).verify(output);
+
+  const int64_t num_tokens_value = num_tokens.unwrap();
+  const int64_t hidden_size_value = hidden_size.unwrap();
+  CHECK_HOST(hidden_size_value <= INT32_MAX) << "hidden_size exceeds int32 range";
+  if (num_tokens_value == 0 || hidden_size_value == 0) return;
+
+  const dim3 grid(static_cast<uint32_t>(num_tokens_value));
+  const dim3 block(static_cast<uint32_t>(std::min<int64_t>(hidden_size_value, 1024)));
+  const auto* input_ptr = static_cast<const T*>(input.data_ptr());
+  auto* output_ptr = static_cast<T*>(output.data_ptr());
+  const int32_t hidden = static_cast<int32_t>(hidden_size_value);
+
+  switch (topk.unwrap()) {
+    case 2:
+      LaunchKernel(grid, block, device.unwrap())(moe_sum_kernel<T, 2>, output_ptr, input_ptr, hidden);
+      break;
+    case 3:
+      LaunchKernel(grid, block, device.unwrap())(moe_sum_kernel<T, 3>, output_ptr, input_ptr, hidden);
+      break;
+    case 4:
+      LaunchKernel(grid, block, device.unwrap())(moe_sum_kernel<T, 4>, output_ptr, input_ptr, hidden);
+      break;
+    default:
+      host::Panic("moe_sum JIT kernel only supports topk 2, 3, and 4");
+  }
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/ops/moe/__init__.py
+++ b/python/sglang/kernels/ops/moe/__init__.py
@@ -70,6 +70,32 @@ register_kernel(
         description="MoE top-k softmax (sglang.kernels.jit).",
     )
 )
+register_kernel(
+    KernelSpec(
+        op="moe.moe_sum",
+        backend=KernelBackend.AOT,
+        target="sgl_kernel:moe_sum",
+        capabilities=_HIP,
+        format_signature=FormatSignature(
+            in_place=True,
+            description="sum of top-k expert outputs per token",
+        ),
+        description="MoE top-k expert-output sum (sgl_kernel ROCm wheel).",
+    )
+)
+register_kernel(
+    KernelSpec(
+        op="moe.moe_sum",
+        backend=KernelBackend.JIT,
+        target="sglang.kernels.ops.moe.moe_sum:moe_sum",
+        capabilities=_CUDA,
+        format_signature=FormatSignature(
+            in_place=True,
+            description="sum of top-k expert outputs per token",
+        ),
+        description="MoE top-k expert-output sum (sglang.kernels.jit).",
+    )
+)
 
 
 def moe_align_block_size(
@@ -128,7 +154,16 @@ def topk_softmax(
     )
 
 
-__all__ = ["moe_align_block_size", "topk_softmax"]
+def moe_sum(input: torch.Tensor, output: torch.Tensor) -> None:
+    """Sum the top-k expert outputs of every token.
+
+    ``output[num_tokens, hidden] = input[num_tokens, topk, hidden].sum(dim=1)``,
+    written in place into the preallocated ``output``.
+    """
+    return get_kernel("moe.moe_sum")(input, output)
+
+
+__all__ = ["moe_align_block_size", "moe_sum", "topk_softmax"]
 
 
 # Fused MoE-LoRA Triton kernels migrated into this group (from lora/triton_ops);

--- a/python/sglang/kernels/ops/moe/moe_sum.py
+++ b/python/sglang/kernels/ops/moe/moe_sum.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _jit_moe_sum_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "moe_sum",
+        *args,
+        cuda_files=["moe/moe_sum.cuh"],
+        cuda_wrappers=[("moe_sum", f"moe_sum<{args}>")],
+    )
+
+
+@register_custom_op(op_name="moe_sum_out", mutates_args=["output"])
+def moe_sum_out(input: torch.Tensor, output: torch.Tensor) -> None:
+    """Sum top-k expert outputs into a preallocated output tensor."""
+    _jit_moe_sum_module(input.dtype).moe_sum(input, output)
+
+
+def moe_sum(input: torch.Tensor, output: torch.Tensor) -> None:
+    """Sum ``input`` over its top-k dimension into ``output`` in place."""
+    if input.shape[1] in (2, 3, 4):
+        moe_sum_out(input, output)
+    else:
+        torch.sum(input, dim=1, out=output)

--- a/python/sglang/srt/layers/quantization/gguf.py
+++ b/python/sglang/srt/layers/quantization/gguf.py
@@ -41,7 +41,7 @@ _is_musa = is_musa()
 _is_npu = is_npu()
 
 if _is_cuda:
-    from sgl_kernel import moe_align_block_size, moe_sum
+    from sgl_kernel import moe_align_block_size
     from sgl_kernel.quantization import (
         ggml_dequantize,
         ggml_moe_a8,
@@ -52,6 +52,7 @@ if _is_cuda:
     )
 
     from sglang.kernels.ops.activation.activation import gelu_and_mul, silu_and_mul
+    from sglang.kernels.ops.moe import moe_sum
 elif _is_musa:
     from sgl_kernel import gelu_and_mul, moe_align_block_size, moe_sum, silu_and_mul
     from sgl_kernel.quantization import (

--- a/test/registered/kernels/benchmark/moe/bench_moe_sum.py
+++ b/test/registered/kernels/benchmark/moe/bench_moe_sum.py
@@ -1,0 +1,36 @@
+import torch
+from sgl_kernel import moe_sum as aot_moe_sum
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.jit.benchmark.utils import create_random
+from sglang.kernels.ops.moe.moe_sum import moe_sum as jit_moe_sum
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=15, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+FN_MAP = {"jit": jit_moe_sum, "aot": aot_moe_sum}
+
+
+@marker.parametrize("num_tokens", [1, 8, 128, 1024, 4096], [1, 128])
+@marker.parametrize("topk", [2, 3, 4], [2, 4])
+@marker.parametrize("hidden_size", [128, 512, 1024, 4096, 8192], [1024, 4096])
+@marker.parametrize("dtype", [torch.float16, torch.bfloat16])
+@marker.benchmark("impl", ["jit", "aot"])
+def benchmark(
+    num_tokens: int, topk: int, hidden_size: int, dtype: torch.dtype, impl: str
+):
+    input = create_random(num_tokens, topk, hidden_size, dtype=dtype)
+    output = torch.empty((num_tokens, hidden_size), dtype=dtype, device="cuda")
+    return marker.do_bench(
+        FN_MAP[impl],
+        input_args=(input, output),
+        memory_args=(input,),
+        memory_output=(output,),
+        graph_clone_args=(0,),
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/ops/moe/test_moe_sum.py
+++ b/test/registered/kernels/ops/moe/test_moe_sum.py
@@ -1,0 +1,107 @@
+"""Correctness tests for the JIT ``moe_sum`` kernel.
+
+``moe_sum`` sums the top-k expert outputs of every token:
+``output[num_tokens, hidden] = input[num_tokens, topk, hidden].sum(dim=1)``.
+
+The JIT kernel is a host-side port of the AOT ``sgl_kernel.moe_sum``: the
+device code is unchanged (topk 2/3/4 are specialised, every other topk falls
+back to ``torch.sum``), so the comparison against the AOT kernel is exact.
+
+Tests go through the public ``sglang.kernels.ops.moe.moe_sum`` wrapper, which
+on CUDA is expected to dispatch to the JIT implementation; a dedicated test
+pins that routing. Every case is also checked against a plain ``torch.sum``
+reference, which accumulates in fp32 and therefore needs a dtype tolerance.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+import torch
+
+from sglang.kernels.jit.utils import get_ci_test_range
+from sglang.kernels.ops.moe import moe_sum
+from sglang.kernels.selector import get_kernel
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=35, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+try:
+    from sgl_kernel import moe_sum as aot_moe_sum
+
+    AOT_AVAILABLE = True
+except ImportError:
+    AOT_AVAILABLE = False
+
+DTYPES = get_ci_test_range(
+    full_range=[torch.float16, torch.bfloat16, torch.float32],
+    ci_range=[torch.bfloat16],
+)
+NUM_TOKENS = get_ci_test_range(full_range=[1, 7, 128, 1024], ci_range=[1, 128])
+# 2/3/4 take the specialised kernel; 1/5/8 exercise the torch.sum fallback.
+TOPKS = get_ci_test_range(full_range=[1, 2, 3, 4, 5, 8], ci_range=[2, 4, 5])
+HIDDEN_SIZES = get_ci_test_range(
+    full_range=[1, 31, 128, 511, 1024, 4096], ci_range=[31, 1024]
+)
+
+# The kernel accumulates in the input dtype (same as AOT); torch.sum accumulates
+# in fp32, so a few ulps of drift are expected for the half-precision types.
+_TOL = {
+    torch.float32: dict(rtol=1e-6, atol=1e-6),
+    torch.float16: dict(rtol=1e-2, atol=1e-2),
+    torch.bfloat16: dict(rtol=2e-2, atol=2e-2),
+}
+
+
+def _make_inputs(num_tokens: int, topk: int, hidden_size: int, dtype: torch.dtype):
+    torch.manual_seed(0)
+    input = torch.randn((num_tokens, topk, hidden_size), dtype=dtype, device="cuda")
+    output = torch.empty((num_tokens, hidden_size), dtype=dtype, device="cuda")
+    return input, output
+
+
+def test_moe_sum_routes_to_jit_on_cuda():
+    kernel = get_kernel("moe.moe_sum")
+    assert kernel.__module__ == "sglang.kernels.ops.moe.moe_sum"
+
+
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("topk", TOPKS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+def test_moe_sum_matches_torch(dtype, num_tokens, topk, hidden_size):
+    input, output = _make_inputs(num_tokens, topk, hidden_size, dtype)
+
+    moe_sum(input, output)
+    ref = input.sum(dim=1)
+
+    assert output.shape == ref.shape
+    assert output.dtype == dtype
+    torch.testing.assert_close(output, ref, **_TOL[dtype])
+
+
+@pytest.mark.skipif(not AOT_AVAILABLE, reason="sgl_kernel not available")
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS)
+@pytest.mark.parametrize("topk", TOPKS)
+@pytest.mark.parametrize("hidden_size", HIDDEN_SIZES)
+def test_moe_sum_matches_aot(dtype, num_tokens, topk, hidden_size):
+    input, jit_output = _make_inputs(num_tokens, topk, hidden_size, dtype)
+    aot_output = torch.empty_like(jit_output)
+
+    moe_sum(input, jit_output)
+    aot_moe_sum(input, aot_output)
+
+    # Same device code on both sides, so the match is bit-exact.
+    torch.testing.assert_close(jit_output, aot_output, rtol=0, atol=0)
+
+
+def test_moe_sum_zero_tokens():
+    input, output = _make_inputs(0, 2, 128, torch.bfloat16)
+    moe_sum(input, output)
+    assert output.shape == (0, 128)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v", "-s"]))


### PR DESCRIPTION
# [JIT Kernel] Migrate moe_sum from AOT to JIT

Test and benchmark on an **H100 PCIe 80GB (sm_90), CUDA 12.8, torch 2.11.0+cu128, Python 3.12**.

**Size comparison** of the compiled files (.so):
Kernel | Variants | JIT | AOT 1-arch | AOT ÷ JIT
-- | -- | -- | -- | --
moe_sum | 3 dtypes | 103.97 KiB | 333.25 KiB | 3.205×
  - JIT: one instantiated runtime variant (`sgl_kernel_jit_moe_sum_bf16_t.so`; fp16/fp32 are 103.9 KiB each).
  - AOT: `aot/csrc/moe/moe_sum.cu` built for sm_90 only, all three dtype variants in one .so.

## Motivation

Part of #17865 (sgl-kernel wheel slimming).

`moe_sum` sums the top-k expert outputs of every token
(`out[M, K] = in[M, topk, K].sum(dim=1)`). It is currently AOT-only, compiled
into the wheel once per shipped arch. This PR adds the JIT implementation so the
kernel is built on demand for the running arch, registers it in the MoE kernel
registry, and routes the CUDA call site through the public wrapper.

Earlier attempts (#19057, #19698) targeted the pre-#29630 layout
(`python/sglang/jit_kernel/`) and did not register the kernel; both were closed
unmerged. This PR follows the current layout and the registry pattern of #34509.

## Modifications

| File | Change |
|---|---|
| `python/sglang/kernels/jit/csrc/moe/moe_sum.cuh` | New. Header-only JIT port of `aot/csrc/moe/moe_sum.cu`; same device code, host launcher on the tvm-ffi `TensorView` API. |
| `python/sglang/kernels/ops/moe/moe_sum.py` | New. `load_jit` wrapper (one module per dtype) + `register_custom_op`; topk ∉ {2, 3, 4} falls back to `torch.sum`, matching the AOT `at::sum_out` fallback. |
| `python/sglang/kernels/ops/moe/__init__.py` | Register `moe.moe_sum`: AOT `sgl_kernel:moe_sum` for HIP, JIT for CUDA; public `moe_sum()` wrapper. |
| `python/sglang/srt/layers/quantization/gguf.py` | CUDA path imports `moe_sum` from `sglang.kernels.ops.moe` instead of `sgl_kernel`. MUSA path unchanged. |
| `test/registered/kernels/ops/moe/test_moe_sum.py` | New. Via the public wrapper: routing pins JIT on CUDA; correctness vs `torch.sum` and bit-exact vs the AOT kernel; zero-token edge case. |
| `test/registered/kernels/benchmark/moe/bench_moe_sum.py` | New. JIT vs AOT on the `marker` framework. |

Note on `moe_topk_sum` (already in tree): that kernel is bf16-only, requires
`K % 8 == 0`, accumulates in fp32 and serves the marlin MoE path. `moe_sum` is
the general fp16/bf16/fp32 drop-in for `sgl_kernel.moe_sum` (accumulating in
the input dtype so it stays bit-exact with the AOT kernel), so the two are kept
separate.

## Accuracy Tests

test/registered/kernels/ops/moe/test_moe_sum.py

```
$ SGLANG_RUN_FULL_TESTS=1 PYTHONPATH=python python -m pytest test/registered/kernels/ops/moe/test_moe_sum.py -q
866 passed, 2 warnings in 34.99s
```

Full matrix: fp32 / fp16 / bf16 × `num_tokens` in {1, 7, 128, 1024} ×
`topk` in {1, 2, 3, 4, 5, 8} × `hidden_size` in {1, 31, 128, 511, 1024, 4096}
(432 cases), each compared against `torch.sum` and bit-exact against
`sgl_kernel.moe_sum`, plus the routing and zero-token tests. Under CI
`get_ci_test_range` trims it to one dtype; the JIT compile of the three dtype
variants dominates the wall time, which is what `est_time=35` reflects.

## Benchmark

test/registered/kernels/benchmark/moe/bench_moe_sum.py

Representative slice at `bf16, topk=4` (full sweep is 150 configs:
5 token counts × 3 topk × 5 hidden sizes × 2 dtypes):

```
     num_tokens      topk  hidden_size           dtype |         jit(us)        aot(us) |       jit(GB/s)      aot(GB/s)
------------------------------------------------------------------------------------------------------------------------
25            1         4         1024  torch.bfloat16 |          2.0150         2.0480 |            4.73           4.66
27            1         4         4096  torch.bfloat16 |          3.6797         3.8509 |           10.37           9.91
29            1         4         8192  torch.bfloat16 |          5.4477         5.8198 |           14.00          13.11
55            8         4         1024  torch.bfloat16 |          2.1610         2.1683 |           35.31          35.19
57            8         4         4096  torch.bfloat16 |          4.0342         4.2026 |           75.65          72.62
59            8         4         8192  torch.bfloat16 |          5.9741         6.3101 |          102.17          96.73
85          128         4         1024  torch.bfloat16 |          2.7222         2.7638 |          448.42         441.67
87          128         4         4096  torch.bfloat16 |          4.9575         5.0975 |          984.93         957.88
89          128         4         8192  torch.bfloat16 |          7.8291         8.0662 |         1247.35        1210.69
115        1024         4         1024  torch.bfloat16 |          7.6145         7.7183 |         1282.50        1265.26
117        1024         4         4096  torch.bfloat16 |         27.5754        27.7422 |         1416.57        1408.05
119        1024         4         8192  torch.bfloat16 |         53.3552        53.5846 |         1464.24        1457.97
145        4096         4         1024  torch.bfloat16 |         28.1277        28.1073 |         1388.76        1389.77
147        4096         4         4096  torch.bfloat16 |        105.0347       105.2251 |         1487.60        1484.91
149        4096         4         8192  torch.bfloat16 |        204.8589       205.5693 |         1525.44        1520.17
```

Across all 150 configs the JIT/AOT latency ratio is **median 0.9859, max 1.0023**
-- no configuration is more than 0.23% slower than AOT, and 18 small-batch
configs are >5% faster. The device code is identical; the difference is
host-side launch overhead.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33025085474](https://github.com/sgl-project/sglang/actions/runs/33025085474)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33025085334](https://github.com/sgl-project/sglang/actions/runs/33025085334)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33025085535](https://github.com/sgl-project/sglang/actions/runs/33025085535)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->