### PR TITLE
feat(openai): accept max_thinking_tokens on the chat completions endpoint

### DIFF
--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -930,6 +930,10 @@ class ChatCompletionRequest(BaseModel):
     separate_reasoning: bool = True
     stream_reasoning: bool = True
     chat_template_kwargs: Optional[Dict] = None
+    # Per-request thinking budget, forwarded to
+    # GenerateReqInput.max_thinking_tokens. Requires the server to be launched
+    # with --enable-strict-thinking.
+    max_thinking_tokens: Optional[int] = None
 
     # SGLang multimodal controls (extensions)
     max_dynamic_patch: Optional[int] = None

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1178,6 +1178,7 @@ class OpenAIServingChat(OpenAIServingBase):
             extra_key=request.extra_key,
             cache_salt=request.cache_salt,
             require_reasoning=processed_messages.require_reasoning,
+            max_thinking_tokens=request.max_thinking_tokens,
             priority=request.priority,
             routing_key=self.extract_routing_key(raw_request),
             custom_labels=custom_labels,

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -506,6 +506,41 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertEqual(adapted.session_id, "session-1")
             self.assertEqual(processed, self.basic_req)
 
+    def _convert_with_stubbed_messages(self, request):
+        """Run _convert_to_internal_request with message processing stubbed out."""
+        with (
+            patch(
+                "sglang.srt.entrypoints.openai.serving_chat.generate_chat_conv"
+            ) as conv_mock,
+            patch.object(self.chat, "_process_messages") as proc_mock,
+        ):
+            conv_ins = Mock()
+            conv_ins.get_prompt.return_value = "Test prompt"
+            conv_ins.image_data = conv_ins.audio_data = None
+            conv_ins.modalities = []
+            conv_ins.stop_str = ["</s>"]
+            conv_mock.return_value = conv_ins
+            proc_mock.return_value = MessageProcessingResult(
+                "Test prompt",
+                [1, 2, 3],
+                None,
+                None,
+                [],
+                ["</s>"],
+                None,
+            )
+            adapted, _ = self.chat._convert_to_internal_request(request)
+            return adapted
+
+    def test_convert_to_internal_request_forwards_max_thinking_tokens(self):
+        self.basic_req.max_thinking_tokens = 1024
+        adapted = self._convert_with_stubbed_messages(self.basic_req)
+        self.assertEqual(adapted.max_thinking_tokens, 1024)
+
+    def test_convert_to_internal_request_leaves_thinking_budget_unset(self):
+        adapted = self._convert_with_stubbed_messages(self.basic_req)
+        self.assertIsNone(adapted.max_thinking_tokens)
+
     def test_chat_applies_pd_header_overrides(self):
         request = ChatCompletionRequest(
             model="x",


### PR DESCRIPTION
## Motivation

`GenerateReqInput.max_thinking_tokens` is wired end to end:

- `io_struct.py` carries the field and propagates it through `_normalize_single_input`,
- `tokenizer_manager.py` gates it on `--enable-strict-thinking` and turns it into
  `sampling_params.custom_params["thinking_budget"]`,
- `grammar_manager.py` reads that back and sets `ReasonerGrammarObject.max_think_tokens`
  at all three attachment points (grammar cache hit, the strict-thinking-only branch, and
  the deferred branch after grammar compilation finishes).

The only thing missing is the entry point: `ChatCompletionRequest` has no
`max_thinking_tokens` field, so a client speaking the OpenAI protocol has no way to
reach any of it. Pydantic drops the unknown key, the request succeeds, and the budget
is silently ignored — no error, no warning, no capped thinking.

That is easy to mistake for "thinking budgets do not work on this model". In a
deployment behind an OpenAI-compatible gateway, unbounded reasoning on agentic
tool-calling turns wasted roughly 730K reasoning tokens in a single day, with a
single request reaching 68,289 reasoning tokens; the per-request budget that should
have capped it was being sent and discarded the whole time.

## Modifications

- `protocol.py`: add `max_thinking_tokens: Optional[int] = None` to
  `ChatCompletionRequest`, next to the other reasoning controls.
- `serving_chat.py`: pass it through to `GenerateReqInput`.

No behavior change when the field is absent, and the existing
`--enable-strict-thinking` requirement in `tokenizer_manager.py` is untouched — a
budget sent to a server launched without that flag still raises the same
`ValueError` it does today on the native path.

## Verification

Measured on a single RTX PRO 6000 Blackwell (SM120, 96 GB) serving
Qwen3.8-Flash-Next with `--enable-strict-thinking`, via `/v1/chat/completions`:

| `max_thinking_tokens` | `usage.completion_tokens_details.reasoning_tokens` |
| --- | --- |
| 16 | 17 |
| 64 | 65 |
| 512 | 513 |
| 3072 | 715 (finished on its own, below budget) |
| not sent | 3,240 |

Each capped run lands on budget + 1, the extra token being `</think>`. The answer is
produced normally after the cut — content length was unaffected.

Tool calling does not regress. A 7-case tool battery (single auto, multi-tool select,
parallel calls, multi-turn follow-up, argument schema/enum conformance, negative
"no tool needed", forced tool) passes 7/7 with thinking enabled, and a request whose
thinking is cut at 16 tokens still emits a well-formed `tool_calls` with correct
arguments. This is expected from the code path — `ReasonerGrammarBackend`
wraps the inner grammar rather than replacing it — but it seemed worth confirming.

## Tests

Two unit tests in `test/registered/unit/entrypoints/openai/test_serving_chat.py`:
the field reaches `GenerateReqInput`, and it stays `None` when the client does not
send it. Reverting the one-line change in `serving_chat.py` makes the first test fail,
so it does constrain the behavior rather than merely passing.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34069973183](https://github.com/sgl-project/sglang/actions/runs/34069973183)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34069973020](https://github.com/sgl-project/sglang/actions/runs/34069973020)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34069973149](https://github.com/sgl-project/sglang/actions/runs/34069973149)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->