### PR TITLE
[AMD] Fix VLM - serialize MemPool use in fast image preprocessing on ROCm

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -5,8 +5,9 @@ import dataclasses
 import multiprocessing as mp
 import os
 import re
+import threading
 from abc import ABC, abstractmethod
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from typing import (
     Any,
     Dict,
@@ -46,6 +47,7 @@ from sglang.srt.utils import (
     configure_media_url_security,
     envs,
     is_cpu,
+    is_hip,
     is_npu,
     is_xpu,
     load_audio,
@@ -55,8 +57,16 @@ from sglang.srt.utils import (
 )
 
 _is_cpu = is_cpu()
+_is_hip = is_hip()
 _is_npu = is_npu()
 _is_xpu = is_xpu()
+
+# torch.cuda.use_mem_pool() drives the allocator's captures_underway bookkeeping,
+# which is process-wide and not re-entrant. Concurrent processor threads entering
+# it at once leave an entry behind, and the MemPool destructor then trips
+# `captures_underway.empty()`. Only ROCm is confirmed affected, so CUDA keeps the
+# unserialized path.
+_fast_processor_pool_lock = threading.Lock() if _is_hip else nullcontext()
 
 
 @dataclasses.dataclass
@@ -713,8 +723,9 @@ class BaseMultimodalProcessor(ABC):
 
         with torch.cuda.device(device):
             pool = torch.cuda.MemPool()
-        with torch.cuda.use_mem_pool(pool, device=device):
-            yield
+        with _fast_processor_pool_lock:
+            with torch.cuda.use_mem_pool(pool, device=device):
+                yield
 
     def process_mm_data(
         self,


### PR DESCRIPTION

## Motivation

On AMD, the VLM MMMU test crashes the server as soon as the first image requests arrive. Every request after that fails, so the test scores 0.2522 — the same as random guessing — against a 0.4 threshold. The job then spends about an hour retrying before it fails.

## Cause

#36295 creates a new `torch.cuda.MemPool` for every image preprocessing call. `torch.cuda.use_mem_pool()` updates allocator state that is shared by the whole process, so it is not safe to enter from two threads at once — but image preprocessing runs on a thread pool (2 threads by default). When two threads enter together, the allocator is left in a bad state, and destroying the pool then aborts the process:

```
captures_underway.empty() INTERNAL ASSERT FAILED at HIPCachingAllocator.cpp
frame #4: at::cuda::MemPool::~MemPool()
```

Confirmed by bisection: reverting #36295 fixes it, and applying #36295 to an older ROCm 7.2.4 image brings it back. One request at a time never crashes; 64 at once crashes every time.

## Modifications

Take a lock around the pool so only one thread uses it at a time. The lock is only active on ROCm, so CUDA is unchanged. It serializes preprocessing, which is not the bottleneck — no slowdown was measurable.

## Accuracy Tests

MMMU on `Qwen/Qwen2.5-VL-3B-Instruct`, MI300X, 900 samples:

| | accuracy | crashes | result |
| --- | --- | --- | --- |
| before | 0.2522 | 2 | FAILED |
| after | 0.4667 | 0 | **PASS** |

0.4667 matches the 0.4622 this test scores on the last image built before #36295 landed. We also ran the failing case on its own: 64 image requests at once, 5 rounds, 320/320 passed, with preprocessing concurrency left at its default of 2.

## Notes for reviewers

**Why CI did not catch this.** `mmmu_vlm_kit.py` sets `SGLANG_USE_CUDA_IPC_TRANSPORT=1` on CUDA only. That transport keeps features on the GPU and never creates the pool, so the NVIDIA job never runs this code. AMD cannot use that transport (it needs NVIDIA CUDA), so it always takes the CPU path — the only one that creates the pool.

**This may not be ROCm-only.** Single-node CUDA also defaults to the `cpu` transport, so the same path looks reachable there, and `HIPCachingAllocator.cpp` is generated from the CUDA allocator, so the same assert should exist on both. We have no NVIDIA hardware to check, so the fix is limited to ROCm rather than claiming a platform we did not test. Happy to drop the gate if someone can reproduce it on CUDA.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829323682](https://github.com/sgl-project/sglang/actions/runs/34829323682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829323491](https://github.com/sgl-project/sglang/actions/runs/34829323491)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829323649](https://github.com/sgl-project/sglang/actions/runs/34829323649)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->