### PR TITLE
[Diffusion] Accept native AMD FP8 dtype in offload test

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_modelopt_fp8_layerwise_offload_load.py
+++ b/python/sglang/multimodal_gen/test/unit/test_modelopt_fp8_layerwise_offload_load.py
@@ -8,6 +8,7 @@ import unittest
 import torch
 from torch import nn
 
+from sglang.kernels.ops.quantization.fp8_kernel import is_fp8_fnuz
 from sglang.multimodal_gen.runtime.distributed.parallel_state import (
     maybe_init_distributed_environment_and_model_parallel,
     model_parallel_is_initialized,
@@ -114,7 +115,10 @@ class TestModelOptFp8LayerwiseOffloadLoad(unittest.TestCase):
         # Postprocess ran: the weight was requantized to the shared max scale
         # and rebound transposed.
         weight = model.qkv.weight
-        self.assertEqual(weight.dtype, torch.float8_e4m3fn)
+        expected_weight_dtype = (
+            torch.float8_e4m3fnuz if is_fp8_fnuz() else torch.float8_e4m3fn
+        )
+        self.assertEqual(weight.dtype, expected_weight_dtype)
         self.assertEqual(tuple(weight.shape), (_IN_FEATURES, 2 * _SHARD_OUT))
         weight_scale = model.qkv.weight_scale
         torch.testing.assert_close(


### PR DESCRIPTION
## Summary

- make the serialized ModelOpt FP8 layerwise-offload contract platform-aware\n- retain `float8_e4m3fn` on CUDA and expect MI300 native `float8_e4m3fnuz` when the shared FP8 capability reports FNUZ\n\nThe runtime already normalizes to the native AMD dtype; this fixes the test-only mismatch that blocks otherwise unrelated diffusion CI.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33223297194](https://github.com/sgl-project/sglang/actions/runs/33223297194)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33224116225](https://github.com/sgl-project/sglang/actions/runs/33224116225)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33223297096](https://github.com/sgl-project/sglang/actions/runs/33223297096)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->