### PR TITLE
Fix DFLASH aux hidden-state capture on mHC models

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -1076,9 +1076,14 @@ class Glm5NextModel(nn.Module):
         return self.embed_tokens
 
     def _prepare_aux_hidden_state(
-        self, hidden_states: torch.Tensor, residual: torch.Tensor
+        self, hidden_states: torch.Tensor, residual: Optional[torch.Tensor]
     ) -> torch.Tensor:
-        aux_hidden_state = hidden_states + residual
+        # Under mHC the residual is folded into the widened hidden state, so the
+        # layer communicator hands back residual=None and hc_contract below does
+        # the merge. Only the plain residual-stream path has a tensor to add.
+        aux_hidden_state = (
+            hidden_states if residual is None else hidden_states + residual
+        )
         if self.dflash_capture and self.config.mhc:
             aux_hidden_state = hc_contract(aux_hidden_state, self.config.hc_mult)
         return aux_hidden_state

--- a/test/registered/unit/models/test_glm5_next_dflash_capture.py
+++ b/test/registered/unit/models/test_glm5_next_dflash_capture.py
@@ -1,5 +1,7 @@
+import sys
 from types import SimpleNamespace
 
+import pytest
 import torch
 from torch import nn
 
@@ -7,6 +9,9 @@ from sglang.srt.models.glm5_next import (
     Glm5NextForConditionalGeneration,
     Glm5NextModel,
 )
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 def test_glm5_next_dflash_contracts_mhc_hidden_state():
@@ -39,6 +44,36 @@ def test_glm5_next_eagle_capture_keeps_mhc_hidden_state():
     torch.testing.assert_close(actual, hidden_states + residual)
 
 
+def test_glm5_next_dflash_contracts_mhc_hidden_state_without_residual():
+    # GLM-5.3-Flash runs with mhc=True, where MHCLayerCommunicator folds the
+    # residual into the widened hidden state and returns residual=None.
+    model = Glm5NextModel.__new__(Glm5NextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(mhc=True, hc_mult=4)
+    model.dflash_capture = True
+
+    hidden_states = torch.arange(24, dtype=torch.float32).reshape(2, 12)
+
+    actual = model._prepare_aux_hidden_state(hidden_states, None)
+    expected = hidden_states.unflatten(-1, (4, -1)).mean(dim=-2)
+
+    torch.testing.assert_close(actual, expected)
+    assert actual.shape == (2, 3)
+
+
+def test_glm5_next_eagle_capture_without_residual():
+    model = Glm5NextModel.__new__(Glm5NextModel)
+    nn.Module.__init__(model)
+    model.config = SimpleNamespace(mhc=False, hc_mult=1)
+    model.dflash_capture = False
+
+    hidden_states = torch.arange(24, dtype=torch.float32).reshape(2, 12)
+
+    actual = model._prepare_aux_hidden_state(hidden_states, None)
+
+    torch.testing.assert_close(actual, hidden_states)
+
+
 def test_glm5_next_dflash_maps_target_layers_to_capture_points():
     model = Glm5NextForConditionalGeneration.__new__(Glm5NextForConditionalGeneration)
     nn.Module.__init__(model)
@@ -51,3 +86,7 @@ def test_glm5_next_dflash_maps_target_layers_to_capture_points():
     assert model.capture_aux_hidden_states
     assert model.model.dflash_capture
     assert model.model.layers_to_capture == [6, 15, 25, 34, 43]
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__]))


### PR DESCRIPTION
## Motivation

`Glm5NextModel._prepare_aux_hidden_state()`, added in #36708, unconditionally computes `hidden_states + residual`. GLM-5.3-Flash sets `mhc=True`, and under mHC every `MHCLayerCommunicator.postprocess_layer()` branch returns `residual=None` — the residual is folded into the widened `[tokens, hc_mult * hidden]` state that `hc_contract()` on the very next line is there to merge back down.

So serving GLM-5.3-Flash with `--speculative-algorithm DFLASH` dies on every TP rank during decode CUDA-graph capture (weights load fine first, so the failure looks late):

```
File "python/sglang/srt/models/glm5_next.py", line 1081, in _prepare_aux_hidden_state
    aux_hidden_state = hidden_states + residual
TypeError: unsupported operand type(s) for +: 'Tensor' and 'NoneType'
```

## Modifications

- Skip the add when there is no separate residual to fold in, and widen the annotation to `Optional[torch.Tensor]`.
- Cover the `residual=None` case for both the DFLASH and the plain EAGLE3 capture paths. The existing tests only exercised the residual-is-a-tensor case, which is the state that cannot occur on an mHC model.
- Register `test/registered/unit/models/test_glm5_next_dflash_capture.py` with `register_cpu_ci` and give it a `__main__` entry. Without them `test/run_suite.py` never discovers the file, so none of its tests have ever run in CI — that is why this crash landed green.

## Accuracy Test

8xB300, TP8/EP8, real checkpoint, draft `incoai/GLM-5.3-Flash-DFlash2`, `--dsa-{prefill,decode}-backend trtllm --kv-cache-dtype fp8_e4m3 --moe-runner-backend deep_gemm --speculative-draft-attention-backend fa4`. The server now reaches ready, and 5-shot GSM8K (temperature 0) gives:

| parallel | accuracy | accept length (token-weighted) |
|---|---|---|
| 1 (60 q) | 0.950 | 4.85 |
| 32 (200 q) | 0.910 | 4.86 |

Unit tests, CPU-only, via the CI invocation `python3 <file> -f`: 5 passed. Reverting only the model change while keeping the new tests makes exactly the 2 new tests fail.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/development_guide_using_docker.html#running-unit-tests-adding-file-to-ci).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33129468763](https://github.com/sgl-project/sglang/actions/runs/33129468763)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33129468645](https://github.com/sgl-project/sglang/actions/runs/33129468645)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33129468766](https://github.com/sgl-project/sglang/actions/runs/33129468766)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->