### PR TITLE
Avoid committing temporary Docker build artifacts

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -436,12 +436,13 @@ WORKDIR /sgl-workspace
 # Copy artifacts from parallel builders
 # =============================================================================
 
-# Copy HPC-Ops wheel and install (empty on non-x86_64; kernels are sm90a-only)
-COPY --from=hpc_ops_builder /wheels /tmp/wheels/hpc-ops
+# Install the HPC-Ops wheel without committing it to the final image
+# (empty on non-x86_64; kernels are sm90a-only).
 RUN --mount=type=cache,target=/root/.cache/pip \
+    --mount=type=bind,from=hpc_ops_builder,source=/wheels,target=/tmp/wheels/hpc-ops \
     if ls /tmp/wheels/hpc-ops/*.whl >/dev/null 2>&1; then \
         pip install --no-deps /tmp/wheels/hpc-ops/*.whl; \
-    fi && rm -rf /tmp/wheels/hpc-ops
+    fi
 
 # Copy flashinfer cubin (always) and jit-cache (if installed) packages
 COPY --from=flashinfer_cache /flashinfer_jit_output/ /opt/sglang/lib/python3.12/site-packages/
@@ -618,8 +619,8 @@ ARG USE_LATEST_SGLANG
 
 WORKDIR /sgl-workspace
 
-COPY --from=local_src /src /tmp/local_src
-RUN if [ "$BRANCH_TYPE" = "local" ]; then \
+RUN --mount=type=bind,from=local_src,source=/src,target=/tmp/local_src \
+    if [ "$BRANCH_TYPE" = "local" ]; then \
         cp -r /tmp/local_src /sgl-workspace/sglang; \
     elif [ "$USE_LATEST_SGLANG" = "1" ]; then \
         git clone --depth=1 https://github.com/sgl-project/sglang.git /sgl-workspace/sglang; \
@@ -627,8 +628,7 @@ RUN if [ "$BRANCH_TYPE" = "local" ]; then \
         echo "ERROR: SGL_VERSION must be set when USE_LATEST_SGLANG=0 and BRANCH_TYPE!=local" && exit 1; \
     else \
         git clone --depth=1 --branch v${SGL_VERSION} https://github.com/sgl-project/sglang.git /sgl-workspace/sglang; \
-    fi \
-    && rm -rf /tmp/local_src
+    fi
 
 # Editable install (fast - dependencies already installed via constraints)
 # Clean up __pycache__/tests/pyc in same RUN to avoid writing ~28k files to layer
@@ -670,10 +670,9 @@ RUN --mount=type=cache,target=/root/.cache/pip \
 
 # Install pre-built gateway artifacts from parallel builder
 COPY --from=gateway_builder /build/sgl-model-gateway-bin /opt/sglang/bin/sgl-model-gateway
-COPY --from=gateway_builder /build/gateway_wheels /tmp/gateway_wheels
 RUN --mount=type=cache,target=/root/.cache/pip \
-    python3 -m pip install --force-reinstall /tmp/gateway_wheels/*.whl \
-    && rm -rf /tmp/gateway_wheels
+    --mount=type=bind,from=gateway_builder,source=/build/gateway_wheels,target=/tmp/gateway_wheels \
+    python3 -m pip install --force-reinstall /tmp/gateway_wheels/*.whl
 
 # Set workspace directory
 WORKDIR /sgl-workspace/sglang


### PR DESCRIPTION
## Motivation

Fixes #36764.

The final framework image currently commits three temporary builder artifacts in COPY layers, then deletes them in later RUN layers. The whiteouts hide the files but do not remove their bytes from the image. The issue measured those layers at 374,205,598 compressed bytes.

## Modifications

- Bind-mount the HPC-Ops wheel directory into its install step.
- Bind-mount the local source stage into the conditional source-copy step.
- Bind-mount the gateway wheel directory into its install step.
- Remove the corresponding cleanup commands because bind mounts are discarded after each RUN.

The installed wheel contents, copied local source, and gateway binary remain unchanged. The CUDA 13.4, ROCm, and gateway-only Dockerfiles are intentionally outside this focused patch because their layer sizes were not measured in the linked report.

## Accuracy Tests

N/A. This changes image construction only and does not affect model output.

## Speed Tests and Profiling

N/A for runtime inference. The linked issue measured the three eliminated staging layers at 374,205,598 compressed bytes in the published image.

## Validation

- npx --yes dockerfilelint docker/Dockerfile parsed the file successfully; it reported the same ten unrelated pre-existing style findings and no findings on the changed instructions.
- Static assertions confirmed each builder artifact is bind-mounted exactly once, the former staging COPY is absent, and every mounted source path is created by its builder stage.
- git diff --check passed.
- Commit includes a Signed-off-by trailer.

## Known limitations

A complete framework image was not built locally because Docker Desktop is not running and the published image is approximately 14 GB, beyond the available local disk budget. CI or a maintainer build should confirm the image-layer delta.

## Checklist

- [x] Format the changed Dockerfile consistently with nearby BuildKit mount instructions.
- [x] Add focused validation for the concrete layer-staging invariant.
- [x] Documentation changes are not required for this packaging-only fix.
- [x] Accuracy and inference-speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

AI assistance: this patch was prepared and validated with an AI coding agent and has not yet received human review.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33136981635](https://github.com/sgl-project/sglang/actions/runs/33136981635)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33136981505](https://github.com/sgl-project/sglang/actions/runs/33136981505)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->