### PR TITLE
Support GLM-5.3 multimodal processor inputs

### DIFF
--- a/python/sglang/srt/configs/glm5_next.py
+++ b/python/sglang/srt/configs/glm5_next.py
@@ -3,7 +3,11 @@ from typing import List, Optional, Union
 from transformers.configuration_utils import PretrainedConfig
 from transformers.models.glm_ocr.configuration_glm_ocr import GlmOcrVisionConfig
 
+from sglang.srt.configs.glm5_next_processing import Glm5NextProcessor
 from sglang.srt.configs.mamba_utils import KimiLinearCacheParams, KimiLinearStateShape
+from sglang.srt.multimodal.customized_mm_processor_utils import (
+    register_customized_processor,
+)
 from sglang.srt.runtime_context import get_parallel
 
 _GLM5_NEXT_TOP_LEVEL_CONFIG_KEYS = (
@@ -290,6 +294,7 @@ class Glm5NextVisionConfig(GlmOcrVisionConfig):
         self.swiglu_limit = swiglu_limit
 
 
+@register_customized_processor(Glm5NextProcessor)
 class Glm5NextConfig(PretrainedConfig):
     model_type = "glm5_next"
     sub_configs = {

--- a/python/sglang/srt/configs/glm5_next_processing.py
+++ b/python/sglang/srt/configs/glm5_next_processing.py
@@ -1,0 +1,350 @@
+# Copyright 2026 the HuggingFace Team. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+"""GLM-5.3 image-processor compatibility for Transformers 5.12.1.
+
+The image preprocessing is adapted from Transformers commit
+eb4d9e2a64a013bec12289288b85d0b1210ba0aa. Remove this compatibility module
+once SGLang's Transformers pin provides ``Glm5NextProcessor``.
+"""
+
+import math
+
+import torch
+from torchvision.transforms.v2 import functional as tvF
+from transformers import AutoTokenizer
+from transformers.image_processing_backends import TorchvisionBackend
+from transformers.image_processing_utils import BatchFeature
+from transformers.image_transforms import group_images_by_shape, reorder_images
+from transformers.image_utils import (
+    OPENAI_CLIP_MEAN,
+    OPENAI_CLIP_STD,
+    ImageInput,
+    PILImageResampling,
+    SizeDict,
+)
+from transformers.models.glm46v.processing_glm46v import Glm46VProcessor
+from transformers.models.glm46v.video_processing_glm46v import (
+    Glm46VVideoProcessor,
+)
+from transformers.processing_utils import ImagesKwargs, Unpack
+from transformers.utils import TensorType
+
+
+class Glm5NextImageProcessorKwargs(ImagesKwargs, total=False):
+    patch_size: int
+    temporal_patch_size: int
+    merge_size: int
+    patch_expand_factor: int
+    min_image_tokens: int
+    max_image_tokens: int
+
+
+def smart_resize(
+    num_frames: int,
+    height: int,
+    width: int,
+    temporal_factor: int = 2,
+    factor: int = 28,
+    min_pixels: int = 16,
+    max_pixels: int = 8000,
+) -> tuple[int, int]:
+    """Compute an aligned canvas within the spatiotemporal pixel budget."""
+    pixels_per_token = temporal_factor * factor**2
+    min_pixels *= pixels_per_token
+    max_pixels *= pixels_per_token
+
+    def align(value: int) -> int:
+        return math.ceil(value / factor) * factor
+
+    def fit_within_budget(aligned_frames: int) -> tuple[int, int]:
+        minimum_pixels = aligned_frames * factor**2
+        if max_pixels < minimum_pixels:
+            raise ValueError(
+                f"max_pixels={max_pixels} is too small. "
+                f"At least {minimum_pixels} pixels are required for one aligned patch."
+            )
+
+        low, high = 1, height
+        best_height = best_width = factor
+        while low <= high:
+            content_height = (low + high) // 2
+            content_width = max(1, math.floor(width * content_height / height))
+            candidate_height = align(content_height)
+            candidate_width = align(content_width)
+            if aligned_frames * candidate_height * candidate_width <= max_pixels:
+                best_height, best_width = candidate_height, candidate_width
+                low = content_height + 1
+            else:
+                high = content_height - 1
+        return best_height, best_width
+
+    aligned_frames = max(
+        temporal_factor, round(num_frames / temporal_factor) * temporal_factor
+    )
+    aligned_height = align(height)
+    aligned_width = align(width)
+    aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+
+    if aligned_pixel_budget < min_pixels:
+        scale = math.sqrt(min_pixels / (num_frames * height * width))
+        aligned_height = align(max(1, math.ceil(height * scale)))
+        aligned_width = align(max(1, math.ceil(width * scale)))
+        aligned_pixel_budget = aligned_frames * aligned_height * aligned_width
+
+    if aligned_pixel_budget > max_pixels:
+        aligned_height, aligned_width = fit_within_budget(aligned_frames)
+
+    return aligned_height, aligned_width
+
+
+class Glm5NextImageProcessor(TorchvisionBackend):
+    """Image-only GLM-5.3 processor matching the upstream dynamic resize."""
+
+    do_resize = True
+    resample = PILImageResampling.BICUBIC
+    size = {"longest_edge": 1}
+    default_to_square = False
+    do_rescale = True
+    rescale_factor = 1 / 255
+    do_normalize = True
+    image_mean = OPENAI_CLIP_MEAN
+    image_std = OPENAI_CLIP_STD
+    do_convert_rgb = True
+    patch_size = 14
+    temporal_patch_size = 2
+    merge_size = 2
+    valid_kwargs = Glm5NextImageProcessorKwargs
+    model_input_names = ["pixel_values", "image_grid_thw"]
+    patch_expand_factor = 1
+    min_image_tokens = 16
+    max_image_tokens = 8000
+
+    def preprocess(
+        self,
+        images: ImageInput,
+        **kwargs: Unpack[Glm5NextImageProcessorKwargs],
+    ) -> BatchFeature:
+        return super().preprocess(images, **kwargs)
+
+    def resize(
+        self,
+        images: torch.Tensor,
+        resample: "PILImageResampling | tvF.InterpolationMode | int | None",
+        factor: int,
+        temporal_factor: int,
+        min_image_tokens: int,
+        max_image_tokens: int,
+        **kwargs,
+    ) -> torch.Tensor:
+        """Resize without upscaling normal images, then pad to the GLM canvas."""
+        height, width = images.shape[-2:]
+        target_height, target_width = smart_resize(
+            height=height,
+            width=width,
+            num_frames=temporal_factor,
+            factor=factor,
+            temporal_factor=temporal_factor,
+            min_pixels=min_image_tokens,
+            max_pixels=max_image_tokens,
+        )
+
+        pixels_per_token = temporal_factor * factor**2
+        scale = min(target_height / height, target_width / width)
+        if temporal_factor * height * width >= pixels_per_token * min_image_tokens:
+            scale = min(1.0, scale)
+        content_height = max(1, min(target_height, math.floor(height * scale)))
+        content_width = max(1, min(target_width, math.floor(width * scale)))
+
+        if (content_height, content_width) != (height, width):
+            images = super().resize(
+                images,
+                SizeDict(height=content_height, width=content_width),
+                resample=resample,
+            )
+        return tvF.pad(
+            images,
+            [0, 0, target_width - content_width, target_height - content_height],
+            fill=0,
+        )
+
+    @staticmethod
+    def patchify(
+        images: torch.Tensor,
+        patch_size: int,
+        merge_size: int,
+        temporal_patch_size: int,
+    ) -> tuple[torch.Tensor, int, int]:
+        """Flatten images in the patch order consumed by the visual tower."""
+        batch_size, channel, resized_height, resized_width = images.shape
+        grid_h, grid_w = resized_height // patch_size, resized_width // patch_size
+        patches = images.reshape(
+            batch_size,
+            channel,
+            grid_h // merge_size,
+            merge_size,
+            patch_size,
+            grid_w // merge_size,
+            merge_size,
+            patch_size,
+        )
+        patches = patches.permute(0, 2, 5, 3, 6, 1, 4, 7)
+        flattened = (
+            patches.unsqueeze(6)
+            .expand(
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                -1,
+                temporal_patch_size,
+                -1,
+                -1,
+            )
+            .reshape(
+                batch_size,
+                grid_h * grid_w,
+                channel * temporal_patch_size * patch_size * patch_size,
+            )
+        )
+        return flattened, grid_h, grid_w
+
+    def _preprocess(
+        self,
+        images: list[torch.Tensor],
+        do_resize: bool,
+        size: SizeDict,
+        resample: "PILImageResampling | tvF.InterpolationMode | int | None",
+        do_rescale: bool,
+        rescale_factor: float,
+        do_normalize: bool,
+        image_mean: float | list[float] | None,
+        image_std: float | list[float] | None,
+        patch_size: int,
+        temporal_patch_size: int,
+        merge_size: int,
+        patch_expand_factor: int,
+        min_image_tokens: int,
+        max_image_tokens: int,
+        disable_grouping: bool | None,
+        return_tensors: str | TensorType | None,
+        **kwargs,
+    ) -> BatchFeature:
+        del size
+        grouped, grouped_index = group_images_by_shape(
+            images, disable_grouping=disable_grouping
+        )
+        resized_groups = {}
+        for shape, stacked_images in grouped.items():
+            if do_resize:
+                stacked_images = self.resize(
+                    images=stacked_images,
+                    resample=resample,
+                    factor=patch_size * merge_size * patch_expand_factor,
+                    temporal_factor=temporal_patch_size,
+                    min_image_tokens=min_image_tokens,
+                    max_image_tokens=max_image_tokens,
+                )
+            resized_groups[shape] = stacked_images
+        resized_images = reorder_images(resized_groups, grouped_index)
+
+        grouped, grouped_index = group_images_by_shape(
+            resized_images, disable_grouping=disable_grouping
+        )
+        processed_groups = {}
+        grid_groups = {}
+        for shape, stacked_images in grouped.items():
+            stacked_images = self.rescale_and_normalize(
+                stacked_images,
+                do_rescale,
+                rescale_factor,
+                do_normalize,
+                image_mean,
+                image_std,
+            )
+            patches, grid_h, grid_w = self.patchify(
+                stacked_images,
+                patch_size=patch_size,
+                merge_size=merge_size,
+                temporal_patch_size=temporal_patch_size,
+            )
+            processed_groups[shape] = patches
+            grid_groups[shape] = [[1, grid_h, grid_w]] * len(stacked_images)
+
+        processed_images = reorder_images(processed_groups, grouped_index)
+        processed_grids = reorder_images(grid_groups, grouped_index)
+        pixel_values = (
+            processed_images[0]
+            if len(processed_images) == 1
+            else torch.cat(processed_images, dim=0)
+        )
+        image_grid_thw = torch.tensor(processed_grids)
+        return BatchFeature(
+            data={
+                "pixel_values": pixel_values,
+                "image_grid_thw": image_grid_thw,
+            },
+            tensor_type=return_tensors,
+        )
+
+    def get_number_of_image_patches(
+        self,
+        height: int,
+        width: int,
+        images_kwargs: dict | None = None,
+    ) -> int:
+        images_kwargs = images_kwargs or {}
+        patch_size = images_kwargs.get("patch_size", self.patch_size)
+        merge_size = images_kwargs.get("merge_size", self.merge_size)
+        min_image_tokens = images_kwargs.get("min_image_tokens", self.min_image_tokens)
+        max_image_tokens = images_kwargs.get("max_image_tokens", self.max_image_tokens)
+        resized_height, resized_width = smart_resize(
+            num_frames=self.temporal_patch_size,
+            height=height,
+            width=width,
+            factor=patch_size * merge_size,
+            min_pixels=min_image_tokens,
+            max_pixels=max_image_tokens,
+            temporal_factor=self.temporal_patch_size,
+        )
+        return (resized_height // patch_size) * (resized_width // patch_size)
+
+
+class Glm5NextProcessor(Glm46VProcessor):
+    """Build GLM-5.3's image processor on the pinned Transformers version."""
+
+    @classmethod
+    def from_pretrained(cls, pretrained_model_name_or_path, *args, **kwargs):
+        processor_config, _ = cls.get_processor_dict(
+            pretrained_model_name_or_path, **kwargs
+        )
+
+        image_config = dict(processor_config.get("image_processor", {}))
+        image_config.pop("image_processor_type", None)
+        image_processor = Glm5NextImageProcessor(**image_config)
+
+        tokenizer = AutoTokenizer.from_pretrained(
+            pretrained_model_name_or_path, *args, **kwargs
+        )
+        return cls(
+            image_processor=image_processor,
+            tokenizer=tokenizer,
+            # ProcessorMixin 5.12 requires every declared component. This
+            # compatibility layer only changes GLM-5.3 image preprocessing.
+            video_processor=Glm46VVideoProcessor(),
+            chat_template=processor_config.get(
+                "chat_template", getattr(tokenizer, "chat_template", None)
+            ),
+        )

--- a/python/sglang/srt/multimodal/processors/glm4v.py
+++ b/python/sglang/srt/multimodal/processors/glm4v.py
@@ -425,6 +425,15 @@ def glm_sample_and_decode_sync(vr, video_config=None):
     return frames, _glm_video_metadata(len(vr), fps, duration, indices)
 
 
+def _collapse_consecutive_token_ids(input_ids: list[int], token_id: int) -> list[int]:
+    """Collapse processor-expanded placeholder spans back to one token."""
+    return [
+        current
+        for index, current in enumerate(input_ids)
+        if current != token_id or index == 0 or input_ids[index - 1] != token_id
+    ]
+
+
 class Glm4vImageProcessor(SGLangBaseProcessor):
     smart_rgb_conversion = True
     video_preprocessing_device = "cpu"
@@ -503,6 +512,13 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
         *args,
         **kwargs,
     ):
+        # RL clients can send the processor-expanded input IDs together with
+        # the original images. Collapse each image-token span before media
+        # loading so one image is not interpreted as N separate placeholders;
+        # process_and_combine_mm_data will expand it to the same span again.
+        if isinstance(input_text, list):
+            input_text = _collapse_consecutive_token_ids(input_text, self.IM_TOKEN_ID)
+
         # Normalize inline media dictionaries before loading. In particular, a
         # bare base64 video must go through SGLang's decoder rather than being
         # forwarded to the HF video loader as a path-like string.

--- a/python/sglang/srt/multimodal/processors/glm4v.py
+++ b/python/sglang/srt/multimodal/processors/glm4v.py
@@ -610,7 +610,7 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
             hf_config=self.hf_config,
             image_grid_thw=getattr(ret, "image_grid_thw", None),
             video_grid_thw=getattr(ret, "video_grid_thw", None),
-            attention_mask=getattr(ret, "attention_mask", None),
+            attention_mask=None,
         )
         mrope_positions = mrope_positions.squeeze(1)
 

--- a/python/sglang/srt/multimodal/processors/glm4v.py
+++ b/python/sglang/srt/multimodal/processors/glm4v.py
@@ -425,12 +425,16 @@ def glm_sample_and_decode_sync(vr, video_config=None):
     return frames, _glm_video_metadata(len(vr), fps, duration, indices)
 
 
-def _collapse_consecutive_token_ids(input_ids: list[int], token_id: int) -> list[int]:
-    """Collapse processor-expanded placeholder spans back to one token."""
+def _collapse_glm5_next_image_tokens(
+    input_ids: list[int], image_token_id: int
+) -> list[int]:
+    """Collapse GLM-5.3 processor-expanded image spans to placeholders."""
     return [
         current
         for index, current in enumerate(input_ids)
-        if current != token_id or index == 0 or input_ids[index - 1] != token_id
+        if current != image_token_id
+        or index == 0
+        or input_ids[index - 1] != image_token_id
     ]
 
 
@@ -516,8 +520,8 @@ class Glm4vImageProcessor(SGLangBaseProcessor):
         # the original images. Collapse each image-token span before media
         # loading so one image is not interpreted as N separate placeholders;
         # process_and_combine_mm_data will expand it to the same span again.
-        if isinstance(input_text, list):
-            input_text = _collapse_consecutive_token_ids(input_text, self.IM_TOKEN_ID)
+        if self.hf_config.model_type == "glm5_next" and isinstance(input_text, list):
+            input_text = _collapse_glm5_next_image_tokens(input_text, self.IM_TOKEN_ID)
 
         # Normalize inline media dictionaries before loading. In particular, a
         # bare base64 video must go through SGLang's decoder rather than being

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -279,6 +279,20 @@ def get_processor(
                 revision=revision,
                 **kwargs,
             )
+        elif config.model_type == "glm5_next":
+            # The matching Miles plugin backports the official GLM-5.3 image
+            # processor while this branch remains pinned to Transformers 5.12.1.
+            # Reuse it so rollout and training produce identical pixels/tokens.
+            from miles_plugins.models.glm5_next.processor import (
+                load_glm5_next_processor,
+            )
+
+            processor = load_glm5_next_processor(
+                tokenizer_name,
+                trust_remote_code=trust_remote_code,
+                revision=revision,
+                **kwargs,
+            )
         else:
             if config.model_type in _CUSTOMIZED_MM_PROCESSOR:
                 processor = _CUSTOMIZED_MM_PROCESSOR[config.model_type].from_pretrained(

--- a/python/sglang/srt/utils/hf_transformers/processor.py
+++ b/python/sglang/srt/utils/hf_transformers/processor.py
@@ -279,20 +279,6 @@ def get_processor(
                 revision=revision,
                 **kwargs,
             )
-        elif config.model_type == "glm5_next":
-            # The matching Miles plugin backports the official GLM-5.3 image
-            # processor while this branch remains pinned to Transformers 5.12.1.
-            # Reuse it so rollout and training produce identical pixels/tokens.
-            from miles_plugins.models.glm5_next.processor import (
-                load_glm5_next_processor,
-            )
-
-            processor = load_glm5_next_processor(
-                tokenizer_name,
-                trust_remote_code=trust_remote_code,
-                revision=revision,
-                **kwargs,
-            )
         else:
             if config.model_type in _CUSTOMIZED_MM_PROCESSOR:
                 processor = _CUSTOMIZED_MM_PROCESSOR[config.model_type].from_pretrained(

--- a/test/registered/unit/multimodal/test_glm4v_processor.py
+++ b/test/registered/unit/multimodal/test_glm4v_processor.py
@@ -1,3 +1,7 @@
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
 from sglang.srt.multimodal.processors.glm4v import _collapse_consecutive_token_ids
 
 

--- a/test/registered/unit/multimodal/test_glm4v_processor.py
+++ b/test/registered/unit/multimodal/test_glm4v_processor.py
@@ -1,0 +1,19 @@
+from sglang.srt.multimodal.processors.glm4v import _collapse_consecutive_token_ids
+
+
+def test_collapse_consecutive_token_ids_preserves_distinct_placeholders():
+    image_token_id = 99
+    input_ids = [1, 99, 99, 99, 2, 99, 99, 3]
+
+    assert _collapse_consecutive_token_ids(input_ids, image_token_id) == [
+        1,
+        99,
+        2,
+        99,
+        3,
+    ]
+
+
+def test_collapse_consecutive_token_ids_handles_boundaries_and_empty_input():
+    assert _collapse_consecutive_token_ids([99, 99, 1, 99, 99], 99) == [99, 1, 99]
+    assert _collapse_consecutive_token_ids([], 99) == []

--- a/test/registered/unit/multimodal/test_glm4v_processor.py
+++ b/test/registered/unit/multimodal/test_glm4v_processor.py
@@ -1,23 +1,169 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import numpy as np
+import pytest
+import torch
+from PIL import Image
+
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 
-from sglang.srt.multimodal.processors.glm4v import _collapse_consecutive_token_ids
+from sglang.srt.configs.glm5_next_processing import (
+    Glm5NextImageProcessor,
+    Glm5NextProcessor,
+    smart_resize,
+)
+from sglang.srt.layers.rotary_embedding import MRotaryEmbedding
+from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+from sglang.srt.multimodal.customized_mm_processor_utils import (
+    _CUSTOMIZED_MM_PROCESSOR,
+)
+from sglang.srt.multimodal.processors.base_processor import (
+    BaseMultiModalProcessorOutput,
+    MultimodalSpecialTokens,
+)
+from sglang.srt.multimodal.processors.glm4v import (
+    Glm4vImageProcessor,
+    _collapse_glm5_next_image_tokens,
+)
+from sglang.srt.utils.hf_transformers import processor as processor_module
 
 
-def test_collapse_consecutive_token_ids_preserves_distinct_placeholders():
+def test_glm5_next_image_processor_uses_dynamic_padded_grid():
+    pixels = np.arange(48 * 64 * 3, dtype=np.uint8).reshape(48, 64, 3)
+
+    output = Glm5NextImageProcessor()(
+        images=Image.fromarray(pixels), return_tensors="pt"
+    )
+
+    assert output.image_grid_thw.tolist() == [[1, 8, 10]]
+    assert output.pixel_values.shape == (80, 1176)
+    assert output.pixel_values.isfinite().all()
+
+
+def test_glm5_next_smart_resize_rejects_impossible_token_budget():
+    with pytest.raises(ValueError, match="max_pixels=0 is too small"):
+        smart_resize(
+            num_frames=2,
+            height=64,
+            width=64,
+            temporal_factor=2,
+            factor=28,
+            max_pixels=0,
+        )
+
+
+def test_collapse_glm5_next_image_tokens_preserves_image_boundaries():
     image_token_id = 99
-    input_ids = [1, 99, 99, 99, 2, 99, 99, 3]
+    image_start_token_id = 10
+    image_end_token_id = 11
+    input_ids = [10, 99, 99, 11, 10, 99, 99, 99, 11]
 
-    assert _collapse_consecutive_token_ids(input_ids, image_token_id) == [
-        1,
+    assert _collapse_glm5_next_image_tokens(input_ids, image_token_id) == [
+        image_start_token_id,
         99,
-        2,
+        image_end_token_id,
+        image_start_token_id,
         99,
-        3,
+        image_end_token_id,
     ]
 
 
-def test_collapse_consecutive_token_ids_handles_boundaries_and_empty_input():
-    assert _collapse_consecutive_token_ids([99, 99, 1, 99, 99], 99) == [99, 1, 99]
-    assert _collapse_consecutive_token_ids([], 99) == []
+def test_collapse_glm5_next_image_tokens_handles_sequence_boundaries():
+    assert _collapse_glm5_next_image_tokens([99, 99, 1, 99, 99], 99) == [
+        99,
+        1,
+        99,
+    ]
+    assert _collapse_glm5_next_image_tokens([], 99) == []
+
+
+def test_glm5_next_preserves_processor_expanded_image_tokens(monkeypatch):
+    image_token_id = 99
+    expanded_input_ids = [1, 10, 99, 99, 99, 99, 11, 2]
+    collapsed_input_ids = [1, 10, 99, 11, 2]
+    image = Image.new("RGB", (28, 28))
+    image_item = MultimodalDataItem(
+        modality=Modality.IMAGE,
+        feature=torch.ones((4, 3)),
+        model_specific_data={"image_grid_thw": torch.tensor([[1, 2, 2]])},
+    )
+    processor_output = SimpleNamespace(
+        image_grid_thw=torch.tensor([[1, 2, 2]]),
+        video_grid_thw=None,
+        attention_mask=torch.ones((1, len(expanded_input_ids))),
+    )
+
+    processor = object.__new__(Glm4vImageProcessor)
+    processor.hf_config = SimpleNamespace(model_type="glm5_next")
+    processor.IM_TOKEN_ID = image_token_id
+    processor.mm_tokens = MultimodalSpecialTokens(
+        image_token_id=image_token_id, video_token_id=98
+    )
+    processor.video_config = {}
+    processor._processor = SimpleNamespace(
+        video_processor=None,
+        _get_num_multimodal_tokens=lambda **_: SimpleNamespace(num_image_tokens=[4]),
+    )
+    processor._tokenizer = MagicMock()
+    processor.preserve_processor_input_ids = False
+    processor.precompute_hash_before_cpu_transfer = False
+    processor.use_cuda_ipc = False
+    processor.load_mm_data = AsyncMock(
+        return_value=BaseMultiModalProcessorOutput(
+            input_text="unused", input_ids=collapsed_input_ids, images=[image]
+        )
+    )
+    processor._process_and_collect_mm_items = MagicMock(
+        return_value=(
+            [image_item],
+            torch.tensor(expanded_input_ids),
+            processor_output,
+        )
+    )
+    monkeypatch.setattr(
+        MRotaryEmbedding,
+        "get_rope_index_glm4v",
+        MagicMock(
+            return_value=(
+                torch.zeros((3, 1, len(expanded_input_ids))),
+                torch.zeros(1),
+            )
+        ),
+    )
+
+    output = asyncio.run(
+        processor.process_mm_data_async(
+            image_data=["image"],
+            input_text=expanded_input_ids,
+            request_obj=SimpleNamespace(video_data=None),
+        )
+    )
+
+    assert processor.load_mm_data.await_args.kwargs["prompt"] == collapsed_input_ids
+    assert output.input_ids == expanded_input_ids
+    assert len(output.mm_items) == 1
+    assert output.mm_items[0].offsets == [(2, 5)]
+
+
+def test_get_processor_uses_registered_glm5_next_processor(monkeypatch):
+    expected_processor = MagicMock()
+    expected_processor.tokenizer.chat_template = "test-template"
+    monkeypatch.setattr(
+        processor_module.AutoConfig,
+        "from_pretrained",
+        lambda *args, **kwargs: type(
+            "Config", (), {"model_type": "glm5_next", "language_model_only": False}
+        )(),
+    )
+    monkeypatch.setattr(
+        Glm5NextProcessor,
+        "from_pretrained",
+        lambda *args, **kwargs: expected_processor,
+    )
+
+    assert _CUSTOMIZED_MM_PROCESSOR["glm5_next"] is Glm5NextProcessor
+    assert processor_module.get_processor("unused-checkpoint") is expected_processor


### PR DESCRIPTION
Adds the missing GLM-5.3 vision-side processor compatibility on top of `sglang-miles-glm53next`.

## Implementation

- add a self-contained `Glm5NextImageProcessor` and `Glm5NextProcessor` for the branch pinned to Transformers 5.12.1, adapted from the official model repository at commit `eb4d9e2a64a013bec12289288b85d0b1210ba0aa`
- register it through SGLang's existing `register_customized_processor` primitive, so local paths and Hugging Face repository IDs work without importing Miles
- normalize processor-expanded pretokenized inputs by collapsing each repeated image-token span before the existing GLM-4V multimodal path expands it around the image payload
- restrict that normalization to `glm5_next` list inputs; existing GLM-4V behavior and the pinned video processor are unchanged

## Relationship to upstream

The base branch already carries the GLM-5.3 text/model port corresponding to #36507. This PR does not duplicate those model changes; it only supplies the image-processor compatibility missing from the pinned Transformers release. Keeping this small and registry-based also avoids conflict when `sglang-miles-glm53next` is refreshed from upstream.

## Validation

- 6 focused multimodal tests pass, covering dynamic padded grids, insufficient token budgets, distinct and boundary token spans, registry routing, and the exact expanded-ID plus image path through `process_mm_data_async`
- standalone processor construction and image preprocessing succeed in `lmsysorg/sglang:v0.5.17` without Miles installed: grid `1 x 8 x 10`, pixels `(80, 1176)`, 20 image tokens
- commit `21572b4470442fe49ea4ff36e64b1118b465c3b0` was exercised end to end by radixark/miles#2792 in a successful two-rollout Geo3K run on one 8 × B300 node
- W&B: https://wandb.ai/nan-playground/miles-glm53-vlm/runs/049apd1e
- Modal app: https://modal.com/apps/modal-labs/nan-dev/ap-46XxFcJ5MeQ8662eDbliq7

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829344130](https://github.com/sgl-project/sglang/actions/runs/34829344130)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829343908](https://github.com/sgl-project/sglang/actions/runs/34829343908)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829344002](https://github.com/sgl-project/sglang/actions/runs/34829344002)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

## CI note

The current lint run fails in the repository-wide `--all-files` pass because it reformats four files already on `sglang-miles-glm53next`: `model_config.py`, `kpool_fp8_index.py`, `dsa_backend.py`, and `eagle_worker_v2.py`. GitHub reports this PR itself as only the four GLM processor files above, and none is modified by the failing hooks. Those unrelated base-branch formatting changes are intentionally not included here. Run: https://github.com/sgl-project/sglang/actions/runs/33189398591/job/98910715776
