### PR TITLE
fix(security): pin multimodal-gen ZMQ scheduler ingress to loopback on wildcard --host

### DIFF
--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -2809,10 +2809,16 @@ class ServerArgs(DisaggServerArgsMixin):
             "::",
         ):
             scheduler_host = "127.0.0.1"
+            host_is_ipv6 = False
+        else:
+            host_is_ipv6 = is_valid_ipv6_address(scheduler_host)
         if self.scheduler_ports is not None:
             port = self.scheduler_ports[replica]
         else:
             port = self.scheduler_port + replica
+        # IPv6 literals must be bracketed in an endpoint string.
+        if host_is_ipv6:
+            return f"tcp://[{scheduler_host}]:{port}"
         return f"tcp://{scheduler_host}:{port}"
 
     @property

--- a/python/sglang/multimodal_gen/runtime/server_args/server_args.py
+++ b/python/sglang/multimodal_gen/runtime/server_args/server_args.py
@@ -2792,9 +2792,22 @@ class ServerArgs(DisaggServerArgsMixin):
         return self.scheduler_endpoint_for(0)
 
     def scheduler_endpoint_for(self, replica: int) -> str:
-        """Ingress endpoint of one DP replica's driver rank."""
+        """Ingress endpoint of one DP replica's driver rank.
+
+        The scheduler ingress is an unauthenticated pickle-RPC endpoint
+        (``managers/scheduler.py`` ``recv_reqs`` deserializes client bytes
+        with ``pickle.loads``), so it must never be derived from the public
+        ``--host``: binding it to ``0.0.0.0`` would expose unsafe
+        deserialization to the network (CVE-2026-3059 family). Wildcard hosts
+        are pinned to loopback; only an explicit non-wildcard host (used for
+        intentional cross-machine deployments) is honored.
+        """
         scheduler_host = self.host
-        if scheduler_host is None or scheduler_host == "localhost":
+        if scheduler_host is None or scheduler_host in (
+            "localhost",
+            "0.0.0.0",
+            "::",
+        ):
             scheduler_host = "127.0.0.1"
         if self.scheduler_ports is not None:
             port = self.scheduler_ports[replica]

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -3202,6 +3202,16 @@ class TestSchedulerEndpointBinding(unittest.TestCase):
         )
         self.assertEqual(args.scheduler_endpoint_for(0), "tcp://10.1.2.3:5555")
 
+    def test_explicit_ipv6_host_is_bracketed(self):
+        args = self._from_dict_without_model_resolution(
+            {
+                "model_path": "/fake/model",
+                "host": "::1",
+                "scheduler_port": 5555,
+            }
+        )
+        self.assertEqual(args.scheduler_endpoint_for(0), "tcp://[::1]:5555")
+
     def test_replica_ports_increment_on_loopback(self):
         args = self._from_dict_without_model_resolution(
             {"model_path": "/fake/model", "host": "0.0.0.0", "scheduler_port": 5555}

--- a/python/sglang/multimodal_gen/test/unit/test_server_args.py
+++ b/python/sglang/multimodal_gen/test/unit/test_server_args.py
@@ -3167,5 +3167,47 @@ class TestDirectGpuWeightLoading(unittest.TestCase):
                 tp_args._validate_direct_gpu_weight_loading()
 
 
+class TestSchedulerEndpointBinding(unittest.TestCase):
+    """The scheduler ingress is an unauthenticated pickle-RPC endpoint; it must
+    never follow a wildcard --host (see ServerArgs.scheduler_endpoint_for)."""
+
+    def _from_dict_without_model_resolution(self, kwargs):
+        return _from_dict_without_model_resolution(kwargs)
+
+    def test_wildcard_host_pinned_to_loopback(self):
+        args = self._from_dict_without_model_resolution(
+            {"model_path": "/fake/model", "host": "0.0.0.0", "scheduler_port": 5555}
+        )
+        self.assertEqual(args.scheduler_endpoint_for(0), "tcp://127.0.0.1:5555")
+
+    def test_ipv6_wildcard_host_pinned_to_loopback(self):
+        args = self._from_dict_without_model_resolution(
+            {"model_path": "/fake/model", "host": "::", "scheduler_port": 5555}
+        )
+        self.assertEqual(args.scheduler_endpoint_for(0), "tcp://127.0.0.1:5555")
+
+    def test_default_host_stays_loopback(self):
+        args = self._from_dict_without_model_resolution(
+            {"model_path": "/fake/model", "scheduler_port": 5555}
+        )
+        self.assertEqual(args.scheduler_endpoint_for(0), "tcp://127.0.0.1:5555")
+
+    def test_explicit_host_is_honored(self):
+        args = self._from_dict_without_model_resolution(
+            {
+                "model_path": "/fake/model",
+                "host": "10.1.2.3",
+                "scheduler_port": 5555,
+            }
+        )
+        self.assertEqual(args.scheduler_endpoint_for(0), "tcp://10.1.2.3:5555")
+
+    def test_replica_ports_increment_on_loopback(self):
+        args = self._from_dict_without_model_resolution(
+            {"model_path": "/fake/model", "host": "0.0.0.0", "scheduler_port": 5555}
+        )
+        self.assertEqual(args.scheduler_endpoint_for(1), "tcp://127.0.0.1:5556")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Motivation

Align the multimodal-generation scheduler ingress with the localhost-binding
principle established by PR #21435 ("[Security] 1/N: Bind ZMQ sockets to
localhost to prevent unauthenticated remote access").

PR #21435 bound the ZMQ **broker** to `127.0.0.1`, but the **scheduler** ingress
was left out: `ServerArgs.scheduler_endpoint_for()` derives its bind address
from the public `--host` verbatim, so the standard `--host 0.0.0.0` deployment
binds it to `tcp://0.0.0.0:<port>` (observed `0.0.0.0:5641`). That endpoint
deserializes client bytes with `pickle.loads` over an unauthenticated ZMQ
ROUTER socket (`managers/scheduler.py` `recv_reqs`), i.e. the same unsafe-
deserialization exposure class as CVE-2026-3059 remains remotely reachable
whenever the HTTP API is served on all interfaces.

## Modifications

- `python/sglang/multimodal_gen/runtime/server_args/server_args.py`
  - `scheduler_endpoint_for()` now pins wildcard hosts (`0.0.0.0`, `::`) to
    `127.0.0.1`, consistent with the existing `localhost` normalization. An
    explicit non-wildcard host (intentional cross-machine deployments) is still
    honored.
- `python/sglang/multimodal_gen/test/unit/test_server_args.py`
  - New `TestSchedulerEndpointBinding` (5 tests): wildcard IPv4/IPv6 pinned to
    loopback, default stays loopback, explicit host honored, replica port
    increment on loopback.

## Accuracy Tests

N/A — bind-address logic only; no model/kernel code touched.

## Speed Tests and Profiling

N/A.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33167944163](https://github.com/sgl-project/sglang/actions/runs/33167944163)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33167944057](https://github.com/sgl-project/sglang/actions/runs/33167944057)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33167944215](https://github.com/sgl-project/sglang/actions/runs/33167944215)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->