### PR TITLE
[Fix][mem_cache] Own HiCache storage threads in one place

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -300,6 +300,15 @@ class HiCacheController:
         # Dedicated stop event for storage background threads (prefetch/backup).
         self.storage_stop_event = threading.Event()
 
+        # Storage threads and the queues wiring them together are created as one
+        # unit in _start_storage_threads(); None means storage was never attached.
+        self.prefetch_thread: Optional[threading.Thread] = None
+        self.prefetch_io_aux_thread: Optional[threading.Thread] = None
+        self.backup_thread: Optional[threading.Thread] = None
+        self.prefetch_queue: Optional[Queue] = None
+        self.prefetch_buffer: Optional[Queue] = None
+        self.backup_queue: Optional[Queue] = None
+
         self.device = self.mem_pool_device.device
         self.layer_num = self.mem_pool_device.layer_num
         self.layer_done_counter = LayerDoneCounter(self.layer_num)
@@ -387,21 +396,40 @@ class HiCacheController:
         assert self.enable_storage
         assert not self.storage_stop_event.is_set()
 
-        self.prefetch_thread = threading.Thread(
-            target=self.prefetch_thread_func, daemon=True
-        )
-        self.backup_thread = threading.Thread(
-            target=self.backup_thread_func, daemon=True
-        )
         self.prefetch_queue = Queue()
+        self.prefetch_buffer = Queue()
         self.backup_queue = Queue()
 
         self.prefetch_hit_queue: Queue[StorageOperation] = Queue()
         self.ack_backup_queue: Queue[StorageOperation] = Queue()
         self.host_mem_release_queue: Queue[torch.Tensor] = Queue()
 
-        self.prefetch_thread.start()
-        self.backup_thread.start()
+        # prefetch_thread and prefetch_io_aux_thread are siblings wired together by
+        # prefetch_buffer: the former resolves how many pages are available, the
+        # latter transfers them into the host pool. Both are created here so that a
+        # single place owns every start, join and rebind of storage threads.
+        self.prefetch_thread = threading.Thread(
+            target=self.prefetch_thread_func, daemon=True, name="hicache-prefetch"
+        )
+        self.prefetch_io_aux_thread = threading.Thread(
+            target=self.prefetch_io_aux_func, daemon=True, name="hicache-prefetch-io"
+        )
+        self.backup_thread = threading.Thread(
+            target=self.backup_thread_func, daemon=True, name="hicache-backup"
+        )
+        for thread in self._storage_threads():
+            thread.start()
+
+    def _storage_threads(self) -> List[threading.Thread]:
+        return [
+            thread
+            for thread in (
+                self.prefetch_thread,
+                self.prefetch_io_aux_thread,
+                self.backup_thread,
+            )
+            if thread is not None
+        ]
 
     def _stop_storage_threads(self):
         """Stop storage prefetch/backup threads and drain internal queues.
@@ -416,36 +444,26 @@ class HiCacheController:
         self.storage_stop_event.set()
 
         # Best-effort wakeups so threads exit promptly even if blocked on queues.
-        try:
-            if hasattr(self, "prefetch_queue"):
-                self.prefetch_queue.put_nowait(None)
-            if hasattr(self, "backup_queue"):
-                self.backup_queue.put_nowait(None)
-            if hasattr(self, "prefetch_buffer"):
-                self.prefetch_buffer.put_nowait(None)
-        except Exception:
-            pass
+        for queue in (self.prefetch_queue, self.prefetch_buffer, self.backup_queue):
+            if queue is not None:
+                try:
+                    queue.put_nowait(None)
+                except Exception:
+                    pass
 
         # Best-effort joins (threads are daemon, but join keeps state clean).
-        threads = []
-        if hasattr(self, "prefetch_thread"):
-            threads.append(self.prefetch_thread)
-        if hasattr(self, "backup_thread"):
-            threads.append(self.backup_thread)
-        if hasattr(self, "prefetch_io_aux_thread"):
-            threads.append(self.prefetch_io_aux_thread)
-
+        threads = self._storage_threads()
         for t in threads:
             try:
                 t.join(timeout=10)
             except Exception:
                 pass
 
-        alive = [t for t in threads if getattr(t, "is_alive", lambda: False)()]
+        alive = [t for t in threads if t.is_alive()]
         if alive:
             logger.error(
                 "Failed to stop HiCache storage threads cleanly: %s",
-                [getattr(t, "name", repr(t)) for t in alive],
+                [t.name for t in alive],
             )
             raise RuntimeError("Failed to stop HiCache storage threads cleanly.")
 
@@ -662,33 +680,22 @@ class HiCacheController:
         )
 
     def reset(self):
-        self.storage_stop_event.set()
-
         self.write_queue.clear()
         self.load_queue.clear()
         self.ack_write_queue.clear()
         self.ack_load_queue.clear()
-        if self.enable_storage:
-            self.prefetch_thread.join()
-            self.backup_thread.join()
-            self.prefetch_queue.queue.clear()
-            self.backup_queue.queue.clear()
-            self.prefetch_hit_queue.queue.clear()
-            self.ack_backup_queue.queue.clear()
-            self.host_mem_release_queue.queue.clear()
-            self.prefetch_tokens_occupied = 0
 
+        if not self.enable_storage:
+            return
+
+        # Delegate to the same start/stop pair attach and detach use, so storage
+        # threads and queues are always created by one owner. Restarting through
+        # _start_storage_threads() also rebuilds the queues, which drops operations
+        # left over from before the reset.
+        self._stop_storage_threads()
+        self.prefetch_tokens_occupied = 0
         self.storage_stop_event.clear()
-
-        if self.enable_storage:
-            self.prefetch_thread = threading.Thread(
-                target=self.prefetch_thread_func, daemon=True
-            )
-            self.backup_thread = threading.Thread(
-                target=self.backup_thread_func, daemon=True
-            )
-            self.prefetch_thread.start()
-            self.backup_thread.start()
+        self._start_storage_threads()
 
     def write(
         self,
@@ -1036,15 +1043,23 @@ class HiCacheController:
         while not self.storage_stop_event.is_set():
             try:
                 operation = self.prefetch_buffer.get(block=True, timeout=1)
-                if operation is None:
-                    continue
-                self._page_transfer(operation)
-                # operation terminated by controller, release pre-allocated memory
-                self.append_host_mem_release(
-                    operation.host_indices[operation.completed_tokens :]
-                )
             except Empty:
                 continue
+            if operation is None:
+                continue
+            try:
+                self._page_transfer(operation)
+            except Exception:
+                # A failed transfer must not take this thread down, otherwise every
+                # later prefetch operation can only end in a timeout.
+                logger.exception(
+                    f"Prefetch operation {operation.request_id} failed during IO transfer."
+                )
+                operation.mark_terminate()
+            # Release whatever the transfer did not fill, success or not.
+            self.append_host_mem_release(
+                operation.host_indices[operation.completed_tokens :]
+            )
 
     def prefetch_rate_limited(self) -> bool:
         """
@@ -1083,12 +1098,11 @@ class HiCacheController:
     def prefetch_thread_func(self):
         """
         Manage prefetching operations from storage backend to host memory.
+
+        Hit-length resolution and the cross-rank all-reduce stay on this thread so
+        that collective ordering is identical across ranks; the storage->host
+        transfer runs on prefetch_io_aux_thread, reached through prefetch_buffer.
         """
-        self.prefetch_buffer = Queue()
-        self.prefetch_io_aux_thread = threading.Thread(
-            target=self.prefetch_io_aux_func, daemon=True
-        )
-        self.prefetch_io_aux_thread.start()
         while (not self.storage_stop_event.is_set()) or not self.prefetch_queue.empty():
             try:
                 operation = self.prefetch_queue.get(block=True, timeout=1)

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -148,8 +148,10 @@ class HybridCacheController(BaseHiCacheController):
             )
 
     def _start_storage_threads(self):
-        super()._start_storage_threads()
+        # Rebuild the release queues before the base class starts the threads, so a
+        # worker can never observe the dict mid-rebuild.
         self._init_extra_host_mem_release_queues()
+        super()._start_storage_threads()
 
     def attach_storage_backend(
         self,
@@ -298,14 +300,6 @@ class HybridCacheController(BaseHiCacheController):
             self._append_host_mem_release_pages(
                 release_queue, transfer.host_indices, entry.host_pool.page_size
             )
-
-    def reset(self):
-        super().reset()
-        if self.enable_storage:
-            self.host_mem_release_queue.queue.clear()
-            for release_queue in self.extra_host_mem_release_queues.values():
-                release_queue.queue.clear()
-            self.prefetch_tokens_occupied = 0
 
     def write(
         self,

--- a/test/registered/unit/mem_cache/test_hicache_storage_thread_lifecycle.py
+++ b/test/registered/unit/mem_cache/test_hicache_storage_thread_lifecycle.py
@@ -1,0 +1,169 @@
+"""Unit tests for HiCache storage thread lifecycle — no server, no model loading."""
+
+import threading
+import time
+import unittest
+from queue import Empty
+from types import SimpleNamespace
+
+import torch
+
+from sglang.srt.managers.cache_controller import HiCacheController
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+WORKER_NAME_PREFIX = "hicache-prefetch-io"
+
+
+def _operation(request_id: str, completed_tokens: int = 0):
+    op = SimpleNamespace(
+        request_id=request_id,
+        host_indices=torch.arange(8, dtype=torch.int64),
+        completed_tokens=completed_tokens,
+        terminated=False,
+    )
+    op.mark_terminate = lambda: setattr(op, "terminated", True)
+    return op
+
+
+def _live_workers():
+    return [t for t in threading.enumerate() if t.name.startswith(WORKER_NAME_PREFIX)]
+
+
+class _LifecycleController(HiCacheController):
+    """Controller stripped down to the storage thread lifecycle.
+
+    The real __init__ needs device/host pools and a model config; none of that is
+    reachable from the lifecycle methods, so this double sets exactly the state
+    _start_storage_threads / _stop_storage_threads / reset touch.
+    """
+
+    def __init__(self):
+        self.enable_storage = True
+        self.storage_stop_event = threading.Event()
+        self.prefetch_thread = None
+        self.prefetch_io_aux_thread = None
+        self.backup_thread = None
+        self.prefetch_queue = None
+        self.prefetch_buffer = None
+        self.backup_queue = None
+        self.write_queue = []
+        self.load_queue = []
+        self.ack_write_queue = []
+        self.ack_load_queue = []
+        self.prefetch_tokens_occupied = 7
+        self.transferred = []
+        self.released = []
+        self.fail_next_transfer = False
+
+    def _idle_loop(self, queue_name):
+        while not self.storage_stop_event.is_set():
+            try:
+                getattr(self, queue_name).get(block=True, timeout=0.05)
+            except Empty:
+                continue
+
+    def prefetch_thread_func(self):
+        self._idle_loop("prefetch_queue")
+
+    def backup_thread_func(self):
+        self._idle_loop("backup_queue")
+
+    def _page_transfer(self, operation):
+        if self.fail_next_transfer:
+            self.fail_next_transfer = False
+            raise RuntimeError("injected transfer failure")
+        self.transferred.append(operation.request_id)
+
+    def append_host_mem_release(self, host_indices):
+        self.released.append(host_indices)
+
+
+class TestHiCacheStorageThreadLifecycle(CustomTestCase):
+    def setUp(self):
+        self.controller = _LifecycleController()
+        self.addCleanup(self._force_stop)
+        self.workers_before = set(_live_workers())
+
+    def _force_stop(self):
+        try:
+            self.controller._stop_storage_threads()
+        except Exception:
+            pass
+
+    def _new_workers(self):
+        return [t for t in _live_workers() if t not in self.workers_before]
+
+    def test_reset_leaves_exactly_one_live_prefetch_io_worker(self):
+        """Reset must not orphan the previous IO worker.
+
+        The worker is only reachable through controller.prefetch_io_aux_thread. If
+        reset restarts the storage threads without joining it first, the old worker
+        keeps running while the attribute points at the new one, so nothing can ever
+        join it and every reset adds one more thread competing for prefetch_buffer.
+        """
+        self.controller._start_storage_threads()
+        first_worker = self.controller.prefetch_io_aux_thread
+        self.assertEqual(len(self._new_workers()), 1)
+
+        for _ in range(3):
+            self.controller.reset()
+
+        self.assertEqual(len(self._new_workers()), 1)
+        self.assertFalse(first_worker.is_alive())
+        self.assertIs(self._new_workers()[0], self.controller.prefetch_io_aux_thread)
+
+    def test_reset_rebuilds_queues_and_clears_occupancy(self):
+        """Reset goes through the same start path as attach.
+
+        Reset used to re-create the threads inline instead of calling
+        _start_storage_threads(), so anything added to that method (queues, a
+        subclass hook) was silently missing after a reset.
+        """
+        self.controller._start_storage_threads()
+        stale_queue = self.controller.prefetch_buffer
+        stale_queue.put(_operation("stale"))
+
+        self.controller.reset()
+
+        self.assertIsNot(self.controller.prefetch_buffer, stale_queue)
+        self.assertTrue(self.controller.prefetch_buffer.empty())
+        self.assertEqual(self.controller.prefetch_tokens_occupied, 0)
+
+    def test_worker_survives_transfer_failure_and_still_releases_memory(self):
+        """A failing transfer must not kill the worker or leak host pages.
+
+        _page_transfer used to run inside the same try that only caught Empty, so
+        any other exception escaped the thread function: the single IO worker died
+        and every later prefetch could only end in a timeout. The release call sat
+        after it, so the failed operation's host pages were never returned either.
+        """
+        self.controller._start_storage_threads()
+        worker = self.controller.prefetch_io_aux_thread
+
+        self.controller.fail_next_transfer = True
+        self.controller.prefetch_buffer.put(_operation("fails"))
+        self.controller.prefetch_buffer.put(_operation("succeeds"))
+
+        deadline = time.monotonic() + 5
+        while time.monotonic() < deadline and len(self.controller.released) < 2:
+            time.sleep(0.01)
+
+        self.assertTrue(worker.is_alive())
+        self.assertEqual(self.controller.transferred, ["succeeds"])
+        self.assertEqual(len(self.controller.released), 2)
+
+    def test_stop_joins_every_storage_thread(self):
+        self.controller._start_storage_threads()
+        threads = self.controller._storage_threads()
+        self.assertEqual(len(threads), 3)
+
+        self.controller._stop_storage_threads()
+
+        self.assertEqual([t.is_alive() for t in threads], [False, False, False])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`prefetch_buffer` and `prefetch_io_aux_thread` were created inside the running
`prefetch_thread_func` instead of alongside `prefetch_thread`. Two bugs follow
from that.

`reset()` restarts `prefetch_thread`, which rebinds both attributes. The previous
IO thread keeps running with nothing referencing it, so `_stop_storage_threads()`
can never join it, and since it re-reads `self.prefetch_buffer` on every
iteration it starts consuming the queue the new thread just created — each reset
leaks one more worker. The IO thread waits on the queue with a 1s timeout while
`reset()` sets and clears the stop event in far less time, so it usually never
observes the stop request: leaking is the normal path, not a rare race. The same
window lets it pick up an operation left in the old queue and write into host
pages the scheduler has already reclaimed.

`reset()` also constructed the threads itself rather than calling
`_start_storage_threads()`, so the two paths were free to diverge — which is how
the missing join arose — and it bypassed `HybridCacheController`'s override of
that method.

Separately, `prefetch_io_aux_func` ran `_page_transfer` in a `try` that only
caught `Empty`. Any other exception escaped the thread function and killed the
only IO worker, after which every prefetch could only end in a timeout. The
host-page release sat after the transfer, so a failed operation leaked its pages
as well.

## Modifications

- Create all three storage threads and their queues in `_start_storage_threads()`,
  and name the threads so the `_stop_storage_threads()` failure log and py-spy
  identify them.
- Initialize the handles in `__init__` so the `hasattr` probes become `None`
  checks; add `_storage_threads()` shared by start and stop.
- `reset()` delegates to the same stop/start pair as attach and detach. Rebuilding
  the queues replaces the per-queue `clear()` calls and drops pre-reset operations.
- `prefetch_io_aux_func()` catches a failed transfer, marks the operation
  terminated, and releases host pages outside the `try`. `get` sits in its own
  `try` so a non-`Empty` error there cannot surface as a `NameError` on
  `operation`.
- `HybridCacheController`: drop the now-redundant `reset()` override, and move
  `_init_extra_host_mem_release_queues()` ahead of
  `super()._start_storage_threads()` so a worker cannot observe the dict
  mid-rebuild.

`reset()` now joins with a 10s timeout and raises instead of hanging forever,
consistent with attach and detach.

## Accuracy Tests

N/A — no change to model outputs.

## Speed Tests and Profiling

N/A — no change on the inference path.

## Checklist

- [x] Format your code according to the Format code with pre-commit
- [x] Add unit tests according to the Run and add unit tests

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->