### PR TITLE
[Diffusion] Optimize segmented varlen attention packing

### DIFF
--- a/python/sglang/kernels/ops/diffusion/README.md
+++ b/python/sglang/kernels/ops/diffusion/README.md
@@ -126,7 +126,8 @@ Several norms look interchangeable and are not. Start here.
 ### Data movement (all bit-exact by construction)
 
 `usp_merge_heads`, `pack_qkv_destination_major`, `fused_pack_qkv`,
-`fused_scatter_to_padded`, `fused_causal_conv3d_cat_pad_cuda`,
+`fused_pack_segmented_qkv`, `fused_scatter_to_padded`,
+`fused_causal_conv3d_cat_pad_cuda`,
 `cat_pad_channels_last_3d`, `dup_up3d_add`, `fused_temb_table_slices`,
 `ltx2_ada_values9`.
 

--- a/python/sglang/kernels/ops/diffusion/__init__.py
+++ b/python/sglang/kernels/ops/diffusion/__init__.py
@@ -292,6 +292,13 @@ _SPECS: tuple[tuple[str, KernelBackend, str, frozenset, str], ...] = (
         "Varlen gather of Q/K/V at valid positions.",
     ),
     (
+        "diffusion.varlen_pack_segmented_qkv",
+        KernelBackend.TRITON,
+        "layout.varlen_pack_pad_triton:fused_pack_segmented_qkv",
+        _CUDA,
+        "Varlen gather from a virtual prefix/main Q/K/V sequence.",
+    ),
+    (
         "diffusion.varlen_scatter_to_padded",
         KernelBackend.TRITON,
         "layout.varlen_pack_pad_triton:fused_scatter_to_padded",
@@ -435,6 +442,7 @@ _EXPORTS: dict[str, str] = {
     "usp_merge_heads": "layout.usp_relayout_jit",
     "build_inv_indices": "layout.varlen_pack_pad_triton",
     "fused_pack_qkv": "layout.varlen_pack_pad_triton",
+    "fused_pack_segmented_qkv": "layout.varlen_pack_pad_triton",
     "fused_scatter_to_padded": "layout.varlen_pack_pad_triton",
     "cat_pad_channels_last_3d": "layout.wan_causal_cache_triton",
     "dup_up3d_add": "layout.wan_causal_cache_triton",

--- a/python/sglang/kernels/ops/diffusion/layout/varlen_pack_pad_triton.py
+++ b/python/sglang/kernels/ops/diffusion/layout/varlen_pack_pad_triton.py
@@ -107,6 +107,120 @@ def fused_pack_qkv(
     )
 
 
+@triton.jit
+def _fused_pack_segmented_qkv_kernel(
+    Q_prefix_ptr,
+    K_prefix_ptr,
+    V_prefix_ptr,
+    Q_main_ptr,
+    K_main_ptr,
+    V_main_ptr,
+    Q_unpad_ptr,
+    K_unpad_ptr,
+    V_unpad_ptr,
+    indices_ptr,
+    PREFIX_ROWS,
+    MAIN_ROWS,
+    HD,
+    prefix_row_stride,
+    main_row_stride,
+    dst_row_stride,
+    BLOCK_HD: tl.constexpr,
+):
+    """Pack a virtual ``[prefix, main]`` sequence without materializing it."""
+    out_row = tl.program_id(0)
+    src_row = tl.load(indices_ptr + out_row).to(tl.int64)
+    joint_rows = PREFIX_ROWS + MAIN_ROWS
+    batch = src_row // joint_rows
+    row_in_batch = src_row - batch * joint_rows
+    from_prefix = row_in_batch < PREFIX_ROWS
+
+    prefix_row = batch * PREFIX_ROWS + row_in_batch
+    main_row = batch * MAIN_ROWS + row_in_batch - PREFIX_ROWS
+    cols = tl.arange(0, BLOCK_HD)
+    col_mask = cols < HD
+    prefix_mask = col_mask & from_prefix
+    main_mask = col_mask & ~from_prefix
+
+    prefix_offset = prefix_row * prefix_row_stride + cols
+    main_offset = main_row * main_row_stride + cols
+    dst_offset = out_row * dst_row_stride + cols
+
+    q_val = tl.load(Q_prefix_ptr + prefix_offset, mask=prefix_mask, other=0.0)
+    k_val = tl.load(K_prefix_ptr + prefix_offset, mask=prefix_mask, other=0.0)
+    v_val = tl.load(V_prefix_ptr + prefix_offset, mask=prefix_mask, other=0.0)
+    q_val += tl.load(Q_main_ptr + main_offset, mask=main_mask, other=0.0)
+    k_val += tl.load(K_main_ptr + main_offset, mask=main_mask, other=0.0)
+    v_val += tl.load(V_main_ptr + main_offset, mask=main_mask, other=0.0)
+
+    tl.store(Q_unpad_ptr + dst_offset, q_val, mask=col_mask)
+    tl.store(K_unpad_ptr + dst_offset, k_val, mask=col_mask)
+    tl.store(V_unpad_ptr + dst_offset, v_val, mask=col_mask)
+
+
+def fused_pack_segmented_qkv(
+    q_prefix: torch.Tensor,
+    k_prefix: torch.Tensor,
+    v_prefix: torch.Tensor,
+    q_main: torch.Tensor,
+    k_main: torch.Tensor,
+    v_main: torch.Tensor,
+    indices: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pack Q/K/V from a virtual ``[prefix, main]`` joint sequence.
+
+    This is bitwise equivalent to concatenating each prefix/main pair and
+    calling :func:`fused_pack_qkv`, but skips the three dense concatenations.
+    All inputs use ``[B, S, H, D]`` layout and share batch/head dimensions.
+    """
+    prefixes = (q_prefix, k_prefix, v_prefix)
+    mains = (q_main, k_main, v_main)
+    assert q_prefix.shape == k_prefix.shape == v_prefix.shape
+    assert q_main.shape == k_main.shape == v_main.shape
+    assert q_prefix.dim() == q_main.dim() == 4
+    assert q_prefix.shape[0] == q_main.shape[0]
+    assert q_prefix.shape[2:] == q_main.shape[2:]
+    assert all(t.dtype == q_prefix.dtype for t in (*prefixes, *mains))
+    assert indices.dtype in (torch.int32, torch.int64)
+
+    q_prefix, k_prefix, v_prefix = (t.contiguous() for t in prefixes)
+    q_main, k_main, v_main = (t.contiguous() for t in mains)
+    prefixes = (q_prefix, k_prefix, v_prefix)
+    mains = (q_main, k_main, v_main)
+    batch_size, prefix_rows, num_heads, head_dim = q_prefix.shape
+    main_rows = q_main.shape[1]
+    hd = num_heads * head_dim
+    n_valid = indices.shape[0]
+    if n_valid == 0:
+        return tuple(
+            t.new_empty(0, num_heads, head_dim) for t in (q_prefix, k_prefix, v_prefix)
+        )
+
+    prefix_flat = tuple(t.view(batch_size * prefix_rows, hd) for t in prefixes)
+    main_flat = tuple(t.view(batch_size * main_rows, hd) for t in mains)
+    outputs = tuple(
+        torch.empty(n_valid, hd, dtype=q_prefix.dtype, device=q_prefix.device)
+        for _ in range(3)
+    )
+    block_hd = triton.next_power_of_2(hd)
+    with torch.get_device_module().device(q_prefix.device):
+        _fused_pack_segmented_qkv_kernel[(n_valid,)](
+            *prefix_flat,
+            *main_flat,
+            *outputs,
+            indices,
+            prefix_rows,
+            main_rows,
+            hd,
+            prefix_flat[0].stride(0),
+            main_flat[0].stride(0),
+            outputs[0].stride(0),
+            BLOCK_HD=block_hd,
+        )
+
+    return tuple(out.view(n_valid, num_heads, head_dim) for out in outputs)
+
+
 # ---------------------------------------------------------------------------
 # Scatter (pad) — write packed output to [B, S, H, D] with zeros at invalid
 # ---------------------------------------------------------------------------

--- a/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/layer.py
@@ -15,6 +15,7 @@ from sglang.kernels.ops.attention.flash_attention import flash_attn_varlen_func
 from sglang.kernels.ops.diffusion import (
     build_inv_indices,
     fused_pack_qkv,
+    fused_pack_segmented_qkv,
     fused_scatter_to_padded,
 )
 from sglang.multimodal_gen.runtime.breakable_cuda_graph.replay_token import (
@@ -827,6 +828,9 @@ class USPAttention(nn.Module):
         attn_mask_meta: dict | None = None,
         qkv_pre_all_to_all: bool = False,
         seq_lens: list[int] | None = None,
+        q_prefix: torch.Tensor | None = None,
+        k_prefix: torch.Tensor | None = None,
+        v_prefix: torch.Tensor | None = None,
     ) -> torch.Tensor:
         """
         Forward pass for USPAttention.
@@ -888,6 +892,18 @@ class USPAttention(nn.Module):
 
         if isinstance(attn_mask_meta, DynamicVarlenMaskMeta):
             attn_mask_meta = attn_mask_meta.resolve(attn_mask)
+
+        segmented_prefix = q_prefix is not None
+        if segmented_prefix != (k_prefix is not None) or segmented_prefix != (
+            v_prefix is not None
+        ):
+            raise ValueError("q_prefix, k_prefix, and v_prefix must be set together")
+        if segmented_prefix and not (
+            effective_skip_sp or get_sequence_parallel_world_size() == 1
+        ):
+            raise NotImplementedError(
+                "Segmented QKV input currently supports only the local attention path."
+            )
 
         # Tail-pad meta alone (sp_shard.tail_attn_meta; mask derivable from the
         # pad span) also opts into the masked SP branch. gap_* = legacy alias.
@@ -991,9 +1007,20 @@ class USPAttention(nn.Module):
                     and q.device.type == "cuda"
                     and attn_mask.device == q.device
                     and q.dtype in (torch.float16, torch.bfloat16)
-                    and q.shape[:2] == attn_mask.shape == k.shape[:2] == v.shape[:2]
+                    and (
+                        (q.shape[0], q.shape[1] + q_prefix.shape[1])
+                        if segmented_prefix
+                        else q.shape[:2]
+                    )
+                    == attn_mask.shape
+                    and q.shape == k.shape == v.shape
+                    and (
+                        not segmented_prefix
+                        or q_prefix.shape == k_prefix.shape == v_prefix.shape
+                    )
                 ):
-                    bs, seq = q.shape[0], q.shape[1]
+                    bs = q.shape[0]
+                    seq = q.shape[1] + (q_prefix.shape[1] if segmented_prefix else 0)
                     indices = attn_mask_meta["indices"]
                     cu_seqlens = attn_mask_meta["cu_seqlens"]
                     max_seqlen = attn_mask_meta["max_seqlen"]
@@ -1008,7 +1035,46 @@ class USPAttention(nn.Module):
                     # (Joint attention with an image side is always non-empty
                     # in practice, so this only guards malformed inputs.)
                     if indices.shape[0] > 0:
-                        q_unpad, k_unpad, v_unpad = fused_pack_qkv(q, k, v, indices)
+                        all_valid = indices.shape[0] == bs * seq
+                        if segmented_prefix:
+                            q_unpad, k_unpad, v_unpad = fused_pack_segmented_qkv(
+                                q_prefix,
+                                k_prefix,
+                                v_prefix,
+                                q,
+                                k,
+                                v,
+                                indices,
+                            )
+                        else:
+                            if all_valid:
+                                q_unpad, k_unpad, v_unpad = q, k, v
+                            else:
+                                q_unpad, k_unpad, v_unpad = fused_pack_qkv(
+                                    q, k, v, indices
+                                )
+                        if bs == 1 or all_valid:
+                            # Empty cu_seqlens selects FA3's faster static
+                            # persistent scheduler. A single packed sequence is
+                            # dense even when its BCG bucket contains padding.
+                            dense_seq = indices.shape[0] if bs == 1 else seq
+                            out_dense = flash_attn_varlen_func(
+                                q=q_unpad.reshape(bs, dense_seq, *q_unpad.shape[-2:]),
+                                k=k_unpad.reshape(bs, dense_seq, *k_unpad.shape[-2:]),
+                                v=v_unpad.reshape(bs, dense_seq, *v_unpad.shape[-2:]),
+                                cu_seqlens_q=None,
+                                cu_seqlens_k=None,
+                                max_seqlen_q=dense_seq,
+                                max_seqlen_k=dense_seq,
+                                softmax_scale=self.softmax_scale,
+                                causal=False,
+                                ver=_fa_backend.fa_ver,
+                            )
+                            if all_valid:
+                                return out_dense
+                            return fused_scatter_to_padded(
+                                out_dense.flatten(0, 1), inv_indices, bs, seq
+                            )
                         out_unpad = flash_attn_varlen_func(
                             q=q_unpad,
                             k=k_unpad,
@@ -1022,6 +1088,11 @@ class USPAttention(nn.Module):
                             ver=_fa_backend.fa_ver,
                         )
                         return fused_scatter_to_padded(out_unpad, inv_indices, bs, seq)
+
+                if segmented_prefix:
+                    q = torch.cat([q_prefix, q], dim=1)
+                    k = torch.cat([k_prefix, k], dim=1)
+                    v = torch.cat([v_prefix, v], dim=1)
 
                 q_ = q.transpose(1, 2)
                 k_ = k.transpose(1, 2)

--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -747,6 +747,17 @@ class QwenImageCrossAttention(nn.Module):
 
         # Joint order [text, image]; join_seqs relocates any SP text tail-pad
         # behind the image (see sp_shard.join_seqs for why).
+        if attn_mask is None and encoder_hidden_states_mask is not None:
+            image_mask = torch.ones(
+                (hidden_states.shape[0], img_query.shape[1]),
+                device=encoder_hidden_states_mask.device,
+                dtype=torch.bool,
+            )
+            attn_mask = torch.cat(
+                [encoder_hidden_states_mask.to(dtype=torch.bool), image_mask],
+                dim=1,
+            )
+
         seg_qkv = None
         # The segmented pre-all-to-all emits Ulysses layout; K/V-gather takes
         # the join_seqs path and exchanges inside the attention instead.
@@ -766,20 +777,15 @@ class QwenImageCrossAttention(nn.Module):
             )
         if seg_qkv is not None:
             joint_query, joint_key, joint_value = seg_qkv
+        elif attn_mask is not None and not sp_text_sharded:
+            # Let the eager attention break point pack directly from the text
+            # and image segments. Materializing three dense joint tensors here
+            # only to gather their valid rows again wastes one launch per Q/K/V.
+            joint_query, joint_key, joint_value = img_query, img_key, img_value
         else:
             joint_query = join_seqs(txt_query, img_query, sp_txt_pad)
             joint_key = join_seqs(txt_key, img_key, sp_txt_pad)
             joint_value = join_seqs(txt_value, img_value, sp_txt_pad)
-        if attn_mask is None and encoder_hidden_states_mask is not None:
-            image_mask = torch.ones(
-                (hidden_states.shape[0], img_query.shape[1]),
-                device=encoder_hidden_states_mask.device,
-                dtype=torch.bool,
-            )
-            attn_mask = torch.cat(
-                [encoder_hidden_states_mask.to(dtype=torch.bool), image_mask],
-                dim=1,
-            )
 
         # Compute joint attention
         joint_hidden_states = self.attn(
@@ -790,6 +796,15 @@ class QwenImageCrossAttention(nn.Module):
             attn_mask_meta=attn_mask_meta,
             num_replicated_prefix=0 if sp_text_sharded else seq_len_txt,
             qkv_pre_all_to_all=seg_qkv is not None,
+            q_prefix=(
+                txt_query if attn_mask is not None and not sp_text_sharded else None
+            ),
+            k_prefix=(
+                txt_key if attn_mask is not None and not sp_text_sharded else None
+            ),
+            v_prefix=(
+                txt_value if attn_mask is not None and not sp_text_sharded else None
+            ),
         )
 
         # Reshape back

--- a/test/registered/kernels/benchmark/diffusion/bench_varlen_segmented_pack.py
+++ b/test/registered/kernels/benchmark/diffusion/bench_varlen_segmented_pack.py
@@ -1,0 +1,95 @@
+import torch
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.ops.diffusion import fused_pack_qkv, fused_pack_segmented_qkv
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=12, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+DEVICE = "cuda"
+DTYPE = torch.bfloat16
+
+
+def _materialized_pack(q_prefix, k_prefix, v_prefix, q_main, k_main, v_main, indices):
+    return fused_pack_qkv(
+        torch.cat([q_prefix, q_main], dim=1),
+        torch.cat([k_prefix, k_main], dim=1),
+        torch.cat([v_prefix, v_main], dim=1),
+        indices,
+    )
+
+
+def _segmented_pack(q_prefix, k_prefix, v_prefix, q_main, k_main, v_main, indices):
+    return fused_pack_segmented_qkv(
+        q_prefix, k_prefix, v_prefix, q_main, k_main, v_main, indices
+    )
+
+
+@marker.parametrize(
+    "batch,prefix_rows,main_rows,heads,head_dim,valid_prefix_rows",
+    [
+        (1, 64, 4096, 12, 128, 24),
+        (2, 64, 1024, 8, 128, 40),
+    ],
+    ci_vals=[(1, 64, 4096, 12, 128, 24)],
+)
+@marker.benchmark("provider", ["materialized", "segmented"])
+def benchmark(
+    batch: int,
+    prefix_rows: int,
+    main_rows: int,
+    heads: int,
+    head_dim: int,
+    valid_prefix_rows: int,
+    provider: str,
+) -> marker.BenchResult:
+    generator = torch.Generator(device=DEVICE).manual_seed(42)
+    prefixes = tuple(
+        torch.randn(
+            batch,
+            prefix_rows,
+            heads,
+            head_dim,
+            dtype=DTYPE,
+            device=DEVICE,
+            generator=generator,
+        )
+        for _ in range(3)
+    )
+    mains = tuple(
+        torch.randn(
+            batch,
+            main_rows,
+            heads,
+            head_dim,
+            dtype=DTYPE,
+            device=DEVICE,
+            generator=generator,
+        )
+        for _ in range(3)
+    )
+    mask = torch.zeros(batch, prefix_rows + main_rows, dtype=torch.bool, device=DEVICE)
+    mask[:, :valid_prefix_rows] = True
+    mask[:, prefix_rows:] = True
+    indices = mask.flatten().nonzero(as_tuple=False).flatten()
+    args = (*prefixes, *mains, indices)
+
+    expected = _materialized_pack(*args)
+    actual = _segmented_pack(*args)
+    assert all(
+        torch.equal(got, want) for got, want in zip(actual, expected, strict=True)
+    )
+
+    fn = _materialized_pack if provider == "materialized" else _segmented_pack
+    return marker.do_bench(
+        fn,
+        input_args=args,
+        graph_clone_args=tuple(range(len(args))),
+        disable_log_bandwidth=True,
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/ops/diffusion/test_layout.py
+++ b/test/registered/kernels/ops/diffusion/test_layout.py
@@ -31,6 +31,7 @@ from sglang.kernels.ops.diffusion import (
 from sglang.kernels.ops.diffusion import (
     fused_causal_conv3d_cat_pad_cuda,
     fused_pack_qkv,
+    fused_pack_segmented_qkv,
     fused_scatter_to_padded,
     pack_qkv_destination_major,
     usp_merge_heads,
@@ -213,6 +214,28 @@ def test_varlen_pack_matches_index_select(dtype, shape):
 
 @pytest.mark.parametrize("dtype", VARLEN_DTYPES)
 @pytest.mark.parametrize("shape", VARLEN_SHAPES, ids=lambda s: s[0])
+def test_varlen_segmented_pack_matches_materialized_joint(dtype, shape):
+    _, bs, s_txt, s_img, num_heads, head_dim, valid_txt_lens = shape
+    torch.manual_seed(42)
+    indices, _ = _build_meta(_build_mask(bs, s_txt, s_img, valid_txt_lens))
+    txt_qkv = tuple(
+        torch.randn(bs, s_txt, num_heads, head_dim, dtype=dtype, device=DEVICE)
+        for _ in range(3)
+    )
+    img_qkv = tuple(
+        torch.randn(bs, s_img, num_heads, head_dim, dtype=dtype, device=DEVICE)
+        for _ in range(3)
+    )
+
+    got = fused_pack_segmented_qkv(*txt_qkv, *img_qkv, indices)
+    for actual, txt, img in zip(got, txt_qkv, img_qkv, strict=True):
+        joint = torch.cat([txt, img], dim=1)
+        expected = joint.flatten(0, 1).index_select(0, indices)
+        assert torch.equal(actual, expected)
+
+
+@pytest.mark.parametrize("dtype", VARLEN_DTYPES)
+@pytest.mark.parametrize("shape", VARLEN_SHAPES, ids=lambda s: s[0])
 def test_varlen_scatter_matches_index_copy(dtype, shape):
     _, bs, s_txt, s_img, num_heads, head_dim, valid_txt_lens = shape
     torch.manual_seed(1)
@@ -342,6 +365,45 @@ def _varlen_path(q, k, v, key_mask, softmax_scale):
         # unit-wise above on every lane.
         pytest.skip(f"FlashAttention varlen v{_fa_backend.fa_ver} unavailable: {exc}")
     return fused_scatter_to_padded(out_unpad, meta["inv_indices"], bs, seq)
+
+
+@pytest.mark.parametrize("dtype", VARLEN_DTYPES)
+def test_fa_dense_scheduler_matches_single_sequence_varlen(dtype):
+    torch.manual_seed(7)
+    batch_size, seq, num_heads, head_dim = 1, 256, 4, 128
+    q, k, v = (
+        torch.randn(
+            batch_size,
+            seq,
+            num_heads,
+            head_dim,
+            dtype=dtype,
+            device=DEVICE,
+        )
+        for _ in range(3)
+    )
+    cu_seqlens = torch.tensor([0, seq], dtype=torch.int32, device=DEVICE)
+    kwargs = dict(
+        max_seqlen_q=seq,
+        max_seqlen_k=seq,
+        softmax_scale=head_dim**-0.5,
+        causal=False,
+        ver=_fa_backend.fa_ver,
+    )
+    try:
+        varlen = flash_attn_varlen_func(
+            q.flatten(0, 1),
+            k.flatten(0, 1),
+            v.flatten(0, 1),
+            cu_seqlens,
+            cu_seqlens,
+            **kwargs,
+        ).view_as(q)
+        dense = flash_attn_varlen_func(q, k, v, None, None, **kwargs)
+    except ImportError as exc:  # pragma: no cover - image-dependent
+        pytest.skip(f"FlashAttention unavailable: {exc}")
+
+    torch.testing.assert_close(dense, varlen, rtol=1e-3, atol=1e-3)
 
 
 @pytest.mark.parametrize("dtype", VARLEN_DTYPES)


### PR DESCRIPTION
## Motivation

Qwen-Image joint attention keeps text and image Q/K/V in separate tensors, then materializes three `[text, image]` concatenations before the masked varlen path immediately gathers the valid rows again. On a 1024x1024 Qwen-Image-2512 request this adds three dense copies in every one of the 60 transformer blocks.

The same profile also showed that batch-1 packed attention used FA3's `VarlenDynamicPersistent` scheduler while vLLM-Omni used the faster `StaticPersistent` scheduler for the equivalent single sequence.

## Modifications

- Add a bitwise segmented Triton pack that reads a virtual `[prefix, main]` Q/K/V sequence without materializing the three concatenations.
- Let `USPAttention` accept an optional Q/K/V prefix on its local masked FA path.
- Use dense FA3 scheduling for a single packed sequence, then scatter back into the BCG bucket.
- Route Qwen-Image's masked TP path through segmented packing.
- Add registered H100/H200 kernel correctness coverage and a production-shape benchmark.
- Document/export the new diffusion data-movement kernel.

## Accuracy Tests

Validated on the latest main used for this PR (`b647ae8`) and 2x NVIDIA H200:

- `pytest -q test/registered/kernels/ops/diffusion/test_layout.py -k "segmented_pack or dense_scheduler"`: 16 passed.
- Segmented packing is bitwise equal to materialized `torch.cat` + `fused_pack_qkv` across BF16/FP16 and batch/shape variants.
- Five Qwen-Image-2512 1024x1024, seed-42 model outputs were byte-identical to the baseline. SHA256 for every measured output: `862fd0c4fbaf443a5595058255e665ff0bd801f7e7cafc1b1f115a16df10161b`.

## Speed Tests and Profiling

Environment: 2x H200, TP=2, Qwen/Qwen-Image-2512, 1024x1024, 50 steps, guidance=1, BCG enabled, torch.compile disabled. The incremental A/B used the same CustomAllReduceV2 stack on both sides.

- Kernel microbenchmark, Qwen production shape `[B=1, text=64, image=4096, H=12, D=128]`: materialized 47.74 us, segmented 21.11 us (2.26x faster).
- Steady denoise: baseline 78.5-78.8 ms/step; segmented pack 77.1-77.5 ms/step; segmented pack + static FA 77.0-77.3 ms/step.
- Torch profiler: 1,212 `CatArrayBatchedCopy` calls / 10.768 ms disappeared from a 402-attention-call trace. The replacement segmented pack costs 18.0 us/call, matching the old pack itself.
- FA3 moved from `VarlenDynamicPersistent` 159.4 us plus `prepare_varlen_num_blocks` 3.44 us to `StaticPersistent` 147.1 us, matching vLLM-Omni's measured 147.4 us.

## Checklist

- [x] Format your code according to the contribution guide.
- [x] Add unit tests according to the contribution guide.
- [x] Update documentation according to the contribution guide.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

Background benchmark investigation: https://github.com/BBuf/how-to-optim-algorithm-in-cuda/issues/21

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33069117658](https://github.com/sgl-project/sglang/actions/runs/33069117658)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33069117413](https://github.com/sgl-project/sglang/actions/runs/33069117413)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33069117562](https://github.com/sgl-project/sglang/actions/runs/33069117562)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->