### PR TITLE
[Docs] Feature GLM-5.3-Flash in the popular-models banner

### DIFF
--- a/docs/cookbook/autoregressive/intro.mdx
+++ b/docs/cookbook/autoregressive/intro.mdx
@@ -22,7 +22,7 @@ metatags:
   <Card
     title="GLM"
     mode="card"
-    href="/cookbook/autoregressive/GLM/GLM-5.2"
+    href="/cookbook/autoregressive/GLM/GLM-5.3-Flash"
     img="/cards/logos/glm.png"
   />
   <Card

--- a/docs/src/snippets/configs/popular-models.jsx
+++ b/docs/src/snippets/configs/popular-models.jsx
@@ -30,6 +30,23 @@ export const popularModels = [
     },
   },
   {
+    name: "GLM-5.3-Flash",
+    vendor: "Z.ai",
+    href: "/cookbook/autoregressive/GLM/GLM-5.3-Flash",
+    logo: "/cards/logos/glm.png",
+    badge: "New",
+    tags: ["9 platforms", "MLA + DSA + KDA hybrid", "Multimodal"],
+    hero: {
+      eyebrow: "Featured model · New",
+      headline: "Meet GLM-5.3-Flash on SGLang",
+      blurb:
+        "Z.ai's natively multimodal Mixture-of-Experts model — 320B total parameters with 18B active, 45 text layers combining MLA, DSA sparse, and KDA linear attention, a 24-layer vision encoder for image and video input, and a native MTP draft layer for speculative decoding. Recipes cover H100 / H200 / B200 / B300 / GB200 / GB300 and AMD MI300X / MI325X / MI355X.",
+      tags: ["320B / 18B active", "1M context", "Text + image + video"],
+      cta: "Open the GLM-5.3-Flash cookbook",
+      caption: "GLM-5.3-Flash deployment guide",
+    },
+  },
+  {
     name: "MiniMax-H3",
     vendor: "MiniMax",
     href: "/cookbook/diffusion/MiniMax/MiniMax-H3",
@@ -61,23 +78,6 @@ export const popularModels = [
       tags: ["2.8T parameters", "Fused KDA decode", "NVIDIA + AMD"],
       cta: "Open the Kimi-K3 cookbook",
       caption: "Kimi-K3 deployment guide",
-    },
-  },
-  {
-    name: "Inkling",
-    vendor: "Thinking Machines",
-    href: "/cookbook/autoregressive/ThinkingMachines/Inkling",
-    logo: "/cards/logos/thinkingmachines.png",
-    badge: "New",
-    tags: ["7 platforms", "NVFP4 / BF16", "MTP + DSpark"],
-    hero: {
-      eyebrow: "Featured model · New",
-      headline: "Meet Inkling on SGLang",
-      blurb:
-        "Thinking Machines' open-weights Mixture-of-Experts model — 975B parameters, 41B active per token, a 1M-token context window, and native text, image, and audio input. The cookbook covers its MTP speculative-decoding path and long-context prefix caching on NVIDIA and AMD.",
-      tags: ["975B · 41B active", "1M context", "Text + image + audio"],
-      cta: "Open the Inkling cookbook",
-      caption: "Inkling deployment guide",
     },
   },
 ];


### PR DESCRIPTION
## Motivation

Refresh the curated popular-models rotation (docs home hero + Cookbook home strip) now that the GLM-5.3-Flash cookbook is live:

1. Add **GLM-5.3-Flash** as the second entry, right after Qwen3.8-Flash-Next, and retire the Inkling entry.
2. Point the **GLM vendor card** on the autoregressive cookbook overview at `GLM/GLM-5.3-Flash` instead of `GLM/GLM-5.2`.

## Modifications

- `docs/src/snippets/configs/popular-models.jsx`: new GLM-5.3-Flash entry (strip tags + hero block). Copy follows the file's own rule — platform count (9) matches the model config's `supportedHardware`, and the blurb paraphrases the GLM-5.3-Flash page's opening (320B / 18B active, MLA + DSA + KDA hybrid attention, 24-layer vision encoder, native MTP draft, 1M context). Inkling entry removed; the rotation stays at 4 entries and the consumer walks `models.length`, so no component change is needed.
- `docs/cookbook/autoregressive/intro.mdx`: GLM card `href` → `/cookbook/autoregressive/GLM/GLM-5.3-Flash`.

## Checklist

- [x] Format your code with pre-commit
- [ ] Add unit tests (docs-only change)
- [ ] Update documentation as needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33142768334](https://github.com/sgl-project/sglang/actions/runs/33142768334)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33142768248](https://github.com/sgl-project/sglang/actions/runs/33142768248)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->