### PR TITLE
[Fix] Clear inherited MoE-only sizes for dense Qwen3_5TextConfig

### DIFF
--- a/python/sglang/srt/configs/qwen3_5.py
+++ b/python/sglang/srt/configs/qwen3_5.py
@@ -30,6 +30,14 @@ class Qwen3_5TextConfig(Qwen3NextConfig):
         if self.rope_scaling is None:
             self.rope_scaling = rope_parameters or {}
 
+        # Dense Qwen3.5 is not MoE: clear the MoE-only sizes inherited from
+        # Qwen3NextConfig (exact type: the MoE subclass keeps its defaults),
+        # or check_quantized_moe_compatibility rejects valid TP sharding of
+        # block-quantized FP8 dense checkpoints.
+        if type(self) is Qwen3_5TextConfig:
+            self.moe_intermediate_size = None
+            self.shared_expert_intermediate_size = None
+
         # Keep both names for compatibility with model code paths that read either.
         self.rope_parameters = rope_parameters or self.rope_scaling
 

--- a/test/registered/unit/configs/test_qwen3_5_config.py
+++ b/test/registered/unit/configs/test_qwen3_5_config.py
@@ -1,0 +1,29 @@
+"""Dense Qwen3_5TextConfig must not surface MoE-only sizes inherited from Qwen3NextConfig.
+
+If it does, check_quantized_moe_compatibility treats block-quantized FP8 dense
+checkpoints as MoE and rejects valid TP sharding at startup.
+"""
+
+import unittest
+
+from sglang.srt.configs.qwen3_5 import Qwen3_5MoeTextConfig, Qwen3_5TextConfig
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestQwen35ConfigMoEInheritance(CustomTestCase):
+    def test_dense_text_config_clears_inherited_moe_sizes(self):
+        cfg = Qwen3_5TextConfig()
+        self.assertIsNone(cfg.moe_intermediate_size)
+        self.assertIsNone(cfg.shared_expert_intermediate_size)
+
+    def test_moe_text_config_keeps_moe_sizes(self):
+        cfg = Qwen3_5MoeTextConfig()
+        self.assertEqual(cfg.moe_intermediate_size, 512)
+        self.assertEqual(cfg.shared_expert_intermediate_size, 512)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Dense Qwen3.5-family checkpoints (e.g. `Qwen/Qwen3.8-27B-FP8`) fail to launch under TP sharding of block-quantized FP8 weights:

```
ValueError: For quantized MoE models, please make sure (moe_intermediate_size=512 / moe_tp_size=8) % weight_block_size_n=128 == 0 where moe_tp_size is equal to tp_size (8) divided by ep_size (1). You can fix this by setting arguments `--tp` and `--ep` correctly.
```

The model is dense - its `config.json` contains no MoE fields at all. Root cause:

- `Qwen3_5TextConfig` inherits `Qwen3NextConfig`, whose `__init__` unconditionally sets MoE defaults (`moe_intermediate_size=512`, `num_experts=512`, ...), even for dense checkpoints.
- `check_quantized_moe_compatibility()` skips the check only when `moe_intermediate_size` is absent, so the inherited phantom `512` defeats that escape hatch. With `--tp 8` the guard computes `512/8=64`, which is not a multiple of the 128 weight block, and startup aborts. The real dense `intermediate_size` (17408) shards cleanly (`17408/8 = 2176 = 17*128`); the dimension the check uses does not exist in this model.

A practical workaround today is to launch with `--ep-size 2`: it turns the arithmetic into `512/4=128` and satisfies the guard. Since a dense model has no experts, EP has no runtime effect - but the flag reads as expert parallelism from the outside and easily confuses whoever reads the deployment command (our own deployment drew exactly that question). `--json-model-override-args '{"text_config": {"moe_intermediate_size": 17408}}'` works too, by feeding the guard the real dense size. Both leave the root cause in place: dense configs keep carrying MoE-only fields.

Fixes #21810 (auto-closed by the inactivity bot, never actually fixed; still repros on current `main`). Revives #24678 rebased onto current `main` - credit to @caijixueIT for the original approach; the test is updated to the current `CustomTestCase` idiom.

## Before / after on 8x SM120 GPUs

**Environment:** 8x NVIDIA GeForce RTX 5090D (Blackwell, SM120), 24 GB each; image `lmsysorg/sglang:nightly-dev-cu13-20260818-c0b6474b`; model `Qwen/Qwen3.8-27B-FP8` (dense, block-quantized FP8, `weight_block_size=[128, 128]`).

**Launch command - identical before and after the fix:**

```bash
python -m sglang.launch_server \
  --model-path Qwen/Qwen3.8-27B-FP8 \
  --tp-size 8 \
  --mem-fraction-static 0.75 \
  --quantization fp8 \
  --reasoning-parser qwen3 \
  --tool-call-parser qwen3_coder \
  --host 0.0.0.0 \
  --port 30001
```

**Before (current `main`):** startup aborts before weight loading:

```
ValueError: For quantized MoE models, please make sure (moe_intermediate_size=512 / moe_tp_size=8) % weight_block_size_n=128 == 0 where moe_tp_size is equal to tp_size (8) divided by ep_size (1). You can fix this by setting arguments `--tp` and `--ep` correctly.
Received sigquit from a child process. It usually means the child failed.
```

**After (this fix):** the same command starts and serves:

```
[TP0] max_total_num_tokens=446824, chunked_prefill_size=2048, max_prefill_tokens=16384, max_running_requests=68, context_len=262144, available_gpu_mem=2.68 GB
The server is fired up and ready to roll!
```

```
$ curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:30001/health
200

$ curl -s http://127.0.0.1:30001/v1/chat/completions \
    -H 'Content-Type: application/json' \
    -d '{"model":"/model","messages":[{"role":"user","content":"What is 17 * 23? Answer with a single number."}],"temperature":0,"max_tokens":32}'
{"choices":[{"message":{"role":"assistant","content":"391"},"finish_reason":"stop"}]}
```

`max_total_num_tokens=446824` is identical to an `--ep-size 2` deployment of the same model, confirming the fix changes config handling only, not TP sharding.

## Changes

- `python/sglang/srt/configs/qwen3_5.py`: in `Qwen3_5TextConfig.__init__`, clear the two inherited MoE-only sizes via an exact type check, so `Qwen3_5MoeTextConfig` keeps its defaults.
- `test/registered/unit/configs/test_qwen3_5_config.py`: regression test covering both branches.

Dense model code never reads these fields: all readers in `models/qwen3_5.py` are gated on `"moe" in model_type` or on `*_moe` module names.

## Test plan

- [x] New unit test: red on `main` (`AssertionError: 512 is not None`), green with the fix; the MoE-subclass case stays green on both.
- [x] Launch check above: fails on current `main`, starts and serves with this fix.

## Note for reviewers

A guard-level alternative exists (#36183, scan the loaded model for `FusedMoE` modules), but `check_quantized_moe_compatibility()` runs in `ModelRunner.__init__` (`model_runner.py:459`) before the model is instantiated (`self.model` is assigned at `:1166`), so that approach would have to move the check after weight load and lose the current fail-fast-before-load behavior. Clearing the phantom fields at the config level fixes the root cause and keeps the check where it is.
