### PR TITLE
Fix/quark shared expert glm52 mtp layer

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -92,7 +92,7 @@ env:
   # default times out on a cold cache.
   HF_HUB_DOWNLOAD_TIMEOUT: 300
   HF_HUB_ETAG_TIMEOUT: 300
-  SKIP_PR_TEST_HEALTH_CHECK: ${{ (fromJson(inputs.caller_inputs).skip_pr_test_health_check || fromJson(inputs.caller_inputs).test_parallel_dispatch || fromJson(inputs.caller_inputs).run_all_tests) && 'true' || 'false' }}
+  SKIP_PR_TEST_HEALTH_CHECK: ${{ (inputs.scheduled || fromJson(inputs.caller_inputs).skip_pr_test_health_check || fromJson(inputs.caller_inputs).test_parallel_dispatch || fromJson(inputs.caller_inputs).run_all_tests) && 'true' || 'false' }}
   PR_TEST_BYPASS_MAINTENANCE_ON_MAIN: ${{ github.ref == 'refs/heads/main' && 'true' || 'false' }}
   USE_VENV: false
 

--- a/python/sglang/kernels/ops/moe/ep_moe_kernels.py
+++ b/python/sglang/kernels/ops/moe/ep_moe_kernels.py
@@ -1944,6 +1944,7 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
     k,
     K_SCALE_BLOCK_SIZE: tl.constexpr,
     K_BLOCK_SIZE: tl.constexpr,
+    HAS_K_TAIL: tl.constexpr,
 ):
     pid_k, pid_m, pid_e = (
         tl.program_id(axis=0),
@@ -1959,6 +1960,11 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
         return
     output_scale_val_inv = 1.0 / tl.load(output_scale_ptr).to(tl.float32)
     k_offsets = pid_k * K_BLOCK_SIZE + tl.arange(0, K_BLOCK_SIZE)
+    # k only has to be a multiple of the 128-wide scale group (e.g. 3584), so the
+    # last k block can be partial.  Specialize on it: hidden sizes that fill
+    # every block keep the unmasked loads, and their codegen is unchanged.
+    if HAS_K_TAIL:
+        k_mask = k_offsets < k
     scale_offsets = (k_offsets // K_SCALE_BLOCK_SIZE) * x_scale_stride2
 
     x_ptrs = x_ptr + pid_e * m * k + k_offsets
@@ -1966,10 +1972,22 @@ def _fp8_per_token_quant_to_per_tensor_quant_kernel(
     x_scale_ptrs = x_scale_ptr + pid_e * x_scale_stride0 + scale_offsets
 
     for tok_idx in tl.range(token_id, last_effective_id, pid_m_dim):
-        hidden = tl.load(x_ptrs + tok_idx * k).to(tl.float32)
-        scale_fp32 = tl.load(x_scale_ptrs + tok_idx * x_scale_stride1).to(tl.float32)
+        if HAS_K_TAIL:
+            hidden = tl.load(x_ptrs + tok_idx * k, mask=k_mask, other=0.0)
+            x_scale = tl.load(
+                x_scale_ptrs + tok_idx * x_scale_stride1, mask=k_mask, other=0.0
+            )
+        else:
+            hidden = tl.load(x_ptrs + tok_idx * k)
+            x_scale = tl.load(x_scale_ptrs + tok_idx * x_scale_stride1)
+        hidden = hidden.to(tl.float32)
+        scale_fp32 = x_scale.to(tl.float32)
         hidden = hidden * scale_fp32 * output_scale_val_inv
-        tl.store(output_ptrs + tok_idx * k, hidden.to(output_ptr.dtype.element_ty))
+        quantized = hidden.to(output_ptr.dtype.element_ty)
+        if HAS_K_TAIL:
+            tl.store(output_ptrs + tok_idx * k, quantized, mask=k_mask)
+        else:
+            tl.store(output_ptrs + tok_idx * k, quantized)
 
 
 def fp8_per_token_to_per_tensor_quant_triton(
@@ -1986,8 +2004,7 @@ def fp8_per_token_to_per_tensor_quant_triton(
     assert output_scale.numel() == 1
 
     K_BLOCK_SIZE = 1024
-    assert x.size(2) % K_BLOCK_SIZE == 0
-    grid = (x.size(2) // K_BLOCK_SIZE, 32, x.size(0))
+    grid = (triton.cdiv(x.size(2), K_BLOCK_SIZE), 32, x.size(0))
     _fp8_per_token_quant_to_per_tensor_quant_kernel[grid](
         x,
         x_scale,
@@ -1999,6 +2016,7 @@ def fp8_per_token_to_per_tensor_quant_triton(
         x.size(2),
         K_SCALE_BLOCK_SIZE=K_SCALE_BLOCK_SIZE,
         K_BLOCK_SIZE=K_BLOCK_SIZE,
+        HAS_K_TAIL=x.size(2) % K_BLOCK_SIZE != 0,
         num_warps=8,
     )
 

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -624,6 +624,28 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
                 "trtllm_mha backend only supports topk = 1 for speculative decoding."
             )
 
+    # ROCm/HIP lacks the CUDA/MUSA sampling-verify kernels, so EAGLE verify would
+    # otherwise silently fall back to greedy (argmax), ignoring temperature/top_p.
+    # Default rejection sampling on (routes verify through the Triton chain sampler)
+    # for configs that support it, unless the user opted in or picked an incompatible
+    # option. Conditions mirror the validation below so the flip never triggers a raise.
+    from sglang.srt.utils import is_hip
+
+    if (
+        is_hip()
+        and not server_args.speculative_use_rejection_sampling
+        and server_args.speculative_algorithm in ("EAGLE", "EAGLE3")
+        and server_args.speculative_eagle_topk == 1
+        and server_args.speculative_accept_threshold_single == 1.0
+        and server_args.speculative_accept_threshold_acc == 1.0
+        and not server_args.enable_deterministic_inference
+    ):
+        server_args.speculative_use_rejection_sampling = True
+        logger.info(
+            "ROCm requires rejection sampling for correct EAGLE spec-decode "
+            "sampling; enabling speculative_use_rejection_sampling by default."
+        )
+
     if server_args.speculative_use_rejection_sampling:
         # Resolved alias by now: NEXTN -> EAGLE, Gemma4 draft -> FROZEN_KV_MTP.
         # Only the EAGLE/EAGLE3 draft workers emit a target-vocab proposal that

--- a/python/sglang/srt/constrained/base_grammar_backend.py
+++ b/python/sglang/srt/constrained/base_grammar_backend.py
@@ -13,6 +13,7 @@
 # ==============================================================================
 """The base class of a backend for grammar-guided constrained decoding."""
 
+import json
 import logging
 import time
 from concurrent.futures import Future, ThreadPoolExecutor
@@ -158,6 +159,35 @@ class GrammarMask(NamedTuple):
         self.grammar.apply_vocab_mask(logits=logits, vocab_mask=self.vocab_mask)
 
 
+def _grammar_key_contains_nul(key_type: str, key_string: str) -> bool:
+    """A NUL in a spec segfaults xgrammar's regex converter, which a JSON schema
+    also reaches through `pattern` (possibly escaped). Drop once the upstream fix
+    https://github.com/mlc-ai/xgrammar/pull/850 is in our pinned version.
+    """
+    if "\x00" in key_string:
+        return True
+    if key_type not in ("json", "structural_tag"):
+        return False
+    try:
+        decoded = json.loads(key_string)
+    except ValueError:
+        # Malformed JSON: the backend's own parse reports it as a normal error.
+        return False
+
+    stack = [decoded]
+    while stack:
+        node = stack.pop()
+        if isinstance(node, str):
+            if "\x00" in node:
+                return True
+        elif isinstance(node, dict):
+            stack.extend(node.keys())
+            stack.extend(node.values())
+        elif isinstance(node, list):
+            stack.extend(node)
+    return False
+
+
 class InvalidGrammarObject(BaseGrammarObject):
     """Represents a grammar that failed to compile, carrying the original error message."""
 
@@ -231,6 +261,11 @@ class BaseGrammarBackend:
     ) -> BaseGrammarObject:
         s = time.perf_counter()
         key_type, key_string = key
+        if _grammar_key_contains_nul(key_type, key_string):
+            logger.error(f"Rejecting {key_type} grammar containing a NUL byte")
+            return InvalidGrammarObject(
+                f"Invalid {key_type}: NUL bytes (\\u0000) are not allowed"
+            )
         if key_type == "json":
             grammar = self.dispatch_json(key_string)
         elif key_type == "regex":

--- a/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
+++ b/python/sglang/srt/distributed/device_communicators/custom_all_reduce.py
@@ -53,6 +53,7 @@ class CustomAllreduce:
         group: ProcessGroup,
         device: Union[int, str, torch.device],
         max_size=_MAX_CAR_SIZE,
+        enable_register_for_capturing: bool = True,
     ) -> None:
         """
         Args:
@@ -60,6 +61,8 @@ class CustomAllreduce:
                 default process group.
             device: the device to bind the CustomAllreduce to. If None,
                 it will be bind to f"cuda:{local_rank}".
+            enable_register_for_capturing: directly register graph-owned input
+                buffers instead of staging them through the shared input buffer.
         It is the caller's responsibility to make sure each communicator
         is bind to a unique device, and all communicators in this group
         are in the same node.
@@ -142,6 +145,9 @@ class CustomAllreduce:
         self.disabled = False
         self.original_disabled = False  # Ensure original_disabled == disabled
         self.tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
+        self.enable_register_for_capturing = (
+            enable_register_for_capturing and not self.tms_cudagraph
+        )
 
     @staticmethod
     def create_shared_buffer(
@@ -313,7 +319,9 @@ class CustomAllreduce:
             return None
         if self._IS_CAPTURING:
             if torch.cuda.is_current_stream_capturing():
-                return self._all_reduce_impl(input, registered=not self.tms_cudagraph)
+                return self._all_reduce_impl(
+                    input, registered=self.enable_register_for_capturing
+                )
             else:
                 # Could be warmup OR piecewise cuda graph split op execution.
                 # In piecewise cuda graph, split ops run eagerly outside the graph
@@ -369,6 +377,7 @@ def dispatch_custom_allreduce(
         return CustomAllreduce
 
     assert _is_hip
+    enable_register_for_capturing = _enable_register_for_capturing()
 
     if envs.SGLANG_USE_1STAGE_ALLREDUCE.is_set():
         if envs.SGLANG_USE_1STAGE_ALLREDUCE.get():
@@ -387,7 +396,10 @@ def dispatch_custom_allreduce(
     # On AMD with 1-stage AR, use sglang's CustomAllreduce
     # (AiterCustomAllreduce doesn't have deterministic_all_reduce method)
     if _use_amd_deterministic_impl():
-        return CustomAllreduce
+        return partial(
+            CustomAllreduce,
+            enable_register_for_capturing=enable_register_for_capturing,
+        )
 
     if get_bool_env_var("SGLANG_USE_AITER_AR", default="true"):
         try:
@@ -396,10 +408,11 @@ def dispatch_custom_allreduce(
             )
 
             logger.info("[AR] Using AiterCustomAllreduce (AMD default)")
-            tms_cudagraph = envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get()
+            if not enable_register_for_capturing:
+                logger.info("[AR] Using copy-in buffers during CUDA graph capture")
             return partial(
                 AiterCustomAllreduce,
-                enable_register_for_capturing=not tms_cudagraph,
+                enable_register_for_capturing=enable_register_for_capturing,
             )
         except ImportError as e:
             logger.warning(
@@ -407,9 +420,34 @@ def dispatch_custom_allreduce(
                 "falling back to sglang CustomAllreduce. Details: %s",
                 e,
             )
-            return CustomAllreduce
+            return partial(
+                CustomAllreduce,
+                enable_register_for_capturing=enable_register_for_capturing,
+            )
 
-    return CustomAllreduce
+    return partial(
+        CustomAllreduce,
+        enable_register_for_capturing=enable_register_for_capturing,
+    )
+
+
+def _enable_register_for_capturing() -> bool:
+    """Whether custom AR may bind graph-owned input pointers directly.
+
+    DSA DP-attention lanes may replay different decode graphs at the same time.
+    Direct registration bakes a peer-pointer tuple for one captured graph into
+    each custom-AR call. If another rank replays a different graph, that tuple
+    still points at the peer buffer from the original graph and reads stale
+    data. Copy-in uses one pre-registered address per rank across every graph,
+    so independently selected graph variants remain compatible.
+    """
+    if envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH.get():
+        return False
+
+    from sglang.srt.runtime_context import attention_backends, get_parallel
+
+    _prefill_backend, decode_backend = attention_backends()
+    return not (get_parallel().enable_dp_attention and decode_backend == "dsa")
 
 
 def _use_amd_deterministic_impl() -> bool:

--- a/python/sglang/srt/entrypoints/grpc_bridge.py
+++ b/python/sglang/srt/entrypoints/grpc_bridge.py
@@ -419,6 +419,9 @@ class RuntimeHandle:
     def get_server_info(self) -> str:
         result: Dict[str, Any] = dataclasses.asdict(self.tokenizer_manager.server_args)
         result.update(self.scheduler_info)
+        result["kv_events"] = (
+            self.tokenizer_manager.server_args.describe_kv_events_publisher()
+        )
         return json.dumps(msgspec_to_builtins(result), default=str)
 
     def health_check(self) -> bool:

--- a/python/sglang/srt/entrypoints/openai/protocol.py
+++ b/python/sglang/srt/entrypoints/openai/protocol.py
@@ -1081,6 +1081,14 @@ class ChatCompletionRequest(BaseModel):
         )
 
         if tool_call_constraint and has_existing_constraints:
+            if self.tool_choice == "required" or isinstance(
+                self.tool_choice, ToolChoice
+            ):
+                raise ValueError(
+                    "tool_choice 'required' or a named tool cannot be combined with "
+                    "response_format, regex, or ebnf: the tool-call constraint and the "
+                    "output constraint cannot both be honored."
+                )
             logger.warning("Constrained decoding is not compatible with tool calls.")
         elif tool_call_constraint:
             constraint_type, constraint_value = tool_call_constraint

--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -2007,15 +2007,25 @@ class OpenAIServingChat(OpenAIServingBase):
             parser = FunctionCallParser(
                 tools, self.tool_call_parser, tokenizer=self.tokenizer_manager.tokenizer
             )
-            should_try_parser = (
-                not is_required
-                or parser.detector.supports_structural_tag()
+            detector_owns_format = (
+                parser.detector.supports_structural_tag()
                 or parser.detector.parses_required_natively()
             )
+            should_try_parser = not is_required or detector_owns_format
             if should_try_parser and parser.has_tool_call(text):
                 try:
                     text, call_info_list = parser.parse_non_stream(text)
                     if not call_info_list:
+                        logger.warning(
+                            "Tool call marker present but no complete call parsed "
+                            "from %s output; dropping the incomplete call",
+                            self.tool_call_parser,
+                        )
+                        logger.debug(
+                            "Unparsed tool call output (%d chars): %r",
+                            len(text),
+                            text[:2000],
+                        )
                         return ToolCallProcessingResult(None, text, finish_reason)
 
                     tool_calls = []
@@ -2041,6 +2051,15 @@ class OpenAIServingChat(OpenAIServingBase):
                     logger.error(f"Tool call parsing error: {e}")
                     return ToolCallProcessingResult(None, text, finish_reason)
 
+            if is_required and detector_owns_format:
+                logger.warning(
+                    "Required tool call missing from %s output (%d chars)",
+                    self.tool_call_parser,
+                    len(text),
+                )
+                logger.debug("Unparsed required tool call output: %r", text[:2000])
+                return ToolCallProcessingResult(None, text, finish_reason)
+
         # json_schema constraint → JSON array output for required/named
         if is_required:
             original_finish_type = finish_reason["type"]
@@ -2049,12 +2068,28 @@ class OpenAIServingChat(OpenAIServingBase):
                 finish_reason["matched"] = None
             try:
                 tool_call_data = orjson.loads(text)
+                if isinstance(tool_call_data, dict):
+                    tool_call_data = [tool_call_data]
+                if not isinstance(tool_call_data, list):
+                    raise ValueError(
+                        "expected a JSON array of tool calls, got "
+                        f"{type(tool_call_data).__name__}"
+                    )
+                if not all(
+                    isinstance(tool, dict) and "name" in tool for tool in tool_call_data
+                ):
+                    raise ValueError(
+                        "every tool call must be a JSON object with a 'name'"
+                    )
                 tool_calls = []
                 for i, tool in enumerate(tool_call_data):
+                    parameters = json.dumps(
+                        tool.get("parameters", {}), ensure_ascii=False
+                    )
                     call_info = ToolCallItem(
                         tool_index=i,
                         name=tool["name"],
-                        parameters=json.dumps(tool["parameters"], ensure_ascii=False),
+                        parameters=parameters,
                     )
                     tool_id = self._process_tool_call_id(
                         call_info, history_tool_calls_cnt
@@ -2065,15 +2100,14 @@ class OpenAIServingChat(OpenAIServingBase):
                             index=i,
                             function=FunctionResponse(
                                 name=tool["name"],
-                                arguments=json.dumps(
-                                    tool["parameters"], ensure_ascii=False
-                                ),
+                                arguments=parameters,
                             ),
                         )
                     )
                 return ToolCallProcessingResult(tool_calls, "", finish_reason)
             except Exception as e:
                 logger.error(f"Tool call parsing error: {e}")
+                logger.debug("Unparsed required tool call output: %r", text[:2000])
                 finish_reason["type"] = original_finish_type
                 return ToolCallProcessingResult(None, text, finish_reason)
 

--- a/python/sglang/srt/entrypoints/openai/serving_responses.py
+++ b/python/sglang/srt/entrypoints/openai/serving_responses.py
@@ -859,6 +859,7 @@ class OpenAIServingResponses(OpenAIServingChat):
         is_required = request.tool_choice == "required"
         tool_call_items: list[ResponseFunctionToolCall] = []
         parsed_via_native = False
+        detector_owns_format = False
         if (
             content
             and chat_tools
@@ -870,9 +871,11 @@ class OpenAIServingResponses(OpenAIServingChat):
                 self.tool_call_parser,
                 tokenizer=self.tokenizer_manager.tokenizer,
             )
-            should_try_native = (
-                not is_required or parser.detector.supports_structural_tag()
+            detector_owns_format = (
+                parser.detector.supports_structural_tag()
+                or parser.detector.parses_required_natively()
             )
+            should_try_native = not is_required or detector_owns_format
             if should_try_native and parser.has_tool_call(content):
                 try:
                     content, call_info_list = parser.parse_non_stream(content)
@@ -891,7 +894,13 @@ class OpenAIServingResponses(OpenAIServingChat):
                 except Exception as e:
                     logger.error("Tool call parsing error: %s", e)
 
-        if content and chat_tools and is_required and not parsed_via_native:
+        if (
+            content
+            and chat_tools
+            and is_required
+            and not parsed_via_native
+            and not detector_owns_format
+        ):
             try:
                 tool_call_data = orjson.loads(content)
                 if isinstance(tool_call_data, dict):

--- a/python/sglang/srt/function_call/kimik3_detector.py
+++ b/python/sglang/srt/function_call/kimik3_detector.py
@@ -19,6 +19,7 @@ from sglang.srt.function_call.kimik3_format import (
     TOOLS_CLOSE,
     TOOLS_OPEN,
     partial_suffix_len,
+    strip_partial_marker_suffix,
     strip_response_wrappers,
 )
 from sglang.srt.function_call.kimik3_structural_tag import (
@@ -216,6 +217,20 @@ class KimiK3Detector(BaseFormatDetector):
             self._buffer = ""
             self._sent_normal_idx = 0
             return StreamingParseResult()
+
+    def finish(self, tools: List[Tool]) -> StreamingParseResult:
+        open_idx = self._buffer.find(self.bot_token)
+        if open_idx != -1:
+            section = self._buffer[open_idx + len(self.bot_token) :]
+            if not self._parse_calls(section):
+                logger.warning(
+                    "Kimi K3 tools section ended with no complete tool call; "
+                    "dropping %d buffered chars",
+                    len(section),
+                )
+            return StreamingParseResult()
+        pending = self._emit_normal_text(limit=len(self._buffer))
+        return StreamingParseResult(normal_text=strip_partial_marker_suffix(pending))
 
     def _emit_normal_text(self, limit: int | None = None) -> str:
         if limit is None:

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -81,6 +81,12 @@ else:
     deepgemm_paged_mqa_logits_native = None
     deepgemm_paged_mqa_logits_split = None
 
+# Plain-torch graph helpers: usable wherever the split-op surface is.
+from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
+    logits_head_gate_graph,
+    scale_head_gate_graph,
+)
+
 if _is_cuda:
     from sglang.kernels.ops.attention.dsa import pick_dsl_expand
 else:
@@ -138,10 +144,6 @@ if _is_cuda:
     from sglang.kernels.ops.quantization.dsv32 import (
         fused_k_indexer_norm_rope,
         fused_k_indexer_norm_rope_store,
-    )
-    from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
-        logits_head_gate_graph,
-        scale_head_gate_graph,
     )
 
     @register_custom_op(mutates_args=["topk_indices"])

--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -81,11 +81,12 @@ else:
     deepgemm_paged_mqa_logits_native = None
     deepgemm_paged_mqa_logits_split = None
 
-# Plain-torch graph helpers: usable wherever the split-op surface is.
-from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
-    logits_head_gate_graph,
-    scale_head_gate_graph,
-)
+if _is_cuda or _is_hip:
+    # Plain-torch graph helpers: usable wherever the split-op surface is.
+    from sglang.srt.layers.attention.dsa.dsa_prefill_cuda_graph import (
+        logits_head_gate_graph,
+        scale_head_gate_graph,
+    )
 
 if _is_cuda:
     from sglang.kernels.ops.attention.dsa import pick_dsl_expand

--- a/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_prefill_cuda_graph.py
@@ -14,7 +14,7 @@ from sglang.srt.model_executor.runner_backend_utils.tc_piecewise_cuda_graph impo
     get_tc_piecewise_forward_context,
     is_in_tc_piecewise_cuda_graph,
 )
-from sglang.srt.utils import is_cuda
+from sglang.srt.utils import is_cuda, is_hip
 from sglang.srt.utils.custom_op import register_custom_op
 
 _is_cuda = is_cuda()
@@ -31,7 +31,7 @@ def _is_in_piecewise_or_breakable_cuda_graph() -> bool:
     return is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph()
 
 
-if _is_cuda:
+if _is_cuda or is_hip():
 
     def _scale_head_gate_graph_fake_impl(
         weights_raw: torch.Tensor,

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -132,21 +132,33 @@ class DSATopKBackend(Enum):
         # with identical output. Everything outside the gate, RAGGED included,
         # falls through to the sgl-kernel transforms below.
         #
-        # The one-row-per-batch-entry shape test is what lets this ignore
-        # cu_seqlens_q_topk: the op indexes the page table by logit row, so it
-        # needs the row -> batch map to be the identity. With as many rows as page
-        # table rows, cu_seqlens_q_topk is necessarily all-ones and the map is the
-        # identity; the expanded shapes (spec verify / draft extend) are not, and
-        # they take the sgl-kernel path. The op is also instantiated for k=2048
-        # only.
+        # The op indexes the page table per logit row, so what it needs is the
+        # row -> page-table-row map. Two shapes provide one:
+        #
+        #   decode, and spec verify / draft extend, which sglang has already
+        #     expanded to one page-table row per logit row (repeat_interleave on
+        #     the eager path, [:bs * draft, :] under CUDA graph). The map is the
+        #     identity, so nothing is passed. This is also what lets the path
+        #     ignore cu_seqlens_q_topk, which is never None here but is
+        #     necessarily all-ones once the row counts match.
+        #   PAGED prefill, a chunk of token rows against a table with one row per
+        #     sequence. The map arrives as batch_idx_list, which the sgl-kernel
+        #     path below spends on page_table_1[batch_idx_list] -- at 100k context
+        #     that expands a 400 KB table into ~1 GB, per chunk, per indexer
+        #     layer. Forwarding it as ptRowMap indexes the table instead.
+        #
+        # RAGGED, the CP form of batch_idx_list and any k != 2048 fall through;
+        # the op is instantiated for k=2048 only.
         if (
             self.is_aiter()
             and topk_transform_method == TopkTransformMethod.PAGED
             and topk == 2048
-            and batch_idx_list is None
-            and lengths.shape[0]
-            == logits.shape[0]
-            == attn_metadata.page_table_1.shape[0]
+            and (
+                pt_row_map := _aiter_pt_row_map(
+                    logits, lengths, attn_metadata, batch_idx_list
+                )
+            )
+            is not _AITER_ROWS_UNSUPPORTED
         ):
             return _topk_transform_aiter_paged(
                 logits,
@@ -154,6 +166,7 @@ class DSATopKBackend(Enum):
                 topk,
                 attn_metadata,
                 row_starts=row_starts,
+                pt_row_map=pt_row_map,
             )
 
         if self.is_sgl_kernel() or self.is_aiter():
@@ -276,12 +289,46 @@ def _topk_unfused(
     return topk_indices
 
 
+_AITER_ROWS_UNSUPPORTED = object()
+
+
+def _aiter_pt_row_map(
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    attn_metadata,
+    batch_idx_list,
+):
+    """Row -> ``page_table_1`` row for the aiter op, or ``_AITER_ROWS_UNSUPPORTED``.
+
+    ``None`` is a valid result and means the identity, which the op reads as "no
+    map"; the sentinel is what says the shape cannot be served. They have to be
+    distinguishable, hence not ``None`` for both.
+
+    The CP form of ``batch_idx_list`` is a Python list of per-chunk batch ids
+    rather than a per-token device tensor. Converting it here would add a
+    host->device copy on every call, so it is left to the sgl-kernel path.
+    """
+    num_rows = logits.shape[0]
+    page_table = attn_metadata.page_table_1
+    if page_table is None or lengths.shape[0] != num_rows:
+        return _AITER_ROWS_UNSUPPORTED
+    if batch_idx_list is None:
+        return None if num_rows == page_table.shape[0] else _AITER_ROWS_UNSUPPORTED
+    if (
+        not isinstance(batch_idx_list, torch.Tensor)
+        or batch_idx_list.shape[0] != num_rows
+    ):
+        return _AITER_ROWS_UNSUPPORTED
+    return batch_idx_list
+
+
 def _topk_transform_aiter_paged(
     logits: torch.Tensor,
     lengths: torch.Tensor,
     topk: int,
     attn_metadata,
     row_starts: Optional[torch.Tensor] = None,
+    pt_row_map: Optional[torch.Tensor] = None,
 ) -> torch.Tensor:
     """Fused top-k + page-table transform via aiter's ``dsa_topk_transform``.
 
@@ -304,6 +351,11 @@ def _topk_transform_aiter_paged(
     Positions are row-local before the lookup, which is what a per-row gather into
     ``page_table_1`` expects, so ``row_starts`` shifts only where the row is *read*
     and needs no correction on the way out.
+
+    ``pt_row_map`` gives each logits row its page-table row, for prefill, where a
+    chunk of token rows shares one table row per sequence. ``None`` is the
+    identity. Passing the map rather than gathering ``page_table[map]`` here is
+    the point: at 100k context that gather expands a 400 KB table into ~1 GB.
     """
     import aiter
 
@@ -328,6 +380,9 @@ def _topk_transform_aiter_paged(
         row_starts = row_starts.to(dtype=torch.int32)
         row_ends = row_starts + lengths_i32
 
+    if pt_row_map is not None:
+        pt_row_map = pt_row_map.to(dtype=torch.int32)
+
     out = logits.new_full((num_rows, topk), -1, dtype=torch.int32)
     aiter.dsa_topk_transform(
         logits,
@@ -337,6 +392,7 @@ def _topk_transform_aiter_paged(
         out,
         1,
         topk,
+        ptRowMap=pt_row_map,
     )
     return out
 

--- a/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_topk_backend.py
@@ -24,6 +24,7 @@ class DSATopKBackend(Enum):
     SGL_KERNEL = "sgl-kernel"
     TORCH = "torch"
     FLASHINFER = "flashinfer"
+    AITER = "aiter"
 
     def is_sgl_kernel(self) -> bool:
         return self == DSATopKBackend.SGL_KERNEL
@@ -33,6 +34,9 @@ class DSATopKBackend(Enum):
 
     def is_flashinfer(self) -> bool:
         return self == DSATopKBackend.FLASHINFER
+
+    def is_aiter(self) -> bool:
+        return self == DSATopKBackend.AITER
 
     def should_use_topk_v2(self) -> bool:
         return self.is_sgl_kernel() and envs.SGLANG_OPT_USE_TOPK_V2.get()
@@ -44,7 +48,10 @@ class DSATopKBackend(Enum):
         topk: int,
         row_starts: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
-        if self.is_sgl_kernel():
+        # The aiter backend replaces only the fused PAGED transform below; the
+        # unfused selection has no aiter equivalent worth a separate path, so it
+        # shares the sgl-kernel one.
+        if self.is_sgl_kernel() or self.is_aiter():
             from sgl_kernel import fast_topk_v2
 
             return fast_topk_v2(score, lengths, topk, row_starts=row_starts)
@@ -119,7 +126,37 @@ class DSATopKBackend(Enum):
         # dispatched to v2 above.
         assert attn_metadata.page_table_1 is not None
 
-        if self.is_sgl_kernel():
+        # The aiter backend fuses selection and the page-table gather into one
+        # kernel (aiter.dsa_topk_transform), which on MI355X measured 1.82-2.22x
+        # fast_topk_transform_fused across batch 1-256 on GLM-5.2 decode logits,
+        # with identical output. Everything outside the gate, RAGGED included,
+        # falls through to the sgl-kernel transforms below.
+        #
+        # The one-row-per-batch-entry shape test is what lets this ignore
+        # cu_seqlens_q_topk: the op indexes the page table by logit row, so it
+        # needs the row -> batch map to be the identity. With as many rows as page
+        # table rows, cu_seqlens_q_topk is necessarily all-ones and the map is the
+        # identity; the expanded shapes (spec verify / draft extend) are not, and
+        # they take the sgl-kernel path. The op is also instantiated for k=2048
+        # only.
+        if (
+            self.is_aiter()
+            and topk_transform_method == TopkTransformMethod.PAGED
+            and topk == 2048
+            and batch_idx_list is None
+            and lengths.shape[0]
+            == logits.shape[0]
+            == attn_metadata.page_table_1.shape[0]
+        ):
+            return _topk_transform_aiter_paged(
+                logits,
+                lengths,
+                topk,
+                attn_metadata,
+                row_starts=row_starts,
+            )
+
+        if self.is_sgl_kernel() or self.is_aiter():
             from sgl_kernel import (
                 fast_topk_transform_fused,
                 fast_topk_transform_ragged_fused,
@@ -237,6 +274,71 @@ def _topk_unfused(
     topk_indices[:, :valid_topk] = topk_local_indices
 
     return topk_indices
+
+
+def _topk_transform_aiter_paged(
+    logits: torch.Tensor,
+    lengths: torch.Tensor,
+    topk: int,
+    attn_metadata,
+    row_starts: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Fused top-k + page-table transform via aiter's ``dsa_topk_transform``.
+
+    Returns the transformed page indices ``(num_rows, topk)`` int32 -- physical
+    page_size=1 KV slots, ``-1`` padded, identical in meaning to what
+    ``fast_topk_transform_fused`` returns for the same inputs.
+
+    One kernel does both halves: a cooperative radix-select picks the top-k of
+    ``logits[row, start:start + lengths[row]]``, then a tail pass maps each winner
+    through ``page_table_1`` before the indices are ever written back. That removes
+    both the second launch and the ``(num_rows, topk)`` round trip that sglang's
+    post-top-k op chain pays (see ``_topk_transform_512_vectorized``).
+
+    This consumes the page_size=1 table rather than the compact ``real_page_table``
+    that ``_topk_transform_v2_paged`` uses. The op itself handles any power-of-two
+    page size, but on HIP the indexer still reads ``page_table_1``, so the wide
+    table exists regardless (see ``dsa_drop_wide_page_table``, which excludes HIP)
+    and there is nothing to save by bypassing it yet.
+
+    Positions are row-local before the lookup, which is what a per-row gather into
+    ``page_table_1`` expects, so ``row_starts`` shifts only where the row is *read*
+    and needs no correction on the way out.
+    """
+    import aiter
+
+    num_rows = logits.shape[0]
+
+    # Same ABI the v2 CUDA path asserts: the indexer emits fp32 with unit row
+    # stride, possibly as a padded view (stride(0) > width, so not contiguous).
+    # Assert the real requirement instead of forcing a copy of the wide buffer.
+    assert (
+        logits.dtype == torch.float32 and logits.stride(1) == 1
+    ), f"aiter top-k expects fp32 scores with unit row stride, got {logits.dtype=} {logits.stride()=}"
+
+    page_table = attn_metadata.page_table_1
+    assert page_table.dtype == torch.int32
+
+    lengths_i32 = lengths.to(dtype=torch.int32)
+    if row_starts is None:
+        # The kernel reads a null rowStarts as "every row starts at 0", which is
+        # what decode wants and what saves a per-call zeros tensor.
+        row_ends = lengths_i32
+    else:
+        row_starts = row_starts.to(dtype=torch.int32)
+        row_ends = row_starts + lengths_i32
+
+    out = logits.new_full((num_rows, topk), -1, dtype=torch.int32)
+    aiter.dsa_topk_transform(
+        logits,
+        row_starts,
+        row_ends,
+        page_table,
+        out,
+        1,
+        topk,
+    )
+    return out
 
 
 def _topk_transform_v2_paged(

--- a/python/sglang/srt/layers/attention/dsa/utils.py
+++ b/python/sglang/srt/layers/attention/dsa/utils.py
@@ -140,9 +140,9 @@ def is_dsa_prefill_cp_round_robin_split():
 # site (e.g. the indexer also excludes DSA prefill context parallelism).
 def is_graph_dsa_split_op_surface(forward_batch: "ForwardBatch") -> bool:
     return (
-        is_cuda()
+        (is_cuda() or is_hip())
         and (is_in_tc_piecewise_cuda_graph() or is_in_breakable_cuda_graph())
-        and forward_batch.forward_mode.is_extend_without_speculative()
+        and forward_batch.forward_mode.is_extend()
     )
 
 

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -719,9 +719,15 @@ class DeepseekSparseAttnBackend(
         metadata.topk_v2_plan.copy_(plan_topk_v2(metadata.dsa_seqlens_expanded))
 
     def _get_fused_topk_page_table(self, topk_indices: torch.Tensor) -> torch.Tensor:
+        # The aiter backend's transform returns the same thing the sgl-kernel one
+        # does -- (num_rows, topk) int32 physical page_size=1 slots, -1 padded --
+        # so the fused table is likewise the indices themselves. It is listed
+        # explicitly rather than by inverting the check because TORCH, whose
+        # topk_func selects without transforming, must keep raising.
         if (
             self.dsa_topk_backend.is_sgl_kernel()
             or self.dsa_topk_backend.is_flashinfer()
+            or self.dsa_topk_backend.is_aiter()
         ):
             return topk_indices
         raise RuntimeError(

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_trtllm.py
@@ -517,6 +517,7 @@ def _compute_g1_scale_c(
     g1_alphas: torch.Tensor,
     g1_alphas_up: torch.Tensor,
     is_gated: bool,
+    activation: Optional[str] = None,
 ) -> torch.Tensor:
     """TRT-LLM GEMM1-output scale for the up (w3) half.
 
@@ -526,6 +527,11 @@ def _compute_g1_scale_c(
     scale passes g1_alphas as g1_alphas_up and recovers the single-scale value;
     non-gated (Relu2) has no gate half, so it is just 1/a2_scale per expert.
     """
+    if activation == "situ":
+        # SiTU consumes both GEMM1 scales before tanh; scale_c carries only
+        # the GEMM2 input requantization factor.
+        num_experts = g1_alphas.shape[0]
+        return w2_input_scale_quant.to(torch.float32).expand(num_experts).contiguous()
     if is_gated:
         return (w2_input_scale_quant * g1_alphas_up).to(torch.float32)
     num_experts = g1_alphas.shape[0]
@@ -596,7 +602,11 @@ def align_fp4_moe_weights_for_flashinfer_trtllm(layer: Module) -> None:
     g1_alphas = cast(torch.Tensor, layer.g1_alphas)
     g1_alphas_up = cast(torch.Tensor, getattr(layer, "g1_alphas_up", g1_alphas))
     g1_scale_c = _compute_g1_scale_c(
-        w2_input_scale_quant, g1_alphas, g1_alphas_up, layer.moe_runner_config.is_gated
+        w2_input_scale_quant,
+        g1_alphas,
+        g1_alphas_up,
+        layer.moe_runner_config.is_gated,
+        activation=layer.moe_runner_config.activation,
     )
     copy_or_rebind_param(layer, "g1_scale_c", g1_scale_c)
 
@@ -612,6 +622,7 @@ def get_activation_type(activation: str, is_gated: bool = True) -> int:
         _ACTIVATION_STR_TO_TYPE = {
             "silu": ActivationType.Swiglu,
             "gelu": ActivationType.Geglu,
+            "situ": ActivationType.Situ,
         }
     else:
         _ACTIVATION_STR_TO_TYPE = {
@@ -956,7 +967,7 @@ def fused_experts_none_to_flashinfer_trtllm_fp4(
     from sglang.srt.layers.moe.topk import TopKOutputChecker
     from sglang.srt.layers.moe.utils import RoutingMethodType
 
-    _SUPPORTED_FP4_ACTIVATIONS = {"silu", "relu2", "gelu"}
+    _SUPPORTED_FP4_ACTIVATIONS = {"silu", "relu2", "gelu", "situ"}
     assert runner_config.activation in _SUPPORTED_FP4_ACTIVATIONS, (
         f"Only {_SUPPORTED_FP4_ACTIVATIONS} are supported for FP4 MoE, "
         f"got '{runner_config.activation}'."

--- a/python/sglang/srt/layers/moe/topk.py
+++ b/python/sglang/srt/layers/moe/topk.py
@@ -1573,9 +1573,17 @@ def biased_grouped_topk_gpu(
         ), f"Number of tokens mismatch: hidden_states.shape[0] = {hidden_states.shape[0]}, gating_output.shape[0] = {gating_output.shape[0]}"
         topk_weights = torch.empty((token, topk), dtype=torch.float32, device=device)
         topk_ids = torch.empty((token, topk), dtype=torch.int32, device=device)
+        # Don't re-downcast an fp32 correction bias: an offset bias loses too many
+        # levels in bf16 and reorders top-k. A bf16 bias keeps the original path.
+        if correction_bias.dtype == torch.float32:
+            aiter_gating_output = gating_output.to(torch.float32)
+            aiter_correction_bias = correction_bias
+        else:
+            aiter_gating_output = gating_output
+            aiter_correction_bias = correction_bias.to(dtype=gating_output.dtype)
         aiter_biased_grouped_topk(
-            gating_output,
-            correction_bias.to(dtype=gating_output.dtype),
+            aiter_gating_output,
+            aiter_correction_bias,
             topk_weights,
             topk_ids,
             num_expert_group,

--- a/python/sglang/srt/layers/quantization/modelopt_quant.py
+++ b/python/sglang/srt/layers/quantization/modelopt_quant.py
@@ -736,6 +736,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         packed_modules_mapping: Optional[Dict[str, List[str]]],
         quantized_layers: Dict[str, Dict[str, Any]],
         fp8_config: ModelOptFp8Config,
+        fp8_pb_wo_config: Fp8Config,
         nvfp4_config: ModelOptFp4Config,
         nvfp4a16_config: ModelOptFp4Config,
         mxfp8_config: Fp8Config,
@@ -743,6 +744,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
         super().__init__(kv_cache_quant_algo, exclude_modules, packed_modules_mapping)
         self.quantized_layers = quantized_layers
         self.fp8_config = fp8_config
+        self.fp8_pb_wo_config = fp8_pb_wo_config
         self.mxfp8_config = mxfp8_config
         self.nvfp4_config = nvfp4_config
         self.nvfp4a16_config = nvfp4a16_config
@@ -827,6 +829,12 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             exclude_modules=[],
             packed_modules_mapping=packed_modules_mapping,
         )
+        fp8_pb_wo_config = Fp8Config(
+            is_checkpoint_fp8_serialized=True,
+            activation_scheme="dynamic",
+            weight_block_size=[128, 128],
+            packed_modules_mapping=packed_modules_mapping,
+        )
         mxfp8_config = Fp8Config(
             is_checkpoint_fp8_serialized=True,
             activation_scheme="dynamic",
@@ -856,6 +864,7 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
             packed_modules_mapping=packed_modules_mapping,
             quantized_layers=quantized_layers,
             fp8_config=fp8_config,
+            fp8_pb_wo_config=fp8_pb_wo_config,
             mxfp8_config=mxfp8_config,
             nvfp4_config=nvfp4_config,
             nvfp4a16_config=nvfp4a16_config,
@@ -937,6 +946,8 @@ class ModelOptMixedPrecisionConfig(ModelOptQuantConfig):
                 return UnquantizedLinearMethod()
             if quant_algo == "FP8":
                 return ModelOptFp8LinearMethod(self.fp8_config)
+            if quant_algo == "FP8_PB_WO":
+                return Fp8LinearMethod(self.fp8_pb_wo_config)
             if quant_algo == "MXFP8":
                 return Fp8LinearMethod(self.mxfp8_config)
             if quant_algo == "NVFP4":
@@ -2471,9 +2482,12 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
         )
 
         if layer.moe_runner_config.is_gated and self.enable_flashinfer_trtllm_moe:
+            runner_config = layer.moe_runner_config
+            is_situ = runner_config.activation == "situ"
             gemm1_clamp_limit = (
-                layer.moe_runner_config.gemm1_clamp_limit
-                or layer.moe_runner_config.swiglu_limit
+                None
+                if is_situ
+                else (runner_config.gemm1_clamp_limit or runner_config.swiglu_limit)
             )
             if gemm1_clamp_limit is not None:
                 copy_or_rebind_param(
@@ -2482,21 +2496,26 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
                     (gemm1_clamp_limit / layer.g1_alphas).to(torch.float32),
                 )
 
-            if layer.moe_runner_config.gemm1_alpha is not None:
+            if runner_config.gemm1_alpha is not None:
                 copy_or_rebind_param(
                     layer,
                     "gemm1_alpha",
                     torch.full_like(
                         layer.g1_alphas,
-                        layer.moe_runner_config.gemm1_alpha,
+                        runner_config.gemm1_alpha,
                         dtype=torch.float32,
                     ),
                 )
-                copy_or_rebind_param(
-                    layer,
-                    "gemm1_beta",
-                    (1.0 / layer.g1_alphas).to(torch.float32),
+                gemm1_beta = (
+                    torch.full_like(
+                        layer.g1_alphas,
+                        runner_config.gemm1_clamp_limit,
+                        dtype=torch.float32,
+                    )
+                    if is_situ
+                    else (1.0 / layer.g1_alphas).to(torch.float32)
                 )
+                copy_or_rebind_param(layer, "gemm1_beta", gemm1_beta)
 
         # TODO: for flashinfer always do MOE_NVFP4_DISPATCH
         use_dispatch_fp4 = not self.quant_config.use_per_token_activation and (
@@ -2762,9 +2781,9 @@ class ModelOptNvFp4FusedMoEMethod(FusedMoEMethodBase):
             self, "_moe_runner_backend", get_moe_runner_backend()
         )
 
-        assert (
-            activation in _SUPPORTED_ACT_STRS
-        ), f"{activation=} not in supported {_SUPPORTED_ACT_STRS}"
+        assert activation in _SUPPORTED_ACT_STRS or (
+            activation == "situ" and moe_runner_backend.is_flashinfer_trtllm()
+        ), f"{activation=} is unsupported by {moe_runner_backend}"
         moe_runner_config = self.moe_runner_config
 
         if moe_runner_backend.is_marlin():

--- a/python/sglang/srt/layers/quantization/quark/quark.py
+++ b/python/sglang/srt/layers/quantization/quark/quark.py
@@ -322,6 +322,14 @@ class QuarkConfig(QuantizationConfig):
         self.kv_cache_config = kv_cache_config
         self.pack_method = pack_method
         self.exclude_layers = cast(list[str], self.quant_config.get("exclude", []))
+        # Both are consumed by _is_draft_layer(), which has to tell an appended
+        # MTP/NextN draft layer from a target-model one. "No draft stack" is
+        # spelled None as often as it is spelled absent -- ModelConfig defaults
+        # the same field to None -- so coerce rather than let range() raise.
+        self.num_hidden_layers = getattr(hf_config, "num_hidden_layers", None)
+        self.num_nextn_predict_layers = int(
+            getattr(hf_config, "num_nextn_predict_layers", 0) or 0
+        )
         self.is_prequantized = is_prequantized
         self.dequantization_config = dequantization_config
         # Load-as-is FP8 config for excluded layers of a mixed-precision source
@@ -555,6 +563,7 @@ class QuarkConfig(QuantizationConfig):
 
         return cls(
             quant_config=config,
+            hf_config=config.get("hf_config"),
             kv_cache_group=kv_cache_group,
             kv_cache_config=kv_cache_config,
             pack_method=pack_method,
@@ -895,12 +904,24 @@ class QuarkConfig(QuantizationConfig):
     def get_scaled_act_names(self) -> List[str]:
         return []
 
+    def _is_draft_layer(self, layer: str) -> bool:
+        """Whether an excluded layer belongs to the MTP/NextN draft stack."""
+        if layer.startswith("mtp."):
+            return True
+        if self.num_hidden_layers is None:
+            return False
+        base = self.num_hidden_layers
+        return any(
+            layer.startswith(f"model.layers.{base + i}.")
+            for i in range(self.num_nextn_predict_layers)
+        )
+
     def can_fuse_shared_expert(self) -> bool:
         # Shared-expert body excluded from quant; the gate must not veto fusion.
         if any(
             "shared_expert" in layer
             and "shared_expert_gate" not in layer
-            and not layer.startswith("mtp.")
+            and not self._is_draft_layer(layer)
             for layer in self.exclude_layers
         ):
             return False

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -1007,9 +1007,11 @@ def build_full_draft_pools(
     controller = tree_cache.cache_controller
     host_pool_group = controller.mem_pool_host
 
+    # Note(kpham-sgl): DCP x DSpark draft KV is replicated and spans the virtual
+    # loc space, so match the target host's logical_size instead of physical size.
     draft_host_pool = _build_mha_mla_host_pool(
         pool=pool,
-        host_to_device_ratio=host_pool_group.size / pool.size,
+        host_to_device_ratio=host_pool_group.logical_size / pool.size,
         page_size=controller.page_size,
         layout=server_args.hicache_mem_layout,
         allocator_type=_get_allocator_type(server_args),

--- a/python/sglang/srt/mem_cache/kv_cache_builder.py
+++ b/python/sglang/srt/mem_cache/kv_cache_builder.py
@@ -117,7 +117,7 @@ def _register_legacy_hicache_draft(
     # so that host indices stay 1-to-1 between target and draft KV caches.
     primary_host_pool = tree_cache.cache_controller.mem_pool_host
     host_pool_kwargs = dict(
-        host_to_device_ratio=primary_host_pool.size / pool.size,
+        host_to_device_ratio=primary_host_pool.logical_size / pool.size,
         host_size=0,
         page_size=page_size,
         layout=server_args.hicache_mem_layout,

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -455,6 +455,13 @@ class DeepseekV2MLP(nn.Module):
         return x
 
 
+def _is_glm_moe_dsa(config) -> bool:
+    """True for GLM-5.2 GlmMoeDsa models -- the ``"GlmMoeDsa"`` substring matches
+    both the main arch ``GlmMoeDsaForCausalLM`` and the NextN draft head
+    ``GlmMoeDsaForCausalLMNextN`` (rewritten in ``configs/model_config.py``)."""
+    return any("GlmMoeDsa" in arch for arch in (config.architectures or []))
+
+
 class MoEGate(nn.Module):
     def __init__(
         self,
@@ -476,7 +483,9 @@ class MoEGate(nn.Module):
 
         if config.topk_method == "noaux_tc" and not is_hash_moe:
             correction_bias_dtype = torch.float32
-            if quant_config is not None:
+            # GLM-5.2's bias sits at an offset where its spread is only a few bf16 ULPs
+            # wide, so bf16 collapses it and reorders top-k routing. HF stores it fp32.
+            if quant_config is not None and not _is_glm_moe_dsa(config):
                 if _use_aiter and quant_config.get_name() in (
                     "fp8",
                     "compressed_tensors",

--- a/python/sglang/srt/models/kimi_k3.py
+++ b/python/sglang/srt/models/kimi_k3.py
@@ -73,6 +73,7 @@ from sglang.srt.layers.moe.utils import (
     get_moe_runner_backend,
 )
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
+from sglang.srt.layers.quantization.fp8_utils import block_quant_dequant
 from sglang.srt.layers.radix_linear_attention import RadixLinearAttention
 from sglang.srt.layers.utils import PPMissingLayer, get_layer_id
 from sglang.srt.layers.vocab_parallel_embedding import (
@@ -140,6 +141,35 @@ _k3_dense_mlp_attn_tp = envs.SGLANG_K3_DENSE_MLP_ATTN_TP.get()
 
 def _cdiv(a: int, b: int) -> int:
     return (a + b - 1) // b
+
+
+def _uses_modelopt_fp8_pb_wo(
+    quant_config: Optional[QuantizationConfig], prefix: str
+) -> bool:
+    resolver = getattr(quant_config, "_resolve_quant_algo", None)
+    return resolver is not None and resolver(prefix) == "FP8_PB_WO"
+
+
+def _maybe_map_fp8_pb_scale_name(name: str, params_dict: dict) -> str:
+    """Map ModelOpt FP8_PB_WO scale keys to SGLang block-FP8 params."""
+    if name.endswith(".weight_scale"):
+        candidate = name.removesuffix(".weight_scale") + ".weight_scale_inv"
+        if candidate in params_dict:
+            return candidate
+    return name
+
+
+def _get_k3_dense_weight(module: nn.Module) -> torch.Tensor:
+    """Return a dense weight with serialized block-FP8 scales applied."""
+    weight = module.weight.data
+    if not hasattr(module, "weight_scale_inv"):
+        return weight
+    return block_quant_dequant(
+        weight,
+        module.weight_scale_inv,
+        module.quant_method.weight_block_size,
+        module.params_dtype,
+    )
 
 
 def _k3_bf16_gemm(
@@ -457,17 +487,17 @@ class KimiK3MoE(nn.Module):
             quant_config=quant_config,
             routed_scaling_factor=self.routed_scaling_factor,
             apply_routed_scaling_factor_on_output=self.experts.should_fuse_routed_scaling_factor_in_topk,
-            # flashinfer_mxfp4 + situ consumes precomputed routing
-            # (PackedPrecomputed): keep the radix router in the TopK layer
-            # and hand its ids/weights to the MoE op. Other quantized paths
-            # keep the runner-resolved format (marlin -> standard anyway,
-            # bypassed only for the public logits-routing path).
+            # TRT-LLM cannot consume fused-front's row-strided router logits;
+            # keep K3's FP32 router and pass precomputed top-k instead.
             output_format=(
                 TopKOutputFormat.STANDARD
                 if quant_config is None
                 or (
                     config.hidden_act == "situ"
-                    and get_moe_runner_backend().is_flashinfer_mxfp4()
+                    and (
+                        get_moe_runner_backend().is_flashinfer_mxfp4()
+                        or get_moe_runner_backend().is_flashinfer_trtllm()
+                    )
                 )
                 # mega pre-dispatch consumes raw topk_ids/topk_weights
                 or get_moe_a2a_backend().is_megamoe()
@@ -1385,11 +1415,12 @@ class KimiK3DeltaAttention(nn.Module):
         self.use_full_rank_gate = config.linear_attn_config.get(
             "use_full_rank_gate", False
         )
+        self._bfa_uses_block_fp8 = self.use_full_rank_gate and _uses_modelopt_fp8_pb_wo(
+            quant_config, f"{prefix}.b_proj"
+        )
 
         # The fused path hardcodes tp_size sharding, so require attn_tp == tp.
-        # For the full-rank gate (K3) the checkpoint quantizes only the MoE
-        # experts; attention linears resolve to UnquantizedLinearMethod, so a
-        # non-None quant_config is fine for the merged projection.
+        # Full-rank K3 also fuses mixed block-FP8 attention projections.
         self.do_fuse_qkvbfg = self.attn_tp_size == self.tp_size and (
             quant_config is None or self.use_full_rank_gate
         )
@@ -1425,6 +1456,8 @@ class KimiK3DeltaAttention(nn.Module):
                 tp_rank=self.attn_tp_rank,
                 tp_size=self.attn_tp_size,
                 prefix=f"{prefix}.b_proj",
+                # TP8 shards K3's 96 beta rows below the 128-row FP8 block.
+                skip_block_quant_check=self._bfa_uses_block_fp8,
             )
             self.f_a_proj = ReplicatedLinear(
                 self.hidden_size,
@@ -1445,6 +1478,7 @@ class KimiK3DeltaAttention(nn.Module):
             # Merged [f_a | b] weight, built after weight loading by
             # _merge_bfa_weights().
             self._bfa_w: Optional[torch.Tensor] = None
+            self._bfa_f_b_w: Optional[torch.Tensor] = None
         elif self.do_fuse_qkvbfg:
             self.qkvb_sizes = [
                 projection_size,
@@ -1661,15 +1695,24 @@ class KimiK3DeltaAttention(nn.Module):
         and the width is padded to a multiple of 8 so every fused-output row
         stays 16-byte aligned for vectorized consumers (tiny-GEMM on f_b).
 
-        Called once from load_weights (after all weights are loaded, before
-        cuda graph capture)."""
+        Called once after weight loading. Block-FP8 inputs are dequantized into
+        the BF16 tiny-GEMM buffers here."""
         if not self.use_full_rank_gate:
             return
         if _is_npu:
             return
-        self._bfa_w, sizes = _merge_weights_as_views(
-            [self.f_a_proj, self.b_proj], pad_rows_to=8
-        )
+        mods = [self.f_a_proj, self.b_proj]
+        if self._bfa_uses_block_fp8:
+            weights = [_get_k3_dense_weight(mod) for mod in mods]
+            sizes = [weight.shape[0] for weight in weights]
+            pad = (-sum(sizes)) % 8
+            if pad:
+                weights.append(weights[0].new_zeros((pad, weights[0].shape[1])))
+            self._bfa_w = torch.cat(weights, dim=0).contiguous()
+            self._bfa_f_b_w = _get_k3_dense_weight(self.f_b_proj).contiguous()
+        else:
+            self._bfa_w, sizes = _merge_weights_as_views(mods, pad_rows_to=8)
+            self._bfa_f_b_w = self.f_b_proj.weight
         self._bfa_fa_size, self._bfa_b_size = sizes
 
     def _prepare_fused_decode(self) -> None:
@@ -1748,7 +1791,7 @@ class KimiK3DeltaAttention(nn.Module):
                     alt.wait_stream(cur)
                     with torch.cuda.stream(alt):
                         bfa = gemm(hidden_states, w)
-                        forget_gate = gemm(bfa[..., :n_fa], self.f_b_proj.weight)
+                        forget_gate = gemm(bfa[..., :n_fa], self._bfa_f_b_w)
                         beta = bfa[..., n_fa : n_fa + n_b]
                     fused_states, _ = self.fused_qkvg_proj(hidden_states)
                     qkv, g_proj_states = torch.split(
@@ -1760,7 +1803,7 @@ class KimiK3DeltaAttention(nn.Module):
                 fused_states, _ = self.fused_qkvg_proj(hidden_states)
                 qkv, g_proj_states = torch.split(fused_states, self.split_sizes, dim=-1)
                 bfa = gemm(hidden_states, w)
-                forget_gate = gemm(bfa[..., :n_fa], self.f_b_proj.weight)
+                forget_gate = gemm(bfa[..., :n_fa], self._bfa_f_b_w)
                 beta = bfa[..., n_fa : n_fa + n_b]
             else:
                 fused_states, _ = self.fused_qkvg_proj(hidden_states)
@@ -2883,6 +2926,8 @@ class KimiK3LinearForCausalLM(nn.Module):
         for args in weights:
             name, loaded_weight = args[:2]
             kwargs = args[2] if len(args) > 2 else {}
+            if name.endswith(".weight_scale") and loaded_weight.ndim == 4:
+                loaded_weight = loaded_weight[:, 0, :, 0]
 
             layer_id = get_layer_id(name)
             if layer_id is not None and (
@@ -2904,13 +2949,20 @@ class KimiK3LinearForCausalLM(nn.Module):
 
             # MLA: fuse q_a_proj + kv_a_proj_with_mqa → fused_qkv_a_proj_with_mqa
             if ".q_a_proj." in name or ".kv_a_proj_with_mqa." in name:
+                is_q_a = ".q_a_proj." in name
                 fused_name = name.replace(".q_a_proj.", ".fused_qkv_a_proj_with_mqa.")
                 fused_name = fused_name.replace(
                     ".kv_a_proj_with_mqa.", ".fused_qkv_a_proj_with_mqa."
                 )
+                fused_name = _maybe_map_fp8_pb_scale_name(fused_name, params_dict)
                 if fused_name in params_dict:
                     param = params_dict[fused_name]
-                    if ".q_a_proj." in name:
+                    if fused_name.endswith(".weight_scale_inv"):
+                        offset = 0 if is_q_a else _cdiv(self.config.q_lora_rank, 128)
+                        param.data[offset : offset + loaded_weight.shape[0]].copy_(
+                            loaded_weight
+                        )
+                    elif is_q_a:
                         param.data[: loaded_weight.shape[0]].copy_(loaded_weight)
                     else:
                         q_lora_rank = self.config.q_lora_rank or 0
@@ -2947,6 +2999,7 @@ class KimiK3LinearForCausalLM(nn.Module):
                 name = name.replace(weight_name, param_name)
                 if name.endswith(".bias") and name not in params_dict:
                     continue
+                name = _maybe_map_fp8_pb_scale_name(name, params_dict)
                 param = params_dict[name]
                 weight_loader = param.weight_loader
                 weight_loader(param, loaded_weight, shard_id)
@@ -2983,13 +3036,18 @@ class KimiK3LinearForCausalLM(nn.Module):
                     name = maybe_remap_kv_scale_name(name, params_dict)
                     if name is None:
                         continue
+                    name = _maybe_map_fp8_pb_scale_name(name, params_dict)
                     if name not in params_dict:
                         continue
                     param = params_dict[name]
-                    weight_loader = getattr(
-                        param, "weight_loader", default_weight_loader
-                    )
-                    weight_loader(param, loaded_weight, **kwargs)
+                    if name.endswith(".b_proj.weight_scale_inv"):
+                        # All TP ranks share K3's single beta output-scale block.
+                        param.data.copy_(loaded_weight)
+                    else:
+                        weight_loader = getattr(
+                            param, "weight_loader", default_weight_loader
+                        )
+                        weight_loader(param, loaded_weight, **kwargs)
             loaded_params.add(name)
 
         self.post_load_weights()
@@ -3007,7 +3065,8 @@ class KimiK3LinearForCausalLM(nn.Module):
             if isinstance(layer, PPMissingLayer):
                 continue
             self_attn = layer.self_attn
-            w_kc, w_vc = self_attn.kv_b_proj.weight.unflatten(
+            kv_b_weight = _get_k3_dense_weight(self_attn.kv_b_proj)
+            w_kc, w_vc = kv_b_weight.unflatten(
                 0, (-1, self_attn.qk_nope_head_dim + self_attn.v_head_dim)
             ).split([self_attn.qk_nope_head_dim, self_attn.v_head_dim], dim=1)
             self_attn.w_kc = w_kc.transpose(1, 2).contiguous().transpose(1, 2)
@@ -3065,7 +3124,7 @@ class KimiK3LinearForCausalLM(nn.Module):
 
             if precompile_k3_recompute_w_u_kernel(
                 num_heads=layer.self_attn.local_num_heads,
-                dtype=layer.self_attn.o_proj.weight.dtype,
+                dtype=layer.self_attn.o_proj.params_dtype,
                 device=layer.self_attn.dt_bias.device,
             ):
                 rank0_log("Precompiled the Kimi-K3 KDA prefill kernel.")

--- a/python/sglang/srt/parser/reasoning_parser.py
+++ b/python/sglang/srt/parser/reasoning_parser.py
@@ -542,6 +542,12 @@ class KimiK3Detector(BaseReasoningFormatDetector):
         open_idx = text.find(self.think_start_token)
         start = open_idx + len(self.think_start_token) if open_idx != -1 else 0
         close_idx = text.find(self.think_end_token, start)
+        tools_idx = text.find(self.tool_start_token, start)
+        if close_idx != -1 and tools_idx != -1 and tools_idx < close_idx:
+            return StreamingParseResult(
+                reasoning_text=strip_partial_marker_suffix(text[start:tools_idx]),
+                normal_text=self._clean_content(text[tools_idx:]),
+            )
         if close_idx == -1:
             channel_idx = self._next_channel_idx(text, start)
             if channel_idx != -1:
@@ -583,7 +589,8 @@ class KimiK3Detector(BaseReasoningFormatDetector):
                     self.stripped_think_start = True
 
             close_idx = buf.find(self.think_end_token)
-            if close_idx != -1:
+            tools_idx = buf.find(self.tool_start_token)
+            if close_idx != -1 and not (tools_idx != -1 and tools_idx < close_idx):
                 reasoning_text = buf[:close_idx]
                 self._buffer = buf[close_idx + len(self.think_end_token) :]
                 self._in_reasoning = False

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -359,7 +359,7 @@ DSA_CHOICES = [
 ]
 NSA_CHOICES = DSA_CHOICES  # deprecated alias
 
-DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer"]
+DSA_TOPK_BACKEND_CHOICES = ["sgl-kernel", "torch", "flashinfer", "aiter"]
 
 DSA_PAGED_MQA_LOGITS_BACKEND_CHOICES = ["auto", "deepgemm", "cutedsl", "aiter"]
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -6028,11 +6028,6 @@ class ServerArgs:
 
         run_post_process_pass(self, _fa4_page_constraint)
 
-        # AMD platforms backends
-        if resolved_view(self).attention_backend == "aiter":
-            if model_config.context_len > 8192:
-                self.mem_fraction_static *= 0.85
-
         # Other platforms backends
         run_post_process_pass(self, _attention_backend_platform_fallbacks)
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -7405,11 +7405,11 @@ class ServerArgs:
                 "backup and the storage keys must become dcp_rank-aware "
                 "first. Run HiCache+DCP with L1/L2 only."
             )
-        if self.speculative_algorithm is not None:
+        if self.speculative_algorithm not in (None, "DSPARK"):
             raise NotImplementedError(
-                "HiCache with --dcp-size > 1 does not support speculative "
-                "decoding yet (the draft-model host pool has no DCP index "
-                "translation)."
+                "HiCache with --dcp-size > 1 only supports DSPARK speculative "
+                "decoding; other draft-model host pools have no DCP index "
+                "translation."
             )
         if self.enable_lmcache:
             raise NotImplementedError(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -9608,6 +9608,13 @@ class ServerArgs:
         ``--speculative-draft-load-format`` needs its own transfer engine."""
         return remote_instance_transfer_engine_of(self, load_format)
 
+    @property
+    def kv_event_block_size(self) -> int:
+        """Width KV events are emitted at: under DCP the radix tree pages at
+        ``page_size * dcp_size`` (``mem_cache/kv_cache_builder.py``).
+        """
+        return self.page_size * self.dcp_size
+
     def describe_kv_events_publisher(self) -> Optional[dict]:
         """Return a structured description of this server's KV-event
         publisher, or `None` if publishing is disabled / misconfigured.
@@ -9633,10 +9640,13 @@ class ServerArgs:
                 "topic": "",                      # ZMQ topic prefix on the
                                                   # SUB filter (empty =
                                                   # subscribe-all)
-                "block_size": <page_size>,        # subscribers MUST hash
-                                                  # prompts at this size
-                "dp_size": <dp_size>,             # number of SUB sockets
-                                                  # to open
+                "block_size": <kv_event_block_size>,  # subscribers MUST
+                                                  # hash prompts at this size
+                "dp_size": <dp_size>,             # number of SUB sockets to
+                                                  # open; not DCP-scaled, as
+                                                  # DCP shards within a rank
+                                                  # rather than adding
+                                                  # publishers
             }
 
         Returns None (i.e. "no publisher to describe") when any of:
@@ -9691,7 +9701,7 @@ class ServerArgs:
             "endpoint_host": host,
             "endpoint_port_base": port,
             "topic": cfg.topic,
-            "block_size": page_size,
+            "block_size": self.kv_event_block_size,
             "dp_size": self.dp_size,
         }
 

--- a/python/sglang/srt/speculative/eagle_utils.py
+++ b/python/sglang/srt/speculative/eagle_utils.py
@@ -6,6 +6,8 @@ from enum import IntEnum
 from typing import TYPE_CHECKING, List, Optional, Tuple
 
 import torch
+import triton
+import triton.language as tl
 
 from sglang.kernels.ops.speculative.spec_tree import (
     sgl_build_tree_kernel_efficient_triton,
@@ -646,6 +648,105 @@ def _verify_coins(
     return coins, coins_for_final_sampling
 
 
+@triton.jit
+def _top_p_renorm_kernel(
+    probs_ptr,
+    out_ptr,
+    top_p_ptr,
+    vocab: tl.constexpr,
+    BLOCK: tl.constexpr,
+    N_ITER: tl.constexpr,
+):
+    # Per-row top-p renorm by pivot binary-search (no sort): keep the largest tau with
+    # sum(p >= tau) >= top_p, then renormalize p >= tau. N_ITER=30 pins tau to
+    # max_prob*2^-30, far below realistic prob gaps, so it matches a sort to <1e-6.
+    row = tl.program_id(0)
+    base = row * vocab
+    tp = tl.load(top_p_ptr + row)
+    offs = tl.arange(0, BLOCK)
+    hi = 0.0
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        hi = tl.maximum(hi, tl.max(p, axis=0))
+    lo = 0.0
+    for _ in range(N_ITER):
+        mid = (lo + hi) * 0.5
+        s = 0.0
+        for start in range(0, vocab, BLOCK):
+            idx = start + offs
+            m = idx < vocab
+            p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+            s += tl.sum(tl.where(p >= mid, p, 0.0), axis=0)
+        take = s >= tp
+        lo = tl.where(take, mid, lo)
+        hi = tl.where(take, hi, mid)
+    Z = 0.0
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        Z += tl.sum(tl.where(p >= lo, p, 0.0), axis=0)
+    Z = tl.maximum(Z, 1e-12)
+    for start in range(0, vocab, BLOCK):
+        idx = start + offs
+        m = idx < vocab
+        p = tl.load(probs_ptr + base + idx, mask=m, other=0.0)
+        tl.store(out_ptr + base + idx, tl.where(p >= lo, p / Z, 0.0), mask=m)
+
+
+def _renorm_top_k_top_p_hip(
+    probs: torch.Tensor, top_ks: torch.Tensor, top_ps: torch.Tensor
+) -> torch.Tensor:
+    """ROCm replacement for sgl_kernel top_k/top_p_renorm_prob (CUDA/MUSA-only).
+
+    top-p runs the Triton pivot kernel; top-k uses a sort only for rows that actually
+    restrict it (a no-op when top_k >= vocab). Rows with top_p >= 1.0 pass through
+    unchanged to stay bit-exact with CUDA's top_p_renorm_prob(p, 1.0) == p.
+    """
+    vocab = probs.shape[-1]
+    probs = probs.contiguous()
+    if bool((top_ks < vocab).any()):
+        sorted_probs, sorted_indices = probs.sort(dim=-1, descending=True)
+        order = torch.arange(vocab, device=probs.device).view(1, -1)
+        sorted_probs = sorted_probs.masked_fill(order >= top_ks.reshape(-1, 1), 0.0)
+        sorted_probs = sorted_probs / sorted_probs.sum(dim=-1, keepdim=True).clamp_min(
+            1e-12
+        )
+        probs = torch.zeros_like(sorted_probs).scatter_(
+            -1, sorted_indices, sorted_probs
+        )
+    top_ps = top_ps.reshape(-1).to(torch.float32).contiguous()
+    out = torch.empty_like(probs)
+    _top_p_renorm_kernel[(probs.shape[0],)](
+        probs, out, top_ps, vocab, BLOCK=4096, N_ITER=30
+    )
+    return torch.where((top_ps >= 1.0).view(-1, 1), probs, out)
+
+
+def _verify_uses_greedy(
+    *,
+    is_all_greedy: bool,
+    is_cpu: bool,
+    is_npu: bool,
+    is_hip: bool,
+    is_xpu: bool,
+    use_rejection_sampling: bool,
+) -> bool:
+    """Whether EAGLE verify must commit argmax(greedy) instead of the sampling path.
+
+    HIP has no CUDA/MUSA sampling-verify kernels, so it historically forced greedy here;
+    route it through the pure-Triton chain sampler when rejection sampling supplies the
+    draft proposal and the batch isn't all-greedy. Reduces to the original predicate on
+    non-HIP platforms.
+    """
+    hip_can_sample = is_hip and use_rejection_sampling and not is_all_greedy
+    return (
+        is_all_greedy or is_cpu or is_npu or is_xpu or (is_hip and not hip_can_sample)
+    )
+
+
 def eagle_sample(
     verify_input: EagleVerifyInput,
     batch: ScheduleBatch,
@@ -723,7 +824,15 @@ def eagle_sample(
 
     # Sample tokens
     target_predict = None
-    if sampling_info.is_all_greedy or _is_cpu or _is_npu or _is_hip or _is_xpu:
+    _use_rej = get_spec().speculative_use_rejection_sampling
+    if _verify_uses_greedy(
+        is_all_greedy=sampling_info.is_all_greedy,
+        is_cpu=_is_cpu,
+        is_npu=_is_npu,
+        is_hip=_is_hip,
+        is_xpu=_is_xpu,
+        use_rejection_sampling=_use_rej,
+    ):
         target_predict = torch.argmax(next_token_logits, dim=-1)
         target_predict = target_predict.reshape(bs, verify_input.draft_token_num)
         predict, accept_index, num_correct_drafts = verify_tree_greedy_func(
@@ -753,17 +862,21 @@ def eagle_sample(
                 tp_group.broadcast(accept_index, src=0)
                 tp_group.broadcast(num_correct_drafts, src=0)
     else:
-        from sgl_kernel import (
-            top_k_renorm_prob,
-            top_p_renorm_prob,
-            tree_speculative_sampling_target_only,
-        )
+        # sgl_kernel renorm/tree-verify ops are CUDA/MUSA-only; import lazily so the HIP
+        # branch never ImportErrors. The gate forces rejection sampling on HIP, so the
+        # CUDA-only tree_speculative_sampling_target_only is never referenced there.
+        if not _is_hip:
+            from sgl_kernel import (
+                top_k_renorm_prob,
+                top_p_renorm_prob,
+                tree_speculative_sampling_target_only,
+            )
 
         from sglang.kernels.ops.speculative.reject_sampling import (
             chain_speculative_sampling_triton,
         )
 
-        use_rejection_sampling = get_spec().speculative_use_rejection_sampling
+        use_rejection_sampling = _use_rej
 
         # Apply temperature and get target probs
         expanded_temperature = torch.repeat_interleave(
@@ -774,22 +887,44 @@ def eagle_sample(
             next_token_logits / expanded_temperature, dim=-1
         )  # (bs * num_draft_tokens, vocab_size)
         maybe_detect_nan(target_probs, "v2 verify: target_probs after softmax")
-        if sampling_info.need_top_k_sampling:
-            target_probs = top_k_renorm_prob(
-                target_probs,
-                torch.repeat_interleave(
-                    sampling_info.top_ks, verify_input.draft_token_num, dim=0
-                ),
-            )  # (bs * num_draft_tokens, vocab_size)
-            maybe_detect_nan(target_probs, "v2 verify: target_probs after top_k_renorm")
-        if sampling_info.need_top_p_sampling:
-            target_probs = top_p_renorm_prob(
-                target_probs,
-                torch.repeat_interleave(
-                    sampling_info.top_ps, verify_input.draft_token_num, dim=0
-                ),
-            )
-            maybe_detect_nan(target_probs, "v2 verify: target_probs after top_p_renorm")
+        if _is_hip:
+            if (
+                sampling_info.need_top_k_sampling
+                or sampling_info.need_top_p_sampling
+            ):
+                target_probs = _renorm_top_k_top_p_hip(
+                    target_probs,
+                    torch.repeat_interleave(
+                        sampling_info.top_ks, verify_input.draft_token_num, dim=0
+                    ),
+                    torch.repeat_interleave(
+                        sampling_info.top_ps, verify_input.draft_token_num, dim=0
+                    ),
+                )
+                maybe_detect_nan(
+                    target_probs, "v2 verify: target_probs after top_k/top_p renorm"
+                )
+        else:
+            if sampling_info.need_top_k_sampling:
+                target_probs = top_k_renorm_prob(
+                    target_probs,
+                    torch.repeat_interleave(
+                        sampling_info.top_ks, verify_input.draft_token_num, dim=0
+                    ),
+                )  # (bs * num_draft_tokens, vocab_size)
+                maybe_detect_nan(
+                    target_probs, "v2 verify: target_probs after top_k_renorm"
+                )
+            if sampling_info.need_top_p_sampling:
+                target_probs = top_p_renorm_prob(
+                    target_probs,
+                    torch.repeat_interleave(
+                        sampling_info.top_ps, verify_input.draft_token_num, dim=0
+                    ),
+                )
+                maybe_detect_nan(
+                    target_probs, "v2 verify: target_probs after top_p_renorm"
+                )
         target_probs = target_probs.reshape(bs, verify_input.draft_token_num, -1)
         draft_probs = (
             verify_input.draft_probs

--- a/test/registered/function_call/test_kimik3_detector.py
+++ b/test/registered/function_call/test_kimik3_detector.py
@@ -208,6 +208,38 @@ def test_streaming_bookkeeping_for_serving_layer() -> None:
     assert json.loads(detector.streamed_args_for_tool[0]) == {"code": "a"}
 
 
+def test_stream_end_reports_truncated_tools_section(caplog) -> None:
+    """A tools section cut off before its closing tag used to vanish at
+    end-of-stream: no call, no text, no log. It must at least be reported."""
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    truncated = TOOLS_OPEN + '<|open|>call tool="python" index="1"<|sep|>'
+    text, calls = _stream(detector, _chunks(truncated, 7), tools)
+    assert calls == []
+    with caplog.at_level("WARNING", logger="sglang.srt.function_call.kimik3_detector"):
+        result = detector.finish(tools)
+    assert result.calls == []
+    assert TOOLS_OPEN not in (result.normal_text or "")
+    assert "no complete tool call" in caplog.text
+
+
+def test_stream_end_releases_held_back_text() -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text, _ = _stream(detector, ["all done", "<"], tools)
+    assert text == "all done"
+    result = detector.finish(tools)
+    assert text + (result.normal_text or "") == "all done<"
+
+
+def test_stream_end_drops_truncated_marker() -> None:
+    detector = KimiK3Detector()
+    tools = [_make_tool("python")]
+    text, _ = _stream(detector, ["all done", "<|open|>"], tools)
+    result = detector.finish(tools)
+    assert text + (result.normal_text or "") == "all done"
+
+
 def test_detector_capabilities_and_registration() -> None:
     detector = KimiK3Detector()
     assert detector.supports_structural_tag()

--- a/test/registered/kernels/ops/moe/test_fp8_per_token_to_per_tensor_quant.py
+++ b/test/registered/kernels/ops/moe/test_fp8_per_token_to_per_tensor_quant.py
@@ -1,0 +1,82 @@
+"""Unit test for ``fp8_per_token_to_per_tensor_quant_triton`` across hidden sizes.
+
+W4AFP8 DeepEP low-latency requantizes the fp8 dispatch payload with this kernel
+before the first CUTLASS grouped GEMM.  The payload's hidden size is only
+guaranteed to be a multiple of the fp8 scale-group size (128) -- e.g. 3584 for
+Kimi-K3 -- so the kernel must handle a ``k`` tail that does not fill a whole
+``K_BLOCK_SIZE`` (1024) block, and must still leave the rows past ``masked_m``
+untouched.
+"""
+
+import pytest
+import torch
+
+from sglang.kernels.ops.moe.ep_moe_kernels import (
+    fp8_per_token_to_per_tensor_quant_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=20, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+dev = "cuda"
+FP8 = torch.float8_e4m3fn
+K_SCALE_BLOCK_SIZE = 128
+# Every value the kernel can produce below is a multiple of 0.25, so this
+# sentinel cannot be matched by a kernel that wrongly writes a padding row.
+SENTINEL = 0.375
+OUTPUT_SCALE = 2.0
+
+
+def _build(num_experts, m, k, seed):
+    g = torch.Generator(device="cpu").manual_seed(seed)
+    # Integers in [-8, 8] with power-of-two per-token-group scales keep every
+    # intermediate exactly representable in e4m3, so the reference below matches
+    # bit-for-bit regardless of the rounding mode of the final cast.
+    x = torch.randint(-8, 9, (num_experts, m, k), generator=g).float()
+    exps = torch.randint(-1, 2, (num_experts, m, k // K_SCALE_BLOCK_SIZE), generator=g)
+    x_scale = torch.pow(2.0, exps.float())
+    return x.to(dev).to(FP8), x_scale.to(dev)
+
+
+def _ref(x, x_scale):
+    dequant = x.float() * x_scale.repeat_interleave(K_SCALE_BLOCK_SIZE, dim=2)
+    return (dequant * (1.0 / OUTPUT_SCALE)).to(FP8)
+
+
+# 7168: exact multiple of K_BLOCK_SIZE (the DeepSeek-V3 hidden size).
+# 3584 / 1152: only 128-aligned, so the last k block is partially masked.
+@pytest.mark.parametrize("k", [7168, 3584, 1152])
+def test_masked_rows_and_k_tail(k):
+    num_experts, m = 4, 48
+    masked = [0, 1, 17, m]
+
+    x, x_scale = _build(num_experts, m, k, seed=k)
+    masked_m = torch.tensor(masked, dtype=torch.int32, device=dev)
+    output_scale = torch.tensor([OUTPUT_SCALE], dtype=torch.float32, device=dev)
+    output = torch.full((num_experts, m, k), SENTINEL, device=dev).to(FP8)
+
+    fp8_per_token_to_per_tensor_quant_triton(
+        x=x,
+        x_scale=x_scale,
+        masked_m=masked_m,
+        output_scale=output_scale,
+        output=output,
+    )
+
+    ref = _ref(x, x_scale)
+    for e, valid in enumerate(masked):
+        torch.testing.assert_close(
+            output[e, :valid].float(), ref[e, :valid].float(), rtol=0, atol=0
+        )
+        # Padding rows are not part of any expert's GEMM problem size and must
+        # stay as the caller left them.
+        padding = output[e, valid:].float()
+        torch.testing.assert_close(
+            padding, torch.full_like(padding, SENTINEL), rtol=0, atol=0
+        )
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(pytest.main([__file__, "-v", "-s"]))

--- a/test/registered/spec/eagle/test_rocm_eagle_renorm.py
+++ b/test/registered/spec/eagle/test_rocm_eagle_renorm.py
@@ -1,0 +1,129 @@
+"""Numerical-equivalence tests for the ROCm EAGLE top-k/top-p renorm.
+
+Guards ``eagle_utils._renorm_top_k_top_p_hip`` (the Triton replacement for the
+CUDA/MUSA-only ``sgl_kernel`` ``top_k_renorm_prob`` + ``top_p_renorm_prob``)
+against an independent torch nucleus reference. A regression in the pivot search
+(wrong iteration count, wrong threshold, broken top-k, or a ``top_p == 1.0`` that
+stops being an exact no-op) turns a case red. The kernel is device-agnostic, so
+this runs on any triton-capable GPU (CUDA in CI); skipped without one.
+"""
+
+import unittest
+
+import torch
+
+from sglang.test.ci.ci_register import register_amd_ci, register_cuda_ci
+from sglang.test.test_utils import CustomTestCase
+
+# Runs on any triton GPU; AMD registration exercises the actual ROCm target path.
+register_cuda_ci(est_time=30, stage="base-b", runner_config="1-gpu-small")
+register_amd_ci(est_time=30, suite="stage-b-test-1-gpu-small-amd")
+
+try:
+    import triton  # noqa: F401
+
+    _HAS_TRITON = True
+except Exception:
+    _HAS_TRITON = False
+
+_RUNNABLE = torch.cuda.is_available() and _HAS_TRITON
+
+
+def _torch_nucleus_reference(probs, top_ks, top_ps):
+    """top-k renorm then nucleus (top-p) renorm, mirroring sgl_kernel semantics.
+
+    Always keeps the argmax token (like the pivot kernel and sgl_kernel), so it
+    agrees on the top_p -> 0 edge instead of zeroing the row.
+    """
+    vocab = probs.shape[-1]
+    order = torch.arange(vocab, device=probs.device).view(1, -1)
+    # top-k
+    sorted_probs, sorted_idx = probs.sort(dim=-1, descending=True)
+    sorted_probs = torch.where(
+        order < top_ks.view(-1, 1), sorted_probs, torch.zeros_like(sorted_probs)
+    )
+    sorted_probs = sorted_probs / sorted_probs.sum(-1, keepdim=True).clamp_min(1e-12)
+    p = torch.zeros_like(probs).scatter_(-1, sorted_idx, sorted_probs)
+    # top-p (nucleus)
+    sorted_probs, sorted_idx = p.sort(dim=-1, descending=True)
+    csum = sorted_probs.cumsum(dim=-1)
+    keep = (csum - sorted_probs) < top_ps.view(-1, 1)
+    keep[..., 0] = True
+    sorted_probs = torch.where(keep, sorted_probs, torch.zeros_like(sorted_probs))
+    sorted_probs = sorted_probs / sorted_probs.sum(-1, keepdim=True).clamp_min(1e-12)
+    return torch.zeros_like(p).scatter_(-1, sorted_idx, sorted_probs)
+
+
+@unittest.skipUnless(_RUNNABLE, "requires a triton-capable GPU")
+class TestRocmEagleRenorm(CustomTestCase):
+    VOCAB = 4096
+    ROWS = 16
+
+    def setUp(self):
+        torch.manual_seed(0)
+
+    def _rand_probs(self, rows=None):
+        rows = rows or self.ROWS
+        return torch.softmax(torch.randn(rows, self.VOCAB, device="cuda"), dim=-1)
+
+    def _unrestricted_top_ks(self, rows=None):
+        rows = rows or self.ROWS
+        return torch.full((rows,), self.VOCAB, dtype=torch.int32, device="cuda")
+
+    def test_top_p_matches_nucleus(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs()
+        top_ks = self._unrestricted_top_ks()
+        for top_p in (0.5, 0.9, 0.95):
+            top_ps = torch.full((self.ROWS,), top_p, device="cuda")
+            got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+            ref = _torch_nucleus_reference(probs.clone(), top_ks, top_ps)
+            self.assertLess((got - ref).abs().max().item(), 1e-6, f"top_p={top_p}")
+
+    def test_top_p_one_is_exact_noop(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs()
+        top_ks = self._unrestricted_top_ks()
+        top_ps = torch.ones(self.ROWS, device="cuda")
+        got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+        self.assertEqual((got - probs).abs().max().item(), 0.0)
+
+    def test_top_k_restriction(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs()
+        top_ks = torch.full((self.ROWS,), 8, dtype=torch.int32, device="cuda")
+        top_ps = torch.ones(self.ROWS, device="cuda")  # top_p no-op -> isolate top-k
+        got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+        self.assertTrue(((got > 0).sum(-1) == 8).all().item())
+        ref = _torch_nucleus_reference(probs.clone(), top_ks, top_ps)
+        self.assertLess((got - ref).abs().max().item(), 1e-6)
+
+    def test_edge_top_p_to_zero_keeps_top1(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        probs = self._rand_probs(rows=1)
+        top_ks = self._unrestricted_top_ks(rows=1)
+        top_ps = torch.full((1,), 1e-4, device="cuda")
+        got = _renorm_top_k_top_p_hip(probs.clone(), top_ks, top_ps)
+        self.assertEqual((got > 0).sum().item(), 1)
+        self.assertEqual(got.argmax().item(), probs.argmax().item())
+
+    def test_edge_single_nonmasked_token(self):
+        from sglang.srt.speculative.eagle_utils import _renorm_top_k_top_p_hip
+
+        one_hot = torch.zeros(1, self.VOCAB, device="cuda")
+        one_hot[0, 123] = 1.0
+        got = _renorm_top_k_top_p_hip(
+            one_hot.clone(),
+            self._unrestricted_top_ks(rows=1),
+            torch.full((1,), 0.9, device="cuda"),
+        )
+        self.assertEqual((got > 0).sum().item(), 1)
+        self.assertAlmostEqual(got[0, 123].item(), 1.0, places=5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/constrained/test_base_grammar_backend.py
+++ b/test/registered/unit/constrained/test_base_grammar_backend.py
@@ -15,6 +15,7 @@ Usage:
     python -m pytest test_base_grammar_backend.py -v
 """
 
+import json
 import unittest
 from concurrent.futures import Future
 from unittest.mock import MagicMock, patch
@@ -249,7 +250,7 @@ class TestCreateGrammarBackend(unittest.TestCase):
         backend="none",
         reasoning_parser=None,
         enable_strict_thinking=False,
-        **fields
+        **fields,
     ):
         published = {
             "grammar_backend": backend,
@@ -464,6 +465,63 @@ class TestLlguidanceStructuralTagTriggerPairing(unittest.TestCase):
         )
         result = backend.dispatch_structural_tag(key)
         self.assertNotIsInstance(result, InvalidGrammarObject)
+
+
+class TestNulByteGrammarRejection(unittest.TestCase):
+    def setUp(self):
+        self.backend = BaseGrammarBackend()
+
+    def tearDown(self):
+        self.backend.executor.shutdown(wait=True)
+
+    def test_nul_payload_never_reaches_backend(self):
+        cases = [
+            ("regex", "\x00\x01\x02\x1f"),
+            ("regex", "\x00"),
+            # a non-leading NUL truncates the pattern instead of crashing; pinned
+            # so the guard cannot be narrowed to startswith()
+            ("regex", "a\x00b"),
+            ("ebnf", "root ::= \x00"),
+            ("structural_tag", '{"triggers": ["\x00"]}'),
+            # escaped forms: no raw NUL byte anywhere in the key string
+            ("json", '{"type":"string","pattern":"\\u0000"}'),
+            (
+                "json",
+                '{"type":"object","properties":'
+                '{"f":{"type":"string","pattern":"\\u0000x"}}}',
+            ),
+            ("structural_tag", '{"format":{"pattern":"\\u0000"}}'),
+        ]
+        for key_type, key_string in cases:
+            with self.subTest(key_type=key_type, key_string=repr(key_string)):
+                dispatch = MagicMock()
+                setattr(self.backend, f"dispatch_{key_type}", dispatch)
+
+                result = self.backend._init_value_dispatch(
+                    (key_type, key_string), False
+                )
+
+                self.assertIsInstance(result, InvalidGrammarObject)
+                dispatch.assert_not_called()
+
+    def test_nul_free_payload_still_dispatches(self):
+        cases = [
+            ("regex", "[0-9]+"),
+            ("regex", r"\x00"),  # escaped in the pattern text, not a raw NUL byte
+            ("regex", "\x01\x02\x1f"),  # other control bytes are not the trigger
+            ("json", json.dumps({"type": "string", "pattern": "[0-9]+"})),
+            # malformed json must reach the backend and get its normal error,
+            # not be swallowed by the NUL scan's decode failure
+            ("json", "{not valid json"),
+        ]
+        for key_type, key_string in cases:
+            with self.subTest(key_type=key_type, key_string=repr(key_string)):
+                dispatch = MagicMock(return_value=BaseGrammarObject())
+                setattr(self.backend, f"dispatch_{key_type}", dispatch)
+
+                self.backend._init_value_dispatch((key_type, key_string), False)
+
+                dispatch.assert_called_once_with(key_string)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/distributed/test_custom_all_reduce_graph_capture_policy.py
+++ b/test/registered/unit/distributed/test_custom_all_reduce_graph_capture_policy.py
@@ -1,0 +1,133 @@
+import sys
+import types
+from functools import partial
+from unittest import mock
+
+import torch
+
+from sglang.srt.distributed.device_communicators import custom_all_reduce
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def test_registered_graph_inputs_enabled_by_default():
+    with (
+        mock.patch.object(
+            custom_all_reduce.envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH,
+            "get",
+            return_value=False,
+        ),
+        mock.patch(
+            "sglang.srt.runtime_context.attention_backends",
+            return_value=("tilelang", "tilelang"),
+        ),
+        mock.patch("sglang.srt.runtime_context.get_parallel") as get_parallel,
+    ):
+        get_parallel.return_value.enable_dp_attention = True
+        assert custom_all_reduce._enable_register_for_capturing()
+
+
+def test_registered_graph_inputs_disabled_for_dsa_dp_attention():
+    with (
+        mock.patch.object(
+            custom_all_reduce.envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH,
+            "get",
+            return_value=False,
+        ),
+        mock.patch(
+            "sglang.srt.runtime_context.attention_backends",
+            return_value=("aiter", "dsa"),
+        ),
+        mock.patch("sglang.srt.runtime_context.get_parallel") as get_parallel,
+    ):
+        get_parallel.return_value.enable_dp_attention = True
+        assert not custom_all_reduce._enable_register_for_capturing()
+
+
+def test_registered_graph_inputs_remain_enabled_for_dsa_without_dp_attention():
+    with (
+        mock.patch.object(
+            custom_all_reduce.envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH,
+            "get",
+            return_value=False,
+        ),
+        mock.patch(
+            "sglang.srt.runtime_context.attention_backends",
+            return_value=("tilelang", "dsa"),
+        ),
+        mock.patch("sglang.srt.runtime_context.get_parallel") as get_parallel,
+    ):
+        get_parallel.return_value.enable_dp_attention = False
+        assert custom_all_reduce._enable_register_for_capturing()
+
+
+def test_memory_saver_always_uses_copy_in():
+    with mock.patch.object(
+        custom_all_reduce.envs.SGLANG_MEMORY_SAVER_CUDA_GRAPH,
+        "get",
+        return_value=True,
+    ):
+        assert not custom_all_reduce._enable_register_for_capturing()
+
+
+def test_policy_is_forwarded_to_sglang_custom_allreduce():
+    with (
+        mock.patch.object(custom_all_reduce, "_is_cuda", False),
+        mock.patch.object(custom_all_reduce, "_is_musa", False),
+        mock.patch.object(custom_all_reduce, "_is_hip", True),
+        mock.patch.object(
+            custom_all_reduce, "_use_amd_deterministic_impl", return_value=False
+        ),
+        mock.patch.object(
+            custom_all_reduce,
+            "_enable_register_for_capturing",
+            return_value=False,
+        ),
+        mock.patch.object(custom_all_reduce, "get_bool_env_var", return_value=False),
+    ):
+        factory = custom_all_reduce.dispatch_custom_allreduce(
+            group=mock.sentinel.group,
+            device=torch.device("cpu"),
+        )
+
+    assert isinstance(factory, partial)
+    assert factory.func is custom_all_reduce.CustomAllreduce
+    assert factory.keywords["enable_register_for_capturing"] is False
+
+
+def test_policy_is_forwarded_to_aiter_custom_allreduce():
+    fake_aiter_module = types.ModuleType(
+        "aiter.dist.device_communicators.custom_all_reduce"
+    )
+
+    class FakeAiterCustomAllreduce:
+        pass
+
+    fake_aiter_module.CustomAllreduce = FakeAiterCustomAllreduce
+    with (
+        mock.patch.dict(
+            sys.modules,
+            {"aiter.dist.device_communicators.custom_all_reduce": fake_aiter_module},
+        ),
+        mock.patch.object(custom_all_reduce, "_is_cuda", False),
+        mock.patch.object(custom_all_reduce, "_is_musa", False),
+        mock.patch.object(custom_all_reduce, "_is_hip", True),
+        mock.patch.object(
+            custom_all_reduce, "_use_amd_deterministic_impl", return_value=False
+        ),
+        mock.patch.object(
+            custom_all_reduce,
+            "_enable_register_for_capturing",
+            return_value=False,
+        ),
+        mock.patch.object(custom_all_reduce, "get_bool_env_var", return_value=True),
+    ):
+        factory = custom_all_reduce.dispatch_custom_allreduce(
+            group=mock.sentinel.group,
+            device=torch.device("cpu"),
+        )
+
+    assert isinstance(factory, partial)
+    assert factory.func is FakeAiterCustomAllreduce
+    assert factory.keywords["enable_register_for_capturing"] is False

--- a/test/registered/unit/entrypoints/openai/test_serving_chat.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_chat.py
@@ -27,13 +27,15 @@ from sglang.srt.entrypoints.openai.chat_encoding import (
 from sglang.srt.entrypoints.openai.protocol import (
     ChatCompletionRequest,
     MessageProcessingResult,
+    ToolChoice,
+    ToolChoiceFuncName,
 )
 from sglang.srt.entrypoints.openai.serving_chat import (
     OpenAIServingChat,
     normalize_tool_content,
 )
 from sglang.srt.environ import envs
-from sglang.srt.function_call.kimik3_format import TOOLS_CLOSE
+from sglang.srt.function_call.kimik3_format import TOOLS_CLOSE, TOOLS_OPEN
 from sglang.srt.managers.io_struct import GenerateReqInput
 from sglang.srt.parser.template_detection import ReasoningToggleConfig
 from sglang.srt.utils import get_or_create_event_loop
@@ -1568,6 +1570,191 @@ class ServingChatTestCase(unittest.TestCase):
             self.assertEqual(tool_calls[0].function.name, "get_weather")
             self.assertEqual(tool_calls[1].id, "functions.get_weather:2")
             self.assertEqual(tool_calls[1].function.name, "get_weather")
+
+    def test_required_tool_choice_skips_json_fallback_for_native_parser(self):
+        """A structural-tag parser owns the output format, so a missing tool
+        call must not be pushed through the json_schema array fallback."""
+        self.chat.tool_call_parser = "kimi_k3"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        texts = {
+            "prose": "<|open|>response<|sep|>I'll check that.<|close|>response<|sep|>",
+            "empty": "",
+            "json_object": '{"name": "get_weather", "parameters": {"city": "Paris"}}',
+        }
+        for choice in (
+            "required",
+            ToolChoice(function=ToolChoiceFuncName(name="get_weather")),
+        ):
+            for label, text in texts.items():
+                with self.subTest(tool_choice=choice, payload=label):
+                    finish_reason = {"type": "stop", "matched": None}
+                    with self.assertLogs(
+                        "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+                    ) as logs:
+                        tool_calls, remaining, finish_reason = (
+                            self.chat._process_tool_calls(
+                                text=text,
+                                tools=tools,
+                                finish_reason=finish_reason,
+                                tool_choice=choice,
+                            )
+                        )
+                    self.assertIsNone(tool_calls)
+                    self.assertEqual(remaining, text)
+                    self.assertEqual(finish_reason["type"], "stop")
+                    self.assertNotIn("Tool call parsing error", "\n".join(logs.output))
+
+    def test_truncated_native_tool_call_logs_and_drops(self):
+        """A tools section cut off before its closing tag parses to zero calls
+        without raising; the sync path used to drop it with no log at all."""
+        self.chat.tool_call_parser = "kimi_k3"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        truncated = TOOLS_OPEN + '<|open|>call tool="get_weather" index="1"<|sep|>'
+        for choice in ("auto", "required"):
+            with self.subTest(tool_choice=choice):
+                finish_reason = {"type": "stop", "matched": None}
+                with self.assertLogs(
+                    "sglang.srt.entrypoints.openai.serving_chat", level="WARNING"
+                ) as logs:
+                    tool_calls, remaining, finish_reason = (
+                        self.chat._process_tool_calls(
+                            text=truncated,
+                            tools=tools,
+                            finish_reason=finish_reason,
+                            tool_choice=choice,
+                        )
+                    )
+                self.assertIsNone(tool_calls)
+                self.assertEqual(remaining, "")
+                self.assertEqual(finish_reason["type"], "stop")
+                self.assertIn("no complete call", "\n".join(logs.output))
+
+    def test_required_tool_choice_json_fallback_tolerates_odd_shapes(self):
+        """Parsers without a structural tag keep the JSON array fallback, but a
+        non-array payload degrades instead of raising an opaque TypeError."""
+        self.chat.tool_call_parser = "glm45"
+        tools = [
+            {
+                "type": "function",
+                "function": {
+                    "name": "get_weather",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                    },
+                },
+            }
+        ]
+        cases = [
+            (
+                '[{"name": "get_weather", "parameters": {"city": "Paris"}}]',
+                '{"city": "Paris"}',
+            ),
+            (
+                '{"name": "get_weather", "parameters": {"city": "Paris"}}',
+                '{"city": "Paris"}',
+            ),
+            ('{"name": "get_weather"}', "{}"),
+        ]
+        for text, expected_args in cases:
+            with self.subTest(text=text):
+                tool_calls, _, finish_reason = self.chat._process_tool_calls(
+                    text=text,
+                    tools=tools,
+                    finish_reason={"type": "stop", "matched": None},
+                    tool_choice="required",
+                )
+                self.assertEqual(len(tool_calls), 1)
+                self.assertEqual(tool_calls[0].function.name, "get_weather")
+                self.assertEqual(tool_calls[0].function.arguments, expected_args)
+                self.assertEqual(finish_reason["type"], "tool_calls")
+
+        finish_reason = {"type": "stop", "matched": None}
+        with self.assertLogs(
+            "sglang.srt.entrypoints.openai.serving_chat", level="ERROR"
+        ):
+            tool_calls, remaining, finish_reason = self.chat._process_tool_calls(
+                text='["get_weather"]',
+                tools=tools,
+                finish_reason=finish_reason,
+                tool_choice="required",
+            )
+        self.assertIsNone(tool_calls)
+        self.assertEqual(remaining, '["get_weather"]')
+        self.assertEqual(finish_reason["type"], "stop")
+
+    def test_required_tool_choice_rejects_conflicting_output_constraint(self):
+        """response_format and a forced tool call cannot both be honored: the
+        tool-call constraint was dropped with only a warning, so the model was
+        constrained to a shape that can never contain a tool call."""
+        tools = [{"type": "function", "function": {"name": "get_weather"}}]
+        constraint = ("structural_tag", None)
+        conflicting = [
+            {"type": "json_object"},
+            {
+                "type": "json_schema",
+                "json_schema": {"name": "a", "schema": {"type": "object"}},
+            },
+        ]
+        for tool_choice in (
+            "required",
+            ToolChoice(function=ToolChoiceFuncName(name="get_weather")),
+        ):
+            for response_format in conflicting:
+                with self.subTest(tool_choice=tool_choice, rf=response_format["type"]):
+                    request = ChatCompletionRequest(
+                        model="x",
+                        messages=[{"role": "user", "content": "hi"}],
+                        tools=tools,
+                        tool_choice=tool_choice,
+                        response_format=response_format,
+                    )
+                    with self.assertRaises(ValueError) as ctx:
+                        request.to_sampling_params(
+                            stop=[],
+                            model_generation_config={},
+                            tool_call_constraint=constraint,
+                        )
+                    self.assertIn("cannot be combined", str(ctx.exception))
+
+    def test_auto_tool_choice_keeps_response_format_without_raising(self):
+        """ "auto" means the model need not call a tool, so dropping the
+        tool-call constraint still leaves a satisfiable request."""
+        request = ChatCompletionRequest(
+            model="x",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=[{"type": "function", "function": {"name": "get_weather"}}],
+            tool_choice="auto",
+            response_format={"type": "json_object"},
+        )
+        sampling_params = request.to_sampling_params(
+            stop=[],
+            model_generation_config={},
+            tool_call_constraint=("structural_tag", None),
+        )
+        self.assertEqual(sampling_params["json_schema"], '{"type": "object"}')
 
     def test_kimi_k2_streaming_tool_call_id_with_history(self):
         """Ensure streaming first chunk tool_call.id increase with tool calls history for kimi_k2 parser."""

--- a/test/registered/unit/entrypoints/openai/test_serving_responses.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_responses.py
@@ -691,6 +691,44 @@ class OutputItemsTestCase(CustomTestCase):
             [],
         )
 
+    def test_required_tool_choice_skips_json_fallback_for_native_parser(self):
+        """muse reports parses_required_natively, so required output must not
+        be pushed through the orjson JSON-array fallback (mirrors chat)."""
+        serving = self.serving
+        serving.tool_call_parser = "muse"
+        request = ResponsesRequest(
+            model="x",
+            input="hi",
+            tool_choice="required",
+            tools=[
+                {
+                    "type": "function",
+                    "name": "get_weather",
+                    "parameters": {"type": "object"},
+                }
+            ],
+            store=False,
+        )
+        raw = '[{"name": "get_weather", "parameters": {"city": "Beijing"}}]'
+
+        output_items = serving._make_response_output_items(
+            request, raw, tokenizer=Mock(), require_reasoning=False
+        )
+
+        self.assertEqual(
+            [
+                item
+                for item in output_items
+                if isinstance(item, ResponseFunctionToolCall)
+            ],
+            [],
+        )
+        message_items = [
+            item for item in output_items if isinstance(item, ResponseOutputMessage)
+        ]
+        self.assertEqual(len(message_items), 1)
+        self.assertEqual(message_items[0].content[0].text, raw)
+
     def test_no_tool_call_extraction_when_tool_choice_none(self):
         serving = self.serving
         request = ResponsesRequest(

--- a/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_scales.py
+++ b/test/registered/unit/layers/quantization/test_modelopt_nvfp4_moe_scales.py
@@ -291,6 +291,26 @@ class TestG1ScaleC(CustomTestCase):
         self.assertTrue(g1_scale_c.is_contiguous())
         torch.testing.assert_close(g1_scale_c, torch.full((num_experts,), 20.0))
 
+    def test_situ_keeps_both_dequant_scales_inside_activation(self):
+        # SiTU keeps both GEMM1 scales before tanh; scale_c contains only the
+        # GEMM2 input requantization.
+        num_experts = GATED_CONFIGS[0][1]
+        w2_input_scale_quant = torch.tensor(20.0)
+        gate = _global_scales(num_experts, 1, seed=8)
+        up = _global_scales(num_experts, 1, seed=9)
+
+        g1_scale_c = _compute_g1_scale_c(
+            w2_input_scale_quant,
+            gate,
+            up,
+            is_gated=True,
+            activation="situ",
+        )
+
+        self.assertEqual(g1_scale_c.shape, (num_experts,))
+        self.assertTrue(g1_scale_c.is_contiguous())
+        torch.testing.assert_close(g1_scale_c, torch.full((num_experts,), 20.0))
+
     def test_scale_c_is_float32(self):
         # Lower-precision inputs are upcast to fp32 for the kernel.
         num_experts = GATED_CONFIGS[0][1]

--- a/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
+++ b/test/registered/unit/mem_cache/test_hybrid_pool_assembler.py
@@ -2,6 +2,7 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
 
 from sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler import (
     _split_hicache_size,
@@ -53,6 +54,39 @@ class TestDraftSidecarPoolDispatch(CustomTestCase):
 
         self.assertEqual(specs, [])
         self.assertEqual(entries, [])
+
+    def test_full_builder_sizes_sidecar_for_anchor_logical_space(self):
+        draft_kv_pool = SimpleNamespace(layer_num=1, size=800)
+        draft_host_pool = SimpleNamespace(layer_num=1)
+        tree_cache = SimpleNamespace(
+            cache_controller=SimpleNamespace(
+                mem_pool_host=SimpleNamespace(size=100, logical_size=800),
+                page_size=512,
+            )
+        )
+        server_args = SimpleNamespace(hicache_mem_layout="page_first")
+
+        with (
+            patch(
+                "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+                "_build_mha_mla_host_pool",
+                return_value=draft_host_pool,
+            ) as build_host_pool,
+            patch(
+                "sglang.srt.mem_cache.hybrid_cache.hybrid_pool_assembler."
+                "_get_allocator_type",
+                return_value="default",
+            ),
+        ):
+            specs, entries = build_full_draft_pools(
+                draft_kv_pool=draft_kv_pool,
+                tree_cache=tree_cache,
+                server_args=server_args,
+            )
+
+        self.assertEqual(build_host_pool.call_args.kwargs["host_to_device_ratio"], 1.0)
+        self.assertEqual(len(specs), 1)
+        self.assertIs(entries[0].host_pool, draft_host_pool)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/model_loader/test_modelopt_loader.py
+++ b/test/registered/unit/model_loader/test_modelopt_loader.py
@@ -693,6 +693,28 @@ class TestModelOptFp4LoaderSelection(CustomTestCase):
 
 
 class TestModelOptMixedPrecisionConfig(CustomTestCase):
+    def test_fp8_pb_wo_dispatches_to_native_block_fp8(self):
+        quant_config = ModelOptMixedPrecisionConfig.from_config(
+            {
+                "quant_algo": "MIXED_PRECISION",
+                "quantized_layers": {
+                    "model.layers.0.self_attn.q_proj": {"quant_algo": "FP8_PB_WO"},
+                },
+                "packed_modules_mapping": {},
+            }
+        )
+
+        # Type dispatch only needs a LinearBase instance; skip GPU weight setup.
+        linear = ReplicatedLinear.__new__(ReplicatedLinear)
+        method = quant_config.get_quant_method(
+            linear, "model.layers.0.self_attn.q_proj"
+        )
+
+        self.assertIsInstance(method, Fp8LinearMethod)
+        self.assertEqual(method.quant_config.weight_block_size, [128, 128])
+        self.assertTrue(method.quant_config.is_checkpoint_fp8_serialized)
+        self.assertEqual(method.quant_config.activation_scheme, "dynamic")
+
     def test_minimax_mixed_precision_resolves_runtime_names_and_mxfp8(self):
         quant_config = ModelOptMixedPrecisionConfig.from_config(
             {

--- a/test/registered/unit/models/test_glmmoedsa_correction_bias_fp32.py
+++ b/test/registered/unit/models/test_glmmoedsa_correction_bias_fp32.py
@@ -1,0 +1,141 @@
+"""Unit tests for the GLM-5.2 (GlmMoeDsa) fp32 MoE correction-bias fix.
+
+GlmMoeDsa's MoE ``e_score_correction_bias`` values are ~34. bf16 has ULP 0.25 at
+that magnitude, so downcasting collapses the ~174 distinct biases to ~3 levels,
+which scrambles top-k expert routing (noaux_tc picks experts by sigmoid-score +
+bias, and the ~34 bias dominates the [0, 1] sigmoid term). The fix keeps the bias
+in fp32 for GlmMoeDsa at both the parameter-construction site (MoEGate) and the
+aiter routing boundary (layers/moe/topk.py). These tests are pure dtype / CPU
+logic -- no server, no weight loading, no GPU required.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.models.deepseek_v2 import MoEGate, _is_glm_moe_dsa
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+GLM_MAIN_ARCH = "GlmMoeDsaForCausalLM"
+GLM_NEXTN_ARCH = "GlmMoeDsaForCausalLMNextN"  # draft head, rewritten in model_config.py
+NON_GLM_ARCH = "DeepseekV3ForCausalLM"
+
+# Biases spanning a ~0.5-wide window around 34: distinct in fp32 (fp32 ULP ~4e-6
+# there), but within ~2-3 bf16 bins (bf16 ULP 0.25 at magnitude 34).
+NUM_EXPERTS = 174
+BIAS_BASE = 34.0
+
+
+def _glm_bias_values() -> torch.Tensor:
+    step = 0.5 / NUM_EXPERTS
+    return torch.tensor(
+        [BIAS_BASE + i * step for i in range(NUM_EXPERTS)], dtype=torch.float32
+    )
+
+
+class TestMoEGateCorrectionBiasDtype(CustomTestCase):
+    """Behavioral guard on the production dtype block in MoEGate.__init__.
+
+    Fails on pre-fix code (GlmMoeDsa was downcast to bf16 like every other aiter
+    fp8 model); passes once the arch-gate skips the downcast for GlmMoeDsa.
+    """
+
+    def _build_gate(self, arch: str) -> MoEGate:
+        config = SimpleNamespace(
+            n_routed_experts=NUM_EXPERTS,
+            hidden_size=16,
+            topk_method="noaux_tc",
+            architectures=[arch],
+        )
+        quant_config = SimpleNamespace(get_name=lambda: "fp8")
+        # Force the aiter fp8 path (the branch that downcasts to bf16 for non-GLM);
+        # _is_cpu=False avoids the AMX PackWeightMethod branch so the test is
+        # deterministic across CPU and GPU CI runners.
+        import sglang.srt.models.deepseek_v2 as dv2
+
+        with patch.object(dv2, "_use_aiter", True), patch.object(dv2, "_is_cpu", False):
+            return MoEGate(config=config, quant_config=quant_config)
+
+    def test_glm_main_keeps_fp32(self):
+        gate = self._build_gate(GLM_MAIN_ARCH)
+        self.assertEqual(gate.e_score_correction_bias.dtype, torch.float32)
+
+    def test_glm_nextn_keeps_fp32(self):
+        # Guards the NextN draft head: the "GlmMoeDsa" substring must cover it too.
+        gate = self._build_gate(GLM_NEXTN_ARCH)
+        self.assertEqual(gate.e_score_correction_bias.dtype, torch.float32)
+
+    def test_non_glm_still_downcasts_bf16(self):
+        # Blast-radius guard: the fix must not widen dtype for other aiter models.
+        # Fails if the gate is accidentally made too broad (e.g. always-skip).
+        gate = self._build_gate(NON_GLM_ARCH)
+        self.assertEqual(gate.e_score_correction_bias.dtype, torch.bfloat16)
+
+
+class TestIsGlmMoeDsaHelper(CustomTestCase):
+    """The arch-gate predicate used at both fix sites."""
+
+    def test_matches_main_and_nextn(self):
+        self.assertTrue(_is_glm_moe_dsa(SimpleNamespace(architectures=[GLM_MAIN_ARCH])))
+        self.assertTrue(
+            _is_glm_moe_dsa(SimpleNamespace(architectures=[GLM_NEXTN_ARCH]))
+        )
+
+    def test_matches_when_present_among_others(self):
+        self.assertTrue(
+            _is_glm_moe_dsa(SimpleNamespace(architectures=["Foo", GLM_MAIN_ARCH]))
+        )
+
+    def test_rejects_non_glm(self):
+        self.assertFalse(_is_glm_moe_dsa(SimpleNamespace(architectures=[NON_GLM_ARCH])))
+
+    def test_returns_false_for_none_or_empty_architectures(self):
+        # A config with architectures=None or [] must return False, never
+        # mis-gating a non-GLM model (matches the direct-access idiom in
+        # configs/model_config.py, which reads config.architectures unguarded).
+        self.assertFalse(_is_glm_moe_dsa(SimpleNamespace(architectures=None)))
+        self.assertFalse(_is_glm_moe_dsa(SimpleNamespace(architectures=[])))
+
+
+class TestCorrectionBiasBf16Collapse(CustomTestCase):
+    """Pins the numeric mechanism the fp32 fix protects against."""
+
+    def test_bf16_collapses_distinct_biases(self):
+        biases = _glm_bias_values()
+        fp32_distinct = torch.unique(biases).numel()
+        bf16_distinct = torch.unique(biases.to(torch.bfloat16)).numel()
+        # fp32 keeps every distinct bias; bf16 collapses the 174 values to a
+        # handful (the documented ~3), i.e. an order-of-magnitude information loss.
+        self.assertEqual(fp32_distinct, NUM_EXPERTS)
+        self.assertLessEqual(bf16_distinct, 4)
+        self.assertLess(bf16_distinct * 20, fp32_distinct)
+
+    def test_bf16_bias_scrambles_topk_routing(self):
+        # noaux_tc selects top-k experts by (sigmoid(logits) + correction_bias).
+        # With the bias collapsed to ~3 levels, selection within a level is decided
+        # by the tiny sigmoid term instead of the intended bias order -> the chosen
+        # expert set diverges from the fp32 (correct) selection for most tokens.
+        torch.manual_seed(0)
+        topk = 8
+        num_tokens = 64
+        biases_fp32 = _glm_bias_values()[torch.randperm(NUM_EXPERTS)]
+        biases_bf16 = biases_fp32.to(torch.bfloat16).to(torch.float32)
+
+        scores = torch.randn(num_tokens, NUM_EXPERTS).sigmoid()
+        top_fp32 = (scores + biases_fp32).topk(topk, dim=-1).indices
+        top_bf16 = (scores + biases_bf16).topk(topk, dim=-1).indices
+
+        differ = sum(
+            set(top_fp32[t].tolist()) != set(top_bf16[t].tolist())
+            for t in range(num_tokens)
+        )
+        self.assertGreater(differ / num_tokens, 0.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/models/test_kimi_k3_bfa_overlap.py
+++ b/test/registered/unit/models/test_kimi_k3_bfa_overlap.py
@@ -8,7 +8,10 @@ from unittest.mock import patch
 
 import torch
 
-from sglang.srt.models.kimi_k3 import KimiK3DeltaAttention
+from sglang.srt.models.kimi_k3 import (
+    KimiK3DeltaAttention,
+    _get_k3_dense_weight,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -39,9 +42,9 @@ def _make_owner(with_stream: bool):
     owner = SimpleNamespace(
         use_full_rank_gate=True,
         _bfa_w=_randn(_BFA_W_ROWS, _H).contiguous(),
+        _bfa_f_b_w=_randn(1536, _N_FA).contiguous(),
         _bfa_fa_size=_N_FA,
         _bfa_b_size=_N_B,
-        f_b_proj=SimpleNamespace(weight=_randn(1536, _N_FA).contiguous()),
         fused_qkvg_proj=fused_qkvg_proj,
         split_sizes=[3 * 1536, 1536],
         _bfa_alt_stream=torch.cuda.Stream() if with_stream else None,
@@ -96,6 +99,39 @@ class TestKimiK3BfaOverlap(CustomTestCase):
         overlap = _run(_make_owner(with_stream=True), x)  # capture mode False
         for got, ref in zip(overlap, serial):
             self.assertTrue(torch.equal(got, ref))
+
+    def test_block_fp8_weight_is_dequantized_for_tiny_gemm(self):
+        module = SimpleNamespace(
+            weight=torch.nn.Parameter(
+                torch.ones((130, 129), device="cuda", dtype=torch.float8_e4m3fn),
+                requires_grad=False,
+            ),
+            weight_scale_inv=torch.nn.Parameter(
+                torch.tensor([[1.0, 2.0], [3.0, 4.0]], device="cuda"),
+                requires_grad=False,
+            ),
+            quant_method=SimpleNamespace(weight_block_size=[128, 128]),
+            params_dtype=torch.bfloat16,
+        )
+
+        weight = _get_k3_dense_weight(module)
+
+        self.assertEqual(weight.dtype, torch.bfloat16)
+        torch.testing.assert_close(
+            weight[[0, 0, 128, 128], [0, 128, 0, 128]].float(),
+            torch.tensor([1.0, 2.0, 3.0, 4.0], device="cuda"),
+        )
+
+    def test_per_tensor_fp8_weight_is_not_block_dequantized(self):
+        weight = torch.nn.Parameter(
+            torch.ones((2, 2), device="cuda", dtype=torch.float8_e4m3fn),
+            requires_grad=False,
+        )
+        module = SimpleNamespace(
+            weight=weight, weight_scale=torch.ones(1, device="cuda")
+        )
+
+        self.assertEqual(_get_k3_dense_weight(module).data_ptr(), weight.data_ptr())
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/parser/test_kimik3_reasoning_parser.py
+++ b/test/registered/unit/parser/test_kimik3_reasoning_parser.py
@@ -154,6 +154,38 @@ def test_streaming_recovers_missing_think_separator() -> None:
     assert content == "reply"
 
 
+_TOOLS_CHANNEL = (
+    f'{TOOLS_OPEN}<|open|>call tool="python" index="1"<|sep|>'
+    "<|close|>call<|sep|>"
+    f"{TOOLS_CLOSE}"
+)
+
+
+def test_non_stream_tools_channel_before_think_close_is_not_reasoning() -> None:
+    """A tools channel emitted inside the think block, with think closing after
+    it, must still reach the tool-call parser.
+
+    The reasoning grammar is deferred until think closes, so nothing stops the
+    model from opening the tools channel first. Splitting on think_end put the
+    whole call in reasoning_text, dropping it with no log line.
+    """
+    detector = KimiK3Detector(force_reasoning=True)
+    result = detector.detect_and_parse(
+        f"thought{_TOOLS_CHANNEL}{THINK_CLOSE}{MESSAGE_CLOSE}"
+    )
+    assert result.reasoning_text == "thought"
+    assert TOOLS_OPEN in result.normal_text
+
+
+@pytest.mark.parametrize("chunk_size", [1, 3, 7, 1000])
+def test_streaming_tools_channel_before_think_close(chunk_size: int) -> None:
+    detector = KimiK3Detector(force_reasoning=True)
+    text = f"thought{_TOOLS_CHANNEL}{THINK_CLOSE}{MESSAGE_CLOSE}"
+    reasoning, content = _stream(detector, _chunks(text, chunk_size))
+    assert reasoning == "thought"
+    assert TOOLS_OPEN in content
+
+
 def test_reasoning_parser_registration() -> None:
     assert isinstance(ReasoningParser("kimi_k3").detector, KimiK3Detector)
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -2212,5 +2212,35 @@ class TestTwoBatchOverlapBackend(CustomTestCase):
         args._check_two_batch_overlap()
 
 
+class TestDcpKvEventContract(CustomTestCase):
+    """DCP widens the radix-tree page to page_size * dcp_size, which the
+    advertised KV-event block size must reflect."""
+
+    KV_EVENTS = '{"publisher":"zmq","topic":"kv","endpoint":"tcp://*:5557"}'
+
+    def test_kv_events_descriptor_reports_logical_block_size(self):
+        """Advertising the physical page_size made every KV-aware router hash
+        prompts at a width no emitted block can match, silently pinning its
+        hit rate to zero while stores kept applying cleanly."""
+        args = ServerArgs(
+            model_path="dummy",
+            tp_size=4,
+            dcp_size=4,
+            page_size=64,
+            kv_events_config=self.KV_EVENTS,
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 256)
+        args = ServerArgs(
+            model_path="dummy", page_size=64, kv_events_config=self.KV_EVENTS
+        )
+        self.assertEqual(args.describe_kv_events_publisher()["block_size"], 64)
+
+    def test_kv_event_block_size_widens_a_single_token_page(self):
+        # page_size=1 + DCP is a real deployment shape: the allocator is still
+        # paged, at dcp_size.
+        args = ServerArgs(model_path="dummy", tp_size=8, dcp_size=8, page_size=1)
+        self.assertEqual(args.kv_event_block_size, 8)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/registered/unit/spec/test_eagle_gate_routing.py
+++ b/test/registered/unit/spec/test_eagle_gate_routing.py
@@ -1,0 +1,91 @@
+"""Gate-routing tests for EAGLE verify: sampling vs. greedy (argmax).
+
+Guards the correctness contract of the ROCm fix in
+``eagle_utils._verify_uses_greedy``: on every non-HIP platform the gate must
+reduce byte-for-byte to the pre-patch predicate
+(``is_all_greedy or is_cpu or is_npu or is_hip or is_xpu``), and HIP may take the
+sampling path only when rejection sampling is on and the batch isn't all-greedy.
+A regression that forced greedy on CUDA, or that let HIP sample without rejection
+sampling, would turn a case here red. Pure-boolean logic, so it runs on CPU CI.
+"""
+
+import itertools
+import unittest
+
+from sglang.srt.speculative.eagle_utils import _verify_uses_greedy
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _pre_patch_gate(is_all_greedy, is_cpu, is_npu, is_hip, is_xpu):
+    # eagle_utils.py gate before this PR. Non-HIP behavior must match this exactly.
+    return is_all_greedy or is_cpu or is_npu or is_hip or is_xpu
+
+
+# (name, is_cpu, is_npu, is_hip, is_xpu); CUDA == no platform flag set.
+_PLATFORMS = {
+    "cuda": (False, False, False, False),
+    "hip": (False, False, True, False),
+    "cpu": (True, False, False, False),
+    "npu": (False, True, False, False),
+    "xpu": (False, False, False, True),
+}
+
+
+class TestEagleGateRouting(CustomTestCase):
+    def _gate(self, is_all_greedy, platform, use_rej):
+        is_cpu, is_npu, is_hip, is_xpu = _PLATFORMS[platform]
+        return _verify_uses_greedy(
+            is_all_greedy=is_all_greedy,
+            is_cpu=is_cpu,
+            is_npu=is_npu,
+            is_hip=is_hip,
+            is_xpu=is_xpu,
+            use_rejection_sampling=use_rej,
+        )
+
+    def test_non_hip_is_byte_identical_to_pre_patch(self):
+        for platform, is_all_greedy, use_rej in itertools.product(
+            _PLATFORMS, (False, True), (False, True)
+        ):
+            is_cpu, is_npu, is_hip, is_xpu = _PLATFORMS[platform]
+            if is_hip:
+                continue
+            got = self._gate(is_all_greedy, platform, use_rej)
+            expected = _pre_patch_gate(is_all_greedy, is_cpu, is_npu, is_hip, is_xpu)
+            self.assertEqual(
+                got,
+                expected,
+                f"{platform} greedy={is_all_greedy} rej={use_rej}: gate diverged "
+                f"from pre-patch ({got} != {expected})",
+            )
+
+    def test_hip_samples_only_with_rejection_and_non_greedy(self):
+        # The single new sampling entry: HIP + rejection sampling + not all-greedy.
+        self.assertFalse(self._gate(False, "hip", True))
+        # Every other HIP combination still commits greedy (argmax).
+        self.assertTrue(self._gate(True, "hip", True))
+        self.assertTrue(self._gate(True, "hip", False))
+        self.assertTrue(self._gate(False, "hip", False))
+
+    def test_cuda_keyed_on_all_greedy_only(self):
+        # CUDA samples whenever the batch isn't all-greedy, regardless of the flag.
+        self.assertFalse(self._gate(False, "cuda", False))
+        self.assertFalse(self._gate(False, "cuda", True))
+        self.assertTrue(self._gate(True, "cuda", False))
+        self.assertTrue(self._gate(True, "cuda", True))
+
+    def test_cpu_npu_xpu_always_greedy(self):
+        for platform in ("cpu", "npu", "xpu"):
+            for is_all_greedy in (False, True):
+                for use_rej in (False, True):
+                    self.assertTrue(
+                        self._gate(is_all_greedy, platform, use_rej),
+                        f"{platform} must force greedy",
+                    )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

GLM-5.2-MXFP4 checkpoints name the MTP draft stack as `model.layers.78.*` (`num_hidden_layers=78`, `num_nextn_predict_layers=1`), not `mtp.*`. In `QuarkConfig.can_fuse_shared_expert()`, excluded shared-expert layers veto fusion globally unless they are recognized as draft-layer entries.

The checkpoint exclude list contains exactly three such entries (layer 78 shared-expert projections). Because the gate only skipped `mtp.`-prefixed names, sglang treated them as target-model high-precision shared experts and disabled shared-expert fusion for **all** target MoE layers (layers 0–77).

This is an optimization-path bug, not a precision bug: fusion is mathematically equivalent (shared expert becomes the 257th routed expert). When fusion is wrongly disabled, each MoE layer runs two extra standalone GEMMs (`_gemm_afp4wfp4`), and the aiter MoE path uses `256 experts / topk 8` instead of the fused `257 / topk 9` configuration.

## Modifications

**File:** `python/sglang/srt/layers/quantization/quark/quark.py`

1. **`_is_draft_layer()`** — Treat an exclude entry as belonging to the MTP/NextN draft stack if:
   - it starts with `mtp.`, or
   - it starts with `model.layers.{num_hidden_layers + i}.` for `i in range(num_nextn_predict_layers)`.

2. **`can_fuse_shared_expert()`** — Replace `not layer.startswith("mtp.")` with `not self._is_draft_layer(layer)`.

3. **`__init__()`** — Store `num_hidden_layers` and `num_nextn_predict_layers` from `hf_config`.

4. **`from_config()` (prequantized path)** — Forward `hf_config=config.get("hf_config")` so `_is_draft_layer()` has layer counts.

No weight changes, no new flags, no API changes.

## Accuracy Tests

Not applicable for a meaningful accuracy delta.

- Shared-expert fusion is a kernel-layout change only; routed + shared outputs should be bitwise identical when fusion is enabled.
- No quantization scheme, exclude policy, or weight layout is changed for target-model layers.
- Draft layer 78 remains excluded from MXFP4 as before; only the **fusion gate** stops treating those three draft excludes as a global veto.

## Speed Tests and Profiling

**Platform:** MI355X ×8 (g56)

**Model:** GLM-5.2-MXFP4

**Server:** tp8/ep8, EAGLE MTP n5, `kv-cache-dtype=fp8_e4m3`, DSA tilelang, real acceptance rate (`SIMULATE_ACC=0`)

**Load:** random ISL=100k / OSL=1024, conc=4, warmup 8 + measure 16 (`sglang.benchmark.serving`)

| Metric | Before | After | Δ |
|--------|--------|-------|---|
| Median TTFT | 20,011 ms | 16,545 ms | **−17.3%** |
| Mean TTFT | 19,892 ms | 16,831 ms | **−15.4%** |
| Median E2E | 20,010 ms | 16,545 ms | **−17.3%** |
| Output throughput | 205 tok/s | 242 tok/s | **+18.2%** |

**Fusion verification (server.log):**

| Arm | Target-model log | aiter `fused_moe` key |
|-----|------------------|------------------------|
| Before | `Shared experts fusion optimization is disabled` | 256 experts, topk **7** |
| After | `Shared experts fusion optimization enabled` | 256 experts, topk **8**, block **33** |

(MTP draft runner still logs fusion disabled for its own stack — expected.)

**Notes:**

- Both arms hit `no tuned FlyDSL config` heuristic fallback; fusion still changes the MoE dispatch key (topk 7→8).
- Benchmark used cold random prefill (hit≈0%), not agentic GSP hit97%.
- TPOT not reported (`disable_stream=True` in benchmark); E2E/TTFT includes prefill + MTP decode.


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->