### PR TITLE
[Docs] GLM-5.3-Flash: point at compute-mamba-ratio for the KDA/KV pool split

### DIFF
--- a/docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx
@@ -35,6 +35,10 @@ import { benchmarks } from "/src/snippets/configs/zai-org/glm-5.3-flash-benchmar
 
 <Deployment config={config} benchmarks={benchmarks} />
 
+<Note>
+Generated commands leave `--mamba-full-memory-ratio` at its `0.9` default, which is a generic starting point rather than a workload-tuned split: too low starves the KDA state pool and clamps `max_running_requests`, too high over-provisions it and shrinks the KV pool. Use the repo-local [`compute-mamba-ratio`](https://github.com/sgl-project/sglang/blob/main/.claude/skills/compute-mamba-ratio/SKILL.md) skill to compute the balanced ratio — or the `--max-mamba-cache-size` pin to use instead — from your average request length and the two pool sizes printed in one boot log. See [Size both memory pools](#size-both-memory-pools) for what each pool caps.
+</Note>
+
 ## Playground
 
 Use the Playground for lower-level tuning such as attention parallelism, MoE communication, and reasoning or tool parsers. It inherits every selection from the deployment panel and shows only the command-line diff.


### PR DESCRIPTION
## Motivation

The GLM-5.3-Flash deployment panel never emits `--mamba-full-memory-ratio` or `--max-mamba-cache-size` (`docs/src/snippets/configs/zai-org/glm-5.3-flash.jsx` has no mamba flag), so every generated command runs at the `ServerArgs` default `0.9`. GLM-5.3-Flash is a hybrid model — a paged MLA/DSA KV pool plus a separate KDA state pool — and that split is a generic default, not a workload-tuned one: too low starves the KDA state pool and clamps `max_running_requests`, too high over-provisions it and shrinks the KV pool.

The page's "Size both memory pools" tip already says to turn the knob, but not how to pick a value. The repo already ships a `compute-mamba-ratio` skill that derives the balanced ratio (or the `--max-mamba-cache-size` pin to use instead) from the average request length and the two pool sizes printed in one boot log. This just connects the two.

## Modifications

- `docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx`: add a `<Note>` directly below the deployment panel pointing at [`.claude/skills/compute-mamba-ratio/SKILL.md`](https://github.com/sgl-project/sglang/blob/main/.claude/skills/compute-mamba-ratio/SKILL.md), stating the `0.9` default and which pool each direction hurts, and cross-linking the existing `#size-both-memory-pools` section.

Docs-only; no code, config, or generated-command changes.

## Accuracy Tests

N/A — documentation only.

## Speed Tests and Profiling

N/A — documentation only.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). (N/A — docs only; `node docs/scripts/check_cookbook_configs.mjs` passes.)
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (N/A — docs only.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33104791045](https://github.com/sgl-project/sglang/actions/runs/33104791045)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33104790828](https://github.com/sgl-project/sglang/actions/runs/33104790828)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->