### PR TITLE
[Diffusion] Rollout API: off-loop serialization, spliced msgpack, timing headers, opt-in uint8 video

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/io_struct.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/io_struct.py
@@ -79,6 +79,8 @@ class RolloutRequest(BaseModel):
     fps: Optional[int] = None
 
     rollout: bool = True
+    # "uint8": quantise the video engine-side; None: ship unchanged
+    rollout_video_dtype: Optional[str] = None
     rollout_sde_type: str = "sde"
     rollout_noise_level: float = 0.7
     rollout_log_prob_no_const: bool = False

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/request_timing.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/request_timing.py
@@ -12,10 +12,13 @@ import json
 import time
 from contextlib import contextmanager
 
-# Compact JSON rides under the header, e.g.
+# Compact JSON rides under each header, e.g.
 #   x-sgld-timing: {"srv_recv":1787472609.104512,...,"msgpack_end":1787472691.63172,"request_id":"abc123"}
 #     mark name -> epoch seconds (6 dp), plus this request's id
+#   x-sgld-stages: {"TextEncodingStage":91.2,"DenoisingStage":448512.301,"DecodingStage":8123.457}
+#     pipeline stage class -> milliseconds (3 dp)
 TIMING_HEADER = "x-sgld-timing"
+STAGES_HEADER = "x-sgld-stages"
 
 MARKS = (
     "srv_recv",
@@ -64,3 +67,17 @@ class RequestStamps:
             payload["request_id"] = self.request_id
         return json.dumps(payload, separators=(",", ":"))
 
+
+def stages_header(metrics) -> str:
+    """The per-stage milliseconds the engine already recorded, verbatim.
+
+    The client sees the whole forward as one number, so without these it cannot
+    tell a slow denoise from a slow VAE decode. Only stage totals travel, never
+    the per-step list, which would grow the header with the step count.
+    """
+    if metrics is None or not metrics.stages:
+        return ""
+    return json.dumps(
+        {name: round(ms, 3) for name, ms in metrics.stages.items()},
+        separators=(",", ":"),
+    )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/request_timing.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/request_timing.py
@@ -1,0 +1,66 @@
+"""Wall-clock marks for the rollout HTTP path.
+
+The client reconstructs one waterfall per request across three processes, so it
+needs absolute marks, not durations. They ride a response header: every mark is
+taken before the response headers are sent, and a header leaves the msgpack
+body contract untouched for clients that ignore it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from contextlib import contextmanager
+
+# Compact JSON rides under the header, e.g.
+#   x-sgld-timing: {"srv_recv":1787472609.104512,...,"msgpack_end":1787472691.63172,"request_id":"abc123"}
+#     mark name -> epoch seconds (6 dp), plus this request's id
+TIMING_HEADER = "x-sgld-timing"
+
+MARKS = (
+    "srv_recv",
+    "forward_start",
+    "forward_end",
+    "build_start",
+    "build_end",
+    "dump_end",
+    "msgpack_end",
+)
+
+
+class RequestStamps:
+    """Absolute wall-clock marks for one rollout request."""
+
+    __slots__ = ("request_id", "_marks")
+
+    def __init__(self, request_id: str = "") -> None:
+        self.request_id = request_id
+        self._marks: dict[str, float] = {}
+
+    def mark(self, name: str) -> None:
+        assert name in MARKS, f"unknown timing mark {name!r}"
+        self._marks[name] = time.time()
+
+    @contextmanager
+    def span(self, name: str):
+        """Mark ``{name}_start`` on entry and ``{name}_end`` on exit.
+
+        dump/msgpack have no start mark: each begins where the previous span
+        ended, so only the end boundary is recorded.
+        """
+        start = f"{name}_start"
+        if start in MARKS:
+            self.mark(start)
+        try:
+            yield
+        finally:
+            self.mark(f"{name}_end")
+
+    def to_header(self) -> str:
+        payload: dict[str, object] = {
+            name: round(t, 6) for name, t in self._marks.items()
+        }
+        if self.request_id:
+            payload["request_id"] = self.request_id
+        return json.dumps(payload, separators=(",", ":"))
+

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -22,6 +22,7 @@ from sglang.multimodal_gen.runtime.entrypoints.post_training.request_timing impo
 )
 from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
     _maybe_serialize,
+    _quantize_video_uint8,
 )
 from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
@@ -201,7 +202,12 @@ def _serialize_rollout_trajectory(
 
 
 def _build_response(
-    request_id: str, prompt: str, seed: int, rollout: bool, result: OutputBatch
+    request_id: str,
+    prompt: str,
+    seed: int,
+    rollout: bool,
+    result: OutputBatch,
+    video_dtype: str | None = None,
 ) -> list[RolloutResponse]:
     """
     rollout: bool - set to False when evaluating the model
@@ -233,6 +239,8 @@ def _build_response(
     for sample_idx in range(batch_size):
         out_i = result.output[sample_idx]
         if isinstance(out_i, torch.Tensor):
+            if video_dtype == "uint8":
+                out_i = _quantize_video_uint8(out_i)
             out_i = out_i.contiguous()
         serialized_generated_output = _maybe_serialize(out_i)
         if not rollout:
@@ -352,7 +360,12 @@ async def rollout_generate(request: RolloutRequest):
         raise HTTPException(status_code=500, detail=output_batch.error)
     with stamps.span("build"):
         rollout_responses = _build_response(
-            request_id, request.prompt, request.seed, request.rollout, output_batch
+            request_id,
+            request.prompt,
+            request.seed,
+            request.rollout,
+            output_batch,
+            video_dtype=request.rollout_video_dtype,
         )
     with stamps.span("dump"):
         payload = [r.model_dump() for r in rollout_responses]

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 from typing import Any
 
-import msgspec
 import torch
 from fastapi import APIRouter, HTTPException, Response
+from fastapi.responses import StreamingResponse
 
 from sglang.multimodal_gen.configs.sample.sampling_params import generate_request_id
 from sglang.multimodal_gen.runtime.entrypoints.openai.utils import build_sampling_params
@@ -23,6 +23,7 @@ from sglang.multimodal_gen.runtime.entrypoints.post_training.request_timing impo
 from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
     _maybe_serialize,
     _quantize_video_uint8,
+    msgpack_encode_spliced,
 )
 from sglang.multimodal_gen.runtime.entrypoints.utils import prepare_request
 from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import OutputBatch
@@ -370,15 +371,19 @@ async def rollout_generate(request: RolloutRequest):
     with stamps.span("dump"):
         payload = [r.model_dump() for r in rollout_responses]
     with stamps.span("msgpack"):
-        content = msgspec.msgpack.encode(payload)
+        parts = msgpack_encode_spliced(payload)
 
-    # Timing rides a header: the last marks postdate the encoded body.
-    headers = {TIMING_HEADER: stamps.to_header()}
+    # Timing rides a header: the last marks postdate the encoded body. The
+    # explicit content-length keeps uvicorn on identity framing, not chunked.
+    headers = {
+        TIMING_HEADER: stamps.to_header(),
+        "content-length": str(sum(len(p) for p in parts)),
+    }
     stages = stages_header(output_batch.metrics)
     if stages:
         headers[STAGES_HEADER] = stages
-    return Response(
-        content=content,
+    return StreamingResponse(
+        iter(parts),
         media_type="application/msgpack",
         headers=headers,
     )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -15,8 +15,10 @@ from sglang.multimodal_gen.runtime.entrypoints.post_training.io_struct import (
     RolloutResponse,
 )
 from sglang.multimodal_gen.runtime.entrypoints.post_training.request_timing import (
+    STAGES_HEADER,
     TIMING_HEADER,
     RequestStamps,
+    stages_header,
 )
 from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
     _maybe_serialize,
@@ -358,8 +360,12 @@ async def rollout_generate(request: RolloutRequest):
         content = msgspec.msgpack.encode(payload)
 
     # Timing rides a header: the last marks postdate the encoded body.
+    headers = {TIMING_HEADER: stamps.to_header()}
+    stages = stages_header(output_batch.metrics)
+    if stages:
+        headers[STAGES_HEADER] = stages
     return Response(
         content=content,
         media_type="application/msgpack",
-        headers={TIMING_HEADER: stamps.to_header()},
+        headers=headers,
     )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -14,6 +14,10 @@ from sglang.multimodal_gen.runtime.entrypoints.post_training.io_struct import (
     RolloutRequest,
     RolloutResponse,
 )
+from sglang.multimodal_gen.runtime.entrypoints.post_training.request_timing import (
+    TIMING_HEADER,
+    RequestStamps,
+)
 from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
     _maybe_serialize,
 )
@@ -317,7 +321,10 @@ def _build_sampling_kwargs(request: RolloutRequest) -> dict:
     },
 )
 async def rollout_generate(request: RolloutRequest):
+    stamps = RequestStamps()
+    stamps.mark("srv_recv")
     request_id = generate_request_id()
+    stamps.request_id = request_id
     server_args = get_global_server_args()
     sampling_kwargs = _build_sampling_kwargs(request)
     try:
@@ -330,9 +337,10 @@ async def rollout_generate(request: RolloutRequest):
         server_args=server_args, sampling_params=sampling_params
     )
     try:
-        output_batch: OutputBatch = await async_scheduler_client.forward(
-            pipeline_request
-        )
+        with stamps.span("forward"):
+            output_batch: OutputBatch = await async_scheduler_client.forward(
+                pipeline_request
+            )
     except Exception as exc:
         logger.error("Rollout generation failed: %s", exc, exc_info=True)
         raise HTTPException(
@@ -340,11 +348,18 @@ async def rollout_generate(request: RolloutRequest):
         ) from exc
     if output_batch.error:
         raise HTTPException(status_code=500, detail=output_batch.error)
-    rollout_responses = _build_response(
-        request_id, request.prompt, request.seed, request.rollout, output_batch
-    )
-    payload = [r.model_dump() for r in rollout_responses]
+    with stamps.span("build"):
+        rollout_responses = _build_response(
+            request_id, request.prompt, request.seed, request.rollout, output_batch
+        )
+    with stamps.span("dump"):
+        payload = [r.model_dump() for r in rollout_responses]
+    with stamps.span("msgpack"):
+        content = msgspec.msgpack.encode(payload)
+
+    # Timing rides a header: the last marks postdate the encoded body.
     return Response(
-        content=msgspec.msgpack.encode(payload),
+        content=content,
         media_type="application/msgpack",
+        headers={TIMING_HEADER: stamps.to_header()},
     )

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import torch
@@ -359,19 +360,23 @@ async def rollout_generate(request: RolloutRequest):
         ) from exc
     if output_batch.error:
         raise HTTPException(status_code=500, detail=output_batch.error)
-    with stamps.span("build"):
-        rollout_responses = _build_response(
-            request_id,
-            request.prompt,
-            request.seed,
-            request.rollout,
-            output_batch,
-            video_dtype=request.rollout_video_dtype,
-        )
-    with stamps.span("dump"):
-        payload = [r.model_dump() for r in rollout_responses]
-    with stamps.span("msgpack"):
-        parts = msgpack_encode_spliced(payload)
+    def _serialize_response() -> list[bytes]:
+        with stamps.span("build"):
+            rollout_responses = _build_response(
+                request_id,
+                request.prompt,
+                request.seed,
+                request.rollout,
+                output_batch,
+                video_dtype=request.rollout_video_dtype,
+            )
+        with stamps.span("dump"):
+            payload = [r.model_dump() for r in rollout_responses]
+        with stamps.span("msgpack"):
+            return msgpack_encode_spliced(payload)
+
+    # Off the event loop: building the response copies hundreds of MB
+    parts = await asyncio.to_thread(_serialize_response)
 
     # Timing rides a header: the last marks postdate the encoded body. The
     # explicit content-length keeps uvicorn on identity framing, not chunked.

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/utils.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from typing import Any
 
+import msgspec
 import numpy as np
 import torch
 from safetensors.torch import load, save
+
+_SPLICE_MIN_BYTES = 1 << 20
 
 
 def tensor_to_bytes(t: torch.Tensor) -> bytes:
@@ -32,6 +35,48 @@ def _maybe_serialize(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return [_maybe_serialize(v) for v in obj]
     return obj
+
+
+def _container_header(tag_fix: int, tag16: bytes, tag32: bytes, n: int) -> bytes:
+    if n <= 15:
+        return bytes([tag_fix | n])
+    if n <= 0xFFFF:
+        return tag16 + n.to_bytes(2, "big")
+    return tag32 + n.to_bytes(4, "big")
+
+
+def msgpack_encode_spliced(obj: Any, threshold: int = _SPLICE_MIN_BYTES) -> list[bytes]:
+    """Encode to msgpack as a list of buffers, splicing large ``bytes`` values.
+
+    Container and bin32 headers are hand-written so a large ``bytes`` payload
+    lands in the output by reference, never copied through the encoder; the
+    concatenated parts are byte-identical to ``msgspec.msgpack.encode(obj)``.
+    """
+    parts: list[bytes] = []
+    small = bytearray()
+
+    def _emit(value: Any) -> None:
+        if isinstance(value, bytes) and len(value) >= threshold:
+            small.extend(b"\xc6" + len(value).to_bytes(4, "big"))
+            parts.append(bytes(small))
+            small.clear()
+            parts.append(value)
+        elif isinstance(value, dict):
+            small.extend(_container_header(0x80, b"\xde", b"\xdf", len(value)))
+            for key, item in value.items():
+                small.extend(msgspec.msgpack.encode(key))
+                _emit(item)
+        elif isinstance(value, (list, tuple)):
+            small.extend(_container_header(0x90, b"\xdc", b"\xdd", len(value)))
+            for item in value:
+                _emit(item)
+        else:
+            small.extend(msgspec.msgpack.encode(value))
+
+    _emit(obj)
+    if small:
+        parts.append(bytes(small))
+    return parts
 
 
 def _maybe_deserialize(obj: Any) -> Any:

--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/utils.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/utils.py
@@ -42,3 +42,11 @@ def _maybe_deserialize(obj: Any) -> Any:
     if isinstance(obj, (list, tuple)):
         return [_maybe_deserialize(v) for v in obj]
     return obj
+
+
+def _quantize_video_uint8(video: torch.Tensor) -> torch.Tensor:
+    """Map the decoded [0,1] float video to 0..255 uint8; consumers divide by 255."""
+    out = video.float()
+    if float(out.max()) <= 1.0 + 1e-3:
+        out = out * 255.0
+    return out.clamp(0, 255).to(torch.uint8)

--- a/python/sglang/multimodal_gen/test/unit/test_msgpack_splice.py
+++ b/python/sglang/multimodal_gen/test/unit/test_msgpack_splice.py
@@ -1,0 +1,67 @@
+"""Unit tests for msgpack_encode_spliced.
+
+Mental model (what we exercise):
+
+    payload = {meta..., "data": <big bytes>, nested: [...]}
+                              |
+        msgpack_encode_spliced(payload)
+                              |
+        [small-parts bytes][big bytes BY REFERENCE][small-parts bytes]
+                              |
+        b"".join(parts)  ==  msgspec.msgpack.encode(payload)   (byte-identical)
+
+Covered:
+1. Joined parts are byte-identical to a plain msgspec encode, across nested
+   dicts/lists, >15-element containers (map16/array16 headers), and all
+   scalar leaves the rollout payload uses.
+2. Large bytes land in the parts list by reference (zero copy), small bytes
+   stay inline.
+"""
+
+import unittest
+
+import msgspec
+
+from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
+    msgpack_encode_spliced,
+)
+
+
+def _sample_payload(big: bytes) -> list:
+    wide_map = {f"k{i}": i for i in range(20)}
+    return [
+        {
+            "request_id": "req-0",
+            "seed": 7,
+            "scale": 1.5,
+            "flag": True,
+            "missing": None,
+            "dit_trajectory": {
+                "timesteps": {"__tensor__": True, "data": b"tiny", "shape": [4]},
+                "latents": {"__tensor__": True, "data": big, "shape": [2, 3]},
+            },
+            "wide": wide_map,
+            "long_list": list(range(30)),
+        }
+    ]
+
+
+class TestMsgpackEncodeSpliced(unittest.TestCase):
+    def test_byte_identical_to_msgspec(self):
+        big = bytes(range(256)) * 8192
+        payload = _sample_payload(big)
+        parts = msgpack_encode_spliced(payload, threshold=1 << 10)
+        self.assertEqual(b"".join(parts), msgspec.msgpack.encode(payload))
+
+    def test_large_bytes_spliced_by_reference(self):
+        big = b"\x00" * (1 << 20)
+        payload = _sample_payload(big)
+        parts = msgpack_encode_spliced(payload, threshold=1 << 10)
+        self.assertTrue(any(part is big for part in parts))
+        decoded = msgspec.msgpack.decode(b"".join(parts))
+        self.assertEqual(decoded[0]["dit_trajectory"]["latents"]["data"], big)
+        self.assertEqual(decoded[0]["dit_trajectory"]["timesteps"]["data"], b"tiny")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
@@ -1,9 +1,10 @@
 """Unit tests for the rollout generate API (serialization, io_struct, rollout_api).
 
-Request timing model (TestRequestStamps):
+Request timing model (TestRequestStamps / TestStagesHeader):
 
     srv_recv .. forward .. build .. dump .. msgpack   (absolute wall-clock marks)
     -> all marks ride the x-sgld-timing response header
+    stages_header: engine per-stage milliseconds -> x-sgld-stages header
 """
 
 import json
@@ -16,6 +17,7 @@ import torch
 from sglang.multimodal_gen.runtime.entrypoints.post_training.request_timing import (
     MARKS,
     RequestStamps,
+    stages_header,
 )
 from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
     _maybe_deserialize,
@@ -470,6 +472,24 @@ class TestRequestStamps(unittest.TestCase):
     def test_unknown_mark_is_rejected(self):
         with self.assertRaises(AssertionError):
             RequestStamps().mark("no_such_mark")
+
+
+class TestStagesHeader(unittest.TestCase):
+    """The engine's own stage breakdown is the only view inside the forward the
+    client waits on, so it has to survive the trip and stay absent when unset."""
+
+    def test_stages_are_reported_in_milliseconds(self):
+        metrics = types.SimpleNamespace(
+            stages={"decoding": 8123.4567, "text_encoding": 91.2}
+        )
+        self.assertEqual(
+            json.loads(stages_header(metrics)),
+            {"decoding": 8123.457, "text_encoding": 91.2},
+        )
+
+    def test_no_metrics_or_no_stages_yields_no_header(self):
+        self.assertEqual(stages_header(None), "")
+        self.assertEqual(stages_header(types.SimpleNamespace(stages={})), "")
 
 
 if __name__ == "__main__":

--- a/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
+++ b/python/sglang/multimodal_gen/test/unit/test_rollout_api.py
@@ -1,10 +1,22 @@
-"""Unit tests for the rollout generate API (serialization, io_struct, rollout_api)."""
+"""Unit tests for the rollout generate API (serialization, io_struct, rollout_api).
 
+Request timing model (TestRequestStamps):
+
+    srv_recv .. forward .. build .. dump .. msgpack   (absolute wall-clock marks)
+    -> all marks ride the x-sgld-timing response header
+"""
+
+import json
+import time
 import types
 import unittest
 
 import torch
 
+from sglang.multimodal_gen.runtime.entrypoints.post_training.request_timing import (
+    MARKS,
+    RequestStamps,
+)
 from sglang.multimodal_gen.runtime.entrypoints.post_training.utils import (
     _maybe_deserialize,
     _maybe_serialize,
@@ -415,6 +427,49 @@ class TestBuildSamplingKwargs(unittest.TestCase):
         req = Req(sampling_params=sp)
         self.assertEqual(req.rollout_sde_step_indices, [0, 2])
         self.assertEqual(req.rollout_return_step_indices, [1, 3])
+
+
+class TestRequestStamps(unittest.TestCase):
+    """The client joins these marks with its own, so what matters is that the
+    header decodes, keeps wall-clock order, and stays readable when a request
+    returned early with only some marks taken."""
+
+    def _decode(self, stamps: RequestStamps) -> dict:
+        header = stamps.to_header()
+        self.assertEqual(header, header.encode("ascii").decode())
+        return json.loads(header)
+
+    def test_marks_decode_in_wall_clock_order(self):
+        before = time.time()
+        stamps = RequestStamps("req-1")
+        for name in MARKS:
+            stamps.mark(name)
+        decoded = self._decode(stamps)
+        self.assertEqual(decoded.pop("request_id"), "req-1")
+        self.assertEqual(set(decoded), set(MARKS))
+        values = [decoded[name] for name in MARKS]
+        self.assertEqual(values, sorted(values))
+        self.assertGreaterEqual(values[0], round(before, 6) - 1e-6)
+
+    def test_span_pairs_start_and_end_marks(self):
+        stamps = RequestStamps()
+        with stamps.span("forward"):
+            pass
+        with stamps.span("dump"):
+            pass
+        self.assertEqual(
+            set(json.loads(stamps.to_header())),
+            {"forward_start", "forward_end", "dump_end"},
+        )
+
+    def test_partial_marks_only_report_what_was_taken(self):
+        stamps = RequestStamps("req-3")
+        stamps.mark("srv_recv")
+        self.assertEqual(set(self._decode(stamps)), {"srv_recv", "request_id"})
+
+    def test_unknown_mark_is_rejected(self):
+        with self.assertRaises(AssertionError):
+            RequestStamps().mark("no_such_mark")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Five standalone commits on the rollout HTTP path (`/rollout/generate`):

1. **Off-loop serialization** — build + serialize the response in a worker thread (`asyncio.to_thread`; the safetensors save releases the GIL) and send the pre-built buffers via a fixed-length response with explicit `content-length`. Identity framing, wire bytes unchanged, zero client change.
2. **msgpack bin-splice** — container/bin32 headers are hand-written so large tensor `bytes` enter the output list by reference instead of being copied through the encoder. `b"".join(parts)` is byte-identical to `msgspec.msgpack.encode(payload)` (unit-tested), and the parts are streamed without re-joining, so a serialized tensor is never copied again after safetensors produces it.
3. **`x-sgld-timing` header** — absolute wall-clock marks (`srv_recv` → `msgpack_end`) per request, so the trainer can reconstruct a cross-process waterfall. Header only; msgpack body contract untouched.
4. **`x-sgld-stages` header** — the engine's per-stage milliseconds (text encode / denoise / decode), distinguishing a slow denoise from a slow VAE decode client-side.
5. **Opt-in `rollout_video_dtype="uint8"`** — engine-side quantization of the decoded [0,1] video to 0..255 uint8 (consumers divide by 255), ~4x smaller video payload. Default `None` ships unchanged.

## Why

An H3 rollout response carries hundreds of MB of trajectory tensors. Encoding them inline held the GIL and blocked the uvicorn event loop for the full serialization — stalling health checks, reply handling, and next-request dispatch. With the loop free, serialization of request N overlaps the denoise of request N+1 under `--sglang-server-concurrency >= 2`.

Verified end-to-end on the MiniMax-H3 2-GPU GRPO recipe (3 rollout steps, wire-identical responses, no regression; unit tests in `test_msgpack_splice.py` / `test_rollout_api.py` are auto-registered CI).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33128328860](https://github.com/sgl-project/sglang/actions/runs/33128328860)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33128328737](https://github.com/sgl-project/sglang/actions/runs/33128328737)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33128328859](https://github.com/sgl-project/sglang/actions/runs/33128328859)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->