### PR TITLE
[HiCache] Wait for load-back before deferred Mamba COW

### DIFF
--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -1407,6 +1407,13 @@ class HybridReqToTokenPool(ReqToTokenPool):
     def get_mamba_indices(self, req_indices: torch.Tensor) -> torch.Tensor:
         return self.req_index_to_mamba_index_mapping[req_indices]
 
+    def wait_for_hicache_load_complete(self) -> None:
+        """Order whole-slot consumers after an active layerwise H->D load."""
+        if self.layer_transfer_counter is not None:
+            self.layer_transfer_counter.wait_until(
+                self.layer_transfer_counter.num_layers - 1
+            )
+
     def translate_mamba_indices(self, mamba_indices: torch.Tensor) -> torch.Tensor:
         """Virtual->physical mamba-slot translate. Identity for a static pool
         (slots are physical); UnifiedHybridReqToTokenPool overrides it for the

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -1683,6 +1683,10 @@ class ModelRunner:
             forward_batch.mamba_cow_src_indices is not None
             and len(forward_batch.mamba_cow_src_indices) > 0
         ):
+            # HiCache publishes restored radix slots while their layerwise H->D
+            # transfer is still in flight. Deferred COW consumes a whole slot,
+            # so it must wait for the final layer rather than copy partial state.
+            pool.wait_for_hicache_load_complete()
             if pool.mamba_ckpt_pool is not None:
                 # int8 checkpoints: dequantize src int8 ckpt slot into the active bf16 dst.
                 pool.mamba_ckpt_pool.load_to_active(

--- a/test/registered/unit/mem_cache/test_mamba_unittest.py
+++ b/test/registered/unit/mem_cache/test_mamba_unittest.py
@@ -1,5 +1,6 @@
 import unittest
 from array import array
+from types import SimpleNamespace
 
 import torch
 
@@ -44,6 +45,61 @@ class TestMamba(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         pass
+
+    def test_whole_slot_consumer_waits_for_final_hicache_layer(self):
+        calls = []
+
+        class Counter:
+            num_layers = 48
+
+            def wait_until(self, layer_id):
+                calls.append(layer_id)
+
+        pool = object.__new__(HybridReqToTokenPool)
+        pool.layer_transfer_counter = Counter()
+
+        pool.wait_for_hicache_load_complete()
+
+        self.assertEqual(calls, [47])
+
+    def test_deferred_cow_waits_for_hicache_before_copy(self):
+        from sglang.srt.model_executor.forward_batch_info import ForwardMode
+        from sglang.srt.model_executor.model_runner import ModelRunner
+
+        calls = []
+
+        class Counter:
+            num_layers = 48
+
+            def wait_until(self, layer_id):
+                calls.append(("wait", layer_id))
+
+        class MambaState:
+            def copy_from(self, src, dst):
+                calls.append(("copy", src.clone(), dst.clone()))
+
+        pool = object.__new__(HybridReqToTokenPool)
+        pool.layer_transfer_counter = Counter()
+        pool.mamba_ckpt_pool = None
+        pool.mamba_pool = MambaState()
+        pool.translate_mamba_indices = lambda indices: indices
+
+        runner = object.__new__(ModelRunner)
+        runner.req_to_token_pool = pool
+        runner.is_draft_worker = False
+        forward_batch = SimpleNamespace(
+            forward_mode=ForwardMode.EXTEND,
+            mamba_clear_indices=None,
+            mamba_cow_src_indices=torch.tensor([2]),
+            mamba_cow_dst_indices=torch.tensor([5]),
+        )
+
+        runner._maybe_execute_deferred_mamba_cow_and_clear(forward_batch)
+
+        self.assertEqual(calls[0], ("wait", 47))
+        self.assertEqual(calls[1][0], "copy")
+        self.assertTrue(torch.equal(calls[1][1], torch.tensor([2])))
+        self.assertTrue(torch.equal(calls[1][2], torch.tensor([5])))
 
     def test_hybrid_linear_kv_pool(self):
         size = 16


### PR DESCRIPTION
## Motivation

HiCache restores Mamba state layer by layer on its H2D transfer stream. A
restored radix slot can be selected as the source of deferred Mamba copy-on-
write before that layerwise transfer has finished. Deferred COW consumes the
entire source slot at once, before the model's existing per-layer waits can
order those reads, so it can copy a partially restored state into the request-
owned destination.

## Modifications

- Add `HybridReqToTokenPool.wait_for_hicache_load_complete()`, which waits for
  the final event in the active layer transfer counter and is a no-op when no
  HiCache load is active.
- Call that fence immediately before deferred whole-slot Mamba COW. The
  clear-only path and ordinary per-layer Mamba reads are unchanged.
- Add focused tests for both the final-layer fence and wait-before-copy
  ordering.

This is complementary to #36738:

- #36738 orders the HiCache load producer after prior forward-stream writes.
- This PR orders a whole-slot COW consumer after that load completes.

The two changes protect opposite sides of the load and can merge independently.

## Accuracy Tests

The two focused regressions fail on `dc10483592`:

- the final-load fence method is absent;
- deferred COW copies before waiting.

They pass with this change:

```text
2 passed, 10 deselected
```

The complete registered Mamba unit file also passes:

```text
12 passed
```

## Speed Tests and Profiling

No benchmark was run. The wait is reached only for deferred whole-slot Mamba
COW while a HiCache layer transfer counter is active. It adds no work when
there is no active load; when there is one, waiting for the final transfer is
the required ordering.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33125188060](https://github.com/sgl-project/sglang/actions/runs/33125188060)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33125187898](https://github.com/sgl-project/sglang/actions/runs/33125187898)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33125188020](https://github.com/sgl-project/sglang/actions/runs/33125188020)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->