### PR TITLE
fix(dspark): use draft expert dtype in mixed checkpoints

### DIFF
--- a/python/sglang/srt/configs/deepseek_v4.py
+++ b/python/sglang/srt/configs/deepseek_v4.py
@@ -52,6 +52,7 @@ class DeepSeekV4Config(PretrainedConfig):
     bos_token_id: int = 0
     eos_token_id: int = 1
     ep_size: int = 1
+    expert_dtype: Optional[str] = None
     first_k_dense_replace: int = 0
     hidden_act: str = "silu"
     hidden_size: int = 4096

--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -165,6 +165,10 @@ def is_deepseek_v4(config) -> bool:
     )
 
 
+def is_dspark_draft_model(config, is_draft_model: bool) -> bool:
+    return is_draft_model and _hf_arch(config) == "DeepseekV4ForCausalLMDSpark"
+
+
 def get_dsa_index_head_dim(config: PretrainedConfig) -> int:
     assert is_deepseek_dsa(config) or is_deepseek_v4(config)
     return config.index_head_dim
@@ -413,6 +417,18 @@ class ModelConfig:
         if is_deepseek_v4(self.hf_config) and routed_experts_quant_method is None:
             self.is_fp4_experts = envs.SGLANG_DSV4_FP4_EXPERTS.get()
             if (
+                is_dspark_draft_model(self.hf_config, self.is_draft_model)
+                and self.hf_config.expert_dtype is not None
+            ):
+                self.is_fp4_experts = self.hf_config.expert_dtype.lower() in (
+                    "fp4",
+                    "mxfp4",
+                )
+                logger.info(
+                    "Detected bundled DSpark draft expert dtype: %s.",
+                    self.hf_config.expert_dtype,
+                )
+            elif (
                 not envs.SGLANG_DSV4_FP4_EXPERTS.is_set()
                 or envs.SGLANG_DSV4_FP4_DEQUANT.is_set()
             ):

--- a/test/registered/unit/configs/test_model_config.py
+++ b/test/registered/unit/configs/test_model_config.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from sglang.srt.configs.model_config import (
     ModelConfig,
     get_hybrid_layer_ids,
+    is_dspark_draft_model,
     is_embedding_gemma,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -54,6 +55,14 @@ class TestEmbeddingGemmaConfig(CustomTestCase):
 
 
 class TestDraftModelConfig(CustomTestCase):
+    def test_dspark_layout_signal_is_draft_only(self):
+        dspark = SimpleNamespace(architectures=["DeepseekV4ForCausalLMDSpark"])
+        target = SimpleNamespace(architectures=["DeepseekV4ForCausalLM"])
+
+        self.assertTrue(is_dspark_draft_model(dspark, True))
+        self.assertFalse(is_dspark_draft_model(dspark, False))
+        self.assertFalse(is_dspark_draft_model(target, True))
+
     def test_qwen35_mtp_depth_is_synced_to_text_config(self):
         config = object.__new__(ModelConfig)
         config.is_draft_model = True


### PR DESCRIPTION
## Summary

The official DeepSeek-V4-Flash-DSpark checkpoint contains FP8 target experts
and packed MXFP4 draft experts in the same bundle.

Previously, the DSpark draft model could reuse the target expert layout
detection and be incorrectly treated as FP8, causing a `32` versus `128`
scale-shape mismatch during weight loading.

This change uses the draft checkpoint `expert_dtype` for
`DeepseekV4ForCausalLMDSpark` draft instances while keeping the existing target
model detection unchanged:

```diff
 self.is_fp4_experts = envs.SGLANG_DSV4_FP4_EXPERTS.get()
-if (
+if (
+    is_dspark_draft_model(self.hf_config, self.is_draft_model)
+    and self.hf_config.expert_dtype is not None
+):
+    self.is_fp4_experts = self.hf_config.expert_dtype.lower() in (
+        "fp4",
+        "mxfp4",
+    )
+elif (
     not envs.SGLANG_DSV4_FP4_EXPERTS.is_set()
     or envs.SGLANG_DSV4_FP4_DEQUANT.is_set()
 ):
```

## Accuracy Tests

The same draft-specific layout selection was smoke-tested on H200 with the
official DSpark bundle over an FP8 target checkpoint. The checkpoint loaded
successfully and early generation requests completed without the expert-scale
shape mismatch.

A CPU unit test covers the draft-only model identification:

```python
def test_dspark_layout_signal_is_draft_only(self):
    dspark = SimpleNamespace(
        architectures=["DeepseekV4ForCausalLMDSpark"]
    )
    target = SimpleNamespace(
        architectures=["DeepseekV4ForCausalLM"]
    )

    self.assertTrue(is_dspark_draft_model(dspark, True))
    self.assertFalse(is_dspark_draft_model(dspark, False))
    self.assertFalse(is_dspark_draft_model(target, True))
```

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33155604070](https://github.com/sgl-project/sglang/actions/runs/33155604070)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33155603815](https://github.com/sgl-project/sglang/actions/runs/33155603815)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33155604046](https://github.com/sgl-project/sglang/actions/runs/33155604046)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->