### PR TITLE
fix(lora): keep the fused MoE LoRA loop unpipelined for fp32 on ROCm

### DIFF
--- a/python/sglang/kernels/ops/moe/fused_moe_lora_kernel.py
+++ b/python/sglang/kernels/ops/moe/fused_moe_lora_kernel.py
@@ -8,10 +8,12 @@ from sglang.srt.distributed import (
     tensor_model_parallel_all_gather,
     tensor_model_parallel_all_reduce,
 )
-from sglang.srt.utils.common import is_blackwell_supported, is_sm90_supported
+from sglang.srt.utils.common import is_blackwell_supported, is_hip, is_sm90_supported
 
 # Import SGLang's standard PDL support detection
 
+
+_IS_HIP = is_hip()
 
 _LORA_PTR_DICT: dict[tuple[int, ...], torch.Tensor] = {}
 
@@ -206,6 +208,18 @@ def _fused_moe_lora_kernel(
         tl.atomic_add(c_ptrs, accumulator, mask=c_mask, sem="relaxed")
 
 
+def _pipelined_num_stages(num_stages: int, dtype: torch.dtype) -> int:
+    # On gfx950 the Triton pipeliner rewrites this loop's operand loads into
+    # direct-to-LDS async copies, and the backend then fails to legalize them
+    # for 32-bit operands: the LoRA weight base pointer is loaded from the
+    # runtime pointer table, so it carries no divisibility information and the
+    # copy vectorizes to one element, which is too narrow to write LDS
+    # coalesced. Running those unpipelined keeps the loop compilable.
+    if _IS_HIP and dtype.itemsize == 4:
+        return 1
+    return num_stages
+
+
 @torch.inference_mode()
 def _fused_moe_lora_shrink(
     a_intermediate_cache1: torch.Tensor,
@@ -249,7 +263,7 @@ def _fused_moe_lora_shrink(
         "BLOCK_SIZE_K": block_size_k,
         "GROUP_SIZE_M": group_size_m,
         "num_warps": num_warps,
-        "num_stages": num_stages,
+        "num_stages": _pipelined_num_stages(num_stages, qcurr_hidden_states.dtype),
         "SPLIT_K": split_k,
         "USE_GDC": use_gdc,
         "launch_pdl": use_gdc,  # triton kernel metadata
@@ -358,7 +372,7 @@ def _fused_moe_lora_expand(
         "BLOCK_SIZE_K": block_size_k,
         "GROUP_SIZE_M": group_size_m,
         "num_warps": num_warps,
-        "num_stages": num_stages,
+        "num_stages": _pipelined_num_stages(num_stages, a_intermediate_cache1.dtype),
         "SPLIT_K": split_k,  # Set split_k = 1 for expand calls
         "USE_GDC": use_gdc,
         "launch_pdl": use_gdc,  # triton kernel metadata


### PR DESCRIPTION
## Problem

`test/registered/lora/test_fused_moe_lora_kernel.py` fails to compile on gfx950 for every `torch.float32` parametrization (36 of 108 cases). `fp16`/`bf16` are unaffected.

```
python/sglang/kernels/ops/moe/fused_moe_lora_kernel.py:183:20: error: failed to legalize
    operation 'ttg.async_copy_global_to_local' that was explicitly marked illegal
...
Pipeline failed while executing [`ConvertTritonAMDGPUToLLVM` on 'builtin.module' operation]
```

Line 183 is the LoRA weight load inside the K loop. Three conditions have to hold together, and a reduced repro confirms each is load-bearing:

1. the operand element type is 32 bits,
2. `num_stages >= 2`, so the loop is software pipelined,
3. the B base pointer is opaque to the compiler.

Condition 3 is specific to this kernel: `cur_b_ptr` comes from `tl.load(b_ptr + slice_id)`, the grouped-GEMM style runtime pointer table, so axis analysis reports `divisibility = [1, 1]` for the B pointer (against `[4, 16]` for A) and the load vectorizes to one element.

The two AMD passes that decide whether a direct-to-LDS copy is usable then disagree. `tritonamdgpu-pipeline` emits the async copy because `1 element x 32 bit` is a width `supportsDirectToLdsLoadBitWidth` accepts; at lowering time `canLoadDirectToLDS` rejects the same copy because a one-element vector cannot produce coalesced LDS writes, `CoalesceAsyncCopy` cannot rewrite it into a legal form, and the op is marked illegal in the conversion target, so compilation aborts rather than falling back to a plain copy.

16-bit types never reach this path: `supportsDirectToLdsLoadBitWidth` disables 8 and 16 bits on every ISA family. gfx942 is unaffected as well, since `is_async_copy_enabled` only defaults to true on gfx950 and gfx1250.

## Change

Skip the pipeline for 32-bit operands on ROCm. `num_stages` is a scheduling hint, so this cannot change results, and the guard is narrow enough that CUDA and the 16-bit ROCm paths compile exactly as before.

An alignment hint (`tl.multiple_of(cur_b_ptr, 16)`) also clears the compile error and is a true statement about the pointer, but it makes the backend miscompile 16-bit operands: `bf16` regresses from 36 passed to 17 failed with a greatest absolute difference of 19840, so it is not a viable fix here.

The underlying issue belongs in Triton, where `CoalesceAsyncCopy` should fall back to a regular copy instead of leaving an illegal op behind.

## Validation

MI355X (`gfx950`), ROCm 7.2, Triton 3.6.0.

Both the baseline and the fixed run are measured on current `main` plus #36379. That prerequisite is needed because `moe_lora_align_block_size` does not JIT-build on ROCm without it, so on plain `main` this test aborts at `fatal error: 'cub/cub.cuh' file not found` before it ever reaches the Triton kernel.

* `test/registered/lora/test_fused_moe_lora_kernel.py`: 108 passed, against 36 failed / 72 passed without this change.
* `test/registered/kernels/ops/moe/test_moe_lora_align_block_size.py`: 32 passed, unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33036089139](https://github.com/sgl-project/sglang/actions/runs/33036089139)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33036089224](https://github.com/sgl-project/sglang/actions/runs/33036089224)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33036089140](https://github.com/sgl-project/sglang/actions/runs/33036089140)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->