### PR TITLE
fix(rocm): fall back to Triton when AITER does not support the GPU

### DIFF
--- a/python/sglang/srt/arg_groups/model_override_base.py
+++ b/python/sglang/srt/arg_groups/model_override_base.py
@@ -13,6 +13,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from sglang.srt.platforms import current_platform
 from sglang.srt.runtime_context import get_platform
+from sglang.srt.utils.aiter import is_aiter_supported_arch
 from sglang.srt.utils.common import is_mps, is_no_spec_infer_or_topk_one
 
 logger = logging.getLogger(__name__)
@@ -319,7 +320,7 @@ def get_default_attn_backend(server_args: Any, use_mla_backend: bool, model_conf
                 return "fa4"
             return "trtllm_mha"
         elif get_platform().is_hip:
-            return "aiter"
+            return "aiter" if is_aiter_supported_arch() else "triton"
         elif is_mps():
             return "torch_native"
         else:

--- a/python/sglang/srt/utils/aiter.py
+++ b/python/sglang/srt/utils/aiter.py
@@ -15,12 +15,31 @@
 
 import logging
 import os
+from functools import lru_cache
+
+import torch
 
 from sglang.srt.utils.common import get_bool_env_var, is_hip
 
 logger = logging.getLogger(__name__)
 
 _aiter_chip_info_cached = False
+
+# AITER exposes no public architecture capability API. Keep this aligned with
+# the validator used by its compiled operators in csrc/cpp_itfs/utils.py.
+_AITER_SUPPORTED_ARCHS = frozenset(
+    {"gfx90a", "gfx940", "gfx941", "gfx942", "gfx950", "gfx1151"}
+)
+
+
+@lru_cache(maxsize=1)
+def is_aiter_supported_arch() -> bool:
+    """Whether the current ROCm GPU passes AITER's compiled-op validator."""
+    if not is_hip():
+        return False
+
+    gcn_arch = getattr(torch.cuda.get_device_properties(0), "gcnArchName", "")
+    return gcn_arch.split(":", 1)[0] in _AITER_SUPPORTED_ARCHS
 
 
 def maybe_pre_warm_aiter_chip_info() -> None:

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -9,6 +9,9 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import sglang.srt.server_args as server_args_module
+import sglang.srt.utils.aiter as aiter_utils
+from sglang.srt.arg_groups import model_override_base as model_override_base_module
+from sglang.srt.arg_groups import overrides as overrides_module
 from sglang.srt.arg_groups import parallel_hook, pd_disaggregation_hook, serving_hook
 from sglang.srt.arg_groups.attention_hook import (
     handle_attention_backend_compatibility,
@@ -995,6 +998,86 @@ class TestFa4PageSizeAutoForce(CustomTestCase):
 
         self.assertEqual(args.page_size, 1)  # the field stays pristine
         self.assertEqual(resolved_view(args).page_size, 128)
+
+
+class TestDefaultAttentionBackend(CustomTestCase):
+    @staticmethod
+    def _model_config():
+        return SimpleNamespace(
+            hf_config=SimpleNamespace(architectures=[]),
+            has_asymmetric_kv=False,
+            has_attention_sinks=False,
+        )
+
+    def _get_mha_backend(self, *, is_hip, gcn_arch, flashinfer_available=False):
+        is_aiter_supported_arch = aiter_utils.is_aiter_supported_arch
+        is_aiter_supported_arch.cache_clear()
+        self.addCleanup(is_aiter_supported_arch.cache_clear)
+
+        with (
+            override_platform(
+                is_hopper_with_cuda_12_3=False,
+                is_sm100=False,
+                is_hip=is_hip,
+                has_flashinfer=flashinfer_available,
+            ),
+            patch.object(
+                model_override_base_module.current_platform,
+                "is_out_of_tree",
+                return_value=False,
+            ),
+            patch.object(
+                model_override_base_module,
+                "is_mps",
+                return_value=False,
+            ),
+            patch.object(aiter_utils, "is_hip", return_value=is_hip),
+            patch.object(
+                aiter_utils.torch.cuda,
+                "get_device_properties",
+                return_value=SimpleNamespace(gcnArchName=gcn_arch),
+            ),
+        ):
+            return model_override_base_module.get_default_attn_backend(
+                SimpleNamespace(_resolved_overrides=[]),
+                use_mla_backend=False,
+                model_config=self._model_config(),
+            )
+
+    def test_hip_supported_arch_defaults_to_aiter(self):
+        self.assertEqual(
+            self._get_mha_backend(is_hip=True, gcn_arch="gfx942:sramecc+:xnack-"),
+            "aiter",
+        )
+
+    def test_hip_gfx1100_defaults_to_triton(self):
+        self.assertEqual(
+            self._get_mha_backend(is_hip=True, gcn_arch="gfx1100"),
+            "triton",
+        )
+
+    def test_non_hip_default_is_unchanged(self):
+        self.assertEqual(
+            self._get_mha_backend(
+                is_hip=False,
+                gcn_arch="",
+                flashinfer_available=True,
+            ),
+            "flashinfer",
+        )
+
+    def test_explicit_aiter_skips_default_arch_gate(self):
+        view = SimpleNamespace(
+            attention_backend="aiter",
+            prefill_attention_backend=None,
+            decode_attention_backend=None,
+        )
+        with patch.object(overrides_module, "get_default_attn_backend") as get_default:
+            self.assertEqual(
+                overrides_module._attention_backend_default(view),
+                {},
+            )
+        get_default.assert_not_called()
 
 
 class TestContextParallelServerArgs(CustomTestCase):


### PR DESCRIPTION
## Motivation

SGLang currently selects AITER by default for MHA on ROCm. AITER rejects `gfx1100` during JIT, so an RX 7900 XTX fails even though the Triton backend works on the same hardware.

## Modifications

- Use AITER only when the current GPU architecture is supported by its compiled operators.
- Fall back to Triton for unsupported architectures such as `gfx1100`.
- Keep explicit backend selection unchanged.

AITER does not expose a stable capability API, so the check follows the architecture list used by its compiled-op validator without importing AITER during argument parsing.

## Accuracy Tests

```text
PYTHONPATH=python .venv/bin/python -m pytest test/registered/unit/server_args/test_server_args.py -k TestDefaultAttentionBackend -q
4 passed, 185 deselected
```

On Windows WSL2 with an RX 7900 XTX (`gfx1100`), default AITER failed during JIT, while Triton completed real MOSS-TTS and Qwen3-ASR requests. Qwen3-ASR passed eager, encoder-graph, and generation-graph lanes with matching transcripts, including a 64.68-second input.

## Speed Tests and Profiling

Not run. This only changes backend selection when AITER cannot run on the detected architecture.

## Checklist

- [x] Format the code with pre-commit.
- [x] Add tests for supported, unsupported, non-HIP, and explicit-backend cases.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35486127211](https://github.com/sgl-project/sglang/actions/runs/35486127211)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35486127069](https://github.com/sgl-project/sglang/actions/runs/35486127069)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35486127153](https://github.com/sgl-project/sglang/actions/runs/35486127153)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->

