### PR TITLE
Add SGLANG_CRASH_ON_JIT_COMPILE to forbid on-the-fly JIT compilation

### DIFF
--- a/python/sglang/kernels/jit/utils/compile/cache.py
+++ b/python/sglang/kernels/jit/utils/compile/cache.py
@@ -298,10 +298,13 @@ def _normalize_text(text: str) -> str:
     return text
 
 
-def build_key_dir(*, module_name: str, build_key: str) -> pathlib.Path:
+def cache_root() -> pathlib.Path:
     configured = envs.SGLANG_JIT_CACHE_DIR.get() or "~/.cache/sglang/jit"
-    root = pathlib.Path(configured).expanduser()
-    return root / _target_tag() / module_name / f"{_BUILD_KEY_PREFIX}{build_key}"
+    return pathlib.Path(configured).expanduser()
+
+
+def build_key_dir(*, module_name: str, build_key: str) -> pathlib.Path:
+    return cache_root() / _target_tag() / module_name / f"{_BUILD_KEY_PREFIX}{build_key}"
 
 
 # ---------------------------------------------------------------------------

--- a/python/sglang/kernels/jit/utils/compile/cache.py
+++ b/python/sglang/kernels/jit/utils/compile/cache.py
@@ -304,7 +304,9 @@ def cache_root() -> pathlib.Path:
 
 
 def build_key_dir(*, module_name: str, build_key: str) -> pathlib.Path:
-    return cache_root() / _target_tag() / module_name / f"{_BUILD_KEY_PREFIX}{build_key}"
+    return (
+        cache_root() / _target_tag() / module_name / f"{_BUILD_KEY_PREFIX}{build_key}"
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/python/sglang/kernels/jit/utils/compile/loader.py
+++ b/python/sglang/kernels/jit/utils/compile/loader.py
@@ -23,6 +23,7 @@ from sglang.kernels.jit.utils.compile.paths import (
 )
 from sglang.kernels.jit.utils.compile.spec import BuildSpec, resolve_sources
 from sglang.kernels.jit.utils.deps import REGISTERED_DEPENDENCIES
+from sglang.srt.environ import envs
 
 if TYPE_CHECKING:
     from tvm_ffi import Module
@@ -124,6 +125,16 @@ def load_jit(
                 spec.module_name,
                 e,
             )
+
+    # Before the lock: with the flag set no process ever publishes a build,
+    # so waiting on the lock cannot turn this miss into a hit.
+    if envs.SGLANG_CRASH_ON_JIT_COMPILE.get():
+        raise RuntimeError(
+            f"JIT module '{spec.module_name}' has no usable cached build under "
+            f"{scope}, and SGLANG_CRASH_ON_JIT_COMPILE forbids compiling at "
+            "runtime. Seed the cache with prebuilt artifacts matching this "
+            "environment, or unset the flag."
+        )
 
     with _build_lock(scope):
         # Re-check: whoever held the lock before us has very likely just

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1095,6 +1095,10 @@ class Envs:
     # is what makes reverting an edit an instant hit instead of a rebuild; set
     # it to trade that away for disk (1 keeps only the most recent build).
     SGLANG_JIT_CACHE_KEEP = EnvInt(None)
+    # Raise instead of compiling when a module misses the cache, so a
+    # deployment that expects a pre-seeded cache fails loudly at startup
+    # rather than silently eating a cold compile.
+    SGLANG_CRASH_ON_JIT_COMPILE = EnvBool(False)
 
     # ===================================================================
     # Expert-parallel dispatch and MoE execution


### PR DESCRIPTION
## Motivation

Container deployments can pre-seed the JIT build cache at image build time:
the build key is a deterministic function of source content, compiler/package
versions, and target arch — no device, host, or timestamp inputs — so a cache
compiled without a GPU is valid at runtime. What such deployments need from
the loader is not a second lookup location but a guarantee: if the seeded
cache silently stops matching (e.g. dependency-hash drift between the build
and runtime environments), startup should fail loudly instead of silently
paying a multi-second cold compile.

## Modifications

- `SGLANG_CRASH_ON_JIT_COMPILE` (default off): when set, `load_jit` raises
  instead of compiling when a module misses the cache. The check runs before
  taking the build lock — with the flag set no process ever publishes a
  build, so waiting on the lock cannot turn the miss into a hit. The error
  names the module and the searched scope.
- Extract `cache_root()` from `build_key_dir()` so external tooling that
  seeds the cache resolves the root exactly the way the loader does.

This replaces the earlier revision of this PR (a read-only fallback cache
directory): seeding the regular cache dir externally needs no extra lookup
tier or env var in the loader, and the crash flag gives the fail-loud
guarantee. Verified on an internal deployment: cache pre-seeded at image
build time, a per-arch verification pass reloads every module with the flag
set (so dependency drift fails the image build), and at runtime all seeded
modules load as plain cache hits.

## Original commits

- `5e7a84fc82`
- `1a54aa4e14`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33607566427](https://github.com/sgl-project/sglang/actions/runs/33607566427)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33607566270](https://github.com/sgl-project/sglang/actions/runs/33607566270)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33607566167](https://github.com/sgl-project/sglang/actions/runs/33607566167)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->