### PR TITLE
fix(runtime): detect tokenizer event loop stalls

### DIFF
--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -733,12 +733,19 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         if get_observability().gc_warning_threshold_secs > 0.0:
             configure_gc_warning(get_observability().gc_warning_threshold_secs)
+        soft_watchdog_timeout = get_device().soft_watchdog_timeout
         self.soft_watchdog = Watchdog.create(
             debug_name="TokenizerManager",
-            watchdog_timeout=get_device().soft_watchdog_timeout,
+            watchdog_timeout=soft_watchdog_timeout,
             soft=True,
             test_stuck_time=envs.SGLANG_TEST_STUCK_TOKENIZER.get(),
         )
+        self.event_loop_watchdog = Watchdog.create(
+            debug_name="TokenizerManager event loop",
+            watchdog_timeout=soft_watchdog_timeout,
+            soft=True,
+        )
+        self.event_loop_watchdog_enabled = soft_watchdog_timeout is not None
 
     def set_startup_time(self, startup_time: Dict[str, Any]) -> None:
         self.startup_time = startup_time
@@ -2145,6 +2152,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.asyncio_tasks.add(
             loop.create_task(print_exception_wrapper(self.handle_loop))
         )
+        if self.event_loop_watchdog_enabled:
+            self.asyncio_tasks.add(
+                loop.create_task(print_exception_wrapper(self.event_loop_watchdog_loop))
+            )
         self.event_loop = loop
 
         # We only add signal handler when the tokenizer manager is in the main thread
@@ -2160,6 +2171,11 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.asyncio_tasks.add(
             loop.create_task(print_exception_wrapper(self.sigterm_watchdog))
         )
+
+    async def event_loop_watchdog_loop(self):
+        while True:
+            self.event_loop_watchdog.feed()
+            await asyncio.sleep(1)
 
     async def handle_loop(self):
         """The event loop that handles requests"""

--- a/python/sglang/srt/managers/tokenizer_manager.py
+++ b/python/sglang/srt/managers/tokenizer_manager.py
@@ -733,19 +733,16 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
 
         if get_observability().gc_warning_threshold_secs > 0.0:
             configure_gc_warning(get_observability().gc_warning_threshold_secs)
-        soft_watchdog_timeout = get_device().soft_watchdog_timeout
         self.soft_watchdog = Watchdog.create(
             debug_name="TokenizerManager",
-            watchdog_timeout=soft_watchdog_timeout,
+            watchdog_timeout=get_device().soft_watchdog_timeout,
             soft=True,
             test_stuck_time=envs.SGLANG_TEST_STUCK_TOKENIZER.get(),
         )
-        self.event_loop_watchdog = Watchdog.create(
-            debug_name="TokenizerManager event loop",
-            watchdog_timeout=soft_watchdog_timeout,
-            soft=True,
+        self.event_loop_watchdog_timeout = (
+            get_serving().tokenizer_event_loop_watchdog_timeout
         )
-        self.event_loop_watchdog_enabled = soft_watchdog_timeout is not None
+        self.event_loop_watchdog = None
 
     def set_startup_time(self, startup_time: Dict[str, Any]) -> None:
         self.startup_time = startup_time
@@ -2152,7 +2149,12 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         self.asyncio_tasks.add(
             loop.create_task(print_exception_wrapper(self.handle_loop))
         )
-        if self.event_loop_watchdog_enabled:
+        if self.event_loop_watchdog_timeout is not None:
+            self.event_loop_watchdog = Watchdog.create(
+                debug_name="TokenizerManager event loop",
+                watchdog_timeout=self.event_loop_watchdog_timeout,
+                soft=True,
+            )
             self.asyncio_tasks.add(
                 loop.create_task(print_exception_wrapper(self.event_loop_watchdog_loop))
             )
@@ -2173,9 +2175,10 @@ class TokenizerManager(TokenizerControlMixin, TokenizerManagerScoreMixin):
         )
 
     async def event_loop_watchdog_loop(self):
+        interval = min(1.0, self.event_loop_watchdog_timeout / 2)
         while True:
             self.event_loop_watchdog.feed()
-            await asyncio.sleep(1)
+            await asyncio.sleep(interval)
 
     async def handle_loop(self):
         """The event loop that handles requests"""

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1234,6 +1234,11 @@ class ServerArgs:
         "Set soft watchdog timeout in seconds. If a forward batch takes longer than this, the server will dump information for debugging.",
         NS("device"),
     ] = None
+    tokenizer_event_loop_watchdog_timeout: A[
+        Optional[float],
+        "Set tokenizer event loop watchdog timeout in seconds. If the event loop stops responding, the server will dump information for debugging.",
+        NS("serving"),
+    ] = None
     sleep_on_idle: A[bool, "Reduce CPU usage when sglang is idle.", NS("device")] = (
         False
     )

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -3844,6 +3844,7 @@ class ServerArgs:
         self._handle_media_url_security()
         self._handle_hicache_ratio_default()
         self._validate_prefill_decode_interval()
+        self._validate_tokenizer_event_loop_watchdog()
 
         # Reject an explicitly enabled but incompatible hardware runtime before
         # model path resolution, downloads, or the dummy-model short circuit.
@@ -9742,9 +9743,17 @@ class ServerArgs:
 
     def _handle_debug_utils(self):
         cfg = resolving_view(self)
+
         if is_in_ci() and cfg.soft_watchdog_timeout is None:
             logger.info("Set soft_watchdog_timeout since in CI")
             self._declare("_handle_debug_utils", soft_watchdog_timeout=300)
+
+    def _validate_tokenizer_event_loop_watchdog(self):
+        timeout = self.tokenizer_event_loop_watchdog_timeout
+        if timeout is not None and (not math.isfinite(timeout) or timeout <= 0):
+            raise ValueError(
+                "--tokenizer-event-loop-watchdog-timeout must be finite and positive"
+            )
 
     @staticmethod
     def add_cli_args(parser: argparse.ArgumentParser):

--- a/python/sglang/srt/utils/watchdog.py
+++ b/python/sglang/srt/utils/watchdog.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import faulthandler
 import logging
 import os
 import signal
@@ -149,6 +150,7 @@ class WatchdogRaw:
         if self.dump_info is not None and (info_msg := self.dump_info()):
             logger.error(f"{self.debug_name} debug info:\n{info_msg}")
 
+        faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
         pyspy_dump_schedulers()
         logger.error(
             f"{self.debug_name} watchdog timeout "

--- a/python/sglang/srt/utils/watchdog.py
+++ b/python/sglang/srt/utils/watchdog.py
@@ -150,7 +150,10 @@ class WatchdogRaw:
         if self.dump_info is not None and (info_msg := self.dump_info()):
             logger.error(f"{self.debug_name} debug info:\n{info_msg}")
 
-        faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        try:
+            faulthandler.dump_traceback(file=sys.stderr, all_threads=True)
+        except Exception:
+            logger.exception(f"{self.debug_name} failed to dump local traceback")
         pyspy_dump_schedulers()
         logger.error(
             f"{self.debug_name} watchdog timeout "

--- a/test/registered/unit/managers/test_tokenizer_event_loop_watchdog.py
+++ b/test/registered/unit/managers/test_tokenizer_event_loop_watchdog.py
@@ -1,0 +1,28 @@
+import asyncio
+import unittest
+from unittest.mock import Mock, patch
+
+from sglang.srt.managers.tokenizer_manager import TokenizerManager
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+register_cpu_ci(est_time=1, suite="base-c-test-cpu")
+
+
+class TestTokenizerEventLoopWatchdog(unittest.IsolatedAsyncioTestCase):
+    async def test_heartbeat_feeds_watchdog(self):
+        manager = TokenizerManager.__new__(TokenizerManager)
+        manager.event_loop_watchdog = Mock()
+
+        with patch(
+            "sglang.srt.managers.tokenizer_manager.asyncio.sleep",
+            side_effect=asyncio.CancelledError,
+        ):
+            with self.assertRaises(asyncio.CancelledError):
+                await manager.event_loop_watchdog_loop()
+
+        manager.event_loop_watchdog.feed.assert_called_once_with()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/managers/test_tokenizer_event_loop_watchdog.py
+++ b/test/registered/unit/managers/test_tokenizer_event_loop_watchdog.py
@@ -13,6 +13,7 @@ class TestTokenizerEventLoopWatchdog(unittest.IsolatedAsyncioTestCase):
     async def test_heartbeat_feeds_watchdog(self):
         manager = TokenizerManager.__new__(TokenizerManager)
         manager.event_loop_watchdog = Mock()
+        manager.event_loop_watchdog_timeout = 30
 
         with patch(
             "sglang.srt.managers.tokenizer_manager.asyncio.sleep",

--- a/test/registered/unit/test_server_args_migration.py
+++ b/test/registered/unit/test_server_args_migration.py
@@ -152,6 +152,10 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
         sa = self._parse(["--stream-output"])
         self.assertTrue(sa.incremental_streaming_output)
 
+    def test_tokenizer_event_loop_watchdog_timeout(self):
+        sa = self._parse(["--tokenizer-event-loop-watchdog-timeout", "30"])
+        self.assertEqual(sa.tokenizer_event_loop_watchdog_timeout, 30.0)
+
     def test_combined_parse(self):
         """Multiple option types parsed together in one invocation."""
         sa = self._parse(

--- a/test/registered/unit/test_server_args_migration.py
+++ b/test/registered/unit/test_server_args_migration.py
@@ -156,6 +156,11 @@ class TestServerArgsAnnotatedCli(CustomTestCase):
         sa = self._parse(["--tokenizer-event-loop-watchdog-timeout", "30"])
         self.assertEqual(sa.tokenizer_event_loop_watchdog_timeout, 30.0)
 
+    def test_rejects_invalid_tokenizer_event_loop_watchdog_timeout(self):
+        for timeout in ("0", "-1", "nan", "inf"):
+            with self.subTest(timeout=timeout), self.assertRaises(ValueError):
+                self._parse(["--tokenizer-event-loop-watchdog-timeout", timeout])
+
     def test_combined_parse(self):
         """Multiple option types parsed together in one invocation."""
         sa = self._parse(

--- a/test/registered/unit/utils/test_subprocess_watchdog.py
+++ b/test/registered/unit/utils/test_subprocess_watchdog.py
@@ -163,6 +163,31 @@ class TestWatchdogRaw(CustomTestCase):
 
         self.assertEqual(calls, ["faulthandler", "pyspy"])
 
+    def test_traceback_failure_does_not_disable_hard_watchdog(self):
+        watchdog = WatchdogRaw.__new__(WatchdogRaw)
+        watchdog.debug_name = "test"
+        watchdog.get_counter = lambda: 0
+        watchdog.is_active = lambda: True
+        watchdog.watchdog_timeout = 1
+        watchdog.soft = False
+        watchdog.dump_info = None
+        watchdog.parent_process = unittest.mock.Mock()
+
+        with (
+            unittest.mock.patch(
+                "sglang.srt.utils.watchdog.time.perf_counter", side_effect=[0, 2]
+            ),
+            unittest.mock.patch("sglang.srt.utils.watchdog.time.sleep"),
+            unittest.mock.patch(
+                "sglang.srt.utils.watchdog.faulthandler.dump_traceback",
+                side_effect=RuntimeError("stderr unavailable"),
+            ),
+            unittest.mock.patch("sglang.srt.utils.watchdog.pyspy_dump_schedulers"),
+        ):
+            watchdog._watchdog_once()
+
+        watchdog.parent_process.send_signal.assert_called_once_with(signal.SIGQUIT)
+
 
 if __name__ == "__main__":
     import unittest

--- a/test/registered/unit/utils/test_subprocess_watchdog.py
+++ b/test/registered/unit/utils/test_subprocess_watchdog.py
@@ -20,7 +20,7 @@ import threading
 import time
 import unittest.mock
 
-from sglang.srt.utils.watchdog import SubprocessWatchdog
+from sglang.srt.utils.watchdog import SubprocessWatchdog, WatchdogRaw
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -133,6 +133,35 @@ class TestSubprocessWatchdog(CustomTestCase):
             self.sigquit_triggered.is_set(),
             "SIGQUIT should not be triggered for normal exit (exitcode=0)",
         )
+
+
+class TestWatchdogRaw(CustomTestCase):
+    def test_timeout_dumps_local_traceback_before_pyspy(self):
+        watchdog = WatchdogRaw.__new__(WatchdogRaw)
+        watchdog.debug_name = "test"
+        watchdog.get_counter = lambda: 0
+        watchdog.is_active = lambda: True
+        watchdog.watchdog_timeout = 1
+        watchdog.soft = True
+        watchdog.dump_info = None
+
+        calls = []
+        with (
+            unittest.mock.patch(
+                "sglang.srt.utils.watchdog.time.perf_counter", side_effect=[0, 2]
+            ),
+            unittest.mock.patch(
+                "sglang.srt.utils.watchdog.faulthandler.dump_traceback",
+                side_effect=lambda **_: calls.append("faulthandler"),
+            ),
+            unittest.mock.patch(
+                "sglang.srt.utils.watchdog.pyspy_dump_schedulers",
+                side_effect=lambda: calls.append("pyspy"),
+            ),
+        ):
+            watchdog._watchdog_once()
+
+        self.assertEqual(calls, ["faulthandler", "pyspy"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

The tokenizer process can stop serving health checks while scheduler subprocesses continue. The existing tokenizer watchdog is disabled while waiting for detokenizer output, and py-spy may be unavailable in restricted production containers.

## Modifications

- Add a tokenizer-specific event-loop watchdog that starts with the request event loop.
- Dump all local thread stacks with `faulthandler` before attempting existing py-spy diagnostics.
- Keep traceback collection best-effort so hard-watchdog recovery continues if stderr is unavailable.
- Add `--tokenizer-event-loop-watchdog-timeout` and reject non-finite or non-positive values.

## Accuracy Tests

No model output changes.

## Speed Tests and Profiling

No benchmark was required. When enabled, the watchdog adds at most one asyncio wakeup per second. It is disabled by default.

## Tests

```bash
PYTHONPATH=python /Users/kflansburg/miniforge3/bin/python -m pytest -q \
  test/registered/unit/utils/test_subprocess_watchdog.py::TestWatchdogRaw \
  test/registered/unit/managers/test_tokenizer_event_loop_watchdog.py \
  test/registered/unit/test_server_args_migration.py::TestServerArgsAnnotatedCli::test_tokenizer_event_loop_watchdog_timeout \
  test/registered/unit/test_server_args_migration.py::TestServerArgsAnnotatedCli::test_rejects_invalid_tokenizer_event_loop_watchdog_timeout
```

Result: 5 passed.

Pre-commit passed for all changed files.

## Checklist

- [x] Format code with pre-commit.
- [x] Add focused unit tests.
- [x] Confirm no model accuracy impact.
- [x] Confirm the watchdog is disabled by default.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->