### PR TITLE
[Fix] step3: parameterless tool calls are dropped, batched calls get mixed up

### DIFF
--- a/python/sglang/srt/function_call/step3_detector.py
+++ b/python/sglang/srt/function_call/step3_detector.py
@@ -66,9 +66,11 @@ class Step3Detector(BaseFormatDetector):
         self.tool_call_end = "<｜tool_call_end｜>"
         self.tool_sep = "<｜tool_sep｜>"
 
-        # Regex for parsing steptml invocations
+        # Regex for parsing steptml invocations. The body is (.*?) rather than
+        # (.+?) so that a call with no parameters — where nothing sits between
+        # the invoke tags — still matches instead of being dropped entirely.
         self.invoke_regex = re.compile(
-            r'<steptml:invoke name="([^"]+)">(.+?)</steptml:invoke>', re.DOTALL
+            r'<steptml:invoke name="([^"]+)">(.*?)</steptml:invoke>', re.DOTALL
         )
         self.param_regex = re.compile(
             r'<steptml:parameter name="([^"]+)">([^<]*)</steptml:parameter>', re.DOTALL
@@ -209,21 +211,37 @@ class Step3Detector(BaseFormatDetector):
 
         # Check if tool block is ending
         if self.eot_token in self._buffer:
-            idx = self._buffer.find(self.eot_token)
-
-            # If we're in the middle of a tool call, we need to handle it
-            if self._in_tool_call:
-                # The buffer before eot_token might contain the end of the current tool call
+            # Drain every complete tool call still sitting before the end token,
+            # not just one that is already in progress. When several tokens (or a
+            # whole response) arrive in a single increment, the calls have not
+            # been started yet, and they used to be discarded together with the
+            # buffer.
+            while True:
+                idx = self._buffer.find(self.eot_token)
                 before_eot = self._buffer[:idx]
-                if self.tool_call_end in before_eot:
-                    # Parse this final tool call
-                    result = self._parse_partial_tool_call(tools)
-                    calls.extend(result.calls)
-                else:
-                    # Incomplete tool call - log warning
-                    logger.warning("Tool block ended with incomplete tool call")
+                if self.tool_call_end not in before_eot:
+                    break
+                if not self._in_tool_call:
+                    if self.tool_call_begin not in before_eot:
+                        break
+                    begin_idx = before_eot.find(self.tool_call_begin)
+                    self._buffer = self._buffer[begin_idx + len(self.tool_call_begin) :]
+                    self._in_tool_call = True
+                    self._function_name_sent = False
+                    self._current_function_name = ""
+                    self._current_parameters = {}
+                calls.extend(self._parse_partial_tool_call(tools).calls)
+                if self._in_tool_call:
+                    # _parse_partial_tool_call clears this once a call completes;
+                    # still set means no progress, so stop instead of looping.
+                    break
 
-            remaining = self._buffer[idx + len(self.eot_token) :]
+            idx = self._buffer.find(self.eot_token)
+            if self._in_tool_call:
+                # Incomplete tool call - log warning
+                logger.warning("Tool block ended with incomplete tool call")
+
+            remaining = self._buffer[idx + len(self.eot_token) :] if idx != -1 else ""
             self._buffer = ""
             self._tool_block_finished = True
 
@@ -266,6 +284,13 @@ class Step3Detector(BaseFormatDetector):
             # Invalid tool type, skip this tool call
             self._reset_streaming_state()
             return StreamingParseResult(calls=calls)
+
+        # Restrict parsing to the call currently being processed. The buffer can
+        # already hold later calls when several tokens arrive in one increment,
+        # and their parameters would otherwise be absorbed into this call.
+        current_call_end = invoke_part.find(self.tool_call_end)
+        if current_call_end != -1:
+            invoke_part = invoke_part[:current_call_end]
 
         # Try to extract function name if not sent yet
         if not self._function_name_sent:
@@ -380,6 +405,18 @@ class Step3Detector(BaseFormatDetector):
                         )
                     )
                     self.streamed_args_for_tool[self.current_tool_id] += "}"
+                else:
+                    # A call with no parameters streams nothing above, because the
+                    # parameter dict never changes. Emit the empty object so the
+                    # streamed arguments parse as JSON and match detect_and_parse,
+                    # which returns "{}".
+                    calls.append(
+                        ToolCallItem(
+                            tool_index=self.current_tool_id,
+                            parameters="{}",
+                        )
+                    )
+                    self.streamed_args_for_tool[self.current_tool_id] = "{}"
 
                 # Find the end position
                 end_idx = self._buffer.find(self.tool_call_end)

--- a/test/registered/unit/function_call/test_step3_detector.py
+++ b/test/registered/unit/function_call/test_step3_detector.py
@@ -1,0 +1,227 @@
+"""Unit tests for Step3Detector — no server, no model loading.
+
+Covers parsing of calls that take no parameters, and streaming/non-streaming
+equivalence when several calls arrive in the same increment.
+"""
+
+import json
+
+from sglang.srt.entrypoints.openai.protocol import Function, Tool
+from sglang.srt.function_call.step3_detector import Step3Detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(1.0, "base-a-test-cpu")
+
+TOOL_CALLS_BEGIN = "<｜tool_calls_begin｜>"
+TOOL_CALLS_END = "<｜tool_calls_end｜>"
+TOOL_CALL_BEGIN = "<｜tool_call_begin｜>"
+TOOL_CALL_END = "<｜tool_call_end｜>"
+TOOL_SEP = "<｜tool_sep｜>"
+
+
+def _block(name, params=""):
+    return (
+        f"{TOOL_CALL_BEGIN}function{TOOL_SEP}"
+        f'<steptml:invoke name="{name}">{params}</steptml:invoke>'
+        f"{TOOL_CALL_END}"
+    )
+
+
+def _param(name, value):
+    return f'<steptml:parameter name="{name}">{value}</steptml:parameter>'
+
+
+def _wrap(*blocks):
+    return TOOL_CALLS_BEGIN + "".join(blocks) + TOOL_CALLS_END
+
+
+class TestStep3Detector(CustomTestCase):
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather information",
+                    parameters={
+                        "type": "object",
+                        "properties": {
+                            "city": {"type": "string"},
+                            "days": {"type": "integer"},
+                        },
+                    },
+                ),
+            ),
+            Tool(
+                type="function",
+                function=Function(
+                    name="noop",
+                    description="Takes no arguments",
+                    parameters={"type": "object", "properties": {}},
+                ),
+            ),
+        ]
+
+    # ---------------- non-streaming ----------------
+
+    def test_parses_call_without_parameters(self):
+        # Regression: the invoke regex required at least one character between
+        # the tags, so a parameterless call matched nothing and was dropped.
+        result = Step3Detector().detect_and_parse(
+            _wrap(_block("get_weather")), self.tools
+        )
+        self.assertEqual(len(result.calls), 1)
+        self.assertEqual(result.calls[0].name, "get_weather")
+        self.assertEqual(json.loads(result.calls[0].parameters), {})
+
+    def test_parses_mix_of_parameterless_and_parameterized_calls(self):
+        result = Step3Detector().detect_and_parse(
+            _wrap(
+                _block("get_weather"),
+                _block("get_weather", _param("city", "Beijing")),
+            ),
+            self.tools,
+        )
+        self.assertEqual(len(result.calls), 2)
+        self.assertEqual(json.loads(result.calls[0].parameters), {})
+        self.assertEqual(json.loads(result.calls[1].parameters), {"city": "Beijing"})
+
+    # ---------------- streaming equivalence ----------------
+
+    def _stream(self, chunks):
+        detector = Step3Detector()
+        seq, normal, cur = [], "", None
+
+        def absorb(result):
+            nonlocal normal, cur
+            normal += result.normal_text or ""
+            for call in result.calls:
+                if call.name:
+                    cur = [call.name, ""]
+                    seq.append(cur)
+                if call.parameters:
+                    if cur is None:
+                        cur = ["", ""]
+                        seq.append(cur)
+                    cur[1] += call.parameters
+
+        for chunk in chunks:
+            absorb(detector.parse_streaming_increment(chunk, self.tools))
+        # Drain at end of stream; serving keeps invoking the detector per token.
+        for _ in range(200):
+            result = detector.parse_streaming_increment("", self.tools)
+            if not result.calls and not result.normal_text:
+                break
+            absorb(result)
+
+        return [tuple(x) for x in seq], normal
+
+    def assert_stream_matches_final(self, text):
+        reference = Step3Detector().detect_and_parse(text, self.tools)
+        want = [(c.name, c.parameters) for c in reference.calls]
+        want_normal = (reference.normal_text or "").strip()
+
+        chunkings = {
+            "char": list(text),
+            "whole": [text],
+            "halves": [text[: len(text) // 2], text[len(text) // 2 :]],
+        }
+        for label, chunks in chunkings.items():
+            got, got_normal = self._stream(chunks)
+
+            self.assertEqual(
+                len(got), len(want), f"[{label}] call count differs for {text!r}"
+            )
+            for (g_name, g_args), (w_name, w_args) in zip(got, want):
+                self.assertEqual(g_name, w_name, f"[{label}] name differs")
+                self.assertEqual(
+                    json.loads(g_args) if g_args else None,
+                    json.loads(w_args) if w_args else None,
+                    f"[{label}] arguments differ for {text!r}",
+                )
+
+            for marker in ("steptml", "tool_call"):
+                self.assertNotIn(
+                    marker, got_normal, f"[{label}] {marker!r} leaked into content"
+                )
+            self.assertEqual(
+                got_normal.strip(), want_normal, f"[{label}] normal text differs"
+            )
+
+    def test_stream_single_call_no_parameters(self):
+        self.assert_stream_matches_final(_wrap(_block("get_weather")))
+
+    def test_stream_single_call_one_parameter(self):
+        self.assert_stream_matches_final(
+            _wrap(_block("get_weather", _param("city", "Beijing")))
+        )
+
+    def test_stream_single_call_two_parameters(self):
+        self.assert_stream_matches_final(
+            _wrap(
+                _block("get_weather", _param("city", "Beijing") + _param("days", "3"))
+            )
+        )
+
+    def test_stream_integer_parameter_keeps_type(self):
+        self.assert_stream_matches_final(
+            _wrap(_block("get_weather", _param("days", "7")))
+        )
+
+    def test_stream_unicode_parameter(self):
+        self.assert_stream_matches_final(
+            _wrap(_block("get_weather", _param("city", "北京")))
+        )
+
+    def test_stream_tool_with_empty_schema(self):
+        self.assert_stream_matches_final(_wrap(_block("noop")))
+
+    def test_stream_two_parameterless_calls(self):
+        self.assert_stream_matches_final(
+            _wrap(_block("get_weather"), _block("get_weather"))
+        )
+
+    def test_stream_two_parameterless_calls_different_tools(self):
+        self.assert_stream_matches_final(_wrap(_block("get_weather"), _block("noop")))
+
+    def test_stream_parameterless_then_parameterized(self):
+        self.assert_stream_matches_final(
+            _wrap(_block("get_weather"), _block("get_weather", _param("city", "x")))
+        )
+
+    def test_stream_parameterized_then_parameterless(self):
+        self.assert_stream_matches_final(
+            _wrap(_block("get_weather", _param("city", "x")), _block("get_weather"))
+        )
+
+    def test_stream_two_calls_distinct_parameters(self):
+        # Regression: with the whole response in one increment, the first call
+        # absorbed the second call's parameters.
+        self.assert_stream_matches_final(
+            _wrap(
+                _block("get_weather", _param("city", "a")),
+                _block("get_weather", _param("city", "b")),
+            )
+        )
+
+    def test_stream_three_mixed_calls(self):
+        self.assert_stream_matches_final(
+            _wrap(
+                _block("get_weather"),
+                _block("get_weather", _param("city", "a")),
+                _block("noop"),
+            )
+        )
+
+    def test_stream_normal_text_before_tool_block(self):
+        self.assert_stream_matches_final("Sure. " + _wrap(_block("get_weather")))
+
+    def test_stream_plain_text_without_tool_call(self):
+        self.assert_stream_matches_final("The weather is nice today.")
+
+
+if __name__ == "__main__":
+    import unittest
+
+    unittest.main()


### PR DESCRIPTION
## Motivation

Partially addresses #35564 — the `step3` row.

The issue reports streaming producing *"one more call, with empty args"* than `detect_and_parse`. Reproducing it on CPU showed the streaming side was actually right and the **non-streaming side was losing a call**: the sample text contains two invoke blocks, but `detect_and_parse` returned only one.

Narrowing that down surfaced three defects.

## Root causes

**1. `detect_and_parse` discarded every call that takes no parameters.**

```python
self.invoke_regex = re.compile(
    r'<steptml:invoke name="([^"]+)">(.+?)</steptml:invoke>', re.DOTALL
)
```

The body group is `(.+?)`, requiring at least one character between the tags. For `<steptml:invoke name="x"></steptml:invoke>` there is nothing between them, so the regex did not match, `_parse_steptml_invoke` returned `(None, {})`, and the `if func_name:` guard dropped the call. A response consisting of a single parameterless call returned **zero** calls:

```python
d.detect_and_parse(wrap(block("get_weather")), tools).calls   # -> [] before, 1 call after
```

**2. Streaming never emitted `{}` for a parameterless call.** The parameter dict never changes, so no fragment is produced, and the closing-brace step is guarded by a truthiness check on the streamed arguments — false in that case. The name was sent with no arguments at all.

**3. Several tokens in one increment lost or corrupted calls.** Two independent problems:

- The end-of-block branch only finished a call that was *already in progress* (`if self._in_tool_call:`). When a whole response (or simply enough tokens) arrived in a single increment, complete calls that had not been started yet were discarded together with the buffer.
- `_parse_partial_tool_call` split on the first tool separator and scanned to the end of the buffer, so with later calls already buffered a call absorbed **their** parameters. Two calls with `city=a` and `city=b` both came out as `city=b`.

## Modifications

`python/sglang/srt/function_call/step3_detector.py`

- `invoke_regex`: `(.+?)` → `(.*?)`
- streaming: emit `{}` when a call completes with no parameters streamed
- block end: drain all buffered complete calls rather than only an in-progress one
- `_parse_partial_tool_call`: bound parameter scanning by the current call's end token

## Tests

New `test/registered/unit/function_call/test_step3_detector.py`, registered for CPU CI (no GPU, no model load).

Two non-streaming tests pin the parameterless-call parsing, plus 14 equivalence cases replayed under three chunkings (character-by-character, whole, halves) asserting the streamed calls equal `detect_and_parse` with argument types preserved and that neither `steptml` nor `tool_call` markers reach the content.

Coverage: parameterless calls (populated and empty schema), one/two parameters, integer typing, unicode, two parameterless calls (same and different tools), parameterless↔parameterized in both orders, two calls with distinct parameters, three mixed calls, leading normal text, plain text.

Verified: 18/42 → 42/42 on that matrix.

## Checklist

- [x] Format the code and add unit tests
- [x] Update documentation as needed — n/a, internal parser behavior

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33069524871](https://github.com/sgl-project/sglang/actions/runs/33069524871)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33069524594](https://github.com/sgl-project/sglang/actions/runs/33069524594)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33069524823](https://github.com/sgl-project/sglang/actions/runs/33069524823)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->