### PR TITLE
[feat] draft prefetch for eagle3

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -188,6 +188,11 @@ def _check_draft_prefetch(server_args: ServerArgs) -> None:
     from sglang.srt.arg_groups.overrides import resolved_view
     from sglang.srt.environ import envs
 
+    # Read every field through the overlay, never the raw record: during
+    # __post_init__ the resolution pipeline stashes its decisions without
+    # writing the fields, so raw reads would miss this hook's own earlier
+    # decisions (alias/auto-params/adaptive) and model overrides
+    # (multi-layer EAGLE).
     cfg = resolved_view(server_args)
 
     if not cfg.enable_draft_prefetch:

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -181,6 +181,62 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
             algo.handle_server_args,
         )
 
+    _check_draft_prefetch(server_args)
+
+
+def _check_draft_prefetch(server_args: ServerArgs) -> None:
+    from sglang.srt.arg_groups.overrides import resolved_view
+    from sglang.srt.environ import envs
+
+    cfg = resolved_view(server_args)
+
+    if not cfg.enable_draft_prefetch:
+        return
+    if cfg.speculative_num_steps is None or cfg.speculative_num_steps <= 1:
+        raise ValueError(
+            "--enable-draft-prefetch requires --speculative-num-steps > 1, got "
+            f"{cfg.speculative_num_steps}."
+        )
+    # NEXTN is absent on purpose: _resolve_speculative_algorithm_alias
+    # (earlier in this hook) promotes NEXTN to EAGLE before this check runs,
+    # so the resolved algorithm is never "NEXTN" here.
+    if cfg.speculative_algorithm not in ("EAGLE3", "EAGLE"):
+        raise ValueError(
+            "--enable-draft-prefetch only supports EAGLE/EAGLE3/NEXTN "
+            f"speculative algorithms, got {cfg.speculative_algorithm}."
+        )
+    if cfg.enable_multi_layer_eagle:
+        raise ValueError(
+            "--enable-draft-prefetch is incompatible with multi-layer EAGLE "
+            "(--enable-multi-layer-eagle, also auto-enabled for some models): "
+            "MultiLayerEagleWorkerV2 does not implement draft prefetch."
+        )
+    if cfg.speculative_eagle_topk != 1:
+        raise ValueError(
+            "--enable-draft-prefetch requires "
+            "--speculative-eagle-topk == 1: the pre-concatenated "
+            "candidate chain assumes a single chain, got "
+            f"{cfg.speculative_eagle_topk}."
+        )
+    if cfg.speculative_adaptive:
+        raise ValueError(
+            "--enable-draft-prefetch is incompatible with "
+            "--speculative-adaptive: adaptive runtime changes "
+            "speculative_num_steps, which the pre-run draft cannot "
+            "follow."
+        )
+    if cfg.speculative_use_rejection_sampling:
+        raise ValueError(
+            "--enable-draft-prefetch is incompatible with "
+            "--speculative-use-rejection-sampling: the draft-prefetch "
+            "verify input does not carry draft_probs."
+        )
+    if envs.SGLANG_ENABLE_OVERLAP_PLAN_STREAM.get():
+        logger.warning(
+            "SGLANG_ENABLE_OVERLAP_PLAN_STREAM is enabled; combining it with "
+            "--enable-draft-prefetch may cause decode stage to go down."
+        )
+
 
 def _handle_dflash(server_args: ServerArgs) -> None:
     cfg = resolving_view(server_args)

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -207,7 +207,7 @@ def _check_draft_prefetch(server_args: ServerArgs) -> None:
     # so the resolved algorithm is never "NEXTN" here.
     if cfg.speculative_algorithm not in ("EAGLE3", "EAGLE"):
         raise ValueError(
-            "--enable-draft-prefetch only supports EAGLE/EAGLE3/NEXTN "
+            "--enable-draft-prefetch only supports EAGLE/EAGLE3 "
             f"speculative algorithms, got {cfg.speculative_algorithm}."
         )
     if cfg.enable_multi_layer_eagle:

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
@@ -60,6 +60,9 @@ class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
         return self.attr_type[AttentionArch.MLA]
 
     def _is_replay_graph_needs_seq_lens_cpu(self):
+        # Non-DSA/V4 replay goes through replay_with_input_update, which
+        # takes per-step CPU seq_lens; DSA/V4 replay reads seq_lens from
+        # the device buffers directly.
         hf_config = self.model_runner.model_config.hf_config
         return not (is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config))
 
@@ -86,6 +89,10 @@ class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
             dtype=torch.int32,
             device="cpu",
         )
+        # CPU tensor + gloo cpu_group: a device-side reduce would force a
+        # stream sync via .item() right after draft_extend's kernels are
+        # enqueued, stalling the launch of the pre-run draft
+        # (draft_prefetch).
         torch.distributed.all_reduce(
             decision,
             op=torch.distributed.ReduceOp.MIN,

--- a/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
+++ b/python/sglang/srt/hardware_backend/npu/graph_runner/eagle_draft_npu_graph_runner.py
@@ -36,6 +36,9 @@ class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
     def __init__(self, eagle_worker: EagleDraftWorker):
         self._init_arch_map()
         super().__init__(eagle_worker)
+        self.replay_graph_needs_seq_lens_cpu = (
+            self._is_replay_graph_needs_seq_lens_cpu()
+        )
 
     def _init_arch_map(self):
         self.attr_name: Dict[str, str] = {
@@ -55,6 +58,10 @@ class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
 
     def _get_update_attr_type(self):
         return self.attr_type[AttentionArch.MLA]
+
+    def _is_replay_graph_needs_seq_lens_cpu(self):
+        hf_config = self.model_runner.model_config.hf_config
+        return not (is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config))
 
     def can_run_graph(self, forward_batch: ForwardBatch):
         can_run_graph = super().can_run_graph(forward_batch)
@@ -77,18 +84,17 @@ class EAGLEDraftNpuGraphRunner(EAGLEDraftCudaGraphRunner):
         decision = torch.tensor(
             int(can_run_graph and seed_ready),
             dtype=torch.int32,
-            device=self.device,
+            device="cpu",
         )
         torch.distributed.all_reduce(
             decision,
             op=torch.distributed.ReduceOp.MIN,
-            group=self.model_runner.tp_group.device_group,
+            group=self.model_runner.tp_group.cpu_group,
         )
         return bool(decision.item())
 
     def _replay_graph(self, shape_key, forward_batch):
-        hf_config = self.model_runner.model_config.hf_config
-        if not (is_deepseek_dsa(hf_config) or is_deepseek_v4(hf_config)):
+        if self.replay_graph_needs_seq_lens_cpu:
             seq_lens_for_each_draft_step = []
             for speculative_step_id in range(self.speculative_num_steps - 1):
                 seq_lens_cpu = (

--- a/python/sglang/srt/model_executor/forward_batch_info.py
+++ b/python/sglang/srt/model_executor/forward_batch_info.py
@@ -826,6 +826,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         ret._maybe_init_non_generation_fields(batch)
 
         device = model_runner.device
+        pin_memory = is_pin_memory_available()
 
         if envs.SGLANG_KV_CANARY_ENABLE_TOKEN_ORACLE.get():
             hashed = _hash_rids_to_tensor(
@@ -854,9 +855,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         num_tokens = len(batch.input_ids) if batch.input_ids is not None else 0
         if enable_num_token_non_padded():
             ret.num_token_non_padded = torch.tensor(
-                num_tokens,
-                dtype=torch.int32,
-                pin_memory=is_pin_memory_available(device),
+                num_tokens, dtype=torch.int32, pin_memory=pin_memory
             ).to(device, non_blocking=True)
         ret.num_token_non_padded_cpu = num_tokens
 
@@ -880,6 +879,7 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
                     for i in range(block_offset, block_offset + block_size)
                 ],
                 dtype=positions_dtype,
+                pin_memory=pin_memory,
             ).to(device, non_blocking=True)
         elif (
             ret.spec_info is not None
@@ -895,7 +895,6 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
             if isinstance(extend_seq_lens, list):
                 # Main path: H2D from host lists; populate *_cpu mirrors.
                 assert isinstance(extend_prefix_lens, list)
-                pin_memory = is_pin_memory_available(device)
                 ret.extend_seq_lens = torch.tensor(
                     extend_seq_lens, dtype=torch.int32, pin_memory=pin_memory
                 ).to(device, non_blocking=True)
@@ -1486,12 +1485,12 @@ class ForwardBatch(ForwardBatchDeepSeekMHAMixin):
         # padding
         self._pad_inputs_to_size(model_runner, num_tokens, bs)
         self.global_num_tokens_cpu = global_num_tokens
-        self.use_pin_memory = not _is_cpu
+        pin_memory = is_pin_memory_available()
         global_num_tokens_pinned = torch.tensor(
-            global_num_tokens, pin_memory=self.use_pin_memory
+            global_num_tokens, pin_memory=pin_memory
         )
         self.global_num_tokens_gpu.copy_(
-            global_num_tokens_pinned, non_blocking=self.use_pin_memory
+            global_num_tokens_pinned, non_blocking=pin_memory
         )
 
         TboForwardBatchPreparer.prepare(

--- a/python/sglang/srt/platforms/__init__.py
+++ b/python/sglang/srt/platforms/__init__.py
@@ -21,6 +21,7 @@ from sglang.srt.environ import envs
 from sglang.srt.platforms.cpu import CpuSRTPlatform
 from sglang.srt.platforms.cuda import CudaSRTPlatform
 from sglang.srt.platforms.interface import SRTPlatform
+from sglang.srt.platforms.npu import NpuSRTPlatform
 from sglang.srt.platforms.rocm import RocmSRTPlatform
 from sglang.srt.platforms.xpu import XpuSRTPlatform
 from sglang.srt.plugins import PLATFORM_PLUGINS_GROUP, load_plugins_by_group
@@ -40,6 +41,10 @@ def _is_rocm_available() -> bool:
 
 def _is_cpu_available() -> bool:
     return os.getenv("SGLANG_USE_CPU_ENGINE", "0") == "1"
+
+
+def _is_npu_available() -> bool:
+    return hasattr(torch, "npu") and torch.npu.is_available()
 
 
 def _is_xpu_available() -> bool:
@@ -127,6 +132,9 @@ def _resolve_platform() -> SRTPlatform:
                 "No platform plugin detected. Using CUDA SRTPlatform defaults."
             )
             return CudaSRTPlatform()
+        if _is_npu_available():
+            logger.debug("No platform plugin detected. Using NPU SRTPlatform defaults.")
+            return NpuSRTPlatform()
         if _is_rocm_available():
             logger.debug(
                 "No platform plugin detected. Using ROCm SRTPlatform defaults."

--- a/python/sglang/srt/platforms/npu.py
+++ b/python/sglang/srt/platforms/npu.py
@@ -1,0 +1,89 @@
+"""NPU (Huawei Ascend)device operations for the SRT platform layer."""
+
+from typing import Optional
+
+import torch
+
+from sglang.srt.platforms.device_mixin import (
+    DeviceCapability,
+    DeviceMixin,
+    PlatformEnum,
+)
+from sglang.srt.platforms.interface import SRTPlatform
+
+
+class NpuDeviceMixin(DeviceMixin):
+    """NPU implementation of the shared device operations."""
+
+    _enum: PlatformEnum = PlatformEnum.NPU
+    device_name: str = "npu"
+    device_type: str = "npu"
+
+    def get_device_total_memory(self, device_id: int = 0) -> int:
+        return int(torch.npu.get_device_properties(device_id).total_memory)
+
+    def get_current_memory_usage(
+        self, device: Optional["torch.device"] = None
+    ) -> float:
+        return float(torch.npu.max_memory_allocated(device))
+
+    def get_device(self, local_rank: int) -> "torch.device":
+        return torch.device("npu", local_rank)
+
+    def set_device(self, device: "torch.device") -> None:
+        torch.npu.set_device(device)
+
+    def get_device_name(self, device_id: int = 0) -> str:
+        return str(torch.npu.get_device_name(device_id))
+
+    def get_device_uuid(self, device_id: int = 0) -> str:
+        return str(torch.npu.get_device_properties(device_id).uuid)
+
+    def get_device_capability(self, device_id: int = 0) -> DeviceCapability:
+        # The return value of torch_npu.npu.get_device_capability() is configured
+        # via the environment variable TORCH_NPU_DEVICE_CAPABILITY, which is only
+        # used for compatibility with native PyTorch and does not represent the
+        # actual capabilities of the NPU hardware
+        return DeviceCapability(0, 0)
+
+    def empty_cache(self) -> None:
+        torch.npu.empty_cache()
+
+    def synchronize(self) -> None:
+        torch.npu.synchronize()
+
+    def get_available_memory(self, device_id: int = 0) -> tuple[int, int]:
+        return torch.npu.mem_get_info(device_id)
+
+    def is_pin_memory_available(self, device=None) -> bool:
+        if device is not None and str(device) == "cpu":
+            return False
+        return True
+
+    @classmethod
+    def seed_everything(cls, seed: int | None = None) -> None:
+        if seed is not None:
+            super().seed_everything(seed)
+            if hasattr(torch, "npu"):
+                torch.npu.manual_seed_all(seed)
+
+
+class NpuSRTPlatform(NpuDeviceMixin, SRTPlatform):
+    """Default in-tree NPU SRT platform."""
+
+    def get_default_attention_backend(self) -> str:
+        return "ascend"
+
+    def get_dispatch_key_name(self) -> str:
+        return "npu"
+
+    def supports_fp8(self) -> bool:
+        # NPU quantization backends in hardware_backend/npu/quantization
+        return True
+
+    def support_cuda_graph(self) -> bool:
+        # NPUGraphRunner in hardware_backend/npu/graph_runner
+        return True
+
+    def support_piecewise_cuda_graph(self) -> bool:
+        return False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2359,7 +2359,8 @@ class ServerArgs:
     ] = None
     enable_draft_prefetch: A[
         bool,
-        "pre-run the next round's draft after draft_extend (EAGLE3, topk=1 only).",
+        "pre-run the next round's draft after draft_extend (EAGLE family, "
+        "topk=1, num_steps > 1 only).",
         NS("spec"),
     ] = False
     # Decoupled speculative decoding: draft and verify run as

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2357,7 +2357,11 @@ class ServerArgs:
         "Path to a JSON config file for adaptive speculative decoding tuning knobs.",
         NS("spec"),
     ] = None
-
+    enable_draft_prefetch: A[
+        bool,
+        "pre-run the next round's draft after draft_extend (EAGLE3, topk=1 only).",
+        NS("spec"),
+    ] = False
     # Decoupled speculative decoding: draft and verify run as
     # separate engines, currently connected by a ZMQ IPC mesh.
     decoupled_spec_bind_endpoint: A[

--- a/python/sglang/srt/speculative/eagle_disaggregation.py
+++ b/python/sglang/srt/speculative/eagle_disaggregation.py
@@ -28,6 +28,8 @@ def build_eagle_disagg_draft_input(
     num_states = spec.speculative_eagle_topk
     if spec.enable_multi_layer_eagle:
         num_states *= spec.speculative_num_steps
+    elif spec.enable_draft_prefetch:
+        num_states *= spec.speculative_num_steps
 
     topk_p = torch.stack(
         [

--- a/python/sglang/srt/speculative/eagle_disaggregation.py
+++ b/python/sglang/srt/speculative/eagle_disaggregation.py
@@ -29,6 +29,8 @@ def build_eagle_disagg_draft_input(
     if spec.enable_multi_layer_eagle:
         num_states *= spec.speculative_num_steps
     elif spec.enable_draft_prefetch:
+        # The relayed topk carries [seed | steps-1 predictions] under
+        # draft-prefetch, so it is steps * topk wide.
         num_states *= spec.speculative_num_steps
 
     topk_p = torch.stack(

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -780,15 +780,18 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
     def _pad_topk_for_draft_prefetch(self, topk_p, topk_index):
         """Pad the prefill-side topk to the draft-prefetch candidate width
-        (steps * topk) so the pre-concatenation in draft_prefetch keeps a
-        uniform width across rounds.
+        (steps * topk): every decode round concatenates [seed | steps-1
+        predictions] into a buffer of exactly that width, and the overlap
+        relay buffer's shape is fixed by this first (prefill) stash.
 
         The padded slots REPEAT the last (for topk=1: the only) candidate
-        instead of zero-padding: the first decode round's tree is then built
-        from the real prefill token repeated N times -- a valid chain (verify
-        accepts at most one of the duplicates), never a bogus token id 0.
-        Also normalizes the prefill seed to the TARGET id space (the
-        concatenated draft-prefetch buffer is uniformly target-id).
+        instead of zero-padding: the first decode round then verifies a
+        chain of the real prefill token -- a valid chain, of which the
+        target may accept any prefix -- rather than one built on an
+        arbitrary token id 0. Also maps the prefill seed to the TARGET id
+        space here: the concatenated buffer is consumed directly by
+        prepare_verify_input_for_draft_prefetch, which skips
+        draft_forward's hot_token_id mapping.
         """
         # [bs, topk] -> [bs, num_steps * topk]  (topk=1: [bs,1] -> [bs,N])
         if self.enable_draft_prefetch and self.speculative_num_steps > 1:
@@ -831,7 +834,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             top_scores_index,
             0,
             topk_index.shape[1],
-            "draft_forward_for_prepare: top_scores_index OOB for gather on topk_index",
+            "prepare_verify_input_for_draft_prefetch: top_scores_index OOB "
+            "for gather on topk_index",
         )
         draft_tokens = torch.gather(topk_index, index=top_scores_index, dim=1)
 
@@ -841,7 +845,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             parent_list,
             top_scores_index,
             draft_tokens,
-            None,  # draft-prefetch: rejection sampling excluded
+            None,  # draft_probs: rejection sampling is rejected at startup
             target_worker=self.target_worker,
             topk=self.topk,
             num_steps=self.speculative_num_steps,
@@ -860,10 +864,12 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         batch_output.next_draft_input.
 
         Runs on the forward stream, back-to-back with draft_extend, so the GPU
-        never idles waiting for the scheduler to re-dispatch the draft. KV slots
-        are NOT re-allocated: the req_to_token row mapping from the scheduler's
-        per-round alloc_for_spec_decode stays valid through the next round (no
-        mid-stream free), so prepare_for_draft's assign reads valid slots.
+        never idles waiting for the scheduler to re-dispatch the draft. No new
+        KV allocation happens: the scheduler reserves 2x
+        max(topk * num_steps, num_draft_tokens) slots per round (see
+        get_alloc_reserve_per_decode), so prepare_for_draft's contiguous
+        assign below lands on exactly the slots the next round's normal draft
+        would take -- the req_to_token rows stay valid through the next round.
         """
         assert self.speculative_num_steps > 1, (
             "draft_prefetch requires num_steps > 1; _check_draft_prefetch "
@@ -883,8 +889,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             next_draft_input = batch_output.next_draft_input
             new_seq_lens = batch_output.new_seq_lens
 
-            # draft_extend left an EagleDraftExtendInput here; the pre-run
-            # draft decode reads the seed tokens (topk_index) from it.
+            # draft_extend left an EagleDraftExtendInput here; rebind to the
+            # next draft input -- draft_forward reads the seed (topk_index)
+            # and hidden_states from spec_info.
             batch.spec_info = next_draft_input
             if not batch.forward_mode.is_idle():
                 # Disguise as the next round's decode batch: under
@@ -900,9 +907,12 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 ) and getattr(
                     self.cuda_graph_runner, "replay_graph_needs_seq_lens_cpu", True
                 ):
-                    # Backends consuming the CPU mirror (e.g. Ascend block
-                    # tables) need the post-verify lengths; a stale mirror
-                    # under-sizes the tables and reads OOB.
+                    # Two readers need the post-verify lengths on the CPU
+                    # mirror: backends consuming it for metadata (e.g.
+                    # Ascend block tables -- a stale mirror under-sizes the
+                    # tables and reads OOB) and the NPU draft graph replay
+                    # (see replay_graph_needs_seq_lens_cpu, which builds
+                    # per-step seq_lens from it).
                     batch.seq_lens_cpu = new_seq_lens.to("cpu")
                     batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
                 # Width-only placeholder: init_new reads len(input_ids) into

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -955,32 +955,33 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                     )
 
             if not batch.forward_mode.is_idle():
-                # topk=1: draft_tokens = [seed, t1, ..., t(N-1)]; the chain output is [:, 1:]
-                ret_topk_index = draft_tokens[:, 1:].reshape(bs, -1)
-                # Greedy chain has no real branch scores; 1.0 matches the
-                # draft_extend seed convention.
-                ret_topk_p = torch.ones_like(ret_topk_index, dtype=torch.float32)
-
-                topk_index = next_draft_input.topk_index
-                topk_p = next_draft_input.topk_p
-
-                if self.hot_token_id is not None:
-                    # The seed is a draft-id argmax; map it to target-id
-                    # space. ret_topk_index is already mapped inside
-                    # draft_forward.
-                    topk_index = self.hot_token_id[topk_index]
-                # [seed | t1..t(N-1)] with width num_draft_tokens - 1; the
-                # next round consumes it via
+                # topk=1: draft_tokens is already the full chain
+                # [seed, t1, ..., t(N-1)] in TARGET id space -- the seed
+                # column is mapped inside draft_forward -- and is already
+                # num_draft_tokens - 1 wide; the next round consumes it via
                 # prepare_verify_input_for_draft_prefetch without re-running
-                # the draft model.
-                topk_index = torch.cat([topk_index, ret_topk_index], dim=1)
-                topk_p = torch.cat([topk_p, ret_topk_p], dim=1)
+                # the draft model. clone() detaches it from the graph
+                # runner's static output buffer, which the next replay
+                # overwrites. Intentional cross-round mutation:
+                # next_draft_input flows to the next round via batch_output
+                # and is NOT restored by the finally block below.
+                next_draft_input.topk_index = draft_tokens.clone()
 
-                # Intentional cross-round mutation: next_draft_input flows to
-                # the next round via batch_output and is NOT restored by the
-                # finally block below.
-                next_draft_input.topk_index = topk_index
-                next_draft_input.topk_p = topk_p
+                # Greedy chain has no real branch scores; 1.0 matches the
+                # draft_extend seed convention. Keeps the seed's
+                # probability at slot 0 and pads the width-1 seed p to the
+                # chain width.
+                next_draft_input.topk_p = torch.cat(
+                    [
+                        next_draft_input.topk_p,
+                        torch.ones(
+                            (bs, self.speculative_num_steps - 1),
+                            dtype=torch.float32,
+                            device=draft_tokens.device,
+                        ),
+                    ],
+                    dim=1,
+                )
         finally:
             (
                 batch.forward_mode,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -977,7 +977,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                         torch.ones(
                             (bs, self.speculative_num_steps - 1),
                             dtype=next_draft_input.topk_p.dtype,
-                            device=next_draft_input.topk_p.dtype.device,
+                            device=next_draft_input.topk_p.device,
                         ),
                     ],
                     dim=1,

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -39,7 +39,11 @@ from sglang.srt.model_executor.cuda_graph_config import (
     Phase,
     check_cuda_graph_backend,
 )
-from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardBatch
+from sglang.srt.model_executor.forward_batch_info import (
+    CaptureHiddenMode,
+    ForwardBatch,
+    ForwardMode,
+)
 from sglang.srt.model_executor.forward_context import ForwardContext, forward_context
 from sglang.srt.model_executor.runner import (
     DecodeCudaGraphRunner,
@@ -155,6 +159,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.speculative_algorithm = SpeculativeAlgorithm.from_string(
             get_spec().speculative_algorithm
         )
+        self.enable_draft_prefetch = get_spec().enable_draft_prefetch
 
         self._rebuild_topk1_chain_buffers()
 
@@ -773,6 +778,210 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         return None, None, None, None
 
+    def _pad_topk_for_draft_prefetch(self, topk_p, topk_index):
+        """Pad the prefill-side topk to the draft-prefetch candidate width
+        (steps * topk) so the pre-concatenation in draft_prefetch keeps a
+        uniform width across rounds.
+
+        The padded slots REPEAT the last (for topk=1: the only) candidate
+        instead of zero-padding: the first decode round's tree is then built
+        from the real prefill token repeated N times -- a valid chain (verify
+        accepts at most one of the duplicates), never a bogus token id 0.
+        Also normalizes the prefill seed to the TARGET id space (the
+        concatenated draft-prefetch buffer is uniformly target-id).
+        """
+        # [bs, topk] -> [bs, num_steps * topk]  (topk=1: [bs,1] -> [bs,N])
+        if self.enable_draft_prefetch and self.speculative_num_steps > 1:
+            if self.hot_token_id is not None:
+                topk_index = self.hot_token_id[topk_index]
+            topk_pad_size = self.speculative_num_steps * self.topk - topk_p.shape[-1]
+            if topk_pad_size > 0:
+                topk_p = torch.cat(
+                    [topk_p, topk_p[:, -1:].repeat(1, topk_pad_size)], dim=1
+                )
+                topk_index = torch.cat(
+                    [topk_index, topk_index[:, -1:].repeat(1, topk_pad_size)], dim=1
+                )
+        return topk_p, topk_index
+
+    def prepare_verify_input_for_draft_prefetch(
+        self, batch: ScheduleBatch
+    ) -> EagleVerifyInput:
+        """Draft-prefetch decode entry: build the EagleVerifyInput from the
+        pre-concatenated topk without running the draft model. The draft GPU
+        work already happened inside the previous round's draft_prefetch."""
+        assert self.speculative_num_steps > 1, (
+            "draft-prefetch requires num_steps > 1; _check_draft_prefetch "
+            "enforces this at startup"
+        )
+        draft_input: EagleDraftInput = batch.spec_info
+        topk_p = draft_input.topk_p
+        topk_index = draft_input.topk_index
+        parent_list = self._topk1_parents_prealloc[: topk_p.shape[0]]
+
+        # The buffer width is exactly num_draft_tokens - 1 (draft_prefetch
+        # concatenates [seed | N-1 predictions]; prefill pads to the same
+        # width), so this topk selects EVERY candidate. The sort restores
+        # chain order: topk returns score-ranked indices (all 1.0 in steady
+        # state, tie order arbitrary), while parent_list assumes position
+        # order.
+        top_scores = torch.topk(topk_p, self.speculative_num_draft_tokens - 1, dim=-1)
+        top_scores_index = torch.sort(top_scores.indices).values
+        maybe_detect_oob(
+            top_scores_index,
+            0,
+            topk_index.shape[1],
+            "draft_forward_for_prepare: top_scores_index OOB for gather on topk_index",
+        )
+        draft_tokens = torch.gather(topk_index, index=top_scores_index, dim=1)
+
+        return build_eagle_verify_input(
+            batch,
+            draft_input,
+            parent_list,
+            top_scores_index,
+            draft_tokens,
+            None,  # draft-prefetch: rejection sampling excluded
+            target_worker=self.target_worker,
+            topk=self.topk,
+            num_steps=self.speculative_num_steps,
+            num_draft_tokens=self.speculative_num_draft_tokens,
+            tree_mask_mode=self.tree_mask_mode,
+            device=self.device,
+        )
+
+    def draft_prefetch(
+        self,
+        batch: ScheduleBatch,
+        batch_output: GenerationBatchResult,
+    ) -> None:
+        """Draft-prefetch: pre-run the next round's draft right after this round's
+        draft_extend, and pre-concatenate its per-step topk into
+        batch_output.next_draft_input.
+
+        Runs on the forward stream, back-to-back with draft_extend, so the GPU
+        never idles waiting for the scheduler to re-dispatch the draft. KV slots
+        are NOT re-allocated: the req_to_token row mapping from the scheduler's
+        per-round alloc_for_spec_decode stays valid through the next round (no
+        mid-stream free), so prepare_for_draft's assign reads valid slots.
+        """
+        assert self.speculative_num_steps > 1, (
+            "draft_prefetch requires num_steps > 1; _check_draft_prefetch "
+            "enforces this at startup"
+        )
+        bs = batch.seq_lens.shape[0]
+        saved_state = (
+            batch.forward_mode,
+            batch.seq_lens,
+            batch.seq_lens_cpu,
+            batch.seq_lens_sum,
+            batch.spec_info,
+            batch.input_ids,
+            batch.out_cache_loc,
+        )
+        try:
+            next_draft_input = batch_output.next_draft_input
+            new_seq_lens = batch_output.new_seq_lens
+
+            # draft_extend left an EagleDraftExtendInput here; the pre-run
+            # draft decode reads the seed tokens (topk_index) from it.
+            batch.spec_info = next_draft_input
+            if not batch.forward_mode.is_idle():
+                # Disguise as the next round's decode batch: under
+                # DRAFT_EXTEND_V2, init_new would take the extend branch and
+                # misread the batch.
+                batch.forward_mode = ForwardMode.DECODE
+                # Post-verify lengths: they drive the draft KV slot
+                # assignment, positions (= seq_lens.repeat_interleave(topk))
+                # and the attention metadata.
+                batch.seq_lens = new_seq_lens
+                if getattr(
+                    self.draft_attn_backend, "needs_cpu_seq_lens", True
+                ) and getattr(
+                    self.cuda_graph_runner, "replay_graph_needs_seq_lens_cpu", True
+                ):
+                    # Backends consuming the CPU mirror (e.g. Ascend block
+                    # tables) need the post-verify lengths; a stale mirror
+                    # under-sizes the tables and reads OOB.
+                    batch.seq_lens_cpu = new_seq_lens.to("cpu")
+                    batch.seq_lens_sum = int(batch.seq_lens_cpu.sum())
+                # Width-only placeholder: init_new reads len(input_ids) into
+                # num_token_non_padded (DP padding), and draft_extend left a
+                # bs*num_draft_tokens-wide tensor here. Content is never read
+                # (draft_forward rebinds input_ids; graph runners don't copy it).
+                batch.input_ids = torch.zeros(
+                    bs, dtype=torch.int64, device=batch.device
+                )
+
+            forward_batch, can_run_decode_cuda_graph = prepare_for_draft(
+                next_draft_input,
+                self.req_to_token_pool,
+                batch,
+                self.cuda_graph_runner,
+                self.draft_runner,
+                self.topk,
+                self.speculative_num_steps,
+            )
+
+            if (
+                can_run_decode_cuda_graph
+                and not batch.forward_mode.is_idle()
+                and self.seed_dsa_topk_from_draft_extend
+                and next_draft_input.dsa_topk_indices is None
+            ):
+                can_run_decode_cuda_graph = False
+
+            with spec_stage_span("draft_prefetch"):
+                if can_run_decode_cuda_graph:
+                    _parent_list, _tsi, draft_tokens, _draft_probs = (
+                        self.cuda_graph_runner.execute(forward_batch)
+                    )
+                else:
+                    if not batch.forward_mode.is_idle():
+                        self.draft_attn_backend.init_forward_metadata(forward_batch)
+                        forward_batch.mark_forward_metadata_ready()
+                    _parent_list, _tsi, draft_tokens, _draft_probs = self.draft_forward(
+                        forward_batch
+                    )
+
+            if not batch.forward_mode.is_idle():
+                # topk=1: draft_tokens = [seed, t1, ..., t(N-1)]; the chain output is [:, 1:]
+                ret_topk_index = draft_tokens[:, 1:].reshape(bs, -1)
+                # Greedy chain has no real branch scores; 1.0 matches the
+                # draft_extend seed convention.
+                ret_topk_p = torch.ones_like(ret_topk_index, dtype=torch.float32)
+
+                topk_index = next_draft_input.topk_index
+                topk_p = next_draft_input.topk_p
+
+                if self.hot_token_id is not None:
+                    # The seed is a draft-id argmax; map it to target-id
+                    # space. ret_topk_index is already mapped inside
+                    # draft_forward.
+                    topk_index = self.hot_token_id[topk_index]
+                # [seed | t1..t(N-1)] with width num_draft_tokens - 1; the
+                # next round consumes it via
+                # prepare_verify_input_for_draft_prefetch without re-running
+                # the draft model.
+                topk_index = torch.cat([topk_index, ret_topk_index], dim=1)
+                topk_p = torch.cat([topk_p, ret_topk_p], dim=1)
+
+                # Intentional cross-round mutation: next_draft_input flows to
+                # the next round via batch_output and is NOT restored by the
+                # finally block below.
+                next_draft_input.topk_index = topk_index
+                next_draft_input.topk_p = topk_p
+        finally:
+            (
+                batch.forward_mode,
+                batch.seq_lens,
+                batch.seq_lens_cpu,
+                batch.seq_lens_sum,
+                batch.spec_info,
+                batch.input_ids,
+                batch.out_cache_loc,
+            ) = saved_state
+
     def draft_extend(self):
         pass
 
@@ -879,6 +1088,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             topk_p, topk_index = fast_sample(probs, num_samples=1)
         else:
             topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+        topk_p, topk_index = self._pad_topk_for_draft_prefetch(topk_p, topk_index)
         return EagleDraftInput(
             topk_p=topk_p,
             topk_index=topk_index,
@@ -1096,6 +1306,8 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 config_path=get_spec().speculative_adaptive_config,
             )
 
+        self.enable_draft_prefetch = get_spec().enable_draft_prefetch
+
         # Some dummy tensors
         self.num_new_pages_per_topk = torch.empty(
             (), dtype=torch.int64, device=self.device
@@ -1203,11 +1415,16 @@ class EAGLEWorkerV2(BaseSpecWorker):
                 hidden_size, hidden_dtype = get_draft_recurrent_hidden_state_spec(
                     self.draft_worker.draft_runner
                 )
+                # Draft-prefetch pre-concatenates the per-step topk along the
+                # candidate axis: the input width is steps * topk.
+                topk = self.topk * (
+                    self.speculative_num_steps if self.enable_draft_prefetch else 1
+                )
                 batch.spec_info = EagleDraftInput.create_idle_input(
                     device=self.device,
                     hidden_size=hidden_size,
                     dtype=hidden_dtype,
-                    topk=self.topk,
+                    topk=topk,
                     capture_hidden_mode=capture_mode,
                     vocab_size=self.target_worker.model_config.vocab_size,
                 )
@@ -1222,9 +1439,19 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     ),
                     speculative_moe_backend_context(),
                     speculative_moe_a2a_backend_context(),
-                    spec_stage_span("draft"),
                 ):
-                    verify_input: EagleVerifyInput = self.draft_worker.draft(batch)
+                    if self.enable_draft_prefetch:
+                        with spec_stage_span("prepare"):
+                            verify_input: EagleVerifyInput = (
+                                self.draft_worker.prepare_verify_input_for_draft_prefetch(
+                                    batch
+                                )
+                            )
+                    else:
+                        with spec_stage_span("draft"):
+                            verify_input: EagleVerifyInput = self.draft_worker.draft(
+                                batch
+                            )
             assert verify_input.is_verify_input()
             batch.spec_info = verify_input
             batch_output = self.verify(batch, grammar_barrier=grammar_barrier)
@@ -1246,6 +1473,11 @@ class EAGLEWorkerV2(BaseSpecWorker):
                     spec_stage_span("draft_extend"),
                 ):
                     self.draft_worker._draft_extend_for_decode(batch, batch_output)
+
+            # Draft-prefetch: pre-run the next round's draft right after
+            # draft_extend, back-to-back on the forward stream.
+            if self.enable_draft_prefetch:
+                self.draft_worker.draft_prefetch(batch, batch_output)
 
             return batch_output
 

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -976,8 +976,8 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                         next_draft_input.topk_p,
                         torch.ones(
                             (bs, self.speculative_num_steps - 1),
-                            dtype=torch.float32,
-                            device=draft_tokens.device,
+                            dtype=next_draft_input.topk_p.dtype,
+                            device=next_draft_input.topk_p.dtype.device,
                         ),
                     ],
                     dim=1,

--- a/test/registered/spec/eagle/test_spec_eagle_draft_prefetch.py
+++ b/test/registered/spec/eagle/test_spec_eagle_draft_prefetch.py
@@ -1,0 +1,71 @@
+"""--enable-draft-prefetch: pre-run the next round's draft after draft_extend.
+
+With draft prefetch, EAGLEWorkerV2 pre-runs the next round's draft decode
+back-to-back with this round's draft_extend (on the forward stream), and
+pre-concatenates the per-step topk into the next draft input. The next decode
+round then builds its verify input from the pre-concatenated candidate chain
+(prepare_verify_fully_async_decoding) instead of re-running the draft. This
+file guards that the optimization is lossless:
+
+  - greedy parity vs a non-spec reference server (SpecParityKit);
+  - acceptance length / verify bookkeeping (SpecCorrectnessKit);
+  - gsm8k quality + accept length (SpecAccuracyKit);
+  - radix / abort / grammar features with a strict memory check -- a leak from
+    the extra pre-run draft would trip it (SpecFeatureKit).
+
+Constraint surface (enforced by _check_draft_prefetch): EAGLE3, topk=1,
+num_steps > 1, non-adaptive, no rejection sampling. The unit tests for that
+validation live in test/registered/unit/spec/test_spec_draft_prefetch_args.py.
+"""
+
+import unittest
+
+from sglang.srt.environ import envs
+from sglang.test.ci.ci_register import register_cuda_ci
+from sglang.test.kits.spec_server_kits import (
+    SpecAccuracyKit,
+    SpecCorrectnessKit,
+    SpecFeatureKit,
+    SpecParityKit,
+)
+from sglang.test.server_fixtures.spec_eagle_fixture import Eagle3Base
+
+register_cuda_ci(est_time=900, stage="base-b", runner_config="1-gpu-small")
+
+
+class _DraftPrefetchBase(Eagle3Base):
+    """EAGLE3 topk=1 chain with the next-round draft pre-run enabled."""
+
+    extra_args = ("--enable-draft-prefetch",)
+    # The pre-run draft allocates/reorders state on the forward stream every
+    # round; turn leaks into failures.
+    env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
+
+
+class TestEagle3DraftPrefetch(
+    _DraftPrefetchBase, SpecCorrectnessKit, SpecAccuracyKit, SpecFeatureKit
+):
+    """Overlap scheduler -- the primary draft-prefetch pipeline."""
+
+    disable_overlap = False
+
+
+class TestEagle3DraftPrefetchNoOverlap(_DraftPrefetchBase, SpecCorrectnessKit):
+    """Synchronous scheduler: the pre-run draft has to work there too."""
+
+    disable_overlap = True
+
+
+class TestEagle3DraftPrefetchParity(SpecParityKit, _DraftPrefetchBase):
+    """Greedy output must equal the non-spec reference (lossless decode).
+
+    SpecParityKit is first in the bases so its setUpClass launches and kills
+    the reference server BEFORE the fixture launches the spec server (one
+    model resident at a time).
+    """
+
+    disable_overlap = False
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/spec/eagle/test_spec_eagle_draft_prefetch.py
+++ b/test/registered/spec/eagle/test_spec_eagle_draft_prefetch.py
@@ -4,8 +4,8 @@ With draft prefetch, EAGLEWorkerV2 pre-runs the next round's draft decode
 back-to-back with this round's draft_extend (on the forward stream), and
 pre-concatenates the per-step topk into the next draft input. The next decode
 round then builds its verify input from the pre-concatenated candidate chain
-(prepare_verify_fully_async_decoding) instead of re-running the draft. This
-file guards that the optimization is lossless:
+(prepare_verify_input_for_draft_prefetch) instead of re-running the draft.
+This file guards that the optimization is lossless:
 
   - greedy parity vs a non-spec reference server (SpecParityKit);
   - acceptance length / verify bookkeeping (SpecCorrectnessKit);
@@ -13,9 +13,10 @@ file guards that the optimization is lossless:
   - radix / abort / grammar features with a strict memory check -- a leak from
     the extra pre-run draft would trip it (SpecFeatureKit).
 
-Constraint surface (enforced by _check_draft_prefetch): EAGLE3, topk=1,
-num_steps > 1, non-adaptive, no rejection sampling. The unit tests for that
-validation live in test/registered/unit/spec/test_spec_draft_prefetch_args.py.
+Constraint surface (enforced by _check_draft_prefetch): EAGLE family (this
+file exercises EAGLE3), topk=1, num_steps > 1, non-adaptive, no rejection
+sampling. The unit tests for that validation live in
+test/registered/unit/spec/test_spec_draft_prefetch_args.py.
 """
 
 import unittest
@@ -38,7 +39,8 @@ class _DraftPrefetchBase(Eagle3Base):
 
     extra_args = ("--enable-draft-prefetch",)
     # The pre-run draft allocates/reorders state on the forward stream every
-    # round; turn leaks into failures.
+    # round, so leaks are likely here; the strict check turns them into
+    # failures.
     env_overrides = ((envs.SGLANG_ENABLE_STRICT_MEM_CHECK_DURING_BUSY, 1),)
 
 

--- a/test/registered/unit/platforms/test_platform_interface.py
+++ b/test/registered/unit/platforms/test_platform_interface.py
@@ -19,6 +19,7 @@ from sglang.srt.platforms.device_mixin import (
     PlatformEnum,
 )
 from sglang.srt.platforms.interface import SRTPlatform
+from sglang.srt.platforms.npu import NpuSRTPlatform
 from sglang.srt.platforms.rocm import RocmSRTPlatform
 from sglang.srt.platforms.xpu import XpuSRTPlatform
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -306,6 +307,134 @@ class TestXpuDeviceMixin(CustomTestCase):
         self.assertFalse(base.supports_fp8())
         self.assertTrue(base.support_cuda_graph())
         self.assertTrue(base.support_piecewise_cuda_graph())
+
+
+class TestNpuDeviceMixin(CustomTestCase):
+    """Tests for NPU device operation defaults."""
+
+    def setUp(self):
+        # torch.device("npu", ...) requires the "npu" device type, which
+        # torch_npu registers via the privateuse1 backend rename; CPU-only
+        # builds lack it. Register it per-test so only this suite carries
+        # the process-wide side effect.
+        try:
+            torch.utils.rename_privateuse1_backend("npu")
+        except Exception:
+            # Re-registration with a different name raises on some versions;
+            # real NPU machines may have already renamed the backend.
+            pass
+        super().setUp()
+
+    def test_default_get_device_returns_npu_device(self):
+        base = NpuSRTPlatform()
+        self.assertEqual(base.get_device(2), torch.device("npu", 2))
+
+    def test_default_get_device_capability_reports_zero(self):
+        # torch_npu's get_device_capability is configured via the environment
+        # variable TORCH_NPU_DEVICE_CAPABILITY purely for native-PyTorch
+        # compatibility; it does not reflect the real NPU hardware. The
+        # platform therefore reports (0, 0) without consulting torch.npu.
+        base = NpuSRTPlatform()
+        mock_npu = MagicMock()
+        with patch.object(torch, "npu", mock_npu, create=True):
+            self.assertEqual(base.get_device_capability(1), DeviceCapability(0, 0))
+        mock_npu.get_device_capability.assert_not_called()
+
+    def test_memory_queries_delegate_to_torch_npu(self):
+        base = NpuSRTPlatform()
+        mock_npu = MagicMock()
+        mock_npu.get_device_properties.return_value.total_memory = 32 * 1024**3
+        mock_npu.max_memory_allocated.return_value = 5 * 10**8
+        mock_npu.mem_get_info.return_value = (10**9, 2 * 10**9)
+        with patch.object(torch, "npu", mock_npu, create=True):
+            self.assertEqual(base.get_device_total_memory(1), 32 * 1024**3)
+            mock_npu.get_device_properties.assert_called_once_with(1)
+            self.assertEqual(base.get_current_memory_usage(), 5 * 10**8)
+            mock_npu.max_memory_allocated.assert_called_once_with(None)
+            device = torch.device("npu", 0)
+            base.get_current_memory_usage(device)
+            mock_npu.max_memory_allocated.assert_called_with(device)
+            self.assertEqual(base.get_available_memory(2), (10**9, 2 * 10**9))
+            mock_npu.mem_get_info.assert_called_once_with(2)
+
+    def test_device_info_queries_delegate_to_torch_npu(self):
+        base = NpuSRTPlatform()
+        mock_npu = MagicMock()
+        mock_npu.get_device_name.return_value = "Ascend910B4"
+        mock_npu.get_device_properties.return_value.uuid = "npu-uuid-0"
+        with patch.object(torch, "npu", mock_npu, create=True):
+            self.assertEqual(base.get_device_name(1), "Ascend910B4")
+            mock_npu.get_device_name.assert_called_once_with(1)
+            self.assertEqual(base.get_device_uuid(1), "npu-uuid-0")
+            mock_npu.get_device_properties.assert_called_once_with(1)
+
+    def test_device_state_ops_delegate_to_torch_npu(self):
+        base = NpuSRTPlatform()
+        mock_npu = MagicMock()
+        with patch.object(torch, "npu", mock_npu, create=True):
+            device = torch.device("npu", 3)
+            base.set_device(device)
+            mock_npu.set_device.assert_called_once_with(device)
+            base.empty_cache()
+            mock_npu.empty_cache.assert_called_once()
+            base.synchronize()
+            mock_npu.synchronize.assert_called_once()
+
+    def test_pin_memory_available_for_npu_targets(self):
+        base = NpuSRTPlatform()
+        self.assertTrue(base.is_pin_memory_available())
+        self.assertTrue(base.is_pin_memory_available(device="npu"))
+        self.assertTrue(base.is_pin_memory_available(device=torch.device("npu", 0)))
+        self.assertFalse(base.is_pin_memory_available(device="cpu"))
+        self.assertFalse(base.is_pin_memory_available(device=torch.device("cpu")))
+
+    def test_default_seed_everything_seeds_npu(self):
+        mock_npu = MagicMock()
+        with (
+            patch.object(torch, "npu", mock_npu, create=True),
+            patch("torch.manual_seed") as mock_torch_seed,
+            patch("sglang.srt.platforms.device_mixin.np.random.seed") as mock_np_seed,
+            patch("sglang.srt.platforms.device_mixin.random.seed") as mock_random_seed,
+        ):
+            NpuSRTPlatform.seed_everything(123)
+        mock_random_seed.assert_called_once_with(123)
+        mock_np_seed.assert_called_once_with(123)
+        mock_torch_seed.assert_called_once_with(123)
+        mock_npu.manual_seed_all.assert_called_once_with(123)
+
+    def test_seed_everything_none_seed_is_noop(self):
+        mock_npu = MagicMock()
+        with (
+            patch.object(torch, "npu", mock_npu, create=True),
+            patch("torch.manual_seed") as mock_torch_seed,
+            patch("sglang.srt.platforms.device_mixin.np.random.seed") as mock_np_seed,
+            patch("sglang.srt.platforms.device_mixin.random.seed") as mock_random_seed,
+        ):
+            NpuSRTPlatform.seed_everything(None)
+        mock_random_seed.assert_not_called()
+        mock_np_seed.assert_not_called()
+        mock_torch_seed.assert_not_called()
+        mock_npu.manual_seed_all.assert_not_called()
+
+    def test_npu_srt_platform_identity(self):
+        base = NpuSRTPlatform()
+        self.assertTrue(base.is_npu())
+        self.assertFalse(base.is_cuda())
+        self.assertFalse(base.is_cuda_alike())
+        self.assertEqual(base.device_name, "npu")
+        self.assertEqual(base.device_type, "npu")
+
+    def test_get_default_attention_backend_is_ascend(self):
+        self.assertEqual(NpuSRTPlatform().get_default_attention_backend(), "ascend")
+
+    def test_get_dispatch_key_name_is_npu(self):
+        self.assertEqual(NpuSRTPlatform().get_dispatch_key_name(), "npu")
+
+    def test_npu_srt_platform_capabilities(self):
+        base = NpuSRTPlatform()
+        self.assertTrue(base.supports_fp8())
+        self.assertTrue(base.support_cuda_graph())
+        self.assertFalse(base.support_piecewise_cuda_graph())
 
 
 class TestCpuDeviceMixin(CustomTestCase):

--- a/test/registered/unit/spec/test_spec_draft_prefetch_args.py
+++ b/test/registered/unit/spec/test_spec_draft_prefetch_args.py
@@ -1,0 +1,181 @@
+"""Unit tests for the --enable-draft-prefetch server-arg validation.
+
+Covers _check_draft_prefetch (sglang.srt.arg_groups.speculative_hook): the
+feature only supports EAGLE/EAGLE3/NEXTN with topk=1 and num_steps > 1, is
+incompatible with adaptive speculative decoding, rejection sampling and
+multi-layer EAGLE, and must be a no-op for configs that don't enable it. The
+E2E behavior is covered by test/registered/spec/eagle/test_spec_eagle_draft_prefetch.py.
+"""
+
+import unittest
+
+from sglang.srt.arg_groups.speculative_hook import _check_draft_prefetch
+from sglang.srt.environ import envs
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+_HOOK_LOGGER = "sglang.srt.arg_groups.speculative_hook"
+
+
+def _make_args(**overrides) -> ServerArgs:
+    # model_path="dummy" short-circuits ServerArgs.__post_init__; invoke the
+    # validation hook directly (same pattern as test_spec_cpu_overlap_constraint).
+    args = ServerArgs(model_path="dummy")
+    args.speculative_algorithm = "EAGLE3"
+    args.speculative_num_steps = 5
+    args.speculative_eagle_topk = 1
+    args.speculative_num_draft_tokens = 6
+    args.enable_draft_prefetch = True
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+class TestDraftPrefetchArgValidation(CustomTestCase):
+    def test_supported_algorithms_pass(self):
+        for algo in ("EAGLE3", "EAGLE"):
+            with self.subTest(algo=algo):
+                _check_draft_prefetch(_make_args(speculative_algorithm=algo))
+
+    def test_nextn_promoted_to_eagle_passes(self):
+        # NEXTN never reaches the check as-is: the alias hook promotes it to
+        # EAGLE in the resolution stash before _check_draft_prefetch runs, so
+        # the check only ever sees EAGLE (never "NEXTN").
+        args = _make_args(speculative_algorithm="NEXTN")
+        args._resolved_overrides = [
+            ("handle_speculative_decoding", {"speculative_algorithm": "EAGLE"}),
+        ]
+        _check_draft_prefetch(args)
+
+    def test_disabled_skips_validation(self):
+        # topk>1 / num_steps<=1 / other algorithms are only rejected when the
+        # feature is enabled; other spec configs must stay unaffected.
+        _check_draft_prefetch(
+            _make_args(
+                enable_draft_prefetch=False,
+                speculative_eagle_topk=8,
+                speculative_adaptive=True,
+            )
+        )
+        _check_draft_prefetch(
+            _make_args(
+                enable_draft_prefetch=False,
+                speculative_algorithm="DFLASH",
+                speculative_num_steps=1,
+                speculative_eagle_topk=1,
+            )
+        )
+        _check_draft_prefetch(
+            _make_args(
+                enable_draft_prefetch=False,
+                speculative_num_steps=None,
+            )
+        )
+
+    def test_num_steps_must_exceed_one(self):
+        for steps in (None, 1):
+            with self.subTest(num_steps=steps):
+                args = _make_args(speculative_num_steps=steps)
+                with self.assertRaisesRegex(ValueError, "num-steps > 1"):
+                    _check_draft_prefetch(args)
+        # 2 steps (the minimum chain with a pre-run draft) is accepted.
+        _check_draft_prefetch(
+            _make_args(speculative_num_steps=2, speculative_num_draft_tokens=3)
+        )
+
+    def test_unsupported_algorithm_rejected(self):
+        args = _make_args(speculative_algorithm="DFLASH")
+        with self.assertRaisesRegex(ValueError, "only supports EAGLE/EAGLE3/NEXTN"):
+            _check_draft_prefetch(args)
+
+    def test_topk_not_one_rejected(self):
+        args = _make_args(speculative_eagle_topk=2)
+        with self.assertRaisesRegex(ValueError, "topk == 1"):
+            _check_draft_prefetch(args)
+
+    def test_adaptive_rejected(self):
+        args = _make_args(speculative_adaptive=True)
+        with self.assertRaisesRegex(ValueError, "speculative-adaptive"):
+            _check_draft_prefetch(args)
+
+    def test_multi_layer_eagle_rejected(self):
+        # Explicit flag: raw field set directly on the record.
+        args = _make_args(enable_multi_layer_eagle=True)
+        with self.assertRaisesRegex(ValueError, "multi-layer EAGLE"):
+            _check_draft_prefetch(args)
+
+    def test_multi_layer_eagle_declared_override_rejected(self):
+        # Auto-declared by a model override (e.g. MiMoV2): the field stays
+        # False; the check must read it through resolved_view's overlay.
+        args = _make_args()
+        args._resolved_overrides = [
+            ("_mimo_v2_overrides", {"enable_multi_layer_eagle": True}),
+        ]
+        with self.assertRaisesRegex(ValueError, "multi-layer EAGLE"):
+            _check_draft_prefetch(args)
+
+    def test_reads_resolution_overlay(self):
+        # declare_resolution never writes the fields during __post_init__;
+        # the decisions live only in the stash. The check must read through
+        # the overlay: raw reads would reject auto-params configs
+        # (num_steps/topk derived, fields still None), lowercase CLI
+        # algorithms (upper() declared), and auto-disabled adaptive.
+        args = _make_args()
+        args.speculative_algorithm = "eagle3"
+        args.speculative_num_steps = None
+        args.speculative_eagle_topk = None
+        args.speculative_adaptive = True
+        args._resolved_overrides = [
+            ("handle_speculative_decoding", {"speculative_algorithm": "EAGLE3"}),
+            (
+                "_handle_eagle_family.auto_params",
+                {
+                    "speculative_num_steps": 3,
+                    "speculative_eagle_topk": 1,
+                    "speculative_num_draft_tokens": 4,
+                },
+            ),
+            ("_maybe_disable_adaptive", {"speculative_adaptive": False}),
+        ]
+        _check_draft_prefetch(args)
+
+    def test_alias_promoted_algorithm_rejected(self):
+        # Gemma4 assistant drafts promote NEXTN/EAGLE to FROZEN_KV_MTP in
+        # the stash while the raw field keeps the user's input; a raw read
+        # would let the promoted algorithm through the gate.
+        args = _make_args(speculative_algorithm="NEXTN")
+        args._resolved_overrides = [
+            (
+                "handle_speculative_decoding",
+                {"speculative_algorithm": "FROZEN_KV_MTP"},
+            ),
+        ]
+        with self.assertRaisesRegex(ValueError, "only supports EAGLE/EAGLE3/NEXTN"):
+            _check_draft_prefetch(args)
+
+    def test_rejection_sampling_rejected(self):
+        args = _make_args(speculative_use_rejection_sampling=True)
+        with self.assertRaisesRegex(ValueError, "rejection-sampling"):
+            _check_draft_prefetch(args)
+
+    def test_overlap_plan_stream_warns(self):
+        args = _make_args()
+        with envs.SGLANG_ENABLE_OVERLAP_PLAN_STREAM.override(True):
+            with self.assertLogs(_HOOK_LOGGER, "WARNING") as logs:
+                _check_draft_prefetch(args)
+        self.assertTrue(
+            any("OVERLAP_PLAN_STREAM" in message for message in logs.output),
+            f"expected an overlap-plan-stream warning, got: {logs.output}",
+        )
+
+    def test_no_warning_when_feature_simply_enabled(self):
+        # A plain enabled config must validate silently (no warnings).
+        with self.assertNoLogs(_HOOK_LOGGER, "WARNING"):
+            _check_draft_prefetch(_make_args())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

Move the Draft process from the beginning of each `run_batch` step (Draft -> Verify -> DraftExtend) to the end of the preceding `run_batch` step (Prepare -> Verify -> DraftExtend -> Draft). Aims to reduce bubbles introduced by the CPU-side hostbound nature of Draft.

## Modifications

<!-- Detail the changes made in this pull request. -->

There is a dependency on a [PR#36472](https://github.com/sgl-project/sglang/pull/36472) intended to standardize the use of `pin_memory`; that PR must be merged first.

- Added two configurable parameters:
  - `--enable-draft-prefetch` is the primary configuration parameter for this PR; it is disabled by default but enables the feature—allowing for the pre-execution of drafts—when configured.
  - `--skip-draft-prefetch-seq-lens-cpu-sync` is an optional configuration parameter for this PR (disabled by default). When enabled, it skips the `seq_lens_cpu` synchronization within `draft_prefetch`. Since this synchronization significantly impacts performance, users can manually enable this flag to bypass it for certain models to boost performance; however, enabling it may cause errors or affect the accepted sequence length for models that rely on `seq_lens_cpu`.
- When enabling the feature:
  - Replaced the original `draft` method with the `prepare` method, wrapping the result passed from the previous round into a valid input for `verify`.
  - After the `draft_extend` method completes, the core method `draft_prefetch` is executed to pre-calculate the draft.
- To achieve performance gains, `pin_memory=True` was added to operations involving H-to-D transfers within `ForwardBatch.init_new`.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

todo 

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

todo

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.



<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33834611380](https://github.com/sgl-project/sglang/actions/runs/33834611380)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33834611186](https://github.com/sgl-project/sglang/actions/runs/33834611186)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33834611376](https://github.com/sgl-project/sglang/actions/runs/33834611376)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->