### PR TITLE
[Fix] Drop the duplicated DSpark draft sample_block call

### DIFF
--- a/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_draft_sampler.py
@@ -157,7 +157,7 @@ class DsparkDraftSampler:
             draft_tokens, corrected_logits = self.markov_head.sample_block(
                 base_logits,
                 first_prev_tokens=anchor,
-                hidden_states=hidden_states.view(bs, self.gamma, -1),
+                hidden_states=sample_hidden,
                 sampler=sampler,
                 collect_corrected=self.folded_sampling,
             )
@@ -166,15 +166,6 @@ class DsparkDraftSampler:
                     corrected_logits.reshape(bs * self.gamma, -1)
                 )
 
-        else:
-            sampler = greedy_step_sampler
-
-        draft_tokens, corrected_logits = self.markov_head.sample_block(
-            base_logits,
-            first_prev_tokens=anchor,
-            hidden_states=sample_hidden,
-            sampler=sampler,
-        )
         self.out[: draft_tokens.numel()].copy_(draft_tokens.reshape(-1))
         if self.confidence_out is not None:
             confidence = self.confidence_fn(


### PR DESCRIPTION
`DsparkDraftSampler.__call__` runs `sample_block` twice: the call added inside the `if draft_tokens is None:` block (#33561) plus the original trailing one, which overwrites it. `self.out` came from the second call and `self.corrected_out` from the first, so the emitted draft tokens and the corrected logits were drawn from two separate passes.

Note this activates the fused greedy fast path, whose result was previously computed and then discarded.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33223878538](https://github.com/sgl-project/sglang/actions/runs/33223878538)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33223878487](https://github.com/sgl-project/sglang/actions/runs/33223878487)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33223878558](https://github.com/sgl-project/sglang/actions/runs/33223878558)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->