### PR TITLE
fix(function_call): skip empty tags for non-string qwen3_coder params

### DIFF
--- a/python/sglang/srt/function_call/qwen3_coder_detector.py
+++ b/python/sglang/srt/function_call/qwen3_coder_detector.py
@@ -98,12 +98,31 @@ class Qwen3CoderDetector(BaseFormatDetector):
             return "string"
         return str(inferred_type).strip().lower()
 
+    def _is_string_type(self, param_name: str, param_config: dict) -> bool:
+        """Whether a parameter's inferred schema type is string-like.
+
+        Unknown parameters (missing from the schema) default to string so the
+        parser stays lossless for them.
+        """
+        return self._get_param_type(
+            param_config[param_name] if param_name in param_config else {}
+        ) in ("string", "str", "text", "varchar", "char", "enum")
+
     def _convert_param_value(
         self, param_value: str, param_name: str, param_config: dict, func_name: str
     ) -> Any:
         """Convert parameter value based on its type in the schema."""
-        # Handle null value for any type
-        if param_value.lower() == "null":
+        # The XML tool-call format has no null literal, so models spell "not
+        # provided" as "null" text, or (on non-string parameters) the Python
+        # literal "None"/"none"; empty tags are handled by the callers.
+        # Normalize those text nulls to None instead of leaking them through as
+        # strings. For string parameters a literal "none" can be a legitimate
+        # value, so it is left as-is.
+        if param_value.strip().lower() == "null":
+            return None
+        if param_value.strip().lower() == "none" and not self._is_string_type(
+            param_name, param_config
+        ):
             return None
 
         if param_name not in param_config:
@@ -217,6 +236,17 @@ class Qwen3CoderDetector(BaseFormatDetector):
                             p_val = p_val[1:]
                         if p_val.endswith("\n"):
                             p_val = p_val[:-1]
+
+                        # An empty/whitespace-only value on a NON-STRING
+                        # parameter means "not provided" (the XML tool-call
+                        # format cannot express null): drop it so the tool's
+                        # default applies instead of leaking "" into strict
+                        # schemas (e.g. openai-agents pydantic). For string
+                        # parameters "" is a legal value, so keep it lossless.
+                        if not p_val.strip() and not self._is_string_type(
+                            p_name, param_config
+                        ):
+                            continue
 
                         parsed_params[p_name] = self._convert_param_value(
                             p_val, p_name, param_config, func_name
@@ -346,6 +376,22 @@ class Qwen3CoderDetector(BaseFormatDetector):
                         if raw_value.endswith("\n"):
                             raw_value = raw_value[:-1]
 
+                        # An empty/whitespace-only value on a NON-STRING
+                        # parameter means "not provided" (the XML tool-call
+                        # format cannot express null). Skip the whole tag (just
+                        # advance the cursor, emit nothing) so the tool's
+                        # default is used instead of leaking "" into strict
+                        # schemas. For string parameters "" is a legal value.
+                        param_config = self._get_arguments_config(
+                            self.current_func_name, tools
+                        )
+                        if not raw_value.strip() and not self._is_string_type(
+                            param_name, param_config
+                        ):
+                            total_len = (name_end + 1) + end_pos + end_token_len
+                            self.parsed_pos += total_len
+                            continue
+
                         # JSON Construction
                         if not self.json_started:
                             calls.append(
@@ -355,9 +401,6 @@ class Qwen3CoderDetector(BaseFormatDetector):
                             )
                             self.json_started = True
 
-                        param_config = self._get_arguments_config(
-                            self.current_func_name, tools
-                        )
                         converted_val = self._convert_param_value(
                             raw_value, param_name, param_config, self.current_func_name
                         )

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -2659,6 +2659,72 @@ null
         params = json.loads(result.calls[0].parameters)
         self.assertEqual(params["location"], "")
 
+    def test_empty_nonstring_parameter_skipped(self):
+        """Empty tags on NON-string params must not leak "".
+
+        The XML tool-call format cannot express null, so an empty tag on an
+        optional int/list/object/bool param means "not provided". Leaking ""
+        into strict schemas (e.g. openai-agents pydantic) would break the tool
+        call, so the parameter is dropped and the tool default is used instead.
+        """
+        text = """<tool_call>
+<function=get_current_weather>
+<parameter=location>Tokyo</parameter>
+<parameter=days></parameter>
+</function>
+</tool_call>"""
+        result = self.detector.detect_and_parse(text, self.tools)
+
+        self.assertEqual(len(result.calls), 1)
+        params = json.loads(result.calls[0].parameters)
+        self.assertEqual(params["location"], "Tokyo")
+        self.assertNotIn("days", params)
+        self.assertTrue(all(v != "" for v in params.values()))
+
+    def test_empty_nonstring_parameter_skipped_streaming(self):
+        """Empty tags on non-string params are dropped in streaming too."""
+        text = """<tool_call>
+<function=get_current_weather>
+<parameter=location>Tokyo</parameter>
+<parameter=days>
+
+</parameter>
+</function>
+</tool_call>"""
+        detector = Qwen3CoderDetector()
+        fragments = []
+        for ch in text:
+            res = detector.parse_streaming_increment(ch, self.tools)
+            fragments.extend(item.parameters or "" for item in (res.calls or []))
+        params_str = "".join(fragments)
+        self.assertIn('"location": "Tokyo"', params_str)
+        # the empty non-string parameter must not be emitted at all
+        self.assertNotIn('"days"', params_str)
+
+    def test_none_text_normalization_only_for_nonstring(self):
+        """Literal 'None'/'none' becomes null for NON-string params, but stays
+        a plain string for string params (where "none" can be a legit value)."""
+        int_text = """<tool_call>
+<function=get_current_weather>
+<parameter=location>Tokyo</parameter>
+<parameter=days>None</parameter>
+</function>
+</tool_call>"""
+        params = json.loads(
+            self.detector.detect_and_parse(int_text, self.tools).calls[0].parameters
+        )
+        self.assertEqual(params["days"], None)
+
+        str_text = """<tool_call>
+<function=get_current_weather>
+<parameter=unit>none</parameter>
+</function>
+</tool_call>"""
+        params = json.loads(
+            self.detector.detect_and_parse(str_text, self.tools).calls[0].parameters
+        )
+        self.assertEqual(params["unit"], "none")
+
     def test_parameter_with_special_characters(self):
         """
         Test handling of parameters with special characters.


### PR DESCRIPTION
   Empty XML tags in qwen3_coder tool calls were parsed as '' and passed through. For non-string parameters (int/list/object/bool) '' is not a legal value and
 breaks strict downstream schemas (e.g. openai-agents pydantic) with 'Invalid JSON input for tool ...'.

   Drop empty tags only for NON-string parameters so the tool default is used instead; keep '' for string parameters where it is a legal value (lossless,
 matches the existing test_empty_parameter_value semantics).

   Also normalize literal 'None'/'none' text to null for non-string params (the XML format has no null literal; models spell 'not provided' as 'null' or the
 Python literal 'None'). A literal 'none' on a string parameter is left as-is since it can be a legitimate value.

   <!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to
 maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

   ## Motivation

   The qwen3_coder XML tool-call format has no `null` literal. When a tool description tells the model an optional parameter "must be left empty" (e.g. "未提
 及时必须留空"), models frequently honor it literally by emitting an empty tag (`<parameter=x></parameter>`) instead of omitting the parameter — measured at
 10–30% of sampled calls on Qwen3.5-4B/9B.

   The parser converts the empty tag to `""` and passes it through unchanged. For **non-string** parameters (`int`/`float`/`bool`/`array`/`object`) `""` is
 not a legal value of that type, so strict downstream validation (e.g. the openai-agents SDK pydantic check) fails with `ModelBehaviorError: Invalid JSON
 input for tool ...`, causing repeated model retries and wasted turns in RL / tool-calling pipelines.

   ## Modifications

   All changes in `python/sglang/srt/function_call/qwen3_coder_detector.py`:

   1. **Skip empty tags only for non-string parameters** in both the non-streaming `detect_and_parse` and the streaming `parse_streaming_increment` paths. The
 parameter is omitted, so the tool's default value applies. String parameters keep `""` — it is a legal value there and the parser has always been lossless
 (asserted by the pre-existing `test_empty_parameter_value`).
   2. **Normalize literal `None`/`none` text to `null` for non-string parameters** — models also spell "not provided" as the bare Python literal. A literal
 `"none"` on a string parameter is left as-is since it can be a legitimate value.
   3. Add a small `_is_string_type()` helper (schema-type based; unknown params default to string to stay lossless). Complements #36626 (top-level
 anyOf/oneOf/allOf schema resolution), which makes type inference correct on complex pydantic tool schemas.

   ## Accuracy Tests

   No model weights or forward paths are touched. Tool-call parsing behavior was validated end-to-end through the OpenAI API (`/v1/chat/completions`,
 server-side qwen3_coder parser, `tool_choice=required`, Qwen3.5-4B, N=100, one required string + two optional params whose description says "must be left
 empty"):

   | version | tool calls | `""` leaked into arguments |
   |---|---|---|
   | before | 100/100 | `{"author": 15, "page": 15, "title": 2}` (`page` is `int` → pydantic failure) |
   | after | 100/100 | `{"author": 11}` (string `""` only, passes validation) |

   Unit tests: `TestQwen3CoderDetector` 20/20 pass (existing `test_empty_parameter_value` unchanged; new tests cover the non-string skip on both paths and the
 `None`-text normalization scope).

   ## Speed Tests and Profiling

   Negligible: one schema-type lookup per parsed parameter (existing `_get_param_type` call); skipping empty params strictly reduces emitted JSON. No
 benchmark needed.

   ## Checklist

   - [x] Format your code according to the [Format code with
 pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
   - [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
   - [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). *(not
 needed — parser behavior only)*
   - [x] Provide accuracy and speed benchmark results according to [Test the
 accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the
 speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
   - [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

   ## Review and Merge Process

   1. Ping Merge Oncalls to start the process. See the [PR Merge
 Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
   2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
   3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to
 do so.
      - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
   4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33158990339](https://github.com/sgl-project/sglang/actions/runs/33158990339)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33158989950](https://github.com/sgl-project/sglang/actions/runs/33158989950)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33158990278](https://github.com/sgl-project/sglang/actions/runs/33158990278)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->