### PR TITLE
[Qwen3.8] Support Qwen3.8-Max residue inference

### DIFF
--- a/python/sglang/kernels/jit/csrc/residue_nvfp4/residue_nvfp4_kext_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/residue_nvfp4/residue_nvfp4_kext_quant.cuh
@@ -1,0 +1,863 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ * Modifications Copyright (c) 2026 Rong Shuo.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// k_ext (selective residue) NVFP4 activation quantization.
+//
+// Ported from ResInfer csrc/nvfp4/src/fp4/nvfp4_residue_pack8.cu and
+// nvfp4_residue_pack16.cu, rehosted on the sglang JIT tvm-ffi conventions.
+// Ratio-specialized no-swap kernels only; the swap-residue experiment was
+// deliberately not ported.
+//
+// Contract (mirrors the reference torch op):
+//   input          [M, K] fp16/bf16, K % 16 == 0
+//   input_sf       float32 scalar (global scale reciprocal)
+//   channel_masks  uint8 [K/8], bit b of byte i marks channel 8*i+b salient;
+//                  every byte carries exactly residue_per_8 set bits (the
+//                  exporter guarantees per-block uniform selection)
+//   output         uint8, >= M * n_ext / 2 bytes; each row is
+//                  [base K/2 bytes | residue (n_ext-K)/2 bytes]
+//   output_sf      uint8 (fp8-e4m3), swizzled 128x4 tiled layout over
+//                  (M, n_ext); residue SFs live at the extended-K positions
+//   n_ext          K + num_salient
+//   residue_per_8  1 (ratio 1/8), 2 (2/8), or 4 (4/8)
+//
+// pack16 gives each thread one full 16-element SF vector (no cross-thread
+// main amax) and loads it with one 256-bit ld on Blackwell; output is
+// bit-identical to pack8. elts_mode: 0=auto (B200-measured policy on cc
+// 10.x, pack8 elsewhere), 8, 16.
+
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include "residue_nvfp4_utils.cuh"
+#include <algorithm>
+#include <cstdint>
+
+namespace sglang {
+namespace residue_nvfp4 {
+
+// ─────────────────────────────── pack8 ─────────────────────────────────────
+
+__device__ __forceinline__ float
+pick_pack8_residue_value(float2 const (&residue)[CVT_FP4_ELTS_PER_THREAD / 2], int idx) {
+  int pairIdx = idx >> 1;
+  return (idx & 1) == 0 ? residue[pairIdx].x : residue[pairIdx].y;
+}
+
+__device__ __forceinline__ uint32_t pack_pack8_residue_group_r0125(float residue0, int laneId) {
+  // Mirrors generic RESIDUE_PER_THREAD=1: each writer lane gathers one
+  // 8-value residue chunk from source lanes writerGroup*8..writerGroup*8+7.
+  int writerGroup = laneId < 4 ? laneId : 0;
+  int sourceFirstThread = writerGroup * 8;
+
+  float2 residueChunk[4];
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    int sourceThread0 = sourceFirstThread + i * 2;
+    int sourceThread1 = sourceThread0 + 1;
+    float val0 = __shfl_sync(uint32_t(-1), residue0, sourceThread0);
+    float val1 = __shfl_sync(uint32_t(-1), residue0, sourceThread1);
+    residueChunk[i] = make_float2(val0, val1);
+  }
+  return fp32_vec_to_e2m1(residueChunk);
+}
+
+__device__ __forceinline__ uint32_t pack_pack8_residue_group_r025(float residue0, float residue1, int laneId) {
+  // ratio=0.25: each thread contributes two residue values; four adjacent
+  // lanes form one uint32 FP4 residue chunk. Constant full shuffle mask is
+  // safe because the launcher rounds block size to full warps.
+  int writerGroup = laneId < 8 ? laneId : 0;
+  int sourceFirstThread = writerGroup * 4;
+
+  float2 residueChunk[4];
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    int sourceThread = sourceFirstThread + i;
+    float val0 = __shfl_sync(uint32_t(-1), residue0, sourceThread);
+    float val1 = __shfl_sync(uint32_t(-1), residue1, sourceThread);
+    residueChunk[i] = make_float2(val0, val1);
+  }
+  return fp32_vec_to_e2m1(residueChunk);
+}
+
+__device__ __forceinline__ uint32_t
+pack_pack8_residue_group_r050(float residue0, float residue1, float residue2, float residue3, int laneId) {
+  // Mirrors generic RESIDUE_PER_THREAD=4: each writer lane gathers one
+  // 8-value residue chunk from two adjacent source lanes.
+  int writerGroup = laneId < 16 ? laneId : 0;
+  int sourceFirstThread = writerGroup * 2;
+
+  float2 residueChunk[4];
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    float vals[2];
+#pragma unroll
+    for (int j = 0; j < 2; ++j) {
+      int residueIdx = i * 2 + j;
+      int sourceThread = sourceFirstThread + (residueIdx >> 2);
+      int sourceOffset = residueIdx & 3;
+      float sourceValue;
+      if (sourceOffset == 0) {
+        sourceValue = residue0;
+      } else if (sourceOffset == 1) {
+        sourceValue = residue1;
+      } else if (sourceOffset == 2) {
+        sourceValue = residue2;
+      } else {
+        sourceValue = residue3;
+      }
+      vals[j] = __shfl_sync(uint32_t(-1), sourceValue, sourceThread);
+    }
+    residueChunk[i] = make_float2(vals[0], vals[1]);
+  }
+  return fp32_vec_to_e2m1(residueChunk);
+}
+
+// Shared main-quant + residue derivation for the pack8 ratio helpers: on
+// return `residues` holds original - dequant for all 8 positions and the
+// packed main data is returned.
+template <class Type, bool UE8M0_SF>
+__device__ __forceinline__ uint32_t pack8_main_quant(
+    PackedVec<Type>& vec, float SFScaleVal, uint8_t* SFout, float2 (&residues)[CVT_FP4_ELTS_PER_THREAD / 2]) {
+  auto localMax = __habs2(vec.elts[0]);
+#pragma unroll
+  for (int i = 1; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    localMax = __hmax2(localMax, __habs2(vec.elts[i]));
+  }
+  localMax = __hmax2(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+  float vecMax = float(__hmax(localMax.x, localMax.y));
+
+  float SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
+  SFValue = encode_sf_to_fp8<UE8M0_SF>(SFValue, SFout);
+  float outputScale = compute_output_scale_precise(SFValue, SFScaleVal);
+
+  float2 fp2ValsOriginal[CVT_FP4_ELTS_PER_THREAD / 2];
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    if constexpr (std::is_same_v<Type, half>) {
+      residues[i] = __half22float2(vec.elts[i]);
+    } else {
+      residues[i] = __bfloat1622float2(vec.elts[i]);
+    }
+    fp2ValsOriginal[i] = residues[i];
+    residues[i].x *= outputScale;
+    residues[i].y *= outputScale;
+  }
+
+  uint32_t e2m1Vec = fp32x8_to_e2m1_with_dequant(residues);
+
+  float inverseOutputScale = outputScale != 0 ? reciprocal_approximate_ftz(outputScale) : 0.0f;
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    residues[i].x *= inverseOutputScale;
+    residues[i].y *= inverseOutputScale;
+    residues[i].x = fp2ValsOriginal[i].x - residues[i].x;
+    residues[i].y = fp2ValsOriginal[i].y - residues[i].y;
+  }
+  return e2m1Vec;
+}
+
+template <class Type, bool UE8M0_SF = false>
+__device__ __forceinline__ uint32_t cvt_warp_fp16_to_fp4_pack8_r0125(
+    PackedVec<Type>& vec,
+    float SFScaleVal,
+    uint8_t* SFout,
+    uint8_t mask,
+    uint32_t* residueDataOut,
+    uint8_t* residueSFOut) {
+  float2 fp2Vals[CVT_FP4_ELTS_PER_THREAD / 2];
+  uint32_t e2m1Vec = pack8_main_quant<Type, UE8M0_SF>(vec, SFScaleVal, SFout, fp2Vals);
+
+  int i0 = __ffs(mask) - 1;
+  float residue0 = pick_pack8_residue_value(fp2Vals, i0);
+
+  float localMaxResidue = fabsf(residue0);
+  int laneId = threadIdx.x % 32;
+  float sfGroupMaxResidue = warp_group_max<16>(localMaxResidue, laneId);
+  float residueSFValue = SFScaleVal * (sfGroupMaxResidue * reciprocal_approximate_ftz(6.0f));
+  residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+  float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+
+  uint32_t packedResidue = pack_pack8_residue_group_r0125(residue0 * residueOutputScale, laneId);
+  if (residueDataOut) {
+    *residueDataOut = packedResidue;
+  }
+  return e2m1Vec;
+}
+
+template <class Type, bool UE8M0_SF = false>
+__device__ __forceinline__ uint32_t cvt_warp_fp16_to_fp4_pack8_r025(
+    PackedVec<Type>& vec,
+    float SFScaleVal,
+    uint8_t* SFout,
+    uint8_t mask,
+    uint32_t* residueDataOut,
+    uint8_t* residueSFOut) {
+  float2 fp2Vals[CVT_FP4_ELTS_PER_THREAD / 2];
+  uint32_t e2m1Vec = pack8_main_quant<Type, UE8M0_SF>(vec, SFScaleVal, SFout, fp2Vals);
+
+  int i0 = __ffs(mask) - 1;
+  int i1 = __ffs(mask & (mask - 1)) - 1;
+  float residue0 = pick_pack8_residue_value(fp2Vals, i0);
+  float residue1 = pick_pack8_residue_value(fp2Vals, i1);
+
+  float localMaxResidue = fmaxf(fabsf(residue0), fabsf(residue1));
+  int laneId = threadIdx.x % 32;
+  float sfGroupMaxResidue = warp_group_max<8>(localMaxResidue, laneId);
+  float residueSFValue = SFScaleVal * (sfGroupMaxResidue * reciprocal_approximate_ftz(6.0f));
+  residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+  float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+
+  uint32_t packedResidue =
+      pack_pack8_residue_group_r025(residue0 * residueOutputScale, residue1 * residueOutputScale, laneId);
+  if (residueDataOut) {
+    *residueDataOut = packedResidue;
+  }
+  return e2m1Vec;
+}
+
+template <class Type, bool UE8M0_SF = false>
+__device__ __forceinline__ uint32_t cvt_warp_fp16_to_fp4_pack8_r050(
+    PackedVec<Type>& vec,
+    float SFScaleVal,
+    uint8_t* SFout,
+    uint8_t mask,
+    uint32_t* residueDataOut,
+    uint8_t* residueSFOut) {
+  float2 fp2Vals[CVT_FP4_ELTS_PER_THREAD / 2];
+  uint32_t e2m1Vec = pack8_main_quant<Type, UE8M0_SF>(vec, SFScaleVal, SFout, fp2Vals);
+
+  int i0 = __ffs(mask) - 1;
+  uint8_t remaining = mask & (mask - 1);
+  int i1 = __ffs(remaining) - 1;
+  remaining = remaining & (remaining - 1);
+  int i2 = __ffs(remaining) - 1;
+  remaining = remaining & (remaining - 1);
+  int i3 = __ffs(remaining) - 1;
+
+  float residue0 = pick_pack8_residue_value(fp2Vals, i0);
+  float residue1 = pick_pack8_residue_value(fp2Vals, i1);
+  float residue2 = pick_pack8_residue_value(fp2Vals, i2);
+  float residue3 = pick_pack8_residue_value(fp2Vals, i3);
+
+  float localMaxResidue = fmaxf(fmaxf(fabsf(residue0), fabsf(residue1)), fmaxf(fabsf(residue2), fabsf(residue3)));
+  int laneId = threadIdx.x % 32;
+  float sfGroupMaxResidue = warp_group_max<4>(localMaxResidue, laneId);
+  float residueSFValue = SFScaleVal * (sfGroupMaxResidue * reciprocal_approximate_ftz(6.0f));
+  residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+  float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+
+  uint32_t packedResidue = pack_pack8_residue_group_r050(
+      residue0 * residueOutputScale,
+      residue1 * residueOutputScale,
+      residue2 * residueOutputScale,
+      residue3 * residueOutputScale,
+      laneId);
+  if (residueDataOut) {
+    *residueDataOut = packedResidue;
+  }
+  return e2m1Vec;
+}
+
+template <class Type, bool UE8M0_SF, int RESIDUE_PER_8_ELTS>
+__global__ void __launch_bounds__(512, RESIDUE_NVFP4_BLOCKS_PER_SM(512)) cvt_fp16_to_fp4_residue_pack8_no_swap(
+    int32_t numRows,
+    int32_t numTotalCols,
+    int32_t numMainCols,
+    Type const* in,
+    float const* SFScale,
+    uint32_t* out,
+    uint32_t* SFout,
+    uint8_t const* channelIndices) {
+  using PackedVecT = PackedVec<Type>;
+  static constexpr int CVT_FP4_NUM_THREADS_PER_SF = (CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD);
+
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+  uint8_t* extraSFStart = reinterpret_cast<uint8_t*>(SFout);
+  int32_t effectiveRows = computeEffectiveRows(numRows);
+
+  int colIdx = blockIdx.y * blockDim.x + threadIdx.x;
+  if (colIdx >= numMainCols / CVT_FP4_ELTS_PER_THREAD) {
+    return;
+  }
+
+  for (int rowIdx = blockIdx.x; rowIdx < effectiveRows; rowIdx += gridDim.x) {
+    bool validRow = rowIdx < numRows;
+    PackedVecT inVec{};
+    if (validRow) {
+      int64_t inOffset = static_cast<int64_t>(rowIdx) * (numMainCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+      inVec = reinterpret_cast<PackedVecT const*>(in)[inOffset];
+    }
+
+    auto sfOut =
+        cvt_quant_to_fp4_get_sf_out_offset<uint32_t, CVT_FP4_NUM_THREADS_PER_SF>(rowIdx, colIdx, numTotalCols, SFout);
+
+    uint32_t* outPos = nullptr;
+    uint32_t* residueDataOut = nullptr;
+    if (validRow) {
+      int64_t outOffset = static_cast<int64_t>(rowIdx) * (numTotalCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+      outPos = out + outOffset;
+      residueDataOut =
+          cvt_residue_data_get_offset<uint32_t, RESIDUE_PER_8_ELTS>(rowIdx, colIdx, numMainCols, numTotalCols, out);
+    }
+
+    auto residueSFOut =
+        cvt_residue_sf_get_offset<uint8_t, RESIDUE_PER_8_ELTS>(rowIdx, colIdx, numTotalCols, numMainCols, extraSFStart);
+
+    uint32_t packed;
+    if constexpr (RESIDUE_PER_8_ELTS == 1) {
+      packed = cvt_warp_fp16_to_fp4_pack8_r0125<Type, UE8M0_SF>(
+          inVec, SFScaleVal, sfOut, channelIndices[colIdx], residueDataOut, residueSFOut);
+    } else if constexpr (RESIDUE_PER_8_ELTS == 2) {
+      packed = cvt_warp_fp16_to_fp4_pack8_r025<Type, UE8M0_SF>(
+          inVec, SFScaleVal, sfOut, channelIndices[colIdx], residueDataOut, residueSFOut);
+    } else {
+      static_assert(RESIDUE_PER_8_ELTS == 4);
+      packed = cvt_warp_fp16_to_fp4_pack8_r050<Type, UE8M0_SF>(
+          inVec, SFScaleVal, sfOut, channelIndices[colIdx], residueDataOut, residueSFOut);
+    }
+    if (outPos) {
+      *outPos = packed;
+    }
+  }
+}
+
+// ─────────────────────────────── pack16 ────────────────────────────────────
+
+namespace pack16 {
+
+__device__ __forceinline__ float pick_residue_value(float2 const (&residue)[4], int idx) {
+  int pairIdx = idx >> 1;
+  return (idx & 1) == 0 ? residue[pairIdx].x : residue[pairIdx].y;
+}
+
+// Residue data chunk address for the elt16 mapping. Chunks are the same
+// element-ordered consecutive uint32s the pack8 helpers emit; an elt16 warp
+// spans two pack8 warp sections, i.e. CHUNKS_PER_WARP = 32 * R2 / 8 chunks
+// starting at warpId * CHUNKS_PER_WARP. R2 = residues per thread.
+template <int R2>
+__device__ __forceinline__ uint32_t*
+residue_data_offset(int rowIdx, int colIdx, int numMainCols, int numTotalCols, uint32_t* out) {
+  constexpr int CHUNKS_PER_WARP = 32 * R2 / 8;
+  int64_t u32PerRow = numTotalCols / CVT_FP4_ELTS_PER_UINT32;
+  int64_t baseU32 = numMainCols / CVT_FP4_ELTS_PER_UINT32;
+  int64_t rowBase = static_cast<int64_t>(rowIdx) * u32PerRow + baseU32;
+  if constexpr (R2 == 8) {
+    return out + rowBase + colIdx;
+  } else {
+    int warpId = colIdx / 32;
+    int laneId = colIdx % 32;
+    if (laneId >= CHUNKS_PER_WARP) return nullptr;
+    return out + rowBase + warpId * CHUNKS_PER_WARP + laneId;
+  }
+}
+
+// Residue SF address for the elt16 mapping: identical placement to
+// cvt_residue_sf_get_offset, re-derived for 16-element threads.
+template <class SFType, int R2>
+__device__ __forceinline__ SFType*
+residue_sf_offset(int rowIdx, int colIdx, int numTotalCols, int numMainCols, SFType* base) {
+  constexpr int THREADS_PER_SF_GROUP = 16 / R2;
+  int warpId = colIdx / 32;
+  int laneId = colIdx % 32;
+  if (laneId % THREADS_PER_SF_GROUP != 0) return nullptr;
+  int sfGroupId = laneId / THREADS_PER_SF_GROUP;
+  int residueElementIdx = numMainCols + warpId * 32 * R2 + sfGroupId * 16;
+  int32_t kIdx = residueElementIdx / CVT_FP4_SF_VEC_SIZE;
+  int64_t SFOffset = compute_tiled_sf_offset<SFType>(rowIdx, kIdx, numTotalCols);
+  return base + SFOffset;
+}
+
+// Main quantization for one 16-element SF vector (thread-local, no
+// shuffles). Math follows the pack8 helpers line-for-line on each 8-element
+// half so the output stays bit-identical. On return lo/hi hold the unscaled
+// residues (original - dequant) for all 16 positions.
+template <class Type, bool UE8M0_SF>
+__device__ __forceinline__ u32x2 main_quant16(
+    PackedVec<Type>& loVec,
+    PackedVec<Type>& hiVec,
+    float SFScaleVal,
+    uint8_t* SFout,
+    float2 (&loResidue)[4],
+    float2 (&hiResidue)[4]) {
+  auto localMax = __habs2(loVec.elts[0]);
+#pragma unroll
+  for (int i = 1; i < 4; ++i) {
+    localMax = __hmax2(localMax, __habs2(loVec.elts[i]));
+  }
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    localMax = __hmax2(localMax, __habs2(hiVec.elts[i]));
+  }
+  float vecMax = float(__hmax(localMax.x, localMax.y));
+
+  float SFValue = compute_sf_from_max(vecMax, SFScaleVal);
+  SFValue = encode_sf_to_fp8<UE8M0_SF>(SFValue, SFout);
+  float outputScale = compute_output_scale_precise(SFValue, SFScaleVal);
+
+  float2 loOriginal[4];
+  float2 hiOriginal[4];
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    if constexpr (std::is_same_v<Type, half>) {
+      loOriginal[i] = __half22float2(loVec.elts[i]);
+      hiOriginal[i] = __half22float2(hiVec.elts[i]);
+    } else {
+      loOriginal[i] = __bfloat1622float2(loVec.elts[i]);
+      hiOriginal[i] = __bfloat1622float2(hiVec.elts[i]);
+    }
+    loResidue[i].x = loOriginal[i].x * outputScale;
+    loResidue[i].y = loOriginal[i].y * outputScale;
+    hiResidue[i].x = hiOriginal[i].x * outputScale;
+    hiResidue[i].y = hiOriginal[i].y * outputScale;
+  }
+
+  u32x2 packed;
+  packed.lo = fp32x8_to_e2m1_with_dequant(loResidue);
+  packed.hi = fp32x8_to_e2m1_with_dequant(hiResidue);
+
+  float inverseOutputScale = outputScale != 0.0f ? reciprocal_approximate_ftz(outputScale) : 0.0f;
+#pragma unroll
+  for (int i = 0; i < 4; ++i) {
+    loResidue[i].x = loOriginal[i].x - loResidue[i].x * inverseOutputScale;
+    loResidue[i].y = loOriginal[i].y - loResidue[i].y * inverseOutputScale;
+    hiResidue[i].x = hiOriginal[i].x - hiResidue[i].x * inverseOutputScale;
+    hiResidue[i].y = hiOriginal[i].y - hiResidue[i].y * inverseOutputScale;
+  }
+  return packed;
+}
+
+}  // namespace pack16
+
+// r0125: 2 residues/thread, 8-thread SF groups, 4 source lanes/chunk
+template <class Type, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(512, 2) cvt_fp16_to_fp4_residue_pack16_r0125_no_swap(
+    int32_t numRows,
+    int32_t numTotalCols,
+    int32_t numMainCols,
+    Type const* in,
+    float const* SFScale,
+    uint32_t* out,
+    uint32_t* SFout,
+    uint8_t const* channelIndices) {
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+  uint8_t* extraSFStart = reinterpret_cast<uint8_t*>(SFout);
+  int32_t effectiveRows = computeEffectiveRows(numRows);
+
+  int colIdx = blockIdx.y * blockDim.x + threadIdx.x;
+  if (colIdx >= numMainCols / 16) {
+    return;
+  }
+  uint8_t mask0 = channelIndices[colIdx * 2];
+  uint8_t mask1 = channelIndices[colIdx * 2 + 1];
+  int laneId = threadIdx.x % 32;
+
+  for (int rowIdx = blockIdx.x; rowIdx < effectiveRows; rowIdx += gridDim.x) {
+    bool validRow = rowIdx < numRows;
+    PackedVec<Type> loVec{};
+    PackedVec<Type> hiVec{};
+    if (validRow) {
+      load_packed_vec16(in + static_cast<int64_t>(rowIdx) * numMainCols + colIdx * 16, loVec, hiVec);
+    }
+
+    auto sfOut = cvt_quant_to_fp4_get_sf_out_offset<uint32_t, 1>(rowIdx, colIdx, numTotalCols, SFout);
+    auto residueSFOut = pack16::residue_sf_offset<uint8_t, 2>(rowIdx, colIdx, numTotalCols, numMainCols, extraSFStart);
+
+    float2 loResidue[4];
+    float2 hiResidue[4];
+    u32x2 packed = pack16::main_quant16<Type, UE8M0_SF>(loVec, hiVec, SFScaleVal, sfOut, loResidue, hiResidue);
+
+    int i0 = __ffs(mask0) - 1;
+    int i1 = __ffs(mask1) - 1;
+    float rv0 = pack16::pick_residue_value(loResidue, i0);
+    float rv1 = pack16::pick_residue_value(hiResidue, i1);
+
+    float localMaxResidue = fmaxf(fabsf(rv0), fabsf(rv1));
+    float sfGroupMaxResidue = warp_group_max<8>(localMaxResidue, laneId);
+    float residueSFValue = compute_sf_from_max(sfGroupMaxResidue, SFScaleVal);
+    residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+    float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+    rv0 *= residueOutputScale;
+    rv1 *= residueOutputScale;
+
+    // Writer lane L packs residues from source lanes 4L..4L+3 (2 each).
+    float2 residueChunk[4];
+#pragma unroll
+    for (int i = 0; i < 4; ++i) {
+      int sourceThread = (laneId < 8 ? laneId : 0) * 4 + i;
+      residueChunk[i] =
+          make_float2(__shfl_sync(uint32_t(-1), rv0, sourceThread), __shfl_sync(uint32_t(-1), rv1, sourceThread));
+    }
+
+    if (validRow) {
+      int64_t outOffset = static_cast<int64_t>(rowIdx) * (numTotalCols / CVT_FP4_ELTS_PER_UINT32) + colIdx * 2;
+      *reinterpret_cast<uint2*>(out + outOffset) = make_uint2(packed.lo, packed.hi);
+      uint32_t* residueDataOut = pack16::residue_data_offset<2>(rowIdx, colIdx, numMainCols, numTotalCols, out);
+      if (residueDataOut) {
+        *residueDataOut = fp32_vec_to_e2m1(residueChunk);
+      }
+    }
+  }
+}
+
+// r025: 4 residues/thread, 4-thread SF groups, 2 source lanes/chunk
+template <class Type, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(512, 2) cvt_fp16_to_fp4_residue_pack16_r025_no_swap(
+    int32_t numRows,
+    int32_t numTotalCols,
+    int32_t numMainCols,
+    Type const* in,
+    float const* SFScale,
+    uint32_t* out,
+    uint32_t* SFout,
+    uint8_t const* channelIndices) {
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+  uint8_t* extraSFStart = reinterpret_cast<uint8_t*>(SFout);
+  int32_t effectiveRows = computeEffectiveRows(numRows);
+
+  int colIdx = blockIdx.y * blockDim.x + threadIdx.x;
+  if (colIdx >= numMainCols / 16) {
+    return;
+  }
+  uint8_t mask0 = channelIndices[colIdx * 2];
+  uint8_t mask1 = channelIndices[colIdx * 2 + 1];
+  int laneId = threadIdx.x % 32;
+
+  for (int rowIdx = blockIdx.x; rowIdx < effectiveRows; rowIdx += gridDim.x) {
+    bool validRow = rowIdx < numRows;
+    PackedVec<Type> loVec{};
+    PackedVec<Type> hiVec{};
+    if (validRow) {
+      load_packed_vec16(in + static_cast<int64_t>(rowIdx) * numMainCols + colIdx * 16, loVec, hiVec);
+    }
+
+    auto sfOut = cvt_quant_to_fp4_get_sf_out_offset<uint32_t, 1>(rowIdx, colIdx, numTotalCols, SFout);
+    auto residueSFOut = pack16::residue_sf_offset<uint8_t, 4>(rowIdx, colIdx, numTotalCols, numMainCols, extraSFStart);
+
+    float2 loResidue[4];
+    float2 hiResidue[4];
+    u32x2 packed = pack16::main_quant16<Type, UE8M0_SF>(loVec, hiVec, SFScaleVal, sfOut, loResidue, hiResidue);
+
+    int i0 = __ffs(mask0) - 1;
+    int i1 = __ffs(mask0 & (mask0 - 1)) - 1;
+    int i2 = __ffs(mask1) - 1;
+    int i3 = __ffs(mask1 & (mask1 - 1)) - 1;
+    float rv0 = pack16::pick_residue_value(loResidue, i0);
+    float rv1 = pack16::pick_residue_value(loResidue, i1);
+    float rv2 = pack16::pick_residue_value(hiResidue, i2);
+    float rv3 = pack16::pick_residue_value(hiResidue, i3);
+
+    float localMaxResidue = fmaxf(fmaxf(fabsf(rv0), fabsf(rv1)), fmaxf(fabsf(rv2), fabsf(rv3)));
+    float sfGroupMaxResidue = warp_group_max<4>(localMaxResidue, laneId);
+    float residueSFValue = compute_sf_from_max(sfGroupMaxResidue, SFScaleVal);
+    residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+    float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+    rv0 *= residueOutputScale;
+    rv1 *= residueOutputScale;
+    rv2 *= residueOutputScale;
+    rv3 *= residueOutputScale;
+
+    // Writer lane L packs residues from source lanes 2L, 2L+1 (4 each).
+    int writerGroup = laneId < 16 ? laneId : 0;
+    float2 residueChunk[4];
+    residueChunk[0] =
+        make_float2(__shfl_sync(uint32_t(-1), rv0, writerGroup * 2), __shfl_sync(uint32_t(-1), rv1, writerGroup * 2));
+    residueChunk[1] =
+        make_float2(__shfl_sync(uint32_t(-1), rv2, writerGroup * 2), __shfl_sync(uint32_t(-1), rv3, writerGroup * 2));
+    residueChunk[2] = make_float2(
+        __shfl_sync(uint32_t(-1), rv0, writerGroup * 2 + 1), __shfl_sync(uint32_t(-1), rv1, writerGroup * 2 + 1));
+    residueChunk[3] = make_float2(
+        __shfl_sync(uint32_t(-1), rv2, writerGroup * 2 + 1), __shfl_sync(uint32_t(-1), rv3, writerGroup * 2 + 1));
+
+    if (validRow) {
+      int64_t outOffset = static_cast<int64_t>(rowIdx) * (numTotalCols / CVT_FP4_ELTS_PER_UINT32) + colIdx * 2;
+      *reinterpret_cast<uint2*>(out + outOffset) = make_uint2(packed.lo, packed.hi);
+      uint32_t* residueDataOut = pack16::residue_data_offset<4>(rowIdx, colIdx, numMainCols, numTotalCols, out);
+      if (residueDataOut) {
+        *residueDataOut = fp32_vec_to_e2m1(residueChunk);
+      }
+    }
+  }
+}
+
+// r050: 8 residues/thread = exactly one chunk, 2-thread SF groups, no gather
+template <class Type, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(512, 2) cvt_fp16_to_fp4_residue_pack16_r050_no_swap(
+    int32_t numRows,
+    int32_t numTotalCols,
+    int32_t numMainCols,
+    Type const* in,
+    float const* SFScale,
+    uint32_t* out,
+    uint32_t* SFout,
+    uint8_t const* channelIndices) {
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+  uint8_t* extraSFStart = reinterpret_cast<uint8_t*>(SFout);
+  int32_t effectiveRows = computeEffectiveRows(numRows);
+
+  int colIdx = blockIdx.y * blockDim.x + threadIdx.x;
+  if (colIdx >= numMainCols / 16) {
+    return;
+  }
+  uint8_t mask0 = channelIndices[colIdx * 2];
+  uint8_t mask1 = channelIndices[colIdx * 2 + 1];
+  int laneId = threadIdx.x % 32;
+
+  for (int rowIdx = blockIdx.x; rowIdx < effectiveRows; rowIdx += gridDim.x) {
+    bool validRow = rowIdx < numRows;
+    PackedVec<Type> loVec{};
+    PackedVec<Type> hiVec{};
+    if (validRow) {
+      load_packed_vec16(in + static_cast<int64_t>(rowIdx) * numMainCols + colIdx * 16, loVec, hiVec);
+    }
+
+    auto sfOut = cvt_quant_to_fp4_get_sf_out_offset<uint32_t, 1>(rowIdx, colIdx, numTotalCols, SFout);
+    auto residueSFOut = pack16::residue_sf_offset<uint8_t, 8>(rowIdx, colIdx, numTotalCols, numMainCols, extraSFStart);
+
+    float2 loResidue[4];
+    float2 hiResidue[4];
+    u32x2 packed = pack16::main_quant16<Type, UE8M0_SF>(loVec, hiVec, SFScaleVal, sfOut, loResidue, hiResidue);
+
+    int i0 = __ffs(mask0) - 1;
+    uint8_t rem = mask0 & (mask0 - 1);
+    int i1 = __ffs(rem) - 1;
+    rem = rem & (rem - 1);
+    int i2 = __ffs(rem) - 1;
+    rem = rem & (rem - 1);
+    int i3 = __ffs(rem) - 1;
+    int j0 = __ffs(mask1) - 1;
+    rem = mask1 & (mask1 - 1);
+    int j1 = __ffs(rem) - 1;
+    rem = rem & (rem - 1);
+    int j2 = __ffs(rem) - 1;
+    rem = rem & (rem - 1);
+    int j3 = __ffs(rem) - 1;
+
+    float rv0 = pack16::pick_residue_value(loResidue, i0);
+    float rv1 = pack16::pick_residue_value(loResidue, i1);
+    float rv2 = pack16::pick_residue_value(loResidue, i2);
+    float rv3 = pack16::pick_residue_value(loResidue, i3);
+    float rv4 = pack16::pick_residue_value(hiResidue, j0);
+    float rv5 = pack16::pick_residue_value(hiResidue, j1);
+    float rv6 = pack16::pick_residue_value(hiResidue, j2);
+    float rv7 = pack16::pick_residue_value(hiResidue, j3);
+
+    float localMaxResidue = fmaxf(
+        fmaxf(fmaxf(fabsf(rv0), fabsf(rv1)), fmaxf(fabsf(rv2), fabsf(rv3))),
+        fmaxf(fmaxf(fabsf(rv4), fabsf(rv5)), fmaxf(fabsf(rv6), fabsf(rv7))));
+    float sfGroupMaxResidue = warp_group_max<2>(localMaxResidue, laneId);
+    float residueSFValue = compute_sf_from_max(sfGroupMaxResidue, SFScaleVal);
+    residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+    float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+
+    float2 residueChunk[4];
+    residueChunk[0] = make_float2(rv0 * residueOutputScale, rv1 * residueOutputScale);
+    residueChunk[1] = make_float2(rv2 * residueOutputScale, rv3 * residueOutputScale);
+    residueChunk[2] = make_float2(rv4 * residueOutputScale, rv5 * residueOutputScale);
+    residueChunk[3] = make_float2(rv6 * residueOutputScale, rv7 * residueOutputScale);
+
+    if (validRow) {
+      int64_t outOffset = static_cast<int64_t>(rowIdx) * (numTotalCols / CVT_FP4_ELTS_PER_UINT32) + colIdx * 2;
+      *reinterpret_cast<uint2*>(out + outOffset) = make_uint2(packed.lo, packed.hi);
+      uint32_t* residueDataOut = pack16::residue_data_offset<8>(rowIdx, colIdx, numMainCols, numTotalCols, out);
+      *residueDataOut = fp32_vec_to_e2m1(residueChunk);
+    }
+  }
+}
+
+// ───────────────────────────── launchers ───────────────────────────────────
+
+inline void pack8_launch_config(int m, int n, int multiProcessorCount, dim3& grid, dim3& block) {
+  int numThreads = std::max(n / CVT_FP4_ELTS_PER_THREAD, 32);
+  // Round block size to full warps: the residue gathers use a constant full
+  // shuffle mask; extra threads early-return via the colIdx bound check.
+  int blockSize = std::min(((std::min(numThreads, 512) + 31) / 32) * 32, 512);
+  block = dim3(blockSize);
+  int const numBlocksPerSM = runtime_blocks_per_sm(blockSize);
+  grid = dim3(
+      std::min(computeEffectiveRows(m), multiProcessorCount * numBlocksPerSM),
+      (numThreads + blockSize - 1) / blockSize);
+}
+
+inline void pack16_launch_config(int m, int n, int multiProcessorCount, dim3& grid, dim3& block) {
+  int numThreads = std::max(n / 16, 32);
+  int blockSize = std::min(((std::min(numThreads, 512) + 31) / 32) * 32, 512);
+  block = dim3(blockSize);
+  int const numBlocksPerSM = runtime_blocks_per_sm(blockSize);
+  grid = dim3(
+      std::min(computeEffectiveRows(m), multiProcessorCount * numBlocksPerSM),
+      (numThreads + blockSize - 1) / blockSize);
+}
+
+// pack16 needs an even uint32 row stride for its 64-bit main-data stores.
+inline bool use_kext_pack16(int elts_mode, int cc_major, int m, int n, int n_ext, int residue_per_8) {
+  if (elts_mode == 8) return false;
+  if (n % 16 != 0 || n_ext % 16 != 0) return false;
+  if (elts_mode == 16) return true;
+  if (cc_major != 10) return false;
+  // B200 measurements: pack16 wins 1.2-1.7x at prefill for every ratio; at
+  // decode it wins for r0125 but loses for r025/r050, whose doubled
+  // per-thread residue state still costs at small M.
+  if (residue_per_8 == 1) return true;
+  return m >= 1024;
+}
+
+template <typename T>
+void invokeFP4QuantizationKExt(
+    int m,
+    int n_ext,
+    int n,
+    T const* input,
+    float const* SFScale,
+    uint32_t* output,
+    uint32_t* SFOuput,
+    bool useUE8M0,
+    uint8_t const* channelIndices,
+    int residue_per_8,
+    int elts_mode,
+    int multiProcessorCount,
+    int ccMajor,
+    cudaStream_t stream) {
+  bool pack16v = use_kext_pack16(elts_mode, ccMajor, m, n, n_ext, residue_per_8);
+
+  dim3 grid, block;
+  if (pack16v) {
+    pack16_launch_config(m, n, multiProcessorCount, grid, block);
+  } else {
+    pack8_launch_config(m, n, multiProcessorCount, grid, block);
+  }
+
+  auto launch = [&](auto kernel) {
+    kernel<<<grid, block, 0, stream>>>(m, n_ext, n, input, SFScale, output, SFOuput, channelIndices);
+    cudaError_t status = cudaGetLastError();
+    host::RuntimeCheck(
+        status == cudaSuccess, "residue nvfp4 k_ext quant kernel launch failed: ", cudaGetErrorString(status));
+  };
+
+  // UE8M0 scales are not used by this integration; keep the template plumbed
+  // through but always instantiate the E4M3 variant.
+  (void)useUE8M0;
+  if (pack16v) {
+    switch (residue_per_8) {
+      case 1:
+        return launch(cvt_fp16_to_fp4_residue_pack16_r0125_no_swap<T, false>);
+      case 2:
+        return launch(cvt_fp16_to_fp4_residue_pack16_r025_no_swap<T, false>);
+      case 4:
+        return launch(cvt_fp16_to_fp4_residue_pack16_r050_no_swap<T, false>);
+      default:
+        break;
+    }
+  } else {
+    switch (residue_per_8) {
+      case 1:
+        return launch(cvt_fp16_to_fp4_residue_pack8_no_swap<T, false, 1>);
+      case 2:
+        return launch(cvt_fp16_to_fp4_residue_pack8_no_swap<T, false, 2>);
+      case 4:
+        return launch(cvt_fp16_to_fp4_residue_pack8_no_swap<T, false, 4>);
+      default:
+        break;
+    }
+  }
+  host::Panic("residue nvfp4 k_ext quant: unsupported residue_per_8 (expected 1, 2, or 4)");
+}
+
+}  // namespace residue_nvfp4
+
+template <typename DType>
+void scaled_fp4_quant_with_mask(
+    tvm::ffi::TensorView input,
+    tvm::ffi::TensorView output,
+    tvm::ffi::TensorView output_sf,
+    tvm::ffi::TensorView input_sf,
+    tvm::ffi::TensorView channel_masks,
+    int64_t n_ext,
+    int64_t residue_per_8,
+    int64_t elts_mode) {
+  using namespace host;
+  namespace rn = residue_nvfp4;
+
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+  auto M = SymbolicSize{"m"};
+  auto K = SymbolicSize{"k"};
+
+  TensorMatcher({M, K})  //
+      .with_dtype<DType>()
+      .with_device(device)
+      .verify(input);
+
+  const auto m = static_cast<int32_t>(M.unwrap());
+  const auto k = static_cast<int32_t>(K.unwrap());
+  RuntimeCheck(k % 16 == 0, "residue nvfp4 k_ext quant: K must be a multiple of 16, got ", k);
+  RuntimeCheck(
+      residue_per_8 == 1 || residue_per_8 == 2 || residue_per_8 == 4,
+      "residue nvfp4 k_ext quant: residue_per_8 must be 1, 2, or 4 (ratio "
+      "1.0 is served by the M-extension path), got ",
+      residue_per_8);
+  RuntimeCheck(
+      n_ext == k + (k / 8) * residue_per_8, "residue nvfp4 k_ext quant: n_ext must equal K + K/8*residue_per_8");
+
+  auto OutLen = SymbolicSize{"out_len"};
+  auto SfLen = SymbolicSize{"sf_len"};
+  auto MaskLen = SymbolicSize{"mask_len"};
+  TensorMatcher({OutLen}).with_dtype<uint8_t>().with_device(device).verify(output);
+  TensorMatcher({SfLen}).with_dtype<uint8_t>().with_device(device).verify(output_sf);
+  TensorMatcher({MaskLen}).with_dtype<uint8_t>().with_device(device).verify(channel_masks);
+  RuntimeCheck(
+      output.numel() >= static_cast<int64_t>(m) * n_ext / 2, "residue nvfp4 k_ext quant: output tensor too small");
+  RuntimeCheck(channel_masks.numel() >= k / 8, "residue nvfp4 k_ext quant: channel_masks must have K/8 bytes");
+
+  const int64_t num_m_tiles = (m + 127) / 128;
+  const int64_t num_k_tiles = (n_ext + 63) / 64;
+  RuntimeCheck(
+      output_sf.numel() >= num_m_tiles * num_k_tiles * 512,
+      "residue nvfp4 k_ext quant: output_sf tensor too small for the swizzled layout");
+
+  auto InSfLen = SymbolicSize{"in_sf_len"};
+  TensorMatcher({InSfLen}).with_dtype<float>().with_device(device).verify(input_sf);
+  RuntimeCheck(input_sf.numel() >= 1, "residue nvfp4 k_ext quant: input_sf must have 1 element");
+
+  const auto dl_device = device.unwrap();
+  const auto info = rn::query_device_info(dl_device.device_id);
+  const auto stream = static_cast<cudaStream_t>(::TVMFFIEnvGetStream(dl_device.device_type, dl_device.device_id));
+
+  rn::invokeFP4QuantizationKExt(
+      m,
+      static_cast<int>(n_ext),
+      k,
+      static_cast<DType const*>(input.data_ptr()),
+      static_cast<float const*>(input_sf.data_ptr()),
+      reinterpret_cast<uint32_t*>(output.data_ptr()),
+      reinterpret_cast<uint32_t*>(output_sf.data_ptr()),
+      /*useUE8M0=*/false,
+      static_cast<uint8_t const*>(channel_masks.data_ptr()),
+      static_cast<int>(residue_per_8),
+      static_cast<int>(elts_mode),
+      info.multi_processor_count,
+      info.cc_major,
+      stream);
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/residue_nvfp4/residue_nvfp4_quant.cuh
+++ b/python/sglang/kernels/jit/csrc/residue_nvfp4/residue_nvfp4_quant.cuh
@@ -1,0 +1,338 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ * Modifications Copyright (c) 2026 Rong Shuo.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// mext_r1 (ratio 1.0 M-extension) NVFP4 activation quantization.
+//
+// Ported from ResInfer csrc/nvfp4/src/fp4/nvfp4_quant_kernels.cu (the mext_r1
+// subset), rehosted on the sglang JIT tvm-ffi conventions. The k_ext masked
+// quantization lives in a separate header (added with the k_ext linear path).
+//
+// Contract (mirrors the reference torch op):
+//   input     [M, K] fp16/bf16, K % 16 == 0
+//   input_sf  float32, 1 element (single global scale reciprocal)
+//   output    uint8, >= 2 * output_M * K / 2 bytes (row-doubled packed FP4)
+//   output_sf uint8 (fp8-e4m3 bytes), swizzled 128x4 tiled layout sized for
+//             (2 * output_M, K) -- or (output_M, 2K) for concat_k
+//   output_M  == M; derived from input.shape inside the op, never passed (a
+//             scalar op-arg desyncs from the buffer under torch.compile
+//             specialization)
+//
+// layout_mode: 0=concat, 1=row_pair, 3=concat_k
+// elts_mode:   0=auto (pack16 on cc 10.x, else pack8), 8, 16
+
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/utils.cuh>
+
+#include "residue_nvfp4_utils.cuh"
+#include <algorithm>
+#include <cstdint>
+
+namespace sglang {
+namespace residue_nvfp4 {
+
+template <class Type, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(512, RESIDUE_NVFP4_BLOCKS_PER_SM(512)) cvt_fp16_to_fp4_mext_r1_pack8(
+    int32_t inputRows,
+    int32_t outputRows,
+    int32_t numCols,
+    Type const* in,
+    float const* SFScale,
+    uint32_t* out,
+    uint32_t* SFout,
+    int32_t layoutMode) {
+  using PackedVec8 = PackedVec<Type>;
+  static constexpr int CVT_FP4_NUM_THREADS_PER_SF = (CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD);
+  static_assert(sizeof(PackedVec8) == sizeof(Type) * CVT_FP4_ELTS_PER_THREAD, "Vec size is not matched.");
+
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+
+  int colIdx = blockIdx.y * blockDim.x + threadIdx.x;
+  int colGroups = numCols / CVT_FP4_ELTS_PER_THREAD;
+  if (colIdx >= colGroups) return;
+
+  for (int rowIdx = blockIdx.x; rowIdx < outputRows; rowIdx += gridDim.x) {
+    bool validRow = rowIdx < inputRows;
+    int32_t baseRow = compute_mext_r1_base_row(rowIdx, outputRows, layoutMode);
+    int32_t residueRow = compute_mext_r1_residue_row(rowIdx, outputRows, layoutMode);
+
+    PackedVec8 in_vec{};
+    if (validRow) {
+      int64_t inOffset = rowIdx * (numCols / CVT_FP4_ELTS_PER_THREAD) + colIdx;
+      in_vec = reinterpret_cast<PackedVec8 const*>(in)[inOffset];
+    }
+
+    // kConcatK (mode 3): one output row per token, [M, 2K] geometry. Base
+    // lands at (row, col), residue at (row, col + K); both data and SF use
+    // the canonical addressing of the (M, 2K) grid, so the doubled-K operand
+    // is indistinguishable from a stock quantization of a 2K-wide input.
+    int32_t colsPerRow = numCols / CVT_FP4_ELTS_PER_THREAD;
+    bool kConcatK = layoutMode == 3;
+    int64_t outOffset = kConcatK ? (int64_t)rowIdx * (2 * colsPerRow) + colIdx : (int64_t)baseRow * colsPerRow + colIdx;
+    auto& out_pos = out[outOffset];
+
+    auto sf_out = kConcatK ? cvt_quant_to_fp4_get_sf_out_offset<uint32_t, CVT_FP4_NUM_THREADS_PER_SF>(
+                                 rowIdx, colIdx, 2 * numCols, SFout)
+                           : cvt_quant_to_fp4_get_sf_out_offset<uint32_t, CVT_FP4_NUM_THREADS_PER_SF>(
+                                 baseRow, colIdx, numCols, SFout);
+
+    int64_t residueOutOffset =
+        kConcatK ? (int64_t)rowIdx * (2 * colsPerRow) + colsPerRow + colIdx : (int64_t)residueRow * colsPerRow + colIdx;
+    uint32_t* residue_data_out = out + residueOutOffset;
+
+    auto residue_sf_out = kConcatK ? cvt_quant_to_fp4_get_sf_out_offset<uint32_t, CVT_FP4_NUM_THREADS_PER_SF>(
+                                         rowIdx, colIdx + colsPerRow, 2 * numCols, SFout)
+                                   : cvt_quant_to_fp4_get_sf_out_offset<uint32_t, CVT_FP4_NUM_THREADS_PER_SF>(
+                                         residueRow, colIdx, numCols, SFout);
+
+    out_pos =
+        cvt_warp_fp16_to_fp4_mext_r1_fast<Type, UE8M0_SF>(in_vec, SFScaleVal, sf_out, residue_data_out, residue_sf_out);
+  }
+}
+
+template <class Type, bool UE8M0_SF = false>
+__global__ void __launch_bounds__(512, RESIDUE_NVFP4_BLOCKS_PER_SM(512)) cvt_fp16_to_fp4_mext_r1_pack16(
+    int32_t inputRows,
+    int32_t outputRows,
+    int32_t numCols,
+    Type const* in,
+    float const* SFScale,
+    uint32_t* out,
+    uint32_t* SFout,
+    int32_t layoutMode) {
+  using PackedVec8 = PackedVec<Type>;
+  constexpr int CVT_FP4_NUM_THREADS_PER_SF = 1;
+
+  float const SFScaleVal = SFScale == nullptr ? 1.0f : SFScale[0];
+
+  int colIdx = blockIdx.y * blockDim.x + threadIdx.x;
+  int colGroups = numCols / 16;
+  if (colIdx >= colGroups) return;
+
+  for (int rowIdx = blockIdx.x; rowIdx < outputRows; rowIdx += gridDim.x) {
+    bool validRow = rowIdx < inputRows;
+    int32_t baseRow = compute_mext_r1_base_row(rowIdx, outputRows, layoutMode);
+    int32_t residueRow = compute_mext_r1_residue_row(rowIdx, outputRows, layoutMode);
+
+    PackedVec8 lo_vec{};
+    PackedVec8 hi_vec{};
+    if (validRow) {
+      // One 256-bit load covers the thread's entire 16-element SF vector.
+      load_packed_vec16(in + static_cast<int64_t>(rowIdx) * numCols + colIdx * 16, lo_vec, hi_vec);
+    }
+
+    int64_t outOffset = baseRow * (numCols / CVT_FP4_ELTS_PER_UINT32) + colIdx * 2;
+
+    auto sf_out =
+        cvt_quant_to_fp4_get_sf_out_offset<uint32_t, CVT_FP4_NUM_THREADS_PER_SF>(baseRow, colIdx, numCols, SFout);
+
+    int64_t residueOutOffset = residueRow * (numCols / CVT_FP4_ELTS_PER_UINT32) + colIdx * 2;
+    uint32_t* residue_data_out = out + residueOutOffset;
+
+    auto residue_sf_out =
+        cvt_quant_to_fp4_get_sf_out_offset<uint32_t, CVT_FP4_NUM_THREADS_PER_SF>(residueRow, colIdx, numCols, SFout);
+
+    u32x2 packed = cvt_warp_fp16_to_fp4_mext_r1_fast16<Type, UE8M0_SF>(
+        lo_vec, hi_vec, SFScaleVal, sf_out, residue_data_out, residue_sf_out);
+    // Single 64-bit store; outOffset is even because numCols % 16 == 0.
+    *reinterpret_cast<uint2*>(out + outOffset) = make_uint2(packed.lo, packed.hi);
+  }
+}
+
+enum class MExtR1EltsMode : int {
+  kAuto = 0,
+  kElts8 = 8,
+  kElts16 = 16,
+};
+
+enum class MExtR1LayoutMode : int {
+  kConcat = 0,
+  kRowPair = 1,
+  // K-concat: ONE output row per token, [M, 2K] geometry -- base in element
+  // cols [0, K), residue in [K, 2K).
+  kConcatK = 3,
+};
+
+inline bool use_pack16_for_mode(int elts_mode, int cc_major) {
+  switch (static_cast<MExtR1EltsMode>(elts_mode)) {
+    case MExtR1EltsMode::kElts8:
+      return false;
+    case MExtR1EltsMode::kElts16:
+      return true;
+    case MExtR1EltsMode::kAuto:
+    default:
+      // B200-measured: pack16 >= pack8 at every shape except M=1/K=4096
+      // (launch-floor regime) and 1.36-1.49x faster at prefill sizes. SM120
+      // decode measured pack8 faster, so only datacenter Blackwell (cc 10.x)
+      // defaults to 16.
+      return cc_major == 10;
+  }
+}
+
+inline int normalize_mext_r1_layout_mode(int layout_mode) {
+  switch (static_cast<MExtR1LayoutMode>(layout_mode)) {
+    case MExtR1LayoutMode::kRowPair:
+      return static_cast<int>(MExtR1LayoutMode::kRowPair);
+    case MExtR1LayoutMode::kConcatK:
+      return static_cast<int>(MExtR1LayoutMode::kConcatK);
+    case MExtR1LayoutMode::kConcat:
+    default:
+      return static_cast<int>(MExtR1LayoutMode::kConcat);
+  }
+}
+
+template <typename T>
+void invokeFP4QuantizationMExtR1(
+    int input_m,
+    int output_m,
+    int n,
+    T const* input,
+    float const* SFScale,
+    uint32_t* output,
+    uint32_t* SFOuput,
+    bool useUE8M0,
+    int elts_mode,
+    int layout_mode,
+    int multiProcessorCount,
+    int ccMajor,
+    cudaStream_t stream) {
+  bool pack16 = use_pack16_for_mode(elts_mode, ccMajor);
+  int normalized_layout_mode = normalize_mext_r1_layout_mode(layout_mode);
+  // kConcatK is implemented in the pack8 kernel only; pack8 is correct on
+  // every arch (pack16 is a cc10.x throughput default, not a semantic).
+  if (normalized_layout_mode == static_cast<int>(MExtR1LayoutMode::kConcatK)) {
+    pack16 = false;
+  }
+  int colGroups = n / (pack16 ? 16 : CVT_FP4_ELTS_PER_THREAD);
+  colGroups = std::max(colGroups, 1);
+
+  // Decode M-extension is intentionally small-M. Split the K dimension into
+  // multiple CTAs so M=1 does not collapse to one row CTA.
+  int desiredGridY = std::max(1, (computeEffectiveRows(output_m) + std::max(output_m, 1) - 1) / std::max(output_m, 1));
+  desiredGridY = std::min(desiredGridY, colGroups);
+  int numThreads = (colGroups + desiredGridY - 1) / desiredGridY;
+  numThreads = std::max(round_up_int(numThreads, 32), 32);
+  dim3 block(std::min(numThreads, 512));
+  int const numBlocksPerSM = runtime_blocks_per_sm(static_cast<int>(block.x));
+  dim3 grid(
+      std::min(int(output_m), multiProcessorCount * numBlocksPerSM),
+      (colGroups + static_cast<int>(block.x) - 1) / static_cast<int>(block.x));
+
+  auto launch = [&](auto kernel) {
+    kernel<<<grid, block, 0, stream>>>(input_m, output_m, n, input, SFScale, output, SFOuput, normalized_layout_mode);
+    cudaError_t status = cudaGetLastError();
+    host::RuntimeCheck(
+        status == cudaSuccess, "residue nvfp4 mext_r1 quant kernel launch failed: ", cudaGetErrorString(status));
+  };
+
+  if (useUE8M0) {
+    if (pack16) {
+      launch(cvt_fp16_to_fp4_mext_r1_pack16<T, true>);
+    } else {
+      launch(cvt_fp16_to_fp4_mext_r1_pack8<T, true>);
+    }
+  } else {
+    if (pack16) {
+      launch(cvt_fp16_to_fp4_mext_r1_pack16<T, false>);
+    } else {
+      launch(cvt_fp16_to_fp4_mext_r1_pack8<T, false>);
+    }
+  }
+}
+
+}  // namespace residue_nvfp4
+
+template <typename DType>
+void scaled_fp4_quant_mext_r1(
+    tvm::ffi::TensorView input,
+    tvm::ffi::TensorView output,
+    tvm::ffi::TensorView output_sf,
+    tvm::ffi::TensorView input_sf,
+    int64_t elts_mode,
+    int64_t layout_mode) {
+  using namespace host;
+  namespace rn = residue_nvfp4;
+
+  auto device = SymbolicDevice{};
+  device.set_options<kDLCUDA>();
+  auto M = SymbolicSize{"m"};
+  auto K = SymbolicSize{"k"};
+
+  TensorMatcher({M, K})  //
+      .with_dtype<DType>()
+      .with_device(device)
+      .verify(input);
+
+  const auto m = static_cast<int32_t>(M.unwrap());
+  const auto k = static_cast<int32_t>(K.unwrap());
+  RuntimeCheck(k % 16 == 0, "residue nvfp4 mext_r1: K must be a multiple of 16, got ", k);
+
+  // output_m is derived HERE from the input row count -- it is NOT an op
+  // argument. As a scalar op-arg,
+  // torch.compile specialized it to a constant while the caller's output
+  // buffer stayed symbolic in M, desyncing the two under CUDA-graph capture.
+  const int64_t output_m = static_cast<int64_t>(m);
+
+  auto OutLen = SymbolicSize{"out_len"};
+  auto SfLen = SymbolicSize{"sf_len"};
+  TensorMatcher({OutLen}).with_dtype<uint8_t>().with_device(device).verify(output);
+  TensorMatcher({SfLen}).with_dtype<uint8_t>().with_device(device).verify(output_sf);
+  RuntimeCheck(
+      output.numel() >= 2 * output_m * k / 2,
+      "residue nvfp4 mext_r1: output tensor too small for the derived output_m");
+
+  // Swizzled SF layout size: 128-row x 4-SF tiles over the OUTPUT geometry
+  // ((2*output_m, k) row-doubled, or (output_m, 2k) for concat_k -- both need
+  // the same byte count).
+  const int64_t num_m_tiles = (2 * output_m + 127) / 128;
+  const int64_t num_k_tiles = (k + 63) / 64;
+  RuntimeCheck(
+      output_sf.numel() >= num_m_tiles * num_k_tiles * 512,
+      "residue nvfp4 mext_r1: output_sf tensor too small for the swizzled layout");
+
+  auto InSfLen = SymbolicSize{"in_sf_len"};
+  TensorMatcher({InSfLen}).with_dtype<float>().with_device(device).verify(input_sf);
+  RuntimeCheck(input_sf.numel() == 1, "residue nvfp4 mext_r1: input_sf must contain exactly 1 element");
+
+  const auto dl_device = device.unwrap();
+  const auto info = rn::query_device_info(dl_device.device_id);
+  const auto stream = static_cast<cudaStream_t>(::TVMFFIEnvGetStream(dl_device.device_type, dl_device.device_id));
+
+  constexpr bool useUE8M0 = false;
+
+  rn::invokeFP4QuantizationMExtR1(
+      m,
+      static_cast<int>(output_m),
+      k,
+      static_cast<DType const*>(input.data_ptr()),
+      static_cast<float const*>(input_sf.data_ptr()),
+      reinterpret_cast<uint32_t*>(output.data_ptr()),
+      reinterpret_cast<uint32_t*>(output_sf.data_ptr()),
+      useUE8M0,
+      static_cast<int>(elts_mode),
+      static_cast<int>(layout_mode),
+      info.multi_processor_count,
+      info.cc_major,
+      stream);
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/residue_nvfp4/residue_nvfp4_utils.cuh
+++ b/python/sglang/kernels/jit/csrc/residue_nvfp4/residue_nvfp4_utils.cuh
@@ -1,0 +1,1089 @@
+/*
+ * Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+ * Modifications Copyright (c) 2026 Rong Shuo.
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Residue NVFP4 quantization device helpers.
+//
+// Ported from ResInfer csrc/nvfp4/src/fp4/nvfp4_utils.cuh (itself adapted from
+// vLLM/TensorRT-LLM NVFP4 quantization). Changes in this port:
+//   - namespace vllm -> sglang::residue_nvfp4
+//   - torch type-converter helpers dropped (the JIT wrapper templates on the
+//     CUDA element type directly)
+//   - launch-bounds macros renamed from VLLM_* to RESIDUE_NVFP4_*
+//
+// The header carries the device machinery for BOTH residue representations:
+//   - mext_r1 (ratio 1.0): cvt_warp_fp16_to_fp4_mext_r1_fast / _fast16 and the
+//     compute_mext_r1_{base,residue}_row layout mapping
+//   - k_ext (ratios 1/8, 2/8, 4/8): masked quantization + residue channel
+//     append (cvt_warp_fp16_to_fp4 and the residue offset helpers)
+
+#pragma once
+
+#include <cstdint>
+#include <cuda_fp8.h>
+#include <cuda_runtime.h>
+#include <type_traits>
+
+// ---------------------------------------------------------------------------
+// Launch-bounds helpers (adapted from vLLM's launch_bounds_utils.h)
+// ---------------------------------------------------------------------------
+
+#ifndef RESIDUE_NVFP4_LAUNCH_BLOCKS_CAP
+#define RESIDUE_NVFP4_LAUNCH_BLOCKS_CAP 4
+#endif
+
+// Compile-time estimate of max threads per SM for __launch_bounds__.
+#ifndef RESIDUE_NVFP4_MAX_THREADS_PER_SM
+#ifdef __CUDA_ARCH__
+/* 1536 thr/SM: Ampere GA10x (sm_86/87), Ada (sm_89), GB20x consumer
+   (sm_120/121), Thor (sm_101/sm_110) */
+#if (__CUDA_ARCH__ == 860) || (__CUDA_ARCH__ == 870) || (__CUDA_ARCH__ == 890) || (__CUDA_ARCH__ == 1010) || \
+    (__CUDA_ARCH__ == 1100) || (__CUDA_ARCH__ == 1200) || (__CUDA_ARCH__ == 1210)
+#define RESIDUE_NVFP4_MAX_THREADS_PER_SM 1536
+#elif (__CUDA_ARCH__ == 750)
+#define RESIDUE_NVFP4_MAX_THREADS_PER_SM 1024
+#else
+/* 2048 thr/SM: GA100, Hopper, Blackwell datacenter (sm_100/103), fallback */
+#define RESIDUE_NVFP4_MAX_THREADS_PER_SM 2048
+#endif
+#else
+#define RESIDUE_NVFP4_MAX_THREADS_PER_SM 2048
+#endif
+#endif
+
+#define RESIDUE_NVFP4_BLOCKS_DIV(VAL) (RESIDUE_NVFP4_MAX_THREADS_PER_SM / (VAL))
+#define RESIDUE_NVFP4_CLAMP_BLOCKS_PER_SM(VAL) \
+  (((VAL) <= 0) ? 1 : (((VAL) < RESIDUE_NVFP4_LAUNCH_BLOCKS_CAP) ? (VAL) : RESIDUE_NVFP4_LAUNCH_BLOCKS_CAP))
+#define RESIDUE_NVFP4_BLOCKS_PER_SM(BLOCK_THREADS) \
+  RESIDUE_NVFP4_CLAMP_BLOCKS_PER_SM(RESIDUE_NVFP4_BLOCKS_DIV(BLOCK_THREADS))
+
+namespace sglang {
+namespace residue_nvfp4 {
+
+// Runtime helper mirroring the compile-time macro above.
+static inline int runtime_blocks_per_sm(int block_threads) {
+  int device = -1;
+  cudaGetDevice(&device);
+  int max_threads_per_sm = RESIDUE_NVFP4_MAX_THREADS_PER_SM;
+  cudaDeviceGetAttribute(&max_threads_per_sm, cudaDevAttrMaxThreadsPerMultiProcessor, device);
+  int blocks = (block_threads > 0) ? (max_threads_per_sm / block_threads) : 1;
+  return RESIDUE_NVFP4_CLAMP_BLOCKS_PER_SM(blocks);
+}
+
+struct DeviceInfo {
+  int multi_processor_count;
+  int cc_major;
+};
+
+inline DeviceInfo query_device_info(int device_id) {
+  // Cached per device: cudaDeviceGetAttribute costs ~1us and this sits on the
+  // decode hot path.
+  static DeviceInfo cache[64];
+  static bool cached[64] = {};
+  if (device_id >= 0 && device_id < 64 && cached[device_id]) {
+    return cache[device_id];
+  }
+  DeviceInfo info{};
+  cudaDeviceGetAttribute(&info.multi_processor_count, cudaDevAttrMultiProcessorCount, device_id);
+  cudaDeviceGetAttribute(&info.cc_major, cudaDevAttrComputeCapabilityMajor, device_id);
+  if (device_id >= 0 && device_id < 64) {
+    cache[device_id] = info;
+    cached[device_id] = true;
+  }
+  return info;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+constexpr int CVT_FP4_ELTS_PER_THREAD = 8;
+constexpr int CVT_FP4_SF_VEC_SIZE = 16;
+constexpr int CVT_FP4_ELTS_PER_UINT32 = 8;
+
+__host__ __device__ __forceinline__ int round_up_int(int x, int n) {
+  return ((x + n - 1) / n) * n;
+}
+
+// Match upstream swizzled-scale quant launch behavior so small-M serving
+// iterations still initialize the full tiled SF layout and avoid collapsing to
+// a single active CTA.
+__host__ __device__ __forceinline__ int computeEffectiveRows(int m) {
+  constexpr int ROW_TILE = 128;
+  return round_up_int(m, ROW_TILE);
+}
+
+// Residue configurations - template-based for multi-ratio support.
+// RESIDUE_PER_8_ELTS values: 1 (12.5%), 2 (25%), 4 (50%).
+template <int RESIDUE_PER_8_ELTS>
+constexpr int get_residue_per_thread() {
+  return RESIDUE_PER_8_ELTS * (CVT_FP4_ELTS_PER_THREAD / 8);
+}
+
+static_assert(CVT_FP4_ELTS_PER_THREAD == 8, "Current implementation assumes 8 elements per thread");
+
+// Helper function to compute warp mask for a contiguous group of threads.
+// THREADS_PER_GROUP must be 1, 2, 4, 8, 16, or 32.
+template <int THREADS_PER_GROUP>
+constexpr uint32_t compute_group_mask(int group_id) {
+  return ((1u << THREADS_PER_GROUP) - 1u) << (group_id * THREADS_PER_GROUP);
+}
+
+// Warp group max reduction using shuffle.
+template <int GROUP_THREADS>
+__device__ __forceinline__ float warp_group_max(float v, int laneId) {
+  int groupId = laneId / GROUP_THREADS;
+  uint32_t mask = compute_group_mask<GROUP_THREADS>(groupId);
+#pragma unroll
+  for (int off = 1; off < GROUP_THREADS; off <<= 1) {
+    v = fmaxf(v, __shfl_xor_sync(mask, v, off));
+  }
+  return v;
+}
+
+// Extract values from float2 array using sparse bitmask iteration.
+template <int MAX_OUTPUT>
+__device__ __forceinline__ int
+extract_values_by_mask(const float2 fp2Vals[CVT_FP4_ELTS_PER_THREAD / 2], uint8_t mask, float output[MAX_OUTPUT]) {
+  int idx = 0;
+  uint8_t extractMask = mask;
+  while (extractMask) {
+    int i = __ffs(extractMask) - 1;
+    int pairIdx = i >> 1;
+    int offset = i & 1;
+    output[idx++] = (offset == 0) ? fp2Vals[pairIdx].x : fp2Vals[pairIdx].y;
+    extractMask &= extractMask - 1;
+  }
+  return idx;
+}
+
+// Get type2 from type or vice versa (applied to half and bfloat16).
+template <typename T>
+struct TypeConverter {
+  using Type = half2;
+};
+
+template <>
+struct TypeConverter<half2> {
+  using Type = half;
+};
+
+template <>
+struct TypeConverter<half> {
+  using Type = half2;
+};
+
+template <>
+struct TypeConverter<__nv_bfloat162> {
+  using Type = __nv_bfloat16;
+};
+
+template <>
+struct TypeConverter<__nv_bfloat16> {
+  using Type = __nv_bfloat162;
+};
+
+// Define a 16 bytes packed data type.
+template <class Type>
+struct PackedVec {
+  typename TypeConverter<Type>::Type elts[4];
+};
+
+template <>
+struct PackedVec<__nv_fp8_e4m3> {
+  __nv_fp8x2_e4m3 elts[8];
+};
+
+// Convert 8 float32 values into 8 e2m1 values (represented as one uint32_t).
+inline __device__ uint32_t fp32_vec_to_e2m1(float (&array)[8]) {
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0]),
+        "f"(array[1]),
+        "f"(array[2]),
+        "f"(array[3]),
+        "f"(array[4]),
+        "f"(array[5]),
+        "f"(array[6]),
+        "f"(array[7]));
+  return val;
+}
+
+// Convert 4 float2 values into 8 e2m1 values (represented as one uint32_t).
+inline __device__ uint32_t fp32_vec_to_e2m1(float2 (&array)[4]) {
+  uint32_t val;
+  asm volatile(
+      "{\n"
+      ".reg .b8 byte0;\n"
+      ".reg .b8 byte1;\n"
+      ".reg .b8 byte2;\n"
+      ".reg .b8 byte3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte0, %2, %1;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte1, %4, %3;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte2, %6, %5;\n"
+      "cvt.rn.satfinite.e2m1x2.f32   byte3, %8, %7;\n"
+      "mov.b32 %0, {byte0, byte1, byte2, byte3};\n"
+      "}"
+      : "=r"(val)
+      : "f"(array[0].x),
+        "f"(array[0].y),
+        "f"(array[1].x),
+        "f"(array[1].y),
+        "f"(array[2].x),
+        "f"(array[2].y),
+        "f"(array[3].x),
+        "f"(array[3].y));
+  return val;
+}
+
+// Quantize 8 scaled fp32 values to e2m1 and dequantize them back in place:
+//   in_out_buffer[i] initially holds scaled input (x, y)
+//   after the call it holds the dequantized values
+__device__ __forceinline__ uint32_t fp32x8_to_e2m1_with_dequant(float2 (&in_out_buffer)[4]) {
+  uint32_t packed_u32;
+  uint32_t f16x2_0, f16x2_1, f16x2_2, f16x2_3;
+
+  asm volatile(
+      "{\n"
+      "  .reg .b8 b0, b1, b2, b3;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b0, %6,  %5;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b1, %8,  %7;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b2, %10, %9;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b3, %12, %11;\n"
+      "  cvt.rn.f16x2.e2m1x2           %0, b0;\n"
+      "  cvt.rn.f16x2.e2m1x2           %1, b1;\n"
+      "  cvt.rn.f16x2.e2m1x2           %2, b2;\n"
+      "  cvt.rn.f16x2.e2m1x2           %3, b3;\n"
+      "  mov.b32 %4, {b0, b1, b2, b3};\n"
+      "}\n"
+      : "=r"(f16x2_0), "=r"(f16x2_1), "=r"(f16x2_2), "=r"(f16x2_3), "=r"(packed_u32)
+      : "f"(in_out_buffer[0].x),
+        "f"(in_out_buffer[0].y),
+        "f"(in_out_buffer[1].x),
+        "f"(in_out_buffer[1].y),
+        "f"(in_out_buffer[2].x),
+        "f"(in_out_buffer[2].y),
+        "f"(in_out_buffer[3].x),
+        "f"(in_out_buffer[3].y));
+
+  union U32Half2 {
+    uint32_t u;
+    __half2 h2;
+  };
+
+  auto residual_inplace = [&](uint32_t f16x2_u32, float2& inout) {
+    U32Half2 v;
+    v.u = f16x2_u32;
+    inout.x = __half2float(__low2half(v.h2));
+    inout.y = __half2float(__high2half(v.h2));
+  };
+
+  residual_inplace(f16x2_0, in_out_buffer[0]);
+  residual_inplace(f16x2_1, in_out_buffer[1]);
+  residual_inplace(f16x2_2, in_out_buffer[2]);
+  residual_inplace(f16x2_3, in_out_buffer[3]);
+
+  return packed_u32;
+}
+
+// Same as above with separate input and output buffers:
+//   input_buffer[i] holds the scaled values (preserved)
+//   dequant_buffer[i] receives the dequantized values
+__device__ __forceinline__ uint32_t
+fp32x8_to_e2m1_separate(const float2 (&input_buffer)[4], float2 (&dequant_buffer)[4]) {
+  uint32_t packed_u32;
+  uint32_t f16x2_0, f16x2_1, f16x2_2, f16x2_3;
+
+  asm volatile(
+      "{\n"
+      "  .reg .b8 b0, b1, b2, b3;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b0, %6,  %5;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b1, %8,  %7;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b2, %10, %9;\n"
+      "  cvt.rn.satfinite.e2m1x2.f32   b3, %12, %11;\n"
+      "  cvt.rn.f16x2.e2m1x2           %0, b0;\n"
+      "  cvt.rn.f16x2.e2m1x2           %1, b1;\n"
+      "  cvt.rn.f16x2.e2m1x2           %2, b2;\n"
+      "  cvt.rn.f16x2.e2m1x2           %3, b3;\n"
+      "  mov.b32 %4, {b0, b1, b2, b3};\n"
+      "}\n"
+      : "=r"(f16x2_0), "=r"(f16x2_1), "=r"(f16x2_2), "=r"(f16x2_3), "=r"(packed_u32)
+      : "f"(input_buffer[0].x),
+        "f"(input_buffer[0].y),
+        "f"(input_buffer[1].x),
+        "f"(input_buffer[1].y),
+        "f"(input_buffer[2].x),
+        "f"(input_buffer[2].y),
+        "f"(input_buffer[3].x),
+        "f"(input_buffer[3].y));
+
+  union U32Half2 {
+    uint32_t u;
+    __half2 h2;
+  };
+
+  auto write_dequant = [&](uint32_t f16x2_u32, float2& out) {
+    U32Half2 v;
+    v.u = f16x2_u32;
+    out.x = __half2float(__low2half(v.h2));
+    out.y = __half2float(__high2half(v.h2));
+  };
+
+  write_dequant(f16x2_0, dequant_buffer[0]);
+  write_dequant(f16x2_1, dequant_buffer[1]);
+  write_dequant(f16x2_2, dequant_buffer[2]);
+  write_dequant(f16x2_3, dequant_buffer[3]);
+
+  return packed_u32;
+}
+
+// Fast reciprocal.
+inline __device__ float reciprocal_approximate_ftz(float a) {
+  float b;
+  asm volatile("rcp.approx.ftz.f32 %0, %1;\n" : "=f"(b) : "f"(a));
+  return b;
+}
+
+// Compute scale factor value from max absolute value.
+// Formula: SF = SFScaleVal * (maxVal / 6.0)
+__device__ __forceinline__ float compute_sf_from_max(float maxVal, float SFScaleVal) {
+  return SFScaleVal * (maxVal * reciprocal_approximate_ftz(6.0f));
+}
+
+// Encode scale factor to FP8 (UE8M0 or E4M3) and return the quantized SF as
+// float. Side effect: writes the FP8 byte to *out_fp8 if non-null.
+template <bool UE8M0_SF>
+__device__ __forceinline__ float encode_sf_to_fp8(float SFValue, uint8_t* out_fp8) {
+  uint8_t fp8;
+  if constexpr (UE8M0_SF) {
+    uint32_t tmp = reinterpret_cast<uint32_t&>(SFValue) >> 23;
+    fp8 = tmp & 0xff;
+    reinterpret_cast<uint32_t&>(SFValue) = tmp << 23;
+  } else {
+    __nv_fp8_e4m3 tmp = __nv_fp8_e4m3(SFValue);
+    reinterpret_cast<__nv_fp8_e4m3&>(fp8) = tmp;
+    SFValue = float(tmp);
+  }
+  if (out_fp8) *out_fp8 = fp8;
+  return SFValue;
+}
+
+// Compute output scale with precise numerical ordering for the FP8->FP4
+// quantization path. DO NOT rewrite: this ordering is numerically chosen and
+// must stay consistent across the main and residue quantization paths.
+__device__ __forceinline__ float compute_output_scale_precise(float SFValue, float SFScaleVal) {
+  return (SFValue != 0.0f) ? SFScaleVal * reciprocal_approximate_ftz(SFValue) : 0.0f;
+}
+
+// Shuffle-based collection of values within a group. Each thread in a group
+// collects all values from its group members into outputChunk[4].
+template <int RESIDUE_PER_THREAD>
+__device__ __forceinline__ void shuffle_collect_group_float2(
+    const float2 (&scaledValues)[(RESIDUE_PER_THREAD + 1) / 2], int groupFirstThread, float2 (&outputChunk)[4]) {
+  if constexpr (RESIDUE_PER_THREAD == 1) {
+    // Special case: 4 groups of 8 threads each.
+#pragma unroll
+    for (int i = 0; i < 4; i++) {
+      int sourceThread0 = groupFirstThread + i * 2;
+      int sourceThread1 = groupFirstThread + i * 2 + 1;
+      float val0 = __shfl_sync(__activemask(), scaledValues[0].x, sourceThread0);
+      float val1 = __shfl_sync(__activemask(), scaledValues[0].x, sourceThread1);
+      outputChunk[i] = make_float2(val0, val1);
+    }
+  } else {
+#pragma unroll
+    for (int i = 0; i < 4; i++) {
+      int sourceThread = groupFirstThread + i / (RESIDUE_PER_THREAD / 2);
+      int float2Offset = i % (RESIDUE_PER_THREAD / 2);
+      unsigned long long tmp = __shfl_sync(
+          __activemask(), reinterpret_cast<const unsigned long long&>(scaledValues[float2Offset]), sourceThread);
+      outputChunk[i] = reinterpret_cast<float2&>(tmp);
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// mext_r1 (ratio 1.0 M-extension) device path
+// ---------------------------------------------------------------------------
+
+// Specialized fast path for the M-extension ratio=1.0 layout.
+//
+// This path intentionally does not reuse the generic residue machinery:
+// no sparse mask extraction, no warp-level residue gather, no extended-K
+// residue address logic. Instead:
+//   1. standard main quantization + QDQ
+//   2. residue = original - dequant(main)
+//   3. a second simple quantization pass for the residue row
+template <class Type, bool UE8M0_SF = false>
+__device__ __forceinline__ uint32_t cvt_warp_fp16_to_fp4_mext_r1_fast(
+    PackedVec<Type>& vec, float SFScaleVal, uint8_t* SFout, uint32_t* residueDataOut, uint8_t* residueSFOut) {
+  constexpr int CVT_FP4_NUM_THREADS_PER_SF = (CVT_FP4_SF_VEC_SIZE / CVT_FP4_ELTS_PER_THREAD);
+
+  // Main quantization (standard FP4 path).
+  auto localMax = __habs2(vec.elts[0]);
+
+#pragma unroll
+  for (int i = 1; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    localMax = __hmax2(localMax, __habs2(vec.elts[i]));
+  }
+
+  if constexpr (CVT_FP4_NUM_THREADS_PER_SF == 2) {
+    localMax = __hmax2(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+  }
+  float vecMax = float(__hmax(localMax.x, localMax.y));
+
+  float SFValue = compute_sf_from_max(vecMax, SFScaleVal);
+  SFValue = encode_sf_to_fp8<UE8M0_SF>(SFValue, SFout);
+  float outputScale = compute_output_scale_precise(SFValue, SFScaleVal);
+
+  float2 fp2ValsOriginal[CVT_FP4_ELTS_PER_THREAD / 2];
+  float2 mainScaled[CVT_FP4_ELTS_PER_THREAD / 2];
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    if constexpr (std::is_same_v<Type, half>) {
+      fp2ValsOriginal[i] = __half22float2(vec.elts[i]);
+    } else {
+      fp2ValsOriginal[i] = __bfloat1622float2(vec.elts[i]);
+    }
+    mainScaled[i].x = fp2ValsOriginal[i].x * outputScale;
+    mainScaled[i].y = fp2ValsOriginal[i].y * outputScale;
+  }
+
+  // QDQ the main tensor so we can form the exact runtime residue.
+  uint32_t e2m1Vec = fp32x8_to_e2m1_with_dequant(mainScaled);
+
+  // Residue quantization (simple dense ratio=1.0 path).
+  float inverseOutputScale = outputScale != 0.0f ? reciprocal_approximate_ftz(outputScale) : 0.0f;
+
+  float2 residueVals[CVT_FP4_ELTS_PER_THREAD / 2];
+  float localMaxResidue = 0.0f;
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    float deq_x = mainScaled[i].x * inverseOutputScale;
+    float deq_y = mainScaled[i].y * inverseOutputScale;
+
+    residueVals[i].x = fp2ValsOriginal[i].x - deq_x;
+    residueVals[i].y = fp2ValsOriginal[i].y - deq_y;
+
+    localMaxResidue = fmaxf(localMaxResidue, fmaxf(fabsf(residueVals[i].x), fabsf(residueVals[i].y)));
+  }
+
+  if constexpr (CVT_FP4_NUM_THREADS_PER_SF == 2) {
+    localMaxResidue = fmaxf(localMaxResidue, __shfl_xor_sync(uint32_t(-1), localMaxResidue, 1));
+  }
+
+  float residueSFValue = compute_sf_from_max(localMaxResidue, SFScaleVal);
+  residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+  float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+
+  float2 residueScaled[CVT_FP4_ELTS_PER_THREAD / 2];
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    residueScaled[i].x = residueVals[i].x * residueOutputScale;
+    residueScaled[i].y = residueVals[i].y * residueOutputScale;
+  }
+
+  if (residueDataOut) {
+    *residueDataOut = fp32_vec_to_e2m1(residueScaled);
+  }
+
+  return e2m1Vec;
+}
+
+struct u32x2 {
+  uint32_t lo, hi;
+};
+
+// Load 16 fp16/bf16 elements (one full SF vector, 32 bytes) in a single
+// 256-bit global load. Blackwell (sm_100+) exposes ld.global.v8.b32
+// (PTX ISA 8.8); older targets fall back to two 128-bit loads. `ptr` must be
+// 32-byte aligned -- guaranteed by K % 16 == 0 plus torch's base alignment.
+template <class Type>
+__device__ __forceinline__ void load_packed_vec16(Type const* ptr, PackedVec<Type>& lo, PackedVec<Type>& hi) {
+#if defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000)
+  union {
+    uint32_t u[8];
+    struct {
+      PackedVec<Type> lo, hi;
+    } v;
+  } tmp;
+  asm volatile("ld.global.v8.b32 {%0, %1, %2, %3, %4, %5, %6, %7}, [%8];"
+               : "=r"(tmp.u[0]),
+                 "=r"(tmp.u[1]),
+                 "=r"(tmp.u[2]),
+                 "=r"(tmp.u[3]),
+                 "=r"(tmp.u[4]),
+                 "=r"(tmp.u[5]),
+                 "=r"(tmp.u[6]),
+                 "=r"(tmp.u[7])
+               : "l"(ptr));
+  lo = tmp.v.lo;
+  hi = tmp.v.hi;
+#else
+  lo = reinterpret_cast<PackedVec<Type> const*>(ptr)[0];
+  hi = reinterpret_cast<PackedVec<Type> const*>(ptr)[1];
+#endif
+}
+
+// pack16 path for mext_r1:
+//   - one thread owns 16 elements
+//   - main/residue SF are each computed once over all 16 elements
+//   - quantization reuses the validated 8-element QDQ helpers on the low/high
+//     8-element half-chunks
+template <class Type, bool UE8M0_SF = false>
+__device__ __forceinline__ u32x2 cvt_warp_fp16_to_fp4_mext_r1_fast16(
+    PackedVec<Type>& loVec,
+    PackedVec<Type>& hiVec,
+    float SFScaleVal,
+    uint8_t* SFout,
+    uint32_t* residueDataOut,
+    uint8_t* residueSFOut) {
+  static_assert(CVT_FP4_ELTS_PER_THREAD == 8, "pack16 path assumes the 8-element base helper.");
+
+  auto localMax = __habs2(loVec.elts[0]);
+
+#pragma unroll
+  for (int i = 1; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    localMax = __hmax2(localMax, __habs2(loVec.elts[i]));
+  }
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    localMax = __hmax2(localMax, __habs2(hiVec.elts[i]));
+  }
+
+  float vecMax = float(__hmax(localMax.x, localMax.y));
+
+  float SFValue = compute_sf_from_max(vecMax, SFScaleVal);
+  SFValue = encode_sf_to_fp8<UE8M0_SF>(SFValue, SFout);
+  float outputScale = compute_output_scale_precise(SFValue, SFScaleVal);
+
+  float2 loOriginal[CVT_FP4_ELTS_PER_THREAD / 2];
+  float2 hiOriginal[CVT_FP4_ELTS_PER_THREAD / 2];
+  float2 loScaled[CVT_FP4_ELTS_PER_THREAD / 2];
+  float2 hiScaled[CVT_FP4_ELTS_PER_THREAD / 2];
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    if constexpr (std::is_same_v<Type, half>) {
+      loOriginal[i] = __half22float2(loVec.elts[i]);
+      hiOriginal[i] = __half22float2(hiVec.elts[i]);
+    } else {
+      loOriginal[i] = __bfloat1622float2(loVec.elts[i]);
+      hiOriginal[i] = __bfloat1622float2(hiVec.elts[i]);
+    }
+    loScaled[i].x = loOriginal[i].x * outputScale;
+    loScaled[i].y = loOriginal[i].y * outputScale;
+    hiScaled[i].x = hiOriginal[i].x * outputScale;
+    hiScaled[i].y = hiOriginal[i].y * outputScale;
+  }
+
+  u32x2 mainPacked;
+  mainPacked.lo = fp32x8_to_e2m1_with_dequant(loScaled);
+  mainPacked.hi = fp32x8_to_e2m1_with_dequant(hiScaled);
+
+  float inverseOutputScale = outputScale != 0.0f ? reciprocal_approximate_ftz(outputScale) : 0.0f;
+
+  float2 loResidue[CVT_FP4_ELTS_PER_THREAD / 2];
+  float2 hiResidue[CVT_FP4_ELTS_PER_THREAD / 2];
+  float localMaxResidue = 0.0f;
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    float loDeqX = loScaled[i].x * inverseOutputScale;
+    float loDeqY = loScaled[i].y * inverseOutputScale;
+    float hiDeqX = hiScaled[i].x * inverseOutputScale;
+    float hiDeqY = hiScaled[i].y * inverseOutputScale;
+
+    loResidue[i].x = loOriginal[i].x - loDeqX;
+    loResidue[i].y = loOriginal[i].y - loDeqY;
+    hiResidue[i].x = hiOriginal[i].x - hiDeqX;
+    hiResidue[i].y = hiOriginal[i].y - hiDeqY;
+
+    localMaxResidue = fmaxf(localMaxResidue, fmaxf(fabsf(loResidue[i].x), fabsf(loResidue[i].y)));
+    localMaxResidue = fmaxf(localMaxResidue, fmaxf(fabsf(hiResidue[i].x), fabsf(hiResidue[i].y)));
+  }
+
+  float residueSFValue = compute_sf_from_max(localMaxResidue, SFScaleVal);
+  residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+  float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+
+  float2 loResidueScaled[CVT_FP4_ELTS_PER_THREAD / 2];
+  float2 hiResidueScaled[CVT_FP4_ELTS_PER_THREAD / 2];
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; ++i) {
+    loResidueScaled[i].x = loResidue[i].x * residueOutputScale;
+    loResidueScaled[i].y = loResidue[i].y * residueOutputScale;
+    hiResidueScaled[i].x = hiResidue[i].x * residueOutputScale;
+    hiResidueScaled[i].y = hiResidue[i].y * residueOutputScale;
+  }
+
+  if (residueDataOut) {
+    // Single 64-bit store (st.global.v2.b32); the residue offset is always an
+    // even uint32 index because numCols % 16 == 0.
+    *reinterpret_cast<uint2*>(residueDataOut) =
+        make_uint2(fp32_vec_to_e2m1(loResidueScaled), fp32_vec_to_e2m1(hiResidueScaled));
+  }
+
+  return mainPacked;
+}
+
+// ---------------------------------------------------------------------------
+// k_ext (selective residue) device path
+// ---------------------------------------------------------------------------
+
+// Swap-residue variant: the salient channels are quantized into the residue
+// section and the (dequantization) residues take their place in the main
+// section.
+template <class Type, bool UE8M0_SF = false, int RESIDUE_PER_8_ELTS = 1>
+__device__ uint32_t cvt_warp_fp16_to_fp4_swap(
+    PackedVec<Type>& vec,
+    float SFScaleVal,
+    uint8_t* SFout,
+    uint8_t mask,
+    uint32_t* residueDataOut,
+    uint8_t* salientSFOut) {
+  constexpr int RESIDUE_PER_THREAD = get_residue_per_thread<RESIDUE_PER_8_ELTS>();
+
+  // Quantization for salient channels.
+  float2 fp2Vals[CVT_FP4_ELTS_PER_THREAD / 2];
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    if constexpr (std::is_same_v<Type, half>) {
+      fp2Vals[i] = __half22float2(vec.elts[i]);
+    } else {
+      fp2Vals[i] = __bfloat1622float2(vec.elts[i]);
+    }
+  }
+
+  float salient[RESIDUE_PER_THREAD > 0 ? RESIDUE_PER_THREAD : 1];
+  extract_values_by_mask<RESIDUE_PER_THREAD>(fp2Vals, mask, salient);
+
+  int laneId = threadIdx.x % 32;
+
+  // Phase 1: compute shared SF for every 16 salient values.
+  float localMaxSalient = 0.0f;
+#pragma unroll
+  for (int i = 0; i < RESIDUE_PER_THREAD; i++) {
+    localMaxSalient = fmaxf(localMaxSalient, fabsf(salient[i]));
+  }
+
+  constexpr int THREADS_PER_SF_GROUP = 16 / RESIDUE_PER_THREAD;
+
+  float sfGroupMaxSalient = warp_group_max<THREADS_PER_SF_GROUP>(localMaxSalient, laneId);
+  float salientSFValue = SFScaleVal * (sfGroupMaxSalient * reciprocal_approximate_ftz(6.0f));
+  salientSFValue = encode_sf_to_fp8<UE8M0_SF>(salientSFValue, salientSFOut);
+
+  float salientOutputScale = compute_output_scale_precise(salientSFValue, SFScaleVal);
+
+  // Prepare salient values for shuffle (handle odd RESIDUE_PER_THREAD).
+  float2 shuffleSalient[(RESIDUE_PER_THREAD + 1) / 2];
+#pragma unroll
+  for (int i = 0; i < (RESIDUE_PER_THREAD + 1) / 2; i++) {
+    float val0 = (i * 2 < RESIDUE_PER_THREAD) ? salient[i * 2] : 0.0f;
+    float val1 = (i * 2 + 1 < RESIDUE_PER_THREAD) ? salient[i * 2 + 1] : 0.0f;
+    shuffleSalient[i] = make_float2(val0, val1);
+  }
+
+  float2 residue[(RESIDUE_PER_THREAD + 1) / 2];
+  float2 salientChunk[4];
+
+  constexpr int numThreadsPerGroup = 8 / RESIDUE_PER_THREAD;
+  int groupId = laneId / numThreadsPerGroup;
+  int threadInGroup = laneId % numThreadsPerGroup;
+  int groupFirstThread = groupId * numThreadsPerGroup;
+
+  // Collect UNSCALED salient values via shuffle (residue computation must not
+  // pick up scale round-trip error).
+  float2 unscaledSalientChunk[4];
+  shuffle_collect_group_float2<RESIDUE_PER_THREAD>(shuffleSalient, groupFirstThread, unscaledSalientChunk);
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    salientChunk[i] =
+        make_float2(unscaledSalientChunk[i].x * salientOutputScale, unscaledSalientChunk[i].y * salientOutputScale);
+  }
+
+  // Quantize salient with separate buffers to preserve the originals.
+  float2 dequantChunk[4];
+  uint32_t quantizedChunk = fp32x8_to_e2m1_separate(salientChunk, dequantChunk);
+
+  if (residueDataOut) {
+    *residueDataOut = quantizedChunk;
+  }
+  // Compute residue: original - dequant.
+  float inverseSalientOutputScale = salientOutputScale != 0 ? reciprocal_approximate_ftz(salientOutputScale) : 0.0f;
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    float deq_x = dequantChunk[i].x * inverseSalientOutputScale;
+    float deq_y = dequantChunk[i].y * inverseSalientOutputScale;
+    float orig_x = unscaledSalientChunk[i].x;
+    float orig_y = unscaledSalientChunk[i].y;
+    salientChunk[i].x = orig_x - deq_x;
+    salientChunk[i].y = orig_y - deq_y;
+  }
+
+  // Each thread directly extracts its residue from salientChunk (all threads
+  // in the group hold identical chunks after quantization).
+  if constexpr (RESIDUE_PER_THREAD == 1) {
+    int pairIdx = threadInGroup / 2;
+    int elemIdx = threadInGroup % 2;
+    float val = (elemIdx == 0) ? salientChunk[pairIdx].x : salientChunk[pairIdx].y;
+    residue[0] = make_float2(val, 0.0f);
+  } else {
+    constexpr int float2PerThread = RESIDUE_PER_THREAD / 2;
+#pragma unroll
+    for (int i = 0; i < float2PerThread; i++) {
+      int idx = threadInGroup * float2PerThread + i;
+      residue[i] = salientChunk[idx];
+    }
+  }
+
+  // Main quantization: place residues back at the salient positions.
+  int residueWriteIdx = 0;
+  uint8_t tempMask = mask;
+  while (tempMask) {
+    int i = __ffs(tempMask) - 1;
+    int pairIdx = i / 2;
+    int offset = i % 2;
+    float val;
+    if constexpr (RESIDUE_PER_THREAD == 1) {
+      val = residue[0].x;
+    } else {
+      int f2Idx = residueWriteIdx / 2;
+      int f2Off = residueWriteIdx % 2;
+      val = (f2Off == 0) ? residue[f2Idx].x : residue[f2Idx].y;
+    }
+    if (offset == 0) {
+      fp2Vals[pairIdx].x = val;
+    } else {
+      fp2Vals[pairIdx].y = val;
+    }
+    residueWriteIdx++;
+    tempMask &= tempMask - 1;
+  }
+
+  // Main SF computation in FLOAT precision (max BEFORE converting to
+  // half/bfloat16 to avoid precision loss).
+  float localMaxFloat = 0.0f;
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    localMaxFloat = fmaxf(localMaxFloat, fmaxf(fabsf(fp2Vals[i].x), fabsf(fp2Vals[i].y)));
+  }
+  localMaxFloat = fmaxf(localMaxFloat, __shfl_xor_sync(uint32_t(-1), localMaxFloat, 1));
+  float vecMax = localMaxFloat;
+
+  float SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
+  SFValue = encode_sf_to_fp8<UE8M0_SF>(SFValue, SFout);
+
+  float outputScale = compute_output_scale_precise(SFValue, SFScaleVal);
+
+  float2 mainVals[CVT_FP4_ELTS_PER_THREAD / 2];
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    mainVals[i].x = fp2Vals[i].x * outputScale;
+    mainVals[i].y = fp2Vals[i].y * outputScale;
+  }
+
+  uint32_t e2m1Vec = fp32_vec_to_e2m1(mainVals);
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    if constexpr (std::is_same_v<Type, half>) {
+      vec.elts[i] = __float22half2_rn(fp2Vals[i]);
+    } else {
+      vec.elts[i] = __float22bfloat162_rn(fp2Vals[i]);
+    }
+  }
+
+  return e2m1Vec;
+}
+
+// Standard (non-swap) k_ext path: quantize the full row, then quantize the
+// dequantization residues of the salient channels into the extension.
+template <class Type, bool UE8M0_SF = false, int RESIDUE_PER_8_ELTS = 1>
+__device__ uint32_t cvt_warp_fp16_to_fp4(
+    PackedVec<Type>& vec,
+    float SFScaleVal,
+    uint8_t* SFout,
+    uint8_t mask,
+    uint32_t* residueDataOut,
+    uint8_t* residueSFOut) {
+  constexpr int RESIDUE_PER_THREAD = get_residue_per_thread<RESIDUE_PER_8_ELTS>();
+  // Main quantization.
+  auto localMax = __habs2(vec.elts[0]);
+
+#pragma unroll
+  for (int i = 1; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    localMax = __hmax2(localMax, __habs2(vec.elts[i]));
+  }
+  localMax = __hmax2(__shfl_xor_sync(uint32_t(-1), localMax, 1), localMax);
+  float vecMax = float(__hmax(localMax.x, localMax.y));
+
+  float SFValue = SFScaleVal * (vecMax * reciprocal_approximate_ftz(6.0f));
+  SFValue = encode_sf_to_fp8<UE8M0_SF>(SFValue, SFout);
+
+  float outputScale = compute_output_scale_precise(SFValue, SFScaleVal);
+
+  float2 fp2Vals[CVT_FP4_ELTS_PER_THREAD / 2];
+  float2 fp2ValsOriginal[CVT_FP4_ELTS_PER_THREAD / 2];
+
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    if constexpr (std::is_same_v<Type, half>) {
+      fp2Vals[i] = __half22float2(vec.elts[i]);
+    } else {
+      fp2Vals[i] = __bfloat1622float2(vec.elts[i]);
+    }
+    fp2ValsOriginal[i] = fp2Vals[i];
+    fp2Vals[i].x *= outputScale;
+    fp2Vals[i].y *= outputScale;
+  }
+
+  // Quantize and dequantize.
+  uint32_t e2m1Vec = fp32x8_to_e2m1_with_dequant(fp2Vals);
+
+  // Residue: original - dequantized (in original space).
+  float inverseOutputScale = outputScale != 0 ? reciprocal_approximate_ftz(outputScale) : 0.0f;
+#pragma unroll
+  for (int i = 0; i < CVT_FP4_ELTS_PER_THREAD / 2; i++) {
+    fp2Vals[i].x *= inverseOutputScale;
+    fp2Vals[i].y *= inverseOutputScale;
+    fp2Vals[i].x = fp2ValsOriginal[i].x - fp2Vals[i].x;
+    fp2Vals[i].y = fp2ValsOriginal[i].y - fp2Vals[i].y;
+  }
+
+  // Residue quantization.
+  float residues[RESIDUE_PER_THREAD > 0 ? RESIDUE_PER_THREAD : 1];
+  extract_values_by_mask<RESIDUE_PER_THREAD>(fp2Vals, mask, residues);
+
+  int laneId = threadIdx.x % 32;
+
+  // Phase 1: shared SF for every 16 residues.
+  float localMaxResidue = 0.0f;
+#pragma unroll
+  for (int i = 0; i < RESIDUE_PER_THREAD; i++) {
+    localMaxResidue = fmaxf(localMaxResidue, fabsf(residues[i]));
+  }
+
+  constexpr int THREADS_PER_SF_GROUP = 16 / RESIDUE_PER_THREAD;
+
+  float sfGroupMaxResidue = warp_group_max<THREADS_PER_SF_GROUP>(localMaxResidue, laneId);
+  float residueSFValue = SFScaleVal * (sfGroupMaxResidue * reciprocal_approximate_ftz(6.0f));
+  residueSFValue = encode_sf_to_fp8<UE8M0_SF>(residueSFValue, residueSFOut);
+
+  float residueOutputScale = compute_output_scale_precise(residueSFValue, SFScaleVal);
+
+  float2 scaledResidues2[(RESIDUE_PER_THREAD + 1) / 2];
+#pragma unroll
+  for (int i = 0; i < (RESIDUE_PER_THREAD + 1) / 2; i++) {
+    float val0 = (i * 2 < RESIDUE_PER_THREAD) ? residues[i * 2] * residueOutputScale : 0.0f;
+    float val1 = (i * 2 + 1 < RESIDUE_PER_THREAD) ? residues[i * 2 + 1] * residueOutputScale : 0.0f;
+    scaledResidues2[i] = make_float2(val0, val1);
+  }
+
+  // Two-stage shuffle for the residue extension:
+  //   Stage 1: group-level shuffle - each group collects its residues
+  //   Stage 2: inter-group shuffle - gather from group leaders to the writer
+  //            threads (0-3)
+  constexpr int numThreadsPerGroup = 8 / RESIDUE_PER_THREAD;
+  int groupId = laneId / numThreadsPerGroup;
+  int groupFirstThread = groupId * numThreadsPerGroup;
+
+  float2 groupResidueChunk[4];
+  shuffle_collect_group_float2<RESIDUE_PER_THREAD>(scaledResidues2, groupFirstThread, groupResidueChunk);
+
+  float2 residueChunk2[4];
+  int mySourceGroupLeader = laneId * numThreadsPerGroup;
+
+#pragma unroll
+  for (int i = 0; i < 4; i++) {
+    unsigned long long tmp =
+        __shfl_sync(__activemask(), reinterpret_cast<unsigned long long&>(groupResidueChunk[i]), mySourceGroupLeader);
+    residueChunk2[i] = reinterpret_cast<float2&>(tmp);
+  }
+
+  uint32_t quantizedChunk = fp32_vec_to_e2m1(residueChunk2);
+
+  if (residueDataOut) {
+    *residueDataOut = quantizedChunk;
+  }
+
+  return e2m1Vec;
+}
+
+// ---------------------------------------------------------------------------
+// Output offset helpers
+// ---------------------------------------------------------------------------
+
+// Residue data write address for the standard k_ext extension.
+// Row-interleaved layout: [Row 0: base|residue][Row 1: base|residue]...
+template <class ResidueType, int RESIDUE_PER_8_ELTS>
+__device__ ResidueType*
+cvt_residue_data_get_offset(int rowIdx, int colIdx, int numMainCols, int numTotalCols, ResidueType* outputStart) {
+  constexpr int RESIDUE_PER_THREAD = get_residue_per_thread<RESIDUE_PER_8_ELTS>();
+  constexpr int RESIDUES_PER_WARP = 32 * RESIDUE_PER_THREAD;
+  constexpr int UINT32_PER_WARP = (RESIDUES_PER_WARP + 7) / 8;
+
+  int warpId = colIdx / 32;
+  int laneId = colIdx % 32;
+
+  if (laneId < UINT32_PER_WARP) {
+    int64_t uint32s_per_row = numTotalCols / CVT_FP4_ELTS_PER_UINT32;
+    int64_t base_uint32s_per_row = numMainCols / CVT_FP4_ELTS_PER_UINT32;
+
+    int64_t residueDataIdx = rowIdx * uint32s_per_row + base_uint32s_per_row + warpId * UINT32_PER_WARP + laneId;
+    return outputStart + residueDataIdx;
+  }
+  return nullptr;
+}
+
+// Residue data write address for the SWAP extension: each group's first
+// thread writes the quantized salient chunk.
+template <class ResidueType, int RESIDUE_PER_8_ELTS>
+__device__ ResidueType*
+cvt_swap_residue_data_get_offset(int rowIdx, int colIdx, int numMainCols, int numTotalCols, ResidueType* outputStart) {
+  constexpr int RESIDUE_PER_THREAD = get_residue_per_thread<RESIDUE_PER_8_ELTS>();
+  constexpr int RESIDUES_PER_WARP = 32 * RESIDUE_PER_THREAD;
+  constexpr int UINT32_PER_WARP = (RESIDUES_PER_WARP + 7) / 8;
+
+  int warpId = colIdx / 32;
+  int laneId = colIdx % 32;
+
+  constexpr int numThreadsPerGroup = 8 / RESIDUE_PER_THREAD;
+  int groupId = laneId / numThreadsPerGroup;
+  int threadInGroup = laneId % numThreadsPerGroup;
+
+  if (threadInGroup == 0 && groupId < UINT32_PER_WARP) {
+    int64_t uint32s_per_row = numTotalCols / CVT_FP4_ELTS_PER_UINT32;
+    int64_t base_uint32s_per_row = numMainCols / CVT_FP4_ELTS_PER_UINT32;
+
+    int64_t residueDataIdx = rowIdx * uint32s_per_row + base_uint32s_per_row + warpId * UINT32_PER_WARP + groupId;
+    return outputStart + residueDataIdx;
+  }
+  return nullptr;
+}
+
+// Tiled (swizzled) scale-factor offset.
+// SF layout [numMTiles, numKTiles, 32 (mTile), 4 (mTile), 4 (kTile)]
+template <class SFType>
+__device__ inline int64_t compute_tiled_sf_offset(int32_t mIdx, int32_t kIdx, int32_t numTotalCols) {
+  int32_t mTileIdx = mIdx / (32 * 4);
+  constexpr int factor = CVT_FP4_SF_VEC_SIZE * 4;  // 64
+  int32_t numKTiles = (numTotalCols + factor - 1) / factor;
+  int64_t mTileStride = numKTiles * 32 * 4 * 4;
+
+  int32_t kTileIdx = (kIdx / 4);
+  int64_t kTileStride = 32 * 4 * 4;
+
+  int32_t outerMIdx = (mIdx % 32);
+  int64_t outerMStride = 4 * 4;
+
+  int32_t innerMIdx = (mIdx % (32 * 4)) / 32;
+  int64_t innerMStride = 4;
+
+  int32_t innerKIdx = (kIdx % 4);
+  int64_t innerKStride = 1;
+
+  return mTileIdx * mTileStride + kTileIdx * kTileStride + outerMIdx * outerMStride + innerMIdx * innerMStride +
+         innerKIdx * innerKStride;
+}
+
+// mext_r1 layout row mapping. layoutMode: 0=concat, 1=row_pair,
+// 3=concat_k (concat_k keeps one output row per token; callers handle its
+// column placement separately).
+__device__ __forceinline__ int32_t compute_mext_r1_base_row(int32_t rowIdx, int32_t numRows, int32_t layoutMode) {
+  (void)numRows;
+  if (layoutMode == 1) {
+    return rowIdx * 2;
+  }
+  return rowIdx;
+}
+
+__device__ __forceinline__ int32_t compute_mext_r1_residue_row(int32_t rowIdx, int32_t numRows, int32_t layoutMode) {
+  if (layoutMode == 1) {
+    return rowIdx * 2 + 1;
+  }
+  return rowIdx + numRows;
+}
+
+template <class SFType, int CVT_FP4_NUM_THREADS_PER_SF>
+__device__ uint8_t* cvt_quant_to_fp4_get_sf_out_offset(int rowIdx, int colIdx, int numTotalCols, SFType* SFout) {
+  static_assert(CVT_FP4_NUM_THREADS_PER_SF == 1 || CVT_FP4_NUM_THREADS_PER_SF == 2);
+
+  // One pair of threads writes one SF to global memory.
+  if (threadIdx.x % CVT_FP4_NUM_THREADS_PER_SF == 0) {
+    // SF vector index (16 elements share one SF in the K dimension).
+    int32_t kIdx = colIdx / CVT_FP4_NUM_THREADS_PER_SF;
+    int32_t mIdx = rowIdx;
+
+    int64_t SFOffset = compute_tiled_sf_offset<SFType>(mIdx, kIdx, numTotalCols);
+    return reinterpret_cast<uint8_t*>(SFout) + SFOffset;
+  }
+  return nullptr;
+}
+
+// Residue scale factor write address for k_ext.
+// One RESIDUE scale factor covers 16 residues == 128/residue_per_8 base
+// channels; the TP sharding rules depend on that grouping (see
+// residue_nvfp4/tp.py).
+template <class ResidueSFType, int RESIDUE_PER_8_ELTS>
+__device__ ResidueSFType*
+cvt_residue_sf_get_offset(int rowIdx, int colIdx, int numTotalCols, int numMainCols, ResidueSFType* residueSFOut) {
+  constexpr int RESIDUE_PER_THREAD = get_residue_per_thread<RESIDUE_PER_8_ELTS>();
+  // Every 16 residues share 1 SF:
+  //   ratio 1:8 -> 16 threads per SF group, 2:8 -> 8, 4:8 -> 4
+  constexpr int THREADS_PER_SF_GROUP = 16 / RESIDUE_PER_THREAD;
+
+  int warpId = colIdx / 32;
+  int laneId = colIdx % 32;
+
+  int sfGroupId = laneId / THREADS_PER_SF_GROUP;
+  int sfGroupThreadId = laneId % THREADS_PER_SF_GROUP;
+
+  // Only the first thread in each SF group writes.
+  if (sfGroupThreadId != 0) return nullptr;
+
+  int warpBaseResidueIdx = warpId * 32 * RESIDUE_PER_THREAD;
+  int sfGroupResidueIdx = sfGroupId * 16;
+  int residueElementIdx = numMainCols + warpBaseResidueIdx + sfGroupResidueIdx;
+
+  int32_t kIdx = residueElementIdx / CVT_FP4_SF_VEC_SIZE;
+  int32_t mIdx = rowIdx;
+  int64_t SFOffset = compute_tiled_sf_offset<ResidueSFType>(mIdx, kIdx, numTotalCols);
+
+  return residueSFOut + SFOffset;
+}
+
+}  // namespace residue_nvfp4
+}  // namespace sglang

--- a/python/sglang/kernels/ops/gemm/__init__.py
+++ b/python/sglang/kernels/ops/gemm/__init__.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
     import torch
 
 _CUDA = frozenset({CapabilityRequirement.CUDA})
+_RESIDUE_BLACKWELL = frozenset(
+    CapabilityRequirement.cuda(min_sm=sm, max_sm=sm) for sm in ((10, 0), (10, 3))
+)
 
 register_kernel(
     KernelSpec(
@@ -161,3 +164,37 @@ for _mod, _fn in _TRITON_KERNELS:
         )
     )
 del _mod, _fn
+
+register_kernel(
+    KernelSpec(
+        op="gemm.residue_fold",
+        backend=KernelBackend.CUTE_DSL,
+        target="sglang.kernels.ops.gemm.residue_fold:run_fold",
+        capabilities=_RESIDUE_BLACKWELL,
+        format_signature=FormatSignature(
+            supported_dtypes=("bfloat16", "float16"),
+            description=(
+                "mext_r1 fold GEMM: row-pair FP4 activation x packed "
+                "FP4 weight, (base, residue) output pairs summed in-kernel"
+            ),
+        ),
+        description="Residue NVFP4 mext_r1 fold GEMM (CuTeDSL, Blackwell).",
+    )
+)
+
+register_kernel(
+    KernelSpec(
+        op="gemm.residue_nvfp4_linear",
+        backend=KernelBackend.CUTE_DSL,
+        target="sglang.kernels.ops.gemm.residue_nvfp4_linear:nvfp4_linear",
+        capabilities=_RESIDUE_BLACKWELL,
+        format_signature=FormatSignature(
+            supported_dtypes=("bfloat16", "float16"),
+            description=(
+                "opaque residue NVFP4 dense linear: quant + GEMM in one op; "
+                "per-layer constants select fold / two-GEMM / plain chains"
+            ),
+        ),
+        description="Residue NVFP4 dense linear dispatch (opaque custom op).",
+    )
+)

--- a/python/sglang/kernels/ops/gemm/residue_fold/__init__.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/__init__.py
@@ -1,0 +1,15 @@
+"""Residue NVFP4 mext_r1 fold GEMM dispatch for Blackwell."""
+
+from sglang.kernels.ops.gemm.residue_fold.fold import (
+    compile_stats,
+    observe_compiles,
+    run_fold,
+    warmup,
+)
+
+__all__ = [
+    "compile_stats",
+    "observe_compiles",
+    "run_fold",
+    "warmup",
+]

--- a/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/__init__.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/__init__.py
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+"""CuTeDSL MExt R1 row-pair fold GEMM for SM100-class GPUs."""
+
+from .host import mext_fold_gemm_sm103  # noqa: F401
+from .tactics import (  # noqa: F401
+    kernel_arch_for_capability,
+    run_fold_default,
+    warmup_fold_default,
+)

--- a/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/fold_epilogue.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/fold_epilogue.py
@@ -1,0 +1,299 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+#
+# MExt R1 pair-fold direct-store epilogue for the SM100/SM103 CuTeDSL
+# block-scaled GEMM. Implemented against the public CuTeDSL helper API
+# (cutlass.utils.gemm.sm100); the calling kernel is the BSD-3-Clause
+# FlashInfer port of CUTLASS's sm103 dense block-scaled example.
+
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+from cutlass.cute.nvgpu import cpasync
+from cutlass.cutlass_dsl import Boolean, Int32, const_expr
+from cutlass.utils.gemm.sm100 import (
+    epilogue_tmem_copy_and_partition,
+    transform_partitioned_tensor_layout,
+)
+
+
+@cute.jit
+def mext_fold_epilogue(
+    gemm_kernel,
+    epi_tidx: Int32,
+    tCtAcc_base: cute.Tensor,
+    tCgC_base: cute.Tensor,
+    epi_tile: cute.Tile,
+    epilogue_op: cutlass.Constexpr,
+    mma_tile_coord_mnl,
+    acc_consumer_state: pipeline.PipelineState,
+    acc_pipeline: pipeline.PipelineAsync,
+    tCcC_base: cute.Tensor = None,
+    mC_mnl: cute.Tensor = None,
+) -> pipeline.PipelineState:
+    """Direct-store epilogue with in-register MExt row-pair folding.
+
+    Contract: the GEMM's logical C is (n_w, m2, l) where m2 = 2*m_tok and the
+    activation (GEMM B) rows are row-pair interleaved [base0, res0, base1,
+    res1, ...]. The caller builds gC/cC from a pair-collapsed view of the
+    physical output D[n_w, m_tok]: logical shape (n_w, (2, m_tok)) with
+    stride (m_tok, (0, 1)), so both members of a (base, residue) pair alias
+    one output address, and the m2 direction is memory-contiguous so the
+    TMEM-load fragment's value mode runs along it.
+
+    The fold sums each adjacent accumulator pair in fp32 before output dtype
+    conversion; both aliased lanes then carry the sum, making the double store
+    benign.
+    """
+    tCgC = transform_partitioned_tensor_layout(tCgC_base)
+    tCtAcc = transform_partitioned_tensor_layout(tCtAcc_base)
+
+    tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = epilogue_tmem_copy_and_partition(
+        gemm_kernel, epi_tidx, tCtAcc, tCgC, epi_tile, gemm_kernel.use_2cta_instrs
+    )
+
+    gC_epi = cute.flat_divide(tCgC, epi_tile)
+    thr_copy_t2r = tiled_copy_t2r.get_slice(epi_tidx)
+    tTR_gC_partitioned = thr_copy_t2r.partition_D(gC_epi)
+    tTR_rC = cute.make_rmem_tensor(
+        tTR_gC_partitioned[(None, None, None, 0, 0, 0, 0, 0)].shape,
+        gemm_kernel.c_dtype,
+    )
+
+    use_predication = tCcC_base is not None and mC_mnl is not None
+    if const_expr(use_predication):
+        tCcC = transform_partitioned_tensor_layout(tCcC_base)
+        cC_epi = cute.flat_divide(tCcC, epi_tile)
+        tTR_cC_partitioned = thr_copy_t2r.partition_D(cC_epi)
+
+    tTR_gC = tTR_gC_partitioned[(None, None, None, None, None, *mma_tile_coord_mnl)]
+    if const_expr(use_predication):
+        tTR_cC = tTR_cC_partitioned[(None, None, None, None, None, *mma_tile_coord_mnl)]
+        tTR_cC = cute.group_modes(tTR_cC, 3, cute.rank(tTR_cC))
+
+    if const_expr(gemm_kernel.overlapping_accum):
+        acc_stage_index = acc_consumer_state.phase
+        reverse_subtile = Boolean(True) if acc_stage_index == 0 else Boolean(False)
+    else:
+        acc_stage_index = acc_consumer_state.index
+    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_stage_index)]
+
+    acc_pipeline.consumer_wait(acc_consumer_state)
+
+    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+    tTR_gC = cute.group_modes(tTR_gC, 3, cute.rank(tTR_gC))
+
+    # Pair members must be adjacent within the fragment's value mode.
+    value_mode_size = cute.size(tTR_rAcc.shape, mode=[0])
+    assert (
+        value_mode_size % 2 == 0
+    ), f"MExt fold requires an even TMEM-load value mode, got {value_mode_size}"
+    frag_size = cute.size(tTR_rAcc.shape)
+
+    # Probe (at trace time) whether the fragment profile supports the
+    # vectorized pair-fold path; vec_ok is a Python constant, so the branch
+    # below is compile-time static (no dynamic type-join in the DSL).
+    _PAIR_EVEN = (((0, None), None), None, None)
+    _PAIR_ODD = (((1, None), None), None, None)
+    tTR_rC_half = None
+    try:
+        _gC_half_probe = tTR_gC[(None, None, None, 0)][_PAIR_EVEN]
+        _rAcc_probe = tTR_rAcc[_PAIR_EVEN]
+        tTR_rC_half = cute.make_rmem_tensor(_gC_half_probe.shape, gemm_kernel.c_dtype)
+    except Exception:
+        tTR_rC_half = None
+    vec_ok = tTR_rC_half is not None
+
+    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+    for subtile_idx in range(subtile_cnt):
+        real_subtile_idx = subtile_idx
+        if const_expr(gemm_kernel.overlapping_accum):
+            # Phase 0 drains in reverse so the columns shared with the other
+            # pseudo-buffer are consumed first (see kernel ctor comment).
+            if reverse_subtile:
+                real_subtile_idx = subtile_cnt - 1 - subtile_idx
+        tTR_gC_subtile = tTR_gC[(None, None, None, real_subtile_idx)]
+        tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+        # Release the accumulator buffer as soon as the shared-column region
+        # (overlapping) / the whole buffer (strict) has been read from TMEM.
+        if const_expr(gemm_kernel.overlapping_accum):
+            release_at = gemm_kernel.iter_acc_early_release_in_epilogue
+        else:
+            release_at = subtile_cnt - 1
+        if subtile_idx == release_at:
+            cute.arch.fence_view_async_tmem_load()
+            with cute.arch.elect_one():
+                acc_pipeline.consumer_release(acc_consumer_state)
+            acc_consumer_state.advance()
+
+        # MExt fold. Vector path: the pair submode is the first submode of
+        # the value mode by construction, so slicing it at 0/1 yields
+        # even/odd half-fragments; one TensorSSA add folds all pairs, and the
+        # even-lane gC slice drops the stride-0 alias mode, leaving
+        # m_tok-contiguous addresses for a vectorized copy. Partitioned
+        # identity coordinates grow monotonically per mode, so one
+        # corner check covers a whole subtile; only ragged M2-edge subtiles
+        # pay per-element guards. vec_ok is trace-time static.
+        half_size = frag_size // 2
+        if const_expr(vec_ok):
+            folded_half = epilogue_op(
+                tTR_rAcc[_PAIR_EVEN].load().to(cutlass.Float32)
+                + tTR_rAcc[_PAIR_ODD].load().to(cutlass.Float32)
+            )
+            tTR_rC_half.store(folded_half.to(gemm_kernel.c_dtype))
+            gC_half = tTR_gC_subtile[_PAIR_EVEN]
+            if const_expr(use_predication):
+                tTR_cC_subtile = tTR_cC[(None, None, None, real_subtile_idx)]
+                if cute.elem_less(tTR_cC_subtile[frag_size - 1], mC_mnl.shape):
+                    cute.autovec_copy(tTR_rC_half, gC_half)
+                else:
+                    cC_half = tTR_cC_subtile[_PAIR_EVEN]
+                    for i in range(half_size):
+                        if cute.elem_less(cC_half[i], mC_mnl.shape):
+                            gC_half[i] = tTR_rC_half[i]
+            else:
+                cute.autovec_copy(tTR_rC_half, gC_half)
+        else:
+            tTR_rFold = cute.make_rmem_tensor(tTR_rAcc.shape, cutlass.Float32)
+            for i in range(0, frag_size, 2):
+                pair_sum = tTR_rAcc[i] + tTR_rAcc[i + 1]
+                tTR_rFold[i] = pair_sum
+                tTR_rFold[i + 1] = pair_sum
+            acc_vec = epilogue_op(tTR_rFold.load()).to(gemm_kernel.c_dtype)
+            tTR_rC.store(acc_vec)
+            if const_expr(use_predication):
+                tTR_cC_subtile = tTR_cC[(None, None, None, real_subtile_idx)]
+                if cute.elem_less(tTR_cC_subtile[frag_size - 1], mC_mnl.shape):
+                    for i in range(0, frag_size, 2):
+                        tTR_gC_subtile[i] = tTR_rC[i]
+                else:
+                    for i in range(0, frag_size, 2):
+                        if cute.elem_less(tTR_cC_subtile[i], mC_mnl.shape):
+                            tTR_gC_subtile[i] = tTR_rC[i]
+            else:
+                for i in range(0, frag_size, 2):
+                    tTR_gC_subtile[i] = tTR_rC[i]
+
+    return acc_consumer_state
+
+
+@cute.jit
+def mext_fold_epilogue_tma(
+    gemm_kernel,
+    epi_tidx: Int32,
+    warp_idx: Int32,
+    tma_atom_c,
+    tCtAcc_base: cute.Tensor,
+    sC: cute.Tensor,
+    tCgC_alias: cute.Tensor,
+    gC_fold_mnl: cute.Tensor,
+    epi_tile: cute.Tile,
+    num_tiles_executed: Int32,
+    epilogue_op: cutlass.Constexpr,
+    mma_tile_coord_mnl,
+    acc_consumer_state: pipeline.PipelineState,
+    acc_pipeline: pipeline.PipelineAsync,
+    c_pipeline,
+) -> pipeline.PipelineState:
+    """TMA-store fold epilogue.
+
+    Accumulator side is stock geometry: t2r partitions against the stride-0
+    alias view (tCgC_alias, m2-wide) exactly like the direct-store variant.
+    After the in-register pair fold the fragment is half-width
+    (one row per thread, m_tok-contiguous), so each thread writes its row of
+    a plain half-width smem tile and the TMA engine bulk-stores that tile to
+    the compact D_t (gC_fold_mnl). TMA clamps at the tensor extent, so no
+    predication is needed. Sequencing mirrors the BSD-3 CUTLASS
+    dense_blockscaled_gemm_persistent example's inline epilogue.
+    """
+    tCgC = transform_partitioned_tensor_layout(tCgC_alias)
+    tCtAcc = transform_partitioned_tensor_layout(tCtAcc_base)
+
+    tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = epilogue_tmem_copy_and_partition(
+        gemm_kernel, epi_tidx, tCtAcc, tCgC, epi_tile, gemm_kernel.use_2cta_instrs
+    )
+
+    epilog_sync_barrier = pipeline.NamedBarrier(
+        barrier_id=gemm_kernel.epilog_sync_bar_id,
+        num_threads=32 * len(gemm_kernel.epilogue_warp_id),
+    )
+
+    _PAIR_EVEN = (((0, None), None), None, None)
+    _PAIR_ODD = (((1, None), None), None, None)
+    _rAcc_half_probe = tTR_rAcc[_PAIR_EVEN]
+    tTR_rC_half = cute.make_rmem_tensor(_rAcc_half_probe.shape, gemm_kernel.c_dtype)
+
+    # TMA partition over the compact fold output. sC: (EPI_M, EPI_N2, STAGE).
+    gC_fold_epi = cute.flat_divide(gC_fold_mnl, gemm_kernel.epi_tile_c)
+    bSG_sC, bSG_gC_all = cpasync.tma_partition(
+        tma_atom_c,
+        0,
+        cute.make_layout(1),
+        cute.group_modes(sC, 0, 2),
+        cute.group_modes(gC_fold_epi, 0, 2),
+    )
+    bSG_gC = bSG_gC_all[(None, None, None, *mma_tile_coord_mnl)]
+    bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+    if const_expr(gemm_kernel.overlapping_accum):
+        acc_stage_index = acc_consumer_state.phase
+        reverse_subtile = Boolean(True) if acc_stage_index == 0 else Boolean(False)
+    else:
+        acc_stage_index = acc_consumer_state.index
+    tTR_tAcc = tTR_tAcc_base[(None, None, None, None, None, acc_stage_index)]
+    acc_pipeline.consumer_wait(acc_consumer_state)
+    tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+
+    subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+    num_prev_subtiles = num_tiles_executed * subtile_cnt
+
+    for subtile_idx in range(subtile_cnt):
+        real_subtile_idx = subtile_idx
+        if const_expr(gemm_kernel.overlapping_accum):
+            # Phase 0 drains in reverse so the shared columns free first.
+            if reverse_subtile:
+                real_subtile_idx = subtile_cnt - 1 - subtile_idx
+        tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+        cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+
+        if const_expr(gemm_kernel.overlapping_accum):
+            release_at = gemm_kernel.iter_acc_early_release_in_epilogue
+        else:
+            release_at = subtile_cnt - 1
+        if subtile_idx == release_at:
+            cute.arch.fence_view_async_tmem_load()
+            with cute.arch.elect_one():
+                acc_pipeline.consumer_release(acc_consumer_state)
+            acc_consumer_state.advance()
+
+        folded_half = epilogue_op(
+            tTR_rAcc[_PAIR_EVEN].load().to(cutlass.Float32)
+            + tTR_rAcc[_PAIR_ODD].load().to(cutlass.Float32)
+        )
+        tTR_rC_half.store(folded_half.to(gemm_kernel.c_dtype))
+
+        # Each thread owns one row of the half-width epi tile (the fragment
+        # has no M/N repeat modes); write it straight into plain smem.
+        c_buffer = (num_prev_subtiles + subtile_idx) % gemm_kernel.num_c_stage
+        sC_row = sC[(epi_tidx, None, c_buffer)]
+        # Transposed staging makes the destination strided (n_w-contiguous
+        # smem): scalar element writes, rank-agnostic via linear indexing.
+        for i in range(cute.size(sC_row.shape)):
+            sC_row[i] = tTR_rC_half[i]
+
+        cute.arch.fence_proxy("async.shared", space="cta")
+        epilog_sync_barrier.arrive_and_wait()
+
+        if warp_idx == gemm_kernel.epilogue_warp_id[0]:
+            cute.copy(
+                tma_atom_c,
+                bSG_sC[(None, c_buffer)],
+                bSG_gC[(None, real_subtile_idx)],
+            )
+            c_pipeline.producer_commit()
+            c_pipeline.producer_acquire()
+        epilog_sync_barrier.arrive_and_wait()
+
+    return acc_consumer_state

--- a/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/host.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/host.py
@@ -1,0 +1,438 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+"""Host entry for the SM103 MExt R1 fold GEMM (CuTeDSL).
+
+Computes D[m_tok, n_w] = fold(A_act[2*m_tok, K] @ W[n_w, K]^T) where the
+activation rows are row-pair interleaved [base0, res0, base1, res1, ...]
+(sglang.kernels.ops.quantization.residue_nvfp4_quant scaled_fp4_quant_mext_r1 layout_mode=row_pair) and fold sums each
+(base, residue) output pair. The kernel writes the transposed compact
+D_t[n_w, m_tok]; callers get [m_tok, n_w] back via a transpose-copy.
+
+Compile/call marshaling mirrors flashinfer's _cute_dsl_gemm_fp4_runner
+(fake tensors + constexpr baking + TVM-FFI env stream).
+"""
+
+from __future__ import annotations
+
+import functools
+
+import torch
+
+_KERNEL_CACHE: dict[tuple, tuple] = {}
+
+# The tactic tables speak `store_mode`; _compile_fold_gemm speaks `mode`.
+# Module-level so the warmup can enumerate the same space the call path
+# reaches, instead of keeping a second copy that drifts.
+STORE_MODE_TO_MODE = {
+    "tma": "fold_tma",
+}
+
+# Valid sm103 tilers: (128|256, 128|256) (flashinfer sm103 candidates).
+DEFAULT_MMA_TILER_MN = (128, 128)
+DEFAULT_CLUSTER_SHAPE_MN = (1, 1)
+SF_VEC_SIZE = 16
+
+
+@functools.lru_cache(maxsize=1)
+def _cutlass_modules():
+    import cutlass
+    import cutlass.cute as cute
+    from cutlass.cute.runtime import make_ptr
+    from flashinfer.cute_dsl.utils import get_max_active_clusters
+
+    from .kernel_sm100_fold import (
+        Sm100BlockScaledPersistentDenseGemmKernel,
+    )
+    from .kernel_sm103_fold import (
+        Sm103BlockScaledPersistentDenseGemmKernel,
+    )
+
+    return (
+        cutlass,
+        cute,
+        make_ptr,
+        get_max_active_clusters,
+        {
+            "sm100": Sm100BlockScaledPersistentDenseGemmKernel,
+            "sm103": Sm103BlockScaledPersistentDenseGemmKernel,
+        },
+    )
+
+
+def _compile_fold_gemm(
+    mma_tiler_mn: tuple[int, int],
+    cluster_shape_mn: tuple[int, int],
+    out_dtype: torch.dtype,
+    mode: str = "fold_tma",
+    kernel_arch: str = "sm103",
+    ab_stage_override: int | None = None,
+    strided_weight: bool = False,
+):
+    """Compile a fold-GEMM kernel variant:
+
+    - "fold_tma":         N-ext fold, register fold + TMA store
+    - "plain_tma":        stock kernel/epilogue baseline (no fold)
+
+    (The former "fold_direct" tiny-m mode was removed: dominated at every
+    m_tok after the transposed-staging fold_tma optimization -- see
+    fold_vs_plain_latency_results.md.)
+    """
+    assert mode in ("fold_tma", "plain_tma", "kloop_tma"), mode
+    assert kernel_arch in ("sm100", "sm103"), kernel_arch
+    assert kernel_arch == "sm103" or mode in ("fold_tma", "plain_tma", "kloop_tma")
+    # kloop_tma: wrapped-K-loop -- act (K-concat, 2K) as A, weight as B with a
+    # wrapped k coordinate, PLAIN epilogue writing C[m_tok, n_w]. sm100-only,
+    # single-alpha.
+    assert mode != "kloop_tma" or (
+        kernel_arch == "sm100" and not strided_weight
+    ), "kloop_tma: sm100, single-alpha"
+    # The AB depth knob is sm100-only (the sm103 ctor has no such param).
+    assert (
+        kernel_arch == "sm100" or ab_stage_override is None
+    ), "ab_stage_override is sm100-only"
+    key = (
+        mma_tiler_mn,
+        cluster_shape_mn,
+        out_dtype,
+        mode,
+        kernel_arch,
+        ab_stage_override,
+        strided_weight,
+    )
+    if key in _KERNEL_CACHE:
+        return _KERNEL_CACHE[key]
+
+    cutlass, cute, make_ptr, get_max_active_clusters, kernel_classes = (
+        _cutlass_modules()
+    )
+    kernel_cls = kernel_classes[kernel_arch]
+    c_cutlass_dtype = (
+        cutlass.BFloat16 if out_dtype == torch.bfloat16 else cutlass.Float16
+    )
+
+    if kernel_arch == "sm100":
+        # sm100 kernel always TMA-stores; no use_tma_store knob.
+        gemm = kernel_cls(
+            sf_vec_size=SF_VEC_SIZE,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            enable_pdl=True,
+            fold_pairs_tma=(mode == "fold_tma"),
+            ab_stage_override=ab_stage_override,
+            k_loop=(mode == "kloop_tma"),
+        )
+    else:
+        gemm = kernel_cls(
+            sf_vec_size=SF_VEC_SIZE,
+            mma_tiler_mn=mma_tiler_mn,
+            cluster_shape_mn=cluster_shape_mn,
+            use_tma_store=True,
+            fold_pairs_tma=(mode == "fold_tma"),
+        )
+
+    sym_m = cute.sym_int()  # n_w (weight rows)
+    sym_n = cute.sym_int()  # m2 = 2 * m_tok
+    sym_k = cute.sym_int()
+    sym_mtok = cute.sym_int()
+
+    # N-ext uses mA=weight and mB=activation. kloop_tma swaps the operands.
+    _a_rows, _b_rows = (sym_n, sym_m) if mode == "kloop_tma" else (sym_m, sym_n)
+    # `strided_weight` supports an ext-K residue layer WITHOUT materialising a
+    # base-K copy: the problem's K is k_base, but the weight rows are k_ext
+    # apart because the tensor is a `weight_ext[:, :k_base_packed]` view.
+    # The B-side scale needs no special handling: `weight_scale_base` is
+    # already the re-swizzled base-K prefix, and sf_k derives from k_base.
+    #
+    # Only the weight operand gets a dynamic leading dim; the activation is
+    # freshly quantised and always compact.
+    #
+    # A compact tensor keeps its own cache entry (strided_weight=False), so the
+    # validated contiguous path compiles to exactly the same binary as before.
+    _w_is_a = mode != "kloop_tma"
+
+    def _operand(rows, is_weight):
+        if strided_weight and is_weight:
+            return cute.runtime.make_fake_tensor(
+                cutlass.Uint8,
+                (rows, sym_k),
+                (cute.sym_int(), 1),
+                assumed_align=32,
+            )
+        return cute.runtime.make_fake_compact_tensor(
+            cutlass.Uint8, (rows, sym_k), stride_order=(1, 0), assumed_align=32
+        )
+
+    a_fake = _operand(_a_rows, _w_is_a)
+    b_fake = _operand(_b_rows, not _w_is_a)
+    if mode == "kloop_tma":
+        # A is the K-concat activation at 2K -- its own symbolic K, unrelated
+        # to B's (the weight's) sym_k. The kernel takes trip count from A and
+        # wraps B; runtime shapes enforce the 2x relation.
+        a_fake = cute.runtime.make_fake_compact_tensor(
+            cutlass.Uint8,
+            (_a_rows, cute.sym_int()),
+            stride_order=(1, 0),
+            assumed_align=32,
+        )
+    if mode == "kloop_tma":
+        # Plain epilogue, C = [act_rows(m_tok), n_w] row-major -- no fold,
+        # no transpose: the operand swap already put tokens on GEMM-M.
+        c_fake = cute.runtime.make_fake_compact_tensor(
+            c_cutlass_dtype,
+            (sym_n, sym_m),
+            stride_order=(1, 0),
+            assumed_align=16,
+        )
+    elif mode == "fold_tma":
+        # Physical output: row-major D[m_tok, n_w], written through a
+        # transposed TMA view.
+        c_fake = cute.runtime.make_fake_compact_tensor(
+            c_cutlass_dtype,
+            (sym_mtok, sym_m),
+            stride_order=(1, 0),
+            assumed_align=16,
+        )
+    else:
+        # Stock C [n_w, m2] row-major.
+        c_fake = cute.runtime.make_fake_compact_tensor(
+            c_cutlass_dtype,
+            (sym_m, sym_n),
+            stride_order=(1, 0),
+            assumed_align=16,
+        )
+    a_sf_ptr = make_ptr(cutlass.Float8E4M3FN, 16, cute.AddressSpace.gmem, 16)
+    b_sf_ptr = make_ptr(cutlass.Float8E4M3FN, 16, cute.AddressSpace.gmem, 16)
+    alpha_fake = cute.runtime.make_fake_compact_tensor(
+        cutlass.Float32, (1,), assumed_align=4
+    )
+    max_active_clusters = get_max_active_clusters(
+        cluster_shape_mn[0] * cluster_shape_mn[1]
+    )
+    stream_fake = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
+
+    if kernel_arch == "sm100":
+        # sm100 wrapper keeps current_stream but has NO fold_pairs param
+        # (the fork keys off self.fold_pairs_tma set in the constructor).
+        compiled = cute.compile(
+            gemm.wrapper,
+            a_fake,
+            b_fake,
+            c_fake,
+            1,
+            1,
+            1,
+            1,  # l
+            a_sf_ptr,
+            b_sf_ptr,
+            alpha_fake,
+            max_active_clusters,
+            stream_fake,
+            False,  # swap_ab
+            lambda x: x,  # epilogue_op (alpha applied inside the kernel)
+            options="--opt-level 2 --enable-tvm-ffi",
+        )
+    else:
+        compiled = cute.compile(
+            gemm.wrapper,
+            a_fake,
+            b_fake,
+            c_fake,
+            # Int64-typed dynamic args: any concrete int marshals at compile
+            # time; the real per-call values are passed at runtime.
+            1,
+            1,
+            1,
+            1,  # l
+            a_sf_ptr,
+            b_sf_ptr,
+            alpha_fake,
+            max_active_clusters,
+            stream_fake,
+            False,  # swap_ab
+            lambda x: x,  # epilogue_op (alpha applied inside the kernel)
+            mode == "fold_tma",  # wrapper fold_pairs
+            options="--opt-level 2 --enable-tvm-ffi",
+        )
+    _KERNEL_CACHE[key] = compiled
+    return compiled
+
+
+def _ceil_div(a: int, b: int) -> int:
+    return (a + b - 1) // b
+
+
+def mext_fold_gemm_sm103(
+    weight_fp4: torch.Tensor,
+    act_fp4_rowpair: torch.Tensor,
+    weight_sf: torch.Tensor,
+    act_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    out_dtype: torch.dtype = torch.bfloat16,
+    mma_tiler_mn: tuple[int, int] = DEFAULT_MMA_TILER_MN,
+    cluster_shape_mn: tuple[int, int] = DEFAULT_CLUSTER_SHAPE_MN,
+    store_mode: str = "tma",
+    kernel_arch: str = "sm103",
+    ab_stage_override: int | None = None,
+) -> torch.Tensor:
+    """Run the fold GEMM. Returns D[m_tok, n_w].
+
+    Args:
+        weight_fp4: [n_w, k_base // 2] uint8 packed FP4, K-major. May be a
+            `weight_ext[:, :k_base_packed]` VIEW of an ext-K residue weight;
+            the row stride is read from the tensor, so no base-K copy is
+            needed. Must stay contiguous within a row.
+        act_fp4_rowpair: [2 * m_tok, k // 2] uint8 packed FP4, row-pair layout.
+        weight_sf: swizzled 128x4 FP8 scale for the k_base prefix
+            (quant.vllm_integration layout_utils weight_scale_base).
+        act_sf: swizzled 128x4 FP8 scale from scaled_fp4_quant_mext_r1.
+        alpha: float32 scalar tensor (global dequant scale product).
+    """
+    n_w, k_packed = weight_fp4.shape
+    m2 = act_fp4_rowpair.shape[0]
+    assert m2 % 2 == 0, "activation must be row-pair interleaved (even rows)"
+    m_tok = m2 // 2
+    k = k_packed * 2
+
+    # ext-K residue: `weight_fp4` may be a `weight_ext[:, :k_base_packed]` view,
+    # so its row stride is k_ext_packed while its width is k_base_packed. The
+    # shape already gives the problem K (= k_base); the stride is what tells the
+    # kernel how far apart the rows sit. Detect it here rather than making the
+    # caller pass k_ext -- a narrowed view carries the fact already, and a
+    # caller-supplied value could disagree with the tensor silently.
+    _w_ld = weight_fp4.stride(0)
+    _strided_w = _w_ld != k_packed
+    if _strided_w:
+        assert weight_fp4.stride(1) == 1, (
+            "weight must stay K-contiguous within a row; got stride "
+            f"{weight_fp4.stride()}"
+        )
+        assert (
+            _w_ld > k_packed
+        ), f"weight row stride {_w_ld} < width {k_packed}: rows would overlap"
+        # TMA needs the row starts aligned, and the operands are declared
+        # assumed_align=32. A contiguous weight satisfies this via k_packed;
+        # a strided one must satisfy it via the EXT width. Every ext layer in
+        # the exported checkpoints does (k_ext in {2880,3200,3840,12160,14592}
+        # -> packed strides all %32 == 0), but a coarser salient granularity
+        # could break it, so refuse loudly instead of corrupting the read.
+        assert _w_ld % 32 == 0, (
+            f"strided weight row stride {_w_ld} is not 32B-aligned; "
+            "materialise a contiguous base-K prefix for this layer"
+        )
+    if act_fp4_rowpair.stride(0) != k_packed or act_fp4_rowpair.stride(1) != 1:
+        # The activation is produced by scaled_fp4_quant_mext_r1 and is always
+        # compact; only the weight operand has a dynamic leading dim compiled in.
+        raise ValueError(
+            f"activation must be compact [{m2}, {k_packed}]; got stride "
+            f"{act_fp4_rowpair.stride()}"
+        )
+
+    _mode = STORE_MODE_TO_MODE[store_mode]
+
+    compiled = _compile_fold_gemm(
+        mma_tiler_mn,
+        cluster_shape_mn,
+        out_dtype,
+        mode=_mode,
+        kernel_arch=kernel_arch,
+        ab_stage_override=ab_stage_override,
+        strided_weight=_strided_w,
+    )
+
+    alpha_t = alpha.reshape(1).to(torch.float32)
+    sf_m = _ceil_div(n_w, 128)  # weight scale-factor tiles
+    sf_n = _ceil_div(m2, 128)  # activation scale-factor tiles
+    sf_k = _ceil_div(k, SF_VEC_SIZE * 4)
+
+    if store_mode == "tma":
+        # N-ext: kernel writes row-major D[m_tok, n_w] via a transposed TMA view.
+        d_t = torch.empty(m_tok, n_w, dtype=out_dtype, device=weight_fp4.device)
+        if kernel_arch == "sm100":
+            compiled(
+                weight_fp4,
+                act_fp4_rowpair,
+                d_t,
+                sf_m,
+                sf_n,
+                sf_k,
+                weight_sf.data_ptr(),
+                act_sf.data_ptr(),
+                alpha_t,
+            )
+        else:
+            compiled(
+                weight_fp4,
+                act_fp4_rowpair,
+                d_t,
+                sf_m,
+                sf_n,
+                sf_k,
+                weight_sf.data_ptr(),
+                act_sf.data_ptr(),
+                alpha_t,
+            )
+        return d_t
+
+    raise ValueError(f"unknown store_mode {store_mode!r}")
+
+
+def kext_kloop_gemm_sm100(
+    weight_fp4: torch.Tensor,
+    act_fp4_kext: torch.Tensor,
+    weight_sf: torch.Tensor,
+    act_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    out_dtype=None,
+    mma_tiler_mn: tuple[int, int] = DEFAULT_MMA_TILER_MN,
+    cluster_shape_mn: tuple[int, int] = DEFAULT_CLUSTER_SHAPE_MN,
+) -> torch.Tensor:
+    """Wrapped-K-loop GEMM on sm100: D[m_tok, n_w] = act[m_tok, 2K] @ [W|W]^T
+    with the weight stored ONCE (its k coordinate wraps in the kernel).
+
+    weight_fp4:   [n_w, k/2] uint8 packed FP4, K-major, contiguous.
+    act_fp4_kext: [m_tok, k] uint8 -- the K-concat quant output
+                  (`scaled_fp4_quant_mext_r1(layout_mode="concat_k")`): 2K
+                  elements per row, base in cols [0, K), residue in [K, 2K).
+    act_sf:       SF bytes in canonical (m_tok, 2K) atom order.
+    weight_sf:    swizzled SF for (n_w, K).
+
+    Compiles ONCE per (tile, dtype): every dim is symbolic, so serving m is
+    a free variable -- no bucket grid needed on this arch.
+    """
+    import torch
+
+    out_dtype = out_dtype or torch.bfloat16
+    n_w, k_packed = weight_fp4.shape
+    k = k_packed * 2
+    assert (
+        weight_fp4.stride(0) == k_packed and weight_fp4.stride(1) == 1
+    ), "kloop_tma expects a contiguous weight (mext_r1 weights are)"
+    m_tok = act_fp4_kext.shape[0]
+    assert act_fp4_kext.shape[1] == k, (
+        f"activation must be [rows, {k}] bytes (2K elements), got "
+        f"{tuple(act_fp4_kext.shape)}"
+    )
+
+    compiled = _compile_fold_gemm(
+        tuple(mma_tiler_mn),
+        tuple(cluster_shape_mn),
+        out_dtype,
+        mode="kloop_tma",
+        kernel_arch="sm100",
+    )
+    d_t = torch.empty(m_tok, n_w, dtype=out_dtype, device=weight_fp4.device)
+    alpha_t = alpha.reshape(1).to(torch.float32).contiguous()
+    # wrapper (sf_m, sf_n, sf_k) = A-side rows/128, B-side rows/128, BASE-K
+    # groups (the wrapper doubles the A side under k_loop).
+    compiled(
+        act_fp4_kext,
+        weight_fp4,
+        d_t,
+        _ceil_div(m_tok, 128),
+        _ceil_div(n_w, 128),
+        _ceil_div(k // SF_VEC_SIZE, 4),
+        act_sf.data_ptr(),
+        weight_sf.data_ptr(),
+        alpha_t,
+    )
+    return d_t

--- a/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/kernel_sm100_fold.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/kernel_sm100_fold.py
@@ -1,0 +1,2389 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# This file is ported from TensorRT-LLM's dense_blockscaled_gemm_persistent.py
+# with modifications for FlashInfer integration.
+# Original: https://github.com/NVIDIA/TensorRT-LLM
+#
+# Adapted from FlashInfer's dense_blockscaled_gemm_sm100.py for residue fold.
+
+from typing import Optional, Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+
+# ResInfer fork shim: cutlass-dsl 4.6 removed the deprecated make_fragment*
+# aliases this kernel still uses (identical signatures, verified in 4.5.2).
+if not hasattr(cute, "make_fragment"):
+    cute.make_fragment = cute.make_rmem_tensor
+if not hasattr(cute, "make_fragment_like") and hasattr(cute, "make_rmem_tensor_like"):
+    cute.make_fragment_like = cute.make_rmem_tensor_like
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm100_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.arch import griddepcontrol_launch_dependents, griddepcontrol_wait
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.pipeline import PipelineTmaUmma, PipelineUmmaAsync
+
+
+class Sm100BlockScaledPersistentDenseGemmKernel:
+    """Implements batched matrix multiplication (C = A x SFA x B x SFB) with support for various data types
+    and Blackwell GPU architectural features, including persistent tile scheduling and warp specialization.
+
+    Notes:
+        - In the current version, tensors A and B must have the same data type.
+          For example, using Float8E4M3FN for A and Float8E5M2 for B is not supported.
+        - Supported combinations of A/B data types, scale factor (SF) data types, and SF vector size:
+            * MXF8:   A/B: Float8E5M2/Float8E4M3FN, SF: Float8E8M0FNU, sf_vec_size: 32
+            * MXF4:   A/B: Float4E2M1FN,            SF: Float8E8M0FNU, sf_vec_size: 32
+            * NVF4:   A/B: Float4E2M1FN,            SF: Float8E8M0FNU/Float8E4M3FN, sf_vec_size: 16
+        - Supported accumulator data types:
+            * Float32
+        - Supported C data types:
+            * Float32
+            * Float16/BFloat16
+            * Float8E4M3FN/Float8E5M2
+        - Constraints:
+            * MMA tiler M must be 128 or 256 (use_2cta_instrs).
+            * MMA tiler N must be 64/128/192/256
+            * Cluster shape M must be a multiple of 2 if MMA tiler M is 256.
+            * Cluster shape M/N must be positive and a power of 2, with total cluster size <= 16.
+            * Cluster shape M/N must be <= 4 for scale factor multicasts due to limited scale factor size.
+
+    Example:
+        >>> gemm = Sm100BlockScaledPersistentDenseGemmKernel(
+        ...     sf_vec_size=16,
+        ...     mma_tiler_mn=(256, 128),
+        ...     cluster_shape_mn=(2, 1)
+        ... )
+        >>> gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, max_active_clusters, stream)
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        enable_pdl: bool = True,
+        fold_pairs_tma: bool = False,
+        ab_stage_override: int | None = None,
+        k_loop: bool = False,
+    ):
+        """Initializes the configuration for a Blackwell dense GEMM kernel.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator, always set to Float32
+            - sf_vec_size: Scalefactor A/B vector size.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        Args:
+            sf_vec_size (int): Scalefactor vector size.
+            mma_tiler_mn (Tuple[int, int]): Shape of the Matrix Multiply-Accumulate (MMA) tile (M, N).
+            cluster_shape_mn (Tuple[int, int]): Cluster dimensions (M, N) for parallel processing.
+        """
+
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        # ResInfer MExt: TMA-store fold mode (see cute_fold/fold_epilogue.py).
+        # Accumulator/SF side keeps stock m2-wide geometry; only the C/TMA
+        # side switches to half-width tiles over compact row-major D.
+        self.fold_pairs_tma = fold_pairs_tma
+        # AB pipeline depth (None = stock heuristic). The fold needs this knob
+        # for real: _compute_stages spends the smem budget BEFORE
+        # _setup_attributes doubles num_c_stage for half-width C staging, so at
+        # narrow tile_N the auto depth overshoots and the launch dies with
+        # cudaErrorInvalidValue. One stage back is enough; see the tactic
+        # table's four-element entries.
+        self.ab_stage_override = ab_stage_override
+        # Wrapped K-loop: A carries the K-concat activation at 2K, while B is
+        # read twice by wrapping
+        # its k coordinate at the midpoint, the MMA's own K-reduction performs
+        # the base+residue fold, and the PLAIN epilogue stores C[m_tok, n_w].
+        # Weight bytes in memory: 1x.
+        self.k_loop = k_loop
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        self.enable_pdl = enable_pdl
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        self.occupancy = 1
+        # Set specialized warp ids
+        self.epilog_warp_id = (
+            0,
+            1,
+            2,
+            3,
+        )
+        self.mma_warp_id = 4
+        self.tma_warp_id = 5
+        self.threads_per_cta = 32 * len(
+            (self.mma_warp_id, self.tma_warp_id, *self.epilog_warp_id)
+        )
+        # Set barrier id for cta sync, epilogue sync and tmem ptr sync
+        self.cta_sync_bar_id = 0
+        self.epilog_sync_bar_id = 1
+        self.tmem_ptr_sync_bar_id = 2
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_100")
+        SM100_TMEM_CAPACITY_COLUMNS = 512
+        self.num_tmem_alloc_cols = SM100_TMEM_CAPACITY_COLUMNS
+
+    def _setup_attributes(self):
+        """Set up configurations that are dependent on GEMM inputs
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B/SFA/SFB
+        - Computing epilogue subtile
+        - Setting up A/B/SFA/SFB/C stage counts in shared memory
+        - Computing A/B/SFA/SFB/C shared memory layout
+        - Computing tensor memory allocation columns
+        """
+        # Compute mma instruction shapes
+        mma_inst_bits_k = 256
+        # (MMA_Tile_Shape_M, MMA_Tile_Shape_N, MMA_Inst_Shape_K)
+        self.mma_inst_shape_mnk = (
+            self.mma_tiler[0],
+            self.mma_tiler[1],
+            mma_inst_bits_k // self.a_dtype.width,
+        )
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        self.mma_inst_shape_mnk_sfb = (
+            self.mma_inst_shape_mnk[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mnk[1], 128),
+            self.mma_inst_shape_mnk[2],
+        )
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mnk[:2],
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mnk_sfb[:2],
+        )
+
+        # Compute mma/cluster/tile shapes
+        mma_inst_tile_k = 4
+        self.mma_tiler = (
+            self.mma_inst_shape_mnk[0],
+            self.mma_inst_shape_mnk[1],
+            self.mma_inst_shape_mnk[2] * mma_inst_tile_k,
+        )
+        self.mma_tiler_sfb = (
+            self.mma_inst_shape_mnk_sfb[0],
+            self.mma_inst_shape_mnk_sfb[1],
+            self.mma_inst_shape_mnk_sfb[2] * mma_inst_tile_k,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        self.cta_tile_shape_mnk_sfb = (
+            self.mma_tiler_sfb[0] // cute.size(tiled_mma.thr_id.shape),
+            self.mma_tiler_sfb[1],
+            self.mma_tiler_sfb[2],
+        )
+
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+        self.tma_cluster_layout_vmnk = self.cluster_layout_vmnk
+        self.tma_cluster_layout_sfb_vmnk = self.cluster_layout_sfb_vmnk
+
+        # Compute epilogue subtile
+        self.epi_tile = sm100_utils.compute_epilogue_tile_shape(
+            self.cta_tile_shape_mnk,
+            self.use_2cta_instrs,
+            self.c_layout,
+            self.c_dtype,
+        )
+
+        self.epi_tile_n = cute.size(self.epi_tile[1])
+        # Half-width C-side epi tile for the TMA fold path.
+        # epi_tile stays untouched for the acc/SF side (num_sf_tmem_cols is
+        # budgeted with epi_tile_n -- do not couple it to the C side).
+        self.epi_tile_c = (
+            cute.size(self.epi_tile[0]),
+            self.epi_tile_n // 2,
+        )
+
+        # Setup A/B/C stage count in shared memory and ACC stage count in tensor memory
+        self.num_acc_stage, self.num_ab_stage, self.num_c_stage = self._compute_stages(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_dtype,
+            self.b_major_mode,
+            self.epi_tile,
+            self.c_dtype,
+            self.c_layout,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.smem_capacity,
+            self.occupancy,
+        )
+        # ab clamps down only -- the heuristic is already smem-greedy-max.
+        if self.ab_stage_override is not None:
+            if self.ab_stage_override > self.num_ab_stage:
+                raise ValueError(
+                    f"ab_stage_override {self.ab_stage_override} exceeds smem-max "
+                    f"{self.num_ab_stage}"
+                )
+            self.num_ab_stage = self.ab_stage_override
+
+        # Compute A/B/SFA/SFB/C shared memory layout
+        self.a_smem_layout_staged = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.a_dtype,
+            self.num_ab_stage,
+        )
+        self.b_smem_layout_staged = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.b_dtype,
+            self.num_ab_stage,
+        )
+        self.sfa_smem_layout_staged = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        self.sfb_smem_layout_staged = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_ab_stage,
+        )
+        if self.fold_pairs_tma:
+            # N-ext: transposed half-width plain staging (n_w contiguous): TMA box
+            # lands directly on row-major D[m_tok, n_w]; half-width frees
+            # smem -> spend it on 2x stages (fewer TMA-drain waits). Threads
+            # write one strided row each; swizzle buys nothing here.
+            self.num_c_stage *= 2
+            _epi_m = cute.size(self.epi_tile[0])
+            _epi_n2 = self.epi_tile_n // 2
+            self.c_smem_layout_staged = cute.make_layout(
+                (_epi_m, _epi_n2, self.num_c_stage),
+                stride=(1, _epi_m, _epi_m * _epi_n2),
+            )
+        else:
+            self.c_smem_layout_staged = sm100_utils.make_smem_layout_epi(
+                self.c_dtype,
+                self.c_layout,
+                self.epi_tile,
+                self.num_c_stage,
+            )
+
+        # Overlapping accumulators use two pseudo-buffers at stride 256-SF-cols,
+        # reversed drain on phase 0, and early release.
+        self.overlapping_accum = self.num_acc_stage == 1
+        sf_atom_mn = 32
+        self.num_sfa_tmem_cols = (
+            self.cta_tile_shape_mnk[0] // sf_atom_mn
+        ) * mma_inst_tile_k
+        self.num_sfb_tmem_cols = (
+            self.cta_tile_shape_mnk_sfb[1] // sf_atom_mn
+        ) * mma_inst_tile_k
+        self.num_sf_tmem_cols = self.num_sfa_tmem_cols + self.num_sfb_tmem_cols
+        self.num_accumulator_tmem_cols = (
+            self.cta_tile_shape_mnk[1] * self.num_acc_stage
+            if not self.overlapping_accum
+            else self.cta_tile_shape_mnk[1] * 2 - self.num_sf_tmem_cols
+        )
+        if (self.num_accumulator_tmem_cols + self.num_sf_tmem_cols) > 512:
+            raise ValueError(
+                f"TMEM over budget: acc {self.num_accumulator_tmem_cols} + sf "
+                f"{self.num_sf_tmem_cols} > 512 cols "
+                f"(num_acc_stage={self.num_acc_stage})"
+            )
+
+        # Only when overlapping_accum is enabled, we need to release accumulator buffer early in epilogue
+        self.iter_acc_early_release_in_epilogue = (
+            self.num_sf_tmem_cols // self.epi_tile_n
+        )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor,
+        b_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor,
+        sfb_tensor: cute.Tensor,
+        c_tensor: cute.Tensor,
+        alpha: cute.Tensor,  # Single-element tensor containing alpha value
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+        c_alias_tensor: cute.Tensor = None,
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes before smem/grid/tma computation
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size with regard to hardware constraints
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        Args:
+            a_tensor (cute.Tensor): Input tensor A
+            b_tensor (cute.Tensor): Input tensor B
+            sfa_tensor (cute.Tensor): Scale factor tensor A
+            sfb_tensor (cute.Tensor): Scale factor tensor B
+            c_tensor (cute.Tensor): Output tensor C
+            max_active_clusters (cutlass.Constexpr): Maximum number of active clusters
+            stream (cuda.CUstream): CUDA stream for asynchronous execution
+            epilogue_op (cutlass.Constexpr): Optional elementwise lambda function to apply to the output tensor
+
+        Raises:
+            TypeError: If input data types are incompatible with the MMA instruction.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        if cutlass.const_expr(self.fold_pairs_tma):
+            # N-ext: physical C is the transposed D view (m-major); pin the enum
+            # to the n-major fiction so the TMEM-load atom keeps the
+            # pair-in-value-mode fragment orientation the fold relies on
+            # (this also feeds compute_epilogue_tile_shape upstream).
+            self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        else:
+            self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        # ((Atom_M, Rest_M),(Atom_K, Rest_K),RestL)
+        sfa_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            a_tensor.shape, self.sf_vec_size
+        )
+        sfa_tensor = cute.make_tensor(sfa_tensor.iterator, sfa_layout)
+
+        # ((Atom_N, Rest_N),(Atom_K, Rest_K),RestL)
+        sfb_layout = blockscaled_utils.tile_atom_to_shape_SF(
+            b_tensor.shape, self.sf_vec_size
+        )
+        sfb_tensor = cute.make_tensor(sfb_tensor.iterator, sfb_layout)
+
+        tiled_mma = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mnk[:2],
+        )
+
+        tiled_mma_sfb = sm100_utils.make_blockscaled_trivial_tiled_mma(
+            self.a_dtype,
+            self.a_major_mode,
+            self.b_major_mode,
+            self.sf_dtype,
+            self.sf_vec_size,
+            cute.nvgpu.tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mnk_sfb[:2],
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        a_smem_layout = cute.slice_(self.a_smem_layout_staged, (None, None, None, 0))
+        tma_atom_a, tma_tensor_a = cute.nvgpu.make_tiled_tma_atom_A(
+            a_op,
+            a_tensor,
+            a_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.tma_cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for B
+        b_op = sm100_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        b_smem_layout = cute.slice_(self.b_smem_layout_staged, (None, None, None, 0))
+        tma_atom_b, tma_tensor_b = cute.nvgpu.make_tiled_tma_atom_B(
+            b_op,
+            b_tensor,
+            b_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.tma_cluster_layout_vmnk.shape,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm100_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.make_tiled_tma_atom_A(
+            sfa_op,
+            sfa_tensor,
+            sfa_smem_layout,
+            self.mma_tiler,
+            tiled_mma,
+            self.tma_cluster_layout_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm100_utils.cluster_shape_to_tma_atom_SFB(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.make_tiled_tma_atom_B(
+            sfb_op,
+            sfb_tensor,
+            sfb_smem_layout,
+            self.mma_tiler_sfb,
+            tiled_mma_sfb,
+            self.tma_cluster_layout_sfb_vmnk.shape,
+            internal_type=cutlass.Int16,
+        )
+        if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+            x = tma_tensor_sfb.stride[0][1]
+            y = cute.ceil_div(tma_tensor_sfb.shape[0][1], 4)
+
+            new_shape = (
+                (tma_tensor_sfb.shape[0][0], ((2, 2), y)),
+                tma_tensor_sfb.shape[1],
+                tma_tensor_sfb.shape[2],
+            )
+            # Use right multiplication for ScaledBasis (3 * x instead of x * 3)
+            x_times_3 = 3 * x
+            new_stride = (
+                (tma_tensor_sfb.stride[0][0], ((x, x), x_times_3)),
+                tma_tensor_sfb.stride[1],
+                tma_tensor_sfb.stride[2],
+            )
+            tma_tensor_sfb_new_layout = cute.make_layout(new_shape, stride=new_stride)
+            tma_tensor_sfb = cute.make_tensor(
+                tma_tensor_sfb.iterator, tma_tensor_sfb_new_layout
+            )
+
+        a_copy_size = cute.size_in_bytes(self.a_dtype, a_smem_layout)
+        b_copy_size = cute.size_in_bytes(self.b_dtype, b_smem_layout)
+        sfa_copy_size = cute.size_in_bytes(self.sf_dtype, sfa_smem_layout)
+        sfb_copy_size = cute.size_in_bytes(self.sf_dtype, sfb_smem_layout)
+        self.num_tma_load_bytes = (
+            a_copy_size + b_copy_size + sfa_copy_size + sfb_copy_size
+        ) * atom_thr_size
+
+        # Setup TMA store for C.
+        epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+        tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+            cpasync.CopyBulkTensorTileS2GOp(),
+            c_tensor,
+            epi_smem_layout,
+            self.epi_tile_c if self.fold_pairs_tma else self.epi_tile,
+        )
+        # Compute grid size. Fold mode: compact C is half the GEMM's logical N,
+        # so tiling must come from the m2-congruent alias view.
+        _grid_c = c_alias_tensor if self.fold_pairs_tma else c_tensor
+        self.tile_sched_params, grid = self._compute_grid(
+            _grid_c,
+            self.cta_tile_shape_mnk,
+            self.cluster_shape_mn,
+            max_active_clusters,
+        )
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (EPI_TILE_M, EPI_TILE_N, STAGE)
+            sC: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.c_dtype,
+                    (
+                        cute.cosize(self.c_smem_layout_staged)
+                        if self.fold_pairs_tma
+                        else cute.cosize(self.c_smem_layout_staged.outer)
+                    ),
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.a_dtype, cute.cosize(self.a_smem_layout_staged.outer)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.b_dtype, cute.cosize(self.b_smem_layout_staged.outer)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfa_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    self.sf_dtype, cute.cosize(self.sfb_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            tiled_mma,
+            tiled_mma_sfb,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            tma_tensor_c,
+            self.tma_cluster_layout_vmnk,
+            self.tma_cluster_layout_sfb_vmnk,
+            self.tma_cluster_layout_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+            alpha,
+            # Always a real tensor: the DSL cannot marshal None kernel args.
+            # Non-fold mode passes a harmless stand-in (read only under
+            # const_expr(self.fold_pairs_tma)).
+            c_alias_tensor if self.fold_pairs_tma else tma_tensor_c,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            smem=self.shared_storage.size_in_bytes(),  # type: ignore[attr-defined]
+            min_blocks_per_mp=1,
+            stream=stream,
+            use_pdl=self.enable_pdl,
+        )
+        return
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tiled_mma_sfb: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: Optional[cute.CopyAtom],
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        pipe_cluster_layout_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+        alpha: cute.Tensor,
+        mC_fold_alias: cute.Tensor,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        # Keep alpha in FP32 for precision: the accumulator is in FP32 and alpha
+        # may be a very small scaling factor. Converting to c_dtype (e.g., FP16)
+        # before multiplication could cause overflow when acc values are large.
+        alpha_value = alpha[0].to(cutlass.Float32)
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+            cpasync.prefetch_descriptor(tma_atom_c)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        # cta_rank_in_cluster is the REAL rank (the DSMEM peer logic needs it).
+        # For TMA we want the rank within the TMA cluster, where the two split
+        # partners are both rank 0 -- they load the same full tile, differing
+        # only in the K window. Identical to the raw rank whenever the two
+        # clusters coincide (every non-dsmem path).
+        _tma_rank = cta_rank_in_cluster % cute.size(cluster_layout_vmnk)
+        _tma_rank_sfb = cta_rank_in_cluster % cute.size(cluster_layout_sfb_vmnk)
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(_tma_rank)
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            _tma_rank_sfb
+        )
+        # Coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Alloc and init: a+b full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        tmem_dealloc_mbar_ptr = storage.tmem_dealloc_mbar_ptr.ptr
+        tmem_holding_buf = storage.tmem_holding_buf.ptr
+
+        # Initialize mainloop ab_pipeline (barrier) and states
+        ab_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_pipeline = PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_pipeline_producer_group,
+            consumer_group=ab_pipeline_consumer_group,
+            tx_count=self.num_tma_load_bytes,
+            cta_layout_vmnk=pipe_cluster_layout_vmnk,
+        )
+
+        # Initialize acc_pipeline (barrier) and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilog_warp_id) * (
+            2 if use_2cta_instrs else 1
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=pipe_cluster_layout_vmnk,
+        )
+
+        # Tensor memory dealloc barrier init
+        if use_2cta_instrs:
+            if warp_idx == self.tma_warp_id:
+                num_tmem_dealloc_threads = 32
+                with cute.arch.elect_one():
+                    cute.arch.mbarrier_init(
+                        tmem_dealloc_mbar_ptr, num_tmem_dealloc_threads
+                    )
+        cute.arch.mbarrier_init_fence()
+
+        # Cluster arrive after barrier init
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_arrive_relaxed(aligned=True)
+
+        #
+        # Setup smem tensor A/B/SFA/SFB/C
+        #
+        # (EPI_TILE_M, EPI_TILE_N, STAGE)
+        if cutlass.const_expr(self.fold_pairs_tma):
+            # Plain (non-composed) half-width fold staging: no swizzle.
+            sC = storage.sC.get_tensor(c_smem_layout_staged)
+        else:
+            sC = storage.sC.get_tensor(
+                c_smem_layout_staged.outer, swizzle=c_smem_layout_staged.inner
+            )
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+        # (MMA, MMA_M, MMA_K, STAGE)
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        #
+        # Compute multicast mask for A/B/SFA/SFB buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
+            )
+
+        #
+        # Local_tile partition global tensors
+        #
+        # (bM, bK, RestM, RestK, RestL)
+        gA_mkl = cute.local_tile(
+            mA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gB_nkl = cute.local_tile(
+            mB_nkl, cute.slice_(self.mma_tiler, (0, None, None)), (None, None, None)
+        )
+        # (bM, bK, RestM, RestK, RestL)
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl, cute.slice_(self.mma_tiler, (None, 0, None)), (None, None, None)
+        )
+        # (bN, bK, RestN, RestK, RestL)
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.mma_tiler_sfb, (0, None, None)),
+            (None, None, None),
+        )
+        # (bM, bN, RestM, RestN, RestL)
+        if cutlass.const_expr(self.fold_pairs_tma):
+            # t2r/partition geometry from the m2-congruent alias (metadata
+            # only, never stored through); TMA targets the compact D tiled
+            # by the half-width CTA tile, indexed by CTA-tile coords.
+            gC_mnl = cute.local_tile(
+                mC_fold_alias,
+                cute.slice_(self.mma_tiler, (None, None, 0)),
+                (None, None, None),
+            )
+            _fold_cta_tile = (
+                self.cta_tile_shape_mnk[0],
+                self.cta_tile_shape_mnk[1] // 2,
+            )
+            gC_fold_mnl = cute.local_tile(
+                mC_mnl,
+                _fold_cta_tile,
+                (None, None, None),
+            )
+        else:
+            gC_mnl = cute.local_tile(
+                mC_mnl,
+                cute.slice_(self.mma_tiler, (None, None, 0)),
+                (None, None, None),
+            )
+            gC_fold_mnl = None
+        k_block_cnt = cutlass.Int32(cute.size(gA_mkl, mode=[3]))
+        # k_loop: A (the K-concat activation) already carries the 2K trip
+        # count above; B (the weight) wraps at the K midpoint using its own
+        # block count as the modulus. An operand and its SF are tiled by the
+        # same tiler, so one wrapped index cannot desynchronise them.
+        k_base_block_cnt = cutlass.Int32(cute.size(gB_nkl, mode=[3]))
+        k_win_cnt = k_block_cnt
+
+        #
+        # Partition global tensor for TiledMMA_A/B/C
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+        thr_mma_sfb = tiled_mma_sfb.get_slice(mma_tile_coord_v)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgA = thr_mma.partition_A(gA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgB = thr_mma.partition_B(gB_nkl)
+        # (MMA, MMA_M, MMA_K, RestM, RestK, RestL)
+        tCgSFA = thr_mma.partition_A(gSFA_mkl)
+        # (MMA, MMA_N, MMA_K, RestN, RestK, RestL)
+        tCgSFB = thr_mma_sfb.partition_B(gSFB_nkl)
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        #
+        # Partition global/shared tensor for TMA load A/B
+        #
+        # TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 3),
+        )
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 3),
+        )
+
+        #  TMA load SFA partition_S/D
+        sfa_cta_layout = a_cta_layout
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestM, RestK, RestL)
+        tAsSFA, tAgSFA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfa,
+            block_in_cluster_coord_vmnk[2],
+            sfa_cta_layout,
+            cute.group_modes(sSFA, 0, 3),
+            cute.group_modes(tCgSFA, 0, 3),
+        )
+        tAsSFA = cute.filter_zeros(tAsSFA)
+        tAgSFA = cute.filter_zeros(tAgSFA)
+
+        # TMA load SFB partition_S/D
+        sfb_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+        )
+        # ((atom_v, rest_v), STAGE)
+        # ((atom_v, rest_v), RestN, RestK, RestL)
+        tBsSFB, tBgSFB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfb,
+            block_in_cluster_coord_sfb_vmnk[1],
+            sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3),
+            cute.group_modes(tCgSFB, 0, 3),
+        )
+        tBsSFB = cute.filter_zeros(tBsSFB)
+        tBgSFB = cute.filter_zeros(tBgSFB)
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/C
+        #
+        # (MMA, MMA_M, MMA_K, STAGE)
+        tCrA = tiled_mma.make_fragment_A(sA)
+        # (MMA, MMA_N, MMA_K, STAGE)
+        tCrB = tiled_mma.make_fragment_B(sB)
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        if cutlass.const_expr(self.overlapping_accum):
+            num_acc_stage_overlapped = 2
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, num_acc_stage_overlapped)
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (256 - self.num_sf_tmem_cols) * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        else:
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, self.num_acc_stage)
+            )
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        if cute.size(self.cluster_shape_mn) > 1:
+            cute.arch.cluster_wait()
+        else:
+            cute.arch.barrier(
+                barrier_id=self.cta_sync_bar_id, number_of_threads=self.threads_per_cta
+            )
+
+        # PDL bookend: griddepcontrol_wait is always emitted; the actual PDL
+        # behavior is controlled by use_pdl= in .launch(). The griddepcontrol
+        # instructions are effectively no-ops when PDL is not enabled at
+        # the driver level.
+        griddepcontrol_wait()
+
+        #
+        # Specialized TMA load warp
+        #
+        if warp_idx == self.tma_warp_id:
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_ab_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                k_lo = cutlass.Int32(0)
+                _m_coord = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
+                _l_coord = cur_tile_coord[2]
+                mma_tile_coord_mnl = (_m_coord, cur_tile_coord[1], _l_coord)
+
+                _l_weight = mma_tile_coord_mnl[2]
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((atom_v, rest_v), RestK)
+                tAgA_slice = tAgA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                # ((atom_v, rest_v), RestK)
+                tBgB_slice = tBgB[(None, mma_tile_coord_mnl[1], None, _l_weight)]
+
+                # ((atom_v, rest_v), RestK)
+                tAgSFA_slice = tAgSFA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                slice_n = mma_tile_coord_mnl[1]
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    slice_n = mma_tile_coord_mnl[1] // 2
+                # ((atom_v, rest_v), RestK)
+                tBgSFB_slice = tBgSFB[(None, slice_n, None, _l_weight)]
+
+                # Peek (try_wait) AB buffer empty for k_block = prefetch_k_block_cnt
+                ab_producer_state.reset_count()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                if ab_producer_state.count < k_win_cnt:
+                    peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                        ab_producer_state
+                    )
+                #
+                # Tma load loop
+                #
+                for k_block in cutlass.range(0, k_win_cnt, 1, unroll=1):
+                    # Conditionally wait for AB buffer empty
+                    ab_pipeline.producer_acquire(
+                        ab_producer_state, peek_ab_empty_status
+                    )
+
+                    # TMA load A/B/SFA/SFB
+                    # k_loop: B (the weight) and its SF wrap at the K
+                    # midpoint -- one compare+subtract in the DMA warp, off
+                    # the critical path. A single subtract suffices: the
+                    # absolute index never reaches 2x the base count twice.
+                    _kb_idx = k_lo + ab_producer_state.count
+                    if cutlass.const_expr(self.k_loop):
+                        _kb_idx = cutlass.Int32(
+                            _kb_idx
+                            if _kb_idx < k_base_block_cnt
+                            else _kb_idx - k_base_block_cnt
+                        )
+                    cute.copy(
+                        tma_atom_a,
+                        tAgA_slice[(None, k_lo + ab_producer_state.count)],
+                        tAsA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=a_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_b,
+                        tBgB_slice[(None, _kb_idx)],
+                        tBsB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=b_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfa,
+                        tAgSFA_slice[(None, k_lo + ab_producer_state.count)],
+                        tAsSFA[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfa_full_mcast_mask,
+                    )
+                    cute.copy(
+                        tma_atom_sfb,
+                        tBgSFB_slice[(None, _kb_idx)],
+                        tBsSFB[(None, ab_producer_state.index)],
+                        tma_bar_ptr=ab_pipeline.producer_get_barrier(ab_producer_state),
+                        mcast_mask=sfb_full_mcast_mask,
+                    )
+
+                    # Peek (try_wait) AB buffer empty for k_block = prefetch_k_block_cnt + k_block + 1
+                    ab_producer_state.advance()
+                    peek_ab_empty_status = cutlass.Boolean(1)
+                    if ab_producer_state.count < k_win_cnt:
+                        peek_ab_empty_status = ab_pipeline.producer_try_acquire(
+                            ab_producer_state
+                        )
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait A/B buffer empty
+            #
+            ab_pipeline.producer_tail(ab_producer_state)
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem_ptr_read_threads = 32 * len((self.mma_warp_id, *self.epilog_warp_id))
+            cute.arch.barrier(
+                barrier_id=self.tmem_ptr_sync_bar_id,
+                number_of_threads=tmem_ptr_read_threads,
+            )
+
+            #
+            # Retrieving tensor memory ptr and make accumulator/SFA/SFB tensor
+            #
+            # Make accumulator tmem tensor
+            acc_tmem_ptr = cute.arch.retrieve_tmem_ptr(
+                self.acc_dtype,
+                alignment=16,
+                ptr_to_buffer_holding_addr=tmem_holding_buf,
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_M, MMA_K)
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + self.num_accumulator_tmem_cols + self.num_sfa_tmem_cols,
+                dtype=self.sf_dtype,
+            )
+            # (MMA, MMA_N, MMA_K)
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+            #
+            # Partition for S2T copy of SFA/SFB
+            #
+            tiled_copy_s2t_sfa, tCsSFA_compact_s2t, tCtSFA_compact_s2t = (
+                self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            )
+            tiled_copy_s2t_sfb, tCsSFB_compact_s2t, tCtSFB_compact_s2t = (
+                self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+            )
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            ab_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_ab_stage
+            )
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                _m_coord = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
+                _l_coord = cur_tile_coord[2]
+                mma_tile_coord_mnl = (_m_coord, cur_tile_coord[1], _l_coord)
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (MMA, MMA_M, MMA_N)
+                tCtAcc = tCtAcc_base[(None, None, None, acc_stage_index)]
+
+                # Peek (try_wait) AB buffer full for k_block = 0
+                ab_consumer_state.reset_count()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if ab_consumer_state.count < k_win_cnt and is_leader_cta:
+                    peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                        ab_consumer_state
+                    )
+
+                #
+                # Wait for accumulator buffer empty
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_acquire(acc_producer_state)
+
+                tCtSFB_mma = tCtSFB
+                if cutlass.const_expr(self.cta_tile_shape_mnk[1] == 192):
+                    # If this is an ODD tile, shift the TMEM start address for cta_tile_shape_n=192 case by two words (ignores first 64 columns of SFB)
+                    offset = (
+                        cutlass.Int32(2)
+                        if mma_tile_coord_mnl[1] % 2 == 1
+                        else cutlass.Int32(0)
+                    )
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + self.num_accumulator_tmem_cols
+                        + self.num_sfa_tmem_cols
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+                elif cutlass.const_expr(self.cta_tile_shape_mnk[1] == 64):
+                    # Move in increments of 64 columns of SFB
+                    offset = cutlass.Int32((mma_tile_coord_mnl[1] % 2) * 2)
+                    shifted_ptr = cute.recast_ptr(
+                        acc_tmem_ptr
+                        + self.num_accumulator_tmem_cols
+                        + self.num_sfa_tmem_cols
+                        + offset,
+                        dtype=self.sf_dtype,
+                    )
+                    tCtSFB_mma = cute.make_tensor(shifted_ptr, tCtSFB_layout)
+
+                #
+                # Reset the ACCUMULATE field for each tile
+                #
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                #
+                # Mma mainloop
+                #
+                for _k_block in range(k_win_cnt):
+                    if is_leader_cta:
+                        # Conditionally wait for AB buffer full
+                        ab_pipeline.consumer_wait(
+                            ab_consumer_state, peek_ab_full_status
+                        )
+
+                        #  Copy SFA/SFB from smem to tmem
+                        s2t_stage_coord = (
+                            None,
+                            None,
+                            None,
+                            None,
+                            ab_consumer_state.index,
+                        )
+                        tCsSFA_compact_s2t_staged = tCsSFA_compact_s2t[s2t_stage_coord]
+                        tCsSFB_compact_s2t_staged = tCsSFB_compact_s2t[s2t_stage_coord]
+                        cute.copy(
+                            tiled_copy_s2t_sfa,
+                            tCsSFA_compact_s2t_staged,
+                            tCtSFA_compact_s2t,
+                        )
+                        cute.copy(
+                            tiled_copy_s2t_sfb,
+                            tCsSFB_compact_s2t_staged,
+                            tCtSFB_compact_s2t,
+                        )
+
+                        # tCtAcc += tCrA * tCrSFA * tCrB * tCrSFB
+                        num_kphases = cute.size(tCrA, mode=[2])
+                        for kphase_idx in cutlass.range(num_kphases, unroll_full=True):
+                            kphase_coord = (
+                                None,
+                                None,
+                                kphase_idx,
+                                ab_consumer_state.index,
+                            )
+
+                            # Set SFA/SFB tensor to tiled_mma
+                            sf_kphase_coord = (None, None, kphase_idx)
+                            tiled_mma.set(
+                                tcgen05.Field.SFA,
+                                tCtSFA[sf_kphase_coord].iterator,
+                            )
+                            tiled_mma.set(
+                                tcgen05.Field.SFB,
+                                tCtSFB_mma[sf_kphase_coord].iterator,
+                            )
+
+                            cute.gemm(
+                                tiled_mma,
+                                tCtAcc,
+                                tCrA[kphase_coord],
+                                tCrB[kphase_coord],
+                                tCtAcc,
+                            )
+
+                            # Enable accumulate on tCtAcc after first kphase
+                            tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # Async arrive AB buffer empty
+                        ab_pipeline.consumer_release(ab_consumer_state)
+
+                    # Peek (try_wait) AB buffer full for k_block = k_block + 1
+                    ab_consumer_state.advance()
+                    peek_ab_full_status = cutlass.Boolean(1)
+                    if ab_consumer_state.count < k_win_cnt:
+                        if is_leader_cta:
+                            peek_ab_full_status = ab_pipeline.consumer_try_wait(
+                                ab_consumer_state
+                            )
+
+                #
+                # Async arrive accumulator buffer full
+                #
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+        #
+        # Specialized epilogue warps
+        #
+        if warp_idx < self.mma_warp_id:
+            #
+            # Alloc tensor memory buffer
+            #
+            if warp_idx == self.epilog_warp_id[0]:
+                cute.arch.alloc_tmem(
+                    self.num_tmem_alloc_cols,
+                    tmem_holding_buf,
+                    is_two_cta=use_2cta_instrs,
+                )
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem_ptr_read_threads = 32 * len((self.mma_warp_id, *self.epilog_warp_id))
+            cute.arch.barrier(
+                barrier_id=self.tmem_ptr_sync_bar_id,
+                number_of_threads=tmem_ptr_read_threads,
+            )
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = cute.arch.retrieve_tmem_ptr(
+                self.acc_dtype,
+                alignment=16,
+                ptr_to_buffer_holding_addr=tmem_holding_buf,
+            )
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Partition for epilogue
+            #
+            epi_tidx = tidx
+            tiled_copy_t2r, tTR_tAcc_base, tTR_rAcc = (
+                self.epilog_tmem_copy_and_partition(
+                    epi_tidx, tCtAcc_base, tCgC, epi_tile, use_2cta_instrs
+                )
+            )
+
+            if cutlass.const_expr(self.fold_pairs_tma):
+                # ResInfer fold: no r2s tiled-copy machinery. Each thread writes
+                # its folded fragment into compact smem, then a coalesced TMA
+                # drains the compact epi tile to D[m_tok, n_w].
+                _PAIR_EVEN = (((0, None), None), None, None)
+                _PAIR_ODD = (((1, None), None), None, None)
+                tTR_rC_half = cute.make_fragment(
+                    tTR_rAcc[_PAIR_EVEN].shape, self.c_dtype
+                )
+                gC_fold_epi = cute.flat_divide(gC_fold_mnl, self.epi_tile_c)
+                bSG_sC, bSG_gC_partitioned = cpasync.tma_partition(
+                    tma_atom_c,
+                    0,
+                    cute.make_layout(1),
+                    cute.group_modes(sC, 0, 2),
+                    cute.group_modes(gC_fold_epi, 0, 2),
+                )
+                tiled_copy_r2s, tRS_rC, tRS_sC = None, None, None
+            else:
+                tTR_rC = cute.make_fragment(tTR_rAcc.shape, self.c_dtype)
+                tiled_copy_r2s, tRS_rC, tRS_sC = self.epilog_smem_copy_and_partition(
+                    tiled_copy_t2r, tTR_rC, epi_tidx, sC
+                )
+                tma_atom_c, bSG_sC, bSG_gC_partitioned = (
+                    self.epilog_gmem_copy_and_partition(
+                        epi_tidx, tma_atom_c, tCgC, epi_tile, sC
+                    )
+                )
+
+            #
+            # Persistent tile scheduling loop
+            #
+            tile_sched = utils.StaticPersistentTileScheduler.create(
+                tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+            )
+            work_tile = tile_sched.initial_work_tile_info()
+
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+
+            # Threads/warps participating in tma store pipeline
+            c_producer_group = pipeline.CooperativeGroup(
+                pipeline.Agent.Thread,
+                32 * len(self.epilog_warp_id),
+                32 * len(self.epilog_warp_id),
+            )
+            c_pipeline = pipeline.PipelineTmaStore.create(
+                num_stages=self.num_c_stage,
+                producer_group=c_producer_group,
+            )
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                _m_coord = cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape)
+                _l_coord = cur_tile_coord[2]
+                mma_tile_coord_mnl = (_m_coord, cur_tile_coord[1], _l_coord)
+
+                #
+                # Slice to per mma tile index
+                #
+                # ((ATOM_V, REST_V), EPI_M, EPI_N)
+                if cutlass.const_expr(self.fold_pairs_tma):
+                    # fold gC tiles are CTA-tile sized (compact D, half CTA tile):
+                    # slice with CTA-level coords (2-CTA MMA: mma-level coords skip
+                    # peer halves). Same for M-ext and N-ext -- both coalesced-TMA.
+                    bSG_gC = bSG_gC_partitioned[
+                        (
+                            None,
+                            None,
+                            None,
+                            cur_tile_coord[0],
+                            cur_tile_coord[1],
+                            _l_coord,
+                        )
+                    ]
+                else:
+                    bSG_gC = bSG_gC_partitioned[
+                        (
+                            None,
+                            None,
+                            None,
+                            *mma_tile_coord_mnl,
+                        )
+                    ]
+
+                if cutlass.const_expr(self.overlapping_accum):
+                    acc_stage_index = acc_consumer_state.phase
+                    reverse_subtile = (
+                        cutlass.Boolean(True)
+                        if acc_stage_index == 0
+                        else cutlass.Boolean(False)
+                    )
+                else:
+                    acc_stage_index = acc_consumer_state.index
+
+                # Set tensor memory buffer for current tile
+                # (T2R, T2R_M, T2R_N, EPI_M, EPI_M)
+                tTR_tAcc = tTR_tAcc_base[
+                    (None, None, None, None, None, acc_stage_index)
+                ]
+
+                #
+                # Wait for accumulator buffer full
+                #
+                acc_pipeline.consumer_wait(acc_consumer_state)
+
+                tTR_tAcc = cute.group_modes(tTR_tAcc, 3, cute.rank(tTR_tAcc))
+                bSG_gC = cute.group_modes(bSG_gC, 1, cute.rank(bSG_gC))
+
+                #
+                # Store accumulator to global memory in sub-tiles
+                #
+                subtile_cnt = cute.size(tTR_tAcc.shape, mode=[3])
+                num_prev_subtiles = tile_sched.num_tiles_executed * subtile_cnt
+
+                for subtile_idx in cutlass.range(subtile_cnt):
+                    real_subtile_idx = subtile_idx
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if reverse_subtile:
+                            real_subtile_idx = (
+                                self.cta_tile_shape_mnk[1] // self.epi_tile_n
+                                - 1
+                                - subtile_idx
+                            )
+                    #
+                    # Load accumulator from tensor memory buffer to register
+                    #
+                    tTR_tAcc_mn = tTR_tAcc[(None, None, None, real_subtile_idx)]
+                    cute.copy(tiled_copy_t2r, tTR_tAcc_mn, tTR_rAcc)
+                    #
+                    # Async arrive accumulator buffer empty earlier when overlapping_accum is enabled
+                    #
+                    if cutlass.const_expr(self.overlapping_accum):
+                        if subtile_idx == self.iter_acc_early_release_in_epilogue:
+                            # Fence for TMEM load
+                            cute.arch.fence_view_async_tmem_load()
+                            with cute.arch.elect_one():
+                                acc_pipeline.consumer_release(acc_consumer_state)
+                            acc_consumer_state.advance()
+                    #
+                    # Convert to C type (fold mode: sum (base,residue) pairs
+                    # in f32, alpha in f32, single rounding; write the half
+                    # fragment as one strided smem row per thread)
+                    #
+                    c_buffer = (num_prev_subtiles + subtile_idx) % self.num_c_stage
+                    if cutlass.const_expr(self.fold_pairs_tma):
+                        folded_half = epilogue_op(
+                            (
+                                alpha_value
+                                * (
+                                    tTR_rAcc[_PAIR_EVEN].load().to(cutlass.Float32)
+                                    + tTR_rAcc[_PAIR_ODD].load().to(cutlass.Float32)
+                                )
+                            ).to(self.c_dtype)
+                        )
+                        tTR_rC_half.store(folded_half)
+                        sC_row = sC[(epi_tidx, None, c_buffer)]
+                        for _i in range(cute.size(sC_row.shape)):
+                            sC_row[_i] = tTR_rC_half[_i]
+                    else:
+                        acc_vec = tiled_copy_r2s.retile(tTR_rAcc).load()
+                        # Multiply alpha in FP32 before converting to c_dtype to
+                        # avoid overflow when c_dtype is FP16 and acc values are large.
+                        acc_vec = epilogue_op((alpha_value * acc_vec).to(self.c_dtype))
+                        tRS_rC.store(acc_vec)
+                        cute.copy(
+                            tiled_copy_r2s,
+                            tRS_rC,
+                            tRS_sC[(None, None, None, c_buffer)],
+                        )
+                    cute.arch.fence_proxy(
+                        "async.shared",
+                        space="cta",
+                    )
+                    epilog_threads = 32 * len(self.epilog_warp_id)
+                    cute.arch.barrier(
+                        barrier_id=self.epilog_sync_bar_id,
+                        number_of_threads=epilog_threads,
+                    )
+
+                    #
+                    # TMA store C to global memory
+                    #
+                    if warp_idx == self.epilog_warp_id[0]:
+                        cute.copy(
+                            tma_atom_c,
+                            bSG_sC[(None, c_buffer)],
+                            bSG_gC[(None, real_subtile_idx)],
+                        )
+                        c_pipeline.producer_commit()
+                        c_pipeline.producer_acquire()
+                    cute.arch.barrier(
+                        barrier_id=self.epilog_sync_bar_id,
+                        number_of_threads=epilog_threads,
+                    )
+
+                #
+                # Async arrive accumulator buffer empty
+                #
+                if cutlass.const_expr(not self.overlapping_accum):
+                    with cute.arch.elect_one():
+                        acc_pipeline.consumer_release(acc_consumer_state)
+                    acc_consumer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            if warp_idx == self.epilog_warp_id[0]:
+                cute.arch.relinquish_tmem_alloc_permit(is_two_cta=use_2cta_instrs)
+            epilog_threads = 32 * len(self.epilog_warp_id)
+            cute.arch.barrier(
+                barrier_id=self.epilog_sync_bar_id, number_of_threads=epilog_threads
+            )
+            if warp_idx == self.epilog_warp_id[0]:
+                if use_2cta_instrs:
+                    cute.arch.mbarrier_arrive(
+                        tmem_dealloc_mbar_ptr, cta_rank_in_cluster ^ 1
+                    )
+                    cute.arch.mbarrier_wait(tmem_dealloc_mbar_ptr, 0)
+                cute.arch.dealloc_tmem(
+                    acc_tmem_ptr, self.num_tmem_alloc_cols, is_two_cta=use_2cta_instrs
+                )
+            #
+            # Wait for C store complete
+            #
+            c_pipeline.producer_tail()
+
+        griddepcontrol_launch_dependents()
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it to partition smem memory (source) and tensor memory (destination).
+
+        Args:
+            sSF (cute.Tensor): The scale factor tensor in smem
+            tSF (cute.Tensor): The scale factor tensor in tmem
+
+        Returns:
+            A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+                - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+                - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+                - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t, tCsSF_compact_s2t_
+        )
+        # ((ATOM_V, REST_V), Rest_Tiler, MMA_MN, MMA_K)
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    def epilog_tmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        tAcc: cute.Tensor,
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        use_2cta_instrs: Union[cutlass.Boolean, bool],
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for tensor memory load, then use it to partition tensor memory (source) and register array (destination).
+
+        Args:
+            tidx (cutlass.Int32): The thread index in epilogue warp groups
+            tAcc (cute.Tensor): The accumulator tensor to be copied and partitioned
+            gC_mnl (cute.Tensor): The global tensor C
+            epi_tile (cute.Tile): The epilogue tiler
+            use_2cta_instrs (bool): Whether use_2cta_instrs is enabled
+
+        Returns:
+            A tuple containing (tiled_copy_t2r, tTR_tAcc, tTR_rAcc) where:
+                - tiled_copy_t2r: The tiled copy operation for tmem to register copy(t2r)
+                - tTR_tAcc: The partitioned accumulator tensor
+                - tTR_rAcc: The accumulated tensor in register used to hold t2r results
+        """
+        # Make tiledCopy for tensor memory load
+        copy_atom_t2r = sm100_utils.get_tmem_load_op(
+            self.cta_tile_shape_mnk,
+            self.c_layout,
+            self.c_dtype,
+            self.acc_dtype,
+            epi_tile,
+            use_2cta_instrs,
+        )
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, STAGE)
+        tAcc_epi = cute.flat_divide(
+            tAcc[((None, None), 0, 0, None)],
+            epi_tile,
+        )
+        # (EPI_TILE_M, EPI_TILE_N)
+        tiled_copy_t2r = tcgen05.make_tmem_copy(
+            copy_atom_t2r, tAcc_epi[(None, None, 0, 0, 0)]
+        )
+
+        thr_copy_t2r = tiled_copy_t2r.get_slice(tidx)
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_M, STAGE)
+        tTR_tAcc = thr_copy_t2r.partition_S(tAcc_epi)
+
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_mnl_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+        # (T2R, T2R_M, T2R_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        tTR_gC = thr_copy_t2r.partition_D(gC_mnl_epi)
+        # (T2R, T2R_M, T2R_N)
+        tTR_rAcc = cute.make_fragment(
+            tTR_gC[(None, None, None, 0, 0, 0, 0, 0)].shape, self.acc_dtype
+        )
+        return tiled_copy_t2r, tTR_tAcc, tTR_rAcc
+
+    def epilog_smem_copy_and_partition(
+        self,
+        tiled_copy_t2r: cute.TiledCopy,
+        tTR_rC: cute.Tensor,
+        tidx: cutlass.Int32,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for shared memory store, then use it to partition register array (source) and shared memory (destination).
+
+        Args:
+            tiled_copy_t2r (cute.TiledCopy): The tiled copy operation for tmem to register copy(t2r)
+            tTR_rC (cute.Tensor): The partitioned accumulator tensor
+            tidx (cutlass.Int32): The thread index in epilogue warp groups
+            sC (cute.Tensor): The shared memory tensor to be copied and partitioned
+            sepi (cute.Tensor):
+
+        Returns:
+            A tuple containing (tiled_copy_r2s, tRS_rC, tRS_sC) where:
+                - tiled_copy_r2s: The tiled copy operation for register to smem copy(r2s)
+                - tRS_rC: The partitioned tensor C (register source)
+                - tRS_sC: The partitioned tensor C (smem destination)
+        """
+        copy_atom_r2s = sm100_utils.get_smem_store_op(
+            self.c_layout, self.c_dtype, self.acc_dtype, tiled_copy_t2r
+        )
+        tiled_copy_r2s = cute.make_tiled_copy_D(copy_atom_r2s, tiled_copy_t2r)
+        # (R2S, R2S_M, R2S_N, PIPE_D)
+        thr_copy_r2s = tiled_copy_r2s.get_slice(tidx)
+        tRS_sC = thr_copy_r2s.partition_D(sC)
+        # (R2S, R2S_M, R2S_N)
+        tRS_rC = tiled_copy_r2s.retile(tTR_rC)
+        return tiled_copy_r2s, tRS_rC, tRS_sC
+
+    def epilog_gmem_copy_and_partition(
+        self,
+        tidx: cutlass.Int32,
+        atom: Union[cute.CopyAtom, cute.TiledCopy],
+        gC_mnl: cute.Tensor,
+        epi_tile: cute.Tile,
+        sC: cute.Tensor,
+    ) -> Tuple[cute.CopyAtom, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for global memory store, then use it to:
+        partition shared memory (source) and global memory (destination) for TMA store version.
+
+        Args:
+            tidx (cutlass.Int32): The thread index in epilogue warp groups
+            atom (Union[cute.CopyAtom, cute.TiledCopy]): The copy_atom_c to be used for TMA store version, or tiled_copy_t2r for none TMA store version
+            gC_mnl (cute.Tensor): The global tensor C
+            epi_tile (cute.Tile): The epilogue tiler
+            sC (cute.Tensor): The shared memory tensor to be copied and partitioned
+
+        Returns:
+            A tuple containing (tma_atom_c, bSG_sC, bSG_gC) where:
+                - tma_atom_c: The TMA copy atom
+                - bSG_sC: The partitioned shared memory tensor C
+                - bSG_gC: The partitioned global tensor C
+        """
+        # (EPI_TILE_M, EPI_TILE_N, EPI_M, EPI_N, RestM, RestN, RestL)
+        gC_epi = cute.flat_divide(
+            gC_mnl[((None, None), 0, 0, None, None, None)], epi_tile
+        )
+
+        tma_atom_c = atom
+        sC_for_tma_partition = cute.group_modes(sC, 0, 2)
+        gC_for_tma_partition = cute.group_modes(gC_epi, 0, 2)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N)
+        # ((ATOM_V, REST_V), EPI_M, EPI_N, RestM, RestN, RestL)
+        bSG_sC, bSG_gC = cpasync.tma_partition(
+            tma_atom_c,
+            0,
+            cute.make_layout(1),
+            sC_for_tma_partition,
+            gC_for_tma_partition,
+        )
+        return tma_atom_c, bSG_sC, bSG_gC
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: Tuple[int, int, int],
+        a_dtype: Type[cutlass.Numeric],
+        a_major_mode: tcgen05.OperandMajorMode,
+        b_dtype: Type[cutlass.Numeric],
+        b_major_mode: tcgen05.OperandMajorMode,
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        smem_capacity: int,
+        occupancy: int,
+    ) -> Tuple[int, int, int]:
+        """Computes the optimal number of pipeline stages for operands.
+
+        This method uses heuristics to determine the number of stages for the
+        accumulator (ACC), A/B operands, and C operand based on the kernel
+        configuration and available shared memory.
+
+        Args:
+            tiled_mma (cute.TiledMma): The tiled MMA object.
+            mma_tiler_mnk (Tuple[int, int, int]): The shape (M, N, K) of the
+                MMA tiler.
+            a_dtype (Type[cutlass.Numeric]): Data type of operand A.
+            a_major_mode (tcgen05.OperandMajorMode): Layout of operand A.
+            b_dtype (Type[cutlass.Numeric]): Data type of operand B.
+            b_major_mode (tcgen05.OperandMajorMode): Layout of operand B.
+            epi_tile (cute.Tile): The epilogue tile shape.
+            c_dtype (Type[cutlass.Numeric]): Data type of operand C.
+            c_layout (utils.LayoutEnum): Layout of operand C.
+            sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
+            sf_vec_size (int): Vector size of the scale factors.
+            smem_capacity (int): Total available shared memory in bytes.
+            occupancy (int): Target number of CTAs per SM.
+
+        Returns:
+            Tuple[int, int, int]: A tuple containing the number of stages for
+                (ACC, A/B, C).
+        """
+        # ACC stages
+        num_acc_stage = 1 if mma_tiler_mnk[1] == 256 else 2
+
+        # Default C stages
+        num_c_stage = 2
+
+        # Calculate smem layout and size for one stage of A, B, SFA, SFB and C
+        a_smem_layout_stage_one = sm100_utils.make_smem_layout_a(
+            tiled_mma,
+            mma_tiler_mnk,
+            a_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        b_smem_layout_staged_one = sm100_utils.make_smem_layout_b(
+            tiled_mma,
+            mma_tiler_mnk,
+            b_dtype,
+            1,  # a tmp 1 stage is provided
+        )
+        sfa_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfa(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+        sfb_smem_layout_staged_one = blockscaled_utils.make_smem_layout_sfb(
+            tiled_mma,
+            mma_tiler_mnk,
+            sf_vec_size,
+            1,  # a tmp 1 stage is provided
+        )
+
+        c_smem_layout_staged_one = sm100_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        ab_bytes_per_stage = (
+            cute.size_in_bytes(a_dtype, a_smem_layout_stage_one)
+            + cute.size_in_bytes(b_dtype, b_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfa_smem_layout_staged_one)
+            + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+        )
+        mbar_helpers_bytes = 1024
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        # Calculate A/B/SFA/SFB stages:
+        # Start with total smem per CTA (capacity / occupancy)
+        # Subtract reserved bytes and initial C stages bytes
+        # Divide remaining by bytes needed per A/B/SFA/SFB stage
+        num_ab_stage = (
+            smem_capacity // occupancy - (mbar_helpers_bytes + c_bytes)
+        ) // ab_bytes_per_stage
+
+        # Refine epilogue stages:
+        # Calculate remaining smem after allocating for A/B/SFA/SFB stages and reserved bytes
+        # Add remaining unused smem to epilogue
+        num_c_stage += (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * (mbar_helpers_bytes + c_bytes)
+        ) // (occupancy * c_bytes_per_stage)
+
+        return num_acc_stage, num_ab_stage, num_c_stage
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
+        """Computes the grid size for the kernel launch.
+
+        This method uses a persistent tile scheduler to determine the grid
+        dimensions based on the output tensor shape and hardware constraints.
+
+        Args:
+            c (cute.Tensor): The output tensor C.
+            cta_tile_shape_mnk (Tuple[int, int, int]): The shape (M, N, K) of the
+                CTA tile.
+            cluster_shape_mn (Tuple[int, int]): The shape of a CTA cluster.
+            max_active_clusters (cutlass.Constexpr): The maximum number of
+                active clusters supported by the hardware.
+
+        Returns:
+            A tuple containing the tile scheduler parameters and the computed
+            grid shape.
+        """
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """Checks if the data types and scale factor vector size are a valid combination.
+
+        Args:
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
+            sf_vec_size (int): Vector size of the scale factors.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+
+        Returns:
+            bool: True if the combination is valid, False otherwise.
+        """
+        is_valid = True
+
+        # Check valid ab_dtype
+        if ab_dtype not in {
+            cutlass.Float4E2M1FN,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            is_valid = False
+
+        # Check valid sf_vec_size
+        if sf_vec_size not in {16, 32}:
+            is_valid = False
+
+        # Check valid sf_dtype
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN}:
+            is_valid = False
+
+        # Check valid sf_dtype and sf_vec_size combinations
+        if sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32:
+            is_valid = False
+        if ab_dtype in {cutlass.Float8E5M2, cutlass.Float8E4M3FN} and sf_vec_size == 16:
+            is_valid = False
+
+        # Check valid c_dtype
+        if c_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            is_valid = False
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_layouts(
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """Checks if the tensor layouts are valid for the given data types.
+
+        Args:
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+            a_major (str): The major layout of tensor A ('k' or 'm').
+            b_major (str): The major layout of tensor B ('k' or 'n').
+            c_major (str): The major layout of tensor C ('n' or 'm').
+
+        Returns:
+            bool: True if the layouts are valid, False otherwise.
+        """
+        is_valid = True
+
+        if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_mma_tiler_and_cluster_shape(
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ) -> bool:
+        """Checks if the MMA tiler and cluster shape are a valid combination.
+
+        Args:
+            mma_tiler_mn (Tuple[int, int]): The (M, N) shape of the MMA tiler.
+            cluster_shape_mn (Tuple[int, int]): The (M, N) shape of the CTA cluster.
+
+        Returns:
+            bool: True if the combination is valid, False otherwise.
+        """
+        is_valid = True
+        # Skip invalid mma tile shape
+        if mma_tiler_mn[0] not in [128, 256]:
+            is_valid = False
+        if mma_tiler_mn[1] not in [64, 128, 192, 256]:
+            is_valid = False
+        # Skip illegal cluster shape
+        if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
+            is_valid = False
+        # Skip invalid cluster shape
+        _is_power_of_2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if (
+            cluster_shape_mn[0] * cluster_shape_mn[1] > 16
+            or cluster_shape_mn[0] <= 0
+            or cluster_shape_mn[1] <= 0
+            # Special cluster shape check for scale factor multicasts.
+            # Due to limited size of scale factors, we can't multicast among more than 4 CTAs.
+            or cluster_shape_mn[0] > 4
+            or cluster_shape_mn[1] > 4
+            or not _is_power_of_2(cluster_shape_mn[0])
+            or not _is_power_of_2(cluster_shape_mn[1])
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: cutlass.Int64,
+        n: cutlass.Int64,
+        k: cutlass.Int64,
+        l: cutlass.Int64,
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """Checks if the tensor dimensions are valid for memory alignment.
+
+        Args:
+            m (cutlass.Int64): The M dimension of the GEMM problem.
+            n (cutlass.Int64): The N dimension of the GEMM problem.
+            k (cutlass.Int64): The K dimension of the GEMM problem.
+            l (cutlass.Int64): The batch dimension (L) of the GEMM problem.
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+            a_major (str): The major layout of tensor A ('k' or 'm').
+            b_major (str): The major layout of tensor B ('k' or 'n').
+            c_major (str): The major layout of tensor C ('n' or 'm').
+
+        Returns:
+            bool: True if the tensor alignment is valid, False otherwise.
+        """
+        is_valid = True
+
+        def check_contigous_16B_alignment(dtype, is_mode0_major, tensor_shape):
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            num_contiguous_elements = 16 * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        if (
+            not check_contigous_16B_alignment(ab_dtype, a_major == "m", (m, k, l))
+            or not check_contigous_16B_alignment(ab_dtype, b_major == "n", (n, k, l))
+            or not check_contigous_16B_alignment(c_dtype, c_major == "m", (m, n, l))
+        ):
+            is_valid = False
+        return is_valid
+
+    @classmethod
+    def can_implement(
+        cls,
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: cutlass.Int64,
+        n: cutlass.Int64,
+        k: cutlass.Int64,
+        l: cutlass.Int64,
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """Checks if the kernel can implement the given GEMM problem.
+
+        This method aggregates checks for data types, layouts, tile shapes,
+        and alignment to determine if the configuration is supported.
+
+        Args:
+            ab_dtype (Type[cutlass.Numeric]): Data type of operands A and B.
+            sf_dtype (Type[cutlass.Numeric]): Data type of the scale factors.
+            sf_vec_size (int): Vector size of the scale factors.
+            c_dtype (Type[cutlass.Numeric]): Data type of the output tensor C.
+            mma_tiler_mn (Tuple[int, int]): The (M, N) shape of the MMA tiler.
+            cluster_shape_mn (Tuple[int, int]): The (M, N) shape of the CTA
+                cluster.
+            m (cutlass.Int64): The M dimension of the GEMM problem.
+            n (cutlass.Int64): The N dimension of the GEMM problem.
+            k (cutlass.Int64): The K dimension of the GEMM problem.
+            l (cutlass.Int64): The batch dimension (L) of the GEMM problem.
+            a_major (str): The major layout of tensor A ('k' or 'm').
+            b_major (str): The major layout of tensor B ('k' or 'n').
+            c_major (str): The major layout of tensor C ('n' or 'm').
+
+        Returns:
+            bool: True if the configuration is supported, False otherwise.
+        """
+        can_implement = True
+        # Skip unsupported types
+        if not cls.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, c_dtype
+        ):
+            can_implement = False
+        # Skip unsupported layouts
+        if not cls.is_valid_layouts(ab_dtype, c_dtype, a_major, b_major, c_major):
+            can_implement = False
+        # Skip invalid mma tile shape and cluster shape
+        if not cls.is_valid_mma_tiler_and_cluster_shape(mma_tiler_mn, cluster_shape_mn):
+            can_implement = False
+        # Skip illegal problem shape for load/store alignment
+        if not cls.is_valid_tensor_alignment(
+            m, n, k, l, ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+        return can_implement
+
+    # fully dynamic shape
+    @cute.jit
+    def wrapper(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        sf_m: cutlass.Int64,
+        sf_n: cutlass.Int64,
+        sf_k: cutlass.Int64,
+        l: cutlass.Constexpr,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        alpha_tensor: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        current_stream,
+        swap_ab: cutlass.Constexpr = False,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+    ):
+        """Executes the wrapped GEMM kernel with dynamically shaped tensors.
+
+        Uses TVM-FFI for efficient tensor passing: A, B, C, and alpha are passed
+        as cute.Tensor directly (torch tensors at runtime via TVM-FFI's C-level
+        dlpack, with negligible conversion cost). Scale factor tensors remain as
+        pointers because their 6D BlockScaledBasicChunk layout cannot be expressed
+        as a torch tensor.
+
+        Args:
+            mA (cute.Tensor): Input tensor A.
+                FP4 path: shape (m, k_packed), dtype Uint8 (2xFP4 packed per byte).
+                MXFP8 path: shape (m, k), dtype Float8.
+            mB (cute.Tensor): Input tensor B.
+                FP4 path: shape (n, k_packed), dtype Uint8.
+                MXFP8 path: shape (n, k), dtype Float8.
+            mC (cute.Tensor): Output tensor C, shape (m, n).
+            sf_m (cutlass.Int64): Scale factor M dim (ceil(m/128)).
+            sf_n (cutlass.Int64): Scale factor N dim (ceil(n/128)).
+            sf_k (cutlass.Int64): Scale factor K dim (ceil(k/sf_vec_size/4)).
+            l (cutlass.Constexpr): Batch dimension (L).
+            a_sf_ptr (cute.Pointer): Pointer to scale factor tensor for A.
+            b_sf_ptr (cute.Pointer): Pointer to scale factor tensor for B.
+            alpha_tensor (cute.Tensor): Alpha scaling factor, shape (1,), float32.
+            max_active_clusters (cutlass.Constexpr): Max active clusters.
+            current_stream: CUDA stream (managed by TVM-FFI fake stream).
+            swap_ab (cutlass.Constexpr): Whether A/B are swapped (controls C layout).
+            epilogue_op (cutlass.Constexpr): Elementwise epilogue function.
+        """
+        # A, B, C are passed as cute.Tensor via TVM-FFI.
+        # Support two input encodings:
+        # 1) FP4 packed as uint8 (recast to Float4E2M1FN, k = k_packed * 2)
+        # 2) MXFP8 as float8 (k = k_raw, no recast)
+        m = cute.size(mA, mode=[0])
+        k_raw = cute.size(mA, mode=[1])
+        # B's contraction extent comes from B ITSELF. Equal to A's for every
+        # mode except k_loop, where A is the K-concat activation at 2K and B
+        # (the weight) stays at K. Rebuilding B with A's K would read across
+        # row boundaries.
+        k_raw_b = cute.size(mB, mode=[1])
+        n = cute.size(mB, mode=[0])
+
+        if cutlass.const_expr(
+            mA.element_type == cutlass.Uint8 and mB.element_type == cutlass.Uint8
+        ):
+            # FP4 packed path: 2 FP4 values per uint8 byte
+            k = k_raw * 2
+            k_b = k_raw_b * 2
+            a_ptr = cute.recast_ptr(mA.iterator, dtype=cutlass.Float4E2M1FN)
+            b_ptr = cute.recast_ptr(mB.iterator, dtype=cutlass.Float4E2M1FN)
+        elif cutlass.const_expr(mA.element_type != mB.element_type):
+            raise TypeError(
+                "Unsupported mixed input dtypes for block-scaled GEMM: "
+                "mA and mB must have matching element_type "
+                "(both Uint8 for FP4 path, or both FP8 for MXFP8 path)."
+            )
+        else:
+            # MXFP8 path: input tensors are already FP8.
+            k = k_raw
+            k_b = k_raw_b
+            a_ptr = mA.iterator
+            b_ptr = mB.iterator
+
+        # Row strides come from the INCOMING tensors, not from (m, k). They are
+        # equal for a compact operand, but an ext-K residue weight arrives as a
+        # `weight_ext[:, :k_base_packed]` view: width k_base, rows k_ext apart.
+        # make_ordered_layout would rebuild a compact layout and silently read
+        # the wrong elements, so build the layout explicitly instead.
+        # The FP4 branch doubled k when recasting uint8 -> Float4E2M1FN, so the
+        # strides must be doubled with it: they are counted in ELEMENTS.
+        _scale = (
+            2
+            if cutlass.const_expr(
+                mA.element_type == cutlass.Uint8 and mB.element_type == cutlass.Uint8
+            )
+            else 1
+        )
+        lda = cute.size(mA.layout.stride[0]) * _scale
+        ldb = cute.size(mB.layout.stride[0]) * _scale
+        a_tensor = cute.make_tensor(
+            a_ptr,
+            layout=cute.make_layout((m, k, l), stride=(lda, 1, m * lda)),
+        )
+        b_tensor = cute.make_tensor(
+            b_ptr,
+            layout=cute.make_layout((n, k_b, l), stride=(ldb, 1, n * ldb)),
+        )
+        # Reshape C to (m, n, l) -- swap_ab is constexpr, determines layout at compile time
+        c_alias_tensor = None
+        if cutlass.const_expr(self.fold_pairs_tma):
+            # N-ext: mC is row-major D[m_tok, n_w]; kernel-facing C = transposed
+            # affine view (n_w contiguous) so the TMA box lands on D
+            # directly. The alias keeps the m2-contiguous stride fiction
+            # (partition-geometry metadata only, never dereferenced).
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_layout((m, n // 2, l), stride=(1, m, m * (n // 2))),
+            )
+            c_alias_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_layout(
+                    (m, (2, n // 2), l),
+                    stride=(n // 2, (0, 1), m * (n // 2)),
+                ),
+            )
+        elif cutlass.const_expr(swap_ab):
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(0, 1, 2)),
+            )
+        else:
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
+            )
+        # Scale factor tensors: 6D BlockScaledBasicChunk layout from pointers
+        # (32, 4, sf_m, 4, sf_k, l) with order (2, 1, 4, 0, 3, 5)
+        # k_loop: A is the K-concat activation at 2K, so its SF grid has twice
+        # the K extent of B's (the weight's). sf_k is passed for the BASE K.
+        if cutlass.const_expr(self.k_loop):
+            _sfa_k = sf_k * 2
+        else:
+            _sfa_k = sf_k
+        sfa_tensor = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_m, 4, _sfa_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+        sfb_tensor = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_n, 4, sf_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+
+        if cutlass.const_expr(self.fold_pairs_tma):
+            self(
+                a_tensor,
+                b_tensor,
+                sfa_tensor,
+                sfb_tensor,
+                c_tensor,
+                alpha_tensor,
+                max_active_clusters,
+                current_stream,
+                epilogue_op,
+                c_alias_tensor,
+            )
+        else:
+            self(
+                a_tensor,
+                b_tensor,
+                sfa_tensor,
+                sfb_tensor,
+                c_tensor,
+                alpha_tensor,
+                max_active_clusters,
+                current_stream,
+                epilogue_op,
+            )

--- a/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/kernel_sm103_fold.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/kernel_sm103_fold.py
@@ -1,0 +1,2798 @@
+# Copyright (c) 2025 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice, this
+# list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+# this list of conditions and the following disclaimer in the documentation
+# and/or other materials provided with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+# This file is ported from CUTLASS's sm103_dense_blockscaled_gemm_persistent.py
+# with modifications for FlashInfer integration (alpha scaling, PDL support, wrapper method).
+# Original: https://github.com/NVIDIA/cutlass/blob/main/examples/python/CuTeDSL/blackwell/sm103_dense_blockscaled_gemm_persistent.py
+#
+# Adapted from FlashInfer's dense_blockscaled_gemm_sm103.py for residue fold.
+
+from dataclasses import dataclass, field
+from typing import Tuple, Type, Union
+
+import cuda.bindings.driver as cuda
+import cutlass
+import cutlass.cute as cute
+import cutlass.pipeline as pipeline
+import cutlass.utils as utils
+import cutlass.utils.blackwell_helpers as sm103_utils
+import cutlass.utils.blockscaled_layout as blockscaled_utils
+from cutlass.cute.arch import griddepcontrol_launch_dependents, griddepcontrol_wait
+from cutlass.cute.nvgpu import cpasync, tcgen05
+from cutlass.pipeline import pipeline_init_arrive, pipeline_init_wait
+
+# ResInfer MExt R1 fork (see fold_epilogue.py): the direct-store epilogue is
+# replaced by a row-pair folding store, and wrapper() gains a fold_pairs mode
+# that builds the pair-collapsed output view. Forked from FlashInfer's
+# dense_blockscaled_gemm_sm103.py (BSD-3-Clause, header retained above).
+from .fold_epilogue import mext_fold_epilogue, mext_fold_epilogue_tma
+
+
+class Sm103BlockScaledPersistentDenseGemmKernel:
+    """This class implements batched matrix multiplication (C = A x SFA x B x SFB) with support for FP4 data types
+    and architectural features specific to Blackwell SM103 GPUs with persistent tile scheduling and warp specialization.
+
+    :param sf_vec_size: Scalefactor vector size.
+    :type sf_vec_size: int
+    :param mma_tiler_mn: Shape of the Matrix Multiply-Accumulate (MMA) tile (M,N)
+    :type mma_tiler_mn: Tuple[int, int]
+    :param cluster_shape_mn: Cluster dimensions (M,N) for parallel processing
+    :type cluster_shape_mn: Tuple[int, int]
+
+
+    :note: In current version, A and B tensor must have the same data type
+        - i.e., Float4E2M1FN for A and Float4E2M1FN for B is not supported
+
+    :note: Supported combinations of A/B data types, SF data typs and SF vector size:
+        - MXF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU + sf_vec_size: 32
+        - NVF4: A/B: Float4E2M1FN + SF: Float8E8M0FNU/Float8E4M3FN + sf_vec_size: 16
+
+    :note: Supported accumulator data types:
+        - Float32
+
+    :note: Supported C data types:
+        - Float32
+        - Float16/BFloat16
+        - Float8E4M3FN/Float8E5M2
+    :note: Constraints:
+        - MMA tiler M must be 128 or 256 (use_2cta_instrs)
+        - MMA tiler N must be 128/256
+        - Cluster shape M must be multiple of 2 if Mma tiler M is 256
+        - Cluster shape M/N must be positive and power of 2, total cluster size <= 16
+        - Cluster shape M/N must be <= 4 for scale factor multicasts due to limited size of scale factors
+
+    Example:
+        >>> gemm = Sm103BlockScaledPersistentDenseGemmKernel(
+        ...     sf_vec_size=16,
+        ...     mma_tiler_mn=(256, 256),
+        ...     cluster_shape_mn=(2, 4)
+        ... )
+        >>> gemm(a_tensor, b_tensor, sfa_tensor, sfb_tensor, c_tensor, max_active_clusters, stream)
+    """
+
+    def __init__(
+        self,
+        sf_vec_size: int,
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        use_tma_store: bool,
+        enable_pdl: bool = True,
+        fold_pairs_tma: bool = False,
+    ):
+        """Initializes the configuration for a Blackwell SM103 3xFP4 GEMM kernel.
+
+        This configuration includes several key aspects:
+
+        1.  MMA Instruction Settings (tcgen05):
+            - acc_dtype: Data types for MMA accumulator, always set to Float32
+            - sf_vec_size: Scalefactor A/B vector size.
+            - mma_tiler_mn: The (M, N) shape of the MMA instruction tiler.
+
+        2.  Cluster Shape:
+            - cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster.
+
+        :param sf_vec_size: Scalefactor vector size.
+        :type sf_vec_size: int
+        :param mma_tiler_mn: Tuple (M, N) shape of the MMA instruction.
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: Tuple (ClusterM, ClusterN) shape of the cluster.
+        :type cluster_shape_mn: Tuple[int, int]
+        :param use_tma_store: Whether TMA store is enabled.
+        :type use_tma_store: bool
+        :param enable_pdl: Whether Programmatic Dependent Launch is enabled.
+        :type enable_pdl: bool
+        """
+        self.acc_dtype = cutlass.Float32
+        self.sf_vec_size = sf_vec_size
+        self.use_2cta_instrs = mma_tiler_mn[0] == 256
+        self.cluster_shape_mn = cluster_shape_mn
+        # K dimension is deferred in _setup_attributes
+        self.mma_tiler = (*mma_tiler_mn, 1)
+        self.use_tma_store = use_tma_store
+        self.enable_pdl = enable_pdl
+        # ResInfer MExt: TMA-store fold mode. The accumulator side keeps
+        # stock m2-wide geometry; the C/TMA side uses half-width tiles over
+        # the compact D_t[n_w, m_tok] (see fold_epilogue.mext_fold_epilogue_tma).
+        self.fold_pairs_tma = fold_pairs_tma and use_tma_store
+        self.cta_group = (
+            tcgen05.CtaGroup.TWO if self.use_2cta_instrs else tcgen05.CtaGroup.ONE
+        )
+
+        self.occupancy = 1
+        # Set specialized warp ids
+        self.epilogue_warp_id = (
+            0,
+            1,
+            2,
+            3,
+        )
+        self.mma_warp_id = 4
+        self.tma_ab_warp_id = 5
+        self.tma_sf_warp_id = 6
+        self.threads_per_cta = 32 * len(
+            (
+                self.mma_warp_id,
+                self.tma_ab_warp_id,
+                self.tma_sf_warp_id,
+                *self.epilogue_warp_id,
+            )
+        )
+        # Set barrier id for epilogue sync and tmem ptr sync
+        self.epilog_sync_bar_id = 1
+        self.tmem_alloc_sync_bar_id = 2
+        self.tmem_dealloc_sync_bar_id = 3
+        self.smem_capacity = utils.get_smem_capacity_in_bytes("sm_103")
+        # SM103 TMEM capacity is 512 columns (same as SM100).
+        # This replaces cute.arch.get_max_tmem_alloc_cols("sm_103") which
+        # may not be available in older cutlass-dsl versions.
+        SM103_TMEM_CAPACITY_COLUMNS = 512
+        self.num_tmem_alloc_cols = SM103_TMEM_CAPACITY_COLUMNS
+        self.sf_buffers_per_tile_k = 4 if self.sf_vec_size == 16 else 2
+
+    def _setup_attributes(self):
+        """Set up kernel attributes that depend on runtime tensor inputs.
+
+        This method configures various attributes based on the input tensor properties
+        (data types, leading dimensions) and kernel settings:
+        - Configuring tiled MMA
+        - Computing MMA/cluster/tile shapes
+        - Computing cluster layout
+        - Computing multicast CTAs for A/B/SFA/SFB
+        - Computing epilogue subtile
+        - Setting up A/B/SFA/SFB/C stage counts in shared memory
+        - Computing A/B/SFA/SFB/C shared memory layout
+        """
+        # Compute mma instruction shapes
+        # (MMA_Tile_Shape_M, MMA_Tile_Shape_N, MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn = (self.mma_tiler[0], self.mma_tiler[1])
+
+        # (CTA_Tile_Shape_M, Round_Up(MMA_Tile_Shape_N, 128), MMA_Inst_Shape_K)
+        self.mma_inst_shape_mn_sfb = (
+            self.mma_inst_shape_mn[0] // (2 if self.use_2cta_instrs else 1),
+            cute.round_up(self.mma_inst_shape_mn[1], 128),
+        )
+
+        tiled_mma = self.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        dummy_tiled_mma_sfb = self.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+
+        # Compute mma/cluster/tile shapes
+        self.mma_tiler = (
+            self.mma_inst_shape_mn[0],
+            self.mma_inst_shape_mn[1],
+            768,
+        )
+        self.cta_tile_shape_mnk = (
+            self.mma_tiler[0] // cute.size(tiled_mma.thr_layout_vmnk.shape[0]),
+            self.mma_tiler[1],
+            self.mma_tiler[2],
+        )
+        blk_mn = 128
+        self.cta_n_sf = cute.round_up(cute.size(self.cta_tile_shape_mnk[1]), blk_mn)
+        self.mma_sf_tiler = (
+            self.cta_tile_shape_mnk[0],
+            self.cta_n_sf,
+            self.cta_tile_shape_mnk[2] // self.sf_buffers_per_tile_k,
+        )
+
+        self.sf_atom = self.Sm103BlockScaledBasicChunk(
+            self.sf_vec_size, tiled_mma.op.a_major_mode
+        ).layout
+
+        # Compute cluster layout
+        self.cluster_layout_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (tiled_mma.thr_id.shape,),
+        )
+        self.cluster_layout_sfb_vmnk = cute.tiled_divide(
+            cute.make_layout((*self.cluster_shape_mn, 1)),
+            (dummy_tiled_mma_sfb.thr_id.shape,),
+        )
+
+        # Compute number of multicast CTAs for A/B
+        self.num_mcast_ctas_a = cute.size(self.cluster_layout_vmnk.shape[2])
+        self.num_mcast_ctas_b = cute.size(self.cluster_layout_vmnk.shape[1])
+        self.num_mcast_ctas_sfb = cute.size(self.cluster_layout_sfb_vmnk.shape[1])
+        self.is_a_mcast = self.num_mcast_ctas_a > 1
+        self.is_b_mcast = self.num_mcast_ctas_b > 1
+        self.is_sfb_mcast = self.num_mcast_ctas_sfb > 1
+
+        # Compute epilogue subtile
+        self.epi_tile = (self.cta_tile_shape_mnk[0], 64)
+        # ResInfer MExt: half-width C-side epi tile for the TMA fold path
+        # (accumulator subtiles stay m2-wide; folded output is m_tok-wide,
+        # same subtile count, 2x narrower).
+        self.epi_tile_c = (self.epi_tile[0], self.epi_tile[1] // 2)
+
+        self.num_acc_stage, self.num_ab_stage, self.num_sf_stage, self.num_c_stage = (
+            self._compute_stages(
+                tiled_mma,
+                self.mma_tiler,
+                self.epi_tile,
+                self.c_dtype,
+                self.c_layout,
+                self.sf_dtype,
+                self.sf_vec_size,
+                self.smem_capacity,
+                self.occupancy,
+                self.use_tma_store,
+            )
+        )
+
+        # Overlapping accumulator (ported from kernel_sm100_fold, measured
+        # +6.8-8.3% on B200 tp1 fold m>=384): at N=256 only one honest acc
+        # stage fits TMEM, so two pseudo-buffers overlap by the SF column
+        # footprint; phase 0 drains its subtiles in reverse so the shared
+        # columns are consumed first and the pipeline is released early.
+        # Scoped to OUR fold epilogues (fold_epilogue.py); the plain path
+        # uses the stock library epilogue, which drains strictly serially.
+        self.overlapping_accum = self.num_acc_stage == 1 and (
+            self.fold_pairs_tma or not self.use_tma_store
+        )
+        # Set at trace time in the kernel body (needs the SF TMEM layouts);
+        # consumed by fold_epilogue.py as a Constexpr attribute.
+        self.iter_acc_early_release_in_epilogue = None
+
+        # Compute A/B/SFA/SFB/C shared memory layout
+        # ((CTA_MMA_M,16bytes),1,8,num_ab_stage)
+        self.a_smem_layout_staged = self.sm103_make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            self.num_ab_stage,
+        )
+
+        # ((CTA_MMA_M,16bytes),1,8,3)
+        self.a_smem_layout_staged_tma = self.sm103_make_smem_layout_a(
+            tiled_mma,
+            self.mma_tiler,
+            3,
+        )
+
+        # ((CTA_MMA_N,16bytes),1,8,num_ab_stage)
+        self.b_smem_layout_staged = self.sm103_make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            self.num_ab_stage,
+        )
+
+        # ((CTA_MMA_N,16bytes),1,8,3)
+        self.b_smem_layout_staged_tma = self.sm103_make_smem_layout_b(
+            tiled_mma,
+            self.mma_tiler,
+            3,
+        )
+
+        # (((8,4,4),(sf_vec_size,4)),1,3,num_sf_stage)
+        self.sfa_smem_layout_staged = self.sm103_make_smem_layout_sfa(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_sf_stage,
+        )
+
+        # (((32,4,2),(sf_vec_size,4)),1,3,num_sf_stage)
+        self.sfb_smem_layout_staged = self.sm103_make_smem_layout_sfb(
+            tiled_mma,
+            self.mma_tiler,
+            self.sf_vec_size,
+            self.num_sf_stage,
+        )
+        self.c_smem_layout_staged = None
+        if self.use_tma_store:
+            if self.fold_pairs_tma:
+                # Transposed half-width staging (n_w contiguous): the TMA box
+                # maps directly onto row-major D[m_tok, n_w], eliminating the
+                # host-side transpose. Threads write their 32 m_tok values at
+                # stride epi_m (scalar STS; instruction count is not the
+                # epilogue bottleneck -- SASS-verified). Half-width staging
+                # frees half the stock smem budget: spend it on 2x stages to
+                # cut TMA-drain waits in producer_acquire.
+                self.num_c_stage *= 2
+                epi_m, epi_n2 = self.epi_tile_c
+                self.c_smem_layout_staged = cute.make_layout(
+                    (epi_m, epi_n2, self.num_c_stage),
+                    stride=(1, epi_m, epi_m * epi_n2),
+                )
+            else:
+                self.c_smem_layout_staged = sm103_utils.make_smem_layout_epi(
+                    self.c_dtype, self.c_layout, self.epi_tile, self.num_c_stage
+                )
+
+    @cute.jit
+    def __call__(
+        self,
+        a_tensor: cute.Tensor,
+        b_tensor: cute.Tensor,
+        sfa_tensor: cute.Tensor,
+        sfb_tensor: cute.Tensor,
+        c_tensor: cute.Tensor,
+        alpha: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        stream: cuda.CUstream,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+        c_alias_tensor: cute.Tensor = None,
+    ):
+        """Execute the GEMM operation in steps:
+        - Setup static attributes before smem/grid/tma computation
+        - Setup TMA load/store atoms and tensors
+        - Compute grid size with regard to hardware constraints
+        - Define shared storage for kernel
+        - Launch the kernel synchronously
+
+        :param a_tensor: Input tensor A
+        :type a_tensor: cute.Tensor
+        :param b_tensor: Input tensor B
+        :type b_tensor: cute.Tensor
+        :param sfa_tensor: Scale factor tensor A
+        :type sfa_tensor: cute.Tensor
+        :param sfb_tensor: Scale factor tensor B
+        :type sfb_tensor: cute.Tensor
+        :param c_tensor: Output tensor C
+        :type c_tensor: cute.Tensor
+        :param alpha: Single-element tensor containing alpha scaling value
+        :type alpha: cute.Tensor
+        :param max_active_clusters: Maximum number of active clusters
+        :type max_active_clusters: cutlass.Constexpr
+        :param stream: CUDA stream for asynchronous execution
+        :type stream: cuda.CUstream
+        :param epilogue_op: Optional elementwise lambda function to apply to the output tensor
+        :type epilogue_op: cutlass.Constexpr
+        :raises TypeError: If input data types are incompatible with the MMA instruction.
+        """
+        # Setup static attributes before smem/grid/tma computation
+        self.a_dtype: Type[cutlass.Numeric] = a_tensor.element_type
+        self.b_dtype: Type[cutlass.Numeric] = b_tensor.element_type
+        self.sf_dtype: Type[cutlass.Numeric] = sfa_tensor.element_type
+        self.c_dtype: Type[cutlass.Numeric] = c_tensor.element_type
+        self.a_major_mode = utils.LayoutEnum.from_tensor(a_tensor).mma_major_mode()
+        self.b_major_mode = utils.LayoutEnum.from_tensor(b_tensor).mma_major_mode()
+        if cutlass.const_expr(self.fold_pairs_tma):
+            # The physical C is the transposed D view (m-major); the TMEM
+            # load atom must still be chosen for the m2-contiguous (n-major)
+            # fragment orientation the fold pairing relies on. Pin the enum
+            # rather than deriving it from the transposed tensor.
+            self.c_layout = utils.LayoutEnum.ROW_MAJOR
+        else:
+            self.c_layout = utils.LayoutEnum.from_tensor(c_tensor)
+        # Check if input data types are compatible with MMA instruction
+        if cutlass.const_expr(self.a_dtype != self.b_dtype):
+            raise TypeError(f"Type must match: {self.a_dtype} != {self.b_dtype}")
+
+        # Setup attributes that dependent on gemm inputs
+        self._setup_attributes()
+
+        # Setup sfa/sfb tensor by filling A/B tensor to scale factor atom layout
+        sfa_layout = cute.tile_to_shape(self.sf_atom, a_tensor.shape, (2, 1, 3))
+        sfa_tensor = cute.make_tensor(sfa_tensor.iterator, sfa_layout)
+
+        sfb_layout = cute.tile_to_shape(self.sf_atom, b_tensor.shape, (2, 1, 3))
+        sfb_tensor = cute.make_tensor(sfb_tensor.iterator, sfb_layout)
+
+        tiled_mma = self.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            self.cta_group,
+            self.mma_inst_shape_mn,
+        )
+
+        dummy_tiled_mma_sfb = self.sm103_make_blockscaled_trivial_tiled_mma(
+            self.sf_dtype,
+            self.sf_vec_size,
+            tcgen05.CtaGroup.ONE,
+            self.mma_inst_shape_mn_sfb,
+        )
+        atom_thr_size = cute.size(tiled_mma.thr_id.shape)
+
+        # Setup TMA load for A
+        a_op = sm103_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        # casting layout as uint8 for multicast
+        a_smem_layout_tma_ready = self.adapt_layout_for_tma_ab(
+            self.a_smem_layout_staged_tma
+        )
+        a_tensor_uint8 = cute.recast_tensor(a_tensor, cutlass.Uint8)
+        tma_atom_a, tma_tensor_a = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            a_op,
+            a_tensor_uint8,
+            a_smem_layout_tma_ready,
+            # 384 corresponds to the number of uint8 elements along the K dimension processed in a single MMA mainloop iteration.
+            (cute.size(tiled_mma.tv_layout_A[1][0]), 384),
+            self.cluster_shape_mn[1],
+            internal_type=cutlass.Uint8,
+        )
+
+        # Setup TMA load for B
+        b_op = sm103_utils.cluster_shape_to_tma_atom_B(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        # casting layout as uint8 for multicast
+        b_smem_layout_tma_ready = self.adapt_layout_for_tma_ab(
+            self.b_smem_layout_staged_tma
+        )
+        b_tensor_uint8 = cute.recast_tensor(b_tensor, cutlass.Uint8)
+        tma_atom_b, tma_tensor_b = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            b_op,
+            b_tensor_uint8,
+            b_smem_layout_tma_ready,
+            (cute.size(tiled_mma.tv_layout_B[1][0]), 384),
+            self.cluster_shape_mn[0] // cute.size(tiled_mma.thr_id.shape),
+            internal_type=cutlass.Uint8,
+        )
+
+        # Setup TMA load for SFA
+        sfa_op = sm103_utils.cluster_shape_to_tma_atom_A(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfa_smem_layout = cute.slice_(
+            self.sfa_smem_layout_staged, (None, None, None, 0)
+        )
+        sfa_smem_layout_tma_ready = self.adapt_layout_for_tma_sf(sfa_smem_layout)
+        tma_atom_sfa, tma_tensor_sfa = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            sfa_op,
+            sfa_tensor,
+            sfa_smem_layout_tma_ready,
+            (self.mma_sf_tiler[0], self.mma_sf_tiler[2]),
+            self.cluster_shape_mn[1],
+            internal_type=cutlass.Uint8,
+        )
+
+        # Setup TMA load for SFB
+        sfb_op = sm103_utils.cluster_shape_to_tma_atom_SFB(
+            self.cluster_shape_mn, tiled_mma.thr_id
+        )
+        sfb_smem_layout = cute.slice_(
+            self.sfb_smem_layout_staged, (None, None, None, 0)
+        )
+        sfb_smem_layout_tma_ready = self.adapt_layout_for_tma_sf(sfb_smem_layout)
+        tma_atom_sfb, tma_tensor_sfb = cute.nvgpu.cpasync.make_tiled_tma_atom(
+            sfb_op,
+            sfb_tensor,
+            sfb_smem_layout_tma_ready,
+            (self.mma_sf_tiler[1], self.mma_sf_tiler[2]),
+            self.cluster_shape_mn[0] // cute.size(dummy_tiled_mma_sfb.thr_id),
+            internal_type=cutlass.Uint8,
+        )
+
+        # Setup TMA store for C
+        tma_atom_c = None
+        tma_tensor_c = None
+        if cutlass.const_expr(self.use_tma_store):
+            epi_smem_layout = cute.slice_(self.c_smem_layout_staged, (None, None, 0))
+            tma_atom_c, tma_tensor_c = cpasync.make_tiled_tma_atom(
+                cpasync.CopyBulkTensorTileS2GOp(),
+                c_tensor,
+                epi_smem_layout,
+                self.epi_tile_c if self.fold_pairs_tma else self.epi_tile,
+            )
+
+        a_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.a_smem_layout_staged_tma, (None, None, None, 0)),
+        )
+        b_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.b_smem_layout_staged_tma, (None, None, None, 0)),
+        )
+        sfa_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.sfa_smem_layout_staged, (None, None, None, 0)),
+        )
+        sfb_copy_size = cute.size_in_bytes(
+            cutlass.Uint8,
+            cute.slice_(self.sfb_smem_layout_staged, (None, None, None, 0)),
+        )
+        self.num_tma_load_bytes_ab = (a_copy_size + b_copy_size) * atom_thr_size
+        self.num_tma_load_bytes_sf = (sfa_copy_size + sfb_copy_size) * atom_thr_size
+
+        # Compute grid size. For the TMA fold path the compact C is half the
+        # GEMM's logical N, so tiling must come from the m2-congruent alias.
+        self.tile_sched_params, grid = self._compute_grid(
+            c_alias_tensor if self.fold_pairs_tma else c_tensor,
+            self.cta_tile_shape_mnk,
+            self.cluster_shape_mn,
+            max_active_clusters,
+        )
+
+        self.buffer_align_bytes = 1024
+
+        # Define shared storage for kernel
+        @cute.struct
+        class SharedStorage:
+            ab_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            ab_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_ab_stage]
+            sf_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_sf_stage]
+            sf_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_sf_stage]
+            acc_full_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            acc_empty_mbar_ptr: cute.struct.MemRange[cutlass.Int64, self.num_acc_stage]
+            tmem_dealloc_mbar_ptr: cutlass.Int64
+            tmem_holding_buf: cutlass.Int32
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sA: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8, cute.cosize(self.a_smem_layout_staged.outer)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sB: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8, cute.cosize(self.b_smem_layout_staged.outer)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_M, MMA_K, STAGE)
+            sSFA: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8, cute.cosize(self.sfa_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+            # (MMA, MMA_N, MMA_K, STAGE)
+            sSFB: cute.struct.Align[
+                cute.struct.MemRange[
+                    cutlass.Uint8, cute.cosize(self.sfb_smem_layout_staged)
+                ],
+                self.buffer_align_bytes,
+            ]
+
+        self.shared_storage = SharedStorage
+
+        # Launch the kernel synchronously
+        self.kernel(
+            tiled_mma,
+            tma_atom_a,
+            tma_tensor_a,
+            tma_atom_b,
+            tma_tensor_b,
+            tma_atom_sfa,
+            tma_tensor_sfa,
+            tma_atom_sfb,
+            tma_tensor_sfb,
+            tma_atom_c,
+            (
+                c_alias_tensor
+                if self.fold_pairs_tma
+                else (tma_tensor_c if self.use_tma_store else c_tensor)
+            ),
+            self.cluster_layout_vmnk,
+            self.cluster_layout_sfb_vmnk,
+            self.a_smem_layout_staged,
+            self.b_smem_layout_staged,
+            self.sfa_smem_layout_staged,
+            self.sfb_smem_layout_staged,
+            self.c_smem_layout_staged,
+            self.epi_tile,
+            self.tile_sched_params,
+            epilogue_op,
+            alpha,
+            tma_tensor_c if self.fold_pairs_tma else None,
+        ).launch(
+            grid=grid,
+            block=[self.threads_per_cta, 1, 1],
+            cluster=(*self.cluster_shape_mn, 1),
+            stream=stream,
+            min_blocks_per_mp=1,
+            use_pdl=self.enable_pdl,
+        )
+        return
+
+    # GPU device kernel
+    @cute.kernel
+    def kernel(
+        self,
+        tiled_mma: cute.TiledMma,
+        tma_atom_a: cute.CopyAtom,
+        mA_mkl: cute.Tensor,
+        tma_atom_b: cute.CopyAtom,
+        mB_nkl: cute.Tensor,
+        tma_atom_sfa: cute.CopyAtom,
+        mSFA_mkl: cute.Tensor,
+        tma_atom_sfb: cute.CopyAtom,
+        mSFB_nkl: cute.Tensor,
+        tma_atom_c: cute.CopyAtom,
+        mC_mnl: cute.Tensor,
+        cluster_layout_vmnk: cute.Layout,
+        cluster_layout_sfb_vmnk: cute.Layout,
+        a_smem_layout_staged: cute.ComposedLayout,
+        b_smem_layout_staged: cute.ComposedLayout,
+        sfa_smem_layout_staged: cute.Layout,
+        sfb_smem_layout_staged: cute.Layout,
+        c_smem_layout_staged: Union[cute.Layout, cute.ComposedLayout, None],
+        epi_tile: cute.Tile,
+        tile_sched_params: utils.PersistentTileSchedulerParams,
+        epilogue_op: cutlass.Constexpr,
+        alpha: cute.Tensor,
+        mC_fold_tma: cute.Tensor = None,
+    ):
+        """
+        GPU device kernel performing the Persistent batched GEMM computation.
+        """
+        # Keep alpha in FP32 for precision: the accumulator is in FP32 and alpha
+        # may be a very small scaling factor. Converting to c_dtype (e.g., FP16)
+        # before multiplication could cause overflow when acc values are large.
+        alpha_value = alpha[0].to(cutlass.Float32)
+
+        warp_idx = cute.arch.warp_idx()
+        warp_idx = cute.arch.make_warp_uniform(warp_idx)
+
+        #
+        # Prefetch tma desc
+        #
+        if warp_idx == self.tma_ab_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_a)
+            cpasync.prefetch_descriptor(tma_atom_b)
+            if cutlass.const_expr(self.use_tma_store):
+                cpasync.prefetch_descriptor(tma_atom_c)
+        if warp_idx == self.tma_sf_warp_id:
+            cpasync.prefetch_descriptor(tma_atom_sfa)
+            cpasync.prefetch_descriptor(tma_atom_sfb)
+
+        use_2cta_instrs = cute.size(tiled_mma.thr_id.shape) == 2
+
+        #
+        # Setup cta/thread coordinates
+        #
+        # Coords inside cluster
+        bidx, bidy, bidz = cute.arch.block_idx()
+        mma_tile_coord_v = bidx % cute.size(tiled_mma.thr_id.shape)
+        is_leader_cta = mma_tile_coord_v == 0
+        cta_rank_in_cluster = cute.arch.make_warp_uniform(
+            cute.arch.block_idx_in_cluster()
+        )
+        block_in_cluster_coord_vmnk = cluster_layout_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        block_in_cluster_coord_sfb_vmnk = cluster_layout_sfb_vmnk.get_flat_coord(
+            cta_rank_in_cluster
+        )
+        # Coord inside cta
+        tidx, _, _ = cute.arch.thread_idx()
+
+        #
+        # Alloc and init: a+b full/empty, sfa+sfb full/empty, accumulator full/empty, tensor memory dealloc barrier
+        #
+        smem = utils.SmemAllocator()
+        storage = smem.allocate(self.shared_storage)
+
+        # Initialize mainloop ab_producer and ab_consumer
+        ab_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        ab_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_tma_producer
+        )
+        ab_producer, ab_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.ab_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_ab_stage,
+            producer_group=ab_producer_group,
+            consumer_group=ab_consumer_group,
+            tx_count=self.num_tma_load_bytes_ab,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        # Initialize mainloop sf_producer and sf_consumer
+        sf_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_sf_tma_producer = self.num_mcast_ctas_a + self.num_mcast_ctas_b - 1
+        sf_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_sf_tma_producer
+        )
+        sf_producer, sf_consumer = pipeline.PipelineTmaUmma.create(
+            barrier_storage=storage.sf_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_sf_stage,
+            producer_group=sf_producer_group,
+            consumer_group=sf_consumer_group,
+            tx_count=self.num_tma_load_bytes_sf,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        ).make_participants()
+
+        # Initialize acc_pipeline (barrier) and states
+        acc_pipeline_producer_group = pipeline.CooperativeGroup(pipeline.Agent.Thread)
+        num_acc_consumer_threads = len(self.epilogue_warp_id) * (
+            2 if use_2cta_instrs else 1
+        )
+        acc_pipeline_consumer_group = pipeline.CooperativeGroup(
+            pipeline.Agent.Thread, num_acc_consumer_threads
+        )
+        acc_pipeline = pipeline.PipelineUmmaAsync.create(
+            barrier_storage=storage.acc_full_mbar_ptr.data_ptr(),
+            num_stages=self.num_acc_stage,
+            producer_group=acc_pipeline_producer_group,
+            consumer_group=acc_pipeline_consumer_group,
+            cta_layout_vmnk=cluster_layout_vmnk,
+            defer_sync=True,
+        )
+
+        tmem_alloc_barrier = pipeline.NamedBarrier(
+            barrier_id=self.tmem_alloc_sync_bar_id,
+            num_threads=32 * len((self.mma_warp_id, *self.epilogue_warp_id)),
+        )
+        tmem_dealloc_barrier = None
+        if cutlass.const_expr(not self.use_tma_store):
+            tmem_dealloc_barrier = pipeline.NamedBarrier(
+                barrier_id=self.tmem_dealloc_sync_bar_id,
+                num_threads=32 * len(self.epilogue_warp_id),
+            )
+        # Tensor memory dealloc barrier init
+        tmem = utils.TmemAllocator(
+            storage.tmem_holding_buf.ptr,
+            barrier_for_retrieve=tmem_alloc_barrier,
+            allocator_warp_id=self.epilogue_warp_id[0],
+            is_two_cta=use_2cta_instrs,
+            two_cta_tmem_dealloc_mbar_ptr=storage.tmem_dealloc_mbar_ptr.ptr,
+        )
+
+        # Cluster arrive after barrier init
+        pipeline_init_arrive(cluster_shape_mn=self.cluster_shape_mn, is_relaxed=True)
+
+        #
+        # Setup smem tensor A/B/SFA/SFB/C
+        #
+        sA = storage.sA.get_tensor(
+            a_smem_layout_staged.outer, swizzle=a_smem_layout_staged.inner
+        )
+        sB = storage.sB.get_tensor(
+            b_smem_layout_staged.outer, swizzle=b_smem_layout_staged.inner
+        )
+
+        sSFA = storage.sSFA.get_tensor(sfa_smem_layout_staged)
+        sSFB = storage.sSFB.get_tensor(sfb_smem_layout_staged)
+
+        #
+        # Compute multicast mask for A/B/SFA/SFB buffer full
+        #
+        a_full_mcast_mask = None
+        b_full_mcast_mask = None
+        sfa_full_mcast_mask = None
+        sfb_full_mcast_mask = None
+        if cutlass.const_expr(self.is_a_mcast or self.is_b_mcast or use_2cta_instrs):
+            a_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            b_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=1
+            )
+            sfa_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_vmnk, block_in_cluster_coord_vmnk, mcast_mode=2
+            )
+            sfb_full_mcast_mask = cpasync.create_tma_multicast_mask(
+                cluster_layout_sfb_vmnk, block_in_cluster_coord_sfb_vmnk, mcast_mode=1
+            )
+
+        #
+        # Local_tile partition global tensors
+        #
+        # (BLK_M, BLK_K, m, k, l)
+        gA_mkl = cute.local_tile(
+            mA_mkl,
+            cute.slice_((self.mma_tiler[0], self.mma_tiler[1], 384), (None, 0, None)),
+            (None, None, None),
+        )
+        # (BLK_N, BLK_K, n, k, l)
+        gB_nkl = cute.local_tile(
+            mB_nkl,
+            cute.slice_((self.mma_tiler[0], self.mma_tiler[1], 384), (0, None, None)),
+            (None, None, None),
+        )
+        gSFA_mkl = cute.local_tile(
+            mSFA_mkl,
+            cute.slice_(self.mma_sf_tiler, (None, 0, None)),
+            (None, None, None),
+        )
+        gSFB_nkl = cute.local_tile(
+            mSFB_nkl,
+            cute.slice_(self.mma_sf_tiler, (0, None, None)),
+            (None, None, None),
+        )
+        gC_mnl = cute.local_tile(
+            mC_mnl, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        # TMA fold path: tile the compact D_t by the half-width CTA tile so
+        # its tile grid matches the m2-wide accumulator tile grid 1:1.
+        gC_fold_mnl = None
+        if cutlass.const_expr(self.fold_pairs_tma):
+            gC_fold_mnl = cute.local_tile(
+                mC_fold_tma,
+                (self.cta_tile_shape_mnk[0], self.cta_tile_shape_mnk[1] // 2),
+                (None, None, None),
+            )
+        k_tile_cnt = cute.size(gA_mkl, mode=[3])
+
+        #
+        # Partition global tensor for TiledMMA_A/B/C
+        #
+        thr_mma = tiled_mma.get_slice(mma_tile_coord_v)
+
+        # create tCgA_tmp
+        tCgA_mkl_tmp = thr_mma.partition_A(gA_mkl)
+        tCgA_layout = self.append_coalesce_layout(tCgA_mkl_tmp.layout)
+        cta_tCgA = cute.make_tensor(tCgA_mkl_tmp.iterator, tCgA_layout)
+        # ((CTA_MMA_M,256),Rest_MMA_M,Rest_MMA_K, m, k, l)
+        tCgA = cute.make_tensor(
+            cta_tCgA.iterator,
+            cute.tiled_divide(
+                cta_tCgA.layout, (cute.size(tiled_mma.tv_layout_A[1][0]), 128)
+            ),
+        )
+
+        tCgB_nkl_tmp = thr_mma.partition_B(gB_nkl)
+        tCgB_layout = self.append_coalesce_layout(tCgB_nkl_tmp.layout)
+        cta_tCgB = cute.make_tensor(tCgB_nkl_tmp.iterator, tCgB_layout)
+        # ((CTA_MMA_N,256),Rest_MMA_N, Rest_MMA_K, n, k, l)
+        tCgB = cute.make_tensor(
+            cta_tCgB.iterator,
+            cute.tiled_divide(
+                cta_tCgB.layout, (cute.size(tiled_mma.tv_layout_B[1][0]), 128)
+            ),
+        )
+
+        tCgSFA = cute.make_tensor(
+            gSFA_mkl.iterator,
+            cute.tiled_divide(
+                gSFA_mkl.layout, (self.mma_sf_tiler[0], self.mma_sf_tiler[2])
+            ),
+        )
+
+        tCgSFB = cute.make_tensor(
+            gSFB_nkl.iterator,
+            cute.tiled_divide(
+                gSFB_nkl.layout, (self.mma_sf_tiler[1], self.mma_sf_tiler[2])
+            ),
+        )
+        tCgC = thr_mma.partition_C(gC_mnl)
+
+        # Create identity tensor for C to use in epilogue predication
+        idC = cute.make_identity_tensor(mC_mnl.shape)
+        cC_mnl = cute.local_tile(
+            idC, cute.slice_(self.mma_tiler, (None, None, 0)), (None, None, None)
+        )
+        # (MMA, MMA_M, MMA_N, RestM, RestN, RestL)
+        tCcC = thr_mma.partition_C(cC_mnl)
+
+        #
+        # Partition global/shared tensor for TMA load A/B
+        #
+        # TMA load A partition_S/D
+        a_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, 0, None, 0)).shape
+        )
+
+        tAsA, tAgA = cpasync.tma_partition(
+            tma_atom_a,
+            block_in_cluster_coord_vmnk[2],
+            a_cta_layout,
+            cute.group_modes(sA, 0, 3),
+            cute.group_modes(tCgA, 0, 1),
+        )
+        # TMA load B partition_S/D
+        b_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_vmnk, (0, None, 0, 0)).shape
+        )
+        tBsB, tBgB = cpasync.tma_partition(
+            tma_atom_b,
+            block_in_cluster_coord_vmnk[1],
+            b_cta_layout,
+            cute.group_modes(sB, 0, 3),
+            cute.group_modes(tCgB, 0, 1),
+        )
+
+        # TMA partition for scale factor A
+        sfa_cta_layout = a_cta_layout
+        tAsSFA, tAgSFA = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfa,
+            block_in_cluster_coord_vmnk[2],
+            sfa_cta_layout,
+            cute.group_modes(sSFA, 0, 3),
+            cute.group_modes(tCgSFA, 0, 3),
+        )
+        tAsSFA_compact = cute.filter_zeros(tAsSFA)
+
+        # TMA partition for scale factor B
+        sfb_cta_layout = cute.make_layout(
+            cute.slice_(cluster_layout_sfb_vmnk, (0, None, 0, 0)).shape
+        )
+        tBsSFB, tBgSFB = cute.nvgpu.cpasync.tma_partition(
+            tma_atom_sfb,
+            block_in_cluster_coord_sfb_vmnk[1],
+            sfb_cta_layout,
+            cute.group_modes(sSFB, 0, 3),
+            cute.group_modes(tCgSFB, 0, 3),
+        )
+        tBsSFB_compact = cute.filter_zeros(tBsSFB)
+
+        #
+        # Partition shared/tensor memory tensor for TiledMMA_A/B/C
+        #
+        # (MMA, MMA_M, MMA_N)
+        acc_shape = tiled_mma.partition_shape_C(self.mma_tiler[:2])
+        # (MMA, MMA_M, MMA_N, STAGE)
+        if cutlass.const_expr(self.overlapping_accum):
+            # Two pseudo-buffers overlapping by the SF TMEM footprint. The SF
+            # column count is a trace-time constant derived from the same
+            # layouts the MMA warp builds; the shared region equals the last
+            # (phase 0) / first (phase 1) sf_cols-wide slice of subtiles, so
+            # the epilogue releases after draining ceil-ish sf_cols/EPI_N
+            # subtile columns (index sf_cols // EPI_N, donor formula).
+            _sf_fp = cute.make_ptr(self.sf_dtype, 0, mem_space=cute.AddressSpace.tmem)
+            _sfa_cols = tcgen05.find_tmem_tensor_col_offset(
+                cute.make_tensor(
+                    _sf_fp,
+                    blockscaled_utils.make_tmem_layout_sfa(
+                        tiled_mma,
+                        self.mma_tiler,
+                        self.sf_vec_size,
+                        cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+                    ),
+                )
+            )
+            _sfb_cols = tcgen05.find_tmem_tensor_col_offset(
+                cute.make_tensor(
+                    _sf_fp,
+                    blockscaled_utils.make_tmem_layout_sfb(
+                        tiled_mma,
+                        self.mma_tiler,
+                        self.sf_vec_size,
+                        cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+                    ),
+                )
+            )
+            _sf_cols = _sfa_cols + _sfb_cols
+            assert _sf_cols < self.cta_tile_shape_mnk[1], (
+                f"overlapping accum needs sf cols ({_sf_cols}) < tile N "
+                f"({self.cta_tile_shape_mnk[1]})"
+            )
+            self.iter_acc_early_release_in_epilogue = _sf_cols // self.epi_tile[1]
+            tCtAcc_fake = tiled_mma.make_fragment_C(cute.append(acc_shape, 2))
+            tCtAcc_fake = cute.make_tensor(
+                tCtAcc_fake.iterator,
+                cute.make_layout(
+                    tCtAcc_fake.shape,
+                    stride=(
+                        tCtAcc_fake.stride[0],
+                        tCtAcc_fake.stride[1],
+                        tCtAcc_fake.stride[2],
+                        (self.cta_tile_shape_mnk[1] - _sf_cols)
+                        * tCtAcc_fake.stride[0][1],
+                    ),
+                ),
+            )
+        else:
+            tCtAcc_fake = tiled_mma.make_fragment_C(
+                cute.append(acc_shape, self.num_acc_stage)
+            )
+
+        #
+        # Cluster wait before tensor memory alloc
+        #
+        pipeline_init_wait(cluster_shape_mn=self.cluster_shape_mn)
+
+        # PDL bookend: always emitted, actual behavior controlled by use_pdl= in .launch()
+        griddepcontrol_wait()
+
+        #
+        # Construct the scheduler
+        #
+        tile_sched = utils.StaticPersistentTileScheduler.create(
+            tile_sched_params, cute.arch.block_idx(), cute.arch.grid_dim()
+        )
+        work_tile = tile_sched.initial_work_tile_info()
+
+        #
+        # Specialized TMA load warp for A/B tensors
+        #
+        if warp_idx == self.tma_ab_warp_id:
+            #
+            # Persistent tile scheduling loop for AB loads
+            #
+            buffers_per_k_tile = 3
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                tAgA_slice = tAgA[
+                    (
+                        None,
+                        None,
+                        None,
+                        mma_tile_coord_mnl[0],
+                        None,
+                        mma_tile_coord_mnl[2],
+                    )
+                ]
+                tBgB_slice = tBgB[
+                    (
+                        None,
+                        None,
+                        None,
+                        mma_tile_coord_mnl[1],
+                        None,
+                        mma_tile_coord_mnl[2],
+                    )
+                ]
+
+                # Peek (try_wait) AB buffer empty for k_tile = prefetch_k_tile_cnt
+                ab_producer.reset()
+                peek_ab_empty_status = cutlass.Boolean(1)
+                peek_ab_empty_status = ab_producer.try_acquire()
+
+                #
+                # TMA load loop for A/B tensors
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Load buffers_per_k_tile buffers
+                    for buffer in cutlass.range(buffers_per_k_tile, unroll_full=True):
+                        # Acquire next empty AB buffer
+                        ab_empty = ab_producer.acquire_and_advance(peek_ab_empty_status)
+
+                        # TMA load A/B
+                        cute.copy(
+                            tma_atom_a,
+                            cute.group_modes(
+                                tAgA_slice[(None, None, buffer, k_tile)], 0, 2
+                            ),
+                            tAsA[(None, ab_empty.index)],
+                            tma_bar_ptr=ab_empty.barrier,
+                            mcast_mask=a_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_b,
+                            cute.group_modes(
+                                tBgB_slice[(None, None, buffer, k_tile)], 0, 2
+                            ),
+                            tBsB[(None, ab_empty.index)],
+                            tma_bar_ptr=ab_empty.barrier,
+                            mcast_mask=b_full_mcast_mask,
+                        )
+
+                        # Peek (try_wait) AB buffer empty for next buffer
+                        peek_ab_empty_status = cutlass.Boolean(1)
+                        # Check if we're not at the last buffer of the last k_tile
+                        if not (
+                            (k_tile == k_tile_cnt - 1)
+                            and (buffer == buffers_per_k_tile - 1)
+                        ):
+                            peek_ab_empty_status = ab_producer.try_acquire()
+
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            # Signal end of AB loads
+            ab_producer.tail()
+
+        #
+        # Specialized TMA load warp for scale factor tensors
+        #
+        if warp_idx == self.tma_sf_warp_id:
+            #
+            # Persistent tile scheduling loop for SF loads
+            #
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0],
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                #
+                # Slice to per mma tile index
+                #
+                tAgSFA_slice = tAgSFA[
+                    (None, mma_tile_coord_mnl[0], None, mma_tile_coord_mnl[2])
+                ]
+                tBgSFB_slice = tBgSFB[
+                    (None, mma_tile_coord_mnl[1], None, mma_tile_coord_mnl[2])
+                ]
+
+                # Peek (try_wait) SF buffer empty
+                sf_producer.reset()
+                peek_sf_empty_status = cutlass.Boolean(1)
+                peek_sf_empty_status = sf_producer.try_acquire()
+
+                #
+                # TMA load loop for scale factors
+                #
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    # Load SF stages based on sf_buffers_per_tile_k
+                    for sf_stage in cutlass.range(
+                        self.sf_buffers_per_tile_k, unroll_full=True
+                    ):
+                        # Acquire next empty SF buffer
+                        sf_empty = sf_producer.acquire_and_advance(peek_sf_empty_status)
+
+                        tAgSFA_compact = cute.filter_zeros(
+                            tAgSFA_slice[
+                                (None, k_tile * self.sf_buffers_per_tile_k + sf_stage)
+                            ]
+                        )
+                        tBgSFB_compact = cute.filter_zeros(
+                            tBgSFB_slice[
+                                (None, k_tile * self.sf_buffers_per_tile_k + sf_stage)
+                            ]
+                        )
+
+                        # TMA load SFA/SFB for this SF stage
+                        cute.copy(
+                            tma_atom_sfa,
+                            tAgSFA_compact,
+                            tAsSFA_compact[(None, sf_empty.index)],
+                            tma_bar_ptr=sf_empty.barrier,
+                            mcast_mask=sfa_full_mcast_mask,
+                        )
+                        cute.copy(
+                            tma_atom_sfb,
+                            tBgSFB_compact,
+                            tBsSFB_compact[(None, sf_empty.index)],
+                            tma_bar_ptr=sf_empty.barrier,
+                            mcast_mask=sfb_full_mcast_mask,
+                        )
+
+                        # Peek (try_wait) SF buffer empty for next stage
+                        peek_sf_empty_status = cutlass.Boolean(1)
+                        # Check if we're not at the last stage of the last k_tile
+                        if not (
+                            k_tile == k_tile_cnt - 1
+                            and sf_stage == self.sf_buffers_per_tile_k - 1
+                        ):
+                            peek_sf_empty_status = sf_producer.try_acquire()
+
+                # Advance to next tile
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            # Signal end of SF loads
+            sf_producer.tail()
+
+        #
+        # Specialized MMA warp
+        #
+        if warp_idx == self.mma_warp_id:
+            #
+            # Bar sync for retrieve tensor memory ptr from shared mem
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator/SFA/SFB tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # Make accumulator tmem tensor
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            # Make SFA tmem tensor
+            sfa_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base),
+                dtype=self.sf_dtype,
+            )
+            tCtSFA_layout = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfa_smem_layout_staged, (None, None, None, 0)),
+            )
+
+            MMA_M = self.cta_tile_shape_mnk[0]
+            MMA_N_SF = self.cta_n_sf
+            MMA_K_SF = self.cta_tile_shape_mnk[2] // 2
+            mnBasicBlockShape = (32, 4)
+            kBasicBlockShape_single = (self.sf_vec_size, 1)
+            mma_iter_SFA_shape = (
+                (mnBasicBlockShape, MMA_M // 128),
+                kBasicBlockShape_single,
+            )
+            sSFA_iter_shape = (mma_iter_SFA_shape, 1, MMA_K_SF // self.sf_vec_size)
+            sSFA_iter_layout = cute.make_layout(sSFA_iter_shape)
+            mma_iter_SFB_shape = (
+                (mnBasicBlockShape, MMA_N_SF // 128),
+                kBasicBlockShape_single,
+            )
+            sSFB_iter_shape = (mma_iter_SFB_shape, 1, MMA_K_SF // self.sf_vec_size)
+            sSFB_iter_layout = cute.make_layout(sSFB_iter_shape)
+
+            tCtSFA_layout_mma = blockscaled_utils.make_tmem_layout_sfa(
+                tiled_mma, self.mma_tiler, self.sf_vec_size, sSFA_iter_layout
+            )
+            tCtSFA = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout)
+            tCtSFA_mma = cute.make_tensor(sfa_tmem_ptr, tCtSFA_layout_mma)
+
+            # Make SFB tmem tensor
+            sfb_tmem_ptr = cute.recast_ptr(
+                acc_tmem_ptr
+                + tcgen05.find_tmem_tensor_col_offset(tCtAcc_base)
+                + tcgen05.find_tmem_tensor_col_offset(tCtSFA),
+                dtype=self.sf_dtype,
+            )
+            tCtSFB_layout = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma,
+                self.mma_tiler,
+                self.sf_vec_size,
+                cute.slice_(sfb_smem_layout_staged, (None, None, None, 0)),
+            )
+            tCtSFB_layout_mma = blockscaled_utils.make_tmem_layout_sfb(
+                tiled_mma, self.mma_tiler, self.sf_vec_size, sSFB_iter_layout
+            )
+            tCtSFB = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout)
+            tCtSFB_mma = cute.make_tensor(sfb_tmem_ptr, tCtSFB_layout_mma)
+
+            #
+            # Partition for S2T copy of SFA/SFB
+            #
+            (
+                tiled_copy_s2t_sfa,
+                tCsSFA_compact_s2t,
+                tCtSFA_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFA, tCtSFA)
+            (
+                tiled_copy_s2t_sfb,
+                tCsSFB_compact_s2t,
+                tCtSFB_compact_s2t,
+            ) = self.mainloop_s2t_copy_and_partition(sSFB, tCtSFB)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            acc_producer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Producer, self.num_acc_stage
+            )
+
+            MmasPerSfBuffer = 8 // self.sf_buffers_per_tile_k
+            sf_stride = 6 if self.sf_vec_size == 16 else 3
+
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+
+                # Set tensor memory buffer for current tile
+                if cutlass.const_expr(self.overlapping_accum):
+                    # Pseudo-buffer parity: producer phase starts at 1, so
+                    # phase ^ 1 gives buffer 0 for the first tile (matches
+                    # the consumer, whose phase starts at 0).
+                    acc_stage_index = acc_producer_state.phase ^ 1
+                else:
+                    acc_stage_index = acc_producer_state.index
+                tCtAcc = tCtAcc_base[(None, 0, 0, acc_stage_index)]
+
+                # Peek (try_wait) AB buffer full for k_tile = 0
+                ab_consumer.reset()
+                peek_ab_full_status = cutlass.Boolean(1)
+                if is_leader_cta:
+                    peek_ab_full_status = ab_consumer.try_wait()
+
+                # Peek (try_wait) SF buffer full
+                sf_consumer.reset()
+                peek_sf_full_status = cutlass.Boolean(1)
+                if is_leader_cta:
+                    peek_sf_full_status = sf_consumer.try_wait()
+
+                #
+                # Reset the ACCUMULATE field for each tile
+                #
+                tiled_mma.set(tcgen05.Field.ACCUMULATE, False)
+
+                is_first_iteration = True
+
+                for k_tile in cutlass.range(0, k_tile_cnt, 1, unroll=1):
+                    if is_leader_cta:
+                        # Conditionally load SFA/SFB for MMA0/MMA1 depending on sf_vec_size
+                        if 0 % MmasPerSfBuffer == 0:
+                            sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                            s2t_stage_coord = (
+                                None,
+                                None,
+                                None,
+                                None,
+                                sf_full.index,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfa,
+                                tCsSFA_compact_s2t[s2t_stage_coord],
+                                tCtSFA_compact_s2t,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfb,
+                                tCsSFB_compact_s2t[s2t_stage_coord],
+                                tCtSFB_compact_s2t,
+                            )
+                            sf_full.release()
+                            peek_sf_full_status = cutlass.Boolean(1)
+                            peek_sf_full_status = sf_consumer.try_wait()
+
+                        # Wait for A/B data to be ready(MMA0, MMA1, part of MMA2)
+                        ab_full0 = ab_consumer.wait_and_advance(peek_ab_full_status)
+
+                        # peek for next stage (MMA2, MMA3, MMA4, part of MMA5)
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        peek_ab_full_status = ab_consumer.try_wait()
+
+                        # delay the acc acquire to ublock tmem
+                        if is_first_iteration:
+                            acc_pipeline.producer_acquire(acc_producer_state)
+                            is_first_iteration = False
+
+                        # MMA0
+                        k_block_coord_cur = (None, 0, 0, ab_full0.index)
+                        k_block_coord_next = (None, 0, 0, ab_full0.index)
+                        sf_kblock_coord = (None, None, 0 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+                        tiled_mma.set(tcgen05.Field.ACCUMULATE, True)
+
+                        # MMA1
+                        k_block_coord_cur = (None, 0, 3, ab_full0.index)
+                        k_block_coord_next = (None, 0, 0, ab_full0.index)
+                        sf_kblock_coord = (None, None, 1 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+
+                        # Conditionally load SFA/SFB for MMA2/MMA3
+                        if 2 % MmasPerSfBuffer == 0:
+                            sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                            s2t_stage_coord = (
+                                None,
+                                None,
+                                None,
+                                None,
+                                sf_full.index,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfa,
+                                tCsSFA_compact_s2t[s2t_stage_coord],
+                                tCtSFA_compact_s2t,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfb,
+                                tCsSFB_compact_s2t[s2t_stage_coord],
+                                tCtSFB_compact_s2t,
+                            )
+                            sf_full.release()
+                            peek_sf_full_status = cutlass.Boolean(1)
+                            peek_sf_full_status = sf_consumer.try_wait()
+
+                        # Wait for A/B data to be ready(MMA2, MMA3, MMA4, part of MMA5)
+                        ab_full1 = ab_consumer.wait_and_advance(peek_ab_full_status)
+
+                        # peek for next stage (part of MMA5, MMA6, MMA7)
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        peek_ab_full_status = ab_consumer.try_wait()
+
+                        # MMA2
+                        k_block_coord_cur = (None, 0, 6, ab_full0.index)
+                        k_block_coord_next = (None, 0, 0, ab_full1.index)
+                        sf_kblock_coord = (None, None, 2 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+
+                        # Release stage_ab_0 as it is no longer needed
+                        ab_full0.release()
+
+                        # MMA3
+                        k_block_coord_cur = (None, 0, 1, ab_full1.index)
+                        k_block_coord_next = (None, 0, 0, ab_full1.index)
+                        sf_kblock_coord = (None, None, 3 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+
+                        # Conditionally load SFA/SFB for MMA4/MMA5
+                        if 4 % MmasPerSfBuffer == 0:
+                            sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                            s2t_stage_coord = (
+                                None,
+                                None,
+                                None,
+                                None,
+                                sf_full.index,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfa,
+                                tCsSFA_compact_s2t[s2t_stage_coord],
+                                tCtSFA_compact_s2t,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfb,
+                                tCsSFB_compact_s2t[s2t_stage_coord],
+                                tCtSFB_compact_s2t,
+                            )
+                            sf_full.release()
+                            peek_sf_full_status = cutlass.Boolean(1)
+                            peek_sf_full_status = sf_consumer.try_wait()
+
+                        # MMA4
+                        k_block_coord_cur = (None, 0, 4, ab_full1.index)
+                        k_block_coord_next = (None, 0, 0, ab_full1.index)
+                        sf_kblock_coord = (None, None, 4 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+
+                        # Wait for A/B data to be ready(part of MMA5, MMA6, MMA7)
+                        ab_full2 = ab_consumer.wait_and_advance(peek_ab_full_status)
+
+                        # peek for next loop's first stage (MMA0, MMA1, part of MMA2)
+                        peek_ab_full_status = cutlass.Boolean(1)
+                        if k_tile + 1 < k_tile_cnt:
+                            peek_ab_full_status = ab_consumer.try_wait()
+
+                        # MMA5
+                        k_block_coord_cur = (None, 0, 7, ab_full1.index)
+                        k_block_coord_next = (None, 0, 0, ab_full2.index)
+                        sf_kblock_coord = (None, None, 5 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+
+                        # Conditionally load SFA/SFB for MMA6/MMA7
+                        if 6 % MmasPerSfBuffer == 0:
+                            sf_full = sf_consumer.wait_and_advance(peek_sf_full_status)
+                            s2t_stage_coord = (
+                                None,
+                                None,
+                                None,
+                                None,
+                                sf_full.index,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfa,
+                                tCsSFA_compact_s2t[s2t_stage_coord],
+                                tCtSFA_compact_s2t,
+                            )
+                            cute.copy(
+                                tiled_copy_s2t_sfb,
+                                tCsSFB_compact_s2t[s2t_stage_coord],
+                                tCtSFB_compact_s2t,
+                            )
+                            sf_full.release()
+                            peek_sf_full_status = cutlass.Boolean(1)
+                            if k_tile + 1 < k_tile_cnt:
+                                peek_sf_full_status = sf_consumer.try_wait()
+
+                        ab_full1.release()
+
+                        # MMA6
+                        k_block_coord_cur = (None, 0, 2, ab_full2.index)
+                        k_block_coord_next = (None, 0, 0, ab_full2.index)
+                        sf_kblock_coord = (None, None, 6 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+
+                        # MMA7
+                        k_block_coord_cur = (None, 0, 5, ab_full2.index)
+                        k_block_coord_next = (None, 0, 0, ab_full2.index)
+                        sf_kblock_coord = (None, None, 7 % MmasPerSfBuffer * sf_stride)
+                        tiled_mma.set(
+                            tcgen05.Field.SFA, tCtSFA_mma[sf_kblock_coord].iterator
+                        )
+                        tiled_mma.set(
+                            tcgen05.Field.SFB, tCtSFB_mma[sf_kblock_coord].iterator
+                        )
+                        self.make_desc_and_call_mma(
+                            tiled_mma,
+                            tCtAcc,
+                            sA[k_block_coord_cur],
+                            sA[k_block_coord_next],
+                            sB[k_block_coord_cur],
+                            sB[k_block_coord_next],
+                            tCtAcc,
+                        )
+
+                        ab_full2.release()
+
+                if is_leader_cta:
+                    acc_pipeline.producer_commit(acc_producer_state)
+                acc_producer_state.advance()
+
+                #
+                # Advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+
+            #
+            # Wait for accumulator buffer empty
+            #
+            acc_pipeline.producer_tail(acc_producer_state)
+
+        sC = None
+        if cutlass.const_expr(self.use_tma_store):
+            if cutlass.const_expr(self.fold_pairs_tma):
+                # Plain half-width staging layout (no swizzle/ComposedLayout).
+                sC = smem.allocate_tensor(
+                    element_type=self.c_dtype,
+                    layout=c_smem_layout_staged,
+                    byte_alignment=128,
+                )
+            else:
+                # (EPI_TILE_M, EPI_TILE_N, STAGE)
+                sC = smem.allocate_tensor(
+                    element_type=self.c_dtype,
+                    layout=c_smem_layout_staged.outer,
+                    byte_alignment=128,
+                    swizzle=c_smem_layout_staged.inner,
+                )
+
+        #
+        # Specialized epilogue warps
+        #
+        if warp_idx < self.mma_warp_id:
+            #
+            # Alloc tensor memory buffer
+            #
+            tmem.allocate(self.num_tmem_alloc_cols)
+
+            #
+            # Bar sync for retrieve tensor memory ptr from shared memory
+            #
+            tmem.wait_for_alloc()
+
+            #
+            # Retrieving tensor memory ptr and make accumulator tensor
+            #
+            acc_tmem_ptr = tmem.retrieve_ptr(self.acc_dtype)
+            # (MMA, MMA_M, MMA_N, STAGE)
+            tCtAcc_base = cute.make_tensor(acc_tmem_ptr, tCtAcc_fake.layout)
+
+            #
+            # Persistent tile scheduling loop
+            #
+            acc_consumer_state = pipeline.make_pipeline_state(
+                pipeline.PipelineUserType.Consumer, self.num_acc_stage
+            )
+            if cutlass.const_expr(self.use_tma_store):
+                assert tma_atom_c is not None and sC is not None
+                c_producer_group = pipeline.CooperativeGroup(
+                    pipeline.Agent.Thread,
+                    32 * len(self.epilogue_warp_id),
+                )
+                c_pipeline = pipeline.PipelineTmaStore.create(
+                    num_stages=self.num_c_stage, producer_group=c_producer_group
+                )
+            # Wrap epilogue_op with alpha scaling. Multiply in f32 and
+            # convert back to the output dtype inside the wrapper:
+            # cutlass-dsl >= 4.6 rejects implicit f32 -> bf16 narrowing at
+            # store time, which the original dtype-promoting lambda hits.
+            alpha_epilogue_op = lambda x: epilogue_op(
+                (alpha_value * x.to(cutlass.Float32)).to(self.c_dtype)
+            )
+            while work_tile.is_valid_tile:
+                # Get tile coord from tile scheduler
+                cur_tile_coord = work_tile.tile_idx
+                mma_tile_coord_mnl = (
+                    cur_tile_coord[0] // cute.size(tiled_mma.thr_id.shape),
+                    cur_tile_coord[1],
+                    cur_tile_coord[2],
+                )
+                #
+                # Pre-advance to next tile
+                #
+                tile_sched.advance_to_next_work()
+                work_tile = tile_sched.get_current_work()
+                num_tiles_executed = tile_sched.num_tiles_executed
+                if cutlass.const_expr(self.fold_pairs_tma):
+                    # fold gC tiles are CTA-tile sized (128 rows): slice with
+                    # the CTA-level coord. For 2-CTA MMA the mma-level coord
+                    # is in 256-row units and would skip every peer CTA's
+                    # half (the historical NaN of the 2SM tactic).
+                    cta_tile_coord_mnl = (
+                        cur_tile_coord[0],
+                        cur_tile_coord[1],
+                        cur_tile_coord[2],
+                    )
+                    acc_consumer_state = mext_fold_epilogue_tma(
+                        self,
+                        tidx,
+                        warp_idx,
+                        tma_atom_c,
+                        tCtAcc_base,
+                        sC,
+                        tCgC,
+                        gC_fold_mnl,
+                        epi_tile,
+                        num_tiles_executed,
+                        alpha_epilogue_op,
+                        cta_tile_coord_mnl,
+                        acc_consumer_state,
+                        acc_pipeline,
+                        c_pipeline,
+                    )
+                elif cutlass.const_expr(self.use_tma_store):
+                    acc_consumer_state = utils.gemm.sm100.epilogue_tma_store(
+                        self,
+                        tidx,
+                        warp_idx,
+                        tma_atom_c,
+                        tCtAcc_base,
+                        sC,
+                        tCgC,
+                        epi_tile,
+                        num_tiles_executed,
+                        alpha_epilogue_op,
+                        mma_tile_coord_mnl,
+                        acc_consumer_state,
+                        acc_pipeline,
+                        c_pipeline,
+                    )
+                else:
+                    acc_consumer_state = mext_fold_epilogue(
+                        self,
+                        tidx,
+                        tCtAcc_base,
+                        tCgC,
+                        epi_tile,
+                        alpha_epilogue_op,
+                        mma_tile_coord_mnl,
+                        acc_consumer_state,
+                        acc_pipeline,
+                        tCcC_base=tCcC,
+                        mC_mnl=mC_mnl,
+                    )
+
+            if cutlass.const_expr(self.use_tma_store):
+                # Wait for C store complete
+                c_pipeline.producer_tail()
+            else:
+                # Synchronize before TMEM dealloc (done by the caller)
+                tmem_dealloc_barrier.arrive_and_wait()
+
+            #
+            # Dealloc the tensor memory buffer
+            #
+            tmem.relinquish_alloc_permit()
+            tmem.free(acc_tmem_ptr)
+
+            cute.arch.mbarrier_init_fence()
+
+        griddepcontrol_launch_dependents()
+
+    @staticmethod
+    def make_desc_and_call_mma(
+        tiled_mma: cute.TiledMma,
+        d: cute.Tensor,
+        sA_cur: cute.Tensor,
+        sA_next: cute.Tensor,
+        sB_cur: cute.Tensor,
+        sB_next: cute.Tensor,
+        c: cute.Tensor,
+    ) -> None:
+        """Specialized GEMM for circular-buffered A/B from SMEM.
+
+        Performs D <- A * B + C where A and B are described by circular SMEM
+        descriptors constructed from the (current, next) buffers. C and D may alias.
+
+        Some tcgen05 MMAs require explicitly toggling an accumulate field outside of
+        this routine; the caller is responsible for that.
+
+        All tensors must already be partitioned for the provided tiled MMA.
+
+        For MMA Atoms that require single-threaded execution, the gemm op automatically handles thread
+        election internally. Manual thread selection is not required in such cases.
+
+        :param atom: MMA atom
+        :type atom: cute.MmaAtom
+        :param d: Destination tensor
+        :type d: cute.Tensor
+        :param sA_cur: Current shared memory tensor for operand A
+        :type sA_cur: cute.Tensor
+        :param sA_next: Next shared memory tensor for operand A, used for circular buffering
+        :type sA_next: cute.Tensor
+        :param sB_cur: Current shared memory tensor for operand B
+        :type sB_cur: cute.Tensor
+        :param sB_next: Next shared memory tensor for operand B, used for circular buffering
+        :type sB_next: cute.Tensor
+        :param c: Third source tensor
+        :type c: cute.Tensor
+        :return: None
+        :rtype: None
+        """
+        a_desc = tcgen05.make_umma_smem_desc(
+            sA_cur.iterator,
+            sA_cur.layout,
+            "k" if tiled_mma.op.a_major_mode.name == "K" else "mn",
+            next_src=sA_next.iterator,
+        )
+        b_desc = tcgen05.make_umma_smem_desc(
+            sB_cur.iterator,
+            sB_cur.layout,
+            "k" if tiled_mma.op.b_major_mode.name == "K" else "mn",
+            next_src=sB_next.iterator,
+        )
+
+        view_layout = cute.make_layout(1, stride=0)
+        a_tensor = cute.make_tensor(a_desc, view_layout)
+        b_tensor = cute.make_tensor(b_desc, view_layout)
+        return cute.mma_atom_call(tiled_mma, d, a_tensor, b_tensor, c)
+
+    @staticmethod
+    def sm103_make_blockscaled_trivial_tiled_mma(
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        cta_group: tcgen05.CtaGroup,
+        mma_tiler_mn: Tuple[int, int],
+        a_source: tcgen05.OperandSource = tcgen05.OperandSource.SMEM,
+    ) -> cute.TiledMma:
+        """Create a blockscaled trivial tiled MMA for SM103 (3xFP4), K fixed to 96.
+
+        Returns a tcgen05 MMA configured for the given (M, N) tiler and CTA group.
+
+        :param sf_dtype: Data type of the scale factor (typically 8-bit)
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size of the scale factor
+        :type sf_vec_size: int
+        :param cta_group: The CTA group configuration
+        :type cta_group: tcgen05.CtaGroup
+        :param mma_tiler_mn: The MMA tiler dimensions (M, N)
+        :type mma_tiler_mn: Tuple[int, int]
+        :param a_source: Source location for operand A (SMEM by default)
+        :type a_source: tcgen05.OperandSource
+
+        :return: A tiled MMA atom configured for SM103 blockscaled operations
+        :rtype: cute.TiledMma
+
+        :raises TypeError: If the data type is not supported.
+        :raises ValueError: If the sf_vec_size is not supported.
+        """
+        if sf_vec_size == 32:
+            mma_op = tcgen05.SM103MmaMXF4Op(
+                (*mma_tiler_mn, 96),
+                cta_group,
+                a_source,
+            )
+        elif sf_vec_size == 16:
+            mma_op = tcgen05.SM103MmaMXF4NVF4Op(
+                sf_dtype,
+                (*mma_tiler_mn, 96),
+                cta_group,
+                a_source,
+            )
+        else:
+            raise ValueError(
+                f"Unsupported sf_vec_size: {sf_vec_size}. Expected 16 or 32."
+            )
+        return cute.make_tiled_mma(cute.make_mma_atom(mma_op))
+
+    # Utils
+    @staticmethod
+    def sm103_make_smem_layout_a(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: cute.Tile,
+        num_stages: int,
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        """
+        Create the SMEM layout for operand A using K_SW128 and Uint8.
+
+        This function creates a SMEM layout for operand A using the make_smem_layout_atom function with K_SW128 kind and Uint8 element type.
+
+        :param tiled_mma: The tiled MMA atom
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The mma tiler shape (M, N, K)
+        :type mma_tiler_mnk: cute.Tile
+        :param num_stages: The number of stages
+        :type num_stages: int
+
+        :return: SMEM layout for operand A
+        :rtype: cute.Layout
+        """
+        is_k_major = tiled_mma.op.a_major_mode == tcgen05.OperandMajorMode.K
+        a_smem_layout_staged = tcgen05.tile_to_mma_shape(
+            tcgen05.make_smem_layout_atom(
+                tcgen05.SmemLayoutAtomKind.K_SW128, cutlass.Uint8
+            ),
+            cute.append(
+                (
+                    (
+                        mma_tiler_mnk[0]
+                        // cute.size(tiled_mma.thr_layout_vmnk.shape[0]),
+                        16,
+                    ),
+                    1,
+                    8,
+                ),
+                num_stages,
+            ),
+            order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        )
+
+        return a_smem_layout_staged
+
+    @staticmethod
+    def sm103_make_smem_layout_b(
+        tiled_mma: cute.TiledMma,
+        mma_tiler_mnk: cute.Tile,
+        num_stages: int,
+    ) -> Union[cute.Layout, cute.ComposedLayout]:
+        """
+        Create the SMEM layout for operand B using K_SW128 and Uint8.
+
+        This function creates a SMEM layout for operand B using the make_smem_layout_atom function with K_SW128 kind and Uint8 element type.
+
+        :param tiled_mma: The tiled MMA atom
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler_mnk: The mma tiler shape (M, N, K)
+        :type mma_tiler_mnk: cute.Tile
+        :param num_stages: The number of stages
+        :type num_stages: int
+
+        :return: SMEM layout for operand B
+        :rtype: cute.Layout
+        """
+        is_k_major = tiled_mma.op.b_major_mode == tcgen05.OperandMajorMode.K
+        b_smem_layout_staged = tcgen05.tile_to_mma_shape(
+            tcgen05.make_smem_layout_atom(
+                tcgen05.SmemLayoutAtomKind.K_SW128, cutlass.Uint8
+            ),
+            cute.append(
+                ((mma_tiler_mnk[1] // cute.size(tiled_mma.thr_id.shape), 16), 1, 8),
+                num_stages,
+            ),
+            order=((1, 0, 2) if not is_k_major else (0, 1, 2)),
+        )
+        return b_smem_layout_staged
+
+    @dataclass(frozen=True)
+    class Sm103BlockScaledBasicChunk:
+        """
+        Basic scale-factor atom layout decided by tcgen05 BlockScaled MMA Ops on SM103.
+
+        Represents the fixed layout pattern for scale factors used by tcgen05
+        BlockScaled MMA Ops on SM103. The layout is determined by the instruction
+        specification and is not configurable.
+        """
+
+        sf_vec_size: int
+        major_mode: tcgen05.OperandMajorMode = tcgen05.OperandMajorMode.K
+        _layout: cute.Layout = field(init=False, repr=False)
+
+        def __post_init__(self) -> None:
+            if self.major_mode == tcgen05.OperandMajorMode.K:
+                atom_shape = ((8, 4, 4), (self.sf_vec_size, 4))
+                atom_stride = ((16, 128, 4), (0, 1))
+            else:
+                atom_shape = ((self.sf_vec_size, 4), (8, 4, 4))  # type: ignore[assignment]
+                atom_stride = ((0, 1), (16, 128, 4))  # type: ignore[assignment]
+
+            object.__setattr__(
+                self, "_layout", cute.make_layout(shape=atom_shape, stride=atom_stride)
+            )
+
+        @property
+        def layout(self) -> cute.Layout:
+            return self._layout
+
+    @staticmethod
+    def sm103_make_smem_layout_sfa(
+        tiled_mma: cute.TiledMma,
+        mma_tiler: cute.Tile,
+        sf_vec_size: int,
+        num_stages: int,
+    ) -> cute.Layout:
+        """
+        Make SMEM layout for SFA based on:
+        1) Sm103BlockScaledBasicChunk, 2) MMA tiler, 3) sf_vec_size, 4) stages.
+
+        :param tiled_mma: The tiled MMA
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler: The mma tiler shape
+        :type mma_tiler: cute.Tile
+        :param sf_vec_size: The scale factor vector size
+        :type sf_vec_size: int
+        :param num_stages: The number of stages
+        :type num_stages: int
+
+        :return: Smem layout for SFA
+        :rtype: cute.Layout
+        """
+        mma_shape_mk = tiled_mma.partition_shape_A((mma_tiler[0], mma_tiler[2]))
+        sf_atom = Sm103BlockScaledPersistentDenseGemmKernel.Sm103BlockScaledBasicChunk(
+            sf_vec_size, tiled_mma.op.a_major_mode
+        ).layout
+        k_divisor = 4 if sf_vec_size == 16 else 2
+        mma_sfa_tiler = (
+            mma_shape_mk[0][0] * mma_shape_mk[1],
+            mma_shape_mk[0][1] * mma_shape_mk[2] // k_divisor,
+        )
+        sfa_smem_atom_layout = cute.tiled_product(
+            sf_atom,
+            cute.make_layout(
+                cute.shape_div(mma_sfa_tiler, cute.product_each(sf_atom.shape))
+            ),
+        )
+        sfa_smem_layout_staged = cute.make_layout(
+            shape=cute.append(sfa_smem_atom_layout.shape, num_stages),
+            stride=cute.append(
+                sfa_smem_atom_layout.stride,
+                cute.size(cute.filter_zeros(sfa_smem_atom_layout)),
+            ),
+        )
+        return sfa_smem_layout_staged
+
+    @staticmethod
+    def sm103_make_smem_layout_sfb(
+        tiled_mma: cute.TiledMma,
+        mma_tiler: cute.Tile,
+        sf_vec_size: int,
+        num_stages: int,
+    ) -> cute.Layout:
+        """
+        Make SMEM layout for SFB based on the basic chunk, MMA tiler, sf_vec_size, stages.
+
+        :param tiled_mma: The tiled MMA
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler: The mma tiler shape
+        :type mma_tiler: cute.Tile
+        :param sf_vec_size: The scale factor vector size
+        :type sf_vec_size: int
+        :param num_stages: The number of stages
+        :type num_stages: int
+
+        :return: Smem layout for SFB
+        :rtype: cute.Layout
+        """
+        sf_atom = Sm103BlockScaledPersistentDenseGemmKernel.Sm103BlockScaledBasicChunk(
+            sf_vec_size, tiled_mma.op.a_major_mode
+        ).layout
+        k_divisor = 4 if sf_vec_size == 16 else 2
+        mma_sfb_tiler = (mma_tiler[1], mma_tiler[2] // k_divisor)
+        if mma_sfb_tiler[0] == 128:
+            sfb_smem_atom_layout = cute.tiled_product(
+                sf_atom,
+                cute.make_layout(
+                    cute.shape_div(mma_sfb_tiler, cute.product_each(sf_atom.shape))
+                ),
+            )
+        else:
+            sf_k_major_atom256 = cute.make_layout(
+                shape=(
+                    (32, 4, 2),
+                    (sf_vec_size, 4),
+                ),
+                stride=(
+                    (16, 4, mma_sfb_tiler[1] // sf_vec_size // 4 * 512),
+                    (0, 1),
+                ),
+            )
+            sfb_smem_atom_layout = cute.tiled_product(
+                sf_k_major_atom256,
+                cute.make_layout(
+                    cute.shape_div(
+                        mma_sfb_tiler, cute.product_each(sf_k_major_atom256.shape)
+                    )
+                ),
+            )
+
+        sfb_smem_layout_staged = cute.make_layout(
+            shape=cute.append(sfb_smem_atom_layout.shape, num_stages),
+            stride=cute.append(
+                sfb_smem_atom_layout.stride,
+                cute.size(cute.filter_zeros(sfb_smem_atom_layout)),
+            ),
+        )
+        return sfb_smem_layout_staged
+
+    def mainloop_s2t_copy_and_partition(
+        self,
+        sSF: cute.Tensor,
+        tSF: cute.Tensor,
+    ) -> Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]:
+        """
+        Make tiledCopy for smem to tmem load for scale factor tensor, then use it to partition smem memory (source) and tensor memory (destination).
+
+        :param sSF: The scale factor tensor in smem
+        :type sSF: cute.Tensor
+        :param tSF: The scale factor tensor in tmem
+        :type tSF: cute.Tensor
+
+        :return: A tuple containing (tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t) where:
+            - tiled_copy_s2t: The tiled copy operation for smem to tmem load for scale factor tensor(s2t)
+            - tCsSF_compact_s2t: The partitioned scale factor tensor in smem
+            - tSF_compact_s2t: The partitioned scale factor tensor in tmem
+        :rtype: Tuple[cute.TiledCopy, cute.Tensor, cute.Tensor]
+        """
+        # (MMA, MMA_MN, MMA_K, STAGE)
+        tCsSF_compact = cute.filter_zeros(sSF)
+        # (MMA, MMA_MN, MMA_K)
+        tCtSF_compact = cute.filter_zeros(tSF)
+        tCtSF_compact_copy = cute.make_tensor(
+            tCtSF_compact.iterator,
+            cute.append(
+                cute.append(tCtSF_compact[(None, 0, 0)].layout, cute.make_layout((1))),
+                cute.make_layout(1),
+            ),
+        )
+        # Make S2T CopyAtom and tiledCopy
+        copy_atom_s2t = cute.make_copy_atom(
+            tcgen05.Cp4x32x128bOp(self.cta_group),
+            self.sf_dtype,
+        )
+        tiled_copy_s2t = tcgen05.make_s2t_copy(copy_atom_s2t, tCtSF_compact_copy)
+        thr_copy_s2t = tiled_copy_s2t.get_slice(0)
+
+        tCsSF_compact_s2t_ = thr_copy_s2t.partition_S(tCsSF_compact)
+        tCsSF_compact_s2t = tcgen05.get_s2t_smem_desc_tensor(
+            tiled_copy_s2t, tCsSF_compact_s2t_
+        )
+        tCtSF_compact_s2t = thr_copy_s2t.partition_D(tCtSF_compact)
+
+        return tiled_copy_s2t, tCsSF_compact_s2t, tCtSF_compact_s2t
+
+    @staticmethod
+    def _compute_stages(
+        tiled_mma: cute.TiledMma,
+        mma_tiler: Tuple[int, int, int],
+        epi_tile: cute.Tile,
+        c_dtype: Type[cutlass.Numeric],
+        c_layout: utils.LayoutEnum,
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        smem_capacity: int,
+        occupancy: int,
+        use_tma_store: bool,
+    ) -> Tuple[int, int, int, int]:
+        """Computes the number of stages for A/B and SF operands based on heuristics.
+
+        SM103 requires separate stage counts for AB and SF pipelines.
+
+        :param tiled_mma: The tiled MMA object defining the core computation.
+        :type tiled_mma: cute.TiledMma
+        :param mma_tiler: The shape (M, N, K) of the MMA tiler.
+        :type mma_tiler: tuple[int, int, int]
+        :param epi_tile: The epilogue tile shape.
+        :type epi_tile: cute.Tile
+        :param c_dtype: Data type of operand C (output).
+        :type c_dtype: type[cutlass.Numeric]
+        :param c_layout: Layout enum of operand C.
+        :type c_layout: utils.LayoutEnum
+        :param sf_dtype: Data type of Scale factor.
+        :type sf_dtype: type[cutlass.Numeric]
+        :param sf_vec_size: Scale factor vector size.
+        :type sf_vec_size: int
+        :param smem_capacity: Total available shared memory capacity in bytes.
+        :type smem_capacity: int
+        :param occupancy: Target number of CTAs per SM (occupancy).
+        :type occupancy: int
+        :param use_tma_store: Whether TMA store is enabled.
+        :type use_tma_store: bool
+
+        :return: A tuple containing the computed number of stages for:
+                 (ACC stages, A/B operand stages, SF stages)
+        :rtype: tuple[int, int, int]
+        """
+        # ACC stages - same as SM100 dense blockscaled gemm
+        num_acc_stage = 1 if mma_tiler[1] == 256 else 2
+
+        # Default C stages
+        num_c_stage = 2 if use_tma_store else 0
+
+        # Calculate smem layout and size for one stage of A, B, SFA, SFB
+        a_smem_layout_stage_one = (
+            Sm103BlockScaledPersistentDenseGemmKernel.sm103_make_smem_layout_a(
+                tiled_mma,
+                mma_tiler,
+                1,
+            )
+        )
+        b_smem_layout_staged_one = (
+            Sm103BlockScaledPersistentDenseGemmKernel.sm103_make_smem_layout_b(
+                tiled_mma,
+                mma_tiler,
+                1,
+            )
+        )
+        sfa_smem_layout_staged_one = (
+            Sm103BlockScaledPersistentDenseGemmKernel.sm103_make_smem_layout_sfa(
+                tiled_mma,
+                mma_tiler,
+                sf_vec_size,
+                1,
+            )
+        )
+        sfb_smem_layout_staged_one = (
+            Sm103BlockScaledPersistentDenseGemmKernel.sm103_make_smem_layout_sfb(
+                tiled_mma,
+                mma_tiler,
+                sf_vec_size,
+                1,
+            )
+        )
+
+        c_smem_layout_staged_one = sm103_utils.make_smem_layout_epi(
+            c_dtype,
+            c_layout,
+            epi_tile,
+            1,
+        )
+
+        c_bytes_per_stage = cute.size_in_bytes(c_dtype, c_smem_layout_staged_one)
+        c_bytes = c_bytes_per_stage * num_c_stage
+
+        ab_bytes_per_stage = cute.size_in_bytes(
+            cutlass.Uint8, a_smem_layout_stage_one
+        ) + cute.size_in_bytes(cutlass.Uint8, b_smem_layout_staged_one)
+        sf_bytes_per_stage = cute.size_in_bytes(
+            sf_dtype, sfa_smem_layout_staged_one
+        ) + cute.size_in_bytes(sf_dtype, sfb_smem_layout_staged_one)
+
+        mbar_helpers_bytes = 1024
+
+        num_ab_stage = (
+            smem_capacity // occupancy
+            - (mbar_helpers_bytes + sf_bytes_per_stage + c_bytes)
+        ) // ab_bytes_per_stage
+
+        num_sf_stage = (
+            smem_capacity
+            - occupancy * ab_bytes_per_stage * num_ab_stage
+            - occupancy * mbar_helpers_bytes
+            - occupancy * c_bytes
+        ) // (occupancy * sf_bytes_per_stage)
+
+        # Refine epilogue stages:
+        # Calculate remaining smem after allocating for A/B stages and reserved bytes
+        # Add remaining unused smem to epilogue
+        if use_tma_store:
+            # xinyu TODO: not sure if aligned with c++
+            num_c_stage += (
+                smem_capacity
+                - occupancy * ab_bytes_per_stage * num_ab_stage
+                - occupancy * sf_bytes_per_stage * num_sf_stage
+                - occupancy * mbar_helpers_bytes
+                - occupancy * c_bytes
+            ) // (occupancy * c_bytes_per_stage)
+
+        return num_acc_stage, num_ab_stage, num_sf_stage, num_c_stage
+
+    @staticmethod
+    def _compute_grid(
+        c: cute.Tensor,
+        cta_tile_shape_mnk: Tuple[int, int, int],
+        cluster_shape_mn: Tuple[int, int],
+        max_active_clusters: cutlass.Constexpr,
+    ) -> Tuple[utils.PersistentTileSchedulerParams, Tuple[int, int, int]]:
+        """Use persistent tile scheduler to compute the grid size for the output tensor C.
+
+        :param c: The output tensor C
+        :type c: cute.Tensor
+        :param cta_tile_shape_mnk: The shape (M, N, K) of the CTA tile.
+        :type cta_tile_shape_mnk: tuple[int, int, int]
+        :param cluster_shape_mn: Shape of each cluster in M, N dimensions.
+        :type cluster_shape_mn: tuple[int, int]
+        :param max_active_clusters: Maximum number of active clusters.
+        :type max_active_clusters: cutlass.Constexpr
+
+        :return: A tuple containing:
+            - tile_sched_params: Parameters for the persistent tile scheduler.
+            - grid: Grid shape for kernel launch.
+        :rtype: Tuple[utils.PersistentTileSchedulerParams, tuple[int, int, int]]
+        """
+        c_shape = cute.slice_(cta_tile_shape_mnk, (None, None, 0))
+        gc = cute.zipped_divide(c, tiler=c_shape)
+        num_ctas_mnl = gc[(0, (None, None, None))].shape
+        cluster_shape_mnl = (*cluster_shape_mn, 1)
+
+        tile_sched_params = utils.PersistentTileSchedulerParams(
+            num_ctas_mnl, cluster_shape_mnl
+        )
+        grid = utils.StaticPersistentTileScheduler.get_grid_shape(
+            tile_sched_params, max_active_clusters
+        )
+
+        return tile_sched_params, grid
+
+    @staticmethod
+    def is_valid_dtypes_and_scale_factor_vec_size(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+    ) -> bool:
+        """
+        Check if the dtypes and sf_vec_size are valid combinations
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size of the scale factor
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+
+        :return: True if the dtypes and sf_vec_size are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        # Check valid ab_dtype
+        if ab_dtype != cutlass.Float4E2M1FN:
+            is_valid = False
+
+        # Check valid sf_vec_size
+        if sf_vec_size not in {16, 32}:
+            is_valid = False
+
+        # Check valid sf_dtype
+        if sf_dtype not in {cutlass.Float8E8M0FNU, cutlass.Float8E4M3FN}:
+            is_valid = False
+
+        # Check valid sf_dtype and sf_vec_size combinations
+        if sf_dtype == cutlass.Float8E4M3FN and sf_vec_size == 32:
+            is_valid = False
+
+        # Check valid c_dtype
+        if c_dtype not in {
+            cutlass.Float32,
+            cutlass.Float16,
+            cutlass.BFloat16,
+            cutlass.Float8E5M2,
+            cutlass.Float8E4M3FN,
+        }:
+            is_valid = False
+
+        return is_valid
+
+    @staticmethod
+    def is_valid_layouts(
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if layouts and dtypes are valid combinations
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major dimension of the A tensor
+        :type a_major: str
+        :param b_major: The major dimension of the B tensor
+        :type b_major: str
+        :param c_major: The major dimension of the C tensor
+        :type c_major: str
+
+        :return: True if the layouts are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        if ab_dtype is cutlass.Float4E2M1FN and not (a_major == "k" and b_major == "k"):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_mma_tiler_and_cluster_shape(
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+    ) -> bool:
+        """
+        Check if the mma tiler and cluster shape are valid
+
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+
+        :return: True if the mma tiler and cluster shape are valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+        # Skip invalid mma tile shape
+        if mma_tiler_mn[0] not in [128, 256]:
+            is_valid = False
+        # ResInfer probe: PTX allows N down to 8 for kind::mxf4nvf4; the
+        # upstream kernel only wired 128/256 (SFB pipeline rounds N up to
+        # 128). N=64 admitted experimentally -- correctness gated by tests.
+        if mma_tiler_mn[1] not in [64, 128, 256]:
+            is_valid = False
+        # Skip illegal cluster shape
+        if cluster_shape_mn[0] % (2 if mma_tiler_mn[0] == 256 else 1) != 0:
+            is_valid = False
+        # Skip invalid cluster shape
+        _is_power_of_2 = lambda x: x > 0 and (x & (x - 1)) == 0
+        if (
+            cluster_shape_mn[0] * cluster_shape_mn[1] > 16
+            or cluster_shape_mn[0] <= 0
+            or cluster_shape_mn[1] <= 0
+            # Special cluster shape check for scale factor multicasts.
+            # Due to limited size of scale factors, we can't multicast among more than 4 CTAs.
+            or cluster_shape_mn[0] > 4
+            or cluster_shape_mn[1] > 4
+            or not _is_power_of_2(cluster_shape_mn[0])
+            or not _is_power_of_2(cluster_shape_mn[1])
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def is_valid_tensor_alignment(
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        ab_dtype: Type[cutlass.Numeric],
+        c_dtype: Type[cutlass.Numeric],
+        a_major: str,
+        b_major: str,
+        c_major: str,
+    ) -> bool:
+        """
+        Check if the tensor alignment is valid
+
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+
+        :return: True if the problem shape is valid, False otherwise
+        :rtype: bool
+        """
+        is_valid = True
+
+        def check_contigous_alignment(
+            dtype, is_mode0_major, tensor_shape, alignment_bytes
+        ):
+            """Check if tensor satisfies the required byte alignment.
+
+            :param dtype: Data type of the tensor
+            :param is_mode0_major: Whether mode 0 is the major (contiguous) mode
+            :param tensor_shape: Shape of the tensor (mode0, mode1, batch)
+            :param alignment_bytes: Required alignment in bytes (e.g., 16 or 32)
+            :return: True if alignment is satisfied
+            """
+            major_mode_idx = 0 if is_mode0_major else 1
+            num_major_elements = tensor_shape[major_mode_idx]
+            # Calculate number of contiguous elements needed for alignment
+            # alignment_bytes * 8 (bits per byte) / dtype.width (bits per element)
+            num_contiguous_elements = alignment_bytes * 8 // dtype.width
+            return num_major_elements % num_contiguous_elements == 0
+
+        # Check A/B tensors for 16B alignment
+        # Check C tensor for 32B alignment
+        if (
+            not check_contigous_alignment(ab_dtype, a_major == "m", (m, k, l), 16)
+            or not check_contigous_alignment(ab_dtype, b_major == "n", (n, k, l), 16)
+            or not check_contigous_alignment(c_dtype, c_major == "m", (m, n, l), 32)
+        ):
+            is_valid = False
+        return is_valid
+
+    @staticmethod
+    def can_implement(
+        ab_dtype: Type[cutlass.Numeric],
+        sf_dtype: Type[cutlass.Numeric],
+        sf_vec_size: int,
+        c_dtype: Type[cutlass.Numeric],
+        mma_tiler_mn: Tuple[int, int],
+        cluster_shape_mn: Tuple[int, int],
+        m: int,
+        n: int,
+        k: int,
+        l: int,
+        a_major: str,
+        b_major: str,
+        c_major: str,
+        use_tma_store: bool,
+    ) -> bool:
+        """
+        Check if the gemm can be implemented
+
+        :param ab_dtype: The data type of the A and B operands
+        :type ab_dtype: Type[cutlass.Numeric]
+        :param sf_dtype: The data type of the scale factor tensor
+        :type sf_dtype: Type[cutlass.Numeric]
+        :param sf_vec_size: The vector size
+        :type sf_vec_size: int
+        :param c_dtype: The data type of the output tensor
+        :type c_dtype: Type[cutlass.Numeric]
+        :param mma_tiler_mn: The (M, N) shape of the MMA instruction tiler
+        :type mma_tiler_mn: Tuple[int, int]
+        :param cluster_shape_mn: The (ClusterM, ClusterN) shape of the CTA cluster
+        :type cluster_shape_mn: Tuple[int, int]
+        :param m: The number of rows in the A tensor
+        :type m: int
+        :param n: The number of columns in the B tensor
+        :type n: int
+        :param k: The number of columns in the A tensor
+        :type k: int
+        :param l: The number of columns in the C tensor
+        :type l: int
+        :param a_major: The major axis of the A tensor
+        :type a_major: str
+        :param b_major: The major axis of the B tensor
+        :type b_major: str
+        :param c_major: The major axis of the C tensor
+        :type c_major: str
+
+        :return: True if the gemm can be implemented, False otherwise
+        :rtype: bool
+        """
+        can_implement = True
+        # Skip unsupported types
+        if not Sm103BlockScaledPersistentDenseGemmKernel.is_valid_dtypes_and_scale_factor_vec_size(
+            ab_dtype, sf_dtype, sf_vec_size, c_dtype
+        ):
+            can_implement = False
+        # Skip unsupported layouts
+        if not Sm103BlockScaledPersistentDenseGemmKernel.is_valid_layouts(
+            ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+        # Skip invalid mma tile shape and cluster shape
+        if not Sm103BlockScaledPersistentDenseGemmKernel.is_valid_mma_tiler_and_cluster_shape(
+            mma_tiler_mn, cluster_shape_mn
+        ):
+            can_implement = False
+        # Skip illegal problem shape for load/store alignment
+        if not Sm103BlockScaledPersistentDenseGemmKernel.is_valid_tensor_alignment(
+            m, n, k, l, ab_dtype, c_dtype, a_major, b_major, c_major
+        ):
+            can_implement = False
+        return can_implement
+
+    # Helper function for append and coalesce layout
+    @staticmethod
+    def append_coalesce_layout(layout):
+        # coalesce is like: cutlass/python/pycute/layout.py:coalesce
+        part1 = cute.coalesce(cute.append(layout[0][0], layout[1]))
+        part2 = cute.coalesce(cute.append(layout[0][1], layout[2]))
+        result = cute.append(part1, part2)
+        result = cute.append(result, layout[3])
+        result = cute.append(result, layout[4])
+        result = cute.append(result, layout[5])
+        return result
+
+    @staticmethod
+    def adapt_layout_for_tma_ab(composed_layout):
+        # input:  S<3,4,3> o 0 o ((128,16),1,8,3):((128,1),0,16,16384)
+        # output: S<3,4,3> o 0 o (128,(128,3)):(128,(1,16384))
+        # for ctaValueMap: (128,384):(1@0,1@1)
+        layout = composed_layout.outer
+        part1 = cute.coalesce(cute.append(layout[0][0], layout[1]))
+        part2 = cute.coalesce(cute.append(layout[0][1], layout[2]))
+        part3 = cute.append(part2, layout[3])
+        result = cute.append(part1, part3)
+        return cute.make_composed_layout(
+            composed_layout.inner, composed_layout.offset, result
+        )
+
+    @staticmethod
+    def adapt_layout_for_tma_sf(layout):
+        # TODO: need ethan check this
+        # input: (((8,4,4),(16,4)),1,3):(((16,128,4),(0,1)),0,512)
+        # output: ((32,4),(16,4,3)):((16,4),(0,1,512))
+        # for ctaValueMap: ((8,4,4),(16,4,3)):((1@0@0@0,1@1@0@0,1@2@0@0),(1@0@0@1,1@1@0@1,1@1@1))
+        part1 = cute.coalesce(cute.append(layout[0][0], layout[1]))
+        part2 = cute.coalesce(cute.append(layout[0][1], layout[2]))
+        result = cute.append(cute.group_modes(part1, 0, cute.rank(part1)), part2)
+        return result
+
+    @cute.jit
+    def wrapper(
+        self,
+        mA: cute.Tensor,
+        mB: cute.Tensor,
+        mC: cute.Tensor,
+        sf_m: cutlass.Int64,
+        sf_n: cutlass.Int64,
+        sf_k: cutlass.Int64,
+        l: cutlass.Constexpr,
+        a_sf_ptr: cute.Pointer,
+        b_sf_ptr: cute.Pointer,
+        alpha_tensor: cute.Tensor,
+        max_active_clusters: cutlass.Constexpr,
+        current_stream,
+        swap_ab: cutlass.Constexpr = False,
+        epilogue_op: cutlass.Constexpr = lambda x: x,
+        fold_pairs: cutlass.Constexpr = False,
+    ):
+        """Execute the wrapped GEMM kernel with dynamically shaped tensors.
+
+        Uses TVM-FFI for efficient tensor passing: A, B, C, and alpha are passed
+        as cute.Tensor directly (torch tensors at runtime via TVM-FFI's C-level
+        dlpack). Scale factor tensors remain as pointers (complex 6D layout).
+
+        Args:
+            mA (cute.Tensor): Input A, shape (m, k_packed), Uint8 (FP4 packed).
+            mB (cute.Tensor): Input B, shape (n, k_packed), Uint8 (FP4 packed).
+            mC (cute.Tensor): Output C, shape (m, n).
+            sf_m/sf_n/sf_k: Scale factor dimensions.
+            l: Batch dimension.
+            a_sf_ptr/b_sf_ptr: Scale factor pointers (6D layout).
+            alpha_tensor: Alpha scaling factor, shape (1,), float32.
+            max_active_clusters: Max active clusters.
+            current_stream: CUDA stream (TVM-FFI fake stream).
+            swap_ab: Whether A/B are swapped (controls C layout).
+            epilogue_op: Elementwise epilogue function.
+        """
+        # A/B come in as Uint8 (FP4 packed as uint8 in torch). Recast to FP4.
+        m = cute.size(mA, mode=[0])
+        k_packed = cute.size(mA, mode=[1])
+        n = cute.size(mB, mode=[0])
+        k = k_packed * 2  # 2 FP4 values per uint8 byte
+
+        # Recast Uint8 -> Float4E2M1FN and reshape to (m, k, l) K-major.
+        # Row strides come from the INCOMING tensors, not from (m, k): they
+        # match for a compact operand, but an ext-K residue weight arrives as a
+        # `weight_ext[:, :k_base_packed]` view (width k_base, rows k_ext apart)
+        # and make_ordered_layout would rebuild it compact, silently reading the
+        # wrong elements. Strides are in ELEMENTS, so the uint8 -> FP4 recast
+        # (which doubled k) doubles them too.
+        lda = cute.size(mA.layout.stride[0]) * 2
+        ldb = cute.size(mB.layout.stride[0]) * 2
+        a_fp4_ptr = cute.recast_ptr(mA.iterator, dtype=cutlass.Float4E2M1FN)
+        a_tensor = cute.make_tensor(
+            a_fp4_ptr,
+            layout=cute.make_layout((m, k, l), stride=(lda, 1, m * lda)),
+        )
+        b_fp4_ptr = cute.recast_ptr(mB.iterator, dtype=cutlass.Float4E2M1FN)
+        b_tensor = cute.make_tensor(
+            b_fp4_ptr,
+            layout=cute.make_layout((n, k, l), stride=(ldb, 1, n * ldb)),
+        )
+        # C: swap_ab is constexpr, determines layout at compile time
+        if cutlass.const_expr(fold_pairs):
+            # MExt R1 fold: A = weight [n_w=m, K], B = row-pair interleaved
+            # activation [m2=n, K] with m2 = 2*m_tok. The physical output is
+            # the transposed compact D[n_w, m_tok]; logical C (m, (2, m_tok))
+            # aliases each (base, residue) pair onto one address (stride-0
+            # pair mode) and keeps the m2 direction memory-contiguous so the
+            # fold epilogue sees pairs adjacent in its fragment value mode.
+            # Row pitch comes from the physical mC width, which the host may
+            # pad (e.g. to 8 elements) so vectorized epilogue stores stay
+            # 16B-aligned; the logical extent stays n // 2 for predication.
+            if cutlass.const_expr(self.fold_pairs_tma):
+                # TMA fold: mC is row-major D[m_tok, n_w]; the kernel-facing C
+                # is its transposed affine view (n_w contiguous), so the TMA
+                # box lands on D directly (no host transpose). The alias is
+                # partition-geometry metadata only -- never dereferenced on
+                # this path -- so it keeps the m2-contiguous stride fiction
+                # that selects the pair-in-value-mode TMEM load atom.
+                c_tensor = cute.make_tensor(
+                    mC.iterator,
+                    layout=cute.make_layout(
+                        (m, n // 2, l), stride=(1, m, m * (n // 2))
+                    ),
+                )
+                c_alias_tensor = cute.make_tensor(
+                    mC.iterator,
+                    layout=cute.make_layout(
+                        (m, (2, n // 2), l),
+                        stride=(n // 2, (0, 1), m * (n // 2)),
+                    ),
+                )
+            else:
+                mtok_phys = cute.size(mC, mode=[1])
+                c_alias_tensor = cute.make_tensor(
+                    mC.iterator,
+                    layout=cute.make_layout(
+                        (m, (2, n // 2), l),
+                        stride=(mtok_phys, (0, 1), m * mtok_phys),
+                    ),
+                )
+                c_tensor = c_alias_tensor
+        elif cutlass.const_expr(swap_ab):
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(0, 1, 2)),
+            )
+        else:
+            c_tensor = cute.make_tensor(
+                mC.iterator,
+                layout=cute.make_ordered_layout((m, n, l), order=(1, 0, 2)),
+            )
+        # Scale factor tensors: 6D BlockScaledBasicChunk layout from pointers
+        sfa_tensor = cute.make_tensor(
+            a_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_m, 4, sf_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+        sfb_tensor = cute.make_tensor(
+            b_sf_ptr,
+            layout=cute.make_ordered_layout(
+                (32, 4, sf_n, 4, sf_k, l),
+                order=(2, 1, 4, 0, 3, 5),
+            ),
+        )
+
+        if cutlass.const_expr(self.fold_pairs_tma):
+            self(
+                a_tensor,
+                b_tensor,
+                sfa_tensor,
+                sfb_tensor,
+                c_tensor,
+                alpha_tensor,
+                max_active_clusters,
+                current_stream,
+                epilogue_op,
+                c_alias_tensor,
+            )
+        else:
+            self(
+                a_tensor,
+                b_tensor,
+                sfa_tensor,
+                sfb_tensor,
+                c_tensor,
+                alpha_tensor,
+                max_active_clusters,
+                current_stream,
+                epilogue_op,
+            )

--- a/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/tactics.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/cute_fold/tactics.py
@@ -1,0 +1,207 @@
+# SPDX-FileCopyrightText: Copyright (c) 2025 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+"""Tile and kernel selection for the SM100/SM103 residue fold GEMM."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+# Escape hatch for harnesses that call the fallback on purpose.
+_SILENCE_DEFAULT = os.environ.get("SGLANG_RESIDUE_FOLD_SILENCE_DEFAULT", "0") == "1"
+
+from .host import mext_fold_gemm_sm103
+
+# ---------------------------------------------------------------------------
+# Arch-aware, token-count-dependent selection. Each arch lists ordered
+# (m_max, kernel_arch, mma_tiler, cluster); the first entry with m_tok <= m_max
+# wins; the last entry always matches (fallback in select_arch_tactic).
+_SENTINEL_M = 1 << 30
+ARCH_TACTIC_BY_M: dict[str, list[tuple[int, str, tuple[int, int], tuple[int, int]]]] = {
+    "sm100": [
+        (64, "sm100", (128, 64), (1, 1)),  # decode: N=64 1SM floor
+        (_SENTINEL_M, "sm100", (256, 128), (2, 1)),  # m>64: 2SM (safe blanket)
+    ],
+    "sm103": [
+        # SM100's narrow tile covers decode sizes; larger inputs use SM103.
+        (64, "sm100", (128, 64), (1, 1)),  # decode: sm100 kernel, N=64 1SM
+        (256, "sm103", (256, 128), (2, 1)),  # transition band (mixed winners)
+        (_SENTINEL_M, "sm103", (256, 256), (2, 1)),  # m>256: K=96 amortization wins
+    ],
+}
+
+
+def kernel_arch_for_capability(major: int, minor: int) -> str | None:
+    """Map a CUDA compute capability to the fold kernel arch, or None if the
+    fold path is unsupported (caller falls back to unfused)."""
+    if (major, minor) == (10, 0):
+        return "sm100"
+    if (major, minor) == (10, 3):
+        return "sm103"
+    return None
+
+
+def select_arch_tactic(
+    arch: str, m_tok: int
+) -> tuple[str, tuple[int, int], tuple[int, int]]:
+    """(kernel_arch, mma_tiler, cluster) for this arch + token count.
+
+    `arch` must come from kernel_arch_for_capability (KeyError otherwise). The
+    last list entry is an unconditional fallback (matches any m_tok, incl. the
+    _SENTINEL_M edge), so this never raises for a valid arch.
+    """
+    entries = ARCH_TACTIC_BY_M[arch]
+    for m_max, kernel_arch, tiler, cluster in entries[:-1]:
+        if m_tok <= m_max:
+            return kernel_arch, tiler, cluster
+    _m_max, kernel_arch, tiler, cluster = entries[-1]  # unconditional fallback
+    return kernel_arch, tiler, cluster
+
+
+def run_fold_default(
+    major: int,
+    minor: int,
+    weight_fp4: torch.Tensor,
+    act_fp4_rowpair: torch.Tensor,
+    weight_sf: torch.Tensor,
+    act_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Run the fold GEMM with the validated default tactic for this GPU/m_tok."""
+    arch = kernel_arch_for_capability(major, minor)
+    if arch is None:
+        raise RuntimeError(f"no fold kernel for capability ({major},{minor})")
+    m_tok = act_fp4_rowpair.shape[0] // 2
+    kernel_arch, tiler, cluster = select_arch_tactic(arch, m_tok)
+    if not _SILENCE_DEFAULT:
+        from ..fold import warn_default_path
+
+        warn_default_path(arch, m_tok, f"tile={tiler}")
+    return mext_fold_gemm_sm103(
+        weight_fp4,
+        act_fp4_rowpair,
+        weight_sf,
+        act_sf,
+        alpha,
+        out_dtype,
+        mma_tiler_mn=tiler,
+        cluster_shape_mn=cluster,
+        store_mode="tma",
+        kernel_arch=kernel_arch,
+    )
+
+
+def warmup_specs(arch: str, strided=(False, True)) -> list[dict]:
+    """Enumerate every static row-pair kernel variant reachable on ``arch``."""
+    specs = []
+    for _m_max, kernel_arch, tiler, cluster in ARCH_TACTIC_BY_M[arch]:
+        for strided_weight in strided:
+            specs.append(
+                dict(
+                    mma_tiler_mn=tiler,
+                    cluster_shape_mn=cluster,
+                    mode="fold_tma",
+                    kernel_arch=kernel_arch,
+                    ab_stage_override=None,
+                    strided_weight=strided_weight,
+                )
+            )
+    return specs
+
+
+def warmup_fold_default(
+    major: int, minor: int, *, strided=(False, True), out_dtype=None
+) -> int:
+    """Pre-compile the fold kernels this GPU can reach. Returns the count.
+
+    Call at engine init outside CUDA graph capture.
+
+    Best-effort per spec: one illegal combination must not cost the rest of
+    the coverage. Failures are printed, never swallowed -- a warmup that
+    silently covers nothing is exactly the state this replaced.
+    """
+    from .host import _compile_fold_gemm
+
+    arch = kernel_arch_for_capability(major, minor)
+    if arch is None:
+        return 0
+    dtype = out_dtype if out_dtype is not None else torch.bfloat16
+
+    compiled = failed = 0
+    for spec in warmup_specs(arch, strided=strided):
+        try:
+            _compile_fold_gemm(
+                spec["mma_tiler_mn"],
+                spec["cluster_shape_mn"],
+                dtype,
+                mode=spec["mode"],
+                kernel_arch=spec["kernel_arch"],
+                ab_stage_override=spec["ab_stage_override"],
+                strided_weight=spec["strided_weight"],
+            )
+            compiled += 1
+        except Exception as e:  # noqa: BLE001
+            failed += 1
+            print(
+                f"[residue] fold warmup: {spec['mode']} "
+                f"{spec['mma_tiler_mn']} strided={spec['strided_weight']} "
+                f"failed: {type(e).__name__}: {str(e)[:70]}",
+                flush=True,
+            )
+    if failed:
+        print(
+            f"[residue] fold warmup: {compiled} compiled, {failed} FAILED "
+            f"-- those shapes will JIT on first use",
+            flush=True,
+        )
+    return compiled
+
+
+# Candidate order is part of the persisted FlashInfer tuner cache contract.
+FAMILY_TACTICS: dict[tuple[str, str], list[tuple]] = {
+    ("row_pair", "std"): [
+        # Narrow N tiles reduce padding at decode sizes. Explicit AB depths
+        # keep the smallest tiles within the shared-memory limit.
+        ("tma", (128, 8), (1, 1), 5),
+        ("tma", (128, 16), (1, 1), 6),
+        ("tma", (128, 16), (1, 1), 5),
+        ("tma", (128, 24), (1, 1)),
+        ("tma", (128, 32), (1, 1), 5),
+        ("tma", (128, 32), (1, 1)),
+        ("tma", (128, 64), (1, 1)),
+        ("tma", (128, 128), (1, 1)),
+        ("tma", (256, 64), (2, 1)),
+        ("tma", (256, 128), (2, 1)),
+        ("tma", (256, 256), (2, 1)),
+    ],
+}
+
+
+def _norm_tactic(t: tuple) -> tuple[str, tuple[int, int], tuple[int, int], int | None]:
+    """Accept 3- or 4-element entries; the 4th is ab_stage (None = auto)."""
+    if len(t) == 3:
+        return t[0], t[1], t[2], None
+    return t[0], t[1], t[2], t[3]
+
+
+def _rank_tactics(family: tuple[str, str], m_tok: int, kernel_arch: str):
+    """Filter legal row-pair candidates and rank by token-axis waste."""
+    del kernel_arch
+    if family != ("row_pair", "std"):
+        raise KeyError(family)
+    prob = 2 * m_tok
+    scored = []
+    for raw in FAMILY_TACTICS[family]:
+        mode, tiler, cluster, ab = _norm_tactic(raw)
+        tile = tiler[1]
+        if tile < 64 and prob > tile:
+            continue
+        n_tiles = (prob + tile - 1) // tile
+        waste = n_tiles * tile - prob
+        scored.append(
+            ((waste, n_tiles, 0 if ab is None else 1), (mode, tiler, cluster, ab))
+        )
+    scored.sort(key=lambda kv: kv[0])
+    return [t for _, t in scored]

--- a/python/sglang/kernels/ops/gemm/residue_fold/fold.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/fold.py
@@ -1,0 +1,127 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+"""Dispatch and warmup for the SM100/SM103 residue fold GEMM."""
+
+from __future__ import annotations
+
+import contextlib
+import sys
+import warnings
+
+import torch
+
+_DEFAULT_PATH_WARNED = False
+
+
+# ── JIT-compile observability ──────────────────────────────────────────────
+# Read `sys.modules` rather than importing so observability never loads CUTLASS.
+_SM10X_HOST = "sglang.kernels.ops.gemm.residue_fold.cute_fold.host"
+
+
+def compile_stats() -> dict[str, dict | None]:
+    """Fold kernels JIT-compiled by this process so far, per arch.
+
+    Side-effect free: never imports a module that is not already loaded.
+    `None` for an arch means its host module has not been imported at all,
+    which is the normal state for the arch this GPU is not.
+    """
+    out: dict[str, dict | None] = {"sm10x": None}
+
+    mod = sys.modules.get(_SM10X_HOST)
+    if mod is not None:
+        cache = getattr(mod, "_KERNEL_CACHE", None)
+        if cache is not None:
+            out["sm10x"] = {"compiled": len(cache), "keys": list(cache)}
+
+    return out
+
+
+def warmup(major: int, minor: int, shapes=None) -> int:
+    """Pre-compile whatever this GPU's fold path can need. Returns the count.
+
+    The compile key has no shape or token count, so ``shapes`` is ignored.
+    Call this at engine init, before CUDA graph capture.
+    """
+    from .cute_fold import tactics as _t
+
+    return _t.warmup_fold_default(major, minor)
+
+
+@contextlib.contextmanager
+def observe_compiles(where: str, *, warn: bool = True):
+    """Report any fold kernel JIT-compiled inside this block.
+
+    Wrap the regions that must already be warm -- cudagraph capture above all,
+    where a JIT is both slow and, for the sm10x path, a sync inside capture.
+    A clean block prints nothing; the whole point is that the silent case
+    stays silent and the broken case does not.
+    """
+    before = compile_stats()
+    try:
+        yield
+    finally:
+        after = compile_stats()
+        for arch in ("sm10x",):
+            b, a = before.get(arch), after.get(arch)
+            if not a:
+                continue
+            n = a["compiled"] - (b["compiled"] if b else 0)
+            if n <= 0:
+                continue
+            detail = ""
+            if a["keys"] is not None:
+                fresh = a["keys"][len(b["keys"]) if b else 0 :]
+                detail = "".join(f"\n[residue]     {k}" for k in fresh[:8])
+                if len(fresh) > 8:
+                    detail += f"\n[residue]     ... and {len(fresh) - 8} more"
+            if warn:
+                print(
+                    f"[residue] WARMUP UNDER-COVERAGE: {n} {arch} fold "
+                    f"kernel(s) JIT-compiled during {where}. Each costs ~1.3 s "
+                    f"and blocks the caller. The pre-compile missed:{detail}",
+                    flush=True,
+                )
+
+
+def warn_default_path(arch: str, m_tok: int, detail: str = "") -> None:
+    """Announce, once per process, that the untuned sm10x table is serving.
+
+    This warning means a tuned path exists but the static fallback is serving.
+
+    Once, not per call: this sits in the decode path and the message is a
+    build-configuration fact, not a per-request event.
+    """
+    global _DEFAULT_PATH_WARNED
+    if _DEFAULT_PATH_WARNED:
+        return
+    _DEFAULT_PATH_WARNED = True
+    warnings.warn(
+        f"[residue] MExt fold is running on the STATIC tactic table "
+        f"(arch={arch}, m_tok={m_tok}{', ' + detail if detail else ''}). "
+        "On sm10x that table is a correctness fallback, not the tuned path: "
+        "it takes (128,64) for every m_tok<=64, which at m_tok=8 wastes three "
+        "quarters of the token axis and measured ~19% slower than the "
+        "exact-fit tile. Enable and precompile the FlashInfer fold tuner at "
+        "engine init, or set SGLANG_RESIDUE_FOLD_SILENCE_DEFAULT=1 if the "
+        "fallback is intentional here.",
+        RuntimeWarning,
+        stacklevel=3,
+    )
+
+
+def run_fold(
+    major: int,
+    minor: int,
+    weight_fp4: torch.Tensor,
+    act_fp4_rowpair: torch.Tensor,
+    weight_sf: torch.Tensor,
+    act_sf: torch.Tensor,
+    alpha: torch.Tensor,
+    out_dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor:
+    """Run the SM100/SM103 row-pair fold GEMM via the static fallback."""
+    from .cute_fold import tactics as _t
+
+    return _t.run_fold_default(
+        major, minor, weight_fp4, act_fp4_rowpair, weight_sf, act_sf, alpha, out_dtype
+    )

--- a/python/sglang/kernels/ops/gemm/residue_fold/tuners/__init__.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/tuners/__init__.py
@@ -1,0 +1,27 @@
+"""FlashInfer-autotuned tactic selection for the residue fold ops.
+
+The tuners share one scaffold (fi_tuner_base): runners[0] is the
+pre-existing serving path (never JITs on a cache miss), candidates are
+indices into a stable list whose hash goes into the persisted cache key,
+and outside the tuning window only precompiled kernels are offered.
+"""
+
+from sglang.kernels.ops.gemm.residue_fold.tuners.mext_prefill_tuner import (
+    precompile_kloop_sm100,
+    tuned_mext_prefill,
+)
+from sglang.kernels.ops.gemm.residue_fold.tuners.sm10x_fold_tuner import (
+    precompile_row_pair,
+    tuned_sm10x_fold,
+)
+from sglang.kernels.ops.gemm.residue_fold.tuners.sm10x_fold_tuner import (
+    tuner_enabled as sm10x_tuner_enabled,
+)
+
+__all__ = [
+    "precompile_kloop_sm100",
+    "precompile_row_pair",
+    "sm10x_tuner_enabled",
+    "tuned_mext_prefill",
+    "tuned_sm10x_fold",
+]

--- a/python/sglang/kernels/ops/gemm/residue_fold/tuners/fi_tuner_base.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/tuners/fi_tuner_base.py
@@ -1,0 +1,224 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+"""Shared FlashInfer AutoTuner scaffold for residue kernels."""
+
+from __future__ import annotations
+
+from typing import Callable, Sequence
+
+import torch
+
+
+def bucket_of(buckets: Sequence[int], m: int) -> int:
+    for b in buckets:
+        if m <= b:
+            return b
+    return buckets[-1]
+
+
+def weight_geometry(weight: torch.Tensor) -> tuple[int, int, int | None]:
+    """(n_w, k_logical, a_ld) off a packed-FP4 weight, view-aware.
+
+    a_ld is the stored row pitch in FP4 elements, None when contiguous --
+    the convention both fold hosts take. It must be part of any whitelist
+    key and cache-key extras: a plain weight and an ext-K prefix view have
+    the SAME shape but different read cost.
+    """
+    n_w = int(weight.shape[0])
+    k_logical = int(weight.shape[1]) * 2
+    k_stored = int(weight.stride(0)) * 2
+    return n_w, k_logical, (None if k_stored == k_logical else k_stored)
+
+
+def make_tuning_config(buckets: Sequence[int], map_fn: Callable[[int], int]):
+    """Build the token-count tuning configuration shared by residue ops."""
+    from flashinfer.autotuner import DynamicTensorSpec, TuningConfig
+
+    return TuningConfig(
+        use_cold_l2_cache=True,
+        dynamic_tensor_specs=(
+            DynamicTensorSpec(
+                input_idx=(0,),
+                dim_idx=(0,),
+                gen_tuning_buckets=tuple(buckets),
+                map_to_tuning_buckets=map_fn,
+            ),
+        ),
+    )
+
+
+# What the last tuning window actually achieved, per op. Reported, never
+# assumed -- see cold_tuning_state.
+_COLD_STATE: dict[str, dict] = {}
+
+
+def cold_tuning_state(op_name: str | None = None):
+    """Return the recorded L2-cold tuning state for one op or all ops."""
+    if op_name is None:
+        return dict(_COLD_STATE)
+    return _COLD_STATE.get(op_name)
+
+
+def prime_cold_tuning(op_name: str, inputs: list) -> dict:
+    """Increase AutoTuner repeats until cloned inputs exceed L2 capacity."""
+    import torch
+    from flashinfer.autotuner import AutoTuner
+
+    tuner = AutoTuner.get()
+    one_buffer = sum(
+        t.numel() * t.element_size() for t in inputs if isinstance(t, torch.Tensor)
+    )
+    try:
+        l2 = tuner._get_l2_cache_size_in_bytes()
+    except Exception:
+        l2 = torch.cuda.get_device_properties(0).L2_cache_size
+    state = {
+        "one_buffer_bytes": one_buffer,
+        "l2_bytes": l2,
+        "repeat_before": tuner.repeat,
+    }
+    if one_buffer <= 0:
+        state.update(cold=False, why="no tensor inputs measured")
+        _COLD_STATE[op_name] = state
+        return state
+    # Enough clones that the working set exceeds L2 outright; the +1 is the
+    # original, and one extra is margin against a partial last touch.
+    need_buffers = int(l2 // one_buffer) + 2
+    uncapped = l2 * 3 // one_buffer + 1
+    need_repeat = min(uncapped, need_buffers) - 1
+    if need_repeat > tuner.repeat:
+        tuner.repeat = need_repeat
+    buffers = min(uncapped, tuner.repeat + 1)
+    workset = buffers * one_buffer
+    state.update(
+        repeat=tuner.repeat,
+        num_buffers=buffers,
+        workset_bytes=workset,
+        workset_over_l2=workset / l2,
+        cold=workset > l2,
+    )
+    if not state["cold"]:
+        state["why"] = (
+            "clone count capped below what L2 needs -- "
+            f"{buffers} x {one_buffer / 1e6:.1f}MB does not clear "
+            f"{l2 / 1e6:.1f}MB"
+        )
+    _COLD_STATE[op_name] = state
+    return state
+
+
+def make_runner_pair(
+    op_name: str,
+    fallback_forward: Callable,  # (inputs) -> Tensor
+    fallback_extras: tuple,
+    valid_tactics: Callable,  # (inputs, tuning: bool) -> list[int]
+    run_tactic: Callable,  # (inputs, idx) -> Tensor
+    candidate_extras: Callable,  # (inputs) -> tuple
+    degraded_flag: list,  # [bool], one per op module
+    on_degrade: Callable[[], None] | None = None,
+):
+    """[FallbackRunner(), CandidateRunner()] with the shared guarantees.
+
+    The candidate runner re-checks validity at serving time: a persisted
+    tactic whose kernel is absent (whitelist drift, partial warmup) degrades
+    to the fallback and SAYS SO once -- a silent degrade lets the caller's
+    announce report "autotuned" while the fallback serves, which is the
+    stale-copy failure shape.
+    """
+    from flashinfer.autotuner import AutoTuner, TunableRunner
+
+    class FallbackRunner(TunableRunner):
+        """runners[0]: any cache miss or skipped op serves this -- the
+        never-JIT guarantee."""
+
+        def get_valid_tactics(self, inputs, profile):
+            return [0]
+
+        def forward(self, inputs, tactic=-1, do_preparation=False, **kwargs):
+            return fallback_forward(inputs)
+
+        def get_cache_key_extras(self, inputs):
+            return fallback_extras
+
+    class CandidateRunner(TunableRunner):
+        def get_valid_tactics(self, inputs, profile):
+            return valid_tactics(inputs, AutoTuner.get().is_tuning_mode)
+
+        def forward(self, inputs, tactic=-1, do_preparation=False, **kwargs):
+            if tactic < 0:
+                return fallback_forward(inputs)
+            if not AutoTuner.get().is_tuning_mode and tactic not in valid_tactics(
+                inputs, False
+            ):
+                if not degraded_flag[0]:
+                    degraded_flag[0] = True
+                    print(
+                        f"[residue] {op_name}: cached tactic {tactic} has "
+                        f"no precompiled kernel -- DEGRADING to the "
+                        f"fallback (once per process; later shapes may do "
+                        f"the same silently)",
+                        flush=True,
+                    )
+                if on_degrade is not None:
+                    on_degrade()
+                return fallback_forward(inputs)
+            return run_tactic(inputs, tactic)
+
+        def get_cache_key_extras(self, inputs):
+            return candidate_extras(inputs)
+
+    return [FallbackRunner(), CandidateRunner()]
+
+
+def tuned_call(
+    op_name: str,
+    runners_getter: Callable[[], list],
+    config_getter: Callable[[], object],
+    inputs: list,
+    fallback_forward: Callable,
+    kill_env_value: str | None,
+    announce_flag: list,
+    announce: Callable[[object, int, list], str] | None = None,
+    record: Callable[[str], None] | None = None,
+):
+    """The shared serving entry: kill switch -> import guard -> choose_one.
+
+    `kill_env_value` is the already-read env value ("0" disables); reading
+    the env stays in the op module so the contract table has one owner.
+
+    ``record`` receives the resolved tactic source on every call.
+    """
+    if kill_env_value == "0":
+        if record is not None:
+            record("offline_table")
+        return fallback_forward(inputs)
+    try:
+        from flashinfer.autotuner import AutoTuner
+    except Exception:  # noqa: BLE001
+        if not announce_flag[0]:
+            announce_flag[0] = True
+            print(
+                f"[residue] {op_name}: flashinfer.autotuner unavailable "
+                f"-- serving the fallback",
+                flush=True,
+            )
+        if record is not None:
+            record("offline_table")
+        return fallback_forward(inputs)
+
+    runners = runners_getter()
+    # Only inside a tuning window does choose_one actually profile, so that
+    # is the only place raising `repeat` costs anything or buys anything.
+    # Outside it this is a cache lookup and the state stays as the window
+    # left it -- which is what the bench should report.
+    if AutoTuner.get().is_tuning_mode:
+        prime_cold_tuning(op_name, inputs)
+    runner, tactic = AutoTuner.get().choose_one(
+        op_name, runners, config_getter(), inputs
+    )
+    if announce is not None and not announce_flag[0]:
+        announce_flag[0] = True
+        print(f"[residue] {op_name}: {announce(runner, tactic, runners)}", flush=True)
+    if record is not None:
+        record("autotuned" if tactic >= 0 else "offline_table")
+    return runner.forward(inputs, tactic=tactic)

--- a/python/sglang/kernels/ops/gemm/residue_fold/tuners/mext_prefill_tuner.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/tuners/mext_prefill_tuner.py
@@ -1,0 +1,192 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+"""Autotuned dispatch for the mext_r1 prefill GEMM.
+
+FlashInfer selects between a two-GEMM implementation and a wrapped-K kernel
+per layer shape and token-count bucket. The two-GEMM path is the cache-miss
+fallback; wrapped-K tactics are exposed only after their kernels are compiled.
+"""
+
+from __future__ import annotations
+
+import torch
+
+# FlashInfer profiles each token-count bucket once; these are tuning keys,
+# not compile keys, because the SM100/103 kernels use symbolic shapes.
+KLOOP_BUCKETS = (128, 256, 512, 1024, 2048)
+# SM100/103 K-loop (tile, cluster) configs. One symbolic-shape compile
+# per config covers every shape and m -- no buckets, no padding, whitelist
+# keyed on the config alone. (256,128) is a 2-SM MMA and needs cluster (2,1).
+KLOOP_SM100_CFGS = (((128, 128), (1, 1)), ((256, 128), (2, 1)))
+
+_CUSTOM_OP = "residue_mext_prefill_fp4_gemm"
+
+# ("sm100", tile, cluster) entries compiled during warmup.
+_PRECOMPILED: set = set()
+
+
+def _bucket_of(m: int) -> int:
+    for b in KLOOP_BUCKETS:
+        if m <= b:
+            return b
+    return KLOOP_BUCKETS[-1]
+
+
+def _map_to_tuning_buckets(x: int) -> int:
+    # Module-level named function: TuningConfig is hashed into the cache key,
+    # so this must be ONE stable object, not a fresh lambda per call.
+    return _bucket_of(int(x))
+
+
+_TUNING_CONFIG = None
+
+
+def _tuning_config():
+    global _TUNING_CONFIG
+    if _TUNING_CONFIG is None:
+        from flashinfer.autotuner import DynamicTensorSpec, TuningConfig
+
+        _TUNING_CONFIG = TuningConfig(
+            dynamic_tensor_specs=(
+                DynamicTensorSpec(
+                    # tuples, not lists: the spec is hashed into the cache key
+                    # (its docstring says "list", its __hash__ says otherwise)
+                    input_idx=(0,),
+                    dim_idx=(0,),
+                    gen_tuning_buckets=KLOOP_BUCKETS,
+                    map_to_tuning_buckets=_map_to_tuning_buckets,
+                ),
+            ),
+        )
+    return _TUNING_CONFIG
+
+
+def _run_two_gemm(inputs):
+    from sglang.kernels.ops.gemm.residue_nvfp4_linear import (
+        _run_mext_r1_two_gemm,
+    )
+
+    x, w, gs_inv, wsb, alpha = inputs
+    return _run_mext_r1_two_gemm(x, w, gs_inv, wsb, alpha, x.dtype)
+
+
+def _run_kloop(inputs, tactic_idx) -> torch.Tensor:
+    from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+        scaled_fp4_quant_mext_r1,
+    )
+
+    x, w, gs_inv, wsb, alpha = inputs
+    from sglang.kernels.ops.gemm.residue_fold.cute_fold.host import (
+        kext_kloop_gemm_sm100,
+    )
+
+    tile, cluster = KLOOP_SM100_CFGS[tactic_idx]
+    f, s = scaled_fp4_quant_mext_r1(x, gs_inv, layout_mode="concat_k")
+    return kext_kloop_gemm_sm100(
+        w,
+        f,
+        wsb,
+        s,
+        alpha,
+        x.dtype,
+        mma_tiler_mn=tile,
+        cluster_shape_mn=cluster,
+    )
+
+
+def precompile_kloop_sm100(out_dtype=torch.bfloat16) -> int:
+    """Compile the (few) symbolic sm100 kloop kernels; whitelist per config."""
+    from sglang.kernels.ops.gemm.residue_fold.cute_fold.host import _compile_fold_gemm
+
+    # A real allocation, not torch.cuda.init(): init() alone leaves no CURRENT
+    # context, and cutlass HardwareInfo then dies with
+    # CUDA_ERROR_INVALID_CONTEXT. PWAL callers always have one; offline
+    # tooling (prewarm scripts, probes) is exactly who hits this.
+    torch.zeros(1, device="cuda")
+    done = 0
+    for tile, cluster in KLOOP_SM100_CFGS:
+        try:
+            _compile_fold_gemm(
+                tile, cluster, out_dtype, mode="kloop_tma", kernel_arch="sm100"
+            )
+            _PRECOMPILED.add(("sm100", tile, cluster))
+            done += 1
+        except Exception as e:  # noqa: BLE001
+            print(
+                f"[residue] sm100 kloop precompile failed tile={tile} "
+                f"cluster={cluster}: {type(e).__name__}: {str(e)[:70]}",
+                flush=True,
+            )
+    return done
+
+
+# The fold kernel is reserved for decode; prefill compares two_gemm and k_loop.
+
+_DEGRADED = [False]
+_ANNOUNCED = [False]
+
+
+def _kloop_valid_tactics(inputs, tuning):
+    if tuning:
+        return list(range(len(KLOOP_SM100_CFGS)))
+    return [
+        i
+        for i, (tile, cluster) in enumerate(KLOOP_SM100_CFGS)
+        if ("sm100", tile, cluster) in _PRECOMPILED
+    ]
+
+
+def _make_runners():
+    from .fi_tuner_base import make_runner_pair
+
+    return make_runner_pair(
+        _CUSTOM_OP,
+        fallback_forward=_run_two_gemm,
+        fallback_extras=("two_gemm", 1),
+        valid_tactics=_kloop_valid_tactics,
+        run_tactic=_run_kloop,
+        candidate_extras=lambda inputs: ("k_loop", 1),
+        degraded_flag=_DEGRADED,
+    )
+
+
+_RUNNERS = None
+
+
+def tuned_mext_prefill(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_global_scale_inv: torch.Tensor,
+    weight_scale_base: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+    force_kloop: bool = False,
+) -> torch.Tensor:
+    """Route one mext_r1 prefill GEMM through FlashInfer's tuned choice."""
+    global _RUNNERS
+    inputs = [x, weight, input_global_scale_inv, weight_scale_base, alpha]
+
+    if force_kloop:
+        for i, (tile, cluster) in enumerate(KLOOP_SM100_CFGS):
+            if ("sm100", tile, cluster) in _PRECOMPILED:
+                return _run_kloop(inputs, i)
+        return _run_two_gemm(inputs)
+
+    from .fi_tuner_base import tuned_call
+
+    def _runners():
+        global _RUNNERS
+        if _RUNNERS is None:
+            _RUNNERS = _make_runners()
+        return _RUNNERS
+
+    return tuned_call(
+        _CUSTOM_OP,
+        runners_getter=_runners,
+        config_getter=_tuning_config,
+        inputs=inputs,
+        fallback_forward=_run_two_gemm,
+        kill_env_value=None,  # no kill switch: two_gemm IS the fallback
+        announce_flag=_ANNOUNCED,
+        announce=None,
+    )

--- a/python/sglang/kernels/ops/gemm/residue_fold/tuners/sm10x_fold_tuner.py
+++ b/python/sglang/kernels/ops/gemm/residue_fold/tuners/sm10x_fold_tuner.py
@@ -1,0 +1,247 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 Rong Shuo
+# SPDX-License-Identifier: Apache-2.0
+"""FlashInfer-autotuned tactic selection for the SM100/SM103 decode fold."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from .fi_tuner_base import (
+    bucket_of,
+    make_runner_pair,
+    make_tuning_config,
+    tuned_call,
+    weight_geometry,
+)
+
+FOLD_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128)
+_FAMILY = ("row_pair", "std")
+_CUSTOM_OP = "residue_fold_tactic_sm10x"
+_LAYOUT_ROW_PAIR = 1
+
+# Tactic indices that executed in this process are safe to serve without a
+# separate precompile step.
+_EXECUTED: set = set()
+_ANNOUNCED = [False]
+_DEGRADED = [False]
+
+# Actual source and tactic of the most recent call.
+_LAST_SOURCE: list = [None]
+# None on the static fallback, which resolves its tile inside tactics.py.
+_LAST_TILE: list = [None]
+
+
+def last_tactic_source() -> str | None:
+    return _LAST_SOURCE[0]
+
+
+def last_tactic_tile():
+    return _LAST_TILE[0]
+
+
+def _record_source(src: str) -> None:
+    _LAST_SOURCE[0] = src
+
+
+_CANDIDATES: list | None = None
+_INDEX_BY_TACTIC: dict | None = None
+
+
+def _bucket_of(m: int) -> int:
+    return bucket_of(FOLD_BUCKETS, m)
+
+
+def _map_to_tuning_buckets(x: int) -> int:
+    # Module-level named function: TuningConfig is hashed into the cache key.
+    return _bucket_of(int(x))
+
+
+_TUNING_CONFIG = None
+
+
+def _tuning_config():
+    global _TUNING_CONFIG
+    if _TUNING_CONFIG is None:
+        _TUNING_CONFIG = make_tuning_config(FOLD_BUCKETS, _map_to_tuning_buckets)
+    return _TUNING_CONFIG
+
+
+def _candidates() -> list:
+    """Normalized (mode, tiler, cluster, ab) list, order = tactic index.
+
+    The order is FAMILY_TACTICS' order, which therefore becomes part of the
+    persisted cache contract -- candidates_hash() invalidates on any edit.
+    """
+    global _CANDIDATES, _INDEX_BY_TACTIC
+    if _CANDIDATES is None:
+        from sglang.kernels.ops.gemm.residue_fold.cute_fold.tactics import (
+            FAMILY_TACTICS,
+            _norm_tactic,
+        )
+
+        _CANDIDATES = [_norm_tactic(t) for t in FAMILY_TACTICS[_FAMILY]]
+        _INDEX_BY_TACTIC = {t: i for i, t in enumerate(_CANDIDATES)}
+    return _CANDIDATES
+
+
+def candidates_hash() -> str:
+    import hashlib
+
+    from sglang.kernels.ops.gemm.residue_fold.cute_fold.tactics import FAMILY_TACTICS
+
+    return hashlib.md5(repr(FAMILY_TACTICS[_FAMILY]).encode()).hexdigest()[:12]
+
+
+def _arch() -> str | None:
+    from sglang.kernels.ops.gemm.residue_fold.cute_fold.tactics import (
+        kernel_arch_for_capability,
+    )
+
+    major, minor = torch.cuda.get_device_capability()
+    return kernel_arch_for_capability(int(major), int(minor))
+
+
+def _legal_indices(m_tok: int) -> list[int]:
+    """m-dependent legality, delegated to the ranking the dict tuner used:
+    narrow tiles must cover 2*m_tok outright, smem-infeasible entries are
+    already absent from the table. Ranking order is irrelevant here (the
+    profiler measures everything offered); only membership matters."""
+    from sglang.kernels.ops.gemm.residue_fold.cute_fold.tactics import _rank_tactics
+
+    cands = _candidates()
+    ranked = _rank_tactics(_FAMILY, m_tok, _arch())
+    return sorted(_INDEX_BY_TACTIC[t] for t in ranked if t in _INDEX_BY_TACTIC)
+
+
+def _quant_row_pair(inputs):
+    from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+        scaled_fp4_quant_mext_r1,
+    )
+
+    x, _, gs_inv, _, _ = inputs
+    x_fp4, x_sf = scaled_fp4_quant_mext_r1(x, gs_inv, layout_mode=_LAYOUT_ROW_PAIR)
+    return x_fp4, x_sf.view(torch.float8_e4m3fn)
+
+
+def _run_tactic(inputs, idx, out_dtype) -> torch.Tensor:
+    from sglang.kernels.ops.gemm.residue_fold.cute_fold.host import mext_fold_gemm_sm103
+
+    mode, tiler, cluster, ab = _candidates()[idx]
+    _LAST_TILE[0] = (mode, tiler, cluster, ab)
+    x_fp4, x_sf = _quant_row_pair(inputs)
+    _, weight, _, wsb, alpha = inputs
+    out = mext_fold_gemm_sm103(
+        weight,
+        x_fp4,
+        wsb,
+        x_sf,
+        alpha,
+        out_dtype,
+        mma_tiler_mn=tiler,
+        cluster_shape_mn=cluster,
+        store_mode=mode,
+        kernel_arch=_arch(),
+        ab_stage_override=ab,
+    )
+    _EXECUTED.add(idx)
+    return out
+
+
+def _run_fallback(inputs, out_dtype) -> torch.Tensor:
+    """Run the static row-pair fallback without entering the tuner again."""
+    from sglang.kernels.ops.gemm.residue_fold.cute_fold.tactics import run_fold_default
+
+    _LAST_TILE[0] = None
+    x_fp4, x_sf = _quant_row_pair(inputs)
+    _, weight, _, wsb, alpha = inputs
+    major, minor = torch.cuda.get_device_capability()
+    return run_fold_default(
+        int(major), int(minor), weight, x_fp4, wsb, x_sf, alpha, out_dtype
+    )
+
+
+def precompile_row_pair() -> bool:
+    """Report unavailable until every row-pair candidate is precompiled."""
+    # The static fallback warmup does not compile the full autotuner candidate
+    # set, so advertising readiness would expose uncompiled tactics at serve time.
+    return False
+
+
+def _make_runners(out_dtype):
+    def _fallback(inputs):
+        return _run_fallback(inputs, out_dtype)
+
+    def _valid(inputs, tuning):
+        legal = _legal_indices(int(inputs[0].shape[0]))
+        if tuning:
+            return legal
+        return [i for i in legal if i in _EXECUTED]
+
+    def _run(inputs, i):
+        return _run_tactic(inputs, i, out_dtype)
+
+    def _extras(inputs):
+        _, _, a_ld = weight_geometry(inputs[1])
+        return ("row_pair", _arch(), candidates_hash(), a_ld, str(out_dtype))
+
+    return make_runner_pair(
+        _CUSTOM_OP,
+        fallback_forward=_fallback,
+        fallback_extras=("static_row_pair", 2),
+        valid_tactics=_valid,
+        run_tactic=_run,
+        candidate_extras=_extras,
+        degraded_flag=_DEGRADED,
+        on_degrade=lambda: _record_source("fallback"),
+    )
+
+
+_RUNNERS_BY_DTYPE: dict = {}
+
+
+def _announce(runner, tactic, runners) -> str:
+    if runner is runners[1] and tactic >= 0:
+        return f"tactic source: autotuned {_candidates()[tactic]}"
+    if tactic >= 0:
+        return "tactic source: autotuned (the static fallback won the profile)"
+    return "tactic source: static row-pair (no tuned entry -- fallback)"
+
+
+def tuner_enabled() -> bool:
+    return os.environ.get("SGLANG_RESIDUE_SM10X_FOLD_TUNER", "1") == "1"
+
+
+def tuned_sm10x_fold(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_global_scale_inv: torch.Tensor,
+    weight_scale_base: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Route one sm10x decode fold through FlashInfer's tuned tactic choice.
+
+    `weight` may be an ext-K base-K prefix VIEW; its stride carries a_ld.
+    Returns D[x.shape[0], n_w].
+    """
+    inputs = [x, weight, input_global_scale_inv, weight_scale_base, alpha]
+
+    def _runners():
+        runners = _RUNNERS_BY_DTYPE.get(output_dtype)
+        if runners is None:
+            runners = _RUNNERS_BY_DTYPE[output_dtype] = _make_runners(output_dtype)
+        return runners
+
+    return tuned_call(
+        _CUSTOM_OP,
+        runners_getter=_runners,
+        config_getter=_tuning_config,
+        inputs=inputs,
+        fallback_forward=lambda ins: _run_fallback(ins, output_dtype),
+        kill_env_value=("1" if tuner_enabled() else "0"),
+        announce_flag=_ANNOUNCED,
+        announce=_announce,
+        record=_record_source,
+    )

--- a/python/sglang/kernels/ops/gemm/residue_nvfp4_linear.py
+++ b/python/sglang/kernels/ops/gemm/residue_nvfp4_linear.py
@@ -1,0 +1,464 @@
+"""Opaque custom op covering the residue NVFP4 dense-linear dispatch.
+
+Why this exists:
+    The residue NVFP4 linear method has distinct kernel chains:
+      - mext fold path: scaled_fp4_quant_mext_r1 + CuTeDSL fold GEMM
+      - two-GEMM prefill path: one plain NVFP4 GEMM at 2M rows + pair-sum
+      - plain path: stock NVFP4 quant + GEMM (no residue)
+      - K-ext hybrid: small M uses base-K fold; large M uses masked quant +
+        GEMM over K_ext
+    Which one a layer gets is NOT purely an M decision: a mext_r1 layer
+    (ratio 1.0, weight stored once) has no K-extended weight to fall back to,
+    so it takes a residue-preserving path at every M. Selecting between the
+    chains at Python level inside apply() makes the routing
+    tensor-shape-dependent; torch.compile then specializes the trace at its
+    dummy input shape and bakes one branch into every captured CUDA graph.
+
+    Wrapping the whole pipeline (quant + GEMM) in a single opaque custom op
+    fixes that: torch.compile captures one node, bakes only per-layer
+    constants into its args, and the internal dispatch runs at execution
+    time, so layout choice is correct for the actual M of each capture.
+
+Shape derivation:
+    All intermediate shapes are computed from x.shape and integer args
+    (per-layer constants). Never from a kernel output's shape -- those are
+    SymInts whose materialization forces a host sync at trace time.
+
+Backend scope:
+    Cutlass-layout NVFP4 backends only (flashinfer cutlass / cute-dsl). The
+    linear method enforces that before routing a layer here.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+
+from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+    MEXT_R1_LAYOUT_ROW_PAIR,
+    scaled_fp4_quant_mext_r1,
+)
+from sglang.srt.utils.custom_op import register_custom_op
+
+# ── how a layer represents its residue ─────────────────────────────────────
+# Derived, never passed: the op receives `num_salient` and `is_mext_r1`
+# separately, so the information is unambiguous AT THE BOUNDARY. What was
+# ambiguous historically was code that branched on `num_salient == 0`, a value
+# that means both "plain layer, no residue" and "mext_r1 layer, every channel
+# is salient". Branch on the name, not the number.
+RESIDUE_NONE = "none"
+RESIDUE_K_EXT = "k_ext"
+RESIDUE_MEXT_R1 = "mext_r1"
+
+
+def residue_kind_of(num_salient: int, is_mext_r1: bool) -> str:
+    """Which residue representation this layer uses.
+
+    `is_mext_r1` wins: a mext_r1 layer legitimately reports num_salient == 0
+    because every channel is salient and the residue lives in the doubled
+    token rows, not in a channel subset.
+    """
+    if is_mext_r1:
+        return RESIDUE_MEXT_R1
+    return RESIDUE_NONE if int(num_salient) == 0 else RESIDUE_K_EXT
+
+
+# M threshold for choosing the fold path on a K-extended checkpoint. This is a
+# PERFORMANCE crossover between two residue-preserving representations: below
+# it, base-K MExt fold; above it, the checkpoint's K-ext quant + GEMM. A
+# mext_r1 layer ignores the threshold as a correctness gate (it must apply its
+# residue at every M), though the threshold still separates its small-M fold
+# from the large-M K-loop/two-GEMM tuner.
+#
+# Defaults are arch-dependent: the crossover was measured at ~128 on the
+# sm100/sm103 CuTeDSL fold and ~64 elsewhere. Read through fold_max_m_for(),
+# never off the constants -- warmup and dispatch must agree or the server JITs
+# inside cudagraph capture for the sizes warmup missed.
+_FOLD_MAX_M_DEFAULT_SM10X = 128
+_FOLD_MAX_M_DEFAULT_OTHER = 64
+_FOLD_MAX_M_ENV = os.environ.get("SGLANG_RESIDUE_DECODE_MEXT_MAX_M")
+
+# PD-disaggregated decode servers: every forward is small-M anyway, but a
+# uniform captured kernel sequence (no M-threshold branch across the captured
+# graph set) is worth forcing. At-call cost is zero -- only the dispatch
+# expression changes.
+_FORCE_FOLD = os.environ.get("SGLANG_RESIDUE_FORCE_DECODE_MEXT", "0") == "1"
+
+# mext_r1 prefill routing above the fold band:
+#   auto    FlashInfer-tuned two_gemm-vs-k_loop dispatch (two_gemm on miss)
+#   k_loop  force the wrapped-K kernel where precompiled
+#   two_gemm  bypass the tuner entirely
+_MEXT_PREFILL_PATH = os.environ.get("SGLANG_RESIDUE_MEXT_PREFILL_PATH", "auto")
+
+
+def fold_max_m_for(arch: str | None) -> int:
+    """The M at or below which a fold-eligible non-mext_r1 layer folds.
+
+    ``arch`` is ``'sm100'`` or ``'sm103'`` when a fold kernel is available.
+    The environment override is a performance knob only.
+    """
+    if _FOLD_MAX_M_ENV is not None:
+        return int(_FOLD_MAX_M_ENV)
+    return _FOLD_MAX_M_DEFAULT_SM10X if arch is not None else _FOLD_MAX_M_DEFAULT_OTHER
+
+
+# ── arch probes (once per process) ──────────────────────────────────────────
+_SM10X_FOLD_ARCH: str | None = None
+_SM10X_FOLD_PROBED = False
+_SM10X_FOLD_FIRED = [False]
+
+
+def _sm10x_fold_arch() -> str | None:
+    """'sm100'/'sm103' if this GPU uses the sm10x CuTeDSL fold, else None."""
+    global _SM10X_FOLD_ARCH, _SM10X_FOLD_PROBED
+    if _SM10X_FOLD_PROBED:
+        return _SM10X_FOLD_ARCH
+    _SM10X_FOLD_PROBED = True
+    if os.environ.get("SGLANG_RESIDUE_DISABLE_SM10X_FOLD", "0") == "1":
+        _SM10X_FOLD_ARCH = None
+        return None
+    try:
+        major, minor = torch.cuda.get_device_capability()
+        from sglang.kernels.ops.gemm.residue_fold.cute_fold.tactics import (
+            kernel_arch_for_capability,
+        )
+
+        _SM10X_FOLD_ARCH = kernel_arch_for_capability(int(major), int(minor))
+    except Exception:
+        _SM10X_FOLD_ARCH = None
+    return _SM10X_FOLD_ARCH
+
+
+# ── helpers ─────────────────────────────────────────────────────────────────
+
+
+def _base_k_weight_view(weight: torch.Tensor, k_base: int) -> torch.Tensor:
+    """Base-K prefix of a (possibly ext-K) packed FP4 weight, as a VIEW.
+
+    For a pure mext_r1 layer k_base already spans the whole tensor and this
+    returns `weight` unchanged. For an extended_k layer the stored weight is
+    [N, k_ext/2] and the fold only needs the first k_base/2 packed columns;
+    the narrowed view keeps row stride k_ext/2, which the CuTeDSL folds
+    consume directly. No copy, so the ext weight is never duplicated.
+    """
+    k_base_packed = int(k_base) // 2
+    if k_base_packed == weight.shape[1]:
+        return weight
+    assert (
+        k_base_packed < weight.shape[1]
+    ), f"k_base {k_base} exceeds stored weight width {weight.shape[1] * 2}"
+    return weight[:, :k_base_packed]
+
+
+def _pad_activation_cols(x_fp4: torch.Tensor, padding_cols: int) -> torch.Tensor:
+    """Pad packed FP4 activations to match the weight's K-dim padding."""
+    if padding_cols > 0:
+        return torch.nn.functional.pad(x_fp4, (0, padding_cols)).contiguous()
+    return x_fp4
+
+
+def _slice_linear_output(
+    out: torch.Tensor, original_m: int, output_size: int
+) -> torch.Tensor:
+    """Remove fold/kernel padding without copying the common exact shape."""
+    target_n = int(output_size) if int(output_size) > 0 else out.shape[-1]
+    if out.shape[0] != int(original_m) or out.shape[-1] != target_n:
+        return out[: int(original_m), :target_n].contiguous()
+    return out
+
+
+def _fp4_gemm(
+    x_fp4: torch.Tensor,
+    x_sf: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    alpha: torch.Tensor,
+    out_dtype: torch.dtype,
+) -> torch.Tensor:
+    """Plain NVFP4 GEMM through SGLang's fp4 runner (flashinfer mm_fp4)."""
+    from sglang.srt.layers.quantization.modelopt_quant import fp4_gemm
+
+    return fp4_gemm(
+        x_fp4, weight.T, x_sf, weight_scale.T, alpha, out_dtype, weight.shape[0]
+    )
+
+
+def _plain_fp4_quantize(
+    x: torch.Tensor, input_global_scale_inv: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
+
+    if fp4_quantize is None:
+        raise RuntimeError("residue nvfp4 linear requires flashinfer's fp4_quantize")
+    return fp4_quantize(x, input_global_scale_inv)
+
+
+def _run_mext_r1_two_gemm(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_global_scale_inv: torch.Tensor,
+    weight_scale_base: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    """mext_r1 prefill: one backend GEMM at 2M rows + pair-sum epilogue.
+
+    out[i] = W . base_i + W . res_i, exactly the fold's math. The mext_r1
+    quant's row_pair SF is bytewise the cutlass 128x4 swizzle over the 2M
+    rows, so the doubled activation feeds the stock GEMM directly and
+    base/residue rows come back interleaved at even/odd indices.
+
+    Every op here has a static compile space: no CuTeDSL, nothing to JIT at
+    serving time, and cudagraph capture sees ordinary torch/GEMM calls.
+    """
+    x_fp4, x_sf = scaled_fp4_quant_mext_r1(
+        x, input_global_scale_inv, layout_mode=MEXT_R1_LAYOUT_ROW_PAIR
+    )
+    two_m, k = x_fp4.shape[0], x.shape[-1]
+    num_m_tiles = (two_m + 127) // 128
+    num_k_tiles = (k + 63) // 64
+    x_sf_v = x_sf.view(torch.float8_e4m3fn).view(num_m_tiles * 128, num_k_tiles * 4)
+    y = _fp4_gemm(x_fp4, x_sf_v, weight, weight_scale_base, alpha, output_dtype)
+    return y[0::2] + y[1::2]
+
+
+def _run_mext_fold_gemm_sm10x(
+    x_fp4_rowpair: torch.Tensor,
+    weight: torch.Tensor,
+    x_sf: torch.Tensor,
+    weight_scale_base: torch.Tensor,
+    alpha: torch.Tensor,
+    output_dtype: torch.dtype,
+) -> torch.Tensor:
+    """CuTeDSL SM100/SM103 row-pair fold GEMM."""
+    from sglang.kernels.ops.gemm.residue_fold import run_fold
+
+    if not _SM10X_FOLD_FIRED[0]:
+        _SM10X_FOLD_FIRED[0] = True
+        print(
+            f"[residue] SM10x MExt fold kernel FIRED: "
+            f"act={tuple(x_fp4_rowpair.shape)} weight={tuple(weight.shape)} "
+            f"arch={_sm10x_fold_arch()}",
+            flush=True,
+        )
+
+    major, minor = torch.cuda.get_device_capability()
+    return run_fold(
+        int(major),
+        int(minor),
+        weight,
+        x_fp4_rowpair,
+        weight_scale_base,
+        x_sf.view(torch.float8_e4m3fn),
+        alpha,
+        output_dtype,
+    )
+
+
+def _nvfp4_linear_fake(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_global_scale_inv: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_scale_base: torch.Tensor,
+    channel_mask: torch.Tensor,
+    alpha: torch.Tensor,
+    k_base: int,
+    num_salient: int,
+    weights_padding_cols: int,
+    output_size: int,
+    fold_eligible: bool,
+    is_mext_r1: bool,
+) -> torch.Tensor:
+    M = x.shape[0]
+    N = int(output_size) if int(output_size) > 0 else weight.shape[0]
+    return torch.empty(M, N, dtype=x.dtype, device=x.device)
+
+
+@register_custom_op(
+    op_name="residue_nvfp4_linear",
+    mutates_args=[],
+    fake_impl=_nvfp4_linear_fake,
+)
+def nvfp4_linear(
+    x: torch.Tensor,
+    weight: torch.Tensor,
+    input_global_scale_inv: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_scale_base: torch.Tensor,
+    channel_mask: torch.Tensor,
+    alpha: torch.Tensor,
+    k_base: int,
+    num_salient: int,
+    weights_padding_cols: int,
+    output_size: int,
+    fold_eligible: bool,
+    is_mext_r1: bool,
+) -> torch.Tensor:
+    """Single opaque op covering the residue NVFP4 dense-linear paths.
+
+    Dispatch rule (computed inside the opaque body, so each cudagraph capture
+    sees the real M of its capture size):
+
+        use_fold = fold_eligible AND (is_mext_r1 OR force_fold
+                                      OR M <= fold_max_m_for(arch))
+
+    Args:
+        x: [M, K_base] fp16/bf16 activation.
+        weight: [N, K_stored/2] packed FP4 weight (K_stored == K_base for
+            mext_r1 / plain layers; K_base + num_salient for extended_k).
+        input_global_scale_inv: scalar reciprocal of the input global scale.
+        weight_scale: full-K swizzled block scale (plain / K-ext GEMM).
+        weight_scale_base: base-K swizzled block scale (fold path; the caller
+            passes weight_scale itself when the layer has no separate one).
+        channel_mask: salient-channel bitmask (k_ext quant only; 1-byte
+            placeholder otherwise).
+        alpha: per-tensor output scale.
+        k_base: effective K for the fold path GEMM.
+        num_salient: salient-channel count (k_ext only; 0 otherwise).
+        weights_padding_cols: cutlass weight K-padding in packed bytes; the
+            plain/K-ext activation is padded to match.
+        output_size: output feature dim; the plain/K-ext output is sliced back
+            to it when the weight was N-padded.
+        fold_eligible: per-layer constant -- the layer has the fold layout
+            prepared (base-K scale + valid k_base).
+        is_mext_r1: per-layer constant -- ratio-1.0 M-extension layer. Must
+            never fall through to the plain path: it was charged for a
+            residue, so it applies one at EVERY M.
+
+    Returns:
+        [M, N] output in x.dtype. Caller adds bias and reshapes outside.
+    """
+    original_m = x.shape[0]
+    output_n = weight.shape[0]
+
+    if original_m == 0:
+        empty_n = int(output_size) if int(output_size) > 0 else output_n
+        return x.new_empty((0, empty_n))
+
+    output_dtype = x.dtype
+    fold_max_m = fold_max_m_for(_sm10x_fold_arch())
+
+    use_fold = fold_eligible and (is_mext_r1 or _FORCE_FOLD or original_m <= fold_max_m)
+
+    if use_fold:
+        # mext_r1 above the fold band: FlashInfer-tuned two_gemm-vs-k_loop
+        # selection per (shape, m-bucket). runners[0]=two_gemm is the
+        # designated fallback on any cache miss, and the kloop runner only
+        # reports precompiled tiles outside the tuning window -- so this can
+        # never JIT while serving. Any tuner-layer error degrades to plain
+        # two_gemm rather than breaking the op.
+        if is_mext_r1 and original_m > fold_max_m:
+            w_view = _base_k_weight_view(weight, k_base)
+            if _MEXT_PREFILL_PATH in ("auto", "k_loop"):
+                try:
+                    from sglang.kernels.ops.gemm.residue_fold.tuners import (
+                        tuned_mext_prefill,
+                    )
+
+                    return tuned_mext_prefill(
+                        x,
+                        w_view,
+                        input_global_scale_inv,
+                        weight_scale_base,
+                        alpha,
+                        output_dtype,
+                        force_kloop=(_MEXT_PREFILL_PATH == "k_loop"),
+                    )
+                except Exception:  # noqa: BLE001
+                    pass
+            return _run_mext_r1_two_gemm(
+                x,
+                w_view,
+                input_global_scale_inv,
+                weight_scale_base,
+                alpha,
+                output_dtype,
+            )
+
+        if _sm10x_fold_arch() is not None:
+            try:
+                from sglang.kernels.ops.gemm.residue_fold.tuners import (
+                    sm10x_tuner_enabled,
+                    tuned_sm10x_fold,
+                )
+
+                if sm10x_tuner_enabled():
+                    out = tuned_sm10x_fold(
+                        x,
+                        _base_k_weight_view(weight, k_base),
+                        input_global_scale_inv,
+                        weight_scale_base,
+                        alpha,
+                        output_dtype,
+                    )
+                    return _slice_linear_output(out, int(original_m), int(output_size))
+            except ImportError:
+                pass
+
+            x_fp4, x_sf = scaled_fp4_quant_mext_r1(
+                x, input_global_scale_inv, layout_mode=MEXT_R1_LAYOUT_ROW_PAIR
+            )
+            out = _run_mext_fold_gemm_sm10x(
+                x_fp4,
+                _base_k_weight_view(weight, k_base),
+                x_sf,
+                weight_scale_base,
+                alpha,
+                output_dtype,
+            )
+            return _slice_linear_output(out, int(original_m), int(output_size))
+
+        major, minor = torch.cuda.get_device_capability()
+        raise RuntimeError(
+            "Residue NVFP4 fold supports SM100 and SM103 only; "
+            f"got SM{major}{minor}."
+        )
+
+    kind = residue_kind_of(num_salient, is_mext_r1)
+
+    if kind == RESIDUE_MEXT_R1:
+        # Unreachable today: use_fold is forced true for mext_r1, so we
+        # returned above. Assert rather than trust it -- fold_eligible can be
+        # False on an unsupported arch, and falling through to the plain path
+        # would compute NO residue: not a degraded answer, the wrong one.
+        raise RuntimeError(
+            "mext_r1 layer reached the non-fold path (fold_eligible="
+            f"{bool(fold_eligible)}, M={int(original_m)}). The residue cannot "
+            "be applied without the fold kernel and there is no K-extended "
+            "weight to fall back to."
+        )
+
+    if kind == RESIDUE_NONE:
+        x_fp4, x_sf = _plain_fp4_quantize(x, input_global_scale_inv)
+        x_fp4 = _pad_activation_cols(x_fp4, int(weights_padding_cols))
+        out = _fp4_gemm(x_fp4, x_sf, weight, weight_scale, alpha, output_dtype)
+        if out.shape[-1] != int(output_size):
+            out = out[..., : int(output_size)].contiguous()
+        return out
+
+    # ── K-extension large-M residue path ────────────────────────────────
+    # n_ext = K_base + num_salient (per residue contract); M stays as M. All
+    # shape math is derived from x.shape and the int num_salient, never from
+    # a kernel output's shape.
+    from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+        scaled_fp4_quant_with_mask,
+    )
+
+    K_base = x.shape[-1]
+    n_ext = K_base + int(num_salient)
+    num_m_tiles = (original_m + 127) // 128
+    num_k_tiles = (n_ext + 63) // 64
+
+    x_fp4, x_sf_block = scaled_fp4_quant_with_mask(
+        x, input_global_scale_inv, channel_mask, int(num_salient)
+    )
+    x_sf_block = x_sf_block.view(torch.float8_e4m3fn).view(
+        num_m_tiles * 128, num_k_tiles * 4
+    )
+    x_fp4 = _pad_activation_cols(x_fp4, int(weights_padding_cols))
+    out = _fp4_gemm(x_fp4, x_sf_block, weight, weight_scale, alpha, output_dtype)
+    if out.shape[-1] != int(output_size):
+        out = out[..., : int(output_size)].contiguous()
+    return out

--- a/python/sglang/kernels/ops/quantization/__init__.py
+++ b/python/sglang/kernels/ops/quantization/__init__.py
@@ -17,6 +17,9 @@ if TYPE_CHECKING:
     import torch
 
 _CUDA = frozenset({CapabilityRequirement.CUDA})
+_RESIDUE_BLACKWELL = frozenset(
+    CapabilityRequirement.cuda(min_sm=sm, max_sm=sm) for sm in ((10, 0), (10, 3))
+)
 
 register_kernel(
     KernelSpec(
@@ -205,5 +208,45 @@ register_kernel(
         ),
         capabilities=frozenset({CapabilityRequirement.cuda(min_sm=(10, 0))}),
         description="Fused NVFP4 GEMM + SwiGLU + NVFP4 quant (CuTe DSL, SM100).",
+    )
+)
+
+register_kernel(
+    KernelSpec(
+        op="quantization.residue_nvfp4_scaled_fp4_quant_mext_r1",
+        backend=KernelBackend.JIT,
+        target=(
+            "sglang.kernels.ops.quantization.residue_nvfp4_quant"
+            ":scaled_fp4_quant_mext_r1"
+        ),
+        capabilities=_RESIDUE_BLACKWELL,
+        format_signature=FormatSignature(
+            supported_dtypes=("float16", "bfloat16"),
+            description=(
+                "ratio-1.0 M-extension NVFP4 activation quant: row-doubled "
+                "packed FP4 data + swizzled fp8-e4m3 scales"
+            ),
+        ),
+        description="Residue NVFP4 mext_r1 activation quantization (JIT).",
+    )
+)
+
+register_kernel(
+    KernelSpec(
+        op="quantization.residue_nvfp4_scaled_fp4_quant_with_mask",
+        backend=KernelBackend.JIT,
+        target=(
+            "sglang.kernels.ops.quantization.residue_nvfp4_quant"
+            ":scaled_fp4_quant_with_mask"
+        ),
+        capabilities=_RESIDUE_BLACKWELL,
+        format_signature=FormatSignature(
+            supported_dtypes=("float16", "bfloat16"),
+            description=(
+                "k_ext NVFP4 activation quant (ratios 1/8, 2/8, 4/8): "
+                "[base | residue] extended packed FP4 rows + swizzled scales"
+            ),
+        ),
+        description="Residue NVFP4 k_ext activation quantization (JIT).",
     )
 )

--- a/python/sglang/kernels/ops/quantization/residue_nvfp4_quant.py
+++ b/python/sglang/kernels/ops/quantization/residue_nvfp4_quant.py
@@ -1,0 +1,388 @@
+"""Residue NVFP4 activation quantization (mext_r1) public wrappers.
+
+mext_r1 IS residue ratio 1.0 -- the storage-efficient implementation of it,
+not a mode competing with the ratio options. Every input channel is salient,
+so instead of duplicating the weight:
+
+    K-ext at ratio 1.0:  [x_q | r_q] @ [W | W]^T = x_q@W^T + r_q@W^T
+    mext_r1:             rows (x_q, r_q) @ W^T, summed in the epilogue
+                                                = (x_q + r_q)@W^T
+
+the weight is stored once at K and the token rows are doubled. Consequently
+this entrypoint takes no salient indices: there is no per-channel selection
+to make on this path.
+
+Kernel output:
+  - data:  [2M, K/2] packed uint8 (two FP4 nibbles per byte), or [M, K] for
+    the concat_k layout ([M, 2K] logical geometry)
+  - scale: fp8-e4m3 bytes in the swizzled 128x4 tiled layout over the output
+    geometry
+
+``input_scale`` is a single global scale reciprocal shared by the base and
+residue halves.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Union
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils.custom_op import register_custom_op
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+# elts mode: auto resolves per-arch in the C++ launcher -- datacenter
+# Blackwell (cc 10.x) uses the pack16 path (per-thread SF vector + 256-bit
+# loads), SM120 keeps pack8.
+MEXT_R1_ELTS_AUTO = 0
+MEXT_R1_ELTS_8 = 8
+MEXT_R1_ELTS_16 = 16
+
+# Activation layouts emitted by the quant kernel.
+MEXT_R1_LAYOUT_CONCAT = 0  # [x rows... | r rows...]
+MEXT_R1_LAYOUT_ROW_PAIR = 1  # [x0, r0, x1, r1, ...]
+# K-concat: [M, 2K] geometry -- base in element cols [0, K), residue in
+# [K, 2K), data AND SF in the canonical order of the (M, 2K) grid. A
+# downstream GEMM cannot tell it from a stock quantization of a 2K-wide input.
+MEXT_R1_LAYOUT_CONCAT_K = 3
+
+_LAYOUT_NAMES = {
+    "concat": MEXT_R1_LAYOUT_CONCAT,
+    "row_pair": MEXT_R1_LAYOUT_ROW_PAIR,
+    "concat_k": MEXT_R1_LAYOUT_CONCAT_K,
+}
+
+
+def _resolve_elts_mode(elts_mode: Union[int, str, None]) -> int:
+    if elts_mode is None:
+        # Perf knob only: forces a pack; numerics are identical either way.
+        elts_mode = os.environ.get("SGLANG_RESIDUE_NVFP4_ELTS_PER_THREAD", "auto")
+    if isinstance(elts_mode, str):
+        normalized = elts_mode.strip().lower()
+        if normalized in ("", "auto", "default"):
+            return MEXT_R1_ELTS_AUTO
+        if normalized == "8":
+            return MEXT_R1_ELTS_8
+        if normalized == "16":
+            return MEXT_R1_ELTS_16
+        raise ValueError(
+            f"Unsupported mext_r1 elts_mode {elts_mode!r}. Expected: auto, 8, 16."
+        )
+    if elts_mode in (MEXT_R1_ELTS_AUTO, MEXT_R1_ELTS_8, MEXT_R1_ELTS_16):
+        return int(elts_mode)
+    raise ValueError(
+        f"Unsupported mext_r1 elts_mode {elts_mode!r}. Expected: auto (0), 8, 16."
+    )
+
+
+def _resolve_layout_mode(layout_mode: Union[int, str]) -> int:
+    if isinstance(layout_mode, str):
+        normalized = layout_mode.strip().lower().replace("-", "_")
+        if normalized in _LAYOUT_NAMES:
+            return _LAYOUT_NAMES[normalized]
+        raise ValueError(
+            f"Unsupported mext_r1 layout_mode {layout_mode!r}. "
+            f"Expected one of: {', '.join(_LAYOUT_NAMES)}."
+        )
+    if layout_mode in _LAYOUT_NAMES.values():
+        return int(layout_mode)
+    raise ValueError(
+        f"Unsupported mext_r1 layout_mode {layout_mode!r}. "
+        f"Expected one of: {', '.join(_LAYOUT_NAMES)} (0-3)."
+    )
+
+
+@cache_once
+def _jit_scaled_fp4_quant_mext_r1_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "residue_nvfp4_scaled_fp4_quant_mext_r1",
+        *args,
+        cuda_files=["residue_nvfp4/residue_nvfp4_quant.cuh"],
+        cuda_wrappers=[
+            ("scaled_fp4_quant_mext_r1", f"scaled_fp4_quant_mext_r1<{args}>")
+        ],
+    )
+
+
+def _mext_r1_fake(
+    input: torch.Tensor,
+    input_scale: torch.Tensor,
+    elts_mode: int,
+    layout_mode: int,
+    output_m: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, k = input.shape
+    del m
+    if layout_mode == MEXT_R1_LAYOUT_CONCAT_K:
+        data = input.new_empty((output_m, k), dtype=torch.uint8)
+        num_m_tiles = (output_m + 127) // 128
+        num_k_tiles = (2 * k + 63) // 64
+    else:
+        data = input.new_empty((2 * output_m, k // 2), dtype=torch.uint8)
+        num_m_tiles = (2 * output_m + 127) // 128
+        num_k_tiles = (k + 63) // 64
+    scale = input.new_empty(num_m_tiles * num_k_tiles * 512, dtype=torch.uint8)
+    return data, scale
+
+
+@register_custom_op(
+    op_name="residue_nvfp4_scaled_fp4_quant_mext_r1",
+    mutates_args=[],
+    fake_impl=_mext_r1_fake,
+)
+def _scaled_fp4_quant_mext_r1_op(
+    input: torch.Tensor,
+    input_scale: torch.Tensor,
+    elts_mode: int,
+    layout_mode: int,
+    output_m: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, k = input.shape
+
+    output = torch.empty(
+        (2 * output_m) * k // 2, dtype=torch.uint8, device=input.device
+    )
+    if layout_mode == MEXT_R1_LAYOUT_CONCAT_K:
+        # (M, 2K) grid: same data bytes, but the SF atom tiling follows the
+        # output geometry, not the row-doubled one.
+        num_m_tiles = (output_m + 127) // 128
+        num_k_tiles = (2 * k + 63) // 64
+    else:
+        num_m_tiles = (2 * output_m + 127) // 128
+        num_k_tiles = (k + 63) // 64
+    output_scale = torch.empty(
+        num_m_tiles * num_k_tiles * 512, dtype=torch.uint8, device=input.device
+    )
+
+    module = _jit_scaled_fp4_quant_mext_r1_module(input.dtype)
+    # output_m is intentionally NOT passed to the kernel: the C++ op derives
+    # it from input.shape so the launch can never desync from the buffers
+    # under torch.compile shape specialization.
+    module.scaled_fp4_quant_mext_r1(
+        input.contiguous(),
+        output,
+        output_scale,
+        input_scale,
+        elts_mode,
+        layout_mode,
+    )
+
+    if layout_mode == MEXT_R1_LAYOUT_CONCAT_K:
+        # [M, 2K] packed: K bytes per row (2 FP4 elements per byte).
+        return output.view(output_m, k), output_scale
+    return output.view(2 * output_m, k // 2), output_scale
+
+
+def scaled_fp4_quant_mext_r1(
+    input: torch.Tensor,
+    input_scale: torch.Tensor,
+    *,
+    elts_mode: Union[int, str, None] = None,
+    layout_mode: Union[int, str] = "concat",
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Ratio-1.0 M-extension FP4 activation quantization.
+
+    Args:
+        input: [M, K] fp16/bf16 CUDA tensor, K % 16 == 0.
+        input_scale: scalar or 1-D float32 CUDA tensor with 1 element (global
+            scale reciprocal).
+        elts_mode: "auto" (default), 8, or 16 elements per thread.
+        layout_mode: "concat", "row_pair", or "concat_k".
+
+    Returns:
+        (data, scale): packed FP4 data ([2*output_M, K/2] uint8, or
+        [output_M, K] for concat_k) and the swizzled fp8-e4m3 scale bytes.
+    """
+    resolved_elts = _resolve_elts_mode(elts_mode)
+    resolved_layout = _resolve_layout_mode(layout_mode)
+
+    m, k = input.shape
+    if k % 16 != 0:
+        raise ValueError(f"scaled_fp4_quant_mext_r1 requires K % 16 == 0, got {k}")
+
+    if input_scale.ndim == 0:
+        # ModelOpt stores per-tensor activation scales as scalar parameters,
+        # while the JIT FFI schema deliberately uses a 1-D tensor.
+        input_scale = input_scale.reshape(1)
+    elif input_scale.ndim != 1:
+        raise ValueError(
+            "scaled_fp4_quant_mext_r1 requires input_scale to be scalar or "
+            f"1-D, got shape {tuple(input_scale.shape)}"
+        )
+    if input_scale.numel() != 1:
+        raise ValueError(
+            "scaled_fp4_quant_mext_r1 requires input_scale with exactly 1 "
+            f"element, got {input_scale.numel()}"
+        )
+
+    return _scaled_fp4_quant_mext_r1_op(
+        input, input_scale, resolved_elts, resolved_layout, m
+    )
+
+
+# ── k_ext (selective residue, ratios 1/8, 2/8, 4/8) ────────────────────────
+
+# ratio -> salient channels per 8-channel block ("residue_per_8").
+# Ratio 1.0 is deliberately absent: K-extension at ratio 1.0 would store the
+# weight twice; full-rank residue is served by mext_r1 instead.
+SUPPORTED_K_EXT_RATIOS = {
+    0.125: 1,
+    0.25: 2,
+    0.5: 4,
+}
+
+
+def _resolve_residue_per_8(num_salient: int, k: int) -> int:
+    ratio = num_salient / k
+    for supported_ratio, residue_per_8 in SUPPORTED_K_EXT_RATIOS.items():
+        if abs(ratio - supported_ratio) < 1e-3:
+            return residue_per_8
+    supported = ", ".join(f"{r:g}" for r in sorted(SUPPORTED_K_EXT_RATIOS))
+    raise ValueError(
+        f"Unsupported salient ratio {ratio:.4f} ({num_salient}/{k}). "
+        f"Supported k_ext ratios: {supported}; ratio 1.0 is mext_r1."
+    )
+
+
+def indices_to_channel_masks(
+    salient_indices: torch.Tensor, num_channels: int
+) -> torch.Tensor:
+    """Per-8-channel salient bitmask consumed by the k_ext quant kernels.
+
+    Byte i's bit b marks channel 8*i+b salient. The exporter selects the same
+    count in every 8-channel block, which the kernels assume.
+    """
+    assert num_channels % 8 == 0, "num_channels must be a multiple of 8"
+    num_masks = num_channels // 8
+    channel_masks = torch.zeros(
+        num_masks, dtype=torch.uint8, device=salient_indices.device
+    )
+    mask_idx = salient_indices // 8
+    bit_pos = salient_indices % 8
+    bit_masks = (1 << bit_pos).to(torch.uint8)
+    channel_masks.index_add_(0, mask_idx, bit_masks)
+    return channel_masks
+
+
+@cache_once
+def _jit_scaled_fp4_quant_with_mask_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "residue_nvfp4_scaled_fp4_quant_with_mask",
+        *args,
+        cuda_files=["residue_nvfp4/residue_nvfp4_kext_quant.cuh"],
+        cuda_wrappers=[
+            ("scaled_fp4_quant_with_mask", f"scaled_fp4_quant_with_mask<{args}>")
+        ],
+    )
+
+
+def _kext_fake(
+    input: torch.Tensor,
+    input_scale: torch.Tensor,
+    channel_masks: torch.Tensor,
+    n_ext: int,
+    residue_per_8: int,
+    elts_mode: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m = input.shape[0]
+    data = input.new_empty((m, n_ext // 2), dtype=torch.uint8)
+    num_m_tiles = (m + 127) // 128
+    num_k_tiles = (n_ext + 63) // 64
+    scale = input.new_empty(num_m_tiles * num_k_tiles * 512, dtype=torch.uint8)
+    return data, scale
+
+
+@register_custom_op(
+    op_name="residue_nvfp4_scaled_fp4_quant_with_mask",
+    mutates_args=[],
+    fake_impl=_kext_fake,
+)
+def _scaled_fp4_quant_with_mask_op(
+    input: torch.Tensor,
+    input_scale: torch.Tensor,
+    channel_masks: torch.Tensor,
+    n_ext: int,
+    residue_per_8: int,
+    elts_mode: int,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    m, k = input.shape
+    output = torch.empty(m * n_ext // 2, dtype=torch.uint8, device=input.device)
+    num_m_tiles = (m + 127) // 128
+    num_k_tiles = (n_ext + 63) // 64
+    output_scale = torch.empty(
+        num_m_tiles * num_k_tiles * 512, dtype=torch.uint8, device=input.device
+    )
+
+    module = _jit_scaled_fp4_quant_with_mask_module(input.dtype)
+    module.scaled_fp4_quant_with_mask(
+        input.contiguous(),
+        output,
+        output_scale,
+        input_scale,
+        channel_masks,
+        n_ext,
+        residue_per_8,
+        elts_mode,
+    )
+    return output.view(m, n_ext // 2), output_scale
+
+
+def scaled_fp4_quant_with_mask(
+    input: torch.Tensor,
+    input_scale: torch.Tensor,
+    channel_masks: torch.Tensor,
+    num_salient: int,
+    *,
+    elts_mode: Union[int, str, None] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """k_ext FP4 activation quantization with precomputed channel masks.
+
+    Quantizes the full row to NVFP4 and appends the quantized dequantization
+    residues of the salient channels, producing the extended activation the
+    K-extended weight consumes.
+
+    Args:
+        input: [M, K] fp16/bf16 CUDA tensor, K % 16 == 0.
+        input_scale: scalar or 1-D float32 CUDA tensor with 1 element (global
+            scale reciprocal).
+        channel_masks: uint8 [K/8] bitmask (see indices_to_channel_masks).
+        num_salient: salient channel count; num_salient/K must be a supported
+            ratio (1/8, 2/8, 4/8).
+        elts_mode: "auto" (default; B200-measured pack16 policy on cc 10.x),
+            8, or 16.
+
+    Returns:
+        (data, scale): [M, (K+num_salient)/2] packed uint8 rows laid out as
+        [base | residue], and the swizzled fp8-e4m3 scale bytes over
+        (M, K+num_salient).
+    """
+    m, k = input.shape
+    del m
+    if input_scale.ndim == 0:
+        # ModelOpt stores per-tensor activation scales as scalar parameters,
+        # while the JIT FFI schema uses a 1-D tensor. Keep this normalization
+        # aligned with scaled_fp4_quant_mext_r1 above.
+        input_scale = input_scale.reshape(1)
+    elif input_scale.ndim != 1:
+        raise ValueError(
+            "scaled_fp4_quant_with_mask requires input_scale to be scalar or "
+            f"1-D, got shape {tuple(input_scale.shape)}"
+        )
+    if input_scale.numel() != 1:
+        raise ValueError(
+            "scaled_fp4_quant_with_mask requires input_scale with 1 element, "
+            f"got {input_scale.numel()}"
+        )
+
+    n_ext = k + int(num_salient)
+    residue_per_8 = _resolve_residue_per_8(int(num_salient), k)
+    resolved_elts = _resolve_elts_mode(elts_mode)
+    return _scaled_fp4_quant_with_mask_op(
+        input, input_scale, channel_masks, n_ext, residue_per_8, resolved_elts
+    )

--- a/python/sglang/srt/layers/quantization/__init__.py
+++ b/python/sglang/srt/layers/quantization/__init__.py
@@ -56,6 +56,9 @@ from sglang.srt.layers.quantization.nvfp4_online import NvFp4OnlineConfig
 from sglang.srt.layers.quantization.petit import PetitNvFp4Config
 from sglang.srt.layers.quantization.quark.quark import QuarkConfig
 from sglang.srt.layers.quantization.quark_int4fp8_moe import QuarkInt4Fp8Config
+from sglang.srt.layers.quantization.residue_nvfp4.config import (
+    ModelOptFp4ResidueConfig,
+)
 from sglang.srt.layers.quantization.w4afp8 import W4AFp8Config
 from sglang.srt.layers.quantization.w8a8_fp8 import W8A8Fp8Config
 from sglang.srt.layers.quantization.w8a8_int8 import W8A8Int8Config
@@ -83,6 +86,7 @@ BASE_QUANTIZATION_METHODS: Dict[str, Type[QuantizationConfig]] = {
     "modelopt": ModelOptFp8Config,  # Auto-detect, defaults to FP8
     "modelopt_fp8": ModelOptFp8Config,
     "modelopt_fp4": ModelOptFp4Config,
+    "modelopt_fp4_residue": ModelOptFp4ResidueConfig,
     "nvfp4_online": NvFp4OnlineConfig,
     "modelopt_mixed": ModelOptMixedPrecisionConfig,
     "w8a8_int8": W8A8Int8Config,

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -235,6 +235,7 @@ class Fp8Config(QuantizationConfig):
         use_mxfp8: bool = False,
         is_fp4_experts: bool = False,
         kv_cache_quant_algo: Optional[str] = None,
+        force_triton_moe_runner: bool = False,
     ) -> None:
         super().__init__()
         # DSV4 mxfp4-packed (True) vs converted FP8 (False); injected by
@@ -259,6 +260,10 @@ class Fp8Config(QuantizationConfig):
         self.packed_modules_mapping = packed_modules_mapping or {}
         self.use_mxfp8 = use_mxfp8
         self.kv_cache_quant_algo = kv_cache_quant_algo
+        # Used by an independently serialized FP8 MTP child config when the
+        # target model selects a MoE backend that cannot consume native FP8
+        # experts. Default-off keeps every stock FP8 config unchanged.
+        self.force_triton_moe_runner = force_triton_moe_runner
         if weight_block_size is not None:
             if not is_checkpoint_fp8_serialized:
                 raise ValueError(
@@ -2345,6 +2350,19 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 moe_runner_backend = MoeRunnerBackend.AITER
             else:
                 moe_runner_backend = MoeRunnerBackend.TRITON
+
+        # A ModelOpt mixed checkpoint can explicitly mark its separately
+        # serialized FP8 MTP config for this fallback. Keep stock FP8 behavior
+        # unchanged and retain FlashInfer CUTLASS for the target's NVFP4 MoE.
+        if moe_runner_backend.is_flashinfer_cutlass() and getattr(
+            self.quant_config, "force_triton_moe_runner", False
+        ):
+            print_warning_once(
+                "The flashinfer_cutlass MoE backend does not support native "
+                "FP8 experts. Falling back to the Triton MoE runner for this "
+                "FP8 layer."
+            )
+            moe_runner_backend = MoeRunnerBackend.TRITON
 
         if (
             moe_runner_backend.is_deep_gemm()

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -780,6 +780,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         nvfp4_config: ModelOptFp4Config,
         nvfp4a16_config: ModelOptFp4Config,
         mxfp8_config: Fp8Config,
+        mtp_quant_config: Optional[QuantizationConfig] = None,
     ) -> None:
         super().__init__(kv_cache_quant_algo, exclude_modules, packed_modules_mapping)
         self.quantized_layers = quantized_layers
@@ -788,6 +789,11 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         self.mxfp8_config = mxfp8_config
         self.nvfp4_config = nvfp4_config
         self.nvfp4a16_config = nvfp4a16_config
+        # Qwen checkpoints normally keep the embedded MTP module unquantized,
+        # even when the target uses ModelOpt mixed precision.  A checkpoint
+        # may opt into a separately serialized MTP format (currently block
+        # FP8) without changing the target model's mixed/residue dispatch.
+        self.mtp_quant_config = mtp_quant_config
 
     @classmethod
     def override_quantization_method(cls, hf_quant_config, user_quant):
@@ -814,6 +820,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         kv_cache_quant_algo = None
         exclude_modules = None
         quantized_layers = {}
+        mtp_quantization_config = config.get("mtp_quantization_config")
 
         quant_algo = config.get("quant_algo")
         if quant_algo is not None:
@@ -841,6 +848,9 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             kv_cache_quant_algo = quantization_section.get("kv_cache_quant_algo")
             exclude_modules = quantization_section.get("exclude_modules")
             quantized_layers = quantization_section.get("quantized_layers", {})
+            mtp_quantization_config = quantization_section.get(
+                "mtp_quantization_config", mtp_quantization_config
+            )
 
         if quant_algo != "MIXED_PRECISION":
             raise ValueError(
@@ -882,6 +892,24 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             packed_modules_mapping=packed_modules_mapping,
             use_mxfp8=True,
         )
+        mtp_quant_config = None
+        if mtp_quantization_config is not None:
+            if not isinstance(mtp_quantization_config, dict):
+                raise ValueError("mtp_quantization_config must be a dictionary.")
+            mtp_quant_method = str(
+                mtp_quantization_config.get("quant_method", "")
+            ).lower()
+            if mtp_quant_method != "fp8":
+                raise ValueError(
+                    "modelopt_mixed currently supports only an FP8 "
+                    "mtp_quantization_config."
+                )
+            mtp_quant_config = Fp8Config.from_config(mtp_quantization_config)
+            # The target's NVFP4 experts use FlashInfer CUTLASS, but this
+            # separately serialized MTP module has native FP8 experts. Mark
+            # only this child config for the supported Triton fallback; stock
+            # FP8 configs and the target model keep their existing routing.
+            mtp_quant_config.force_triton_moe_runner = True
         nvfp4_config = ModelOptFp4Config(
             is_checkpoint_nvfp4_serialized=True,
             kv_cache_quant_algo=kv_cache_quant_algo,
@@ -908,6 +936,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             mxfp8_config=mxfp8_config,
             nvfp4_config=nvfp4_config,
             nvfp4a16_config=nvfp4a16_config,
+            mtp_quant_config=mtp_quant_config,
         )
 
     def apply_weight_name_mapper(self, hf_to_sglang_mapper: WeightsMapper):

--- a/python/sglang/srt/layers/quantization/residue_nvfp4/__init__.py
+++ b/python/sglang/srt/layers/quantization/residue_nvfp4/__init__.py
@@ -1,0 +1,47 @@
+"""Metadata-driven dense NVFP4 residue support."""
+
+from sglang.srt.layers.quantization.residue_nvfp4.metadata import (
+    METADATA_FILENAME,
+    ResidueLayerSpec,
+    ResidueMetadataError,
+    ResidueMode,
+    ResidueModelSpec,
+    find_residue_metadata,
+    load_residue_model_spec,
+    parse_residue_metadata,
+)
+
+__all__ = [
+    "METADATA_FILENAME",
+    "ModelOptFp4ResidueConfig",
+    "ModelOptFp4ResidueLinearMethod",
+    "ModelOptMixedPrecisionResidueConfig",
+    "ResidueLayerSpec",
+    "ResidueMetadataError",
+    "ResidueMode",
+    "ResidueModelSpec",
+    "find_residue_metadata",
+    "load_residue_model_spec",
+    "maybe_wrap_residue_fp4_config",
+    "parse_residue_metadata",
+]
+
+
+def __getattr__(name):
+    # config/linear_method pull in the full quantization stack; load lazily
+    # so the metadata contract stays importable on its own.
+    if name in (
+        "ModelOptFp4ResidueConfig",
+        "ModelOptMixedPrecisionResidueConfig",
+        "maybe_wrap_residue_fp4_config",
+    ):
+        from sglang.srt.layers.quantization.residue_nvfp4 import config
+
+        return getattr(config, name)
+    if name == "ModelOptFp4ResidueLinearMethod":
+        from sglang.srt.layers.quantization.residue_nvfp4.linear_method import (
+            ModelOptFp4ResidueLinearMethod,
+        )
+
+        return ModelOptFp4ResidueLinearMethod
+    raise AttributeError(name)

--- a/python/sglang/srt/layers/quantization/residue_nvfp4/config.py
+++ b/python/sglang/srt/layers/quantization/residue_nvfp4/config.py
@@ -1,0 +1,204 @@
+"""Residue-aware ModelOpt NVFP4 quantization config.
+
+A residue checkpoint IS a stock ModelOpt NVFP4 checkpoint plus
+residue_kernel_metadata.json. The wrappers in this module cover both a plain
+ModelOptFp4Config and the NVFP4 dense layers inside a
+ModelOptMixedPrecisionConfig. They differ from the stock configs in exactly
+one way: dense NVFP4 linear layers named by the metadata get the residue
+linear method. Everything else -- exclusions, KV cache, MoE, other precision
+families, and layers without residue metadata -- behaves like the parent.
+
+Selection is checkpoint-driven: model loading wraps a supported ModelOpt
+config when the metadata file is present and valid (see
+maybe_wrap_residue_fp4_config), and `--quantization modelopt_fp4_residue`
+selects it explicitly. A present-but-invalid metadata file fails the load; it
+never silently degrades to plain NVFP4.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import torch
+
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptFp4Config,
+    ModelOptFp4LinearMethod,
+    ModelOptMixedPrecisionConfig,
+)
+from sglang.srt.layers.quantization.residue_nvfp4.metadata import (
+    ResidueMetadataError,
+    ResidueModelSpec,
+    load_residue_model_spec,
+)
+
+
+class ModelOptFp4ResidueConfig(ModelOptFp4Config):
+    """ModelOptFp4Config + a validated per-layer residue spec."""
+
+    def __init__(self, *args, residue_spec: ResidueModelSpec, **kwargs):
+        super().__init__(*args, **kwargs)
+        if not self.is_checkpoint_nvfp4_serialized:
+            raise ResidueMetadataError(
+                "residue metadata requires a serialized NVFP4 checkpoint"
+            )
+        if self.is_awq:
+            raise ResidueMetadataError(
+                "residue metadata is not supported for NVFP4_AWQ checkpoints"
+            )
+        self.residue_spec = residue_spec
+
+    @classmethod
+    def get_name(cls) -> str:
+        return "modelopt_fp4_residue"
+
+    @classmethod
+    def get_min_capability(cls) -> int:
+        # The residue kernels support datacenter Blackwell (SM100/SM103).
+        return 100
+
+    @classmethod
+    def from_config(cls, config) -> ModelOptFp4ResidueConfig:
+        # The metadata file lives next to the weights, not inside the HF
+        # quantization config, so from_config alone cannot build this class.
+        # Model loading attaches the spec via from_modelopt_config.
+        raise ResidueMetadataError(
+            "modelopt_fp4_residue cannot be built from the HF quantization "
+            "config alone; it is selected by the residue_kernel_metadata.json "
+            "next to the checkpoint (model loading wraps the modelopt_fp4 "
+            "config automatically)."
+        )
+
+    @classmethod
+    def from_modelopt_config(
+        cls, base: ModelOptFp4Config, residue_spec: ResidueModelSpec
+    ) -> ModelOptFp4ResidueConfig:
+        """Wrap an already-parsed stock config with a validated residue spec."""
+        self = cls.__new__(cls)
+        self.__dict__.update(base.__dict__)
+        if not base.is_checkpoint_nvfp4_serialized:
+            raise ResidueMetadataError(
+                "residue metadata requires a serialized NVFP4 checkpoint"
+            )
+        if base.is_awq:
+            raise ResidueMetadataError(
+                "residue metadata is not supported for NVFP4_AWQ checkpoints"
+            )
+        self.residue_spec = residue_spec
+        return self
+
+    def get_quant_method(self, layer: torch.nn.Module, prefix: str):
+        from sglang.srt.layers.linear import LinearBase
+        from sglang.srt.layers.quantization.residue_nvfp4.linear_method import (
+            ModelOptFp4ResidueLinearMethod,
+        )
+        from sglang.srt.layers.quantization.utils import is_layer_skipped
+
+        if isinstance(layer, LinearBase):
+            if not (
+                is_layer_skipped(
+                    prefix, self.exclude_modules, self.packed_modules_mapping
+                )
+                or self.is_layer_excluded(prefix)
+            ):
+                # The method resolves the layer's residue spec by prefix; a
+                # layer without one behaves exactly like the parent method.
+                return ModelOptFp4ResidueLinearMethod(self, prefix)
+        # Excluded linears, ParallelLMHead, attention KV cache, MoE: stock.
+        return super().get_quant_method(layer, prefix)
+
+
+class ModelOptMixedPrecisionResidueConfig(ModelOptMixedPrecisionConfig):
+    """Mixed-precision ModelOpt config with residue on dense NVFP4 only.
+
+    The outer mixed config remains responsible for resolving each layer's
+    quantization algorithm. Only when the stock resolver chose the serialized
+    NVFP4 dense-linear method do we substitute the residue-aware method.
+    Consequently FP8/MXFP8/W4A16 layers, embeddings, KV cache, ParallelLMHead,
+    and especially FusedMoE all remain on their stock implementations.
+    """
+
+    @classmethod
+    def from_modelopt_config(
+        cls,
+        base: ModelOptMixedPrecisionConfig,
+        residue_spec: ResidueModelSpec,
+    ) -> ModelOptMixedPrecisionResidueConfig:
+        self = cls.__new__(cls)
+        self.__dict__.update(base.__dict__)
+        self.residue_spec = residue_spec
+        self.nvfp4_config = ModelOptFp4ResidueConfig.from_modelopt_config(
+            base.nvfp4_config, residue_spec
+        )
+        return self
+
+    def get_quant_method(self, layer: torch.nn.Module, prefix: str):
+        from sglang.srt.layers.linear import LinearBase
+        from sglang.srt.layers.quantization.residue_nvfp4.linear_method import (
+            ModelOptFp4ResidueLinearMethod,
+        )
+        from sglang.srt.layers.vocab_parallel_embedding import ParallelLMHead
+
+        method = super().get_quant_method(layer, prefix)
+        if (
+            isinstance(layer, LinearBase)
+            and not isinstance(layer, ParallelLMHead)
+            and type(method) is ModelOptFp4LinearMethod
+            and self.residue_spec.spec_for(prefix) is not None
+        ):
+            return ModelOptFp4ResidueLinearMethod(self.nvfp4_config, prefix)
+        return method
+
+
+def maybe_wrap_residue_fp4_config(model_config, quant_config):
+    """Wrap a ModelOpt config when the checkpoint carries residue metadata.
+
+    Called from model loading with the resolved quant config. Returns the
+    (possibly wrapped) config. Raises when the user explicitly requested
+    modelopt_fp4_residue but the checkpoint has no metadata file, and when a
+    metadata file exists but cannot be served -- never a silent fallback.
+    """
+    explicit = getattr(model_config, "quantization", None) == "modelopt_fp4_residue"
+
+    supported_config = isinstance(
+        quant_config, (ModelOptFp4Config, ModelOptMixedPrecisionConfig)
+    )
+    already_wrapped = isinstance(
+        quant_config,
+        (ModelOptFp4ResidueConfig, ModelOptMixedPrecisionResidueConfig),
+    )
+    if not supported_config or already_wrapped:
+        if explicit:
+            raise ResidueMetadataError(
+                "--quantization modelopt_fp4_residue requires a plain ModelOpt "
+                "NVFP4 "
+                f"checkpoint; resolved config is {type(quant_config).__name__}"
+            )
+        return quant_config
+
+    model_path = getattr(model_config, "model_path", None)
+    if not model_path or not os.path.isdir(model_path):
+        # Residue checkpoints are local exports; auto-detection only looks at
+        # local directories.
+        if explicit:
+            raise ResidueMetadataError(
+                "modelopt_fp4_residue requires a local checkpoint directory "
+                f"containing residue_kernel_metadata.json (got {model_path!r})"
+            )
+        return quant_config
+
+    spec: Optional[ResidueModelSpec] = load_residue_model_spec(model_path)
+    if spec is None:
+        if explicit:
+            raise ResidueMetadataError(
+                f"no residue_kernel_metadata.json in {model_path}; use "
+                "--quantization modelopt_fp4 for a plain NVFP4 checkpoint"
+            )
+        return quant_config
+
+    if isinstance(quant_config, ModelOptMixedPrecisionConfig):
+        return ModelOptMixedPrecisionResidueConfig.from_modelopt_config(
+            quant_config, spec
+        )
+    return ModelOptFp4ResidueConfig.from_modelopt_config(quant_config, spec)

--- a/python/sglang/srt/layers/quantization/residue_nvfp4/linear_method.py
+++ b/python/sglang/srt/layers/quantization/residue_nvfp4/linear_method.py
@@ -1,0 +1,341 @@
+"""Residue-aware NVFP4 dense linear method (mext_r1, extended_k, standard).
+
+Subclasses ModelOptFp4LinearMethod. A layer whose prefix resolves to no
+residue spec follows the parent implementation exactly (same create_weights,
+same process_weights_after_loading, same apply) -- the stock path stays
+bit-for-bit and layout-for-layout unchanged. Only layers the metadata names
+enter residue code.
+
+mext_r1 layers keep the parent weight contract (weight stays at the original
+K; the residue lives in the activation's M dimension at runtime), so
+create_weights is inherited unchanged. extended_k layers store a K-extended
+weight, so create_weights overrides the input sizes and, for row-parallel
+layers, installs the two-range TP shard plan. Their PWAL also derives a
+base-K scale layout: decode can use MExt fold over a strided weight prefix,
+while larger M retains the full K-ext path. Both modes route apply() through
+the opaque residue linear op.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+from sglang.srt.layers.quantization.fp4_utils import (
+    Fp4GemmRunnerBackend,
+    get_fp4_gemm_runner_backend,
+)
+from sglang.srt.layers.quantization.modelopt_quant import ModelOptFp4LinearMethod
+from sglang.srt.layers.quantization.residue_nvfp4.metadata import (
+    ResidueLayerSpec,
+    ResidueMode,
+)
+from sglang.srt.layers.quantization.residue_nvfp4.tp import (
+    SF_VEC_SIZE,
+    ResidueShardPlan,
+    current_tp_rank,
+    interleave_extended_for_tp,
+    plan_from_partition,
+)
+
+# Backends whose process_weights_after_loading produces the cutlass-dialect
+# weight/scale layout the residue kernels consume. This is a LAYOUT
+# compatibility set, not a preference: marlin repacks, trtllm shuffles, and
+# neither layout can feed the fold or the residue quant chain. AUTO is
+# accepted because it only survives to PWAL when the runner config was never
+# initialized (tests / offline tools), and the parent PWAL routes AUTO
+# through the cutlass-layout branch.
+_CUTLASS_LAYOUT_BACKENDS = (
+    Fp4GemmRunnerBackend.AUTO,
+    Fp4GemmRunnerBackend.FLASHINFER_CUTLASS,
+    Fp4GemmRunnerBackend.FLASHINFER_CUTEDSL,
+)
+
+
+def _require_cutlass_layout_backend(layer_name: str) -> None:
+    backend = get_fp4_gemm_runner_backend()
+    if backend not in _CUTLASS_LAYOUT_BACKENDS:
+        raise ValueError(
+            f"residue NVFP4 layer {layer_name!r} needs a cutlass-layout FP4 "
+            f"GEMM backend; the server selected {backend.value!r}. Pin one "
+            "with --fp4-gemm-runner-backend flashinfer_cutlass (or "
+            "flashinfer_cutedsl)."
+        )
+
+
+def _wrap_extended_weight_loaders(layer, plan: ResidueShardPlan) -> None:
+    """Interleave extended columns before the stock loader slices them.
+
+    `weight` is packed FP4 (two nibbles per byte, so K_ext/2 columns) and
+    `weight_scale` holds one scale per 16 channels -- hence the differing
+    `scale` factors. A loaded tensor whose last dim is not the extended width
+    is left alone: it is not a K-extended tensor.
+    """
+    targets = (("weight", 2), ("weight_scale", SF_VEC_SIZE))
+    for name, scale in targets:
+        param = getattr(layer, name, None)
+        if param is None:
+            continue
+        orig = getattr(param, "weight_loader", None)
+        if orig is None:
+            continue
+
+        def make(orig_loader, col_scale):
+            def loader(param_, loaded_weight, *args, **kwargs):
+                if loaded_weight.shape[-1] == plan.k_ext // col_scale:
+                    loaded_weight = interleave_extended_for_tp(
+                        loaded_weight, plan, scale=col_scale
+                    )
+                return orig_loader(param_, loaded_weight, *args, **kwargs)
+
+            return loader
+
+        # weight_loader is a read-only property backed by _weight_loader on
+        # sglang's parameter classes.
+        param._weight_loader = make(orig, scale)
+
+
+class ModelOptFp4ResidueLinearMethod(ModelOptFp4LinearMethod):
+    """ModelOptFp4LinearMethod with residue dispatch for metadata-named layers."""
+
+    def __init__(self, quant_config, prefix: str = ""):
+        super().__init__(quant_config)
+        self.prefix = prefix
+        self.layer_spec: Optional[ResidueLayerSpec] = (
+            quant_config.residue_spec.spec_for(prefix) if prefix else None
+        )
+
+    def create_weights(
+        self,
+        layer: torch.nn.Module,
+        input_size_per_partition: int,
+        output_partition_sizes,
+        input_size: int,
+        output_size: int,
+        params_dtype: torch.dtype,
+        **extra_weight_attrs,
+    ):
+        spec = self.layer_spec
+        shard_plan: Optional[ResidueShardPlan] = None
+
+        if spec is not None and spec.mode is ResidueMode.K_EXT:
+            # The stored weight is K-extended. Row-parallel layers arrive with
+            # the input already sharded (input_size_per_partition <
+            # input_size IS the row-parallel signal), so the extended K has to
+            # be sharded too; column-parallel layers get the whole extension.
+            shard_plan = plan_from_partition(
+                extended_dim=spec.k_ext,
+                input_size_per_partition=input_size_per_partition,
+                input_size=input_size,
+                num_salient=spec.num_salient,
+                tp_rank=current_tp_rank(),
+            )
+            if shard_plan is not None:
+                input_size_per_partition = shard_plan.k_ext_shard
+                input_size = spec.k_ext
+            else:
+                if input_size != spec.k_base:
+                    raise ValueError(
+                        f"layer {self.prefix!r}: metadata K_base={spec.k_base} "
+                        f"does not match the layer input size {input_size}"
+                    )
+                input_size_per_partition = spec.k_ext
+                input_size = spec.k_ext
+
+        super().create_weights(
+            layer,
+            input_size_per_partition,
+            output_partition_sizes,
+            input_size,
+            output_size,
+            params_dtype,
+            **extra_weight_attrs,
+        )
+        layer._residue_spec = spec
+
+        if shard_plan is not None:
+            # Row-parallel: permute the checkpoint's extended columns so the
+            # stock loader's contiguous narrow lands on this rank's two
+            # ranges. Far less invasive than replacing the loader.
+            layer._residue_shard_plan = shard_plan
+            _wrap_extended_weight_loaders(layer, shard_plan)
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        spec = self.layer_spec
+        if spec is None:
+            super().process_weights_after_loading(layer)
+            return
+
+        _require_cutlass_layout_backend(self.prefix)
+        if spec.mode is ResidueMode.MEXT_R1:
+            self._pwal_mext_r1(layer, spec)
+        else:
+            assert spec.mode is ResidueMode.K_EXT
+            self._pwal_extended_k(layer, spec)
+
+    def _pwal_mext_r1(self, layer: torch.nn.Module, spec: ResidueLayerSpec) -> None:
+        k = layer.input_size_per_partition
+        n = layer.output_size_per_partition
+        if spec.k_base != k and (spec.k_base % k != 0):
+            raise ValueError(
+                f"layer {self.prefix!r}: metadata K={spec.k_base} does not "
+                f"match or shard onto the loaded weight K={k}"
+            )
+        # The fold consumes the weight and scale in their checkpoint geometry;
+        # requiring these alignments keeps the parent PWAL from padding
+        # (padding would desync the swizzled base scale from the raw layout).
+        if k % 64 != 0 or n % 32 != 0:
+            raise ValueError(
+                f"layer {self.prefix!r}: mext_r1 requires K % 64 == 0 and "
+                f"N % 32 == 0, got K={k}, N={n}"
+            )
+
+        super().process_weights_after_loading(layer)
+
+        assert getattr(layer, "weights_padding_cols", 0) == 0, (
+            f"layer {self.prefix!r}: parent PWAL padded the weight "
+            "unexpectedly; the fold layout contract is violated"
+        )
+
+        # Fold layout: full K is the only K -- the fold reads the entire
+        # weight, so the full swizzled scale doubles as its own base scale.
+        layer._mext_decode_k_base = int(k)
+        layer.weight_scale_base = layer.weight_scale_interleaved
+        layer._residue_fold_eligible = True
+        layer._residue_num_salient = 0
+        layer._residue_channel_mask = None
+
+        # Tell the pre-capture warmup this shape exists. k_ext is the STORED
+        # width in FP4 elements (== k_base here; ext-K layers differ).
+        from sglang.srt.layers.quantization.residue_nvfp4.warmup import (
+            register_fold_shape,
+        )
+
+        register_fold_shape(
+            int(layer.weight.shape[0]),
+            int(k),
+            int(layer.weight.shape[1]) * 2,
+            is_mext_r1=True,
+        )
+
+    def _pwal_extended_k(self, layer: torch.nn.Module, spec: ResidueLayerSpec) -> None:
+        from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+            indices_to_channel_masks,
+        )
+        from sglang.srt.layers.quantization.utils import swizzle_blockscale
+
+        # The weight this rank holds is K_ext (or K_ext/tp) wide, so the
+        # salient indices must be this rank's too -- otherwise the channel
+        # mask would be built over the wrong K.
+        shard_plan: Optional[ResidueShardPlan] = getattr(
+            layer, "_residue_shard_plan", None
+        )
+        indices = torch.tensor(spec.salient_indices, dtype=torch.int64)
+        if shard_plan is not None:
+            indices = shard_plan.local_salient_indices(indices)
+            k_base_local = shard_plan.base_shard
+            num_salient_local = shard_plan.salient_shard
+        else:
+            k_base_local = spec.k_base
+            num_salient_local = spec.num_salient
+
+        stored_k = int(layer.weight.shape[1]) * 2  # packed FP4: 2/byte
+        if stored_k != k_base_local + num_salient_local:
+            raise ValueError(
+                f"layer {self.prefix!r}: stored weight K={stored_k} does not "
+                f"match K_base+S = {k_base_local}+{num_salient_local}"
+            )
+
+        if k_base_local % SF_VEC_SIZE != 0:
+            raise ValueError(
+                f"layer {self.prefix!r}: base K={k_base_local} is not aligned "
+                f"to the NVFP4 scale group size {SF_VEC_SIZE}"
+            )
+
+        # The parent PWAL may alias weight_scale_interleaved back onto the
+        # original Parameter storage. Preserve the checkpoint-order scale
+        # first: decode fold consumes only the base-K prefix, while the
+        # large-M K-ext GEMM still consumes the full extended-K scale.
+        base_scale_groups = int(k_base_local) // SF_VEC_SIZE
+        if layer.weight_scale.shape[-1] < base_scale_groups:
+            raise ValueError(
+                f"layer {self.prefix!r}: raw weight scale width "
+                f"{layer.weight_scale.shape[-1]} cannot cover base K="
+                f"{k_base_local}"
+            )
+        raw_base_weight_scale = (
+            layer.weight_scale[..., :base_scale_groups].detach().clone()
+        )
+
+        # Parent PWAL pads/swizzles for the extended-K GEMM; the shard-plan
+        # validation guarantees K_ext%32==0 so no K padding actually fires,
+        # but N padding is fine (the op slices the output back).
+        super().process_weights_after_loading(layer)
+
+        # Reproduce the parent's CUTLASS scale layout for the BASE prefix.
+        # The packed weight stays in one allocation; nvfp4_linear narrows it
+        # to a strided base-K view for fold and retains the full tensor for
+        # large-M K-ext.
+        layer.weight_scale_base = swizzle_blockscale(raw_base_weight_scale)
+        layer._mext_decode_k_base = int(k_base_local)
+        layer._residue_fold_eligible = True
+        layer._residue_num_salient = int(num_salient_local)
+        layer._residue_k_base = int(k_base_local)
+        layer._residue_channel_mask = indices_to_channel_masks(
+            indices.to(layer.weight.device), k_base_local
+        )
+
+        from sglang.srt.layers.quantization.residue_nvfp4.warmup import (
+            register_fold_shape,
+        )
+
+        register_fold_shape(
+            int(layer.weight.shape[0]),
+            int(k_base_local),
+            int(layer.weight.stride(0)) * 2,
+            is_mext_r1=False,
+        )
+
+    def apply(
+        self,
+        layer: torch.nn.Module,
+        x: torch.Tensor,
+        bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        spec = self.layer_spec
+        if spec is None:
+            return super().apply(layer, x, bias)
+
+        from sglang.kernels.ops.gemm.residue_nvfp4_linear import nvfp4_linear
+
+        output_size = layer.output_size_per_partition
+        output_shape = [*x.shape[:-1], output_size]
+        x_2d = x.reshape(-1, x.shape[-1])
+
+        is_mext_r1 = spec.mode is ResidueMode.MEXT_R1
+        channel_mask = getattr(layer, "_residue_channel_mask", None)
+        if channel_mask is None:
+            # The op signature requires a mask tensor; mext_r1 has no channel
+            # selection, so pass a 1-byte placeholder.
+            channel_mask = x_2d.new_zeros(1, dtype=torch.uint8)
+
+        output = nvfp4_linear(
+            x_2d,
+            layer.weight,
+            layer.input_scale_inv,
+            layer.weight_scale_interleaved,
+            layer.weight_scale_base,
+            channel_mask,
+            layer.alpha,
+            int(getattr(layer, "_mext_decode_k_base", 0)),
+            int(getattr(layer, "_residue_num_salient", 0)),
+            int(getattr(layer, "weights_padding_cols", 0)),
+            int(output_size),
+            bool(getattr(layer, "_residue_fold_eligible", False)),
+            is_mext_r1,
+        )
+
+        if bias is not None:
+            output = output + bias
+        return output.view(*output_shape)

--- a/python/sglang/srt/layers/quantization/residue_nvfp4/metadata.py
+++ b/python/sglang/srt/layers/quantization/residue_nvfp4/metadata.py
@@ -1,0 +1,402 @@
+"""Residue NVFP4 metadata contract.
+
+A residue checkpoint is a stock ModelOpt NVFP4 export plus a
+``residue_kernel_metadata.json`` file in the model directory. This module is
+the single validated reader for that file. The runtime never inspects the
+JSON directly and never infers a layer's residue representation from tensor
+shapes or from ``num_salient == 0`` (that value historically meant both
+"plain NVFP4" and "mext_r1", which produced silent-wrong-numerics bugs in the
+reference implementation; here the representation is always an explicit enum).
+
+Supported representations:
+
+- ``k_ext`` (on-disk ``runtime_mode: "extended_k"``): selective residue for
+  ratios 1/8, 2/8, 4/8. The weight is stored K-extended
+  (``K_ext = K_base + num_salient``) and the activation quantizer appends the
+  selected residue channels.
+- ``mext_r1`` (on-disk ``runtime_mode: "mext_r1"``): full-rank ratio 1.0. The
+  weight stays at ``K_base``; the activation quantizer doubles the token rows
+  and a fold GEMM sums both contributions.
+
+Anything else in the file that would change runtime behavior we do not
+support (MoE residue, unknown modes, unsupported ratios) fails at load time.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Mapping, Optional, Sequence
+
+METADATA_FILENAME = "residue_kernel_metadata.json"
+
+# Salient channels are selected top-k within blocks of this many channels.
+# The k_ext quant kernels and the TP sharding rules both assume it.
+SALIENT_BLOCK = 8
+
+# ratio -> salient channels per SALIENT_BLOCK. Ratio 1.0 is deliberately not
+# here: full-rank residue is only served as mext_r1 (K-extension at ratio 1.0
+# would store the weight twice and was removed from the reference kernels).
+SUPPORTED_K_EXT_RATIOS: Mapping[float, int] = {
+    0.125: 1,
+    0.25: 2,
+    0.5: 4,
+}
+
+
+class ResidueMetadataError(ValueError):
+    """The residue metadata file is missing required data, self-contradictory,
+    or requests something this integration does not support."""
+
+
+class ResidueMode(Enum):
+    """How a dense linear layer represents its residue. Values match the
+    on-disk ``runtime_mode`` strings."""
+
+    K_EXT = "extended_k"
+    MEXT_R1 = "mext_r1"
+
+
+@dataclass(frozen=True)
+class ResidueLayerSpec:
+    """Validated residue description of one dense linear layer.
+
+    ``salient_indices`` is populated for K_EXT only. A MEXT_R1 layer's salient
+    set is by definition every input channel; storing it would be redundant.
+    """
+
+    name: str
+    mode: ResidueMode
+    k_base: int
+    num_salient: int
+    salient_indices: tuple[int, ...] = field(default=())
+
+    @property
+    def k_ext(self) -> int:
+        """Extended K consumed by the k_ext GEMM. Equals k_base for mext_r1."""
+        if self.mode is ResidueMode.MEXT_R1:
+            return self.k_base
+        return self.k_base + self.num_salient
+
+    @property
+    def ratio(self) -> float:
+        return self.num_salient / self.k_base
+
+    @property
+    def residue_per_block(self) -> int:
+        """Salient channels per SALIENT_BLOCK ("residue_per_8" in the kernels)."""
+        if self.mode is ResidueMode.MEXT_R1:
+            return SALIENT_BLOCK
+        return SUPPORTED_K_EXT_RATIOS[self.ratio]
+
+
+# vLLM/SGLang fuse these HF projections into one linear; the metadata is
+# written against HF names, so a fused layer resolves through its parts.
+_FUSED_SUFFIXES: Mapping[str, tuple[str, ...]] = {
+    "qkv_proj": ("q_proj", "k_proj", "v_proj"),
+    "gate_up_proj": ("gate_proj", "up_proj"),
+    # Qwen3.5/Qwen3-Next Gated DeltaNet checkpoints serialize these as two
+    # HF tensors, while the SGLang runtime executes one fused projection.
+    "in_proj_qkvz": ("in_proj_qkv", "in_proj_z"),
+}
+
+
+def layer_name_candidates(layer_name: str) -> list[str]:
+    """Metadata lookup candidates for a possibly-fused layer name."""
+    candidates = [layer_name]
+    for fused_suffix, part_suffixes in _FUSED_SUFFIXES.items():
+        if layer_name.endswith(fused_suffix):
+            base = layer_name[: -len(fused_suffix)]
+            candidates.extend(base + part for part in part_suffixes)
+    return candidates
+
+
+@dataclass(frozen=True)
+class ResidueModelSpec:
+    """All residue layers of one checkpoint, keyed by exported layer name."""
+
+    layers: Mapping[str, ResidueLayerSpec]
+    block_size: int
+    source: str
+
+    def spec_for(self, layer_name: str) -> Optional[ResidueLayerSpec]:
+        """Resolve a runtime layer name, including fused-layer fallbacks.
+
+        Fused layers share one activation quantization, so every constituent
+        that carries residue metadata must agree on the residue contract; a
+        disagreement is an export this integration cannot serve.
+        """
+        direct = self.layers.get(layer_name)
+        if direct is not None:
+            return direct
+
+        found: list[ResidueLayerSpec] = [
+            self.layers[name]
+            for name in layer_name_candidates(layer_name)[1:]
+            if name in self.layers
+        ]
+        if not found:
+            return None
+
+        head = found[0]
+        for other in found[1:]:
+            if (
+                other.mode is not head.mode
+                or other.k_base != head.k_base
+                or other.num_salient != head.num_salient
+                or other.salient_indices != head.salient_indices
+            ):
+                raise ResidueMetadataError(
+                    f"fused layer {layer_name!r} resolves to constituents with "
+                    f"conflicting residue metadata ({head.name!r} vs "
+                    f"{other.name!r}); a fused linear shares one activation "
+                    "quantization and cannot serve two contracts"
+                )
+        return ResidueLayerSpec(
+            name=layer_name,
+            mode=head.mode,
+            k_base=head.k_base,
+            num_salient=head.num_salient,
+            salient_indices=head.salient_indices,
+        )
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ResidueMetadataError(message)
+
+
+def _validate_salient_indices(
+    name: str, indices: Sequence[Any], k_base: int
+) -> tuple[int, ...]:
+    _require(
+        all(isinstance(i, int) and not isinstance(i, bool) for i in indices),
+        f"layer {name!r}: salient_indices must be integers",
+    )
+    out = tuple(int(i) for i in indices)
+    _require(
+        all(0 <= i < k_base for i in out),
+        f"layer {name!r}: salient_indices out of range [0, {k_base})",
+    )
+    _require(
+        all(a < b for a, b in zip(out, out[1:])),
+        f"layer {name!r}: salient_indices must be strictly increasing "
+        "(sorted, no duplicates); the TP sharding contract depends on it",
+    )
+    return out
+
+
+def _parse_k_ext_layer(
+    name: str, entry: Mapping[str, Any], extended_dim: Any
+) -> ResidueLayerSpec:
+    _require(
+        extended_dim is not None,
+        f"layer {name!r}: runtime_mode is 'extended_k' but the layer has no "
+        "entry in extended_linear_dims; the stored weight width is unknown",
+    )
+    _require(
+        isinstance(extended_dim, int) and not isinstance(extended_dim, bool),
+        f"layer {name!r}: extended_linear_dims entry must be an integer",
+    )
+
+    raw_indices = entry.get("salient_indices")
+    _require(
+        isinstance(raw_indices, list) and len(raw_indices) > 0,
+        f"layer {name!r}: extended_k requires a non-empty salient_indices list",
+    )
+    num_salient = entry.get("num_salient", len(raw_indices))
+    _require(
+        num_salient == len(raw_indices),
+        f"layer {name!r}: num_salient={num_salient} does not match "
+        f"len(salient_indices)={len(raw_indices)}",
+    )
+
+    k_base = int(extended_dim) - int(num_salient)
+    _require(
+        k_base > 0 and k_base % 16 == 0,
+        f"layer {name!r}: derived K_base={k_base} must be a positive multiple "
+        "of 16 (NVFP4 group size)",
+    )
+
+    ratio = num_salient / k_base
+    supported = ", ".join(f"{r:g}" for r in sorted(SUPPORTED_K_EXT_RATIOS))
+    _require(
+        any(abs(ratio - r) < 1e-3 for r in SUPPORTED_K_EXT_RATIOS),
+        f"layer {name!r}: residue ratio {ratio:.4f} ({num_salient}/{k_base}) "
+        f"is not supported; supported extended_k ratios: {supported}. "
+        "Ratio 1.0 must be exported as mext_r1.",
+    )
+
+    indices = _validate_salient_indices(name, raw_indices, k_base)
+    return ResidueLayerSpec(
+        name=name,
+        mode=ResidueMode.K_EXT,
+        k_base=k_base,
+        num_salient=int(num_salient),
+        salient_indices=indices,
+    )
+
+
+def _parse_mext_r1_layer(
+    name: str, entry: Mapping[str, Any], extended_dim: Any
+) -> ResidueLayerSpec:
+    _require(
+        extended_dim is None,
+        f"layer {name!r}: runtime_mode is 'mext_r1' but the layer appears in "
+        "extended_linear_dims; mext_r1 weights must stay at the original K",
+    )
+    raw_indices = entry.get("salient_indices")
+    _require(
+        isinstance(raw_indices, list) and len(raw_indices) > 0,
+        f"layer {name!r}: mext_r1 requires salient_indices covering every "
+        "input channel (the export writes them; their length defines K)",
+    )
+    num_salient = entry.get("num_salient", len(raw_indices))
+    _require(
+        num_salient == len(raw_indices),
+        f"layer {name!r}: num_salient={num_salient} does not match "
+        f"len(salient_indices)={len(raw_indices)}",
+    )
+    k_base = int(num_salient)
+    _require(
+        k_base > 0 and k_base % 16 == 0,
+        f"layer {name!r}: K={k_base} must be a positive multiple of 16",
+    )
+    indices = _validate_salient_indices(name, raw_indices, k_base)
+    _require(
+        indices == tuple(range(k_base)),
+        f"layer {name!r}: mext_r1 means ratio 1.0, so salient_indices must be "
+        "exactly every channel 0..K-1",
+    )
+    return ResidueLayerSpec(
+        name=name,
+        mode=ResidueMode.MEXT_R1,
+        k_base=k_base,
+        num_salient=k_base,
+    )
+
+
+def _validate_moe_section(moe: Any) -> None:
+    """Residue MoE is out of scope. A checkpoint whose MoE policy is entirely
+    'off' is fine (the experts are plain NVFP4); anything else is a format we
+    must refuse rather than silently serve without its residue."""
+    _require(isinstance(moe, dict), "'moe' section must be an object")
+    layers = moe.get("layers")
+    _require(isinstance(layers, dict), "'moe' section must contain 'layers'")
+    active = sorted(
+        name
+        for name, policy in layers.items()
+        if not (isinstance(policy, dict) and policy.get("impl") == "off")
+    )
+    _require(
+        not active,
+        "checkpoint requests residue MoE, which this integration does not "
+        f"support (non-'off' impl for: {active[:5]}"
+        f"{'...' if len(active) > 5 else ''})",
+    )
+
+
+def parse_residue_metadata(data: Any, source: str = "<memory>") -> ResidueModelSpec:
+    """Validate a decoded residue_kernel_metadata.json into a ResidueModelSpec.
+
+    Raises ResidueMetadataError on anything missing, ambiguous, or
+    unsupported. A spec that parses is fully servable by this integration.
+    """
+    _require(isinstance(data, dict), f"{source}: metadata root must be an object")
+
+    raw_layers = data.get("layers")
+    _require(
+        isinstance(raw_layers, dict),
+        f"{source}: metadata must contain a 'layers' object",
+    )
+
+    global_section = data.get("global", {})
+    _require(
+        isinstance(global_section, dict),
+        f"{source}: 'global' section must be an object",
+    )
+    block_size = global_section.get("block_size", SALIENT_BLOCK)
+    _require(
+        block_size == SALIENT_BLOCK,
+        f"{source}: block_size={block_size} is not supported; the residue "
+        f"kernels assume salient selection in blocks of {SALIENT_BLOCK}",
+    )
+
+    if "moe" in data:
+        _validate_moe_section(data["moe"])
+
+    extended_dims = data.get("extended_linear_dims", {})
+    _require(
+        isinstance(extended_dims, dict),
+        f"{source}: 'extended_linear_dims' must be an object",
+    )
+
+    layers: dict[str, ResidueLayerSpec] = {}
+    for name, entry in raw_layers.items():
+        _require(
+            isinstance(entry, dict),
+            f"{source}: layer {name!r} entry must be an object",
+        )
+        if "salient_indices" not in entry and "runtime_mode" not in entry:
+            # Entry carries no residue contract (e.g. only debug fields).
+            continue
+
+        mode_str = entry.get("runtime_mode")
+        _require(
+            mode_str is not None,
+            f"{source}: layer {name!r} has residue data but no explicit "
+            "runtime_mode; refusing to guess the representation",
+        )
+        extended_dim = extended_dims.get(name)
+        if mode_str == ResidueMode.K_EXT.value:
+            spec = _parse_k_ext_layer(name, entry, extended_dim)
+        elif mode_str == ResidueMode.MEXT_R1.value:
+            spec = _parse_mext_r1_layer(name, entry, extended_dim)
+        elif mode_str == "standard":
+            _require(
+                not entry.get("salient_indices"),
+                f"{source}: layer {name!r} is marked 'standard' but carries "
+                "salient_indices; the entry contradicts itself",
+            )
+            continue
+        else:
+            raise ResidueMetadataError(
+                f"{source}: layer {name!r} has unknown runtime_mode "
+                f"{mode_str!r}; supported: 'extended_k', 'mext_r1', 'standard'"
+            )
+        layers[name] = spec
+
+    orphaned = sorted(set(extended_dims) - set(layers))
+    _require(
+        not orphaned,
+        f"{source}: extended_linear_dims names layers without a valid residue "
+        f"entry: {orphaned[:5]}{'...' if len(orphaned) > 5 else ''}",
+    )
+
+    return ResidueModelSpec(layers=layers, block_size=SALIENT_BLOCK, source=source)
+
+
+def find_residue_metadata(model_dir: str | Path) -> Optional[Path]:
+    """Path of the residue metadata file in a local model dir, if present."""
+    path = Path(model_dir) / METADATA_FILENAME
+    return path if path.is_file() else None
+
+
+def load_residue_model_spec(model_dir: str | Path) -> Optional[ResidueModelSpec]:
+    """Load and validate the residue metadata of a local checkpoint.
+
+    Returns None when the checkpoint has no residue metadata file (the stock
+    modelopt_fp4 path applies). Raises ResidueMetadataError when the file
+    exists but cannot be served: a present-but-broken file must never fall
+    back to plain NVFP4 silently.
+    """
+    path = find_residue_metadata(model_dir)
+    if path is None:
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as e:
+        raise ResidueMetadataError(f"cannot read {path}: {e}") from e
+    return parse_residue_metadata(data, source=str(path))

--- a/python/sglang/srt/layers/quantization/residue_nvfp4/tp.py
+++ b/python/sglang/srt/layers/quantization/residue_nvfp4/tp.py
@@ -1,0 +1,269 @@
+"""Tensor-parallel sharding for the residue K-extension.
+
+Only the K-extension (extended_k) path needs any of this. mext_r1 keeps its
+weight at K_base and puts the residue in the activation's M dimension, so
+stock sharding already applies unchanged.
+
+The extended weight is laid out as ``[N, K_base | S]``. Under row-parallel
+TP rank ``r`` must hold two *disjoint* column ranges:
+
+    base     [ r*Kb/tp , (r+1)*Kb/tp )
+    salient  Kb + [ r*S/tp , (r+1)*S/tp )
+
+The stock row-parallel loader takes a single contiguous range. Because
+``K_ext/tp == Kb/tp + S/tp`` the shapes still agree, so nothing raises -- it
+just pairs activation columns with the wrong weight columns. That silent
+failure is why this module exists.
+
+Both ranges being contiguous, and the split being balanced, are properties of
+how the export picks salient channels (top-k inside each 8-channel block,
+globally sorted), not assumptions. They are asserted here and pinned by
+tests.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+# Salient channels are selected top-k within blocks of this many channels.
+SALIENT_BLOCK = 8
+# One FP4 scale factor covers this many channels.
+SF_VEC_SIZE = 16
+# Swizzled block-scale tiles span 4 SF blocks along K.
+SF_SWIZZLE_BLOCKS = 4
+# One RESIDUE scale factor is a warp_group_max over 16/residue_per_8 threads,
+# each covering 8 channels -- i.e. 128/residue_per_8 base channels, worst case
+# 128 at the production ratio 0.125. A shard boundary inside such a group
+# would give that rank a different residue amax than the single-GPU run: the
+# residue values themselves change, silently, with no shape error anywhere.
+RESIDUE_SF_GROUP_CHANNELS = 128
+
+
+class ResidueTPError(ValueError):
+    """A shape the residue TP sharding rule cannot honour."""
+
+
+@dataclass(frozen=True)
+class ResidueShardPlan:
+    """How to cut one extended tensor for one rank.
+
+    Attributes are in *logical channels*; helpers convert to packed-FP4 and
+    scale-factor coordinates.
+    """
+
+    k_base: int
+    num_salient: int
+    tp_size: int
+    tp_rank: int
+
+    @property
+    def k_ext(self) -> int:
+        return self.k_base + self.num_salient
+
+    @property
+    def base_shard(self) -> int:
+        return self.k_base // self.tp_size
+
+    @property
+    def salient_shard(self) -> int:
+        return self.num_salient // self.tp_size
+
+    @property
+    def k_ext_shard(self) -> int:
+        """Per-rank extended width. Equals k_ext // tp_size."""
+        return self.base_shard + self.salient_shard
+
+    def validate(self) -> None:
+        """Reject shapes the two-range rule cannot serve, loudly.
+
+        Every constraint is a real requirement: an unbalanced salient split
+        would need ragged per-rank shapes, and a boundary off the SF-swizzle
+        grid would slice a scale-factor tile in half.
+        """
+        tp = self.tp_size
+        if tp <= 0 or self.tp_rank not in range(tp):
+            raise ResidueTPError(f"bad tp_rank={self.tp_rank} for tp_size={tp}")
+        if self.k_base % tp:
+            raise ResidueTPError(f"K_base={self.k_base} not divisible by tp_size={tp}")
+        if self.num_salient % tp:
+            raise ResidueTPError(
+                f"num_salient={self.num_salient} not divisible by tp_size={tp};"
+                " the salient split would be ragged"
+            )
+        # Balanced split needs the boundary to land on a salient block.
+        if self.base_shard % SALIENT_BLOCK:
+            raise ResidueTPError(
+                f"K_base/tp={self.base_shard} is not a multiple of "
+                f"{SALIENT_BLOCK}: ranks would get different salient counts"
+            )
+        # ...and must not cut a residue scale-factor group in half.
+        if self.base_shard % RESIDUE_SF_GROUP_CHANNELS:
+            raise ResidueTPError(
+                f"K_base/tp={self.base_shard} is not a multiple of "
+                f"{RESIDUE_SF_GROUP_CHANNELS}: the boundary would split a "
+                "residue scale-factor group, so this rank would compute a "
+                "different residue amax than the unsharded model"
+            )
+        # Both ranges are sliced in scale-factor space too.
+        grid = SF_VEC_SIZE * SF_SWIZZLE_BLOCKS
+        for name, width in (
+            ("K_base/tp", self.base_shard),
+            ("S/tp", self.salient_shard),
+        ):
+            if width % grid:
+                raise ResidueTPError(
+                    f"{name}={width} is not a multiple of {grid}; the "
+                    "swizzled block-scale tile cannot be split there"
+                )
+        assert self.k_ext_shard * tp == self.k_ext, "K_ext must split evenly"
+
+    # -- range helpers ------------------------------------------------------
+
+    def ranges(self, scale: int = 1) -> tuple[tuple[int, int], tuple[int, int]]:
+        """(base, salient) ranges as (offset, length), divided by `scale`.
+
+        `scale` = 1 for logical channels, 2 for packed FP4 (two nibbles per
+        byte), SF_VEC_SIZE for block scales.
+        """
+        for name, v in (
+            ("k_base", self.k_base),
+            ("base_shard", self.base_shard),
+            ("salient_shard", self.salient_shard),
+        ):
+            if v % scale:
+                raise ResidueTPError(f"{name}={v} not divisible by scale={scale}")
+        base = (self.tp_rank * self.base_shard // scale, self.base_shard // scale)
+        sal = (
+            (self.k_base + self.tp_rank * self.salient_shard) // scale,
+            self.salient_shard // scale,
+        )
+        return base, sal
+
+    def gather(self, full: torch.Tensor, scale: int = 1, dim: int = -1) -> torch.Tensor:
+        """Assemble this rank's shard from the two ranges."""
+        (b_off, b_len), (s_off, s_len) = self.ranges(scale)
+        want = full.shape[dim]
+        need = self.k_ext // scale
+        if want != need:
+            raise ResidueTPError(
+                f"expected extended dim {need} along dim {dim}, got {want}"
+            )
+        return torch.cat(
+            [full.narrow(dim, b_off, b_len), full.narrow(dim, s_off, s_len)],
+            dim=dim,
+        )
+
+    # -- runtime state ------------------------------------------------------
+
+    def local_channel_mask(self, full_mask: torch.Tensor) -> torch.Tensor:
+        """This rank's slice of the per-8-channel salient bitmask."""
+        if full_mask.numel() != self.k_base // SALIENT_BLOCK:
+            raise ResidueTPError(
+                f"channel_mask has {full_mask.numel()} bytes, expected "
+                f"{self.k_base // SALIENT_BLOCK} for K_base={self.k_base}"
+            )
+        per = self.base_shard // SALIENT_BLOCK
+        return full_mask.narrow(0, self.tp_rank * per, per).contiguous()
+
+    def local_salient_indices(self, full_indices: torch.Tensor) -> torch.Tensor:
+        """This rank's salient indices, rebased to rank-local channels.
+
+        Relies on the indices being globally sorted, so this rank's are the
+        r-th contiguous run -- verified rather than assumed.
+        """
+        lo = self.tp_rank * self.base_shard
+        hi = lo + self.base_shard
+        mine = full_indices[(full_indices >= lo) & (full_indices < hi)]
+        if mine.numel() != self.salient_shard:
+            raise ResidueTPError(
+                f"rank {self.tp_rank} owns {mine.numel()} salient channels, "
+                f"expected {self.salient_shard}: the export's per-block "
+                "uniformity no longer holds, so TP sharding is unsafe"
+            )
+        run = full_indices.narrow(
+            0, self.tp_rank * self.salient_shard, self.salient_shard
+        )
+        if not torch.equal(mine, run):
+            raise ResidueTPError(
+                "salient indices are not globally sorted; the contiguous-run "
+                "assumption behind TP sharding is broken"
+            )
+        return mine - lo
+
+
+def interleave_extended_for_tp(
+    full: torch.Tensor, plan: ResidueShardPlan, scale: int = 1, dim: int = -1
+) -> torch.Tensor:
+    """Reorder ``[base | salient]`` into ``[base_0 | sal_0 | base_1 | ...]``.
+
+    This is the trick that avoids replacing the stock weight loader. After
+    the permutation, rank r's *contiguous* range
+
+        [ r*K_ext/tp , (r+1)*K_ext/tp )
+
+    is exactly the two-range gather it needs. So the loader keeps doing its
+    ordinary contiguous narrow and still lands on the right columns -- we
+    only have to hand it a permuted checkpoint tensor.
+
+    Applied to the full tensor, identically on every rank, so it stays a
+    pure function of the checkpoint (no rank in the result).
+    """
+    tp = plan.tp_size
+    pieces = []
+    for r in range(tp):
+        r_plan = ResidueShardPlan(plan.k_base, plan.num_salient, tp, r)
+        pieces.append(r_plan.gather(full, scale=scale, dim=dim))
+    return torch.cat(pieces, dim=dim).contiguous()
+
+
+def plan_from_partition(
+    *,
+    extended_dim: int,
+    input_size_per_partition: int,
+    input_size: int,
+    num_salient: int,
+    tp_rank: int = 0,
+) -> ResidueShardPlan | None:
+    """Build a shard plan from what create_weights is handed.
+
+    Returns None for a column-parallel layer: its input is not sharded, so
+    the whole extended K lives on every rank and there is nothing to cut.
+
+    The row-parallel signal is `input_size_per_partition < input_size` --
+    tp_size follows from their ratio, so this needs no process-group lookup
+    and stays testable off-device.
+    """
+    if input_size_per_partition >= input_size:
+        return None
+    if input_size % input_size_per_partition:
+        raise ResidueTPError(
+            f"input_size={input_size} is not a whole multiple of "
+            f"input_size_per_partition={input_size_per_partition}"
+        )
+    tp_size = input_size // input_size_per_partition
+    k_base = extended_dim - num_salient
+    if k_base != input_size:
+        raise ResidueTPError(
+            f"extended_dim={extended_dim} minus num_salient={num_salient} "
+            f"is {k_base}, which does not match input_size={input_size}"
+        )
+    plan = ResidueShardPlan(
+        k_base=k_base,
+        num_salient=num_salient,
+        tp_size=tp_size,
+        tp_rank=tp_rank,
+    )
+    plan.validate()
+    return plan
+
+
+def current_tp_rank() -> int:
+    """This process's TP rank, or 0 outside a distributed run."""
+    try:
+        from sglang.srt.distributed import get_tensor_model_parallel_rank
+
+        return get_tensor_model_parallel_rank()
+    except Exception:
+        return 0

--- a/python/sglang/srt/layers/quantization/residue_nvfp4/warmup.py
+++ b/python/sglang/srt/layers/quantization/residue_nvfp4/warmup.py
@@ -1,0 +1,121 @@
+"""Fold warmup: pre-compile the residue fold kernels before CUDA graph capture.
+
+The CuTeDSL fold JIT-compiles. A JIT inside cudagraph capture is both slow
+(~1.3 s per kernel, multiplied by capture sizes) and, on some paths, a sync in
+a place that cannot take one. The two halves of the defense:
+
+  1. Every fold-eligible layer registers its shape at the end of its
+     process_weights_after_loading -- PWAL always runs, always before capture,
+     and the layer knows its own shape there. Registering from a runner hook
+     was tried in the reference implementation and failed silently twice.
+  2. capture setup calls maybe_warmup_residue_fold() before the first capture
+     and wraps the capture in observe_residue_fold_compiles(), which turns
+     warmup under-coverage from "the server is mysteriously slow" into a
+     printed report naming the missed kernels.
+
+The SM100/SM103 kernels compile per tactic rather than per shape, so one
+warmup covers every registered layer.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+# (n_w, k_base, k_ext_in_fp4_elements, is_mext_r1)
+_FOLD_SHAPES: set[tuple[int, int, int, bool]] = set()
+_WARMED_UP = False
+
+
+def register_fold_shape(n_w: int, k_base: int, k_ext: int, is_mext_r1: bool) -> None:
+    """Record a fold-eligible layer's shape for the pre-capture warmup.
+
+    k_ext is the STORED weight width in FP4 elements: == k_base for a
+    contiguous mext_r1 weight, > k_base for an ext-K prefix view (which
+    selects a different compiled kernel via the strided weight read).
+    """
+    _FOLD_SHAPES.add((int(n_w), int(k_base), int(k_ext), bool(is_mext_r1)))
+
+
+def registered_fold_shapes() -> frozenset[tuple[int, int, int, bool]]:
+    return frozenset(_FOLD_SHAPES)
+
+
+def maybe_warmup_residue_fold() -> int:
+    """Compile every fold kernel the registered layers can reach.
+
+    Returns the number of kernels compiled; 0 when no residue layer is
+    loaded (the common case: the whole function is a set-emptiness check).
+    Call at engine init, OUTSIDE cudagraph capture. Idempotent.
+
+    Also pre-compiles the FlashInfer tuner candidates: a persisted autotune
+    cache entry restored on a later boot must find its winning kernel
+    already compiled, or the first serving call would JIT inside cudagraph
+    capture. Best-effort per spec -- one failure must not cost the rest.
+    """
+    global _WARMED_UP
+    if not _FOLD_SHAPES or _WARMED_UP:
+        return 0
+    _WARMED_UP = True
+
+    from sglang.kernels.ops.gemm.residue_fold import warmup
+
+    major, minor = torch.cuda.get_device_capability()
+    shapes = sorted(_FOLD_SHAPES)
+    count = warmup(int(major), int(minor), shapes=shapes)
+    count += _precompile_tuner_candidates(int(major), shapes)
+    logger.info(
+        "Residue fold warmup: %d kernel(s) compiled for %d registered "
+        "shape(s) on sm%d%d.",
+        count,
+        len(shapes),
+        major,
+        minor,
+    )
+    return count
+
+
+def _precompile_tuner_candidates(major: int, shapes) -> int:
+    try:
+        from sglang.kernels.ops.gemm.residue_fold import tuners
+    except ImportError as e:
+        logger.info("Residue fold tuner precompile skipped: %s", e)
+        return 0
+
+    compiled = 0
+    has_mext_r1 = any(is_mext for (_, _, _, is_mext) in shapes)
+    try:
+        if major == 10:
+            if tuners.sm10x_tuner_enabled():
+                # Symbolic shapes: one candidate set serves every layer.
+                if tuners.precompile_row_pair():
+                    compiled += 1
+            if has_mext_r1:
+                compiled += tuners.precompile_kloop_sm100()
+    except Exception as e:  # noqa: BLE001
+        logger.warning(
+            "Residue fold tuner precompile failed (%s: %s); cache hits may "
+            "degrade to the fallback path.",
+            type(e).__name__,
+            e,
+        )
+    return compiled
+
+
+def observe_residue_fold_compiles(where: str):
+    """Context manager reporting any fold JIT that happens inside the block.
+
+    No-ops (cheaply) when no residue layer is loaded. Wrap cudagraph capture
+    with it: a clean block prints nothing; a missed warmup names the keys.
+    """
+    if not _FOLD_SHAPES:
+        import contextlib
+
+        return contextlib.nullcontext()
+
+    from sglang.kernels.ops.gemm.residue_fold import observe_compiles
+
+    return observe_compiles(where)

--- a/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/cuda_graph_setup.py
@@ -165,34 +165,45 @@ def capture_cuda_graphs(
             available_memory_gb,
         )
 
+    # Residue NVFP4: the CuTeDSL fold JIT-compiles; every compile must happen
+    # before capture. No-ops unless residue layers registered shapes at load.
+    from sglang.srt.layers.quantization.residue_nvfp4.warmup import (
+        maybe_warmup_residue_fold,
+        observe_residue_fold_compiles,
+    )
+
+    maybe_warmup_residue_fold()
+
     # cuda-graph capture: prefill before decode, so both coalesce onto the
     # eager buffer allocated above. (capture_prefill_graph routes prefill
     # to the eager runner when the prefill graph is disabled.)
-    prefill = capture_prefill_graph(
-        model_runner=model_runner, eager_runner=eager_runner
-    )
+    with observe_residue_fold_compiles("cuda graph capture"):
+        prefill = capture_prefill_graph(
+            model_runner=model_runner, eager_runner=eager_runner
+        )
 
-    decode_phase = "draft_decode" if model_runner.is_draft_worker else "decode"
-    decode = GraphCapture(
-        runner=None,
-        memory_phase=decode_phase,
-        memory_usage_gb=0,
-        capture_time=0,
-    )
-    if capture_decode_cuda_graph:
-        if model_runner.device in ("cuda", "musa", "cpu", "npu", "xpu"):
-            decode = capture_decode_graph(model_runner=model_runner)
-        elif (
-            current_platform.is_out_of_tree() and current_platform.support_cuda_graph()
-        ):
-            decode = capture_decode_graph(model_runner=model_runner)
-    else:
+        decode_phase = "draft_decode" if model_runner.is_draft_worker else "decode"
         decode = GraphCapture(
-            runner=eager_runner,
+            runner=None,
             memory_phase=decode_phase,
             memory_usage_gb=0,
             capture_time=0,
         )
+        if capture_decode_cuda_graph:
+            if model_runner.device in ("cuda", "musa", "cpu", "npu", "xpu"):
+                decode = capture_decode_graph(model_runner=model_runner)
+            elif (
+                current_platform.is_out_of_tree()
+                and current_platform.support_cuda_graph()
+            ):
+                decode = capture_decode_graph(model_runner=model_runner)
+        else:
+            decode = GraphCapture(
+                runner=eager_runner,
+                memory_phase=decode_phase,
+                memory_usage_gb=0,
+                capture_time=0,
+            )
 
     # Register forward hooks AFTER cuda-graph capture so their tensor ops are
     # not traced into any captured graph — capture stays hook-free and hooks

--- a/python/sglang/srt/model_loader/weight_utils.py
+++ b/python/sglang/srt/model_loader/weight_utils.py
@@ -259,6 +259,24 @@ def _resolve_explicit_draft_quant_config(
     return quant_config
 
 
+def _finalize_quant_config(
+    model_config: ModelConfig,
+    quant_config: QuantizationConfig,
+) -> QuantizationConfig:
+    """Draft-config resolution + checkpoint-driven residue detection.
+
+    A ModelOpt NVFP4 checkpoint that ships residue_kernel_metadata.json is
+    served by the residue-aware config; without the file the stock config is
+    returned unchanged. A present-but-invalid file raises at load.
+    """
+    quant_config = _resolve_explicit_draft_quant_config(model_config, quant_config)
+    from sglang.srt.layers.quantization.residue_nvfp4.config import (
+        maybe_wrap_residue_fp4_config,
+    )
+
+    return maybe_wrap_residue_fp4_config(model_config, quant_config)
+
+
 # TODO(woosuk): Move this to other place.
 def get_quant_config(
     model_config: ModelConfig,
@@ -266,7 +284,13 @@ def get_quant_config(
     packed_modules_mapping: Dict[str, List[str]],
     remap_prefix: Dict[str, str] | None = None,
 ) -> QuantizationConfig:
-    quant_cls = get_quantization_config(model_config.quantization)
+    if model_config.quantization == "modelopt_fp4_residue":
+        # The residue config cannot be built from the HF config alone; parse
+        # as stock modelopt_fp4 and let _finalize_quant_config attach the
+        # (required) residue metadata.
+        quant_cls = get_quantization_config("modelopt_fp4")
+    else:
+        quant_cls = get_quantization_config(model_config.quantization)
 
     # GGUF doesn't have config file
     if model_config.quantization == "gguf":
@@ -297,7 +321,7 @@ def get_quant_config(
             if model_config.quantization in REQUANTIZATION_METHODS:
                 hf_quant_config["requantization_method"] = model_config.quantization
 
-            return _resolve_explicit_draft_quant_config(
+            return _finalize_quant_config(
                 model_config, quant_cls.from_config(hf_quant_config)
             )
 
@@ -415,12 +439,10 @@ def get_quant_config(
             elif "FP4" in quant_algo:
                 if not issubclass(quant_cls, ModelOptFp4Config):
                     quant_cls = ModelOptFp4Config
-                return _resolve_explicit_draft_quant_config(
+                return _finalize_quant_config(
                     model_config, quant_cls.from_config(config)
                 )
-        return _resolve_explicit_draft_quant_config(
-            model_config, quant_cls.from_config(config)
-        )
+        return _finalize_quant_config(model_config, quant_cls.from_config(config))
 
 
 def _check_index_files_exist(snapshot_dir: str) -> Tuple[bool, Optional[str]]:

--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -57,12 +57,11 @@ def _mtp_quant_config(quant_config):
     # Serialized Qwen3.5 ModelOpt checkpoints keep embedded MTP weights in
     # BF16. Disable quantization for those checkpoints; non-serialized
     # modelopt_fp4 still converts MoE expert weights on load.
+    if quant_config and quant_config.get_name() == "modelopt_mixed":
+        return getattr(quant_config, "mtp_quant_config", None)
     if quant_config and (
-        quant_config.get_name() == "modelopt_mixed"
-        or (
-            quant_config.get_name() == "modelopt_fp4"
-            and quant_config.is_checkpoint_nvfp4_serialized
-        )
+        quant_config.get_name() == "modelopt_fp4"
+        and quant_config.is_checkpoint_nvfp4_serialized
     ):
         return None
     if is_npu() and get_spec().speculative_draft_model_quantization is None:

--- a/python/sglang/test/kernels/residue_nvfp4.py
+++ b/python/sglang/test/kernels/residue_nvfp4.py
@@ -1,0 +1,127 @@
+"""Pure-torch oracle helpers for residue NVFP4 kernel tests.
+
+Shared by the quantization parity tests and the fold GEMM tests: FP4 e2m1
+nibble decoding, the swizzled 128x4 scale-factor layout (both directions),
+mext_r1 layout row mapping, and a simple NVFP4 weight quantizer.
+"""
+
+from __future__ import annotations
+
+import torch
+
+E2M1_LUT = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ]
+)
+
+# mext_r1 layout modes (must match the kernel's enum).
+LAYOUT_CONCAT = 0
+LAYOUT_ROW_PAIR = 1
+LAYOUT_CONCAT_K = 3
+
+
+def decode_fp4(packed: torch.Tensor) -> torch.Tensor:
+    """[R, K/2] packed uint8 -> [R, K] float32 (low nibble = even element)."""
+    lo = (packed & 0xF).long()
+    hi = (packed >> 4).long()
+    codes = torch.stack([lo, hi], dim=-1).reshape(packed.shape[0], -1)
+    return E2M1_LUT.to(packed.device)[codes]
+
+
+def sf_unswizzle(sf_bytes: torch.Tensor, rows: int, cols: int) -> torch.Tensor:
+    """Swizzled 128x4-atom SF bytes -> row-major (rows, cols // 16) float32."""
+    device = sf_bytes.device
+    m_i = torch.arange(rows, device=device).view(-1, 1)
+    ks = torch.arange(cols // 16, device=device).view(1, -1)
+    n_kt = (cols + 63) // 64
+    idx = (
+        (m_i // 128) * (n_kt * 512)
+        + (ks // 4) * 512
+        + (m_i % 32) * 16
+        + ((m_i % 128) // 32) * 4
+        + (ks % 4)
+    ).reshape(-1)
+    picked = sf_bytes.reshape(-1)[idx].reshape(rows, cols // 16)
+    return picked.view(torch.float8_e4m3fn).float()
+
+
+def swizzle_scale(scale: torch.Tensor) -> torch.Tensor:
+    """Row-major [R, K/16] fp8 scale -> swizzled 128x4 tiled layout bytes."""
+    r, k_groups = scale.shape
+    r_pad = (r + 127) // 128 * 128
+    k_pad = (k_groups + 3) // 4 * 4
+    padded = torch.zeros(r_pad, k_pad, dtype=scale.dtype, device=scale.device)
+    padded[:r, :k_groups] = scale
+    out = (
+        padded.reshape(r_pad // 128, 4, 32, k_pad // 4, 4)
+        .permute(0, 3, 2, 1, 4)
+        .contiguous()
+    )
+    return out.reshape(r_pad, k_pad)
+
+
+def base_row(r: torch.Tensor, out_m: int, mode: int) -> torch.Tensor:
+    """mext_r1: output row index of token r's BASE row for a layout mode."""
+    if mode == LAYOUT_ROW_PAIR:
+        return 2 * r
+    return r
+
+
+def residue_row(r: torch.Tensor, out_m: int, mode: int) -> torch.Tensor:
+    """mext_r1: output row index of token r's RESIDUE row for a layout mode."""
+    if mode == LAYOUT_ROW_PAIR:
+        return 2 * r + 1
+    return r + out_m
+
+
+def quantize_nvfp4_weight(
+    w: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Simple per-16-group NVFP4 weight quantization (torch oracle).
+
+    Returns (packed uint8 [N, K/2], swizzled fp8-e4m3 scale bytes,
+    w_global_scale). Round-to-nearest against the e2m1 grid; tie behavior is
+    bucketize's, which is fine for decomposition-tolerance tests.
+    """
+    n, k = w.shape
+    wf = w.float().reshape(n, k // 16, 16)
+    w_global = (448.0 * 6.0) / wf.abs().max()
+    sf = (wf.abs().amax(dim=-1) / 6.0) * w_global  # [N, K/16]
+    sf_fp8 = sf.to(torch.float8_e4m3fn)
+    sf_dec = sf_fp8.float()
+    scale = torch.where(sf_dec > 0, w_global / sf_dec, torch.zeros_like(sf_dec))
+    scaled = wf * scale.unsqueeze(-1)
+
+    lut = E2M1_LUT[:8].to(w.device)
+    mags = scaled.abs().clamp(max=6.0)
+    idx = torch.bucketize(mags, (lut[1:] + lut[:-1]) / 2)
+    codes = torch.where(scaled < 0, idx + 8, idx).to(torch.uint8).reshape(n, k)
+    packed = (codes[:, 0::2] | (codes[:, 1::2] << 4)).contiguous()
+    return packed, swizzle_scale(sf_fp8), w_global
+
+
+def dequant_nvfp4_weight(
+    packed: torch.Tensor, sf_swizzled: torch.Tensor, w_global: torch.Tensor
+) -> torch.Tensor:
+    """Invert quantize_nvfp4_weight back to float32 [N, K]."""
+    n, k_half = packed.shape
+    k = k_half * 2
+    vals = decode_fp4(packed)
+    sf = sf_unswizzle(sf_swizzled, (n + 127) // 128 * 128, k)[:n]
+    return vals * sf.repeat_interleave(16, dim=1) / w_global

--- a/test/registered/kernels/ops/gemm/test_residue_fold.py
+++ b/test/registered/kernels/ops/gemm/test_residue_fold.py
@@ -1,0 +1,91 @@
+"""GPU tests for the residue NVFP4 mext_r1 fold GEMM (sm100/sm103).
+
+The fold computes fold(A[2M, K] @ W[N, K]^T) where A holds row-pair
+interleaved (base, residue) activation rows and the kernel sums each output
+pair: out[m] = (x_q[m] + r_q[m]) @ W_q^T * alpha. The reference is the same
+contraction done in BF16/FP32 on the dequantized operands, so the test
+isolates the GEMM (quantization error cancels out by construction).
+"""
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+if torch.cuda.get_device_capability()[0] != 10:
+    pytest.skip("sm100/sm103 (datacenter Blackwell) required", allow_module_level=True)
+pytest.importorskip("cutlass", reason="nvidia-cutlass-dsl required")
+
+from sglang.kernels.ops.gemm.residue_fold import run_fold, warmup
+from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+    scaled_fp4_quant_mext_r1,
+)
+from sglang.test.kernels.residue_nvfp4 import (
+    base_row,
+    decode_fp4,
+    dequant_nvfp4_weight,
+    quantize_nvfp4_weight,
+    residue_row,
+    sf_unswizzle,
+)
+
+MAJOR, MINOR = torch.cuda.get_device_capability()
+
+
+@pytest.mark.parametrize("m", [1, 4, 16, 64, 128])
+@pytest.mark.parametrize("n,k", [(512, 1024), (2048, 4096)])
+def test_fold_matches_bf16_decomposition(m, n, k):
+    torch.manual_seed(m + n + k)
+    x = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    w = torch.randn(n, k, dtype=torch.bfloat16, device="cuda") / (k**0.5)
+
+    x_global = ((448.0 * 6.0) / x.float().abs().max()).reshape(1).cuda()
+    act_fp4, act_sf = scaled_fp4_quant_mext_r1(x, x_global, layout_mode="row_pair")
+
+    w_packed, w_sf_swz, w_global = quantize_nvfp4_weight(w)
+    alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+
+    out = run_fold(
+        MAJOR,
+        MINOR,
+        w_packed,
+        act_fp4,
+        w_sf_swz.view(torch.float8_e4m3fn),
+        act_sf.view(torch.float8_e4m3fn),
+        alpha,
+        torch.bfloat16,
+    )
+    assert out.shape == (m, n)
+
+    # Reference: dequantize both operands and contract in fp32. The fold sums
+    # the (base, residue) row pair before the weight contraction.
+    r = torch.arange(m, device="cuda")
+    act_sf_grid = sf_unswizzle(act_sf, 2 * m, k)
+    a_base = decode_fp4(act_fp4[base_row(r, m, 1)]) * act_sf_grid[
+        base_row(r, m, 1)
+    ].repeat_interleave(16, dim=1)
+    a_res = decode_fp4(act_fp4[residue_row(r, m, 1)]) * act_sf_grid[
+        residue_row(r, m, 1)
+    ].repeat_interleave(16, dim=1)
+    a_deq = (a_base + a_res) / x_global
+    w_deq = dequant_nvfp4_weight(w_packed, w_sf_swz, w_global)
+
+    ref = a_deq @ w_deq.T
+
+    rel = (out.float() - ref).norm() / ref.norm()
+    assert rel < 5e-3, f"fold vs decomposition rel err {rel:.2e} (m={m} n={n} k={k})"
+
+
+def test_warmup_compiles_static_table():
+    count = warmup(MAJOR, MINOR)
+    assert count > 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/kernels/ops/gemm/test_residue_nvfp4_linear.py
+++ b/test/registered/kernels/ops/gemm/test_residue_nvfp4_linear.py
@@ -1,0 +1,363 @@
+"""GPU tests for the opaque residue NVFP4 linear op (mext_r1 + plain paths).
+
+The op must produce the same math regardless of which internal chain M
+dispatches to: the CuTeDSL fold at decode M, the two-GEMM pair-sum above the
+fold band, and the plain chain for layers without residue.
+"""
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+if torch.cuda.get_device_capability()[0] != 10:
+    pytest.skip("sm100/sm103 (datacenter Blackwell) required", allow_module_level=True)
+pytest.importorskip("cutlass", reason="nvidia-cutlass-dsl required")
+pytest.importorskip("flashinfer", reason="flashinfer required")
+
+from sglang.kernels.ops.gemm.residue_nvfp4_linear import (
+    RESIDUE_MEXT_R1,
+    RESIDUE_NONE,
+    fold_max_m_for,
+    nvfp4_linear,
+    residue_kind_of,
+)
+from sglang.test.kernels.residue_nvfp4 import (
+    dequant_nvfp4_weight,
+    quantize_nvfp4_weight,
+    sf_unswizzle,
+    swizzle_scale,
+)
+
+
+def test_residue_kind_disambiguation():
+    assert residue_kind_of(0, False) == RESIDUE_NONE
+    assert residue_kind_of(0, True) == RESIDUE_MEXT_R1
+    assert residue_kind_of(512, True) == RESIDUE_MEXT_R1
+    assert residue_kind_of(512, False) == "k_ext"
+
+
+def _make_layer(n, k, seed=0):
+    torch.manual_seed(seed)
+    w = torch.randn(n, k, dtype=torch.bfloat16, device="cuda") / (k**0.5)
+    w_packed, w_sf, w_global = quantize_nvfp4_weight(w)
+    return w, w_packed, w_sf.view(torch.float8_e4m3fn), w_global
+
+
+def _call_op_mext_r1(x, w_packed, w_sf, x_global, w_global):
+    alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+    placeholder_mask = x.new_zeros(1, dtype=torch.uint8)
+    return nvfp4_linear(
+        x,
+        w_packed,
+        x_global.reshape(1),
+        w_sf,
+        w_sf,  # full scale doubles as base scale for mext_r1
+        placeholder_mask,
+        alpha,
+        int(w_packed.shape[1] * 2),  # k_base == full K
+        0,  # num_salient
+        0,  # weights_padding_cols
+        int(w_packed.shape[0]),
+        True,  # fold_eligible
+        True,  # is_mext_r1
+    )
+
+
+@pytest.mark.parametrize("m", [1, 8, 64, 128, 256, 512])
+def test_mext_r1_matches_reference_at_every_m(m):
+    """Below fold_max_m the op takes the fold; above it the two-GEMM path.
+    Both must apply the residue -- the error vs the BF16 reference must stay
+    at second-order (residue-corrected) magnitude at EVERY M."""
+    n, k = 2048, 4096
+    w, w_packed, w_sf, w_global = _make_layer(n, k)
+    torch.manual_seed(m)
+    x = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    x_global = ((448.0 * 6.0) / x.float().abs().max()).cuda()
+
+    out = _call_op_mext_r1(x, w_packed, w_sf, x_global, w_global)
+    assert out.shape == (m, n)
+
+    w_deq = dequant_nvfp4_weight(w_packed, w_sf.view(torch.uint8), w_global)
+    ref = x.float() @ w_deq.T
+
+    # The activation is residue-corrected, so the dominant error is the
+    # weight quantization; base+residue keeps the activation contribution
+    # second-order. Compare against plain-NVFP4-activation error.
+    from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
+
+    x_fp4, x_sf = fp4_quantize(x, x_global.reshape(1))
+    from sglang.srt.layers.quantization.modelopt_quant import fp4_gemm
+
+    alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+    out_plain = fp4_gemm(x_fp4, w_packed.T, x_sf, w_sf.T, alpha, torch.bfloat16, n)
+
+    err_residue = (out.float() - ref).norm() / ref.norm()
+    err_plain = (out_plain.float() - ref).norm() / ref.norm()
+    assert err_residue < 0.8 * err_plain, (
+        f"m={m}: residue path not better than plain "
+        f"(residue={err_residue:.5f} plain={err_plain:.5f})"
+    )
+
+
+def test_mext_r1_fold_and_two_gemm_agree():
+    """The fold (decode band) and two-GEMM (above the band) chains are the
+    same linear form; forcing the same input through both via the M threshold
+    must give closely matching outputs."""
+    n, k = 1024, 2048
+    _, w_packed, w_sf, w_global = _make_layer(n, k, seed=7)
+    fold_m = fold_max_m_for("sm100")
+    m = fold_m  # in-band -> fold
+    torch.manual_seed(99)
+    x = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    x_global = ((448.0 * 6.0) / x.float().abs().max()).cuda()
+
+    out_fold = _call_op_mext_r1(x, w_packed, w_sf, x_global, w_global)
+
+    # Same rows replicated past the band -> two-GEMM path; the first m rows
+    # must agree with the fold output.
+    x_big = torch.cat([x, x], dim=0)
+    out_two = _call_op_mext_r1(x_big, w_packed, w_sf, x_global, w_global)[:m]
+
+    rel = (out_fold.float() - out_two.float()).norm() / out_two.float().norm()
+    assert rel < 2e-2, f"fold vs two_gemm rel err {rel:.2e}"
+
+
+def test_plain_kind_matches_stock_gemm():
+    n, k = 1024, 2048
+    _, w_packed, w_sf, w_global = _make_layer(n, k, seed=3)
+    m = 16
+    torch.manual_seed(5)
+    x = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    x_global = ((448.0 * 6.0) / x.float().abs().max()).cuda()
+    alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+    placeholder_mask = x.new_zeros(1, dtype=torch.uint8)
+
+    out = nvfp4_linear(
+        x,
+        w_packed,
+        x_global.reshape(1),
+        w_sf,
+        w_sf,
+        placeholder_mask,
+        alpha,
+        0,
+        0,
+        0,
+        n,
+        False,  # not fold eligible
+        False,  # not mext_r1
+    )
+
+    from sglang.srt.layers.quantization.fp4_utils import fp4_quantize
+    from sglang.srt.layers.quantization.modelopt_quant import fp4_gemm
+
+    x_fp4, x_sf = fp4_quantize(x, x_global.reshape(1))
+    ref = fp4_gemm(x_fp4, w_packed.T, x_sf, w_sf.T, alpha, torch.bfloat16, n)
+
+    torch.testing.assert_close(out, ref, rtol=0, atol=0)
+
+
+def test_mext_r1_never_falls_through_to_plain():
+    n, k = 512, 1024
+    _, w_packed, w_sf, w_global = _make_layer(n, k, seed=1)
+    x = torch.randn(4, k, dtype=torch.bfloat16, device="cuda")
+    x_global = torch.tensor(1.0, device="cuda")
+    alpha = torch.ones(1, device="cuda")
+    with pytest.raises(RuntimeError, match="mext_r1 layer reached"):
+        nvfp4_linear(
+            x,
+            w_packed,
+            x_global.reshape(1),
+            w_sf,
+            w_sf,
+            x.new_zeros(1, dtype=torch.uint8),
+            alpha,
+            k,
+            0,
+            0,
+            n,
+            False,  # NOT fold eligible -- must raise, not serve plain
+            True,  # is_mext_r1
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))
+
+
+# ── k_ext (extended-K) dispatch ──────────────────────────────────────────────
+
+
+def test_k_ext_matches_extended_decomposition():
+    """The k_ext chain quantizes [base | residue] and contracts against the
+    K-extended weight; the salient channels' effective precision must beat
+    the plain chain on the same base weight."""
+    from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+        indices_to_channel_masks,
+    )
+
+    n, k, per_block = 1024, 2048, 2
+    num_salient = k * per_block // 8
+    n_ext = k + num_salient
+    torch.manual_seed(21)
+
+    # Build the K-extended weight the exporter would produce:
+    # W_ext = [W | W[:, salient]] so the residue columns re-hit the salient
+    # weight columns.
+    w = torch.randn(n, k, dtype=torch.bfloat16, device="cuda") / (k**0.5)
+    indices = torch.tensor(
+        sorted(i for b in range(0, k, 8) for i in range(b, b + per_block)),
+        device="cuda",
+    )
+    w_ext = torch.cat([w, w[:, indices]], dim=1)
+    w_packed, w_sf, w_global = quantize_nvfp4_weight(w_ext)
+    w_sf = w_sf.view(torch.float8_e4m3fn)
+
+    m = 32
+    x = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    x_global = ((448.0 * 6.0) / x.float().abs().max()).cuda()
+    alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+    masks = indices_to_channel_masks(indices, k)
+
+    out = nvfp4_linear(
+        x,
+        w_packed,
+        x_global.reshape(1),
+        w_sf,
+        w_sf,
+        masks,
+        alpha,
+        k,  # k_base (unused: not fold eligible)
+        num_salient,
+        0,  # weights_padding_cols (n_ext % 32 == 0 here)
+        n,
+        False,  # fold_eligible
+        False,  # is_mext_r1
+    )
+    assert out.shape == (m, n)
+
+    # Reference: BF16 contraction against the dequantized EXTENDED weight,
+    # with the activation's residue-corrected decomposition.
+    w_ext_deq = dequant_nvfp4_weight(w_packed, w_sf.view(torch.uint8), w_global)
+    ref = x.float() @ w_ext_deq[:, :k].T  # base-only reference
+
+    err_kext = (out.float() - ref).norm() / ref.norm()
+    # Sanity band: the residue adds signal beyond the base contraction, so
+    # the difference from base-only must be small but nonzero.
+    assert 1e-5 < err_kext < 0.05, f"k_ext output implausible: {err_kext:.2e}"
+
+    # Plain chain on the base weight for comparison of salient accuracy.
+    w_base_packed, w_base_sf, w_base_global = quantize_nvfp4_weight(w)
+    w_base_sf = w_base_sf.view(torch.float8_e4m3fn)
+    alpha_base = (1.0 / (x_global * w_base_global)).reshape(1).float().cuda()
+    out_plain = nvfp4_linear(
+        x,
+        w_base_packed,
+        x_global.reshape(1),
+        w_base_sf,
+        w_base_sf,
+        x.new_zeros(1, dtype=torch.uint8),
+        alpha_base,
+        0,
+        0,
+        0,
+        n,
+        False,
+        False,
+    )
+
+    # True reference with full-precision operands.
+    true_ref = x.float() @ w.float().T
+    err_res = (out.float() - true_ref).norm() / true_ref.norm()
+    err_pln = (out_plain.float() - true_ref).norm() / true_ref.norm()
+    assert (
+        err_res < err_pln
+    ), f"k_ext not better than plain: kext={err_res:.5f} plain={err_pln:.5f}"
+
+
+def test_k_ext_hybrid_uses_fold_small_m_and_extended_k_large_m():
+    """An extended checkpoint has two valid runtime views of one allocation:
+    base-K strided fold for decode and full K-ext for larger batches."""
+    from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+        indices_to_channel_masks,
+    )
+
+    output_n, padded_n, k, per_block = 1000, 1024, 2048, 2
+    num_salient = k * per_block // 8
+    k_ext = k + num_salient
+    indices = torch.tensor(
+        sorted(i for b in range(0, k, 8) for i in range(b, b + per_block)),
+        device="cuda",
+    )
+    torch.manual_seed(31)
+    w = torch.randn(output_n, k, dtype=torch.bfloat16, device="cuda") / (k**0.5)
+    w_ext = torch.cat([w, w[:, indices]], dim=1)
+    # Match parent PWAL's N-padding contract before quantizing the test weight.
+    w_ext = torch.nn.functional.pad(w_ext, (0, 0, 0, padded_n - output_n))
+    w_packed, w_sf_full, w_global = quantize_nvfp4_weight(w_ext)
+    w_sf_full = w_sf_full.view(torch.float8_e4m3fn)
+
+    raw_sf = sf_unswizzle(w_sf_full.view(torch.uint8), padded_n, k_ext).to(
+        torch.float8_e4m3fn
+    )
+    w_sf_base = swizzle_scale(raw_sf[:, : k // 16])
+    masks = indices_to_channel_masks(indices, k)
+
+    def call(x, *, fold_eligible):
+        x_global = ((448.0 * 6.0) / x.float().abs().max()).cuda()
+        alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+        return nvfp4_linear(
+            x,
+            w_packed,
+            x_global.reshape(1),
+            w_sf_full,
+            w_sf_base,
+            masks,
+            alpha,
+            k,
+            num_salient,
+            0,
+            output_n,
+            fold_eligible,
+            False,
+        )
+
+    # Small M: hybrid must equal a direct fold over the base-prefix VIEW,
+    # including its K-ext row stride, and slice parent N padding away.
+    small_m = min(8, fold_max_m_for("sm100"))
+    x_small = torch.randn(small_m, k, dtype=torch.bfloat16, device="cuda")
+    out_hybrid_small = call(x_small, fold_eligible=True)
+    x_global = ((448.0 * 6.0) / x_small.float().abs().max()).cuda()
+    alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+    out_fold = nvfp4_linear(
+        x_small,
+        w_packed[:, : k // 2],
+        x_global.reshape(1),
+        w_sf_base,
+        w_sf_base,
+        x_small.new_zeros(1, dtype=torch.uint8),
+        alpha,
+        k,
+        0,
+        0,
+        output_n,
+        True,
+        True,
+    )
+    assert out_hybrid_small.shape == (small_m, output_n)
+    torch.testing.assert_close(out_hybrid_small, out_fold, rtol=0, atol=0)
+
+    # Above the crossover: enabling fold eligibility must not change the
+    # existing K-ext result.
+    large_m = fold_max_m_for("sm100") + 1
+    x_large = torch.randn(large_m, k, dtype=torch.bfloat16, device="cuda")
+    out_hybrid_large = call(x_large, fold_eligible=True)
+    out_kext_large = call(x_large, fold_eligible=False)
+    torch.testing.assert_close(out_hybrid_large, out_kext_large, rtol=0, atol=0)

--- a/test/registered/kernels/ops/gemm/test_residue_nvfp4_tp_sim.py
+++ b/test/registered/kernels/ops/gemm/test_residue_nvfp4_tp_sim.py
@@ -1,0 +1,157 @@
+"""Simulated TP=2 coverage for the residue NVFP4 linear op.
+
+Real TP runs need a process group; the sharding MATH does not. Row-parallel
+TP splits the contraction dim and all-reduces partial outputs, so this test
+builds each rank's weight shard exactly the way the loader would (via the
+shard plan's two-range gather for k_ext, contiguous split for mext_r1), runs
+the opaque op per rank, sums the partials, and compares against the
+unsharded run and the full-precision reference.
+"""
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+if torch.cuda.get_device_capability()[0] != 10:
+    pytest.skip("sm100/sm103 (datacenter Blackwell) required", allow_module_level=True)
+pytest.importorskip("cutlass", reason="nvidia-cutlass-dsl required")
+pytest.importorskip("flashinfer", reason="flashinfer required")
+
+from sglang.kernels.ops.gemm.residue_nvfp4_linear import nvfp4_linear
+from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+    indices_to_channel_masks,
+)
+from sglang.srt.layers.quantization.residue_nvfp4.tp import ResidueShardPlan
+from sglang.test.kernels.residue_nvfp4 import quantize_nvfp4_weight
+
+TP = 2
+N, K, PER_BLOCK = 512, 4096, 2
+NUM_SALIENT = K * PER_BLOCK // 8
+K_EXT = K + NUM_SALIENT
+
+
+def salient_indices():
+    return torch.tensor(
+        sorted(i for b in range(0, K, 8) for i in range(b, b + PER_BLOCK)),
+        device="cuda",
+    )
+
+
+def run_kext(x, w_bf16_ext, indices, k_base, num_salient):
+    """Quantize an extended weight and run the op's k_ext chain."""
+    w_packed, w_sf, w_global = quantize_nvfp4_weight(w_bf16_ext)
+    w_sf = w_sf.view(torch.float8_e4m3fn)
+    x_global = ((448.0 * 6.0) / x.float().abs().max()).cuda()
+    alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+    masks = indices_to_channel_masks(indices, k_base)
+    return nvfp4_linear(
+        x,
+        w_packed,
+        x_global.reshape(1),
+        w_sf,
+        w_sf,
+        masks,
+        alpha,
+        k_base,
+        num_salient,
+        0,
+        w_packed.shape[0],
+        False,
+        False,
+    )
+
+
+def test_row_parallel_kext_shards_sum_to_unsharded():
+    torch.manual_seed(0)
+    indices = salient_indices()
+    w = torch.randn(N, K, dtype=torch.bfloat16, device="cuda") / (K**0.5)
+    w_ext = torch.cat([w, w[:, indices]], dim=1)
+    m = 16
+    x = torch.randn(m, K, dtype=torch.bfloat16, device="cuda")
+
+    # Unsharded (TP=1) run.
+    out_full = run_kext(x, w_ext, indices, K, NUM_SALIENT)
+
+    # Per-rank runs: weight shard via the two-range gather, activation via
+    # the contiguous base split, salient indices rebased per rank.
+    out_sum = torch.zeros_like(out_full)
+    for r in range(TP):
+        plan = ResidueShardPlan(K, NUM_SALIENT, TP, r)
+        plan.validate()
+        w_shard = plan.gather(w_ext, scale=1)  # logical channels
+        x_shard = x[:, r * plan.base_shard : (r + 1) * plan.base_shard]
+        local_idx = plan.local_salient_indices(indices.cpu()).cuda()
+        out_sum += run_kext(
+            x_shard, w_shard, local_idx, plan.base_shard, plan.salient_shard
+        )
+
+    ref = x.float() @ w.float().T
+    err_full = (out_full.float() - ref).norm() / ref.norm()
+    err_sum = (out_sum.float() - ref).norm() / ref.norm()
+
+    # Per-rank quantization is independent, so bitwise equality is not
+    # expected -- but the sharded run must stay in the same error band as
+    # the unsharded one (the silent-corruption failure mode is off by ~100%).
+    assert err_sum < 2.0 * err_full + 5e-3, (
+        f"TP={TP} row-parallel k_ext error band violated: "
+        f"sharded={err_sum:.5f} unsharded={err_full:.5f}"
+    )
+
+
+def test_row_parallel_mext_r1_shards_sum_to_unsharded():
+    from sglang.kernels.ops.quantization.residue_nvfp4_quant import (  # noqa: F401  (op path exercises it)
+        scaled_fp4_quant_mext_r1,
+    )
+
+    torch.manual_seed(1)
+    w = torch.randn(N, K, dtype=torch.bfloat16, device="cuda") / (K**0.5)
+    m = 8
+    x = torch.randn(m, K, dtype=torch.bfloat16, device="cuda")
+
+    def run_mext(x_part, w_part):
+        w_packed, w_sf, w_global = quantize_nvfp4_weight(w_part)
+        w_sf = w_sf.view(torch.float8_e4m3fn)
+        x_global = ((448.0 * 6.0) / x_part.float().abs().max()).cuda()
+        alpha = (1.0 / (x_global * w_global)).reshape(1).float().cuda()
+        return nvfp4_linear(
+            x_part,
+            w_packed,
+            x_global.reshape(1),
+            w_sf,
+            w_sf,
+            x_part.new_zeros(1, dtype=torch.uint8),
+            alpha,
+            w_part.shape[1],
+            0,
+            0,
+            w_packed.shape[0],
+            True,
+            True,
+        )
+
+    out_full = run_mext(x, w)
+    out_sum = torch.zeros_like(out_full)
+    for r in range(TP):
+        # mext_r1 weights shard like stock NVFP4: contiguous K split.
+        w_shard = w[:, r * (K // TP) : (r + 1) * (K // TP)]
+        x_shard = x[:, r * (K // TP) : (r + 1) * (K // TP)]
+        out_sum += run_mext(x_shard.contiguous(), w_shard.contiguous())
+
+    ref = x.float() @ w.float().T
+    err_full = (out_full.float() - ref).norm() / ref.norm()
+    err_sum = (out_sum.float() - ref).norm() / ref.norm()
+    assert err_sum < 2.0 * err_full + 5e-3, (
+        f"TP={TP} row-parallel mext_r1 error band violated: "
+        f"sharded={err_sum:.5f} unsharded={err_full:.5f}"
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/kernels/ops/quantization/test_residue_nvfp4_quant.py
+++ b/test/registered/kernels/ops/quantization/test_residue_nvfp4_quant.py
@@ -1,0 +1,304 @@
+"""GPU parity tests for the residue NVFP4 mext_r1 activation quantization.
+
+Everything is checked against a pure-torch oracle: FP4 e2m1 nibbles are
+decoded through a LUT, the swizzled fp8-e4m3 scale bytes are de-swizzled with
+the tiled-layout gather formula, and the base+residue reconstruction is
+compared to the original activation. The residue must reduce the
+reconstruction error by a large factor -- that property (not bit-exactness of
+a re-derived oracle) is the contract the fold GEMM relies on.
+"""
+
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+if not torch.cuda.is_available():
+    pytest.skip("CUDA required", allow_module_level=True)
+if torch.cuda.get_device_capability()[0] not in (10, 12):
+    pytest.skip("Blackwell (SM100/SM103/SM120) required", allow_module_level=True)
+
+from sglang.kernels.ops.quantization.residue_nvfp4_quant import (
+    MEXT_R1_LAYOUT_CONCAT,
+    MEXT_R1_LAYOUT_CONCAT_K,
+    MEXT_R1_LAYOUT_ROW_PAIR,
+    scaled_fp4_quant_mext_r1,
+)
+from sglang.test.kernels.residue_nvfp4 import (
+    base_row,
+    decode_fp4,
+    residue_row,
+    sf_unswizzle,
+)
+
+
+def dequant_rows(
+    data: torch.Tensor, sf: torch.Tensor, rows: torch.Tensor, scale_val: float
+) -> torch.Tensor:
+    """Dequantize the selected rows: code * SF / SFScale."""
+    vals = decode_fp4(data[rows])
+    sfs = sf[rows].repeat_interleave(16, dim=1)
+    return vals * sfs / scale_val
+
+
+def reconstruct(
+    x: torch.Tensor,
+    layout_mode: int,
+    scale: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return (base_only, base_plus_residue) reconstructions of x."""
+    m, k = x.shape
+    data, sf_bytes = scaled_fp4_quant_mext_r1(x, scale, layout_mode=layout_mode)
+    out_m = (
+        data.shape[0] // 2 if layout_mode != MEXT_R1_LAYOUT_CONCAT_K else data.shape[0]
+    )
+    r = torch.arange(m, device=x.device)
+    s_base = float(scale[0])
+
+    if layout_mode == MEXT_R1_LAYOUT_CONCAT_K:
+        sf = sf_unswizzle(sf_bytes, out_m, 2 * k)
+        vals = decode_fp4(data)  # [out_m, 2K]
+        sfs = sf.repeat_interleave(16, dim=1)
+        base = vals[:m, :k] * sfs[:m, :k] / s_base
+        residue = vals[:m, k:] * sfs[:m, k:] / s_base
+        return base, base + residue
+
+    sf = sf_unswizzle(sf_bytes, 2 * out_m, k)
+    base = dequant_rows(data, sf, base_row(r, out_m, layout_mode), s_base)
+    residue = dequant_rows(data, sf, residue_row(r, out_m, layout_mode), s_base)
+    return base, base + residue
+
+
+LAYOUTS = [
+    ("concat", MEXT_R1_LAYOUT_CONCAT),
+    ("row_pair", MEXT_R1_LAYOUT_ROW_PAIR),
+    ("concat_k", MEXT_R1_LAYOUT_CONCAT_K),
+]
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("m", [1, 8, 64, 129])
+@pytest.mark.parametrize("k", [512, 4096])
+@pytest.mark.parametrize("layout_name,layout_mode", LAYOUTS)
+def test_reconstruction_accuracy(dtype, m, k, layout_name, layout_mode):
+    torch.manual_seed(m * k + layout_mode)
+    x = torch.randn(m, k, dtype=dtype, device="cuda")
+    xf = x.float()
+    amax = xf.abs().max()
+    scale = ((448.0 * 6.0) / amax).reshape(1).float().cuda()
+
+    base, full = reconstruct(x, layout_mode, scale)
+
+    err_base = (base - xf).norm() / xf.norm()
+    err_full = (full - xf).norm() / xf.norm()
+
+    # Plain NVFP4 relative error is a few percent; the residue must cut it by
+    # a large factor (second-order quantization error).
+    assert err_base < 0.10, f"base-only error too large: {err_base:.4f}"
+    assert err_full < 0.35 * err_base, (
+        f"residue does not improve reconstruction: "
+        f"base={err_base:.5f} full={err_full:.5f} ({layout_name})"
+    )
+
+
+@pytest.mark.parametrize("elts_mode", [8, 16])
+def test_pack8_pack16_equivalent_reconstruction(elts_mode):
+    """pack8 vs pack16 differ in SF granularity only at the thread level; both
+    must reconstruct within the same tolerance and produce identical shapes."""
+    torch.manual_seed(0)
+    m, k = 32, 2048
+    x = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    scale = torch.tensor([448.0 * 6.0 / x.float().abs().max()], device="cuda")
+
+    data, sf = scaled_fp4_quant_mext_r1(
+        x, scale, layout_mode="row_pair", elts_mode=elts_mode
+    )
+    assert data.shape == (2 * m, k // 2)
+
+    r = torch.arange(m, device="cuda")
+    sf_grid = sf_unswizzle(sf, 2 * m, k)
+    s = float(scale[0])
+    base = dequant_rows(data, sf_grid, base_row(r, m, MEXT_R1_LAYOUT_ROW_PAIR), s)
+    res = dequant_rows(data, sf_grid, residue_row(r, m, MEXT_R1_LAYOUT_ROW_PAIR), s)
+    err = ((base + res) - x.float()).norm() / x.float().norm()
+    assert err < 0.02, f"elts_mode={elts_mode} reconstruction error {err:.5f}"
+
+
+def test_layouts_hold_identical_row_data():
+    """All layouts hold the same base/residue data in different positions."""
+    torch.manual_seed(1)
+    m, k = 16, 1024
+    x = torch.randn(m, k, dtype=torch.bfloat16, device="cuda")
+    scale = torch.tensor([448.0 * 6.0 / x.float().abs().max()], device="cuda")
+
+    r = torch.arange(m, device="cuda")
+    rows = {}
+    for name, mode in LAYOUTS:
+        data, _ = scaled_fp4_quant_mext_r1(x, scale, layout_mode=mode)
+        if mode == MEXT_R1_LAYOUT_CONCAT_K:
+            rows[name] = (data[:, : k // 2], data[:, k // 2 :])
+        else:
+            rows[name] = (data[base_row(r, m, mode)], data[residue_row(r, m, mode)])
+
+    ref_base, ref_res = rows["concat"]
+    for name in ("row_pair", "concat_k"):
+        got_base, got_res = rows[name]
+        assert torch.equal(ref_base, got_base), f"{name}: base rows differ"
+        assert torch.equal(ref_res, got_res), f"{name}: residue rows differ"
+
+
+def test_scalar_input_scale_matches_single_element_vector():
+    """ModelOpt per-tensor scales are 0-D parameters in real checkpoints."""
+    torch.manual_seed(4)
+    x = torch.randn(7, 512, dtype=torch.bfloat16, device="cuda")
+    scalar_scale = (448.0 * 6.0 / x.float().abs().max()).float()
+
+    scalar_data, scalar_sf = scaled_fp4_quant_mext_r1(
+        x, scalar_scale, layout_mode="row_pair"
+    )
+    vector_data, vector_sf = scaled_fp4_quant_mext_r1(
+        x, scalar_scale.reshape(1), layout_mode="row_pair"
+    )
+
+    assert torch.equal(scalar_data, vector_data)
+    # The swizzled allocation includes padding bytes outside the logical
+    # [2M, K/16] scale grid; only compare the initialized logical entries.
+    scalar_sf_grid = sf_unswizzle(scalar_sf, 2 * x.shape[0], x.shape[1])
+    vector_sf_grid = sf_unswizzle(vector_sf, 2 * x.shape[0], x.shape[1])
+    assert torch.equal(scalar_sf_grid, vector_sf_grid)
+
+
+def test_rejects_bad_k():
+    x = torch.randn(4, 24, dtype=torch.bfloat16, device="cuda")
+    scale = torch.ones(1, device="cuda")
+    with pytest.raises(ValueError, match="K % 16"):
+        scaled_fp4_quant_mext_r1(x, scale)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))
+
+
+# ── k_ext (selective residue) parity ─────────────────────────────────────────
+
+from sglang.kernels.ops.quantization.residue_nvfp4_quant import (  # noqa: E402
+    indices_to_channel_masks,
+    scaled_fp4_quant_with_mask,
+)
+
+
+def salient_indices_for(k: int, per_block: int) -> torch.Tensor:
+    """Top-`per_block` channels of every 8-channel block (exporter shape)."""
+    idx = [i for b in range(0, k, 8) for i in range(b, b + per_block)]
+    return torch.tensor(sorted(idx), dtype=torch.int64, device="cuda")
+
+
+def kext_reconstruct(x, num_salient, indices, elts_mode):
+    """(base_only, base_plus_residue) reconstructions via the k_ext op."""
+    m, k = x.shape
+    n_ext = k + num_salient
+    scale = torch.tensor([448.0 * 6.0 / x.float().abs().max()], device="cuda")
+    masks = indices_to_channel_masks(indices, k)
+    data, sf_bytes = scaled_fp4_quant_with_mask(
+        x, scale, masks, num_salient, elts_mode=elts_mode
+    )
+    assert data.shape == (m, n_ext // 2)
+
+    s = float(scale[0])
+    sf = sf_unswizzle(sf_bytes, (m + 127) // 128 * 128, n_ext)[:m]
+    vals = decode_fp4(data)  # [m, n_ext]
+    deq = vals * sf.repeat_interleave(16, dim=1) / s
+
+    base = deq[:, :k]
+    residue = deq[:, k:]
+    full = base.clone()
+    # The g-th salient channel (global sorted order) lands at extension
+    # position g -- per-block-uniform selection makes this ordering exact.
+    full[:, indices] += residue
+    return base, full
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize("per_block,ratio", [(1, 0.125), (2, 0.25), (4, 0.5)])
+@pytest.mark.parametrize("elts_mode", ["auto", 8, 16])
+@pytest.mark.parametrize("m", [1, 33, 256])
+def test_kext_reconstruction(dtype, per_block, ratio, elts_mode, m):
+    k = 2048
+    num_salient = int(k * ratio)
+    torch.manual_seed(per_block * m)
+    x = torch.randn(m, k, dtype=dtype, device="cuda")
+    xf = x.float()
+    indices = salient_indices_for(k, per_block)
+
+    base, full = kext_reconstruct(x, num_salient, indices, elts_mode)
+
+    err_base = (base - xf).norm() / xf.norm()
+    err_sal_base = (base[:, indices] - xf[:, indices]).norm() / xf[:, indices].norm()
+    err_sal_full = (full[:, indices] - xf[:, indices]).norm() / xf[:, indices].norm()
+
+    assert err_base < 0.10, f"base reconstruction too lossy: {err_base:.4f}"
+    # The residue must sharply improve the SALIENT channels.
+    assert err_sal_full < 0.35 * err_sal_base, (
+        f"residue does not improve salient channels: "
+        f"base={err_sal_base:.5f} full={err_sal_full:.5f} "
+        f"(ratio={ratio}, elts={elts_mode}, m={m})"
+    )
+
+
+def test_kext_pack8_pack16_bitwise_identical():
+    """pack16 is a thread-mapping change only; output must be bit-identical
+    to pack8 (same data bytes, same SF placement)."""
+    k, per_block = 2048, 2
+    num_salient = k * per_block // 8
+    torch.manual_seed(11)
+    x = torch.randn(64, k, dtype=torch.bfloat16, device="cuda")
+    scale = torch.tensor([448.0 * 6.0 / x.float().abs().max()], device="cuda")
+    masks = indices_to_channel_masks(salient_indices_for(k, per_block), k)
+
+    d8, s8 = scaled_fp4_quant_with_mask(x, scale, masks, num_salient, elts_mode=8)
+    d16, s16 = scaled_fp4_quant_with_mask(x, scale, masks, num_salient, elts_mode=16)
+    assert torch.equal(d8, d16), "pack8 vs pack16 data bytes differ"
+    # SF buffers cover (M_pad, n_ext); rows beyond M are uninitialized in
+    # both, so compare the decoded in-range grid.
+    m, n_ext = x.shape[0], k + num_salient
+    g8 = sf_unswizzle(s8, (m + 127) // 128 * 128, n_ext)[:m]
+    g16 = sf_unswizzle(s16, (m + 127) // 128 * 128, n_ext)[:m]
+    assert torch.equal(g8, g16), "pack8 vs pack16 SF grids differ"
+
+
+def test_kext_scalar_input_scale_matches_single_element_vector():
+    """Real ModelOpt checkpoints store per-tensor scales as 0-D parameters."""
+    k, per_block = 2048, 1
+    num_salient = k * per_block // 8
+    torch.manual_seed(12)
+    x = torch.randn(33, k, dtype=torch.bfloat16, device="cuda")
+    scalar_scale = (448.0 * 6.0 / x.float().abs().max()).float()
+    masks = indices_to_channel_masks(salient_indices_for(k, per_block), k)
+
+    scalar_data, scalar_sf = scaled_fp4_quant_with_mask(
+        x, scalar_scale, masks, num_salient
+    )
+    vector_data, vector_sf = scaled_fp4_quant_with_mask(
+        x, scalar_scale.reshape(1), masks, num_salient
+    )
+
+    assert torch.equal(scalar_data, vector_data)
+    n_ext = k + num_salient
+    scalar_sf_grid = sf_unswizzle(scalar_sf, 128, n_ext)[: x.shape[0]]
+    vector_sf_grid = sf_unswizzle(vector_sf, 128, n_ext)[: x.shape[0]]
+    assert torch.equal(scalar_sf_grid, vector_sf_grid)
+
+
+def test_kext_rejects_unsupported_ratio():
+    k = 2048
+    x = torch.randn(4, k, dtype=torch.bfloat16, device="cuda")
+    scale = torch.ones(1, device="cuda")
+    masks = torch.zeros(k // 8, dtype=torch.uint8, device="cuda")
+    with pytest.raises(ValueError, match="ratio 1.0 is mext_r1"):
+        scaled_fp4_quant_with_mask(x, scale, masks, k)  # ratio 1.0
+    with pytest.raises(ValueError, match="Unsupported salient ratio"):
+        scaled_fp4_quant_with_mask(x, scale, masks, k * 3 // 8)

--- a/test/registered/unit/layers/quantization/test_fp8_moe_runner_fallback.py
+++ b/test/registered/unit/layers/quantization/test_fp8_moe_runner_fallback.py
@@ -1,0 +1,64 @@
+import sys
+from types import SimpleNamespace
+
+from sglang.srt.layers.moe import MoeRunnerBackend, MoeRunnerConfig
+from sglang.srt.layers.quantization import fp8
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+
+def test_flashinfer_cutlass_falls_back_to_triton_for_native_fp8(monkeypatch):
+    created = []
+    warnings = []
+
+    class StubRunner:
+        def __init__(self, backend, config):
+            self.runner_backend = backend
+            self.config = config
+            created.append(self)
+
+    monkeypatch.setattr(
+        fp8,
+        "get_moe_runner_backend",
+        lambda: MoeRunnerBackend.FLASHINFER_CUTLASS,
+    )
+    monkeypatch.setattr(fp8, "MoeRunner", StubRunner)
+    monkeypatch.setattr(fp8, "print_warning_once", warnings.append)
+
+    method = object.__new__(fp8.Fp8MoEMethod)
+    method.quant_config = SimpleNamespace(force_triton_moe_runner=True)
+    config = MoeRunnerConfig()
+    method.create_moe_runner(layer=None, moe_runner_config=config)
+
+    assert len(created) == 1
+    assert method.runner is created[0]
+    assert method.runner.runner_backend is MoeRunnerBackend.TRITON
+    assert method.runner.config is config
+    assert warnings and "native FP8 experts" in warnings[0]
+
+
+def test_stock_fp8_does_not_enable_mtp_runner_fallback(monkeypatch):
+    created = []
+
+    class StubRunner:
+        def __init__(self, backend, config):
+            created.append((backend, config))
+
+    monkeypatch.setattr(
+        fp8,
+        "get_moe_runner_backend",
+        lambda: MoeRunnerBackend.FLASHINFER_CUTLASS,
+    )
+    monkeypatch.setattr(fp8, "MoeRunner", StubRunner)
+
+    method = object.__new__(fp8.Fp8MoEMethod)
+    method.quant_config = SimpleNamespace()
+    method.create_moe_runner(layer=None, moe_runner_config=MoeRunnerConfig())
+
+    assert not created
+    assert not hasattr(method, "runner")
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/test/registered/unit/layers/quantization/test_residue_nvfp4_config.py
+++ b/test/registered/unit/layers/quantization/test_residue_nvfp4_config.py
@@ -1,0 +1,489 @@
+"""CPU tests for residue NVFP4 config selection and stock-path guards.
+
+These run without a GPU: they cover the checkpoint-driven wrap
+(residue_kernel_metadata.json next to the weights selects the residue
+config), the explicit --quantization modelopt_fp4_residue contract, and
+that layers without residue metadata resolve to stock-behaving methods.
+"""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from sglang.srt.layers.quantization import (
+    BASE_QUANTIZATION_METHODS,
+    get_quantization_config,
+)
+from sglang.srt.layers.quantization.modelopt_quant import (
+    ModelOptFp4Config,
+    ModelOptFp4LinearMethod,
+    ModelOptFp8LinearMethod,
+    ModelOptMixedPrecisionConfig,
+)
+from sglang.srt.layers.quantization.residue_nvfp4 import (
+    METADATA_FILENAME,
+    ResidueMetadataError,
+    ResidueMode,
+)
+from sglang.srt.layers.quantization.residue_nvfp4.config import (
+    ModelOptFp4ResidueConfig,
+    ModelOptMixedPrecisionResidueConfig,
+    maybe_wrap_residue_fp4_config,
+)
+from sglang.srt.layers.quantization.residue_nvfp4.linear_method import (
+    ModelOptFp4ResidueLinearMethod,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+K = 4096
+
+
+def make_fp4_config() -> ModelOptFp4Config:
+    return ModelOptFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo="auto",
+        group_size=16,
+        exclude_modules=["lm_head"],
+        packed_modules_mapping={},
+    )
+
+
+def make_mixed_config() -> ModelOptMixedPrecisionConfig:
+    return ModelOptMixedPrecisionConfig.from_config(
+        {
+            "quant_algo": "MIXED_PRECISION",
+            "quantized_layers": {
+                "model.layers.0.self_attn.q_proj": {
+                    "quant_algo": "NVFP4",
+                    "group_size": 16,
+                },
+                "model.layers.0.self_attn.k_proj": {
+                    "quant_algo": "NVFP4",
+                    "group_size": 16,
+                },
+                "model.layers.0.self_attn.v_proj": {
+                    "quant_algo": "NVFP4",
+                    "group_size": 16,
+                },
+                "model.layers.0.fp8_proj": {"quant_algo": "FP8"},
+            },
+            "packed_modules_mapping": {"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+        }
+    )
+
+
+def write_metadata(model_dir, layers=None):
+    layers = layers or {
+        "model.layers.0.self_attn.q_proj": {
+            "salient_indices": list(range(K)),
+            "num_salient": K,
+            "runtime_mode": "mext_r1",
+        }
+    }
+    (model_dir / METADATA_FILENAME).write_text(
+        json.dumps(
+            {"layers": layers, "global": {"residue_ratio": 1.0, "block_size": 8}}
+        )
+    )
+
+
+def model_config_for(path, quantization="modelopt_fp4"):
+    return SimpleNamespace(model_path=str(path), quantization=quantization)
+
+
+class TestRegistry:
+    def test_residue_method_registered(self):
+        assert (
+            BASE_QUANTIZATION_METHODS["modelopt_fp4_residue"]
+            is ModelOptFp4ResidueConfig
+        )
+        assert (
+            get_quantization_config("modelopt_fp4_residue") is ModelOptFp4ResidueConfig
+        )
+
+    def test_from_config_alone_refuses(self):
+        with pytest.raises(ResidueMetadataError, match="metadata"):
+            ModelOptFp4ResidueConfig.from_config({"quant_algo": "NVFP4"})
+
+
+class TestCheckpointDrivenWrap:
+    def test_metadata_present_wraps(self, tmp_path):
+        write_metadata(tmp_path)
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path), make_fp4_config()
+        )
+        assert isinstance(cfg, ModelOptFp4ResidueConfig)
+        spec = cfg.residue_spec.spec_for("model.layers.0.self_attn.q_proj")
+        assert spec.mode is ResidueMode.MEXT_R1
+        # Parent fields survive the wrap.
+        assert cfg.group_size == 16
+        assert cfg.exclude_modules == ["lm_head"]
+
+    def test_metadata_absent_returns_stock_config(self, tmp_path):
+        base = make_fp4_config()
+        cfg = maybe_wrap_residue_fp4_config(model_config_for(tmp_path), base)
+        assert cfg is base
+        assert not isinstance(cfg, ModelOptFp4ResidueConfig)
+
+    def test_broken_metadata_raises_never_falls_back(self, tmp_path):
+        (tmp_path / METADATA_FILENAME).write_text("{not json")
+        with pytest.raises(ResidueMetadataError):
+            maybe_wrap_residue_fp4_config(model_config_for(tmp_path), make_fp4_config())
+
+    def test_explicit_name_requires_metadata(self, tmp_path):
+        with pytest.raises(ResidueMetadataError, match="no residue"):
+            maybe_wrap_residue_fp4_config(
+                model_config_for(tmp_path, "modelopt_fp4_residue"),
+                make_fp4_config(),
+            )
+
+    def test_explicit_name_with_metadata_wraps(self, tmp_path):
+        write_metadata(tmp_path)
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path, "modelopt_fp4_residue"), make_fp4_config()
+        )
+        assert isinstance(cfg, ModelOptFp4ResidueConfig)
+
+    def test_non_fp4_config_passes_through(self, tmp_path):
+        write_metadata(tmp_path)
+        other = object()
+        assert maybe_wrap_residue_fp4_config(model_config_for(tmp_path), other) is other
+
+    def test_awq_checkpoint_rejected(self, tmp_path):
+        write_metadata(tmp_path)
+        base = make_fp4_config()
+        base.is_awq = True
+        with pytest.raises(ResidueMetadataError, match="AWQ"):
+            maybe_wrap_residue_fp4_config(model_config_for(tmp_path), base)
+
+
+class TestMixedPrecisionCheckpointDrivenWrap:
+    def test_metadata_present_wraps_outer_mixed_config(self, tmp_path):
+        write_metadata(tmp_path)
+        base = make_mixed_config()
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path, "modelopt_mixed"), base
+        )
+
+        assert isinstance(cfg, ModelOptMixedPrecisionResidueConfig)
+        assert isinstance(cfg.nvfp4_config, ModelOptFp4ResidueConfig)
+        assert cfg.fp8_config is base.fp8_config
+        assert cfg.nvfp4a16_config is base.nvfp4a16_config
+        assert cfg.mtp_quant_config is base.mtp_quant_config
+
+    def test_metadata_absent_returns_stock_mixed_config(self, tmp_path):
+        base = make_mixed_config()
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path, "modelopt_mixed"), base
+        )
+        assert cfg is base
+
+    def test_only_dense_nvfp4_is_intercepted(self, tmp_path):
+        from sglang.srt.layers.linear import ReplicatedLinear
+
+        write_metadata(tmp_path)
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path, "modelopt_mixed"), make_mixed_config()
+        )
+        layer = ReplicatedLinear.__new__(ReplicatedLinear)
+
+        qkv_method = cfg.get_quant_method(layer, "model.layers.0.self_attn.qkv_proj")
+        assert isinstance(qkv_method, ModelOptFp4ResidueLinearMethod)
+        assert qkv_method.layer_spec is not None
+        assert qkv_method.layer_spec.mode is ResidueMode.MEXT_R1
+
+        fp8_method = cfg.get_quant_method(layer, "model.layers.0.fp8_proj")
+        assert type(fp8_method) is ModelOptFp8LinearMethod
+
+    def test_metadata_less_nvfp4_dense_layer_keeps_exact_stock_method(self, tmp_path):
+        from sglang.srt.layers.linear import ReplicatedLinear
+
+        write_metadata(tmp_path)
+        base = make_mixed_config()
+        base.quantized_layers["model.layers.1.down_proj"] = {
+            "quant_algo": "NVFP4",
+            "group_size": 16,
+        }
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path, "modelopt_mixed"), base
+        )
+        layer = ReplicatedLinear.__new__(ReplicatedLinear)
+        method = cfg.get_quant_method(layer, "model.layers.1.down_proj")
+
+        assert type(method) is ModelOptFp4LinearMethod
+
+    def test_non_linear_module_matches_stock_mixed_config(self, tmp_path):
+        import torch
+
+        write_metadata(tmp_path)
+        base = make_mixed_config()
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path, "modelopt_mixed"), base
+        )
+        layer = torch.nn.Module()
+        prefix = "model.layers.0.self_attn.qkv_proj"
+        assert cfg.get_quant_method(layer, prefix) == base.get_quant_method(
+            layer, prefix
+        )
+
+
+class TestMethodResolution:
+    def _residue_config(self, tmp_path):
+        write_metadata(tmp_path)
+        return maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path), make_fp4_config()
+        )
+
+    def test_residue_layer_gets_residue_method(self, tmp_path):
+        cfg = self._residue_config(tmp_path)
+        method = ModelOptFp4ResidueLinearMethod(cfg, "model.layers.0.self_attn.q_proj")
+        assert method.layer_spec is not None
+        assert method.layer_spec.mode is ResidueMode.MEXT_R1
+        assert method.layer_spec.k_base == K
+
+    def test_fused_qkv_resolves_through_parts(self, tmp_path):
+        cfg = self._residue_config(tmp_path)
+        method = ModelOptFp4ResidueLinearMethod(
+            cfg, "model.layers.0.self_attn.qkv_proj"
+        )
+        assert method.layer_spec is not None
+
+    def test_layer_without_metadata_is_stock(self, tmp_path):
+        cfg = self._residue_config(tmp_path)
+        method = ModelOptFp4ResidueLinearMethod(cfg, "model.layers.0.mlp.down_proj")
+        assert method.layer_spec is None
+        # Stock-path guard: every stage delegates to the parent class.
+        assert isinstance(method, ModelOptFp4LinearMethod)
+        assert type(method).process_weights_after_loading.__qualname__.startswith(
+            "ModelOptFp4ResidueLinearMethod"
+        )
+
+    def test_k_ext_layer_resolves(self):
+        n_sal = K // 4
+        indices = sorted(i for b in range(0, K, 8) for i in range(b, b + 2))
+        import tempfile
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as d:
+            tmp_path = Path(d)
+            (tmp_path / METADATA_FILENAME).write_text(
+                json.dumps(
+                    {
+                        "layers": {
+                            "model.layers.0.mlp.up_proj": {
+                                "salient_indices": indices,
+                                "num_salient": n_sal,
+                                "runtime_mode": "extended_k",
+                            }
+                        },
+                        "global": {"residue_ratio": 0.25, "block_size": 8},
+                        "extended_linear_dims": {
+                            "model.layers.0.mlp.up_proj": K + n_sal
+                        },
+                    }
+                )
+            )
+            cfg = maybe_wrap_residue_fp4_config(
+                model_config_for(tmp_path), make_fp4_config()
+            )
+            method = ModelOptFp4ResidueLinearMethod(cfg, "model.layers.0.mlp.up_proj")
+            assert method.layer_spec.mode is ResidueMode.K_EXT
+            assert method.layer_spec.k_ext == K + n_sal
+            assert method.layer_spec.residue_per_block == 2
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))
+
+
+class TestKExtCreateWeights:
+    """create_weights must size the k_ext weight to the EXTENDED K (per rank),
+    and install the two-range shard plan on row-parallel layers."""
+
+    def _method(self, tmp_path, n_sal=K // 4):
+        import torch  # noqa: F401
+
+        indices = sorted(i for b in range(0, K, 8) for i in range(b, b + 2))
+        (tmp_path / METADATA_FILENAME).write_text(
+            json.dumps(
+                {
+                    "layers": {
+                        "l.down_proj": {
+                            "salient_indices": indices,
+                            "num_salient": n_sal,
+                            "runtime_mode": "extended_k",
+                        }
+                    },
+                    "global": {"residue_ratio": 0.25, "block_size": 8},
+                    "extended_linear_dims": {"l.down_proj": K + n_sal},
+                }
+            )
+        )
+        cfg = maybe_wrap_residue_fp4_config(
+            model_config_for(tmp_path), make_fp4_config()
+        )
+        return ModelOptFp4ResidueLinearMethod(cfg, "l.down_proj")
+
+    def test_column_parallel_gets_full_extension(self, tmp_path):
+        import torch
+
+        method = self._method(tmp_path)
+        layer = torch.nn.Module()
+        method.create_weights(
+            layer,
+            input_size_per_partition=K,
+            output_partition_sizes=[512],
+            input_size=K,
+            output_size=512,
+            params_dtype=torch.bfloat16,
+        )
+        n_ext = K + K // 4
+        assert layer.weight.shape == (512, n_ext // 2)
+        assert layer.weight_scale.shape == (512, n_ext // 16)
+        assert getattr(layer, "_residue_shard_plan", None) is None
+
+    def test_row_parallel_gets_sharded_extension_and_plan(self, tmp_path):
+        import torch
+
+        def dummy_loader(param, loaded_weight, *args, **kwargs):
+            return None
+
+        method = self._method(tmp_path)
+        layer = torch.nn.Module()
+        method.create_weights(
+            layer,
+            input_size_per_partition=K // 2,
+            output_partition_sizes=[512],
+            input_size=K,
+            output_size=512,
+            params_dtype=torch.bfloat16,
+            weight_loader=dummy_loader,
+        )
+        n_ext_shard = (K + K // 4) // 2
+        assert layer.weight.shape == (512, n_ext_shard // 2)
+        plan = layer._residue_shard_plan
+        assert plan is not None and plan.tp_size == 2
+        # The loaders were wrapped for the extended-column permutation.
+        assert layer.weight.weight_loader is not dummy_loader
+        assert layer.weight_scale.weight_loader is not dummy_loader
+
+    def test_standard_layer_weight_shape_unchanged(self, tmp_path):
+        import torch
+
+        method = self._method(tmp_path)
+        # Different prefix -> no residue spec -> stock contract.
+        method_std = ModelOptFp4ResidueLinearMethod(method.quant_config, "l.other_proj")
+        layer = torch.nn.Module()
+        method_std.create_weights(
+            layer,
+            input_size_per_partition=K,
+            output_partition_sizes=[512],
+            input_size=K,
+            output_size=512,
+            params_dtype=torch.bfloat16,
+        )
+        assert layer.weight.shape == (512, K // 2)
+
+    def test_pwal_prepares_base_k_fold_layout(self, tmp_path, monkeypatch):
+        """K-ext keeps the full scale for prefill and derives a separately
+        swizzled base-prefix scale for decode fold before parent PWAL can
+        overwrite the raw Parameter storage."""
+        import torch
+
+        method = self._method(tmp_path)
+        n = 130
+        k_ext = K + K // 4
+        layer = torch.nn.Module()
+        layer.weight = torch.zeros(n, k_ext // 2, dtype=torch.uint8)
+        layer.weight_scale = torch.ones(n, k_ext // 16, dtype=torch.float8_e4m3fn)
+
+        full_scale_marker = torch.empty(1, dtype=torch.float8_e4m3fn)
+
+        def fake_parent_pwal(_self, target):
+            # Simulate both parent effects relevant to the residue method:
+            # aliasing destroys the raw-scale contents and N gets padded.
+            target.weight_scale.zero_()
+            target.weight = torch.zeros(160, k_ext // 2, dtype=torch.uint8)
+            target.weight_scale_interleaved = full_scale_marker
+            target.weights_padding_cols = 0
+
+        monkeypatch.setattr(
+            ModelOptFp4LinearMethod,
+            "process_weights_after_loading",
+            fake_parent_pwal,
+        )
+
+        seen = {}
+
+        def fake_swizzle(scale):
+            seen["raw_base"] = scale.clone()
+            return torch.full_like(scale, 2)
+
+        import sglang.srt.layers.quantization.utils as quant_utils
+
+        monkeypatch.setattr(quant_utils, "swizzle_blockscale", fake_swizzle)
+
+        import sglang.srt.layers.quantization.residue_nvfp4.warmup as warmup
+
+        monkeypatch.setattr(
+            warmup,
+            "register_fold_shape",
+            lambda *args, **kwargs: seen.setdefault("shape", (args, kwargs)),
+        )
+
+        method.process_weights_after_loading(layer)
+
+        assert seen["raw_base"].shape == (n, K // 16)
+        assert torch.all(seen["raw_base"].float() == 1)
+        assert layer.weight_scale_interleaved is full_scale_marker
+        assert layer.weight_scale_base.shape == (n, K // 16)
+        assert layer._mext_decode_k_base == K
+        assert layer._residue_fold_eligible is True
+        assert seen["shape"] == ((160, K, k_ext), {"is_mext_r1": False})
+
+
+class TestStockSurfaceGuard:
+    """Attention, MoE, embeddings, and excluded layers must resolve exactly as
+    the stock modelopt_fp4 config resolves them -- the residue override only
+    intercepts LinearBase."""
+
+    def _cfg_pair(self, tmp_path):
+        write_metadata(tmp_path)
+        base = make_fp4_config()
+        wrapped = maybe_wrap_residue_fp4_config(model_config_for(tmp_path), base)
+        return base, wrapped
+
+    def test_non_linear_module_defers_to_parent(self, tmp_path):
+        import torch
+
+        base, wrapped = self._cfg_pair(tmp_path)
+        plain_module = torch.nn.Module()
+        assert wrapped.get_quant_method(plain_module, "model.layers.0.foo") == (
+            base.get_quant_method(plain_module, "model.layers.0.foo")
+        )
+
+    def test_excluded_linear_matches_parent(self, tmp_path):
+        from sglang.srt.layers.linear import ReplicatedLinear
+
+        base, wrapped = self._cfg_pair(tmp_path)
+        # lm_head is in exclude_modules for both configs.
+        layer = ReplicatedLinear.__new__(ReplicatedLinear)
+        got = wrapped.get_quant_method(layer, "lm_head")
+        want = base.get_quant_method(layer, "lm_head")
+        assert type(got) is type(want)
+
+    def test_metadata_less_linear_gets_residue_method_with_stock_behavior(
+        self, tmp_path
+    ):
+        from sglang.srt.layers.linear import ReplicatedLinear
+
+        _, wrapped = self._cfg_pair(tmp_path)
+        layer = ReplicatedLinear.__new__(ReplicatedLinear)
+        method = wrapped.get_quant_method(layer, "model.layers.5.mlp.down_proj")
+        assert isinstance(method, ModelOptFp4ResidueLinearMethod)
+        assert method.layer_spec is None  # stock delegation

--- a/test/registered/unit/layers/quantization/test_residue_nvfp4_metadata.py
+++ b/test/registered/unit/layers/quantization/test_residue_nvfp4_metadata.py
@@ -1,0 +1,321 @@
+"""CPU tests for the residue NVFP4 metadata contract.
+
+No torch, no GPU: the metadata reader is pure Python by design so these run
+anywhere (including the macOS dev host).
+"""
+
+import json
+
+import pytest
+
+from sglang.srt.layers.quantization.residue_nvfp4.metadata import (
+    METADATA_FILENAME,
+    ResidueMetadataError,
+    ResidueMode,
+    layer_name_candidates,
+    load_residue_model_spec,
+    parse_residue_metadata,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+K = 4096  # K_base used throughout; multiple of 16 and of the salient blocks
+
+
+def k_ext_indices(k_base: int, per_block: int) -> list[int]:
+    """Top-`per_block` channels of every 8-channel block, globally sorted --
+    the shape the exporter guarantees."""
+    out = []
+    for block_start in range(0, k_base, 8):
+        out.extend(range(block_start, block_start + per_block))
+    return sorted(out)
+
+
+def k_ext_layer(name: str, k_base: int = K, per_block: int = 2) -> tuple[dict, dict]:
+    indices = k_ext_indices(k_base, per_block)
+    entry = {
+        "salient_indices": indices,
+        "num_salient": len(indices),
+        "runtime_mode": "extended_k",
+    }
+    return entry, {name: k_base + len(indices)}
+
+
+def mext_r1_layer(k_base: int = K) -> dict:
+    return {
+        "salient_indices": list(range(k_base)),
+        "num_salient": k_base,
+        "runtime_mode": "mext_r1",
+    }
+
+
+def make_metadata(layers: dict, extended_dims: dict | None = None, **extra) -> dict:
+    data = {
+        "layers": layers,
+        "global": {"residue_ratio": 0.25, "block_size": 8},
+    }
+    if extended_dims:
+        data["extended_linear_dims"] = extended_dims
+    data.update(extra)
+    return data
+
+
+class TestValidMetadata:
+    def test_k_ext_layer_parses(self):
+        entry, dims = k_ext_layer("model.layers.0.self_attn.q_proj")
+        spec = parse_residue_metadata(
+            make_metadata({"model.layers.0.self_attn.q_proj": entry}, dims)
+        )
+        layer = spec.spec_for("model.layers.0.self_attn.q_proj")
+        assert layer is not None
+        assert layer.mode is ResidueMode.K_EXT
+        assert layer.k_base == K
+        assert layer.num_salient == K // 4
+        assert layer.k_ext == K + K // 4
+        assert layer.ratio == pytest.approx(0.25)
+        assert layer.residue_per_block == 2
+
+    @pytest.mark.parametrize("per_block,ratio", [(1, 0.125), (2, 0.25), (4, 0.5)])
+    def test_all_supported_k_ext_ratios(self, per_block, ratio):
+        entry, dims = k_ext_layer("l", per_block=per_block)
+        spec = parse_residue_metadata(make_metadata({"l": entry}, dims))
+        layer = spec.spec_for("l")
+        assert layer.ratio == pytest.approx(ratio)
+        assert layer.residue_per_block == per_block
+
+    def test_mext_r1_layer_parses(self):
+        spec = parse_residue_metadata(make_metadata({"l": mext_r1_layer()}))
+        layer = spec.spec_for("l")
+        assert layer.mode is ResidueMode.MEXT_R1
+        assert layer.k_base == K
+        assert layer.num_salient == K
+        assert layer.k_ext == K  # weight is NOT extended
+        assert layer.ratio == pytest.approx(1.0)
+        assert layer.salient_indices == ()  # not stored for mext_r1
+
+    def test_unknown_layer_resolves_to_none(self):
+        spec = parse_residue_metadata(make_metadata({"l": mext_r1_layer()}))
+        assert spec.spec_for("other_layer") is None
+
+    def test_standard_entry_is_no_residue(self):
+        spec = parse_residue_metadata(
+            make_metadata({"l": {"runtime_mode": "standard"}})
+        )
+        assert spec.spec_for("l") is None
+
+    def test_moe_all_off_is_accepted(self):
+        spec = parse_residue_metadata(
+            make_metadata(
+                {"l": mext_r1_layer()},
+                moe={
+                    "granularity": "layer",
+                    "layers": {"model.layers.0.mlp": {"impl": "off", "ratio": 0.0}},
+                },
+            )
+        )
+        assert spec.spec_for("l") is not None
+
+
+class TestFusedLayerResolution:
+    def test_candidates(self):
+        assert layer_name_candidates("model.layers.0.self_attn.qkv_proj") == [
+            "model.layers.0.self_attn.qkv_proj",
+            "model.layers.0.self_attn.q_proj",
+            "model.layers.0.self_attn.k_proj",
+            "model.layers.0.self_attn.v_proj",
+        ]
+        assert layer_name_candidates("model.layers.0.mlp.gate_up_proj") == [
+            "model.layers.0.mlp.gate_up_proj",
+            "model.layers.0.mlp.gate_proj",
+            "model.layers.0.mlp.up_proj",
+        ]
+        assert layer_name_candidates("model.layers.1.linear_attn.in_proj_qkvz") == [
+            "model.layers.1.linear_attn.in_proj_qkvz",
+            "model.layers.1.linear_attn.in_proj_qkv",
+            "model.layers.1.linear_attn.in_proj_z",
+        ]
+
+    def test_qkv_resolves_through_parts_when_consistent(self):
+        layers, dims = {}, {}
+        for part in ("q_proj", "k_proj", "v_proj"):
+            entry, d = k_ext_layer(f"m.self_attn.{part}")
+            layers[f"m.self_attn.{part}"] = entry
+            dims.update(d)
+        spec = parse_residue_metadata(make_metadata(layers, dims))
+        fused = spec.spec_for("m.self_attn.qkv_proj")
+        assert fused is not None
+        assert fused.mode is ResidueMode.K_EXT
+        assert fused.name == "m.self_attn.qkv_proj"
+
+    def test_conflicting_parts_raise(self):
+        e1, d1 = k_ext_layer("m.self_attn.q_proj", per_block=2)
+        e2, d2 = k_ext_layer("m.self_attn.k_proj", per_block=4)
+        spec = parse_residue_metadata(
+            make_metadata(
+                {"m.self_attn.q_proj": e1, "m.self_attn.k_proj": e2},
+                {**d1, **d2},
+            )
+        )
+        with pytest.raises(ResidueMetadataError, match="conflicting"):
+            spec.spec_for("m.self_attn.qkv_proj")
+
+    def test_linear_attention_qkvz_resolves_through_split_parts(self):
+        layers, dims = {}, {}
+        for part in ("in_proj_qkv", "in_proj_z"):
+            name = f"m.linear_attn.{part}"
+            entry, d = k_ext_layer(name, per_block=1)
+            layers[name] = entry
+            dims.update(d)
+        spec = parse_residue_metadata(make_metadata(layers, dims))
+        fused = spec.spec_for("m.linear_attn.in_proj_qkvz")
+        assert fused is not None
+        assert fused.mode is ResidueMode.K_EXT
+        assert fused.name == "m.linear_attn.in_proj_qkvz"
+        assert fused.ratio == pytest.approx(0.125)
+
+    def test_linear_attention_qkvz_rejects_conflicting_split_parts(self):
+        qkv, qkv_dims = k_ext_layer("m.linear_attn.in_proj_qkv", per_block=1)
+        z, z_dims = k_ext_layer("m.linear_attn.in_proj_z", per_block=2)
+        spec = parse_residue_metadata(
+            make_metadata(
+                {
+                    "m.linear_attn.in_proj_qkv": qkv,
+                    "m.linear_attn.in_proj_z": z,
+                },
+                {**qkv_dims, **z_dims},
+            )
+        )
+        with pytest.raises(ResidueMetadataError, match="conflicting"):
+            spec.spec_for("m.linear_attn.in_proj_qkvz")
+
+
+class TestRejection:
+    def test_missing_runtime_mode(self):
+        entry, dims = k_ext_layer("l")
+        del entry["runtime_mode"]
+        with pytest.raises(ResidueMetadataError, match="runtime_mode"):
+            parse_residue_metadata(make_metadata({"l": entry}, dims))
+
+    def test_unknown_runtime_mode(self):
+        entry, dims = k_ext_layer("l")
+        entry["runtime_mode"] = "wext_r2"
+        with pytest.raises(ResidueMetadataError, match="unknown runtime_mode"):
+            parse_residue_metadata(make_metadata({"l": entry}, dims))
+
+    def test_unsupported_ratio(self):
+        # 3 per 8-channel block = ratio 0.375, not a supported kernel
+        entry, dims = k_ext_layer("l", per_block=3)
+        with pytest.raises(ResidueMetadataError, match="not supported"):
+            parse_residue_metadata(make_metadata({"l": entry}, dims))
+
+    def test_k_ext_without_extended_dim(self):
+        entry, _ = k_ext_layer("l")
+        with pytest.raises(ResidueMetadataError, match="extended_linear_dims"):
+            parse_residue_metadata(make_metadata({"l": entry}))
+
+    def test_k_ext_num_salient_mismatch(self):
+        entry, dims = k_ext_layer("l")
+        entry["num_salient"] = entry["num_salient"] - 1
+        with pytest.raises(ResidueMetadataError, match="num_salient"):
+            parse_residue_metadata(make_metadata({"l": entry}, dims))
+
+    def test_k_ext_unsorted_indices(self):
+        entry, dims = k_ext_layer("l")
+        entry["salient_indices"][0], entry["salient_indices"][1] = (
+            entry["salient_indices"][1],
+            entry["salient_indices"][0],
+        )
+        with pytest.raises(ResidueMetadataError, match="strictly increasing"):
+            parse_residue_metadata(make_metadata({"l": entry}, dims))
+
+    def test_k_ext_out_of_range_indices(self):
+        entry, dims = k_ext_layer("l")
+        entry["salient_indices"][-1] = K + 5
+        with pytest.raises(ResidueMetadataError, match="out of range"):
+            parse_residue_metadata(make_metadata({"l": entry}, dims))
+
+    def test_mext_r1_with_extended_dim_conflicts(self):
+        with pytest.raises(ResidueMetadataError, match="mext_r1"):
+            parse_residue_metadata(make_metadata({"l": mext_r1_layer()}, {"l": 2 * K}))
+
+    def test_mext_r1_with_partial_indices(self):
+        entry = mext_r1_layer()
+        entry["salient_indices"] = entry["salient_indices"][:-1]
+        entry["num_salient"] = len(entry["salient_indices"])
+        with pytest.raises(ResidueMetadataError):
+            parse_residue_metadata(make_metadata({"l": entry}))
+
+    def test_standard_with_indices_contradicts(self):
+        entry, dims = k_ext_layer("l")
+        entry["runtime_mode"] = "standard"
+        with pytest.raises(ResidueMetadataError, match="contradicts"):
+            parse_residue_metadata(make_metadata({"l": entry}, dims))
+
+    def test_moe_active_impl_rejected(self):
+        with pytest.raises(ResidueMetadataError, match="residue MoE"):
+            parse_residue_metadata(
+                make_metadata(
+                    {"l": mext_r1_layer()},
+                    moe={
+                        "granularity": "layer",
+                        "layers": {
+                            "model.layers.0.mlp": {"impl": "mext_r1", "ratio": 1.0}
+                        },
+                    },
+                )
+            )
+
+    def test_unsupported_block_size(self):
+        data = make_metadata({"l": mext_r1_layer()})
+        data["global"]["block_size"] = 16
+        with pytest.raises(ResidueMetadataError, match="block_size"):
+            parse_residue_metadata(data)
+
+    def test_orphaned_extended_dim(self):
+        with pytest.raises(ResidueMetadataError, match="without a valid residue"):
+            parse_residue_metadata(
+                make_metadata({"l": mext_r1_layer()}, {"ghost_layer": 2 * K})
+            )
+
+    def test_root_not_object(self):
+        with pytest.raises(ResidueMetadataError, match="root"):
+            parse_residue_metadata(["not", "a", "dict"])
+
+    def test_missing_layers_section(self):
+        with pytest.raises(ResidueMetadataError, match="layers"):
+            parse_residue_metadata({"global": {}})
+
+
+class TestFileLoading:
+    def test_absent_file_returns_none(self, tmp_path):
+        assert load_residue_model_spec(tmp_path) is None
+
+    def test_valid_file_loads(self, tmp_path):
+        entry, dims = k_ext_layer("l")
+        (tmp_path / METADATA_FILENAME).write_text(
+            json.dumps(make_metadata({"l": entry}, dims))
+        )
+        spec = load_residue_model_spec(tmp_path)
+        assert spec is not None
+        assert spec.spec_for("l").mode is ResidueMode.K_EXT
+
+    def test_malformed_json_raises_not_falls_back(self, tmp_path):
+        (tmp_path / METADATA_FILENAME).write_text("{not json")
+        with pytest.raises(ResidueMetadataError, match="cannot read"):
+            load_residue_model_spec(tmp_path)
+
+    def test_broken_contract_raises_not_falls_back(self, tmp_path):
+        entry, dims = k_ext_layer("l")
+        del entry["runtime_mode"]
+        (tmp_path / METADATA_FILENAME).write_text(
+            json.dumps(make_metadata({"l": entry}, dims))
+        )
+        with pytest.raises(ResidueMetadataError):
+            load_residue_model_spec(tmp_path)
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/unit/layers/quantization/test_residue_nvfp4_tp.py
+++ b/test/registered/unit/layers/quantization/test_residue_nvfp4_tp.py
@@ -1,0 +1,169 @@
+"""CPU tests for the residue K-extension TP shard plan.
+
+Pure tensor math -- no GPU, no process group. The two-range rule, the
+interleave-for-loader trick, and the rank-local salient rebasing are the
+things that silently corrupt outputs when wrong, so they are pinned here.
+"""
+
+import pytest
+import torch
+
+from sglang.srt.layers.quantization.residue_nvfp4.tp import (
+    ResidueShardPlan,
+    ResidueTPError,
+    interleave_extended_for_tp,
+    plan_from_partition,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+KB = 4096  # K_base
+S = 1024  # num_salient (ratio 0.25)
+
+
+def sorted_block_indices(k_base: int, per_block: int) -> torch.Tensor:
+    return torch.tensor(
+        sorted(i for b in range(0, k_base, 8) for i in range(b, b + per_block)),
+        dtype=torch.int64,
+    )
+
+
+class TestPlanFromPartition:
+    def test_column_parallel_returns_none(self):
+        assert (
+            plan_from_partition(
+                extended_dim=KB + S,
+                input_size_per_partition=KB,
+                input_size=KB,
+                num_salient=S,
+            )
+            is None
+        )
+
+    def test_row_parallel_builds_plan(self):
+        plan = plan_from_partition(
+            extended_dim=KB + S,
+            input_size_per_partition=KB // 2,
+            input_size=KB,
+            num_salient=S,
+            tp_rank=1,
+        )
+        assert plan is not None
+        assert plan.tp_size == 2
+        assert plan.base_shard == KB // 2
+        assert plan.salient_shard == S // 2
+        assert plan.k_ext_shard == (KB + S) // 2
+
+    def test_mismatched_extension_rejected(self):
+        with pytest.raises(ResidueTPError, match="does not match"):
+            plan_from_partition(
+                extended_dim=KB + S + 8,
+                input_size_per_partition=KB // 2,
+                input_size=KB,
+                num_salient=S,
+            )
+
+    def test_ragged_salient_rejected(self):
+        with pytest.raises(ResidueTPError, match="not divisible"):
+            plan_from_partition(
+                extended_dim=KB + S + 1,
+                input_size_per_partition=KB // 2,
+                input_size=KB,
+                num_salient=S + 1,
+            )
+
+
+class TestValidation:
+    def test_boundary_off_sf_group_rejected(self):
+        # base_shard = 96 is a multiple of 8 but not of 128: the shard
+        # boundary would split a residue SF group.
+        plan = ResidueShardPlan(k_base=192, num_salient=48, tp_size=2, tp_rank=0)
+        with pytest.raises(ResidueTPError, match="residue scale-factor group"):
+            plan.validate()
+
+    def test_salient_shard_off_swizzle_grid_rejected(self):
+        # salient_shard = 32 is not a multiple of 64 (SF swizzle tile).
+        plan = ResidueShardPlan(k_base=2048, num_salient=64, tp_size=2, tp_rank=0)
+        with pytest.raises(ResidueTPError, match="swizzled block-scale"):
+            plan.validate()
+
+
+class TestGatherInterleave:
+    def test_gather_covers_disjoint_ranges(self):
+        plan = ResidueShardPlan(k_base=KB, num_salient=S, tp_size=2, tp_rank=1)
+        plan.validate()
+        full = torch.arange(KB + S)
+        shard = plan.gather(full.unsqueeze(0), scale=1)
+        expected = torch.cat(
+            [
+                full[KB // 2 : KB],  # rank 1's base half
+                full[KB + S // 2 : KB + S],  # rank 1's salient half
+            ]
+        )
+        assert torch.equal(shard[0], expected)
+
+    @pytest.mark.parametrize("scale", [1, 2, 16])
+    def test_interleave_then_contiguous_narrow_equals_gather(self, scale):
+        """The whole point of the permutation: after it, the stock loader's
+        contiguous narrow yields exactly the two-range gather per rank."""
+        tp = 2
+        width = (KB + S) // scale
+        full = torch.arange(2 * width).reshape(2, width).float()
+        plan0 = ResidueShardPlan(KB, S, tp, 0)
+        plan0.validate()
+        permuted = interleave_extended_for_tp(full, plan0, scale=scale)
+
+        per_rank = width // tp
+        for r in range(tp):
+            plan_r = ResidueShardPlan(KB, S, tp, r)
+            contiguous = permuted.narrow(-1, r * per_rank, per_rank)
+            gathered = plan_r.gather(full, scale=scale)
+            assert torch.equal(contiguous, gathered), f"rank {r} mismatch"
+
+    def test_interleave_is_rank_free(self):
+        full = torch.arange(KB + S).float()
+        out0 = interleave_extended_for_tp(full, ResidueShardPlan(KB, S, 2, 0), scale=1)
+        out1 = interleave_extended_for_tp(full, ResidueShardPlan(KB, S, 2, 1), scale=1)
+        assert torch.equal(out0, out1)
+
+
+class TestLocalSalient:
+    def test_rebasing(self):
+        plan = ResidueShardPlan(KB, S, 2, 1)
+        plan.validate()
+        indices = sorted_block_indices(KB, 2)
+        local = plan.local_salient_indices(indices)
+        assert local.numel() == S // 2
+        assert local.min() >= 0
+        assert local.max() < plan.base_shard
+        # Rank 1's channels are the global channels shifted down by its base.
+        assert torch.equal(local, indices[S // 2 :] - KB // 2)
+
+    def test_unsorted_indices_rejected(self):
+        plan = ResidueShardPlan(KB, S, 2, 0)
+        indices = sorted_block_indices(KB, 2)
+        shuffled = indices[torch.randperm(indices.numel())]
+        with pytest.raises(ResidueTPError):
+            plan.local_salient_indices(shuffled)
+
+    def test_non_uniform_selection_rejected(self):
+        plan = ResidueShardPlan(KB, S, 2, 0)
+        # All salient channels in the first half: rank 0 would own all of
+        # them, rank 1 none -- the balanced-split contract is broken.
+        indices = torch.arange(S, dtype=torch.int64)
+        with pytest.raises(ResidueTPError, match="owns"):
+            plan.local_salient_indices(indices)
+
+    def test_local_channel_mask_slice(self):
+        plan = ResidueShardPlan(KB, S, 2, 1)
+        full_mask = torch.arange(KB // 8, dtype=torch.uint8)
+        local = plan.local_channel_mask(full_mask)
+        assert local.numel() == KB // 16
+        assert torch.equal(local, full_mask[KB // 16 :])
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/unit/layers/quantization/test_residue_nvfp4_warmup.py
+++ b/test/registered/unit/layers/quantization/test_residue_nvfp4_warmup.py
@@ -1,0 +1,74 @@
+"""CPU tests for the residue fold warmup registry."""
+
+import contextlib
+
+import pytest
+
+from sglang.srt.layers.quantization.residue_nvfp4 import warmup as W
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-c-test-cpu")
+
+
+@pytest.fixture(autouse=True)
+def clean_registry():
+    saved_shapes = set(W._FOLD_SHAPES)
+    saved_flag = W._WARMED_UP
+    W._FOLD_SHAPES.clear()
+    W._WARMED_UP = False
+    yield
+    W._FOLD_SHAPES.clear()
+    W._FOLD_SHAPES.update(saved_shapes)
+    W._WARMED_UP = saved_flag
+
+
+def test_register_and_dedup():
+    W.register_fold_shape(4096, 4096, 4096, True)
+    W.register_fold_shape(4096, 4096, 4096, True)
+    W.register_fold_shape(2048, 4096, 5120, False)
+    assert W.registered_fold_shapes() == frozenset(
+        {(4096, 4096, 4096, True), (2048, 4096, 5120, False)}
+    )
+
+
+def test_warmup_noops_without_registered_shapes():
+    # Must not touch CUDA or import the fold package on a plain checkpoint.
+    assert W.maybe_warmup_residue_fold() == 0
+
+
+def test_observer_noops_without_registered_shapes():
+    ctx = W.observe_residue_fold_compiles("test")
+    assert isinstance(ctx, contextlib.nullcontext)
+    with ctx:
+        pass
+
+
+def test_warmup_is_idempotent(monkeypatch):
+    calls = []
+
+    def fake_warmup(major, minor, shapes=None):
+        calls.append((major, minor, tuple(shapes)))
+        return 3
+
+    import sglang.kernels.ops.gemm.residue_fold as rf
+
+    monkeypatch.setattr(rf, "warmup", fake_warmup)
+    monkeypatch.setattr(W, "_precompile_tuner_candidates", lambda major, shapes: 0)
+
+    class _Cap:
+        @staticmethod
+        def get_device_capability():
+            return (10, 0)
+
+    monkeypatch.setattr(W.torch, "cuda", _Cap)
+
+    W.register_fold_shape(4096, 4096, 4096, True)
+    assert W.maybe_warmup_residue_fold() == 3
+    assert W.maybe_warmup_residue_fold() == 0  # second call is a no-op
+    assert len(calls) == 1
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-q"]))

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -696,6 +696,49 @@ class TestModelOptFp4LoaderSelection(CustomTestCase):
 
 
 class TestModelOptMixedPrecisionConfig(CustomTestCase):
+    def test_qwen_embedded_mtp_can_use_independent_block_fp8(self):
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.layers.0.self_attn.q_proj": {
+                        "quant_algo": "NVFP4",
+                        "group_size": 16,
+                    }
+                },
+                "mtp_quantization_config": {
+                    "quant_method": "fp8",
+                    "activation_scheme": "dynamic",
+                    "weight_block_size": [128, 128],
+                    "modules_to_not_convert": ["mtp.fc", "mtp.norm"],
+                },
+            }
+        )
+
+        self.assertIsInstance(quant_config.mtp_quant_config, Fp8Config)
+        self.assertTrue(quant_config.mtp_quant_config.is_checkpoint_fp8_serialized)
+        self.assertEqual(
+            quant_config.mtp_quant_config.weight_block_size, [128, 128]
+        )
+        self.assertTrue(quant_config.mtp_quant_config.force_triton_moe_runner)
+        self.assertFalse(quant_config.fp8_config.force_triton_moe_runner)
+        self.assertIn("mtp.fc", quant_config.mtp_quant_config.ignored_layers)
+
+    def test_qwen_embedded_mtp_rejects_non_fp8_subconfig(self):
+        with self.assertRaisesRegex(ValueError, "only an FP8"):
+            ModelOptMixedPrecisionConfig.from_config(
+                {
+                    "quant_algo": "MIXED_PRECISION",
+                    "quantized_layers": {
+                        "model.layers.0.self_attn.q_proj": {
+                            "quant_algo": "NVFP4",
+                            "group_size": 16,
+                        }
+                    },
+                    "mtp_quantization_config": {"quant_method": "modelopt_fp4"},
+                }
+            )
+
     def test_fp8_pb_wo_dispatches_to_native_block_fp8(self):
         quant_config = ModelOptMixedPrecisionConfig.from_config(
             {

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -617,6 +617,11 @@ class TestWrapperEntryClassGates(_FusionGateCase):
 
         # The normalization the constructor applies, shared with the gate.
         self.assertIsNone(_mtp_quant_config(_quant("modelopt_mixed")))
+        fp8_mtp = object()
+        mixed_with_fp8_mtp = SimpleNamespace(
+            get_name=lambda: "modelopt_mixed", mtp_quant_config=fp8_mtp
+        )
+        self.assertIs(_mtp_quant_config(mixed_with_fp8_mtp), fp8_mtp)
         serialized = SimpleNamespace(
             get_name=lambda: "modelopt_fp4", is_checkpoint_nvfp4_serialized=True
         )


### PR DESCRIPTION
[Qwen3.8] Support Qwen3.8-Max residue inference

## Summary

Add SGLang inference support for Qwen3.8-Max checkpoints with
residue-enhanced NVFP4 target weights and independently quantized FP8 MTP
weights.

The integration is selected only for compatible checkpoints. Models without
the corresponding configuration continue to use the existing SGLang paths.

## Changes

- Support residue-enhanced NVFP4 dense projections used by Qwen3.8-Max.
- Preserve the existing ModelOpt NVFP4 MoE execution path.
- Support independently quantized FP8 MTP weights with NEXTN speculative
  decoding.
- Support tensor-parallel execution on Blackwell GPUs.

## End-to-end validation

Tested commit:

```text
6f3153b04f58bac60c480129749a6cf88530761b
```

Launch command:

```bash
MODEL_PATH=/path/to/qwen3.8-max

PYTHONUNBUFFERED=1 python3 -m sglang.launch_server \
  --model-path "${MODEL_PATH}" \
  --served-model-name qwen-max \
  --host 0.0.0.0 \
  --port 10000 \
  --tp-size 8 \
  --ep-size 1 \
  --trust-remote-code \
  --quantization modelopt_mixed \
  --dtype bfloat16 \
  --kv-cache-dtype bfloat16 \
  --context-length 262144 \
  --attention-backend trtllm_mha \
  --fp4-gemm-backend flashinfer_cutlass \
  --moe-runner-backend flashinfer_cutlass \
  --mem-fraction-static 0.8 \
  --max-running-requests 128 \
  --chunked-prefill-size 8192 \
  --max-prefill-tokens 8192 \
  --page-size 64 \
  --speculative-algorithm NEXTN \
  --speculative-draft-model-path "${MODEL_PATH}" \
  --speculative-draft-model-quantization modelopt_mixed \
  --speculative-moe-runner-backend triton \
  --speculative-num-steps 3 \
  --speculative-eagle-topk 1 \
  --speculative-num-draft-tokens 4 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --weight-loader-prefetch-checkpoints \
  --weight-loader-prefetch-num-threads 4 \
  --watchdog-timeout 28800
```

Input:

```bash
curl --location 'localhost:10000/v1/chat/completions' \
  --header 'Content-Type: application/json' \
  --data '{
    "messages": [
      {
        "role": "user",
        "content": [
          {
            "type": "image_url",
            "image_url": {
              "url": "https://modelscope.oss-cn-beijing.aliyuncs.com/resource/qwen.png"
            }
          },
          {
            "type": "text",
            "text": "Describe this image."
          }
        ]
      }
    ]
  }'
```

Raw curl output:

```json
{
  "id": "f1a2b56c13c24bf6b97d0f4a4a5e3fd0",
  "object": "chat.completion",
  "created": 1787819963,
  "model": "default",
  "choices": [
    {
      "index": 0,
      "message": {
        "role": "assistant",
        "content": "\n\nThis image is the logo for **Tongyi Qwen (Qwen)**, Alibaba Cloud's large‑model AI brand. It contains two main elements:\n\n- **Left side – graphic emblem:** An abstract, geometric mark made of angular, interlocking ribbon‑like segments arranged with rotational symmetry, forming a hexagon/knot‑shaped figure. It is drawn in outline in a violet‑blue (periwinkle) color.\n- **Right side – wordmark:** Two lines of text. The top line reads \"**TONGYI**\" in bold, uppercase sans‑type in the same violet‑blue as the emblem. Below it, \"**Qwen**\" appears in a larger, gray sans‑typeface.\n\nThe overall design is clean, modern, and tech‑oriented, with the purple symbol and \"TONGYI\" contrasting against the gray \"Qwen,\" all set on a plain dark/transparent background.",
        "reasoning_content": "The user is asking for a description of this image. Let me look at the image carefully.\n\nThe image shows a logo. On the left side, there's a geometric symbol/shape in purple/blue (close to periwinkle or violet blue), which looks like an abstract hexagonal shape composed of interlocking angular segments, seemingly forming a stylized triangular or hexagonal knot pattern.\n\nOn the right side, there's text in two lines:\n- Top line: \"TONGYI\" in purple/blue uppercase letters (same color as the symbol)\n- Bottom line: \"Qwen\" in gray letters, with only the Q capitalized.\n\nThe background is black (or transparent, but appears black in the image... actually, the background looks white? Let me think. The image description says black text? No, the background appears dark/black? Looking at the image, the background is probably white or transparent. The image provided shows a logo on a black background? Hard to judge. Usually, this logo is displayed on a white or transparent background. In the image, the symbol is purple and \"Qwen\" is gray. The background might be transparent, rendered as black or white.\n\nLet me describe it neutrally: The logo of Tongyi Qwen, Alibaba's large language model series. The geometric emblem resembles an abstract hexagon composed of three interlocking angular arrow-like shapes outlined in purple/blue. The text \"TONGYI\" is in purple uppercase, and \"Qwen\" is in gray.\n\nI should describe the layout, colors, and typography. I might also mention that this is the branding for Qwen (Tongyi Qianwen), Alibaba Cloud's AI model.\n\nLet me look at the shape in a bit more detail: it looks like a stylized hexagram composed of three bent angular ribbons forming a triangular rotation pattern, outlined in purple with a black fill (or transparent fill). The lines are angular, giving a geometric, techy impression.\n\nThe background of the image seems to be black (the interior of the symbol looks black). Actually, the symbol is outline-only, and the interior might be transparent/black. Since the overall image background is likely transparent, it may be displayed as black in some viewers. I'll just say the background appears dark/black, or just say the logo is on a plain background.\n\nTo be safe: \"On a dark (black) background...\" Hmm, but if it's transparent, describing it as black might be wrong. The image shown in the conversation likely has a black background because the transparency renders as black. I could say \"the background appears black (possibly transparency rendered as black).\"\n\nLet me think about what's most accurate: the image is likely a PNG with transparency. In the rendered image, the background might be white. I can't be sure. I'll describe it as: \"The logo is displayed against a plain background.\"\n\nBetter to focus on the elements: geometric mark on the left, wordmark on the right.\n\nLet me write the description:\n\n- Left: An abstract geometric emblem composed of interlocking angular segments outlined in violet blue, forming a hexagonal/triangular knot-like shape.\n- Right: Two lines of text: \"TONGYI\" in bold uppercase sans-serif in the same violet blue; below it, \"Qwen\" in a gray sans-serif font, larger in size.\n- This is the logo for Tongyi Qwen (Qwen), the large language model developed by Alibaba Cloud.\n\nI might also mention the color codes: purple roughly #6B5BFF or similar periwinkle. Gray is roughly #6E6E6E.\n\nFormat: The user asked to \"describe this image.\" A short paragraph or a few bullet points would be appropriate. A concise description of a few sentences to one paragraph. No special instructions. I'll provide a clear description.\n\nLet me draft:\n\n\"This image shows the logo of Tongyi Qwen (Qwen), the AI large model brand from Alibaba Cloud. On the left is an abstract geometric mark: three angular, arrow-like ribbon segments interlock to form a hexagonal, knot-like emblem, outlined in violet blue. To its right is the wordmark in two lines: 'TONGYI' in bold uppercase sans-serif in the same violet blue, with 'Qwen' below it in a larger gray sans-serif typeface. The design is clean and modern, set against a plain (dark/transparent) background.\"\n\nI need to be careful about asserting the background color. I could say \"against a solid background.\" Or just not mention the background, or say \"the background is black.\" Looking at the image: the symbol's interior is black, and the whole image's background is probably black? The text colors are visible. If the background were white, the interior of the symbol would also be white. In the image, the interior of the symbol looks black, suggesting the background is black/transparent.\n\nI'll say \"the background appears black (likely a transparent PNG rendered on black).\"\n\nHmm, that's speculative. Simpler: \"set against a dark background.\" That should suffice.\n\nFinal answer: a description including the elements. Keep it concise but complete.\n\nLet me double-check the shape once more: does it resemble a Penrose-triangle-style interlocking design? It looks like three chevron/arrow shapes arranged with rotational symmetry forming a hexagonal outline. I'll describe it that way.\n\nFinal answer structure:\n\n1. Overall: logo of Tongyi Qwen.\n2. Emblem description.\n3. Text description.\n4. Colors and style.\n\nLet me write it.\n",
        "tool_calls": null
      },
      "logprobs": null,
      "finish_reason": "stop",
      "matched_stop": 248046
    }
  ],
  "usage": {
    "prompt_tokens": 94,
    "total_tokens": 1463,
    "completion_tokens": 1369,
    "prompt_tokens_details": {
      "cached_tokens": 0,
      "image_tokens": 78
    },
    "reasoning_tokens": 1175
  },
  "metadata": {
    "weight_version": "default",
    "weight_versions": [
      {
        "version": "default",
        "start": 0,
        "end": 1369
      }
    ]
  }
}
```

This is the direct OpenAI-compatible response body returned by the local
SGLang server. The request completed with `finish_reason=stop`; reasoning
remained separate in `reasoning_content`, with no `<think>` tag leakage or
repeated answer.

## Checklist

- [x] TP=8 target-model execution.
- [x] Residue NVFP4 dense-layer execution.
- [x] Existing ModelOpt NVFP4 MoE execution.
- [x] NEXTN execution with independently quantized FP8 MTP weights.
- [x] Multimodal chat-completions request with a remote image.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33059101147](https://github.com/sgl-project/sglang/actions/runs/33059101147)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33059100935](https://github.com/sgl-project/sglang/actions/runs/33059100935)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33059101070](https://github.com/sgl-project/sglang/actions/runs/33059101070)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->