### PR TITLE
[CI] Fix Q8KV8 sparse prefill test fixture

### DIFF
--- a/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
+++ b/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
@@ -203,6 +203,7 @@ def _make_sparse_prefill_case(
         ),
         page_size=page_size,
     )
+    backend.token_to_kv_pool = token_to_kv_pool
 
     generator = torch.Generator(device=device)
     generator.manual_seed(11)


### PR DESCRIPTION
[by Codex]

## Summary

- initialize `token_to_kv_pool` on the test-created DeepSeek V4 backend
- keep the Q8KV8 sparse-prefill fixture compatible with the cache-builder refactor from #35947

## Testing

- `python3 -m pytest test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py -q -p no:cacheprovider` — 12 passed, 2 SM90-only tests skipped on L40S
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure` — passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33048448530](https://github.com/sgl-project/sglang/actions/runs/33048448530)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33048448333](https://github.com/sgl-project/sglang/actions/runs/33048448333)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33048448519](https://github.com/sgl-project/sglang/actions/runs/33048448519)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->