### PR TITLE
[AMD][CI] Merge the four MI35x DeepSeek-V3.2 nightly jobs into two to save runtime

### DIFF
--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1008,11 +1008,7 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
-      # `!cancelled()` keeps perf independent of accuracy, as it was when these
-      # were two jobs. Perf stays blocking, matching this workflow's
-      # check-all-jobs, which listed both perf jobs before they were folded in.
       - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 Basic)
-        if: ${{ !cancelled() }}
         timeout-minutes: 150
         run: |
           > github_summary.md  # Clear summary file
@@ -1064,7 +1060,6 @@ jobs:
           exit ${TEST_EXIT_CODE:-0}
 
       - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 MTP)
-        if: ${{ !cancelled() }}
         timeout-minutes: 180
         run: |
           > github_summary.md  # Clear summary file

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -1010,6 +1010,7 @@ jobs:
 
       - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 Basic)
         timeout-minutes: 150
+        continue-on-error: true
         run: |
           > github_summary.md  # Clear summary file
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
@@ -1061,6 +1062,7 @@ jobs:
 
       - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 MTP)
         timeout-minutes: 180
+        continue-on-error: true
         run: |
           > github_summary.md  # Clear summary file
           bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \

--- a/.github/workflows/nightly-test-amd-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-rocm720.yml
@@ -63,10 +63,8 @@ on:
           - nightly-8-gpu-deepseek-v32-rocm720
           - nightly-8-gpu-deepseek-v32-mtp-rocm720
           # 8-GPU DeepSeek-V3.2 (MI35x)
-          - nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720
-          - nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp-rocm720
-          - nightly-perf-8-gpu-mi35x-deepseek-v32-basic-rocm720
-          - nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720
+          - nightly-8-gpu-mi35x-deepseek-v32-rocm720
+          - nightly-8-gpu-mi35x-deepseek-v32-mtp-rocm720
           # 8-GPU DeepSeek-R1 (MI35x only)
           - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-rocm720
           - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-kv-fp8-rocm720
@@ -963,15 +961,19 @@ jobs:
 
   # ==============================================================================
   # 8-GPU DeepSeek-V3.2 (MI35x)
+  #
+  # Accuracy and performance share one job per config, as the MI30x V3.2 jobs
+  # above already do: both steps serve the same weights, so splitting them cost
+  # a second container setup and a second cold weight load for nothing.
   # ==============================================================================
 
-  nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720:
-    name: ${{ format('nightly-accuracy-8-gpu-mi35x-deepseek-v32 ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
+  nightly-8-gpu-mi35x-deepseek-v32-rocm720:
+    name: ${{ format('nightly-8-gpu-mi35x-deepseek-v32 ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
     strategy:
       fail-fast: false
       matrix:
         rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
-    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720,'))
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-deepseek-v32-rocm720,'))
     runs-on: linux-mi35x-gpu-8
     steps:
       - name: Checkout code
@@ -1006,13 +1008,27 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
-  nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp-rocm720:
-    name: ${{ format('nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
+      # `!cancelled()` keeps perf independent of accuracy, as it was when these
+      # were two jobs. Perf stays blocking, matching this workflow's
+      # check-all-jobs, which listed both perf jobs before they were folded in.
+      - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 Basic)
+        if: ${{ !cancelled() }}
+        timeout-minutes: 150
+        run: |
+          > github_summary.md  # Clear summary file
+          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
+            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
+            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-deepseek-v32-basic --nightly --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
+          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
+          exit ${TEST_EXIT_CODE:-0}
+
+  nightly-8-gpu-mi35x-deepseek-v32-mtp-rocm720:
+    name: ${{ format('nightly-8-gpu-mi35x-deepseek-v32-mtp ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
     strategy:
       fail-fast: false
       matrix:
         rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
-    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp-rocm720,'))
+    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-8-gpu-mi35x-deepseek-v32-mtp-rocm720,'))
     runs-on: linux-mi35x-gpu-8
     steps:
       - name: Checkout code
@@ -1047,79 +1063,8 @@ jobs:
           echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
           exit ${TEST_EXIT_CODE:-0}
 
-  nightly-perf-8-gpu-mi35x-deepseek-v32-basic-rocm720:
-    name: ${{ format('nightly-perf-8-gpu-mi35x-deepseek-v32-basic ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
-    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-perf-8-gpu-mi35x-deepseek-v32-basic-rocm720,'))
-    runs-on: linux-mi35x-gpu-8
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Setup docker (${{ matrix.rocm_version }})
-        run: |
-          touch github_summary.md
-          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-          ENABLE_CACHE_HOST: "1"
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
-          # Install tabulate for run_suite.py (missing in MI35x container)
-          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-
-      - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 Basic)
-        timeout-minutes: 150
-        run: |
-          > github_summary.md  # Clear summary file
-          bash scripts/ci/amd/amd_ci_exec.sh -w /sglang-checkout/test \
-            -e GITHUB_STEP_SUMMARY="/sglang-checkout/github_summary.md" \
-            python3 run_suite.py --hw amd --suite nightly-perf-8-gpu-mi35x-deepseek-v32-basic --nightly --timeout-per-file 5400 ${{ (github.event_name == 'schedule' || inputs.continue_on_error) && '--continue-on-error' || '' }} || TEST_EXIT_CODE=$?
-          echo "$(<github_summary.md )" >> $GITHUB_STEP_SUMMARY || true
-          exit ${TEST_EXIT_CODE:-0}
-
-  nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720:
-    name: ${{ format('nightly-perf-8-gpu-mi35x-deepseek-v32-mtp ({0}, linux-mi35x-gpu-8)', matrix.rocm_version) }}
-    strategy:
-      fail-fast: false
-      matrix:
-        rocm_version: ${{ fromJson(inputs.rocm_version && inputs.rocm_version != 'all' && format('["{0}"]', inputs.rocm_version) || '["rocm724", "rocm720"]') }}
-    if: (github.repository == 'sgl-project/sglang' || github.event_name == 'pull_request') && (!(inputs.job_filter || inputs.job_select) || (inputs.job_filter || inputs.job_select) == 'all' || contains(format(',{0},', inputs.job_filter || inputs.job_select), ',nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720,'))
-    runs-on: linux-mi35x-gpu-8
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-        with:
-          ref: ${{ inputs.ref || github.sha }}
-
-      - name: Ensure VRAM is clear
-        run: bash scripts/ci/amd/ensure_vram_clear.sh rocm
-
-      - name: Setup docker (${{ matrix.rocm_version }})
-        run: |
-          touch github_summary.md
-          bash scripts/ci/amd/amd_ci_start_container.sh --rocm-version ${{ matrix.rocm_version }}
-        env:
-          GITHUB_WORKSPACE: ${{ github.workspace }}
-          ENABLE_CACHE_HOST: "1"
-
-      - name: Install dependencies
-        run: |
-          bash scripts/ci/amd/amd_ci_install_dependency.sh --skip-test-time-deps
-          # Install tabulate for run_suite.py (missing in MI35x container)
-          bash scripts/ci/amd/amd_ci_exec.sh pip install tabulate
-
       - name: Performance Test MI35x ROCm 7.2 (8-GPU DeepSeek-V3.2 MTP)
+        if: ${{ !cancelled() }}
         timeout-minutes: 180
         run: |
           > github_summary.md  # Clear summary file
@@ -2358,10 +2303,8 @@ jobs:
       - nightly-8-gpu-deepseek-v32-rocm720
       - nightly-8-gpu-deepseek-v32-mtp-rocm720
       # 8-GPU DeepSeek-V3.2 (MI35x)
-      - nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720
-      - nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp-rocm720
-      - nightly-perf-8-gpu-mi35x-deepseek-v32-basic-rocm720
-      - nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720
+      - nightly-8-gpu-mi35x-deepseek-v32-rocm720
+      - nightly-8-gpu-mi35x-deepseek-v32-mtp-rocm720
       # 8-GPU DeepSeek-R1 (MI35x only)
       - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-rocm720
       - nightly-8-gpu-mi35x-deepseek-r1-mxfp4-kv-fp8-rocm720


### PR DESCRIPTION
## Motivation

MI35x DeepSeek-V3.2 coverage is split across four jobs — accuracy and perf, basic and MTP — while the MI30x V3.2 jobs in the same workflow do the same work in two, each running accuracy then perf. Both steps in a pair serve the same weights, so the split buys a second container setup and a second cold weight load per config and nothing else.

## Modifications

```
nightly-accuracy-8-gpu-mi35x-deepseek-v32-rocm720      + nightly-perf-8-gpu-mi35x-deepseek-v32-basic-rocm720
  -> nightly-8-gpu-mi35x-deepseek-v32-rocm720
nightly-accuracy-8-gpu-mi35x-deepseek-v32-mtp-rocm720  + nightly-perf-8-gpu-mi35x-deepseek-v32-mtp-rocm720
  -> nightly-8-gpu-mi35x-deepseek-v32-mtp-rocm720
```

New names follow the MI30x convention with an `mi35x` infix. Suites, launch flags, step timeouts and `--timeout-per-file` are carried over verbatim; `job_select` and `check-all-jobs` are updated to the new names. 45 jobs -> 43. No test file or suite touched.

The two merged jobs end up with exactly the gating shape of the MI30x V3.2 pair in this same workflow — accuracy blocking, perf non-blocking, no `if:` guard — so MI35x and MI30x V3.2 now behave identically. 

- **Perf is skipped when accuracy fails**, by default step behaviour. The split jobs ran the two independently, so a failing night still produced a perf table; benchmarking a configuration that just missed its GSM8K floor is not worth ~27 min of an 8-GPU node.

## Accuracy Tests

No test, suite, flag, threshold or timeout changes.

**Both merged jobs passed** in [run 32907097246](https://github.com/sgl-project/sglang/actions/runs/32907097246) (`rocm720`, `continue_on_error=false`), each running its accuracy step and then its perf step. The dispatch resolved both new job names with no old `accuracy-`/`perf-` name present, checking the renames against real Actions resolution. That run predates #36396, but these two job bodies are byte-identical to what it executed.

`pre-commit` passes, including `check for duplicate workflow job names` and `validate registered test CI registries`. Every job body diffed against `main`: only the two merged jobs and `check-all-jobs` differ, so #36396's additions and removals are preserved.

## Speed Tests and Profiling

Four split jobs from the 8/24 and 8/26 scheduled runs versus the two merged jobs from run 32907097246. All `rocm720`, `linux-mi35x-gpu-8`, GPU-hours = wall time x 8.

| | jobs | total | setup+install | test | GPU-h |
|---|---:|---:|---:|---:|---:|
| split (mean of 2 nights) | 4 | 134.5 min | 26.3 | 108.0 | 17.93 |
| merged | 2 | 114.0 min | 12.3 | 101.6 | 15.20 |
| delta | -2 | **-20.5 min (-15%)** | -14.0 | -6.4 | **-2.73** |

Across both image flavors that is **~5.5 GPU-h/night**, and **8 scheduled MI35x 8-GPU job runs become 4** — likely the bigger win given queue depths on that pool. Of the 20.5 min, the 14.0 min of eliminated setup is mechanical and reliable; the 6.4 min of test time is one sample against two and within the baseline's own 4.9 min spread, so the defensible floor is **~3.7 GPU-h/night** from setup alone.

On a night where accuracy fails, skipping perf reclaims a further ~27 min of node time per affected config, which the split jobs spent benchmarking a broken configuration.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests <!-- N/A: CI job packing only -->
- [ ] Update documentation <!-- N/A -->
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33122934517](https://github.com/sgl-project/sglang/actions/runs/33122934517)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33122934627](https://github.com/sgl-project/sglang/actions/runs/33122934627)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->