### PR TITLE
[Fix] Honor iteration settings in fused collective benchmark

### DIFF
--- a/benchmark/kernels/flashinfer_allreduce_fusion/benchmark_fused_collective.py
+++ b/benchmark/kernels/flashinfer_allreduce_fusion/benchmark_fused_collective.py
@@ -68,6 +68,7 @@ except ImportError:
 
 # Constants
 MiB = 1024 * 1024
+_NUM_OPS_PER_CUDAGRAPH = 10
 
 # FlashInfer max sizes per world size
 # Enable 64MB for 2, 4, 8 world sizes to verify large input sizes
@@ -564,10 +565,25 @@ def create_test_tensors(
     )
 
 
+def _validate_benchmark_iterations(warmup: int, trials: int) -> None:
+    if warmup < 0:
+        raise ValueError(f"warmup must be non-negative, got {warmup}")
+    if trials < _NUM_OPS_PER_CUDAGRAPH:
+        raise ValueError(
+            f"trials must be at least {_NUM_OPS_PER_CUDAGRAPH}, got {trials}"
+        )
+    if trials % _NUM_OPS_PER_CUDAGRAPH != 0:
+        raise ValueError(
+            f"trials must be a multiple of {_NUM_OPS_PER_CUDAGRAPH}, got {trials}"
+        )
+
+
 def benchmark_operation(
     operation_func, *args, warmup: int = 5, trials: int = 20, **kwargs
 ):
     """Benchmark a single operation using CUDA graphs."""
+    _validate_benchmark_iterations(warmup, trials)
+
     # Warmup before graph capture
     for _ in range(warmup):
         operation_func(*args, **kwargs)
@@ -575,7 +591,7 @@ def benchmark_operation(
 
     # Create CUDA graph
     graph = torch.cuda.CUDAGraph()
-    num_op_per_cudagraph = 10
+    num_op_per_cudagraph = _NUM_OPS_PER_CUDAGRAPH
 
     # Use sglang's graph_capture to make tensor_model_parallel_all_reduce graph-safe
     with graph_capture() as graph_capture_context:
@@ -592,14 +608,16 @@ def benchmark_operation(
     torch.cuda.synchronize()
     start_time = time.perf_counter()
 
-    for _ in range(trials // num_op_per_cudagraph):
+    num_graph_replays = trials // num_op_per_cudagraph
+    for _ in range(num_graph_replays):
         # operation_func(*args, **kwargs)
         graph.replay()
 
     torch.cuda.synchronize()
     end_time = time.perf_counter()
 
-    avg_time_ms = ((end_time - start_time) / trials) * 1000
+    num_measured_ops = num_graph_replays * num_op_per_cudagraph
+    avg_time_ms = ((end_time - start_time) / num_measured_ops) * 1000
     return avg_time_ms
 
 
@@ -611,12 +629,21 @@ def run_benchmarks(
     allreduce_params: Optional[FlashInferFusedAllReduceParams],
     quant_mode: str = "all",
     disable_oneshot: bool = False,
+    warmup: int = 5,
+    trials: int = 20,
 ):
     """Run all benchmarks for given configuration.
 
     Args:
         quant_mode: "none", "fp8_only", "fp4_only", or "all"
+        warmup: Warmup calls before capture and warmup graph replays.
+        trials: Measured operations; must be a multiple of the graph's ten ops.
     """
+    _validate_benchmark_iterations(warmup, trials)
+
+    def benchmark(*args, **kwargs):
+        return benchmark_operation(*args, warmup=warmup, trials=trials, **kwargs)
+
     (
         input_tensor,
         norm_out,
@@ -639,7 +666,7 @@ def run_benchmarks(
     if quant_mode in ["all", "none"]:
         # Standard AllReduce + RMSNorm
         try:
-            time_ms = benchmark_operation(
+            time_ms = benchmark(
                 standard_allreduce_rmsnorm,
                 input_tensor,
                 norm_out=norm_out,
@@ -654,7 +681,7 @@ def run_benchmarks(
 
         # Standard AllReduce + RMSNorm Native Compiled
         try:
-            time_ms = benchmark_operation(
+            time_ms = benchmark(
                 standard_allreduce_rmsnorm_native_compiled,
                 input_tensor,
                 residual=residual,
@@ -670,7 +697,7 @@ def run_benchmarks(
         if flashinfer_comm is not None and allreduce_params is not None:
             try:
                 if not disable_oneshot:
-                    time_ms = benchmark_operation(
+                    time_ms = benchmark(
                         flashinfer_fused_allreduce_rmsnorm,
                         input_tensor,
                         residual=residual,
@@ -687,7 +714,7 @@ def run_benchmarks(
 
             # FlashInfer Fused AllReduce + RMSNorm Two-shot
             try:
-                time_ms = benchmark_operation(
+                time_ms = benchmark(
                     flashinfer_fused_allreduce_rmsnorm,
                     input_tensor,
                     residual=residual,
@@ -707,7 +734,7 @@ def run_benchmarks(
     if quant_mode in ["all", "fp8_only"]:
         # Standard AllReduce + RMSNorm + FP8 Quant
         try:
-            time_ms = benchmark_operation(
+            time_ms = benchmark(
                 standard_allreduce_rmsnorm_fp8_quant,
                 input_tensor,
                 norm_out=norm_out,
@@ -724,7 +751,7 @@ def run_benchmarks(
 
         # Standard AllReduce + RMSNorm + FP8 Quant Native Compiled
         try:
-            time_ms = benchmark_operation(
+            time_ms = benchmark(
                 standard_allreduce_rmsnorm_fp8_quant_native_compiled,
                 input_tensor,
                 residual=residual,
@@ -745,7 +772,7 @@ def run_benchmarks(
         if flashinfer_comm is not None and allreduce_params is not None:
             try:
                 if not disable_oneshot:
-                    time_ms = benchmark_operation(
+                    time_ms = benchmark(
                         flashinfer_fused_allreduce_rmsnorm_fp8_quant,
                         input_tensor,
                         norm_out=norm_out,
@@ -770,7 +797,7 @@ def run_benchmarks(
                 )
             # FlashInfer Fused AllReduce + RMSNorm + FP8 Quant Two-shot
             try:
-                time_ms = benchmark_operation(
+                time_ms = benchmark(
                     flashinfer_fused_allreduce_rmsnorm_fp8_quant,
                     input_tensor,
                     norm_out=norm_out,
@@ -797,7 +824,7 @@ def run_benchmarks(
     if quant_mode in ["all", "fp4_only"]:
         # Standard AllReduce + RMSNorm + FP4 Quant
         try:
-            time_ms = benchmark_operation(
+            time_ms = benchmark(
                 standard_allreduce_rmsnorm_fp4_quant,
                 input_tensor,
                 norm_out=norm_out,
@@ -815,7 +842,7 @@ def run_benchmarks(
 
         # Standard AllReduce + RMSNorm + FP4 Quant Native Compiled
         try:
-            time_ms = benchmark_operation(
+            time_ms = benchmark(
                 standard_allreduce_rmsnorm_fp4_quant_native_compiled,
                 input_tensor,
                 residual=residual,
@@ -836,7 +863,7 @@ def run_benchmarks(
         if flashinfer_comm is not None and allreduce_params is not None:
             try:
                 if not disable_oneshot:
-                    time_ms = benchmark_operation(
+                    time_ms = benchmark(
                         flashinfer_fused_allreduce_rmsnorm_fp4_quant,
                         input_tensor,
                         residual=residual,
@@ -864,7 +891,7 @@ def run_benchmarks(
         # FlashInfer Fused AllReduce + RMSNorm + FP4 Quant Two-shot
         if flashinfer_comm is not None and allreduce_params is not None:
             try:
-                time_ms = benchmark_operation(
+                time_ms = benchmark(
                     flashinfer_fused_allreduce_rmsnorm_fp4_quant,
                     input_tensor,
                     residual=residual,
@@ -1145,7 +1172,10 @@ def main():
         "--warmup", type=int, default=5, help="Number of warmup iterations"
     )
     parser.add_argument(
-        "--trials", type=int, default=20, help="Number of benchmark trials"
+        "--trials",
+        type=int,
+        default=20,
+        help="Number of measured operations (at least 10 and divisible by 10)",
     )
     parser.add_argument(
         "--output-file",
@@ -1156,6 +1186,7 @@ def main():
     )
 
     args = parser.parse_args()
+    _validate_benchmark_iterations(args.warmup, args.trials)
 
     # Check if running with torchrun (required for collective operations)
     if "RANK" not in os.environ or "WORLD_SIZE" not in os.environ:
@@ -1271,6 +1302,8 @@ def main():
                 allreduce_params,
                 quant_mode=quant_mode,
                 disable_oneshot=args.disable_oneshot,
+                warmup=args.warmup,
+                trials=args.trials,
             )
 
             # Store results for markdown export

--- a/test/registered/unit/bench/test_flashinfer_collective_benchmark_iterations.py
+++ b/test/registered/unit/bench/test_flashinfer_collective_benchmark_iterations.py
@@ -1,0 +1,122 @@
+import contextlib
+import importlib.util
+import inspect
+import types
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+
+def _load_benchmark_module():
+    repo_root = Path(__file__).resolve().parents[4]
+    path = (
+        repo_root
+        / "benchmark/kernels/flashinfer_allreduce_fusion/benchmark_fused_collective.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "_flashinfer_collective_benchmark_under_test", path
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+benchmark = _load_benchmark_module()
+
+
+class _FakeGraph:
+    def __init__(self):
+        self.replays = 0
+
+    def replay(self):
+        self.replays += 1
+
+
+class TestFlashInferCollectiveBenchmarkIterations(CustomTestCase):
+    def test_run_benchmarks_forwards_warmup_and_trials(self):
+        parameters = inspect.signature(benchmark.run_benchmarks).parameters
+        self.assertIn("warmup", parameters)
+        self.assertIn("trials", parameters)
+
+        norm = types.SimpleNamespace(weight=types.SimpleNamespace(data=None))
+        tensors = tuple(MagicMock() for _ in range(9))
+        with (
+            patch.object(benchmark, "create_test_tensors", return_value=tensors),
+            patch.object(benchmark, "RMSNorm", return_value=norm),
+            patch.object(benchmark, "flashinfer_comm", None),
+            patch.object(
+                benchmark, "benchmark_operation", return_value=1.0
+            ) as operation,
+        ):
+            benchmark.run_benchmarks(
+                seq_len=1,
+                hidden_dim=8,
+                dtype=MagicMock(),
+                use_residual=True,
+                allreduce_params=None,
+                quant_mode="none",
+                warmup=7,
+                trials=40,
+            )
+
+        self.assertEqual(operation.call_count, 2)
+        for call in operation.call_args_list:
+            self.assertEqual(call.kwargs["warmup"], 7)
+            self.assertEqual(call.kwargs["trials"], 40)
+
+    def test_invalid_iteration_counts_fail_before_cuda_work(self):
+        validate = getattr(benchmark, "_validate_benchmark_iterations", None)
+        self.assertIsNotNone(validate, "benchmark iteration validation is missing")
+
+        for warmup, trials in ((-1, 20), (0, 0), (0, 5), (0, 25)):
+            with self.subTest(warmup=warmup, trials=trials):
+                with self.assertRaises(ValueError):
+                    validate(warmup, trials)
+
+    def test_main_rejects_invalid_iterations_before_distributed_setup(self):
+        args = types.SimpleNamespace(warmup=-1, trials=20)
+        with (
+            patch.object(
+                benchmark.argparse.ArgumentParser,
+                "parse_args",
+                return_value=args,
+            ),
+            patch.object(benchmark, "init_distributed_environment") as init_dist,
+        ):
+            with self.assertRaises(ValueError):
+                benchmark.main()
+
+        init_dist.assert_not_called()
+
+    def test_timing_uses_the_executed_operation_count(self):
+        fake_graph = _FakeGraph()
+        graph_context = types.SimpleNamespace(stream=object())
+        with (
+            patch.object(benchmark.torch.cuda, "synchronize"),
+            patch.object(benchmark.torch.cuda, "CUDAGraph", return_value=fake_graph),
+            patch.object(
+                benchmark.torch.cuda,
+                "graph",
+                return_value=contextlib.nullcontext(),
+            ),
+            patch.object(
+                benchmark,
+                "graph_capture",
+                return_value=contextlib.nullcontext(graph_context),
+            ),
+            patch.object(benchmark.time, "perf_counter", side_effect=(1.0, 2.0)),
+        ):
+            latency_ms = benchmark.benchmark_operation(MagicMock(), warmup=2, trials=20)
+
+        self.assertEqual(fake_graph.replays, 4)
+        self.assertEqual(latency_ms, 50.0)
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

`benchmark_fused_collective.py` exposed `--warmup` and `--trials` and recorded them in the Markdown title, but did not pass either value into `run_benchmarks`/`benchmark_operation`. Every run therefore still used the hard-coded defaults. In addition, the CUDA Graph contains ten operations, so a nonmultiple such as `--trials 25` executed only twenty operations while dividing elapsed time by twenty-five.

## Changes

- Thread the requested warmup and trial counts through all fused-collective variants.
- Reject invalid counts before distributed/CUDA initialization; measured trials must be at least ten and divisible by the ten-operation graph size.
- Divide elapsed time by the operation count actually replayed.
- Add CPU regression coverage for CLI propagation, validation order/boundaries, graph replay count, and timing arithmetic.

## Validation

- `python -m ruff format --check benchmark/kernels/flashinfer_allreduce_fusion/benchmark_fused_collective.py test/registered/unit/bench/test_flashinfer_collective_benchmark_iterations.py`
- `python -m ruff check benchmark/kernels/flashinfer_allreduce_fusion/benchmark_fused_collective.py test/registered/unit/bench/test_flashinfer_collective_benchmark_iterations.py`
- `python -m py_compile benchmark/kernels/flashinfer_allreduce_fusion/benchmark_fused_collective.py test/registered/unit/bench/test_flashinfer_collective_benchmark_iterations.py`
- `python -m pytest -q test/registered/unit/bench/test_flashinfer_collective_benchmark_iterations.py` (`4 passed`, `4 subtests passed`)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33061619111](https://github.com/sgl-project/sglang/actions/runs/33061619111)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33061618976](https://github.com/sgl-project/sglang/actions/runs/33061618976)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33061619313](https://github.com/sgl-project/sglang/actions/runs/33061619313)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->