### PR TITLE
Fix BailingMoeV3 reading enable_dp_lm_head off live topology instead of config

### DIFF
--- a/python/sglang/srt/models/bailing_moe_v3.py
+++ b/python/sglang/srt/models/bailing_moe_v3.py
@@ -1333,7 +1333,7 @@ class BailingMoeV3ForCausalLM(nn.Module):
                     # in the logits processor. Accuracy-neutral on ling-v3.
                     params_dtype=torch.bfloat16,
                     quant_config=quant_config,
-                    use_attn_tp_group=get_parallel().enable_dp_lm_head,
+                    use_attn_tp_group=get_parallel().config.enable_dp_lm_head,
                 )
             )
             self.logits_processor = LogitsProcessor(config)

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -335,7 +335,7 @@ class TestBailingMoeV3Gate(_FusionGateCase):
         parallel = SimpleNamespace(
             tp_size=1,
             moe_ep_size=1,
-            enable_dp_lm_head=False,
+            config=SimpleNamespace(enable_dp_lm_head=False),
         )
         with (
             unittest.mock.patch.object(


### PR DESCRIPTION
`base-a-test-cpu` shard 8 fails on `main`: `test_shared_experts_fusion_gates.py::TestBailingMoeV3Gate::test_nextn_constructor_calls_v3_fusion_setup` raises `AttributeError: 'types.SimpleNamespace' object has no attribute 'config'`.

Introduced by #33561, which reads `enable_dp_lm_head` off the wrong tier of `get_parallel()` in two places:

- `bailing_moe_v3.py` uses `get_parallel().enable_dp_lm_head`. That is a config leaf, not live topology, so `ParallelContext.__getattr__` raises `AttributeError: ParallelContext has no 'enable_dp_lm_head'`. It sits on the last-PP-rank, untied-embeddings branch of `BailingMoeV3ForCausalLM.__init__`, so it fires at model construction — the broken test was hiding a real one.
- The test's `get_parallel()` stub is flat rather than nested under `config`. That shape matched the stale v3 call site (hiding it) while breaking `bailing_moe_nextn.py`, which reads `.config.enable_dp_lm_head` correctly.

Fix: read through `.config` at the v3 call site, and give the stub the same shape as the real object.

Verified on a clean checkout of `main@20621aa`: reproduced first (1 failed, 3 passed in `TestBailingMoeV3Gate`), then `32 passed` across the whole file with the fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33029227286](https://github.com/sgl-project/sglang/actions/runs/33029227286)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33029227092](https://github.com/sgl-project/sglang/actions/runs/33029227092)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33029227281](https://github.com/sgl-project/sglang/actions/runs/33029227281)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->