### PR TITLE
Fix DSA seed metadata sizing when DSA is disabled

### DIFF
--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -19,7 +19,7 @@ import numpy as np
 import torch
 import torch.distributed as dist
 
-from sglang.srt.configs.model_config import get_dsa_index_topk
+from sglang.srt.configs.model_config import get_dsa_index_topk, is_deepseek_dsa
 from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import (
@@ -69,6 +69,8 @@ def poll_and_all_reduce_pp(
 
 def get_dsa_seed_metadata_dim(hf_config) -> int:
     """Return the model-defined PD seed width, independent of local spec mode."""
+    if not is_deepseek_dsa(hf_config):
+        return 0
     if not getattr(hf_config, "index_share_for_mtp_iteration", False):
         return 0
     return get_dsa_index_topk(hf_config)

--- a/test/registered/unit/disaggregation/test_dsa_seed_metadata_dim.py
+++ b/test/registered/unit/disaggregation/test_dsa_seed_metadata_dim.py
@@ -1,0 +1,49 @@
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.configs.model_config import is_deepseek_dsa
+from sglang.srt.disaggregation.utils import get_dsa_seed_metadata_dim
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _dsa_config(*, index_topk, index_share_for_mtp_iteration):
+    """Minimal stand-in for a DSA checkpoint's HF config (e.g. GLM-5.3)."""
+    return SimpleNamespace(
+        architectures=["GlmMoeDsaForCausalLM"],
+        index_topk=index_topk,
+        index_share_for_mtp_iteration=index_share_for_mtp_iteration,
+    )
+
+
+def test_seed_metadata_dim_zero_when_dsa_disabled_but_share_flag_set():
+    """DSA disabled via index_topk=None must not assert in get_dsa_index_topk.
+
+    Regression for https://github.com/sgl-project/sglang/issues/36598: the
+    scheduler gates PD seed-metadata sizing on index_share_for_mtp_iteration
+    only, so a DSA-disabled checkpoint (index_topk overridden to null) with the
+    share flag still true reached get_dsa_index_topk, which asserts
+    is_deepseek_dsa(). With DSA off the share flag is moot: the width is 0.
+    """
+    cfg = _dsa_config(index_topk=None, index_share_for_mtp_iteration=True)
+    assert not is_deepseek_dsa(cfg)
+    assert get_dsa_seed_metadata_dim(cfg) == 0
+
+
+def test_seed_metadata_dim_with_dsa_enabled_and_share_flag():
+    cfg = _dsa_config(index_topk=2048, index_share_for_mtp_iteration=True)
+    assert is_deepseek_dsa(cfg)
+    assert get_dsa_seed_metadata_dim(cfg) == 2048
+
+
+def test_seed_metadata_dim_with_dsa_enabled_without_share_flag():
+    cfg = _dsa_config(index_topk=2048, index_share_for_mtp_iteration=False)
+    assert is_deepseek_dsa(cfg)
+    assert get_dsa_seed_metadata_dim(cfg) == 0
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Why are these changes needed?

Disabling DSA via `--json-model-override-args '{"index_topk": null}'` can crash the scheduler when the checkpoint config still has `index_share_for_mtp_iteration: true`.

`get_dsa_seed_metadata_dim` previously checked only `index_share_for_mtp_iteration`, then called `get_dsa_index_topk`, which asserts `is_deepseek_dsa(config)`. After `index_topk` is overridden to `null`, `is_deepseek_dsa()` becomes false, so the scheduler reaches a DSA-only helper even though DSA has already been disabled.

Fixes #36598

## What changes are included in this PR?

- Update `get_dsa_seed_metadata_dim` to return `0` when DSA is disabled.
- Treat `index_share_for_mtp_iteration` as irrelevant when `is_deepseek_dsa(hf_config)` is false.
- Keep the protective `assert is_deepseek_dsa(config)` in `get_dsa_index_topk` unchanged.
- Preserve existing behavior for DSA-enabled configurations.

## Are these changes tested?

Added CPU regression coverage for:

- DSA disabled + `index_share_for_mtp_iteration=True` → returns `0` without asserting.
- DSA enabled + `index_share_for_mtp_iteration=True` → returns the configured `index_topk`.
- DSA enabled + `index_share_for_mtp_iteration=False` → returns `0`.

Validation performed locally:

- Targeted regression tests: `3 passed`
- Verified the regression fails on the pre-fix logic with the expected `AssertionError`
- `git diff --check`
- File-scoped pre-commit hooks passed

The broader adjacent/full test suite was not run locally because this environment does not have the GPU/import dependencies required by the full SGLang disaggregation stack.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/sgl-project/sglang/blob/main/CONTRIBUTING.md) document.
- [x] My changes don't require a change to the documentation.
- [x] I have added tests to cover my changes.
- [ ] New and existing unit tests pass locally.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33050212209](https://github.com/sgl-project/sglang/actions/runs/33050212209)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33050212037](https://github.com/sgl-project/sglang/actions/runs/33050212037)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33050212191](https://github.com/sgl-project/sglang/actions/runs/33050212191)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->