### PR TITLE
CI: split JIT kernel unit tests into two partitions

### DIFF
--- a/.github/workflows/pr-test-jit-kernel.yml
+++ b/.github/workflows/pr-test-jit-kernel.yml
@@ -47,6 +47,10 @@ jobs:
     # Runs whenever call-jit-kernel-tests dispatches this workflow. That caller is the
     # single gate (PR jit_kernel changes, or scheduled/parallel-dispatch full runs), so
     # the sub-jobs no longer re-exclude schedule/parallel-dispatch here.
+    strategy:
+      fail-fast: false
+      matrix:
+        partition: [0, 1]
     runs-on: 1-gpu-h100
     timeout-minutes: 240
     steps:
@@ -85,7 +89,10 @@ jobs:
         timeout-minutes: 30
         run: |
           cd test/
-          python3 run_suite.py --hw cuda --suite base-b-kernel-unit-test-1-gpu-large
+          python3 run_suite.py --hw cuda \
+            --suite base-b-kernel-unit-test-1-gpu-large \
+            --auto-partition-id ${{ matrix.partition }} \
+            --auto-partition-size 2
 
   jit-kernel-multigpu-unit-test:
     # Runs whenever call-jit-kernel-tests dispatches this workflow. That caller is the


### PR DESCRIPTION
[by Codex]

## Summary

- split `jit-kernel-unit-test` into two independently scheduled H100 matrix jobs
- use the existing `run_suite.py` LPT auto-partitioner to balance tests by registered estimated runtime
- keep the existing 30-minute timeout for each partition and disable matrix fail-fast so both partitions report results

## Motivation

The unsplit suite is intermittently reaching the 30-minute step timeout on different runners:

- https://github.com/sgl-project/sglang/actions/runs/33076953593/job/98568117228
- https://github.com/sgl-project/sglang/actions/runs/33130734311/job/98719508356

A nearby successful run took 27m59s for the test step, leaving only about two minutes of margin:

- https://github.com/sgl-project/sglang/actions/runs/33132683057/job/98725789751

The failures occurred on different hosts and showed active JIT compilation at timeout. Splitting the suite makes the stage robust to cold-JIT variance while reducing its wall-clock latency.

## Validation

- YAML parse check
- `git diff --check`
- `BLACK_NUM_WORKERS=1 SKIP=no-commit-to-branch pre-commit run --all-files --show-diff-on-failure`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33139682722](https://github.com/sgl-project/sglang/actions/runs/33139682722)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33139682671](https://github.com/sgl-project/sglang/actions/runs/33139682671)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->