### PR TITLE
[Speculative Decoding] Add hybrid MTP and N-gram retrieval

### DIFF
--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -434,6 +434,51 @@ print(response.json())
 
 ---
 
+## Hybrid MTP and Ngram Retrieval
+
+Hybrid retrieval extends a top-k=1 EAGLE/NEXTN draft chain with a continuation
+from SGLang's ngram corpus. The MTP prefix is truncated only at configured
+low-confidence positions, and the retrieval tail is appended only when it agrees
+with the retained MTP prefix. Target-model verification remains authoritative, so
+enabling hybrid retrieval does not change speculative decoding correctness.
+
+Add the following options to an EAGLE/NEXTN launch:
+
+```bash Command
+--speculative-num-steps 3 \
+--speculative-eagle-topk 1 \
+--speculative-num-draft-tokens 9 \
+--speculative-hybrid-retrieval \
+--speculative-hybrid-tau-per-pos off,off,0.40,0.55 \
+--speculative-hybrid-full-cuda-graph
+```
+
+`--speculative-num-draft-tokens` is the maximum verify width, including the
+target-produced bonus token. `--speculative-hybrid-tau-per-pos` is indexed by
+verify-chain column: column 0 is the bonus token and column 1 is the first MTP
+draft, so both must be disabled. An empty per-position value uses
+`--speculative-hybrid-tau` for columns 2 and later.
+
+The following options tune retrieval behavior:
+
+- `--speculative-hybrid-index-prompt` also indexes prompt tokens in the corpus.
+- `--speculative-hybrid-dynamic-tau` adjusts enabled thresholds using the
+  retrieval-extension exponential moving average.
+- `--speculative-hybrid-overlap` overlaps the CPU corpus query with MTP drafting.
+  Without this option, hybrid retrieval disables the overlap scheduler.
+
+On the DeepSeek V4 attention backend, `--speculative-hybrid-ragged` can compact
+the variable-length verify rows and round their total to a captured CUDA graph
+tier. This mode is greedy-only and has stricter startup checks for attention,
+parallelism, CUDA graph preparation, LoRA, and overlap compatibility. The tier
+grid can be controlled with `--speculative-hybrid-ragged-floor`,
+`--speculative-hybrid-ragged-tier-step`,
+`--speculative-hybrid-ragged-max-tiers`, and
+`--speculative-hybrid-ragged-tiers`. In DP-attention deployments, also enable
+`--speculative-hybrid-ragged-dp-tier` so all ranks choose the same graph tier.
+
+---
+
 ## DFlash Decoding
 
 SGLang also supports **DFLASH** speculative decoding using a dedicated draft model checkpoint. Compared with EAGLE-style tree verification, DFLASH verifies a linear draft block and is configured around a block size / draft window. This path is useful when the target model has a matching DFlash draft checkpoint, such as `meta-llama/Llama-3.1-8B-Instruct` with `z-lab/LLaMA3.1-8B-Instruct-DFlash-UltraChat`.

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.cpp
@@ -144,9 +144,14 @@ void Ngram::insertWorker() {
 Result Ngram::batchMatch(
     const std::vector<int64_t>& state_ids,
     const std::vector<std::vector<int32_t>>& tokens,
-    const std::vector<size_t>& total_lens) {
+    const std::vector<size_t>& total_lens,
+    std::vector<int32_t>* valid_lens) {
   if (state_ids.size() != tokens.size() || state_ids.size() != total_lens.size()) {
     throw std::runtime_error("batchMatch expects state_ids, tokens, and total_lens to match in size");
+  }
+  if (valid_lens != nullptr) {
+    valid_lens->clear();
+    valid_lens->reserve(state_ids.size());
   }
 
   std::unique_lock<std::mutex> lock(mutex_);
@@ -188,6 +193,9 @@ Result Ngram::batchMatch(
           suffix.data(), suffix.size(), suffix.back(), total_draft_token_num, param_, state, total_lens[i]);
       merged.token.insert(merged.token.end(), res.token.begin(), res.token.end());
       merged.mask.insert(merged.mask.end(), res.mask.begin(), res.mask.end());
+      if (valid_lens != nullptr) {
+        valid_lens->emplace_back(res.num_valid);
+      }
       continue;
     }
 
@@ -202,6 +210,9 @@ Result Ngram::batchMatch(
 
     merged.token.insert(merged.token.end(), combined.token.begin(), combined.token.end());
     merged.mask.insert(merged.mask.end(), combined.mask.begin(), combined.mask.end());
+    if (valid_lens != nullptr) {
+      valid_lens->emplace_back(combined.num_valid);
+    }
   }
   return merged;
 }

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram.h
@@ -63,10 +63,16 @@ class Ngram {
 
   std::vector<std::pair<std::string, int64_t>> listExternalCorpora() const;
 
+  // `valid_lens`, when non-null, receives one entry per request: the number of
+  // REAL nodes that request's result carries (see Result::num_valid). The
+  // merged Result concatenates every request's padded block, so its own
+  // num_valid is meaningless -- this out-param is the only way to recover the
+  // per-request counts. Defaulted to nullptr so existing callers are unchanged.
   Result batchMatch(
       const std::vector<int64_t>& state_ids,
       const std::vector<std::vector<int32_t>>& tokens,
-      const std::vector<size_t>& total_lens);
+      const std::vector<size_t>& total_lens,
+      std::vector<int32_t>* valid_lens = nullptr);
 
   void eraseMatchState(const std::vector<int64_t>& state_ids);
 

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -78,6 +78,45 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     write_result_(result, out_tokens, out_mask);
   }
 
+  // Same as batch_match_stateful, plus the per-request count of REAL nodes.
+  // Deliberately a SEPARATE entry point rather than an extra argument on the
+  // existing one: batch_match_stateful is on the NGRAM speculative algorithm's
+  // hot path, and this keeps that path byte-identical.
+  void batch_match_stateful_lens(
+      const tvm::ffi::TensorView state_ids_tv,
+      const tvm::ffi::TensorView tokens_flat,
+      const tvm::ffi::TensorView offsets,
+      const tvm::ffi::TensorView total_lens_tv,
+      const tvm::ffi::TensorView out_tokens,
+      const tvm::ffi::TensorView out_mask,
+      const tvm::ffi::TensorView out_valid_lens) {
+    auto* sid = static_cast<const int64_t*>(state_ids_tv.data_ptr());
+    auto* data = static_cast<const int32_t*>(tokens_flat.data_ptr());
+    auto* offs = static_cast<const int64_t*>(offsets.data_ptr());
+    auto* tlens = static_cast<const int64_t*>(total_lens_tv.data_ptr());
+    int64_t batch_size = offsets.size(0) - 1;
+
+    std::vector<int64_t> state_ids(sid, sid + batch_size);
+    std::vector<std::vector<int32_t>> tokens(batch_size);
+    std::vector<size_t> total_lens(batch_size);
+    for (int64_t i = 0; i < batch_size; ++i) {
+      tokens[i].assign(data + offs[i], data + offs[i + 1]);
+      total_lens[i] = static_cast<size_t>(tlens[i]);
+    }
+
+    std::vector<int32_t> valid_lens;
+    auto result = ngram_->batchMatch(state_ids, tokens, total_lens, &valid_lens);
+    write_result_(result, out_tokens, out_mask);
+
+    if (static_cast<int64_t>(valid_lens.size()) != out_valid_lens.size(0)) {
+      throw std::runtime_error(
+          "out_valid_lens size mismatch: expected " + std::to_string(valid_lens.size()) + ", got " +
+          std::to_string(out_valid_lens.size(0)));
+    }
+    std::memcpy(
+        static_cast<int32_t*>(out_valid_lens.data_ptr()), valid_lens.data(), valid_lens.size() * sizeof(int32_t));
+  }
+
   void erase_match_state(const tvm::ffi::TensorView state_ids_tv) {
     auto* sid = static_cast<const int64_t*>(state_ids_tv.data_ptr());
     int64_t n = state_ids_tv.size(0);
@@ -158,6 +197,7 @@ void register_ngram_corpus() {
       .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)
+      .def("batch_match_stateful_lens", &NgramCorpusObj::batch_match_stateful_lens)
       .def("erase_match_state", &NgramCorpusObj::erase_match_state)
       .def("start_external_corpus_load", &NgramCorpusObj::start_external_corpus_load)
       .def("append_external_corpus_tokens", &NgramCorpusObj::append_external_corpus_tokens)

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/result.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/result.cpp
@@ -31,6 +31,11 @@ Result fillResult(int last_token, int draft_token_num, std::vector<Node>& tree, 
     }
   }
 
+  // Record the real node count BEFORE padding: this is the last point at which
+  // it is knowable. Padding below writes `prev = 0`, which makes a pad's mask
+  // row identical to a real depth-1 child's.
+  info.num_valid = static_cast<int32_t>(info.token.size());
+
   // zero padding to length
   while (info.token.size() < static_cast<size_t>(draft_token_num)) {
     info.token.emplace_back(0);
@@ -51,7 +56,12 @@ Result fillResult(int last_token, int draft_token_num, std::vector<Node>& tree, 
 }
 
 std::vector<std::vector<int32_t>> extractLeafPaths_(const Result& result) {
-  const auto n = static_cast<int>(result.token.size());
+  const auto full_n = static_cast<int>(result.token.size());
+  // Only walk real nodes.  Padding rows deliberately have the same mask as a
+  // depth-1 child, and token 0 is legal, so neither token nor mask can tell a
+  // padded [0] path from a genuine one.  fillResult recorded the boundary
+  // before padding; use that producer truth here as well as at the FFI layer.
+  const auto n = std::clamp(static_cast<int>(result.num_valid), 0, full_n);
   if (n <= 1) {
     return {};
   }
@@ -60,7 +70,7 @@ std::vector<std::vector<int32_t>> extractLeafPaths_(const Result& result) {
   std::vector<bool> has_child(n, false);
   for (int i = 1; i < n; ++i) {
     for (int j = i - 1; j >= 0; --j) {
-      if (result.mask[i * n + j]) {
+      if (result.mask[i * full_n + j]) {
         parent[i] = j;
         has_child[j] = true;
         break;
@@ -78,9 +88,6 @@ std::vector<std::vector<int32_t>> extractLeafPaths_(const Result& result) {
       path.emplace_back(result.token[cursor]);
     }
     std::reverse(path.begin(), path.end());
-    if (path.size() == 1 && path.front() == 0) {
-      continue;
-    }
     paths.emplace_back(std::move(path));
   }
   return paths;
@@ -133,6 +140,9 @@ void Result::truncate(size_t n) {
     }
     token.resize(n);
     mask.resize(n * n);
+    if (num_valid > static_cast<int32_t>(n)) {
+      num_valid = static_cast<int32_t>(n);
+    }
   }
 }
 

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/result.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/result.h
@@ -12,6 +12,17 @@ namespace ngram {
 struct Result {
   std::vector<int32_t> token;
   std::vector<uint8_t> mask;
+  // Number of REAL nodes in `token` (the anchor plus every matched node), i.e.
+  // `token[0 : num_valid)` is the tree and `token[num_valid : )` is padding.
+  //
+  // Only fillResult can know this. Once the tail is zero-padded the padding is
+  // indistinguishable from a genuine match: a pad gets `prev = 0`, so its mask
+  // row is exactly `{0, i}` -- byte-identical to a real depth-1 child whose
+  // token happens to be 0 (a legal id; it is <|begin_of_sentence|> in DSV4, and
+  // it IS in the trie whenever the prompt is indexed). Consumers that count
+  // non-zero tokens, or walk leaf paths, therefore report a no-match result as
+  // a length-1 continuation of token 0.
+  int32_t num_valid = 0;
 
   void truncate(size_t n);
 };

--- a/python/sglang/kernels/ops/speculative/ngram_corpus.py
+++ b/python/sglang/kernels/ops/speculative/ngram_corpus.py
@@ -97,6 +97,48 @@ def get_ngram_corpus_cls():
                 np.int64
             )
 
+        def match_stateful_lens(
+            self,
+            state_ids: List[int],
+            batch_tokens: List[List[int]],
+            total_lens: List[int],
+        ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+            """match_stateful plus the per-request count of REAL result nodes.
+
+            The third array is the ONLY way to tell a no-match result (anchor
+            plus zero padding) from a genuine one-token continuation of token 0:
+            both give ``token[1] == 0`` and the same mask row. See
+            ``Result::num_valid`` in ``csrc/ngram_corpus/result.h``.
+
+            A separate entry point rather than an extra return value on
+            ``match_stateful``, so the NGRAM algorithm's hot path is unchanged.
+            """
+            tokens_flat, offsets = _to_csr(batch_tokens)
+            batch_size = len(batch_tokens)
+            d = self._draft_token_num
+
+            state_ids_t = torch.tensor(state_ids, dtype=torch.int64)
+            total_lens_t = torch.tensor(total_lens, dtype=torch.int64)
+            out_tokens = torch.zeros(batch_size * d, dtype=torch.int32)
+            out_mask = torch.zeros(batch_size * d * d, dtype=torch.uint8)
+            out_valid_lens = torch.zeros(batch_size, dtype=torch.int32)
+
+            self.batch_match_stateful_lens(  # type: ignore
+                state_ids_t,
+                tokens_flat,
+                offsets,
+                total_lens_t,
+                out_tokens,
+                out_mask,
+                out_valid_lens,
+            )
+
+            return (
+                out_tokens.numpy().astype(np.int64),
+                out_mask.numpy().astype(np.int64),
+                out_valid_lens.numpy().astype(np.int64),
+            )
+
         def erase_states(self, state_ids: List[int]) -> None:
             state_ids_t = torch.tensor(state_ids, dtype=torch.int64)
             self.erase_match_state(state_ids_t)  # type: ignore

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -814,6 +814,7 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
 
     if (
         cfg.speculative_eagle_topk == 1
+        and not cfg.speculative_hybrid_retrieval
         and cfg.speculative_num_draft_tokens != cfg.speculative_num_steps + 1
     ):
         logger.warning(
@@ -824,6 +825,19 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             "_handle_eagle_family",
             speculative_num_draft_tokens=cfg.speculative_num_steps + 1,
         )
+    elif cfg.speculative_eagle_topk == 1 and cfg.speculative_hybrid_retrieval:
+        # Hybrid MTP+retrieval intentionally uses L = num_draft_tokens >
+        # num_steps + 1 (retrieval fills the extra slots). Collapsing it here
+        # would silently remove the retrieval extension room.
+        logger.warning(
+            "speculative_hybrid_retrieval: keeping speculative_num_draft_tokens=%d "
+            "(L) > speculative_num_steps + 1 = %d for the retrieval extension.",
+            cfg.speculative_num_draft_tokens,
+            cfg.speculative_num_steps + 1,
+        )
+
+    if cfg.speculative_hybrid_retrieval:
+        _handle_hybrid_retrieval(server_args)
 
     # topk > 1 + page_size > 1 needs the two-pass cascade draft-decode (shared prefix
     # pass + per-branch expand pass with prefix-tail dup). Only these backends implement
@@ -840,6 +854,84 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
             f"{_PAGE_TREE_SPEC_BACKENDS}; got attention_backend="
             f"{view.attention_backend!r}. Use page_size == 1 or one of those backends."
         )
+
+
+def _handle_hybrid_retrieval(server_args: ServerArgs) -> None:
+    """Pin the co-requisites of hybrid MTP + retrieval (hybrid retrieval).
+
+    Mutations live here, next to ``_disable_overlap_schedule_for_cpu``, so they
+    land while the configuration is still resolving; ``ServerArgs.
+    check_hybrid_retrieval_server_args`` only validates afterwards (a bare field
+    write after resolution trips the strict-config-mutation guard).
+    """
+    cfg = resolving_view(server_args)
+
+    # Chain-only retrieval: the splice and the agreement gate both assume a
+    # single linear continuation, so pin the ngram BFS breadth to 1.
+    declare_resolution(
+        server_args,
+        "_handle_hybrid_retrieval",
+        speculative_ngram_min_bfs_breadth=1,
+        speculative_ngram_max_bfs_breadth=1,
+    )
+
+    # The retrieval query conditions on the verified context. By default that is
+    # req.output_ids, which under the overlap scheduler LAGS the real chain
+    # position (just-accepted tokens are committed only after the forward), so
+    # the retrieved continuation is offset from the MTP chain and the agreement
+    # gate never matches. Force --disable-overlap-schedule, exactly as the NGRAM
+    # worker does. --speculative-hybrid-overlap instead flips the retriever to a
+    # self-maintained shadow context fed by an async accepted-token relay, which
+    # is fresh at query time, so overlap can stay on.
+    if cfg.speculative_hybrid_overlap:
+        logger.warning(
+            "speculative_hybrid_retrieval + --speculative-hybrid-overlap: keeping "
+            "the overlap scheduler ON; retrieval uses the shadow verified context "
+            "(async accepted-token relay)."
+        )
+    elif not cfg.disable_overlap_schedule:
+        logger.warning(
+            "speculative_hybrid_retrieval: forcing --disable-overlap-schedule so "
+            "the retrieval query sees the current verified context. (Pass "
+            "--speculative-hybrid-overlap to run under overlap.)"
+        )
+        declare_resolution(
+            server_args,
+            "_handle_hybrid_retrieval",
+            disable_overlap_schedule=True,
+        )
+
+    if cfg.speculative_hybrid_ragged:
+        _arm_hybrid_ragged_env()
+
+
+def _arm_hybrid_ragged_env() -> None:
+    """Map ``--speculative-hybrid-ragged`` onto the substrate's env knob.
+
+    The ragged substrate is driven by ``SGLANG_RAGGED_VERIFY_MODE``, a GLOBAL
+    env read by the DSV4 attention backend, the decode cuda-graph runner and the
+    overlap relay. Hybrid retrieval deliberately exposes its own server arg instead of
+    asking users to set that env: the env would then mean two things at once
+    ("which ragged flavour" and "is hybrid retrieval ragged on"), and it is validated at
+    startup for every algorithm. Set it here, while config is still resolving, so
+    the value is inherited by the TP worker processes.
+
+    Turning it to COMPACT does not affect other EAGLE launches: the token-tier
+    verify graphs are additionally gated by ``SpeculativeAlgorithm.
+    supports_ragged_verify()``, which checks the resolved hybrid-ragged flag.
+    """
+    from sglang.srt.speculative.ragged_verify import RaggedVerifyMode
+
+    key = "SGLANG_RAGGED_VERIFY_MODE"
+    wanted = RaggedVerifyMode.COMPACT.value
+    current = os.environ.get(key)
+    if current is not None and current != wanted:
+        raise ValueError(
+            f"--speculative-hybrid-ragged needs {key}={wanted!r}, but the "
+            f"environment already sets {key}={current!r}. Unset it, or drop "
+            "--speculative-hybrid-ragged."
+        )
+    os.environ[key] = wanted
 
 
 def _handle_ngram(server_args: ServerArgs) -> None:

--- a/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_common_hooks.py
+++ b/python/sglang/srt/hardware_backend/npu/dsv4/dsv4_common_hooks.py
@@ -201,12 +201,18 @@ def maybe_build_dsv4_verify_bundle(
     draft_token_num: int,
     *,
     live_seq_lens_cpu: torch.Tensor | None = None,
+    verify_lens_cpu: list[int] | None = None,
 ):
     """Build the DSV4 cache-location view for one target-verify pass.
 
     Spec-v2 reserves cache ahead of time, so target verify must select only the
     current draft interval from the per-request DSV4 tables instead of reusing
     the larger allocation bundle produced during decode preparation.
+
+    ``verify_lens_cpu`` is the hybrid retrieval ragged per-request width ``w_r``; when
+    given, request r's interval is ``[seq_len, seq_len + w_r)`` instead of the
+    uniform ``[seq_len, seq_len + draft_token_num)``, matching the compact rows
+    the forward actually writes.
     """
     pool = batch.req_to_token_pool
     if not hasattr(pool, "req_to_c128_sidecar"):
@@ -216,14 +222,22 @@ def maybe_build_dsv4_verify_bundle(
         return None
 
     req_indices = batch.req_pool_indices_cpu.tolist()
-
     if live_seq_lens_cpu is None:
         live_seq_lens_cpu = batch.seq_lens_cpu
     if live_seq_lens_cpu is None:
         live_seq_lens_cpu = batch.seq_lens[: len(req_indices)].cpu()
     live_seq_lens = live_seq_lens_cpu[: len(req_indices)].tolist()
 
-    verify_lens = [int(draft_token_num)] * len(req_indices)
+    verify_lens = (
+        [int(w) for w in verify_lens_cpu]
+        if verify_lens_cpu is not None
+        else [int(draft_token_num)] * len(req_indices)
+    )
+    if len(verify_lens) != len(req_indices):
+        raise ValueError(
+            "verify_lens_cpu must have one entry per request: "
+            f"got {len(verify_lens)} lengths for {len(req_indices)} requests"
+        )
 
     def flatten_interval(table: torch.Tensor, ratio: int) -> torch.Tensor:
         page_size = pool.c128_page_size

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -1631,6 +1631,97 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     spec_info.hidden_states, num_tokens
                 )
 
+    def _undo_idle_padding(self) -> None:
+        """Exact inverse of `_pad_inputs_to_size` for a rank with NO requests.
+
+        Under DP attention an idle rank still joins every forward. Whether its
+        inputs get stretched depends on arithmetic it does not control:
+        `DpPaddingMode.get_dp_padding_mode` picks MAX_LEN as soon as
+        `sum_len * 2 >= max_len * dp_size`, which for one draft row per busy rank
+        means "at least half the ranks are busy" -- 4 busy out of 8 flips it,
+        1 busy out of 8 does not. Under MAX_LEN this rank's 0-row tensors are
+        padded up to the global max.
+
+        `post_forward_mlp_sync_batch` truncates the OUTPUT back to zero rows, but
+        the padded INPUT tensors stay on the batch, and the batch is reused:
+        `EagleDraftWorker.draft_forward` runs `speculative_num_steps` forwards on
+        one ForwardBatch and pairs `forward_batch.positions` with the logits the
+        forward returned (`draft_topk1_postprocess` asserts the two agree, and
+        the fused kernel advances positions in place). A padded `positions`
+        therefore kills every idle rank the moment the padding mode flips --
+        which is what it did: 4 of 8 DP ranks asserted in `draft_forward` on the
+        first decode step after four requests landed on the other four.
+
+        The inverse is exact rather than "close enough": every field below is
+        sliced under the SAME `is not None` guard the padding used, so a field
+        that was None stays None, and slicing a padded tensor to zero rows
+        reproduces the empty tensor that was there before (a 0-row original
+        contributes nothing to the `torch.cat`). Which is also why this is
+        restricted to genuinely empty batches -- see the caller's guard.
+
+        Two things are deliberately NOT undone here:
+          * `spec_info.hidden_states` -- owned by `hidden_states_backup`, which
+            holds the pre-padding tensor and is restored by the caller.
+          * the fabricated-row conversion in `prepare_mlp_sync_batch` (hybrid-SSM
+            and prefill-breakable-graph idle ranks), which invents a whole dummy
+            request (`extend_*`, `orig_seq_lens`, `num_token_non_padded`) instead
+            of padding. Undoing half of that would leave a batch that is neither
+            empty nor the dummy request, so the caller skips this method
+            entirely for a converted batch.
+        """
+        assert self.batch_size == 0, (
+            f"_undo_idle_padding on a non-empty batch (batch_size="
+            f"{self.batch_size}); it restores EMPTY shapes and would drop rows"
+        )
+        self.input_ids = self.input_ids[:0]
+        self.req_pool_indices = self.req_pool_indices[:0]
+        if self.lora_ids is not None:
+            self.lora_ids = []
+        if self.seq_lens_sum is not None:
+            # The padding added `seq_len_fill_value * bs`; an empty batch sums to
+            # zero. Not folded into the slice below because seq_lens_sum is a
+            # plain int that the attention backends size allocations from.
+            self.seq_lens_sum = 0
+        self.seq_lens = self.seq_lens[:0]
+        if self.seq_lens_cpu is not None:
+            self.seq_lens_cpu = self.seq_lens_cpu[:0]
+        self.out_cache_loc = self.out_cache_loc[:0]
+        if self.encoder_lens is not None:
+            self.encoder_lens = self.encoder_lens[:0]
+        self.positions = self.positions[:0]
+        if self.mamba_track_indices is not None:
+            self.mamba_track_indices = self.mamba_track_indices[:0]
+        if self.mamba_track_mask is not None:
+            self.mamba_track_mask = self.mamba_track_mask[:0]
+        if self.mamba_track_seqlens is not None:
+            self.mamba_track_seqlens = self.mamba_track_seqlens[:0]
+        if self.mrope_positions is not None:
+            self.mrope_positions = self.mrope_positions[:, :0]
+        if self.extend_seq_lens is not None:
+            self.extend_seq_lens = self.extend_seq_lens[:0]
+        if self.rids_int is not None:
+            self.rids_int = self.rids_int[:0]
+            if self.sampling_info is not None:
+                self.sampling_info.rids_int = self.rids_int
+        if self.bootstrap_room_ids_int is not None:
+            self.bootstrap_room_ids_int = self.bootstrap_room_ids_int[:0]
+            if self.sampling_info is not None:
+                self.sampling_info.bootstrap_room_ids_int = self.bootstrap_room_ids_int
+        if self.spec_info is not None and self.spec_info.is_draft_input():
+            spec_info = self.spec_info
+            # getattr for the same reason the padding side uses it: spec_info is
+            # EagleDraftInput | EagleDraftExtendInput and each carries a disjoint
+            # subset of these fields.
+            if getattr(spec_info, "topk_p", None) is not None:
+                spec_info.topk_p = spec_info.topk_p[:0]
+            if getattr(spec_info, "topk_index", None) is not None:
+                spec_info.topk_index = spec_info.topk_index[:0]
+            if getattr(spec_info, "draft_probs", None) is not None:
+                spec_info.draft_probs = spec_info.draft_probs[:0]
+            if getattr(spec_info, "num_correct_drafts", None) is not None:
+                spec_info.num_correct_drafts = spec_info.num_correct_drafts[:0]
+                spec_info.num_accept_tokens = spec_info.num_accept_tokens[:0]
+
     def prepare_attn_tp_scatter_input(self, model_runner: ModelRunner):
         from sglang.srt.layers.communicator import get_attn_tp_context
 
@@ -1715,6 +1806,20 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             ]
             if logits_output.hidden_states is not None:
                 logits_output.hidden_states = logits_output.hidden_states[:num_tokens]
+
+        # The output is back to its real row count; the INPUTS are still padded.
+        # For a rank with requests that is fine (the branches above restore what
+        # the decode loop reads), but an idle rank's batch is reused by the draft
+        # loop against these tensors, so give it back the empty shapes it came
+        # in with -- last, so this is the final word on every field, including
+        # the two `*_backup` re-assignments above.
+        #
+        # `_original_forward_mode is not None` means prepare_mlp_sync_batch
+        # CONVERTED this idle rank into a fabricated one-request EXTEND /
+        # TARGET_VERIFY batch instead of padding an empty one; see
+        # _undo_idle_padding for why those keep their fabricated shape.
+        if self.forward_mode.is_idle() and self._original_forward_mode is None:
+            self._undo_idle_padding()
 
     @property
     def can_run_tbo(self):

--- a/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
+++ b/python/sglang/srt/model_executor/runner/decode_cuda_graph_runner.py
@@ -214,6 +214,27 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
     pluggable self.backend that handles the actual capture/replay.
     """
 
+    # --- capture contract for the subclasses that skip this __init__ -------
+    # EAGLEDraftCudaGraphRunner, EAGLEDraftExtendCudaGraphRunner,
+    # FrozenKVMTPCudaGraphRunner and MultiLayerEagleDraftExtendCudaGraphRunner
+    # deliberately do NOT call this __init__ (it builds decode-only SWA /
+    # encoder-decoder / MLA-aware state they have no use for); each one
+    # hand-initializes the fields the INHERITED capture loop reads. So a field
+    # that `_capture_one_stream` / `_capture_ragged_tiers` touches must have a
+    # value even when this __init__ never ran, and that default belongs here --
+    # declared once, identical for every subclass, and still overwritten below
+    # for the runner that does construct normally -- rather than as a
+    # `getattr(self, ..., False)` at the read site, which would also swallow a
+    # genuinely missing field.
+    #
+    # False/None are not merely inert placeholders: ragged verify is a
+    # TARGET-worker mode (see __init__), so no draft-side runner can ever be in
+    # it. test/registered/unit/model_executor/runner/test_decode_capture_contract.py
+    # pins the closure -- a new field read from the capture path has to be
+    # declared here or set by all four subclasses.
+    ragged_verify_mode: bool = False
+    capture_num_tokens: Optional[list[int]] = None
+
     def __init__(
         self,
         model_runner: ModelRunner,
@@ -351,10 +372,23 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             if self.ragged_verify_mode
             else None
         )
+        # Membership, not range: `_can_run_ragged_verify_graph` has to reject a
+        # layout whose token count sits BETWEEN two captured tiers, and the grid
+        # is deliberately not dense (see _validate_hybrid_ragged_tier_grid). Frozen
+        # for the runner's lifetime, so hoist the set out of the per-step path.
+        self._ragged_capture_token_set: frozenset[int] = frozenset(
+            self.capture_num_tokens or ()
+        )
         self._ragged_graph_size = 0
         # Per-tier capture layouts; their verify_lens / qo_indptr tensors are
         # baked into the captured graphs and refreshed in place each replay.
         self._captured_ragged_layouts: dict[int, object] = {}
+        # How many verify steps ran EAGER because no captured tier could hold
+        # them. In ragged mode that is not a cheap fallback -- there is no
+        # fixed-width verify graph left -- so it needs to be countable rather
+        # than invisible.
+        self._ragged_verify_eager_steps = 0
+        self._ragged_verify_eager_next_log = 1
         if self.ragged_verify_mode and (
             self.enable_two_batch_overlap
             or model_runner.lora_manager is not None
@@ -537,6 +571,70 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.model_runner.shared_read_done_event = read_done
 
     def _build_ragged_verify_token_buckets(self) -> list[int]:
+        server_args = self.model_runner.server_args
+        if server_args.speculative_hybrid_ragged:
+            # hybrid retrieval brings its own grid: the default {bs * width} below has
+            # spacing `width`, while the hybrid chain's totals move in quanta of
+            # `width - floor`, so the round-up eats almost all of the saving.
+            # See build_hybrid_ragged_tier_grid.
+            from sglang.srt.speculative.hybrid_ragged import (
+                build_hybrid_ragged_tier_plan,
+                resolve_hybrid_ragged_tier_params,
+            )
+
+            params = resolve_hybrid_ragged_tier_params(
+                server_args=server_args,
+                verify_width=self.captured_req_width,
+                capture_bs=self.capture_bs,
+            )
+            plan = build_hybrid_ragged_tier_plan(
+                capture_bs=self.capture_bs,
+                verify_width=self.captured_req_width,
+                floor=params.floor,
+                tier_step=params.tier_step,
+                max_tiers=params.max_tiers,
+                explicit_tiers=params.explicit_tiers,
+            )
+            buckets = plan.tiers
+            if get_parallel().tp_rank == 0:
+                # The EFFECTIVE step and the anchor count are what say whether
+                # this is the quantum-aligned grid used by the measurements
+                # on or a coarsened fallback -- printing only the requested step
+                # would show `step=5` on a grid that actually ran at 2080.
+                logger.info(
+                    "hybrid retrieval ragged verify tier grid: %s (floor=%d, "
+                    "requested_step=%d, width=%d, max_tiers=%d). Tiers: %s. "
+                    "%d verify graphs will be captured; the fixed-width path "
+                    "would capture %d.",
+                    plan.describe(),
+                    params.floor,
+                    params.tier_step,
+                    self.captured_req_width,
+                    params.max_tiers,
+                    buckets,
+                    len(buckets),
+                    len(self.capture_bs),
+                )
+                if plan.coarsened(params.tier_step):
+                    logger.warning(
+                        "hybrid retrieval ragged verify: the grid was COARSENED to fit "
+                        "--speculative-hybrid-ragged-max-tiers=%d (%s). The "
+                        "The reported saving numbers used an uncoarsened "
+                        "quantum grid, so expect less. Raise max-tiers (and pay "
+                        "startup capture time) or lower --cuda-graph-max-bs.",
+                        params.max_tiers,
+                        plan.describe_coarsening(params.tier_step),
+                    )
+                if params.max_tiers > 0 and len(buckets) > params.max_tiers:
+                    logger.warning(
+                        "hybrid retrieval ragged verify: %d tiers still exceeds "
+                        "--speculative-hybrid-ragged-max-tiers=%d at the "
+                        "coarsest reachable grid; capturing all of them.",
+                        len(buckets),
+                        params.max_tiers,
+                    )
+            return buckets
+
         buckets = sorted({bs * self.captured_req_width for bs in self.capture_bs})
         assert buckets and buckets[0] > 0, f"{buckets=}"
         return buckets
@@ -624,7 +722,11 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
 
     def _ragged_capture_slots(self, num_tokens: int) -> int:
         if envs.SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE.get():
-            return num_tokens // self.captured_req_width
+            # This test knob assumes every tier is a whole number of full-width
+            # requests, which holds for the substrate's {bs * width} grid but not
+            # for hybrid retrieval's quantum grid (4, 8, 13, 17, ... at width 9). Floor
+            # at 1 slot: 0 would make build_capture_verify_lens raise at capture.
+            return max(num_tokens // self.captured_req_width, 1)
         return min(num_tokens, self.max_bs)
 
     def _capture_ragged_verify_layout(self, num_tokens: int):
@@ -678,15 +780,40 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         if forward_batch.replace_embeds is not None:
             return False
 
-        ragged_layout = (
-            resolve_ragged_verify_layout(forward_batch)
-            if self.ragged_verify_mode
-            else None
-        )
-        if ragged_layout is not None:
-            return self._can_run_ragged_verify_graph(forward_batch, ragged_layout)
-        if self.ragged_verify_mode and forward_batch.forward_mode.is_target_verify():
+        ragged_layout = resolve_ragged_verify_layout(forward_batch)
+        if ragged_layout is not None and not self.ragged_verify_mode:
+            # A layout means the forward's inputs are COMPACT (sum(w_r) rows,
+            # not bs * width). This runner captured fixed-width graphs, so
+            # replaying one here would feed a short input_ids/out_cache_loc into
+            # a graph whose static buffers assume the full rectangle. Fall back
+            # to eager -- correct, just slower. Reachable when the token-keyed
+            # captures were never built (SGLANG_RAGGED_VERIFY_MODE not compact,
+            # or this is the draft runner, which stays fixed width by design).
             return False
+        if self.ragged_verify_mode:
+            # In ragged mode the layout is the ONLY thing that can name a captured
+            # graph: `_capture_ragged_tiers` REPLACES the batch-size capture loop,
+            # so `self._graphs` is keyed purely by token tier. Two consequences,
+            # and both of them are decided here rather than per forward mode:
+            #
+            #  * no layout  -> no graph, whatever the mode. That has to include an
+            #    IDLE batch. Under DP attention a single rank's veto drops the
+            #    layout on EVERY rank (the tier is agreed from one gathered
+            #    vector), and an idle rank that kept replaying here would enter a
+            #    captured graph while its busy peers ran eager -- the two halves of
+            #    the group would then disagree on the shape of every in-graph
+            #    collective, which hangs with no assertion firing first. Falling
+            #    through to the fixed-width admission below is not a lesser
+            #    version of that bug: it derives its key from `bs * width`, which
+            #    the ragged grid does not have to contain at all.
+            #  * a layout the captures cannot hold -> also eager, counted the same
+            #    way (see _can_run_ragged_verify_graph).
+            if ragged_layout is None or not self._can_run_ragged_verify_graph(
+                forward_batch, ragged_layout
+            ):
+                self._note_ragged_verify_ran_eager(forward_batch, ragged_layout)
+                return False
+            return True
 
         # Uniform-width replay invariant: the batch's actual per-request width
         # must match this runner's capture width; anything else falls back to
@@ -750,14 +877,56 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             and is_ngram_supported
         )
 
+    def _note_ragged_verify_ran_eager(
+        self, forward_batch: ForwardBatch, layout
+    ) -> None:
+        """Count (and occasionally log) a verify step that could not be replayed.
+
+        In ragged mode this is not the cheap fallback it is on the fixed-width
+        path -- there is no fixed-width verify graph left to take -- so it shows
+        up as "throughput mysteriously collapsed" rather than as an error. Logged
+        on the first occurrence and then on a geometric schedule, so a persistent
+        fallback keeps saying so without one log line per decode step.
+        """
+        self._ragged_verify_eager_steps += 1
+        count = self._ragged_verify_eager_steps
+        if count < self._ragged_verify_eager_next_log:
+            return
+        self._ragged_verify_eager_next_log = max(count * 10, 1)
+        logger.warning(
+            "Ragged verify is on but %d batch(es) ran EAGER: every captured verify "
+            "graph is token-keyed, so there is no fixed-width graph to fall back "
+            "to. This step was mode=%s, batch_size=%d, tier=%s. Expected for a "
+            "non-greedy batch, a DP tier veto (which takes the WHOLE group -- busy "
+            "and idle -- to eager together), speculative_num_steps == 0, a step "
+            "total above the grid's last tier (%d), or an intended-eager exact "
+            "layout whose token count is not a captured tier.",
+            count,
+            forward_batch.forward_mode.name,
+            forward_batch.batch_size,
+            None if layout is None else layout.graph_num_tokens,
+            self.capture_num_tokens[-1],
+        )
+
     def _can_run_ragged_verify_graph(self, forward_batch: ForwardBatch, ragged_layout):
         if not self.attn_backend.supports_ragged_verify_graph:
             return False
 
         admission_tokens = ragged_layout.graph_num_tokens
-        is_tokens_supported = admission_tokens <= self.capture_num_tokens[
-            -1
-        ] and forward_batch.batch_size <= self._ragged_capture_slots(admission_tokens)
+        # MEMBERSHIP, not `<= capture_num_tokens[-1]`. `load_batch` keys the replay
+        # off `round_up_grid(graph_num_tokens)`, so a token count that merely sits
+        # inside the grid's range selects a DIFFERENT graph than the layout
+        # describes -- caught by load_batch's tier assert, i.e. a dead request
+        # rather than an eager step. Non-members are a NORMAL occurrence, not a
+        # corrupt layout: the planner builds an EXACT layout
+        # (graph_num_tokens == Σ w_r) precisely when it wants the step to run
+        # eager -- when cuda graphs are off, and when the next captured tier is
+        # above `bs * verify_width` so its slack could not be spent inside the
+        # per-request cap (resolve_hybrid_ragged_tier's `max_tier`).
+        is_tokens_supported = (
+            admission_tokens in self._ragged_capture_token_set
+            and forward_batch.batch_size <= self._ragged_capture_slots(admission_tokens)
+        )
 
         is_dp_supported = (
             forward_batch.can_run_decode_cuda_graph if self.require_mlp_sync else True
@@ -1097,16 +1266,20 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             self.model_runner.gpu_id,
             empty_cache=False,
         )
+        lora_variants = (
+            [("lora", True), ("nolora", False)]
+            if getattr(self, "record_nolora_graph", False)
+            else [(None, None)]
+        )
+        if self.ragged_verify_mode:
+            self._capture_ragged_tiers(stream_idx, lora_variants)
+            return
+
         # Reverse so cuda graphs share memory better.
         capture_range = (
             tqdm.tqdm(list(reversed(self.capture_bs)))
             if get_parallel().tp_rank == 0
             else reversed(self.capture_bs)
-        )
-        lora_variants = (
-            [("lora", True), ("nolora", False)]
-            if getattr(self, "record_nolora_graph", False)
-            else [(None, None)]
         )
         # DSA: capture a dense (k-only) and a sparse (full indexer) graph
         # per bs bucket. Order: dense first so its (smaller) capture-time peak
@@ -1150,6 +1323,62 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                             )
         _set_capture_dsa_variant(None)
 
+    def _capture_ragged_tiers(self, stream_idx, lora_variants) -> None:
+        """Capture one graph per TOKEN TIER (ragged verify only).
+
+        Kept as a separate loop rather than folded into the batch-size one on
+        purpose. Every speculative subclass of this runner
+        (EAGLEDraftCudaGraphRunner, EAGLEDraftExtendCudaGraphRunner,
+        MultiLayerEagleDraftExtendCudaGraphRunner, FrozenKVMTPCudaGraphRunner)
+        overrides ``capture_one_shape`` WITHOUT the ``num_tokens`` parameter and
+        inherits ``_capture_one_stream`` unchanged -- so a unified loop that
+        always passed ``num_tokens=`` would raise TypeError at startup for every
+        one of them. None of them can reach this method: ``ragged_verify_mode``
+        requires the TARGET worker and a TARGET_VERIFY capture mode.
+        """
+        capture_range = (
+            tqdm.tqdm(list(reversed(self.capture_num_tokens)))
+            if get_parallel().tp_rank == 0
+            else reversed(self.capture_num_tokens)
+        )
+        for num_tokens in capture_range:
+            slots = self._ragged_capture_slots(num_tokens)
+            if get_parallel().tp_rank == 0:
+                avail_mem = get_available_gpu_memory(
+                    self.model_runner.device,
+                    self.model_runner.gpu_id,
+                    empty_cache=False,
+                )
+                capture_range.set_description(
+                    f"Capturing tiers (tokens={num_tokens} slots={slots} "
+                    f"{avail_mem=:.2f} GB)"
+                )
+
+            # torch.compile is keyed by REQUEST count and `compile_bs` is a
+            # subset of `capture_bs`, so a tier that is not a whole number of
+            # full-width requests has no request count and no pre-graph-tier mode
+            # counterpart; it stays uncompiled rather than being opted in by a
+            # rounding choice.
+            compile_this_shape = (
+                num_tokens % self.captured_req_width == 0
+                and (num_tokens // self.captured_req_width) in self.compile_bs
+            )
+            for variant_label, _variant_has_lora in lora_variants:
+                _set_capture_lora_variant(variant_label)
+                with torch_compile_decoration.patch_model(
+                    self.model_runner.model,
+                    compile_this_shape,
+                    num_tokens=num_tokens,
+                    tp_group=self.model_runner.tp_group,
+                ) as forward:
+                    self.capture_one_shape(
+                        slots,
+                        forward,
+                        stream_idx,
+                        variant_label,
+                        num_tokens=num_tokens,
+                    )
+
     def capture_one_shape(
         self,
         size: int,
@@ -1157,8 +1386,10 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         stream_idx: Optional[int] = None,
         variant_label: Optional[str] = None,
         dsa_variant: Optional[str] = None,
+        num_tokens: Optional[int] = None,
     ):
-        num_tokens = size * self.captured_req_width
+        if num_tokens is None:
+            num_tokens = size * self.captured_req_width
         bs = self._ragged_capture_slots(num_tokens) if self.ragged_verify_mode else size
 
         # Sanity-check: --debug-cuda-graph requires breakable backend.
@@ -1298,8 +1529,8 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                 )
             )
             if is_ragged:
-                assert self.raw_num_token == ragged_layout.graph_num_tokens, (
-                    f"stale ragged raw_num_token {self.raw_num_token} != "
+                assert self.raw_num_token <= ragged_layout.graph_num_tokens, (
+                    f"stale ragged raw_num_token {self.raw_num_token} > tier "
                     f"{ragged_layout.graph_num_tokens}"
                 )
                 self._stage_ragged_verify_layout(ragged_layout, graph_size_key)
@@ -1328,11 +1559,25 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
         raw_bs = forward_batch.batch_size
 
         if is_ragged:
-            raw_num_token = ragged_layout.graph_num_tokens
-            graph_size_key = self._ragged_graph_num_tokens(raw_num_token)
+            # The graph is keyed by the layout's tier, but only the rows the
+            # batch actually carries get copied in. Those are the same number
+            # for a busy rank (the planner pads its compact window to the tier),
+            # and ZERO for an idle DP rank, which has no requests yet still has
+            # to enter the same captured graph as its peers or the in-graph DP
+            # collectives mismatch. The registry resets the [raw, padded) tail,
+            # which is exactly what the fixed-width idle path already relies on.
+            graph_size_key = self._ragged_graph_num_tokens(
+                ragged_layout.graph_num_tokens
+            )
             assert graph_size_key == ragged_layout.graph_num_tokens, (
                 f"ragged verify tier mismatch: runner tier {graph_size_key} != "
                 f"layout graph_num_tokens {ragged_layout.graph_num_tokens}"
+            )
+            raw_num_token = forward_batch.input_ids.numel()
+            assert raw_num_token <= graph_size_key, (
+                f"ragged verify batch carries {raw_num_token} rows but its tier "
+                f"is {graph_size_key}; the planner must pad the compact window "
+                "to the tier"
             )
             bs = self._ragged_capture_slots(graph_size_key)
             assert bs >= raw_bs, (
@@ -1342,6 +1587,18 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
             padded_num_tokens = graph_size_key
             self._stage_ragged_verify_layout(ragged_layout, graph_size_key)
         else:
+            # The fixed-width key is `bs * captured_req_width`, which the ragged
+            # grid need not contain -- and even where it does, that tier was
+            # captured with `min(tokens, max_bs)` request slots rather than `bs`.
+            # can_run_graph rejects every layout-less batch in ragged mode, so
+            # arriving here means that gate regressed; say so instead of replaying
+            # a graph whose geometry does not describe this batch.
+            assert not self.ragged_verify_mode, (
+                f"ragged verify mode reached the fixed-width replay path "
+                f"(mode={forward_batch.forward_mode.name}, raw_bs={raw_bs}): every "
+                "captured graph is token-keyed, so can_run_graph must have sent "
+                "this batch to eager"
+            )
             raw_num_token = raw_bs * self.captured_req_width
             if self.require_mlp_tp_gather:
                 max_batch_size = self._max_dp_batch_size(forward_batch)
@@ -1545,6 +1802,16 @@ class DecodeCudaGraphRunner(BaseCudaGraphRunner):
                     capture_hidden_mode=capture_mode,
                     seq_lens_sum=None,
                     seq_lens_cpu=None,
+                    # hybrid retrieval ragged verify: without a layout here the capture
+                    # would plan FIXED-WIDTH attention metadata (uniform
+                    # extend_seq_lens = width, qo_indptr with stride width) and
+                    # then be replayed against a ragged batch. The DSV4 backend
+                    # rebuilds its metadata inside the graph from the layout's
+                    # device tensors, so what capture fixes is the SHAPE -- and a
+                    # fixed-width shape at a tier that is not a multiple of the
+                    # width does not even exist. None when ragged is off, which
+                    # keeps every non-hybrid retrieval EAGLE capture byte-identical.
+                    ragged_verify_layout=self._capture_ragged_verify_layout(num_tokens),
                 )
                 # MTP models (e.g. deepseek_nextn) read spec_info.hidden_states
                 spec_info.hidden_states = torch.zeros(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2373,6 +2373,91 @@ class ServerArgs:
         NS("spec"),
     ] = 10000000
 
+    # Speculative decoding (hybrid MTP + retrieval, chain-only)
+    # -------------------------------------------------------------------------
+    # MTP heads the chain; chain positions whose draft prob falls below that
+    # position's tau are truncated and refilled by ngram retrieval up to
+    # speculative_num_draft_tokens (= L > num_steps + 1). EAGLE family + topk==1
+    # only. See python/sglang/srt/speculative/hybrid_chain.py.
+    speculative_hybrid_retrieval: A[
+        bool,
+        "Enable hybrid MTP + ngram-retrieval speculative decoding (chain-only): MTP heads the chain, low-draft-prob positions are truncated and refilled by retrieval up to --speculative-num-draft-tokens. EAGLE family + topk==1 only.",
+        NS("spec"),
+    ] = False
+    speculative_hybrid_tau: A[
+        float,
+        "Draft-prob truncation threshold applied to verify columns 2..num_steps when --speculative-hybrid-tau-per-pos is not given: keep the leading MTP positions whose top-1 prob >= tau, refill the rest by retrieval.",
+        NS("spec"),
+    ] = 0.4
+    speculative_hybrid_tau_per_pos: A[
+        str,
+        "Per-position truncation thresholds indexed by VERIFY-CHAIN COLUMN (column 0 = the bonus token, columns 1..S = the S MTP drafts), so it takes exactly --speculative-num-steps + 1 comma-separated entries. An entry of off/disabled/none/0 never truncates at that column; columns 0 and 1 MUST both be disabled (column 0 is the bonus token; column 1's draft logprob comes from the previous iteration's draft-extend). For --speculative-num-steps 3 the DSV4-calibrated setting is 'off,off,0.40,0.55'. Empty = use the scalar --speculative-hybrid-tau on columns >= 2.",
+        NS("spec"),
+    ] = ""
+    speculative_hybrid_tau_min: A[
+        float,
+        "Lower bound of the dynamic tau range (minimal truncation ~ pure MTP).",
+        NS("spec"),
+    ] = 0.05
+    speculative_hybrid_dynamic_tau: A[
+        bool,
+        "Adapt each position's hybrid truncation tau between --speculative-hybrid-tau-min and its configured tau via an EMA of the retrieval-extension rate, so a workload where retrieval never grafts pays no truncation cost.",
+        NS("spec"),
+    ] = False
+    speculative_hybrid_index_prompt: A[
+        bool,
+        Arg(
+            help="Insert the full prompt into the ngram trie at prefill so hybrid retrieval can copy from the prompt (RAG / long-context / code-with-context). Use --no-speculative-hybrid-index-prompt to disable.",
+            action=argparse.BooleanOptionalAction,
+        ),
+        NS("spec"),
+    ] = True
+    speculative_hybrid_full_cuda_graph: A[
+        bool,
+        "Also capture the draft-loop and draft-extend cuda graphs under hybrid (per-step draft logprobs go through a graph-safe static buffer). Off = eager draft, target-verify graph only.",
+        NS("spec"),
+    ] = False
+    speculative_hybrid_overlap: A[
+        bool,
+        "Run hybrid under the overlap scheduler. The retrieval query stops reading req.output_ids (which lags one batch under overlap) and uses a self-maintained shadow verified context fed by an async accepted-token relay from each verify. Off (default) forces --disable-overlap-schedule.",
+        NS("spec"),
+    ] = False
+    speculative_hybrid_ragged: A[
+        bool,
+        "Run the hybrid target-verify forward RAGGED: a request whose retrieval graft failed verifies only its 1 + num_steps MTP columns instead of being padded to --speculative-num-draft-tokens. Compact rows are scattered back to the fixed [bs, L] stride right after the forward, so every downstream consumer is unchanged. DeepSeek-V4 + greedy only.",
+        NS("spec"),
+    ] = False
+    speculative_hybrid_ragged_floor: A[
+        Optional[int],
+        "Starting point of each per-batch-size series in the ragged GRAPH-TIER GRID. Defaults to speculative_num_steps + 1, the width a request whose graft failed actually needs. NOTE: this only moves the grid anchors -- it does NOT change any request's verify width w_r, which is always derived from speculative_num_steps and the retrieval chain length. Set it away from the default only to reshape the tier grid.",
+        NS("spec"),
+    ] = None
+    speculative_hybrid_ragged_tier_step: A[
+        Optional[int],
+        "Spacing of the ragged graph-tier grid, in tokens. Defaults to one QUANTUM = speculative_num_draft_tokens - floor, the extra tokens one request costs when its graft succeeds, which is the spacing the step totals actually move on. Larger values capture fewer graphs and collect less of the saving.",
+        NS("spec"),
+    ] = None
+    speculative_hybrid_ragged_max_tiers: A[
+        int,
+        "Cap on the number of captured ragged verify graphs. -1 (default) = auto = max(16, 2 * number of captured batch sizes), which keeps small deployments on the exact quantum grid while stopping a large --cuda-graph-max-bs from producing thousands of captures (the per-batch-size union is nearly one tier per integer). 0 = genuinely unlimited. When the derived grid exceeds the cap, the TIER STEP is widened first and the captured batch sizes are thinned only as a last resort -- thinning punches holes in the grid, which costs far more than a coarse step. The startup log reports the effective step and the anchor count actually used; if even the coarsest combination does not fit, the full grid is captured and a warning names the count.",
+        NS("spec"),
+    ] = -1
+    speculative_hybrid_ragged_tiers: A[
+        str,
+        "Explicit comma-separated ragged tier grid, e.g. '16,21,26,31,36'. Non-empty completely overrides floor/tier-step/max-tiers. Must be strictly increasing, positive, and must END at max(capture_bs) * speculative_num_draft_tokens -- a step total above the last tier has no captured graph and falls back to eager. Intermediate bs * num_draft_tokens values need NOT be members: a batch may round up past its own bs * L, and the substrate then hands the surplus to padding requests. Escape hatch for reproducing a parameter sweep without code changes.",
+        NS("spec"),
+    ] = ""
+    speculative_hybrid_ragged_tier_policy: A[
+        str,
+        "How the ragged graph tier is chosen. Only 'sync' is currently supported; it copies the exact per-request widths to the host each step and rounds their sum up to a captured tier.",
+        NS("spec"),
+    ] = "sync"
+    speculative_hybrid_ragged_dp_tier: A[
+        bool,
+        "Agree the ragged graph tier across DP-attention ranks with a per-step gloo all-gather, so all ranks replay the same token-keyed verify graph. Required to combine --speculative-hybrid-ragged with --enable-dp-attention: without the agreement the ranks pick different graphs and the group hangs with no assertion firing first, so this is opt-in rather than implied.",
+        NS("spec"),
+    ] = False
+
     # -------------------------------------------------------------------------
     # Expert parallelism
     # -------------------------------------------------------------------------
@@ -10283,6 +10368,334 @@ class ServerArgs:
                 "(DeepSeek-V4 non-EP DP TBO path)."
             )
 
+    def check_hybrid_retrieval_server_args(self):
+        """Validate hybrid MTP + retrieval and its co-requisites."""
+        from sglang.srt.speculative.hybrid_chain import parse_position_thresholds
+        from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+        algo = SpeculativeAlgorithm.from_string(self.speculative_algorithm)
+        assert algo.is_eagle(), (
+            "speculative_hybrid_retrieval requires an EAGLE-family speculative "
+            f"algorithm (got {self.speculative_algorithm})."
+        )
+        assert self.speculative_eagle_topk == 1, (
+            "speculative_hybrid_retrieval requires --speculative-eagle-topk 1 "
+            f"(chain-only); got {self.speculative_eagle_topk}."
+        )
+        assert (
+            self.speculative_num_steps is not None and self.speculative_num_steps >= 1
+        ), (
+            "speculative_hybrid_retrieval requires speculative_num_steps >= 1; at 0 "
+            "steps there is no MTP chain to truncate and verify routes through the "
+            f"1-token trivial path. Got {self.speculative_num_steps}."
+        )
+        assert (
+            self.speculative_num_draft_tokens is not None
+            and self.speculative_num_draft_tokens >= self.speculative_num_steps + 1
+        ), (
+            "speculative_hybrid_retrieval requires speculative_num_draft_tokens (L) "
+            ">= speculative_num_steps + 1 so retrieval has slots to fill; got "
+            f"L={self.speculative_num_draft_tokens}, "
+            f"num_steps={self.speculative_num_steps}."
+        )
+        assert 0.0 < self.speculative_hybrid_tau <= 1.0, (
+            "speculative_hybrid_tau must be in (0, 1]; got "
+            f"{self.speculative_hybrid_tau}."
+        )
+        assert 0.0 < self.speculative_hybrid_tau_min <= 1.0, (
+            "speculative_hybrid_tau_min must be in (0, 1]; got "
+            f"{self.speculative_hybrid_tau_min}."
+        )
+        # Fail at startup, not on the first decode step, if the per-position
+        # threshold list is malformed.
+        parse_position_thresholds(
+            self.speculative_hybrid_tau_per_pos,
+            self.speculative_hybrid_tau,
+            self.speculative_num_steps,
+        )
+
+        # The truncation reads the real per-step draft logprob, which is only
+        # assembled on the fused topk=1 CUDA chain fast path in draft_forward.
+        # Each condition below silently routes the draft loop off that path, so
+        # reject them at startup instead of failing on the first decode step.
+        assert self.device == "cuda", (
+            "speculative_hybrid_retrieval needs the fused topk=1 CUDA chain fast "
+            f"path for the per-step draft logprobs; got device={self.device}."
+        )
+        assert not self.speculative_use_rejection_sampling, (
+            "speculative_hybrid_retrieval is incompatible with "
+            "--speculative-use-rejection-sampling: the spliced chain carries "
+            "retrieval tokens that have no draft proposal distribution, and the "
+            "rejection-sampling kernel requires one for every candidate."
+        )
+        assert self.speculative_token_map is None, (
+            "speculative_hybrid_retrieval is incompatible with "
+            "--speculative-token-map: a reduced (hot) draft vocab routes the "
+            "draft loop off the fused topk=1 chain fast path."
+        )
+        assert not self.speculative_adaptive, (
+            "speculative_hybrid_retrieval is incompatible with "
+            "--speculative-adaptive: adaptive spec re-captures the worker at "
+            "other speculative_num_steps values, but the per-position tau vector "
+            "is sized once from the launch-time num_steps."
+        )
+        if self.speculative_hybrid_ragged:
+            self._check_hybrid_ragged_server_args()
+
+        # Mutations (ngram breadth, overlap) live in the speculative hook's
+        # _handle_hybrid_retrieval so they land while config is still resolving.
+
+    def _check_hybrid_ragged_server_args(self):
+        """Validate the ragged (variable-length) verify support matrix.
+
+        Every condition below either has no ragged implementation at all, or --
+        worse -- has one that would silently produce a fixed-width fallback and
+        make the option ineffective. Reject them at startup.
+        """
+        from sglang.srt.arg_groups.overrides import attention_backends_of
+
+        # Only the DSV4 backend resolves a RaggedVerifyLayout off the spec input
+        # (deepseek_v4_backend.py::_resolve_verify_layout). Any other backend
+        # would build fixed-width [bs*L] attention metadata for a compact
+        # forward -- shapes would mismatch, or worse, quietly mis-attend.
+        # This runs from check_server_args, i.e. post-resolution, so the fields
+        # already carry their final values.
+        _prefill_backend, decode_backend = attention_backends_of(self)
+        assert decode_backend == "dsv4", (
+            "speculative_hybrid_ragged is implemented on the DeepSeek-V4 "
+            f"attention backend only; got decode attention backend "
+            f"{decode_backend!r}."
+        )
+
+        assert not self.speculative_hybrid_overlap, (
+            "speculative_hybrid_ragged does not support "
+            "--speculative-hybrid-overlap yet; the accepted-token relay and the "
+            "ragged tier planner currently require synchronous scheduling."
+        )
+        self._check_hybrid_ragged_tier_server_args()
+        assert not self.enable_two_batch_overlap, (
+            "speculative_hybrid_ragged is incompatible with two-batch-overlap "
+            "(the compact ragged cuda-graph runner rejects it at construction)."
+        )
+        assert not self.enable_lora, (
+            "speculative_hybrid_ragged is incompatible with LoRA (the compact "
+            "ragged cuda-graph runner rejects it at construction)."
+        )
+        assert not self.disable_cuda_graph_padding, (
+            "speculative_hybrid_ragged is incompatible with "
+            "--disable-cuda-graph-padding."
+        )
+        assert self.attn_cp_size == 1, (
+            "speculative_hybrid_ragged does not support context parallel "
+            "(deepseek_v4_backend::_resolve_verify_layout raises on CP); got "
+            f"attn_cp_size={self.attn_cp_size}."
+        )
+        assert not self.speculative_use_rejection_sampling, (
+            "speculative_hybrid_ragged is greedy-only: the accept cutoff is a "
+            "port of DSPARK's CapCorrectLen, which operates on a greedy "
+            "correct_len. (Non-greedy BATCHES are handled at runtime by falling "
+            "back to the fixed-width path for that step.)"
+        )
+
+        from sglang.srt.environ import envs
+
+        # With the plan stream on, eagle_prepare_for_verify runs off the compute
+        # stream (so the compact window tensors would need their own
+        # record_stream) AND the backend's update_verify_buffers_to_fill_after_
+        # draft refills `positions` assuming the fixed [bs * L] stride, which
+        # ragged has just rebound to the compact window.
+        assert not envs.SGLANG_ENABLE_OVERLAP_PLAN_STREAM.get(), (
+            "speculative_hybrid_ragged requires "
+            "SGLANG_ENABLE_OVERLAP_PLAN_STREAM=0; the verify plan stream rebinds "
+            "verify buffers at the fixed width."
+        )
+
+        # PREP=0 routes the DSV4 backend to init_forward_metadata_target_verify_old,
+        # which reads layout.verify_lens_cpu -- but the backend has by then run
+        # layout.padded_to_bucket(), and that rebuilds the layout through
+        # _assemble_device() WITHOUT the host fields, so verify_lens_cpu is None
+        # and compute_ragged_extend_lengths does list(None). Failing here beats
+        # failing with a TypeError on the first request, after the weights load.
+        # Supporting PREP=0 would require padded_to_bucket to retain host lengths.
+        assert envs.SGLANG_PREP_IN_CUDA_GRAPH.get(), (
+            "speculative_hybrid_ragged requires SGLANG_PREP_IN_CUDA_GRAPH=1: with "
+            "it off the DSV4 backend takes the host-metadata path, whose "
+            "verify_lens_cpu is dropped by RaggedVerifyLayout.padded_to_bucket() "
+            "-- the first ragged verify would die with "
+            "\"TypeError: 'NoneType' object is not iterable\"."
+        )
+        assert not (
+            envs.SGLANG_OPT_USE_ONLINE_COMPRESS.get()
+            and envs.SGLANG_EXPERIMENTAL_ONLINE_C128_MTP.get()
+        ), (
+            "speculative_hybrid_ragged is incompatible with online c128 MTP "
+            "(SGLANG_OPT_USE_ONLINE_COMPRESS + SGLANG_EXPERIMENTAL_ONLINE_C128_MTP): "
+            "DSV4's _resolve_verify_layout raises NotImplementedError for that "
+            "combination on the first ragged verify."
+        )
+
+    def _check_hybrid_ragged_tier_server_args(self):
+        """Validate graph-tier knobs and the DP tier agreement.
+
+        The grid itself is only buildable once ``capture_bs`` is known (in the
+        decode cuda-graph runner), so this checks what can be checked from the
+        args alone -- and, more importantly, refuses the combinations whose
+        failure mode is a hung cluster rather than an exception.
+        """
+        assert self.speculative_hybrid_ragged_tier_policy == "sync", (
+            "speculative_hybrid_ragged_tier_policy must be 'sync' for now; got "
+            f"{self.speculative_hybrid_ragged_tier_policy!r}. The 'ema' policy "
+            "is not implemented yet; accepting it here would "
+            "silently run the exact policy under an ema name."
+        )
+        floor = self.speculative_hybrid_ragged_floor
+        if floor is not None:
+            assert 1 <= floor <= self.speculative_num_draft_tokens, (
+                "speculative_hybrid_ragged_floor must be in "
+                f"[1, speculative_num_draft_tokens={self.speculative_num_draft_tokens}]; "
+                f"got {floor}."
+            )
+        tier_step = self.speculative_hybrid_ragged_tier_step
+        if tier_step is not None:
+            assert tier_step >= 1, (
+                "speculative_hybrid_ragged_tier_step must be >= 1; got " f"{tier_step}."
+            )
+        assert self.speculative_hybrid_ragged_max_tiers >= -1, (
+            "speculative_hybrid_ragged_max_tiers must be >= -1 (-1 = auto, "
+            f"0 = unlimited); got {self.speculative_hybrid_ragged_max_tiers}."
+        )
+        if self.speculative_hybrid_ragged_tiers.strip():
+            # Parse here so a typo fails at startup rather than inside the
+            # cuda-graph capture loop, after the weights are already resident.
+            tiers = [
+                int(piece)
+                for piece in self.speculative_hybrid_ragged_tiers.split(",")
+                if piece.strip()
+            ]
+            assert tiers and tiers == sorted(set(tiers)) and tiers[0] >= 1, (
+                "speculative_hybrid_ragged_tiers must be a strictly increasing "
+                f"list of positive ints; got {self.speculative_hybrid_ragged_tiers!r}."
+            )
+            # The runtime grid validator also checks this, but it runs while
+            # constructing the decode runner after weights are resident.  When
+            # max-running is explicit, the effective
+            # capture ceiling is already known here and a bad endpoint must be
+            # rejected before the model load.
+            max_running_requests = getattr(self, "max_running_requests", None)
+            if max_running_requests is not None:
+                effective_max_bs = max_running_requests
+                if self.enable_dp_attention:
+                    assert effective_max_bs % self.dp_size == 0, (
+                        "max_running_requests must be divisible by dp_size for "
+                        "the DP capture grid; got "
+                        f"{effective_max_bs} and dp_size={self.dp_size}."
+                    )
+                    effective_max_bs //= self.dp_size
+                ceiling = effective_max_bs * self.speculative_num_draft_tokens
+                assert tiers[-1] == ceiling, (
+                    "speculative_hybrid_ragged_tiers must end at the pre-weight "
+                    "capture ceiling max_effective_bs * "
+                    f"speculative_num_draft_tokens = {ceiling}; got {tiers[-1]}."
+                )
+
+        from sglang.srt.environ import envs
+
+        # This test-only knob replaces the token-tier capture layout with a
+        # uniform rectangle.  That is a different mechanism, not a supported
+        # configuration; in DP it can additionally strand an idle rank in a
+        # collective.  Refuse it for both non-DP and DP before the early return.
+        assert not envs.SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE.get(), (
+            "speculative_hybrid_ragged is incompatible with "
+            "SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE=1: the knob "
+            "bypasses the token-tier capture layout."
+        )
+
+        if not self.enable_dp_attention:
+            assert not self.speculative_hybrid_ragged_dp_tier, (
+                "--speculative-hybrid-ragged-dp-tier does nothing without "
+                "--enable-dp-attention; drop it rather than leave a knob on that "
+                "has no effect."
+            )
+            return
+
+        # DP attention: the tier MUST be agreed, or the ranks replay different
+        # graphs and the group hangs inside the in-graph MoE all-gather with no
+        # assertion firing first.
+        assert self.speculative_hybrid_ragged_dp_tier, (
+            "speculative_hybrid_ragged with --enable-dp-attention requires "
+            "--speculative-hybrid-ragged-dp-tier: the ragged verify graph is "
+            "keyed by the layout's token count and the decode runner takes no "
+            "cross-rank max of its own, so each rank would pick its own graph "
+            "and the group would hang."
+        )
+        # DERIVED, not a field: ServerArgs has tp_size / dp_size / attn_cp_size
+        # but no attn_tp_size. Same formula as compute_dp_attention_world_info
+        # (layers/dp_attention.py) and the MiMoV2 check in this file.
+        attn_dp_size = self.dp_size if self.enable_dp_attention else 1
+        attn_tp_size = self.tp_size // attn_dp_size // self.attn_cp_size
+        assert attn_tp_size == 1, (
+            "speculative_hybrid_ragged DP tier agreement requires "
+            f"attn_tp_size == 1 (got {attn_tp_size} from tp_size={self.tp_size}, "
+            f"dp_size={self.dp_size}, attn_cp_size={self.attn_cp_size}): the "
+            "all-gather runs over the tp group, and only with one rank per DP "
+            "rank is the gathered vector the per-DP-rank vector."
+        )
+
+        # The whole mechanism is the token-tier graph's cross-rank agreement, so
+        # without decode cuda graphs there is no tier to agree on: every rank
+        # would vote VETO and drop to fixed width, every step, forever -- and the
+        # eager-fallback counter that would say so lives on the decode runner,
+        # which does not exist either. A permanent silent no-op that still
+        # reports "ragged + dp-tier enabled" is worse than a refusal.
+        from sglang.srt.model_executor.cuda_graph_config import Backend, Phase
+
+        decode_backend = getattr(self.cuda_graph_config, Phase.DECODE).backend
+        assert decode_backend != Backend.DISABLED, (
+            "speculative_hybrid_ragged with --enable-dp-attention requires the "
+            "decode CUDA graph: the DP tier IS the captured graph's token count, "
+            "so with graphs off every rank votes VETO, every step falls back to "
+            "fixed width, and the feature is a permanent silent no-op (the "
+            "eager-fallback counter that would say so lives on the decode runner, "
+            "which does not exist either). Drop --disable-cuda-graph / "
+            "--disable-decode-cuda-graph, or run this arm without "
+            "--enable-dp-attention -- non-DP ragged IS supported eager."
+        )
+
+        # The runtime gate (hybrid_ragged_dp_tier_enabled) also requires this.
+        # Checking it HERE too is the point: if the two ever disagree, startup
+        # succeeds, the per-step all-gather silently never happens, and each rank
+        # picks its own tier -- the exact hang this whole mechanism exists to
+        # prevent, reached by passing validation. It is true for the DSV4 shapes
+        # hybrid retrieval targets (enable_dp_attention with moe_dense_tp_size unset),
+        # but that is a property of the config, not something to rely on.
+        from sglang.srt.utils.common import require_mlp_tp_gather
+
+        assert require_mlp_tp_gather(self), (
+            "speculative_hybrid_ragged DP tier agreement requires an MLP TP "
+            "gather (require_mlp_tp_gather); without it the runtime gate turns "
+            "the per-step tier all-gather off while DP attention stays on, and "
+            "the ranks would each choose their own graph tier. Check "
+            "--moe-dense-tp-size / --enable-dp-lm-head / the MoE a2a backend."
+        )
+        assert not self.speculative_skip_dp_mlp_sync, (
+            "speculative_hybrid_ragged DP tier agreement needs the MLP sync: the "
+            "tier vote reads is_extend_in_batch / can_run_dp_cuda_graph, which "
+            "only the sync makes dp-global."
+        )
+        assert self.disaggregation_mode == "null" and self.pp_size == 1, (
+            "speculative_hybrid_ragged DP tier agreement is not supported with "
+            f"disaggregation ({self.disaggregation_mode!r}) or pp_size="
+            f"{self.pp_size}: both change which ranks reach the per-step "
+            "all-gather."
+        )
+
+        assert not envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.get(), (
+            "speculative_hybrid_ragged DP tier agreement requires the scheduler "
+            "all-gather (SGLANG_SCHEDULER_SKIP_ALL_GATHER=0); with it skipped "
+            "is_extend_in_batch and can_run_dp_cuda_graph are local values and "
+            "the ranks can vote differently."
+        )
+
     def check_server_args(self):
         cfg = resolving_view(self)
 
@@ -10346,6 +10759,22 @@ class ServerArgs:
             assert (
                 not cfg.enable_mixed_chunk
             ), "enable_mixed_chunk is required for speculative decoding"
+
+        # Checked OUTSIDE the hybrid gate below: --speculative-hybrid-ragged on
+        # its own would otherwise never reach a single check and silently do
+        # nothing, which only shows up as "the run saved no tokens" after a full
+        # experiment.
+        assert not (
+            self.speculative_hybrid_ragged and not self.speculative_hybrid_retrieval
+        ), (
+            "--speculative-hybrid-ragged only applies to the hybrid MTP+retrieval "
+            "verify chain; pass --speculative-hybrid-retrieval as well (without it "
+            "the flag would be silently ignored and the run would fall back to "
+            "plain fixed-width EAGLE)."
+        )
+
+        if self.speculative_hybrid_retrieval:
+            self.check_hybrid_retrieval_server_args()
 
         # Check chunked prefill
         # Skip validation if chunked prefill is disabled (i.e., size <= 0).

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -106,6 +106,29 @@ class NgramCorpus:
         state_ids = [self._get_state_id(rid) for rid in req_ids]
         return self._obj.match_stateful(state_ids, batch_tokens, total_lens)
 
+    def batch_get_with_lens(
+        self,
+        req_ids: List[str],
+        batch_tokens: List[List[int]],
+        total_lens: List[int],
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """batch_get plus ``valid_lens[bs]``: how many entries of each request's
+        ``[draft_token_num]`` block are REAL nodes (anchor included).
+
+        Needed because the padding is not self-identifying. ``fillResult``
+        zero-pads the tail and gives each pad ``prev = 0``, so a pad's mask row
+        is exactly ``{0, i}`` -- byte-identical to a real depth-1 child whose
+        token happens to be 0. Token 0 is legal (DSV4's
+        ``<|begin_of_sentence|>``, and it is in the trie whenever the prompt is
+        indexed), so counting non-zeros or walking leaf paths reports a no-match
+        result as a length-1 continuation of token 0.
+
+        Kept separate from ``batch_get`` so the NGRAM worker's call site is
+        untouched.
+        """
+        state_ids = [self._get_state_id(rid) for rid in req_ids]
+        return self._obj.match_stateful_lens(state_ids, batch_tokens, total_lens)
+
     def erase_match_state(self, req_ids: List[str]):
         state_ids = []
         for rid in req_ids:

--- a/python/sglang/srt/speculative/eagle_info.py
+++ b/python/sglang/srt/speculative/eagle_info.py
@@ -1,6 +1,6 @@
 import logging
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import TYPE_CHECKING, List, Optional
 
 import torch
 
@@ -8,6 +8,9 @@ from sglang.kernels.ops.attention.utils import create_flashinfer_kv_indices_trit
 from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
 from sglang.srt.runtime_context import get_spec
 from sglang.srt.speculative.spec_info import SpecInput, SpecInputType
+
+if TYPE_CHECKING:
+    from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
 
 logger = logging.getLogger(__name__)
 
@@ -33,6 +36,36 @@ class EagleVerifyInput(SpecInput):
 
     # Shape info for padding
     num_tokens_per_req: int = -1  # -1 auto-fills from draft_token_num.
+
+    # ---- ragged (variable-length) verify, hybrid retrieval only ---------------------
+    # `SpecInput` declares ragged_verify_layout as a CLASS-level default, which
+    # makes it readable on every verify input but NOT constructible. Redeclaring
+    # it as a dataclass field here is what lets the hybrid path actually set it;
+    # without this line the constructor raises TypeError and the natural "fix"
+    # (assigning after construction) would work for some call sites and silently
+    # fall back to fixed width for others.
+    # When set, `positions` is REBOUND to the compact [sum(w_r)] window by
+    # eagle_prepare_for_verify (ForwardBatch.init_new copies spec_info.positions
+    # straight into the forward). `draft_token` stays the FIXED-STRIDE [bs * L]
+    # chain: eagle_sample reshapes it into `candidates` AFTER the scatter seam,
+    # and the grammar path views it at [bs, L].
+    ragged_verify_layout: Optional["RaggedVerifyLayout"] = None
+    # The ACCEPT widths (true `w_r`). `ragged_verify_layout.verify_lens` holds
+    # the FORWARD widths, which graph-tier mode's tier padding grows to fill the captured
+    # graph's token count; the grown columns carry zero-padded candidates, and
+    # `0 == 0` would chain acceptance to the end of the row, so the cutoff has to
+    # clamp against these instead. Equal to the layout's widths whenever the
+    # step's total already sits on a tier, including every eager ragged step.
+    ragged_accept_verify_lens: Optional[torch.Tensor] = None
+    ragged_accept_verify_lens_cpu: Optional[List[int]] = None
+    # The ordinary [bs * L] cache map, stashed while `batch.out_cache_loc` holds
+    # the compact one for the duration of the forward. `prepare_for_draft_extend`
+    # REUSES whatever cache map verify left on the shared ScheduleBatch (on the
+    # fixed-width path the two stages address the same bs*L slots, so it never
+    # rebuilds one) -- so the scatter seam has to put this back, or draft-extend
+    # gets bs*L tokens against sum(w_r) locations.
+    ragged_fixed_cache_loc: Optional[torch.Tensor] = None
+    ragged_fixed_cache_loc_dsv4: Optional[object] = None
 
     def __post_init__(self):
         super().__init__(SpecInputType.EAGLE_VERIFY)
@@ -88,22 +121,36 @@ class EagleVerifyInput(SpecInput):
     ):
         device = req_pool_indices.device
         batch_size = len(req_pool_indices)
-        qo_indptr = torch.arange(
-            0,
-            (1 + batch_size) * self.draft_token_num,
-            step=self.draft_token_num,
-            dtype=torch.int32,
-            device=device,
-        )
+        layout = self.ragged_verify_layout
+        if layout is None:
+            qo_indptr = torch.arange(
+                0,
+                (1 + batch_size) * self.draft_token_num,
+                step=self.draft_token_num,
+                dtype=torch.int32,
+                device=device,
+            )
+            verify_lens = self.draft_token_num
+            kv_indices_extra = self.draft_token_num * batch_size
+        else:
+            # Ragged: request r contributes w_r query rows, not draft_token_num.
+            # Mirrors DFlashVerifyInput.generate_attn_arg_prefill. The DSV4
+            # backend never reaches here (it resolves the layout itself in
+            # _resolve_verify_layout), so this is the path for any other backend
+            # that grows ragged support later.
+            qo_indptr = layout.qo_indptr_device
+            verify_lens = layout.verify_lens
+            kv_indices_extra = layout.total_verify_tokens
+
         cum_kv_seq_len = torch.zeros(
             (batch_size + 1,), dtype=torch.int32, device=device
         )
 
-        paged_kernel_lens = paged_kernel_lens + self.draft_token_num
+        paged_kernel_lens = paged_kernel_lens + verify_lens
         cum_kv_seq_len[1:] = torch.cumsum(paged_kernel_lens, dim=0)
 
         kv_indices = torch.empty(
-            paged_kernel_lens_sum + self.draft_token_num * batch_size,
+            paged_kernel_lens_sum + kv_indices_extra,
             dtype=torch.int32,
             device=device,
         )

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -508,34 +508,83 @@ def eagle_prepare_for_verify(
         ForwardBatch,
         ForwardMode,
     )
+    from sglang.srt.speculative.hybrid_ragged import build_hybrid_ragged_window
     from sglang.srt.speculative.spec_utils import prepare_mamba_track_for_verify
 
     if not batch.forward_mode.is_idle():
         # Assign cache locations
         bs = len(batch.req_pool_indices)
-        batch.input_ids = verify_input.draft_token
+        device = batch.device
+        layout = verify_input.ragged_verify_layout
+        if layout is None:
+            batch.input_ids = verify_input.draft_token
+            batch.out_cache_loc = assign_extend_cache_locs_uniform_func(
+                req_pool_indices=batch.req_pool_indices,
+                req_to_token=req_to_token_pool.req_to_token,
+                start_offset=batch.seq_lens,
+                batch_size=bs,
+                draft_token_num=verify_input.draft_token_num,
+                device=device,
+            )
+        else:
+            # Ragged verify (hybrid retrieval): the forward runs on sum(w_r) compact
+            # rows. `verify_input.draft_token` / `.positions` stay the fixed
+            # [bs * L] stride -- eagle_sample reshapes draft_token into
+            # `candidates` AFTER the scatter seam, so compacting them here would
+            # break acceptance. Only the batch-level forward inputs change.
+            #
+            # Only w_r of the L pre-reserved KV slots are written. The remaining
+            # [seq_len + w_r, seq_len + L) slots keep stale contents, but they
+            # sit past new_seq_lens = seq_len + accept_len (accept_len <= w_r,
+            # enforced by cap_accept_to_verify_lens) so nothing ever reads them,
+            # and the next iteration re-allocates from the new seq_len.
+            #
+            # The compact cache map is scoped to THIS FORWARD ONLY. The fixed
+            # [bs * L] map is stashed on the verify input and put back by the
+            # scatter seam in run_eagle_verify, because draft-extend reuses
+            # whatever map verify leaves on the shared batch.
+            window = build_hybrid_ragged_window(
+                batch=batch,
+                layout=layout,
+                draft_token=verify_input.draft_token,
+                verify_width=verify_input.draft_token_num,
+                req_to_token=req_to_token_pool.req_to_token,
+                device=device,
+            )
+            #
+            # `positions` IS rebound, because ForwardBatch.init_new copies
+            # spec_info.positions straight into the forward and the compact rows
+            # need their own absolute positions. The fixed-stride positions that
+            # build_tree_kernel_efficient produced have no consumer past this
+            # point (only the overlap plan-stream refill reads them back, and
+            # ragged asserts overlap off).
+            batch.input_ids = window.verify_ids
+            batch.out_cache_loc = window.verify_cache_loc
+            verify_input.positions = window.positions
+            verify_input.ragged_fixed_cache_loc = window.fixed_cache_loc
         maybe_detect_oob(
             batch.input_ids,
             0,
             batch.model_config.vocab_size,
             "v2 prepare_for_verify input_ids",
         )
-        device = batch.device
-        # Uniform variant: end offsets (= start + draft_token_num) are computed
-        # inside the kernel, keeping the eager `seq_lens + N` add off the host
-        # critical path (bs=1 MTP inter-phase seam).
-        batch.out_cache_loc = assign_extend_cache_locs_uniform_func(
-            req_pool_indices=batch.req_pool_indices,
-            req_to_token=req_to_token_pool.req_to_token,
-            start_offset=batch.seq_lens,
-            batch_size=bs,
-            draft_token_num=verify_input.draft_token_num,
-            device=device,
-        )
-
         batch.out_cache_loc_dsv4 = maybe_build_dsv4_verify_bundle(
-            batch, verify_input.draft_token_num
+            batch,
+            verify_input.draft_token_num,
+            verify_lens_cpu=(None if layout is None else layout.verify_lens_cpu),
         )
+        if layout is not None:
+            # Same story as out_cache_loc: build the fixed-width bundle too and
+            # let the seam restore it. The helper reads `batch.out_cache_loc` for
+            # its `out_full_loc`, so point it at the fixed map while building.
+            # (No-op on CUDA, where the helper returns None -- the DSV4 per-req
+            # compression tables are an NPU-only path.)
+            compact_loc = batch.out_cache_loc
+            batch.out_cache_loc = window.fixed_cache_loc
+            verify_input.ragged_fixed_cache_loc_dsv4 = maybe_build_dsv4_verify_bundle(
+                batch, verify_input.draft_token_num
+            )
+            batch.out_cache_loc = compact_loc
 
         prepare_mamba_track_for_verify(batch)
 
@@ -669,6 +718,7 @@ def eagle_sample(
     from sglang.srt.sampling.penaltylib.repetition_penalty import (
         apply_scaling_penalties,
     )
+    from sglang.srt.speculative.hybrid_ragged import cap_accept_to_verify_lens
     from sglang.srt.speculative.spec_utils import (
         SIMULATE_ACC_LEN,
         SIMULATE_ACC_TOKEN_MODE,
@@ -904,6 +954,32 @@ def eagle_sample(
             bs=bs,
             spec_steps=verify_input.max_tree_depth - 1,
         )
+
+    if verify_input.ragged_verify_layout is not None:
+        # Ragged verify: columns >= w_r hold no real candidate. Either they were
+        # never computed (the scatter seam filled them with `fill_value`) or --
+        # for the columns graph-tier padding added -- they were computed over the
+        # spliced chain's zero padding. Both are token 0 against a logits row
+        # whose argmax is also 0 on the fill path, and `0 == 0` chains acceptance
+        # all the way to L, so the failure mode is systematic rather than
+        # occasional. This is the one place a ragged forward could produce WRONG
+        # OUTPUT. Clamp correct_len to w_r - 1 (DSPARK's CapCorrectLen) against
+        # the ACCEPT widths, never the layout's padded forward widths, and drop
+        # the out-of-range accept_index entries.
+        accept_verify_lens = verify_input.ragged_accept_verify_lens
+        assert accept_verify_lens is not None or batch.forward_mode.is_idle(), (
+            "ragged verify carries a layout but no accept widths; the cutoff "
+            "would have to clamp against the tier-padded forward widths and could "
+            "accept a zero-padded column. Only an IDLE DP rank may carry a "
+            "layout without them -- it rides the agreed tier to enter the same "
+            "captured graph and has nothing to accept."
+        )
+        if accept_verify_lens is not None:
+            num_correct_drafts, accept_index = cap_accept_to_verify_lens(
+                num_correct_drafts=num_correct_drafts,
+                accept_index=accept_index,
+                verify_lens=accept_verify_lens,
+            )
 
     # `num_correct_drafts` stays drafts-only inside this function; the returned
     # tensor includes the trailing/bonus token via out-of-place +1 so the

--- a/python/sglang/srt/speculative/eagle_worker_common.py
+++ b/python/sglang/srt/speculative/eagle_worker_common.py
@@ -22,6 +22,7 @@ from sglang.srt.speculative.eagle_utils import (
     eagle_prepare_for_verify,
     eagle_sample,
 )
+from sglang.srt.speculative.hybrid_ragged import scatter_hybrid_verify_outputs
 from sglang.srt.speculative.spec_utils import (
     GrammarTree,
     build_grammar_vocab_mask,
@@ -146,6 +147,21 @@ def prepare_for_draft_extend(
             )
     else:
         batch.input_ids = predict
+        # This branch REUSES the cache map the previous stage (target verify)
+        # left on the shared ScheduleBatch: on the fixed-width path both stages
+        # address the same bs * num_draft_tokens slots, so rebuilding it would
+        # be redundant. That makes it an unstated cross-stage invariant, and a
+        # stage that installs a narrower map (e.g. hybrid retrieval's compact ragged
+        # verify window) silently hands this forward more tokens than locations.
+        # Cheap enough to check on every decode.
+        if not batch.forward_mode.is_idle():
+            assert batch.out_cache_loc.numel() == extend_num_tokens, (
+                f"draft-extend needs a fixed-width cache map of "
+                f"{extend_num_tokens} (= bs {bs} * {num_window_tokens}) entries, "
+                f"got {batch.out_cache_loc.numel()}: a previous stage left a "
+                "compact/ragged map on the shared ScheduleBatch without "
+                "restoring the fixed-width one."
+            )
     maybe_detect_oob(
         batch.input_ids,
         0,
@@ -501,6 +517,31 @@ def run_eagle_verify(
             target_worker,
         )
 
+    # A ragged verify that did NOT get a graph must have an EXACT layout. With
+    # slack, the eager DSV4 path runs padded_to_bucket(padded_bs=bs) with no pad
+    # requests, so the substrate folds the whole remainder into the LAST REAL
+    # request -- widening its attention window past num_draft_tokens and past the
+    # KV slots the scheduler reserved for it. The planner prevents this (it caps
+    # the non-DP tier at bs * num_draft_tokens, and the DP vote makes the graph a
+    # precondition), so reaching here means an admission condition changed under
+    # the planner. Say so loudly rather than let it read stale KV silently.
+    _layout = verify_input.ragged_verify_layout
+    if (
+        _layout is not None
+        and not can_run_cuda_graph
+        and not batch.forward_mode.is_idle()
+        and _layout.verify_lens_cpu is not None
+        and _layout.graph_num_tokens > sum(_layout.verify_lens_cpu)
+    ):
+        raise RuntimeError(
+            "ragged verify fell back to eager while carrying tier slack "
+            f"(tier={_layout.graph_num_tokens}, "
+            f"sum(forward_lens)={sum(_layout.verify_lens_cpu)}, bs={_layout.bs}): "
+            "the eager path would widen the last request past its reserved KV "
+            "window. The planner's graph-admission predicate and the runner's "
+            "can_run_graph decision have diverged."
+        )
+
     # Cover post-prepare rebinds: draft_token, plan_stream-allocated out_cache_loc.
     record_stream_each((batch.input_ids, batch.out_cache_loc), fwd_stream)
 
@@ -565,6 +606,53 @@ def run_eagle_verify(
         is_verify=True,
     )
     logits_output = forward_batch_output.logits_output
+
+    # ---- THE RAGGED SEAM ----------------------------------------------------
+    # Ragged verify ran the forward on sum(w_r) compact rows. Restore the FULL
+    # fixed-width view HERE, before anything else touches the batch or the
+    # outputs, so every consumer below (sampling, accept, logprob, draft-extend,
+    # the scheduler's stride arithmetic) sees the exact rectangle it sees on the
+    # fixed-width path.
+    #
+    # "Full view" means more than the two output tensors. `batch.out_cache_loc`
+    # is also part of it: `prepare_for_draft_extend`'s non-widening branch
+    # deliberately does NOT rebuild the cache map -- on the fixed-width path
+    # verify and draft-extend address the same bs*L slots, so it reuses whatever
+    # verify left on the shared ScheduleBatch. Leaving the compact map there
+    # hands draft-extend bs*L tokens against sum(w_r) locations.
+    #
+    # The ordering is load-bearing, not cosmetic: eagle_sample sizes its
+    # `predict` buffer from next_token_logits.shape[:-1] while retrieve_index
+    # carries global row ids up to bs * num_draft_tokens - 1, so a compact
+    # logits tensor here means an out-of-bounds write inside the verify kernel.
+    #
+    # An IDLE batch is excluded even when it carries a layout. Under DP attention
+    # an idle rank rides the busy ranks' agreed tier so it enters the same
+    # captured graph, but it has no requests: the runner hands back zero logits
+    # rows, and the layout's single fake request describes the graph's shape, not
+    # anything to scatter. Scattering here would inflate an empty tensor to
+    # `[1 * num_draft_tokens, V]` of fill values and hand that to `eagle_sample`.
+    if (
+        verify_input.ragged_verify_layout is not None
+        and not batch.forward_mode.is_idle()
+    ):
+        assert verify_input.ragged_verify_layout.bs == bs, (
+            f"ragged verify layout describes {verify_input.ragged_verify_layout.bs} "
+            f"requests but the batch has {bs}: ScatterCompactToStrided sizes its "
+            "output as layout.bs * num_draft_tokens, while retrieve_index carries "
+            "global row ids up to bs * num_draft_tokens - 1, so a mismatch is an "
+            "out-of-bounds write inside the verify kernel. (A padded_to_bucket "
+            "layout must never reach the spec input.)"
+        )
+        scatter_hybrid_verify_outputs(
+            logits_output=logits_output,
+            layout=verify_input.ragged_verify_layout,
+            verify_width=num_draft_tokens,
+        )
+        if verify_input.ragged_fixed_cache_loc is not None:
+            batch.out_cache_loc = verify_input.ragged_fixed_cache_loc
+            batch.out_cache_loc_dsv4 = verify_input.ragged_fixed_cache_loc_dsv4
+            record_stream_each((batch.out_cache_loc,), fwd_stream)
 
     # Generate vocab mask for constrained decoding
     grammar_mask = None

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -85,6 +85,23 @@ from sglang.srt.speculative.eagle_worker_common import (
     prepare_for_draft_extend,
     run_eagle_verify,
 )
+from sglang.srt.speculative.hybrid_chain import (
+    HybridChainState,
+    build_hybrid_verify_input,
+    parse_position_thresholds,
+)
+from sglang.srt.speculative.hybrid_ragged import (
+    HYBRID_RAGGED_TIER_VETO,
+    agree_hybrid_ragged_dp_tier,
+    build_hybrid_ragged_idle_layout,
+    build_hybrid_ragged_layout,
+    hybrid_ragged_capture_max_bs,
+    hybrid_ragged_capture_tiers,
+    hybrid_ragged_dp_tier_enabled,
+    plan_hybrid_ragged_tier,
+    resolve_hybrid_ragged_tier,
+)
+from sglang.srt.speculative.hybrid_retrieval import HybridRetriever
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
 from sglang.srt.speculative.spec_utils import (
     draft_tp_context,
@@ -156,6 +173,55 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             get_spec().speculative_algorithm
         )
 
+        # Hybrid MTP + retrieval (hybrid retrieval). Init-static: the flags are fixed
+        # for the process lifetime. When enabled, the draft chain is MTP-headed,
+        # truncated per request at the first chain position whose draft prob
+        # falls below that position's tau, and refilled by NGRAM retrieval up to
+        # L = speculative_num_draft_tokens (> num_steps + 1). See hybrid_chain.
+        self.hybrid_enabled = server_args.speculative_hybrid_retrieval
+        # When on, the draft-loop step logprobs are written to a graph-safe
+        # STATIC buffer instead of a Python list, so the draft-loop and
+        # draft-extend cuda graphs can be captured and replayed. Off (default)
+        # keeps the draft loop eager (list-based) and captures only the
+        # target-verify graph.
+        self.hybrid_full_cuda_graph = server_args.speculative_hybrid_full_cuda_graph
+        self.hybrid_state: Optional[HybridChainState] = None
+        self.hybrid_retriever: Optional[HybridRetriever] = None
+        if self.hybrid_enabled:
+            self.hybrid_state = HybridChainState(
+                thresholds=parse_position_thresholds(
+                    server_args.speculative_hybrid_tau_per_pos,
+                    server_args.speculative_hybrid_tau,
+                    self.speculative_num_steps,
+                ),
+                tau_min=server_args.speculative_hybrid_tau_min,
+                dynamic_tau=server_args.speculative_hybrid_dynamic_tau,
+                device=self.device,
+            )
+            self.hybrid_retriever = HybridRetriever(server_args, self.device)
+        # This step's [bs, num_steps-1] draft-loop logprobs, stashed by
+        # draft_forward for the verify-input build (eager path); None on the
+        # full-cuda-graph path, where they live in the static buffer below.
+        self._hybrid_step_logprobs: Optional[torch.Tensor] = None
+        self._hybrid_step_logprobs_buf: Optional[torch.Tensor] = None
+        # One-shot warning latch for the non-greedy ragged fallback.
+        self._hybrid_ragged_nongreedy_warned = False
+        # Whether the graph tier has to be agreed across DP ranks each step.
+        # Resolved once: every input is a frozen server arg or a parallel-state
+        # constant, and re-deriving it per step would risk the ranks disagreeing
+        # about whether the collective happens at all.
+        self.hybrid_ragged_dp_tier = hybrid_ragged_dp_tier_enabled(
+            server_args=server_args
+        )
+        # Advances once per step on EVERY rank (the all-gather is
+        # unconditional), so it is the only key that lines dump rows up across
+        # ranks for the tier-equality check.
+        self._hybrid_ragged_dp_step = 0
+        self._hybrid_ragged_dp_tier_num_tokens: Optional[int] = None
+
+        # Pre-allocated constants for the topk=1 chain fast path in draft_forward.
+        self._topk1_parents_prealloc = None
+        self._topk1_score_indices_prealloc = None
         self._rebuild_topk1_chain_buffers()
 
         # Load draft model weights only.
@@ -265,6 +331,64 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             self.index_share_for_mtp_iteration and self.dsa_index_topk is not None
         )
 
+    def _rebuild_topk1_chain_buffers(self) -> None:
+        # For topk=1 the draft tree degenerates to a chain, so parent_list and
+        # top_scores_index are runtime-invariant. Must be rebuilt after any
+        # change to speculative_num_steps / speculative_num_draft_tokens.
+        if self.topk != 1:
+            return
+        # _override_worker_state can set both directly, bypassing the hook that
+        # pins this relation; the fast path is only valid when it holds.
+        # Hybrid MTP+retrieval intentionally runs with L = num_draft_tokens >
+        # num_steps + 1 (retrieval fills the extra slots). The preallocs below
+        # stay width num_steps -- the MTP draft chain is still num_steps deep --
+        # and the wider verify chain is synthesized in hybrid_chain.
+        if self.hybrid_enabled:
+            assert (
+                self.speculative_num_draft_tokens >= self.speculative_num_steps + 1
+            ), (
+                "hybrid topk=1 requires speculative_num_draft_tokens (L) >= "
+                f"speculative_num_steps + 1, got L={self.speculative_num_draft_tokens} "
+                f"and num_steps={self.speculative_num_steps}"
+            )
+        else:
+            assert (
+                self.speculative_num_draft_tokens == self.speculative_num_steps + 1
+            ), (
+                "topk=1 requires speculative_num_draft_tokens == speculative_num_steps + 1, "
+                f"got {self.speculative_num_draft_tokens} and {self.speculative_num_steps}"
+            )
+        num_steps = self.speculative_num_steps
+        decode_max_bs = (
+            get_exec().graph.cuda_graph_config.decode.max_bs
+            if get_exec().graph.cuda_graph_config is not None
+            else None
+        )
+        max_bs = max(
+            decode_max_bs or 0,
+            get_schedule().max_running_requests or 0,
+            1,
+        )
+        # A single-step chain has no parent entries (slow path drops the last
+        # step). repeat (not expand): the kernel reads these as contiguous.
+        parent_width = num_steps if num_steps > 1 else 0
+        self._topk1_parents_prealloc = torch.arange(
+            -1, parent_width - 1, dtype=torch.long, device=self.device
+        ).repeat(max_bs, 1)
+        self._topk1_score_indices_prealloc = torch.arange(
+            num_steps, dtype=torch.long, device=self.device
+        ).repeat(max_bs, 1)
+        # Graph-safe per-step draft-logprob buffer (chain positions 1..num_steps-1).
+        # A fixed address so draft_forward's in-place writes are captured by the
+        # draft cuda graph and re-executed on replay. Sized to the same max_bs as
+        # the chain preallocs (covers eager max_running and captured graph bs).
+        if self.hybrid_enabled and self.hybrid_full_cuda_graph and num_steps > 1:
+            self._hybrid_step_logprobs_buf = torch.zeros(
+                (max_bs, num_steps - 1), dtype=torch.float32, device=self.device
+            )
+        else:
+            self._hybrid_step_logprobs_buf = None
+
     def init_token_map(self):
         # Load hot token ids
         if self.speculative_algorithm.is_eagle3():
@@ -357,6 +481,24 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             return
 
         if get_model().model_impl == "mindspore":
+            return
+
+        # Hybrid MTP+retrieval keeps the DRAFT loop and the draft-extend reseed
+        # EAGER so draft_forward can assemble the real per-step draft logprobs
+        # the tau truncation reads (a draft-graph replay would skip the Python
+        # list that carries them). The expensive TARGET-verify forward is
+        # captured independently by the target worker at the fixed width L, so
+        # verify still runs as a graph. --speculative-hybrid-full-cuda-graph
+        # routes the logprobs through a static buffer instead, which IS
+        # capturable, and re-enables both draft graphs.
+        if self.hybrid_enabled and not self.hybrid_full_cuda_graph:
+            log_info_on_rank0(
+                logger,
+                "hybrid MTP+retrieval: skipping draft / draft-extend cuda graphs "
+                "(eager draft for real per-step logprobs); the target-verify graph "
+                "is still captured. Pass --speculative-hybrid-full-cuda-graph to "
+                "capture them too.",
+            )
             return
 
         Device2DraftCudaGraphRunner = {
@@ -505,6 +647,10 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             )
 
     def draft(self, batch: ScheduleBatch):
+        # Drop any stash left by a previous iteration (an idle batch never
+        # reaches the hybrid build, so its [0, ...] tensor would otherwise be
+        # consumed by the next real one). draft_forward re-populates it.
+        self._hybrid_step_logprobs = None
         draft_input: EagleDraftInput = batch.spec_info
         forward_batch, can_run_decode_cuda_graph = prepare_for_draft(
             draft_input,
@@ -552,20 +698,336 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                     self.draft_forward(forward_batch)
                 )
 
-        return build_eagle_verify_input(
-            batch,
-            draft_input,
-            parent_list,
-            top_scores_index,
-            draft_tokens,
-            draft_probs,
-            target_worker=self.target_worker,
-            topk=self.topk,
-            num_steps=self.speculative_num_steps,
-            num_draft_tokens=self.speculative_num_draft_tokens,
-            tree_mask_mode=self.tree_mask_mode,
-            device=self.device,
+        if self.hybrid_enabled and not batch.forward_mode.is_idle():
+            verify_input = self._build_hybrid_verify_input(
+                batch, draft_input, draft_tokens
+            )
+        else:
+            verify_input = build_eagle_verify_input(
+                batch,
+                draft_input,
+                parent_list,
+                top_scores_index,
+                draft_tokens,
+                draft_probs,
+                target_worker=self.target_worker,
+                topk=self.topk,
+                num_steps=self.speculative_num_steps,
+                num_draft_tokens=self.speculative_num_draft_tokens,
+                tree_mask_mode=self.tree_mask_mode,
+                device=self.device,
+            )
+
+        # BOTH branches, including the idle one: under DP attention the graph
+        # tier is a collective, and an idle rank has to join it.
+        return self._finalize_hybrid_ragged_layout(batch, verify_input)
+
+    def _build_hybrid_verify_input(
+        self,
+        batch: ScheduleBatch,
+        draft_input: EagleDraftInput,
+        mtp_draft_tokens: torch.Tensor,
+    ) -> EagleVerifyInput:
+        """Truncate the MTP chain by per-position tau and refill it to width L
+        with an agreement-gated retrieval continuation."""
+        bs = mtp_draft_tokens.shape[0]
+        if self.hybrid_full_cuda_graph:
+            # Written by draft_forward (captured + replayed under the graph).
+            step_logprobs = (
+                self._hybrid_step_logprobs_buf[:bs]
+                if self._hybrid_step_logprobs_buf is not None
+                else None
+            )
+        else:
+            step_logprobs, self._hybrid_step_logprobs = self._hybrid_step_logprobs, None
+            assert step_logprobs is not None or self.speculative_num_steps == 1, (
+                "hybrid MTP+retrieval needs the eager topk=1 chain with real draft "
+                "logprobs, but draft_forward produced none (cuda-graph replay or "
+                "oversized-batch slow path). Use --speculative-hybrid-full-cuda-graph "
+                "for the graph path."
+            )
+        assert step_logprobs is None or step_logprobs.shape[0] == bs, (
+            "hybrid MTP+retrieval: draft logprob rows "
+            f"({step_logprobs.shape[0]}) do not match the batch ({bs}); the "
+            "draft-loop stash is stale."
         )
+
+        # The trie walk was launched on a worker thread before draft_forward so
+        # the CPU match overlaps the GPU draft; join it here. The retriever
+        # reports its own continuation lengths -- they cannot be recovered from
+        # the chain, because the padding value 0 is a legal token id.
+        retrieval_chains, retrieval_lens = self.hybrid_retriever.collect()
+        if retrieval_chains is not None:
+            retrieval_chains = retrieval_chains.to(mtp_draft_tokens.dtype)
+
+        return build_hybrid_verify_input(
+            batch=batch,
+            draft_input=draft_input,
+            mtp_draft_tokens=mtp_draft_tokens,
+            step_logprobs=step_logprobs,
+            retrieval_chains=retrieval_chains,
+            retrieval_lens=retrieval_lens,
+            state=self.hybrid_state,
+            topk=self.topk,
+            verify_width=self.speculative_num_draft_tokens,
+            tree_mask_mode=self.tree_mask_mode,
+            target_worker=self.target_worker,
+            ragged=self._hybrid_ragged_enabled_for(batch),
+        )
+
+    def _hybrid_ragged_enabled_for(self, batch: ScheduleBatch) -> bool:
+        """Whether THIS step runs the ragged (variable-length) verify forward.
+
+        The accept cutoff is a port of DSPARK's ``CapCorrectLen``, which caps a
+        GREEDY ``correct_len``. The sampling paths
+        (``tree_speculative_sampling_target_only`` / rejection sampling) walk the
+        tree themselves and would need a per-position draft distribution to cap
+        equivalently -- which the topk=1 chain does not have (``topk_p`` is
+        fused to a constant 1.0). Rather than fail the request, fall back to the
+        fixed-width forward for that step: correctness is identical, only the
+        token saving is lost. Startup already rejects the CONFIGURATIONS that can
+        never be greedy (see ``_check_hybrid_ragged_server_args``); this handles a
+        single non-greedy request landing in an otherwise greedy deployment.
+        """
+        if not self.server_args.speculative_hybrid_ragged:
+            return False
+        if batch.forward_mode.is_idle():
+            return False
+        sampling_info = batch.sampling_info
+        if sampling_info is None or not sampling_info.is_all_greedy:
+            if not self._hybrid_ragged_nongreedy_warned:
+                self._hybrid_ragged_nongreedy_warned = True
+                logger.warning(
+                    "speculative_hybrid_ragged: batch is not all-greedy; this "
+                    "verify step falls back to the fixed-width forward. Output "
+                    "is unaffected; the ragged token saving is not taken."
+                )
+            return False
+        return True
+
+    def _finalize_hybrid_ragged_layout(
+        self, batch: ScheduleBatch, verify_input: EagleVerifyInput
+    ) -> EagleVerifyInput:
+        """Attach the ``RaggedVerifyLayout`` once the graph tier is settled.
+
+        Split out of ``build_hybrid_verify_input`` for one reason: the tier is a
+        CROSS-RANK agreement under DP attention, and an idle rank -- which never
+        builds a hybrid chain -- has to take part in it and then replay the same
+        captured graph. So both of ``draft()``'s branches land here, and this is
+        the single place that writes ``ragged_verify_layout``.
+
+        Three outcomes:
+          * layout with a tier      -- replayable on the token-keyed verify graph
+          * layout without a tier   -- exact ``graph_num_tokens == Σ w_r``; the
+                                      verify runs eager (eager mode's path, and what a
+                                      ``--disable-cuda-graph`` run gets)
+          * no layout               -- plain fixed-width verify
+        """
+        if not self.server_args.speculative_hybrid_ragged:
+            return verify_input
+
+        tier_grid = hybrid_ragged_capture_tiers(target_worker=self.target_worker)
+        accept_lens_cpu = verify_input.ragged_accept_verify_lens_cpu
+
+        if self.hybrid_ragged_dp_tier:
+            tier = self._agree_hybrid_ragged_dp_tier(
+                batch=batch,
+                accept_lens_cpu=accept_lens_cpu,
+                tier_grid=tier_grid,
+            )
+            if tier is None:
+                # Some rank vetoed (or nobody had work). Every rank reaches this
+                # from the same gathered vector, so the whole group drops to
+                # fixed width together -- which is mandatory, not conservative:
+                # a compact batch that does NOT replay a graph goes through
+                # `prepare_mlp_sync_batch`, whose DP padding stretches input_ids
+                # to `bs * num_tokens_per_req` and would not match the compact
+                # attention metadata.
+                return self._clear_hybrid_ragged(verify_input)
+            if accept_lens_cpu is None:
+                # Idle rank: no requests, but it still has to enter the graph.
+                # This branch can ONLY be the idle case: a non-idle rank with no
+                # accept widths (a non-greedy batch) votes VETO, which forces the
+                # agreed tier to None and returns above.
+                assert batch.forward_mode.is_idle(), (
+                    "ragged DP tier agreed but this rank has no accept widths and "
+                    "is not idle; its veto should have taken the whole group to "
+                    "fixed width"
+                )
+                verify_input.ragged_verify_layout = build_hybrid_ragged_idle_layout(
+                    tier_num_tokens=tier, target_worker=self.target_worker
+                )
+                return verify_input
+        elif accept_lens_cpu is None:
+            return self._clear_hybrid_ragged(verify_input)
+        else:
+            # Non-DP. Two differences from the DP branch, both because nothing
+            # here GUARANTEES the graph will be admitted:
+            #
+            #  * the tier is capped at `bs * L`. Above that, plan_hybrid_ragged_tier
+            #    cannot spend all the slack, and if the verify then falls back to
+            #    eager the substrate folds the remainder into the LAST REAL
+            #    request -- widening it past L and past its reserved KV window.
+            #    (On the graph path that same tier is fine: captured slots exceed
+            #    bs, so the remainder lands on pad requests.) When no grid member
+            #    fits under the cap, tier is None and the step runs exact+eager,
+            #    which costs a graph but is always safe.
+            #  * if the runner would not admit this batch at all, do not build a
+            #    tier -- same predicate the DP vote uses, so the two cannot drift.
+            admits = self._hybrid_ragged_graph_admits(
+                batch=batch, accept_lens_cpu=accept_lens_cpu, tier_grid=tier_grid
+            )
+            tier = (
+                resolve_hybrid_ragged_tier(
+                    total_verify_tokens=sum(accept_lens_cpu),
+                    tier_grid=tier_grid,
+                    max_tier=len(accept_lens_cpu) * self.speculative_num_draft_tokens,
+                )
+                if admits
+                else None
+            )
+
+        plan = (
+            plan_hybrid_ragged_tier(
+                accept_verify_lens=accept_lens_cpu,
+                verify_width=self.speculative_num_draft_tokens,
+                tier_num_tokens=tier,
+            )
+            if tier is not None
+            else None
+        )
+        forward_lens = plan.forward_verify_lens if plan else accept_lens_cpu
+        layout = build_hybrid_ragged_layout(
+            verify_lens_cpu=forward_lens,
+            device=self.device,
+            tier_num_tokens=tier,
+        )
+        verify_input.ragged_verify_layout = layout
+        return verify_input
+
+    def _clear_hybrid_ragged(self, verify_input: EagleVerifyInput) -> EagleVerifyInput:
+        """Drop every ragged field so this step is byte-for-byte fixed width.
+
+        The accept widths have to go too, not just the layout: `eagle_sample`
+        keys the cutoff off the layout, so a leftover width vector would be dead
+        weight that a later reader could mistake for "ragged ran".
+        """
+        verify_input.ragged_verify_layout = None
+        verify_input.ragged_accept_verify_lens = None
+        verify_input.ragged_accept_verify_lens_cpu = None
+        return verify_input
+
+    def _agree_hybrid_ragged_dp_tier(
+        self,
+        *,
+        batch: ScheduleBatch,
+        accept_lens_cpu: Optional[List[int]],
+        tier_grid: Optional[List[int]],
+    ) -> Optional[int]:
+        """This rank's vote, then the group's tier. Runs on EVERY rank, every step.
+
+        Unconditional participation is the whole point: the all-gather is the
+        only thing keeping the ranks on one graph shape, so a rank that skipped
+        it (or voted on a locally-derived predicate) would leave the others
+        blocked in the collective. `is_extend_in_batch` and
+        `can_run_dp_cuda_graph` are already dp-global (max- and min-reduced by
+        the MLP sync), so voting them is redundant for agreement -- but it is
+        free, and it keeps the "graph will run" precondition in one place instead
+        of implicitly spread across the runner's admission checks.
+        """
+        self._hybrid_ragged_dp_step += 1
+        local = self._hybrid_ragged_dp_vote(
+            batch=batch, accept_lens_cpu=accept_lens_cpu, tier_grid=tier_grid
+        )
+        tier = agree_hybrid_ragged_dp_tier(
+            local_total_verify_tokens=local,
+            tier_grid=tier_grid,
+            # NOT get_tp_group(): draft() runs inside draft_tp_context under DP,
+            # which patches the global tp group to the draft runner's (world_size
+            # 1 at attn_tp_size == 1). See agree_hybrid_ragged_dp_tier's docstring.
+            cpu_group=self.target_worker.model_runner.tp_group.cpu_group,
+        )
+        self._hybrid_ragged_dp_tier_num_tokens = tier
+        return tier
+
+    def _hybrid_ragged_graph_admits(
+        self,
+        *,
+        batch: ScheduleBatch,
+        accept_lens_cpu: Optional[List[int]],
+        tier_grid: Optional[List[int]],
+    ) -> bool:
+        """Will the decode runner admit this step's ragged verify to a graph?
+
+        The PER-RANK, per-step subset of `can_run_graph` /
+        `_can_run_ragged_verify_graph` that is knowable here. It has two callers
+        that must never disagree:
+
+          * the DP vote -- a rank that would not be admitted has to veto, or it
+            runs its compact batch eager (through prepare_mlp_sync_batch's DP
+            padding) while its peers replay the graph, and the group hangs;
+          * the non-DP tier choice -- a tier above `bs * verify_width` is only
+            safe when the graph runs, because only then do captured PAD requests
+            exist to absorb the slack. On the eager path the substrate folds it
+            into the last real request instead.
+
+        Conditions deliberately NOT here because they are process-static or
+        dp-global rather than per-rank: `supports_ragged_verify_graph`, the
+        capture_hidden_mode match, `can_run_dp_cuda_graph` and
+        `is_extend_in_batch` (the last two are voted separately, since they are
+        dp-global by construction and belong to the DP decision).
+        """
+        if accept_lens_cpu is None or not tier_grid:
+            return False
+        if batch.replace_embeds is not None:
+            # can_run_graph's FIRST test, before it ever reaches the ragged
+            # branch, so the vote has to cover it or the two drift apart. It is a
+            # PER-RANK property: only ranks holding a request with a
+            # token-embedding override carry it, so one rank refusing the graph
+            # must take the whole group to fixed width.
+            #
+            # `prepare_for_decode` now clears the overrides (they address prefill
+            # rows), so on a decode-family batch this is normally already None.
+            # Keep the test anyway: it is the union with can_run_graph, and if a
+            # future field ever survives into decode again, the group still falls
+            # back together instead of splitting.
+            return False
+        if sum(accept_lens_cpu) > tier_grid[-1]:
+            return False
+        if len(accept_lens_cpu) > hybrid_ragged_capture_max_bs(
+            target_worker=self.target_worker
+        ):
+            # The runner's `batch_size <= _ragged_capture_slots(tier)` =
+            # `min(tier, max_bs)`. Every w_r >= 1 makes the tier >= bs, so it
+            # reduces exactly to `bs <= max_bs` -- and max_bs = max(capture_bs)
+            # comes from --cuda-graph-max-bs, which is INDEPENDENT of
+            # --max-running-requests.
+            return False
+        return True
+
+    def _hybrid_ragged_dp_vote(
+        self,
+        *,
+        batch: ScheduleBatch,
+        accept_lens_cpu: Optional[List[int]],
+        tier_grid: Optional[List[int]],
+    ) -> int:
+        if batch.forward_mode.is_idle():
+            # Nothing to verify, no objection: an idle rank rides whatever tier
+            # the busy ranks agree on.
+            return 0
+        if accept_lens_cpu is None:
+            # Ragged is off for this step on this rank (non-greedy batch). A 0
+            # here would read as "no objection" and let the peers go ragged while
+            # this rank runs fixed width -- different graph, hung group.
+            return HYBRID_RAGGED_TIER_VETO
+        if batch.is_extend_in_batch or not batch.can_run_dp_cuda_graph:
+            return HYBRID_RAGGED_TIER_VETO
+        if not self._hybrid_ragged_graph_admits(
+            batch=batch, accept_lens_cpu=accept_lens_cpu, tier_grid=tier_grid
+        ):
+            return HYBRID_RAGGED_TIER_VETO
+        return sum(accept_lens_cpu)
 
     def draft_forward(self, forward_batch: ForwardBatch):
         # Parse args
@@ -619,6 +1081,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 device=topk_index.device,
             )
             draft_tokens_topk1[:, :1].copy_(topk_index)
+
+        # Real per-step draft logprobs on the topk=1 chain fast path (production
+        # fakes topk_p to 1.0 inside the fused kernel). The hybrid chain uses
+        # them for confidence-based truncation.
+        hybrid_on = self.hybrid_enabled and draft_tokens_topk1 is not None
+        step_logprobs_buf = self._hybrid_step_logprobs_buf if hybrid_on else None
+        step_lp_list: List[torch.Tensor] = []
 
         # Forward multiple steps
         scores = None
@@ -703,6 +1172,21 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                     )
                     topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
                     forward_batch.positions.add_(1)
+                if hybrid_on:
+                    # log p_draft(argmax token) = gather - logsumexp; avoids
+                    # materializing the full [bs, vocab] log_softmax. This
+                    # forward produces chain position i + 1.
+                    step_logits = logits_output.next_token_logits
+                    step_lp = torch.gather(
+                        step_logits, -1, topk_index
+                    ) - torch.logsumexp(step_logits, dim=-1, keepdim=True)
+                    if step_logprobs_buf is not None:
+                        # In-place write into the graph-safe static buffer
+                        # (column i = chain position i + 1), so the draft cuda
+                        # graph captures it and replays it.
+                        step_logprobs_buf[: step_lp.shape[0], i] = step_lp.squeeze(-1)
+                    else:
+                        step_lp_list.append(step_lp)
                 maybe_detect_oob(
                     topk_index,
                     0,
@@ -718,6 +1202,12 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             if get_spec().speculative_use_rejection_sampling
             else None
         )
+
+        step_logprobs = torch.cat(step_lp_list, dim=1) if step_lp_list else None
+        if hybrid_on and step_logprobs_buf is None:
+            # Stash for the hybrid verify-input build (draft -> build is
+            # sequential within this forward step).
+            self._hybrid_step_logprobs = step_logprobs
 
         # Organize the results
         if draft_tokens_topk1 is not None:
@@ -1102,6 +1592,23 @@ class EAGLEWorkerV2(BaseSpecWorker):
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
 
+    def clear_cache_pool(self):
+        """Clear hybrid retrieval's process-local online retrieval state."""
+        dw = self._draft_worker
+        if dw.hybrid_retriever is not None:
+            dw.hybrid_retriever.reset()
+
+        state = dw.hybrid_state
+        if state is not None:
+            state.extension_ema = 0.0
+            state.last_num_keep_drafts = None
+            state.last_graft_ok = None
+
+        # The static graph buffer is deliberately retained: it has a
+        # capture-stable address and every active slice is overwritten before use.
+        dw._hybrid_step_logprobs = None
+        logger.info("Hybrid NGRAM corpus and retrieval state reset")
+
     @property
     def last_shared_read_runner(self):
         # Per the base contract: the step's last shared-buffer-reading phase is
@@ -1188,6 +1695,16 @@ class EAGLEWorkerV2(BaseSpecWorker):
                         batch_output.logits_output.mm_input_embeds,
                     )
                 )
+                # Index the full prompt into the trie so hybrid retrieval can
+                # copy from the prompt (RAG / long-context / code-with-context).
+                # The decode-time insert only adds sliding windows of generated
+                # text, so without this the prompt body is never matchable.
+                if (
+                    self.draft_worker.hybrid_retriever is not None
+                    and self.server_args.speculative_hybrid_index_prompt
+                    and not batch.forward_mode.is_idle()
+                ):
+                    self.draft_worker.hybrid_retriever.insert_prompt(batch.reqs)
                 return batch_output
         else:
             self.activate_step_by_batch(batch.seq_lens.shape[0])
@@ -1214,6 +1731,14 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 # runs, keeping draft KV warm for when the batch shrinks.
                 verify_input = self._build_trivial_verify_input(batch)
             else:
+                # Kick off the NGRAM trie walk on a worker thread BEFORE the GPU
+                # draft_forward so the CPU match overlaps it; the hybrid
+                # verify-input build joins it.
+                if (
+                    self.draft_worker.hybrid_retriever is not None
+                    and not batch.forward_mode.is_idle()
+                ):
+                    self.draft_worker.hybrid_retriever.launch_query(batch.reqs)
                 with (
                     self.draft_worker.draft_tp_context(
                         self.draft_worker.draft_runner.tp_group
@@ -1229,6 +1754,10 @@ class EAGLEWorkerV2(BaseSpecWorker):
             # Publish before draft_extend so the fence is at verify-end.
             if on_publish is not None:
                 on_publish(batch_output.new_seq_lens)
+            # Must run after on_publish (seq_lens published first) and before
+            # the next launch_query drains the relay.
+            if not batch.forward_mode.is_idle():
+                self._hybrid_after_verify(batch, batch_output)
             if (
                 self.speculative_num_steps == 0
                 and envs.SGLANG_SPEC_SKIP_ZERO_STEP_DRAFT_EXTEND.get()
@@ -1245,7 +1774,44 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 ):
                     self.draft_worker._draft_extend_for_decode(batch, batch_output)
 
+            # Fold the verified context into the trie AFTER querying it
+            # (query-first / insert-after mirrors NGRAMWorker, so a query
+            # matches earlier occurrences of the suffix, not the just-written
+            # leaf), then drop match state for finished/retracted requests.
+            if (
+                self.draft_worker.hybrid_retriever is not None
+                and not batch.forward_mode.is_idle()
+            ):
+                self.draft_worker.hybrid_retriever.insert(batch.reqs)
+                self.draft_worker.hybrid_retriever.erase(batch.reqs)
+
             return batch_output
+
+    def _hybrid_after_verify(
+        self, batch: ScheduleBatch, batch_output: GenerationBatchResult
+    ) -> None:
+        """Post-verify hybrid bookkeeping: the overlap accepted-token relay and
+        the retrieval-extension EMA that drives dynamic tau."""
+        retriever = self.draft_worker.hybrid_retriever
+        if retriever is None:
+            return
+        if retriever.overlap:
+            # Relay this step's accepted tokens into the retriever's shadow
+            # context via an async D2H, off the forward hot path.
+            # next_token_ids / accept_lens are the same tensors the scheduler
+            # commits from; the stride is speculative_num_draft_tokens (= L).
+            retriever.publish_accepted(
+                batch.reqs,
+                batch_output.next_token_ids,
+                batch_output.accept_lens,
+                batch_output.speculative_num_draft_tokens,
+            )
+        state = self.draft_worker.hybrid_state
+        if state is not None and state.dynamic_tau:
+            state.update_extension_ema(
+                num_correct_drafts=batch_output.accept_lens - 1,
+                keep_on_device=retriever.overlap,
+            )
 
     def _build_trivial_verify_input(self, batch: ScheduleBatch) -> EagleVerifyInput:
         """Build a 1-node EagleVerifyInput rooted at the previous bonus token.

--- a/python/sglang/srt/speculative/hybrid_chain.py
+++ b/python/sglang/srt/speculative/hybrid_chain.py
@@ -1,0 +1,483 @@
+"""Hybrid MTP + retrieval verify chain (hybrid retrieval).
+
+The MTP (EAGLE/NextN, topk=1) draft heads the chain. Per request, the chain is
+truncated at the first position whose draft probability falls below that
+position's threshold tau, and the remaining slots -- up to the fixed verify
+width ``L = speculative_num_draft_tokens`` -- are refilled with an
+agreement-gated NGRAM retrieval continuation. The spliced linear chain is handed
+to the shared ``build_tree_kernel_efficient`` as a topk=1 chain of depth
+``L - 1``, so every verify tensor (mask / positions / retrieve_*) matches the
+kernels exactly and the target verify is a plain (wider) TARGET_VERIFY forward.
+
+Two invariants keep this safe:
+
+* **Correctness is untouched.** A retrieved token is committed only if it equals
+  the target model's argmax at that position, exactly like an MTP draft token.
+  Retrieval changes accept LENGTH, never the emitted text.
+* **Monotonicity.** Retrieval is appended AFTER the kept MTP block, and
+  attention is causal, so a retrieval slot can never change the accept/reject
+  decision of an MTP slot. When the agreement gate fails the full MTP chain is
+  kept (no truncation), so a hybrid step never accepts fewer tokens than the
+  pure-MTP step would have.
+
+Numbering: everything user-facing is indexed by **verify-chain column**. For
+``num_steps = S`` the chain is ``[column 0 = bonus token, column 1 = MTP draft
+0, ..., column S = MTP draft S-1]``, and retrieval fills columns ``S+1 ..
+L-1``. Internally the chain math is indexed by draft position (column - 1).
+
+The FIRST MTP draft (verify column 1) is ALWAYS kept. Its draft logprob is
+produced by the previous iteration's draft-extend and would have to be carried
+across a batch re-composition boundary. Avoiding that cross-iteration carrier
+also lets the draft loop run under a CUDA graph (see ``full_cuda_graph``).
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional, Tuple
+
+import torch
+
+from sglang.srt.distributed import get_tp_group
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+from sglang.srt.runtime_context import get_parallel
+from sglang.srt.speculative.eagle_info import EagleDraftInput, EagleVerifyInput
+from sglang.srt.speculative.eagle_utils import TreeMaskMode, build_tree_kernel_efficient
+from sglang.srt.speculative.hybrid_ragged import compute_hybrid_verify_lens
+
+# Sentinel for "never truncate at this chain position".
+TAU_DISABLED = ("off", "disabled", "none", "")
+
+
+def parse_position_thresholds(
+    spec: str, scalar_tau: float, num_steps: int
+) -> List[float]:
+    """Resolve the per-position truncation thresholds (probabilities).
+
+    ``spec`` is indexed by **verify-chain column**. For
+    ``--speculative-num-steps S`` the verify chain that the MTP draft produces
+    is::
+
+        column 0  = the bonus token (the target's own last prediction, the
+                    chain root) -- never a draft, never truncatable
+        column 1  = MTP draft 0
+        ...
+        column S  = MTP draft S-1
+
+    so ``spec`` must carry exactly ``S + 1`` comma-separated entries. An entry
+    in :data:`TAU_DISABLED` (or ``0``) means "never truncate at this column".
+    Columns 0 and 1 must both be disabled -- column 0 because it is the bonus
+    token, column 1 because its draft logprob comes from the previous
+    iteration's draft-extend (see the module docstring).
+
+    Example for ``S = 3`` (verify columns 0,1,2,3): ``off,off,0.40,0.55``
+    keeps the bonus and the first draft unconditionally, truncates before the
+    second draft when its confidence < 0.40, and before the third when < 0.55.
+
+    An empty ``spec`` falls back to ``scalar_tau`` on columns 2..S.
+
+    Returns ``num_steps`` probabilities indexed by DRAFT position
+    (``result[i]`` is the threshold of verify column ``i + 1``); ``0.0`` marks
+    a disabled position.
+    """
+    if not spec.strip():
+        return [0.0] + [scalar_tau] * (num_steps - 1)
+
+    entries = [x.strip().lower() for x in spec.split(",")]
+    if len(entries) != num_steps + 1:
+        raise ValueError(
+            "speculative_hybrid_tau_per_pos is indexed by verify-chain column "
+            "(column 0 = the bonus token, columns 1..S = the MTP drafts), so it "
+            f"must have exactly speculative_num_steps + 1 = {num_steps + 1} "
+            f"comma-separated entries; got {len(entries)}: {spec!r}. For S=3 the "
+            "calibrated setting is 'off,off,0.40,0.55'."
+        )
+    columns = []
+    for column, entry in enumerate(entries):
+        if entry in TAU_DISABLED:
+            columns.append(0.0)
+            continue
+        value = float(entry)
+        if not 0.0 <= value <= 1.0:
+            raise ValueError(
+                f"speculative_hybrid_tau_per_pos column {column} must be a "
+                f"probability in [0, 1] or one of {TAU_DISABLED}; got {entry!r}"
+            )
+        columns.append(value)
+    if columns[0] != 0.0:
+        raise ValueError(
+            "speculative_hybrid_tau_per_pos column 0 must be disabled (one of "
+            f"{TAU_DISABLED}, or 0): column 0 is the bonus token, which the "
+            "target model itself produced -- it is never a draft and is never "
+            "truncated."
+        )
+    if columns[1] != 0.0:
+        raise ValueError(
+            "speculative_hybrid_tau_per_pos column 1 must be disabled (one of "
+            f"{TAU_DISABLED}, or 0): the first MTP draft's logprob comes from "
+            "the previous iteration's draft-extend and is not carried across "
+            "batch re-composition, so it cannot gate a truncation."
+        )
+    # Drop the bonus column; the chain math is indexed by draft position.
+    return columns[1:]
+
+
+class HybridChainState:
+    """Per-worker mutable state of the hybrid chain.
+
+    Holds the truncation thresholds (init-static), the retrieval-extension EMA
+    that drives dynamic tau, and the previous step's per-request diagnostics
+    that the EMA update reads back after target verification.
+    """
+
+    # EMA smoothing of the retrieval-extension rate (dynamic tau).
+    EMA_DECAY = 0.95
+
+    def __init__(
+        self,
+        *,
+        thresholds: List[float],
+        tau_min: float,
+        dynamic_tau: bool,
+        device: str,
+    ):
+        self.thresholds = thresholds  # [num_steps] probabilities, 0 = disabled
+        self.tau_min = tau_min
+        self.dynamic_tau = dynamic_tau
+        # log thresholds for chain positions 1..num_steps-1 (position 0 is
+        # always kept, so it never participates in the comparison).
+        self._tail_log = torch.tensor(
+            [_safe_log(t) for t in thresholds[1:]],
+            dtype=torch.float32,
+            device=device,
+        )
+        self._tail_log_min = torch.full_like(self._tail_log, _safe_log(tau_min))
+        # Positions configured as "disabled" must stay disabled under dynamic
+        # tau as well, so remember them and re-apply -inf after interpolation.
+        self._tail_enabled = torch.tensor(
+            [t > 0.0 for t in thresholds[1:]], dtype=torch.bool, device=device
+        )
+        # Interpolation operand with -inf swapped for tau_min: (-inf) - (-inf)
+        # is NaN, and even though the NaN is discarded by the torch.where below
+        # it would trip the async NaN probes.
+        self._tail_log_finite = torch.where(
+            self._tail_enabled, self._tail_log, self._tail_log_min
+        )
+
+        # Retrieval-extension EMA: 0 = retrieval is not extending anything, so
+        # the cold start avoids paying any truncation cost.
+        self.extension_ema: float | torch.Tensor = 0.0
+        # Stashed [bs] tensors from the last built chain, read by the EMA update.
+        self.last_num_keep_drafts: Optional[torch.Tensor] = None
+        self.last_graft_ok: Optional[torch.Tensor] = None
+
+    def tail_log_thresholds(self) -> torch.Tensor:
+        """Effective log thresholds for chain positions 1..num_steps-1.
+
+        With dynamic tau on, each enabled position drifts between ``tau_min``
+        (minimal truncation ~ pure MTP, when retrieval is idle) and its
+        configured tau (aggressive handoff, when retrieval is extending), driven
+        by the retrieval-extension EMA. Disabled positions stay disabled.
+        """
+        if not self.dynamic_tau:
+            return self._tail_log
+        ema = self.extension_ema
+        # Interpolate in LOG space: monotone in the same direction as
+        # probability space and avoids a device round-trip when the EMA is a
+        # device scalar (overlap mode keeps it on GPU to dodge a per-step D2H).
+        effective = (
+            self._tail_log_min + (self._tail_log_finite - self._tail_log_min) * ema
+        )
+        return torch.where(self._tail_enabled, effective, self._tail_log)
+
+    def update_extension_ema(
+        self, *, num_correct_drafts: torch.Tensor, keep_on_device: bool
+    ) -> None:
+        """Fold this verify's retrieval-extension rate into the EMA.
+
+        "Extended" = acceptance reached past the kept MTP prefix AND the graft
+        actually happened -- i.e. RETRIEVAL contributed. Gating on ``graft_ok``
+        is required: on a failed graft the full (un-truncated) MTP chain is
+        kept, so ``num_correct_drafts > num_keep_drafts`` there is plain MTP
+        acceptance, and counting it would push tau up while retrieval was idle.
+        """
+        if self.last_num_keep_drafts is None or self.last_graft_ok is None:
+            return
+        extended = (num_correct_drafts > self.last_num_keep_drafts) & self.last_graft_ok
+        rate = extended.float().mean()
+        if keep_on_device:
+            # Overlap: keep the EMA on GPU -- a per-step .item() would
+            # re-serialize the hot path. It is only ever read as a broadcast
+            # operand in tail_log_thresholds().
+            self.extension_ema = (
+                self.EMA_DECAY * self.extension_ema + (1.0 - self.EMA_DECAY) * rate
+            )
+        else:
+            self.extension_ema = (
+                self.EMA_DECAY * float(self.extension_ema)
+                + (1.0 - self.EMA_DECAY) * rate.item()
+            )
+
+
+def _safe_log(p: float) -> float:
+    """log(p) with 0 mapped to -inf (= "never truncate at this position")."""
+    return -math.inf if p <= 0.0 else math.log(p)
+
+
+def splice_hybrid_chain(
+    *,
+    mtp_draft_tokens: torch.Tensor,
+    step_logprobs: Optional[torch.Tensor],
+    retrieval_chains: Optional[torch.Tensor],
+    retrieval_lens: Optional[torch.Tensor],
+    tail_log_thresholds: torch.Tensor,
+    verify_width: int,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Build the ``[bs, L-1]`` spliced chain body (verify columns 1..L-1).
+
+    ``mtp_draft_tokens`` is ``[bs, num_steps]`` (column i = chain position i);
+    ``step_logprobs`` is ``[bs, num_steps-1]`` (column j = log p_draft of chain
+    position j+1), or None when ``num_steps == 1``; ``retrieval_chains`` is
+    ``[bs, L]`` with column 0 = the root (verified context's last token) and
+    ``retrieval_lens`` is ``[bs]``, the retriever's own count of how many of the
+    columns after the root are REAL.
+
+    ``retrieval_lens`` is not optional bookkeeping: the padding value is 0 and
+    token id 0 is a legal vocabulary entry, so without it the agreement gate
+    would match padding against a genuine MTP token 0 and report a graft that
+    never happened.
+
+    Returns ``(spliced, num_keep_drafts, num_agree_drafts, graft_ok)``.
+    """
+    bs, num_steps = mtp_draft_tokens.shape
+    device = mtp_draft_tokens.device
+
+    # Leading run of kept MTP positions. Position 0 is always kept, so start at
+    # 1 and extend while each tail position clears its threshold. cumprod over
+    # the 0/1 keep mask is exact and device-portable.
+    if step_logprobs is None:
+        num_keep_drafts = torch.ones(bs, dtype=torch.long, device=device)
+    else:
+        keep = (step_logprobs >= tail_log_thresholds).to(torch.float32)
+        num_keep_drafts = 1 + torch.cumprod(keep, dim=1).sum(dim=1).to(torch.long)
+
+    if retrieval_chains is None:
+        retrieval_chains = torch.zeros(
+            (bs, verify_width), dtype=mtp_draft_tokens.dtype, device=device
+        )
+        retrieval_lens = torch.zeros(bs, dtype=torch.long, device=device)
+    assert retrieval_lens is not None, (
+        "splice_hybrid_chain needs the retriever's own continuation lengths; "
+        "they cannot be recovered from the chain because the padding value 0 is "
+        "a legal token id"
+    )
+
+    # Agreement gate: graft the retrieval tail only when the retrieved chain
+    # matches the kept MTP prefix, so the tail is validly conditioned on it.
+    # Compare only against columns the retriever actually filled: past its
+    # length the chain holds zero PADDING, and a genuine MTP token 0 there would
+    # otherwise register as agreement and fake a graft that never happened.
+    step_col = torch.arange(1, num_steps + 1, device=device)
+    retrieval_valid = step_col[None, :] <= retrieval_lens.to(torch.long)[:, None]
+    agree = (
+        (retrieval_chains[:, 1 : num_steps + 1] == mtp_draft_tokens) & retrieval_valid
+    ).to(torch.float32)
+    num_agree_drafts = torch.cumprod(agree, dim=1).sum(dim=1).to(torch.long)
+    graft_ok = num_agree_drafts >= num_keep_drafts
+
+    # When the agreement gate FAILS, do NOT truncate: feed the full MTP chain
+    # into verify instead of zero-padding the tail. A pad token is always
+    # rejected; a real MTP token still has a chance, so a failed graft must not
+    # waste the truncated positions.
+    effective_keep = torch.where(
+        graft_ok, num_keep_drafts, torch.full_like(num_keep_drafts, num_steps)
+    )
+
+    # Verify column c (1..L-1) carries chain position c: MTP draft c-1 while
+    # c <= effective_keep, otherwise the retrieval continuation (or a zero pad
+    # when the graft failed).
+    col = torch.arange(1, verify_width, device=device)  # [L-1]
+    keep_width = effective_keep[:, None]
+    is_mtp = col[None, :] <= keep_width
+    mtp_at = mtp_draft_tokens[:, (col - 1).clamp(0, num_steps - 1)]
+    retrieval_at = retrieval_chains[:, col]
+    use_retrieval = (col[None, :] > keep_width) & graft_ok[:, None]
+    spliced = torch.where(
+        is_mtp,
+        mtp_at,
+        torch.where(use_retrieval, retrieval_at, torch.zeros_like(retrieval_at)),
+    )
+    return spliced, num_keep_drafts, num_agree_drafts, graft_ok
+
+
+def build_hybrid_verify_input(
+    *,
+    batch,
+    draft_input: EagleDraftInput,
+    mtp_draft_tokens: torch.Tensor,
+    step_logprobs: Optional[torch.Tensor],
+    retrieval_chains: Optional[torch.Tensor],
+    retrieval_lens: Optional[torch.Tensor],
+    state: HybridChainState,
+    topk: int,
+    verify_width: int,
+    tree_mask_mode: TreeMaskMode,
+    target_worker,
+    ragged: bool = False,
+) -> EagleVerifyInput:
+    """Assemble the hybrid ``EagleVerifyInput`` at width ``L = verify_width``.
+
+    Mirrors ``eagle_worker_common.build_eagle_verify_input`` but feeds the
+    spliced MTP+retrieval chain and declares ``spec_steps = L - 1`` so the
+    accept kernel's row width (``spec_steps + 1``) is L and acceptance is not
+    capped at the MTP chain depth.
+
+    With ``ragged=True`` the input additionally carries a ``RaggedVerifyLayout``
+    so the target-verify forward only computes each request's live columns; see
+    ``hybrid_ragged.py``. The spliced chain itself stays ``[bs, L]`` either way.
+    """
+    spliced, num_keep_drafts, num_agree_drafts, graft_ok = splice_hybrid_chain(
+        mtp_draft_tokens=mtp_draft_tokens,
+        step_logprobs=step_logprobs,
+        retrieval_chains=retrieval_chains,
+        retrieval_lens=retrieval_lens,
+        tail_log_thresholds=state.tail_log_thresholds(),
+        verify_width=verify_width,
+    )
+    state.last_num_keep_drafts = num_keep_drafts
+    state.last_graft_ok = graft_ok
+
+    bs = mtp_draft_tokens.shape[0]
+    device = mtp_draft_tokens.device
+
+    tree_mask_buf, position_buf = (
+        target_worker.model_runner.attn_backend.get_verify_buffers_to_fill_after_draft()
+    )
+    # build_tree_kernel uses seq_lens_sum only to size the (non-preallocated)
+    # tree mask; over-sizing is safe. Skip the per-iter .sum().item() D2H.
+    seq_lens_sum = batch.seq_lens_sum
+    if seq_lens_sum is None:
+        if tree_mask_buf is None:
+            seq_lens_sum = bs * target_worker.model_runner.attn_backend.max_context_len
+        else:
+            seq_lens_sum = 0  # preallocated buffer -> the kernel ignores it
+
+    # parent_list / top_scores_index are the runtime-invariant linear chain,
+    # same closed form as the topk=1 preallocs but at width L-1.
+    parent_list = torch.arange(
+        -1, verify_width - 2, dtype=torch.long, device=device
+    ).repeat(bs, 1)
+    top_scores_index = torch.arange(
+        verify_width - 1, dtype=torch.long, device=device
+    ).repeat(bs, 1)
+    (
+        tree_mask,
+        positions,
+        retrieve_index,
+        retrieve_next_token,
+        retrieve_next_sibling,
+        draft_tokens,
+    ) = build_tree_kernel_efficient(
+        draft_input.bonus_tokens,
+        parent_list,
+        top_scores_index,
+        spliced,
+        batch.seq_lens,
+        seq_lens_sum,
+        topk,
+        verify_width - 1,  # chain depth
+        verify_width,  # num_verify_tokens
+        tree_mask_mode,
+        tree_mask_buf,
+        position_buf,
+    )
+
+    # The retriever's own length. NOT a non-zero count: token id 0 is a legal
+    # vocabulary entry (DSV4's <|begin_of_sentence|>, and it is in the trie
+    # because the full prompt is indexed), so counting non-zeros conflates a
+    # genuine 0 with tail padding and reports a chain shorter than it is --
+    # which would make w_r violate its own `>= 1 + num_keep_drafts` floor.
+    num_retrieval_tokens = (
+        retrieval_lens.to(num_keep_drafts.dtype)
+        if retrieval_lens is not None
+        else torch.zeros_like(num_keep_drafts)
+    )
+    verify_lens = (
+        compute_hybrid_verify_lens(
+            num_keep_drafts=num_keep_drafts,
+            graft_ok=graft_ok,
+            num_retrieval_tokens=num_retrieval_tokens,
+            num_steps=mtp_draft_tokens.shape[1],
+            verify_width=verify_width,
+        )
+        if ragged
+        else None
+    )
+
+    # TP consistency: num_keep_drafts thresholds a continuous logsumexp of the
+    # TP-sharded all-reduced draft logits (NOT bit-identical across ranks), and
+    # mtp_draft_tokens is a per-rank argmax. The GREEDY verify path does not
+    # broadcast accept_index, so any per-rank divergence in the spliced
+    # candidates would desync seq_lens across the TP group (hang / KV
+    # corruption). Broadcast the final candidate chain from rank 0, mirroring
+    # what the sampling path does for predict/accept_index. positions /
+    # retrieve_* / tree_mask are deterministic (derived from parent_list and
+    # seq_lens), so only draft_tokens needs syncing.
+    #
+    # verify_lens is derived from the SAME non-bit-identical quantities, and
+    # under ragged it selects the forward's shape: a per-rank disagreement would
+    # give the ranks differently-shaped collectives and hang the group. It is
+    # concatenated into the existing broadcast rather than sent separately --
+    # one collective, and the two can never be broadcast out of step.
+    tp_group = (
+        get_parallel().attn_tp_group if is_dp_attention_enabled() else get_tp_group()
+    )
+    if tp_group.world_size > 1:
+        if verify_lens is None:
+            tp_group.broadcast(draft_tokens, src=0)
+        else:
+            payload = torch.cat(
+                [draft_tokens.view(-1), verify_lens.to(draft_tokens.dtype)]
+            )
+            tp_group.broadcast(payload, src=0)
+            draft_tokens.view(-1).copy_(payload[: draft_tokens.numel()])
+            verify_lens = payload[draft_tokens.numel() :].to(torch.int32)
+
+    accept_verify_lens_cpu = None
+    if verify_lens is not None:
+        # T2 (exact) tier policy: one small D2H per step. verify_lens_cpu is not
+        # optional here -- the eager DSV4 metadata path reads it through
+        # compute_ragged_extend_lengths, and RaggedVerifyLayout's invariant
+        # checks only run when it is populated. future no-sync mode replaces this with the lagged
+        # EMA budget (T1), which needs no sync at all.
+        accept_verify_lens_cpu = [int(v) for v in verify_lens.tolist()]
+
+    return EagleVerifyInput(
+        draft_token=draft_tokens,
+        custom_mask=tree_mask,
+        positions=positions,
+        retrieve_index=retrieve_index,
+        retrieve_next_token=retrieve_next_token,
+        retrieve_next_sibling=retrieve_next_sibling,
+        retrieve_cum_len=None,
+        # spec_steps = L-1 so max_tree_depth (= spec_steps + 1) is L; otherwise
+        # the accept kernel caps acceptance at num_steps + 1 and silently drops
+        # every retrieval slot past the MTP chain.
+        spec_steps=verify_width - 1,
+        topk=topk,
+        draft_token_num=verify_width,
+        capture_hidden_mode=None,
+        seq_lens_sum=None,
+        seq_lens_cpu=None,
+        draft_probs=None,
+        # NO layout yet, on purpose. The layout carries `graph_num_tokens` = the
+        # captured tier, and under DP attention that tier is a CROSS-RANK
+        # agreement -- which an idle rank must join too, and an idle rank never
+        # reaches this function. So the layout is built one level up, in
+        # `EagleDraftWorker._finalize_hybrid_ragged_layout`, where the hybrid and
+        # the idle branches converge. Only the accept widths (true `w_r`) are
+        # settled here.
+        ragged_verify_layout=None,
+        ragged_accept_verify_lens=verify_lens,
+        ragged_accept_verify_lens_cpu=accept_verify_lens_cpu,
+    )

--- a/python/sglang/srt/speculative/hybrid_ragged.py
+++ b/python/sglang/srt/speculative/hybrid_ragged.py
@@ -1,0 +1,957 @@
+"""hybrid retrieval ragged (variable-length) verify -- the compact-forward seam.
+
+The hybrid chain (``hybrid_chain.py``) is extremely bimodal in how many verify
+columns it actually needs: a request whose retrieval graft FAILED only needs the
+``1 + num_steps`` MTP columns, while a request whose graft SUCCEEDED wants the
+full ``L`` width. Padding every request to ``L`` burns ~40% of the verify tokens
+on columns that are known-dead before the forward even starts.
+
+This module makes the target-verify forward *ragged*: request ``r`` contributes
+only ``w_r`` rows, packed back to back. Everything is organised around ONE seam,
+mirroring DSPARK (``dspark_verify.py:run_compact``)::
+
+    1. build_hybrid_ragged_layout   -> per-request w_r + a RaggedVerifyLayout
+    2. build_hybrid_ragged_window   -> compact verify_ids / positions / cache_loc
+    3. target forward                  compact logits/hidden [total_tokens, ...]
+    4. scatter_hybrid_verify_outputs-> fixed stride  [bs * L, ...]     <-- SEAM
+    5. everything downstream (accept, retrieve_index, scheduler stride,
+       draft-extend, grammar, logprob) sees the SAME [bs, L] rectangle it sees
+       today and is byte-for-byte unchanged.
+
+Only one piece of NEW semantics is required past the seam: the columns beyond
+``w_r`` were never computed, so they are filled with ``fill_value`` and MUST NOT
+be acceptable. That is :func:`cap_accept_to_verify_lens`, a straight port of
+DSPARK's ``CapCorrectLen``. This is not defensive programming -- the padded
+logits are zeros so ``argmax`` is token 0, the padded candidate columns are also
+0, and ``0 == 0`` chains all the way to ``L``. Without the cap the failure is
+systematic, not occasional.
+
+Graph-tier mode adds token-tier CUDA graphs and DP cross-rank tier agreement:
+
+  * **The tier grid.** A captured graph has ONE token count, so the step's
+    ``sum(w_r)`` is rounded UP to a captured tier. The substrate's default grid
+    is ``{bs * L}``, whose spacing is ``L`` while the real totals move in
+    quanta of ``L - floor``. A quantum-aligned grid therefore preserves more of
+    the ragged saving, so hybrid retrieval builds its own.
+  * **Two length vectors.** ``sum(w_r)`` rarely lands exactly on a tier, and the
+    substrate disposes of the difference by inflating the LAST REAL request's
+    verify_len (``pad_verify_lens_to_bucket``, the ``num_pad_reqs == 0`` branch)
+    -- which can push a real request past ``L`` and make the attention read KV
+    slots the scheduler never reserved. Hybrid retrieval instead spends the slack
+    itself, spread across requests and capped at ``L`` each, so the substrate's
+    leftover is zero and nothing is ever inflated out of its reservation. The
+    price is that the forward now computes columns that are real geometry but
+    hold zero-padded candidates, so the accept cutoff must use the ORIGINAL
+    widths: hence ``accept_verify_lens`` (true ``w_r``, drives the cutoff and
+    the length contract) alongside ``layout.verify_lens`` (padded, drives the
+    forward geometry).
+"""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence, Tuple
+
+import msgspec
+import torch
+
+from sglang.kernels.ops.speculative.cache_locs import assign_extend_cache_locs_func
+from sglang.srt.speculative.ragged_verify import RaggedVerifyLayout
+
+# The compact-window / scatter / cutoff kernels are algorithm-agnostic but live
+# under dspark_components, whose package root pulls in the whole DFlash+DSPARK
+# stack. Import them inside the call sites so an EAGLE-only deployment does not
+# pay for that at import time (and so this module cannot participate in an
+# import cycle through eagle_worker_common).
+
+# Padded logits/hidden rows never reach a consumer: the accept cap keeps every
+# read inside [0, w_r), and draft-extend gathers by accept_index. 0.0 matches
+# what DSPARK fills so the two paths stay comparable under a debugger.
+RAGGED_FILL_VALUE = 0.0
+
+
+def compute_hybrid_verify_lens(
+    *,
+    num_keep_drafts: torch.Tensor,
+    graft_ok: torch.Tensor,
+    num_retrieval_tokens: torch.Tensor,
+    num_steps: int,
+    verify_width: int,
+) -> torch.Tensor:
+    """Per-request verify width ``w_r`` for one hybrid step -- ``[bs]`` int32.
+
+    This is the device-side twin of what ``splice_hybrid_chain`` laid out, so
+    the two MUST agree column for column. The spliced chain is::
+
+        column 0                      the bonus token (always present)
+        columns 1 .. effective_keep   MTP drafts
+        columns effective_keep+1 ..   the retrieval continuation, but only when
+                                      the agreement gate passed; zero pad
+                                      otherwise
+
+    with ``effective_keep = num_keep_drafts`` on a successful graft and
+    ``num_steps`` (the full, untruncated MTP chain) on a failed one. So::
+
+        graft failed:   w_r = 1 + num_steps                       (the floor)
+        graft ok:       w_r = 1 + min(num_retrieval_tokens, L-1)
+
+    The lower bound ``w_r >= 1 + num_keep_drafts`` holds for free: a successful
+    graft means ``num_agree_drafts >= num_keep_drafts``, and agreement is only
+    possible on columns the retrieval chain actually carries, hence
+    ``num_retrieval_tokens >= num_keep_drafts``. In other words ragged NEVER
+    verifies fewer tokens than the kept MTP prefix -- the worst case degrades to
+    plain MTP, never to something shorter.
+
+    ``num_retrieval_tokens`` is the retriever's OWN reported continuation length
+    (``HybridRetriever`` returns it alongside the chain). It must not be derived
+    by counting non-zero entries: token id 0 is a real vocabulary token in DSV4
+    (``<|begin_of_sentence|>``, present in the trie because the full prompt is
+    indexed), so a zero inside a chain is indistinguishable from tail padding.
+    Calibration data contained real token-0 chain positions. They are rare, but
+    treating them as padding would silently shorten ``w_r``.
+
+    The ``max(..., 1 + num_keep_drafts)`` at the end is defence in depth for
+    exactly that class of bug: whatever the length source says, ``w_r`` can never
+    come out shorter than the MTP prefix that was actually spliced in.
+    """
+    keep = torch.where(
+        graft_ok,
+        torch.minimum(
+            num_retrieval_tokens.to(num_keep_drafts.dtype),
+            torch.full_like(num_keep_drafts, verify_width - 1),
+        ),
+        torch.full_like(num_keep_drafts, num_steps),
+    )
+    keep = torch.maximum(keep, num_keep_drafts)
+    return (keep + 1).clamp_(1, verify_width).to(torch.int32)
+
+
+def build_hybrid_ragged_layout(
+    *,
+    verify_lens_cpu: Sequence[int],
+    device: str | torch.device,
+    tier_num_tokens: Optional[int] = None,
+) -> RaggedVerifyLayout:
+    """Wrap the per-request FORWARD widths in the substrate's layout.
+
+    ``verify_lens_cpu`` is the forward geometry (``forward_verify_lens`` from
+    :func:`plan_hybrid_ragged_tier`), not the accept widths -- see the module
+    docstring on why the two differ.
+
+    ``tier_num_tokens`` is the captured graph's token count. Without it (no
+    CUDA graph: eager mode, or ``--disable-cuda-graph``) the layout is EXACT, i.e.
+    ``graph_num_tokens == sum(w_r)`` and ``tier_slack == 0``; the singleton grid
+    satisfies the substrate's ``round_up_grid`` contract without special-casing
+    it. Passing a tier is what makes the batch replayable on the token-keyed
+    graph captured at that tier.
+    """
+    verify_lens_list = [int(v) for v in verify_lens_cpu]
+    total = sum(verify_lens_list)
+    tier = total if tier_num_tokens is None else int(tier_num_tokens)
+    assert tier >= total, (
+        f"hybrid ragged tier {tier} < sum(forward verify_lens) {total}: the "
+        "compact window would overflow the captured graph's token buffers"
+    )
+    return RaggedVerifyLayout.from_verify_lens(
+        verify_lens_cpu=verify_lens_list,
+        device=device,
+        grid=[tier],
+    )
+
+
+# compact_row_index_triton resolves the row -> request mapping with a FIXED
+# 11-round binary search (`_SEARCH_NBITS`, dspark_verify_window.py:219), which
+# covers at most 2048 boundaries and fails SILENTLY above that (the torch
+# reference has no such limit, so the two implementations would diverge). Half
+# that, as headroom; the real batches here are <= 32.
+MAX_RAGGED_BS = 1024
+
+
+class HybridRaggedWindow(msgspec.Struct, frozen=True):
+    """One ragged target-verify forward's inputs.
+
+    The first three are COMPACT (length ``layout.graph_num_tokens``) and feed the
+    forward. ``fixed_cache_loc`` is the ordinary ``[bs * L]`` map that every
+    stage AFTER the scatter seam still expects -- see the class docstring note
+    below and ``run_eagle_verify``.
+    """
+
+    verify_ids: torch.Tensor
+    positions: torch.Tensor
+    verify_cache_loc: torch.Tensor
+    fixed_cache_loc: torch.Tensor
+
+
+def build_hybrid_ragged_window(
+    *,
+    batch,
+    layout: RaggedVerifyLayout,
+    draft_token: torch.Tensor,
+    verify_width: int,
+    req_to_token: torch.Tensor,
+    device: str | torch.device,
+) -> HybridRaggedWindow:
+    """Pack the ``[bs, L]`` verify rectangle down to ``sum(w_r)`` live rows.
+
+    ``draft_token`` stays the FIXED-STRIDE ``[bs * L]`` chain that
+    ``build_tree_kernel_efficient`` produced -- it is what ``eagle_sample``
+    reshapes into ``candidates`` after the seam, so it must not be compacted.
+    Only the forward's inputs are compacted here.
+
+    **The cache map is built FIXED-WIDTH FIRST and the compact one is gathered
+    out of it.** That is deliberate, on two counts:
+
+    1. The fixed map is byte-for-byte the same tensor today's fixed-width path
+       builds (same kernel, same ``end_offset = seq_lens + L``), so ragged does
+       not introduce a second KV-slot allocation path. The compact map is a pure
+       subset of it.
+    2. The fixed map is REQUIRED after the forward. ``prepare_for_draft_extend``
+       (``eagle_worker_common.py``, the non-widening branch) deliberately does
+       NOT rebuild ``batch.out_cache_loc``: on the fixed-width path the verify
+       map and the draft-extend map are the same ``bs * L`` slots, so it just
+       reuses whatever verify left behind. Handing that stage a compact map
+       leaves it with ``bs * L`` tokens and only ``sum(w_r)`` locations. So the
+       scatter seam restores this one; see ``run_eagle_verify``.
+
+    Unlike DSPARK's ``compact_verify_ids`` (which splices a separate anchor
+    tensor with a per-block draft matrix) the hybrid chain already carries its
+    anchor in column 0, so the gather is a plain 2-D index. Reusing DSPARK's
+    kernel would mean passing ``draft_block_ids`` with a row stride that its
+    triton kernel derives from ``draft_tokens.shape[1]``; the strides differ and
+    the mismatch is silent, so gather directly instead.
+    """
+    from sglang.srt.speculative.dspark_components.kernels.dspark_verify_window import (
+        CompactRowIndex,
+    )
+
+    bs = layout.bs
+    assert bs <= MAX_RAGGED_BS, (
+        f"hybrid ragged verify: bs={bs} exceeds MAX_RAGGED_BS={MAX_RAGGED_BS}. "
+        "compact_row_index_triton resolves the row->request mapping with a fixed "
+        "11-round binary search and fails SILENTLY past 2048 boundaries; raise "
+        "_SEARCH_NBITS in dspark_verify_window.py before lifting this."
+    )
+    total = layout.graph_num_tokens
+    req_id, within, valid = CompactRowIndex.execute(
+        verify_lens=layout.verify_lens, padded_total=total, device=device
+    )
+    safe_req = req_id.clamp(max=bs - 1)
+
+    prefix_lens = batch.seq_lens
+    positions = torch.where(
+        valid,
+        prefix_lens.to(torch.int64)[safe_req] + within,
+        torch.zeros_like(within),
+    )
+
+    # Identical to the fixed-width path's own call: the L slots at
+    # [seq_len, seq_len + L) were already reserved by the scheduler, this only
+    # reads them out of req_to_token.
+    fixed_cache_loc = assign_extend_cache_locs_func(
+        req_pool_indices=batch.req_pool_indices,
+        req_to_token=req_to_token,
+        start_offset=prefix_lens,
+        end_offset=prefix_lens + verify_width,
+        batch_size=bs,
+        draft_token_num=verify_width,
+        device=device,
+    )
+    fixed_2d = fixed_cache_loc.view(bs, verify_width)
+    verify_cache_loc = fixed_2d[safe_req, within]
+    verify_cache_loc = torch.where(
+        valid, verify_cache_loc, torch.zeros_like(verify_cache_loc)
+    )
+
+    draft_token_2d = draft_token.view(bs, verify_width)
+    verify_ids = draft_token_2d[safe_req, within]
+    verify_ids = torch.where(valid, verify_ids, torch.zeros_like(verify_ids))
+
+    return HybridRaggedWindow(
+        verify_ids=verify_ids.to(torch.int64),
+        positions=positions,
+        verify_cache_loc=verify_cache_loc,
+        fixed_cache_loc=fixed_cache_loc,
+    )
+
+
+def scatter_hybrid_verify_outputs(
+    *,
+    logits_output,
+    layout: RaggedVerifyLayout,
+    verify_width: int,
+) -> None:
+    """THE SEAM. Re-inflate the compact forward outputs to the ``[bs * L, ...]``
+    fixed stride, in place on ``logits_output``.
+
+    Ordering is a HARD constraint, not a style choice: ``eagle_sample`` sizes its
+    ``predict`` buffer from ``next_token_logits.shape[:-1]``
+    (``eagle_utils.py:641``) while ``retrieve_index`` holds global row ids up to
+    ``bs * L - 1``. If the verify kernel ran against a compact
+    ``[graph_num_tokens]`` predict buffer it would write OUT OF BOUNDS. So this
+    must run immediately after the forward and before anything reads
+    ``logits_output``.
+    """
+    from sglang.srt.speculative.dspark_components.kernels.dspark_verify_window import (
+        ScatterCompactToStrided,
+    )
+
+    compact_logits = logits_output.next_token_logits
+    logits_output.next_token_logits = ScatterCompactToStrided.execute(
+        compact=compact_logits,
+        layout=layout,
+        fill_value=RAGGED_FILL_VALUE,
+        verify_num_draft_tokens=verify_width,
+    )
+    compact_hidden = logits_output.hidden_states
+    if compact_hidden is not None:
+        logits_output.hidden_states = ScatterCompactToStrided.execute(
+            compact=compact_hidden,
+            layout=layout,
+            fill_value=RAGGED_FILL_VALUE,
+            verify_num_draft_tokens=verify_width,
+        )
+
+
+def cap_accept_to_verify_lens(
+    *,
+    num_correct_drafts: torch.Tensor,
+    accept_index: torch.Tensor,
+    verify_lens: torch.Tensor,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Forbid accepting a column the forward never computed (DSPARK's
+    ``CapCorrectLen``, ``dspark_accept.py:816``).
+
+    Request ``r`` computed columns ``[0, w_r)``, so the last acceptable DRAFT
+    index is ``w_r - 1`` and ``num_correct_drafts`` is clamped there. The
+    accepted chain then spans columns ``0 .. num_correct_drafts``, all real, and
+    the bonus token (``predict`` at the last accepted column) is real too.
+
+    ``accept_index`` is truncated rather than rebuilt from ``arange``. For a
+    linear chain the two are identical -- ``accept_index[b, i] == b * L + i`` --
+    but truncating preserves whatever the verify kernel actually produced, so a
+    future tree-shaped chain cannot silently get an arange grafted onto it.
+    """
+    from sglang.srt.speculative.dspark_components.kernels.dspark_accept import (
+        CapCorrectLen,
+    )
+
+    capped, _cap_trim_lens = CapCorrectLen.execute(
+        correct_len=num_correct_drafts, verify_lens=verify_lens
+    )
+    capped = capped.to(num_correct_drafts.dtype)
+    depth = accept_index.shape[1]
+    col = torch.arange(depth, device=accept_index.device)
+    keep = col[None, :] <= capped.to(torch.int64)[:, None]
+    accept_index = torch.where(keep, accept_index, torch.full_like(accept_index, -1))
+    return capped, accept_index
+
+
+# =============================================================================
+# graph-tier mode: graph tiers
+# =============================================================================
+
+# Gathered value meaning "this rank refuses ragged for this step" (non-greedy
+# batch, no captured grid, a total the grid cannot hold, ...). Any rank vetoing
+# takes the WHOLE dp group back to the fixed-width path for that step, because
+# a per-rank decision would have the ranks replay differently-shaped graphs.
+# Mirrors DSPARK's sentinel (`dp_global_verify_tier_num_tokens`: `any(t < 0)`
+# -> None -> pinned to the full rectangle).
+HYBRID_RAGGED_TIER_VETO = -1
+
+
+class HybridRaggedTierParams(msgspec.Struct, frozen=True):
+    floor: int
+    tier_step: int
+    max_tiers: int
+    explicit_tiers: Tuple[int, ...]
+
+
+def resolve_hybrid_ragged_tier_params(
+    *, server_args, verify_width: int, capture_bs: Sequence[int]
+) -> HybridRaggedTierParams:
+    """Turn the ``--speculative-hybrid-ragged-*`` args into grid parameters.
+
+    The two derived defaults are the measured shape of the hybrid chain, not
+    tuning knobs picked by feel:
+
+      ``floor = num_steps + 1``   the width a graft-FAILED request needs (the
+                                  bonus token plus the full MTP chain), which is
+                                  also every request's lower bound
+      ``tier_step = width - floor`` one QUANTUM: the extra tokens a request costs
+                                  when its graft succeeds, i.e. the spacing the
+                                  step totals actually move on
+
+    Both are overridable so the grid can be reproduced from the command line
+    without touching code.
+    """
+    floor = server_args.speculative_hybrid_ragged_floor
+    if floor is None:
+        floor = int(server_args.speculative_num_steps) + 1
+    tier_step = server_args.speculative_hybrid_ragged_tier_step
+    if tier_step is None:
+        tier_step = max(verify_width - int(floor), 1)
+    raw_tiers = (server_args.speculative_hybrid_ragged_tiers or "").strip()
+    explicit = tuple(int(piece) for piece in raw_tiers.split(",") if piece.strip())
+    max_tiers = int(server_args.speculative_hybrid_ragged_max_tiers)
+    if max_tiers < 0:
+        # AUTO: at most twice the number of verify graphs the fixed-width path
+        # would capture, floor 16. The floor keeps the small deployments the
+        # measurements came from (max_running=4 -> capture_bs [1,2,3,4] -> 14
+        # tiers) on the exact grid, while the ratio stops a large
+        # --cuda-graph-max-bs from turning a near-dense union into thousands of
+        # captures. `0` still means genuinely unlimited, for sweeps.
+        max_tiers = max(16, 2 * len(capture_bs))
+    return HybridRaggedTierParams(
+        floor=int(floor),
+        tier_step=int(tier_step),
+        max_tiers=max_tiers,
+        explicit_tiers=explicit,
+    )
+
+
+class HybridRaggedTierGrid(msgspec.Struct, frozen=True):
+    """The captured tier grid plus what coarsening it took to get there.
+
+    The diagnostics are not decoration: with an unbounded union running to
+    thousands of tiers, "which knob fired and how far" is the only way to read a
+    startup log and tell whether the grid is quantum-aligned or a coarsened
+    fallback.
+    """
+
+    tiers: List[int]
+    effective_step: int
+    anchor_level: int
+    num_anchors: int
+    num_capture_bs: int
+    max_tiers: int
+
+    @property
+    def anchors_thinned(self) -> bool:
+        return self.anchor_level > 0 or self.num_anchors < self.num_capture_bs
+
+    def step_widened(self, requested_step: int) -> bool:
+        return self.effective_step > requested_step
+
+    def coarsened(self, requested_step: int) -> bool:
+        """Whether the grid is NOT the requested quantum-aligned one.
+
+        Takes the requested step because widening it is the FIRST coarsening
+        lever and the more common one -- a property that only looked at anchor
+        thinning reported `coarsened=False` on the H100 default, where the step
+        had in fact gone from 5 to 2080. Any caller deciding whether it got the
+        requested grid needs both.
+        """
+        return self.anchors_thinned or self.step_widened(requested_step)
+
+    def describe(self) -> str:
+        return (
+            f"{len(self.tiers)} tiers, effective_step={self.effective_step}, "
+            f"anchors={self.num_anchors}/{self.num_capture_bs} "
+            f"(thin_level={self.anchor_level})"
+        )
+
+    def describe_coarsening(self, requested_step: int) -> str:
+        if not self.coarsened(requested_step):
+            return "not coarsened"
+        parts = []
+        if self.step_widened(requested_step):
+            parts.append(f"step {requested_step} -> {self.effective_step}")
+        if self.anchors_thinned:
+            parts.append(f"anchors {self.num_capture_bs} -> {self.num_anchors}")
+        return ", ".join(parts)
+
+
+def build_hybrid_ragged_tier_grid(
+    *,
+    capture_bs: Sequence[int],
+    verify_width: int,
+    floor: int,
+    tier_step: int,
+    max_tiers: int = 0,
+    explicit_tiers: Sequence[int] = (),
+) -> List[int]:
+    """The tier list alone; see :func:`build_hybrid_ragged_tier_plan`."""
+    return build_hybrid_ragged_tier_plan(
+        capture_bs=capture_bs,
+        verify_width=verify_width,
+        floor=floor,
+        tier_step=tier_step,
+        max_tiers=max_tiers,
+        explicit_tiers=explicit_tiers,
+    ).tiers
+
+
+def build_hybrid_ragged_tier_plan(
+    *,
+    capture_bs: Sequence[int],
+    verify_width: int,
+    floor: int,
+    tier_step: int,
+    max_tiers: int = 0,
+    explicit_tiers: Sequence[int] = (),
+) -> HybridRaggedTierGrid:
+    """The captured token grid, aligned to the hybrid chain's own quantum.
+
+    A step's total is ``Σ_r w_r`` where each ``w_r`` is either ``floor``
+    (``1 + num_steps``, the graft-failed width) or up to ``verify_width``. So
+    per request the total moves by one QUANTUM of ``verify_width - floor``, and
+    for ``bs`` requests the reachable totals cluster on
+    ``bs * floor + j * quantum``. That is the grid this builds::
+
+        grid = { bs * floor + j * tier_step } ∪ { bs * verify_width }
+               for every captured bs, sorted and deduplicated
+
+    ``tier_step`` defaults to one quantum (see ``ServerArgs``); a larger step
+    trades saving for fewer captured graphs. The substrate's own default grid is
+    ``{bs * verify_width}``, i.e. spacing ``verify_width`` against a signal that
+    moves in ``verify_width - floor`` -- which is why it collects almost none of
+    the available saving.
+
+    ``max(capture_bs) * verify_width`` is always the LAST tier: it is the grid's
+    ceiling, and a step total above the ceiling has no graph to replay.
+
+    **Bounding the size matters more than it looks.** The union runs over every
+    captured batch size, and ``bs * floor mod tier_step`` walks every residue as
+    ``bs`` varies, so an unbounded union is very nearly one tier per integer:
+    at the H100 default ``--cuda-graph-max-bs 512`` the naive union is thousands
+    of tiers against ~67 fixed-width graphs. Every tier is a captured graph, and
+    while they share the graph memory pool (so the high-water mark does not move)
+    each one still costs a warmup + capture at startup. So ``max_tiers``
+    coarsens, in this order:
+
+      1. **widen the step**, up to ``max(anchors) * (verify_width - floor)``.
+         Past that width every per-bs series has collapsed to its two endpoints
+         and the grid is the SKELETON ``{bs*floor} ∪ {bs*verify_width}``.
+      2. only if that still does not fit, **thin the anchor batch sizes**.
+
+    That order is deliberate and is the opposite of what looks right. Widening
+    the step costs intra-bs resolution, but the skeleton it leaves behind is
+    dense in absolute terms -- 67 anchors give 134 tiers spread over the whole
+    range, and a bs=4 step needing 21 tokens still lands on 24. Dropping anchors
+    instead punches HOLES: thinning 67 anchors down to {1, 512} leaves the grid
+    ``[4, 9, 2048, 2068, ...]``, and that same 21-token step rounds up to 2048 --
+    a 97x blow-up. Resolution inside one batch size is worth much less than
+    having any tier at all near the batch sizes actually in flight.
+
+    Thinning is therefore the last resort, and when it does run it keeps a
+    MULTIPLICATIVELY spread subset (see :func:`_thin_anchor_batch_sizes`) so the
+    relative gap it introduces stays bounded instead of collapsing to the two
+    endpoints. With the auto ``max_tiers`` (``max(16, 2 * len(capture_bs))``) the
+    skeleton always fits and thinning never runs at all; only an explicitly small
+    ``--speculative-hybrid-ragged-max-tiers`` reaches it.
+
+    If even the coarsest combination exceeds ``max_tiers`` the grid is returned
+    as is and the caller warns. Truncating instead would drop the ceiling and
+    strand the largest batches with no graph.
+    """
+    num_capture_bs = len(set(int(bs) for bs in capture_bs))
+    if explicit_tiers:
+        tiers = _validate_hybrid_ragged_tier_grid(
+            tiers=[int(t) for t in explicit_tiers],
+            capture_bs=capture_bs,
+            verify_width=verify_width,
+            source="--speculative-hybrid-ragged-tiers",
+        )
+        return HybridRaggedTierGrid(
+            tiers=tiers,
+            effective_step=0,
+            anchor_level=0,
+            num_anchors=num_capture_bs,
+            num_capture_bs=num_capture_bs,
+            max_tiers=max_tiers,
+        )
+
+    assert 1 <= floor <= verify_width, (
+        f"hybrid ragged floor must be in [1, verify_width={verify_width}], got "
+        f"{floor}"
+    )
+    assert tier_step >= 1, f"hybrid ragged tier_step must be >= 1, got {tier_step}"
+
+    anchors_full = sorted(set(int(bs) for bs in capture_bs))
+    coarsest_step = max(max(anchors_full) * (verify_width - floor), 1)
+    level = 0
+    while True:
+        anchors = _thin_anchor_batch_sizes(anchors_full, level=level)
+        step = tier_step
+        while True:
+            tiers = _hybrid_ragged_tier_series(
+                capture_bs=anchors,
+                verify_width=verify_width,
+                floor=floor,
+                tier_step=step,
+            )
+            fits = max_tiers <= 0 or len(tiers) <= max_tiers
+            exhausted = step >= coarsest_step and len(anchors) <= 2
+            if fits or exhausted:
+                return HybridRaggedTierGrid(
+                    tiers=_validate_hybrid_ragged_tier_grid(
+                        tiers=tiers,
+                        capture_bs=capture_bs,
+                        verify_width=verify_width,
+                        source="derived grid",
+                    ),
+                    effective_step=step,
+                    anchor_level=level,
+                    num_anchors=len(anchors),
+                    num_capture_bs=num_capture_bs,
+                    max_tiers=max_tiers,
+                )
+            if step >= coarsest_step:
+                break
+            step += tier_step
+        level += 1
+
+
+def _thin_anchor_batch_sizes(anchors: List[int], *, level: int) -> List[int]:
+    """Keep a MULTIPLICATIVELY spread subset of the captured batch sizes.
+
+    Spread by ratio, not by list index. Index striding looks equivalent but is
+    not: ``capture_bs`` is itself geometric-ish, so a large index stride keeps
+    only the two endpoints and leaves a hole spanning most of the range -- and a
+    hole is far more expensive than a coarse step, because a batch landing in it
+    rounds up by a multiple rather than by a few tokens.
+
+    Level ``k`` keeps anchors at least ``2 ** k`` apart in ratio, so the relative
+    gap this introduces is bounded by that factor no matter how many anchors are
+    dropped. The first and last are always kept: the last sets the grid's
+    ceiling, and small batches are where most of the measured saving occurs.
+    """
+    if level <= 0:
+        return list(anchors)
+    ratio = float(2**level)
+    kept = [anchors[0]]
+    for bs in anchors[1:]:
+        if bs >= kept[-1] * ratio:
+            kept.append(bs)
+    if kept[-1] != anchors[-1]:
+        kept.append(anchors[-1])
+    return kept
+
+
+def _hybrid_ragged_tier_series(
+    *,
+    capture_bs: Sequence[int],
+    verify_width: int,
+    floor: int,
+    tier_step: int,
+) -> List[int]:
+    tiers = set()
+    for bs in capture_bs:
+        lo = bs * floor
+        hi = bs * verify_width
+        tier = lo
+        while tier < hi:
+            tiers.add(tier)
+            tier += tier_step
+        tiers.add(hi)
+    return sorted(tiers)
+
+
+def _validate_hybrid_ragged_tier_grid(
+    *,
+    tiers: List[int],
+    capture_bs: Sequence[int],
+    verify_width: int,
+    source: str,
+) -> List[int]:
+    if not tiers:
+        raise ValueError(f"hybrid ragged tier grid is empty ({source})")
+    if sorted(set(tiers)) != tiers:
+        raise ValueError(
+            f"hybrid ragged tier grid must be strictly increasing and unique "
+            f"({source}); got {tiers}"
+        )
+    if tiers[0] < 1:
+        raise ValueError(
+            f"hybrid ragged tier grid must be positive ({source}); got {tiers}"
+        )
+    ceiling = max(capture_bs) * verify_width
+    if tiers[-1] != ceiling:
+        raise ValueError(
+            f"hybrid ragged tier grid must top out at max(capture_bs) * "
+            f"verify_width = {ceiling} ({source}); got {tiers[-1]}. round_up_grid "
+            "raises on any total above the last tier, so the largest batch would "
+            "have no graph to replay."
+        )
+    # Deliberately NOT required: that every `bs * verify_width` be a member. A
+    # batch CAN round up to a tier above its own `bs * verify_width`, leaving
+    # slack that plan_hybrid_ragged_tier cannot spend inside the per-request cap
+    # -- but that is safe, because `tier > bs * verify_width` forces
+    # `slots = min(tier, max_bs) > bs` (tier > bs*width >= bs gives it when
+    # tier <= max_bs; tier <= max_bs*width with tier > bs*width gives bs < max_bs
+    # otherwise), so the substrate's `pad_verify_lens_to_bucket` hands the
+    # remainder to PAD requests rather than inflating a real one. Requiring
+    # membership would force the grid to contain one tier per captured batch
+    # size, which is a large part of what makes the naive union explode.
+    return tiers
+
+
+class HybridRaggedTierPlan(msgspec.Struct, frozen=True):
+    """One verify step's resolved ragged geometry.
+
+    ``accept_verify_lens`` are the true ``w_r``: they drive the accept cutoff
+    and the length contract the acceptance script checks. ``forward_verify_lens``
+    are those widths grown to fill the tier (each still ``<= verify_width``);
+    they drive the compact window, the attention geometry and the KV writes.
+    They are equal exactly when ``sum(w_r)`` already sits on a tier.
+    """
+
+    accept_verify_lens: List[int]
+    forward_verify_lens: List[int]
+    tier_num_tokens: int
+
+
+def plan_hybrid_ragged_tier(
+    *,
+    accept_verify_lens: Sequence[int],
+    verify_width: int,
+    tier_num_tokens: int,
+) -> HybridRaggedTierPlan:
+    """Grow ``w_r`` to fill ``tier_num_tokens``, never past ``verify_width``.
+
+    The slack (``tier - Σ w_r``) has to go somewhere: the substrate's
+    ``pad_verify_lens_to_bucket`` puts ALL of it on the last real request when
+    the batch already fills the captured slots, which can push that request's
+    width past ``verify_width``. A request only ever had ``verify_width`` KV
+    slots reserved at ``[seq_len, seq_len + verify_width)``, so a wider window
+    makes the attention read slots the scheduler never gave it.
+
+    Spending the slack here instead keeps every request inside its reservation
+    and leaves the substrate's leftover at zero, so nothing is inflated later.
+    Whatever cannot be spent (only possible when ``tier > bs * verify_width``,
+    i.e. a DP peer with more requests set the tier) is left for the substrate --
+    and in exactly that case the captured slots strictly exceed ``bs``, so the
+    substrate hands the remainder to PAD requests, never to a real one.
+
+    Allocation is lowest-index-first, which is arbitrary but must be
+    DETERMINISTIC: every TP rank runs this on the same broadcast widths and the
+    result selects the forward's shape, so a rank computing a different split
+    would give the group differently-shaped collectives.
+    """
+    lens = [int(w) for w in accept_verify_lens]
+    tier = int(tier_num_tokens)
+    total = sum(lens)
+    assert tier >= total, (
+        f"hybrid ragged tier {tier} < sum(w_r) {total}; the tier must be a "
+        "round-UP of the step's total"
+    )
+    spendable = min(tier, len(lens) * verify_width) - total
+    forward = list(lens)
+    index = 0
+    while spendable > 0 and index < len(forward):
+        room = verify_width - forward[index]
+        take = min(room, spendable)
+        forward[index] += take
+        spendable -= take
+        index += 1
+    return HybridRaggedTierPlan(
+        accept_verify_lens=lens,
+        forward_verify_lens=forward,
+        tier_num_tokens=tier,
+    )
+
+
+def resolve_hybrid_ragged_tier(
+    *,
+    total_verify_tokens: int,
+    tier_grid: Optional[Sequence[int]],
+    max_tier: Optional[int] = None,
+) -> Optional[int]:
+    """Round the step's total up to a captured tier, or None to stay eager.
+
+    None means "no token-keyed graph can hold this step": nothing was captured
+    (``--disable-cuda-graph``, or the runner is not in ragged mode), the total is
+    above the grid's ceiling, or no grid member fits under ``max_tier``. All are
+    correctness-neutral -- ``build_hybrid_ragged_layout`` then makes the layout
+    exact and the verify runs eager, which is the eager mode path. Returning None rather
+    than letting ``round_up_grid`` raise matters: a batch the grid cannot serve is
+    a throughput event, not a crash.
+
+    ``max_tier`` is how the caller says "a tier above this is only safe if the
+    graph is CERTAIN to run". Pass ``bs * verify_width`` on any path where the
+    verify might fall back to eager: a tier above that leaves slack that
+    :func:`plan_hybrid_ragged_tier` cannot spend, and the eager DSV4 path calls
+    ``padded_to_bucket(padded_bs=bs)`` with NO pad requests, so the substrate
+    folds the whole remainder into the LAST REAL request -- widening it past
+    ``verify_width`` and past the KV window the scheduler reserved for it. On the
+    graph path the same tier is safe, because ``tier > bs * verify_width`` forces
+    the captured slots above ``bs`` and the remainder lands on pad requests
+    instead.
+    """
+    from sglang.srt.speculative.ragged_verify import round_up_grid
+
+    if not tier_grid:
+        return None
+    ceiling = tier_grid[-1] if max_tier is None else min(tier_grid[-1], max_tier)
+    if total_verify_tokens > ceiling:
+        return None
+    tier = round_up_grid(total=total_verify_tokens, grid=tier_grid)
+    return tier if tier <= ceiling else None
+
+
+def hybrid_ragged_capture_tiers(*, target_worker) -> Optional[List[int]]:
+    """The target decode runner's captured token grid, or None.
+
+    None whenever no token-keyed verify graph exists: cuda graphs disabled, or
+    the runner did not enter ragged mode (``supports_ragged_verify()`` false, or
+    this is the draft runner, which stays fixed width by design).
+    """
+    runner = target_worker.model_runner.decode_cuda_graph_runner
+    if runner is None or not runner.ragged_verify_mode:
+        return None
+    return runner.capture_num_tokens
+
+
+def hybrid_ragged_capture_max_bs(*, target_worker) -> int:
+    """Largest request count any captured ragged verify graph can hold.
+
+    This is the runner's ``max_bs = max(capture_bs)``, i.e. ``--cuda-graph-max-bs``
+    clamped to the request pool -- NOT ``--max-running-requests``, which can be
+    larger. It bounds the runner's per-rank admission test
+    (``batch_size <= _ragged_capture_slots(tier) == min(tier, max_bs)``); since
+    every ``w_r >= 1`` implies ``tier >= bs``, that test reduces exactly to
+    ``bs <= max_bs``.
+
+    Returns 0 when there is no ragged runner, so a caller comparing ``bs >`` this
+    treats "no graphs" as "cannot admit", which is the safe direction.
+    """
+    runner = target_worker.model_runner.decode_cuda_graph_runner
+    if runner is None or not runner.ragged_verify_mode:
+        return 0
+    return int(runner.max_bs)
+
+
+def hybrid_ragged_dp_tier_enabled(*, server_args) -> bool:
+    """Whether this process must agree the graph tier with its DP peers.
+
+    Mirrors DSPARK's ``_dp_tier_gather_enabled`` (``dspark_planner.py``) with two
+    deliberate differences:
+
+      * DSPARK additionally requires ``not disable_overlap_schedule``, because it
+        hides the all-gather inside the overlap pipeline. hybrid retrieval's tier is
+        EXACT (T2): it is only known after the draft forward, so the gather is
+        synchronous by construction and the overlap condition does not apply.
+        future no-sync mode's lagged budget is where that changes.
+      * The whole thing is additionally gated on an explicit opt-in
+        (``--speculative-hybrid-ragged-dp-tier``). A ragged tier that the ranks
+        disagree on hangs the group with no assertion firing first, so turning it
+        on is a deliberate act rather than a side effect of passing
+        ``--enable-dp-attention``.
+
+    ``attn_tp_size == 1`` is load-bearing, not inherited caution: the gather runs
+    over the tp group, so one rank per DP rank is what makes the gathered vector
+    the per-DP-rank vector.
+    """
+    if not server_args.speculative_hybrid_ragged:
+        return False
+    if not server_args.speculative_hybrid_ragged_dp_tier:
+        return False
+
+    from sglang.srt.environ import envs
+    from sglang.srt.layers.dp_attention import is_dp_attention_enabled
+    from sglang.srt.runtime_context import get_parallel
+
+    # From utils.common, NOT layers.dp_attention -- the latter does not re-export
+    # it, so importing it from there is an ImportError at worker init. This is
+    # the same module server_args._check_hybrid_ragged_tier_server_args and
+    # dspark_planner import it from; the startup guard and this runtime gate MUST
+    # agree, and sharing the import site is half of what makes that true.
+    from sglang.srt.utils.common import require_mlp_tp_gather
+
+    return (
+        is_dp_attention_enabled()
+        and require_mlp_tp_gather(server_args)
+        and get_parallel().attn_tp_size == 1
+        and get_parallel().attn_cp_size == 1
+        and not server_args.speculative_skip_dp_mlp_sync
+        and server_args.disaggregation_mode == "null"
+        and server_args.pp_size == 1
+        and not envs.SGLANG_SCHEDULER_SKIP_ALL_GATHER.get()
+    )
+
+
+def agree_hybrid_ragged_dp_tier(
+    *,
+    local_total_verify_tokens: int,
+    tier_grid: Optional[Sequence[int]],
+    cpu_group,
+) -> Optional[int]:
+    """All-gather the per-rank totals and return the tier EVERY rank must use.
+
+    Under DP attention all ranks replay ONE graph shape: the decode runner keys
+    the ragged verify graph off ``layout.graph_num_tokens`` with no cross-rank
+    max of its own (unlike the fixed-width path, which takes
+    ``max(original_global_num_tokens_cpu)``), so the agreement has to be baked
+    into the layout before it gets there. Ranks that disagree select different
+    graphs, the in-graph MoE all-gather shapes mismatch, and the group hangs --
+    with no assertion firing first, which is why this is a collective rather
+    than a local computation.
+
+    Contract on the gathered value, mirroring DSPARK:
+      ``> 0``  this rank's ``Σ w_r``
+      ``0``    this rank has nothing to verify (idle) but does not object
+      ``< 0``  this rank VETOES ragged this step
+
+    Returns None when any rank vetoed, when no rank had work, or when the agreed
+    maximum does not fit the grid. None means the whole group takes the
+    fixed-width path this step -- the decision is derived from the gathered
+    vector, so it is identical on every rank by construction.
+
+    ``cpu_group`` MUST be passed in, and must be the TARGET worker's tp group
+    (gloo side). Resolving it here with ``get_tp_group()`` -- which is what DSPARK
+    does from the scheduler -- would be wrong at this call site: hybrid retrieval gathers
+    from inside ``EagleDraftWorker.draft()``, which under DP attention runs within
+    ``draft_tp_context`` (``eagle_worker_v2.py``), and that context PATCHES the
+    process-global tp group to the draft runner's own group. With
+    ``attn_tp_size == 1`` that group has world_size 1, so ``get_tp_group()`` here
+    would give every rank a private one-element gather -- each rank would then
+    "agree" its own tier and the group would hang, i.e. exactly the failure this
+    function exists to prevent, silently.
+
+    hybrid retrieval's DP support requires ``attn_tp_size == 1`` (validated at startup),
+    so the target tp group has exactly one rank per DP rank and the gathered
+    vector is the per-DP-rank vector.
+    """
+    import torch.distributed as dist
+
+    world_size = dist.get_world_size(group=cpu_group)
+    local = torch.tensor([int(local_total_verify_tokens)], dtype=torch.int64)
+    gathered = torch.empty((world_size,), dtype=torch.int64)
+    dist.all_gather_into_tensor(gathered, local, group=cpu_group)
+
+    totals = gathered.tolist()
+    if any(total < 0 for total in totals):
+        return None
+    peak = max(totals, default=0)
+    if peak <= 0:
+        return None
+    return resolve_hybrid_ragged_tier(total_verify_tokens=peak, tier_grid=tier_grid)
+
+
+def build_hybrid_ragged_idle_layout(
+    *,
+    tier_num_tokens: int,
+    target_worker,
+) -> RaggedVerifyLayout:
+    """The layout an IDLE DP rank rides so it replays the busy ranks' graph.
+
+    An idle rank has no requests, but it still has to enter the same captured
+    graph as everybody else or the in-graph DP collectives mismatch. The layout's
+    only job is to carry the agreed tier: the batch itself stays empty, the
+    decode runner copies zero rows into the static buffers, and the verify seam
+    and the accept cutoff both skip an idle batch.
+
+    It delegates to the runner's OWN capture-layout builder rather than inventing
+    a shape, so the widths an idle rank presents are byte-for-byte the ones the
+    graph was captured with (``num_tokens`` spread evenly over the captured
+    slots). Inventing one -- e.g. a single fake request holding the whole tier --
+    would hand the attention a query block wider than ``verify_width`` for a
+    request whose seq_len is the graph's fill value, i.e. a much longer stale KV
+    read than the fixed-width idle path has ever done.
+    """
+    runner = target_worker.model_runner.decode_cuda_graph_runner
+    layout = runner._capture_ragged_verify_layout(int(tier_num_tokens))
+    assert layout is not None and layout.graph_num_tokens == int(tier_num_tokens), (
+        "idle DP rank could not build the agreed tier "
+        f"{tier_num_tokens}; got {layout}"
+    )
+    return layout

--- a/python/sglang/srt/speculative/hybrid_retrieval.py
+++ b/python/sglang/srt/speculative/hybrid_retrieval.py
@@ -1,0 +1,441 @@
+"""NGRAM retrieval engine for the hybrid MTP + retrieval chain (hybrid retrieval).
+
+Wraps the existing :class:`NgramCorpus` (an online, per-process trie over each
+request's own running tokens) and exposes a CHAIN-ONLY query for the EAGLE
+hybrid path: given each request's verified context, return a fixed-width
+``[bs, L]`` continuation chain ``[root, c1, ..., c_{L-1}]`` (root = the
+context's last token; unmatched positions zero-padded) that
+``hybrid_chain.build_hybrid_verify_input`` splices onto the kept MTP prefix
+(agreement-gated) and verifies.
+
+Design notes:
+  * Chain-only: the corpus is built with bfs breadth fixed to 1. (breadth=1
+    caps children-per-node but the corpus may still seed BFS from several
+    suffix anchors, so the flattened result can occasionally branch; this only
+    costs accept length -- the agreement gate and verify reject any off-path
+    token, so greedy output and TP determinism are unaffected.)
+  * The corpus is updated (``insert``) only with VERIFIED tokens, AFTER each
+    verify step (mirroring ``NGRAMWorker``: query first, insert after -- so a
+    query matches earlier occurrences of the suffix, not the just-written leaf).
+  * Greedy output is independent of trie content: a retrieved token is accepted
+    only if it equals the target's argmax, so retrieval changes accept LENGTH,
+    never correctness.
+  * Per-TP-rank: each worker process holds its own corpus. Every rank inserts
+    the same verified tokens (the batch is replicated) and issues the same
+    query, so ``batch_get`` is deterministic and returns an identical chain on
+    every rank. The spliced chain is additionally broadcast from rank 0 (see
+    ``hybrid_chain``) because the truncation threshold reads a continuous
+    logprob.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from concurrent.futures import ThreadPoolExecutor
+from typing import Dict, List, Optional, Tuple
+
+import msgspec
+import numpy as np
+import torch
+
+from sglang.srt.speculative.cpp_ngram.ngram_corpus import NgramCorpus
+
+
+class PendingAccepted(msgspec.Struct):
+    """One batch's accepted tokens, copied D2H on a side stream (overlap mode).
+
+    ``cpu_tokens`` is ``[bs, stride]`` pinned host memory, ``cpu_lens`` is
+    ``[bs]`` pinned host accept lengths (incl. bonus), ``done`` is the CUDA
+    event marking copy completion (None on the synchronous/CPU fallback path).
+    """
+
+    rids: List[str]
+    cpu_tokens: torch.Tensor
+    cpu_lens: torch.Tensor
+    done: Optional[torch.cuda.Event] = None
+
+
+def verified_context_tail(req, n: int) -> List[int]:
+    """Last ``n`` tokens of ``req.origin_input_ids ++ req.output_ids``.
+
+    Slices before materializing: ``output_ids`` is an ``array``, and both
+    sequences can be tens of thousands of tokens long, so copying either in full
+    once per request per decode step is a real cost for an ``n`` of ~18.
+    """
+    output_tail = list(req.output_ids[-n:])
+    if len(output_tail) >= n:
+        return output_tail
+    need = n - len(output_tail)
+    return list(req.origin_input_ids[-need:]) + output_tail
+
+
+class HybridRetriever:
+    # Cap on the closed-rid set (see erase); relays are at most a couple of
+    # batches deep, so this is far more headroom than the drain ever needs.
+    _MAX_CLOSED_RIDS = 4096
+
+    def __init__(self, server_args, device: str):
+        self.device = device
+        # = L, the verify width; also the retrieval chain width.
+        self.draft_token_num: int = server_args.speculative_num_draft_tokens
+        self.max_trie_depth: int = server_args.speculative_ngram_max_trie_depth
+        # Chain-only retrieval: breadth fixed to 1. draft_token_num = L so the
+        # returned chain is [root + up to L-1 continuation tokens], zero-padded.
+        self.corpus = NgramCorpus(
+            min_bfs_breadth=1,
+            max_bfs_breadth=1,
+            match_type=server_args.speculative_ngram_match_type,
+            capacity=server_args.speculative_ngram_capacity,
+            max_trie_depth=self.max_trie_depth,
+            draft_token_num=self.draft_token_num,
+        )
+        # Run the (host-side, CPU) trie walk on a worker thread so it overlaps
+        # the GPU draft_forward. launch_query() submits before draft();
+        # collect() joins in the verify-input build. Safe because the walk is
+        # joined before verify, so no insert/publish runs concurrently with it.
+        self._pool = ThreadPoolExecutor(max_workers=1)
+        self._fut = None
+
+        # Overlap mode: the retriever stops reading req.output_ids (which lags
+        # one batch under the overlap scheduler) and maintains its OWN per-req
+        # verified context, fed by an async accepted-token relay from verify.
+        self.overlap: bool = server_args.speculative_hybrid_overlap
+        # Shadow verified context: last max_trie_depth verified tokens per req
+        # (query/insert source) + running total length (for batch_get position).
+        self._ctx_tail: Dict[str, List[int]] = {}
+        self._ctx_total_len: Dict[str, int] = {}
+        # The exact per-req context we queried this step; inserted after verify
+        # (query-first / insert-after), so a query matches earlier occurrences.
+        self._last_query_snapshot: Optional[List[List[int]]] = None
+        # Async accepted-token relay: verify enqueues a D2H copy on a side
+        # stream and appends a PendingAccepted; the next launch_query drains it
+        # (sync the event, fold tokens into the shadow context). Keeps the D2H
+        # off the forward hot path. FIFO of at most a couple of batches.
+        self._pending: deque[PendingAccepted] = deque()
+        self._closed_rids: set = set()  # departed; the relay drain skips them
+        # rids of the last decode batch, for the departed-request eviction.
+        self._prev_rids: set = set()
+        self._accept_copy_stream = (
+            torch.cuda.Stream(device=device)
+            if (self.overlap and torch.cuda.is_available())
+            else None
+        )
+
+    def reset(self) -> None:
+        """Clear the online corpus and all per-request retrieval state.
+
+        The scheduler only calls this through ``/flush_cache`` while the
+        engine is fully idle.  Idle does not, however, imply that the CPU trie
+        walk, overlap D2H relay, or asynchronous corpus inserts have finished,
+        so drain them in that order before resetting the trie.  In particular,
+        ``NgramCorpus.reset()`` does not drain inserts that are already queued.
+        """
+        fut, self._fut = self._fut, None
+        if fut is not None:
+            fut.result()
+
+        # Keep every pending pinned destination alive until its D2H copy has
+        # completed.  Synchronizing the dedicated stream covers all queued
+        # events; the fallback path synchronizes them individually.
+        if self._accept_copy_stream is not None:
+            self._accept_copy_stream.synchronize()
+        else:
+            for pending in self._pending:
+                if pending.done is not None:
+                    pending.done.synchronize()
+        self._pending.clear()
+
+        # This ordering is critical: otherwise a pre-reset queued insert can
+        # land after reset and leak corpus data into the next experiment arm.
+        self.corpus.synchronize()
+        self.corpus.reset()
+
+        self._ctx_tail.clear()
+        self._ctx_total_len.clear()
+        self._last_query_snapshot = None
+        self._prev_rids.clear()
+        self._closed_rids.clear()
+
+    # ---------------------------- query / collect ----------------------------
+
+    def launch_query(self, reqs) -> None:
+        """Submit the trie walk for the current verified context to the worker
+        thread (call at the start of the decode step, before draft_forward)."""
+        if self.overlap:
+            self._launch_query_overlap(reqs)
+            return
+        req_ids: List[str] = []
+        batch_tokens: List[List[int]] = []
+        total_lens: List[int] = []
+        for req in reqs:
+            req_ids.append(req.rid)
+            batch_tokens.append(verified_context_tail(req, self.max_trie_depth))
+            total_lens.append(len(req.origin_input_ids) + len(req.output_ids))
+        self._fut = self._pool.submit(
+            self._trie_walk, req_ids, batch_tokens, total_lens, len(reqs)
+        )
+
+    def collect(self) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Join the worker thread and return ``(chains, lens)`` on device:
+        ``[bs, L]`` retrieved chains and the ``[bs]`` TRUE continuation length of
+        each (excluding the root). Returns ``(None, None)`` when launch_query was
+        never called.
+
+        The length is reported explicitly rather than recovered from the chain,
+        because there is no value that can mean "no token": token id 0 is a real
+        vocabulary entry (``<|begin_of_sentence|>`` in DSV4, and it IS in the
+        trie since the full prompt is indexed). Counting non-zeros would confuse
+        a genuine 0 with tail padding.
+        """
+        fut, self._fut = self._fut, None
+        if fut is None:
+            return None, None
+        chains, lens = fut.result()
+        return (
+            torch.from_numpy(chains).to(self.device, non_blocking=True),
+            torch.from_numpy(lens).to(self.device, non_blocking=True),
+        )
+
+    def query(self, reqs) -> Tuple[torch.Tensor, torch.Tensor]:
+        """Synchronous launch+collect (kept for non-threaded callers/tests)."""
+        self.launch_query(reqs)
+        return self.collect()
+
+    def _trie_walk(
+        self, req_ids, batch_tokens, total_lens, bs
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """CPU trie match + linear-chain extraction.
+
+        Returns ``(chains[bs, L], lens[bs])``. Column 0 of a chain is the
+        context's last token (root); columns ``1..lens[r]`` are the retrieved
+        continuation and the rest is zero padding. ``lens`` is produced here, not
+        inferred downstream, because the padding value 0 is also a legal token.
+        """
+        self.corpus.synchronize()  # drain pending async inserts before matching
+        # valid_lens[r] = how many entries of request r's block are REAL nodes
+        # (anchor included). It comes from the C++ producer because it is not
+        # recoverable afterwards: fillResult zero-pads the tail and gives each
+        # pad prev=0, making a pad's mask row identical to a real depth-1 child
+        # whose token is 0 -- and token 0 is legal (DSV4's
+        # <|begin_of_sentence|>, present in the trie because the prompt is
+        # indexed). Counting non-zeros or walking leaf paths over the padded
+        # arrays reports a NO-MATCH result as a length-1 continuation of token 0,
+        # which fakes a graft and throws away the whole MTP fallback.
+        req_drafts, mask, valid_lens = self.corpus.batch_get_with_lens(
+            req_ids, batch_tokens, total_lens
+        )
+        num_draft_tokens = self.draft_token_num
+        drafts = np.asarray(req_drafts).reshape(bs, num_draft_tokens)
+        masks = np.asarray(mask).reshape(bs, num_draft_tokens, num_draft_tokens)
+        valid = np.asarray(valid_lens).reshape(bs)
+        # NGRAM with breadth=1 can still return a BRANCHING tree: BFS is seeded
+        # from every expandable suffix anchor, so the root may have several
+        # children and the result is flattened in BFS order (siblings first) --
+        # i.e. column j is NOT chain depth j. The hybrid splice + agreement gate
+        # require a single LINEAR chain, so extract the longest root-to-leaf
+        # path (deepest suffix match = best continuation) and lay it out as
+        # [root, c1, c2, ...] padded with 0. Without this the retrieved chain
+        # never aligns with the MTP chain and is never grafted.
+        out = np.zeros((bs, num_draft_tokens), dtype=np.int64)
+        lens = np.zeros((bs,), dtype=np.int32)
+        for r in range(bs):
+            out[r, 0] = int(drafts[r, 0])  # root = verified-context last token
+            # Cut the padding off FIRST, using the producer's count, then find
+            # the longest path over what is left. Padding is removed
+            # structurally, so nothing here infers a length from token values.
+            # k == 1 (anchor only) means no match: the loop below leaves
+            # lens[r] == 0, which is what makes the agreement gate reject.
+            k = int(valid[r])
+            if k <= 1:
+                continue
+            sub_tokens = drafts[r, :k].tolist()
+            sub_mask = [row[:k] for row in masks[r, :k].tolist()]
+            # Still the longest ROOT-TO-LEAF path, not k - 1: breadth is pinned
+            # to 1 but BFS is seeded from every expandable suffix anchor, so the
+            # real tree can branch and k counts all of its nodes.
+            paths = self.corpus.leaf_paths_from_mask(sub_tokens, sub_mask)
+            if paths:
+                longest = max(paths, key=len)  # [root, c1, ..., leaf]
+                m = min(len(longest), num_draft_tokens)
+                out[r, :m] = longest[:m]
+                # m counts the root, so the continuation is m - 1 tokens long.
+                lens[r] = m - 1
+        return out, lens  # collect() moves both to device
+
+    # -------------------------- corpus maintenance ---------------------------
+
+    def insert_prompt(self, reqs) -> None:
+        """Insert each request's FULL prompt into the trie at prefill so
+        retrieval can copy from the prompt (RAG / long-context / code-with-
+        context). The decode-time insert() only adds sliding windows of
+        generated text, so without this the prompt body is never matchable."""
+        batch_tokens = [
+            list(req.origin_input_ids) for req in reqs if req.origin_input_ids
+        ]
+        if batch_tokens:
+            self.corpus.batch_put(batch_tokens)
+
+    def insert(self, reqs) -> None:
+        """Insert each request's verified-context tail into the trie (after verify)."""
+        if self.overlap:
+            # Overlap: insert exactly the (fresh, shadow-context) tail we queried.
+            snap, self._last_query_snapshot = self._last_query_snapshot, None
+            if snap:
+                self.corpus.batch_put(snap)
+            return
+        self.corpus.batch_put(
+            [verified_context_tail(req, self.max_trie_depth) for req in reqs]
+        )
+
+    def erase(self, reqs) -> None:
+        """Drop per-request state for requests that LEFT the decode batch.
+
+        ``req.finished()`` is unusable here: under overlap it flips at result
+        processing, one iteration after the request left the batch. Mirrors the
+        upstream NGRAM worker's set-difference policy; the last batch's entries
+        persist while the engine is idle (bounded and small).
+        """
+        current_rids = {req.rid for req in reqs}
+        departed_rids = self._prev_rids - current_rids
+        self._prev_rids = current_rids
+        if not departed_rids:
+            return
+        for rid in departed_rids:
+            self._ctx_tail.pop(rid, None)
+            self._ctx_total_len.pop(rid, None)
+        # Close the rids so a still-in-flight accepted-token relay for them is
+        # dropped instead of resurrecting a shadow context nobody will read.
+        # Bound the set: it only has to cover relays still queued, which is at
+        # most a couple of batches deep.
+        if len(self._closed_rids) > self._MAX_CLOSED_RIDS:
+            self._closed_rids.clear()
+        self._closed_rids |= departed_rids
+        self.corpus.erase_match_state(list(departed_rids))
+
+    # ------------- overlap: shadow context + async accepted relay -------------
+
+    def publish_accepted(
+        self,
+        reqs,
+        next_token_ids: torch.Tensor,
+        accept_lens: torch.Tensor,
+        stride: int,
+    ) -> None:
+        """After verify, relay this step's accepted tokens into the shadow
+        context WITHOUT stalling the forward stream.
+
+        ``next_token_ids`` is the flat ``[bs*stride]`` committed-token buffer
+        (the same one the scheduler slices with
+        ``stride = speculative_num_draft_tokens``); row i's first
+        ``accept_lens[i]`` entries are req i's accepted tokens (incl. the bonus
+        root). We copy them D2H on a side stream and drain at the next
+        launch_query.
+        """
+        if not reqs:
+            return
+        rids = [req.rid for req in reqs]
+        bs = len(rids)
+        # Clone on the CURRENT (forward) stream first, so the async D2H reads a
+        # PRIVATE tensor -- never a cuda-graph-reused output buffer that the
+        # next verify replay could overwrite before the copy finishes. The
+        # clones are tiny int tensors; record_stream keeps them alive until the
+        # copy stream is done. Slice to exactly the region the scheduler commits
+        # from; the buffer may be over-allocated, so never rely on
+        # numel == bs*stride.
+        tokens_2d = next_token_ids[: bs * stride].reshape(bs, stride).clone()
+        lens = accept_lens[:bs].reshape(bs).clone()
+        if self._accept_copy_stream is None:
+            # Non-cuda / synchronous fallback: resolve immediately.
+            self._pending.append(
+                PendingAccepted(
+                    rids=rids, cpu_tokens=tokens_2d.to("cpu"), cpu_lens=lens.to("cpu")
+                )
+            )
+            return
+        current = torch.cuda.current_stream(next_token_ids.device)
+        copy_stream = self._accept_copy_stream
+        # Copy waits for verify+clone; the forward does NOT wait for the copy.
+        copy_stream.wait_stream(current)
+        cpu_tokens = torch.empty((bs, stride), dtype=tokens_2d.dtype, pin_memory=True)
+        cpu_lens = torch.empty((bs,), dtype=lens.dtype, pin_memory=True)
+        done = torch.cuda.Event()
+        with torch.cuda.stream(copy_stream):
+            cpu_tokens.copy_(tokens_2d, non_blocking=True)
+            cpu_lens.copy_(lens, non_blocking=True)
+            done.record(copy_stream)
+        tokens_2d.record_stream(copy_stream)
+        lens.record_stream(copy_stream)
+        self._pending.append(
+            PendingAccepted(
+                rids=rids, cpu_tokens=cpu_tokens, cpu_lens=cpu_lens, done=done
+            )
+        )
+
+    def _drain_pending_accepts(self) -> None:
+        """Fold every enqueued batch of accepted tokens into the shadow context.
+
+        Called at the start of launch_query so that, by the time we build this
+        step's query, all prior verifies are reflected (the D2H has typically
+        finished at least one iteration ago; ``event.synchronize()`` is the only
+        potential wait).
+        """
+        while self._pending:
+            pending = self._pending.popleft()
+            if pending.done is not None:
+                pending.done.synchronize()
+            lens = pending.cpu_lens.tolist()
+            rows = pending.cpu_tokens.tolist()
+            for rid, num_accept_tokens, row in zip(pending.rids, lens, rows):
+                num_accept_tokens = int(num_accept_tokens)
+                if num_accept_tokens <= 0 or rid in self._closed_rids:
+                    continue
+                self._append_ctx(rid, row[:num_accept_tokens])
+
+    def _launch_query_overlap(self, reqs) -> None:
+        self._drain_pending_accepts()
+        req_ids: List[str] = []
+        batch_tokens: List[List[int]] = []
+        total_lens: List[int] = []
+        for req in reqs:
+            rid = req.rid
+            self._ensure_req(rid, req)
+            req_ids.append(rid)
+            # Copy the tail so the worker thread and the post-verify insert both
+            # read an immutable snapshot (never a list a later _append_ctx
+            # mutates).
+            batch_tokens.append(list(self._ctx_tail[rid]))
+            total_lens.append(self._ctx_total_len[rid])
+        self._last_query_snapshot = batch_tokens
+        self._fut = self._pool.submit(
+            self._trie_walk, req_ids, batch_tokens, total_lens, len(reqs)
+        )
+
+    def _ensure_req(self, rid: str, req) -> None:
+        """Seed the shadow context for a first-seen req from its prompt only.
+
+        The prefill's first generated token is NOT added here: it arrives as
+        column 0 (the bonus root) of the FIRST decode step's accepted tokens, so
+        publish_accepted folds it in exactly once. (Seeding from output_ids
+        would risk double-counting it, since under overlap it may or may not
+        have landed there yet.)
+        """
+        if rid in self._ctx_total_len:
+            return
+        # A rid can come back after being retracted; un-close it so its relays
+        # are folded in again.
+        self._closed_rids.discard(rid)
+        self._ctx_tail[rid] = list(req.origin_input_ids[-self.max_trie_depth :])
+        self._ctx_total_len[rid] = len(req.origin_input_ids)
+
+    def _append_ctx(self, rid: str, tokens: List[int]) -> None:
+        if not tokens:
+            return
+        tail = self._ctx_tail.get(rid)
+        if tail is None:
+            tail = []
+            self._ctx_tail[rid] = tail
+        tail.extend(int(t) for t in tokens)
+        overflow = len(tail) - self.max_trie_depth
+        if overflow > 0:
+            del tail[:overflow]
+        self._ctx_total_len[rid] = self._ctx_total_len.get(rid, 0) + len(tokens)

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -131,8 +131,23 @@ class SpeculativeAlgorithm(Enum):
     def supports_ragged_verify(self) -> bool:
         """Whether this algorithm's verify step may carry a RaggedVerifyLayout
         (per-request verify lengths); gates the token-bucket-keyed verify
-        graphs in the decode cuda graph runner."""
-        return self.is_dspark()
+        graphs in the decode cuda graph runner.
+
+        EAGLE qualifies only when hybrid retrieval's ragged verify is switched ON for
+        this process. The extra condition is not belt-and-braces: on plain
+        ``is_eagle()`` every EAGLE deployment would swap its fixed-width verify
+        graphs for token-keyed ones and inherit the compact path's restrictions
+        (no TBO, no LoRA, no ``--disable-cuda-graph-padding``) without asking for
+        any of it. The flag is a resolved server arg, so it is the same on every
+        rank and for the whole process lifetime.
+        """
+        if self.is_dspark():
+            return True
+        if not self.is_eagle():
+            return False
+        from sglang.srt.runtime_context import get_server_args
+
+        return bool(get_server_args().speculative_hybrid_ragged)
 
     def supports_grammar_overlap(self) -> bool:
         # Whether the worker advances the grammar FSM inside verify() (via the

--- a/test/registered/unit/model_executor/runner/test_decode_capture_contract.py
+++ b/test/registered/unit/model_executor/runner/test_decode_capture_contract.py
@@ -1,0 +1,277 @@
+"""The inherited capture loop must not read state a subclass never set.
+
+Four speculative runners subclass ``DecodeCudaGraphRunner`` and inherit its
+``capture()`` / ``_capture_one_stream()`` while deliberately NOT calling its
+``__init__`` -- they hand-initialize the fields the inherited loop reads. That
+is a contract with no compiler behind it: adding one ``self.new_field`` read to
+``_capture_one_stream`` takes down every one of those runners at startup with
+``AttributeError``, and it does so on the shared full-draft-graph path, so a
+feature that only the target runner can use still stops a service that has the
+feature switched off.
+
+That has already happened once: ``_capture_one_stream`` grew an unconditional
+``if self.ragged_verify_mode:`` dispatch, and all four runners lost the ability
+to capture. The fix declared the ragged capture fields as class-level defaults
+on ``DecodeCudaGraphRunner``; this test is what keeps the next field from
+repeating it.
+
+It is a source-level (AST) contract check rather than a live capture: capturing
+needs a model, a device and a real attention backend, so a runnable test would
+have to be a GPU test, and a GPU test is not where a missing attribute should
+first be noticed. What it computes:
+
+  required = attribute names read off ``self`` inside the capture loop that graph-tier mode
+             changed (``_capture_one_stream``, ``_capture_ragged_tiers``, plus
+             the parent helpers they call on ``self``)
+  provided = names each subclass assigns to ``self`` in ``__init__`` (following
+             the helpers ``__init__`` calls) + class-level defaults on the
+             subclass or on ``DecodeCudaGraphRunner`` + method/property names
+             visible on either class
+
+and requires ``required <= provided`` for every subclass.
+
+Scope, stated so the next reader does not assume more: the closure stops at the
+methods the subclasses override (``capture_one_shape``) and does not walk
+``capture()`` itself. Those read state that ``capture()`` installs at capture
+time (``self.stream``, ``self.bs``, ...), never ``__init__`` state, so widening
+the closure would turn this into a list of exceptions rather than a contract.
+"""
+
+import ast
+import unittest
+from pathlib import Path
+
+import sglang
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+# Read the sources from the installed/importable sglang, not from a path
+# relative to this test file: the same contract has to hold for whichever tree
+# CI actually runs.
+_SRT = Path(sglang.__file__).resolve().parent / "srt"
+_PARENT_FILE = _SRT / "model_executor" / "runner" / "decode_cuda_graph_runner.py"
+_BASE_FILES = (
+    _SRT / "model_executor" / "runner" / "base_cuda_graph_runner.py",
+    _SRT / "model_executor" / "runner" / "base_runner.py",
+)
+# Every direct subclass that inherits the capture loop while skipping
+# DecodeCudaGraphRunner.__init__. NPUGraphRunner / XPUGraphRunner also subclass
+# it but call super().__init__(), so the contract holds for them by
+# construction.
+_SUBCLASSES = (
+    (
+        "EAGLEDraftCudaGraphRunner",
+        _SRT / "speculative" / "eagle_draft_cuda_graph_runner.py",
+    ),
+    (
+        "EAGLEDraftExtendCudaGraphRunner",
+        _SRT / "speculative" / "eagle_draft_extend_cuda_graph_runner.py",
+    ),
+    (
+        "FrozenKVMTPCudaGraphRunner",
+        _SRT / "speculative" / "frozen_kv_mtp_cuda_graph_runner.py",
+    ),
+    (
+        "MultiLayerEagleDraftExtendCudaGraphRunner",
+        _SRT / "speculative" / "multi_layer_eagle_draft_extend_cuda_graph_runner.py",
+    ),
+)
+# The capture loop graph-tier mode rewrote. `capture_one_shape` is excluded on purpose: all
+# four subclasses override it, so their own version is what runs.
+_CAPTURE_ENTRYPOINTS = ("_capture_one_stream", "_capture_ragged_tiers")
+
+
+def _class_def(path: Path, name: str) -> ast.ClassDef:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ClassDef) and node.name == name:
+            return node
+    raise AssertionError(f"{path}: no class {name}")
+
+
+def _methods(cls: ast.ClassDef) -> set:
+    return {
+        node.name
+        for node in cls.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+
+
+def _class_level_names(cls: ast.ClassDef) -> set:
+    """Names bound in the class body itself (the declared defaults)."""
+    names = set()
+    for node in cls.body:
+        if isinstance(node, ast.AnnAssign) and node.value is not None:
+            if isinstance(node.target, ast.Name):
+                names.add(node.target.id)
+        elif isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    names.add(target.id)
+    return names
+
+
+def _method_node(cls: ast.ClassDef, name: str):
+    for node in cls.body:
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == name
+        ):
+            return node
+    return None
+
+
+def _self_reads(node: ast.AST) -> set:
+    """`self.x` in a load context -> {"x"}.
+
+    `getattr(self, "x", default)` is deliberately NOT collected: it does not
+    produce a `self.x` attribute node, and a caller that spells the read that
+    way has already declared the field optional.
+    """
+    reads = set()
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Attribute)
+            and isinstance(sub.value, ast.Name)
+            and sub.value.id == "self"
+            and isinstance(sub.ctx, ast.Load)
+        ):
+            reads.add(sub.attr)
+    return reads
+
+
+def _self_writes(node: ast.AST) -> set:
+    writes = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, (ast.Assign, ast.AugAssign, ast.AnnAssign)):
+            targets = sub.targets if isinstance(sub, ast.Assign) else [sub.target]
+            for target in targets:
+                for leaf in ast.walk(target):
+                    if (
+                        isinstance(leaf, ast.Attribute)
+                        and isinstance(leaf.value, ast.Name)
+                        and leaf.value.id == "self"
+                    ):
+                        writes.add(leaf.attr)
+    return writes
+
+
+def _self_calls(node: ast.AST) -> set:
+    calls = set()
+    for sub in ast.walk(node):
+        if (
+            isinstance(sub, ast.Call)
+            and isinstance(sub.func, ast.Attribute)
+            and isinstance(sub.func.value, ast.Name)
+            and sub.func.value.id == "self"
+        ):
+            calls.add(sub.func.attr)
+    return calls
+
+
+def _closure(cls: ast.ClassDef, entrypoints, *, skip: set):
+    """Fixpoint over `self.method()` calls, returning the reads and the methods walked."""
+    pending = [name for name in entrypoints]
+    walked = set()
+    reads = set()
+    while pending:
+        name = pending.pop()
+        if name in walked or name in skip:
+            continue
+        node = _method_node(cls, name)
+        if node is None:
+            continue
+        walked.add(name)
+        reads |= _self_reads(node)
+        pending.extend(_self_calls(node))
+    return reads, walked
+
+
+class TestDecodeCaptureContract(CustomTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.parent = _class_def(_PARENT_FILE, "DecodeCudaGraphRunner")
+        cls.parent_methods = _methods(cls.parent)
+        for path in _BASE_FILES:
+            for base in ("BaseCudaGraphRunner", "BaseRunner"):
+                try:
+                    cls.parent_methods |= _methods(_class_def(path, base))
+                except AssertionError:
+                    continue
+        cls.required, cls.walked = _closure(
+            cls.parent, _CAPTURE_ENTRYPOINTS, skip={"capture_one_shape"}
+        )
+
+    def test_capture_entrypoints_still_exist(self):
+        """If the loop is renamed, the rest of this file silently checks nothing."""
+        self.assertEqual(
+            set(_CAPTURE_ENTRYPOINTS), self.walked & set(_CAPTURE_ENTRYPOINTS)
+        )
+        self.assertIn("ragged_verify_mode", self.required)
+        self.assertIn("capture_num_tokens", self.required)
+
+    def test_ragged_capture_fields_have_class_level_defaults(self):
+        """The two fields the loop reads before any subclass state exists."""
+        declared = _class_level_names(self.parent)
+        self.assertIn("ragged_verify_mode", declared)
+        self.assertIn("capture_num_tokens", declared)
+
+    def test_every_bypassing_subclass_satisfies_the_capture_contract(self):
+        parent_class_level = _class_level_names(self.parent)
+        for name, path in _SUBCLASSES:
+            with self.subTest(runner=name):
+                sub = _class_def(path, name)
+                init = _method_node(sub, "__init__")
+                self.assertIsNotNone(init, f"{name} has no __init__")
+                # Follow the helpers __init__ calls on self, so a runner that
+                # sets its fields in a private setup method still counts.
+                provided = set()
+                pending = ["__init__"]
+                seen = set()
+                while pending:
+                    method_name = pending.pop()
+                    if method_name in seen:
+                        continue
+                    node = _method_node(sub, method_name)
+                    if node is None:
+                        continue
+                    seen.add(method_name)
+                    provided |= _self_writes(node)
+                    pending.extend(_self_calls(node))
+                provided |= _class_level_names(sub)
+                provided |= parent_class_level
+                provided |= _methods(sub)
+                provided |= self.parent_methods
+                missing = sorted(self.required - provided)
+                self.assertEqual(
+                    missing,
+                    [],
+                    f"{name} inherits the capture loop but never provides "
+                    f"{missing}; declare a class-level default on "
+                    f"DecodeCudaGraphRunner or set it in {name}.__init__",
+                )
+
+    def test_subclasses_really_do_bypass_the_parent_init(self):
+        """The premise. If a runner starts calling super().__init__(), it no
+        longer needs the class-level defaults and should be dropped from
+        _SUBCLASSES rather than left here asserting nothing."""
+        for name, path in _SUBCLASSES:
+            with self.subTest(runner=name):
+                init = _method_node(_class_def(path, name), "__init__")
+                super_init = [
+                    node
+                    for node in ast.walk(init)
+                    if isinstance(node, ast.Call)
+                    and isinstance(node.func, ast.Attribute)
+                    and node.func.attr == "__init__"
+                    and isinstance(node.func.value, ast.Call)
+                    and isinstance(node.func.value.func, ast.Name)
+                    and node.func.value.func.id == "super"
+                ]
+                self.assertEqual(super_init, [], f"{name} now calls super().__init__()")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/model_executor/test_idle_dp_padding_restore.py
+++ b/test/registered/unit/model_executor/test_idle_dp_padding_restore.py
@@ -1,0 +1,194 @@
+"""An idle DP rank must leave the forward with the empty batch it arrived with.
+
+Under DP attention every rank joins every forward, including the ones with no
+requests. Whether an idle rank's 0-row inputs get PADDED is decided by
+arithmetic it does not control: ``DpPaddingMode.get_dp_padding_mode`` switches
+from SUM_LEN to MAX_LEN once ``sum_len * 2 >= max_len * dp_size``, which for one
+draft row per busy rank means "half the ranks are busy" -- 4 of 8 flips it, 1 of
+8 does not.
+
+``post_forward_mlp_sync_batch`` truncates the OUTPUT back to zero rows. It used
+to leave the padded INPUT tensors on the batch, which is fatal because the batch
+is reused: ``EagleDraftWorker.draft_forward`` runs ``speculative_num_steps``
+forwards on one ForwardBatch and pairs ``forward_batch.positions`` with the
+logits that forward returned. With a 1-row ``positions`` and 0-row logits, the
+topk=1 draft kernel's precondition fails, and four of eight DP ranks died on the
+first decode step after four requests arrived.
+
+CPU-only: this is shape bookkeeping, so a stub attention backend supplying the
+seq-len fill value is the only collaborator needed. The batch is built with
+``__new__`` + explicit fields rather than ``init_new`` so the test states exactly
+which fields it is talking about.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.dp_attention import DpPaddingMode
+from sglang.srt.model_executor.forward_batch_info import ForwardBatch, ForwardMode
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+SEQ_LEN_FILL_VALUE = 1
+_MODEL_RUNNER = SimpleNamespace(
+    attn_backend=SimpleNamespace(
+        get_cuda_graph_seq_len_fill_value=lambda: SEQ_LEN_FILL_VALUE
+    )
+)
+
+
+class _StubDraftInput:
+    """The EagleDraftInput fields `_pad_inputs_to_size` pads."""
+
+    def __init__(self, rows, *, hidden=4):
+        self.hidden_states = torch.zeros((rows, hidden), dtype=torch.float32)
+        self.topk_p = torch.zeros((rows, 1), dtype=torch.float32)
+        self.topk_index = torch.zeros((rows, 1), dtype=torch.int64)
+        self.draft_probs = None
+        self.num_tokens_per_req = 1
+
+    def is_draft_input(self):
+        return True
+
+
+def _make_batch(rows, *, forward_mode):
+    batch = ForwardBatch.__new__(ForwardBatch)
+    batch.forward_mode = forward_mode
+    batch.batch_size = rows
+    batch.input_ids = torch.arange(rows, dtype=torch.int64)
+    batch.req_pool_indices = torch.arange(rows, dtype=torch.int64)
+    batch.positions = torch.arange(rows, dtype=torch.int64)
+    batch.out_cache_loc = torch.arange(rows, dtype=torch.int64)
+    batch.seq_lens = torch.full((rows,), 7, dtype=torch.int64)
+    batch.seq_lens_cpu = torch.full((rows,), 7, dtype=torch.int64)
+    batch.seq_lens_sum = 7 * rows
+    batch.lora_ids = None
+    batch.encoder_lens = None
+    batch.mamba_track_indices = None
+    batch.mamba_track_mask = None
+    batch.mamba_track_seqlens = None
+    batch.mrope_positions = None
+    batch.extend_seq_lens = None
+    batch.rids_int = None
+    batch.bootstrap_room_ids_int = None
+    batch.sampling_info = None
+    batch.spec_info = _StubDraftInput(rows)
+    batch._original_forward_mode = None
+    batch._original_batch_size = None
+    return batch
+
+
+def _pad_like_mlp_sync(batch, *, num_tokens, bs):
+    """The two bookkeeping writes prepare_mlp_sync_batch makes around padding.
+
+    `_original_forward_mode` stays None: that is the plain-IDLE case, the one the
+    draft loop reuses. The fabricated-row conversions (hybrid-SSM, prefill
+    breakable graph) set it, and keep their fabricated shape by design.
+    """
+    batch._original_batch_size = batch.batch_size
+    batch.batch_size = bs
+    batch._pad_inputs_to_size(_MODEL_RUNNER, num_tokens, bs)
+
+
+def _logits(rows, *, vocab=8, hidden=4):
+    return SimpleNamespace(
+        next_token_logits=torch.zeros((rows, vocab), dtype=torch.float32),
+        hidden_states=torch.zeros((rows, hidden), dtype=torch.float32),
+    )
+
+
+class TestIdleDpPaddingRestore(CustomTestCase):
+    @mock.patch("sglang.srt.layers.dp_attention.get_attention_dp_size", return_value=8)
+    def test_max_len_is_reached_at_half_the_ranks(self, _mock_dp_size):
+        """The trigger is a threshold, so it stays invisible until it is hit."""
+        self.assertEqual(
+            DpPaddingMode.get_dp_padding_mode(
+                is_extend_in_batch=False, global_num_tokens=[1, 0, 0, 0, 0, 0, 0, 0]
+            ),
+            DpPaddingMode.SUM_LEN,
+        )
+        self.assertEqual(
+            DpPaddingMode.get_dp_padding_mode(
+                is_extend_in_batch=False, global_num_tokens=[0, 0, 1, 1, 1, 1, 0, 0]
+            ),
+            DpPaddingMode.MAX_LEN,
+        )
+
+    def test_idle_rank_comes_back_empty(self):
+        batch = _make_batch(0, forward_mode=ForwardMode.IDLE)
+        _pad_like_mlp_sync(batch, num_tokens=1, bs=1)
+        # The padding really happened, else the restore below proves nothing.
+        self.assertEqual(batch.positions.shape[0], 1)
+        self.assertEqual(batch.seq_lens.shape[0], 1)
+        self.assertEqual(batch.seq_lens_sum, SEQ_LEN_FILL_VALUE)
+        self.assertEqual(batch.spec_info.hidden_states.shape[0], 1)
+
+        logits_output = _logits(1)
+        batch.post_forward_mlp_sync_batch(logits_output)
+
+        self.assertEqual(logits_output.next_token_logits.shape[0], 0)
+        for field in (
+            "input_ids",
+            "req_pool_indices",
+            "positions",
+            "out_cache_loc",
+            "seq_lens",
+            "seq_lens_cpu",
+        ):
+            self.assertEqual(getattr(batch, field).shape[0], 0, f"{field} left padded")
+        self.assertEqual(batch.seq_lens_sum, 0)
+        self.assertEqual(batch.batch_size, 0)
+        self.assertEqual(batch.spec_info.topk_p.shape[0], 0)
+        self.assertEqual(batch.spec_info.topk_index.shape[0], 0)
+        self.assertEqual(batch.spec_info.hidden_states.shape[0], 0)
+
+    def test_positions_and_logits_agree_after_restore(self):
+        """The invariant the draft loop asserts on, stated directly."""
+        batch = _make_batch(0, forward_mode=ForwardMode.IDLE)
+        _pad_like_mlp_sync(batch, num_tokens=1, bs=1)
+        logits_output = _logits(1)
+        batch.post_forward_mlp_sync_batch(logits_output)
+        self.assertEqual(
+            batch.positions.shape[0], logits_output.next_token_logits.shape[0]
+        )
+
+    def test_busy_decode_rank_is_untouched(self):
+        """No collateral damage: a rank WITH requests keeps the narrower restore
+        it always had (per-token tensors to the pre-padding token count, per-request
+        tensors to the real batch size) and must not be emptied."""
+        batch = _make_batch(1, forward_mode=ForwardMode.DECODE)
+        _pad_like_mlp_sync(batch, num_tokens=2, bs=2)
+        self.assertEqual(batch.positions.shape[0], 2)
+
+        logits_output = _logits(2)
+        batch.post_forward_mlp_sync_batch(logits_output)
+
+        self.assertEqual(batch.positions.shape[0], 1)
+        self.assertEqual(batch.seq_lens.shape[0], 1)
+        self.assertEqual(batch.req_pool_indices.shape[0], 1)
+        self.assertEqual(batch.batch_size, 1)
+        self.assertEqual(logits_output.next_token_logits.shape[0], 1)
+
+    def test_converted_idle_rank_keeps_its_fabricated_request(self):
+        """A hybrid-SSM / prefill-graph idle rank is given a whole dummy request
+        by prepare_mlp_sync_batch instead of having an empty one padded. Undoing
+        only the padding half would leave a batch that is neither, so the restore
+        deliberately skips it -- pinned here so the skip stays a decision."""
+        batch = _make_batch(0, forward_mode=ForwardMode.IDLE)
+        _pad_like_mlp_sync(batch, num_tokens=1, bs=1)
+        batch._original_forward_mode = ForwardMode.IDLE
+        batch.forward_mode = ForwardMode.TARGET_VERIFY
+
+        batch.post_forward_mlp_sync_batch(_logits(1))
+
+        self.assertEqual(batch.forward_mode, ForwardMode.IDLE)
+        self.assertEqual(batch.positions.shape[0], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_hybrid_chain.py
+++ b/test/registered/unit/spec/test_hybrid_chain.py
@@ -1,0 +1,165 @@
+import math
+import unittest
+
+import torch
+
+from sglang.srt.speculative.hybrid_chain import (
+    HybridChainState,
+    parse_position_thresholds,
+    splice_hybrid_chain,
+)
+from sglang.srt.speculative.hybrid_ragged import (
+    build_hybrid_ragged_tier_grid,
+    compute_hybrid_verify_lens,
+    plan_hybrid_ragged_tier,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestHybridThresholds(CustomTestCase):
+    def test_parse_per_verify_column(self):
+        self.assertEqual(
+            parse_position_thresholds("off,off,0.40,0.55", 0.4, 3),
+            [0.0, 0.4, 0.55],
+        )
+        self.assertEqual(parse_position_thresholds("", 0.4, 3), [0.0, 0.4, 0.4])
+
+    def test_rejects_thresholds_for_non_draft_columns(self):
+        for value in ("0.1,off,0.4,0.5", "off,0.1,0.4,0.5"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                parse_position_thresholds(value, 0.4, 3)
+
+    def test_rejects_wrong_width_and_range(self):
+        for value in ("off,off,0.4", "off,off,0.4,1.1"):
+            with self.subTest(value=value), self.assertRaises(ValueError):
+                parse_position_thresholds(value, 0.4, 3)
+
+
+class TestHybridChainSplice(CustomTestCase):
+    def setUp(self):
+        self.mtp = torch.tensor(
+            [[11, 12, 13], [21, 22, 23], [31, 32, 33], [41, 42, 43]]
+        )
+        self.retrieval = torch.tensor(
+            [
+                [10, 11, 12, 13, 14, 15],
+                [20, 21, 99, 98, 97, 96],
+                [30, 77, 76, 75, 74, 73],
+                [40, 0, 0, 0, 0, 0],
+            ]
+        )
+        self.retrieval_lens = torch.tensor([5, 5, 5, 0])
+        self.step_logprobs = torch.log(
+            torch.tensor([[0.9, 0.9], [0.1, 0.9], [0.9, 0.1], [0.9, 0.9]])
+        )
+        self.thresholds = torch.log(torch.tensor([0.4, 0.55]))
+
+    def test_splices_only_after_prefix_agreement(self):
+        spliced, kept, agreed, grafted = splice_hybrid_chain(
+            mtp_draft_tokens=self.mtp,
+            step_logprobs=self.step_logprobs,
+            retrieval_chains=self.retrieval,
+            retrieval_lens=self.retrieval_lens,
+            tail_log_thresholds=self.thresholds,
+            verify_width=6,
+        )
+
+        self.assertEqual(kept.tolist(), [3, 1, 2, 3])
+        self.assertEqual(agreed.tolist(), [3, 1, 0, 0])
+        self.assertEqual(grafted.tolist(), [True, True, False, False])
+        self.assertEqual(
+            spliced.tolist(),
+            [
+                [11, 12, 13, 14, 15],
+                [21, 99, 98, 97, 96],
+                [31, 32, 33, 0, 0],
+                [41, 42, 43, 0, 0],
+            ],
+        )
+
+    def test_failed_graft_preserves_full_mtp_chain(self):
+        spliced, kept, _, grafted = splice_hybrid_chain(
+            mtp_draft_tokens=self.mtp,
+            step_logprobs=self.step_logprobs,
+            retrieval_chains=None,
+            retrieval_lens=None,
+            tail_log_thresholds=self.thresholds,
+            verify_width=6,
+        )
+
+        self.assertFalse(bool(grafted.any()))
+        self.assertEqual(kept.tolist(), [3, 1, 2, 3])
+        torch.testing.assert_close(spliced[:, :3], self.mtp)
+
+    def test_token_zero_does_not_count_as_retrieval_padding(self):
+        spliced, _, agreed, grafted = splice_hybrid_chain(
+            mtp_draft_tokens=torch.tensor([[0]]),
+            step_logprobs=None,
+            retrieval_chains=torch.tensor([[7, 0, 0]]),
+            retrieval_lens=torch.tensor([0]),
+            tail_log_thresholds=torch.empty(0),
+            verify_width=3,
+        )
+
+        self.assertEqual(agreed.item(), 0)
+        self.assertFalse(grafted.item())
+        self.assertEqual(spliced.tolist(), [[0, 0]])
+
+
+class TestHybridRaggedLengths(CustomTestCase):
+    def test_lengths_cover_mtp_floor_and_retrieval_tail(self):
+        widths = compute_hybrid_verify_lens(
+            num_keep_drafts=torch.tensor([3, 3, 3, 3]),
+            graft_ok=torch.tensor([False, True, True, False]),
+            num_retrieval_tokens=torch.tensor([3, 8, 4, 2]),
+            num_steps=3,
+            verify_width=9,
+        )
+
+        self.assertEqual(widths.dtype, torch.int32)
+        self.assertEqual(widths.tolist(), [4, 9, 5, 4])
+
+    def test_extension_ema_counts_only_retrieval_extensions(self):
+        state = HybridChainState(
+            thresholds=[0.0, 0.4, 0.55],
+            tau_min=0.1,
+            dynamic_tau=True,
+            device="cpu",
+        )
+        state.last_num_keep_drafts = torch.tensor([1, 2, 1, 2])
+        state.last_graft_ok = torch.tensor([True, True, False, False])
+        state.update_extension_ema(
+            num_correct_drafts=torch.tensor([2, 2, 3, 4]), keep_on_device=False
+        )
+
+        self.assertTrue(math.isclose(state.extension_ema, 0.0125))
+
+
+class TestHybridRaggedTiers(CustomTestCase):
+    def test_grid_tracks_each_batch_floor_and_ceiling(self):
+        tiers = build_hybrid_ragged_tier_grid(
+            capture_bs=[1, 2],
+            verify_width=9,
+            floor=4,
+            tier_step=5,
+        )
+
+        self.assertEqual(tiers, [4, 8, 9, 13, 18])
+
+    def test_plan_spends_slack_without_exceeding_request_width(self):
+        plan = plan_hybrid_ragged_tier(
+            accept_verify_lens=[4, 5],
+            verify_width=9,
+            tier_num_tokens=14,
+        )
+
+        self.assertEqual(plan.accept_verify_lens, [4, 5])
+        self.assertEqual(plan.forward_verify_lens, [9, 5])
+        self.assertEqual(sum(plan.forward_verify_lens), 14)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -220,6 +220,22 @@ class TestNgramCorpusNoMatch(CustomTestCase):
         self.assertEqual(ids_list[0], 3)
         self.assertTrue(all(t == 0 for t in ids_list[1:]))
 
+    def test_valid_lengths_distinguish_padding_from_token_zero(self):
+        corpus = _make_corpus("BFS")
+        corpus.batch_put([[55, 0, 66]])
+        corpus.synchronize()
+
+        ids, _, valid_lens = corpus.batch_get_with_lens(
+            req_ids=["no-match", "real-zero"],
+            batch_tokens=[[333], [55]],
+            total_lens=[1, 1],
+        )
+        ids = ids.reshape(2, -1)
+
+        self.assertEqual(ids[0, 1], 0)
+        self.assertEqual(ids[1, 1], 0)
+        self.assertEqual(valid_lens.tolist(), [1, 3])
+
 
 class TestNgramCorpusMultipleInserts(CustomTestCase):
     """Verify that multiple inserts accumulate correctly."""


### PR DESCRIPTION
## Motivation

EAGLE/MTP and N-gram retrieval cover complementary repetition patterns. MTP provides model-learned short drafts, while retrieval can extend much farther when prompts, code, tool calls, or agent trajectories repeat. Today these modes are selected independently.

This PR adds an opt-in hybrid path that keeps the high-confidence MTP prefix and grafts an N-gram continuation only when the retrieved chain agrees with that prefix. If agreement fails, the full MTP chain is preserved, so enabling retrieval cannot shorten the pure-MTP proposal. All proposed tokens are still committed only after the target model verifies them.

This is opened as a draft because the implementation was originally developed and GPU-tested on SGLang v0.5.16, then ported onto current `main`. Current-main GPU CI and benchmark reruns are still required before it is ready for review.

## Modifications

- Add a hybrid MTP + N-gram chain with per-position confidence thresholds, an optional dynamic threshold, and agreement-gated retrieval splicing.
- Add a request-local retrieval shadow context and asynchronous accepted-token relay so retrieval remains aligned with overlap scheduling.
- Extend the in-tree N-gram corpus JIT/FFI with per-request `valid_lens`. This distinguishes legal token ID 0 from zero padding without changing the existing NGRAM hot-path API.
- Add ragged target verification:
  - compact per-request verify windows;
  - fixed-stride scatter before the existing accept path;
  - an accept-length cutoff for uncomputed columns;
  - token-count CUDA graph tiers;
  - cross-rank tier agreement for DP attention;
  - fixed-width restoration for the following draft-extend step.
- Add CLI validation, DSV4/NPU integration hooks, documentation, and registered CPU regression tests.

The feature is disabled by default. The existing EAGLE and NGRAM paths remain unchanged unless the hybrid flags are enabled.

## Accuracy Tests

Current-`main` local validation:

- `pre-commit run --all-files`: passed twice, including Python, C++, CI registration, and Rust checks.
- 10 focused CPU unit tests passed for threshold parsing, agreement-gated splicing, token-0 padding, ragged lengths, dynamic-threshold EMA, graph-tier construction, and tier slack allocation.
- The N-gram JIT test passed with `valid_lens == [1, 3]` for the ambiguous no-match versus genuine-token-0 case.
- Python compile checks and `git diff --check` passed.

Archived v0.5.16 GPU validation:

- TP8 DSV4 Gate 2 compared fixed and ragged verification on the same greedy samples. Emitted text was identical for 4/4 samples in eager mode and 4/4 samples with CUDA graphs.
A current-`main` GPU correctness/evaluation run is pending; this is why the PR is a draft.

## Speed Tests and Profiling

Current-`main` GPU speed benchmarks and profiling are pending.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide current-`main` accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33142692804](https://github.com/sgl-project/sglang/actions/runs/33142692804)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33142692549](https://github.com/sgl-project/sglang/actions/runs/33142692549)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33142692652](https://github.com/sgl-project/sglang/actions/runs/33142692652)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->