### PR TITLE
[AMD] Add GLM-5.3-Flash recipes for MI300X, MI325X, and MI355X

### DIFF
--- a/docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx
@@ -1,6 +1,6 @@
 ---
 title: GLM-5.3-Flash
-description: "Deploy GLM-5.3-Flash with SGLang using recipes for H100, H200, B200, B300, GB200, and GB300, with MTP and multimodal serving."
+description: "Deploy GLM-5.3-Flash with SGLang using NVIDIA CUDA and AMD ROCm recipes, with MTP and multimodal serving where validated."
 tag: NEW
 ---
 
@@ -10,7 +10,7 @@ tag: NEW
 
 <Accordion title="Install SGLang">
 
-Use an SGLang build that includes GLM-5.3-Flash support.
+Use an SGLang build that includes GLM-5.3-Flash support. The AMD ROCm recipes also require [the ROCm engine changes in PR #36607](https://github.com/sgl-project/sglang/pull/36607) until they are available in a published SGLang image.
 
 ```bash Command
 docker pull lmsysorg/sglang:glm-5.3-flash
@@ -25,7 +25,7 @@ Choose your hardware, then choose the operating point that matches your workload
 - **Low Latency** starts with adaptive MTP 5/1/6 speculative decoding and tensor parallelism to shorten interactive responses.
 - **High Throughput** starts with speculative decoding off, which avoids draft-and-verify overhead under sustained batches.
 
-Every listed hardware platform exposes both strategies. A **Verified** badge means that exact hardware and command were tested. **Final Verification In Progress** means the recipe runs and is queued for measurement on the final weights. **Not Verified** means the command is a supported starting point that still needs workload validation. A choice is disabled only when the underlying runtime combination is known to be unsupported.
+NVIDIA platforms expose both strategies. AMD ROCm currently exposes only the non-speculative High Throughput recipe because MTP has not been validated there. A **Verified** badge means that exact hardware and command were tested. **Final Verification In Progress** means the recipe runs and is queued for measurement on the final weights. **Not Verified** means the command is a supported starting point that still needs workload validation. A choice is disabled only when the underlying runtime combination is known to be unsupported.
 
 The recommended selection is only a starting point. The same panel also lets you override the KV/DSA pairing, multimodal feature transport, and HiCache tiers. Changing an option that was not part of the measured command changes the badge to **Not Verified** without hiding the option.
 
@@ -65,7 +65,7 @@ GLM-5.3-Flash is a natively multimodal Mixture-of-Experts model built around a h
     </tr>
     <tr>
       <td style={{padding: "9px 12px"}}>Precision</td>
-      <td style={{padding: "9px 12px"}}>FP8 weights; FP8 KV cache by default on Blackwell, BF16 KV cache on H100 and H200</td>
+      <td style={{padding: "9px 12px"}}>FP8 weights; FP8 KV cache by default on Blackwell, BF16 KV cache on H100, H200, and the AMD ROCm recipes</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Context</td>
@@ -90,7 +90,7 @@ The deployment recipes use the checkpoint's generation configuration. Override s
 
 Start with **Low Latency** for chat and agent workloads. Adaptive MTP changes the draft depth as acceptance changes, reducing unnecessary draft work when the server is busy. Measure **High Throughput** for heavily batched traffic where disabling speculative decoding can be more efficient. SGLang serves MTP through `--speculative-algorithm NEXTN`, so generated commands use that flag value.
 
-Strategy labels describe the workload goal, not a hardware restriction. Both strategies stay available when you switch hardware; only the verification badge changes.
+Strategy labels describe the workload goal. Both strategies stay available on NVIDIA GPUs; the AMD ROCm recipes expose only High Throughput until MTP speculative decoding is validated there.
 
 ### Size both memory pools
 
@@ -103,6 +103,8 @@ Keep the checkpoint's KDA lower-bound setting unchanged. In particular, do not o
 ### Keep the KV and DSA backends paired
 
 On Blackwell, the recipes default to an FP8 KV cache with TRT-LLM DSA: on GB300 this pairing measured 2.3–5.5% higher throughput and about 1.8x the KV token capacity at identical pool bytes, with GSM8K accuracy within noise of BF16. BF16 KV with TileLang DSA remains selectable in the deployment panel and is the default on H100 and H200, where FP8 KV with TRT-LLM DSA is disabled. Switch the dtype and both DSA backends together; TileLang DSA with FP8 KV is not a valid CUDA combination.
+
+On AMD ROCm, use BF16 KV cache with TileLang DSA, set `SGLANG_USE_AITER=1`, keep the MoE runner on Triton, and disable CUDA graphs. The ROCm recipe uses TP8 on a single eight-GPU node. MI300X and MI325X both use gfx942, but the MI325X entry remains explicitly unverified because it is inferred from MI300X rather than measured directly. AMD validation covers text generation and GSM8K only; multimodal serving remains unverified.
 
 ### Extend the cache hierarchy
 

--- a/docs/src/snippets/configs/zai-org/glm-5.3-flash-benchmarks.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.3-flash-benchmarks.jsx
@@ -144,4 +144,19 @@ export const benchmarks = [
   { match: { hw: "b300", strategy: "high-throughput" } },
   { match: { hw: "gb200", strategy: "low-latency" } },
   { match: { hw: "gb200", strategy: "high-throughput" } },
+  {
+    match: { hw: "mi300x", strategy: "high-throughput" },
+    sglang_version: "9e692c9216",
+    accuracy: { gsm8k_pct: 97.35 },
+    notes:
+      "Accuracy-only validation on 8x MI300X (gfx942, TP8) with zai-org/GLM-5.3-Flash revision 3f1971b7b5f7a528c9c4ef6212c8785298a8c24a, SGLang PR #36607 head 9e692c9216c3b5e5c443fecf6b995700eb68d2e4 (validated source manifest 2c240e0e01d5fdf04acc485ebfa25f8a1793ba45fb07f165eecedfba7ec1db80), and lmsysorg/sglang:v0.5.18-rocm720-mi30x with the PR source mounted over the image tree. Full GSM8K scored 1,284/1,319 with a 100% stop rate and zero request errors, empty generations, or truncations. No throughput or latency benchmark was run.",
+  },
+  { match: { hw: "mi325x", strategy: "high-throughput" } },
+  {
+    match: { hw: "mi355x", strategy: "high-throughput" },
+    sglang_version: "9e692c9216",
+    accuracy: { gsm8k_pct: 97.65 },
+    notes:
+      "Accuracy-only validation on 8x MI355X (gfx950, TP8) with zai-org/GLM-5.3-Flash revision 3f1971b7b5f7a528c9c4ef6212c8785298a8c24a, SGLang PR #36607 head 9e692c9216c3b5e5c443fecf6b995700eb68d2e4 (validated source manifest 2c240e0e01d5fdf04acc485ebfa25f8a1793ba45fb07f165eecedfba7ec1db80), and lmsysorg/sglang:v0.5.18-rocm720-mi35x with the PR source mounted over the image tree. Full GSM8K scored 1,288/1,319 with a 100% stop rate and zero request errors, empty generations, or truncations. No throughput or latency benchmark was run.",
+  },
 ];

--- a/docs/src/snippets/configs/zai-org/glm-5.3-flash.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.3-flash.jsx
@@ -1,21 +1,32 @@
 export const config = {
   modelName: "GLM-5.3-Flash",
 
-  supportedHardware: ["gb300", "h100", "h200", "b200", "b300", "gb200"],
+  supportedHardware: [
+    "gb300", "h100", "h200", "b200", "b300", "gb200",
+    "mi300x", "mi325x", "mi355x",
+  ],
 
   matchDims: [
     {
       id: "strategy",
       title: "Strategy",
       options: [
-        { id: "low-latency", label: "Low Latency", subtitle: "Adaptive MTP 5/1/6" },
+        {
+          id: "low-latency",
+          label: "Low Latency",
+          subtitle: "Adaptive MTP 5/1/6",
+          disabled: (s) => ["mi300x", "mi325x", "mi355x"].includes(s.hw),
+          disableReason: "MTP speculative decoding has not been validated for GLM-5.3-Flash on AMD ROCm; use the non-speculative High Throughput recipe.",
+        },
         { id: "high-throughput", label: "High Throughput", subtitle: "Spec decode off" },
       ],
     },
   ],
 
   isRecommendedSelection(s) {
-    const pairing = ["h100", "h200"].includes(s.hw) ? "bf16-tilelang" : "fp8-trtllm";
+    const pairing = ["h100", "h200", "mi300x", "mi325x", "mi355x"].includes(s.hw)
+      ? "bf16-tilelang"
+      : "fp8-trtllm";
     return (
       s.kvDsaPair === pairing &&
       s.mmTransport === "auto" &&
@@ -32,8 +43,8 @@ export const config = {
         {
           id: "fp8-trtllm",
           label: "FP8 + TRT-LLM",
-          disabled: (s) => ["h100", "h200"].includes(s.hw),
-          disableReason: "FP8 KV cache with TRT-LLM DSA is not supported on Hopper GPUs.",
+          disabled: (s) => ["h100", "h200", "mi300x", "mi325x", "mi355x"].includes(s.hw),
+          disableReason: "This recipe uses BF16 KV cache with TileLang DSA on Hopper and AMD ROCm GPUs.",
           stripPrefixes: ["--kv-cache-dtype", "--dsa-prefill-backend", "--dsa-decode-backend"],
           flags: [
             "--kv-cache-dtype fp8_e4m3",
@@ -147,8 +158,9 @@ sgl-eval run gsm8k \\
     ["gsm8k_pct", "GSM8K", "%"],
   ],
 
-  // Support is not in a public sglang release yet, so the nightly images do
-  // not work; every NVIDIA lane uses the purpose-built CUDA 13 image.
+  // Support is not in a public sglang release yet. NVIDIA uses the
+  // purpose-built CUDA 13 image. AMD validation used these ROCm 7.2 images
+  // with the GLM-5.3 ROCm engine branch mounted over the image source tree.
   dockerImages: {
     gb300: "lmsysorg/sglang:glm-5.3-flash",
     h100: "lmsysorg/sglang:glm-5.3-flash",
@@ -156,6 +168,9 @@ sgl-eval run gsm8k \\
     b200: "lmsysorg/sglang:glm-5.3-flash",
     b300: "lmsysorg/sglang:glm-5.3-flash",
     gb200: "lmsysorg/sglang:glm-5.3-flash",
+    mi300x: "lmsysorg/sglang:v0.5.18-rocm720-mi30x",
+    mi325x: "lmsysorg/sglang:v0.5.18-rocm720-mi30x",
+    mi355x: "lmsysorg/sglang:v0.5.18-rocm720-mi35x",
   },
 
   github: {
@@ -213,6 +228,8 @@ sgl-eval run gsm8k \\
             id: "deep_gemm",
             label: "DeepGemm",
             flags: ["--moe-runner-backend deep_gemm"],
+            disabled: (s) => ["mi300x", "mi325x", "mi355x"].includes(s.hw),
+            disableReason: "The validated AMD ROCm recipe uses the Triton MoE runner.",
           },
         ],
       },
@@ -519,6 +536,72 @@ sgl-eval run gsm8k \\
         "--kv-cache-dtype fp8_e4m3",
         "--moe-runner-backend deep_gemm",
         "--disable-shared-experts-fusion",
+        "--reasoning-parser glm45",
+        "--tool-call-parser glm47",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    // AMD ROCm — one non-speculative TP8 operating point. The explicit BF16
+    // KV and TileLang DSA flags match the resolved defaults observed in the
+    // validation server logs. AITER remains enabled for the ROCm kernel paths,
+    // while Triton owns the MoE runner. CUDA graphs stay disabled because that
+    // is the architecture-gated configuration used for correctness validation.
+    {
+      match: { hw: "mi300x", strategy: "high-throughput" },
+      nnodes: 1,
+      verified: true,
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--tp-size 8",
+        "--trust-remote-code",
+        "--disable-cuda-graph",
+        "--dsa-prefill-backend tilelang",
+        "--dsa-decode-backend tilelang",
+        "--kv-cache-dtype bfloat16",
+        "--moe-runner-backend triton",
+        "--reasoning-parser glm45",
+        "--tool-call-parser glm47",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi325x", strategy: "high-throughput" },
+      nnodes: 1,
+      verified: false,
+      warn: "This MI325X recipe is inferred from the validated MI300X gfx942 path. It has not been measured directly on MI325X.",
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--tp-size 8",
+        "--trust-remote-code",
+        "--disable-cuda-graph",
+        "--dsa-prefill-backend tilelang",
+        "--dsa-decode-backend tilelang",
+        "--kv-cache-dtype bfloat16",
+        "--moe-runner-backend triton",
+        "--reasoning-parser glm45",
+        "--tool-call-parser glm47",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi355x", strategy: "high-throughput" },
+      nnodes: 1,
+      verified: true,
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--tp-size 8",
+        "--trust-remote-code",
+        "--disable-cuda-graph",
+        "--dsa-prefill-backend tilelang",
+        "--dsa-decode-backend tilelang",
+        "--kv-cache-dtype bfloat16",
+        "--moe-runner-backend triton",
         "--reasoning-parser glm45",
         "--tool-call-parser glm47",
         "--host {{HOST_IP}}",


### PR DESCRIPTION
## Motivation

Add copy-pasteable AMD ROCm deployment recipes for `zai-org/GLM-5.3-Flash` alongside the existing NVIDIA recipes.

The AMD commands require the engine changes in [#36607](https://github.com/sgl-project/sglang/pull/36607), which is stacked on the model-support PR [#36507](https://github.com/sgl-project/sglang/pull/36507).

## Modifications

- Add single-node TP8 ROCm recipes for MI300X, MI325X, and MI355X.
- Use the validated BF16 KV + TileLang DSA configuration with `SGLANG_USE_AITER=1`, Triton MoE, and CUDA graphs disabled.
- Mark MI300X and MI355X as verified from full GSM8K runs.
- Keep MI325X explicitly unverified: it shares gfx942 with MI300X, but it was not measured directly.
- Disable the unvalidated AMD MTP/low-latency lane and unvalidated backend combinations.
- Add accuracy-only benchmark records with exact model revision, engine PR/source manifest, image, and request accounting. No throughput or latency result is presented.

This PR is based on current `main` (`02dfd3782601277bcf7e74c7a836a70011183165`). It does not duplicate the separate NVIDIA HiCache/fusion cleanup in [#36544](https://github.com/sgl-project/sglang/pull/36544).

## Accuracy Tests

| GPU | Recipe status | Full GSM8K | Request accounting |
|---|---|---:|---|
| MI300X / gfx942 | Verified | 1,284 / 1,319 = **97.35%** | 1,319 unique records; 100% `stop`; 0 errors, empty generations, or truncations |
| MI325X / gfx942 | **Not verified**; inferred from MI300X | — | No MI325X hardware run |
| MI355X / gfx950 | Verified | 1,288 / 1,319 = **97.65%** | 1,319 unique records; 100% `stop`; 0 errors, empty generations, or truncations |

Validated model revision: `3f1971b7b5f7a528c9c4ef6212c8785298a8c24a`.

Validated engine source:

- PR #36607 head: `9e692c9216c3b5e5c443fecf6b995700eb68d2e4`
- Source manifest SHA256: `2c240e0e01d5fdf04acc485ebfa25f8a1793ba45fb07f165eecedfba7ec1db80`
- MI300X image: `lmsysorg/sglang:v0.5.18-rocm720-mi30x`
- MI355X image: `lmsysorg/sglang:v0.5.18-rocm720-mi35x`

## Speed Tests and Profiling

Not measured. These are accuracy/correctness results only.

## Documentation validation

- `node docs/scripts/check_cookbook_configs.mjs`
- focused `pre-commit run --files ...`
- `npx --yes mintlify broken-links`
- `npx --yes mintlify validate`

All passed. The final rebase changed only the parent with an unrelated test-file commit; the validated `docs/` tree hash remained `fc5d92e264b3271bd347f5acd91e06dde38fba2f`.

## Checklist

- [x] Document platform, image, model revision, TP/DP topology, and required environment settings.
- [x] Mark measured and inferred hardware separately.
- [x] Run the cookbook config checker and docs validation.
- [x] Avoid performance claims without a matched throughput benchmark.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33037066265](https://github.com/sgl-project/sglang/actions/runs/33037066265)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33037402765](https://github.com/sgl-project/sglang/actions/runs/33037402765)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->