### PR TITLE
[Fix] Re-encode multimodal embeddings after cache mismatch

### DIFF
--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -160,6 +160,13 @@ def _flatten_embedding_result(
     return embedding
 
 
+def _embedding_token_count(embedding: torch.Tensor) -> int:
+    """Return the number of multimodal tokens represented by an embedding."""
+    # Vision encoders may return [tokens, hidden] or a higher-rank tensor.  The
+    # scheduler always consumes the flattened token dimension.
+    return embedding.reshape(-1, embedding.shape[-1]).shape[0]
+
+
 def _can_skip_pre_embed_feature_move(data_embedding_func: DataEmbeddingFunc) -> bool:
     """Models that materialize and batch visual features inside their encoder.
 
@@ -230,6 +237,18 @@ def _get_chunked_embedding_full(
     embedding_items_hash = MultiModalStaticCache.combine_hashes(item_hashes)
     embedding_per_req = embedding_cache.get(item_hashes)
 
+    # A compact feature hash can collide for inputs with different token
+    # counts.  Never feed a stale cache entry into the scheduler: the length
+    # mismatch would otherwise surface much later in _adjust_embedding_length
+    # as an unrecoverable prefill crash.
+    if embedding_per_req is not None and not isinstance(
+        embedding_per_req, EVSEmbeddingResult
+    ):
+        expected_token_count = sum(end - start + 1 for start, end in items_offset)
+        if _embedding_token_count(embedding_per_req.embedding) != expected_token_count:
+            embedding_cache.free(embedding_items_hash, None)
+            embedding_per_req = None
+
     if embedding_per_req is None:
         if not _can_skip_pre_embed_feature_move(data_embedding_func):
             _move_items_to_device(embedding_items_per_req, device)
@@ -286,16 +305,19 @@ def _batch_encode_per_image_misses(
     data_embedding_func: DataEmbeddingFunc,
     per_image_requests: List[PerImageRequestInfo],
     device: torch.device,
-) -> Dict[int, torch.Tensor]:
+) -> Dict[Tuple[Optional[int], int], torch.Tensor]:
     """
     Collect cache misses across ALL per-image requests, deduplicate by hash,
     encode in a single ViT call, and populate the cache.
 
     Returns:
-        hash_to_embedding: mapping from item.hash to its full embedding tensor.
+        hash_to_embedding: mapping from (item.hash, token_count) to its full
+            embedding tensor.  Including the token count prevents two
+            colliding hashes with different placeholder spans from being
+            deduplicated within the same batch.
     """
-    unique_misses: Dict[int, Tuple[MultimodalDataItem, int]] = {}
-    hash_to_embedding: Dict[int, torch.Tensor] = {}
+    unique_misses: Dict[Tuple[Optional[int], int], Tuple[MultimodalDataItem, int]] = {}
+    hash_to_embedding: Dict[Tuple[Optional[int], int], torch.Tensor] = {}
 
     # Phase 1a: find overlapping items per request and collect cache misses
     for req_info in per_image_requests:
@@ -311,20 +333,26 @@ def _batch_encode_per_image_misses(
         req_info.overlapping = overlapping
 
         for _idx, item, start, end in overlapping:
-            if item.hash in hash_to_embedding:
+            expected_token_count = end - start + 1
+            cache_key = (item.hash, expected_token_count)
+            if cache_key in hash_to_embedding:
                 continue
             cached = embedding_cache.get_single(item.hash)
             if cached is not None:
-                hash_to_embedding[item.hash] = cached.embedding
-            elif item.hash not in unique_misses:
-                token_count = end - start + 1
-                unique_misses[item.hash] = (item, token_count)
+                cached_embedding = cached.embedding
+                if _embedding_token_count(cached_embedding) == expected_token_count:
+                    hash_to_embedding[cache_key] = cached_embedding
+                else:
+                    embedding_cache.free(item.hash, None)
+                    unique_misses[cache_key] = (item, expected_token_count)
+            elif cache_key not in unique_misses:
+                unique_misses[cache_key] = (item, expected_token_count)
 
     # Phase 1b: single ViT call for all unique cache misses
     if unique_misses:
-        ordered_hashes = list(unique_misses.keys())
-        miss_items = [unique_misses[h][0] for h in ordered_hashes]
-        token_counts = [unique_misses[h][1] for h in ordered_hashes]
+        ordered_cache_keys = list(unique_misses.keys())
+        miss_items = [unique_misses[key][0] for key in ordered_cache_keys]
+        token_counts = [unique_misses[key][1] for key in ordered_cache_keys]
 
         if not _can_skip_pre_embed_feature_move(data_embedding_func):
             _move_items_to_device(miss_items, device)
@@ -347,10 +375,10 @@ def _batch_encode_per_image_misses(
                 -1, all_miss_embedding.shape[-1]
             )
             split_embeddings = torch.split(all_miss_embedding, token_counts, dim=0)
-        for h, emb in zip(ordered_hashes, split_embeddings):
-            embedding_cache.set(h, EmbeddingResult(embedding=emb))
+        for cache_key, emb in zip(ordered_cache_keys, split_embeddings):
+            embedding_cache.set(cache_key[0], EmbeddingResult(embedding=emb))
             # Keep a local ref (no extra GPU memory) so assembly never fails due to LRU eviction.
-            hash_to_embedding[h] = emb
+            hash_to_embedding[cache_key] = emb
 
     return hash_to_embedding
 
@@ -386,10 +414,16 @@ def _get_chunked_embedding_by_item(
     cached_embeddings = {}
     miss_items = []
     for idx, item, start, end in overlapping:
+        expected_token_count = end - start + 1
         cached = embedding_cache.get_single(item.hash)
         if cached is not None:
-            cached_embeddings[idx] = cached.embedding
-            _acknowledge_deferred_cuda_ipc_cache_hits([item])
+            cached_embedding = cached.embedding
+            if _embedding_token_count(cached_embedding) == expected_token_count:
+                cached_embeddings[idx] = cached_embedding
+                _acknowledge_deferred_cuda_ipc_cache_hits([item])
+            else:
+                embedding_cache.free(item.hash, None)
+                miss_items.append((idx, item, start, end))
         else:
             miss_items.append((idx, item, start, end))
 
@@ -436,7 +470,7 @@ def _get_chunked_embedding_by_item(
 
 def _assemble_per_image_chunk(
     overlapping: List[Tuple[int, MultimodalDataItem, int, int]],
-    hash_to_embedding: Dict[int, torch.Tensor],
+    hash_to_embedding: Dict[Tuple[Optional[int], int], torch.Tensor],
     extend_prefix_len: int,
     extend_seq_len: int,
 ) -> Optional[torch.Tensor]:
@@ -452,7 +486,8 @@ def _assemble_per_image_chunk(
 
     chunk_slices = []
     for _idx, item, start, end in overlapping:
-        emb = hash_to_embedding[item.hash]  # shape: (end - start + 1, hidden)
+        cache_key = (item.hash, end - start + 1)
+        emb = hash_to_embedding[cache_key]  # shape: (end - start + 1, hidden)
         overlap_start = max(start, chunk_start)
         overlap_end = min(end, chunk_end - 1)  # inclusive
         local_start = overlap_start - start
@@ -530,7 +565,7 @@ def _get_chunked_prefill_embedding(
             full_path_requests.append(req_info)
 
     # Phase 1: batch encode all per-image cache misses in ONE ViT call
-    hash_to_embedding: Dict[int, torch.Tensor] = {}
+    hash_to_embedding: Dict[Tuple[Optional[int], int], torch.Tensor] = {}
     if per_image_requests:
         hash_to_embedding = _batch_encode_per_image_misses(
             data_embedding_func, per_image_requests, device

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -307,8 +307,8 @@ def _batch_encode_per_image_misses(
     device: torch.device,
 ) -> Dict[Tuple[Optional[int], int], torch.Tensor]:
     """
-    Collect cache misses across ALL per-image requests, deduplicate by hash,
-    encode in a single ViT call, and populate the cache.
+    Collect cache misses across ALL per-image requests, deduplicate by hash and
+    expected token count, encode in a single ViT call, and populate the cache.
 
     Returns:
         hash_to_embedding: mapping from (item.hash, token_count) to its full

--- a/python/sglang/srt/managers/mm_schedule.py
+++ b/python/sglang/srt/managers/mm_schedule.py
@@ -167,6 +167,22 @@ def _embedding_token_count(embedding: torch.Tensor) -> int:
     return embedding.reshape(-1, embedding.shape[-1]).shape[0]
 
 
+def _discard_mismatched_cached_embedding(
+    cache_key: Optional[int],
+    expected_token_count: int,
+    cached_token_count: int,
+) -> None:
+    """Log and remove a cache entry that cannot serve the current item."""
+    logger.warning(
+        "Discarding cached multimodal embedding due to a token-count mismatch: "
+        "cache_key=%s, expected_tokens=%d, cached_tokens=%d. Recomputing embedding.",
+        cache_key,
+        expected_token_count,
+        cached_token_count,
+    )
+    embedding_cache.free(cache_key, None)
+
+
 def _can_skip_pre_embed_feature_move(data_embedding_func: DataEmbeddingFunc) -> bool:
     """Models that materialize and batch visual features inside their encoder.
 
@@ -245,8 +261,11 @@ def _get_chunked_embedding_full(
         embedding_per_req, EVSEmbeddingResult
     ):
         expected_token_count = sum(end - start + 1 for start, end in items_offset)
-        if _embedding_token_count(embedding_per_req.embedding) != expected_token_count:
-            embedding_cache.free(embedding_items_hash, None)
+        cached_token_count = _embedding_token_count(embedding_per_req.embedding)
+        if cached_token_count != expected_token_count:
+            _discard_mismatched_cached_embedding(
+                embedding_items_hash, expected_token_count, cached_token_count
+            )
             embedding_per_req = None
 
     if embedding_per_req is None:
@@ -340,10 +359,13 @@ def _batch_encode_per_image_misses(
             cached = embedding_cache.get_single(item.hash)
             if cached is not None:
                 cached_embedding = cached.embedding
-                if _embedding_token_count(cached_embedding) == expected_token_count:
+                cached_token_count = _embedding_token_count(cached_embedding)
+                if cached_token_count == expected_token_count:
                     hash_to_embedding[cache_key] = cached_embedding
                 else:
-                    embedding_cache.free(item.hash, None)
+                    _discard_mismatched_cached_embedding(
+                        item.hash, expected_token_count, cached_token_count
+                    )
                     unique_misses[cache_key] = (item, expected_token_count)
             elif cache_key not in unique_misses:
                 unique_misses[cache_key] = (item, expected_token_count)
@@ -418,11 +440,14 @@ def _get_chunked_embedding_by_item(
         cached = embedding_cache.get_single(item.hash)
         if cached is not None:
             cached_embedding = cached.embedding
-            if _embedding_token_count(cached_embedding) == expected_token_count:
+            cached_token_count = _embedding_token_count(cached_embedding)
+            if cached_token_count == expected_token_count:
                 cached_embeddings[idx] = cached_embedding
                 _acknowledge_deferred_cuda_ipc_cache_hits([item])
             else:
-                embedding_cache.free(item.hash, None)
+                _discard_mismatched_cached_embedding(
+                    item.hash, expected_token_count, cached_token_count
+                )
                 miss_items.append((idx, item, start, end))
         else:
             miss_items.append((idx, item, start, end))

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -9,6 +9,7 @@ of the combined tensor pins the whole concatenated buffer).
 CPU-only: exercises mm_schedule internals directly, no engine or GPU.
 """
 
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -259,7 +260,7 @@ def test_batched_colliding_hashes_with_different_lengths_are_not_deduplicated():
     encoder.assert_called_once()
 
 
-def test_full_mismatched_cache_entry_is_reencoded():
+def test_full_mismatched_cache_entry_is_reencoded(caplog):
     mm_schedule.init_mm_embedding_cache(1 << 30)
     items = _make_items()
     combined_hash = mm_schedule.MultiModalStaticCache.combine_hashes(
@@ -272,12 +273,16 @@ def test_full_mismatched_cache_entry_is_reencoded():
     input_ids = torch.zeros(TOTAL_LEN, dtype=torch.long)
     encoder = Mock(side_effect=_encoder_tensor)
 
-    chunk, _ = mm_schedule._get_chunked_embedding_full(
-        encoder, items, ITEM_OFFSETS, 0, TOTAL_LEN, input_ids, _CPU
-    )
+    with caplog.at_level(logging.WARNING, logger=mm_schedule.logger.name):
+        chunk, _ = mm_schedule._get_chunked_embedding_full(
+            encoder, items, ITEM_OFFSETS, 0, TOTAL_LEN, input_ids, _CPU
+        )
 
     assert chunk.shape == (sum(_num_tokens(item) for item in items), HIDDEN)
     encoder.assert_called_once()
+    assert "Discarding cached multimodal embedding" in caplog.text
+    assert "expected_tokens=15" in caplog.text
+    assert "cached_tokens=1" in caplog.text
 
 
 if __name__ == "__main__":

--- a/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
+++ b/test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py
@@ -9,6 +9,8 @@ of the combined tensor pins the whole concatenated buffer).
 CPU-only: exercises mm_schedule internals directly, no engine or GPU.
 """
 
+from unittest.mock import Mock
+
 import pytest
 import torch
 
@@ -183,6 +185,99 @@ def test_tensor_cache_entries_share_storage():
         assert (
             emb.untyped_storage().nbytes() == total_tokens * HIDDEN * emb.element_size()
         )
+
+
+def test_by_item_mismatched_cache_entry_is_reencoded():
+    mm_schedule.init_mm_embedding_cache(1 << 30)
+    items = _make_items()
+    first_item = items[0]
+    mm_schedule.embedding_cache.set(
+        first_item.hash,
+        mm_schedule.EmbeddingResult(embedding=torch.zeros(1, HIDDEN)),
+    )
+    encoder = Mock(side_effect=_encoder_list)
+
+    chunk = mm_schedule._get_chunked_embedding_by_item(
+        encoder, items, ITEM_OFFSETS, 0, TOTAL_LEN, _CPU
+    )
+
+    assert chunk.shape == (sum(_num_tokens(item) for item in items), HIDDEN)
+    encoder.assert_called_once()
+    assert mm_schedule.embedding_cache.get_single(first_item.hash).embedding.shape[
+        0
+    ] == _num_tokens(first_item)
+
+
+def test_batched_mismatched_cache_entry_is_reencoded():
+    mm_schedule.init_mm_embedding_cache(1 << 30)
+    items = _make_items()
+    first_item = items[0]
+    mm_schedule.embedding_cache.set(
+        first_item.hash,
+        mm_schedule.EmbeddingResult(embedding=torch.zeros(1, HIDDEN)),
+    )
+    request = mm_schedule.PerImageRequestInfo(
+        req_idx=0,
+        items=items,
+        items_offset=ITEM_OFFSETS,
+        extend_prefix_len=0,
+        extend_seq_len=TOTAL_LEN,
+    )
+    encoder = Mock(side_effect=_encoder_list)
+
+    embeddings = mm_schedule._batch_encode_per_image_misses(encoder, [request], _CPU)
+
+    assert embeddings[(first_item.hash, _num_tokens(first_item))].shape == (
+        _num_tokens(first_item),
+        HIDDEN,
+    )
+    encoder.assert_called_once()
+
+
+def test_batched_colliding_hashes_with_different_lengths_are_not_deduplicated():
+    mm_schedule.init_mm_embedding_cache(1 << 30)
+    items = _make_items()
+    # Simulate the compact-hash collision that motivated the cache guard.
+    items[1].hash = items[0].hash
+    requests = [
+        mm_schedule.PerImageRequestInfo(
+            req_idx=0,
+            items=items[:2],
+            items_offset=ITEM_OFFSETS[:2],
+            extend_prefix_len=0,
+            extend_seq_len=TOTAL_LEN,
+        )
+    ]
+    encoder = Mock(side_effect=_encoder_list)
+
+    embeddings = mm_schedule._batch_encode_per_image_misses(encoder, requests, _CPU)
+
+    first_key = (items[0].hash, _num_tokens(items[0]))
+    second_key = (items[1].hash, _num_tokens(items[1]))
+    assert embeddings[first_key].shape == (_num_tokens(items[0]), HIDDEN)
+    assert embeddings[second_key].shape == (_num_tokens(items[1]), HIDDEN)
+    encoder.assert_called_once()
+
+
+def test_full_mismatched_cache_entry_is_reencoded():
+    mm_schedule.init_mm_embedding_cache(1 << 30)
+    items = _make_items()
+    combined_hash = mm_schedule.MultiModalStaticCache.combine_hashes(
+        [item.hash for item in items]
+    )
+    mm_schedule.embedding_cache.set(
+        combined_hash,
+        mm_schedule.EmbeddingResult(embedding=torch.zeros(1, HIDDEN)),
+    )
+    input_ids = torch.zeros(TOTAL_LEN, dtype=torch.long)
+    encoder = Mock(side_effect=_encoder_tensor)
+
+    chunk, _ = mm_schedule._get_chunked_embedding_full(
+        encoder, items, ITEM_OFFSETS, 0, TOTAL_LEN, input_ids, _CPU
+    )
+
+    assert chunk.shape == (sum(_num_tokens(item) for item in items), HIDDEN)
+    encoder.assert_called_once()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

based on #32404

 
A compact multimodal feature-hash collision can return a cached embedding whose token count does not match the placeholder span in the request. The mismatch currently reaches `_adjust_embedding_length` and aborts prefill with `Insufficient multimodal embedding length`.

## Modifications

- Validate cached embedding token counts against the item offsets on all chunked-prefill cache-hit paths.
- Evict malformed entries and re-encode them instead of passing them to the scheduler.
- Include `(hash, token_count)` in the per-batch temporary map so colliding items with different placeholder lengths are not deduplicated.
- Add regression coverage for full, per-item, and batched cache paths.

## Validation

- `pre-commit run --files python/sglang/srt/managers/mm_schedule.py test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py`
- `python3 -m compileall -q python/sglang/srt/managers/mm_schedule.py test/registered/chunked_prefill/test_mm_chunked_embedding_unit.py`
- Pytest was unavailable locally because PyTorch/pytest are not installed; NVIDIA CI is still required.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33052289112](https://github.com/sgl-project/sglang/actions/runs/33052289112)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33052288823](https://github.com/sgl-project/sglang/actions/runs/33052288823)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33052289142](https://github.com/sgl-project/sglang/actions/runs/33052289142)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->