### PR TITLE
fix(security): bound top_logprobs_num, parallel sample n, and input_ids to prevent request-level DoS

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -79,6 +79,10 @@ else:
 
 logger = logging.getLogger(__name__)
 
+# Maximum number of parallel samples (``n``) accepted per request. See
+# GenerateReqInput._handle_parallel_sampling for why this bound exists.
+MAX_PARALLEL_SAMPLE_NUM = 1024
+
 
 class BaseReq(msgspec.Struct, tag=True, kw_only=True, array_like=True):
     """Base for single-request IPC payloads."""
@@ -495,6 +499,26 @@ class GenerateReqInput:
                     )
 
         self.parallel_sample_num = self._handle_beam_search_parallel_sampling()
+
+        # Bound the per-request fan-out. Without a cap, a single tiny request
+        # with a huge ``n`` materializes one per-sample sub-object plus one
+        # request state (ReqState / asyncio.Event) per rid in the tokenizer
+        # manager, letting one HTTP request stall the event loop for minutes
+        # and exhaust host memory (DoS). 1024 parallel samples far exceeds any
+        # legitimate serving configuration; requests above it are rejected
+        # before any expansion happens.
+        if not isinstance(self.parallel_sample_num, int) or isinstance(
+            self.parallel_sample_num, bool
+        ):
+            raise ValueError(
+                "n (parallel sample num) must be an integer, got "
+                f"{self.parallel_sample_num!r}."
+            )
+        if not 1 <= self.parallel_sample_num <= MAX_PARALLEL_SAMPLE_NUM:
+            raise ValueError(
+                f"n (parallel sample num) must be in [1, {MAX_PARALLEL_SAMPLE_NUM}], "
+                f"got {self.parallel_sample_num}."
+            )
 
         # If using parallel sampling with a single example, convert to batch
         if self.parallel_sample_num > 1 and self.is_single:

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1226,6 +1226,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         # Validate generation-specific fields
         if isinstance(obj, GenerateReqInput):
             self._validate_token_ids_logprob(obj)
+            self._validate_top_logprobs_num(obj)
+            self._validate_input_ids_in_vocab(
+                input_ids, vocab_size=self.model_config.vocab_size
+            )
             requested_hidden_mode = get_request_return_hidden_states_mode(
                 obj.return_hidden_states
             )
@@ -1316,22 +1320,59 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
                     f"{token_id}; valid range is [0, {vocab_size})."
                 )
 
+    def _validate_top_logprobs_num(self, obj: GenerateReqInput) -> None:
+        """Reject out-of-range top_logprobs_num before it reaches torch.topk.
+
+        An unbounded value makes the sampler call ``torch.topk(k=n, ...)``
+        with ``n > vocab_size``, which raises inside the scheduler and kills
+        the whole server (DoS). Every value (int or per-request list) must lie
+        within the vocabulary."""
+        top_logprobs_num = obj.top_logprobs_num
+        if top_logprobs_num is None:
+            return
+        if isinstance(top_logprobs_num, int):
+            values = [top_logprobs_num]
+        elif isinstance(top_logprobs_num, (list, tuple)):
+            values = list(top_logprobs_num)
+        else:
+            raise ValueError(
+                "top_logprobs_num must be an integer or a list of integers."
+            )
+
+        vocab_size = self.model_config.vocab_size
+        for v in values:
+            if not isinstance(v, int):
+                raise ValueError(
+                    "top_logprobs_num must be an integer or a list of integers."
+                )
+            if v < 0 or v > vocab_size:
+                raise ValueError(
+                    f"top_logprobs_num must be in [0, {vocab_size}], got {v}."
+                )
+
     def _validate_input_ids_in_vocab(
-        self, input_ids: Union[List[int], List[List[int]]], vocab_size: int
+        self, input_ids: Optional[Union[List[int], List[List[int]]]], vocab_size: int
     ) -> None:
-        # Handle both single sequence and batch of sequences
+        """Reject out-of-vocabulary input ids before they reach the embedding
+        gather. Negative ids would otherwise trigger a CUDA device-side assert
+        (or a host-side IndexError) inside the model forward, killing the
+        entire server (DoS)."""
+        if not input_ids:
+            return
         if isinstance(input_ids[0], list):
             # Batch of sequences
             for seq in input_ids:
-                if any(id >= vocab_size for id in seq):
+                if any(not (0 <= id < vocab_size) for id in seq):
                     raise ValueError(
-                        f"The input_ids {seq} contains values greater than the vocab size ({vocab_size})."
+                        f"The input_ids {seq} contains values outside the vocab "
+                        f"range [0, {vocab_size})."
                     )
         else:
             # Single sequence
-            if any(id >= vocab_size for id in input_ids):
+            if any(not (0 <= id < vocab_size) for id in input_ids):
                 raise ValueError(
-                    f"The input_ids {input_ids} contains values greater than the vocab size ({vocab_size})."
+                    f"The input_ids {input_ids} contains values outside the vocab "
+                    f"range [0, {vocab_size})."
                 )
 
     def _create_tokenized_object(

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -1341,7 +1341,8 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         vocab_size = self.model_config.vocab_size
         for v in values:
-            if not isinstance(v, int):
+            # bool is an int subclass; JSON true/false must not pass as 1/0.
+            if not isinstance(v, int) or isinstance(v, bool):
                 raise ValueError(
                     "top_logprobs_num must be an integer or a list of integers."
                 )
@@ -1362,14 +1363,19 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         if isinstance(input_ids[0], list):
             # Batch of sequences
             for seq in input_ids:
-                if any(not (0 <= id < vocab_size) for id in seq):
+                # bool is an int subclass; JSON true/false must not pass as 1/0.
+                if any(
+                    isinstance(id, bool) or not (0 <= id < vocab_size) for id in seq
+                ):
                     raise ValueError(
                         f"The input_ids {seq} contains values outside the vocab "
                         f"range [0, {vocab_size})."
                     )
         else:
             # Single sequence
-            if any(not (0 <= id < vocab_size) for id in input_ids):
+            if any(
+                isinstance(id, bool) or not (0 <= id < vocab_size) for id in input_ids
+            ):
                 raise ValueError(
                     f"The input_ids {input_ids} contains values outside the vocab "
                     f"range [0, {vocab_size})."

--- a/test/registered/unit/managers/test_request_param_validation.py
+++ b/test/registered/unit/managers/test_request_param_validation.py
@@ -82,6 +82,15 @@ class TestTopLogprobsNumValidation(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, r"top_logprobs_num must be in \[0, 100\]"):
             self.tm._validate_top_logprobs_num(req)
 
+    def test_boolean_top_logprobs_num_rejected(self):
+        # bool is an int subclass; JSON true/false must not pass as 1/0.
+        for bad in (True, False, [1, True]):
+            req = GenerateReqInput(
+                text="hi", return_logprob=True, top_logprobs_num=bad
+            )
+            with self.assertRaisesRegex(ValueError, "must be an integer"):
+                self.tm._validate_top_logprobs_num(req)
+
     def test_valid_top_logprobs_num_accepted(self):
         req = GenerateReqInput(text="hi", return_logprob=True, top_logprobs_num=10)
         # Should not raise.
@@ -103,6 +112,13 @@ class TestInputIdsInVocabValidation(unittest.TestCase):
     def test_nested_batch_input_ids_rejected(self):
         with self.assertRaisesRegex(ValueError, r"outside the vocab range"):
             self.tm._validate_input_ids_in_vocab([[1, 2], [3, -5]], vocab_size=100)
+
+    def test_boolean_input_ids_rejected(self):
+        # bool is an int subclass; JSON true/false must not pass as 1/0.
+        with self.assertRaisesRegex(ValueError, r"outside the vocab range"):
+            self.tm._validate_input_ids_in_vocab([1, True], vocab_size=100)
+        with self.assertRaisesRegex(ValueError, r"outside the vocab range"):
+            self.tm._validate_input_ids_in_vocab([[False, 2]], vocab_size=100)
 
     def test_valid_input_ids_accepted(self):
         # Should not raise.

--- a/test/registered/unit/managers/test_request_param_validation.py
+++ b/test/registered/unit/managers/test_request_param_validation.py
@@ -52,9 +52,7 @@ class TestParallelSampleNumBound(unittest.TestCase):
             req.normalize_batch_and_arguments()
 
     def test_legitimate_n_still_works(self):
-        req = GenerateReqInput(
-            text="hi", sampling_params={"n": 4, "max_new_tokens": 1}
-        )
+        req = GenerateReqInput(text="hi", sampling_params={"n": 4, "max_new_tokens": 1})
         req.normalize_batch_and_arguments()
         self.assertEqual(req.parallel_sample_num, 4)
 
@@ -64,30 +62,32 @@ class TestTopLogprobsNumValidation(unittest.TestCase):
         self.tm = _make_tokenizer_manager(vocab_size=100)
 
     def test_over_vocab_top_logprobs_num_rejected(self):
-        req = GenerateReqInput(
-            text="hi", return_logprob=True, top_logprobs_num=10**9
-        )
-        with self.assertRaisesRegex(ValueError, r"top_logprobs_num must be in \[0, 100\]"):
+        req = GenerateReqInput(text="hi", return_logprob=True, top_logprobs_num=10**9)
+        with self.assertRaisesRegex(
+            ValueError, r"top_logprobs_num must be in \[0, 100\]"
+        ):
             self.tm._validate_top_logprobs_num(req)
 
     def test_negative_top_logprobs_num_rejected(self):
         req = GenerateReqInput(text="hi", return_logprob=True, top_logprobs_num=-1)
-        with self.assertRaisesRegex(ValueError, r"top_logprobs_num must be in \[0, 100\]"):
+        with self.assertRaisesRegex(
+            ValueError, r"top_logprobs_num must be in \[0, 100\]"
+        ):
             self.tm._validate_top_logprobs_num(req)
 
     def test_top_logprobs_num_list_validated_elementwise(self):
         req = GenerateReqInput(
             text="hi", return_logprob=True, top_logprobs_num=[1, 2, 10**9]
         )
-        with self.assertRaisesRegex(ValueError, r"top_logprobs_num must be in \[0, 100\]"):
+        with self.assertRaisesRegex(
+            ValueError, r"top_logprobs_num must be in \[0, 100\]"
+        ):
             self.tm._validate_top_logprobs_num(req)
 
     def test_boolean_top_logprobs_num_rejected(self):
         # bool is an int subclass; JSON true/false must not pass as 1/0.
         for bad in (True, False, [1, True]):
-            req = GenerateReqInput(
-                text="hi", return_logprob=True, top_logprobs_num=bad
-            )
+            req = GenerateReqInput(text="hi", return_logprob=True, top_logprobs_num=bad)
             with self.assertRaisesRegex(ValueError, "must be an integer"):
                 self.tm._validate_top_logprobs_num(req)
 

--- a/test/registered/unit/managers/test_request_param_validation.py
+++ b/test/registered/unit/managers/test_request_param_validation.py
@@ -1,0 +1,119 @@
+"""Tests for request parameter validation guards.
+
+Covers the bounds introduced for request-level DoS hardening:
+- ``n`` (parallel sample num) is capped before expansion.
+- ``top_logprobs_num`` is bounded by the vocabulary size.
+- ``input_ids`` must lie in [0, vocab_size).
+"""
+
+import unittest
+from types import SimpleNamespace
+
+from sglang.srt.managers.io_struct import (
+    MAX_PARALLEL_SAMPLE_NUM,
+    GenerateReqInput,
+)
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_tokenizer_manager(vocab_size: int = 100) -> TokenizerManager:
+    """A bare TokenizerManager instance with a stubbed model config.
+
+    Only the fields used by the validation helpers under test are populated.
+    """
+    tm = object.__new__(TokenizerManager)
+    tm.model_config = SimpleNamespace(vocab_size=vocab_size)
+    return tm
+
+
+class TestParallelSampleNumBound(unittest.TestCase):
+    def test_huge_n_is_rejected_before_expansion(self):
+        req = GenerateReqInput(text="hi", sampling_params={"n": 5_000_000})
+        with self.assertRaisesRegex(
+            ValueError,
+            f"n \\(parallel sample num\\) must be in \\[1, {MAX_PARALLEL_SAMPLE_NUM}\\]",
+        ):
+            # Raises in _handle_parallel_sampling, i.e. before any per-sample
+            # state is materialized.
+            req.normalize_batch_and_arguments()
+
+    def test_non_positive_n_is_rejected(self):
+        for bad_n in (0, -1):
+            req = GenerateReqInput(text="hi", sampling_params={"n": bad_n})
+            with self.assertRaisesRegex(ValueError, "parallel sample num"):
+                req.normalize_batch_and_arguments()
+
+    def test_non_int_n_is_rejected(self):
+        req = GenerateReqInput(text="hi", sampling_params={"n": "1024"})
+        with self.assertRaisesRegex(ValueError, "must be an integer"):
+            req.normalize_batch_and_arguments()
+
+    def test_legitimate_n_still_works(self):
+        req = GenerateReqInput(
+            text="hi", sampling_params={"n": 4, "max_new_tokens": 1}
+        )
+        req.normalize_batch_and_arguments()
+        self.assertEqual(req.parallel_sample_num, 4)
+
+
+class TestTopLogprobsNumValidation(unittest.TestCase):
+    def setUp(self):
+        self.tm = _make_tokenizer_manager(vocab_size=100)
+
+    def test_over_vocab_top_logprobs_num_rejected(self):
+        req = GenerateReqInput(
+            text="hi", return_logprob=True, top_logprobs_num=10**9
+        )
+        with self.assertRaisesRegex(ValueError, r"top_logprobs_num must be in \[0, 100\]"):
+            self.tm._validate_top_logprobs_num(req)
+
+    def test_negative_top_logprobs_num_rejected(self):
+        req = GenerateReqInput(text="hi", return_logprob=True, top_logprobs_num=-1)
+        with self.assertRaisesRegex(ValueError, r"top_logprobs_num must be in \[0, 100\]"):
+            self.tm._validate_top_logprobs_num(req)
+
+    def test_top_logprobs_num_list_validated_elementwise(self):
+        req = GenerateReqInput(
+            text="hi", return_logprob=True, top_logprobs_num=[1, 2, 10**9]
+        )
+        with self.assertRaisesRegex(ValueError, r"top_logprobs_num must be in \[0, 100\]"):
+            self.tm._validate_top_logprobs_num(req)
+
+    def test_valid_top_logprobs_num_accepted(self):
+        req = GenerateReqInput(text="hi", return_logprob=True, top_logprobs_num=10)
+        # Should not raise.
+        self.tm._validate_top_logprobs_num(req)
+
+
+class TestInputIdsInVocabValidation(unittest.TestCase):
+    def setUp(self):
+        self.tm = _make_tokenizer_manager(vocab_size=100)
+
+    def test_negative_input_ids_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"outside the vocab range"):
+            self.tm._validate_input_ids_in_vocab([-1], vocab_size=100)
+
+    def test_over_vocab_input_ids_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"outside the vocab range"):
+            self.tm._validate_input_ids_in_vocab([10**9], vocab_size=100)
+
+    def test_nested_batch_input_ids_rejected(self):
+        with self.assertRaisesRegex(ValueError, r"outside the vocab range"):
+            self.tm._validate_input_ids_in_vocab([[1, 2], [3, -5]], vocab_size=100)
+
+    def test_valid_input_ids_accepted(self):
+        # Should not raise.
+        self.tm._validate_input_ids_in_vocab([0, 50, 99], vocab_size=100)
+        self.tm._validate_input_ids_in_vocab([[1, 2], [3, 4]], vocab_size=100)
+
+    def test_empty_input_ids_accepted(self):
+        # Should not raise.
+        self.tm._validate_input_ids_in_vocab(None, vocab_size=100)
+        self.tm._validate_input_ids_in_vocab([], vocab_size=100)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Three attacker-controlled request parameters can kill a default SGLang server
(no `--api-key`) with a **single unauthenticated HTTP request**. All three were
verified end-to-end against HEAD `989e51ba` with Qwen2.5-0.5B-Instruct on CUDA;
each crashed the entire server (HTTP frontend + tokenizer manager + scheduler +
workers) via the SIGQUIT kill-chain (`run_scheduler_process` -> SIGQUIT ->
`running_phase_sigquit_handler` -> `kill_process_tree`):

1. **`top_logprobs_num` unbounded** — `POST /generate {"return_logprob":true, "top_logprobs_num":10**9}` (also `/v1/chat/completions` with `top_logprobs`): the value reaches `logprobs.topk(k=n)` (`srt/layers/logprob_processor.py:94`) with `n > vocab_size` -> `RuntimeError: selected index k out of range` in the scheduler -> whole server dies.

2. **`n` (parallel sample num) unbounded** — `POST /generate {"sampling_params":{"n":5_000_000}}`: the tokenizer manager materializes one `GenerateReqInput` + `ReqState` + `asyncio.Event` **per rid** (`srt/managers/tokenizer_manager.py:3390-3433`) even though only `batch_size` are used; a ~65-byte request grew the process RSS past 22 GB and blocked the event loop for minutes (client disconnect does not stop the allocation).

3. **Out-of-vocabulary `input_ids`** — `POST /generate {"input_ids":[-1]}`: `_validate_input_ids_in_vocab` exists but was **never called**, and it only checked `id >= vocab_size` (negative ids pass). On tp=1 the ids reach an unmasked `F.embedding` gather (`srt/layers/vocab_parallel_embedding.py:566-576`) -> CUDA device-side assert `srcIndex < srcSelectDimSize` -> CUDA context poisoned, server dead. On CPU the same request raises `IndexError` in the scheduler -> same kill-chain.

## Modifications

- `python/sglang/srt/managers/tokenizer_manager.py`
  - Add `_validate_top_logprobs_num()`: reject values outside `[0, vocab_size]` (handles both int and per-request list forms).
  - Wire the existing (dead) `_validate_input_ids_in_vocab()` into `_validate_one_request()` and strengthen it to enforce `0 <= id < vocab_size` (negative ids included); guard against `None`/empty input.
- `python/sglang/srt/managers/io_struct.py`
  - Add `MAX_PARALLEL_SAMPLE_NUM = 1024` and reject `n` outside `[1, 1024]` in `_handle_parallel_sampling()` **before** any expansion (`_expand_inputs` / `_normalize_rid` / state materialization). Also reject non-integer `n`.
- `test/registered/unit/managers/test_request_param_validation.py` (new)
  - 13 tests covering the three guards (huge/zero/negative/non-int `n`, over-vocab/negative/list-form `top_logprobs_num`, negative/over-vocab/nested-batch `input_ids`, plus legitimate-value pass cases).

All rejections return an HTTP 400 error and leave the server alive; legitimate
requests are unaffected (verified live: normal generation and
`top_logprobs_num=3` both return 200 after the fix).

## Accuracy Tests

N/A — validation-only change, no model/kernel code touched.

## Speed Tests and Profiling

N/A — the new checks run once per request before tokenization; no inference-path
overhead. Verified live: baseline generate latency unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Test results

```
$ python -m pytest test/registered/unit/managers/test_request_param_validation.py -q
13 passed in 10.12s

$ python -m pytest test/registered/unit/managers/test_io_struct.py -q      # regression
47 passed, 2 skipped in 10.35s
```

Live E2E regression (patched server, CUDA, Qwen2.5-0.5B):

```
baseline generate                                  -> 200 OK
top_logprobs_num=1000000000                        -> 400 {"error":{"message":"top_logprobs_num must be in [0, 151936], got 1000000000."}}
n=5000000                                          -> 400 {"error":{"message":"n (parallel sample num) must be in [1, 1024], got 5000000."}}
input_ids=[-1]                                     -> 400 {"error":{"message":"The input_ids [-1] contains values outside the vocab range [0, 151936)."}}
server alive after all four                        -> /health OK, process count unchanged
top_logprobs_num=3 (valid)                         -> 200 OK
```

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33169744922](https://github.com/sgl-project/sglang/actions/runs/33169744922)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33169744657](https://github.com/sgl-project/sglang/actions/runs/33169744657)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33169744902](https://github.com/sgl-project/sglang/actions/runs/33169744902)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->