### PR TITLE
[Bugfix] Stop video_decoder truncating and orphaning its temp file

### DIFF
--- a/python/sglang/srt/utils/video_decoder.py
+++ b/python/sglang/srt/utils/video_decoder.py
@@ -74,11 +74,24 @@ class VideoDecoderWrapper:
                 import tempfile
 
                 fd, tmp_path = tempfile.mkstemp(suffix=".mp4")
-                try:
-                    os.write(fd, source)
-                finally:
-                    os.close(fd)
+                # Record the path before writing. The write can fail part way
+                # through (ENOSPC on a large video, for instance) and the file
+                # still exists on disk, but close() only removes what
+                # _tmp_path names, so assigning afterwards orphans the file.
                 self._tmp_path = tmp_path
+                try:
+                    # Write through a buffered writer rather than a bare
+                    # os.write(). os.write() is a single write(2), which the
+                    # kernel caps (0x7ffff000 bytes on Linux) and which reports
+                    # a short count rather than raising, so it silently
+                    # truncated videos above ~2 GiB.
+                    with os.fdopen(fd, "wb") as tmp_file:
+                        tmp_file.write(source)
+                except BaseException:
+                    # __del__ is not a reliable cleanup path for an object
+                    # whose __init__ raised, so remove the file here.
+                    self.close()
+                    raise
                 self._decoder = VideoReader(tmp_path, ctx=cpu(0))
             else:
                 self._decoder = VideoReader(source, ctx=cpu(0))

--- a/test/registered/vlm/test_video_decoder_tmpfile.py
+++ b/test/registered/vlm/test_video_decoder_tmpfile.py
@@ -1,0 +1,113 @@
+"""Tests for the temporary file VideoDecoderWrapper writes for byte sources."""
+
+import errno
+import os
+import sys
+import types
+from unittest import mock
+
+import pytest
+
+from sglang.srt.utils import video_decoder as video_decoder_mod
+from sglang.srt.utils.video_decoder import VideoDecoderWrapper
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+PAYLOAD = b"\x00\x01\x02\x03" * 4096
+
+
+@pytest.fixture
+def decord_backend(monkeypatch):
+    """Force the decord code path with a stub module, and capture the temp path."""
+    recorded = {}
+
+    class StubVideoReader:
+        def __init__(self, path, ctx=None):
+            recorded["decoded_path"] = path
+            recorded["decoded_size"] = os.path.getsize(path)
+
+        def __len__(self):
+            return 0
+
+    stub = types.ModuleType("decord")
+    stub.VideoReader = StubVideoReader
+    stub.cpu = lambda _idx: None
+    monkeypatch.setitem(sys.modules, "decord", stub)
+    monkeypatch.setattr(video_decoder_mod, "_BACKEND", "decord")
+
+    import tempfile as _tempfile
+
+    real = _tempfile.mkstemp
+
+    def capturing_mkstemp(*args, **kwargs):
+        fd, path = real(*args, **kwargs)
+        recorded["tmp_path"] = path
+        return fd, path
+
+    monkeypatch.setattr(_tempfile, "mkstemp", capturing_mkstemp)
+    yield recorded
+    path = recorded.get("tmp_path")
+    if path and os.path.exists(path):
+        os.unlink(path)
+
+
+def test_byte_source_is_written_in_full(decord_backend):
+    """A short write(2) must not truncate the video.
+
+    The kernel caps a single write(2) (0x7ffff000 bytes on Linux) and reports a
+    short count instead of raising, so a bare os.write() silently truncates
+    large videos. Simulate that cap by making os.write report a short count.
+    """
+    real_write = os.write
+
+    def short_write(fd, data):
+        # Mimic the kernel writing only part of a large buffer.
+        return real_write(fd, data[: len(data) // 4])
+
+    with mock.patch.object(os, "write", side_effect=short_write):
+        decoder = VideoDecoderWrapper(PAYLOAD)
+
+    assert decord_backend["decoded_size"] == len(PAYLOAD)
+    decoder.close()
+
+
+def test_tmp_file_not_orphaned_when_write_fails(decord_backend):
+    """A failed write must not leave the temp file behind forever.
+
+    close() can only remove what _tmp_path names, so if the path is recorded
+    only after a successful write, an ENOSPC leaves the .mp4 on disk with
+    nothing left holding a reference to it. __del__ is not a reliable cleanup
+    path for an object whose __init__ raised, so __init__ must remove it.
+    """
+    enospc = OSError(errno.ENOSPC, "No space left on device")
+
+    class FailingWriter:
+        def __init__(self, fd, *args, **kwargs):
+            self._fd = fd
+
+        def write(self, _data):
+            raise enospc
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *exc_info):
+            os.close(self._fd)
+            return False
+
+    def failing_write(fd, data):
+        raise enospc
+
+    with (
+        mock.patch.object(os, "write", side_effect=failing_write),
+        mock.patch.object(os, "fdopen", side_effect=FailingWriter),
+    ):
+        with pytest.raises(OSError):
+            VideoDecoderWrapper(PAYLOAD)
+
+    tmp_path = decord_backend["tmp_path"]
+    assert not os.path.exists(
+        tmp_path
+    ), f"temp file {tmp_path} was orphaned after a failed write"


### PR DESCRIPTION
## Motivation

`VideoDecoderWrapper` spills video bytes to a temporary `.mp4` when the decord backend is in use (`python/sglang/srt/utils/video_decoder.py`). There are two defects on that path.

**1. The video could be silently truncated.**

```python
os.write(fd, source)   # return value discarded
```

`os.write()` is a single `write(2)`. The kernel caps one call (`0x7ffff000` bytes on Linux) and reports a **short count** rather than raising, so the discarded return value means a video above ~2 GiB was written only partially. decord then decoded a truncated file with no error anywhere.

**2. A failed write orphaned the temp file forever.**

`self._tmp_path` was assigned only *after* the write returned, but `close()` removes exactly what `_tmp_path` names. A write that fails part way through — ENOSPC is the realistic case when spilling a multi-gigabyte video to `/tmp` — propagates out of `__init__` with `_tmp_path` still `None`, so nothing ever removes the `.mp4`. Unlike a leaked fd, a file orphaned before its path is recorded is not reclaimed by anything.

## Modifications

- Write through a buffered writer (`os.fdopen(fd, "wb")`), which loops until the entire buffer is written.
- Record `self._tmp_path` **before** the write, and clean up explicitly if the write fails. `__del__` is not a reliable cleanup path for an object whose `__init__` raised — I verified that the file survives even a forced `gc.collect()` — so the removal has to happen in `__init__`.

## Accuracy Test / Checklist

Added `test/registered/vlm/test_video_decoder_tmpfile.py`, registered for CPU CI. Both tests simulate the failure rather than needing a multi-gigabyte file: one makes `os.write` report a short count the way the kernel does at the cap, the other raises `ENOSPC` at the write.

Toggled against the unmodified file to confirm the tests actually catch the bugs:

```
before  short write      FAIL  (wrote 4096 of 16384 bytes - truncated)
before  failed write     FAIL  (temp file orphaned)
after   short write      PASS
after   failed write     PASS
```

Lint, using the versions pinned in `.pre-commit-config.yaml`: `black==26.1.0` and `isort==7.0.0` report both files unchanged, `ruff==0.15.1 --select=F401,F821,UP037` reports all checks passed.

---

*AI assistance (Claude Code) was used for the investigation and drafting. I reviewed the root cause, the fix and the toggle results above before opening this PR.*

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33213435645](https://github.com/sgl-project/sglang/actions/runs/33213435645)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33213435049](https://github.com/sgl-project/sglang/actions/runs/33213435049)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33213434875](https://github.com/sgl-project/sglang/actions/runs/33213434875)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->