### PR TITLE
fix(glm): mirror should_use_dp_reduce_scatterv() into the MHC communicator

### DIFF
--- a/python/sglang/srt/layers/communicator_mhc.py
+++ b/python/sglang/srt/layers/communicator_mhc.py
@@ -52,10 +52,12 @@ from sglang.srt.layers.dp_attention import (
     dp_gather_replicate,
     dp_reduce_scatter_tensor,
     dp_scatter,
+    get_dp_global_num_tokens,
     get_global_dp_buffer,
     get_local_dp_buffer_mhc,
     is_allocation_symmetric,
 )
+from sglang.srt.layers.moe import should_use_dp_reduce_scatterv
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 
 
@@ -365,7 +367,19 @@ class MHCCommunicateSummableTensorPairFn(CommunicateSummableTensorPairFn):
             get_local_dp_buffer_mhc(get_tp_group(), 1),
             hidden_states,
         )
-        if allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
+        # Mirror CommunicateSummableTensorPairFn._scatter_hidden_states: when
+        # should_use_dp_reduce_scatterv() is true, the MoE skipped its
+        # post-experts all-reduce (should_skip_post_experts_all_reduce) on the
+        # promise that THIS scatter performs the combine. Without this branch,
+        # SUM_LEN rounds take the non-reducing dp_scatter and every DP rank's
+        # tokens keep only that rank's local-expert partial sums.
+        if should_use_dp_reduce_scatterv():
+            get_tp_group().reduce_scatterv(
+                global_hidden_states,
+                output=hidden_states,
+                sizes=get_dp_global_num_tokens(),
+            )
+        elif allow_reduce_scatter and forward_batch.dp_padding_mode.is_max_len():
             dp_reduce_scatter_tensor(hidden_states, global_hidden_states)
         else:
             dp_scatter(hidden_states, global_hidden_states, forward_batch)
@@ -581,9 +595,15 @@ class MHCLayerCommunicator(LayerCommunicator):
         if (
             self._communicate_summable_tensor_pair_fn
             is MHCCommunicateSummableTensorPairFn._scatter_hidden_states
-            and forward_batch.dp_padding_mode.is_max_len()
         ):
-            return True
+            # Mirror LayerCommunicator.should_use_reduce_scatter (PR #24785):
+            # True on should_use_dp_reduce_scatterv() regardless of padding
+            # mode, else RowParallelLinear keeps all-reducing the dense MLP
+            # while the scatter above reduce-scatters on top of it.
+            if should_use_dp_reduce_scatterv():
+                return True
+            if forward_batch.dp_padding_mode.is_max_len():
+                return True
 
         if dsa_use_prefill_cp(forward_batch):
             return True


### PR DESCRIPTION
Fixes the two `should_use_dp_reduce_scatterv()` omissions reported in #36879.

Based on this PR's head (`aa8c950a3d`) rather than `main`, since
`communicator_mhc.py` only exists on this branch.

## Why

Under DP attention with `moe_a2a_backend == none` and
`tp_size == attn_dp_size == moe_ep_size` (e.g. GLM-5.3-Flash
`--tp-size 4 --ep-size 4 --dp-size 4 --enable-dp-attention`),
`should_use_dp_reduce_scatterv()` is true, so
`should_skip_post_experts_all_reduce()` skips the MoE post-experts all-reduce
— on the promise that the layer communicator's scatter performs a
`reduce_scatterv` combine instead. `communicator_mhc.py` was adapted from a
`communicator.py` snapshot predating #24785 and is missing that branch in two
places:

1. **`MHCCommunicateSummableTensorPairFn._scatter_hidden_states`** never
   reduces under SUM_LEN padding (which is every eager DP prefill), so every
   token leaves every MoE layer holding only its owner DP rank's local expert
   shard — 1/4 of the routed experts at EP4. Output is deterministically
   degenerate: repetition loops to the token limit, prompt echo, wrong answers.

2. **`MHCLayerCommunicator.should_use_reduce_scatter`** publishes
   `mlp_reduce_scatter=False` under SUM_LEN. `should_skip_mlp_all_reduce()`
   consults only that flag (unlike `should_skip_post_experts_all_reduce()`,
   which also consults the predicate directly), so once the scatter starts
   reducing, `RowParallelLinear` is still all-reducing the dense MLPs (GLM
   layers 0–2) and the scatter then sums four identical fully-reduced buffers
   — dense-MLP output scaled by exactly **4×**. This second defect is only
   reachable once the first is fixed, so both are fixed here; landing only the
   first ships a quieter regression (fluent output, 22% of tool calls failing
   schema validation).

`main`'s `LayerCommunicator` has had both branches since #22642 (2026-04-14)
and #24785 (2026-05-10) respectively — the latter titled *"Fix reduce_scatterv
producer contract for SUM_LEN"*, i.e. the identical bug class fixed on the base
path 3.5 months before this file was added. The override carries the pre-#24785
fused single-`if` shape but the post-2026-05-20 `dsa_use_prefill_cp` name, and
its docstring notes it was *"Adapted from the GLM reference"* — a stale copy,
not a deliberate divergence.

## Two things deliberately not mirrored from the base

- The fn-identity check stays against
  `MHCCommunicateSummableTensorPairFn._scatter_hidden_states`. Naming the base
  fn (as a verbatim copy would) makes the branch dead on MHC instances.
- The `input_scattered` branch keeps its lack of base's
  `and not self.is_last_layer`. MHC's `_trivial` reduce-scatters the last layer
  itself and needs the flag True there; adding the exclusion would introduce a
  new last-layer double reduction.

`MHCHybridDSACPLayerCommunicator` inherits `should_use_reduce_scatter`, so it
is covered by this change.

## Validation

4×B200, fp8 KV cache, `deep_gemm` MoE runner, CUDA graphs on. Per-rank sum of
input-token logprobs on a fixed 26-token completion prompt, temperature 0,
pinned per DP rank via `routed_dp_rank`; plain-TP reference on the same host
and weights is **−29.7**:

| | rank0 | rank1 | rank2 | rank3 |
|---|---|---|---|---|
| before | −127.4 | −155.1 | −55.0 | −54.5 |
| hunk 1 only | −36.1 | −41.1 | −33.8 | −36.7 |
| this PR | **−30.6** | **−30.2** | **−32.4** | **−31.3** |

tau2-airline through an OpenAI-compatible gateway, complete runs:

| | task score | schema-valid tool calls |
|---|---|---|
| hunk 1 only | 5 of 6 tasks `too_many_errors` | 49/63 |
| this PR | 44/50 (88.0%) | 354/354 (100%) |
| plain-TP reference | 44/50 (88.0%) | 372/372 (100%) |

Exact task-score parity with plain TP, zero InvalidJson / UnknownName /
SchemaMismatch, 50/50 normal terminations. This change is deployed in
production-equivalent serving.

The state before hunk 1 was never benchmarked (it produces degenerate output,
not scoreable completions) — the benchmark rows above measure the hunk-2
defect.

## Follow-up suggestion (not in this PR)

The skip predicates are global (`moe/utils.py`) while the compensating combine
is per-communicator, and `should_use_reduce_scatter` gates on function
identity, which silently excludes subclass overrides. A startup assertion — if
`should_use_dp_reduce_scatterv()` holds, the active communicator must have a
reducing combine and must report reduce-scatter under SUM_LEN — would catch
this class rather than these two instances. Happy to send that separately if
you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33186082808](https://github.com/sgl-project/sglang/actions/runs/33186082808)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33186082533](https://github.com/sgl-project/sglang/actions/runs/33186082533)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33186082804](https://github.com/sgl-project/sglang/actions/runs/33186082804)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->