### PR TITLE
[Bugfix] Load BF16 MTP weights in Qwen3.5/3.8 MXFP4 compressed-tensors checkpoints

### DIFF
--- a/python/sglang/srt/models/qwen3_5_mtp.py
+++ b/python/sglang/srt/models/qwen3_5_mtp.py
@@ -51,14 +51,19 @@ def _mtp_quant_config(quant_config):
     quantized; the loader's fusion gate has to see the same normalization the
     constructor applies, or it would answer for the target's quantization.
     """
-    # Serialized Qwen3.5 ModelOpt checkpoints keep embedded MTP weights in
-    # BF16. Disable quantization for those checkpoints; non-serialized
-    # modelopt_fp4 still converts MoE expert weights on load.
+    # Some quantized Qwen3.5/3.8 checkpoints keep embedded MTP weights in BF16.
+    # Disable quantization for serialized ModelOpt checkpoints and
+    # compressed-tensors exports that explicitly exclude the complete MTP
+    # branch; non-serialized modelopt_fp4 still converts MoE weights on load.
     if quant_config and (
         quant_config.get_name() == "modelopt_mixed"
         or (
             quant_config.get_name() == "modelopt_fp4"
             and quant_config.is_checkpoint_nvfp4_serialized
+        )
+        or (
+            quant_config.get_name() == "compressed_tensors"
+            and "re:^mtp.*" in getattr(quant_config, "ignore", [])
         )
     ):
         return None


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Qwen3.5/3.8 checkpoints may quantize the target model with MXFP4 or NVFP4 while keeping MTP weights in BF16, such as `RadixArk/Qwen3.8-Flash-Next-NVFP4`.

The current Qwen MTP implementation already handles this layout for ModelOpt checkpoints. This PR adds the corresponding condition for compressed-tensors checkpoints: when MTP is excluded with `re:^mtp.*`, MTP quantization is disabled so its BF16 weights can be loaded correctly.

## Modifications

<!-- Detail the changes made in this pull request. -->


## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->