### PR TITLE
[Fix] Qwen3.5-VL grounding: skip fused NeoX RoPE kernel for M-RoPE models

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -992,6 +992,16 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
             dtype=torch.get_default_dtype(),
         )
 
+        # The fused_qk_gemma_rmsnorm_rope_gate CUDA kernel applies a plain NeoX
+        # RoPE over the flat `positions`. It cannot express M-RoPE (the
+        # mrope_section 3D position split, optionally interleaved), so for
+        # M-RoPE models such as Qwen3.5-VL it silently corrupts the rotary
+        # encoding of the vision tokens (grounding/bbox is offset). Only take
+        # the fused CUDA path when the rotary embedding is a plain, non-M-RoPE
+        # RoPE; M-RoPE models fall back to forward_prepare_fused_gate, which
+        # runs the correct Python MRotaryEmbedding.
+        self._can_fuse_qk_rope = not getattr(self.rotary_emb, "mrope_section", None)
+
         # Q stays sharded across attention TP ranks; K/V are replicated within
         # each DCP group.
         self.qkv_proj = QKVParallelLinear(
@@ -1239,12 +1249,14 @@ class Qwen3_5AttentionDecoderLayer(nn.Module):
         forward_batch: ForwardBatch,
     ) -> torch.Tensor:
         """Full attention forward pass."""
-        if _is_cuda and self.attn_output_gate:
+        if _is_cuda and self.attn_output_gate and self._can_fuse_qk_rope:
             q, k, v, gate = self.forward_prepare_cuda_fused(
                 positions=positions,
                 hidden_states=hidden_states,
             )
-        elif (_is_hip or _is_xpu or _is_cpu) and self.attn_output_gate:
+        elif (_is_hip or _is_xpu or _is_cpu or _is_cuda) and self.attn_output_gate:
+            # Non-CUDA gated path, and CUDA M-RoPE models that must skip the
+            # fused NeoX RoPE kernel above.
             q, k, v, gate = self.forward_prepare_fused_gate(
                 positions=positions,
                 hidden_states=hidden_states,


### PR DESCRIPTION
## Motivation

Fixes #36762. Same root cause as the earlier report #35772 (Qwen3-VL fine-grained grounding diverging from Transformers/vLLM).

Qwen3.5-VL grounding / bbox predictions are offset by ~90px on CUDA, while OCR / text / math stay correct. Root cause: the `fused_qk_gemma_rmsnorm_rope_gate` CUDA kernel used by `Qwen3_5AttentionDecoderLayer.forward_prepare_cuda_fused` applies a plain **NeoX RoPE over the flat `positions`**. It cannot express **M-RoPE** — the `mrope_section` 3D position split, optionally interleaved (`mrope_interleaved=True`) — which Qwen3.5-VL uses (`partial_rotary_factor=0.25`, `mrope_section=[11,11,10]`). So the rotary spatial encoding of vision tokens is silently corrupted; language tokens are robust enough to look fine, which is why only grounding regresses.

The non-CUDA path (`forward_prepare_fused_gate`) fuses only the QK-norm + gate and then calls the real Python `MRotaryEmbedding` (`self.rotary_emb(positions, q, k)`), which handles M-RoPE correctly.

## Modification

Guard the fused CUDA RoPE path so it is only taken for **plain, non-M-RoPE** rotary embeddings. M-RoPE models fall back to `forward_prepare_fused_gate` (correct Python `MRotaryEmbedding`).

- `__init__`: `self._can_fuse_qk_rope = not getattr(self.rotary_emb, "mrope_section", None)` — `MRotaryEmbedding` sets `mrope_section`; plain `RotaryEmbedding` does not.
- dispatch: add `and self._can_fuse_qk_rope` to the CUDA fused branch, and `or _is_cuda` to the fused-gate branch so CUDA M-RoPE models land there.

Non-M-RoPE models keep the fused fast path unchanged; NPU / HIP / XPU / CPU behaviour is unchanged.

## Impact / performance

Only the few `full_attention` layers use this fusion (Qwen3.5 is mostly linear-attention / GDN), and only M-RoPE models change path. In an end-to-end decode-throughput A/B on B300 the fused vs. fixed paths were within run-to-run noise (~2.8–3.1k tok/s both), i.e. no measurable regression.

## Verification

Grounding center-in-box accuracy on Qwen3.5-VL (temperature 0, thinking off):

| build | grounding acc |
|---|---|
| CUDA fused (before) | ~26% |
| this fix (`forward_prepare_fused_gate`) | ~81.7% (matches HF / vLLM) |

Confirmed by a full component bisection vs HF: pixel_values cos≈1.0, ViT+merger embeds cos≈0.9995, M-RoPE position ids exact, linear-attention (GDN) layers identical; the first `full_attention` layer's hidden states diverge ~10x — exactly the layers that call the fused RoPE kernel.

## Checklist

- [x] Minimal, backward-compatible for non-M-RoPE models
- [x] `python -m py_compile` passes
- [x] Signed-off-by (DCO)
