### PR TITLE
[Docs][AMD] Add optimized GLM-5.3-Flash MI355X recipe

### DIFF
--- a/docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx
+++ b/docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx
@@ -10,7 +10,7 @@ tag: NEW
 
 <Accordion title="Install SGLang">
 
-Use an SGLang build that includes GLM-5.3-Flash support. The AMD ROCm recipes also require [the ROCm engine changes in PR #36607](https://github.com/sgl-project/sglang/pull/36607) until they are available in a published SGLang image.
+Use an SGLang build that includes GLM-5.3-Flash support. The optimized MI355X recipe also requires [the ROCm engine changes in SGLang PR #36607](https://github.com/sgl-project/sglang/pull/36607) and [the gfx950 BF16 GEMM tuning in AITER PR #5060](https://github.com/ROCm/aiter/pull/5060) until both are available in published packages.
 
 ```bash Command
 docker pull lmsysorg/sglang:glm-5.3-flash
@@ -69,7 +69,7 @@ GLM-5.3-Flash is a natively multimodal Mixture-of-Experts model built around a h
     </tr>
     <tr>
       <td style={{padding: "9px 12px"}}>Precision</td>
-      <td style={{padding: "9px 12px"}}>FP8 weights; FP8 KV cache by default on Blackwell, BF16 KV cache on H100, H200, and the AMD ROCm recipes</td>
+      <td style={{padding: "9px 12px"}}>FP8 weights; FP8 KV cache by default on Blackwell and MI355X, BF16 KV cache on H100, H200, MI300X, and MI325X</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Context</td>
@@ -100,7 +100,7 @@ Strategy labels describe the workload goal. Both strategies stay available on NV
 
 GLM-5.3-Flash maintains a paged KV pool for attention and a separate KDA state pool. The KDA state pool can limit concurrency before the KV pool is full. If startup reduces `max_running_requests` because of KDA state capacity, increase `--mamba-full-memory-ratio` or set `--max-mamba-cache-size` for the expected concurrency, then tune `--max-running-requests` to the workload.
 
-Keep the prefix cache enabled for every strategy.
+Keep the prefix cache enabled for production workloads that reuse prefixes. The published MI355X speed rows pass `--disable-radix-cache` to isolate model execution under the requested random-data benchmark protocol; remove that flag when prefix reuse is part of your workload.
 
 Keep the checkpoint's KDA lower-bound setting unchanged. In particular, do not override `linear_lower_bound` through `--json-model-override-args`.
 
@@ -108,7 +108,11 @@ Keep the checkpoint's KDA lower-bound setting unchanged. In particular, do not o
 
 On Blackwell, the recipes default to an FP8 KV cache with TRT-LLM DSA: on GB300 this pairing measured 2.9–5.7% higher throughput and about 1.8x the KV token capacity at identical pool bytes, with GSM8K accuracy within noise of BF16. BF16 KV with TileLang DSA remains selectable in the deployment panel and is the default on H100 and H200, where FP8 KV with TRT-LLM DSA is disabled. Switch the dtype and both DSA backends together; TileLang DSA with FP8 KV is not a valid CUDA combination.
 
-On AMD ROCm, use BF16 KV cache with TileLang DSA, set `SGLANG_USE_AITER=1`, keep the MoE runner on Triton, and disable CUDA graphs. The ROCm recipe uses TP8 on a single eight-GPU node. MI300X and MI325X both use gfx942, but the MI325X entry remains explicitly unverified because it is inferred from MI300X rather than measured directly. AMD validation covers text generation and GSM8K only; multimodal serving remains unverified.
+On AMD ROCm, set `SGLANG_USE_AITER=1` and use TileLang DSA. MI300X and MI325X retain the correctness-validated BF16 KV, Triton MoE, graph-disabled path; MI325X remains explicitly unverified because it is inferred from MI300X rather than measured directly. The optimized MI355X recipe uses TP8/EP1, FP8 KV, AITER MoE, the AITER mHC pre/post dispatch added by SGLang PR #36607, shared-expert fusion, the HIP fused k-pool path, and full decode graphs for batch sizes 1 and 32. Its small BF16 decode GEMMs require the model-specific gfx950 rows in AITER PR #5060. The graph batch list matches the measured workload; tune it for other production concurrency ranges. AMD multimodal serving remains unverified.
+
+### Reproduce the MI355X speed rows
+
+The MI355X rows use the random dataset with seed 42, ignored EOS, 1,024 input tokens, and 1,024 output tokens. Concurrency 1 uses 10 prompts and concurrency 32 uses 320 prompts. Radix caching is disabled, every completed request has exactly 1,024 input and output tokens, and the results report median TTFT and TPOT. Total throughput includes input and output tokens; the deployment table divides aggregate throughput by eight GPUs. Median interactivity is `1,000 / median TPOT`: 145.61 tok/s/user at concurrency 1 and 93.72 tok/s/user at concurrency 32.
 
 ### Decode context parallelism
 

--- a/docs/src/snippets/configs/zai-org/glm-5.3-flash-benchmarks.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.3-flash-benchmarks.jsx
@@ -244,9 +244,36 @@ export const benchmarks = [
   { match: { hw: "mi325x", strategy: "high-throughput" } },
   {
     match: { hw: "mi355x", strategy: "high-throughput" },
-    sglang_version: "9e692c9216",
+    sglang_version: "9d20876939",
+    latencyPercentile: "Median",
+    speed: [
+      {
+        workload: {
+          dataset: "random",
+          isl: 1024,
+          osl: 1024,
+          max_concurrency: 1,
+          num_prompts: 10,
+        },
+        ttft_ms: 84.8435,
+        tpot_ms: 6.8675,
+        tokens_per_sec_per_gpu: 35.9812,
+      },
+      {
+        workload: {
+          dataset: "random",
+          isl: 1024,
+          osl: 1024,
+          max_concurrency: 32,
+          num_prompts: 320,
+        },
+        ttft_ms: 514.8845,
+        tpot_ms: 10.6696,
+        tokens_per_sec_per_gpu: 716.4206,
+      },
+    ],
     accuracy: { gsm8k_pct: 97.65 },
     notes:
-      "Accuracy-only validation on 8x MI355X (gfx950, TP8) with zai-org/GLM-5.3-Flash revision 3f1971b7b5f7a528c9c4ef6212c8785298a8c24a, SGLang PR #36607 head 9e692c9216c3b5e5c443fecf6b995700eb68d2e4 (validated source manifest 2c240e0e01d5fdf04acc485ebfa25f8a1793ba45fb07f165eecedfba7ec1db80), and lmsysorg/sglang:v0.5.18-rocm720-mi35x with the PR source mounted over the image tree. Full GSM8K scored 1,288/1,319 with a 100% stop rate and zero request errors, empty generations, or truncations. No throughput or latency benchmark was run.",
+      "Speed was measured on 8x MI355X (gfx950, TP8/EP1) with SGLang PR #36607 head 9d2087693988 and AITER PR #5060 head 95565e33c828. FP8 KV, AITER MoE, TileLang DSA, AITER mHC dispatch, shared-expert fusion, the HIP fused k-pool path, and full decode graphs for batch sizes 1 and 32 were enabled; prefill graphs and radix caching were disabled. With random seed 42, ignored EOS, and exact 1,024-token inputs and outputs, all 10/10 and 320/320 requests completed with empty errors. Aggregate total throughput was 287.8493 and 5,731.3649 tok/s; median interactivity was 145.6126 and 93.7246 tok/s/user at concurrency 1 and 32. The 97.65% accuracy row is from the separate full 1,319-sample GSM8K validation on the earlier PR #36607 head 9e692c9216; it completed with a 100% stop rate and zero request errors, empty generations, or truncations.",
   },
 ];

--- a/docs/src/snippets/configs/zai-org/glm-5.3-flash.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.3-flash.jsx
@@ -24,9 +24,12 @@ export const config = {
   ],
 
   isRecommendedSelection(s) {
-    const pairing = ["h100", "h200", "mi300x", "mi325x", "mi355x"].includes(s.hw)
-      ? "bf16-tilelang"
-      : "fp8-trtllm";
+    const pairing =
+      s.hw === "mi355x"
+        ? "fp8-tilelang"
+        : ["h100", "h200", "mi300x", "mi325x"].includes(s.hw)
+          ? "bf16-tilelang"
+          : "fp8-trtllm";
     return (
       s.kvDsaPair === pairing &&
       s.mmTransport === "auto" &&
@@ -45,7 +48,7 @@ export const config = {
           id: "fp8-trtllm",
           label: "FP8 + TRT-LLM",
           disabled: (s) => ["h100", "h200", "mi300x", "mi325x", "mi355x"].includes(s.hw),
-          disableReason: "This recipe uses BF16 KV cache with TileLang DSA on Hopper and AMD ROCm GPUs.",
+          disableReason: "Hopper and gfx942 use BF16 + TileLang; MI355X uses FP8 + TileLang because TRT-LLM DSA is CUDA-only.",
           stripPrefixes: ["--kv-cache-dtype", "--dsa-prefill-backend", "--dsa-decode-backend"],
           flags: [
             "--kv-cache-dtype fp8_e4m3",
@@ -63,6 +66,19 @@ export const config = {
             "--dsa-prefill-backend tilelang",
             "--dsa-decode-backend tilelang",
           ],
+        },
+        {
+          id: "fp8-tilelang",
+          label: "FP8 + TileLang",
+          disabled: (s) => s.hw !== "mi355x",
+          disableReason: "This pairing is validated only on MI355X/gfx950.",
+          stripPrefixes: ["--kv-cache-dtype", "--dsa-prefill-backend", "--dsa-decode-backend"],
+          flags: [
+            "--kv-cache-dtype fp8_e4m3",
+            "--dsa-prefill-backend tilelang",
+            "--dsa-decode-backend tilelang",
+          ],
+          hints: ["Validated on 8x MI355X with AITER MoE and full decode graphs."],
         },
       ],
     },
@@ -563,11 +579,10 @@ sgl-eval run gsm8k \\
         "--port {{PORT}}",
       ],
     },
-    // AMD ROCm — one non-speculative TP8 operating point. The explicit BF16
-    // KV and TileLang DSA flags match the resolved defaults observed in the
-    // validation server logs. AITER remains enabled for the ROCm kernel paths,
-    // while Triton owns the MoE runner. CUDA graphs stay disabled because that
-    // is the architecture-gated configuration used for correctness validation.
+    // AMD ROCm — non-speculative TP8 operating points. gfx942 retains the
+    // correctness-validated BF16 KV, Triton MoE, graph-disabled path. MI355X
+    // uses the performance-validated FP8 KV, AITER MoE, shared-expert fusion,
+    // HIP fused k-pool path, and full decode graphs from PR #36607.
     {
       match: { hw: "mi300x", strategy: "high-throughput" },
       nnodes: 1,
@@ -617,12 +632,16 @@ sgl-eval run gsm8k \\
       flags: [
         "--model-path {{MODEL_NAME}}",
         "--tp-size 8",
+        "--ep-size 1",
         "--trust-remote-code",
-        "--disable-cuda-graph",
         "--dsa-prefill-backend tilelang",
         "--dsa-decode-backend tilelang",
-        "--kv-cache-dtype bfloat16",
-        "--moe-runner-backend triton",
+        "--kv-cache-dtype fp8_e4m3",
+        "--moe-runner-backend aiter",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-backend-prefill disabled",
+        "--cuda-graph-bs-decode 1 32",
+        "--disable-radix-cache",
         "--reasoning-parser glm45",
         "--tool-call-parser glm47",
         "--host {{HOST_IP}}",


### PR DESCRIPTION
## Motivation

Document the measured GLM-5.3-Flash FP8 serving recipe for 8x MI355X and publish the exact 1K/1K concurrency-1 and concurrency-32 results. The optimized recipe depends on the ROCm engine work in #36607 and the model-specific gfx950 BF16 GEMM tuning in ROCm/aiter#5060.

## Modifications

- Select FP8 KV cache with TileLang DSA for MI355X while retaining the existing BF16/Triton/graph-disabled gfx942 recipes.
- Use TP8/EP1, AITER MoE, full decode graphs at batch sizes 1 and 32, disabled prefill graphs, and disabled radix cache for the measured MI355X recipe.
- Add median TTFT/TPOT and total-throughput-per-GPU rows for concurrency 1 and 32.
- Document exact request accounting, aggregate throughput, median interactivity, engine/AITER revisions, and the distinction between the speed run and the earlier full GSM8K accuracy run.
- Keep CUDA selections unchanged; TRT-LLM DSA remains CUDA-only.

## Accuracy Tests

The existing MI355X accuracy result is retained and explicitly identified as a separate run:

- 8x MI355X, TP8, full GSM8K: 1,288/1,319 = 97.65%.
- 100% stop rate.
- Zero request errors, empty generations, or truncations.
- Accuracy source: SGLang PR #36607 head `9e692c9216`.

The performance run completed all 330 requests with exact 1,024-token inputs and outputs and empty error strings.

## Speed Tests and Profiling

Hardware and software:

- 8x AMD Instinct MI355X (`gfx950`), TP8/EP1.
- SGLang PR #36607 head `9d2087693988`.
- AITER PR ROCm/aiter#5060 head `95565e33c828`.
- FP8 E4M3 KV, AITER MoE, TileLang DSA, AITER mHC dispatch, shared-expert fusion, HIP fused k-pool, full decode graphs at batch sizes 1 and 32.
- Random dataset, seed 42, ISL/OSL 1,024/1,024, ignored EOS, radix cache disabled.

| Concurrency | Requests | Aggregate total throughput | Total throughput/GPU | Median TTFT | Median TPOT | Median interactivity |
|---:|---:|---:|---:|---:|---:|---:|
| 1 | 10/10 | 287.8493 tok/s | 35.9812 tok/s/GPU | 84.8435 ms | 6.8675 ms | 145.6126 tok/s/user |
| 32 | 320/320 | 5,731.3649 tok/s | 716.4206 tok/s/GPU | 514.8845 ms | 10.6696 ms | 93.7246 tok/s/user |

Against the recorded 8x B200 baseline, MI355X reached 90.18% / 89.11% of B200 total throughput / median interactivity at concurrency 1 and 101.07% / 98.35% at concurrency 32. The B200 raw JSON is not locally available, so the docs publish only independently preserved MI355X measurements rather than presenting the comparison as a new revalidation.

## Validation

- `node docs/scripts/check_cookbook_configs.mjs`
- `pre-commit run --files docs/cookbook/autoregressive/GLM/GLM-5.3-Flash.mdx docs/src/snippets/configs/zai-org/glm-5.3-flash.jsx docs/src/snippets/configs/zai-org/glm-5.3-flash-benchmarks.jsx`
- `npx -y mint@latest validate`
- Static assertion of all MI355X flags and absence of TRT-LLM DSA, DeepGEMM, and `--disable-cuda-graph` in the MI355X cell.
- Direct extraction of TTFT, TPOT, throughput, token lengths, completion counts, and error counts from the saved benchmark JSON.

## Checklist

- [x] Format and changed-file pre-commit checks pass.
- [x] Cookbook config validation passes.
- [x] Mintlify build validation passes.
- [x] Documentation updated with exact platform, topology, dependencies, and benchmark protocol.
- [x] Accuracy and speed provenance are separated.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33117751830](https://github.com/sgl-project/sglang/actions/runs/33117751830)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33117751273](https://github.com/sgl-project/sglang/actions/runs/33117751273)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->