### PR TITLE
[Docs][AMD] Refresh Qwen3.8-Flash-Next ROCm recipes

### DIFF
--- a/docs/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next.mdx
+++ b/docs/cookbook/autoregressive/Qwen/Qwen3.8-Flash-Next.mdx
@@ -10,31 +10,28 @@ tag: NEW
 
 <Accordion title="Install SGLang">
 
-For all methods and hardware platforms, see the [official SGLang installation guide](../../../docs/get-started/install). The two paths below match the **Python / Docker** toggle in the command panel.
+For all methods and hardware platforms, see the [official SGLang installation guide](../../../docs/get-started/install). The available paths below match the command modes exposed for each hardware selection.
 
 <Tabs>
 
 <Tab title="Python (pip / uv)">
 
-Qwen3.8-Flash-Next support is not in a tagged release yet, so build the model-support PR rather than installing from PyPI:
+Generic Qwen3.8-Flash-Next model support is on `main`, but it is not in a tagged release yet. For a source install:
 
 ```bash Command
 pip install -U uv
 uv venv --python 3.12 && source .venv/bin/activate
 
-# Qwen3.8-Flash-Next model support:
-# https://github.com/sgl-project/sglang/pull/36497
 git clone https://github.com/sgl-project/sglang.git
 cd sglang
-git fetch origin pull/36497/head && git checkout FETCH_HEAD
 uv pip install -e python
 ```
 
 <Note>
-Model support lands in [#36497](https://github.com/sgl-project/sglang/pull/36497). Once it is in a release, `uv pip install sglang` is enough and this whole step goes away.
+The AMD path validated below additionally needs the ROCm fixes in [#36601](https://github.com/sgl-project/sglang/pull/36601). Until that PR lands in an official nightly, the AMD Docker commands use an immutable official nightly and mount the exact checked-out PR source. No custom registry image is required.
 </Note>
 
-Then run the **Python** output of the command panel below in that environment.
+NVIDIA selections expose Python and Docker commands. AMD selections expose the Docker path used for validation; prepare the source checkout below and run the generated command from its repository root.
 
 </Tab>
 
@@ -52,13 +49,32 @@ docker pull lmsysorg/sglang:qwen38flashnext
 docker pull lmsysorg/sglang:dev-qwen38-next-local
 ```
 
-**AMD GPUs** (MI350X / MI355X): the matching ROCm build. It targets CDNA4 (gfx950) and is **not** interchangeable with the CUDA image above:
+**AMD source overlay** — check out the exact validated [#36601](https://github.com/sgl-project/sglang/pull/36601) head:
 
 ```bash Command
-docker pull lmsysorg/sglang-rocm:qwen38flashnext
+git clone https://github.com/sgl-project/sglang.git
+cd sglang
+git fetch origin pull/36601/head
+git checkout --detach 0b4f96ff745b7b498e49e613dfeea046a60052fc
 ```
 
-For how to launch either image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). Substitute the inner `sglang serve ...` with whatever the command generator below produces.
+**AMD MI300X / MI325X (gfx942)** — pull the immutable September 11 ROCm 10 MI30X nightly:
+
+```bash Command
+docker pull rocm/sgl-dev@sha256:151005265cf3f4e98c41abc41f5cd317ab2e83085ec24d82f0bd36465f886457
+```
+
+**AMD MI350X / MI355X (gfx950)** — pull the corresponding immutable MI35X nightly:
+
+```bash Command
+docker pull rocm/sgl-dev@sha256:9252e847c0ebcef375543d3bf61d935cbd80ef5ac86ed3ba16e31bb7e1f1be47
+```
+
+<Warning>
+As of September 12, 2026, these official nightlies do not contain #36601 and do not provide the validated AMD MXFP4 path by themselves. The generated AMD command bind-mounts `$PWD/python/sglang` into the container, so run it from the exact checkout above. Do not substitute the old `lmsysorg/sglang-rocm:qwen38flashnext` image or the August `aigmkt` images; those predate the current fixes.
+</Warning>
+
+For how to launch an image, see [Install → Method 3: Using Docker](../../../docs/get-started/install#method-3-using-docker). The command panel emits ROCm device access, the read-only source mount, and `python3 -m sglang.launch_server`.
 
 </Tab>
 
@@ -67,6 +83,12 @@ For how to launch either image, see [Install → Method 3: Using Docker](../../.
 </Accordion>
 
 Pick your hardware + quantization to generate the launch command.
+
+On AMD, BF16 and FP8 **Low Latency** recipes are available on MI300X, MI325X, MI350X, and MI355X. Quark MXFP4 is limited to MI350X and MI355X: **High Throughput** is the non-speculative control, while **Low Latency** enables EAGLE/MTP. Every AMD recipe uses TP8+EP8, explicit AITER attention and MoE, page size 64, and full decode graphs; every low-latency recipe uses EAGLE/MTP 3/1/4. Full five-shot GSM8K was measured directly on MI300X and MI355X. MI325X inherits the tested gfx942 path from MI300X, and MI350X inherits the tested gfx950 path from MI355X; inherited rows do not duplicate the measured scores.
+
+<Note>
+The quantized checkpoint layouts make expert parallelism part of the eight-GPU recipe. FP8 plain TP2/TP4/TP8 splits the expert width across quantization blocks, and MXFP4 plain TP8 cannot shard its expert-scale tensor evenly. TP8+EP8 keeps complete expert quantization groups on each rank and is the validated topology.
+</Note>
 
 import { Deployment } from "/src/snippets/_deployment.jsx";
 import { config }     from "/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx";
@@ -153,19 +175,24 @@ Each precision is its own repository:
     <tr style={{background: "rgba(255,255,255,0.02)"}}>
       <td style={{padding: "9px 12px"}}><strong>BF16</strong></td>
       <td style={{padding: "9px 12px"}}><a href="https://huggingface.co/Qwen/Qwen3.8-Flash-Next">Qwen/Qwen3.8-Flash-Next</a></td>
-      <td style={{padding: "9px 12px"}}>H200, B200, B300, GB300, MI350X, MI355X</td>
+      <td style={{padding: "9px 12px"}}>H200, B200, B300, GB300, MI300X, MI325X, MI350X, MI355X</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px"}}><strong>FP8</strong></td>
       <td style={{padding: "9px 12px"}}><a href="https://huggingface.co/Qwen/Qwen3.8-Flash-Next-FP8">Qwen/Qwen3.8-Flash-Next-FP8</a></td>
-      <td style={{padding: "9px 12px"}}>H200, B200, B300, GB300, MI350X, MI355X</td>
+      <td style={{padding: "9px 12px"}}>H200, B200, B300, GB300, MI300X, MI325X, MI350X, MI355X</td>
     </tr>
     <tr style={{background: "rgba(255,255,255,0.02)"}}>
+      <td style={{padding: "9px 12px"}}><strong>MXFP4 (Quark)</strong></td>
+      <td style={{padding: "9px 12px"}}><a href="https://huggingface.co/amd/Qwen3.8-Flash-Next-Quark-MXFP4">amd/Qwen3.8-Flash-Next-Quark-MXFP4</a></td>
+      <td style={{padding: "9px 12px"}}>MI350X, MI355X (gfx950 only)</td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px"}}><strong>NVFP4 (RDXA)</strong></td>
       <td style={{padding: "9px 12px"}}><a href="https://huggingface.co/RadixArk/Qwen3.8-Flash-Next-NVFP4">RadixArk/Qwen3.8-Flash-Next-NVFP4</a></td>
       <td style={{padding: "9px 12px"}}>B200, B300, GB300, RTX PRO 6000, 1x or 2x DGX Spark (Blackwell only)</td>
     </tr>
-    <tr>
+    <tr style={{background: "rgba(255,255,255,0.02)"}}>
       <td style={{padding: "9px 12px"}}><strong>NVFP4 (NVDA)</strong></td>
       <td style={{padding: "9px 12px"}}><a href="https://huggingface.co/nvidia/Qwen3.8-Flash-Next-NVFP4">nvidia/Qwen3.8-Flash-Next-NVFP4</a> (ModelOpt MIXED_PRECISION)</td>
       <td style={{padding: "9px 12px"}}>RTX PRO 6000, 1x or 2x DGX Spark (needs <a href="https://github.com/sgl-project/sglang/pull/38121">#38121</a>: the <code>dev-qwen38-next-local</code> image or the Python install path)</td>
@@ -178,7 +205,7 @@ Each precision is its own repository:
 ## 2. Advanced Usage
 
 <Note>
-The `model` argument in the examples below is the BF16 repo id. Every precision is a **separate repo**, so `model` has to be the checkpoint the server was actually launched with — `…-Flash-Next-FP8` or `…-Flash-Next-NVFP4`. The Deploy panel's cURL snippet always shows the right id for the cell you have selected.
+The `model` argument in the examples below is the BF16 repo id. Every precision is a **separate repo**, so `model` has to be the checkpoint the server was actually launched with — `…-Flash-Next-FP8`, `amd/Qwen3.8-Flash-Next-Quark-MXFP4`, or one of the NVFP4 repositories. The Deploy panel's cURL snippet always shows the right id for the cell you have selected.
 </Note>
 
 ### 2.1 Reasoning

--- a/docs/scripts/check_cookbook_configs.mjs
+++ b/docs/scripts/check_cookbook_configs.mjs
@@ -27,10 +27,16 @@ import { fileURLToPath } from "node:url";
 const SNIPPETS = join(dirname(fileURLToPath(import.meta.url)), "..", "src", "snippets");
 const CONFIGS = join(SNIPPETS, "configs");
 const DIFFUSION_COOKBOOK = join(SNIPPETS, "..", "..", "cookbook", "diffusion");
+const QWEN38_COOKBOOK = join(
+  SNIPPETS, "..", "..", "cookbook", "autoregressive", "Qwen",
+  "Qwen3.8-Flash-Next.mdx");
 const COOKBOOK_MODEL_TEMPLATE = join(
   SNIPPETS, "..", "..", "..", ".claude", "skills", "cookbook-add-model",
   "templates", "config.jsx.tmpl");
 const LEGACY_DIMS = ["variants", "quantizations", "strategies", "nodesOptions"];
+const QWEN38_GFX942_IMAGE = "rocm/sgl-dev@sha256:151005265cf3f4e98c41abc41f5cd317ab2e83085ec24d82f0bd36465f886457";
+const QWEN38_GFX950_IMAGE = "rocm/sgl-dev@sha256:9252e847c0ebcef375543d3bf61d935cbd80ef5ac86ed3ba16e31bb7e1f1be47";
+const QWEN38_SOURCE_MOUNT = "\"$PWD/python/sglang:/sgl-workspace/sglang/python/sglang:ro\"";
 
 const failures = [];
 const fail = (where, msg) => failures.push(`${where}: ${msg}`);
@@ -69,9 +75,18 @@ if (a && b && a !== b) {
 // current base cell from a true sibling. This previously made every cookbook
 // show a spurious "matches … / switch base" hint before the reader changed
 // anything.
+const deploymentSource = readFileSync(join(SNIPPETS, "_deployment.jsx"), "utf8");
 const playgroundSource = readFileSync(join(SNIPPETS, "_playground.jsx"), "utf8");
 if (/\bmatchedCell\s*!==\s*baseCell\b/.test(playgroundSource)) {
   fail("_playground.jsx", "sibling detection compares cloned cells by object identity");
+}
+for (const [engine, source] of [
+  ["_deployment.jsx", deploymentSource],
+  ["_playground.jsx", playgroundSource],
+]) {
+  if (!source.includes('typeof config.dockerMounts === "function"')) {
+    fail(engine, "does not resolve selection-dependent Docker mounts");
+  }
 }
 
 const cookbookModelTemplate = readFileSync(COOKBOOK_MODEL_TEMPLATE, "utf8");
@@ -90,13 +105,13 @@ if (!cookbookModelTemplate.includes("--enable-w4a4-mxfp4-megamoe")) {
 // --------------------------------------------------------------- 3/4. Configs
 // Configs are .jsx with a single `export const config` literal; import them
 // through a data: URL so no temp file is needed.
-const loadConfig = async (path) => {
+const loadModule = async (path) => {
   const src = readFileSync(path, "utf8");
-  const mod = await import(
+  return import(
     "data:text/javascript," + encodeURIComponent(src)
   );
-  return mod.config;
 };
+const loadConfig = async (path) => (await loadModule(path)).config;
 
 // Every combination of match dims + overlay dims the reader can produce.
 const selectionSpace = (config) => {
@@ -169,6 +184,183 @@ for (const path of walk(CONFIGS)) {
     // silently degrades a multi-node recipe to single-node.
     if (custom && !matchIds.includes("nodes") && cell.nnodes === undefined) {
       fail(where, `cells[${i}] has no \`nnodes\` and the config declares no nodes dim`);
+    }
+  }
+
+  // Qwen3.8-Flash-Next's AMD recipes use immutable official architecture-
+  // specific nightlies plus an exact PR #36601 source bind mount. Keep the
+  // matrix from drifting back to stale/custom images or plain TP8.
+  if (config.modelName === "Qwen3.8-Flash-Next") {
+    const cookbookSource = readFileSync(QWEN38_COOKBOOK, "utf8");
+    const benchmarkPath = path.replace(/\.jsx$/, "-benchmarks.jsx");
+    let benchmarks = [];
+    try {
+      benchmarks = (await loadModule(benchmarkPath)).benchmarks || [];
+    } catch (e) {
+      fail(where, `cannot load benchmark rows: ${e.message}`);
+    }
+    const amdImages = {
+      mi300x: QWEN38_GFX942_IMAGE,
+      mi325x: QWEN38_GFX942_IMAGE,
+      mi350x: QWEN38_GFX950_IMAGE,
+      mi355x: QWEN38_GFX950_IMAGE,
+    };
+    for (const image of new Set(Object.values(amdImages))) {
+      if (!/^rocm\/sgl-dev@sha256:[0-9a-f]{64}$/.test(image)) {
+        fail(where, `AMD image is not an immutable official ROCm nightly: ${image}`);
+      }
+      if (!cookbookSource.includes(`docker pull ${image}`)) {
+        fail(where, `cookbook install instructions do not pull ${image}`);
+      }
+    }
+    if (cookbookSource.includes("aigmkt/qwen3.8-flash-next")
+        || cookbookSource.includes("GFX942_DIGEST")
+        || cookbookSource.includes("GFX950_DIGEST")) {
+      fail(where, "cookbook must not depend on custom Docker Hub images or digest placeholders");
+    }
+    if (!cookbookSource.includes("git checkout --detach 0b4f96ff745b7b498e49e613dfeea046a60052fc")) {
+      fail(where, "cookbook must check out the exact validated PR #36601 head");
+    }
+    for (const [hw, image] of Object.entries(amdImages)) {
+      if (config.dockerImages?.[hw] !== image) {
+        fail(where, `${hw} must use its architecture-specific official ROCm nightly`);
+      }
+      const selection = { hw, variant: "default", quant: "fp8",
+        strategy: "low-latency", nodes: "single" };
+      if (config.runModes?.(selection)?.join(",") !== "docker") {
+        fail(where, `${hw} must expose only the validated Docker command`);
+      }
+      if (config.dockerRunCommand?.(selection) !== "python3 -m sglang.launch_server") {
+        fail(where, `${hw} must launch the image's embedded SGLang source`);
+      }
+      if (config.dockerGpuVendor?.(selection) !== "amd") {
+        fail(where, `${hw} must render ROCm device access in both command panels`);
+      }
+      if (config.dockerMounts?.(selection)?.join(",") !== QWEN38_SOURCE_MOUNT) {
+        fail(where, `${hw} must mount the exact checked-out PR source tree read-only`);
+      }
+    }
+    const nvidiaSelection = { hw: "h200", variant: "default", quant: "bf16",
+      strategy: "low-latency", nodes: "single" };
+    if ((config.dockerMounts?.(nvidiaSelection) || []).length !== 0) {
+      fail(where, "the AMD source overlay must not leak into NVIDIA commands");
+    }
+
+    const expected = [
+      ["mi300x", "bf16", "low-latency", false],
+      ["mi300x", "fp8", "low-latency", false],
+      ["mi325x", "bf16", "low-latency", true],
+      ["mi325x", "fp8", "low-latency", true],
+      ["mi350x", "bf16", "low-latency", true],
+      ["mi350x", "fp8", "low-latency", true],
+      ["mi350x", "mxfp4", "high-throughput", true],
+      ["mi350x", "mxfp4", "low-latency", true],
+      ["mi355x", "bf16", "low-latency", false],
+      ["mi355x", "fp8", "low-latency", false],
+      ["mi355x", "mxfp4", "high-throughput", false],
+      ["mi355x", "mxfp4", "low-latency", false],
+    ];
+    const amdCells = (config.cells || []).filter((cell) =>
+      Object.hasOwn(amdImages, cell.match?.hw));
+    if (amdCells.length !== expected.length) {
+      fail(where, `expected ${expected.length} AMD cells, found ${amdCells.length}`);
+    }
+    for (const [hw, quant, strategy, inherited] of expected) {
+      const cell = amdCells.find((entry) => entry.match.quant === quant
+        && entry.match.strategy === strategy && entry.match.hw === hw);
+      const label = `${hw}/${quant}/${strategy}`;
+      if (!cell) {
+        fail(where, `missing ${label} cell`);
+        continue;
+      }
+      if (cell.verified !== true) fail(where, `${label} must be marked supported`);
+      if (inherited && !cell.warn) {
+        fail(where, `${label} must state which architecture-identical GPU was measured`);
+      }
+      for (const flag of [
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+      ]) {
+        if (!cell.flags.includes(flag)) fail(where, `${label} is missing ${flag}`);
+      }
+      if (!cell.env.includes("SGLANG_USE_AITER=1")) {
+        fail(where, `${label} does not enable AITER`);
+      }
+      const revision = {
+        bf16: "--revision de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        fp8: "--revision 236dfdf285828023ca3bcd3f37366c58a3469b13",
+        mxfp4: "--revision 1ad7d941b239f6dc83cba6e49234c0efe1ca5477",
+      }[quant];
+      if (!cell.flags.includes(revision)) fail(where, `${label} is missing ${revision}`);
+      const speculative = cell.flags.some((flag) => flag.startsWith("--speculative-"));
+      if (strategy === "low-latency") {
+        for (const flag of [
+          "--speculative-algorithm EAGLE",
+          "--speculative-num-steps 3",
+          "--speculative-eagle-topk 1",
+          "--speculative-num-draft-tokens 4",
+        ]) {
+          if (!cell.flags.includes(flag)) fail(where, `${label} is missing ${flag}`);
+        }
+      } else if (speculative) {
+        fail(where, `${label} must remain the non-MTP control`);
+      }
+    }
+    for (const cell of amdCells) {
+      if (cell.flags.includes("--tp-size 8") && !cell.flags.includes("--ep-size 8")) {
+        fail(where, `${cell.match.hw}/${cell.match.quant}/${cell.match.strategy} exposes invalid plain TP8`);
+      }
+    }
+    for (const hw of ["mi300x", "mi325x"]) {
+      if (amdCells.some((cell) => cell.match.hw === hw && cell.match.quant === "mxfp4")) {
+        fail(where, `${hw} must not expose the MI35X-only MXFP4 checkpoint`);
+      }
+    }
+
+    const benchmarkKey = (match) => [
+      match.hw, match.quant, match.strategy, match.nodes,
+    ].join("|");
+    const amdBenchmarks = benchmarks.filter((row) =>
+      Object.hasOwn(amdImages, row.match?.hw));
+    if (amdBenchmarks.length !== expected.length) {
+      fail(where, `expected ${expected.length} AMD benchmark rows, found ${amdBenchmarks.length}`);
+    }
+    const benchmarkByKey = new Map(amdBenchmarks.map((row) => [
+      benchmarkKey(row.match), row,
+    ]));
+    if (benchmarkByKey.size !== amdBenchmarks.length) {
+      fail(where, "AMD benchmark rows contain duplicate hardware/quantization/strategy keys");
+    }
+    for (const [hw, quant, strategy] of expected) {
+      const key = [hw, quant, strategy, "single"].join("|");
+      if (!benchmarkByKey.has(key)) fail(where, `missing benchmark row for ${key}`);
+    }
+    const exactDirectScores = new Map([
+      ["mi300x|bf16|low-latency|single", 97.1842],
+      ["mi300x|fp8|low-latency|single", 96.4231],
+      ["mi355x|bf16|low-latency|single", 96.8798],
+      ["mi355x|fp8|low-latency|single", 96.8037],
+      ["mi355x|mxfp4|low-latency|single", 96.6514],
+    ]);
+    for (const [key, score] of exactDirectScores) {
+      const row = benchmarkByKey.get(key);
+      if (row?.accuracy?.gsm8k_pct !== score) {
+        fail(where, `${key} must retain direct GSM8K score ${score}`);
+      }
+      if (!row?.notes?.includes("1,314") || !row.notes.includes("zero request errors")) {
+        fail(where, `${key} must retain the direct full five-shot GSM8K evidence`);
+      }
+    }
+    for (const row of amdBenchmarks.filter((entry) =>
+      ["mi325x", "mi350x"].includes(entry.match.hw))) {
+      if (row.accuracy !== undefined) {
+        fail(where, `${benchmarkKey(row.match)} must not copy accuracy from another GPU`);
+      }
     }
   }
 

--- a/docs/src/snippets/_deployment.jsx
+++ b/docs/src/snippets/_deployment.jsx
@@ -84,7 +84,8 @@
 //                      `hw|quant|strategy` then `hw|quant` then `hw`;
 //                      falls back to `lmsysorg/sglang:dev`
 //   dockerHostNetworkWhen optional — `(selection, {flags, env}) => boolean`
-//   dockerMounts       optional — additional `-v` mount specs
+//   dockerMounts       optional — additional `-v` mount specs, as an array or
+//                      `(selection) => array`
 //   dockerRunCommand   optional — command placed after the image and before
 //                      generated server flags; string or `(selection) => string`
 //   runModes           optional — command output tabs to show (`python` and/or
@@ -794,6 +795,9 @@ export const Deployment = ({ config, benchmarks }) => {
       const dockerRunCommand = typeof config.dockerRunCommand === "function"
         ? config.dockerRunCommand(sel)
         : (config.dockerRunCommand || "sglang serve");
+      const dockerMounts = typeof config.dockerMounts === "function"
+        ? config.dockerMounts(sel)
+        : (config.dockerMounts || []);
       const portFlag = flags.find((x) => x.split(/[\s=]/)[0] === "--port");
       const servePort = portFlag ? portFlag.slice("--port".length).trim() : "{{PORT}}";
       const hostNetwork = multinode || (typeof config.dockerHostNetworkWhen === "function"
@@ -856,7 +860,7 @@ export const Deployment = ({ config, benchmarks }) => {
         // The NPU device block already mounts ~/.cache/.
         ...(vendorOf(sel.hw) === "npu"
           ? [] : ["  -v ~/.cache/huggingface:/root/.cache/huggingface"]),
-        ...(config.dockerMounts || []).map((mount) => `  -v ${mount}`),
+        ...dockerMounts.map((mount) => `  -v ${mount}`),
         // HF token only for gated checkpoints — configs that declare an HF_TOKEN placeholder.
         ...(config.placeholders && config.placeholders.HF_TOKEN
           ? [`  --env "HF_TOKEN={{HF_TOKEN}}"`] : []),

--- a/docs/src/snippets/_playground.jsx
+++ b/docs/src/snippets/_playground.jsx
@@ -3,7 +3,8 @@
 // See the cookbook-add-model skill (.claude/skills/cookbook-add-model/) for the
 // authoring workflow; references/engine-axis.md covers adding a new axis.
 //
-// Consumes the same config shape as `_deployment.jsx`, plus
+// Consumes the same config shape as `_deployment.jsx`, including dynamic
+// `runModes` / `dockerMounts` and the optional `dockerGpuVendor` override, plus
 // `config.playgroundFeatures` — a keyed map where each present key opts that
 // axis in. Recognised axes:
 //   attention   — TP/CP/DP-Attention knobs
@@ -1535,6 +1536,9 @@ export const Playground = ({ config }) => {
       const dockerRunCommand = typeof config.dockerRunCommand === "function"
         ? config.dockerRunCommand(sel)
         : (config.dockerRunCommand || "sglang serve");
+      const dockerMounts = typeof config.dockerMounts === "function"
+        ? config.dockerMounts(sel)
+        : (config.dockerMounts || []);
       const portFlag = f.find((x) => x.split(/[\s=]/)[0] === "--port");
       const servePort = portFlag ? portFlag.slice("--port".length).trim() : "{{PORT}}";
       const hostNetwork = multinode || pdMode || (typeof config.dockerHostNetworkWhen === "function"
@@ -1547,13 +1551,28 @@ export const Playground = ({ config }) => {
         ],
       };
       const fabricFlags = HW_MULTINODE_DOCKER_FLAGS[sel.hw] || [];
+      const configuredDockerVendor = typeof config.dockerGpuVendor === "function"
+        ? config.dockerGpuVendor(sel)
+        : config.dockerGpuVendor;
+      const dockerVendor = configuredDockerVendor || "nvidia";
+      const gpuAccessLines = dockerVendor === "amd"
+        ? [
+            "docker run",
+            "  --device=/dev/kfd --device=/dev/dri",
+            "  --group-add video",
+            "  --cap-add=SYS_PTRACE --security-opt seccomp=unconfined",
+            "  --shm-size 32g",
+          ]
+        : [
+            "docker run --gpus all",
+            "  --shm-size 32g",
+          ];
       const dockerLines = [
-        "docker run --gpus all",
-        "  --shm-size 32g",
+        ...gpuAccessLines,
         hostNetwork ? "  --network host" : `  -p ${servePort}:${servePort}`,
         ...(multinode ? fabricFlags.map((x) => "  " + x) : []),
         "  -v ~/.cache/huggingface:/root/.cache/huggingface",
-        ...(config.dockerMounts || []).map((mount) => `  -v ${mount}`),
+        ...dockerMounts.map((mount) => `  -v ${mount}`),
         `  --env "HF_TOKEN={{HF_TOKEN}}"`,
         ...cellEnv.map((e) => `  --env ${e}`),
         "  --ipc=host",
@@ -2098,7 +2117,17 @@ export const Playground = ({ config }) => {
   const [routerCopied, setRouterCopied] = useState(false);
   const [envDraft, setEnvDraft] = useState(env);
   useEffect(() => { if (modal === "env") setEnvDraft(env); }, [modal, env]);
-  const [runMode, setRunMode] = useState("python");
+  const configuredRunModes = typeof config.runModes === "function"
+    ? config.runModes(base)
+    : config.runModes;
+  const runModes = configuredRunModes || ["python", "docker"];
+  const [runMode, setRunMode] = useState(runModes[0]);
+  const hasRunMode = runModes.includes(runMode);
+  const fallbackRunMode = runModes[0];
+  const activeRunMode = hasRunMode ? runMode : fallbackRunMode;
+  useEffect(() => {
+    if (!hasRunMode) setRunMode(fallbackRunMode);
+  }, [hasRunMode, fallbackRunMode]);
 
   // Submit-verified-cell modal state, reset each time the modal opens.
   const [submitDraft, setSubmitDraft] = useState({
@@ -2225,11 +2254,11 @@ export const Playground = ({ config }) => {
     return out;
   };
   if (baseCell) {
-    baseCommand = renderCommandLines(baseCell, withRatio(baseCell.flags, pgRatios.base), baseCell.env, base, env, null, runMode);
+    baseCommand = renderCommandLines(baseCell, withRatio(baseCell.flags, pgRatios.base), baseCell.env, base, env, null, activeRunMode);
     const { flags: pgFlags, env: pgEnv, pdMode } = applyAllDeltas(baseCell.flags, baseCell.env, deltas, base, derivedMap);
     pgFlagsLatest = pgFlags;
     pgEnvLatest = pgEnv;
-    playgroundCommand = renderCommandLines(baseCell, withRatio(pgFlags, pgRatios.eff), pgEnv, base, env, pdMode, runMode);
+    playgroundCommand = renderCommandLines(baseCell, withRatio(pgFlags, pgRatios.eff), pgEnv, base, env, pdMode, activeRunMode);
     diffLines = computeDiff(baseCommand, playgroundCommand);
   }
   // Broadcast both configs for outside consumers (the mamba ratio calculator):
@@ -2498,22 +2527,28 @@ export const Playground = ({ config }) => {
                 </span>
               )}
               <div style={s.runModeWrap} role="tablist" aria-label="Output format">
-                <span
-                  style={s.runModeChip(runMode === "python")}
-                  onClick={() => setRunMode("python")}
-                  role="tab"
-                  aria-selected={runMode === "python"}
-                >
-                  Python
-                </span>
-                <span
-                  style={s.runModeChipLast(runMode === "docker")}
-                  onClick={() => setRunMode("docker")}
-                  role="tab"
-                  aria-selected={runMode === "docker"}
-                >
-                  Docker
-                </span>
+                {runModes.map((mode, index) => (
+                  <span
+                    key={mode}
+                    style={{
+                      ...(index === runModes.length - 1
+                        ? s.runModeChipLast(activeRunMode === mode)
+                        : s.runModeChip(activeRunMode === mode)),
+                      ...(runModes.length === 1 ? { borderRadius: 7 } : {}),
+                    }}
+                    onClick={() => setRunMode(mode)}
+                    onKeyDown={(e) => {
+                      if (e.key !== "Enter" && e.key !== " ") return;
+                      e.preventDefault();
+                      setRunMode(mode);
+                    }}
+                    role="tab"
+                    tabIndex={0}
+                    aria-selected={activeRunMode === mode}
+                  >
+                    {mode === "docker" ? "Docker" : "Python"}
+                  </span>
+                ))}
               </div>
             </div>
             <div style={s.iconRow}>

--- a/docs/src/snippets/configs/Qwen/qwen3.8-flash-next-benchmarks.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-flash-next-benchmarks.jsx
@@ -246,8 +246,47 @@ export const benchmarks = [
         ttft_ms: 2958.76, tpot_ms: 54.4, tokens_per_sec_per_gpu: 4530 },
     ],
   },
-  { match: { hw: "mi350x", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" } },
-  { match: { hw: "mi350x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" } },
-  { match: { hw: "mi355x", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" } },
-  { match: { hw: "mi355x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" } },
+  // AMD ROCm validation uses the September 11 ROCm 10 nightlies with the exact
+  // #36601 Python tree (0b4f96ff7), embedded for validation and exposed to
+  // cookbook users as an equivalent read-only source overlay.
+  // MI300X and MI355X are direct measurements. MI325X and MI350X inherit the
+  // corresponding gfx942/gfx950 recipes, so their rows intentionally carry no
+  // copied accuracy result.
+  {
+    match: { hw: "mi300x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
+    sglang_version: "PR #36601 @ 0b4f96ff7",
+    accuracy: { gsm8k_pct: 97.1842 },
+    notes: "8x MI300X, TP8+EP8, AITER attention/MoE, full target/draft decode graphs, and EAGLE MTP 3/1/4. The exact-image run requested all 1,319 GSM8K examples and scored 1,277/1,314 after reserving five demonstrations, with zero request errors or fatal server patterns, 379/379 graph-backed decode summaries, and mean MTP acceptance 3.5666.",
+  },
+  {
+    match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+    sglang_version: "PR #36601 @ 0b4f96ff7",
+    accuracy: { gsm8k_pct: 96.4231 },
+    notes: "8x MI300X, TP8+EP8, AITER attention/MoE, full target/draft decode graphs, and EAGLE MTP 3/1/4. The exact-image run requested all 1,319 GSM8K examples and scored 1,267/1,314 after reserving five demonstrations, with zero request errors or fatal server patterns, 379/379 graph-backed decode summaries, and mean MTP acceptance 3.5693.",
+  },
+  { match: { hw: "mi325x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" } },
+  { match: { hw: "mi325x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" } },
+  { match: { hw: "mi350x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" } },
+  { match: { hw: "mi350x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" } },
+  { match: { hw: "mi350x", variant: "default", quant: "mxfp4", strategy: "high-throughput", nodes: "single" } },
+  { match: { hw: "mi350x", variant: "default", quant: "mxfp4", strategy: "low-latency", nodes: "single" } },
+  {
+    match: { hw: "mi355x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
+    sglang_version: "PR #36601 @ 0b4f96ff7",
+    accuracy: { gsm8k_pct: 96.8798 },
+    notes: "8x MI355X, TP8+EP8, AITER attention/MoE, full target/draft decode graphs, and EAGLE MTP 3/1/4. The exact-image run requested all 1,319 GSM8K examples and scored 1,273/1,314 after reserving five demonstrations, with zero request errors or fatal server patterns, 379/379 graph-backed decode summaries, and mean MTP acceptance 3.5669.",
+  },
+  {
+    match: { hw: "mi355x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+    sglang_version: "PR #36601 @ 0b4f96ff7",
+    accuracy: { gsm8k_pct: 96.8037 },
+    notes: "8x MI355X, TP8+EP8, AITER attention/MoE, full target/draft decode graphs, and EAGLE MTP 3/1/4. The exact-image run requested all 1,319 GSM8K examples and scored 1,272/1,314 after reserving five demonstrations, with zero request errors or fatal server patterns, 374/374 graph-backed decode summaries, and mean MTP acceptance 3.5690.",
+  },
+  { match: { hw: "mi355x", variant: "default", quant: "mxfp4", strategy: "high-throughput", nodes: "single" } },
+  {
+    match: { hw: "mi355x", variant: "default", quant: "mxfp4", strategy: "low-latency", nodes: "single" },
+    sglang_version: "PR #36601 @ 0b4f96ff7",
+    accuracy: { gsm8k_pct: 96.6514 },
+    notes: "8x MI355X, TP8+EP8, AITER attention/MoE, full target/draft decode graphs, and EAGLE MTP 3/1/4. The exact-head run requested all 1,319 GSM8K examples and scored 1,270/1,314 after reserving five demonstrations, with zero request errors or fatal server patterns, 374/374 graph-backed decode summaries, and mean MTP acceptance 3.5524.",
+  },
 ];

--- a/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
+++ b/docs/src/snippets/configs/Qwen/qwen3.8-flash-next.jsx
@@ -9,8 +9,8 @@
 //
 // Every datacenter recipe on this page is single-node: BF16 and FP8 run TP4 (so
 // four GPUs of an 8-GPU H200/B200/B300 host, or a whole 4-GPU GB300 node), NVFP4
-// runs on a single GPU, and the AMD cells run TP8. That fits because 6B active
-// params keeps compute small and the N-gram table is the only large weight block.
+// runs on a single GPU, and the AMD BF16/FP8/MXFP4 cells run TP8+EP8. Plain TP8
+// is not a valid substitute for the expert-parallel AMD topology.
 // The one multi-node shape is NVFP4 on a pair of DGX Sparks (GB10): the 126 GiB
 // checkpoint does not fit one 128 GB unified-memory box with the N-gram table
 // resident, so it runs TP=2 across two of them over the 200GbE ConnectX-7 link;
@@ -26,7 +26,10 @@
 export const config = {
   modelName: "Qwen3.8-Flash-Next",
 
-  supportedHardware: ["h200", "b200", "b300", "gb300", "rtx6000", "dgx-spark", "mi350x", "mi355x"],
+  supportedHardware: [
+    "h200", "b200", "b300", "gb300", "rtx6000", "dgx-spark",
+    "mi300x", "mi325x", "mi350x", "mi355x",
+  ],
 
   // RTX PRO 6000 (SM120, Blackwell workstation) is not in the shared
   // HARDWARE_CATALOG, so it carries a local vendor override here (same id and
@@ -39,8 +42,8 @@ export const config = {
     { id: "default", label: "Default" },
   ],
   // Checkpoint precisions. NVFP4 is SGLang's own Blackwell-only quantization of
-  // the BF16 weights (RadixArk), so it has no H200 or AMD cell — SM90 and CDNA4
-  // have no NVFP4 path. AMD serves the upstream BF16 and FP8 repos.
+  // the BF16 weights (RadixArk), so it has no H200 or AMD cell. AMD serves the
+  // upstream BF16 and FP8 repos, plus the Quark MXFP4 checkpoint on CDNA4.
   // Two NVFP4 exports exist: RadixArk's (routed experts NVFP4, everything else
   // BF16 with an FP8 N-gram table) and NVIDIA's ModelOpt MIXED_PRECISION export
   // (NVFP4 experts, FP8 N-gram table, FP8 block-scaled MTP experts). The NVIDIA
@@ -48,15 +51,15 @@ export const config = {
   quantizations: [
     { id: "bf16",       label: "BF16"         },
     { id: "fp8",        label: "FP8"          },
+    { id: "mxfp4",      label: "MXFP4 (Quark)" },
     { id: "nvfp4",      label: "NVFP4 (RDXA)" },
     { id: "nvfp4-nvda", label: "NVFP4 (NVDA)" },
   ],
   // BF16, FP8 and NVFP4 each ship two operating points, low latency adding the
-  // in-checkpoint MTP head (NEXTN 3/1/4) on top of the high-throughput shape.
-  // The two AMD platforms ship one recipe each, which parks under `balanced`.
+  // in-checkpoint MTP head on top of the high-throughput shape. AMD BF16/FP8
+  // use the validated MTP operating point; MXFP4 also keeps a no-MTP control.
   strategies: [
     { id: "low-latency",     label: "Low Latency"     },
-    { id: "balanced",        label: "Balanced"        },
     { id: "high-throughput", label: "High Throughput" },
   ],
   // `multi-N` id carries the node count for `--nnodes N`; only the DGX Spark
@@ -94,7 +97,7 @@ export const config = {
       // of weights plus the pools to fit, so Auto and Off are greyed out and On
       // is the only pick — the forced chip appends --ple-offload-embedding, so
       // the cells do not list it themselves.
-      showWhen: (sel) => !["mi350x", "mi355x"].includes(sel.hw),
+      showWhen: (sel) => !["mi300x", "mi325x", "mi350x", "mi355x"].includes(sel.hw),
       default: "auto",
       options: [
         { id: "auto", label: "Auto",
@@ -137,6 +140,7 @@ export const config = {
     "default|bf16":  "Qwen/Qwen3.8-Flash-Next",
     // Separate repos, not revisions of the BF16 one.
     "default|fp8":   "Qwen/Qwen3.8-Flash-Next-FP8",
+    "default|mxfp4": "amd/Qwen3.8-Flash-Next-Quark-MXFP4",
     "default|nvfp4": "RadixArk/Qwen3.8-Flash-Next-NVFP4",
     "default|nvfp4-nvda": "nvidia/Qwen3.8-Flash-Next-NVFP4",
   },
@@ -177,9 +181,9 @@ export const config = {
     ["mmmu_pro_pct", "MMMU-Pro", "%"],
   ],
 
-  // Launch images — this is a day-0 model with no release cut, so both tags are
-  // purpose-built rather than a version. The ROCm build targets CDNA4 (gfx950)
-  // and is not interchangeable with the CUDA one.
+  // Launch images — this is a day-0 model with no release cut, so the NVIDIA
+  // tags are purpose-built rather than a version. AMD uses immutable official
+  // September 11 ROCm nightlies and bind-mounts exact PR #36601 Python source.
   // Prepended as `# ...` comments above multi-node commands.
   multiNodeHints: {
     "dgx-spark": [
@@ -202,9 +206,22 @@ export const config = {
     b200:   "lmsysorg/sglang:qwen38flashnext",
     b300:   "lmsysorg/sglang:qwen38flashnext",
     gb300:  "lmsysorg/sglang:qwen38flashnext",
-    mi350x: "lmsysorg/sglang-rocm:qwen38flashnext",
-    mi355x: "lmsysorg/sglang-rocm:qwen38flashnext",
+    mi300x: "rocm/sgl-dev@sha256:151005265cf3f4e98c41abc41f5cd317ab2e83085ec24d82f0bd36465f886457",
+    mi325x: "rocm/sgl-dev@sha256:151005265cf3f4e98c41abc41f5cd317ab2e83085ec24d82f0bd36465f886457",
+    mi350x: "rocm/sgl-dev@sha256:9252e847c0ebcef375543d3bf61d935cbd80ef5ac86ed3ba16e31bb7e1f1be47",
+    mi355x: "rocm/sgl-dev@sha256:9252e847c0ebcef375543d3bf61d935cbd80ef5ac86ed3ba16e31bb7e1f1be47",
   },
+
+  dockerMounts: (sel) => ["mi300x", "mi325x", "mi350x", "mi355x"].includes(sel.hw)
+    ? ["\"$PWD/python/sglang:/sgl-workspace/sglang/python/sglang:ro\""]
+    : [],
+  dockerGpuVendor: (sel) => ["mi300x", "mi325x", "mi350x", "mi355x"].includes(sel.hw)
+    ? "amd" : "nvidia",
+  dockerRunCommand: (sel) => ["mi300x", "mi325x", "mi350x", "mi355x"].includes(sel.hw)
+    ? "python3 -m sglang.launch_server"
+    : "sglang serve",
+  runModes: (sel) => ["mi300x", "mi325x", "mi350x", "mi355x"].includes(sel.hw)
+    ? ["docker"] : ["python", "docker"],
 
   github: {
     cookbookModel: "Qwen/Qwen3.8-Flash-Next",
@@ -258,8 +275,12 @@ export const config = {
         { id: "current", label: "Inherited from base" },
         { id: "off",     label: "Off (greedy)" },
         { id: "mtp",     label: "NEXTN / MTP",
-          flags: ["--speculative-algorithm NEXTN", "--speculative-num-steps 3",
-                  "--speculative-eagle-topk 1", "--speculative-num-draft-tokens 4"] },
+          flags: (sel) => [
+            `--speculative-algorithm ${["mi300x", "mi325x", "mi350x", "mi355x"].includes(sel.hw) ? "EAGLE" : "NEXTN"}`,
+            "--speculative-num-steps 3",
+            "--speculative-eagle-topk 1",
+            "--speculative-num-draft-tokens 4",
+          ] },
       ],
     },
   },
@@ -1191,84 +1212,352 @@ export const config = {
       ],
     },
 
-    // ==== AMD CDNA4 (MI350X / MI355X) ====
-    // One recipe, identical for BF16 and FP8 and for both cards (same gfx950,
-    // same 288GB, same ROCm image) — hence `balanced` on all four cells. This is
-    // its own shape rather than a port of the NVIDIA one: TP8, the aiter
-    // attention backend with `--page-size 32`, and a 16384-token prefill chunk.
-    // `--kv-cache-dtype auto` is stated rather than left off so the checkpoint's
-    // own declaration is visibly what decides KV precision.
+    // ==== AMD CDNA3 / CDNA4 ====
+    // BF16 and FP8 use the same TP8+EP8, AITER, full-decode-graph, and EAGLE
+    // 3/1/4 recipe on gfx942 and gfx950. MXFP4 is exposed only on gfx950.
+    // MI300X and MI355X are the measured systems; MI325X and MI350X inherit
+    // support from the architecture-identical gfx942 and gfx950 paths.
     {
-      match: { hw: "mi350x", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" },
+      match: { hw: "mi300x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
       verified: true,
-      env: [],
+      env: ["SGLANG_USE_AITER=1"],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--revision de4b8e4d43b917e7706784d8bb445c9af86a3540",
         "--tp-size 8",
+        "--ep-size 8",
         "--attention-backend aiter",
-        "--page-size 32",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
         "--kv-cache-dtype auto",
         "--chunked-prefill-size 16384",
         "--watchdog-timeout 1200",
         "--mem-fraction-static 0.9",
         "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
         "--trust-remote-code",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],
     },
     {
-      match: { hw: "mi350x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" },
+      match: { hw: "mi300x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
       verified: true,
-      env: [],
+      env: ["SGLANG_USE_AITER=1"],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--revision 236dfdf285828023ca3bcd3f37366c58a3469b13",
         "--tp-size 8",
+        "--ep-size 8",
         "--attention-backend aiter",
-        "--page-size 32",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
         "--kv-cache-dtype auto",
         "--chunked-prefill-size 16384",
         "--watchdog-timeout 1200",
         "--mem-fraction-static 0.9",
         "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
         "--trust-remote-code",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],
     },
     {
-      match: { hw: "mi355x", variant: "default", quant: "bf16", strategy: "balanced", nodes: "single" },
+      match: { hw: "mi325x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
       verified: true,
-      env: [],
+      warn: "Validated on MI300X; MI325X uses the same gfx942 execution path.",
+      env: ["SGLANG_USE_AITER=1"],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--revision de4b8e4d43b917e7706784d8bb445c9af86a3540",
         "--tp-size 8",
+        "--ep-size 8",
         "--attention-backend aiter",
-        "--page-size 32",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
         "--kv-cache-dtype auto",
         "--chunked-prefill-size 16384",
         "--watchdog-timeout 1200",
         "--mem-fraction-static 0.9",
         "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
         "--trust-remote-code",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",
       ],
     },
     {
-      match: { hw: "mi355x", variant: "default", quant: "fp8", strategy: "balanced", nodes: "single" },
+      match: { hw: "mi325x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
       verified: true,
-      env: [],
+      warn: "Validated on MI300X; MI325X uses the same gfx942 execution path.",
+      env: ["SGLANG_USE_AITER=1"],
       flags: [
         "--model-path {{MODEL_NAME}}",
+        "--revision 236dfdf285828023ca3bcd3f37366c58a3469b13",
         "--tp-size 8",
+        "--ep-size 8",
         "--attention-backend aiter",
-        "--page-size 32",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
         "--kv-cache-dtype auto",
         "--chunked-prefill-size 16384",
         "--watchdog-timeout 1200",
         "--mem-fraction-static 0.9",
         "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi350x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      warn: "Validated on MI355X; MI350X uses the same gfx950 execution path.",
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi350x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      warn: "Validated on MI355X; MI350X uses the same gfx950 execution path.",
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision 236dfdf285828023ca3bcd3f37366c58a3469b13",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi350x", variant: "default", quant: "mxfp4", strategy: "high-throughput", nodes: "single" },
+      verified: true,
+      warn: "Validated on MI355X; MI350X uses the same gfx950 execution path.",
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision 1ad7d941b239f6dc83cba6e49234c0efe1ca5477",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi350x", variant: "default", quant: "mxfp4", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      warn: "Validated on MI355X; MI350X uses the same gfx950 execution path.",
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision 1ad7d941b239f6dc83cba6e49234c0efe1ca5477",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi355x", variant: "default", quant: "bf16", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision de4b8e4d43b917e7706784d8bb445c9af86a3540",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi355x", variant: "default", quant: "fp8", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision 236dfdf285828023ca3bcd3f37366c58a3469b13",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi355x", variant: "default", quant: "mxfp4", strategy: "high-throughput", nodes: "single" },
+      verified: true,
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision 1ad7d941b239f6dc83cba6e49234c0efe1ca5477",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--trust-remote-code",
+        "--host {{HOST_IP}}",
+        "--port {{PORT}}",
+      ],
+    },
+    {
+      match: { hw: "mi355x", variant: "default", quant: "mxfp4", strategy: "low-latency", nodes: "single" },
+      verified: true,
+      env: ["SGLANG_USE_AITER=1"],
+      flags: [
+        "--model-path {{MODEL_NAME}}",
+        "--revision 1ad7d941b239f6dc83cba6e49234c0efe1ca5477",
+        "--tp-size 8",
+        "--ep-size 8",
+        "--attention-backend aiter",
+        "--moe-runner-backend aiter",
+        "--page-size 64",
+        "--kv-cache-dtype auto",
+        "--chunked-prefill-size 16384",
+        "--watchdog-timeout 1200",
+        "--mem-fraction-static 0.9",
+        "--model-loader-extra-config '{\"enable_multithread_load\": true}'",
+        "--max-running-requests 4",
+        "--cuda-graph-backend-decode full",
+        "--cuda-graph-max-bs-decode 4",
+        "--speculative-algorithm EAGLE",
+        "--speculative-num-steps 3",
+        "--speculative-eagle-topk 1",
+        "--speculative-num-draft-tokens 4",
         "--trust-remote-code",
         "--host {{HOST_IP}}",
         "--port {{PORT}}",


### PR DESCRIPTION
## Motivation

Refresh the AMD portion of the Qwen3.8-Flash-Next cookbook against the current runtime fixes in #36601 and the latest official ROCm 10 nightlies.

As of September 12, 2026, SGLang `main` and the September 11 MI30X/MI35X nightlies do not contain #36601. The official nightlies therefore are not the validated out-of-box path for these AMD recipes yet, so neither #36601 nor this cookbook PR should be closed.

## Cookbook scope

| Architecture | Hardware | BF16 | FP8 | Quark MXFP4 |
| --- | --- | --- | --- | --- |
| gfx942 | MI300X | Directly validated | Directly validated | Not exposed |
| gfx942 | MI325X | Inherits MI300X path | Inherits MI300X path | Not exposed |
| gfx950 | MI350X | Inherits MI355X path | Inherits MI355X path | Inherits MI355X path |
| gfx950 | MI355X | Directly validated | Directly validated | Directly validated |

The AMD command matrix contains:

- BF16 and FP8 low-latency recipes on MI300X, MI325X, MI350X, and MI355X.
- Quark MXFP4 high-throughput and low-latency recipes on MI350X and MI355X only.
- TP8+EP8, `SGLANG_USE_AITER=1`, explicit AITER attention and MoE, page size 64, and full decode CUDA graphs on every AMD cell.
- EAGLE/MTP 3/1/4 on every low-latency cell; the MXFP4 high-throughput cell is the non-speculative control.
- Docker-only rendering for AMD, using immutable official ROCm nightlies, a read-only mount of the exact #36601 Python source, and ROCm device access. NVIDIA cells keep their existing Python and Docker modes.

MI325X shares the tested gfx942 execution path with MI300X. MI350X shares the tested gfx950 execution path with MI355X. The inherited benchmark rows intentionally do not copy accuracy measured on a different GPU model.

## Engine, image, and model provenance

- dependency: #36601
- validated #36601 head: `0b4f96ff745b7b498e49e613dfeea046a60052fc`
- nightly embedded SGLang revision: `358c163250ad3b1f62939b01ce1314a0a31a0365`
- PR Python tree: `15b675eb400c3fa48d0f65c2ee2d4a369f4ce591`
- tracked source aggregate: `02745069648ce3d26b774764091d312137d903909b216d5b0eb7b87978a34586`
- gfx942 nightly base: `rocm/sgl-dev@sha256:151005265cf3f4e98c41abc41f5cd317ab2e83085ec24d82f0bd36465f886457`
- gfx950 nightly base: `rocm/sgl-dev@sha256:9252e847c0ebcef375543d3bf61d935cbd80ef5ac86ed3ba16e31bb7e1f1be47`
- BF16 revision: `de4b8e4d43b917e7706784d8bb445c9af86a3540`
- FP8 revision: `236dfdf285828023ca3bcd3f37366c58a3469b13`
- Quark MXFP4 revision: `1ad7d941b239f6dc83cba6e49234c0efe1ca5477`

The cookbook does not depend on a custom Docker Hub image. Until #36601 lands in an official nightly, readers check out the exact validated PR head and the generated AMD command bind-mounts `$PWD/python/sglang` read-only over the matching immutable official nightly. All seven #36601 files are either under that mounted runtime tree or are tests; no compiled runtime artifact is omitted by the overlay.

The Quark MXFP4 repository has newer README-only commits after the validated revision. The cookbook keeps the validated payload revision because all non-README model blobs are unchanged and the pin makes the result reproducible.

## Full five-shot GSM8K validation

All direct runs used one eight-GPU node, TP8+EP8, AITER attention/MoE, full target and draft decode graphs, EAGLE/MTP 3/1/4, and the exact #36601 Python source described above. Each run requested the complete 1,319-row GSM8K set; five rows were reserved as demonstrations and 1,314 responses were scored.

| GPU | Model | Score | Correct | Request errors | Graph-backed decode | Mean MTP acceptance |
| --- | --- | ---: | ---: | ---: | ---: | ---: |
| MI300X | BF16 | 97.1842% | 1,277/1,314 | 0 | 379/379 | 3.5666 |
| MI300X | FP8 | 96.4231% | 1,267/1,314 | 0 | 379/379 | 3.5693 |
| MI355X | BF16 | 96.8798% | 1,273/1,314 | 0 | 379/379 | 3.5669 |
| MI355X | FP8 | 96.8037% | 1,272/1,314 | 0 | 374/374 | 3.5690 |
| MI355X | Quark MXFP4 | 96.6514% | 1,270/1,314 | 0 | 374/374 | 3.5524 |

Every completed run exited successfully, exceeded the 94% gate, had zero fatal server patterns, and retained HTTP health after evaluation. The gfx942 focused suite passed 13 tests; the gfx950 MXFP4 focused suite passed 14 tests. No performance claim is made from these correctness runs.

## Checks

- `node docs/scripts/check_cookbook_configs.mjs`
- targeted `pre-commit run --files ...` across all six changed files
- `git diff --check`
- `npx --yes mintlify broken-links`
- `npx --yes mintlify validate`
- generated-command inspection for both official nightly digests, ROCm device access, and the exact read-only source mount
- direct full five-shot GSM8K on MI300X and MI355X

## Checklist

- [x] Format the changed files with the repository hooks.
- [x] Add focused guard coverage for image immutability, hardware/quantization scope, TP8+EP8, AITER, graph mode, MTP, model revisions, direct scores, and inherited benchmark rows.
- [x] Validate the gfx942 path on MI300X.
- [x] Complete the gfx950 FP8 validation on MI355X.
- [x] Remove the custom-image publication dependency and document the official-nightly source-overlay workflow.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #34716812435](https://github.com/sgl-project/sglang/actions/runs/34716812435)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34716812231](https://github.com/sgl-project/sglang/actions/runs/34716812231)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
