### PR TITLE
[Feature] Accept multiple API keys via comma-separated --api-key

### DIFF
--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1315,7 +1315,7 @@ class ServerArgs:
     # -------------------------------------------------------------------------
     api_key: A[
         Optional[str],
-        "Set API key of the server. It is also used in the OpenAI API compatible server.",
+        "Set API key of the server. It is also used in the OpenAI API compatible server. Accepts a comma-separated list to allow multiple keys; a request bearing any listed key (or the full raw string) is accepted.",
         NS("serving"),
     ] = None
     admin_api_key: A[

--- a/python/sglang/srt/utils/auth.py
+++ b/python/sglang/srt/utils/auth.py
@@ -100,10 +100,10 @@ def decide_request_auth(
     if path.startswith("/health") or path.startswith("/metrics"):
         return AuthDecision(allowed=True)
 
-    def _check_bearer_token(
+    def _check_single_bearer_token(
         authorization_header: Optional[str], expected_token: str
     ) -> bool:
-        """Check bearer token with constant-time comparison."""
+        """Check bearer token against exactly one key (no comma splitting)."""
         if not authorization_header:
             return False
         parts = authorization_header.split(" ", 1)
@@ -111,12 +111,40 @@ def decide_request_auth(
             return False
         return secrets.compare_digest(parts[1], expected_token)
 
+    def _check_bearer_token(
+        authorization_header: Optional[str], expected_token: str
+    ) -> bool:
+        """Check bearer token with constant-time comparison.
+
+        `--api-key` accepts a comma-separated list; a bearer token matching any
+        entry (or the full raw string, so keys containing literal commas and
+        internal clients that send the configured value verbatim keep working)
+        is accepted. `--admin-api-key` stays a single key.
+        """
+        if not authorization_header:
+            return False
+        parts = authorization_header.split(" ", 1)
+        if len(parts) != 2 or parts[0].lower() != "bearer":
+            return False
+        token = parts[1]
+        candidates = [expected_token]
+        if "," in expected_token:
+            candidates.extend(
+                k for k in (p.strip() for p in expected_token.split(",")) if k
+            )
+        # No early exit: identical work for every candidate.
+        matched = False
+        for candidate in candidates:
+            if secrets.compare_digest(token, candidate):
+                matched = True
+        return matched
+
     # Force-auth endpoints: only admin_api_key can unlock them; if admin_api_key is unset,
     # reject them unconditionally (explicitly "not allowed").
     if auth_level == AuthLevel.ADMIN_FORCE:
         if not admin_api_key:
             return AuthDecision(allowed=False, error_status_code=403)
-        if not _check_bearer_token(authorization_header, admin_api_key):
+        if not _check_single_bearer_token(authorization_header, admin_api_key):
             return AuthDecision(allowed=False)
         return AuthDecision(allowed=True)
 
@@ -128,7 +156,7 @@ def decide_request_auth(
     if auth_level == AuthLevel.ADMIN_OPTIONAL:
         if admin_api_key:
             return AuthDecision(
-                allowed=_check_bearer_token(authorization_header, admin_api_key)
+                allowed=_check_single_bearer_token(authorization_header, admin_api_key)
             )
         elif api_key:
             return AuthDecision(

--- a/test/registered/unit/utils/test_auth.py
+++ b/test/registered/unit/utils/test_auth.py
@@ -292,6 +292,90 @@ class TestDecideRequestAuth(CustomTestCase):
         )
         self.assertFalse(decision.allowed)
 
+    # ==================== Multi-Key (comma-separated --api-key) ====================
+
+    def test_normal_multi_key_each_accepted(self):
+        for key in ("key-one", "key-two", "key-three"):
+            decision = decide_request_auth(
+                method="POST",
+                path="/v1/chat/completions",
+                authorization_header=f"Bearer {key}",
+                api_key="key-one,key-two,key-three",
+                admin_api_key=None,
+                auth_level=AuthLevel.NORMAL,
+            )
+            self.assertTrue(decision.allowed, key)
+
+    def test_normal_multi_key_raw_string_accepted(self):
+        # Internal clients (e.g. warmup) send the configured value verbatim;
+        # a legacy key containing a literal comma also keeps working.
+        decision = decide_request_auth(
+            method="POST",
+            path="/v1/chat/completions",
+            authorization_header="Bearer key-one,key-two",
+            api_key="key-one,key-two",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertTrue(decision.allowed)
+
+    def test_normal_multi_key_wrong_rejected(self):
+        decision = decide_request_auth(
+            method="POST",
+            path="/v1/chat/completions",
+            authorization_header="Bearer key-four",
+            api_key="key-one,key-two,key-three",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertFalse(decision.allowed)
+
+    def test_normal_multi_key_whitespace_tolerated(self):
+        decision = decide_request_auth(
+            method="POST",
+            path="/v1/chat/completions",
+            authorization_header="Bearer key-two",
+            api_key="key-one, key-two",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertTrue(decision.allowed)
+
+    def test_normal_multi_key_empty_segment_not_a_key(self):
+        # "key-one," must not admit an empty bearer token
+        decision = decide_request_auth(
+            method="POST",
+            path="/v1/chat/completions",
+            authorization_header="Bearer ",
+            api_key="key-one,",
+            admin_api_key=None,
+            auth_level=AuthLevel.NORMAL,
+        )
+        self.assertFalse(decision.allowed)
+
+    def test_admin_key_never_split(self):
+        # admin_api_key stays a single key even if it contains commas
+        decision = decide_request_auth(
+            method="POST",
+            path="/some_admin_endpoint",
+            authorization_header="Bearer admin-one",
+            api_key=None,
+            admin_api_key="admin-one,admin-two",
+            auth_level=AuthLevel.ADMIN_FORCE,
+        )
+        self.assertFalse(decision.allowed)
+
+    def test_admin_optional_multi_api_key(self):
+        decision = decide_request_auth(
+            method="POST",
+            path="/some_endpoint",
+            authorization_header="Bearer key-two",
+            api_key="key-one,key-two",
+            admin_api_key=None,
+            auth_level=AuthLevel.ADMIN_OPTIONAL,
+        )
+        self.assertTrue(decision.allowed)
+
     def test_bearer_case_insensitive(self):
         decision = decide_request_auth(
             method="POST",


### PR DESCRIPTION
## Motivation

When one SGLang server fronts several consumers (per-user or per-service keys that can be revoked independently), a single `--api-key` forces everyone to share one credential. This adds multi-key support with zero new flags: `--api-key` accepts a comma-separated list, and a request bearing any listed key is accepted.

We run this in production on a DGX Spark pair serving `Qwen3.8-Flash-Next` to multiple internal consumers, each with their own revocable key.

## Modifications

All in `srt/utils/auth.py` (`decide_request_auth` stays pure/unit-testable):

- `_check_bearer_token` now matches the token against each comma-separated entry **and the full raw string**. Keeping the raw string valid matters for two back-compat reasons:
  - internal clients send the configured value verbatim — e.g. the warmup request (`http_server.py` builds `Bearer {server_args.api_key}`), which would otherwise 401 against its own server (we hit exactly this in an earlier internal version of the patch);
  - a legacy key containing a literal comma keeps working unchanged.
- `--admin-api-key` deliberately stays a single key and is never split (new `_check_single_bearer_token`); splitting an admin credential implicitly seemed like a footgun. Happy to extend if maintainers prefer symmetry.
- Whitespace around commas is tolerated; empty segments are dropped (so `"key-one,"` cannot admit an empty bearer token).
- Constant-time comparison per candidate, no early exit on match.
- `--api-key` help text updated.

Single-key behavior is byte-for-byte unchanged (a value without commas produces exactly one candidate, the raw string).

## Checklist

- Unit tests added to `test/registered/unit/utils/test_auth.py`: each listed key accepted, raw string accepted, wrong key rejected, whitespace tolerated, empty segment rejected, admin key never split, `ADMIN_OPTIONAL` multi-key.
- Verified end-to-end on our production deployment (5 keys, all authenticate; warmup self-auth works; keyless `/health` still open).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33059127500](https://github.com/sgl-project/sglang/actions/runs/33059127500)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33059127310](https://github.com/sgl-project/sglang/actions/runs/33059127310)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33059127511](https://github.com/sgl-project/sglang/actions/runs/33059127511)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->