### PR TITLE
docs(cookbook): fix Qwen3.8 Flash Next H200 MTP verify with BF16 SSM state

### DIFF
--- a/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
@@ -181,11 +181,11 @@ export const config = {
   // Every cell below is a verified recipe. Ordering: the first cell seeds the
   // Deploy panel's default selection.
   //
-  // Within a quantization the NVIDIA cells are identical across
-  // H200/B200/B300/GB300, and `--linear-attn-{prefill,decode}-backend flashinfer` is
-  // pinned explicitly rather than left to the GDN default, which differs by GPU
-  // generation (Triton on SM90, and the flashinfer decode default is gated on
-  // `--mamba-ssm-dtype bfloat16`). Pinning both makes one recipe portable.
+  // `--linear-attn-{prefill,decode}-backend flashinfer` is pinned explicitly
+  // rather than left to the GDN default, which differs by GPU generation
+  // (Triton on SM90, and the flashinfer decode default is gated on
+  // `--mamba-ssm-dtype bfloat16`). The H200 low-latency cells use Triton for
+  // MTP verify because the SM90 FlashInfer verify path requires fp32 SSM state.
   cells: [
     // ==== BF16 ====
     // Low latency: MTP on, concurrency capped at 96. Without an explicit
@@ -202,6 +202,7 @@ export const config = {
         "--chunked-prefill-size 8192",
         "--linear-attn-prefill-backend flashinfer",
         "--linear-attn-decode-backend flashinfer",
+        "--linear-attn-verify-backend triton",
         "--mamba-ssm-dtype bfloat16",
         "--speculative-algorithm NEXTN",
         "--speculative-num-steps 3",
@@ -443,6 +444,7 @@ export const config = {
         "--chunked-prefill-size 8192",
         "--linear-attn-prefill-backend flashinfer",
         "--linear-attn-decode-backend flashinfer",
+        "--linear-attn-verify-backend triton",
         "--mamba-ssm-dtype bfloat16",
         "--speculative-algorithm NEXTN",
         "--speculative-num-steps 3",

--- a/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
@@ -181,11 +181,11 @@ export const config = {
   // Every cell below is a verified recipe. Ordering: the first cell seeds the
   // Deploy panel's default selection.
   //
-  // `--linear-attn-{prefill,decode}-backend flashinfer` is pinned explicitly
-  // rather than left to the GDN default, which differs by GPU generation
-  // (Triton on SM90, and the flashinfer decode default is gated on
-  // `--mamba-ssm-dtype bfloat16`). The H200 low-latency cells use Triton for
-  // MTP verify because the SM90 FlashInfer verify path requires fp32 SSM state.
+  // Within a quantization the NVIDIA cells are identical across
+  // H200/B200/B300/GB300, and `--linear-attn-{prefill,decode}-backend flashinfer` is
+  // pinned explicitly rather than left to the GDN default, which differs by GPU
+  // generation (Triton on SM90, and the flashinfer decode default is gated on
+  // `--mamba-ssm-dtype bfloat16`). Pinning both makes one recipe portable.
   cells: [
     // ==== BF16 ====
     // Low latency: MTP on, concurrency capped at 96. Without an explicit


### PR DESCRIPTION
## Summary

- pin Triton as the linear-attention verify backend for the H200 BF16 and FP8 low-latency recipes
- keep FlashInfer as the prefill and decode backend

## Motivation

The H200 low-latency recipes combine NEXTN with `--mamba-ssm-dtype bfloat16`. On SM90, the FlashInfer MTP verify path requires fp32 SSM state, so auto-selecting it can fail during target verify CUDA graph capture with:

```text
AssertionError: initial_state must be float32, got torch.bfloat16
```

#34592 made SGLang honor an explicitly selected Triton verify backend while intentionally leaving auto selection unchanged. The verified Cookbook commands therefore need to opt into that backend explicitly.

## Validation

- `node docs/scripts/check_cookbook_configs.mjs`
- checked that only the H200 BF16/FP8 low-latency cells receive the new flag
- H20 SM90, TP8/EP8, `Qwen/Qwen3.8-Flash-Next-FP8`: server startup, target verify CUDA graph capture, `/health`, and a Chat Completions smoke request succeeded
- runtime dispatcher resolved to `decode=FlashInferGDNKernel, extend=FlashInferGDNKernel, verify=TritonGDNKernel`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33038758235](https://github.com/sgl-project/sglang/actions/runs/33038758235)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33038758119](https://github.com/sgl-project/sglang/actions/runs/33038758119)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->