### PR TITLE
Add configurable HTTP/2 connection window

### DIFF
--- a/python/sglang/srt/arg_groups/serving_hook.py
+++ b/python/sglang/srt/arg_groups/serving_hook.py
@@ -80,6 +80,11 @@ def handle_ssl_validation(server_args: Any):
             raise ValueError(
                 "--http2-max-concurrent-streams must be between 1 and " "4294967295."
             )
+        if not 1024 <= cfg.http2_initial_connection_window_size < 2**31:
+            raise ValueError(
+                "--http2-initial-connection-window-size must be between "
+                "1024 and 2147483647."
+            )
 
         try:
             import granian  # noqa: F401

--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2438,6 +2438,7 @@ def _run_granian_server(
     port,
     log_level,
     http2_max_concurrent_streams,
+    http2_initial_connection_window_size,
     tokenizer_worker_num=1,
     ssl_certfile=None,
     ssl_keyfile=None,
@@ -2475,7 +2476,8 @@ def _run_granian_server(
         interface=Interfaces.ASGI,
         http=HTTPModes.auto,
         http2_settings=HTTP2Settings(
-            max_concurrent_streams=http2_max_concurrent_streams
+            initial_connection_window_size=http2_initial_connection_window_size,
+            max_concurrent_streams=http2_max_concurrent_streams,
         ),
         log_level=log_level,
         ssl_cert=ssl_certfile,
@@ -2610,6 +2612,9 @@ def _setup_and_run_http_server(
                     http2_max_concurrent_streams=(
                         server_args.http2_max_concurrent_streams
                     ),
+                    http2_initial_connection_window_size=(
+                        server_args.http2_initial_connection_window_size
+                    ),
                     ssl_certfile=server_args.ssl_certfile,
                     ssl_keyfile=server_args.ssl_keyfile,
                     ssl_ca_certs=server_args.ssl_ca_certs,
@@ -2699,6 +2704,9 @@ def _setup_and_run_http_server(
                     or get_observability().log_level,
                     http2_max_concurrent_streams=(
                         server_args.http2_max_concurrent_streams
+                    ),
+                    http2_initial_connection_window_size=(
+                        server_args.http2_initial_connection_window_size
                     ),
                     tokenizer_worker_num=server_args.tokenizer_worker_num,
                     ssl_certfile=server_args.ssl_certfile,

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -1283,6 +1283,14 @@ class ServerArgs:
         "connection (1 to 2^32 - 1). Only applies with --enable-http2.",
         NS("serving"),
     ] = 200
+    http2_initial_connection_window_size: A[
+        int,
+        "Initial connection-level HTTP/2 receive window in bytes (1024 to "
+        "2^31 - 1). Only applies with --enable-http2.",
+        NS("serving"),
+    ] = (
+        1024 * 1024
+    )
 
     # -------------------------------------------------------------------------
     # SSL/TLS

--- a/test/registered/unit/entrypoints/test_http2_server_config.py
+++ b/test/registered/unit/entrypoints/test_http2_server_config.py
@@ -31,9 +31,14 @@ class TestGranianHTTP2Config(unittest.TestCase):
                 port=30000,
                 log_level="info",
                 http2_max_concurrent_streams=37,
+                http2_initial_connection_window_size=8 * 1024 * 1024,
             )
 
         self.assertEqual(configured["http2_settings"].max_concurrent_streams, 37)
+        self.assertEqual(
+            configured["http2_settings"].initial_connection_window_size,
+            8 * 1024 * 1024,
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

Increasing `--http2-max-concurrent-streams` alone does not prevent connection-level flow-control stalls when clients concurrently upload many large request bodies. Granian defaults the HTTP/2 connection receive window to 1 MiB, so serving workloads need a way to tune that window independently of the stream limit.

## Modifications

- Add `--http2-initial-connection-window-size`, defaulting to Granian's existing 1 MiB default.
- Validate the value against Granian's supported range of 1,024 through `2^31 - 1` bytes.
- Pass the configured value to `HTTP2Settings` for both single- and multi-tokenizer-worker servers.
- Extend the Granian configuration unit test to cover the new setting.

## Accuracy Tests

Not applicable. This changes HTTP/2 transport configuration only and does not affect model execution or outputs.

## Speed Tests and Profiling

Tested with prewarmed HTTP/2 connections, 64 requests per connection, and representative 32,861-byte request bodies. The server held responses until all request bodies arrived so connection reuse could not hide upload latency.

With Granian's default 1 MiB connection window, a 1,024-request batch stalled after 1,008 bodies (`16 connections * 63 bodies`). With a 64 MiB window:

- 1,024 requests reached the server in 0.326, 0.332, and 0.361 seconds (0.332-second median).
- 2,048 requests reached the server in 0.677, 0.729, and 0.774 seconds (0.729-second median).

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). The annotated server argument supplies the generated CLI help; no standalone documentation is needed.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33214434659](https://github.com/sgl-project/sglang/actions/runs/33214434659)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33214434482](https://github.com/sgl-project/sglang/actions/runs/33214434482)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33214434754](https://github.com/sgl-project/sglang/actions/runs/33214434754)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

