### PR TITLE
fix(deps): pin compressed-tensors to 0.18.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
   "av==16.1.0 ; sys_platform == 'linux' and (platform_machine == 'aarch64' or platform_machine == 'arm64' or platform_machine == 'armv7l')",
   "blobfile==3.0.0",
   "build",
-  "compressed-tensors",
+  "compressed-tensors==0.18.0",
   "cuda-python>=13.0",
   # Transitive dep of flashinfer-python, pinned because 1.6.0rc6 shipped no cp310 linux x86_64 wheel.
   "cuda-tile==1.6.0rc5",


### PR DESCRIPTION
## Motivation

SGLang's Base CPU CI installs development dependencies with `--prerelease allow`. The unbounded `compressed-tensors` dependency therefore resolved to `0.18.1a20260827`, which includes the intentional removal of GPTQ group/dynamic activation ordering from [vllm-project/compressed-tensors#840](https://github.com/vllm-project/compressed-tensors/pull/840).

Current SGLang still references `ActivationOrdering.GROUP` in its production compressed-tensors WNA16 scheme and retains coverage for legacy `actorder="group"` configurations. This breaks unrelated PRs during dependency installation and CPU validation:

- [Base-A CPU shard 3: `AttributeError: GROUP`](https://github.com/sgl-project/sglang/actions/runs/33141090594/job/98752121243)
- [Base-A CPU shard 8: `actorder='group' has been removed`](https://github.com/sgl-project/sglang/actions/runs/33141090594/job/98752121328)

## Modification

Pin the primary SGLang package dependency to `compressed-tensors==0.18.0`, the latest stable release that retains `ActivationOrdering.GROUP` and accepts the existing configuration contract.

This is a short-term compatibility pin. A separate follow-up can decide how SGLang should migrate or retire legacy group-actorder checkpoint support before moving to `compressed-tensors>=0.18.1`.

## Validation

- Parsed `python/pyproject.toml` and verified the dependency resolves exactly to `compressed-tensors==0.18.0`.
- Downloaded the published `compressed-tensors==0.18.0` wheel and verified it retains `ActivationOrdering.GROUP`.
- `git diff --check` passes.

Full CI is left to this draft PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33145815123](https://github.com/sgl-project/sglang/actions/runs/33145815123)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33145815055](https://github.com/sgl-project/sglang/actions/runs/33145815055)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33145815122](https://github.com/sgl-project/sglang/actions/runs/33145815122)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->