### PR TITLE
[Fix] mistral: only the first tool call of an array survives streaming

### DIFF
--- a/python/sglang/srt/function_call/mistral_detector.py
+++ b/python/sglang/srt/function_call/mistral_detector.py
@@ -125,6 +125,18 @@ class MistralDetector(BaseFormatDetector):
         self._buffer += new_text
         current_text = self._buffer
 
+        # Later calls of a JSON array no longer carry the marker: it was consumed
+        # together with the first call, so what remains starts with the separator.
+        # Without recognising that, every remaining call is flushed as normal text
+        # and lost.
+        if self.current_tool_id > 0 and self._tool_calls_marker not in current_text:
+            if current_text.startswith(self.tool_call_separator):
+                return super().parse_streaming_increment(new_text="", tools=tools)
+            if current_text and self.tool_call_separator.startswith(current_text):
+                # Separator itself is still arriving; keep buffering so it is not
+                # emitted as content one character at a time.
+                return StreamingParseResult()
+
         # No marker: either flush as normal text or keep buffering a partial marker.
         if self._tool_calls_marker not in current_text:
             if not self._ends_with_partial_token(self._buffer, self._tool_calls_marker):

--- a/test/registered/unit/function_call/test_mistral_detector_streaming.py
+++ b/test/registered/unit/function_call/test_mistral_detector_streaming.py
@@ -1,0 +1,175 @@
+"""Streaming unit tests for MistralDetector — no server, no model loading.
+
+Asserts that replaying the same text through `parse_streaming_increment` in
+arbitrary chunk sizes reproduces the `detect_and_parse` result, in particular
+for JSON arrays holding more than one call.
+"""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.mistral_detector import MistralDetector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+
+class TestMistralDetectorStreaming(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "days": {"type": "integer"},
+                        },
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="search",
+                    description="Search the web",
+                    parameters={
+                        "type": "object",
+                        "properties": {"q": {"type": "string"}},
+                    },
+                ),
+            ),
+        ]
+
+    # ---------------- helpers ----------------
+
+    def _stream(self, chunks):
+        detector = MistralDetector()
+        seq, normal, cur = [], "", None
+
+        def absorb(result):
+            nonlocal normal, cur
+            normal += result.normal_text or ""
+            for call in result.calls:
+                if call.name:
+                    cur = [call.name, ""]
+                    seq.append(cur)
+                if call.parameters:
+                    if cur is None:
+                        cur = ["", ""]
+                        seq.append(cur)
+                    cur[1] += call.parameters
+
+        for chunk in chunks:
+            absorb(detector.parse_streaming_increment(chunk, self.tools))
+        # The base detector advances one call per invocation and real serving
+        # keeps calling it per token, so drain until idle at end of stream.
+        for _ in range(200):
+            result = detector.parse_streaming_increment("", self.tools)
+            if not result.calls and not result.normal_text:
+                break
+            absorb(result)
+
+        return [tuple(x) for x in seq], normal
+
+    def _chunkings(self, text):
+        third = len(text) // 3
+        return {
+            "char": list(text),
+            "whole": [text],
+            "halves": [text[: len(text) // 2], text[len(text) // 2 :]],
+            "thirds": [text[:third], text[third : 2 * third], text[2 * third :]],
+        }
+
+    def assert_stream_matches_final(self, text):
+        reference = MistralDetector().detect_and_parse(text, self.tools)
+        want = [(c.name, c.parameters) for c in reference.calls]
+        want_normal = (reference.normal_text or "").strip()
+
+        for label, chunks in self._chunkings(text).items():
+            got, got_normal = self._stream(chunks)
+
+            self.assertEqual(
+                len(got), len(want), f"[{label}] call count differs for {text!r}"
+            )
+            for (g_name, g_args), (w_name, w_args) in zip(got, want):
+                self.assertEqual(g_name, w_name, f"[{label}] name differs")
+                self.assertEqual(
+                    json.loads(g_args) if g_args else None,
+                    json.loads(w_args) if w_args else None,
+                    f"[{label}] arguments differ for {text!r}",
+                )
+
+            self.assertNotIn(
+                "[TOOL_CALLS", got_normal, f"[{label}] marker leaked into content"
+            )
+            self.assertEqual(
+                got_normal.strip(), want_normal, f"[{label}] normal text differs"
+            )
+
+    # ---------------- tests ----------------
+
+    def test_single_call_no_arguments(self):
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}]'
+        )
+
+    def test_single_call_with_arguments(self):
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Beijing"}}]'
+        )
+
+    def test_two_calls_empty_arguments(self):
+        # Regression: the second call was emitted as normal text, because after
+        # the first call the remaining buffer no longer carries the marker.
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}, '
+            '{"name": "get_weather", "arguments": {}}]'
+        )
+
+    def test_two_calls_with_arguments(self):
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "Beijing"}}, '
+            '{"name": "search", "arguments": {"q": "food"}}]'
+        )
+
+    def test_three_calls(self):
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}, '
+            '{"name": "search", "arguments": {"q": "a"}}, '
+            '{"name": "get_weather", "arguments": {"days": 3}}]'
+        )
+
+    def test_empty_arguments_followed_by_populated(self):
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}, '
+            '{"name": "search", "arguments": {"q": "x"}}]'
+        )
+
+    def test_integer_argument_keeps_type(self):
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"days": 7}}]'
+        )
+
+    def test_unicode_argument(self):
+        self.assert_stream_matches_final(
+            '[TOOL_CALLS] [{"name": "get_weather", "arguments": {"city": "北京"}}]'
+        )
+
+    def test_normal_text_before_tool_call(self):
+        self.assert_stream_matches_final(
+            'Sure. [TOOL_CALLS] [{"name": "get_weather", "arguments": {}}]'
+        )
+
+    def test_plain_text_without_tool_call(self):
+        self.assert_stream_matches_final("The weather is nice today.")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Partially addresses #35564 — the `mistral` row, reported as *"the 2nd call is gone"*.

In a JSON array holding several calls, only the first one carries the `[TOOL_CALLS] [` marker. That marker is consumed together with the first call, so the buffer for every later call starts with the `", "` separator instead.

`parse_streaming_increment` only tested for the marker, so once the first call was parsed the remainder of the array fell into the no-marker branch and was flushed as normal text. The calls were lost **and** their raw JSON leaked into user-visible content, one character at a time under real detokenized streaming.

Reproducible on CPU, no server or model needed:

```python
from sglang.srt.function_call.function_call_parser import FunctionCallParser

text = ('[TOOL_CALLS] [{"name": "get_weather", "arguments": {}}, '
        '{"name": "get_weather", "arguments": {}}]')

d = FunctionCallParser.ToolCallParserEnum["mistral"]()
# detect_and_parse -> 2 calls
# streamed char-by-char -> 1 call, and the second call's JSON appears as content
```

## Root cause

`BaseFormatDetector.parse_streaming_increment` already handles a mid-array resume with

```python
self.current_tool_id > 0 and current_text.startswith(self.tool_call_separator)
```

but `MistralDetector` overrides the method and dropped that condition.

## Modifications

`python/sglang/srt/function_call/mistral_detector.py` — restore the equivalent check, and delegate to the base implementation when an array is being continued. This also covers the intermediate state where the separator is itself still arriving character by character (buffer is `","` before it becomes `", "`), which must be buffered rather than emitted as content.

## Tests

New `test/registered/unit/function_call/test_mistral_detector_streaming.py`, registered for CPU CI (no GPU, no model load).

10 cases replayed under 4 chunkings — character-by-character, whole string, halves, thirds — for 40 assertions. Each asserts the streamed calls equal the `detect_and_parse` result with argument types preserved, and that `[TOOL_CALLS` never appears in the returned content.

Coverage: one / two / three calls, empty and populated arguments, an empty-argument call followed by a populated one, integer argument typing, unicode, leading normal text, and plain text with no call.

At end of stream the tests drain the detector until idle, mirroring how serving keeps invoking it per token (the base detector advances one call per invocation).

Verified: 24/40 → 40/40 on that matrix, and the 18 existing tests in `test_mistral_detector.py` still pass.

## Checklist

- [x] Format the code and add unit tests
- [x] Update documentation as needed — n/a, internal parser behavior

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33068962203](https://github.com/sgl-project/sglang/actions/runs/33068962203)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33068962016](https://github.com/sgl-project/sglang/actions/runs/33068962016)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33068962225](https://github.com/sgl-project/sglang/actions/runs/33068962225)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->