### PR TITLE
[CI] Graceful teardown for the radix_cache server fixtures

### DIFF
--- a/test/registered/radix_cache/test_radix_attention.py
+++ b/test/registered/radix_cache/test_radix_attention.py
@@ -13,8 +13,8 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     is_in_ci,
-    kill_process_tree,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 # RadixAttention server integration tests
@@ -44,7 +44,7 @@ class TestRadixCacheFCFS(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
     def test_radix_attention(self):
         run_radix_attention_test(self.base_url)

--- a/test/registered/radix_cache/test_radix_cache_hit.py
+++ b/test/registered/radix_cache/test_radix_cache_hit.py
@@ -1,6 +1,5 @@
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import (
     register_amd_ci,
     register_cpu_ci,
@@ -13,6 +12,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 register_cuda_ci(est_time=55, stage="base-b", runner_config="1-gpu-small")
@@ -35,7 +35,7 @@ class TestRadixCacheHit(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
     def test_multiturn_cache_hit(self):
         run_multiturn_cache_hit_test(

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_hicache_pp_kl.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_hicache_pp_kl.py
@@ -5,7 +5,6 @@ import unittest
 from types import SimpleNamespace
 from urllib.parse import urlparse
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.unified_radix_cache_kit import (
     AccuracyTwoPassMixin,
@@ -17,6 +16,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 register_cuda_ci(est_time=900, stage="base-c", runner_config="4-gpu-h100")
@@ -105,7 +105,7 @@ class TestUnifiedQwen3HiCachePP(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
 
 class TestUnifiedQwen3HiCachePPL3(AccuracyTwoPassMixin, CustomTestCase):
@@ -157,7 +157,7 @@ class TestUnifiedQwen3HiCachePPL3(AccuracyTwoPassMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
         if os.path.isdir(cls.hicache_dir):
             shutil.rmtree(cls.hicache_dir, ignore_errors=True)
 

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_cp.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_cp.py
@@ -1,6 +1,5 @@
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.unified_radix_cache_kit import UnifiedRadixTreeTestMixin
 from sglang.test.kl_multiturn_utils import get_input_ids
@@ -9,6 +8,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 register_cuda_ci(est_time=950, stage="extra-b", runner_config="4-gpu-h100")
@@ -69,7 +69,7 @@ class TestUnifiedQwen3HiCacheCP(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
 
 if __name__ == "__main__":

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dcp.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dcp.py
@@ -10,7 +10,6 @@ Blackwell-only: the MLA DCP decode path needs ``tokenspeed_mla`` (SM100/12x).
 import subprocess
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.unified_radix_cache_kit import UnifiedRadixTreeTestMixin
 from sglang.test.kl_multiturn_utils import (
@@ -23,6 +22,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 register_cuda_ci(est_time=1500, stage="extra-b", runner_config="4-gpu-b200")
@@ -104,7 +104,7 @@ class TestUnifiedKimiLinearDcpHiCache(UnifiedRadixTreeTestMixin, CustomTestCase)
             cls.process.wait(timeout=60)
         except subprocess.TimeoutExpired:
             pass
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
 
 if __name__ == "__main__":

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_dsv4.py
@@ -6,7 +6,6 @@ import unittest
 
 import requests
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.unified_radix_cache_kit import (
     AccuracyTwoPassMixin,
@@ -18,6 +17,7 @@ from sglang.test.test_utils import (
     CustomTestCase,
     is_in_ci,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 DSV4_FLASH_MODEL = "sgl-project/DeepSeek-V4-Flash-FP8"
@@ -109,7 +109,7 @@ class TestUnifiedDeepSeekV4FlashHiCache(UnifiedRadixTreeTestMixin, CustomTestCas
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
 
 class TestUnifiedDeepSeekV4FlashHiCachePageFirstDirect(
@@ -180,7 +180,7 @@ class TestUnifiedDeepSeekV4FlashHiCacheL3(AccuracyTwoPassMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
         if os.path.isdir(cls.hicache_dir):
             shutil.rmtree(cls.hicache_dir, ignore_errors=True)
 
@@ -257,7 +257,7 @@ class TestUnifiedDeepSeekV4FlashEagleHiCacheL3(AccuracyTwoPassMixin, CustomTestC
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
         if os.path.isdir(cls.hicache_dir):
             shutil.rmtree(cls.hicache_dir, ignore_errors=True)
 

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_full.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_full.py
@@ -1,6 +1,5 @@
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.kits.unified_radix_cache_kit import UnifiedRadixTreeTestMixin
 from sglang.test.kl_multiturn_utils import get_input_ids
@@ -9,6 +8,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 register_cuda_ci(est_time=250, stage="base-b", runner_config="2-gpu-large")
@@ -44,7 +44,7 @@ class TestUnifiedFullRadixCache(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
 
 if __name__ == "__main__":

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_glm52.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_glm52.py
@@ -9,13 +9,13 @@ import shutil
 import tempfile
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.unified_radix_cache_kit import AccuracyTwoPassMixin
 from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 GLM5_MODEL = "zai-org/GLM-5.2-FP8"
@@ -76,7 +76,7 @@ class TestGLM5UnifiedRadixCacheL3Accuracy(AccuracyTwoPassMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
         if os.path.isdir(cls.hicache_dir):
             shutil.rmtree(cls.hicache_dir, ignore_errors=True)
 

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_hybrid_bitexact.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_hybrid_bitexact.py
@@ -42,7 +42,6 @@ import os
 import random
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kl_multiturn_utils import (
     make_mamba_decode_assert,
@@ -67,6 +66,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 register_cuda_ci(est_time=1150, stage="base-b", runner_config="1-gpu-large")
@@ -158,7 +158,7 @@ class TestUnifiedHybridBitExact(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         if getattr(cls, "process", None) is not None:
-            kill_process_tree(cls.process.pid)
+            terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
     def _run(self, helper):
         helper(
@@ -270,7 +270,7 @@ class TestUnifiedHybridHiCacheBitExact(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         if getattr(cls, "process", None) is not None:
-            kill_process_tree(cls.process.pid)
+            terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
     def test_multiturn_decode_cache_hit_branching(self):
         groups, branches = 3, 3
@@ -350,7 +350,7 @@ class TestUnifiedHybridMTPBitExact(CustomTestCase):
     @classmethod
     def tearDownClass(cls):
         if getattr(cls, "process", None) is not None:
-            kill_process_tree(cls.process.pid)
+            terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
     def _run(self, helper):
         helper(

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mimo.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_mimo.py
@@ -3,7 +3,6 @@
 import random
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kl_test_utils import (
     _extract_output_logprobs,
@@ -16,6 +15,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 MIMO_MODEL = "XiaomiMiMo/MiMo-V2.5"
@@ -97,7 +97,7 @@ class TestUnifiedMiMoHiCacheLoadBackKL(CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
     @classmethod
     def _prompt(cls, seed: int) -> list[int]:

--- a/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_swa.py
+++ b/test/registered/radix_cache/unified_radix_tree/test_unified_radix_cache_kl_swa.py
@@ -1,6 +1,5 @@
 import unittest
 
-from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.unified_radix_cache_kit import UnifiedRadixTreeTestMixin
 from sglang.test.kl_multiturn_utils import get_input_ids
@@ -9,6 +8,7 @@ from sglang.test.test_utils import (
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
     popen_launch_server,
+    terminate_and_kill_process_tree,
 )
 
 register_cuda_ci(est_time=250, stage="base-b", runner_config="2-gpu-large")
@@ -43,7 +43,7 @@ class TestUnifiedSWARadixCache(UnifiedRadixTreeTestMixin, CustomTestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill_process_tree(cls.process.pid)
+        terminate_and_kill_process_tree(cls.process, wait_timeout=60)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The nightly 8-gpu-h200 KL/HiCache tests fail in `setUpClass` with `GPU(s) still not idle after waiting 30s`. The previous class SIGKILLs its TP8 server, and the driver is still reclaiming ~122 GiB/GPU when the next class's idle gate runs — the error even reports the schedulers as already gone while the memory is still held.

SIGTERM first and wait, so the server releases GPU memory and unpins host memory in userspace, then SIGKILL whatever is left. Same `terminate_and_kill_process_tree` treatment already applied to the shared server fixtures in #32829 and #31871; these files were never converted.

Seen on https://github.com/sgl-project/sglang/actions/runs/32858458603/job/97836286546 (in `test_unified_radix_cache_kl_nightly.py`, since split into `test_unified_radix_cache_kl_glm52.py` by #36281, which carried the bare kill over).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33036119871](https://github.com/sgl-project/sglang/actions/runs/33036119871)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33036119683](https://github.com/sgl-project/sglang/actions/runs/33036119683)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33036119889](https://github.com/sgl-project/sglang/actions/runs/33036119889)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->