### PR TITLE
[Logging] Downgrade missing TokenizerManager request state log to warning

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -2197,7 +2197,7 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                 # Known race: /health_generate pops its rid as soon as ANY message bumps last_receive_tstamp.
                 if rid.startswith(HEALTH_CHECK_RID_PREFIX):
                     continue
-                logger.error(
+                logger.warning(
                     f"Received output for {rid=} but the state was deleted in TokenizerManager."
                 )
                 continue


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

When a client actively cancels or disconnects from a request, its state may already have been removed from `TokenizerManager` by the time an in-flight output arrives.

This condition is currently logged at the `ERROR` level. In deployments where SGLang logs are collected by a centralized logging system, these records are counted as server errors and may trigger alerts when their frequency crosses a configured threshold.

Because client-initiated cancellation is not necessarily a server-side failure, `WARNING` more accurately represents the severity of this condition while preserving its visibility for diagnostics.

## Modifications

Change the missing request-state log in `TokenizerManager._handle_batch_output` from `logger.error` to `logger.warning`.

The log message and request-handling behavior remain unchanged. This PR does not modify request cancellation, state cleanup, or scheduler logic.

## Accuracy Tests

Not applicable. This change only adjusts a log level and does not affect model execution or output.

Validation performed:

- Python syntax compilation passed.
- Targeted Ruff checks passed.
- `git diff --check` passed.

## Speed Tests and Profiling

Not applicable. This change does not affect the inference path or scheduling behavior.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #34906994644](https://github.com/sgl-project/sglang/actions/runs/34906994644)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34906994136](https://github.com/sgl-project/sglang/actions/runs/34906994136)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #34906994427](https://github.com/sgl-project/sglang/actions/runs/34906994427)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->