### PR TITLE
fix(modelopt): expand is_layer_excluded for fused and model.-prefixed names

### DIFF
--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -349,6 +349,27 @@ class ModelOptQuantConfig(QuantizationConfig):
         if prefix.startswith("language_model."):
             prefixes_to_check.append(prefix.removeprefix("language_model."))
 
+        # Expand fused module names to their checkpoint shard names. The exclude
+        # list may reference per-projection names (e.g. "q_proj") while the model
+        # builds a fused module (e.g. "qkv_proj"), so matching must consider the
+        # unfused constituents.
+        if self.packed_modules_mapping:
+            expanded = []
+            for p in prefixes_to_check:
+                head, _, tail = p.rpartition(".")
+                for shard_name in self.packed_modules_mapping.get(tail, []):
+                    expanded_prefix = f"{head}.{shard_name}" if head else shard_name
+                    expanded.append(expanded_prefix)
+                    if expanded_prefix.startswith("language_model."):
+                        expanded.append(expanded_prefix.removeprefix("language_model."))
+            prefixes_to_check.extend(expanded)
+
+        # Vision-language checkpoints sometimes rename "model.visual.*" to
+        # "visual.*" during load; also test the "model."-prefixed variant.
+        prefixes_to_check.extend(
+            "model." + p for p in prefixes_to_check if not p.startswith("model.")
+        )
+
         # Fused module patterns: the exclude list may reference a sub-component
         # (e.g., "q_a_proj") that is fused into a combined parameter name
         # (e.g., "fused_qkv_a_proj_with_mqa"). We check if the last segment of

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4.py
@@ -17,6 +17,55 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
+class TestModelOptIsLayerExcluded(unittest.TestCase):
+    def test_exact_match(self):
+        config = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+        self.assertTrue(config.is_layer_excluded("lm_head"))
+        self.assertFalse(config.is_layer_excluded("embed_tokens"))
+
+    def test_language_model_prefix_stripping(self):
+        config = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.0.self_attn.q_proj"],
+        )
+        self.assertTrue(
+            config.is_layer_excluded("language_model.model.layers.0.self_attn.q_proj")
+        )
+
+    def test_packed_modules_mapping_expansion(self):
+        config = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.layers.0.self_attn.q_proj"],
+            packed_modules_mapping={"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+        )
+        self.assertTrue(config.is_layer_excluded("model.layers.0.self_attn.qkv_proj"))
+
+    def test_model_prefix_variant(self):
+        config = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.visual.encoder.layers.0.attn.qkv_proj"],
+            packed_modules_mapping={"qkv_proj": ["q_proj", "k_proj", "v_proj"]},
+        )
+        self.assertTrue(
+            config.is_layer_excluded("visual.encoder.layers.0.attn.qkv_proj")
+        )
+
+    def test_wildcard_pattern(self):
+        config = ModelOptFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            group_size=16,
+            exclude_modules=["model.visual.*"],
+        )
+        self.assertTrue(config.is_layer_excluded("visual.encoder.layers.0.attn.q_proj"))
+
+
 class TestModelOptNvfp4(CustomTestCase):
     def _make_layer(self):
         return MergedColumnParallelLinear(


### PR DESCRIPTION
This PR fixes the `ModelOptQuantConfig.is_layer_excluded` matcher so mixed-precision ModelOpt FP4/FP8 checkpoints correctly honor their exclusion lists when SGLang builds fused modules or renames `model.visual.*` to `visual.*` during load (reported in #36596).

Changes:
- `python/sglang/srt/layers/quantization/modelopt_quant.py`:
  - Expand a prefix through `packed_modules_mapping` before matching, so an exclude entry like `*.self_attn.q_proj` also matches a built `qkv_proj`.
  - Also test `model.`-prefixed variants of every candidate prefix, so `model.visual.*` exclusions still match after the vision tower is renamed to `visual.*`.
- `test/registered/unit/layers/quantization/test_modelopt_nvfp4.py`: add `TestModelOptIsLayerExcluded` covering exact match, `language_model.` prefix stripping, fused-module expansion, `model.visual`/`visual` renaming, and wildcard patterns.

The new unit tests pass:
```bash
python -m pytest test/registered/unit/layers/quantization/test_modelopt_nvfp4.py::TestModelOptIsLayerExcluded -v
```

All existing tests in `test_modelopt_nvfp4.py` still pass, and `ruff check --select=F401,F821,UP037` and `black` are clean on the changed files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33132248773](https://github.com/sgl-project/sglang/actions/runs/33132248773)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33132248698](https://github.com/sgl-project/sglang/actions/runs/33132248698)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33132248727](https://github.com/sgl-project/sglang/actions/runs/33132248727)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->