### PR TITLE
[Mamba][Fix] Register a split node under its own key in the mamba radix cache

### DIFF
--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -984,6 +984,29 @@ class MambaRadixCache(BasePrefixCache):
             return
         self.full_lru_list.sanity_check(self)
         self.mamba_lru_list.sanity_check(self)
+        if _MAMBA_DEBUG_ASSERTS:
+            self._sanity_check_child_keys()
+
+    def _sanity_check_child_keys(self) -> None:
+        """Every node must be reachable under the slot its own key derives.
+
+        `_delete_leaf` / `_delete_tombstone_leaf` remove a node with
+        `parent.children.pop(node.key.child_key(page_size))`, so a node filed under
+        any other slot can never be removed: the pop misses, the assert fires far
+        from the write that caused it, and until then the node leaks its KV. Checked
+        here so a drift is attributed to the operation that introduced it.
+        """
+        stack = [self.root_node]
+        while stack:
+            node = stack.pop()
+            for slot, child in node.children.items():
+                expected = child.key.child_key(self.page_size)
+                assert slot == expected, (
+                    f"child registered under a slot its key does not derive: "
+                    f"{slot=}, {expected=}, {child.id=}, {node.id=}, "
+                    f"{len(child.key)=}, {self.page_size=}"
+                )
+                stack.append(child)
 
     def evictable_size(self) -> Tuple[int, int]:
         # Note: use full_evictable_size() and mamba_evictable_size() instead.
@@ -1207,6 +1230,17 @@ class MambaRadixCache(BasePrefixCache):
         )
 
     def _split_node(self, key: RadixKey, child: TreeNode, split_len: int) -> TreeNode:
+        # A split must consume at least one full page. `match()` rounds down to a
+        # page multiple, so a caller that only splits when the child's first page
+        # already matched can never land here with 0 -- and a 0 would build a
+        # node whose key is empty, which `child_key()` renders as `()` for
+        # page_size > 1 instead of raising. Such a node is unfindable in its
+        # parent's `children` and only surfaces much later, as an eviction-time
+        # "parent does not have child key, ()". Fail at the corruption instead.
+        assert split_len > 0, (
+            f"_split_node with split_len=0 would create an empty-key node, "
+            f"{child.id=}, {len(child.key)=}, {self.page_size=}"
+        )
         # new_node -> child
         new_node = TreeNode()
         new_node.children = {key[split_len:].child_key(self.page_size): child}
@@ -1227,7 +1261,12 @@ class MambaRadixCache(BasePrefixCache):
         child.parent = new_node
         child.key = child.key[split_len:]
         child.value = child.value[split_len:].clone()
-        new_node.parent.children[key.child_key(self.page_size)] = new_node
+        # Register under the node's OWN key: `_delete_leaf` / `_delete_tombstone_leaf`
+        # look the node up with `node.key.child_key(...)`, so deriving the slot from
+        # anything else (here: the pre-split `key`) lets the two drift apart whenever
+        # `split_len < page_size`, leaving a node that can never be removed. Equal to
+        # `key.child_key(...)` in the healthy `split_len >= page_size` case.
+        new_node.parent.children[new_node.key.child_key(self.page_size)] = new_node
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
         )

--- a/test/registered/unit/mem_cache/test_mamba_radix_child_key.py
+++ b/test/registered/unit/mem_cache/test_mamba_radix_child_key.py
@@ -1,0 +1,150 @@
+"""Child-slot bookkeeping of MambaRadixCache._split_node.
+
+Regression for an eviction-time crash on Ling-3.0-Flash (hybrid KDA + radix cache,
+page_size > 1): `AssertionError: parent does not have child key, ()` raised from
+`_delete_tombstone_leaf` during `alloc_req_slots -> evict -> evict_mamba`.
+
+A node is filed in `parent.children` under a slot computed at registration, but
+removed with a slot recomputed from `node.key`. `_split_node` used to register the
+new intermediate node under the *pre-split* key while giving it the *post-split*
+(truncated) key, so the two agree only when `split_len >= page_size`. Below that the
+node becomes unremovable; at `split_len == 0` its key is empty and `child_key()`
+renders it as `()` -- the exact crash signature.
+"""
+
+import unittest
+from array import array
+
+from sglang.srt.mem_cache.mamba_radix_cache import MambaRadixCache, TreeNode
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+PAGE_SIZE = 64
+
+
+def _bare_cache(page_size: int = PAGE_SIZE) -> MambaRadixCache:
+    """A MambaRadixCache with only what the split/delete bookkeeping touches.
+
+    __init__ builds GPU pools, so bypass it: these paths read `page_size` and the
+    tree, nothing else.
+    """
+    cache = MambaRadixCache.__new__(MambaRadixCache)
+    cache.page_size = page_size
+    cache.disable = False
+    cache.full_evictable_size_ = 0
+    cache.mamba_evictable_size_ = 0
+    cache.root_node = TreeNode()
+    cache.root_node.key = RadixKey(array("q"), None)
+    cache.root_node.value = None
+    return cache
+
+
+def _key(start: int, n: int) -> RadixKey:
+    return RadixKey(array("q", range(start, start + n)), None)
+
+
+class TestMambaRadixChildKey(unittest.TestCase):
+    def _split_and_get(self, split_len: int):
+        """Split a child at `split_len`; return (cache, new_node)."""
+        cache = _bare_cache()
+        child = TreeNode()
+        child.key = _key(1000, 3 * PAGE_SIZE)
+        child.parent = cache.root_node
+        child.full_lock_ref = 0
+        cache.root_node.children[child.key.child_key(PAGE_SIZE)] = child
+
+        # _split_node touches the LRU lists and hash helpers; stub them out so the
+        # test isolates the children-slot bookkeeping.
+        cache.full_lru_list = _NoopLru()
+        cache.mamba_lru_list = _NoopLru()
+        child.value = _FakeValue(3 * PAGE_SIZE)
+        child.hash_value = []
+        child.event_hash_value = []
+
+        new_node = cache._split_node(child.key, child, split_len)
+        return cache, new_node
+
+    def test_registered_slot_matches_node_key_when_page_aligned(self):
+        """Healthy path: a page-aligned split stays consistent."""
+        for split_len in (PAGE_SIZE, 2 * PAGE_SIZE):
+            with self.subTest(split_len=split_len):
+                cache, new_node = self._split_and_get(split_len)
+                slot = next(
+                    k for k, v in cache.root_node.children.items() if v is new_node
+                )
+                self.assertEqual(slot, new_node.key.child_key(PAGE_SIZE))
+
+    def test_sub_page_split_stays_removable(self):
+        """The bug: a sub-page split filed the node under a slot its key never derives.
+
+        Pre-fix the registered slot came from the pre-split key, so this lookup --
+        the one `_delete_tombstone_leaf` performs -- missed and the node could never
+        be removed.
+        """
+        cache, new_node = self._split_and_get(PAGE_SIZE // 2)
+        slot = next(k for k, v in cache.root_node.children.items() if v is new_node)
+        self.assertEqual(
+            slot,
+            new_node.key.child_key(PAGE_SIZE),
+            "node is filed under a slot its own key does not derive; "
+            "_delete_tombstone_leaf would raise 'parent does not have child key'",
+        )
+        # And the removal itself must find it.
+        popped = cache.root_node.children.pop(new_node.key.child_key(PAGE_SIZE), None)
+        self.assertIs(popped, new_node)
+
+    def test_zero_split_is_rejected(self):
+        """split_len == 0 builds an empty-key node, whose slot renders as `()`.
+
+        `child_key()` returns `()` for an empty key at page_size > 1 rather than
+        raising, so without this guard the corruption is silent until eviction.
+        """
+        with self.assertRaises(AssertionError):
+            self._split_and_get(0)
+
+    def test_sanity_check_detects_a_drifted_slot(self):
+        """The tree-wide invariant catches a mis-filed node directly."""
+        cache = _bare_cache()
+        child = TreeNode()
+        child.key = _key(2000, 2 * PAGE_SIZE)
+        child.parent = cache.root_node
+        cache.root_node.children[("wrong", "slot")] = child
+
+        with self.assertRaises(AssertionError):
+            cache._sanity_check_child_keys()
+
+
+class _NoopLru:
+    def remove_node(self, node):
+        pass
+
+    def insert_mru(self, node):
+        pass
+
+    def reset_node_mru(self, node):
+        pass
+
+
+class _FakeValue:
+    """Stands in for the kv-index tensor: only slicing and len are exercised."""
+
+    def __init__(self, n: int, offset: int = 0):
+        self.n = n
+        self.offset = offset
+
+    def __len__(self):
+        return self.n
+
+    def __getitem__(self, s):
+        start = s.start or 0
+        stop = self.n if s.stop is None else min(s.stop, self.n)
+        return _FakeValue(max(0, stop - start), self.offset + start)
+
+    def clone(self):
+        return _FakeValue(self.n, self.offset)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

A production Ling-3.0-Flash deployment crashed the TP0 scheduler with an assertion raised deep inside eviction:

```
File "sglang/srt/managers/scheduler.py", line 2730, in get_next_batch_to_run
  ...
File "sglang/srt/managers/schedule_batch.py", line 2238, in prepare_for_extend
  out_cache_loc, req_pool_indices_tensor, req_pool_indices_cpu = alloc_for_extend(
File "sglang/srt/mem_cache/common.py", line 437, in alloc_req_slots
  tree_cache.evict(EvictParams(num_tokens=0, mamba_num=mamba_num))
File "sglang/srt/mem_cache/mamba_radix_cache.py", line 847, in evict_mamba
  _, mamba_evicted_delta, _, x_next = self._evict_leaf_node(x, True)
File "sglang/srt/mem_cache/mamba_radix_cache.py", line 1289, in _iteratively_delete_tombstone_leaf
  self._delete_tombstone_leaf(node.parent)
File "sglang/srt/mem_cache/mamba_radix_cache.py", line 1318, in _delete_tombstone_leaf
  assert v == node, f"parent does not have child key, {key}"
AssertionError: parent does not have child key, ()
```

The call chain is entirely ordinary — admit a request, run out of mamba slots, evict. The scheduler is not at fault: the assertion is `MambaRadixCache` discovering that **its own tree is corrupt**, at a point arbitrarily far from the write that corrupted it.

### The defect: a child's slot key is written once and recomputed twice

A node is filed in its parent as `parent.children[slot] = node`. The slot is derived at registration, and derived **again, from a different expression**, at deletion — with a `node.key` rewrite in between and nothing enforcing that the two agree:

```python
# registration, _split_node
new_node.key = child.key[:split_len]                            # the truncated key
new_node.parent.children[key.child_key(self.page_size)] = new_node   # slot from the PRE-split key

# deletion, _delete_leaf / _delete_tombstone_leaf
key = node.key.child_key(self.page_size)                        # slot from the node's OWN key
v = node.parent.children.pop(key, None)
assert v == node, f"parent does not have child key, {key}"
```

Those two expressions coincide only when `split_len >= page_size`. Below one page they diverge and the node becomes **permanently unremovable** — every later `pop` misses, and until the assertion fires the node silently leaks its KV. At `split_len == 0` the node's key is empty, and `RadixKey.child_key()` renders an empty key as `()` for `page_size > 1` rather than raising, which is exactly the reported signature.

### The invariant was already known, just checked in the wrong place

`_print_helper` — a human-readable debug dump that never runs in production — already asserts precisely the invariant `_split_node` violates:

```python
for key, child in current_node.children.items():
    assert key == child.key.child_key(self.page_size), f"{key=}, {child.key.child_key(self.page_size)=}"
```

### Reproduction

Driving the real `_split_node` and `_delete_tombstone_leaf` bookkeeping over a stub tree at `page_size=64`, sweeping `split_len`:

| `split_len` | before | after |
|---|---|---|
| 128 (2 pages) | delete OK | delete OK |
| 64 (1 page) | delete OK | delete OK |
| 32 (sub-page) | `parent does not have child key, (1000, 1001, ...)` | delete OK |
| 1 | `parent does not have child key, (1000,)` | delete OK |
| 0 | `parent does not have child key, ()` | rejected at the split |

### Scope

Any deployment combining a hybrid Mamba/linear-attention model, the radix cache, and `page_size > 1`. It stayed hidden for us because our benchmark runs used `--disable-radix-cache`, which never enters this code. Production traffic hit it once a single request (a ~146k-token prompt that then ran its full 32768-token output budget in a degenerate repetition loop) exhausted the mamba pool and forced aggressive eviction.

## Modifications

`python/sglang/srt/mem_cache/mamba_radix_cache.py`

- `_split_node` now registers the new intermediate node under **its own** key, `new_node.key.child_key(page_size)`, instead of the pre-split `key.child_key(page_size)`. Registration and deletion now derive the slot from the same source, so they cannot drift by construction. In the healthy `split_len >= page_size` case the two expressions are equal, so this is a no-op on the working path.
- `_split_node` asserts `split_len > 0`. A zero-length split builds an empty-key node whose slot renders as `()` instead of raising, so without this the corruption is silent until some later eviction trips over it. Failing at the split attributes the problem to the operation that caused it.
- New `_sanity_check_child_keys()`, called from `sanity_check()` behind the existing `SGLANG_MAMBA_DEBUG_ASSERTS` env gate (zero cost by default). It walks the tree and asserts every child is filed under the slot its own key derives — promoting the invariant out of `_print_helper` into a check that can actually run against a live tree.

`test/registered/unit/mem_cache/test_mamba_radix_child_key.py` (new, registered `base-a-test-cpu`)

CPU-only: it constructs the cache via `__new__` and stubs the LRU lists, so it exercises the tree bookkeeping without allocating GPU pools. Four cases: page-aligned splits stay consistent; a sub-page split leaves the node removable (the regression); `split_len == 0` is rejected; and the tree-wide sanity check catches a deliberately mis-filed node.

## Accuracy Tests

No model outputs change. The registration expression is provably equal to the previous one whenever `split_len >= page_size`, which is the only case reachable on a healthy tree — `match()` rounds its result down to a page multiple, so a caller that splits only after the child's first page matched cannot produce a smaller value. The other two changes are assertions and a debug-gated checker.

## Speed Tests and Profiling

No hot-path change. `_split_node` swaps one `child_key()` call for another on the same object; `_sanity_check_child_keys` is behind `SGLANG_MAMBA_DEBUG_ASSERTS` and does not run by default.

## Notes for reviewers

Two things I could not close, stated plainly.

**How the first drift arises is still open.** Both `_split_node` call sites split only after the child's first page matched, and `match()` returns page multiples, so `split_len` should be either 0 or at least one page — the derivation does not yield 0 on its own. Either there is a third path I did not find (an eviction-time re-parent is the strongest suspect), or the asymmetry where `RadixKey.match()` and `child_key()` read the raw `token_ids` while `__len__`/`__getitem__` honour `limit` admits a case I did not construct. **This PR removes the amplifier — a drift can no longer corrupt the tree silently — and closes the `split_len == 0` entry point, but it does not prove the first cause.** The new debug checker is the instrument for that: running with `SGLANG_MAMBA_DEBUG_ASSERTS=1` reports the offending `slot`, the `expected` slot, and both node ids at the operation that introduces the drift, rather than at a later eviction.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33158284908](https://github.com/sgl-project/sglang/actions/runs/33158284908)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33158284805](https://github.com/sgl-project/sglang/actions/runs/33158284805)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33158284915](https://github.com/sgl-project/sglang/actions/runs/33158284915)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->