### PR TITLE
[AMD] Enable GLM-5.3-Flash on gfx942 and gfx950

### DIFF
--- a/python/sglang/kernels/jit/csrc/dsa/kpool_topk_transform.cuh
+++ b/python/sglang/kernels/jit/csrc/dsa/kpool_topk_transform.cuh
@@ -314,11 +314,9 @@ void setup_kernel_smem_once(host::DebugInfo where = {}) {
   static const auto result = [] {
     const auto fptr = std::bit_cast<const void*>(f);
 #if defined(__HIP_PLATFORM_AMD__)
-    return ::hipFuncSetAttribute(
-        fptr, ::hipFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+    return ::hipFuncSetAttribute(fptr, ::hipFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
 #else
-    return ::cudaFuncSetAttribute(
-        fptr, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+    return ::cudaFuncSetAttribute(fptr, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
 #endif
   }();
   host::RuntimeDeviceCheck(result, where);

--- a/python/sglang/kernels/jit/csrc/dsa/kpool_topk_transform.cuh
+++ b/python/sglang/kernels/jit/csrc/dsa/kpool_topk_transform.cuh
@@ -19,7 +19,11 @@
 #include <bit>
 #include <cstddef>
 #include <cstdint>
+#if defined(__HIP_PLATFORM_AMD__)
+#include <hip/hip_fp16.h>
+#else
 #include <cuda_fp16.h>
+#endif
 
 namespace sglang {
 namespace {
@@ -309,7 +313,13 @@ void setup_kernel_smem_once(host::DebugInfo where = {}) {
   [[maybe_unused]]
   static const auto result = [] {
     const auto fptr = std::bit_cast<const void*>(f);
-    return ::cudaFuncSetAttribute(fptr, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+#if defined(__HIP_PLATFORM_AMD__)
+    return ::hipFuncSetAttribute(
+        fptr, ::hipFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+#else
+    return ::cudaFuncSetAttribute(
+        fptr, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+#endif
   }();
   host::RuntimeDeviceCheck(result, where);
 }

--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -885,13 +885,16 @@ def sparse_mla_fwd_decode_partial(
         with T.Kernel(seq_len * REPLICATE_H, N_GROUPS, threads=threads) as (bx, by):
             if _q_in_shared:
                 Q_buf = T.alloc_shared([H_per_block, D], dtype)
-                Q_tail_buf = T.alloc_shared([H_per_block, D_tail], dtype)
+                if D_tail > 0:
+                    Q_tail_buf = T.alloc_shared([H_per_block, D_tail], dtype)
             else:
                 Q_buf = T.alloc_fragment([H_per_block, D], dtype)
-                Q_tail_buf = T.alloc_fragment([H_per_block, D_tail], dtype)
+                if D_tail > 0:
+                    Q_tail_buf = T.alloc_fragment([H_per_block, D_tail], dtype)
 
             KV_shared = T.alloc_shared([BI, D], dtype)
-            K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
+            if D_tail > 0:
+                K_tail_shared = T.alloc_shared([BI, D_tail], dtype)
             S_shared = T.alloc_shared([H_per_block, BI], dtype)
             mask = T.alloc_fragment([BI], T.bool)
 
@@ -914,7 +917,8 @@ def sparse_mla_fwd_decode_partial(
             H1 = H0 + H_per_block
 
             T.copy(Q[b_i, s_i, H0:H1, :D], Q_buf)
-            T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_buf)
+            if D_tail > 0:
+                T.copy(Q[b_i, s_i, H0:H1, D:], Q_tail_buf)
 
             for k_i in T.Pipelined(inner_iter, num_stages=num_stages):
                 topk_block_i = group_i * inner_iter + k_i
@@ -926,11 +930,12 @@ def sparse_mla_fwd_decode_partial(
                     KV_shared[bi_i, d_i] = KV[
                         b_i, T.if_then_else(idx >= 0, idx, 0), g_i, d_i
                     ]
-                for bi_i, d_i in T.Parallel(BI, D_tail):
-                    idx = Indices[b_i, s_i, g_i, topk_block_i * BI + bi_i]
-                    K_tail_shared[bi_i, d_i] = KV[
-                        b_i, T.if_then_else(idx >= 0, idx, 0), g_i, D + d_i
-                    ]
+                if D_tail > 0:
+                    for bi_i, d_i in T.Parallel(BI, D_tail):
+                        idx = Indices[b_i, s_i, g_i, topk_block_i * BI + bi_i]
+                        K_tail_shared[bi_i, d_i] = KV[
+                            b_i, T.if_then_else(idx >= 0, idx, 0), g_i, D + d_i
+                        ]
 
                 for h_i, bi_i in T.Parallel(H_per_block, BI):
                     acc_s[h_i, bi_i] = T.if_then_else(
@@ -944,13 +949,14 @@ def sparse_mla_fwd_decode_partial(
                     transpose_B=True,
                     policy=T.GemmWarpPolicy.FullCol,
                 )
-                T.gemm(
-                    Q_tail_buf,
-                    K_tail_shared,
-                    acc_s,
-                    transpose_B=True,
-                    policy=T.GemmWarpPolicy.FullCol,
-                )
+                if D_tail > 0:
+                    T.gemm(
+                        Q_tail_buf,
+                        K_tail_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullCol,
+                    )
 
                 T.copy(m_i, m_i_prev)
                 T.reduce_max(acc_s, m_i, dim=1, clear=False)
@@ -1161,8 +1167,9 @@ def sparse_mla_fwd_decode_partial_fp8(
             kv_tile1 = T.alloc_shared([BI, group_size], fp8_dtype)
             kv_tile2 = T.alloc_shared([BI, group_size], fp8_dtype)
             kv_tile3 = T.alloc_shared([BI, group_size], fp8_dtype)
-            q_tail_buf = T.alloc_shared([h_per_block, d_tail], fp8_dtype)
-            k_tail_shared = T.alloc_shared([BI, d_tail], fp8_dtype)
+            if d_tail > 0:
+                q_tail_buf = T.alloc_shared([h_per_block, d_tail], fp8_dtype)
+                k_tail_shared = T.alloc_shared([BI, d_tail], fp8_dtype)
             s_fp8_shared = T.alloc_shared([h_per_block, BI], fp8_dtype)
             page_idx_shared = T.alloc_shared([BI], T.int32)
 
@@ -1189,7 +1196,8 @@ def sparse_mla_fwd_decode_partial_fp8(
             T.fill(sumexp, 0)
             T.fill(m_i, -(2**30))
 
-            T.copy(q_fp8[b_i, s_i, H0:H1, d_v:], q_tail_buf)
+            if d_tail > 0:
+                T.copy(q_fp8[b_i, s_i, H0:H1, d_v:], q_tail_buf)
             T.copy(q_fp8[b_i, s_i, H0:H1, 0 * group_size : 1 * group_size], q_tile0)
             T.copy(q_fp8[b_i, s_i, H0:H1, 1 * group_size : 2 * group_size], q_tile1)
             T.copy(q_fp8[b_i, s_i, H0:H1, 2 * group_size : 3 * group_size], q_tile2)
@@ -1211,9 +1219,12 @@ def sparse_mla_fwd_decode_partial_fp8(
                     kv_tile2[bi_i, j] = kv_fp8[b_i, page, g_i, 2 * group_size + j]
                     kv_tile3[bi_i, j] = kv_fp8[b_i, page, g_i, 3 * group_size + j]
 
-                for bi_i, j in T.Parallel(BI, d_tail):
-                    page = page_idx_shared[bi_i]
-                    k_tail_shared[bi_i, j] = kv_fp8[b_i, page, g_i, rope_offset_fp8 + j]
+                if d_tail > 0:
+                    for bi_i, j in T.Parallel(BI, d_tail):
+                        page = page_idx_shared[bi_i]
+                        k_tail_shared[bi_i, j] = kv_fp8[
+                            b_i, page, g_i, rope_offset_fp8 + j
+                        ]
 
                 for h_i, bi_i in T.Parallel(h_per_block, BI):
                     acc_s[h_i, bi_i] = T.if_then_else(
@@ -1230,13 +1241,14 @@ def sparse_mla_fwd_decode_partial_fp8(
                 T.gemm(q_tile3, kv_tile3, acc_tile, transpose_B=True, clear_accum=True)
                 for h_i, bi_i in T.Parallel(h_per_block, BI):
                     acc_s[h_i, bi_i] += acc_tile[h_i, bi_i]
-                T.gemm(
-                    q_tail_buf,
-                    k_tail_shared,
-                    acc_s,
-                    transpose_B=True,
-                    policy=T.GemmWarpPolicy.FullCol,
-                )
+                if d_tail > 0:
+                    T.gemm(
+                        q_tail_buf,
+                        k_tail_shared,
+                        acc_s,
+                        transpose_B=True,
+                        policy=T.GemmWarpPolicy.FullCol,
+                    )
 
                 T.copy(m_i, m_i_prev)
                 T.reduce_max(acc_s, m_i, dim=1, clear=False)

--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -117,6 +117,43 @@ def transform_index_page_table_decode_kernel(
 
 
 @triton.jit
+def transform_index_page_table_decode_tiled_kernel(
+    page_table_ptr: torch.Tensor,
+    topk_indices_ptr: torch.Tensor,
+    result_ptr: torch.Tensor,
+    page_table_row_stride: tl.constexpr,
+    topk_indices_stride_0: tl.constexpr,
+    topk_indices_stride_1: tl.constexpr,
+    result_stride_0: tl.constexpr,
+    result_stride_1: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_TOPK: tl.constexpr,
+):
+    req_id = tl.program_id(0)
+    topk_offsets = tl.program_id(1) * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
+    mask = topk_offsets < TOPK
+
+    loaded_topk_indices = tl.load(
+        topk_indices_ptr
+        + req_id * topk_indices_stride_0
+        + topk_offsets * topk_indices_stride_1,
+        mask=mask,
+        other=-1,
+    )
+    valid_topk_mask = mask & (loaded_topk_indices >= 0)
+    loaded_kv_indices = tl.load(
+        page_table_ptr + req_id * page_table_row_stride + loaded_topk_indices,
+        mask=valid_topk_mask,
+        other=-1,
+    )
+    tl.store(
+        result_ptr + req_id * result_stride_0 + topk_offsets * result_stride_1,
+        loaded_kv_indices,
+        mask=mask,
+    )
+
+
+@triton.jit
 def transform_index_page_table_prefill_kernel(
     page_table_ptr: torch.Tensor,
     topk_indices_ptr: torch.Tensor,
@@ -191,19 +228,38 @@ def transform_index_page_table_decode_fast(
     """
     assert page_size == 1
     assert page_table.shape[0] == topk_indices.shape[0]
-    assert topk_indices.shape[1] == 2048
     qo_len = topk_indices.shape[0]
     if result is None:
         result = torch.empty_like(topk_indices, dtype=torch.int32)
-    # Launch triton kernel
-    grid = (qo_len,)
-    transform_index_page_table_decode_kernel[grid](
-        page_table,
-        topk_indices,
-        result,
-        page_size,
-        page_table_row_stride=page_table.stride(0),
-    )
+    topk = topk_indices.shape[1]
+    if topk == 2048:
+        # Preserve the existing single-program fast path for the standard DSA
+        # width. KPool can append a live partial-pool tail, which is handled by
+        # the generic tiled path below without changing this common path.
+        transform_index_page_table_decode_kernel[(qo_len,)](
+            page_table,
+            topk_indices,
+            result,
+            page_size,
+            page_table_row_stride=page_table.stride(0),
+        )
+    else:
+        block_topk = 256
+        transform_index_page_table_decode_tiled_kernel[
+            (qo_len, triton.cdiv(topk, block_topk))
+        ](
+            page_table,
+            topk_indices,
+            result,
+            page_table.stride(0),
+            topk_indices.stride(0),
+            topk_indices.stride(1),
+            result.stride(0),
+            result.stride(1),
+            TOPK=topk,
+            BLOCK_TOPK=block_topk,
+            num_warps=4,
+        )
     return result
 
 
@@ -217,7 +273,6 @@ def transform_index_page_table_prefill_fast(
     cu_seqlens_q: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     assert page_size == 1
-    assert topk_indices.shape[1] == 2048
     real_num_tokens = sum(extend_lens_cpu)
     result = _allocate_prefill_result(topk_indices, real_num_tokens, output_num_tokens)
     if real_num_tokens == 0:

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -16,9 +16,98 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.utils.common import strict_contiguous
-from sglang.srt.utils import is_hip
+from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
+
+_AITER_MHC_RUNTIME_DISABLED = False
+_AITER_MHC_IMPORT_WARNED = False
+_AITER_MHC_ACTIVE_LOGGED = False
+
+
+def _use_aiter_mhc() -> bool:
+    return (
+        not _AITER_MHC_RUNTIME_DISABLED
+        and is_hip()
+        and is_gfx95_supported()
+        and get_bool_env_var("SGLANG_USE_AITER")
+    )
+
+
+def _try_aiter_mhc_pre(
+    residual: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    norm_weight: torch.Tensor | None,
+    norm_eps: float | None,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor] | None:
+    global _AITER_MHC_RUNTIME_DISABLED, _AITER_MHC_IMPORT_WARNED
+    global _AITER_MHC_ACTIVE_LOGGED
+
+    try:
+        from aiter.ops.mhc import mhc_pre as aiter_mhc_pre
+    except Exception as err:
+        if not _AITER_MHC_IMPORT_WARNED:
+            logger.warning("AITER mHC pre is unavailable, falling back: %s", err)
+            _AITER_MHC_IMPORT_WARNED = True
+        _AITER_MHC_RUNTIME_DISABLED = True
+        return None
+
+    kwargs = {}
+    if norm_weight is not None:
+        kwargs["norm_weight"] = norm_weight
+        kwargs["norm_eps"] = norm_eps if norm_eps is not None else rms_eps
+
+    try:
+        result = aiter_mhc_pre(
+            residual,
+            fn,
+            hc_scale,
+            hc_base,
+            rms_eps,
+            hc_pre_eps,
+            hc_sinkhorn_eps,
+            hc_post_mult_value,
+            sinkhorn_repeat,
+            **kwargs,
+        )
+    except Exception as err:
+        logger.warning("AITER mHC pre failed, disabling fast path: %s", err)
+        _AITER_MHC_RUNTIME_DISABLED = True
+        return None
+
+    if not _AITER_MHC_ACTIVE_LOGGED:
+        logger.info("Using AITER gfx950 mHC pre/post kernels")
+        _AITER_MHC_ACTIVE_LOGGED = True
+    return result
+
+
+def _try_aiter_mhc_post(
+    x: torch.Tensor,
+    residual: torch.Tensor,
+    post_layer_mix: torch.Tensor,
+    comb_res_mix: torch.Tensor,
+) -> torch.Tensor | None:
+    global _AITER_MHC_RUNTIME_DISABLED
+
+    try:
+        from aiter.ops.mhc import mhc_post as aiter_mhc_post
+
+        out = torch.empty_like(residual)
+        aiter_mhc_post(out, x, residual, post_layer_mix, comb_res_mix)
+        return out
+    except Exception as err:
+        logger.warning("AITER mHC post failed, disabling fast path: %s", err)
+        _AITER_MHC_RUNTIME_DISABLED = True
+        return None
+
 
 # This module is imported during model-registry discovery. Do not import the real
 # TileLang package here: it loads native CUDA stubs. The proxy below lets
@@ -1678,6 +1767,24 @@ def _mhc_pre_dispatch(
     Returns (post_mix=(s,n,1), comb_mix=(s,n,n), layer_input=(s,h), norm_fused).
     """
     assert residual.dim() == 3, f"residual must be (s, n, h); got {residual.shape}"
+    if _use_aiter_mhc():
+        result = _try_aiter_mhc_pre(
+            residual=residual,
+            fn=fn,
+            hc_scale=hc_scale,
+            hc_base=hc_base,
+            rms_eps=rms_eps,
+            hc_pre_eps=hc_pre_eps,
+            hc_sinkhorn_eps=hc_sinkhorn_eps,
+            hc_post_mult_value=hc_post_mult_value,
+            sinkhorn_repeat=sinkhorn_repeat,
+            norm_weight=norm_weight,
+            norm_eps=norm_eps,
+        )
+        if result is not None:
+            post_mix, comb_mix, layer_input = result
+            return post_mix, comb_mix, layer_input, norm_weight is not None
+
     if not _use_tilelang_mhc_pre():
         post_mix, comb_mix, layer_input = _mhc_pre_torch(
             residual=residual,
@@ -1717,6 +1824,16 @@ def _mhc_post_dispatch(
 ) -> torch.Tensor:
     assert x.dim() == 2 and residual.dim() == 3
     assert post_layer_mix.dim() == 3 and comb_res_mix.dim() == 3
+    if _use_aiter_mhc():
+        result = _try_aiter_mhc_post(
+            x=x,
+            residual=residual,
+            post_layer_mix=post_layer_mix,
+            comb_res_mix=comb_res_mix,
+        )
+        if result is not None:
+            return result
+
     if not _use_tilelang_mhc_post():
         return _mhc_post_torch(x, residual, post_layer_mix, comb_res_mix)
     return mhc_post(x, residual, post_layer_mix, comb_res_mix)

--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -16,6 +16,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.utils.common import strict_contiguous
+from sglang.srt.utils import is_hip
 
 logger = logging.getLogger(__name__)
 
@@ -115,6 +116,24 @@ pass_configs = {
     tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
     tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
 }
+
+
+def _use_deep_gemm_hc_prenorm() -> bool:
+    if not envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
+        return False
+
+    from sglang.srt.layers.deep_gemm_wrapper.configurer import ENABLE_JIT_DEEPGEMM
+
+    return ENABLE_JIT_DEEPGEMM
+
+
+def _use_tilelang_mhc_pre() -> bool:
+    return envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get() and not is_hip()
+
+
+def _use_tilelang_mhc_post() -> bool:
+    return envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get() and not is_hip()
+
 
 FP8 = "float8_e4m3"
 BF16 = "bfloat16"
@@ -835,7 +854,7 @@ def mhc_pre(
             num_tokens, hidden_size, dtype=torch.bfloat16, device=residual.device
         )
 
-    if envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
+    if _use_deep_gemm_hc_prenorm():
         n_splits = _compute_num_split_for_mhc_pre(num_tokens, hc_hidden_size)
 
         gemm_out_mul = torch.empty(
@@ -1447,7 +1466,7 @@ def mhc_fused_post_pre(
             hidden_size,
         )
 
-        if envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.get():
+        if _use_deep_gemm_hc_prenorm():
             import deep_gemm
 
             deep_gemm.tf32_hc_prenorm_gemm(
@@ -1659,7 +1678,7 @@ def _mhc_pre_dispatch(
     Returns (post_mix=(s,n,1), comb_mix=(s,n,n), layer_input=(s,h), norm_fused).
     """
     assert residual.dim() == 3, f"residual must be (s, n, h); got {residual.shape}"
-    if not envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.get():
+    if not _use_tilelang_mhc_pre():
         post_mix, comb_mix, layer_input = _mhc_pre_torch(
             residual=residual,
             fn=fn,
@@ -1698,7 +1717,7 @@ def _mhc_post_dispatch(
 ) -> torch.Tensor:
     assert x.dim() == 2 and residual.dim() == 3
     assert post_layer_mix.dim() == 3 and comb_res_mix.dim() == 3
-    if not envs.SGLANG_OPT_USE_TILELANG_MHC_POST.get():
+    if not _use_tilelang_mhc_post():
         return _mhc_post_torch(x, residual, post_layer_mix, comb_res_mix)
     return mhc_post(x, residual, post_layer_mix, comb_res_mix)
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer_kpool.py
@@ -30,6 +30,7 @@ if is_npu():
 from sglang.srt.environ import envs
 from sglang.srt.layers import deep_gemm_wrapper
 from sglang.srt.layers.attention.dsa.utils import (
+    aiter_can_use_preshuffle_paged_mqa,
     cp_zigzag_full_plan_rows,
     dsa_use_prefill_cp,
     is_dsa_enable_prefill_cp,
@@ -164,6 +165,39 @@ class IndexerKPool(MultiPlatformOp):
         weights = weights * self.n_heads**-0.5
         weights = weights.unsqueeze(-1) * q_scale * self.softmax_scale
         return weights
+
+    @staticmethod
+    def _fp8_mqa_logits(
+        q_fp8: torch.Tensor,
+        k_fp8: torch.Tensor,
+        k_scale: torch.Tensor,
+        weights: torch.Tensor,
+        starts: torch.Tensor,
+        ends: torch.Tensor,
+        *,
+        clean_logits: bool,
+    ) -> torch.Tensor:
+        if is_hip():
+            from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
+
+            return fp8_mqa_logits(
+                q_fp8,
+                k_fp8,
+                k_scale,
+                weights,
+                starts,
+                ends,
+                clean_logits=clean_logits,
+            )
+
+        return deep_gemm.fp8_mqa_logits(
+            q_fp8,
+            (k_fp8, k_scale),
+            weights,
+            starts,
+            ends,
+            clean_logits=clean_logits,
+        )
 
     @staticmethod
     def _cp_gather_concat(
@@ -831,7 +865,7 @@ class IndexerKPool(MultiPlatformOp):
         if not is_cuda():
             return False
         arch_major, _ = torch.cuda.get_device_capability(q_fp8.device)
-        num_heads = q_fp8.shape[2]
+        num_heads = q_fp8.shape[1]
         return arch_major == 9 and num_heads not in (32, 64)
 
     def _get_topk_paged(
@@ -869,7 +903,6 @@ class IndexerKPool(MultiPlatformOp):
         if n_real < num_q_padded:
             q_fp8 = q_fp8[:n_real]
             weights = weights[:n_real]
-        q_fp8 = q_fp8.unsqueeze(1)  # the next_n dim is 1 now
         assert len(kv_cache_fp8.shape) == 2
         block_kv = 64
         num_heads_kv = 1
@@ -879,7 +912,11 @@ class IndexerKPool(MultiPlatformOp):
         )
         assert len(weights.shape) == 3
         weights = weights.squeeze(2)
-        use_tilelang_paged_mqa = self._should_use_tilelang_paged_mqa_logits(q_fp8)
+        use_aiter_paged_mqa = is_hip()
+        use_tilelang_paged_mqa = (
+            not use_aiter_paged_mqa
+            and self._should_use_tilelang_paged_mqa_logits(q_fp8)
+        )
 
         pool_seqlens, pool_context_lens, pool_block_tables, pool_schedule_metadata = (
             self._get_kpool_decode_metadata(
@@ -887,17 +924,36 @@ class IndexerKPool(MultiPlatformOp):
                 block_tables,
                 seqlens_32,
                 blocksize,
-                build_schedule_metadata=not use_tilelang_paged_mqa,
+                build_schedule_metadata=not (
+                    use_aiter_paged_mqa or use_tilelang_paged_mqa
+                ),
             )
         )
         pool_max_seq_len = pool_block_tables.shape[1] * blocksize
-        if use_tilelang_paged_mqa:
+        if use_aiter_paged_mqa:
+            if not aiter_can_use_preshuffle_paged_mqa():
+                raise RuntimeError(
+                    "ROCm kpool indexer requires the AITER preshuffle paged-MQA kernel"
+                )
+            from sglang.kernels.ops.attention.dsa import aiter_paged_mqa_logits
+
+            logits = aiter_paged_mqa_logits(
+                q_fp8,
+                kv_cache_fp8,
+                weights,
+                pool_seqlens,
+                pool_block_tables,
+                pool_max_seq_len,
+                preshuffle=True,
+                kv_block_size=block_kv,
+            )
+        elif use_tilelang_paged_mqa:
             from sglang.kernels.ops.attention.dsa.tilelang_kernel import (
                 tilelang_fp8_paged_mqa_logits,
             )
 
             logits = tilelang_fp8_paged_mqa_logits(
-                q_fp8,
+                q_fp8.unsqueeze(1),
                 kv_cache_fp8,
                 weights,
                 pool_seqlens,
@@ -908,7 +964,7 @@ class IndexerKPool(MultiPlatformOp):
             )
         else:
             logits = deep_gemm.fp8_paged_mqa_logits(
-                q_fp8,
+                q_fp8.unsqueeze(1),
                 kv_cache_fp8,
                 weights,
                 pool_context_lens,
@@ -1001,9 +1057,10 @@ class IndexerKPool(MultiPlatformOp):
                 scale_out=k_scale,
             )
             k_fp8 = k_u8.view(torch.float8_e4m3fn)
-            logits = deep_gemm.fp8_mqa_logits(
+            logits = self._fp8_mqa_logits(
                 q_fp8[:n_real].contiguous(),
-                (k_fp8.contiguous(), k_scale.contiguous()),
+                k_fp8.contiguous(),
+                k_scale.contiguous(),
                 weights[:n_real].contiguous(),
                 ks_per_q,
                 ke_per_q,
@@ -1115,9 +1172,10 @@ class IndexerKPool(MultiPlatformOp):
             ke = torch.div(tail_tokens, pool_size, rounding_mode="floor").to(
                 torch.int32
             )
-            logits = deep_gemm.fp8_mqa_logits(
+            logits = self._fp8_mqa_logits(
                 q_work,
-                (k_fp8.contiguous(), k_scale.contiguous()),
+                k_fp8.contiguous(),
+                k_scale.contiguous(),
                 weights_work,
                 ks,
                 ke,
@@ -1349,9 +1407,10 @@ class IndexerKPool(MultiPlatformOp):
                     and zero_starts_by_batch[i] is not None
                     else torch.zeros((q_len,), dtype=torch.int32, device=q_fp8.device)
                 )
-                local_logits = deep_gemm.fp8_mqa_logits(
+                local_logits = self._fp8_mqa_logits(
                     q_fp8[q_slice].contiguous(),
-                    (k_fp8.contiguous(), k_scale.contiguous()),
+                    k_fp8.contiguous(),
+                    k_scale.contiguous(),
                     weights[q_slice].contiguous(),
                     row_starts,
                     local_pool_lens,
@@ -1697,7 +1756,7 @@ class IndexerKPool(MultiPlatformOp):
         if weights is None:
             weights = self._get_logits_head_gate(x, q_scale)
 
-        if is_cuda():
+        if is_cuda() or is_hip():
             if (
                 forward_batch.forward_mode.is_decode_or_idle()
                 or forward_batch.forward_mode.is_target_verify()

--- a/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
@@ -636,7 +636,10 @@ def topk_from_pooled_history_logits(
             f"is disabled. Got device={logits.device}, dtype={logits.dtype}."
         )
 
-    if is_hip():
+    # The JIT fused path supports the dedicated 128..512 group-topk kernels on
+    # both CUDA and HIP. Keep the legacy HIP fallback only for the separate
+    # 2048-group AOT path, which is not covered by the JIT implementation.
+    if is_hip() and group_topk == 2048:
         return _topk_from_pooled_history_logits_unfused(
             logits=logits,
             group_lengths=group_lengths,

--- a/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
+++ b/python/sglang/srt/layers/attention/dsa/kpool_fp8_index.py
@@ -4,9 +4,45 @@ import torch
 import triton
 import triton.language as tl
 
+from sglang.srt.layers.attention.dsa.utils import (
+    INDEXER_K_CACHE_PRESHUFFLE_TILE,
+    aiter_can_use_preshuffle_paged_mqa,
+)
+from sglang.srt.utils import is_hip
+
 BLOCK_SIZE_K = 64
 INDEX_HEAD_DIM = 128
 KPOOL_SCORE_DTYPES = (torch.float16, torch.bfloat16, torch.float32)
+
+
+def _preshuffle_tile() -> int:
+    return (
+        INDEXER_K_CACHE_PRESHUFFLE_TILE if aiter_can_use_preshuffle_paged_mqa() else 0
+    )
+
+
+@triton.jit
+def _kpool_cache_k_offsets(
+    page,
+    slot,
+    cols,
+    PAGE_BYTES: tl.constexpr,
+    HEAD_DIM: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
+):
+    if PRESHUFFLE_TILE:
+        token_tile_id = slot // PRESHUFFLE_TILE
+        token_in_tile = slot % PRESHUFFLE_TILE
+        col_tile_id = cols // PRESHUFFLE_TILE
+        col_in_tile = cols % PRESHUFFLE_TILE
+        return (
+            page * PAGE_BYTES
+            + token_tile_id * (PRESHUFFLE_TILE * HEAD_DIM)
+            + col_tile_id * (PRESHUFFLE_TILE * PRESHUFFLE_TILE)
+            + token_in_tile * PRESHUFFLE_TILE
+            + col_in_tile
+        )
+    return page * PAGE_BYTES + slot * HEAD_DIM + cols
 
 
 def kpool_max_closed_pools(num_draft_tokens: int, pool_size: int) -> int:
@@ -68,6 +104,7 @@ def gather_index_k_scale_prefix_into(
         BUF_NUMEL_PER_PAGE=buf.shape[1],
         HEAD_DIM=INDEX_HEAD_DIM,
         S_OFFSET_NBYTES_IN_PAGE=pool.page_size * INDEX_HEAD_DIM,
+        PRESHUFFLE_TILE=_preshuffle_tile(),
         BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
     )
 
@@ -83,6 +120,7 @@ def _gather_index_k_scale_prefix_into_kernel(
     BUF_NUMEL_PER_PAGE: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     token_id = tl.program_id(0)
@@ -92,7 +130,14 @@ def _gather_index_k_scale_prefix_into_kernel(
 
     offs = tl.arange(0, BLOCK_D)
     mask = offs < HEAD_DIM
-    src_k_offsets = page * BUF_NUMEL_PER_PAGE + token_offset_in_page * HEAD_DIM + offs
+    src_k_offsets = _kpool_cache_k_offsets(
+        page,
+        token_offset_in_page,
+        offs,
+        BUF_NUMEL_PER_PAGE,
+        HEAD_DIM,
+        PRESHUFFLE_TILE,
+    )
     dst_k_offsets = token_id * HEAD_DIM + offs
     k = tl.load(buf_u8_ptr + src_k_offsets, mask=mask)
     tl.store(k_out_ptr + dst_k_offsets, k, mask=mask)
@@ -591,6 +636,20 @@ def topk_from_pooled_history_logits(
             f"is disabled. Got device={logits.device}, dtype={logits.dtype}."
         )
 
+    if is_hip():
+        return _topk_from_pooled_history_logits_unfused(
+            logits=logits,
+            group_lengths=group_lengths,
+            pool_size=pool_size,
+            topk=topk,
+            page_table=page_table,
+            topk_offsets=topk_offsets,
+            seq_lens=seq_lens,
+            row_starts=row_starts,
+            out_rows=out_rows,
+            page_table_row_index=page_table_row_index,
+        )
+
     if group_topk in (128, 160, 192, 224, 256, 512):
         from sglang.kernels.ops.moe.kpool_topk_transform import (
             fast_kpool_topk_transform_fused,
@@ -652,6 +711,66 @@ def topk_from_pooled_history_logits(
             pool_lens=group_lengths,
             pool_size=pool_size,
             page_table=page_table,
+            topk_offsets=topk_offsets,
+        )
+    if out_rows is None or out_rows == result.shape[0]:
+        return result
+    padded = torch.full(
+        (out_rows, result.shape[1]), -1, dtype=result.dtype, device=result.device
+    )
+    padded[: result.shape[0]] = result
+    return padded
+
+
+def _topk_from_pooled_history_logits_unfused(
+    logits: torch.Tensor,
+    group_lengths: torch.Tensor,
+    pool_size: int,
+    topk: int,
+    page_table: torch.Tensor | None = None,
+    topk_offsets: torch.Tensor | None = None,
+    seq_lens: torch.Tensor | None = None,
+    row_starts: torch.Tensor | None = None,
+    out_rows: int | None = None,
+    page_table_row_index: torch.Tensor | None = None,
+) -> torch.Tensor:
+    from sglang.srt.layers.attention.dsa.dsa_topk_backend import _topk_unfused
+
+    group_topk = history_group_budget_for_topk(topk, pool_size)
+    selected_groups = _topk_unfused(
+        logits,
+        group_lengths,
+        group_topk,
+        row_starts=row_starts,
+        topk_op=torch.topk,
+        topk_op_kwargs={"dim": -1},
+    )
+    group_valid = selected_groups >= 0
+
+    page_table_for_rows = page_table
+    if page_table_row_index is not None:
+        assert page_table is not None
+        page_table_for_rows = page_table.index_select(
+            0, page_table_row_index.to(dtype=torch.int64, device=page_table.device)
+        )
+
+    expanded = expand_pooled_groups_to_topk(
+        selected_groups.contiguous(),
+        group_valid,
+        topk=topk,
+        pool_size=pool_size,
+        page_table=page_table_for_rows,
+        topk_offsets=topk_offsets,
+    )
+    if seq_lens is None:
+        result = expanded
+    else:
+        result = append_kpool_tail_to_topk(
+            expanded,
+            seq_lens=seq_lens,
+            pool_lens=group_lengths,
+            pool_size=pool_size,
+            page_table=page_table_for_rows,
             topk_offsets=topk_offsets,
         )
     if out_rows is None or out_rows == result.shape[0]:
@@ -747,6 +866,7 @@ def kpool_softmax_rotate_write_cache(
         POOL_SIZE=slot_k.shape[1],
         HEAD_DIM=slot_k.shape[2],
         S_OFFSET_NBYTES_IN_PAGE=pool.page_size * pool.index_head_dim,
+        PRESHUFFLE_TILE=_preshuffle_tile(),
         ROUND_SCALE=round_scale,
         HAS_WRITE_MASK=has_write_mask,
         RETURN_COMPRESSED=return_compressed,
@@ -842,6 +962,7 @@ def kpool_decode_update_and_maybe_write_cache(
         HEAD_DIM=tail_k.shape[2],
         BLOCK_TABLE_COLS=block_tables.shape[1],
         S_OFFSET_NBYTES_IN_PAGE=pool.slots_per_page * pool.index_head_dim,
+        PRESHUFFLE_TILE=_preshuffle_tile(),
         ROUND_SCALE=round_scale,
         BLOCK_D=triton.next_power_of_2(tail_k.shape[2]),
         SLOTS_PER_PAGE=pool.slots_per_page,
@@ -891,6 +1012,7 @@ def _kpool_softmax_rotate_write_cache_kernel(
     POOL_SIZE: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
     ROUND_SCALE: tl.constexpr,
     HAS_WRITE_MASK: tl.constexpr,
     RETURN_COMPRESSED: tl.constexpr,
@@ -966,10 +1088,13 @@ def _kpool_softmax_rotate_write_cache_kernel(
         loc = tl.load(loc_ptr + row, mask=do_write, other=0)
         loc_page_index = loc // PAGE_SIZE
         loc_token_offset_in_page = loc % PAGE_SIZE
-        out_k_offsets = (
-            loc_page_index * BUF_NUMEL_PER_PAGE
-            + loc_token_offset_in_page * HEAD_DIM
-            + offs
+        out_k_offsets = _kpool_cache_k_offsets(
+            loc_page_index,
+            loc_token_offset_in_page,
+            offs,
+            BUF_NUMEL_PER_PAGE,
+            HEAD_DIM,
+            PRESHUFFLE_TILE,
         )
         out_s_offset = (
             loc_page_index * BUF_NUMEL_PER_PAGE // 4
@@ -1019,6 +1144,7 @@ def _kpool_decode_update_and_maybe_write_cache_kernel(
     HEAD_DIM: tl.constexpr,
     BLOCK_TABLE_COLS: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
     ROUND_SCALE: tl.constexpr,
     BLOCK_D: tl.constexpr,
     SLOTS_PER_PAGE: tl.constexpr,
@@ -1131,10 +1257,13 @@ def _kpool_decode_update_and_maybe_write_cache_kernel(
         )
         loc_page_index = packed_page.to(tl.int64)
         loc_token_offset_in_page = pool_id % SLOTS_PER_PAGE
-        out_k_offsets = (
-            loc_page_index * BUF_NUMEL_PER_PAGE
-            + loc_token_offset_in_page * HEAD_DIM
-            + offs
+        out_k_offsets = _kpool_cache_k_offsets(
+            loc_page_index,
+            loc_token_offset_in_page,
+            offs,
+            BUF_NUMEL_PER_PAGE,
+            HEAD_DIM,
+            PRESHUFFLE_TILE,
         )
         out_s_offset = (
             loc_page_index * BUF_NUMEL_PER_PAGE // 4
@@ -1194,6 +1323,7 @@ def _kpool_assemble_softmax_rotate_write_cache_kernel(
     TAIL_SIZE: tl.constexpr,
     HEAD_DIM: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
     ROUND_SCALE: tl.constexpr,
     HAS_WRITE_MASK: tl.constexpr,
     BLOCK_D: tl.constexpr,
@@ -1241,8 +1371,13 @@ def _kpool_assemble_softmax_rotate_write_cache_kernel(
     loc = tl.load(loc_ptr + row)
     loc_page_index = loc // SLOTS_PER_PAGE
     loc_token_offset_in_page = loc % SLOTS_PER_PAGE
-    out_k_offsets = (
-        loc_page_index * BUF_NUMEL_PER_PAGE + loc_token_offset_in_page * HEAD_DIM + offs
+    out_k_offsets = _kpool_cache_k_offsets(
+        loc_page_index,
+        loc_token_offset_in_page,
+        offs,
+        BUF_NUMEL_PER_PAGE,
+        HEAD_DIM,
+        PRESHUFFLE_TILE,
     )
     out_s_offset = (
         loc_page_index * BUF_NUMEL_PER_PAGE // 4
@@ -1313,6 +1448,7 @@ def kpool_assemble_softmax_rotate_write_cache(
         TAIL_SIZE=tail_k.shape[1],
         HEAD_DIM=INDEX_HEAD_DIM,
         S_OFFSET_NBYTES_IN_PAGE=slots_per_page * INDEX_HEAD_DIM,
+        PRESHUFFLE_TILE=_preshuffle_tile(),
         ROUND_SCALE=round_scale,
         HAS_WRITE_MASK=has_write_mask,
         BLOCK_D=triton.next_power_of_2(INDEX_HEAD_DIM),
@@ -1410,6 +1546,7 @@ def _pack_pool_slots_to_payload_kernel(
     head_dim: tl.constexpr,
     page_bytes: tl.constexpr,
     scale_region_off: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     row = tl.program_id(0)
@@ -1420,7 +1557,14 @@ def _pack_pool_slots_to_payload_kernel(
 
     offs = tl.arange(0, BLOCK_D)
     mask = offs < head_dim
-    src = page_base + slot * head_dim + offs
+    src = _kpool_cache_k_offsets(
+        page,
+        slot,
+        offs,
+        page_bytes,
+        head_dim,
+        PRESHUFFLE_TILE,
+    )
     val = tl.load(buf_ptr + src, mask=mask, other=0).to(tl.uint8)
     tl.store(payload_ptr + row * payload_bytes + offs, val, mask=mask)
 
@@ -1443,6 +1587,7 @@ def _select_and_scatter_pool_slots_kernel(
     page_bytes: tl.constexpr,
     scale_region_off: tl.constexpr,
     n_total: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
     row = tl.program_id(0)
@@ -1459,7 +1604,14 @@ def _select_and_scatter_pool_slots_kernel(
     offs = tl.arange(0, BLOCK_D)
     mask = offs < head_dim
     val = tl.load(recv_ptr + recv_row_base + offs, mask=mask, other=0).to(tl.uint8)
-    dst = page_base + slot * head_dim + offs
+    dst = _kpool_cache_k_offsets(
+        page,
+        slot,
+        offs,
+        page_bytes,
+        head_dim,
+        PRESHUFFLE_TILE,
+    )
     tl.store(buf_ptr + dst, val, mask=mask)
 
     s_offs = tl.arange(0, 4)
@@ -1501,6 +1653,7 @@ def all_gather_and_scatter_pool_slots(
         head_dim=head_dim,
         page_bytes=page_bytes,
         scale_region_off=scale_region_off,
+        PRESHUFFLE_TILE=_preshuffle_tile(),
         BLOCK_D=triton.next_power_of_2(head_dim),
     )
 
@@ -1523,6 +1676,7 @@ def all_gather_and_scatter_pool_slots(
         page_bytes=page_bytes,
         scale_region_off=scale_region_off,
         n_total=n_total,
+        PRESHUFFLE_TILE=_preshuffle_tile(),
         BLOCK_D=triton.next_power_of_2(head_dim),
     )
 
@@ -1556,6 +1710,7 @@ def _kpool_write_tail_and_maybe_compress_kernel(
     SLOTS_PER_PAGE: tl.constexpr,
     BUF_NUMEL_PER_PAGE: tl.constexpr,
     S_OFFSET_NBYTES_IN_PAGE: tl.constexpr,
+    PRESHUFFLE_TILE: tl.constexpr,
     ROUND_SCALE: tl.constexpr,
     HAS_EFFECTIVE_N: tl.constexpr,
     MAX_CLOSED_POOLS: tl.constexpr,
@@ -1620,10 +1775,13 @@ def _kpool_write_tail_and_maybe_compress_kernel(
             loc = tl.load(write_loc_ptr + b * write_loc_stride_0 + p)
             loc_page_index = loc // SLOTS_PER_PAGE
             loc_token_offset_in_page = loc % SLOTS_PER_PAGE
-            out_k_offsets = (
-                loc_page_index * BUF_NUMEL_PER_PAGE
-                + loc_token_offset_in_page * HEAD_DIM
-                + offs
+            out_k_offsets = _kpool_cache_k_offsets(
+                loc_page_index,
+                loc_token_offset_in_page,
+                offs,
+                BUF_NUMEL_PER_PAGE,
+                HEAD_DIM,
+                PRESHUFFLE_TILE,
             )
             out_s_offset = (
                 loc_page_index * BUF_NUMEL_PER_PAGE // 4
@@ -1714,6 +1872,7 @@ def kpool_write_tail_and_maybe_compress(
         SLOTS_PER_PAGE=slots_per_page,
         BUF_NUMEL_PER_PAGE=buf.shape[1],
         S_OFFSET_NBYTES_IN_PAGE=slots_per_page * pool.index_head_dim,
+        PRESHUFFLE_TILE=_preshuffle_tile(),
         ROUND_SCALE=round_scale,
         HAS_EFFECTIVE_N=effective_n_per_batch is not None,
         MAX_CLOSED_POOLS=max_closed_pools,

--- a/python/sglang/srt/layers/communicator_mhc.py
+++ b/python/sglang/srt/layers/communicator_mhc.py
@@ -86,6 +86,7 @@ class MHCState:
     hc_attn_pre: Callable
     hc_ffn_pre: Callable
     hc_post: Callable
+    hc_attn_to_mlp: Optional[Callable] = None
     h_res: Optional[torch.Tensor] = None
     h_post: Optional[torch.Tensor] = None
 
@@ -108,9 +109,34 @@ class MHCState:
     def attn_to_mlp(
         self, hidden_states, residual, out_norm: Optional[torch.nn.Module] = None
     ):
+        out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
+        if self.hc_attn_to_mlp is not None:
+            fused = self.hc_attn_to_mlp(
+                hidden_states,
+                residual,
+                self.h_res,
+                self.h_post,
+                out_norm_weight,
+                out_norm_eps,
+            )
+            if fused is not None:
+                (
+                    hidden_states,
+                    residual,
+                    self.h_res,
+                    self.h_post,
+                    norm_fused,
+                ) = fused
+                if (
+                    out_norm is not None
+                    and not norm_fused
+                    and hidden_states.shape[0] != 0
+                ):
+                    hidden_states = out_norm(hidden_states)
+                return hidden_states, residual
+
         hidden_states = self.hc_post(hidden_states, residual, self.h_res, self.h_post)
         residual = hidden_states
-        out_norm_weight, out_norm_eps = self._resolve_out_norm(out_norm)
         hidden_states, self.h_res, self.h_post, norm_fused = self.hc_ffn_pre(
             hidden_states, out_norm_weight, out_norm_eps
         )
@@ -412,6 +438,7 @@ class MHCLayerCommunicator(LayerCommunicator):
         hc_attn_pre: Callable,
         hc_ffn_pre: Callable,
         hc_post: Callable,
+        hc_attn_to_mlp: Optional[Callable] = None,
     ):
         self.is_first_layer = is_first_layer
         self.mhc = MHCState(
@@ -419,6 +446,7 @@ class MHCLayerCommunicator(LayerCommunicator):
             hc_attn_pre=hc_attn_pre,
             hc_ffn_pre=hc_ffn_pre,
             hc_post=hc_post,
+            hc_attn_to_mlp=hc_attn_to_mlp,
         )
 
         super().__init__(

--- a/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
+++ b/python/sglang/srt/layers/moe/moe_runner/triton_utils/fused_moe.py
@@ -96,6 +96,12 @@ padding_size = get_moe_padding_size(_use_aiter)
 logger = logging.getLogger(__name__)
 
 
+def _clamp_swiglu_inputs_(x: torch.Tensor, limit: float) -> None:
+    half = x.shape[-1] // 2
+    x[..., :half].clamp_(max=limit)
+    x[..., half:].clamp_(min=-limit, max=limit)
+
+
 def _use_moe_sum_reduce_torch_compile(num_tokens: int) -> bool:
     return num_tokens <= 32 and not is_batch_invariant_mode_enabled()
 
@@ -690,6 +696,10 @@ def _fused_moe_kernel_sequence(
 
             if filter_expert:
                 swiglu_limit_for_triton = swiglu_limit
+            elif _is_hip:
+                # The fused clamp kernel is CUDA/XPU-only; apply its gate/up
+                # contract before the regular HIP silu_and_mul kernel.
+                _clamp_swiglu_inputs_(intermediate_cache1, swiglu_limit)
             else:
                 assert (
                     _is_cuda or _is_xpu

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1574,8 +1574,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 layer.w13_input_scale = None
                 layer.w2_input_scale = None
             runner_is_aiter = (
-                getattr(self, "runner", None) is not None
-                and self.runner.runner_backend.is_aiter()
+                self._owns_moe_runner and self.runner.runner_backend.is_aiter()
             )
             if _use_aiter and runner_is_aiter:
                 layer.w13_weight.data = shuffle_weight(
@@ -1615,14 +1614,21 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 w2_weight_scale, requires_grad=False
             )
             layer.w2_input_scale = None
-            if _use_aiter:
+            runner_is_aiter = (
+                self._owns_moe_runner and self.runner.runner_backend.is_aiter()
+            )
+            if _use_aiter and runner_is_aiter:
                 layer.w13_weight.data = shuffle_weight(
                     layer.w13_weight.contiguous(), (16, 16)
                 )
                 layer.w2_weight.data = shuffle_weight(
                     layer.w2_weight.contiguous(), (16, 16)
                 )
-        elif _use_aiter:
+        elif (
+            _use_aiter
+            and self._owns_moe_runner
+            and self.runner.runner_backend.is_aiter()
+        ):
             # Pre-shuffle weights
             t = shuffle_weight(layer.w13_weight, (16, 16))
             layer.w13_weight.copy_(t)

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -15,7 +15,11 @@ from sglang.srt.layers.quantization.base_config import (  # noqa: E501
     QuantizationConfig,
     QuantizeMethodBase,
 )
-from sglang.srt.layers.quantization.fp8 import Fp8Config, Fp8LinearMethod
+from sglang.srt.layers.quantization.fp8 import (
+    Fp8Config,
+    Fp8LinearMethod,
+    Fp8MoEMethod,
+)
 from sglang.srt.layers.quantization.kv_cache import BaseKVCacheMethod
 from sglang.srt.layers.quantization.quark.schemes import (
     QuarkLinearScheme,
@@ -376,9 +380,59 @@ class QuarkConfig(QuantizationConfig):
                 expanded.append(name.removeprefix("language_model."))
         self.exclude_layers = list(dict.fromkeys(expanded))
 
+        layer_quant_config = self.quant_config.get("layer_quant_config")
+        if layer_quant_config:
+            self.quant_config["layer_quant_config"] = hf_to_sglang_mapper.apply_dict(
+                layer_quant_config
+            )
+
+        if self.kv_cache_group:
+            self.kv_cache_group = hf_to_sglang_mapper.apply_list(self.kv_cache_group)
+
+    @staticmethod
+    def _get_block_fp8_config(
+        layer_quant_config: Optional[dict[str, Any]],
+        packed_modules_mapping: dict[str, list[str]],
+    ) -> Optional[Fp8Config]:
+        if layer_quant_config is None:
+            return None
+
+        weight_config = layer_quant_config.get("weight") or {}
+        input_config = layer_quant_config.get("input_tensors") or {}
+        block_size = weight_config.get("block_size")
+        if not (
+            weight_config.get("dtype") in {"fp8_e4m3", "fp8_e4m3fn"}
+            and weight_config.get("qscheme") == "per_block"
+            and weight_config.get("is_dynamic") is False
+            and isinstance(block_size, list)
+            and len(block_size) == 2
+            and input_config.get("dtype") in {"fp8_e4m3", "fp8_e4m3fn"}
+            and input_config.get("is_dynamic") is True
+        ):
+            return None
+
+        return Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=block_size,
+            packed_modules_mapping=packed_modules_mapping,
+        )
+
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> Optional["QuantizeMethodBase"]:
+        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
+
+        explicit_layer_config = self._find_matched_layer_config(prefix, layer)
+        block_fp8_config = self._get_block_fp8_config(
+            explicit_layer_config, self.packed_modules_mapping
+        )
+        if block_fp8_config is not None:
+            if isinstance(layer, LinearBase):
+                return Fp8LinearMethod(block_fp8_config)
+            if isinstance(layer, FusedMoE):
+                return Fp8MoEMethod(block_fp8_config)
+
         # Check if the layer is skipped for quantization.
         if should_ignore_layer(
             prefix,
@@ -406,8 +460,6 @@ class QuarkConfig(QuantizationConfig):
         if isinstance(layer, RadixAttention):
             self._online_quantized_layers.add(prefix)
             return QuarkKVCacheMethod(self)
-
-        from sglang.srt.layers.moe.fused_moe_triton.layer import FusedMoE
 
         if isinstance(layer, FusedMoE):
             self._online_quantized_layers.add(prefix)
@@ -783,9 +835,9 @@ class QuarkConfig(QuantizationConfig):
         )
         return is_mx_fp4_weight and is_static_fp8_activation
 
-    def _find_matched_config(
+    def _find_matched_layer_config(
         self, layer_name: str, module: torch.nn.Module
-    ) -> dict[str, Any]:
+    ) -> Optional[dict[str, Any]]:
 
         proj_name = layer_name.split(".")[-1]
         if proj_name in self.packed_modules_mapping:
@@ -797,9 +849,17 @@ class QuarkConfig(QuantizationConfig):
                 for shard_proj_name in shard_proj_names
             ]
             shard_configs = [
-                self._find_matched_config(shard_name, module)
+                self._find_matched_layer_config(shard_name, module)
                 for shard_name in shard_names
             ]
+            if all(q_config is None for q_config in shard_configs):
+                return None
+            if any(q_config is None for q_config in shard_configs):
+                raise ValueError(
+                    f"Found a partially specified quantization configuration for "
+                    f"{shard_proj_names} in {layer_name}. SGLang requires all "
+                    "fused shards to use the same scheme."
+                )
             if not all(
                 deep_compare(q_config, shard_configs[0]) for q_config in shard_configs
             ):
@@ -824,10 +884,19 @@ class QuarkConfig(QuantizationConfig):
             if layer_type in layer_type_quant_config:
                 return layer_type_quant_config[layer_type]
 
-            global_quant_config = cast(
-                dict[str, Any], self.quant_config.get("global_quant_config")
-            )
-            return global_quant_config
+            return None
+
+    def _find_matched_config(
+        self, layer_name: str, module: torch.nn.Module
+    ) -> dict[str, Any]:
+        layer_config = self._find_matched_layer_config(layer_name, module)
+        if layer_config is not None:
+            return layer_config
+
+        global_quant_config = cast(
+            dict[str, Any], self.quant_config.get("global_quant_config")
+        )
+        return global_quant_config
 
     def _get_scheme_from_config(self, config: dict[str, Any]) -> "QuarkLinearScheme":
         if config.get("output_tensors") or config.get("bias"):

--- a/python/sglang/srt/layers/quantization/quark/utils.py
+++ b/python/sglang/srt/layers/quantization/quark/utils.py
@@ -55,6 +55,12 @@ def should_ignore_layer(
     # proj_name = qkv_proj
     proj_name = layer_name.split(".")[-1]
 
+    # Some checkpoints serialize an already-fused module (for example a
+    # vision ``qkv`` projection) and list that fused name in ``exclude``.
+    # Honor the direct match before expanding model-level packed mappings.
+    if check_equal_or_regex_match(layer_name=layer_name, targets=ignore):
+        return True
+
     # Fused layers like gate_up_proj or qkv_proj will not be fused
     # in the safetensors checkpoint. So, we convert the name
     # from the fused version to unfused + check to make sure that

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha_rocm.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mha_rocm.py
@@ -269,8 +269,12 @@ class DeepseekMHARocmForwardMixin:
     def _concat_and_cast_mha_k_rocm(
         self: DeepseekV2AttentionMLA,
         k_nope: torch.Tensor,
-        k_pe: torch.Tensor,
+        k_pe: torch.Tensor | None,
     ):
+        if self.qk_rope_head_dim == 0:
+            assert k_pe is None or k_pe.shape[-1] == 0
+            return k_nope.contiguous()
+
         k_shape = (k_nope.shape[0], self.num_local_heads, self.qk_head_dim)
         k = k_nope.new_empty(*k_shape)
         if self.current_attention_backend == "aiter":

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1358,9 +1358,12 @@ class Glm5NextForConditionalGeneration(nn.Module):
         text_config = getattr(hf_config, "text_config", hf_config)
         if not getattr(text_config, "n_shared_experts", None):
             return "No shared experts are defined in the config."
-        if not _is_cuda:
-            return "Shared experts fusion currently requires CUDA devices."
-        if _device_sm is not None and _device_sm < 80:
+        if not (_is_cuda or _use_aiter_gfx95):
+            return (
+                "Shared experts fusion requires CUDA or the supported "
+                "AITER ROCm path."
+            )
+        if _is_cuda and _device_sm is not None and _device_sm < 80:
             return "Shared experts fusion requires SM80 or newer GPUs."
         if get_parallel().moe_ep_size > 1:
             return (

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -135,6 +135,7 @@ if _use_aiter_gfx95:
     )
 
 logger = logging.getLogger(__name__)
+_GLM_AITER_FUSED_MHC_LOGGED = False
 
 
 @torch.compile
@@ -759,6 +760,7 @@ class Glm5NextDecoderLayer(nn.Module):
                 hc_attn_pre=self.hc_attn_pre,
                 hc_ffn_pre=self.hc_ffn_pre,
                 hc_post=self.hc_post,
+                hc_attn_to_mlp=(self.hc_attn_to_mlp if _use_aiter_gfx95 else None),
             )
             if self.dsa_enable_prefill_cp:
                 self.layer_communicator = MHCHybridDSACPLayerCommunicator(
@@ -823,6 +825,58 @@ class Glm5NextDecoderLayer(nn.Module):
             h_post=h_post,
             h_res=h_res,
             hc_mult=self.config.hc_mult,
+        )
+
+    def hc_attn_to_mlp(
+        self,
+        hidden_states,
+        residual,
+        h_res,
+        h_post,
+        out_norm_weight,
+        out_norm_eps,
+    ):
+        """Fuse attention mHC post with FFN mHC pre on AITER gfx95."""
+        global _GLM_AITER_FUSED_MHC_LOGGED
+
+        from sglang.srt.models.deepseek_common.amd.deepseek_v4_fused_mhc import (
+            apply_mhc_post_pre_boundary,
+        )
+
+        num_tokens, hidden_size = hidden_states.shape
+        if num_tokens == 0:
+            return None
+        hc_mult = self.config.hc_mult
+        fused = apply_mhc_post_pre_boundary(
+            layer_input=hidden_states,
+            residual=residual.view(num_tokens, hc_mult, hidden_size),
+            post=h_post.view(num_tokens, hc_mult),
+            comb=h_res.view(num_tokens, hc_mult, hc_mult),
+            hc_fn=self.hc_ffn_fn,
+            hc_scale=self.hc_ffn_scale,
+            hc_base=self.hc_ffn_base,
+            hc_mult=hc_mult,
+            rms_eps=self.config.rms_norm_eps,
+            hc_eps=self.config.hc_eps,
+            hc_post_mult=2.0,
+            sinkhorn_iters=self.config.hc_sinkhorn_iters,
+            norm_weight=out_norm_weight,
+            norm_eps=out_norm_eps,
+            fn_transpose=True,
+        )
+        if fused is None:
+            return None
+        if not _GLM_AITER_FUSED_MHC_LOGGED:
+            logger.info("Using fused AITER mHC attention-to-FFN boundary")
+            _GLM_AITER_FUSED_MHC_LOGGED = True
+
+        next_residual, layer_input, next_h_post, next_h_res, norm_fused = fused
+        return (
+            layer_input,
+            next_residual.view(num_tokens, -1),
+            next_h_res.reshape(num_tokens, hc_mult * hc_mult),
+            next_h_post.reshape(num_tokens, hc_mult),
+            norm_fused,
         )
 
     def _is_layer_sparse(self, layer_id: int, is_nextn: bool) -> bool:

--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -112,6 +112,7 @@ from sglang.srt.models.glm_ocr import (
     GlmOcrVisionPatchEmbed,
     GlmOcrVisionPatchMerger,
 )
+from sglang.srt.models.utils import WeightsMapper
 from sglang.srt.multimodal.mm_utils import (
     run_dp_presharded_mrope_vision_model,
     run_dp_sharded_mrope_vision_model,
@@ -1201,6 +1202,13 @@ class Glm5NextModel(nn.Module):
 
 
 class Glm5NextForConditionalGeneration(nn.Module):
+    hf_to_sglang_mapper = WeightsMapper(
+        orig_to_new_prefix={
+            "model.language_model.": "model.",
+            "model.visual.": "visual.",
+        },
+        orig_to_new_suffix={".attn.qkv": ".attn.qkv_proj"},
+    )
     packed_modules_mapping = {
         "fused_qkv_a_proj_with_mqa": ["q_a_proj", "kv_a_proj_with_mqa"],
         "fused_qkvbfg_a_proj": [
@@ -1607,6 +1615,14 @@ class Glm5NextForConditionalGeneration(nn.Module):
             fused_cat_dim = 0
 
         params_dict = dict(self.named_parameters())
+
+        def maybe_map_fp8_block_scale_name(name: str) -> str:
+            if name.endswith(".weight_scale"):
+                candidate = name.removesuffix(".weight_scale") + ".weight_scale_inv"
+                if candidate in params_dict:
+                    return candidate
+            return name
+
         weight_names = []
         for name, loaded_weight in weights:
             is_visual_weight = "visual" in name
@@ -1670,6 +1686,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                 if "mlp.experts" in name:
                     continue
                 candidate = name.replace(weight_name, param_name)
+                candidate = maybe_map_fp8_block_scale_name(candidate)
                 if (
                     param_name
                     in {
@@ -1698,6 +1715,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                         continue
                     is_expert_weight = True
                     name = name.replace(weight_name, param_name)
+                    name = maybe_map_fp8_block_scale_name(name)
                     if name not in params_dict:
                         continue
                     param = params_dict[name]
@@ -1749,6 +1767,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                                     "fused_qkv_a_proj_with_mqa",
                                 )
                             )
+                            target = maybe_map_fp8_block_scale_name(target)
                             if target in params_dict:
                                 param = params_dict[target]
                                 weight_loader = getattr(
@@ -1759,6 +1778,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
                             cached_a_proj.pop(kv_a_proj_name, None)
                         continue
 
+                    name = maybe_map_fp8_block_scale_name(name)
                     if name not in params_dict:
                         continue
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -84,6 +84,7 @@ from sglang.srt.utils.common import (
     is_cpu,
     is_cuda,
     is_flashinfer_available,
+    is_gfx95_supported,
     is_hip,
     is_hopper_with_cuda_12_3,
     is_host_cpu_arm64,
@@ -1898,7 +1899,7 @@ class ServerArgs:
     dsa_topk_backend: A[
         str,
         Arg(
-            help="DSA indexer top-k backend for the target model. Options: 'sgl-kernel', 'torch', 'flashinfer'. The 'torch' backend currently requires SGLANG_DSA_FUSE_TOPK=false.",
+            help="DSA indexer top-k backend for the target model. Options: 'sgl-kernel', 'torch', 'flashinfer'. On non-gfx95 ROCm GPUs, 'sgl-kernel' falls back to the portable 'torch' backend with fused top-k disabled. The 'torch' backend otherwise requires SGLANG_DSA_FUSE_TOPK=false.",
             choices=DSA_TOPK_BACKEND_CHOICES,
         ),
         NS("exec.kernel"),
@@ -5655,6 +5656,23 @@ class ServerArgs:
 
         run_post_process_pass(self, _dsa_split_backend_resolution)
 
+    def _handle_rocm_dsa_topk_compatibility(self) -> None:
+        if not is_hip() or is_gfx95_supported():
+            return
+
+        cfg = resolving_view(self)
+        if cfg.dsa_topk_backend != "sgl-kernel":
+            return
+
+        # The fused SGL transform requires gfx95 on ROCm. Torch returns raw
+        # indices, so it must use the unfused PAGED/RAGGED transform path.
+        envs.SGLANG_DSA_FUSE_TOPK.set(False)
+        self._declare("_handle_rocm_dsa_topk_compatibility", dsa_topk_backend="torch")
+        logger.warning(
+            "Use the portable Torch DSA top-k backend with fused top-k disabled "
+            "on non-gfx95 ROCm GPUs."
+        )
+
     def _validate_hisparse_dsa_backend(self, attr: str, label: str):
         from sglang.srt.arg_groups.hisparse_hook import validate_hisparse_dsa_backend
 
@@ -5919,6 +5937,7 @@ class ServerArgs:
                     # here for the rest of the DSA family (DeepSeek-V3.2 /
                     # GLM-5.x) that shares the same decode top-k path.
                     envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+                    self._handle_rocm_dsa_topk_compatibility()
                 if not self._resolved().enable_dp_attention and cfg.nnodes == 1:
                     # TODO (Hubert): Put this back later
                     # self.enable_aiter_allreduce_fusion = True

--- a/test/registered/kernels/ops/attention/test_dsa_transform_index.py
+++ b/test/registered/kernels/ops/attention/test_dsa_transform_index.py
@@ -33,9 +33,11 @@ class TestDSATransformIndex(CustomTestCase):
         )
         return columns.unsqueeze(0) + row_bias
 
-    def _make_topk(self, rows: int, context_length: int) -> torch.Tensor:
+    def _make_topk(
+        self, rows: int, context_length: int, topk: int = TOPK
+    ) -> torch.Tensor:
         topk = (
-            torch.arange(TOPK, dtype=torch.int64, device=self.device)
+            torch.arange(topk, dtype=torch.int64, device=self.device)
             .remainder(context_length)
             .repeat(rows, 1)
         )
@@ -55,7 +57,7 @@ class TestDSATransformIndex(CustomTestCase):
     ) -> torch.Tensor:
         real_num_tokens = sum(extend_lens_cpu)
         expected = torch.full(
-            (output_num_tokens, TOPK),
+            (output_num_tokens, topk_indices.shape[1]),
             -1,
             dtype=torch.int32,
             device=self.device,
@@ -91,14 +93,15 @@ class TestDSATransformIndex(CustomTestCase):
         *,
         zero_row_stride: bool = False,
         provide_result: bool = False,
+        topk: int = TOPK,
     ) -> None:
         if zero_row_stride:
             page_table = self._make_page_table(1, context_length).expand(batch_size, -1)
         else:
             page_table = self._make_page_table(batch_size, context_length)
-        topk_indices = self._make_topk(batch_size, context_length)
+        topk_indices = self._make_topk(batch_size, context_length, topk)
         expected = torch.empty(
-            (batch_size, TOPK), dtype=torch.int32, device=self.device
+            (batch_size, topk), dtype=torch.int32, device=self.device
         )
         torch.gather(
             page_table,
@@ -127,6 +130,7 @@ class TestDSATransformIndex(CustomTestCase):
         page_table_is_expanded: bool,
         topk_padding: int = 0,
         output_padding: int = 0,
+        topk: int = TOPK,
     ) -> None:
         real_num_tokens = sum(extend_lens_cpu)
         page_table_rows = (
@@ -135,7 +139,7 @@ class TestDSATransformIndex(CustomTestCase):
         topk_num_tokens = real_num_tokens + topk_padding
         output_num_tokens = topk_num_tokens + output_padding
         page_table = self._make_page_table(page_table_rows, context_length)
-        topk_indices = self._make_topk(topk_num_tokens, context_length)
+        topk_indices = self._make_topk(topk_num_tokens, context_length, topk)
         expected = self._expected(
             page_table,
             topk_indices,
@@ -234,6 +238,16 @@ class TestDSATransformIndex(CustomTestCase):
     def test_decode_fast_extreme_shapes(self):
         self._check_decode_case(8192, 4096)
         self._check_decode_case(2, 1_000_000)
+
+    def test_kpool_tail_extended_width(self):
+        kpool_topk = TOPK + 15
+        self._check_decode_case(17, 8192, topk=kpool_topk)
+        self._check_case(
+            [2, 1],
+            8192,
+            page_table_is_expanded=False,
+            topk=kpool_topk,
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/test_dsa_kpool_multi_pool.py
+++ b/test/registered/kernels/test_dsa_kpool_multi_pool.py
@@ -1,32 +1,44 @@
-"""CUDA regressions for DSA kpool speculative writes spanning multiple pools."""
+"""GPU regressions for DSA kpool speculative writes and cache layout."""
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
+from sglang.kernels.ops.attention.dsa import aiter_paged_mqa_logits
+from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
+from sglang.srt.layers.attention.dsa import kpool_fp8_index
 from sglang.srt.layers.attention.dsa.kpool_fp8_index import (
     INDEX_HEAD_DIM,
+    gather_index_k_scale_prefix_into,
     kpool_assemble_softmax_rotate_write_cache,
     kpool_max_closed_pools,
+    kpool_softmax_rotate_write_cache,
     kpool_write_tail_and_maybe_compress,
     update_kpool_write_plan_cuda_graph,
 )
 from sglang.srt.layers.attention.dsa.kpool_plan import (
     _alloc_kpool_write_plan_buffers,
 )
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.srt.layers.attention.dsa.utils import (
+    aiter_can_use_preshuffle_paged_mqa,
+)
+from sglang.srt.utils import is_hip
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=15, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_amd_ci(est_time=20, stage="jit-kernel-unit", runner_config="amd")
 
 
-@unittest.skipUnless(torch.cuda.is_available(), "Test requires CUDA")
+@unittest.skipUnless(torch.cuda.is_available(), "Test requires a GPU")
 class TestDsaKpoolMultiPool(CustomTestCase):
     POOL_SIZE = 4
     PAGE_SIZE = 64
     SLOTS_PER_PAGE = 64
     NUM_DRAFT_TOKENS = 6
+    NUM_INDEX_HEADS = 32
 
     def _pool(self) -> SimpleNamespace:
         return SimpleNamespace(
@@ -207,6 +219,202 @@ class TestDsaKpoolMultiPool(CustomTestCase):
 
     def test_effective_n_only_compresses_accepted_pools(self):
         self._run_compress_case(effective_n=2, expected_closed_pools=1)
+
+    def test_preshuffled_cache_round_trip_and_raw_layout(self):
+        torch.manual_seed(43)
+        pool = self._pool()
+        num_slots = self.SLOTS_PER_PAGE
+        tile = 16
+        num_col_tiles = INDEX_HEAD_DIM // tile
+
+        slot_k = torch.randn(
+            num_slots,
+            self.POOL_SIZE,
+            INDEX_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device="cuda",
+        )
+        slot_score = torch.zeros_like(slot_k)
+        ape = torch.zeros(
+            self.POOL_SIZE,
+            INDEX_HEAD_DIM,
+            dtype=torch.float32,
+            device="cuda",
+        )
+        loc = torch.arange(num_slots, dtype=torch.int64, device="cuda")
+        cache = self._empty_cache()
+
+        with patch.object(kpool_fp8_index, "_preshuffle_tile", return_value=tile):
+            compressed_k, compressed_scale = kpool_softmax_rotate_write_cache(
+                pool=pool,
+                buf=cache,
+                slot_k=slot_k,
+                slot_score=slot_score,
+                ape=ape,
+                loc=loc,
+                return_compressed=True,
+            )
+
+            gathered_k = torch.empty(
+                (num_slots, INDEX_HEAD_DIM), dtype=torch.uint8, device="cuda"
+            )
+            gathered_scale = torch.empty(
+                (num_slots,), dtype=torch.float32, device="cuda"
+            )
+            gather_index_k_scale_prefix_into(
+                pool=pool,
+                buf=cache,
+                page_indices=torch.zeros(1, dtype=torch.int32, device="cuda"),
+                seq_len=num_slots,
+                k_out=gathered_k,
+                scale_out=gathered_scale,
+            )
+
+        compressed_k_u8 = compressed_k.view(torch.uint8)
+        torch.testing.assert_close(gathered_k, compressed_k_u8, atol=0, rtol=0)
+        torch.testing.assert_close(gathered_scale, compressed_scale, atol=0, rtol=0)
+
+        raw_k = cache[0, : num_slots * INDEX_HEAD_DIM].view(
+            num_slots // tile, num_col_tiles, tile, tile
+        )
+        expected_raw_k = (
+            compressed_k_u8.view(num_slots // tile, tile, num_col_tiles, tile)
+            .permute(0, 2, 1, 3)
+            .contiguous()
+        )
+        torch.testing.assert_close(raw_k, expected_raw_k, atol=0, rtol=0)
+
+    @unittest.skipUnless(
+        is_hip() and aiter_can_use_preshuffle_paged_mqa(),
+        "requires the ROCm AITER preshuffle paged-MQA path",
+    )
+    def test_preshuffled_paged_mqa_matches_gathered_mqa(self):
+        from aiter.ops.triton.fp8_mqa_logits import fp8_mqa_logits
+
+        torch.manual_seed(44)
+        pool = self._pool()
+        page_nbytes = self.SLOTS_PER_PAGE * (INDEX_HEAD_DIM + 4)
+        tile = 16
+        num_token_tiles = self.SLOTS_PER_PAGE // tile
+        num_col_tiles = INDEX_HEAD_DIM // tile
+
+        for batch_size in (1, 8):
+            with self.subTest(batch_size=batch_size):
+                cache = torch.zeros(
+                    (batch_size, page_nbytes), dtype=torch.uint8, device="cuda"
+                )
+                k = (
+                    torch.randn(
+                        batch_size,
+                        self.SLOTS_PER_PAGE,
+                        INDEX_HEAD_DIM,
+                        device="cuda",
+                    )
+                    * 2
+                ).to(fp8_dtype)
+                k_scale = (
+                    torch.rand(batch_size, self.SLOTS_PER_PAGE, device="cuda") + 0.25
+                )
+
+                preshuffled = (
+                    k.view(
+                        batch_size,
+                        num_token_tiles,
+                        tile,
+                        num_col_tiles,
+                        tile,
+                    )
+                    .permute(0, 1, 3, 2, 4)
+                    .contiguous()
+                    .view(batch_size, -1)
+                    .view(torch.uint8)
+                )
+                k_region_bytes = self.SLOTS_PER_PAGE * INDEX_HEAD_DIM
+                cache[:, :k_region_bytes].copy_(preshuffled)
+                cache[:, k_region_bytes:].view(torch.float32).copy_(k_scale)
+
+                q = (
+                    torch.randn(
+                        batch_size,
+                        self.NUM_INDEX_HEADS,
+                        INDEX_HEAD_DIM,
+                        device="cuda",
+                    )
+                    * 2
+                ).to(fp8_dtype)
+                weights = torch.randn(
+                    batch_size,
+                    self.NUM_INDEX_HEADS,
+                    dtype=torch.float32,
+                    device="cuda",
+                )
+                if batch_size == 1:
+                    seq_lens = torch.tensor([53], dtype=torch.int32, device="cuda")
+                else:
+                    seq_lens = torch.tensor(
+                        [1, 7, 16, 31, 32, 47, 63, 64],
+                        dtype=torch.int32,
+                        device="cuda",
+                    )
+                block_tables = torch.arange(
+                    batch_size, dtype=torch.int32, device="cuda"
+                ).view(batch_size, 1)
+
+                paged_logits = aiter_paged_mqa_logits(
+                    q,
+                    cache.view(batch_size, self.SLOTS_PER_PAGE, 1, INDEX_HEAD_DIM + 4),
+                    weights,
+                    seq_lens,
+                    block_tables,
+                    self.SLOTS_PER_PAGE,
+                    preshuffle=True,
+                    kv_block_size=self.SLOTS_PER_PAGE,
+                )
+
+                gathered_k = []
+                gathered_scale = []
+                for batch_idx, seq_len in enumerate(seq_lens.tolist()):
+                    k_out = torch.empty(
+                        (seq_len, INDEX_HEAD_DIM), dtype=torch.uint8, device="cuda"
+                    )
+                    scale_out = torch.empty(
+                        (seq_len,), dtype=torch.float32, device="cuda"
+                    )
+                    gather_index_k_scale_prefix_into(
+                        pool=pool,
+                        buf=cache,
+                        page_indices=torch.tensor(
+                            [batch_idx], dtype=torch.int32, device="cuda"
+                        ),
+                        seq_len=seq_len,
+                        k_out=k_out,
+                        scale_out=scale_out,
+                    )
+                    gathered_k.append(k_out.view(fp8_dtype))
+                    gathered_scale.append(scale_out)
+
+                flat_k = torch.cat(gathered_k)
+                flat_scale = torch.cat(gathered_scale)
+                ends = seq_lens.cumsum(0)
+                starts = ends - seq_lens
+                gathered_logits = fp8_mqa_logits(
+                    q,
+                    flat_k,
+                    flat_scale,
+                    weights,
+                    starts,
+                    ends,
+                    clean_logits=True,
+                )
+
+                for batch_idx, seq_len in enumerate(seq_lens.tolist()):
+                    start = starts[batch_idx].item()
+                    torch.testing.assert_close(
+                        paged_logits[batch_idx, :seq_len],
+                        gathered_logits[batch_idx, start : start + seq_len],
+                        atol=2e-2,
+                        rtol=2e-2,
+                    )
 
 
 if __name__ == "__main__":

--- a/test/registered/kernels/test_dsa_kpool_multi_pool.py
+++ b/test/registered/kernels/test_dsa_kpool_multi_pool.py
@@ -11,11 +11,13 @@ from sglang.kernels.ops.quantization.fp8_kernel import fp8_dtype
 from sglang.srt.layers.attention.dsa import kpool_fp8_index
 from sglang.srt.layers.attention.dsa.kpool_fp8_index import (
     INDEX_HEAD_DIM,
+    _topk_from_pooled_history_logits_unfused,
     gather_index_k_scale_prefix_into,
     kpool_assemble_softmax_rotate_write_cache,
     kpool_max_closed_pools,
     kpool_softmax_rotate_write_cache,
     kpool_write_tail_and_maybe_compress,
+    topk_from_pooled_history_logits,
     update_kpool_write_plan_cuda_graph,
 )
 from sglang.srt.layers.attention.dsa.kpool_plan import (
@@ -53,6 +55,47 @@ class TestDsaKpoolMultiPool(CustomTestCase):
     def _empty_cache(self) -> torch.Tensor:
         page_nbytes = self.SLOTS_PER_PAGE * INDEX_HEAD_DIM + self.SLOTS_PER_PAGE * 4
         return torch.zeros((1, page_nbytes), dtype=torch.uint8, device="cuda")
+
+    def test_fused_topk_matches_unfused_physical_token_sets(self):
+        torch.manual_seed(45)
+        batch_size = 2
+        score_cols = 4096
+        pool_size = self.POOL_SIZE
+        topk = 2048
+        logits = torch.randn(batch_size, score_cols, dtype=torch.float32, device="cuda")
+        group_lengths = torch.tensor([256, 511], dtype=torch.int32, device="cuda")
+        seq_lens = group_lengths * pool_size + torch.tensor(
+            [0, 3], dtype=torch.int32, device="cuda"
+        )
+        page_table = torch.arange(
+            batch_size * score_cols * pool_size,
+            dtype=torch.int32,
+            device="cuda",
+        ).view(batch_size, score_cols * pool_size)
+
+        actual = topk_from_pooled_history_logits(
+            logits=logits,
+            group_lengths=group_lengths,
+            pool_size=pool_size,
+            topk=topk,
+            page_table=page_table,
+            seq_lens=seq_lens,
+        )
+        expected = _topk_from_pooled_history_logits_unfused(
+            logits=logits,
+            group_lengths=group_lengths,
+            pool_size=pool_size,
+            topk=topk,
+            page_table=page_table,
+            seq_lens=seq_lens,
+        )
+
+        torch.testing.assert_close(
+            torch.sort(actual, dim=1).values,
+            torch.sort(expected, dim=1).values,
+            atol=0,
+            rtol=0,
+        )
 
     def test_write_plan_records_every_candidate_pool(self):
         batch_size = 2

--- a/test/registered/unit/layers/moe/test_fused_moe_swiglu_clamp.py
+++ b/test/registered/unit/layers/moe/test_fused_moe_swiglu_clamp.py
@@ -1,0 +1,38 @@
+import unittest
+
+import torch
+import torch.nn.functional as F
+
+from sglang.srt.layers.moe.moe_runner.triton_utils.fused_moe import (
+    _clamp_swiglu_inputs_,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestFusedMoeSwigluClamp(CustomTestCase):
+    def test_clamps_gate_and_up_with_the_deepseek_contract(self):
+        inputs = torch.tensor([[-20.0, 20.0, -20.0, 20.0], [3.0, 11.0, -4.0, 5.0]])
+
+        _clamp_swiglu_inputs_(inputs, limit=10.0)
+
+        torch.testing.assert_close(
+            inputs,
+            torch.tensor([[-20.0, 10.0, -10.0, 10.0], [3.0, 10.0, -4.0, 5.0]]),
+        )
+
+    def test_clamped_inputs_match_reference_swiglu(self):
+        inputs = torch.tensor([[-12.0, 14.0, -13.0, 15.0]])
+
+        _clamp_swiglu_inputs_(inputs, limit=10.0)
+        output = F.silu(inputs[..., :2]) * inputs[..., 2:]
+
+        expected_gate = torch.tensor([[-12.0, 10.0]])
+        expected_up = torch.tensor([[-10.0, 10.0]])
+        torch.testing.assert_close(output, F.silu(expected_gate) * expected_up)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_fp8_moe_runner_ownership.py
+++ b/test/registered/unit/layers/quantization/test_fp8_moe_runner_ownership.py
@@ -1,10 +1,9 @@
 """Unit tests for srt/layers/quantization/fp8.py MoE runner ownership.
 
-`--moe-runner-backend flashinfer_trtllm[_routed]` is a global setting, so
-`Fp8MoEMethod.process_weights_after_loading` must also require that this
-instance owns a MoeRunner before materializing the TRT-LLM SwiGLU params:
-the MxFP4 wrapper methods borrow an `Fp8MoEMethod` for weight loading only
-and never give it a `moe_runner_config` (issue #36264).
+MoE backend flags are global, so `Fp8MoEMethod.process_weights_after_loading`
+must require that this instance owns a MoeRunner before materializing
+backend-specific parameters or layouts. MxFP4 wrappers borrow an `Fp8MoEMethod`
+for weight loading without giving it a runner (issue #36264).
 """
 
 import unittest
@@ -112,6 +111,81 @@ class TestFp8MoERunnerOwnership(CustomTestCase):
         self._run_post_load(method=method, layer=layer)
 
         self._assert_activation_params_absent(layer)
+
+    def test_global_aiter_does_not_shuffle_triton_runner_weights(self):
+        """SGLANG_USE_AITER also enables non-MoE kernels, so the selected MoE
+        runner must own the preshuffled layout before weights are rewritten."""
+        method = self._make_block_fp8_method()
+        method.convert_mxfp8_to_block = True
+        method.use_mxfp8 = True
+        method.runner = SimpleNamespace(runner_backend=MoeRunnerBackend.TRITON)
+        method._owns_moe_runner = True
+        layer = SimpleNamespace(
+            w13_weight=torch.nn.Parameter(torch.arange(16.0).reshape(1, 4, 4)),
+            w2_weight=torch.nn.Parameter(torch.arange(16.0).reshape(1, 4, 4)),
+        )
+
+        with (
+            patch("sglang.srt.layers.quantization.fp8._use_aiter", True),
+            patch("sglang.srt.layers.quantization.fp8._is_fp8_fnuz", False),
+            patch.object(method, "_convert_mxfp8_moe_to_block_fp8"),
+            patch("sglang.srt.layers.quantization.fp8.shuffle_weight") as shuffle,
+        ):
+            method.process_weights_after_loading_block_quant(layer)
+
+        shuffle.assert_not_called()
+
+    def test_borrowed_delegate_skips_aiter_weight_shuffle(self):
+        """MxFP4 delegates do not own a runner, so global AITER enablement must
+        not make weight loading dereference or prepare an absent runner."""
+        method = self._make_block_fp8_method()
+        method.convert_mxfp8_to_block = True
+        method.use_mxfp8 = True
+        layer = SimpleNamespace(
+            w13_weight=torch.nn.Parameter(torch.arange(16.0).reshape(1, 4, 4)),
+            w2_weight=torch.nn.Parameter(torch.arange(16.0).reshape(1, 4, 4)),
+        )
+
+        with (
+            patch("sglang.srt.layers.quantization.fp8._use_aiter", True),
+            patch("sglang.srt.layers.quantization.fp8._is_fp8_fnuz", False),
+            patch.object(method, "_convert_mxfp8_moe_to_block_fp8"),
+            patch("sglang.srt.layers.quantization.fp8.shuffle_weight") as shuffle,
+        ):
+            method.process_weights_after_loading_block_quant(layer)
+
+        shuffle.assert_not_called()
+
+    def test_aiter_runner_keeps_preshuffled_weight_layout(self):
+        method = self._make_block_fp8_method()
+        method.convert_mxfp8_to_block = True
+        method.use_mxfp8 = True
+        method.runner = SimpleNamespace(runner_backend=MoeRunnerBackend.AITER)
+        method._owns_moe_runner = True
+        original_w13 = torch.arange(16.0).reshape(1, 4, 4)
+        original_w2 = torch.arange(16.0, 32.0).reshape(1, 4, 4)
+        layer = SimpleNamespace(
+            w13_weight=torch.nn.Parameter(original_w13.clone()),
+            w2_weight=torch.nn.Parameter(original_w2.clone()),
+        )
+
+        def add_one(weight, _tile):
+            return weight + 1
+
+        with (
+            patch("sglang.srt.layers.quantization.fp8._use_aiter", True),
+            patch("sglang.srt.layers.quantization.fp8._is_fp8_fnuz", False),
+            patch.object(method, "_convert_mxfp8_moe_to_block_fp8"),
+            patch(
+                "sglang.srt.layers.quantization.fp8.shuffle_weight",
+                side_effect=add_one,
+            ) as shuffle,
+        ):
+            method.process_weights_after_loading_block_quant(layer)
+
+        self.assertEqual(shuffle.call_count, 2)
+        torch.testing.assert_close(layer.w13_weight, original_w13 + 1)
+        torch.testing.assert_close(layer.w2_weight, original_w2 + 1)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/quantization/test_quark_config.py
+++ b/test/registered/unit/layers/quantization/test_quark_config.py
@@ -5,10 +5,13 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import unittest
+from copy import deepcopy
 from unittest.mock import patch
 
 import torch
 
+from sglang.srt.layers.linear import LinearBase
+from sglang.srt.layers.quantization.fp8 import Fp8LinearMethod
 from sglang.srt.layers.quantization.quark.quark import (
     QuarkConfig,
     _build_mixed_precision_layer_quant_config,
@@ -16,6 +19,7 @@ from sglang.srt.layers.quantization.quark.quark import (
     _parse_nvfp4_excludes,
 )
 from sglang.srt.layers.quantization.quark.utils import check_equal_or_regex_match
+from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
 from sglang.test.test_utils import CustomTestCase
 
 _GET_CAP = "sglang.srt.layers.quantization.quark.quark.get_device_capability"
@@ -205,6 +209,116 @@ class TestParseNvfp4Excludes(CustomTestCase):
         self.assertFalse(
             check_equal_or_regex_match("model.layers.0.mlp.experts", excludes)
         )
+
+
+class TestQuarkPerLayerBlockFp8(CustomTestCase):
+    _BLOCK_FP8_CONFIG = {
+        "weight": {
+            "dtype": "fp8_e4m3",
+            "qscheme": "per_block",
+            "block_size": [128, 128],
+            "is_dynamic": False,
+        },
+        "input_tensors": {
+            "dtype": "fp8_e4m3",
+            "qscheme": "per_group",
+            "group_size": 128,
+            "is_dynamic": True,
+        },
+        "output_tensors": None,
+        "bias": None,
+    }
+
+    def _build_bare_config(self) -> QuarkConfig:
+        config = _bare_config()
+        config.quant_config = {
+            "layer_quant_config": {
+                "model.language_model.layers.0.mlp.down_proj": self._BLOCK_FP8_CONFIG
+            },
+            "layer_type_quant_config": {},
+            "global_quant_config": {
+                "weight": {
+                    "dtype": "fp4",
+                    "qscheme": "per_group",
+                    "group_size": 32,
+                    "is_dynamic": False,
+                    "scale_format": "e8m0",
+                },
+                "input_tensors": {
+                    "dtype": "fp4",
+                    "qscheme": "per_group",
+                    "group_size": 32,
+                    "is_dynamic": True,
+                    "scale_format": "e8m0",
+                },
+            },
+        }
+        config.exclude_layers = []
+        config.kv_cache_group = []
+        config.packed_modules_mapping = {}
+        config.excluded_fp8_config = None
+        config._online_quantized_layers = set()
+        return config
+
+    def test_model_mapper_rewrites_explicit_layer_config(self):
+        config = self._build_bare_config()
+
+        config.apply_weight_name_mapper(
+            Glm5NextForConditionalGeneration.hf_to_sglang_mapper
+        )
+
+        self.assertIn(
+            "model.layers.0.mlp.down_proj",
+            config.quant_config["layer_quant_config"],
+        )
+
+    def test_model_mapper_rewrites_fused_visual_exclusion(self):
+        config = self._build_bare_config()
+        config.exclude_layers = ["model.visual.blocks.0.attn.qkv"]
+
+        config.apply_weight_name_mapper(
+            Glm5NextForConditionalGeneration.hf_to_sglang_mapper
+        )
+
+        self.assertEqual(
+            config.exclude_layers,
+            ["visual.blocks.0.attn.qkv_proj"],
+        )
+        self.assertNotIn(
+            "model.language_model.layers.0.mlp.down_proj",
+            config.quant_config["layer_quant_config"],
+        )
+
+    def test_explicit_block_fp8_linear_uses_fp8_method(self):
+        config = self._build_bare_config()
+        config.apply_weight_name_mapper(
+            Glm5NextForConditionalGeneration.hf_to_sglang_mapper
+        )
+        layer = LinearBase.__new__(LinearBase)
+
+        method = config.get_quant_method(layer, "model.layers.0.mlp.down_proj")
+
+        self.assertIsInstance(method, Fp8LinearMethod)
+        self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
+        self.assertEqual(method.quant_config.weight_block_size, [128, 128])
+
+    def test_dynamic_block_fp8_weight_is_not_treated_as_serialized(self):
+        layer_config = deepcopy(self._BLOCK_FP8_CONFIG)
+        layer_config["weight"]["is_dynamic"] = True
+
+        self.assertIsNone(QuarkConfig._get_block_fp8_config(layer_config, {}))
+
+    def test_unmatched_layer_still_uses_global_quark_config(self):
+        config = self._build_bare_config()
+        config.apply_weight_name_mapper(
+            Glm5NextForConditionalGeneration.hf_to_sglang_mapper
+        )
+
+        matched = config._find_matched_config(
+            "model.layers.4.mlp.down_proj", torch.nn.Module()
+        )
+
+        self.assertEqual(matched["weight"]["dtype"], "fp4")
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/quantization/test_quark_utils.py
+++ b/test/registered/unit/layers/quantization/test_quark_utils.py
@@ -8,7 +8,10 @@ import unittest
 
 import torch
 
-from sglang.srt.layers.quantization.quark.utils import e8m0_to_f32
+from sglang.srt.layers.quantization.quark.utils import (
+    e8m0_to_f32,
+    should_ignore_layer,
+)
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -64,6 +67,17 @@ class TestE8M0ToF32(CustomTestCase):
         self.assertEqual(out[0].item(), 1.0)
         self.assertEqual(out[1].item(), 128.0)
         self.assertTrue(torch.isnan(out[2]).item())
+
+
+class TestShouldIgnoreLayer(CustomTestCase):
+    def test_direct_fused_module_exclusion_takes_precedence(self):
+        self.assertTrue(
+            should_ignore_layer(
+                "visual.blocks.0.attn.qkv_proj",
+                ["visual.blocks.0.attn.qkv_proj"],
+                {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+            )
+        )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_dsa_indexer_kpool_backend.py
+++ b/test/registered/unit/layers/test_dsa_indexer_kpool_backend.py
@@ -1,0 +1,102 @@
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.attention.dsa import dsa_indexer_kpool
+from sglang.srt.layers.attention.dsa.kpool_fp8_index import (
+    _topk_from_pooled_history_logits_unfused,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestKPoolMqaBackend(CustomTestCase):
+    def test_cuda_tilelang_selector_reads_heads_from_unexpanded_query(self):
+        with (
+            patch.object(dsa_indexer_kpool, "is_cuda", return_value=True),
+            patch("torch.cuda.get_device_capability", return_value=(9, 0)),
+        ):
+            self.assertFalse(
+                dsa_indexer_kpool.IndexerKPool._should_use_tilelang_paged_mqa_logits(
+                    torch.empty(1, 32, 128)
+                )
+            )
+            self.assertTrue(
+                dsa_indexer_kpool.IndexerKPool._should_use_tilelang_paged_mqa_logits(
+                    torch.empty(1, 16, 128)
+                )
+            )
+
+    def test_rocm_uses_aiter_mqa_logits(self):
+        marker = object()
+        aiter_impl = MagicMock(return_value=marker)
+        module = ModuleType("aiter.ops.triton.fp8_mqa_logits")
+        module.fp8_mqa_logits = aiter_impl
+
+        args = tuple(object() for _ in range(6))
+        with (
+            patch.object(dsa_indexer_kpool, "is_hip", return_value=True),
+            patch.dict(
+                sys.modules,
+                {"aiter.ops.triton.fp8_mqa_logits": module},
+            ),
+        ):
+            result = dsa_indexer_kpool.IndexerKPool._fp8_mqa_logits(
+                *args, clean_logits=False
+            )
+
+        self.assertIs(result, marker)
+        aiter_impl.assert_called_once_with(*args, clean_logits=False)
+
+    def test_cuda_keeps_deep_gemm_mqa_logits(self):
+        marker = object()
+        deep_gemm = MagicMock()
+        deep_gemm.fp8_mqa_logits.return_value = marker
+        q_fp8, k_fp8, k_scale, weights, starts, ends = (object() for _ in range(6))
+
+        with (
+            patch.object(dsa_indexer_kpool, "is_hip", return_value=False),
+            patch.object(dsa_indexer_kpool, "deep_gemm", deep_gemm, create=True),
+        ):
+            result = dsa_indexer_kpool.IndexerKPool._fp8_mqa_logits(
+                q_fp8,
+                k_fp8,
+                k_scale,
+                weights,
+                starts,
+                ends,
+                clean_logits=True,
+            )
+
+        self.assertIs(result, marker)
+        deep_gemm.fp8_mqa_logits.assert_called_once_with(
+            q_fp8,
+            (k_fp8, k_scale),
+            weights,
+            starts,
+            ends,
+            clean_logits=True,
+        )
+
+    def test_portable_topk_masks_invalid_groups_and_expands(self):
+        logits = torch.tensor([[0.1, 0.9, 0.8, 50.0]], dtype=torch.float32)
+        result = _topk_from_pooled_history_logits_unfused(
+            logits=logits,
+            group_lengths=torch.tensor([3], dtype=torch.int32),
+            pool_size=2,
+            topk=4,
+        )
+
+        torch.testing.assert_close(
+            result,
+            torch.tensor([[2, 3, 4, 5]], dtype=torch.int32),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/test_dsa_indexer_kpool_backend.py
+++ b/test/registered/unit/layers/test_dsa_indexer_kpool_backend.py
@@ -8,6 +8,7 @@ import torch
 from sglang.srt.layers.attention.dsa import dsa_indexer_kpool
 from sglang.srt.layers.attention.dsa.kpool_fp8_index import (
     _topk_from_pooled_history_logits_unfused,
+    topk_from_pooled_history_logits,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -96,6 +97,99 @@ class TestKPoolMqaBackend(CustomTestCase):
             result,
             torch.tensor([[2, 3, 4, 5]], dtype=torch.int32),
         )
+
+    def test_rocm_uses_fused_kpool_topk_for_supported_group_count(self):
+        logits = MagicMock()
+        logits.ndim = 2
+        logits.shape = (1, 512)
+        logits.is_cuda = True
+        logits.dtype = torch.float32
+        group_lengths = torch.tensor([256], dtype=torch.int32)
+        marker = MagicMock()
+        marker.shape = (1, 2048)
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.dsa.kpool_fp8_index.is_hip",
+                return_value=True,
+            ),
+            patch(
+                "sglang.kernels.ops.moe.kpool_topk_transform.fast_kpool_topk_transform_fused",
+                return_value=marker,
+            ) as fused,
+            patch(
+                "sglang.srt.layers.attention.dsa.kpool_fp8_index._topk_from_pooled_history_logits_unfused"
+            ) as unfused,
+        ):
+            result = topk_from_pooled_history_logits(
+                logits=logits,
+                group_lengths=group_lengths,
+                pool_size=4,
+                topk=2048,
+            )
+
+        self.assertIs(result, marker)
+        fused.assert_called_once()
+        unfused.assert_not_called()
+
+    def test_rocm_keeps_2048_group_topk_on_unfused_path(self):
+        logits = MagicMock()
+        logits.ndim = 2
+        logits.shape = (1, 2048)
+        logits.is_cuda = True
+        logits.dtype = torch.float32
+        group_lengths = torch.tensor([2048], dtype=torch.int32)
+        marker = object()
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.dsa.kpool_fp8_index.is_hip",
+                return_value=True,
+            ),
+            patch(
+                "sglang.srt.layers.attention.dsa.kpool_fp8_index._topk_from_pooled_history_logits_unfused",
+                return_value=marker,
+            ) as unfused,
+        ):
+            result = topk_from_pooled_history_logits(
+                logits=logits,
+                group_lengths=group_lengths,
+                pool_size=4,
+                topk=8192,
+            )
+
+        self.assertIs(result, marker)
+        unfused.assert_called_once()
+
+    def test_cuda_keeps_supported_group_count_on_fused_path(self):
+        logits = MagicMock()
+        logits.ndim = 2
+        logits.shape = (1, 512)
+        logits.is_cuda = True
+        logits.dtype = torch.float32
+        group_lengths = torch.tensor([256], dtype=torch.int32)
+        marker = MagicMock()
+        marker.shape = (1, 2048)
+
+        with (
+            patch(
+                "sglang.srt.layers.attention.dsa.kpool_fp8_index.is_hip",
+                return_value=False,
+            ),
+            patch(
+                "sglang.kernels.ops.moe.kpool_topk_transform.fast_kpool_topk_transform_fused",
+                return_value=marker,
+            ) as fused,
+        ):
+            result = topk_from_pooled_history_logits(
+                logits=logits,
+                group_lengths=group_lengths,
+                pool_size=4,
+                topk=2048,
+            )
+
+        self.assertIs(result, marker)
+        fused.assert_called_once()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_mhc_deep_gemm_gate.py
+++ b/test/registered/unit/layers/test_mhc_deep_gemm_gate.py
@@ -1,0 +1,89 @@
+import unittest
+from unittest.mock import patch
+
+from sglang.kernels.ops.layernorm import mhc
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestMhcDeepGemmGate(CustomTestCase):
+    def test_falls_back_when_deep_gemm_is_unavailable(self):
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.override(True),
+            patch(
+                "sglang.srt.layers.deep_gemm_wrapper.configurer.ENABLE_JIT_DEEPGEMM",
+                False,
+            ),
+        ):
+            self.assertFalse(mhc._use_deep_gemm_hc_prenorm())
+
+    def test_preserves_deep_gemm_path_when_available(self):
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.override(True),
+            patch(
+                "sglang.srt.layers.deep_gemm_wrapper.configurer.ENABLE_JIT_DEEPGEMM",
+                True,
+            ),
+        ):
+            self.assertTrue(mhc._use_deep_gemm_hc_prenorm())
+
+    def test_explicit_disable_takes_precedence(self):
+        with (
+            envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.override(False),
+            patch(
+                "sglang.srt.layers.deep_gemm_wrapper.configurer.ENABLE_JIT_DEEPGEMM",
+                True,
+            ),
+        ):
+            self.assertFalse(mhc._use_deep_gemm_hc_prenorm())
+
+
+class TestMhcTilelangBackendGate(CustomTestCase):
+    def test_cuda_keeps_env_selected_tilelang_pre_path(self):
+        with (
+            envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.override(True),
+            patch.object(mhc, "is_hip", return_value=False),
+        ):
+            self.assertTrue(mhc._use_tilelang_mhc_pre())
+
+    def test_hip_always_uses_torch_pre_path(self):
+        with (
+            envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.override(True),
+            patch.object(mhc, "is_hip", return_value=True),
+        ):
+            self.assertFalse(mhc._use_tilelang_mhc_pre())
+
+    def test_explicit_tilelang_pre_disable_takes_precedence(self):
+        with (
+            envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.override(False),
+            patch.object(mhc, "is_hip", return_value=False),
+        ):
+            self.assertFalse(mhc._use_tilelang_mhc_pre())
+
+    def test_cuda_keeps_env_selected_tilelang_post_path(self):
+        with (
+            envs.SGLANG_OPT_USE_TILELANG_MHC_POST.override(True),
+            patch.object(mhc, "is_hip", return_value=False),
+        ):
+            self.assertTrue(mhc._use_tilelang_mhc_post())
+
+    def test_hip_always_uses_torch_post_path(self):
+        with (
+            envs.SGLANG_OPT_USE_TILELANG_MHC_POST.override(True),
+            patch.object(mhc, "is_hip", return_value=True),
+        ):
+            self.assertFalse(mhc._use_tilelang_mhc_post())
+
+    def test_explicit_tilelang_post_disable_takes_precedence(self):
+        with (
+            envs.SGLANG_OPT_USE_TILELANG_MHC_POST.override(False),
+            patch.object(mhc, "is_hip", return_value=False),
+        ):
+            self.assertFalse(mhc._use_tilelang_mhc_post())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_glm5_next_hybrid_pool.py
+++ b/test/registered/unit/mem_cache/test_glm5_next_hybrid_pool.py
@@ -1,0 +1,121 @@
+"""Regression coverage for GLM-5.3's hybrid DSA/KDA KV pool."""
+
+import sys
+import unittest
+from types import ModuleType, SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestGlm5NextHybridPool(CustomTestCase):
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.HybridLinearKVPool",
+        autospec=True,
+    )
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.calculate_mla_kv_cache_dim",
+        autospec=True,
+        return_value=576,
+    )
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.get_dsa_index_kpool_compress",
+        return_value=True,
+    )
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.get_dsa_index_kpool",
+        return_value=1,
+    )
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.get_dsa_index_head_dim",
+        return_value=128,
+    )
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.dsa_layer_skips_topk",
+        return_value=False,
+    )
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.is_deepseek_dsa",
+        return_value=True,
+    )
+    def test_dsa_kv_dimension_uses_current_calculator_contract(
+        self,
+        _mock_is_deepseek_dsa,
+        _mock_dsa_layer_skips_topk,
+        _mock_index_head_dim,
+        _mock_index_kpool,
+        _mock_index_kpool_compress,
+        mock_calculate_mla_kv_cache_dim,
+        mock_hybrid_pool,
+    ):
+        from sglang.srt.mem_cache.kv_cache_configurator import KVCacheConfigurator
+
+        configurator = object.__new__(KVCacheConfigurator)
+        configurator.is_draft_worker = False
+        configurator.mambaish_config = SimpleNamespace(full_attention_layer_ids=[3])
+        configurator.layer_info = SimpleNamespace(start_layer=0, end_layer=4)
+        configurator.use_mla_backend = True
+        configurator.model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(),
+            kv_lora_rank=512,
+            qk_rope_head_dim=64,
+            head_dim=128,
+            get_num_kv_heads=lambda _tp_size, _dcp_size: 1,
+        )
+        configurator.kv_cache_dtype = torch.bfloat16
+        configurator.kv_cache_dtype_str = "bfloat16"
+        configurator.device = "cuda"
+        configurator.post_capture_kv_active = False
+
+        req_to_token_pool = SimpleNamespace(mamba_pool=object())
+        fake_cp_utils = ModuleType("sglang.srt.layers.cp.utils")
+        fake_cp_utils.get_glm_dsa_cp_layer_shard_info = lambda _configurator: (0, 1)
+        with (
+            patch.dict(
+                sys.modules,
+                {"sglang.srt.layers.cp.utils": fake_cp_utils},
+            ),
+            patch.object(
+                KVCacheConfigurator,
+                "_build_fp4_quant_method",
+                return_value=None,
+            ),
+            patch(
+                "sglang.srt.mem_cache.kv_cache_configurator.get_parallel",
+                return_value=SimpleNamespace(attn_tp_size=8, attn_dcp_size=1),
+            ),
+            patch(
+                "sglang.srt.mem_cache.kv_cache_configurator.get_exec",
+                return_value=SimpleNamespace(
+                    features=SimpleNamespace(enable_memory_saver=False)
+                ),
+            ),
+            patch(
+                "sglang.srt.mem_cache.kv_cache_configurator.get_schedule",
+                return_value=SimpleNamespace(page_size=64),
+            ),
+            patch(
+                "sglang.srt.mem_cache.kv_cache_configurator.get_spec",
+                return_value=SimpleNamespace(speculative_algorithm=None),
+            ),
+        ):
+            configurator._build_hybrid_linear_kv_pool(
+                max_total_num_tokens=1024,
+                req_to_token_pool=req_to_token_pool,
+                mha_pool_class=object,
+            )
+
+        mock_calculate_mla_kv_cache_dim.assert_called_once_with(
+            model_config=configurator.model_config,
+            kv_cache_dtype=torch.bfloat16,
+        )
+        self.assertEqual(mock_hybrid_pool.call_args.kwargs["kv_cache_dim"], 576)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_glm5_next_aiter_mhc.py
+++ b/test/registered/unit/models/test_glm5_next_aiter_mhc.py
@@ -1,0 +1,238 @@
+import sys
+from types import ModuleType, SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+from torch import nn
+
+from sglang.kernels.ops.layernorm import mhc
+from sglang.srt.layers.communicator_mhc import MHCState
+from sglang.srt.models import glm5_next
+from sglang.srt.models.glm5_next import Glm5NextDecoderLayer
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=6, suite="base-a-test-cpu")
+
+
+def _fake_aiter_mhc_module(*, mhc_pre=None, mhc_post=None):
+    aiter_module = ModuleType("aiter")
+    ops_module = ModuleType("aiter.ops")
+    mhc_module = ModuleType("aiter.ops.mhc")
+    if mhc_pre is not None:
+        mhc_module.mhc_pre = mhc_pre
+    if mhc_post is not None:
+        mhc_module.mhc_post = mhc_post
+    aiter_module.ops = ops_module
+    ops_module.mhc = mhc_module
+    return {
+        "aiter": aiter_module,
+        "aiter.ops": ops_module,
+        "aiter.ops.mhc": mhc_module,
+    }
+
+
+def test_aiter_mhc_gate_is_rocm_gfx95_only():
+    with (
+        patch.object(mhc, "is_hip", return_value=True),
+        patch.object(mhc, "is_gfx95_supported", return_value=True),
+        patch.object(mhc, "get_bool_env_var", return_value=True),
+        patch.object(mhc, "_AITER_MHC_RUNTIME_DISABLED", False),
+    ):
+        assert mhc._use_aiter_mhc()
+
+    for is_hip, is_gfx95, use_aiter in (
+        (False, True, True),
+        (True, False, True),
+        (True, True, False),
+    ):
+        with (
+            patch.object(mhc, "is_hip", return_value=is_hip),
+            patch.object(mhc, "is_gfx95_supported", return_value=is_gfx95),
+            patch.object(mhc, "get_bool_env_var", return_value=use_aiter),
+            patch.object(mhc, "_AITER_MHC_RUNTIME_DISABLED", False),
+        ):
+            assert not mhc._use_aiter_mhc()
+
+
+def test_aiter_mhc_pre_dispatch_forwards_norm_contract():
+    residual = torch.randn(2, 4, 8)
+    fn = torch.randn(24, 32)
+    hc_scale = torch.randn(3)
+    hc_base = torch.randn(24)
+    norm_weight = torch.randn(8)
+    expected = (
+        torch.randn(2, 4, 1),
+        torch.randn(2, 4, 4),
+        torch.randn(2, 8),
+    )
+    fake_pre = MagicMock(return_value=expected)
+
+    with (
+        patch.dict(sys.modules, _fake_aiter_mhc_module(mhc_pre=fake_pre)),
+        patch.object(mhc, "_use_aiter_mhc", return_value=True),
+        patch.object(mhc, "_AITER_MHC_ACTIVE_LOGGED", False),
+    ):
+        actual = mhc._mhc_pre_dispatch(
+            residual=residual,
+            fn=fn,
+            hc_scale=hc_scale,
+            hc_base=hc_base,
+            rms_eps=1e-6,
+            hc_pre_eps=1e-5,
+            hc_sinkhorn_eps=1e-5,
+            hc_post_mult_value=2.0,
+            sinkhorn_repeat=20,
+            norm_weight=norm_weight,
+            norm_eps=1e-4,
+        )
+
+    assert actual[0] is expected[0]
+    assert actual[1] is expected[1]
+    assert actual[2] is expected[2]
+    assert actual[3] is True
+    fake_pre.assert_called_once_with(
+        residual,
+        fn,
+        hc_scale,
+        hc_base,
+        1e-6,
+        1e-5,
+        1e-5,
+        2.0,
+        20,
+        norm_weight=norm_weight,
+        norm_eps=1e-4,
+    )
+
+
+def test_aiter_mhc_post_dispatch_uses_preallocated_output():
+    x = torch.randn(2, 8)
+    residual = torch.randn(2, 4, 8)
+    post = torch.randn(2, 4, 1)
+    comb = torch.randn(2, 4, 4)
+
+    def fake_post(out, x_arg, residual_arg, post_arg, comb_arg):
+        assert x_arg is x
+        assert residual_arg is residual
+        assert post_arg is post
+        assert comb_arg is comb
+        out.copy_(residual + 1)
+
+    with (
+        patch.dict(sys.modules, _fake_aiter_mhc_module(mhc_post=fake_post)),
+        patch.object(mhc, "_use_aiter_mhc", return_value=True),
+    ):
+        actual = mhc._mhc_post_dispatch(x, residual, post, comb)
+
+    torch.testing.assert_close(actual, residual + 1)
+
+
+class _AddOneNorm(nn.Module):
+    def __init__(self, hidden_size):
+        super().__init__()
+        self.weight = nn.Parameter(torch.ones(hidden_size))
+        self.variance_epsilon = 1e-6
+
+    def forward(self, x):
+        return x + 1
+
+
+def test_mhc_state_uses_optional_fused_attention_to_mlp_boundary():
+    hidden_states = torch.randn(2, 8)
+    residual = torch.randn(2, 32)
+    next_hidden_states = torch.randn(2, 8)
+    next_residual = torch.randn(2, 32)
+    next_h_res = torch.randn(2, 16)
+    next_h_post = torch.randn(2, 4)
+    fused = MagicMock(
+        return_value=(
+            next_hidden_states,
+            next_residual,
+            next_h_res,
+            next_h_post,
+            False,
+        )
+    )
+    initial_h_res = torch.randn(2, 16)
+    initial_h_post = torch.randn(2, 4)
+    state = MHCState(
+        hc_mult=4,
+        hc_attn_pre=MagicMock(),
+        hc_ffn_pre=MagicMock(side_effect=AssertionError("unfused pre called")),
+        hc_post=MagicMock(side_effect=AssertionError("unfused post called")),
+        hc_attn_to_mlp=fused,
+        h_res=initial_h_res,
+        h_post=initial_h_post,
+    )
+    norm = _AddOneNorm(8)
+
+    actual_hidden_states, actual_residual = state.attn_to_mlp(
+        hidden_states, residual, norm
+    )
+
+    torch.testing.assert_close(actual_hidden_states, next_hidden_states + 1)
+    assert actual_residual is next_residual
+    assert state.h_res is next_h_res
+    assert state.h_post is next_h_post
+    fused.assert_called_once_with(
+        hidden_states,
+        residual,
+        initial_h_res,
+        initial_h_post,
+        norm.weight.data,
+        norm.variance_epsilon,
+    )
+
+
+def test_glm_aiter_mhc_boundary_preserves_communicator_shapes():
+    layer = Glm5NextDecoderLayer.__new__(Glm5NextDecoderLayer)
+    nn.Module.__init__(layer)
+    layer.config = SimpleNamespace(
+        hc_mult=4,
+        rms_norm_eps=1e-6,
+        hc_eps=1e-5,
+        hc_sinkhorn_iters=20,
+    )
+    layer.hc_ffn_fn = nn.Parameter(torch.randn(24, 32))
+    layer.hc_ffn_scale = nn.Parameter(torch.randn(3))
+    layer.hc_ffn_base = nn.Parameter(torch.randn(24))
+
+    hidden_states = torch.randn(2, 8)
+    residual = torch.randn(2, 32)
+    h_res = torch.randn(2, 16)
+    h_post = torch.randn(2, 4)
+    next_residual = torch.randn(2, 4, 8)
+    next_hidden_states = torch.randn(2, 8)
+    next_h_post = torch.randn(2, 4)
+    next_h_res = torch.randn(2, 4, 4)
+
+    with (
+        patch(
+            "sglang.srt.models.deepseek_common.amd.deepseek_v4_fused_mhc.apply_mhc_post_pre_boundary",
+            return_value=(
+                next_residual,
+                next_hidden_states,
+                next_h_post,
+                next_h_res,
+                True,
+            ),
+        ) as fused,
+        patch.object(glm5_next, "_GLM_AITER_FUSED_MHC_LOGGED", False),
+    ):
+        actual = layer.hc_attn_to_mlp(
+            hidden_states,
+            residual,
+            h_res,
+            h_post,
+            torch.ones(8),
+            1e-6,
+        )
+
+    actual_hidden, actual_residual, actual_h_res, actual_h_post, norm_fused = actual
+    assert actual_hidden is next_hidden_states
+    torch.testing.assert_close(actual_residual, next_residual.reshape(2, 32))
+    torch.testing.assert_close(actual_h_res, next_h_res.reshape(2, 16))
+    assert actual_h_post is next_h_post
+    assert norm_fused
+    assert fused.call_args.kwargs["fn_transpose"] is True
+    assert fused.call_args.kwargs["residual"].shape == (2, 4, 8)

--- a/test/registered/unit/models/test_glm5_next_aiter_mhc.py
+++ b/test/registered/unit/models/test_glm5_next_aiter_mhc.py
@@ -174,14 +174,14 @@ def test_mhc_state_uses_optional_fused_attention_to_mlp_boundary():
     assert actual_residual is next_residual
     assert state.h_res is next_h_res
     assert state.h_post is next_h_post
-    fused.assert_called_once_with(
-        hidden_states,
-        residual,
-        initial_h_res,
-        initial_h_post,
-        norm.weight.data,
-        norm.variance_epsilon,
-    )
+    fused.assert_called_once()
+    call_args = fused.call_args.args
+    assert call_args[0] is hidden_states
+    assert call_args[1] is residual
+    assert call_args[2] is initial_h_res
+    assert call_args[3] is initial_h_post
+    torch.testing.assert_close(call_args[4], norm.weight)
+    assert call_args[5] == norm.variance_epsilon
 
 
 def test_glm_aiter_mhc_boundary_preserves_communicator_shapes():
@@ -232,7 +232,7 @@ def test_glm_aiter_mhc_boundary_preserves_communicator_shapes():
     assert actual_hidden is next_hidden_states
     torch.testing.assert_close(actual_residual, next_residual.reshape(2, 32))
     torch.testing.assert_close(actual_h_res, next_h_res.reshape(2, 16))
-    assert actual_h_post is next_h_post
+    torch.testing.assert_close(actual_h_post, next_h_post)
     assert norm_fused
     assert fused.call_args.kwargs["fn_transpose"] is True
     assert fused.call_args.kwargs["residual"].shape == (2, 4, 8)

--- a/test/registered/unit/models/test_glm5_next_dflash_capture.py
+++ b/test/registered/unit/models/test_glm5_next_dflash_capture.py
@@ -7,6 +7,9 @@ from sglang.srt.models.glm5_next import (
     Glm5NextForConditionalGeneration,
     Glm5NextModel,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
 
 
 def test_glm5_next_dflash_contracts_mhc_hidden_state():

--- a/test/registered/unit/models/test_glm5_next_weight_loading.py
+++ b/test/registered/unit/models/test_glm5_next_weight_loading.py
@@ -1,0 +1,54 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.models.glm5_next import Glm5NextForConditionalGeneration
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _FakeParam:
+    def __init__(self):
+        self.loaded = None
+
+    def weight_loader(self, param, loaded_weight):
+        self.loaded = loaded_weight
+
+
+class TestGlm5NextWeightLoading(unittest.TestCase):
+    @patch("sglang.srt.models.glm5_next.DeepseekV2WeightLoaderMixin.post_load_weights")
+    def test_quark_block_fp8_weight_scale_loads_scale_inv(self, post_load):
+        scale_param = _FakeParam()
+        model = SimpleNamespace(
+            config=SimpleNamespace(
+                n_routed_experts=0,
+                num_hidden_layers=45,
+                num_nextn_predict_layers=1,
+            ),
+            num_fused_shared_experts=0,
+            quant_config=None,
+            named_parameters=lambda: iter(
+                [("model.layers.0.mlp.down_proj.weight_scale_inv", scale_param)]
+            ),
+        )
+        loaded_scale = torch.arange(6, dtype=torch.float32).reshape(2, 3)
+
+        Glm5NextForConditionalGeneration.load_weights(
+            model,
+            [
+                (
+                    "model.language_model.layers.0.mlp.down_proj.weight_scale",
+                    loaded_scale,
+                )
+            ],
+        )
+
+        self.assertIs(scale_param.loaded, loaded_scale)
+        post_load.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_nope_mha_k_cast.py
+++ b/test/registered/unit/models/test_nope_mha_k_cast.py
@@ -5,7 +5,10 @@ from unittest import mock
 import pytest
 import torch
 
-from sglang.srt.models.deepseek_common.attention_forward_methods import forward_mha
+from sglang.srt.models.deepseek_common.attention_forward_methods import (
+    forward_mha,
+    forward_mha_rocm,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(
@@ -46,6 +49,21 @@ def _run_nope_concat(backend: str, kv_cache_dtype: str, pool_dtype: torch.dtype)
 def test_nope_mha_k_cast(backend, kv_cache_dtype, pool_dtype, expected_dtype):
     out = _run_nope_concat(backend, kv_cache_dtype, pool_dtype)
     assert out.dtype == expected_dtype
+
+
+@pytest.mark.parametrize("k_pe", [None, torch.empty(4, 1, 0)])
+def test_nope_mha_k_rocm_skips_empty_rope_tail(k_pe):
+    fake_self = SimpleNamespace(qk_rope_head_dim=0)
+    k_nope = torch.randn(4, 2, 128, dtype=torch.bfloat16)
+
+    out = forward_mha_rocm.DeepseekMHARocmForwardMixin._concat_and_cast_mha_k_rocm(
+        fake_self,
+        k_nope,
+        k_pe,
+    )
+
+    torch.testing.assert_close(out, k_nope)
+    assert out.is_contiguous()
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -192,6 +192,62 @@ class TestGlmMoeGate(_FusionGateCase):
         )
 
 
+class TestGlm5NextGate(_FusionGateCase):
+    def _config(self):
+        return SimpleNamespace(n_shared_experts=1)
+
+    def _reason_for_backend(
+        self,
+        *,
+        is_cuda=False,
+        use_aiter_gfx95=False,
+        device_sm=None,
+        moe_ep_size=1,
+        deepep=False,
+    ):
+        import sglang.srt.models.glm5_next as glm5_next
+
+        backend = SimpleNamespace(is_deepep=lambda: deepep)
+        with (
+            unittest.mock.patch.object(glm5_next, "_is_cuda", is_cuda),
+            unittest.mock.patch.object(glm5_next, "_use_aiter_gfx95", use_aiter_gfx95),
+            unittest.mock.patch.object(glm5_next, "_device_sm", device_sm),
+            unittest.mock.patch.object(
+                glm5_next, "get_moe_a2a_backend", return_value=backend
+            ),
+        ):
+            return self._reason(
+                glm5_next.Glm5NextForConditionalGeneration,
+                self._config(),
+                moe_ep_size=moe_ep_size,
+            )
+
+    def test_aiter_gfx95_enables_shared_expert_fusion(self):
+        self.assertIsNone(self._reason_for_backend(use_aiter_gfx95=True))
+
+    def test_unsupported_non_cuda_backend_disables_shared_expert_fusion(self):
+        self.assertIn("requires CUDA", self._reason_for_backend())
+
+    def test_cuda_sm80_path_is_unchanged(self):
+        self.assertIsNone(self._reason_for_backend(is_cuda=True, device_sm=80))
+        self.assertIn(
+            "SM80 or newer",
+            self._reason_for_backend(is_cuda=True, device_sm=75),
+        )
+
+    def test_expert_parallelism_still_disables_shared_expert_fusion(self):
+        self.assertIn(
+            "expert parallelism",
+            self._reason_for_backend(use_aiter_gfx95=True, moe_ep_size=2),
+        )
+
+    def test_deepep_still_disables_shared_expert_fusion(self):
+        self.assertIn(
+            "Deepep",
+            self._reason_for_backend(use_aiter_gfx95=True, deepep=True),
+        )
+
+
 class TestMiniMaxGates(_FusionGateCase):
     def test_a_config_without_shared_experts_cannot_fuse(self):
         from sglang.srt.models.minimax_m3 import MiniMaxM3SparseForCausalLM

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -740,6 +740,74 @@ class TestSkipTokenizerInit(unittest.TestCase):
         self.assertEqual(resolution_result(server_args, "detokenizer_worker_num"), 1)
 
 
+class TestRocmDsaTopKCompatibility(CustomTestCase):
+    def test_gfx942_defaults_to_torch_unfused_topk(self):
+        args = ServerArgs(model_path="dummy")
+
+        with (
+            envs.SGLANG_DSA_FUSE_TOPK.override(True),
+            patch.object(server_args_module, "is_hip", return_value=True),
+            patch.object(server_args_module, "is_gfx95_supported", return_value=False),
+        ):
+            args._handle_rocm_dsa_topk_compatibility()
+
+            self.assertEqual(resolution_result(args, "dsa_topk_backend"), "torch")
+            self.assertEqual(
+                resolution_result(args, "speculative_dsa_topk_backend"),
+                "sgl-kernel",
+            )
+            self.assertFalse(envs.SGLANG_DSA_FUSE_TOPK.get())
+
+    def test_gfx950_keeps_sgl_kernel_fused_topk(self):
+        args = ServerArgs(model_path="dummy")
+
+        with (
+            envs.SGLANG_DSA_FUSE_TOPK.override(True),
+            patch.object(server_args_module, "is_hip", return_value=True),
+            patch.object(server_args_module, "is_gfx95_supported", return_value=True),
+        ):
+            args._handle_rocm_dsa_topk_compatibility()
+
+            self.assertEqual(resolution_result(args, "dsa_topk_backend"), "sgl-kernel")
+            self.assertEqual(
+                resolution_result(args, "speculative_dsa_topk_backend"),
+                "sgl-kernel",
+            )
+            self.assertTrue(envs.SGLANG_DSA_FUSE_TOPK.get())
+
+    def test_cuda_and_explicit_backends_are_unchanged(self):
+        cuda_args = ServerArgs(model_path="dummy")
+        explicit_args = ServerArgs(
+            model_path="dummy",
+            dsa_topk_backend="torch",
+            speculative_dsa_topk_backend="flashinfer",
+        )
+
+        with envs.SGLANG_DSA_FUSE_TOPK.override(True):
+            with patch.object(server_args_module, "is_hip", return_value=False):
+                cuda_args._handle_rocm_dsa_topk_compatibility()
+            self.assertEqual(
+                resolution_result(cuda_args, "dsa_topk_backend"), "sgl-kernel"
+            )
+            self.assertTrue(envs.SGLANG_DSA_FUSE_TOPK.get())
+
+            with (
+                patch.object(server_args_module, "is_hip", return_value=True),
+                patch.object(
+                    server_args_module, "is_gfx95_supported", return_value=False
+                ),
+            ):
+                explicit_args._handle_rocm_dsa_topk_compatibility()
+            self.assertEqual(
+                resolution_result(explicit_args, "dsa_topk_backend"), "torch"
+            )
+            self.assertEqual(
+                resolution_result(explicit_args, "speculative_dsa_topk_backend"),
+                "flashinfer",
+            )
+            self.assertTrue(envs.SGLANG_DSA_FUSE_TOPK.get())
+
+
 class TestHiSparseDsaBackendPolicy(unittest.TestCase):
     # The backend selection moved to the resolution pipeline; these policy
     # tests drive the pass through its read-only view.


### PR DESCRIPTION
## Motivation

[#36507](https://github.com/sgl-project/sglang/pull/36507) adds the upstream GLM-5.3-Flash model implementation. This stacked PR makes that implementation run correctly and efficiently on AMD ROCm gfx942 and gfx950 without adding model-name checks to shared engine paths.

This PR intentionally targets `xinyuan/glm-5.3-flash-support`. Its current dependency head is `c4d5d45e506dcd978a65661a503eda1a272c39a4`.

## Modifications

### ROCm enablement and loading

- Add the ROCm KPool/AITER paged-MQA path and its required preshuffled cache layout.
- Use the portable unfused Torch DSA top-k path on non-gfx95 ROCm while preserving gfx950's fused SGL-kernel path.
- Support KPool tail widths in the DSA index transform while preserving the existing 2,048-column single-program path.
- Handle GLM's zero-width RoPE tail and gate unavailable DeepGEMM/TileLang mHC paths on ROCm.
- Keep AITER weight preshuffling owned by the selected MoE runner and apply the SwiGLU clamp contract on the Triton ROCm path.
- Support mixed Quark MXFP4 and explicitly block-quantized FP8 checkpoint loading.

### gfx950 performance paths

- Enable shared-expert fusion for GLM when the AITER gfx95 path is active.
- Enable the existing fused k-pool top-k/expand/page-transform JIT path on HIP for supported group-top-k sizes.
- Dispatch GLM mHC pre/post through AITER on HIP gfx95 when `SGLANG_USE_AITER=1`.
- Fuse the attention mHC post operation with the following FFN mHC pre operation through the existing AITER boundary implementation.

The mHC paths are gated on HIP + gfx95 + `SGLANG_USE_AITER`. CUDA retains its existing dispatch and behavior.

## Accuracy validation

The original ROCm enablement was validated on the earlier engine head `9e692c9216c3b5e5c443fecf6b995700eb68d2e4`:

| GPU | Full GSM8K | Request accounting |
|---|---:|---|
| MI300X / gfx942 | 1,284 / 1,319 = **97.35%** | 1,319 unique records; 0 errors or empty generations |
| MI355X / gfx950 | 1,288 / 1,319 = **97.65%** | 1,319 unique records; 0 errors or empty generations |

The current performance head adds backend-equivalent mHC dispatch and boundary fusion. Its focused validation is listed below; full GSM8K has not been rerun on this head.

## MI355X performance validation

### Provenance and workload

- PR head: `9d208769398882e20220cb97722bf610397e66d8`
- Hardware: 8x AMD Instinct MI355X (`gfx950`)
- Image: `lmsysorg/sglang:v0.5.18-rocm720-mi35x`
- Model: `zai-org/GLM-5.3-Flash`, revision `3f1971b7b5f7a528c9c4ef6212c8785298a8c24a`
- TP8 / EP1, FP8 E4M3 KV cache, AITER MoE, TileLang DSA
- Full decode graphs at batch sizes 1 and 32; prefill graphs disabled
- Random dataset, seed 42, 1,024 input tokens, 1,024 output tokens
- Ignore EOS enabled, radix cache disabled, infinite request rate
- AITER BF16 table from [ROCm/aiter#5060](https://github.com/ROCm/aiter/pull/5060)

`total throughput` is input plus output tokens divided by benchmark duration. `median interactivity` is `1000 / median TPOT_ms`.

| Case | Requests | Total throughput | Median TPOT | Median interactivity |
|---|---:|---:|---:|---:|
| concurrency 1 | 10/10 | **287.85 tok/s** | 6.8675 ms | **145.61 tok/s/user** |
| concurrency 32 | 320/320 | **5,731.36 tok/s** | 10.6696 ms | **93.72 tok/s/user** |

All 330 measured requests completed with exactly 1,024 input and 1,024 output tokens and empty error strings. Both clients and the supervisor exited zero; server exit 143 is the intentional post-benchmark SIGTERM. Post-run process, port, KFD, GPU-use, and kernel-fault checks were clean.

### B200 comparison

The matched B200 reference used TP8/EP8, FP8 KV cache, DeepGEMM MoE, TRT-LLM DSA, the same random 1K/1K workload, and the same request accounting. Its raw JSON is no longer available locally, so these are recorded outputs from that preceding run.

| Case | B200 total | MI355X total | MI355X/B200 | B200 interactivity | MI355X interactivity | MI355X/B200 |
|---|---:|---:|---:|---:|---:|---:|
| concurrency 1 | 319.18 | 287.85 | **90.18%** | 163.40 | 145.61 | **89.11%** |
| concurrency 32 | 5,670.46 | 5,731.36 | **101.07%** | 95.30 | 93.72 | **98.35%** |

Both workloads exceed the target of 80% of B200 for total throughput and median interactivity.

### Why the mHC integration is required

The published pre-mHC head `91c66b874ac56ad9a79598de5f89156a9d33014a` was run with the same MI355X serving configuration:

| Case | Pre-mHC total throughput | Current total throughput | Speedup |
|---|---:|---:|---:|
| concurrency 1 | 53.08 tok/s | 287.85 tok/s | **5.42x** |
| concurrency 32 | 1,326.39 tok/s | 5,731.36 tok/s | **4.32x** |

The pre-mHC log enabled shared-expert fusion but never selected AITER mHC. The current log reports both `Using AITER gfx950 mHC pre/post kernels` and `Using fused AITER mHC attention-to-FFN boundary` on all eight ranks.

### K-pool kernel evidence

For the 1K-to-2K decode interval, the fused k-pool operation measured about 8.8–9.6 us versus 159–164 us for the previous ROCm path, a 16.9–18.2x kernel-level speedup. The focused test verifies identical selected physical-token sets. The select-all fast path can produce a different ordering than `torch.topk`; DSA attention is permutation-invariant over the selected set, but this is not a bitwise-output-equivalence claim.

## Tests

- AITER mHC and fused-boundary tests on MI355X: `18 passed`, `5 subtests passed`.
- GLM/shared-expert/k-pool focused selection on MI355X: `53 passed`, `4 subtests passed`, `1 deselected`.
  - The deselected dependency-owned case is explicitly an off-ROCm assertion and observes valid ROCm behavior when executed on gfx950.
- All changed-file pre-commit hooks passed, including Ruff, isort, clang-format, codespell, and registered-test validation.
- Current GitHub lint check passes. GPU suites remain skipped until maintainers apply the repository's CI labels.

## Checklist

- [x] Keep CUDA behavior unchanged through explicit backend gates.
- [x] Add CPU and gfx95 regression coverage.
- [x] Validate exact request/token accounting and post-run GPU health.
- [x] Publish model-specific BF16 tuning separately in ROCm/aiter#5060.
- [ ] After ROCm/aiter#5060 merges, advance SGLang's `AITER_COMMIT_DEFAULT` to a merged AITER commit that contains it, unless a routine AITER pin update lands it first.
- [ ] Request `run-ci` and AMD CI labels from a maintainer.
- [x] Publish the cookbook/performance recipe separately in #36732.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33140078236](https://github.com/sgl-project/sglang/actions/runs/33140078236)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #33140078181](https://github.com/sgl-project/sglang/actions/runs/33140078181)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33140078246](https://github.com/sgl-project/sglang/actions/runs/33140078246)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->