### PR TITLE
Fix GDN GQA head pairing for HV=2H models (Qwen3.5-35B)

### DIFF
--- a/python/sglang/kernels/ops/attention/fla/fused_recurrent.py
+++ b/python/sglang/kernels/ops/attention/fla/fused_recurrent.py
@@ -41,7 +41,10 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    i_h = i_hv // (HV // H)
+    # Tiled GQA head pairing (i_hv % H), matching Qwen3.5/Qwen3-Next GDN weights.
+    # Interleaved (i_hv // (HV//H)) is only correct when HV == H; for HV = 2H it
+    # misroutes v_head 16 to q_head 8 instead of q_head 0, causing garbage output.
+    i_h = i_hv % H
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
             cu_seqlens + i_n + 1
@@ -211,7 +214,10 @@ def fused_recurrent_gated_delta_rule_packed_decode_kernel(
 ):
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    i_h = i_hv // (HV // H)
+    # Tiled GQA head pairing (i_hv % H), matching Qwen3.5/Qwen3-Next GDN weights.
+    # Interleaved (i_hv // (HV//H)) is only correct when HV == H; for HV = 2H it
+    # misroutes v_head 16 to q_head 8 instead of q_head 0, causing garbage output.
+    i_h = i_hv % H
 
     o_k = tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
@@ -436,7 +442,10 @@ def fused_recurrent_kda_packed_decode_kernel(
     so the state decay is a per-K vector ``exp(g)`` rather than a scalar."""
     i_v, i_nh = tl.program_id(0), tl.program_id(1)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    i_h = i_hv // (HV // H)
+    # Tiled GQA head pairing (i_hv % H), matching Qwen3.5/Qwen3-Next GDN weights.
+    # Interleaved (i_hv // (HV//H)) is only correct when HV == H; for HV = 2H it
+    # misroutes v_head 16 to q_head 8 instead of q_head 0, causing garbage output.
+    i_h = i_hv % H
 
     o_k = tl.arange(0, BK)
     o_v = i_v * BV + tl.arange(0, BV)
@@ -906,7 +915,10 @@ def fused_recurrent_gated_delta_rule_update_fwd_kernel(
 ):
     i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
     i_n, i_hv = i_nh // HV, i_nh % HV
-    i_h = i_hv // (HV // H)
+    # Tiled GQA head pairing (i_hv % H), matching Qwen3.5/Qwen3-Next GDN weights.
+    # Interleaved (i_hv // (HV//H)) is only correct when HV == H; for HV = 2H it
+    # misroutes v_head 16 to q_head 8 instead of q_head 0, causing garbage output.
+    i_h = i_hv % H
     if IS_VARLEN:
         bos, eos = tl.load(cu_seqlens + i_n).to(tl.int64), tl.load(
             cu_seqlens + i_n + 1


### PR DESCRIPTION
## Summary

The GDN kernels in `fused_recurrent.py` use the FLA-style interleaved head index `i_hv // (HV // H)`, which is only correct when `HV == H`. For models with `HV = 2H` (e.g. **Qwen3.5-35B-A3B**: 16 kv_heads / 32 value_heads, also Qwen3-Next-80B-A3B), this misroutes `v_head 16` to `q_head 8` instead of `q_head 0`, producing garbage output.

Qwen3.5 GDN weights follow the **tiled** pairing inherited from Qwen2.5 (also used by llama.cpp and HF transformers reference implementations). This PR changes the index to `i_hv % H`.

## Why this is safe

| Model | H / HV | `i_hv % H` vs `i_hv // (HV//H)` |
|---|---|---|
| HV == H (Kimi, Qwen3-Next) | 16/16, 32/32 | **Identical** — zero behavior change |
| HV = 2H (Qwen3.5-35B) | 16/32 | **Fixed** — tiled pairing now correct |

This is a real bug that also affects the **safetensors** path (not just GGUF), since Qwen3.5 loads with 16/32 heads through these same kernels. It was found while bringing up Qwen3.5-35B-A3B (verified against llama.cpp output which uses the same tiled pairing).

## Changes

- `python/sglang/kernels/ops/attention/fla/fused_recurrent.py`: 4 kernels updated (decode / packed-decode / KDA-packed-decode / update).

Many thanks to the SGLang team for this excellent framework — the fused GDN kernels and CUDA graph support made long-context MoE serving on a single 24GB GPU practical. Grateful for your work! 🙏

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33106087234](https://github.com/sgl-project/sglang/actions/runs/33106087234)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33106086997](https://github.com/sgl-project/sglang/actions/runs/33106086997)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33106087151](https://github.com/sgl-project/sglang/actions/runs/33106087151)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->