### PR TITLE
Fix generic Transformers-fallback multimodal path for Chameleon and Fuyu

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1883,6 +1883,7 @@ def is_generation_model(model_architectures: List[str], is_embedding: bool = Fal
 
 
 multimodal_model_archs = [
+    "ChameleonForConditionalGeneration",
     "CLIPModel",
     "Cohere2VisionForConditionalGeneration",
     "DeepseekVL2ForCausalLM",

--- a/python/sglang/srt/models/transformers.py
+++ b/python/sglang/srt/models/transformers.py
@@ -574,6 +574,24 @@ class TransformersBase(nn.Module):
         self.config = config
         self.text_config = get_hf_text_config(config)
         self.weight_mapper = self.hf_to_sglang_mapper
+
+        # Early-fusion mixed-modal models (e.g. Chameleon) share one vocabulary
+        # across text and image (VQ codebook) tokens and, unlike HF's own
+        # generate() (which gates this via multimodal_generation_mode="text-only"),
+        # sglang's generic wrapper does not implement .generate() at all -- so
+        # nothing stops the sampler from picking a codebook id, which decodes to
+        # an empty/invisible string. Derive the image-token id range once from
+        # the model's own vocabulary_map (keys emitted by the image tokenizer are
+        # named "IMGIMG..." in Chameleon's config) and mask them out of every
+        # next-token distribution by default, unless the config also declares an
+        # explicit image-generation entrypoint (none of sglang's serving paths
+        # support one today, so this is always the desired behavior).
+        self._suppressed_token_ids = None
+        vocabulary_map = getattr(config, "vocabulary_map", None)
+        if vocabulary_map:
+            image_ids = [v for k, v in vocabulary_map.items() if k.startswith("IMGIMG")]
+            if image_ids:
+                self._suppressed_token_ids = torch.tensor(image_ids, dtype=torch.long)
         self.pp_group = get_pp_group()
 
         # Weight loading attrs
@@ -1079,9 +1097,16 @@ class TransformersBase(nn.Module):
             return self.pooler(hidden_states, forward_batch)
 
         assert self.logits_processor is not None and self.lm_head is not None
-        return self.logits_processor(
+        output = self.logits_processor(
             input_ids, hidden_states, self.lm_head, forward_batch, None
         )
+        if self._suppressed_token_ids is not None and output.next_token_logits is not None:
+            output.next_token_logits.index_fill_(
+                -1,
+                self._suppressed_token_ids.to(output.next_token_logits.device),
+                -float("inf"),
+            )
+        return output
 
     # -- Weight loading -----------------------------------------------------
     def load_weights(self, weights: Iterable[tuple[str, torch.Tensor]]) -> set[str]:
@@ -1345,6 +1370,34 @@ class MultiModalMixin:
         super().__init__(*args, **kwargs)
         self._mm_padding_pattern = MultiModalityDataPaddingPatternMultimodalTokens()
 
+        # Early-fusion models (e.g. Chameleon) keep the decoder stack directly on
+        # the backbone (embed_tokens/layers/norm/rotary_emb as siblings of the
+        # image tokenizer, e.g. vqmodel) instead of nesting it under a separate
+        # "language_model" submodule like compositional VLMs (Qwen2.5-VL, LLaVA,
+        # etc). The class-level hf_to_sglang_mapper assumes the compositional
+        # layout; override those four prefixes back to identity when there is no
+        # "language_model" child so weight names actually match the constructed
+        # module tree.
+        if not any(
+            name == "language_model" for name, _ in self.model.named_children()
+        ):
+            self.weight_mapper = self.weight_mapper | WeightsMapper(
+                orig_to_new_prefix={
+                    "model.layers.": "model.layers.",
+                    "model.embed_tokens.": "model.embed_tokens.",
+                    "model.norm.": "model.norm.",
+                    "model.rotary_emb.": "model.rotary_emb.",
+                }
+            )
+
+        # Fuyu (and any other model whose forward() takes raw patches instead of
+        # a vision-tower's "pixel_values") needs its feature tensor forwarded
+        # under the name its own forward() actually accepts. Detect this from the
+        # real signature rather than hardcoding by architecture name.
+        fwd_params = inspect.signature(self.model.forward).parameters
+        if "pixel_values" not in fwd_params and "image_patches" in fwd_params:
+            self._mm_feature_kwarg = {**self._mm_feature_kwarg, "image": "image_patches"}
+
         # transformers v5 flattened SigLIP/CLIP (dropped the "vision_model"
         # wrapper); older checkpoints still ship "vision_tower.vision_model.*"
         # keys, so remap them when the live model lacks that sub-module.
@@ -1513,6 +1566,18 @@ class MultiModalMixin:
         ):
             mm_inputs = forward_batch.mm_inputs
             target_device = next(self.model.parameters()).device
+            # Only pixel-value-like floating tensors need this -- integer tensors
+            # (e.g. mm_token_type_ids collected above) must stay integer dtype.
+            target_dtype = next(
+                (p.dtype for p in self.model.parameters() if p.is_floating_point()),
+                None,
+            )
+
+            def _to_device_and_dtype(t: torch.Tensor) -> torch.Tensor:
+                if target_dtype is not None and t.is_floating_point():
+                    return t.to(device=target_device, dtype=target_dtype)
+                return t.to(device=target_device)
+
             # 5D features (num_images, num_patches, C, H, W) can't be flattened
             # here: anyres models pad num_patches per HF processor call, so a
             # flattened concat would leave stray padding rows once items with
@@ -1529,7 +1594,7 @@ class MultiModalMixin:
                 for item in mm_input.mm_items or []:
                     for key, value in (item.model_specific_data or {}).items():
                         if isinstance(value, torch.Tensor):
-                            value = value.to(device=target_device)
+                            value = _to_device_and_dtype(value)
                         if key not in kwargs:
                             kwargs[key] = value
                         elif isinstance(value, torch.Tensor) and isinstance(
@@ -1542,7 +1607,7 @@ class MultiModalMixin:
                         )
                         feature = item.feature
                         if isinstance(feature, torch.Tensor):
-                            feature = feature.to(device=target_device)
+                            feature = _to_device_and_dtype(feature)
                             if feature.dim() == 5:
                                 pending_5d_features.setdefault(feature_key, []).append(
                                     feature

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -392,6 +392,8 @@ class BaseMultimodalProcessor(ABC):
             "patch_pixel_values": Modality.IMAGE,
             "block_sizes": Modality.IMAGE,
             "grid_thws": Modality.IMAGE,  # for kimi k2.5
+            "image_patches": Modality.IMAGE,  # Fuyu: raw flattened patches, embedded inside forward()
+            "image_patches_indices": Modality.IMAGE,  # Fuyu: sequence positions for each patch
             # Audio-related attributes
             "audio_features": Modality.AUDIO,
             "audio_feature_lens": Modality.AUDIO,
@@ -410,6 +412,7 @@ class BaseMultimodalProcessor(ABC):
         # name of the feature filed
         # TODO: pass from processors
         self.FEATURE_NAMES = [
+            "image_patches",  # Fuyu: raw flattened patches, treated as the primary feature tensor
             "pixel_values",
             "pixel_values_videos",
             "audio_features",


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Two models that fall back to the generic `TransformersMultiModalForCausalLM` path (no native sglang model implementation) currently produce broken output:

- `facebook/chameleon-7b` generates garbage/invisible text for every prompt, text-only or with an image.
- `adept/fuyu-8b` silently drops its image input — no error, no `image_tokens` in the response usage, the model just answers as if no image was given.

Neither is usable today via `--enable-multimodal` with `--model-impl transformers` (or via the automatic fallback when no native implementation exists).

## Modifications

**Chameleon (`facebook/chameleon-7b`)** — three separate gaps in the fallback path:

1. `ChameleonForConditionalGeneration` was never registered in `multimodal_model_archs` (`configs/model_config.py`), so it never took the multimodal fallback path at all and loaded as a text-only model.
2. Chameleon is an early-fusion model: its backbone keeps `embed_tokens`/`layers`/`norm`/`rotary_emb` as direct siblings of the image tokenizer (`vqmodel`), with no `language_model` submodule. `MultiModalMixin.hf_to_sglang_mapper` assumes the compositional VLM layout (Qwen2.5-VL, LLaVA, etc.) and remaps these prefixes under `model.language_model.*`, which doesn't exist for Chameleon and breaks weight loading. `MultiModalMixin.__init__` now detects the absence of a `language_model` child and remaps those four prefixes back to identity.
3. sglang's generic wrapper never calls HF's own `.generate()`, which is what normally restricts sampling to text-only via `multimodal_generation_mode="text-only"` for mixed-modal models. With that gate bypassed, nothing stops the sampler from emitting image/VQ-codebook token ids (Chameleon shares one vocabulary across text and image tokens), which decode to invisible/garbage text. `TransformersBase` now derives the image-token id range once from the model's own `vocabulary_map` (keys prefixed `IMGIMG...`) and masks them out of every next-token distribution.

**Fuyu (`adept/fuyu-8b`)**:

Fuyu's `forward()` takes raw `image_patches`/`image_patches_indices` directly instead of the standard `pixel_values` → `get_image_features()` pattern used by other VLMs. Neither attribute was recognized by `collect_mm_items_from_processor_output()` (`multimodal/processors/base_processor.py`), so no `MultimodalDataItem` was ever created for the image — it was dropped before it could reach the model. Added both to `ATTR_NAME_TO_MODALITY` and `image_patches` to `FEATURE_NAMES`. `MultiModalMixin.__init__` also now inspects the model's actual `forward()` signature and forwards the feature tensor under `image_patches` instead of the default `pixel_values` when the model doesn't accept the latter.

**Shared fix**: `_collect_mm_kwargs` only moved floating-point `model_specific_data`/`feature` tensors to the target device, never cast them to the model's dtype. Any early-fusion model whose `forward()` consumes these tensors directly (bypassing the `get_image_feature()` encoder path) hits a dtype mismatch crash against bf16 weights (`Input type (float) and bias type (c10::BFloat16) should be the same`). Both Chameleon and Fuyu hit this.

## Accuracy Tests

Verified locally on H200 with `facebook/chameleon-7b` and `adept/fuyu-8b` via raw HTTP requests against `sglang.launch_server`:

- Chameleon, vision (`/v1/chat/completions` with an image, `--chat-template chatml`): coherent English response, `image_tokens: 1024` in usage, `finish_reason: "stop"` — previously decoded to empty/invisible text.
- Chameleon, text-only chat: correct, coherent answer (e.g. "The capital of France is Paris.") with proper stop.
- Chameleon, plain completion (no chat template): coherent reasoning-style continuation.
- Fuyu, vision (`/v1/chat/completions` with an image, `--chat-template unlimited-ocr`): model correctly reads text rendered in a synthetic test image (" Hello world."), `image_tokens: 40` in usage, `finish_reason: "stop"` — previously the image was silently dropped and `image_tokens` was absent.

No existing sglang test suite exercises either model's multimodal path today, so no prior baseline was regressed by this fix (both were fully non-functional before it).

## Speed Tests and Profiling

Not applicable — this is a correctness fix for the generic fallback path (no native sglang implementation exists for either model), not a performance change.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33067982314](https://github.com/sgl-project/sglang/actions/runs/33067982314)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33067982358](https://github.com/sgl-project/sglang/actions/runs/33067982358)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33067982307](https://github.com/sgl-project/sglang/actions/runs/33067982307)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->