### PR TITLE
[AMD] Add dense NVFP4 support for gfx1201

### DIFF
--- a/docs/docs/advanced_features/quantization.mdx
+++ b/docs/docs/advanced_features/quantization.mdx
@@ -29,7 +29,7 @@ The following table summarizes quantization method support across NVIDIA and AMD
     <tr>
       <th>Method</th>
       <th>NVIDIA GPUs</th>
-      <th>AMD GPUs</th>
+      <th>AMD GPUs (MI300X/MI325X/MI350X)</th>
       <th>Ascend NPUs (A2/A3/A5)</th>
       <th>Notes</th>
     </tr>
@@ -173,7 +173,7 @@ The following table summarizes quantization method support across NVIDIA and AMD
       <td>No</td>
       <td>Yes (MI250/MI300X/MI325X/R9700)</td>
       <td>No</td>
-      <td>Auto-selected when loading dense ModelOpt NVFP4 checkpoints on AMD. MI250/MI300X/MI325X use <a href="https://github.com/causalflow-ai/petit-kernel">Petit</a>; exact <code>gfx1201</code> uses the in-tree HIP/Triton W4A16 backend and does not require Petit. Use <code>modelopt_fp4</code> on NVIDIA Blackwell.</td>
+      <td>Enables dense W4A16 NVFP4 on ROCm; auto-selected when loading ModelOpt NVFP4 checkpoints on AMD. MI250/MI300X/MI325X use <a href="https://github.com/causalflow-ai/petit-kernel">Petit</a>; RDNA4 (<code>gfx1201</code>, Radeon AI PRO R9700) uses the in-tree HIP/Triton backend and does not require Petit. Use <code>modelopt_fp4</code> on NVIDIA Blackwell. See <a href="https://lmsys.org/blog/2025-09-21-petit-amdgpu/">LMSYS blog</a> and <a href="https://rocm.blogs.amd.com/artificial-intelligence/fp4-mixed-precision/README.html">AMD ROCm blog</a>.</td>
     </tr>
     <tr>
       <td><code>bitsandbytes</code></td>

--- a/docs/docs/advanced_features/quantization.mdx
+++ b/docs/docs/advanced_features/quantization.mdx
@@ -29,7 +29,7 @@ The following table summarizes quantization method support across NVIDIA and AMD
     <tr>
       <th>Method</th>
       <th>NVIDIA GPUs</th>
-      <th>AMD GPUs (MI300X/MI325X/MI350X)</th>
+      <th>AMD GPUs</th>
       <th>Ascend NPUs (A2/A3/A5)</th>
       <th>Notes</th>
     </tr>
@@ -171,9 +171,9 @@ The following table summarizes quantization method support across NVIDIA and AMD
     <tr>
       <td><code>petit_nvfp4</code></td>
       <td>No</td>
-      <td>Yes (MI250/MI300X/MI325X)</td>
+      <td>Yes (MI250/MI300X/MI325X/R9700)</td>
       <td>No</td>
-      <td>Enables NVFP4 on ROCm via <a href="https://github.com/causalflow-ai/petit-kernel">Petit</a>; use <code>modelopt_fp4</code> on NVIDIA Blackwell. Auto-selected when loading NVFP4 models on AMD. See <a href="https://lmsys.org/blog/2025-09-21-petit-amdgpu/">LMSYS blog</a> and <a href="https://rocm.blogs.amd.com/artificial-intelligence/fp4-mixed-precision/README.html">AMD ROCm blog</a>.</td>
+      <td>Auto-selected when loading dense ModelOpt NVFP4 checkpoints on AMD. MI250/MI300X/MI325X use <a href="https://github.com/causalflow-ai/petit-kernel">Petit</a>; exact <code>gfx1201</code> uses the in-tree HIP/Triton W4A16 backend and does not require Petit. Use <code>modelopt_fp4</code> on NVIDIA Blackwell.</td>
     </tr>
     <tr>
       <td><code>bitsandbytes</code></td>

--- a/docs/docs/hardware-platforms/amd_gpu.mdx
+++ b/docs/docs/hardware-platforms/amd_gpu.mdx
@@ -117,18 +117,18 @@ With your AMD system properly configured and SGLang installed, you can now fully
 
 ## Quantization on AMD GPUs
 
-The [Quantization documentation](../advanced_features/quantization#platform-compatibility) has a full compatibility matrix. The short version: FP8, AWQ, MXFP4, W8A8, GPTQ, compressed-tensors, Quark, and **petit_nvfp4** all work on supported AMD GPUs. Methods that depend on Marlin or NVIDIA-specific kernels (`awq_marlin`, `gptq_marlin`, `gguf`, `modelopt_fp8`) do not.
+The [Quantization documentation](../advanced_features/quantization#platform-compatibility) has a full compatibility matrix. The short version: FP8, AWQ, MXFP4, W8A8, GPTQ, compressed-tensors, Quark, and **petit_nvfp4** all work on supported AMD GPUs. Methods that depend on Marlin or NVIDIA-specific kernels (`awq_marlin`, `gptq_marlin`, `gguf`, `modelopt_fp8`, `modelopt_fp4`) do not -- a dense NVFP4 checkpoint that would use `modelopt_fp4` on NVIDIA is served by `petit_nvfp4` here instead.
 
 A few things to keep in mind:
 
 - FP8 works via Aiter or Triton. Pre-quantized FP8 models like DeepSeek-V3/R1 work out of the box.
 - AWQ uses Triton dequantization kernels on AMD. The faster Marlin path is not available.
 - MXFP4 requires CDNA3/CDNA4 and `SGLANG_USE_AITER=1`.
-- `petit_nvfp4` enables dense W4A16 NVFP4 models. MI250/MI300X use [Petit](https://github.com/causalflow-ai/petit-kernel) and require `pip install petit-kernel`. The Radeon AI PRO R9700 (`gfx1201`) uses an in-tree HIP decode and Triton prefill backend, so it does not require Petit. Pre-quantized ModelOpt NVFP4 checkpoints are detected automatically; do not add `--quantization`.
+- `petit_nvfp4` enables dense W4A16 NVFP4 models (e.g., [Llama 3.3 70B FP4](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP4)). MI250/MI300X use [Petit](https://github.com/causalflow-ai/petit-kernel) and require `pip install petit-kernel`. The Radeon AI PRO R9700 (`gfx1201`) uses an in-tree HIP decode and Triton prefill backend, so it does not require Petit. Pre-quantized ModelOpt NVFP4 checkpoints are detected automatically; do not add `--quantization`. MoE checkpoints are not supported on either path.
 - `quark_int4fp8_moe` is an AMD-only online quantization method for MoE models on CDNA3/CDNA4.
 
 <Note>
-On `gfx1201`, the first use of an NVFP4 prefill tile and activation dtype compiles its Triton kernel. Keep the Triton disk cache between server runs and warm up decode and prefill before measuring latency.
+On `gfx1201`, the HIP decode kernel and each NVFP4 Triton prefill tile compile on first use. Loading a quantized layer forces those compiles, so CUDA graph capture is safe, but the compile still costs wall time on a cold cache. Keep the Triton disk cache between server runs, and warm up before measuring latency.
 </Note>
 
 Several of these backends are accelerated by [Aiter](https://github.com/ROCm/aiter). Enable it with:

--- a/docs/docs/hardware-platforms/amd_gpu.mdx
+++ b/docs/docs/hardware-platforms/amd_gpu.mdx
@@ -117,15 +117,19 @@ With your AMD system properly configured and SGLang installed, you can now fully
 
 ## Quantization on AMD GPUs
 
-The [Quantization documentation](../advanced_features/quantization#platform-compatibility) has a full compatibility matrix. The short version: FP8, AWQ, MXFP4, W8A8, GPTQ, compressed-tensors, Quark, and **petit_nvfp4** (NVFP4 on ROCm via [Petit](https://github.com/causalflow-ai/petit-kernel)) all work on AMD. Methods that depend on Marlin or NVIDIA-specific kernels (`awq_marlin`, `gptq_marlin`, `gguf`, `modelopt_fp8`, `modelopt_fp4`) do not.
+The [Quantization documentation](../advanced_features/quantization#platform-compatibility) has a full compatibility matrix. The short version: FP8, AWQ, MXFP4, W8A8, GPTQ, compressed-tensors, Quark, and **petit_nvfp4** all work on supported AMD GPUs. Methods that depend on Marlin or NVIDIA-specific kernels (`awq_marlin`, `gptq_marlin`, `gguf`, `modelopt_fp8`) do not.
 
 A few things to keep in mind:
 
 - FP8 works via Aiter or Triton. Pre-quantized FP8 models like DeepSeek-V3/R1 work out of the box.
 - AWQ uses Triton dequantization kernels on AMD. The faster Marlin path is not available.
 - MXFP4 requires CDNA3/CDNA4 and `SGLANG_USE_AITER=1`.
-- `petit_nvfp4` enables NVFP4 models (e.g., [Llama 3.3 70B FP4](https://huggingface.co/nvidia/Llama-3.3-70B-Instruct-FP4)) on MI250/MI300X via [Petit](https://github.com/causalflow-ai/petit-kernel). Install with `pip install petit-kernel`; no `--quantization` flag needed when loading pre-quantized NVFP4 models.
+- `petit_nvfp4` enables dense W4A16 NVFP4 models. MI250/MI300X use [Petit](https://github.com/causalflow-ai/petit-kernel) and require `pip install petit-kernel`. The Radeon AI PRO R9700 (`gfx1201`) uses an in-tree HIP decode and Triton prefill backend, so it does not require Petit. Pre-quantized ModelOpt NVFP4 checkpoints are detected automatically; do not add `--quantization`.
 - `quark_int4fp8_moe` is an AMD-only online quantization method for MoE models on CDNA3/CDNA4.
+
+<Note>
+On `gfx1201`, the first use of an NVFP4 prefill tile and activation dtype compiles its Triton kernel. Keep the Triton disk cache between server runs and warm up decode and prefill before measuring latency.
+</Note>
 
 Several of these backends are accelerated by [Aiter](https://github.com/ROCm/aiter). Enable it with:
 

--- a/python/sglang/kernels/jit/csrc/gemm/rdna4_nvfp4.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/rdna4_nvfp4.cuh
@@ -1,0 +1,183 @@
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <sgl_kernel/tensor.h>
+#include <sgl_kernel/utils.h>
+
+#include <sgl_kernel/type.cuh>
+#include <sgl_kernel/utils.cuh>
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+
+namespace sglang {
+
+namespace device {
+namespace rdna4_nvfp4 {
+
+constexpr int kBlockThreads = 256;
+constexpr int kNvfp4BlockSize = 16;
+
+SGL_DEVICE inline float decode_e2m1(uint8_t bits) {
+  const uint8_t magnitude = bits & 0x7;
+  float value;
+  switch (magnitude) {
+    case 0:
+      value = 0.0f;
+      break;
+    case 1:
+      value = 0.5f;
+      break;
+    case 2:
+      value = 1.0f;
+      break;
+    case 3:
+      value = 1.5f;
+      break;
+    case 4:
+      value = 2.0f;
+      break;
+    case 5:
+      value = 3.0f;
+      break;
+    case 6:
+      value = 4.0f;
+      break;
+    default:
+      value = 6.0f;
+      break;
+  }
+  return (bits & 0x8) != 0 ? -value : value;
+}
+
+SGL_DEVICE inline float decode_e4m3fn(uint8_t bits) {
+  const uint8_t sign = bits >> 7;
+  const uint8_t exponent = (bits >> 3) & 0xf;
+  const uint8_t mantissa = bits & 0x7;
+
+  float value;
+  if (exponent == 0) {
+    value = static_cast<float>(mantissa) * 0x1p-9f;
+  } else if (exponent == 0xf && mantissa == 0x7) {
+    value = nanf("");
+  } else {
+    value = ldexpf(1.0f + static_cast<float>(mantissa) * 0.125f, exponent - 7);
+  }
+  return sign != 0 ? -value : value;
+}
+
+template <typename DType>
+__global__ void linear_kernel(
+    const DType* input,
+    const uint8_t* weight,
+    const uint8_t* weight_scale,
+    const float* weight_global_scale,
+    DType* output,
+    int64_t size_m,
+    int64_t size_n,
+    int64_t size_k) {
+#if defined(__HIP_DEVICE_COMPILE__) && !defined(__gfx1201__)
+#error "The RDNA4 NVFP4 kernel must only be compiled for gfx1201."
+#endif
+  __shared__ float partial[kBlockThreads];
+
+  const int64_t output_index = static_cast<int64_t>(blockIdx.x);
+  const int64_t output_row = output_index / size_n;
+  const int64_t output_col = output_index - output_row * size_n;
+  const int64_t packed_k = size_k / 2;
+
+  float accumulator = 0.0f;
+  for (int64_t packed_index = threadIdx.x; packed_index < packed_k; packed_index += blockDim.x) {
+    const uint8_t packed_weight = weight[output_col * packed_k + packed_index];
+    const int64_t input_index = packed_index * 2;
+    const float scale =
+        decode_e4m3fn(weight_scale[output_col * (size_k / kNvfp4BlockSize) + input_index / kNvfp4BlockSize]);
+    const float input_low = device::cast<float>(input[output_row * size_k + input_index]);
+    const float input_high = device::cast<float>(input[output_row * size_k + input_index + 1]);
+    accumulator +=
+        (input_low * decode_e2m1(packed_weight & 0xf) + input_high * decode_e2m1(packed_weight >> 4)) * scale;
+  }
+
+  partial[threadIdx.x] = accumulator;
+  __syncthreads();
+  for (int offset = kBlockThreads / 2; offset > 0; offset /= 2) {
+    if (threadIdx.x < offset) {
+      partial[threadIdx.x] += partial[threadIdx.x + offset];
+    }
+    __syncthreads();
+  }
+
+  if (threadIdx.x == 0) {
+    output[output_index] = device::cast<DType>(partial[0] * weight_global_scale[0]);
+  }
+}
+
+}  // namespace rdna4_nvfp4
+}  // namespace device
+
+template <typename DType>
+struct Rdna4Nvfp4LinearKernel {
+  static void
+  run(tvm::ffi::TensorView input,
+      tvm::ffi::TensorView weight,
+      tvm::ffi::TensorView weight_scale,
+      tvm::ffi::TensorView weight_global_scale,
+      tvm::ffi::TensorView output) {
+    using namespace host;
+
+    SymbolicSize size_m{"M"};
+    SymbolicSize size_n{"N"};
+    SymbolicSize size_k{"K"};
+    SymbolicSize packed_k{"packed K"};
+    SymbolicSize scale_k{"scale K"};
+    SymbolicDevice gpu_device;
+    gpu_device.set_options<kDLROCM>();
+
+    TensorMatcher({size_m, size_k}).with_dtype<DType>().with_device(gpu_device).verify(input);
+    TensorMatcher({size_n, packed_k}).with_dtype<uint8_t>().with_device(gpu_device).verify(weight);
+    TensorMatcher({size_n, scale_k}).with_device(gpu_device).verify(weight_scale);
+    TensorMatcher({1}).with_dtype<float>().with_device(gpu_device).verify(weight_global_scale);
+    TensorMatcher({size_m, size_n}).with_dtype<DType>().with_device(gpu_device).verify(output);
+
+    RuntimeCheck(size_m.unwrap() == 1, "The HIP decode kernel requires M=1");
+    RuntimeCheck(size_n.unwrap() > 0, "N must be positive");
+    RuntimeCheck(
+        size_k.unwrap() > 0 && size_k.unwrap() % device::rdna4_nvfp4::kNvfp4BlockSize == 0,
+        "K must be positive and divisible by 16");
+    RuntimeCheck(packed_k.unwrap() * 2 == size_k.unwrap(), "packed weight K must equal K/2");
+    RuntimeCheck(
+        scale_k.unwrap() * device::rdna4_nvfp4::kNvfp4BlockSize == size_k.unwrap(), "weight scale K must equal K/16");
+    RuntimeCheck(
+        weight_scale.dtype().code == DLDataTypeCode::kDLFloat8_e4m3fn && weight_scale.dtype().bits == 8 &&
+            weight_scale.dtype().lanes == 1,
+        "weight_scale must be float8_e4m3fn");
+
+    const int64_t output_count = size_m.unwrap() * size_n.unwrap();
+    RuntimeCheck(output_count <= std::numeric_limits<uint32_t>::max(), "M*N exceeds the supported launch range");
+
+    const auto* input_ptr = static_cast<const DType*>(input.data_ptr());
+    const auto* weight_ptr = static_cast<const uint8_t*>(weight.data_ptr());
+    const auto* weight_scale_ptr = static_cast<const uint8_t*>(weight_scale.data_ptr());
+    const auto* global_scale_ptr = static_cast<const float*>(weight_global_scale.data_ptr());
+    auto* output_ptr = static_cast<DType*>(output.data_ptr());
+
+    LaunchKernel(static_cast<uint32_t>(output_count), device::rdna4_nvfp4::kBlockThreads, gpu_device.unwrap())(
+        device::rdna4_nvfp4::linear_kernel<DType>,
+        input_ptr,
+        weight_ptr,
+        weight_scale_ptr,
+        global_scale_ptr,
+        output_ptr,
+        size_m.unwrap(),
+        size_n.unwrap(),
+        size_k.unwrap());
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/gemm/rdna4_nvfp4.cuh
+++ b/python/sglang/kernels/jit/csrc/gemm/rdna4_nvfp4.cuh
@@ -24,6 +24,7 @@ namespace rdna4_nvfp4 {
 constexpr int kBlockThreads = 256;
 constexpr int kNvfp4BlockSize = 16;
 
+/// \brief Decode one packed E2M1 (FP4) nibble to fp32.
 SGL_DEVICE inline float decode_e2m1(uint8_t bits) {
   const uint8_t magnitude = bits & 0x7;
   float value;
@@ -56,6 +57,7 @@ SGL_DEVICE inline float decode_e2m1(uint8_t bits) {
   return (bits & 0x8) != 0 ? -value : value;
 }
 
+/// \brief Decode one E4M3FN (OCP FP8) byte to fp32.
 SGL_DEVICE inline float decode_e4m3fn(uint8_t bits) {
   const uint8_t sign = bits >> 7;
   const uint8_t exponent = (bits >> 3) & 0xf;
@@ -72,13 +74,15 @@ SGL_DEVICE inline float decode_e4m3fn(uint8_t bits) {
   return sign != 0 ? -value : value;
 }
 
+/// \brief W4A16 GEMV: one block reduces one output element over K.
+/// \tparam DType The activation and output type (bf16_t or fp16_t).
 template <typename DType>
 __global__ void linear_kernel(
-    const DType* input,
-    const uint8_t* weight,
-    const uint8_t* weight_scale,
-    const float* weight_global_scale,
-    DType* output,
+    const DType* __restrict__ input,
+    const uint8_t* __restrict__ weight,
+    const uint8_t* __restrict__ weight_scale,
+    const float* __restrict__ weight_global_scale,
+    DType* __restrict__ output,
     int64_t size_m,
     int64_t size_n,
     int64_t size_k) {
@@ -121,8 +125,21 @@ __global__ void linear_kernel(
 }  // namespace rdna4_nvfp4
 }  // namespace device
 
+/// \brief Host launcher for the gfx1201 NVFP4 decode GEMV.
+///
+/// Consumes the canonical ModelOpt checkpoint layout with no repacking:
+/// packed E2M1 weights of shape [N, K/2] and E4M3FN block scales of shape
+/// [N, K/16], scaled by one fp32 global scale.
+///
+/// \tparam DType The activation and output type (bf16_t or fp16_t).
 template <typename DType>
 struct Rdna4Nvfp4LinearKernel {
+  /// \brief Launch the kernel; every argument is verified before launch.
+  /// \param input Activations, [M, K] with M == 1.
+  /// \param weight Packed E2M1 weights, [N, K/2] uint8.
+  /// \param weight_scale Block scales, [N, K/16] float8_e4m3fn.
+  /// \param weight_global_scale One fp32 scalar.
+  /// \param output Destination, [M, N].
   static void
   run(tvm::ffi::TensorView input,
       tvm::ffi::TensorView weight,
@@ -137,7 +154,7 @@ struct Rdna4Nvfp4LinearKernel {
     SymbolicSize packed_k{"packed K"};
     SymbolicSize scale_k{"scale K"};
     SymbolicDevice gpu_device;
-    gpu_device.set_options<kDLROCM>();
+    gpu_device.set_options<kDLGPU>();
 
     TensorMatcher({size_m, size_k}).with_dtype<DType>().with_device(gpu_device).verify(input);
     TensorMatcher({size_n, packed_k}).with_dtype<uint8_t>().with_device(gpu_device).verify(weight);
@@ -145,21 +162,24 @@ struct Rdna4Nvfp4LinearKernel {
     TensorMatcher({1}).with_dtype<float>().with_device(gpu_device).verify(weight_global_scale);
     TensorMatcher({size_m, size_n}).with_dtype<DType>().with_device(gpu_device).verify(output);
 
-    RuntimeCheck(size_m.unwrap() == 1, "The HIP decode kernel requires M=1");
-    RuntimeCheck(size_n.unwrap() > 0, "N must be positive");
-    RuntimeCheck(
-        size_k.unwrap() > 0 && size_k.unwrap() % device::rdna4_nvfp4::kNvfp4BlockSize == 0,
-        "K must be positive and divisible by 16");
-    RuntimeCheck(packed_k.unwrap() * 2 == size_k.unwrap(), "packed weight K must equal K/2");
-    RuntimeCheck(
-        scale_k.unwrap() * device::rdna4_nvfp4::kNvfp4BlockSize == size_k.unwrap(), "weight scale K must equal K/16");
-    RuntimeCheck(
+    CHECK_HOST(size_m.unwrap() == 1) << "rdna4_nvfp4: the HIP decode kernel requires M=1, got " << size_m.unwrap();
+    CHECK_HOST(size_n.unwrap() > 0) << "rdna4_nvfp4: N must be positive";
+    CHECK_HOST(size_k.unwrap() > 0 && size_k.unwrap() % device::rdna4_nvfp4::kNvfp4BlockSize == 0)
+        << "rdna4_nvfp4: K must be positive and divisible by " << device::rdna4_nvfp4::kNvfp4BlockSize << ", got "
+        << size_k.unwrap();
+    CHECK_HOST(packed_k.unwrap() * 2 == size_k.unwrap())
+        << "rdna4_nvfp4: packed weight K must equal K/2, got " << packed_k.unwrap() << " for K=" << size_k.unwrap();
+    CHECK_HOST(scale_k.unwrap() * device::rdna4_nvfp4::kNvfp4BlockSize == size_k.unwrap())
+        << "rdna4_nvfp4: weight scale K must equal K/" << device::rdna4_nvfp4::kNvfp4BlockSize << ", got "
+        << scale_k.unwrap() << " for K=" << size_k.unwrap();
+    CHECK_HOST(
         weight_scale.dtype().code == DLDataTypeCode::kDLFloat8_e4m3fn && weight_scale.dtype().bits == 8 &&
-            weight_scale.dtype().lanes == 1,
-        "weight_scale must be float8_e4m3fn");
+        weight_scale.dtype().lanes == 1)
+        << "rdna4_nvfp4: weight_scale must be float8_e4m3fn";
 
     const int64_t output_count = size_m.unwrap() * size_n.unwrap();
-    RuntimeCheck(output_count <= std::numeric_limits<uint32_t>::max(), "M*N exceeds the supported launch range");
+    CHECK_HOST(output_count <= std::numeric_limits<uint32_t>::max())
+        << "rdna4_nvfp4: M*N exceeds the supported launch range, got " << output_count;
 
     const auto* input_ptr = static_cast<const DType*>(input.data_ptr());
     const auto* weight_ptr = static_cast<const uint8_t*>(weight.data_ptr());

--- a/python/sglang/kernels/ops/gemm/rdna4_nvfp4.py
+++ b/python/sglang/kernels/ops/gemm/rdna4_nvfp4.py
@@ -1,47 +1,38 @@
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 import torch
 
 from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.srt.utils import is_gfx1201_supported
 
 if TYPE_CHECKING:
     from tvm_ffi.module import Module
 
-_SUPPORTED_GCN_ARCH = "gfx1201"
+logger = logging.getLogger(__name__)
+
 _SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
-
-
-def normalize_gcn_arch_name(arch_name: str) -> str:
-    """Remove optional feature suffixes from a ROCm GCN architecture name."""
-    return arch_name.split(":", 1)[0].lower()
 
 
 def is_rdna4_nvfp4_device(device: torch.device | int | None = None) -> bool:
     """Return whether device is the exact ROCm target supported by this kernel."""
-    if torch.version.hip is None or not torch.cuda.is_available():
-        return False
-
     if device is None:
-        device_index = torch.cuda.current_device()
-    else:
-        resolved_device = torch.device(device)
-        if resolved_device.type != "cuda":
-            return False
-        device_index = (
-            torch.cuda.current_device()
-            if resolved_device.index is None
-            else resolved_device.index
-        )
+        return is_gfx1201_supported()
 
-    properties = torch.cuda.get_device_properties(device_index)
-    arch_name = getattr(properties, "gcnArchName", "")
-    return normalize_gcn_arch_name(arch_name) == _SUPPORTED_GCN_ARCH
+    resolved_device = torch.device(device)
+    if resolved_device.type != "cuda":
+        return False
+    return is_gfx1201_supported(resolved_device.index)
 
 
 @cache_once
 def _jit_rdna4_nvfp4_module(dtype: torch.dtype) -> Module:
+    if dtype not in _SUPPORTED_DTYPES:
+        raise TypeError(
+            f"RDNA4 NVFP4 supports BF16 and FP16 activations, but received {dtype}."
+        )
     args = make_cpp_args(dtype)
     return load_jit(
         "rdna4_nvfp4",
@@ -54,6 +45,61 @@ def _jit_rdna4_nvfp4_module(dtype: torch.dtype) -> Module:
     )
 
 
+@cache_once
+def warmup_rdna4_nvfp4(
+    dtype: torch.dtype, device: torch.device, size_n: int, size_k: int
+) -> None:
+    """Compile every specialisation of one layer shape before graph capture.
+
+    Both back ends compile on first use -- the HIP module through hipcc, the
+    Triton prefill kernel once per tile shape and per Triton argument
+    specialisation. Neither is capturable, so a server that captures CUDA
+    graphs before its first real forward would compile inside the capture.
+    Loading a layer is the last point where a plain launch is still safe.
+
+    N and K are the layer's own so the Triton argument specialisations match
+    what the layer will really launch; in practice every 16-divisible N and K
+    collapses onto one specialisation, which makes every shape after the first
+    almost free. The M sweep covers the remaining axes: M=1 is the HIP kernel,
+    and the four Triton combinations are the two tile shapes (split at M=128)
+    times Triton's `M == 1` / `M % 16` argument specialisations.
+
+    Measured on an R9700: about 26 s for the first shape on a cold Triton
+    cache, about 2 s warm, and about 10 ms for every shape after it.
+    """
+    weight = torch.zeros((size_n, size_k // 2), dtype=torch.uint8, device=device)
+    weight_scale = torch.zeros(
+        (size_n, size_k // 16), dtype=torch.float8_e4m3fn, device=device
+    )
+    global_scale = torch.ones(1, dtype=torch.float32, device=device)
+    for size_m in (1, 2, 16, 128, 129):
+        rdna4_nvfp4_linear(
+            torch.zeros((size_m, size_k), dtype=dtype, device=device),
+            weight,
+            weight_scale,
+            global_scale,
+        )
+    torch.cuda.synchronize(device)
+
+
+def try_warmup_rdna4_nvfp4(
+    dtype: torch.dtype, device: torch.device, size_n: int, size_k: int
+) -> None:
+    """Warm up if we can; a failure only costs a later compile, never the load."""
+    try:
+        warmup_rdna4_nvfp4(dtype, device, size_n, size_k)
+    except Exception as error:  # noqa: BLE001 - warmup is best effort
+        logger.warning(
+            "RDNA4 NVFP4 warmup failed for N=%d K=%d (%s): %s. The kernels will "
+            "compile on first use instead, which is not safe inside a CUDA graph "
+            "capture.",
+            size_n,
+            size_k,
+            dtype,
+            error,
+        )
+
+
 def rdna4_nvfp4_linear(
     input: torch.Tensor,
     weight: torch.Tensor,
@@ -61,6 +107,9 @@ def rdna4_nvfp4_linear(
     weight_global_scale: torch.Tensor,
 ) -> torch.Tensor:
     """Apply a canonical packed ModelOpt NVFP4 linear layer on gfx1201."""
+    # The HIP launcher re-verifies shapes and dtypes through TensorMatcher, but
+    # the Triton prefill path has no such launcher, so the contract is checked
+    # here for both. Every check below is a cached bool or an integer compare.
     if not is_rdna4_nvfp4_device(input.device):
         raise RuntimeError(
             "The RDNA4 NVFP4 JIT backend requires an exact gfx1201 ROCm device."
@@ -98,17 +147,19 @@ def rdna4_nvfp4_linear(
             f"{tuple(weight_scale.shape)} for N={n}, K={k}."
         )
 
-    tensors = (input, weight, weight_scale, weight_global_scale)
-    if any(t.device != input.device for t in tensors):
+    device = input.device
+    if (
+        weight.device != device
+        or weight_scale.device != device
+        or weight_global_scale.device != device
+    ):
         raise ValueError("All RDNA4 NVFP4 tensors must be on the same device.")
 
     reshaped_input = input.reshape(-1, k).contiguous()
     packed_weight = weight.contiguous()
     block_scale = weight_scale.contiguous()
     global_scale = weight_global_scale.reshape(1).contiguous()
-    output = torch.empty(
-        (reshaped_input.shape[0], n), dtype=input.dtype, device=input.device
-    )
+    output = torch.empty((reshaped_input.shape[0], n), dtype=input.dtype, device=device)
 
     if reshaped_input.shape[0] == 1:
         module = _jit_rdna4_nvfp4_module(input.dtype)

--- a/python/sglang/kernels/ops/gemm/rdna4_nvfp4.py
+++ b/python/sglang/kernels/ops/gemm/rdna4_nvfp4.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+_SUPPORTED_GCN_ARCH = "gfx1201"
+_SUPPORTED_DTYPES = (torch.bfloat16, torch.float16)
+
+
+def normalize_gcn_arch_name(arch_name: str) -> str:
+    """Remove optional feature suffixes from a ROCm GCN architecture name."""
+    return arch_name.split(":", 1)[0].lower()
+
+
+def is_rdna4_nvfp4_device(device: torch.device | int | None = None) -> bool:
+    """Return whether device is the exact ROCm target supported by this kernel."""
+    if torch.version.hip is None or not torch.cuda.is_available():
+        return False
+
+    if device is None:
+        device_index = torch.cuda.current_device()
+    else:
+        resolved_device = torch.device(device)
+        if resolved_device.type != "cuda":
+            return False
+        device_index = (
+            torch.cuda.current_device()
+            if resolved_device.index is None
+            else resolved_device.index
+        )
+
+    properties = torch.cuda.get_device_properties(device_index)
+    arch_name = getattr(properties, "gcnArchName", "")
+    return normalize_gcn_arch_name(arch_name) == _SUPPORTED_GCN_ARCH
+
+
+@cache_once
+def _jit_rdna4_nvfp4_module(dtype: torch.dtype) -> Module:
+    args = make_cpp_args(dtype)
+    return load_jit(
+        "rdna4_nvfp4",
+        *args,
+        cuda_files=["gemm/rdna4_nvfp4.cuh"],
+        cuda_wrappers=[
+            ("run", f"sglang::Rdna4Nvfp4LinearKernel<{args}>::run"),
+        ],
+        extra_cuda_cflags=["-O3"],
+    )
+
+
+def rdna4_nvfp4_linear(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_global_scale: torch.Tensor,
+) -> torch.Tensor:
+    """Apply a canonical packed ModelOpt NVFP4 linear layer on gfx1201."""
+    if not is_rdna4_nvfp4_device(input.device):
+        raise RuntimeError(
+            "The RDNA4 NVFP4 JIT backend requires an exact gfx1201 ROCm device."
+        )
+    if input.dtype not in _SUPPORTED_DTYPES:
+        raise TypeError(
+            "RDNA4 NVFP4 supports BF16 and FP16 activations, "
+            f"but received {input.dtype}."
+        )
+    if input.ndim < 1 or input.shape[-1] == 0:
+        raise ValueError("RDNA4 NVFP4 input must have a non-empty K dimension.")
+    if input.numel() == 0:
+        raise ValueError("RDNA4 NVFP4 input must contain at least one row.")
+    if weight.ndim != 2 or weight.dtype != torch.uint8:
+        raise TypeError("RDNA4 NVFP4 weight must be a 2D uint8 packed tensor.")
+    if weight.shape[0] == 0:
+        raise ValueError("RDNA4 NVFP4 weight must contain at least one output row.")
+    if weight_scale.ndim != 2 or weight_scale.dtype != torch.float8_e4m3fn:
+        raise TypeError("RDNA4 NVFP4 weight_scale must be a 2D float8_e4m3fn tensor.")
+    if weight_global_scale.numel() != 1 or weight_global_scale.dtype != torch.float32:
+        raise TypeError("RDNA4 NVFP4 global weight scale must be one float32 value.")
+
+    k = input.shape[-1]
+    n = weight.shape[0]
+    if k % 16 != 0:
+        raise ValueError(f"RDNA4 NVFP4 requires K divisible by 16, but got K={k}.")
+    if weight.shape[1] * 2 != k:
+        raise ValueError(
+            "Packed RDNA4 NVFP4 weight shape does not match input K: "
+            f"weight={tuple(weight.shape)}, K={k}."
+        )
+    if tuple(weight_scale.shape) != (n, k // 16):
+        raise ValueError(
+            "RDNA4 NVFP4 scale shape must be [N, K/16], but got "
+            f"{tuple(weight_scale.shape)} for N={n}, K={k}."
+        )
+
+    tensors = (input, weight, weight_scale, weight_global_scale)
+    if any(t.device != input.device for t in tensors):
+        raise ValueError("All RDNA4 NVFP4 tensors must be on the same device.")
+
+    reshaped_input = input.reshape(-1, k).contiguous()
+    packed_weight = weight.contiguous()
+    block_scale = weight_scale.contiguous()
+    global_scale = weight_global_scale.reshape(1).contiguous()
+    output = torch.empty(
+        (reshaped_input.shape[0], n), dtype=input.dtype, device=input.device
+    )
+
+    if reshaped_input.shape[0] == 1:
+        module = _jit_rdna4_nvfp4_module(input.dtype)
+        module.run(
+            reshaped_input,
+            packed_weight,
+            block_scale,
+            global_scale,
+            output,
+        )
+    else:
+        from sglang.kernels.ops.gemm.rdna4_nvfp4_triton import (
+            rdna4_nvfp4_prefill,
+        )
+
+        rdna4_nvfp4_prefill(
+            reshaped_input,
+            packed_weight,
+            block_scale,
+            global_scale,
+            output,
+        )
+    return output.reshape(input.shape[:-1] + (n,))

--- a/python/sglang/kernels/ops/gemm/rdna4_nvfp4_triton.py
+++ b/python/sglang/kernels/ops/gemm/rdna4_nvfp4_triton.py
@@ -38,8 +38,10 @@ def _rdna4_nvfp4_prefill_kernel(
 ):
     pid_m = tl.program_id(0)
     pid_n = tl.program_id(1)
-    offsets_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offsets_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    # int64 row/column offsets: `offsets_m * size_n` reaches past 2**31 for a
+    # large prefill chunk against a wide projection, and int32 would wrap.
+    offsets_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offsets_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
     offsets_k = tl.arange(0, BLOCK_K)
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 

--- a/python/sglang/kernels/ops/gemm/rdna4_nvfp4_triton.py
+++ b/python/sglang/kernels/ops/gemm/rdna4_nvfp4_triton.py
@@ -1,0 +1,108 @@
+"""Triton prefill GEMM for canonical ModelOpt NVFP4 weights on RDNA4."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _decode_e2m1(bits):
+    magnitude = bits & 0x7
+    value = tl.where(
+        magnitude <= 4,
+        magnitude.to(tl.float32) * 0.5,
+        tl.where(
+            magnitude == 5,
+            3.0,
+            tl.where(magnitude == 6, 4.0, 6.0),
+        ),
+    )
+    return tl.where((bits & 0x8) != 0, -value, value)
+
+
+@triton.jit
+def _rdna4_nvfp4_prefill_kernel(
+    input_ptr,
+    weight_ptr,
+    weight_scale_ptr,
+    weight_global_scale_ptr,
+    output_ptr,
+    size_m,
+    size_n,
+    size_k,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    offsets_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offsets_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offsets_k = tl.arange(0, BLOCK_K)
+    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k_tile in range(0, tl.cdiv(size_k, BLOCK_K)):
+        k = k_tile * BLOCK_K + offsets_k
+        activation = tl.load(
+            input_ptr + offsets_m[:, None] * size_k + k[None, :],
+            mask=(offsets_m[:, None] < size_m) & (k[None, :] < size_k),
+            other=0.0,
+        )
+        packed_weight = tl.load(
+            weight_ptr + offsets_n[None, :] * (size_k // 2) + (k[:, None] // 2),
+            mask=(offsets_n[None, :] < size_n) & (k[:, None] < size_k),
+            other=0,
+        )
+        nibble = tl.where(
+            (k[:, None] & 1) == 0,
+            packed_weight & 0xF,
+            packed_weight >> 4,
+        )
+        block_scale = tl.load(
+            weight_scale_ptr + offsets_n[None, :] * (size_k // 16) + (k[:, None] // 16),
+            mask=(offsets_n[None, :] < size_n) & (k[:, None] < size_k),
+            other=0.0,
+        )
+        weight = (_decode_e2m1(nibble) * block_scale).to(activation.dtype)
+        accumulator = tl.dot(activation, weight, accumulator)
+
+    output = accumulator * tl.load(weight_global_scale_ptr)
+    tl.store(
+        output_ptr + offsets_m[:, None] * size_n + offsets_n[None, :],
+        output,
+        mask=(offsets_m[:, None] < size_m) & (offsets_n[None, :] < size_n),
+    )
+
+
+def rdna4_nvfp4_prefill(
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    weight_scale: torch.Tensor,
+    weight_global_scale: torch.Tensor,
+    output: torch.Tensor,
+) -> None:
+    """Launch a matrix-instruction prefill kernel for validated tensors."""
+    size_m, size_k = input.shape
+    size_n = weight.shape[0]
+    if size_m >= 128:
+        block_m, block_n, num_warps = 128, 64, 4
+    else:
+        block_m, block_n, num_warps = 64, 32, 4
+    block_k = 32
+    grid = (triton.cdiv(size_m, block_m), triton.cdiv(size_n, block_n))
+    _rdna4_nvfp4_prefill_kernel[grid](
+        input,
+        weight,
+        weight_scale,
+        weight_global_scale,
+        output,
+        size_m,
+        size_n,
+        size_k,
+        BLOCK_M=block_m,
+        BLOCK_N=block_n,
+        BLOCK_K=block_k,
+        num_warps=num_warps,
+    )

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -200,6 +200,17 @@ class QuantizationConfig(ABC):
         # Check if this is a ModelOpt config
         quant_algo = hf_quant_config.get("quant_algo", "").upper()
 
+        if quant_algo == "NVFP4":
+            if user_quant == "petit_nvfp4":
+                return user_quant
+
+            if torch.version.hip is not None and user_quant in (
+                None,
+                "modelopt",
+                "modelopt_fp4",
+            ):
+                return "petit_nvfp4"
+
         # If user specified generic "modelopt", auto-detect the specific method
         if user_quant == "modelopt":
             canonical_method = canonicalize_modelopt_quant_algo(quant_algo)

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -200,16 +200,13 @@ class QuantizationConfig(ABC):
         # Check if this is a ModelOpt config
         quant_algo = hf_quant_config.get("quant_algo", "").upper()
 
-        if quant_algo == "NVFP4":
-            if user_quant == "petit_nvfp4":
-                return user_quant
-
-            if torch.version.hip is not None and user_quant in (
-                None,
-                "modelopt",
-                "modelopt_fp4",
-            ):
-                return "petit_nvfp4"
+        # ROCm has no modelopt_fp4 kernels, so the ModelOpt configs decline a
+        # dense NVFP4 checkpoint there and let PetitNvFp4Config -- which sits
+        # later in QUANTIZATION_METHODS -- claim it. Only the exact "NVFP4"
+        # algorithm is declined; the AWQ/W4A16 variants Petit cannot serve keep
+        # resolving to modelopt_fp4 and its explicit "unsupported on ROCm" error.
+        if quant_algo == "NVFP4" and torch.version.hip is not None:
+            return None
 
         # If user specified generic "modelopt", auto-detect the specific method
         if user_quant == "modelopt":

--- a/python/sglang/srt/layers/quantization/petit.py
+++ b/python/sglang/srt/layers/quantization/petit.py
@@ -72,6 +72,11 @@ class PetitNvFp4Config(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "PetitNvFp4Config":
+        # Two checkpoint shapes reach here: hf_quant_config.json nests the
+        # metadata under "quantization", while a config.json
+        # "quantization_config" block is already flat. The alternative key
+        # spellings below mirror the ModelOpt parsing in
+        # ModelConfig._parse_modelopt_quant_config.
         quant_config = config.get("quantization", config)
         quant_method = quant_config["quant_algo"]
         group_size = quant_config.get("group_size", None)
@@ -124,8 +129,18 @@ class PetitNvFp4Config(QuantizationConfig):
 
     @classmethod
     def is_petit_nvfp4_compatible(cls, quant_config: Dict[str, Any]) -> bool:
+        if not _is_hip:
+            return False
         quant_method = quant_config.get("quant_method", "").lower()
-        return _is_hip and quant_method == "modelopt"
+        if quant_method == "modelopt":
+            return True
+        # Newer ModelOpt exports name the method after the format instead of the
+        # producer. Those reach ROCm as "modelopt_fp4"; the dense NVFP4 ones are
+        # served here because modelopt_fp4 has no ROCm kernels.
+        return (
+            quant_method == "modelopt_fp4"
+            and (quant_config.get("quant_algo", "") or "").upper() == "NVFP4"
+        )
 
     def is_layer_excluded(self, prefix: str, exclude_modules: list):
         for pattern in exclude_modules:
@@ -137,12 +152,27 @@ class PetitNvFp4Config(QuantizationConfig):
     def get_quant_method(
         self, layer: torch.nn.Module, prefix: str
     ) -> Optional["QuantizeMethodBase"]:
+        from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
+
         if isinstance(layer, LinearBase):
             if is_layer_skipped(prefix, self.exclude_modules) or self.is_layer_excluded(
                 prefix, self.exclude_modules
             ):
                 return UnquantizedLinearMethod()
             return PetitNvFp4LinearMethod(self)
+        if isinstance(layer, FusedMoE) and not (
+            is_layer_skipped(prefix, self.exclude_modules)
+            or self.is_layer_excluded(prefix, self.exclude_modules)
+        ):
+            # Returning None here would hand the packed FP4 experts to the
+            # unquantized MoE method, which fails much later with an opaque
+            # shape mismatch. This path only covers dense linear layers.
+            raise NotImplementedError(
+                "The ROCm NVFP4 (petit_nvfp4) backend does not support quantized "
+                f"MoE layers, but '{prefix}' is one. Only dense linear layers are "
+                "supported; exclude the experts from the checkpoint or use a "
+                "different quantization method."
+            )
         return None
 
     def get_scaled_act_names(self) -> List[str]:

--- a/python/sglang/srt/layers/quantization/petit.py
+++ b/python/sglang/srt/layers/quantization/petit.py
@@ -72,16 +72,31 @@ class PetitNvFp4Config(QuantizationConfig):
 
     @classmethod
     def from_config(cls, config: Dict[str, Any]) -> "PetitNvFp4Config":
-        quant_config = cls.get_from_keys(config, ["quantization"])
+        quant_config = config.get("quantization", config)
         quant_method = quant_config["quant_algo"]
         group_size = quant_config.get("group_size", None)
+        if group_size is None:
+            config_groups = quant_config.get("config_groups", {})
+            first_group = next(iter(config_groups.values()), {})
+            group_size = first_group.get("weights", {}).get("group_size")
+        if group_size is None and quant_method == "NVFP4":
+            group_size = 16
         verify_petit_nvfp4_supported(quant_method, group_size)
 
         is_checkpoint_nvfp4_serialized = "NVFP4" in quant_method
-        kv_cache_quant_algo = quant_config["kv_cache_quant_algo"]
+        kv_cache_quant_algo = quant_config.get("kv_cache_quant_algo")
+        kv_cache_scheme = quant_config.get("kv_cache_scheme")
+        if kv_cache_quant_algo is None and isinstance(kv_cache_scheme, dict):
+            if (
+                kv_cache_scheme.get("type") == "float"
+                and kv_cache_scheme.get("num_bits") == 8
+            ):
+                kv_cache_quant_algo = "FP8"
         if not kv_cache_quant_algo:
             kv_cache_quant_algo = "auto"
-        exclude_modules = quant_config.get("exclude_modules", None)
+        exclude_modules = quant_config.get(
+            "exclude_modules", quant_config.get("ignore")
+        )
         if not (group_size and kv_cache_quant_algo and (exclude_modules is not None)):
             logger.warning(
                 f"group_size: {group_size},"
@@ -252,4 +267,5 @@ class PetitNvFp4LinearMethod(LinearMethodBase):
             size_n=layer.output_size_per_partition,
             size_k=layer.input_size_per_partition,
             bias=bias,
+            backend=layer.nvfp4_backend,
         )

--- a/python/sglang/srt/layers/quantization/petit_utils.py
+++ b/python/sglang/srt/layers/quantization/petit_utils.py
@@ -8,6 +8,7 @@ import torch
 from sglang.kernels.ops.gemm.rdna4_nvfp4 import (
     is_rdna4_nvfp4_device,
     rdna4_nvfp4_linear,
+    try_warmup_rdna4_nvfp4,
 )
 
 PETIT_NVFP4_BACKEND = "petit"
@@ -96,6 +97,14 @@ def prepare_nvfp4_layer_for_petit(layer: torch.nn.Module) -> None:
     )
     layer.weight_scale = torch.nn.Parameter(
         layer.weight_scale.data.contiguous(), requires_grad=False
+    )
+    # Force the HIP and Triton compiles now: loading a layer is the last point
+    # before CUDA graph capture where a plain launch is still safe.
+    try_warmup_rdna4_nvfp4(
+        getattr(layer, "params_dtype", None) or torch.get_default_dtype(),
+        layer.weight.device,
+        layer.output_size_per_partition,
+        layer.input_size_per_partition,
     )
 
 

--- a/python/sglang/srt/layers/quantization/petit_utils.py
+++ b/python/sglang/srt/layers/quantization/petit_utils.py
@@ -1,36 +1,40 @@
-from typing import Optional
+from __future__ import annotations
+
+from functools import lru_cache
+from typing import NamedTuple, Optional
 
 import torch
 
-try:
-    from petit_kernel import mul_nvfp4_a16, process_nvfp4_scales, repack_nvfp4
-except ImportError:
+from sglang.kernels.ops.gemm.rdna4_nvfp4 import (
+    is_rdna4_nvfp4_device,
+    rdna4_nvfp4_linear,
+)
 
-    def _check_petit_nvfp4_supported(
-        quant_method: str, group_size: Optional[int]
-    ) -> tuple[bool, Optional[str]]:
-        return (
-            False,
-            "Petit is not installed. Please install it with `pip install petit-kernel`.",
-        )
+PETIT_NVFP4_BACKEND = "petit"
+RDNA4_NVFP4_BACKEND = "rdna4_jit"
 
-    def prepare_nvfp4_layer_for_petit(layer: torch.nn.Module) -> None:
-        raise ValueError(
-            "Petit is not installed. Please install it with `pip install petit-kernel`."
-        )
 
-    def apply_petit_nvfp4_linear(
-        input: torch.Tensor,
-        weight: torch.Tensor,
-        weight_scale: torch.Tensor,
-        weight_scale_2: torch.Tensor,
-        size_n: int,
-        size_k: int,
-        bias: Optional[torch.Tensor] = None,
-    ) -> torch.Tensor:
-        raise ValueError(
-            "Petit is not installed. Please install it with `pip install petit-kernel`."
+class _PetitOps(NamedTuple):
+    mul_nvfp4_a16: object
+    process_nvfp4_scales: object
+    repack_nvfp4: object
+
+
+@lru_cache(maxsize=1)
+def _load_petit_ops() -> _PetitOps:
+    try:
+        from petit_kernel import (
+            mul_nvfp4_a16,
+            process_nvfp4_scales,
+            repack_nvfp4,
         )
+    except (ImportError, OSError) as error:
+        raise RuntimeError(
+            "The Petit NVFP4 backend is unavailable or ABI-incompatible. "
+            "Install a petit-kernel build matching the active ROCm runtime. "
+            f"Original import error: {error}"
+        ) from error
+    return _PetitOps(mul_nvfp4_a16, process_nvfp4_scales, repack_nvfp4)
 
 
 def _check_petit_nvfp4_supported(
@@ -39,15 +43,13 @@ def _check_petit_nvfp4_supported(
     if quant_method != "NVFP4":
         return (
             False,
-            "Petit currently only supports: NVFP4"
-            " quantizations in sglang. Please check the "
-            "`hf_quant_config.json` file for your model's "
-            "quant configuration.",
+            "The dense ROCm NVFP4 path only supports quant_algo=NVFP4. "
+            "Check the model hf_quant_config.json file.",
         )
     if group_size is not None and group_size != 16:
         return (
             False,
-            "Petit currently only supports: group_size=16" " quantizations.",
+            "The dense ROCm NVFP4 path only supports group_size=16.",
         )
     return (True, None)
 
@@ -58,21 +60,43 @@ def verify_petit_nvfp4_supported(quant_method: str, group_size: Optional[int]) -
         raise ValueError(error_msg)
 
 
+def select_nvfp4_backend(device: torch.device | int | None = None) -> str:
+    if not is_rdna4_nvfp4_device(device):
+        return PETIT_NVFP4_BACKEND
+    return RDNA4_NVFP4_BACKEND
+
+
 def prepare_nvfp4_layer_for_petit(layer: torch.nn.Module) -> None:
-    # Repack weights to petit format
-    part_size_n = layer.output_size_per_partition
-    part_size_k = layer.input_size_per_partition
-    qweight = layer.weight.view(torch.int32).contiguous()
-    petit_qweight = repack_nvfp4(qweight, size_n=part_size_n, size_k=part_size_k)
-    layer.weight = torch.nn.Parameter(petit_qweight, requires_grad=False)
+    backend = select_nvfp4_backend(layer.weight.device)
+    layer.nvfp4_backend = backend
 
-    # Permute scales
-    weight_scale = process_nvfp4_scales(
-        scales=layer.weight_scale, size_k=part_size_k, size_n=part_size_n
+    if backend == PETIT_NVFP4_BACKEND:
+        petit_ops = _load_petit_ops()
+        part_size_n = layer.output_size_per_partition
+        part_size_k = layer.input_size_per_partition
+        qweight = layer.weight.view(torch.int32).contiguous()
+        petit_qweight = petit_ops.repack_nvfp4(
+            qweight, size_n=part_size_n, size_k=part_size_k
+        )
+        layer.weight = torch.nn.Parameter(petit_qweight, requires_grad=False)
+
+        weight_scale = petit_ops.process_nvfp4_scales(
+            scales=layer.weight_scale, size_k=part_size_k, size_n=part_size_n
+        )
+        layer.weight_scale = torch.nn.Parameter(weight_scale, requires_grad=False)
+        return
+
+    if backend != RDNA4_NVFP4_BACKEND:
+        raise ValueError(f"Unknown NVFP4 backend: {backend}")
+
+    # The RDNA4 JIT consumes the canonical checkpoint layout directly.
+    # Keep this decision on the layer so apply does not query the device.
+    layer.weight = torch.nn.Parameter(
+        layer.weight.data.contiguous(), requires_grad=False
     )
-    layer.weight_scale = torch.nn.Parameter(weight_scale, requires_grad=False)
-
-    return
+    layer.weight_scale = torch.nn.Parameter(
+        layer.weight_scale.data.contiguous(), requires_grad=False
+    )
 
 
 def apply_petit_nvfp4_linear(
@@ -83,22 +107,35 @@ def apply_petit_nvfp4_linear(
     size_n: int,
     size_k: int,
     bias: Optional[torch.Tensor] = None,
+    backend: str = PETIT_NVFP4_BACKEND,
 ) -> torch.Tensor:
-    reshaped_x = input.reshape(-1, input.shape[-1])
-    out_shape = input.shape[:-1] + (size_n,)
+    if backend == PETIT_NVFP4_BACKEND:
+        reshaped_x = input.reshape(-1, input.shape[-1])
+        out_shape = input.shape[:-1] + (size_n,)
+        petit_ops = _load_petit_ops()
+        output = petit_ops.mul_nvfp4_a16(
+            a=reshaped_x,
+            b=weight,
+            s=weight_scale,
+            global_scale=weight_scale_2,
+            size_m=reshaped_x.size(0),
+            size_n=size_n,
+            size_k=size_k,
+            solution_id=-1,
+        )
+        if bias is not None:
+            output.add_(bias)
+        return output.reshape(out_shape)
 
-    # TODO: Use auto-tuning to find the performant solution_id
-    output = mul_nvfp4_a16(
-        a=reshaped_x,
-        b=weight,
-        s=weight_scale,
-        global_scale=weight_scale_2,
-        size_m=reshaped_x.size(0),
-        size_n=size_n,
-        size_k=size_k,
-        solution_id=-1,
+    if backend != RDNA4_NVFP4_BACKEND:
+        raise ValueError(f"Unknown NVFP4 backend: {backend}")
+
+    output = rdna4_nvfp4_linear(
+        input=input,
+        weight=weight,
+        weight_scale=weight_scale,
+        weight_global_scale=weight_scale_2,
     )
     if bias is not None:
-        output.add_(bias)  # In-place add
-
-    return output.reshape(out_shape)
+        output.add_(bias)
+    return output

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -17,6 +17,7 @@ from sglang.srt.utils import (
     get_bool_env_var,
     is_cpu,
     is_cuda,
+    is_gfx1201_supported,
     is_hip,
     is_mps,
     is_musa,
@@ -33,18 +34,6 @@ logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
-_is_gfx1201 = (
-    _is_hip
-    and torch.cuda.is_available()
-    and getattr(
-        torch.cuda.get_device_properties(torch.cuda.current_device()),
-        "gcnArchName",
-        "",
-    )
-    .split(":", 1)[0]
-    .lower()
-    == "gfx1201"
-)
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_npu = is_npu()
 _is_cpu_amx_available = cpu_has_amx_support()
@@ -88,7 +77,11 @@ if _is_xpu:
 
 
 def _should_force_native_rope() -> bool:
-    return _is_gfx1201 or (
+    # gfx1201: released ROCm sgl-kernel wheels are not built for that arch, so
+    # the fused RoPE entry point is unavailable there. Queried lazily -- reading
+    # device properties at import time would initialise a HIP context in every
+    # process that merely imports this module.
+    return is_gfx1201_supported() or (
         publish_role() is not None
         and get_exec().deterministic.rl_on_policy_target is not None
     )

--- a/python/sglang/srt/layers/rotary_embedding/base.py
+++ b/python/sglang/srt/layers/rotary_embedding/base.py
@@ -33,6 +33,18 @@ logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
 _is_hip = is_hip()
+_is_gfx1201 = (
+    _is_hip
+    and torch.cuda.is_available()
+    and getattr(
+        torch.cuda.get_device_properties(torch.cuda.current_device()),
+        "gcnArchName",
+        "",
+    )
+    .split(":", 1)[0]
+    .lower()
+    == "gfx1201"
+)
 _use_aiter = get_bool_env_var("SGLANG_USE_AITER") and _is_hip
 _is_npu = is_npu()
 _is_cpu_amx_available = cpu_has_amx_support()
@@ -75,6 +87,13 @@ if _is_xpu:
     from sgl_kernel import fused_qk_rope_with_cos_sin_cache_inplace
 
 
+def _should_force_native_rope() -> bool:
+    return _is_gfx1201 or (
+        publish_role() is not None
+        and get_exec().deterministic.rl_on_policy_target is not None
+    )
+
+
 class RotaryEmbedding(BaseFusedOp):
     """Original rotary positional embedding."""
 
@@ -94,10 +113,7 @@ class RotaryEmbedding(BaseFusedOp):
         self.base = base
         self.is_neox_style = is_neox_style
         self.dtype = dtype
-        self._force_native = (
-            publish_role() is not None
-            and get_exec().deterministic.rl_on_policy_target is not None
-        )
+        self._force_native = _should_force_native_rope()
 
         cache = self._compute_cos_sin_cache()
         # NOTE(ByronHsu): cache needs to be in FP32 for numerical stability.

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1037,6 +1037,23 @@ def is_gfx95_supported():
         return False
 
 
+@lru_cache(maxsize=None)
+def is_gfx1201_supported(device: Optional[int] = None) -> bool:
+    """Whether `device` is an AMD gfx1201 GPU (RDNA4 -- Radeon AI PRO R9700).
+
+    `device` defaults to the current one. False on every non-HIP build, so
+    callers do not need their own is_hip(). Matched exactly: the RDNA4 paths
+    keyed off this are validated on gfx1201 only, not on gfx1200 or gfx11xx.
+    """
+    if not torch.version.hip or not torch.cuda.is_available():
+        return False
+    if device is None:
+        device = torch.cuda.current_device()
+    gcn_arch = getattr(torch.cuda.get_device_properties(device), "gcnArchName", "")
+    # gcnArchName carries optional feature suffixes, e.g. "gfx1201:sramecc+:xnack-".
+    return gcn_arch.split(":", 1)[0].lower() == "gfx1201"
+
+
 @lru_cache(maxsize=1)
 def is_gfx942_supported():
     """

--- a/test/manual/quant/test_rdna4_nvfp4.py
+++ b/test/manual/quant/test_rdna4_nvfp4.py
@@ -1,0 +1,203 @@
+"""Fail-closed numerical test for the exact gfx1201 NVFP4 JIT backend."""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.gemm.rdna4_nvfp4 import (
+    is_rdna4_nvfp4_device,
+    rdna4_nvfp4_linear,
+)
+from sglang.srt.layers.quantization.petit import PetitNvFp4Config
+from sglang.srt.layers.quantization.petit_utils import RDNA4_NVFP4_BACKEND
+from sglang.test.layer_ut_utils import (
+    init_single_process_dist,
+    load_linear_weights,
+    make_tp1_column_parallel_linear,
+)
+
+E2M1_VALUES = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def _dequantize_weight(
+    packed: torch.Tensor,
+    block_scale: torch.Tensor,
+    global_scale: torch.Tensor,
+) -> torch.Tensor:
+    packed_cpu = packed.cpu().long()
+    n, packed_k = packed_cpu.shape
+    weight = torch.empty((n, packed_k * 2), dtype=torch.float32)
+    weight[:, 0::2] = E2M1_VALUES[packed_cpu & 0xF]
+    weight[:, 1::2] = E2M1_VALUES[packed_cpu >> 4]
+    weight *= block_scale.float().cpu().repeat_interleave(16, dim=1)
+    return weight * global_scale.float().cpu()
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+@pytest.mark.parametrize(
+    "m,n,k",
+    [
+        (1, 1, 16),
+        (1, 17, 528),
+        (2, 3, 32),
+        (7, 17, 272),
+        (9, 33, 528),
+        (127, 31, 272),
+        (128, 64, 528),
+        (129, 65, 272),
+    ],
+)
+def test_rdna4_nvfp4_matches_independent_oracle(dtype, m, n, k):
+    if not is_rdna4_nvfp4_device():
+        raise RuntimeError(
+            "This fail-closed test requires an exact gfx1201 ROCm device."
+        )
+
+    torch.manual_seed(20260828 + m + n + k)
+    input_tensor = torch.randn((m, k), dtype=dtype, device="cuda")
+    packed = torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device="cuda")
+    block_scale = (
+        (torch.rand((n, k // 16), dtype=torch.float32) * 3.75 + 0.0625)
+        .to(torch.float8_e4m3fn)
+        .cuda()
+    )
+    global_scale = torch.tensor([0.125], dtype=torch.float32, device="cuda")
+
+    output = rdna4_nvfp4_linear(
+        input_tensor,
+        packed,
+        block_scale,
+        global_scale,
+    )
+    dequantized_weight = _dequantize_weight(
+        packed,
+        block_scale,
+        global_scale,
+    )
+    reference = input_tensor.float().cpu() @ dequantized_weight.T
+    rounded_reference = reference.to(dtype).float()
+
+    torch.testing.assert_close(
+        output.float().cpu(),
+        rounded_reference,
+        rtol=2e-2,
+        atol=1.0 if dtype == torch.float16 else 0.5,
+    )
+
+
+def test_rdna4_nvfp4_real_linear_layer_path():
+    if not is_rdna4_nvfp4_device():
+        raise RuntimeError(
+            "This fail-closed test requires an exact gfx1201 ROCm device."
+        )
+
+    init_single_process_dist()
+    m, n, k = 3, 17, 32
+    config = PetitNvFp4Config(
+        is_checkpoint_nvfp4_serialized=True,
+        kv_cache_quant_algo="FP8",
+        group_size=16,
+        exclude_modules=[],
+    )
+    layer = make_tp1_column_parallel_linear(config, n, k)
+
+    torch.manual_seed(20260828)
+    packed = torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device="cuda")
+    block_scale = (
+        (torch.rand((n, k // 16), dtype=torch.float32) * 3.75 + 0.0625)
+        .to(torch.float8_e4m3fn)
+        .cuda()
+    )
+    global_scale = torch.tensor([0.125], dtype=torch.float32, device="cuda")
+    load_linear_weights(
+        layer,
+        weight=packed,
+        weight_scale=block_scale,
+        weight_scale_2=global_scale,
+        input_scale=torch.ones(1, dtype=torch.float32, device="cuda"),
+    )
+    layer.quant_method.process_weights_after_loading(layer)
+    assert layer.nvfp4_backend == RDNA4_NVFP4_BACKEND
+
+    input_tensor = torch.randn((m, k), dtype=torch.bfloat16, device="cuda")
+    output, _ = layer(input_tensor)
+    dequantized_weight = _dequantize_weight(
+        packed,
+        block_scale,
+        global_scale,
+    )
+    reference = input_tensor.float().cpu() @ dequantized_weight.T
+    torch.testing.assert_close(
+        output.float().cpu(),
+        reference.to(torch.bfloat16).float(),
+        rtol=2e-2,
+        atol=0.5,
+    )
+
+
+@pytest.mark.parametrize("m", [1, 7])
+def test_rdna4_nvfp4_cuda_graph_replay(m):
+    if not is_rdna4_nvfp4_device():
+        raise RuntimeError(
+            "This fail-closed test requires an exact gfx1201 ROCm device."
+        )
+
+    n, k = 17, 272
+    torch.manual_seed(20260828 + m)
+    input_tensor = torch.randn((m, k), dtype=torch.bfloat16, device="cuda")
+    packed = torch.randint(0, 256, (n, k // 2), dtype=torch.uint8, device="cuda")
+    block_scale = (
+        (torch.rand((n, k // 16), dtype=torch.float32) * 3.75 + 0.0625)
+        .to(torch.float8_e4m3fn)
+        .cuda()
+    )
+    global_scale = torch.tensor([0.125], dtype=torch.float32, device="cuda")
+
+    rdna4_nvfp4_linear(input_tensor, packed, block_scale, global_scale)
+    torch.cuda.synchronize()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        output = rdna4_nvfp4_linear(
+            input_tensor,
+            packed,
+            block_scale,
+            global_scale,
+        )
+    graph.replay()
+    torch.cuda.synchronize()
+
+    dequantized_weight = _dequantize_weight(
+        packed,
+        block_scale,
+        global_scale,
+    )
+    reference = input_tensor.float().cpu() @ dequantized_weight.T
+    torch.testing.assert_close(
+        output.float().cpu(),
+        reference.to(torch.bfloat16).float(),
+        rtol=2e-2,
+        atol=0.5,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/layers/quantization/test_petit_nvfp4_backends.py
+++ b/test/registered/unit/layers/quantization/test_petit_nvfp4_backends.py
@@ -1,0 +1,297 @@
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+import torch
+import torch.nn as nn
+
+from sglang.kernels.ops.gemm import rdna4_nvfp4
+from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.petit import PetitNvFp4Config
+from sglang.srt.layers.quantization.petit_utils import (
+    PETIT_NVFP4_BACKEND,
+    RDNA4_NVFP4_BACKEND,
+    apply_petit_nvfp4_linear,
+    prepare_nvfp4_layer_for_petit,
+    select_nvfp4_backend,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestRdna4Nvfp4BackendSelection(CustomTestCase):
+    def test_gcn_arch_normalization(self):
+        self.assertEqual(
+            rdna4_nvfp4.normalize_gcn_arch_name("gfx1201:sramecc+:xnack-"),
+            "gfx1201",
+        )
+        self.assertEqual(
+            rdna4_nvfp4.normalize_gcn_arch_name("GFX942:xnack-"),
+            "gfx942",
+        )
+
+    def test_exact_gfx1201_device_detection(self):
+        with (
+            mock.patch.object(torch.version, "hip", "7.0"),
+            mock.patch.object(torch.cuda, "is_available", return_value=True),
+            mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName="gfx1201:sramecc+:xnack-"),
+            ),
+        ):
+            self.assertTrue(rdna4_nvfp4.is_rdna4_nvfp4_device("cuda:0"))
+
+        with (
+            mock.patch.object(torch.version, "hip", "7.0"),
+            mock.patch.object(torch.cuda, "is_available", return_value=True),
+            mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName="gfx942"),
+            ),
+        ):
+            self.assertFalse(rdna4_nvfp4.is_rdna4_nvfp4_device("cuda:0"))
+
+    def test_selector_preserves_petit_for_non_rdna4(self):
+        with mock.patch(
+            "sglang.srt.layers.quantization.petit_utils." "is_rdna4_nvfp4_device",
+            return_value=False,
+        ):
+            self.assertEqual(select_nvfp4_backend(), PETIT_NVFP4_BACKEND)
+
+    def test_rdna4_preparation_keeps_canonical_layout_without_petit(self):
+        layer = nn.Module()
+        layer.input_size_per_partition = 16
+        layer.output_size_per_partition = 3
+        layer.weight = nn.Parameter(
+            torch.arange(24, dtype=torch.uint8).reshape(3, 8),
+            requires_grad=False,
+        )
+        layer.weight_scale = nn.Parameter(
+            torch.ones(3, 1, dtype=torch.float32).to(torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        expected_weight = layer.weight.clone()
+        expected_scale = layer.weight_scale.clone()
+
+        with (
+            mock.patch(
+                "sglang.srt.layers.quantization.petit_utils." "select_nvfp4_backend",
+                return_value=RDNA4_NVFP4_BACKEND,
+            ),
+            mock.patch(
+                "sglang.srt.layers.quantization.petit_utils._load_petit_ops",
+                side_effect=AssertionError("Petit must not be imported"),
+            ),
+        ):
+            prepare_nvfp4_layer_for_petit(layer)
+
+        self.assertEqual(layer.nvfp4_backend, RDNA4_NVFP4_BACKEND)
+        torch.testing.assert_close(layer.weight, expected_weight)
+        torch.testing.assert_close(layer.weight_scale, expected_scale)
+
+    def test_non_rdna4_preparation_preserves_petit_repack(self):
+        layer = nn.Module()
+        layer.input_size_per_partition = 16
+        layer.output_size_per_partition = 3
+        layer.weight = nn.Parameter(
+            torch.arange(24, dtype=torch.uint8).reshape(3, 8),
+            requires_grad=False,
+        )
+        layer.weight_scale = nn.Parameter(
+            torch.ones(3, 1, dtype=torch.float32).to(torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        repacked = torch.arange(6, dtype=torch.int32).reshape(3, 2)
+        processed_scale = torch.arange(3, dtype=torch.float32).reshape(3, 1)
+        petit_ops = SimpleNamespace(
+            repack_nvfp4=mock.Mock(return_value=repacked),
+            process_nvfp4_scales=mock.Mock(return_value=processed_scale),
+        )
+
+        with (
+            mock.patch(
+                "sglang.srt.layers.quantization.petit_utils.select_nvfp4_backend",
+                return_value=PETIT_NVFP4_BACKEND,
+            ),
+            mock.patch(
+                "sglang.srt.layers.quantization.petit_utils._load_petit_ops",
+                return_value=petit_ops,
+            ),
+        ):
+            prepare_nvfp4_layer_for_petit(layer)
+
+        self.assertEqual(layer.nvfp4_backend, PETIT_NVFP4_BACKEND)
+        torch.testing.assert_close(layer.weight, repacked)
+        torch.testing.assert_close(layer.weight_scale, processed_scale)
+        petit_ops.repack_nvfp4.assert_called_once_with(
+            mock.ANY,
+            size_n=3,
+            size_k=16,
+        )
+        petit_ops.process_nvfp4_scales.assert_called_once_with(
+            scales=mock.ANY,
+            size_k=16,
+            size_n=3,
+        )
+
+    def test_apply_uses_cached_rdna4_backend(self):
+        input_tensor = torch.randn(2, 16, dtype=torch.bfloat16)
+        expected = torch.randn(2, 3, dtype=torch.bfloat16)
+        with mock.patch(
+            "sglang.srt.layers.quantization.petit_utils." "rdna4_nvfp4_linear",
+            return_value=expected,
+        ) as rdna4_linear:
+            output = apply_petit_nvfp4_linear(
+                input=input_tensor,
+                weight=torch.empty(3, 8, dtype=torch.uint8),
+                weight_scale=torch.empty(3, 1, dtype=torch.float8_e4m3fn),
+                weight_scale_2=torch.ones(1),
+                size_n=3,
+                size_k=16,
+                backend=RDNA4_NVFP4_BACKEND,
+            )
+
+        self.assertIs(output, expected)
+        rdna4_linear.assert_called_once()
+
+    def test_apply_preserves_petit_shape_and_bias(self):
+        input_tensor = torch.randn(1, 2, 16, dtype=torch.bfloat16)
+        petit_output = torch.zeros(2, 3, dtype=torch.bfloat16)
+        petit_ops = SimpleNamespace(mul_nvfp4_a16=mock.Mock(return_value=petit_output))
+        with mock.patch(
+            "sglang.srt.layers.quantization.petit_utils._load_petit_ops",
+            return_value=petit_ops,
+        ):
+            output = apply_petit_nvfp4_linear(
+                input=input_tensor,
+                weight=torch.empty(3, 2, dtype=torch.int32),
+                weight_scale=torch.empty(3, 1),
+                weight_scale_2=torch.ones(1),
+                size_n=3,
+                size_k=16,
+                bias=torch.ones(3, dtype=torch.bfloat16),
+                backend=PETIT_NVFP4_BACKEND,
+            )
+
+        self.assertEqual(output.shape, (1, 2, 3))
+        torch.testing.assert_close(output, torch.ones_like(output))
+        petit_ops.mul_nvfp4_a16.assert_called_once_with(
+            a=mock.ANY,
+            b=mock.ANY,
+            s=mock.ANY,
+            global_scale=mock.ANY,
+            size_m=2,
+            size_n=3,
+            size_k=16,
+            solution_id=-1,
+        )
+
+    def test_rdna4_wrapper_rejects_unsupported_contracts_before_launch(self):
+        valid_input = torch.randn(2, 16, dtype=torch.bfloat16)
+        valid_weight = torch.empty(3, 8, dtype=torch.uint8)
+        valid_scale = torch.empty(3, 1, dtype=torch.float8_e4m3fn)
+        valid_global_scale = torch.ones(1, dtype=torch.float32)
+        cases = (
+            (
+                {"input": valid_input.float()},
+                TypeError,
+                "supports BF16 and FP16",
+            ),
+            (
+                {"input": torch.randn(2, 15, dtype=torch.bfloat16)},
+                ValueError,
+                "K divisible by 16",
+            ),
+            (
+                {"input": torch.empty(0, 16, dtype=torch.bfloat16)},
+                ValueError,
+                "at least one row",
+            ),
+            (
+                {"weight": valid_weight.to(torch.int8)},
+                TypeError,
+                "2D uint8 packed tensor",
+            ),
+            (
+                {"weight": torch.empty(0, 8, dtype=torch.uint8)},
+                ValueError,
+                "at least one output row",
+            ),
+            (
+                {"weight_scale": valid_scale.float()},
+                TypeError,
+                "2D float8_e4m3fn tensor",
+            ),
+            (
+                {"weight_global_scale": valid_global_scale.bfloat16()},
+                TypeError,
+                "one float32 value",
+            ),
+        )
+
+        with mock.patch.object(rdna4_nvfp4, "is_rdna4_nvfp4_device", return_value=True):
+            for override, error_type, message in cases:
+                arguments = {
+                    "input": valid_input,
+                    "weight": valid_weight,
+                    "weight_scale": valid_scale,
+                    "weight_global_scale": valid_global_scale,
+                    **override,
+                }
+                with self.subTest(override=override):
+                    with self.assertRaisesRegex(error_type, message):
+                        rdna4_nvfp4.rdna4_nvfp4_linear(**arguments)
+
+    def test_modelopt_nvfp4_routes_to_rocm_config(self):
+        config = {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"}
+        with mock.patch.object(torch.version, "hip", "7.0"):
+            for requested_method in (None, "modelopt", "modelopt_fp4"):
+                with self.subTest(requested_method=requested_method):
+                    override = (
+                        QuantizationConfig._modelopt_override_quantization_method(
+                            config, requested_method
+                        )
+                    )
+                    self.assertEqual(override, "petit_nvfp4")
+
+    def test_explicit_petit_is_preserved_without_rdna4_detection(self):
+        config = {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"}
+        with mock.patch.object(torch.version, "hip", None):
+            override = QuantizationConfig._modelopt_override_quantization_method(
+                config, "petit_nvfp4"
+            )
+        self.assertEqual(override, "petit_nvfp4")
+
+    def test_cuda_flagless_modelopt_nvfp4_routing_is_unchanged(self):
+        config = {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"}
+        with mock.patch.object(torch.version, "hip", None):
+            override = QuantizationConfig._modelopt_override_quantization_method(
+                config, None
+            )
+        self.assertEqual(override, "modelopt_fp4")
+
+    def test_flat_modelopt_config_is_supported(self):
+        config = PetitNvFp4Config.from_config(
+            {
+                "quant_algo": "NVFP4",
+                "config_groups": {
+                    "group_0": {
+                        "weights": {"group_size": 16},
+                    }
+                },
+                "ignore": ["lm_head"],
+                "kv_cache_scheme": {"type": "float", "num_bits": 8},
+            }
+        )
+        self.assertTrue(config.is_checkpoint_nvfp4_serialized)
+        self.assertEqual(config.group_size, 16)
+        self.assertEqual(config.kv_cache_quant_algo, "FP8")
+        self.assertEqual(config.exclude_modules, ["lm_head"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_petit_nvfp4_backends.py
+++ b/test/registered/unit/layers/quantization/test_petit_nvfp4_backends.py
@@ -1,3 +1,4 @@
+import contextlib
 import unittest
 from types import SimpleNamespace
 from unittest import mock
@@ -15,6 +16,7 @@ from sglang.srt.layers.quantization.petit_utils import (
     prepare_nvfp4_layer_for_petit,
     select_nvfp4_backend,
 )
+from sglang.srt.utils import is_gfx1201_supported
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -22,42 +24,58 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestRdna4Nvfp4BackendSelection(CustomTestCase):
-    def test_gcn_arch_normalization(self):
-        self.assertEqual(
-            rdna4_nvfp4.normalize_gcn_arch_name("gfx1201:sramecc+:xnack-"),
-            "gfx1201",
-        )
-        self.assertEqual(
-            rdna4_nvfp4.normalize_gcn_arch_name("GFX942:xnack-"),
-            "gfx942",
+    def setUp(self):
+        super().setUp()
+        # is_gfx1201_supported caches per device; the mocked properties below
+        # would otherwise leak between subtests.
+        is_gfx1201_supported.cache_clear()
+        self.addCleanup(is_gfx1201_supported.cache_clear)
+
+    @staticmethod
+    def _mock_device(gcn_arch_name, hip="7.0"):
+        return (
+            mock.patch.object(torch.version, "hip", hip),
+            mock.patch.object(torch.cuda, "is_available", return_value=True),
+            mock.patch.object(
+                torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName=gcn_arch_name),
+            ),
         )
 
     def test_exact_gfx1201_device_detection(self):
-        with (
-            mock.patch.object(torch.version, "hip", "7.0"),
-            mock.patch.object(torch.cuda, "is_available", return_value=True),
-            mock.patch.object(
-                torch.cuda,
-                "get_device_properties",
-                return_value=SimpleNamespace(gcnArchName="gfx1201:sramecc+:xnack-"),
-            ),
-        ):
-            self.assertTrue(rdna4_nvfp4.is_rdna4_nvfp4_device("cuda:0"))
+        cases = (
+            # A feature suffix must not defeat the match; a near neighbour must.
+            ("gfx1201:sramecc+:xnack-", True),
+            ("GFX1201", True),
+            ("gfx1200", False),
+            ("gfx942", False),
+        )
+        for gcn_arch_name, expected in cases:
+            with self.subTest(gcn_arch_name=gcn_arch_name):
+                is_gfx1201_supported.cache_clear()
+                with contextlib.ExitStack() as stack:
+                    for patcher in self._mock_device(gcn_arch_name):
+                        stack.enter_context(patcher)
+                    self.assertEqual(
+                        rdna4_nvfp4.is_rdna4_nvfp4_device("cuda:0"), expected
+                    )
 
-        with (
-            mock.patch.object(torch.version, "hip", "7.0"),
-            mock.patch.object(torch.cuda, "is_available", return_value=True),
-            mock.patch.object(
-                torch.cuda,
-                "get_device_properties",
-                return_value=SimpleNamespace(gcnArchName="gfx942"),
-            ),
-        ):
+    def test_non_hip_and_non_gpu_devices_are_rejected(self):
+        with contextlib.ExitStack() as stack:
+            for patcher in self._mock_device("gfx1201", hip=None):
+                stack.enter_context(patcher)
             self.assertFalse(rdna4_nvfp4.is_rdna4_nvfp4_device("cuda:0"))
+
+        is_gfx1201_supported.cache_clear()
+        with contextlib.ExitStack() as stack:
+            for patcher in self._mock_device("gfx1201"):
+                stack.enter_context(patcher)
+            self.assertFalse(rdna4_nvfp4.is_rdna4_nvfp4_device("cpu"))
 
     def test_selector_preserves_petit_for_non_rdna4(self):
         with mock.patch(
-            "sglang.srt.layers.quantization.petit_utils." "is_rdna4_nvfp4_device",
+            "sglang.srt.layers.quantization.petit_utils.is_rdna4_nvfp4_device",
             return_value=False,
         ):
             self.assertEqual(select_nvfp4_backend(), PETIT_NVFP4_BACKEND)
@@ -79,15 +97,20 @@ class TestRdna4Nvfp4BackendSelection(CustomTestCase):
 
         with (
             mock.patch(
-                "sglang.srt.layers.quantization.petit_utils." "select_nvfp4_backend",
+                "sglang.srt.layers.quantization.petit_utils.select_nvfp4_backend",
                 return_value=RDNA4_NVFP4_BACKEND,
             ),
             mock.patch(
                 "sglang.srt.layers.quantization.petit_utils._load_petit_ops",
                 side_effect=AssertionError("Petit must not be imported"),
             ),
+            mock.patch(
+                "sglang.srt.layers.quantization.petit_utils.try_warmup_rdna4_nvfp4"
+            ) as warmup,
         ):
             prepare_nvfp4_layer_for_petit(layer)
+
+        warmup.assert_called_once()
 
         self.assertEqual(layer.nvfp4_backend, RDNA4_NVFP4_BACKEND)
         torch.testing.assert_close(layer.weight, expected_weight)
@@ -142,7 +165,7 @@ class TestRdna4Nvfp4BackendSelection(CustomTestCase):
         input_tensor = torch.randn(2, 16, dtype=torch.bfloat16)
         expected = torch.randn(2, 3, dtype=torch.bfloat16)
         with mock.patch(
-            "sglang.srt.layers.quantization.petit_utils." "rdna4_nvfp4_linear",
+            "sglang.srt.layers.quantization.petit_utils.rdna4_nvfp4_linear",
             return_value=expected,
         ) as rdna4_linear:
             output = apply_petit_nvfp4_linear(
@@ -246,25 +269,84 @@ class TestRdna4Nvfp4BackendSelection(CustomTestCase):
                     with self.assertRaisesRegex(error_type, message):
                         rdna4_nvfp4.rdna4_nvfp4_linear(**arguments)
 
-    def test_modelopt_nvfp4_routes_to_rocm_config(self):
+    def test_modelopt_declines_dense_nvfp4_on_rocm(self):
+        """The ModelOpt configs must step aside so Petit can claim the checkpoint."""
         config = {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"}
         with mock.patch.object(torch.version, "hip", "7.0"):
-            for requested_method in (None, "modelopt", "modelopt_fp4"):
+            for requested_method in (None, "modelopt", "modelopt_fp4", "petit_nvfp4"):
                 with self.subTest(requested_method=requested_method):
-                    override = (
+                    self.assertIsNone(
                         QuantizationConfig._modelopt_override_quantization_method(
                             config, requested_method
                         )
                     )
-                    self.assertEqual(override, "petit_nvfp4")
 
-    def test_explicit_petit_is_preserved_without_rdna4_detection(self):
-        config = {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"}
-        with mock.patch.object(torch.version, "hip", None):
-            override = QuantizationConfig._modelopt_override_quantization_method(
-                config, "petit_nvfp4"
+    def test_petit_claims_both_modelopt_method_spellings_on_rocm(self):
+        configs = (
+            {"quant_method": "modelopt", "quant_algo": "NVFP4"},
+            {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"},
+        )
+        with mock.patch(
+            "sglang.srt.layers.quantization.petit._is_hip",
+            True,
+        ):
+            for config in configs:
+                with self.subTest(quant_method=config["quant_method"]):
+                    self.assertEqual(
+                        PetitNvFp4Config.override_quantization_method(config, None),
+                        "petit_nvfp4",
+                    )
+
+    def test_petit_declines_algorithms_it_cannot_serve(self):
+        # NVFP4_AWQ / W4A16_NVFP4 keep resolving to modelopt_fp4 and its
+        # explicit "not supported in ROCm" error rather than silently landing
+        # on a backend that only implements group-16 dense NVFP4.
+        with mock.patch("sglang.srt.layers.quantization.petit._is_hip", True):
+            for quant_algo in ("NVFP4_AWQ", "W4A16_NVFP4"):
+                with self.subTest(quant_algo=quant_algo):
+                    config = {
+                        "quant_method": "modelopt_fp4",
+                        "quant_algo": quant_algo,
+                    }
+                    self.assertIsNone(
+                        PetitNvFp4Config.override_quantization_method(config, None)
+                    )
+        with mock.patch.object(torch.version, "hip", "7.0"):
+            self.assertEqual(
+                QuantizationConfig._modelopt_override_quantization_method(
+                    {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4_AWQ"}, None
+                ),
+                "modelopt_fp4",
             )
-        self.assertEqual(override, "petit_nvfp4")
+
+    def test_petit_declines_everything_off_rocm(self):
+        with mock.patch("sglang.srt.layers.quantization.petit._is_hip", False):
+            self.assertIsNone(
+                PetitNvFp4Config.override_quantization_method(
+                    {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"}, None
+                )
+            )
+
+    def test_quantized_moe_layers_fail_fast(self):
+        """A quantized expert must not silently fall through to unquantized MoE."""
+
+        class _FakeFusedMoE(nn.Module):
+            pass
+
+        config = PetitNvFp4Config(
+            is_checkpoint_nvfp4_serialized=True,
+            kv_cache_quant_algo="FP8",
+            group_size=16,
+            exclude_modules=["lm_head"],
+        )
+        with mock.patch(
+            "sglang.srt.layers.moe.fused_moe_triton.FusedMoE",
+            _FakeFusedMoE,
+        ):
+            with self.assertRaisesRegex(NotImplementedError, "does not support"):
+                config.get_quant_method(_FakeFusedMoE(), "model.layers.0.mlp.experts")
+            # An excluded expert stays unquantized instead of raising.
+            self.assertIsNone(config.get_quant_method(_FakeFusedMoE(), "lm_head"))
 
     def test_cuda_flagless_modelopt_nvfp4_routing_is_unchanged(self):
         config = {"quant_method": "modelopt_fp4", "quant_algo": "NVFP4"}
@@ -274,7 +356,7 @@ class TestRdna4Nvfp4BackendSelection(CustomTestCase):
             )
         self.assertEqual(override, "modelopt_fp4")
 
-    def test_flat_modelopt_config_is_supported(self):
+    def test_config_json_style_flat_quant_block_is_supported(self):
         config = PetitNvFp4Config.from_config(
             {
                 "quant_algo": "NVFP4",

--- a/test/registered/unit/layers/test_rdna4_rope_fallback.py
+++ b/test/registered/unit/layers/test_rdna4_rope_fallback.py
@@ -10,8 +10,15 @@ register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 class TestRdna4RopeFallback(CustomTestCase):
     def test_gfx1201_forces_native_rope(self):
-        with mock.patch.object(base, "_is_gfx1201", True):
+        with mock.patch.object(base, "is_gfx1201_supported", return_value=True):
             self.assertTrue(base._should_force_native_rope())
+
+    def test_other_architectures_keep_the_fused_path(self):
+        with (
+            mock.patch.object(base, "is_gfx1201_supported", return_value=False),
+            mock.patch.object(base, "publish_role", return_value=None),
+        ):
+            self.assertFalse(base._should_force_native_rope())
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_rdna4_rope_fallback.py
+++ b/test/registered/unit/layers/test_rdna4_rope_fallback.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest import mock
+
+from sglang.srt.layers.rotary_embedding import base
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestRdna4RopeFallback(CustomTestCase):
+    def test_gfx1201_forces_native_rope(self):
+        with mock.patch.object(base, "_is_gfx1201", True):
+            self.assertTrue(base._should_force_native_rope())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/test_checkpoint_quantization.py
+++ b/test/registered/unit/test_checkpoint_quantization.py
@@ -1,6 +1,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import unittest
+from unittest import mock
+
+import torch
 
 from sglang.srt.layers.modelopt_utils import canonicalize_modelopt_quant_algo
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
@@ -44,17 +47,20 @@ class TestResolveCheckpointQuantSpec(CustomTestCase):
                 self.assertEqual(canonicalize_modelopt_quant_algo(quant_algo), expected)
 
     def test_srt_modelopt_override_uses_the_exact_algorithm_allowlist(self):
-        self.assertEqual(
-            QuantizationConfig._modelopt_override_quantization_method(
-                {"quant_algo": "NVFP4"}, "modelopt"
-            ),
-            "modelopt_fp4",
-        )
-        self.assertIsNone(
-            QuantizationConfig._modelopt_override_quantization_method(
-                {"quant_algo": "NVFP4_FAKE"}, "modelopt"
+        # Pinned to a non-HIP build: on ROCm the ModelOpt configs decline dense
+        # NVFP4 so that PetitNvFp4Config can claim it.
+        with mock.patch.object(torch.version, "hip", None):
+            self.assertEqual(
+                QuantizationConfig._modelopt_override_quantization_method(
+                    {"quant_algo": "NVFP4"}, "modelopt"
+                ),
+                "modelopt_fp4",
             )
-        )
+            self.assertIsNone(
+                QuantizationConfig._modelopt_override_quantization_method(
+                    {"quant_algo": "NVFP4_FAKE"}, "modelopt"
+                )
+            )
 
     def test_top_level_quantization_config(self):
         config = {


### PR DESCRIPTION
## Summary

- Route dense ModelOpt NVFP4 checkpoint metadata to the ROCm NVFP4 config
  while preserving CUDA ModelOpt FP4 and non-RDNA4 Petit behavior.
- Add an exact-gfx1201 backend that consumes canonical packed E2M1 weights and
  E4M3FN block scales without importing or repacking through Petit.
- Use an in-tree HIP JIT FP32 reduction for decode and a tiled Triton `tl.dot`
  path for prefill. Keep the packed weight resident; do not materialize a
  persistent BF16 weight matrix.
- Force native RoPE on exact gfx1201 because released ROCm `sglang-kernel` AOT
  binaries do not target that architecture.
- Document the R9700 backend and first-use Triton warmup requirement.

## Scope

The patch supports exact `gfx1201`, dense Linear, serialized ModelOpt/Petit
NVFP4 W4A16, group size 16, BF16/FP16 activations and output, and one GPU.
MoE, online quantization, FP4 KV cache, W4A4, other RDNA targets, and multi-GPU
validation are out of scope.

## Correctness and model evidence

- Hardware: AMD Radeon AI PRO R9700, 32 GiB, exact `gfx1201`.
- Environment: `sglang-rocm-gfx1201-jit:qwen38-smoke`, local image
  `sha256:c1d4c10a53da...`, PyTorch 2.9.1 + ROCm 7.2, HIP 7.2.
- Exact-device suite: 19 PASS, no skips. It covers BF16/FP16, HIP decode,
  Triton prefill, M=127/128/129, N/K tails, `ColumnParallelLinear`, and CUDA
  Graph capture/replay against an independent CPU FP32-dequantized oracle.
- Focused combined suite: 58 PASS plus 27 subtests, no skips.
- Model: `nvidia/Llama-3.1-8B-Instruct-NVFP4` at
  `bdb54e24298451af785c0ac63c1b485e9b7400a2` loaded without a quantization
  flag and generated deterministic coherent output.
- Resident model weight memory reported by SGLang: 5.701 GiB, consistent with
  the 6.028 GB packed checkpoint and not a full BF16 expansion.
- Local OpenBookQA generative sanity: validation 0:100 = 85/100, 100:200 =
  80/100, zero unparsed answers. This is not an official lm-eval comparison.

## Performance observations

Representative warm operator ratios versus PyTorch BF16 GEMM on the R9700:

| M | N | K | NVFP4 / BF16 latency |
| ---: | ---: | ---: | ---: |
| 1 | 4096 | 4096 | 1.0--1.3x |
| 1 | 28672 | 4096 | 1.0--1.2x |
| 6 | 4096 | 4096 | 0.8--1.5x |
| 64 | 4096 | 4096 | 1.6--1.7x |
| 512 | 4096 | 4096 | about 2.3--2.6x |
| 2048 | 4096 | 4096 | about 2.7x |
| 64 | 4096 | 14336 | 0.7x |

A disjoint warm 100-question OpenBookQA batch took 1.482 s (67.47
questions/s). The first engine batch took 129.280 s, but an isolated manifest
showed that all BF16/FP16 small/large NVFP4 prefill variants compile and run in
3.075 s with a fresh cache and 0.944 s from a new container reusing that cache.
The engine-wide cold figure must not be attributed to NVFP4. Deployments should
retain the Triton cache and warm decode/prefill before traffic. The PR does not
claim native FP4 arithmetic or universal speedup over BF16. Generated AMDGCN
contains `v_wmma_f32_16x16x16_bf16` and `v_wmma_f32_16x16x16_f16`, confirming
that prefill uses RDNA4 matrix instructions after software E2M1 decode.

## Compatibility

- CUDA flagless ModelOpt NVFP4 remains `modelopt_fp4`.
- Existing ROCm MI250/MI300X/MI325X remains on Petit and retains its repack and
  scale-processing calls.
- Exact gfx1201 does not import Petit and fails explicitly for unsupported
  dtypes, layouts, dimensions, or devices.
- Local end-to-end proof used Aiter for auxiliary ops because the installed
  AOT package targets gfx942. This caveat is separate from NVFP4 numerics.

## Checks

Final branch base: `sgl-project/sglang@43b5a57dbb`.

```bash
# Inside the pinned ROCm 7.2 container on the exact gfx1201 device:
python3 -m pytest -q \
  test/registered/quant/test_quant_config_parsing.py \
  test/registered/unit/layers/quantization/test_modelopt_nvfp4.py \
  test/registered/unit/layers/quantization/test_petit_nvfp4_backends.py \
  test/registered/unit/layers/test_rdna4_rope_fallback.py \
  test/manual/quant/test_rdna4_nvfp4.py

pre-commit run --files <all changed files>
cd docs && npx -y mint@4.2.559 broken-links \
  --check-anchors --check-redirects
cd docs && npx -y mint@4.2.559 validate
git diff --check
```

Results: environment PASS; focused tests 43 passed plus 10 subtests, no skips;
pre-commit PASS; Mintlify links/build PASS; diff check PASS.

## Review questions

1. Is the measured large-M latency ratio acceptable for first-pass gfx1201
   support given the resident-memory benefit and decode/small-prefill results?
2. Should the exact-gfx1201 native RoPE guard remain in this patch or be split
   into an AMD platform compatibility PR?
3. Is a manual fail-closed R9700 suite preferable until upstream has a
   registered gfx1201 runner?

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33151266118](https://github.com/sgl-project/sglang/actions/runs/33151266118)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33151265956](https://github.com/sgl-project/sglang/actions/runs/33151265956)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33151266061](https://github.com/sgl-project/sglang/actions/runs/33151266061)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->