### PR TITLE
fix: kill_process_tree waits for the reap by default

### DIFF
--- a/python/sglang/lang/backend/runtime_endpoint.py
+++ b/python/sglang/lang/backend/runtime_endpoint.py
@@ -443,7 +443,9 @@ class Runtime:
         from sglang.srt.utils import kill_process_tree
 
         if self.pid is not None:
-            kill_process_tree(self.pid)
+            # Note(kpham-sgl): __del__ routes here, so the reap wait has to stay
+            # off -- blocking inside GC stalls whichever thread is allocating.
+            kill_process_tree(self.pid, wait_timeout=None)
             self.pid = None
 
     def start_profile(self):

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -3166,7 +3166,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         deadline = time.monotonic() + 15
         while time.monotonic() < deadline and collect_scheduler_processes():
             time.sleep(0.1)
-        kill_process_tree(os.getpid(), include_parent=True)
+        kill_process_tree(os.getpid(), include_parent=False, wait_timeout=60)
         sys.exit(0)
 
     def force_exit_handler(self):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -2219,14 +2219,17 @@ def kill_process_tree(
     parent_pid,
     include_parent: bool = True,
     skip_pid: int = None,
-    wait_timeout: Optional[float] = None,
+    wait_timeout: Optional[float] = 60,
 ):
     """Kill the process and all its child processes.
 
     `wait_timeout` (seconds) blocks until every killed process is reaped and
-    raises `RuntimeError` on timeout; `None` is fire-and-forget. The
-    `parent_pid == os.getpid()` branch calls `sys.exit(0)` and cannot wait
-    for itself -- use `include_parent=False` if child reap must finish first.
+    raises `RuntimeError` on timeout. SIGKILL only queues the teardown, so
+    returning without waiting leaves the GPU context, the pinned host memory
+    and the ports held for seconds; pass `None` only where blocking is
+    unacceptable, such as a `__del__`. The `parent_pid == os.getpid()` branch
+    calls `sys.exit(0)` and cannot wait for itself -- use
+    `include_parent=False` if child reap must finish first.
     """
     logger.info(
         f"kill_process_tree called: parent_pid={parent_pid}, "
@@ -2239,10 +2242,10 @@ def kill_process_tree(
 
     try:
         itself = psutil.Process(parent_pid)
+        children = itself.children(recursive=True)
     except psutil.NoSuchProcess:
         return
 
-    children = itself.children(recursive=True)
     killed = []
     for child in children:
         if child.pid == skip_pid:


### PR DESCRIPTION
## Motivation

SIGKILL does not free anything — it marks the task. The device allocations are released later, inside the dying process's `do_exit`, when `exit_files()` closes the `/dev/nvidia*` fds. So `kill_process_tree` returns while the tree still holds its GPU context, pinned host memory and ports.

`wait_timeout` (#23213) exists for this — it polls until every signalled pid is gone or a zombie, and a zombie has already been through `exit_mm`/`exit_files`. But it defaults to `None`, so only callers that know to pass it are safe. All 37 that do pass `60`.

[Job 95963112642](https://github.com/sgl-project/sglang/actions/runs/32215766590/job/95963112642) — at the instant `test_metrics`' teardown returned, the server's child still held 29.14 GiB:

```
07:44:43  [CI GPU Idle] Waiting for GPU to become idle: GPU 5 uses 29.63 GiB (pid=2455061 29.14 GiB)
07:44:45  <next class starts>
08:02:11  ##[error]The action 'Run test' has timed out after 30 minutes.
```

The early return is what the log shows; that it caused *this* 17.5-minute stall is inference, since the GPU-idle gate cleared on its next poll. It is the documented hazard either way — `wait_port_available` notes ">30s observed on GB300" (`srt/utils/network.py:63`).

324 of the 395 server-launching files in `test/registered/` tear down with a bare `kill_process_tree(cls.process.pid)`, so the default is the only change that reaches them.

## Modifications

- `srt/utils/common.py`: `wait_timeout` defaults to `60`. Also moves the `children()` walk inside the `NoSuchProcess` guard — a target dying between the lookup and the walk let the exception escape to the caller.
- `srt/managers/tokenizer_manager.py`: `sigterm_watchdog` reaps its children before exiting (`include_parent=False`), so the launcher's exit means its subtree is released rather than reparented mid-teardown. Its existing `sys.exit(0)` becomes live, so the graceful-SIGTERM exit status changes `-9` → `0`.
- `lang/backend/runtime_endpoint.py`: `Runtime.shutdown` keeps `None` — `__del__` routes into it, and blocking inside GC is not acceptable.

Caller audit:

| Group | Sites | Effect |
|---|---|---|
| `kill_process_tree(os.getpid())` / `include_parent=True` | 7 | unchanged — short-circuits at `itself.kill(); sys.exit(0)`. Covers every signal handler. |
| `Runtime.shutdown` (reached from `__del__`) | 1 | explicit `None` |
| CLI/bench teardowns + `python/sglang/test/` helpers | rest | now wait; all `finally` blocks or explicit teardowns |

`atexit` is not a problem case — `Engine.shutdown` has waited 60 s from its atexit handler since #2996.

No unit test: `wait_timeout`'s wait path is already covered by #23213, and what is left here is a default and two call sites. The regression this guards against re-breaks CI directly.

**Open question:** `_wait_for_reap_or_raise` raises on timeout and some newly-waiting sites are `finally` blocks, where that masks the original exception. I think loud is right — it is the same condition `cli/killall.py` aborts the next job on — but happy to log-and-continue instead.

## Follow-ups

1. **Split `kill_process_tree` into discovery and kill,** exposing `kill_processes(procs, ...)`. Then `terminate_and_kill_process_tree` can snapshot descendants *before* SIGTERM while `Popen.wait()` keeps the reap, so the server's returncode stays truthful. Alternative to the `terminate_timeout` mode in #35507, which has psutil reap the caller's `Popen` child — `Popen.poll()` then reports `0` for a process that was SIGKILLed.
2. **Make the process group the unit of cleanup:** `start_new_session=True` in the launch helpers plus a guarded `killpg` sweep. A group outlives its leader, so it also catches descendants spawned during teardown or reparented before the snapshot, and it disarms `SGLANG_KILLPG_ON_SCHEDULER_EXCEPTION`, which today would `killpg` the test runner's own group.

## Accuracy Tests

N/A — process teardown only.

## Speed Tests and Profiling

N/A. Teardown now blocks until the tree is reaped (usually well under a second); that time was previously paid by the next fixture's port wait and GPU-idle gate.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33044698806](https://github.com/sgl-project/sglang/actions/runs/33044698806)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33044698609](https://github.com/sgl-project/sglang/actions/runs/33044698609)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33044698742](https://github.com/sgl-project/sglang/actions/runs/33044698742)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->