### PR TITLE
Fix KeyError on batch requests whose state is freed before it is read

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1693,11 +1693,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
     ):
-        # Look the state up now rather than inside the generator: a batch builds
-        # every generator before advancing any, and _handle_batch_output drops the
-        # rid_to_state entry as soon as a request finishes.
+        # Resolve the state before the generator starts: batch dispatch builds
+        # every waiter before advancing any. Holding the ReqState keeps the output
+        # deliverable; both removers append it after the del.
         state = self.rid_to_state[obj.rid]
-        return self._stream_one_response(obj, state, request)
+        return self._stream_one_response(obj=obj, state=state, request=request)
 
     async def _stream_one_response(
         self,
@@ -1705,7 +1705,6 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         state: ReqState,
         request: Optional[fastapi.Request] = None,
     ):
-        """Wait for the response of one request."""
         # Not all request types have `stream` (e.g., EmbeddingReqInput). Default to non-streaming.
         is_stream = getattr(obj, "stream", False)
         while True:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1693,9 +1693,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
     ):
-        # Resolve the state before the generator starts: batch dispatch builds
-        # every waiter before advancing any. Holding the ReqState keeps the output
-        # deliverable; both removers append it after the del.
+        # Batch dispatch builds every waiter before advancing any.
+        # Both removers append the output after the del, so the ReqState stays valid.
         state = self.rid_to_state[obj.rid]
         return self._stream_one_response(obj=obj, state=state, request=request)
 

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1688,13 +1688,24 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         return None
 
-    async def _wait_one_response(
+    def _wait_one_response(
         self,
         obj: Union[GenerateReqInput, EmbeddingReqInput],
         request: Optional[fastapi.Request] = None,
     ):
-        """Wait for the response of one request."""
+        # Look the state up now rather than inside the generator: a batch builds
+        # every generator before advancing any, and _handle_batch_output drops the
+        # rid_to_state entry as soon as a request finishes.
         state = self.rid_to_state[obj.rid]
+        return self._stream_one_response(obj, state, request)
+
+    async def _stream_one_response(
+        self,
+        obj: Union[GenerateReqInput, EmbeddingReqInput],
+        state: ReqState,
+        request: Optional[fastapi.Request] = None,
+    ):
+        """Wait for the response of one request."""
         # Not all request types have `stream` (e.g., EmbeddingReqInput). Default to non-streaming.
         is_stream = getattr(obj, "stream", False)
         while True:

--- a/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
+++ b/test/registered/unit/managers/test_tokenizer_manager_rid_cleanup.py
@@ -613,5 +613,33 @@ class TestGenerateRequestCleanupOnDispatchFailure(CustomTestCase):
         self.assertFalse(tm.rid_to_state)
 
 
+class TestWaitOneResponseAfterStateFreed(CustomTestCase):
+    """A waiter built before its request finishes must still deliver the output.
+
+    Batch dispatch builds every waiter before advancing any, and the
+    scheduler-response path drops rid_to_state as soon as a request finishes.
+    """
+
+    def test_generator_built_before_finish_still_delivers_output(self):
+        tm = _make_tokenizer_manager(self)
+        tm.request_logger = Mock()
+        tm.request_metrics_exporter_manager = MagicMock()
+        tm.request_metrics_exporter_manager.exporter_enabled.return_value = False
+        rid = "freed_state_rid"
+        state = _make_req_state(rid)
+        state.obj.background = True  # skip the fastapi disconnect probe
+        tm.rid_to_state[rid] = state
+
+        async def drive():
+            waiter = tm._wait_one_response(state.obj, None)
+            await tm._handle_batch_output(_make_batch_str_output(rid))
+            self.assertNotIn(rid, tm.rid_to_state)
+            return await waiter.__anext__()
+
+        out = asyncio.run(drive())
+        self.assertEqual(out["meta_info"]["id"], rid)
+        self.assertEqual(out["text"], "hello")
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

`_wait_one_response` was an `async def` generator, so its `rid_to_state[obj.rid]` lookup
ran only when the generator was first advanced. Batch dispatch builds a generator per
request and advances them all after the loop, so a request that finishes meanwhile has
its entry deleted by `_handle_batch_output`, and advancing its generator then raised
`KeyError` and failed the whole batch. Multimodal batches hit this every time, which is
why `test_vlms_perf.py` fails in the nightly.

The fix resolves the state eagerly and hands it to the generator; holding the `ReqState`
keeps the output deliverable after the dict entry is gone (`.get()` would have dropped
completed responses silently). All five call sites are unchanged.

`TestWaitOneResponseAfterStateFreed` fails pre-fix and passes here. On 2xH200 the nightly
test goes 3/3 fail to 3/3 pass.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33046675762](https://github.com/sgl-project/sglang/actions/runs/33046675762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33046675591](https://github.com/sgl-project/sglang/actions/runs/33046675591)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33046675708](https://github.com/sgl-project/sglang/actions/runs/33046675708)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->