### PR TITLE
Fix memory-saver subprocess crash on CUDA 13 pip envs: expose wheel libcudart to LD_PRELOAD hook

### DIFF
--- a/python/sglang/srt/utils/torch_memory_saver_adapter.py
+++ b/python/sglang/srt/utils/torch_memory_saver_adapter.py
@@ -1,6 +1,10 @@
+import importlib.util
 import logging
+import os
 from abc import ABC
 from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterable, List, Optional
 
 try:
     import torch_memory_saver
@@ -12,6 +16,131 @@ except ImportError as e:
     pass
 
 logger = logging.getLogger(__name__)
+
+
+def _loaded_libcudart_dirs() -> List[str]:
+    """Directories of CUDA runtime libraries already mapped into this process.
+
+    Once torch is imported, ``/proc/self/maps`` names the exact libcudart the
+    parent uses, so the subprocess can resolve the same one. Returns an empty
+    list on platforms without ``/proc`` or in CPU-only processes.
+    """
+    try:
+        with open("/proc/self/maps") as f:
+            maps = f.read()
+    except OSError:
+        return []
+
+    dirs: List[str] = []
+    for line in maps.splitlines():
+        fields = line.split(None, 5)
+        if len(fields) < 6 or not fields[5].startswith("/"):
+            continue
+        path = fields[5]
+        if "libcudart.so" not in os.path.basename(path):
+            continue
+        parent = os.path.dirname(path)
+        if parent not in dirs:
+            dirs.append(parent)
+    return dirs
+
+
+def _pip_nvidia_roots() -> List[Path]:
+    """Candidate ``site-packages/nvidia`` roots holding pip CUDA wheels."""
+    roots: List[Path] = []
+    try:
+        spec = importlib.util.find_spec("nvidia")
+    except (ImportError, ValueError):
+        spec = None
+    for location in getattr(spec, "submodule_search_locations", None) or []:
+        root = Path(location)
+        if root not in roots:
+            roots.append(root)
+
+    # Also look next to torch, which covers environments where the ``nvidia``
+    # namespace package is not importable by name.
+    try:
+        import torch
+
+        root = Path(torch.__file__).resolve().parent.parent / "nvidia"
+        if root not in roots:
+            roots.append(root)
+    except Exception:
+        pass
+    return roots
+
+
+def _cudart_lib_dirs(nvidia_roots: Iterable[Path]) -> List[str]:
+    """``<root>/*/lib`` directories that contain a CUDA runtime library.
+
+    Covers both pip wheel layouts: CUDA 12 component wheels
+    (``nvidia/cuda_runtime/lib/libcudart.so.12``) and consolidated CUDA 13
+    wheels (``nvidia/cu13/lib/libcudart.so.13``). Only directories that hold
+    libcudart are returned, so unrelated libraries are not exposed to the
+    subprocess.
+    """
+    dirs: List[str] = []
+    for root in nvidia_roots:
+        root = Path(root)
+        if not root.is_dir():
+            continue
+        for lib_dir in sorted(root.glob("*/lib")):
+            if not lib_dir.is_dir():
+                continue
+            if any(lib_dir.glob("libcudart.so*")):
+                path = str(lib_dir)
+                if path not in dirs:
+                    dirs.append(path)
+    return dirs
+
+
+def _prepend_ld_library_path(dirs: List[str], current: Optional[str]) -> str:
+    """Prepend ``dirs`` to a ``:``-separated path string without duplicates."""
+    merged: List[str] = []
+    for entry in [*dirs, *(current or "").split(":")]:
+        if entry and entry not in merged:
+            merged.append(entry)
+    return ":".join(merged)
+
+
+@contextmanager
+def _cuda_runtime_ld_library_path():
+    """Expose the CUDA runtime directory to subprocesses via LD_LIBRARY_PATH.
+
+    torch_memory_saver injects its preload hook into child processes with
+    LD_PRELOAD, so the dynamic loader must resolve the hook's
+    ``libcudart.so.<major>`` dependency before Python (and torch's
+    RPATH-carrying libraries) are loaded. The hook ships without an RPATH,
+    and pip installs the CUDA runtime under ``site-packages/nvidia/*/lib``,
+    which is normally not on LD_LIBRARY_PATH, so the child dies with
+    ``libcudart.so.13: cannot open shared object file`` (issue #36533).
+    Prepending the discovered runtime directories lets the loader find the
+    same libcudart the parent already uses. No-op when nothing is discovered
+    (e.g. CPU-only builds) or the directories are already present.
+    """
+    lib_dirs = _loaded_libcudart_dirs()
+    for lib_dir in _cudart_lib_dirs(_pip_nvidia_roots()):
+        if lib_dir not in lib_dirs:
+            lib_dirs.append(lib_dir)
+
+    old_value = os.environ.get("LD_LIBRARY_PATH")
+    new_value = _prepend_ld_library_path(lib_dirs, old_value)
+    if not lib_dirs or new_value == old_value:
+        yield
+        return
+
+    logger.debug(
+        "memory saver subprocess LD_LIBRARY_PATH gains CUDA runtime dirs: %s",
+        lib_dirs,
+    )
+    os.environ["LD_LIBRARY_PATH"] = new_value
+    try:
+        yield
+    finally:
+        if old_value is None:
+            os.environ.pop("LD_LIBRARY_PATH", None)
+        else:
+            os.environ["LD_LIBRARY_PATH"] = old_value
 
 
 class TorchMemorySaverAdapter(ABC):
@@ -61,8 +190,11 @@ class TorchMemorySaverAdapter(ABC):
 class _TorchMemorySaverAdapterReal(TorchMemorySaverAdapter):
     """Adapter for TorchMemorySaver with tag-based control"""
 
+    @contextmanager
     def configure_subprocess(self):
-        return torch_memory_saver.configure_subprocess()
+        with _cuda_runtime_ld_library_path():
+            with torch_memory_saver.configure_subprocess():
+                yield
 
     def region(self, tag: str, enable_cpu_backup: bool = False):
         return _memory_saver.region(tag=tag, enable_cpu_backup=enable_cpu_backup)

--- a/test/registered/unit/utils/test_torch_memory_saver_adapter.py
+++ b/test/registered/unit/utils/test_torch_memory_saver_adapter.py
@@ -1,0 +1,141 @@
+"""Unit tests for the memory-saver subprocess CUDA runtime path discovery.
+
+`--enable-memory-saver` preloads torch_memory_saver's hook .so into scheduler
+subprocesses via LD_PRELOAD. The hook links against libcudart but ships
+without an RPATH, so in pip CUDA environments the child's dynamic loader
+cannot resolve ``libcudart.so.<major>`` unless the wheel runtime directory is
+on LD_LIBRARY_PATH (issue #36533). These tests cover the pure path-discovery
+helpers on CPU only; no CUDA, server, or model loading involved.
+"""
+
+import sys
+
+import pytest
+
+from sglang.srt.utils import torch_memory_saver_adapter as adapter
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_lib(tmp_path, *parts):
+    lib_dir = tmp_path.joinpath(*parts[:-1])
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    (lib_dir / parts[-1]).touch()
+    return lib_dir
+
+
+class TestCudartLibDirs:
+    def test_cu13_consolidated_layout(self, tmp_path):
+        # CUDA 13 pip wheels install into a single nvidia/cu13 tree.
+        lib_dir = _make_lib(tmp_path, "nvidia", "cu13", "lib", "libcudart.so.13")
+        _make_lib(tmp_path, "nvidia", "cu13", "include", "cuda.h")
+
+        assert adapter._cudart_lib_dirs([tmp_path / "nvidia"]) == [str(lib_dir)]
+
+    def test_cu12_component_layout_filters_non_runtime(self, tmp_path):
+        # CUDA 12 pip wheels install one component per directory; only the
+        # cuda_runtime component holds libcudart and should be returned.
+        runtime = _make_lib(
+            tmp_path, "nvidia", "cuda_runtime", "lib", "libcudart.so.12"
+        )
+        _make_lib(tmp_path, "nvidia", "cublas", "lib", "libcublas.so.12")
+        _make_lib(tmp_path, "nvidia", "cudnn", "lib", "libcudnn.so.9")
+
+        assert adapter._cudart_lib_dirs([tmp_path / "nvidia"]) == [str(runtime)]
+
+    def test_multiple_roots_and_majors_deduplicated(self, tmp_path):
+        root_a = tmp_path / "site_a" / "nvidia"
+        root_b = tmp_path / "site_b" / "nvidia"
+        dir_cu12 = _make_lib(
+            tmp_path, "site_a", "nvidia", "cuda_runtime", "lib", "libcudart.so.12"
+        )
+        dir_cu13 = _make_lib(
+            tmp_path, "site_b", "nvidia", "cu13", "lib", "libcudart.so.13"
+        )
+
+        result = adapter._cudart_lib_dirs([root_a, root_b, root_a])
+
+        assert result == [str(dir_cu12), str(dir_cu13)]
+
+    def test_missing_or_empty_roots(self, tmp_path):
+        empty = tmp_path / "nvidia"
+        empty.mkdir()
+        _make_lib(tmp_path, "nvidia", "nvjitlink", "lib", "libnvJitLink.so.13")
+
+        assert adapter._cudart_lib_dirs([]) == []
+        assert adapter._cudart_lib_dirs([tmp_path / "does_not_exist"]) == []
+        assert adapter._cudart_lib_dirs([empty]) == []
+
+
+class TestPrependLdLibraryPath:
+    def test_without_existing_value(self):
+        assert adapter._prepend_ld_library_path(["/a", "/b"], None) == "/a:/b"
+        assert adapter._prepend_ld_library_path(["/a"], "") == "/a"
+
+    def test_preserves_existing_entries(self):
+        result = adapter._prepend_ld_library_path(["/nv/lib"], "/usr/lib:/opt/lib")
+        assert result == "/nv/lib:/usr/lib:/opt/lib"
+
+    def test_deduplicates_and_drops_empty_entries(self):
+        result = adapter._prepend_ld_library_path(
+            ["/nv/lib", "/nv/lib"], "/usr/lib::/nv/lib:"
+        )
+        assert result == "/nv/lib:/usr/lib"
+
+
+class TestCudaRuntimeLdLibraryPath:
+    @pytest.fixture
+    def fake_discovery(self, monkeypatch, tmp_path):
+        lib_dir = _make_lib(tmp_path, "nvidia", "cu13", "lib", "libcudart.so.13")
+        monkeypatch.setattr(adapter, "_loaded_libcudart_dirs", lambda: [])
+        monkeypatch.setattr(adapter, "_pip_nvidia_roots", lambda: [tmp_path / "nvidia"])
+        return str(lib_dir)
+
+    def test_sets_and_unsets_when_absent(self, monkeypatch, fake_discovery):
+        import os
+
+        monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+        with adapter._cuda_runtime_ld_library_path():
+            assert os.environ["LD_LIBRARY_PATH"] == fake_discovery
+        assert "LD_LIBRARY_PATH" not in os.environ
+
+    def test_prepends_and_restores_existing_value(self, monkeypatch, fake_discovery):
+        import os
+
+        monkeypatch.setenv("LD_LIBRARY_PATH", "/usr/lib")
+        with adapter._cuda_runtime_ld_library_path():
+            assert os.environ["LD_LIBRARY_PATH"] == f"{fake_discovery}:/usr/lib"
+        assert os.environ["LD_LIBRARY_PATH"] == "/usr/lib"
+
+    def test_noop_when_nothing_discovered(self, monkeypatch):
+        import os
+
+        monkeypatch.setattr(adapter, "_loaded_libcudart_dirs", lambda: [])
+        monkeypatch.setattr(adapter, "_pip_nvidia_roots", lambda: [])
+        monkeypatch.delenv("LD_LIBRARY_PATH", raising=False)
+        with adapter._cuda_runtime_ld_library_path():
+            assert "LD_LIBRARY_PATH" not in os.environ
+        assert "LD_LIBRARY_PATH" not in os.environ
+
+    def test_noop_when_already_present(self, monkeypatch, fake_discovery):
+        import os
+
+        monkeypatch.setenv("LD_LIBRARY_PATH", fake_discovery)
+        with adapter._cuda_runtime_ld_library_path():
+            assert os.environ["LD_LIBRARY_PATH"] == fake_discovery
+        assert os.environ["LD_LIBRARY_PATH"] == fake_discovery
+
+
+class TestDiscoverySmoke:
+    def test_discovery_helpers_run_on_any_platform(self):
+        # CPU machines and machines without /proc must degrade to empty
+        # results, never raise.
+        assert isinstance(adapter._loaded_libcudart_dirs(), list)
+        roots = adapter._pip_nvidia_roots()
+        assert isinstance(roots, list)
+        assert isinstance(adapter._cudart_lib_dirs(roots), list)
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Motivation

Fixes #36533. On CUDA 13 pip installs, `--enable-memory-saver` kills every scheduler subprocess at startup:

```text
$VENV/bin/python: error while loading shared libraries: libcudart.so.13: cannot open shared object file: No such file or directory
RuntimeError: Rank 0 scheduler died during initialization (exit code: 127). ...
```

Root cause: torch_memory_saver's `configure_subprocess()` sets `LD_PRELOAD` to its preload hook `.so` before the scheduler process is spawned. The child's dynamic loader must resolve the preloaded object's `NEEDED libcudart.so.13` before Python (and torch's RPATH-carrying libraries) load, so torch cannot help. The shipped hook has no `RPATH`/`RUNPATH`, and pip wheels keep the CUDA runtime under `site-packages/nvidia/cu13/lib` (cu12: `nvidia/cuda_runtime/lib`), which is not on `LD_LIBRARY_PATH`. An unresolvable `NEEDED` of a preloaded object is a fatal loader error, hence exit code 127:

```text
readelf -d site-packages/torch_memory_saver_hook_mode_preload_cu13.abi3.so
 0x0000000000000001 (NEEDED)             Shared library: [libcuda.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libcudart.so.13]
 # ... no RPATH/RUNPATH entry
```

## Modifications

`python/sglang/srt/utils/torch_memory_saver_adapter.py`:

- `_loaded_libcudart_dirs()`: directories of CUDA runtime libraries already mapped into the parent process (`/proc/self/maps`), so the child resolves the exact libcudart the parent uses.
- `_pip_nvidia_roots()` / `_cudart_lib_dirs()`: walk `site-packages/nvidia/*/lib` for directories containing `libcudart.so*`, covering both the cu12 component-wheel layout and the cu13 consolidated layout.
- `_cuda_runtime_ld_library_path()`: context manager that prepends the discovered directories to `LD_LIBRARY_PATH` (existing value preserved, no duplicates) and restores the previous value afterwards. No-op when nothing is discovered (CPU-only builds, system CUDA already resolvable).
- `_TorchMemorySaverAdapterReal.configure_subprocess()` wraps `torch_memory_saver.configure_subprocess()` with that context manager, so the environment is adjusted exactly around `proc.start()`.

`test/registered/unit/utils/test_torch_memory_saver_adapter.py`: pure-CPU unit tests for the discovery and path-merging helpers (fake site-packages trees, env set/restore semantics), registered via `register_cpu_ci(est_time=5, suite="base-a-test-cpu")`.

This works with already-released torch_memory_saver wheels. A complementary upstream fix (fzyzcjy/torch_memory_saver#108) bakes an `$ORIGIN`-relative RPATH into the hook `.so` itself so future wheels resolve libcudart on their own; the two are independent and safe to have in place together.

## Validation

Unit tests (CPU only):

```text
pytest test/registered/unit/utils/test_torch_memory_saver_adapter.py
12 passed
```

GPU validation on a CUDA 13 pip env: Python 3.11.10, torch 2.13.0+cu130, torch-memory-saver 0.0.9.post1, flashinfer-python 0.6.17, Qwen2.5-0.5B-Instruct, the reporter's exact launch flags, 5-run loop per phase plus a no-memory-saver control per phase. Hardware note: NVIDIA L40S, driver 570.124.06 with NVIDIA's `cuda-compat-13.0` forward-compat driver libraries on `LD_LIBRARY_PATH` (driver libs only — the harness asserts before each phase that neither `LD_LIBRARY_PATH` nor `ldconfig` can resolve `libcudart.so.13`, so the bug is not masked).

main @ adcf73d7f7 (unfixed) — control passes, memory saver fails 5/5 with the reporter's signature:

```text
summary[control]: pass=1/1 crash_libcudart=0/1 other=0/1
attempt=1 verdict=CRASH_LIBCUDART missing_runtime=2 scheduler_exit127=1
attempt=2 verdict=CRASH_LIBCUDART missing_runtime=2 scheduler_exit127=1
attempt=3 verdict=CRASH_LIBCUDART missing_runtime=2 scheduler_exit127=1
attempt=4 verdict=CRASH_LIBCUDART missing_runtime=2 scheduler_exit127=1
attempt=5 verdict=CRASH_LIBCUDART missing_runtime=2 scheduler_exit127=1
summary[memsaver]: pass=0/5 crash_libcudart=5/5 other=0/5
```

```text
/workspace/envs/sglcu13/bin/python: error while loading shared libraries: libcudart.so.13: cannot open shared object file: No such file or directory
RuntimeError: Rank 0 scheduler died during initialization (exit code: 127). If exit code is -9 (SIGKILL), a common cause is the OS OOM killer. Run `dmesg -T | grep -i oom` to check.
```

with this PR @ 392ae6efbc — same environment, same flags, memory saver reaches `Application startup complete.` 5/5:

```text
summary[control]: pass=1/1 crash_libcudart=0/1 other=0/1
attempt=1 verdict=PASS missing_runtime=0 scheduler_exit127=0
attempt=2 verdict=PASS missing_runtime=0 scheduler_exit127=0
attempt=3 verdict=PASS missing_runtime=0 scheduler_exit127=0
attempt=4 verdict=PASS missing_runtime=0 scheduler_exit127=0
attempt=5 verdict=PASS missing_runtime=0 scheduler_exit127=0
summary[memsaver]: pass=5/5 crash_libcudart=0/5 other=0/5
```

The passing servers log `'enable_memory_saver': True` in their `server_args`, so the memory-saver path (and its `LD_PRELOAD` hook) was exercised. Full-transparency note: an earlier run of this loop went 4/5 because one attempt failed KV-cache profiling when the harness relaunched before the previous server's GPU memory was released (`missing_runtime=0`, no loader errors — unrelated to this fix); the loop above is a rerun started on an idle GPU.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit) (all hooks pass on the changed files, including the registered-test lint checks).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests) (12 CPU unit tests, registered in `base-a-test-cpu`).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations) (not applicable — no user-facing behavior change beyond the bug fix).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed) (not applicable — startup environment fix, no kernel/model-forward change).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33049612751](https://github.com/sgl-project/sglang/actions/runs/33049612751)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33049612614](https://github.com/sgl-project/sglang/actions/runs/33049612614)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33049612722](https://github.com/sgl-project/sglang/actions/runs/33049612722)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->