### PR TITLE
[WIP][Diffusion] Rework exact component precision

### DIFF
--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -131,7 +131,7 @@ pipeline's registered module name:
 | --- | --- | --- | --- |
 | Replace a component | `--component-paths.<component> {MODEL}` | `--<component>-path {MODEL}` | Load the replacement component's configuration and weights |
 | Replace only its weights | `--component-weights-paths.<component> {WEIGHTS}` | `--<component>-weights-path {WEIGHTS}` | Retain the base component configuration and replace its weights |
-| Set load and compute precision | `--component-precisions.<component> {fp32|fp16|bf16}` | None | Override the family precision for one exact component key |
+| Set load and compute precision | `--component-precisions.<component> fp32\|fp16\|bf16` | None | Override the family precision for one exact component key |
 | Quantize an unquantized component online | `--component-quantizations.<component> {METHOD}` | `--<component>-quantization {METHOD}` | Apply a method supported by that component's native loader |
 | Keep selected component layers unquantized | `--component-quantization-ignored-layers.<component> {PATTERN...}` | None | Pass component-local ignored-layer patterns to its online quantizer |
 

--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -131,6 +131,7 @@ pipeline's registered module name:
 | --- | --- | --- | --- |
 | Replace a component | `--component-paths.<component> {MODEL}` | `--<component>-path {MODEL}` | Load the replacement component's configuration and weights |
 | Replace only its weights | `--component-weights-paths.<component> {WEIGHTS}` | `--<component>-weights-path {WEIGHTS}` | Retain the base component configuration and replace its weights |
+| Set load and compute precision | `--component-precisions.<component> {fp32|fp16|bf16}` | None | Override the family precision for one exact component key |
 | Quantize an unquantized component online | `--component-quantizations.<component> {METHOD}` | `--<component>-quantization {METHOD}` | Apply a method supported by that component's native loader |
 | Keep selected component layers unquantized | `--component-quantization-ignored-layers.<component> {PATTERN...}` | None | Pass component-local ignored-layer patterns to its online quantizer |
 
@@ -149,6 +150,14 @@ actual component name, which is pipeline-specific. Use `--quantization` only
 to override the method inferred by the transformer loader, and
 `--quantization-ignored-layers` to keep matching transformer layers
 unquantized during online quantization.
+
+Component precision controls weight materialization and the component's default
+native forward/autocast path; it does not change quantized storage formats.
+Existing family options such as `--dit-precision`, `--vae-precision`, and
+`--text-encoder-precisions` remain fallbacks. VAE decode-specific precision can
+temporarily take precedence during decode. Paired DiTs currently require one
+shared precision, and the whole-pipeline Diffusers backend rejects component
+precision overrides.
 
 For a native text encoder:
 
@@ -210,7 +219,7 @@ width: 1280
 num_inference_steps: 6
 seed: 1024
 fps: 24
-precision: bf16
+dit_precision: bf16
 vae_precision: fp16
 vae_tiling: true
 vae_sp: true

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -315,6 +315,13 @@ class ComponentLoader(ABC):
             logger.error("Load %s failed", component_name)
             consumed = 0.0
         else:
+            if component_name in server_args.component_precisions and not isinstance(
+                component, nn.Module
+            ):
+                raise ValueError(
+                    f"Component precision override for {component_name!r} is not "
+                    "supported because the loaded component is not a torch module."
+                )
             if isinstance(component, nn.Module):
                 component = component.eval()
                 if not is_fsdp_managed_module(component):

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -45,7 +45,10 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     prepare_diffusers_component_path_for_loading,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.runtime.utils.precision import resolve_component_precision
+from sglang.multimodal_gen.runtime.utils.precision import (
+    component_precision_overrides,
+    resolve_component_precision,
+)
 from sglang.multimodal_gen.runtime.weights.source import (
     materialize_weight,
     resolve_weight,
@@ -315,7 +318,8 @@ class ComponentLoader(ABC):
             logger.error("Load %s failed", component_name)
             consumed = 0.0
         else:
-            if component_name in server_args.component_precisions and not isinstance(
+            precision_overrides = component_precision_overrides(server_args)
+            if component_name in precision_overrides and not isinstance(
                 component, nn.Module
             ):
                 raise ValueError(

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/image_encoder_loader.py
@@ -8,6 +8,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     get_diffusers_component_config,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import resolve_component_precision
 
 logger = init_logger(__name__)
 
@@ -53,6 +54,8 @@ class ImageEncoderLoader(TextEncoderLoader):
             encoder_config,
             server_args.encoder_parallel,
         )
+        encoder_dtype = resolve_component_precision(server_args, component_name)
+        assert encoder_dtype is not None
 
         # Always start with local device; load_model will adjust for offload if needed
         # TODO(will): add support for other dtypes
@@ -60,6 +63,6 @@ class ImageEncoderLoader(TextEncoderLoader):
             component_weights_path,
             encoder_config,
             server_args,
-            server_args.pipeline_config.image_encoder_precision,
+            encoder_dtype,
             component_name=component_name,
         )

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/pe_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/pe_loader.py
@@ -20,6 +20,9 @@ from sglang.multimodal_gen.runtime.models.encoders.mistral_3 import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_exact_component_precision,
+)
 
 logger = init_logger(__name__)
 
@@ -168,9 +171,12 @@ class PELoader(ComponentLoader):
         if tokenizer.pad_token_id is None:
             tokenizer.pad_token_id = tokenizer.eos_token_id
 
+        model_dtype = resolve_exact_component_precision(server_args, component_name)
+        if model_dtype is None:
+            model_dtype = torch.bfloat16
         model = Ministral3ForCausalLM.from_pretrained(
             component_model_path,
-            torch_dtype=torch.bfloat16,
+            torch_dtype=model_dtype,
             trust_remote_code=server_args.trust_remote_code,
         )
 

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/sound_tokenizer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/sound_tokenizer_loader.py
@@ -11,7 +11,7 @@ from sglang.multimodal_gen.runtime.loader.utils import (
 from sglang.multimodal_gen.runtime.models.registry import ModelRegistry
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import resolve_precision
 
 logger = init_logger(__name__)
 
@@ -34,11 +34,9 @@ class SoundTokenizerLoader(PlainStateDictComponentLoader):
 
         server_args.model_paths[component_name] = component_model_path
 
-        try:
-            precision = server_args.pipeline_config.vae_precision
-        except AttributeError:
-            precision = "bf16"
-        dtype = PRECISION_TO_TYPE[precision]
+        dtype = resolve_precision(
+            server_args, component_name, precision_attr="vae_precision"
+        )
         target_device = self.target_device(
             server_args.should_start_component_on_cpu(component_name)
         )

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/text_encoder_loader.py
@@ -96,6 +96,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     load_dict,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import resolve_component_precision
 from sglang.multimodal_gen.runtime.utils.quantization_utils import (
     get_quant_config,
     get_quant_config_from_safetensors_metadata,
@@ -764,9 +765,8 @@ class TextEncoderLoader(ComponentLoader):
             server_args.encoder_parallel,
             prefer_dp=prefer_dp,
         )
-        encoder_dtype = server_args.pipeline_config.text_encoder_precisions[
-            encoder_index
-        ]
+        encoder_dtype = resolve_component_precision(server_args, component_name)
+        assert encoder_dtype is not None
         # TODO(will): add support for other dtypes
         try:
             return self.load_model(
@@ -813,13 +813,15 @@ class TextEncoderLoader(ComponentLoader):
         model_path: str,
         model_config: EncoderConfig,
         server_args: ServerArgs,
-        dtype: str = "fp16",
+        dtype: str | torch.dtype = "fp16",
         component_starts_on_cpu: bool | None = None,
         component_name: str = "text_encoder",
     ):
         local_torch_device = get_local_torch_device()
         quant_config = model_config.quant_config
-        param_dtype = PRECISION_TO_TYPE[dtype]
+        param_dtype = (
+            dtype if isinstance(dtype, torch.dtype) else PRECISION_TO_TYPE[dtype]
+        )
         if quant_config is not None:
             if param_dtype not in quant_config.get_supported_act_dtypes():
                 raise ValueError(
@@ -877,7 +879,7 @@ class TextEncoderLoader(ComponentLoader):
 
         encoder_tp_group = get_folding_tp_group(model_config)
         with use_tensor_parallel_group(encoder_tp_group), set_default_torch_dtype(
-            PRECISION_TO_TYPE[dtype]
+            param_dtype
         ):
             with model_device, skip_init_modules():
                 architectures = getattr(model_config, "architectures", [])

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
@@ -16,6 +16,9 @@ from sglang.multimodal_gen.runtime.models.upsampler.latent_upsampler import (
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_exact_component_precision,
+)
 
 logger = init_logger(__name__)
 
@@ -222,12 +225,15 @@ class UpsamplerLoader(PlainStateDictComponentLoader):
             component_name
         )
         target_device = self.target_device(component_starts_on_cpu)
+        target_dtype = resolve_exact_component_precision(server_args, component_name)
+        if target_dtype is None:
+            target_dtype = torch.bfloat16
 
         with torch.device("meta"):
             model = LatentUpsampler(**config)
 
         model.load_state_dict(state_dict, assign=True)
-        model = model.to(device=target_device, dtype=torch.bfloat16).eval()
+        model = model.to(device=target_device, dtype=target_dtype).eval()
 
         logger.info("Loaded LatentUpsampler to %s", target_device)
         return model

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -339,16 +339,18 @@ class VAELoader(ComponentLoader):
 
         if component_name in ("vae", "video_vae"):
             pipeline_vae_config_attr = "vae_config"
-            pipeline_vae_precision = "vae_precision"
+            legacy_vae_precision = server_args.pipeline_config.vae_precision
         elif component_name in ("audio_vae",):
             pipeline_vae_config_attr = "audio_vae_config"
-            pipeline_vae_precision = "audio_vae_precision"
+            legacy_vae_precision = server_args.pipeline_config.audio_vae_precision
         else:
             raise ValueError(
                 f"Unsupported module name for VAE loader: {component_name}"
             )
         vae_config = getattr(server_args.pipeline_config, pipeline_vae_config_attr)
-        vae_precision = getattr(server_args.pipeline_config, pipeline_vae_precision)
+        vae_precision = server_args.component_precisions.get(
+            component_name, legacy_vae_precision
+        )
         resolved_vae_dtype = resolve_component_precision(server_args, component_name)
         vae_dtype = (
             resolved_vae_dtype

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vae_loader.py
@@ -35,6 +35,7 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.precision import (
     autocast_enabled,
+    component_precision_overrides,
     resolve_component_precision,
     resolve_decode_precision,
 )
@@ -348,7 +349,7 @@ class VAELoader(ComponentLoader):
                 f"Unsupported module name for VAE loader: {component_name}"
             )
         vae_config = getattr(server_args.pipeline_config, pipeline_vae_config_attr)
-        vae_precision = server_args.component_precisions.get(
+        vae_precision = component_precision_overrides(server_args).get(
             component_name, legacy_vae_precision
         )
         resolved_vae_dtype = resolve_component_precision(server_args, component_name)

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/vl_encoder_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/vl_encoder_loader.py
@@ -8,6 +8,9 @@ from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader imp
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import get_hf_config
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_exact_component_precision,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -61,11 +64,15 @@ class VisionLanguageEncoderLoader(ComponentLoader):
             target_device = self.target_device(
                 server_args.should_start_component_on_cpu("vision_language_encoder")
             )
+            model_dtype = resolve_exact_component_precision(
+                server_args, "vision_language_encoder"
+            )
             model = GlmImageForConditionalGeneration.from_pretrained(
                 component_model_path,
                 config=config,
                 trust_remote_code=server_args.trust_remote_code,
                 revision=server_args.revision,
+                **({"torch_dtype": model_dtype} if model_dtype is not None else {}),
             ).to(target_device)
             return model
         else:

--- a/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
@@ -820,7 +820,23 @@ def resolve_transformer_quant_load_spec(
         quant_config=quant_config,
         nunchaku_config=nunchaku_config,
         server_args=server_args,
+        component_name=component_name or "transformer",
     )
+    activation_dtype = resolve_precision(
+        server_args,
+        component_name or "transformer",
+        precision_attr="dit_precision",
+    )
+    runtime_quant_config = quant_config or nunchaku_config
+    if (
+        runtime_quant_config is not None
+        and activation_dtype not in runtime_quant_config.get_supported_act_dtypes()
+    ):
+        raise ValueError(
+            f"{component_name or 'transformer'!r} quantization method "
+            f"{runtime_quant_config.get_name()!r} does not support activation "
+            f"dtype {activation_dtype}"
+        )
 
     adapters = _build_transformer_quant_adapters(
         cls_name=cls_name,
@@ -1078,7 +1094,10 @@ def _resolve_target_param_dtype(
     quant_config: Optional[QuantizationConfig],
     nunchaku_config: Optional[NunchakuConfig],
     server_args: ServerArgs,
+    component_name: str,
 ) -> Optional[torch.dtype]:
     if quant_config is not None or nunchaku_config is not None:
         return None
-    return resolve_precision(server_args, "dit", precision_attr="dit_precision")
+    return resolve_precision(
+        server_args, component_name, precision_attr="dit_precision"
+    )

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass, replace
+from dataclasses import dataclass
 from typing import Mapping, MutableMapping, Protocol, Sequence
 
 import torch
@@ -26,7 +26,6 @@ from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.nvtx_pytorch_hooks import DiffusionNvtxHooks
-from sglang.multimodal_gen.runtime.utils.precision import precision_to_dtype
 
 logger = init_logger(__name__)
 
@@ -173,10 +172,7 @@ class ComponentResidencyManager:
         self._uses_seen.clear()
         self._modules_seen.clear()
         self._stage_uses_by_index = [
-            tuple(
-                self._effective_use(use)
-                for use in stage.component_uses(server_args, self.stage_name(stage))
-            )
+            tuple(stage.component_uses(server_args, self.stage_name(stage)))
             for stage in stages
         ]
         self._ordered_uses = tuple(
@@ -223,7 +219,6 @@ class ComponentResidencyManager:
 
         Repeated calls for the same component/phase extend the active interval.
         """
-        use = self._effective_use(use)
         if self._active_use is not None and self._same_use(self._active_use, use):
             previous_use = self._active_use
             if self._use_key(self._active_use) != self._use_key(use):
@@ -277,7 +272,6 @@ class ComponentResidencyManager:
 
     def end_use(self, use: ComponentUse, module: nn.Module | None = None) -> None:
         """End one sequential component use interval."""
-        use = self._effective_use(use)
         if self._active_use is None or not self._same_use(self._active_use, use):
             return
         self._disable_active_nvtx()
@@ -307,19 +301,7 @@ class ComponentResidencyManager:
 
     def ensure_ready(self, use: ComponentUse, module: nn.Module | None = None) -> None:
         """Prepare a shared component and wait without making it the active use."""
-        self._prepare_forward_use(self._effective_use(use), module=module)
-
-    def _effective_use(self, use: ComponentUse) -> ComponentUse:
-        precision = (
-            vars(self.server_args)
-            .get("component_precisions", {})
-            .get(use.component_name)
-        )
-        return (
-            use
-            if precision is None or use.target_dtype is not None
-            else replace(use, target_dtype=precision_to_dtype(precision))
-        )
+        self._prepare_forward_use(use, module=module)
 
     def remove_nvtx_hooks_for_module(self, module: nn.Module | None) -> None:
         """Detach NVTX hooks before a component object is deleted or replaced."""
@@ -456,7 +438,6 @@ class ComponentResidencyManager:
 
     def _prefetch_use(self, use: ComponentUse) -> None:
         """Prepare a future memory-intensive component without waiting."""
-        use = self._effective_use(use)
         if not use.allow_prefetch:
             return
         module = self.get_module(use.component_name)

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
@@ -1,6 +1,6 @@
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Mapping, MutableMapping, Protocol, Sequence
 
 import torch
@@ -26,6 +26,7 @@ from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.nvtx_pytorch_hooks import DiffusionNvtxHooks
+from sglang.multimodal_gen.runtime.utils.precision import precision_to_dtype
 
 logger = init_logger(__name__)
 
@@ -172,7 +173,10 @@ class ComponentResidencyManager:
         self._uses_seen.clear()
         self._modules_seen.clear()
         self._stage_uses_by_index = [
-            tuple(stage.component_uses(server_args, self.stage_name(stage)))
+            tuple(
+                self._effective_use(use)
+                for use in stage.component_uses(server_args, self.stage_name(stage))
+            )
             for stage in stages
         ]
         self._ordered_uses = tuple(
@@ -219,6 +223,7 @@ class ComponentResidencyManager:
 
         Repeated calls for the same component/phase extend the active interval.
         """
+        use = self._effective_use(use)
         if self._active_use is not None and self._same_use(self._active_use, use):
             previous_use = self._active_use
             if self._use_key(self._active_use) != self._use_key(use):
@@ -272,6 +277,7 @@ class ComponentResidencyManager:
 
     def end_use(self, use: ComponentUse, module: nn.Module | None = None) -> None:
         """End one sequential component use interval."""
+        use = self._effective_use(use)
         if self._active_use is None or not self._same_use(self._active_use, use):
             return
         self._disable_active_nvtx()
@@ -301,7 +307,19 @@ class ComponentResidencyManager:
 
     def ensure_ready(self, use: ComponentUse, module: nn.Module | None = None) -> None:
         """Prepare a shared component and wait without making it the active use."""
-        self._prepare_forward_use(use, module=module)
+        self._prepare_forward_use(self._effective_use(use), module=module)
+
+    def _effective_use(self, use: ComponentUse) -> ComponentUse:
+        precision = (
+            vars(self.server_args)
+            .get("component_precisions", {})
+            .get(use.component_name)
+        )
+        return (
+            use
+            if precision is None or use.target_dtype is not None
+            else replace(use, target_dtype=precision_to_dtype(precision))
+        )
 
     def remove_nvtx_hooks_for_module(self, module: nn.Module | None) -> None:
         """Detach NVTX hooks before a component object is deleted or replaced."""
@@ -438,6 +456,7 @@ class ComponentResidencyManager:
 
     def _prefetch_use(self, use: ComponentUse) -> None:
         """Prepare a future memory-intensive component without waiting."""
+        use = self._effective_use(use)
         if not use.allow_prefetch:
             return
         module = self.get_module(use.component_name)

--- a/python/sglang/multimodal_gen/runtime/pipelines/comfyui_flux_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/comfyui_flux_pipeline.py
@@ -614,7 +614,7 @@ class ComfyUIFluxPipeline(LoRAPipeline, ComposedPipelineBase):
         safetensors_list = [self.model_path]
         logger.info("Loading weights from: %s", safetensors_list)
         default_dtype = resolve_precision(
-            server_args, "dit", precision_attr="dit_precision"
+            server_args, "transformer", precision_attr="dit_precision"
         )
         server_args.model_paths["transformer"] = os.path.dirname(self.model_path) or "."
         hf_config = {}

--- a/python/sglang/multimodal_gen/runtime/pipelines/comfyui_qwen_image_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/comfyui_qwen_image_pipeline.py
@@ -187,7 +187,7 @@ class ComfyUIQwenImagePipelineBase(LoRAPipeline, ComposedPipelineBase):
         logger.info("Resolved transformer class: %s", cls_name)
 
         default_dtype = resolve_precision(
-            server_args, "dit", precision_attr="dit_precision"
+            server_args, "transformer", precision_attr="dit_precision"
         )
         server_args.model_paths["transformer"] = os.path.dirname(self.model_path) or "."
         assert server_args.hsdp_shard_dim is not None, "hsdp_shard_dim must be set"

--- a/python/sglang/multimodal_gen/runtime/pipelines/comfyui_zimage_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/comfyui_zimage_pipeline.py
@@ -269,7 +269,7 @@ class ComfyUIZImagePipeline(LoRAPipeline, ComposedPipelineBase):
         logger.info("Loading weights from: %s", safetensors_list)
 
         default_dtype = resolve_precision(
-            server_args, "dit", precision_attr="dit_precision"
+            server_args, "transformer", precision_attr="dit_precision"
         )
         server_args.model_paths["transformer"] = os.path.dirname(self.model_path) or "."
         hf_config = {}

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -371,6 +371,12 @@ class DiffusersPipeline(ComposedPipelineBase):
         loaded_modules: dict[str, torch.nn.Module] | None = None,
         executor: PipelineExecutor | None = None,
     ):
+        if server_args.component_precisions:
+            raise ValueError(
+                "--component-precisions requires the native SGLang backend; "
+                "a whole Diffusers pipeline cannot guarantee per-component "
+                "load and autocast precision"
+            )
         self.server_args = server_args
         self.model_path = model_path
         self._stages: list[PipelineStage] = []

--- a/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/diffusers_pipeline.py
@@ -45,7 +45,10 @@ from sglang.multimodal_gen.runtime.platforms import (
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import maybe_download_model
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.runtime.utils.precision import resolve_precision
+from sglang.multimodal_gen.runtime.utils.precision import (
+    component_precision_overrides,
+    resolve_precision,
+)
 from sglang.multimodal_gen.runtime.utils.vision import load_image as load_vision_image
 
 logger = init_logger(__name__)
@@ -371,7 +374,7 @@ class DiffusersPipeline(ComposedPipelineBase):
         loaded_modules: dict[str, torch.nn.Module] | None = None,
         executor: PipelineExecutor | None = None,
     ):
-        if server_args.component_precisions:
+        if component_precision_overrides(server_args):
             raise ValueError(
                 "--component-precisions requires the native SGLang backend; "
                 "a whole Diffusers pipeline cannot guarantee per-component "

--- a/python/sglang/multimodal_gen/runtime/pipelines/hunyuan3d_pipeline.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/hunyuan3d_pipeline.py
@@ -62,7 +62,11 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.h
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_component_precision,
+    resolve_exact_component_precision,
+    resolve_precision,
+)
 
 logger = init_logger(__name__)
 
@@ -408,7 +412,6 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
         server_args: ServerArgs,
         config: Hunyuan3D2PipelineConfig,
     ) -> dict[str, Any]:
-        dtype = PRECISION_TO_TYPE[config.dit_precision]
         components: dict[str, Any] = {}
 
         paint_dir = cls._resolve_model_subfolder(
@@ -422,12 +425,12 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
         )
         components["paint_vae"] = cls._load_stable_diffusion_vae(
             os.path.join(paint_dir, "vae"),
-            dtype,
+            resolve_precision(server_args, "paint_vae", precision_attr="dit_precision"),
             cls._component_device(server_args, "paint_vae"),
         )
         components["paint_transformer"] = cls._load_stable_diffusion_unet(
             os.path.join(paint_dir, "unet"),
-            dtype,
+            resolve_component_precision(server_args, "paint_transformer"),
             cls._component_device(server_args, "paint_transformer"),
             paint=True,
             is_turbo=config.paint_turbo_mode,
@@ -460,12 +463,14 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
             )
             components["delight_vae"] = cls._load_stable_diffusion_vae(
                 os.path.join(delight_dir, "vae"),
-                dtype,
+                resolve_precision(
+                    server_args, "delight_vae", precision_attr="dit_precision"
+                ),
                 cls._component_device(server_args, "delight_vae"),
             )
             components["delight_transformer"] = cls._load_stable_diffusion_unet(
                 os.path.join(delight_dir, "unet"),
-                dtype,
+                resolve_component_precision(server_args, "delight_transformer"),
                 cls._component_device(server_args, "delight_transformer"),
                 paint=False,
             )
@@ -535,7 +540,7 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
                 if server_args.should_start_component_on_cpu("hy3dshape_model")
                 else device
             ),
-            dtype,
+            resolve_exact_component_precision(server_args, "hy3dshape_model") or dtype,
         )
 
         components["hy3dshape_vae"] = self._load_simple_component(
@@ -546,7 +551,7 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
                 if server_args.should_start_component_on_cpu("hy3dshape_vae")
                 else device
             ),
-            dtype,
+            resolve_exact_component_precision(server_args, "hy3dshape_vae") or dtype,
         )
 
         components["hy3dshape_conditioner"] = self._load_simple_component(
@@ -557,7 +562,8 @@ class Hunyuan3D2Pipeline(ComposedPipelineBase):
                 if server_args.should_start_component_on_cpu("hy3dshape_conditioner")
                 else device
             ),
-            dtype,
+            resolve_exact_component_precision(server_args, "hy3dshape_conditioner")
+            or dtype,
         )
 
         components["hy3dshape_scheduler"] = self._instantiate_component(

--- a/python/sglang/multimodal_gen/runtime/pipelines/longcat_image.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/longcat_image.py
@@ -15,7 +15,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.model_specific_stages.l
     LongCatImageEditTextEncodingStage,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import resolve_component_precision
 
 
 def _prepare_mu(batch, server_args):
@@ -48,9 +48,7 @@ class LongCatImagePipeline(LoRAPipeline, ComposedPipelineBase):
         rewrite_stage = LongCatPromptRewriteStage(
             text_encoder=self.get_module("text_encoder"),
             text_processor=self.get_module("text_processor"),
-            text_encoder_dtype=PRECISION_TO_TYPE[
-                server_args.pipeline_config.text_encoder_precisions[0]
-            ],
+            text_encoder_dtype=resolve_component_precision(server_args, "text_encoder"),
         )
         self.add_stage(rewrite_stage)
 
@@ -107,9 +105,9 @@ class LongCatImageEditPipeline(LoRAPipeline, ComposedPipelineBase):
                 text_encoder=self.get_module("text_encoder"),
                 tokenizer=self.get_module("tokenizer"),
                 text_processor=self.get_module("text_processor"),
-                text_encoder_dtype=PRECISION_TO_TYPE[
-                    server_args.pipeline_config.text_encoder_precisions[0]
-                ],
+                text_encoder_dtype=resolve_component_precision(
+                    server_args, "text_encoder"
+                ),
             )
         )
 

--- a/python/sglang/multimodal_gen/runtime/pipelines/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines/qwen_image.py
@@ -19,7 +19,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.progressive_resolution.
     QwenImageProgressiveDenoisingStage,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import resolve_component_precision
 
 
 def prepare_mu(batch: Req, server_args: ServerArgs):
@@ -112,10 +112,10 @@ class QwenImageLayeredPipeline(QwenImageEditPipeline):
                 processor=self.get_module("processor"),
                 transformer=self.get_module("transformer"),
                 scheduler=self.get_module("scheduler"),
-                vae_dtype=PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision],
-                text_encoder_dtype=PRECISION_TO_TYPE[
-                    server_args.pipeline_config.text_encoder_precisions[0]
-                ],
+                vae_dtype=resolve_component_precision(server_args, "vae"),
+                text_encoder_dtype=resolve_component_precision(
+                    server_args, "text_encoder"
+                ),
             )
             return stage
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -107,6 +107,7 @@ class ComposedPipelineBase(ABC):
         self.model_path: str = model_path
         self._stages: list[PipelineStage] = []
         self._stage_name_mapping: dict[str, PipelineStage] = {}
+        self._declared_component_names: set[str] = set()
         self.component_residency_strategies: dict[str, ComponentResidencyStrategy] = {}
         self.executor = executor or self.build_executor(server_args=server_args)
         self.component_residency_manager: ComponentResidencyManager | None = None
@@ -145,6 +146,26 @@ class ComposedPipelineBase(ABC):
         # Load modules directly in initialization
         logger.info("Loading pipeline modules...")
         self.modules = self.load_modules(server_args, loaded_modules)
+        valid_precision_components = self._declared_component_names.union(self.modules)
+        unknown = set(server_args.component_precisions).difference(
+            valid_precision_components
+        )
+        if unknown:
+            raise ValueError(
+                "Unknown component precision override(s): "
+                f"{', '.join(sorted(unknown))}."
+            )
+        unsupported = sorted(
+            component_name
+            for component_name in server_args.component_precisions
+            if component_name in self.modules
+            and not isinstance(self.modules[component_name], torch.nn.Module)
+        )
+        if unsupported:
+            raise ValueError(
+                "Component precision override(s) require torch modules: "
+                f"{', '.join(unsupported)}."
+            )
 
         self.__post_init__()
 
@@ -426,6 +447,13 @@ class ComposedPipelineBase(ABC):
         model_index.pop("boundary_ratio", None)
         # used by Wan2.2 ti2v
         model_index.pop("expand_timesteps", None)
+        self._declared_component_names = {
+            name
+            for name, spec in model_index.items()
+            if isinstance(spec, (list, tuple))
+            and len(spec) == 2
+            and spec[0] is not None
+        }
 
         # some sanity checks
         assert (

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -57,6 +57,9 @@ from sglang.multimodal_gen.runtime.utils.hf_diffusers_utils import (
     verify_model_config_and_directory,
 )
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import (
+    component_precision_overrides,
+)
 
 logger = init_logger(__name__)
 
@@ -112,8 +115,9 @@ class ComposedPipelineBase(ABC):
         self.executor = executor or self.build_executor(server_args=server_args)
         self.component_residency_manager: ComponentResidencyManager | None = None
 
+        precision_overrides = component_precision_overrides(server_args)
         preloaded_precision_overrides = set(loaded_modules or ()).intersection(
-            server_args.component_precisions
+            precision_overrides
         )
         if preloaded_precision_overrides:
             raise ValueError(
@@ -156,9 +160,7 @@ class ComposedPipelineBase(ABC):
         logger.info("Loading pipeline modules...")
         self.modules = self.load_modules(server_args, loaded_modules)
         valid_precision_components = self._declared_component_names.union(self.modules)
-        unknown = set(server_args.component_precisions).difference(
-            valid_precision_components
-        )
+        unknown = set(precision_overrides).difference(valid_precision_components)
         if unknown:
             raise ValueError(
                 "Unknown component precision override(s): "
@@ -166,7 +168,7 @@ class ComposedPipelineBase(ABC):
             )
         unsupported = sorted(
             component_name
-            for component_name in server_args.component_precisions
+            for component_name in precision_overrides
             if component_name in self.modules
             and not isinstance(self.modules[component_name], torch.nn.Module)
         )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/composed_pipeline_base.py
@@ -112,6 +112,15 @@ class ComposedPipelineBase(ABC):
         self.executor = executor or self.build_executor(server_args=server_args)
         self.component_residency_manager: ComponentResidencyManager | None = None
 
+        preloaded_precision_overrides = set(loaded_modules or ()).intersection(
+            server_args.component_precisions
+        )
+        if preloaded_precision_overrides:
+            raise ValueError(
+                "Component precision overrides cannot be applied to preloaded "
+                "modules: " + ", ".join(sorted(preloaded_precision_overrides))
+            )
+
         base_required_config_modules = (
             required_config_modules
             if required_config_modules is not None

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
@@ -174,7 +174,13 @@ class CausalDMDDenoisingStage(DenoisingStage):
         self._causal_attn_metadata_builder_cls = None
         self._causal_attn_metadata_builder = None
 
-    def _target_dtype(self) -> torch.dtype:
+    def _target_dtype(self, server_args: ServerArgs) -> torch.dtype:
+        component_name = self._component_name_for_stage_module(
+            self.transformer, "transformer"
+        )
+        precision = server_args.component_precisions.get(component_name)
+        if precision is not None and precision != "bf16":
+            raise ValueError("Causal denoising supports only bf16 component precision")
         return torch.bfloat16
 
     def _autocast_enabled(
@@ -338,7 +344,7 @@ class CausalDMDDenoisingStage(DenoisingStage):
         batch: Req,
         server_args: ServerArgs,
     ) -> CausalDMDForwardContext:
-        target_dtype = self._target_dtype()
+        target_dtype = self._target_dtype(server_args)
         autocast_enabled = self._autocast_enabled(target_dtype, server_args)
         device = get_local_torch_device()
         scheduler = self._get_causal_dmd_scheduler(batch, server_args)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/causal_denoising.py
@@ -43,6 +43,9 @@ from sglang.multimodal_gen.runtime.utils.precision import (
 from sglang.multimodal_gen.runtime.utils.precision import (
     autocast_enabled as precision_autocast_enabled,
 )
+from sglang.multimodal_gen.runtime.utils.precision import (
+    component_precision_overrides,
+)
 
 logger = init_logger(__name__)
 
@@ -178,7 +181,7 @@ class CausalDMDDenoisingStage(DenoisingStage):
         component_name = self._component_name_for_stage_module(
             self.transformer, "transformer"
         )
-        precision = server_args.component_precisions.get(component_name)
+        precision = component_precision_overrides(server_args).get(component_name)
         if precision is not None and precision != "bf16":
             raise ValueError("Causal denoising supports only bf16 component precision")
         return torch.bfloat16

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/denoising.py
@@ -147,6 +147,7 @@ from sglang.multimodal_gen.runtime.utils.precision import (
 )
 from sglang.multimodal_gen.runtime.utils.precision import (
     resolve_precision,
+    validate_shared_component_autocast,
 )
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
 from sglang.multimodal_gen.runtime.utils.torch_compile import (
@@ -1140,8 +1141,19 @@ class DenoisingStage(PipelineStage, RolloutDenoisingMixin):
         )
 
         # Setup precision and autocast settings
+        transformer_component = self._component_name_for_stage_module(
+            self.transformer, "transformer"
+        )
+        transformer_components = [transformer_component]
+        if self.transformer_2 is not None:
+            transformer_components.append(
+                self._component_name_for_stage_module(
+                    self.transformer_2, "transformer_2"
+                )
+            )
+        validate_shared_component_autocast(server_args, transformer_components)
         target_dtype = resolve_precision(
-            server_args, "dit", precision_attr="dit_precision"
+            server_args, transformer_component, precision_attr="dit_precision"
         )
         autocast_enabled = precision_autocast_enabled(
             target_dtype, server_args.disable_autocast

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/image_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/image_encoding.py
@@ -42,6 +42,8 @@ from sglang.multimodal_gen.runtime.utils.precision import (
     align_tensor_to_module_dtype,
     autocast_context,
     autocast_enabled,
+    explicit_component_autocast_context,
+    resolve_component_precision,
     resolve_precision,
     temporary_module_dtype,
 )
@@ -150,16 +152,27 @@ class ImageEncodingStage(PipelineStage):
         self.image_encoder = image_encoder
         self.text_encoder = text_encoder
 
+    def _component_name(self, module, default_name: str) -> str:
+        manager = self._component_residency_manager
+        if manager is None or module is None:
+            return default_name
+        for name, candidate in manager.pipeline.modules.items():
+            if candidate is module:
+                return name
+        return default_name
+
     def component_uses(
         self, server_args: ServerArgs, stage_name: str | None = None
     ) -> list[ComponentUse]:
         stage_name = self._component_stage_name(stage_name)
-        uses = []
-        if self.image_encoder is not None:
-            uses.append(ComponentUse(stage_name, "image_encoder"))
-        if self.text_encoder is not None:
-            uses.append(ComponentUse(stage_name, "text_encoder"))
-        return uses
+        return [
+            ComponentUse(stage_name, self._component_name(module, name))
+            for module, name in (
+                (self.image_encoder, "image_encoder"),
+                (self.text_encoder, "text_encoder"),
+            )
+            if module is not None
+        ]
 
     def encoding_image_edit(self, outputs, image_inputs, pipeline_config):
         """Encode image-edit text features via pipeline-configured postprocess hook."""
@@ -249,8 +262,11 @@ class ImageEncodingStage(PipelineStage):
 
             if self.image_encoder:
                 # if an image encoder is provided
+                image_encoder_component = self._component_name(
+                    self.image_encoder, "image_encoder"
+                )
                 with self.use_declared_component(
-                    component_name="image_encoder",
+                    component_name=image_encoder_component,
                     module=self.image_encoder,
                 ) as image_encoder:
                     assert image_encoder is not None
@@ -263,7 +279,15 @@ class ImageEncodingStage(PipelineStage):
                             self.image_encoder,
                             device=cuda_device,
                         )
-                    with set_forward_context(current_timestep=0, attn_metadata=None):
+                    image_encoder_dtype = resolve_component_precision(
+                        server_args, image_encoder_component
+                    )
+                    assert image_encoder_dtype is not None
+                    with explicit_component_autocast_context(
+                        server_args,
+                        image_encoder_component,
+                        image_encoder_dtype,
+                    ), set_forward_context(current_timestep=0, attn_metadata=None):
                         outputs = self.image_encoder(
                             **image_inputs,
                             **server_args.pipeline_config.image_encoder_extra_args,
@@ -291,8 +315,11 @@ class ImageEncodingStage(PipelineStage):
                         **neg_image_processor_kwargs,
                     ).to(cuda_device)
 
+                text_encoder_component = self._component_name(
+                    self.text_encoder, "text_encoder"
+                )
                 with self.use_declared_component(
-                    component_name="text_encoder",
+                    component_name=text_encoder_component,
                     module=self.text_encoder,
                 ) as text_encoder:
                     assert text_encoder is not None
@@ -315,7 +342,15 @@ class ImageEncodingStage(PipelineStage):
                             self.text_encoder,
                             device=cuda_device,
                         )
-                    with set_forward_context(current_timestep=0, attn_metadata=None):
+                    text_encoder_dtype = resolve_component_precision(
+                        server_args, text_encoder_component
+                    )
+                    assert text_encoder_dtype is not None
+                    with explicit_component_autocast_context(
+                        server_args,
+                        text_encoder_component,
+                        text_encoder_dtype,
+                    ), set_forward_context(current_timestep=0, attn_metadata=None):
                         outputs = self.text_encoder(
                             input_ids=image_inputs.input_ids,
                             attention_mask=image_inputs.attention_mask,
@@ -664,11 +699,13 @@ class LTX2ImageEncodingStage(PipelineStage):
         self, video_condition: torch.Tensor, server_args: ServerArgs
     ) -> torch.Tensor:
         """LTX-2.3 condition-image encoder path (bypasses VAE)."""
-        vae_dtype = resolve_precision(
-            server_args, "vae", precision_attr="vae_precision"
+        encoder_dtype = resolve_precision(
+            server_args,
+            "condition_image_encoder",
+            precision_attr="vae_precision",
         )
 
-        with autocast_context(vae_dtype, server_args.disable_autocast):
+        with autocast_context(encoder_dtype, server_args.disable_autocast):
             return self._condition_image_encoder(video_condition)
 
     @staticmethod
@@ -747,7 +784,7 @@ class LTX2ImageEncodingStage(PipelineStage):
         use_condition_encoder = self._ensure_condition_image_encoder(server_args)
 
         device = get_local_torch_device()
-        encode_dtype = batch.latents.dtype
+        output_dtype = batch.latents.dtype
 
         if use_condition_encoder:
             component_name = "condition_image_encoder"
@@ -755,12 +792,15 @@ class LTX2ImageEncodingStage(PipelineStage):
         else:
             component_name = "vae"
             encoder = self.vae
+        component_dtype = resolve_precision(
+            server_args, component_name, precision_attr="vae_precision"
+        )
 
         packed_latents = []
         with self.use_declared_component(
             component_name=component_name,
             module=encoder,
-            target_dtype=encode_dtype,
+            target_dtype=component_dtype,
         ) as active_encoder:
             assert active_encoder is not None
             if use_condition_encoder:
@@ -774,18 +814,17 @@ class LTX2ImageEncodingStage(PipelineStage):
                     width=int(batch.width),
                     height=int(batch.height),
                     device=device,
-                    dtype=encode_dtype,
+                    dtype=component_dtype,
                 )
 
                 # 3. Encode
                 if use_condition_encoder:
-                    latent = self._condition_encode(video_condition, server_args).to(
-                        dtype=encode_dtype
-                    )
+                    latent = self._condition_encode(video_condition, server_args)
                 else:
                     latent = self._vae_encode(
                         video_condition, server_args, batch.generator
                     )
+                latent = latent.to(dtype=output_dtype)
 
                 packed = server_args.pipeline_config.maybe_pack_latents(
                     latent, latent.shape[0], batch
@@ -1043,7 +1082,9 @@ class ImageVAEEncodingStage(PipelineStage):
             width=batch.width,
             num_frames=batch.num_frames,
             encode_sample_mode=sample_mode,
-            vae_precision=server_args.pipeline_config.vae_precision,
+            vae_precision=server_args.component_precisions.get(
+                "vae", server_args.pipeline_config.vae_precision
+            ),
             vae_tiling=bool(server_args.pipeline_config.vae_tiling),
         )
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/image_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/image_encoding.py
@@ -42,6 +42,7 @@ from sglang.multimodal_gen.runtime.utils.precision import (
     align_tensor_to_module_dtype,
     autocast_context,
     autocast_enabled,
+    component_precision_overrides,
     explicit_component_autocast_context,
     resolve_component_precision,
     resolve_precision,
@@ -1082,7 +1083,7 @@ class ImageVAEEncodingStage(PipelineStage):
             width=batch.width,
             num_frames=batch.num_frames,
             encode_sample_mode=sample_mode,
-            vae_precision=server_args.component_precisions.get(
+            vae_precision=component_precision_overrides(server_args).get(
                 "vae", server_args.pipeline_config.vae_precision
             ),
             vae_tiling=bool(server_args.pipeline_config.vae_tiling),

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_decoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_decoding.py
@@ -14,7 +14,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.decoding import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import resolve_decode_precision
 
 logger = init_logger(__name__)
 
@@ -48,7 +48,7 @@ class HeliosDecodingStage(DecodingStage):
         # Load VAE if needed
         self.load_model()
 
-        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        vae_dtype = resolve_decode_precision(server_args, self.component_name)
         # Decode each chunk separately and concatenate in pixel space
         video_chunks = []
         with self.use_declared_component(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/helios_denoising.py
@@ -29,8 +29,8 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
+from sglang.multimodal_gen.runtime.utils.precision import resolve_precision
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 logger = init_logger(__name__)
 
@@ -488,8 +488,8 @@ class HeliosChunkedDenoisingStage(PipelineStage):
             if hasattr(batch, "latents") and batch.latents is not None
             else torch.device("cuda")
         )
-        target_dtype = PRECISION_TO_TYPE.get(
-            server_args.pipeline_config.precision, torch.bfloat16
+        target_dtype = resolve_precision(
+            server_args, "transformer", precision_attr="precision"
         )
 
         # Get config params

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ideogram.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ideogram.py
@@ -39,7 +39,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.nvtx_pytorch_hooks import maybe_nvtx_range
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import resolve_decode_precision
 
 SEQUENCE_PADDING_INDICATOR = -1
 OUTPUT_IMAGE_INDICATOR = 2
@@ -508,9 +508,7 @@ class Ideogram4DecodingStage(PipelineStage):
             ComponentUse(
                 self._component_stage_name(stage_name),
                 "vae",
-                target_dtype=PRECISION_TO_TYPE[
-                    server_args.pipeline_config.vae_precision
-                ],
+                target_dtype=resolve_decode_precision(server_args),
                 keep_ready_after_warmup=True,
             )
         ]
@@ -531,7 +529,7 @@ class Ideogram4DecodingStage(PipelineStage):
         z = z.view(batch_size, grid_h, grid_w, patch, patch, ae_channels)
         z = z.permute(0, 5, 1, 3, 2, 4).contiguous()
         z = z.view(batch_size, ae_channels, grid_h * patch, grid_w * patch)
-        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        vae_dtype = resolve_decode_precision(server_args)
         with self.use_declared_component(component_name="vae", module=self.vae) as vae:
             z = z.to(vae_dtype)
             decoded = vae.decode(z)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/krea2.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/krea2.py
@@ -18,6 +18,9 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_exact_component_precision,
+)
 
 logger = init_logger(__name__)
 
@@ -49,11 +52,15 @@ class Krea2BeforeDenoisingStage(PipelineStage):
     def component_uses(self, server_args: ServerArgs, stage_name: str | None = None):
         # Declare the text encoder so the residency manager can CPU-offload it
         # (with --text-encoder-cpu-offload) for the denoise loop, where it is idle.
+        text_encoder_dtype = (
+            resolve_exact_component_precision(server_args, "text_encoder")
+            or torch.bfloat16
+        )
         return [
             ComponentUse(
                 self._component_stage_name(stage_name),
                 "text_encoder",
-                target_dtype=torch.bfloat16,
+                target_dtype=text_encoder_dtype,
             )
         ]
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/decoding_av.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/decoding_av.py
@@ -45,13 +45,16 @@ class LTX2AVDecodingStage(DecodingStage):
         audio_vae_dtype = resolve_precision(
             server_args, "audio_vae", precision_attr="audio_vae_precision"
         )
+        diffusion_decoder_dtype = resolve_decode_precision(
+            server_args, "diffusion_decoder"
+        )
         uses = [ComponentUse(stage_name, "vae", target_dtype=vae_dtype)]
         if self.diffusion_decoder is not None:
             uses.append(
                 ComponentUse(
                     stage_name,
                     "diffusion_decoder",
-                    target_dtype=vae_dtype,
+                    target_dtype=diffusion_decoder_dtype,
                     allow_prefetch=False,
                 )
             )
@@ -110,13 +113,19 @@ class LTX2AVDecodingStage(DecodingStage):
                 assert decoder is not None
                 decoder.eval()
                 latents = self._prepare_video_latents(batch, decoder, server_args)
+                diffusion_decoder_dtype = resolve_decode_precision(
+                    server_args, "diffusion_decoder"
+                )
+                diffusion_decoder_autocast_enabled = autocast_enabled(
+                    diffusion_decoder_dtype, server_args.disable_autocast
+                )
                 with autocast_context(
-                    dtype=vae_dtype,
+                    dtype=diffusion_decoder_dtype,
                     disable_autocast=server_args.disable_autocast,
-                    enabled=vae_autocast_enabled,
+                    enabled=diffusion_decoder_autocast_enabled,
                 ):
-                    if not vae_autocast_enabled:
-                        latents = latents.to(vae_dtype)
+                    if not diffusion_decoder_autocast_enabled:
+                        latents = latents.to(diffusion_decoder_dtype)
                     decode_output = self._decode_with_diffusion_decoder(
                         decoder, latents, batch, server_args
                     )

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/latent_preparation_av.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/latent_preparation_av.py
@@ -82,7 +82,9 @@ class LTX2AVLatentPreparationStage(LatentPreparationStage):
             return batch.prompt_embeds[0].dtype
         if isinstance(batch.prompt_embeds, torch.Tensor):
             return batch.prompt_embeds.dtype
-        return resolve_precision(server_args, "dit", precision_attr="dit_precision")
+        return resolve_precision(
+            server_args, "transformer", precision_attr="dit_precision"
+        )
 
     @staticmethod
     def _packed_video_latent_shape(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/upsampling.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/ltx_2/upsampling.py
@@ -8,6 +8,9 @@ from sglang.multimodal_gen.runtime.pipelines_core.schedule_batch import Req
 from sglang.multimodal_gen.runtime.pipelines_core.stages.base import PipelineStage
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_exact_component_precision,
+)
 
 logger = init_logger(__name__)
 
@@ -75,24 +78,40 @@ class LTX2UpsampleStage(PipelineStage):
         self, server_args: ServerArgs, stage_name: str | None = None
     ) -> list[ComponentUse]:
         stage_name = self._component_stage_name(stage_name)
-        return [ComponentUse(stage_name, "spatial_upsampler")]
+        upsampler_dtype = (
+            resolve_exact_component_precision(server_args, "spatial_upsampler")
+            or torch.bfloat16
+        )
+        return [
+            ComponentUse(
+                stage_name,
+                "spatial_upsampler",
+                target_dtype=upsampler_dtype,
+            )
+        ]
 
     def _upsample_video_latents(
         self, latents: torch.Tensor, server_args: ServerArgs, device: torch.device
     ) -> torch.Tensor:
+        output_dtype = latents.dtype
+        upsampler_dtype = (
+            resolve_exact_component_precision(server_args, "spatial_upsampler")
+            or torch.bfloat16
+        )
         vae_mean = self.vae.latents_mean.view(1, -1, 1, 1, 1).to(
-            device=device, dtype=latents.dtype
+            device=device, dtype=output_dtype
         )
         vae_std = self.vae.latents_std.view(1, -1, 1, 1, 1).to(
-            device=device, dtype=latents.dtype
+            device=device, dtype=output_dtype
         )
         latents = latents * vae_std + vae_mean
         with self.use_declared_component(
             component_name="spatial_upsampler",
             module=self.spatial_upsampler,
-            target_dtype=latents.dtype,
         ) as spatial_upsampler:
-            latents = spatial_upsampler(latents)
+            latents = spatial_upsampler(latents.to(dtype=upsampler_dtype)).to(
+                dtype=output_dtype
+            )
         latents = (latents - vae_mean) / vae_std
         return latents
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/mova.py
@@ -71,8 +71,12 @@ from sglang.multimodal_gen.runtime.utils.perf_logger import StageProfiler
 from sglang.multimodal_gen.runtime.utils.precision import (
     autocast_context as precision_autocast_context,
 )
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_component_precision,
+    resolve_decode_precision,
+    validate_shared_component_autocast,
+)
 from sglang.multimodal_gen.runtime.utils.profiler import SGLDiffusionProfiler
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 from sglang.srt.utils.common import get_compiler_backend
 
 _is_npu = current_platform.is_npu()
@@ -110,7 +114,11 @@ class MOVALatentPreparationStage(PipelineStage):
                 f" size of {batch_size}. Make sure the batch size matches the length of the generators."
             )
 
-        dit_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.dit_precision]
+        validate_shared_component_autocast(
+            server_args, ["video_dit", "audio_dit", "dual_tower_bridge"]
+        )
+        dit_dtype = resolve_component_precision(server_args, "video_dit")
+        assert dit_dtype is not None
         batch.latents = randn_tensor(
             video_shape, generator=generator, device=device, dtype=dit_dtype
         )
@@ -941,7 +949,7 @@ class MOVADecodingStage(PipelineStage):
         self, server_args: ServerArgs, stage_name: str | None = None
     ) -> list[ComponentUse]:
         stage_name = self._component_stage_name(stage_name)
-        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        vae_dtype = resolve_decode_precision(server_args, "video_vae")
         return [
             ComponentUse(stage_name, "video_vae", target_dtype=vae_dtype),
             ComponentUse(stage_name, "audio_vae"),
@@ -959,7 +967,7 @@ class MOVADecodingStage(PipelineStage):
 
     @torch.no_grad()
     def forward(self, batch: Req, server_args: ServerArgs) -> OutputBatch:
-        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        vae_dtype = resolve_decode_precision(server_args, "video_vae")
         vae_autocast_enabled = (
             vae_dtype != torch.float32
         ) and not server_args.disable_autocast

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
@@ -47,9 +47,21 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.text_encoding import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_component_precision,
+    resolve_precision,
+)
 
 logger = init_logger(__name__)
+
+
+def resolve_sana_wm_dit_dtype(
+    server_args: ServerArgs, component_name: str = "transformer"
+) -> torch.dtype:
+    return resolve_precision(
+        server_args, component_name, precision_attr="dit_precision"
+    )
+
 
 SANA_WM_TARGET_HEIGHT = 704
 SANA_WM_TARGET_WIDTH = 1280
@@ -831,10 +843,7 @@ class SanaWMDenoisingStage(DenoisingStage):
             )
 
         device = get_local_torch_device()
-        target_dtype = PRECISION_TO_TYPE.get(
-            getattr(server_args.pipeline_config, "dit_precision", "bf16"),
-            torch.bfloat16,
-        )
+        target_dtype = resolve_sana_wm_dit_dtype(server_args)
         scheduler = getattr(
             batch, "scheduler", None
         ) or get_or_create_request_scheduler(batch, self.scheduler)
@@ -1080,8 +1089,9 @@ class SanaWMBeforeDenoisingStage(PipelineStage):
         if self.vae is None:
             return []
         stage_name = self._component_stage_name(stage_name)
-        pipeline_config = getattr(server_args, "pipeline_config", self.pipeline_config)
-        vae_dtype = PRECISION_TO_TYPE[pipeline_config.vae_precision]
+        vae_dtype = resolve_precision(
+            server_args, "vae", precision_attr="vae_precision"
+        )
         return [
             ComponentUse(
                 stage_name=stage_name,
@@ -1100,9 +1110,7 @@ class SanaWMBeforeDenoisingStage(PipelineStage):
         """Encode a single image frame through the VAE encoder."""
         vae = self.vae
         configure_sana_wm_ltx2_vae_for_long_video(vae, self.pipeline_config)
-        vae_dtype = PRECISION_TO_TYPE.get(
-            self.pipeline_config.vae_precision, torch.bfloat16
-        )
+        vae_dtype = dtype
 
         # Normalize image to [-1, 1] range expected by the VAE
         if image.max() > 1.01:
@@ -2200,10 +2208,8 @@ class SanaWMBeforeDenoisingStage(PipelineStage):
         Expects batch to already have prompt_embeds set by SanaWMTextEncodingStage.
         """
         device = get_local_torch_device()
-        dtype = PRECISION_TO_TYPE.get(
-            getattr(self.pipeline_config, "dit_precision", "bf16"),
-            torch.bfloat16,
-        )
+        dtype = resolve_sana_wm_dit_dtype(server_args)
+        vae_dtype = resolve_component_precision(server_args, "vae") or dtype
         if not hasattr(batch, "extra") or batch.extra is None:
             batch.extra = {}
 
@@ -2255,7 +2261,7 @@ class SanaWMBeforeDenoisingStage(PipelineStage):
         if condition_image is not None:
             try:
                 latents = self._splice_first_frame(
-                    latents, condition_image, dtype, device, batch=batch
+                    latents, condition_image, vae_dtype, device, batch=batch
                 )
                 self.log_info("First-frame spliced into noise latents.")
             except Exception as e:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/base.py
@@ -48,6 +48,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.text_encoding import (
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
 from sglang.multimodal_gen.runtime.utils.precision import (
+    precision_to_dtype,
     resolve_component_precision,
     resolve_precision,
 )
@@ -1089,9 +1090,11 @@ class SanaWMBeforeDenoisingStage(PipelineStage):
         if self.vae is None:
             return []
         stage_name = self._component_stage_name(stage_name)
-        vae_dtype = resolve_precision(
-            server_args, "vae", precision_attr="vae_precision"
-        )
+        vae_dtype = resolve_component_precision(server_args, "vae")
+        if vae_dtype is None:
+            vae_dtype = precision_to_dtype(
+                self.pipeline_config.vae_precision, "vae_precision"
+            )
         return [
             ComponentUse(
                 stage_name=stage_name,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/realtime_chain.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/realtime_chain.py
@@ -36,7 +36,9 @@ from sglang.multimodal_gen.runtime.realtime.states import (
     get_realtime_causal_dit_state,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_decode_precision,
+)
 
 from . import parity_probe
 from .base import (
@@ -44,6 +46,7 @@ from .base import (
     _SANA_WM_DEFAULT_TRANSLATION_SPEED,
     SanaWMBeforeDenoisingStage,
     configure_sana_wm_ltx2_vae_for_long_video,
+    resolve_sana_wm_dit_dtype,
     snap_sana_wm_num_frames,
 )
 from .realtime_stage import (
@@ -138,11 +141,8 @@ class SanaWMCondFrameEncodeStage(SanaWMRealtimeStage):
         session = self.require_session(batch, context="SANA-WM realtime chain")
         self._pipeline_config = server_args.pipeline_config
         device = get_local_torch_device()
-        weight_dtype = PRECISION_TO_TYPE.get(
-            getattr(server_args.pipeline_config, "dit_precision", "bf16"),
-            torch.bfloat16,
-        )
-        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        weight_dtype = resolve_sana_wm_dit_dtype(server_args)
+        vae_dtype = resolve_decode_precision(server_args)
 
         self.vae = self.vae.to(device=device, dtype=vae_dtype).eval()
         configure_sana_wm_ltx2_vae_for_long_video(self.vae, server_args.pipeline_config)
@@ -213,10 +213,7 @@ class SanaWMRealtimeLatentPrepStage(SanaWMRealtimeStage):
     @torch.no_grad()
     def forward(self, batch: Req, server_args: ServerArgs) -> Req:
         device = get_local_torch_device()
-        weight_dtype = PRECISION_TO_TYPE.get(
-            getattr(server_args.pipeline_config, "dit_precision", "bf16"),
-            torch.bfloat16,
-        )
+        weight_dtype = resolve_sana_wm_dit_dtype(server_args)
         session = self.require_session(batch, context="SANA-WM realtime chain")
         inputs = session.get_or_create_state(SanaWMSessionInputsState)
         noise = session.get_or_create_state(SanaWMNoiseState)
@@ -331,10 +328,7 @@ class SanaWMCameraCondStage(SanaWMRealtimeStage):
     @torch.no_grad()
     def forward(self, batch: Req, server_args: ServerArgs) -> Req:
         device = get_local_torch_device()
-        weight_dtype = PRECISION_TO_TYPE.get(
-            getattr(server_args.pipeline_config, "dit_precision", "bf16"),
-            torch.bfloat16,
-        )
+        weight_dtype = resolve_sana_wm_dit_dtype(server_args)
         session = self.require_session(batch, context="SANA-WM realtime chain")
         inputs = session.get_or_create_state(SanaWMSessionInputsState)
         cache = get_realtime_causal_dit_state(session)
@@ -538,7 +532,7 @@ class SanaWMCausalDecodeChainStage(SanaWMRealtimeStage):
     @torch.no_grad()
     def forward(self, batch: Req, server_args: ServerArgs) -> OutputBatch:
         device = get_local_torch_device()
-        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        vae_dtype = resolve_decode_precision(server_args)
 
         self.vae = self.vae.to(device=device, dtype=vae_dtype).eval()
         configure_sana_wm_ltx2_vae_for_long_video(self.vae, server_args.pipeline_config)

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/refiner.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/refiner.py
@@ -37,11 +37,11 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.base import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 from .base import (
     SanaWMDecodingStage,
     log_sana_wm_tensor_stats,
+    resolve_sana_wm_dit_dtype,
     sana_wm_diagnostics_enabled,
 )
 
@@ -129,8 +129,7 @@ def sana_wm_skip_refiner_enabled(batch: Req | None = None) -> bool:
 
 
 def default_sana_wm_refiner_dtype(server_args: ServerArgs) -> torch.dtype:
-    precision = getattr(server_args.pipeline_config, "dit_precision", "bf16")
-    return PRECISION_TO_TYPE.get(precision, torch.bfloat16)
+    return resolve_sana_wm_dit_dtype(server_args, "transformer_2")
 
 
 def _is_current_cfg_main_rank() -> bool:

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/sana_wm/streaming.py
@@ -47,7 +47,6 @@ from sglang.multimodal_gen.runtime.realtime.states import (
     get_realtime_causal_dit_state,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
 
 from . import parity_probe
 from .base import (
@@ -56,6 +55,7 @@ from .base import (
     _first_tensor,
     _to_device_dtype,
     log_sana_wm_tensor_stats,
+    resolve_sana_wm_dit_dtype,
 )
 
 _SANAWM_INJECT_DIR = _os.environ.get(parity_probe.ENV_INJECT)
@@ -193,9 +193,7 @@ class SanaWMStreamingDenoisingStage(CausalDMDDenoisingStage):
             ComponentUse(
                 stage_name,
                 "transformer",
-                target_dtype=PRECISION_TO_TYPE[
-                    server_args.pipeline_config.dit_precision
-                ],
+                target_dtype=resolve_sana_wm_dit_dtype(server_args),
                 memory_intensive=True,
                 keep_ready_after_warmup=True,
             ),
@@ -248,11 +246,8 @@ class SanaWMStreamingDenoisingStage(CausalDMDDenoisingStage):
                 "SANA-WM realtime denoising expects this tick's pre-noised chunk "
                 "latents (B, C, n, H, W) from the latent-preparation stage."
             )
-        pcfg = server_args.pipeline_config
         device = get_local_torch_device()
-        target_dtype = PRECISION_TO_TYPE.get(
-            getattr(pcfg, "dit_precision", "bf16"), torch.bfloat16
-        )
+        target_dtype = resolve_sana_wm_dit_dtype(server_args)
         if batch.session is None:
             raise ValueError("SANA-WM realtime denoising requires a realtime session")
         state = get_realtime_causal_dit_state(batch.session)
@@ -544,9 +539,7 @@ class SanaWMStreamingDenoisingStage(CausalDMDDenoisingStage):
 
         pcfg = server_args.pipeline_config
         device = get_local_torch_device()
-        target_dtype = PRECISION_TO_TYPE.get(
-            getattr(pcfg, "dit_precision", "bf16"), torch.bfloat16
-        )
+        target_dtype = resolve_sana_wm_dit_dtype(server_args)
 
         # .clone() detaches from the loader's InferenceMode tensor so the
         # per-chunk in-place latent updates below are allowed.

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/realtime/base.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/realtime/base.py
@@ -20,7 +20,7 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.decoding import (
     scale_and_shift_latents,
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import resolve_precision
 
 
 @dataclass(frozen=True)
@@ -81,8 +81,11 @@ class RealtimeDiffusionStage(PipelineStage):
         for spec in self.component_specs:
             target_dtype = None
             if spec.precision_attr is not None:
-                precision = getattr(server_args.pipeline_config, spec.precision_attr)
-                target_dtype = PRECISION_TO_TYPE[precision]
+                target_dtype = resolve_precision(
+                    server_args,
+                    spec.component_name,
+                    precision_attr=spec.precision_attr,
+                )
             uses.append(
                 ComponentUse(
                     stage_name,

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/realtime/vae.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/realtime/vae.py
@@ -21,7 +21,9 @@ from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.precision import (
     autocast_context as precision_autocast_context,
 )
-from sglang.multimodal_gen.utils import PRECISION_TO_TYPE
+from sglang.multimodal_gen.runtime.utils.precision import (
+    resolve_decode_precision,
+)
 
 
 class RealtimeVAEState(BaseRealtimeState):
@@ -130,7 +132,7 @@ class CausalVaeDecodingStage(DecodingStage):
         *,
         first_chunk: bool,
     ) -> torch.Tensor:
-        vae_dtype = PRECISION_TO_TYPE[server_args.pipeline_config.vae_precision]
+        vae_dtype = resolve_decode_precision(server_args, self.component_name)
         self.vae = self.vae.to(device=get_local_torch_device(), dtype=vae_dtype)
         latents = latents.to(get_local_torch_device())
         vae_autocast_enabled = (

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/text_encoding.py
@@ -41,6 +41,10 @@ from sglang.multimodal_gen.runtime.pipelines_core.stages.validators import (
 )
 from sglang.multimodal_gen.runtime.server_args import ServerArgs
 from sglang.multimodal_gen.runtime.utils.logging_utils import init_logger
+from sglang.multimodal_gen.runtime.utils.precision import (
+    explicit_component_autocast_context,
+    resolve_component_precision,
+)
 
 logger = init_logger(__name__)
 
@@ -707,16 +711,22 @@ class TextEncodingStage(ConditionEncodingStage):
             dp_group = self._text_encode_dp_group(
                 server_args, encoder_config, input_ids.shape[0], text_encoder
             )
-            if dp_group is not None:
-                outputs = _data_parallel_text_encode(
-                    lambda kw: self._forward_text_encoder(text_encoder, kw),
-                    encoder_forward_kwargs,
-                    dp_group,
-                )
-            else:
-                outputs = self._forward_text_encoder(
-                    text_encoder, encoder_forward_kwargs
-                )
+            component_name = "text_encoder" if i == 0 else f"text_encoder_{i + 1}"
+            encoder_dtype = resolve_component_precision(server_args, component_name)
+            assert encoder_dtype is not None
+            with explicit_component_autocast_context(
+                server_args, component_name, encoder_dtype
+            ):
+                if dp_group is not None:
+                    outputs = _data_parallel_text_encode(
+                        lambda kw: self._forward_text_encoder(text_encoder, kw),
+                        encoder_forward_kwargs,
+                        dp_group,
+                    )
+                else:
+                    outputs = self._forward_text_encoder(
+                        text_encoder, encoder_forward_kwargs
+                    )
             postprocess_sig = inspect.signature(postprocess_func)
 
             postprocess_kwargs = {}

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -306,6 +306,8 @@ class ServerArgs(DisaggServerArgsMixin):
     component_paths: dict[str, str] = field(default_factory=dict)
     # Exact weight-file overrides retain the base component configuration.
     component_weights_paths: dict[str, str] = field(default_factory=dict)
+    # Exact component precision overrides. Family precision flags remain the fallback.
+    component_precisions: dict[str, str] = field(default_factory=dict)
     # Explicit quantization override for one component. Self-describing
     # checkpoints remain auto-detected and do not need this override.
     component_quantizations: dict[str, str] = field(default_factory=dict)
@@ -1751,6 +1753,28 @@ class ServerArgs(DisaggServerArgsMixin):
             component_weights_paths[component] = path
         self.component_paths = component_paths
         self.component_weights_paths = component_weights_paths
+        normalized_precisions: dict[str, str] = {}
+        for component, precision in self.component_precisions.items():
+            component = str(component).strip().replace("-", "_").lower()
+            precision = str(precision).strip().lower()
+            if not component or precision not in {"fp16", "bf16", "fp32"}:
+                raise ValueError(
+                    "Component precision entries require an exact component key "
+                    "and one of fp16, bf16, or fp32"
+                )
+            previous = normalized_precisions.get(component)
+            if previous is not None and previous != precision:
+                raise ValueError(
+                    f"Conflicting precision overrides for {component!r}: "
+                    f"{previous!r} and {precision!r}"
+                )
+            normalized_precisions[component] = precision
+        self.component_precisions = normalized_precisions
+        if self.backend == Backend.DIFFUSERS and self.component_precisions:
+            raise ValueError(
+                "The whole-pipeline Diffusers backend does not support component "
+                "precision overrides."
+            )
         normalized_quantizations: dict[str, str] = {}
         for component, quantization in self.component_quantizations.items():
             component = str(component).strip().replace("-", "_")
@@ -2845,7 +2869,7 @@ class ServerArgs(DisaggServerArgsMixin):
         unknown_args: list[str],
         *,
         option_prefixes: tuple[str, ...],
-        alias_suffix: str,
+        alias_suffix: str | None = None,
     ) -> tuple[dict[str, str], list[str]]:
         component_values: dict[str, str] = {}
         remaining: list[str] = []
@@ -2860,6 +2884,7 @@ class ServerArgs(DisaggServerArgsMixin):
                     break
             if (
                 component is None
+                and alias_suffix is not None
                 and key_part.startswith("--")
                 and key_part.endswith(alias_suffix)
             ):
@@ -2926,6 +2951,20 @@ class ServerArgs(DisaggServerArgsMixin):
                 "--component_quantizations.",
             ),
             alias_suffix="-quantization",
+        )
+
+    @classmethod
+    def _extract_component_precisions(
+        cls,
+        unknown_args: list[str],
+    ) -> tuple[dict[str, str], list[str]]:
+        """Extract exact per-component precision overrides."""
+        return cls._extract_dynamic_component_map(
+            unknown_args,
+            option_prefixes=(
+                "--component-precisions.",
+                "--component_precisions.",
+            ),
         )
 
     @staticmethod
@@ -3018,6 +3057,7 @@ class ServerArgs(DisaggServerArgsMixin):
         dynamic_quantizations, remaining = cls._extract_component_quantizations(
             unknown_args
         )
+        dynamic_precisions, remaining = cls._extract_component_precisions(remaining)
         dynamic_ignored_layers, remaining = (
             cls._extract_component_quantization_ignored_layers(remaining)
         )
@@ -3061,6 +3101,16 @@ class ServerArgs(DisaggServerArgsMixin):
             existing.update(dynamic_quantizations)
             provided_args["component_quantizations"] = existing
             explicit_arg_names.add("component_quantizations")
+        if dynamic_precisions:
+            existing = {
+                str(component).strip().replace("-", "_").lower(): precision
+                for component, precision in dict(
+                    provided_args.get("component_precisions") or {}
+                ).items()
+            }
+            existing.update(dynamic_precisions)
+            provided_args["component_precisions"] = existing
+            explicit_arg_names.add("component_precisions")
         if dynamic_ignored_layers:
             existing = dict(
                 provided_args.get("component_quantization_ignored_layers") or {}

--- a/python/sglang/multimodal_gen/runtime/utils/precision.py
+++ b/python/sglang/multimodal_gen/runtime/utils/precision.py
@@ -3,6 +3,13 @@ from typing import Iterator, Optional, Union
 
 import torch
 
+from sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload_components import (
+    component_base_name,
+    is_legacy_dit_offload_component_name,
+    is_legacy_image_encoder_offload_component_name,
+    is_text_encoder_component_name,
+    is_vae_component_name,
+)
 from sglang.multimodal_gen.runtime.platforms import current_platform
 from sglang.multimodal_gen.runtime.utils.precision_types import PRECISION_TO_TYPE
 
@@ -24,6 +31,13 @@ def resolve_precision(
     precision_attr: Optional[str] = None,
     field_name: Optional[str] = None,
 ) -> torch.dtype:
+    component_precisions = vars(server_args).get("component_precisions", {})
+    component_precision = component_precisions.get(component_or_precision_attr)
+    if component_precision is not None:
+        return precision_to_dtype(
+            component_precision,
+            f"component_precisions.{component_or_precision_attr}",
+        )
     precision_attr = precision_attr or component_or_precision_attr
     precision = getattr(server_args.pipeline_config, precision_attr)
     return precision_to_dtype(precision, field_name or precision_attr)
@@ -59,31 +73,30 @@ def resolve_decode_precision(
 
 
 def resolve_component_precision(server_args, module_name: str) -> Optional[torch.dtype]:
+    exact_precision = resolve_exact_component_precision(server_args, module_name)
+    if exact_precision is not None:
+        return exact_precision
+
     pipeline_config = getattr(server_args, "pipeline_config", None)
     if pipeline_config is None:
         return None
 
-    if module_name in ("audio_vae", "vocoder"):
+    base_name = component_base_name(module_name)
+    if base_name in ("audio_vae", "vocoder"):
         precision_attr = "audio_vae_precision"
-    elif module_name in ("vae", "video_vae", "diffusion_decoder"):
+    elif is_vae_component_name(module_name):
         precision_attr = "vae_precision"
-    elif module_name in (
-        "transformer",
-        "transformer_2",
-        "audio_dit",
-        "video_dit",
-        "connectors",
-        "dual_tower_bridge",
-    ):
+    elif is_legacy_dit_offload_component_name(module_name):
         precision_attr = "dit_precision"
-    elif module_name == "image_encoder":
+    elif is_legacy_image_encoder_offload_component_name(module_name):
         precision_attr = "image_encoder_precision"
-    elif module_name == "text_encoder" or module_name.startswith("text_encoder_"):
-        precisions = getattr(pipeline_config, "text_encoder_precisions", None)
+    elif is_text_encoder_component_name(module_name):
+        precisions = vars(pipeline_config).get("text_encoder_precisions")
         if not precisions:
             return None
         suffix = module_name.removeprefix("text_encoder")
-        index = 0 if suffix == "" else int(suffix.removeprefix("_")) - 1
+        numbered_suffix = suffix.removeprefix("_")
+        index = max(int(numbered_suffix) - 1, 0) if numbered_suffix.isdigit() else 0
         if index < 0 or index >= len(precisions):
             raise ValueError(
                 f"No configured precision for {module_name!r}; "
@@ -94,9 +107,46 @@ def resolve_component_precision(server_args, module_name: str) -> Optional[torch
     else:
         return None
 
-    if not hasattr(pipeline_config, precision_attr):
+    if precision_attr not in vars(pipeline_config):
         return None
-    return resolve_precision(server_args, precision_attr)
+    return resolve_precision(server_args, module_name, precision_attr=precision_attr)
+
+
+def resolve_exact_component_precision(
+    server_args, component_name: str
+) -> Optional[torch.dtype]:
+    precision = vars(server_args).get("component_precisions", {}).get(component_name)
+    if precision is None:
+        return None
+    return precision_to_dtype(precision, f"component_precisions.{component_name}")
+
+
+def validate_shared_component_autocast(server_args, component_names: list[str]) -> None:
+    if len(component_names) < 2 or not any(
+        name in server_args.component_precisions for name in component_names
+    ):
+        return
+    precisions = {
+        resolve_component_precision(server_args, name) for name in component_names
+    }
+    if len(precisions) > 1:
+        raise ValueError(
+            "Components sharing one execution path must use one precision because "
+            "they share a single autocast context"
+        )
+
+
+def explicit_component_autocast_context(
+    server_args, component_name: str, dtype: torch.dtype
+):
+    return autocast_context(
+        dtype,
+        server_args.disable_autocast,
+        enabled=(
+            component_name in server_args.component_precisions
+            and autocast_enabled(dtype, server_args.disable_autocast)
+        ),
+    )
 
 
 def autocast_enabled(dtype: torch.dtype, disable_autocast: bool) -> bool:

--- a/python/sglang/multimodal_gen/runtime/utils/precision.py
+++ b/python/sglang/multimodal_gen/runtime/utils/precision.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from contextlib import contextmanager, nullcontext
 from typing import Iterator, Optional, Union
 
@@ -24,6 +25,11 @@ def precision_to_dtype(precision: str, field_name: str = "precision") -> torch.d
         ) from exc
 
 
+def component_precision_overrides(server_args: object) -> Mapping[str, str]:
+    overrides = vars(server_args).get("component_precisions")
+    return {} if overrides is None else overrides
+
+
 def resolve_precision(
     server_args,
     component_or_precision_attr: str,
@@ -31,8 +37,9 @@ def resolve_precision(
     precision_attr: Optional[str] = None,
     field_name: Optional[str] = None,
 ) -> torch.dtype:
-    component_precisions = vars(server_args).get("component_precisions", {})
-    component_precision = component_precisions.get(component_or_precision_attr)
+    component_precision = component_precision_overrides(server_args).get(
+        component_or_precision_attr
+    )
     if component_precision is not None:
         return precision_to_dtype(
             component_precision,
@@ -77,7 +84,7 @@ def resolve_component_precision(server_args, module_name: str) -> Optional[torch
     if exact_precision is not None:
         return exact_precision
 
-    pipeline_config = getattr(server_args, "pipeline_config", None)
+    pipeline_config = vars(server_args).get("pipeline_config")
     if pipeline_config is None:
         return None
 
@@ -90,13 +97,22 @@ def resolve_component_precision(server_args, module_name: str) -> Optional[torch
         precision_attr = "dit_precision"
     elif is_legacy_image_encoder_offload_component_name(module_name):
         precision_attr = "image_encoder_precision"
+    elif module_name == "text_encoder":
+        index = 0
+    elif module_name.startswith("text_encoder_"):
+        suffix = module_name.removeprefix("text_encoder_")
+        if not suffix.isdigit():
+            return None
+        index = max(int(suffix) - 1, 0)
     elif is_text_encoder_component_name(module_name):
+        return None
+    else:
+        return None
+
+    if is_text_encoder_component_name(module_name):
         precisions = vars(pipeline_config).get("text_encoder_precisions")
         if not precisions:
             return None
-        suffix = module_name.removeprefix("text_encoder")
-        numbered_suffix = suffix.removeprefix("_")
-        index = max(int(numbered_suffix) - 1, 0) if numbered_suffix.isdigit() else 0
         if index < 0 or index >= len(precisions):
             raise ValueError(
                 f"No configured precision for {module_name!r}; "
@@ -104,8 +120,6 @@ def resolve_component_precision(server_args, module_name: str) -> Optional[torch
             )
         precision = precisions[index]
         return precision_to_dtype(precision, f"text_encoder_precisions[{index}]")
-    else:
-        return None
 
     if precision_attr not in vars(pipeline_config):
         return None
@@ -115,15 +129,16 @@ def resolve_component_precision(server_args, module_name: str) -> Optional[torch
 def resolve_exact_component_precision(
     server_args, component_name: str
 ) -> Optional[torch.dtype]:
-    precision = vars(server_args).get("component_precisions", {}).get(component_name)
+    precision = component_precision_overrides(server_args).get(component_name)
     if precision is None:
         return None
     return precision_to_dtype(precision, f"component_precisions.{component_name}")
 
 
 def validate_shared_component_autocast(server_args, component_names: list[str]) -> None:
+    overrides = component_precision_overrides(server_args)
     if len(component_names) < 2 or not any(
-        name in server_args.component_precisions for name in component_names
+        name in overrides for name in component_names
     ):
         return
     precisions = {
@@ -139,11 +154,12 @@ def validate_shared_component_autocast(server_args, component_names: list[str]) 
 def explicit_component_autocast_context(
     server_args, component_name: str, dtype: torch.dtype
 ):
+    overrides = component_precision_overrides(server_args)
     return autocast_context(
         dtype,
         server_args.disable_autocast,
         enabled=(
-            component_name in server_args.component_precisions
+            component_name in overrides
             and autocast_enabled(dtype, server_args.disable_autocast)
         ),
     )

--- a/python/sglang/multimodal_gen/runtime/utils/precision.py
+++ b/python/sglang/multimodal_gen/runtime/utils/precision.py
@@ -105,7 +105,7 @@ def resolve_component_precision(server_args, module_name: str) -> Optional[torch
             return None
         index = max(int(suffix) - 1, 0)
     elif is_text_encoder_component_name(module_name):
-        return None
+        index = 0
     else:
         return None
 

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_causal_denoising.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_causal_denoising.py
@@ -161,7 +161,10 @@ def test_causal_dmd_forward_context_uses_prepare_hooks(monkeypatch):
         seen["frame_shape"] = (h, w)
         return self.num_token_per_frame
 
-    stage._target_dtype = MethodType(lambda self: torch.float16, stage)
+    stage._target_dtype = MethodType(
+        lambda self, server_args: torch.float16,
+        stage,
+    )
     stage._autocast_enabled = MethodType(lambda self, dtype, server_args: False, stage)
     stage._get_causal_dmd_scheduler = MethodType(
         lambda self, batch, server_args: "scheduler", stage

--- a/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_vae.py
+++ b/python/sglang/multimodal_gen/test/unit/realtime/test_realtime_vae.py
@@ -80,8 +80,7 @@ def test_causal_vae_decoding_stage_keeps_wan_decoder_cache(monkeypatch):
     vae = _WanVAE()
     vae.clear_cache()
     vae.clear_calls = 0
-    stage = CausalVaeDecodingStage.__new__(CausalVaeDecodingStage)
-    stage.vae = vae
+    stage = CausalVaeDecodingStage(vae)
     server_args = SimpleNamespace(
         pipeline_config=_PipelineConfig(),
         disable_autocast=True,
@@ -158,8 +157,7 @@ def test_causal_vae_decoding_stage_prefers_native_causal_decode(monkeypatch):
     )
 
     vae = _NativeCausalVAE()
-    stage = CausalVaeDecodingStage.__new__(CausalVaeDecodingStage)
-    stage.vae = vae
+    stage = CausalVaeDecodingStage(vae)
     server_args = SimpleNamespace(
         pipeline_config=_PipelineConfig(),
         disable_autocast=True,

--- a/python/sglang/multimodal_gen/test/unit/test_component_residency.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_residency.py
@@ -186,22 +186,6 @@ def test_single_component_stage_is_prepared_at_stage_entry():
     strategy.wait_for_use.assert_called_once_with(module, use, manager.state)
 
 
-def test_exact_precision_fills_missing_target_but_preserves_stage_override():
-    module = torch.nn.Linear(2, 2)
-    stage = _Stage(ComponentUse("stage", "text_encoder"))
-    manager, server_args = _manager_for_stage(stage, {"text_encoder": module})
-    server_args.component_precisions = {"text_encoder": "bf16"}
-    manager.begin_request([stage], SimpleNamespace(is_warmup=False), server_args)
-
-    assert manager._ordered_uses[0].target_dtype == torch.bfloat16
-
-    decode_stage = _Stage(
-        ComponentUse("decode", "text_encoder", target_dtype=torch.float32)
-    )
-    manager.begin_request([decode_stage], SimpleNamespace(is_warmup=False), server_args)
-    assert manager._ordered_uses[0].target_dtype == torch.float32
-
-
 def test_explicit_component_use_is_prepared_only_at_call_site():
     module = torch.nn.Linear(2, 2)
     use = ComponentUse("stage", "text_encoder", start_at_stage_entry=False)

--- a/python/sglang/multimodal_gen/test/unit/test_component_residency.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_residency.py
@@ -186,6 +186,22 @@ def test_single_component_stage_is_prepared_at_stage_entry():
     strategy.wait_for_use.assert_called_once_with(module, use, manager.state)
 
 
+def test_exact_precision_fills_missing_target_but_preserves_stage_override():
+    module = torch.nn.Linear(2, 2)
+    stage = _Stage(ComponentUse("stage", "text_encoder"))
+    manager, server_args = _manager_for_stage(stage, {"text_encoder": module})
+    server_args.component_precisions = {"text_encoder": "bf16"}
+    manager.begin_request([stage], SimpleNamespace(is_warmup=False), server_args)
+
+    assert manager._ordered_uses[0].target_dtype == torch.bfloat16
+
+    decode_stage = _Stage(
+        ComponentUse("decode", "text_encoder", target_dtype=torch.float32)
+    )
+    manager.begin_request([decode_stage], SimpleNamespace(is_warmup=False), server_args)
+    assert manager._ordered_uses[0].target_dtype == torch.float32
+
+
 def test_explicit_component_use_is_prepared_only_at_call_site():
     module = torch.nn.Linear(2, 2)
     use = ComponentUse("stage", "text_encoder", start_at_stage_entry=False)
@@ -252,15 +268,18 @@ def test_qwen_layered_uses_loaded_text_encoder(monkeypatch):
         qwen_image, "QwenImageLayeredBeforeDenoisingStage", create_stage
     )
     server_args = SimpleNamespace(
+        component_precisions={"text_encoder": "fp32", "vae": "fp16"},
         pipeline_config=SimpleNamespace(
             vae_precision="bf16",
             text_encoder_precisions=("bf16",),
-        )
+        ),
     )
 
     pipeline.create_pipeline_stages(server_args)
 
     assert stage_kwargs["text_encoder"] is text_encoder
+    assert stage_kwargs["text_encoder_dtype"] == torch.float32
+    assert stage_kwargs["vae_dtype"] == torch.float16
 
 
 def test_single_component_stage_is_finished_at_stage_exit():

--- a/python/sglang/multimodal_gen/test/unit/test_precision_consistency.py
+++ b/python/sglang/multimodal_gen/test/unit/test_precision_consistency.py
@@ -14,11 +14,14 @@ def _load_precision_module():
         "sglang",
         "sglang.multimodal_gen",
         "sglang.multimodal_gen.runtime",
+        "sglang.multimodal_gen.runtime.managers",
+        "sglang.multimodal_gen.runtime.managers.memory_managers",
         "sglang.multimodal_gen.runtime.utils",
     )
     stub_names = (
         *package_names,
         "sglang.multimodal_gen.runtime.platforms",
+        "sglang.multimodal_gen.runtime.managers.memory_managers.layerwise_offload_components",
         "sglang.multimodal_gen.utils",
     )
     missing = object()
@@ -42,6 +45,18 @@ def _load_precision_module():
             package.__path__ = []
             sys.modules[package_name] = package
         sys.modules["sglang.multimodal_gen.runtime.platforms"] = platforms_module
+        component_names_path = (
+            Path(__file__).resolve().parents[2]
+            / "runtime/managers/memory_managers/layerwise_offload_components.py"
+        )
+        component_names_spec = importlib.util.spec_from_file_location(
+            "sglang.multimodal_gen.runtime.managers.memory_managers."
+            "layerwise_offload_components",
+            component_names_path,
+        )
+        component_names_module = importlib.util.module_from_spec(component_names_spec)
+        sys.modules[component_names_spec.name] = component_names_module
+        component_names_spec.loader.exec_module(component_names_module)
         sys.modules["sglang.multimodal_gen.utils"] = utils_module
 
         precision_path = (
@@ -71,8 +86,10 @@ get_module_dtype = precision.get_module_dtype
 precision_to_dtype = precision.precision_to_dtype
 resolve_component_precision = precision.resolve_component_precision
 resolve_decode_precision = precision.resolve_decode_precision
+resolve_exact_component_precision = precision.resolve_exact_component_precision
 resolve_precision = precision.resolve_precision
 temporary_module_dtype = precision.temporary_module_dtype
+validate_shared_component_autocast = precision.validate_shared_component_autocast
 
 
 class _DtypedNoParameterModule(torch.nn.Module):
@@ -103,6 +120,7 @@ class _FakePlatform:
 
 class TestDiffusionPrecisionConsistency(unittest.TestCase):
     def _server_args(self, **overrides):
+        component_precisions = overrides.pop("component_precisions", {})
         config = {
             "vae_precision": "fp16",
             "vae_decode_precision": None,
@@ -113,7 +131,10 @@ class TestDiffusionPrecisionConsistency(unittest.TestCase):
             "text_encoder_precisions": ["fp16", "bf16"],
         }
         config.update(overrides)
-        return SimpleNamespace(pipeline_config=SimpleNamespace(**config))
+        return SimpleNamespace(
+            pipeline_config=SimpleNamespace(**config),
+            component_precisions=component_precisions,
+        )
 
     def test_precision_lookup(self):
         server_args = self._server_args()
@@ -163,6 +184,68 @@ class TestDiffusionPrecisionConsistency(unittest.TestCase):
                 self._server_args(vae_decode_precision_high="fp8"), quality="high"
             )
 
+    def test_exact_component_precision_and_decode_precedence(self):
+        server_args = self._server_args(
+            component_precisions={
+                "transformer_2": "bf16",
+                "text_encoder_2": "fp32",
+                "vae": "bf16",
+            },
+            vae_decode_precision="fp16",
+        )
+
+        self.assertEqual(
+            resolve_precision(
+                server_args, "transformer_2", precision_attr="dit_precision"
+            ),
+            torch.bfloat16,
+        )
+        self.assertEqual(
+            resolve_component_precision(server_args, "text_encoder_2"),
+            torch.float32,
+        )
+        self.assertEqual(resolve_decode_precision(server_args), torch.float16)
+        self.assertIsNone(
+            resolve_exact_component_precision(self._server_args(), "hy3dshape_vae")
+        )
+        self.assertEqual(
+            resolve_precision(
+                self._server_args(), "paint_vae", precision_attr="dit_precision"
+            ),
+            torch.float32,
+        )
+        self.assertEqual(
+            resolve_exact_component_precision(
+                self._server_args(component_precisions={"hy3dshape_vae": "bf16"}),
+                "hy3dshape_vae",
+            ),
+            torch.bfloat16,
+        )
+
+        self.assertEqual(
+            resolve_component_precision(self._server_args(), "video_dit_2"),
+            torch.float32,
+        )
+        self.assertIsNone(
+            resolve_component_precision(self._server_args(), "text_encoder_aux")
+        )
+        self.assertEqual(
+            resolve_component_precision(self._server_args(), "text_encoder_0"),
+            torch.float16,
+        )
+
+    def test_paired_dit_rejects_mixed_component_precision(self):
+        server_args = self._server_args(component_precisions={"transformer_2": "bf16"})
+        with self.assertRaisesRegex(ValueError, "single autocast context"):
+            validate_shared_component_autocast(
+                server_args, ["transformer", "transformer_2"]
+            )
+
+        server_args.component_precisions["transformer"] = "bf16"
+        validate_shared_component_autocast(
+            server_args, ["transformer", "transformer_2"]
+        )
+
     def test_component_precision_mapping(self):
         server_args = self._server_args()
         expected = {
@@ -174,6 +257,7 @@ class TestDiffusionPrecisionConsistency(unittest.TestCase):
             "transformer_2": torch.float32,
             "audio_dit": torch.float32,
             "video_dit": torch.float32,
+            "sound_tokenizer": torch.float16,
             "connectors": torch.float32,
             "dual_tower_bridge": torch.float32,
             "image_encoder": torch.float16,

--- a/python/sglang/multimodal_gen/test/unit/test_precision_consistency.py
+++ b/python/sglang/multimodal_gen/test/unit/test_precision_consistency.py
@@ -152,6 +152,19 @@ class TestDiffusionPrecisionConsistency(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "Unsupported custom_precision"):
             precision_to_dtype("fp8", "custom_precision")
 
+    def test_component_precision_overrides_are_optional(self):
+        server_args = self._server_args()
+        del server_args.component_precisions
+
+        self.assertEqual(
+            resolve_precision(server_args, "vae", precision_attr="vae_precision"),
+            torch.float16,
+        )
+        self.assertIsNone(resolve_exact_component_precision(server_args, "vae"))
+        validate_shared_component_autocast(
+            server_args, ["transformer", "transformer_2"]
+        )
+
     def test_decode_precision_override_and_fallback(self):
         self.assertEqual(
             resolve_decode_precision(self._server_args()),

--- a/python/sglang/multimodal_gen/test/unit/test_precision_consistency.py
+++ b/python/sglang/multimodal_gen/test/unit/test_precision_consistency.py
@@ -246,6 +246,19 @@ class TestDiffusionPrecisionConsistency(unittest.TestCase):
             resolve_component_precision(self._server_args(), "text_encoder_0"),
             torch.float16,
         )
+        self.assertEqual(
+            resolve_component_precision(self._server_args(), "delight_text_encoder"),
+            torch.float16,
+        )
+        self.assertEqual(
+            resolve_component_precision(
+                self._server_args(
+                    component_precisions={"delight_text_encoder": "bf16"}
+                ),
+                "delight_text_encoder",
+            ),
+            torch.bfloat16,
+        )
 
     def test_paired_dit_rejects_mixed_component_precision(self):
         server_args = self._server_args(component_precisions={"transformer_2": "bf16"})
@@ -276,6 +289,7 @@ class TestDiffusionPrecisionConsistency(unittest.TestCase):
             "image_encoder": torch.float16,
             "text_encoder": torch.float16,
             "text_encoder_2": torch.bfloat16,
+            "delight_text_encoder": torch.float16,
         }
 
         for module_name, expected_dtype in expected.items():

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -155,6 +155,43 @@ class TestServerArgsPathExpansion(unittest.TestCase):
         )
         self.assertEqual(args.model_path, "/data/my-model")
 
+    def test_component_precisions_are_exact_and_validated(self):
+        values, remaining = ServerArgs._extract_component_precisions(
+            [
+                "--component-precisions.text-encoder-2=fp32",
+                "--component-precisions.transformer",
+                "bf16",
+                "--other",
+            ]
+        )
+        self.assertEqual(values, {"text_encoder_2": "fp32", "transformer": "bf16"})
+        self.assertEqual(remaining, ["--other"])
+
+        args = self._from_dict_without_model_resolution(
+            {
+                "model_path": "/data/my-model",
+                "component_precisions": {"Text-Encoder-2": "FP16"},
+            }
+        )
+        self.assertEqual(args.component_precisions, {"text_encoder_2": "fp16"})
+
+        with self.assertRaisesRegex(ValueError, "one of fp16, bf16, or fp32"):
+            self._from_dict_without_model_resolution(
+                {
+                    "model_path": "/data/my-model",
+                    "component_precisions": {"text_encoder": "fp8"},
+                }
+            )
+
+        with self.assertRaisesRegex(ValueError, "Diffusers backend"):
+            self._from_dict_without_model_resolution(
+                {
+                    "model_path": "/data/my-model",
+                    "backend": "diffusers",
+                    "component_precisions": {"vae": "bf16"},
+                }
+            )
+
     def test_component_paths_are_expanded_before_pipeline_resolution(self):
         args = self._from_dict_without_model_resolution(
             {

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -725,6 +725,25 @@ class TestTransformerQuantHelpers(unittest.TestCase):
         self.assertTrue(spec.is_comfy_fp8)
         self.assertTrue(spec.needs_device_weight_postprocess)
 
+    def test_component_precision_validates_quantized_activation_dtype(self):
+        server_args = self._make_server_args(
+            component_precisions={"transformer_2": "fp32"}
+        )
+
+        with self.assertRaisesRegex(
+            ValueError, "does not support activation dtype torch.float32"
+        ):
+            resolve_transformer_quant_load_spec(
+                hf_config={},
+                server_args=server_args,
+                safetensors_list=["model.safetensors"],
+                component_model_path="/unused/component/path",
+                model_cls=_FakeFluxTransformer,
+                cls_name=_FakeFluxTransformer.__name__,
+                component_name="transformer_2",
+                checkpoint_quant_config=ComfyFp8Config({}),
+            )
+
     def test_checkpoint_quantization_rejects_explicit_quantization(self):
         server_args = self._make_server_args(quantization="fp8")
 


### PR DESCRIPTION
## Status

This branch predates the exact component-identity contract and is being reworked. It must not be used as evidence that arbitrary pipeline components support an exact precision override.

The replacement will only admit an override when the exact component has both a typed loader path and a real compute scope; unsupported stages will fail at startup rather than inherit an unrelated autocast context.