### PR TITLE
fix(qsa): enable trtllm-gen sparse decode on sm_121 (GB10 / DGX Spark)

### DIFF
--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -53,9 +53,9 @@ def _resolve_trtllm_sparse_decode():
     at decode row counts; the trtllm-gen decode kernel over a page-aligned
     scratch measures ~35% faster for the gather+attention pair.
     """
-    from sglang.srt.utils import is_sm100_supported
+    from sglang.srt.utils import is_sm100_supported, is_sm121
 
-    if not is_sm100_supported():
+    if not (is_sm100_supported() or is_sm121()):
         return None
     try:
         from flashinfer.decode import trtllm_batch_decode_with_kv_cache


### PR DESCRIPTION
### Motivation

`_resolve_trtllm_sparse_decode()` gates the trtllm-gen paged decode kernel on
`is_sm100_supported()`. GB10 (DGX Spark, sm_121) fails that check, so QSA decode
falls through to the FA4 cute varlen fallback.

As the resolver's own docstring notes, that fallback "runs a prefill-shaped kernel
at decode row counts". On sm_121 it does not merely run slower, it aborts during
CUDA graph capture:

```
File "flash_attn/cute/flash_fwd.py", line 393, in epilogue
cutlass._mlir._mlir_libs._site_initialize.<locals>.MLIRError: Operation creation failed:
error: unknown: expects `coord` and shape of view are weakly congruent, but got
'!cute.layout<"(?,?):(?{i64 div=8},1)">', '!cute.coord<"(_,_,?)">'
```

This makes Qwen3.8-Flash-Next unservable on DGX Spark, because
`_forward_paged_attention` is the only decode path QSA has.

`flashinfer.decode.trtllm_batch_decode_with_kv_cache` imports fine on sm_121, and
the repo already ships an `is_sm121()` helper (added for GB10). Admitting sm_121
to the gate selects the working kernel.

### Modifications

`python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py`: widen the gate
from `is_sm100_supported()` to `is_sm100_supported() or is_sm121()`. One line;
no behaviour change on any other architecture.

### Accuracy Test

Verified on 2x DGX Spark (GB10, sm_121, 128 GB unified each, ConnectX 200 Gb/s)
serving `RadixArk/Qwen3.8-Flash-Next-NVFP4` at `--tp-size 2 --nnodes 2`:

- before: crash at CUDA graph capture, server never reaches ready
- after: server reaches ready and returns coherent generations

### Benchmarking and Profiling

Same host, `--mem-fraction-static 0.70`, `--ple-offload-embedding`,
`--moe-runner-backend flashinfer_cutlass`, context 65536:

| metric | value |
|---|---|
| prefill (49,317-token prompt) | ~1318 tok/s |
| decode, short prompt, no spec decode | ~24.8 tok/s |

No before-numbers are possible: the server does not start without this change.

### Checklist

- [x] Change is covered by the existing QSA decode path; no new API surface.
- [x] No effect on sm_90/sm_100 code paths.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33052279089](https://github.com/sgl-project/sglang/actions/runs/33052279089)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33052278925](https://github.com/sgl-project/sglang/actions/runs/33052278925)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33052279077](https://github.com/sgl-project/sglang/actions/runs/33052279077)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->