### PR TITLE
[Bugfix] Route Qwen3 MoE through configured expert locations

### DIFF
--- a/python/sglang/srt/models/qwen3_moe.py
+++ b/python/sglang/srt/models/qwen3_moe.py
@@ -31,7 +31,10 @@ from sglang.srt.distributed import (
     moe_tensor_model_parallel_all_reduce,
 )
 from sglang.srt.eplb.expert_distribution import get_global_expert_distribution_recorder
-from sglang.srt.eplb.expert_location import ModelConfigForExpertLocation
+from sglang.srt.eplb.expert_location import (
+    ModelConfigForExpertLocation,
+    get_global_expert_location_metadata,
+)
 from sglang.srt.eplb.expert_location_dispatch import ExpertLocationDispatchInfo
 from sglang.srt.layers.communicator import LayerCommunicator, LayerScatterModes
 from sglang.srt.layers.cp.utils import is_cp_v2_active
@@ -326,7 +329,16 @@ class Qwen3MoeSparseMoeBlock(nn.Module):
 
         # router_logits: (num_tokens, n_experts)
         router_logits, _ = self.gate(hidden_states)
-        topk_output = self.topk(hidden_states, router_logits)
+        dispatch_info = (
+            ExpertLocationDispatchInfo.init_new(layer_id=self.layer_id)
+            if get_global_expert_location_metadata() is not None
+            else None
+        )
+        topk_output = self.topk(
+            hidden_states,
+            router_logits,
+            expert_location_dispatch_info=dispatch_info,
+        )
         final_hidden_states = self.experts(hidden_states, topk_output)
 
         if self.ep_size > 1 and not should_skip_post_experts_all_reduce(

--- a/test/registered/unit/models/test_qwen3_moe_expert_location.py
+++ b/test/registered/unit/models/test_qwen3_moe_expert_location.py
@@ -1,0 +1,101 @@
+"""Regression tests for Qwen3 MoE expert-location dispatch.
+
+The ordinary (non-DeepEP) Qwen3 MoE path must translate logical router choices
+to the configured physical expert locations before executing the experts.  A
+non-trivial initial placement otherwise loads each rank's physical slots using
+the placement map while routing tokens as if the slots were still trivial.
+
+This test exercises the real forward method with tiny CPU-only fake modules; it
+does not require model weights, CUDA, or a distributed process group.
+"""
+
+import unittest
+from unittest import mock
+
+import torch
+from torch import nn
+
+from sglang.srt.models.qwen3_moe import Qwen3MoeSparseMoeBlock
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _Gate(nn.Module):
+    def forward(self, hidden_states):
+        return torch.zeros(hidden_states.shape[0], 4), None
+
+
+class _TopK(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.dispatch_info = None
+
+    def forward(
+        self,
+        hidden_states,
+        router_logits,
+        *,
+        expert_location_dispatch_info=None,
+    ):
+        self.dispatch_info = expert_location_dispatch_info
+        return object()
+
+
+class _Experts(nn.Module):
+    def forward(self, hidden_states, topk_output):
+        return hidden_states
+
+
+class TestQwen3MoeExpertLocation(CustomTestCase):
+    def _make_block(self):
+        block = Qwen3MoeSparseMoeBlock.__new__(Qwen3MoeSparseMoeBlock)
+        nn.Module.__init__(block)
+        block.layer_id = 7
+        block.ep_size = 1
+        block.tp_size = 1
+        block.gate = _Gate()
+        block.topk = _TopK()
+        block.experts = _Experts()
+        return block
+
+    def test_forward_normal_passes_expert_location_dispatch_info(self):
+        block = self._make_block()
+        dispatch_info = object()
+        with (
+            mock.patch(
+                "sglang.srt.models.qwen3_moe.get_global_expert_location_metadata",
+                return_value=object(),
+            ),
+            mock.patch(
+                "sglang.srt.models.qwen3_moe.ExpertLocationDispatchInfo.init_new",
+                return_value=dispatch_info,
+            ) as init_dispatch,
+        ):
+            output = block.forward_normal(torch.ones(2, 8))
+
+        init_dispatch.assert_called_once_with(layer_id=7)
+        self.assertIs(block.topk.dispatch_info, dispatch_info)
+        self.assertEqual(output.shape, (2, 8))
+
+    def test_forward_normal_skips_dispatch_without_location_metadata(self):
+        block = self._make_block()
+        with (
+            mock.patch(
+                "sglang.srt.models.qwen3_moe.get_global_expert_location_metadata",
+                return_value=None,
+            ),
+            mock.patch(
+                "sglang.srt.models.qwen3_moe.ExpertLocationDispatchInfo.init_new"
+            ) as init_dispatch,
+        ):
+            output = block.forward_normal(torch.ones(2, 8))
+
+        init_dispatch.assert_not_called()
+        self.assertIsNone(block.topk.dispatch_info)
+        self.assertEqual(output.shape, (2, 8))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [Bugfix] Route Qwen3 MoE through configured expert locations on the normal path

## Motivation

Qwen3's normal (non-DeepEP) MoE forward path currently calls `TopK` without
`ExpertLocationDispatchInfo`. With a non-trivial `--init-expert-location`, the
weights are loaded into remapped physical slots, but the router's logical expert
IDs are therefore executed against the wrong slots.

We reproduced this on Qwen3-30B-A3B BF16 with EP4 across four NVIDIA L4 workers.
The unpatched non-trivial-placement run collapsed to 128 re-tokenized copies of
one token ID even though the server reported 256 completion tokens. After passing
the location dispatch metadata into `TopK`, the corrected run and its bracketed
controls returned 256/256 server token IDs without repeated-token collapse in all
50 measured requests.

This PR is intentionally limited to the Qwen3 routing correctness defect. It does
not include the experimental sparse communication protocol discussed in #36820.

## Modifications

- Initialize per-layer `ExpertLocationDispatchInfo` in
  `Qwen3MoeSparseMoeBlock.forward_normal` when expert-location metadata is
  available.
- Pass that information to `TopK`, matching the Qwen3 DeepEP path.
- Keep the no-metadata path unchanged. This is important for draft workers, which
  intentionally do not initialize global expert-location metadata.
- Add two CPU-only regression tests using the real Qwen3 normal forward method:
  one verifies dispatch metadata reaches `TopK`; the other verifies the
  no-metadata path remains safe.

## Accuracy Tests

- Added:
  `test/registered/unit/models/test_qwen3_moe_expert_location.py`
- The test requires no CUDA, distributed process group, or model weights and is
  registered in `base-a-test-cpu`.
- Four-L4 integration reproduction: before the fix, the non-trivial placement
  produced repeated-token collapse; after the fix, every one of 50 measured
  1,000-input/256-output requests returned all 256 server token IDs with more
  than one unique token ID.

The distributed experiment is a structural routing-correctness reproduction,
not a claim of task-level quality equivalence. The unit regression isolates the
call-site defect directly.

## Speed Tests and Profiling

This is a correctness fix for the opt-in non-trivial-placement path, not a speed
optimization. The default configuration resolves to no dispatch remap. No new
GPU synchronization, collective, kernel, or tensor copy is added.

The related sparse communication experiment is deliberately excluded because
its Python/GPU-to-host prototype regressed throughput; it belongs in the design
issue until a GPU-resident implementation has a positive isolated benchmark.

## Local validation

- `scripts/lint/check_registered_tests.py`
- `scripts/lint/check_no_bare_pytest_main.py`
- `python -m py_compile` on both changed Python files
- SGLang pre-commit Ruff rule set (`F401,F821,UP037`)
- isort check
- Black check
- `git diff --check`

The focused pytest module could not be collected on the contributor's macOS host
because SGLang imports Triton unconditionally and Triton is unavailable on that
platform. The test is CPU-only after module import and is intended for SGLang's
Linux CPU CI lane.

## Checklist

- [x] The code is formatted and linted.
- [x] A focused regression test is registered in CPU CI.
- [x] The change is backward-compatible when location metadata is absent.
- [x] The performance research prototype is kept out of this correctness PR.

Related: #36820

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33170759872](https://github.com/sgl-project/sglang/actions/runs/33170759872)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33170759632](https://github.com/sgl-project/sglang/actions/runs/33170759632)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33170759788](https://github.com/sgl-project/sglang/actions/runs/33170759788)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->