### PR TITLE
[Fix] Lazy-import aiter in DSv4 paged_decode to unbreak CPU CI

### DIFF
--- a/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode.py
+++ b/python/sglang/kernels/ops/attention/dsv4/unified_kv_kernels/paged_decode.py
@@ -56,7 +56,6 @@ import functools
 import torch
 import triton
 import triton.language as tl
-from aiter.ops.triton.utils.device_info import get_num_sms
 
 from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.srt.utils import is_hip
@@ -94,7 +93,12 @@ def _cu_count() -> int:
     Wrapped in ``lru_cache`` so the first decode call pays the device-property
     lookup and all subsequent calls hit the cache — important inside a hot
     decode loop and CUDAGraph capture (no data-dependent host work).
+
+    ``aiter`` is imported lazily: it is a ROCm-only package, and the pure-Python
+    heuristics below must stay importable on a machine without it.
     """
+    from aiter.ops.triton.utils.device_info import get_num_sms
+
     return get_num_sms()
 
 


### PR DESCRIPTION
`test_dsv4_kv_splits_heuristic.py` is registered in the CPU suite but imports `paged_decode.py`, which imports the ROCm-only `aiter` at module level. Move it into `_cu_count()` so the pure-Python heuristics stay importable without aiter.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33211836851](https://github.com/sgl-project/sglang/actions/runs/33211836851)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:no_entry_sign: [Run #33211836746](https://github.com/sgl-project/sglang/actions/runs/33211836746)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33211836841](https://github.com/sgl-project/sglang/actions/runs/33211836841)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->