### PR TITLE
[DFLASH] Support GLM-5.3-Flash hidden-state capture

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -8,6 +8,7 @@ from torch import nn
 from torch.nn import functional as F
 
 from sglang.kernels.ops.attention.fla.fused_norm_gate import FusedRMSNormGated
+from sglang.kernels.ops.layernorm.mhc import hc_contract
 from sglang.kernels.ops.layernorm.mhc import hc_post as _hc_post_fn
 from sglang.kernels.ops.layernorm.mhc import hc_pre as _hc_pre_fn
 from sglang.srt.batch_overlap.two_batch_overlap import (
@@ -959,6 +960,7 @@ class Glm5NextModel(nn.Module):
         prefix: str = "",
     ) -> None:
         super().__init__()
+        self.config = config
         self.padding_id = config.pad_token_id
         self.vocab_size = config.vocab_size
         self.first_k_dense_replace = config.first_k_dense_replace
@@ -1064,6 +1066,7 @@ class Glm5NextModel(nn.Module):
                 )
             )
         self.layers_to_capture = []
+        self.dflash_capture = False
         if get_moe_a2a_backend().is_deepep() or get_moe_a2a_backend().is_mooncake():
             self.enable_a2a_moe = True
         else:
@@ -1071,6 +1074,14 @@ class Glm5NextModel(nn.Module):
 
     def get_input_embeddings(self) -> torch.Tensor:
         return self.embed_tokens
+
+    def _prepare_aux_hidden_state(
+        self, hidden_states: torch.Tensor, residual: torch.Tensor
+    ) -> torch.Tensor:
+        aux_hidden_state = hidden_states + residual
+        if self.dflash_capture and self.config.mhc:
+            aux_hidden_state = hc_contract(aux_hidden_state, self.config.hc_mult)
+        return aux_hidden_state
 
     def forward(
         self,
@@ -1122,7 +1133,7 @@ class Glm5NextModel(nn.Module):
 
         normal_start_layer = self.start_layer
         normal_end_layer = self.end_layer
-        if forward_batch.can_run_tbo:
+        if forward_batch.can_run_tbo and not self.dflash_capture:
             if (
                 self.first_k_dense_replace > normal_start_layer
                 and self.first_k_dense_replace < normal_end_layer
@@ -1141,13 +1152,14 @@ class Glm5NextModel(nn.Module):
             )
             with ctx:
                 if i in self.layers_to_capture:
+                    aux_hidden_state = self._prepare_aux_hidden_state(
+                        hidden_states, residual
+                    )
                     if self.enable_a2a_moe and i > self.first_k_dense_replace:
                         aux_hidden_state = get_parallel().attn_tp_group.all_gather(
-                            hidden_states + residual, dim=0
+                            aux_hidden_state, dim=0
                         )
-                        aux_hidden_states.append(aux_hidden_state)
-                    else:
-                        aux_hidden_states.append(hidden_states + residual)
+                    aux_hidden_states.append(aux_hidden_state)
                 layer = self.layers[i]
                 hidden_states, residual, topk_indices = layer(
                     positions,
@@ -1387,6 +1399,20 @@ class Glm5NextForConditionalGeneration(nn.Module):
         else:
             self.capture_aux_hidden_states = True
             self.model.layers_to_capture = [val + 1 for val in layer_ids]
+
+    def set_dflash_layers_to_capture(self, layer_ids: List[int]):
+        if not self.pp_group.is_last_rank:
+            return
+
+        if layer_ids is None:
+            raise ValueError(
+                "DFLASH requires explicit layer_ids for aux hidden capture."
+            )
+
+        self.capture_aux_hidden_states = True
+        self.model.dflash_capture = True
+        # Capturing before layer k + 1 gives the completed output of layer k.
+        self.model.layers_to_capture = [val + 1 for val in layer_ids]
 
     def prepare_context_parallel_metadata_for_dcp(
         self,

--- a/test/registered/unit/models/test_glm5_next_dflash_capture.py
+++ b/test/registered/unit/models/test_glm5_next_dflash_capture.py
@@ -1,0 +1,53 @@
+from types import SimpleNamespace
+
+import torch
+from torch import nn
+
+from sglang.srt.models.glm5_next import (
+    Glm5NextForConditionalGeneration,
+    Glm5NextModel,
+)
+
+
+def test_glm5_next_dflash_contracts_mhc_hidden_state():
+    model = Glm5NextModel.__new__(Glm5NextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(mhc=True, hc_mult=4)
+    model.dflash_capture = True
+
+    hidden_states = torch.arange(24, dtype=torch.float32).reshape(2, 12)
+    residual = torch.full_like(hidden_states, 2)
+
+    actual = model._prepare_aux_hidden_state(hidden_states, residual)
+    expected = (hidden_states + residual).unflatten(-1, (4, -1)).mean(dim=-2)
+
+    torch.testing.assert_close(actual, expected)
+    assert actual.shape == (2, 3)
+
+
+def test_glm5_next_eagle_capture_keeps_mhc_hidden_state():
+    model = Glm5NextModel.__new__(Glm5NextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(mhc=True, hc_mult=4)
+    model.dflash_capture = False
+
+    hidden_states = torch.arange(24, dtype=torch.float32).reshape(2, 12)
+    residual = torch.full_like(hidden_states, 2)
+
+    actual = model._prepare_aux_hidden_state(hidden_states, residual)
+
+    torch.testing.assert_close(actual, hidden_states + residual)
+
+
+def test_glm5_next_dflash_maps_target_layers_to_capture_points():
+    model = Glm5NextForConditionalGeneration.__new__(Glm5NextForConditionalGeneration)
+    nn.Module.__init__(model)
+    model.pp_group = SimpleNamespace(is_last_rank=True)
+    model.model = SimpleNamespace(dflash_capture=False, layers_to_capture=[])
+    model.capture_aux_hidden_states = False
+
+    model.set_dflash_layers_to_capture([5, 14, 24, 33, 42])
+
+    assert model.capture_aux_hidden_states
+    assert model.model.dflash_capture
+    assert model.model.layers_to_capture == [6, 15, 25, 34, 43]


### PR DESCRIPTION
## Motivation

Enable DFLASH speculative decoding for `Glm5NextForConditionalGeneration`.

GLM-5.3-Flash keeps its inter-layer mHC state at `hc_mult * hidden_size`, while a DFLASH draft consumes one `hidden_size` stream per selected target layer. The existing generic aux-hidden path therefore needs an mHC contraction when it is configured by DFLASH.

This PR is stacked on #36507 and only contains the DFLASH adapter change.

## Changes

- implement the standard `set_dflash_layers_to_capture` model hook
- contract completed mHC states from `hc_mult * hidden_size` to `hidden_size`
- keep the existing EAGLE3 capture behavior unchanged
- keep DFLASH per-layer capture on the eager layer loop when TBO is enabled
- add unit coverage for mHC contraction, EAGLE3 isolation, and target-layer mapping

## Tests

Run in the GLM-5.3-Flash SGLang serving image based on the #36507 head:

- `python3 -m pytest -q test_glm5_next_dflash_capture.py` — 3 passed
- `python3 -m pytest -q test_glm5_next_config.py test_glm5_next_pp_metadata.py test_glm5_next_dcp.py` — 8 passed

Static checks:

- `ruff check` passed
- `git diff --check` passed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33085155037](https://github.com/sgl-project/sglang/actions/runs/33085155037)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33085154794](https://github.com/sgl-project/sglang/actions/runs/33085154794)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33085154963](https://github.com/sgl-project/sglang/actions/runs/33085154963)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->