### PR TITLE
fix(anthropic): return 400 for template-rejected effort, stop rewriting xhigh

### DIFF
--- a/python/sglang/srt/entrypoints/anthropic/protocol.py
+++ b/python/sglang/srt/entrypoints/anthropic/protocol.py
@@ -329,9 +329,9 @@ class AnthropicTaskBudget(BaseModel):
 class AnthropicOutputConfig(BaseModel):
     """Claude 4.7 ``output_config`` block.
 
-    ``effort`` maps to the OpenAI ``reasoning_effort`` knob (``xhigh`` →
-    ``max`` because the OpenAI Literal does not include ``xhigh``).
-    ``task_budget`` is propagated as a custom-param hint.
+    ``effort`` maps directly onto the OpenAI ``reasoning_effort`` knob,
+    which accepts every tier in this Literal. ``task_budget`` is
+    propagated as a custom-param hint.
     """
 
     effort: Optional[Literal["minimal", "low", "medium", "high", "xhigh", "max"]] = None

--- a/python/sglang/srt/entrypoints/anthropic/serving.py
+++ b/python/sglang/srt/entrypoints/anthropic/serving.py
@@ -621,17 +621,14 @@ class AnthropicServing:
             self.openai_serving_chat.apply_reasoning_enabled(chat_request, enabled)
 
         # Claude 4.7 ``output_config``: map ``effort`` onto the OpenAI
-        # ``reasoning_effort`` knob. ``xhigh`` collapses to ``max`` because
-        # the OpenAI Literal does not include the Anthropic-only ``xhigh``.
-        # ``task_budget`` is a soft hint forwarded as a custom param so the
-        # model can see it without it becoming a hard cap (``max_tokens``
-        # is still the hard cap).
+        # ``reasoning_effort`` knob, which accepts every tier the Anthropic
+        # Literal allows. ``task_budget`` is a soft hint forwarded as a
+        # custom param so the model can see it without it becoming a hard
+        # cap (``max_tokens`` is still the hard cap).
         if anthropic_request.output_config is not None:
             oc = anthropic_request.output_config
             if oc.effort is not None:
-                chat_request.reasoning_effort = (
-                    "max" if oc.effort == "xhigh" else oc.effort
-                )
+                chat_request.reasoning_effort = oc.effort
             if oc.task_budget is not None:
                 # Custom params are silently ignored by backends that
                 # don't recognise them; logging it makes the propagation
@@ -768,6 +765,15 @@ class AnthropicServing:
             )
         except asyncio.CancelledError:
             raise
+        except ValueError as e:
+            # Template rejections (e.g. an effort tier the template does not
+            # accept) arrive as ValueError; the OpenAI path returns 400 for
+            # these, so mirror it instead of reporting a server fault.
+            return self._error_response(
+                status_code=400,
+                error_type="invalid_request_error",
+                message=_scrub_error_message(str(e), 400),
+            )
         except Exception as e:
             logger.exception("Error processing Anthropic request: %s", e)
             return self._error_response(
@@ -813,6 +819,15 @@ class AnthropicServing:
             adapted_request.received_time = received_time
         except asyncio.CancelledError:
             raise
+        except ValueError as e:
+            # Template rejections (e.g. an effort tier the template does not
+            # accept) arrive as ValueError; the OpenAI path returns 400 for
+            # these, so mirror it instead of reporting a server fault.
+            return self._error_response(
+                status_code=400,
+                error_type="invalid_request_error",
+                message=_scrub_error_message(str(e), 400),
+            )
         except Exception as e:
             logger.exception("Error converting streaming request: %s", e)
             return self._error_response(

--- a/test/registered/unit/entrypoints/anthropic/test_serving.py
+++ b/test/registered/unit/entrypoints/anthropic/test_serving.py
@@ -86,6 +86,19 @@ class _FakeNonStreamingErrorOpenAI:
         )
 
 
+class _FakeRaisingOpenAI:
+    """Raises a configurable exception from ``_convert_to_internal_request``."""
+
+    def __init__(self, exc):
+        self._exc = exc
+
+    def _validate_request(self, chat_request):
+        return None
+
+    def _convert_to_internal_request(self, chat_request, raw_request):
+        raise self._exc
+
+
 class _FakeNonStreamingOpenAI:
     """Returns a configurable ChatCompletionResponse from the OpenAI handler."""
 
@@ -531,6 +544,50 @@ class TestAnthropicServing(unittest.TestCase):
         self.assertEqual(payload["error"]["type"], "invalid_request_error")
         self.assertEqual(payload["error"]["message"], "context length exceeded")
 
+    def test_template_rejection_returns_400(self):
+        """A template that rejects the request is a client error, not a 500."""
+        message = (
+            "Unexpected reasoning effort high. "
+            "Supported types are xhigh (default), medium, and low."
+        )
+        chat_request = ChatCompletionRequest(
+            model="test-model",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        for stream, handler_name in [
+            (False, "_handle_non_streaming"),
+            (True, "_handle_streaming"),
+        ]:
+            with self.subTest(stream=stream):
+                serving = AnthropicServing(_FakeRaisingOpenAI(ValueError(message)))
+                handler = getattr(serving, handler_name)
+                anthropic_request = self._anthropic_request(stream=stream)
+                response = asyncio.run(
+                    handler(chat_request, anthropic_request, object())
+                )
+                payload = json.loads(response.body)
+                self.assertEqual(response.status_code, 400)
+                self.assertEqual(payload["error"]["type"], "invalid_request_error")
+                self.assertIn("Supported types are xhigh", payload["error"]["message"])
+
+    def test_unexpected_exception_still_returns_500(self):
+        """Only ValueError is reclassified; other failures stay server faults."""
+        serving = AnthropicServing(_FakeRaisingOpenAI(RuntimeError("boom")))
+        chat_request = ChatCompletionRequest(
+            model="test-model",
+            max_tokens=16,
+            messages=[{"role": "user", "content": "hello"}],
+        )
+        response = asyncio.run(
+            serving._handle_non_streaming(
+                chat_request, self._anthropic_request(stream=False), object()
+            )
+        )
+        payload = json.loads(response.body)
+        self.assertEqual(response.status_code, 500)
+        self.assertEqual(payload["error"]["message"], "Internal server error")
+
     # ------------------------------------------------------------------
     # Edge-case coverage added in the review-fix pass
     # ------------------------------------------------------------------
@@ -887,7 +944,7 @@ class TestAnthropicServing(unittest.TestCase):
             ("low", "low"),
             ("medium", "medium"),
             ("high", "high"),
-            ("xhigh", "max"),  # OpenAI Literal has no xhigh
+            ("xhigh", "xhigh"),
             ("max", "max"),
         ]:
             with self.subTest(anthropic_effort=anthropic_effort):


### PR DESCRIPTION
## Motivation

Fixes #36741.

`output_config.effort` is forwarded into the chat template unvalidated. A template that restricts the set raises `jinja2.TemplateError`, which `_apply_jinja_template` re-raises as `ValueError`; the OpenAI surface maps that to 400, but both Anthropic handlers caught it in their generic `except Exception` and returned 500. `_scrub_error_message` blanks 5xx bodies by design, so the accepted values never reached the client. The reporter lost 27.6% of requests while 4xx-based health checks read clean.

The `xhigh -> max` rewrite is separately stale. It landed in #25876 when `ReasoningEffortTier` had no `xhigh`; #31681 added one. `_EFFORT_MAP` maps both tiers to the same `0.99`, so the rewrite changed nothing downstream while replacing a template-visible string some templates accept with one they reject, including the reporter's, where `xhigh` is the template default.

## Modifications

- `anthropic/serving.py`: pass `oc.effort` through unchanged, and catch `ValueError` ahead of the generic handler in both `_handle_non_streaming` and `_handle_streaming`, returning 400 / `invalid_request_error` with the scrubbed message. The Anthropic `effort` Literal is a subset of `ReasoningEffortTier`, so every value it can carry is valid downstream.
- `anthropic/protocol.py`: drop the same stale mapping note from the `AnthropicOutputConfig` docstring.
- `test_serving.py`: cover both handlers, pin that non-`ValueError` failures stay 500, and correct the `("xhigh", "max")` row that encoded the old behaviour. Verified red before the fix — `'max' != 'xhigh'` and `500 != 400` on both handlers.

## Accuracy Tests

N/A. No kernel, model forward, or sampling changes.

## Speed Tests and Profiling

N/A. The added branch runs only on a request that was already failing.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Notes

- Catching `ValueError` as a client error mirrors what `serving_base.py` already does for the OpenAI surface, rather than introducing a new rule. A test pins that other exception types still return 500.
- I have not reproduced this on the reporter's model. The reasoning is template-generic and the tests drive the handlers directly. Happy to narrow the catch to the template path specifically if you'd rather not treat every `ValueError` here as a 400.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33125663262](https://github.com/sgl-project/sglang/actions/runs/33125663262)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33125663172](https://github.com/sgl-project/sglang/actions/runs/33125663172)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33125663397](https://github.com/sgl-project/sglang/actions/runs/33125663397)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->