### PR TITLE
[Bug] Bound deterministic FlashInfer CUDA-graph decode launches

### DIFF
--- a/python/sglang/srt/layers/attention/flashinfer_backend.py
+++ b/python/sglang/srt/layers/attention/flashinfer_backend.py
@@ -19,7 +19,16 @@ import os
 from dataclasses import dataclass
 from enum import Enum, auto
 from functools import partial
-from typing import TYPE_CHECKING, Callable, List, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Callable,
+    List,
+    Optional,
+    Sequence,
+    TypeVar,
+    Union,
+    cast,
+)
 
 import torch
 
@@ -65,6 +74,97 @@ if TYPE_CHECKING:
     from sglang.srt.model_executor.model_runner import ModelRunner
 
 logger = logging.getLogger(__name__)
+
+
+_PlanInfoT = TypeVar("_PlanInfoT", bound=Sequence[int])
+
+# PrefillPlanInfo::ToVector() field positions in SGLang's pinned FlashInfer ABI.
+_FLASHINFER_PREFILL_PLAN_INFO_LENGTH = 15
+_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX = 0
+_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX = 1
+_FLASHINFER_PREFILL_CTA_TILE_Q_INDEX = 3
+_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX = 13
+_FLASHINFER_PREFILL_SPLIT_KV_INDEX = 14
+
+
+def _narrow_deterministic_cuda_graph_decode_plan(
+    plan_info: _PlanInfoT,
+    *,
+    batch_size: int,
+    num_qo_heads: int,
+    num_kv_heads: int,
+) -> _PlanInfoT:
+    """Narrow FlashInfer's deterministic FA2 decode plan to initialized q tiles.
+
+    Tensor-core decode reuses ``PrefillPlanInfo``. With split-KV disabled, its
+    CUDA-graph padding has no validity mask, so only the initialized q-tile
+    entries may be launched.
+    """
+    if len(plan_info) != _FLASHINFER_PREFILL_PLAN_INFO_LENGTH:
+        raise RuntimeError(
+            "Unexpected FlashInfer FA2 plan ABI for deterministic CUDA-graph "
+            f"decode: expected {_FLASHINFER_PREFILL_PLAN_INFO_LENGTH} fields from "
+            f"SGLang's pinned FlashInfer, got {len(plan_info)}."
+        )
+    if batch_size <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode plan batch_size: expected a positive value, "
+            f"got {batch_size}."
+        )
+    if num_qo_heads <= 0 or num_kv_heads <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode head counts: num_qo_heads and num_kv_heads "
+            f"must be positive, got {num_qo_heads} and {num_kv_heads}."
+        )
+    if num_qo_heads % num_kv_heads != 0:
+        raise RuntimeError(
+            "Invalid FlashInfer decode head counts: "
+            f"num_qo_heads ({num_qo_heads}) must be divisible by "
+            f"num_kv_heads ({num_kv_heads})."
+        )
+    if plan_info[_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX] != 1:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: expected a CUDA graph plan, "
+            f"got enable_cuda_graph={plan_info[_FLASHINFER_PREFILL_ENABLE_CUDA_GRAPH_INDEX]}."
+        )
+    if plan_info[_FLASHINFER_PREFILL_SPLIT_KV_INDEX] != 0:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: expected split-KV to be disabled, "
+            f"got split_kv={plan_info[_FLASHINFER_PREFILL_SPLIT_KV_INDEX]}."
+        )
+    if plan_info[_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX] != batch_size:
+        raise RuntimeError(
+            "Invalid FlashInfer deterministic decode plan: expected one query row "
+            f"per request, got total_num_rows="
+            f"{plan_info[_FLASHINFER_PREFILL_TOTAL_NUM_ROWS_INDEX]} and "
+            f"batch_size={batch_size}."
+        )
+
+    cta_tile_q = plan_info[_FLASHINFER_PREFILL_CTA_TILE_Q_INDEX]
+    if cta_tile_q <= 0:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: CTA q tile size must be positive, "
+            f"got {cta_tile_q}."
+        )
+
+    group_size = num_qo_heads // num_kv_heads
+    tiles_per_request = (group_size + cta_tile_q - 1) // cta_tile_q
+    # With one q row per request, FA2 packs the GQA group into q rows and
+    # initializes exactly one scheduler entry per CTA q tile. Split-KV-disabled
+    # plans have no validity mask, so the captured grid must stop at that bound.
+    exact_grid_x = batch_size * tiles_per_request
+    padded_batch_size = plan_info[_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX]
+    if exact_grid_x > padded_batch_size:
+        raise RuntimeError(
+            "Invalid FlashInfer FA2 prefill plan: narrowing would enlarge "
+            f"padded_batch_size from {padded_batch_size} to {exact_grid_x}."
+        )
+    if exact_grid_x == padded_batch_size:
+        return plan_info
+
+    narrowed_plan = list(plan_info)
+    narrowed_plan[_FLASHINFER_PREFILL_PADDED_BATCH_SIZE_INDEX] = exact_grid_x
+    return cast(_PlanInfoT, type(plan_info)(narrowed_plan))
 
 
 if envs.SGLANG_ENABLE_TORCH_COMPILE.get():
@@ -1826,6 +1926,24 @@ class FlashInferIndicesUpdaterDecode:
 
         if locally_override:
             global_override_indptr_cpu = None
+
+        if (
+            disable_split_kv is True
+            and wrapper.is_cuda_graph_enabled
+            and wrapper.use_tensor_cores
+            and getattr(wrapper, "_backend", None) == "fa2"
+        ):
+            plan_info = getattr(wrapper, "_plan_info", None)
+            if plan_info is None:
+                raise RuntimeError(
+                    "FlashInfer split-KV-disabled CUDA graph decode did not produce a plan."
+                )
+            wrapper._plan_info = _narrow_deterministic_cuda_graph_decode_plan(
+                plan_info,
+                batch_size=bs,
+                num_qo_heads=self.num_qo_heads,
+                num_kv_heads=self.num_kv_heads,
+            )
 
 
 class FlashInferIndicesUpdaterPrefill:

--- a/test/registered/unit/layers/attention/test_flashinfer_decode_plan.py
+++ b/test/registered/unit/layers/attention/test_flashinfer_decode_plan.py
@@ -1,0 +1,223 @@
+"""Unit tests for deterministic FlashInfer CUDA-graph decode launch bounds."""
+
+import unittest
+
+from tvm_ffi import Array
+
+from sglang.srt.layers.attention.flashinfer_backend import (
+    _narrow_deterministic_cuda_graph_decode_plan,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _plan_info(
+    *,
+    padded_batch_size=132,
+    total_num_rows=2,
+    cta_tile_q=16,
+    enable_cuda_graph=1,
+    split_kv=0,
+    offset_seed=100,
+):
+    """Build SGLang's pinned 15-field FlashInfer PrefillPlanInfo vector."""
+    return [
+        padded_batch_size,
+        total_num_rows,
+        offset_seed + 2,
+        cta_tile_q,
+        offset_seed + 4,
+        offset_seed + 5,
+        offset_seed + 6,
+        offset_seed + 7,
+        offset_seed + 8,
+        offset_seed + 9,
+        offset_seed + 10,
+        offset_seed + 11,
+        offset_seed + 12,
+        enable_cuda_graph,
+        split_kv,
+    ]
+
+
+class TestFlashInferDecodePlanLaunchBound(CustomTestCase):
+    def test_narrows_mha_and_gqa_to_one_tile_per_request(self):
+        for name, num_qo_heads, num_kv_heads in (
+            ("mha", 16, 16),
+            ("gqa", 16, 2),
+        ):
+            with self.subTest(name=name):
+                plan_info = _plan_info(total_num_rows=4)
+                narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+                    plan_info,
+                    batch_size=4,
+                    num_qo_heads=num_qo_heads,
+                    num_kv_heads=num_kv_heads,
+                )
+                self.assertEqual(narrowed[0], 4)
+
+    def test_group_larger_than_cta_tile_keeps_all_query_tiles(self):
+        plan_info = _plan_info(total_num_rows=3)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=3,
+            num_qo_heads=32,
+            num_kv_heads=1,
+        )
+
+        # GQA group size 32 needs two CTA-q tiles per request when CTA_TILE_Q=16.
+        self.assertEqual(narrowed[0], 6)
+
+    def test_preserves_native_ffi_array_without_mutating_input(self):
+        plan_info = Array(_plan_info())
+        original = tuple(plan_info)
+
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertIs(type(narrowed), type(plan_info))
+        self.assertIsNot(narrowed, plan_info)
+        self.assertEqual(tuple(plan_info), original)
+
+    def test_changes_only_padded_batch_size(self):
+        plan_info = _plan_info(offset_seed=700)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertEqual(narrowed[0], 2)
+        self.assertEqual(narrowed[1:], plan_info[1:])
+
+    def test_equal_bound_returns_the_same_object(self):
+        plan_info = _plan_info(padded_batch_size=2)
+        narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+            plan_info,
+            batch_size=2,
+            num_qo_heads=16,
+            num_kv_heads=2,
+        )
+
+        self.assertIs(narrowed, plan_info)
+
+    def test_representative_normal_and_fast_plan_vectors(self):
+        # The normal capture planner and fast replay planner can produce
+        # different workspace offsets, but share the same scheduling ABI.
+        for planner, offset_seed in (("normal", 100), ("fast", 1000)):
+            with self.subTest(planner=planner):
+                plan_info = _plan_info(offset_seed=offset_seed)
+                narrowed = _narrow_deterministic_cuda_graph_decode_plan(
+                    plan_info,
+                    batch_size=2,
+                    num_qo_heads=16,
+                    num_kv_heads=2,
+                )
+                self.assertEqual(narrowed[0], 2)
+                self.assertEqual(narrowed[1:], plan_info[1:])
+
+    def test_rejects_malformed_plan_abi(self):
+        for length in (14, 16):
+            with self.subTest(length=length):
+                plan_info = _plan_info()
+                plan_info = plan_info[:length] if length < 15 else plan_info + [0]
+                with self.assertRaisesRegex(RuntimeError, "expected 15 fields"):
+                    _narrow_deterministic_cuda_graph_decode_plan(
+                        plan_info,
+                        batch_size=2,
+                        num_qo_heads=16,
+                        num_kv_heads=2,
+                    )
+
+    def test_rejects_non_target_plan_flags_and_row_count(self):
+        cases = (
+            (
+                "not_cuda_graph",
+                _plan_info(enable_cuda_graph=0),
+                "expected a CUDA graph plan",
+            ),
+            (
+                "split_kv",
+                _plan_info(split_kv=1),
+                "expected split-KV to be disabled",
+            ),
+            (
+                "multiple_query_rows",
+                _plan_info(total_num_rows=3),
+                "expected one query row per request",
+            ),
+        )
+        for name, plan_info, message in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    _narrow_deterministic_cuda_graph_decode_plan(
+                        plan_info,
+                        batch_size=2,
+                        num_qo_heads=16,
+                        num_kv_heads=2,
+                    )
+
+    def test_rejects_invalid_dimensions(self):
+        cases = (
+            (
+                "batch_size",
+                _plan_info(),
+                dict(batch_size=0, num_qo_heads=16, num_kv_heads=2),
+                "expected a positive value",
+            ),
+            (
+                "qo_heads",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=0, num_kv_heads=2),
+                "num_qo_heads and num_kv_heads must be positive",
+            ),
+            (
+                "kv_heads",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=0),
+                "num_qo_heads and num_kv_heads must be positive",
+            ),
+            (
+                "head_divisibility",
+                _plan_info(),
+                dict(batch_size=2, num_qo_heads=10, num_kv_heads=3),
+                r"num_qo_heads \(10\) must be divisible by num_kv_heads \(3\)",
+            ),
+            (
+                "zero_cta_tile",
+                _plan_info(cta_tile_q=0),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=2),
+                "CTA q tile size must be positive",
+            ),
+            (
+                "negative_cta_tile",
+                _plan_info(cta_tile_q=-16),
+                dict(batch_size=2, num_qo_heads=16, num_kv_heads=2),
+                "CTA q tile size must be positive",
+            ),
+        )
+        for name, plan_info, kwargs, message in cases:
+            with self.subTest(name=name):
+                with self.assertRaisesRegex(RuntimeError, message):
+                    _narrow_deterministic_cuda_graph_decode_plan(plan_info, **kwargs)
+
+    def test_rejects_attempted_enlargement(self):
+        plan_info = _plan_info(padded_batch_size=1)
+        with self.assertRaisesRegex(RuntimeError, "narrowing would enlarge"):
+            _narrow_deterministic_cuda_graph_decode_plan(
+                plan_info,
+                batch_size=2,
+                num_qo_heads=16,
+                num_kv_heads=2,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

SGLang main pins `flashinfer_python[cu13]==0.6.18`. Deterministic CUDA-graph decode selects FlashInfer's FA2 tensor-core path and disables split-KV.

In that configuration FlashInfer initializes scheduler entries only for real request/query-tile work, but `PrefillPlanInfo[0]` is padded to a split-KV occupancy bound. A no-split plan has no validity mask for that tail. On an H100 with batch size 2, 16 query heads, 2 KV heads, head dimension 128, and page size 1, the pinned planner returns grid-x 132 while only 2 scheduler entries are initialized.

The planner defect is tracked in [flashinfer-ai/flashinfer#4002](https://github.com/flashinfer-ai/flashinfer/issues/4002), with the root fix proposed in [flashinfer-ai/flashinfer#4794](https://github.com/flashinfer-ai/flashinfer/pull/4794). This PR provides a guarded integration fix while SGLang uses the affected release.

## Modifications

- Validate SGLang's pinned 15-field FA2 `PrefillPlanInfo` ABI, CUDA-graph/no-split flags, one query row per request, head divisibility, CTA tile size, and the no-enlargement invariant.
- Replace only `plan_info[0]` with `batch_size * ceil((num_qo_heads / num_kv_heads) / cta_tile_q)`. Fields 1 through 14 and all workspace allocations remain unchanged.
- Preserve FlashInfer's native immutable `tvm_ffi.Array` container.
- Apply the transform after both regular planning and `fast_decode_plan()`, restricted to FA2 tensor-core CUDA-graph decode with `disable_split_kv=True`.
- Add a registered CPU unit test covering MHA, GQA, multi-tile groups, native-container preservation, normal/fast vectors, malformed ABI/flags/dimensions, equal bounds, and attempted enlargement.

Eager decode, split-KV graphs, CUDA-core decode, prefill, extend, verify, FA3, and non-deterministic execution retain their existing paths. Public APIs, wire formats, dependencies, and workspace ownership are unchanged.

## Validation

Final commit: `423596a1c73e17f8128a05735e69ca5a7cc0a20b`, one commit on SGLang main `253020450290328e9deb307eece1e402fa17f35e`. The clean H100 tree hash matched the local final tree exactly: `e7c69f1213a13f5ce19b407ee189feab60032f78`.

| Check | Result |
|---|---|
| Python compile, `git diff --check`, changed-file pre-commit, Ruff import checks, and registered-test registry validation | Pass |
| Pure helper regression cases with native `tvm_ffi.Array` | 10/10 pass |
| FlashInfer 0.6.18 native regular/fast plan matrix: batch sizes 1, 2, 8 × KV lengths 2, 1,024, 8,192 | 18/18 pass; only field 0 changes |
| MHA/GQA scheduler controls | Native plan type preserved; initialized-grid bound retained |
| CUDA graph captured at KV length 2, then fast-replanned and replayed at KV length 8,192 | Both raw grids 132 → 2; fields 1–14 unchanged; replay matches eager controls with max absolute difference 0.0 |
| Eager no-split control | Existing exact grid-x 2 remains unchanged |
| Split-KV CUDA-graph control | Existing grid-x 132 and nonzero validity-mask offset remain unchanged |

GPU environment: NVIDIA H100 80GB HBM3, driver 580.105.08, Python 3.12.3, PyTorch 2.13.0+cu130, CUDA 13.0, FlashInfer 0.6.18, and Apache TVM FFI 0.1.11.

The disposable GPU image did not install every optional SGLang package. The registered pure-helper cases therefore executed the exact final helper source with the real TVM FFI container, while native FlashInfer planning and CUDA-graph replay exercised the affected runtime boundary directly. Full maintainer CI still requires the repository's `run-ci` authorization. No end-to-end throughput claim or timing assertion is made.

## Checklist

- [x] Rebased on current main and reviewed the complete upstream-to-HEAD diff.
- [x] Added a registered regression test and ran changed-file pre-commit.
- [x] Reproduced the affected pinned planner behavior and validated normal, fast, replay, eager, and split-KV controls on the exact final tree.
- [x] Verified one exact author/committer/sign-off identity and no unrelated files or generated artifacts.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33436250833](https://github.com/sgl-project/sglang/actions/runs/33436250833)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33436250835](https://github.com/sgl-project/sglang/actions/runs/33436250835)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33436250946](https://github.com/sgl-project/sglang/actions/runs/33436250946)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->