### PR TITLE
[AMD] release rocm10 image for gfx1250 from amd_helios

### DIFF
--- a/.github/workflows/release-docker-amd-rocm10.yml
+++ b/.github/workflows/release-docker-amd-rocm10.yml
@@ -10,6 +10,7 @@ on:
         options:
           - 'all'
           - publish
+          - publish-gfx1250
       gpu_arch:
         description: 'Select which ROCm 10 GPU arch to build'
         required: false
@@ -116,3 +117,79 @@ jobs:
         run: |
           docker tag "rocm/sgl-dev:${IMAGE_TAG}" "lmsysorg/sglang-rocm:${IMAGE_TAG}"
           docker push "lmsysorg/sglang-rocm:${IMAGE_TAG}"
+
+  # gfx1250 (MI45x) is still being brought up on the amd_helios branch: main
+  # has no gfx1250 stage in docker/rocm.Dockerfile, so this job builds from
+  # that branch rather than from the ref the workflow was triggered on. It runs
+  # on the same schedule as the pair above but stays a separate job, because
+  # there is no MI450 runner pool consuming the image and a bring-up build
+  # failure must not gate the released gfx942/gfx950 images.
+  publish-gfx1250:
+    if: github.repository == 'sgl-project/sglang' && (github.event_name != 'workflow_dispatch' || inputs.job_select == 'all' || inputs.job_select == 'publish-gfx1250')
+    runs-on: amd-docker-scale
+    environment: 'prod'
+    steps:
+      - name: Checkout amd_helios
+        uses: actions/checkout@v4
+        with:
+          ref: amd_helios
+          fetch-depth: 0
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10'
+
+      - name: Set date
+        run: echo "DATE=$(date +%Y%m%d)" >> "$GITHUB_ENV"
+
+      - name: Get version and branch head
+        id: version
+        run: |
+          VERSION=$(python3 scripts/release/get_version_tag.py --tag-only | sed 's/^v//')
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::Could not determine version from git tags"
+            exit 1
+          fi
+
+          # The checkout above is amd_helios, so this is the branch head that
+          # both the build context and the cloned sglang source come from.
+          BRANCH_SHA=$(git rev-parse HEAD)
+          COMMIT_HASH=$(git rev-parse --short HEAD)
+          PRETEND_VERSION="${VERSION}.dev${DATE}+g${COMMIT_HASH}"
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "branch_sha=${BRANCH_SHA}" >> "$GITHUB_OUTPUT"
+          echo "pretend_version=${PRETEND_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Building gfx1250 from amd_helios at ${BRANCH_SHA}"
+
+      - name: Login to Docker Hub (AMD)
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_AMD_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_AMD_TOKEN }}
+
+      - name: Build and push to rocm/sgl-dev
+        env:
+          BRANCH_SHA: ${{ steps.version.outputs.branch_sha }}
+          PRETEND_VERSION: ${{ steps.version.outputs.pretend_version }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          # `dev` marks this as built from a bring-up branch rather than from
+          # the ref the release ran on, so it never reads as a released tag.
+          image_tag="v${VERSION}-rocm10-mi45x-dev-${DATE}"
+          echo "Publishing rocm/sgl-dev:${image_tag}"
+
+          docker build . \
+            -f docker/rocm.Dockerfile \
+            --build-arg "SGL_BRANCH=${BRANCH_SHA}" \
+            --build-arg BUILD_TYPE=all \
+            --build-arg GPU_ARCH=gfx1250-rocm1000 \
+            --build-arg ENABLE_MORI=1 \
+            --build-arg ENABLE_NIXL=1 \
+            --build-arg "SETUPTOOLS_SCM_PRETEND_VERSION=${PRETEND_VERSION}" \
+            --build-arg UBUNTU_MIRROR=https://archive.ubuntu.com \
+            -t "rocm/sgl-dev:${image_tag}" \
+            --no-cache
+          docker push "rocm/sgl-dev:${image_tag}"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Adds a daily gfx1250 (MI45x) image to the ROCm 10 release workflow, on the same schedule as gfx942/gfx950.

The job checks out `amd_helios` instead of the triggering ref because main has no gfx1250 stage in `docker/rocm.Dockerfile` yet, so both the build context and `SGL_BRANCH` come from that branch head. It publishes `v<version>-rocm10-mi45x-dev-<date>` to `rocm/sgl-dev` only, where `dev` marks the image as built from the bring-up branch rather than the released ref. It stays a separate job from `publish` so a bring-up build failure cannot gate the released gfx942/gfx950 images.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33195533519](https://github.com/sgl-project/sglang/actions/runs/33195533519)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33195533369](https://github.com/sgl-project/sglang/actions/runs/33195533369)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->