### PR TITLE
[Fix] Resolve tool argument types through top-level anyOf/oneOf/allOf

### DIFF
--- a/python/sglang/srt/function_call/dots_detector.py
+++ b/python/sglang/srt/function_call/dots_detector.py
@@ -16,7 +16,10 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
-from sglang.srt.function_call.utils import _is_complete_json
+from sglang.srt.function_call.utils import (
+    _is_complete_json,
+    get_schema_properties,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -137,10 +140,9 @@ class DotsToolDetector(BaseFormatDetector):
             schema = tool.function.parameters
             if not isinstance(schema, dict):
                 break
-            properties = schema.get("properties", {})
             defs = schema.get("$defs", {})
             return (
-                properties if isinstance(properties, dict) else {},
+                get_schema_properties(schema),
                 defs if isinstance(defs, dict) else {},
             )
         return {}, {}

--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -17,6 +17,7 @@ from sglang.srt.function_call.core_types import (
     _GetInfoFunc,
 )
 from sglang.srt.function_call.utils import (
+    get_schema_properties,
     infer_type_from_json_schema,
     safe_literal_eval,
 )
@@ -79,15 +80,8 @@ def get_argument_type(
 
     # Get parameters safely using getattr
     params = getattr(tool.function, "parameters", None)
-    if not isinstance(params, dict):
-        return None
 
-    # Navigate to the type using dict.get() for safe access
-    properties = params.get("properties")
-    if not isinstance(properties, dict):
-        return None
-
-    arg_spec = properties.get(arg_key)
+    arg_spec = get_schema_properties(params).get(arg_key)
     if isinstance(arg_spec, dict):
         # Use the new type inference function for complex JSON Schema support
         return infer_type_from_json_schema(arg_spec)
@@ -613,8 +607,9 @@ class Glm47MoeDetector(BaseFormatDetector):
             self._last_arguments += "{}"
             self.streamed_args_for_tool[self.current_tool_id] += "{}"
             self._sent_empty_object = True
-        elif not self._last_arguments.endswith("}") and not self._sent_empty_object:
-            # Need to close brace
+        elif not self._is_first_param and not self._sent_empty_object:
+            # The streamed outer `{` is only closed here; a trailing "}" in
+            # _last_arguments may belong to a nested object value.
             calls.append(
                 ToolCallItem(
                     tool_index=self.current_tool_id,

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -12,6 +12,7 @@ from sglang.srt.function_call.core_types import (
     _GetInfoFunc,
 )
 from sglang.srt.function_call.utils import (
+    get_schema_properties,
     infer_type_from_json_schema,
     safe_literal_eval,
 )
@@ -54,9 +55,7 @@ def get_argument_type(
     if func_name not in name2tool:
         return None
     tool = name2tool[func_name]
-    properties = (tool.function.parameters or {}).get("properties", {})
-    if not isinstance(properties, dict):
-        properties = {}
+    properties = get_schema_properties(tool.function.parameters)
     if arg_key not in properties:
         return None
 
@@ -572,7 +571,9 @@ class Glm4MoeDetector(BaseFormatDetector):
                             self.streamed_args_for_tool[
                                 self.current_tool_id
                             ] += empty_object
-                        elif not self._last_arguments.endswith("}"):
+                        else:
+                            # The streamed outer `{` is only closed here; a
+                            # trailing "}" may belong to a nested object value.
                             closing_brace = "}"
                             calls.append(
                                 ToolCallItem(

--- a/python/sglang/srt/function_call/hunyuan_detector.py
+++ b/python/sglang/srt/function_call/hunyuan_detector.py
@@ -12,6 +12,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import get_schema_properties
 
 logger = logging.getLogger(__name__)
 
@@ -176,7 +177,7 @@ class HunyuanDetector(BaseFormatDetector):
             if tool.function.name == function_name:
                 if tool.function.parameters is None:
                     return {}
-                return tool.function.parameters.get("properties", {}).get(arg_key, {})
+                return get_schema_properties(tool.function.parameters).get(arg_key, {})
         return {}
 
     @staticmethod

--- a/python/sglang/srt/function_call/kimik2_detector.py
+++ b/python/sglang/srt/function_call/kimik2_detector.py
@@ -15,6 +15,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import get_schema_properties
 
 logger = logging.getLogger(__name__)
 
@@ -144,7 +145,7 @@ class KimiK2Detector(BaseFormatDetector):
         best_score = -1
         for tool in tools:
             params = tool.function.parameters or {}
-            props = set(params.get("properties", {}).keys())
+            props = set(get_schema_properties(params).keys())
             if not props:
                 continue
             overlap = len(arg_keys & props)

--- a/python/sglang/srt/function_call/mimo_detector.py
+++ b/python/sglang/srt/function_call/mimo_detector.py
@@ -22,7 +22,10 @@ from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.environ import envs
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import StreamingParseResult, _GetInfoFunc
-from sglang.srt.function_call.utils import safe_literal_eval
+from sglang.srt.function_call.utils import (
+    get_schema_properties,
+    safe_literal_eval,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -31,7 +34,7 @@ def _get_param_type(func_name: str, param_name: str, tools: List[Tool]) -> str:
     """Get parameter type from tool schema."""
     for tool in tools:
         if tool.function.name == func_name:
-            props = tool.function.parameters.get("properties", {})
+            props = get_schema_properties(tool.function.parameters)
             if param_name in props:
                 return props[param_name].get("type", "string")
     return "string"

--- a/python/sglang/srt/function_call/minicpm5_detector.py
+++ b/python/sglang/srt/function_call/minicpm5_detector.py
@@ -9,7 +9,10 @@ from sglang.srt.function_call.core_types import (
     StreamingParseResult,
     _GetInfoFunc,
 )
-from sglang.srt.function_call.utils import safe_literal_eval
+from sglang.srt.function_call.utils import (
+    get_schema_properties,
+    safe_literal_eval,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -38,7 +41,7 @@ def get_argument_type(
     params = tool.function.parameters or {}
     if not isinstance(params, dict):
         return None
-    return params.get("properties", {}).get(arg_key, {}).get("type")
+    return get_schema_properties(params).get(arg_key, {}).get("type")
 
 
 def parse_arguments(json_value):
@@ -84,10 +87,7 @@ class MiniCPM5Detector(BaseFormatDetector):
         name_to_required = {}
         for name, t in name_to_tool.items():
             params = t.function.parameters or {}
-            props = (
-                (params.get("properties", {}) or {}) if isinstance(params, dict) else {}
-            )
-            name_to_allowed_props[name] = set(props.keys())
+            name_to_allowed_props[name] = set(get_schema_properties(params).keys())
             req = params.get("required", []) if isinstance(params, dict) else []
             try:
                 name_to_required[name] = set(req)

--- a/python/sglang/srt/function_call/minimax_m2.py
+++ b/python/sglang/srt/function_call/minimax_m2.py
@@ -10,6 +10,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import get_schema_properties
 
 logger = logging.getLogger(__name__)
 
@@ -508,8 +509,8 @@ class MinimaxM2Detector(BaseFormatDetector):
         for tool in tools:
             if tool.function.name == fname and tool.function.parameters is not None:
                 parameters = tool.function.parameters
-                if isinstance(parameters, dict) and "properties" in parameters:
-                    param_config = parameters["properties"]
+                if isinstance(parameters, dict):
+                    param_config = get_schema_properties(parameters)
                     break
 
         param_type = self._get_param_types_from_config(pname, param_config)

--- a/python/sglang/srt/function_call/minimax_m3.py
+++ b/python/sglang/srt/function_call/minimax_m3.py
@@ -10,6 +10,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import get_schema_properties
 
 logger = logging.getLogger(__name__)
 
@@ -374,8 +375,8 @@ class MinimaxM3Detector(BaseFormatDetector):
         if self._schema_has_type(parent_schema, ("array",)) and child_tag == "item":
             return self._get_array_item_schema(parent_schema, parent_value)
 
-        properties = parent_schema.get("properties")
-        if isinstance(properties, dict) and child_tag in properties:
+        properties = get_schema_properties(parent_schema)
+        if child_tag in properties:
             child_schema = properties[child_tag]
             return child_schema if isinstance(child_schema, dict) else None
 

--- a/python/sglang/srt/function_call/poolside_v1_detector.py
+++ b/python/sglang/srt/function_call/poolside_v1_detector.py
@@ -11,7 +11,10 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
-from sglang.srt.function_call.utils import safe_literal_eval
+from sglang.srt.function_call.utils import (
+    get_schema_properties,
+    safe_literal_eval,
+)
 
 
 class _ParseState(Enum):
@@ -150,7 +153,7 @@ class PoolsideV1Detector(BaseFormatDetector):
                     and tool.function.name == func_name
                     and isinstance(tool.function.parameters, dict)
                 ):
-                    return tool.function.parameters.get("properties", {})
+                    return get_schema_properties(tool.function.parameters)
             except AttributeError:
                 continue
         return {}

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -11,6 +11,7 @@ from sglang.srt.function_call.core_types import (
     _GetInfoFunc,
 )
 from sglang.srt.function_call.utils import (
+    get_schema_properties,
     infer_type_from_json_schema,
     safe_literal_eval,
 )
@@ -80,9 +81,10 @@ class Qwen3CoderDetector(BaseFormatDetector):
                 except AttributeError:
                     return {}
 
-                if isinstance(params, dict) and "properties" in params:
-                    return params["properties"]
-                elif isinstance(params, dict):
+                if isinstance(params, dict):
+                    properties = get_schema_properties(params)
+                    if properties:
+                        return properties
                     return params
                 else:
                     return {}

--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -83,7 +83,7 @@ class Qwen3CoderDetector(BaseFormatDetector):
 
                 if isinstance(params, dict):
                     properties = get_schema_properties(params)
-                    if properties:
+                    if properties or "properties" in params:
                         return properties
                     return params
                 else:

--- a/python/sglang/srt/function_call/spark25_detector.py
+++ b/python/sglang/srt/function_call/spark25_detector.py
@@ -10,6 +10,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
+from sglang.srt.function_call.utils import get_schema_properties
 
 TOOL_CALL_BEGIN = "<tool_call>"
 TOOL_CALL_END = "</tool_call>"
@@ -47,10 +48,7 @@ def _get_param_type(tools: list[Tool], function_name: str, param_name: str) -> s
         parameters = getattr(function, "parameters", None)
         if not isinstance(parameters, dict):
             continue
-        properties = parameters.get("properties")
-        if not isinstance(properties, dict):
-            continue
-        definition = properties.get(param_name)
+        definition = get_schema_properties(parameters).get(param_name)
         if isinstance(definition, dict) and isinstance(definition.get("type"), str):
             return definition["type"]
     return "string"

--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -10,7 +10,10 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
-from sglang.srt.function_call.utils import safe_literal_eval
+from sglang.srt.function_call.utils import (
+    get_schema_properties,
+    safe_literal_eval,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -22,7 +25,7 @@ def get_argument_type(func_name: str, arg_key: str, defined_tools: List[Tool]) -
         return None
     tool = name2tool[func_name]
     parameters = tool.function.parameters or {}
-    properties = parameters.get("properties", {})
+    properties = get_schema_properties(parameters)
     if arg_key not in properties:
         return None
     return properties[arg_key].get("type", None)

--- a/python/sglang/srt/function_call/utils.py
+++ b/python/sglang/srt/function_call/utils.py
@@ -304,6 +304,25 @@ def _get_tool_schema(tool: Tool) -> dict:
     }
 
 
+def get_schema_properties(schema: Any) -> Dict[str, Any]:
+    """Top-level ``properties`` of a tool ``parameters`` schema, descending
+    into ``anyOf``/``oneOf``/``allOf`` branches when the top level declares
+    none (legal JSON Schema, e.g. discriminated-union arguments)."""
+    if not isinstance(schema, dict):
+        return {}
+    properties = schema.get("properties")
+    if isinstance(properties, dict):
+        return properties
+    merged: Dict[str, Any] = {}
+    for keyword in ("anyOf", "oneOf", "allOf"):
+        branches = schema.get(keyword)
+        if isinstance(branches, list):
+            for branch in branches:
+                for key, value in get_schema_properties(branch).items():
+                    merged.setdefault(key, value)
+    return merged
+
+
 def infer_type_from_json_schema(schema: Dict[str, Any]) -> Optional[str]:
     """
     Infer the primary type of a parameter from JSON Schema.

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -33,6 +33,7 @@ from sglang.srt.function_call.llama32_detector import Llama32Detector
 from sglang.srt.function_call.mistral_detector import MistralDetector
 from sglang.srt.function_call.pythonic_detector import PythonicDetector
 from sglang.srt.function_call.qwen3_coder_detector import Qwen3CoderDetector
+from sglang.srt.function_call.utils import get_schema_properties
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=20, suite="base-a-test-cpu")
@@ -5634,6 +5635,201 @@ class TestGemma4Detector(unittest.TestCase):
         params1 = json.loads(tool_calls_by_index[1]["parameters"])
         self.assertEqual(params0["location"], "Paris")
         self.assertEqual(params1["timezone"], "UTC")
+
+
+class TestGetSchemaProperties(unittest.TestCase):
+    def test_flat_properties(self):
+        schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+        self.assertEqual(get_schema_properties(schema), {"a": {"type": "string"}})
+
+    def test_top_level_combinators(self):
+        schema = {
+            "type": "object",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "kind": {"const": "acme"},
+                        "payload": {"type": "object"},
+                    },
+                },
+                {"type": "object", "properties": {"kind": {"const": "other"}}},
+            ],
+        }
+        # first branch wins on duplicate keys, matching oneOf preference order
+        self.assertEqual(
+            get_schema_properties(schema),
+            {"kind": {"const": "acme"}, "payload": {"type": "object"}},
+        )
+
+    def test_anyof_allof_and_nesting(self):
+        anyof = {
+            "anyOf": [{"properties": {"x": {"type": "integer"}}}, {"type": "null"}]
+        }
+        self.assertEqual(get_schema_properties(anyof), {"x": {"type": "integer"}})
+        allof = {
+            "allOf": [
+                {"oneOf": [{"properties": {"y": {"type": "boolean"}}}]},
+                {"properties": {"z": {"type": "string"}}},
+            ]
+        }
+        self.assertEqual(
+            get_schema_properties(allof),
+            {"y": {"type": "boolean"}, "z": {"type": "string"}},
+        )
+
+    def test_non_dict_and_missing(self):
+        self.assertEqual(get_schema_properties(None), {})
+        self.assertEqual(
+            get_schema_properties(
+                {"type": "object"},
+            ),
+            {},
+        )
+        self.assertEqual(get_schema_properties({"oneOf": "not-a-list"}), {})
+
+
+class TestTopLevelCompositeToolSchema(unittest.TestCase):
+    """Parsers must resolve argument types when tool ``parameters`` declares
+    its properties under a top-level anyOf/oneOf/allOf instead of directly."""
+
+    def setUp(self):
+        self.oneof_tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="acme",
+                    description="Send a value to Acme.",
+                    parameters={
+                        "type": "object",
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {"const": "acme"},
+                                    "payload": {
+                                        "type": "object",
+                                        "properties": {
+                                            "value": {"type": "string"},
+                                        },
+                                        "required": ["value"],
+                                    },
+                                },
+                                "required": ["kind", "payload"],
+                            },
+                            {
+                                "type": "object",
+                                "properties": {"kind": {"const": "other"}},
+                                "required": ["kind"],
+                            },
+                        ],
+                    },
+                ),
+            ),
+        ]
+        self.flat_tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="acme",
+                    description="Send a value to Acme.",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "kind": {"type": "string"},
+                            "payload": {
+                                "type": "object",
+                                "properties": {"value": {"type": "string"}},
+                                "required": ["value"],
+                            },
+                        },
+                        "required": ["kind", "payload"],
+                    },
+                ),
+            ),
+        ]
+        self.glm47_text = (
+            "<tool_call>acme"
+            "<arg_key>kind</arg_key><arg_value>acme</arg_value>"
+            "<arg_key>payload</arg_key>"
+            '<arg_value>{"value": "hello"}</arg_value>'
+            "</tool_call>"
+        )
+        self.glm4_text = (
+            "<tool_call>acme\n"
+            "<arg_key>kind</arg_key>\n<arg_value>acme</arg_value>\n"
+            "<arg_key>payload</arg_key>\n"
+            '<arg_value>{"value": "hello"}</arg_value>\n'
+            "</tool_call>"
+        )
+        self.qwen_text = (
+            "<tool_call><function=acme>"
+            "<parameter=kind>acme</parameter>"
+            '<parameter=payload>{"value": "hello"}</parameter>'
+            "</function></tool_call>"
+        )
+        self.expected = {"kind": "acme", "payload": {"value": "hello"}}
+
+    def _stream_arguments(self, detector, text, tools, chunk_size=8):
+        name = None
+        arguments = ""
+        for i in range(0, len(text), chunk_size):
+            result = detector.parse_streaming_increment(text[i : i + chunk_size], tools)
+            for call in result.calls:
+                if call.name:
+                    name = call.name
+                arguments += call.parameters
+        return name, arguments
+
+    def test_glm47_detect_and_parse(self):
+        detector = Glm47MoeDetector()
+        result = detector.detect_and_parse(self.glm47_text, self.oneof_tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(json.loads(result.calls[0].parameters), self.expected)
+
+    def test_glm47_streaming(self):
+        detector = Glm47MoeDetector()
+        name, arguments = self._stream_arguments(
+            detector, self.glm47_text, self.oneof_tools
+        )
+        self.assertEqual(name, "acme")
+        self.assertEqual(json.loads(arguments), self.expected)
+
+    def test_glm47_streaming_object_argument_closes_outer_brace(self):
+        detector = Glm47MoeDetector()
+        name, arguments = self._stream_arguments(
+            detector, self.glm47_text, self.flat_tools
+        )
+        self.assertEqual(name, "acme")
+        self.assertEqual(json.loads(arguments), self.expected)
+
+    def test_glm4_detect_and_parse(self):
+        detector = Glm4MoeDetector()
+        result = detector.detect_and_parse(self.glm4_text, self.oneof_tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(json.loads(result.calls[0].parameters), self.expected)
+
+    def test_glm4_streaming(self):
+        detector = Glm4MoeDetector()
+        name, arguments = self._stream_arguments(
+            detector, self.glm4_text, self.oneof_tools
+        )
+        self.assertEqual(name, "acme")
+        self.assertEqual(json.loads(arguments), self.expected)
+
+    def test_qwen3_coder_detect_and_parse(self):
+        detector = Qwen3CoderDetector()
+        result = detector.detect_and_parse(self.qwen_text, self.oneof_tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(json.loads(result.calls[0].parameters), self.expected)
+
+    def test_qwen3_coder_streaming(self):
+        detector = Qwen3CoderDetector()
+        name, arguments = self._stream_arguments(
+            detector, self.qwen_text, self.oneof_tools
+        )
+        self.assertEqual(name, "acme")
+        self.assertEqual(json.loads(arguments), self.expected)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -5781,12 +5781,6 @@ class TestTopLevelCompositeToolSchema(unittest.TestCase):
                 arguments += call.parameters
         return name, arguments
 
-    def test_glm47_detect_and_parse(self):
-        detector = Glm47MoeDetector()
-        result = detector.detect_and_parse(self.glm47_text, self.oneof_tools)
-        self.assertEqual(len(result.calls), 1)
-        self.assertEqual(json.loads(result.calls[0].parameters), self.expected)
-
     def test_glm47_streaming(self):
         detector = Glm47MoeDetector()
         name, arguments = self._stream_arguments(
@@ -5802,12 +5796,6 @@ class TestTopLevelCompositeToolSchema(unittest.TestCase):
         )
         self.assertEqual(name, "acme")
         self.assertEqual(json.loads(arguments), self.expected)
-
-    def test_glm4_detect_and_parse(self):
-        detector = Glm4MoeDetector()
-        result = detector.detect_and_parse(self.glm4_text, self.oneof_tools)
-        self.assertEqual(len(result.calls), 1)
-        self.assertEqual(json.loads(result.calls[0].parameters), self.expected)
 
     def test_glm4_streaming(self):
         detector = Glm4MoeDetector()

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -5656,7 +5656,7 @@ class TestGetSchemaProperties(unittest.TestCase):
                 {"type": "object", "properties": {"kind": {"const": "other"}}},
             ],
         }
-        # first branch wins on duplicate keys, matching oneOf preference order
+        # duplicate keys resolve to the first branch that declares them
         self.assertEqual(
             get_schema_properties(schema),
             {"kind": {"const": "acme"}, "payload": {"type": "object"}},
@@ -5813,6 +5813,14 @@ class TestTopLevelCompositeToolSchema(unittest.TestCase):
         detector = Glm4MoeDetector()
         name, arguments = self._stream_arguments(
             detector, self.glm4_text, self.oneof_tools
+        )
+        self.assertEqual(name, "acme")
+        self.assertEqual(json.loads(arguments), self.expected)
+
+    def test_glm4_streaming_object_argument_closes_outer_brace(self):
+        detector = Glm4MoeDetector()
+        name, arguments = self._stream_arguments(
+            detector, self.glm4_text, self.flat_tools
         )
         self.assertEqual(name, "acme")
         self.assertEqual(json.loads(arguments), self.expected)

--- a/test/registered/unit/function_call/test_minimax_m3_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m3_detector.py
@@ -535,5 +535,63 @@ def _parse_segments_text(text, tools):
     ], result.normal_text
 
 
+class TestMinimaxM3TopLevelOneOf(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="acme",
+                    description="Send a value to Acme.",
+                    parameters={
+                        "type": "object",
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "properties": {
+                                    "kind": {"const": "acme"},
+                                    "payload": {
+                                        "type": "object",
+                                        "properties": {"value": {"type": "string"}},
+                                        "required": ["value"],
+                                    },
+                                },
+                                "required": ["kind", "payload"],
+                            },
+                            {
+                                "type": "object",
+                                "properties": {"kind": {"const": "other"}},
+                                "required": ["kind"],
+                            },
+                        ],
+                    },
+                ),
+            ),
+        ]
+        self.segments = (
+            "<tool_call>",
+            '<invoke name="acme">',
+            "<kind>acme",
+            "</kind>",
+            "<payload>",
+            "<value>hello",
+            "</value>",
+            "</payload>",
+            "</invoke>",
+            "</tool_call>",
+        )
+        self.expected = {"kind": "acme", "payload": {"value": "hello"}}
+
+    def test_detect_and_parse(self):
+        calls, _ = _parse_segments(self.segments, self.tools)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["args"], self.expected)
+
+    def test_streaming(self):
+        calls = _stream_segments(self.segments, self.tools)
+        self.assertEqual(len(calls), 1)
+        self.assertEqual(calls[0]["args"], self.expected)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/function_call/test_minimax_m3_detector.py
+++ b/test/registered/unit/function_call/test_minimax_m3_detector.py
@@ -549,14 +549,10 @@ class TestMinimaxM3TopLevelOneOf(CustomTestCase):
                             {
                                 "type": "object",
                                 "properties": {
-                                    "kind": {"const": "acme"},
-                                    "payload": {
-                                        "type": "object",
-                                        "properties": {"value": {"type": "string"}},
-                                        "required": ["value"],
-                                    },
+                                    "count": {"type": "integer"},
+                                    "verbose": {"type": "boolean"},
                                 },
-                                "required": ["kind", "payload"],
+                                "required": ["count", "verbose"],
                             },
                             {
                                 "type": "object",
@@ -571,24 +567,17 @@ class TestMinimaxM3TopLevelOneOf(CustomTestCase):
         self.segments = (
             "<tool_call>",
             '<invoke name="acme">',
-            "<kind>acme",
-            "</kind>",
-            "<payload>",
-            "<value>hello",
-            "</value>",
-            "</payload>",
+            "<count>7",
+            "</count>",
+            "<verbose>true",
+            "</verbose>",
             "</invoke>",
             "</tool_call>",
         )
-        self.expected = {"kind": "acme", "payload": {"value": "hello"}}
+        self.expected = {"count": 7, "verbose": True}
 
     def test_detect_and_parse(self):
         calls, _ = _parse_segments(self.segments, self.tools)
-        self.assertEqual(len(calls), 1)
-        self.assertEqual(calls[0]["args"], self.expected)
-
-    def test_streaming(self):
-        calls = _stream_segments(self.segments, self.tools)
         self.assertEqual(len(calls), 1)
         self.assertEqual(calls[0]["args"], self.expected)
 


### PR DESCRIPTION
## Summary

Tool schemas that compose subschemas with a **top-level** `anyOf`/`oneOf`/`allOf` (legal JSON Schema / OpenAI spec, e.g. discriminated-union arguments) break most SGLang tool-call parsers: nested object/array/scalar arguments are returned to the client as JSON-encoded **strings** instead of typed values, or (glm45/glm47 streaming) as invalid JSON.

```jsonc
"parameters": {
  "type": "object",
  "oneOf": [
    { "type": "object",
      "properties": { "kind": {"const": "acme"},
                      "payload": {"type": "object", "properties": {"value": {"type": "string"}}} },
      "required": ["kind", "payload"] },
    { "type": "object", "properties": { "kind": {"const": "other"} }, "required": ["kind"] }
  ]
}
```

With this schema, calling `acme(kind="acme", payload={"value":"hello"})` yields `payload == "{\"value\": \"hello\"}"` (a string) on the `qwen3_coder` parser in both streaming and non-streaming modes, and on the `glm47` parser when streaming.

## Root cause

Every affected detector navigated `parameters["properties"][arg]` only at the **top level**. With a top-level combinator there is no `properties` key, so argument-type inference failed and each parser fell back to treating values as strings:

- `qwen3_coder`: `_get_arguments_config` returns the whole schema (with `oneOf`/`type` keys) as the param map → every value returned raw, both modes. Scalars are also affected (`"count": "7"`, `"verbose": "True"`).
- `glm45`/`glm47`: streaming decides the value type when `<arg_value>` opens; with no schema info it defaults to `string` and JSON-quotes the value. Non-streaming survives only because of a `json.loads` fallback.

A second, pre-existing bug sits on the same path: glm45/glm47 streaming decides whether to emit the outer closing `}` via `_last_arguments.endswith("}")`. When the last argument is object/array-typed, the trailing `}` belongs to the *nested* value, so the outer object is never closed and streamed `arguments` is invalid JSON (masked live only when the model emits trailing whitespace inside `</arg_value>`).

## Fix

- New shared `get_schema_properties()` in `function_call/utils.py`: returns top-level `properties`, descending into `anyOf`/`oneOf`/`allOf` branches when absent (first branch wins on duplicate keys, matching oneOf preference order).
- Adopted in every detector with a parse-path property lookup: `glm45`, `glm47`, `qwen3_coder`, `step3`, `minicpm5`, `hunyuan`, `spark25`, `minimax_m2`, `minimax_m3`, `dots`, `poolside_v1`, `mimo`, `kimik2` (1–3 lines each).
- glm45/glm47 streaming finalize: close the outer arguments object whenever a parameter was started, instead of the `endswith("}")` heuristic.

Two deliberate behavior notes:

- `minicpm5`: for top-level-combinator tools the allowed-props filter was previously bypassed (empty property set); it now activates, so *undeclared* arguments are dropped as they already are for flat schemas.
- `qwen3_coder`: a declared-but-empty `properties: {}` keeps its old semantics (no spurious "param not defined" warnings).

`kimik3_structural_tag` is intentionally untouched: it builds grammars and already degrades gracefully to `AnyTextFormat` with top-level combinators.

## Test plan

- New registered tests: `TestGetSchemaProperties` (4) + `TestTopLevelCompositeToolSchema` (6: glm45/glm47 streaming with oneOf schema, flat-schema streaming brace cases, qwen3_coder stream/non-stream) in `test_function_call_parser.py`, and `TestMinimaxM3TopLevelOneOf` (1: scalar coercion under oneOf) in `test_minimax_m3_detector.py`. Every detector test was verified red on unpatched main; cases that also pass on unfixed code (glm non-streaming, structure-driven minimax streaming) were deliberately dropped.
- Full `test_function_call_parser.py` + `test_minimax_m3_detector.py` (270 tests): no regressions.
- GPU A/B on 2×H200, 6 schema shapes (oneOf nested object, anyOf, allOf, array/scalar coercion, flat control, multi-tool mixed) × stream/non-stream, asserting decoded argument **types** and `finish_reason=tool_calls`:

| model / parser | baseline | this PR |
|---|---|---|
| Qwen/Qwen3-Coder-30B-A3B-Instruct + `qwen3_coder` | 2/12 | 12/12 |
| zai-org/GLM-4.5-Air-FP8 + `glm45` | 7/12 | 12/12 |

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33100877731](https://github.com/sgl-project/sglang/actions/runs/33100877731)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33100877307](https://github.com/sgl-project/sglang/actions/runs/33100877307)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33100877334](https://github.com/sgl-project/sglang/actions/runs/33100877334)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->