### PR TITLE
[Kimi-K3] Deferred decode-side KV release (#35049 + #35360) on the zmq-mitigation base

### DIFF
--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -160,6 +160,9 @@ class CommonKVManager(BaseKVManager):
         self.is_hybrid_mla_backend = getattr(args, "is_hybrid_mla_backend", False)
         self.disaggregation_mode = disaggregation_mode
         self.server_args = server_args
+        self.enable_deferred_decode_kv_release = (
+            envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE.get()
+        )
         # for p/d multi node infer
         self.bootstrap_host = server_args.host
         self.bootstrap_port = server_args.disaggregation_bootstrap_port
@@ -254,6 +257,10 @@ class CommonKVManager(BaseKVManager):
             self.session_pool_lock = threading.Lock()
             self.addr_to_rooms_tracker: Dict[str, Set[int]] = defaultdict(set)
             self.prefill_response_tracker: Dict[int, Set[int]] = defaultdict(set)
+            # Deferred KV release: room -> prefill ranks that acked their transfer
+            # drained. Entry exists only while the room is held, so a stale/late
+            # ack for a reused bootstrap_room is dropped.
+            self._deferred_abort_ack_tracker: Dict[int, Set[int]] = {}
             # Heartbeat interval should be at least 2 seconds
             self.heartbeat_interval = max(
                 envs.SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL.get(), 2.0
@@ -337,6 +344,28 @@ class CommonKVManager(BaseKVManager):
     def record_failure(self, bootstrap_room: int, failure_reason: str):
         with self.failure_lock:
             self.failure_records[bootstrap_room] = failure_reason
+
+    def register_deferred_abort_room(self, bootstrap_room: int) -> None:
+        """Arm drain-ack accounting for a held room; a fresh set wipes stale acks
+        from a prior request that reused this bootstrap_room."""
+        self._deferred_abort_ack_tracker[bootstrap_room] = set()
+
+    def note_abort_ack(self, bootstrap_room: int, prefill_rank: int) -> None:
+        """Record a prefill rank's drain ack (decode receiver thread). Only counts
+        while the room is held; grabs the set by reference to avoid racing clear."""
+        acks = self._deferred_abort_ack_tracker.get(bootstrap_room)
+        if acks is not None:
+            acks.add(prefill_rank)
+
+    def is_abort_release_safe(self, bootstrap_room: int, required_acks: int) -> bool:
+        """True once every prefill rank that could still write these pages has acked."""
+        return (
+            len(self._deferred_abort_ack_tracker.get(bootstrap_room, ()))
+            >= required_acks
+        )
+
+    def clear_deferred_abort_state(self, bootstrap_room: int) -> None:
+        self._deferred_abort_ack_tracker.pop(bootstrap_room, None)
 
     def get_kv_replica_factor(self) -> int:
         if self._kv_replica_factor is None:
@@ -1240,6 +1269,10 @@ class CommonKVSender(BaseKVSender):
             self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
         if hasattr(self.kv_mgr, "transfer_infos"):
             self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+        if hasattr(self.kv_mgr, "_deferred_ack_targets"):
+            # Drop a held ack target if the room concluded without draining
+            # (e.g. aborted before any chunk enqueued); else it leaks on prefill.
+            self.kv_mgr._deferred_ack_targets.pop(self.bootstrap_room, None)
 
     def abort(self):
         self.kv_mgr.record_failure(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -239,6 +239,9 @@ class CommonKVManager(BaseKVManager):
             )
             self.register_to_bootstrap()
             self.transfer_infos = {}
+            # Deferred KV release: aborted room -> (decode_ip, decode_port);
+            # ack held until the transfer drains.
+            self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
             self.req_to_decode_prefix_len: Dict[int, int] = {}
             self.decode_kv_args_table = {}
             self.pp_group = get_pp_group()
@@ -366,6 +369,47 @@ class CommonKVManager(BaseKVManager):
 
     def clear_deferred_abort_state(self, bootstrap_room: int) -> None:
         self._deferred_abort_ack_tracker.pop(bootstrap_room, None)
+
+    def _prefill_unique_rank(self) -> int:
+        """Stable per-sender id, matching what the transfer worker syncs on Success."""
+        return (
+            self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
+            + self.pp_rank * self.attn_cp_size
+            + self.attn_cp_rank
+        )
+
+    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
+        """Best-effort ack that this rank's transfer for an aborted room drained."""
+        try:
+            na = NetworkAddress(decode_ip, decode_port)
+            self._send_multipart_locked(
+                na.to_tcp(),
+                [
+                    b"ABORT_ACK",
+                    str(room).encode("ascii"),
+                    str(self._prefill_unique_rank()).encode("ascii"),
+                ],
+                is_ipv6=na.is_ipv6,
+            )
+        except Exception as e:
+            logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
+
+    def _maybe_ack_drained_abort(self, room: int) -> None:
+        """Send the deferred ack once an aborted room's chunks have drained
+        (outstanding == 0). pop() makes it fire at most once."""
+        if self._staging_outstanding.get(room, 0) > 0:
+            return
+        target = self._deferred_ack_targets.pop(room, None)
+        if target is not None:
+            self._send_abort_ack(target[0], target[1], room)
+
+    def register_deferred_ack_target(
+        self, room: int, decode_ip: str, decode_port: int
+    ) -> None:
+        """Hold this room's ack until its transfer drains. Callers must mark the
+        room Failed FIRST -- registering while it still accepts chunks lets the
+        worker ack, then a new chunk writes pages the decode already released."""
+        self._deferred_ack_targets[room] = (decode_ip, decode_port)
 
     def get_kv_replica_factor(self) -> int:
         if self._kv_replica_factor is None:

--- a/python/sglang/srt/disaggregation/common/staging_buffer.py
+++ b/python/sglang/srt/disaggregation/common/staging_buffer.py
@@ -771,3 +771,29 @@ def resolve_total_kv_heads(
         "nor kv_head_num. "
         "Ensure DecodePreallocQueue._init_kv_manager sets kv_args.kv_head_num."
     )
+
+
+def staging_grid_tokens(chunked_prefill_size: Optional[int], page_size: int) -> int:
+    """Token width of one staging grid slot; shared by prefetch and the
+    sender's grid alignment."""
+    cps = chunked_prefill_size or 8192
+    return max(1, cps // page_size) * page_size
+
+
+def compute_grid_segments(
+    start_idx: int, end_idx: int, base: int, grid_tokens: int
+) -> List[Tuple[int, int]]:
+    """Split [start_idx, end_idx) at grid boundaries base + k * grid_tokens
+    so each segment maps to exactly one staging slot. An empty range yields
+    one empty segment (a metadata-only last chunk still needs a send).
+    """
+    segments: List[Tuple[int, int]] = []
+    seg_start = start_idx
+    while seg_start < end_idx:
+        next_boundary = base + ((seg_start - base) // grid_tokens + 1) * grid_tokens
+        seg_end = min(next_boundary, end_idx)
+        segments.append((seg_start, seg_end))
+        seg_start = seg_end
+    if not segments:
+        segments = [(start_idx, end_idx)]
+    return segments

--- a/python/sglang/srt/disaggregation/common/staging_handler.py
+++ b/python/sglang/srt/disaggregation/common/staging_handler.py
@@ -12,6 +12,7 @@ import dataclasses
 import logging
 import struct
 import threading
+import time
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
@@ -82,11 +83,21 @@ class DecodeStagingHandler:
         self.total_kv_heads = total_kv_heads
         self.tp_rank = tp_rank
         self.scheduler = scheduler
+        # Same stall->Failed semantics (and knob) as _check_waiting_timeout,
+        # which is unreachable once the receiver has concluded Success.
+        from sglang.srt.environ import envs
+
+        self.completion_timeout = float(
+            envs.SGLANG_DISAGGREGATION_WAITING_TIMEOUT.get()
+        )
         self._room_to_decode_req: dict = {}
         # Stashed at registration: removal paths null decode_req.kv_receiver
         # before unregister runs, but release_room still needs it.
         self._room_to_receiver: dict = {}
         self._wm_subscribers: dict = {}
+        # room -> chunk_idx -> [(page_start, num_pages, writer_id)] fan-in
+        # arrivals; handler-owned so room teardown can purge them.
+        self._writer_counts: dict = {}
 
     def register_wm_subscriber(self, receiver, session_id: str) -> None:
         """Register a prefill's bootstrap connection for watermark broadcasts."""
@@ -96,9 +107,9 @@ class DecodeStagingHandler:
         if key not in self._wm_subscribers:
             self._wm_subscribers[key] = (receiver, session_id)
 
-    def num_writers_for(self, decode_req) -> int:
+    def num_writers_for(self, receiver) -> int:
         """Compute num_writers for a specific request based on its prefill TP."""
-        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
+        prefill_tp = receiver.prefill_info.attn_tp_size
         if prefill_tp > self.decode_tp:
             return prefill_tp // max(1, self.decode_tp)
         return 1
@@ -141,15 +152,33 @@ class DecodeStagingHandler:
 
     def register_decode_req(self, room: int, decode_req: DecodeRequest) -> None:
         # Called once per room from pop_preallocated, before send_metadata.
+        decode_req._staging_all_success = False
+        decode_req._staging_success_ts = 0.0
+        decode_req._staging_failed = False
         decode_req._staging_scatter_done = False
         decode_req._chunk_events = []
         self._room_to_decode_req[room] = decode_req
         self._room_to_receiver[room] = decode_req.kv_receiver
+        # Scatter offsets shift suffix-relative page_start by the decode prefix,
+        # exact only when the prefix is page-aligned. Fail just this request on a
+        # mismatch instead of raising, which would kill the prefill scheduler.
+        page_size = self.kv_buffer_info["page_size"]
+        if decode_req.req.cache_protected_len % page_size != 0:
+            logger.error(
+                "[STAGING] decode prefix length %s is not page-aligned "
+                "(page_size=%s); failing room=%s (staging scatter offsets "
+                "would be wrong).",
+                decode_req.req.cache_protected_len,
+                page_size,
+                room,
+            )
+            decode_req._staging_failed = True
 
     def unregister_decode_req(self, room: int) -> None:
         # Pop before release_room so no new arrival can start consuming the slots.
         decode_req = self._room_to_decode_req.pop(room, None)
         receiver = self._room_to_receiver.pop(room, None)
+        self._writer_counts.pop(room, None)
         if decode_req is not None:
             self.release_room(room, decode_req, receiver)
         self.kv_manager._staging_ctx.room_receivers.pop(room, None)
@@ -214,7 +243,9 @@ class DecodeStagingHandler:
         if staging_offset < 0 or alloc_id < 0:
             return False
 
-        ok = self._scatter_region(staging_offset, page_start, num_pages, decode_req)
+        ok = self._scatter_region(
+            staging_offset, page_start, num_pages, decode_req, receiver
+        )
         if ok:
             event = torch.cuda.Event()
             event.record(self.staging_allocator._scatter_stream)
@@ -242,38 +273,36 @@ class DecodeStagingHandler:
         page_start: int,
         num_pages: int,
         writer_id: str,
-        chunk_writer_counts: dict,
     ) -> bool:
         """Process a staging chunk arrival from any transport (NIXL RDMA notif or ZMQ CHUNK_READY).
 
-        Accumulates writer arrivals in *chunk_writer_counts* and submits scatter
-        once all writers for this chunk have reported in. Returns True if scatter
-        was submitted.
+        Accumulates writer arrivals and submits scatter once all writers for
+        this chunk have reported in. Returns True if scatter was submitted.
         """
-        chunk_writer_counts[room][chunk_idx].append((page_start, num_pages, writer_id))
-        decode_req = self._room_to_decode_req.get(room)
-        if decode_req is None:
+        # Read from the stash, not decode_req.kv_receiver: a concurrent teardown
+        # nulls the latter before unregister removes the room.
+        receiver = self._room_to_receiver.get(room)
+        if receiver is None:
             logger.warning(
-                "Staging chunk arrived for unregistered room=%s chunk=%d, skipping",
+                "Staging chunk arrived for unregistered room=%s chunk=%d, " "skipping",
                 room,
                 chunk_idx,
             )
             return False
-        writers_arrived = len(chunk_writer_counts[room][chunk_idx])
-        num_writers = self.num_writers_for(decode_req)
-        if writers_arrived >= num_writers:
+        room_counts = self._writer_counts.setdefault(room, {})
+        arrivals = room_counts.setdefault(chunk_idx, [])
+        arrivals.append((page_start, num_pages, writer_id))
+        num_writers = self.num_writers_for(receiver)
+        if len(arrivals) >= num_writers:
             self.submit_chunk_scatter(room, chunk_idx, page_start, num_pages)
-            del chunk_writer_counts[room][chunk_idx]
+            del room_counts[chunk_idx]
             return True
         return False
 
     def submit_last_scatter_async(self, room: int) -> bool:
-        """Submit scatter for the last chunk when all ranks report Success.
-
-        Called from decode_thread.  Sets ``_scatter_event`` **before**
-        ``_staging_last_scatter_submitted`` so the main thread sees the
-        event when it checks the flag (CPython GIL guarantees ordering).
-        """
+        """Record all-ranks Success. Scatter is fully arrival-driven (every
+        chunk, including the last); advance_scatter completes the room once
+        no allocation is still waiting for its arrival."""
         decode_req = self._room_to_decode_req.get(room)
         if decode_req is None:
             logger.warning(
@@ -283,15 +312,11 @@ class DecodeStagingHandler:
                 room,
             )
             return False
-        alloc_id = self._submit_last_scatter(decode_req)
-        if alloc_id >= 0:
-            event = torch.cuda.Event()
-            event.record(self.staging_allocator._scatter_stream)
-            decode_req._scatter_event = event
-            decode_req._scatter_alloc_id = alloc_id
-            decode_req._staging_last_scatter_submitted = True
-        else:
-            decode_req._staging_scatter_done = True
+        if not decode_req._staging_all_success:
+            # Set the timestamp before the flag so the deadline check never
+            # reads a zero ts.
+            decode_req._staging_success_ts = time.monotonic()
+            decode_req._staging_all_success = True
         return True
 
     # ------------------------------------------------------------------
@@ -302,15 +327,19 @@ class DecodeStagingHandler:
         """Return True if staging scatter is complete for this request."""
         return decode_req._staging_scatter_done and not decode_req._chunk_events
 
-    def advance_scatter(self, decode_req: DecodeRequest) -> None:
-        """Check CUDA events and free completed staging allocations.
+    def is_failed(self, decode_req: DecodeRequest) -> bool:
+        """Return True if staging completion timed out for this request."""
+        return decode_req._staging_failed
 
-        Scatter kernels have already been submitted by the decode_thread
-        (via submit_chunk_scatter / submit_last_scatter_async).  This
-        method only polls the recorded events and releases staging memory.
+    def advance_scatter(self, decode_req: DecodeRequest) -> None:
+        """Poll scatter events, free completed allocations, detect completion.
+
+        The room is done once all ranks reported Success AND every allocation
+        was scattered AND every event fired; gating on outstanding allocations
+        keeps it open while a CHUNK_READY is still in flight after Success.
+        Rooms incomplete past the disaggregation waiting timeout are failed.
         """
-        room = decode_req.req.bootstrap_room
-        chunk_events = getattr(decode_req, "_chunk_events", None)
+        chunk_events = decode_req._chunk_events
         if chunk_events:
             for i in range(len(chunk_events) - 1, -1, -1):
                 event, alloc_id = chunk_events[i]
@@ -318,15 +347,24 @@ class DecodeStagingHandler:
                     chunk_events.pop(i)
                     self._free_and_send_watermark(alloc_id, decode_req)
 
-        if not getattr(decode_req, "_staging_last_scatter_submitted", False):
+        if not decode_req._staging_all_success:
             return
-
-        event = getattr(decode_req, "_scatter_event", None)
-        if event is not None and event.query():
-            self._free_and_send_watermark(decode_req._scatter_alloc_id, decode_req)
-            decode_req._scatter_event = None
-            decode_req._scatter_alloc_id = -1
+        room = decode_req.req.bootstrap_room
+        receiver = self._room_to_receiver.get(room)
+        chunk_infos = receiver.chunk_staging_infos if receiver is not None else []
+        incomplete = bool(chunk_events) or any(info[0] >= 0 for info in chunk_infos)
+        if not incomplete:
             decode_req._staging_scatter_done = True
+            return
+        elapsed = time.monotonic() - decode_req._staging_success_ts
+        if elapsed > self.completion_timeout:
+            logger.error(
+                "[STAGING] room=%s not complete %.0fs after all-ranks Success "
+                "(a scatter never arrived); failing the request.",
+                room,
+                elapsed,
+            )
+            decode_req._staging_failed = True
 
     # ------------------------------------------------------------------
     # Internal methods
@@ -338,6 +376,7 @@ class DecodeStagingHandler:
         page_start: int,
         num_pages: int,
         decode_req: DecodeRequest,
+        receiver,
     ) -> bool:
         """Submit scatter kernels for a staging region to scatter_stream.
 
@@ -365,9 +404,12 @@ class DecodeStagingHandler:
         staging_view = self.staging_allocator.buffer.buffer[staging_offset:]
 
         req_pool_idx = decode_req.req.req_pool_idx
-        token_start = page_start * page_size
+        # page_start is suffix-relative (pages after the decode-side cached
+        # prefix); req_to_token rows are absolute.
+        prefix_tokens = decode_req.req.cache_protected_len
+        token_start = prefix_tokens + page_start * page_size
         token_end = token_start + num_pages * page_size
-        prefill_tp = decode_req.kv_receiver.prefill_info.attn_tp_size
+        prefill_tp = receiver.prefill_info.attn_tp_size
 
         with torch.cuda.stream(scatter_stream):
             kv_indices = self.scheduler.req_to_token_pool.req_to_token[
@@ -391,28 +433,6 @@ class DecodeStagingHandler:
             )
 
         return True
-
-    def _submit_last_scatter(self, decode_req: DecodeRequest) -> int:
-        """Submit scatter for the last chunk. Returns alloc_id >= 0, or -1."""
-        receiver = decode_req.kv_receiver
-        chunk_infos = receiver.chunk_staging_infos if receiver is not None else []
-        if not chunk_infos:
-            return -1
-
-        last_info = chunk_infos[-1]
-        alloc_id, staging_offset, _, _, last_num_pages = last_info
-        if staging_offset < 0 or alloc_id < 0:
-            return -1
-
-        seq_len = len(decode_req.req.origin_input_ids)
-        ps = self.scheduler.token_to_kv_pool_allocator.page_size
-        total_pages = (seq_len + ps - 1) // ps
-        page_start = total_pages - last_num_pages
-
-        ok = self._scatter_region(
-            staging_offset, page_start, last_num_pages, decode_req
-        )
-        return alloc_id if ok else -1
 
     def _free_and_send_watermark(
         self, alloc_id: int, decode_req: DecodeRequest
@@ -542,11 +562,17 @@ class PrefillStagingStrategy:
     """
 
     def __init__(self, kv_manager, staging_buffer):
+        from sglang.srt.disaggregation.common.staging_buffer import (
+            staging_grid_tokens,
+        )
+
         self.kv_manager = kv_manager
         self.staging_buffer = staging_buffer
         page_size = kv_manager.kv_buffer_tensors["page_size"]
-        cps = kv_manager.server_args.chunked_prefill_size or 8192
-        self.full_chunk_pages = max(1, cps // page_size)
+        self.full_chunk_pages = (
+            staging_grid_tokens(kv_manager.server_args.chunked_prefill_size, page_size)
+            // page_size
+        )
 
     def check_ready(
         self,
@@ -831,11 +857,11 @@ def prefetch_staging_reqs(
     """
     import zmq
 
+    from sglang.srt.disaggregation.common.staging_buffer import staging_grid_tokens
     from sglang.srt.utils.network import NetworkAddress
 
     page_size = kv_buffer_tensors["page_size"]
-    cps = chunked_prefill_size or 8192
-    full_chunk_pages = max(1, cps // page_size)
+    full_chunk_pages = staging_grid_tokens(chunked_prefill_size, page_size) // page_size
 
     for session_id, tinfo in transfer_infos[room].items():
         # mooncake exposes is_dummy as a dataclass bool field, NIXL exposes it

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -29,6 +29,9 @@ class TransferKVChunk:
     trace_ctx: Union[TraceReqContext, TraceNullContext] = dataclasses.field(
         default_factory=TraceNullContext
     )
+    # Set when the staging worker first counts this chunk toward the per-room
+    # outstanding count; stays set across re-enqueue on a watermark defer.
+    staging_counted: bool = False
 
 
 def pack_list_of_buffers(buffers: List[bytes]) -> bytes:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -1756,6 +1756,15 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.spec_algorithm = scheduler.spec_algorithm
         self.enable_staging = envs.SGLANG_DISAGG_STAGING_BUFFER.get()
         self.staging_handler = None
+        self.enable_deferred_kv_release = (
+            envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE.get()
+        )
+        self.deferred_kv_release_timeout = (
+            envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT.get()
+        )
+        # Aborted-mid-transfer requests whose KV pages/slot are held until drained
+        # or timed out. Entries: (decode_req, deadline, metadata_idx, required_acks).
+        self._deferred_releases: List[Tuple[DecodeRequest, float, int, int]] = []
 
     def add(self, decode_req: DecodeRequest) -> None:
         self.queue.append(decode_req)
@@ -1971,6 +1980,9 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
         transferred_reqs = []
         indices_to_remove = set()
+        # Queue-removed but held for deferred release; excluded from the metadata
+        # teardown below.
+        deferred_indices = set()
         for i, (decode_req, poll) in enumerate(zip(self.queue, polls)):
             if rids_to_check is not None and decode_req.req.rid not in rids_to_check:
                 continue
@@ -2008,11 +2020,23 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 )
                 if self.scheduler.enable_hisparse:
                     self.scheduler.hisparse_coordinator.request_finished(decode_req.req)
-                # release pre-allocated kv cache, but don't insert into the tree since it's failed
-                release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
-                decode_req.kv_receiver.clear()
-                decode_req.kv_receiver = None
-                indices_to_remove.add(i)
+                if (
+                    self.enable_deferred_kv_release
+                    and decode_req.kv_receiver.abort_notified
+                ):
+                    # Decode-initiated abort: a prefill write may still target
+                    # these pages, so hold them until the drain ack or timeout.
+                    # (A prefill-initiated failure has already stopped writing ->
+                    # immediate release below.)
+                    self._defer_release(decode_req)
+                    deferred_indices.add(i)
+                    indices_to_remove.add(i)
+                else:
+                    # release pre-allocated kv cache, but don't insert into the tree since it's failed
+                    release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
+                    decode_req.kv_receiver.clear()
+                    decode_req.kv_receiver = None
+                    indices_to_remove.add(i)
                 if self.scheduler.metrics_reporter.enable_metrics:
                     self.scheduler.metrics_collector.increment_transfer_failed_reqs()
                 continue
@@ -2050,6 +2074,9 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 raise ValueError(f"Unexpected poll case: {poll}")
 
         for i in indices_to_remove:
+            if i in deferred_indices:
+                # Held for deferred release; metadata buffer freed at resolve time.
+                continue
             if self.enable_staging and self.staging_handler.is_staging_room(
                 self.queue[i].req.bootstrap_room
             ):
@@ -2069,9 +2096,67 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
 
         return transferred_reqs
 
+    def _defer_release(self, decode_req: DecodeRequest) -> None:
+        deadline = time.monotonic() + self.deferred_kv_release_timeout
+        # Require an ack from every notified prefill rank (dummy-proof). Snapshot
+        # now -- the receiver may be cleared by resolve time.
+        required_acks = len(decode_req.kv_receiver.bootstrap_infos)
+        self._deferred_releases.append(
+            (decode_req, deadline, decode_req.metadata_buffer_index, required_acks)
+        )
+
+    def _do_release(self, decode_req: DecodeRequest, idx: int) -> None:
+        room = decode_req.req.bootstrap_room
+        if self.enable_staging and self.staging_handler.is_staging_room(room):
+            self.staging_handler.unregister_decode_req(room)
+        # release pre-allocated kv cache, but don't insert into the tree since it's failed
+        release_kv_cache(decode_req.req, self.tree_cache, is_insert=False)
+        self.metadata_buffers.bootstrap_room[idx] = 0
+        self.req_to_metadata_buffer_idx_allocator.free(idx)
+        decode_req.kv_receiver.kv_mgr.clear_deferred_abort_state(room)
+        decode_req.kv_receiver.clear()
+        decode_req.kv_receiver = None
+
+    def has_pending_deferred_releases(self) -> bool:
+        return bool(self._deferred_releases)
+
+    def resolve_deferred_releases(self) -> None:
+        """Release held requests once every prefill rank acks the drain, or the
+        hold times out."""
+        if not self._deferred_releases:
+            return
+        now = time.monotonic()
+        still_held = []
+        to_release = []
+        for decode_req, deadline, idx, required_acks in self._deferred_releases:
+            room = decode_req.req.bootstrap_room
+            kv_mgr = decode_req.kv_receiver.kv_mgr
+            drained = kv_mgr.is_abort_release_safe(room, required_acks)
+            if not drained and now < deadline:
+                still_held.append((decode_req, deadline, idx, required_acks))
+            else:
+                to_release.append((decode_req, idx, room, drained))
+        # Commit the survivors before releasing so a _do_release exception can't
+        # leave a released entry in the list (double-free / None receiver on retry).
+        self._deferred_releases = still_held
+        for decode_req, idx, room, drained in to_release:
+            if not drained:
+                logger.warning(
+                    f"Deferred KV release for room {room} timed out after "
+                    f"{self.deferred_kv_release_timeout}s without a full drain "
+                    f"ack from prefill; releasing anyway."
+                )
+            try:
+                self._do_release(decode_req, idx)
+            except Exception:
+                # Isolate a failed release so the rest still run; entry already dropped.
+                logger.exception(f"Deferred KV release failed for room {room}")
+
     def release_memory_occupation(self):
         """Clean up in-flight transfers before releasing GPU memory."""
         self.queue.clear()
+        # Pool is being torn down; drop held entries without per-request release.
+        self._deferred_releases.clear()
 
     def resume_memory_occupation(self):
         """Queues are already cleared on release; new transfers can be accepted."""
@@ -2289,6 +2374,10 @@ class SchedulerDisaggregationDecodeMixin:
 
         if get_disagg().disaggregation_decode_enable_offload_kvcache:
             self.decode_offload_manager.check_offload_progress()
+
+        # Resolve held releases every iteration (before the retraction/polling
+        # gates below) so their timeouts fire under memory pressure.
+        self.disagg_decode_transfer_queue.resolve_deferred_releases()
 
         # try to resume retracted requests if there are enough space for another `num_reserved_decode_tokens` decode steps
         resumed_reqs = self.disagg_decode_prealloc_queue.resume_retracted_reqs()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -8,7 +8,7 @@ import struct
 import threading
 import time
 from collections import defaultdict
-from typing import List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -204,6 +204,10 @@ class MooncakeKVManager(CommonKVManager):
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
+            # Deferred KV release: aborted room -> (decode_ip, decode_port), ack
+            # held until the transfer drains. Written by the bootstrap thread,
+            # popped by the single transfer worker that owns the room.
+            self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
             self.session_lock = threading.Lock()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
@@ -732,17 +736,30 @@ class MooncakeKVManager(CommonKVManager):
                 )
                 for (src_ptr, dst_ptr, item_len) in layers_params
             ]
-            for future in concurrent.futures.as_completed(futures):
-                status = future.result()
-                if status != 0:
-                    for f in futures:
-                        f.cancel()
-                    return status
-            return 0
+            return self._await_transfer_futures(futures)
         else:
             # Combining all layers' params in one batch transfer is more efficient
             # compared to using multiple threads
             return process_layers(layers_params)
+
+    def _await_transfer_futures(self, futures) -> int:
+        """Await a chunk's per-layer RDMA writes; return the first non-zero status.
+        cancel() is a no-op for a running future, so with deferred release on we
+        still drain the running ones before returning (no write may outlive this
+        call, which the drain-ack relies on). Off: original early-return."""
+        ret = 0
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                status = future.result()
+            except concurrent.futures.CancelledError:
+                continue
+            if status != 0 and ret == 0:
+                ret = status
+                for f in futures:
+                    f.cancel()
+                if not self.enable_deferred_decode_kv_release:
+                    return ret
+        return ret
 
     def send_kvcache(
         self,
@@ -850,13 +867,7 @@ class MooncakeKVManager(CommonKVManager):
                 executor.submit(process_layer, src_ptr, dst_ptr, token_item_len)
                 for src_ptr, dst_ptr, token_item_len in layers_params
             ]
-            for future in concurrent.futures.as_completed(futures):
-                status = future.result()
-                if status != 0:
-                    for pending in futures:
-                        pending.cancel()
-                    return status
-            return 0
+            return self._await_transfer_futures(futures)
 
         transfer_blocks = []
         for src_ptr, dst_ptr, token_item_len in layers_params:
@@ -984,14 +995,7 @@ class MooncakeKVManager(CommonKVManager):
                 executor.submit(process_layer_tp_aware, src_v_ptrs[i], dst_v_ptrs[i])
             )
 
-        for future in concurrent.futures.as_completed(futures):
-            status = future.result()
-            if status != 0:
-                for f in futures:
-                    f.cancel()
-                return status
-
-        return 0
+        return self._await_transfer_futures(futures)
 
     def send_aux(
         self,
@@ -1473,6 +1477,39 @@ class MooncakeKVManager(CommonKVManager):
             is_ipv6=na.is_ipv6,
         )
 
+    def _prefill_unique_rank(self) -> int:
+        """Stable per-sender id, matching what the transfer worker syncs on Success."""
+        return (
+            self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
+            + self.pp_rank * self.attn_cp_size
+            + self.attn_cp_rank
+        )
+
+    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
+        """Best-effort ack that this rank's transfer for an aborted room drained."""
+        try:
+            na = NetworkAddress(decode_ip, decode_port)
+            self._send_multipart_locked(
+                na.to_tcp(),
+                [
+                    b"ABORT_ACK",
+                    str(room).encode("ascii"),
+                    str(self._prefill_unique_rank()).encode("ascii"),
+                ],
+                is_ipv6=na.is_ipv6,
+            )
+        except Exception as e:
+            logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
+
+    def _maybe_ack_drained_abort(self, room: int) -> None:
+        """Send the deferred ack once an aborted room's chunks have drained
+        (outstanding == 0). pop() makes it fire at most once."""
+        if self._staging_outstanding.get(room, 0) > 0:
+            return
+        target = self._deferred_ack_targets.pop(room, None)
+        if target is not None:
+            self._send_abort_ack(target[0], target[1], room)
+
     def transfer_worker(
         self,
         queue: FastQueue,
@@ -1512,6 +1549,9 @@ class MooncakeKVManager(CommonKVManager):
                             thread_finish_flag=True,
                         )
                     self._staging_outstanding.pop(kv_chunk.room, None)
+                    if self.enable_deferred_decode_kv_release:
+                        # Skipped => nothing written for this aborted room; ack.
+                        self._maybe_ack_drained_abort(kv_chunk.room)
                     continue
 
                 # Count each chunk once; the flag survives re-enqueue on defer.
@@ -1764,6 +1804,10 @@ class MooncakeKVManager(CommonKVManager):
                     continue
 
                 self._staging_outstanding[kv_chunk.room] -= 1
+                if self.enable_deferred_decode_kv_release:
+                    # In-flight write finished; if aborted and nothing outstanding,
+                    # the pages are idle -> release the held ack.
+                    self._maybe_ack_drained_abort(kv_chunk.room)
                 # Tear down only when no chunk is still outstanding and the room
                 # has concluded: already cleared, Success, or a Failed *last*
                 # chunk. A non-last Failed chunk keeps the room (more chunks may
@@ -1823,11 +1867,36 @@ class MooncakeKVManager(CommonKVManager):
                     room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
                     decode_ip = waiting_req_bytes[2].decode("ascii")
                     decode_port = int(waiting_req_bytes[3].decode("ascii"))
-                    # No need to abort the room if it has already succeeded
-                    if (
+                    room_active = (
                         room_to_be_aborted in self.request_status
                         and self.check_status(room_to_be_aborted) != KVPoll.Success
-                    ):
+                    )
+                    if self.enable_deferred_decode_kv_release:
+                        # Mark Failed FIRST (stops add_transfer_request enqueuing
+                        # new chunks), THEN register the ack target: registering
+                        # first would let the worker drain+ack while the room is
+                        # not yet Failed, so a newly enqueued chunk could still
+                        # write to the freed pages. The worker (not this thread)
+                        # acks once its in-flight write drains; if nothing is in
+                        # flight, decode falls back to the release timeout.
+                        if room_active:
+                            self.update_status(room_to_be_aborted, KVPoll.Failed)
+                            self._deferred_ack_targets[room_to_be_aborted] = (
+                                decode_ip,
+                                decode_port,
+                            )
+                            logger.debug(
+                                f"Received abort notification for room {room_to_be_aborted}, "
+                                f"marked as Failed; ACK deferred until transfer drains"
+                            )
+                        else:
+                            # Already completed/unknown: no in-flight write, ack now.
+                            self._send_abort_ack(
+                                decode_ip, decode_port, room_to_be_aborted
+                            )
+                        continue
+                    # No need to abort the room if it has already succeeded
+                    if room_active:
                         self.update_status(room_to_be_aborted, KVPoll.Failed)
                         logger.debug(
                             f"Received abort notification for room {room_to_be_aborted}, "
@@ -1941,9 +2010,14 @@ class MooncakeKVManager(CommonKVManager):
 
                 # Prefill acknowledges abort notification
                 if msg[0] == b"ABORT_ACK":
-                    # TODO(shangming): use this info to implement the deferred release mechanism if needed
                     ack_aborted_room = int(msg[1].decode("ascii"))
                     logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
+                    # Deferred release: the 3-frame ack carries the prefill rank
+                    # and means its transfer drained; aggregate for is_abort_release_safe.
+                    if self.enable_deferred_decode_kv_release and len(msg) >= 3:
+                        self.note_abort_ack(
+                            ack_aborted_room, int(msg[2].decode("ascii"))
+                        )
                     continue
 
                 bootstrap_room, status, prefill_rank = msg

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -201,6 +201,9 @@ class MooncakeKVManager(CommonKVManager):
             self.start_prefill_thread()
             self.session_failures = defaultdict(int)
             self.failed_sessions = set()
+            # Per-room count of chunks not yet transferred; teardown waits for
+            # zero so a deferred chunk is not dropped by an early conclude.
+            self._staging_outstanding = defaultdict(int)
             self.session_lock = threading.Lock()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
@@ -264,7 +267,6 @@ class MooncakeKVManager(CommonKVManager):
             if self.enable_staging:
                 self._init_staging_allocator()
                 self._staging_handler = None
-                self._chunk_writer_counts: dict = defaultdict(lambda: defaultdict(list))
             self.start_decode_thread()
 
     def init_engine(self):
@@ -396,7 +398,8 @@ class MooncakeKVManager(CommonKVManager):
         return PrefillStagingStrategy(self, staging_buffer)
 
     def _send_chunk_ready(self, req, chunk_idx, kv_chunk, prefill_unique_rank):
-        """Notify decode that a non-last staging chunk RDMA is complete."""
+        """Notify decode that a staging chunk RDMA is complete (every chunk;
+        scatter is arrival-driven)."""
         na = NetworkAddress(req.endpoint, req.dst_port)
         self._send_multipart_locked(
             na.to_tcp(),
@@ -471,7 +474,7 @@ class MooncakeKVManager(CommonKVManager):
                 "reduce chunked_prefill_size."
             )
             return (-1, False)
-        if ret == 0 and not kv_chunk.is_last_chunk:
+        if ret == 0:
             self._send_chunk_ready(req, chunk_idx, kv_chunk, prefill_unique_rank)
         return (ret, False)
 
@@ -1508,7 +1511,13 @@ class MooncakeKVManager(CommonKVManager):
                             MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
                             thread_finish_flag=True,
                         )
+                    self._staging_outstanding.pop(kv_chunk.room, None)
                     continue
+
+                # Count each chunk once; the flag survives re-enqueue on defer.
+                if not kv_chunk.staging_counted:
+                    self._staging_outstanding[kv_chunk.room] += 1
+                    kv_chunk.staging_counted = True
 
                 if (
                     self.enable_staging
@@ -1754,10 +1763,21 @@ class MooncakeKVManager(CommonKVManager):
                 if staging_deferred:
                     continue
 
-                if (
+                self._staging_outstanding[kv_chunk.room] -= 1
+                # Tear down only when no chunk is still outstanding and the room
+                # has concluded: already cleared, Success, or a Failed *last*
+                # chunk. A non-last Failed chunk keeps the room (more chunks may
+                # follow), not on the last chunk alone since an earlier deferred
+                # chunk may still need to transfer.
+                if self._staging_outstanding.get(kv_chunk.room, 0) <= 0 and (
                     kv_chunk.room not in self.request_status
                     or self.check_status(kv_chunk.room) == KVPoll.Success
+                    or (
+                        kv_chunk.is_last_chunk
+                        and self.check_status(kv_chunk.room) == KVPoll.Failed
+                    )
                 ):
+                    self._staging_outstanding.pop(kv_chunk.room, None)
                     if kv_chunk.room in self.transfer_infos:
                         self.transfer_infos.pop(kv_chunk.room)
                     self.req_to_decode_prefix_len.pop(kv_chunk.room, None)
@@ -1911,7 +1931,6 @@ class MooncakeKVManager(CommonKVManager):
                         page_start,
                         num_pages,
                         session_id,
-                        self._chunk_writer_counts,
                     )
                     continue
 
@@ -1946,7 +1965,6 @@ class MooncakeKVManager(CommonKVManager):
                                 handler = self._staging_handler
                                 if handler.is_staging_room(bootstrap_room):
                                     handler.submit_last_scatter_async(bootstrap_room)
-                                self._chunk_writer_counts.pop(bootstrap_room, None)
                             self.update_status(bootstrap_room, KVPoll.Success)
                 elif status == KVPoll.Failed:
                     self.record_failure(
@@ -2119,6 +2137,13 @@ class MooncakeKVSender(CommonKVSender):
     def poll(self) -> KVPoll:
         if self.conclude_state is None:
             status = self.kv_mgr.check_status(self.bootstrap_room)
+            # Hold Success until all staging chunks transferred: a deferred
+            # chunk can still be pending, and concluding now would drop it.
+            if (
+                status == KVPoll.Success
+                and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
+            ):
+                return KVPoll.Transferring
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status
                 self.trace_ctx.trace_req_finish()

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -8,7 +8,7 @@ import struct
 import threading
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional, Tuple, Union
+from typing import List, Optional, Tuple, Union
 
 import numpy as np
 import numpy.typing as npt
@@ -204,10 +204,6 @@ class MooncakeKVManager(CommonKVManager):
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
-            # Deferred KV release: aborted room -> (decode_ip, decode_port), ack
-            # held until the transfer drains. Written by the bootstrap thread,
-            # popped by the single transfer worker that owns the room.
-            self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
             self.session_lock = threading.Lock()
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
@@ -1477,39 +1473,6 @@ class MooncakeKVManager(CommonKVManager):
             is_ipv6=na.is_ipv6,
         )
 
-    def _prefill_unique_rank(self) -> int:
-        """Stable per-sender id, matching what the transfer worker syncs on Success."""
-        return (
-            self.attn_tp_rank * (self.pp_size * self.attn_cp_size)
-            + self.pp_rank * self.attn_cp_size
-            + self.attn_cp_rank
-        )
-
-    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
-        """Best-effort ack that this rank's transfer for an aborted room drained."""
-        try:
-            na = NetworkAddress(decode_ip, decode_port)
-            self._send_multipart_locked(
-                na.to_tcp(),
-                [
-                    b"ABORT_ACK",
-                    str(room).encode("ascii"),
-                    str(self._prefill_unique_rank()).encode("ascii"),
-                ],
-                is_ipv6=na.is_ipv6,
-            )
-        except Exception as e:
-            logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
-
-    def _maybe_ack_drained_abort(self, room: int) -> None:
-        """Send the deferred ack once an aborted room's chunks have drained
-        (outstanding == 0). pop() makes it fire at most once."""
-        if self._staging_outstanding.get(room, 0) > 0:
-            return
-        target = self._deferred_ack_targets.pop(room, None)
-        if target is not None:
-            self._send_abort_ack(target[0], target[1], room)
-
     def transfer_worker(
         self,
         queue: FastQueue,
@@ -1535,6 +1498,14 @@ class MooncakeKVManager(CommonKVManager):
                         MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
                     )
 
+                # Counted at dequeue, before the status check, so
+                # `outstanding == 0` means nothing is dequeued or in flight --
+                # the predicate the abort ack relies on. The flag survives
+                # re-enqueue on defer.
+                if not kv_chunk.staging_counted:
+                    self._staging_outstanding[kv_chunk.room] += 1
+                    kv_chunk.staging_counted = True
+
                 if (
                     kv_chunk.room not in self.request_status
                     or self.check_status(kv_chunk.room) == KVPoll.Failed
@@ -1553,11 +1524,6 @@ class MooncakeKVManager(CommonKVManager):
                         # Skipped => nothing written for this aborted room; ack.
                         self._maybe_ack_drained_abort(kv_chunk.room)
                     continue
-
-                # Count each chunk once; the flag survives re-enqueue on defer.
-                if not kv_chunk.staging_counted:
-                    self._staging_outstanding[kv_chunk.room] += 1
-                    kv_chunk.staging_counted = True
 
                 if (
                     self.enable_staging
@@ -1881,16 +1847,20 @@ class MooncakeKVManager(CommonKVManager):
                         # flight, decode falls back to the release timeout.
                         if room_active:
                             self.update_status(room_to_be_aborted, KVPoll.Failed)
-                            self._deferred_ack_targets[room_to_be_aborted] = (
-                                decode_ip,
-                                decode_port,
+                            self.register_deferred_ack_target(
+                                room_to_be_aborted, decode_ip, decode_port
                             )
+                            # Try once: the room may already be quiescent and
+                            # never revisited by the worker.
+                            self._maybe_ack_drained_abort(room_to_be_aborted)
                             logger.debug(
                                 f"Received abort notification for room {room_to_be_aborted}, "
                                 f"marked as Failed; ACK deferred until transfer drains"
                             )
-                        else:
-                            # Already completed/unknown: no in-flight write, ack now.
+                        elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
+                            # Concluded/unknown AND quiescent: ack now. A cleared
+                            # room is not automatically quiescent -- clear() can
+                            # drop a room whose chunk is still transferring.
                             self._send_abort_ack(
                                 decode_ip, decode_port, room_to_be_aborted
                             )

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -481,6 +481,9 @@ class NixlKVManager(CommonKVManager):
                 FastQueue() for _ in range(transfer_queue_size)
             ]
             self.exceptions: Dict[int, Exception] = {}
+            # Per-room count of chunks not yet transferred; teardown waits for
+            # zero so a deferred chunk is not dropped by an early conclude.
+            self._staging_outstanding = defaultdict(int)
             # Mirror mooncake: one staging buffer per worker queue, all
             # built before workers spawn so each worker owns a private
             # buffer (no cross-worker contention on the staging ring).
@@ -506,7 +509,6 @@ class NixlKVManager(CommonKVManager):
             if self.enable_staging:
                 self._init_staging_decode_ctx()
                 self._staging_handler = None
-                self._chunk_writer_counts: dict = defaultdict(lambda: defaultdict(list))
                 self._start_decode_staging_thread()
             self._start_heartbeat_checker_thread()
         else:
@@ -1115,9 +1117,15 @@ class NixlKVManager(CommonKVManager):
             handles: List[Any] = []
             try:
                 if self.check_status(room) == KVPoll.Failed:
+                    self._staging_outstanding.pop(room, None)
                     continue
 
                 assert room in self.transfer_infos
+
+                # Count each chunk once; the flag survives re-enqueue on defer.
+                if not kv_chunk.staging_counted:
+                    self._staging_outstanding[room] += 1
+                    kv_chunk.staging_counted = True
 
                 # Lazily build a per-worker staging strategy bound to this
                 # worker's private staging buffer (matches mooncake).
@@ -1329,10 +1337,26 @@ class NixlKVManager(CommonKVManager):
                         break
                     time.sleep(0)
 
+                self._staging_outstanding[room] -= 1
                 if kv_chunk.is_last_chunk:
                     self.update_status(room, KVPoll.Success)
-                    # Drop per-room state on Success (parity with mooncake
-                    # transfer_worker; staging prefetch sets are NIXL-only).
+                elif self.check_status(room) != KVPoll.Success:
+                    # A deferred earlier chunk can complete after the last chunk
+                    # already concluded Success; don't regress the status.
+                    self.update_status(room, KVPoll.Transferring)
+
+                # Drop per-room state only when no chunk is still outstanding and
+                # the room has concluded: Success, or a Failed *last* chunk. A
+                # non-last Failed chunk keeps the room (more chunks may follow); a
+                # late chunk for an already-Failed room is skipped at loop top.
+                if self._staging_outstanding.get(room, 0) <= 0 and (
+                    self.check_status(room) == KVPoll.Success
+                    or (
+                        kv_chunk.is_last_chunk
+                        and self.check_status(room) == KVPoll.Failed
+                    )
+                ):
+                    self._staging_outstanding.pop(room, None)
                     self.transfer_infos.pop(room, None)
                     self.req_to_decode_prefix_len.pop(room, None)
                     if self.enable_staging and self._staging_ctx is not None:
@@ -1341,8 +1365,6 @@ class NixlKVManager(CommonKVManager):
                         for k in list(self._staging_ctx.prefetch_requested):
                             if k[0] == room:
                                 self._staging_ctx.prefetch_requested.discard(k)
-                else:
-                    self.update_status(room, KVPoll.Transferring)
             except Exception as e:
                 # Catch all exceptions to prevent silently killing this
                 # worker thread, but still propagate via failure_exception().
@@ -2461,10 +2483,12 @@ class NixlKVManager(CommonKVManager):
         page_start = int(components[6])
         num_pages = int(components[7])
         agent_name = components[8] if len(components) > 8 else ""
-        self._track_kv_arrival(room, chunk_id, is_last_chunk, pp_rank)
+        # Count this notif's own arrival BEFORE _track_kv_arrival, which can
+        # conclude the transfer and record all-ranks Success.
         self._handle_staging_chunk_arrived(
             room, chunk_idx, page_start, num_pages, agent_name
         )
+        self._track_kv_arrival(room, chunk_id, is_last_chunk, pp_rank)
 
     def _handle_aux_notification(self, room: int, components: List[str]):
         """Handle an aux notification and trigger last scatter if staging is complete.
@@ -2567,7 +2591,6 @@ class NixlKVManager(CommonKVManager):
             page_start,
             num_pages,
             agent_name,
-            self._chunk_writer_counts,
         )
 
     def _maybe_submit_last_scatter(self, room: int):
@@ -2587,7 +2610,6 @@ class NixlKVManager(CommonKVManager):
         handler = self._staging_handler
         if handler is not None and handler.is_staging_room(room):
             handler.submit_last_scatter_async(room)
-            self._chunk_writer_counts.pop(room, None)
 
     def check_transfer_done(self, room: int):
         if room not in self.transfer_statuses:
@@ -2762,6 +2784,13 @@ class NixlKVSender(CommonKVSender):
         if self._send_failed:
             return KVPoll.Failed  # type: ignore
         status = self.kv_mgr.check_status(self.bootstrap_room)
+        # Hold Success until all staging chunks transferred: a deferred chunk
+        # can still be pending, and concluding now would drop it.
+        if (
+            status == KVPoll.Success
+            and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
+        ):
+            return KVPoll.Transferring  # type: ignore
         if (
             status == KVPoll.Success
             and self._transfer_start_time is not None

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -509,7 +509,8 @@ class NixlKVManager(CommonKVManager):
             if self.enable_staging:
                 self._init_staging_decode_ctx()
                 self._staging_handler = None
-                self._start_decode_staging_thread()
+            if self.enable_staging or self.enable_deferred_decode_kv_release:
+                self._start_decode_listener_thread()
             self._start_heartbeat_checker_thread()
         else:
             raise ValueError(
@@ -589,21 +590,30 @@ class NixlKVManager(CommonKVManager):
 
         return is_watermark_ready(self._staging_ctx, agent_name, alloc_round, alloc_end)
 
-    def _start_decode_staging_thread(self):
-        """Start a thread on the decode side to recv STAGING_REQ from prefill via ZMQ."""
+    def _start_decode_listener_thread(self):
+        """Decode-side ZMQ listener for STAGING_REQ and ABORT_ACK. A thread, not
+        NIXL notifs: the decode agent has no progress thread, so notifs only drain
+        inside a live receiver's poll() and would be missed while idle."""
 
-        def decode_staging_thread():
+        def decode_listener_thread():
             while True:
                 msg = self.server_socket.recv_multipart()
                 if msg[0] == b"STAGING_REQ":
                     self._handle_staging_req(msg)
                     continue
+                if msg[0] == b"ABORT_ACK":
+                    # Drain ack for an aborted room; aggregate per prefill rank.
+                    if len(msg) >= 3:
+                        self.note_abort_ack(
+                            int(msg[1].decode("ascii")), int(msg[2].decode("ascii"))
+                        )
+                    continue
                 logger.warning(
-                    "decode_staging_thread: unexpected message tag %s",
+                    "decode_listener_thread: unexpected message tag %s",
                     msg[0][:20],
                 )
 
-        threading.Thread(target=decode_staging_thread, daemon=True).start()
+        threading.Thread(target=decode_listener_thread, daemon=True).start()
 
     def _handle_staging_req(self, msg):
         from sglang.srt.disaggregation.common.staging_handler import (
@@ -1116,16 +1126,22 @@ class NixlKVManager(CommonKVManager):
             room = kv_chunk.room
             handles: List[Any] = []
             try:
-                if self.check_status(room) == KVPoll.Failed:
-                    self._staging_outstanding.pop(room, None)
-                    continue
-
-                assert room in self.transfer_infos
-
-                # Count each chunk once; the flag survives re-enqueue on defer.
+                # Counted at dequeue, before the status check, so
+                # `outstanding == 0` means nothing is dequeued or in flight --
+                # the predicate the abort ack relies on. The flag survives
+                # re-enqueue on defer.
                 if not kv_chunk.staging_counted:
                     self._staging_outstanding[room] += 1
                     kv_chunk.staging_counted = True
+
+                if self.check_status(room) == KVPoll.Failed:
+                    self._staging_outstanding.pop(room, None)
+                    if self.enable_deferred_decode_kv_release:
+                        # Skipped => nothing written for this aborted room; ack.
+                        self._maybe_ack_drained_abort(room)
+                    continue
+
+                assert room in self.transfer_infos
 
                 # Lazily build a per-worker staging strategy bound to this
                 # worker's private staging buffer (matches mooncake).
@@ -1338,6 +1354,10 @@ class NixlKVManager(CommonKVManager):
                     time.sleep(0)
 
                 self._staging_outstanding[room] -= 1
+                if self.enable_deferred_decode_kv_release:
+                    # Handles all DONE => this room's writes landed; ack if it
+                    # was aborted and nothing else is outstanding.
+                    self._maybe_ack_drained_abort(room)
                 if kv_chunk.is_last_chunk:
                     self.update_status(room, KVPoll.Success)
                 elif self.check_status(room) != KVPoll.Success:
@@ -1377,6 +1397,8 @@ class NixlKVManager(CommonKVManager):
                 self.exceptions[room] = e
                 self.record_failure(room, str(e))
                 self.update_status(room, KVPoll.Failed)
+                # No ack here on purpose: the DONE barrier bails on the first
+                # ERR, so siblings may still be writing; fall back to the timeout.
 
     def register_buffer_to_engine(self):
         self.kv_descs = []
@@ -2622,14 +2644,17 @@ class NixlKVManager(CommonKVManager):
 
         try:
             room_to_be_aborted = int(msg[1].decode("ascii"))
+            decode_ip = msg[2].decode("ascii") if len(msg) > 2 else None
+            decode_port = int(msg[3].decode("ascii")) if len(msg) > 3 else None
         except Exception as e:
             logger.debug(f"Ignoring malformed abort notification: {e}")
             return True
 
-        if (
+        room_active = (
             room_to_be_aborted in self.request_status
             and self.check_status(room_to_be_aborted) != KVPoll.Success
-        ):
+        )
+        if room_active:
             self.record_failure(
                 room_to_be_aborted,
                 "Aborted by decode-side abort notification.",
@@ -2645,8 +2670,20 @@ class NixlKVManager(CommonKVManager):
                 f"ignoring (already completed or unknown)"
             )
 
-        # TODO: Define real ACK/deferred-release semantics if decode-side buffer
-        # release needs to wait for prefill-side NIXL transfer quiescence.
+        # Deferred KV release: register only after the status flip above (see
+        # register_deferred_ack_target), then try once -- the room may already be
+        # quiescent and never revisited by the worker. A concluded/unknown room is
+        # acked only when nothing is still counted for it: the ERR path abandons
+        # sibling handles that may still be writing and clear() then drops the
+        # room, so "unknown" alone does not imply quiescent.
+        if self.enable_deferred_decode_kv_release and decode_port is not None:
+            if room_active:
+                self.register_deferred_ack_target(
+                    room_to_be_aborted, decode_ip, decode_port
+                )
+                self._maybe_ack_drained_abort(room_to_be_aborted)
+            elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
+                self._send_abort_ack(decode_ip, decode_port, room_to_be_aborted)
 
         return True
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -32,6 +32,10 @@ import torch
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.disaggregation.base.conn import StateType
 from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.common.staging_buffer import (
+    compute_grid_segments,
+    staging_grid_tokens,
+)
 from sglang.srt.disaggregation.utils import (
     FAKE_BOOTSTRAP_HOST,
     DisaggregationMode,
@@ -334,6 +338,8 @@ class PrefillBootstrapQueue:
         decode_prefix_len = req.disagg_kv_sender.pop_decode_prefix_len()
         num_kv_indices = len(req.origin_input_ids)
         req.start_send_idx = decode_prefix_len
+        # Base of the staging chunk grid (suffix-relative send coordinates).
+        req.disagg_decode_prefix_len = decode_prefix_len
         num_kv_indices_to_send = num_kv_indices - decode_prefix_len
         num_pages = kv_to_page_num(
             num_kv_indices_to_send,
@@ -1075,16 +1081,26 @@ class SchedulerDisaggregationPrefillMixin:
                 running_batch.batch_is_full = False
 
     def maybe_send_cached_prefix_chunk(self: Scheduler, req: Req) -> None:
-        # Only bootstrap-finalized requests; staging excluded.
-        if (
-            not envs.SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get()
-            or self.enable_staging
-            or req.pending_bootstrap
-        ):
+        if not envs.SGLANG_DISAGG_PREFILL_EARLY_SEND_CACHED_PREFIX.get():
+            return
+
+        # Staging sends into positional grid slots, so the early-send boundary
+        # must stay stable across the request's batches: snapshot the at-rest
+        # prefix on the first batch. Non-staging reads the live prefix.
+        if self.enable_staging and req.early_send_prefix_end is None:
+            req.early_send_prefix_end = max(
+                0, len(req.prefix_indices) - req.host_hit_length
+            )
+
+        if req.pending_bootstrap:
             return
 
         # Device-resident prefix only; page-aligned so start_send_idx stays exact.
-        cached_end = len(req.prefix_indices) - req.host_hit_length
+        cached_end = (
+            req.early_send_prefix_end
+            if self.enable_staging
+            else len(req.prefix_indices) - req.host_hit_length
+        )
         if cached_end <= req.start_send_idx:
             return
         if cached_end % self.token_to_kv_pool_allocator.page_size != 0:
@@ -1124,6 +1140,15 @@ class SchedulerDisaggregationPrefillMixin:
         if not last_chunk:
             # if not the last chunk and the last page is partial, delay the last partial page to the next send
             end_idx = end_idx - end_idx % page_size
+            if self.enable_staging:
+                # Staging identifies chunks positionally against a uniform
+                # prefetched grid, so non-last sends must end on a grid
+                # boundary; the remainder rides with the next send.
+                grid_tokens = staging_grid_tokens(
+                    self.server_args.chunked_prefill_size, page_size
+                )
+                base = req.disagg_decode_prefix_len
+                end_idx = base + ((end_idx - base) // grid_tokens) * grid_tokens
 
         if end_idx < start_idx:
             logger.debug(
@@ -1238,17 +1263,35 @@ class SchedulerDisaggregationPrefillMixin:
                 payloads[st]() if st in payloads else None for st in state_types
             ]
 
-        kv_indices = self.req_to_token_pool.req_to_token[
-            req.req_pool_idx, start_idx:end_idx
-        ]
-        page_indices = kv_to_page_indices(kv_indices, page_size)
-        if not req.disagg_kv_sender.should_send_kv_chunk(len(page_indices), last_chunk):
-            return
-        req.disagg_kv_sender.send(
-            page_indices,
-            state_indices,
-            num_kv_tokens=end_idx - start_idx,
-        )
+        if self.enable_staging:
+            # One sender.send per grid slot; the sender's cumulative page
+            # counter marks only the final sub-send of the final chunk as
+            # is_last, routing aux/state correctly.
+            segments = compute_grid_segments(
+                start_idx,
+                end_idx,
+                req.disagg_decode_prefix_len,
+                staging_grid_tokens(self.server_args.chunked_prefill_size, page_size),
+            )
+        else:
+            segments = [(start_idx, end_idx)]
+
+        for seg_start, seg_end in segments:
+            is_final_segment = seg_end == end_idx
+            kv_indices = self.req_to_token_pool.req_to_token[
+                req.req_pool_idx, seg_start:seg_end
+            ]
+            page_indices = kv_to_page_indices(kv_indices, page_size)
+            segment_is_last = last_chunk and is_final_segment
+            if not req.disagg_kv_sender.should_send_kv_chunk(
+                len(page_indices), segment_is_last
+            ):
+                continue
+            req.disagg_kv_sender.send(
+                page_indices,
+                state_indices if segment_is_last else None,
+                num_kv_tokens=seg_end - seg_start,
+            )
         req.start_send_idx = end_idx
 
     def optimistic_release_and_requeue(self: Scheduler, req: Req) -> None:
@@ -1260,6 +1303,8 @@ class SchedulerDisaggregationPrefillMixin:
         req.output_ids = array("q")
         req.start_send_idx = 0
         req.tmp_end_idx = -1
+        req.disagg_decode_prefix_len = 0
+        req.early_send_prefix_end = None
         req.hidden_states_tensor = None
         req.output_dsa_topk_indices = None
         req.pending_bootstrap = True

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -218,6 +218,13 @@ def poll_and_all_reduce_with_staging(
     receivers = [dr.kv_receiver for dr in decode_reqs]
     raw_polls = _poll_with_failure_injection(receivers)
     for i, decode_req in enumerate(decode_reqs):
+        if decode_req.kv_receiver.require_staging and staging_handler.is_failed(
+            decode_req
+        ):
+            # Staging completion timed out; KVPoll.Failed == 0 propagates
+            # through the MIN all_reduce.
+            raw_polls[i] = int(KVPoll.Failed)
+            continue
         if raw_polls[i] == int(KVPoll.Success):
             if decode_req.kv_receiver.require_staging and not staging_handler.is_done(
                 decode_req

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -415,6 +415,11 @@ class Envs:
     SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER = EnvBool(False)
     SGLANG_DISAGGREGATION_FORCE_QUERY_PREFILL_DP_RANK = EnvBool(False)
     SGLANG_DISAGGREGATION_SAMPLING_MASK_MAX_TOKENS = EnvInt(0)
+    # Deferred decode-side KV release: on abort, hold an in-flight request's KV
+    # pages/slot until the prefill acks the transfer drained, or the timeout
+    # below fires. Off by default (no behavior/perf impact when disabled).
+    SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE = EnvBool(False)
+    SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT = EnvFloat(30.0)
 
     # Scheduler: others:
     # in seconds. Set if you observe high memory accumulation over a long serving period.

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1134,6 +1134,12 @@ class Req(ReqDllmMixin):
         # This is because kv is not ready in `process_prefill_chunk`.
         # We use `tmp_end_idx` to store the end index of the kv cache to send.
         self.tmp_end_idx: int = -1
+        # Decode-side cached-prefix length; base of the staging chunk grid
+        # (start_send_idx starts here but advances with every send).
+        self.disagg_decode_prefix_len: int = 0
+        # At-rest device-resident prefix end, snapshotted on the request's
+        # first prefill batch; the cached-prefix early-send never goes past it.
+        self.early_send_prefix_end: Optional[int] = None
         self.metadata_buffer_index: int = -1
         # Used in overlap sequence to signal that an optimistic request should
         # abort chunking. Set in create_sender, consumed in process_batch_result.

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3850,7 +3850,14 @@ class Scheduler(
 
         # memory leak check (skipped for hisparse — pool counters intentionally
         # diverge during host-backup, see _get_swa_token_info clamp).
-        if not self.enable_hisparse:
+        # Also skipped while deferred KV releases are pending: they hold pages out
+        # of the allocator by design, so the pool is transiently below `total` and
+        # would trip the idle leak invariant. Resumes once the holds resolve.
+        deferred_pending = (
+            self.disaggregation_mode == DisaggregationMode.DECODE
+            and self.disagg_decode_transfer_queue.has_pending_deferred_releases()
+        )
+        if not self.enable_hisparse and not deferred_pending:
             has_leak, messages = self.invariant_checker._check_all_pools(
                 self.pool_stats_observer.get_pool_stats(),
             )
@@ -4328,7 +4335,21 @@ class Scheduler(
             for decode_req in self.disagg_decode_transfer_queue.queue:
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
-                    decode_req.kv_receiver.abort()
+                    receiver = decode_req.kv_receiver
+                    receiver.abort()
+                    # Arm drain-ack accounting once the ABORT is sent, so acks
+                    # arriving before this req is deferred (e.g. during the next
+                    # forward step) are captured. A fresh set also drops stale acks
+                    # from a prior request that reused this bootstrap_room. A
+                    # redundant abort only re-wipes -- holds longer, never releases
+                    # early -- so no transition guard is needed.
+                    if (
+                        receiver.kv_mgr.enable_deferred_decode_kv_release
+                        and receiver.abort_notified
+                    ):
+                        receiver.kv_mgr.register_deferred_abort_room(
+                            decode_req.req.bootstrap_room
+                        )
 
             # Abort requests already retracted to CPU cache
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1466,6 +1466,9 @@ class SchedulerPPMixin:
     def process_decode_transfer_queue(
         self: Scheduler, release_rids: Optional[List[str]]
     ):
+        # Resolve held deferred releases every call, independent of release_rids,
+        # so ack/timeout-driven releases still fire when no rids are being polled.
+        self.disagg_decode_transfer_queue.resolve_deferred_releases()
         if release_rids is not None:
             released_reqs = self.disagg_decode_transfer_queue.pop_transferred(
                 release_rids

--- a/test/registered/disaggregation/test_disaggregation_different_tp.py
+++ b/test/registered/disaggregation/test_disaggregation_different_tp.py
@@ -595,5 +595,104 @@ class TestDisaggregationGDNHybridHeteroTP(PDDisaggregationServerBase):
         self.assertGreater(metrics["score"], 0.60)
 
 
+class TestDisaggregationStagingRadixPrefillLargerTP(PDDisaggregationServerBase):
+    """Prefill TP=4 -> Decode TP=2, staging + radix cache on both sides.
+
+    The gsm8k few-shot preamble is a prefix shared by every request. With a
+    small chunked-prefill-size it spans several staging grid slots, so a
+    prefill radix hit bundles a multi-slot prefix into the first send and the
+    decode side reuses its own cached prefix -- the exact grid-split and
+    decode-prefix scatter-offset paths that a default (single-slot) prefix
+    never reaches. Unpatched, this configuration corrupts KV or wedges; the
+    gsm8k score guards against both.
+    """
+
+    # Small enough that the shared gsm8k few-shot prefix (~900 tokens) spans
+    # several staging grid slots, so a radix hit exercises the grid-split path.
+    CHUNKED_PREFILL_SIZE = "256"
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        envs.SGLANG_ENABLE_JIT_DEEPGEMM.set(False)
+
+        cls.model = try_cached_model(DEFAULT_MODEL_NAME_FOR_TEST)
+
+        cls.start_prefill()
+        cls.start_decode()
+
+        cls.wait_server_ready(cls.prefill_url + "/health", process=cls.process_prefill)
+        cls.wait_server_ready(cls.decode_url + "/health", process=cls.process_decode)
+
+        cls.launch_lb()
+
+    @classmethod
+    def start_prefill(cls):
+        prefill_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "prefill",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "4",
+            "--chunked-prefill-size",
+            cls.CHUNKED_PREFILL_SIZE,
+            "--enable-metrics",
+            "--enable-request-time-stats-logging",
+        ]
+        prefill_args += cls.transfer_backend + cls.rdma_devices
+        env = {**os.environ, **STAGING_ENV}
+        cls.process_prefill = popen_launch_pd_server(
+            cls.model,
+            cls.prefill_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=prefill_args,
+            env=env,
+        )
+
+    @classmethod
+    def start_decode(cls):
+        decode_args = [
+            "--trust-remote-code",
+            "--disaggregation-mode",
+            "decode",
+            "--disaggregation-bootstrap-port",
+            cls.bootstrap_port,
+            "--tp",
+            "2",
+            "--base-gpu-id",
+            "4",
+            "--chunked-prefill-size",
+            cls.CHUNKED_PREFILL_SIZE,
+            "--disaggregation-decode-enable-radix-cache",
+            "--enable-metrics",
+            "--enable-request-time-stats-logging",
+        ]
+        decode_args += cls.transfer_backend + cls.rdma_devices
+        env = {**os.environ, **STAGING_ENV}
+        cls.process_decode = popen_launch_pd_server(
+            cls.model,
+            cls.decode_url,
+            timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
+            other_args=decode_args,
+            env=env,
+        )
+
+    def test_gsm8k(self):
+        args = SimpleNamespace(
+            base_url=self.base_url,
+            model=self.model,
+            eval_name="gsm8k",
+            api="completion",
+            max_tokens=512,
+            num_examples=200,
+            num_threads=128,
+        )
+        metrics = run_eval(args)
+        print(f"[Staging Radix PrefillLargerTP] Evaluation metrics: {metrics}")
+        self.assertGreater(metrics["score"], 0.60)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -155,6 +155,7 @@ class TestDecodeQueueCleanup(CustomTestCase):
         queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
         queue.queue = [decode_req]
         queue.enable_staging = False
+        queue.enable_deferred_kv_release = False
         queue.gloo_group = MagicMock()
         queue.req_to_metadata_buffer_idx_allocator = MagicMock()
         queue.tp_rank = 0

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -1,0 +1,247 @@
+"""Unit tests for the deferred decode-side KV release mechanism.
+
+When a decode request is aborted while its prefill->decode KV transfer may still
+be in flight, the decode side holds its KV pages / req-slot instead of freeing
+them immediately (which could let the still-in-flight write land on pages already
+reused by another request). The pages are released once every prefill rank acks
+that its transfer drained (CommonKVManager.is_abort_release_safe), or a timeout
+fires. See DecodeTransferQueue.resolve_deferred_releases.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.disaggregation import decode as decode_mod
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.decode import DecodeTransferQueue
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_manager():
+    """A bare CommonKVManager carrying only the deferred-ack state the helpers
+    touch (avoids the heavy real __init__)."""
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr._deferred_abort_ack_tracker = {}
+    return mgr
+
+
+class TestAbortAckAggregation(CustomTestCase):
+    def test_release_safe_only_after_all_required_ranks_ack(self):
+        mgr = _make_manager()
+        room = 100
+        mgr.register_deferred_abort_room(room)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+
+        mgr.note_abort_ack(room, 0)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+
+        mgr.note_abort_ack(room, 1)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
+
+    def test_duplicate_rank_ack_does_not_over_count(self):
+        mgr = _make_manager()
+        room = 101
+        mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0)
+        mgr.note_abort_ack(room, 0)  # same rank twice
+        # Two acks arrived but from one rank: not safe for a 2-rank prefill.
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+
+    def test_single_rank_fast_path(self):
+        mgr = _make_manager()
+        room = 102
+        mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=1))
+
+    def test_clear_deferred_abort_state(self):
+        mgr = _make_manager()
+        room = 103
+        mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0)
+        mgr.clear_deferred_abort_state(room)
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
+
+    def test_ack_before_register_is_dropped(self):
+        # An ack for a room that isn't actively held must not be recorded (it
+        # would otherwise pollute a later request reusing the same room).
+        mgr = _make_manager()
+        room = 104
+        mgr.note_abort_ack(room, 0)  # no register yet
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
+
+    def test_late_ack_after_release_does_not_pollute_reused_room(self):
+        # Regression for bootstrap_room reuse: req A (room R) releases, then a
+        # late ack from A arrives, then req B reuses room R. B must start from a
+        # clean slate and not inherit A's ack (which would release B early while
+        # its transfer is still in flight -> KV corruption).
+        mgr = _make_manager()
+        room = 105
+
+        # Req A: held, one of two ranks acks, then released (e.g. timed out).
+        mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0)
+        mgr.clear_deferred_abort_state(room)
+
+        # Late ack from A's other rank arrives after release -> dropped.
+        mgr.note_abort_ack(room, 1)
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+
+        # Req B reuses room R.
+        mgr.register_deferred_abort_room(room)
+        # Only B's rank-0 has acked so far; a 2-rank prefill is NOT safe yet.
+        mgr.note_abort_ack(room, 0)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+        mgr.note_abort_ack(room, 1)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
+
+    def test_register_resets_stale_acks(self):
+        mgr = _make_manager()
+        room = 106
+        mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0)
+        mgr.note_abort_ack(room, 1)
+        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
+        # Re-registering (a later reuse) wipes the prior acks.
+        mgr.register_deferred_abort_room(room)
+        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
+
+
+class _FakeIdxAllocator:
+    def __init__(self):
+        self.freed = []
+
+    def free(self, idx):
+        self.freed.append(idx)
+
+
+def _make_queue(timeout=30.0):
+    q = DecodeTransferQueue.__new__(DecodeTransferQueue)
+    q._deferred_releases = []
+    q.deferred_kv_release_timeout = timeout
+    q.enable_staging = False
+    q.staging_handler = None
+    q.tree_cache = object()
+    q.metadata_buffers = SimpleNamespace(bootstrap_room={})
+    q.req_to_metadata_buffer_idx_allocator = _FakeIdxAllocator()
+    return q
+
+
+def _make_decode_req(room, idx, mgr, n_prefill_ranks=1):
+    receiver = SimpleNamespace(
+        kv_mgr=mgr,
+        # One entry per prefill rank the decode notified of the abort; its length
+        # is the required drain-ack count (see DecodeTransferQueue._defer_release).
+        bootstrap_infos=[{"rank": r} for r in range(n_prefill_ranks)],
+        clear=lambda: None,
+    )
+    return SimpleNamespace(
+        req=SimpleNamespace(bootstrap_room=room),
+        kv_receiver=receiver,
+        metadata_buffer_index=idx,
+    )
+
+
+class TestResolveDeferredReleases(CustomTestCase):
+    def test_noop_when_nothing_deferred(self):
+        q = _make_queue()
+        with patch.object(decode_mod, "release_kv_cache") as rel:
+            q.resolve_deferred_releases()
+        rel.assert_not_called()
+
+    def test_holds_until_drained_then_releases(self):
+        mgr = _make_manager()
+        room, idx = 200, 7
+        q = _make_queue()
+        dreq = _make_decode_req(room, idx, mgr, n_prefill_ranks=2)
+        # In production the room is armed in abort_request when the ABORT is
+        # sent, before the scheduler defers here.
+        mgr.register_deferred_abort_room(room)
+        q._defer_release(dreq)
+
+        with patch.object(decode_mod, "release_kv_cache") as rel:
+            # Not yet acked -> held, not released.
+            q.resolve_deferred_releases()
+            rel.assert_not_called()
+            self.assertEqual(len(q._deferred_releases), 1)
+
+            # One of two ranks acked -> still held.
+            mgr.note_abort_ack(room, 0)
+            q.resolve_deferred_releases()
+            rel.assert_not_called()
+            self.assertEqual(len(q._deferred_releases), 1)
+
+            # Both ranks acked -> released exactly once.
+            mgr.note_abort_ack(room, 1)
+            q.resolve_deferred_releases()
+            rel.assert_called_once_with(dreq.req, q.tree_cache, is_insert=False)
+
+        # Held state fully cleaned up.
+        self.assertEqual(q._deferred_releases, [])
+        self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [idx])
+        self.assertEqual(q.metadata_buffers.bootstrap_room[idx], 0)
+        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
+        self.assertIsNone(dreq.kv_receiver)
+
+    def test_releases_on_timeout_without_ack(self):
+        mgr = _make_manager()
+        room, idx = 300, 3
+        q = _make_queue(timeout=30.0)
+        dreq = _make_decode_req(room, idx, mgr, n_prefill_ranks=1)
+        # Force an already-expired deadline (no ack will ever arrive).
+        q._deferred_releases.append((dreq, float("-inf"), idx, 1))
+
+        with patch.object(decode_mod, "release_kv_cache") as rel:
+            q.resolve_deferred_releases()
+            rel.assert_called_once_with(dreq.req, q.tree_cache, is_insert=False)
+
+        self.assertEqual(q._deferred_releases, [])
+        self.assertEqual(q.req_to_metadata_buffer_idx_allocator.freed, [idx])
+        self.assertIsNone(dreq.kv_receiver)
+
+    def test_failed_release_is_isolated_and_not_retried(self):
+        # A raising _do_release must drop the entry (no double-free on retry) and
+        # not brick resolve for the remaining entries or subsequent calls.
+        mgr = _make_manager()
+        q = _make_queue()
+        good = _make_decode_req(700, 1, mgr)
+        bad = _make_decode_req(701, 2, mgr)
+        # Both already past deadline -> both selected for release.
+        q._deferred_releases.append((bad, float("-inf"), 2, 1))
+        q._deferred_releases.append((good, float("-inf"), 1, 1))
+
+        calls = []
+
+        def fake_release(req, tree_cache, is_insert):
+            calls.append(req)
+            if req is bad.req:
+                raise RuntimeError("boom")
+
+        with patch.object(decode_mod, "release_kv_cache", side_effect=fake_release):
+            q.resolve_deferred_releases()  # must not raise
+            # The good one still released despite the bad one throwing.
+            self.assertIn(good.req, calls)
+            # Nothing left held, and a second call is a clean no-op (no retry).
+            self.assertEqual(q._deferred_releases, [])
+            q.resolve_deferred_releases()
+
+    def test_defer_release_records_deadline_and_idx(self):
+        mgr = _make_manager()
+        q = _make_queue(timeout=12.5)
+        dreq = _make_decode_req(room=400, idx=9, mgr=mgr)
+        q._defer_release(dreq)
+        self.assertEqual(len(q._deferred_releases), 1)
+        held_req, deadline, held_idx, required = q._deferred_releases[0]
+        self.assertIs(held_req, dreq)
+        self.assertEqual(held_idx, 9)
+        self.assertIsInstance(deadline, float)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -466,6 +466,7 @@ class TestNixlTransferWorker(CustomTestCase):
         mgr.req_to_decode_prefix_len = {room: 4}
         mgr.enable_staging = False
         mgr._staging_ctx = None
+        mgr._staging_outstanding = defaultdict(int)
         mgr.is_mla_backend = False
         mgr.is_hybrid_mla_backend = False
         mgr.attn_tp_size = 1

--- a/test/registered/unit/disaggregation/test_nixl_backend_basic.py
+++ b/test/registered/unit/disaggregation/test_nixl_backend_basic.py
@@ -347,6 +347,9 @@ class TestNixlAbortHandling(CustomTestCase):
         mgr._connect = MagicMock()
         mgr.failure_lock = threading.Lock()
         mgr.failure_records = {}
+        # These cases cover the legacy no-ack behavior; the deferred-release ack
+        # path is exercised in test_nixl_deferred_kv_release.py.
+        mgr.enable_deferred_decode_kv_release = False
         return mgr
 
     def test_given_known_incomplete_room_when_abort_arrives_then_room_fails_without_ack(
@@ -465,6 +468,7 @@ class TestNixlTransferWorker(CustomTestCase):
         }
         mgr.req_to_decode_prefix_len = {room: 4}
         mgr.enable_staging = False
+        mgr.enable_deferred_decode_kv_release = False
         mgr._staging_ctx = None
         mgr._staging_outstanding = defaultdict(int)
         mgr.is_mla_backend = False

--- a/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
@@ -1,0 +1,188 @@
+"""Deferred decode-side KV release on the NIXL backend.
+
+When a decode request is aborted while its prefill->decode transfer may still be
+in flight, the decode holds its KV pages until every prefill rank acks that its
+transfer drained. NIXL transfers are asynchronous (agent.transfer() posts, the
+worker polls check_xfer_state), so the ack must come from the transfer worker
+after its DONE barrier -- never from the bootstrap thread for an active room.
+"""
+
+import unittest
+from unittest.mock import MagicMock
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _prefill_mgr(cls=CommonKVManager, enabled=True):
+    """Bare manager carrying only the prefill-side deferred-ack state."""
+    mgr = cls.__new__(cls)
+    mgr.enable_deferred_decode_kv_release = enabled
+    mgr._deferred_ack_targets = {}
+    mgr._staging_outstanding = {}
+    mgr.request_status = {}
+    mgr._sent = []
+    # Capture acks instead of opening a socket.
+    mgr._send_abort_ack = lambda ip, port, room: mgr._sent.append((ip, port, room))
+    return mgr
+
+
+class TestDeferredAckTargets(CustomTestCase):
+    def test_ack_held_until_outstanding_drains(self):
+        mgr = _prefill_mgr()
+        mgr.register_deferred_ack_target(7, "10.0.0.1", 5000)
+
+        mgr._staging_outstanding[7] = 1
+        mgr._maybe_ack_drained_abort(7)
+        self.assertEqual(mgr._sent, [])  # still writing -> no ack
+
+        mgr._staging_outstanding[7] = 0
+        mgr._maybe_ack_drained_abort(7)
+        self.assertEqual(mgr._sent, [("10.0.0.1", 5000, 7)])
+
+    def test_ack_fires_at_most_once(self):
+        mgr = _prefill_mgr()
+        mgr.register_deferred_ack_target(8, "10.0.0.2", 5001)
+        mgr._maybe_ack_drained_abort(8)
+        mgr._maybe_ack_drained_abort(8)
+        self.assertEqual(len(mgr._sent), 1)
+        self.assertNotIn(8, mgr._deferred_ack_targets)
+
+    def test_unregistered_room_is_noop(self):
+        mgr = _prefill_mgr()
+        mgr._maybe_ack_drained_abort(999)
+        self.assertEqual(mgr._sent, [])
+
+    def test_prefill_unique_rank_matches_success_sync_formula(self):
+        mgr = CommonKVManager.__new__(CommonKVManager)
+        mgr.attn_tp_rank, mgr.pp_size, mgr.attn_cp_size = 2, 3, 4
+        mgr.pp_rank, mgr.attn_cp_rank = 1, 3
+        self.assertEqual(mgr._prefill_unique_rank(), 2 * (3 * 4) + 1 * 4 + 3)
+
+
+class TestNixlAbortNotification(CustomTestCase):
+    """_handle_abort_notification is the prefill bootstrap-thread entry point."""
+
+    @staticmethod
+    def _abort_msg(room=11, ip="10.0.0.3", port=6000):
+        return [
+            b"ABORT",
+            str(room).encode("ascii"),
+            ip.encode("ascii"),
+            str(port).encode("ascii"),
+        ]
+
+    def _mgr(self, enabled=True, room=11, status=KVPoll.WaitingForInput):
+        mgr = _prefill_mgr(NixlKVManager, enabled=enabled)
+        if status is not None:
+            mgr.request_status[room] = status
+        mgr.record_failure = MagicMock()
+        mgr.update_status = MagicMock(
+            side_effect=lambda r, s: mgr.request_status.__setitem__(r, s)
+        )
+        mgr.check_status = lambda r: mgr.request_status[r]
+        return mgr
+
+    def test_in_flight_room_registers_target_and_does_not_ack_yet(self):
+        # A counted chunk holds the ack: only the worker knows when it landed.
+        mgr = self._mgr()
+        mgr._staging_outstanding[11] = 1
+        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+
+        self.assertEqual(mgr._deferred_ack_targets[11], ("10.0.0.3", 6000))
+        self.assertEqual(mgr._sent, [])
+        # Marked Failed first, so no new chunk can be enqueued for the room.
+        self.assertEqual(mgr.request_status[11], KVPoll.Failed)
+
+    def test_quiescent_active_room_acks_without_waiting_for_a_worker_visit(self):
+        # Window 2: chunks already drained with none left to come, so the worker
+        # never revisits the room -- acking here keeps it off the timeout path.
+        mgr = self._mgr()
+        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+
+        self.assertEqual(mgr._sent, [("10.0.0.3", 6000, 11)])
+        self.assertEqual(mgr._deferred_ack_targets, {})
+
+    def test_worker_skip_before_registration_still_acks(self):
+        # Window 1: the worker can pass its skip point between the Failed flip
+        # and registration; the ack attempt at registration covers that.
+        mgr = self._mgr()
+        mgr._staging_outstanding[11] = 1
+
+        real_update = mgr.update_status.side_effect
+
+        def failed_then_worker_skips(room, status):
+            real_update(room, status)
+            # Worker dequeues, sees Failed, uncounts, and finds no target yet.
+            mgr._staging_outstanding.pop(room, None)
+            mgr._maybe_ack_drained_abort(room)
+
+        mgr.update_status = MagicMock(side_effect=failed_then_worker_skips)
+        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+
+        self.assertEqual(mgr._sent, [("10.0.0.3", 6000, 11)])
+        self.assertEqual(mgr._deferred_ack_targets, {})
+
+    def test_concluded_room_acks_immediately(self):
+        # Concluded and quiescent: ack straight away.
+        mgr = self._mgr(status=None)
+        mgr.check_status = lambda r: KVPoll.Success
+        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+
+        self.assertEqual(mgr._sent, [("10.0.0.3", 6000, 11)])
+        self.assertEqual(mgr._deferred_ack_targets, {})
+
+    def test_cleared_room_with_outstanding_chunk_does_not_ack(self):
+        # The ERR path abandons sibling handles that may still be writing and
+        # leaves the chunk counted; clear() then drops the room. Acking on
+        # "unknown room" alone would release decode pages under those writes.
+        mgr = self._mgr(status=None)  # room absent == cleared/unknown
+        mgr._staging_outstanding[11] = 1
+        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+
+        self.assertEqual(mgr._sent, [])
+        self.assertEqual(mgr._deferred_ack_targets, {})
+
+    def test_feature_off_registers_nothing_and_acks_nothing(self):
+        mgr = self._mgr(enabled=False)
+        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+
+        self.assertEqual(mgr._deferred_ack_targets, {})
+        self.assertEqual(mgr._sent, [])
+        # Legacy behavior preserved: the room is still failed.
+        self.assertEqual(mgr.request_status[11], KVPoll.Failed)
+
+    def test_legacy_two_frame_abort_is_tolerated(self):
+        # Older peers send [ABORT, room] with no return address.
+        mgr = self._mgr()
+        self.assertTrue(mgr._handle_abort_notification([b"ABORT", b"11"]))
+        self.assertEqual(mgr._deferred_ack_targets, {})
+        self.assertEqual(mgr._sent, [])
+
+    def test_non_abort_message_is_not_claimed(self):
+        mgr = self._mgr()
+        self.assertFalse(mgr._handle_abort_notification([b"STAGING_REQ", b"11"]))
+
+
+class TestNixlDecodeAckIngest(CustomTestCase):
+    def test_abort_ack_is_aggregated_per_rank(self):
+        # Mirrors the decode listener thread's ABORT_ACK branch.
+        mgr = CommonKVManager.__new__(CommonKVManager)
+        mgr._deferred_abort_ack_tracker = {}
+        mgr.register_deferred_abort_room(21)
+
+        for rank in (b"0", b"1", b"1"):
+            msg = [b"ABORT_ACK", b"21", rank]
+            mgr.note_abort_ack(int(msg[1].decode()), int(msg[2].decode()))
+
+        self.assertFalse(mgr.is_abort_release_safe(21, required_acks=3))
+        self.assertTrue(mgr.is_abort_release_safe(21, required_acks=2))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

This is the exact Kimi-K3 serving tree used to A/B-test the deferred
decode-side KV release fix on a GB300 PD deployment. It is
`kimi-k3-zmq-max-sockets-mitigation` (6dfdebf0fb) with the deferred-release work
cherry-picked on top, so the branch can be built into a serving image and
compared directly against the unpatched build.

Cherry-picks, in order:

| upstream | commit | why |
| --- | --- | --- |
| #30545 | `05c7ebf64c` | `[Disagg][StagingBuffer][2/2] Support radix cache` — prerequisite for the two below |
| #35049 | `97dedd1ce9` | `[PD] Deferred decode-side KV release for aborts mid-transfer` |
| #35360 | `adca19c497` | `[PD] Deferred decode-side KV release for the NIXL backend` |

Three conflicts came up, all purely additive (two `from typing import ...`
lines, plus new blocks in `environ.py` and `mooncake/conn.py`); each was
resolved by taking the incoming side.

The resulting tree hash is `a7845862cd43eecbd923fff557df1f180fcd8502`, which
matches the tree that was actually exercised on hardware — that equality is the
point of this branch, so a reviewer can confirm the image and the measurements
came from the same bytes.

## What the measurements showed

Reproduced on a 2-prefill/1-decode Kimi-K3 deployment (mooncake, dp16 prefill ×2
+ dp32 decode) with a deterministic barrier that parks one prefill's
`send_kvcache` until released, so the abort/free/realloc ordering is enforced
rather than raced. Greedy decoding, 512 output tokens.

**Without the fix**, request B was allocated exactly the 32 KV pages and the
mamba slot that request A had just freed. A's stale write then landed in them
mid-generation: a checksum over 64 head-of-prompt KV rows (rows decode never
rewrites) changed 4 ms after prefill logged `WRITE_END ret=0`, and B's output
diverged from its own baseline at token 269, with 241 of 512 tokens differing.
B returned HTTP 200 and `finish_reason=length` throughout, so nothing surfaced
to the client. Notably A's prefill had already returned
`finish_reason={'type': 'abort'}` seconds earlier — the scheduler considered the
request finished while its transfer worker went on to write successfully.

**With the fix**, when the stalled write completes inside the hold window,
decode logs `DEFER_HOLD` instead of `FREE`, B is not admitted while the pages
are held, and B's output is bit-identical to baseline.

## One caveat worth reviewer attention

In every control run the hold ended via the timeout, not an ack:

```
Deferred KV release for room ... timed out after 30.0s without a full drain ack
from prefill; releasing anyway.
```

The drain ack is sent by the prefill transfer worker, which is precisely the
thread that is stuck, so it cannot arrive while the write is stalled and
`SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT` always decides. When
the write outlives that timeout the original window reopens — in that
configuration B diverged at token 314 (197/512 tokens) with the fix enabled.

So on this workload the feature bounds the exposure to the timeout rather than
closing it. Whether that is acceptable depends on how long a real stalled RDMA
transfer can run; it may be worth either blocking the release until the ack
regardless of elapsed time, or having the sender drop the write when it observes
the room already failed at the point of send rather than only at dequeue.

Draft: opened to share the tested tree and these results, not proposing new code.

## Test plan

- `git rev-parse HEAD^{tree}` = `a7845862cd43eecbd923fff557df1f180fcd8502`,
  matching the tree that ran on hardware (independently re-derived by redoing
  the cherry-picks from `6dfdebf0fb` in a clean worktree).
- End-to-end PD serving on 16 GB300 nodes: both arms brought up, health-checked,
  and driven through the three scenarios in the table above.
- Greedy determinism established first — three runs of the same prompt through
  two different prefill engines returned byte-identical output ids.
- Ordinary mooncake transfers validated against the live stack before any change.
- Not run: no unit or CI suite was executed for this branch; the cherry-picked
  PRs ship their own tests (`test_deferred_decode_kv_release.py`,
  `test_nixl_deferred_kv_release.py`) but they were not run here. Each arm was
  measured once, so there is no variance estimate.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829317759](https://github.com/sgl-project/sglang/actions/runs/34829317759)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829317288](https://github.com/sgl-project/sglang/actions/runs/34829317288)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->