### PR TITLE
Update Qwen3.5 MI355X MXFP4 for AgentX HiCache MTP

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx
@@ -1029,6 +1029,73 @@ python3 -m sglang.launch_server \
   --hicache-write-policy write_through_selective
 ```
 
+#### 5.2.4 Agentic Long-Context with HiCache DRAM Offload (MI355X MXFP4, MTP)
+
+The MI355X counterpart of the recipe above, using the MXFP4 checkpoint and the AITER attention backend.
+
+Container image (pinned for reproducibility):
+`lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260818`.
+
+Server Launch Command (TP4, EP1):
+```bash Command
+SGLANG_USE_AITER=1 \
+SGLANG_USE_AITER_UNIFIED_ATTN=1 \
+AITER_FLYDSL_FORCE=1 \
+SGLANG_MAMBA_SSM_DTYPE=bfloat16 \
+SGLANG_TIMEOUT_KEEP_ALIVE=1800 \
+python3 -m sglang.launch_server \
+  --model-path amd/Qwen3.5-397B-A17B-MXFP4 \
+  --served-model-name amd/Qwen3.5-397B-A17B-MXFP4 \
+  --trust-remote-code \
+  --tp 4 \
+  --dp 1 \
+  --ep-size 1 \
+  --attention-backend aiter \
+  --page-size 16 \
+  --kv-cache-dtype fp8_e4m3 \
+  --mem-fraction-static 0.80 \
+  --max-prefill-tokens 32768 \
+  --chunked-prefill-size 32768 \
+  --cuda-graph-max-bs 64 \
+  --max-running-requests 128 \
+  --scheduler-recv-interval 30 \
+  --stream-interval 50 \
+  --tokenizer-worker-num 6 \
+  --reasoning-parser qwen3 \
+  --tool-call-parser qwen3_coder \
+  --model-loader-extra-config '{"enable_multithread_load": true}' \
+  --watchdog-timeout 1200 \
+  --enable-metrics \
+  --enable-cache-report \
+  --speculative-algorithm EAGLE \
+  --speculative-num-steps 3 \
+  --speculative-eagle-topk 1 \
+  --speculative-num-draft-tokens 4 \
+  --enable-hierarchical-cache \
+  --hicache-ratio 1.5 \
+  --hicache-write-policy write_through \
+  --hicache-io-backend direct \
+  --hicache-mem-layout page_first_direct
+```
+
+For the TP2 arm, set `--tp 2` and drop `--tokenizer-worker-num 6`, which is only applied from TP4 up.
+
+`--cuda-graph-max-bs` tracks the client concurrency and is capped at 64; `--max-running-requests` is twice the concurrency. The command above is the top of the sweep, concurrency 64.
+
+The host tier is what extends the sweep. With device KV only, TP4 tops out at concurrency 40 and TP2 at 20; the HiCache arms cover 40 to 64 and 20 to 32 respectively. Each HiCache arm deliberately repeats its device-only neighbor's last concurrency so the host tier's contribution is read at a fixed operating point instead of across a concurrency step. Keep `--page-size 16` identical between the two arms so they differ only in the cache tier.
+
+`--hicache-ratio 1.5` sizes the host tier at 1.5x the device KV cache, so the node needs that much free CPU DRAM per server on top of the model weights. It is the first knob to retune if the host pool is oversubscribed or the hit rate is poor.
+
+For throughput measurement, pin the acceptance length instead of letting it drift between runs:
+
+```bash Command
+export SGLANG_SIMULATE_ACC_LEN=3.39
+export SGLANG_SIMULATE_ACC_METHOD=match-expected
+export SGLANG_SIMULATE_ACC_TOKEN_MODE=real-draft-token
+```
+
+Leave these unset for accuracy runs so the draft tokens are verified against the target model.
+
 ### 5.3 Vision Speed Benchmark
 
 We use SGLang's built-in benchmarking tool to conduct performance evaluation with random images. Each request has 128 input tokens, two 720p images, and 1024 output tokens.


### PR DESCRIPTION
## Motivation

Best config based on https://github.com/SemiAnalysisAI/InferenceX/pull/2693.

The Qwen3.5 cookbook has an agentic HiCache section for H200 FP8 (§5.2.3, added in #35194) but no MI355X counterpart, even though the AMD arm of the AgentX sweep now carries a HiCache host-DRAM KV tier.

Upstream InferenceX #2693 closed two structural gaps between `qwen3.5-fp4-mi355x-sglang-agentic-mtp` and its B200 sibling: the MI355X arm ran GPU-resident KV only and stopped at concurrency 40 while B200 rode a host-DRAM tier past 64, and the 2-GPU point swept TP2/EP2 against B200's TP2/EP1. With that landed upstream, the cookbook is the remaining place where an AMD user reproducing the AgentX recipe has nothing to copy.

## Modifications

Add §5.2.4 "Agentic Long-Context with HiCache DRAM Offload (MI355X MXFP4, MTP)" to `docs/cookbook/autoregressive/Qwen/Qwen3.5.mdx`, mirroring the structure of the H200 FP8 section above it.

The launch command is transcribed from `benchmarks/single_node/agentic/qwen3.5_fp4_mi355x_sglang_mtp.sh` at the TP4/EP1 arm, pinned to the same container image the sweep runs (`lmsysorg/sglang-rocm:v0.5.17-rocm720-mi35x-20260818`) and the same checkpoint (`amd/Qwen3.5-397B-A17B-MXFP4`):

- HiCache tier: `--enable-hierarchical-cache --hicache-ratio 1.5 --hicache-write-policy write_through --hicache-io-backend direct --hicache-mem-layout page_first_direct`. This is the combination already validated on `cluster:mi355x-amds` by the sibling `dsv4` and `glm5.2` MI355X AgentX recipes, and it matches what the Qwen3.5 deployment generator already emits for the MI355X Host DRAM (HiCache) option.
- MTP: EAGLE with `--speculative-num-steps 3 --speculative-eagle-topk 1 --speculative-num-draft-tokens 4`.
- ROCm serving path: `SGLANG_USE_AITER=1`, `SGLANG_USE_AITER_UNIFIED_ATTN=1`, `AITER_FLYDSL_FORCE=1`, `SGLANG_MAMBA_SSM_DTYPE=bfloat16`, `--attention-backend aiter`, `--page-size 16`, `--kv-cache-dtype fp8_e4m3`.

Accompanying prose covers what a reader cannot read off the flag list:

- the TP2 arm differs only by `--tp 2` and dropping `--tokenizer-worker-num 6`, which the sweep applies from TP4 up;
- `--cuda-graph-max-bs` tracks client concurrency capped at 64 and `--max-running-requests` is twice concurrency, so the pasted values correspond to concurrency 64;
- the device-only arms top out at concurrency 40 (TP4) and 20 (TP2) while the HiCache arms cover 40-64 and 20-32, and each HiCache arm repeats its neighbor's ceiling concurrency so the host tier's contribution is read at a fixed operating point rather than across a concurrency step;
- `--page-size 16` is held identical across both arms so they differ only in the cache tier;
- `--hicache-ratio 1.5` sizes the host tier at 1.5x the device KV cache, so it needs that much free CPU DRAM per server beyond the weights, and it is the first knob to retune;
- throughput runs pin the acceptance length with `SGLANG_SIMULATE_ACC_LEN=3.39` / `match-expected` / `real-draft-token`, and accuracy runs leave those unset so draft tokens are verified against the target model.

Docs-only change; no code paths touched.

## Accuracy Tests

Not applicable — documentation only, no inference logic changed. The recipe's accuracy arm is the AgentX eval, which retains real target-model verification (the `SGLANG_SIMULATE_ACC_*` knobs are documented as throughput-only and explicitly left unset for accuracy runs).

## Speed Tests and Profiling

No SGLang code changed, so there is nothing to benchmark in this repo. The numbers backing the recipe come from the upstream sweep triggered on InferenceX #2693; per that PR, `HICACHE_RATIO` is the starting point inherited from the sibling MI355X recipes and the first knob to retune if the host pool is oversubscribed or the hit rate is poor.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829329564](https://github.com/sgl-project/sglang/actions/runs/34829329564)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829329293](https://github.com/sgl-project/sglang/actions/runs/34829329293)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->