### PR TITLE
[CI] Remove GLM-4.1V-9B-Thinking from nightly VLM MMMU eval

### DIFF
--- a/test/registered/eval/test_vlms_mmmu_eval.py
+++ b/test/registered/eval/test_vlms_mmmu_eval.py
@@ -47,7 +47,6 @@ MODEL_THRESHOLDS = {
     ),
     ModelLaunchSettings("unsloth/Mistral-Small-3.1-24B-Instruct-2503"): (0.30, 43.0),
     ModelLaunchSettings("XiaomiMiMo/MiMo-VL-7B-RL"): (0.28, 40.0),
-    ModelLaunchSettings("zai-org/GLM-4.1V-9B-Thinking"): (0.280, 35.5),
     ModelLaunchSettings("zai-org/GLM-4.5V-FP8", extra_args=["--tp=2"]): (0.26, 140.0),
 }
 


### PR DESCRIPTION
zai-org/GLM-4.1V-9B-Thinking fails the nightly VLM MMMU eval on latency: 37.31s vs the 35.5s threshold (accuracy is fine at 0.4802 vs 0.28). Removing it from the nightly model list.

Failing job: https://github.com/sgl-project/sglang/actions/runs/32858458603/job/97836286693

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33035808456](https://github.com/sgl-project/sglang/actions/runs/33035808456)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33035808254](https://github.com/sgl-project/sglang/actions/runs/33035808254)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33035808420](https://github.com/sgl-project/sglang/actions/runs/33035808420)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->