### PR TITLE
[AMD] Support Qwen3.8-Flash-Next MXFP4 on ROCm

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/mqa.py
+++ b/python/sglang/srt/layers/attention/qsa/mqa.py
@@ -6,6 +6,8 @@ from typing import Optional
 
 import torch
 
+from sglang.srt.utils.common import is_hip
+
 try:
     import flashinfer.comm  # noqa: F401
 except ImportError:
@@ -349,10 +351,14 @@ def tilelang_qsa_mqa_decode(
     )
     if not q.shape[0] or not max_model_len:
         return logits
-    # The validated MMA layout requires N (the Q-head dimension) to be a
-    # multiple of eight. Zero-padding preserves the weight-free head sum.
+    # CUDA MMA accepts an eight-wide N dimension, while ROCm MFMA requires
+    # sixteen. Zero-padding preserves the weight-free head sum on both paths.
     query_heads, head_dim = q.shape[1:]
-    kernel_heads = max(8, ((query_heads + 7) // 8) * 8)
+    head_alignment = 16 if is_hip() else 8
+    kernel_heads = max(
+        head_alignment,
+        ((query_heads + head_alignment - 1) // head_alignment) * head_alignment,
+    )
     q_kernel = q.to(torch.bfloat16)
     if kernel_heads != query_heads:
         q_kernel = torch.cat(

--- a/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
+++ b/python/sglang/srt/layers/attention/qsa/qsa_indexer.py
@@ -38,6 +38,15 @@ def _qsa_prefill_row_chunk_size(rows: int, keys: int, heads: int) -> int:
     return min(rows, max_padded_rows)
 
 
+def _mask_padded_group_locs(
+    group_locs: torch.Tensor, write_locs: torch.Tensor
+) -> torch.Tensor:
+    """Redirect fixed-capacity padding reads to the reserved source slot 0."""
+    return torch.where(
+        write_locs.ne(0).unsqueeze(1), group_locs, torch.zeros_like(group_locs)
+    )
+
+
 class QSAIndexer(MultiPlatformOp):
     """Config-driven fused-QK, weight-free sparse-attention indexer."""
 
@@ -338,6 +347,11 @@ class QSAIndexer(MultiPlatformOp):
                 )
             source_keys = pool.get_qsa_key_state_buffer(self.layer_id)
             source_rope = pool.qsa_rope_position_buffer
+        # The write plan has a fixed, shape-derived capacity. Entries without a
+        # completed group write the inert compressed slot 0, but their source
+        # indices must also be inert: a short extend can have fewer token rows
+        # than one full compression group.
+        group_locs = _mask_padded_group_locs(group_locs, compressed_locs)
         if self._use_fused_compress(pool):
             self._fused_compress_store(
                 pool,

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -65,7 +65,7 @@ def _resolve_trtllm_sparse_decode():
 
 @lru_cache(maxsize=1)
 def _resolve_flash_attn_varlen_func():
-    from sglang.srt.utils import is_sm121
+    from sglang.srt.utils import is_hip, is_sm121
 
     if is_sm121():
         from sglang.kernels.ops.attention import (
@@ -73,6 +73,22 @@ def _resolve_flash_attn_varlen_func():
         )
 
         return qwen38_qsa_sm121_varlen
+    if is_hip():
+        # ROCm ships neither flash_attn (FA2) nor flash-attn-4; aiter provides an
+        # FA2-compatible varlen kernel (CK) with the same call signature. Fall
+        # through to the flash_attn probes below if aiter is unavailable.
+        try:
+            from aiter import flash_attn_varlen_func as aiter_varlen_func
+        except ImportError:
+            aiter_varlen_func = None
+        if aiter_varlen_func is not None:
+
+            def flash_attn_varlen_func(*args, **kwargs):
+                output = aiter_varlen_func(*args, **kwargs)
+                # aiter returns a tuple when return_lse/return_attn_probs is set.
+                return output[0] if isinstance(output, tuple) else output
+
+            return flash_attn_varlen_func
     try:
         from flash_attn import flash_attn_varlen_func
 
@@ -90,8 +106,8 @@ def _resolve_flash_attn_varlen_func():
         return flash_attn_varlen_func
     except ImportError as exc:
         raise ImportError(
-            "QSA decode requires flash_attn (FA2) or flash-attn-4 "
-            "(FA4 cute) for its packed varlen fallback."
+            "QSA decode requires flash_attn (FA2), flash-attn-4 (FA4 cute), "
+            "or aiter (ROCm) for its packed varlen fallback."
         ) from exc
 
 

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -40,12 +40,9 @@ from sglang.srt.runtime_context import (
     get_parallel,
     get_spec,
 )
-from sglang.srt.utils import add_prefix, get_bool_env_var, is_hip, is_npu
+from sglang.srt.utils import add_prefix, is_npu
 
 logger = logging.getLogger(__name__)
-
-_is_hip = is_hip()
-_use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 
 
 def _mtp_quant_config(quant_config):
@@ -261,12 +258,11 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         num_experts = getattr(self.config, "num_experts", None)
         # A fused shared expert lives in routed slot `num_experts`.
         num_fused_shared_experts = 0
-        if _use_aiter:
-            for module in self.modules():
-                fused = getattr(module, "num_fused_shared_experts", 0)
-                if fused:
-                    num_fused_shared_experts = fused
-                    break
+        for module in self.modules():
+            fused = getattr(module, "num_fused_shared_experts", 0)
+            if fused:
+                num_fused_shared_experts = fused
+                break
         if num_experts is not None:
             expert_params_mapping = FusedMoE.make_expert_params_mapping(
                 ckpt_gate_proj_name="gate_proj",
@@ -357,11 +353,7 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
             if ".self_attn." in name:
                 name = name.replace(".self_attn", "")
 
-            if (
-                _use_aiter
-                and num_fused_shared_experts > 0
-                and "mlp.shared_expert." in name
-            ):
+            if num_fused_shared_experts > 0 and "mlp.shared_expert." in name:
                 # Map mlp.shared_expert.xx_proj to mlp.experts.{num_experts}.xx_proj
                 name = name.replace(
                     "mlp.shared_expert.",

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -287,8 +287,11 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
             "_input_scale",
         )
 
-        # fused experts: experts.w13_weight / experts.w2_weight
-        is_fused_expert = False
+        # Fused checkpoint tensors: experts.gate_up_proj / experts.down_proj.
+        # Keep this mapping separate from the per-expert mapping below.  The
+        # checkpoint may interleave fused routed-expert tensors with separate
+        # shared-expert tensors, so selecting one mapping must not affect the
+        # next weight.
         fused_expert_params_mapping = [
             ("experts.w13_weight", "experts.gate_up_proj", 0, "w1"),
             ("experts.w2_weight", "experts.down_proj", 0, "w2"),
@@ -319,6 +322,9 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
         loaded_params: set[str] = set()
 
         for name, loaded_weight in weights:
+            checkpoint_name = name
+            loaded_name = None
+
             # The last-stage MTP draft cannot share the target embedding on PP0.
             # Load the checkpoint embedding into its retained local copy instead
             # of leaving the torch.empty() allocation uninitialized.
@@ -335,7 +341,6 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                     weight_loader(param, loaded_weight)
                     loaded_params.add(param_name)
                 continue
-
             if "rotary_emb.inv_freq" in name:
                 continue
 
@@ -360,13 +365,17 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                     f"mlp.experts.{num_experts}.",
                 )
 
+            is_fused_expert = (
+                "experts.gate_up_proj" in name or "experts.down_proj" in name
+            )
+            current_expert_params_mapping = (
+                fused_expert_params_mapping
+                if is_fused_expert
+                else expert_params_mapping
+            )
+
             # 1) Process stacked parameters (q_proj/k_proj/v_proj & gate_proj/up_proj)
             for param_name, weight_name, shard_id in stacked_params_mapping:
-                # Check if this is a fused expert weight
-                if "experts.gate_up_proj" in name or "experts.down_proj" in name:
-                    is_fused_expert = True
-                    expert_params_mapping = fused_expert_params_mapping
-
                 # Skip non-matching weights
                 if weight_name not in name:
                     continue
@@ -391,12 +400,13 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight, shard_id)
                 name = name_mapped
+                loaded_name = name_mapped
                 break
             else:
                 # 2) Process MoE expert weights (including fused experts)
                 is_expert_weight = False
 
-                for mapping in expert_params_mapping:
+                for mapping in current_expert_params_mapping:
                     param_name, weight_name, expert_id, shard_id = mapping
                     if weight_name not in name:
                         continue
@@ -432,6 +442,7 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                                 shard_id,
                                 num_experts,
                             )
+                        loaded_name = name_mapped
                     else:
                         # Non-fused expert, load by expert_id/shard
                         if (
@@ -450,6 +461,7 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                             shard_id=shard_id,
                             expert_id=expert_id,
                         )
+                        loaded_name = name_mapped
                     name = name_mapped
                     break
                 else:
@@ -467,12 +479,21 @@ class Qwen3_5ForCausalLMMTP(nn.Module):
                             param, "weight_loader", default_weight_loader
                         )
                         weight_loader(param, loaded_weight)
+                        loaded_name = name
                     else:
                         logger.warning_once(
                             f"Parameter {name} not found in params_dict, skip loading"
                         )
 
-            loaded_params.add(name)
+            if loaded_name is not None:
+                loaded_params.add(loaded_name)
+            elif ".mlp.shared_expert." in checkpoint_name and checkpoint_name.endswith(
+                ("gate_proj.weight", "up_proj.weight", "down_proj.weight")
+            ):
+                raise ValueError(
+                    "Required MTP shared-expert parameter could not be loaded: "
+                    f"{checkpoint_name} (resolved as {name})"
+                )
         return loaded_params
 
 

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -67,6 +67,33 @@ from sglang.srt.utils import logger
 # bound and serializing them on one stream is faster than contending.
 _QSA_INDEXER_OVERLAP_TOKEN_THRESHOLD = 1024
 
+_QWEN4_EXP_FUSED_SHARED_EXPERT_MAPPING = (
+    ("gate_proj", "w13", "w1"),
+    ("up_proj", "w13", "w3"),
+    ("down_proj", "w2", "w2"),
+)
+
+
+def _qwen4_exp_fused_shared_expert_mapping(
+    name: str, params_dict: dict, num_experts: int
+) -> tuple[str, str, int] | None:
+    """Map a separate shared-expert checkpoint tensor to its fused MoE slot."""
+    if ".mlp.shared_expert." not in name or "visual" in name:
+        return None
+
+    for projection, fused_param, shard_id in _QWEN4_EXP_FUSED_SHARED_EXPERT_MAPPING:
+        checkpoint_fragment = f".mlp.shared_expert.{projection}."
+        if checkpoint_fragment not in name:
+            continue
+        target_name = name.replace(
+            checkpoint_fragment,
+            f".mlp.experts.{fused_param}_",
+            1,
+        )
+        if target_name in params_dict:
+            return target_name, shard_id, num_experts
+    return None
+
 
 def _get_ple_forward_mode(forward_batch: ForwardBatch) -> ForwardMode:
     if forward_batch._original_forward_mode is not None:
@@ -1921,9 +1948,10 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
         params_dict = dict(self.named_parameters(remove_duplicate=False))
         buffers = dict(self.named_buffers())
 
+        modules_dict = dict(self.named_modules())
         ple_modules = {
             mod_name: mod
-            for mod_name, mod in self.named_modules()
+            for mod_name, mod in modules_dict.items()
             if isinstance(mod, Qwen4ExpNGramEmbedding)
         }
         text_config = getattr(self.config, "text_config", self.config)
@@ -1990,6 +2018,26 @@ class Qwen4ExpForConditionalGeneration(Qwen3VLForConditionalGeneration):
             is_fused_expert = (
                 "experts.gate_up_proj" in name or "experts.down_proj" in name
             )
+
+            mlp_prefix = name.split(".shared_expert.", 1)[0]
+            mlp = modules_dict.get(mlp_prefix)
+            shared_expert_mapping = (
+                _qwen4_exp_fused_shared_expert_mapping(name, params_dict, num_experts)
+                if getattr(mlp, "enable_shared_expert_fusion", False)
+                else None
+            )
+            if shared_expert_mapping is not None:
+                mapped_name, shard_id, expert_id = shared_expert_mapping
+                param = params_dict[mapped_name]
+                param.weight_loader(
+                    param,
+                    loaded_weight,
+                    mapped_name,
+                    shard_id=shard_id,
+                    expert_id=expert_id,
+                )
+                loaded_params.add(mapped_name)
+                continue
 
             for param_name, weight_name, shard_id in stacked_params_mapping:
                 if weight_name not in name:

--- a/test/registered/kernel/qsa/test_qsa_rocm.py
+++ b/test/registered/kernel/qsa/test_qsa_rocm.py
@@ -1,0 +1,121 @@
+"""ROCm coverage for the QSA packed-varlen decode fallback.
+
+On HIP there is neither flash_attn (FA2) nor flash-attn-4, so
+``_resolve_flash_attn_varlen_func`` resolves to aiter's FA2-compatible varlen
+kernel. The first two tests are device-independent (fake modules); the last one
+runs the real aiter kernel against a torch reference and only executes on ROCm.
+"""
+
+import sys
+from types import ModuleType
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention import qwen_sparse_attn_backend as qsa_backend_module
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-small")
+register_amd_ci(est_time=60, stage="jit-kernel-unit", runner_config="amd")
+
+
+def _fake_aiter(varlen_func):
+    module = ModuleType("aiter")
+    module.flash_attn_varlen_func = varlen_func
+    return module
+
+
+@pytest.mark.parametrize("returns_tuple", [False, True], ids=["tensor", "tuple"])
+def test_qsa_hip_resolves_aiter_varlen_kernel(monkeypatch, returns_tuple):
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+    sentinel = object()
+    calls = []
+
+    def aiter_varlen(*args, **kwargs):
+        calls.append(kwargs)
+        return (sentinel, None) if returns_tuple else sentinel
+
+    monkeypatch.setattr("sglang.srt.utils.is_sm121", lambda: False)
+    monkeypatch.setattr("sglang.srt.utils.is_hip", lambda: True)
+    monkeypatch.setitem(sys.modules, "aiter", _fake_aiter(aiter_varlen))
+
+    try:
+        func = resolver()
+        assert func(q=1, causal=True) is sentinel
+        assert calls == [{"q": 1, "causal": True}]
+    finally:
+        resolver.cache_clear()
+
+
+def test_qsa_hip_without_aiter_falls_through_to_flash_attn(monkeypatch):
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+    fa2_func = object()
+    flash_attn = ModuleType("flash_attn")
+    flash_attn.flash_attn_varlen_func = fa2_func
+
+    monkeypatch.setattr("sglang.srt.utils.is_sm121", lambda: False)
+    monkeypatch.setattr("sglang.srt.utils.is_hip", lambda: True)
+    monkeypatch.setitem(sys.modules, "aiter", None)  # makes `import aiter` fail
+    monkeypatch.setitem(sys.modules, "flash_attn", flash_attn)
+
+    try:
+        assert resolver() is fa2_func
+    finally:
+        resolver.cache_clear()
+
+
+def test_qsa_hip_aiter_varlen_matches_torch_reference():
+    if not (is_hip() and torch.cuda.is_available()):
+        pytest.skip("ROCm-only kernel")
+    pytest.importorskip("aiter")
+
+    resolver = qsa_backend_module._resolve_flash_attn_varlen_func
+    resolver.cache_clear()
+    torch.manual_seed(2028)
+    device = torch.device("cuda")
+    # Qwen3.8-Flash-Next full-attention shape: 24 query heads, 2 KV heads, d=256.
+    batch, topk = 3, 2048
+    num_q_heads, num_kv_heads, head_dim = 24, 2, 256
+    valid_counts = torch.tensor([5, topk, 700], dtype=torch.int32, device=device)
+    cu_seqlens_k = torch.zeros(batch + 1, dtype=torch.int32, device=device)
+    cu_seqlens_k[1:] = torch.cumsum(valid_counts, 0)
+    cu_seqlens_q = torch.arange(batch + 1, dtype=torch.int32, device=device)
+    q = torch.randn(batch, num_q_heads, head_dim, device=device, dtype=torch.bfloat16)
+    packed_k = torch.randn(
+        int(valid_counts.sum()),
+        num_kv_heads,
+        head_dim,
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    packed_v = torch.randn_like(packed_k)
+    scale = head_dim**-0.5
+
+    try:
+        # Mirrors the decode call in QwenSparseAttnBackend._forward_paged_attention.
+        out = resolver()(
+            q=q,
+            k=packed_k,
+            v=packed_v,
+            cu_seqlens_q=cu_seqlens_q,
+            cu_seqlens_k=cu_seqlens_k,
+            max_seqlen_q=1,
+            max_seqlen_k=topk,
+            softmax_scale=scale,
+            causal=True,
+        )
+    finally:
+        resolver.cache_clear()
+
+    assert out.shape == (batch, num_q_heads, head_dim)
+    repeats = num_q_heads // num_kv_heads
+    for row in range(batch):
+        start, end = int(cu_seqlens_k[row]), int(cu_seqlens_k[row + 1])
+        keys = packed_k[start:end].float().repeat_interleave(repeats, dim=1)
+        values = packed_v[start:end].float().repeat_interleave(repeats, dim=1)
+        scores = torch.einsum("hd,khd->hk", q[row].float(), keys) * scale
+        expected = torch.einsum("hk,khd->hd", scores.softmax(dim=-1), values)
+        torch.testing.assert_close(out[row].float(), expected, atol=2e-2, rtol=2e-2)

--- a/test/registered/kernel/qsa/test_qsa_rocm.py
+++ b/test/registered/kernel/qsa/test_qsa_rocm.py
@@ -14,6 +14,7 @@ import torch
 
 from sglang.srt.layers.attention import qwen_sparse_attn_backend as qsa_backend_module
 from sglang.srt.layers.attention.qsa.mqa import HAS_TILELANG, qsa_mqa_decode
+from sglang.srt.layers.attention.qsa.qsa_indexer import _mask_padded_group_locs
 from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
@@ -25,6 +26,17 @@ def _fake_aiter(varlen_func):
     module = ModuleType("aiter")
     module.flash_attn_varlen_func = varlen_func
     return module
+
+
+def test_qsa_padded_group_reads_use_reserved_slot():
+    source = torch.arange(6).reshape(3, 1, 2)
+    group_locs = torch.tensor([[0, 1], [2, 3]])
+    write_locs = torch.tensor([7, 0], dtype=torch.int32)
+
+    safe_locs = _mask_padded_group_locs(group_locs, write_locs)
+
+    assert safe_locs.tolist() == [[0, 1], [0, 0]]
+    assert source[safe_locs].shape == (2, 2, 1, 2)
 
 
 @pytest.mark.parametrize("returns_tuple", [False, True], ids=["tensor", "tuple"])

--- a/test/registered/kernel/qsa/test_qsa_rocm.py
+++ b/test/registered/kernel/qsa/test_qsa_rocm.py
@@ -13,6 +13,7 @@ import pytest
 import torch
 
 from sglang.srt.layers.attention import qwen_sparse_attn_backend as qsa_backend_module
+from sglang.srt.layers.attention.qsa.mqa import HAS_TILELANG, qsa_mqa_decode
 from sglang.srt.utils import is_hip
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
@@ -119,3 +120,45 @@ def test_qsa_hip_aiter_varlen_matches_torch_reference():
         scores = torch.einsum("hd,khd->hk", q[row].float(), keys) * scale
         expected = torch.einsum("hk,khd->hd", scores.softmax(dim=-1), values)
         torch.testing.assert_close(out[row].float(), expected, atol=2e-2, rtol=2e-2)
+
+
+def test_qsa_hip_tilelang_decode_matches_production_shape():
+    """Exercise Qwen3.8's 4x128 indexer shape through the real ROCm MFMA path."""
+
+    if not (is_hip() and torch.cuda.is_available()):
+        pytest.skip("ROCm-only kernel")
+    if not HAS_TILELANG:
+        pytest.skip("TileLang is unavailable")
+
+    torch.manual_seed(2029)
+    device = torch.device("cuda")
+    batch, num_q_heads, head_dim = 4, 4, 128
+    page_size, max_pages = 64, 4
+    q = torch.randn(batch, num_q_heads, head_dim, device=device, dtype=torch.bfloat16)
+    cache = torch.randn(12, page_size, 1, head_dim, device=device, dtype=torch.bfloat16)
+    page_table = torch.tensor(
+        [[3, 1, 5, 8], [4, 2, 0, 9], [7, 6, 11, 10], [1, 8, 3, 5]],
+        device=device,
+        dtype=torch.int32,
+    )
+    context_lens = torch.tensor([1, 64, 130, 255], device=device, dtype=torch.int32)
+    max_model_len = page_size * max_pages
+
+    actual = qsa_mqa_decode(
+        q,
+        cache,
+        page_table,
+        context_lens,
+        max_model_len=max_model_len,
+    )
+    torch.cuda.synchronize()
+
+    gathered = cache[page_table.long(), :, 0].reshape(batch, max_model_len, head_dim)
+    expected = torch.einsum("bhd,bnd->bnh", q.float(), gathered.float())
+    expected = torch.relu(expected).sum(-1) / (head_dim**0.5)
+    positions = torch.arange(max_model_len, device=device).unsqueeze(0)
+    expected.masked_fill_(positions >= context_lens[:, None], -float("inf"))
+
+    finite = torch.isfinite(expected)
+    assert torch.equal(torch.isfinite(actual), finite)
+    torch.testing.assert_close(actual[finite], expected[finite], atol=5e-2, rtol=2e-2)

--- a/test/registered/unit/models/test_qwen4_exp_shared_expert_weight_loader.py
+++ b/test/registered/unit/models/test_qwen4_exp_shared_expert_weight_loader.py
@@ -1,0 +1,213 @@
+"""Regression tests for Qwen4Exp fused shared-expert checkpoint loading."""
+
+from types import SimpleNamespace
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=4, suite="base-a-test-cpu")
+
+from sglang.srt.models.qwen4_exp import (
+    Qwen4ExpForConditionalGeneration,
+    _qwen4_exp_fused_shared_expert_mapping,
+)
+
+
+class _RecordingParameter:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def weight_loader(self, param, loaded_weight, mapped_name, *, shard_id, expert_id):
+        assert param is self
+        self.calls.append((mapped_name, shard_id, expert_id, loaded_weight.item()))
+
+
+class _RecordingStackedParameter:
+    def __init__(self, calls, name):
+        self.calls = calls
+        self.name = name
+
+    def weight_loader(self, param, loaded_weight, shard_id=None):
+        assert param is self
+        self.calls.append((self.name, shard_id, loaded_weight.item()))
+
+
+def _make_fused_model(num_layers=48):
+    calls = []
+    params = {}
+    modules = {}
+    for layer_id in range(num_layers):
+        prefix = f"model.layers.{layer_id}.mlp.experts"
+        params[f"{prefix}.w13_weight"] = _RecordingParameter(calls)
+        params[f"{prefix}.w2_weight"] = _RecordingParameter(calls)
+        modules[f"model.layers.{layer_id}.mlp"] = SimpleNamespace(
+            enable_shared_expert_fusion=True
+        )
+
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            num_experts=512,
+            tie_word_embeddings=False,
+            encoder_only=False,
+            text_config=SimpleNamespace(split_ngram_parts=512),
+        ),
+        language_model_only=True,
+        start_layer=0,
+        end_layer=num_layers,
+        named_parameters=lambda remove_duplicate=False: params.items(),
+        named_buffers=lambda: (),
+        named_modules=lambda: modules.items(),
+        modules=lambda: (),
+        _load_qwen4_exp_ple_buffer=lambda *args: False,
+    )
+    return model, calls
+
+
+def _make_unfused_model():
+    calls = []
+    params = {
+        "model.layers.0.mlp.shared_expert.gate_up_proj.weight": (
+            _RecordingStackedParameter(calls, "gate_up_proj")
+        ),
+        "model.layers.0.mlp.shared_expert.down_proj.weight": (
+            _RecordingStackedParameter(calls, "down_proj")
+        ),
+    }
+    model = SimpleNamespace(
+        config=SimpleNamespace(
+            num_experts=512,
+            tie_word_embeddings=False,
+            encoder_only=False,
+            text_config=SimpleNamespace(split_ngram_parts=512),
+        ),
+        language_model_only=True,
+        start_layer=0,
+        end_layer=1,
+        named_parameters=lambda remove_duplicate=False: params.items(),
+        named_buffers=lambda: (),
+        named_modules=lambda: (
+            (
+                "model.layers.0.mlp",
+                SimpleNamespace(enable_shared_expert_fusion=False),
+            ),
+        ),
+        modules=lambda: (),
+        _load_qwen4_exp_ple_buffer=lambda *args: False,
+    )
+    return model, calls
+
+
+def test_shared_expert_projections_load_into_fused_slot():
+    model, calls = _make_fused_model(num_layers=1)
+    weights = [
+        (
+            "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight",
+            torch.tensor(1.0),
+        ),
+        (
+            "model.language_model.layers.0.mlp.shared_expert.up_proj.weight",
+            torch.tensor(2.0),
+        ),
+        (
+            "model.language_model.layers.0.mlp.shared_expert.down_proj.weight",
+            torch.tensor(3.0),
+        ),
+    ]
+
+    loaded = Qwen4ExpForConditionalGeneration.load_weights(model, weights)
+
+    assert calls == [
+        ("model.layers.0.mlp.experts.w13_weight", "w1", 512, 1.0),
+        ("model.layers.0.mlp.experts.w13_weight", "w3", 512, 2.0),
+        ("model.layers.0.mlp.experts.w2_weight", "w2", 512, 3.0),
+    ]
+    assert loaded == {
+        "model.layers.0.mlp.experts.w13_weight",
+        "model.layers.0.mlp.experts.w2_weight",
+    }
+
+
+def test_all_48_layers_consume_all_144_shared_projection_names():
+    model, calls = _make_fused_model()
+    projections = {"gate_proj": "w1", "up_proj": "w3", "down_proj": "w2"}
+    weights = [
+        (
+            (
+                f"model.language_model.layers.{layer_id}.mlp.shared_expert."
+                f"{projection}.weight"
+            ),
+            torch.tensor(float(layer_id)),
+        )
+        for layer_id in range(48)
+        for projection in projections
+    ]
+
+    Qwen4ExpForConditionalGeneration.load_weights(model, weights)
+
+    assert len(calls) == 144
+    assert {(name, shard, expert) for name, shard, expert, _ in calls} == {
+        (
+            (
+                f"model.layers.{layer_id}.mlp.experts."
+                f"{'w2' if projection == 'down_proj' else 'w13'}_weight"
+            ),
+            shard,
+            512,
+        )
+        for layer_id in range(48)
+        for projection, shard in projections.items()
+    }
+
+
+def test_shared_expert_uses_separate_parameters_when_fusion_is_disabled():
+    model, calls = _make_unfused_model()
+    weights = [
+        (
+            "model.language_model.layers.0.mlp.shared_expert.gate_proj.weight",
+            torch.tensor(1.0),
+        ),
+        (
+            "model.language_model.layers.0.mlp.shared_expert.up_proj.weight",
+            torch.tensor(2.0),
+        ),
+        (
+            "model.language_model.layers.0.mlp.shared_expert.down_proj.weight",
+            torch.tensor(3.0),
+        ),
+    ]
+
+    loaded = Qwen4ExpForConditionalGeneration.load_weights(model, weights)
+
+    assert calls == [
+        ("gate_up_proj", 0, 1.0),
+        ("gate_up_proj", 1, 2.0),
+        ("down_proj", None, 3.0),
+    ]
+    assert loaded == {
+        "model.layers.0.mlp.shared_expert.gate_up_proj.weight",
+        "model.layers.0.mlp.shared_expert.down_proj.weight",
+    }
+
+
+def test_mapping_does_not_capture_routed_visual_or_nonfused_weights():
+    params = {"model.layers.0.mlp.experts.w13_weight": object()}
+
+    assert (
+        _qwen4_exp_fused_shared_expert_mapping(
+            "model.layers.0.mlp.experts.0.gate_proj.weight", params, 512
+        )
+        is None
+    )
+    assert (
+        _qwen4_exp_fused_shared_expert_mapping(
+            "visual.layers.0.mlp.shared_expert.gate_proj.weight", params, 512
+        )
+        is None
+    )
+    assert (
+        _qwen4_exp_fused_shared_expert_mapping(
+            "model.layers.0.mlp.shared_expert.gate_proj.weight", {}, 512
+        )
+        is None
+    )

--- a/test/registered/unit/models/test_qwen4_exp_shared_expert_weight_loader.py
+++ b/test/registered/unit/models/test_qwen4_exp_shared_expert_weight_loader.py
@@ -2,6 +2,7 @@
 
 from types import SimpleNamespace
 
+import pytest
 import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -12,6 +13,7 @@ from sglang.srt.models.qwen4_exp import (
     Qwen4ExpForConditionalGeneration,
     _qwen4_exp_fused_shared_expert_mapping,
 )
+from sglang.srt.models.qwen4_exp_mtp import Qwen4ExpForCausalLMMTP
 
 
 class _RecordingParameter:
@@ -31,6 +33,24 @@ class _RecordingStackedParameter:
     def weight_loader(self, param, loaded_weight, shard_id=None):
         assert param is self
         self.calls.append((self.name, shard_id, loaded_weight.item()))
+
+
+class _RecordingMTPExpertParameter:
+    def __init__(self, calls):
+        self.calls = calls
+
+    def weight_loader(
+        self,
+        param,
+        loaded_weight,
+        mapped_name,
+        shard_id=None,
+        expert_id=None,
+    ):
+        assert param is self
+        self.calls.append(
+            (mapped_name, shard_id, expert_id, loaded_weight.flatten().tolist())
+        )
 
 
 def _make_fused_model(num_layers=48):
@@ -94,6 +114,20 @@ def _make_unfused_model():
         ),
         modules=lambda: (),
         _load_qwen4_exp_ple_buffer=lambda *args: False,
+    )
+    return model, calls
+
+
+def _make_fused_mtp_model(num_experts=2):
+    calls = []
+    params = {
+        "model.layers.0.mlp.experts.w13_weight": _RecordingMTPExpertParameter(calls),
+        "model.layers.0.mlp.experts.w2_weight": _RecordingMTPExpertParameter(calls),
+    }
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_experts=num_experts),
+        named_parameters=lambda: params.items(),
+        modules=lambda: (SimpleNamespace(num_fused_shared_experts=1),),
     )
     return model, calls
 
@@ -211,3 +245,63 @@ def test_mapping_does_not_capture_routed_visual_or_nonfused_weights():
         )
         is None
     )
+
+
+def test_mtp_shared_expert_loads_after_fused_routed_expert_weights():
+    model, calls = _make_fused_mtp_model()
+    weights = [
+        (
+            "mtp.layers.0.mlp.experts.gate_up_proj",
+            torch.tensor([[[1.0], [2.0]], [[3.0], [4.0]]]),
+        ),
+        (
+            "mtp.layers.0.mlp.experts.down_proj",
+            torch.tensor([[[5.0]], [[6.0]]]),
+        ),
+        ("mtp.layers.0.mlp.shared_expert.gate_proj.weight", torch.tensor(7.0)),
+        ("mtp.layers.0.mlp.shared_expert.up_proj.weight", torch.tensor(8.0)),
+        ("mtp.layers.0.mlp.shared_expert.down_proj.weight", torch.tensor(9.0)),
+    ]
+
+    loaded = Qwen4ExpForCausalLMMTP.load_weights(model, weights)
+
+    shared_expert_calls = [call for call in calls if call[2] == 2]
+    assert shared_expert_calls == [
+        ("model.layers.0.mlp.experts.w13_weight", "w1", 2, [7.0]),
+        ("model.layers.0.mlp.experts.w13_weight", "w3", 2, [8.0]),
+        ("model.layers.0.mlp.experts.w2_weight", "w2", 2, [9.0]),
+    ]
+    assert loaded == {
+        "model.layers.0.mlp.experts.w13_weight",
+        "model.layers.0.mlp.experts.w2_weight",
+    }
+
+
+def test_mtp_missing_parameter_is_not_reported_as_loaded():
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_experts=None),
+        named_parameters=lambda: (),
+        modules=lambda: (),
+    )
+
+    loaded = Qwen4ExpForCausalLMMTP.load_weights(
+        model, [("mtp.required.weight", torch.tensor(1.0))]
+    )
+
+    assert loaded == set()
+
+
+def test_mtp_required_shared_expert_missing_fails_closed():
+    model = SimpleNamespace(
+        config=SimpleNamespace(num_experts=512),
+        named_parameters=lambda: (),
+        modules=lambda: (SimpleNamespace(num_fused_shared_experts=1),),
+    )
+
+    with pytest.raises(
+        ValueError, match="Required MTP shared-expert parameter could not be loaded"
+    ):
+        Qwen4ExpForCausalLMMTP.load_weights(
+            model,
+            [("mtp.layers.0.mlp.shared_expert.gate_proj.weight", torch.tensor(1.0))],
+        )


### PR DESCRIPTION
## Motivation

Generic Qwen3.8-Flash-Next model support is now on `main` through #37500, but the public `amd/Qwen3.8-Flash-Next-Quark-MXFP4` checkpoint still needs the shared-expert loader and ROCm QSA fixes in this PR for end-to-end serving on gfx950.

The refreshed branch is intentionally scoped to the remaining runtime fixes. Related focused ROCm changes are also under review in #38875 and #38909, with their original authorship preserved here. The pool-backed fixed-capacity padding mask in this PR is separate from #38346's clamp for the per-forward `token_k` source path; the added regression covers an incomplete compression group in the pool-backed path.

## Modifications

- Load fused Qwen3.8 shared-expert tensors correctly in the target model.
- Apply the same shared-expert mapping to the MTP/EAGLE model and fail loudly if a required shared-expert parameter is not loaded.
- Pad QSA MQA decode query heads to the 16-wide MFMA shape required on ROCm while retaining the existing CUDA alignment.
- Resolve QSA's packed-varlen decode path to AITER on HIP.
- Mask fixed-capacity padding entries before QSA compression gathers, preventing an incomplete compression group from reading beyond the source tensor.
- Add focused loader, resolver, real-kernel, production-shape, and padded-read regression coverage.

## Provenance

- validated head: `0b4f96ff745b7b498e49e613dfeea046a60052fc`
- nightly embedded SGLang revision: `358c163250ad3b1f62939b01ce1314a0a31a0365`
- PR Python tree: `15b675eb400c3fa48d0f65c2ee2d4a369f4ce591`
- tracked source aggregate: `02745069648ce3d26b774764091d312137d903909b216d5b0eb7b87978a34586`
- gfx942 nightly: `rocm/sgl-dev@sha256:151005265cf3f4e98c41abc41f5cd317ab2e83085ec24d82f0bd36465f886457`
- gfx950 nightly: `rocm/sgl-dev@sha256:9252e847c0ebcef375543d3bf61d935cbd80ef5ac86ed3ba16e31bb7e1f1be47`
- BF16 revision: `de4b8e4d43b917e7706784d8bb445c9af86a3540`
- FP8 revision: `236dfdf285828023ca3bcd3f37366c58a3469b13`
- Quark MXFP4 revision: `1ad7d941b239f6dc83cba6e49234c0efe1ca5477`

Validation used exact-source local images built on the immutable official nightlies above. No custom Docker Hub image was published or required.

## Full five-shot GSM8K validation

Every direct run used one eight-GPU node, TP8+EP8, `SGLANG_USE_AITER=1`, explicit AITER attention and MoE, page size 64, full target and draft decode CUDA graphs, EAGLE/MTP 3/1/4, seed 42, and the exact source at this PR head. Each run requested all 1,319 GSM8K rows; five were used as demonstrations and 1,314 responses were scored.

| GPU | Model | Score | Correct | Request errors | Fatal patterns | Graph-backed decode | Mean MTP acceptance |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| MI300X | BF16 | 97.1842% | 1,277/1,314 | 0 | 0 | 379/379 | 3.5666 |
| MI300X | FP8 | 96.4231% | 1,267/1,314 | 0 | 0 | 379/379 | 3.5693 |
| MI355X | BF16 | 96.8798% | 1,273/1,314 | 0 | 0 | 379/379 | 3.5669 |
| MI355X | FP8 | 96.8037% | 1,272/1,314 | 0 | 0 | 374/374 | 3.5690 |
| MI355X | Quark MXFP4 | 96.6514% | 1,270/1,314 | 0 | 0 | 374/374 | 3.5524 |

All five runs exceeded the 94% correctness gate, exited successfully, retained HTTP health after evaluation, and completed with clean GPU/KFD postflight. The MI355X BF16 and FP8 validations ran in AgentX job `134851` on `crsuse2-m2m-239`; the orchestrator exited `0` and produced its `all-success` marker before the reservation was released.

Artifact roots:

- MI355X BF16: `/shared_nfs/anluo/qwen38-pr36919-20260912/results/bf16-image-20260912T194013Z`
- MI355X FP8: `/shared_nfs/anluo/qwen38-pr36919-20260912/results/fp8-image-20260912T195959Z`
- MI355X Quark MXFP4: `/shared_nfs/anluo/qwen38-pr36601-20260911/results/20260912T003308Z`

MI325X shares the validated gfx942 path with MI300X, and MI350X shares the validated gfx950 path with MI355X. No accuracy result is copied to those inherited hardware rows.

## Focused tests

- gfx942 focused suite: `13 passed`
- gfx950 focused suite: `14 passed`
- Coverage includes target/MTP shared-expert loading, ROCm QSA backend resolution, the exact 4x128 production decode shape, and the fixed-capacity padded-group regression.

No performance claim is made from these correctness runs.

## Documentation

#36919 adds the corresponding cookbook matrix: BF16/FP8 on MI300X, MI325X, MI350X, and MI355X, plus Quark MXFP4 high-throughput and low-latency recipes on MI350X and MI355X. Until this PR lands in an official nightly, the cookbook uses immutable official nightly digests with a read-only mount of this exact Python source tree.

## Checklist

- [x] Format and compile checks pass for the changed files.
- [x] Focused unit/kernel coverage passes on gfx942 and gfx950.
- [x] Full-model BF16 and FP8 regression coverage passes on MI300X and MI355X.
- [x] Full-model Quark MXFP4 correctness coverage passes on MI355X.
- [x] AITER, full decode CUDA graphs, and MTP are proven in every low-latency run.
- [x] No custom image publication is required.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34663040138](https://github.com/sgl-project/sglang/actions/runs/34663040138)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34663039903](https://github.com/sgl-project/sglang/actions/runs/34663039903)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34663040157](https://github.com/sgl-project/sglang/actions/runs/34663040157)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
