### PR TITLE
[AMD][CI] Add targeted Mori test labels

### DIFF
--- a/.github/workflows/pr-test-amd-mori.yml
+++ b/.github/workflows/pr-test-amd-mori.yml
@@ -1,0 +1,101 @@
+name: PR Test Mori (AMD)
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Git ref to test"
+        required: false
+        type: string
+        default: ""
+      amd_ci_image:
+        description: "Override AMD CI Docker image"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+env:
+  AMD_CI_IMAGE: ${{ inputs.amd_ci_image }}
+  DOCKERHUB_AMD_USERNAME: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+  DOCKERHUB_AMD_TOKEN: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+
+concurrency:
+  group: pr-test-amd-mori-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'pull_request' || github.event.action != 'labeled' }}
+
+jobs:
+  mori-pd:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-mori-pd') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-mori-pd'))
+    runs-on: linux-mi35x-gpu-8.fabric
+    timeout-minutes: 90
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Detect RDMA device
+        run: |
+          if compgen -G "/sys/class/infiniband/*" > /dev/null; then
+            echo "SGLANG_TEST_RDMA_DEVICE=rdma0" >> "$GITHUB_ENV"
+          fi
+
+      - name: Start disaggregation container
+        run: bash scripts/ci/amd/amd_ci_start_container_disagg.sh --rocm-version rocm724
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh
+
+      - name: Run Mori PD tests
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            -e SGLANG_TEST_RDMA_DEVICE="${{ env.SGLANG_TEST_RDMA_DEVICE }}" \
+            -w /sglang-checkout/test \
+            python3 registered/amd/disaggregation/test_mori_transfer_engine_e2e.py
+
+  mori-hicache:
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.action == 'labeled' && github.event.label.name == 'run-mori-hicache') ||
+      (github.event.action != 'labeled' && contains(github.event.pull_request.labels.*.name, 'run-mori-hicache'))
+    runs-on: linux-mi35x-gpu-8
+    timeout-minutes: 120
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref || github.sha }}
+
+      - name: Ensure VRAM is clear
+        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
+
+      - name: Start CI container
+        run: bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version rocm724
+        env:
+          GITHUB_WORKSPACE: ${{ github.workspace }}
+          ENABLE_CACHE_HOST: "1"
+
+      - name: Install dependencies
+        run: bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
+
+      - name: Run Mori HiCache tests
+        run: |
+          bash scripts/ci/amd/amd_ci_exec.sh \
+            -e SGLANG_HACK_FLASHMLA_BACKEND=unified_kv_triton \
+            -e SGLANG_MOE_COPY_WEIGHT_VIEWS_BEFORE_H2D=1 \
+            -w /sglang-checkout/test \
+            python3 registered/hicache/test_hicache_storage_umbp_backend.py

--- a/docs/docs/developer_guide/contribution_guide.mdx
+++ b/docs/docs/developer_guide/contribution_guide.mdx
@@ -125,8 +125,6 @@ For CI to run on a pull request, it must have the "run-ci" label. Authorized use
 - `/rerun-test <test-spec> [<test-spec> ...]`: Reruns one or more specific tests directly. A spec may select a file, class, or method using `<file>::<TestClass>[.<test_method>]`. Multiple specs and file globs are supported. Examples: `/rerun-test test_srt_endpoint.py`, `/rerun-test registered/core/test_srt_endpoint.py::TestSRTEndpoint.test_simple_decode`, `/rerun-test test_a.py test_b.py`, or `/rerun-test test_*backend*.py`.
 - `/rerun-group <group> [<group> ...]`: Expands one or more registered test groups (for example, `/rerun-group hicache`) and dispatches their tests through the same selective-rerun workflow.
 
-Maintainers can apply `run-mori-pd` or `run-mori-hicache` to run only the corresponding AMD Mori end-to-end tests. These labels do not require `run-ci` and remain active for later commits on the PR.
-
 The rerun commands have the following permission rules:
 
 | Command | PR author | Other users | Additional rule for fork PRs |

--- a/docs/docs/developer_guide/contribution_guide.mdx
+++ b/docs/docs/developer_guide/contribution_guide.mdx
@@ -125,6 +125,8 @@ For CI to run on a pull request, it must have the "run-ci" label. Authorized use
 - `/rerun-test <test-spec> [<test-spec> ...]`: Reruns one or more specific tests directly. A spec may select a file, class, or method using `<file>::<TestClass>[.<test_method>]`. Multiple specs and file globs are supported. Examples: `/rerun-test test_srt_endpoint.py`, `/rerun-test registered/core/test_srt_endpoint.py::TestSRTEndpoint.test_simple_decode`, `/rerun-test test_a.py test_b.py`, or `/rerun-test test_*backend*.py`.
 - `/rerun-group <group> [<group> ...]`: Expands one or more registered test groups (for example, `/rerun-group hicache`) and dispatches their tests through the same selective-rerun workflow.
 
+Maintainers can apply `run-mori-pd` or `run-mori-hicache` to run only the corresponding AMD Mori end-to-end tests. These labels do not require `run-ci` and remain active for later commits on the PR.
+
 The rerun commands have the following permission rules:
 
 | Command | PR author | Other users | Additional rule for fork PRs |


### PR DESCRIPTION

## Motivation

Mori PD and HiCache tests are currently embedded in broader AMD stages and can be blocked by unrelated failures. AMD tests registered through `register_amd_ci` also cannot currently be dispatched through `/rerun-test` or `/rerun-group`.
cc @HaiShaw  @ShangmingCai  @hzh0425 
## Changes

- Add `run-mori-pd` to run the existing Mori PD E2E on the MI35x 8-GPU fabric runner.
- Add `run-mori-hicache` to run the existing UMBPStore unit tests and Mori/UMBP HiCache E2E on the MI35x 8-GPU runner.
- Reuse the existing AMD runner, container, dependency setup, and test files.
- Re-run the selected tests on later PR commits while the labels remain attached.
- Keep both labels independent from `run-ci`.
- Support manual workflow dispatch.

Mori EP tests are intentionally outside the scope of these two labels.

## Test plan

- [x] Repository pre-commit checks pass.
- [x] Workflow YAML and job structure validated.
- [ ] Create the `run-mori-pd` and `run-mori-hicache` repository labels.
- [ ] Apply each label and verify only the corresponding Mori test subset runs.
