### PR TITLE
[Diffusion] Respect component weight overrides for upsamplers

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
@@ -197,6 +197,7 @@ def _load_explicit_config(
 class UpsamplerLoader(PlainStateDictComponentLoader):
     component_names = ["spatial_upsampler"]
     expected_library = "diffusers"
+    supports_component_weight_override = True
 
     def load_customized(
         self,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/upsampler_loader.py
@@ -204,7 +204,10 @@ class UpsamplerLoader(PlainStateDictComponentLoader):
         server_args: ServerArgs,
         component_name: str,
     ):
-        safetensors_path = _find_safetensors_file(component_model_path)
+        component_weights_path = self.resolve_component_weights_path(
+            component_model_path, server_args, component_name
+        )
+        safetensors_path = _find_safetensors_file(component_weights_path)
         raw_config = _load_explicit_config(safetensors_path, component_model_path)
         if raw_config is not None:
             self.ensure_plain_state_dict_checkpoint(raw_config, component_name)

--- a/python/sglang/multimodal_gen/test/unit/test_component_quantization_admission.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_quantization_admission.py
@@ -165,6 +165,32 @@ class TestComponentQuantizationAdmission(unittest.TestCase):
 
         load_weights.assert_not_called()
 
+    def test_upsampler_uses_exact_component_weight_override(self):
+        server_args = SimpleNamespace(
+            component_weights_paths={"spatial_upsampler": "owner/repo/upsampler"}
+        )
+        with (
+            patch.object(
+                UpsamplerLoader,
+                "resolve_component_weights_path",
+                return_value="/cache/upsampler.safetensors",
+            ) as resolve_weights,
+            patch(
+                "sglang.multimodal_gen.runtime.loader.component_loaders."
+                "upsampler_loader._find_safetensors_file",
+                side_effect=RuntimeError("stop after routing"),
+            ) as find_weights,
+            self.assertRaisesRegex(RuntimeError, "stop after routing"),
+        ):
+            UpsamplerLoader().load_customized(
+                "/base/spatial_upsampler", server_args, "spatial_upsampler"
+            )
+
+        resolve_weights.assert_called_once_with(
+            "/base/spatial_upsampler", server_args, "spatial_upsampler"
+        )
+        find_weights.assert_called_once_with("/cache/upsampler.safetensors")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_component_quantization_admission.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_quantization_admission.py
@@ -141,6 +141,7 @@ class TestComponentQuantizationAdmission(unittest.TestCase):
             "_class_name": "LatentUpsampler",
             "quantization_config": {"quant_method": "bitsandbytes"},
         }
+        server_args = SimpleNamespace(component_weights_paths={})
 
         with (
             patch(
@@ -160,7 +161,7 @@ class TestComponentQuantizationAdmission(unittest.TestCase):
             self.assertRaises(ComponentCheckpointUnsupportedError),
         ):
             UpsamplerLoader().load_customized(
-                "/model/spatial_upsampler", None, "spatial_upsampler"
+                "/model/spatial_upsampler", server_args, "spatial_upsampler"
             )
 
         load_weights.assert_not_called()

--- a/python/sglang/multimodal_gen/test/unit/test_component_quantization_admission.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_quantization_admission.py
@@ -166,6 +166,7 @@ class TestComponentQuantizationAdmission(unittest.TestCase):
         load_weights.assert_not_called()
 
     def test_upsampler_uses_exact_component_weight_override(self):
+        self.assertTrue(UpsamplerLoader.supports_component_weight_override)
         server_args = SimpleNamespace(
             component_weights_paths={"spatial_upsampler": "owner/repo/upsampler"}
         )


### PR DESCRIPTION
## Summary

- route spatial_upsampler through the shared exact component weight resolver
- preserve the base component config while allowing a local path, Hub repo, or explicit supported weight source
- add a focused routing regression test

## Validation

- targeted pre-commit hooks passed
- no local pytest, per SGLang-Diffusion development policy

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33180819804](https://github.com/sgl-project/sglang/actions/runs/33180819804)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33180819583](https://github.com/sgl-project/sglang/actions/runs/33180819583)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33180819715](https://github.com/sgl-project/sglang/actions/runs/33180819715)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->