### PR TITLE
[DSA] Enable tilelang fp8_e4m3 KV cache on CUDA (raw layout) — verified on sm_121

### DIFF
--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -1369,9 +1369,7 @@ def tilelang_sparse_fwd(
 
     is_fp8_kv = kv.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
     if _is_hip or is_fp8_kv:
-        assert (
-            not return_lse
-        ), "tilelang partial+combine sparse fwd does not return LSE"
+        assert not return_lse, "tilelang partial+combine sparse fwd does not return LSE"
         if is_fp8_kv:
             if q.dtype != kv.dtype:
                 q = q.to(kv.dtype)

--- a/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
+++ b/python/sglang/kernels/ops/attention/dsa/tilelang_kernel.py
@@ -71,6 +71,13 @@ def fast_round_scale(amax, fp8_max_inv):
     return fast_pow2(fast_log2_ceil(amax * fp8_max_inv))
 
 
+@lru_cache(maxsize=1)
+def _cuda_sm_count() -> int:
+    return torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+
+
 @lru_cache(maxsize=8)
 def _pick_inner_iter(seq: int, ni: int, cu: int, block_per_cu: int) -> int:
     """
@@ -1360,13 +1367,22 @@ def tilelang_sparse_fwd(
     topk = indices.shape[-1]
     assert topk % 64 == 0, "topk must be padded to a multiple of 64"
 
-    if _is_hip:
-        assert not return_lse, "tilelang HIP sparse fwd does not return LSE"
-        is_fp8_kv = kv.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+    is_fp8_kv = kv.dtype in (torch.float8_e4m3fn, torch.float8_e4m3fnuz)
+    if _is_hip or is_fp8_kv:
+        assert (
+            not return_lse
+        ), "tilelang partial+combine sparse fwd does not return LSE"
         if is_fp8_kv:
             if q.dtype != kv.dtype:
                 q = q.to(kv.dtype)
-            if _is_gfx95_supported:
+            if not _is_hip:
+                # CUDA: the fp8 partial kernel is generic TileLang (no HIP
+                # intrinsics). Tiles sized for the ~100 KB dynamic-smem class
+                # (SM12x): fp8 K tiles are half the bytes of bf16, so
+                # block_I=32/threads=128 uses ~25 KB smem and block_I=64
+                # would use ~42 KB; 32/128 is the shape validated on GB10.
+                block_I, threads, block_per_cu, cu = 32, 128, 1, _cuda_sm_count()
+            elif _is_gfx95_supported:
                 block_I, threads, block_per_cu, cu = 64, 256, 2, 256
             else:
                 block_I, threads, block_per_cu, cu = 64, 256, 1, 304

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1918,6 +1918,7 @@ def _check_tilelang_dsa_fp8_kv(
     decode_backend: Optional[str],
     *,
     hip: bool,
+    dcp_size: int = 1,
 ) -> None:
     """tilelang's fp8 KV path stores the raw MLA layout (nope + rope cast to
     fp8_e4m3, no per-tile scales). On ROCm/HIP it is the default DSA path. On
@@ -1932,6 +1933,13 @@ def _check_tilelang_dsa_fp8_kv(
         or "tilelang" not in {prefill_backend, decode_backend}
     ):
         return
+    if dcp_size > 1:
+        raise ValueError(
+            "The tilelang DSA fp8_e4m3 KV path on CUDA stores the raw MLA "
+            "layout and its fused-quant writer does not apply the DCP rank "
+            "filter, so it is incompatible with --dcp-size > 1. Use "
+            "--kv-cache-dtype bfloat16 with DCP, or dcp_size 1 with fp8."
+        )
     if prefill_backend != decode_backend:
         raise ValueError(
             "On CUDA, an fp8_e4m3 KV cache with a tilelang DSA backend requires "
@@ -2034,7 +2042,13 @@ def _dsa_split_backend_resolution(view: Any) -> dict:
 
     prefill = declared.get("dsa_prefill_backend", view.dsa_prefill_backend)
     decode = declared.get("dsa_decode_backend", view.dsa_decode_backend)
-    _check_tilelang_dsa_fp8_kv(kv_cache_dtype, prefill, decode, hip=is_hip())
+    _check_tilelang_dsa_fp8_kv(
+        kv_cache_dtype,
+        prefill,
+        decode,
+        hip=is_hip(),
+        dcp_size=getattr(view, "dcp_size", 1) or 1,
+    )
     logger.warning(
         f"Set DSA backends for {kv_cache_dtype} KV Cache: "
         f"prefill={prefill}, decode={decode}."

--- a/python/sglang/srt/arg_groups/overrides.py
+++ b/python/sglang/srt/arg_groups/overrides.py
@@ -1919,20 +1919,42 @@ def _check_tilelang_dsa_fp8_kv(
     *,
     hip: bool,
 ) -> None:
-    """tilelang's fp8 KV path is ROCm-only; the CUDA kernel hardcodes bfloat16.
-    Reject here instead of crashing at decode CUDA-graph capture."""
+    """tilelang's fp8 KV path stores the raw MLA layout (nope + rope cast to
+    fp8_e4m3, no per-tile scales). On ROCm/HIP it is the default DSA path. On
+    CUDA the same generic TileLang fp8 kernel is used, but it requires fp8
+    tensor-core MMA (SM89+) and BOTH DSA backends to be tilelang, because every
+    other CUDA fp8 backend expects the scaled pool layout
+    (nope_fp8 + per-tile scales + bf16 rope). Reject unsupported combinations
+    here instead of crashing at decode CUDA-graph capture."""
     if (
-        not hip
-        and kv_cache_dtype == "fp8_e4m3"
-        and "tilelang" in {prefill_backend, decode_backend}
+        hip
+        or kv_cache_dtype != "fp8_e4m3"
+        or "tilelang" not in {prefill_backend, decode_backend}
     ):
+        return
+    if prefill_backend != decode_backend:
         raise ValueError(
-            "The tilelang DSA prefill/decode kernels only support an fp8_e4m3 KV "
-            "cache on ROCm/HIP; on CUDA they require a bfloat16 KV cache. Use "
-            "--kv-cache-dtype bfloat16 with the tilelang backend, or keep "
-            "--kv-cache-dtype fp8_e4m3 and pick an fp8-capable DSA backend "
+            "On CUDA, an fp8_e4m3 KV cache with a tilelang DSA backend requires "
+            "BOTH --dsa-prefill-backend and --dsa-decode-backend to be tilelang: "
+            "tilelang consumes the raw fp8 MLA KV layout, while the other CUDA "
+            "backends expect the scaled (nope_fp8 + scales + bf16 rope) layout "
+            f"(got prefill={prefill_backend}, decode={decode_backend})."
+        )
+    import torch
+
+    major, minor = torch.cuda.get_device_capability()
+    if major * 10 + minor < 89:
+        raise ValueError(
+            "The tilelang DSA fp8_e4m3 KV path on CUDA requires fp8 tensor-core "
+            f"MMA (SM89+); got sm_{major}{minor}. Use --kv-cache-dtype bfloat16 "
+            "with the tilelang backend, or pick an fp8-capable DSA backend "
             "(flashmla_kv on Hopper, trtllm on Blackwell)."
         )
+    logger.warning(
+        "Enabling the tilelang DSA fp8_e4m3 KV cache on CUDA: KV is stored as "
+        "raw fp8 (no per-tile scales), matching the ROCm tilelang path. Expect "
+        "a small accuracy delta vs a bfloat16 KV cache."
+    )
 
 
 @register_post_process

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -535,6 +535,16 @@ class DeepseekSparseAttnBackend(
         self.supports_mha_one_shot: bool = True
         self.dsa_prefill_impl: _DSA_IMPL_T = get_exec().kernel.dsa_prefill_backend
         self.dsa_decode_impl: _DSA_IMPL_T = get_exec().kernel.dsa_decode_backend
+        if (
+            not _is_hip
+            and self.token_to_kv_pool.dtype == torch.float8_e4m3fn
+            and not self.dsa_kv_cache_store_fp8
+            and "tilelang" in (self.dsa_prefill_impl, self.dsa_decode_impl)
+        ):
+            # CUDA TileLang fp8 path stores the raw (unscaled) MLA KV layout;
+            # the MHA_ONE_SHOT fp8 dequant helpers assume the scaled layout,
+            # so keep the one-shot MHA fast path off.
+            self.supports_mha_one_shot = False
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend.resolve(model_runner)
         if self.num_q_heads <= 64:
             self.flashmla_kv_num_q_heads = 64

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -2291,6 +2291,16 @@ def calculate_mla_kv_cache_dim(
     ):
         return kv_cache_dim
 
+    # On CUDA, the TileLang DSA kernels likewise consume the raw MLA KV layout
+    # when the KV cache is fp8. Arg validation (_check_tilelang_dsa_fp8_kv)
+    # guarantees prefill == decode == tilelang whenever tilelang is combined
+    # with an fp8_e4m3 KV cache on CUDA, so no mixed-layout consumer exists.
+    if not _is_hip and (
+        get_exec().kernel.dsa_prefill_backend == "tilelang"
+        and get_exec().kernel.dsa_decode_backend == "tilelang"
+    ):
+        return kv_cache_dim
+
     quant_block_size = DSATokenToKVPool.quant_block_size
     rope_storage_dtype = DSATokenToKVPool.rope_storage_dtype
     # Calculate override_kv_cache_dim for FP8 storage in backends that use scaled KV layout

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4463,9 +4463,18 @@ class MLATokenToKVPool(KVCache):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ) -> None:
-        if _is_hip and self.use_dsa and self.dtype == fp8_dtype:
-            # HIP FP8 path uses raw MLA KV layout (nope + rope) without per-block scales.
+        if (
+            self.use_dsa
+            and self.dtype == fp8_dtype
+            and not self.dsa_kv_cache_store_fp8
+        ):
+            # Raw MLA KV layout (nope + rope cast to fp8) without per-block
+            # scales: the HIP DSA kernels and the CUDA TileLang fp8 path.
             # Fuse BF16/FP16 -> FP8 cast with paged KV write.
+            if cache_k_rope is None:
+                cache_k_rope = cache_k_nope.new_empty(
+                    (*cache_k_nope.shape[:-1], 0)
+                )
             set_mla_kv_buffer_triton_fp8_quant(
                 dst_buffer,
                 loc,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4463,18 +4463,12 @@ class MLATokenToKVPool(KVCache):
         cache_k_nope: torch.Tensor,
         cache_k_rope: torch.Tensor,
     ) -> None:
-        if (
-            self.use_dsa
-            and self.dtype == fp8_dtype
-            and not self.dsa_kv_cache_store_fp8
-        ):
+        if self.use_dsa and self.dtype == fp8_dtype and not self.dsa_kv_cache_store_fp8:
             # Raw MLA KV layout (nope + rope cast to fp8) without per-block
             # scales: the HIP DSA kernels and the CUDA TileLang fp8 path.
             # Fuse BF16/FP16 -> FP8 cast with paged KV write.
             if cache_k_rope is None:
-                cache_k_rope = cache_k_nope.new_empty(
-                    (*cache_k_nope.shape[:-1], 0)
-                )
+                cache_k_rope = cache_k_nope.new_empty((*cache_k_nope.shape[:-1], 0))
             set_mla_kv_buffer_triton_fp8_quant(
                 dst_buffer,
                 loc,

--- a/test/registered/attention/test_dsa_tilelang_fp8_kv_cuda.py
+++ b/test/registered/attention/test_dsa_tilelang_fp8_kv_cuda.py
@@ -1,0 +1,62 @@
+"""Execution test for the CUDA raw-fp8 tilelang DSA sparse path.
+
+Validated on sm_121 (DGX Spark GB10); requires SM89+ for fp8 tensor-core MMA.
+One-hot construction makes the sparse attention output exactly recoverable, so
+the fp8 path must match a bf16 reference to tight tolerance; a scrambled-index
+negative control must NOT match (guards against the test passing vacuously).
+"""
+
+import pytest
+import torch
+
+tilelang_kernel = pytest.importorskip(
+    "sglang.kernels.ops.attention.dsa.tilelang_kernel"
+)
+
+requires_fp8_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available()
+    or torch.cuda.get_device_capability() < (8, 9),
+    reason="needs CUDA SM89+ for fp8 tensor-core MMA",
+)
+
+H, DV, TOPK, SKV = 32, 512, 128, 4096  # GLM-5.3-Flash per-rank geometry, NoPE
+
+
+def _one_hot_case(seed: int):
+    g = torch.Generator(device="cuda").manual_seed(seed)
+    q = torch.randn(1, 1, H, DV, device="cuda", generator=g, dtype=torch.bfloat16)
+    kv = torch.randn(1, SKV, 1, DV, device="cuda", generator=g, dtype=torch.bfloat16)
+    # One hot: q row i attends overwhelmingly to kv row target[i] by scaling.
+    target = torch.randint(0, TOPK, (H,), device="cuda", generator=g)
+    indices = torch.randperm(SKV, device="cuda", generator=g)[:TOPK]
+    indices = indices.view(1, 1, TOPK).int()
+    for h in range(H):
+        q[0, 0, h] = 100.0 * kv[0, indices[0, 0, target[h]].long(), 0]
+    expected = kv[0, indices[0, 0, target.long()].long(), 0].float()
+    return q, kv, indices, expected
+
+
+@requires_fp8_cuda
+def test_fp8_one_hot_matches_reference():
+    q, kv, indices, expected = _one_hot_case(0)
+    out = tilelang_kernel.tilelang_sparse_fwd(
+        q.to(torch.float8_e4m3fn), kv.to(torch.float8_e4m3fn), indices
+    )
+    got = out.view(H, DV).float()
+    rel = (got - expected).abs().max() / expected.abs().max()
+    assert rel < 0.08, f"fp8 one-hot rel err {rel:.4f} exceeds tolerance"
+
+
+@requires_fp8_cuda
+def test_fp8_negative_control_scrambled_indices_fails():
+    q, kv, indices, expected = _one_hot_case(1)
+    scrambled = indices.flip(-1).contiguous()
+    out = tilelang_kernel.tilelang_sparse_fwd(
+        q.to(torch.float8_e4m3fn), kv.to(torch.float8_e4m3fn), scrambled
+    )
+    got = out.view(H, DV).float()
+    rel = (got - expected).abs().max() / expected.abs().max()
+    assert rel > 0.5, (
+        "scrambled indices still matched the reference — the harness is not "
+        f"actually testing the sparse path (rel err {rel:.4f})"
+    )

--- a/test/registered/attention/test_dsa_tilelang_fp8_kv_cuda.py
+++ b/test/registered/attention/test_dsa_tilelang_fp8_kv_cuda.py
@@ -15,13 +15,16 @@ fail when the path is broken:
 import pytest
 import torch
 
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=90, stage="base-b", runner_config="1-gpu-small")
+
 tilelang_kernel = pytest.importorskip(
     "sglang.kernels.ops.attention.dsa.tilelang_kernel"
 )
 
 requires_fp8_cuda = pytest.mark.skipif(
-    not torch.cuda.is_available()
-    or torch.cuda.get_device_capability() < (8, 9),
+    not torch.cuda.is_available() or torch.cuda.get_device_capability() < (8, 9),
     reason="needs CUDA SM89+ for fp8 tensor-core MMA",
 )
 
@@ -83,12 +86,8 @@ def test_fp8_spread_within_budget_and_negative_control_fails():
     assert rel < 0.04, f"spread-case rel err {rel:.5f} exceeds fp8-prob budget"
 
     idx_bad = idx.clone()
-    idx_bad[:, :, : TOPK // 2] = idx[:, :, TOPK // 2 : TOPK].flip(-1)[
-        :, :, : TOPK // 2
-    ]
-    out_bad = tilelang_kernel.tilelang_sparse_fwd(
-        q, kv_fp8, idx_bad, SM_SCALE, d_v=DV
-    )
+    idx_bad[:, :, : TOPK // 2] = idx[:, :, TOPK // 2 : TOPK].flip(-1)[:, :, : TOPK // 2]
+    out_bad = tilelang_kernel.tilelang_sparse_fwd(q, kv_fp8, idx_bad, SM_SCALE, d_v=DV)
     torch.cuda.synchronize()
     rel_bad = _rel_err(out_bad.reshape(S, H, DV), ref)
     assert rel_bad > 0.04, (

--- a/test/registered/attention/test_dsa_tilelang_fp8_kv_cuda.py
+++ b/test/registered/attention/test_dsa_tilelang_fp8_kv_cuda.py
@@ -1,9 +1,15 @@
 """Execution test for the CUDA raw-fp8 tilelang DSA sparse path.
 
-Validated on sm_121 (DGX Spark GB10); requires SM89+ for fp8 tensor-core MMA.
-One-hot construction makes the sparse attention output exactly recoverable, so
-the fp8 path must match a bf16 reference to tight tolerance; a scrambled-index
-negative control must NOT match (guards against the test passing vacuously).
+Ported from the probe validated on sm_121 (DGX Spark GB10); requires SM89+
+for fp8 tensor-core MMA. Two properties, each of which has been observed to
+fail when the path is broken:
+  1. one-hot: a single valid index per token makes softmax exactly 1.0 and
+     the fp8 prob-quant exact, so the kernel must return the gathered V row
+     nearly bit-exactly (decisive for gather/mask/normalize plumbing);
+  2. spread case vs an fp32 reference computed from the SAME quantized
+     inputs must sit inside the analytic fp8-prob-GEMM budget (0.04), and a
+     scrambled-index negative control must blow past it (proves the
+     comparator discriminates).
 """
 
 import pytest
@@ -19,44 +25,73 @@ requires_fp8_cuda = pytest.mark.skipif(
     reason="needs CUDA SM89+ for fp8 tensor-core MMA",
 )
 
-H, DV, TOPK, SKV = 32, 512, 128, 4096  # GLM-5.3-Flash per-rank geometry, NoPE
+S, H, DV, TOPK, POOL = 4, 32, 512, 2112, 32768  # GLM-5.3-Flash NoPE geometry
+SM_SCALE = DV**-0.5
 
 
-def _one_hot_case(seed: int):
+def _rel_err(a, b):
+    return ((a.float() - b.float()).abs().max() / b.float().abs().max()).item()
+
+
+def _make_inputs(seed):
     g = torch.Generator(device="cuda").manual_seed(seed)
-    q = torch.randn(1, 1, H, DV, device="cuda", generator=g, dtype=torch.bfloat16)
-    kv = torch.randn(1, SKV, 1, DV, device="cuda", generator=g, dtype=torch.bfloat16)
-    # One hot: q row i attends overwhelmingly to kv row target[i] by scaling.
-    target = torch.randint(0, TOPK, (H,), device="cuda", generator=g)
-    indices = torch.randperm(SKV, device="cuda", generator=g)[:TOPK]
-    indices = indices.view(1, 1, TOPK).int()
-    for h in range(H):
-        q[0, 0, h] = 100.0 * kv[0, indices[0, 0, target[h]].long(), 0]
-    expected = kv[0, indices[0, 0, target.long()].long(), 0].float()
-    return q, kv, indices, expected
+    q = torch.randn(S, H, DV, device="cuda", dtype=torch.float32, generator=g) * 0.5
+    kv = torch.randn(POOL, 1, DV, device="cuda", dtype=torch.float32, generator=g) * 0.5
+    idx = torch.randint(1, POOL, (S, 1, TOPK), device="cuda", generator=g).to(
+        torch.int32
+    )
+    idx[:, :, -37:] = -1  # exercise the padded-tail mask path
+    return q.to(torch.bfloat16), kv.to(torch.bfloat16), idx
+
+
+def _ref_attn_fp32(q32, kv32, idx):
+    out = torch.empty(S, H, DV, device="cuda", dtype=torch.float32)
+    kvf = kv32.squeeze(1)
+    for i in range(S):
+        ids = idx[i, 0].long()
+        m = ids >= 0
+        k = kvf[ids.clamp(min=0)]
+        logits = (q32[i] @ k.T) * SM_SCALE
+        logits[:, ~m] = float("-inf")
+        p = torch.softmax(logits, dim=-1)
+        out[i] = p @ k
+    return out
 
 
 @requires_fp8_cuda
-def test_fp8_one_hot_matches_reference():
-    q, kv, indices, expected = _one_hot_case(0)
-    out = tilelang_kernel.tilelang_sparse_fwd(
-        q.to(torch.float8_e4m3fn), kv.to(torch.float8_e4m3fn), indices
-    )
-    got = out.view(H, DV).float()
-    rel = (got - expected).abs().max() / expected.abs().max()
-    assert rel < 0.08, f"fp8 one-hot rel err {rel:.4f} exceeds tolerance"
+def test_fp8_one_hot_exact():
+    q, kv, _ = _make_inputs(0)
+    kv_fp8 = kv.to(torch.float8_e4m3fn)
+    idx_hot = torch.full((S, 1, TOPK), -1, device="cuda", dtype=torch.int32)
+    hot = torch.randint(1, POOL, (S,), device="cuda")
+    idx_hot[:, 0, 0] = hot.to(torch.int32)
+    out = tilelang_kernel.tilelang_sparse_fwd(q, kv_fp8, idx_hot, SM_SCALE, d_v=DV)
+    torch.cuda.synchronize()
+    expect = kv_fp8.float().squeeze(1)[hot.long()].unsqueeze(1).expand(S, H, DV)
+    rel = _rel_err(out.reshape(S, H, DV), expect)
+    assert rel < 1e-3, f"one-hot rel err {rel:.6f} exceeds 1e-3"
 
 
 @requires_fp8_cuda
-def test_fp8_negative_control_scrambled_indices_fails():
-    q, kv, indices, expected = _one_hot_case(1)
-    scrambled = indices.flip(-1).contiguous()
-    out = tilelang_kernel.tilelang_sparse_fwd(
-        q.to(torch.float8_e4m3fn), kv.to(torch.float8_e4m3fn), scrambled
+def test_fp8_spread_within_budget_and_negative_control_fails():
+    q, kv, idx = _make_inputs(1)
+    kv_fp8 = kv.to(torch.float8_e4m3fn)
+    out = tilelang_kernel.tilelang_sparse_fwd(q, kv_fp8, idx, SM_SCALE, d_v=DV)
+    torch.cuda.synchronize()
+    ref = _ref_attn_fp32(q.to(torch.float8_e4m3fn).float(), kv_fp8.float(), idx)
+    rel = _rel_err(out.reshape(S, H, DV), ref)
+    assert rel < 0.04, f"spread-case rel err {rel:.5f} exceeds fp8-prob budget"
+
+    idx_bad = idx.clone()
+    idx_bad[:, :, : TOPK // 2] = idx[:, :, TOPK // 2 : TOPK].flip(-1)[
+        :, :, : TOPK // 2
+    ]
+    out_bad = tilelang_kernel.tilelang_sparse_fwd(
+        q, kv_fp8, idx_bad, SM_SCALE, d_v=DV
     )
-    got = out.view(H, DV).float()
-    rel = (got - expected).abs().max() / expected.abs().max()
-    assert rel > 0.5, (
-        "scrambled indices still matched the reference — the harness is not "
-        f"actually testing the sparse path (rel err {rel:.4f})"
+    torch.cuda.synchronize()
+    rel_bad = _rel_err(out_bad.reshape(S, H, DV), ref)
+    assert rel_bad > 0.04, (
+        "scrambled indices still matched the reference — the comparator is "
+        f"not discriminating (rel err {rel_bad:.5f})"
     )


### PR DESCRIPTION
**Stacked on #36507; mergeable once that lands. Opening now for visibility per #36830.**

## Summary
The tilelang DSA backend already ships a complete raw-fp8 sparse attention kernel (`sparse_mla_fwd_decode_partial_fp8` — generic TileLang, no HIP intrinsics). It is unreachable on CUDA because three plumbing sites are HIP-gated, and CUDA is always handed the scaled 528 B/token pool layout the kernel cannot parse. This PR routes the raw 512 B/token layout on CUDA when both DSA backends are tilelang, relaxes the arg gate accordingly (SM89+, hard error on mixed backends), and keys the raw fused-quant write on layout rather than platform (strictly more correct on HIP as well).

## Changes (5 files + test)
1. `srt/arg_groups/overrides.py` — `_check_tilelang_dsa_fp8_kv`: allow CUDA when prefill+decode backends are both tilelang and SM>=89; explicit ValueError on mixed backends; warning log on enablement (serves as a point-of-effect check)
2. `srt/mem_cache/kv_cache_configurator.py` — `calculate_mla_kv_cache_dim`: CUDA + both-tilelang -> raw dim -> raw fp8 pool
3. `srt/mem_cache/memory_pool.py` — `_write_mla_kv_buffer`: raw-write branch keyed on `not dsa_kv_cache_store_fp8` instead of `_is_hip`; None-guard for `cache_k_rope` (NoPE models: GLM-5.3-Flash has `qk_rope_head_dim=0`)
4. `kernels/ops/attention/dsa/tilelang_kernel.py` — dispatch to the fp8 partial kernel on CUDA under the same condition, with fp8-sized tiles for the ~100KB dynamic-smem class. The broader GB10 tile retune is deliberately NOT in this PR (separate arch-conditional proposal per our #36507 comment) — this diff is fp8 routing only.
5. `srt/layers/attention/dsa_backend.py` — `supports_mha_one_shot=False` for raw-fp8 (the one-shot fp8 dequant helpers assume the scaled layout)
6. `test/registered/attention/test_dsa_tilelang_fp8_kv_cuda.py` — one-hot exactness vs gathered reference, spread case within the analytic fp8-prob budget, and a scrambled-index negative control that must fail (guards against a vacuous comparator). Executed on sm_121: 2 passed.

## Hardware coverage — stated plainly
Validated end-to-end ONLY on sm_121 (2x DGX Spark GB10). The SM89+ gate follows the kernel's own requirements, but SM89/SM90 are untested by us. Review/CI verification on other archs invited.

## Validation (2x DGX Spark GB10 sm_121, GLM-5.3-Flash NVFP4, TP=2, DFlash2 drafter bf16)
- Kernel: one-hot exact rel_err 0.000000; scrambled-index negative control fails at 91%; spread case 2.35% = analytic fp8-prob GEMM noise
- Boot-gate negative control (tilelang + flashmla_sparse + fp8) dies with the new error, as required
- Decode n=5 medians: 29.2 code vs 29.8 same-image bf16 (parity); temp-0 outputs 4/5 exactly identical; 32k-depth recall probe pass (re #36390); TTFT@16k warm 6.6 s vs 7.9 s bf16 (~17% faster prefill)
- Concurrency note: an earlier "raw layout resolves single-stream" caveat was wrong — root cause was the mamba state cache capping ALL DFLASH configs at 2 streams, filed separately as #36889 (+75% aggregate at c12 once lifted). fp8-KV and 8-way concurrency coexist.

## Credits
Kernel-path analysis and port from a 2x DGX Spark homelab; validation protocol and full experiment ladder: https://github.com/beastllama/GLM-5.3-Flash-DFlash2-SGLang-2x-DGX-Spark

Addresses #36830. Concurrency companion: #36889. Relevant to #36390 (ROCm fp8 accuracy) and the sm_121 bring-up in #36845/#36806.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33206743796](https://github.com/sgl-project/sglang/actions/runs/33206743796)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33206743584](https://github.com/sgl-project/sglang/actions/runs/33206743584)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33206743786](https://github.com/sgl-project/sglang/actions/runs/33206743786)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->