### PR TITLE
[multimodal_gen] fix: make tail_attn_meta CUDA-graph capturable

### DIFF
--- a/python/sglang/multimodal_gen/runtime/distributed/sp_shard_utils.py
+++ b/python/sglang/multimodal_gen/runtime/distributed/sp_shard_utils.py
@@ -195,10 +195,10 @@ def tail_attn_meta(
         return None
     seq = shard.sp_size * (shard.local_len + image_seq_len)
     valid = seq - shard.num_pad
-    row = torch.tensor([valid, shard.num_pad], dtype=torch.int32, device=device)
-    seglens = row.repeat(batch_size)
+    row_starts = torch.arange(batch_size, dtype=torch.int32, device=device) * seq
     cu_seqlens = torch.zeros(2 * batch_size + 1, dtype=torch.int32, device=device)
-    cu_seqlens[1:] = torch.cumsum(seglens, dim=0)
+    cu_seqlens[1::2] = row_starts + valid
+    cu_seqlens[2::2] = row_starts + seq
     return {
         "pad_start": valid,
         "pad_end": seq,

--- a/python/sglang/multimodal_gen/test/unit/test_sp_shard.py
+++ b/python/sglang/multimodal_gen/test/unit/test_sp_shard.py
@@ -108,6 +108,29 @@ def test_tail_meta_max_seqlen_covers_pad_segment():
     assert meta["max_seqlen_tail"] == 3
 
 
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="needs CUDA graph capture")
+def test_tail_meta_is_cuda_graph_capturable():
+    """The meta is built inside the DiT forward, which breakable-cuda-graph
+    captures; host-staged tensor construction aborts capture with 'Cannot copy
+    between CPU and CUDA tensors'."""
+    device = torch.device("cuda")
+    shard = SpShard(orig_len=15, local_len=8, num_pad=1, sp_size=2, sp_rank=1)
+    eager = tail_attn_meta(shard, 2, device, image_seq_len=100)
+
+    side = torch.cuda.Stream()
+    side.wait_stream(torch.cuda.current_stream())
+    with torch.cuda.stream(side):
+        tail_attn_meta(shard, 2, device, image_seq_len=100)
+    torch.cuda.current_stream().wait_stream(side)
+
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        captured = tail_attn_meta(shard, 2, device, image_seq_len=100)
+    graph.replay()
+    torch.cuda.synchronize()
+    assert torch.equal(captured["cu_seqlens_tail"], eager["cu_seqlens_tail"])
+
+
 def test_tail_meta_matches_legacy_gap_formula():
     # The tail layout puts the pad exactly where the legacy per-model gap
     # formula pointed, minus the relocation: end == S (global tail).


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

`tail_attn_meta` builds `cu_seqlens_tail` with `torch.tensor([valid, num_pad], device=cuda)`, which stages the Python list through pageable host memory. That H2D copy is illegal inside CUDA graph capture:

```
RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph capture unless the CPU tensor is pinned.
```

The meta is built inside the DiT forwards that breakable-cuda-graph captures (`flux_2.py`, `qwen_image.py`, `mova.py` all call it), and it runs on every forward call, so any SP-sharded stream with tail padding aborts capture for its whole signature and silently falls back to eager.

No allowlisted model reaches the padded path in default configs today (Qwen-Image's BCG text buckets divide the usual power-of-two SP sizes), so on current main this is hardening for the BCG x SP surface. It is not far from the surface, though: Klein's fixed 512 does not divide non-power-of-two SP sizes (e.g. `--ulysses-degree 3`), and any SP model whose sharded stream picks up tail padding inside a captured forward trips it immediately.

## Modifications

<!-- Detail the changes made in this pull request. -->

- `sp_shard_utils.tail_attn_meta`: build the cumulative segment lengths from device-side `arange` arithmetic instead of a host-staged `torch.tensor`. Values are unchanged.
- New regression test `test_tail_meta_is_cuda_graph_capturable`: captures the construction inside `torch.cuda.graph`. It fails on main with the exact production error above and passes with the fix.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

- The existing CPU value tests (`test_tail_meta_*`) pin the produced `cu_seqlens_tail` values; the whole `test_sp_shard.py` suite passes (24 tests).
- End to end on 2x H200 (a local experiment: the Qwen-Image BCG prompt padder was temporarily made a no-op so the unmasked text stream takes the SP shard path and picks up tail padding): `Qwen/Qwen-Image --num-gpus 2 --ulysses-degree 2 --enable-breakable-cuda-graph` with an odd-length prompt aborts every capture with the exact error above on main, and captures 61 segments with this fix. No in-tree config reaches the line today; the unit test is the standing regression guard.

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

No math or hot-path change; the fix only lets capture succeed where it previously fell back to eager.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33056243947](https://github.com/sgl-project/sglang/actions/runs/33056243947)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33056243658](https://github.com/sgl-project/sglang/actions/runs/33056243658)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33056243869](https://github.com/sgl-project/sglang/actions/runs/33056243869)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->