### PR TITLE
xpu: move prefill-only model tests to the nightly-xpu-1-gpu grid

### DIFF
--- a/test/registered/xpu/test_xpu_classification.py
+++ b/test/registered/xpu/test_xpu_classification.py
@@ -14,7 +14,7 @@ from sglang.test.ci.ci_register import register_xpu_ci
 from sglang.test.runners import HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase, empty_gpu_cache
 
-register_xpu_ci(est_time=120, suite="stage-b-test-1-gpu-xpu")
+register_xpu_ci(est_time=120, suite="nightly-xpu-1-gpu", nightly=True)
 
 MODEL_PATH = "jason9693/Qwen2.5-1.5B-apeach"
 TP_SIZE = 1

--- a/test/registered/xpu/test_xpu_embedding.py
+++ b/test/registered/xpu/test_xpu_embedding.py
@@ -17,7 +17,7 @@ from sglang.test.ci.ci_register import register_xpu_ci
 from sglang.test.runners import DEFAULT_PROMPTS, HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase, empty_gpu_cache, get_similarities
 
-register_xpu_ci(est_time=180, suite="stage-b-test-1-gpu-xpu")
+register_xpu_ci(est_time=180, suite="nightly-xpu-1-gpu", nightly=True)
 
 MODEL_PATH = "Alibaba-NLP/gte-Qwen2-1.5B-instruct"
 TP_SIZE = 1

--- a/test/registered/xpu/test_xpu_rerank.py
+++ b/test/registered/xpu/test_xpu_rerank.py
@@ -24,17 +24,7 @@ from sglang.test.runners import TEST_RERANK_QUERY_DOCS, HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase, empty_gpu_cache
 
 
-def _xpu_total_gib() -> float:
-    if not torch.xpu.is_available():
-        return 0.0
-    return torch.xpu.get_device_properties(0).total_memory / (1024**3)
-
-
-# fp32+Triton fits on B60 (22GiB) but hangs on B580 (~12GiB).
-_LARGE_XPU_VRAM_GIB = 20.0
-_HAS_LARGE_XPU = _xpu_total_gib() >= _LARGE_XPU_VRAM_GIB
-
-register_xpu_ci(est_time=180, suite="stage-b-test-1-gpu-xpu")
+register_xpu_ci(est_time=180, suite="nightly-xpu-1-gpu", nightly=True)
 
 MODEL_PATH = "Qwen/Qwen3-Reranker-0.6B"
 TP_SIZE = 1
@@ -168,10 +158,6 @@ class TestXPUDecoderRerank(CustomTestCase):
             self._assert_close_scores(prompts)
 
 
-# Ported from test/manual/prefill_only/test_cross_encoder_models.py.
-# fp32+triton fits on B60 (22GiB) but OOMs on B580 (~12GiB); bf16+intel_xpu on
-# this encoder model does not match HF (tracked separately), so on <20GiB XPU
-# the class is skipped rather than shipping a knowingly-wrong config.
 CROSS_ENCODER_MODEL_PATH = "BAAI/bge-reranker-v2-m3"
 CROSS_ENCODER_TP_SIZE = 1
 CROSS_ENCODER_SCORE_TOLERANCE = 1e-2
@@ -180,11 +166,6 @@ CROSS_ENCODER_ATTENTION_BACKEND = "triton"
 CROSS_ENCODER_MEM_FRACTION_STATIC = 0.65
 
 
-@unittest.skipUnless(
-    _HAS_LARGE_XPU,
-    "bge-reranker-v2-m3 fp32+triton OOMs on <20GiB XPU (B580); "
-    "bf16+intel_xpu on this encoder produces wrong scores.",
-)
 class TestXPUCrossEncoderRerank(CustomTestCase):
     @classmethod
     def setUpClass(cls):

--- a/test/registered/xpu/test_xpu_rerank.py
+++ b/test/registered/xpu/test_xpu_rerank.py
@@ -23,7 +23,6 @@ from sglang.test.ci.ci_register import register_xpu_ci
 from sglang.test.runners import TEST_RERANK_QUERY_DOCS, HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase, empty_gpu_cache
 
-
 register_xpu_ci(est_time=180, suite="nightly-xpu-1-gpu", nightly=True)
 
 MODEL_PATH = "Qwen/Qwen3-Reranker-0.6B"

--- a/test/registered/xpu/test_xpu_reward.py
+++ b/test/registered/xpu/test_xpu_reward.py
@@ -15,7 +15,7 @@ from sglang.test.ci.ci_register import register_xpu_ci
 from sglang.test.runners import HFRunner, SRTRunner
 from sglang.test.test_utils import CustomTestCase, empty_gpu_cache
 
-register_xpu_ci(est_time=60, suite="stage-b-test-1-gpu-xpu")
+register_xpu_ci(est_time=60, suite="nightly-xpu-1-gpu", nightly=True)
 
 MODEL_PATH = "Skywork/Skywork-Reward-V2-Qwen3-0.6B"
 TP_SIZE = 1


### PR DESCRIPTION
## Summary
- Move the four prefill-only model tests added in #35072 (classification / embedding / rerank / reward) from the `stage-b-test-1-gpu-xpu` PR suite to the `nightly-xpu-1-gpu` nightly suite.
- Drop the >=20GiB VRAM skip on `TestXPUCrossEncoderRerank` in `test_xpu_rerank.py`. The gate existed to keep fp32+triton off B580 (~12GiB) PR runners; the nightly-xpu-1-gpu runners are B60 (22GiB), so the class runs unconditionally there.

## Test plan
- [ ] `nightly-test-intel.yml` -> `nightly-xpu-1-gpu` picks up the four tests and passes on B60.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33361498484](https://github.com/sgl-project/sglang/actions/runs/33361498484)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33361498236](https://github.com/sgl-project/sglang/actions/runs/33361498236)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33361498569](https://github.com/sgl-project/sglang/actions/runs/33361498569)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->