### PR TITLE
[AMD] Add packed DCP C4 top-k ROCm kernels

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
@@ -1,0 +1,386 @@
+#include "topk_v1.cuh"
+
+namespace sglang {
+
+struct DCPTopKCandidateParams {
+  const float* __restrict__ scores;
+  const int32_t* __restrict__ local_lens;
+  int64_t* __restrict__ candidates;
+  int64_t score_stride;
+  uint32_t topk;
+  uint32_t dcp_size;
+  uint32_t dcp_rank;
+};
+
+struct DCPTopKMergeParams {
+  const int64_t* __restrict__ candidates;
+  const int32_t* __restrict__ local_page_table;
+  int32_t* __restrict__ page_indices;
+  int32_t* __restrict__ local_raw_indices;
+  int32_t* __restrict__ local_lens;
+  int64_t page_table_stride;
+  uint32_t batch_size;
+  uint32_t page_bits;
+  uint32_t topk;
+  uint32_t dcp_rank;
+};
+
+SGL_DEVICE int64_t pack_dcp_candidate(float score, int32_t global_index) {
+  const uint64_t score_bits = static_cast<uint64_t>(__float_as_uint(score));
+  const uint64_t index_bits = static_cast<uint32_t>(global_index);
+  return static_cast<int64_t>((score_bits << 32) | index_bits);
+}
+
+SGL_DEVICE float unpack_dcp_candidate_score(int64_t candidate) {
+  return __uint_as_float(static_cast<uint64_t>(candidate) >> 32);
+}
+
+SGL_DEVICE int32_t unpack_dcp_candidate_index(int64_t candidate) {
+  return static_cast<int32_t>(static_cast<uint32_t>(candidate));
+}
+
+SGL_DEVICE float canonicalize_dcp_score(float score) {
+  if (score != score) return __uint_as_float(0xff800000u);
+  return score == 0.0f ? 0.0f : score;
+}
+
+SGL_DEVICE uint32_t ordered_dcp_score(float score) {
+  return convert_to_uint32(canonicalize_dcp_score(score));
+}
+
+template <bool kUsePDL>
+__global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandidateParams params) {
+  const uint32_t batch_idx = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t local_len = params.local_lens[batch_idx];
+  const auto score_ptr = params.scores + batch_idx * params.score_stride;
+  const auto candidate_ptr = params.candidates + batch_idx * params.topk;
+
+  device::PDLWaitPrimary<kUsePDL>();
+
+  __shared__ int32_t selected[kMaxTopK];
+  __shared__ uint32_t threshold_key;
+  __shared__ uint32_t output_count;
+  __shared__ uint32_t tile_base;
+
+  if (tx < params.topk) {
+    candidate_ptr[tx] = pack_dcp_candidate(__uint_as_float(0xff800000u), -1);
+  }
+
+  if (local_len <= params.topk) {
+    if (tx < local_len) {
+      const int32_t global_index = static_cast<int32_t>(tx * params.dcp_size + params.dcp_rank);
+      candidate_ptr[tx] = pack_dcp_candidate(canonicalize_dcp_score(score_ptr[tx]), global_index);
+    }
+    device::PDLTriggerSecondary<kUsePDL>();
+    return;
+  }
+
+  radix_topk(score_ptr, selected, local_len, params.topk);
+  if (tx == 0) {
+    threshold_key = 0xffffffffu;
+    output_count = 0;
+  }
+  __syncthreads();
+
+  if (tx < params.topk) {
+    atomicMin(&threshold_key, ordered_dcp_score(score_ptr[selected[tx]]));
+  }
+  __syncthreads();
+
+  for (uint32_t local_index = tx; local_index < local_len; local_index += kTopKBlockSize) {
+    const float score = canonicalize_dcp_score(score_ptr[local_index]);
+    if (ordered_dcp_score(score) > threshold_key) {
+      const uint32_t output_pos = atomicAdd(&output_count, 1u);
+      const int32_t global_index =
+          static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
+      candidate_ptr[output_pos] = pack_dcp_candidate(score, global_index);
+    }
+  }
+  __syncthreads();
+
+  for (uint32_t tile_start = 0; tile_start < local_len; tile_start += kTopKBlockSize) {
+    if (output_count >= params.topk) break;
+    const uint32_t local_index = tile_start + tx;
+    const bool is_threshold =
+        local_index < local_len && ordered_dcp_score(score_ptr[local_index]) == threshold_key;
+    selected[tx] = is_threshold ? 1 : 0;
+    if (tx == 0) tile_base = output_count;
+    __syncthreads();
+
+    for (uint32_t offset = 1; offset < kTopKBlockSize; offset <<= 1) {
+      const int32_t addend = tx >= offset ? selected[tx - offset] : 0;
+      __syncthreads();
+      if (tx >= offset) selected[tx] += addend;
+      __syncthreads();
+    }
+
+    const uint32_t position = tile_base + static_cast<uint32_t>(selected[tx]);
+    if (is_threshold && position <= params.topk) {
+      const int32_t global_index =
+          static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
+      candidate_ptr[position - 1] =
+          pack_dcp_candidate(canonicalize_dcp_score(score_ptr[local_index]), global_index);
+    }
+    __syncthreads();
+    if (tx == 0) {
+      output_count = min(params.topk, tile_base + static_cast<uint32_t>(selected[kTopKBlockSize - 1]));
+    }
+    __syncthreads();
+  }
+
+  device::PDLTriggerSecondary<kUsePDL>();
+}
+
+template <bool kUsePDL, uint32_t kDCPSize>
+__global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams params) {
+  static_assert(kDCPSize == 2 || kDCPSize == 4 || kDCPSize == 8);
+  constexpr uint32_t kMaxCandidateCount = kDCPSize * kMaxTopK;
+
+  const uint32_t batch_idx = blockIdx.x;
+  const uint32_t tx = threadIdx.x;
+  const uint32_t candidate_count = kDCPSize * params.topk;
+  const auto page_table = params.local_page_table + batch_idx * params.page_table_stride;
+  const auto page_indices = params.page_indices + batch_idx * params.topk;
+  const auto local_raw_indices =
+      params.local_raw_indices != nullptr ? params.local_raw_indices + batch_idx * params.topk : nullptr;
+
+  __shared__ float candidate_scores[kMaxCandidateCount];
+  __shared__ int32_t candidate_indices[kMaxCandidateCount];
+  __shared__ int32_t selected[kMaxTopK];
+  __shared__ uint32_t valid_count;
+  __shared__ uint32_t output_count;
+  __shared__ uint32_t threshold_key;
+  __shared__ uint32_t greater_count;
+  __shared__ uint32_t tie_count;
+
+  device::PDLWaitPrimary<kUsePDL>();
+
+  if (tx == 0) {
+    valid_count = 0;
+    output_count = 0;
+    threshold_key = 0xffffffffu;
+    greater_count = 0;
+    tie_count = 0;
+  }
+  if (tx < params.topk) {
+    page_indices[tx] = -1;
+    if (local_raw_indices != nullptr) {
+      local_raw_indices[tx] = -1;
+    }
+  }
+
+  for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
+    const uint32_t source_rank = candidate_id / params.topk;
+    const uint32_t local_id = candidate_id - source_rank * params.topk;
+    const int64_t candidate =
+        params.candidates[(source_rank * params.batch_size + batch_idx) * params.topk + local_id];
+    const int32_t global_index = unpack_dcp_candidate_index(candidate);
+    candidate_scores[candidate_id] = canonicalize_dcp_score(unpack_dcp_candidate_score(candidate));
+    candidate_indices[candidate_id] = global_index;
+    if (global_index >= 0) {
+      atomicAdd(&valid_count, 1u);
+    }
+  }
+  __syncthreads();
+
+  if (valid_count > params.topk) {
+    radix_topk(candidate_scores, selected, candidate_count, params.topk);
+    __syncthreads();
+
+    if (tx < params.topk) {
+      atomicMin(&threshold_key, ordered_dcp_score(candidate_scores[selected[tx]]));
+    }
+    __syncthreads();
+
+    for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
+      const int32_t global_index = candidate_indices[candidate_id];
+      const uint32_t score_key = ordered_dcp_score(candidate_scores[candidate_id]);
+      if (global_index >= 0 && score_key > threshold_key) {
+        atomicAdd(&greater_count, 1u);
+        if (static_cast<uint32_t>(global_index) % kDCPSize == params.dcp_rank) {
+          const uint32_t output_pos = atomicAdd(&output_count, 1u);
+          const uint32_t local_raw = static_cast<uint32_t>(global_index) / kDCPSize;
+          page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
+          if (local_raw_indices != nullptr) {
+            local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
+          }
+        }
+      }
+    }
+    __syncthreads();
+
+    if (tx == 0) {
+      tie_count = params.topk - greater_count;
+    }
+    for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
+      const int32_t global_index = candidate_indices[candidate_id];
+      const bool is_threshold =
+          global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key;
+      candidate_scores[candidate_id] =
+          is_threshold ? -static_cast<float>(global_index) : __uint_as_float(0xff800000u);
+    }
+    __syncthreads();
+
+    if (tie_count > 0) {
+      radix_topk(candidate_scores, selected, candidate_count, tie_count);
+      __syncthreads();
+      if (tx < tie_count) {
+        const int32_t global_index = candidate_indices[selected[tx]];
+        if (static_cast<uint32_t>(global_index) % kDCPSize == params.dcp_rank) {
+          const uint32_t output_pos = atomicAdd(&output_count, 1u);
+          const uint32_t local_raw = static_cast<uint32_t>(global_index) / kDCPSize;
+          page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
+          if (local_raw_indices != nullptr) {
+            local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
+          }
+        }
+      }
+    }
+  } else {
+    for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
+      const int32_t global_index = candidate_indices[candidate_id];
+      if (global_index >= 0 && static_cast<uint32_t>(global_index) % kDCPSize == params.dcp_rank) {
+        const uint32_t output_pos = atomicAdd(&output_count, 1u);
+        const uint32_t local_raw = static_cast<uint32_t>(global_index) / kDCPSize;
+        page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
+        if (local_raw_indices != nullptr) {
+          local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
+        }
+      }
+    }
+  }
+  __syncthreads();
+
+  if (tx == 0) {
+    params.local_lens[batch_idx] = static_cast<int32_t>(output_count);
+  }
+
+  device::PDLTriggerSecondary<kUsePDL>();
+}
+
+template <bool kUsePDL>
+struct DCPTopKKernel {
+  static constexpr auto candidate_kernel = dcp_topk_candidates_kernel<kUsePDL>;
+
+  static void candidates(
+      const tvm::ffi::TensorView scores,
+      const tvm::ffi::TensorView local_lens,
+      const tvm::ffi::TensorView candidates,
+      const uint32_t dcp_size,
+      const uint32_t dcp_rank) {
+    using namespace host;
+    auto B = SymbolicSize{"batch_size"};
+    auto S = SymbolicSize{"score_stride"};
+    auto K = SymbolicSize{"topk"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLGPU>();
+
+    TensorMatcher({B, -1})
+        .with_strides({S, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(scores);
+    TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(local_lens);
+    TensorMatcher({B, K}).with_dtype<int64_t>().with_device(device).verify(candidates);
+
+    const auto topk = static_cast<uint32_t>(K.unwrap());
+    RuntimeCheck(topk > 0 && topk <= kMaxTopK, "topk must be in (0, 1024]");
+    RuntimeCheck(dcp_size == 2 || dcp_size == 4 || dcp_size == 8, "dcp_size must be in {2, 4, 8}");
+    RuntimeCheck(dcp_rank < dcp_size, "dcp_rank must be smaller than dcp_size");
+
+    const auto params = DCPTopKCandidateParams{
+        .scores = static_cast<const float*>(scores.data_ptr()),
+        .local_lens = static_cast<const int32_t*>(local_lens.data_ptr()),
+        .candidates = static_cast<int64_t*>(candidates.data_ptr()),
+        .score_stride = S.unwrap(),
+        .topk = topk,
+        .dcp_size = dcp_size,
+        .dcp_rank = dcp_rank,
+    };
+    constexpr auto kDynamicSMEM = kSMEM + sizeof(int32_t);
+    setup_kernel_smem_once<candidate_kernel, kDynamicSMEM>();
+    LaunchKernel(B.unwrap(), kTopKBlockSize, device.unwrap(), kDynamicSMEM)
+        .enable_pdl(kUsePDL)(candidate_kernel, params);
+  }
+
+  template <uint32_t kDCPSize>
+  static void launch_merge(
+      const DCPTopKMergeParams& params, uint32_t batch_size, DLDevice device) {
+    constexpr auto kernel = dcp_topk_merge_kernel<kUsePDL, kDCPSize>;
+    constexpr auto kDynamicSMEM = kSMEM + sizeof(int32_t);
+    setup_kernel_smem_once<kernel, kDynamicSMEM>();
+    host::LaunchKernel(batch_size, kTopKBlockSize, device, kDynamicSMEM)
+        .enable_pdl(kUsePDL)(kernel, params);
+  }
+
+  static void merge(
+      const tvm::ffi::TensorView candidates,
+      const tvm::ffi::TensorView local_page_table,
+      const tvm::ffi::TensorView page_indices,
+      const tvm::ffi::TensorView local_lens,
+      const uint32_t page_size,
+      const uint32_t dcp_size,
+      const uint32_t dcp_rank,
+      const tvm::ffi::Optional<tvm::ffi::TensorView> local_raw_indices) {
+    using namespace host;
+    auto C = SymbolicSize{"candidate_rows"};
+    auto B = SymbolicSize{"batch_size"};
+    auto P = SymbolicSize{"page_table_stride"};
+    auto K = SymbolicSize{"topk"};
+    auto device = SymbolicDevice{};
+    device.set_options<kDLGPU>();
+
+    TensorMatcher({C, K}).with_dtype<int64_t>().with_device(device).verify(candidates);
+    TensorMatcher({B, -1})
+        .with_strides({P, 1})
+        .with_dtype<int32_t>()
+        .with_device(device)
+        .verify(local_page_table);
+    TensorMatcher({B, K}).with_dtype<int32_t>().with_device(device).verify(page_indices);
+    TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(local_lens);
+
+    int32_t* local_raw_ptr = nullptr;
+    if (local_raw_indices.has_value()) {
+      TensorMatcher({B, K}).with_dtype<int32_t>().with_device(device).verify(local_raw_indices.value());
+      local_raw_ptr = static_cast<int32_t*>(local_raw_indices.value().data_ptr());
+    }
+
+    const auto batch_size = static_cast<uint32_t>(B.unwrap());
+    const auto topk = static_cast<uint32_t>(K.unwrap());
+    RuntimeCheck(topk > 0 && topk <= kMaxTopK, "topk must be in (0, 1024]");
+    RuntimeCheck(C.unwrap() == B.unwrap() * dcp_size, "candidate rows must equal batch_size * dcp_size");
+    RuntimeCheck(std::has_single_bit(page_size), "page_size must be power of 2");
+    RuntimeCheck(dcp_size == 2 || dcp_size == 4 || dcp_size == 8, "dcp_size must be in {2, 4, 8}");
+    RuntimeCheck(dcp_rank < dcp_size, "dcp_rank must be smaller than dcp_size");
+
+    const auto params = DCPTopKMergeParams{
+        .candidates = static_cast<const int64_t*>(candidates.data_ptr()),
+        .local_page_table = static_cast<const int32_t*>(local_page_table.data_ptr()),
+        .page_indices = static_cast<int32_t*>(page_indices.data_ptr()),
+        .local_raw_indices = local_raw_ptr,
+        .local_lens = static_cast<int32_t*>(local_lens.data_ptr()),
+        .page_table_stride = P.unwrap(),
+        .batch_size = batch_size,
+        .page_bits = static_cast<uint32_t>(std::countr_zero(page_size)),
+        .topk = topk,
+        .dcp_rank = dcp_rank,
+    };
+
+    switch (dcp_size) {
+      case 2:
+        launch_merge<2>(params, batch_size, device.unwrap());
+        break;
+      case 4:
+        launch_merge<4>(params, batch_size, device.unwrap());
+        break;
+      case 8:
+        launch_merge<8>(params, batch_size, device.unwrap());
+        break;
+      default:
+        host::RuntimeCheck(false, "Unsupported dcp_size=", dcp_size);
+    }
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
@@ -7,6 +7,7 @@ struct DCPTopKCandidateParams {
   const int32_t* __restrict__ local_lens;
   int64_t* __restrict__ candidates;
   int64_t score_stride;
+  uint32_t score_width;
   uint32_t topk;
   uint32_t dcp_size;
   uint32_t dcp_rank;
@@ -52,7 +53,7 @@ template <bool kUsePDL>
 __global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandidateParams params) {
   const uint32_t batch_idx = blockIdx.x;
   const uint32_t tx = threadIdx.x;
-  const uint32_t local_len = params.local_lens[batch_idx];
+  const uint32_t local_len = min(static_cast<uint32_t>(params.local_lens[batch_idx]), params.score_width);
   const auto score_ptr = params.scores + batch_idx * params.score_stride;
   const auto candidate_ptr = params.candidates + batch_idx * params.topk;
 
@@ -62,6 +63,10 @@ __global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandid
   __shared__ uint32_t threshold_key;
   __shared__ uint32_t output_count;
   __shared__ uint32_t tile_base;
+  __shared__ uint32_t radix_prefix;
+  __shared__ uint32_t radix_mask;
+  __shared__ uint32_t radix_remaining;
+  __shared__ uint32_t radix_bin;
 
   if (tx < params.topk) {
     candidate_ptr[tx] = pack_dcp_candidate(__uint_as_float(0xff800000u), -1);
@@ -76,24 +81,118 @@ __global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandid
     return;
   }
 
-  radix_topk(score_ptr, selected, local_len, params.topk);
-  if (tx == 0) {
-    threshold_key = 0xffffffffu;
-    output_count = 0;
-  }
-  __syncthreads();
+  const bool radix_scratch_overflow = radix_topk(score_ptr, selected, local_len, params.topk, true);
+  if (!radix_scratch_overflow) {
+    if (tx == 0) {
+      threshold_key = 0xffffffffu;
+      output_count = 0;
+    }
+    __syncthreads();
 
-  if (tx < params.topk) {
-    atomicMin(&threshold_key, ordered_dcp_score(score_ptr[selected[tx]]));
+    if (tx < params.topk) {
+      atomicMin(&threshold_key, ordered_dcp_score(score_ptr[selected[tx]]));
+    }
+    __syncthreads();
+  } else {
+    // topk_v1 reports when its fixed index scratch clipped a dense coarse
+    // bucket. Select the exact 32-bit threshold with four bounded histogram
+    // passes only for those score distributions; wide rows that fit the fast
+    // path keep its lower latency.
+    constexpr uint32_t kRadix = 256;
+    constexpr uint32_t kHistogramStride = kRadix + 32;
+    constexpr uint32_t kWaveSize = 64;
+    constexpr uint32_t kWaveCount = kTopKBlockSize / kWaveSize;
+    auto* histogram_0 = reinterpret_cast<uint32_t*>(selected);
+    auto* histogram_1 = histogram_0 + kHistogramStride;
+    extern __shared__ uint32_t dynamic_smem[];
+    auto* wave_histograms = dynamic_smem;
+
+    if (tx == 0) {
+      radix_prefix = 0;
+      radix_mask = 0;
+      radix_remaining = params.topk;
+    }
+    __syncthreads();
+
+#pragma unroll
+    for (int32_t shift = 24; shift >= 0; shift -= 8) {
+      for (uint32_t index = tx; index < kWaveCount * kRadix; index += kTopKBlockSize) {
+        wave_histograms[index] = 0;
+      }
+      __syncthreads();
+
+      const uint32_t prefix = radix_prefix;
+      const uint32_t mask = radix_mask;
+      const uint32_t wave_id = tx / kWaveSize;
+      uint32_t pending_bin = 0;
+      uint32_t pending_count = 0;
+      for (uint32_t local_index = tx; local_index < local_len; local_index += kTopKBlockSize) {
+        const uint32_t key = ordered_dcp_score(score_ptr[local_index]);
+        if ((key & mask) == prefix) {
+          const uint32_t bin = (key >> shift) & 0xffu;
+          if (pending_count != 0 && bin != pending_bin) {
+            atomicAdd(&wave_histograms[wave_id * kRadix + pending_bin], pending_count);
+            pending_count = 0;
+          }
+          pending_bin = bin;
+          ++pending_count;
+        }
+      }
+      if (pending_count != 0) {
+        atomicAdd(&wave_histograms[wave_id * kRadix + pending_bin], pending_count);
+      }
+      __syncthreads();
+
+      if (tx < kRadix) {
+        uint32_t count = 0;
+#pragma unroll
+        for (uint32_t wave = 0; wave < kWaveCount; ++wave) {
+          count += wave_histograms[wave * kRadix + tx];
+        }
+        histogram_0[tx] = count;
+      } else if (tx == kRadix) {
+        histogram_0[kRadix] = 0;
+      }
+      __syncthreads();
+
+#pragma unroll
+      for (int32_t level = 0; level < 8; ++level) {
+        const int32_t offset = 1 << level;
+        auto* input_histogram = level & 1 ? histogram_1 : histogram_0;
+        auto* output_histogram = level & 1 ? histogram_0 : histogram_1;
+        if (tx < kRadix) {
+          output_histogram[tx] = input_histogram[tx] + (tx + offset < kRadix ? input_histogram[tx + offset] : 0u);
+        }
+        __syncthreads();
+      }
+
+      if (tx < kRadix && histogram_0[tx] >= radix_remaining && histogram_0[tx + 1] < radix_remaining) {
+        radix_bin = tx;
+      }
+      __syncthreads();
+      if (tx == 0) {
+        radix_remaining -= histogram_0[radix_bin + 1];
+        radix_prefix |= radix_bin << shift;
+        radix_mask |= 0xffu << shift;
+      }
+      __syncthreads();
+    }
+
+    if (tx == 0) {
+      threshold_key = radix_prefix;
+      output_count = 0;
+    }
+    __syncthreads();
   }
-  __syncthreads();
 
   for (uint32_t local_index = tx; local_index < local_len; local_index += kTopKBlockSize) {
     const float score = canonicalize_dcp_score(score_ptr[local_index]);
     if (ordered_dcp_score(score) > threshold_key) {
       const uint32_t output_pos = atomicAdd(&output_count, 1u);
-      const int32_t global_index = static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
-      candidate_ptr[output_pos] = pack_dcp_candidate(score, global_index);
+      if (output_pos < params.topk) {
+        const int32_t global_index = static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
+        candidate_ptr[output_pos] = pack_dcp_candidate(score, global_index);
+      }
     }
   }
   __syncthreads();
@@ -144,20 +243,20 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
   __shared__ float candidate_scores[kMaxCandidateCount];
   __shared__ int32_t candidate_indices[kMaxCandidateCount];
   __shared__ int32_t selected[kMaxTopK];
-  __shared__ uint32_t valid_count;
   __shared__ uint32_t output_count;
   __shared__ uint32_t threshold_key;
   __shared__ uint32_t greater_count;
+  __shared__ uint32_t threshold_valid_count;
   __shared__ uint32_t tie_count;
   __shared__ uint32_t tie_min_index;
 
   device::PDLWaitPrimary<kUsePDL>();
 
   if (tx == 0) {
-    valid_count = 0;
     output_count = 0;
     threshold_key = 0xffffffffu;
     greater_count = 0;
+    threshold_valid_count = 0;
     tie_count = 0;
     tie_min_index = 0xffffffffu;
   }
@@ -175,26 +274,25 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
     const int32_t global_index = unpack_dcp_candidate_index(candidate);
     candidate_scores[candidate_id] = canonicalize_dcp_score(unpack_dcp_candidate_score(candidate));
     candidate_indices[candidate_id] = global_index;
-    if (global_index >= 0) {
-      atomicAdd(&valid_count, 1u);
-    }
   }
   __syncthreads();
 
-  if (valid_count > params.topk) {
-    radix_topk(candidate_scores, selected, candidate_count, params.topk);
-    __syncthreads();
+  radix_topk(candidate_scores, selected, candidate_count, params.topk);
+  __syncthreads();
 
-    if (tx < params.topk) {
-      atomicMin(&threshold_key, ordered_dcp_score(candidate_scores[selected[tx]]));
-    }
-    __syncthreads();
+  if (tx < params.topk) {
+    atomicMin(&threshold_key, ordered_dcp_score(candidate_scores[selected[tx]]));
+  }
+  __syncthreads();
 
-    for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
-      const int32_t global_index = candidate_indices[candidate_id];
-      const uint32_t score_key = ordered_dcp_score(candidate_scores[candidate_id]);
-      if (global_index >= 0 && score_key > threshold_key) {
-        atomicAdd(&greater_count, 1u);
+  uint32_t thread_greater_count = 0;
+  uint32_t thread_threshold_valid_count = 0;
+  for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
+    const int32_t global_index = candidate_indices[candidate_id];
+    const uint32_t score_key = ordered_dcp_score(candidate_scores[candidate_id]);
+    if (global_index >= 0) {
+      if (score_key > threshold_key) {
+        ++thread_greater_count;
         if (static_cast<uint32_t>(global_index) % kDCPSize == params.dcp_rank) {
           const uint32_t output_pos = atomicAdd(&output_count, 1u);
           const uint32_t local_raw = static_cast<uint32_t>(global_index) / kDCPSize;
@@ -203,60 +301,55 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
             local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
           }
         }
+      } else if (score_key == threshold_key) {
+        ++thread_threshold_valid_count;
       }
     }
-    __syncthreads();
+  }
+  if (thread_greater_count != 0) {
+    atomicAdd(&greater_count, thread_greater_count);
+  }
+  if (thread_threshold_valid_count != 0) {
+    atomicAdd(&threshold_valid_count, thread_threshold_valid_count);
+  }
+  __syncthreads();
 
-    if (tx == 0) {
-      tie_count = params.topk - greater_count;
-    }
-    __syncthreads();
+  if (tx == 0) {
+    const uint32_t remaining = greater_count < params.topk ? params.topk - greater_count : 0;
+    tie_count = min(remaining, threshold_valid_count);
+  }
+  __syncthreads();
 
-    if (tie_count == 1) {
-      // Random model scores almost always have one item at the top-k boundary.
-      // Avoid a second full radix selection in that common case.
-      for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
-        const int32_t global_index = candidate_indices[candidate_id];
-        if (global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key) {
-          atomicMin(&tie_min_index, static_cast<uint32_t>(global_index));
-        }
-      }
-      __syncthreads();
-      if (tx == 0 && tie_min_index % kDCPSize == params.dcp_rank) {
-        const uint32_t output_pos = atomicAdd(&output_count, 1u);
-        const uint32_t local_raw = tie_min_index / kDCPSize;
-        page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
-        if (local_raw_indices != nullptr) {
-          local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
-        }
-      }
-    } else if (tie_count > 1) {
-      for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
-        const int32_t global_index = candidate_indices[candidate_id];
-        const bool is_threshold =
-            global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key;
-        candidate_scores[candidate_id] =
-            is_threshold ? -static_cast<float>(global_index) : __uint_as_float(0xff800000u);
-      }
-      __syncthreads();
-      radix_topk(candidate_scores, selected, candidate_count, tie_count);
-      __syncthreads();
-      if (tx < tie_count) {
-        const int32_t global_index = candidate_indices[selected[tx]];
-        if (static_cast<uint32_t>(global_index) % kDCPSize == params.dcp_rank) {
-          const uint32_t output_pos = atomicAdd(&output_count, 1u);
-          const uint32_t local_raw = static_cast<uint32_t>(global_index) / kDCPSize;
-          page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
-          if (local_raw_indices != nullptr) {
-            local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
-          }
-        }
-      }
-    }
-  } else {
+  if (tie_count == 1) {
+    // Random model scores almost always have one item at the top-k boundary.
+    // Avoid a second full radix selection in that common case.
     for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
       const int32_t global_index = candidate_indices[candidate_id];
-      if (global_index >= 0 && static_cast<uint32_t>(global_index) % kDCPSize == params.dcp_rank) {
+      if (global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key) {
+        atomicMin(&tie_min_index, static_cast<uint32_t>(global_index));
+      }
+    }
+    __syncthreads();
+    if (tx == 0 && tie_min_index % kDCPSize == params.dcp_rank) {
+      const uint32_t output_pos = atomicAdd(&output_count, 1u);
+      const uint32_t local_raw = tie_min_index / kDCPSize;
+      page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
+      if (local_raw_indices != nullptr) {
+        local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
+      }
+    }
+  } else if (tie_count > 1) {
+    for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
+      const int32_t global_index = candidate_indices[candidate_id];
+      const bool is_threshold = global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key;
+      candidate_scores[candidate_id] = is_threshold ? -static_cast<float>(global_index) : __uint_as_float(0xff800000u);
+    }
+    __syncthreads();
+    radix_topk(candidate_scores, selected, candidate_count, tie_count);
+    __syncthreads();
+    if (tx < tie_count) {
+      const int32_t global_index = candidate_indices[selected[tx]];
+      if (static_cast<uint32_t>(global_index) % kDCPSize == params.dcp_rank) {
         const uint32_t output_pos = atomicAdd(&output_count, 1u);
         const uint32_t local_raw = static_cast<uint32_t>(global_index) / kDCPSize;
         page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
@@ -287,12 +380,13 @@ struct DCPTopKKernel {
       const uint32_t dcp_rank) {
     using namespace host;
     auto B = SymbolicSize{"batch_size"};
+    auto W = SymbolicSize{"score_width"};
     auto S = SymbolicSize{"score_stride"};
     auto K = SymbolicSize{"topk"};
     auto device = SymbolicDevice{};
     device.set_options<kDLGPU>();
 
-    TensorMatcher({B, -1}).with_strides({S, 1}).with_dtype<float>().with_device(device).verify(scores);
+    TensorMatcher({B, W}).with_strides({S, 1}).with_dtype<float>().with_device(device).verify(scores);
     TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(local_lens);
     TensorMatcher({B, K}).with_dtype<int64_t>().with_device(device).verify(candidates);
 
@@ -306,6 +400,7 @@ struct DCPTopKKernel {
         .local_lens = static_cast<const int32_t*>(local_lens.data_ptr()),
         .candidates = static_cast<int64_t*>(candidates.data_ptr()),
         .score_stride = S.unwrap(),
+        .score_width = static_cast<uint32_t>(W.unwrap()),
         .topk = topk,
         .dcp_size = dcp_size,
         .dcp_rank = dcp_rank,

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
@@ -92,8 +92,7 @@ __global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandid
     const float score = canonicalize_dcp_score(score_ptr[local_index]);
     if (ordered_dcp_score(score) > threshold_key) {
       const uint32_t output_pos = atomicAdd(&output_count, 1u);
-      const int32_t global_index =
-          static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
+      const int32_t global_index = static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
       candidate_ptr[output_pos] = pack_dcp_candidate(score, global_index);
     }
   }
@@ -102,8 +101,7 @@ __global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandid
   for (uint32_t tile_start = 0; tile_start < local_len; tile_start += kTopKBlockSize) {
     if (output_count >= params.topk) break;
     const uint32_t local_index = tile_start + tx;
-    const bool is_threshold =
-        local_index < local_len && ordered_dcp_score(score_ptr[local_index]) == threshold_key;
+    const bool is_threshold = local_index < local_len && ordered_dcp_score(score_ptr[local_index]) == threshold_key;
     selected[tx] = is_threshold ? 1 : 0;
     if (tx == 0) tile_base = output_count;
     __syncthreads();
@@ -117,10 +115,8 @@ __global__ void dcp_topk_candidates_kernel(const __grid_constant__ DCPTopKCandid
 
     const uint32_t position = tile_base + static_cast<uint32_t>(selected[tx]);
     if (is_threshold && position <= params.topk) {
-      const int32_t global_index =
-          static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
-      candidate_ptr[position - 1] =
-          pack_dcp_candidate(canonicalize_dcp_score(score_ptr[local_index]), global_index);
+      const int32_t global_index = static_cast<int32_t>(local_index * params.dcp_size + params.dcp_rank);
+      candidate_ptr[position - 1] = pack_dcp_candidate(canonicalize_dcp_score(score_ptr[local_index]), global_index);
     }
     __syncthreads();
     if (tx == 0) {
@@ -175,8 +171,7 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
   for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
     const uint32_t source_rank = candidate_id / params.topk;
     const uint32_t local_id = candidate_id - source_rank * params.topk;
-    const int64_t candidate =
-        params.candidates[(source_rank * params.batch_size + batch_idx) * params.topk + local_id];
+    const int64_t candidate = params.candidates[(source_rank * params.batch_size + batch_idx) * params.topk + local_id];
     const int32_t global_index = unpack_dcp_candidate_index(candidate);
     candidate_scores[candidate_id] = canonicalize_dcp_score(unpack_dcp_candidate_score(candidate));
     candidate_indices[candidate_id] = global_index;
@@ -220,11 +215,9 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
     if (tie_count == 1) {
       // Random model scores almost always have one item at the top-k boundary.
       // Avoid a second full radix selection in that common case.
-      for (uint32_t candidate_id = tx; candidate_id < candidate_count;
-           candidate_id += kTopKBlockSize) {
+      for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
         const int32_t global_index = candidate_indices[candidate_id];
-        if (global_index >= 0 &&
-            ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key) {
+        if (global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key) {
           atomicMin(&tie_min_index, static_cast<uint32_t>(global_index));
         }
       }
@@ -238,8 +231,7 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
         }
       }
     } else if (tie_count > 1) {
-      for (uint32_t candidate_id = tx; candidate_id < candidate_count;
-           candidate_id += kTopKBlockSize) {
+      for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
         const int32_t global_index = candidate_indices[candidate_id];
         const bool is_threshold =
             global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key;
@@ -300,11 +292,7 @@ struct DCPTopKKernel {
     auto device = SymbolicDevice{};
     device.set_options<kDLGPU>();
 
-    TensorMatcher({B, -1})
-        .with_strides({S, 1})
-        .with_dtype<float>()
-        .with_device(device)
-        .verify(scores);
+    TensorMatcher({B, -1}).with_strides({S, 1}).with_dtype<float>().with_device(device).verify(scores);
     TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(local_lens);
     TensorMatcher({B, K}).with_dtype<int64_t>().with_device(device).verify(candidates);
 
@@ -329,13 +317,11 @@ struct DCPTopKKernel {
   }
 
   template <uint32_t kDCPSize>
-  static void launch_merge(
-      const DCPTopKMergeParams& params, uint32_t batch_size, DLDevice device) {
+  static void launch_merge(const DCPTopKMergeParams& params, uint32_t batch_size, DLDevice device) {
     constexpr auto kernel = dcp_topk_merge_kernel<kUsePDL, kDCPSize>;
     constexpr auto kDynamicSMEM = kSMEM + sizeof(int32_t);
     setup_kernel_smem_once<kernel, kDynamicSMEM>();
-    host::LaunchKernel(batch_size, kTopKBlockSize, device, kDynamicSMEM)
-        .enable_pdl(kUsePDL)(kernel, params);
+    host::LaunchKernel(batch_size, kTopKBlockSize, device, kDynamicSMEM).enable_pdl(kUsePDL)(kernel, params);
   }
 
   static void merge(
@@ -356,11 +342,7 @@ struct DCPTopKKernel {
     device.set_options<kDLGPU>();
 
     TensorMatcher({C, K}).with_dtype<int64_t>().with_device(device).verify(candidates);
-    TensorMatcher({B, -1})
-        .with_strides({P, 1})
-        .with_dtype<int32_t>()
-        .with_device(device)
-        .verify(local_page_table);
+    TensorMatcher({B, -1}).with_strides({P, 1}).with_dtype<int32_t>().with_device(device).verify(local_page_table);
     TensorMatcher({B, K}).with_dtype<int32_t>().with_device(device).verify(page_indices);
     TensorMatcher({B}).with_dtype<int32_t>().with_device(device).verify(local_lens);
 

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/dcp_topk.cuh
@@ -153,6 +153,7 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
   __shared__ uint32_t threshold_key;
   __shared__ uint32_t greater_count;
   __shared__ uint32_t tie_count;
+  __shared__ uint32_t tie_min_index;
 
   device::PDLWaitPrimary<kUsePDL>();
 
@@ -162,6 +163,7 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
     threshold_key = 0xffffffffu;
     greater_count = 0;
     tie_count = 0;
+    tie_min_index = 0xffffffffu;
   }
   if (tx < params.topk) {
     page_indices[tx] = -1;
@@ -213,16 +215,38 @@ __global__ void dcp_topk_merge_kernel(const __grid_constant__ DCPTopKMergeParams
     if (tx == 0) {
       tie_count = params.topk - greater_count;
     }
-    for (uint32_t candidate_id = tx; candidate_id < candidate_count; candidate_id += kTopKBlockSize) {
-      const int32_t global_index = candidate_indices[candidate_id];
-      const bool is_threshold =
-          global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key;
-      candidate_scores[candidate_id] =
-          is_threshold ? -static_cast<float>(global_index) : __uint_as_float(0xff800000u);
-    }
     __syncthreads();
 
-    if (tie_count > 0) {
+    if (tie_count == 1) {
+      // Random model scores almost always have one item at the top-k boundary.
+      // Avoid a second full radix selection in that common case.
+      for (uint32_t candidate_id = tx; candidate_id < candidate_count;
+           candidate_id += kTopKBlockSize) {
+        const int32_t global_index = candidate_indices[candidate_id];
+        if (global_index >= 0 &&
+            ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key) {
+          atomicMin(&tie_min_index, static_cast<uint32_t>(global_index));
+        }
+      }
+      __syncthreads();
+      if (tx == 0 && tie_min_index % kDCPSize == params.dcp_rank) {
+        const uint32_t output_pos = atomicAdd(&output_count, 1u);
+        const uint32_t local_raw = tie_min_index / kDCPSize;
+        page_indices[output_pos] = page_to_indices(page_table, local_raw, params.page_bits);
+        if (local_raw_indices != nullptr) {
+          local_raw_indices[output_pos] = static_cast<int32_t>(local_raw);
+        }
+      }
+    } else if (tie_count > 1) {
+      for (uint32_t candidate_id = tx; candidate_id < candidate_count;
+           candidate_id += kTopKBlockSize) {
+        const int32_t global_index = candidate_indices[candidate_id];
+        const bool is_threshold =
+            global_index >= 0 && ordered_dcp_score(candidate_scores[candidate_id]) == threshold_key;
+        candidate_scores[candidate_id] =
+            is_threshold ? -static_cast<float>(global_index) : __uint_as_float(0xff800000u);
+      }
+      __syncthreads();
       radix_topk(candidate_scores, selected, candidate_count, tie_count);
       __syncthreads();
       if (tx < tie_count) {

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v1.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v1.cuh
@@ -78,8 +78,12 @@ SGL_DEVICE void naive_transform(
 }
 
 [[maybe_unused]]
-SGL_DEVICE void
-radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const uint32_t length, const uint32_t topk) {
+SGL_DEVICE bool radix_topk(
+    const float* __restrict__ input,
+    int32_t* __restrict__ output,
+    const uint32_t length,
+    const uint32_t topk,
+    const bool stop_on_scratch_overflow = false) {
   constexpr uint32_t RADIX = 256;
   constexpr uint32_t BLOCK_SIZE = kTopKBlockSize;
   constexpr uint32_t SMEM_INPUT_SIZE = kSMEM / (2 * sizeof(int32_t));
@@ -130,6 +134,7 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
   __syncthreads();
 
   const auto threshold_bin = s_threshold_bin_id;
+  const bool scratch_overflow = s_histogram[threshold_bin] - s_histogram[threshold_bin + 1] > SMEM_INPUT_SIZE;
   remain_topk -= s_histogram[threshold_bin + 1];
   if (remain_topk == 0) {
     for (uint32_t idx = tx; idx < length; idx += BLOCK_SIZE) {
@@ -140,7 +145,9 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
       }
     }
     __syncthreads();
-    return;
+    return false;
+  } else if (scratch_overflow && stop_on_scratch_overflow) {
+    return true;
   } else {
     __syncthreads();
     if (tx < RADIX + 1) {
@@ -234,6 +241,7 @@ radix_topk(const float* __restrict__ input, int32_t* __restrict__ output, const 
       __syncthreads();
     }
   }
+  return scratch_overflow;
 }
 
 template <bool kUsePDL>

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v1.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/topk_v1.cuh
@@ -275,7 +275,11 @@ void setup_kernel_smem_once(host::DebugInfo where = {}) {
   [[maybe_unused]]
   static const auto result = [] {
     const auto fptr = std::bit_cast<const void*>(f);
+#ifdef USE_ROCM
+    return ::hipFuncSetAttribute(fptr, ::hipFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+#else
     return ::cudaFuncSetAttribute(fptr, ::cudaFuncAttributeMaxDynamicSharedMemorySize, kMaxDynamicSMEM);
+#endif
   }();
   host::RuntimeDeviceCheck(result, where);
 }
@@ -297,7 +301,7 @@ struct TopKKernel {
     auto P = SymbolicSize{"page_table_stride"};
     auto K = SymbolicSize{"topk"};
     auto device = SymbolicDevice{};
-    device.set_options<kDLCUDA>();
+    device.set_options<kDLGPU>();
 
     TensorMatcher({B, -1})  // strided scores
         .with_strides({S, 1})

--- a/python/sglang/kernels/ops/attention/dsv4/__init__.py
+++ b/python/sglang/kernels/ops/attention/dsv4/__init__.py
@@ -32,7 +32,13 @@ from .moe import (
     silu_and_mul_contig_post_quant,
     silu_and_mul_masked_post_quant,
 )
-from .topk import plan_topk_v2, topk_transform_512, topk_transform_512_v2
+from .topk import (
+    dcp_topk_candidates,
+    dcp_topk_merge,
+    plan_topk_v2,
+    topk_transform_512,
+    topk_transform_512_v2,
+)
 from .utils import make_name
 
 __all__ = [
@@ -54,6 +60,8 @@ __all__ = [
     "linear_bf16_fp32",
     "get_paged_mqa_logits_metadata",
     "triton_create_paged_compress_data",
+    "dcp_topk_candidates",
+    "dcp_topk_merge",
     "topk_transform_512",
     "topk_transform_512_v2",
     "plan_topk_v2",

--- a/python/sglang/kernels/ops/attention/dsv4/topk.py
+++ b/python/sglang/kernels/ops/attention/dsv4/topk.py
@@ -46,6 +46,62 @@ def _jit_topk_v2_module():
     )
 
 
+@cache_once
+def _jit_dcp_topk_module():
+    args = make_cpp_args(is_arch_support_pdl())
+    return load_jit(
+        make_name("dcp_topk"),
+        *args,
+        cuda_files=["deepseek_v4/dcp_topk.cuh"],
+        cuda_wrappers=[
+            ("dcp_topk_candidates", f"DCPTopKKernel<{args}>::candidates"),
+            ("dcp_topk_merge", f"DCPTopKKernel<{args}>::merge"),
+        ],
+    )
+
+
+def dcp_topk_candidates(
+    scores: torch.Tensor,
+    local_lens: torch.Tensor,
+    out_candidates: torch.Tensor,
+    dcp_size: int,
+    dcp_rank: int,
+) -> None:
+    if not is_hip_runtime():
+        raise NotImplementedError("The packed DCP C4 candidate kernel requires ROCm")
+    _jit_dcp_topk_module().dcp_topk_candidates(
+        scores,
+        local_lens,
+        out_candidates,
+        dcp_size,
+        dcp_rank,
+    )
+
+
+def dcp_topk_merge(
+    gathered_candidates: torch.Tensor,
+    local_page_table: torch.Tensor,
+    out_page_indices: torch.Tensor,
+    out_local_lens: torch.Tensor,
+    page_size: int,
+    dcp_size: int,
+    dcp_rank: int,
+    out_local_raw_indices: Optional[torch.Tensor] = None,
+) -> None:
+    if not is_hip_runtime():
+        raise NotImplementedError("The packed DCP C4 merge kernel requires ROCm")
+    _jit_dcp_topk_module().dcp_topk_merge(
+        gathered_candidates,
+        local_page_table,
+        out_page_indices,
+        out_local_lens,
+        page_size,
+        dcp_size,
+        dcp_rank,
+        out_local_raw_indices,
+    )
+
+
 def topk_transform_512(
     scores: torch.Tensor,
     seq_lens: torch.Tensor,

--- a/test/registered/kernels/ops/attention/test_dsv4_dcp_packed_topk.py
+++ b/test/registered/kernels/ops/attention/test_dsv4_dcp_packed_topk.py
@@ -1,0 +1,148 @@
+import pytest
+import torch
+
+from sglang.kernels.ops.attention.dsv4 import (
+    dcp_topk_candidates,
+    dcp_topk_merge,
+)
+from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.test.ci.ci_register import register_amd_ci
+
+register_amd_ci(est_time=90, stage="jit-kernel-unit", runner_config="amd")
+
+pytestmark = pytest.mark.skipif(
+    not torch.cuda.is_available() or not is_hip() or not is_gfx95_supported(),
+    reason="Packed DSV4 DCP top-k requires ROCm gfx950",
+)
+
+C4_PAGE_SIZE = 64
+
+
+def _local_lens(global_lens: torch.Tensor, dcp_size: int, rank: int) -> torch.Tensor:
+    return (global_lens // dcp_size + (rank < global_lens % dcp_size)).to(torch.int32)
+
+
+def test_candidate_mapping_uses_compressed_row_owner_order() -> None:
+    candidates = torch.empty((1, 2), dtype=torch.int64, device="cuda")
+    dcp_topk_candidates(
+        torch.tensor([[1.0, 2.0]], device="cuda"),
+        torch.tensor([2], dtype=torch.int32, device="cuda"),
+        candidates,
+        dcp_size=2,
+        dcp_rank=1,
+    )
+    global_indices = candidates.view(torch.int32).reshape(1, 2, 2)[..., 0]
+    torch.testing.assert_close(
+        global_indices,
+        torch.tensor([[1, 3]], dtype=torch.int32, device="cuda"),
+    )
+
+
+@pytest.mark.parametrize("topk", [512, 1024])
+@pytest.mark.parametrize("dcp_size", [2, 4, 8])
+@pytest.mark.parametrize("tied", [False, True])
+def test_packed_dcp_topk_matches_global_score_set(
+    topk: int, dcp_size: int, tied: bool
+) -> None:
+    device = torch.device("cuda")
+    global_lens = torch.tensor(
+        [1, topk - 1, topk, topk + 1, 4 * topk + 3, 8 * topk + 1],
+        dtype=torch.int32,
+        device=device,
+    )
+    batch_size = global_lens.numel()
+    global_width = int(global_lens.max())
+    generator = torch.Generator(device=device).manual_seed(20260828 + topk + dcp_size)
+    if tied:
+        global_scores = torch.zeros(
+            (batch_size, global_width), dtype=torch.float32, device=device
+        )
+    else:
+        global_scores = torch.randn(
+            (batch_size, global_width),
+            dtype=torch.float32,
+            device=device,
+            generator=generator,
+        )
+
+    rank_candidates = []
+    rank_page_tables = []
+    for rank in range(dcp_size):
+        local_scores = global_scores[:, rank::dcp_size].contiguous()
+        local_lens = _local_lens(global_lens, dcp_size, rank)
+        candidates = torch.empty((batch_size, topk), dtype=torch.int64, device=device)
+        dcp_topk_candidates(
+            local_scores,
+            local_lens,
+            candidates,
+            dcp_size,
+            rank,
+        )
+        rank_candidates.append(candidates)
+
+        num_pages = (local_scores.shape[1] + C4_PAGE_SIZE - 1) // C4_PAGE_SIZE
+        page_table = (
+            torch.arange(num_pages, dtype=torch.int32, device=device)
+            .unsqueeze(0)
+            .expand(batch_size, -1)
+            .clone()
+        )
+        page_table += (
+            rank * 10000
+            + torch.arange(batch_size, dtype=torch.int32, device=device).unsqueeze(1)
+            * 100
+        )
+        rank_page_tables.append(page_table)
+
+    gathered = torch.cat(rank_candidates, dim=0)
+    per_rank_raw = []
+    for rank in range(dcp_size):
+        page_indices = torch.empty((batch_size, topk), dtype=torch.int32, device=device)
+        local_raw = torch.empty_like(page_indices)
+        local_lens = torch.empty((batch_size,), dtype=torch.int32, device=device)
+        dcp_topk_merge(
+            gathered,
+            rank_page_tables[rank],
+            page_indices,
+            local_lens,
+            C4_PAGE_SIZE,
+            dcp_size,
+            rank,
+            local_raw,
+        )
+        torch.cuda.synchronize()
+
+        for batch_idx in range(batch_size):
+            count = int(local_lens[batch_idx])
+            raw = local_raw[batch_idx, :count].to(torch.int64)
+            expected_pages = (
+                rank_page_tables[rank][batch_idx, raw // C4_PAGE_SIZE] * C4_PAGE_SIZE
+                + raw % C4_PAGE_SIZE
+            ).to(torch.int32)
+            torch.testing.assert_close(page_indices[batch_idx, :count], expected_pages)
+            assert torch.all(page_indices[batch_idx, count:] == -1)
+            assert torch.all(local_raw[batch_idx, count:] == -1)
+        per_rank_raw.append(local_raw)
+
+    for batch_idx, length_tensor in enumerate(global_lens):
+        length = int(length_tensor)
+        selected = []
+        for rank in range(dcp_size):
+            count = int((per_rank_raw[rank][batch_idx] >= 0).sum().item())
+            local_raw = per_rank_raw[rank][batch_idx, :count].to(torch.int64)
+            selected.extend((local_raw * dcp_size + rank).tolist())
+
+        expected_count = min(length, topk)
+        assert len(selected) == expected_count
+        assert len(set(selected)) == expected_count
+        assert all(0 <= index < length for index in selected)
+        if tied:
+            assert set(selected) == set(range(expected_count))
+        elif length <= topk:
+            assert set(selected) == set(range(length))
+        else:
+            actual_scores = torch.sort(global_scores[batch_idx, selected]).values
+            expected_scores = torch.sort(
+                torch.topk(global_scores[batch_idx, :length], topk).values
+            ).values
+            torch.testing.assert_close(actual_scores, expected_scores)

--- a/test/registered/kernels/ops/attention/test_dsv4_dcp_packed_topk.py
+++ b/test/registered/kernels/ops/attention/test_dsv4_dcp_packed_topk.py
@@ -38,6 +38,120 @@ def test_candidate_mapping_uses_compressed_row_owner_order() -> None:
     )
 
 
+def test_candidate_clamps_metadata_length_to_score_width() -> None:
+    candidates = torch.empty((1, 4), dtype=torch.int64, device="cuda")
+    dcp_topk_candidates(
+        torch.tensor([[3.0, 1.0]], device="cuda"),
+        torch.tensor([99], dtype=torch.int32, device="cuda"),
+        candidates,
+        dcp_size=4,
+        dcp_rank=2,
+    )
+    global_indices = candidates.view(torch.int32).reshape(1, 4, 2)[..., 0]
+    torch.testing.assert_close(
+        global_indices,
+        torch.tensor([[2, 6, -1, -1]], dtype=torch.int32, device="cuda"),
+    )
+
+
+@pytest.mark.parametrize("tied", [False, True])
+def test_candidate_large_width_preserves_guard_rows(tied: bool) -> None:
+    batch_size, score_width, topk = 64, 32768, 1024
+    sentinel = 0x123456789ABCDEF
+    storage = torch.full(
+        (batch_size + 2, topk),
+        sentinel,
+        dtype=torch.int64,
+        device="cuda",
+    )
+    candidates = storage[1:-1]
+    scores = (
+        torch.zeros((batch_size, score_width), dtype=torch.float32, device="cuda")
+        if tied
+        else torch.randn((batch_size, score_width), dtype=torch.float32, device="cuda")
+    )
+    dcp_topk_candidates(
+        scores,
+        torch.full((batch_size,), score_width, dtype=torch.int32, device="cuda"),
+        candidates,
+        dcp_size=4,
+        dcp_rank=3,
+    )
+    torch.cuda.synchronize()
+
+    assert torch.all(storage[0] == sentinel)
+    assert torch.all(storage[-1] == sentinel)
+    global_indices = candidates.view(torch.int32).reshape(batch_size, topk, 2)[..., 0]
+    assert torch.all(global_indices >= 0)
+    assert torch.all(global_indices < score_width * 4)
+    assert torch.all(torch.remainder(global_indices, 4) == 3)
+
+
+def test_candidate_large_concentrated_scores_matches_topk() -> None:
+    score_width, topk, dcp_size, dcp_rank = 32768, 1024, 4, 0
+    scores = (
+        1.0
+        + torch.arange(score_width, dtype=torch.float32, device="cuda").unsqueeze(0)
+        * 1.0e-7
+    )
+    candidates = torch.empty((1, topk), dtype=torch.int64, device="cuda")
+    dcp_topk_candidates(
+        scores,
+        torch.tensor([score_width], dtype=torch.int32, device="cuda"),
+        candidates,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
+    )
+    torch.cuda.synchronize()
+
+    global_indices = candidates.view(torch.int32).reshape(1, topk, 2)[0, :, 0]
+    expected = (
+        torch.argsort(scores[0], descending=True, stable=True)[:topk].to(torch.int32)
+        * dcp_size
+        + dcp_rank
+    )
+    torch.testing.assert_close(
+        torch.sort(global_indices).values,
+        torch.sort(expected).values,
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("score_width", [8193, 16384, 32768, 65536])
+def test_candidate_long_random_scores_match_exact_topk(score_width: int) -> None:
+    topk, dcp_size, dcp_rank = 1024, 4, 3
+    generator = torch.Generator(device="cuda").manual_seed(20260828 + score_width)
+    scores = torch.randn(
+        (1, score_width),
+        dtype=torch.float32,
+        device="cuda",
+        generator=generator,
+    )
+    candidates = torch.empty((1, topk), dtype=torch.int64, device="cuda")
+    dcp_topk_candidates(
+        scores,
+        torch.tensor([score_width], dtype=torch.int32, device="cuda"),
+        candidates,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
+    )
+    torch.cuda.synchronize()
+
+    global_indices = candidates.view(torch.int32).reshape(1, topk, 2)[0, :, 0]
+    expected = (
+        torch.argsort(scores[0], descending=True, stable=True)[:topk].to(torch.int32)
+        * dcp_size
+        + dcp_rank
+    )
+    torch.testing.assert_close(
+        torch.sort(global_indices).values,
+        torch.sort(expected).values,
+        rtol=0,
+        atol=0,
+    )
+
+
 @pytest.mark.parametrize("topk", [512, 1024])
 @pytest.mark.parametrize("dcp_size", [2, 4, 8])
 @pytest.mark.parametrize("tied", [False, True])


### PR DESCRIPTION
## Summary

- add gfx950 ROCm JIT kernels for owner-local DCP C4 candidate selection and deterministic global top-k merge
- pack score and global index into one int64 candidate buffer for a single collective payload
- expose focused Python wrappers for candidate generation and rank-local merge
- fast-path the common unique top-k boundary while retaining exact deterministic tie handling
- keep all DCP runtime integration and feature gating out of this PR

## Performance

MI355X, DCP8, top-k 1024:

- merge microbenchmark at the 65K production shape: 27.7 us -> 19.2 us (-31%)
- full-model TPOT with packed C4 + A2A + AITER AG:
  - ISL 8K: 16.03 ms -> 15.75 ms
  - ISL 65K: 16.43 ms -> 16.14 ms
  - ISL 131K: 16.59 ms -> 16.30 ms

## Test plan

- [x] MI355X deterministic tie and compressed-row mapping coverage
- [x] DCP sizes 2, 4, and 8
- [x] top-k 512 and 1024
- [x] `13 passed` on MI355X
- [x] full-model three-repeat validation at ISL 8K, 65K, and 131K
- [ ] AMD CI

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33197334412](https://github.com/sgl-project/sglang/actions/runs/33197334412)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33197333985](https://github.com/sgl-project/sglang/actions/runs/33197333985)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33197334537](https://github.com/sgl-project/sglang/actions/runs/33197334537)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->