### PR TITLE
[Qwen3.8] Fix FP8 KV cache support in QSA

### DIFF
--- a/python/sglang/srt/layers/attention/qsa/kernel.py
+++ b/python/sglang/srt/layers/attention/qsa/kernel.py
@@ -40,9 +40,7 @@ def qsa_fast_topk(
 
         from sgl_kernel import top_k as top_k_module
 
-        supported_topk = getattr(
-            top_k_module, "_FAST_TOPK_SUPPORTED_K", (2048,)
-        )
+        supported_topk = getattr(top_k_module, "_FAST_TOPK_SUPPORTED_K", (2048,))
         if topk in supported_topk:
             return top_k_module.fast_topk_v2(
                 logits, lengths, topk=topk, row_starts=starts
@@ -196,9 +194,7 @@ def _expand_qsa_block_indices_kernel(
         ).to(tl.int32),
         axis=0,
     )
-    valid_token_count = tl.minimum(
-        valid_block_count * COMPRESS_RATIO, TOKEN_TOPK
-    )
+    valid_token_count = tl.minimum(valid_block_count * COMPRESS_RATIO, TOKEN_TOPK)
 
     query_position = tl.load(query_positions + row)
     visible_tokens = query_position + 1
@@ -300,6 +296,8 @@ def qsa_sparse_attention(
     v_cache: torch.Tensor,
     token_slots: torch.Tensor,
     softmax_scale: Optional[float] = None,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
 ) -> torch.Tensor:
     """Torch reference for sparse GQA over physical token slots."""
 
@@ -315,7 +313,7 @@ def qsa_sparse_attention(
     if q.shape[1] % k_cache.shape[1] != 0:
         raise ValueError("query heads must be divisible by KV heads")
     return qsa_sparse_attention_reference(
-        q, k_cache, v_cache, token_slots, softmax_scale
+        q, k_cache, v_cache, token_slots, softmax_scale, k_scale, v_scale
     )
 
 
@@ -325,10 +323,14 @@ def qsa_sparse_attention_reference(
     v_cache: torch.Tensor,
     token_slots: torch.Tensor,
     softmax_scale: Optional[float] = None,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
 ) -> torch.Tensor:
     """Device-agnostic sparse GQA reference."""
 
     scale = softmax_scale or q.shape[-1] ** -0.5
+    k_scale = 1.0 if k_scale is None else k_scale
+    v_scale = 1.0 if v_scale is None else v_scale
     outputs = []
     repeats = q.shape[1] // k_cache.shape[1]
     for row in range(q.shape[0]):
@@ -337,13 +339,17 @@ def qsa_sparse_attention_reference(
         if slots.numel() == 0:
             outputs.append(torch.zeros_like(q[row]))
             continue
-        keys = k_cache.index_select(0, slots).repeat_interleave(repeats, dim=1)
-        values = v_cache.index_select(0, slots).repeat_interleave(repeats, dim=1)
-        scores = torch.einsum("hd,khd->hk", q[row].float(), keys.float()) * scale
-        probabilities = torch.softmax(scores, dim=-1)
-        outputs.append(
-            torch.einsum("hk,khd->hd", probabilities, values.float()).to(q.dtype)
+        keys = (
+            k_cache.index_select(0, slots).float().repeat_interleave(repeats, dim=1)
+            * k_scale
         )
+        values = (
+            v_cache.index_select(0, slots).float().repeat_interleave(repeats, dim=1)
+            * v_scale
+        )
+        scores = torch.einsum("hd,khd->hk", q[row].float(), keys) * scale
+        probabilities = torch.softmax(scores, dim=-1)
+        outputs.append(torch.einsum("hk,khd->hd", probabilities, values).to(q.dtype))
     return torch.stack(outputs)
 
 

--- a/python/sglang/srt/layers/attention/qsa/sparse_attn.py
+++ b/python/sglang/srt/layers/attention/qsa/sparse_attn.py
@@ -6,6 +6,38 @@ import torch
 import triton
 import triton.language as tl
 
+_FP8_DTYPES = (
+    torch.float8_e4m3fn,
+    torch.float8_e4m3fnuz,
+    torch.float8_e5m2,
+)
+
+
+def is_fp8_kv_dtype(dtype: torch.dtype) -> bool:
+    return dtype in _FP8_DTYPES
+
+
+def _validate_sparse_gqa_dtypes(
+    q: torch.Tensor, k: torch.Tensor, v: torch.Tensor
+) -> bool:
+    """Return whether K/V are FP8 after validating the QSA compute contract."""
+
+    if k.dtype != v.dtype:
+        raise ValueError(f"QSA K/V dtypes must match, got {k.dtype} and {v.dtype}")
+    is_fp8 = is_fp8_kv_dtype(k.dtype)
+    if q.dtype not in (torch.bfloat16, torch.float16):
+        raise ValueError(f"QSA expects BF16/FP16 queries, got {q.dtype}")
+    if not is_fp8 and k.dtype != q.dtype:
+        raise ValueError(
+            f"QSA K/V must match query dtype {q.dtype} or use FP8, got {k.dtype}"
+        )
+    return is_fp8
+
+
+def _unit_scale(scale: Optional[float]) -> float:
+    return 1.0 if scale is None else float(scale)
+
+
 _H20_CONFIGS = [
     (32, (32, 8, 2)),
     (64, (64, 8, 2)),
@@ -35,6 +67,8 @@ def _sparse_gqa_prefill(
     indices,
     cu_seqlens,
     scale,
+    k_scale,
+    v_scale,
     topk,
     sq_m: tl.constexpr,
     sq_h: tl.constexpr,
@@ -56,6 +90,7 @@ def _sparse_gqa_prefill(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     HEAD_DIM: tl.constexpr,
+    KV_IS_FP8: tl.constexpr,
 ):
     batch_group = tl.program_id(1)
     group = batch_group % NUM_KV_HEADS
@@ -97,18 +132,34 @@ def _sparse_gqa_prefill(
             mask=valid[None, :],
             other=0.0,
         )
+        if KV_IS_FP8:
+            # Triton does not support the BF16/FP16 x FP8 dot used by QSA.
+            # Widen cached K/V on load; bandwidth remains FP8 while MMA stays
+            # in the model dtype. Per-layer scales reconstruct calibrated KV.
+            keys = keys.to(q_values.dtype)
         values = tl.load(
             v_base + token[:, None] * sv_n + offs_d[None, :] * sv_d,
             mask=valid[:, None],
             other=0.0,
         )
-        scores = tl.where(valid[None, :], tl.dot(q_values, keys), -float("inf"))
+        if KV_IS_FP8:
+            values = values.to(q_values.dtype)
+        scores = tl.dot(q_values, keys)
+        if KV_IS_FP8:
+            scores *= k_scale
+        scores = tl.where(valid[None, :], scores, -float("inf"))
         next_max = tl.maximum(max_value, tl.max(scores, 1))
         alpha = tl.math.exp2(max_value - next_max)
         probabilities = tl.math.exp2(scores - next_max[:, None])
-        accumulator = tl.dot(
-            probabilities.to(values.dtype), values, accumulator * alpha[:, None]
-        )
+        if KV_IS_FP8:
+            accumulator = (
+                accumulator * alpha[:, None]
+                + tl.dot(probabilities.to(values.dtype), values) * v_scale
+            )
+        else:
+            accumulator = tl.dot(
+                probabilities.to(values.dtype), values, accumulator * alpha[:, None]
+            )
         normalizer = normalizer * alpha + tl.sum(probabilities, 1)
         max_value = next_max
     output = accumulator / normalizer[:, None]
@@ -122,7 +173,18 @@ def _sparse_gqa_prefill(
     )
 
 
-def sparse_gqa_fwd_interface_triton(q, k, v, max_seqlen_k, indices, cu_seqlens, scale):
+def sparse_gqa_fwd_interface_triton(
+    q,
+    k,
+    v,
+    max_seqlen_k,
+    indices,
+    cu_seqlens,
+    scale,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
+):
+    kv_is_fp8 = _validate_sparse_gqa_dtypes(q, k, v)
     total_q, num_q_heads, head_dim = q.shape
     num_kv_heads = k.shape[1]
     group_size = num_q_heads // num_kv_heads
@@ -137,6 +199,8 @@ def sparse_gqa_fwd_interface_triton(q, k, v, max_seqlen_k, indices, cu_seqlens, 
         indices,
         cu_seqlens,
         scale,
+        _unit_scale(k_scale),
+        _unit_scale(v_scale),
         indices.shape[-1],
         q.stride(0),
         q.stride(1),
@@ -158,6 +222,7 @@ def sparse_gqa_fwd_interface_triton(q, k, v, max_seqlen_k, indices, cu_seqlens, 
         BLOCK_M=block_m,
         BLOCK_N=block_n,
         HEAD_DIM=head_dim,
+        KV_IS_FP8=kv_is_fp8,
         num_warps=warps,
         num_stages=stages,
     )
@@ -175,6 +240,8 @@ def _sparse_gqa_chunk_prefill(
     cu_k,
     kv_lens,
     scale,
+    k_scale,
+    v_scale,
     topk,
     sq_m: tl.constexpr,
     sq_h: tl.constexpr,
@@ -196,6 +263,7 @@ def _sparse_gqa_chunk_prefill(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     HEAD_DIM: tl.constexpr,
+    KV_IS_FP8: tl.constexpr,
 ):
     query_relative = tl.program_id(0).to(tl.int64)
     batch_group = tl.program_id(1)
@@ -238,18 +306,31 @@ def _sparse_gqa_chunk_prefill(
             mask=valid[None, :],
             other=0.0,
         )
+        if KV_IS_FP8:
+            keys = keys.to(q_values.dtype)
         values = tl.load(
             v_base + token[:, None] * sv_n + offs_d[None, :] * sv_d,
             mask=valid[:, None],
             other=0.0,
         )
-        scores = tl.where(valid[None, :], tl.dot(q_values, keys), -float("inf"))
+        if KV_IS_FP8:
+            values = values.to(q_values.dtype)
+        scores = tl.dot(q_values, keys)
+        if KV_IS_FP8:
+            scores *= k_scale
+        scores = tl.where(valid[None, :], scores, -float("inf"))
         next_max = tl.maximum(max_value, tl.max(scores, 1))
         alpha = tl.math.exp2(max_value - next_max)
         probabilities = tl.math.exp2(scores - next_max[:, None])
-        accumulator = tl.dot(
-            probabilities.to(values.dtype), values, accumulator * alpha[:, None]
-        )
+        if KV_IS_FP8:
+            accumulator = (
+                accumulator * alpha[:, None]
+                + tl.dot(probabilities.to(values.dtype), values) * v_scale
+            )
+        else:
+            accumulator = tl.dot(
+                probabilities.to(values.dtype), values, accumulator * alpha[:, None]
+            )
         normalizer = normalizer * alpha + tl.sum(probabilities, 1)
         max_value = next_max
     output = accumulator / normalizer[:, None]
@@ -263,8 +344,20 @@ def _sparse_gqa_chunk_prefill(
     )
 
 
-def sparse_gqa_fwd_interface_triton_ck(q, k, v, indices, cu_q, cu_k, kv_lens, scale):
+def sparse_gqa_fwd_interface_triton_ck(
+    q,
+    k,
+    v,
+    indices,
+    cu_q,
+    cu_k,
+    kv_lens,
+    scale,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
+):
     k, v = k.contiguous(), v.contiguous()
+    kv_is_fp8 = _validate_sparse_gqa_dtypes(q, k, v)
     total_q, num_q_heads, head_dim = q.shape
     num_kv_heads = k.shape[1]
     group_size = num_q_heads // num_kv_heads
@@ -282,6 +375,8 @@ def sparse_gqa_fwd_interface_triton_ck(q, k, v, indices, cu_q, cu_k, kv_lens, sc
         cu_k,
         kv_lens,
         scale,
+        _unit_scale(k_scale),
+        _unit_scale(v_scale),
         indices.shape[-1],
         q.stride(0),
         q.stride(1),
@@ -303,6 +398,7 @@ def sparse_gqa_fwd_interface_triton_ck(q, k, v, indices, cu_q, cu_k, kv_lens, sc
         BLOCK_M=block_m,
         BLOCK_N=block_n,
         HEAD_DIM=head_dim,
+        KV_IS_FP8=kv_is_fp8,
         num_warps=warps,
         num_stages=stages,
     )
@@ -377,6 +473,8 @@ def _compact_kv(
     cu_k,
     out_k,
     out_v,
+    k_scale,
+    v_scale,
     topk: tl.constexpr,
     heads: tl.constexpr,
     dim: tl.constexpr,
@@ -384,6 +482,7 @@ def _compact_kv(
     idx_stride: tl.constexpr,
     BLOCK_TOPK: tl.constexpr,
     BLOCK_D: tl.constexpr,
+    DEQUANTIZE_FP8: tl.constexpr,
 ):
     batch, head, block = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     cols = block * BLOCK_TOPK + tl.arange(0, BLOCK_TOPK)
@@ -402,8 +501,13 @@ def _compact_kv(
     src = slots[:, None] * heads * dim + head * dim + dims[None, :]
     dst = (pack_start + cols)[:, None] * heads * dim + head * dim + dims[None, :]
     mask = valid[:, None] & (dims[None, :] < dim)
-    tl.store(out_k + dst, tl.load(k + src, mask=mask, other=0.0), mask=mask)
-    tl.store(out_v + dst, tl.load(v + src, mask=mask, other=0.0), mask=mask)
+    k_values = tl.load(k + src, mask=mask, other=0.0)
+    v_values = tl.load(v + src, mask=mask, other=0.0)
+    if DEQUANTIZE_FP8:
+        k_values = k_values.to(tl.float32) * k_scale
+        v_values = v_values.to(tl.float32) * v_scale
+    tl.store(out_k + dst, k_values, mask=mask)
+    tl.store(out_v + dst, v_values, mask=mask)
 
 
 def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
@@ -422,8 +526,23 @@ def qwen_sparse_valid_counts_triton(seq_lens, indices, counts, batch, topk):
 
 
 def qwen_sparse_kv_extraction_compact_triton(
-    k, v, req_to_token, req_indices, indices, seq_lens, cu_k, out_k, out_v, batch, topk
+    k,
+    v,
+    req_to_token,
+    req_indices,
+    indices,
+    seq_lens,
+    cu_k,
+    out_k,
+    out_v,
+    batch,
+    topk,
+    k_scale: Optional[float] = None,
+    v_scale: Optional[float] = None,
 ):
+    if k.dtype != v.dtype or out_k.dtype != out_v.dtype:
+        raise ValueError("QSA compact K/V input and output dtype pairs must match")
+    dequantize_fp8 = is_fp8_kv_dtype(k.dtype) and not is_fp8_kv_dtype(out_k.dtype)
     _, heads, dim = k.shape
     block_topk = 16
     _compact_kv[(batch, heads, triton.cdiv(topk, block_topk))](
@@ -436,6 +555,8 @@ def qwen_sparse_kv_extraction_compact_triton(
         cu_k,
         out_k,
         out_v,
+        _unit_scale(k_scale),
+        _unit_scale(v_scale),
         topk,
         heads,
         dim,
@@ -443,11 +564,13 @@ def qwen_sparse_kv_extraction_compact_triton(
         indices.stride(0),
         BLOCK_TOPK=block_topk,
         BLOCK_D=triton.next_power_of_2(dim),
+        DEQUANTIZE_FP8=dequantize_fp8,
         num_warps=8,
     )
 
 
 __all__ = [
+    "is_fp8_kv_dtype",
     "qwen_sparse_fa2_cu_seqlens_triton",
     "qwen_sparse_valid_counts_triton",
     "qwen_sparse_kv_extraction_compact_triton",

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -31,6 +31,7 @@ from sglang.srt.layers.attention.qsa.metadata import (
     compressed_decode_view,
 )
 from sglang.srt.layers.attention.qsa.sparse_attn import (
+    is_fp8_kv_dtype,
     qwen_sparse_fa2_cu_seqlens_triton,
     qwen_sparse_kv_extraction_compact_triton,
     qwen_sparse_valid_counts_triton,
@@ -78,9 +79,7 @@ def _resolve_flash_attn_varlen_func():
     except ImportError:
         pass
     try:
-        from flash_attn.cute.interface import (
-            flash_attn_varlen_func as cute_varlen_func,
-        )
+        from flash_attn.cute.interface import flash_attn_varlen_func as cute_varlen_func
 
         def flash_attn_varlen_func(*args, **kwargs):
             output = cute_varlen_func(*args, **kwargs)
@@ -93,7 +92,6 @@ def _resolve_flash_attn_varlen_func():
             "QSA decode requires flash_attn (FA2) or flash-attn-4 "
             "(FA4 cute) for its packed varlen fallback."
         ) from exc
-
 
 
 class QwenSparseAttnMetadata(msgspec.Struct, frozen=True):
@@ -247,6 +245,34 @@ class QwenSparseAttnBackend(AttentionBackend):
         self._graph_extend_lens_pin = None
 
     @staticmethod
+    def _kv_descales(layer, kv_dtype: torch.dtype) -> Tuple[float, float]:
+        if not is_fp8_kv_dtype(kv_dtype):
+            return 1.0, 1.0
+        k_scale = getattr(layer, "k_scale_float", None)
+        v_scale = getattr(layer, "v_scale_float", None)
+        k_scale = 1.0 if k_scale is None else float(k_scale)
+        v_scale = 1.0 if v_scale is None else float(v_scale)
+        return (
+            k_scale if k_scale > 0.0 else 1.0,
+            v_scale if v_scale > 0.0 else 1.0,
+        )
+
+    def _store_kv(self, layer, loc, k: torch.Tensor, v: torch.Tensor) -> None:
+        cache_dtype = getattr(self.token_to_kv_pool, "dtype", k.dtype)
+        if not is_fp8_kv_dtype(cache_dtype):
+            self.token_to_kv_pool.set_kv_buffer(layer, loc, k, v)
+            return
+        k_scale, v_scale = self._kv_descales(layer, cache_dtype)
+        if k_scale == 1.0 and v_scale == 1.0:
+            self.token_to_kv_pool.set_kv_buffer(layer, loc, k, v)
+            return
+        # MHATokenToKVPool applies non-unit scales in-place before casting.
+        # Preserve the current K/V because prefill consumes them after the write.
+        self.token_to_kv_pool.set_kv_buffer(
+            layer, loc, k.clone(), v.clone(), k_scale, v_scale
+        )
+
+    @staticmethod
     def _is_speculative_paged_mode(forward_mode) -> bool:
         if forward_mode is None:
             return False
@@ -257,8 +283,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             return
         if int(getattr(spec_info, "topk", 1) or 1) != 1:
             raise NotImplementedError(
-                "Qwen QSA target verification supports only "
-                "speculative_eagle_topk=1"
+                "Qwen QSA target verification supports only " "speculative_eagle_topk=1"
             )
         draft_tokens = int(getattr(spec_info, "draft_token_num", 0) or 0)
         if draft_tokens > self.compress_ratio:
@@ -288,9 +313,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
             return max(1, int(sequence_lengths.max()))
         spec_info = forward_batch.spec_info
-        draft_window = (
-            int(spec_info.draft_token_num) if spec_info is not None else 0
-        )
+        draft_window = int(spec_info.draft_token_num) if spec_info is not None else 0
         return max(1, int(seq_lens_cpu.max()) + draft_window)
 
     @staticmethod
@@ -378,9 +401,7 @@ class QwenSparseAttnBackend(AttentionBackend):
                     extend_lengths = torch.cat(
                         [
                             extend_lengths,
-                            torch.zeros(
-                                bs - extend_lengths.numel(), dtype=torch.int32
-                            ),
+                            torch.zeros(bs - extend_lengths.numel(), dtype=torch.int32),
                         ]
                     )
             else:
@@ -414,9 +435,7 @@ class QwenSparseAttnBackend(AttentionBackend):
                 torch.full((int(extend_len),), prefix_len, dtype=torch.int32)
             )
         row_lengths = (
-            torch.cat(row_lengths)
-            if row_lengths
-            else torch.empty(0, dtype=torch.int32)
+            torch.cat(row_lengths) if row_lengths else torch.empty(0, dtype=torch.int32)
         )
         row_prefix_lengths = (
             torch.cat(row_prefix_lengths)
@@ -429,12 +448,8 @@ class QwenSparseAttnBackend(AttentionBackend):
                 "QSA CUDA graph speculative layout has inconsistent token count: "
                 f"capacity={num_tokens}, actual={actual_rows}"
             )
-        repeats = extend_lengths.to(
-            device=req_pool_indices.device, dtype=torch.long
-        )
-        row_req_pool_indices = torch.repeat_interleave(
-            req_pool_indices[:bs], repeats
-        )
+        repeats = extend_lengths.to(device=req_pool_indices.device, dtype=torch.long)
+        row_req_pool_indices = torch.repeat_interleave(req_pool_indices[:bs], repeats)
         # Draft-extend graphs always execute the captured static token shape,
         # while a replay can contain fewer accepted tokens.  The runner packs
         # real rows first and zero-fills the tail, so give those tail rows safe
@@ -542,9 +557,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             # member sits chunk-locally at (block * ratio - prefix).
             member_rows = torch.where(
                 valid,
-                row_token_starts[rows]
-                + blocks * compress_ratio
-                - prefix_lens[rows],
+                row_token_starts[rows] + blocks * compress_ratio - prefix_lens[rows],
                 torch.zeros_like(blocks),
             )
         return write_locs, group_end_positions, rows, member_rows
@@ -609,10 +622,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             self.device = forward_batch.seq_lens.device
         if not self.max_context_len:
             self.max_context_len = self.req_to_token.shape[1]
-        if (
-            forward_batch.forward_mode.is_idle()
-            or forward_batch.seq_lens.numel() == 0
-        ):
+        if forward_batch.forward_mode.is_idle() or forward_batch.seq_lens.numel() == 0:
             # DP attention runs IDLE dummy forwards on ranks without work, and
             # the MTP multi-step wrapper forwards them as zero-row DECODE
             # steps.  Model layers skip attention for these batches, but
@@ -620,9 +630,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             # of falling into the extend/decode paths on empty tensors.
             return self._empty_metadata(forward_batch)
         original_mode = getattr(forward_batch, "_original_forward_mode", None)
-        if original_mode is not None and self._is_speculative_paged_mode(
-            original_mode
-        ):
+        if original_mode is not None and self._is_speculative_paged_mode(original_mode):
             # DP MAX_LEN pseudo-extend rewrites the mode to EXTEND with
             # extend_seq_lens == 1 per request, which loses the per-request
             # draft fan-out of target_verify/draft_extend.  Refuse to guess
@@ -632,9 +640,7 @@ class QwenSparseAttnBackend(AttentionBackend):
                 f"speculative mode {original_mode}: token rows would be "
                 "mis-mapped to requests"
             )
-        speculative_paged = self._is_speculative_paged_mode(
-            forward_batch.forward_mode
-        )
+        speculative_paged = self._is_speculative_paged_mode(forward_batch.forward_mode)
         if speculative_paged:
             logical_positions = forward_batch.positions
             if logical_positions.ndim == 2:
@@ -690,9 +696,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             else:
                 extend_seq_lens = forward_batch.extend_seq_lens
                 if extend_seq_lens is None:
-                    raise ValueError(
-                        "QSA extend metadata requires extend_seq_lens"
-                    )
+                    raise ValueError("QSA extend metadata requires extend_seq_lens")
                 token_to_batch_idx = torch.repeat_interleave(
                     torch.arange(
                         batch_size,
@@ -912,8 +916,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             max_bs, dtype=torch.int32, device=self.device
         )
         self._graph_extend_lens_pin = [
-            torch.zeros(max_bs, dtype=torch.int32, pin_memory=True)
-            for _ in range(2)
+            torch.zeros(max_bs, dtype=torch.int32, pin_memory=True) for _ in range(2)
         ]
         self._extend_lens_pin_idx = 0
 
@@ -1064,9 +1067,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
         else:
             metadata.sequence_lengths.copy_(seq_lens[:bs].to(torch.int32))
-            metadata.row_req_pool_indices.copy_(
-                req_pool_indices[:bs].to(torch.int32)
-            )
+            metadata.row_req_pool_indices.copy_(req_pool_indices[:bs].to(torch.int32))
             metadata.indexer_metadata.graph_prefix_lengths.copy_(
                 (seq_lens[:bs] - 1).clamp_min(0).to(torch.int32)
             )
@@ -1228,8 +1229,7 @@ class QwenSparseAttnBackend(AttentionBackend):
         row_width_pages = self.req_to_token.shape[1] // full_page
         num_pages = min(max_pages, row_width_pages)
         table = (
-            self.req_to_token[req_indices, : num_pages * full_page : full_page]
-            .long()
+            self.req_to_token[req_indices, : num_pages * full_page : full_page].long()
             // full_page
         ).clamp_min(0)
         page_table[:, :num_pages].copy_(table.to(torch.int32))
@@ -1408,9 +1408,7 @@ class QwenSparseAttnBackend(AttentionBackend):
         if topk_indices is None:
             raise ValueError("QSA sparse attention requires topk_indices")
         if save_kv_cache:
-            self.token_to_kv_pool.set_kv_buffer(
-                layer, forward_batch.out_cache_loc, k, v
-            )
+            self._store_kv(layer, forward_batch.out_cache_loc, k, v)
         q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
         num_output_rows = q.shape[0]
         num_valid_rows = topk_indices.shape[0]
@@ -1432,12 +1430,19 @@ class QwenSparseAttnBackend(AttentionBackend):
             metadata = self._resolve_metadata(forward_batch)
             slots = self._logical_to_physical(topk_indices, metadata)
             pool = self.token_to_kv_pool
+            k_buffer = pool.get_key_buffer(layer.layer_id)
+            v_buffer = pool.get_value_buffer(layer.layer_id)
+            scale_kwargs = {}
+            if is_fp8_kv_dtype(k_buffer.dtype):
+                k_scale, v_scale = self._kv_descales(layer, k_buffer.dtype)
+                scale_kwargs = {"k_scale": k_scale, "v_scale": v_scale}
             output = qsa_sparse_attention(
                 q,
-                pool.get_key_buffer(layer.layer_id),
-                pool.get_value_buffer(layer.layer_id),
+                k_buffer,
+                v_buffer,
                 slots,
                 layer.scaling,
+                **scale_kwargs,
             )
             return self._pad_extend_output(output, num_output_rows)
 
@@ -1468,6 +1473,10 @@ class QwenSparseAttnBackend(AttentionBackend):
         pool = self.token_to_kv_pool
         k_buffer = pool.get_key_buffer(layer.layer_id)
         v_buffer = pool.get_value_buffer(layer.layer_id)
+        scale_kwargs = {}
+        if is_fp8_kv_dtype(k_buffer.dtype):
+            k_scale, v_scale = self._kv_descales(layer, k_buffer.dtype)
+            scale_kwargs = {"k_scale": k_scale, "v_scale": v_scale}
         req_to_token = self.req_to_token_pool.req_to_token
         req_indices = forward_batch.req_pool_indices.tolist()
         k_parts = [
@@ -1495,6 +1504,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             cu_seqlens_k,
             sequence_lens_tensor,
             layer.scaling,
+            **scale_kwargs,
         )
         return self._pad_extend_output(output, num_output_rows)
 
@@ -1531,7 +1541,6 @@ class QwenSparseAttnBackend(AttentionBackend):
             self._fa2_scratch[key] = buffers
         return buffers[0][:capacity], buffers[1][:capacity]
 
-
     def _get_trtllm_sparse_tables(self, batch, pages_per_row, page, device):
         key = (batch, pages_per_row, device)
         cached = self._trtllm_sparse_tables.get(key)
@@ -1541,9 +1550,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             block_tables = (
                 torch.arange(batch, dtype=torch.int32, device=device)[:, None]
                 * pages_per_row
-                + torch.arange(pages_per_row, dtype=torch.int32, device=device)[
-                    None, :
-                ]
+                + torch.arange(pages_per_row, dtype=torch.int32, device=device)[None, :]
             ).contiguous()
             cached = (cu, block_tables)
             self._trtllm_sparse_tables[key] = cached
@@ -1582,9 +1589,7 @@ class QwenSparseAttnBackend(AttentionBackend):
         cu_strided, block_tables = self._get_trtllm_sparse_tables(
             batch, pages_per_row, page, device
         )
-        capacity_rows = (
-            self._cuda_graph_max_tokens if metadata.is_cuda_graph else batch
-        )
+        capacity_rows = self._cuda_graph_max_tokens if metadata.is_cuda_graph else batch
         packed_k, packed_v = self._get_fa2_scratch(
             max(capacity_rows, batch) * stride,
             k_buffer.shape[1],
@@ -1625,6 +1630,7 @@ class QwenSparseAttnBackend(AttentionBackend):
             self._trtllm_workspace = torch.zeros(
                 128 * 1024 * 1024, dtype=torch.uint8, device=device
             )
+        k_scale, v_scale = self._kv_descales(layer, k_buffer.dtype)
         output = trtllm_decode(
             query=q.contiguous(),
             kv_cache=(kc, vc),
@@ -1632,8 +1638,8 @@ class QwenSparseAttnBackend(AttentionBackend):
             block_tables=block_tables,
             seq_lens=valid_counts,
             max_seq_len=stride,
-            bmm1_scale=layer.scaling,
-            bmm2_scale=1.0,
+            bmm1_scale=layer.scaling * k_scale,
+            bmm2_scale=v_scale,
         )
         return output.reshape(q.shape[0], -1)
 
@@ -1651,9 +1657,7 @@ class QwenSparseAttnBackend(AttentionBackend):
         if topk_indices is None:
             raise ValueError("QSA sparse attention requires topk_indices")
         if save_kv_cache:
-            self.token_to_kv_pool.set_kv_buffer(
-                layer, forward_batch.out_cache_loc, k, v
-            )
+            self._store_kv(layer, forward_batch.out_cache_loc, k, v)
         q = q.reshape(-1, layer.tp_q_head_num, layer.head_dim)
         return self._forward_paged_attention(q, layer, forward_batch, topk_indices)
 
@@ -1670,7 +1674,18 @@ class QwenSparseAttnBackend(AttentionBackend):
         if not q.is_cuda:
             metadata = self._resolve_metadata(forward_batch)
             slots = self._logical_to_physical(topk_indices, metadata)
-            output = qsa_sparse_attention(q, k_buffer, v_buffer, slots, layer.scaling)
+            scale_kwargs = {}
+            if is_fp8_kv_dtype(k_buffer.dtype):
+                k_scale, v_scale = self._kv_descales(layer, k_buffer.dtype)
+                scale_kwargs = {"k_scale": k_scale, "v_scale": v_scale}
+            output = qsa_sparse_attention(
+                q,
+                k_buffer,
+                v_buffer,
+                slots,
+                layer.scaling,
+                **scale_kwargs,
+            )
             return output.reshape(q.shape[0], -1)
 
         metadata = self._resolve_metadata(forward_batch)
@@ -1714,13 +1729,15 @@ class QwenSparseAttnBackend(AttentionBackend):
             if metadata.is_cuda_graph
             else batch * topk
         )
+        scratch_dtype = q.dtype if is_fp8_kv_dtype(k_buffer.dtype) else k_buffer.dtype
         packed_k, packed_v = self._get_fa2_scratch(
             scratch_capacity,
             k_buffer.shape[1],
             k_buffer.shape[2],
-            k_buffer.dtype,
+            scratch_dtype,
             k_buffer.device,
         )
+        k_scale, v_scale = self._kv_descales(layer, k_buffer.dtype)
         qwen_sparse_kv_extraction_compact_triton(
             k_buffer,
             v_buffer,
@@ -1737,6 +1754,8 @@ class QwenSparseAttnBackend(AttentionBackend):
             packed_v,
             batch,
             topk,
+            k_scale=k_scale,
+            v_scale=v_scale,
         )
         output = flash_attn_varlen_func(
             q=q,
@@ -1812,9 +1831,7 @@ class QwenSparseMultiStepDraftBackend:
             .reshape(steps, -1)[step]
         )
 
-    def _make_step_forward_batch(
-        self, forward_batch, step: int, num_padding: int = 0
-    ):
+    def _make_step_forward_batch(self, forward_batch, step: int, num_padding: int = 0):
         step_forward_batch = copy(forward_batch)
         step_forward_batch.forward_mode = ForwardMode.DECODE
         step_forward_batch.seq_lens = (forward_batch.seq_lens + step + 1).to(
@@ -1841,9 +1858,7 @@ class QwenSparseMultiStepDraftBackend:
                 )
                 step_forward_batch.seq_lens_cpu[-num_padding:] = 1
         step_forward_batch.batch_size = int(step_forward_batch.seq_lens.numel())
-        step_forward_batch.out_cache_loc = self._step_out_cache_loc(
-            forward_batch, step
-        )
+        step_forward_batch.out_cache_loc = self._step_out_cache_loc(forward_batch, step)
         return step_forward_batch
 
     def set_mtp_shared_sparse_indices(self, state) -> None:
@@ -1860,9 +1875,7 @@ class QwenSparseMultiStepDraftBackend:
         for backend in self.attn_backends:
             backend.init_cuda_graph_state(max_bs, max_num_tokens)
 
-    def init_forward_metadata_out_graph(
-        self, forward_batch, in_capture: bool = False
-    ):
+    def init_forward_metadata_out_graph(self, forward_batch, in_capture: bool = False):
         if in_capture:
             for step, backend in enumerate(self.attn_backends):
                 # Every capture row is synthetic.  Keep its sequence length

--- a/test/registered/kernels/test_qsa_fp8_kv.py
+++ b/test/registered/kernels/test_qsa_fp8_kv.py
@@ -1,0 +1,328 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.attention import qwen_sparse_attn_backend as qsa_backend_module
+from sglang.srt.layers.attention.qsa.kernel import qsa_sparse_attention
+from sglang.srt.layers.attention.qsa.sparse_attn import (
+    qwen_sparse_kv_extraction_compact_triton,
+    sparse_gqa_fwd_interface_triton,
+    sparse_gqa_fwd_interface_triton_ck,
+)
+from sglang.srt.layers.attention.qwen_sparse_attn_backend import (
+    QwenSparseAttnBackend,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="4-gpu-b200")
+
+
+def _quantize_fp8(tensor: torch.Tensor, scale: float) -> torch.Tensor:
+    return (tensor / scale).to(torch.float8_e4m3fn)
+
+
+def test_qsa_sparse_attention_reference_applies_fp8_kv_descales():
+    torch.manual_seed(23)
+    q = torch.randn(2, 4, 16, dtype=torch.bfloat16)
+    k_scale, v_scale = 0.25, 0.5
+    k = _quantize_fp8(torch.randn(7, 2, 16, dtype=torch.bfloat16), k_scale)
+    v = _quantize_fp8(torch.randn(7, 2, 16, dtype=torch.bfloat16), v_scale)
+    slots = torch.tensor([[0, 2, 4, 6], [1, 3, 5, -1]], dtype=torch.int32)
+
+    actual = qsa_sparse_attention(q, k, v, slots, k_scale=k_scale, v_scale=v_scale)
+    expected = qsa_sparse_attention(
+        q,
+        k.float() * k_scale,
+        v.float() * v_scale,
+        slots,
+    )
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_qsa_fp8_prefill_matches_dequantized_reference():
+    if not torch.cuda.is_available():
+        return
+
+    torch.manual_seed(27)
+    device = "cuda"
+    q = torch.randn(3, 4, 128, dtype=torch.bfloat16, device=device)
+    k_scale, v_scale = 0.25, 0.5
+    k = _quantize_fp8(
+        torch.randn(3, 1, 128, dtype=torch.bfloat16, device=device), k_scale
+    )
+    v = _quantize_fp8(
+        torch.randn(3, 1, 128, dtype=torch.bfloat16, device=device), v_scale
+    )
+    indices = torch.tensor(
+        [[0, -1, -1], [0, 1, -1], [0, 1, 2]],
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_seqlens = torch.tensor([0, 3], dtype=torch.int32, device=device)
+    softmax_scale = 128**-0.5
+
+    actual = sparse_gqa_fwd_interface_triton(
+        q,
+        k,
+        v,
+        max_seqlen_k=3,
+        indices=indices,
+        cu_seqlens=cu_seqlens,
+        scale=softmax_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    expected = qsa_sparse_attention(
+        q,
+        k,
+        v,
+        indices,
+        softmax_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
+
+
+def test_qsa_fp8_chunk_prefill_matches_dequantized_reference():
+    if not torch.cuda.is_available():
+        return
+
+    torch.manual_seed(29)
+    device = "cuda"
+    q = torch.randn(3, 4, 128, dtype=torch.bfloat16, device=device)
+    k_scale, v_scale = 0.25, 0.5
+    k = _quantize_fp8(
+        torch.randn(6, 1, 128, dtype=torch.bfloat16, device=device), k_scale
+    )
+    v = _quantize_fp8(
+        torch.randn(6, 1, 128, dtype=torch.bfloat16, device=device), v_scale
+    )
+    indices = torch.tensor(
+        [[0, 1, 2, 3], [0, 2, 3, 4], [1, 3, 4, 5]],
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_q = torch.tensor([0, 3], dtype=torch.int32, device=device)
+    cu_k = torch.tensor([0, 6], dtype=torch.int32, device=device)
+    kv_lens = torch.tensor([6], dtype=torch.int32, device=device)
+    softmax_scale = 128**-0.5
+
+    actual = sparse_gqa_fwd_interface_triton_ck(
+        q,
+        k,
+        v,
+        indices,
+        cu_q,
+        cu_k,
+        kv_lens,
+        softmax_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    expected = qsa_sparse_attention(
+        q,
+        k,
+        v,
+        indices,
+        softmax_scale,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    torch.testing.assert_close(actual, expected, rtol=3e-2, atol=3e-2)
+
+
+def test_qsa_bf16_chunk_prefill_regression():
+    if not torch.cuda.is_available():
+        return
+
+    torch.manual_seed(30)
+    device = "cuda"
+    q = torch.randn(3, 4, 128, dtype=torch.bfloat16, device=device)
+    k = torch.randn(6, 1, 128, dtype=torch.bfloat16, device=device)
+    v = torch.randn(6, 1, 128, dtype=torch.bfloat16, device=device)
+    indices = torch.tensor(
+        [[0, 1, 2, 3], [0, 2, 3, 4], [1, 3, 4, 5]],
+        dtype=torch.int32,
+        device=device,
+    )
+    cu_q = torch.tensor([0, 3], dtype=torch.int32, device=device)
+    cu_k = torch.tensor([0, 6], dtype=torch.int32, device=device)
+    kv_lens = torch.tensor([6], dtype=torch.int32, device=device)
+    softmax_scale = 128**-0.5
+
+    actual = sparse_gqa_fwd_interface_triton_ck(
+        q, k, v, indices, cu_q, cu_k, kv_lens, softmax_scale
+    )
+    expected = qsa_sparse_attention(q, k, v, indices, softmax_scale)
+    torch.testing.assert_close(actual, expected, rtol=2e-2, atol=2e-2)
+
+
+def test_qsa_fp8_compact_gather_dequantizes_for_flash_attention():
+    if not torch.cuda.is_available():
+        return
+
+    torch.manual_seed(31)
+    device = "cuda"
+    k_scale, v_scale = 0.25, 0.5
+    k = _quantize_fp8(
+        torch.randn(16, 1, 16, dtype=torch.bfloat16, device=device), k_scale
+    )
+    v = _quantize_fp8(
+        torch.randn(16, 1, 16, dtype=torch.bfloat16, device=device), v_scale
+    )
+    req_to_token = torch.tensor(
+        [[3, 5, 7, 9, 11, 13], [2, 4, 6, 8, 10, 12]],
+        dtype=torch.int32,
+        device=device,
+    )
+    req_indices = torch.tensor([0, 1], dtype=torch.int32, device=device)
+    indices = torch.tensor(
+        [[0, 3, 5, -1], [1, 4, -1, -1]], dtype=torch.int32, device=device
+    )
+    seq_lens = torch.tensor([6, 5], dtype=torch.int32, device=device)
+    cu_k = torch.tensor([0, 3, 5], dtype=torch.int32, device=device)
+    out_k = torch.empty(8, 1, 16, dtype=torch.bfloat16, device=device)
+    out_v = torch.empty_like(out_k)
+
+    qwen_sparse_kv_extraction_compact_triton(
+        k,
+        v,
+        req_to_token,
+        req_indices,
+        indices,
+        seq_lens,
+        cu_k,
+        out_k,
+        out_v,
+        batch=2,
+        topk=4,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    selected_slots = torch.tensor([3, 9, 13, 4, 10], device=device)
+    torch.testing.assert_close(
+        out_k[:5].float(),
+        k[selected_slots].float() * k_scale,
+        rtol=0,
+        atol=2e-2,
+    )
+    torch.testing.assert_close(
+        out_v[:5].float(),
+        v[selected_slots].float() * v_scale,
+        rtol=0,
+        atol=2e-2,
+    )
+
+    # TRTLLM consumes FP8 scratch directly and applies the descales in BMM1/BMM2.
+    out_k_fp8 = torch.empty(8, 1, 16, dtype=torch.float8_e4m3fn, device=device)
+    out_v_fp8 = torch.empty_like(out_k_fp8)
+    qwen_sparse_kv_extraction_compact_triton(
+        k,
+        v,
+        req_to_token,
+        req_indices,
+        indices,
+        seq_lens,
+        cu_k,
+        out_k_fp8,
+        out_v_fp8,
+        batch=2,
+        topk=4,
+        k_scale=k_scale,
+        v_scale=v_scale,
+    )
+    torch.testing.assert_close(
+        out_k_fp8[:5].float(), k[selected_slots].float(), rtol=0, atol=0
+    )
+    torch.testing.assert_close(
+        out_v_fp8[:5].float(), v[selected_slots].float(), rtol=0, atol=0
+    )
+
+
+def test_qsa_fp8_cache_write_preserves_prefill_kv():
+    class MutatingPool:
+        dtype = torch.float8_e4m3fn
+
+        def set_kv_buffer(
+            self, layer, loc, cache_k, cache_v, k_scale=None, v_scale=None
+        ):
+            self.args = (cache_k, cache_v, k_scale, v_scale)
+            if k_scale is not None:
+                cache_k.div_(k_scale)
+                cache_v.div_(v_scale)
+
+    backend = QwenSparseAttnBackend.__new__(QwenSparseAttnBackend)
+    backend.token_to_kv_pool = MutatingPool()
+    layer = SimpleNamespace(layer_id=0, k_scale_float=0.25, v_scale_float=0.5)
+    k = torch.randn(3, 1, 16, dtype=torch.bfloat16)
+    v = torch.randn(3, 1, 16, dtype=torch.bfloat16)
+    expected_k, expected_v = k.clone(), v.clone()
+
+    backend._store_kv(layer, torch.arange(3, dtype=torch.int32), k, v)
+
+    written_k, written_v, written_k_scale, written_v_scale = (
+        backend.token_to_kv_pool.args
+    )
+    assert written_k is not k and written_v is not v
+    assert written_k_scale == 0.25 and written_v_scale == 0.5
+    torch.testing.assert_close(k, expected_k)
+    torch.testing.assert_close(v, expected_v)
+
+
+def test_qsa_trtllm_decode_receives_fp8_kv_descales(monkeypatch):
+    seen = {}
+
+    def fake_valid_counts(seq_lens, indices, counts, batch, topk):
+        counts.fill_(topk)
+
+    def fake_compact(*args, **kwargs):
+        return None
+
+    def fake_decode(**kwargs):
+        seen.update(kwargs)
+        return torch.zeros_like(kwargs["query"])
+
+    monkeypatch.setattr(
+        qsa_backend_module, "qwen_sparse_valid_counts_triton", fake_valid_counts
+    )
+    monkeypatch.setattr(
+        qsa_backend_module,
+        "qwen_sparse_kv_extraction_compact_triton",
+        fake_compact,
+    )
+    backend = QwenSparseAttnBackend.__new__(QwenSparseAttnBackend)
+    backend.req_to_token_pool = SimpleNamespace(
+        req_to_token=torch.arange(8, dtype=torch.int32).reshape(1, 8)
+    )
+    backend._fa2_scratch = {}
+    backend._trtllm_sparse_tables = {}
+    backend._trtllm_workspace = torch.empty(1, dtype=torch.uint8)
+    backend._cuda_graph_max_tokens = 0
+    layer = SimpleNamespace(scaling=0.125, k_scale_float=0.25, v_scale_float=0.5)
+    q = torch.randn(1, 4, 16, dtype=torch.bfloat16)
+    k = torch.empty(8, 1, 16, dtype=torch.float8_e4m3fn)
+    v = torch.empty_like(k)
+    topk_indices = torch.tensor([[0, 1, 2, 3]], dtype=torch.int32)
+    forward_batch = SimpleNamespace(req_pool_indices=torch.tensor([0]))
+    metadata = SimpleNamespace(
+        sequence_lengths=torch.tensor([8], dtype=torch.int32),
+        row_req_pool_indices=None,
+        is_cuda_graph=False,
+    )
+
+    output = backend._forward_trtllm_sparse(
+        q, k, v, layer, forward_batch, metadata, topk_indices, fake_decode
+    )
+
+    assert output.shape == (1, 64)
+    assert seen["kv_cache"][0].dtype == torch.float8_e4m3fn
+    assert seen["bmm1_scale"] == 0.125 * 0.25
+    assert seen["bmm2_scale"] == 0.5
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

- support FP8 KV cache in QSA normal and chunked prefill by widening cached K/V to the query dtype and applying the per-layer KV descales
- dequantize compacted FP8 cache into query-dtype scratch buffers for the FlashAttention fallback, while preserving FP8 cache buffers for the TRT-LLM decode path and passing its BMM descales
- use per-layer scales when writing the KV cache without mutating the K/V tensors still consumed by initial prefill
- keep the existing BF16 paths compile-time separated, and add focused coverage for FP8, non-unit scales, fallback, decode, and cache writes

Addresses the remaining prefill/chunk-prefill FP8 path related to #36545.

## Context

With an FP8 KV cache, a long cached chunk-prefill request reaches the QSA Triton kernel with BF16 queries and FP8 cached keys/values. `tl.dot` then rejects the mixed input dtypes. PR #36806 fixes the exact-SM120 QSA sparse-decode routing and supersedes the broader SM12x routing proposed in #36556. That decode-path fix does not dequantize FP8 QSA cache entries consumed by normal or chunked prefill; this PR covers that orthogonal data path.

This PR is stacked on #36497 because the Qwen3.8/QSA implementation is not on `main` yet.

## Validation

- `pre-commit run --from-ref 73a255206f --to-ref d2c8b42cb1`: all hooks passed
- existing QSA GPU suite on RTX 5090 (SM120): `52 passed`
- new focused QSA FP8 KV GPU suite on RTX 5090: `7 passed`
  - normal prefill and cached chunk prefill against a dequantized reference
  - non-unit K/V descales
  - BF16 regression path
  - FlashAttention fallback compaction and native TRT-LLM decode scaling
  - scaled cache writes preserve the original prefill tensors
- real checkpoint smoke test: `RadixArk/Qwen3.8-Flash-Next-NVFP4`, TP=8 on 8x RTX 5090, `--kv-cache-dtype fp8_e4m3`
  - FP8 K/V cache allocated successfully
  - decode CUDA Graphs captured for batch sizes 1, 2, 4, and 8
  - WikiText-103 50k-token request after a 45k-token prewarm: 44,992 cached tokens (89.984%) and successful generation
  - 8 concurrent distinct-suffix requests and an 8-concurrent cached replay both completed; the server reported an 8-request decode batch with CUDA Graph enabled

- fresh current-base RED/GREEN revalidation ([full setup and results](https://github.com/sgl-project/sglang/pull/36644#issuecomment-5466422753)) on `qwen4-main-squashed` `99c9362` (including #36806), 4x RTX 5090, TP=4, and real WikiText-103 token IDs
  - RED: a 45,000-token prewarm failed in `_sparse_gqa_chunk_prefill` at `tl.dot(q_values, keys)` with `Unsupported rhs dtype fp8e4nv`
  - GREEN: the same prewarm passed; a follow-up 50,000-token request reused 44,992 cached prompt tokens (89.984%) and generated successfully

The original TP=8 end-to-end worktree additionally carried #36556. The fresh TP=4 RED/GREEN revalidation instead used the current base `99c9362`, including #36806. Both sides of each A/B carried the same unrelated ModelOpt NVFP4 MoE TP-padding loader fix required to load this particular exported checkpoint; none of those auxiliary changes are included in this PR. The checkpoint exposes unit/default KV scales, while non-unit scale behavior is covered by the focused kernel tests above.

## Accuracy

Full official GSM8K A/B (`python -m sglang.test.run_eval`, all 1,314 examples, Chat API, thinking disabled, temperature 0, max 512 output tokens, concurrency 8) on the same patched source, checkpoint, and TP=8 host; only `--kv-cache-dtype` changes:

| Metric | BF16 KV | FP8 KV | FP8 delta |
|---|---:|---:|---:|
| Correct / 1,314 | 1,265 | 1,261 | -4 |
| Accuracy | 96.2709% | 95.9665% | -0.3044 pp |
| Output throughput (tok/s) | 437.24 | 437.84 | +0.14% |

The paired result agrees on 1,298/1,314 examples (98.78%): 1,255 are correct under both KV dtypes, 43 are wrong under both, 10 are BF16-only correct, and 6 are FP8-only correct. A two-sided exact McNemar test on the 16 discordant examples gives p=0.45, so this run does not show a statistically significant task-accuracy difference. The focused GPU tests separately compare normal and cached chunk-prefill FP8 outputs against a dequantized reference with non-unit K/V scales.

## Serving performance

Controlled A/B on the same patched source, model, 8x RTX 5090 host, and exact WikiText-103 token-ID prompts; each setting contains 16 requests and only `--kv-cache-dtype` changes:

| Workload / metric | BF16 KV | FP8 KV | FP8 delta |
|---|---:|---:|---:|
| 1k input / 1k output, c=8, output tok/s | 764.50 | 764.44 | -0.01% |
| 50k input / 400 output, 89.98% cache hit, c=1, output tok/s | 99.79 | 100.25 | +0.46% |
| same c=1, TTFT p50 / p90 (ms) | 928 / 1,001 | 925 / 961 | -0.28% / -3.95% |
| 50k input / 400 output, 89.98% cache hit, c=8, output tok/s | 255.21 | 257.25 | +0.80% |
| same c=8, TTFT p50 / p90 (ms) | 4,299 / 8,751 | 4,284 / 8,684 | -0.37% / -0.76% |

The same long-context BF16 workload before vs. after this patch was -0.44% at c=1 and +1.17% at c=8, showing no measurable BF16 regression. FP8 increased allocated KV capacity per GPU from 762,496 to 1,440,320 tokens (+88.9%). The unpatched 50k / 90%-hit FP8 case crashes in the QSA mixed-dtype dot before producing a comparable result, so these numbers are intended as a regression guardrail rather than a broad speedup claim.

## Integration note

Commit `d2c8b42cb1` applies cleanly to the current `qwen4-main-squashed` head `99c9362` (including #36806). The controlled RED/GREEN revalidation above reproduces the failure on the base and passes with this commit. The full changed-file pre-commit suite passes, and the four files changed here pass the same hooks.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829312782](https://github.com/sgl-project/sglang/actions/runs/34829312782)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829312532](https://github.com/sgl-project/sglang/actions/runs/34829312532)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829312674](https://github.com/sgl-project/sglang/actions/runs/34829312674)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->