### PR TITLE
docs(cookbook): add --enable-dp-lm-head to the Kimi-K3 GB200 decode cell

### DIFF
--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -61,6 +61,18 @@ export const config = {
   specCollapses(s) {
     return config.isPipelined(s) && !!(config.cellFor(s) || {}).specCollapsePp;
   },
+  // DSPARK refuses DP attention at dp_size > 1 unless the LM head is sharded
+  // with it (speculative_hook.py `_handle_dspark` — dp_size == 1 is degenerate
+  // and exempt there, hence the same > 1 test). The flag re-shapes the LM head
+  // whether or not speculation is on, so it rides on the DSPARK overlay rather
+  // than on a cell, where it would reach the Non-Spec selections too. A cell
+  // that declares it keeps its own — overlay flags append without dedup.
+  needsDpLmHead(s) {
+    const cell = config.cellFor(s);
+    return !!config.flagOf(cell, "--enable-dp-attention")
+      && config.sizeOf(cell, "--dp-size") > 1
+      && !config.flagOf(cell, "--enable-dp-lm-head");
+  },
   // The playground's chip `disable` is declarative only (no predicates), so the
   // DCP-carrying recipes are enumerated — but generated from the cells here
   // rather than typed out per platform, so it is the same single source of truth
@@ -295,6 +307,7 @@ export const config = {
               : [],
           flags: (s) => [
             ...(config.specCollapses(s) ? config.specCollapsedFlags(s) : []),
+            ...(config.needsDpLmHead(s) ? ["--enable-dp-lm-head"] : []),
             "--speculative-algorithm DSPARK",
             "--speculative-draft-model-path RadixArk/Kimi-K3-DSpark",
             "--speculative-dspark-block-size 7",
@@ -2297,7 +2310,6 @@ export const config = {
         "--dcp-size 8",
         "--dp-size 2",
         "--enable-dp-attention",
-        "--enable-dp-lm-head",
         "--ep-size 16",
         "--mem-fraction-static 0.85",
         "--disaggregation-decode-extra-slots 16",

--- a/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
+++ b/docs/src/snippets/configs/moonshotai/kimi-k3.jsx
@@ -2297,6 +2297,7 @@ export const config = {
         "--dcp-size 8",
         "--dp-size 2",
         "--enable-dp-attention",
+        "--enable-dp-lm-head",
         "--ep-size 16",
         "--mem-fraction-static 0.85",
         "--disaggregation-decode-extra-slots 16",


### PR DESCRIPTION
The GB200 / Decode / High-Throughput cell in this panel runs DP attention
(`--dp-size 2 --enable-dp-attention`) and the Spec Decode card defaults to DSPARK, but
nothing in that combination supplies `--enable-dp-lm-head`. `_handle_dspark` refuses it
while resolving arguments, so the command the panel renders for this cell on its default
selection stops before anything is loaded:

```
ValueError: DSpark with dp attention requires --enable-dp-lm-head.
  python/sglang/srt/arg_groups/speculative_hook.py:358
```

The flag is supplied by the `spec: dspark` overlay rather than by the cell, under the
same condition `_handle_dspark` tests — the cell runs DP attention with `--dp-size > 1`
— read off the cell the way that overlay already reads `--pp-size` and `--dcp-size`. It
belongs on the overlay because it is not speculation-scoped at runtime: `lm_head` is
built as `ParallelLMHead(..., use_attn_tp_group=get_parallel().enable_dp_lm_head)` in
`models/kimi_k3.py`, and `LogitsProcessor` selects its all-gather path off the same
value, so a cell carrying the flag would re-shape the LM head for the Non-Spec
selections as well, which do not ask for it. A cell that declares the flag itself — the
A3 cell in this file — keeps its own copy; overlay flags are appended without
deduplication.

## Effect on this cell's selections

Argument resolution over all 12 selections the cell can render, before and after:

| Spec Decode | HiCache | before | after |
|---|---|---|---|
| DSPARK (default) | off (default) | `speculative_hook.py:358` | resolves |
| DSPARK | L2 / L3 | `speculative_hook.py:358` | `server_args.py:9152` |
| Non-Spec | off | resolves | unchanged |
| Non-Spec | L2 | `pd_disaggregation_hook.py:69` | unchanged |
| Non-Spec | L3 | `server_args.py:9152` | unchanged |

The dp-lm-head check clears on all six DSPARK selections, and the default selection
resolves. The four HiCache rows then land on HiCache restrictions that predate this
change and are independent of the flag — the same `server_args.py:9152` check that
already blocks the Non-Spec L3 rows — so this change neither causes nor hides them. The
six Non-Spec commands are byte-identical to main — the rendered strings match, not just
their resolution verdicts. Enumerating every launch coordinate the cookbook deployment
panels can render, before and after, gives 1624 commands of which 6 differ, all of them
DSPARK selections of this cell.

## What this is not verified against

Argument resolution and the rendered command text only, on CPU with a substituted
checkpoint. I have no K3 weights and no GB200 node, so I have not started a server on
this recipe and cannot confirm at runtime that `--enable-dp-lm-head` matches the LM-head
layout the GB200 numbers in this cell were taken under. The cell is still
`verificationStatus: "in-progress"` — if the verification round intends a different shape
here, such as dropping DP attention or gating the DSPARK chip under DP attention the way
`Qwen/qwen3.8.jsx:209-218` does, that supersedes this patch and I'm happy to close it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33169338662](https://github.com/sgl-project/sglang/actions/runs/33169338662)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33169338388](https://github.com/sgl-project/sglang/actions/runs/33169338388)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
