### PR TITLE
[AMD] Register test_store_cache_4d for AMD 1-GPU PR CI (rocm720 Triton bug fixed)

### DIFF
--- a/test/registered/unit/mem_cache/test_store_cache_4d.py
+++ b/test/registered/unit/mem_cache/test_store_cache_4d.py
@@ -21,7 +21,7 @@ import unittest
 
 import torch
 
-from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
 
 _HAS_CUDA = torch.cuda.is_available()
 # The set_kv_buffer integration test needs UnifiedMHATokenToKVPool, which only
@@ -31,6 +31,7 @@ _HAS_SHARED_POOL = (
 )
 
 register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, stage="stage-b", runner_config="1-gpu-small-amd")
 
 
 def _legacy_advanced_indexing_write(


### PR DESCRIPTION
## Motivation

Re-register `test/registered/unit/mem_cache/test_store_cache_4d.py` for AMD
1-GPU PR CI. It already runs on NVIDIA per-commit CI and is a Triton parity
test for the `store_cache_4d` data-move kernel.

It was intentionally kept CUDA-only in #29782 because the `store_cache_4d`
Triton kernel hit a **ROCm 7.2.0 Triton AMDGPU compiler-pass failure**
(`TritonAMDGPUCanonicalizePointers` → `RuntimeError: PassManager::run failed`),
tracked in #29864. That bug is now fixed: per
[#29864](https://github.com/sgl-project/sglang/issues/29864#issuecomment-5435649898),
the kernel compiles cleanly and all 10 tests pass on MI300X (`gfx942`) using the
current ROCm 7.2.0 image (`rocm/sgl-dev:v0.5.18-rocm720-mi30x-20260826`).

## Change

Add `register_amd_ci(...)` mirroring the existing `register_cuda_ci(...)`
(`base-b` → `stage-b-test-1-gpu-small-amd`); `register_cuda_ci` unchanged.

## AMD CI runs

Both AMD lanes dispatched on this branch to confirm the fix on real CI (not
just the manual run reported in the issue):

| Lane | Run |
|---|---|
| ROCm 7.0 (mi3xx per-commit) `stage-b-test-1-gpu-small-amd` | https://github.com/sgl-project/sglang/actions/runs/33128213173 |
| ROCm 7.2 (the lane that originally failed) | https://github.com/sgl-project/sglang/actions/runs/33128214860 |

Results will be summarised here once both finish.

## Test plan

- [ ] AMD `stage-b-test-1-gpu-small-amd` (ROCm 7.0 / mi3xx) passes on the file.
- [ ] AMD ROCm 7.2 lane passes on the file (the lane that originally failed).
- [ ] NVIDIA per-commit CI stays green.

Closes #29864 once both AMD lanes are confirmed green.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33128206648](https://github.com/sgl-project/sglang/actions/runs/33128206648)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33128213195](https://github.com/sgl-project/sglang/actions/runs/33128213195)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33128206616](https://github.com/sgl-project/sglang/actions/runs/33128206616)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
