### PR TITLE
Fix disaggregated prefill cache leak after abort

### DIFF
--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -1044,26 +1044,28 @@ class SchedulerDisaggregationPrefillMixin:
         """
         self.clear_pending_chunk_send(req)
         owns_resources = (
-            req.req_pool_idx is not None
-            or req.kv is not None
+            req.is_holding_kv
             or req.mamba_pool_idx is not None
             or req.metadata_buffer_index >= 0
         )
         if not owns_resources:
             return False
 
-        req.disagg_kv_sender.abort()
+        try:
+            req.disagg_kv_sender.abort()
+        except Exception:
+            logger.warning(
+                "Failed to abort KV transfer while retiring request %s",
+                req.rid,
+                exc_info=True,
+            )
         if req.to_finish is not None and not req.finished():
             req.update_finish_state()
         maybe_release_metadata_buffer(req, self.req_to_metadata_buffer_idx_allocator)
         req.pending_bootstrap = False
         if self.enable_hicache_storage:
             self.tree_cache.release_aborted_request(req.rid)
-        if (
-            req.req_pool_idx is not None
-            or req.kv is not None
-            or req.mamba_pool_idx is not None
-        ):
+        if req.is_holding_kv or req.mamba_pool_idx is not None:
             release_kv_cache(req, self.tree_cache, is_insert=False)
         return True
 

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -718,6 +718,7 @@ class SchedulerDisaggregationPrefillMixin:
             result.indexer_topk_output = None
 
         logprob_pt = 0
+        aborted_reqs: List[Req] = []
         assert batch.spec_info is result.next_draft_input
         draft_input = result.next_draft_input
         draft_hidden_states_cpu = None
@@ -751,6 +752,13 @@ class SchedulerDisaggregationPrefillMixin:
         ):
             if req.inflight_middle_chunks <= 0:
                 req.time_stats.set_prefill_finished_time()
+
+                if is_aborted(req):
+                    if self._retire_aborted_prefill_result(req):
+                        req.time_stats.set_completion_time()
+                        aborted_reqs.append(req)
+                    advance_logprob_pt(i, req)
+                    continue
 
                 # Test hook: exercise the release/requeue retry path.
                 if req.pending_bootstrap and should_force_retry(req):
@@ -820,16 +828,19 @@ class SchedulerDisaggregationPrefillMixin:
                     req.extend_range is not None
                     and req.extend_range.end >= len(req.origin_input_ids)
                 )
-                if req.pending_bootstrap and not still_chunking:
-                    self.optimistic_release_and_requeue(req)
+
+                # Abort is terminal. In particular, do not requeue an aborted
+                # optimistic request merely because bootstrap is still pending.
+                if is_aborted(req):
+                    if not still_chunking and self._retire_aborted_prefill_result(req):
+                        req.time_stats.set_completion_time()
+                        aborted_reqs.append(req)
                     advance_logprob_pt(i, req)
                     req.time_stats.set_last_chunked_prefill_finish_time()
                     continue
 
-                # Optimistic bootstrap can fail while this overlapped chunk is
-                # already running. Drop aborted chunks instead of sending KV.
-                if is_aborted(req):
-                    self.clear_pending_chunk_send(req)
+                if req.pending_bootstrap and not still_chunking:
+                    self.optimistic_release_and_requeue(req)
                     advance_logprob_pt(i, req)
                     req.time_stats.set_last_chunked_prefill_finish_time()
                     continue
@@ -863,6 +874,12 @@ class SchedulerDisaggregationPrefillMixin:
                 batch,
                 auxiliary_output,
                 auxiliary_output_starts,
+            )
+
+        if aborted_reqs:
+            self.output_streamer.stream_output(
+                aborted_reqs,
+                any(req.return_logprob for req in aborted_reqs),
             )
 
         can_run_cuda_graph = result.can_run_cuda_graph
@@ -1017,6 +1034,38 @@ class SchedulerDisaggregationPrefillMixin:
         for the process lifetime.
         """
         self.disagg_prefill_pending_chunk_rids.discard(req.rid)
+
+    def _retire_aborted_prefill_result(self: Scheduler, req: Req) -> bool:
+        """Release an aborted request still owned by a completed prefill batch.
+
+        Returns whether this result performed the terminal cleanup. A bootstrap
+        failure or deferred chunked-abort may have already released the request;
+        delayed overlap results for those paths must be ignored.
+        """
+        self.clear_pending_chunk_send(req)
+        owns_resources = (
+            req.req_pool_idx is not None
+            or req.kv is not None
+            or req.mamba_pool_idx is not None
+            or req.metadata_buffer_index >= 0
+        )
+        if not owns_resources:
+            return False
+
+        req.disagg_kv_sender.abort()
+        if req.to_finish is not None and not req.finished():
+            req.update_finish_state()
+        maybe_release_metadata_buffer(req, self.req_to_metadata_buffer_idx_allocator)
+        req.pending_bootstrap = False
+        if self.enable_hicache_storage:
+            self.tree_cache.release_aborted_request(req.rid)
+        if (
+            req.req_pool_idx is not None
+            or req.kv is not None
+            or req.mamba_pool_idx is not None
+        ):
+            release_kv_cache(req, self.tree_cache, is_insert=False)
+        return True
 
     def handle_bootstrap_failure(self: Scheduler, req: Req) -> None:
         self.clear_pending_chunk_send(req)

--- a/test/registered/unit/disaggregation/test_prefill_abort_result_cleanup.py
+++ b/test/registered/unit/disaggregation/test_prefill_abort_result_cleanup.py
@@ -16,7 +16,7 @@ class _Req:
         self.rid = "aborted-prefill"
         self.inflight_middle_chunks = inflight_middle_chunks
         self.req_pool_idx = 1 if allocated else None
-        self.kv = object() if allocated else None
+        self.kv = object()
         self.mamba_pool_idx = object() if allocated else None
         self.metadata_buffer_index = 7 if allocated else -1
         self.pending_bootstrap = allocated
@@ -37,6 +37,10 @@ class _Req:
 
     def finished(self):
         return self.finished_reason is not None
+
+    @property
+    def is_holding_kv(self):
+        return self.req_pool_idx is not None
 
     def update_finish_state(self):
         self.finished_reason = self.to_finish
@@ -78,7 +82,6 @@ def _result():
 def _free_req(req, _tree_cache, *, is_insert):
     assert is_insert is False
     req.req_pool_idx = None
-    req.kv = None
     req.mamba_pool_idx = None
 
 
@@ -104,6 +107,20 @@ def test_aborted_final_result_releases_hybrid_cache(
     assert req.to_finish is None
     assert req.metadata_buffer_index == -1
     assert req.rid not in scheduler.disagg_prefill_pending_chunk_rids
+
+
+@patch("sglang.srt.disaggregation.prefill.release_kv_cache", side_effect=_free_req)
+def test_transport_abort_failure_does_not_bypass_local_cleanup(release_kv_cache):
+    scheduler = _Scheduler()
+    req = _Req(inflight_middle_chunks=0)
+    req.disagg_kv_sender.abort.side_effect = RuntimeError("transport unavailable")
+
+    scheduler.process_batch_result_disagg_prefill(_batch(req), _result())
+
+    release_kv_cache.assert_called_once_with(req, scheduler.tree_cache, is_insert=False)
+    scheduler.req_to_metadata_buffer_idx_allocator.free.assert_called_once_with(7)
+    scheduler.tree_cache.release_aborted_request.assert_called_once_with(req.rid)
+    scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
 
 
 @patch("sglang.srt.disaggregation.prefill.release_kv_cache", side_effect=_free_req)

--- a/test/registered/unit/disaggregation/test_prefill_abort_result_cleanup.py
+++ b/test/registered/unit/disaggregation/test_prefill_abort_result_cleanup.py
@@ -1,0 +1,158 @@
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.disaggregation.prefill import SchedulerDisaggregationPrefillMixin
+from sglang.srt.managers.schedule_batch import FINISH_ABORT
+from sglang.srt.managers.utils import GenerationBatchResult
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _Req:
+    def __init__(self, *, inflight_middle_chunks: int, allocated: bool = True):
+        self.rid = "aborted-prefill"
+        self.inflight_middle_chunks = inflight_middle_chunks
+        self.req_pool_idx = 1 if allocated else None
+        self.kv = object() if allocated else None
+        self.mamba_pool_idx = object() if allocated else None
+        self.metadata_buffer_index = 7 if allocated else -1
+        self.pending_bootstrap = allocated
+        self.disagg_kv_sender = Mock()
+        self.to_finish = FINISH_ABORT() if allocated else None
+        self.finished_reason = None if allocated else FINISH_ABORT()
+        self.return_logprob = False
+        self.return_sampling_mask = False
+        self.grammar = None
+        self.output_ids = []
+        self.origin_input_ids = list(range(100))
+        self.extend_range = None
+        self.time_stats = SimpleNamespace(
+            set_prefill_finished_time=Mock(),
+            set_last_chunked_prefill_finish_time=Mock(),
+            set_completion_time=Mock(),
+        )
+
+    def finished(self):
+        return self.finished_reason is not None
+
+    def update_finish_state(self):
+        self.finished_reason = self.to_finish
+        self.to_finish = None
+
+
+class _Scheduler(SchedulerDisaggregationPrefillMixin):
+    def __init__(self):
+        self.batch_result_processor = SimpleNamespace(
+            snapshot_auxiliary_output_starts=Mock(return_value=[]),
+            move_logprobs_to_cpu=Mock(),
+            consume_auxiliary_output=Mock(),
+        )
+        self.spec_algorithm = SimpleNamespace(is_eagle=lambda: False)
+        self.tree_cache = Mock()
+        self.disagg_prefill_inflight_queue = []
+        self.disagg_prefill_pending_chunk_rids = {"aborted-prefill"}
+        self.send_kv_chunk = Mock()
+        self.output_streamer = Mock()
+        self.metrics_reporter = SimpleNamespace(report_prefill_stats=Mock())
+        self.req_to_metadata_buffer_idx_allocator = Mock()
+        self.enable_hicache_storage = True
+        self.chunked_req = None
+
+
+def _batch(req):
+    return SimpleNamespace(
+        reqs=[req],
+        spec_info=None,
+        prefill_stats=None,
+        dp_cooperation_info=None,
+    )
+
+
+def _result():
+    return GenerationBatchResult(next_token_ids=torch.tensor([11]))
+
+
+def _free_req(req, _tree_cache, *, is_insert):
+    assert is_insert is False
+    req.req_pool_idx = None
+    req.kv = None
+    req.mamba_pool_idx = None
+
+
+@patch("sglang.srt.disaggregation.prefill.release_kv_cache", side_effect=_free_req)
+@patch("sglang.srt.disaggregation.prefill.maybe_cache_unfinished_req")
+def test_aborted_final_result_releases_hybrid_cache(
+    maybe_cache_unfinished_req, release_kv_cache
+):
+    scheduler = _Scheduler()
+    req = _Req(inflight_middle_chunks=0)
+
+    scheduler.process_batch_result_disagg_prefill(_batch(req), _result())
+
+    release_kv_cache.assert_called_once_with(req, scheduler.tree_cache, is_insert=False)
+    maybe_cache_unfinished_req.assert_not_called()
+    req.disagg_kv_sender.abort.assert_called_once_with()
+    scheduler.req_to_metadata_buffer_idx_allocator.free.assert_called_once_with(7)
+    scheduler.tree_cache.release_aborted_request.assert_called_once_with(req.rid)
+    scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+    scheduler.send_kv_chunk.assert_not_called()
+    assert req.output_ids == []
+    assert req.finished()
+    assert req.to_finish is None
+    assert req.metadata_buffer_index == -1
+    assert req.rid not in scheduler.disagg_prefill_pending_chunk_rids
+
+
+@patch("sglang.srt.disaggregation.prefill.release_kv_cache", side_effect=_free_req)
+def test_aborted_middle_result_releases_when_no_later_chunk_is_inflight(
+    release_kv_cache,
+):
+    scheduler = _Scheduler()
+    req = _Req(inflight_middle_chunks=1)
+    req.extend_range = SimpleNamespace(end=50)
+
+    scheduler.process_batch_result_disagg_prefill(_batch(req), _result())
+
+    assert req.inflight_middle_chunks == 0
+    release_kv_cache.assert_called_once_with(req, scheduler.tree_cache, is_insert=False)
+    scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+    req.time_stats.set_last_chunked_prefill_finish_time.assert_called_once_with()
+
+
+@patch("sglang.srt.disaggregation.prefill.release_kv_cache", side_effect=_free_req)
+def test_aborted_middle_result_defers_release_until_final_result(
+    release_kv_cache,
+):
+    scheduler = _Scheduler()
+    req = _Req(inflight_middle_chunks=1)
+    req.extend_range = SimpleNamespace(end=len(req.origin_input_ids))
+
+    scheduler.process_batch_result_disagg_prefill(_batch(req), _result())
+
+    assert req.inflight_middle_chunks == 0
+    release_kv_cache.assert_not_called()
+    scheduler.output_streamer.stream_output.assert_not_called()
+    assert req.rid in scheduler.disagg_prefill_pending_chunk_rids
+
+    scheduler.process_batch_result_disagg_prefill(_batch(req), _result())
+
+    release_kv_cache.assert_called_once_with(req, scheduler.tree_cache, is_insert=False)
+    scheduler.output_streamer.stream_output.assert_called_once_with([req], False)
+
+
+@patch("sglang.srt.disaggregation.prefill.release_kv_cache")
+def test_delayed_result_ignores_request_already_cleaned_by_bootstrap_failure(
+    release_kv_cache,
+):
+    scheduler = _Scheduler()
+    req = _Req(inflight_middle_chunks=0, allocated=False)
+
+    scheduler.process_batch_result_disagg_prefill(_batch(req), _result())
+
+    release_kv_cache.assert_not_called()
+    req.disagg_kv_sender.abort.assert_not_called()
+    scheduler.output_streamer.stream_output.assert_not_called()
+    assert req.rid not in scheduler.disagg_prefill_pending_chunk_rids


### PR DESCRIPTION
## Motivation

An aborted disaggregated prefill request can lose scheduler ownership when an overlapped middle or final chunk result arrives after AbortReq or bootstrap failure. The result path currently drops aborted middle chunks and does not check final chunks before caching and enqueueing them.

For hybrid Mamba models this leaves one request allocation unaccounted for: one full prefill chunk plus the request Mamba state and overlap buffers. The observed production invariant failure was a 16,384-token full-KV deficit and three missing Mamba states.

## Modifications

- Treat abort as terminal before optimistic-bootstrap retry.
- Retire aborted final results and abandoned middle results through one idempotent cleanup helper.
- Release metadata, HiCache request state, KV pages, and Mamba state without inserting the aborted request into radix cache.
- Defer cleanup while a later overlapped chunk is still running.
- Ignore delayed results when bootstrap-failure cleanup already released the request.
- Stream the terminal abort exactly once from the result path that owns cleanup.

## Accuracy Tests

No model-output behavior changes for successful requests.

- 9 focused CPU tests passed, including delayed middle result, delayed final result, already-cleaned bootstrap failure, and unified-memory move-gate coverage.
- All file-scoped pre-commit hooks passed.

GPU reproduction on the original GLM-5.3-Flash B300 deployment is still pending.

## Speed Tests and Profiling

Not applicable. The new checks only run for completed disaggregated-prefill results; no model-forward path changes.

## Checklist

- [x] Format code with pre-commit.
- [x] Add unit tests.
- [ ] Update documentation (not needed for this lifecycle bug fix).
- [ ] Provide accuracy and speed benchmarks (not applicable; production GPU reproduction remains pending).
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33272687086](https://github.com/sgl-project/sglang/actions/runs/33272687086)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33272686834](https://github.com/sgl-project/sglang/actions/runs/33272686834)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33272687029](https://github.com/sgl-project/sglang/actions/runs/33272687029)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->