### PR TITLE
[Fix] Match compressed-tensors weight_packed names when loading MXFP4 MoE

### DIFF
--- a/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
+++ b/python/sglang/srt/layers/moe/fused_moe_triton/layer.py
@@ -565,7 +565,13 @@ class FusedMoE(torch.nn.Module):
         return [
             (name, tensor)
             for name, tensor in sorted(found.items())
-            if name not in ("w13_weight", "w2_weight")
+            if name
+            not in (
+                "w13_weight",
+                "w2_weight",
+                "w13_weight_packed",
+                "w2_weight_packed",
+            )
             and tensor.ndim > 0
             and tensor.shape[0] == num_local_experts
         ]
@@ -584,10 +590,11 @@ class FusedMoE(torch.nn.Module):
         # 1. CPU (always)
         # 2. GPU with flashinfer_trtllm padding (when intermediate_size is padded to 128)
         # 3. GPU with Aiter padding
+        w2_weight = getattr(self, "w2_weight", getattr(self, "w2_weight_packed", None))
         aiter_padded = (
             _use_aiter
-            and hasattr(self, "w2_weight")
-            and getattr(self.w2_weight, "weight_padded", False)
+            and w2_weight is not None
+            and getattr(w2_weight, "weight_padded", False)
         )
 
         return _is_cpu or self.use_flashinfer_trtllm_moe or aiter_padded
@@ -865,7 +872,12 @@ class FusedMoE(torch.nn.Module):
         if not is_weight and not is_scale:
             return False
 
-        weight_param = self.w2_weight if shard_id == "w2" else self.w13_weight
+        runtime_weight_name = "w2_weight" if shard_id == "w2" else "w13_weight"
+        weight_param = getattr(
+            self,
+            runtime_weight_name,
+            getattr(self, f"{runtime_weight_name}_packed", None),
+        )
         scale_param = (
             self.w2_weight_scale_inv if shard_id == "w2" else self.w13_weight_scale_inv
         )

--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -165,6 +165,9 @@ class KTEPWrapperMethod(FusedMoEMethodBase):
         # Store parameters needed for KT initialization
         self._layer_params = None
 
+    def prepare_weights_for_post_load(self, layer: torch.nn.Module) -> None:
+        self.gpu_method.prepare_weights_for_post_load(layer)
+
     def create_weights(
         self,
         layer: torch.nn.Module,

--- a/python/sglang/srt/layers/quantization/base_config.py
+++ b/python/sglang/srt/layers/quantization/base_config.py
@@ -22,6 +22,18 @@ if TYPE_CHECKING:
 class QuantizeMethodBase(ABC):
     """Base class for different quantized methods."""
 
+    def prepare_weights_for_post_load(self, layer: nn.Module) -> None:
+        """Prepare registered state before post-load device staging.
+
+        This hook runs after checkpoint loading and before parameters are moved
+        to the device used by ``process_weights_after_loading``. Quantization
+        methods that rename registered parameters should do so here, allowing
+        the staging context to preserve the renamed slots' original devices.
+        Implementations must be idempotent because post-load processing may
+        invoke the hook again.
+        """
+        return
+
     def create_weights(
         self, layer: torch.nn.Module, *weight_args, **extra_weight_attrs
     ):

--- a/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
+++ b/python/sglang/srt/layers/quantization/compressed_tensors/compressed_tensors.py
@@ -230,7 +230,10 @@ class CompressedTensorsConfig(QuantizationConfig):
                 logger.info_once(
                     "Using Mxfp4MoEMethod for MXFP4 compressed-tensors MoE"
                 )
-                return Mxfp4MoEMethod(prefix=prefix)
+                return Mxfp4MoEMethod(
+                    prefix=prefix,
+                    checkpoint_weight_suffix="weight_packed",
+                )
 
             layer.scheme = self.get_moe_scheme(layer=layer, layer_name=prefix)
             if layer.scheme is None:  # ignored layer

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -469,6 +469,9 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             delattr(layer, checkpoint_name)
             layer.register_parameter(runtime_name, checkpoint_param)
 
+    def prepare_weights_for_post_load(self, layer: torch.nn.Module) -> None:
+        self._bind_runtime_weight_names(layer)
+
     def create_weights(
         self,
         layer: torch.nn.Module,
@@ -641,7 +644,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer):
-        self._bind_runtime_weight_names(layer)
+        self.prepare_weights_for_post_load(layer)
 
         if self.use_marlin and not self.use_mega_moe:
             from sglang.srt.layers.quantization.marlin_utils import (

--- a/python/sglang/srt/layers/quantization/mxfp4.py
+++ b/python/sglang/srt/layers/quantization/mxfp4.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 from dataclasses import replace
 from functools import lru_cache
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, List, Literal, Optional
 
 import torch
 from torch.nn.parameter import Parameter
@@ -385,10 +385,12 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
     def __init__(
         self,
         prefix: str,
+        checkpoint_weight_suffix: Literal["weight", "weight_packed"] = "weight",
     ):
         super().__init__()
 
         self.prefix = prefix
+        self.checkpoint_weight_suffix = checkpoint_weight_suffix
         self.topk_indices_dtype = None
         self.use_triton_kernels = get_moe_runner_backend().is_triton_kernels()
         self.with_bias = False
@@ -431,6 +433,41 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
                     "moe_runner_backend=flashinfer_mxfp4 requires SM90, SM100, "
                     "or SM120."
                 )
+
+    def _checkpoint_weight_name(self, fused_weight_name: str) -> str:
+        return f"{fused_weight_name}_{self.checkpoint_weight_suffix}"
+
+    def _bind_runtime_weight_names(self, layer: torch.nn.Module) -> None:
+        """Expose loaded checkpoint weights under the runtime MoE ABI names."""
+        if self.checkpoint_weight_suffix == "weight":
+            return
+
+        bindings = []
+        for fused_weight_name in ("w13", "w2"):
+            checkpoint_name = self._checkpoint_weight_name(fused_weight_name)
+            runtime_name = f"{fused_weight_name}_weight"
+            checkpoint_param = layer._parameters.get(checkpoint_name)
+            runtime_param = layer._parameters.get(runtime_name)
+
+            # Keep this idempotent for callers that finalize an already-loaded
+            # layer more than once.
+            if checkpoint_param is None:
+                if runtime_param is not None:
+                    continue
+                raise RuntimeError(
+                    f"Missing MXFP4 MoE checkpoint parameter {checkpoint_name!r}"
+                )
+            if runtime_param is not None:
+                raise RuntimeError(
+                    f"Both MXFP4 MoE parameters {checkpoint_name!r} and "
+                    f"{runtime_name!r} are registered"
+                )
+
+            bindings.append((checkpoint_name, runtime_name, checkpoint_param))
+
+        for checkpoint_name, runtime_name, checkpoint_param in bindings:
+            delattr(layer, checkpoint_name)
+            layer.register_parameter(runtime_name, checkpoint_param)
 
     def create_weights(
         self,
@@ -534,7 +571,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             ),
             requires_grad=False,
         )
-        layer.register_parameter("w13_weight", w13_weight)
+        layer.register_parameter(self._checkpoint_weight_name("w13"), w13_weight)
         set_weight_attrs(w13_weight, extra_weight_attrs)
 
         w13_weight_scale = torch.nn.Parameter(
@@ -576,7 +613,7 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             ),
             requires_grad=False,
         )
-        layer.register_parameter("w2_weight", w2_weight)
+        layer.register_parameter(self._checkpoint_weight_name("w2"), w2_weight)
         set_weight_attrs(w2_weight, extra_weight_attrs)
 
         w2_weight_scale = torch.nn.Parameter(
@@ -604,6 +641,8 @@ class Mxfp4MoEMethod(FusedMoEMethodBase):
             set_weight_attrs(w2_weight_bias, extra_weight_attrs)
 
     def process_weights_after_loading(self, layer):
+        self._bind_runtime_weight_names(layer)
+
         if self.use_marlin and not self.use_mega_moe:
             from sglang.srt.layers.quantization.marlin_utils import (
                 check_moe_marlin_supports_layer,

--- a/python/sglang/srt/model_loader/loader.py
+++ b/python/sglang/srt/model_loader/loader.py
@@ -149,6 +149,11 @@ logger = logging.getLogger(__name__)
 
 @contextmanager
 def device_loading_context(module: torch.nn.Module, target_device: torch.device):
+    quant_method = getattr(module, "quant_method", None)
+    prepare_weights = getattr(quant_method, "prepare_weights_for_post_load", None)
+    if prepare_weights is not None:
+        prepare_weights(module)
+
     if target_device.type == "cpu":
         yield module
         return

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -3024,10 +3024,6 @@ class KimiK3LinearForCausalLM(nn.Module):
                 if _lid.isdigit() and int(_lid) >= num_hidden_layers:
                     continue
 
-            # compressed-tensors MXFP4 stores as weight_packed; Mxfp4MoEMethod uses weight
-            if "weight_packed" in name:
-                name = name.replace("weight_packed", "weight")
-
             # MLA: fuse q_a_proj + kv_a_proj_with_mqa → fused_qkv_a_proj_with_mqa
             if ".q_a_proj." in name or ".kv_a_proj_with_mqa." in name:
                 is_q_a = ".q_a_proj." in name

--- a/test/registered/unit/layers/quantization/test_mxfp4_checkpoint_weight_names.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_checkpoint_weight_names.py
@@ -1,0 +1,140 @@
+"""CPU tests for MXFP4 MoE checkpoint and runtime parameter names."""
+
+import unittest
+from unittest import mock
+
+import torch
+
+from sglang.srt.layers.moe.fused_moe_triton import FusedMoE
+from sglang.srt.layers.quantization.compressed_tensors.compressed_tensors import (
+    CompressedTensorsConfig,
+)
+from sglang.srt.layers.quantization.mxfp4 import Mxfp4MoEMethod
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestMxfp4CheckpointWeightNames(CustomTestCase):
+    @staticmethod
+    def _make_method(checkpoint_weight_suffix: str) -> Mxfp4MoEMethod:
+        method = Mxfp4MoEMethod.__new__(Mxfp4MoEMethod)
+        method.checkpoint_weight_suffix = checkpoint_weight_suffix
+        return method
+
+    def test_packed_mode_registers_checkpoint_names(self):
+        method = self._make_method("weight_packed")
+        method.use_marlin = False
+        method.use_mega_moe = False
+        method.use_deep_gemm = False
+        method.use_flashinfer = False
+        method._fi_kernel = None
+        layer = torch.nn.Module()
+        layer.num_local_experts = 2
+
+        with (
+            mock.patch(
+                "sglang.srt.layers.quantization.mxfp4.is_sm100_supported",
+                return_value=False,
+            ),
+            mock.patch("sglang.srt.layers.quantization.mxfp4._use_aiter", False),
+            mock.patch(
+                "sglang.srt.layers.quantization.mxfp4.has_triton_kernels", False
+            ),
+        ):
+            method.create_weights(
+                layer=layer,
+                num_experts=2,
+                hidden_size=64,
+                intermediate_size_per_partition=64,
+                params_dtype=torch.bfloat16,
+            )
+
+        self.assertIn("w13_weight_packed", layer._parameters)
+        self.assertIn("w2_weight_packed", layer._parameters)
+        self.assertNotIn("w13_weight", layer._parameters)
+        self.assertNotIn("w2_weight", layer._parameters)
+
+    def test_compressed_tensors_selects_packed_checkpoint_names(self):
+        config = CompressedTensorsConfig(
+            target_scheme_map={},
+            ignore=[],
+            quant_format="mxfp4-quantized",
+            sparsity_scheme_map={},
+            sparsity_ignore_list=[],
+        )
+        layer = FusedMoE.__new__(FusedMoE)
+        torch.nn.Module.__init__(layer)
+
+        with mock.patch(
+            "sglang.srt.layers.quantization.mxfp4.Mxfp4MoEMethod"
+        ) as method_cls:
+            config.get_quant_method(layer, "model.layers.0.mlp.experts")
+
+        method_cls.assert_called_once_with(
+            prefix="model.layers.0.mlp.experts",
+            checkpoint_weight_suffix="weight_packed",
+        )
+
+    def test_packed_parameters_are_rebound_without_copying(self):
+        method = self._make_method("weight_packed")
+        layer = torch.nn.Module()
+        w13 = torch.nn.Parameter(torch.tensor([1], dtype=torch.uint8), False)
+        w2 = torch.nn.Parameter(torch.tensor([2], dtype=torch.uint8), False)
+        loader = object()
+        w13.weight_loader = loader
+        layer.register_parameter("w13_weight_packed", w13)
+        layer.register_parameter("w2_weight_packed", w2)
+
+        method._bind_runtime_weight_names(layer)
+
+        self.assertIs(layer.w13_weight, w13)
+        self.assertIs(layer.w2_weight, w2)
+        self.assertIs(layer.w13_weight.weight_loader, loader)
+        self.assertFalse(hasattr(layer, "w13_weight_packed"))
+        self.assertFalse(hasattr(layer, "w2_weight_packed"))
+
+        # Finalization can be called again without changing the parameters.
+        method._bind_runtime_weight_names(layer)
+        self.assertIs(layer.w13_weight, w13)
+        self.assertIs(layer.w2_weight, w2)
+
+    def test_packed_main_weights_are_not_treated_as_side_tensors(self):
+        layer = FusedMoE.__new__(FusedMoE)
+        torch.nn.Module.__init__(layer)
+        layer.register_parameter(
+            "w13_weight_packed",
+            torch.nn.Parameter(torch.zeros(2, 4, 2, dtype=torch.uint8), False),
+        )
+        layer.register_parameter(
+            "w2_weight_packed",
+            torch.nn.Parameter(torch.zeros(2, 2, 2, dtype=torch.uint8), False),
+        )
+        layer.register_parameter(
+            "w13_weight_scale",
+            torch.nn.Parameter(torch.zeros(2, 4, 1, dtype=torch.uint8), False),
+        )
+
+        names = {name for name, _ in layer.named_per_expert_tensors(2)}
+
+        self.assertNotIn("w13_weight_packed", names)
+        self.assertNotIn("w2_weight_packed", names)
+        self.assertIn("w13_weight_scale", names)
+
+    def test_native_mxfp4_keeps_runtime_names(self):
+        method = self._make_method("weight")
+        layer = torch.nn.Module()
+        w13 = torch.nn.Parameter(torch.tensor([1], dtype=torch.uint8), False)
+        w2 = torch.nn.Parameter(torch.tensor([2], dtype=torch.uint8), False)
+        layer.register_parameter("w13_weight", w13)
+        layer.register_parameter("w2_weight", w2)
+
+        method._bind_runtime_weight_names(layer)
+
+        self.assertIs(layer.w13_weight, w13)
+        self.assertIs(layer.w2_weight, w2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_mxfp4_checkpoint_weight_names.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_checkpoint_weight_names.py
@@ -87,7 +87,7 @@ class TestMxfp4CheckpointWeightNames(CustomTestCase):
         layer.register_parameter("w13_weight_packed", w13)
         layer.register_parameter("w2_weight_packed", w2)
 
-        method._bind_runtime_weight_names(layer)
+        method.prepare_weights_for_post_load(layer)
 
         self.assertIs(layer.w13_weight, w13)
         self.assertIs(layer.w2_weight, w2)
@@ -96,7 +96,7 @@ class TestMxfp4CheckpointWeightNames(CustomTestCase):
         self.assertFalse(hasattr(layer, "w2_weight_packed"))
 
         # Finalization can be called again without changing the parameters.
-        method._bind_runtime_weight_names(layer)
+        method.prepare_weights_for_post_load(layer)
         self.assertIs(layer.w13_weight, w13)
         self.assertIs(layer.w2_weight, w2)
 
@@ -130,7 +130,7 @@ class TestMxfp4CheckpointWeightNames(CustomTestCase):
         layer.register_parameter("w13_weight", w13)
         layer.register_parameter("w2_weight", w2)
 
-        method._bind_runtime_weight_names(layer)
+        method.prepare_weights_for_post_load(layer)
 
         self.assertIs(layer.w13_weight, w13)
         self.assertIs(layer.w2_weight, w2)

--- a/test/registered/unit/test_quantization_post_load.py
+++ b/test/registered/unit/test_quantization_post_load.py
@@ -23,6 +23,31 @@ PROCESS_DEVICE = _process_device()
 
 @unittest.skipUnless(PROCESS_DEVICE is not None, "requires CUDA")
 class TestModulePostLoadStaging(unittest.TestCase):
+    def test_prepares_parameter_rename_before_staging_snapshot(self):
+        class RenameWeightForRuntime:
+            @staticmethod
+            def prepare_weights_for_post_load(module: nn.Module) -> None:
+                weight = module._parameters["weight_packed"]
+                delattr(module, "weight_packed")
+                module.register_parameter("weight", weight)
+
+        module = nn.Module()
+        module.weight_packed = nn.Parameter(torch.ones(2))
+        module.resident = nn.Parameter(torch.ones(1, device=PROCESS_DEVICE))
+        module.quant_method = RenameWeightForRuntime()
+
+        with device_loading_context(module, PROCESS_DEVICE):
+            self.assertFalse(hasattr(module, "weight_packed"))
+            self.assertEqual(module.weight.device, PROCESS_DEVICE)
+            module.weight = nn.Parameter(torch.ones(3, device=PROCESS_DEVICE))
+
+        # The owner has mixed CPU/GPU residency and post-load processing
+        # replaced the renamed parameter. The runtime slot must still inherit
+        # the checkpoint slot's original CPU device.
+        self.assertEqual(module.weight.device.type, "cpu")
+        self.assertEqual(module.weight.shape, (3,))
+        self.assertEqual(module.resident.device, PROCESS_DEVICE)
+
     def test_preserves_unchanged_parameter_and_buffer_storage(self):
         module = nn.Module()
         module.weight = nn.Parameter(torch.arange(4.0).reshape(2, 2))


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->
Compressed-tensors MXFP4 MoE checkpoints store expert weights with the `weight_packed` suffix. After applying the FusedMoE expert mapping, these names become `w13_weight_packed` and `w2_weight_packed`, while `Mxfp4MoEMethod` previously registered only `w13_weight` and `w2_weight`. This mismatch prevents the expert weights from being loaded correctly.

Kimi K3 previously worked around the mismatch by globally replacing `weight_packed` with `weight`. However, this could also rename unrelated compressed-tensors parameters whose registered names should remain `weight_packed`.


## Modifications

<!-- Detail the changes made in this pull request. -->
- Register compressed-tensors MXFP4 MoE weights with their checkpoint-native `weight_packed` names while preserving native MXFP4 naming.
- Rebind packed weights to the runtime names without copying, before device staging, and remove the Kimi K3 global name-replacement workaround.
- Update FusedMoE/KTEP compatibility and add unit tests for naming, rebinding, and device placement.

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33159515224](https://github.com/sgl-project/sglang/actions/runs/33159515224)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33159514960](https://github.com/sgl-project/sglang/actions/runs/33159514960)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33159515210](https://github.com/sgl-project/sglang/actions/runs/33159515210)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->