### PR TITLE
[Fix][Humming] Initialize MXFP4 scales directly as E8M0

### DIFF
--- a/python/sglang/srt/layers/quantization/mxfp4_humming_moe.py
+++ b/python/sglang/srt/layers/quantization/mxfp4_humming_moe.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING
 import torch
 from torch.nn import Module, Parameter
 
-from sglang.srt.layers.moe.utils import MoeRunnerBackend
+from sglang.srt.layers.moe.utils import MoeRunnerBackend, get_moe_a2a_backend
 from sglang.srt.utils import log_info_on_rank0
 
 if TYPE_CHECKING:
@@ -21,9 +21,11 @@ class Mxfp4HummingMoEMethod:
     Used for DeepSeek-V4 FP8 checkpoints when `--moe-runner-backend humming` is
     selected together with `SGLANG_DSV4_FP4_EXPERTS=1` (which sets
     ``Fp8Config.is_fp4_experts``). The FP8 base method handles raw weight
-    creation; after load we cast ``w{13,2}_weight_scale_inv`` to
+    creation; after load we register ``w{13,2}_weight_scale`` in
     ``float8_e8m0fnu`` and call ``prepare_humming_moe_layer`` to lay out the
-    experts in the format the Humming kernel expects.
+    experts in the format the Humming kernel expects. Since MXFP4 scales use
+    E8M0, create them directly in that dtype for Humming. MegaMoE keeps FP32
+    scales because its current DeepGEMM layout transform expects FP32.
     """
 
     def __init__(self, fp8_method, prefix: str):
@@ -44,12 +46,18 @@ class Mxfp4HummingMoEMethod:
         params_dtype: torch.dtype,
         **extra_weight_attrs,
     ):
+        fp4_scale_dtype = (
+            torch.float32
+            if get_moe_a2a_backend().is_megamoe()
+            else torch.float8_e8m0fnu
+        )
         self._fp8.create_weights(
             layer,
             num_experts,
             hidden_size,
             intermediate_size_per_partition,
             params_dtype,
+            fp4_scale_dtype=fp4_scale_dtype,
             **extra_weight_attrs,
         )
 

--- a/test/registered/unit/layers/quantization/test_mxfp4_humming_moe.py
+++ b/test/registered/unit/layers/quantization/test_mxfp4_humming_moe.py
@@ -1,0 +1,62 @@
+import unittest
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers.quantization.mxfp4_humming_moe import (
+    Mxfp4HummingMoEMethod,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _FakeFp8Method:
+    def __init__(self):
+        self.args = None
+        self.kwargs = None
+
+    def create_weights(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+
+
+class TestMxfp4HummingMoEMethod(CustomTestCase):
+    def _create_weights_and_get_scale_dtype(self, use_megamoe: bool):
+        fp8_method = _FakeFp8Method()
+        method = Mxfp4HummingMoEMethod(fp8_method, prefix="model.layers.0.mlp")
+        layer = torch.nn.Module()
+
+        with patch(
+            "sglang.srt.layers.quantization.mxfp4_humming_moe.get_moe_a2a_backend"
+        ) as get_backend:
+            get_backend.return_value.is_megamoe.return_value = use_megamoe
+            method.create_weights(
+                layer,
+                num_experts=8,
+                hidden_size=128,
+                intermediate_size_per_partition=64,
+                params_dtype=torch.bfloat16,
+                weight_loader="sentinel",
+            )
+
+        self.assertEqual(fp8_method.args[0], layer)
+        self.assertEqual(fp8_method.kwargs["weight_loader"], "sentinel")
+        return fp8_method.kwargs["fp4_scale_dtype"]
+
+    def test_create_weights_uses_e8m0_scales_for_humming(self):
+        self.assertEqual(
+            self._create_weights_and_get_scale_dtype(use_megamoe=False),
+            torch.float8_e8m0fnu,
+        )
+
+    def test_create_weights_keeps_fp32_scales_for_megamoe(self):
+        self.assertEqual(
+            self._create_weights_and_get_scale_dtype(use_megamoe=True),
+            torch.float32,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

While deploying DeepSeek-V4-Pro-DSpark on a single 8-GPU H20-3e node, the
prefill worker ran out of GPU memory during model loading after CP8 was enabled.

The issue was reproduced with the following configuration:

```text
Model: DeepSeek-V4-Pro-DSpark
Hardware: 1 node, 8 x H20-3e GPUs
Parallelism: PP1 / TP8 / CP8
Prefill CP strategy: interleave
Attention backend: dsv4
DSA prefill backend: flashmla_sparse
MoE runner backend: humming
MoE A2A backend: none
Chunked prefill size: 32768
Memory fraction static: 0.962
SWA full tokens ratio: 0.07
```

The relevant server arguments were:

```text
--tp-size 8
--enable-prefill-cp
--cp-strategy interleave
--moe-runner-backend humming
--moe-a2a-backend none
--chunked-prefill-size 32768
--mem-fraction-static 0.962
--swa-full-tokens-ratio 0.07
```

The OOM was traced to the initialization of MXFP4 MoE scales in the Humming
path:

- MXFP4 expert scales are ultimately consumed as E8M0 by Humming.
- Before this change, `Mxfp4HummingMoEMethod.create_weights()` relied on the
  FP8 base method's default behavior, which creates the scale parameters as
  FP32 on NVIDIA GPUs.
- The FP32 scale parameters for all MoE layers remain allocated until
  `process_weights_after_loading()` converts them to
  `torch.float8_e8m0fnu` and releases the original parameters.

For DeepSeek-V4-Pro, this temporary whole-model FP32 scale representation adds
approximately 16.89 GiB of memory usage per GPU.

- In the same environment without CP, there is enough headroom to reach Humming
  post-processing and release these parameters.
- With CP8, the higher attention-weight footprint exposes this overhead and
  causes an OOM before Humming post-processing and KV-pool initialization.

In the reproduced failure, PyTorch had already allocated 137.42 GiB, with only
about 0.78 GiB remaining, when mHC prewarm requested another 1.75 GiB.

This PR creates the MXFP4 scale parameters directly as E8M0 for the
non-MegaMoE Humming path. This removes the unnecessary FP32 intermediate
without changing the final scale dtype, Humming weight layout, or inference
path.

<details>
<summary>Full reproduction command</summary>

Adjust `IB_DEVICE`, `NCCL_IB_HCA`, and `NCCL_SOCKET_IFNAME` for the local
network configuration.

```bash
MODEL_PATH=/path/to/DeepSeek-V4-Pro-DSpark
MASTER_ADDR=127.0.0.1
IB_DEVICE=mlx5_bond_0,mlx5_bond_1,mlx5_bond_2,mlx5_bond_3

env -u SGLANG_GRPC_PORT \
  SGLANG_DSV4_FP4_EXPERTS=1 \
  SGLANG_JIT_DEEPGEMM_PRECOMPILE=0 \
  SGLANG_ENABLE_JIT_DEEPGEMM=1 \
  SGLANG_APPLY_CONFIG_BACKUP=large \
  SGLANG_ALLOW_OVERWRITE_LONGER_CONTEXT_LEN=1 \
  PYTHONUNBUFFERED=1 \
  NCCL_IB_HCA=mlx5_bond \
  NCCL_IB_GID_INDEX=3 \
  NCCL_IB_SL=5 \
  NCCL_IB_TIMEOUT=22 \
  NCCL_SOCKET_IFNAME=bond0 \
  sglang serve \
  --model-path "${MODEL_PATH}" \
  --trust-remote-code \
  --context-length 1048640 \
  --host 0.0.0.0 \
  --port 60001 \
  --nnodes 1 \
  --node-rank 0 \
  --dist-init-addr "${MASTER_ADDR}:62201" \
  --pp-size 1 \
  --tp-size 8 \
  --enable-prefill-cp \
  --cp-strategy interleave \
  --attention-backend dsv4 \
  --dsa-prefill-backend flashmla_sparse \
  --moe-runner-backend humming \
  --moe-a2a-backend none \
  --disaggregation-mode prefill \
  --disaggregation-transfer-backend mooncake \
  --disaggregation-ib-device "${IB_DEVICE}" \
  --disaggregation-bootstrap-port 9000 \
  --chunked-prefill-size 32768 \
  --mem-fraction-static 0.962 \
  --swa-full-tokens-ratio 0.07 \
  --max-running-requests 16 \
  --page-size 64 \
  --disable-radix-cache \
  --watchdog-timeout 3600 \
  --tool-call-parser deepseekv4 \
  --reasoning-parser deepseek-v4 \
  --enable-metrics \
  --enable-cache-report
```

</details>

## Modifications

- Pass `fp4_scale_dtype=torch.float8_e8m0fnu` to the FP8 base weight creator
  for the non-MegaMoE Humming MXFP4 path, so the scale parameters are allocated
  directly in their final dtype.
- Preserve FP32 scale parameters when `moe_a2a_backend=megamoe`, because the
  current DeepGEMM MegaMoE layout transform expects FP32 scale inputs.
- Update the Humming MXFP4 method documentation to reflect the new loading
  behavior and the MegaMoE compatibility path.
- Add registered CPU unit tests that verify:

  - the non-MegaMoE Humming path requests E8M0 scale parameters;
  - the MegaMoE path keeps FP32 scale parameters;
  - existing weight attributes continue to be forwarded to the FP8 base
    weight creator.

## Accuracy Tests

Not applicable. This PR does not modify the model forward path, inference
kernels, final scale dtype, or Humming weight layout. It only removes an
intermediate FP32 representation during model loading.

## Speed Tests and Profiling

No inference speed change is expected because this PR only changes parameter
allocation during model loading. The following per-GPU results were collected
with the same CP8 configuration:

| Metric | Before the fix | After the fix |
|---|---:|---:|
| PyTorch allocated after model construction | 137.423 GiB | 120.623 GiB |
| Sampled GPU memory remaining | 784 MiB | 17,986 MiB |
| Result | OOM during mHC prewarm when allocating another 1.75 GiB | Model loading and server startup completed |

The fix removes approximately 16.8 GiB of temporary scale-parameter memory per
GPU. It changes model initialization only and does not modify the inference
path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33163812937](https://github.com/sgl-project/sglang/actions/runs/33163812937)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33163812730](https://github.com/sgl-project/sglang/actions/runs/33163812730)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33163812858](https://github.com/sgl-project/sglang/actions/runs/33163812858)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->