### PR TITLE
dsv4(npu): support prefill context parallelism with interleave and zi…

### DIFF
--- a/python/sglang/kernels/ops/layernorm/mhc_head.py
+++ b/python/sglang/kernels/ops/layernorm/mhc_head.py
@@ -132,20 +132,30 @@ def fused_hc_head(
 
     hc_mult_pow2 = max(1, triton.next_power_of_2(hc_mult))
 
-    grid = (T,)
-    _hc_head_kernel[grid](
-        x,
-        hc_fn,
-        hc_scale,
-        hc_base,
-        y,
-        hidden_size=hidden_size,
-        HC_MULT=hc_mult_pow2,
-        K_TOTAL=hc_mult * hidden_size,
-        BLOCK_K=BLOCK_K,
-        BLOCK_D=BLOCK_D,
-        norm_eps=norm_eps,
-        hc_eps=hc_eps,
-        num_warps=4,
-    )
+    # Ascend caps a kernel grid's dim-0 (coreDim) at 65535. A single prefill
+    # forward can exceed that (e.g. under prefill context parallelism the
+    # cross-rank all-gather reconstructs the full-order sequence, which pads to
+    # max_rank_len * cp_size and can land at 65536). Tile the one-CTA-per-token
+    # launch over <=65535-row slices; each slice is a contiguous view of the
+    # (T, hc_mult, hidden_size) / (T, hidden_size) tensors, so the per-token
+    # pointer arithmetic (pid * K_TOTAL / pid * hidden_size) stays correct. For
+    # T <= MAX_GRID_DIM this is a single launch identical to the untiled path.
+    MAX_GRID_DIM = 65535
+    for start in range(0, T, MAX_GRID_DIM):
+        n_rows = min(MAX_GRID_DIM, T - start)
+        _hc_head_kernel[(n_rows,)](
+            x[start : start + n_rows],
+            hc_fn,
+            hc_scale,
+            hc_base,
+            y[start : start + n_rows],
+            hidden_size=hidden_size,
+            HC_MULT=hc_mult_pow2,
+            K_TOTAL=hc_mult * hidden_size,
+            BLOCK_K=BLOCK_K,
+            BLOCK_D=BLOCK_D,
+            norm_eps=norm_eps,
+            hc_eps=hc_eps,
+            num_warps=4,
+        )
     return y

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -11,7 +11,7 @@ from sglang.srt.arg_groups.overrides import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_platform
-from sglang.srt.utils.common import is_npu
+from sglang.srt.utils import is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -156,6 +156,57 @@ def apply_deepseek_v4_defaults(server_args: ServerArgs, model_arch: str) -> None
             ), f"Only EAGLE speculative algorithm with topk == 1 is supported for {model_arch}"
 
 
+def validate_deepseek_v4_layer_split(server_args: ServerArgs) -> None:
+    """Validate --enable-dsa-cache-layer-split for DeepSeek V4.
+
+    Shards the NPU KV/indexer cache layers across prefill CP ranks; only legal
+    on PD prefill workers (decode needs a full local cache).
+    """
+    cfg = resolving_view(server_args)
+    if not cfg.enable_dsa_cache_layer_split:
+        return
+
+    if cfg.disaggregation_mode != "prefill":
+        if cfg.disaggregation_mode == "decode":
+            raise ValueError(
+                "--enable-dsa-cache-layer-split is not supported on decode "
+                "workers. This flag is a prefill-CP optimization; decode "
+                "receives the full cache through PD transfer."
+            )
+        raise ValueError(
+            "--enable-dsa-cache-layer-split is only supported on PD prefill "
+            "workers. Non-PD workers also run decode and require ordinary "
+            "local decode cache semantics."
+        )
+    if not cfg.enable_prefill_cp:
+        raise ValueError(
+            "--enable-dsa-cache-layer-split requires --enable-prefill-cp "
+            "(it shards cache layers across context-parallel ranks)."
+        )
+    if cfg.pp_size > 1:
+        raise ValueError(
+            "--enable-dsa-cache-layer-split is not supported with pipeline "
+            "parallelism (pp_size > 1) yet."
+        )
+    # The ascend backend subclasses the mooncake transfer path that layer
+    # split builds on, so both are allowed; mori/nixl are not.
+    if cfg.disaggregation_transfer_backend not in ("mooncake", "ascend"):
+        raise ValueError(
+            "--enable-dsa-cache-layer-split supports the mooncake and ascend "
+            "transfer backends, got "
+            f"--disaggregation-transfer-backend {cfg.disaggregation_transfer_backend!r}."
+        )
+    if not is_npu():
+        raise ValueError(
+            "--enable-dsa-cache-layer-split for DeepSeek V4 currently requires "
+            "the NPU (Ascend) backend."
+        )
+    logger.info(
+        "DeepSeek V4 DSA cache layer split enabled: sharding KV/indexer cache "
+        f"layers across attn_cp_size={cfg.tp_size // cfg.dp_size} CP ranks."
+    )
+
+
 def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     """Validate DeepSeek V4 context-parallel configuration."""
     cfg = resolving_view(server_args)
@@ -207,7 +258,8 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
         assert (
             cfg.tp_size <= 8
         ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
-    if cfg.moe_a2a_backend not in ("none", "deepep", "megamoe"):
+    supported_a2a_backends = ("none", "deepep", "megamoe", "ascend_fuseep")
+    if cfg.moe_a2a_backend not in supported_a2a_backends:
         raise ValueError(
             f"DeepSeekV4 CP supports moe_a2a_backend in {supported_a2a_backends}, "
             f"got {cfg.moe_a2a_backend!r}."

--- a/python/sglang/srt/arg_groups/deepseek_v4_hook.py
+++ b/python/sglang/srt/arg_groups/deepseek_v4_hook.py
@@ -11,6 +11,7 @@ from sglang.srt.arg_groups.overrides import (
 )
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import get_platform
+from sglang.srt.utils.common import is_npu
 
 if TYPE_CHECKING:
     from sglang.srt.server_args import ServerArgs
@@ -161,9 +162,10 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     if not cfg.enable_prefill_cp:
         return
 
-    if cfg.cp_strategy != "interleave":
+    if cfg.cp_strategy not in ("interleave", "zigzag"):
         raise ValueError(
-            "DeepSeekV4 only supports interleave CP strategy, " f"got {cfg.cp_strategy}"
+            "DeepSeekV4 only supports interleave/zigzag CP strategy, "
+            f"got {cfg.cp_strategy}"
         )
 
     declare_resolution(
@@ -179,7 +181,9 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     declare_resolution(
         server_args,
         "validate_deepseek_v4_cp",
-        dsa_prefill_cp_mode="round-robin-split",
+        dsa_prefill_cp_mode=(
+            "round-robin-split" if cfg.cp_strategy == "interleave" else "in-seq-split"
+        ),
     )
     declare_resolution(
         server_args,
@@ -196,14 +200,14 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
         "validate_deepseek_v4_cp",
         attn_cp_size=cfg.tp_size // cfg.dp_size,
     )
-    assert (
-        cfg.dp_size == 1
-    ), "For round-robin split mode, dp attention is not supported."
-    assert (
-        cfg.tp_size <= 8
-    ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
-    supported_a2a_backends = ("none", "deepep", "megamoe", "mori")
-    if cfg.moe_a2a_backend not in supported_a2a_backends:
+    if not is_npu():
+        assert (
+            cfg.dp_size == 1
+        ), "For round-robin split mode, dp attention is not supported."
+        assert (
+            cfg.tp_size <= 8
+        ), "Context parallel only supports single machine (tp_size <= 8). Cross-machine CP has precision issues."
+    if cfg.moe_a2a_backend not in ("none", "deepep", "megamoe"):
         raise ValueError(
             f"DeepSeekV4 CP supports moe_a2a_backend in {supported_a2a_backends}, "
             f"got {cfg.moe_a2a_backend!r}."
@@ -215,6 +219,7 @@ def validate_deepseek_v4_cp(server_args: ServerArgs) -> None:
     envs.SGLANG_OPT_FLASHMLA_SPARSE_PREFILL.set(False)
     logger.warning(
         f"Enable Context Parallel for DeepSeekV4, "
+        f"strategy={cfg.cp_strategy}, "
         f"dp_size={cfg.dp_size}, moe_dense_tp_size={cfg.moe_dense_tp_size}, "
         f"attn_cp_size={cfg.attn_cp_size}, ep_size={cfg.ep_size}, tp_size={cfg.tp_size}"
     )

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -50,6 +50,7 @@ def handle_model_specific_adjustments(server_args: Any):
     from sglang.srt.configs.model_config import (
         get_mimo_v2_fused_qkv_expected_tp_size,
         is_deepseek_dsa,
+        is_deepseek_v4,
     )
 
     if cfg.enable_deterministic_inference:
@@ -84,10 +85,12 @@ def handle_model_specific_adjustments(server_args: Any):
                 "Intern-S2-Mobius does not support: " + "; ".join(unsupported) + "."
             )
 
-    if cfg.enable_dsa_cache_layer_split and not is_deepseek_dsa(hf_config):
+    if cfg.enable_dsa_cache_layer_split and not (
+        is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config)
+    ):
         raise ValueError(
             "--enable-dsa-cache-layer-split is only supported for DSA "
-            "(DeepSeek Sparse Attention) models."
+            "(DeepSeek Sparse Attention) models, including DeepSeek V4."
         )
 
     if cfg.enable_cp_decode_attn_tp:
@@ -334,10 +337,12 @@ def handle_model_specific_adjustments(server_args: Any):
     ]:
         from sglang.srt.arg_groups.deepseek_v4_hook import (
             validate_deepseek_v4_cp,
+            validate_deepseek_v4_layer_split,
             validate_deepseek_v4_mega_moe_token_budget,
         )
 
         validate_deepseek_v4_cp(server_args)
+        validate_deepseek_v4_layer_split(server_args)
         validate_deepseek_v4_mega_moe_token_budget(server_args)
 
         if get_platform().is_sm120:

--- a/python/sglang/srt/disaggregation/ascend/conn.py
+++ b/python/sglang/srt/disaggregation/ascend/conn.py
@@ -1,6 +1,7 @@
 import concurrent.futures
 import enum
 import logging
+import os
 from typing import List, Optional, Tuple
 
 import numpy as np
@@ -15,6 +16,12 @@ from sglang.srt.disaggregation.mooncake.conn import (
     MooncakeKVReceiver,
     MooncakeKVSender,
 )
+from sglang.srt.disaggregation.utils import (
+    DisaggregationMode,
+    build_transfer_entry_pairs,
+)
+from sglang.srt.environ import envs
+from sglang.srt.runtime_context import get_parallel
 from sglang.srt.utils.network import get_local_ip_auto
 
 logger = logging.getLogger(__name__)
@@ -34,6 +41,13 @@ class AscendKVManager(MooncakeKVManager):
         return (
             super()._requires_exact_state_index_match(st)
             or st in _DSV4_KVCACHE_STATE_TYPES
+        )
+
+    def _is_layer_split_kv_transfer(self) -> bool:
+        """Layer split registers only owned layers, so the positional
+        pp_size == 1 send path cannot be used."""
+        return self.disaggregation_mode == DisaggregationMode.PREFILL and (
+            get_parallel().enable_dsa_cache_layer_split
         )
 
     def init_engine(self):
@@ -59,8 +73,50 @@ class AscendKVManager(MooncakeKVManager):
         ):
             ptrs.extend(component_ptrs)
             lens.extend(component_lens)
+        logger.info(
+            "LSREG: pid=%d mode=%s layer_split=%d registering %d ranges, %d bytes",
+            os.getpid(),
+            self.disaggregation_mode,
+            int(self._is_layer_split_kv_transfer()),
+            len(ptrs),
+            sum(lens),
+        )
+        if envs.SGLANG_DSV4_VERIFY_PROBE.get() and ptrs:
+            # Full table (sorted) so a failing transfer block can be matched
+            # against the registered ranges on this rank.
+            table = sorted(zip(ptrs, lens))
+            logger.info(
+                "LSREG-FULL: pid=%d %s",
+                os.getpid(),
+                " ".join(f"{p:x}+{n:x}" for p, n in table),
+            )
         if ptrs:
             self.engine.batch_register(ptrs, lens)
+
+    def _transfer_data(self, mooncake_session_id, transfer_blocks):
+        if not transfer_blocks:
+            return 0
+        src_addrs, dst_addrs, lengths = zip(*transfer_blocks)
+        ret = self.engine.batch_transfer_sync(
+            mooncake_session_id, list(src_addrs), list(dst_addrs), list(lengths)
+        )
+        if ret != 0 and envs.SGLANG_DSV4_VERIFY_PROBE.get():
+            # The rejected batch is the ground truth behind an SMMU terminate:
+            # dump its address span to match against both peers' LSREG-FULL.
+            logger.error(
+                "LSXFER-FAIL: session=%s ret=%d blocks=%d "
+                "src=[%#x,%#x) dst=[%#x,%#x) first=%s last=%s",
+                mooncake_session_id,
+                ret,
+                len(transfer_blocks),
+                min(b[0] for b in transfer_blocks),
+                max(b[0] + b[2] for b in transfer_blocks),
+                min(b[1] for b in transfer_blocks),
+                max(b[1] + b[2] for b in transfer_blocks),
+                transfer_blocks[0],
+                transfer_blocks[-1],
+            )
+        return ret
 
     def get_mla_kv_ptrs_with_pp(
         self, src_kv_ptrs: List[int], dst_kv_ptrs: List[int], state_type=None
@@ -80,6 +136,29 @@ class AscendKVManager(MooncakeKVManager):
 
             if state_type == AscendStateType.DSV4_C128:
                 dst = dst_kv_ptrs[c128_start:c128_end]
+                return src_kv_ptrs, dst, len(src_kv_ptrs)
+
+            # NPU main KV layout [C4 KV, index K, index scale]; slice each dst
+            # section to the owned range (the trailing draft buffers pair
+            # positionally).
+            if state_type is None and self._is_layer_split_kv_transfer():
+                assert (
+                    end_layer is not None
+                ), "prefill_end_layer must be set for layer-split KV transfer"
+                owned_c4 = c4_end - c4_start
+                # Only the last CP rank ships the draft cache, so the src draft
+                # tail may be shorter than (or absent from) the dst tail.
+                n_draft_src = len(src_kv_ptrs) - 3 * owned_c4
+                n_draft_dst = len(dst_kv_ptrs) - 3 * c4_full
+                assert 0 <= n_draft_src <= n_draft_dst, (
+                    "Layer-split KV entry mismatch: src has "
+                    f"{len(src_kv_ptrs)} entries ({n_draft_src} draft), dst has "
+                    f"{len(dst_kv_ptrs)} ({n_draft_dst} draft)."
+                )
+                dst = []
+                for offset in (0, c4_full, 2 * c4_full):
+                    dst.extend(dst_kv_ptrs[offset + c4_start : offset + c4_end])
+                dst.extend(dst_kv_ptrs[3 * c4_full : 3 * c4_full + n_draft_src])
                 return src_kv_ptrs, dst, len(src_kv_ptrs)
 
             # NPU main KV layout: [C4 KV, index K, index scale].
@@ -145,19 +224,61 @@ class AscendKVManager(MooncakeKVManager):
             prefill_kv_indices, dst_kv_indices
         )
 
-        if self.pp_size > 1:
+        if self.pp_size > 1 or self._is_layer_split_kv_transfer():
             if self.is_mla_backend:
-                src_kv_ptrs, sliced_dst_kv_ptrs, layers_current_pp_stage = (
-                    self.get_mla_kv_ptrs_with_pp(self.kv_args.kv_data_ptrs, dst_kv_ptrs)
-                )
-                layers_params = [
-                    (
-                        src_kv_ptrs[layer_id],
-                        sliced_dst_kv_ptrs[layer_id],
-                        self.kv_args.kv_item_lens[layer_id],
+                layers_params = None
+                if self.kv_args.kv_layer_ids or dst_layer_ids:
+                    # Pair (buffer section, global layer id) entries. Layer
+                    # split registers only owned layers, so a positional
+                    # fallback would ship bytes into the wrong decode layers;
+                    # there it is a hard error.
+                    pairs = build_transfer_entry_pairs(
+                        self.kv_args.kv_layer_ids,
+                        dst_layer_ids or [],
+                        len(self.kv_args.kv_data_ptrs),
+                        len(dst_kv_ptrs),
+                        allow_positional_fallback=not self._is_layer_split_kv_transfer(),
                     )
-                    for layer_id in range(layers_current_pp_stage)
-                ]
+                    layers_params = [
+                        (
+                            self.kv_args.kv_data_ptrs[src],
+                            dst_kv_ptrs[dst],
+                            self.kv_args.kv_item_lens[src],
+                        )
+                        for src, dst in pairs
+                    ]
+                    if envs.SGLANG_DSV4_VERIFY_PROBE.get():
+                        import collections
+
+                        lens = collections.Counter(
+                            item_len for _, _, item_len in layers_params
+                        )
+                        logger.info(
+                            "LSSEND: pid=%d pages=%d src_entries=%d dst_entries=%d "
+                            "pairs=%d item_lens=%s dst_item_len=%s bytes=%d",
+                            os.getpid(),
+                            len(prefill_kv_indices),
+                            len(self.kv_args.kv_data_ptrs),
+                            len(dst_kv_ptrs),
+                            len(pairs),
+                            dict(lens),
+                            dst_kv_item_len,
+                            sum(l * len(prefill_kv_indices) for l in lens.elements()),
+                        )
+                if layers_params is None:
+                    src_kv_ptrs, sliced_dst_kv_ptrs, layers_current_pp_stage = (
+                        self.get_mla_kv_ptrs_with_pp(
+                            self.kv_args.kv_data_ptrs, dst_kv_ptrs
+                        )
+                    )
+                    layers_params = [
+                        (
+                            src_kv_ptrs[layer_id],
+                            sliced_dst_kv_ptrs[layer_id],
+                            self.kv_args.kv_item_lens[layer_id],
+                        )
+                        for layer_id in range(layers_current_pp_stage)
+                    ]
             else:
                 (
                     src_k_ptrs,

--- a/python/sglang/srt/disaggregation/ascend/transfer_engine.py
+++ b/python/sglang/srt/disaggregation/ascend/transfer_engine.py
@@ -86,11 +86,24 @@ class AscendTransferEngine(MooncakeTransferEngine):
     def batch_register(self, ptrs: List[int], lengths: List[int]):
         try:
             ret_value = self.engine.batch_register_memory(ptrs, lengths)
-        except Exception:
+        except Exception as exc:
             # Mark register as failed
             ret_value = -1
+            logger.warning(
+                "Ascend batch_register_memory raised: %d ptrs, %d bytes: %s",
+                len(ptrs),
+                sum(lengths),
+                exc,
+            )
         if ret_value != 0:
-            logger.debug(f"Ascend memory registration for ptr {ptrs} failed.")
+            # A rejected range only surfaces later as an SMMU terminate on the
+            # first DMA touching it, so this must be loud, not debug.
+            logger.error(
+                "Ascend memory registration FAILED: ret=%d, %d ptrs, %d bytes",
+                ret_value,
+                len(ptrs),
+                sum(lengths),
+            )
 
     @staticmethod
     def _get_transfer_protocol():

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import time
 from collections import deque
 from concurrent.futures import Future
@@ -2661,6 +2662,18 @@ class SchedulerDisaggregationDecodeMixin:
         self.waiting_queue = waiting_queue
         if len(can_run_list) == 0:
             return None
+        if envs.SGLANG_DSV4_VERIFY_PROBE.get():
+            for req in can_run_list:
+                logger.info(
+                    "DECODE admit: pid=%d rid=%s room=%s seq_len=%s "
+                    "kv_committed=%s prefix=%d",
+                    os.getpid(),
+                    req.rid,
+                    getattr(req, "bootstrap_room", None),
+                    getattr(req, "seq_len", None),
+                    getattr(req.kv, "kv_committed_len", None),
+                    len(req.prefix_indices),
+                )
 
         set_time_batch(can_run_list, "set_forward_entry_time")
 

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -704,6 +704,17 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 layers_params = [
                     (src_data_ptrs[i], dst_data_ptrs[j], item_lens[i]) for i, j in pairs
                 ]
+                if envs.SGLANG_DSV4_VERIFY_PROBE.get():
+                    logger.info(
+                        "LSSEND-STATE: pid=%d state_type=%s pairs=%d "
+                        "src_entries=%d dst_entries=%d first_pair=%s",
+                        os.getpid(),
+                        state_type,
+                        len(layers_params),
+                        len(src_data_ptrs),
+                        len(dst_data_ptrs),
+                        layers_params[0] if layers_params else None,
+                    )
             else:
                 src_kv_ptrs, dst_kv_ptrs, layers_current_pp_stage = (
                     self.get_mla_kv_ptrs_with_pp(
@@ -1451,6 +1462,13 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
                         state_type=st,
+                        # State components must pair by layer id like the main
+                        # KV: a layer-split prefill registers a subset, so
+                        # positional slicing lands ring bytes in KV buffers
+                        # and the slot-id offset runs past the buffer (SMMU
+                        # terminate).
+                        src_layer_ids=src_state_layer_ids or None,
+                        dst_layer_ids=dst_state_layer_ids or None,
                     )
                     or rc
                 )

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -234,11 +234,18 @@ class PrefillBootstrapQueue:
         kv_data_ptrs, kv_data_lens, kv_item_lens = (
             self.token_to_kv_pool.get_contiguous_buf_infos()
         )
-        kv_args.prefill_end_layer = (
-            kv_args.prefill_start_layer + len(kv_data_ptrs)
-            if layer_shard_enabled
-            else getattr(self.token_to_kv_pool, "end_layer", None)
-        )
+        if layer_shard_enabled:
+            # Bucket-layout pools (e.g. DSV4) expose the owned global layer
+            # range directly; len() covers one-buffer-per-layer pools.
+            kv_args.prefill_end_layer = getattr(
+                self.token_to_kv_pool,
+                "layer_shard_end",
+                kv_args.prefill_start_layer + len(kv_data_ptrs),
+            )
+        else:
+            kv_args.prefill_end_layer = getattr(
+                self.token_to_kv_pool, "end_layer", None
+            )
 
         draft_kv_pool = self.draft_token_to_kv_pool if transfer_draft_cache else None
         num_draft_entries = 0

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -936,9 +936,13 @@ def build_kv_layer_ids(
     """
     from sglang.srt.mem_cache.memory_pool import HybridLinearKVPool
 
-    if not isinstance(token_to_kv_pool, HybridLinearKVPool):
+    if is_npu() and isinstance(token_to_kv_pool, DSV4NPUTokenToKVPool):
+        # Bucket-organized main KV; the pool reports one id per section entry.
+        layer_ids = token_to_kv_pool.get_kv_layer_ids()
+    elif isinstance(token_to_kv_pool, HybridLinearKVPool):
+        layer_ids = token_to_kv_pool.get_kv_layer_ids()
+    else:
         return []
-    layer_ids = token_to_kv_pool.get_kv_layer_ids()
     if draft_token_to_kv_pool is None:
         return layer_ids
 
@@ -1122,8 +1126,14 @@ def setup_state_kv_args(
         # DeepSeekV4TokenToKVPool inherits BaseSWAKVPool; its heterogeneous
         # state list is described per-entry via get_state_buf_infos.
         if isinstance(token_to_kv_pool, BaseSWAKVPool):
+            layer_ids = (
+                token_to_kv_pool.get_state_layer_ids()
+                if is_npu() and isinstance(token_to_kv_pool, DSV4NPUTokenToKVPool)
+                else None
+            )
             append_state_component(
-                kv_args, StateType.SWA, data_ptrs, data_lens, item_lens
+                kv_args, StateType.SWA, data_ptrs, data_lens, item_lens,
+                layer_ids=layer_ids,
             )
             # MXFP8 KV: each sub-pool's block scales ride as their own component
             # so they inherit the index payload of the KV they describe.
@@ -1169,6 +1179,12 @@ def setup_state_kv_args(
                         c128_ptrs,
                         c128_lens,
                         c128_item_lens,
+                        layer_ids=(
+                            token_to_kv_pool.get_c128_layer_ids()
+                            if is_npu()
+                            and isinstance(token_to_kv_pool, DSV4NPUTokenToKVPool)
+                            else None
+                        ),
                     )
         elif isinstance(token_to_kv_pool, HybridLinearKVPool):
             dim = (
@@ -1236,6 +1252,7 @@ def setup_state_kv_args(
                 c128_ptrs,
                 c128_lens,
                 c128_item_lens,
+                layer_ids=token_to_kv_pool.get_c128_layer_ids(),
             )
 
     # DSV4 NextN shares the target allocator, so target and draft use the same

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -467,6 +467,21 @@ class Envs:
     # ===================================================================
     SGLANG_DETECT_SLOW_RANK = EnvBool(False)
     SGLANG_DEBUG_MEMORY_POOL = EnvBool(False)
+    # Log every unified-radix match/insert (key lengths and hit length).
+    SGLANG_DEBUG_RADIX_CACHE = EnvBool(False)
+    # DSV4 NPU layer-split probe: LS_DEBUG logs every owner read with pre/post
+    # checksums and NaN counts; LS_SYNC device-syncs around them so the probe
+    # reads are ground truth across streams.
+    SGLANG_DSV4_LS_DEBUG = EnvBool(False)
+    SGLANG_DSV4_LS_SYNC = EnvBool(False)
+    # DSV4 decode verify-buffer probe: dump per-step invariants of the verify
+    # positions fill (shapes, seq-lens, gather bounds) to localize the aicore
+    # fault on that path; also logs decode request admissions.
+    SGLANG_DSV4_VERIFY_PROBE = EnvBool(False)
+    # DSV4 layer-split: owner reads stage <=N-byte chunks through a fresh
+    # staging tensor and a chunked all-gather; broadcast corrupts payload
+    # bytes on the ZBAL-interposed torch.distributed of this stack.
+    SGLANG_DSV4_LS_CHUNK_BYTES = EnvInt(1024 * 1024)
     SGLANG_VALIDATE_MAMBA_REPLAY_STATE_INDICES = EnvBool(False)
     SGLANG_GDN_DECODE_FUSION_LOG_LAYER_HITS = EnvBool(False)
     SGLANG_GDN_DECODE_FUSION_VERIFY_REAL_TENSORS = EnvBool(False)

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Optional
 
@@ -17,6 +18,11 @@ from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
 from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.attention.ascend_backend import AscendAttnBackend
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_rope import Dsv4NpuRoPE
+<<<<<<< HEAD
+=======
+from sglang.srt.layers.cp.base import get_cp_strategy
+from sglang.srt.hardware_backend.npu.utils import is_npu_arch35
+>>>>>>> 2fdfe9ff76 (dsv4(npu): support prefill context parallelism with interleave and zigzag (#23))
 from sglang.srt.model_executor.forward_batch_info import DSV4OutCacheLoc, ForwardMode
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.runtime_context import get_parallel
@@ -356,6 +362,17 @@ class CompressorAscendBackendMixin:
             return
         compressor(x, forward_batch)
 
+    def forward_indexer_compressor(
+        self,
+        x: torch.Tensor,
+        forward_batch: ForwardBatch,
+        layer_id: int,
+        compressor,
+    ) -> None:
+        if forward_batch.forward_mode.is_idle():
+            return
+        compressor(x, forward_batch)
+
     def forward_compress(
         self,
         compressor,
@@ -521,11 +538,13 @@ class C4IndexerAscendBackendMixin:
         x: torch.Tensor,
         q_lora: torch.Tensor,
         forward_batch: ForwardBatch,
+        skip_compressor: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         q = self._compute_q_npu(c4_indexer, q_lora, forward_batch.positions)
         weights, _ = c4_indexer.weights_proj(x)
         weights = weights * (c4_indexer.softmax_scale * c4_indexer.n_heads**-0.5)
-        c4_indexer.compressor(x, forward_batch)
+        if not skip_compressor:
+            c4_indexer.compressor(x, forward_batch)
         return q, weights
 
     def _can_use_indexer_multi_stream(self) -> bool:
@@ -545,6 +564,7 @@ class C4IndexerAscendBackendMixin:
         q_lora: torch.Tensor,
         forward_batch: ForwardBatch,
         q_lora_ready,
+        skip_compressor: bool = False,
     ) -> tuple[torch.Tensor, torch.Tensor]:
         from sglang.srt.hardware_backend.npu.utils import (
             get_indexer_weight_stream,
@@ -559,7 +579,8 @@ class C4IndexerAscendBackendMixin:
         stream_w.wait_stream(cur)
 
         # route-KV write on cur; ordered before the topk read by cur's program order.
-        c4_indexer.compressor(x, forward_batch)
+        if not skip_compressor:
+            c4_indexer.compressor(x, forward_batch)
 
         # weights_proj + scale on stream_w.
         with torch.npu.stream(stream_w):
@@ -763,16 +784,16 @@ class C4IndexerAscendBackendMixin:
     ) -> None:
         if forward_batch.forward_mode.is_idle():
             return
-        assert (
-            not skip_compressor
-        ), "skip_compressor=True is not supported on the NPU indexer path"
         self._ensure_npu_c4_indexer(c4_indexer, x.device)
+        # CP path runs the compressor separately under full metadata.
         if self._can_use_indexer_multi_stream():
             q, weights = self._forward_prepare_multi_stream(
-                c4_indexer, x, q_lora, forward_batch, q_lora_ready
+                c4_indexer, x, q_lora, forward_batch, q_lora_ready, skip_compressor
             )
         else:
-            q, weights = self._forward_prepare(c4_indexer, x, q_lora, forward_batch)
+            q, weights = self._forward_prepare(
+                c4_indexer, x, q_lora, forward_batch, skip_compressor
+            )
         topk_idxs = self._forward_indexer(c4_indexer, x, q, weights, forward_batch)
         self.forward_metadata.c4_topk_indices = topk_idxs
 
@@ -780,6 +801,27 @@ class C4IndexerAscendBackendMixin:
 class DeepseekV4AscendAttnBackend(
     AscendAttnBackend, C4IndexerAscendBackendMixin, CompressorAscendBackendMixin
 ):
+    _DSV4_CP_LOCAL_FIELDS = (
+        "actual_seq_lengths_q",
+        "actual_seq_lengths_q_pa",
+        "actual_seq_lengths_kv",
+        "block_tables",
+        "swa_page_table",
+        "c4_page_table",
+        "c128_page_table",
+        "kernel_metadata",
+        "c4_topk_indices",
+        "positions_cmp_padding_c4",
+        "positions_cmp_padding_c128",
+        "c4_state_page_table",
+        "c128_state_page_table",
+        "c4_loc",
+        "c128_loc",
+        "c4_state_loc",
+        "c128_state_loc",
+        "start_pos",
+        "seqused",
+    )
 
     def __init__(
         self,
@@ -906,6 +948,180 @@ class DeepseekV4AscendAttnBackend(
             page_index_aligned_size=128,
         )
         return ori_sparse_indices
+
+    def prepare_dsv4_cp_metadata(self, forward_batch: ForwardBatch) -> None:
+        if getattr(forward_batch, "dsv4_cp_metadata_prepared", False):
+            return
+        if getattr(forward_batch, "attn_cp_metadata", None) is None:
+            return
+        if not forward_batch.forward_mode.is_context_parallel_extend():
+            return
+        if forward_batch.forward_mode.is_target_verify():
+            return
+
+        # The shared prepare_context_parallel_metadata still returns the legacy
+        # round-robin metadata (no per-rank lengths); the strategy gather needs
+        # them. Rebuild interleave metadata here -- NPU-only, the shared
+        # builder stays untouched.
+        from sglang.srt.layers.attention.dsa.utils import (
+            is_dsa_prefill_cp_round_robin_split,
+        )
+
+        if is_dsa_prefill_cp_round_robin_split():
+            from sglang.srt.layers.cp.interleave import InterleaveCPStrategy
+
+            forward_batch.attn_cp_metadata = InterleaveCPStrategy(
+                cp_size=get_parallel().attn_cp_size
+            ).build_metadata(
+                num_tokens=forward_batch.input_ids.shape[0],
+                seqs_len=forward_batch.seq_lens_cpu.tolist(),
+                extend_seqs_len=forward_batch.extend_seq_lens_cpu,
+            )
+
+        strategy = get_cp_strategy()
+        if strategy is None:
+            from sglang.srt.layers.attention.dsa.utils import (
+                is_dsa_prefill_cp_in_seq_split,
+                is_dsa_prefill_cp_round_robin_split,
+            )
+
+            cp_size = get_parallel().attn_cp_size
+            if is_dsa_prefill_cp_round_robin_split():
+                from sglang.srt.layers.cp.interleave import InterleaveCPStrategy
+
+                strategy = InterleaveCPStrategy(cp_size=cp_size)
+            elif is_dsa_prefill_cp_in_seq_split():
+                from sglang.srt.layers.cp.zigzag import ZigzagCPStrategy
+
+                strategy = ZigzagCPStrategy(cp_size=cp_size)
+        if strategy is None or strategy.cp_size <= 1:
+            return
+
+        fm = self.forward_metadata
+        global_positions = forward_batch.positions
+        if global_positions is None:
+            return
+
+        device = global_positions.device
+        num_tokens = int(global_positions.shape[0])
+        local_idx = strategy.local_q_indices(num_tokens, forward_batch).to(
+            device=device, dtype=torch.long
+        )
+        if local_idx.numel() > 0:
+            local_idx = local_idx[local_idx < num_tokens]
+        local_positions = global_positions.index_select(0, local_idx)
+
+        extend_lens = getattr(forward_batch, "extend_seq_lens_cpu", None)
+        if extend_lens is None:
+            seq_lens_cpu = getattr(forward_batch, "seq_lens_cpu", None)
+            if seq_lens_cpu is not None:
+                extend_lens = seq_lens_cpu.tolist()
+            else:
+                extend_lens = [num_tokens]
+        extend_lens = [int(x) for x in extend_lens]
+        real_num_tokens = min(sum(extend_lens), num_tokens)
+
+        batch_ids_parts = []
+        for batch_id, length in enumerate(extend_lens):
+            if length <= 0:
+                continue
+            batch_ids_parts.append(
+                torch.full((length,), batch_id, dtype=torch.long, device=device)
+            )
+        if batch_ids_parts:
+            batch_ids = torch.cat(batch_ids_parts, dim=0)
+        else:
+            batch_ids = torch.empty(0, dtype=torch.long, device=device)
+        if batch_ids.shape[0] < num_tokens:
+            pad_len = num_tokens - batch_ids.shape[0]
+            batch_ids = torch.cat(
+                [batch_ids, torch.zeros(pad_len, dtype=torch.long, device=device)],
+                dim=0,
+            )
+        elif batch_ids.shape[0] > num_tokens:
+            batch_ids = batch_ids[:num_tokens]
+
+        local_batch_ids = batch_ids.index_select(0, local_idx)
+        valid_rows = local_idx < real_num_tokens
+        seqused_kv = torch.where(
+            valid_rows,
+            local_positions.to(torch.int32) + 1,
+            torch.ones_like(local_positions, dtype=torch.int32),
+        ).clamp(min=1)
+
+        full_fields = {
+            field: getattr(fm, field, None) for field in self._DSV4_CP_LOCAL_FIELDS
+        }
+        setattr(fm, "dsv4_cp_full_fields", full_fields)
+
+        def _select_rows(table: Optional[torch.Tensor]):
+            if table is None:
+                return None
+            if local_batch_ids.numel() == 0:
+                return table.new_empty((0, *table.shape[1:]))
+            return table.index_select(0, local_batch_ids)
+
+        fm.block_tables = _select_rows(full_fields["block_tables"])
+        fm.swa_page_table = _select_rows(full_fields["swa_page_table"])
+        if self._dsv4_has_c4:
+            fm.c4_page_table = _select_rows(full_fields["c4_page_table"])
+        if self._dsv4_has_c128:
+            fm.c128_page_table = _select_rows(full_fields["c128_page_table"])
+
+        local_t = int(local_idx.numel())
+        fm.actual_seq_lengths_q = torch.arange(
+            1, local_t + 1, dtype=torch.int32, device=device
+        )
+        fm.actual_seq_lengths_q_pa = torch.arange(
+            0, local_t + 1, dtype=torch.int32, device=device
+        )
+        fm.actual_seq_lengths_kv = seqused_kv
+        fm.kernel_metadata = self._kernel_metadata_from_parts(
+            bs=local_t,
+            actual_seq_lengths_q_pa=fm.actual_seq_lengths_q_pa,
+            actual_seq_lengths_kv=fm.actual_seq_lengths_kv,
+            block_tables=fm.block_tables,
+            max_seqlen_q=1,
+            is_nextn=False,
+        )
+        if self._dsv4_has_c4:
+            fm.c4_topk_indices = torch.full(
+                (local_t, self._dsv4_index_topk),
+                -1,
+                dtype=torch.int32,
+                device=device,
+            )
+
+        forward_batch.dsv4_cp_metadata_prepared = True
+        forward_batch.dsv4_cp_global_positions = global_positions
+        forward_batch.dsv4_cp_local_positions = local_positions
+        forward_batch.dsv4_cp_local_q_indices = local_idx
+        forward_batch.dsv4_cp_local_valid_mask = valid_rows
+        forward_batch.dsv4_cp_real_num_tokens = real_num_tokens
+
+    @contextmanager
+    def use_dsv4_cp_full_metadata(self, forward_batch: ForwardBatch):
+        fm = self.forward_metadata
+        full_fields = getattr(fm, "dsv4_cp_full_fields", None)
+        if not full_fields:
+            yield
+            return
+
+        local_fields = {
+            field: getattr(fm, field, None) for field in self._DSV4_CP_LOCAL_FIELDS
+        }
+        previous_positions = getattr(forward_batch, "positions", None)
+        try:
+            for field, value in full_fields.items():
+                setattr(fm, field, value)
+            global_positions = getattr(forward_batch, "dsv4_cp_global_positions", None)
+            if global_positions is not None:
+                forward_batch.positions = global_positions
+            yield
+        finally:
+            for field, value in local_fields.items():
+                setattr(fm, field, value)
+            forward_batch.positions = previous_positions
 
     def _init_dsv4_graph_buffers(self, *, max_bs: int, max_num_tokens: int) -> None:
         device = self.device

--- a/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
+++ b/python/sglang/srt/hardware_backend/npu/attention/ascend_dsv4_backend.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 from contextlib import contextmanager
 from types import SimpleNamespace
 from typing import TYPE_CHECKING, Optional
@@ -18,11 +19,7 @@ from sglang.kernels.ops.speculative.dspark.dspark_attn_metadata import (
 from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.npu.attention.ascend_backend import AscendAttnBackend
 from sglang.srt.hardware_backend.npu.dsv4.dsv4_rope import Dsv4NpuRoPE
-<<<<<<< HEAD
-=======
 from sglang.srt.layers.cp.base import get_cp_strategy
-from sglang.srt.hardware_backend.npu.utils import is_npu_arch35
->>>>>>> 2fdfe9ff76 (dsv4(npu): support prefill context parallelism with interleave and zigzag (#23))
 from sglang.srt.model_executor.forward_batch_info import DSV4OutCacheLoc, ForwardMode
 from sglang.srt.model_executor.forward_context import get_attn_backend
 from sglang.srt.runtime_context import get_parallel
@@ -2084,11 +2081,32 @@ class DeepseekV4AscendAttnBackend(
 
         if indices.numel() == 0:
             return
+        if envs.SGLANG_DSV4_VERIFY_PROBE.get():
+            oob = int(indices.max().item()) >= positions.numel()
+            logger.info(
+                "VERIFYFILL pre: rank=%d ratio=%d pos_numel=%d n_draft=%d "
+                "req_num=%d dst_numel=%d idx_numel=%d idx_max=%d oob=%s "
+                "seq_numel=%d seq_min=%d seq_max=%d",
+                os.getpid(),
+                ratio,
+                positions.numel(),
+                n_draft,
+                request_num,
+                dst.numel(),
+                indices.numel(),
+                int(indices.max().item()),
+                oob,
+                seq_lens_cpu.numel(),
+                int(seq_lens_cpu.min().item()),
+                int(seq_lens_cpu.max().item()),
+            )
         # This tiny H2D copy runs on the verify metadata path. Keep it blocking:
         # on NPU, a non-blocking copy from a short-lived pinned CPU tensor can
         # surface later as an unrelated CopyKernel stream failure.
         indices = indices[: dst.numel()].to(device=positions.device)
         dst[: indices.numel()].copy_(torch.gather(positions, 0, indices))
+        if envs.SGLANG_DSV4_VERIFY_PROBE.get():
+            logger.info("VERIFYFILL post: pid=%d ratio=%d", os.getpid(), ratio)
 
     def update_verify_buffers_to_fill_after_draft(
         self, spec_info, cuda_graph_bs: Optional[int]

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_cache_layer_split.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_cache_layer_split.py
@@ -1,0 +1,761 @@
+"""Layer-sharded DSV4 KV pool for NPU prefill context parallelism.
+
+``LayerSplitDSV4NPUTokenToKVPool`` splits the DeepSeek-V4 NPU KV/indexer cache
+layers across context-parallel (CP) ranks so each rank only materializes the
+layers it owns, cutting per-rank KV memory on PD prefill workers. When a rank
+reads a layer owned by another CP rank, the CP group runs a chunked all-gather
+into a per-family remote scratch buffer: the owner stages each chunk into a
+fresh staging tensor (never pool storage) and every rank copies the owner's
+slot. All-gather is the only collective that delivers correct payload bytes on
+the ZBAL-interposed torch.distributed of this stack; broadcast corrupts them.
+
+Compress-state pools are not sharded: the compressor runs on every rank for
+every layer (its internal CP all-gather requires the whole group), so every
+rank holds identical per-layer state and only the KV/indexer buffers are
+sharded.
+
+Layer split is enabled only for DSV4 PD prefill workers under prefill-CP (see
+``sglang.srt.layers.cp.utils.is_glm_dsa_cache_layer_split_enabled``).
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Callable, Dict, List, Optional, Tuple
+
+import torch
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.environ import envs
+from sglang.srt.hardware_backend.npu.dsv4.dsv4_layer_split_plan import (
+    DSV4LayerShardPlan,
+)
+from sglang.srt.hardware_backend.npu.dsv4.dsv4_memory_pool import (
+    DeepSeekV4SingleKVPool,
+    DSV4NPUTokenToKVPool,
+    NPUDeepSeekV4IndexerPool,
+    NPUDeepSeekV4SingleKVPool,
+)
+from sglang.srt.runtime_context import get_parallel
+
+logger = logging.getLogger(__name__)
+
+
+def _num_pages(size: int, page_size: int) -> int:
+    """Physical pages covering ``size`` tokens at ``page_size`` tokens/page."""
+    return (size + page_size + 1) // page_size
+
+
+def _probe_stats(tensor: torch.Tensor) -> Tuple[str, int]:
+    """``(checksum, NaN count)`` of ``tensor``; non-finite sums report verbatim."""
+    flat = tensor.reshape(-1)
+    if not flat.numel():
+        return "na", 0
+    values = flat.float()
+    nan = int(torch.isnan(values).sum().item())
+    total = values.sum().item()
+    checksum = str(int(total)) if math.isfinite(total) else repr(total)
+    return checksum, nan
+
+
+_LS_DEBUG = envs.SGLANG_DSV4_LS_DEBUG.get()
+# The compressor can write on a stream the current-stream sync does not order
+# against; only a device-wide sync makes the probe's pre/post reads ground
+# truth across streams.
+_LS_SYNC = envs.SGLANG_DSV4_LS_SYNC.get()
+# Owner reads stage chunks of this many bytes through a fresh staging tensor
+# so no collective operand is pool-resident multi-MB memory (ZBAL/VMM), the
+# operand class that corrupts on this stack.
+_LS_CHUNK_BYTES = envs.SGLANG_DSV4_LS_CHUNK_BYTES.get()
+assert _LS_CHUNK_BYTES > 0, "SGLANG_DSV4_LS_CHUNK_BYTES must be positive"
+_LS_DEBUG_VERBOSE = False
+_LS_FINGERPRINT_BLOCKS = 16
+
+
+def _fingerprint_equal(lo: torch.Tensor, hi: torch.Tensor) -> bool:
+    """NaN-safe exact comparison: identical buffers with NaNs must compare equal."""
+    return bool(torch.equal(torch.nan_to_num(lo), torch.nan_to_num(hi)))
+
+
+class LayerSplitNPUDeepSeekV4SingleKVPool(NPUDeepSeekV4SingleKVPool):
+    """NPU bf16 KV pool allocating full buffers for owned layers only.
+
+    Non-owned layers get 0-row placeholders so ``kv_buffer`` stays index
+    aligned; their content is materialized on read via the parent pool's
+    owner all-gather scratch buffer.
+    """
+
+    def __init__(self, *args, layer_owned_fn: Callable[[int], bool], **kwargs):
+        self._layer_owned_fn = layer_owned_fn
+        super().__init__(*args, **kwargs)
+
+    def _num_pages_for(self, local_layer_idx: int) -> int:
+        full_pages = _num_pages(self.size, self.kernel_page_size)
+        return full_pages if self._layer_owned_fn(local_layer_idx) else 0
+
+    def create_buffer(self, *, num_pages: int):
+        # The NPU base derives the page count from self.size; honor num_pages
+        # so non-owned layers are 0-row, not narrowed full storage.
+        assert self.store_dtype == torch.bfloat16, (
+            "LayerSplitDSV4NPUTokenToKVPool requires a bf16 KV cache; other "
+            "store dtypes fall back to a layout that cannot express 0-row "
+            f"non-owned layers (got {self.store_dtype})."
+        )
+        kv_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        self.kv_cache_total_dim = kv_dim
+        return torch.zeros(
+            num_pages,
+            self.kernel_page_size,
+            1,
+            kv_dim,
+            dtype=torch.bfloat16,
+            device=self.device,
+        )
+
+    def _create_buffers(self):
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.kv_buffer = [
+                self.create_buffer(num_pages=self._num_pages_for(i))
+                for i in range(self.layer_num)
+            ]
+
+
+class LayerSplitNPUDeepSeekV4IndexerPool(NPUDeepSeekV4IndexerPool):
+    """NPU c4-indexer pool allocating owned layers only.
+
+    The packed CUDA ``index_k_with_scale_buffer`` (NSA compat, unused for NPU
+    reads) and the dedicated int8 K / fp16 scale buffers all follow ownership.
+    """
+
+    def __init__(self, *args, layer_owned_fn: Callable[[int], bool], **kwargs):
+        self._layer_owned_fn = layer_owned_fn
+        super().__init__(*args, **kwargs)
+
+    def _owned_pages(self, local_layer_idx: int) -> int:
+        full_pages = _num_pages(self.size, self._kernel_page_size)
+        return full_pages if self._layer_owned_fn(local_layer_idx) else 0
+
+    def _create_buffer(self):
+        kp = self._kernel_page_size
+        page_bytes = self.page_size * self.get_bytes_per_token()
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            self.index_k_with_scale_buffer = [
+                torch.zeros(
+                    self._owned_pages(i),
+                    page_bytes,
+                    dtype=self.index_k_with_scale_buffer_dtype,
+                    device=self.device,
+                )
+                for i in range(self.layer_num)
+            ]
+            self.index_k_buffer = [
+                torch.zeros(
+                    self._owned_pages(i), kp, 1, self.index_head_dim,
+                    dtype=torch.int8, device=self.device,
+                )
+                for i in range(self.layer_num)
+            ]
+            self.index_scale_buffer = [
+                torch.zeros(
+                    self._owned_pages(i), kp, 1, 1,
+                    dtype=torch.float16, device=self.device,
+                )
+                for i in range(self.layer_num)
+            ]
+
+
+# Buffer families served through owner all-gather scratch copies. index_k and
+# index_scale exist only on c4 layers.
+_REMOTE_FAMILIES = ("swa", "c4", "c128", "index_k", "index_scale")
+
+
+class LayerSplitDSV4NPUTokenToKVPool(DSV4NPUTokenToKVPool):
+    """DSV4 NPU KV pool that shards layers across CP ranks.
+
+    Reads of non-owned layers are served from a per-family remote scratch
+    buffer filled by an owner all-gather; writes only land on owner ranks and
+    invalidate the local scratch copy so the next read re-gathers.
+    """
+
+    def __init__(self, *args, layer_shard_rank: int, layer_shard_size: int, **kwargs):
+        assert (
+            layer_shard_rank is not None and layer_shard_size > 1
+        ), "LayerSplitDSV4NPUTokenToKVPool requires layer_shard_size > 1"
+        self.layer_shard_rank = layer_shard_rank
+        self.layer_shard_size = layer_shard_size
+        self.layer_shard_enabled = True
+        # Built on the first _make_kv_pool call inside super().__init__: the
+        # plan needs layer_num / ratios / stage range the base sets before it.
+        self._shard_plan: Optional[DSV4LayerShardPlan] = None
+        super().__init__(*args, **kwargs)
+        assert (
+            not self._unified_kv
+        ), "Layer split does not support the unified-KV layout yet"
+        self._init_remote_buffers()
+        plan = self._get_shard_plan()
+        # Global (absolute) layer range owned by this rank, read by the PD
+        # bootstrap (disaggregation/prefill.py) to advertise the shard window.
+        self.layer_shard_start = plan.shard_start
+        self.layer_shard_end = plan.shard_end
+        logger.info(
+            "DSV4 layer shard plan (continuous): layer_num=%d, shard_size=%d, "
+            "rank=%d, global=[%d,%d), owned c4 range=%s, owned c128 range=%s, "
+            "partitions=%s",
+            self.layer_num,
+            self.layer_shard_size,
+            self.layer_shard_rank,
+            plan.shard_start,
+            plan.shard_end,
+            plan.owned_bucket_range("c4"),
+            plan.owned_bucket_range("c128"),
+            plan.partition_summary(),
+        )
+
+    # ---- ownership plan ----------------------------------------------------
+
+    def _get_shard_plan(self) -> DSV4LayerShardPlan:
+        if self._shard_plan is None:
+            self._shard_plan = DSV4LayerShardPlan(
+                rank=self.layer_shard_rank,
+                shard_size=self.layer_shard_size,
+                num_layers=self.layer_num,
+                stage_start=self._stage_start,
+                ratios=self.compression_ratios[self._stage_start : self._stage_end],
+            )
+        return self._shard_plan
+
+    def _is_layer_owned(self, layer_id: int) -> bool:
+        return self._get_shard_plan().is_layer_owned(layer_id)
+
+    def _layer_owner_rank(self, layer_id: int) -> int:
+        return self._get_shard_plan().owner_rank(layer_id)
+
+    def _owned_fn_for_bucket(self, bucket: str) -> Callable[[int], bool]:
+        plan = self._get_shard_plan()
+        ids = plan.bucket_layer_ids(bucket)
+        return lambda local_idx: plan.is_stage_local_owned(ids[local_idx])
+
+    # ---- sub-pool factories ------------------------------------------------
+
+    def _make_kv_pool(
+        self,
+        *,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        layer_num: int,
+        device: str,
+        enable_memory_saver: bool,
+        global_page_size: int,
+        cls: type = DeepSeekV4SingleKVPool,
+    ) -> LayerSplitNPUDeepSeekV4SingleKVPool:
+        assert cls is DeepSeekV4SingleKVPool, (
+            "enable_hisparse is incompatible with --enable-dsa-cache-layer-split "
+            f"(got c4 pool class {cls.__name__})."
+        )
+        # Full/SWA use the global page size, C4 its native page, C128 its own;
+        # mirrors the NPU base _make_kv_pool.
+        if page_size * 4 == global_page_size:
+            bucket, kernel_page_size = "c4", page_size
+        elif page_size * 128 == global_page_size:
+            bucket, kernel_page_size = "c128", self.c128_page_size
+        else:
+            bucket, kernel_page_size = "swa", global_page_size
+        return LayerSplitNPUDeepSeekV4SingleKVPool(
+            size,
+            page_size,
+            dtype,
+            self.qk_nope_head_dim,
+            self.qk_rope_head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+            kernel_page_size=kernel_page_size,
+            layer_owned_fn=self._owned_fn_for_bucket(bucket),
+        )
+
+    def _make_indexer_pool(
+        self,
+        size: int,
+        page_size: int,
+        dtype: torch.dtype,
+        index_head_dim: int,
+        layer_num: int,
+        device: str,
+        enable_memory_saver: bool,
+    ) -> LayerSplitNPUDeepSeekV4IndexerPool:
+        # Indexer shares C4 addresses and therefore uses the same native page.
+        return LayerSplitNPUDeepSeekV4IndexerPool(
+            size,
+            page_size,
+            dtype,
+            index_head_dim,
+            layer_num,
+            device,
+            enable_memory_saver,
+            kernel_page_size=page_size,
+            layer_owned_fn=self._owned_fn_for_bucket("c4"),
+        )
+
+    # ---- remote scratch + owner all-gather --------------------------------
+
+    def _init_remote_buffers(self) -> None:
+        # One full-layer scratch per family, allocated on every rank: a rank
+        # with no owned layer of a bucket still receives its gathers.
+        with self.memory_saver_adapter.region(GPU_MEMORY_TYPE_KV_CACHE):
+            device = self.device
+            kv_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+            dtype = self.swa_kv_pool.store_dtype
+
+            def scratch(sub_pool, page_size: int, rows: int, cols: int, dt: torch.dtype):
+                return torch.zeros(
+                    _num_pages(sub_pool.size, page_size),
+                    page_size,
+                    rows,
+                    cols,
+                    dtype=dt,
+                    device=device,
+                )
+
+            indexer = self.c4_indexer_kv_pool
+            self._remote_buffers = {
+                "swa": scratch(
+                    self.swa_kv_pool, self.swa_kv_pool.kernel_page_size, 1, kv_dim, dtype
+                ),
+                "c4": scratch(
+                    self.c4_kv_pool, self.c4_kv_pool.kernel_page_size, 1, kv_dim, dtype
+                ),
+                "c128": scratch(
+                    self.c128_kv_pool,
+                    self.c128_kv_pool.kernel_page_size,
+                    1,
+                    kv_dim,
+                    dtype,
+                ),
+                "index_k": scratch(
+                    indexer, indexer._kernel_page_size, 1, self.indexer_head_dim, torch.int8
+                ),
+                "index_scale": scratch(
+                    indexer, indexer._kernel_page_size, 1, 1, torch.float16
+                ),
+            }
+        # family -> layer_id of the last materialized remote copy.
+        self._remote_layer_cache: Dict[str, Optional[int]] = {
+            family: None for family in _REMOTE_FAMILIES
+        }
+        # Shared chunk-staging operand; int8 is the smallest family dtype, so
+        # byte capacity == element capacity.
+        self._staging = torch.zeros(
+            _LS_CHUNK_BYTES, dtype=torch.int8, device=self.device
+        )
+        # Read issue counter for the symmetric-participation probe
+        # (SGLANG_DSV4_LS_DEBUG=1): CP partners must log identical sequences.
+        self._read_seq = 0
+        self._read_mismatch = 0
+        self._self_test_pending = _LS_DEBUG
+
+    def _self_test_delivery(self) -> None:
+        """One-shot delivery check before the first read, exercising the same
+        chunked all-gather the production path uses: the shard's first rank
+        fills a pattern, all ranks gather, and the fingerprints must match."""
+        group = get_parallel().attn_cp_group
+        scratch = self._remote_buffers["swa"]
+        elem = scratch.element_size()
+        probe_elems = min(
+            scratch.numel(), _LS_CHUNK_BYTES // elem
+        )
+        if self.layer_shard_rank == 0:
+            scratch.reshape(-1)[:probe_elems].copy_(
+                torch.arange(
+                    1, probe_elems + 1, dtype=torch.float32, device=self.device
+                ).to(scratch.dtype)
+            )
+        torch.npu.synchronize()
+        send = self._staging[: probe_elems * elem].view(scratch.dtype)
+        send.copy_(scratch.reshape(-1)[:probe_elems])
+        gathered = torch.empty(
+            (group.world_size, probe_elems), dtype=scratch.dtype, device=scratch.device
+        )
+        torch.distributed.all_gather_into_tensor(
+            gathered, send, group=group.device_group
+        )
+        values = gathered[0].float()
+        stats = torch.stack([values.sum(), values.isnan().sum().float()])
+        lo = stats.clone()
+        hi = stats.clone()
+        torch.distributed.all_reduce(
+            lo, op=torch.distributed.ReduceOp.MIN, group=group.device_group
+        )
+        torch.distributed.all_reduce(
+            hi, op=torch.distributed.ReduceOp.MAX, group=group.device_group
+        )
+        logger.warning(
+            "LSSELF rank=%d equal=%d sum=%.6g nan=%.0f",
+            self.layer_shard_rank,
+            int(_fingerprint_equal(lo, hi)),
+            stats[0].item(),
+            stats[1].item(),
+        )
+        scratch.zero_()
+        torch.npu.synchronize()
+
+    def _read_layer_buffer(self, family: str, layer_id: int) -> torch.Tensor:
+        """This rank's buffer for ``family``/``layer_id``, remote layers included.
+
+        The scratch holds one layer per family, so the result must be consumed
+        before the next read overwrites it; the collective is issued on the
+        current stream, so it orders after the owner's staging writes. All
+        ranks issue these in the same order (a skipped call hangs the group)
+        and invalidation rides the write calls every rank issues.
+        """
+        local = self._local_family_buffer(family, layer_id)
+        remote = self._remote_buffers[family]
+        if self._remote_layer_cache[family] == layer_id:
+            if _LS_DEBUG and family in ("c4", "c128"):
+                logger.warning(
+                    "LSDBG-HIT rank=%d %s:%d", self.layer_shard_rank, family, layer_id
+                )
+            return local if local is not None else remote
+
+        if self._self_test_pending:
+            # Deferred to the first read: at pool-init time the ZBAL process
+            # -group adaptor is not initialized yet and the collective raises
+            # "Check failed: init" (zbal_pytorch_process_group.cpp).
+            self._self_test_pending = False
+            try:
+                self._self_test_delivery()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("LSSELF failed: %s", exc)
+        target = local if local is not None else remote
+        # attn_cp_group must have no other submitters while layer split is on:
+        # the duplicate attn_cp_overlap group (bootstrap.py) owns the side
+        # -stream CP collectives, and HCCL pairs this group's collectives by
+        # submission order only.
+        group = get_parallel().attn_cp_group
+        if _LS_DEBUG and _LS_SYNC:
+            torch.npu.synchronize()
+        pre = _probe_stats(target) if _LS_DEBUG else None
+        self._read_via_allgather_chunks(family, layer_id, local, remote, group)
+        self._remote_layer_cache[family] = layer_id
+        self._read_seq += 1
+        if _LS_DEBUG:
+            if _LS_SYNC:
+                torch.npu.synchronize()
+            post = _probe_stats(target)
+            # CP partners align offline by seq: on the owner, pre is the
+            # compressor-written source content; on receivers, post is the
+            # copy that arrived. NaN counts separate a NaN source from a
+            # corrupted copy, pre/post sums separate faithfulness from loss.
+            logger.warning(
+                "LSDBG rank=%d seq=%d %s:%d src=%d owned=%d pre=%s/%d post=%s/%d",
+                self.layer_shard_rank,
+                self._read_seq,
+                family,
+                layer_id,
+                self._layer_owner_rank(layer_id),
+                int(local is not None),
+                pre[0],
+                pre[1],
+                post[0],
+                post[1],
+            )
+            # Device-truth check: order-insensitive fingerprints (min/max are
+            # exact reductions, the NaN count is integral) over fixed buffer
+            # blocks, compared via MIN/MAX all_reduce so neither host-side
+            # D2H reads of VMM-mapped pages nor fp32 sum-order differences
+            # between ranks can skew the verdict. Per-block results localize
+            # where a partial copy stops matching. Only a 1-element boolean
+            # reaches the host.
+            values = target.float().reshape(-1)
+            blocks = values.chunk(_LS_FINGERPRINT_BLOCKS)
+            cols = []
+            for block in blocks:
+                cols.append(block.min())
+                cols.append(block.max())
+            cols.append(values.isnan().sum().float())
+            stats = torch.stack(cols)
+            lo = stats.clone()
+            hi = stats.clone()
+            torch.distributed.all_reduce(lo, op=torch.distributed.ReduceOp.MIN, group=group.device_group)
+            torch.distributed.all_reduce(hi, op=torch.distributed.ReduceOp.MAX, group=group.device_group)
+            equal = _fingerprint_equal(lo, hi)
+            if not equal:
+                bad_cols = (
+                    ~torch.eq(torch.nan_to_num(lo), torch.nan_to_num(hi))
+                ).nonzero().flatten().tolist()
+                bad_blocks = sorted({c // 2 for c in bad_cols if c < 2 * len(blocks)})
+                block_elems = max(1, blocks[0].numel())
+                logger.warning(
+                    "LSSEQ rank=%d seq=%d %s:%d equal=0 bad_blocks=%s/%d "
+                    "block_bytes=%dKB first_bad_off=%dKB",
+                    self.layer_shard_rank,
+                    self._read_seq,
+                    family,
+                    layer_id,
+                    bad_blocks[:8],
+                    len(blocks),
+                    block_elems * values.element_size() // 1024,
+                    min(bad_blocks) * block_elems * values.element_size() // 1024,
+                )
+                self._read_mismatch += 1
+            elif _LS_DEBUG_VERBOSE:
+                logger.warning(
+                    "LSSEQ rank=%d seq=%d %s:%d equal=1",
+                    self.layer_shard_rank,
+                    self._read_seq,
+                    family,
+                    layer_id,
+                )
+        return target
+
+    def _read_via_allgather_chunks(
+        self,
+        family: str,
+        layer_id: int,
+        local: Optional[torch.Tensor],
+        remote: torch.Tensor,
+        group,
+    ) -> None:
+        """Materialize ``family``/``layer_id`` via chunked all-gather.
+
+        On this stack the ZBAL-interposed broadcast corrupts the delivered
+        bytes while all-gather (the compressor's per-layer KV rerange) delivers
+        correctly. Every chunk is staged into the fresh staging tensor, all
+        ranks gather it, and the non-owner copies the owner's slot into its
+        scratch.
+        """
+        flat_src = local.reshape(-1) if local is not None else None
+        flat_dst = remote.reshape(-1)
+        elem = flat_dst.element_size()
+        total = flat_dst.numel()
+        step = max(1, _LS_CHUNK_BYTES // elem)
+        owner_slot = self._layer_owner_rank(layer_id)
+        world = group.world_size
+        for start in range(0, total, step):
+            end = min(start + step, total)
+            width = end - start
+            send = self._staging[: width * elem].view(flat_dst.dtype)
+            if flat_src is not None:
+                send.copy_(flat_src[start:end])
+            gathered = torch.empty(
+                (world, width), dtype=flat_dst.dtype, device=flat_dst.device
+            )
+            group.all_gather_into_tensor(gathered, send)
+            if flat_src is None:
+                flat_dst[start:end].copy_(gathered[owner_slot])
+
+    def _invalidate_family(self, families: Tuple[str, ...], layer_id: int) -> None:
+        for family in families:
+            if self._remote_layer_cache[family] == layer_id:
+                self._remote_layer_cache[family] = None
+
+    def _local_family_buffer(
+        self, family: str, layer_id: int
+    ) -> Optional[torch.Tensor]:
+        """This rank's own buffer for ``family``/``layer_id``, or None when the
+        layer belongs to another CP rank."""
+        if not self._is_layer_owned(layer_id):
+            return None
+        if family == "swa":
+            return self.swa_kv_pool.kv_buffer[layer_id]
+        item = self.layer_mapping[layer_id]
+        if family == "c4":
+            assert item.compress_ratio == 4
+            return self.c4_kv_pool.kv_buffer[item.compress_layer_id]
+        if family == "c128":
+            assert item.compress_ratio == 128
+            return self.c128_kv_pool.kv_buffer[item.compress_layer_id]
+        if family == "index_k":
+            assert item.compress_ratio == 4
+            return self.c4_indexer_kv_pool.index_k_buffer[item.compress_layer_id]
+        assert family == "index_scale" and item.compress_ratio == 4
+        return self.c4_indexer_kv_pool.index_scale_buffer[item.compress_layer_id]
+
+    # ---- KV reads: owner all-gather -----------------------------------------
+
+    def get_swa_buffer(
+        self, layer_id: int, loc: Optional[torch.Tensor] = None
+    ) -> torch.Tensor:
+        kv = self._read_layer_buffer("swa", layer_id)
+        if loc is not None:
+            kv = kv.flatten(0, 1)[loc]
+        return kv
+
+    def get_compress_buffer(
+        self,
+        layer_id: int,
+        from_indexer: bool = False,
+        loc: Optional[torch.Tensor] = None,
+    ) -> Optional[torch.Tensor]:
+        item = self.layer_mapping[layer_id]
+        if item.compress_ratio == 0:
+            return None
+        if _LS_DEBUG and not from_indexer:
+            logger.warning(
+                "LSDBG-CALL rank=%d %s:%d",
+                self.layer_shard_rank,
+                "c4" if item.compress_ratio == 4 else "c128",
+                layer_id,
+            )
+        if from_indexer:
+            assert item.compress_ratio == 4, "indexer only on c4 layers"
+            kv = self._read_layer_buffer("index_k", layer_id)
+        elif item.compress_ratio == 4:
+            kv = self._read_layer_buffer("c4", layer_id)
+        else:
+            kv = self._read_layer_buffer("c128", layer_id)
+        if loc is not None:
+            kv = kv.flatten(0, 1)[loc]
+        return kv
+
+    def get_compress_dequant_scale_buffer(
+        self, layer_id: int, from_indexer: bool
+    ) -> torch.Tensor:
+        assert from_indexer, "only indexer compress pool has dequant scale"
+        return self._read_layer_buffer("index_scale", layer_id)
+
+    def get_key_buffer(self, layer_id: int) -> torch.Tensor:
+        item = self.layer_mapping[layer_id]
+        if item.compress_ratio == 0:
+            return self._read_layer_buffer("swa", layer_id)
+        if item.compress_ratio == 4:
+            return self._read_layer_buffer("c4", layer_id)
+        return self._read_layer_buffer("c128", layer_id)
+
+    def get_swa_raw_buffer(self, layer_id: int) -> torch.Tensor:
+        return self._read_layer_buffer("swa", layer_id)
+
+    # ---- KV writes: owned-only, invalidate remote copies --------------------
+
+    def _log_write_loc(self, kind: str, layer_id: int, loc: torch.Tensor) -> None:
+        if _LS_DEBUG and loc is not None and loc.numel():
+            owned = self._is_layer_owned(layer_id)
+            logger.warning(
+                "LSLOC rank=%d %s:%d owned=%d n=%d min=%d max=%d",
+                self.layer_shard_rank,
+                kind,
+                layer_id,
+                int(owned),
+                loc.numel(),
+                int(loc.min()),
+                int(loc.max()),
+            )
+
+    def set_swa_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        cache: torch.Tensor,
+    ) -> None:
+        self._invalidate_family(("swa",), layer_id)
+        self._log_write_loc("swa", layer_id, loc)
+        if not self._is_layer_owned(layer_id):
+            return
+        super().set_swa_buffer(layer_id, loc, cache)
+
+    def set_compress_buffer(
+        self,
+        layer_id: int,
+        loc: torch.Tensor,
+        kv: torch.Tensor,
+        kv_scale: Optional[torch.Tensor],
+        from_indexer: bool,
+    ) -> None:
+        self._log_write_loc(
+            "index" if from_indexer else "cmp", layer_id, loc
+        )
+        ratio = self.layer_mapping[layer_id].compress_ratio
+        if ratio == 4:
+            self._invalidate_family(("c4", "index_k", "index_scale"), layer_id)
+        elif ratio == 128:
+            self._invalidate_family(("c128",), layer_id)
+        if not self._is_layer_owned(layer_id):
+            return
+        super().set_compress_buffer(layer_id, loc, kv, kv_scale, from_indexer)
+
+    # ---- PD transfer: report owned layers only ------------------------------
+
+    def get_contiguous_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        """Main PD buffers: [c4 KV, index K, index scale], each section sliced
+        to this rank's owned c4 layers."""
+        buffers = (
+            self._owned_bucket_buffers(self.c4_kv_pool.kv_buffer, "c4")
+            + self._owned_bucket_buffers(self.c4_indexer_kv_pool.index_k_buffer, "c4")
+            + self._owned_bucket_buffers(
+                self.c4_indexer_kv_pool.index_scale_buffer, "c4"
+            )
+        )
+        return (
+            [buf.data_ptr() for buf in buffers],
+            [buf.nbytes for buf in buffers],
+            [buf[0].nbytes for buf in buffers],
+        )
+
+    def get_state_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        """SWA component (owned only): SWA KV + c4 attn/indexer states."""
+        plan = self._get_shard_plan()
+        swa_start, swa_end = plan.owned_stage_local_range()
+        data_ptrs: List[int] = []
+        data_lens: List[int] = []
+        item_lens: List[int] = []
+        for buf in self.swa_kv_pool.kv_buffer[swa_start:swa_end]:
+            data_ptrs.append(buf.data_ptr())
+            data_lens.append(buf.nbytes)
+            item_lens.append(buf[0].nbytes)
+        for pools in (self.compress_state_pools, self.indexer_compress_state_pools):
+            # compress_state_pools is absolute-layer-indexed; layer split
+            # requires pp_size == 1, so stage-local ids coincide.
+            for idx in plan.owned_stage_local_ids("c4"):
+                state = pools[idx].kv_score_buffer.kv_score
+                data_ptrs.append(state.data_ptr())
+                data_lens.append(state.nbytes)
+                item_lens.append(state[0].nbytes * pools[idx].ring_size)
+        return data_ptrs, data_lens, item_lens
+
+    def get_c128_kv_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        buffers = self._owned_bucket_buffers(self.c128_kv_pool.kv_buffer, "c128")
+        return (
+            [buf.data_ptr() for buf in buffers],
+            [buf.nbytes for buf in buffers],
+            [buf[0].nbytes for buf in buffers],
+        )
+
+    def get_c128_state_buf_infos(self) -> Tuple[List[int], List[int], List[int]]:
+        data_ptrs: List[int] = []
+        data_lens: List[int] = []
+        item_lens: List[int] = []
+        for idx in self._get_shard_plan().owned_stage_local_ids("c128"):
+            pool = self.compress_state_pools[idx]
+            state = pool.kv_score_buffer.kv_score
+            data_ptrs.append(state.data_ptr())
+            data_lens.append(state.nbytes)
+            item_lens.append(state[0].nbytes * pool.ring_size)
+        return data_ptrs, data_lens, item_lens
+
+    def _owned_bucket_buffers(
+        self, buffers: List[torch.Tensor], bucket: str
+    ) -> List[torch.Tensor]:
+        start, end = self._get_shard_plan().owned_bucket_range(bucket)
+        return buffers[start:end]
+
+    # ---- PD transfer: layer ids parallel to the owned buf lists -------------
+
+    def _owned_global_bucket_ids(self, bucket: str) -> List[int]:
+        plan = self._get_shard_plan()
+        return [self._stage_start + i for i in plan.owned_stage_local_ids(bucket)]
+
+    def get_kv_layer_ids(self) -> List[int]:
+        return self._owned_global_bucket_ids("c4") * 3
+
+    def get_state_layer_ids(self) -> List[int]:
+        plan = self._get_shard_plan()
+        start, end = plan.owned_stage_local_range()
+        owned_c4 = self._owned_global_bucket_ids("c4")
+        return (
+            [self._stage_start + i for i in range(start, end)]
+            + owned_c4 * 2
+        )
+
+    def get_c128_layer_ids(self) -> List[int]:
+        return self._owned_global_bucket_ids("c128")

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_layer_split_plan.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_layer_split_plan.py
@@ -1,0 +1,102 @@
+"""Pure layer-ownership math for the DSV4 NPU cache layer-split pool.
+
+Kept free of torch / torch_npu imports so unit tests can exercise the shard
+plan on CPU. See ``dsv4_cache_layer_split.py`` for the pool that consumes it.
+"""
+
+from __future__ import annotations
+
+from typing import Dict, List, Tuple
+
+from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
+
+
+def owned_bucket_range(
+    bucket_layer_ids: List[int], owned_start: int, owned_end: int
+) -> Tuple[int, int]:
+    """Owned ``[start, end)`` sub-range of a monotonic bucket-id list.
+
+    ``bucket_layer_ids[i]`` is the stage-local layer id of bucket buffer ``i``;
+    ownership over stage-local ids is a contiguous range, so the owned bucket
+    indices are contiguous too.
+    """
+    start = 0
+    while start < len(bucket_layer_ids) and bucket_layer_ids[start] < owned_start:
+        start += 1
+    end = start
+    while end < len(bucket_layer_ids) and bucket_layer_ids[end] < owned_end:
+        end += 1
+    return start, end
+
+
+class DSV4LayerShardPlan:
+    """Contiguous layer->CP-rank ownership for one DSV4 pool instance.
+
+    Layers are split as evenly as possible over stage-local ids (the first
+    ``num_layers % shard_size`` ranks own one extra layer). Because a layer's
+    per-bucket id is a monotonic function of its stage-local id, each bucket's
+    owned set is a contiguous sub-range of that bucket's buffer list.
+
+    Consumers that index absolute-layer lists with stage-local ids (e.g.
+    ``get_state_buf_infos`` on ``compress_state_pools``) rely on
+    ``stage_start == 0``, which holds because layer split rejects pp_size > 1
+    (``validate_deepseek_v4_layer_split``).
+    """
+
+    def __init__(
+        self,
+        *,
+        rank: int,
+        shard_size: int,
+        num_layers: int,
+        stage_start: int,
+        ratios: List[int],
+    ):
+        self.rank = rank
+        self.shard_size = shard_size
+        self.num_layers = num_layers
+        self.stage_start = stage_start
+        self.owned_start, self.owned_end = get_layer_shard_range(
+            rank, shard_size, num_layers
+        )
+        # SWA buffers are 1:1 with stage-local layer ids.
+        self._bucket_ids: Dict[str, List[int]] = {
+            "swa": list(range(num_layers)),
+            "c4": [i for i, r in enumerate(ratios) if r == 4],
+            "c128": [i for i, r in enumerate(ratios) if r == 128],
+        }
+        self.shard_start = stage_start + self.owned_start
+        self.shard_end = stage_start + self.owned_end
+
+    def is_stage_local_owned(self, local_layer_idx: int) -> bool:
+        return self.owned_start <= local_layer_idx < self.owned_end
+
+    def is_layer_owned(self, layer_id: int) -> bool:
+        return self.is_stage_local_owned(layer_id - self.stage_start)
+
+    def owner_rank(self, layer_id: int) -> int:
+        return get_layer_owner(
+            layer_id - self.stage_start, self.shard_size, self.num_layers
+        )
+
+    def bucket_layer_ids(self, bucket: str) -> List[int]:
+        return self._bucket_ids[bucket]
+
+    def owned_bucket_range(self, bucket: str) -> Tuple[int, int]:
+        """``[start, end)`` of the owned sub-range of a bucket buffer list."""
+        return owned_bucket_range(
+            self._bucket_ids[bucket], self.owned_start, self.owned_end
+        )
+
+    def owned_stage_local_range(self) -> Tuple[int, int]:
+        return self.owned_start, self.owned_end
+
+    def owned_stage_local_ids(self, bucket: str) -> List[int]:
+        start, end = self.owned_bucket_range(bucket)
+        return self._bucket_ids[bucket][start:end]
+
+    def partition_summary(self) -> str:
+        return "; ".join(
+            f"r{r}:{get_layer_shard_range(r, self.shard_size, self.num_layers)}"
+            for r in range(self.shard_size)
+        )

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_layer_split_staging.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_layer_split_staging.py
@@ -1,0 +1,94 @@
+"""Active-page staging and remap for the DSV4 NPU layer-split pool.
+
+Remote-layer reads compact only the pages the current batch references (the
+union across the attention-CP group) into the scratch buffer instead of whole
+layers, and remap indices/page tables onto the compacted copy. Pure torch;
+the collective is an int32 all-reduce over the CP group's device group.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+
+
+def build_active_pages_mask(
+    indices: torch.Tensor,
+    page_size: int,
+    max_pages: int,
+) -> torch.Tensor:
+    """Per-page hit counts for token ``indices`` (-1 entries are padding)."""
+    local_mask = torch.zeros(max_pages, dtype=torch.int32, device=indices.device)
+    valid = indices >= 0
+    safe_indices = torch.clamp(indices, min=0)
+    page_ids = torch.div(safe_indices, page_size, rounding_mode="floor")
+    local_mask.index_put_(
+        (page_ids.flatten().to(torch.long),),
+        valid.flatten().to(torch.int32),
+        accumulate=True,
+    )
+    return local_mask
+
+
+def all_reduce_active_pages_mask(local_mask: torch.Tensor, group) -> torch.Tensor:
+    """Sum the per-rank active-page mask across the attention-CP group."""
+    torch.distributed.all_reduce(local_mask, group=group.device_group)
+    return local_mask
+
+
+def selected_active_pages(local_mask: torch.Tensor) -> torch.Tensor:
+    """Sorted page ids with a nonzero hit count."""
+    return torch.nonzero(local_mask, as_tuple=False).flatten()
+
+
+def remap_indices_to_staging(
+    indices: torch.Tensor,
+    selected_pages: torch.Tensor,
+    page_size: int,
+    max_pages: int,
+) -> torch.Tensor:
+    """Token indices rebased onto the compacted staging copy (padding kept)."""
+    page_map = torch.full((max_pages,), -1, dtype=torch.int32, device=indices.device)
+    page_map[selected_pages.to(torch.long)] = torch.arange(
+        selected_pages.numel(), dtype=torch.int32, device=indices.device
+    )
+
+    valid = indices >= 0
+    safe_indices = torch.clamp(indices, min=0)
+    page_ids = torch.div(safe_indices, page_size, rounding_mode="floor")
+    offsets = safe_indices - page_ids * page_size
+    new_pages = page_map[page_ids.to(torch.long)].to(indices.dtype)
+    remapped = new_pages * page_size + offsets
+    return torch.where(valid, remapped, indices)
+
+
+def remap_page_table_to_staging(
+    page_table: torch.Tensor,
+    selected_pages: torch.Tensor,
+    max_pages: int,
+) -> torch.Tensor:
+    """Page table entries rebased onto the compacted staging copy."""
+    page_map = torch.full(
+        (max_pages,), -1, dtype=torch.int32, device=page_table.device
+    )
+    page_map[selected_pages.to(torch.long)] = torch.arange(
+        selected_pages.numel(), dtype=torch.int32, device=page_table.device
+    )
+
+    valid = page_table >= 0
+    safe_pages = torch.clamp(page_table, min=0)
+    remapped = page_map[safe_pages.to(torch.long)].to(page_table.dtype)
+    return torch.where(valid, remapped, page_table)
+
+
+def active_pages_for_indices(
+    indices: torch.Tensor,
+    page_size: int,
+    max_pages: int,
+    group,
+) -> torch.Tensor:
+    """Pages touched by any CP rank; all ranks must call in the same order."""
+    local_mask = build_active_pages_mask(indices, page_size, max_pages)
+    local_mask = all_reduce_active_pages_mask(local_mask, group)
+    return selected_active_pages(local_mask)

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_memory_pool.py
@@ -30,6 +30,17 @@ from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
 from sglang.srt.runtime_context import get_schedule
 
 
+def bucket_layer_ids(
+    compression_ratios: List[int], stage_start: int, stage_end: int, ratio: int
+) -> List[int]:
+    """Global ids of the stage layers compressed at ``ratio``, in buffer order."""
+    return [
+        layer_id
+        for layer_id in range(stage_start, stage_end)
+        if compression_ratios[layer_id] == ratio
+    ]
+
+
 class NPUDeepSeekV4SingleKVPool(DeepSeekV4SingleKVPool):
     """NPU bf16 variant of the full / SWA / c4 / c128 single-KV pool.
 
@@ -399,6 +410,35 @@ class DSV4NPUTokenToKVPool(DeepSeekV4TokenToKVPool):
             [buf.data_ptr() for buf in buffers],
             [buf.nbytes for buf in buffers],
             [buf[0].nbytes for buf in buffers],
+        )
+
+    # ---- PD transfer layer ids ---------------------------------------------
+    # Each reports one global layer id per entry of the matching buf-infos
+    # list, letting the transfer layer pair prefill/decode entries by id
+    # (build_transfer_entry_pairs) instead of positional slicing.
+
+    def get_kv_layer_ids(self) -> List[int]:
+        """Ids for ``get_contiguous_buf_infos``: three same-length sections
+        (c4 KV, index K, index scale), so each c4 id appears once per section."""
+        return self._c4_layer_ids() * 3
+
+    def get_state_layer_ids(self) -> List[int]:
+        """Ids for ``get_state_buf_infos``: per-layer SWA KV, then c4
+        attention and c4 indexer states."""
+        return (
+            list(range(self._stage_start, self._stage_end))
+            + self._c4_layer_ids() * 2
+        )
+
+    def get_c128_layer_ids(self) -> List[int]:
+        """Ids for ``get_c128_kv_buf_infos`` / ``get_c128_state_buf_infos``."""
+        return bucket_layer_ids(
+            self.compression_ratios, self._stage_start, self._stage_end, 128
+        )
+
+    def _c4_layer_ids(self) -> List[int]:
+        return bucket_layer_ids(
+            self.compression_ratios, self._stage_start, self._stage_end, 4
         )
 
     def get_state_cache(self, layer_id: int, from_indexer: bool) -> torch.Tensor:

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -252,7 +252,13 @@ def pad_dsa_cache_seqlens(forward_batch: "ForwardBatch", dsa_cache_seqlens):
     return dsa_cache_seqlens
 
 
-def can_dsa_cp_split(seq_len: int, cp_size: int, use_dsa: bool, forward_batch):
+def can_dsa_cp_split(
+    seq_len: int,
+    cp_size: int,
+    use_dsa: bool,
+    forward_batch,
+    require_divisible: bool = True,
+):
     if (
         cp_size <= 1
         or not use_dsa
@@ -263,10 +269,11 @@ def can_dsa_cp_split(seq_len: int, cp_size: int, use_dsa: bool, forward_batch):
         return False
 
     if is_dsa_prefill_cp_round_robin_split():
-        cur_cp_seq_len = seq_len // cp_size
-        assert (
-            seq_len % cp_size == 0
-        ), f"seq_len {seq_len} is not divisible by cp_size {cp_size} when dsa_prefill_cp_mode is round-robin-split"
+        if require_divisible:
+            assert (
+                seq_len % cp_size == 0
+            ), f"seq_len {seq_len} is not divisible by cp_size {cp_size} when dsa_prefill_cp_mode is round-robin-split"
+        cur_cp_seq_len = ceil_div(seq_len, cp_size)
     else:
         # TODO current just support prefill batch=1 and len(input_ids) > self.cp_size * 2
         # Note: (self.cp_size * 2) To achieve load balancing for seq computation,

--- a/python/sglang/srt/layers/cp/base.py
+++ b/python/sglang/srt/layers/cp/base.py
@@ -146,6 +146,11 @@ class ContextParallelStrategy(ABC):
     ) -> Any:
         """Gather rank-local KV payloads back to full token order."""
 
+    def local_q_indices(self, num_tokens: int, forward_batch: ForwardBatch) -> Any:
+        raise NotImplementedError(
+            f"{self.name} strategy does not support local q indices"
+        )
+
     def shard_per_request(
         self,
         extend_seqs_cpu: List[int],

--- a/python/sglang/srt/layers/cp/interleave.py
+++ b/python/sglang/srt/layers/cp/interleave.py
@@ -122,6 +122,14 @@ class InterleaveCPStrategy(ContextParallelStrategy):
 
         return input_.view(-1, cp_size, *input_.shape[1:])[:, cp_rank].contiguous()
 
+    def local_q_indices(self, num_tokens: int, forward_batch) -> Any:
+        device = getattr(getattr(forward_batch, "input_ids", None), "device", None)
+        if device is None:
+            device = torch.device("cpu")
+        return torch.arange(
+            self.cp_rank, int(num_tokens), self.cp_size, device=device, dtype=torch.long
+        )
+
     def shard_local_tokens(self, input_: Any) -> Any:
         return self._interleave_shard(input_)
 
@@ -204,6 +212,19 @@ class InterleaveCPStrategy(ContextParallelStrategy):
         ):
             gathered = x.new_empty((self.cp_size * physical_rank_len, *x.shape[1:]))
         attn_cp_all_gather_into_tensor(gathered, padded_x.contiguous())
+
+        # Equal per-rank lengths: one interleave copy restores the original
+        # token order; cheaper than the index_select fallback below.
+        actual = metadata.per_rank_actual_token
+        if (
+            total_tokens == self.cp_size * physical_rank_len
+            and all(int(n) == physical_rank_len for n in actual)
+        ):
+            return (
+                gathered.view(self.cp_size, physical_rank_len, *x.shape[1:])
+                .transpose(0, 1)
+                .reshape(total_tokens, *x.shape[1:])
+            )
 
         flat_indices = torch.arange(total_tokens, device=x.device)
         gather_indices = (

--- a/python/sglang/srt/layers/cp/utils.py
+++ b/python/sglang/srt/layers/cp/utils.py
@@ -57,15 +57,22 @@ def is_glm_dsa_cache_layer_split_enabled(model_runner: "ModelRunner") -> bool:
     """Whether DSA GPU KV/indexer cache layers are sharded across CP ranks.
 
     Layer split is a prefill-CP-only optimization for DSA (DeepSeek Sparse
-    Attention) MLA models (e.g. GLM-5.2). Draft workers keep the full cache.
+    Attention) models: the MLA DSA family (e.g. GLM-5.2) and DeepSeek V4,
+    whose attention arch is MHA but whose pools are still DSA-style per-layer
+    caches. Draft workers keep the full cache.
     """
-    from sglang.srt.configs.model_config import is_deepseek_dsa
+    from sglang.srt.configs.model_config import is_deepseek_dsa, is_deepseek_v4
 
+    hf_config = model_runner.model_config.hf_config
     return (
         not model_runner.is_draft_worker
         and get_parallel().enable_dsa_cache_layer_split
-        and model_runner.use_mla_backend
-        and is_deepseek_dsa(model_runner.model_config.hf_config)
+        and (
+            # V4 is AttentionArch.MHA, so the MLA backend term only gates the
+            # MLA DSA family.
+            (model_runner.use_mla_backend and is_deepseek_dsa(hf_config))
+            or is_deepseek_v4(hf_config)
+        )
     )
 
 
@@ -118,15 +125,21 @@ def get_layer_shard_range(
 
 
 def get_layer_owner(local_layer_idx: int, shard_size: int, total_layers: int) -> int:
-    """CP rank that owns ``local_layer_idx`` under the contiguous split."""
-    for rank in range(shard_size):
-        start, end = get_layer_shard_range(rank, shard_size, total_layers)
-        if start <= local_layer_idx < end:
-            return rank
-    raise ValueError(
-        f"Invalid local_layer_idx={local_layer_idx} for "
-        f"shard_size={shard_size}, total_layers={total_layers}"
-    )
+    """CP rank that owns ``local_layer_idx`` under the contiguous split.
+
+    Closed form of :func:`get_layer_shard_range`: the first ``total_layers %
+    shard_size`` ranks own ``base + 1`` layers, the rest own ``base``.
+    """
+    if not 0 <= local_layer_idx < total_layers:
+        raise ValueError(
+            f"Invalid local_layer_idx={local_layer_idx} for "
+            f"shard_size={shard_size}, total_layers={total_layers}"
+        )
+    base, rem = divmod(total_layers, shard_size)
+    head = rem * (base + 1)
+    if local_layer_idx < head:
+        return local_layer_idx // (base + 1)
+    return rem + (local_layer_idx - head) // base
 
 
 def enable_cp_v2() -> bool:

--- a/python/sglang/srt/layers/cp/zigzag.py
+++ b/python/sglang/srt/layers/cp/zigzag.py
@@ -334,6 +334,25 @@ class ZigzagCPStrategy(ContextParallelStrategy):
             [chunks[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index], dim=0
         )
 
+    def local_q_indices(self, num_tokens: int, forward_batch) -> Any:
+        meta = forward_batch.attn_cp_metadata
+        device = getattr(getattr(forward_batch, "input_ids", None), "device", None)
+        if device is None and meta.cu_seqlens_q_prev_tensor is not None:
+            device = meta.cu_seqlens_q_prev_tensor.device
+        if device is None:
+            device = torch.device("cpu")
+
+        offsets = [0] + list(accumulate(meta.split_list))
+        pieces = []
+        for chunk_idx in meta.zigzag_index:
+            start = offsets[chunk_idx]
+            end = offsets[chunk_idx + 1]
+            if end > start:
+                pieces.append(torch.arange(start, end, device=device, dtype=torch.long))
+        if not pieces:
+            return torch.empty(0, device=device, dtype=torch.long)
+        return torch.cat(pieces, dim=0)
+
     def get_supported_attention_backend(self):
         return [
             CPAttentionBackendKind.FLASH_ATTENTION,

--- a/python/sglang/srt/layers/utils/cp_utils.py
+++ b/python/sglang/srt/layers/utils/cp_utils.py
@@ -129,11 +129,33 @@ def can_cp_split(seq_len: int, cp_size: int, forward_batch):
     return True
 
 
+def _get_strategy_for_metadata(forward_batch):
+    """Return the CP strategy only for metadata created by the strategy API.
+
+    DSV4 CP-v1 still builds the legacy ``ContextParallelMetadata`` below.  It
+    intentionally does not carry the CP-v2 logical/physical padding contract,
+    so passing it to a target-branch strategy would mix the two protocols.
+    """
+    from sglang.srt.layers.cp.base import (
+        BaseContextParallelMetadata,
+        get_cp_strategy,
+    )
+
+    metadata = getattr(forward_batch, "attn_cp_metadata", None)
+    if not isinstance(metadata, BaseContextParallelMetadata):
+        return None
+    return get_cp_strategy()
+
+
 def cp_split_and_rebuild_data(forward_batch, input_: torch.Tensor):
     from sglang.srt.layers.attention.dsa.utils import (
         dsa_cp_round_robin_split_data,
         is_dsa_prefill_cp_round_robin_split,
     )
+
+    strategy = _get_strategy_for_metadata(forward_batch)
+    if strategy is not None:
+        return strategy.shard_hidden_states(input_, forward_batch)
 
     if is_dsa_prefill_cp_round_robin_split():
         cp_size = get_parallel().attn_cp_size
@@ -147,7 +169,7 @@ def cp_split_and_rebuild_data(forward_batch, input_: torch.Tensor):
     )
     result = torch.cat(
         [input_list[i] for i in forward_batch.attn_cp_metadata.zigzag_index], dim=0
-    ).view(-1, input_.shape[-1])
+    )
     return result
 
 
@@ -156,6 +178,10 @@ def cp_split_and_rebuild_position(forward_batch, positions: torch.Tensor):
         dsa_cp_round_robin_split_data,
         is_dsa_prefill_cp_round_robin_split,
     )
+
+    strategy = _get_strategy_for_metadata(forward_batch)
+    if strategy is not None:
+        return strategy.shard_position_ids(positions, forward_batch)
 
     if is_dsa_prefill_cp_round_robin_split():
         cp_size = get_parallel().attn_cp_size
@@ -193,7 +219,7 @@ def cp_round_robin_input_ids(input_ids):
     cp_size = get_parallel().attn_cp_size
     cp_rank = get_parallel().attn_cp_rank
     if get_moe_a2a_backend().is_none():
-        input_ids = input_ids.reshape(-1, cp_size).T.flatten()
+        input_ids = torch.cat([input_ids[rank::cp_size] for rank in range(cp_size)])
     else:
         input_ids = input_ids[cp_rank::cp_size].contiguous()
     return input_ids
@@ -202,6 +228,8 @@ def cp_round_robin_input_ids(input_ids):
 def cp_all_gather_reorganized_into_tensor(input_tensor, cp_size, forward_batch, stream):
     """
     Allgather communication for context_parallel(kv_cache, index_k, hidden_states).
+    Handles tensors with arbitrary trailing dimensions, including DSV4 mHC
+    hidden states shaped as [num_tokens, hc_mult, hidden_size].
     This implementation mainly consists of three parts:
     Step 1, padding the input shape to unify the shape for allgather communication (the shape must be the same).
     Step 2, synchronized allgather communication.
@@ -210,14 +238,13 @@ def cp_all_gather_reorganized_into_tensor(input_tensor, cp_size, forward_batch, 
     max_len = forward_batch.attn_cp_metadata.max_rank_len[0]
     pad_size = max_len - input_tensor.shape[0]
     if pad_size > 0:
-        input_tensor = F.pad(
-            input_tensor, (0, 0, 0, pad_size), mode="constant", value=0
-        )
+        padding = [0, 0] * (input_tensor.ndim - 1) + [0, pad_size]
+        input_tensor = F.pad(input_tensor, padding, mode="constant", value=0)
     group = get_parallel().attn_cp_group
     with use_symmetric_memory(group, disabled=not is_allocation_symmetric()):
         input_tensor_full = torch.empty(
             max_len * cp_size,
-            input_tensor.shape[1],
+            *input_tensor.shape[1:],
             device=input_tensor.device,
             dtype=input_tensor.dtype,
         )
@@ -367,6 +394,10 @@ def cp_all_gather_rerange_output(input_tensor, cp_size, forward_batch, stream):
         is_dsa_prefill_cp_round_robin_split,
     )
 
+    strategy = _get_strategy_for_metadata(forward_batch)
+    if strategy is not None:
+        return strategy.gather_hidden_states(input_tensor, forward_batch, stream)
+
     if is_dsa_prefill_cp_round_robin_split():
         with use_symmetric_memory(
             get_parallel().attn_cp_group, disabled=not is_allocation_symmetric()
@@ -387,7 +418,6 @@ def cp_all_gather_rerange_output(input_tensor, cp_size, forward_batch, stream):
         return output_tensor
 
     # TODO: Do we need to remove the padding here?
-    bs_seq_len, hidden_size = input_tensor.shape
     output_tensor = cp_all_gather_reorganized_into_tensor(
         input_tensor,
         cp_size,
@@ -403,7 +433,6 @@ def cp_all_gather_rerange_output(input_tensor, cp_size, forward_batch, stream):
         [outputs_list[i] for i in forward_batch.attn_cp_metadata.cp_reverse_index],
         dim=0,
     )
-    output_tensor = output_tensor.view(-1, hidden_size)
     return output_tensor
 
 
@@ -425,6 +454,10 @@ def cp_all_gather_rerange_kv_cache(input_tensor, cp_size, forward_batch, stream)
     | block0 | block1 | block2 | block3 | block4 | block5 | block6 | block7 |
     |   +-------------------------+
     """
+    strategy = _get_strategy_for_metadata(forward_batch)
+    if strategy is not None:
+        return strategy.gather_kv_cache(input_tensor, forward_batch, stream)
+
     output_tensor = cp_all_gather_reorganized_into_tensor_kv_cache(
         input_tensor,
         cp_size,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1294,12 +1294,26 @@ class KVCacheConfigurator:
         # follows the same fixed ring ownership as GPU. Do not replace the
         # configurator's C4-SWA/C128-request budgets with a paged allocator
         # estimate: Atlas A3 cache_mode=2 consumes explicit flat state_locs.
+        pool_kwargs = {}
         if _is_npu:
             from sglang.srt.hardware_backend.npu.dsv4.dsv4_memory_pool import (
                 DSV4NPUTokenToKVPool,
             )
 
             pool_cls = DSV4NPUTokenToKVPool
+            # Prefill-CP layer split: shard the KV/indexer cache layers across
+            # CP ranks.
+            from sglang.srt.layers.cp.utils import get_glm_dsa_cp_layer_shard_info
+
+            layer_shard_rank, layer_shard_size = get_glm_dsa_cp_layer_shard_info(self)
+            if layer_shard_rank is not None:
+                from sglang.srt.hardware_backend.npu.dsv4.dsv4_cache_layer_split import (
+                    LayerSplitDSV4NPUTokenToKVPool,
+                )
+
+                pool_cls = LayerSplitDSV4NPUTokenToKVPool
+                pool_kwargs["layer_shard_rank"] = layer_shard_rank
+                pool_kwargs["layer_shard_size"] = layer_shard_size
         else:
             pool_cls = DeepSeekV4TokenToKVPool
 
@@ -1330,6 +1344,7 @@ class KVCacheConfigurator:
             end_layer=self.layer_info.end_layer,
             enable_hisparse=get_memory().enable_hisparse,
             online_mtp_max_draft_tokens=(max_speculative_num_draft_tokens() or 0),
+            **pool_kwargs,
         )
         return token_to_kv_pool
 

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -523,6 +523,12 @@ class UnifiedRadixCache(BasePrefixCache):
     def match_prefix(self, params: MatchPrefixParams) -> MatchResult:
         result = self.session.try_match_prefix(params)
         if result is not None:
+            if envs.SGLANG_DEBUG_RADIX_CACHE.get():
+                logger.info(
+                    "RADIX match(session): key_len=%d hit=%d",
+                    len(params.key),
+                    len(result.device_indices),
+                )
             return result
         if self.disable:
             return self.tree_core.empty_match_result
@@ -536,6 +542,13 @@ class UnifiedRadixCache(BasePrefixCache):
         assert not result.cache_actions
         if self.linker is not None and params.req is not None:
             result = self.linker.match(params.key, params.req, result)
+        if envs.SGLANG_DEBUG_RADIX_CACHE.get():
+            logger.info(
+                "RADIX match: key_len=%d hit=%d full_hit=%d",
+                len(params.key),
+                len(result.device_indices),
+                result.full_kv_hit_length,
+            )
         return result
 
     def is_chunk_cache(self) -> bool:
@@ -554,6 +567,13 @@ class UnifiedRadixCache(BasePrefixCache):
                 if step.result is not None:
                     # Walk actions flow through the steps; the result is action-free.
                     assert not step.result.cache_actions
+                    if envs.SGLANG_DEBUG_RADIX_CACHE.get():
+                        logger.info(
+                            "RADIX insert: key_len=%d prev_prefix=%d inserted=%d",
+                            len(params.key or ()),
+                            params.prev_prefix_len,
+                            step.result.prefix_len,
+                        )
                     return step.result
                 step = self.tree_core.resume_insert()
         finally:
@@ -925,6 +945,15 @@ class UnifiedRadixCache(BasePrefixCache):
                 self.session_refs.register_session_ref(req)
 
     def cache_unfinished_req(self, req: Req, chunked: bool = False, **kwargs) -> None:
+        _dbg = envs.SGLANG_DEBUG_RADIX_CACHE.get()
+        if _dbg:
+            logger.info(
+                "RADIX cache_unfinished: rid=%s chunked=%s fill=%d disable=%s",
+                req.rid,
+                chunked,
+                len(req.get_fill_ids()),
+                self.disable,
+            )
         if self.session.try_cache_unfinished_req(req, chunked=chunked, **kwargs):
             return
 
@@ -975,6 +1004,10 @@ class UnifiedRadixCache(BasePrefixCache):
                 comp.free_out_of_window_slots(req, len(radix_key) - 1, insert_params)
 
         if effective_cache_len <= 0:
+            if _dbg:
+                logger.info(
+                    "RADIX cache_unfinished early-return: effective=%d", effective_cache_len
+                )
             req.prefix_indices = kv_indices_orig.to(dtype=torch.int64, copy=True)
             for comp in self._components_tuple:
                 comp.cleanup_after_caching_req(

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -32,6 +32,7 @@ from sglang.srt.configs.model_config import (
     is_minimax_sparse,
 )
 from sglang.srt.environ import envs
+from sglang.srt.layers.cp.utils import get_layer_shard_range
 from sglang.srt.mem_cache.allocation_sizing import get_alloc_len_per_decode
 from sglang.srt.mem_cache.deepseek_v4_memory_pool import (
     get_compress_state_ring_size,
@@ -815,20 +816,61 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
         self.num_layers_ca4 = sum(1 for r in self.compression_ratios if r == 4)
         self.num_layers_ca128 = sum(1 for r in self.compression_ratios if r == 128)
 
+        # Layer split (prefill CP) stores only the owned layer slice per rank,
+        # so the KV/indexer terms shrink by the owned fraction and the token
+        # capacity grows accordingly. Both CP ranks must derive the SAME
+        # capacity: take the min over ranks' owned slices. Compress state
+        # pools are not sharded, so their terms keep full-layer counts.
+        self.layer_shard_size = 1
+        if (
+            not kvc.is_draft_worker
+            and get_parallel().enable_dsa_cache_layer_split
+            and get_parallel().attn_cp_size > 1
+            and is_deepseek_v4(cfg.hf_config)
+        ):
+            self.layer_shard_size = get_parallel().attn_cp_size
+        owned_slices = [self.compression_ratios]
+        if self.layer_shard_size > 1:
+            owned_slices = [
+                self.compression_ratios[s:e]
+                for s, e in (
+                    get_layer_shard_range(
+                        rank, self.layer_shard_size, self.num_layers_total
+                    )
+                    for rank in range(self.layer_shard_size)
+                )
+            ]
+
         if self.is_speculative:
             # Ring is sized once here, so it must serve the largest adaptive tier.
             self._assert_ring_serves_draft_tokens(
                 max_speculative_num_draft_tokens() or 0
             )
 
-        self.bytes_per_full_token = self._get_bytes_per_full_token()
+        per_rank_bytes = [
+            self._get_bytes_per_full_token(slice_) for slice_ in owned_slices
+        ]
+        self._owned_ratio_slice = owned_slices[per_rank_bytes.index(min(per_rank_bytes))]
+        self.bytes_per_full_token = min(per_rank_bytes)
+        if self.layer_shard_size > 1:
+            logger.info(
+                "DSV4 layer-split capacity: shard_size=%d owned_layers=%d/%d "
+                "bytes_per_full_token=%.1f (unsharded=%.1f)",
+                self.layer_shard_size,
+                len(self._owned_ratio_slice),
+                self.num_layers_total,
+                self.bytes_per_full_token,
+                per_rank_bytes and self._get_bytes_per_full_token(),
+            )
         if self.is_speculative:
             # Reserve memory for the speculative draft worker by inflating
             # per-token bytes by (target+draft)/target. Equivalent to dflash's
             # scale_kv_cell_size_per_token_for_dflash but applied to
-            # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T).
+            # bytes_per_full_token: tokens = avail / (bpft * (T+D)/T). The
+            # 1-layer draft pool is not layer-split sharded, so the target
+            # count is the owned slice.
             draft_layers = 1
-            target_layers = self.num_layers_total
+            target_layers = len(self._owned_ratio_slice)
             self.bytes_per_full_token *= (target_layers + draft_layers) / target_layers
 
         # Online c128 keeps a single in-progress (max, sum, kv) state per index
@@ -881,7 +923,15 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
                 f"get_compress_state_ring_size()."
             )
 
-    def _get_bytes_per_full_token(self) -> float:
+    def _get_bytes_per_full_token(self, ratios=None) -> float:
+        # ``ratios`` is the layer-split owned slice (default: the full PP
+        # slice). Only the KV/indexer pools are sharded; the compress state
+        # terms keep full-layer counts (states run unsharded on every rank).
+        ratios = self.compression_ratios if ratios is None else ratios
+        layers_total = len(ratios)
+        layers_ca4 = sum(1 for r in ratios if r == 4)
+        layers_ca128 = sum(1 for r in ratios if r == 128)
+
         kv_bytes = self.qk_nope_head_dim + self.qk_rope_head_dim * 2 + 8
 
         quant_block_size = 128
@@ -911,10 +961,10 @@ class DSV4PoolConfigurator(MemoryPoolConfigurator):
 
         c4_frac = 1 / (4 * self.c4_shrink_factor)
         return (
-            self.swa_ratio * kv_bytes * self.num_layers_total
-            + c4_frac * kv_bytes * self.num_layers_ca4
-            + 1 / 128 * kv_bytes * self.num_layers_ca128
-            + 1 / 4 * indexer_bytes * self.num_layers_ca4
+            self.swa_ratio * kv_bytes * layers_total
+            + c4_frac * kv_bytes * layers_ca4
+            + 1 / 128 * kv_bytes * layers_ca128
+            + 1 / 4 * indexer_bytes * layers_ca4
             + self.swa_ratio * c4_state_ratio * c4_state_bytes * self.num_layers_ca4
             + c128_state_ratio * c128_state_bytes * self.num_layers_ca128
             + self.swa_ratio

--- a/python/sglang/srt/models/deepseek_v4.py
+++ b/python/sglang/srt/models/deepseek_v4.py
@@ -1456,9 +1456,17 @@ class MQALayer(MqaAttentionBase):
                 sin4,
                 qk_nope_dim=self.qk_nope_head_dim,
             )
+            kv_for_cache = kv
+            if use_cp:
+                kv_for_cache = cp_all_gather_rerange_output(
+                    kv.contiguous(),
+                    get_parallel().attn_cp_size,
+                    forward_batch,
+                    torch.cuda.current_stream(),
+                )
             attn_backend.store_cache(
                 layer_id=self.layer_id,
-                swa_k=kv,
+                swa_k=kv_for_cache,
                 forward_batch=forward_batch,
             )
             kv = None
@@ -1516,20 +1524,48 @@ class MQALayer(MqaAttentionBase):
 
         del qkv_a
 
+        use_npu_cp_full_metadata = (
+            use_cp and _is_npu and hasattr(attn_backend, "use_dsv4_cp_full_metadata")
+        )
         if self.indexer is not None:
-            self.indexer(
-                x=x,
-                q_lora=q_lora,
-                forward_batch=forward_batch,
-                attn_backend=attn_backend,
-            )
+            if use_npu_cp_full_metadata:
+                with attn_backend.use_dsv4_cp_full_metadata(forward_batch):
+                    attn_backend.forward_indexer_compressor(
+                        x,
+                        forward_batch,
+                        self.indexer.layer_id,
+                        self.indexer.compressor,
+                    )
+                self.indexer(
+                    x=x,
+                    q_lora=q_lora,
+                    forward_batch=forward_batch,
+                    attn_backend=attn_backend,
+                    skip_compressor=True,
+                )
+            else:
+                self.indexer(
+                    x=x,
+                    q_lora=q_lora,
+                    forward_batch=forward_batch,
+                    attn_backend=attn_backend,
+                )
         if self.compressor is not None:
-            attn_backend.forward_core_compressor(
-                x,
-                forward_batch,
-                self.layer_id,
-                self.compressor,
-            )
+            if use_npu_cp_full_metadata:
+                with attn_backend.use_dsv4_cp_full_metadata(forward_batch):
+                    attn_backend.forward_core_compressor(
+                        x,
+                        forward_batch,
+                        self.layer_id,
+                        self.compressor,
+                    )
+            else:
+                attn_backend.forward_core_compressor(
+                    x,
+                    forward_batch,
+                    self.layer_id,
+                    self.compressor,
+                )
 
         if _is_hip and kv_handle is not None:
             kv = cp_all_gather_rerange_finish(kv_handle)
@@ -3113,6 +3149,23 @@ class DeepseekV4Model(nn.Module):
                 positions = cp_split_and_rebuild_position(forward_batch, positions)
                 input_ids = cp_round_robin_input_ids(input_ids)
             input_ids_global = input_ids
+        elif use_prefill_cp:
+            # TBO skips the branch above, but input_ids still need the CP
+            # shard (positions/hidden are split per-ubatch by the TBO path).
+            input_ids = cp_split_and_rebuild_data(forward_batch, input_ids)
+            input_ids_global = input_ids
+
+        attn_backend = get_attn_backend()
+        if getattr(forward_batch, "attn_cp_metadata", None) is not None and hasattr(
+            attn_backend, "prepare_dsv4_cp_metadata"
+        ):
+            attn_backend.prepare_dsv4_cp_metadata(forward_batch)
+            local_positions = getattr(forward_batch, "dsv4_cp_local_positions", None)
+            if (
+                local_positions is not None
+                and positions.shape[0] == local_positions.shape[0]
+            ):
+                forward_batch.positions = positions
 
         # Reset Compressor's per-step freqs_cis cache from any previous step.
         for _attr in ("freqs_cis_c4", "freqs_cis_c128"):
@@ -3330,7 +3383,18 @@ class DeepseekV4ForCausalLM(nn.Module):
         pp_proxy_tensors: Optional[PPProxyTensors] = None,
     ) -> torch.Tensor:
         if self.dsa_enable_prefill_cp:
-            if can_dsa_cp_split(len(input_ids), self.cp_size, True, forward_batch):
+            attn_backend = get_attn_backend()
+            # Only the Ascend DSV4 backend rebuilds uneven-split attention
+            # metadata; the GPU path keeps the divisibility requirement.
+            if can_dsa_cp_split(
+                len(input_ids),
+                self.cp_size,
+                True,
+                forward_batch,
+                require_divisible=not hasattr(
+                    attn_backend, "prepare_dsv4_cp_metadata"
+                ),
+            ):
                 forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
                     len(input_ids),
                     self.cp_rank,
@@ -3338,13 +3402,18 @@ class DeepseekV4ForCausalLM(nn.Module):
                     forward_batch.seq_lens_cpu.tolist(),
                     extend_seqs_len=forward_batch.extend_seq_lens_cpu,
                 )
-                if is_dsa_prefill_cp_round_robin_split():
-                    attn_backend = get_attn_backend()
+                if hasattr(attn_backend, "prepare_dsv4_cp_metadata"):
+                    attn_backend.prepare_dsv4_cp_metadata(forward_batch)
+                elif is_dsa_prefill_cp_round_robin_split():
                     metadata = attn_backend.forward_metadata
-                    core_meta = metadata.core_attn_metadata
-                    core_meta.apply_cp_reindex()
-                    core_meta.init_flashmla_related(is_prefill=True)
-                    if metadata.indexer_metadata is not None:
+                    core_meta = getattr(metadata, "core_attn_metadata", None)
+                    if core_meta is not None:
+                        core_meta.apply_cp_reindex()
+                        core_meta.init_flashmla_related(is_prefill=True)
+                    if (
+                        core_meta is not None
+                        and getattr(metadata, "indexer_metadata", None) is not None
+                    ):
                         metadata.indexer_metadata = (
                             attn_backend.init_forward_metadata_indexer(core_meta)
                         )

--- a/python/sglang/srt/models/deepseek_v4_nextn.py
+++ b/python/sglang/srt/models/deepseek_v4_nextn.py
@@ -262,7 +262,18 @@ class DeepseekV4ForCausalLMNextN(DeepseekV4ForCausalLM):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         if self.dsa_enable_prefill_cp and not is_cp_v2_active(forward_batch):
-            if can_dsa_cp_split(len(input_ids), self.cp_size, True, forward_batch):
+            attn_backend = get_attn_backend()
+            # Mirrors DeepseekV4ForCausalLM.forward: only the Ascend DSV4
+            # backend rebuilds uneven-split attention metadata.
+            if can_dsa_cp_split(
+                len(input_ids),
+                self.cp_size,
+                True,
+                forward_batch,
+                require_divisible=not hasattr(
+                    attn_backend, "prepare_dsv4_cp_metadata"
+                ),
+            ):
                 forward_batch.attn_cp_metadata = prepare_context_parallel_metadata(
                     len(input_ids),
                     self.cp_rank,
@@ -270,13 +281,18 @@ class DeepseekV4ForCausalLMNextN(DeepseekV4ForCausalLM):
                     forward_batch.seq_lens_cpu.tolist(),
                     extend_seqs_len=forward_batch.extend_seq_lens_cpu,
                 )
-                if is_dsa_prefill_cp_round_robin_split():
-                    attn_backend = get_attn_backend()
+                if hasattr(attn_backend, "prepare_dsv4_cp_metadata"):
+                    attn_backend.prepare_dsv4_cp_metadata(forward_batch)
+                elif is_dsa_prefill_cp_round_robin_split():
                     metadata = attn_backend.forward_metadata
-                    core_meta = metadata.core_attn_metadata
-                    core_meta.apply_cp_reindex()
-                    core_meta.init_flashmla_related(is_prefill=True)
-                    if metadata.indexer_metadata is not None:
+                    core_meta = getattr(metadata, "core_attn_metadata", None)
+                    if core_meta is not None:
+                        core_meta.apply_cp_reindex()
+                        core_meta.init_flashmla_related(is_prefill=True)
+                    if (
+                        core_meta is not None
+                        and getattr(metadata, "indexer_metadata", None) is not None
+                    ):
                         metadata.indexer_metadata = (
                             attn_backend.init_forward_metadata_indexer(core_meta)
                         )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3770,7 +3770,3716 @@ class ServerArgs:
     # CUDA graph configuration resolution
     # ------------------------------------------------------------------
 
-    # ===== END TO BE REFACTORED ====
+    def _apply_muse_glimmer_prefill_cuda_graph_max_bs_default(self):
+        cfg = resolving_view(self)
+        if (
+            cfg.cuda_graph_max_bs_prefill is not None
+            or parse_connector_type(cfg.model_path) == ConnectorType.INSTANCE
+        ):
+            return
+        arch = self.get_model_config().hf_config.architectures[0]
+        if arch in ("MuseGlimmerForCausalLM", "MuseGlimmerForConditionalGeneration"):
+            self._declare(
+                "_apply_muse_glimmer_prefill_cuda_graph_max_bs_default",
+                cuda_graph_max_bs_prefill=512,
+            )
+
+    def _handle_cuda_graph_config(self):
+        cfg = resolving_view(self)
+        from sglang.srt.arg_groups.kimi_k3_hook import disable_kimi_k3_symm_mem
+
+        self._parse_cuda_graph_config()
+        # Reads the resolved per-phase backends; must precede the compat rules
+        # below and _handle_gpu_memory_settings, which key off enable_symm_mem.
+        disable_kimi_k3_symm_mem(self)
+        self._apply_cuda_graph_compatibility()
+        self._apply_deepep_adjustments()
+        self._apply_cuda_graph_disaggregation_roles()
+        self._validate_cuda_graph_config()
+        # Warn on the final resolved config (not inside the compat cascade —
+        # that path is skipped when the user explicitly sets the backend,
+        # which is the only way to get 'full' for prefill today).
+        if cfg.cuda_graph_config.prefill.backend == Backend.FULL:
+            logger.warning(
+                "cuda_graph_config[prefill].backend='full' is experimental. "
+                "Use breakable or tc_piecewise for production workloads."
+            )
+
+    def _apply_deepep_adjustments(self):
+        """Config adjustments required by the DeepEP a2a backend."""
+        cfg = resolving_view(self)
+        if resolved_view(self).moe_a2a_backend != "deepep":
+            return
+
+        # Non-multiple-of-8 prefill buckets can hang DeepEP a2a capture under
+        # breakable CUDA graph
+        if cfg.cuda_graph_config.prefill.backend == Backend.BREAKABLE:
+            bs = cfg.cuda_graph_config.prefill.bs
+            if bs is None:
+                # 2048 = documented prefill default; max_bs unresolved here.
+                max_bs = cfg.cuda_graph_config.prefill.max_bs or 2048
+                bs = self._generate_prefill_cuda_graph_batch_sizes(max_bs)
+            aligned = sorted({((b + 7) // 8) * 8 for b in bs})
+            if aligned != sorted(bs):
+                logger.info(
+                    "Breakable prefill CUDA graph with DeepEP requires bucket "
+                    "sizes divisible by 8; aligning %s -> %s.",
+                    sorted(bs),
+                    aligned,
+                )
+                cfg.cuda_graph_config.prefill.bs = aligned
+                cfg.cuda_graph_config.prefill.max_bs = aligned[-1]
+
+    def _parse_cuda_graph_config(self):
+        """Resolve cuda_graph_config from explicit JSON, per-phase
+        convenience flags, legacy global flags, and defaults.
+        Precedence (highest first): explicit JSON > convenience > legacy > defaults.
+        Also populates self._cuda_graph_config_locked — the set of
+        (phase, key) tuples that came from non-default sources; the
+        auto-disable cascade respects this lock (the old
+        --enforce-piecewise-cuda-graph semantics generalized).
+        """
+        cfg = resolving_view(self)
+        raw_input = cfg.cuda_graph_config
+        if isinstance(raw_input, CudaGraphConfig):
+            explicit_input = raw_input.to_dict()
+        else:
+            explicit_input = raw_input or {}
+        config = default_cuda_graph_config()
+        locked: set = set()
+
+        def _set(phase: str, key: str, value: Any) -> None:
+            setattr(getattr(config, phase), key, value)
+            locked.add((phase, key))
+
+        # ---- Legacy global flags (lowest precedence above defaults) ----
+        if cfg.disable_cuda_graph:
+            _set(Phase.DECODE, "backend", Backend.DISABLED)
+            _set(Phase.PREFILL, "backend", Backend.DISABLED)
+
+        # ---- Boolean per-phase off-switches ----
+        # Below the explicit backend selectors so --cuda-graph-backend-*
+        # wins if both are given.
+        if cfg.disable_prefill_cuda_graph:
+            _set(Phase.PREFILL, "backend", Backend.DISABLED)
+        if cfg.disable_decode_cuda_graph:
+            _set(Phase.DECODE, "backend", Backend.DISABLED)
+
+        # ---- Per-phase convenience flags ----
+        if cfg.cuda_graph_backend_decode is not None:
+            _set(Phase.DECODE, "backend", cfg.cuda_graph_backend_decode)
+        if cfg.cuda_graph_backend_prefill is not None:
+            _set(Phase.PREFILL, "backend", cfg.cuda_graph_backend_prefill)
+        if cfg.cuda_graph_max_bs_decode is not None:
+            _set(Phase.DECODE, "max_bs", cfg.cuda_graph_max_bs_decode)
+        if cfg.cuda_graph_max_bs_prefill is not None:
+            _set(Phase.PREFILL, "max_bs", cfg.cuda_graph_max_bs_prefill)
+        if cfg.cuda_graph_bs_decode is not None:
+            _set(Phase.DECODE, "bs", cfg.cuda_graph_bs_decode)
+        if cfg.cuda_graph_bs_prefill is not None:
+            _set(Phase.PREFILL, "bs", cfg.cuda_graph_bs_prefill)
+        if cfg.cuda_graph_tc_compiler is not None:
+            # Written to both phases so the value is in place when TC_PIECEWISE
+            # decode is implemented; today decode ignores it.
+            _set(Phase.DECODE, "tc_compiler", cfg.cuda_graph_tc_compiler)
+            _set(Phase.PREFILL, "tc_compiler", cfg.cuda_graph_tc_compiler)
+
+        # ---- Explicit JSON config (highest precedence) ----
+        for phase, phase_config in explicit_input.items():
+            if not isinstance(phase_config, dict):
+                continue
+            for key, value in phase_config.items():
+                _set(phase, key, value)
+
+        self._declare(
+            "_parse_cuda_graph_config",
+            cuda_graph_config=config,
+        )
+        self._cuda_graph_config_locked = locked
+
+    def _apply_cuda_graph_compatibility(self):
+        """Auto-disable prefill cuda graph for incompatible configs.
+        Rules are split per backend — TcPiecewise and Breakable have
+        different constraints. Skipped when the user explicitly set the
+        prefill backend (this folds in the old
+        --enforce-piecewise-cuda-graph contract).
+        """
+        cfg = resolving_view(self)
+        if (Phase.PREFILL, "backend") in self._cuda_graph_config_locked:
+            return
+
+        # Breakable is the CUDA default but not multimodal-compatible;
+        # piecewise-allowlisted archs run their validated decoder prefill
+        # there instead. Archs also on the breakable allowlist keep it --
+        # this runs first, so piecewise would otherwise silently win.
+        if (
+            cfg.cuda_graph_config.prefill.backend == Backend.BREAKABLE
+            and self.get_model_config().is_multimodal_piecewise_cuda_graph_supported
+            and not self.get_model_config().is_multimodal_breakable_cuda_graph_supported
+            # Keep trtllm_mla on the preferred breakable path, which now serves
+            # MLA by falling back to the flashinfer MLA impl for extend.
+            and self._resolved_attention_backends()[0] != "trtllm_mla"
+        ):
+            logger.info(
+                "Using tc_piecewise CUDA graph for validated multimodal "
+                "decoder prefill."
+            )
+            cfg.cuda_graph_config.prefill.backend = Backend.TC_PIECEWISE
+
+        if cfg.cuda_graph_config.prefill.backend == Backend.TC_PIECEWISE:
+            self._disable_tc_piecewise_cudagraph_if_incompatible()
+        elif cfg.cuda_graph_config.prefill.backend == Backend.BREAKABLE:
+            self._disable_breakable_cudagraph_if_incompatible()
+        elif cfg.cuda_graph_config.prefill.backend == Backend.FULL:
+            self._disable_full_prefill_cudagraph_if_incompatible()
+
+    def _apply_cuda_graph_disaggregation_roles(self):
+        cfg = resolving_view(self)
+        if cfg.disaggregation_mode == "prefill":
+            if (Phase.DECODE, "backend") not in self._cuda_graph_config_locked:
+                cfg.cuda_graph_config.decode.backend = Backend.DISABLED
+        elif cfg.disaggregation_mode == "decode":
+            if (Phase.PREFILL, "backend") not in self._cuda_graph_config_locked:
+                cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+
+    def _disable_tc_piecewise_cudagraph_if_incompatible(self):
+        """TcPiecewise (torch.compile + piecewise) is incompatible with
+        these configurations. Most are torch.compile / dynamo limitations.
+        """
+        cfg = resolving_view(self)
+
+        rules = [
+            (
+                "model-arch blacklist",
+                lambda: self.get_model_config().is_piecewise_cuda_graph_disabled_model,
+            ),
+            ("DP attention", lambda: self._resolved().enable_dp_attention),
+            ("full torch.compile mode", lambda: cfg.enable_torch_compile),
+            ("pipeline parallelism (pp_size > 1)", lambda: cfg.pp_size > 1),
+            (
+                "non-CUDA hardware (HIP/NPU/CPU/MPS/XPU)",
+                lambda: is_hip() or is_npu() or is_cpu() or is_mps() or is_xpu(),
+            ),
+            (
+                "OOT platform without piecewise support",
+                lambda: current_platform.is_out_of_tree()
+                and not current_platform.support_piecewise_cuda_graph(),
+            ),
+            (
+                "MoE A2A backend",
+                lambda: resolved_view(self).moe_a2a_backend != "none",
+            ),
+            # Dynamo blocks LoRA under tc_piecewise (per-batch LoRABatchInfo
+            # rebinds break guards); breakable/full support LoRA.
+            ("LoRA", lambda: bool(cfg.lora_paths) or cfg.enable_lora),
+            (
+                "multimodal model",
+                lambda: self.get_model_config().is_multimodal
+                and not self.get_model_config().is_multimodal_piecewise_cuda_graph_supported,
+            ),
+            (
+                "GGUF quantization",
+                lambda: cfg.load_format == "gguf"
+                or resolved_view(self).quantization == "gguf"
+                or check_gguf_file(cfg.model_path),
+            ),
+            ("DLLM (diffusion LLM)", lambda: cfg.dllm_algorithm is not None),
+            (
+                "CPU offload / hierarchical cache",
+                lambda: cfg.cpu_offload_gb > 0 or cfg.enable_hierarchical_cache,
+            ),
+            (
+                "deterministic inference",
+                lambda: cfg.enable_deterministic_inference,
+            ),
+            ("PD disaggregation", lambda: cfg.disaggregation_mode != "null"),
+            ("symmetric memory", lambda: cfg.enable_symm_mem),
+            (
+                "expert distribution recorder",
+                lambda: cfg.enable_eplb
+                or cfg.expert_distribution_recorder_mode is not None,
+            ),
+            (
+                "context parallel (attn_cp_size > 1)",
+                lambda: self._resolved().attn_cp_size > 1,
+            ),
+            ("CUDA graph debug mode", lambda: cfg.debug_cuda_graph),
+            (
+                "DSA prefill context parallelism",
+                lambda: cfg.enable_dsa_prefill_context_parallel,
+            ),
+            # Capture builds a dummy extend forward with attn_dcp_metadata=None.
+            (
+                "decode context parallel (dcp_size > 1)",
+                lambda: cfg.dcp_size > 1,
+            ),
+        ]
+        for _name, predicate in rules:
+            if predicate():
+                cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+
+    def _disable_breakable_cudagraph_if_incompatible(self):
+        """Breakable (segmented capture, no torch.compile). Breakable enforces
+        memory-saver rejection in its own __init__; config-time rules can be
+        added here as they're discovered.
+        """
+        cfg = resolving_view(self)
+        from sglang.srt.configs.model_config import is_deepseek_v4
+        from sglang.srt.layers.cp.bcg import supports_prefill_cp_bcg
+
+        rules = [
+            # DSV4 is BCG-compatible but introduces heavy memory pressure: the
+            # c4 indexer scratch is pinned in the capture pool and OOMs. Disable.
+            (
+                "DeepSeek-V4 (heavy capture-pool memory pressure)",
+                lambda: is_deepseek_v4(self.get_model_config().hf_config),
+            ),
+            # CP all_gather replay size mismatch under BCG.
+            (
+                "context parallel (attn_cp_size > 1)",
+                lambda: self._resolved().attn_cp_size > 1
+                and not supports_prefill_cp_bcg(self),
+            ),
+            # Capture builds a dummy extend forward with attn_dcp_metadata=None.
+            (
+                "decode context parallel (dcp_size > 1)",
+                lambda: cfg.dcp_size > 1,
+            ),
+            # TBO capture is unsupported.
+            (
+                "two-batch overlap",
+                lambda: cfg.enable_two_batch_overlap,
+            ),
+            (
+                "unvalidated a2a backend",
+                lambda: resolved_view(self).moe_a2a_backend
+                not in ("none", "deepep", "megamoe", "flashinfer"),
+            ),
+            # Multimodal prefill replay faults under BCG; allowlisted archs opt back in.
+            (
+                "multimodal model",
+                lambda: self.get_model_config().is_multimodal
+                and not self.get_model_config().is_multimodal_breakable_cuda_graph_supported,
+            ),
+        ]
+        for name, predicate in rules:
+            if predicate():
+                logger.warning(
+                    "Breakable CUDA graph is incompatible with %s; "
+                    "disabling prefill CUDA graph.",
+                    name,
+                )
+                cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+                return
+
+    def _disable_full_prefill_cudagraph_if_incompatible(self):
+        """Full prefill CG: empty rule list today; see the experimental warning."""
+        cfg = resolving_view(self)
+        rules = []
+        for name, predicate in rules:
+            if predicate():
+                logger.warning(
+                    "Full prefill CUDA graph is incompatible with %s; "
+                    "disabling prefill CUDA graph.",
+                    name,
+                )
+                cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+                return
+
+    def _disable_prefill_cuda_graph_for_deepseek_trtllm_mla(self):
+        """Disable prefill CUDA graph for dsr1 by default when using the trtllm_mla
+        attention backend. Under any captured prefill CUDA graph (tc_piecewise or
+        breakable) trtllm_mla falls back to FlashAttention for prefill and regresses
+        performance, so disable whichever prefill graph backend is in effect.
+        """
+        cfg = resolving_view(self)
+
+        if (Phase.PREFILL, "backend") in self._cuda_graph_config_locked:
+            return
+        if cfg.cuda_graph_config.prefill.backend == Backend.DISABLED:
+            return
+        if (
+            "DeepseekV3ForCausalLM"
+            not in self.get_model_config().hf_config.architectures
+        ):
+            return
+        prefill_attention_backend, _ = self._resolved_attention_backends()
+        if prefill_attention_backend != "trtllm_mla":
+            return
+        logger.warning(
+            "Disabling prefill CUDA graph (%s) by default for the DeepSeek-V3 arch on "
+            "the trtllm_mla attention backend (a captured prefill graph forces a "
+            "FlashAttention fallback that regresses prefill). Set the prefill cuda graph "
+            "backend explicitly (e.g. --cuda-graph-backend-prefill tc_piecewise) to override.",
+            cfg.cuda_graph_config.prefill.backend,
+        )
+        cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+
+    def _validate_cuda_graph_config(self):
+        cfg = resolving_view(self)
+        if cfg.cuda_graph_config is None:
+            return
+        for phase in Phase.ALL:
+            backend = getattr(cfg.cuda_graph_config, phase).backend
+            if backend not in ALLOWED_BACKENDS_PER_PHASE[phase]:
+                raise ValueError(
+                    f"--cuda-graph-config[{phase}].backend={backend!r} not allowed; "
+                    f"allowed: {ALLOWED_BACKENDS_PER_PHASE[phase]}"
+                )
+
+    def _handle_multi_item_scoring(self):
+        """Setup and validate multi-item scoring constraints.
+
+        Auto-disables settings incompatible with MIS mechanics (CUDA graph,
+        radix cache, chunked prefill). Asserts on attention backend since
+        changing it silently could surprise users who intentionally picked
+        a non-flashinfer backend.
+        """
+        cfg = resolving_view(self)
+        if not cfg.enable_mis:
+            return
+
+        if cfg.cuda_graph_config.decode.backend != Backend.DISABLED:
+            logger.warning("CUDA graph is disabled because --enable-mis is set.")
+        cfg.cuda_graph_config.decode.backend = Backend.DISABLED
+        cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+
+        if not cfg.disable_radix_cache:
+            logger.warning("Radix cache is disabled because --enable-mis is set.")
+            self._declare(
+                "_handle_multi_item_scoring",
+                disable_radix_cache=True,
+            )
+
+        if cfg.chunked_prefill_size != -1:
+            logger.warning("Chunked prefill is disabled because --enable-mis is set.")
+            self._declare(
+                "_handle_multi_item_scoring",
+                chunked_prefill_size=-1,
+            )
+
+        prefill_backend, decode_backend = self._resolved_attention_backends()
+        assert prefill_backend == "flashinfer" and decode_backend == "flashinfer", (
+            "Multi-item scoring requires flashinfer attention backend for custom attention mask support. "
+            f"Please set --attention-backend flashinfer when using --enable-mis. "
+            f"Current backends: prefill={prefill_backend}, decode={decode_backend}"
+        )
+
+    def _handle_gpu_memory_settings(self, gpu_mem):
+        """
+        Configure GPU memory-dependent settings including
+        chunked_prefill_size, cuda_graph_config[decode].max_bs, and mem_fraction_static.
+
+        Here are our heuristics:
+        - Set chunked_prefill_size and cuda_graph_config[decode].max_bs based on the GPU memory capacity.
+          This is because GPUs with more memory are generally more powerful, we need to use a larger
+          chunked_prefill_size and a larger decode max_bs to fully utilize the GPU.
+        - Then set mem_fraction_static based on chunked_prefill_size and decode max_bs.
+
+          GPU memory capacity = model weights + KV cache pool + activations + cuda graph buffers
+
+          The argument mem_fraction_static is defined as (model weights + KV cache pool) / GPU memory capacity,
+          or equivalently, mem_fraction_static = (GPU memory capacity - activations - cuda graph buffers) / GPU memory capacity.
+
+          In order to compute mem_fraction_static, we need to estimate the size of activations and cuda graph buffers.
+          The activation memory is proportional to the chunked_prefill_size.
+          The cuda graph memory is proportional to the decode max_bs.
+          We use reserved_mem = chunked_prefill_size * 1.5 + max_bs * 2 to estimate the size of activations and cuda graph buffers in GB,
+          and set mem_fraction_static = (GPU memory capacity - reserved_mem) / GPU memory capacity.
+
+          The coefficient 1.5 is a heuristic value, in the future, we can do better estimation by looking at the model types, hidden sizes or even do a dummy run.
+        """
+        cfg = resolving_view(self)
+        decode_cuda_graph_config = cfg.cuda_graph_config.decode
+        prefill_cuda_graph_config = cfg.cuda_graph_config.prefill
+
+        if gpu_mem is not None:
+            if gpu_mem < 20 * 1024:
+                # T4, 4080
+                # (chunked_prefill_size 2k, max_bs 8)
+                if cfg.chunked_prefill_size is None:
+                    self._declare(
+                        "_handle_gpu_memory_settings",
+                        chunked_prefill_size=2048,
+                    )
+                if decode_cuda_graph_config.max_bs is None:
+                    decode_cuda_graph_config.max_bs = 8
+            elif gpu_mem < 35 * 1024:
+                # A10, 4090, 5090
+                # (chunked_prefill_size 2k, max_bs 24 if tp < 4 else 80)
+                if cfg.chunked_prefill_size is None:
+                    self._declare(
+                        "_handle_gpu_memory_settings",
+                        chunked_prefill_size=2048,
+                    )
+                if decode_cuda_graph_config.max_bs is None:
+                    if cfg.tp_size < 4:
+                        decode_cuda_graph_config.max_bs = 24
+                    else:
+                        decode_cuda_graph_config.max_bs = 80
+            elif gpu_mem < 60 * 1024:
+                # A100 (40GB), L40,
+                # (chunked_prefill_size 4k, max_bs 32 if tp < 4 else 160)
+                if cfg.chunked_prefill_size is None:
+                    self._declare(
+                        "_handle_gpu_memory_settings",
+                        chunked_prefill_size=4096,
+                    )
+                if decode_cuda_graph_config.max_bs is None:
+                    if cfg.tp_size < 4:
+                        decode_cuda_graph_config.max_bs = 32
+                    else:
+                        decode_cuda_graph_config.max_bs = 160
+            elif gpu_mem < 90 * 1024:
+                # H100, A100
+                # (chunked_prefill_size 8k, max_bs 256 if tp < 4 else 512)
+                if cfg.chunked_prefill_size is None:
+                    self._declare(
+                        "_handle_gpu_memory_settings",
+                        chunked_prefill_size=8192,
+                    )
+                if decode_cuda_graph_config.max_bs is None:
+                    if cfg.tp_size < 4:
+                        decode_cuda_graph_config.max_bs = 256
+                    else:
+                        decode_cuda_graph_config.max_bs = 512
+            elif gpu_mem < 160 * 1024:
+                # H20, H200
+                # (chunked_prefill_size 8k, max_bs 256 if tp < 4 else 512)
+                if cfg.chunked_prefill_size is None:
+                    self._declare(
+                        "_handle_gpu_memory_settings",
+                        chunked_prefill_size=8192,
+                    )
+                if decode_cuda_graph_config.max_bs is None:
+                    if cfg.tp_size < 4:
+                        decode_cuda_graph_config.max_bs = 256
+                    else:
+                        decode_cuda_graph_config.max_bs = 512
+            else:
+                # B200, MI300
+                # (chunked_prefill_size 16k, max_bs 512)
+                if cfg.chunked_prefill_size is None:
+                    self._declare(
+                        "_handle_gpu_memory_settings",
+                        chunked_prefill_size=16384,
+                    )
+                if decode_cuda_graph_config.max_bs is None:
+                    decode_cuda_graph_config.max_bs = 512
+        else:
+            # Fallback defaults when gpu_mem is None
+            if cfg.chunked_prefill_size is None:
+                self._declare(
+                    "_handle_gpu_memory_settings",
+                    chunked_prefill_size=4096,
+                )
+            if decode_cuda_graph_config.max_bs is None:
+                decode_cuda_graph_config.max_bs = 160
+
+        # Set cuda graph batch sizes
+        if cfg.device != "cpu":
+            if decode_cuda_graph_config.bs is None:
+                decode_cuda_graph_config.bs = (
+                    self._generate_decode_cuda_graph_batch_sizes(
+                        decode_cuda_graph_config.max_bs
+                    )
+                )
+            else:
+                decode_cuda_graph_config.max_bs = max(decode_cuda_graph_config.bs)
+        else:
+            # Reuse decode_cuda_graph_config.bs for cpu graph and use torch_compile_max_bs for cpu graph batch size limit,
+            # as cpu graph is based on torch.compile
+            if decode_cuda_graph_config.bs is not None:
+                self._declare(
+                    "_handle_gpu_memory_settings",
+                    torch_compile_max_bs=max(decode_cuda_graph_config.bs),
+                )
+            else:
+                # If decode_cuda_graph_config.bs is not set, we will preferentially use torch_compile_max_bs
+                # to generate decode_cuda_graph_config.bs
+                self._declare(
+                    "_handle_gpu_memory_settings",
+                    torch_compile_max_bs=cfg.torch_compile_max_bs
+                    or decode_cuda_graph_config.max_bs,
+                )
+                decode_cuda_graph_config.bs = self._generate_cpu_graph_batch_sizes()
+
+            assert (
+                cfg.torch_compile_max_bs > 0
+            ), "cuda_graph_config[decode].bs should contain positive batch sizes"
+            decode_cuda_graph_config.max_bs = cfg.torch_compile_max_bs
+
+        if prefill_cuda_graph_config.max_bs is None:
+            # Refer to pr #15927, by default we set the prefill max_bs to the chunked prefill size.
+            # For MLA backend, the introduction of piecewise cuda graph will influence the kernel dispatch difference compared to the original mode.
+            # To avoid the performance regression, we set max_bs to 2048 by default.
+            if not self.use_mla_backend():
+                prefill_cuda_graph_config.max_bs = cfg.chunked_prefill_size
+            else:
+                prefill_cuda_graph_config.max_bs = 2048
+
+            # If max_total_tokens is set, cap prefill max_bs to not exceed max_total_tokens.
+            if cfg.max_total_tokens is not None:
+                prefill_cuda_graph_config.max_bs = min(
+                    prefill_cuda_graph_config.max_bs, cfg.max_total_tokens
+                )
+
+            # For Llama2 series models, max_bs is limited to 4096.
+            # TODO(yuwei): remove this after the issue is fixed
+            if "llama-2" in cfg.model_path.lower():
+                prefill_cuda_graph_config.max_bs = min(
+                    prefill_cuda_graph_config.max_bs, 4096
+                )
+
+        if prefill_cuda_graph_config.bs is None:
+            prefill_cuda_graph_config.bs = (
+                self._generate_prefill_cuda_graph_batch_sizes(
+                    prefill_cuda_graph_config.max_bs
+                )
+            )
+
+        if cfg.mem_fraction_static is None:
+            if self.post_capture_kv_sizing_planned():
+                # Post-capture sizing measures free memory after graph capture, so
+                # skip the graph/activation reserve; keep only the floor + parallel slack.
+                reserved_mem = 1536
+                reserved_mem += cfg.tp_size * cfg.pp_size / 8 * 1024
+            else:
+                # Tokens the activation working set scales with (per serving mode).
+                if cfg.disaggregation_mode == "decode":
+                    running_requests = (
+                        cfg.max_running_requests or decode_cuda_graph_config.max_bs or 1
+                    )
+                    draft_tokens = cfg.speculative_num_draft_tokens or 1
+                    activation_tokens = max(running_requests * draft_tokens, 2048)
+                elif cfg.chunked_prefill_size > 0:
+                    activation_tokens = max(cfg.chunked_prefill_size, 2048)
+                else:
+                    activation_tokens = max(cfg.max_prefill_tokens, 2048)
+                # Constant meta data (e.g., from attention backend) + activation slack.
+                reserved_mem = 512
+                reserved_mem += activation_tokens * 1.5
+                # Some adjustments for large parallel size
+                reserved_mem += cfg.tp_size * cfg.pp_size / 8 * 1024
+                reserved_mem += self.reserve_for_graph_mb()
+                if gpu_mem is not None and gpu_mem > 60 * 1024:
+                    reserved_mem = max(reserved_mem, 10 * 1024)
+                # Reserve headroom for DeepEP all-to-all buffers on top of the floor.
+                reserved_mem += self.reserve_for_deepep_a2a_mb()
+
+            self._declare(
+                "_handle_gpu_memory_settings",
+                mem_fraction_static=(
+                    round((gpu_mem - reserved_mem) / gpu_mem, 3)
+                    if gpu_mem is not None
+                    else 0.88
+                ),
+            )
+
+            # Multimodal models need more memory for the image processing,
+            # so we adjust the mem_fraction_static accordingly. The VLM encoder
+            # only runs on the prefill stage, so PD decode engines do not need
+            # this headroom; prefill engines and normal (non-PD) engines do.
+            model_config = self.get_model_config()
+            if (
+                model_config.is_multimodal
+                and not cfg.language_only
+                and not cfg.language_model_only
+                and cfg.disaggregation_mode != "decode"
+            ):
+                self.adjust_mem_fraction_for_vlm(model_config)
+
+        # If symm mem is enabled and prealloc size is not set, set it to 4GB
+        if cfg.enable_symm_mem and not envs.SGLANG_SYMM_MEM_PREALLOC_GB_SIZE.is_set():
+            envs.SGLANG_SYMM_MEM_PREALLOC_GB_SIZE.set(4)
+            logger.warning(
+                "Symmetric memory is enabled, setting symmetric memory prealloc size to 4GB as default."
+                "Use environment variable SGLANG_SYMM_MEM_PREALLOC_GB_SIZE to change the prealloc size."
+            )
+
+    def post_capture_kv_sizing_planned(self) -> bool:
+        """Whether the mem_fraction heuristic may skip the graph reserve; must be
+        False for any config the runtime won't post-capture-size, else it gets an
+        under-reserved fraction."""
+        cfg = resolving_view(self)
+        # use_mla_backend is a method at args time but ModelRunner overwrites it
+        # with a bool on global_server_args (see the FIXME there) -- handle both.
+        use_mla = self.use_mla_backend
+        mla_enabled = use_mla() if callable(use_mla) else use_mla
+        if not envs.SGLANG_ENABLE_POST_CAPTURE_KV_SIZING.get():
+            return False
+        if cfg.device != "cuda":
+            return False
+        if cfg.dcp_size != 1:
+            return False
+        if mla_enabled:
+            return False
+        if cfg.kv_cache_dtype == "fp4_e2m1":
+            return False
+        if cfg.prefill_only_disable_kv_cache:
+            return False
+        if cfg.enable_memory_saver:
+            return False
+        if envs.SGLANG_MOONCAKE_CUSTOM_MEM_POOL.get() is not None:
+            return False
+
+        if (
+            cfg.disaggregation_mode != "prefill"
+            and cfg.cuda_graph_config.decode.backend == Backend.DISABLED
+        ):
+            return False
+
+        if cfg.disaggregation_mode != "decode":
+            prefill_cfg = cfg.cuda_graph_config.prefill
+            # We can only skip eager activation headroom when the largest
+            # prefill forward batch size is already graph-captured. Otherwise,
+            # an eager forward will need more memory and lead to OOM.
+            if (
+                prefill_cfg.backend == Backend.DISABLED
+                or cfg.chunked_prefill_size <= 0
+                or self.max_prefill_buffer_tokens() > max(prefill_cfg.bs or (0,))
+            ):
+                return False
+
+        from sglang.srt.configs.model_config import is_deepseek_v4, is_minimax_sparse
+
+        hf_config = self.get_model_config().hf_config
+        if is_deepseek_v4(hf_config) or is_minimax_sparse(hf_config):
+            return False
+
+        return True
+
+    def pre_capture_activation_reserve_mb(self, gpu_mem: Optional[float]) -> float:
+        # Runtime activation working-set reserve for eager decode above the captured
+        # max_bs and transient prefill/logits; also covers fixed state caches.
+        cfg = resolving_view(self)
+        if cfg.disaggregation_mode == "decode":
+            running_requests = (
+                cfg.max_running_requests or cfg.cuda_graph_config.decode.max_bs or 1
+            )
+            activation_tokens = max(
+                running_requests * (cfg.speculative_num_draft_tokens or 1), 2048
+            )
+        elif cfg.chunked_prefill_size > 0:
+            activation_tokens = max(cfg.chunked_prefill_size, 2048)
+        else:
+            activation_tokens = max(cfg.max_prefill_tokens, 2048)
+        reserved_mem = (
+            512 + activation_tokens * 1.5 + cfg.tp_size * cfg.pp_size / 8 * 1024
+        )
+        if gpu_mem is not None and gpu_mem > 60 * 1024:
+            reserved_mem = max(reserved_mem, 10 * 1024)
+        return reserved_mem
+
+    def reserve_for_graph_mb(self) -> float:
+        cfg = resolving_view(self)
+        decode_cuda_graph_config = cfg.cuda_graph_config.decode
+        prefill_cuda_graph_config = cfg.cuda_graph_config.prefill
+
+        reserved_mem = 0.0
+        if (
+            cfg.disaggregation_mode != "prefill"
+            and decode_cuda_graph_config.backend != Backend.DISABLED
+        ):
+            reserved_mem += decode_cuda_graph_config.max_bs * 2
+
+        if (
+            self._resolved().enable_dp_attention
+            and cfg.disaggregation_mode != "prefill"
+        ):
+            # DP attention needs more padding for some operations, and much more for large
+            # cuda graph max bs (torch allocator / implementation inefficiencies).
+            reserved_mem += decode_cuda_graph_config.max_bs * cfg.dp_size * 3
+            if decode_cuda_graph_config.max_bs > 300:
+                reserved_mem += decode_cuda_graph_config.max_bs * cfg.dp_size * 1.5
+
+        if (
+            cfg.disaggregation_mode != "decode"
+            and prefill_cuda_graph_config.backend != Backend.DISABLED
+        ):
+            if not self.use_mla_backend():
+                # Only non-torch memory is counted; torch memory is reused by cuda graph capture.
+                reserved_mem += len(prefill_cuda_graph_config.bs) * 8
+            else:
+                # MLA backend overhead is much higher than expected with fa3.
+                reserved_mem += 1.5 * 1024
+
+            if (
+                prefill_cuda_graph_config.backend == Backend.BREAKABLE
+                and resolved_view(self).moe_a2a_backend == "deepep"
+            ):
+                # Prefill-BCG DeepEP delta (bridge pool + NVL first-touch
+                # during capture); decode-side DeepEP is a baseline cost.
+                reserved_mem += 1 * 1024
+
+        return reserved_mem
+
+    def reserve_for_deepep_a2a_mb(self) -> float:
+        # DeepEP all-to-all buffers captured in the decode graph are real extra
+        # allocations, reserved on top of the floor.
+
+        cfg = resolving_view(self)
+        decode_cuda_graph_config = cfg.cuda_graph_config.decode
+        if (
+            cfg.disaggregation_mode != "prefill"
+            and decode_cuda_graph_config.backend != Backend.DISABLED
+            and resolved_view(self).moe_a2a_backend == "deepep"
+        ):
+            return 2 * 1024
+        return 0.0
+
+    def _generate_decode_cuda_graph_batch_sizes(self, max_bs: int):
+        """
+        Generate the list of batch sizes for CUDA graph capture based on max_bs.
+        This integrates the logic from cuda_graph_runner.py.
+        """
+        cfg = resolving_view(self)
+        # Handle disable_cuda_graph_padding as the first condition for both spec and non-spec
+        if cfg.disable_cuda_graph_padding:
+            capture_bs = list(range(1, max_bs + 1))
+        elif cfg.speculative_algorithm is None:
+            # Normal case:
+            capture_bs = (
+                [1, 2, 4, 8, 12]
+                + list(range(16, 257, 8))
+                + list(range(272, 512, 16))
+                + list(range(512, max_bs + 1, 32))
+            )
+        else:
+            # Spec decoding case: less padding for smaller batch sizes
+            capture_bs = (
+                list(range(1, 9, 1))
+                + list(range(10, 33, 2))
+                + list(range(40, 65, 4))
+                + list(range(72, 257, 8))
+                + list(range(272, max_bs + 1, 16))
+            )
+
+        capture_bs = [bs for bs in capture_bs if bs <= max_bs]
+
+        if max_bs not in capture_bs:
+            capture_bs.append(max_bs)
+
+        return capture_bs
+
+    def _generate_cpu_graph_batch_sizes(self):
+        """
+        Generate the list of batch sizes for CPU graph capture based on torch_compile_max_bs.
+        """
+        cfg = resolving_view(self)
+        if cfg.disable_cuda_graph_padding:
+            capture_bs = list(range(1, cfg.torch_compile_max_bs + 1))
+        else:
+            capture_bs = sorted(
+                set().union(
+                    range(1, 17),
+                    range(18, 31, 2),
+                    range(32, 81, 4),
+                    range(84, cfg.torch_compile_max_bs + 1, 8),
+                    {cfg.torch_compile_max_bs},
+                )
+            )
+        capture_bs = [bs for bs in capture_bs if bs <= cfg.torch_compile_max_bs]
+
+        return capture_bs
+
+    def _generate_prefill_cuda_graph_batch_sizes(self, max_bs: int):
+        """
+        Generate the list of batch sizes for prefill CUDA graph capture
+        based on max_bs. For tc_piecewise prefill, bs carries the
+        captured token count (one shape knob per phase).
+        """
+        capture_sizes = (
+            list(range(4, 33, 4))
+            + list(range(48, 257, 16))
+            + list(range(288, 513, 32))
+            + list(range(576, 1024 + 1, 64))
+            + list(range(1280, 4096 + 1, 256))
+            + list(range(4608, max_bs + 1, 512))
+        )
+
+        capture_sizes = [s for s in capture_sizes if s <= max_bs]
+
+        return capture_sizes
+
+    def _set_default_dsa_kv_cache_dtype(self, major: int, quantization: str) -> None:
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _dsa_kv_cache_dtype_default), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _dsa_kv_cache_dtype_default,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _dsa_kv_cache_dtype_default)
+
+    def _set_default_dsa_backends(self, major: int) -> None:
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _dsa_split_backend_resolution), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _dsa_split_backend_resolution,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _dsa_split_backend_resolution)
+
+    def _validate_hisparse_dsa_backend(self, attr: str, label: str):
+        from sglang.srt.arg_groups.hisparse_hook import validate_hisparse_dsa_backend
+
+        validate_hisparse_dsa_backend(self, attr, label)
+
+    def _validate_hisparse_kv_cache_dtype(self):
+        from sglang.srt.arg_groups.hisparse_hook import validate_hisparse_kv_cache_dtype
+
+        validate_hisparse_kv_cache_dtype(self)
+
+    def _handle_model_specific_adjustments(self):
+        cfg = resolving_view(self)
+        from sglang.srt.configs.model_config import (
+            get_mimo_v2_fused_qkv_expected_tp_size,
+            is_deepseek_dsa,
+            is_deepseek_v4,
+        )
+
+        if cfg.enable_deterministic_inference:
+            self._declare(
+                "_handle_model_specific_adjustments",
+                enforce_disable_flashinfer_allreduce_fusion=True,
+            )
+
+        self._declare(
+            "_handle_model_specific_adjustments",
+            uses_mamba_radix_cache=False,
+        )
+        if parse_connector_type(cfg.model_path) == ConnectorType.INSTANCE:
+            # No model overrides for an instance connector: no hf_config to
+            # key them on.
+            return
+
+        model_config = self.get_model_config()
+        hf_config = model_config.hf_config
+        model_arch = hf_config.architectures[0]
+
+        if model_arch == "InternS2MobiusForConditionalGeneration":
+            unsupported = []
+            if cfg.pp_size != 1:
+                unsupported.append("pipeline parallelism (--pp-size must be 1)")
+            if cfg.ep_size != 1:
+                unsupported.append("expert parallelism (--ep-size must be 1)")
+            if unsupported:
+                raise ValueError(
+                    "Intern-S2-Mobius does not support: " + "; ".join(unsupported) + "."
+                )
+
+        if cfg.enable_dsa_cache_layer_split and not (
+            is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config)
+        ):
+            raise ValueError(
+                "--enable-dsa-cache-layer-split is only supported for DSA "
+                "(DeepSeek Sparse Attention) models, including DeepSeek V4."
+            )
+
+        if cfg.enable_cp_decode_attn_tp:
+            from sglang.srt.layers.cp.cp_decode_attn_tp import (
+                CP_DECODE_ATTN_TP_SUPPORTED_ARCHS,
+            )
+
+            if model_arch not in CP_DECODE_ATTN_TP_SUPPORTED_ARCHS:
+                raise ValueError(
+                    "--enable-cp-decode-attn-tp is only supported for models "
+                    "whose attention linears are replicated across CP ranks "
+                    f"(attn_tp_size=1). Got {model_arch}; supported: "
+                    f"{sorted(CP_DECODE_ATTN_TP_SUPPORTED_ARCHS)}."
+                )
+
+        _hybrid_spec = get_linear_attn_spec_by_arch(model_arch)
+        if _hybrid_spec is not None and _hybrid_spec.uses_mamba_radix_cache:
+            self._handle_mamba_radix_cache(model_arch=model_arch)
+
+        # Collect the declarative model overrides (registry) on the
+        # pristine config and stash them for publish-time flags resolution;
+        # server_args is never mutated — mid-resolution readers see the
+        # declared values through resolved_view, runtime readers through the
+        # flags tier.
+        from sglang.srt.arg_groups.overrides import (
+            collect_model_override_declarations,
+            validate_declarations,
+        )
+
+        model_overrides = collect_model_override_declarations(
+            model_arch, self, hf_config
+        )
+        validate_declarations(self, model_overrides)
+        self._resolved_overrides.extend(model_overrides)
+
+        if model_arch in (
+            "KimiLinearForCausalLM",
+            "KimiK3ForConditionalGeneration",
+        ):
+            from sglang.srt.arg_groups.kimi_k3_hook import (
+                apply_kimi_k3_linear_attn_defaults,
+                apply_kimi_k3_spec_backend_defaults,
+            )
+
+            apply_kimi_k3_linear_attn_defaults(self)
+            apply_kimi_k3_spec_backend_defaults(self)
+
+        if model_arch in [
+            "DeepseekV4ForCausalLM",
+        ]:
+            from sglang.srt.arg_groups.deepseek_v4_hook import (
+                apply_deepseek_v4_defaults,
+            )
+
+            apply_deepseek_v4_defaults(self, model_arch)
+
+        if model_arch in [
+            "DeepseekV3ForCausalLM",
+            "DeepseekV32ForCausalLM",
+            "KimiK25ForConditionalGeneration",
+            "MistralLarge3ForCausalLM",
+            "PixtralForConditionalGeneration",
+            "GlmMoeDsaForCausalLM",
+            "LongcatFlashForCausalLM",
+            "Dots3NoteForCausalLM",
+        ]:
+            # Set attention backend for DeepSeek
+            if is_deepseek_dsa(hf_config):  # DeepSeek 3.2/GLM 5
+                if envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.is_set():
+                    logger.warning(
+                        f"Dense attention kv len threshold is manually set to {envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()} for DSA. Caution: This may cause performance regression if the threshold is larger than the index topk of model."
+                    )
+                else:
+                    # When threshold is not manually set, set it to the index topk of model
+                    from sglang.srt.configs.model_config import get_dsa_index_topk
+
+                    envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.set(
+                        get_dsa_index_topk(hf_config)
+                    )
+                    logger.warning(
+                        f"Set dense attention kv len threshold to model index_topk={envs.SGLANG_DSA_PREFILL_DENSE_ATTN_KV_LEN_THRESHOLD.get()} for DeepSeek with DSA."
+                    )
+                # The "dsa" attention fill moved to the override registry
+                # (arg_groups/overrides.py: _deepseek_family_overrides).
+
+                index_topk_freq = getattr(hf_config, "index_topk_freq", 1) or 1
+                index_topk_pattern = getattr(hf_config, "index_topk_pattern", None)
+                if cfg.enable_two_batch_overlap and (
+                    index_topk_freq > 1
+                    or (index_topk_pattern is not None and "S" in index_topk_pattern)
+                ):
+                    raise ValueError(
+                        "--enable-two-batch-overlap is not supported with DSA "
+                        "index-topk sharing (index_topk_freq > 1 or an "
+                        "index_topk_pattern containing shared layers): the TBO op "
+                        "path does not propagate topk indices across layers, so "
+                        "shared layers would run sparse attention without indices."
+                    )
+
+                if not is_npu() and not is_xpu():  # CUDA or ROCm GPU
+                    if cfg.enable_prefill_cp:
+                        # The DSA CP field declarations moved to the override
+                        # registry (arg_groups/overrides.py:
+                        # _deepseek_family_overrides).
+                        cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+                    else:
+                        # Pure TP and partial DP Attention mode is active for DSA, logging a warning
+                        if cfg.dp_size < cfg.tp_size:
+                            logger.warning(
+                                f"DSA with TP mode is active, dp_size={cfg.dp_size}, tp_size={cfg.tp_size}, "
+                                f"attn_tp_size={cfg.tp_size}, attention weights will be sharded across {cfg.tp_size} ranks."
+                            )
+
+                    # The DSA page-size selection moved to the override registry
+                    # (arg_groups/overrides.py: _deepseek_family_overrides).
+
+                    import torch
+
+                    major, _ = torch.cuda.get_device_capability()
+                    self._set_default_dsa_kv_cache_dtype(
+                        major, resolved_view(self).quantization
+                    )
+                    self._set_default_dsa_backends(major)
+
+                if cfg.enable_prefill_cp:
+                    assert (
+                        cfg.disaggregation_mode != "decode"
+                    ), "CP is only supported for prefill when PD disaggregation, please remove --enable-prefill-cp."
+                if (
+                    cfg.enable_dsa_cache_layer_split
+                    and cfg.disaggregation_mode != "prefill"
+                ):
+                    if cfg.disaggregation_mode == "decode":
+                        raise ValueError(
+                            "--enable-dsa-cache-layer-split is not supported on "
+                            "decode workers. This flag is a prefill-CP "
+                            "optimization; decode receives full cache shards "
+                            "through PD transfer."
+                        )
+                    raise ValueError(
+                        "--enable-dsa-cache-layer-split is only supported on PD "
+                        "prefill workers. Non-PD workers also run decode and "
+                        "require ordinary local decode cache semantics."
+                    )
+                if cfg.enable_dsa_cache_layer_split and (
+                    not cfg.enable_prefill_cp or cfg.cp_strategy != "interleave"
+                ):
+                    raise ValueError(
+                        "--enable-dsa-cache-layer-split requires "
+                        "--enable-prefill-cp and --cp-strategy interleave "
+                        "(or legacy --enable-nsa-prefill-context-parallel with "
+                        "--nsa-prefill-cp-mode round-robin-split)."
+                    )
+                # Layer split relies on the mooncake all-CP-rank KV/indexer
+                # transfer path. mori/nixl support is a temporary limitation
+                # and will be added later by the community.
+                if (
+                    cfg.enable_dsa_cache_layer_split
+                    and cfg.disaggregation_transfer_backend != "mooncake"
+                ):
+                    raise ValueError(
+                        "--enable-dsa-cache-layer-split currently only supports "
+                        "the mooncake transfer backend (mooncake / mooncake_tcp). "
+                        f"Got --disaggregation-transfer-backend "
+                        f"{cfg.disaggregation_transfer_backend!r}. mori/nixl "
+                        "support will be added later by the community."
+                    )
+                if cfg.enable_dsa_cache_layer_split and cfg.pp_size > 1:
+                    raise ValueError(
+                        "--enable-dsa-cache-layer-split is not supported with "
+                        "pipeline parallelism (pp_size > 1) yet. It requires "
+                        "prefill context parallelism, and CP + PP has not been "
+                        "validated for this feature."
+                    )
+
+            else:
+                # DeepSeek V3/R1/V3.1
+                if cfg.cuda_graph_config.prefill.backend != Backend.DISABLED:
+                    logger.info("Piecewise CUDA graph is enabled, use MLA for prefill.")
+
+                # The sm100 trtllm_mla fill moved to the override registry
+                # (arg_groups/overrides.py: _deepseek_family_overrides).
+
+                # MLA prefill CP auto-config: the field declarations moved to
+                # the override registry (arg_groups/overrides.py:
+                # _deepseek_family_overrides).
+                if cfg.enable_prefill_cp and self.use_mla_backend():
+                    cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+
+            # Set moe backend for DeepSeek: the sm100 quant/moe resolution
+            # moved to the resolution pipeline (arg_groups/overrides.py:
+            # _deepseek_moe_quant_resolution -- a slot pass, because the DSA
+            # kv-cache-dtype default above must read the pristine
+            # quantization). The HIP arm (fusion log + spec_moe writes, the
+            # latter awaiting the speculative-hook migration) stays below.
+            from sglang.srt.arg_groups.overrides import (
+                _deepseek_moe_quant_resolution,
+                run_post_process_pass,
+            )
+
+            run_post_process_pass(self, _deepseek_moe_quant_resolution)
+            if is_hip():
+                if is_deepseek_dsa(hf_config):
+                    # The fused top-k v2 kernel (topk_transform_512_v2) is a
+                    # CUDA/Hopper-only path: its JIT source includes
+                    # <cooperative_groups.h> and uses cg::this_cluster()
+                    # (thread-block clusters), neither of which exists on ROCm,
+                    # so it fails to JIT-compile on gfx9xx during CUDA-graph
+                    # capture. DeepSeek-V4 already disables it on HIP; mirror that
+                    # here for the rest of the DSA family (DeepSeek-V3.2 /
+                    # GLM-5.x) that shares the same decode top-k path.
+                    envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+                if not self._resolved().enable_dp_attention and cfg.nnodes == 1:
+                    # TODO (Hubert): Put this back later
+                    # self.enable_aiter_allreduce_fusion = True
+                    logger.info(
+                        "Enable Aiter AllReduce Fusion for DeepseekV3ForCausalLM"
+                    )
+
+                # The fp4-checkpoint draft spec-MoE resolution moved to the
+                # resolution pipeline (arg_groups/overrides.py:
+                # _deepseek_spec_moe_resolution), invoked here at its legacy
+                # slot.
+                from sglang.srt.arg_groups.overrides import (
+                    _deepseek_spec_moe_resolution,
+                )
+
+                run_post_process_pass(self, _deepseek_spec_moe_resolution)
+
+        elif model_arch in [
+            "DeepseekV4ForCausalLM",
+        ]:
+            from sglang.srt.arg_groups.deepseek_v4_hook import (
+                validate_deepseek_v4_cp,
+                validate_deepseek_v4_layer_split,
+                validate_deepseek_v4_mega_moe_token_budget,
+            )
+
+            validate_deepseek_v4_cp(self)
+            validate_deepseek_v4_layer_split(self)
+            validate_deepseek_v4_mega_moe_token_budget(self)
+
+            if is_sm120_supported():
+                # SM120 lacks tcgen05/TMEM: disable features that depend on
+                # DeepGEMM or require >99KB SMEM (topk_v2).
+                envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+                envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+                envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
+                if not envs.SGLANG_OPT_FUSE_MHC_POST_PRE.is_set():
+                    envs.SGLANG_OPT_FUSE_MHC_POST_PRE.set(True)
+                envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
+                envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
+                # Prefer TileLang over the Torch fallback.
+                envs.SGLANG_OPT_USE_TILELANG_INDEXER.set(True)
+            elif is_hip():
+                envs.SGLANG_OPT_DEEPGEMM_HC_PRENORM.set(False)
+                envs.SGLANG_OPT_FP8_WO_A_GEMM.set(False)
+                envs.SGLANG_OPT_USE_JIT_INDEXER_METADATA.set(False)
+                envs.SGLANG_OPT_USE_TOPK_V2.set(False)
+                envs.SGLANG_OPT_USE_AITER_INDEXER.set(True)
+                envs.SGLANG_OPT_USE_TILELANG_MHC_PRE.set(False)
+                envs.SGLANG_OPT_USE_TILELANG_MHC_POST.set(False)
+                envs.SGLANG_FP8_PAGED_MQA_LOGITS_TORCH.set(True)
+                envs.SGLANG_OPT_USE_MULTI_STREAM_OVERLAP.set(False)
+                envs.SGLANG_EAGER_INPUT_NO_COPY.set(True)
+
+        elif model_arch in ["GptOssForCausalLM"]:
+            # Attention backend selection + XPU dtype validation moved to the
+            # override registry (arg_groups/overrides.py: _gpt_oss_overrides).
+            # Exempt MLX only: none of these backends exist on MPS, and MLX runs
+            # attention inside its own runner, so attention_backend is still
+            # unset here.  Plain macOS stays on the list -- torch_native has
+            # neither sliding window nor attention sinks.
+            if not (is_mps() and use_mlx()):
+                supported_backends = [
+                    "triton",
+                    "trtllm_mha",
+                    "fa3",
+                    "fa4",
+                    "ascend",
+                    "intel_amx",
+                    "intel_xpu",
+                    "aiter",
+                ]
+                prefill_attn_backend, decode_attn_backend = (
+                    self._resolved_attention_backends()
+                )
+                assert (
+                    prefill_attn_backend in supported_backends
+                    and decode_attn_backend in supported_backends
+                ), (
+                    f"GptOssForCausalLM requires one of {supported_backends} attention backend, but got the following backends\n"
+                    f"- Prefill: {prefill_attn_backend}\n"
+                    f"- Decode: {decode_attn_backend}\n"
+                )
+
+            quant_method = get_quantization_config(hf_config)
+            is_mxfp4_quant_format = quant_method == "mxfp4"
+            if (
+                not self._resolved().enable_dp_attention
+                and cfg.nnodes == 1
+                and is_hip()
+            ):
+                # TODO (Hubert): Put this back later
+                # self.enable_aiter_allreduce_fusion = True
+                logger.info("Enable Aiter AllReduce Fusion for GptOssForCausalLM")
+            quantization_config = getattr(hf_config, "quantization_config", None)
+            is_mxfp4_quant_format = (
+                quantization_config is not None
+                and quantization_config.get("quant_method") == "mxfp4"
+            )
+            # The mxfp4 dtype override moved to the override registry
+            # (arg_groups/overrides.py: _gpt_oss_overrides).
+
+            # The moe_runner_backend selection moved to the override registry
+            # (arg_groups/overrides.py: _gpt_oss_overrides).
+
+            if resolved_view(self).moe_runner_backend == "triton_kernel":
+                assert (
+                    self._resolved().ep_size == 1
+                ), "Triton kernel MoE is only supported when ep_size == 1"
+
+        elif model_arch in ("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM"):
+            if model_arch == "MiMoV2ForCausalLM" and not cfg.encoder_only:
+                expected_attn_tp_size = get_mimo_v2_fused_qkv_expected_tp_size(
+                    hf_config
+                )
+                view = self._resolved()
+                attn_dp_size = cfg.dp_size if view.enable_dp_attention else 1
+                effective_attn_tp_size = (
+                    cfg.tp_size // attn_dp_size // view.attn_cp_size
+                )
+                if (
+                    expected_attn_tp_size is not None
+                    and expected_attn_tp_size % effective_attn_tp_size != 0
+                ):
+                    raise ValueError(
+                        "MiMoV2ForCausalLM requires effective attention TP "
+                        f"size {expected_attn_tp_size} because its fused "
+                        "qkv_proj weights are "
+                        f"TP={expected_attn_tp_size}-interleaved; got "
+                        f"{effective_attn_tp_size} "
+                        f"(tp_size={cfg.tp_size}, dp_size={cfg.dp_size}, "
+                        f"enable_dp_attention={view.enable_dp_attention}, "
+                        f"attn_cp_size={view.attn_cp_size}). "
+                        "Set --tp, --dp, --enable-dp-attention, and "
+                        "--attention-context-parallel-size so the effective "
+                        f"attention TP size is {expected_attn_tp_size}."
+                    )
+
+            # enable_multi_layer_eagle for EAGLE moved to the override registry
+            # (arg_groups/overrides.py: _mimo_v2_overrides).
+
+            # MiMoV2 hierarchical cache runs on the unified radix tree, which
+            # is the default tree cache now. MiMoV2 has head_dim != v_head_dim,
+            # so the host KV pool uses asymmetric K/V allocation. Both
+            # kernel/page_first and direct/page_first_direct have split K/V
+            # transfer paths.
+        elif (
+            "Step3p5ForCausalLM" in model_arch
+            or "Step3p7ForConditionalGeneration" in model_arch
+        ):
+            # Attention backend selection + EAGLE multi-layer +
+            # hierarchical-cache SWA writes moved to the override registry
+            # (arg_groups/overrides.py: _step3p_overrides).
+            pass
+        elif (
+            model_arch in ("Llama4ForConditionalGeneration", "Llama4ForCausalLM")
+            and cfg.device != "cpu"
+        ):
+            # Attention backend auto-select moved to the override registry
+            # (arg_groups/overrides.py: _llama4_overrides).
+            attention_backend = resolved_view(self).attention_backend
+            assert attention_backend in {
+                "fa3",
+                "aiter",
+                "triton",
+                "ascend",
+                "trtllm_mha",
+                "intel_xpu",
+            }, f"fa3, aiter, triton, ascend, trtllm_mha or intel_xpu is required for Llama4 model but got {attention_backend}"
+            # The moe_runner_backend selection moved to the override registry
+            # (arg_groups/overrides.py: _llama4_overrides).
+        # Gemma2/Gemma3 (disable_hybrid_swa_memory) moved to the override registry
+        # (arg_groups/overrides.py: _gemma2_gemma3_overrides).
+        elif model_arch in (
+            "Gemma4ForConditionalGeneration",
+            "Gemma4ForCausalLM",
+            "Gemma4UnifiedForConditionalGeneration",
+        ):
+            # Default attention backend selection moved to the override registry
+            # (arg_groups/overrides.py: _gemma4_overrides).
+            prefill_backend, decode_backend = self._resolved_attention_backends()
+            accepted_backends = (
+                "trtllm_mha",
+                "triton",
+                "ascend",
+                "intel_xpu",
+                "intel_amx",
+            )
+            assert (
+                prefill_backend in accepted_backends
+                and decode_backend in accepted_backends
+            ), (
+                "Gemma4 only supports trtllm_mha, triton, ascend, intel_xpu, or intel_amx "
+                f"attention backend, got prefill={prefill_backend}, decode={decode_backend}"
+            )
+
+            # The quantization/moe_runner_backend resolution moved to the override
+            # registry (arg_groups/overrides.py: _gemma4_overrides).
+        elif model_arch == "MossVLForConditionalGeneration":
+            # The prefill attention backend default + validation moved to the
+            # override registry (arg_groups/overrides.py: _moss_vl_overrides).
+            pass
+        elif model_arch in ["Exaone4ForCausalLM", "ExaoneMoEForCausalLM"]:
+            if hf_config.sliding_window_pattern is not None:
+                # disable_hybrid_swa_memory moved to the override registry
+                # (arg_groups/overrides.py: _exaone_overrides).
+                # https://docs.sglang.ai/advanced_features/attention_backend.html
+                accepted_backends = ["fa3", "triton", "trtllm_mha"]
+                attention_backend = resolved_view(self).attention_backend
+                assert (
+                    attention_backend in accepted_backends
+                ), f"One of the attention backends in {accepted_backends} is required for {model_arch}, but got {attention_backend}"
+        elif model_arch in ["Olmo2ForCausalLM"]:
+            # disable_hybrid_swa_memory + attention backend selection moved to
+            # the override registry (arg_groups/overrides.py: _olmo2_overrides).
+
+            # Flashinfer appears to degrade performance when sliding window attention
+            # is used for the Olmo2 architecture. Olmo2 does not use sliding window attention
+            # but Olmo3 does.
+            attention_backend = resolved_view(self).attention_backend
+            assert (
+                attention_backend != "flashinfer"
+            ), "FlashInfer backend can significantly degrade the performance of Olmo3 models."
+
+            logger.info(
+                f"Using {attention_backend} as attention backend for {model_arch}."
+            )
+        elif model_arch in [
+            "Qwen3MoeForCausalLM",
+            "Qwen3VLMoeForConditionalGeneration",
+            "Qwen3NextForCausalLM",
+            "Qwen3_5MoeForConditionalGeneration",
+            "InternS2PreviewForConditionalGeneration",
+            "Qwen3_5ForConditionalGeneration",
+        ]:
+            # The quantization/moe_runner_backend resolution moved to the
+            # override registry (arg_groups/overrides.py:
+            # _qwen3_moe_family_overrides); the hybrid sub-family's attention
+            # backend + page size defaults to _qwen3_5_hybrid_overrides.
+            pass
+
+        elif model_arch in ["Glm4MoeForCausalLM"]:
+            # The quantization/moe_runner_backend/enable_tf32_matmul resolution
+            # moved to the override registry (arg_groups/overrides.py:
+            # _glm4_moe_overrides).
+            pass
+
+        elif model_arch in ["Lfm2ForCausalLM", "Lfm2MoeForCausalLM"]:
+            # Attention backend selection moved to the override registry
+            # (arg_groups/overrides.py: _lfm2_overrides).
+            assert resolved_view(self).attention_backend != "triton", (
+                f"{model_arch} does not support triton attention backend, "
+                "as the first layer might not be an attention layer"
+            )
+
+        # MiniMaxM2ForCausalLM (enable_tf32_matmul) moved to the override registry
+        # (arg_groups/overrides.py: _minimax_m2_overrides).
+
+        # Qwen3VL aiter unified-attention page_size moved to the override registry
+        # (arg_groups/overrides.py: _qwen3vl_overrides).
+
+        # Hybrid-mamba radix cache handling for the per-arch branch call sites
+        # dissolved above: the resolution pass self-guards on the arch union
+        # (and the Granite layer_types probe), so one call covers them all.
+        # Hybrid-spec archs already resolved at the pre-dispatch call above;
+        # for them this re-invocation is an idempotent no-op plus validation.
+        # Kept ahead of the sparse-head pass: the legacy per-branch calls
+        # resolved before that tail write of disable_overlap_schedule.
+        self._handle_mamba_radix_cache(model_arch=model_arch)
+
+        from sglang.srt.arg_groups.overrides import (
+            _sparse_head_overlap_disable,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _sparse_head_overlap_disable)
+
+        # The FlashInfer AllReduce Fusion auto-enable and the enforce-disable
+        # terminal moved to the resolution pipeline (arg_groups/overrides.py:
+        # _flashinfer_allreduce_fusion_auto_enable /
+        # _enforce_disable_allreduce_fusion), invoked here at their legacy
+        # slots.
+        from sglang.srt.arg_groups.overrides import (
+            _enforce_disable_allreduce_fusion,
+            _flashinfer_allreduce_fusion_auto_enable,
+        )
+
+        run_post_process_pass(self, _flashinfer_allreduce_fusion_auto_enable)
+        run_post_process_pass(self, _enforce_disable_allreduce_fusion)
+
+    def _support_mamba_cache_extra_buffer(self, model_arch: str):
+        from sglang.srt.arg_groups.overrides import supports_mamba_cache_extra_buffer
+
+        return supports_mamba_cache_extra_buffer(self, model_arch)
+
+    def _validate_mamba_no_buffer(self, view, model_arch: str):
+        assert view.page_size in (1, None), "no_buffer only supports page_size=1."
+        assert (
+            view.disable_overlap_schedule
+        ), "no_buffer do not support overlap schedule. Try to set disable_overlap_schedule=True."
+        assert (
+            view.attention_backend != "trtllm_mha"
+        ), "no_buffer do not support trtllm_mha attention backend."
+
+    def _validate_mamba_extra_buffer(self, view, model_arch: str):
+        from sglang.srt.arg_groups.overrides import supports_mamba_cache_extra_buffer
+
+        assert supports_mamba_cache_extra_buffer(
+            view, model_arch
+        ), f"extra_buffer is not supported for {model_arch}; use no_buffer."
+        assert (
+            is_cuda() or is_musa() or is_npu() or is_hip() or is_xpu()
+        ), "extra_buffer needs CUDA/MUSA/NPU/ROCm/XPU (FLA)."
+        if view.mamba_radix_cache_strategy == "extra_buffer_lazy":
+            # The PD-disagg decode pool is not wired for lazy slots.
+            assert view.disaggregation_mode == "null", (
+                "extra_buffer_lazy unsupported under PD disaggregation; use "
+                "--mamba-radix-cache-strategy extra_buffer."
+            )
+            # eagle/ngram/dspark/dflash all verify through
+            # prepare_mamba_track_for_verify (lazy plan wired); dflash gained
+            # the hook in DFlashVerifyInput.prepare_for_verify.
+        if view.speculative_num_draft_tokens is not None:
+            assert view.mamba_track_interval >= view.speculative_num_draft_tokens
+        if view.page_size is not None:
+            assert view.mamba_track_interval % view.page_size == 0
+            assert self.mamba_cache_chunk_size is not None
+
+            if (
+                view.chunked_prefill_size is not None
+                and 0 < view.chunked_prefill_size < self.mamba_cache_chunk_size
+            ):
+                logger.warning(
+                    "Mamba radix extra-buffer is enabled with chunked_prefill_size=%s "
+                    "smaller than mamba_cache_chunk_size=%s. This can make "
+                    "mamba_track_mask false for unfinished chunked-prefill handoff "
+                    "and skip Mamba state checkpoints.",
+                    view.chunked_prefill_size,
+                    self.mamba_cache_chunk_size,
+                )
+
+    def _handle_mamba_radix_cache(self, model_arch: str):
+        # Resolution moved to the resolution pipeline (arg_groups/overrides.py:
+        # _mamba_radix_cache_resolution), invoked here at each legacy call
+        # slot; this handler keeps the validation.
+        from sglang.srt.arg_groups.overrides import (
+            _mamba_radix_cache_resolution,
+            mamba_extra_buffer_of,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _mamba_radix_cache_resolution)
+        view = resolved_view(self)
+        if not view.uses_mamba_radix_cache:
+            return
+
+        if mamba_extra_buffer_of(view):
+            self._validate_mamba_extra_buffer(view, model_arch)
+        else:
+            self._validate_mamba_no_buffer(view, model_arch)
+
+    def _handle_sampling_backend(self):
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _sampling_backend_default), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _sampling_backend_default,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _sampling_backend_default)
+
+    def _get_default_attn_backend(self, use_mla_backend: bool, model_config):
+        """
+        Auto select the fastest attention backend.
+
+        1. Models with MHA Architecture (e.g: Llama, QWen)
+            1.1 We will turn on FA3 on hopper unless user use spec decode with topk > 1 or page_size > 1.
+            1.2 Use trtllm_mha for SM100/SM103 (Blackwell B200/GB200/B300) excluding spec with topk > 1.
+               Note: trtllm_mha does not support SM120, which will fall back to flashinfer.
+            1.3 In other cases, we will use flashinfer if available, otherwise use triton.
+        2. Models with MLA Architecture and using FA3
+            2.1 We will use FA3 backend on hopper.
+            2.2 We will use Flashinfer backend on blackwell.
+            2.3 Otherwise, we will use triton backend.
+        """
+        cfg = resolving_view(self)
+        # OOT platforms provide their own default attention backend.
+        if current_platform.is_out_of_tree():
+            return current_platform.get_default_attention_backend()
+
+        # Whisper requires flashinfer for cross-attention CUDA graph support.
+        if "WhisperForConditionalGeneration" in (
+            model_config.hf_config.architectures or []
+        ):
+            return "flashinfer"
+
+        if not use_mla_backend:
+            # MHA architecture
+
+            if is_hopper_with_cuda_12_3() and is_no_spec_infer_or_topk_one(
+                resolved_view(self)
+            ):
+                # Note: flashinfer 0.6.1 caused performance regression on Hopper attention kernel
+                # Before the kernel is fixed, we choose fa3 as the default backend on Hopper MHA
+                # ref: https://github.com/sgl-project/sglang/issues/17411
+                return "fa3"
+            elif (
+                is_sm100_supported()
+                and is_no_spec_infer_or_topk_one(resolved_view(self))
+                and (
+                    cfg.speculative_algorithm is None
+                    or cfg.speculative_eagle_topk is not None
+                )
+            ):
+                # trtllm_mha requires equal K/V row widths; fa4 carries
+                # v_head_dim through.
+                if model_config.has_asymmetric_kv:
+                    return "fa4"
+                return "trtllm_mha"
+            elif is_hip():
+                return "aiter"
+            elif is_mps():
+                return "torch_native"
+            else:
+                # FlashInfer does not support attention sinks.
+                if is_flashinfer_available() and not model_config.has_attention_sinks:
+                    return "flashinfer"
+                return "triton"
+        else:
+            # MLA architecture
+            if is_hopper_with_cuda_12_3():
+                return "fa3"
+            elif is_sm100_supported():
+                return "flashinfer"
+            elif is_hip():
+                head_num = model_config.get_num_kv_heads(self.tp_size)
+                # TODO current aiter only support head number 16 or 128 head number
+                if head_num == 128 or head_num == 16:
+                    return "aiter"
+                else:
+                    return "triton"
+            elif is_mps():
+                return "torch_native"
+            else:
+                return "triton"
+
+    def _handle_attention_backend_compatibility(self):
+        cfg = resolving_view(self)
+        model_config = self.get_model_config()
+
+        # The attention_backend write clusters of this handler moved to the
+        # resolution pipeline (arg_groups/overrides.py), each invoked below at
+        # its legacy slot; the interleaved non-attention adjustments stay.
+        from sglang.srt.arg_groups.overrides import (
+            _attention_backend_default,
+            _attention_backend_dual_chunk,
+            _attention_backend_fa3_fp8_fallback,
+            _attention_backend_platform_fallbacks,
+            _fa4_page_constraint,
+            _intel_xpu_page_constraint,
+            _mla_backend_page_constraints,
+            run_post_process_pass,
+        )
+
+        # Split-backend override + default fill.
+        run_post_process_pass(self, _attention_backend_default)
+
+        # Torch native and flex attention backends
+        attention_backend = resolved_view(self).attention_backend
+        if attention_backend == "torch_native":
+            logger.warning(
+                "Cuda graph is disabled because of using torch native attention backend"
+            )
+            cfg.cuda_graph_config.decode.backend = Backend.DISABLED
+            cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+
+        if attention_backend == "flex_attention":
+            logger.warning(
+                "Cuda graph is disabled because of using torch Flex Attention backend"
+            )
+            cfg.cuda_graph_config.decode.backend = Backend.DISABLED
+            cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+            assert (
+                cfg.speculative_algorithm is None
+            ), "Speculative decoding is currently not supported with Flex Attention backend"
+
+        # Whisper's encoder token padding conflicts with prefix caching.
+        # Only disable for Whisper; other encoder-decoder models (e.g., mllama) use radix cache.
+        if (
+            model_config.is_encoder_decoder
+            and not cfg.disable_radix_cache
+            and "WhisperForConditionalGeneration"
+            in (model_config.hf_config.architectures or [])
+        ):
+            logger.info("Radix cache is disabled for Whisper")
+            self._declare(
+                "_handle_attention_backend_compatibility",
+                disable_radix_cache=True,
+            )
+
+        # Major NVIDIA platforms backends: the page-size snaps of this family
+        # moved to the resolution pipeline (arg_groups/overrides.py:
+        # _mla_backend_page_constraints); the raises and the cutedsl prefill
+        # fallback stay below.
+        run_post_process_pass(self, _mla_backend_page_constraints)
+
+        # The TRT-LLM / tokenspeed MLA kv-dtype validations moved to the
+        # resolution pipeline (arg_groups/overrides.py:
+        # _mla_kv_cache_dtype_checks), invoked here at their legacy slot.
+        from sglang.srt.arg_groups.overrides import _mla_kv_cache_dtype_checks
+
+        run_post_process_pass(self, _mla_kv_cache_dtype_checks)
+
+        # The CuteDSL MLA validation + prefill fill moved to the resolution
+        # pipeline (arg_groups/overrides.py: _cutedsl_prefill_backend_fill),
+        # invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import _cutedsl_prefill_backend_fill
+
+        run_post_process_pass(self, _cutedsl_prefill_backend_fill)
+
+        prefill_backend, decode_backend = self._resolved_attention_backends()
+        if "trtllm_mha" in (prefill_backend, decode_backend):
+            if prefill_backend == "trtllm_mha" and not (
+                is_sm90_supported() or is_sm100_supported() or is_sm120_supported()
+            ):
+                raise ValueError(
+                    "TRTLLM MHA backend for prefill requires Hopper (SM90), Blackwell (SM100), or SM120 GPUs. "
+                    "Please use a different prefill backend."
+                )
+            if (
+                prefill_backend == "trtllm_mha"
+                and is_sm120_supported()
+                and (
+                    cfg.kv_cache_dtype == "fp8_e4m3"
+                    or (
+                        envs.SGLANG_SKIP_SOFTMAX_PREFILL_THRESHOLD_SCALE_FACTOR.get()
+                        or 0.0
+                    )
+                    > 0
+                )
+            ):
+                raise ValueError(
+                    "TRTLLM FMHAv2 prefill on SM120 does not support "
+                    "fp8_e4m3 KV cache or skip-softmax."
+                )
+            if decode_backend == "trtllm_mha" and not (
+                is_sm90_supported() or is_sm100_supported() or is_sm120_supported()
+            ):
+                raise ValueError(
+                    "TRTLLM MHA backend for decode is only supported on Hopper (SM90), Blackwell (SM100) and (SM120) GPUs. Please use a different decode backend."
+                )
+            if (
+                prefill_backend == "trtllm_mha"
+                and not is_sm100_supported()
+                and (cfg.enable_prefill_context_parallel or cfg.attn_cp_size > 1)
+            ):
+                raise ValueError(
+                    "Prefill context parallelism with the TRTLLM MHA prefill backend "
+                    "requires SM100 (trtllm-gen context kernel): the SM90/SM120 "
+                    "fmha_v2 prefill path does not implement CP shard masking."
+                )
+
+        run_post_process_pass(self, _attention_backend_fa3_fp8_fallback)
+
+        run_post_process_pass(self, _fa4_page_constraint)
+
+        # AMD platforms backends
+        if resolved_view(self).attention_backend == "aiter":
+            if model_config.context_len > 8192:
+                self._declare(
+                    "_handle_attention_backend_compatibility",
+                    mem_fraction_static=cfg.mem_fraction_static * 0.85,
+                )
+
+        # Other platforms backends
+        run_post_process_pass(self, _attention_backend_platform_fallbacks)
+
+        prefill_backend, decode_backend = self._resolved_attention_backends()
+        if self.use_mla_backend() and prefill_backend == "intel_xpu":
+            raise ValueError(
+                "intel_xpu backend is only supported on decode for MLA models, please set --decode-attention-backend to intel_xpu and do not set --attention-backend or --prefill-attention-backend to intel_xpu for prefill instead use triton."
+            )
+
+        run_post_process_pass(self, _intel_xpu_page_constraint)
+
+        # Dual chunk flash attention backend
+        run_post_process_pass(self, _attention_backend_dual_chunk)
+        if resolved_view(self).attention_backend == "dual_chunk_flash_attn":
+            logger.warning(
+                "Mixed chunk and radix cache are disabled when using dual-chunk flash attention backend"
+            )
+            self._declare(
+                "_handle_attention_backend_compatibility",
+                enable_mixed_chunk=False,
+            )
+            self._declare(
+                "_handle_attention_backend_compatibility",
+                disable_radix_cache=True,
+            )
+
+    def _handle_mxfp8_kv_cache_compatibility(self):
+        """MXFP8 KV cache uses operands available only on SM100+ (Blackwell)."""
+        cfg = resolving_view(self)
+        if cfg.kv_cache_dtype != "mxfp8":
+            return
+        if not is_blackwell_supported():
+            raise ValueError(
+                "--kv-cache-dtype mxfp8 requires an SM100+ (Blackwell) GPU for the "
+                "block-scaled operands used by the FA4 MXFP8 attention path."
+            )
+
+    def _handle_kv4_compatibility(self):
+        """Check FP4 KV cache compatibility with the attention backend"""
+        cfg = resolving_view(self)
+
+        if cfg.kv_cache_dtype not in ("nvfp4", "fp4_mx_block16"):
+            return
+
+        use_mla_backend = self.use_mla_backend()
+        prefill_backend, decode_backend = self._resolved_attention_backends()
+        attention_backend = resolved_view(self).attention_backend
+
+        if is_cuda():
+            if cfg.kv_cache_dtype == "nvfp4" and not (
+                is_sm100_supported() or is_sm120_supported()
+            ):
+                raise RuntimeError(
+                    "--kv-cache-dtype=nvfp4 requires Blackwell SM100 or SM120. "
+                    "Use --kv-cache-dtype=fp4_mx_block16 for the block-size-16 FP4 recipe."
+                )
+            if (
+                prefill_backend != decode_backend and prefill_backend != "fa4"
+            ):  # Take care of prefill=fa4 later
+                logger.warning(
+                    f"Attention: Using KV4 with PREFILL = {prefill_backend} "
+                    f"and DECODE = {decode_backend}. "
+                    f"Compatibility issues are unlikely, but may occur in rare edge cases."
+                )
+            else:
+                if prefill_backend == "fa4":
+                    if use_mla_backend:  # FA4 + MLA
+                        KV4_FA4_MLA_BACKEND_CHOICES = [
+                            "cutlass_mla",
+                            "flashinfer",
+                            "trtllm_mla",
+                        ]
+                        assert decode_backend in KV4_FA4_MLA_BACKEND_CHOICES, (
+                            f"KV4 FA4 MLA expects decode_attention_backend to be one of "
+                            f"{KV4_FA4_MLA_BACKEND_CHOICES}, but got {decode_backend}"
+                        )
+                    else:  # FA4 + MHA
+                        KV4_FA4_MHA_BACKEND_CHOICES = [
+                            "triton",
+                            "torch_native",
+                            "flex_attention",
+                        ]
+                        assert decode_backend in KV4_FA4_MHA_BACKEND_CHOICES, (
+                            f"KV4 FA4 MHA expects decode_attention_backend to be one of "
+                            f"{KV4_FA4_MHA_BACKEND_CHOICES}, but got {decode_backend}"
+                        )
+                else:
+                    if use_mla_backend:  # !FA4 + MLA
+                        KV4_ATTENTION_MLA_BACKEND_CHOICES = [
+                            "cutlass_mla",
+                            "flashinfer",
+                            "trtllm_mla",
+                        ]
+                        assert attention_backend in KV4_ATTENTION_MLA_BACKEND_CHOICES, (
+                            f"KV4 MLA expects attention_backend to be one of "
+                            f"{KV4_ATTENTION_MLA_BACKEND_CHOICES}, but got {attention_backend}"
+                        )
+                    else:  # !FA4 + MHA
+                        KV4_ATTENTION_MHA_BACKEND_CHOICES = [
+                            "triton",
+                            "torch_native",
+                            "flex_attention",
+                            "trtllm_mha",
+                        ]
+                        assert attention_backend in KV4_ATTENTION_MHA_BACKEND_CHOICES, (
+                            f"KV4 MHA expects attention_backend to be one of "
+                            f"{KV4_ATTENTION_MHA_BACKEND_CHOICES}, but got {attention_backend}"
+                        )
+        else:
+            raise RuntimeError("KV4 is not tested on non-CUDA platforms.")
+
+    def _handle_page_size(self):
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _page_size_default), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _page_size_default,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _page_size_default)
+
+    def _handle_amd_specifics(self):
+        if is_hip():
+            self._declare("_handle_amd_specifics", triton_attention_num_kv_splits=16)
+
+    def _handle_nccl_pre_warm(self):
+        # pre_warm_nccl is only used with CUDA or HIP hardware or NPU hardware
+        cfg = resolving_view(self)
+        if cfg.pre_warm_nccl and not (is_cuda() or is_hip() or is_npu()):
+            logger.warning(
+                "pre_warm_nccl is only applicable for CUDA or HIP hardware or NPU hardware. "
+                "Ignoring pre_warm_nccl setting on current hardware."
+            )
+            self._declare("_handle_nccl_pre_warm", pre_warm_nccl=False)
+
+    def _handle_grammar_backend(self):
+        cfg = resolving_view(self)
+        if cfg.grammar_backend is None:
+            self._declare("_handle_grammar_backend", grammar_backend="xgrammar")
+
+    def _handle_mamba_backend(self):
+        cfg = resolving_view(self)
+        if cfg.mamba_cache_philox_rounds < 0:
+            raise ValueError("--mamba-cache-philox-rounds must be non-negative.")
+
+        if cfg.mamba_max_states_per_path == 0 or cfg.mamba_max_states_per_path < -1:
+            raise ValueError(
+                "--mamba-max-states-per-path must be -1 (unlimited) or a positive "
+                f"integer, got {cfg.mamba_max_states_per_path}."
+            )
+
+        if cfg.enable_mamba_cache_stochastic_rounding:
+            if cfg.mamba_ssm_dtype != "float16":
+                raise ValueError(
+                    "Stochastic rounding for the Mamba SSM cache requires "
+                    f"--mamba-ssm-dtype float16, got {cfg.mamba_ssm_dtype!r}. "
+                    "Run with --mamba-ssm-dtype float16 or disable "
+                    "--enable-mamba-cache-stochastic-rounding."
+                )
+            if not is_cuda():
+                raise ValueError(
+                    "Stochastic rounding for the Mamba SSM cache is only "
+                    "supported on NVIDIA CUDA platforms. Disable "
+                    "--enable-mamba-cache-stochastic-rounding on this platform."
+                )
+            if cfg.mamba_backend == "triton" and not is_sm100_supported():
+                raise ValueError(
+                    "Stochastic rounding for the Mamba SSM cache with "
+                    "--mamba-backend triton requires SM100 with CUDA >= 12.8 "
+                    "because it uses the cvt.rs.f16x2.f32 PTX instruction. On "
+                    "H100/SM90, run with --mamba-backend flashinfer "
+                    "--mamba-ssm-dtype float16, or disable "
+                    "--enable-mamba-cache-stochastic-rounding."
+                )
+
+        if cfg.mamba_backend == "flashinfer":
+            flashinfer_error = (
+                "FlashInfer mamba module not available, please check the "
+                "FlashInfer installation."
+            )
+            if cfg.enable_mamba_cache_stochastic_rounding:
+                flashinfer_error += (
+                    " Stochastic rounding with --mamba-backend flashinfer "
+                    "requires FlashInfer Mamba and --mamba-ssm-dtype float16."
+                )
+            if is_flashinfer_available():
+                try:
+                    import flashinfer.mamba  # noqa: F401
+
+                    logger.info("Successfully imported FlashInfer mamba module")
+                except (ImportError, AttributeError):
+                    raise ValueError(flashinfer_error)
+            else:
+                raise ValueError(flashinfer_error)
+
+    def _handle_int8_mamba_checkpoint(self):
+        # The int8 mamba checkpoint pool is only wired into the built-in
+        # MambaRadixCache. The host-offload path (enabled by
+        # --enable-hierarchical-cache) and custom radix-cache backends are NOT
+        # int8-aware: they would read int8 checkpoint slots as bf16 active slots
+        # (wrong pool / out-of-range). Reject the combination up front rather than
+        # silently corrupting state.
+        cfg = resolving_view(self)
+        if not cfg.enable_int8_mamba_checkpoint:
+            return
+        if cfg.enable_hierarchical_cache:
+            raise ValueError(
+                "--enable-int8-mamba-checkpoint is not supported together with "
+                "--enable-hierarchical-cache: the host-offload path "
+                "is not int8-aware. Disable one of them."
+            )
+        if cfg.radix_cache_backend is not None:
+            raise ValueError(
+                "--enable-int8-mamba-checkpoint only supports the built-in mamba "
+                f"radix cache; --radix-cache-backend={cfg.radix_cache_backend!r} "
+                "is not int8-aware. Omit --radix-cache-backend."
+            )
+
+    def _handle_linear_attn_backend(self):
+        cfg = resolving_view(self)
+        import torch
+
+        # SM100+: default to FlashInfer GDN decode (and MTP verify, via pool API)
+        # when the user hasn't explicitly chosen a decode backend and
+        # mamba-ssm-dtype is bf16 (required by FlashInfer GDN on SM100+).
+        # Fixed in FlashInfer v0.6.7: flashinfer-ai/flashinfer#2810
+        if (
+            cfg.linear_attn_decode_backend is None
+            and cfg.linear_attn_backend != "helion"
+            and is_sm100_supported()
+            and cfg.mamba_ssm_dtype == "bfloat16"
+            # Stage 4: flashinfer's recurrent_kda compiles the state slot stride
+            # as a free int64, so it reads the page-major/unified envelope-strided
+            # state correctly — the unified-memory skip is no longer needed (the
+            # page-major gate now allows flashinfer for linear-attn decode).
+        ):
+            self._declare(
+                "_handle_linear_attn_backend",
+                linear_attn_decode_backend="flashinfer",
+            )
+            logger.info(
+                "SM100+ detected with mamba-ssm-dtype=bfloat16, "
+                "defaulting --linear-attn-decode-backend to flashinfer."
+            )
+
+        # SM100+ FlashInfer GDN decode requires bf16 state; SM90 uses float32.
+        decode = cfg.linear_attn_decode_backend or cfg.linear_attn_backend
+
+        # FlashKDA is a prefill-only KDA kernel (no decode kernel) but shares the
+        # backend choice list, so guard it from being selected for decode: error
+        # on an explicit --linear-attn-decode-backend flashkda, and fall back to
+        # triton decode when it was only inherited from base=flashkda (prefill
+        # keeps FlashKDA).
+        if decode == "flashkda":
+            if cfg.linear_attn_decode_backend == "flashkda":
+                raise ValueError(
+                    "--linear-attn-decode-backend flashkda is not supported: "
+                    "FlashKDA is prefill-only. Use "
+                    "--linear-attn-prefill-backend flashkda (decode stays on triton)."
+                )
+            self._declare(
+                "_handle_linear_attn_backend",
+                linear_attn_decode_backend="triton",
+            )
+            decode = "triton"
+            logger.info(
+                "FlashKDA is prefill-only; using triton for KDA decode "
+                "(FlashKDA stays on prefill)."
+            )
+
+        if (
+            decode == "flashinfer"
+            and cfg.mamba_ssm_dtype != "bfloat16"
+            and is_cuda()
+            and torch.cuda.get_device_capability()[0] >= 10
+        ):
+            raise ValueError(
+                "--linear-attn-decode-backend flashinfer on SM100+ requires "
+                "--mamba-ssm-dtype bfloat16, "
+                f"got {cfg.mamba_ssm_dtype!r}"
+            )
+
+        verify = cfg.linear_attn_verify_backend
+        if verify is None and decode == "flashinfer":
+            verify = "flashinfer"
+        if (
+            verify == "flashinfer"
+            and cfg.mamba_ssm_dtype != "bfloat16"
+            and is_cuda()
+            and torch.cuda.get_device_capability()[0] >= 10
+        ):
+            raise ValueError(
+                "--linear-attn-verify-backend flashinfer on SM100+ requires "
+                "--mamba-ssm-dtype bfloat16, "
+                f"got {cfg.mamba_ssm_dtype!r}"
+            )
+
+        # SM100+ FlashInfer GDN prefill requires CUDA 13+ (CuTe DSL kernel)
+        # for correctness and best performance.
+        prefill = cfg.linear_attn_prefill_backend or cfg.linear_attn_backend
+        cuda_version = torch.version.cuda
+        cuda_major = int(cuda_version.split(".")[0]) if cuda_version is not None else 0
+        if (
+            prefill == "flashinfer"
+            and is_cuda()
+            and torch.cuda.get_device_capability()[0] >= 10
+            and cuda_major < 13
+        ):
+            raise ValueError(
+                "--linear-attn-prefill-backend flashinfer on SM100+ requires CUDA 13+, "
+                f"got CUDA {cuda_version or 'unknown'}"
+            )
+
+        # ReplaySSM buffered decode guards. Runs on Triton, or Helion for KDA.
+        # cuda-graph is supported (slice 1b: CUDA-graph-safe static
+        # write-cursor buffers). The RADIX prefix cache is now supported (slice
+        # 2b: the decode kernel force-flushes the ring into temporal[slot] on
+        # the radix track boundary `seq_lens % mamba_track_interval == 0`, and
+        # the COW copy-into-slot path resets the ring cursor) -- so the
+        # --disable-radix-cache requirement is dropped.
+        #
+        # Slice 2b only wires the no_buffer mamba scheduler strategy (the
+        # default). The extra_buffer strategy donates the track snapshot via
+        # `donate_mamba_ping_pong_slot` with a separate ping-pong slot swap that
+        # does NOT route through MambaPool.copy_from, so the ReplaySSM ring
+        # cursor of the donated/kept slot would not be reset there. Handling
+        # that donation path is a follow-up; for now require no_buffer.
+        if cfg.enable_linear_replayssm:
+            if decode not in {"triton", "helion"}:
+                raise ValueError(
+                    "--enable-linear-replayssm requires Triton, or Helion for "
+                    "KDA, as the linear-attn decode backend; got "
+                    f"--linear-attn-decode-backend={decode!r}."
+                )
+            from sglang.srt.arg_groups.overrides import (
+                mamba_extra_buffer_of,
+            )
+
+            if mamba_extra_buffer_of(resolved_view(self)):
+                raise ValueError(
+                    "--enable-linear-replayssm requires --mamba-radix-cache-strategy "
+                    "no_buffer (the default); the extra_buffer ping-pong "
+                    "donation path is not yet supported (follow-up). Got "
+                    f"--mamba-radix-cache-strategy={cfg.mamba_radix_cache_strategy!r}."
+                )
+            if cfg.disaggregation_mode != "null":
+                # The disaggregated decode pool (HybridMambaDecodeReqToTokenPool)
+                # is not wired for the ReplaySSM ring, so the flag would silently
+                # no-op there; disagg also runs a different cache/coordination
+                # flow that is not yet validated for ReplaySSM (follow-up).
+                raise ValueError(
+                    "--enable-linear-replayssm is not supported under PD "
+                    "disaggregation yet (follow-up). Got "
+                    f"--disaggregation-mode={cfg.disaggregation_mode!r}."
+                )
+            if cfg.linear_replayssm_cache_len < 1:
+                raise ValueError(
+                    "--linear-replayssm-cache-len must be >= 1, got "
+                    f"{cfg.linear_replayssm_cache_len}."
+                )
+
+        # ReplaySSM spec-verify (Part B of #28511): linear-chain target verify via
+        # fold-every-commit -- the verify stores each draft step's raw inputs into
+        # the per-slot (rawv, rawk, g, beta) window and the commit replays the
+        # accepted prefix into the fp32 checkpoint. The intra-window interaction
+        # uses a strictly-lower causal mask, so it is valid ONLY for a linear
+        # draft chain (speculative_eagle_topk in {None, 1}, i.e. NEXTN / MTP);
+        # EAGLE tree verify (topk > 1) must fall back to the recurrent verify.
+        # GDN sizes the window to the draft maximum; KDA (kda_backend) keeps a
+        # --linear-replayssm-cache-len window and folds via its own fused
+        # verify ring-write + commit_kda_replayssm_after_verify.
+        if cfg.enable_linear_replayssm_spec:
+            if cfg.speculative_eagle_topk not in (None, 1):
+                raise ValueError(
+                    "--enable-linear-replayssm-spec requires a linear draft chain "
+                    "(--speculative-eagle-topk in {None, 1}); the chunked verify "
+                    "kernel uses a strictly-lower causal mask and is invalid for "
+                    "EAGLE tree verify. Got "
+                    f"--speculative-eagle-topk={cfg.speculative_eagle_topk!r}."
+                )
+            if decode not in ("triton", "flashinfer"):
+                raise ValueError(
+                    "--enable-linear-replayssm-spec requires the triton or "
+                    "flashinfer linear-attn decode backend, got "
+                    f"--linear-attn-decode-backend={decode!r}."
+                )
+            from sglang.srt.speculative.ragged_verify import (
+                RaggedVerifyMode,
+                read_ragged_verify_mode,
+            )
+
+            ragged_mode = read_ragged_verify_mode()
+            if ragged_mode is not RaggedVerifyMode.STATIC:
+                # Ragged ring-writes need the KDA fold-every-commit family
+                # (DSPARK/DFLASH) + the triton verify kernel (nv_cutedsl falls
+                # back to it for ragged layouts). The GDN ring-write kernels do
+                # not take the ragged layout and the flashinfer verify kernel
+                # never writes the ring -> a stale ring would be folded; keep
+                # refusing those combinations.
+                _algo = (cfg.speculative_algorithm or "").upper()
+                verify = cfg.linear_attn_verify_backend
+                if _algo not in ("DSPARK", "DFLASH") or verify not in (
+                    "triton",
+                    "nv_cutedsl",
+                ):
+                    raise ValueError(
+                        "--enable-linear-replayssm-spec with "
+                        f"SGLANG_RAGGED_VERIFY_MODE={ragged_mode.value} requires the "
+                        "KDA fold-every-commit family (DSPARK/DFLASH) and a "
+                        "ring-writing verify kernel (--linear-attn-verify-backend "
+                        "triton or nv_cutedsl); got "
+                        f"algorithm={cfg.speculative_algorithm!r}, "
+                        f"verify={verify!r}. Use SGLANG_RAGGED_VERIFY_MODE=static."
+                    )
+            if cfg.disaggregation_mode == "prefill":
+                raise ValueError(
+                    "--enable-linear-replayssm-spec is not supported on a PD "
+                    "prefill server: the ring is spec-verify-only scratch and "
+                    "the prefill server never runs spec verify."
+                )
+            if cfg.enable_linear_replayssm:
+                raise ValueError(
+                    "--enable-linear-replayssm-spec and --enable-linear-replayssm are "
+                    "mutually exclusive: they share the ring storage but drive it "
+                    "with incompatible cursor protocols (per-decode-forward vs "
+                    "per-verify-commit advance)."
+                )
+            if cfg.mamba_ssm_dtype is None:
+                logger.info(
+                    "--enable-linear-replayssm-spec: setting --mamba-ssm-dtype "
+                    "float32 (the closed-loop exact fold keeps the SSM checkpoint "
+                    "bit-identical to the recurrent baseline)."
+                )
+                self._declare(
+                    "_handle_linear_attn_backend",
+                    mamba_ssm_dtype="float32",
+                )
+            elif cfg.mamba_ssm_dtype != "float32":
+                logger.warning(
+                    "--enable-linear-replayssm-spec with --mamba-ssm-dtype=%s: the "
+                    "closed-loop fold re-quantizes the committed state each "
+                    "commit/flush (fp32 keeps it bit-exact to the fp32 recurrent "
+                    "baseline), so it may drift over long sequences. Validate "
+                    "accuracy for your model.",
+                    cfg.mamba_ssm_dtype,
+                )
+
+    def _handle_legacy_cp_arguments(self):
+        cfg = resolving_view(self)
+        legacy_mode_to_strategy = {
+            "in-seq-split": "zigzag",
+            "round-robin-split": "interleave",
+        }
+        strategy_to_legacy_mode = {
+            "zigzag": "in-seq-split",
+            "interleave": "round-robin-split",
+        }
+
+        if (
+            cfg.enable_prefill_context_parallel
+            or cfg.enable_dsa_prefill_context_parallel
+        ):
+            self._declare(
+                "_handle_legacy_cp_arguments",
+                enable_prefill_cp=True,
+            )
+
+        if cfg.enable_prefill_context_parallel and cfg.cp_strategy is None:
+            self._declare(
+                "_handle_legacy_cp_arguments",
+                cp_strategy=legacy_mode_to_strategy[cfg.prefill_cp_mode],
+            )
+        if cfg.enable_dsa_prefill_context_parallel and cfg.cp_strategy is None:
+            self._declare(
+                "_handle_legacy_cp_arguments",
+                cp_strategy=legacy_mode_to_strategy[cfg.dsa_prefill_cp_mode],
+            )
+
+        if (
+            cfg.enable_prefill_context_parallel
+            and cfg.enable_dsa_prefill_context_parallel
+        ):
+            return
+
+        if not cfg.enable_prefill_cp or cfg.cp_strategy is None:
+            return
+
+        mode = strategy_to_legacy_mode[cfg.cp_strategy]
+        use_dsa_legacy_aliases = cfg.enable_dsa_prefill_context_parallel or getattr(
+            self._resolved(), "attention_backend", None
+        ) in ("dsa", "dsv4")
+        if use_dsa_legacy_aliases:
+            self._declare(
+                "_handle_legacy_cp_arguments",
+                enable_dsa_prefill_context_parallel=True,
+            )
+            self._declare(
+                "_handle_legacy_cp_arguments",
+                enable_prefill_context_parallel=False,
+            )
+        else:
+            self._declare(
+                "_handle_legacy_cp_arguments",
+                enable_prefill_context_parallel=True,
+            )
+        self._declare(
+            "_handle_legacy_cp_arguments",
+            dsa_prefill_cp_mode=mode,
+        )
+        self._declare(
+            "_handle_legacy_cp_arguments",
+            prefill_cp_mode=mode,
+        )
+
+    def _handle_context_parallelism(self):
+        cfg = resolving_view(self)
+        if parse_connector_type(cfg.model_path) != ConnectorType.INSTANCE:
+            from sglang.srt.configs.model_config import is_deepseek_dsa
+            from sglang.srt.layers.cp.utils import CP_V2_DEFAULT_MODEL_CLASSES
+
+            model_config = self.get_model_config()
+            hf_config = model_config.hf_config
+            model_arch = hf_config.architectures[0]
+            if model_arch in CP_V2_DEFAULT_MODEL_CLASSES:
+                is_dsa_default_model = is_deepseek_dsa(hf_config)
+                # DSA CP-v2 currently supports only the interleave strategy.
+                enable_default_cp_v2 = not is_dsa_default_model or (
+                    cfg.enable_prefill_cp and cfg.cp_strategy == "interleave"
+                )
+                if enable_default_cp_v2 and not envs.SGLANG_ENABLE_CP_V2.is_set():
+                    envs.SGLANG_ENABLE_CP_V2.set(True)
+
+            if (
+                cfg.enable_prefill_cp
+                and model_arch in ("MiMoV2ForCausalLM", "MiMoV2FlashForCausalLM")
+                and envs.SGLANG_ENABLE_CP_V2.get()
+            ):
+                if cfg.cp_strategy != "zigzag":
+                    raise ValueError(
+                        "MiMo V2 CP-v2 only supports --cp-strategy zigzag."
+                    )
+                if (
+                    model_config.is_multimodal
+                    and not cfg.language_only
+                    and not cfg.language_model_only
+                ):
+                    raise ValueError(
+                        "MiMo V2 CP-v2 only supports text inference; add "
+                        "--language-only."
+                    )
+
+        if cfg.enable_prefill_cp and cfg.cp_strategy is None:
+            raise ValueError(
+                "--cp-strategy must be set when --enable-prefill-cp is enabled."
+            )
+
+        if (
+            cfg.enable_prefill_context_parallel
+            and cfg.enable_dsa_prefill_context_parallel
+        ):
+            raise ValueError(
+                "--enable-prefill-context-parallel and "
+                "--enable-nsa-prefill-context-parallel are mutually "
+                "exclusive. Use --enable-nsa-prefill-context-parallel for "
+                "DeepSeek V3.2 (NSA) models and "
+                "--enable-prefill-context-parallel for MLA-based models "
+                "(DeepSeek V3/R1, Kimi K2.5) or MHA/GQA-based models."
+            )
+
+        view = self._resolved()
+        if view.attn_cp_size > 1:
+            # The tp_size is the world size, not the real tensor parallel size
+            assert (
+                cfg.tp_size % view.attn_cp_size == 0
+            ), "tp_size must be divisible by attn_cp_size"
+            assert (
+                cfg.tp_size % (cfg.dp_size * view.attn_cp_size) == 0
+            ), "tp_size must be divisible by dp_size * attn_cp_size"
+
+            assert (
+                not cfg.enable_aiter_allreduce_fusion
+            ), "Aiter allreduce fusion is not supported with context parallelism"
+
+        if cfg.moe_dp_size > 1:
+            # The tp_size is the world size, not the real tensor parallel size
+            assert (
+                cfg.tp_size % cfg.moe_dp_size == 0
+            ), "tp_size must be divisible by moe_dp_size"
+            assert (
+                view.ep_size * cfg.moe_dp_size <= cfg.tp_size
+            ), "ep_size * moe_dp_size must be less than or equal to tp_size"
+            assert cfg.pp_size == 1, "PP is not supported with context parallelism"
+
+            if view.ep_size > 1:
+                assert (
+                    view.ep_size * cfg.moe_dp_size == cfg.tp_size
+                ), "ep_size * moe_dp_size must be equal to tp_size"
+
+            assert (
+                not cfg.enable_aiter_allreduce_fusion
+            ), "Aiter allreduce fusion is not supported with context parallelism"
+
+        if view.attn_cp_size != cfg.moe_dp_size:
+            assert (
+                cfg.moe_dp_size == 1
+            ), "attn_cp_size != moe_dp_size is only supported when moe_dp_size == 1"
+
+        from sglang.srt.layers.cp.base import init_cp_strategy
+
+        init_cp_strategy(
+            enable_prefill_cp=bool(cfg.enable_prefill_cp),
+            cp_size=cfg.attn_cp_size,
+            cp_strategy=cfg.cp_strategy,
+        )
+
+    def _handle_dwdp(self):
+        cfg = resolving_view(self)
+        if cfg.dwdp_size <= 1:
+            return
+
+        assert (
+            cfg.dwdp_size >= 2
+        ), f"dwdp_size must be >= 2 when enabled, got {cfg.dwdp_size}"
+        assert (
+            cfg.dwdp_size == cfg.tp_size
+        ), f"dwdp_size ({cfg.dwdp_size}) must equal tp_size ({cfg.tp_size})"
+        assert cfg.disaggregation_mode in (
+            "null",
+            "prefill",
+        ), "DWDP requires --disaggregation-mode null or prefill"
+        assert (
+            not cfg.enable_eplb
+        ), "EPLB dynamic migration conflicts with static DWDP partitioning"
+        assert (
+            cfg.speculative_algorithm is None
+        ), "DWDP does not support speculative decoding (MTP/draft workers)"
+        assert cfg.pp_size == 1, "DWDP requires pp_size == 1"
+        assert (
+            not cfg.enable_two_batch_overlap
+        ), "DWDP's prefetch event protocol does not support two-batch overlap"
+
+        if cfg.disaggregation_mode == "null":
+            logger.warning(
+                "DWDP with --disaggregation-mode null: decode steps re-fetch all "
+                "remote expert weights every step, which is slow. DWDP is "
+                "recommended only with --disaggregation-mode prefill."
+            )
+
+        self._declare(
+            "_handle_dwdp",
+            dp_size=cfg.dwdp_size,
+        )
+        self._declare(
+            "_handle_dwdp",
+            enable_dp_attention=True,
+        )
+        self._declare("_handle_dwdp", enable_dp_attention_local_control_broadcast=True)
+        self._declare(
+            "_handle_dwdp",
+            enable_dp_lm_head=True,
+        )
+        self._declare(
+            "_handle_dwdp",
+            moe_dense_tp_size=1,
+        )
+        self._declare(
+            "_handle_dwdp",
+            ep_size=cfg.dwdp_size,
+        )
+        self.moe_ep_size = cfg.dwdp_size
+        self._declare(
+            "_handle_dwdp",
+            moe_dp_size=1,
+        )
+        self._declare(
+            "_handle_dwdp",
+            moe_a2a_backend="none",
+        )
+
+        envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.set(True)
+
+        self._declare(
+            "_handle_dwdp",
+            disable_cuda_graph=True,
+        )
+
+        logger.info(
+            f"DWDP enabled: dwdp_size={cfg.dwdp_size}, "
+            f"auto-forced dp_size={cfg.dp_size}, moe_ep_size={self.moe_ep_size}, "
+            f"moe_dense_tp_size=1, moe_a2a_backend=none, "
+            f"dp_attention_local_control_broadcast=True, "
+            f"enable_dp_lm_head=True, SCHEDULER_SKIP_ALL_GATHER=True, "
+            f"disable_cuda_graph=True"
+        )
+
+    def _handle_data_parallelism(self):
+        # The dp_size==1 resets moved to the resolution pipeline
+        # (arg_groups/overrides.py: _data_parallelism_defaults).
+        cfg = resolving_view(self)
+        from sglang.srt.arg_groups.overrides import (
+            _data_parallelism_defaults,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _data_parallelism_defaults)
+
+        if cfg.mm_enable_dp_encoder:
+            if cfg.tp_size == 1:
+                logger.warning(
+                    "--mm-enable-dp-encoder is enabled with TP=1, so the encoder "
+                    "has no data-parallel work to distribute. Disable it unless "
+                    "you need to validate this configuration."
+                )
+            else:
+                logger.info(
+                    "--mm-enable-dp-encoder is enabled across TP=%d. It replicates "
+                    "the vision encoder and distributes image work across ranks; "
+                    "this is most useful when high-resolution or multi-image ViT "
+                    "prefill is a material part of TTFT. Measure against the default "
+                    "for small-image workloads because replication and aggregation "
+                    "can increase memory use and overhead.",
+                    cfg.tp_size,
+                )
+
+        if self._resolved().enable_dp_attention:
+            self._declare(
+                "_handle_data_parallelism",
+                schedule_conservativeness=cfg.schedule_conservativeness * 0.3,
+            )
+            assert cfg.tp_size % cfg.dp_size == 0
+            original_chunked_prefill_size = cfg.chunked_prefill_size
+            self._declare(
+                "_handle_data_parallelism",
+                chunked_prefill_size=cfg.chunked_prefill_size // cfg.dp_size,
+            )
+            logger.warning(
+                f"DP attention is enabled. chunked prefill size is adjusted "
+                f"from {original_chunked_prefill_size} to {cfg.chunked_prefill_size}."
+            )
+
+            # The prefill CUDA graph max_bs was derived from the pre-DP-division
+            # chunked_prefill_size in _handle_gpu_memory_settings (which runs
+            # before this handler). Re-clamp it (and the captured shape list) to
+            # the per-DP-rank chunked_prefill_size so breakable CUDA graph
+            # capture never exceeds the MoE all-to-all's max_num_tokens budget,
+            # which is also sized from the DP-adjusted chunked_prefill_size.
+            prefill_cfg = cfg.cuda_graph_config.prefill
+            if (
+                prefill_cfg.backend != Backend.DISABLED
+                and prefill_cfg.max_bs is not None
+                and prefill_cfg.max_bs > cfg.chunked_prefill_size
+                and (Phase.PREFILL, "max_bs") not in self._cuda_graph_config_locked
+            ):
+                prefill_cfg.max_bs = cfg.chunked_prefill_size
+                if (Phase.PREFILL, "bs") not in self._cuda_graph_config_locked:
+                    prefill_cfg.bs = self._generate_prefill_cuda_graph_batch_sizes(
+                        prefill_cfg.max_bs
+                    )
+
+        # Resolve the phase-aware TP LM-head default before validating the
+        # resulting DP/TP LM-head configuration.
+        from sglang.srt.arg_groups.overrides import (
+            _dp_lm_head_validation,
+            _tp_lm_head_all_to_all_default,
+        )
+
+        run_post_process_pass(self, _tp_lm_head_all_to_all_default)
+        run_post_process_pass(self, _dp_lm_head_validation)
+
+    def _handle_moe_kernel_config(self):
+        # The quantization-driven runner resolutions moved to the pipeline
+        # (arg_groups/overrides.py: _moe_runner_backend_quant_constraints);
+        # the compatibility asserts and fusion writes stay below.
+        cfg = resolving_view(self)
+        from sglang.srt.arg_groups.overrides import (
+            _moe_runner_backend_quant_constraints,
+            _moe_runner_fusion_disable,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _moe_runner_backend_quant_constraints)
+
+        view = resolved_view(self)
+        if view.moe_runner_backend == "flashinfer_cutlass":
+            assert view.quantization in [
+                "modelopt_fp4",
+                "modelopt_fp8",
+                "modelopt_mixed",
+                None,
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
+            assert view.ep_size in [
+                1,
+                cfg.tp_size,
+            ], "The expert parallel size must be 1 or the same as the tensor parallel size"
+
+        if view.moe_runner_backend == "flashinfer_cutedsl":
+            # modelopt_mixed with non-NVFP4 MoE layers is rejected at load time.
+            assert (
+                view.quantization in ["modelopt_fp4", "modelopt_mixed", "nvfp4_online"]
+                or self.get_model_config().nvfp4_moe_meta is not None
+            ), f"Invalid quantization '{view.quantization}'. \nFlashInfer CuteDSL MOE currently supports only: 'modelopt_fp4', 'modelopt_mixed' (with NVFP4 MoE layers), 'nvfp4_online', or hybrid NVFP4 models."
+            assert view.ep_size in [
+                1,
+                cfg.tp_size,
+            ], "The expert parallel size must be 1 or the same as the tensor parallel size"
+            assert view.moe_a2a_backend in [
+                "none",
+                "deepep",
+                "flashinfer",
+            ], (
+                f"flashinfer_cutedsl supports moe_a2a_backend='none', 'deepep', or 'flashinfer', "
+                f"got '{view.moe_a2a_backend}'."
+            )
+            if view.moe_a2a_backend == "deepep" and (
+                view.quantization == "nvfp4_online"
+                or envs.SGLANG_FLASHINFER_NVFP4_PER_TOKEN_ACTIVATION.get()
+            ):
+                raise ValueError(
+                    "flashinfer_cutedsl per-token NVFP4 activation requires "
+                    "moe_a2a_backend='none' or 'flashinfer'."
+                )
+
+        if view.moe_runner_backend in ["flashinfer_trtllm", "experimental_sgl_trtllm"]:
+            assert view.quantization in [
+                "modelopt_fp4",
+                "nvfp4_online",
+                "fp8",
+                "mxfp8",
+                "modelopt_fp8",
+                "modelopt_mixed",
+                "compressed-tensors",
+                None,
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer TRTLLM MOE supports only: 'modelopt_fp4', 'nvfp4_online', 'fp8', 'modelopt_fp8', 'modelopt_mixed', 'compressed-tensors', or bfloat16 (None)."
+
+        if view.moe_runner_backend == "flashinfer_trtllm_routed":
+            assert view.quantization in [
+                "fp8",
+                "mxfp8",
+                "modelopt_fp4",
+                "modelopt_mixed",
+                "nvfp4_online",
+                None,
+            ], f"Invalid quantization '{view.quantization}'. \nFlashInfer TRTLLM routed MOE supports only: 'fp8', 'mxfp8', 'modelopt_fp4', 'modelopt_mixed', 'nvfp4_online', or bfloat16 (None)."
+
+        # The runner-driven shared-experts fusion disables moved to the
+        # pipeline (arg_groups/overrides.py: _moe_runner_fusion_disable),
+        # invoked here at the legacy write slots.
+        run_post_process_pass(self, _moe_runner_fusion_disable)
+
+        if resolved_view(self).moe_runner_backend == "cutlass" and resolved_view(
+            self
+        ).quantization in [
+            "fp8",
+            "mxfp8",
+        ]:
+            assert (
+                resolved_view(self).ep_size == 1
+            ), "FP8/MXFP8 Cutlass MoE is only supported with ep_size == 1"
+
+    def cutedsl_moe_max_num_tokens(self) -> int:
+        """Largest number of tokens a single forward routes through a CuteDSL
+        MoE layer on one (DP) rank. Single source of truth for both the
+        standard-allgather wrapper buffers and the FlashInfer A2A dispatcher
+        budget. Max over the prefill (max_prefill_tokens), piecewise-prefill
+        capture, and decode/verify bounds; num_tokens_per_req is
+        speculative_num_draft_tokens under speculative decoding, else 1.
+        """
+        cfg = resolving_view(self)
+        if cfg.speculative_algorithm:
+            num_tokens_per_req = cfg.speculative_num_draft_tokens or 1
+        else:
+            num_tokens_per_req = 1
+        prefill_tokens = cfg.max_prefill_tokens
+        cg_config = cfg.cuda_graph_config
+        if cg_config is not None and cg_config.prefill.backend == Backend.TC_PIECEWISE:
+            prefill_tokens = max(prefill_tokens, cg_config.prefill.max_bs or 0)
+        decode_max_bs = (cg_config.decode.max_bs if cg_config is not None else 0) or 0
+        decode_tokens = decode_max_bs * num_tokens_per_req
+        return max(prefill_tokens, decode_tokens)
+
+    def max_prefill_buffer_tokens(self) -> int:
+        """Prefill-buffer ceiling: chunked_prefill_size, except PP dynamic
+        chunking can grow chunks toward max_prefill_tokens and probe at 1.25x."""
+        cfg = resolving_view(self)
+        chunked = (
+            cfg.chunked_prefill_size
+            if cfg.chunked_prefill_size and cfg.chunked_prefill_size > 0
+            else 0
+        )
+        tokens = chunked
+        if cfg.enable_dynamic_chunking and cfg.pp_size > 1 and chunked:
+            tokens = max(tokens, cfg.max_prefill_tokens or 0, math.ceil(chunked * 1.25))
+        return tokens
+
+    def _validate_cutedsl_a2a_token_budget(self):
+        """Fail fast if the FlashInfer A2A dispatcher workspace cannot cover the
+        largest CuteDSL MoE forward. Runs after speculative decoding is resolved
+        so cutedsl_moe_max_num_tokens() sees the final num_tokens_per_req."""
+        cfg = resolving_view(self)
+
+        view = resolved_view(self)
+        if not (
+            view.moe_a2a_backend == "flashinfer"
+            and view.moe_runner_backend == "flashinfer_cutedsl"
+            and cfg.max_prefill_tokens > 0
+            and cfg.disaggregation_mode != "decode"
+        ):
+            return
+        required_tokens = self.cutedsl_moe_max_num_tokens()
+        max_dispatch_tokens_per_rank = (
+            envs.SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get() or 1024
+        )
+        max_cutedsl_tokens = max_dispatch_tokens_per_rank * view.ep_size
+        if max_cutedsl_tokens < required_tokens:
+            required_per_rank = (required_tokens + view.ep_size - 1) // view.ep_size
+            raise ValueError(
+                "FlashInfer MoE A2A with flashinfer_cutedsl requires "
+                "SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK * "
+                "ep_size to cover the largest CuteDSL MoE forward "
+                f"({required_tokens} tokens). Otherwise the FlashInfer "
+                "dispatcher can crash at runtime with "
+                "`ValueError: num_tokens (...) exceeds max_num_tokens (...)`. "
+                "Current values: "
+                f"SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK="
+                f"{max_dispatch_tokens_per_rank}, ep_size={view.ep_size}, "
+                f"capacity={max_cutedsl_tokens}, required={required_tokens}. "
+                f"Set `export "
+                f"SGLANG_FLASHINFER_NUM_MAX_DISPATCH_TOKENS_PER_RANK="
+                f"{required_per_rank}` or lower the relevant limit "
+                f"(e.g. --max-prefill-tokens) to <= {max_cutedsl_tokens}."
+            )
+
+    def _validate_deepep_v2_dispatch_token_budget(self) -> None:
+        """Check the configured prefill and decode-graph buffer bounds."""
+        view = resolved_view(self)
+        if view.moe_a2a_backend != "deepep_v2":
+            return
+
+        capacity = envs.SGLANG_DEEPEP_V2_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get()
+        if view.disaggregation_mode != "decode":
+            prefill_tokens = self.max_prefill_buffer_tokens() or (
+                view.max_prefill_tokens or 0
+            )
+            if prefill_tokens > capacity:
+                raise ValueError(
+                    "DeepEP v2 per-rank prefill budget exceeds "
+                    "SGLANG_DEEPEP_V2_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "
+                    f"required={prefill_tokens}, capacity={capacity}. Raise the "
+                    "environment value or lower --chunked-prefill-size/"
+                    "--max-prefill-tokens."
+                )
+
+        if view.disaggregation_mode == "prefill":
+            return
+        decode_config = getattr(view.cuda_graph_config, "decode", None)
+        if decode_config is None or decode_config.backend == Backend.DISABLED:
+            return
+
+        graph_bs = decode_config.max_bs or 0
+        if view.max_running_requests is not None:
+            attn_dp_size = view.dp_size if view.enable_dp_attention else 1
+            per_rank_pool_bs = max(1, view.max_running_requests // attn_dp_size)
+            graph_bs = min(graph_bs, per_rank_pool_bs)
+        tokens_per_req = (
+            self.max_speculative_num_draft_tokens or 1
+            if view.speculative_algorithm
+            else 1
+        )
+        graph_tokens = graph_bs * tokens_per_req
+        if graph_tokens > capacity:
+            raise ValueError(
+                "DeepEP v2 per-rank decode CUDA graph exceeds "
+                "SGLANG_DEEPEP_V2_NUM_MAX_DISPATCH_TOKENS_PER_RANK: "
+                f"required={graph_tokens}, capacity={capacity} "
+                f"(requests={graph_bs}, tokens/request={tokens_per_req}). Raise "
+                "the environment value or lower --cuda-graph-max-bs."
+            )
+
+    def _validate_deepep_v2_model_architecture(self) -> None:
+        """Allow DeepEP v2 only where its model workflow is validated."""
+        if (
+            parse_connector_type(resolved_view(self).model_path)
+            == ConnectorType.INSTANCE
+        ):
+            raise ValueError(
+                "DeepEP v2 MoE cannot validate a model loaded through an instance "
+                "connector. Load it from a model path or use "
+                "--moe-a2a-backend deepep."
+            )
+
+        architectures = (
+            getattr(self.get_model_config().hf_config, "architectures", None) or []
+        )
+
+        architecture = architectures[0] if architectures else None
+        if architecture not in _DEEPEP_V2_VALIDATED_ARCHITECTURES:
+            raise ValueError(
+                f"DeepEP v2 MoE is not validated for {architecture!r}; supported "
+                f"architectures are {sorted(_DEEPEP_V2_VALIDATED_ARCHITECTURES)}. "
+                "Other model workflows may require an all-reduce after A2A "
+                "combine. Use --moe-a2a-backend deepep."
+            )
+
+    def _validate_deepep_v2_speculative_draft(self) -> None:
+        """Reject an explicit or inherited DeepEP v2 draft backend."""
+        view = resolved_view(self)
+        draft_backend = view.speculative_moe_a2a_backend
+        if draft_backend is None and view.speculative_algorithm:
+            from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+            algorithm = SpeculativeAlgorithm.from_string(view.speculative_algorithm)
+            if not algorithm.is_ngram():
+                draft_backend = view.moe_a2a_backend
+        if draft_backend == "deepep_v2":
+            raise ValueError(
+                "DeepEP v2 MoE is not validated as a speculative draft backend. "
+                "Select another --speculative-moe-a2a-backend."
+            )
+
+    def _handle_a2a_moe(self):
+        # The backend overrides and the ep_size=tp_size adjustments moved to
+        # the resolution pipeline (arg_groups/overrides.py:
+        # _a2a_backend_overrides / _a2a_ep_size); the per-backend logs,
+        # asserts, fusion/deepep_mode/env/cuda-graph writes stay below.
+        cfg = resolving_view(self)
+        from sglang.srt.arg_groups.overrides import (
+            _a2a_backend_overrides,
+            _a2a_ep_size,
+            _a2a_fusion_adjustments,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _a2a_backend_overrides)
+        run_post_process_pass(self, _a2a_ep_size)
+
+        # The a2a-driven shared-experts fusion adjustments moved to the
+        # pipeline (arg_groups/overrides.py: _a2a_fusion_adjustments),
+        # invoked here at the legacy write slots.
+        run_post_process_pass(self, _a2a_fusion_adjustments)
+
+        a2a_backend = resolved_view(self).moe_a2a_backend
+        if cfg.enable_waterfill:
+            self._declare("_handle_a2a_moe", enforce_shared_experts_fusion=True)
+            logger.info(f"Waterfill is enabled with moe_a2a_backend='{a2a_backend}'.")
+
+        if a2a_backend == "deepep":
+            if cfg.moe_runner_backend == "flashinfer_cutedsl":
+                if cfg.deepep_mode == "auto":
+                    self._declare(
+                        "_handle_a2a_moe",
+                        deepep_mode="low_latency",
+                    )
+                    logger.warning(
+                        "Forcing --deepep-mode low_latency: flashinfer_cutedsl "
+                        "FP4 MoE has no DeepEP normal-dispatch handler, so "
+                        "deepep auto mode would crash during prefill. "
+                        "low_latency covers both prefill and decode."
+                    )
+                elif cfg.deepep_mode == "normal":
+                    raise ValueError(
+                        "flashinfer_cutedsl FP4 MoE only supports DeepEP "
+                        "low_latency dispatch (masked layout). DeepEP normal "
+                        "(prefill) dispatch has no CuteDSL FP4 handler. Pass "
+                        "--deepep-mode low_latency or auto."
+                    )
+            if cfg.deepep_mode == "normal":
+                logger.warning("Cuda graph is disabled because deepep_mode=`normal`")
+                cfg.cuda_graph_config.decode.backend = Backend.DISABLED
+                cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+
+        if a2a_backend == "deepep_v2":
+            self._validate_deepep_v2_model_architecture()
+            if resolved_view(self).enable_deterministic_inference:
+                raise ValueError(
+                    "DeepEP v2 does not forward deterministic=True to "
+                    "ElasticBuffer, so deterministic sorting remains disabled. "
+                    "Disable --enable-deterministic-inference or use "
+                    "--moe-a2a-backend deepep."
+                )
+            # ElasticBuffer requires CUMEM, but not NVLS or its preallocation.
+            os.environ.setdefault("NCCL_CUMEM_ENABLE", "1")
+            # Respect model-level runner declarations before resolving auto.
+            resolved_runner = resolved_view(self).moe_runner_backend
+            if resolved_runner == "auto":
+                self._declare("_handle_a2a_moe", moe_runner_backend="deep_gemm")
+                logger.warning(
+                    "DeepEP v2 MoE: resolved --moe-runner-backend auto -> deep_gemm."
+                )
+            elif resolved_runner != "deep_gemm":
+                raise ValueError(
+                    "DeepEP v2 MoE currently supports only "
+                    f"--moe-runner-backend deep_gemm. Got {resolved_runner!r}. "
+                    "Add a runner adapter before enabling DeepEP v2 with other "
+                    "MoE runners."
+                )
+            if cfg.enable_two_batch_overlap or cfg.enable_single_batch_overlap:
+                raise ValueError(
+                    "DeepEP v2 MoE has not implemented the TBO/SBO overlap hooks yet. "
+                    "Disable --enable-two-batch-overlap and "
+                    "--enable-single-batch-overlap when using --moe-a2a-backend deepep_v2."
+                )
+            if cfg.enforce_shared_experts_fusion:
+                raise ValueError(
+                    "DeepEP v2 MoE has not validated fused shared experts yet. "
+                    "Remove --enforce-shared-experts-fusion when using "
+                    "--moe-a2a-backend deepep_v2."
+                )
+            # Prefill reads host counts and is not graph-capturable.
+            cfg.cuda_graph_config.prefill.backend = Backend.DISABLED
+            logger.warning(
+                f"DeepEP v2 MoE is enabled. The expert parallel size is adjusted to be the same as the tensor parallel size[{cfg.tp_size}]."
+            )
+            logger.warning(
+                "DeepEP v2 MoE is using deepep_v2_mode=%s. This controls "
+                "ElasticBuffer direct/hybrid mode and is independent from "
+                "--deepep-mode normal/low_latency. DeepEP v2 MoE enables the "
+                "decode CUDA graph on the masked decode path (any comm mode) "
+                "and disables shared expert fusion. "
+                "SGLANG_DEEPEP_V2_NUM_MAX_DISPATCH_TOKENS_PER_RANK is a "
+                "per-rank communication buffer capacity, not a model limit; "
+                "increase it for large prefill/chunked-prefill workloads.",
+                cfg.deepep_v2_mode,
+            )
+
+        # The resolving view, not the field: `_a2a_backend_overrides` may have
+        # moved this already (waterfill forces `deepep`).
+        a2a_now = resolved_view(self).moe_a2a_backend
+        if (a2a_now == "none" and is_npu()) or a2a_now == "ascend_tp":
+            # FIXME (OrangeRedeng): for some reasons if pass "ascend_tp" accuracy drops to zero
+            self._declare(
+                "_handle_a2a_moe",
+                moe_a2a_backend="none",
+            )
+
+        if cfg.moe_a2a_backend == "flashinfer":
+            assert (
+                resolved_view(self).enable_dp_attention and cfg.dp_size == cfg.tp_size
+            ), "Flashinfer MoE A2A is only supported with dp_size == tp_size and --enable-dp-attention"
+            if cfg.deepep_mode != "auto":
+                logger.warning("--deepep-mode is ignored for Flashinfer MoE A2A")
+            if not envs.SGLANG_MOE_NVFP4_DISPATCH.is_set() and (
+                resolved_view(self).quantization == "modelopt_fp4"
+                or self.get_model_config().nvfp4_moe_meta is not None
+            ):
+                envs.SGLANG_MOE_NVFP4_DISPATCH.set(True)
+                logger.warning(
+                    "SGLANG_MOE_NVFP4_DISPATCH is set to True for Flashinfer MoE A2A"
+                )
+            assert resolved_view(self).moe_runner_backend in [
+                "flashinfer_cutlass",
+                "flashinfer_cutedsl",
+                "flashinfer_trtllm_routed",
+            ], "Flashinfer MoE A2A is only supported with flashinfer_cutlass, flashinfer_cutedsl or flashinfer_trtllm_routed moe runner backend"
+
+        if a2a_backend == "mori":
+            if cfg.deepep_mode == "auto":
+                self._declare(
+                    "_handle_a2a_moe",
+                    deepep_mode="normal",
+                )
+                logger.warning("auto set deepep_mode=`normal` for MORI EP")
+
+            # Check chunked prefill for mori
+            # Skip validation if chunked prefill is disabled (i.e., size <= 0).
+            # Skip validation if disaggregation mode is decode.
+            if cfg.chunked_prefill_size > 0 and cfg.disaggregation_mode != "decode":
+                assert (
+                    self._required_mori_dispatch_tokens_per_rank()
+                ) <= envs.SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), (
+                    "SGLANG_MORI_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 4096) "
+                    "must be >= the per-rank MoRI dispatch tokens "
+                    "(chunked_prefill_size by default)"
+                )
+
+        if a2a_backend == "pplx":
+            if cfg.deepep_mode == "normal":
+                raise ValueError(
+                    "moe_a2a_backend='pplx' only supports low-latency mode; "
+                    "set --deepep-mode to 'low_latency' or 'auto'."
+                )
+            if cfg.deepep_mode == "auto":
+                self._declare(
+                    "_handle_a2a_moe",
+                    deepep_mode="low_latency",
+                )
+                logger.warning("auto set deepep_mode=`low_latency` for PPLX EP")
+            # pplx-kernels' AllToAll needs numDPGroups (== attention dp_size) > 1;
+            # without DP attention numDPGroups == 1 and construction fails deep in
+            # the kernel. This also implies ep_size >= 2.
+            assert resolved_view(self).enable_dp_attention and cfg.dp_size >= 2, (
+                "moe_a2a_backend='pplx' requires --enable-dp-attention with at "
+                "least 2 DP groups (--dp-size >= 2)."
+            )
+            # pplx runs the masked DeepGEMM expert path (sm_90a): reject other
+            # runners and resolve auto -> deep_gemm. Unquantized bf16 pplx needs
+            # an explicit deep_gemm backend, otherwise the expert layer falls
+            # through to the deprecated masked path and asserts at runtime.
+            assert resolved_view(self).moe_runner_backend in ("deep_gemm", "auto"), (
+                "moe_a2a_backend='pplx' is only supported with --moe-runner-backend "
+                "deep_gemm (or auto)."
+            )
+            if cfg.moe_runner_backend == "auto":
+                self._declare(
+                    "_handle_a2a_moe",
+                    moe_runner_backend="deep_gemm",
+                )
+                logger.warning("auto set moe_runner_backend=`deep_gemm` for PPLX EP")
+
+            # Check per-rank dispatch tokens for pplx
+            # Skip validation if chunked prefill is disabled (i.e., size <= 0)
+            # Skip validation if disaggregation mode is decode
+            if cfg.chunked_prefill_size > 0 and cfg.disaggregation_mode != "decode":
+                assert (
+                    self._required_pplx_dispatch_tokens_per_rank()
+                ) <= envs.SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK.get(), (
+                    "SGLANG_PPLX_NUM_MAX_DISPATCH_TOKENS_PER_RANK (default 128) "
+                    "must be >= the per-rank pplx dispatch tokens "
+                    "(chunked_prefill_size, or the decode cuda-graph batch size)"
+                )
+
+    def _required_mori_dispatch_tokens_per_rank(self) -> int:
+        """Max tokens a single rank dispatches through MoRI in one forward."""
+        cfg = resolving_view(self)
+        return cfg.chunked_prefill_size
+
+    def _required_pplx_dispatch_tokens_per_rank(self) -> int:
+        """Max tokens a single rank dispatches through pplx in one forward."""
+        cfg = resolving_view(self)
+        required = cfg.chunked_prefill_size
+        if cfg.cuda_graph_max_bs_decode is not None:
+            required = max(required, cfg.cuda_graph_max_bs_decode)
+        return required
+
+    def _handle_eplb_and_dispatch(self):
+        cfg = resolving_view(self)
+        if cfg.enable_eplb and (cfg.expert_distribution_recorder_mode is None):
+            self._declare(
+                "_handle_eplb_and_dispatch",
+                expert_distribution_recorder_mode="stat",
+            )
+            logger.warning(
+                "EPLB is enabled. The expert_distribution_recorder_mode is automatically set."
+            )
+
+        # Without an a2a backend all EP ranks run the MoE over the same tokens and
+        # sum their partial outputs, so the pick has to agree across ranks.
+        needs_rank_invariant_dispatch = self._resolved().moe_a2a_backend == "none"
+
+        if (cfg.enable_eplb or (cfg.init_expert_location != "trivial")) and (
+            cfg.ep_dispatch_algorithm is None
+        ):
+            self._declare(
+                "_handle_eplb_and_dispatch",
+                ep_dispatch_algorithm=(
+                    "dynamic" if needs_rank_invariant_dispatch else "static"
+                ),
+            )
+
+        # `dynamic` / `fake` switch to the row-index pick; `static` reads a
+        # per-rank table and `lp` samples inside its kernel.
+        if needs_rank_invariant_dispatch and cfg.ep_dispatch_algorithm in (
+            "static",
+            "lp",
+        ):
+            raise ValueError(
+                f"--ep-dispatch-algorithm {cfg.ep_dispatch_algorithm} picks a "
+                "different physical replica per rank, which only holds up when an "
+                "a2a backend routes each token to a single rank. Use "
+                "--ep-dispatch-algorithm dynamic with --moe-a2a-backend none."
+            )
+
+        if cfg.enable_eplb and cfg.ep_join_mode != "scale":
+            assert self._resolved().ep_size > 1
+
+    def _handle_elastic_ep(self):
+        cfg = resolving_view(self)
+        if cfg.elastic_ep_rejoin:
+            if cfg.ep_join_mode is None:
+                logger.warning(
+                    "--elastic-ep-rejoin is deprecated, use --elastic-ep-join-mode recover instead."
+                )
+                self._declare(
+                    "_handle_elastic_ep",
+                    ep_join_mode="recover",
+                )
+            else:
+                assert cfg.ep_join_mode == "recover", (
+                    "--elastic-ep-rejoin (deprecated) conflicts with "
+                    f"--elastic-ep-join-mode {cfg.ep_join_mode}."
+                )
+        if cfg.elastic_ep_backend is not None:
+            if cfg.enable_eplb:
+                if cfg.eplb_algorithm == "auto":
+                    self._declare(
+                        "_handle_elastic_ep",
+                        eplb_algorithm="elasticity_aware",
+                    )
+                assert cfg.eplb_algorithm in [
+                    "elasticity_aware",
+                    "elasticity_aware_hierarchical",
+                ], "Elastic EP requires eplb_algorithm to be set to 'auto' or 'elasticity_aware(_hierarchical)'."
+
+            assert cfg.pp_size == 1, "PP size should be set to 1 under elastic EP"
+
+            if cfg.elastic_ep_backend == "mooncake":
+                self._declare(
+                    "_handle_elastic_ep",
+                    mooncake_ib_device=self._validate_ib_devices(
+                        cfg.mooncake_ib_device
+                    ),
+                )
+        if cfg.ep_join_mode is not None:
+            assert (
+                cfg.elastic_ep_backend is not None
+            ), "--elastic-ep-join-mode requires --elastic-ep-backend to be set."
+            if cfg.ep_join_mode == "scale":
+                assert cfg.node_rank == 1, (
+                    "Elastic EP scale-up requires one joining TP group at "
+                    f"--node-rank 1 (got {cfg.node_rank})."
+                )
+                assert cfg.ep_join_rank_offset > 0, (
+                    "Elastic EP scale joiners require "
+                    "--elastic-ep-join-rank-offset set to the current "
+                    "effective EP size."
+                )
+        if cfg.ep_join_rank_offset != 0:
+            assert cfg.ep_join_mode == "scale", (
+                "--elastic-ep-join-rank-offset is only valid with "
+                "--elastic-ep-join-mode scale."
+            )
+            assert (
+                cfg.ep_join_rank_offset >= 0
+            ), "elastic EP join rank offset must be >= 0."
+        if cfg.max_ep_size is not None:
+            assert (
+                cfg.elastic_ep_backend is not None
+            ), "--max-ep-size requires --elastic-ep-backend to be set."
+            assert cfg.max_ep_size > 0, "--max-ep-size must be a positive integer."
+
+        scaling_active = (
+            cfg.elastic_ep_backend is not None
+            and cfg.max_ep_size is not None
+            and cfg.max_ep_size > cfg.tp_size
+        )
+        if cfg.elastic_ep_initial_size is not None:
+            assert scaling_active, (
+                "--elastic-ep-initial-size is only valid for an Elastic EP "
+                "deployment with --max-ep-size larger than its local TP size."
+            )
+        if scaling_active:
+            resolved = self._resolved()
+            assert (
+                cfg.elastic_ep_scale_timeout > 0
+            ), "--elastic-ep-scale-timeout must be greater than zero."
+            assert cfg.tokenizer_worker_num == 1, (
+                "Elastic EP runtime scale-up currently requires "
+                "--tokenizer-worker-num 1."
+            )
+            assert (
+                not cfg.use_ray
+            ), "Elastic EP runtime scale-up does not support --use-ray."
+            assert not cfg.enable_elastic_expert_backup, (
+                "Elastic EP runtime scale-up does not support "
+                "--enable-elastic-expert-backup."
+            )
+            self._declare(
+                "_handle_elastic_ep",
+                enable_dp_attention_local_control_broadcast=True,
+            )
+            if cfg.ep_join_mode == "scale":
+                assert cfg.elastic_ep_initial_size is not None, (
+                    "Elastic EP scale joiners require --elastic-ep-initial-size "
+                    "set to the primary deployment's launch-time EP size."
+                )
+                assert cfg.elastic_ep_initial_size <= cfg.ep_join_rank_offset, (
+                    "--elastic-ep-initial-size cannot exceed the current EP size "
+                    f"(initial={cfg.elastic_ep_initial_size}, "
+                    f"current={cfg.ep_join_rank_offset})."
+                )
+                join_target = cfg.ep_join_rank_offset + cfg.tp_size
+                assert join_target <= cfg.max_ep_size, (
+                    "Elastic EP joining group exceeds --max-ep-size "
+                    f"(join_target={join_target}, max_ep_size={cfg.max_ep_size})."
+                )
+                if cfg.tp_size == 1:
+                    assert cfg.moe_dense_tp_size == 1, (
+                        "A single-rank Elastic EP joining group requires "
+                        "--moe-dense-tp-size 1."
+                    )
+            else:
+                if cfg.elastic_ep_initial_size is None:
+                    self._declare(
+                        "_handle_elastic_ep",
+                        elastic_ep_initial_size=cfg.tp_size,
+                    )
+                assert cfg.elastic_ep_initial_size == cfg.tp_size, (
+                    "The primary --elastic-ep-initial-size must equal its "
+                    f"launch-time TP size ({cfg.tp_size})."
+                )
+            assert cfg.elastic_ep_initial_size > 0
+            assert cfg.load_balance_method == "round_robin", (
+                "Elastic EP scale-up requires --load-balance-method round_robin; "
+                "load-aware methods "
+                "require global-rank load snapshots after scale "
+                f"(got {cfg.load_balance_method})."
+            )
+            assert cfg.elastic_ep_backend == "mooncake", (
+                "Elastic EP runtime scale-up requires --elastic-ep-backend "
+                f"mooncake (got elastic_ep_backend={cfg.elastic_ep_backend})."
+            )
+            assert cfg.pp_size == 1, (
+                "Elastic EP scale-up requires --pp-size 1 "
+                f"(got pp_size={cfg.pp_size}); WORLD must not span PP stages."
+            )
+
+            decode_cuda_graph_disabled = (
+                cfg.cuda_graph_config.decode.backend == Backend.DISABLED
+            )
+            prefill_cuda_graph_disabled = (
+                cfg.cuda_graph_config.prefill.backend == Backend.DISABLED
+            )
+            assert decode_cuda_graph_disabled and prefill_cuda_graph_disabled, (
+                "Elastic EP runtime scale-up requires decode and prefill CUDA "
+                "graphs to be disabled."
+            )
+            assert resolved.enable_dp_attention, (
+                "Elastic EP scale-up requires --enable-dp-attention; without it "
+                "the TP group is not equivalent to WORLD and the post-scale "
+                "collective path is invalid."
+            )
+            assert resolved.enable_dp_lm_head, (
+                "Elastic EP scale-up requires --enable-dp-lm-head so output "
+                "projection does not depend on the joining group's TP size."
+            )
+            assert resolved.attn_cp_size == 1, (
+                "Elastic EP scale-up requires --attn-cp-size 1 "
+                f"(got attn_cp_size={resolved.attn_cp_size})."
+            )
+            assert cfg.moe_dp_size == 1, (
+                "Elastic EP scale-up requires --moe-dp-size 1 "
+                f"(got moe_dp_size={cfg.moe_dp_size})."
+            )
+            assert resolved.ep_size == cfg.tp_size, (
+                "Elastic EP scale-up requires ep_size == tp_size "
+                f"(got ep_size={resolved.ep_size}, tp_size={cfg.tp_size}); EP, TP "
+                "and the attention DP group must all coincide with WORLD."
+            )
+            assert cfg.dp_size == cfg.tp_size, (
+                "Elastic EP scale-up requires dp_size == tp_size "
+                f"(got dp_size={cfg.dp_size}, tp_size={cfg.tp_size})."
+            )
+            assert resolved.moe_a2a_backend == "nixl", (
+                "Elastic EP scale-up requires --moe-a2a-backend nixl "
+                f"(got moe_a2a_backend={resolved.moe_a2a_backend})."
+            )
+
+    def _validate_experimental_sgl_marlin(self):
+        view = self._resolved()
+        if view.moe_runner_backend != "experimental_sgl_marlin":
+            return
+
+        # ===== TO BE REFACTORED ====
+        from sglang.srt.lora.marlin_lora_temp.policy import (
+            validate_experimental_sgl_marlin_server_args,
+        )
+
+        validate_experimental_sgl_marlin_server_args(self, view)
+        # ===== END TO BE REFACTORED ====
+
+    def _handle_expert_distribution_metrics(self):
+        cfg = resolving_view(self)
+        if "SGLANG_ENABLE_EPLB_BALANCEDNESS_METRIC" in os.environ:
+            raise ValueError(
+                "SGLANG_ENABLE_EPLB_BALANCEDNESS_METRIC is no longer supported. Use "
+                "--expert-balancedness-report-mode with one of: off, server_log, "
+                "prometheus, both."
+            )
+
+        if self.should_report_expert_balancedness() and (
+            cfg.expert_distribution_recorder_mode is None
+        ):
+            self._declare(
+                "_handle_expert_distribution_metrics",
+                expert_distribution_recorder_mode="stat",
+            )
+
+        if cfg.expert_distribution_recorder_buffer_size is None:
+            if (x := cfg.eplb_rebalance_num_iterations) is not None:
+                self._declare(
+                    "_handle_expert_distribution_metrics",
+                    expert_distribution_recorder_buffer_size=x,
+                )
+            elif cfg.expert_distribution_recorder_mode is not None:
+                self._declare(
+                    "_handle_expert_distribution_metrics",
+                    expert_distribution_recorder_buffer_size=1000,
+                )
+
+    def _handle_pipeline_parallelism(self):
+        # Moved to the resolution pipeline (arg_groups/overrides.py:
+        # _pipeline_parallel_overlap_disable), invoked here at its legacy slot.
+        from sglang.srt.arg_groups.overrides import (
+            _pipeline_parallel_overlap_disable,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _pipeline_parallel_overlap_disable)
+
+    def _validate_prefill_only_disable_kv_cache_args(self):
+        """Validate --prefill-only-disable-kv-cache flag/precondition constraints.
+
+        Backend resolution is checked separately by
+        _handle_prefill_only_disable_kv_cache after backends settle.
+        """
+        cfg = resolving_view(self)
+        if not cfg.prefill_only_disable_kv_cache:
+            return
+
+        # This flag is intentionally scoped to embedding mode for now. Other
+        # prefill-only paths (for example scoring and MIS) can benefit from
+        # the same idea later, but some of them still stage K/V through the
+        # paged cache today.
+        if not cfg.is_embedding:
+            raise ValueError(
+                "--prefill-only-disable-kv-cache currently requires --is-embedding. "
+                "Other prefill-only workloads may be supported in a future change once "
+                "their attention paths stop reading or writing the paged KV cache."
+            )
+        if cfg.kv_cache_dtype in ("nvfp4", "fp4_mx_block16"):
+            raise ValueError(
+                "--prefill-only-disable-kv-cache does not currently support "
+                "--kv-cache-dtype=nvfp4 or --kv-cache-dtype=fp4_mx_block16 because "
+                "the FP4 pool uses a separate allocation path."
+            )
+        if cfg.kv_cache_dtype == "mxfp8":
+            raise ValueError(
+                "--prefill-only-disable-kv-cache does not currently support "
+                "--kv-cache-dtype=mxfp8 because the MXFP8 pool stores separate "
+                "scale-factor buffers."
+            )
+
+        # Structural preconditions for the FA backend's fa_skip_kv_cache path,
+        # which is the only embedding path that doesn't read or write the pool:
+        # - chunked_prefill_size == -1 keeps a request in a single forward,
+        #   so K/V never has to be reused across prefill chunks.
+        # - disable_radix_cache stops the prefix cache from indexing pool
+        #   slots that no longer hold real data.
+        if cfg.chunked_prefill_size != -1:
+            raise ValueError(
+                "--prefill-only-disable-kv-cache requires --chunked-prefill-size=-1 so the FA "
+                "backend takes the fa_skip_kv_cache path; otherwise the pool would be touched "
+                "between prefill chunks."
+            )
+        if not cfg.disable_radix_cache:
+            raise ValueError(
+                "--prefill-only-disable-kv-cache requires --disable-radix-cache because the "
+                "radix cache indexes KV pool slots that no longer hold real data."
+            )
+
+        # Context-parallel prefill stages K/V through cp_allgather_and_save_kv_cache,
+        # which writes to the pool via set_kv_buffer. NoOpMHATokenToKVPool intentionally
+        # raises on writes, so the engine would boot fine but fail on the first request.
+        if self._resolved().attn_cp_size > 1:
+            raise ValueError(
+                "--prefill-only-disable-kv-cache is incompatible with --attn-cp-size > 1: "
+                "the context-parallel attention path writes K/V to the pool via set_kv_buffer, "
+                "which the no-op pool intentionally rejects."
+            )
+        if cfg.enable_prefill_cp:
+            raise ValueError(
+                "--prefill-only-disable-kv-cache is incompatible with "
+                "--enable-prefill-cp: the prefill-CP path stages K/V through "
+                "the paged cache, which the no-op pool does not support."
+            )
+
+        # HiSparse selects a different pool class (HiSparseDSATokenToKVPool /
+        # HiSparseTokenToKVPoolAllocator) that is not the no-op pool.
+        if cfg.enable_hisparse:
+            raise ValueError(
+                "--prefill-only-disable-kv-cache is incompatible with --enable-hisparse: "
+                "HiSparse uses a dedicated pool family that is not the no-op MHA pool."
+            )
+
+    def _handle_prefill_only_disable_kv_cache(self):
+        """Validate --prefill-only-disable-kv-cache backend constraint.
+
+        Must run after _handle_attention_backend_compatibility() (which fills
+        the default attention_backend if unset) and _handle_multi_item_scoring()
+        (which may further mutate it). The assertion below guards against
+        accidental call-site reordering: if the resolved attention_backend is
+        still None, backends haven't settled yet and the resolved (prefill,
+        decode) pair would be a stale (None, None).
+        """
+        cfg = resolving_view(self)
+
+        if not cfg.prefill_only_disable_kv_cache:
+            return
+
+        assert resolved_view(self).attention_backend is not None, (
+            "_handle_prefill_only_disable_kv_cache must run after "
+            "_handle_attention_backend_compatibility() so the prefill backend is resolved."
+        )
+
+        prefill_backend, _ = self._resolved_attention_backends()
+        if prefill_backend not in ("fa3", "fa4"):
+            raise ValueError(
+                "--prefill-only-disable-kv-cache currently requires the FA prefill backend "
+                f"(fa3/fa4), but got prefill backend {prefill_backend!r}. Other prefill-only "
+                "workloads and backends may be supported in a future change."
+            )
+
+    def _handle_hicache_ratio_default(self):
+        """Default the host/device ratio per host memory mode.
+
+        Runs before the dummy-model boundary: direct HostKVCache consumers
+        (unit fixtures, dummy-model launches) must never see a None ratio.
+        buffer_only stages in flight rather than retaining, so it needs only
+        enough to cover the write backlog plus parked prefetches.
+
+        A decode server keeps the ratio unset here: kv_cache_builder resolves
+        it against the retraction-backup backend (1.0 for host_pool, else 2.0).
+        """
+        cfg = resolving_view(self)
+        if cfg.hicache_ratio is None and cfg.disaggregation_mode != "decode":
+            self._declare(
+                "_handle_hicache_ratio_default",
+                hicache_ratio=(
+                    1.2 if cfg.hicache_host_memory_mode == "buffer_only" else 2.0
+                ),
+            )
+
+    def _handle_hicache(self):
+        """Normalize hicache-related knobs into a valid runtime configuration.
+
+        Resolution order:
+        1) Layout <-> I/O compatibility for direct conflicts.
+        2) Storage <-> layout compatibility (may rewrite layout).
+        """
+        cfg = resolving_view(self)
+        # Skip all normalization when neither hicache nor decode-offload path is active.
+        if not (
+            cfg.enable_hierarchical_cache
+            or cfg.disaggregation_decode_enable_offload_kvcache
+            or (
+                cfg.disaggregation_mode == "decode"
+                and cfg.disaggregation_decode_retraction_backup in (None, "host_pool")
+            )
+        ):
+            return
+
+        self._validate_hicache_host_memory_mode()
+
+        # Step 1: Initial layout-io compatibility normalization.
+        self._resolve_layout_io_compatibility()
+
+        # Step 2: Storage-layout normalization without changing io backend.
+        self._resolve_storage_layout_compatibility()
+
+        # Step 3: DCP compatibility for the L2 (device<->host) path.
+        self._resolve_hicache_dcp_compatibility()
+
+    def _validate_hicache_host_memory_mode(self):
+        cfg = resolving_view(self)
+        if cfg.hicache_host_memory_mode not in ("cache", "buffer_only"):
+            raise ValueError(
+                "hicache_host_memory_mode must be 'cache' or 'buffer_only', "
+                f"got {cfg.hicache_host_memory_mode!r}"
+            )
+
+        # Both modes are defaulted upstream (a decode server resolves the
+        # ratio later, in kv_cache_builder), so this fires only if that
+        # defaulting regresses -- never build an unsized host pool.
+        if (
+            cfg.hicache_size <= 0
+            and cfg.hicache_ratio is None
+            and cfg.disaggregation_mode != "decode"
+        ):
+            raise ValueError(
+                f"--hicache-host-memory-mode {cfg.hicache_host_memory_mode} "
+                "requires a host pool size: pass --hicache-size or "
+                "--hicache-ratio."
+            )
+
+        if cfg.hicache_host_memory_mode == "cache":
+            return
+
+        if cfg.hicache_storage_backend is None:
+            raise ValueError(
+                "--hicache-host-memory-mode buffer_only requires a storage backend "
+                "(--hicache-storage-backend): host memory is only a staging buffer "
+                "and all cached data lives in storage."
+            )
+        if cfg.hicache_write_policy == "write_back":
+            raise ValueError(
+                "--hicache-host-memory-mode buffer_only does not support "
+                "--hicache-write-policy write_back; use write_through or "
+                "write_through_selective."
+            )
+        if cfg.disaggregation_mode == "decode":
+            raise ValueError(
+                "--hicache-host-memory-mode buffer_only is not supported on "
+                "decode instances: the decode-side prefetch and offload paths "
+                "bypass the buffer-mode pipeline, fetching without its prefix "
+                "context and never consuming its staged holds. Prefill "
+                "instances share the standard scheduler path and are supported."
+            )
+
+    def _resolve_hicache_dcp_compatibility(self):
+        cfg = resolving_view(self)
+        if cfg.dcp_size <= 1 or not cfg.enable_hierarchical_cache:
+            return
+        if cfg.hicache_storage_backend is not None:
+            raise NotImplementedError(
+                "--hicache-storage-backend (L3) with --dcp-size > 1 is not "
+                "supported yet: under DCP each rank holds a distinct "
+                "interleaved MLA KV shard, so the rank-0-only replicated-MLA "
+                "backup and the storage keys must become dcp_rank-aware "
+                "first. Run HiCache+DCP with L1/L2 only."
+            )
+        if cfg.speculative_algorithm not in (None, "DSPARK"):
+            raise NotImplementedError(
+                "HiCache with --dcp-size > 1 only supports DSPARK speculative "
+                "decoding; other draft-model host pools have no DCP index "
+                "translation."
+            )
+        if cfg.enable_lmcache:
+            raise NotImplementedError(
+                "--enable-lmcache with --dcp-size > 1 is not supported: "
+                "LMCache has no DCP-aware index translation."
+            )
+        if cfg.enable_hisparse:
+            raise NotImplementedError(
+                "--enable-hisparse with --dcp-size > 1 is not supported: the "
+                "HiSparse host pool is constructed without DCP translation."
+            )
+        if not self.use_mla_backend():
+            raise NotImplementedError(
+                "HiCache with --dcp-size > 1 is only supported for MLA models: "
+                "the index translation lives in MLATokenToKVPoolHost, and the "
+                "MHA host pool has none."
+            )
+        logger.info(
+            "HiCache + DCP enabled (L1/L2 only): host pool uses widened "
+            "logical slot accounting with per-rank physical translation at "
+            "the transfer boundary (dcp_size=%d).",
+            cfg.dcp_size,
+        )
+
+    def _resolve_layout_io_compatibility(self):
+        cfg = resolving_view(self)
+        if (
+            cfg.hicache_mem_layout == "page_first_direct"
+            and cfg.hicache_io_backend == "kernel"
+        ):
+            self._declare(
+                "_resolve_layout_io_compatibility",
+                hicache_io_backend="direct",
+            )
+            logger.warning(
+                "Kernel io backend does not support page first direct layout, switching to direct io backend"
+            )
+
+        if (
+            cfg.hicache_mem_layout == "page_first"
+            and cfg.hicache_io_backend == "direct"
+        ):
+            self._declare(
+                "_resolve_layout_io_compatibility",
+                hicache_mem_layout="page_first_direct",
+            )
+            logger.warning(
+                "Page first layout is not supported with direct IO backend, switching to page first direct layout"
+            )
+
+    def _resolve_storage_layout_compatibility(self):
+        cfg = resolving_view(self)
+        if (
+            cfg.hicache_storage_backend != "mooncake"
+            or cfg.hicache_mem_layout != "layer_first"
+        ):
+            return
+
+        if cfg.hicache_io_backend == "direct":
+            new_layout = "page_first_direct"
+        elif cfg.hicache_io_backend == "kernel":
+            new_layout = "page_first"
+        else:
+            # Keep current behavior for unknown backends (e.g., kernel_ascend).
+            new_layout = cfg.hicache_mem_layout
+
+        self._declare(
+            "_resolve_storage_layout_compatibility",
+            hicache_mem_layout=new_layout,
+        )
+        logger.warning(
+            f"Mooncake storage backend does not support layer_first layout, "
+            f"switching to {new_layout} layout for {cfg.hicache_io_backend} io backend"
+        )
+
+    def _resolve_hf_gguf_model_path(self):
+        """Turn a Hub reference to a .gguf into a local file path."""
+        cfg = resolving_view(self)
+        from sglang.srt.utils.hf_transformers_utils import resolve_hf_gguf_reference
+
+        resolved = resolve_hf_gguf_reference(cfg.model_path, revision=cfg.revision)
+        if resolved is not None:
+            logger.info("Resolved GGUF %s -> %s", cfg.model_path, resolved)
+            if cfg.tokenizer_path == cfg.model_path:
+                self._declare(
+                    "_resolve_hf_gguf_model_path",
+                    tokenizer_path=resolved,
+                )
+            self._declare(
+                "_resolve_hf_gguf_model_path",
+                model_path=resolved,
+            )
+
+        # A speculative draft can be a .gguf too, and it is loaded by path, so it
+        # needs the same Hub-reference resolution as the target.
+        if cfg.speculative_draft_model_path:
+            resolved_draft = resolve_hf_gguf_reference(
+                cfg.speculative_draft_model_path,
+                revision=cfg.speculative_draft_model_revision,
+            )
+            if resolved_draft is not None:
+                logger.info(
+                    "Resolved draft GGUF %s -> %s",
+                    cfg.speculative_draft_model_path,
+                    resolved_draft,
+                )
+                self._declare(
+                    "_resolve_hf_gguf_model_path",
+                    speculative_draft_model_path=resolved_draft,
+                )
+
+    def _handle_expert_pack(self):
+        from sglang.srt.arg_groups.expert_pack_hook import handle_expert_pack
+
+        handle_expert_pack(self)
+
+    def _handle_load_format(self):
+        # The quantization side of the gguf coupling moved to the pipeline
+        # (arg_groups/overrides.py: _gguf_quantization); load_format itself is
+        # genuine config (runtime user updates write it) and stays imperative.
+        cfg = resolving_view(self)
+        from sglang.srt.arg_groups.overrides import (
+            _gguf_quantization,
+            run_post_process_pass,
+        )
+
+        run_post_process_pass(self, _gguf_quantization)
+        if (cfg.load_format == "auto" or cfg.load_format == "gguf") and check_gguf_file(
+            cfg.model_path
+        ):
+            self._declare(
+                "_handle_load_format",
+                load_format="gguf",
+            )
+
+        if cfg.load_format == "auto" and self._is_mistral_native_format():
+            self._declare(
+                "_handle_load_format",
+                load_format="mistral",
+            )
+            logger.info(
+                "Detected Mistral native format checkpoint, setting load_format='mistral'"
+            )
+
+        if is_runai_obj_uri(cfg.model_path):
+            self._declare(
+                "_handle_load_format",
+                load_format="runai_streamer",
+            )
+        elif is_remote_url(cfg.model_path):
+            self._declare(
+                "_handle_load_format",
+                load_format="remote",
+            )
+
+        if (
+            cfg.speculative_draft_model_path is not None
+            and is_runai_obj_uri(cfg.speculative_draft_model_path)
+            and cfg.speculative_draft_load_format is None
+        ):
+            self._declare(
+                "_handle_load_format",
+                speculative_draft_load_format="runai_streamer",
+            )
+
+        if cfg.custom_weight_loader is None:
+            self._declare("_handle_load_format", custom_weight_loader=[])
+
+        if cfg.load_format == "remote_instance":
+            if cfg.remote_instance_weight_loader_backend != "modelexpress" and (
+                cfg.remote_instance_weight_loader_seed_instance_ip is None
+                or cfg.remote_instance_weight_loader_seed_instance_service_port is None
+            ):
+                logger.warning(
+                    "Fallback load_format to 'auto' due to incomplete remote instance weight loader settings."
+                )
+                self._declare(
+                    "_handle_load_format",
+                    load_format="auto",
+                )
+            elif (
+                cfg.remote_instance_weight_loader_send_weights_group_ports is None
+                and cfg.remote_instance_weight_loader_backend == "nccl"
+            ):
+                logger.warning(
+                    "Fallback load_format to 'auto' due to incomplete remote instance weight loader NCCL group ports settings."
+                )
+                self._declare(
+                    "_handle_load_format",
+                    load_format="auto",
+                )
+            elif (
+                cfg.remote_instance_weight_loader_backend == "transfer_engine"
+                and not self.validate_transfer_engine()
+            ):
+                logger.warning(
+                    "Fallback load_format to 'auto' due to 'transfer_engine' backend is not supported."
+                )
+                self._declare(
+                    "_handle_load_format",
+                    load_format="auto",
+                )
+
+        # Check whether TransferEngine can be used when users want to start seed service that supports TransferEngine backend.
+        if cfg.remote_instance_weight_loader_start_seed_via_transfer_engine:
+            self._declare(
+                "_handle_load_format",
+                remote_instance_weight_loader_start_seed_via_transfer_engine=self.validate_transfer_engine(),
+            )
+
+        # "ipc_cache" is an internal-only load format: ModelRunner sets it
+        # automatically when the weight cache is enabled, and it is not a public
+        # --load-format choice. Setting it directly is always wrong (no daemon is
+        # launched, and fallback_load_format inherits a nonsensical format), so
+        # reject it and point at the knob (defense-in-depth; the CLI already
+        # rejects it via LOAD_FORMAT_CHOICES).
+        if cfg.load_format == "ipc_cache":
+            raise ValueError(
+                "load_format='ipc_cache' is an internal-only format and must not "
+                "be set directly. Enable the weight cache via --weight-cache-mode "
+                "client (connect to an existing daemon) or daemon (launch one); "
+                "that selects IPC loading automatically."
+            )
+
+        # Speculative decoding loads an extra draft model whose weights the
+        # daemon does not export, so refuse the combination up front instead of
+        # failing deep inside draft-worker load (draft-model daemon TBD).
+        if cfg.weight_cache_mode != "off" and cfg.speculative_algorithm is not None:
+            raise ValueError(
+                "--weight-cache-mode is not supported together with speculative "
+                "decoding (--speculative-algorithm): the weight cache daemon does "
+                "not export the draft model's weights. Disable one of them "
+                "(--weight-cache-mode off) for this configuration."
+            )
+
+    def _is_mistral_native_format(self) -> bool:
+        """True iff the checkpoint requires load_format=mistral.
+
+        Looks for consolidated*.safetensors with no competing
+        model*.safetensors; when both weight formats ship in the
+        same checkpoint (e.g. Mistral-7B-Instruct-v0.3) the HF path is
+        preferred to avoid loading Mistral-named weights into an
+        HF-named architecture.
+
+        Name override: mistral-large-3 / mistral-small-4 /
+        leanstral always treat as Mistral-native when params.json
+        is present -- those families need Mistral weight loading
+        regardless of which weight files happen to be present.
+        """
+        cfg = resolving_view(self)
+        _MISTRAL_NATIVE_PATTERNS = (
+            "mistral-large-3",
+            "mistral-small-4",
+            "leanstral",
+        )
+        name_matches = any(
+            p in str(cfg.model_path).lower() for p in _MISTRAL_NATIVE_PATTERNS
+        )
+
+        def _check_format(has_params, has_consolidated, has_hf_weights) -> bool:
+            if has_params and name_matches:
+                return True
+            return has_consolidated and not has_hf_weights
+
+        if os.path.isdir(cfg.model_path):
+            return _check_format(
+                has_params=os.path.exists(os.path.join(cfg.model_path, "params.json")),
+                has_consolidated=bool(
+                    glob.glob(os.path.join(cfg.model_path, "consolidated*.safetensors"))
+                ),
+                has_hf_weights=bool(
+                    glob.glob(os.path.join(cfg.model_path, "model*.safetensors"))
+                ),
+            )
+
+        try:
+            from huggingface_hub import HfApi
+
+            files = {s.rfilename for s in HfApi().model_info(cfg.model_path).siblings}
+            return _check_format(
+                has_params="params.json" in files,
+                has_consolidated=any(
+                    f.startswith("consolidated") and f.endswith(".safetensors")
+                    for f in files
+                ),
+                has_hf_weights=any(
+                    f.startswith("model")
+                    and f.endswith(".safetensors")
+                    and "/" not in f
+                    for f in files
+                ),
+            )
+        except Exception:
+            return False
 
     LANGUAGE_MODEL_ONLY_ARCHITECTURES = ("MuseGlimmerForConditionalGeneration",)
 

--- a/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_broadcast.py
+++ b/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_broadcast.py
@@ -1,0 +1,315 @@
+"""Multi-NPU integration test for LayerSplitDSV4NPUTokenToKVPool owner reads.
+
+Spawns ``world`` processes forming a single attention-CP group, builds a tiny
+layer-split DSV4 NPU pool on each rank, writes the owner's bytes into every
+owned buffer family, then verifies that reading ANY layer (owned or not)
+surfaces the *owning* rank's contents -- i.e. the per-family owner all-gather
+over the CP group works for the SWA / c4 / c128 KV buffers and the c4 indexer
+K/scale buffers. Also checks the allocation shape contract (owned layers full,
+non-owned 0-row placeholders) and that the PD buffer reports list owned layers
+only.
+
+Run directly on 2+ NPUs:
+    ASCEND_RT_VISIBLE_DEVICES=0,1 python -m pytest \\
+        test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_broadcast.py
+"""
+
+import os
+import unittest
+
+import torch
+import torch.multiprocessing as mp
+
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_npu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_npu_ci(est_time=240, suite="per-commit-2-npu-a2")
+
+LAYER_NUM = 4
+RATIOS = [4, 0, 4, 128]
+PAGE_SIZE = 128
+SWA_PAGE = 128
+C128_KERNEL_PAGE = 16
+NOPE_DIM = 448
+ROPE_DIM = 64
+INDEX_HEAD_DIM = 128
+SWA_SIZE = SWA_PAGE * 2
+C4_SIZE = 8
+C128_SIZE = 8
+PORT = int(os.environ.get("DSV4_LS_PORT", "29811"))
+
+
+def _setup_context_bags(rank: int, world: int):
+    """Publish the minimal config leaves the DSV4 pool constructors read."""
+    from sglang.srt.runtime_context import _ConfigBag, get_context
+
+    schedule = _ConfigBag("schedule")
+    schedule._set("page_size", PAGE_SIZE)
+    schedule._set("c128_page_size", C128_KERNEL_PAGE)
+    spec = _ConfigBag("spec")
+    spec._set("speculative_algorithm", None)
+    exec_bag = _ConfigBag("exec")
+    kernel = _ConfigBag("kernel")
+    kernel._set("enable_deepseek_v4_fp4_indexer", False)
+    exec_bag._set_sub("kernel", kernel)
+    # attn_cp_size is a config-only leaf (no live-group fallback), so the
+    # parallel bag must exist before the pool reads it.
+    parallel = _ConfigBag("parallel")
+    parallel._set("attn_cp_size", world)
+    parallel._set("attn_cp_rank", rank)
+    ctx = get_context()
+    ctx._config_bags = {
+        "schedule": schedule,
+        "spec": spec,
+        "exec": exec_bag,
+        "parallel": parallel,
+    }
+    ctx.parallel._config = parallel
+
+
+def _build_pool(rank, cp_size, device):
+    from sglang.srt.hardware_backend.npu.dsv4.dsv4_cache_layer_split import (
+        LayerSplitDSV4NPUTokenToKVPool,
+    )
+
+    return LayerSplitDSV4NPUTokenToKVPool(
+        max_num_reqs=4,
+        num_req_slots=5,
+        swa_size=SWA_SIZE,
+        c4_size=C4_SIZE,
+        c128_size=C128_SIZE,
+        c4_state_pool_size=16,
+        c128_state_pool_size=256,
+        page_size=PAGE_SIZE,
+        swa_page_size=SWA_PAGE,
+        sliding_window=128,
+        dtype=torch.bfloat16,
+        c4_state_dtype=torch.float32,
+        c128_state_dtype=torch.float32,
+        qk_nope_head_dim=NOPE_DIM,
+        qk_rope_head_dim=ROPE_DIM,
+        indexer_head_dim=INDEX_HEAD_DIM,
+        layer_num=LAYER_NUM,
+        device=device,
+        enable_memory_saver=False,
+        compression_ratios=RATIOS,
+        layer_shard_rank=rank,
+        layer_shard_size=cp_size,
+    )
+
+
+def _fill_owned(pool, rank):
+    """Write rank-distinct constants into every owned buffer family."""
+    for layer_id in range(LAYER_NUM):
+        if pool._is_layer_owned(layer_id):
+            pool.swa_kv_pool.kv_buffer[layer_id].fill_(float(layer_id + 1))
+        item = pool.layer_mapping[layer_id]
+        if item.compress_ratio == 4 and pool._is_layer_owned(layer_id):
+            pool.c4_kv_pool.kv_buffer[item.compress_layer_id].fill_(10.0 + layer_id)
+            pool.c4_indexer_kv_pool.index_k_buffer[item.compress_layer_id].fill_(
+                20.0 + layer_id
+            )
+            pool.c4_indexer_kv_pool.index_scale_buffer[item.compress_layer_id].fill_(
+                30.0 + layer_id
+            )
+        if item.compress_ratio == 128 and pool._is_layer_owned(layer_id):
+            pool.c128_kv_pool.kv_buffer[item.compress_layer_id].fill_(10.0 + layer_id)
+
+
+def _run(rank: int, world: int, port: int):
+    import torch_npu  # noqa: F401
+
+    os.environ["MASTER_ADDR"] = "127.0.0.1"
+    os.environ["MASTER_PORT"] = str(port)
+    os.environ["RANK"] = str(rank)
+    os.environ["WORLD_SIZE"] = str(world)
+    os.environ.setdefault("no_proxy", "127.0.0.1,localhost")
+    torch.npu.set_device(rank)
+
+    from sglang.srt.distributed.parallel_state import (
+        init_distributed_environment,
+        initialize_model_parallel,
+    )
+    from sglang.srt.runtime_context import get_parallel
+
+    init_distributed_environment(
+        world_size=world,
+        rank=rank,
+        local_rank=rank,
+        distributed_init_method=f"tcp://127.0.0.1:{port}",
+        backend="hccl",
+    )
+    initialize_model_parallel(
+        tensor_model_parallel_size=world,
+        attention_context_model_parallel_size=world,
+    )
+    _setup_context_bags(rank, world)
+
+    cp_rank = get_parallel().attn_cp_rank
+    cp_size = get_parallel().attn_cp_size
+    assert cp_size == world, (cp_size, world)
+
+    pool = _build_pool(cp_rank, cp_size, f"npu:{rank}")
+
+    # --- allocation shape checks: owned layers full, others 0-row ----------
+    owned = [pool._is_layer_owned(i) for i in range(LAYER_NUM)]
+    start = owned.index(True) if any(owned) else LAYER_NUM
+    end = LAYER_NUM - owned[::-1].index(True) if any(owned) else 0
+    assert owned == [start <= i < end for i in range(LAYER_NUM)], owned
+    assert sum(owned) in (LAYER_NUM // world, LAYER_NUM // world + 1)
+    swa_pages = (SWA_SIZE + SWA_PAGE + 1) // SWA_PAGE
+    for layer_id in range(LAYER_NUM):
+        expect = swa_pages if owned[layer_id] else 0
+        actual = pool.swa_kv_pool.kv_buffer[layer_id].shape[0]
+        assert actual == expect, (layer_id, actual, expect)
+    for layer_id in (0, 2):  # c4 layers
+        item = pool.layer_mapping[layer_id]
+        expect = (C4_SIZE + 32 + 1) // 32 if pool._is_layer_owned(layer_id) else 0
+        assert pool.c4_kv_pool.kv_buffer[item.compress_layer_id].shape[0] == expect
+        # The indexer pool is sized by c4_logical_size (= c128_size * 32).
+        indexer_pages = (C128_SIZE * 32 + 32 + 1) // 32
+        expect_k = indexer_pages if pool._is_layer_owned(layer_id) else 0
+        assert (
+            pool.c4_indexer_kv_pool.index_k_buffer[item.compress_layer_id].shape[0]
+            == expect_k
+        )
+        assert (
+            pool.c4_indexer_kv_pool.index_scale_buffer[item.compress_layer_id].shape[0]
+            == expect_k
+        )
+    c128_item = pool.layer_mapping[3]
+    expect128 = (
+        (C128_SIZE + C128_KERNEL_PAGE + 1) // C128_KERNEL_PAGE if owned[3] else 0
+    )
+    assert (
+        pool.c128_kv_pool.kv_buffer[c128_item.compress_layer_id].shape[0] == expect128
+    )
+
+    # --- owned-only PD buffer reports ---------------------------------------
+    kv_ptrs, _, _ = pool.get_contiguous_buf_infos()
+    owned_c4 = sum(1 for i in (0, 2) if pool._is_layer_owned(i))
+    assert len(kv_ptrs) == 3 * owned_c4, (len(kv_ptrs), owned_c4)
+    state_ptrs, _, _ = pool.get_state_buf_infos()
+    owned_swa = sum(owned)
+    assert len(state_ptrs) == owned_swa + 2 * owned_c4
+    c128_ptrs, _, _ = pool.get_c128_kv_buf_infos()
+    assert len(c128_ptrs) == (1 if owned[3] else 0)
+    c128_state_ptrs, _, _ = pool.get_c128_state_buf_infos()
+    assert len(c128_state_ptrs) == (1 if owned[3] else 0)
+    assert (pool.layer_shard_start, pool.layer_shard_end) == (start, end)
+
+    # --- transfer layer ids parallel the buffer reports ----------------------
+    assert len(pool.get_kv_layer_ids()) == len(kv_ptrs)
+    assert len(pool.get_state_layer_ids()) == len(state_ptrs)
+    assert len(pool.get_c128_layer_ids()) == len(c128_ptrs)
+    assert len(pool.get_c128_layer_ids()) == len(c128_state_ptrs)
+
+    # --- owner broadcast: every rank reads the owner's bytes ---------------
+    # Reads are enqueued WITHOUT intermediate host syncs: the scratch is one
+    # buffer per family, so this also proves each broadcast lands before its
+    # consumer and is not overwritten by the next layer's broadcast.
+    _fill_owned(pool, cp_rank)
+    torch.npu.synchronize()
+    torch.distributed.barrier()
+
+    got_means = {}
+    ok = True
+    for layer_id in range(LAYER_NUM):
+        got_means[f"swa{layer_id}"] = pool.get_swa_buffer(layer_id).float().mean()
+        item = pool.layer_mapping[layer_id]
+        if item.compress_ratio == 4:
+            got_means[f"c4{layer_id}"] = (
+                pool.get_compress_buffer(layer_id).float().mean()
+            )
+            got_means[f"k{layer_id}"] = (
+                pool.get_compress_buffer(layer_id, True).float().mean()
+            )
+            got_means[f"s{layer_id}"] = pool.get_compress_dequant_scale_buffer(
+                layer_id, True
+            ).float().mean()
+        if item.compress_ratio == 128:
+            got_means[f"c128{layer_id}"] = (
+                pool.get_compress_buffer(layer_id).float().mean()
+            )
+    torch.npu.synchronize()
+    got = {k: v.item() for k, v in got_means.items()}
+    for layer_id in range(LAYER_NUM):
+        expected = float(layer_id + 1)
+        if abs(got[f"swa{layer_id}"] - expected) > 1e-3:
+            print(f"[rank {rank}] swa layer {layer_id}: exp {expected}, got {got[f'swa{layer_id}']}")
+            ok = False
+        item = pool.layer_mapping[layer_id]
+        if item.compress_ratio == 4:
+            if abs(got[f"c4{layer_id}"] - (10.0 + layer_id)) > 1e-3:
+                print(f"[rank {rank}] c4 layer {layer_id}: got {got[f'c4{layer_id}']}")
+                ok = False
+            if abs(got[f"k{layer_id}"] - (20.0 + layer_id)) > 1e-3 or abs(
+                got[f"s{layer_id}"] - (30.0 + layer_id)
+            ) > 1e-3:
+                print(
+                    f"[rank {rank}] index layer {layer_id}: "
+                    f"k {got[f'k{layer_id}']} s {got[f's{layer_id}']}"
+                )
+                ok = False
+        if item.compress_ratio == 128:
+            if abs(got[f"c128{layer_id}"] - (10.0 + layer_id)) > 1e-3:
+                print(f"[rank {rank}] c128 layer {layer_id}: got {got[f'c128{layer_id}']}")
+                ok = False
+    assert ok, f"rank {rank} read stale/incorrect broadcast contents"
+
+    # --- non-owned writes are no-ops; owner writes re-broadcast ------------
+    for layer_id in range(LAYER_NUM):
+        pool.set_swa_buffer(
+            layer_id=layer_id,
+            loc=torch.arange(1, device=f"npu:{rank}"),
+            cache=torch.full(
+                (1, 1, NOPE_DIM + ROPE_DIM), 99.0, dtype=torch.bfloat16,
+                device=f"npu:{rank}",
+            ),
+        )
+    torch.npu.synchronize()
+    torch.distributed.barrier()
+    post_means = []
+    for layer_id in range(LAYER_NUM):
+        buf = pool.get_swa_buffer(layer_id)
+        rows = buf.shape[0] * buf.shape[1]
+        post_means.append((layer_id, buf.float().mean(), rows))
+    torch.npu.synchronize()
+    for layer_id, mean, rows in post_means:
+        got = mean.item()
+        # The owner's write (99 into row 1) must be visible on every rank: the
+        # owner reads its local buffer, a non-owner re-broadcasts after its own
+        # (no-op) write call invalidated the cached copy.
+        expected = (float(layer_id + 1) * (rows - 1) + 99.0) / rows
+        if abs(got - expected) > 1e-2:
+            print(f"[rank {rank}] post-write layer {layer_id}: exp {expected}, got {got}")
+            ok = False
+    assert ok, f"rank {rank} post-write contents incorrect"
+
+    print(f"[rank {cp_rank}] OK: allocation, PD reports and owner broadcast verified")
+    torch.distributed.barrier()
+
+
+class TestLayerSplitDSV4Broadcast(CustomTestCase):
+    def _spawn_world(self, port: int) -> None:
+        world = min(
+            int(os.environ.get("DSV4_LS_WORLD", "2")), torch.npu.device_count()
+        )
+        if world < 2:
+            self.skipTest("LayerSplitDSV4NPUTokenToKVPool read test needs >= 2 NPUs")
+        mp.spawn(_run, args=(world, port), nprocs=world, join=True)
+
+    def test_owner_read(self):
+        self._spawn_world(PORT)
+
+    def test_owner_read_chunked(self):
+        # Force many all-gather chunks per family buffer: the default chunk
+        # size exceeds this test's buffers, so only this case walks the
+        # per-chunk staging copy / owner-slot copy loop.
+        with envs.SGLANG_DSV4_LS_CHUNK_BYTES.override(8192):
+            self._spawn_world(PORT + 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_shard_plan.py
+++ b/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_shard_plan.py
@@ -1,0 +1,129 @@
+"""Unit tests for the DSV4 (NPU) cache layer-split ownership plan.
+
+The shard plan maps a contiguous per-rank layer range onto the DSV4 pool's
+compression-ratio buckets (swa / c4 / c128). Each rank's owned set inside a
+bucket must be a contiguous sub-range of that bucket's buffer list so the PD
+transfer can slice the decode-side buffer lists positionally.
+"""
+
+import unittest
+
+from sglang.srt.hardware_backend.npu.dsv4.dsv4_layer_split_plan import (
+    DSV4LayerShardPlan,
+    owned_bucket_range,
+)
+from sglang.srt.layers.cp.utils import get_layer_owner, get_layer_shard_range
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestDSV4LayerSplitShardPlan(CustomTestCase):
+    # DSV4-Flash-like pattern: two c4 layers and one c128 layer per 5 layers.
+    RATIOS = [4, 0, 4, 0, 128] * 12
+
+    def _plan(self, rank, shard_size, ratios=None):
+        ratios = self.RATIOS if ratios is None else ratios
+        return DSV4LayerShardPlan(
+            rank=rank,
+            shard_size=shard_size,
+            num_layers=len(ratios),
+            stage_start=0,
+            ratios=ratios,
+        )
+
+    def test_shard_ranges_cover_all_layers_once(self):
+        ranges = [self._plan(r, 2).owned_stage_local_range() for r in range(2)]
+        covered = [i for start, end in ranges for i in range(start, end)]
+        self.assertEqual(covered, list(range(len(self.RATIOS))))
+
+    def test_owner_rank_round_trip(self):
+        for shard_size in (2, 3, 4):
+            for layer in range(len(self.RATIOS)):
+                owners = [
+                    r
+                    for r in range(shard_size)
+                    if self._plan(r, shard_size).is_layer_owned(layer)
+                ]
+                self.assertEqual(len(owners), 1)
+                self.assertEqual(
+                    owners[0],
+                    self._plan(owners[0], shard_size).owner_rank(layer),
+                )
+
+    def test_owned_bucket_slices_partition_each_bucket(self):
+        for shard_size in (2, 3, 4):
+            for bucket in ("swa", "c4", "c128"):
+                bucket_ids = self._plan(0, shard_size).bucket_layer_ids(bucket)
+                covered, next_start = [], 0
+                for rank in range(shard_size):
+                    plan = self._plan(rank, shard_size)
+                    start, end = plan.owned_bucket_range(bucket)
+                    # Contiguous in bucket index, no gap to the previous rank.
+                    self.assertEqual(start, next_start)
+                    self.assertLessEqual(end, len(bucket_ids))
+                    for idx in range(start, end):
+                        self.assertTrue(plan.is_stage_local_owned(bucket_ids[idx]))
+                    covered.extend(bucket_ids[start:end])
+                    next_start = end
+                self.assertEqual(next_start, len(bucket_ids))
+                self.assertEqual(sorted(covered), sorted(bucket_ids))
+
+    def test_dense_and_degenerate_ratio_patterns(self):
+        for ratios in ([0] * 16, [0, 4, 128] * 8, [4] * 7):
+            num_layers = len(ratios)
+            for shard_size in (2, 3):
+                plans = [
+                    DSV4LayerShardPlan(
+                        rank=r,
+                        shard_size=shard_size,
+                        num_layers=num_layers,
+                        stage_start=0,
+                        ratios=ratios,
+                    )
+                    for r in range(shard_size)
+                ]
+                for bucket in ("swa", "c4", "c128"):
+                    ids = plans[0].bucket_layer_ids(bucket)
+                    covered, next_start = [], 0
+                    for plan in plans:
+                        start, end = plan.owned_bucket_range(bucket)
+                        self.assertEqual(start, next_start)
+                        covered.extend(ids[start:end])
+                        next_start = end
+                    self.assertEqual(next_start, len(ids))
+                    self.assertEqual(sorted(covered), sorted(ids))
+
+    def test_stage_offset_shifts_global_shard_window(self):
+        plan = DSV4LayerShardPlan(
+            rank=1,
+            shard_size=2,
+            num_layers=60,
+            stage_start=8,
+            ratios=self.RATIOS,
+        )
+        self.assertEqual(plan.shard_start, 8 + plan.owned_start)
+        self.assertEqual(plan.shard_end, 8 + plan.owned_end)
+        self.assertTrue(plan.is_layer_owned(8 + plan.owned_start))
+        self.assertFalse(plan.is_layer_owned(8 + plan.owned_start - 1))
+
+    def test_owned_bucket_range_helper_monotonic_ids(self):
+        self.assertEqual(owned_bucket_range([2, 4, 6, 8], 4, 8), (1, 3))
+        self.assertEqual(owned_bucket_range([2, 4, 6, 8], 0, 100), (0, 4))
+        self.assertEqual(owned_bucket_range([2, 4, 6, 8], 5, 5), (2, 2))
+        self.assertEqual(owned_bucket_range([], 0, 4), (0, 0))
+
+    def test_matches_cp_utils_shard_math(self):
+        self.assertEqual(
+            [get_layer_shard_range(r, 4, 10) for r in range(4)],
+            [(0, 3), (3, 6), (6, 8), (8, 10)],
+        )
+        self.assertEqual(
+            [get_layer_owner(i, 4, 10) for i in range(10)],
+            [0, 0, 0, 1, 1, 1, 2, 2, 3, 3],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_staging.py
+++ b/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_staging.py
@@ -1,0 +1,75 @@
+"""Unit tests for DSV4 (NPU) layer-split active-page staging math.
+
+The staging read path serves a remote layer from only the pages the batch
+references, so the mask/union/remap helpers must agree on page ids and keep
+padding (-1) entries untouched through the rebase.
+"""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.hardware_backend.npu.dsv4 import dsv4_layer_split_staging as staging
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _FakeRemoteRank:
+    """All-reduce stand-in that marks one page active on a CP partner."""
+
+    def __init__(self, remote_page: int):
+        self.remote_page = remote_page
+
+    def all_reduce(self, mask):
+        mask[self.remote_page] += 1
+        return mask
+
+
+class TestDSV4LayerSplitStaging(CustomTestCase):
+    def test_active_pages_include_remote_cp_ranks(self):
+        indices = torch.tensor([0, 7, -1], dtype=torch.int32)
+
+        with patch.object(
+            staging,
+            "all_reduce_active_pages_mask",
+            side_effect=lambda mask, group: _FakeRemoteRank(3).all_reduce(mask),
+        ):
+            selected = staging.active_pages_for_indices(
+                indices, page_size=4, max_pages=4, group=None
+            )
+
+        # Local pages {0, 1} plus the partner's page 3, in sorted order.
+        self.assertEqual(selected.tolist(), [0, 1, 3])
+
+    def test_indices_remap_preserves_padding(self):
+        selected = torch.tensor([1, 3], dtype=torch.int64)
+        remapped = staging.remap_indices_to_staging(
+            torch.tensor([4, 5, 12, 15, -1], dtype=torch.int32),
+            selected,
+            page_size=4,
+            max_pages=4,
+        )
+        self.assertEqual(remapped.tolist(), [0, 1, 4, 7, -1])
+
+    def test_page_table_remap_preserves_padding(self):
+        remapped = staging.remap_page_table_to_staging(
+            torch.tensor([3, 1, -1], dtype=torch.int32),
+            torch.tensor([1, 3], dtype=torch.int64),
+            max_pages=4,
+        )
+        self.assertEqual(remapped.tolist(), [1, 0, -1])
+
+    def test_mask_counts_hits_per_page(self):
+        mask = staging.build_active_pages_mask(
+            torch.tensor([0, 1, 2, 3, -1, 7], dtype=torch.int32),
+            page_size=4,
+            max_pages=3,
+        )
+        self.assertEqual(mask.tolist(), [4, 1, 0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_transfer_ids.py
+++ b/test/registered/unit/hardware_backend/npu/test_dsv4_layer_split_transfer_ids.py
@@ -1,0 +1,142 @@
+"""Unit tests for DSV4 (NPU) layer-split PD transfer layer ids.
+
+A layer-split prefill rank registers only its owned layers while decode
+registers the full cache, so transfer entries must be paired by (buffer
+section, global layer id) -- positional pairing would ship bytes into the
+wrong decode layers. These tests pin the pool id sequences and the pairings
+they produce.
+"""
+
+import unittest
+
+from sglang.srt.disaggregation.utils import (
+    build_kv_layer_ids,
+    build_transfer_entry_pairs,
+)
+from sglang.srt.hardware_backend.npu.dsv4.dsv4_cache_layer_split import (
+    LayerSplitDSV4NPUTokenToKVPool,
+)
+from sglang.srt.hardware_backend.npu.dsv4.dsv4_layer_split_plan import (
+    DSV4LayerShardPlan,
+)
+from sglang.srt.hardware_backend.npu.dsv4.dsv4_memory_pool import (
+    DSV4NPUTokenToKVPool,
+    bucket_layer_ids,
+)
+from sglang.srt.utils import is_npu
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+# 15 stage layers: c4 at 0,2,5,7,10,12; c128 at 4,9,14.
+RATIOS = [4, 0, 4, 0, 128] * 3
+C4_IDS = [0, 2, 5, 7, 10, 12]
+C128_IDS = [4, 9, 14]
+
+
+def _bare(pool_cls, **attrs):
+    pool = object.__new__(pool_cls)
+    for name, value in attrs.items():
+        setattr(pool, name, value)
+    return pool
+
+
+def _full_pool():
+    return _bare(
+        DSV4NPUTokenToKVPool,
+        compression_ratios=RATIOS,
+        _stage_start=0,
+        _stage_end=len(RATIOS),
+    )
+
+
+def _shard_pool(rank: int, shard_size: int = 2):
+    return _bare(
+        LayerSplitDSV4NPUTokenToKVPool,
+        compression_ratios=RATIOS,
+        _stage_start=0,
+        _stage_end=len(RATIOS),
+        _shard_plan=DSV4LayerShardPlan(
+            rank=rank,
+            shard_size=shard_size,
+            num_layers=len(RATIOS),
+            stage_start=0,
+            ratios=RATIOS,
+        ),
+    )
+
+
+class TestDSV4TransferLayerIds(CustomTestCase):
+    def test_bucket_layer_ids(self):
+        self.assertEqual(
+            bucket_layer_ids(RATIOS, 0, len(RATIOS), 4), C4_IDS
+        )
+        self.assertEqual(
+            bucket_layer_ids(RATIOS, 0, len(RATIOS), 128), C128_IDS
+        )
+
+    def test_full_pool_ids_cover_every_buf_entry(self):
+        pool = _full_pool()
+        # Main KV: three same-length sections (c4 KV, index K, index scale).
+        self.assertEqual(pool.get_kv_layer_ids(), C4_IDS * 3)
+        # SWA component: per-layer SWA KV, then c4 attention and indexer states.
+        self.assertEqual(
+            pool.get_state_layer_ids(), list(range(len(RATIOS))) + C4_IDS * 2
+        )
+        self.assertEqual(pool.get_c128_layer_ids(), C128_IDS)
+
+    def test_shard_pool_ids_are_owned_only(self):
+        # 15 layers over 2 ranks: rank0 owns [0,8), rank1 owns [8,15).
+        rank0, rank1 = _shard_pool(0), _shard_pool(1)
+        self.assertEqual(rank0.get_kv_layer_ids(), [0, 2, 5, 7] * 3)
+        self.assertEqual(rank1.get_kv_layer_ids(), [10, 12] * 3)
+        self.assertEqual(
+            rank0.get_state_layer_ids(), list(range(8)) + [0, 2, 5, 7] * 2
+        )
+        self.assertEqual(
+            rank1.get_state_layer_ids(), list(range(8, 15)) + [10, 12] * 2
+        )
+        self.assertEqual(rank0.get_c128_layer_ids(), [4])
+        self.assertEqual(rank1.get_c128_layer_ids(), [9, 14])
+
+    def test_ids_pair_owned_entries_to_matching_decode_layers(self):
+        dst_ids = _full_pool().get_kv_layer_ids()
+        src_ids = _shard_pool(1).get_kv_layer_ids()
+        pairs = build_transfer_entry_pairs(src_ids, dst_ids, len(src_ids), len(dst_ids))
+
+        self.assertEqual(len(pairs), len(src_ids))
+        for src_idx, dst_idx in pairs:
+            # Every transfer moves bytes between the SAME global layer, and
+            # each source entry is used exactly once.
+            self.assertEqual(src_ids[src_idx], dst_ids[dst_idx])
+        self.assertEqual(sorted(src for src, _ in pairs), list(range(len(src_ids))))
+        # Positional pairing would have been plain (i, i): the id sequences
+        # must actually differ there for this test to guard anything.
+        self.assertNotEqual(src_ids, dst_ids[: len(src_ids)])
+
+    def test_state_component_ids_pair_across_shard(self):
+        dst_ids = _full_pool().get_state_layer_ids()
+        src_ids = _shard_pool(1).get_state_layer_ids()
+        pairs = build_transfer_entry_pairs(src_ids, dst_ids, len(src_ids), len(dst_ids))
+
+        self.assertEqual(len(pairs), len(src_ids))
+        for src_idx, dst_idx in pairs:
+            self.assertEqual(src_ids[src_idx], dst_ids[dst_idx])
+
+    @unittest.skipUnless(is_npu(), "layer ids engage the transfer only on NPU")
+    def test_build_kv_layer_ids_reports_npu_pool_ids(self):
+        pool = _full_pool()
+        self.assertEqual(
+            build_kv_layer_ids(
+                token_to_kv_pool=pool,
+                draft_token_to_kv_pool=None,
+                num_draft_entries=0,
+                num_hidden_layers=len(RATIOS),
+            ),
+            C4_IDS * 3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
…gzag

Adapt DSV4 CP-v1 to the strategy API on the NPU backend:

- deepseek_v4_hook accepts --cp-strategy {interleave,zigzag}; interleave maps to round-robin-split, zigzag to in-seq-split, and the MLA alias flag is cleared. Drops the dp_size==1 gate so CP runs under --dp-size 4 prefill disaggregation.
- InterleaveCPStrategy/ZigzagCPStrategy gain local_q_indices so the backend can rebuild rank-local attention metadata.
- cp_utils routes shard/gather through the strategy when the forward batch carries strategy-built metadata; non-divisible round-robin splits are allowed, the all-gather handles mHC-rank trailing dims, and prepare_context_parallel_metadata builds real interleave metadata under round-robin-split.
- Ascend DSV4 backend: prepare_dsv4_cp_metadata reindexes page tables and seq metrics onto the rank-local token slice; use_dsv4_cp_full_metadata runs the indexer/compressor against full-order KV while attention uses the local slice; skip_compressor threads through the C4 indexer.
- MQALayer gathers full-order bf16 KV before store_cache under CP and dispatches indexer/compressor via the full-metadata context.
- fused_hc_head tiles launches at 65535 rows (Ascend coreDim cap reached by all-gathered CP prefill lengths).

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->