### PR TITLE
[HiCache] Handle fragmented page-first write-back indices

### DIFF
--- a/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/staged_write_back.cuh
@@ -8,6 +8,40 @@
 
 namespace sglang {
 
+inline bool validate_page_first_destination_indices(
+    const std::vector<tvm::ffi::TensorView>& dst_ptrs,
+    const int64_t* dst_indices_ptr,
+    int64_t num_pages,
+    int64_t page_size) {
+  using namespace host;
+
+  RuntimeCheck(!dst_ptrs.empty(), "HiCache staged write-back: destination tensor list must not be empty");
+  const int64_t dst_token_capacity = dst_ptrs.front().shape()[0];
+  for (const auto tensor_id : irange(dst_ptrs.size())) {
+    RuntimeCheck(
+        dst_ptrs[tensor_id].shape()[0] == dst_token_capacity,
+        "HiCache staged write-back: destination tensors must have the same token capacity");
+  }
+
+  bool all_pages_contiguous = true;
+  for (const auto page_offset : irange(num_pages)) {
+    const int64_t token_begin = page_offset * page_size;
+    const int64_t first_dst_index = dst_indices_ptr[token_begin];
+    for (const auto token_offset : irange(page_size)) {
+      const int64_t dst_index = dst_indices_ptr[token_begin + token_offset];
+      RuntimeCheck(
+          dst_index >= 0 && dst_index < dst_token_capacity,
+          "HiCache staged write-back: destination index ",
+          dst_index,
+          " is outside [0, ",
+          dst_token_capacity,
+          ")");
+      all_pages_contiguous &= dst_index == first_dst_index + token_offset;
+    }
+  }
+  return all_pages_contiguous;
+}
+
 #if !defined(USE_ROCM) && defined(CUDA_VERSION) && CUDA_VERSION >= 12080
 #if CUDA_VERSION >= 13000
 using CudaMemcpyBatchPtr = const void*;
@@ -67,6 +101,7 @@ inline void copy_page_first_pages_fallback(
     const int64_t* dst_indices_ptr,
     int64_t num_pages,
     int64_t page_size,
+    bool pages_are_contiguous,
     cudaStream_t stream) {
   using namespace host;
 
@@ -78,15 +113,30 @@ inline void copy_page_first_pages_fallback(
     const int64_t elem_size = host::dtype_bytes(src_ptrs[tensor_id].dtype());
     const int64_t src_stride0 = src_ptrs[tensor_id].stride(0);
     const int64_t dst_stride0 = dst_ptrs[tensor_id].stride(0);
+    const size_t src_token_bytes = static_cast<size_t>(src_stride0 * elem_size);
+    const size_t dst_token_bytes = static_cast<size_t>(dst_stride0 * elem_size);
     const size_t src_page_bytes = static_cast<size_t>(page_size * src_stride0 * elem_size);
     const size_t dst_page_bytes = static_cast<size_t>(page_size * dst_stride0 * elem_size);
+    RuntimeCheck(src_token_bytes == dst_token_bytes, "Source and destination token spans must match");
     RuntimeCheck(src_page_bytes == dst_page_bytes, "Source and destination page spans must match");
     for (const auto page_offset : irange(num_pages)) {
-      const char* src_ptr = static_cast<const char*>(src_ptrs[tensor_id].data_ptr()) +
-                            static_cast<size_t>(page_offset * page_size * src_stride0 * elem_size);
-      char* dst_ptr = static_cast<char*>(dst_ptrs[tensor_id].data_ptr()) +
-                      static_cast<size_t>(dst_indices_ptr[page_offset * page_size] * dst_stride0 * elem_size);
-      RuntimeDeviceCheck(cudaMemcpyAsync(dst_ptr, src_ptr, src_page_bytes, cudaMemcpyDeviceToHost, stream));
+      const int64_t token_begin = page_offset * page_size;
+      if (pages_are_contiguous) {
+        const char* src_ptr = static_cast<const char*>(src_ptrs[tensor_id].data_ptr()) +
+                              static_cast<size_t>(token_begin) * src_token_bytes;
+        char* dst_ptr = static_cast<char*>(dst_ptrs[tensor_id].data_ptr()) +
+                        static_cast<size_t>(dst_indices_ptr[token_begin]) * dst_token_bytes;
+        RuntimeDeviceCheck(cudaMemcpyAsync(dst_ptr, src_ptr, src_page_bytes, cudaMemcpyDeviceToHost, stream));
+      } else {
+        for (const auto token_offset : irange(page_size)) {
+          const int64_t token_id = token_begin + token_offset;
+          const char* src_ptr = static_cast<const char*>(src_ptrs[tensor_id].data_ptr()) +
+                                static_cast<size_t>(token_id) * src_token_bytes;
+          char* dst_ptr = static_cast<char*>(dst_ptrs[tensor_id].data_ptr()) +
+                          static_cast<size_t>(dst_indices_ptr[token_id]) * dst_token_bytes;
+          RuntimeDeviceCheck(cudaMemcpyAsync(dst_ptr, src_ptr, src_token_bytes, cudaMemcpyDeviceToHost, stream));
+        }
+      }
     }
   }
 }
@@ -243,6 +293,7 @@ struct HiCacheStagedWriteBackKernel {
         .with_device<kDLGPU>(device_)
         .verify(page_indices_src);
     TensorMatcher({T})  //
+        .with_strides({1})
         .with_dtype<int64_t>(dst_indices_dtype)
         .with_device<kDLCPU, kDLGPUHost>()
         .verify(dst_indices_cpu);
@@ -253,6 +304,14 @@ struct HiCacheStagedWriteBackKernel {
         kElementSize == D.unwrap() * dtype_bytes(cache_dtype.unwrap()),
         "HiCache staged relayout: element size mismatch");
     RuntimeCheck(kElementSize % 16 == 0, "HiCache staged relayout: element size must be 16-byte aligned");
+
+    const int64_t* dst_indices_ptr = static_cast<const int64_t*>(dst_indices_cpu.data_ptr());
+    const bool pages_are_contiguous = validate_page_first_destination_indices(
+        kIsMLA ? std::vector<tvm::ffi::TensorView>{k_cache_dst}
+               : std::vector<tvm::ffi::TensorView>{k_cache_dst, v_cache_dst},
+        dst_indices_ptr,
+        P.unwrap(),
+        page_size);
 
     const auto params = HicacheRelayoutParams{
         .k_cache_dst = staging_k.data_ptr(),
@@ -269,23 +328,30 @@ struct HiCacheStagedWriteBackKernel {
     launch_hicache_relayout_kernel<kElementSize, kIsMLA>(params, P.unwrap(), N.unwrap(), page_size, use_int32, device);
 
     auto stream = LaunchKernel::resolve_device(device);
-    const int64_t* dst_indices_ptr = static_cast<const int64_t*>(dst_indices_cpu.data_ptr());
     if constexpr (kIsMLA) {
-      if (!try_copy_page_first_pages_batch(
+      if (!pages_are_contiguous ||
+          !try_copy_page_first_pages_batch(
               {staging_k}, {k_cache_dst}, dst_indices_ptr, P.unwrap(), page_size, device.device_id, stream)) {
-        copy_page_first_pages_fallback({staging_k}, {k_cache_dst}, dst_indices_ptr, P.unwrap(), page_size, stream);
+        copy_page_first_pages_fallback(
+            {staging_k}, {k_cache_dst}, dst_indices_ptr, P.unwrap(), page_size, pages_are_contiguous, stream);
       }
     } else {
-      if (!try_copy_page_first_pages_batch(
-              {staging_k, staging_v},
-              {k_cache_dst, v_cache_dst},
-              dst_indices_ptr,
-              P.unwrap(),
-              page_size,
-              device.device_id,
-              stream)) {
+      if (!pages_are_contiguous || !try_copy_page_first_pages_batch(
+                                       {staging_k, staging_v},
+                                       {k_cache_dst, v_cache_dst},
+                                       dst_indices_ptr,
+                                       P.unwrap(),
+                                       page_size,
+                                       device.device_id,
+                                       stream)) {
         copy_page_first_pages_fallback(
-            {staging_k, staging_v}, {k_cache_dst, v_cache_dst}, dst_indices_ptr, P.unwrap(), page_size, stream);
+            {staging_k, staging_v},
+            {k_cache_dst, v_cache_dst},
+            dst_indices_ptr,
+            P.unwrap(),
+            page_size,
+            pages_are_contiguous,
+            stream);
       }
     }
   }

--- a/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
+++ b/test/registered/kernels/ops/kvcache/test_hicache_page_first_write_back.py
@@ -95,6 +95,15 @@ def _assert_pages_equal(host_ref, device_ref, host_pages, device_pages) -> None:
         )
 
 
+def _fragmented_host_indices(page_count: int) -> torch.Tensor:
+    indices = torch.arange(page_count * PAGE_SIZE, dtype=torch.int64).reshape(
+        page_count, PAGE_SIZE
+    )
+    if PAGE_SIZE > 1:
+        indices[:, [0, 1]] = indices[:, [1, 0]]
+    return indices.flatten()
+
+
 def _run_mha(element_dim: int, page_count: int) -> None:
     pool_size = PAGE_SIZE * (page_count + 8)
     device_pool = MHATokenToKVPool(
@@ -243,6 +252,46 @@ def _run_mla(element_dim: int, page_count: int) -> None:
         )
 
 
+def _run_mla_fragmented_destination_indices() -> None:
+    page_count = 3
+    pool_size = PAGE_SIZE * (page_count + 8)
+    device_pool = MLATokenToKVPool(
+        size=pool_size,
+        page_size=PAGE_SIZE,
+        kv_lora_rank=MLA_ELEMENT_DIMS[0] - 64,
+        qk_rope_head_dim=64,
+        dtype=torch.bfloat16,
+        layer_num=NUM_LAYERS,
+        device=DEVICE,
+        enable_memory_saver=False,
+    )
+    host_pool = _pinned_host_pool(
+        MLATokenToKVPoolHost, device_pool=device_pool, layout="page_first"
+    )
+    assert host_pool.can_use_write_back_jit
+
+    for layer_id in range(NUM_LAYERS):
+        _fill_with_offset(device_pool.kv_buffer[layer_id], layer_id)
+
+    device_pages = torch.arange(2, 2 + page_count, device=DEVICE, dtype=torch.int64)
+    device_indices = _token_indices_for_pages(device_pages)
+    host_indices = _fragmented_host_indices(page_count)
+    expected = [
+        device_pool.kv_buffer[layer_id][device_indices].cpu()
+        for layer_id in range(NUM_LAYERS)
+    ]
+
+    host_pool.backup_from_device_all_layer(
+        device_pool, host_indices, device_indices, "kernel"
+    )
+    torch.cuda.synchronize()
+
+    for layer_id in range(NUM_LAYERS):
+        assert torch.equal(
+            host_pool.data_refs[layer_id][host_indices].cpu(), expected[layer_id]
+        )
+
+
 @pytest.mark.parametrize("element_dim", MHA_ELEMENT_DIMS)
 @pytest.mark.parametrize("page_count", PAGE_COUNTS)
 def test_page_first_staged_write_back_mha(element_dim: int, page_count: int) -> None:
@@ -253,6 +302,10 @@ def test_page_first_staged_write_back_mha(element_dim: int, page_count: int) -> 
 @pytest.mark.parametrize("page_count", PAGE_COUNTS)
 def test_page_first_staged_write_back_mla(element_dim: int, page_count: int) -> None:
     _run_mla(element_dim, page_count)
+
+
+def test_page_first_staged_write_back_mla_fragmented_destination_indices() -> None:
+    _run_mla_fragmented_destination_indices()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The staged page-first write-back path assumed every destination page was represented by contiguous token indices. Fragmented or reordered indices could therefore copy data into the wrong host slots, and the CUDA batch-copy path cannot express those destinations as one page copy.

## Changes

- Validate destination indices before dispatch.
- Keep the fast batched page copy for contiguous pages.
- Fall back to per-token asynchronous copies when a destination page is fragmented.
- Validate bounds and require contiguous index tensor storage.
- Add a CUDA regression case for fragmented MLA destinations.

This correctness fix is extracted from #26691 and does not depend on MLA host dedup.

## Validation

- Full pre-commit checks, including clang-format, passed.
- 13 CUDA cases collect successfully and are skipped on the local non-CUDA host.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33146599193](https://github.com/sgl-project/sglang/actions/runs/33146599193)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33146599100](https://github.com/sgl-project/sglang/actions/runs/33146599100)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33146599210](https://github.com/sgl-project/sglang/actions/runs/33146599210)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->