### PR TITLE
config: validate cuda graph config values

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -62,6 +62,7 @@ from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.lora.lora_registry import LoRARef
 from sglang.srt.model_executor.cuda_graph_config import (
     ALLOWED_BACKENDS_PER_PHASE,
+    ALLOWED_KEYS_PER_PHASE,
     Backend,
     CudaGraphConfig,
     Phase,
@@ -4937,9 +4938,22 @@ class ServerArgs:
 
         # ---- Explicit JSON config (highest precedence) ----
         for phase, phase_config in explicit_input.items():
+            if phase not in Phase.ALL:
+                raise ValueError(
+                    f"--cuda-graph-config: unknown phase {phase!r}, "
+                    f"expected one of {Phase.ALL}"
+                )
             if not isinstance(phase_config, dict):
-                continue
+                raise ValueError(
+                    f"--cuda-graph-config[{phase!r}] must be a dict, got "
+                    f"{type(phase_config).__name__}"
+                )
             for key, value in phase_config.items():
+                if key not in ALLOWED_KEYS_PER_PHASE[phase]:
+                    raise ValueError(
+                        f"--cuda-graph-config[{phase!r}]: unknown key {key!r}, "
+                        f"expected one of {ALLOWED_KEYS_PER_PHASE[phase]}"
+                    )
                 _set(phase, key, value)
 
         self._declare(
@@ -5176,6 +5190,50 @@ class ServerArgs:
                 raise ValueError(
                     f"--cuda-graph-config[{phase}].backend={backend!r} not allowed; "
                     f"allowed: {ALLOWED_BACKENDS_PER_PHASE[phase]}"
+                )
+            phase_config = getattr(cfg.cuda_graph_config, phase)
+            if phase_config.max_bs is not None and (
+                isinstance(phase_config.max_bs, bool)
+                or not isinstance(phase_config.max_bs, int)
+                or phase_config.max_bs <= 0
+            ):
+                raise ValueError(
+                    f"--cuda-graph-config[{phase}].max_bs must be a positive "
+                    f"integer or None, got {phase_config.max_bs!r}"
+                )
+            if phase == Phase.DECODE and phase_config.bs == []:
+                raise ValueError(
+                    "--cuda-graph-config[decode].bs must be a non-empty list "
+                    "of positive integers or None, got []"
+                )
+            if phase_config.bs is not None and (
+                not isinstance(phase_config.bs, list)
+                or any(
+                    isinstance(value, bool) or not isinstance(value, int) or value <= 0
+                    for value in phase_config.bs
+                )
+            ):
+                raise ValueError(
+                    f"--cuda-graph-config[{phase}].bs must be a list of "
+                    f"positive integers or None, got {phase_config.bs!r}"
+                )
+            if phase_config.tc_compiler not in ("eager", "inductor"):
+                raise ValueError(
+                    f"--cuda-graph-config[{phase}].tc_compiler must be 'eager' "
+                    f"or 'inductor', got {phase_config.tc_compiler!r}"
+                )
+        prefill_config = cfg.cuda_graph_config.prefill
+        for key in (
+            "full_prefill_max_req",
+            "full_prefill_prefix_chunk_tokens",
+        ):
+            value = getattr(prefill_config, key)
+            if value is not None and (
+                isinstance(value, bool) or not isinstance(value, int) or value <= 0
+            ):
+                raise ValueError(
+                    f"--cuda-graph-config[prefill].{key} must be a positive "
+                    f"integer or None, got {value!r}"
                 )
 
     def _handle_multi_item_scoring(self):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1769,6 +1769,87 @@ class TestPrefillOnlyDisableKvCache(unittest.TestCase):
 
 
 class TestCudaGraphConfigDataclassAccess(CustomTestCase):
+    def test_rejects_invalid_programmatic_cuda_graph_config_schema(self):
+        cases = (
+            ({"bogus": {"backend": Backend.FULL}}, "unknown phase 'bogus'"),
+            ({Phase.DECODE: {"bogus": 1}}, "unknown key 'bogus'"),
+            ({Phase.DECODE: Backend.FULL}, "must be a dict"),
+        )
+        for config, message in cases:
+            with self.subTest(config=config):
+                args = ServerArgs(model_path="dummy", cuda_graph_config=config)
+                with self.assertRaisesRegex(ValueError, message):
+                    args._handle_cuda_graph_config()
+
+    def test_empty_bs_only_disables_prefill_cuda_graph(self):
+        decode_args = ServerArgs(
+            model_path="dummy",
+            cuda_graph_config=CudaGraphConfig(decode=PhaseConfig(bs=[])),
+        )
+        with self.assertRaisesRegex(ValueError, "bs must be a non-empty list"):
+            decode_args._validate_cuda_graph_config()
+
+        prefill_args = ServerArgs(
+            model_path="dummy",
+            cuda_graph_config=CudaGraphConfig(prefill=PhaseConfig(bs=[])),
+        )
+        prefill_args._validate_cuda_graph_config()
+
+    def test_rejects_invalid_common_cuda_graph_settings(self):
+        cases = (
+            ("max_bs", "4", "max_bs must be a positive integer or None"),
+            ("max_bs", 0, "max_bs must be a positive integer or None"),
+            ("max_bs", True, "max_bs must be a positive integer or None"),
+            ("bs", "4", "bs must be a list of positive integers or None"),
+            ("bs", [1, 0], "bs must be a list of positive integers or None"),
+            ("bs", [True], "bs must be a list of positive integers or None"),
+            ("tc_compiler", "invalid", "tc_compiler must be 'eager' or 'inductor'"),
+        )
+        for phase in Phase.ALL:
+            for key, value, message in cases:
+                with self.subTest(phase=phase, key=key, value=value):
+                    phase_config = PhaseConfig()
+                    setattr(phase_config, key, value)
+                    config = CudaGraphConfig()
+                    setattr(config, phase, phase_config)
+                    args = ServerArgs(model_path="dummy", cuda_graph_config=config)
+                    with self.assertRaisesRegex(ValueError, message):
+                        args._validate_cuda_graph_config()
+
+    def test_full_prefill_optional_positive_integer_settings(self):
+        for key in (
+            "full_prefill_max_req",
+            "full_prefill_prefix_chunk_tokens",
+        ):
+            for value in (1, 4, None):
+                with self.subTest(key=key, value=value):
+                    prefill = PhaseConfig(backend=Backend.FULL)
+                    setattr(prefill, key, value)
+                    args = ServerArgs(
+                        model_path="dummy",
+                        cuda_graph_config=CudaGraphConfig(prefill=prefill),
+                    )
+                    args._validate_cuda_graph_config()
+
+    def test_rejects_invalid_full_prefill_positive_integer_settings(self):
+        for key in (
+            "full_prefill_max_req",
+            "full_prefill_prefix_chunk_tokens",
+        ):
+            for value in ("4", 4.0, True, False, 0, -1):
+                with self.subTest(key=key, value=value):
+                    prefill = PhaseConfig(backend=Backend.FULL)
+                    setattr(prefill, key, value)
+                    args = ServerArgs(
+                        model_path="dummy",
+                        cuda_graph_config=CudaGraphConfig(prefill=prefill),
+                    )
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        rf"{key} must be a positive integer or None",
+                    ):
+                        args._validate_cuda_graph_config()
+
     @patch(
         "sglang.srt.model_executor.runner_backend."
         "tc_piecewise_cuda_graph_backend.get_moe_a2a_backend"


### PR DESCRIPTION

## Motivation

`--cuda-graph-config` validates the JSON structure and supported keys, but its
values currently bypass the validation provided by the corresponding command-line
arguments. Invalid values can therefore fail later during model initialization or
silently disable CUDA graph capture. For example:

- `"full_prefill_max_req": "four"` reaches arithmetic code and raises a
  `TypeError`.
- A negative `full_prefill_max_req` filters out every prefill capture bucket and
  silently falls back to eager execution.

The same validation gap applies to phase-level fields such as `max_bs`, `bs`, and
`tc_compiler`.

## Modifications

- Validate phase-level `max_bs`, `bs`, and `tc_compiler` values in
  `ServerArgs._validate_cuda_graph_config`.
- Validate Full prefill options `full_prefill_max_req` and
  `full_prefill_prefix_chunk_tokens` as positive integers when specified.
- Reject booleans explicitly, since Python otherwise treats them as integers.
- Preserve the existing meanings of `None` for automatic configuration and an
  empty `bs` list for disabling CUDA graph capture for a phase.
- Add unit coverage for valid and invalid values in both decode and prefill
  configurations.

## Accuracy Tests

Not applicable. This change only rejects invalid configuration values; valid CUDA
graph configurations are unchanged.

## Speed Tests and Profiling

Not applicable. Validation runs once while parsing server arguments and does not
affect inference performance.

## How to Verify

The focused unit tests pass:

```bash
SGLANG_CACHE_DIR=/tmp/sglang-test-cache .venv/bin/python -m unittest \
  test.registered.unit.server_args.test_server_args.TestCudaGraphConfigDataclassAccess.test_cuda_graph_config_value_validation \
  test.registered.unit.server_args.test_server_args.TestCudaGraphConfigDataclassAccess.test_full_prefill_cuda_graph_config_valid_values \
  test.registered.unit.server_args.test_server_args.TestCudaGraphConfigDataclassAccess.test_full_prefill_cuda_graph_config_invalid_values
```

All pre-commit hooks pass for the changed files:

```bash
pre-commit run --files \
  python/sglang/srt/server_args.py \
  test/registered/unit/server_args/test_server_args.py
```

## Checklist

- [x] Run `pre-commit` for linting and formatting.
- [x] Add unit tests for the new validation behavior.
- [x] Follow the existing code style and validation patterns.
- [x] No documentation update is needed because no valid user-facing option or
  behavior changes.
- [x] No performance evaluation is needed because the change only affects startup
  validation.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33055516520](https://github.com/sgl-project/sglang/actions/runs/33055516520)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33055516390](https://github.com/sgl-project/sglang/actions/runs/33055516390)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33055516481](https://github.com/sgl-project/sglang/actions/runs/33055516481)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->