### PR TITLE
[DSv4] Optional aiter fp8 ASM MLA decode for the unified_kv path (default off)

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/quant_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsv4/quant_k_cache.py
@@ -69,6 +69,143 @@ def _quant_k_cache_fused_kernel(
         tl.store(scale_k_nope_uint8_ptr + out_scale_offset, scale_uint8)
 
 
+@triton.jit
+def _quant_k_cache_aiter_2buff_kernel(
+    k_bf16_ptr,
+    nope_scale_fp8_ptr,
+    nope_scale_uint8_ptr,
+    k_rope_bf16_ptr,
+    k_bf16_stride_0,
+    nope_scale_stride_0,
+    k_rope_bf16_stride_0,
+    DIM_NOPE: tl.constexpr,
+    DIM_ROPE: tl.constexpr,
+    TILE_SIZE: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    SCALE_OFFSET: tl.constexpr,
+    PAD_OFFSET: tl.constexpr,
+    PAD_SIZE: tl.constexpr,
+    FP8_MIN: tl.constexpr,
+    FP8_MAX: tl.constexpr,
+    EPS: tl.constexpr,
+):
+    """Quantize K directly into AITER MLA's 512-byte two-buffer layout."""
+    # int64 for the same reason _quant_k_cache_fused_kernel needs it: token_id
+    # multiplies a 512/576-element row stride, which overflows int32 past ~3.7M
+    # rows, well inside the pool sizes long-context serving allocates.
+    token_id = tl.program_id(0).to(tl.int64)
+    tile_id = tl.program_id(1)
+
+    if tile_id == NUM_TILES:
+        offsets = tl.arange(0, TILE_SIZE)
+
+        rope_data = tl.load(
+            k_bf16_ptr + token_id * k_bf16_stride_0 + DIM_NOPE + offsets,
+            mask=offsets < DIM_ROPE,
+            other=0.0,
+        )
+        tl.store(
+            k_rope_bf16_ptr + token_id * k_rope_bf16_stride_0 + offsets,
+            rope_data,
+            mask=offsets < DIM_ROPE,
+        )
+
+        # The AITER reader reserves bytes [462:512]. Initialize them in this
+        # same launch instead of allocating the output with torch.zeros().
+        tl.store(
+            nope_scale_uint8_ptr
+            + token_id * nope_scale_stride_0
+            + PAD_OFFSET
+            + offsets,
+            0,
+            mask=offsets < PAD_SIZE,
+        )
+    else:
+        tile_range = tl.arange(0, TILE_SIZE)
+        in_offsets = token_id * k_bf16_stride_0 + tile_id * TILE_SIZE + tile_range
+        x_fp32 = tl.load(k_bf16_ptr + in_offsets).to(tl.float32)
+
+        abs_x = tl.abs(x_fp32)
+        max_abs = tl.max(abs_x)
+        max_abs_clamped = tl.maximum(max_abs, EPS)
+        scale = max_abs_clamped / FP8_MAX
+        ceil_log2 = tl.math.ceil(tl.log2(scale))
+        scale_pow2_fp32 = tl.exp2(ceil_log2)
+        scale_inv = 1.0 / scale_pow2_fp32
+        x_scaled = x_fp32 * scale_inv
+        x_fp8 = tl.clamp(x_scaled, FP8_MIN, FP8_MAX).to(
+            nope_scale_fp8_ptr.dtype.element_ty
+        )
+
+        tl.store(
+            nope_scale_fp8_ptr
+            + token_id * nope_scale_stride_0
+            + tile_id * TILE_SIZE
+            + tile_range,
+            x_fp8,
+        )
+
+        # AITER expects every e8m0 exponent byte twice:
+        # [s0, s0, s1, s1, ..., s6, s6].
+        scale_uint8 = (ceil_log2.to(tl.int32) + 127).to(tl.uint8)
+        scale_offset = token_id * nope_scale_stride_0 + SCALE_OFFSET + 2 * tile_id
+        tl.store(nope_scale_uint8_ptr + scale_offset, scale_uint8)
+        tl.store(nope_scale_uint8_ptr + scale_offset + 1, scale_uint8)
+
+
+def quant_to_aiter_2buff_triton(
+    k_bf16: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return AITER MLA's packed FP8 nope/scale buffer and BF16 rope buffer.
+
+    The first output is ``[num_tokens, 512]`` bytes laid out as
+    ``[448 fp8 nope | 14 duplicated e8m0 scale bytes | 50 zero pad bytes]``.
+    The kernel writes the complete layout directly, avoiding four subsequent
+    PyTorch fill/copy launches.
+    """
+    assert k_bf16.dtype == torch.bfloat16
+    num_tokens, hidden_dim = k_bf16.shape
+    assert hidden_dim == 512
+
+    dim_nope = 448
+    dim_rope = 64
+    tile_size = 64
+    num_tiles = dim_nope // tile_size
+    scale_offset = dim_nope
+    pad_offset = scale_offset + 2 * num_tiles
+
+    k_bf16 = k_bf16.contiguous()
+    nope_scale_fp8 = torch.empty(
+        (num_tokens, hidden_dim), dtype=fp8_dtype, device=k_bf16.device
+    )
+    k_rope_bf16 = torch.empty(
+        (num_tokens, dim_rope), dtype=torch.bfloat16, device=k_bf16.device
+    )
+
+    fp8_dtype_info = torch.finfo(fp8_dtype)
+    grid = (num_tokens, num_tiles + 1)
+    _quant_k_cache_aiter_2buff_kernel[grid](
+        k_bf16,
+        nope_scale_fp8,
+        nope_scale_fp8.view(torch.uint8),
+        k_rope_bf16,
+        k_bf16.stride(0),
+        nope_scale_fp8.stride(0),
+        k_rope_bf16.stride(0),
+        DIM_NOPE=dim_nope,
+        DIM_ROPE=dim_rope,
+        TILE_SIZE=tile_size,
+        NUM_TILES=num_tiles,
+        SCALE_OFFSET=scale_offset,
+        PAD_OFFSET=pad_offset,
+        PAD_SIZE=hidden_dim - pad_offset,
+        FP8_MIN=fp8_dtype_info.min,
+        FP8_MAX=fp8_dtype_info.max,
+        EPS=1e-8,
+    )
+    return nope_scale_fp8, k_rope_bf16
+
+
 def quant_to_nope_fp8_rope_bf16_pack_triton(
     k_bf16: torch.Tensor,
 ) -> NopeFp8RopeBf16Pack:

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/aiter_v4nm_decode.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/aiter_v4nm_decode.py
@@ -1,0 +1,191 @@
+"""Adapter: SGLang unified_kv decode -> aiter ``mla_decode_fwd_v4_nm`` (fp8 ASM).
+
+Bridges SGLang's bf16 unified_kv decode contract onto aiter's fp8 v4 nm MLA
+decode kernel. Gated by ``SGLANG_USE_AITER_MLA_DECODE`` in the runtime decode
+entry; falls back to the triton path if the kernel/import is unavailable.
+
+Kernel contract (verified against SGLang bf16 baseline, cos>0.999):
+  * q          : [T, H, 512] bf16 -> packed to (q_fp8 [T,H,512], q_rope [T,H,64])
+  * kv_buffer  : [pages, 1, 1, 512] fp8  (nope448 + 14 dup e8m0 scales + 50 pad)
+  * kvrope     : [pages, 1, 1, 64]  bf16
+  * qo_indptr  : arange(T+1)          (qseqlen1: one q token == one sequence)
+  * kv_indptr  : per-token prefix sum (== SGLang kv_indptr)
+  * kv_page_indices : SGLang kv_indices
+  * sink       : [H] fp32, REQUIRED
+  * result read from ``output`` (single-pass writes bf16 straight into it)
+
+fp8 2-buffer packing uses a specialized SGLang Triton quant kernel which emits
+the final AITER reader layout directly:
+``[nope_fp8[448], duplicated scale_ue8m0[14], zero padding[50]]`` plus the
+separate ``rope_bf16[64]`` buffer.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+    quant_to_aiter_2buff_triton,
+)
+
+
+def _resolve_num_kv_splits() -> Optional[int]:
+    """Split-K count for the v4 nm decode kernel.
+
+    Default ``None`` = let aiter auto-pick via its CU-occupancy heuristic
+    (``get_meta_param``), matching ATOM. This routes decode through the
+    faster split-K + ``_fwd_kernel_stage2_asm`` merge path instead of the
+    monolithic single-pass kernel. Override with an int via
+    ``SGLANG_AITER_MLA_KV_SPLITS`` (e.g. ``1`` to force single-pass).
+    """
+    v = os.environ.get("SGLANG_AITER_MLA_KV_SPLITS")
+    if v is None or v == "" or v.lower() == "auto":
+        return None
+    try:
+        return int(v)
+    except ValueError:
+        return None
+
+
+_D = 512
+_D_ROPE = 64
+
+_HAS_AITER: Optional[bool] = None
+_mla_decode_fwd_v4_nm = None
+
+# qo_indptr for qseqlen1 decode is just arange(T+1); it is deterministic in T and
+# read-only, yet the decode adapter is called once per attention layer (~60/forward),
+# so rebuilding the arange each call spends ~1 tiny launch per layer. Cache it keyed
+# by (T, device) and reuse the same buffer across layers/steps. CUDA-graph safe: the
+# tensor is a stable read-only input, and each captured decode bs (=T) gets its own
+# cached entry.
+_QO_INDPTR_CACHE: dict = {}
+
+
+def _get_qo_indptr(T: int, device: torch.device) -> torch.Tensor:
+    key = (T, str(device))
+    buf = _QO_INDPTR_CACHE.get(key)
+    if buf is None:
+        buf = torch.arange(0, T + 1, dtype=torch.int32, device=device)
+        _QO_INDPTR_CACHE[key] = buf
+    return buf
+
+
+def _load_aiter():
+    global _HAS_AITER, _mla_decode_fwd_v4_nm
+    if _HAS_AITER is not None:
+        return _HAS_AITER
+    try:
+        from aiter.mla import mla_decode_fwd_v4_nm  # noqa: F401
+
+        _mla_decode_fwd_v4_nm = mla_decode_fwd_v4_nm
+        _HAS_AITER = True
+    except Exception:
+        _HAS_AITER = False
+    return _HAS_AITER
+
+
+def pack_native_bf16_to_2buff(x_bf16: torch.Tensor):
+    """[..., 512] bf16 -> (nope_scale_buff [..., 512] fp8, rope_buff [..., 64] bf16).
+
+    Byte layout of nope_scale_buff (matches the v4 nm asm reader):
+      [ nope (448 fp8) | scale (14 e8m0 = s0,s0,..,s6,s6) | pad (50) ] = 512 B
+    """
+    leading = x_bf16.shape[:-1]
+    n = 1
+    for s in leading:
+        n *= s
+    flat = x_bf16.reshape(n, _D).contiguous()
+
+    buff, rope_bf16 = quant_to_aiter_2buff_triton(flat)
+
+    buff = buff.reshape(*leading, _D)
+    rope_bf16 = rope_bf16.reshape(*leading, _D_ROPE)
+    return buff, rope_bf16
+
+
+def is_available() -> bool:
+    return _load_aiter()
+
+
+def aiter_v4nm_paged_decode(
+    q: torch.Tensor,  # [T, H, 512] bf16 (local heads)
+    unified_kv: torch.Tensor,  # [pages, 512] bf16 OR pre-packed fp8 (see kv_fp8)
+    kv_indices: torch.Tensor,  # [total_indices] int32 (per-token flat)
+    kv_indptr: torch.Tensor,  # [T+1] int32 (per-token prefix sum)
+    attn_sink: torch.Tensor,  # [H] fp32
+    softmax_scale: float,  # ignored by kernel (hardcodes 1/sqrt(512))
+    *,
+    kv_fp8: Optional[torch.Tensor] = None,  # [pages,512] fp8 packed (store-time)
+    kv_rope: Optional[torch.Tensor] = None,  # [pages,64]  bf16 (store-time)
+) -> torch.Tensor:
+    """Run aiter v4 nm decode; returns out [T, H, 512] bf16.
+
+    KV source: if ``kv_fp8``/``kv_rope`` are provided (store-time fp8 pool), they
+    are used directly; otherwise ``unified_kv`` (bf16) is packed on the fly
+    (correctness/dispatch proof — adds a per-step quant of the whole pool rows
+    referenced, so NOT a clean perf number).
+    """
+    assert _load_aiter(), "aiter mla_decode_fwd_v4_nm unavailable"
+    T, H, D = q.shape
+    assert D == _D
+    dev = q.device
+
+    # Q is packed here, once per decode step per layer. Fusing this into the
+    # upstream RMSNorm+RoPE launch would remove it, which is worth doing: it is
+    # the largest attention-side kernel on the decode critical path.
+    q_fp8, q_rope = pack_native_bf16_to_2buff(q)  # [T,H,512]fp8 / [T,H,64]
+
+    if kv_fp8 is None or kv_rope is None:
+        # On-the-fly repack of ONLY the gathered pages (bounded per step, unlike
+        # packing the whole pool). Gather the referenced bf16 rows, pack them to
+        # a compact fp8 2-buffer, and reindex kv_page_indices to arange. The
+        # kernel does identical work (same total KV entries) so mla_a8w8 self-
+        # time is representative; the pack is a separate (ignorable) op in the
+        # trace. Correct because it reads the real bf16 KV. NOT cuda-graph safe
+        # (variable gather size) -> run with --disable-cuda-graph.
+        # kv_indices is a RAGGED-PACKED buffer allocated at worst-case width;
+        # only kv_indices[:kv_indptr[-1]] are valid, the tail is uninitialized
+        # garbage. Gather ONLY the valid prefix (gathering the garbage tail
+        # faults the GPU with an OOB read).
+        total_valid = int(kv_indptr[-1].item())
+        gathered = unified_kv.index_select(
+            0, kv_indices[:total_valid].long()
+        )  # [total_valid, 512]
+        kv_fp8, kv_rope = pack_native_bf16_to_2buff(gathered)
+        kv_indices = torch.arange(total_valid, device=dev, dtype=torch.int32)
+
+    P = kv_fp8.shape[0]
+    kv_buffer = kv_fp8.view(P, 1, 1, _D)
+    kvrope = kv_rope.view(P, 1, 1, _D_ROPE).contiguous()
+
+    if attn_sink.dtype != torch.float32:
+        attn_sink = attn_sink.float()
+    attn_sink = attn_sink.contiguous()
+
+    qo_indptr = _get_qo_indptr(T, dev)
+    output = torch.empty(T, H, _D, dtype=torch.bfloat16, device=dev)
+
+    _mla_decode_fwd_v4_nm(
+        q=q_fp8,
+        qrope=q_rope.contiguous(),
+        kv_buffer=kv_buffer,
+        kvrope=kvrope,
+        output=output,
+        qo_indptr=qo_indptr,
+        kv_indptr=(
+            kv_indptr if kv_indptr.dtype == torch.int32 else kv_indptr.to(torch.int32)
+        ),
+        kv_page_indices=(
+            kv_indices
+            if kv_indices.dtype == torch.int32
+            else kv_indices.to(torch.int32)
+        ),
+        max_seqlen_q=1,
+        sink=attn_sink,
+        num_kv_splits=_resolve_num_kv_splits(),
+    )
+    return output

--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/runtime.py
@@ -24,6 +24,7 @@ on via ``topk_length``); the per-token compressed count is recovered from the
 
 from __future__ import annotations
 
+import os
 from typing import Optional, Tuple
 
 import torch
@@ -40,6 +41,11 @@ from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_decode_indices i
 from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.paged_prefill import (
     sparse_attn_v4_paged_prefill,
 )
+
+# A/B gate: route decode through aiter's fp8 ASM MLA kernel
+# (``mla_decode_fwd_v4_nm``) instead of the triton bf16 path. Read once at
+# import so it's stable across CUDA-graph capture/replay.
+_USE_AITER_MLA_DECODE = os.environ.get("SGLANG_USE_AITER_MLA_DECODE", "0") == "1"
 
 
 # ---------------------------------------------------------------------------
@@ -84,6 +90,8 @@ def store_swa_into_unified(
     win: int,  # SWA attention window length
     ring_stride: int,  # SWA ring stride
     final_pos: Optional[torch.Tensor] = None,  # [T] req's last position
+    unified_kv_fp8: Optional[torch.Tensor] = None,  # [pages, 512] fp8 mirror
+    unified_kv_rope: Optional[torch.Tensor] = None,  # [pages, 64]  bf16 mirror
 ) -> None:
     n_rows, D = kv.shape
     if n_rows == 0:
@@ -108,6 +116,29 @@ def store_swa_into_unified(
         BLOCK_D=triton.next_power_of_2(D),
         num_warps=8,
     )
+
+    # Mirror the same rows into the store-time fp8 pool so decode can read
+    # fixed-shape fp8 (cuda-graph safe). Reuses the identical scatter kernel
+    # (same loc + final-window mask), so the fp8/rope mirror stays byte-for-byte
+    # consistent with the bf16 SWA ring. fp8 is stored/scattered as raw bytes
+    # (uint8 view) since triton has no float8 store.
+    if unified_kv_fp8 is not None and unified_kv_rope is not None:
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.aiter_v4nm_decode import (
+            pack_native_bf16_to_2buff,
+        )
+
+        buff, rope = pack_native_bf16_to_2buff(kv)  # [T,512] fp8, [T,64] bf16
+        swa_scatter_fp8_mirror(
+            buff=buff,
+            rope=rope,
+            state_slot=state_slot,
+            positions=positions,
+            unified_kv_fp8=unified_kv_fp8,
+            unified_kv_rope=unified_kv_rope,
+            win=win,
+            ring_stride=ring_stride,
+            final_pos=final_pos,
+        )
 
 
 @triton.jit
@@ -161,6 +192,64 @@ def scatter_bf16_into_unified(
     )
 
 
+def swa_scatter_fp8_mirror(
+    *,
+    buff: torch.Tensor,  # [T, 512] fp8 (already packed)
+    rope: torch.Tensor,  # [T, 64]  bf16 (already packed)
+    state_slot: torch.Tensor,  # [T] int
+    positions: torch.Tensor,  # [T] int
+    unified_kv_fp8: torch.Tensor,  # [pages, 512] fp8 mirror
+    unified_kv_rope: torch.Tensor,  # [pages, 64]  bf16 mirror
+    win: int,
+    ring_stride: int,
+    final_pos: Optional[torch.Tensor] = None,  # [T] req's last position
+) -> None:
+    """Scatter pre-packed fp8/rope rows into the SWA ring mirror.
+
+    Uses the same loc + final-window mask as the bf16 SWA scatter. Split out of
+    ``store_swa_into_unified`` so the decode path can pack the SWA new-token rows
+    together with the compressed rows in a *single* ``_quant_k_cache`` launch and
+    then scatter each slice, instead of paying two separate pack launches per
+    layer. fp8 is scattered as raw bytes (uint8 view) since triton has no float8
+    store.
+    """
+    n_rows = buff.shape[0]
+    if n_rows == 0:
+        return
+    has_final = final_pos is not None
+    fp_arg = final_pos if has_final else positions
+    buff_u8 = buff.contiguous().view(torch.uint8)
+    rope = rope.contiguous()
+    _swa_scatter_kernel[(n_rows,)](
+        buff_u8,
+        state_slot,
+        positions,
+        fp_arg,
+        unified_kv_fp8.view(torch.uint8),
+        n_rows,
+        ring_stride,
+        win=win,
+        D=512,
+        HAS_FINAL=has_final,
+        BLOCK_D=triton.next_power_of_2(512),
+        num_warps=8,
+    )
+    _swa_scatter_kernel[(n_rows,)](
+        rope,
+        state_slot,
+        positions,
+        fp_arg,
+        unified_kv_rope,
+        n_rows,
+        ring_stride,
+        win=win,
+        D=64,
+        HAS_FINAL=has_final,
+        BLOCK_D=triton.next_power_of_2(64),
+        num_warps=4,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Ragged indptr helper (shared by the decode streams + prefill builders)
 # ---------------------------------------------------------------------------
@@ -177,7 +266,26 @@ def decode(
     kv_indptr: torch.Tensor,
     attn_sink: torch.Tensor,  # [H] fp32
     softmax_scale: float,
+    kv_fp8: Optional[torch.Tensor] = None,  # [pages,512] fp8 store-time pool
+    kv_rope: Optional[torch.Tensor] = None,  # [pages,64]  bf16 store-time pool
 ) -> torch.Tensor:
+    if _USE_AITER_MLA_DECODE:
+        from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.aiter_v4nm_decode import (
+            aiter_v4nm_paged_decode,
+            is_available,
+        )
+
+        if is_available():
+            return aiter_v4nm_paged_decode(
+                q,
+                unified_kv,
+                kv_indices,
+                kv_indptr,
+                attn_sink,
+                softmax_scale,
+                kv_fp8=kv_fp8,
+                kv_rope=kv_rope,
+            )
     return sparse_attn_v4_paged_decode(
         q, unified_kv, kv_indices, kv_indptr, attn_sink, softmax_scale
     )

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend_hip_radix.py
@@ -1230,6 +1230,17 @@ class DeepseekV4HipRadixBackend(
         pool = self.token_to_kv_pool
         layer_id = layer.layer_id
         unified = pool.get_unified_kv(layer_id)
+        # store-time fp8 mirror (aiter decode); None unless aiter mode is on
+        unified_fp8 = (
+            pool.get_unified_kv_fp8(layer_id)
+            if hasattr(pool, "get_unified_kv_fp8")
+            else None
+        )
+        unified_rope = (
+            pool.get_unified_kv_rope(layer_id)
+            if hasattr(pool, "get_unified_kv_rope")
+            else None
+        )
         win = pool.unified_swa_window
         ring_stride = pool.unified_swa_ring_size
         swa_pages = pool.unified_swa_pages
@@ -1257,7 +1268,10 @@ class DeepseekV4HipRadixBackend(
                 state_slot = core_attn_metadata.unified.verify_store_state_slot[:T]
             else:
                 state_slot = forward_batch.req_pool_indices[:T]
+            unified_metadata = core_attn_metadata.unified
             if save_kv_cache:
+                # bf16 SWA ring scatter (fp8 mirror is handled by the single
+                # merged pack below, so don't pass the fp8 buffers here).
                 runtime.store_swa_into_unified(
                     kv=kv,
                     state_slot=state_slot,
@@ -1267,7 +1281,49 @@ class DeepseekV4HipRadixBackend(
                     ring_stride=ring_stride,
                     final_pos=positions,
                 )
-            unified_metadata = core_attn_metadata.unified
+
+            # Pack fp8 mirrors from bf16 unified_kv with the SGLang 2-buffer
+            # kernel decode is proven against. Always do this when the mirror
+            # exists: fused-store decode sets save_kv_cache=False (Triton
+            # already wrote the ring) and used to skip this pack, leaving
+            # decode to read stale/AITER-internal fp8. Shapes are static
+            # (T fixed per graph), so this stays cuda-graph safe.
+            if unified_fp8 is not None:
+                if compress_ratio == 128:
+                    comp_loc = getattr(unified_metadata, "c128_out_loc", None)
+                elif compress_ratio == 4:
+                    comp_loc = getattr(unified_metadata, "c4_out_loc", None)
+                else:
+                    comp_loc = None
+                if save_kv_cache:
+                    swa_src = kv
+                else:
+                    swa_loc = self.get_unified_swa_loc(forward_batch)[:T].long()
+                    swa_src = unified[swa_loc]
+                if comp_loc is not None:
+                    comp_loc = comp_loc[:T].long()
+                    rows = torch.cat([swa_src, unified[comp_loc]], dim=0)
+                else:
+                    rows = swa_src
+                from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.aiter_v4nm_decode import (
+                    pack_native_bf16_to_2buff,
+                )
+
+                buff, rope = pack_native_bf16_to_2buff(rows)
+                runtime.swa_scatter_fp8_mirror(
+                    buff=buff[:T],
+                    rope=rope[:T],
+                    state_slot=state_slot,
+                    positions=positions,
+                    unified_kv_fp8=unified_fp8,
+                    unified_kv_rope=unified_rope,
+                    win=win,
+                    ring_stride=ring_stride,
+                    final_pos=positions,
+                )
+                if comp_loc is not None:
+                    unified_fp8[comp_loc] = buff[T:]
+                    unified_rope[comp_loc] = rope[T:]
             if compress_ratio == 0:
                 kv_indices = unified_metadata.swa_indices
                 kv_indptr = unified_metadata.swa_indptr
@@ -1294,6 +1350,8 @@ class DeepseekV4HipRadixBackend(
                 kv_indptr=kv_indptr,
                 attn_sink=attn_sink,
                 softmax_scale=self.softmax_scale,
+                kv_fp8=unified_fp8,
+                kv_rope=unified_rope,
             )
 
         # prefill / extend
@@ -1392,6 +1450,8 @@ class DeepseekV4HipRadixBackend(
                 win=win,
                 ring_stride=ring_stride,
                 final_pos=_ring_final_pos,
+                unified_kv_fp8=unified_fp8,
+                unified_kv_rope=unified_rope,
             )
         return o
 

--- a/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
+++ b/python/sglang/srt/layers/attention/dsv4/compressor_v2.py
@@ -257,6 +257,25 @@ class CompressorBackendMixin:
             use_fp4_indexer=use_fp4_indexer,
             bf16_store=bf16_store,
         )
+        # Compressed K lands in unified_kv as bf16. When the aiter fp8 MLA decode
+        # is active, its fp8 mirror has to be kept in step with those rows, and
+        # the mirror must be written by the same 2-buffer packer prefill history
+        # already went through. Decode does not pack here: the backend folds the
+        # SWA and compressed rows into one pack from bf16 unified_kv.
+        if bf16_store and not compressor.is_in_indexer:
+            if not forward_batch.forward_mode.is_decode_or_idle():
+                get_fp8 = getattr(token_to_kv_pool, "get_unified_kv_fp8", None)
+                fp8_buf = get_fp8(layer_id) if get_fp8 is not None else None
+                if fp8_buf is not None:
+                    from sglang.kernels.ops.attention.dsv4.unified_kv_kernels.aiter_v4nm_decode import (
+                        pack_native_bf16_to_2buff,
+                    )
+
+                    rope_buf = token_to_kv_pool.get_unified_kv_rope(layer_id)
+                    loc = out_loc.long()
+                    buff, rope = pack_native_bf16_to_2buff(kv_cache[loc])
+                    fp8_buf[loc] = buff
+                    rope_buf[loc] = rope
         online_c128_mtp = getattr(self, "online_c128_mtp", None)
         if online_c128_mtp is not None:
             online_c128_mtp.write_prefix_states(

--- a/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
+++ b/python/sglang/srt/mem_cache/deepseek_v4_memory_pool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import nullcontext
 from typing import List, Literal, NamedTuple, Optional, Tuple
 
@@ -450,8 +451,58 @@ class DeepSeekV4UnifiedKVPool:
                     )
         self.kv_buffer = bufs
 
+        # ---- store-time fp8 mirror (aiter mla_decode_fwd_v4_nm) ----------------
+        # When decode is routed through aiter's fp8 ASM MLA kernel we keep a
+        # per-layer fp8 mirror of every unified_kv row so decode reads
+        # fixed-shape fp8 (cuda-graph safe) instead of repacking on the fly.
+        #   kv_buffer_fp8[L]:  [rows, 512] fp8   (nope448 + 14 e8m0 scale + pad)
+        #   kv_buffer_rope[L]: [rows, 64]  bf16  (rope, byte-identical to
+        #                                         unified_kv[:, 448:512])
+        # Gated to aiter mode so the triton bf16 decode path pays no extra VRAM.
+        self._aiter_fp8_mirror = (
+            os.environ.get("SGLANG_USE_AITER_MLA_DECODE", "0") == "1"
+        )
+        self.kv_buffer_fp8 = None
+        self.kv_buffer_rope = None
+        if self._aiter_fp8_mirror and len(bufs) > 0:
+            from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+                quant_to_nope_fp8_rope_bf16_pack_triton,
+            )
+
+            probe = quant_to_nope_fp8_rope_bf16_pack_triton(
+                torch.zeros(1, self.head_dim, dtype=torch.bfloat16, device=device)
+            )
+            fp8_dtype = probe.k_nope_fp8.dtype
+            fp8_bufs, rope_bufs = [], []
+            with memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+                with (
+                    torch.cuda.use_mem_pool(custom_mem_pool)
+                    if custom_mem_pool
+                    else nullcontext()
+                ):
+                    for buf in bufs:
+                        rows = buf.shape[0]
+                        fp8_bufs.append(
+                            torch.zeros(rows, 512, dtype=fp8_dtype, device=device)
+                        )
+                        rope_bufs.append(
+                            torch.zeros(rows, 64, dtype=torch.bfloat16, device=device)
+                        )
+            self.kv_buffer_fp8 = fp8_bufs
+            self.kv_buffer_rope = rope_bufs
+
     def get_unified_kv(self, local_layer_id: int) -> torch.Tensor:
         return self.kv_buffer[local_layer_id]
+
+    def get_unified_kv_fp8(self, local_layer_id: int) -> Optional[torch.Tensor]:
+        if self.kv_buffer_fp8 is None:
+            return None
+        return self.kv_buffer_fp8[local_layer_id]
+
+    def get_unified_kv_rope(self, local_layer_id: int) -> Optional[torch.Tensor]:
+        if self.kv_buffer_rope is None:
+            return None
+        return self.kv_buffer_rope[local_layer_id]
 
     def get_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
         data_ptrs = [b.data_ptr() for b in self.kv_buffer]
@@ -660,6 +711,12 @@ class DeepSeekV4TokenToKVPool(BaseSWAKVPool):
         # layer's transfer before attention reads it. No-op when HiCache is off.
         self.wait_layer_transfer(layer_id)
         return self.unified_kv_pool.get_unified_kv(layer_id - self._stage_start)
+
+    def get_unified_kv_fp8(self, layer_id: int) -> Optional[torch.Tensor]:
+        return self.unified_kv_pool.get_unified_kv_fp8(layer_id - self._stage_start)
+
+    def get_unified_kv_rope(self, layer_id: int) -> Optional[torch.Tensor]:
+        return self.unified_kv_pool.get_unified_kv_rope(layer_id - self._stage_start)
 
     def register_mapping(self, full_to_swa_index_mapping: torch.Tensor):
         self.full_to_swa_index_mapping = full_to_swa_index_mapping


### PR DESCRIPTION
## Motivation

The DSv4 `unified_kv` decode path currently runs `sparse_attn_v4_paged_decode`, a Triton bf16 kernel. On ROCm, aiter ships an fp8 ASM MLA decode kernel, `mla_decode_fwd_v4_nm`, that reads half the KV bytes. This adds it as an **opt-in alternative** behind `SGLANG_USE_AITER_MLA_DECODE`, defaulting to off.

Opening as a draft because the measurements are mixed and I would rather have the design reviewed than the number defended. See "Results" below: it helps at short context and slightly hurts at long. The aiter MLA kernels should be faster in isolation compared to the _paged_decode SGLang kernels, but the additional glue overhead and quantization eats into that gain and so we get mixed results for now. 

## Design

`mla_decode_fwd_v4_nm` wants bf16 RoPE handed to it separately from fp8 NoPE, in a 512-byte layout: fp8 NoPE in `[0:448)`, fourteen duplicated e8m0 scales in `[448:462)`, zero pad in `[462:512)`. Three consequences shape the patch.

1. **A packer that emits that layout directly.** `_quant_k_cache_aiter_2buff_kernel` quantizes bf16 K straight into it, writing the pad in the same launch so callers need no `torch.zeros()`.
2. **Store-time fp8 mirrors, not per-step repacking.** Decode has to see fixed-shape fp8 for cuda-graph capture to be valid, so the pool holds a per-layer `[rows, 512]` fp8 mirror plus a `[rows, 64]` bf16 rope mirror, allocated only when the gate is on. The mirrors are written by the same packer prefill history went through, so decode never reads a mix of two packers.
3. **The gate is read once at import.** `SGLANG_USE_AITER_MLA_DECODE` cannot change between graph capture and replay.

Commits are split so each one builds and is separately reviewable; the routing gate lands last, so everything before it is dead code by construction.

## Results

MI355X, DeepSeek-V4 FP4, TP8/EP8 with dp-attention and MTP. Relative to the Triton decode on the same machine with only the gate flipped:

| Workload | Output throughput |
|---|---|
| 8k/1k, concurrency 64 | **+8.6%** |
| 3600 s agentic trace, concurrency 48, ~132k mean input | **-3.4%** |

The long-context case is the interesting one. Median per-rank generation throughput over roughly 8,000 decode batches is within **0.3%** either way, so the fp8 kernel is not actually buying anything at the shapes that trace decodes at (batch of about 4 per rank against ~590k KV tokens in the batch), while the mirrors still cost **28.7 GB per rank**. MTP accept length, decode batch occupancy and KV pool size were identical across the pair, and GSM8K scores the same with the gate on and off.
For accuracy check, we ran the diff on GSM 8k with 1319 test prompts in parallel and accuracy scores look good and do not show any regression.

|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value |   |Stderr|
|-----|------:|----------------|-----:|-----------|---|-----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.9689|±  |0.0048|
|     |       |strict-match    |     5|exact_match|↑  |0.9689|±  |0.0048|

My leading hypothesis is the per-step Q pack in the adapter: Q is packed once per decode step per layer, and that wants folding into the RMSNorm+RoPE launch rather than standing as its own kernel. I have not confirmed it with a trace yet.

## Why default off

Off is byte-for-byte the existing Triton path: no mirror allocation, no packer calls, no behaviour change. Given the long-context regression and the VRAM cost, opt-in is the only honest default until the Q pack is fused and re-measured.

## Notes for reviewers

- The on-the-fly repack fallback in the adapter (used when the caller has no mirrors) gathers a variable number of rows and is therefore **not** cuda-graph safe. It exists for bring-up and correctness checking, not for performance.
- `_quant_k_cache_aiter_2buff_kernel` casts `token_id` to int64, matching the hardening already in `_quant_k_cache_fused_kernel`: it multiplies a 512- or 576-element row stride, which overflows int32 past roughly 3.7M rows, well inside the pool sizes long-context serving allocates.
- DeepSeek-V4 weights are not public, so reviewers cannot reproduce these numbers directly. Happy to run any additional configuration you want to see.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit)
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-tests)
- [x] Update documentation as needed, including docstrings or example tutorials

Made with [Cursor](https://cursor.com)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33065477408](https://github.com/sgl-project/sglang/actions/runs/33065477408)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33065477294](https://github.com/sgl-project/sglang/actions/runs/33065477294)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33065477456](https://github.com/sgl-project/sglang/actions/runs/33065477456)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->