### PR TITLE
Revert "[NPU] [bugfix] Fix import of ggml_moe_a8_vec and Fix NPU MLA HiCache backup accessing missing data_ptrs"

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_flashinfer_trtllm_moe.py
@@ -17,7 +17,6 @@ from sglang.srt.layers.moe.utils import RoutingMethodType
 from sglang.srt.runtime_context import get_exec
 from sglang.srt.utils import (
     is_flashinfer_available,
-    is_npu,
     log_info_on_rank0,
     set_weight_attrs,
 )
@@ -381,6 +380,7 @@ def maybe_fuse_routed_scale_and_shared_add(
     # alpha=scale)`. With no shared output, the missing scale is applied
     # in-place. Otherwise `routed` is already scale-final and we just add
     # `shared` (or pass through if there is none).
+    from sglang.srt.layers.quantization.expert_pack import ExpertPackMoEMethod
     from sglang.srt.layers.quantization.mxfp4_flashinfer_cutlass_moe import (
         Mxfp4FlashinferCutlassMoEMethod,
     )
@@ -388,17 +388,15 @@ def maybe_fuse_routed_scale_and_shared_add(
         Mxfp4MarlinMoEMethod,
     )
 
-    fused_methods = [
-        Mxfp4FlashinferTrtllmMoEMethod,
-        Mxfp4FlashinferCutlassMoEMethod,
-        Mxfp4MarlinMoEMethod,
-    ]
-    if not is_npu():
-        from sglang.srt.layers.quantization.expert_pack import ExpertPackMoEMethod
-
-        fused_methods.append(ExpertPackMoEMethod)
-
-    fused = isinstance(experts.quant_method, tuple(fused_methods))
+    fused = isinstance(
+        experts.quant_method,
+        (
+            Mxfp4FlashinferTrtllmMoEMethod,
+            Mxfp4FlashinferCutlassMoEMethod,
+            Mxfp4MarlinMoEMethod,
+            ExpertPackMoEMethod,
+        ),
+    )
     if fused:
         already_scaled = experts.should_fuse_routed_scaling_factor_in_topk
         if shared is not None:

--- a/python/sglang/srt/mem_cache/pool_host/mla.py
+++ b/python/sglang/srt/mem_cache/pool_host/mla.py
@@ -436,14 +436,9 @@ class MLATokenToKVPoolHost(HiSparseHostPoolMixin, HostKVCache):
                 )
             return
 
-        if io_backend == "kernel_ascend":
-            # NPU pools use contiguous multi-layer tensors and intentionally do
-            # not build the CUDA-style data_ptrs array.
-            device_data_ptrs, device_kv_buffers = None, None
-        else:
-            device_data_ptrs, device_kv_buffers = self._resolve_device_transfer_buffers(
-                device_pool
-            )
+        device_data_ptrs, device_kv_buffers = self._resolve_device_transfer_buffers(
+            device_pool
+        )
 
         if io_backend == "kernel":
             if self.layout == "layer_first":


### PR DESCRIPTION
Reverts sgl-project/sglang#36640

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33125680932](https://github.com/sgl-project/sglang/actions/runs/33125680932)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33125680522](https://github.com/sgl-project/sglang/actions/runs/33125680522)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33125680741](https://github.com/sgl-project/sglang/actions/runs/33125680741)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->