### PR TITLE
[GGUF] Fix qwen3_5 GGUF weight loading (conv1d / A_log / shared_expert_gate / lm_head qweight)

### DIFF
--- a/python/sglang/srt/models/qwen3_5.py
+++ b/python/sglang/srt/models/qwen3_5.py
@@ -2013,6 +2013,21 @@ class Qwen3_5ForConditionalGeneration(Qwen3VLForConditionalGeneration):
                 param = params_dict[name]
 
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
+
+                # GGUF conv1d data is already [dim, kernel] dim-major
+                # (data[dim][kernel]); the SGLang conv1d kernel expects a
+                # [dim, 1, kernel] layout, so only unsqueeze is needed.
+                if "conv1d.weight" in name and loaded_weight.ndim == 2:
+                    loaded_weight = loaded_weight.contiguous().unsqueeze(1)
+                # GGUF ssm_a stores raw negative decay rates; the model keeps
+                # A_log in log-space: -exp(A_log) = ssm_a.
+                if "A_log" in name and loaded_weight.dtype == torch.float32:
+                    loaded_weight = torch.log(-loaded_weight)
+                # GGUF shared_expert_gate is [hidden] but the model expects
+                # [1, hidden].
+                if "shared_expert_gate" in name and loaded_weight.ndim == 1:
+                    loaded_weight = loaded_weight.unsqueeze(0)
+
                 weight_loader(param, loaded_weight)
                 if (
                     self.config.tie_word_embeddings

--- a/python/sglang/srt/models/qwen3_5_text.py
+++ b/python/sglang/srt/models/qwen3_5_text.py
@@ -168,15 +168,28 @@ class Qwen3_5ForCausalLM(nn.Module):
         for name, loaded_weight in weights:
             if name.startswith(_MODEL_PREFIX):
                 body_weights.append((name[len(_MODEL_PREFIX) :], loaded_weight))
-            elif name == "lm_head.weight":
+            elif name in ("lm_head.weight", "lm_head.qweight"):
                 if self.config.tie_word_embeddings:
                     continue
-                if "lm_head.weight" not in params_dict:
+                # GGUF loads the quantized lm_head into a "lm_head.qweight"
+                # parameter (via GGUFLinearMethod); safetensors uses "weight".
+                _pd_key = (
+                    "lm_head.qweight"
+                    if "lm_head.qweight" in params_dict
+                    else "lm_head.weight"
+                )
+                if _pd_key not in params_dict:
                     continue
-                param = params_dict["lm_head.weight"]
+                param = params_dict[_pd_key]
                 weight_loader = getattr(param, "weight_loader", default_weight_loader)
                 weight_loader(param, loaded_weight)
-                loaded_params.add("lm_head.weight")
+                loaded_params.add(_pd_key)
+            elif name == "lm_head.qweight_type":
+                if "lm_head.qweight_type" in params_dict:
+                    param = params_dict["lm_head.qweight_type"]
+                    weight_loader = getattr(param, "weight_loader", default_weight_loader)
+                    weight_loader(param, loaded_weight)
+                    loaded_params.add("lm_head.qweight_type")
 
         body_loaded = self.model.load_weights(body_weights)
         loaded_params.update(f"{_MODEL_PREFIX}{n}" for n in body_loaded)


### PR DESCRIPTION
### Problem
Qwen3.5 hybrid (Gated Delta Network) models fail to load GGUF weights correctly:
- conv1d weights are scrambled (GGUF data is already `[dim, kernel]` dim-major, but no handling)
- `A_log` is not converted from raw negative decay to log-space
- `shared_expert_gate` is loaded as `[hidden]` instead of `[1, hidden]`
- the quantized `lm_head` (`lm_head.qweight`) is never loaded

### Fixes
- `python/sglang/srt/models/qwen3_5.py`: GGUF conv1d loading — data is already dim-major, only `contiguous().unsqueeze(1)` is needed (never transpose/reshape)
- `python/sglang/srt/models/qwen3_5.py`: A_log conversion `torch.log(-x)` so `-exp(A_log) == ssm_a`
- `python/sglang/srt/models/qwen3_5.py`: shared_expert_gate `[hidden] -> [1, hidden]`
- `python/sglang/srt/models/qwen3_5_text.py`: load GGUF quantized lm_head into `lm_head.qweight` + `lm_head.qweight_type` (safetensors path unchanged)

### Validation
- Loaded weights match gguf-py dequantized values exactly (multi-component cross-check)
- Same GGUF (Qwen3.5-35B-A3B hybrid, e.g. Ornith-1.5) runs correctly in llama.cpp; with these fixes SGLang output matches llama.cpp

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33171757844](https://github.com/sgl-project/sglang/actions/runs/33171757844)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33171757702](https://github.com/sgl-project/sglang/actions/runs/33171757702)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33171757754](https://github.com/sgl-project/sglang/actions/runs/33171757754)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->