### PR TITLE
fix(hicache): accept direct DSA MTP draft pools

### DIFF
--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -92,6 +92,10 @@ def _with_mtp_layer_mapping(
         for depth in range(draft_layer_num)
     }
 
+def _resolve_mtp_full_kv_pool(pool: Any) -> Any:
+    return getattr(pool, "full_kv_pool", pool)
+
+
 
 def build_kv_host_pool(
     *,
@@ -713,7 +717,8 @@ def build_hybrid_mamba_stack(
     transfer_layer_num = len(full_layer_mapping | mamba_layer_mapping)
     mamba_allocator = params.req_to_token_pool.mamba_allocator
     mtp_draft_device_pools = tuple(
-        pool.full_kv_pool for pool in params.mtp_draft_device_pools
+        _resolve_mtp_full_kv_pool(pool)
+        for pool in params.mtp_draft_device_pools
     )
     kv_host_size, mamba_host_size = None, 0
     if get_memory().hicache_size > 0:

--- a/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
+++ b/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
@@ -10,6 +10,7 @@ from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
     _evict_swa_for_device_alloc,
     _split_hicache_size,
     build_full_draft_pools,
+    _resolve_mtp_full_kv_pool,
 )
 from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -79,6 +80,17 @@ class TestSplitHicacheSize(CustomTestCase):
 
 
 class TestDraftSidecarPoolDispatch(CustomTestCase):
+    def test_mtp_pool_preserves_direct_dsa_style_pool(self):
+        draft_kv_pool = SimpleNamespace(layer_num=1)
+
+        self.assertIs(_resolve_mtp_full_kv_pool(draft_kv_pool), draft_kv_pool)
+
+    def test_mtp_pool_unwraps_hybrid_linear_pool(self):
+        full_kv_pool = SimpleNamespace(layer_num=1)
+        draft_kv_pool = SimpleNamespace(full_kv_pool=full_kv_pool)
+
+        self.assertIs(_resolve_mtp_full_kv_pool(draft_kv_pool), full_kv_pool)
+
     def test_full_builder_unwraps_empty_hybrid_linear_pool(self):
         draft_kv_pool = object.__new__(HybridLinearKVPool)
         draft_kv_pool.full_kv_pool = SimpleNamespace(layer_num=0)


### PR DESCRIPTION
## Problem

`build_hybrid_mamba_stack` assumes every MTP draft pool is a `HybridLinearKVPool` wrapper and unconditionally reads `pool.full_kv_pool`.

GLM-5.3-Flash uses DSA for its MTP draft layer and exposes a direct `DSATokenToKVPool`. Starting the official NEXTN recipe with HiCache fails after CUDA graph capture:

```text
AttributeError: 'DSATokenToKVPool' object has no attribute 'full_kv_pool'
```

## Fix

Resolve the wrapped `full_kv_pool` when present, otherwise preserve the direct KV pool. Add unit coverage for both layouts.

## Validation

- `ruff check` passes for both touched files.
- Reproduced on the dedicated `lmsysorg/sglang:glm-5.3-flash` image, GLM-5.3-Flash TP8/EP8, NEXTN adaptive MTP 5/1/6, FP8 KV + TRT-LLM DSA, HiCache dynamic backend.
- Before patch: scheduler aborts in `build_hybrid_mamba_stack`.
- After patch: server reaches HTTP 200 and serves requests.
- MTP benchmark (8K input / 1K output, 64 prompts, concurrency 16): 223.16 output tok/s, 1850.53 total tok/s, accept length 2.58.
- The same no-MTP configuration measured 147.62 output tok/s and 1284.56 total tok/s.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33032299250](https://github.com/sgl-project/sglang/actions/runs/33032299250)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33032299045](https://github.com/sgl-project/sglang/actions/runs/33032299045)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33032299204](https://github.com/sgl-project/sglang/actions/runs/33032299204)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->