### PR TITLE
[PD][NIXL] Prevent abort ACK with unresolved errored transfers

### DIFF
--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -1101,9 +1101,15 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     kv_chunk.staging_counted = True
 
                 if self.check_status(room) == KVPoll.Failed:
-                    self._staging_outstanding.pop(room, None)
+                    # This chunk was counted above but never posted. Remove only
+                    # its contribution so an earlier unresolved group remains
+                    # outstanding.
+                    self._staging_outstanding[room] -= 1
+                    if self._staging_outstanding[room] <= 0:
+                        self._staging_outstanding.pop(room, None)
                     if self.enable_deferred_decode_kv_release:
-                        # Skipped => nothing written for this aborted room; ack.
+                        # Ack only if this skipped chunk was the room's final
+                        # outstanding group.
                         self._maybe_ack_drained_abort(room)
                     continue
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -493,6 +493,11 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
             self._staging_outstanding = defaultdict(int)
+            # NIXL caches terminal ERR, which does not prove that the transfer
+            # is quiescent. Keep every ERR or otherwise unresolved handle alive
+            # and leave its transfer group counted so it can never enable an
+            # abort ack or be finalized after ownership was forgotten.
+            self._failed_transfer_handles: Dict[int, List[Any]] = defaultdict(list)
             # Mirror mooncake: one staging buffer per worker queue, all
             # built before workers spawn so each worker owns a private
             # buffer (no cross-worker contention on the staging ring).
@@ -1102,14 +1107,14 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
 
                 if self.check_status(room) == KVPoll.Failed:
                     # This chunk was counted above but never posted. Remove only
-                    # its contribution so an earlier unresolved group remains
-                    # outstanding.
+                    # its count: an earlier ERR group for the room deliberately
+                    # remains outstanding and must not be erased here.
                     self._staging_outstanding[room] -= 1
                     if self._staging_outstanding[room] <= 0:
                         self._staging_outstanding.pop(room, None)
                     if self.enable_deferred_decode_kv_release:
                         # Ack only if this skipped chunk was the room's final
-                        # outstanding group.
+                        # outstanding group. An ERR group keeps the count nonzero.
                         self._maybe_ack_drained_abort(room)
                     continue
 
@@ -1314,24 +1319,41 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                     # Chunk has been re-enqueued; do not advance status.
                     continue
 
-                while handles:
-                    all_done = True
-                    for handle in handles:
+                pending_handles = list(handles)
+                while pending_handles:
+                    still_pending = []
+                    unproven_handles = []
+                    num_handle_errors = 0
+                    for handle in pending_handles:
                         state = self.agent.check_xfer_state(handle)
-                        if state == "ERR":
-                            raise RuntimeError(
-                                f"NIXL transfer encountered ERR room={room}"
-                            )
                         if state != "DONE":
-                            all_done = False
-                    if all_done:
-                        break
-                    time.sleep(0)
+                            unproven_handles.append(handle)
+                        if state == "ERR":
+                            num_handle_errors += 1
+                        elif state != "DONE":
+                            still_pending.append(handle)
+
+                    if num_handle_errors:
+                        # ERR is terminal at the public NIXL handle but does not
+                        # establish backend quiescence. Retain the ERR handles
+                        # and every sibling still unresolved after this poll
+                        # sweep, then promptly return to the worker loop. DONE
+                        # siblings need no retained ownership.
+                        self._failed_transfer_handles[room].extend(unproven_handles)
+                        raise RuntimeError(
+                            "NIXL transfer encountered ERR "
+                            f"room={room} handles={num_handle_errors}/{len(handles)}"
+                        )
+
+                    pending_handles = still_pending
+                    if pending_handles:
+                        time.sleep(0)
 
                 self._staging_outstanding[room] -= 1
                 if self.enable_deferred_decode_kv_release:
-                    # Handles all DONE => this room's writes landed; ack if it
-                    # was aborted and nothing else is outstanding.
+                    # Every handle is DONE, so this room's already-posted writes
+                    # are quiescent. Ack an aborted room only after every other
+                    # transfer group is also drained.
                     self._maybe_ack_drained_abort(room)
                 if kv_chunk.is_last_chunk:
                     self.update_status(room, KVPoll.Success)
@@ -1372,8 +1394,11 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 self.exceptions[room] = e
                 self.record_failure(room, str(e))
                 self.update_status(room, KVPoll.Failed)
-                # No ack here on purpose: the DONE barrier bails on the first
-                # ERR, so siblings may still be writing; fall back to the timeout.
+                # Do not decrement or ack setup, posting, polling, or handle
+                # errors: none proves that every already-posted write is
+                # quiescent. After a NIXL ERR, the polling path above retains
+                # each ERR or unresolved handle without waiting for unresolved
+                # siblings to finish.
 
     def register_buffer_to_engine(self):
         self.kv_descs = []
@@ -2648,9 +2673,9 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         # Deferred KV release: register only after the status flip above (see
         # register_deferred_ack_target), then try once -- the room may already be
         # quiescent and never revisited by the worker. A concluded/unknown room is
-        # acked only when nothing is still counted for it: the ERR path abandons
-        # sibling handles that may still be writing and clear() then drops the
-        # room, so "unknown" alone does not imply quiescent.
+        # acked only when nothing is still counted for it: errored groups remain
+        # counted because ERR does not prove their writes are quiescent, so
+        # "unknown" alone does not imply quiescent.
         if self.enable_deferred_decode_kv_release and decode_port is not None:
             if room_active:
                 self.register_deferred_ack_target(

--- a/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
@@ -138,9 +138,9 @@ class TestNixlAbortNotification(CustomTestCase):
         self.assertEqual(mgr._deferred_ack_targets, {})
 
     def test_cleared_room_with_outstanding_chunk_does_not_ack(self):
-        # The ERR path abandons sibling handles that may still be writing and
-        # leaves the chunk counted; clear() then drops the room. Acking on
-        # "unknown room" alone would release decode pages under those writes.
+        # An ERR group may still be writing and remains counted even after
+        # clear() drops the room. Acking on "unknown room" alone would release
+        # decode pages under those writes.
         mgr = self._mgr(status=None)  # room absent == cleared/unknown
         mgr._staging_outstanding[11] = 1
         self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))

--- a/test/registered/unit/disaggregation/test_nixl_transfer_quiescence.py
+++ b/test/registered/unit/disaggregation/test_nixl_transfer_quiescence.py
@@ -1,0 +1,56 @@
+"""CPU regressions for NIXL transfer quiescence accounting."""
+
+import unittest
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import numpy as np
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.utils import TransferKVChunk
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestNixlTransferGroupErrOwnership(unittest.TestCase):
+    room = 73
+
+    def test_failed_room_skip_preserves_unresolved_group_and_does_not_ack(self):
+        mgr = object.__new__(NixlKVManager)
+        mgr.request_status = {self.room: KVPoll.Failed}
+        mgr.enable_deferred_decode_kv_release = True
+        mgr._staging_outstanding = defaultdict(int, {self.room: 1})
+        mgr._deferred_ack_targets = {}
+        mgr._sent_acks = []
+        mgr._send_abort_ack = lambda ip, port, room: mgr._sent_acks.append(
+            (ip, port, room)
+        )
+        mgr.register_deferred_ack_target(self.room, "10.0.0.8", 6000)
+        mgr.maybe_send_extra = MagicMock()
+        mgr.send_aux = MagicMock()
+        chunk = TransferKVChunk(
+            room=self.room,
+            prefill_kv_indices=np.array([], dtype=np.int32),
+            index_slice=slice(0, 0),
+            is_last_chunk=True,
+            chunk_id=0,
+            prefill_aux_index=0,
+            state_indices=[[1]],
+        )
+        queue = SimpleNamespace(get=MagicMock(side_effect=[chunk, SystemExit()]))
+
+        with self.assertRaises(SystemExit):
+            mgr.transfer_worker(queue)
+
+        self.assertEqual(mgr._staging_outstanding[self.room], 1)
+        self.assertEqual(mgr._sent_acks, [])
+        self.assertIn(self.room, mgr._deferred_ack_targets)
+        mgr.maybe_send_extra.assert_not_called()
+        mgr.send_aux.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_nixl_transfer_quiescence.py
+++ b/test/registered/unit/disaggregation/test_nixl_transfer_quiescence.py
@@ -1,5 +1,11 @@
-"""CPU regressions for NIXL transfer quiescence accounting."""
+"""CPU regressions for NIXL transfer-group ERR ownership.
 
+NIXL ERR is terminal at the public handle but does not prove transport
+quiescence. These tests exercise the real transfer-worker loop with fake
+handles and a fake agent; no GPU, RDMA device, or NIXL installation is needed.
+"""
+
+import threading
 import unittest
 from collections import defaultdict
 from types import SimpleNamespace
@@ -9,47 +15,259 @@ import numpy as np
 
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.utils import TransferKVChunk
-from sglang.srt.disaggregation.nixl.conn import NixlKVManager
+from sglang.srt.disaggregation.nixl.conn import NixlKVManager, TransferInfo
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
+class _ScriptedAgent:
+    def __init__(self, scripts, on_check=None):
+        self.scripts = {handle: list(states) for handle, states in scripts.items()}
+        self.checks = defaultdict(int)
+        self.on_check = on_check
+        self.release_proc = threading.Event()
+        self.release_xfer_handle = MagicMock()
+
+    def check_xfer_state(self, handle):
+        self.checks[handle] += 1
+        if self.on_check is not None:
+            self.on_check(handle, self.checks[handle])
+        states = self.scripts[handle]
+        state = states.pop(0)
+        if not states:
+            self.scripts[handle] = [state]
+        if state == "PROC" and self.release_proc.is_set():
+            return "DONE"
+        return state
+
+
 class TestNixlTransferGroupErrOwnership(unittest.TestCase):
     room = 73
+    later_room = 74
 
-    def test_failed_room_skip_preserves_unresolved_group_and_does_not_ack(self):
+    @staticmethod
+    def _transfer_info(room):
+        return TransferInfo(
+            room=room,
+            endpoint="127.0.0.1",
+            dst_port=5555,
+            agent_name="agent",
+            dst_kv_indices=np.array([], dtype=np.int32),
+            dst_aux_index=0,
+            required_dst_info_num=1,
+            dst_state_indices=[[9]],
+            decode_prefix_len=1,
+        )
+
+    def _make_manager(self, scripts, *, deferred=False, on_check=None):
         mgr = object.__new__(NixlKVManager)
-        mgr.request_status = {self.room: KVPoll.Failed}
-        mgr.enable_deferred_decode_kv_release = True
-        mgr._staging_outstanding = defaultdict(int, {self.room: 1})
+        rooms = (self.room, self.later_room)
+        mgr.request_status = {room: KVPoll.WaitingForInput for room in rooms}
+        mgr.transfer_infos = {
+            room: {"agent": self._transfer_info(room)} for room in rooms
+        }
+        mgr.decode_kv_args_table = {
+            "agent": SimpleNamespace(
+                decode_tp_size=1,
+                decode_tp_rank=0,
+                dst_kv_ptrs=[],
+                dst_aux_ptrs=[0],
+                dst_state_data_ptrs=[[0]],
+                dst_state_item_lens=[[1]],
+                dst_state_dim_per_tensor=[[]],
+                dst_state_layer_ids=[[]],
+                gpu_id=0,
+                staging_base_ptr=0,
+                staging_total_size=0,
+                kv_xfer_segments=None,
+                dst_homogeneous_mem_kind="VRAM",
+                requires_dcp_relayout=False,
+            )
+        }
+        mgr.req_to_decode_prefix_len = {room: 0 for room in rooms}
+        mgr.enable_staging = False
+        mgr.enable_deferred_decode_kv_release = deferred
+        mgr._staging_ctx = None
+        mgr._staging_outstanding = defaultdict(int)
+        mgr._failed_transfer_handles = defaultdict(list)
         mgr._deferred_ack_targets = {}
+        mgr.is_mla_backend = False
+        mgr.is_hybrid_mla_backend = False
+        mgr.attn_tp_size = 1
+        mgr.transfer_source_rank = 0
+        mgr.kv_args = SimpleNamespace(engine_rank=0, kv_data_ptrs=[])
+        mgr.exceptions = {}
+        mgr.failure_lock = threading.Lock()
+        mgr.failure_records = {}
+        mgr.agent = _ScriptedAgent(scripts, on_check=on_check)
         mgr._sent_acks = []
         mgr._send_abort_ack = lambda ip, port, room: mgr._sent_acks.append(
             (ip, port, room)
         )
-        mgr.register_deferred_ack_target(self.room, "10.0.0.8", 6000)
-        mgr.maybe_send_extra = MagicMock()
-        mgr.send_aux = MagicMock()
-        chunk = TransferKVChunk(
-            room=self.room,
+        return mgr
+
+    def _chunk(self, *, room=None, with_state=False):
+        return TransferKVChunk(
+            room=self.room if room is None else room,
             prefill_kv_indices=np.array([], dtype=np.int32),
             index_slice=slice(0, 0),
             is_last_chunk=True,
             chunk_id=0,
             prefill_aux_index=0,
-            state_indices=[[1]],
+            state_indices=[[1]] if with_state else None,
         )
-        queue = SimpleNamespace(get=MagicMock(side_effect=[chunk, SystemExit()]))
 
+    def _run_once(self, mgr, chunk):
+        queue = SimpleNamespace(get=MagicMock(side_effect=[chunk, SystemExit()]))
         with self.assertRaises(SystemExit):
             mgr.transfer_worker(queue)
+
+    def _assert_failed_group(self, mgr, expected_checks, expected_handles):
+        self.assertEqual(dict(mgr.agent.checks), expected_checks)
+        self.assertEqual(mgr._staging_outstanding.get(self.room, 0), 1)
+        self.assertEqual(mgr._failed_transfer_handles[self.room], expected_handles)
+        self.assertEqual(mgr.request_status[self.room], KVPoll.Failed)
+        self.assertIn(self.room, mgr.exceptions)
+        self.assertEqual(mgr._sent_acks, [])
+        mgr.agent.release_xfer_handle.assert_not_called()
+
+    def test_failed_room_skip_preserves_unresolved_group_and_does_not_ack(self):
+        mgr = self._make_manager({}, deferred=True)
+        mgr.request_status[self.room] = KVPoll.Failed
+        mgr._staging_outstanding[self.room] = 1
+        mgr.register_deferred_ack_target(self.room, "10.0.0.8", 6000)
+        mgr.maybe_send_extra = MagicMock()
+        mgr.send_aux = MagicMock()
+
+        self._run_once(mgr, self._chunk(with_state=True))
 
         self.assertEqual(mgr._staging_outstanding[self.room], 1)
         self.assertEqual(mgr._sent_acks, [])
         self.assertIn(self.room, mgr._deferred_ack_targets)
         mgr.maybe_send_extra.assert_not_called()
         mgr.send_aux.assert_not_called()
+
+    def test_err_proc_forever_and_done_returns_to_later_queue_work(self):
+        mgr = self._make_manager(
+            {
+                "h1-err": ["ERR"],
+                "h2-proc": ["PROC"],
+                "h3-done": ["DONE"],
+                "later-done": ["DONE"],
+            },
+            deferred=True,
+        )
+        mgr.maybe_send_extra = MagicMock(return_value=["h1-err", "h2-proc"])
+        mgr.send_aux = MagicMock(side_effect=["h3-done", "later-done"])
+        mgr.register_deferred_ack_target(self.room, "10.0.0.8", 6000)
+
+        # Include a queued chunk for the failed room before independent work.
+        # Skipping it must not erase the failed group's outstanding count.
+        queue = SimpleNamespace(
+            get=MagicMock(
+                side_effect=[
+                    self._chunk(with_state=True),
+                    self._chunk(),
+                    self._chunk(room=self.later_room),
+                    SystemExit(),
+                ]
+            )
+        )
+
+        def run_worker():
+            try:
+                mgr.transfer_worker(queue)
+            except SystemExit:
+                pass
+
+        worker = threading.Thread(target=run_worker, daemon=True)
+        worker.start()
+        worker.join(timeout=1)
+        returned_promptly = not worker.is_alive()
+        if not returned_promptly:
+            # Let a regressed worker exit so it cannot spin after the assertion.
+            mgr.agent.release_proc.set()
+            worker.join(timeout=1)
+
+        self.assertTrue(returned_promptly, "worker blocked on the PROC sibling")
+        self._assert_failed_group(
+            mgr,
+            {
+                "h1-err": 1,
+                "h2-proc": 1,
+                "h3-done": 1,
+                "later-done": 1,
+            },
+            ["h1-err", "h2-proc"],
+        )
+        self.assertNotIn("h3-done", mgr._failed_transfer_handles[self.room])
+        self.assertEqual(mgr.request_status[self.later_room], KVPoll.Success)
+        self.assertNotIn(self.later_room, mgr.transfer_infos)
+        self.assertIn(self.room, mgr._deferred_ack_targets)
+
+    def test_err_and_done_retains_only_err(self):
+        mgr = self._make_manager({"err": ["ERR"], "done": ["DONE"]})
+        mgr.maybe_send_extra = MagicMock(return_value=["err"])
+        mgr.send_aux = MagicMock(return_value="done")
+
+        self._run_once(mgr, self._chunk(with_state=True))
+
+        self._assert_failed_group(mgr, {"err": 1, "done": 1}, ["err"])
+
+    def test_multiple_err_handles_are_retained(self):
+        mgr = self._make_manager({"err-1": ["ERR"], "err-2": ["ERR"]})
+        mgr.maybe_send_extra = MagicMock(return_value=["err-1"])
+        mgr.send_aux = MagicMock(return_value="err-2")
+
+        self._run_once(mgr, self._chunk(with_state=True))
+
+        self._assert_failed_group(mgr, {"err-1": 1, "err-2": 1}, ["err-1", "err-2"])
+
+    def test_state_handle_err_is_retained(self):
+        mgr = self._make_manager({"state": ["ERR"], "aux": ["DONE"]})
+        mgr.maybe_send_extra = MagicMock(return_value=["state"])
+        mgr.send_aux = MagicMock(return_value="aux")
+
+        self._run_once(mgr, self._chunk(with_state=True))
+
+        self._assert_failed_group(mgr, {"state": 1, "aux": 1}, ["state"])
+        mgr.maybe_send_extra.assert_called_once()
+
+    def test_aux_handle_err_is_retained(self):
+        mgr = self._make_manager({"state": ["DONE"], "aux": ["ERR"]})
+        mgr.maybe_send_extra = MagicMock(return_value=["state"])
+        mgr.send_aux = MagicMock(return_value="aux")
+
+        self._run_once(mgr, self._chunk(with_state=True))
+
+        self._assert_failed_group(mgr, {"state": 1, "aux": 1}, ["aux"])
+
+    def test_abort_racing_with_err_never_acks(self):
+        mgr = None
+        abort_sent = False
+
+        def abort_on_first_check(_handle, _check_number):
+            nonlocal abort_sent
+            if abort_sent:
+                return
+            abort_sent = True
+            mgr._handle_abort_notification(
+                [b"ABORT", str(self.room).encode("ascii"), b"10.0.0.8", b"6000"]
+            )
+
+        mgr = self._make_manager(
+            {"err": ["ERR"], "done": ["DONE"]},
+            deferred=True,
+            on_check=abort_on_first_check,
+        )
+        mgr.maybe_send_extra = MagicMock(return_value=["err"])
+        mgr.send_aux = MagicMock(return_value="done")
+
+        self._run_once(mgr, self._chunk(with_state=True))
+
+        self._assert_failed_group(mgr, {"err": 1, "done": 1}, ["err"])
+        self.assertIn(self.room, mgr._deferred_ack_targets)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

#35360 made `_staging_outstanding` the Prefill-side drain condition for
deferred Decode-side KV release: chunks are counted at dequeue so that
`Failed` with `outstanding == 0` means there is no remaining transfer work
that can still write.

The follow-up fix in `30a50a2` relies on the same invariant for NIXL errors:
when the NIXL DONE barrier exits on `ERR`, the transfer group remains counted,
so `ABORT_ACK` is withheld and Decode falls back to the release timeout rather
than treating the room as drained.

The current Failed-room skip path can defeat that invariant.

If another chunk for the same room was already queued, it is dequeued after
the room becomes `Failed`. The worker first counts that chunk, then the skip
path removes the entire room-level `_staging_outstanding` entry with `pop()`.
That also erases the deliberately retained count from the earlier errored
transfer group.

A later deferred-ACK check can therefore observe `outstanding == 0` and emit
`ABORT_ACK` even though the earlier NIXL transfer group has not been proven
quiescent.

A deterministic negative control reproduces this on upstream `main`:

    existing unresolved count: 1
    stale Failed-room chunk dequeued: 1 -> 2
    current skip path: pop(room)
    observed count: 0
    ABORT_ACK emitted: ('10.0.0.8', 6000, 73)

This PR restores the intended outstanding-count invariant.

## Changes

The PR is intentionally split into two independently reviewable commits.

### 1. Preserve unresolved accounting on the Failed-room skip

`fix(pd): preserve unresolved count when skipping failed NIXL chunks`

The Failed-room skip now removes only the skipped chunk's own contribution
instead of clearing the entire room-level count.

This preserves any earlier unresolved group's outstanding state and keeps
`ABORT_ACK` blocked.

### 2. Retain unresolved handles after NIXL transfer errors

`fix(pd): retain unresolved NIXL handles after transfer errors`

When a handle reports `ERR`, the worker performs one complete poll sweep,
retains errored and otherwise unresolved handles, does not retain already-DONE
handles, marks the room Failed, and returns to the worker loop without waiting
indefinitely for a sibling that may remain `PROC`.

The failed group's outstanding count remains positive, so it cannot become
eligible for deferred `ABORT_ACK`.

The existing all-DONE path is unchanged.

## Mooncake

I also checked the analogous Failed-room skip in Mooncake.

The NIXL-specific failure sequence fixed here does not apply to Mooncake's
normal path:

- chunks for the same destination sessions are assigned to the same transfer
  queue and processed serially;
- the normal transfer path uses synchronous `batch_transfer_sync`;
- ordinary transfer failures still reach the per-chunk outstanding decrement;
- unexpected worker exceptions terminate the worker instead of surviving to
  process a later same-room Failed skip.

Mooncake is therefore not modified by this PR.

## Why unresolved NIXL handles are retained

This PR deliberately does not call `release_xfer_handle()` on errored or
unresolved handles.

The current NIXL UCX release path does not provide SGLang with a reliable
"abort incomplete" result that could be used as a quiescence proof. Retaining
unresolved ownership is therefore the conservative behavior here.

Transport-backed reclamation for permanently unresolved handles is left as
follow-up work.

## Tests

All added regressions are deterministic CPU tests; no GPU, RDMA device, or
installed NIXL runtime is required.

Negative control on upstream main:

    FAIL as expected
    expected unresolved count: 1
    observed count: 0
    false ABORT_ACK emitted: yes

Patched branch:

    targeted false-ACK regression: 1 passed
    ERR/accounting regression file: 7 passed
    relevant NIXL/disaggregation suite:
      84 passed, 0 failed, 0 skipped, 2 subtests passed

Also verified:

    py_compile: PASS
    Black 26.1.0: PASS
    isort 7.0.0: PASS
    git diff --check: PASS

The new regression file is registered with:

    register_cpu_ci(est_time=2, suite="base-a-test-cpu")

No `runner_configs.yml` change is required.

## Not covered / follow-ups

- No reclamation policy is added for permanently unresolved errored handles.
- No observability metric is added for retained unresolved groups.
- The existing deferred Decode-side release timeout is unchanged.
- This PR does not modify NIXL abort/release semantics.
- Open PR #35281 introduces additional stale-room cleanup paths. I separately
  validated that those paths must preserve the same per-chunk accounting
  invariant; the #35281-specific compatibility change is intentionally not
  included here because it is not on `main`.

## Checklist

- [x] Format with Black/isort
- [x] Add deterministic unit tests
- [x] Existing relevant disaggregation tests pass
- [ ] Accuracy benchmark — N/A: abort-path correctness; no model-math change
- [ ] Speed benchmark — N/A: no inference hot-path change
- [x] Code style

Related: #35360, #35049, #35281, `30a50a2`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33084550496](https://github.com/sgl-project/sglang/actions/runs/33084550496)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33084550468](https://github.com/sgl-project/sglang/actions/runs/33084550468)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33084552980](https://github.com/sgl-project/sglang/actions/runs/33084552980)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->