### PR TITLE
[AMD] Qwen3.5 ASM FMHA chunked-prefill context attention

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -97,12 +97,6 @@ _use_fp8_prefill_attn = (
     get_bool_env_var("SGLANG_AITER_FP8_PREFILL_ATTN", "True") and is_gfx95_supported()
 )
 
-# Route context-chunk prefill (extend with a prefix) to the gfx950 ASM fmha.
-_use_asm_context_prefill = (
-    get_bool_env_var("SGLANG_AITER_ASM_CONTEXT_PREFILL", "True")
-    and is_gfx95_supported()
-)
-
 # Persist
 # fast_mode=True if _use_mla_ps_kernel else False
 # intra_batch_mode=False if _use_mla_ps_kernel else True
@@ -2481,7 +2475,7 @@ class AiterAttnBackend(AttentionBackend):
             # buffer costs only ~20 us per layer at 70k context. The no-prefix
             # first chunk already takes the ASM branch below.
             if (
-                _use_asm_context_prefill
+                is_gfx95_supported()
                 and forward_batch.forward_mode.is_extend()
                 and forward_batch.extend_prefix_lens_cpu is not None
                 and any(forward_batch.extend_prefix_lens_cpu)

--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -97,6 +97,12 @@ _use_fp8_prefill_attn = (
     get_bool_env_var("SGLANG_AITER_FP8_PREFILL_ATTN", "True") and is_gfx95_supported()
 )
 
+# Route context-chunk prefill (extend with a prefix) to the gfx950 ASM fmha.
+_use_asm_context_prefill = (
+    get_bool_env_var("SGLANG_AITER_ASM_CONTEXT_PREFILL", "True")
+    and is_gfx95_supported()
+)
+
 # Persist
 # fast_mode=True if _use_mla_ps_kernel else False
 # intra_batch_mode=False if _use_mla_ps_kernel else True
@@ -2467,6 +2473,109 @@ class AiterAttnBackend(AttentionBackend):
             window_size = (-1, -1)
             if layer.sliding_window_size is not None and layer.sliding_window_size > -1:
                 window_size = (layer.sliding_window_size, -1)
+
+            # Context-chunk prefill (extend batches WITH a prefix) via the
+            # gfx950 ASM fp8 varlen fmha. The ck_tile paged batch_prefill runs
+            # at ~15% FP8 MFU at these shapes while the ASM kernel is ~3.5x
+            # faster; gathering the paged fp8 KV into a contiguous varlen
+            # buffer costs only ~20 us per layer at 70k context. The no-prefix
+            # first chunk already takes the ASM branch below.
+            if (
+                _use_asm_context_prefill
+                and forward_batch.forward_mode.is_extend()
+                and forward_batch.extend_prefix_lens_cpu is not None
+                and any(forward_batch.extend_prefix_lens_cpu)
+                and window_size == (-1, -1)
+                and sinks is None
+                and self.logits_soft_cap == 0.0
+                and layer.qk_head_dim == 256
+                and layer.v_head_dim == 256
+                and self.kv_cache_dtype == fp8_dtype
+                and not self.kv_cache_is_vectorized_5d
+                and self.forward_metadata.max_kv_len is not None
+            ):
+                bs = forward_batch.batch_size
+                k_cache, v_cache = self.token_to_kv_pool.get_kv_buffer(layer.layer_id)
+                page = self.page_size
+                kv_indptr = self.forward_metadata.kv_indptr[: bs + 1]
+                kv_pages = self.forward_metadata.kv_indices
+                seq_lens = forward_batch.seq_lens[:bs].to(torch.long)
+                # kvlen must not exceed the pages this batch actually has in
+                # kv_indices (metadata is page-granular for plain extend, but
+                # can disagree with seq_lens in mixed/spec batches -> OOB
+                # gather). Clamp per-seq kvlen to pages*page and fall back to
+                # the paged kernel on any inconsistency.
+                pages_per_seq = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.long)
+                kvlen_cap = pages_per_seq * page
+                seq_lens = torch.minimum(seq_lens, kvlen_cap)
+                total_k = int(seq_lens.sum().item())
+                cu_k = torch.zeros(bs + 1, dtype=torch.long, device=q.device)
+                torch.cumsum(seq_lens, 0, out=cu_k[1:])
+                seq_ids = torch.repeat_interleave(
+                    torch.arange(bs, device=q.device), seq_lens
+                )
+                pos_in_seq = torch.arange(total_k, device=q.device) - cu_k[seq_ids]
+                page_slot = kv_indptr[seq_ids].to(torch.long) + pos_in_seq // page
+                asm_cp_ok = bool(int(page_slot.max().item()) < kv_pages.numel())
+                if not asm_cp_ok:
+                    logger.warning(
+                        "[asm-context-prefill] metadata mismatch, falling back:"
+                        " mode=%s bs=%s page_slot_max=%s kv_pages=%s seq_lens=%s"
+                        " kv_indptr=%s",
+                        forward_batch.forward_mode,
+                        bs,
+                        int(page_slot.max().item()),
+                        kv_pages.numel(),
+                        seq_lens.tolist(),
+                        kv_indptr.tolist(),
+                    )
+                if asm_cp_ok:
+                    tok_idx = (
+                        kv_pages[page_slot].to(torch.long) * page + pos_in_seq % page
+                    )
+                    asm_cp_ok = int(tok_idx.max().item()) < (
+                        self.token_to_kv_pool.get_key_buffer(layer.layer_id).shape[0]
+                    )
+                if asm_cp_ok:
+                    hk = layer.tp_k_head_num * layer.qk_head_dim
+                    hv = layer.tp_v_head_num * layer.v_head_dim
+                    # uint8 view: index_select is not implemented for fp8.
+                    k_gather = (
+                        k_cache.view(-1, hk)
+                        .view(torch.uint8)
+                        .index_select(0, tok_idx)
+                        .view(k_cache.dtype)
+                        .view(-1, layer.tp_k_head_num, layer.qk_head_dim)
+                    )
+                    v_gather = (
+                        v_cache.view(-1, hv)
+                        .view(torch.uint8)
+                        .index_select(0, tok_idx)
+                        .view(v_cache.dtype)
+                        .view(-1, layer.tp_v_head_num, layer.v_head_dim)
+                    )
+                    fp8_q_descale = (
+                        layer.k_scale if layer.k_scale is not None else self.k_scale
+                    )
+                    o = flash_attn_varlen_fp8_pertensor_func(
+                        q.contiguous()
+                        .view(-1, layer.tp_q_head_num, layer.qk_head_dim)
+                        .to(fp8_dtype),
+                        k_gather,
+                        v_gather,
+                        fp8_q_descale.reshape(1),
+                        k_descale.reshape(1),
+                        v_descale.reshape(1),
+                        self.qo_indptr[:bs0],
+                        cu_k.to(torch.int32),
+                        self.forward_metadata.max_q_len,
+                        int(self.forward_metadata.max_kv_len),
+                        softmax_scale=layer.scaling,
+                        causal=True,
+                    )
+                    if o.dtype != self.input_dtype:
+                        o = o.to(self.input_dtype)
+                    return o.view(-1, layer.tp_q_head_num * layer.qk_head_dim)
 
             if (
                 is_gfx95_supported()


### PR DESCRIPTION
## Motivation

On MI355X, long-input Qwen3.5 serving (70k prompt, chunked prefill) spends most of its prefill attention time in aiter's ck_tile paged `mha_batch_prefill`. Measured at production shapes (head_dim 256, fp8 KV, 16k-token chunks), that kernel runs at roughly 15% of the GPU's FP8 peak — and paging is not the reason: a fully contiguous KV layout is just as slow, and fp8 inputs are only ~1.2x faster than bf16, so the pipeline never reaches the fp8 rate.

The gfx950 ASM kernel `fmha_fwd_hd256_fp8_causal_group` (already used by SGLang for the no-prefix first chunk) runs the same shapes 3.5x faster. The only reason context chunks cannot use it today is that it wants contiguous varlen K/V, while the KV cache is paged.

It turns out the gather is nearly free: copying 70k tokens of fp8 KV (~72 MB) into a contiguous buffer takes ~18 µs, against several milliseconds for the attention itself. So we gather and call the ASM kernel.

## Modifications

`python/sglang/srt/layers/attention/aiter_backend.py`, in `forward_extend`:

- New branch for extend batches **with** a prefix (the no-prefix case already had an ASM path). It expands the page-granular `kv_indptr` / `kv_indices` metadata into per-token pool indices, gathers K/V into a contiguous varlen buffer (via a `uint8` view, since `index_select` is not implemented for fp8), and calls `flash_attn_varlen_fp8_pertensor_func` with bottom-right causal masking.
- Guard rails:
  - The branch checks that the page metadata actually covers `seq_lens` before gathering (mixed / speculative batches can disagree); on any mismatch it logs once and falls back to the original paged path. Nothing crashes, worst case is the old speed.
  - Gated on gfx950, bf16 Q, fp8 KV cache, head_dim 256, no sliding window, no sink, no softcap.
  - Disabled when the KV pool uses the `vectorized_5d` layout (different physical layout).
- Draft-model catch-up chunks (EAGLE/MTP) hit the same branch and get the same speedup — they are ordinary extend batches with a prefix.

## Accuracy Tests

GSM8K, 5-shot, all 1319 questions, temperature 0, max new tokens 2048; Qwen3.5-397B-A17B-MXFP4, TP2, MI355X. 

| Backend | Accuracy | Correct | Invalid |
|---|---:|---:|---:|
| AITER | 92.8% | 1224/1319 | 1/1319 |

## Benchmarking and Profiling

Benchmarks were run on a tree with #36330 applied (the current MI355X perf baseline for this model); the change itself is independent of it and this PR is based on `main`.

### Kernel microbenchmark

Single MI355X GPU, causal, head_dim 256, fp8 KV, 16384 new tokens attending to a 32k-token paged context (the production context-chunk shape):

| kernel | TP2 shape (16 q-heads / 2 kv-heads) | TFLOP/s | TP4 shape (8 / 1) |
|---|---|---|---|
| ck_tile paged batch_prefill, fp8 KV (current path) | 14.24 ms | 772 (~15% fp8 MFU) | 7.21 ms / 762 |
| ck_tile contiguous (page_size 1), fp8 KV | 14.45 ms | 761 | — |
| ck_tile paged, bf16 KV | 17.48 ms | 629 | — |
| ASM `fmha_fwd_hd256_fp8_causal_group` + gather | **4.04 ms** | **2,725 (~55% fp8 MFU)** | **2.00 ms / 2,753** |

Paged and contiguous ck_tile run at the same speed, and fp8 is only ~1.2x faster than bf16 there — so paging is not the bottleneck, kernel efficiency is. Tail chunks show the same ratio (4464 new tokens over a 65k context: 2.44 ms vs 8.99 ms). The KV gather this PR adds costs 17.6 µs at 65k context (~7.6 TB/s effective), negligible against the attention itself.

### End-to-end serving

End-to-end serving on MI355X, Qwen3.5-397B-A17B-MXFP4, random-ids 70k input / 300 output, EAGLE (3 steps, top-k 1, 4 draft tokens), warmup + measured requests, otherwise the pinned recipe (`--attention-backend aiter --page-size 16 --kv-cache-dtype fp8_e4m3 --chunked-prefill-size 16384`):

| config | metric | before | after | delta |
|---|---|---|---|---|
| TP2 c4 | mean E2E | 13,393 ms | 10,057 ms | -24.9% |
| TP2 c4 | mean TTFT | 8,274 ms | 6,382 ms | -22.9% |
| TP2 c4 | mean TPOT | 17.12 ms | 12.29 ms | -28.2% |
| TP4 c4 | mean E2E | 8,512 ms | 6,415 ms | -24.6% |
| TP4 c4 | mean TTFT | 4,942 ms | 3,638 ms | -26.4% |
| TP4 c8 | mean E2E | 16,098 ms | 11,724 ms | -27.2% |
| TP4 c12 | mean E2E | 23,690 ms | 16,933 ms | -28.5% |
| TP4 c16 | mean E2E | 31,154 ms | 22,585 ms | -27.5% |

TPOT improves as a side effect: other requests' prefill chunks block decode for less time. No crashes and zero guard fallbacks across all runs above.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.ai/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.ai/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the [SGLang code style guidance](https://docs.sglang.ai/developer_guide/contribution_guide.html).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33142874228](https://github.com/sgl-project/sglang/actions/runs/33142874228)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33142885073](https://github.com/sgl-project/sglang/actions/runs/33142885073)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33142874151](https://github.com/sgl-project/sglang/actions/runs/33142874151)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->