### PR TITLE
fix(cuda-graph): size BCG buffers by token rows, support LogitsProcessorOutput

### DIFF
--- a/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
+++ b/python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py
@@ -18,6 +18,7 @@ No torch.compile.
 
 from __future__ import annotations
 
+import dataclasses
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Callable, Dict, Optional
 
@@ -26,6 +27,7 @@ import torch
 from sglang.srt.distributed.device_communicators.pynccl_allocator import (
     set_graph_pool_id,
 )
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
 from sglang.srt.model_executor.forward_batch_info import PPProxyTensors
 from sglang.srt.model_executor.runner_backend.base_cuda_graph_backend import (
     BaseCudaGraphBackend,
@@ -44,6 +46,11 @@ from sglang.srt.model_executor.runner_utils.pool import (
 )
 from sglang.srt.utils import get_bool_env_var
 from sglang.srt.utils.torch_memory_saver_adapter import TorchMemorySaverAdapter
+
+# The only LogitsProcessorOutput fields populated at CUDA-graph capture time:
+# capture runs inside the model forward, so the Sampler has not filled the
+# logprob / prefill / diffusion parts yet.
+_LPO_CAPTURE_FIELDS = ("next_token_logits", "hidden_states")
 
 if TYPE_CHECKING:
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -125,7 +132,13 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
         )
         size = shape_key.size
         if self._shared_output_buffer is None:
-            self._shared_output_buffer = self._alloc_full_buffer(warmup_out, size)
+            # The first capture is the largest shape, so the warmup output's own
+            # row count is the required capacity. A body whose row unit is tokens
+            # rather than requests needs more than ``size`` rows; ``max`` keeps the
+            # existing full-``size`` allocation for bodies that shard or prune.
+            self._shared_output_buffer = self._alloc_full_buffer(
+                warmup_out, max(size, self._output_rows(warmup_out, size))
+            )
         with BreakableCUDAGraphCapture(
             cuda_graph=graph,
             pool=self._pool,
@@ -143,10 +156,12 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
         self._capture_inputs[shape_key] = capture_inputs
 
     def _output_rows(self, output: Any, cap: int) -> int:
-        """Leading-dim row count actually produced by the body, clamped to ``cap``.
+        """Leading-dim row count actually produced by the body.
 
         A body that shards or prunes its output along dim 0 returns fewer than
-        ``cap`` rows; everything else returns exactly ``cap``.
+        ``cap`` rows; everything else returns exactly ``cap``. The one shape that
+        exceeds ``cap`` is a LogitsProcessorOutput whose row unit is tokens
+        instead of requests -- see that branch.
         """
         if torch.is_tensor(output):
             return min(cap, output.shape[0])
@@ -155,7 +170,44 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return min([cap, *rows])
         if isinstance(output, (list, tuple)) and output:
             return min(self._output_rows(o, cap) for o in output if o is not None)
+        if isinstance(output, LogitsProcessorOutput):
+            # Rows here are tokens, not requests: a speculative verify body emits
+            # ``cap * num_draft_tokens`` rows for ``cap`` requests. Clamping to
+            # ``cap`` makes verify read a fraction of the logits and index
+            # accept_index past the end of the tensor, so report the real count.
+            self._assert_lpo_capturable(output)
+            rows = [
+                tensor.shape[0]
+                for tensor in (output.next_token_logits, output.hidden_states)
+                if tensor is not None
+            ]
+            if not rows:
+                return cap
+            if min(rows) != max(rows):
+                raise ValueError(
+                    f"BCG LogitsProcessorOutput fields disagree on row count: {rows}"
+                )
+            return rows[0]
         return cap
+
+    @staticmethod
+    def _assert_lpo_capturable(output: LogitsProcessorOutput) -> None:
+        """Fail loudly if a capture-time LogitsProcessorOutput carries more than
+        ``_LPO_CAPTURE_FIELDS``.
+
+        Field introspection is deliberate here: it is a completeness guard, so a
+        future capture point that also fills logprob or diffusion fields fails
+        instead of silently dropping them from the replay buffer.
+        """
+        for field in dataclasses.fields(output):
+            if field.name in _LPO_CAPTURE_FIELDS:
+                continue
+            if getattr(output, field.name) is not None:
+                raise TypeError(
+                    "BCG cannot capture a LogitsProcessorOutput with "
+                    f"{field.name!r} set; only {_LPO_CAPTURE_FIELDS} are "
+                    "populated at capture time"
+                )
 
     def _alloc_full_buffer(self, output: Any, size: int) -> Any:
         """A same-structure buffer as ``output`` but with ``size`` leading rows."""
@@ -174,6 +226,14 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return tuple(self._alloc_full_buffer(o, size) for o in output)
         if isinstance(output, list):
             return [self._alloc_full_buffer(o, size) for o in output]
+        if isinstance(output, LogitsProcessorOutput):
+            self._assert_lpo_capturable(output)
+            return LogitsProcessorOutput(
+                next_token_logits=self._alloc_full_buffer(
+                    output.next_token_logits, size
+                ),
+                hidden_states=self._alloc_full_buffer(output.hidden_states, size),
+            )
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _slice_output(self, output: Any, num_tokens: int) -> Any:
@@ -187,6 +247,13 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
             return tuple(self._slice_output(item, num_tokens) for item in output)
         if isinstance(output, list):
             return [self._slice_output(item, num_tokens) for item in output]
+        if isinstance(output, LogitsProcessorOutput):
+            return LogitsProcessorOutput(
+                next_token_logits=self._slice_output(
+                    output.next_token_logits, num_tokens
+                ),
+                hidden_states=self._slice_output(output.hidden_states, num_tokens),
+            )
         raise TypeError(f"Unsupported BCG output type: {type(output)}")
 
     def _copy_output_to_buffer(
@@ -225,6 +292,18 @@ class BreakableCudaGraphBackend(DedupedCudaGraphMixin, BaseCudaGraphBackend):
                 )
             for item, buffer in zip(output, output_buffer):
                 self._copy_output_to_buffer(item, buffer, num_tokens)
+            return
+        if isinstance(output, LogitsProcessorOutput) and isinstance(
+            output_buffer, LogitsProcessorOutput
+        ):
+            self._copy_output_to_buffer(
+                output.next_token_logits,
+                output_buffer.next_token_logits,
+                num_tokens,
+            )
+            self._copy_output_to_buffer(
+                output.hidden_states, output_buffer.hidden_states, num_tokens
+            )
             return
         raise TypeError(
             "Unsupported BCG output buffer pair: "

--- a/test/registered/unit/model_executor/runner_backend/test_breakable_cuda_graph_backend_lpo.py
+++ b/test/registered/unit/model_executor/runner_backend/test_breakable_cuda_graph_backend_lpo.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``BreakableCudaGraphBackend`` output handling of
+``LogitsProcessorOutput`` — CPU-only.
+
+Black-box statement of the bug these guard: BCG sized its replay buffer and its
+row count from the graph's batch size, on the assumption that a captured body
+never emits more leading rows than there are requests. A speculative-verify
+decode body breaks that assumption — its row unit is tokens, so it emits
+``size * num_draft_tokens`` rows. Two failures followed:
+
+  * ``_output_rows`` clamped the count down to ``size``, so the verify step saw
+    only ``1 / num_draft_tokens`` of the logits and indexed ``accept_index``
+    past the end of the tensor (a device-side assert, surfacing as a hang).
+  * ``_alloc_full_buffer`` reserved only ``size`` rows, so the copy-back had
+    nowhere to put the remaining tokens.
+
+``LogitsProcessorOutput`` was also not an accepted output structure at all
+(``TypeError`` from the alloc / slice / copy helpers), which is why the decode
+path had to run eager whenever speculative decoding was on.
+
+The capture path itself needs CUDA, so the graph and capture-context objects are
+mocked; the logic under test (row counting, buffer sizing, structured copy and
+slice) is pure tensor bookkeeping and runs on CPU.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.logits_processor import LogitsProcessorOutput
+from sglang.srt.model_executor.runner.shape_key import ShapeKey
+from sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend import (
+    BreakableCudaGraphBackend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_MODULE = "sglang.srt.model_executor.runner_backend.breakable_cuda_graph_backend"
+_VOCAB = 8
+_HIDDEN = 4
+
+
+class _FakeCapture:
+    """Stand-in for ``BreakableCUDAGraphCapture`` — a no-op context manager."""
+
+    def __init__(self, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _make_backend():
+    """Build the backend without ``__init__`` (which would touch CUDA), wiring
+    only the attributes ``capture_one`` reads."""
+    backend = BreakableCudaGraphBackend.__new__(BreakableCudaGraphBackend)
+    backend._graphs = {}
+    backend._outputs = {}
+    backend._capture_inputs = {}
+    backend._pool = None
+    backend._capture_stream = None
+    backend._shared_output_buffer = None
+    backend._debug_eager = False
+    backend.deduped_cuda_graph = None
+    backend._device_module = SimpleNamespace(synchronize=mock.Mock())
+    backend._tp_group = SimpleNamespace(barrier=mock.Mock())
+    return backend
+
+
+def _lpo(rows, *, with_hidden=True, fill=0.0):
+    return LogitsProcessorOutput(
+        next_token_logits=torch.full((rows, _VOCAB), fill),
+        hidden_states=torch.full((rows, _HIDDEN), fill) if with_hidden else None,
+    )
+
+
+class TestOutputRows(CustomTestCase):
+    def test_reports_token_rows_for_speculative_verify(self):
+        # size=3 requests x num_draft_tokens=4 => 12 token rows. Reporting the
+        # request count here is what truncated the verify logits.
+        backend = _make_backend()
+        self.assertEqual(backend._output_rows(_lpo(12), 3), 12)
+
+    def test_no_tensor_fields_falls_back_to_cap(self):
+        backend = _make_backend()
+        empty = LogitsProcessorOutput(next_token_logits=None, hidden_states=None)
+        self.assertEqual(backend._output_rows(empty, 5), 5)
+
+    def test_tensor_output_still_clamps_to_cap(self):
+        # Guards the pre-existing contract for every other output structure: a
+        # body that prunes rows must still report at most ``cap``.
+        backend = _make_backend()
+        self.assertEqual(backend._output_rows(torch.zeros(8, _VOCAB), 4), 4)
+        self.assertEqual(backend._output_rows(torch.zeros(2, _VOCAB), 4), 2)
+
+    def test_field_row_mismatch_raises(self):
+        backend = _make_backend()
+        mismatched = LogitsProcessorOutput(
+            next_token_logits=torch.zeros(12, _VOCAB),
+            hidden_states=torch.zeros(3, _HIDDEN),
+        )
+        with self.assertRaises(ValueError):
+            backend._output_rows(mismatched, 3)
+
+    def test_unexpected_populated_field_raises(self):
+        # A capture point that also filled a Sampler field would otherwise have
+        # it silently dropped from the replay buffer.
+        backend = _make_backend()
+        output = _lpo(4)
+        output.next_token_logprobs = torch.zeros(4)
+        with self.assertRaises(TypeError):
+            backend._output_rows(output, 4)
+
+
+class TestSliceAndCopy(CustomTestCase):
+    def test_alloc_slice_copy_roundtrip(self):
+        backend = _make_backend()
+        buffer = backend._alloc_full_buffer(_lpo(12), 12)
+        self.assertEqual(buffer.next_token_logits.shape, (12, _VOCAB))
+        self.assertEqual(buffer.hidden_states.shape, (12, _HIDDEN))
+
+        produced = _lpo(12, fill=7.0)
+        backend._copy_output_to_buffer(produced, buffer, 12)
+        stored = backend._slice_output(buffer, 12)
+        self.assertTrue(
+            torch.equal(stored.next_token_logits, produced.next_token_logits)
+        )
+        self.assertTrue(torch.equal(stored.hidden_states, produced.hidden_states))
+
+    def test_none_field_is_preserved_across_alloc_and_slice(self):
+        backend = _make_backend()
+        buffer = backend._alloc_full_buffer(_lpo(6, with_hidden=False), 6)
+        self.assertIsNone(buffer.hidden_states)
+        stored = backend._slice_output(buffer, 6)
+        self.assertIsNone(stored.hidden_states)
+        self.assertEqual(stored.next_token_logits.shape, (6, _VOCAB))
+
+
+class TestCaptureOne(CustomTestCase):
+    def _capture(self, backend, *, size, forward_fn):
+        with mock.patch(
+            f"{_MODULE}.BreakableCUDAGraph", return_value="GRAPH"
+        ), mock.patch(f"{_MODULE}.BreakableCUDAGraphCapture", _FakeCapture):
+            backend.capture_one(ShapeKey(size=size), forward_fn)
+
+    def test_buffer_holds_token_rows_not_request_rows(self):
+        backend = _make_backend()
+        self._capture(backend, size=3, forward_fn=lambda: _lpo(12, fill=2.0))
+
+        buffer = backend._shared_output_buffer
+        self.assertEqual(buffer.next_token_logits.shape, (12, _VOCAB))
+
+        stored = backend._outputs[ShapeKey(size=3)]
+        self.assertEqual(stored.next_token_logits.shape, (12, _VOCAB))
+        self.assertTrue(
+            torch.equal(stored.next_token_logits, torch.full((12, _VOCAB), 2.0))
+        )
+
+    def test_tensor_body_keeps_full_size_buffer(self):
+        # A pruning tensor body must keep its full-``size`` buffer: later
+        # captures of the same shared buffer may not prune.
+        backend = _make_backend()
+        self._capture(backend, size=4, forward_fn=lambda: torch.full((2, _VOCAB), 3.0))
+
+        self.assertEqual(backend._shared_output_buffer.shape, (4, _VOCAB))
+        stored = backend._outputs[ShapeKey(size=4)]
+        self.assertEqual(stored.shape, (2, _VOCAB))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`BreakableCudaGraphBackend._output_rows()` documents its contract as:

> Leading-dim row count actually produced by the body, clamped to `cap`. A body that
> shards or prunes its output along dim 0 returns fewer than `cap` rows; everything else
> returns exactly `cap`.

A speculative-verify decode body breaks that assumption in the other direction: its row
unit is **tokens**, not requests, so it emits `size * num_draft_tokens` rows.

Observed on a single RTX PRO 6000 Blackwell (SM120, 96 GB) serving Qwen3.8-Flash-Next
(#36497) with `--speculative-algorithm NEXTN --speculative-num-steps 3
--speculative-eagle-topk 1 --speculative-num-draft-tokens 4` and
`--cuda-graph-backend-decode breakable`. Instrumenting the capture showed
`ShapeKey(size=3)` with `next_token_logits` of shape `(12, vocab)`, while
`_output_rows()` returned `3`. Consequences:

1. The verify step saw `1 / num_draft_tokens` of the logits and indexed `accept_index`
   past the end of the tensor — a device-side assert, which presents as a hang rather
   than an exception (found by re-running under `CUDA_LAUNCH_BLOCKING=1` and bisecting
   with speculation off).
2. `_alloc_full_buffer()` reserved only `size` rows, so the copy-back had nowhere to put
   the remaining tokens.

Separately, `LogitsProcessorOutput` was not an accepted output structure at all — the
alloc / slice / copy helpers raised `TypeError: Unsupported BCG output type`. That is why
the decode path has to fall back to eager whenever speculative decoding is on.

**Why the existing tests don't cover this.** BCG's speculative coverage is on the
*prefill* side: `test/registered/cuda_graph/breakable/test_bcg_with_speculative_decoding.py`
runs `--cuda-graph-backend-prefill=breakable` with EAGLE3, and the integration case in
`test_breakable_cuda_graph.py` also sets `--cuda-graph-backend-prefill=breakable`.
`TestCopyOutput` covers tensor / dict / object / non-tensor writeback, but no case
exercises a `LogitsProcessorOutput` and no case exercises a body whose row count
*exceeds* the capture size. So neither the missing output type nor the row-unit
assumption had a guard.

## Modifications

`python/sglang/srt/model_executor/runner_backend/breakable_cuda_graph_backend.py`:

1. **`_output_rows()`** — new `LogitsProcessorOutput` branch reporting the real row count.
   Every other structure keeps its existing clamp, unchanged.
2. **`capture_one()`** — size the shared buffer with
   `max(size, self._output_rows(warmup_out, size))`. For tensors / `PPProxyTensors` /
   sequences the reported rows are `<= size`, so `max` reproduces the previous
   full-`size` allocation exactly; it only grows for a token-unit body.
3. **`_alloc_full_buffer()` / `_slice_output()` / `_copy_output_to_buffer()`** —
   `LogitsProcessorOutput` branches carrying the two fields that exist at capture time
   (`next_token_logits`, `hidden_states`; capture runs inside the model forward, before
   the Sampler).
4. **`_assert_lpo_capturable()`** — completeness guard: any other populated field raises
   instead of being silently dropped from the replay buffer. Field introspection is
   deliberate here so that a future capture point which also fills logprob or diffusion
   fields fails loudly.

**Open question for reviewers.** The same clamp exists on the tensor and `PPProxyTensors`
paths, so a future spec-verify body returning a bare tensor would be truncated the same
way. I kept the change scoped to the new branch rather than removing the clamp
generally, to avoid altering semantics for existing callers — happy to widen it if you
would rather fix the contract at its root.

## Accuracy Tests

New CPU-only unit test:
`test/registered/unit/model_executor/runner_backend/test_breakable_cuda_graph_backend_lpo.py`,
registered as `register_cpu_ci(est_time=10, suite="base-a-test-cpu")`. 9 cases covering
the row count for a verify-shaped output, the retained clamp for tensor outputs, buffer
sizing through `capture_one`, the alloc/copy/slice round trip, `None`-field handling, and
the two fail-loud paths (field row mismatch, unexpected populated field).

Per the unit-test admission criteria, each bug-regression case was verified to fail on
the pre-fix file: reverting
`breakable_cuda_graph_backend.py` to its base revision gives **6 failed, 3 passed**; the
3 that pass are the deliberate regression guards for existing tensor behaviour. With the
fix: **9 passed**.

End-to-end sanity on the configuration that exercises this path (decode CUDA graph +
NEXTN, single card): HumanEval+ 0.957 / 0.927 (base / extra), GSM8K 0.98, 9/9
needle-in-a-haystack retrieval, 24/24 tool calls over a long agent session. Note that
this build also carries two other local patches — a cherry-pick of #36556 (SM120 sparse
decode) and an FP8-KV dequant fix in the same area as #36644 — so those numbers validate
the graph path as a whole, not this diff in isolation.

## Speed Tests and Profiling

_Pending: single-stream decode A/B with only `--cuda-graph-backend-decode` flipped
between `disabled` and `breakable`, same server and flags, reported from `usage`._

## Checklist

- [x] Format with the pinned pre-commit tool versions: `isort==7.0.0`, `black==26.1.0`,
      `ruff==0.15.1` (`--select=F401,F821,UP037`), `codespell==2.4.1` — all clean.
      Repo-local hooks also run: `check_registered_tests.py`,
      `check_no_bare_pytest_main.py`, `check_no_registered_tests_in_package.py` — all
      exit 0.
- [x] Unit test added under `test/registered/unit/`, CPU suite.
- [ ] Speed benchmark — see above.
- [x] No documentation change needed (internal backend behaviour, no user-facing flag).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34069972641](https://github.com/sgl-project/sglang/actions/runs/34069972641)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34069972422](https://github.com/sgl-project/sglang/actions/runs/34069972422)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34069972537](https://github.com/sgl-project/sglang/actions/runs/34069972537)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->