### PR TITLE
[Spec] Reject unsupported multi-layer EAGLE configurations

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1758,7 +1758,7 @@ Please consult the documentation below and [server_args.py](https://github.com/s
   <tbody>
         <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--enable-multi-layer-eagle`</td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable multi-layer Eagle speculative decoding.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable multi-layer EAGLE for supported native models whose target checkpoint bundles multi-layer MTP weights. This mode cannot use a separate speculative draft model.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>bool flag (set to enable)</td>
     </tr>

--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -951,7 +951,7 @@ Below is a comprehensive list of all speculative decoding parameters available i
   <tbody>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--enable-multi-layer-eagle</code></td>
-      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Enable multi-layer EAGLE (auto-enabled for MiMoV2 and Step3p5 models)</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Use multi-layer MTP weights bundled in a native MiMoV2, Step3p5/Step3p7, or Inkling target checkpoint with EAGLE/NEXTN. Do not set a separate draft model path. This mode is auto-enabled for MiMoV2 and Step3p5/Step3p7 models.</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--enable-torch-compile</code></td>

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -707,6 +707,36 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
         )
 
     model_arch = server_args.get_model_config().hf_config.architectures[0]
+    if resolved_view(server_args).enable_multi_layer_eagle:
+        if cfg.speculative_algorithm == "EAGLE3":
+            raise ValueError(
+                "--enable-multi-layer-eagle only supports --speculative-algorithm "
+                "EAGLE (or its NEXTN alias), not EAGLE3."
+            )
+        if cfg.speculative_algorithm == "EAGLE":
+            from sglang.srt.configs.model_config import MULTI_LAYER_EAGLE_MODEL_ARCHS
+
+            if cfg.speculative_draft_model_path is not None:
+                raise ValueError(
+                    "--enable-multi-layer-eagle uses MTP weights bundled in "
+                    "--model-path and cannot be combined with "
+                    "--speculative-draft-model-path. For a separate EAGLE draft "
+                    "model, remove --enable-multi-layer-eagle."
+                )
+            if cfg.model_impl not in ("auto", "sglang"):
+                raise ValueError(
+                    "--enable-multi-layer-eagle requires the native SGLang model "
+                    f"implementation, but --model-impl is {cfg.model_impl!r}."
+                )
+            if model_arch not in MULTI_LAYER_EAGLE_MODEL_ARCHS:
+                raise ValueError(
+                    "--enable-multi-layer-eagle requires a model with bundled "
+                    "multi-layer MTP weights, but model architecture "
+                    f"{model_arch!r} is not supported. Supported architectures: "
+                    f"{', '.join(MULTI_LAYER_EAGLE_MODEL_ARCHS)}. For a separate "
+                    "EAGLE draft model, remove --enable-multi-layer-eagle and set "
+                    "--speculative-draft-model-path."
+                )
     if model_arch in [
         "DeepseekV32ForCausalLM",
         "DeepseekV3ForCausalLM",

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -49,6 +49,15 @@ MIMO_V2_MODEL_ARCHS = (
 )
 MIMO_V2_MULTIMODAL_ARCHS = ("MiMoV2ForCausalLM",)
 
+# Native target architectures with bundled multi-layer MTP support. Their
+# draft remaps implement the per-head construction and weight-selection contract.
+MULTI_LAYER_EAGLE_MODEL_ARCHS = (
+    *MIMO_V2_MODEL_ARCHS,
+    "Step3p5ForCausalLM",
+    "Step3p7ForConditionalGeneration",
+    "InklingForConditionalGeneration",
+)
+
 SWA_SINK_ARCHS = frozenset(
     {
         "GptOssForCausalLM",

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2342,7 +2342,11 @@ class ServerArgs:
     enable_multi_layer_eagle: A[
         bool,
         Arg(
-            help="Enable multi-layer Eagle speculative decoding.",
+            help=(
+                "Enable multi-layer EAGLE for supported native models whose "
+                "target checkpoint bundles multi-layer MTP weights. This mode "
+                "cannot use a separate speculative draft model."
+            ),
             resolvable=True,
         ),
         NS("spec"),

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1640,6 +1640,144 @@ class TestAdaptiveSpecArgs(CustomTestCase):
         self.assertEqual(resolution_result(args, "speculative_num_draft_tokens"), 4)
 
 
+class TestMultiLayerEagleArgs(CustomTestCase):
+    def _make_args(self, architecture: str, **overrides):
+        args = ServerArgs(
+            model_path="dummy",
+            speculative_algorithm="EAGLE",
+            enable_multi_layer_eagle=True,
+        )
+        args.device = "cuda"
+        args.get_model_config = lambda: SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=[architecture])
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+        return args
+
+    def test_llama_autofill_is_rejected_before_worker_startup(self):
+        args = self._make_args("LlamaForCausalLM")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "LlamaForCausalLM.*not supported",
+        ):
+            handle_speculative_decoding(args)
+
+        self.assertIsNone(resolution_result(args, "speculative_num_steps"))
+        self.assertIsNone(resolution_result(args, "speculative_eagle_topk"))
+        self.assertIsNone(resolution_result(args, "speculative_num_draft_tokens"))
+
+    def test_llama_explicit_chain_is_rejected_before_model_loading(self):
+        args = self._make_args(
+            "LlamaForCausalLM",
+            speculative_num_steps=5,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=6,
+        )
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "LlamaForCausalLM.*not supported",
+        ):
+            handle_speculative_decoding(args)
+
+    def test_bundled_multi_layer_mtp_architectures_remain_supported(self):
+        supported_architectures = (
+            "MiMoV2ForCausalLM",
+            "MiMoV2FlashForCausalLM",
+            "Step3p5ForCausalLM",
+            "Step3p7ForConditionalGeneration",
+            "InklingForConditionalGeneration",
+        )
+        for architecture in supported_architectures:
+            with self.subTest(architecture=architecture):
+                args = self._make_args(
+                    architecture,
+                    speculative_num_steps=3,
+                    speculative_eagle_topk=1,
+                    speculative_num_draft_tokens=4,
+                )
+
+                handle_speculative_decoding(args)
+
+    def test_separate_draft_model_remains_supported_without_multi_layer_mode(self):
+        args = self._make_args(
+            "LlamaForCausalLM",
+            enable_multi_layer_eagle=False,
+            page_size=1,
+            speculative_draft_model_path="dummy-draft",
+        )
+
+        with patch(
+            "sglang.srt.utils.hf_transformers_utils.get_config",
+            return_value=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+        ):
+            handle_speculative_decoding(args)
+
+        self.assertEqual(resolution_result(args, "speculative_num_steps"), 5)
+        self.assertEqual(resolution_result(args, "speculative_eagle_topk"), 4)
+        self.assertEqual(resolution_result(args, "speculative_num_draft_tokens"), 8)
+
+    def test_multi_layer_mode_rejects_separate_draft_model(self):
+        args = self._make_args(
+            "Step3p5ForCausalLM",
+            speculative_draft_model_path="dummy-draft",
+        )
+
+        with (
+            patch(
+                "sglang.srt.utils.hf_transformers_utils.get_config",
+                return_value=SimpleNamespace(architectures=["LlamaForCausalLM"]),
+            ),
+            self.assertRaisesRegex(ValueError, "cannot be combined"),
+        ):
+            handle_speculative_decoding(args)
+
+    def test_multi_layer_mode_rejects_transformers_implementation(self):
+        args = self._make_args(
+            "Step3p5ForCausalLM",
+            model_impl="transformers",
+        )
+
+        with self.assertRaisesRegex(ValueError, "native SGLang"):
+            handle_speculative_decoding(args)
+
+    def test_multi_layer_mode_rejects_eagle3(self):
+        args = self._make_args(
+            "Step3p5ForCausalLM",
+            speculative_algorithm="EAGLE3",
+        )
+
+        with self.assertRaisesRegex(ValueError, "not EAGLE3"):
+            handle_speculative_decoding(args)
+
+    def test_nextn_alias_uses_supported_multi_layer_eagle_path(self):
+        args = self._make_args(
+            "Step3p5ForCausalLM",
+            speculative_algorithm="NEXTN",
+            speculative_num_steps=3,
+            speculative_eagle_topk=1,
+            speculative_num_draft_tokens=4,
+        )
+
+        handle_speculative_decoding(args)
+
+        self.assertEqual(resolution_result(args, "speculative_algorithm"), "EAGLE")
+
+    def test_flag_does_not_restrict_standalone_algorithm(self):
+        args = self._make_args(
+            "LlamaForCausalLM",
+            speculative_algorithm="STANDALONE",
+        )
+
+        handle_speculative_decoding(args)
+
+        self.assertEqual(resolution_result(args, "speculative_num_steps"), 3)
+        self.assertEqual(resolution_result(args, "speculative_eagle_topk"), 1)
+        self.assertEqual(resolution_result(args, "speculative_num_draft_tokens"), 4)
+
+
 class TestWaterfillArgs(CustomTestCase):
     def test_waterfill_enforces_shared_experts_fusion(self):
         server_args = ServerArgs(


### PR DESCRIPTION
## Motivation

Fixes #36536.

`--enable-multi-layer-eagle` currently accepts architectures that do not bundle multi-layer MTP weights. With `TinyLlama/TinyLlama-1.1B-Chat-v1.0`, both the auto-filled and explicit EAGLE parameter paths pass argument resolution and then fail during worker startup.

## Modifications

- Validate multi-layer EAGLE during argument resolution and reject unsupported target architectures before worker startup.
- Restrict this mode to EAGLE/NEXTN, native SGLang model implementations, bundled target-model MTP weights, and no separate draft-model path.
- Preserve supported MiMoV2, Step3p5/Step3p7, and Inkling paths, along with standalone and separate-draft EAGLE behavior outside multi-layer mode.
- Document the support boundary in CLI help and the speculative-decoding/server-arguments pages.
- Add CPU-registered regression coverage for invalid and supported configurations.

## Accuracy Tests

This changes startup argument validation only and does not change model outputs.

- `pytest -q test/registered/unit/server_args/test_server_args.py::TestMultiLayerEagleArgs`: 9 passed, 5 subtests passed.
- `pytest -q test/registered/unit/configs/test_model_config.py test/registered/unit/test_model_overrides.py test/registered/unit/server_args/test_model_config_reads_resolved_input.py`: 96 passed, 1 skipped, 23 subtests passed.
- Full `test_server_args.py`: 191 passed and 20 subtests passed; two unrelated tests require the installed `deep_ep` JIT package to find a CUDA toolkit on this CPU-only host. The same two failures reproduce on an untouched `origin/main` worktree (182 passed, 15 subtests passed).
- Controlled resolution with the TinyLlama configuration rejects both issue configurations before worker startup.

## Speed Tests and Profiling

Not applicable. The new checks run once during startup argument resolution and do not change inference kernels or the runtime hot path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). (`pre-commit run --all-files` passed.)
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (`mint broken-links --check-anchors --check-redirects` and `mint validate` passed with `mint@4.2.559`.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable because this change only rejects invalid startup configurations and does not affect model outputs or inference performance.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33046629551](https://github.com/sgl-project/sglang/actions/runs/33046629551)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33046629421](https://github.com/sgl-project/sglang/actions/runs/33046629421)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33046629573](https://github.com/sgl-project/sglang/actions/runs/33046629573)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->