### PR TITLE
fix: KT's last MoE layer stops deferring experts again

### DIFF
--- a/python/sglang/srt/layers/moe/kt_ep_wrapper.py
+++ b/python/sglang/srt/layers/moe/kt_ep_wrapper.py
@@ -76,14 +76,9 @@ def create_kt_config_from_server_args(
     if server_args.kt_weight_path is None:
         return None
 
-    # Try to get num_layers from model config
-    num_layers = None
-    try:
-        hf_config = server_args.get_hf_config()
-        num_layers = getattr(hf_config, "num_hidden_layers", None)
-    except Exception:
-        # If we can't get the config, num_layers will be None
-        pass
+    num_layers = getattr(
+        server_args.get_model_config().hf_config, "num_hidden_layers", None
+    )
 
     return KTConfig(
         layer_idx=layer_idx,


### PR DESCRIPTION
## Motivation

`create_kt_config_from_server_args` resolves `num_layers` for one reason: so the
KT wrapper can recognise the model's final layer, which must defer no experts.

```python
if (self.kt_config.max_deferred_experts_per_token is not None
        and self.kt_config.num_layers is not None
        and self.kt_config.layer_idx == self.kt_config.num_layers - 1):
    layer_max_deferred = 0
```

That branch has not fired since December 2025.

#12834 wrote the read as `server_args.get_hf_config()`, which was correct at the
time. #15298 removed `ServerArgs.get_hf_config` and rewrote the three call sites
*inside* `server_args.py` to `get_model_config().hf_config` — but not this one,
which lives in another file. The call has raised `AttributeError` on every
invocation since.

Three things kept it quiet:

- the read sat inside a bare `except Exception: pass` whose comment described the
  intended case (*"If we can't get the config, num_layers will be None"*), so the
  failure was indistinguishable from the handled one;
- the consumer guards on `num_layers is not None`, so the symptom is a rule that
  silently stops applying, not an error;
- the function returns early unless `kt_weight_path` is set, so only
  KTransformers runs reach it at all.

## Modifications

The read becomes `server_args.get_model_config().hf_config` — the same spelling
#15298 moved everything else to — and the swallow is gone. Three lines in, eight
out.

## Accuracy Tests

Measured on an 8×H200 box against a 7-layer checkpoint:

| | `KTConfig.num_layers` | layer 6 recognised as last |
|---|---|---|
| main | `None` | no |
| this PR | `7` | yes |

`sa.get_hf_config()` on main raises `AttributeError: 'ServerArgs' object has no
attribute 'get_hf_config'`, confirming the call could never have succeeded.
`test/registered/unit/layers/moe/` is green (54 passed).

## Speed Tests and Profiling

None. One attribute read replaces one that always raised.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

**This changes runtime behaviour** for runs with
`--kt-max-deferred-experts-per-token` set: the final MoE layer stops deferring
experts, which is what the code was written to do. A KTransformers owner should
confirm that is still the intent before this merges.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33215278000](https://github.com/sgl-project/sglang/actions/runs/33215278000)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33215277586](https://github.com/sgl-project/sglang/actions/runs/33215277586)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33215277910](https://github.com/sgl-project/sglang/actions/runs/33215277910)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
