### PR TITLE
[GGUF] Qwen3.5 GDN GQA head expansion + merged-layer shard loading

### DIFF
--- a/python/sglang/srt/layers/attention/linear/gdn_backend.py
+++ b/python/sglang/srt/layers/attention/linear/gdn_backend.py
@@ -424,6 +424,41 @@ class GDNAttnBackend(MambaAttnBackendBase):
                     forward_batch, self.forward_metadata, self.device
                 )
 
+    @staticmethod
+    def _gguf_gqa_expand_mixed_qkv(
+        mixed_qkv: torch.Tensor,
+        num_k_heads: int,
+        num_v_heads: int,
+        head_k_dim: int,
+        head_v_dim: int,
+    ) -> torch.Tensor:
+        """Tiled-expand the q/k segments of a packed ``mixed_qkv``.
+
+        GDN linear attention may use fewer key heads than value heads (GQA).
+        The packed ``mixed_qkv`` is laid out as ``[q | k | v]`` where q/k use
+        ``num_k_heads`` heads and v uses ``num_v_heads`` heads. Expanding the
+        q/k segments to ``num_v_heads`` with a tiled repeat makes the fused
+        kernels infer ``H == HV`` and take their plain (non-GQA) path, so no
+        kernel change is required. It is a no-op when the head counts already
+        match or the tensor layout is unexpected.
+        """
+        if num_k_heads == num_v_heads:
+            return mixed_qkv
+        if mixed_qkv.ndim != 2:
+            return mixed_qkv
+        batch, dim = mixed_qkv.shape
+        k_dim = num_k_heads * head_k_dim
+        v_dim = num_v_heads * head_v_dim
+        if dim != 2 * k_dim + v_dim:
+            return mixed_qkv
+        ratio = num_v_heads // num_k_heads
+        q = mixed_qkv[:, :k_dim].view(batch, num_k_heads, head_k_dim)
+        k = mixed_qkv[:, k_dim : 2 * k_dim].view(batch, num_k_heads, head_k_dim)
+        v = mixed_qkv[:, 2 * k_dim :]
+        q = q.repeat(1, ratio, 1).reshape(batch, -1)
+        k = k.repeat(1, ratio, 1).reshape(batch, -1)
+        return torch.cat([q, k, v], dim=-1)
+
     def forward_decode(
         self,
         layer: RadixLinearAttention,
@@ -466,6 +501,16 @@ class GDNAttnBackend(MambaAttnBackendBase):
         # Skip split + reshape + separate gating kernel by consuming
         # the packed mixed_qkv directly in a single fused Triton kernel.
         if self.kernel_dispatcher.supports_packed_decode:
+            # GQA: expand the packed q/k segments to num_v_heads so the fused
+            # decode kernel infers H == HV and skips its GQA pairing path.
+            if layer.num_k_heads != layer.num_v_heads:
+                mixed_qkv = self._gguf_gqa_expand_mixed_qkv(
+                    mixed_qkv,
+                    layer.num_k_heads,
+                    layer.num_v_heads,
+                    layer.head_k_dim,
+                    layer.head_v_dim,
+                )
             core_attn_out = self.kernel_dispatcher.packed_decode(
                 mixed_qkv=mixed_qkv,
                 a=a,
@@ -647,6 +692,13 @@ class GDNAttnBackend(MambaAttnBackendBase):
             query = query.view(1, actual_seq_len, layer.num_q_heads, layer.head_q_dim)
             key = key.view(1, actual_seq_len, layer.num_k_heads, layer.head_k_dim)
             value = value.view(1, actual_seq_len, layer.num_v_heads, layer.head_v_dim)
+
+        # GQA: tiled-expand the q/k heads to num_v_heads so the extend kernel
+        # sees H == HV and skips its GQA pairing path.
+        if layer.num_k_heads != layer.num_v_heads:
+            gqa_ratio = layer.num_v_heads // layer.num_k_heads
+            query = query.repeat(1, 1, gqa_ratio, 1)
+            key = key.repeat(1, 1, gqa_ratio, 1)
 
         if is_target_verify:
             # ReplaySSM verify protocols: fold-every-commit (ring-write during

--- a/python/sglang/srt/layers/linear.py
+++ b/python/sglang/srt/layers/linear.py
@@ -579,25 +579,66 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
         loaded_weight: torch.Tensor,
         loaded_shard_id: tuple[int, ...] | int | None = None,
     ):
-        if isinstance(loaded_shard_id, tuple):
-            if hasattr(param, "load_merged_column_weight"):
-                return self.weight_loader_v2(param, loaded_weight, loaded_shard_id)
-            raise NotImplementedError(
-                "Shard id with multiple indices is not supported in weight_loader, "
-                "please use weight_loader_v2 instead."
-            )
-
         # Special case for GGUF
         # initialize GGUF param after we know the quantize type
         is_gguf_weight = getattr(param, "is_gguf_weight", False)
         is_gguf_weight_type = getattr(param, "is_gguf_weight_type", False)
+
         if is_gguf_weight_type:
+            # q/k/v string shard ids index the per-shard weight types by
+            # logical order; a tuple shard id (e.g. in_proj_qkv -> shards
+            # (0,1,2)) carries one shared weight type for the fused tensor;
+            # a None shard id is a fused tensor split by output_sizes, so the
+            # type applies to every logical shard.
+            if isinstance(loaded_shard_id, tuple):
+                param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
+                return
+            if isinstance(loaded_shard_id, str):
+                loaded_shard_id = {"q": 0, "k": 1, "v": 2}[loaded_shard_id]
+            if loaded_shard_id is None:
+                for shard_id in range(len(self.output_sizes)):
+                    param.shard_weight_type[shard_id] = loaded_weight.item()
+                return
             param.data[loaded_shard_id].copy_(loaded_weight)
             param.shard_weight_type[loaded_shard_id] = loaded_weight.item()
             return
 
         if is_gguf_weight:
             output_dim = getattr(param, "output_dim", None)
+            # A single fused GGUF tensor can span several logical shards
+            # (e.g. in_proj_qkv -> in_proj_qkvz shards (0,1,2)). Collect it as
+            # one container entry; the logical order is resolved by
+            # process_weights_after_loading.
+            if isinstance(loaded_shard_id, tuple):
+                shard_size = loaded_weight.size(output_dim) // self.tp_size
+                loaded_weight = loaded_weight.narrow(
+                    output_dim, self.tp_rank * shard_size, shard_size
+                )
+                param.shard_id.append(loaded_shard_id)
+                param.shard_id_map[loaded_shard_id] = len(param.data_container)
+                param.data_container.append(loaded_weight)
+                return
+
+            if isinstance(loaded_shard_id, str):
+                loaded_shard_id = {"q": 0, "k": 1, "v": 2}.get(
+                    loaded_shard_id, loaded_shard_id
+                )
+
+            if loaded_shard_id is None:
+                # Fused-in-checkpoint GGUF tensor covering all output sizes:
+                # split by output_sizes so each logical shard keeps its own
+                # quantized block and weight type.
+                current_shard_offset = 0
+                for shard_id, output_size in enumerate(self.output_sizes):
+                    shard_size = output_size // self.tp_size
+                    shard_offset = current_shard_offset + self.tp_rank * shard_size
+                    shard = loaded_weight.narrow(output_dim, shard_offset, shard_size)
+                    param.shard_id.append(shard_id)
+                    param.shard_id_map[shard_id] = len(param.data_container)
+                    param.data_container.append(shard)
+                    current_shard_offset += output_size
+                return
+
             shard_size = loaded_weight.size(output_dim) // self.tp_size
             start_idx = self.tp_rank * shard_size
 
@@ -607,6 +648,14 @@ class MergedColumnParallelLinear(ColumnParallelLinear):
             param.shard_id_map[loaded_shard_id] = len(param.data_container)
             param.data_container.append(loaded_weight)
             return
+
+        if isinstance(loaded_shard_id, tuple):
+            if hasattr(param, "load_merged_column_weight"):
+                return self.weight_loader_v2(param, loaded_weight, loaded_shard_id)
+            raise NotImplementedError(
+                "Shard id with multiple indices is not supported in weight_loader, "
+                "please use weight_loader_v2 instead."
+            )
 
         param_data = param.data
         output_dim = getattr(param, "output_dim", None)

--- a/python/sglang/srt/layers/quantization/gguf.py
+++ b/python/sglang/srt/layers/quantization/gguf.py
@@ -79,7 +79,20 @@ def _ordered_gguf_shard_ids(shard_ids: list) -> list:
         shard_ids
     ) == set(range(len(shard_ids))):
         return sorted(shard_ids)
-    return list(shard_ids)
+
+    # A single fused GGUF tensor can span several logical shards and arrive
+    # with a tuple shard id (e.g. in_proj_qkv -> in_proj_qkvz shards
+    # (0,1,2)). Order mixed shard ids by their first logical index so the
+    # fused tensor lands in front of trailing single-shard tensors (e.g.
+    # in_proj_z -> 3), regardless of the GGUF file's tensor order.
+    def _logical_index(shard_id):
+        if isinstance(shard_id, tuple):
+            return min(shard_id)
+        if isinstance(shard_id, str):
+            return {"q": 0, "k": 1, "v": 2}.get(shard_id, 999)
+        return 999 if shard_id is None else shard_id
+
+    return sorted(shard_ids, key=_logical_index)
 
 
 class GGUFConfig(QuantizationConfig):


### PR DESCRIPTION
Thanks to the SGLang team for the great engine — it has been my go-to
for local deployment.

This PR follows up on #36864 (GGUF weight loading for Qwen3.5 GDN
models) with two more non-invasive fixes for GGUF model support. No
inference kernel code is modified.

## 1. GDN GQA head expansion (adapter layer, kernel unchanged)

Qwen3.5 GDN linear attention can use fewer key heads than value heads
(GQA). The fused decode/extend kernels infer the head count from the
input shapes and only run their plain (H == HV) path when the counts
match.

`GDNAttnBackend._gguf_gqa_expand_mixed_qkv` tiled-expands the q/k
segments of the packed `mixed_qkv` to `num_v_heads` before the fused
kernels see them, so they naturally take the non-GQA path. It is a
no-op when the head counts already match. This mirrors the reference
behaviour (tiled repeat, not repeat_interleave).

- `python/sglang/srt/layers/attention/linear/gdn_backend.py`

## 2. GGUF merged-layer shard loading

`MergedColumnParallelLinear.weight_loader` now handles all three GGUF
checkpoint layouts instead of raising `NotImplementedError`:

- **tuple shard id** (e.g. `in_proj_qkv` -> `in_proj_qkvz` shards
  `(0,1,2)`): the single fused GGUF tensor is kept as one container
  entry and ordered by `process_weights_after_loading`
- **string shard id** (`q`/`k`/`v`): mapped to the `0`/`1`/`2` logical
  order
- **None shard id** (fused-in-checkpoint): split by `output_sizes` so
  each logical shard keeps its own quantized block and weight type

`_ordered_gguf_shard_ids` also sorts mixed shard ids (tuple + int) by
their first logical index, so a fused tensor lands ahead of trailing
single-shard tensors regardless of the GGUF file's tensor order.

- `python/sglang/srt/layers/linear.py`
- `python/sglang/srt/layers/quantization/gguf.py`

Verified against a Qwen3.5-MoE GGUF: all GDN weights load with the
correct layout, and the fused projections are reconstructed in the
right shard order.

Note: this is the second part of the Qwen3.5 GGUF support series;
the loading fixes are in #36864.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33176394804](https://github.com/sgl-project/sglang/actions/runs/33176394804)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33176394484](https://github.com/sgl-project/sglang/actions/runs/33176394484)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33176394515](https://github.com/sgl-project/sglang/actions/runs/33176394515)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->