### PR TITLE
refactor: make checkpoint quant metadata access explicit

### DIFF
--- a/python/sglang/srt/model_loader/checkpoint_quantization.py
+++ b/python/sglang/srt/model_loader/checkpoint_quantization.py
@@ -8,6 +8,8 @@ from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Literal, Mapping, TypeAlias
 
+from transformers import PretrainedConfig
+
 __all__ = [
     "CheckpointQuantSpec",
     "QuantMetadataSource",
@@ -36,41 +38,38 @@ class CheckpointQuantSpec:
     source: QuantMetadataSource
 
 
-def _get_field(config: object, name: str) -> Any:
+def _config_to_mapping(config: object, *, name: str) -> Mapping[str, Any]:
     if isinstance(config, Mapping):
-        return config.get(name)
-    return getattr(config, name, None)
+        return config
+    if isinstance(config, PretrainedConfig):
+        return config.to_dict()
+    raise TypeError(
+        f"{name} must be a mapping or transformers.PretrainedConfig, "
+        f"got {type(config).__name__}"
+    )
 
 
 def _to_metadata_dict(value: object, source: QuantMetadataSource) -> dict[str, Any]:
-    if isinstance(value, Mapping):
-        return deepcopy(dict(value))
-
-    to_dict = getattr(value, "to_dict", None)
-    if callable(to_dict):
-        metadata = to_dict()
-        if isinstance(metadata, Mapping):
-            return deepcopy(dict(metadata))
-
-    raise TypeError(
-        f"{source} must be a mapping or expose to_dict(), "
-        f"got {type(value).__name__}"
-    )
+    return deepcopy(dict(_config_to_mapping(value, name=source)))
 
 
 def _select_hf_quant_metadata(
     hf_config: object,
 ) -> tuple[QuantMetadataSource, object] | None:
-    value = _get_field(hf_config, "quantization_config")
+    config = _config_to_mapping(hf_config, name="HF config")
+    value = config.get("quantization_config")
     if value is not None:
         return "quantization_config", value
 
-    text_config = _get_field(hf_config, "text_config")
-    value = _get_field(text_config, "quantization_config")
-    if value is not None:
-        return "text_config.quantization_config", value
+    text_config = config.get("text_config")
+    if text_config is not None:
+        value = _config_to_mapping(text_config, name="text_config").get(
+            "quantization_config"
+        )
+        if value is not None:
+            return "text_config.quantization_config", value
 
-    value = _get_field(hf_config, "compression_config")
+    value = config.get("compression_config")
     if value is not None:
         return "compression_config", value
 

--- a/test/registered/unit/test_checkpoint_quantization.py
+++ b/test/registered/unit/test_checkpoint_quantization.py
@@ -2,6 +2,8 @@
 
 import unittest
 
+from transformers import PretrainedConfig
+
 from sglang.srt.layers.modelopt_utils import canonicalize_modelopt_quant_algo
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.model_loader.checkpoint_quantization import (
@@ -12,19 +14,6 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
-
-
-class _ConfigObject:
-    def __init__(self, **values):
-        self.__dict__.update(values)
-
-
-class _QuantConfigObject:
-    def __init__(self, values):
-        self._values = values
-
-    def to_dict(self):
-        return self._values
 
 
 class TestResolveCheckpointQuantSpec(CustomTestCase):
@@ -75,11 +64,9 @@ class TestResolveCheckpointQuantSpec(CustomTestCase):
             ),
         )
 
-    def test_text_config_fallback_supports_config_objects(self):
-        config = _ConfigObject(
-            text_config=_ConfigObject(
-                quantization_config={"quant_method": "gptq", "bits": 4}
-            ),
+    def test_text_config_fallback_supports_pretrained_config(self):
+        config = PretrainedConfig(
+            text_config={"quantization_config": {"quant_method": "gptq", "bits": 4}},
             compression_config={"quant_method": "compressed-tensors"},
         )
 
@@ -90,7 +77,7 @@ class TestResolveCheckpointQuantSpec(CustomTestCase):
         self.assertEqual(spec.source, "text_config.quantization_config")
 
     def test_compression_config_fallback(self):
-        config = _ConfigObject(
+        config = PretrainedConfig(
             compression_config={"quant_method": "compressed-tensors"}
         )
 
@@ -114,11 +101,12 @@ class TestResolveCheckpointQuantSpec(CustomTestCase):
         self.assertIsNone(spec.declared_method)
         self.assertEqual(spec.config["quant_algo"], "FP8")
 
-    def test_quant_config_object_is_converted(self):
-        config = _ConfigObject(
-            quantization_config=_QuantConfigObject(
-                {"quant_method": "bitsandbytes", "load_in_4bit": True}
-            )
+    def test_pretrained_config_is_converted(self):
+        config = PretrainedConfig(
+            quantization_config={
+                "quant_method": "bitsandbytes",
+                "load_in_4bit": True,
+            }
         )
 
         spec = resolve_checkpoint_quant_spec(config)


### PR DESCRIPTION
## Summary
- replace reflective checkpoint metadata access with explicit `Mapping` / `transformers.PretrainedConfig` handling
- preserve metadata precedence and deep-copy behavior
- remove test-only dynamic config objects

## Validation
- `pre-commit run --files python/sglang/srt/model_loader/checkpoint_quantization.py test/registered/unit/test_checkpoint_quantization.py`
- registered CPU unit test covers the resolver

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33219972065](https://github.com/sgl-project/sglang/actions/runs/33219972065)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33219971880](https://github.com/sgl-project/sglang/actions/runs/33219971880)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33219972154](https://github.com/sgl-project/sglang/actions/runs/33219972154)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->