### PR TITLE
[HiCache] Skip mamba radix caching instead of asserting when no slot can be evicted

### DIFF
--- a/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/mamba_component.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import logging
+import time
 from collections import defaultdict
 from typing import TYPE_CHECKING, Callable, Optional, Sequence
 
@@ -53,6 +55,9 @@ if TYPE_CHECKING:
         UnifiedRadixCache,
         UnifiedTreeNode,
     )
+
+
+logger = logging.getLogger(__name__)
 
 
 class MambaComponent(TreeComponent):
@@ -489,14 +494,77 @@ class MambaComponent(TreeComponent):
                 self.tree_core.component_protected_size_[ct] -= vlen
             cd.lock_ref -= 1
 
-    def _alloc_mamba_slot(self) -> torch.Tensor:
-        """Allocate one mamba pool slot, evicting if necessary."""
+    def _try_alloc_mamba_slot(self) -> Optional[torch.Tensor]:
+        """Allocate one mamba pool slot for the radix cache, evicting if necessary.
+
+        Returns None when no slot is free and the one-shot eviction could not
+        free one either: every cached mamba state is momentarily unevictable
+        (held by a running request's lock_ref, or pinned by an in-flight
+        write-through backup / H->D load-back). Callers on the caching path
+        must degrade (skip caching this chunk) rather than crash: the radix
+        cache is an optimization and the request's own live state is untouched.
+        Logs a throttled pin census so a persistent pin leak is distinguishable
+        from a transient DMA window.
+        """
         slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
         if slot is None:
             self.cache.evict_for_alloc(EvictParams(num_tokens=0, mamba_num=1))
             slot = self.cache.req_to_token_pool.mamba_allocator.alloc(1)
-            assert slot is not None, "Can not alloc mamba cache"
+        if slot is None:
+            self._on_mamba_alloc_failed()
         return slot
+
+    _CENSUS_THROTTLE_S = 60.0
+    _last_census_t = 0.0
+
+    def _on_mamba_alloc_failed(self) -> None:
+        """Account for a caching-path mamba slot alloc failure: bump the
+        radix-cache metric and emit a throttled WARNING census of the tree's
+        mamba-bearing device nodes by pin class. Never raises."""
+        if self.cache.metrics_collector is not None:
+            self.cache.metrics_collector.increment_aux_alloc_failed()
+        now = time.monotonic()
+        if now - self._last_census_t < self._CENSUS_THROTTLE_S:
+            return
+        self._last_census_t = now
+        try:
+            ct = self.component_type
+            total = locked = host_locked = wt_pending = lb_pending = 0
+            stack = [self.tree_core.root_node]
+            while stack:
+                node = stack.pop()
+                stack.extend(node.children.values())
+                cd = node.component_data[ct]
+                if cd.value is None:
+                    continue
+                total += 1
+                if cd.lock_ref > 0:
+                    locked += 1
+                if cd.host_lock_ref > 0:
+                    host_locked += 1
+                if node.write_through_pending_id is not None:
+                    wt_pending += 1
+                if node.load_back_pending_id is not None:
+                    lb_pending += 1
+            logger.warning(
+                "mamba slot alloc failed after eviction; skipping radix caching "
+                "for this chunk. census: device_nodes=%d lock_ref>0=%d "
+                "host_lock_ref>0=%d write_through_pending=%d load_back_pending=%d "
+                "evictable_size=%d protected_size=%d",
+                total,
+                locked,
+                host_locked,
+                wt_pending,
+                lb_pending,
+                self.tree_core.component_evictable_size_[ct],
+                self.tree_core.component_protected_size_[ct],
+            )
+        except Exception:
+            logger.warning(
+                "mamba slot alloc failed after eviction; skipping radix caching "
+                "for this chunk (census unavailable)",
+                exc_info=True,
+            )
 
     @property
     def int8_ckpt_pool(self):
@@ -570,10 +638,16 @@ class MambaComponent(TreeComponent):
         else:
             if cache_len is None:
                 return 0
-            # Donate the mamba index to the radix cache instead of copying.
+            # Donate the mamba index to the radix cache instead of copying. A
+            # failed slot alloc (every cached state transiently pinned) degrades
+            # to "cache nothing this chunk" (return 0 -> the caller's existing
+            # effective_cache_len<=0 skip path) instead of crashing: the request
+            # keeps its own live state and a later chunk retries the insert.
             if self.int8_ckpt_pool is not None:
                 if self.cache.enable_mamba_extra_buffer:
-                    new_slot = self._alloc_mamba_slot()
+                    new_slot = self._try_alloc_mamba_slot()
+                    if new_slot is None:
+                        return 0
                     src_active = (
                         self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                             req, new_slot
@@ -586,14 +660,18 @@ class MambaComponent(TreeComponent):
                         req.mamba_pool_idx.view(-1)
                     )
             elif self.cache.enable_mamba_extra_buffer:
-                new_slot = self._alloc_mamba_slot()
+                new_slot = self._try_alloc_mamba_slot()
+                if new_slot is None:
+                    return 0
                 mamba_value_donated = (
                     self.cache.req_to_token_pool.donate_mamba_ping_pong_slot(
                         req, new_slot
                     )
                 )
             else:
-                mamba_value_donated = self._alloc_mamba_slot()
+                mamba_value_donated = self._try_alloc_mamba_slot()
+                if mamba_value_donated is None:
+                    return 0
                 # mamba_pool is a pure PHYSICAL store; translate both slot ids
                 # virtual->physical (identity for the non-unified memory pool) first.
                 translate = self.cache.req_to_token_pool.translate_mamba_indices

--- a/python/sglang/srt/observability/metrics_collector.py
+++ b/python/sglang/srt/observability/metrics_collector.py
@@ -2153,6 +2153,16 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
             labelnames=list(labels.keys()) + ["pool"],
         )
 
+        self.aux_alloc_failed_total = Counter(
+            name="sglang:radix_cache_aux_alloc_failed_total",
+            documentation="Radix-cache inserts skipped because an auxiliary "
+            "device pool (e.g. the mamba state pool) could not allocate a slot "
+            "even after eviction: every cached state was held by a running "
+            "request or an in-flight hicache transfer. The request keeps "
+            "serving; only that chunk goes uncached.",
+            labelnames=labels.keys(),
+        )
+
         self.hicache_dropped_tokens = Counter(
             name="sglang:hicache_dropped_tokens_total",
             documentation="The number of device KV tokens destroyed without a "
@@ -2163,6 +2173,9 @@ class RadixCacheMetricsCollector(_StatLoggerDIMixin):
 
     def increment_eviction_num_tokens(self, num_tokens: int) -> None:
         self.eviction_num_tokens.labels(**self.labels).inc(num_tokens)
+
+    def increment_aux_alloc_failed(self) -> None:
+        self.aux_alloc_failed_total.labels(**self.labels).inc()
 
     def increment_load_back_num_tokens(self, num_tokens: int, pool: str) -> None:
         self.load_back_num_tokens.labels(**self.labels, pool=pool).inc(num_tokens)

--- a/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
+++ b/test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py
@@ -1365,6 +1365,65 @@ class UnifiedRadixCacheSuite:
         )
         cache.sanity_check()
 
+    def test_cache_unfinished_req_degrades_when_mamba_pool_exhausted(self):
+        """A caching-path mamba slot alloc that still fails after the one-shot
+        eviction (every cached state pinned by running requests or in-flight
+        hicache DMAs) must skip caching the chunk, never kill the scheduler:
+        nothing is inserted, the request keeps its live state and prefix, no
+        slot leaks, and the failure is observable (metric + WARNING census)."""
+        if not self.cfg.has_mamba:
+            self.skipTest("requires Mamba")
+        cache, allocator, req_to_token_pool = build_fixture(self.cfg)
+
+        req = self._make_req(req_to_token_pool)
+        tokens = self._make_seq(1, 3)
+        req.origin_input_ids = array("q", tokens)
+        req.output_ids = array("q")
+        req.full_untruncated_fill_ids = array("q", tokens)
+        req.set_extend_range(
+            len(req.prefix_indices), len(req.full_untruncated_fill_ids)
+        )
+        kv_len = len(tokens)
+        kv_indices = self._alloc(allocator, kv_len)
+        req_to_token_pool.write((req.req_pool_idx, slice(0, kv_len)), kv_indices)
+        req.kv_committed_len = kv_len
+        req.last_node = cache.root_node_handle()
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        req.mamba_last_track_seqlen = kv_len
+
+        pool = req_to_token_pool.mamba_allocator
+        live_slot = int(req.mamba_pool_idx)
+        free_before = pool.available_size()
+        collector = mock.Mock()
+        cache.metrics_collector = collector
+        mamba_logger = "sglang.srt.mem_cache.unified_cache.components.mamba_component"
+
+        # The pool hands out nothing and eviction cannot free anything.
+        with (
+            mock.patch.object(pool, "alloc", return_value=None),
+            mock.patch.object(
+                cache, "evict_for_alloc", autospec=True
+            ) as evict_for_alloc,
+            self.assertLogs(mamba_logger, level="WARNING") as logs,
+        ):
+            cache.cache_unfinished_req(req)
+
+        evict_for_alloc.assert_called_once_with(EvictParams(num_tokens=0, mamba_num=1))
+        collector.increment_aux_alloc_failed.assert_called_once_with()
+        self.assertEqual(len(logs.output), 1)
+        self.assertIn("census", logs.output[0])
+
+        # Nothing was cached ...
+        self.assertEqual(list(_node_children(cache, cache.root_node_handle())), [])
+        # ... and the request is untouched: it still owns its live mamba slot,
+        # its prefix indices cover the whole fill, and the pool did not leak.
+        self.assertEqual(int(req.mamba_pool_idx), live_slot)
+        self.assertEqual(len(req.prefix_indices), kv_len)
+        self.assertEqual(pool.available_size(), free_before)
+        cache.sanity_check()
+
     def test_swa_unfinished_req_preserves_existing_eviction_boundary(self):
         if not self.cfg.has_swa or self.cfg.has_mamba:
             self.skipTest("requires SWA without Mamba")
@@ -5544,6 +5603,86 @@ class UnifiedRadixCacheSuite:
         evict_for_alloc.assert_called_once_with(EvictParams(num_tokens=0, mamba_num=1))
         self.assertIs(prep.allocated_mamba_slot, retry_slot)
         self.assertEqual(int(req.mamba_pool_idx), int(retry_slot[0]))
+
+    def test_hicache_concurrent_full_and_mamba_load_back_on_shared_node(self):
+        """End-to-end regression for the cross-component load-back overlap
+        (production shape reported in #34975; fixed by #36317).
+
+        A load-back anchored at a descendant pins an evicted ancestor through
+        its Full-KV chain. Before that DMA acks, a second request anchors AT
+        the ancestor to restore its independently-evicted mamba state. The
+        mamba transfer must ride its own host lock rather than the Full
+        pending owner, so the second load-back commits, both acks drain, and
+        the tree stays consistent.
+        """
+        if not self.cfg.has_mamba or self.cfg.has_swa or self.cfg.page_size != 1:
+            self.skipTest("requires page_size=1 Full+Mamba")
+        cache, allocator, req_to_token_pool = build_fixture(self.cfg)
+        self._init_hicache(cache, write_policy="write_back")
+        core = cache.tree_core
+        MAMBA = ComponentType.MAMBA
+
+        chain = self._build_chain_pages(cache, allocator, req_to_token_pool, 4)
+        self.assertGreaterEqual(len(chain), 2, "need a >=2 node chain")
+        self._backup_tree(cache)
+        total = sum(_node_key_length(cache, n) for n in chain)
+        cache.evict(EvictParams(num_tokens=total + 16, mamba_num=64))
+
+        leaf = chain[-1]
+        self.assertTrue(core.is_full_device_evicted(leaf))
+        # An ancestor that is Full-evicted (so the leaf anchor's KV chain
+        # covers it) and mamba host-only (so a second anchor can target it).
+        ancestor = next(
+            (
+                n
+                for n in chain[:-1]
+                if core.is_full_device_evicted(n)
+                and core.component_has_host_value_only(n, MAMBA)
+            ),
+            None,
+        )
+        self.assertIsNotNone(
+            ancestor, "fixture produced no Full-evicted + mamba-host-only ancestor"
+        )
+
+        # Load-back 1: anchored at the leaf; its Full-KV chain pins the
+        # ancestor. The ack is withheld, so the pin stays live.
+        self.assertTrue(cache.load_back(leaf))
+        self.assertEqual(core.node_by_id(ancestor).load_back_pending_id, leaf)
+        # Commit republishes the Full device value before the ack, so a second
+        # anchor's Full chain stops above the ancestor; only its mamba state
+        # is still host-only.
+        self.assertFalse(core.is_full_device_evicted(ancestor))
+        self.assertTrue(core.component_has_host_value_only(ancestor, MAMBA))
+
+        # Load-back 2: anchored AT the still-pinned ancestor for its mamba
+        # state. Before #36317 this died with
+        # AssertionError: node <ancestor> pinned by load-back <leaf>, new anchor <ancestor>
+        req = self._make_req(req_to_token_pool)
+        req_to_token_pool.mamba_allocator.free(req.mamba_pool_idx.unsqueeze(0))
+        req.mamba_pool_idx = None
+        self.assertTrue(cache.load_back(ancestor, req=req))
+        self.assertIsNotNone(req.mamba_pool_idx)
+        # The Full pending owner is untouched by the aux transfer ...
+        self.assertEqual(core.node_by_id(ancestor).load_back_pending_id, leaf)
+        # ... whose source is protected by the mamba host lock until the ack.
+        self.assertGreater(
+            core.node_by_id(ancestor).component_data[MAMBA].host_lock_ref, 0
+        )
+
+        # Both DMAs ack; the Full pin drains and the mamba state is on device.
+        self._finish_pending_loads(cache)
+        for n in chain:
+            self.assertIsNone(
+                core.node_by_id(n).load_back_pending_id,
+                f"node {n} kept a stale load-back pin",
+            )
+        self.assertIsNotNone(_device_value(cache, ancestor, MAMBA))
+        self._release_ongoing_load_back_locks(cache)
+        self.assertEqual(
+            core.node_by_id(ancestor).component_data[MAMBA].host_lock_ref, 0
+        )
+        cache.sanity_check()
 
     def test_hicache_swa_load_back_min_suffix(self):
         """LOAD_BACK collects only the suffix nodes needed to cover sliding_window_size."""


### PR DESCRIPTION
## Motivation

Running a hybrid GDN/mamba model with `--enable-hierarchical-cache` on a 32GB GPU, the scheduler crashes under heavy eviction/load-back traffic:

```
AssertionError: Can not alloc mamba cache
  mamba_component.py, line 498, in _alloc_mamba_slot
  mamba_component.py, line 589, in prepare_for_caching_req
  unified_radix_cache.py, line 927, in cache_unfinished_req
  batch_result_processor.py, line 337, in process_batch_result_prefill
```

`prepare_for_caching_req` needs a mamba slot to donate the chunk's state to the radix tree. If the pool is out of free slots and `evict_for_alloc(mamba_num=1)` cannot free one, because every cached mamba state is currently locked by a running request or is in the middle of a write-through backup or load-back, the assert takes down the scheduler. The pool looks half empty at that point (usage around 0.5 in our logs), it is just that nothing in it is evictable. On one GPU this killed the scheduler 16 times in a day.

The original report of this workload was #34975; the other crash from that thread (the load-back pin assert) was fixed by #36317.

## Modifications

- `mamba_component.py`: `_alloc_mamba_slot` becomes `_try_alloc_mamba_slot` and returns `None` when nothing can be evicted. The three callers in `prepare_for_caching_req` (unfinished-request path) return 0 in that case, which goes through the existing `effective_cache_len <= 0` skip in `unified_radix_cache.py`: the chunk is not cached, the request keeps its own state and prefix, and the next chunk or the finish path (which does not allocate) tries again. This is the same treatment `prepare_prefetch` already gets with `PreparePrefetchResult(alloc_failed=True)`.
- When it happens, bump a new counter `sglang:radix_cache_aux_alloc_failed_total` on `RadixCacheMetricsCollector` and log a WARNING with a census of the mamba device nodes by pin class (`lock_ref>0`, `host_lock_ref>0`, `write_through_pending`, `load_back_pending`, evictable/protected sizes), throttled to once a minute. That is enough to tell a transient DMA window from a real pin leak.
- Not changed: the allocation in the match/load-back path (around line 200 of `mamba_component.py`) is for a request's live slot, not a cache entry, so it stays fatal. Happy to discuss that separately.

## Tests

Added to `test/registered/unit/mem_cache/test_unified_radix_cache_unittest.py`:

- `test_cache_unfinished_req_degrades_when_mamba_pool_exhausted`: pool `alloc` returns `None` and `evict_for_alloc` is mocked to free nothing. Checks that nothing is inserted, the request keeps its slot and full prefix, the pool free count is unchanged, the counter and the WARNING fire once, and `sanity_check` passes. Fails on main with the assert above in all six mamba configs, passes with this change.
- `test_hicache_concurrent_full_and_mamba_load_back_on_shared_node`: end-to-end version of the #36317 scenario on a real tree (write-back, backup, evict, load-back at the leaf with the ack held, second load-back at the pinned ancestor for its mamba state). Second commit, can be dropped if you would rather keep it separate.

The rest of the file has the same pass/fail set before and after on a 1-GPU run.

## Serving check

RTX 5090 (32GB), `nvidia/Qwen3.6-35B-A3B-NVFP4`, main @20a491d plus only this change, `--attention-backend flashinfer --kv-cache-dtype fp8_e4m3 --enable-hierarchical-cache --hicache-ratio 12 --hicache-write-policy write_through --speculative-algorithm EAGLE --mamba-radix-cache-strategy extra_buffer_lazy --max-mamba-cache-size 24` (small pool on purpose), replaying a recorded production trace (long prompts, roughly 85% prefix hit) at 4x speed.

| | main | this PR |
|---|---|---|
| 400 requests | scheduler died at request 204 with the assert, pool usage 0.50 | 400/400 served, one WARNING |
| 2 x 1618 requests, 81 min | | no assert, 4 exhaustion events all skipped cleanly, counter = 4, mamba usage back to 0 between passes, 84.8% / 84.9% hit, 373 then 397 output tok/s |

Census at one of the events: `device_nodes=14 lock_ref>0=14 host_lock_ref>0=0 write_through_pending=10 load_back_pending=0 evictable_size=0 protected_size=14`

## Checklist

- [x] Format your code according to the Code Formatting with Pre-Commit.
- [x] Add unit tests as outlined in the Running Unit Tests.
- [x] Update documentation / docstrings as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33136829333](https://github.com/sgl-project/sglang/actions/runs/33136829333)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33136829166](https://github.com/sgl-project/sglang/actions/runs/33136829166)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33136829274](https://github.com/sgl-project/sglang/actions/runs/33136829274)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->