### PR TITLE
[Fix] GLM detectors: streamed tool-call arguments disagree with non-streaming

### DIFF
--- a/python/sglang/srt/function_call/glm47_moe_detector.py
+++ b/python/sglang/srt/function_call/glm47_moe_detector.py
@@ -331,6 +331,21 @@ class Glm47MoeDetector(BaseFormatDetector):
         # Default to string (safest fallback)
         return "string"
 
+    def _needs_closing_brace(self, streamed_args: str) -> bool:
+        """Whether the streamed argument object is still missing its final "}".
+
+        This cannot be decided from the last character: when the final argument
+        value is itself an object, ``streamed_args`` already ends with "}" (the
+        value's own brace) while the outer object is still open, e.g.
+        ``{"o": {"k": 1}``. Parse instead and only treat it as complete when it
+        is valid JSON on its own.
+        """
+        try:
+            json.loads(streamed_args)
+            return False
+        except (json.JSONDecodeError, ValueError):
+            return True
+
     def _format_value_complete(self, value: str, value_type: str) -> str:
         """Format complete value based on type.
 
@@ -345,15 +360,14 @@ class Glm47MoeDetector(BaseFormatDetector):
             # Ensure proper JSON string formatting with quotes
             return json.dumps(value, ensure_ascii=False)
         elif value_type == "number":
-            try:
-                num = _convert_to_number(value.strip() if value else "")
+            num = _convert_to_number(value.strip() if value else "")
+            # _convert_to_number returns the input unchanged when it is not
+            # numeric, so an isinstance check is required: returning str(num)
+            # blindly would emit a bare, invalid JSON token (123abc).
+            if isinstance(num, (int, float)) and not isinstance(num, bool):
                 return str(num)
-            except (ValueError, AttributeError):
-                # Fallback to string if not a valid number
-                logger.warning(
-                    f"Failed to parse '{value}' as number, treating as string"
-                )
-                return json.dumps(str(value) if value else "", ensure_ascii=False)
+            logger.warning(f"Failed to parse '{value}' as number, treating as string")
+            return json.dumps(str(value) if value else "", ensure_ascii=False)
         else:
             # For object/array types, return as-is (should already be valid JSON)
             return value
@@ -403,8 +417,11 @@ class Glm47MoeDetector(BaseFormatDetector):
                     self._current_value = ""
                     self._xml_tag_buffer = ""
                     self._value_started = False
-                    # Determine and cache the value type at the start
-                    self._cached_value_type = self._get_value_type(
+                    # Only the schema-declared type is known this early. Value
+                    # based auto-detection is deferred to </arg_value>, because
+                    # _current_value is still empty here and inferring now would
+                    # always fall back to "string".
+                    self._cached_value_type = get_argument_type(
                         func_name, self._current_key, tools
                     )
 
@@ -412,6 +429,13 @@ class Glm47MoeDetector(BaseFormatDetector):
                 if self._xml_tag_buffer.endswith("</arg_value>"):
                     final_value = self._xml_tag_buffer[:-12]
                     self._current_value += final_value
+
+                    # The schema declared no type, so infer it now that the
+                    # complete value is known.
+                    if self._cached_value_type is None:
+                        self._cached_value_type = self._get_value_type(
+                            func_name, self._current_key, tools
+                        )
 
                     # Use cached value type for consistency
                     value_type = self._cached_value_type or "string"
@@ -448,9 +472,18 @@ class Glm47MoeDetector(BaseFormatDetector):
                     if not is_potential_closing:
                         content = self._xml_tag_buffer
                         # Use cached value type for consistency
-                        value_type = self._cached_value_type or "string"
+                        value_type = self._cached_value_type
 
-                        if value_type == "string":
+                        if value_type is None:
+                            # No schema type for this argument. Buffer the value
+                            # instead of emitting it: the type can only be
+                            # decided once the whole value is known. Guessing
+                            # from the leading characters would quote a number
+                            # (123 -> "123") or emit malformed JSON.
+                            if content:
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+                        elif value_type == "string":
                             if not self._value_started:
                                 json_output += '"'
                                 self._value_started = True
@@ -613,7 +646,10 @@ class Glm47MoeDetector(BaseFormatDetector):
             self._last_arguments += "{}"
             self.streamed_args_for_tool[self.current_tool_id] += "{}"
             self._sent_empty_object = True
-        elif not self._last_arguments.endswith("}") and not self._sent_empty_object:
+        elif (
+            self._needs_closing_brace(self._last_arguments)
+            and not self._sent_empty_object
+        ):
             # Need to close brace
             calls.append(
                 ToolCallItem(

--- a/python/sglang/srt/function_call/glm4_moe_detector.py
+++ b/python/sglang/srt/function_call/glm4_moe_detector.py
@@ -289,6 +289,21 @@ class Glm4MoeDetector(BaseFormatDetector):
         # Default to string (safest fallback)
         return "string"
 
+    def _needs_closing_brace(self, streamed_args: str) -> bool:
+        """Whether the streamed argument object is still missing its final "}".
+
+        This cannot be decided from the last character: when the final argument
+        value is itself an object, ``streamed_args`` already ends with "}" (the
+        value's own brace) while the outer object is still open, e.g.
+        ``{"o": {"k": 1}``. Parse instead and only treat it as complete when it
+        is valid JSON on its own.
+        """
+        try:
+            json.loads(streamed_args)
+            return False
+        except (json.JSONDecodeError, ValueError):
+            return True
+
     def _format_value_complete(self, value: str, value_type: str) -> str:
         """Format complete value based on type.
 
@@ -303,15 +318,14 @@ class Glm4MoeDetector(BaseFormatDetector):
             # Ensure proper JSON string formatting with quotes
             return json.dumps(value, ensure_ascii=False)
         elif value_type == "number":
-            try:
-                num = _convert_to_number(value.strip())
+            num = _convert_to_number(value.strip())
+            # _convert_to_number returns the input unchanged when it is not
+            # numeric, so an isinstance check is required: returning str(num)
+            # blindly would emit a bare, invalid JSON token (123abc).
+            if isinstance(num, (int, float)) and not isinstance(num, bool):
                 return str(num)
-            except (ValueError, AttributeError):
-                # Fallback to string if not a valid number
-                logger.warning(
-                    f"Failed to parse '{value}' as number, treating as string"
-                )
-                return json.dumps(str(value), ensure_ascii=False)
+            logger.warning(f"Failed to parse '{value}' as number, treating as string")
+            return json.dumps(str(value), ensure_ascii=False)
         else:
             # For object/array types, return as-is (should already be valid JSON)
             return value
@@ -361,8 +375,11 @@ class Glm4MoeDetector(BaseFormatDetector):
                     self._current_value = ""
                     self._xml_tag_buffer = ""
                     self._value_started = False
-                    # Determine and cache the value type at the start
-                    self._cached_value_type = self._get_value_type(
+                    # Only the schema-declared type is known this early. Value
+                    # based auto-detection is deferred to </arg_value>, because
+                    # _current_value is still empty here and inferring now would
+                    # always fall back to "string".
+                    self._cached_value_type = get_argument_type(
                         func_name, self._current_key, tools
                     )
 
@@ -370,6 +387,13 @@ class Glm4MoeDetector(BaseFormatDetector):
                 if self._xml_tag_buffer.endswith("</arg_value>"):
                     final_value = self._xml_tag_buffer[:-12]
                     self._current_value += final_value
+
+                    # The schema declared no type, so infer it now that the
+                    # complete value is known.
+                    if self._cached_value_type is None:
+                        self._cached_value_type = self._get_value_type(
+                            func_name, self._current_key, tools
+                        )
 
                     # Use cached value type for consistency
                     value_type = self._cached_value_type or "string"
@@ -406,9 +430,18 @@ class Glm4MoeDetector(BaseFormatDetector):
                     if not is_potential_closing:
                         content = self._xml_tag_buffer
                         # Use cached value type for consistency
-                        value_type = self._cached_value_type or "string"
+                        value_type = self._cached_value_type
 
-                        if value_type == "string":
+                        if value_type is None:
+                            # No schema type for this argument. Buffer the value
+                            # instead of emitting it: the type can only be
+                            # decided once the whole value is known. Guessing
+                            # from the leading characters would quote a number
+                            # (123 -> "123") or emit malformed JSON.
+                            if content:
+                                self._current_value += content
+                                self._xml_tag_buffer = ""
+                        elif value_type == "string":
                             if not self._value_started:
                                 json_output += '"'
                                 self._value_started = True
@@ -572,7 +605,7 @@ class Glm4MoeDetector(BaseFormatDetector):
                             self.streamed_args_for_tool[
                                 self.current_tool_id
                             ] += empty_object
-                        elif not self._last_arguments.endswith("}"):
+                        elif self._needs_closing_brace(self._last_arguments):
                             closing_brace = "}"
                             calls.append(
                                 ToolCallItem(

--- a/test/registered/unit/function_call/test_glm_detector_streaming.py
+++ b/test/registered/unit/function_call/test_glm_detector_streaming.py
@@ -1,0 +1,187 @@
+"""Unit tests for the GLM tool-call detectors — no server, no model loading.
+
+These focus on streaming/non-streaming equivalence: the concatenation of the
+streamed argument deltas must parse to the same JSON that `detect_and_parse`
+produces for the same text.
+"""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.glm4_moe_detector import Glm4MoeDetector
+from sglang.srt.function_call.glm47_moe_detector import Glm47MoeDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+def _mk_tool(name, properties):
+    return Tool(
+        type="function",
+        function=Function(
+            name=name, parameters={"type": "object", "properties": properties}
+        ),
+    )
+
+
+# "typed" declares a schema for every argument; "untyped" declares none, which
+# is what exposes the value-type inference path.
+TOOLS = [
+    _mk_tool(
+        "typed",
+        {
+            "s": {"type": "string"},
+            "n": {"type": "number"},
+            "b": {"type": "boolean"},
+            "o": {"type": "object"},
+            "a": {"type": "array"},
+        },
+    ),
+    _mk_tool("untyped", {}),
+]
+
+
+class _GlmStreamingEquivalenceMixin:
+    """Shared assertions; subclasses provide detector_cls and build_text."""
+
+    detector_cls = None
+
+    def build_text(self, func_name, pairs):
+        raise NotImplementedError
+
+    def _stream_args(self, text):
+        """Feed text one character at a time, return {tool_index: (name, args)}."""
+        detector = self.detector_cls()
+        acc, order = {}, []
+        for ch in list(text) + ["", ""]:  # trailing flushes, as serving does
+            for call in detector.parse_streaming_increment(ch, TOOLS).calls:
+                if call.tool_index not in acc:
+                    acc[call.tool_index] = ["", ""]
+                    order.append(call.tool_index)
+                if call.name:
+                    acc[call.tool_index][0] = call.name
+                if call.parameters:
+                    acc[call.tool_index][1] += call.parameters
+        return [(acc[i][0], acc[i][1]) for i in order]
+
+    def assert_stream_matches_final(self, func_name, pairs):
+        text = self.build_text(func_name, pairs)
+
+        final = [
+            (c.name, c.parameters)
+            for c in self.detector_cls().detect_and_parse(text, TOOLS).calls
+        ]
+        streamed = self._stream_args(text)
+
+        self.assertEqual(len(streamed), len(final), f"call count differs for {text!r}")
+        for (s_name, s_args), (f_name, f_args) in zip(streamed, final):
+            self.assertEqual(s_name, f_name)
+            # Streamed arguments must be valid JSON on their own ...
+            parsed_streamed = json.loads(s_args) if s_args else None
+            parsed_final = json.loads(f_args) if f_args else None
+            # ... and must agree with the non-streaming result, types included
+            # (123 must not become "123").
+            self.assertEqual(
+                parsed_streamed,
+                parsed_final,
+                f"streamed args {s_args!r} != final args {f_args!r} for {text!r}",
+            )
+
+    # ---- schema-declared types: must keep char-by-char streaming behavior ----
+
+    def test_typed_string(self):
+        self.assert_stream_matches_final("typed", [("s", "hello")])
+
+    def test_typed_number(self):
+        self.assert_stream_matches_final("typed", [("n", "42")])
+
+    def test_typed_number_negative(self):
+        self.assert_stream_matches_final("typed", [("n", "-7")])
+
+    def test_typed_number_float(self):
+        self.assert_stream_matches_final("typed", [("n", "3.14")])
+
+    def test_typed_boolean(self):
+        self.assert_stream_matches_final("typed", [("b", "true")])
+
+    def test_typed_array(self):
+        self.assert_stream_matches_final("typed", [("a", "[1, 2]")])
+
+    def test_typed_empty_string(self):
+        self.assert_stream_matches_final("typed", [("s", "")])
+
+    def test_typed_multiple_arguments(self):
+        self.assert_stream_matches_final("typed", [("s", "abc"), ("n", "5")])
+
+    def test_typed_object_closing_brace(self):
+        # An object-valued last argument makes the streamed buffer end with "}"
+        # while the outer argument object is still open, so the outer closing
+        # brace must not be skipped.
+        self.assert_stream_matches_final("typed", [("o", '{"k": 1}')])
+
+    # ---- no schema type: value must be inferred from the complete value ----
+
+    def test_untyped_int_stays_int(self):
+        self.assert_stream_matches_final("untyped", [("x", "123")])
+
+    def test_untyped_negative_int_stays_int(self):
+        self.assert_stream_matches_final("untyped", [("x", "-123")])
+
+    def test_untyped_float_stays_float(self):
+        self.assert_stream_matches_final("untyped", [("x", "1.5")])
+
+    def test_untyped_bool_stays_bool(self):
+        self.assert_stream_matches_final("untyped", [("x", "true")])
+
+    def test_untyped_plain_text_stays_string(self):
+        self.assert_stream_matches_final("untyped", [("x", "hello world")])
+
+    def test_untyped_text_starting_with_digit_stays_string(self):
+        # Must not be mistaken for a number just because it starts with "1".
+        self.assert_stream_matches_final("untyped", [("x", "123abc")])
+
+    def test_untyped_object(self):
+        self.assert_stream_matches_final("untyped", [("x", '{"k": 1}')])
+
+    def test_untyped_array(self):
+        self.assert_stream_matches_final("untyped", [("x", "[1, 2]")])
+
+    def test_untyped_empty_value(self):
+        self.assert_stream_matches_final("untyped", [("x", "")])
+
+    def test_untyped_unicode(self):
+        self.assert_stream_matches_final("untyped", [("x", "北京")])
+
+    def test_untyped_mixed_arguments(self):
+        self.assert_stream_matches_final("untyped", [("x", "7"), ("y", "text")])
+
+
+class TestGlm4MoeDetectorStreaming(_GlmStreamingEquivalenceMixin, CustomTestCase):
+    """Covers the parsers registered as "glm" and "glm45"."""
+
+    detector_cls = Glm4MoeDetector
+
+    def build_text(self, func_name, pairs):
+        body = "".join(
+            f"<arg_key>{k}</arg_key>\n<arg_value>{v}</arg_value>\n" for k, v in pairs
+        )
+        return f"<tool_call>{func_name}\n{body}</tool_call>"
+
+
+class TestGlm47MoeDetectorStreaming(_GlmStreamingEquivalenceMixin, CustomTestCase):
+    """Covers the parser registered as "glm47"."""
+
+    detector_cls = Glm47MoeDetector
+
+    def build_text(self, func_name, pairs):
+        body = "".join(
+            f"<arg_key>{k}</arg_key><arg_value>{v}</arg_value>" for k, v in pairs
+        )
+        return f"<tool_call>{func_name}{body}</tool_call>"
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Partially addresses #35564 — specifically the `glm` / `glm45` / `glm47` rows, where the concatenation of the streamed argument deltas does not parse to the same JSON that `detect_and_parse` returns for the same text.

Reproducible on CPU with no server and no model, using the reporter's script:

```
glm / glm45 / glm47:  {"get_weather": 123}  streams as  {"get_weather": "123"}   # int -> str
```

While writing regression tests for that, two further streaming-only defects in the same code path surfaced, both also breaking streaming/non-streaming equivalence:

```
{"x": "123abc"}   streams as  {"x": 123abc}     # bare token, invalid JSON
{"o": {"k": 1}}   streams as  {"o": {"k": 1}    # outer object never closed
```

All three are fixed here since they share the same argument-emission path.

## Root causes

**1. Type inference ran before any value was available.** The value type was resolved when `<arg_value>` was seen, but `_current_value` is reset to `""` immediately before that call, so the auto-detection branch of `_get_value_type` always saw an empty string and returned `"string"`. Every argument without a declared schema type was therefore emitted quoted.

Inference is now deferred until the complete value is known (at `</arg_value>`). For schema-less arguments the value is buffered instead of being emitted incrementally, because the type cannot be decided from the leading characters without risking a wrong guess — the non-streaming path has the whole value available and this makes the streaming path agree with it. Arguments **with** a declared schema type are unaffected and keep true character-by-character streaming.

**2. `_format_value_complete` relied on an exception that never fires.** `_convert_to_number` catches `ValueError`/`AttributeError` internally and returns its input unchanged, so the `except` branch was dead code and `str(num)` emitted the raw string as if it were a number (`123abc` → `{"x": 123abc}`). It now checks the returned value's type and falls back to a JSON string, which also hardens the pre-existing case where a schema says `number` but the model emits something else.

**3. Outer closing brace was decided by the last character.** `not self._last_arguments.endswith("}")` is wrong when the final argument value is itself an object: the buffer already ends with the value's own brace while the outer object is still open. Completion is now determined by attempting to parse the buffer.

## Modifications

- `python/sglang/srt/function_call/glm4_moe_detector.py` (parsers `glm`, `glm45`)
- `python/sglang/srt/function_call/glm47_moe_detector.py` (parser `glm47`)

The two detectors carry near-identical copies of this logic, so the same three changes are applied to both.

## Tests

New `test/registered/unit/function_call/test_glm_detector_streaming.py`, registered for CPU CI (no GPU, no model load): 20 cases run against **both** detectors (40 tests), each feeding the text one character at a time and asserting the streamed deltas are (a) valid JSON on their own and (b) equal to the non-streaming result with types preserved.

Coverage includes schema-typed values of every kind (string / number / negative / float / boolean / array / object / empty / multiple arguments) to pin the unchanged fast path, plus schema-less values of every JSON type, `123abc`, empty values, unicode, and mixed arguments.

Verified before/after on the same suite: 34/40 → 40/40, with the 6 previously failing cases being exactly the three defects above across the two detectors.

## Checklist

- [x] Format the code and add unit tests
- [x] Update documentation as needed — n/a, internal parser behavior

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33068160711](https://github.com/sgl-project/sglang/actions/runs/33068160711)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33068160560](https://github.com/sgl-project/sglang/actions/runs/33068160560)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33068160792](https://github.com/sgl-project/sglang/actions/runs/33068160792)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->