### PR TITLE
Log cold JIT compiles in load_jit

### DIFF
--- a/python/sglang/kernels/jit/utils/compile/loader.py
+++ b/python/sglang/kernels/jit/utils/compile/loader.py
@@ -8,6 +8,7 @@ import logging
 import os
 import pathlib
 import shutil
+import time
 import uuid
 from typing import TYPE_CHECKING, List, Tuple
 
@@ -156,7 +157,14 @@ def load_jit(
         # meant to be a shared mount, where two machines can hold the same pid.
         staging = scope / f".staging-{uuid.uuid4().hex}"
         try:
+            logger.info("JIT-compiling %s (cold cache) -> %s", spec.module_name, scope)
+            build_start = time.monotonic()
             library = ninja.build(spec=spec, build_dir=staging, build_file=build_file)
+            logger.info(
+                "JIT-compiled %s in %.1fs",
+                spec.module_name,
+                time.monotonic() - build_start,
+            )
             # Loaded before publishing, so a broken artifact never becomes a
             # leaf that later runs have to discover and discard.
             module = _load(library)


### PR DESCRIPTION
## Summary

Cold JIT compiles in `load_jit` are currently silent. This adds two INFO
log lines around the cold `ninja` build: one before it starts (module
name and build directory) and one after it finishes (elapsed seconds).
Cache hits are unaffected and remain silent — this is an observability-only
change.

## Original commits

- `31fbbaad68`

## Test plan

- `python3 -m py_compile python/sglang/kernels/jit/utils/compile/loader.py`
- `ruff check --select=F401,F821,UP037` on the changed file: clean
- Manual review confirms no logic changed outside the two added `logger.info`
  calls and the `time.monotonic()` timestamps that feed them; the
  cache-hit and lock-reacquire paths are untouched.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33039714824](https://github.com/sgl-project/sglang/actions/runs/33039714824)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33039714554](https://github.com/sgl-project/sglang/actions/runs/33039714554)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33039714827](https://github.com/sgl-project/sglang/actions/runs/33039714827)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->