### PR TITLE
[Feature] Support PD disaggregation on /v1/responses

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1630,6 +1630,18 @@ class ResponsesRequest(BaseModel):
         default=None, description="Cache salt for request caching"
     )
 
+    # For PD disaggregation
+    bootstrap_host: Optional[Union[List[str], str]] = None
+    bootstrap_port: Optional[Union[List[Optional[int]], int]] = None
+    bootstrap_room: Optional[Union[List[int], int]] = None
+
+    # For DP routing — external router assigns a specific DP worker
+    routed_dp_rank: Optional[int] = None
+    # For PD disagg — hint telling decode which prefill DP worker has the KV cache
+    disagg_prefill_dp_rank: Optional[int] = None
+    # Deprecated: use routed_dp_rank instead
+    data_parallel_rank: Optional[int] = None
+
     # SGLang sampling extras. ``None`` defers to ``--preferred-sampling-params``.
     frequency_penalty: float = 0.0
     presence_penalty: float = 0.0
@@ -1646,6 +1658,11 @@ class ResponsesRequest(BaseModel):
         "min_p": 0.0,
         "repetition_penalty": 1.0,
     }
+
+    @model_validator(mode="before")
+    @classmethod
+    def _handle_deprecated_dp_rank(cls, values):
+        return _migrate_deprecated_dp_rank(values)
 
     @model_validator(mode="before")
     @classmethod

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -456,6 +456,13 @@ class OpenAIServingResponses(OpenAIServingChat):
                         session_id=request.session_id,
                         extra_key=request.extra_key,
                         cache_salt=request.cache_salt,
+                        bootstrap_host=request.bootstrap_host,
+                        bootstrap_port=request.bootstrap_port,
+                        bootstrap_room=request.bootstrap_room,
+                        routed_dp_rank=self.extract_routed_dp_rank_from_header(
+                            raw_request, request.routed_dp_rank
+                        ),
+                        disagg_prefill_dp_rank=request.disagg_prefill_dp_rank,
                         # background+stream streams on this connection, so don't detach.
                         background=request.background and not request.stream,
                         require_reasoning=require_reasoning,

--- a/test/registered/unit/entrypoints/openai/test_responses_protocol.py
+++ b/test/registered/unit/entrypoints/openai/test_responses_protocol.py
@@ -1,9 +1,12 @@
 import json
 import unittest
+import warnings
 
 from utils import make_serving  # noqa: F401 — bootstrap import
 
 from sglang.srt.entrypoints.openai.protocol import (
+    ChatCompletionRequest,
+    CompletionRequest,
     PromptTokensDetails,
     ResponsesRequest,
     ResponsesResponse,
@@ -404,6 +407,93 @@ class ToolChoiceObjectFormTestCase(CustomTestCase):
             ort.ResponseCreatedEvent(
                 type="response.created", sequence_number=0, response=resp.model_dump()
             )
+
+
+class PDDisaggregationFieldsTestCase(CustomTestCase):
+    """/v1/responses must accept the same PD-disaggregation body parameters as
+    /v1/chat/completions and /v1/completions, otherwise it cannot be used in a
+    PD disaggregated deployment at all."""
+
+    PD_FIELDS = (
+        "bootstrap_host",
+        "bootstrap_port",
+        "bootstrap_room",
+        "routed_dp_rank",
+        "disagg_prefill_dp_rank",
+        "data_parallel_rank",
+    )
+
+    def test_declares_same_pd_fields_as_other_endpoints(self):
+        for field in self.PD_FIELDS:
+            self.assertIn(field, ChatCompletionRequest.model_fields)
+            self.assertIn(field, CompletionRequest.model_fields)
+            self.assertIn(
+                field,
+                ResponsesRequest.model_fields,
+                f"/v1/responses is missing {field!r}",
+            )
+
+    def test_scalar_values_round_trip(self):
+        req = ResponsesRequest.model_validate(
+            {
+                "input": "hi",
+                "bootstrap_host": "10.0.0.1",
+                "bootstrap_port": 8998,
+                "bootstrap_room": 12345,
+                "routed_dp_rank": 2,
+                "disagg_prefill_dp_rank": 3,
+            }
+        )
+        self.assertEqual(req.bootstrap_host, "10.0.0.1")
+        self.assertEqual(req.bootstrap_port, 8998)
+        self.assertEqual(req.bootstrap_room, 12345)
+        self.assertEqual(req.routed_dp_rank, 2)
+        self.assertEqual(req.disagg_prefill_dp_rank, 3)
+
+    def test_list_shaped_bootstrap_values_accepted(self):
+        req = ResponsesRequest.model_validate(
+            {
+                "input": "hi",
+                "bootstrap_host": ["h1", "h2"],
+                "bootstrap_port": [1, 2],
+                "bootstrap_room": [10, 20],
+            }
+        )
+        self.assertEqual(req.bootstrap_host, ["h1", "h2"])
+        self.assertEqual(req.bootstrap_port, [1, 2])
+        self.assertEqual(req.bootstrap_room, [10, 20])
+
+    def test_deprecated_data_parallel_rank_migrates(self):
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            req = ResponsesRequest.model_validate(
+                {"input": "hi", "data_parallel_rank": 5}
+            )
+        self.assertEqual(req.routed_dp_rank, 5)
+        self.assertTrue(any(w.category is DeprecationWarning for w in caught))
+
+    def test_explicit_routed_dp_rank_wins_over_deprecated_alias(self):
+        with warnings.catch_warnings(record=True):
+            warnings.simplefilter("always")
+            req = ResponsesRequest.model_validate(
+                {"input": "hi", "data_parallel_rank": 5, "routed_dp_rank": 9}
+            )
+        self.assertEqual(req.routed_dp_rank, 9)
+
+    def test_fields_default_to_none(self):
+        req = ResponsesRequest.model_validate({"input": "hi"})
+        for field in self.PD_FIELDS:
+            self.assertIsNone(getattr(req, field))
+
+    def test_existing_reasoning_validator_still_applies(self):
+        # Guard against the added validator shadowing the existing ones.
+        req = ResponsesRequest.model_validate(
+            {"input": "hi", "reasoning": {"effort": "none"}}
+        )
+        self.assertEqual(
+            req.chat_template_kwargs,
+            {"thinking": False, "enable_thinking": False},
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #35497.

`ResponsesRequest` does not declare the bootstrap or DP-routing fields that `CompletionRequest` and `ChatCompletionRequest` already have, and `serving_responses.py` does not forward them when building `GenerateReqInput`. A request carrying `bootstrap_host` / `bootstrap_port` / `bootstrap_room` is therefore silently dropped by pydantic before it can reach the engine, so `/v1/responses` cannot be used in any PD disaggregated deployment.

Confirmed against `main`: none of the six fields exist on `ResponsesRequest`, while both other request models have all of them.

## Modifications

**`python/sglang/srt/entrypoints/openai/protocol.py`**

Add to `ResponsesRequest`, matching the existing blocks on the other two models:

- `bootstrap_host`, `bootstrap_port`, `bootstrap_room` — accepting both scalar and list shapes, as the other endpoints do
- `routed_dp_rank`, `disagg_prefill_dp_rank`
- `data_parallel_rank` plus a `_handle_deprecated_dp_rank` validator reusing the shared `_migrate_deprecated_dp_rank` helper, so the deprecated alias keeps working and still emits its `DeprecationWarning`

**`python/sglang/srt/entrypoints/openai/serving_responses.py`**

Forward them to `GenerateReqInput`, mirroring `serving_chat.py` — including `extract_routed_dp_rank_from_header` so the `X-Data-Parallel-Rank` header keeps priority over the body value.

Every field defaults to `None`, so requests that omit them behave exactly as before.

## Tests

Extends `test/registered/unit/entrypoints/openai/test_responses_protocol.py` (already CPU-registered) with `PDDisaggregationFieldsTestCase`, 7 tests:

- field parity — every PD field present on all three request models
- scalar values round-trip from a JSON body
- list-shaped bootstrap values accepted (batch form)
- deprecated `data_parallel_rank` migrates to `routed_dp_rank` and warns
- an explicit `routed_dp_rank` wins over the deprecated alias
- all fields default to `None` when omitted
- the added validator does not shadow the existing reasoning-effort normalization

Ran the full file locally: 28 passed (21 pre-existing + 7 new).

Note that running this suite requires the pinned `transformers==5.12.1`; a newer version fails at import with an unrelated `qwen3_asr` config-registration clash on clean `main` too.

## Checklist

- [x] Format the code and add unit tests
- [x] Update documentation as needed — n/a, the parameters mirror the documented ones on /v1/chat/completions

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33070088544](https://github.com/sgl-project/sglang/actions/runs/33070088544)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33070088401](https://github.com/sgl-project/sglang/actions/runs/33070088401)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33070088516](https://github.com/sgl-project/sglang/actions/runs/33070088516)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->