### PR TITLE
[HiCache] Stop populating host-pool mmaps twice (-13% allocation time)

### DIFF
--- a/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
+++ b/python/sglang/srt/mem_cache/storage/mmap/mmap_allocator.py
@@ -1,5 +1,6 @@
 import ctypes
 import ctypes.util
+import functools
 import logging
 import math
 import mmap
@@ -41,6 +42,49 @@ _MAP_HUGE_2MB = 21 << 26  # 0x1400000
 _MAP_HUGE_1GB = 30 << 26  # 0x78000000
 _MAP_FAILED = ctypes.c_void_p(-1).value
 _MADV_POPULATE_WRITE = getattr(mmap, "MADV_POPULATE_WRITE", 23)
+_PROT_RW = mmap.PROT_READ | mmap.PROT_WRITE
+
+
+@functools.cache
+def _has_madv_populate_write() -> bool:
+    """Whether this kernel implements MADV_POPULATE_WRITE (Linux 5.14+).
+
+    Probed once on a single page. Probing on the real allocation is not an
+    option: the answer decides how that allocation gets pre-faulted.
+    """
+    try:
+        probe = mmap.mmap(
+            -1,
+            mmap.PAGESIZE,
+            flags=mmap.MAP_PRIVATE | mmap.MAP_ANONYMOUS,
+            prot=_PROT_RW,
+        )
+    except OSError:
+        return False
+    try:
+        probe.madvise(_MADV_POPULATE_WRITE)
+        return True
+    except (OSError, ValueError):
+        return False
+    finally:
+        probe.close()
+
+
+def _mmap_prefaulted(fileno: int, alloc_bytes: int, flags: int) -> mmap.mmap:
+    """mmap `alloc_bytes` with every page already faulted in and writable.
+
+    cudaHostRegister has to pin real, pre-faulted pages, so these mappings can
+    never be handed back lazily. MAP_POPULATE and MADV_POPULATE_WRITE each give
+    that guarantee on their own, but asking for both makes the kernel walk the
+    whole mapping twice. Prefer the madvise, which additionally reports a
+    failure (e.g. ENOMEM) instead of leaving pages quietly unpopulated, and fall
+    back to MAP_POPULATE only where the kernel lacks it.
+    """
+    if _has_madv_populate_write():
+        mm = mmap.mmap(fileno, alloc_bytes, flags=flags, prot=_PROT_RW)
+        mm.madvise(_MADV_POPULATE_WRITE)
+        return mm
+    return mmap.mmap(fileno, alloc_bytes, flags=flags | _MAP_POPULATE, prot=_PROT_RW)
 
 
 def _alloc_hugepage(n_bytes: int, alloc_bytes: int, extra_flags: int) -> ctypes.Array:
@@ -120,19 +164,7 @@ def alloc_mmap(dims: tuple, dtype: torch.dtype) -> torch.Tensor:
     # Plain mmap path -- used directly when no hugepages requested, or as fallback.
     # torch.frombuffer keeps a reference to mm inside the tensor storage, so mm
     # stays alive until the tensor is freed and mmap.mmap.__del__ calls munmap.
-    mm = mmap.mmap(
-        -1,
-        alloc_bytes,
-        flags=mmap.MAP_SHARED | mmap.MAP_ANONYMOUS | _MAP_POPULATE,
-        prot=mmap.PROT_READ | mmap.PROT_WRITE,
-    )
-    try:
-        # MADV_POPULATE_WRITE guarantees pages are populated and writable,
-        # throwing an error on failure (e.g. out of memory).
-        mm.madvise(_MADV_POPULATE_WRITE)
-    except OSError:
-        # Fall back to MAP_POPULATE if MADV_POPULATE_WRITE is not supported (<5.14 kernel).
-        pass
+    mm = _mmap_prefaulted(-1, alloc_bytes, mmap.MAP_SHARED | mmap.MAP_ANONYMOUS)
     return torch.frombuffer(mm, dtype=dtype, count=math.prod(dims)).reshape(dims)
 
 
@@ -179,19 +211,7 @@ def alloc_shm(dims: tuple, dtype: torch.dtype) -> tuple[torch.Tensor, int, mmap.
 
     try:
         os.ftruncate(fd, alloc_bytes)
-        mm = mmap.mmap(
-            fd,
-            alloc_bytes,
-            flags=mmap.MAP_SHARED | _MAP_POPULATE,
-            prot=mmap.PROT_READ | mmap.PROT_WRITE,
-        )
-        try:
-            # MADV_POPULATE_WRITE guarantees pages are populated and writable,
-            # throwing an error on failure (e.g. out of memory).
-            mm.madvise(_MADV_POPULATE_WRITE)
-        except OSError:
-            # Fall back to MAP_POPULATE if MADV_POPULATE_WRITE is not supported (<5.14 kernel).
-            pass
+        mm = _mmap_prefaulted(fd, alloc_bytes, mmap.MAP_SHARED)
     except Exception as e:
         if fd is not None:
             os.close(fd)

--- a/test/registered/unit/mem_cache/test_mmap_allocator.py
+++ b/test/registered/unit/mem_cache/test_mmap_allocator.py
@@ -5,14 +5,18 @@ register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 import sys
 
 sys.modules["libtpu"] = None
+import ctypes
+import ctypes.util
 import mmap
 import os
 import unittest
+import unittest.mock
 
 import torch
 
 from sglang.srt.mem_cache.pool_host.common import ShmHostTensorAllocator
 from sglang.srt.mem_cache.storage.mmap import alloc_mmap, alloc_shm
+from sglang.srt.mem_cache.storage.mmap.mmap_allocator import _mmap_prefaulted
 
 
 class TestMmapAllocator(unittest.TestCase):
@@ -49,6 +53,45 @@ class TestMmapAllocator(unittest.TestCase):
         # Cleanup
         mm.close()
         os.close(fd)
+
+    def _assert_resident(self, mm, alloc_bytes):
+        # mincore() reports per-page residency, so the invariant is checked
+        # rather than inferred from the flags that were passed.
+        addr = ctypes.addressof(ctypes.c_char.from_buffer(mm))
+        npages = alloc_bytes // mmap.PAGESIZE
+        vec = (ctypes.c_ubyte * npages)()
+        libc = ctypes.CDLL(ctypes.util.find_library("c"), use_errno=True)
+        if libc.mincore(ctypes.c_void_p(addr), ctypes.c_size_t(alloc_bytes), vec) != 0:
+            self.skipTest("mincore unavailable")
+        self.assertTrue(all(v & 1 for v in vec), "mapping was not fully pre-faulted")
+
+    def test_mmap_prefaulted_leaves_no_lazy_page(self):
+        """Both populate paths must return a mapping with every page resident.
+
+        cudaHostRegister pins these buffers, so a page still unfaulted at
+        registration lets the device read memory that is not backed yet.
+        """
+        alloc_bytes = 64 * mmap.PAGESIZE
+        flags = mmap.MAP_SHARED | mmap.MAP_ANONYMOUS
+
+        with self.subTest(path="madvise"):
+            mm = _mmap_prefaulted(-1, alloc_bytes, flags)
+            try:
+                self._assert_resident(mm, alloc_bytes)
+            finally:
+                mm.close()
+
+        # MAP_POPULATE is unreachable on a 5.14+ kernel, so CI never runs it;
+        # force the branch or it ships untested.
+        with self.subTest(path="map_populate"), unittest.mock.patch(
+            "sglang.srt.mem_cache.storage.mmap.mmap_allocator._has_madv_populate_write",
+            return_value=False,
+        ):
+            mm = _mmap_prefaulted(-1, alloc_bytes, flags)
+            try:
+                self._assert_resident(mm, alloc_bytes)
+            finally:
+                mm.close()
 
     def test_shm_host_tensor_allocator(self):
         allocator = ShmHostTensorAllocator()


### PR DESCRIPTION
## Motivation

`alloc_mmap` and `alloc_shm` in `mem_cache/storage/mmap/mmap_allocator.py` ask the kernel to pre-fault the mapping **twice**: `MAP_POPULATE` is passed in the mmap flags, and `madvise(MADV_POPULATE_WRITE)` is then called on the same range.

Either one alone already provides the guarantee these mappings need — `cudaHostRegister` pins them, so every page must be faulted in and writable before the caller touches the buffer. Doing both just makes the kernel walk the whole mapping a second time, and the HiCache host pool is exactly where that is expensive: with `--hicache-ratio 6` on a PP=2 run I measured each rank allocating **418 GB**, and this allocation is on the critical path of server startup.

Fixes #31424.

## Modifications

- Probe `MADV_POPULATE_WRITE` support once, on a single page (`_has_madv_populate_write`, `functools.cache`).
- Add `_mmap_prefaulted(fileno, alloc_bytes, flags)`, which both call sites now use: it drops `MAP_POPULATE` where the madvise is available (Linux 5.14+) and keeps `MAP_POPULATE` where it is not. The "pages are populated and writable on return" contract is identical on both paths.
- The hugepage path is deliberately untouched — `MAP_HUGETLB` reserves its pages up front and was not part of the measurement.

This also stops swallowing a real failure. The old code wrapped the madvise in `except OSError: pass` to tolerate pre-5.14 kernels, which meant an `ENOMEM` was silently ignored as well — the opposite of what its own comment said it was for ("throwing an error on failure (e.g. out of memory)"). Kernel support is now decided by the probe, so a genuine failure propagates.

## Accuracy / performance

Measured with the **real `alloc_mmap`**, running `sglang/main` and this branch in the same process on the same host — a 288-core / 3 TB machine, kernel 6.8.0-124, `MAP_SHARED | MAP_ANONYMOUS`, median of 5 runs per size:

| size | before | after | delta |
|---|---|---|---|
| 8 GiB | 2.726 s | 2.355 s | **-13.6%** |
| 16 GiB | 5.435 s | 4.713 s | **-13.3%** |
| 32 GiB | 10.854 s | 9.443 s | **-13.0%** |
| 64 GiB | 21.739 s | 18.803 s | **-13.5%** |

`mincore()` reports **1.0000 residency before and after** at every size, i.e. the mapping is still fully pre-faulted — only the redundant second walk is gone.

## Checklist

- [x] One unit case added, `test_mmap_prefaulted_leaves_no_lazy_page`: it asserts via `mincore()` that both branches leave every page resident. The `MAP_POPULATE` branch is unreachable on any CI kernel (5.14+), so it is forced with a patched probe rather than left untested.
- [x] Mutation-checked on a 5.15 kernel — the case is red if the `madvise` call is dropped, red if `| _MAP_POPULATE` is dropped from the fallback, and green on the code as written. Each mutation fails exactly the corresponding subtest.
- [x] `test/registered/unit/mem_cache/test_mmap_allocator.py`: 7 passed (6 pre-existing + 1 new, 2 subtests).
- [x] `pre-commit run` clean on both changed files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33086572455](https://github.com/sgl-project/sglang/actions/runs/33086572455)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33086570925](https://github.com/sgl-project/sglang/actions/runs/33086570925)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33086573092](https://github.com/sgl-project/sglang/actions/runs/33086573092)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->