### PR TITLE
[Fix] Route the Mooncake MoE A2A backend through Kimi K3's EP-A2A / SP-MoE fast path

### DIFF
--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -531,15 +531,17 @@ class KimiK3MoE(nn.Module):
                 "got a checkpoint with different constants"
             )
 
-        # EP a2a backends (megamoe / DeepEP / MoRI) move each row to its
-        # experts directly, so the MoE region can consume whatever rows this
-        # rank holds — an SP-MoE token shard (attn_tp > 1) or the DP-local
-        # batch (DP attention) — with every global token dispatched exactly
-        # once. No DP gather and no TP reduce is needed anywhere in the region.
+        # EP a2a backends (megamoe / DeepEP / Mooncake / Ascend-FuseEP / MoRI)
+        # move each row to its experts directly, so the MoE region can consume
+        # whatever rows this rank holds — an SP-MoE token shard (attn_tp > 1) or
+        # the DP-local batch (DP attention) — with every global token dispatched
+        # exactly once. No DP gather and no TP reduce is needed anywhere in the
+        # region.
         _a2a_backend = get_moe_a2a_backend()
         self._ep_a2a = (
             _a2a_backend.is_megamoe()
             or _a2a_backend.is_deepep()
+            or _a2a_backend.is_mooncake()
             or _a2a_backend.is_ascend_fuseep()
             or _a2a_backend.is_mori()
         )
@@ -2162,8 +2164,9 @@ class KimiK3DecoderLayer(nn.Module):
             and layer_idx >= config.first_k_dense_replace
             and layer_idx % config.moe_layer_freq == 0
         )
-        # SP-MoE (EP a2a backend — megamoe, DeepEP or MoRI): o_proj defers its
-        # attention-TP reduction; this layer completes it as a reduce-scatter
+        # SP-MoE (EP a2a backend — megamoe, DeepEP, Mooncake, Ascend-FuseEP or
+        # MoRI): o_proj defers its attention-TP reduction; this layer completes
+        # it as a reduce-scatter
         # so the whole MoE region (agg2, norms, gate, latent projs, tp1
         # shared experts, EP a2a dispatch) runs on 1/attn_tp of the rows,
         # then all-gathers rows back after the MoE tail add. RS+AG moves the
@@ -2184,6 +2187,7 @@ class KimiK3DecoderLayer(nn.Module):
             (
                 _a2a_backend.is_megamoe()
                 or _a2a_backend.is_deepep()
+                or _a2a_backend.is_mooncake()
                 or _a2a_backend.is_ascend_fuseep()
                 or _a2a_backend.is_mori()
             )


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

<!--
Suggested PR title:
[Fix] Route the Mooncake MoE A2A backend through Kimi K3's EP-A2A / SP-MoE fast path
-->

## Motivation

Kimi K3 selects two backend-specific optimizations at construction time:

- `self._ep_a2a` — when the MoE A2A backend routes each row to its experts directly, the MoE region consumes the rank-local rows (an SP-MoE token shard or the DP-local batch) with **no DP gather and no TP reduce**, and every global token is dispatched exactly once.
- `self._sp_moe` — on top of `_ep_a2a`, MoE layers with `attn_tp > 1` convert the deferred `o_proj` attention-TP all-reduce into a reduce-scatter, so the whole MoE front (norms, gate, latent projections, tp1 shared experts, A2A dispatch) runs on `1/attn_tp` of the rows and all-gathers back afterwards.

Both predicates already list the EP-A2A family — `is_megamoe()`, `is_deepep()`, `is_ascend_fuseep()`, `is_mori()` — but **Mooncake was missing**, even though `is_deepep_class_backend()` already classifies Mooncake as a DeepEP-family backend, `DeepEPMoE` documents that Mooncake shares the same interface, and the dispatcher factory builds the same `MaybeTboDeepEPDispatcher` with the `DEEPEP_LL` output format for both.

As a result, `moe_a2a_backend='mooncake'` correctly reached the Mooncake dispatcher on the data plane, but Kimi K3 still treated it as a plain TP/DP MoE:

| Backend  | `_ep_a2a` | `_sp_moe` |
| -------- | --------- | --------- |
| DeepEP   | True      | True      |
| Mooncake | False     | False     |

With `_ep_a2a=False`, K3 first gathers all DP replicas into a global batch before the A2A; with `_sp_moe=False`, the attention output keeps the full `B` rows on every attn-TP rank instead of a `B/attn_tp` shard. On a `TP=32, DP=4` (attn-TP=8) decode config this inflates each process's dispatch input to `~32x` DeepEP's, replicating dispatch, expert GEMM and combine work. The service stays numerically correct but is significantly slower, and it also skews QP-level profiling comparisons because the two backends were being fed very different token-row counts.

The Mooncake side of Kimi K3 support has already been merged into its main branch: https://github.com/kvcache-ai/Mooncake/pull/3727. This PR is the SGLang-side counterpart so Mooncake reaches full parity with DeepEP on the K3 path.

## Modifications

`python/sglang/srt/models/kimi_k3.py`:

- Add `is_mooncake()` to the `_ep_a2a` predicate so Mooncake takes the EP-A2A fast path (no DP gather, no TP reduce) exactly like DeepEP.
- Add `is_mooncake()` to the `_sp_moe` predicate so Mooncake MoE layers with `attn_tp > 1` also perform the reduce-scatter / all-gather sequence-parallel MoE optimization.
- Both predicates are updated together on purpose: changing only `_sp_moe` would shard the input to `B/attn_tp` rows while the MoE still enters the DP-gather path under `_ep_a2a=False`, and the shape assumptions would conflict.
- Update the surrounding comments to include Mooncake (and Ascend-FuseEP) in the enumerated EP-A2A backend list.

Note on memory: enabling `_ep_a2a` for Mooncake switches its shared experts from TP-sharded to per-rank replicated (`_shared_experts_tp1`), matching DeepEP. This adds roughly ~264 MB/layer of replicated shared-expert weights (~24 GB/rank across the MoE layers) — the same cost DeepEP already pays — so H200 memory headroom should be re-checked when deploying with Mooncake.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33171362814](https://github.com/sgl-project/sglang/actions/runs/33171362814)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33171362694](https://github.com/sgl-project/sglang/actions/runs/33171362694)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33171362928](https://github.com/sgl-project/sglang/actions/runs/33171362928)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->