### PR TITLE
Add opt-in prefill server warmup

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2185,6 +2185,24 @@ async def _send_disaggregation_warmup_requests(
         )
 
 
+def _resolve_warmup_prefill_tokens(
+    server_args: ServerArgs, configured_tokens: int, output_tokens: int
+) -> int:
+    """Cap the warmup prefill length to the server request limits."""
+    num_tokens = configured_tokens
+    if server_args.chunked_prefill_size and server_args.chunked_prefill_size > 0:
+        num_tokens = min(num_tokens, server_args.chunked_prefill_size)
+    if server_args.context_length:
+        max_prefill_tokens = server_args.context_length - output_tokens
+        if max_prefill_tokens <= 0:
+            raise ValueError(
+                "context_length must exceed the warmup output token count "
+                f"({output_tokens})"
+            )
+        num_tokens = min(num_tokens, max_prefill_tokens)
+    return num_tokens
+
+
 def _execute_server_warmup(server_args: ServerArgs):
     headers = {}
     url = server_args.url()
@@ -2310,6 +2328,42 @@ def _execute_server_warmup(server_args: ServerArgs):
                 verify=ssl_verify,
             )
             assert res.status_code == 200, f"{res.text}"
+
+            warmup_prefill_tokens = envs.SGLANG_WARMUP_PREFILL_TOKENS.get()
+            if model_info["is_generation"] and warmup_prefill_tokens > 0:
+                warmup_output_tokens = 8
+                num_tokens = _resolve_warmup_prefill_tokens(
+                    server_args, warmup_prefill_tokens, warmup_output_tokens
+                )
+                logger.info(
+                    "Triggering prefill warmup with %d input tokens and %d output "
+                    "tokens per sequence (configured input tokens: %d)",
+                    num_tokens,
+                    warmup_output_tokens,
+                    warmup_prefill_tokens,
+                )
+                warmup_ids = ([10, 11, 12, 13] * ((num_tokens + 3) // 4))[:num_tokens]
+                big_json_data = {
+                    "input_ids": (
+                        warmup_ids
+                        if get_parallel().dp_size == 1
+                        else [warmup_ids for _ in range(get_parallel().dp_size)]
+                    ),
+                    "sampling_params": {
+                        "temperature": 0,
+                        "max_new_tokens": warmup_output_tokens,
+                        "ignore_eos": True,
+                    },
+                }
+                res = requests.post(
+                    url + "/generate",
+                    json=big_json_data,
+                    headers=headers,
+                    timeout=warmup_timeout if warmup_timeout > 0 else 600,
+                    verify=ssl_verify,
+                )
+                assert res.status_code == 200, f"{res.text}"
+
             # Skip server_status update for Rust server
             if not envs.SGLANG_RUST_SERVER.get():
                 _global_state.tokenizer_manager.server_status = ServerStatus.Up

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -305,6 +305,8 @@ class Envs:
     # In seconds. If a warmup forward batch takes longer than this, the server will crash to prevent hanging.
     # Recommend to increase warmup timeout to 1800 to accommodate some kernel JIT precache e.g. deep gemm
     SGLANG_WARMUP_TIMEOUT = EnvFloat(-1)
+    # Extra boot-warmup prefill length in tokens; 0 disables it.
+    SGLANG_WARMUP_PREFILL_TOKENS = EnvInt(0)
     SGLANG_EXTERNAL_MODEL_PACKAGE = EnvStr("")
     SGLANG_EXTERNAL_MM_MODEL_ARCH = EnvStr("")
     SGLANG_EXTERNAL_MM_PROCESSOR_PACKAGE = EnvStr("")

--- a/test/registered/unit/entrypoints/test_server_warmup.py
+++ b/test/registered/unit/entrypoints/test_server_warmup.py
@@ -3,17 +3,38 @@
 import base64
 import struct
 import unittest
+from types import SimpleNamespace
 
 from sglang.srt.entrypoints.http_server import (
     KIMI_K3_VLM_WARMUP_PNG_PICTURE_BASE64,
     KIMI_VLM_WARMUP_PNG_PICTURE_BASE64,
     MINIMUM_PNG_PICTURE_BASE64,
     _get_vlm_warmup_image_base64,
+    _resolve_warmup_prefill_tokens,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestPrefillWarmup(unittest.TestCase):
+    def test_caps_to_chunked_prefill_size(self):
+        server_args = SimpleNamespace(chunked_prefill_size=512, context_length=4096)
+        self.assertEqual(_resolve_warmup_prefill_tokens(server_args, 2048, 8), 512)
+
+    def test_caps_to_context_length(self):
+        server_args = SimpleNamespace(chunked_prefill_size=-1, context_length=1024)
+        self.assertEqual(_resolve_warmup_prefill_tokens(server_args, 2048, 8), 1016)
+
+    def test_preserves_configured_length_within_limits(self):
+        server_args = SimpleNamespace(chunked_prefill_size=4096, context_length=4096)
+        self.assertEqual(_resolve_warmup_prefill_tokens(server_args, 2048, 8), 2048)
+
+    def test_rejects_context_without_input_room(self):
+        server_args = SimpleNamespace(chunked_prefill_size=-1, context_length=8)
+        with self.assertRaisesRegex(ValueError, "context_length must exceed"):
+            _resolve_warmup_prefill_tokens(server_args, 2048, 8)
 
 
 class TestVlmWarmupImage(CustomTestCase):


### PR DESCRIPTION
## Motivation

Some deployments need to exercise a larger prefill shape during server startup so relevant kernels are initialized before serving traffic. The existing warmup request is intentionally small and does not cover that shape.

## Modifications

- Add `SGLANG_WARMUP_PREFILL_TOKENS`, disabled by default.
- Send an additional token-input generation request during startup when enabled.
- Cap the requested prefill length to chunked-prefill and context-length limits.
- Add unit coverage for the length resolution behavior.

## Accuracy Tests

Not applicable; this adds an opt-in startup request and does not change model math.

## Speed Tests and Profiling

Not run; the default remains disabled, and the enabled path intentionally adds startup warmup work.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). The environment variable is documented inline and disabled by default.
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Not applicable to the disabled-by-default startup hook.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Original commits

- `372906d16`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33199994274](https://github.com/sgl-project/sglang/actions/runs/33199994274)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33199993319](https://github.com/sgl-project/sglang/actions/runs/33199993319)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33199989871](https://github.com/sgl-project/sglang/actions/runs/33199989871)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->