### PR TITLE
Fix MMLU thresholds in NPU DeepEP tests

### DIFF
--- a/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_auto_qwen3_480b.py
+++ b/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_auto_qwen3_480b.py
@@ -73,7 +73,7 @@ class TestDeepEpQwen(GSM8KAscendMixin, TestMMLU, CustomTestCase):
 
     # MMLU Configs
     mmlu_num_examples = 8
-    accuracy_mmlu_threshold = 0.61  # MMLU accuracy ≥0.61
+    accuracy_mmlu = 0.61  # MMLU accuracy ≥0.61
 
     # GSM8K Configs
     accuracy = 0.91  # GSM8K accuracy ≥0.91

--- a/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_auto_qwen3_next.py
+++ b/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_auto_qwen3_next.py
@@ -73,7 +73,7 @@ class TestQwen3Next(GSM8KAscendMixin, TestMMLU, CustomTestCase):
 
     # MMLU Configs
     mmlu_num_examples = 8
-    accuracy_mmlu_threshold = 0.56  # MMLU accuracy ≥0.56
+    accuracy_mmlu = 0.56  # MMLU accuracy ≥0.56
 
     # GSM8K Configs
     accuracy = 0.9  # GSM8K accuracy ≥0.9

--- a/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_low_latency_deepseek_v3_2_w8a8.py
+++ b/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_low_latency_deepseek_v3_2_w8a8.py
@@ -57,7 +57,7 @@ class TestDeepEpDeepseekV32(GSM8KAscendMixin, TestMMLU, CustomTestCase):
 
     # MMLU Configs
     mmlu_num_examples = 128
-    accuracy_mmlu_threshold = 0.85  # MMLU accuracy ≥0.85
+    accuracy_mmlu = 0.85  # MMLU accuracy ≥0.85
 
     # GSM8K Configs
     accuracy = 0.95  # GSM8K accuracy ≥0.95

--- a/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_low_latency_qwen3_480b.py
+++ b/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_low_latency_qwen3_480b.py
@@ -74,7 +74,7 @@ class TestDeepEpQwen(GSM8KAscendMixin, TestMMLU, CustomTestCase):
 
     # MMLU Configs
     mmlu_num_examples = 8
-    accuracy_mmlu_threshold = 0.61  # MMLU accuracy ≥0.61
+    accuracy_mmlu = 0.61  # MMLU accuracy ≥0.61
 
     # GSM8K Configs
     accuracy = 0.91  # GSM8K accuracy ≥0.91

--- a/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_low_latency_qwen3_next.py
+++ b/test/registered/npu/basic_function/parallel_strategy/expert_parallelism/test_npu_deepep_low_latency_qwen3_next.py
@@ -77,7 +77,7 @@ class TestQwen3Next(GSM8KAscendMixin, TestMMLU, CustomTestCase):
 
     # MMLU Configs
     mmlu_num_examples = 8
-    accuracy_mmlu_threshold = 0.56  # MMLU accuracy ≥0.56
+    accuracy_mmlu = 0.56  # MMLU accuracy ≥0.56
 
     # GSM8K Configs
     accuracy = 0.9  # GSM8K accuracy ≥0.9


### PR DESCRIPTION
## Motivation

Fixes #36776.

Five Ascend NPU test classes define `accuracy_mmlu_threshold`, but the shared `TestMMLU` mixin reads `accuracy_mmlu`. As a result, those tests silently fall back to a `0.00` threshold and can report false success.

## Modifications

- Rename the five stale class attributes to `accuracy_mmlu`.
- Preserve each existing threshold value and all model/test configuration.

## Accuracy Tests

No model accuracy run was performed because the affected tests require 8-16 Ascend NPUs and project-hosted model weights. This change does not modify model output; it restores the thresholds the tests already document.

Static AST validation confirmed that current `main` reproduces the stale attribute in all five files and that this branch exposes `accuracy_mmlu` with the original values (`0.61`, `0.56`, `0.85`, `0.61`, and `0.56`).

## Speed Tests and Profiling

Not applicable; test configuration only.

## Validation

- File-scoped pre-commit hooks, including the registered-test CI validator
- Ruff check and format check on all five changed files
- Python compilation of all five changed files
- Focused AST contract check against the attribute consumed by `TestMMLU`
- `git diff --check` and commit whitespace checks

## Known limitations

- The hardware-backed MMLU tests were not run locally because Ascend NPU hardware and the required model weights are unavailable.

## Checklist

- [x] Format code according to the project pre-commit configuration.
- [x] Keep the regression fix within the existing registered accuracy tests.
- [x] Confirm no documentation update is needed.
- [x] Confirm accuracy and speed benchmarks are not applicable to model output.
- [x] Follow the SGLang code style guidance.

This focused change was prepared with AI assistance and has not yet been human-reviewed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33147219012](https://github.com/sgl-project/sglang/actions/runs/33147219012)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33147218868](https://github.com/sgl-project/sglang/actions/runs/33147218868)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33147218965](https://github.com/sgl-project/sglang/actions/runs/33147218965)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->