### PR TITLE
[XPU] Re-add intel xpu on triton paths in diffusion platforms 

### DIFF
--- a/python/sglang/kernels/ops/diffusion/common/platform.py
+++ b/python/sglang/kernels/ops/diffusion/common/platform.py
@@ -31,7 +31,7 @@ _CUDA_LIKE = frozenset({"cuda", "hip"})
 
 
 def platform_key() -> str:
-    """Return the live device family: ``cuda``/``hip``/``npu``/``mps``/``musa``/``cpu``.
+    """Return the live device family: ``cuda``/``hip``/``npu``/``mps``/``musa``/``xpu``/``cpu``.
 
     Deliberately *not* memoized: :func:`select_impl` calls it at module import
     time, and latching that first answer would freeze the choice before the
@@ -40,7 +40,7 @@ def platform_key() -> str:
     """
     from sglang.multimodal_gen.runtime.platforms import current_platform
 
-    for name in ("cuda", "hip", "npu", "mps", "musa"):
+    for name in ("cuda", "hip", "npu", "mps", "musa", "xpu"):
         if getattr(current_platform, f"is_{name}")():
             return name
     return "cpu"

--- a/python/sglang/multimodal_gen/runtime/platforms/__init__.py
+++ b/python/sglang/multimodal_gen/runtime/platforms/__init__.py
@@ -201,6 +201,7 @@ def resolve_current_platform_cls_qualname() -> str:
             "mps": "sglang.multimodal_gen.runtime.platforms.mps.MpsPlatform",
             "npu": "sglang.multimodal_gen.runtime.platforms.npu.NPUPlatformBase",
             "musa": "sglang.multimodal_gen.runtime.platforms.musa.MusaPlatform",
+            "xpu": "sglang.multimodal_gen.runtime.platforms.xpu.XpuPlatform",
         }
         qualname = forced_map.get(forced_platform.lower())
         if qualname is None:


### PR DESCRIPTION
`platform_key()` probed cuda/hip/npu/mps/musa and returned "cpu" for anything else. XPU is not in that list, so it reported "cpu" and `select_impl` handed it every `cpu=` fallback instead of the Triton implementation.

`select_impl`'s contract is that an unlisted platform keeps the Triton impl, which is what the per-module `if current_platform.is_*()` chains did before #35114 -- `is_cpu()` is False on XPU, so the Triton binding survived. Routing through `platform_key()` inverted that: XPU is not unlisted, it is actively reported as cpu.

All five `select_impl` sites declare `cpu=`, so XPU silently lost apply_rotary_embedding, fuse_scale_shift_kernel, norm_infer, rms_norm_fn and triton_one_pass_rms_norm. The kernels were written to run there -- scale_shift_triton.py asserts `x.is_xpu` -- but the dispatch made them unreachable.

Measured on Z-Image-Turbo (1024x1024, 8 steps, bs 1, Intel Arc Pro B60), bisected to #35114: denoise 5.5310s -> 6.0124s (+8.7%/step), end-to-end 8.42s -> 8.94s. A torch profile shows `_rotary_embedding_kernel` going from 308 launches to 0, replaced by ~3000 extra elementwise launches. With this change, end-to-end returns to 8.42s.

Also added the `xpu` in the forced_map as override env `SGLANG_DIFFUSION_PLATFORM_OVERRIDE=xpu` fails. 

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33833751105](https://github.com/sgl-project/sglang/actions/runs/33833751105)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #34086932802](https://github.com/sgl-project/sglang/actions/runs/34086932802)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33833751089](https://github.com/sgl-project/sglang/actions/runs/33833751089)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->