### PR TITLE
[Fix] llama32 detector silently drops leading JSON from message content

### DIFF
--- a/python/sglang/srt/function_call/llama32_detector.py
+++ b/python/sglang/srt/function_call/llama32_detector.py
@@ -57,8 +57,10 @@ class Llama32Detector(BaseFormatDetector):
 
         if "<|python_tag|>" in text:
             normal_text, action_text = text.split("<|python_tag|>", maxsplit=1)
+            has_bot_token = True
         else:
             normal_text, action_text = "", text
+            has_bot_token = False
 
         decoder = json.JSONDecoder()
         idx = 0
@@ -104,6 +106,16 @@ class Llama32Detector(BaseFormatDetector):
 
         # Only process if we found valid JSON objects
         calls = self.parse_base_json(all_actions, tools) if all_actions else []
+
+        # Without the <|python_tag|> marker, a leading "{" is only a heuristic
+        # guess that the model emitted a tool call. When that guess yields no
+        # calls (e.g. the JSON has no "name", or names an undefined tool, so
+        # parse_base_json skips it) the text is ordinary content and must be
+        # returned untouched. Otherwise the consumed objects are silently
+        # dropped: '{}' became '' and '{"a": 1} is a dict' became 'is a dict'.
+        if not calls and not has_bot_token:
+            return StreamingParseResult(normal_text=text, calls=[])
+
         # Use safe_idx to avoid idx containing the last part of an invalid JSON object
         trailing_text = (
             action_text[safe_idx:].strip() if safe_idx < action_text_len else ""

--- a/test/registered/unit/function_call/test_llama32_detector.py
+++ b/test/registered/unit/function_call/test_llama32_detector.py
@@ -100,6 +100,44 @@ class TestLlama32Detector(CustomTestCase):
         self.assertEqual(result.calls[0].name, "get_weather")
         self.assertEqual(result.calls[1].name, "search")
 
+    # ============ Content preservation when no tool call is produced ============
+    # Regression tests: without <|python_tag|>, a leading "{" is only a guess that
+    # a tool call follows. When the guess yields no calls the text must survive
+    # unchanged instead of being silently consumed.
+
+    def test_empty_json_object_is_not_dropped(self):
+        text = "{}"
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_leading_json_object_is_not_dropped(self):
+        text = '{"a": 1} is a dict'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_json_naming_undefined_tool_is_not_dropped(self):
+        text = '{"name": "not_a_registered_tool", "arguments": {}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_json_only_message_is_not_dropped(self):
+        text = '{"status": "ok", "count": 3}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 0)
+        self.assertEqual(result.normal_text, text)
+
+    def test_valid_tool_call_still_consumes_json(self):
+        # Guard against over-correcting: a real call must still be extracted and
+        # must not leak its JSON back into the content.
+        text = '{"name": "get_weather", "arguments": {"city": "Beijing"}}'
+        result = self.detector.detect_and_parse(text, self.tools)
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(result.normal_text, "")
+
     def test_tool_call_with_multiple_arguments(self):
         text = '<|python_tag|>{"name": "get_weather", "arguments": {"city": "London", "unit": "celsius"}}'
         result = self.detector.detect_and_parse(text, self.tools)


### PR DESCRIPTION
## Motivation

Fixes #35562.

Without the `<|python_tag|>` marker, `Llama32Detector.detect_and_parse` treats a leading `{` as a tool-call candidate and consumes the decoded JSON objects from the text. When `parse_base_json` produces **no** calls — the object has no `"name"`, or names a tool that is not registered, so it is skipped — the consumed text was never restored, silently deleting user-visible content:

```
input = '{}'                  ->  content = ''           (whole message gone)
input = '{"a": 1} is a dict'  ->  content = 'is a dict'  (leading JSON gone)
```

Reproducible with no GPU and no server, as noted in the issue:

```python
from sglang.srt.entrypoints.openai.protocol import Function, Tool
from sglang.srt.function_call.function_call_parser import FunctionCallParser

tools = [Tool(type="function", function=Function(name="get_weather", parameters={}))]
parser = FunctionCallParser.ToolCallParserEnum["llama3"]()

result = parser.detect_and_parse('{"a": 1} is a dict', tools)
print(repr(result.normal_text), result.calls)   # before: 'is a dict' []
                                                # after:  '{"a": 1} is a dict' []
```

## Modifications

`python/sglang/srt/function_call/llama32_detector.py`

Return the original text unchanged when the leading-`{` heuristic yields no calls.

The `<|python_tag|>` path is deliberately left untouched: there the model explicitly signalled a tool call, so consuming the marked region stays intentional. The guard only covers the case where detection was a *guess* based on `text.startswith("{")` and that guess did not pan out.

## Tests

`test/registered/unit/function_call/test_llama32_detector.py` — 5 new cases in the existing CPU-registered suite (no GPU, no model load):

- `test_empty_json_object_is_not_dropped` — `'{}'` survives
- `test_leading_json_object_is_not_dropped` — the reported `'{"a": 1} is a dict'` case
- `test_json_naming_undefined_tool_is_not_dropped` — object naming an unregistered tool survives
- `test_json_only_message_is_not_dropped` — a JSON-only message that is not a tool call survives
- `test_valid_tool_call_still_consumes_json` — guards against over-correcting: a genuine call is still extracted and does not leak its JSON back into content

All pre-existing cases in the file (including the `<|python_tag|>`, multi-object, and streaming tests) keep their current expectations and still pass.

## Checklist

- [x] Format the code and add unit tests
- [x] Update documentation as needed — n/a, internal parser behavior

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33059859396](https://github.com/sgl-project/sglang/actions/runs/33059859396)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33059859181](https://github.com/sgl-project/sglang/actions/runs/33059859181)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33059859464](https://github.com/sgl-project/sglang/actions/runs/33059859464)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->