### PR TITLE
[Diffusion] Fuse Qwen-Image text QKV projections

### DIFF
--- a/python/sglang/multimodal_gen/configs/models/dits/qwenimage.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/qwenimage.py
@@ -26,6 +26,25 @@ class QwenImageArchConfig(DiTArchConfig):
 
     param_names_mapping: dict = field(
         default_factory=lambda: {
+            # Merge the short text-stream projections into one tensor-parallel
+            # GEMM. The loader only applies these rules when the fused target
+            # exists, so quantization backends that keep the original modules
+            # continue to load their unfused parameters.
+            r"^(.*\.attn)\.add_q_proj\.(.+)$": (
+                r"\1.to_added_qkv.\2",
+                0,
+                3,
+            ),
+            r"^(.*\.attn)\.add_k_proj\.(.+)$": (
+                r"\1.to_added_qkv.\2",
+                1,
+                3,
+            ),
+            r"^(.*\.attn)\.add_v_proj\.(.+)$": (
+                r"\1.to_added_qkv.\2",
+                2,
+                3,
+            ),
             # LoRA mappings
             r"^(transformer_blocks\.\d+\.attn\..*\.lora_[AB])\.default$": r"\1",
             # SVDquant mappings

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -576,7 +576,9 @@ class QwenImageCrossAttention(nn.Module):
             self.norm_k = RMSNorm(head_dim, eps=eps) if qk_norm else nn.Identity()
 
         if added_kv_proj_dim is not None:
-            self.use_fused_added_qkv = isinstance(quant_config, NunchakuConfig)
+            self.use_fused_added_qkv = quant_config is None or isinstance(
+                quant_config, NunchakuConfig
+            )
             if self.use_fused_added_qkv:
                 self.to_added_qkv = MergedColumnParallelLinear(
                     added_kv_proj_dim,

--- a/test/registered/unit/models/test_qwen_image_fused_qkv.py
+++ b/test/registered/unit/models/test_qwen_image_fused_qkv.py
@@ -1,0 +1,81 @@
+"""CPU-only coverage for Qwen-Image fused QKV projection wiring."""
+
+import unittest
+from unittest.mock import patch
+
+from torch import nn
+
+import sglang.multimodal_gen.runtime.models.dits.qwen_image as qwen_image
+from sglang.multimodal_gen.configs.models.dits.qwenimage import QwenImageArchConfig
+from sglang.multimodal_gen.runtime.loader.utils import get_param_names_mapping
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _ModuleStub(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+
+
+class TestQwenImageFusedQKV(CustomTestCase):
+    def _make_attention(self, quant_config):
+        with (
+            patch.object(qwen_image, "get_tp_world_size", return_value=2),
+            patch.object(qwen_image, "MergedColumnParallelLinear", _ModuleStub),
+            patch.object(qwen_image, "ColumnParallelLinear", _ModuleStub),
+            patch.object(qwen_image, "RowParallelLinear", _ModuleStub),
+            patch.object(qwen_image, "RMSNorm", _ModuleStub),
+            patch.object(qwen_image, "USPAttention", _ModuleStub),
+        ):
+            return qwen_image.QwenImageCrossAttention(
+                dim=16,
+                num_heads=4,
+                head_dim=4,
+                added_kv_proj_dim=16,
+                context_pre_only=False,
+                quant_config=quant_config,
+                prefix="transformer_blocks.0.attn",
+            )
+
+    def test_unquantized_attention_merges_only_text_projection(self):
+        attention = self._make_attention(quant_config=None)
+
+        self.assertFalse(attention.use_fused_qkv)
+        self.assertTrue(attention.use_fused_added_qkv)
+        self.assertIsInstance(attention.to_q, _ModuleStub)
+        self.assertIsInstance(attention.to_added_qkv, _ModuleStub)
+        self.assertFalse(hasattr(attention, "to_qkv"))
+        self.assertFalse(hasattr(attention, "add_q_proj"))
+
+    def test_other_quantization_keeps_unfused_projections(self):
+        attention = self._make_attention(quant_config=object())
+
+        self.assertFalse(attention.use_fused_qkv)
+        self.assertFalse(attention.use_fused_added_qkv)
+        self.assertIsInstance(attention.to_q, _ModuleStub)
+        self.assertIsInstance(attention.add_q_proj, _ModuleStub)
+        self.assertFalse(hasattr(attention, "to_qkv"))
+        self.assertFalse(hasattr(attention, "to_added_qkv"))
+
+    def test_checkpoint_projection_rules_merge_in_qkv_order(self):
+        mapping = get_param_names_mapping(QwenImageArchConfig().param_names_mapping)
+
+        cases = (
+            ("add_q_proj", "to_added_qkv", 0),
+            ("add_k_proj", "to_added_qkv", 1),
+            ("add_v_proj", "to_added_qkv", 2),
+        )
+        for source, target, merge_index in cases:
+            with self.subTest(source=source):
+                mapped, actual_index, merge_count = mapping(
+                    f"transformer_blocks.0.attn.{source}.weight"
+                )
+                self.assertEqual(mapped, f"transformer_blocks.0.attn.{target}.weight")
+                self.assertEqual(actual_index, merge_index)
+                self.assertEqual(merge_count, 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Qwen-Image projects the short text stream with three separate tensor-parallel Q/K/V GEMMs in every transformer block. vLLM-Omni uses one merged QKV projection. A torch-profiler comparison on 2x H200 showed that merging only the short text branch removes two small split-K launches per block without exposing the large image stream to packed-view materialization costs.

This PR is intentionally separate from the bitwise attention packing optimization because a merged BF16 GEMM changes reduction association.

## Modifications

- Use `MergedColumnParallelLinear` for the unquantized Qwen-Image added/text QKV projection.
- Add checkpoint mappings that merge Diffusers `add_q_proj`, `add_k_proj`, and `add_v_proj` weights in Q/K/V order.
- Preserve the existing unfused layout for other quantization backends; Nunchaku remains on its existing fused path.
- Add CPU-only wiring and loader-mapping tests.

## Accuracy Tests

Validated on the latest main used for this PR (`b647ae8`) and 2x NVIDIA H200:

- `python3 test/registered/unit/models/test_qwen_image_fused_qkv.py`: 3 passed.
- Five repeated candidate generations were deterministic and byte-identical to each other.
- Versus the separate-GEMM BF16 baseline: pixel MAE 1.393/255, PSNR 40.55 dB. The difference is expected from GEMM reduction-order reassociation; no model weights or mathematical operation change.

This remains a Draft so maintainers can decide whether that BF16 numerical delta is acceptable for the default speed path.

## Speed Tests and Profiling

Environment: 2x H200, TP=2, Qwen/Qwen-Image-2512, 1024x1024, 50 steps, guidance=1, BCG enabled, torch.compile disabled. The incremental A/B used the same CustomAllReduceV2 stack on both sides.

- Steady denoise baseline: 78.5-78.8 ms/step.
- Text-QKV candidate: 78.0-78.5 ms/step (78.2 ms median), about 0.4 ms/step / 0.5% faster.
- Torch trace: removed 1,212 split-K GEMMs (7.606 ms) and 1,212 split-K reductions (3.108 ms); added 403 merged GEMMs (4.797 ms) and the expected packed-slice copies (3.161 ms).
- Isolated projection microbench, CUDA graph: text seq=64 separate 31 us vs merged 13 us. The large image branch is deliberately left unfused because full-model A/B showed it regressed denoise to about 82 ms/step.

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add unit tests according to the contribution guide.
- [ ] Update documentation according to the contribution guide (no user-facing API or flag change).
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

Background benchmark investigation: https://github.com/BBuf/how-to-optim-algorithm-in-cuda/issues/21

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33069116662](https://github.com/sgl-project/sglang/actions/runs/33069116662)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33069116477](https://github.com/sgl-project/sglang/actions/runs/33069116477)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33069116717](https://github.com/sgl-project/sglang/actions/runs/33069116717)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->