### PR TITLE
fix(kda): stop remapping the -1 padding sentinel onto a live mamba slot

### DIFF
--- a/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
+++ b/python/sglang/srt/layers/attention/linear/kernels/kda_triton.py
@@ -231,13 +231,10 @@ class TritonKDAKernel(LinearAttnKernelBase):
         return_intermediate_states: bool = False,
         **kwargs,
     ) -> torch.Tensor:
-        # CP/DP padding marks zero-length requests with -1. The Triton state
-        # kernel performs raw pointer arithmetic on these indices, so route
-        # padding to MambaPool's trailing sentinel slot instead of indexing
-        # before the state pool.
-        ssm_cache_indices = torch.where(
-            cache_indices >= 0, cache_indices, ssm_states.shape[0] - 1
-        ).to(torch.int32)
+        # CP/DP padding marks zero-length requests with -1, which
+        # chunk_gated_delta_rule_fwd_h skips (`valid_state = index >= 0` gates
+        # both the initial-state load and the in-place final-state store), so
+        # the sentinel is passed through unmodified as on the non-GLM path.
         return chunk_kda(
             q=q,
             k=k,
@@ -245,7 +242,7 @@ class TritonKDAKernel(LinearAttnKernelBase):
             g=g,
             beta=beta,
             initial_state=ssm_states,
-            initial_state_indices=ssm_cache_indices,
+            initial_state_indices=cache_indices,
             use_qk_l2norm_in_kernel=True,
             cu_seqlens=query_start_loc,
             A_log=A_log,


### PR DESCRIPTION
Fixes the padding-slot aliasing reported in #36880.

Based on this PR's head (`aa8c950a3d`) rather than `main`, since the remap
being removed exists only on this branch — `main`'s `TritonKDAKernel.extend`
already passes `cache_indices` through unmodified.

## The bug

`TritonKDAKernel.extend` routed padded rows away from the `-1` sentinel and
onto `ssm_states.shape[0] - 1`, described in the comment as *"MambaPool's
trailing sentinel slot"*. That slot is not reserved — the reservation is at the
other end of the pool:

- `MambaPool` allocates `size + 1` rows.
- `MambaSlotAllocator` reserves **slot 0** as the dummy write target and hands
  out `1..size` inclusive
  (`allocator/mamba.py`: `# Slot 0 is reserved as a dummy write target for
  padded tokens.` / `self.free_slots = torch.arange(1, self.size + 1, ...)`).

So `ssm_states.shape[0] - 1 == size` — the last *allocatable* slot. A padded
row remapped there reads that slot's contents as its initial state and writes
its final state back into it, because making the index non-negative is exactly
what defeats `chunk_gated_delta_rule_fwd_h`'s `valid_state = index >= 0` guard
(which gates both the load and the `INPLACE_UPDATE` store). If a live request
or a mamba radix checkpoint owns slot `size` at that moment, its recurrent
state is silently corrupted and it produces wrong output with no error. The
slot is handed out under memory pressure, so the profile is rare and
load-dependent.

## The fix

Drop the remap and pass the sentinel through, matching the same call on `main`.
The remap is not merely misdirected but unnecessary: the guard added in #33810
already handles `-1` in the chunked extend path, and
`chunk_gated_delta_rule_fwd_h` is the only consumer of `initial_state_indices`
in the `chunk_kda` pipeline (`chunk_kda` / `chunk_kda_fwd` just thread it
through).

Remapping to slot `0` instead would also close the aliasing if you would rather
keep an explicit scratch target; passing through is proposed here because it
converges with `main` and avoids the pool write entirely.

The `.to(torch.int32)` cast goes away with the `torch.where` — the mamba index
mapping is already `int32` (`req_index_to_mamba_index_mapping`), and the
`main` call site passes `cache_indices` without a cast. Happy to keep the cast
if you prefer it retained.

## Status

Found by code audit during an unrelated DP-attention investigation (#36879), not
by an observed failure — our configuration does not produce the padded extend
rows that trigger it, so this is offered as a latent-correctness fix rather
than a validated one. The reasoning above is verified against this PR's head;
the runtime behavior change is confined to batches that actually carry `-1`
rows into the KDA extend path.

Two smaller observations from the same audit are recorded in #36880 rather than
fixed here, since both are latent and touch shared kernels: `chunk_kda` writes
its output into the caller's `v` tensor in place, and the `T=1` chunked path
reads uninitialized memory (visible as NaNs under
`torch.utils.deterministic.fill_uninitialized_memory = True`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33186220916](https://github.com/sgl-project/sglang/actions/runs/33186220916)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33186220749](https://github.com/sgl-project/sglang/actions/runs/33186220749)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33186220918](https://github.com/sgl-project/sglang/actions/runs/33186220918)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->