### PR TITLE
[OpenAI] Honor explicit --chat-template over built-in chat encoders; force reasoning for hardcoded-<think> templates

### DIFF
--- a/python/sglang/srt/entrypoints/openai/chat_encoding.py
+++ b/python/sglang/srt/entrypoints/openai/chat_encoding.py
@@ -110,12 +110,48 @@ def resolve_chat_encoding_spec(
     hf_config: Any,
     tokenizer: Any,
     tool_call_parser: Optional[str] = None,
+    explicit_chat_template: bool = False,
 ) -> Optional[str]:
     """Return the chat encoding spec for a model.
 
     None means the default path (HF chat template); any non-None spec also owns
     reasoning-history rendering (:func:`spec_owns_reasoning_history`).
+
+    ``explicit_chat_template`` is True when the operator passed
+    ``--chat-template``: an explicitly supplied template overrides the
+    built-in Python chat encoders for prompt rendering (output parsing --
+    reasoning / tool-call parsers -- is unaffected). Inkling is the one
+    exception: it cannot render through ``apply_chat_template`` at all.
     """
+    spec = _resolve_chat_encoding_spec_for_model(
+        hf_config=hf_config, tokenizer=tokenizer, tool_call_parser=tool_call_parser
+    )
+    if spec is not None and explicit_chat_template:
+        if spec == "inkling":
+            logger.warning(
+                "--chat-template is not supported for Inkling (no Jinja-renderable "
+                "tokenizer); keeping the built-in '%s' chat encoder.",
+                spec,
+            )
+            return spec
+        logger.warning(
+            "--chat-template was given, so the built-in '%s' chat encoder is "
+            "bypassed for prompt rendering; chat requests now render through the "
+            "user-specified template (reasoning/tool-call output parsers are "
+            "unaffected). Remove --chat-template to restore the built-in encoder.",
+            spec,
+        )
+        return None
+    return spec
+
+
+def _resolve_chat_encoding_spec_for_model(
+    *,
+    hf_config: Any,
+    tokenizer: Any,
+    tool_call_parser: Optional[str] = None,
+) -> Optional[str]:
+    """Model-derived encoding spec, ignoring any user-supplied chat template."""
     if tool_call_parser == "deepseekv4":
         return "dsv4"
     if tool_call_parser == "deepseekv32":

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -405,6 +405,8 @@ class OpenAIServingChat(OpenAIServingBase):
             hf_config=self.tokenizer_manager.model_config.hf_config,
             tokenizer=self.tokenizer_manager.tokenizer,
             tool_call_parser=self.tool_call_parser,
+            explicit_chat_template=self.tokenizer_manager.server_args.chat_template
+            is not None,
         )
 
     def _request_id_prefix(self) -> str:
@@ -1199,7 +1201,7 @@ class OpenAIServingChat(OpenAIServingBase):
                 result.stop.append(tool_call_stop)
 
         result.tool_call_constraint = tool_call_constraint
-        result.require_reasoning = thinking_mode
+        result.require_reasoning = thinking_mode or result.require_reasoning
         result.skip_special_tokens = request.skip_special_tokens
         return result
 
@@ -1219,6 +1221,7 @@ class OpenAIServingChat(OpenAIServingBase):
         modalities = []
 
         template_content_format = self.template_manager.jinja_template_content_format
+        template_forces_reasoning = False
 
         # Try custom encoding first (override in subclass for custom renderers)
         thinking_requested = (request.chat_template_kwargs or {}).get(
@@ -1422,6 +1425,16 @@ class OpenAIServingChat(OpenAIServingBase):
                     # should be treated as client errors (400 BadRequest)
                     raise ValueError(str(template_error)) from template_error
 
+            # A template that unconditionally opens the reasoning block (the
+            # rendered prompt ends with "<think>") forces the model into
+            # reasoning regardless of chat_template_kwargs; keep
+            # require_reasoning in sync so the reasoning parser splits the
+            # reply into reasoning_content instead of leaking "</think>".
+            if isinstance(rendered_prompt, str) and rendered_prompt.rstrip().endswith(
+                "<think>"
+            ):
+                template_forces_reasoning = True
+
             # Append assistant prefix if continue_final_message is enabled
             if assistant_prefix:
                 prompt_ids = self._append_assistant_prefix_to_prompt_ids(
@@ -1444,6 +1457,7 @@ class OpenAIServingChat(OpenAIServingBase):
             audio_data=audio_data,
             modalities=modalities,
             stop=stop,
+            require_reasoning=template_forces_reasoning,
         )
 
     def _apply_conversation_template(

--- a/python/sglang/srt/parser/template_detection.py
+++ b/python/sglang/srt/parser/template_detection.py
@@ -563,7 +563,35 @@ def detect_reasoning_pattern(
         if rule.predicate(ctx):
             return rule.value.always_on, rule.value
 
+    # Fallback: a template whose generation prompt unconditionally ends by
+    # opening the reasoning block (e.g. DeepSeek-style "<|Assistant|><think>")
+    # forces the model to start inside <think>, so reasoning must be treated
+    # as always-on for the parser to split replies into reasoning_content.
+    # Probe by rendering: source text is unreliable because Jinja control
+    # flow may sit between the role marker and the literal "<think>".
+    if (
+        "enable_thinking" not in template
+        and "thinking_mode" not in template
+        and _renders_forced_think_open(template)
+    ):
+        return True, ReasoningToggleConfig(special_case="always")
+
     return False, None
+
+
+def _renders_forced_think_open(template: str) -> bool:
+    """True if the rendered generation prompt ends with an open "<think>"."""
+    try:
+        env = jinja2.sandbox.ImmutableSandboxedEnvironment()
+        rendered = env.from_string(template).render(
+            messages=[{"role": "user", "content": "hi"}],
+            add_generation_prompt=True,
+            bos_token="",
+            eos_token="",
+        )
+    except Exception:
+        return False
+    return isinstance(rendered, str) and rendered.rstrip().endswith("<think>")
 
 
 def detect_reasoning_parser(


### PR DESCRIPTION
## Motivation

`--chat-template <file>.jinja` is silently ignored for models with a built-in Python chat encoder (`dsv4` / `dsv32` / `kimi_k3`): `resolve_chat_encoding_spec` returns the encoder spec unconditionally (by architecture or `--tool-call-parser`), so `/v1/chat/completions` never renders the user's template — with no warning. On a DeepSeek-V4-Flash deployment this surfaced as: a jinja passed via `--chat-template` loads at startup ("Detected user specified Jinja chat template…") yet chat prompts render through the built-in encoder (20 prompt tokens instead of the templated 99), and template-directed `chat_template_kwargs` are lost.

Additionally, once a DeepSeek-style **hardcoded-thinking** template (generation prompt ends with `<｜Assistant｜><think>`) does render, replies leak a raw `</think>` into `content`: the response-side reasoning split is gated on `template_manager.force_reasoning`, and the source-text detection rules can't recognize these templates because Jinja control flow sits between the role marker and the `<think>` literal.

## Modifications

1. **`chat_encoding.py`** — `resolve_chat_encoding_spec` gains `explicit_chat_template`: when the operator passed `--chat-template`, the built-in encoder is bypassed for prompt rendering (loud startup warning; reasoning/tool-call **output** parsers unaffected). Inkling is exempt — it cannot render via `apply_chat_template` (warned separately). No-template behavior is unchanged.
2. **`template_detection.py`** — `detect_reasoning_pattern` gains a render-probe fallback: a toggle-less template whose rendered generation prompt ends with an open `<think>` forces reasoning (`special_case="always"`), so the parser splits replies into `reasoning_content`. Rendering (same sandboxed-jinja approach as `detect_inline_system_support`) is used because source-text rules cannot catch these templates.
3. **`serving_chat.py`** — template-forced reasoning propagates into `MessageProcessingResult.require_reasoning` (scheduler-side state), and the kwargs-derived flag no longer clobbers it.

## Verification

Offline unit checks (resolver matrix + detection):
- dsv4 arch, no `--chat-template` → `dsv4` (unchanged); with explicit template → `None` + warning; Inkling keeps its encoder
- hardcoded-think jinja → `(True, always)`; `enable_thinking`-toggle template → `(False, None)`; plain template → `(False, None)`

Live on 2× DGX Spark (GB10), DeepSeek-V4-Flash-0731, TP2, `--chat-template` = official-encoding jinja + `--reasoning-parser deepseek-v4` (backport of this diff onto our benchmark branch):

| scenario | before | after |
|---|---|---|
| plain chat request | 20 prompt tok (encoder, template ignored), `</think>` leaked in content | 99 prompt tok (template), `reasoning_content` populated, no leak |
| `chat_template_kwargs {"thinking": true}` | works (encoder path) | works (template path) |
| multi-turn | template ignored | 105 prompt tok, split correctly |
| streaming | no `reasoning_content` deltas | 662 reasoning deltas, 0 leaks |
| GSM8K few-shot (completion path) | 0.970/0.945 | unaffected (route untouched) |

Draft for discussion: the priority choice (explicit template wins over built-in encoder, with a warning) follows the principle that an explicit operator flag is intent; happy to flip to hard-error or to encoder-wins-with-warning if maintainers prefer. The dsv32 arch fallback already had `has_chat_template` semantics; this extends the same courtesy to the flag itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829331567](https://github.com/sgl-project/sglang/actions/runs/34829331567)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829331124](https://github.com/sgl-project/sglang/actions/runs/34829331124)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829331473](https://github.com/sgl-project/sglang/actions/runs/34829331473)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->