### PR TITLE
[CPU] Use the shm kernel for all_gather_into_tensor

### DIFF
--- a/python/sglang/srt/distributed/parallel_state.py
+++ b/python/sglang/srt/distributed/parallel_state.py
@@ -65,6 +65,7 @@ from sglang.srt.utils import (
     is_musa,
     is_npu,
     is_shm_available,
+    is_shm_gather_available,
     is_xpu,
 )
 from sglang.srt.utils.custom_op import register_custom_op
@@ -1266,8 +1267,15 @@ class GroupCoordinator:
         return envs.SGLANG_ENABLE_DETERMINISTIC_INFERENCE.get()
 
     def all_gather_into_tensor(self, output: torch.Tensor, input: torch.Tensor):
-        if _is_npu or _is_cpu:
-            # TODO: add optimized all_gather_into_tensor kernel for cpu
+        # The shm region is sized to the TP group, so a degenerate group must not
+        # reach it -- the kernel would gather over the initialized world instead.
+        if (
+            _is_cpu
+            and self.world_size > 1
+            and is_shm_gather_available(self.world_size, self.local_size)
+        ):
+            torch.ops.sgl_kernel.shm_allgather_into_tensor(output, input)
+        elif _is_npu or _is_cpu:
             self._all_gather_into_tensor(output, input)
         else:
             # XPU and CUDA both go through reg_all_gather_into_tensor (custom_op) to
@@ -1333,7 +1341,7 @@ class GroupCoordinator:
 
         # All-gather.
         if input_.is_cpu:
-            if is_shm_available(input_.dtype, self.world_size, self.local_size):
+            if is_shm_gather_available(self.world_size, self.local_size):
                 return torch.ops.sgl_kernel.shm_allgather(input_, dim)
             else:
                 torch.distributed.all_gather_into_tensor(

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -4151,13 +4151,21 @@ def get_cpu_ids_by_node():
     return cpu_ids
 
 
-def is_shm_available(dtype, world_size, local_size):
+def is_shm_gather_available(world_size, local_size):
+    # Gather collectives only move bytes, so unlike allreduce they are dtype-agnostic.
     return (
         (cpu_has_amx_support() or is_host_cpu_arm64())
-        and dtype in [torch.bfloat16, torch.float16, torch.float]
         and world_size >= 1
         and world_size == local_size
     )
+
+
+def is_shm_available(dtype, world_size, local_size):
+    return is_shm_gather_available(world_size, local_size) and dtype in [
+        torch.bfloat16,
+        torch.float16,
+        torch.float,
+    ]
 
 
 def lru_cache_frozenset(maxsize=128):

--- a/test/registered/cpu/test_comm.py
+++ b/test/registered/cpu/test_comm.py
@@ -54,11 +54,28 @@ def all_reduce_fn(rank, world_size):
         torch.testing.assert_close(tensor, tensor_shm)
 
 
+def _sample(dtype):
+    if dtype.is_floating_point:
+        return torch.randn(2, 10, dtype=dtype)
+    return torch.randint(-1000, 1000, (2, 10), dtype=dtype)
+
+
+# Gather moves bytes instead of reducing, so it is not limited to the float
+# dtypes shm_allreduce supports.
+GATHER_DTYPES = [
+    torch.float32,
+    torch.bfloat16,
+    torch.float16,
+    torch.int64,
+    torch.int32,
+]
+
+
 def all_gather_fn(rank, world_size):
     dim = -1
 
-    for dtype in [torch.float32, torch.bfloat16, torch.float16]:
-        tensor = torch.randn(2, 10, dtype=dtype)
+    for dtype in GATHER_DTYPES:
+        tensor = _sample(dtype)
 
         if dim < 0:
             # Convert negative dim to positive.
@@ -82,8 +99,8 @@ def all_gather_fn(rank, world_size):
 
 
 def all_gather_into_tensor_fn(rank, world_size):
-    for dtype in [torch.float32, torch.bfloat16, torch.float16]:
-        tensor = torch.randn(2, 10, dtype=dtype)
+    for dtype in GATHER_DTYPES:
+        tensor = _sample(dtype)
 
         input_size = tensor.size()
         output_size = (input_size[0] * world_size,) + input_size[1:]


### PR DESCRIPTION
## Motivation

`GroupCoordinator.all_gather_into_tensor` falls back to gloo on CPU:

```python
def all_gather_into_tensor(self, output, input):
    if _is_npu or _is_cpu:
        # TODO: add optimized all_gather_into_tensor kernel for cpu
        self._all_gather_into_tensor(output, input)
```

The kernel that TODO asks for already exists. `shm_allgather_into_tensor` was
added in #13397 and is covered by `test/registered/cpu/test_comm.py`, but
nothing calls it.

The sibling method `all_gather` does use the shm path, gated on
`is_shm_available`. That predicate is shared with `shm_allreduce` and
`shm_reduce_scatter_tensor`, so it requires a float dtype:

```python
dtype in [torch.bfloat16, torch.float16, torch.float]
```

That restriction is right for the reducing collectives, which vectorize a sum
over the element type, and unnecessary for gather. `naive_all_gather` in
`shm.cpp` takes `char*` and moves bytes with `parallel_memcpy`; the element type
only ever appears as a stride. So the float-only gate excludes integer tensors
from a kernel that already handles them.

The visible cost is in speculative decoding. The DFlash draft's greedy gather
issues two collectives per verify step, one float (`max`) and one `int64`
(`argmax` ids), and both land on gloo.

## Modifications

| Area | Change |
| --- | --- |
| `utils/common.py` | Split out `is_shm_gather_available(world_size, local_size)` without the dtype test. `is_shm_available` now delegates to it and adds the float check, so the reducing collectives keep exactly their current behavior. |
| `distributed/parallel_state.py` | `all_gather_into_tensor` dispatches to `torch.ops.sgl_kernel.shm_allgather_into_tensor` on CPU; `all_gather` uses the relaxed predicate. |
| `test/registered/cpu/test_comm.py` | Extend both gather tests to `int64` and `int32`. |

The shm region is sized to the TP group by
`torch.ops.sgl_kernel.initialize(tp_size, tp_rank)`, under the same
AMX/arm64 condition the predicate tests, so a group that passes the gate is
always initialized. A `world_size > 1` guard keeps a degenerate group off the
path, since the kernel would otherwise gather over the initialized world rather
than over the one-rank group.

The op writes into the caller's buffer, so there is no extra allocation or copy
relative to the gloo path.

## Accuracy Tests

`test/registered/cpu/test_comm.py` on a 4-rank Xeon, each case checked against
`torch.distributed` as reference:

```
test_all_gather PASSED
test_all_gather_into_tensor PASSED
test_all_reduce PASSED
test_reduce_scatter_tensor PASSED
4 passed in 43.37s
```

The integer cases are new. The gather kernel had only ever been tested on float
dtypes, so its dtype independence was implied by the implementation rather than
checked.

End to end, `meta-llama/Llama-3.1-8B-Instruct` with DFlash speculative decoding
at `--tp 4` reports an accept length of 3.75 before and after. This change
relocates bytes and must not perturb a value.

## Speed Tests

Intel Xeon 6, 128 physical cores across 4 NUMA nodes, `--tp 4`,
`SGLANG_CPU_OMP_THREADS_BIND="0-31|32-63|64-95|96-127"`. HumanEval, 20 prompts,
128 output tokens with EOS ignored, greedy, `--max-concurrency 1`.

DFlash speculative decoding (needs #36782 to run on CPU at all):

| | before | after |
| --- | --- | --- |
| Output token throughput | 76.9 token/s | **83.4 token/s** |
| Mean TPOT | 12.23 ms | **11.28 ms** |
| Benchmark duration | 33.30 s | **30.69 s** |
| Accept length | 3.75 | 3.75 |

A verify step costs `TPOT x accept_length`, so it falls from 45.9 ms to 42.3 ms,
which is the 3.6 ms of gloo latency the two collectives were spending. Max ITL
drops from 53.40 ms to 45.83 ms, agreeing with that independently of the mean.

The non-speculative baseline is unchanged at 28.53 ms TPOT against 28.56 ms.
`all_gather_into_tensor` is not on the CPU decode path, so on CPU today the
beneficiaries are the DFlash and DSpark draft gathers; the dtype relaxation is
what makes the `int64` half of that pair eligible.

## Checklist

- [x] Format your code according to the Format code with pre-commit.
- [x] Add unit tests according to the Run and add unit tests.
- [ ] Update documentation according to Write documentations.
- [x] Provide accuracy and speed benchmark results according to Test the accuracy and Benchmark the speed.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33206992054](https://github.com/sgl-project/sglang/actions/runs/33206992054)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33206991876](https://github.com/sgl-project/sglang/actions/runs/33206991876)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33206992092](https://github.com/sgl-project/sglang/actions/runs/33206992092)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->