### PR TITLE
remove tuning env switches, hoist lazy imports

### DIFF
--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -959,11 +959,6 @@ class Envs:
     # Enable the allowlisted low-M BF16 Split-K GEMM path on Blackwell. Shapes
     # outside the measured allowlist continue to use CuTe DSL/cuBLAS.
     SGLANG_ENABLE_BF16_SPLITK_GEMM = EnvBool(True)
-    # Route decode-size HC mix through the fused CuTe split-K GEMM pair
-    # instead of the persistent Triton mix.
-    SGLANG_HC_MIX_CUDA = EnvBool(True)
-    # Split the HC combine gate dot across CTAs instead of one CTA per row.
-    SGLANG_HC_COMBINE_SPLIT = EnvBool(True)
     SGLANG_DEEPGEMM_STANDARD_LAYOUT = EnvStr("auto")
     SGLANG_DEEPGEMM_MASKED_MEMORY_BUDGET_FRACTION = EnvFloat(0.25)
     # Cap the DeepGEMM masked grouped-GEMM per-expert padded capacity at

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -962,8 +962,6 @@ class Envs:
     # Route decode-size HC mix through the fused CuTe split-K GEMM pair
     # instead of the persistent Triton mix.
     SGLANG_HC_MIX_CUDA = EnvBool(True)
-    # Log each distinct (m, n, k) the BF16 GEMM dispatch sees (allowlist tuning).
-    SGLANG_BF16_GEMM_LOG_SHAPES = EnvBool(False)
     # Split the HC combine gate dot across CTAs instead of one CTA per row.
     SGLANG_HC_COMBINE_SPLIT = EnvBool(True)
     SGLANG_DEEPGEMM_STANDARD_LAYOUT = EnvStr("auto")

--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -22,6 +22,10 @@ from sglang.srt.layers.attention.qsa.config import (
     is_qwen_qsa,
     parse_qsa_profile,
 )
+from sglang.srt.layers.attention.qsa.graph_metadata import (
+    launch_graph_metadata,
+    supports_graph_metadata_kernels,
+)
 from sglang.srt.layers.attention.qsa.kernel import qsa_sparse_attention
 from sglang.srt.layers.attention.qsa.metadata import (
     QSAIndexerMetadata,
@@ -38,6 +42,7 @@ from sglang.srt.layers.attention.qsa.sparse_attn import (
     sparse_gqa_fwd_interface_triton_ck,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.utils import is_sm100_supported, is_sm121
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +58,6 @@ def _resolve_trtllm_sparse_decode():
     at decode row counts; the trtllm-gen decode kernel over a page-aligned
     scratch measures ~35% faster for the gather+attention pair.
     """
-    from sglang.srt.utils import is_sm100_supported, is_sm121
-
     if not (is_sm100_supported() or is_sm121()):
         return None
     try:
@@ -1078,10 +1081,6 @@ class QwenSparseAttnBackend(AttentionBackend):
     def _can_replay_with_gpu_kernels(self, metadata, seq_lens) -> bool:
         if self.req_to_token is None:
             return False
-        from sglang.srt.layers.attention.qsa.graph_metadata import (
-            supports_graph_metadata_kernels,
-        )
-
         return seq_lens.is_cuda and supports_graph_metadata_kernels(
             metadata.indexer_metadata.token_to_kv_pool, seq_lens.device
         )
@@ -1131,10 +1130,6 @@ class QwenSparseAttnBackend(AttentionBackend):
         then rebuild every per-row graph buffer on-GPU from lengths plus
         the sidecar — no allocation, no reserve, no copy-on-write.
         """
-
-        from sglang.srt.layers.attention.qsa.graph_metadata import (
-            launch_graph_metadata,
-        )
 
         indexer = metadata.indexer_metadata
         pool = indexer.token_to_kv_pool

--- a/python/sglang/srt/layers/hyperconnection.py
+++ b/python/sglang/srt/layers/hyperconnection.py
@@ -151,14 +151,11 @@ class GatedResidual(HyperConnectionBase):
                 device=torch.cuda.current_device(),
                 dtype=config.params_dtype,
             )
-            from sglang.srt.environ import envs
-
             lowrank = self.config.hc_lowrank
             self._jit_mix_ok = (
-                envs.SGLANG_HC_MIX_CUDA.get()
-                and torch.cuda.is_available()
-                # The CuTe split-K pair is tcgen05 (sm_100 family) only; the
-                # default-on env must not route Hopper/Ada to it.
+                torch.cuda.is_available()
+                # The CuTe split-K pair is tcgen05 (sm_100 family) only; do not
+                # route Hopper/Ada to it.
                 and torch.cuda.get_device_capability()[0] == 10
                 and (self.hc_count * self.hidden_size) % 2048 == 0
                 and self.hidden_size % 8 == 0
@@ -182,12 +179,9 @@ class GatedResidual(HyperConnectionBase):
                 self.hidden_size % 8 == 0
                 and (self.hc_count * self.hidden_size) % 2048 == 0
             )
-            from sglang.srt.environ import envs
-
             vecs = self.hc_count * self.hidden_size // 8
             self._split_combine_ok = (
-                envs.SGLANG_HC_COMBINE_SPLIT.get()
-                and self._jit_combine_ok
+                self._jit_combine_ok
                 and vecs % (8 * 160) == 0
                 and (self.hidden_size // 8) % (vecs // 8) == 0
             )

--- a/python/sglang/srt/layers/hyperconnection.py
+++ b/python/sglang/srt/layers/hyperconnection.py
@@ -5,6 +5,9 @@ import torch
 import torch.nn as nn
 import torch.nn.functional as F
 
+from sglang.kernels.ops.elementwise.hc_combine import hc_combine, hc_combine_split
+from sglang.kernels.ops.elementwise.hc_mix import hc_mix, permute_pad_up_weight
+from sglang.kernels.ops.layernorm.grouped_gemma_rmsnorm import grouped_gemma_rmsnorm
 from sglang.srt.layers.hc_mix_triton import fused_hc_mix, fused_hc_mix_supported
 
 
@@ -50,10 +53,6 @@ class GroupedGemmaRMSNorm(nn.Module):
             and x.is_cuda
             and x.dtype in (torch.bfloat16, torch.float16)
         ):
-            from sglang.kernels.ops.layernorm.grouped_gemma_rmsnorm import (
-                grouped_gemma_rmsnorm,
-            )
-
             return grouped_gemma_rmsnorm(
                 x, self.weight, self._jit_group_size, self.variance_epsilon
             )
@@ -244,11 +243,6 @@ class GatedResidual(HyperConnectionBase):
             and hyper_input_normed.dtype in (torch.bfloat16, torch.float16)
             and hyper_input_normed.shape[0] <= 24
         ):
-            from sglang.kernels.ops.elementwise.hc_mix import (
-                hc_mix,
-                permute_pad_up_weight,
-            )
-
             if self._mix_up_weight_padded is None:
                 self._mix_up_weight_padded = permute_pad_up_weight(
                     self.input_mix_weight_up.weight, self.hc_count
@@ -298,10 +292,6 @@ class GatedResidual(HyperConnectionBase):
             and self.block_inject_weight.weight.dtype == block_output.dtype
         ):
             if self._split_combine_ok and block_output.shape[0] <= 32:
-                from sglang.kernels.ops.elementwise.hc_combine import (
-                    hc_combine_split,
-                )
-
                 return hc_combine_split(
                     block_output,
                     hyper_input,
@@ -310,8 +300,6 @@ class GatedResidual(HyperConnectionBase):
                     self.hc_count,
                     self.hidden_size,
                 )
-            from sglang.kernels.ops.elementwise.hc_combine import hc_combine
-
             return hc_combine(
                 block_output,
                 hyper_input,

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -39,6 +39,7 @@ from sglang.srt.utils import (
     is_cuda,
     is_hip,
     is_npu,
+    is_sm100_supported,
     set_weight_attrs,
     use_intel_amx_backend,
     use_intel_xpu_backend,
@@ -143,8 +144,6 @@ def initialize_bf16_gemm_config(server_args: ServerArgs) -> None:
     global _BF16_GEMM_BACKEND, _cutedsl_bf16_gemm, _use_cutedsl_bf16_gemm
     global _flashinfer_pr4266_run_splitk_dense, _flashinfer_pr4266_splitk_tactic
     global _enable_bf16_splitk_gemm
-
-    from sglang.srt.utils import is_sm100_supported
 
     backend_str = server_args.bf16_gemm_backend
     if backend_str == "auto" and is_sm100_supported():

--- a/python/sglang/srt/layers/quantization/unquant.py
+++ b/python/sglang/srt/layers/quantization/unquant.py
@@ -87,7 +87,6 @@ _use_cutedsl_bf16_gemm = None
 _flashinfer_pr4266_run_splitk_dense = None
 _flashinfer_pr4266_splitk_tactic = None
 _enable_bf16_splitk_gemm = False
-_logged_bf16_gemm_shapes = set()
 
 # Qwen4-Exp TP4 decode tactics measured on B300 (sm103) under CUDA graph
 # replay against cuBLAS/nvjet with splitKreduce. Every entry beat the
@@ -138,13 +137,6 @@ _FLASHINFER_PR4266_TUNED_TACTICS = {
 
 def use_flashinfer_pr4266_bf16_gemm(m: int, n: int, k: int) -> bool:
     return (m, n, k) in _FLASHINFER_PR4266_TUNED_TACTICS
-
-
-def _log_bf16_gemm_shape(m: int, n: int, k: int) -> None:
-    key = (m, n, k)
-    if key not in _logged_bf16_gemm_shapes:
-        _logged_bf16_gemm_shapes.add(key)
-        logger.info("BF16_GEMM_SHAPE m=%d n=%d k=%d", m, n, k)
 
 
 def initialize_bf16_gemm_config(server_args: ServerArgs) -> None:
@@ -238,8 +230,6 @@ def bf16_gemm_dispatch(
     x: torch.Tensor, weight: torch.Tensor, bias: Optional[torch.Tensor]
 ) -> torch.Tensor:
     m = x.numel() // x.shape[-1]
-    if envs.SGLANG_BF16_GEMM_LOG_SHAPES.get():
-        _log_bf16_gemm_shape(m, weight.shape[0], weight.shape[1])
     if (
         _enable_bf16_splitk_gemm
         and bias is None
@@ -368,8 +358,6 @@ class UnquantizedLinearMethod(LinearMethodBase):
                 # keeping the per-shape kernel choice.
                 return bf16_gemm_dispatch(x, layer.weight, bias)
             m = x.numel() // x.shape[-1]
-            if envs.SGLANG_BF16_GEMM_LOG_SHAPES.get():
-                _log_bf16_gemm_shape(m, layer.weight.shape[0], layer.weight.shape[1])
             if (
                 _enable_bf16_splitk_gemm
                 and bias is None
@@ -400,10 +388,6 @@ class UnquantizedLinearMethod(LinearMethodBase):
         bias: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Run an inference-only BF16 linear into caller-owned storage."""
-        if envs.SGLANG_BF16_GEMM_LOG_SHAPES.get() and x.ndim == 2:
-            _log_bf16_gemm_shape(
-                x.shape[0], layer.weight.shape[0], layer.weight.shape[1]
-            )
         if (
             _enable_bf16_splitk_gemm
             and bias is None

--- a/python/sglang/srt/models/qwen4_exp.py
+++ b/python/sglang/srt/models/qwen4_exp.py
@@ -21,6 +21,12 @@ from sglang.srt.distributed.device_communicators.pynccl_allocator import (
 from sglang.srt.environ import envs
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
 from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.layers.attention.qsa.config import is_qwen_qsa
+from sglang.srt.layers.attention.qsa.glue import (
+    build_qsa_indexer,
+    get_qsa_indexer_metadata,
+    resolve_qsa_sparse_backend,
+)
 from sglang.srt.layers.communicator import get_attn_tp_context
 from sglang.srt.layers.dp_attention import (
     attn_tp_all_gather,
@@ -1439,9 +1445,6 @@ class Qwen4ExpAttentionDecoderLayer(
     ) -> None:
         config.attn_output_gate = True
         super().__init__(config, layer_id, quant_config, prefix, alt_stream, is_nextn)
-        from sglang.srt.layers.attention.qsa.config import is_qwen_qsa
-        from sglang.srt.layers.attention.qsa.glue import build_qsa_indexer
-
         self.is_qsa = is_qwen_qsa(config)
         if self.is_qsa:
             self.indexer = build_qsa_indexer(
@@ -1459,11 +1462,6 @@ class Qwen4ExpAttentionDecoderLayer(
         positions: torch.Tensor,
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
-        from sglang.srt.layers.attention.qsa.glue import (
-            get_qsa_indexer_metadata,
-            resolve_qsa_sparse_backend,
-        )
-
         backend = get_attn_backend()
         sparse_backend = resolve_qsa_sparse_backend(backend)
         should_reuse = getattr(sparse_backend, "should_reuse_mtp_sparse_indices", None)

--- a/python/sglang/srt/speculative/draft_utils.py
+++ b/python/sglang/srt/speculative/draft_utils.py
@@ -1,3 +1,8 @@
+from sglang.srt.layers.attention.qsa.config import (
+    QSA_VARIANT_COMPRESSED,
+    is_qwen_qsa,
+    parse_qsa_profile,
+)
 from sglang.srt.runtime_context import attention_backends, get_spec
 from sglang.srt.utils.common import (
     cpu_has_amx_support,
@@ -108,11 +113,6 @@ class DraftBackendFactory:
 
     def create_draft_extend_backend(self):
         if self._is_qwen_qsa_draft_model():
-            from sglang.srt.layers.attention.qsa.config import (
-                QSA_VARIANT_COMPRESSED,
-                parse_qsa_profile,
-            )
-
             profile = parse_qsa_profile(
                 self.draft_model_runner.model_config.hf_config
             )
@@ -172,8 +172,6 @@ class DraftBackendFactory:
         return wrapped
 
     def _is_qwen_qsa_draft_model(self) -> bool:
-        from sglang.srt.layers.attention.qsa.config import is_qwen_qsa
-
         return is_qwen_qsa(self.draft_model_runner.model_config.hf_config)
 
     def _create_qwen_qsa_decode_backend(self):


### PR DESCRIPTION
### Motivation

Remove three dev-time env switches whose defaults are already the desired behavior:

- `SGLANG_BF16_GEMM_LOG_SHAPES` (off by default): shape-logging aid used during split-K tactic tuning; the allowlist is tuned, re-add from history if more tuning is needed.
- `SGLANG_HC_MIX_CUDA` (on by default): decode HC mix now always prefers the fused CuTe split-K GEMM pair on sm_100, with the persistent Triton mix as the non-sm_100 fallback.
- `SGLANG_HC_COMBINE_SPLIT` (on by default): the split HC combine kernel is selected purely by static shape checks.

No behavior change.

### Modifications

Deleting the switches removes their only reason to be read at call time, so the
lazy imports that guarded them are hoisted to module top level in the files
touched, plus the neighbouring lazy imports in the same call paths:

- `python/sglang/srt/environ.py`: drop the three `EnvBool` declarations.
- `python/sglang/srt/layers/quantization/unquant.py`: drop `_log_bf16_gemm_shape()`, the `_logged_bf16_gemm_shapes` set, and its three call sites; hoist `is_sm100_supported`.
- `python/sglang/srt/layers/hyperconnection.py`: `_jit_mix_ok` / `_split_combine_ok` now depend on static shape and arch checks only. The `device_capability()[0] == 10` guard is kept, so Hopper/Ada still take the Triton path. Hoist `hc_combine`, `hc_combine_split`, `hc_mix`, `permute_pad_up_weight`, `grouped_gemma_rmsnorm`.
- `python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py`, `python/sglang/srt/models/qwen4_exp.py`, `python/sglang/srt/speculative/draft_utils.py`: hoist the QSA lazy imports.

Rebased on top of #36649. That PR widened the same arch gate in
`_resolve_trtllm_sparse_decode()`, so the one conflict is resolved by keeping its
`is_sm100_supported() or is_sm121()` condition and importing both helpers at
module top level:

```python
from sglang.srt.utils import is_sm100_supported, is_sm121
...
if not (is_sm100_supported() or is_sm121()):
    return None
```

### Checklist

- [x] The three env names have no remaining references under `python/`, `test/`, `benchmark/`, `docs/`.
- [x] The hoisted modules do not import back into their importers, and their top level pulls in only `torch` plus the deferred JIT loader, so no import cycle or import-time kernel build is introduced.
- [x] No new API surface; every removed switch was already at its default.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33060683128](https://github.com/sgl-project/sglang/actions/runs/33060683128)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33060682651](https://github.com/sgl-project/sglang/actions/runs/33060682651)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33060683178](https://github.com/sgl-project/sglang/actions/runs/33060683178)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->