### PR TITLE
[HiCache] Fence load-back behind the forward stream

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -361,6 +361,9 @@ class HiCacheController:
         self.load_queue: List[CacheOperation] = []
         self.write_queue: List[CacheOperation] = []
         self.ack_load_queue: List[HiCacheAck] = []
+        # Set by the scheduler to the forward stream; gates load-back H2D
+        # behind in-flight forwards (see start_loading).
+        self.load_fence_stream = None
         self.ack_write_queue: List[HiCacheAck] = []
 
         self.l2_transfer_engine = L2TransferEngine(io_backend)
@@ -921,6 +924,14 @@ class HiCacheController:
         self.load_queue.clear()
         producer_event = self.layer_done_counter.events[producer_id]
         producer_event.start_event.record()
+
+        if self.load_fence_stream is not None:
+            # Pages reallocated to this load can still take writes from rounds
+            # launched before their free; compute-stream consumers are ordered
+            # after those writes implicitly, this H2D load must fence.
+            self.l2_transfer_engine.host_to_device_stream.wait_stream(
+                self.load_fence_stream
+            )
 
         completion = self.l2_transfer_engine.submit_host_to_device(
             self._l2_load_transfers(host_indices, device_indices, pool_transfers),

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -284,12 +284,6 @@ class PrefetchOperation(StorageOperation):
 
 class HiCacheController:
 
-    # Set by the scheduler to the forward stream; gates load-back H2D behind
-    # in-flight forwards (see start_loading). Declared on the class so that
-    # instances built without __init__ -- and Mock(spec=...) doubles -- still
-    # resolve it.
-    load_fence_stream = None
-
     def __init__(
         self,
         token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
@@ -367,6 +361,9 @@ class HiCacheController:
         self.load_queue: List[CacheOperation] = []
         self.write_queue: List[CacheOperation] = []
         self.ack_load_queue: List[HiCacheAck] = []
+        # Set by the scheduler to the forward stream; gates load-back H2D
+        # behind in-flight forwards (see start_loading).
+        self.load_fence_stream = None
         self.ack_write_queue: List[HiCacheAck] = []
 
         self.l2_transfer_engine = L2TransferEngine(io_backend)
@@ -929,9 +926,9 @@ class HiCacheController:
         producer_event.start_event.record()
 
         if self.load_fence_stream is not None:
-            # Pages reallocated to this load can still take writes from rounds
-            # launched before their free; compute-stream consumers are ordered
-            # after those writes implicitly, this H2D load must fence.
+            # in overlap scheduling, reclaimed pages might still be written by the forward thread
+            # therefore a fence is needed for loading thread to prevent memory corruption
+            # todo: it's possible to use a finer-grained fence
             self.l2_transfer_engine.host_to_device_stream.wait_stream(
                 self.load_fence_stream
             )

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -284,6 +284,12 @@ class PrefetchOperation(StorageOperation):
 
 class HiCacheController:
 
+    # Set by the scheduler to the forward stream; gates load-back H2D behind
+    # in-flight forwards (see start_loading). Declared on the class so that
+    # instances built without __init__ -- and Mock(spec=...) doubles -- still
+    # resolve it.
+    load_fence_stream = None
+
     def __init__(
         self,
         token_to_kv_pool_allocator: BaseTokenToKVPoolAllocator,
@@ -361,9 +367,6 @@ class HiCacheController:
         self.load_queue: List[CacheOperation] = []
         self.write_queue: List[CacheOperation] = []
         self.ack_load_queue: List[HiCacheAck] = []
-        # Set by the scheduler to the forward stream; gates load-back H2D
-        # behind in-flight forwards (see start_loading).
-        self.load_fence_stream = None
         self.ack_write_queue: List[HiCacheAck] = []
 
         self.l2_transfer_engine = L2TransferEngine(io_backend)

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -577,6 +577,12 @@ class Scheduler(
         self.token_to_kv_pool_allocator = result.token_to_kv_pool_allocator
         self.disable_radix_cache = result.disable_radix_cache
         self.tree_cache = result.tree_cache
+        if self.enable_hierarchical_cache:
+            cache_controller = self.tree_cache.cache_controller
+            if cache_controller is not None:
+                cache_controller.load_fence_stream = (
+                    self.tp_worker.model_runner.forward_stream
+                )
         self.emit_metrics_constants()
         self.maybe_init_hccl_dp_prewarm()
 

--- a/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
+++ b/test/registered/unit/mem_cache/test_hicache_staged_write_back_dispatch.py
@@ -230,6 +230,7 @@ class TestHiCacheStagedWriteBackDispatch(CustomTestCase):
         controller._num_tokens_by_pool.return_value = {}
         controller._transfer_num_bytes.return_value = 0
         controller.l2_transfer_engine = mock.Mock()
+        controller.load_fence_stream = None
         completion = SimpleNamespace(
             start_event=object(), finish_event=object(), timing_enabled=False
         )


### PR DESCRIPTION
## Motivation

Overlap scheduling frees a finished or retracted request's KV pages while the
round already launched for it is still writing them. A consumer that reuses
those pages from the compute stream is ordered after those writes implicitly,
so it sees correct data.

The hicache load-back H2D has no such ordering: it writes the reallocated pages
from the transfer stream. In-flight writes from the earlier round can therefore
race the restore and corrupt a restored prefix.

## Modifications

- `managers/cache_controller.py`: add `HiCacheController.load_fence_stream`
  (default `None`). In `start_loading`, when it is set, wait the transfer
  engine's `host_to_device_stream` on it before submitting the load's copies.
- `managers/scheduler.py`: after the tree cache is built, point
  `cache_controller.load_fence_stream` at the model runner's `forward_stream`
  when hierarchical cache is enabled.

`HybridCacheController` subclasses `HiCacheController`, so it inherits both the
new attribute and the fenced `start_loading`; the guard also tolerates tree
caches with no controller, since `BasePrefixCache` defaults `cache_controller`
to `None`.

The stream-binding change in #36572 is what actually places these copies on the
fenced transfer stream. Without it this wait is a harmless no-op, so the two can
merge in either order.

## Accuracy Tests

N/A as a standalone numerical check — the change adds stream ordering and does
not alter any computation. Its purpose is to remove a data race that corrupted
restored prefixes; the corruption is timing-dependent and does not reproduce
deterministically in a unit test.

## Speed Tests and Profiling

One `wait_stream` per load-back submission, not per copy. It can delay a
load-back until the in-flight forward completes, which is the intended ordering.

## Original commits

- `585c6a7524`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33147439310](https://github.com/sgl-project/sglang/actions/runs/33147439310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33150271970](https://github.com/sgl-project/sglang/actions/runs/33150271970)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33147439350](https://github.com/sgl-project/sglang/actions/runs/33147439350)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->