### PR TITLE
Fix KV cache pool sized far too small when weight-loading memory is still referenced

### DIFF
--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import gc
 import logging
 import math
 from dataclasses import dataclass, field
@@ -1812,6 +1813,12 @@ class KVCacheConfigurator:
         # KV pool budget = currently-free GPU memory minus the non-static runtime
         # slack (pre_model_load_memory * (1 - mem_fraction_static)). Whatever is
         # already resident (model weights, etc.) is thus charged against it.
+        # Weight-loading temporaries can still be referenced at this point, and
+        # empty_cache() (which get_available_gpu_memory already calls) cannot
+        # reclaim referenced blocks. Without collecting first, the KV budget is
+        # measured against an understated free-memory figure and the pool can be
+        # sized orders of magnitude too small while GPU memory sits idle.
+        gc.collect()
         available_gpu_memory = get_available_gpu_memory(
             self.device,
             self.gpu_id,


### PR DESCRIPTION
The KV pool budget is measured right after weights load, from currently-free GPU memory. `get_available_gpu_memory()` calls `empty_cache()`, but that only returns *unreferenced* blocks — loader temporaries that are still referenced count as used, so the budget can come out orders of magnitude too small while GPU memory sits idle. Collecting before the measurement drops those references first.

Reproduced on 4×H200 with memory held back to emulate 80 GB cards, TP4 + EAGLE, `--mem-fraction-static 0.8 --context-length 65536`:

| | `max_total_num_tokens` | free memory left unused |
|---|---|---|
| before | 1,741 | 46.9 GB |
| after | 349,377 | 17.0 GB |

Before the fix a 3000-word prompt is rejected with `Input length (3034 tokens) exceeds the maximum allowed length (1735 tokens)`; after it, 3000- and 12000-word prompts both complete normally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33030917002](https://github.com/sgl-project/sglang/actions/runs/33030917002)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33030916853](https://github.com/sgl-project/sglang/actions/runs/33030916853)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33030916968](https://github.com/sgl-project/sglang/actions/runs/33030916968)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->