### PR TITLE
[Fix] Use a safe stop-string decode window

### DIFF
--- a/python/sglang/srt/sampling/sampling_params.py
+++ b/python/sglang/srt/sampling/sampling_params.py
@@ -225,11 +225,12 @@ class SamplingParams(msgspec.Struct, kw_only=True, array_like=True):
 
             stop_str_max_len = 0
             for stop_str in self.stop_strs:
+                # Generated text may use a longer, non-canonical tokenization
+                # than encoding the stop string in isolation.
+                stop_str_max_len = max(stop_str_max_len, len(stop_str.encode("utf-8")))
                 if tokenizer is not None:
                     stop_str_ids = tokenizer.encode(stop_str, add_special_tokens=False)
                     stop_str_max_len = max(stop_str_max_len, len(stop_str_ids))
-                else:
-                    stop_str_max_len = max(stop_str_max_len, len(stop_str))
             self.stop_str_max_len = stop_str_max_len
 
         # Process stop regex strings

--- a/test/registered/unit/sampling/test_sampling_params.py
+++ b/test/registered/unit/sampling/test_sampling_params.py
@@ -344,25 +344,18 @@ class TestSamplingParamsNormalize(CustomTestCase):
         sp.normalize(tokenizer=tokenizer)
         self.assertEqual(sp.stop_strs, ["stop1", "stop2"])
 
-    def test_stop_str_max_len_uses_encoded_length(self):
-        """Test that max_len is based on encoded token count, not character count."""
-        # "ab" encodes to 1 token, "cdef" encodes to 2 tokens
-        tokenizer = self._mock_tokenizer(encode_map={"ab": [1], "cdef": [2, 3]})
-        sp = SamplingParams(stop=["ab", "cdef"])
-        sp.normalize(tokenizer=tokenizer)
-        self.assertEqual(sp.stop_str_max_len, 2)  # max token count
-
-    def test_stop_str_max_len_with_tokenizer(self):
-        """Test that with a tokenizer, max_len counts encoded token IDs."""
-        tokenizer = MagicMock()
-        # "hello" encodes to 2 tokens, "world!!" to 3 tokens
-        tokenizer.encode.side_effect = lambda s, add_special_tokens=False: {
-            "hello": [101, 102],
-            "world!!": [201, 202, 203],
-        }[s]
-        sp = SamplingParams(stop=["hello", "world!!"])
-        sp.normalize(tokenizer=tokenizer)
-        self.assertEqual(sp.stop_str_max_len, 3)
+    def test_stop_str_max_len_is_safe_token_bound(self):
+        """Use the larger of encoded token count and the UTF-8 byte length."""
+        cases = [
+            ("<END>", [1, 2, 3], 5),
+            ("x", [1, 2, 3], 3),
+        ]
+        for stop_str, token_ids, expected in cases:
+            with self.subTest(stop_str=stop_str):
+                tokenizer = self._mock_tokenizer(encode_map={stop_str: token_ids})
+                sp = SamplingParams(stop=stop_str)
+                sp.normalize(tokenizer=tokenizer)
+                self.assertEqual(sp.stop_str_max_len, expected)
 
     def test_none_stop_regex_becomes_empty_list(self):
         """Test that normalize() converts None stop_regex to empty list with max_len=0."""
@@ -452,7 +445,7 @@ class TestSamplingParamsMsgspecStruct(CustomTestCase):
         self.assertIsInstance(rebuilt, SamplingParams)
         self.assertTrue(rebuilt.is_normalized)
         self.assertEqual(rebuilt.stop_strs, ["hello", "world"])
-        self.assertEqual(rebuilt.stop_str_max_len, 2)
+        self.assertEqual(rebuilt.stop_str_max_len, 5)
         self.assertEqual(rebuilt.stop_regex_strs, [r"[a-z]{3}"])
         self.assertEqual(rebuilt.stop_regex_max_len, 3)
         self.assertEqual(rebuilt.stop_token_ids, {1, 2})


### PR DESCRIPTION
## Motivation

Fixes #36698.

Stop-string matching decodes a bounded tail of generated tokens. The bound was derived only from encoding the stop string in isolation, but generated text can use a longer non-canonical tokenization. For DeepSeek-V4-Flash-0731, `<END>` canonically encodes to 3 tokens but can be generated as 5 tokens, causing the decode window to retain only `END>` and miss the stop.

## Modifications

- Size the stop-string window using the larger of the canonical token count and UTF-8 byte length.
- Consolidate the two existing length tests into one regression test covering both sides of that bound.
- Update the existing serialization assertion for the corrected normalized value.

## Accuracy Tests

This does not change model forward computation or numerical accuracy.

- `pytest test/registered/unit/sampling/test_sampling_params.py -q`: 70 passed, 13 subtests passed.
- `pytest test/registered/unit/managers/test_stop_str_speculative.py -q`: 9 passed.
- DeepSeek-V4-Flash-0731 tokenizer check: canonical `<END>` IDs `[30, 16860, 32]`; non-canonical IDs `[30, 39, 48, 38, 32]`; corrected window decodes `香蕉<END>` and contains the stop string.

## Speed Tests and Profiling

Not run; this is a correctness fix. Normalization adds one UTF-8 encoding per configured stop string, and the existing tail decoder reads up to the corrected bound only when it is larger than the canonical token count.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No documentation change is needed for this internal correctness fix.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable; rationale and proportional correctness checks are reported above.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33114659412](https://github.com/sgl-project/sglang/actions/runs/33114659412)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33114659213](https://github.com/sgl-project/sglang/actions/runs/33114659213)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33114659289](https://github.com/sgl-project/sglang/actions/runs/33114659289)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->