### PR TITLE
[Docs] Qwen3.8-Flash-Next: use a float32 SSM state for the H200 speculative cells

### DIFF
--- a/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
@@ -182,10 +182,24 @@ export const config = {
   // Deploy panel's default selection.
   //
   // Within a quantization the NVIDIA cells are identical across
-  // H200/B200/B300/GB300, and `--linear-attn-{prefill,decode}-backend flashinfer` is
+  // H200/B200/B300/GB300 except for `--mamba-ssm-dtype`, and
+  // `--linear-attn-{prefill,decode}-backend flashinfer` is
   // pinned explicitly rather than left to the GDN default, which differs by GPU
   // generation (Triton on SM90, and the flashinfer decode default is gated on
-  // `--mamba-ssm-dtype bfloat16`). Pinning both makes one recipe portable.
+  // `--mamba-ssm-dtype bfloat16`).
+  //
+  // The state dtype is the one flag that cannot be shared. SM100+ *requires*
+  // bfloat16 whenever the flashinfer linear-attn decode backend is selected;
+  // server_args rejects anything else up front. SM90 needs the opposite as
+  // soon as speculation is on: FlashInferGDNKernels installs the bf16 MTP
+  // adapter only when `use_state_pool` (SM100+), so on Hopper the verify path
+  // still calls flashinfer's fp32-only `gated_delta_rule_mtp`, which asserts
+  //     initial_state must be float32, got torch.bfloat16
+  // during CUDA graph capture -- after the model has fully loaded, and with no
+  // mention of the flag that caused it. Nothing validates that direction, so
+  // the H200 speculative cells below pin float32 explicitly. The H200
+  // non-speculative cells keep bfloat16: SM90 decode gathers and casts the
+  // state itself, so only the verify path is affected.
   cells: [
     // ==== BF16 ====
     // Low latency: MTP on, concurrency capped at 96. Without an explicit
@@ -202,7 +216,9 @@ export const config = {
         "--chunked-prefill-size 8192",
         "--linear-attn-prefill-backend flashinfer",
         "--linear-attn-decode-backend flashinfer",
-        "--mamba-ssm-dtype bfloat16",
+        // SM90 has no bf16 GDN MTP-verify kernel, so a speculative run needs
+        // a float32 state here. See the note above the cells.
+        "--mamba-ssm-dtype float32",
         "--speculative-algorithm NEXTN",
         "--speculative-num-steps 3",
         "--speculative-eagle-topk 1",
@@ -443,7 +459,9 @@ export const config = {
         "--chunked-prefill-size 8192",
         "--linear-attn-prefill-backend flashinfer",
         "--linear-attn-decode-backend flashinfer",
-        "--mamba-ssm-dtype bfloat16",
+        // SM90 has no bf16 GDN MTP-verify kernel, so a speculative run needs
+        // a float32 state here. See the note above the cells.
+        "--mamba-ssm-dtype float32",
         "--speculative-algorithm NEXTN",
         "--speculative-num-steps 3",
         "--speculative-eagle-topk 1",


### PR DESCRIPTION
## Motivation

The Qwen3.8-Flash-Next cookbook's two **H200 low-latency** cells (bf16 and fp8) pair `--mamba-ssm-dtype bfloat16` with `--speculative-algorithm NEXTN`. That combination cannot run on SM90.

`FlashInferGDNKernels.__init__` installs the bf16 MTP adapter only when `use_state_pool`:

```python
self.use_state_pool = sm_major >= 10
...
if self.use_state_pool and mtp_bf16_fn is not None:
    # Adapt bf16 kernel to fp32 kernel interface so target_verify needs no branching.
    self._mtp_fn = _mtp_bf16_adapted
```

So on Hopper `_mtp_fn` stays flashinfer's fp32-only `gated_delta_rule_mtp`, while `supports_target_verify = sm_major in (9, 10)` keeps SM90 on the verify path. Copying the cookbook command onto an H200 gives:

```
[TP0 EP0] Capture target verify CUDA graph begin. backend=full, num_tokens_per_req=4, ...
Scheduler hit an exception: Traceback (most recent call last):
  ...
  File ".../linear/gdn_backend.py", line 331, in target_verify
  File ".../linear/kernels/gdn_flashinfer.py", line 419, in target_verify
    output_fi, _ = self._mtp_fn(
  File ".../flashinfer/gdn_decode.py", line 761, in gated_delta_rule_mtp
    assert initial_state.dtype == torch.float32, (
AssertionError: initial_state must be float32, got torch.bfloat16
```

It surfaces during CUDA graph capture — after the model has fully loaded — and names neither the flag responsible nor the value that fixes it. `_handle_linear_attn_backend` does not catch it either: it validates only that SM100+ uses bfloat16.

## Modifications

- Pin `--mamba-ssm-dtype float32` on the two H200 cells that enable NEXTN (bf16 and fp8 low-latency), with a short inline note.
- Correct the comment above the cell table. It currently says the NVIDIA cells are *"identical across H200/B200/B300/GB300"* and that pinning the backends *"makes one recipe portable"*. The state dtype is precisely the flag that is **not** portable, and the two generations want opposite values:
  - **SM100+** *requires* `bfloat16` whenever the flashinfer linear-attn decode backend is selected — `server_args` rejects anything else up front with `--linear-attn-decode-backend flashinfer on SM100+ requires --mamba-ssm-dtype bfloat16`.
  - **SM90** requires `float32` as soon as speculation is on, for the reason above, and nothing validates it.

The H200 **non-speculative** cells deliberately keep `bfloat16`: SM90 decode gathers and casts the state itself

```python
# State must be float32; kernel requires int64 cu_seqlens.
initial_state_fi = ssm_states[ssm_cache_indices].to(torch.float32)
```

so only the verify path is affected. NVFP4 has no H200 cell, so it needs no change.

## Verification

Reproduced on H200 (TP4/EP4, FP8 weights, NEXTN 3/1/4) with the cookbook command as published: fails at graph capture with the assert above. With `--mamba-ssm-dtype float32` and everything else unchanged, the server captures graphs and serves normally, and a full agentic benchmark sweep at concurrency 1/4/8/12/16 passes.

Docs-only change; no runtime code touched.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#running-unit-tests-adding-tests) — n/a, documentation snippet only.
- [x] Update documentation as listed in the [Documentation Guide](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#updating-documentation) — this PR is the documentation update.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33043306219](https://github.com/sgl-project/sglang/actions/runs/33043306219)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33043306016](https://github.com/sgl-project/sglang/actions/runs/33043306016)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->