### PR TITLE
[SM100] Add optimized Q8KV8 sparse prefill for DeepSeek-V4-Flash

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
-ignore-words-list = ans, als, hel, boostrap, childs, te, vas, hsa, ment, cann, thi, makro, wil, rouge, PRIS, ather, MIS, medias, allready, inout, nd, fo, visibles, nothink, renderD, ond, tbe, CopyIn, notin, subtile, subtiles, dout, IST, kInf, datas
+ignore-words-list = ans, als, hel, boostrap, childs, te, vas, hsa, ment, cann, thi, makro, wil, rouge, PRIS, ather, MIS, medias, allready, inout, nd, fo, visibles, nothink, renderD, ond, tbe, CopyIn, notin, subtile, subtiles, dout, IST, kInf, datas, ThrID
 skip = *.json, *.jsonl, *.patch, *.txt, *.lock

--- a/benchmark/kernels/deepseek/benchmark_dsv4_prefill_paths.py
+++ b/benchmark/kernels/deepseek/benchmark_dsv4_prefill_paths.py
@@ -1,0 +1,869 @@
+#!/usr/bin/env python3
+"""Microbenchmark the two DeepSeek-V4-Flash prefill attention paths.
+
+This benchmark intentionally excludes model, CP/NCCL, PD transfer and scheduler
+time. It models one rank of a CP-v2 interleave prefill, then compares the
+production-shaped calls of:
+
+* ``DeepseekV4AttnBackend._forward_prefill_sparse`` (including FP8-cache
+  dequantization, BF16 workspace construction and sparse attention), and
+* ``flash_mla_with_kvcache`` over the same packed FP8 KV cache.
+
+The default workload matches the serving benchmark: a 61,440-token cached
+prefix plus a 4,096-token extend, CP2, and batch sizes 8/16/24/32. C0/C4/C128
+are reported separately and, when all three are requested, combined using the
+DeepSeek-V4-Flash 3/20/20-layer weights.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import math
+import os
+import statistics
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Callable
+
+# Prefer the checkout containing this script; the standalone copy under
+# /upfs/abing/sglang/deepseek-v4 falls back to the explicitly configured repo.
+_SCRIPT_REPO = Path(__file__).resolve().parents[3]
+_REPO_ROOT = Path(os.environ.get("SGLANG_REPO_ROOT", _SCRIPT_REPO))
+if not (_REPO_ROOT / "python" / "sglang").is_dir():
+    _REPO_ROOT = Path("/upfs/abing/sglang/sglang")
+sys.path.insert(0, str(_REPO_ROOT / "python"))
+
+import torch  # noqa: E402
+
+from sglang.kernels.ops.attention.dsv4.index_buf_accessor import SetKAndS  # noqa: E402
+from sglang.kernels.ops.attention.dsv4.quant_k_cache import (  # noqa: E402
+    quant_to_nope_fp8_rope_bf16_pack_triton,
+)
+from sglang.srt.environ import envs  # noqa: E402
+from sglang.srt.layers.attention.deepseek_v4_backend import (  # noqa: E402
+    DeepseekV4AttnBackend,
+)
+from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (  # noqa: E402
+    SparsePrefillWorkspace,
+)
+from sglang.srt.layers.cp.base import init_cp_strategy  # noqa: E402
+from sglang.srt.layers.cp.interleave import InterleaveCPStrategy  # noqa: E402
+from sglang.srt.model_executor.forward_batch_info import (  # noqa: E402
+    ForwardBatch,
+    ForwardMode,
+)
+from sglang.srt.runtime_context import get_parallel  # noqa: E402
+
+DSV4_HEAD_DIM = 512
+DSV4_HEAD_DIM_V = 512
+DSV4_SWA_WINDOW = 128
+DSV4_PAGE_SIZE = 256
+DSV4_C4_TOPK = 512
+PACKED_BYTES_PER_TOKEN = 448 + 64 * 2 + 8
+FLASHMLA_TMA_K_STRIDE = 576
+DEFAULT_LAYER_WEIGHTS = {0: 3, 4: 20, 128: 20}
+
+
+class _PoolLayout:
+    def __init__(self, page_size: int):
+        self.page_size = page_size
+
+
+class _TokenToKVPool:
+    """Minimum DeepSeekV4TokenToKVPool surface used by sparse prefill."""
+
+    def __init__(
+        self,
+        *,
+        swa_cache: torch.Tensor,
+        extra_cache: torch.Tensor,
+        full_to_swa: torch.Tensor,
+        swa_page_size: int,
+        extra_page_size: int,
+    ) -> None:
+        self._swa_cache = swa_cache
+        self._extra_cache = extra_cache
+        self.full_to_swa_index_mapping = full_to_swa
+        self.swa_window_size = swa_page_size
+        self._extra_page_size = extra_page_size
+
+    def get_swa_key_buffer_radix(self, layer_id: int) -> torch.Tensor:
+        del layer_id
+        return self._swa_cache
+
+    def get_extra_key_page_size(self, layer_id: int) -> int:
+        del layer_id
+        return self._extra_page_size
+
+    def get_extra_key_buffer(self, layer_id: int) -> torch.Tensor:
+        del layer_id
+        return self._extra_cache
+
+
+@dataclass
+class BenchmarkCase:
+    prefix_len: int
+    extend_len: int
+    context_len: int
+    batch_size: int
+    cp_size: int
+    cp_rank: int
+    local_q_tokens: int
+    compress_ratio: int
+    backend: DeepseekV4AttnBackend
+    forward_batch: ForwardBatch
+    token_pool: _TokenToKVPool
+    core_metadata: SimpleNamespace
+    q: torch.Tensor
+    attn_sink: torch.Tensor
+    dense_k_cache: torch.Tensor
+    dense_indices: torch.Tensor
+    dense_topk_length: torch.Tensor
+    dense_extra_k_cache: torch.Tensor | None
+    dense_extra_indices: torch.Tensor | None
+    dense_extra_topk_length: torch.Tensor | None
+
+
+@dataclass
+class Timing:
+    mean_ms: float
+    median_ms: float
+    p10_ms: float
+    p90_ms: float
+    minimum_ms: float
+    maximum_ms: float
+
+
+def _align_up(value: int, alignment: int) -> int:
+    return (value + alignment - 1) // alignment * alignment
+
+
+def _make_packed_cache(
+    *,
+    total_slots: int,
+    page_size: int,
+    device: torch.device,
+    generator: torch.Generator,
+) -> torch.Tensor:
+    total_slots = max(total_slots, 1)
+    num_pages = math.ceil(total_slots / page_size)
+    padded_slots = num_pages * page_size
+    page_bytes = page_size * PACKED_BYTES_PER_TOKEN
+    padded_page_bytes = _align_up(page_bytes, FLASHMLA_TMA_K_STRIDE)
+    raw_cache = torch.zeros(
+        num_pages,
+        padded_page_bytes,
+        dtype=torch.uint8,
+        device=device,
+    )
+    k_bf16 = (
+        torch.randn(
+            padded_slots,
+            DSV4_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        * 0.05
+    )
+    packed = quant_to_nope_fp8_rope_bf16_pack_triton(k_bf16)
+    locations = torch.arange(padded_slots, dtype=torch.int32, device=device)
+    SetKAndS.torch(_PoolLayout(page_size), raw_cache, locations, packed)
+    return raw_cache
+
+
+def _make_local_query_layout(
+    *,
+    prefix_len: int,
+    extend_len: int,
+    batch_size: int,
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return global causal positions and request ids owned by one CP rank."""
+    global_q = extend_len * batch_size
+    flat_query = torch.arange(global_q, dtype=torch.int64, device=device)
+    owned = flat_query.remainder(cp_size) == cp_rank
+    owned_query = flat_query[owned]
+    request_ids = torch.div(owned_query, extend_len, rounding_mode="floor")
+    query_positions = prefix_len + owned_query.remainder(extend_len)
+    return query_positions.to(torch.int32), request_ids.to(torch.int32)
+
+
+def _make_forward_batch(
+    *,
+    prefix_len: int,
+    extend_len: int,
+    batch_size: int,
+    cp_size: int,
+    cp_rank: int,
+    device: torch.device,
+) -> tuple[ForwardBatch, torch.Tensor, torch.Tensor, torch.Tensor]:
+    context_len = prefix_len + extend_len
+    global_q = extend_len * batch_size
+    seq_lens = torch.full((batch_size,), context_len, dtype=torch.int32, device=device)
+    extend_seq_lens = torch.full(
+        (batch_size,), extend_len, dtype=torch.int32, device=device
+    )
+    req_pool_indices = torch.arange(batch_size, dtype=torch.int32, device=device)
+    req_to_token = torch.arange(
+        batch_size * context_len, dtype=torch.int32, device=device
+    ).view(batch_size, context_len)
+    global_positions = torch.arange(
+        prefix_len, context_len, dtype=torch.int32, device=device
+    ).repeat(batch_size)
+    local_positions, local_request_ids = _make_local_query_layout(
+        prefix_len=prefix_len,
+        extend_len=extend_len,
+        batch_size=batch_size,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        device=device,
+    )
+    extend_start_loc = (
+        torch.arange(batch_size, dtype=torch.int32, device=device) * extend_len
+    )
+    request_base = (
+        torch.arange(batch_size, dtype=torch.int64, device=device).repeat_interleave(
+            extend_len
+        )
+        * context_len
+    )
+    extend_offset = torch.arange(
+        prefix_len, context_len, dtype=torch.int64, device=device
+    ).repeat(batch_size)
+    batch = ForwardBatch(
+        forward_mode=ForwardMode.EXTEND,
+        batch_size=batch_size,
+        input_ids=torch.zeros(global_q, dtype=torch.int64, device=device),
+        req_pool_indices=req_pool_indices,
+        seq_lens=seq_lens,
+        seq_lens_cpu=seq_lens.cpu(),
+        out_cache_loc=request_base + extend_offset,
+        seq_lens_sum=batch_size * context_len,
+        positions=global_positions.to(torch.int64),
+        extend_num_tokens=global_q,
+        extend_seq_lens=extend_seq_lens,
+        extend_seq_lens_cpu=[extend_len] * batch_size,
+        extend_start_loc=extend_start_loc,
+        extend_prefix_lens=torch.zeros(
+            batch_size, dtype=torch.int32, device=device
+        ).fill_(prefix_len),
+        extend_prefix_lens_cpu=[prefix_len] * batch_size,
+    )
+    strategy = InterleaveCPStrategy(cp_size=cp_size)
+    batch.attn_cp_metadata = strategy.build_metadata(
+        num_tokens=global_q,
+        seqs_len=[context_len] * batch_size,
+        extend_seqs_len=[extend_len] * batch_size,
+    )
+    return batch, req_to_token, local_positions, local_request_ids
+
+
+def _make_swa_indices(
+    *,
+    query_positions: torch.Tensor,
+    request_ids: torch.Tensor,
+    context_len: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    request_base = request_ids * context_len
+    offsets = (
+        query_positions[:, None]
+        - torch.arange(DSV4_SWA_WINDOW, dtype=torch.int32, device=device)[None, :]
+    )
+    valid = offsets >= 0
+    physical = request_base[:, None] + offsets.clamp_min(0)
+    indices = torch.where(valid, physical, torch.full_like(physical, -1))
+    topk_length = (query_positions + 1).clamp(max=DSV4_SWA_WINDOW)
+    return indices.unsqueeze(1).contiguous(), topk_length.contiguous()
+
+
+def _make_c4_metadata(
+    *,
+    context_len: int,
+    batch_size: int,
+    query_positions: torch.Tensor,
+    request_ids: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, int]:
+    c4_per_request = max(context_len // 4, 1)
+    page_size = DSV4_PAGE_SIZE // 4
+    pages_per_request = math.ceil(c4_per_request / page_size)
+
+    page_ids = (
+        torch.arange(pages_per_request, dtype=torch.int32, device=device)[None, :]
+        + torch.arange(batch_size, dtype=torch.int32, device=device)[:, None]
+        * pages_per_request
+    )
+    page_table = page_ids.index_select(0, request_ids.long()).contiguous()
+
+    raw = torch.arange(DSV4_C4_TOPK, dtype=torch.int32, device=device)[None, :]
+    raw = raw.expand(query_positions.shape[0], -1).clone()
+    available = ((query_positions + 1) // 4).clamp(max=DSV4_C4_TOPK)
+    valid = raw < available[:, None]
+    raw.masked_fill_(~valid, -1)
+
+    physical_base = request_ids[:, None] * pages_per_request * page_size
+    physical = torch.where(valid, physical_base + raw.clamp_min(0), -1)
+    topk_length = available.clamp(min=1)
+    total_slots = batch_size * pages_per_request * page_size
+    return (
+        page_table,
+        raw.contiguous(),
+        physical.unsqueeze(1).contiguous(),
+        topk_length.contiguous(),
+        total_slots,
+    )
+
+
+def _make_c128_metadata(
+    *,
+    context_len: int,
+    batch_size: int,
+    query_positions: torch.Tensor,
+    request_ids: torch.Tensor,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor, int]:
+    c128_per_request = max(context_len // 128, 1)
+    width = _align_up(c128_per_request, 64)
+    local = torch.arange(width, dtype=torch.int32, device=device)[None, :].expand(
+        query_positions.shape[0], -1
+    )
+    available = ((query_positions + 1) // 128).clamp(min=1, max=c128_per_request)
+    valid = local < available[:, None]
+    physical = request_ids[:, None] * c128_per_request + local
+    physical = torch.where(valid, physical, torch.full_like(physical, -1))
+    total_slots = batch_size * c128_per_request
+    return (
+        physical.contiguous(),
+        available.contiguous(),
+        total_slots,
+    )
+
+
+def build_case(
+    *,
+    prefix_len: int,
+    extend_len: int,
+    batch_size: int,
+    cp_size: int,
+    cp_rank: int,
+    compress_ratio: int,
+    num_heads: int,
+    device: torch.device,
+    seed: int,
+) -> BenchmarkCase:
+    if compress_ratio not in (0, 4, 128):
+        raise ValueError(f"Unsupported compress ratio: {compress_ratio}")
+    context_len = prefix_len + extend_len
+    generator = torch.Generator(device=device)
+    generator.manual_seed(seed + context_len * 17 + batch_size * 31 + compress_ratio)
+
+    forward_batch, req_to_token, query_positions, request_ids = _make_forward_batch(
+        prefix_len=prefix_len,
+        extend_len=extend_len,
+        batch_size=batch_size,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        device=device,
+    )
+    total_q = query_positions.shape[0]
+    total_context_slots = context_len * batch_size
+    swa_cache_raw = _make_packed_cache(
+        total_slots=total_context_slots,
+        page_size=DSV4_PAGE_SIZE,
+        device=device,
+        generator=generator,
+    )
+    dense_k_cache = swa_cache_raw[:, : DSV4_PAGE_SIZE * PACKED_BYTES_PER_TOKEN].view(
+        swa_cache_raw.shape[0],
+        DSV4_PAGE_SIZE,
+        1,
+        PACKED_BYTES_PER_TOKEN,
+    )
+    full_to_swa = torch.arange(total_context_slots, dtype=torch.int64, device=device)
+    dense_indices, dense_topk_length = _make_swa_indices(
+        query_positions=query_positions,
+        request_ids=request_ids,
+        context_len=context_len,
+        device=device,
+    )
+
+    page_table = None
+    c4_raw_indices = None
+    c128_page_indices = None
+    dense_extra_indices = None
+    dense_extra_topk_length = None
+    dense_extra_k_cache = None
+    extra_page_size = DSV4_PAGE_SIZE
+    extra_cache_raw = swa_cache_raw
+
+    if compress_ratio == 4:
+        (
+            page_table,
+            c4_raw_indices,
+            dense_extra_indices,
+            dense_extra_topk_length,
+            extra_slots,
+        ) = _make_c4_metadata(
+            context_len=context_len,
+            batch_size=batch_size,
+            query_positions=query_positions,
+            request_ids=request_ids,
+            device=device,
+        )
+        extra_page_size = DSV4_PAGE_SIZE // 4
+        extra_cache_raw = _make_packed_cache(
+            total_slots=extra_slots,
+            page_size=extra_page_size,
+            device=device,
+            generator=generator,
+        )
+    elif compress_ratio == 128:
+        (
+            c128_page_indices,
+            dense_extra_topk_length,
+            extra_slots,
+        ) = _make_c128_metadata(
+            context_len=context_len,
+            batch_size=batch_size,
+            query_positions=query_positions,
+            request_ids=request_ids,
+            device=device,
+        )
+        dense_extra_indices = c128_page_indices.unsqueeze(1)
+        extra_page_size = DSV4_PAGE_SIZE // 128
+        extra_cache_raw = _make_packed_cache(
+            total_slots=extra_slots,
+            page_size=extra_page_size,
+            device=device,
+            generator=generator,
+        )
+
+    if compress_ratio != 0:
+        dense_extra_k_cache = extra_cache_raw[
+            :, : extra_page_size * PACKED_BYTES_PER_TOKEN
+        ].view(
+            extra_cache_raw.shape[0],
+            extra_page_size,
+            1,
+            PACKED_BYTES_PER_TOKEN,
+        )
+
+    token_pool = _TokenToKVPool(
+        swa_cache=swa_cache_raw,
+        extra_cache=extra_cache_raw,
+        full_to_swa=full_to_swa,
+        swa_page_size=DSV4_PAGE_SIZE,
+        extra_page_size=extra_page_size,
+    )
+    backend = DeepseekV4AttnBackend.__new__(DeepseekV4AttnBackend)
+    backend.forward_metadata = SimpleNamespace(sparse_prefill_cache=None)
+    backend.req_to_token = req_to_token
+    backend.sparse_prefill_workspace = SparsePrefillWorkspace(device)
+    backend.softmax_scale = DSV4_HEAD_DIM**-0.5
+    backend.head_dim_v = DSV4_HEAD_DIM_V
+    backend.dsv4_prefill_backend = "flashmla_sparse"
+
+    q = (
+        torch.randn(
+            total_q,
+            1,
+            num_heads,
+            DSV4_HEAD_DIM,
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        * 0.05
+    ).contiguous()
+    attn_sink = torch.zeros(num_heads, dtype=torch.float32, device=device)
+    core_metadata = SimpleNamespace(
+        positions_casual=query_positions,
+        page_table=page_table,
+        c4_sparse_raw_indices=c4_raw_indices,
+        c128_page_indices=c128_page_indices,
+    )
+    return BenchmarkCase(
+        prefix_len=prefix_len,
+        extend_len=extend_len,
+        context_len=context_len,
+        batch_size=batch_size,
+        cp_size=cp_size,
+        cp_rank=cp_rank,
+        local_q_tokens=total_q,
+        compress_ratio=compress_ratio,
+        backend=backend,
+        forward_batch=forward_batch,
+        token_pool=token_pool,
+        core_metadata=core_metadata,
+        q=q,
+        attn_sink=attn_sink,
+        dense_k_cache=dense_k_cache,
+        dense_indices=dense_indices,
+        dense_topk_length=dense_topk_length,
+        dense_extra_k_cache=dense_extra_k_cache,
+        dense_extra_indices=dense_extra_indices,
+        dense_extra_topk_length=dense_extra_topk_length,
+    )
+
+
+def _make_sparse_call(case: BenchmarkCase) -> Callable[[], torch.Tensor]:
+    def call() -> torch.Tensor:
+        return case.backend._forward_prefill_sparse(
+            q=case.q,
+            layer_id=0,
+            compress_ratio=case.compress_ratio,
+            forward_batch=case.forward_batch,
+            token_to_kv_pool=case.token_pool,
+            core_attn_metadata=case.core_metadata,
+            attn_sink=case.attn_sink,
+        )
+
+    return call
+
+
+def _make_dense_call(case: BenchmarkCase) -> Callable[[], torch.Tensor]:
+    from sgl_kernel.flash_mla import flash_mla_with_kvcache, get_mla_metadata
+
+    scheduler_metadata = get_mla_metadata()[0]
+
+    def call() -> torch.Tensor:
+        return flash_mla_with_kvcache(
+            q=case.q,
+            k_cache=case.dense_k_cache,
+            block_table=None,
+            cache_seqlens=None,
+            head_dim_v=DSV4_HEAD_DIM_V,
+            tile_scheduler_metadata=scheduler_metadata,
+            softmax_scale=DSV4_HEAD_DIM**-0.5,
+            is_fp8_kvcache=True,
+            indices=case.dense_indices,
+            topk_length=case.dense_topk_length,
+            attn_sink=case.attn_sink,
+            extra_k_cache=case.dense_extra_k_cache,
+            extra_indices_in_kvcache=case.dense_extra_indices,
+            extra_topk_length=case.dense_extra_topk_length,
+        )[0]
+
+    return call
+
+
+def _percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    index = round((len(ordered) - 1) * fraction)
+    return ordered[index]
+
+
+@torch.inference_mode()
+def benchmark_cuda(
+    fn: Callable[[], torch.Tensor], *, warmup: int, repeats: int
+) -> tuple[Timing, torch.Tensor]:
+    output = None
+    for _ in range(warmup):
+        output = fn()
+    torch.cuda.synchronize()
+
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(repeats)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(repeats)]
+    for start, end in zip(starts, ends, strict=True):
+        start.record()
+        output = fn()
+        end.record()
+    torch.cuda.synchronize()
+    elapsed = [start.elapsed_time(end) for start, end in zip(starts, ends, strict=True)]
+    assert output is not None
+    return (
+        Timing(
+            mean_ms=statistics.mean(elapsed),
+            median_ms=statistics.median(elapsed),
+            p10_ms=_percentile(elapsed, 0.10),
+            p90_ms=_percentile(elapsed, 0.90),
+            minimum_ms=min(elapsed),
+            maximum_ms=max(elapsed),
+        ),
+        output,
+    )
+
+
+def _format_row(row: dict[str, object]) -> str:
+    return (
+        f"prefix={row['prefix_len']:>6} extend={row['extend_len']:>5} "
+        f"batch={row['batch_size']:>2} local_q={row['local_q_tokens']:>7} "
+        f"C{row['compress_ratio']:<3}  "
+        f"sparse={row['sparse_median_ms']:>8.3f} ms  "
+        f"dense={row['dense_median_ms']:>8.3f} ms  "
+        f"dense/sparse={row['dense_over_sparse']:>6.3f}x  "
+        f"winner={row['winner']}"
+    )
+
+
+def _weighted_rows(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    by_shape: dict[tuple[int, int, int, int, int], dict[int, dict[str, object]]] = {}
+    for row in rows:
+        key = (
+            int(row["prefix_len"]),
+            int(row["extend_len"]),
+            int(row["batch_size"]),
+            int(row["cp_size"]),
+            int(row["cp_rank"]),
+        )
+        by_shape.setdefault(key, {})[int(row["compress_ratio"])] = row
+
+    weighted = []
+    for shape, ratio_rows in sorted(by_shape.items()):
+        if not all(ratio in ratio_rows for ratio in DEFAULT_LAYER_WEIGHTS):
+            continue
+        prefix_len, extend_len, batch_size, cp_size, cp_rank = shape
+        sparse_ms = sum(
+            float(ratio_rows[ratio]["sparse_median_ms"]) * weight
+            for ratio, weight in DEFAULT_LAYER_WEIGHTS.items()
+        )
+        dense_ms = sum(
+            float(ratio_rows[ratio]["dense_median_ms"]) * weight
+            for ratio, weight in DEFAULT_LAYER_WEIGHTS.items()
+        )
+        weighted.append(
+            {
+                "prefix_len": prefix_len,
+                "extend_len": extend_len,
+                "batch_size": batch_size,
+                "cp_size": cp_size,
+                "cp_rank": cp_rank,
+                "sparse_ms": sparse_ms,
+                "dense_ms": dense_ms,
+                "dense_over_sparse": dense_ms / sparse_ms,
+                "winner": "sparse" if sparse_ms < dense_ms else "dense",
+            }
+        )
+    return weighted
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--prefix-len", type=int, default=61440)
+    parser.add_argument("--extend-len", type=int, default=4096)
+    parser.add_argument("--cp-size", type=int, default=2)
+    parser.add_argument("--cp-rank", type=int, default=0)
+    parser.add_argument("--batch-sizes", type=int, nargs="+", default=[8, 16, 24, 32])
+    parser.add_argument("--compress-ratios", type=int, nargs="+", default=[0, 4, 128])
+    parser.add_argument("--num-heads", type=int, default=64)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--device", default="cuda:0")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Compare a small output sample after timing (not included in timing).",
+    )
+    parser.add_argument(
+        "--csv",
+        type=Path,
+        default=None,
+        help="Output CSV path. Defaults to a timestamped file in the current directory.",
+    )
+    return parser.parse_args()
+
+
+def _main(args: argparse.Namespace) -> None:
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required")
+    if args.prefix_len < 0 or args.extend_len <= 0:
+        raise SystemExit("--prefix-len must be non-negative and --extend-len positive")
+    if args.cp_size <= 1 or not 0 <= args.cp_rank < args.cp_size:
+        raise SystemExit("--cp-size must be >1 and --cp-rank must be in range")
+    if args.num_heads <= 0 or any(batch <= 0 for batch in args.batch_sizes):
+        raise SystemExit("--batch-sizes and --num-heads must be positive")
+    if any(
+        batch_size * args.extend_len % args.cp_size for batch_size in args.batch_sizes
+    ):
+        raise SystemExit(
+            "Every batch_size * extend_len must be divisible by cp_size so the "
+            "single-rank benchmark has production-shaped equal CP padding"
+        )
+    if args.warmup < 1 or args.repeats < 1:
+        raise SystemExit("--warmup and --repeats must be positive")
+    invalid_ratios = set(args.compress_ratios) - {0, 4, 128}
+    if invalid_ratios:
+        raise SystemExit(f"Unsupported compress ratios: {sorted(invalid_ratios)}")
+
+    device = torch.device(args.device)
+    torch.cuda.set_device(device)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+    csv_path = args.csv or Path(
+        f"dsv4-prefill-cpv2-functions-{time.strftime('%Y%m%d-%H%M%S')}.csv"
+    )
+
+    print("DeepSeek-V4-Flash prefill function benchmark")
+    print(f"device={torch.cuda.get_device_name(device)}")
+    print(
+        f"prefix={args.prefix_len}, extend={args.extend_len}, "
+        f"context={args.prefix_len + args.extend_len}, "
+        f"cp={args.cp_size}, rank={args.cp_rank}"
+    )
+    print(
+        f"batches={sorted(set(args.batch_sizes))}, heads={args.num_heads}, "
+        f"warmup={args.warmup}, repeats={args.repeats}"
+    )
+    print("Q/indices are CP-v2 interleave rank-local; KV capacity is global-context.")
+    print("sparse timing includes dequant/workspace/index-combine; CP/NCCL is excluded")
+
+    rows: list[dict[str, object]] = []
+    for batch_index, batch_size in enumerate(sorted(set(args.batch_sizes))):
+        for ratio_index, compress_ratio in enumerate(args.compress_ratios):
+            try:
+                case = build_case(
+                    prefix_len=args.prefix_len,
+                    extend_len=args.extend_len,
+                    batch_size=batch_size,
+                    cp_size=args.cp_size,
+                    cp_rank=args.cp_rank,
+                    compress_ratio=compress_ratio,
+                    num_heads=args.num_heads,
+                    device=device,
+                    seed=args.seed,
+                )
+                sparse_call = _make_sparse_call(case)
+                dense_call = _make_dense_call(case)
+
+                # Alternate the first measured path by batch size to reduce
+                # persistent clock/thermal ordering bias.
+                if (batch_index + ratio_index) % 2 == 0:
+                    sparse_timing, sparse_out = benchmark_cuda(
+                        sparse_call, warmup=args.warmup, repeats=args.repeats
+                    )
+                    dense_timing, dense_out = benchmark_cuda(
+                        dense_call, warmup=args.warmup, repeats=args.repeats
+                    )
+                else:
+                    dense_timing, dense_out = benchmark_cuda(
+                        dense_call, warmup=args.warmup, repeats=args.repeats
+                    )
+                    sparse_timing, sparse_out = benchmark_cuda(
+                        sparse_call, warmup=args.warmup, repeats=args.repeats
+                    )
+
+                if args.check:
+                    q_rows = torch.linspace(
+                        0,
+                        sparse_out.shape[0] - 1,
+                        steps=min(16, sparse_out.shape[0]),
+                        device=device,
+                    ).long()
+                    torch.testing.assert_close(
+                        sparse_out.index_select(0, q_rows)[:, :2, :32].float(),
+                        dense_out.squeeze(1)
+                        .index_select(0, q_rows)[:, :2, :32]
+                        .float(),
+                        atol=0.2,
+                        rtol=0.2,
+                    )
+
+                speedup = dense_timing.median_ms / sparse_timing.median_ms
+                row: dict[str, object] = {
+                    "prefix_len": args.prefix_len,
+                    "extend_len": args.extend_len,
+                    "context_len": args.prefix_len + args.extend_len,
+                    "batch_size": batch_size,
+                    "cp_size": args.cp_size,
+                    "cp_rank": args.cp_rank,
+                    "global_q_tokens": batch_size * args.extend_len,
+                    "local_q_tokens": case.local_q_tokens,
+                    "compress_ratio": compress_ratio,
+                    "sparse_mean_ms": sparse_timing.mean_ms,
+                    "sparse_median_ms": sparse_timing.median_ms,
+                    "sparse_p10_ms": sparse_timing.p10_ms,
+                    "sparse_p90_ms": sparse_timing.p90_ms,
+                    "dense_mean_ms": dense_timing.mean_ms,
+                    "dense_median_ms": dense_timing.median_ms,
+                    "dense_p10_ms": dense_timing.p10_ms,
+                    "dense_p90_ms": dense_timing.p90_ms,
+                    "dense_over_sparse": speedup,
+                    "winner": "sparse" if speedup > 1.0 else "dense",
+                }
+                rows.append(row)
+                print(_format_row(row), flush=True)
+                del case, sparse_out, dense_out, sparse_call, dense_call
+            except torch.OutOfMemoryError as exc:
+                print(
+                    f"OOM: prefix={args.prefix_len}, extend={args.extend_len}, "
+                    f"batch={batch_size}, "
+                    f"C{compress_ratio}: {exc}",
+                    flush=True,
+                )
+            finally:
+                torch.cuda.empty_cache()
+
+    if not rows:
+        raise SystemExit("No benchmark case completed")
+    csv_path.parent.mkdir(parents=True, exist_ok=True)
+    with csv_path.open("w", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+
+    print("\nWeighted 43-layer estimate (C0x3 + C4x20 + C128x20):")
+    weighted = _weighted_rows(rows)
+    for row in weighted:
+        print(
+            f"prefix={row['prefix_len']:>6} extend={row['extend_len']:>5} "
+            f"batch={row['batch_size']:>2}  "
+            f"sparse={row['sparse_ms']:>9.3f} ms  "
+            f"dense={row['dense_ms']:>9.3f} ms  "
+            f"dense/sparse={row['dense_over_sparse']:>6.3f}x  "
+            f"winner={row['winner']}"
+        )
+
+    print("\nFirst measured sparse-winning batch size:")
+    for ratio in args.compress_ratios:
+        sparse_wins = [
+            int(row["batch_size"])
+            for row in rows
+            if int(row["compress_ratio"]) == ratio and row["winner"] == "sparse"
+        ]
+        print(f"C{ratio}: {min(sparse_wins) if sparse_wins else 'not found'}")
+    weighted_wins = [row["batch_size"] for row in weighted if row["winner"] == "sparse"]
+    if weighted:
+        print(f"weighted: {min(weighted_wins) if weighted_wins else 'not found'}")
+    print(f"CSV: {csv_path.resolve()}")
+
+
+def main() -> None:
+    args = parse_args()
+    # Model CP communication is intentionally excluded, but the attention
+    # backend must see the same CP-v2/interleave topology and local coordinates
+    # as production. No process group is touched by either measured function.
+    with envs.SGLANG_ENABLE_CP_V2.override(True), get_parallel().override(
+        world_size=args.cp_size,
+        world_rank=args.cp_rank,
+        tp_size=args.cp_size,
+        tp_rank=args.cp_rank,
+        attn_tp_size=1,
+        attn_tp_rank=0,
+        attn_cp_size=args.cp_size,
+        attn_cp_rank=args.cp_rank,
+    ):
+        init_cp_strategy(
+            SimpleNamespace(
+                enable_prefill_cp=True,
+                attn_cp_size=args.cp_size,
+                cp_strategy="interleave",
+            )
+        )
+        if not hasattr(DeepseekV4AttnBackend, "_get_or_build_sparse_prefill_cache"):
+            raise SystemExit(
+                "This benchmark requires the DSV4 CP-v2 sparse-prefill patch"
+            )
+        _main(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/deepseek/sm100_q8kv8/README.md
+++ b/benchmark/kernels/deepseek/sm100_q8kv8/README.md
@@ -1,0 +1,86 @@
+# DeepSeek-V4-Flash SM100 Q8KV8 experiments
+
+This directory contains reproducible B200 experiments for comparing the full
+DeepSeek-V4-Flash sparse-prefill backend functions:
+
+- BF16 golden: `DeepseekV4AttnBackend._forward_prefill_sparse`
+- SM100 Q8KV8: `DeepseekV4AttnBackend._forward_prefill_sparse_q8kv8`
+
+The benchmark includes Q conversion, packed-KV gather/conversion, sparse index
+adaptation, attention, and output handling. It reports C0/C4/C128 separately
+and the model's 43-layer weighted estimate (`C0x3 + C4x20 + C128x20`).
+The default uses the production TP8 shape with 8 local Q heads; pass
+`--num-heads 64` to measure the TP1/full-head kernel shape separately.
+The default sequence-length matrix is 512, 1024, 2048, 4096, 8192, 16384,
+and 32768 tokens.
+
+Run the long-sequence accuracy gate on the assigned physical GPU 7 only. By
+default it compares 12 cases (4K/8K/16K/32K x C0/C4/C128) against the complete
+BF16 sparse-prefill backend and writes a timestamped JSON artifact:
+
+```bash
+CUDA_VISIBLE_DEVICES=7 python benchmark/kernels/deepseek/sm100_q8kv8/validate_dsv4_q8kv8_accuracy.py
+```
+
+The default acceptance thresholds are cosine >= 0.999, mean absolute error <=
+0.001, and maximum absolute error <= 0.02. The script exits nonzero if any
+case fails.
+
+Run the performance matrix on the same physical GPU:
+
+```bash
+CUDA_VISIBLE_DEVICES=7 python benchmark/kernels/deepseek/sm100_q8kv8/benchmark_dsv4_q8kv8.py
+```
+
+Timestamped CSV and JSON artifacts are written to `results/`. The script has a
+hard safety guard and refuses to run if any physical GPU other than 7 is made
+visible.
+
+The 12-case long-sequence accuracy gate passed on B200 GPU7 with cosine
+similarity in `[0.99992138, 0.99993408]`, mean absolute error no greater than
+`4.23e-5`, and maximum absolute error no greater than `0.00342`. The artifact is
+`results/20260827-072748-gpu7-v49-long-accuracy.json`.
+
+The repository-integrated 30-repeat performance regression is
+`results/20260827-072925-gpu7-v49-integrated-long-performance.json`. Its
+DeepSeek-V4-Flash weighted BF16/Q8 speedups are 1.395x, 1.324x, 1.318x, and
+1.321x at 4K, 8K, 16K, and 32K respectively.
+
+## Current B200 result
+
+The current best valid CUDA configuration is native E4M3 tcgen05 with an
+internal 32-head tile and a 128-key double-block tile. D512 uses three KV
+stages; D576 uses two to remain within the SM100 shared-memory limit. The KV
+producer dispatch is adaptive: 384 threads / 7 producer warps below 4096 query
+tokens and 512 threads / 11 producer warps at or above 4096. It also retains
+compact TP8 Q storage, four-warp TMEM output extraction, direct active-head
+global stores, KV `EVICT_LAST`, and the backend-only no-metadata
+specialization. The stable 30-repeat GPU7 result is
+`results/20260827-065905-gpu7-best-valid-v49-adaptive-double-block-full.json`:
+
+| Sequence | BF16/Q8 weighted speedup | Gain |
+| ---: | ---: | ---: |
+| 512 | 0.873x | -12.69% |
+| 1024 | 0.875x | -12.49% |
+| 2048 | 1.211x | +21.12% |
+| 4096 | 1.397x | +39.70% |
+| 8192 | 1.333x | +33.29% |
+| 16384 | 1.317x | +31.75% |
+| 32768 | 1.320x | +32.05% |
+
+The requested 1.5x target is not yet met. Results marked as `smoke` or from
+negative experiments must not be used as the best result. Results through v33
+are also invalid as correctness baselines: they read only warp0/warp2's TMEM
+output fragments and duplicated/permuted the remaining 256 columns. Rejected
+performance variants include two/four KV buffers, N=128 with two buffers,
+cp.async KV loading, per-K-tile barriers, 224/256-thread role layouts, explicit
+TMEM offsets, direct in-CTA BF16-Q conversion, dual-block softmax batching, and
+M=16 tcgen05 (unsupported by both SM100 WS and non-WS 1SM TMEM traits). The
+occupancy-forced two-buffer variant is also rejected:
+`launch_bounds(..., 2)` reduced the trusted kernel from 147 to 86 registers but
+introduced a 176-byte stack spill and regressed 32768/C4 from 3.626 ms to
+4.696 ms. An N=128/two-buffer bring-up was also slower because 256 tokens of
+lookahead did not hide the larger random-TMA stage; the production D512
+three-buffer version increases lookahead to 384 tokens. The next large
+opportunity is removing or fusing the Q cast and combined-index adapter work
+before the attention kernel.

--- a/benchmark/kernels/deepseek/sm100_q8kv8/benchmark_dsv4_q8kv8.py
+++ b/benchmark/kernels/deepseek/sm100_q8kv8/benchmark_dsv4_q8kv8.py
@@ -1,0 +1,343 @@
+#!/usr/bin/env python3
+"""Benchmark DeepSeek-V4-Flash BF16 sparse prefill against SM100 Q8KV8.
+
+The measurement covers the complete backend functions, including Q casting,
+KV workspace gathering/conversion, sparse-index adaptation, attention, and
+output slicing.  It intentionally excludes the rest of the model and NCCL.
+
+For safety on the shared B200 host this script refuses to run unless physical
+GPU 7 is the only CUDA-visible device.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import importlib.util
+import json
+import os
+import socket
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Callable
+
+THIS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("SGLANG_REPO_ROOT", THIS_DIR.parents[3]))
+if not (REPO_ROOT / "python/sglang").is_dir():
+    REPO_ROOT = Path("/upfs/abing/sglang/pr/cpp_radix_tree/sglang")
+os.environ.setdefault("SGLANG_REPO_ROOT", str(REPO_ROOT))
+BASE_BENCHMARK = THIS_DIR / "benchmark_dsv4_prefill_paths.py"
+if not BASE_BENCHMARK.is_file():
+    BASE_BENCHMARK = (
+        REPO_ROOT / "benchmark/kernels/deepseek/benchmark_dsv4_prefill_paths.py"
+    )
+RESULTS_DIR = THIS_DIR / "results"
+
+
+def _load_base_benchmark():
+    spec = importlib.util.spec_from_file_location("dsv4_prefill_base", BASE_BENCHMARK)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load benchmark helpers from {BASE_BENCHMARK}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+base = _load_base_benchmark()
+torch = base.torch
+
+
+def _git_output(*args: str) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", *args], cwd=REPO_ROOT, text=True, stderr=subprocess.DEVNULL
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _make_q16_call(case) -> Callable[[], torch.Tensor]:
+    def call() -> torch.Tensor:
+        return case.backend._forward_prefill_sparse(
+            q=case.q,
+            layer_id=0,
+            compress_ratio=case.compress_ratio,
+            forward_batch=case.forward_batch,
+            token_to_kv_pool=case.token_pool,
+            core_attn_metadata=case.core_metadata,
+            attn_sink=case.attn_sink,
+        )
+
+    return call
+
+
+def _make_q8_call(
+    case, q_active: torch.Tensor, sink_active: torch.Tensor
+) -> Callable[[], torch.Tensor]:
+    def call() -> torch.Tensor:
+        return case.backend._forward_prefill_sparse_q8kv8(
+            q=q_active,
+            layer_id=0,
+            compress_ratio=case.compress_ratio,
+            forward_batch=case.forward_batch,
+            token_to_kv_pool=case.token_pool,
+            core_attn_metadata=case.core_metadata,
+            attn_sink=sink_active,
+        )
+
+    return call
+
+
+def _reset_backend(case) -> None:
+    case.backend.forward_metadata.sparse_prefill_cache = None
+    case.backend._q8kv8_qpad_buf = None
+    case.backend._q8kv8_attn_sink_pad = None
+    case.backend._q8kv8_attn_sink_pad_cache = None
+    case.backend._q8kv8_identity_scale = None
+    case.backend._q8kv8_output_buffers = None
+    case.backend._q8kv8_sparse_prefill_log_emitted = True
+
+
+def _accuracy(q8: torch.Tensor, q16: torch.Tensor) -> dict[str, float]:
+    lhs = q8.float()
+    rhs = q16[:, : q8.shape[1]].float()
+    diff = (lhs - rhs).abs()
+    lhs_flat = lhs.flatten()
+    rhs_flat = rhs.flatten()
+    cosine = torch.nn.functional.cosine_similarity(lhs_flat, rhs_flat, dim=0)
+    return {
+        "mean_abs_error": diff.mean().item(),
+        "max_abs_error": diff.max().item(),
+        "cosine_similarity": cosine.item(),
+    }
+
+
+def _weighted_summary(rows: list[dict[str, object]]) -> list[dict[str, object]]:
+    grouped: dict[tuple[int, int], dict[int, dict[str, object]]] = {}
+    for row in rows:
+        key = (int(row["seq_len"]), int(row["batch_size"]))
+        grouped.setdefault(key, {})[int(row["compress_ratio"])] = row
+
+    summary: list[dict[str, object]] = []
+    for (seq_len, batch_size), ratio_rows in sorted(grouped.items()):
+        if not all(ratio in ratio_rows for ratio in base.DEFAULT_LAYER_WEIGHTS):
+            continue
+        q16_ms = sum(
+            float(ratio_rows[ratio]["q16_median_ms"]) * weight
+            for ratio, weight in base.DEFAULT_LAYER_WEIGHTS.items()
+        )
+        q8_ms = sum(
+            float(ratio_rows[ratio]["q8_median_ms"]) * weight
+            for ratio, weight in base.DEFAULT_LAYER_WEIGHTS.items()
+        )
+        summary.append(
+            {
+                "seq_len": seq_len,
+                "batch_size": batch_size,
+                "q16_weighted_43_layers_ms": q16_ms,
+                "q8_weighted_43_layers_ms": q8_ms,
+                "speedup": q16_ms / q8_ms,
+                "gain_percent": (q16_ms / q8_ms - 1.0) * 100.0,
+            }
+        )
+    return summary
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seq-lens",
+        type=int,
+        nargs="+",
+        default=[512, 1024, 2048, 4096, 8192, 16384, 32768],
+    )
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument("--compress-ratios", type=int, nargs="+", default=[0, 4, 128])
+    parser.add_argument(
+        "--num-heads",
+        type=int,
+        default=8,
+        help="TP-local Q heads; DeepSeek-V4-Flash TP8 uses 8.",
+    )
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--tag", default="baseline")
+    parser.add_argument("--results-dir", type=Path, default=RESULTS_DIR)
+    return parser.parse_args()
+
+
+def _main() -> None:
+    args = _parse_args()
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible != "7":
+        raise SystemExit(
+            "Safety check failed: run with CUDA_VISIBLE_DEVICES=7; "
+            f"current value is {visible!r}"
+        )
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required")
+    if torch.cuda.device_count() != 1:
+        raise SystemExit(
+            "Safety check failed: exactly one CUDA-visible GPU is required, got "
+            f"{torch.cuda.device_count()}"
+        )
+    capability = torch.cuda.get_device_capability(0)
+    if capability[0] != 10:
+        raise SystemExit(f"SM100 is required, got compute capability {capability}")
+
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    run_name = f"{timestamp}-{args.tag}"
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    csv_path = args.results_dir / f"{run_name}.csv"
+    json_path = args.results_dir / f"{run_name}.json"
+
+    environment = {
+        "timestamp": timestamp,
+        "hostname": socket.gethostname(),
+        "physical_gpu": 7,
+        "cuda_visible_devices": visible,
+        "gpu_name": torch.cuda.get_device_name(device),
+        "compute_capability": list(capability),
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "git_branch": _git_output("branch", "--show-current"),
+        "git_commit": _git_output("rev-parse", "HEAD"),
+        "git_diff_stat": _git_output("diff", "--stat"),
+        "sm100_q8kv8_kernel": {
+            "implementation": "cuda_tcgen05",
+            "block_h": 32,
+            "block_topk": 128,
+            "producer_dispatch": {
+                "short": {"max_s_q": 4095, "threads": 384, "warps": 7},
+                "long": {"min_s_q": 4096, "threads": 512, "warps": 11},
+            },
+            "kv_buffers_d512": 3,
+            "kv_buffers_d576": 2,
+            "double_block_tcgen05": True,
+            "d512_tma_width_bytes": 128,
+            "kv_tma_cache_hint": "evict_last",
+            "compact_q_storage": True,
+            "output_epilogue": "direct_global_active_heads",
+            "batched_output_tma": False,
+            "store_meta": False,
+        },
+        "arguments": vars(args) | {"results_dir": str(args.results_dir)},
+    }
+    print(json.dumps(environment, indent=2), flush=True)
+
+    rows: list[dict[str, object]] = []
+    for seq_index, seq_len in enumerate(sorted(set(args.seq_lens))):
+        for ratio_index, compress_ratio in enumerate(args.compress_ratios):
+            case = base.build_case(
+                prefix_len=0,
+                extend_len=seq_len,
+                batch_size=args.batch_size,
+                cp_size=1,
+                cp_rank=0,
+                compress_ratio=compress_ratio,
+                # The BF16 FlashMLA baseline has the production 64-head
+                # padding requirement. Q8 below receives only the active TP
+                # prefix, matching the optimized SM100 model path.
+                num_heads=max(64, args.num_heads),
+                device=device,
+                seed=args.seed,
+            )
+            _reset_backend(case)
+            q_active = case.q[:, :, : args.num_heads].contiguous()
+            sink_active = case.attn_sink[: args.num_heads].contiguous()
+            q16_call = _make_q16_call(case)
+            q8_call = _make_q8_call(case, q_active, sink_active)
+
+            # Alternate order across shapes to reduce persistent clock bias.
+            if (seq_index + ratio_index) % 2:
+                q8_timing, q8_out = base.benchmark_cuda(
+                    q8_call, warmup=args.warmup, repeats=args.repeats
+                )
+                q16_timing, q16_out = base.benchmark_cuda(
+                    q16_call, warmup=args.warmup, repeats=args.repeats
+                )
+            else:
+                q16_timing, q16_out = base.benchmark_cuda(
+                    q16_call, warmup=args.warmup, repeats=args.repeats
+                )
+                q8_timing, q8_out = base.benchmark_cuda(
+                    q8_call, warmup=args.warmup, repeats=args.repeats
+                )
+
+            accuracy = _accuracy(q8_out, q16_out)
+            speedup = q16_timing.median_ms / q8_timing.median_ms
+            row: dict[str, object] = {
+                "seq_len": seq_len,
+                "batch_size": args.batch_size,
+                "total_q_tokens": seq_len * args.batch_size,
+                "compress_ratio": compress_ratio,
+                "num_heads": args.num_heads,
+                "q16_mean_ms": q16_timing.mean_ms,
+                "q16_median_ms": q16_timing.median_ms,
+                "q16_p10_ms": q16_timing.p10_ms,
+                "q16_p90_ms": q16_timing.p90_ms,
+                "q8_mean_ms": q8_timing.mean_ms,
+                "q8_median_ms": q8_timing.median_ms,
+                "q8_p10_ms": q8_timing.p10_ms,
+                "q8_p90_ms": q8_timing.p90_ms,
+                "speedup": speedup,
+                "gain_percent": (speedup - 1.0) * 100.0,
+                **accuracy,
+            }
+            rows.append(row)
+            print(
+                f"seq={seq_len:>6} C{compress_ratio:<3} "
+                f"q16={q16_timing.median_ms:>8.3f} ms "
+                f"q8={q8_timing.median_ms:>8.3f} ms "
+                f"speedup={speedup:>6.3f}x "
+                f"gain={(speedup - 1.0) * 100.0:>+7.2f}% "
+                f"cos={accuracy['cosine_similarity']:.6f}",
+                flush=True,
+            )
+            del case, q16_out, q8_out, q16_call, q8_call, q_active, sink_active
+            torch.cuda.empty_cache()
+
+    weighted = _weighted_summary(rows)
+    with csv_path.open("w", newline="") as output:
+        writer = csv.DictWriter(output, fieldnames=list(rows[0]))
+        writer.writeheader()
+        writer.writerows(rows)
+    with json_path.open("w") as output:
+        json.dump(
+            {"environment": environment, "rows": rows, "weighted": weighted},
+            output,
+            indent=2,
+        )
+
+    print("Weighted C0x3 + C4x20 + C128x20:")
+    for row in weighted:
+        print(
+            f"seq={row['seq_len']:>6} speedup={row['speedup']:.3f}x "
+            f"gain={row['gain_percent']:+.2f}%"
+        )
+    print(f"CSV: {csv_path}")
+    print(f"JSON: {json_path}")
+
+
+def main() -> None:
+    with base.get_parallel().override(
+        world_size=1,
+        world_rank=0,
+        tp_size=1,
+        tp_rank=0,
+        attn_tp_size=1,
+        attn_tp_rank=0,
+        attn_cp_size=1,
+        attn_cp_rank=0,
+    ):
+        _main()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/deepseek/sm100_q8kv8/benchmark_sm100_triton_tiles.py
+++ b/benchmark/kernels/deepseek/sm100_q8kv8/benchmark_sm100_triton_tiles.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Sweep SM100 Triton Q8KV8 tiles for the DeepSeek-V4-Flash TP8 shape."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from pathlib import Path
+
+import torch
+
+from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
+    _sparse_mla_q8kv8_prefill_fwd_sm100_trusted,
+)
+from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm100 import (
+    sparse_mla_q8kv8_prefill_fwd_sm100,
+)
+
+
+def _measure(fn, warmup: int, repeats: int) -> float:
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    starts = [torch.cuda.Event(enable_timing=True) for _ in range(repeats)]
+    ends = [torch.cuda.Event(enable_timing=True) for _ in range(repeats)]
+    for start, end in zip(starts, ends, strict=True):
+        start.record()
+        fn()
+        end.record()
+    torch.cuda.synchronize()
+    values = sorted(
+        start.elapsed_time(end) for start, end in zip(starts, ends, strict=True)
+    )
+    return values[len(values) // 2]
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--s-q", type=int, default=512)
+    parser.add_argument("--s-kv", type=int, default=2048)
+    parser.add_argument("--topk", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--repeats", type=int, default=20)
+    parser.add_argument("--results-dir", type=Path, required=True)
+    args = parser.parse_args()
+
+    if os.environ.get("CUDA_VISIBLE_DEVICES") != "7" or torch.cuda.device_count() != 1:
+        raise SystemExit("Safety check failed: expose physical GPU7 only")
+    if torch.cuda.get_device_capability(0)[0] != 10:
+        raise SystemExit("SM100 is required")
+
+    generator = torch.Generator(device="cuda").manual_seed(42)
+    q = (torch.randn(args.s_q, 8, 512, device="cuda", generator=generator) * 0.05).to(
+        torch.float8_e4m3fn
+    )
+    kv = (torch.randn(args.s_kv, 1, 512, device="cuda", generator=generator) * 0.05).to(
+        torch.float8_e4m3fn
+    )
+    indices = torch.randint(
+        0,
+        args.s_kv,
+        (args.s_q, 1, args.topk),
+        dtype=torch.int32,
+        device="cuda",
+        generator=generator,
+    )
+    scale = torch.ones((), dtype=torch.float32, device="cuda")
+    sink = torch.zeros(8, dtype=torch.float32, device="cuda")
+    lengths = torch.full((args.s_q,), args.topk, dtype=torch.int32, device="cuda")
+    out = torch.empty(args.s_q, 8, 512, dtype=torch.bfloat16, device="cuda")
+    max_logits = torch.empty(args.s_q, 8, dtype=torch.float32, device="cuda")
+    lse = torch.empty_like(max_logits)
+
+    max_logits_cuda = torch.empty(args.s_q, 32, dtype=torch.float32, device="cuda")
+    lse_cuda = torch.empty_like(max_logits_cuda)
+
+    def launch_cuda() -> None:
+        _sparse_mla_q8kv8_prefill_fwd_sm100_trusted(
+            q=q,
+            kv=kv,
+            indices=indices,
+            sm_scale=1.0 / (512**0.5),
+            q_scale=scale,
+            kv_scale=scale,
+            attn_sink=sink,
+            topk_length=lengths,
+            out=out,
+            max_logits=max_logits_cuda,
+            lse=lse_cuda,
+            active_heads=8,
+        )
+
+    rows = [
+        {
+            "implementation": "cuda_tcgen05",
+            "median_ms": _measure(launch_cuda, args.warmup, args.repeats),
+        }
+    ]
+    print(rows[0], flush=True)
+
+    os.environ["SGLANG_SM100_Q8KV8_TRITON"] = "1"
+    for block_h in (8, 16, 32):
+        for block_n in (64, 128, 256):
+            for num_warps in (4, 8):
+                os.environ["SGLANG_SM100_Q8KV8_BLOCK_H"] = str(block_h)
+                os.environ["SGLANG_SM100_Q8KV8_BLOCK_N"] = str(block_n)
+                os.environ["SGLANG_SM100_Q8KV8_NUM_WARPS"] = str(num_warps)
+                os.environ["SGLANG_SM100_Q8KV8_NUM_STAGES"] = "1"
+
+                def launch() -> None:
+                    sparse_mla_q8kv8_prefill_fwd_sm100(
+                        q=q,
+                        kv=kv,
+                        indices=indices,
+                        sm_scale=1.0 / (512**0.5),
+                        q_scale=scale,
+                        kv_scale=scale,
+                        attn_sink=sink,
+                        topk_length=lengths,
+                        out=out,
+                        max_logits=max_logits,
+                        lse=lse,
+                    )
+
+                try:
+                    median_ms = _measure(launch, args.warmup, args.repeats)
+                    row = {
+                        "implementation": "triton",
+                        "block_h": block_h,
+                        "block_n": block_n,
+                        "num_warps": num_warps,
+                        "median_ms": median_ms,
+                    }
+                except Exception as error:
+                    row = {
+                        "implementation": "triton",
+                        "block_h": block_h,
+                        "block_n": block_n,
+                        "num_warps": num_warps,
+                        "error": str(error),
+                    }
+                rows.append(row)
+                print(row, flush=True)
+
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    path = args.results_dir / f"{time.strftime('%Y%m%d-%H%M%S')}-triton-tile-sweep.json"
+    path.write_text(
+        json.dumps(
+            {
+                "arguments": vars(args) | {"results_dir": str(args.results_dir)},
+                "rows": rows,
+            },
+            indent=2,
+        )
+    )
+    print(path)
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/deepseek/sm100_q8kv8/diagnose_tmem_output_layout.py
+++ b/benchmark/kernels/deepseek/sm100_q8kv8/diagnose_tmem_output_layout.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Check whether SM100 TMEM output fragments are accidentally duplicated."""
+
+from __future__ import annotations
+
+import os
+
+import torch
+from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
+    _sparse_mla_q8kv8_prefill_fwd_sm100_trusted,
+)
+
+
+def main() -> None:
+    if os.environ.get("CUDA_VISIBLE_DEVICES") != "7":
+        raise SystemExit("Safety check failed: use CUDA_VISIBLE_DEVICES=7")
+    if torch.cuda.device_count() != 1:
+        raise SystemExit("Safety check failed: expose exactly one GPU")
+
+    torch.manual_seed(1234)
+    device = torch.device("cuda:0")
+    q = (torch.randn(1, 8, 512, device=device) * 0.25).to(torch.float8_e4m3fn)
+    kv = (torch.randn(128, 1, 512, device=device) * 0.25).to(torch.float8_e4m3fn)
+    indices = torch.arange(128, dtype=torch.int32, device=device).reshape(1, 1, 128)
+    scale = torch.ones((), dtype=torch.float32, device=device)
+    sink = torch.zeros(32, dtype=torch.float32, device=device)
+    lengths = torch.full((1,), 128, dtype=torch.int32, device=device)
+    out = torch.empty(1, 8, 512, dtype=torch.bfloat16, device=device)
+    max_logits = torch.empty(1, 32, dtype=torch.float32, device=device)
+    lse = torch.empty_like(max_logits)
+
+    _sparse_mla_q8kv8_prefill_fwd_sm100_trusted(
+        q=q,
+        kv=kv,
+        indices=indices,
+        sm_scale=512**-0.5,
+        q_scale=scale,
+        kv_scale=scale,
+        attn_sink=sink,
+        topk_length=lengths,
+        out=out,
+        max_logits=max_logits,
+        lse=lse,
+        active_heads=8,
+    )
+    torch.cuda.synchronize()
+
+    q_padded = torch.zeros(1, 64, 512, dtype=torch.bfloat16, device=device)
+    q_padded[:, :8].copy_(q.to(torch.bfloat16))
+    sink_padded = torch.zeros(64, dtype=torch.float32, device=device)
+    golden, _, _ = flash_mla_sparse_fwd(
+        q=q_padded,
+        kv=kv.to(torch.bfloat16),
+        indices=indices,
+        sm_scale=512**-0.5,
+        d_v=512,
+        attn_sink=sink_padded,
+        topk_length=lengths,
+    )
+    torch.cuda.synchronize()
+
+    segments = out.float().reshape(8, 8, 64)
+    print("pairwise max_abs_diff for head0 64-column segments:")
+    for lhs in range(8):
+        values = []
+        for rhs in range(8):
+            values.append((segments[0, lhs] - segments[0, rhs]).abs().max().item())
+        print(" ".join(f"{value:.7f}" for value in values))
+
+    golden_segments = golden[:, :8].float().reshape(8, 8, 64)
+    print("actual-to-golden cosine for head0 64-column segments:")
+    for lhs in range(8):
+        values = []
+        for rhs in range(8):
+            values.append(
+                torch.nn.functional.cosine_similarity(
+                    segments[0, lhs], golden_segments[0, rhs], dim=0
+                ).item()
+            )
+        print(" ".join(f"{value:+.5f}" for value in values))
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/kernels/deepseek/sm100_q8kv8/profile_dsv4_q8kv8.py
+++ b/benchmark/kernels/deepseek/sm100_q8kv8/profile_dsv4_q8kv8.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+"""Capture a GPU-operator profile of the complete DSV4 q16/q8 prefill paths."""
+
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import sys
+import time
+from pathlib import Path
+
+THIS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = Path(os.environ.get("SGLANG_REPO_ROOT", THIS_DIR.parents[3]))
+if not (REPO_ROOT / "python/sglang").is_dir():
+    REPO_ROOT = Path("/upfs/abing/sglang/pr/cpp_radix_tree/sglang")
+os.environ.setdefault("SGLANG_REPO_ROOT", str(REPO_ROOT))
+
+
+def _load(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+base_path = THIS_DIR / "benchmark_dsv4_prefill_paths.py"
+if not base_path.is_file():
+    base_path = REPO_ROOT / "benchmark/kernels/deepseek/benchmark_dsv4_prefill_paths.py"
+base = _load("dsv4_profile_base", base_path)
+bench_path = THIS_DIR / "benchmark_dsv4_q8kv8.py"
+if not bench_path.is_file():
+    bench_path = (
+        REPO_ROOT / "benchmark/kernels/deepseek/sm100_q8kv8/benchmark_dsv4_q8kv8.py"
+    )
+bench = _load("dsv4_q8_bench", bench_path)
+torch = base.torch
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seq-len", type=int, default=2048)
+    parser.add_argument("--compress-ratio", type=int, default=4)
+    parser.add_argument("--active-heads", type=int, default=8)
+    parser.add_argument("--iterations", type=int, default=5)
+    parser.add_argument("--results-dir", type=Path, default=THIS_DIR / "results")
+    args = parser.parse_args()
+
+    if os.environ.get("CUDA_VISIBLE_DEVICES") != "7":
+        raise SystemExit("Safety check failed: use CUDA_VISIBLE_DEVICES=7")
+    device = torch.device("cuda:0")
+    case = base.build_case(
+        seq_len=args.seq_len,
+        batch_size=1,
+        compress_ratio=args.compress_ratio,
+        num_heads=max(64, args.active_heads),
+        device=device,
+        seed=42,
+    )
+    bench._reset_backend(case)
+    q_active = case.q[:, :, : args.active_heads].contiguous()
+    sink_active = case.attn_sink[: args.active_heads].contiguous()
+    q16_call = bench._make_q16_call(case)
+    q8_call = bench._make_q8_call(case, q_active, sink_active)
+
+    for _ in range(3):
+        q16_call()
+        q8_call()
+    torch.cuda.synchronize()
+
+    activities = [
+        torch.profiler.ProfilerActivity.CPU,
+        torch.profiler.ProfilerActivity.CUDA,
+    ]
+    with torch.profiler.profile(
+        activities=activities,
+        record_shapes=True,
+        with_stack=False,
+    ) as profiler:
+        for _ in range(args.iterations):
+            with torch.profiler.record_function("q16_complete"):
+                q16_call()
+            with torch.profiler.record_function("q8_complete"):
+                q8_call()
+        torch.cuda.synchronize()
+
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    stem = (
+        f"{time.strftime('%Y%m%d-%H%M%S')}-profile-s{args.seq_len}"
+        f"-c{args.compress_ratio}-h{args.active_heads}"
+    )
+    trace_path = args.results_dir / f"{stem}.json"
+    table_path = args.results_dir / f"{stem}.txt"
+    profiler.export_chrome_trace(str(trace_path))
+    table = profiler.key_averages().table(sort_by="self_cuda_time_total", row_limit=80)
+    table_path.write_text(table + "\n")
+    print(table)
+    print(f"Trace: {trace_path}")
+    print(f"Table: {table_path}")
+
+
+if __name__ == "__main__":
+    with base.get_parallel().override(
+        world_size=1,
+        world_rank=0,
+        tp_size=1,
+        tp_rank=0,
+        attn_tp_size=1,
+        attn_tp_rank=0,
+        attn_cp_size=1,
+        attn_cp_rank=0,
+    ):
+        main()

--- a/benchmark/kernels/deepseek/sm100_q8kv8/validate_dsv4_q8kv8_accuracy.py
+++ b/benchmark/kernels/deepseek/sm100_q8kv8/validate_dsv4_q8kv8_accuracy.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Validate SM100 Q8KV8 sparse prefill against the BF16 backend golden.
+
+The default matrix is the DeepSeek-V4-Flash TP8 production shape across
+4K/8K/16K/32K query lengths and C0/C4/C128 layers.  The comparison covers the
+complete backend functions rather than calling only the attention kernels.
+
+For safety on the shared B200 host this script refuses to run unless physical
+GPU 7 is the only CUDA-visible device.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import socket
+import subprocess
+import time
+from pathlib import Path
+
+import benchmark_dsv4_q8kv8 as benchmark
+
+torch = benchmark.torch
+base = benchmark.base
+THIS_DIR = Path(__file__).resolve().parent
+RESULTS_DIR = THIS_DIR / "results"
+
+
+def _git_output(*args: str) -> str:
+    try:
+        return subprocess.check_output(
+            ["git", *args],
+            cwd=benchmark.REPO_ROOT,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        ).strip()
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--seq-lens", type=int, nargs="+", default=[4096, 8192, 16384, 32768]
+    )
+    parser.add_argument("--compress-ratios", type=int, nargs="+", default=[0, 4, 128])
+    parser.add_argument("--batch-size", type=int, default=1)
+    parser.add_argument(
+        "--num-heads",
+        type=int,
+        default=8,
+        help="TP-local active heads; DeepSeek-V4-Flash TP8 uses 8.",
+    )
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--min-cosine", type=float, default=0.999)
+    parser.add_argument("--max-mean-abs-error", type=float, default=1e-3)
+    parser.add_argument("--max-abs-error", type=float, default=2e-2)
+    parser.add_argument("--tag", default="gpu7-long-accuracy")
+    parser.add_argument("--results-dir", type=Path, default=RESULTS_DIR)
+    return parser.parse_args()
+
+
+def _validate_args(args: argparse.Namespace) -> None:
+    visible = os.environ.get("CUDA_VISIBLE_DEVICES")
+    if visible != "7":
+        raise SystemExit(
+            "Safety check failed: run with CUDA_VISIBLE_DEVICES=7; "
+            f"current value is {visible!r}"
+        )
+    if not torch.cuda.is_available():
+        raise SystemExit("CUDA is required")
+    if torch.cuda.device_count() != 1:
+        raise SystemExit(
+            "Safety check failed: exactly one CUDA-visible GPU is required, got "
+            f"{torch.cuda.device_count()}"
+        )
+    capability = torch.cuda.get_device_capability(0)
+    if capability[0] != 10:
+        raise SystemExit(f"SM100 is required, got compute capability {capability}")
+    if args.batch_size <= 0 or args.num_heads <= 0:
+        raise SystemExit("--batch-size and --num-heads must be positive")
+    if any(seq_len <= 0 for seq_len in args.seq_lens):
+        raise SystemExit("--seq-lens must be positive")
+    invalid_ratios = set(args.compress_ratios) - {0, 4, 128}
+    if invalid_ratios:
+        raise SystemExit(f"Unsupported compress ratios: {sorted(invalid_ratios)}")
+
+
+@torch.no_grad()
+def _main() -> None:
+    args = _parse_args()
+    _validate_args(args)
+    device = torch.device("cuda:0")
+    torch.cuda.set_device(device)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    timestamp = time.strftime("%Y%m%d-%H%M%S")
+    args.results_dir.mkdir(parents=True, exist_ok=True)
+    json_path = args.results_dir / f"{timestamp}-{args.tag}.json"
+    environment = {
+        "timestamp": timestamp,
+        "hostname": socket.gethostname(),
+        "physical_gpu": 7,
+        "cuda_visible_devices": os.environ["CUDA_VISIBLE_DEVICES"],
+        "gpu_name": torch.cuda.get_device_name(device),
+        "compute_capability": list(torch.cuda.get_device_capability(device)),
+        "torch_version": torch.__version__,
+        "cuda_version": torch.version.cuda,
+        "git_branch": _git_output("branch", "--show-current"),
+        "git_commit": _git_output("rev-parse", "HEAD"),
+        "arguments": vars(args) | {"results_dir": str(args.results_dir)},
+        "golden": "DeepseekV4AttnBackend._forward_prefill_sparse",
+        "actual": "DeepseekV4AttnBackend._forward_prefill_sparse_q8kv8",
+    }
+
+    rows: list[dict[str, object]] = []
+    failures: list[dict[str, object]] = []
+    for seq_len in sorted(set(args.seq_lens)):
+        for compress_ratio in args.compress_ratios:
+            case = base.build_case(
+                prefix_len=0,
+                extend_len=seq_len,
+                batch_size=args.batch_size,
+                cp_size=1,
+                cp_rank=0,
+                compress_ratio=compress_ratio,
+                num_heads=max(64, args.num_heads),
+                device=device,
+                seed=args.seed,
+            )
+            benchmark._reset_backend(case)
+            q_active = case.q[:, :, : args.num_heads].contiguous()
+            sink_active = case.attn_sink[: args.num_heads].contiguous()
+
+            bf16_out = benchmark._make_q16_call(case)()
+            q8_out = benchmark._make_q8_call(case, q_active, sink_active)()
+            torch.cuda.synchronize()
+            accuracy = benchmark._accuracy(q8_out, bf16_out)
+            passed = (
+                accuracy["cosine_similarity"] >= args.min_cosine
+                and accuracy["mean_abs_error"] <= args.max_mean_abs_error
+                and accuracy["max_abs_error"] <= args.max_abs_error
+            )
+            row: dict[str, object] = {
+                "seq_len": seq_len,
+                "batch_size": args.batch_size,
+                "compress_ratio": compress_ratio,
+                "num_heads": args.num_heads,
+                **accuracy,
+                "passed": passed,
+            }
+            rows.append(row)
+            if not passed:
+                failures.append(row)
+            print(
+                f"{'PASS' if passed else 'FAIL'} seq={seq_len:>6} "
+                f"C{compress_ratio:<3} cos={accuracy['cosine_similarity']:.8f} "
+                f"mean_abs={accuracy['mean_abs_error']:.8g} "
+                f"max_abs={accuracy['max_abs_error']:.8g}",
+                flush=True,
+            )
+
+            del case, bf16_out, q8_out, q_active, sink_active
+            torch.cuda.empty_cache()
+
+    result = {
+        "environment": environment,
+        "thresholds": {
+            "min_cosine": args.min_cosine,
+            "max_mean_abs_error": args.max_mean_abs_error,
+            "max_abs_error": args.max_abs_error,
+        },
+        "passed": not failures,
+        "num_cases": len(rows),
+        "num_failures": len(failures),
+        "rows": rows,
+    }
+    with json_path.open("w") as output:
+        json.dump(result, output, indent=2)
+    print(f"JSON: {json_path}")
+    if failures:
+        raise SystemExit(f"Accuracy validation failed for {len(failures)} case(s)")
+    print(f"All {len(rows)} accuracy cases passed")
+
+
+def main() -> None:
+    with base.get_parallel().override(
+        world_size=1,
+        world_rank=0,
+        tp_size=1,
+        tp_rank=0,
+        attn_tp_size=1,
+        attn_tp_rank=0,
+        attn_cp_size=1,
+        attn_cp_rank=0,
+    ):
+        _main()
+
+
+if __name__ == "__main__":
+    main()

--- a/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/entry.cuh
+++ b/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/entry.cuh
@@ -1,0 +1,276 @@
+/* Copyright 2025 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// JIT dispatch entry for the SM100 Q8KV8 sparse MLA prefill kernel.
+#pragma once
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include "kernel.cuh"
+#include <cmath>
+#include <cstdint>
+#include <cuda_runtime.h>
+
+namespace sglang {
+
+static inline void
+_set_device_and_stream(SparseMlaQ8Kv8PrefillParams& params, tvm::ffi::TensorView q, int64_t cuda_stream) {
+  DLDevice dev = q.device();
+  cudaSetDevice(dev.device_id);
+  params.stream = reinterpret_cast<cudaStream_t>(cuda_stream);
+}
+
+template <int D_QK, bool StoreMeta = true>
+static inline void _run_q8kv8_for_head_dim(SparseMlaQ8Kv8PrefillParams& params, bool, bool, int active_heads) {
+  sm100_q8kv8::run_sparse_prefill_q8kv8_sm100<D_QK, StoreMeta>(params, active_heads);
+}
+
+template <bool StoreMeta = true>
+static inline void
+_run_q8kv8(SparseMlaQ8Kv8PrefillParams& params, bool have_topk_length, bool have_attn_sink, int active_heads) {
+  switch (params.d_qk) {
+    case 512:
+      _run_q8kv8_for_head_dim<512, StoreMeta>(params, have_topk_length, have_attn_sink, active_heads);
+      return;
+    case 576:
+      _run_q8kv8_for_head_dim<576, StoreMeta>(params, have_topk_length, have_attn_sink, active_heads);
+      return;
+    default:
+      fprintf(stderr, "sparse_prefill_q8kv8_sm100_cuda: unsupported d_qk=%d (must be 512 or 576)\n", params.d_qk);
+      exit(1);
+  }
+}
+
+static inline SparseMlaQ8Kv8PrefillParams _make_common_params(
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView kv,
+    tvm::ffi::TensorView indices,
+    tvm::ffi::TensorView q_scale,
+    tvm::ffi::TensorView kv_scale,
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView max_logits,
+    tvm::ffi::TensorView lse,
+    int64_t s_q_val,
+    int64_t s_kv_val,
+    int64_t h_q_val,
+    int64_t h_kv_val,
+    int64_t d_qk_val,
+    int64_t d_v_val,
+    int64_t topk_val,
+    double sm_scale_val,
+    int64_t cuda_stream) {
+  SparseMlaQ8Kv8PrefillParams params;
+  params.s_q = (int)s_q_val;
+  params.s_kv = (int)s_kv_val;
+  params.h_q = (int)h_q_val;
+  params.h_kv = (int)h_kv_val;
+  params.d_qk = (int)d_qk_val;
+  params.d_v = (int)d_v_val;
+  params.topk = (int)topk_val;
+  params.sm_scale_div_log2 = (float)sm_scale_val * (float)M_LOG2E;
+
+  params.q = reinterpret_cast<const uint8_t*>(q.data_ptr());
+  params.kv = reinterpret_cast<const uint8_t*>(kv.data_ptr());
+  params.indices = static_cast<int*>(indices.data_ptr());
+  params.attn_sink = nullptr;
+  params.topk_length = nullptr;
+
+  params.q_scale_ptr = static_cast<const float*>(q_scale.data_ptr());
+  params.kv_scale_ptr = static_cast<const float*>(kv_scale.data_ptr());
+
+  params.stride_q_s_q = (int)h_q_val * (int)d_qk_val;
+  params.stride_q_h_q = (int)d_qk_val;
+  params.stride_kv_s_kv = (int64_t)h_kv_val * (int64_t)d_qk_val;
+  params.stride_kv_h_kv = (int)d_qk_val;
+  params.stride_indices_s_q = (int)h_kv_val * (int)topk_val;
+  params.stride_indices_h_kv = (int)topk_val;
+
+  params.out = reinterpret_cast<cutlass::bfloat16_t*>(out.data_ptr());
+  params.max_logits = static_cast<float*>(max_logits.data_ptr());
+  params.lse = static_cast<float*>(lse.data_ptr());
+
+  _set_device_and_stream(params, q, cuda_stream);
+  return params;
+}
+
+void sparse_prefill_q8kv8_dispatch(
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView kv,
+    tvm::ffi::TensorView indices,
+    tvm::ffi::TensorView q_scale,
+    tvm::ffi::TensorView kv_scale,
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView max_logits,
+    tvm::ffi::TensorView lse,
+    int64_t s_q_val,
+    int64_t s_kv_val,
+    int64_t h_q_val,
+    int64_t h_kv_val,
+    int64_t d_qk_val,
+    int64_t d_v_val,
+    int64_t topk_val,
+    double sm_scale_val,
+    int64_t cuda_stream) {
+  SparseMlaQ8Kv8PrefillParams params = _make_common_params(
+      q,
+      kv,
+      indices,
+      q_scale,
+      kv_scale,
+      out,
+      max_logits,
+      lse,
+      s_q_val,
+      s_kv_val,
+      h_q_val,
+      h_kv_val,
+      d_qk_val,
+      d_v_val,
+      topk_val,
+      sm_scale_val,
+      cuda_stream);
+  _run_q8kv8(params, false, false, params.h_q);
+}
+
+void sparse_prefill_q8kv8_dispatch_full(
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView kv,
+    tvm::ffi::TensorView indices,
+    tvm::ffi::TensorView q_scale,
+    tvm::ffi::TensorView kv_scale,
+    tvm::ffi::TensorView attn_sink,
+    tvm::ffi::TensorView topk_length,
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView max_logits,
+    tvm::ffi::TensorView lse,
+    int64_t s_q_val,
+    int64_t s_kv_val,
+    int64_t h_q_val,
+    int64_t h_kv_val,
+    int64_t d_qk_val,
+    int64_t d_v_val,
+    int64_t topk_val,
+    double sm_scale_val,
+    int64_t cuda_stream) {
+  SparseMlaQ8Kv8PrefillParams params = _make_common_params(
+      q,
+      kv,
+      indices,
+      q_scale,
+      kv_scale,
+      out,
+      max_logits,
+      lse,
+      s_q_val,
+      s_kv_val,
+      h_q_val,
+      h_kv_val,
+      d_qk_val,
+      d_v_val,
+      topk_val,
+      sm_scale_val,
+      cuda_stream);
+  params.attn_sink = static_cast<float*>(attn_sink.data_ptr());
+  params.topk_length = static_cast<int*>(topk_length.data_ptr());
+  _run_q8kv8(params, true, true, params.h_q);
+}
+
+void sparse_prefill_q8kv8_dispatch_topk_length(
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView kv,
+    tvm::ffi::TensorView indices,
+    tvm::ffi::TensorView q_scale,
+    tvm::ffi::TensorView kv_scale,
+    tvm::ffi::TensorView topk_length,
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView max_logits,
+    tvm::ffi::TensorView lse,
+    int64_t s_q_val,
+    int64_t s_kv_val,
+    int64_t h_q_val,
+    int64_t h_kv_val,
+    int64_t d_qk_val,
+    int64_t d_v_val,
+    int64_t topk_val,
+    double sm_scale_val,
+    int64_t cuda_stream) {
+  SparseMlaQ8Kv8PrefillParams params = _make_common_params(
+      q,
+      kv,
+      indices,
+      q_scale,
+      kv_scale,
+      out,
+      max_logits,
+      lse,
+      s_q_val,
+      s_kv_val,
+      h_q_val,
+      h_kv_val,
+      d_qk_val,
+      d_v_val,
+      topk_val,
+      sm_scale_val,
+      cuda_stream);
+  params.topk_length = static_cast<int*>(topk_length.data_ptr());
+  _run_q8kv8(params, true, false, params.h_q);
+}
+
+void sparse_prefill_q8kv8_dispatch_full_active(
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView kv,
+    tvm::ffi::TensorView indices,
+    tvm::ffi::TensorView q_scale,
+    tvm::ffi::TensorView kv_scale,
+    tvm::ffi::TensorView attn_sink,
+    tvm::ffi::TensorView topk_length,
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView max_logits,
+    tvm::ffi::TensorView lse,
+    int64_t s_q_val,
+    int64_t s_kv_val,
+    int64_t h_q_val,
+    int64_t h_kv_val,
+    int64_t d_qk_val,
+    int64_t d_v_val,
+    int64_t topk_val,
+    int64_t active_heads_val,
+    double sm_scale_val,
+    int64_t cuda_stream) {
+  SparseMlaQ8Kv8PrefillParams params = _make_common_params(
+      q,
+      kv,
+      indices,
+      q_scale,
+      kv_scale,
+      out,
+      max_logits,
+      lse,
+      s_q_val,
+      s_kv_val,
+      h_q_val,
+      h_kv_val,
+      d_qk_val,
+      d_v_val,
+      topk_val,
+      sm_scale_val,
+      cuda_stream);
+  params.attn_sink = static_cast<float*>(attn_sink.data_ptr());
+  params.topk_length = static_cast<int*>(topk_length.data_ptr());
+  _run_q8kv8<false>(params, true, true, static_cast<int>(active_heads_val));
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/fp8_mma.cuh
+++ b/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/fp8_mma.cuh
@@ -1,0 +1,105 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cute/atom/mma_traits_sm100.hpp>
+#include <cute/tensor.hpp>
+
+// CUTLASS exposes the generic F8F6F4 instruction traits, but the pinned
+// versions used by SGLang have changed their public spelling over time. Keep
+// the tiny instruction atom local so the JIT kernel has one stable interface.
+namespace cute {
+
+template <
+    class AType,
+    class BType,
+    class CType,
+    int M,
+    int N,
+    UMMA::Major AMajor,
+    UMMA::Major BMajor,
+    UMMA::ScaleIn AScale = UMMA::ScaleIn::One,
+    UMMA::ScaleIn BScale = UMMA::ScaleIn::One>
+struct SM100_MMA_F8F6F4_WS_SS_SGL {
+  using DRegisters = void;
+  using ARegisters = uint64_t[1];
+  using BRegisters = uint64_t[1];
+  using CRegisters = uint32_t[1];
+
+  CUTE_HOST_DEVICE static void
+  fma(uint64_t const& desc_a,
+      uint64_t const& desc_b,
+      uint32_t const& tmem_c,
+      uint32_t const& scale_c,
+      uint64_t const& idesc_e) {
+    asm volatile(
+        "{\n\t"
+        ".reg .pred p;\n\t"
+        "setp.ne.b32 p, %4, 0;\n\t"
+        "tcgen05.mma.ws.cta_group::1.kind::f8f6f4 "
+        "[%0], %1, %2, %3, p, 0;\n\t"
+        "}\n"
+        :
+        : "r"(tmem_c), "l"(desc_a), "l"(desc_b), "r"(uint32_t(idesc_e >> 32)), "r"(scale_c));
+  }
+};
+
+template <
+    class AType,
+    class BType,
+    class CType,
+    int M,
+    int N,
+    UMMA::Major AMajor,
+    UMMA::Major BMajor,
+    UMMA::ScaleIn AScale,
+    UMMA::ScaleIn BScale>
+struct MMA_Traits<SM100_MMA_F8F6F4_WS_SS_SGL<AType, BType, CType, M, N, AMajor, BMajor, AScale, BScale>> {
+  using ValTypeD = CType;
+  using ValTypeA = AType;
+  using ValTypeB = BType;
+  using ValTypeC = CType;
+
+  using FrgTypeA = UMMA::smem_desc<AMajor>;
+  using FrgTypeB = UMMA::smem_desc<BMajor>;
+  using FrgTypeC = UMMA::tmem_frg_ws_1sm<CType>;
+
+  using Shape_MNK = Shape<Int<M>, Int<N>, Int<32>>;
+  using ThrID = Layout<_1>;
+  using ALayout = Layout<Shape<_1, Shape<Int<M>, Int<32>>>, Stride<_0, Stride<_1, Int<M>>>>;
+  using BLayout = Layout<Shape<_1, Shape<Int<N>, Int<32>>>, Stride<_0, Stride<_1, Int<N>>>>;
+  using CLayout = Layout<Shape<_1, Shape<Int<M>, Int<N>>>, Stride<_0, Stride<_1, Int<M>>>>;
+
+  UMMA::ScaleOut accumulate_ = UMMA::ScaleOut::One;
+  UMMA::InstrDescriptor idesc_ = UMMA::make_instr_desc<AType, BType, CType, M, N, AMajor, BMajor, AScale, BScale>();
+
+  template <class TD, class DL, class TA, class AL, class TB, class BL, class TC, class CL>
+  CUTE_HOST_DEVICE constexpr friend void mma_unpack(
+      MMA_Traits const& traits,
+      Tensor<TD, DL>& d,
+      Tensor<TA, AL> const& a,
+      Tensor<TB, BL> const& b,
+      Tensor<TC, CL> const&) {
+    uint64_t const desc_a = a[0];
+    uint64_t const desc_b = b[0];
+    uint32_t const tmem_c = raw_pointer_cast(d.data());
+    uint64_t const idesc = UMMA::make_runtime_instr_desc<>(traits.idesc_);
+    SM100_MMA_F8F6F4_WS_SS_SGL<AType, BType, CType, M, N, AMajor, BMajor, AScale, BScale>::fma(
+        desc_a, desc_b, tmem_c, uint32_t(traits.accumulate_), idesc);
+  }
+};
+
+}  // namespace cute

--- a/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/helpers.cuh
+++ b/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/helpers.cuh
@@ -1,0 +1,103 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+#pragma once
+
+#include <cute/tensor.hpp>
+#include <cutlass/arch/barrier.h>
+
+namespace sglang::sm100_q8kv8 {
+
+using transac_bar_t = cutlass::arch::ClusterTransactionBarrier;
+
+CUTE_DEVICE void tcgen05_before_thread_sync() {
+  asm volatile("tcgen05.fence::before_thread_sync;");
+}
+
+CUTE_DEVICE void tcgen05_after_thread_sync() {
+  asm volatile("tcgen05.fence::after_thread_sync;");
+}
+
+CUTE_DEVICE void umma_arrive(transac_bar_t& bar) {
+  uint32_t const addr = cute::cast_smem_ptr_to_uint(&bar);
+  asm volatile("tcgen05.commit.cta_group::1.mbarrier::arrive::one.shared::cluster.b64 [%0];\n" : : "r"(addr));
+}
+
+template <class TiledMMA, class TensorA, class TensorB, class TensorC>
+CUTE_DEVICE void umma_ss(TiledMMA& tiled_mma, TensorA s_a, TensorB s_b, TensorC t_c, bool clear_accum) {
+  using namespace cute;
+  tiled_mma.accumulate_ = clear_accum ? UMMA::ScaleOut::Zero : UMMA::ScaleOut::One;
+  auto thr_mma = tiled_mma.get_slice(_0{});
+  auto a_frag = thr_mma.partition_fragment_A(s_a);
+  auto b_frag = thr_mma.partition_fragment_B(s_b);
+  static_assert(size<2>(a_frag) == size<2>(b_frag));
+  CUTE_UNROLL
+  for (int k = 0; k < size<2>(a_frag); ++k) {
+    cute::gemm(tiled_mma, a_frag(_, _, k), b_frag(_, _, k), t_c);
+    tiled_mma.accumulate_ = UMMA::ScaleOut::One;
+  }
+}
+
+template <int N>
+CUTE_DEVICE void tmem_load(uint32_t col, float* values) {
+  static_assert(N == 1 || N == 2 || N == 4 || N == 8 || N == 16 || N == 32 || N == 64 || N == 128);
+  auto* data = reinterpret_cast<uint32_t*>(values);
+  [&]<size_t... Is>(cute::index_sequence<Is...>) {
+    if constexpr (N == 1) {
+      cute::SM100_TMEM_LOAD_32dp32b1x::copy(col, data[Is]...);
+    } else if constexpr (N == 2) {
+      cute::SM100_TMEM_LOAD_32dp32b2x::copy(col, data[Is]...);
+    } else if constexpr (N == 4) {
+      cute::SM100_TMEM_LOAD_32dp32b4x::copy(col, data[Is]...);
+    } else if constexpr (N == 8) {
+      cute::SM100_TMEM_LOAD_32dp32b8x::copy(col, data[Is]...);
+    } else if constexpr (N == 16) {
+      cute::SM100_TMEM_LOAD_32dp32b16x::copy(col, data[Is]...);
+    } else if constexpr (N == 32) {
+      cute::SM100_TMEM_LOAD_32dp32b32x::copy(col, data[Is]...);
+    } else if constexpr (N == 64) {
+      cute::SM100_TMEM_LOAD_32dp32b64x::copy(col, data[Is]...);
+    } else if constexpr (N == 128) {
+      cute::SM100_TMEM_LOAD_32dp32b128x::copy(col, data[Is]...);
+    }
+  }(cute::make_index_sequence<N>{});
+}
+
+template <int N>
+CUTE_DEVICE void tmem_store(uint32_t col, float const* values) {
+  static_assert(N == 1 || N == 2 || N == 4 || N == 8 || N == 16 || N == 32 || N == 64 || N == 128);
+  auto const* data = reinterpret_cast<uint32_t const*>(values);
+  [&]<size_t... Is>(cute::index_sequence<Is...>) {
+    if constexpr (N == 1) {
+      cute::SM100_TMEM_STORE_32dp32b1x::copy(data[Is]..., col);
+    } else if constexpr (N == 2) {
+      cute::SM100_TMEM_STORE_32dp32b2x::copy(data[Is]..., col);
+    } else if constexpr (N == 4) {
+      cute::SM100_TMEM_STORE_32dp32b4x::copy(data[Is]..., col);
+    } else if constexpr (N == 8) {
+      cute::SM100_TMEM_STORE_32dp32b8x::copy(data[Is]..., col);
+    } else if constexpr (N == 16) {
+      cute::SM100_TMEM_STORE_32dp32b16x::copy(data[Is]..., col);
+    } else if constexpr (N == 32) {
+      cute::SM100_TMEM_STORE_32dp32b32x::copy(data[Is]..., col);
+    } else if constexpr (N == 64) {
+      cute::SM100_TMEM_STORE_32dp32b64x::copy(data[Is]..., col);
+    } else if constexpr (N == 128) {
+      cute::SM100_TMEM_STORE_32dp32b128x::copy(data[Is]..., col);
+    }
+  }(cute::make_index_sequence<N>{});
+}
+
+}  // namespace sglang::sm100_q8kv8

--- a/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/kernel.cuh
+++ b/python/sglang/kernels/jit/csrc/sparse_mla_q8kv8_prefill_sm100/kernel.cuh
@@ -1,0 +1,599 @@
+/* Copyright 2026 SGLang Team. All Rights Reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+==============================================================================*/
+
+// SM100 bring-up kernel for Q8KV8 sparse MLA prefill.
+//
+// It deliberately preserves the SM90 CUDA kernel's numerical dataflow:
+//   QK: E4M3 x E4M3 -> FP32
+//   softmax: FP32 online max/sum
+//   PV: E4M3 probabilities x E4M3 values -> FP32
+//   epilogue: FP32 normalization/descale -> BF16
+//
+// This first SM100 CUDA implementation is stage-synchronous. It establishes a
+// native tcgen05 correctness/performance baseline before the KV gather and the
+// QK/softmax/PV stages are overlapped with the three-buffer pipeline.
+
+#pragma once
+
+#include <cutlass/cuda_host_adapter.hpp>
+
+#include "../sparse_mla_q8kv8_prefill_sm90/config.h"
+#include "../sparse_mla_q8kv8_prefill_sm90/params.h"
+#include "fp8_mma.cuh"
+#include "helpers.cuh"
+#include <cuda_fp8.h>
+#include <math_constants.h>
+
+namespace sglang::sm100_q8kv8 {
+
+using namespace cute;
+using fp8_t = cutlass::float_e4m3_t;
+using bf16_t = cutlass::bfloat16_t;
+
+constexpr int kBlockH = 32;
+// Consume two logical 64-token sparse blocks in one tcgen05 frame.  Besides
+// halving the softmax rendezvous count, N=128 maps one 32-column P fragment to
+// each of WG0's four warps instead of leaving warp1/warp3 without P work.
+constexpr int kBlockTopK = 128;
+constexpr int kDv = 512;
+// Short grids favor fewer resident warps; long grids amortize a wider producer
+// and benefit from two additional TMA-issuing warps.
+constexpr int kShortThreads = 384;
+constexpr int kShortProducerWarps = 7;
+constexpr int kLongThreads = 512;
+constexpr int kLongProducerWarps = 11;
+constexpr int kLongProducerMinSq = 4096;
+constexpr int kMaxBlocks = 32;
+// D512 (the DeepSeek-V4 production shape) fits three 128-row stages under the
+// SM100 per-CTA shared-memory limit.  D576 retains two stages so its wider KV
+// rows remain launchable.
+template <int Dqk>
+constexpr int kBuffersFor = Dqk == 512 ? 3 : 2;
+constexpr float kMaxInit = -1.0e30f;
+// Scaling the probabilities before their E4M3 cast retains weights near
+// 1/topk. The inverse is folded into the final value scale.
+constexpr float kProbFp8Scale = 256.0f;
+
+namespace tmem_col {
+constexpr int kO = 0;
+constexpr int kP = 400;
+}  // namespace tmem_col
+
+template <int Rows, int Cols, bool UseSw128>
+struct SmemLayoutQKSelector;
+
+template <int Rows, int Cols>
+struct SmemLayoutQKSelector<Rows, Cols, true> {
+  using type = decltype(coalesce(
+      tile_to_shape(UMMA::Layout_K_SW128_Atom<fp8_t>{}, Shape<Int<Rows>, Int<Cols>>{}, Step<_1, _2>{}),
+      Shape<_1, _1>{}));
+};
+
+template <int Rows, int Cols>
+struct SmemLayoutQKSelector<Rows, Cols, false> {
+  using type = decltype(coalesce(
+      tile_to_shape(UMMA::Layout_K_SW64_Atom<fp8_t>{}, Shape<Int<Rows>, Int<Cols>>{}, Step<_1, _2>{}),
+      Shape<_1, _1>{}));
+};
+
+template <int Dqk>
+using SmemLayoutQK = typename SmemLayoutQKSelector<kBlockH, Dqk, Dqk == 512>::type;
+
+template <int Dqk>
+using SmemLayoutKV = typename SmemLayoutQKSelector<kBlockTopK, Dqk, Dqk == 512>::type;
+
+// The first 512 bytes of every KV row serve as K for QK and as V for PV.
+// Re-view the same physical K-major storage as a (K=64, N=512) B operand.
+template <int Dqk>
+using SmemLayoutV = decltype(coalesce(
+    composition(SmemLayoutKV<Dqk>{}, Layout<Shape<Int<kDv>, Int<kBlockTopK>>, Stride<Int<kBlockTopK>, _1>>{}),
+    Shape<_1, _1>{}));
+
+using SmemLayoutS = decltype(coalesce(
+    tile_to_shape(UMMA::Layout_K_INTER_Atom<fp8_t>{}, Shape<Int<kBlockH>, Int<kBlockTopK>>{}, Step<_1, _2>{}),
+    Shape<_1, _1>{}));
+
+// Stage half of the 512-wide output at a time. The 256-column buffer exactly
+// aliases the FP8 Q allocation (32 * 256 * bf16 == 32 * 512 * fp8), allowing
+// four 64-column TMA stores to be committed together instead of fencing and
+// waiting after every individual store.
+using SmemLayoutO = decltype(coalesce(
+    tile_to_shape(UMMA::Layout_K_SW128_Atom<bf16_t>{}, Shape<Int<kBlockH>, Int<256>>{}, Step<_1, _2>{}),
+    Shape<_1, _1>{}));
+
+using TiledMmaQK = decltype(make_tiled_mma(
+    SM100_MMA_F8F6F4_WS_SS_SGL<fp8_t, fp8_t, float, kBlockH, kBlockTopK, UMMA::Major::K, UMMA::Major::K>{}));
+
+using TiledMmaPV = decltype(make_tiled_mma(
+    SM100_MMA_F8F6F4_WS_SS_SGL<fp8_t, fp8_t, float, kBlockH, 256, UMMA::Major::K, UMMA::Major::MN>{}));
+
+template <int Dqk>
+struct SharedStorage {
+  union {
+    array_aligned<fp8_t, cosize_v<SmemLayoutQK<Dqk>>> q;
+    array_aligned<bf16_t, cosize_v<SmemLayoutO>> o;
+  } q_o;
+  // Dqk is 512 or 576. The first 512 columns use SmemLayoutKV, while the
+  // optional final 64-column RoPE tail immediately follows it.
+  array_aligned<fp8_t, kBlockTopK * Dqk> kv[kBuffersFor<Dqk>];
+  array_aligned<fp8_t, cosize_v<SmemLayoutS>> s;
+  bool valid[kBuffersFor<Dqk>][kBlockTopK];
+  float exchange_max[128];
+  float exchange_sum[128];
+  array_aligned<uint32_t, 1> tmem_start;
+  transac_bar_t qk_done[kBuffersFor<Dqk>];
+  transac_bar_t pv_done[kBuffersFor<Dqk>];
+  transac_bar_t kv_ready[kBuffersFor<Dqk>];
+  transac_bar_t p_free;
+  transac_bar_t s_ready;
+  transac_bar_t q_ready;
+};
+
+struct TmaParams {
+  CUtensorMap tensor_map_q;
+  CUtensorMap tensor_map_kv;
+  CUtensorMap tensor_map_o;
+  int active_heads;
+};
+
+CUTE_DEVICE void tma_load_3d(void const* desc, transac_bar_t& barrier, void* smem_ptr, int col, int head, int query) {
+  uint32_t const smem_addr = cute::cast_smem_ptr_to_uint(smem_ptr);
+  uint32_t const barrier_addr = cute::cast_smem_ptr_to_uint(&barrier);
+  int64_t const cache_hint = int64_t(TMA::CacheHintSm90::EVICT_LAST);
+  asm volatile(
+      "cp.async.bulk.tensor.3d.shared::cta.global.tile."
+      "mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint "
+      "[%0], [%1, {%2, %3, %4}], [%5], %6;\n"
+      :
+      : "r"(smem_addr), "l"(desc), "r"(col), "r"(head), "r"(query), "r"(barrier_addr), "l"(cache_hint)
+      : "memory");
+}
+
+enum NamedBarriers : int {
+  kSoftmaxExchange = 0,
+  kEpilogueExchange = 1,
+};
+
+CUTE_DEVICE void tma_gather4(void const* desc, transac_bar_t& barrier, void* smem_ptr, int col, int4 rows) {
+  uint32_t const smem_addr = cute::cast_smem_ptr_to_uint(smem_ptr);
+  uint32_t const barrier_addr = cute::cast_smem_ptr_to_uint(&barrier);
+  int64_t const cache_hint = int64_t(TMA::CacheHintSm90::EVICT_LAST);
+  asm volatile(
+      "cp.async.bulk.tensor.2d.shared::cta.global.tile::gather4."
+      "mbarrier::complete_tx::bytes.cta_group::1.L2::cache_hint "
+      "[%0], [%1, {%2, %3, %4, %5, %6}], [%7], %8;\n"
+      :
+      : "r"(smem_addr),
+        "l"(desc),
+        "r"(col),
+        "r"(rows.x),
+        "r"(rows.y),
+        "r"(rows.z),
+        "r"(rows.w),
+        "r"(barrier_addr),
+        "l"(cache_hint)
+      : "memory");
+}
+
+template <int Dqk, int ProducerWarps>
+CUTE_DEVICE void load_kv(
+    SharedStorage<Dqk>& smem,
+    SparseMlaQ8Kv8PrefillParams const& params,
+    TmaParams const& tma_params,
+    int const* g_indices,
+    int block_idx,
+    int buffer_idx) {
+  int const warp = threadIdx.x / 32;
+  int const lane = threadIdx.x & 31;
+
+  // WG1 owns the validity stores; one thread per row for N=128.
+  if (threadIdx.x >= 128 && threadIdx.x < 256) {
+    int const row = threadIdx.x - 128;
+    int const index = __ldg(g_indices + block_idx * kBlockTopK + row);
+    smem.valid[buffer_idx][row] = index >= 0 && index < params.s_kv;
+  }
+
+  // Producer ranks 0..3 are warp4..7; later ranks are warp9 and above. Warp8 is
+  // reserved for the tcgen05 issuer.
+  int const producer_rank = warp < 8 ? warp - 4 : warp - 5;
+  if (lane == 0) {
+    constexpr int kTmaWidth = Dqk == 512 ? 128 : 64;
+    constexpr int kGatherGroups = kBlockTopK / 4;
+    for (int group = producer_rank; group < kGatherGroups; group += ProducerWarps) {
+      int4 const rows = __ldg(reinterpret_cast<int4 const*>(g_indices + block_idx * kBlockTopK) + group);
+      CUTE_UNROLL
+      for (int tile = 0; tile < Dqk / kTmaWidth; ++tile) {
+        tma_gather4(
+            &tma_params.tensor_map_kv,
+            smem.kv_ready[buffer_idx],
+            smem.kv[buffer_idx].data() + group * 4 * kTmaWidth + tile * kBlockTopK * kTmaWidth,
+            tile * kTmaWidth,
+            rows);
+      }
+    }
+  }
+}
+
+template <int Dqk, bool StoreMeta, int Threads, int ProducerWarps>
+__global__ void __launch_bounds__(Threads, 1) sparse_prefill_q8kv8_sm100_kernel(
+    __grid_constant__ SparseMlaQ8Kv8PrefillParams const params, __grid_constant__ TmaParams const tma_params) {
+#if defined(__CUDA_ARCH__) && __CUDA_ARCH__ >= 1000 && __CUDA_ARCH__ < 1100
+  int const s_q_idx = blockIdx.x / (params.h_q / kBlockH);
+  int const q_h_idx = blockIdx.x % (params.h_q / kBlockH);
+  int const warp_idx = cutlass::canonical_warp_idx_sync();
+  int const wg_idx = threadIdx.x / 128;
+  int const wg_tid = threadIdx.x & 127;
+
+  extern __shared__ char smem_raw[];
+  auto& smem = *reinterpret_cast<SharedStorage<Dqk>*>(smem_raw);
+
+  int const* g_indices = params.indices + s_q_idx * params.stride_indices_s_q;
+  int const topk_length = params.topk_length == nullptr ? params.topk : __ldg(params.topk_length + s_q_idx);
+  int const num_blocks = max((topk_length + kBlockTopK - 1) / kBlockTopK, 1);
+  int const active_tile_heads = max(min(tma_params.active_heads - q_h_idx * kBlockH, kBlockH), 0);
+  constexpr int kBuffers = kBuffersFor<Dqk>;
+
+  if (warp_idx == 0) {
+    if (elect_one_sync()) {
+      CUTE_UNROLL
+      for (int i = 0; i < kBuffers; ++i) {
+        smem.qk_done[i].init(1);
+        smem.pv_done[i].init(1);
+        smem.kv_ready[i].init(1);
+      }
+      smem.p_free.init(kBlockH * 4);
+      smem.s_ready.init(kBlockH * 4);
+      smem.q_ready.init(1);
+      cutlass::arch::fence_barrier_init();
+    }
+    cute::TMEM::Allocator1Sm().allocate(512, smem.tmem_start.data());
+    cute::TMEM::Allocator1Sm().release_allocation_lock();
+  }
+
+  __syncthreads();
+
+  if (warp_idx == 4 && elect_one_sync()) {
+    constexpr int kTmaWidth = Dqk == 512 ? 128 : 64;
+    CUTE_UNROLL
+    for (int tile = 0; tile < Dqk / kTmaWidth; ++tile) {
+      tma_load_3d(
+          &tma_params.tensor_map_q,
+          smem.q_ready,
+          smem.q_o.q.data() + tile * kBlockH * kTmaWidth,
+          tile * kTmaWidth,
+          q_h_idx * kBlockH,
+          s_q_idx);
+    }
+  }
+
+  TiledMmaQK tiled_qk;
+  TiledMmaPV tiled_pv;
+  Tensor t_p = partition_fragment_C(tiled_qk, Shape<Int<kBlockH>, Int<kBlockTopK>>{});
+  Tensor t_o = partition_fragment_C(tiled_pv, Shape<Int<kBlockH>, Int<kDv>>{});
+  t_p.data().get() = tmem_col::kP;
+  t_o.data().get() = tmem_col::kO;
+
+  float mi = kMaxInit;
+  float li = 0.0f;
+  float real_mi = -CUDART_INF_F;
+  float const qk_scale_log2 = __ldg(params.q_scale_ptr) * __ldg(params.kv_scale_ptr) * params.sm_scale_div_log2;
+
+  if (wg_idx == 1 || warp_idx > 8) {
+    // Nine-warp KV producer. It can run up to three blocks ahead of the MMA
+    // warp for D512; D576 uses two stages to remain within the smem limit.
+    for (int block = 0; block < num_blocks; ++block) {
+      int const buffer = block % kBuffers;
+      if (block >= kBuffers) {
+        smem.pv_done[buffer].wait(((block / kBuffers) & 1) ^ 1);
+      }
+      load_kv<Dqk, ProducerWarps>(smem, params, tma_params, g_indices, block, buffer);
+      cutlass::arch::fence_view_async_shared();
+    }
+  } else if (wg_idx == 2) {
+    // Batch two QK/PV blocks around one softmax synchronization frame.
+    if (warp_idx == 8 && elect_one_sync()) {
+      smem.q_ready.arrive_and_expect_tx(kBlockH * Dqk * sizeof(fp8_t));
+      smem.q_ready.wait(0);
+      tcgen05_after_thread_sync();
+      auto s_q = make_tensor(make_smem_ptr(smem.q_o.q.data()), SmemLayoutQK<Dqk>{});
+      auto s_s = make_tensor(make_smem_ptr(smem.s.data()), SmemLayoutS{});
+      for (int step = 0; step < num_blocks + 1; ++step) {
+        if (step < num_blocks) {
+          int const buffer = step % kBuffers;
+          smem.p_free.wait((step & 1) ^ 1);
+          smem.kv_ready[buffer].arrive_and_expect_tx(kBlockTopK * Dqk * sizeof(fp8_t));
+          smem.kv_ready[buffer].wait((step / kBuffers) & 1);
+          tcgen05_after_thread_sync();
+          auto s_k = make_tensor(make_smem_ptr(smem.kv[buffer].data()), SmemLayoutQK<Dqk>{});
+          umma_ss(tiled_qk, s_q, s_k, t_p, true);
+          umma_arrive(smem.qk_done[buffer]);
+        }
+        if (step > 0) {
+          int const prev = step - 1;
+          int const buffer = prev % kBuffers;
+          smem.s_ready.wait(prev & 1);
+          tcgen05_after_thread_sync();
+          auto s_v = make_tensor(make_smem_ptr(smem.kv[buffer].data()), SmemLayoutV<Dqk>{});
+          umma_ss(tiled_pv, s_s, s_v, t_o, prev == 0);
+          umma_arrive(smem.pv_done[buffer]);
+        }
+      }
+    }
+  } else {
+    // QK's N=128 fragment is split evenly across all four warps.  They keep a
+    // common online-softmax state so each can independently rescale its
+    // quarter of the N=512 output fragment when the running maximum changes.
+    int const warp_in_wg = wg_tid / 32;
+    int const lane = wg_tid & 31;
+    bool const active_head = lane < active_tile_heads;
+    int const col_base = warp_in_wg * 32;
+    float p[32];
+    for (int block = 0; block < num_blocks; ++block) {
+      int const buffer = block % kBuffers;
+      smem.qk_done[buffer].wait((block / kBuffers) & 1);
+      tcgen05_after_thread_sync();
+      tmem_load<32>(tmem_col::kP, p);
+      cutlass::arch::fence_view_async_tmem_load();
+      tcgen05_before_thread_sync();
+      smem.p_free.arrive();
+
+      float cur_max = -CUDART_INF_F;
+      if (active_head) {
+        CUTE_UNROLL
+        for (int i = 0; i < 32; ++i) {
+          int const col = col_base + i;
+          bool const valid = col < topk_length - block * kBlockTopK && smem.valid[buffer][col];
+          p[i] = valid ? p[i] : -CUDART_INF_F;
+          cur_max = max(cur_max, p[i]);
+        }
+      }
+      cur_max *= qk_scale_log2;
+      smem.exchange_max[wg_tid] = cur_max;
+      NamedBarrier::arrive_and_wait(kBlockH * 4, kSoftmaxExchange);
+      cur_max =
+          max(max(smem.exchange_max[lane], smem.exchange_max[32 + lane]),
+              max(smem.exchange_max[64 + lane], smem.exchange_max[96 + lane]));
+      if constexpr (StoreMeta) {
+        real_mi = max(real_mi, cur_max);
+      }
+
+      // Keep the current softmax frame while the new block remains close.
+      // This is algebraically valid (the block probabilities are evaluated in
+      // the old frame) and avoids a full 64x512 TMEM read/scale/write for most
+      // blocks. __any_sync makes the TMEM branch warp-uniform as required.
+      bool const should_scale_o = block == 0 || __any_sync(0xffffffff, cur_max - mi > 6.0f);
+      float const new_mi = should_scale_o ? max(mi, cur_max) : mi;
+      float const alpha = block == 0 ? 0.0f : exp2f(mi - new_mi);
+      if (block > 0 && should_scale_o) {
+        int const prev_buffer = (block - 1) % kBuffers;
+        smem.pv_done[prev_buffer].wait(((block - 1) / kBuffers) & 1);
+        tcgen05_after_thread_sync();
+        float o[32];
+        CUTE_UNROLL
+        for (int chunk = 0; chunk < (kDv / 4) / 32; ++chunk) {
+          tmem_load<32>(tmem_col::kO + chunk * 32, o);
+          cutlass::arch::fence_view_async_tmem_load();
+          CUTE_UNROLL
+          for (int i = 0; i < 32; ++i) {
+            o[i] *= alpha;
+          }
+          tmem_store<32>(tmem_col::kO + chunk * 32, o);
+          cutlass::arch::fence_view_async_tmem_store();
+        }
+        tcgen05_before_thread_sync();
+      }
+
+      float local_sum = 0.0f;
+      auto s_s = make_tensor(make_smem_ptr(smem.s.data()), SmemLayoutS{});
+      if (active_head) {
+        CUTE_UNROLL
+        for (int i = 0; i < 32; ++i) {
+          float const prob = exp2f(p[i] * qk_scale_log2 - new_mi);
+          local_sum += prob;
+          s_s(lane, col_base + i) = fp8_t(prob * kProbFp8Scale);
+        }
+      }
+      smem.exchange_sum[wg_tid] = local_sum;
+      NamedBarrier::arrive_and_wait(kBlockH * 4, kSoftmaxExchange);
+      li = li * alpha + smem.exchange_sum[lane] + smem.exchange_sum[32 + lane] + smem.exchange_sum[64 + lane] +
+           smem.exchange_sum[96 + lane];
+      mi = new_mi;
+      cutlass::arch::fence_view_async_shared();
+      smem.s_ready.arrive();
+    }
+
+    int const last = num_blocks - 1;
+    smem.pv_done[last % kBuffers].wait((last / kBuffers) & 1);
+    tcgen05_after_thread_sync();
+  }
+
+  if (wg_idx == 0) {
+    int const warp_in_wg = wg_tid / 32;
+    int const lane = wg_tid & 31;
+    bool const active_head = lane < active_tile_heads;
+    float const sink =
+        params.attn_sink == nullptr ? -CUDART_INF_F : __ldg(params.attn_sink + q_h_idx * kBlockH + lane) * CUDART_L2E_F;
+    float const denom = li + exp2f(sink - mi);
+    float const output_scale = li == 0.0f ? 0.0f : __ldg(params.kv_scale_ptr) / (kProbFp8Scale * denom);
+
+    CUTE_UNROLL
+    for (int wave = 0; wave < 2; ++wave) {
+      float o[64];
+      tmem_load<64>(tmem_col::kO + wave * 64, o);
+      cutlass::arch::fence_view_async_tmem_load();
+      if constexpr (!StoreMeta) {
+        // The trusted DeepSeek-V4 backend supplies a compact active-head
+        // output.  Each warp owns one 64-column TMEM tile, so it can write
+        // that tile directly without the shared-memory/TMA epilogue's two
+        // warpgroup rendezvous per wave.
+        if (active_head) {
+          bf16_t* g_o = params.out + (s_q_idx * tma_params.active_heads + q_h_idx * kBlockH + lane) * kDv +
+                        (wave * 4 + warp_in_wg) * 64;
+          CUTE_UNROLL
+          for (int i = 0; i < 64; i += 8) {
+            uint4 packed;
+            auto* values = reinterpret_cast<bf16_t*>(&packed);
+            CUTE_UNROLL
+            for (int j = 0; j < 8; ++j) {
+              values[j] = bf16_t(o[i + j] * output_scale);
+            }
+            *reinterpret_cast<uint4*>(g_o + i) = packed;
+          }
+        }
+      } else {
+        auto s_o = make_tensor(make_smem_ptr(smem.q_o.o.data()), SmemLayoutO{});
+        if (active_head) {
+          CUTE_UNROLL
+          for (int i = 0; i < 64; i += 8) {
+            uint4 packed;
+            auto* values = reinterpret_cast<bf16_t*>(&packed);
+            CUTE_UNROLL
+            for (int j = 0; j < 8; ++j) {
+              values[j] = bf16_t(o[i + j] * output_scale);
+            }
+            *reinterpret_cast<uint4*>(&s_o(lane, warp_in_wg * 64 + i)) = packed;
+          }
+        }
+        cutlass::arch::fence_view_async_shared();
+        NamedBarrier::arrive_and_wait(kBlockH * 4, kEpilogueExchange);
+
+        if (wg_tid == 0) {
+          CUTE_UNROLL
+          for (int tile = 0; tile < 4; ++tile) {
+            SM90_TMA_STORE_3D::copy(
+                &tma_params.tensor_map_o,
+                smem.q_o.o.data() + tile * kBlockH * 64,
+                (wave * 4 + tile) * 64,
+                q_h_idx * kBlockH,
+                s_q_idx);
+          }
+          cute::tma_store_arrive();
+          cute::tma_store_wait<0>();
+        }
+        NamedBarrier::arrive_and_wait(kBlockH * 4, kEpilogueExchange);
+      }
+    }
+
+    if constexpr (StoreMeta) {
+      if (warp_in_wg == 0 && lane < active_tile_heads) {
+        int const meta_idx = s_q_idx * params.h_q + q_h_idx * kBlockH + lane;
+        if (li == 0.0f) {
+          params.max_logits[meta_idx] = -CUDART_INF_F;
+          params.lse[meta_idx] = -CUDART_INF_F;
+        } else {
+          params.max_logits[meta_idx] = real_mi * CUDART_LN2_F;
+          params.lse[meta_idx] = mi * CUDART_LN2_F + logf(li);
+        }
+      }
+    }
+  }
+
+  __syncthreads();
+  if (warp_idx == 0) {
+    cute::TMEM::Allocator1Sm().free(0, 512);
+  }
+#else
+  if (cute::thread0()) {
+    CUTE_INVALID_CONTROL_PATH("SM100 Q8KV8 kernel requires sm_100a/f");
+  }
+#endif
+}
+
+template <int Dqk, bool StoreMeta = true>
+inline void run_sparse_prefill_q8kv8_sm100(SparseMlaQ8Kv8PrefillParams const& params, int active_heads) {
+  KU_ASSERT(params.h_kv == 1);
+  KU_ASSERT(params.h_q > 0 && params.h_q % kBlockH == 0);
+  KU_ASSERT(params.d_qk == Dqk);
+  KU_ASSERT(params.d_v == kDv);
+  KU_ASSERT(params.topk > 0 && params.topk % 128 == 0);
+  KU_ASSERT(params.topk <= kMaxBlocks * kBlockTopK);
+  KU_ASSERT(active_heads > 0 && active_heads <= params.h_q);
+
+  CUtensorMap tensor_map_q;
+  uint64_t q_size[3] = {Dqk, static_cast<uint64_t>(active_heads), static_cast<uint64_t>(params.s_q)};
+  uint64_t q_stride[2] = {static_cast<uint64_t>(Dqk), static_cast<uint64_t>(active_heads) * Dqk};
+  constexpr uint32_t kTmaWidth = Dqk == 512 ? 128 : 64;
+  uint32_t q_box_size[3] = {kTmaWidth, kBlockH, 1};
+  uint32_t q_elem_stride[3] = {1, 1, 1};
+  CUresult result = CUTLASS_CUDA_DRIVER_WRAPPER_CALL(cuTensorMapEncodeTiled)(
+      &tensor_map_q,
+      CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_UINT8,
+      3,
+      const_cast<uint8_t*>(params.q),
+      q_size,
+      q_stride,
+      q_box_size,
+      q_elem_stride,
+      CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+      Dqk == 512 ? CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B : CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_64B,
+      CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_L2_256B,
+      CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  KU_ASSERT(result == CUresult::CUDA_SUCCESS);
+
+  CUtensorMap tensor_map_kv;
+  uint64_t size[2] = {Dqk, static_cast<uint64_t>(params.s_kv)};
+  uint64_t stride[1] = {static_cast<uint64_t>(params.stride_kv_s_kv) * sizeof(fp8_t)};
+  uint32_t box_size[2] = {kTmaWidth, 1};
+  uint32_t elem_stride[2] = {1, 1};
+  result = CUTLASS_CUDA_DRIVER_WRAPPER_CALL(cuTensorMapEncodeTiled)(
+      &tensor_map_kv,
+      CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_UINT8,
+      2,
+      const_cast<uint8_t*>(params.kv),
+      size,
+      stride,
+      box_size,
+      elem_stride,
+      CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+      Dqk == 512 ? CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B : CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_64B,
+      CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_L2_256B,
+      CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  KU_ASSERT(result == CUresult::CUDA_SUCCESS);
+
+  CUtensorMap tensor_map_o;
+  uint64_t o_size[3] = {kDv, static_cast<uint64_t>(active_heads), static_cast<uint64_t>(params.s_q)};
+  uint64_t o_stride[2] = {
+      static_cast<uint64_t>(kDv) * sizeof(bf16_t), static_cast<uint64_t>(active_heads) * kDv * sizeof(bf16_t)};
+  uint32_t o_box_size[3] = {64, static_cast<uint32_t>(min(active_heads, kBlockH)), 1};
+  uint32_t o_elem_stride[3] = {1, 1, 1};
+  result = CUTLASS_CUDA_DRIVER_WRAPPER_CALL(cuTensorMapEncodeTiled)(
+      &tensor_map_o,
+      CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_BFLOAT16,
+      3,
+      params.out,
+      o_size,
+      o_stride,
+      o_box_size,
+      o_elem_stride,
+      CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+      CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B,
+      CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_L2_256B,
+      CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+  KU_ASSERT(result == CUresult::CUDA_SUCCESS);
+  TmaParams tma_params{tensor_map_q, tensor_map_kv, tensor_map_o, active_heads};
+
+  bool const use_long_producer = params.s_q >= kLongProducerMinSq;
+  auto kernel = use_long_producer
+                    ? &sparse_prefill_q8kv8_sm100_kernel<Dqk, StoreMeta, kLongThreads, kLongProducerWarps>
+                    : &sparse_prefill_q8kv8_sm100_kernel<Dqk, StoreMeta, kShortThreads, kShortProducerWarps>;
+  constexpr size_t smem_size = sizeof(SharedStorage<Dqk>);
+  KU_CUDA_CHECK(cudaFuncSetAttribute(kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+  int const grid = params.s_q * (params.h_q / kBlockH);
+  int const threads = use_long_producer ? kLongThreads : kShortThreads;
+  kernel<<<grid, threads, smem_size, params.stream>>>(params, tma_params);
+  KU_CHECK_KERNEL_LAUNCH();
+}
+
+}  // namespace sglang::sm100_q8kv8

--- a/python/sglang/kernels/ops/attention/dsv4/dequant_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsv4/dequant_k_cache.py
@@ -169,24 +169,30 @@ def cast_q_fp8_for_q8kv8_prefill(
     q: torch.Tensor,
     padded_num_heads: Optional[int] = None,
     out: Optional[torch.Tensor] = None,
+    q_scale: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor]:
     """Cast DeepSeek-V4 sparse-prefill Q to the Q8KV8 kernel format.
 
     The incoming Q is the model-produced BF16/FP16 tensor already shaped as
     ``(num_tokens, num_heads, 512)`` after removing the singleton MQA axis.
 
-    The SM90 kernel processes query heads in 64-head blocks. Tensor parallelism
-    commonly leaves fewer than 64 local heads, so the active heads are copied
-    into a zero-padded 64/128-head FP8 tensor.
+    The SM90 kernel processes query heads in 64-head blocks and therefore uses
+    a zero-padded FP8 tensor. The SM100 backend may keep only the active local
+    heads in storage; its 32-row TMA tile supplies zeros for out-of-bounds rows.
     """
     assert q.ndim == 3
     assert q.shape[-1] == DIM_NOPE + DIM_ROPE
+    assert q.is_contiguous()
 
     num_tokens, num_heads, head_dim = q.shape
     if padded_num_heads is None:
         padded_num_heads = q8kv8_padded_num_heads(num_heads)
 
-    if padded_num_heads not in (64, 128) or padded_num_heads < num_heads:
+    if (
+        padded_num_heads < num_heads
+        or padded_num_heads > 128
+        or (padded_num_heads != num_heads and padded_num_heads % 32 != 0)
+    ):
         raise ValueError(
             f"invalid padded_num_heads={padded_num_heads} for num_heads={num_heads}"
         )
@@ -194,7 +200,7 @@ def cast_q_fp8_for_q8kv8_prefill(
     expected_shape = (num_tokens, padded_num_heads, head_dim)
 
     if out is None:
-        q_fp8 = torch.zeros(
+        q_fp8 = torch.empty(
             expected_shape,
             dtype=fp8_dtype,
             device=q.device,
@@ -211,12 +217,51 @@ def cast_q_fp8_for_q8kv8_prefill(
                 f"{tuple(out.shape)}/{out.dtype}/{out.device}"
             )
         q_fp8 = out
-        if padded_num_heads > num_heads:
-            q_fp8[:, num_heads:].zero_()
 
-    q_fp8[:, :num_heads].copy_(q)
-    q_scale = torch.ones((), dtype=torch.float32, device=q.device)
+    total_output = num_tokens * padded_num_heads * head_dim
+    block_size = 8192
+    _cast_q_fp8_and_zero_pad_kernel[(triton.cdiv(total_output, block_size),)](
+        q,
+        q_fp8,
+        num_heads,
+        padded_num_heads,
+        head_dim,
+        total_output,
+        BLOCK_SIZE=block_size,
+        num_warps=8,
+    )
+
+    if q_scale is None:
+        q_scale = torch.ones((), dtype=torch.float32, device=q.device)
+    elif (
+        q_scale.numel() != 1
+        or q_scale.dtype != torch.float32
+        or q_scale.device != q.device
+    ):
+        raise ValueError("q_scale must be a float32 scalar on q's device")
     return q_fp8, q_scale
+
+
+@triton.jit
+def _cast_q_fp8_and_zero_pad_kernel(
+    q_ptr,
+    out_ptr,
+    num_heads,
+    padded_num_heads,
+    head_dim,
+    total_output,
+    BLOCK_SIZE: tl.constexpr,
+):
+    output_offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    output_mask = output_offsets < total_output
+    output_rows = output_offsets // head_dim
+    dim_offsets = output_offsets - output_rows * head_dim
+    head_offsets = output_rows % padded_num_heads
+    token_offsets = output_rows // padded_num_heads
+    active_mask = output_mask & (head_offsets < num_heads)
+    input_offsets = (token_offsets * num_heads + head_offsets) * head_dim + dim_offsets
+    values = tl.load(q_ptr + input_offsets, mask=active_mask, other=0.0)
+    tl.store(out_ptr + output_offsets, values, mask=output_mask)
 
 
 @triton.jit

--- a/python/sglang/kernels/ops/attention/sparse_mla_q8kv8_prefill_sm100.py
+++ b/python/sglang/kernels/ops/attention/sparse_mla_q8kv8_prefill_sm100.py
@@ -1,0 +1,378 @@
+"""Native FP8 sparse MLA prefill for NVIDIA Blackwell (SM100).
+
+This is the SM100 counterpart of ``sparse_mla_q8kv8_prefill_sm90``.  The
+kernel keeps Q and KV in E4M3 for both tensor-core matrix products while the
+online-softmax state and output accumulator stay in FP32:
+
+* QK: E4M3 x E4M3 -> FP32
+* PV: scaled E4M3 probabilities x E4M3 values -> FP32
+
+The probability tile is multiplied by ``P_FP8_SCALE`` before its E4M3 cast
+and the dot result is divided by the same value.  This preserves small
+probabilities at the large top-k values used by DeepSeek-V4-Flash without
+changing the represented attention result.
+"""
+
+from __future__ import annotations
+
+import os
+
+import torch
+import triton
+import triton.language as tl
+
+_LOG2E = tl.constexpr(1.4426950408889634)
+_P_FP8_SCALE = tl.constexpr(256.0)
+
+
+@triton.jit
+def _q8kv8_load_kv_tile(
+    kv,
+    token_ids,
+    valid,
+    offs_d,
+    d_qk: tl.constexpr,
+):
+    ptrs = kv + token_ids[:, None] * d_qk + offs_d[None, :]
+    return tl.load(ptrs, mask=valid[:, None], other=0.0)
+
+
+@triton.jit
+def _q8kv8_sparse_prefill_kernel(
+    q,
+    kv,
+    indices,
+    q_scale,
+    kv_scale,
+    attn_sink,
+    topk_length,
+    out,
+    max_logits,
+    lse,
+    s_kv,
+    h_q: tl.constexpr,
+    d_qk: tl.constexpr,
+    topk,
+    sm_scale,
+    HAVE_ATTN_SINK: tl.constexpr,
+    HAVE_TOPK_LENGTH: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    q_idx = tl.program_id(0)
+    h_block = tl.program_id(1)
+
+    offs_h = h_block * BLOCK_H + tl.arange(0, BLOCK_H)
+    h_mask = offs_h < h_q
+    offs_d = tl.arange(0, 64)
+
+    q_base = q + q_idx * h_q * d_qk + offs_h[:, None] * d_qk
+
+    m_i = tl.full([BLOCK_H], float("-inf"), tl.float32)
+    l_i = tl.zeros([BLOCK_H], tl.float32)
+    if d_qk == 512:
+        acc = tl.zeros([BLOCK_H, 512], tl.float32)
+    else:
+        acc0 = tl.zeros([BLOCK_H, 64], tl.float32)
+        acc1 = tl.zeros([BLOCK_H, 64], tl.float32)
+        acc2 = tl.zeros([BLOCK_H, 64], tl.float32)
+        acc3 = tl.zeros([BLOCK_H, 64], tl.float32)
+        acc4 = tl.zeros([BLOCK_H, 64], tl.float32)
+        acc5 = tl.zeros([BLOCK_H, 64], tl.float32)
+        acc6 = tl.zeros([BLOCK_H, 64], tl.float32)
+        acc7 = tl.zeros([BLOCK_H, 64], tl.float32)
+
+    qk_scale = tl.load(q_scale) * tl.load(kv_scale) * sm_scale
+    valid_topk = tl.load(topk_length + q_idx) if HAVE_TOPK_LENGTH else topk
+
+    for start_n in range(0, topk, BLOCK_N):
+        offs_n = start_n + tl.arange(0, BLOCK_N)
+        token_ids = tl.load(
+            indices + q_idx * topk + offs_n,
+            mask=offs_n < topk,
+            other=-1,
+        )
+        valid = (offs_n < valid_topk) & (token_ids >= 0) & (token_ids < s_kv)
+        safe_token_ids = tl.where(valid, token_ids, 0)
+
+        if d_qk == 512:
+            offs_d_full = tl.arange(0, 512)
+            q_full = tl.load(
+                q_base + offs_d_full[None, :],
+                mask=h_mask[:, None],
+                other=0.0,
+            )
+            kv_full = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d_full, d_qk)
+            scores = tl.dot(q_full, tl.trans(kv_full), out_dtype=tl.float32)
+        else:
+            scores = tl.zeros([BLOCK_H, BLOCK_N], tl.float32)
+            q0 = tl.load(
+                q_base + (offs_d + 0)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k0 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 0, d_qk)
+            scores += tl.dot(q0, tl.trans(k0), out_dtype=tl.float32)
+            q1 = tl.load(
+                q_base + (offs_d + 64)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k1 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 64, d_qk)
+            scores += tl.dot(q1, tl.trans(k1), out_dtype=tl.float32)
+            q2 = tl.load(
+                q_base + (offs_d + 128)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k2 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 128, d_qk)
+            scores += tl.dot(q2, tl.trans(k2), out_dtype=tl.float32)
+            q3 = tl.load(
+                q_base + (offs_d + 192)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k3 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 192, d_qk)
+            scores += tl.dot(q3, tl.trans(k3), out_dtype=tl.float32)
+            q4 = tl.load(
+                q_base + (offs_d + 256)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k4 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 256, d_qk)
+            scores += tl.dot(q4, tl.trans(k4), out_dtype=tl.float32)
+            q5 = tl.load(
+                q_base + (offs_d + 320)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k5 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 320, d_qk)
+            scores += tl.dot(q5, tl.trans(k5), out_dtype=tl.float32)
+            q6 = tl.load(
+                q_base + (offs_d + 384)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k6 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 384, d_qk)
+            scores += tl.dot(q6, tl.trans(k6), out_dtype=tl.float32)
+            q7 = tl.load(
+                q_base + (offs_d + 448)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k7 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 448, d_qk)
+            scores += tl.dot(q7, tl.trans(k7), out_dtype=tl.float32)
+            q8 = tl.load(
+                q_base + (offs_d + 512)[None, :], mask=h_mask[:, None], other=0.0
+            )
+            k8 = _q8kv8_load_kv_tile(kv, safe_token_ids, valid, offs_d + 512, d_qk)
+            scores += tl.dot(q8, tl.trans(k8), out_dtype=tl.float32)
+
+        scores *= qk_scale
+        scores = tl.where(h_mask[:, None] & valid[None, :], scores, float("-inf"))
+
+        block_max = tl.max(scores, axis=1)
+        block_max = tl.where(block_max == float("-inf"), -1.0e30, block_max)
+        m_new = tl.maximum(m_i, block_max)
+        alpha = tl.where(
+            m_i == float("-inf"),
+            0.0,
+            tl.math.exp2((m_i - m_new) * _LOG2E),
+        )
+        p = tl.where(
+            valid[None, :] & h_mask[:, None],
+            tl.math.exp2((scores - m_new[:, None]) * _LOG2E),
+            0.0,
+        )
+        l_i = l_i * alpha + tl.sum(p, axis=1)
+
+        # Scaling before the E4M3 cast avoids losing probabilities around
+        # 1/topk while keeping the largest possible value (256) representable.
+        p_fp8 = (p * _P_FP8_SCALE).to(tl.float8e4nv)
+        pv_scale = 1.0 / _P_FP8_SCALE
+
+        if d_qk == 512:
+            acc = (
+                acc * alpha[:, None]
+                + tl.dot(p_fp8, kv_full, out_dtype=tl.float32) * pv_scale
+            )
+        else:
+            acc0 = (
+                acc0 * alpha[:, None]
+                + tl.dot(p_fp8, k0, out_dtype=tl.float32) * pv_scale
+            )
+            acc1 = (
+                acc1 * alpha[:, None]
+                + tl.dot(p_fp8, k1, out_dtype=tl.float32) * pv_scale
+            )
+            acc2 = (
+                acc2 * alpha[:, None]
+                + tl.dot(p_fp8, k2, out_dtype=tl.float32) * pv_scale
+            )
+            acc3 = (
+                acc3 * alpha[:, None]
+                + tl.dot(p_fp8, k3, out_dtype=tl.float32) * pv_scale
+            )
+            acc4 = (
+                acc4 * alpha[:, None]
+                + tl.dot(p_fp8, k4, out_dtype=tl.float32) * pv_scale
+            )
+            acc5 = (
+                acc5 * alpha[:, None]
+                + tl.dot(p_fp8, k5, out_dtype=tl.float32) * pv_scale
+            )
+            acc6 = (
+                acc6 * alpha[:, None]
+                + tl.dot(p_fp8, k6, out_dtype=tl.float32) * pv_scale
+            )
+            acc7 = (
+                acc7 * alpha[:, None]
+                + tl.dot(p_fp8, k7, out_dtype=tl.float32) * pv_scale
+            )
+        m_i = m_new
+
+    denominator = l_i
+    if HAVE_ATTN_SINK:
+        sink = tl.load(attn_sink + offs_h, mask=h_mask, other=float("-inf"))
+        denominator += tl.math.exp2((sink - m_i) * _LOG2E)
+
+    nonempty = l_i > 0.0
+    inv_denom = tl.where(denominator > 0.0, 1.0 / denominator, 0.0)
+    value_scale = tl.load(kv_scale) * inv_denom
+
+    out_base = out + q_idx * h_q * 512 + offs_h[:, None] * 512
+    if d_qk == 512:
+        tl.store(
+            out_base + tl.arange(0, 512)[None, :],
+            acc * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+    else:
+        tl.store(
+            out_base + (offs_d + 0)[None, :],
+            acc0 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+        tl.store(
+            out_base + (offs_d + 64)[None, :],
+            acc1 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+        tl.store(
+            out_base + (offs_d + 128)[None, :],
+            acc2 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+        tl.store(
+            out_base + (offs_d + 192)[None, :],
+            acc3 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+        tl.store(
+            out_base + (offs_d + 256)[None, :],
+            acc4 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+        tl.store(
+            out_base + (offs_d + 320)[None, :],
+            acc5 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+        tl.store(
+            out_base + (offs_d + 384)[None, :],
+            acc6 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+        tl.store(
+            out_base + (offs_d + 448)[None, :],
+            acc7 * value_scale[:, None],
+            mask=h_mask[:, None],
+        )
+
+    meta_ptrs = q_idx * h_q + offs_h
+    tl.store(max_logits + meta_ptrs, tl.where(nonempty, m_i, -1.0e30), mask=h_mask)
+    tl.store(
+        lse + meta_ptrs,
+        tl.where(nonempty, m_i + tl.log(l_i), float("-inf")),
+        mask=h_mask,
+    )
+
+
+def sparse_mla_q8kv8_prefill_fwd_sm100(
+    *,
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    q_scale: torch.Tensor,
+    kv_scale: torch.Tensor,
+    attn_sink: torch.Tensor | None,
+    topk_length: torch.Tensor | None,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+) -> None:
+    """Launch the validated SM100 implementation into caller-owned buffers."""
+    s_q, h_q, d_qk = q.shape
+    s_kv = kv.shape[0]
+    topk = indices.shape[-1]
+    # The production path uses the dedicated CUDA/tcgen05 kernel. Keep the
+    # Triton implementation below as a bring-up fallback for unpadded head
+    # counts while the CUDA kernel intentionally matches FlashMLA's head64
+    # specialization.
+    if h_q % 32 == 0 and os.environ.get("SGLANG_SM100_Q8KV8_TRITON", "0") != "1":
+        from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm100_cuda import (
+            sparse_mla_q8kv8_prefill_fwd_sm100_cuda,
+        )
+
+        sparse_mla_q8kv8_prefill_fwd_sm100_cuda(
+            q=q,
+            kv=kv,
+            indices=indices,
+            sm_scale=sm_scale,
+            q_scale=q_scale,
+            kv_scale=kv_scale,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            out=out,
+            max_logits=max_logits,
+            lse=lse,
+        )
+        return
+    # Unlike the SM90 kernel, SM100 does not require TP-local Q heads to be
+    # padded to 64.  DeepSeek-V4-Flash TP8 has only 8 active heads per rank;
+    # using the smallest legal 32-row tcgen05 tile avoids half of the redundant
+    # work of the SM90-compatible 64-row shape.
+    if d_qk == 512:
+        # Environment overrides are intentionally limited to tile-selection
+        # knobs so B200 experiments can compare compiler specializations
+        # without editing kernel math between runs. Invalid combinations fail
+        # during compilation instead of silently changing semantics.
+        block_h = int(os.environ.get("SGLANG_SM100_Q8KV8_BLOCK_H", "32"))
+        block_n = int(os.environ.get("SGLANG_SM100_Q8KV8_BLOCK_N", "256"))
+        num_warps = int(os.environ.get("SGLANG_SM100_Q8KV8_NUM_WARPS", "8"))
+        num_stages = int(os.environ.get("SGLANG_SM100_Q8KV8_NUM_STAGES", "1"))
+        if block_h not in (8, 16, 32, 64) or block_n not in (64, 128, 256):
+            raise ValueError(
+                "SM100 Q8KV8 tile overrides require BLOCK_H in {8,16,32,64} and "
+                f"BLOCK_N in {{64,128,256}}, got {block_h}/{block_n}"
+            )
+    else:
+        block_h = 32
+        block_n = 64
+        num_warps = 8
+        num_stages = 2
+    grid = (s_q, triton.cdiv(h_q, block_h))
+
+    # Optional pointers are represented by any valid CUDA pointer when their
+    # corresponding constexpr flag is false; the kernel will not dereference
+    # them in that specialization.
+    sink_arg = attn_sink if attn_sink is not None else max_logits
+    length_arg = topk_length if topk_length is not None else indices
+    _q8kv8_sparse_prefill_kernel[grid](
+        q,
+        kv,
+        indices,
+        q_scale,
+        kv_scale,
+        sink_arg,
+        length_arg,
+        out,
+        max_logits,
+        lse,
+        s_kv,
+        h_q=h_q,
+        d_qk=d_qk,
+        topk=topk,
+        sm_scale=sm_scale,
+        HAVE_ATTN_SINK=attn_sink is not None,
+        HAVE_TOPK_LENGTH=topk_length is not None,
+        BLOCK_H=block_h,
+        BLOCK_N=block_n,
+        num_warps=num_warps,
+        num_stages=num_stages,
+    )

--- a/python/sglang/kernels/ops/attention/sparse_mla_q8kv8_prefill_sm100_cuda.py
+++ b/python/sglang/kernels/ops/attention/sparse_mla_q8kv8_prefill_sm100_cuda.py
@@ -1,0 +1,122 @@
+"""CUDA/tcgen05 launcher for SM100 Q8KV8 sparse MLA prefill."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+def _cuda_flags() -> list[str]:
+    return [
+        "-O3",
+        "-DNDEBUG",
+        "-DCUTE_USE_PACKED_TUPLE=1",
+        "-DCUTLASS_ENABLE_TENSOR_CORE_MMA=1",
+        "--use_fast_math",
+        "--threads=4",
+    ]
+
+
+@cache_once
+def _jit_module() -> Module:
+    return load_jit(
+        "sparse_mla_q8kv8_prefill_sm100_cuda",
+        cuda_files=["sparse_mla_q8kv8_prefill_sm100/entry.cuh"],
+        cuda_wrappers=[
+            ("dispatch", "sparse_prefill_q8kv8_dispatch"),
+            ("dispatch_full", "sparse_prefill_q8kv8_dispatch_full"),
+            ("dispatch_topk_length", "sparse_prefill_q8kv8_dispatch_topk_length"),
+            ("dispatch_full_active", "sparse_prefill_q8kv8_dispatch_full_active"),
+        ],
+        extra_cuda_cflags=_cuda_flags(),
+        extra_dependencies=["cutlass"],
+    )
+
+
+_entries: tuple | None = None
+
+
+def _get_entries() -> tuple:
+    global _entries
+    if _entries is None:
+        module = _jit_module()
+        _entries = (
+            module["dispatch"],
+            module["dispatch_full"],
+            module["dispatch_topk_length"],
+            module["dispatch_full_active"],
+        )
+    return _entries
+
+
+def sparse_mla_q8kv8_prefill_fwd_sm100_cuda(
+    *,
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    q_scale: torch.Tensor,
+    kv_scale: torch.Tensor,
+    attn_sink: torch.Tensor | None,
+    topk_length: torch.Tensor | None,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+    active_heads: int | None = None,
+) -> None:
+    """Launch the caller-buffer SM100 CUDA implementation."""
+    s_q, q_storage_heads, d_qk = q.shape
+    h_q = (
+        ((active_heads + 31) // 32) * 32
+        if active_heads is not None
+        else q_storage_heads
+    )
+    s_kv, h_kv, _ = kv.shape
+    topk = indices.shape[-1]
+    stream = torch._C._cuda_getCurrentRawStream(q.device.index)
+    common = (
+        q,
+        kv,
+        indices,
+        q_scale,
+        kv_scale,
+    )
+    tail = (
+        out,
+        max_logits,
+        lse,
+        s_q,
+        s_kv,
+        h_q,
+        h_kv,
+        d_qk,
+        512,
+        topk,
+        sm_scale,
+        stream,
+    )
+    dispatch, dispatch_full, dispatch_topk_length, dispatch_full_active = _get_entries()
+    if active_heads is not None:
+        assert attn_sink is not None and topk_length is not None
+        dispatch_full_active(
+            *common,
+            attn_sink,
+            topk_length,
+            *tail[:-2],
+            active_heads,
+            *tail[-2:],
+        )
+        return
+    if attn_sink is not None:
+        assert topk_length is not None
+        dispatch_full(*common, attn_sink, topk_length, *tail)
+    elif topk_length is not None:
+        dispatch_topk_length(*common, topk_length, *tail)
+    else:
+        dispatch(*common, *tail)

--- a/python/sglang/kernels/ops/attention/sparse_mla_q8kv8_prefill_sm90.py
+++ b/python/sglang/kernels/ops/attention/sparse_mla_q8kv8_prefill_sm90.py
@@ -1,11 +1,13 @@
-"""JIT-compiled Q8KV8 sparse prefill attention kernel for SM90 (Hopper/H200).
+"""Q8KV8 sparse prefill attention with SM90 and SM100 dispatch.
 
 Uses native FP8 GMMA instructions via CUTLASS/CUTE for MLA attention
-with FP8 quantized Q and KV tensors.
+with FP8 quantized Q and KV tensors on SM90.  The public entry point dispatches
+to the native FP8 Triton implementation on SM100.
 """
 
 from __future__ import annotations
 
+import os
 from typing import TYPE_CHECKING, Optional
 
 import torch
@@ -118,6 +120,43 @@ def _check_out_buffer(
         raise ValueError(f"{name} must be on device {device}, got {t.device}")
     if not t.is_contiguous():
         raise ValueError(f"{name} must be contiguous")
+
+
+def _sparse_mla_q8kv8_prefill_fwd_sm100_trusted(
+    *,
+    q: torch.Tensor,
+    kv: torch.Tensor,
+    indices: torch.Tensor,
+    sm_scale: float,
+    q_scale: torch.Tensor,
+    kv_scale: torch.Tensor,
+    attn_sink: torch.Tensor,
+    topk_length: torch.Tensor,
+    out: torch.Tensor,
+    max_logits: torch.Tensor,
+    lse: torch.Tensor,
+    active_heads: int,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Launch SM100 CUDA for backend-owned, already-validated tensors."""
+    from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm100_cuda import (
+        sparse_mla_q8kv8_prefill_fwd_sm100_cuda,
+    )
+
+    sparse_mla_q8kv8_prefill_fwd_sm100_cuda(
+        q=q,
+        kv=kv,
+        indices=indices,
+        sm_scale=sm_scale,
+        q_scale=q_scale,
+        kv_scale=kv_scale,
+        attn_sink=attn_sink,
+        topk_length=topk_length,
+        out=out,
+        max_logits=max_logits,
+        lse=lse,
+        active_heads=active_heads,
+    )
+    return out, max_logits, lse
 
 
 # Internal custom-op wrappers so the JIT kernel calls participate in
@@ -281,7 +320,7 @@ def sparse_mla_q8kv8_prefill_fwd(
     max_logits: Optional[torch.Tensor] = None,  # [s_q, h_q], float32
     lse: Optional[torch.Tensor] = None,  # [s_q, h_q], float32
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-    """Run Q8KV8 (FP8) sparse prefill attention on SM90.
+    """Run Q8KV8 (FP8) sparse prefill attention on SM90 or SM100.
 
     The kernel writes into three output tensors. By default fresh tensors
     are allocated and returned; callers that want to reuse buffers may pass
@@ -303,7 +342,7 @@ def sparse_mla_q8kv8_prefill_fwd(
         )
     if indices.ndim != 3:
         raise ValueError(
-            "indices must have shape (s_q, h_kv, topk), " f"got {tuple(indices.shape)}"
+            f"indices must have shape (s_q, h_kv, topk), got {tuple(indices.shape)}"
         )
 
     s_q, h_q, d_qk = q.shape
@@ -327,6 +366,13 @@ def sparse_mla_q8kv8_prefill_fwd(
             f"indices must be on q's device {device}, got {indices.device}"
         )
 
+    device_major = torch.cuda.get_device_capability(device)[0]
+    if device_major not in (9, 10):
+        raise ValueError(
+            "sparse_mla_q8kv8_prefill_fwd requires an SM90 or SM100 CUDA GPU, "
+            f"got compute capability {torch.cuda.get_device_capability(device)}"
+        )
+
     if q.dtype != torch.float8_e4m3fn:
         raise ValueError(f"q must be torch.float8_e4m3fn, got {q.dtype}")
     if kv.dtype != torch.float8_e4m3fn:
@@ -342,14 +388,13 @@ def sparse_mla_q8kv8_prefill_fwd(
     if kv_d_qk != d_qk:
         raise ValueError(f"kv d_qk must match q d_qk={d_qk}, got {kv_d_qk}")
 
-    # The CUDA implementation uses B_H=64 and launches h_q / B_H CTAs.
-    # Reject unpadded TP-local head counts instead of launching zero CTAs and
-    # returning uninitialized outputs, which can appear to callers as a hang or
-    # a later collective failure.
-    if h_q == 0 or h_q % 64 != 0:
+    # The SM90 CUDA implementation uses B_H=64 and launches h_q / B_H CTAs.
+    # SM100 specializes its Triton tile to the active TP-local head count and
+    # therefore deliberately accepts unpadded head counts (notably TP8's 8).
+    if h_q == 0 or (device_major == 9 and h_q % 64 != 0):
         raise ValueError(
-            "sparse_mla_q8kv8_prefill_fwd requires h_q padded to a positive "
-            f"multiple of 64, got {h_q}"
+            "SM90 sparse_mla_q8kv8_prefill_fwd requires h_q padded to a "
+            f"positive multiple of 64, got {h_q}"
         )
 
     if h_kv != 1:
@@ -362,8 +407,7 @@ def sparse_mla_q8kv8_prefill_fwd(
 
     if indices.shape[:2] != (s_q, h_kv):
         raise ValueError(
-            "indices must have shape "
-            f"({s_q}, {h_kv}, topk), got {tuple(indices.shape)}"
+            f"indices must have shape ({s_q}, {h_kv}, topk), got {tuple(indices.shape)}"
         )
 
     if indices.dtype != torch.int32:
@@ -385,14 +429,18 @@ def sparse_mla_q8kv8_prefill_fwd(
             raise ValueError("topk_length must be a CUDA tensor")
         if topk_length.device != device:
             raise ValueError(
-                "topk_length must be on q's device "
-                f"{device}, got {topk_length.device}"
+                f"topk_length must be on q's device {device}, got {topk_length.device}"
             )
         if not topk_length.is_contiguous():
             raise ValueError("topk_length must be contiguous")
-        if torch.any(topk_length < 0).item() or torch.any(topk_length > topk).item():
+        # Value validation synchronizes the CUDA stream twice through .item().
+        # Production metadata is generated by trusted in-tree kernels, so keep
+        # the synchronization-heavy check behind an explicit diagnostic flag.
+        if os.environ.get("SGLANG_Q8KV8_VALIDATE_TOPK_LENGTH", "0") == "1" and (
+            torch.any(topk_length < 0).item() or torch.any(topk_length > topk).item()
+        ):
             raise ValueError(
-                "topk_length values must satisfy " f"0 <= topk_length <= topk ({topk})"
+                f"topk_length values must satisfy 0 <= topk_length <= topk ({topk})"
             )
 
     if d_v != 512:
@@ -459,6 +507,25 @@ def sparse_mla_q8kv8_prefill_fwd(
     if out_ptr == ml_ptr or out_ptr == lse_ptr or ml_ptr == lse_ptr:
         raise ValueError("out, max_logits and lse must not alias each other")
 
+    if device_major == 10:
+        from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm100 import (
+            sparse_mla_q8kv8_prefill_fwd_sm100,
+        )
+
+        sparse_mla_q8kv8_prefill_fwd_sm100(
+            q=q,
+            kv=kv,
+            indices=indices,
+            sm_scale=sm_scale,
+            q_scale=q_scale,
+            kv_scale=kv_scale,
+            attn_sink=attn_sink,
+            topk_length=topk_length,
+            out=out,
+            max_logits=max_logits,
+            lse=lse,
+        )
+        return out, max_logits, lse
     cuda_stream = _get_current_stream_raw(q.device.index)
 
     if attn_sink is not None and topk_length is not None:

--- a/python/sglang/srt/layers/attention/deepseek_v4_backend.py
+++ b/python/sglang/srt/layers/attention/deepseek_v4_backend.py
@@ -78,7 +78,13 @@ from sglang.srt.speculative.ragged_verify import (
     read_ragged_verify_mode,
     resolve_ragged_verify_layout,
 )
-from sglang.srt.utils import ceil_align, is_cuda, is_sm90_supported, is_xpu
+from sglang.srt.utils import (
+    ceil_align,
+    is_cuda,
+    is_sm90_supported,
+    is_sm100_supported,
+    is_xpu,
+)
 from sglang.srt.utils.common import is_sm120_supported
 
 if TYPE_CHECKING:
@@ -564,9 +570,10 @@ class DeepseekV4AttnBackend(
             model_runner.server_args, "dsv4_prefill_backend", "auto"
         )
         if use_dsv4_q8kv8_sparse_prefill(self.dsv4_prefill_backend):
-            if not is_sm90_supported():
+            if not (is_sm90_supported() or is_sm100_supported()):
                 raise ValueError(
-                    "DeepSeek-V4 flashmla_sparse_q8 prefill requires SM90 CUDA GPUs."
+                    "DeepSeek-V4 flashmla_sparse_q8 prefill requires an SM90 "
+                    "or SM100 CUDA GPU."
                 )
             if self.head_dim_v != 512:
                 raise ValueError(
@@ -1885,21 +1892,27 @@ class DeepseekV4AttnBackend(
         self,
         q: torch.Tensor,
         attn_sink: torch.Tensor,
-    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int]:
-        """Pad TP-local heads to the SM90 kernel's 64-head CTA granularity."""
+        layer_id: int,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, int, int]:
+        """Prepare compact FP8 Q storage and architecture-specific head tiles."""
         num_tokens, num_heads, head_dim = q.shape
-        padded_heads = q8kv8_padded_num_heads(num_heads)
+        kernel_heads = (
+            ceil_align(num_heads, 32)
+            if is_sm100_supported()
+            else q8kv8_padded_num_heads(num_heads)
+        )
+        q_storage_heads = num_heads if is_sm100_supported() else kernel_heads
 
         qpad = getattr(self, "_q8kv8_qpad_buf", None)
         if (
             qpad is None
             or qpad.shape[0] < num_tokens
-            or qpad.shape[1] != padded_heads
+            or qpad.shape[1] != q_storage_heads
             or qpad.shape[2] != head_dim
             or qpad.device != q.device
         ):
             qpad = torch.empty(
-                (num_tokens, padded_heads, head_dim),
+                (num_tokens, q_storage_heads, head_dim),
                 dtype=fp8_dtype,
                 device=q.device,
             )
@@ -1907,31 +1920,42 @@ class DeepseekV4AttnBackend(
 
         qpad = qpad[:num_tokens]
 
-        q_fp8, _ = cast_q_fp8_for_q8kv8_prefill(
-            q,
-            padded_num_heads=padded_heads,
-            out=qpad,
-        )
-
-        sink_pad = getattr(self, "_q8kv8_attn_sink_pad", None)
-        if (
-            sink_pad is None
-            or sink_pad.shape != (padded_heads,)
-            or sink_pad.device != q.device
-        ):
-            sink_pad = torch.zeros(padded_heads, dtype=torch.float32, device=q.device)
-            self._q8kv8_attn_sink_pad = sink_pad
-
-        sink_pad[:num_heads].copy_(attn_sink.reshape(-1)[:num_heads])
-        if padded_heads > num_heads:
-            sink_pad[num_heads:].zero_()
-
         scale = getattr(self, "_q8kv8_identity_scale", None)
         if scale is None or scale.device != q.device:
             scale = torch.ones((), dtype=torch.float32, device=q.device)
             self._q8kv8_identity_scale = scale
 
-        return q_fp8, sink_pad, scale, num_heads
+        q_kernel, _ = cast_q_fp8_for_q8kv8_prefill(
+            q,
+            padded_num_heads=q_storage_heads,
+            out=qpad,
+            q_scale=scale,
+        )
+
+        sink_cache = getattr(self, "_q8kv8_attn_sink_pad_cache", None)
+        if sink_cache is None:
+            sink_cache = {}
+            self._q8kv8_attn_sink_pad_cache = sink_cache
+        sink_entry = sink_cache.get(layer_id)
+        sink_version = getattr(attn_sink, "_version", 0)
+        if (
+            sink_entry is None
+            or sink_entry[0].shape != (kernel_heads,)
+            or sink_entry[0].device != q.device
+            or sink_entry[1] != attn_sink.data_ptr()
+            or sink_entry[2] != sink_version
+        ):
+            sink_pad = torch.zeros(kernel_heads, dtype=torch.float32, device=q.device)
+            sink_pad[:num_heads].copy_(attn_sink.reshape(-1)[:num_heads])
+            sink_cache[layer_id] = (
+                sink_pad,
+                attn_sink.data_ptr(),
+                sink_version,
+            )
+        else:
+            sink_pad = sink_entry[0]
+
+        return q_kernel, sink_pad, scale, num_heads, kernel_heads
 
     def _forward_prefill_sparse_q8kv8(
         self,
@@ -1946,15 +1970,12 @@ class DeepseekV4AttnBackend(
         """Experimental DeepSeek-V4 sparse prefill path using Q8KV8 kernels.
 
         This mirrors ``_forward_prefill_sparse``'s cache/index construction, but
-        writes the gathered KV workspace as FP8 and calls the SM90 Q8KV8 sparse
-        prefill kernel. The path is selected by ``--dsv4-prefill-backend
-        flashmla_sparse_q8``; ``SGLANG_DSV4_Q8KV8_PREFILL`` remains as a debug
-        override for focused runtime validation.
+        writes the gathered KV workspace as FP8 and calls the architecture-
+        specific SM90/SM100 Q8KV8 sparse prefill kernel. The path is selected
+        by ``--dsv4-prefill-backend flashmla_sparse_q8``;
+        ``SGLANG_DSV4_Q8KV8_PREFILL`` remains as a debug override for focused
+        runtime validation.
         """
-
-        from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
-            sparse_mla_q8kv8_prefill_fwd,
-        )
 
         q_flat = q.squeeze(1)
         if q_flat.ndim != 3:
@@ -1968,18 +1989,20 @@ class DeepseekV4AttnBackend(
                 f"{q_flat.shape[1]} local heads"
             )
 
-        q_fp8, attn_sink_pad, identity_scale, active_heads = (
-            self._prepare_q8kv8_q_and_sink(q_flat, attn_sink)
+        q_kernel, attn_sink_pad, identity_scale, active_heads, kernel_heads = (
+            self._prepare_q8kv8_q_and_sink(q_flat, attn_sink, layer_id)
         )
 
         if not getattr(self, "_q8kv8_sparse_prefill_log_emitted", False):
             logger.info(
                 "DSV4_Q8KV8_SPARSE_PREFILL_HIT layer_id=%s "
-                "compress_ratio=%s q_shape=%s padded_heads=%s d_v=%s",
+                "compress_ratio=%s q_shape=%s q_storage_heads=%s "
+                "kernel_heads=%s d_v=%s",
                 layer_id,
                 compress_ratio,
                 tuple(q_flat.shape),
-                q_fp8.shape[1],
+                q_kernel.shape[1],
+                kernel_heads,
                 self.head_dim_v,
             )
             self._q8kv8_sparse_prefill_log_emitted = True
@@ -2017,8 +2040,7 @@ class DeepseekV4AttnBackend(
 
         if compress_ratio == 0:
             workspace = self.sparse_prefill_workspace.get(
-                cache.swa_token_ids.shape[0] + 1,
-                dtype=fp8_dtype,
+                cache.swa_token_ids.shape[0], dtype=fp8_dtype
             )
             combined_indices = cache.c0_combined_indices
             combined_lens = cache.c0_combined_lens
@@ -2048,8 +2070,7 @@ class DeepseekV4AttnBackend(
 
             n_compressed = flat_token_ids.shape[0]
             workspace = self.sparse_prefill_workspace.get(
-                n_compressed + cache.swa_token_ids.shape[0] + 1,
-                dtype=fp8_dtype,
+                n_compressed + cache.swa_token_ids.shape[0], dtype=fp8_dtype
             )
             compressed_slice = workspace[:n_compressed]
             swa_slice = workspace[n_compressed:]
@@ -2066,30 +2087,71 @@ class DeepseekV4AttnBackend(
             token_to_kv_pool.get_swa_key_buffer_radix(layer_id),
             cache.swa_token_ids,
             page_size=cache.swa_page_size,
-            extra_rows=1,
             out=swa_slice,
         )
 
-        sentinel_row = workspace.shape[0] - 1
-        q8_indices = torch.where(
-            combined_indices < 0,
-            torch.full_like(combined_indices, sentinel_row),
-            combined_indices,
-        )
+        output_buffers = getattr(self, "_q8kv8_output_buffers", None)
+        required_out_shape = (q_kernel.shape[0], active_heads, self.head_dim_v)
+        required_meta_shape = (q_kernel.shape[0], kernel_heads)
+        if (
+            output_buffers is None
+            or output_buffers[0].shape[0] < required_out_shape[0]
+            or output_buffers[0].shape[1:] != required_out_shape[1:]
+            or output_buffers[1].shape[0] < required_meta_shape[0]
+            or output_buffers[1].shape[1:] != required_meta_shape[1:]
+            or output_buffers[0].device != q_kernel.device
+        ):
+            output_buffers = (
+                torch.empty(
+                    required_out_shape, dtype=torch.bfloat16, device=q_kernel.device
+                ),
+                torch.empty(
+                    required_meta_shape, dtype=torch.float32, device=q_kernel.device
+                ),
+                torch.empty(
+                    required_meta_shape, dtype=torch.float32, device=q_kernel.device
+                ),
+            )
+            self._q8kv8_output_buffers = output_buffers
+        out_buf = output_buffers[0][: required_out_shape[0]]
+        max_logits_buf = output_buffers[1][: required_meta_shape[0]]
+        lse_buf = output_buffers[2][: required_meta_shape[0]]
 
-        o, _, _ = sparse_mla_q8kv8_prefill_fwd(
-            q=q_fp8,
+        kernel_args = dict(
+            q=q_kernel,
             kv=workspace,
-            indices=q8_indices.unsqueeze(1),
+            # Both architecture kernels mask negative/past-length indices
+            # internally. Keeping the cache's native indices removes an
+            # elementwise torch.where launch and the workspace sentinel row.
+            indices=combined_indices.unsqueeze(1),
             sm_scale=self.softmax_scale,
             q_scale=identity_scale,
             kv_scale=identity_scale,
-            d_v=self.head_dim_v,
             attn_sink=attn_sink_pad,
             topk_length=combined_lens,
+            out=out_buf,
+            max_logits=max_logits_buf,
+            lse=lse_buf,
         )
+        if is_sm100_supported():
+            from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
+                _sparse_mla_q8kv8_prefill_fwd_sm100_trusted,
+            )
 
-        return o[:, :active_heads]
+            o, _, _ = _sparse_mla_q8kv8_prefill_fwd_sm100_trusted(
+                **kernel_args, active_heads=active_heads
+            )
+        else:
+            from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
+                sparse_mla_q8kv8_prefill_fwd,
+            )
+
+            o, _, _ = sparse_mla_q8kv8_prefill_fwd(
+                **kernel_args,
+                d_v=self.head_dim_v,
+            )
+
+        return o
 
     def expand_prefill_casually(
         self,

--- a/test/registered/kernels/benchmark/attention/bench_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/kernels/benchmark/attention/bench_sparse_mla_q8kv8_prefill_sm90.py
@@ -10,7 +10,7 @@ from sglang.kernels.jit.benchmark.utils import run_benchmark_no_cudagraph
 from sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90 import (
     sparse_mla_q8kv8_prefill_fwd,
 )
-from sglang.srt.utils import is_sm90_supported
+from sglang.srt.utils import is_sm90_supported, is_sm100_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.utils import is_in_ci
 
@@ -58,8 +58,8 @@ if HAS_Q16_FLASHMLA:
     STYLES.insert(0, ("orange", "--"))
 
 
-def _sm90_available() -> bool:
-    return is_sm90_supported()
+def _q8kv8_available() -> bool:
+    return is_sm90_supported() or is_sm100_supported()
 
 
 def _make_indices(s_q: int, s_kv: int, topk: int, d_qk: int) -> torch.Tensor:
@@ -115,7 +115,7 @@ def _make_q8_inputs(s_q: int, s_kv: int, h_q: int, d_qk: int, topk: int):
         line_names=LINE_NAMES,
         styles=STYLES,
         ylabel="us",
-        plot_name="sparse-mla-q8kv8-prefill-sm90-performance",
+        plot_name="sparse-mla-q8kv8-prefill-performance",
         args={},
     )
 )
@@ -133,8 +133,10 @@ def bench_sparse_mla_q8kv8_prefill_sm90(
             return flash_mla_sparse_fwd(q, kv, indices, sm_scale, D_V)
 
     elif provider == "q8_fp8_jit":
-        if not _sm90_available():
-            raise RuntimeError("Q8KV8 sparse prefill benchmark requires SM90 CUDA")
+        if not _q8kv8_available():
+            raise RuntimeError(
+                "Q8KV8 sparse prefill benchmark requires SM90 or SM100 CUDA"
+            )
         q, kv, indices, sm_scale, q_scale, kv_scale = _make_q8_inputs(
             s_q, s_kv, h_q, d_qk, topk
         )

--- a/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
+++ b/test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
@@ -30,7 +30,7 @@ from sglang.srt.layers.attention.dsv4.sparse_prefill_utils import (
     use_dsv4_q8kv8_sparse_prefill,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
-from sglang.srt.utils import is_sm90_supported
+from sglang.srt.utils import is_sm90_supported, is_sm100_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=120, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -91,8 +91,8 @@ class _TokenToKVPool:
         return self._extra_key_buffer
 
 
-def _sm90_available() -> bool:
-    return torch.cuda.is_available() and is_sm90_supported()
+def _q8kv8_available() -> bool:
+    return torch.cuda.is_available() and (is_sm90_supported() or is_sm100_supported())
 
 
 def _make_v4_paged_kv_cache(
@@ -372,6 +372,9 @@ def _patched_sparse_kernels(
         d_v,
         attn_sink,
         topk_length,
+        out=None,
+        max_logits=None,
+        lse=None,
     ):
         q8_capture.record(
             q=q,
@@ -384,13 +387,25 @@ def _patched_sparse_kernels(
             attn_sink=attn_sink,
             topk_length=topk_length,
         )
-        out = torch.zeros(
-            (q.shape[0], q.shape[1], d_v), dtype=torch.bfloat16, device=q.device
-        )
-        meta = torch.zeros(
-            (q.shape[0], q.shape[1]), dtype=torch.float32, device=q.device
-        )
-        return out, meta, meta
+        if out is None:
+            out = torch.zeros(
+                (q.shape[0], q.shape[1], d_v),
+                dtype=torch.bfloat16,
+                device=q.device,
+            )
+        else:
+            out.zero_()
+        if max_logits is None:
+            max_logits = torch.zeros(
+                (q.shape[0], q.shape[1]), dtype=torch.float32, device=q.device
+            )
+        else:
+            max_logits.zero_()
+        if lse is None:
+            lse = torch.zeros_like(max_logits)
+        else:
+            lse.zero_()
+        return out, max_logits, lse
 
     sgl_kernel_pkg = types.ModuleType("sgl_kernel")
     flash_mla_mod = types.ModuleType("sgl_kernel.flash_mla")
@@ -400,6 +415,12 @@ def _patched_sparse_kernels(
     q8_module_name = "sglang.kernels.ops.attention.sparse_mla_q8kv8_prefill_sm90"
     q8_mod = types.ModuleType(q8_module_name)
     q8_mod.sparse_mla_q8kv8_prefill_fwd = fake_sparse_mla_q8kv8_prefill_fwd
+    q8_mod._sparse_mla_q8kv8_prefill_fwd_sm100_trusted = (
+        lambda **kwargs: fake_sparse_mla_q8kv8_prefill_fwd(
+            **{key: value for key, value in kwargs.items() if key != "active_heads"},
+            d_v=kwargs["out"].shape[-1],
+        )
+    )
 
     old_modules = {
         name: sys.modules.get(name)
@@ -441,9 +462,10 @@ def test_q8kv8_sparse_prefill_helper_builds_fp8_workspace_matching_bf16_path(
 
     bf16_capture = _Capture()
     q8_capture = _Capture()
-    with _patched_sparse_kernels(
-        bf16_capture, q8_capture
-    ), _patched_compressed_sparse_cache_paths(compress_ratio):
+    with (
+        _patched_sparse_kernels(bf16_capture, q8_capture),
+        _patched_compressed_sparse_cache_paths(compress_ratio),
+    ):
         bf16_out = backend._forward_prefill_sparse(
             q=q,
             layer_id=0,
@@ -485,30 +507,23 @@ def test_q8kv8_sparse_prefill_helper_builds_fp8_workspace_matching_bf16_path(
     assert bf16_kv.dtype == torch.bfloat16
     assert q8_kv.dtype == fp8_dtype
     assert q8_call["q"].dtype == fp8_dtype
-    assert q8_call["q"].shape[1] == 64
-    assert torch.count_nonzero(q8_call["q"][:, 16:]).item() == 0
-    assert q8_call["attn_sink"].shape == (64,)
-    assert q8_kv.shape[0] == bf16_kv.shape[0] + 1
+    expected_q_heads = 16 if is_sm100_supported() else 64
+    expected_kernel_heads = 32 if is_sm100_supported() else 64
+    assert q8_call["q"].shape[1] == expected_q_heads
+    if expected_q_heads > 16:
+        assert torch.count_nonzero(q8_call["q"][:, 16:]).item() == 0
+    assert q8_call["attn_sink"].shape == (expected_kernel_heads,)
+    assert q8_kv.shape[0] == bf16_kv.shape[0]
     torch.testing.assert_close(
-        q8_kv[:-1].to(torch.bfloat16).float(),
+        q8_kv.to(torch.bfloat16).float(),
         bf16_kv.float(),
         atol=3e-2,
         rtol=2e-1,
     )
-    assert torch.equal(
-        q8_kv[-1].to(torch.bfloat16),
-        torch.zeros_like(q8_kv[-1].to(torch.bfloat16)),
-    )
 
     bf16_indices = bf16_call["indices"]
     q8_indices = q8_call["indices"]
-    sentinel_row = q8_kv.shape[0] - 1
-    valid_mask = bf16_indices >= 0
-    assert torch.equal(q8_indices[valid_mask], bf16_indices[valid_mask])
-    assert torch.equal(
-        q8_indices[~valid_mask],
-        torch.full_like(q8_indices[~valid_mask], sentinel_row),
-    )
+    assert torch.equal(q8_indices, bf16_indices)
     assert torch.equal(q8_call["topk_length"], bf16_call["topk_length"])
     assert q8_call["q_scale"].item() == pytest.approx(1.0)
     assert q8_call["kv_scale"].item() == pytest.approx(1.0)
@@ -575,7 +590,9 @@ def test_q8kv8_sparse_prefill_rejects_invalid_tensor_contracts(
 @pytest.mark.parametrize("bad_length", [-1, 129])
 def test_q8kv8_sparse_prefill_rejects_invalid_topk_length_bounds(
     bad_length: int,
+    monkeypatch: pytest.MonkeyPatch,
 ):
+    monkeypatch.setenv("SGLANG_Q8KV8_VALIDATE_TOPK_LENGTH", "1")
     args = _make_q8kv8_kernel_args(device=torch.device("cuda"), topk=128)
     args["topk_length"][0] = bad_length
 
@@ -584,33 +601,43 @@ def test_q8kv8_sparse_prefill_rejects_invalid_topk_length_bounds(
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(),
+    reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA",
 )
-def test_q8kv8_sparse_prefill_real_kernel_matches_bf16_sparse_path():
+@pytest.mark.parametrize("compress_ratio", [0, 4, 128])
+def test_q8kv8_sparse_prefill_real_kernel_matches_bf16_sparse_path(
+    compress_ratio: int,
+):
     device = torch.device("cuda")
     backend, forward_batch, token_to_kv_pool, q, attn_sink, core_attn_metadata = (
         _make_sparse_prefill_case(device, local_heads=64)
     )
+    _populate_compress_metadata(
+        core_attn_metadata,
+        compress_ratio=compress_ratio,
+        device=device,
+    )
 
-    bf16_out = backend._forward_prefill_sparse(
-        q=q,
-        layer_id=0,
-        compress_ratio=0,
-        forward_batch=forward_batch,
-        token_to_kv_pool=token_to_kv_pool,
-        core_attn_metadata=core_attn_metadata,
-        attn_sink=attn_sink,
-    )
-    sparse_cache = backend.forward_metadata.sparse_prefill_cache
-    q8_out = backend._forward_prefill_sparse_q8kv8(
-        q=q,
-        layer_id=0,
-        compress_ratio=0,
-        forward_batch=forward_batch,
-        token_to_kv_pool=token_to_kv_pool,
-        core_attn_metadata=core_attn_metadata,
-        attn_sink=attn_sink,
-    )
+    with _patched_compressed_sparse_cache_paths(compress_ratio):
+        bf16_out = backend._forward_prefill_sparse(
+            q=q,
+            layer_id=0,
+            compress_ratio=compress_ratio,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+            core_attn_metadata=core_attn_metadata,
+            attn_sink=attn_sink,
+        )
+        sparse_cache = backend.forward_metadata.sparse_prefill_cache
+        q8_out = backend._forward_prefill_sparse_q8kv8(
+            q=q,
+            layer_id=0,
+            compress_ratio=compress_ratio,
+            forward_batch=forward_batch,
+            token_to_kv_pool=token_to_kv_pool,
+            core_attn_metadata=core_attn_metadata,
+            attn_sink=attn_sink,
+        )
     torch.cuda.synchronize()
 
     assert backend.forward_metadata.sparse_prefill_cache is sparse_cache
@@ -640,7 +667,98 @@ def test_q8kv8_sparse_prefill_real_kernel_matches_bf16_sparse_path():
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(),
+    reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA",
+)
+def test_q8kv8_deepseek_v4_flash_shape_matches_bf16_sparse_kernel():
+    """Exercise DeepSeek-V4-Flash's 64-head, D=512, index_topk=512 shape."""
+    from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+    args = _make_q8kv8_kernel_args(
+        device=torch.device("cuda"),
+        s_q=5,
+        h_q=64,
+        d_qk=512,
+        s_kv=1024,
+        h_kv=1,
+        topk=512,
+    )
+    q_bf16 = args["q"].to(torch.bfloat16)
+    kv_bf16 = args["kv"].to(torch.bfloat16)
+
+    golden, _, _ = flash_mla_sparse_fwd(
+        q=q_bf16,
+        kv=kv_bf16,
+        indices=args["indices"],
+        sm_scale=args["sm_scale"],
+        d_v=args["d_v"],
+        attn_sink=args["attn_sink"],
+        topk_length=args["topk_length"],
+    )
+    actual, _, _ = sparse_mla_q8kv8_prefill_fwd(**args)
+    torch.cuda.synchronize()
+
+    abs_diff = (actual.float() - golden.float()).abs()
+    assert abs_diff.mean().item() < 0.02
+    assert torch.quantile(abs_diff.flatten(), 0.99).item() < 0.1
+    torch.testing.assert_close(
+        actual.float(),
+        golden.float(),
+        atol=1.5e-1,
+        rtol=2.0e-1,
+    )
+
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and is_sm100_supported()),
+    reason="Unpadded TP8 Q heads require SM100 CUDA",
+)
+def test_q8kv8_deepseek_v4_flash_tp8_heads_match_bf16_sparse_kernel():
+    """Exercise the production TP8 shape without SM90's 64-head padding."""
+    from sgl_kernel.flash_mla import flash_mla_sparse_fwd
+
+    args = _make_q8kv8_kernel_args(
+        device=torch.device("cuda"),
+        s_q=32,
+        h_q=8,
+        d_qk=512,
+        s_kv=1024,
+        h_kv=1,
+        topk=512,
+    )
+    q_bf16_padded = torch.zeros(
+        (args["q"].shape[0], 64, args["q"].shape[2]),
+        dtype=torch.bfloat16,
+        device=args["q"].device,
+    )
+    q_bf16_padded[:, :8].copy_(args["q"])
+    sink_padded = torch.zeros(64, dtype=torch.float32, device=args["q"].device)
+    sink_padded[:8].copy_(args["attn_sink"])
+    golden, _, _ = flash_mla_sparse_fwd(
+        q=q_bf16_padded,
+        kv=args["kv"].to(torch.bfloat16),
+        indices=args["indices"],
+        sm_scale=args["sm_scale"],
+        d_v=args["d_v"],
+        attn_sink=sink_padded,
+        topk_length=args["topk_length"],
+    )
+    actual, _, _ = sparse_mla_q8kv8_prefill_fwd(**args)
+    torch.cuda.synchronize()
+
+    assert actual.shape == (32, 8, 512)
+    cosine = torch.nn.functional.cosine_similarity(
+        actual.float().flatten(), golden[:, :8].float().flatten(), dim=0
+    )
+    assert cosine.item() > 0.995
+    torch.testing.assert_close(
+        actual.float(), golden[:, :8].float(), atol=1.5e-1, rtol=2.0e-1
+    )
+
+
+@pytest.mark.skipif(
+    not _q8kv8_available(),
+    reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA",
 )
 def test_q8kv8_sparse_prefill_real_kernel_repeated_launch_stable():
     args = _make_q8kv8_kernel_args(

--- a/test/registered/kernels/ops/attention/test_sparse_mla_q8kv8_prefill_sm90.py
+++ b/test/registered/kernels/ops/attention/test_sparse_mla_q8kv8_prefill_sm90.py
@@ -6,7 +6,7 @@ import sys
 import pytest
 import torch
 
-from sglang.srt.utils import is_sm90_supported
+from sglang.srt.utils import is_sm90_supported, is_sm100_supported
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=240, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -24,8 +24,8 @@ S_KV = 256
 # optional kernel full path and partial topk_length handling.
 
 
-def _sm90_available() -> bool:
-    return is_sm90_supported()
+def _q8kv8_available() -> bool:
+    return is_sm90_supported() or is_sm100_supported()
 
 
 def _make_fp8_tensor(shape: tuple[int, ...], seed: int) -> torch.Tensor:
@@ -162,7 +162,7 @@ def _run_and_check(d_qk, with_sink, s_q=2, topk=TOPK, s_kv=S_KV):
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 @pytest.mark.parametrize("d_qk,with_sink", [(512, False), (576, False)])
 def test_sparse_mla_q8kv8_prefill_matches_reference(d_qk: int, with_sink: bool):
@@ -173,7 +173,7 @@ def test_sparse_mla_q8kv8_prefill_matches_reference(d_qk: int, with_sink: bool):
 # configurations, and optional sink+topk_length feature coverage. The kernel
 # requires topk to be a multiple of 128, so 128 is the minimum supported.
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 @pytest.mark.parametrize(
     "d_qk,with_sink,s_q,topk,s_kv",
@@ -197,7 +197,7 @@ def test_sparse_mla_q8kv8_prefill_corner_cases(
 # be BITWISE identical to the full-topk dispatch that masks those pads, and
 # must match the fp32 reference on the truncated index range.
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 @pytest.mark.parametrize(
     "d_qk,s_q,topk,s_kv",
@@ -276,7 +276,7 @@ def test_sparse_mla_q8kv8_prefill_topk_length_only(
 # above as kernel feature coverage, but sink-enabled precision numbers should
 # not be used as E2E proxy results until the E2E pipeline wires attn_sink.
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 @pytest.mark.parametrize(
     "d_qk,s_q,topk,s_kv",
@@ -359,7 +359,7 @@ def test_sparse_mla_q8kv8_prefill_precision(d_qk: int, s_q: int, topk: int, s_kv
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 def test_sparse_mla_q8kv8_prefill_no_alias_between_calls():
     """Two default-allocation calls with the same shape must return independent
@@ -406,7 +406,7 @@ def test_sparse_mla_q8kv8_prefill_no_alias_between_calls():
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 def test_sparse_mla_q8kv8_prefill_caller_owned_buffers():
     """Caller-provided ``out`` / ``max_logits`` / ``lse`` tensors must be
@@ -448,7 +448,7 @@ def test_sparse_mla_q8kv8_prefill_caller_owned_buffers():
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 def test_sparse_mla_q8kv8_prefill_rejects_bad_buffers():
     """Validation: wrong shape/dtype and aliasing must raise ValueError."""
@@ -542,7 +542,7 @@ def _ref_masked_blocked(q, kv, indices, sm_scale, d_v, row_start, row_end):
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 @pytest.mark.parametrize("s_q", [2048, 4096])
 def test_sparse_mla_q8kv8_prefill_masked_sentinels(s_q: int):
@@ -604,7 +604,7 @@ def test_sparse_mla_q8kv8_prefill_masked_sentinels(s_q: int):
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 @pytest.mark.parametrize("s_q", [2048, 4096, 6144])
 def test_sparse_mla_q8kv8_prefill_sq_envelope(s_q: int):
@@ -648,7 +648,7 @@ def test_sparse_mla_q8kv8_prefill_sq_envelope(s_q: int):
 
 
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 def test_sparse_mla_q8kv8_prefill_large_skv():
     """NEW gate (bug class 3): large gathered buffers / large index values
@@ -687,7 +687,7 @@ def test_sparse_mla_q8kv8_prefill_large_skv():
 # (interleaved -1s, all-pad, full rows) where the trailing-run semantics still
 # define the correct consumed range.
 @pytest.mark.skipif(
-    not _sm90_available(), reason="Q8KV8 sparse prefill requires SM90 CUDA"
+    not _q8kv8_available(), reason="Q8KV8 sparse prefill requires SM90 or SM100 CUDA"
 )
 @pytest.mark.parametrize("s_q,topk", [(437, 2048), (7, 128), (65, 256), (4096, 2048)])
 def test_q8kv8_topk_length_backscan(s_q: int, topk: int):


### PR DESCRIPTION
## Summary

This PR adds and optimizes the SM100/B200 implementation of Q8KV8 sparse
prefill for DeepSeek-V4-Flash.

It enables:

```python
DeepseekV4AttnBackend._forward_prefill_sparse_q8kv8
```

on SM100 while preserving the existing SM90 CUDA dispatch path.
The implementation is compared against the complete BF16 sparse-prefill
backend:
```python
DeepseekV4AttnBackend._forward_prefill_sparse
```
The comparison includes Q conversion, KV workspace gather/conversion, sparse
index preparation, attention, and output handling.

## Implementation
The SM100 kernel uses native E4M3 tcgen05 MMA and includes the following
optimizations:
- Use a 32-query-head internal tile for the DeepSeek-V4 TP8 shape.
- Consume two logical 64-token sparse blocks in one 128-key tcgen05 frame.
- Execute softmax using all four consumer warps.
- Overlap KV production, QK, softmax, and PV execution.
- Use three KV pipeline stages for D=512.
- Use two KV pipeline stages for D=576 to stay within the SM100 shared-memory
  limit.
- Adapt the producer layout according to query length:
  - Below 4096 tokens: 384 threads and 7 producer warps.
  - At or above 4096 tokens: 512 threads and 11 producer warps.
- Use compact TP8 Q storage with 8 active heads.
- Write active-head output directly to global memory.
- Use the EVICT_LAST cache hint for sparse KV TMA loads.
- Avoid unnecessary metadata stores in the trusted backend path.
The backend changes also add the required FP8 KV workspace preparation, Q
conversion, output buffer reuse, and SM100 dispatch.
Correctness
Correctness is validated against the BF16
_forward_prefill_sparse implementation using the DeepSeek-V4-Flash TP8 shape.
The long-sequence accuracy matrix covers:
- Sequence lengths: 4096, 8192, 16384, and 32768.
- Compression ratios: C0, C4, and C128.
- TP-local active heads: 8.
- Head dimension: 512.
All 12 cases passed:
- Cosine similarity: 0.99992138 - 0.99993408
- Maximum mean absolute error: 4.23e-5
- Maximum absolute error: 0.00342
The default acceptance thresholds are:
- Cosine similarity >= 0.999
- Mean absolute error <= 0.001
- Maximum absolute error <= 0.02

## Performance
Benchmark environment:
- GPU: NVIDIA B200
- Architecture: SM100
- CUDA: 13.0
- PyTorch: 2.11.0
- DeepSeek-V4-Flash TP8 shape with 8 active local heads
- 5 warmup iterations
- 30 measured iterations
- Full backend function latency, not kernel-only latency
Per-case results:
<img width="1218" height="984" alt="image" src="https://github.com/user-attachments/assets/45017a05-9721-46f2-92d4-5484603c60ea" />

## Tests
Run the backend and kernel unit tests:
```shell
pytest -v \
  test/registered/kernels/ops/attention/test_q8kv8_sparse_prefill_backend.py
```

Run the long-sequence accuracy matrix:
```shell
CUDA_VISIBLE_DEVICES=7 \
python benchmark/kernels/deepseek/sm100_q8kv8/validate_dsv4_q8kv8_accuracy.py
```







<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33141167337](https://github.com/sgl-project/sglang/actions/runs/33141167337)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33141167195](https://github.com/sgl-project/sglang/actions/runs/33141167195)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33141167306](https://github.com/sgl-project/sglang/actions/runs/33141167306)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->