### PR TITLE
[BugFix] Handle rank-4 queries in RadixAttention padded-token narrowing

### DIFF
--- a/python/sglang/srt/layers/radix_attention.py
+++ b/python/sglang/srt/layers/radix_attention.py
@@ -76,6 +76,22 @@ def _zero_skipped_attn_outputs(*bufs: Optional[torch.Tensor]) -> None:
             buf.zero_()
 
 
+def _restore_token_axis(
+    query: torch.Tensor, output: torch.Tensor
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Remove a singleton model batch axis before token-based PCG slicing."""
+    if query.ndim <= 3:
+        return query, output
+
+    assert query.ndim == 4
+    assert query.shape[0] == 1
+    query = query.squeeze(0)
+    if output.ndim == 4:
+        assert output.shape[0] == 1
+        output = output.squeeze(0)
+    return query, output
+
+
 if TYPE_CHECKING:
     from sglang.srt.layers.quantization.base_config import QuantizationConfig
     from sglang.srt.model_executor.forward_batch_info import ForwardBatch
@@ -338,6 +354,7 @@ def _unified_attention_with_output_impl(
             )
         return None
 
+    query, output = _restore_token_axis(query, output)
     query = query[:real_query_num_tokens]
     if key is not None:
         key = key[:key_value_num_tokens]

--- a/test/registered/unit/layers/test_radix_attention.py
+++ b/test/registered/unit/layers/test_radix_attention.py
@@ -300,6 +300,50 @@ class TestRadixAttentionGraphInterface(CustomTestCase):
         self.assertTrue(torch.all(output[:2] == 3))
         self.assertIs(forward_batch.out_cache_loc, original_out_cache_loc)
 
+    def test_impl_rank4_query_restores_token_axis_before_narrowing(self):
+        # Regression: Gemma3 can supply Q/output as [1, padded_tokens, heads, dim].
+        # Treating dim 0 as tokens leaves Q untrimmed, violates the ragged-attention
+        # row-count invariant, and prevents the padded output tail from being zeroed.
+        attention_layer = SimpleNamespace()
+        context = self._new_impl_context([attention_layer])
+        context.num_tokens = 4
+        context.raw_num_tokens = 2
+        backend = _RecordingAttentionBackend(return_lse=False)
+        query = torch.zeros((1, 4, 2, 3))
+        key = torch.zeros((4, 2, 3))
+        value = torch.zeros((4, 2, 3))
+        output = torch.full_like(query, float("nan"))
+
+        with (
+            patch.object(
+                radix_attention_module,
+                "get_tc_piecewise_forward_context",
+                return_value=context,
+            ),
+            patch.object(
+                radix_attention_module, "get_attn_backend", return_value=backend
+            ),
+        ):
+            lse = radix_attention_module._unified_attention_with_output_impl(
+                query,
+                key,
+                value,
+                output,
+                False,
+                0,
+                False,
+                False,
+            )
+
+        call_record = backend.calls[-1]
+        self.assertIsNone(lse)
+        self.assertEqual(call_record.query.shape, (2, 2, 3))
+        self.assertEqual(call_record.key.shape, (2, 2, 3))
+        self.assertEqual(call_record.value.shape, (2, 2, 3))
+        self.assertEqual(call_record.output.shape, (2, 2, 3))
+        self.assertTrue(torch.all(output[:, :2] == 3))
+        self.assertTrue(torch.all(output[:, 2:] == 0))
+
     def test_impl_zero_real_tokens_returns_zeroed_lse(self):
         # Regression: an idle DP rank whose fabricated EXTEND batch is masked to
         # 0 real tokens skips attention entirely. The skip must still honor the


### PR DESCRIPTION
## Motivation

<!-- Add `Fixes #<issue-number>` after filing the accompanying bug report. -->

### Bug-report checklist

- [x] I searched related issues but found no solution.
- [x] The bug persists on current `main` (`1e6d041f78`).
- [x] Reproduction and environment information are included below.
- [x] This is a bug report, not a general question.
- [x] This report is in English.

### Describe the bug

Serving `google/gemma-3-12b-it` with FlashInfer at `tp=1` can crash during breakable-prefill CUDA-graph replay with:

```text
ValueError: q.shape[0] (8) does not match qo_indptr[-1] (7)
```

`_unified_attention_with_output_impl` narrows a padded query using:

```python
query = query[:real_query_num_tokens]
```

This assumes that dim 0 is the token axis. That is correct for a rank-3 query shaped `[tokens, heads, head_dim]`, but Gemma-3 supplies a rank-4 query shaped `[1, tokens, heads, head_dim]`. In that layout, dim 0 is a singleton batch axis, so slicing it is a no-op.

The padded query therefore retains eight token rows while `qo_indptr` describes the seven real tokens. FlashInfer later flattens the query to token-major rank 3 and detects the mismatch.

The same incorrect axis assumption affects the preallocated output: `_zero_padded_pcg_tail` sees `output.shape[0] == 1`, so the padded token tail is not zeroed.

This path is reachable with default settings because:

1. Breakable prefill CUDA graph has been the default CUDA prefill graph backend since [#29458](https://github.com/sgl-project/sglang/pull/29458).
2. `Gemma3ForConditionalGeneration` is in `mm_disabled_models`, so `is_multimodal` is false unless `--enable-multimodal` is supplied. The multimodal compatibility guard therefore does not disable breakable-prefill CUDA graph.
3. Gemma-3 uses the rank-4 query layout even for plain-text requests.

### Reproduction

On an environment where FlashInfer is the default attention backend:

```bash
python3 -m sglang.launch_server \
  --model-path google/gemma-3-12b-it \
  --tp-size 1 \
  --trust-remote-code
```

On systems where another backend is selected by default, add:

```text
--attention-backend flashinfer
```

Then send a plain-text request:

```bash
curl http://127.0.0.1:30000/generate \
  -H 'Content-Type: application/json' \
  -d '{
    "text": "Write a long paragraph about the ocean.",
    "sampling_params": {"max_new_tokens": 64}
  }'
```

Expected: the request completes under breakable-prefill CUDA-graph replay.

Actual: when the seven-token request replays in an eight-token graph bucket, FlashInfer raises:

```text
ValueError: q.shape[0] (8) does not match qo_indptr[-1] (7)
```

The following settings avoid the crash by making this path unreachable, but are not fixes:

- `--cuda-graph-backend-prefill tc_piecewise`
- `--cuda-graph-backend-prefill disabled`
- `--enable-multimodal`, which causes the compatibility guard to disable breakable-prefill CUDA graph for Gemma-3

### Reproduction environment

`python3 -m sglang.check_env` could not be run because the automated CI container was not retained after the server crashed. Package and system information captured by the workload was:

| Item | Value |
| --- | --- |
| SGLang | `0.0.0.dev1+gc0b6474b4`; also reproduced on `0.0.0.dev1+gcb12a1547` and public commit `bfefdc52d` |
| SGLang PR base | `1e6d041f78cd4a4d94ed43fa0634ccaa231fe048` |
| sgl-kernel | `0.4.6.post1` |
| flashinfer-python | `0.6.17` |
| FlashInfer commit | `a0a6b019b9b27d49d209f85d028a1ae5a9b347d7` |
| PyTorch | `2.13.0+cu130` |
| CUDA | `13.0.3` |
| Python | `3.12.3` |
| Base image | `lmsysorg/sglang:dev@sha256:51e576f02368480c055c7aadb67590d82b172e2392123ce4cf4cc8251b2d8caf` |
| Model | `google/gemma-3-12b-it`, including BF16, FP8, and NVFP4 variants |
| Attention backend | FlashInfer |
| Prefill graph backend | Breakable |
| Topology | One node, one GPU, `tp=1`, `dp=1`, DP attention disabled |
| Architecture | `aarch64`, NVIDIA Jetson AGX Thor, integrated Blackwell-generation GPU |

The unpatched failure was observed with FP8 and NVFP4 using the identical `(8)` versus `(7)` shapes. The proposed normalization was successfully exercised with FP8 and BF16.

### Related work

This is related to, but distinct from, [#29008](https://github.com/sgl-project/sglang/issues/29008), [#30916](https://github.com/sgl-project/sglang/pull/30916), and [#35876](https://github.com/sgl-project/sglang/pull/35876). Those changes concern DP-attention padding in the FlashInfer MLA/DeepSeek path. This failure occurs at `tp=1`, without DP attention, in `radix_attention.py`.

Notably, #30916 normalizes its query to rank 3 before token slicing. This PR applies the same token-major invariant to the unified RadixAttention path.

## Modifications

- Add `_restore_token_axis` to normalize singleton rank-4 `[1, tokens, heads, dim]` query and output views before token-based narrowing.
- Preserve the existing rank-3 path unchanged.
- Reject unsupported ranks and genuine multi-sequence rank-4 batches instead of silently flattening them.
- Perform normalization after the zero-token early return, preserving existing skipped-attention and LSE behavior.
- Add a focused CPU regression test covering:
  - backend-visible Q/K/V and output token counts;
  - copy-back through the preallocated output view;
  - zeroing of the padded token tail.

The normalization uses `squeeze(0)`, so it creates a view and does not allocate or copy the query/output tensors.

## Accuracy Tests

The same rank-normalization logic was validated end-to-end against the previously failing workload:

| Configuration | Result |
| --- | --- |
| Unpatched FP8 | Fails with `q.shape[0] (8) != qo_indptr[-1] (7)` |
| Unpatched NVFP4 | Fails with the same shapes |
| Patched FP8 | Passes; full concurrency sweep completes |
| Patched BF16 | Passes; 1,056 HTTP 200 responses and all benchmark phases report zero errors |
| Unpatched non-Gemma control | Passes |
| Patched NVFP4 | Not scored; the job was externally cancelled before the container started |

The patched BF16 run recorded 13 padded-query events, including the exact formerly crashing case:

```text
q.shape=(8, 16, 256) real_q=7 padded=True
```

The request completed through CUDA-graph replay with no eager fallback and no `qo_indptr` mismatch.

Local validation:

- [x] All repository pre-commit hooks pass.
- [x] Focused CPU regression test added.
- [ ] Focused test execution is pending CI; the local checkout does not have PyTorch installed.

## Speed Tests and Profiling

There is no green unpatched FlashInfer baseline for this path because the request crashes.

Two patched FP8 runs produced 17.364 and 17.39 output tokens/s for the concurrency-1 workload. These demonstrate stable patched behavior but are not presented as a controlled before/after performance comparison.

The production change adds only an `ndim` check on the existing rank-3 path and a view-only `squeeze(0)` for the rank-4 path.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation update is required for this internal shape fix.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33168060032](https://github.com/sgl-project/sglang/actions/runs/33168060032)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33168059841](https://github.com/sgl-project/sglang/actions/runs/33168059841)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33168059960](https://github.com/sgl-project/sglang/actions/runs/33168059960)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->