### PR TITLE
[MoE] Quantize online MXFP8 weights during loading

### DIFF
--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -129,6 +129,7 @@ _mxfp8_to_block_fp8_required = mxfp8_block_convert_required() or get_bool_env_va
 _use_hip_int4 = get_bool_env_var("SGLANG_INT4_WEIGHT") and _is_hip
 _use_aiter = envs.SGLANG_USE_AITER.get() and _is_hip
 _is_shuffle_moe_mxfp4 = is_gfx95_supported()
+_ONLINE_MXFP8_MAX_CHUNK_BYTES = 64 * 1024 * 1024
 
 
 def _require_fp4_dtype():
@@ -1143,7 +1144,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         """
         from sglang.srt.layers.moe.fused_moe_triton import FusedMoeWeightScaleSupported
 
-        if is_checkpoint_fp8_serialized:
+        loads_quantized_weights = is_checkpoint_fp8_serialized or (
+            use_mxfp8 and not is_fp4_expert
+        )
+        if loads_quantized_weights:
             params_dtype = torch.uint32 if _use_hip_int4 else torch.float8_e4m3fn
 
         tp_size = get_parallel().tp_size
@@ -1364,10 +1368,10 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             else {"quant_method": FusedMoeWeightScaleSupported.TENSOR.value}
         )
 
-        # If loading fp8 checkpoint, pass the weight loaders.
-        # If loading an fp16 checkpoint, do not (we will quantize in
-        #   process_weights_after_loading()
-        if quant_config.is_checkpoint_fp8_serialized:
+        # Serialized and load-time MXFP8 scales are populated through the MoE
+        # weight loader. Other online paths create scales only in
+        # process_weights_after_loading().
+        if loads_quantized_weights:
             set_weight_attrs(w13_weight_scale, extra_weight_attrs)
             set_weight_attrs(w2_weight_scale, extra_weight_attrs)
 
@@ -1402,6 +1406,185 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             layer.w13_input_scale = None
             layer.w2_input_scale = None
 
+    @staticmethod
+    def _should_skip_loaded_expert(
+        layer: torch.nn.Module,
+        param: torch.nn.Parameter,
+        expert_id: Optional[int],
+    ) -> bool:
+        if expert_id is None or getattr(param, "_sglang_require_global_experts", False):
+            return False
+
+        # Preserve the canonical loader's EPLB/explicit-placement mapping. A
+        # logical expert may map to more than one physical expert there.
+        from sglang.srt.eplb.expert_location import (
+            get_global_expert_location_metadata,
+        )
+
+        if get_global_expert_location_metadata() is not None:
+            return False
+        return layer._map_global_expert_id_to_local_expert_id(expert_id) == -1
+
+    @staticmethod
+    def _mxfp8_scale_weight_name(weight_name: str) -> str:
+        if "weight" in weight_name:
+            prefix, suffix = weight_name.rsplit("weight", 1)
+            return f"{prefix}weight_scale_inv{suffix}"
+        return f"{weight_name}.weight_scale_inv"
+
+    @classmethod
+    def get_online_mxfp8_weight_loader(cls, layer, original_weight_loader):
+        """Quantize BF16/FP16 MoE expert shards as the checkpoint streams in."""
+
+        expert_id_unset = object()
+        backend = get_moe_runner_backend()
+        use_flashinfer_quantizer = (
+            is_blackwell_supported()
+            and is_flashinfer_available()
+            and (
+                backend.is_flashinfer_trtllm() or backend.is_flashinfer_trtllm_routed()
+            )
+        )
+
+        def load_quantized_tensor(
+            param: torch.nn.Parameter,
+            loaded_weight: torch.Tensor,
+            weight_name: str,
+            shard_id: Optional[str],
+            expert_id,
+        ) -> None:
+            kwargs: Dict[str, Any] = {
+                "weight_name": weight_name,
+                "shard_id": shard_id,
+            }
+            if expert_id is not expert_id_unset:
+                kwargs["expert_id"] = expert_id
+            original_weight_loader(param, loaded_weight, **kwargs)
+
+        def mxfp8_online_weight_loader(
+            param: torch.nn.Parameter,
+            loaded_weight: torch.Tensor,
+            weight_name: str,
+            shard_id: Optional[str],
+            expert_id=expert_id_unset,
+        ) -> None:
+            is_expert_weight = param is layer.w13_weight or param is layer.w2_weight
+            if not is_expert_weight:
+                load_quantized_tensor(
+                    param,
+                    loaded_weight,
+                    weight_name,
+                    shard_id,
+                    expert_id,
+                )
+                return
+            if expert_id is not expert_id_unset and cls._should_skip_loaded_expert(
+                layer, param, expert_id
+            ):
+                return
+            if loaded_weight.ndim < 2 or not loaded_weight.is_floating_point():
+                raise ValueError(
+                    "Online MXFP8 weight conversion expects floating-point MoE "
+                    f"expert matrices, got shape={tuple(loaded_weight.shape)} "
+                    f"and dtype={loaded_weight.dtype}."
+                )
+            if loaded_weight.shape[-1] % 32 != 0:
+                raise ValueError(
+                    "Online MXFP8 weight conversion requires expert weight K "
+                    f"to be a multiple of 32, got shape {tuple(loaded_weight.shape)}."
+                )
+
+            quantizer_name = "FlashInfer" if use_flashinfer_quantizer else "Triton"
+            logger.info_once(
+                f"Running online MXFP8 quantization for MoE expert weights "
+                f"with the {quantizer_name} quantizer."
+            )
+            source_weight = loaded_weight.contiguous()
+            k = source_weight.shape[-1]
+            source_weight_2d = source_weight.view(-1, k)
+
+            # Fused checkpoints can present every expert in one tensor. Keep
+            # their accumulated output on CPU; per-expert loaders accumulate
+            # directly on the parameter device. In both cases, move only
+            # bounded source row chunks through the accelerator.
+            output_device = (
+                param.device
+                if expert_id is not expert_id_unset and expert_id is not None
+                else torch.device("cpu")
+            )
+            rows_per_chunk = max(
+                1,
+                _ONLINE_MXFP8_MAX_CHUNK_BYTES // (k * source_weight.element_size()),
+            )
+            qweight_2d = torch.empty(
+                source_weight_2d.shape,
+                dtype=torch.float8_e4m3fn,
+                device=output_device,
+            )
+            weight_scale_2d = torch.empty(
+                (source_weight_2d.shape[0], k // 32),
+                dtype=torch.uint8,
+                device=output_device,
+            )
+            for row_start in range(0, source_weight_2d.shape[0], rows_per_chunk):
+                row_end = min(row_start + rows_per_chunk, source_weight_2d.shape[0])
+                source_chunk = (
+                    source_weight_2d[row_start:row_end].to(param.device).contiguous()
+                )
+                if use_flashinfer_quantizer:
+                    from sglang.srt.layers.quantization.fp8_utils import (
+                        flashinfer_mxfp8_quantize,
+                    )
+
+                    qweight_chunk, weight_scale_chunk = flashinfer_mxfp8_quantize(
+                        source_chunk, False
+                    )
+                else:
+                    qweight_chunk, weight_scale_chunk = mxfp8_group_quantize(
+                        source_chunk
+                    )
+                qweight_2d[row_start:row_end].copy_(qweight_chunk.to(output_device))
+                weight_scale_2d[row_start:row_end].copy_(
+                    weight_scale_chunk.view(torch.uint8)
+                    .contiguous()
+                    .view(row_end - row_start, k // 32)
+                    .to(output_device)
+                )
+
+            qweight = qweight_2d.view(source_weight.shape)
+            weight_scale = weight_scale_2d.view(*source_weight.shape[:-1], k // 32)
+
+            load_quantized_tensor(
+                param,
+                qweight,
+                weight_name,
+                shard_id,
+                expert_id,
+            )
+            scale_param = (
+                layer.w2_weight_scale_inv
+                if param is layer.w2_weight
+                else layer.w13_weight_scale_inv
+            )
+            load_quantized_tensor(
+                scale_param,
+                weight_scale,
+                cls._mxfp8_scale_weight_name(weight_name),
+                shard_id,
+                expert_id,
+            )
+
+        return mxfp8_online_weight_loader
+
+    def prepare_weight_loader(self, layer, weight_loader):
+        if (
+            not self.use_mxfp8
+            or self.is_fp4_expert
+            or self.quant_config.is_checkpoint_fp8_serialized
+        ):
+            return weight_loader
+        return self.get_online_mxfp8_weight_loader(layer, weight_loader)
+
     def create_weights(
         self,
         layer: Module,
@@ -1412,6 +1595,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         with_bias: bool = False,
         **extra_weight_attrs,
     ):
+        extra_weight_attrs["weight_loader"] = self.prepare_weight_loader(
+            layer, extra_weight_attrs["weight_loader"]
+        )
         Fp8MoEMethod.create_fp8_moe_weight_(
             layer=layer,
             num_experts=num_experts,
@@ -1586,9 +1772,7 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 )
             return
         elif self.use_mxfp8:
-            self._process_mxfp8_moe_weights(
-                layer, quantize=not self.quant_config.is_checkpoint_fp8_serialized
-            )
+            self._process_mxfp8_moe_weights(layer, quantize=False)
             return
 
         # If ROCm, normalize the weights and scales to e4m3fnuz
@@ -1824,7 +2008,9 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         ):
             num_experts, m, k = weight_shape
             aligned_m = ((m + 127) // 128) * 128
-            scale = scale.view(num_experts, aligned_m, k // 32)
+            scale = scale.contiguous().view(num_experts, m, k // 32)
+            if aligned_m != m:
+                scale = F.pad(scale, (0, 0, 0, aligned_m - m))
             num_warps = 8
             scale = _swizzle_mxfp8_sf(scale, num_warps)
             # convert_layout may pad for alignment; we can't view back to the

--- a/test/registered/unit/layers/quantization/test_mxfp8_online_moe_loading.py
+++ b/test/registered/unit/layers/quantization/test_mxfp8_online_moe_loading.py
@@ -1,0 +1,365 @@
+"""Online MXFP8 MoE loading must never materialize the full BF16 model."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.moe.moe_runner.base import MoeRunnerConfig
+from sglang.test.test_utils import CustomTestCase
+
+NUM_EXPERTS = 4
+HIDDEN = 256
+INTERMEDIATE = 640
+
+
+class _RecordingLayer:
+    def __init__(self, is_gated: bool = False):
+        self.moe_runner_config = MoeRunnerConfig(is_gated=is_gated)
+        self.params = {}
+
+    def register_parameter(self, name, param):
+        self.params[name] = param
+        setattr(self, name, param)
+
+    @staticmethod
+    def _map_global_expert_id_to_local_expert_id(expert_id):
+        return expert_id if 0 <= expert_id < NUM_EXPERTS else -1
+
+
+def _backend(*, flashinfer_trtllm: bool):
+    backend = MagicMock()
+    backend.is_flashinfer_trtllm.return_value = flashinfer_trtllm
+    backend.is_flashinfer_trtllm_routed.return_value = False
+    backend.is_cutlass.return_value = False
+    return backend
+
+
+def _method(*, flashinfer_trtllm: bool = True):
+    from sglang.srt.layers.quantization import fp8 as fp8_quant
+
+    quant_config = SimpleNamespace(
+        use_mxfp8=True,
+        weight_block_size=[1, 32],
+        is_fp4_experts=False,
+        dequant_fp4_to_fp8=False,
+        is_checkpoint_fp8_serialized=False,
+        activation_scheme="dynamic",
+    )
+    with patch.object(
+        fp8_quant,
+        "get_moe_runner_backend",
+        return_value=_backend(flashinfer_trtllm=flashinfer_trtllm),
+    ):
+        return fp8_quant.Fp8MoEMethod(quant_config)
+
+
+def _create_online_weights(
+    *,
+    flashinfer_trtllm: bool = True,
+    blackwell: bool | None = None,
+    is_gated: bool = False,
+    weight_loader=None,
+):
+    from sglang.srt.layers.quantization import fp8 as fp8_quant
+
+    method = _method(flashinfer_trtllm=flashinfer_trtllm)
+    layer = _RecordingLayer(is_gated=is_gated)
+    original_weight_loader = weight_loader or MagicMock()
+    blackwell = flashinfer_trtllm if blackwell is None else blackwell
+    with (
+        patch.object(fp8_quant, "get_parallel") as parallel,
+        patch.object(fp8_quant, "is_blackwell_supported", return_value=blackwell),
+        patch.object(fp8_quant, "is_flashinfer_available", return_value=blackwell),
+        patch.object(
+            fp8_quant,
+            "get_moe_runner_backend",
+            return_value=_backend(flashinfer_trtllm=flashinfer_trtllm),
+        ),
+    ):
+        parallel.return_value.tp_size = 1
+        method.create_weights(
+            layer=layer,
+            num_experts=NUM_EXPERTS,
+            hidden_size=HIDDEN,
+            intermediate_size_per_partition=INTERMEDIATE,
+            params_dtype=torch.bfloat16,
+            weight_loader=original_weight_loader,
+        )
+    return method, layer, original_weight_loader
+
+
+class TestMxfp8OnlineMoeLoading(CustomTestCase):
+    def test_flashinfer_online_mxfp8_allocates_final_dtypes(self):
+        _, layer, _ = _create_online_weights()
+
+        self.assertEqual(layer.w13_weight.dtype, torch.float8_e4m3fn)
+        self.assertEqual(layer.w2_weight.dtype, torch.float8_e4m3fn)
+        self.assertEqual(layer.w13_weight_scale_inv.dtype, torch.uint8)
+        self.assertEqual(layer.w2_weight_scale_inv.dtype, torch.uint8)
+        self.assertTrue(callable(layer.w13_weight.weight_loader))
+        self.assertIs(
+            layer.w13_weight.weight_loader,
+            layer.w13_weight_scale_inv.weight_loader,
+        )
+
+    def test_gated_online_mxfp8_allocates_merged_w13(self):
+        _, layer, _ = _create_online_weights(is_gated=True)
+        self.assertEqual(
+            layer.w13_weight.shape,
+            (NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN),
+        )
+        self.assertEqual(
+            layer.w13_weight_scale_inv.shape,
+            (NUM_EXPERTS, 2 * INTERMEDIATE, HIDDEN // 32),
+        )
+
+    def test_other_backends_use_load_time_quantization(self):
+        method, layer, original_weight_loader = _create_online_weights(
+            flashinfer_trtllm=False
+        )
+        self.assertEqual(layer.w13_weight.dtype, torch.float8_e4m3fn)
+        self.assertEqual(layer.w13_weight_scale_inv.dtype, torch.uint8)
+        self.assertTrue(callable(layer.w13_weight_scale_inv.weight_loader))
+
+        loaded_weight = torch.randn(HIDDEN, INTERMEDIATE, dtype=torch.bfloat16)
+        with patch(
+            "sglang.srt.layers.quantization.fp8.mxfp8_group_quantize",
+            return_value=(
+                loaded_weight.to(torch.float8_e4m3fn),
+                torch.zeros(HIDDEN, INTERMEDIATE // 32, dtype=torch.uint8),
+            ),
+        ) as quantize:
+            layer.w2_weight.weight_loader(
+                layer.w2_weight,
+                loaded_weight,
+                weight_name="experts.0.down_proj.weight",
+                shard_id="w2",
+                expert_id=0,
+            )
+        quantize.assert_called_once()
+        self.assertEqual(original_weight_loader.call_count, 2)
+
+        method._process_mxfp8_moe_weights = MagicMock()
+        with patch(
+            "sglang.srt.layers.quantization.fp8.get_moe_runner_backend",
+            return_value=_backend(flashinfer_trtllm=False),
+        ):
+            method.process_weights_after_loading_block_quant(layer)
+        method._process_mxfp8_moe_weights.assert_called_once_with(layer, quantize=False)
+
+    def test_weight_loader_quantizes_and_stores_weight_and_scale(self):
+        _, layer, original_weight_loader = _create_online_weights()
+        online_loader = layer.w13_weight.weight_loader
+        loaded_weight = torch.randn(INTERMEDIATE, HIDDEN, dtype=torch.bfloat16)
+
+        def fake_quantize(weight, is_sf_swizzled_layout):
+            self.assertEqual(weight.shape, (INTERMEDIATE, HIDDEN))
+            self.assertFalse(is_sf_swizzled_layout)
+            return (
+                weight.to(torch.float8_e4m3fn),
+                torch.zeros(INTERMEDIATE * HIDDEN // 32, dtype=torch.uint8),
+            )
+
+        with patch(
+            "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
+            side_effect=fake_quantize,
+            create=True,
+        ):
+            online_loader(
+                layer.w13_weight,
+                loaded_weight,
+                weight_name="experts.0.up_proj.weight",
+                shard_id="w3",
+                expert_id=0,
+            )
+
+        self.assertEqual(original_weight_loader.call_count, 2)
+        weight_call, scale_call = original_weight_loader.call_args_list
+        self.assertEqual(weight_call.args[1].dtype, torch.float8_e4m3fn)
+        self.assertEqual(weight_call.kwargs["shard_id"], "w3")
+        self.assertIs(scale_call.args[0], layer.w13_weight_scale_inv)
+        self.assertEqual(scale_call.args[1].dtype, torch.uint8)
+        self.assertEqual(
+            scale_call.kwargs["weight_name"],
+            "experts.0.up_proj.weight_scale_inv",
+        )
+
+    def test_fused_weight_loader_quantizes_weight_and_scale(self):
+        calls = []
+
+        def record_fused(_label, param, loaded_weight, weight_name, shard_id):
+            calls.append((param, loaded_weight, weight_name, shard_id))
+
+        _, layer, _ = _create_online_weights(
+            weight_loader=partial(record_fused, "fused")
+        )
+        loaded_weight = torch.randn(
+            NUM_EXPERTS, INTERMEDIATE, HIDDEN, dtype=torch.bfloat16
+        )
+
+        def fake_quantize(weight, is_sf_swizzled_layout):
+            self.assertEqual(weight.shape, (NUM_EXPERTS * INTERMEDIATE, HIDDEN))
+            self.assertFalse(is_sf_swizzled_layout)
+            return (
+                weight.to(torch.float8_e4m3fn),
+                torch.zeros(
+                    NUM_EXPERTS * INTERMEDIATE * HIDDEN // 32,
+                    dtype=torch.uint8,
+                ),
+            )
+
+        with patch(
+            "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
+            side_effect=fake_quantize,
+            create=True,
+        ):
+            layer.w13_weight.weight_loader(
+                layer.w13_weight,
+                loaded_weight,
+                weight_name="experts.gate_up_proj.weight",
+                shard_id="w13",
+            )
+
+        self.assertEqual(len(calls), 2)
+        self.assertIs(calls[1][0], layer.w13_weight_scale_inv)
+        self.assertEqual(calls[1][2], "experts.gate_up_proj.weight_scale_inv")
+        self.assertEqual(calls[1][1].shape, (NUM_EXPERTS, INTERMEDIATE, HIDDEN // 32))
+
+    def test_fused_weight_loader_supports_unset_shard_id(self):
+        calls = []
+
+        def record_fused(_label, param, loaded_weight, weight_name, shard_id):
+            calls.append((param, loaded_weight, weight_name, shard_id))
+
+        _, layer, _ = _create_online_weights(
+            flashinfer_trtllm=False,
+            weight_loader=partial(record_fused, "fused"),
+        )
+
+        def fake_quantize(weight):
+            return (
+                weight.to(torch.float8_e4m3fn),
+                torch.zeros(weight.shape[0], weight.shape[1] // 32, dtype=torch.uint8),
+            )
+
+        with patch(
+            "sglang.srt.layers.quantization.fp8.mxfp8_group_quantize",
+            side_effect=fake_quantize,
+        ):
+            for param, loaded_weight, weight_name in (
+                (
+                    layer.w13_weight,
+                    torch.randn(
+                        NUM_EXPERTS, INTERMEDIATE, HIDDEN, dtype=torch.bfloat16
+                    ),
+                    "experts.gate_up_proj.weight",
+                ),
+                (
+                    layer.w2_weight,
+                    torch.randn(
+                        NUM_EXPERTS, HIDDEN, INTERMEDIATE, dtype=torch.bfloat16
+                    ),
+                    "experts.down_proj.weight",
+                ),
+            ):
+                param.weight_loader(
+                    param,
+                    loaded_weight,
+                    weight_name=weight_name,
+                    shard_id=None,
+                )
+
+        self.assertEqual(len(calls), 4)
+        self.assertIs(calls[1][0], layer.w13_weight_scale_inv)
+        self.assertIs(calls[3][0], layer.w2_weight_scale_inv)
+        self.assertTrue(all(call[3] is None for call in calls))
+
+    def test_nonlocal_expert_is_skipped_before_quantization(self):
+        _, layer, original_weight_loader = _create_online_weights()
+        online_loader = layer.w2_weight.weight_loader
+        with patch(
+            "sglang.srt.layers.quantization.fp8_utils.flashinfer_mxfp8_quantize",
+            create=True,
+        ) as quantize:
+            online_loader(
+                layer.w2_weight,
+                torch.randn(HIDDEN, INTERMEDIATE, dtype=torch.bfloat16),
+                weight_name="experts.9.down_proj.weight",
+                shard_id="w2",
+                expert_id=9,
+            )
+        quantize.assert_not_called()
+        original_weight_loader.assert_not_called()
+
+    def test_flashinfer_backend_falls_back_to_triton_off_blackwell(self):
+        from sglang.srt.layers.quantization import fp8 as fp8_quant
+
+        _, layer, _ = _create_online_weights(
+            flashinfer_trtllm=True,
+            blackwell=False,
+        )
+        loaded_weight = torch.randn(INTERMEDIATE, HIDDEN, dtype=torch.bfloat16)
+        quantized = loaded_weight.to(torch.float8_e4m3fn)
+        scale = torch.zeros(INTERMEDIATE, HIDDEN // 32, dtype=torch.uint8)
+        with patch.object(
+            fp8_quant,
+            "mxfp8_group_quantize",
+            return_value=(quantized, scale),
+        ) as triton_quantize:
+            layer.w13_weight.weight_loader(
+                layer.w13_weight,
+                loaded_weight,
+                weight_name="experts.0.up_proj.weight",
+                shard_id="w3",
+                expert_id=0,
+            )
+        triton_quantize.assert_called_once()
+
+    def test_post_load_only_finalizes_layout(self):
+        method = _method()
+        method._process_mxfp8_moe_weights = MagicMock()
+        layer = MagicMock()
+        method.process_weights_after_loading_block_quant(layer)
+        method._process_mxfp8_moe_weights.assert_called_once_with(layer, quantize=False)
+
+    def test_serialized_mxfp8_keeps_existing_loader_and_finalization(self):
+        from sglang.srt.layers.quantization import fp8 as fp8_quant
+
+        method = _method()
+        method.quant_config.is_checkpoint_fp8_serialized = True
+        layer = _RecordingLayer()
+        original_weight_loader = MagicMock()
+        with (
+            patch.object(fp8_quant, "get_parallel") as parallel,
+            patch.object(
+                fp8_quant,
+                "get_moe_runner_backend",
+                return_value=_backend(flashinfer_trtllm=True),
+            ),
+        ):
+            parallel.return_value.tp_size = 1
+            method.create_weights(
+                layer=layer,
+                num_experts=NUM_EXPERTS,
+                hidden_size=HIDDEN,
+                intermediate_size_per_partition=INTERMEDIATE,
+                params_dtype=torch.bfloat16,
+                weight_loader=original_weight_loader,
+            )
+
+        self.assertIs(layer.w13_weight.weight_loader, original_weight_loader)
+        self.assertIs(layer.w13_weight_scale_inv.weight_loader, original_weight_loader)
+        method._process_mxfp8_moe_weights = MagicMock()
+        method.process_weights_after_loading_block_quant(layer)
+        method._process_mxfp8_moe_weights.assert_called_once_with(layer, quantize=False)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_mxfp8_online_moe_loading_cuda.py
+++ b/test/registered/unit/layers/quantization/test_mxfp8_online_moe_loading_cuda.py
@@ -1,0 +1,121 @@
+"""GPU parity checks for chunked online MXFP8 MoE weight loading."""
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=60, stage="base-b", runner_config="4-gpu-b200")
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.test.test_utils import CustomTestCase
+
+ROWS = 65
+K = 256
+TEST_CHUNK_BYTES = 4096
+
+
+def _backend(*, flashinfer_trtllm: bool):
+    backend = MagicMock()
+    backend.is_flashinfer_trtllm.return_value = flashinfer_trtllm
+    backend.is_flashinfer_trtllm_routed.return_value = False
+    return backend
+
+
+class TestMxfp8OnlineMoeLoadingCuda(CustomTestCase):
+    def _run_parity_case(self, *, flashinfer_trtllm: bool):
+        from sglang.srt.layers.quantization import fp8 as fp8_quant
+        from sglang.srt.layers.quantization import fp8_utils
+
+        torch.manual_seed(42)
+        source = torch.randn(ROWS, K, dtype=torch.bfloat16)
+
+        if flashinfer_trtllm:
+            expected_q, expected_scale = fp8_utils.flashinfer_mxfp8_quantize(
+                source.cuda(), False
+            )
+        else:
+            expected_q, expected_scale = fp8_quant.mxfp8_group_quantize(source.cuda())
+        expected_q = expected_q.cpu().view(torch.uint8)
+        expected_scale = expected_scale.view(torch.uint8).cpu().view(ROWS, K // 32)
+
+        weight_param = torch.nn.Parameter(
+            torch.empty(ROWS, K, dtype=torch.float8_e4m3fn, device="cuda"),
+            requires_grad=False,
+        )
+        scale_param = torch.nn.Parameter(
+            torch.empty(ROWS, K // 32, dtype=torch.uint8, device="cuda"),
+            requires_grad=False,
+        )
+        layer = SimpleNamespace(
+            w13_weight=weight_param,
+            w2_weight=object(),
+            w13_weight_scale_inv=scale_param,
+            w2_weight_scale_inv=scale_param,
+            _map_global_expert_id_to_local_expert_id=lambda expert_id: expert_id,
+        )
+        calls = []
+
+        def original_weight_loader(
+            param, loaded_weight, *, weight_name, shard_id, expert_id
+        ):
+            calls.append(
+                (param, loaded_weight.clone(), weight_name, shard_id, expert_id)
+            )
+
+        with (
+            patch.object(
+                fp8_quant,
+                "get_moe_runner_backend",
+                return_value=_backend(flashinfer_trtllm=flashinfer_trtllm),
+            ),
+            patch.object(
+                fp8_quant,
+                "_ONLINE_MXFP8_MAX_CHUNK_BYTES",
+                TEST_CHUNK_BYTES,
+            ),
+        ):
+            loader = fp8_quant.Fp8MoEMethod.get_online_mxfp8_weight_loader(
+                layer, original_weight_loader
+            )
+            if flashinfer_trtllm:
+                quantizer = fp8_utils.flashinfer_mxfp8_quantize
+                quantizer_patch = patch.object(
+                    fp8_utils,
+                    "flashinfer_mxfp8_quantize",
+                    wraps=quantizer,
+                )
+            else:
+                quantizer = fp8_quant.mxfp8_group_quantize
+                quantizer_patch = patch.object(
+                    fp8_quant,
+                    "mxfp8_group_quantize",
+                    wraps=quantizer,
+                )
+            with quantizer_patch as chunk_quantize:
+                loader(
+                    weight_param,
+                    source,
+                    weight_name="experts.0.up_proj.weight",
+                    shard_id="w3",
+                    expert_id=0,
+                )
+
+        self.assertGreater(chunk_quantize.call_count, 1)
+        self.assertEqual(len(calls), 2)
+        self.assertTrue(torch.equal(calls[0][1].view(torch.uint8).cpu(), expected_q))
+        self.assertTrue(torch.equal(calls[1][1].cpu(), expected_scale))
+        self.assertIs(calls[1][0], scale_param)
+        self.assertEqual(calls[1][2], "experts.0.up_proj.weight_scale_inv")
+
+    def test_flashinfer_chunking_matches_whole_tensor_quantization(self):
+        self._run_parity_case(flashinfer_trtllm=True)
+
+    def test_triton_chunking_matches_whole_tensor_quantization(self):
+        self._run_parity_case(flashinfer_trtllm=False)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Online `--quantization mxfp8` currently allocates every MoE expert in the checkpoint dtype and starts module-by-module conversion only after the full local BF16/FP16 model has loaded. Large expert models can therefore OOM during startup even when the final MXFP8 model fits.

This follows the existing online NVFP4 loader design: quantize expert weights as checkpoint shards arrive, then leave only backend-specific layout finalization for post-load processing.

## Modifications

- Allocate final E4M3 expert weights and UE8M0 scales for online MXFP8 MoE layers before checkpoint loading.
- Wrap the existing FusedMoE loader and send both the quantized weight and generated `weight_scale_inv` through the canonical loader, preserving TP slicing, EP/EPLB placement, fused versus per-expert loaders, and w1/w3 ordering.
- Skip trivially non-local experts before quantization and process source rows in bounded 64 MiB accelerator chunks. Per-expert loads accumulate directly on the parameter device; fused all-expert checkpoints keep the accumulated output on CPU.
- The conversion unit is one incoming wrapped weight-loader invocation, not a full MoE layer. The wrapper sends the resulting weight and scale through the original canonical loader. Ultra's separate expert tensors are 20 MiB BF16 matrices and therefore one accelerator chunk. For fused tensors, the 64 MiB bound applies to accelerator source chunks; the completed quantized accumulator remains on CPU and scales with that incoming tensor.
- Keep the existing `_process_mxfp8_moe_weights` backend dispatcher and all of its HIP, CUTLASS ES, DeepGEMM, FlashInfer TRT-LLM/routed, and Triton branches. This change adds the streaming loader alongside that code instead of replacing or flattening the existing backend structure.
- Write load-time output in canonical MXFP8 layout. Native-MXFP8 branches then call the existing `quantize=False` path for FlashInfer TRT-LLM alignment, DeepGEMM scale packing, Triton-layout scale swizzling, or ROCm finalization. Gfx942 and forced block-FP8 conversion remain on the separate existing `_convert_mxfp8_moe_to_block_fp8` path.
- On Blackwell, explicit `flashinfer_trtllm` / `flashinfer_trtllm_routed` runners use FlashInfer's canonical-layout MXFP8 quantizer when FlashInfer is available. All other cases use the existing Triton MXFP8 quantizer during loading and then their existing backend-specific finalization.
- Keep serialized MXFP8 and FP4-expert paths outside the new online converter. Serialized tensors still bypass conversion and reuse backend layout finalization; dense-linear online MXFP8 is outside this change.
- Add no flag or alternate mode: load-time conversion is the online MXFP8 MoE behavior.

Base revision: `ff5578eb4e1d68d842303e3ab9ce4c86038c1c26`.
Head revision: `88060ea79fbbc0385f5d30964a6851acc9ae6222`.

Pinned-image backport revision: `c24ab2738e18f8e5b2cc809e37afe843e597a3af`.
Cumulative patch SHA-256: `8415f99f4486b532d5cf0a5297c6496b995af85b064fd1cf4bb446d1d0ad6bc8`.
Patched source tree: `63900a50605aa569737ee57e852dc0170f5aa41c`.

## Accuracy Tests

The cleaned additive implementation at head `88060ea79fbbc0385f5d30964a6851acc9ae6222` was validated with pinned image `lmsysorg/sglang@sha256:65376f9f5c317da614be2d6e2c683d8c4d7964cf8fa63f663a1cd058929598ca` (`nightly-dev-cu13-20260825-1ec20fd2`), PyTorch `2.13.0+cu130`, and FlashInfer `0.6.17`. The image checkout used backport `c24ab2738e18f8e5b2cc809e37afe843e597a3af`, which includes this change and prerequisite non-gated sizing fix `46d9427b913b20ce0d72b95a9209717448b37368`.

```text
test_mxfp8_online_moe_loading.py (CPU-only devbox)
Ran 10 tests
OK

test_mxfp8_online_moe_loading_cuda.py (NVIDIA B300)
Ran 2 tests
OK
```

The CUDA tests force multiple chunks and require bit-identical qweights and UE8M0 scales against whole-tensor quantization for both the FlashInfer and Triton quantizers.

The current CPU suite additionally covers final-dtype allocation, non-gated and gated W13 sizing, canonical weight/scale loader calls, fused four-argument loaders, `shard_id=None` routing for both W13 and W2, non-local expert skipping, Triton fallback, and serialized-MXFP8 bypass/finalization.

### Full-model accuracy

The original BF16 Ultra checkpoint loaded successfully on the clean head with two TP4/EP4 prefills and one TP8/EP8 decode. Prefill ranks reported 142.22 GB model memory after loading; decode ranks reported 72.93 GB. There was no OOM or backend fallback.

GSM8K used the exact Platinum command twice because the first clean-head result differed materially from the retained historical pass:

```bash
python3 bench_sglang.py --num-shots 8 --num-questions 1209 --parallel 1209 --platinum
```

```text
clean head pass 1: 1165/1209 correct, 2 invalid, 0.9636062861869313 exact accuracy, 45.560 s, 3473.579 output tok/s
clean head pass 2: 1160/1209 correct, 0 invalid, 0.9594706368899917 exact accuracy, 44.591 s, 3517.613 output tok/s
retained BF16:      1172/1209 correct, 2 invalid, 0.9693961952026469 exact accuracy
pre-refactor MXFP8: 1174/1209 correct, 0 invalid, 0.9710504549214226 exact accuracy
```

The clean-head passes have 1,180/1,209 equal parsed predictions and 791 byte-identical outputs; 29 parsed answers differ and accuracy moves by five questions. The retained BF16 control is non-contemporaneous and topology-confounded. These are task-level screens, not numerical-equivalence claims, and the single-pass deltas are not attributed to the loader change.

## Speed Tests and Profiling

The clean-head run used the pinned image on two B300 nodes (16 GPUs total): two colocated TP4/EP4 prefill engines on one node and one TP8/EP8 decode engine on the second. Every engine used `--quantization mxfp8 --moe-runner-backend flashinfer_trtllm --moe-a2a-backend none`.

The benchmark ran `sglang.benchmark.serving` with `random-ids`, tokenized prompts, 32,768 target input tokens, 2,048 target output tokens, the default non-uniform range (`--random-range-ratio 0`), seed 42, infinite request rate, and 256 prompts. A 16-request precondition completed first; all worker caches were then flushed, and the measured run used zero warmup requests.

| Completed | Input tokens | Output tokens | Duration (s) | Total tok/s | Output tok/s | Mean TTFT (ms) | Mean ITL (ms) | Mean E2E (ms) |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 256/256 | 4,317,108 | 270,665 | 106.803664 | 42,955.202302 | 2,534.229534 | 33,810.724080 | 15.979319 | 61,931.637979 |

```text
Successful requests: 256
Benchmark duration (s): 106.80366414692253
Total input tokens: 4317108
Total generated tokens: 270665
Request throughput (req/s): 2.3969215105564
Input token throughput (tok/s): 40420.97276794969
Output token throughput (tok/s): 2534.2295338076096
Peak output token throughput (tok/s): 2967.0
Total token throughput (tok/s): 42955.2023017573
Mean E2E Latency (ms): 61931.63797944271
P99 E2E Latency (ms): 104799.14466210174
Mean TTFT (ms): 33810.72407958163
P99 TTFT (ms): 86212.90899985468
Mean TPOT (ms): 66.43002845461918
P99 TPOT (ms): 823.4148158242413
Mean ITL (ms): 15.979319413538283
P99 ITL (ms): 20.537813908886164
```

This change reduces the checkpoint-dtype expert footprint retained during startup rather than changing steady-state kernels. The reported post-load model-memory values are not startup peaks, and no matched pre-change peak-memory run was collected. Against the pre-refactor reference, this single rerun had 2.3774% higher total throughput, 4.6532% higher mean TTFT, and 1.6442% higher mean ITL; it is consistent end-to-end validation, not an isolated performance attribution.

The current Ultra HXML run covers the explicit FlashInfer TRT-LLM backend. Triton and FlashInfer quantization have CUDA bitwise coverage, while CUTLASS, DeepGEMM, and ROCm layout finalization are retained existing code paths but have not received new clean-head end-to-end forwards. Existing global `auto` runner resolution semantics are unchanged; the HAI deployment sets its runner explicitly.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (No user-facing option or behavior switch was added.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
