### PR TITLE
fix(function_call): defer partial DeepSeek non-string values

### DIFF
--- a/python/sglang/srt/function_call/deepseekv32_detector.py
+++ b/python/sglang/srt/function_call/deepseekv32_detector.py
@@ -2,9 +2,6 @@ import json
 import logging
 import re
 
-from partial_json_parser.core.exceptions import MalformedJSON
-from partial_json_parser.core.options import Allow
-
 from sglang.srt.entrypoints.openai.protocol import Tool
 from sglang.srt.function_call.base_format_detector import BaseFormatDetector
 from sglang.srt.function_call.core_types import (
@@ -13,7 +10,7 @@ from sglang.srt.function_call.core_types import (
     ToolCallItem,
     _GetInfoFunc,
 )
-from sglang.srt.function_call.utils import _find_common_prefix, _partial_json_loads
+from sglang.srt.function_call.utils import _find_common_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -75,6 +72,7 @@ class DeepSeekV32Detector(BaseFormatDetector):
         self.bot_token = "<｜DSML｜function_calls>"
         self.eot_token = "</｜DSML｜function_calls>"
         self.invoke_end_token = "</｜DSML｜invoke>"
+        self.parameter_end_token = "</｜DSML｜parameter>"
         self.parameter_regex = r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*?)</｜DSML｜parameter>'
         self.partial_parameter_regex = (
             r'<｜DSML｜parameter\s+name="([^"]+)"\s+string="([^"]+)"\s*>(.*)$'
@@ -90,8 +88,6 @@ class DeepSeekV32Detector(BaseFormatDetector):
             r"(?:(?P<self_close>/>)"
             r"|>(?P<body>.*?)(?P<end>(?:</｜DSML｜invoke>|$)))"
         )
-        self.prefix_parameter_end_call = ["</", "｜DSML｜", "parameter"]
-        self.prefix_invoke_end_call = ["</", "｜DSML｜", "inv", "oke"]
         self.current_tool_id = -1
 
     def has_tool_call(self, text: str) -> bool:
@@ -112,6 +108,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
             return name, "", True
         return name, m.group("body"), bool(m.group("end"))
 
+    @staticmethod
+    def _strip_partial_tag_suffix(text: str, tag: str) -> str:
+        for length in range(min(len(tag), len(text)), 0, -1):
+            if text.endswith(tag[:length]):
+                return text[:-length]
+        return text
+
     def _parse_parameters_from_xml(
         self, invoke_content: str, allow_partial: bool = False
     ) -> str:
@@ -123,12 +126,13 @@ class DeepSeekV32Detector(BaseFormatDetector):
         2. Direct JSON: { "key": "value" }
         """
         # First, try to parse as direct JSON (new format)
+        if allow_partial:
+            invoke_content = self._strip_partial_tag_suffix(
+                invoke_content, self.invoke_end_token
+            )
         invoke_content_stripped = invoke_content.strip()
         if invoke_content_stripped.startswith("{"):
             if allow_partial:
-                # Remove incomplete invoke end call prefix in case they are captured by param
-                for token in reversed(self.prefix_invoke_end_call):
-                    invoke_content_stripped = invoke_content_stripped.rstrip(token)
                 return invoke_content_stripped
             elif invoke_content_stripped.endswith("}"):
                 return invoke_content_stripped
@@ -159,11 +163,9 @@ class DeepSeekV32Detector(BaseFormatDetector):
 
         # If allowed, try to parse a partial parameter at the end
         if allow_partial:
-            remaining_content = invoke_content[last_match_end:]
-
-            # Remove incomplete parameter_end_call prefix in case they are captured by param
-            for token in reversed(self.prefix_parameter_end_call):
-                remaining_content = remaining_content.rstrip(token)
+            remaining_content = self._strip_partial_tag_suffix(
+                invoke_content[last_match_end:], self.parameter_end_token
+            )
 
             # Match start of a parameter tag + value (potentially incomplete)
             # Regex: <tag name="..." string="...">VALUE... (no end tag)
@@ -175,13 +177,6 @@ class DeepSeekV32Detector(BaseFormatDetector):
                 param_name = partial_match.group(1)
                 if partial_match.group(2) == "true":
                     parameters[param_name] = param_value.strip()
-                else:
-                    try:
-                        parameters[param_name] = _partial_json_loads(
-                            param_value, Allow.ALL
-                        )[0]
-                    except (json.JSONDecodeError, MalformedJSON, ValueError):
-                        parameters[param_name] = param_value.strip()
 
         return json.dumps(parameters, ensure_ascii=False)
 

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -107,26 +107,28 @@ class TestDeepSeekV4Streaming(CustomTestCase):
         ]
 
         for value in ("[{]", "[}"):
-            with self.subTest(value=value):
-                text = _wrapped(
-                    _invoke("create_tasks", _param("tasks", "false", value))
-                )
-                split = text.index(f"</{DSML}parameter>")
-                detector = DeepSeekV4Detector()
-                normal, calls = "", []
-                for chunk in (text[:split], text[split:]):
-                    result = detector.parse_streaming_increment(chunk, tools)
-                    normal += result.normal_text
-                    calls.extend(result.calls)
+            text = _wrapped(_invoke("create_tasks", _param("tasks", "false", value)))
+            expected = DeepSeekV4Detector().detect_and_parse(text, tools).calls[0]
+            for width in range(1, len(text) + 1):
+                with self.subTest(value=value, width=width):
+                    chunks = [
+                        text[index : index + width]
+                        for index in range(0, len(text), width)
+                    ]
+                    detector = DeepSeekV4Detector()
+                    normal, calls = "", []
+                    for chunk in chunks:
+                        result = detector.parse_streaming_increment(chunk, tools)
+                        normal += result.normal_text
+                        calls.extend(result.calls)
 
-                expected = DeepSeekV4Detector().detect_and_parse(text, tools).calls[0]
-                self.assertEqual(normal, "")
-                self.assertEqual(
-                    [call.name for call in calls if call.name], ["create_tasks"]
-                )
-                self.assertEqual(
-                    "".join(call.parameters for call in calls), expected.parameters
-                )
+                    self.assertEqual(normal, "")
+                    self.assertEqual(
+                        [call.name for call in calls if call.name], ["create_tasks"]
+                    )
+                    self.assertEqual(
+                        "".join(call.parameters for call in calls), expected.parameters
+                    )
 
     def test_tolerated_outer_formats_keep_existing_streaming_results(self):
         invoke_start = f'<{DSML}tool_calls><{DSML}invoke name="get_weather">'

--- a/test/registered/unit/function_call/test_deepseekv4_detector.py
+++ b/test/registered/unit/function_call/test_deepseekv4_detector.py
@@ -94,6 +94,69 @@ class TestDeepSeekV4Streaming(CustomTestCase):
 
         self.assertEqual([c.name for c in result.calls if c.name], ["get_weather"])
 
+    def test_malformed_non_string_parameter_waits_for_closing_tag(self):
+        tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="create_tasks",
+                    description="Create tasks",
+                    parameters={"type": "object"},
+                ),
+            )
+        ]
+
+        for value in ("[{]", "[}"):
+            with self.subTest(value=value):
+                text = _wrapped(
+                    _invoke("create_tasks", _param("tasks", "false", value))
+                )
+                split = text.index(f"</{DSML}parameter>")
+                detector = DeepSeekV4Detector()
+                normal, calls = "", []
+                for chunk in (text[:split], text[split:]):
+                    result = detector.parse_streaming_increment(chunk, tools)
+                    normal += result.normal_text
+                    calls.extend(result.calls)
+
+                expected = DeepSeekV4Detector().detect_and_parse(text, tools).calls[0]
+                self.assertEqual(normal, "")
+                self.assertEqual(
+                    [call.name for call in calls if call.name], ["create_tasks"]
+                )
+                self.assertEqual(
+                    "".join(call.parameters for call in calls), expected.parameters
+                )
+
+    def test_tolerated_outer_formats_keep_existing_streaming_results(self):
+        invoke_start = f'<{DSML}tool_calls><{DSML}invoke name="get_weather">'
+        invoke_end = f"</{DSML}invoke></{DSML}tool_calls>"
+        duplicate = _param("city", "true", "first")
+        duplicate_end = _param("city", "true", "second") + invoke_end
+        cases = [
+            ([invoke_start + '{"city":"SF"', invoke_end], "{}"),
+            (
+                [
+                    invoke_start + f'<{DSML}parameter name="city" string="true">SF',
+                    invoke_end,
+                ],
+                "{}",
+            ),
+            ([invoke_start + duplicate, duplicate_end], '{"city": "second"}'),
+        ]
+
+        for chunks, expected in cases:
+            with self.subTest(chunks=chunks):
+                _, calls = self._feed(chunks)
+                self.assertEqual("".join(call.parameters for call in calls), expected)
+
+    def test_partial_tag_suffix_trim_does_not_eat_value_characters(self):
+        trim = DeepSeekV4Detector()._strip_partial_tag_suffix
+        end = f"</{DSML}parameter>"
+
+        self.assertEqual(trim("read the note", end), "read the note")
+        self.assertEqual(trim(f"value</{DSML}par", end), "value")
+
     def test_non_streaming_parses_every_tool_calls_section(self):
         """A turn with two tool_calls sections must yield both calls."""
         result = DeepSeekV4Detector().detect_and_parse(


### PR DESCRIPTION
## Motivation

DeepSeek V3.2/V4 streaming tool parsing can expose raw DSML text when an incomplete non-string parameter contains mismatched JSON delimiters. `partial_json_parser` raises during the partial scan, and the detector fallback returns its DSML buffer as normal assistant content.

This is a narrower alternative to #36339. It fixes the failing non-string path without changing the existing provisional streaming behavior for direct JSON or `string="true"` parameters.

## Modifications

- Do not parse or emit an incomplete `string="false"` parameter value. Completed earlier parameters continue to stream, and the non-string value is parsed when its closing parameter tag arrives.
- Replace character-set `rstrip()` calls with exact partial closing-tag suffix removal.
- Preserve current behavior for malformed outer DSML and duplicate parameter names.
- Add regression and compatibility tests, including every fixed chunk width for the observed assertion shapes.

## Accuracy Tests

Not applicable. This changes response parsing only, not model forward output. Streaming and non-streaming arguments match for valid nested arrays and malformed non-string values that fall back to strings.

## Speed Tests and Profiling

No inference-path impact. The change removes repeated partial JSON parsing for incomplete non-string parameters. Those argument fragments are delayed until the parameter closes; direct JSON and string parameters retain their existing streaming behavior.

## Tests

- Confirmed the new regression tests fail against the existing parser with mismatched array/object delimiter assertions.
- Swept every fixed chunk width for both failing values using production dependency versions.
- Verified valid nested arrays, malformed non-string fallback, incomplete outer DSML, duplicate parameters, and partial closing-tag suffixes.
- `pre-commit run --files python/sglang/srt/function_call/deepseekv32_detector.py test/registered/unit/function_call/test_deepseekv4_detector.py`
- Python compilation passed for both changed files.

## Checklist

- [x] Format your code according to the pre-commit guidance.
- [x] Add unit tests.
- [ ] Update documentation. No user-facing behavior or option changed.
- [x] Provide accuracy and speed impact.
- [x] Follow the SGLang code style guidance.

## Review and Merge Process

1. Ping Merge Oncalls to start the process.
2. Get approvals from CODEOWNERS and other reviewers.
3. Trigger CI tests.
4. After green CI and required approvals, ask Merge Oncalls to merge.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33125928209](https://github.com/sgl-project/sglang/actions/runs/33125928209)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33125927973](https://github.com/sgl-project/sglang/actions/runs/33125927973)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33125928127](https://github.com/sgl-project/sglang/actions/runs/33125928127)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->