### PR TITLE
fix(vlm): validate precomputed embedding lengths

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -592,8 +592,8 @@ class BaseMultimodalProcessor(ABC):
                 embedding_start : embedding_start + num_tokens
             ]
             if embedding_slice.shape[0] != num_tokens:
-                raise ValueError(
-                    f"Invalid precomputed {modality.name.lower()} embeddings: "
+                raise RuntimeError(
+                    f"Precomputed {modality.name.lower()} embedding length mismatch: "
                     f"expected {num_tokens} rows, got {embedding_slice.shape[0]}"
                 )
             consumed_per_modality[modality] = embedding_start + num_tokens

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -591,6 +591,11 @@ class BaseMultimodalProcessor(ABC):
             embedding_slice = embeddings[modality][
                 embedding_start : embedding_start + num_tokens
             ]
+            if embedding_slice.shape[0] != num_tokens:
+                raise ValueError(
+                    f"Invalid precomputed {modality.name.lower()} embeddings: "
+                    f"expected {num_tokens} rows, got {embedding_slice.shape[0]}"
+                )
             consumed_per_modality[modality] = embedding_start + num_tokens
             mm_items.append(
                 MultimodalDataItem(

--- a/test/registered/unit/multimodal/test_base_processor_get_mm_data.py
+++ b/test/registered/unit/multimodal/test_base_processor_get_mm_data.py
@@ -29,7 +29,7 @@ class TestGetMmData(unittest.TestCase):
         processor = _StubProcessor(num_tokens=4010)
         embeddings = {Modality.IMAGE: torch.empty(877, 16)}
 
-        with self.assertRaisesRegex(ValueError, "expected 4010.*got 877"):
+        with self.assertRaisesRegex(RuntimeError, "expected 4010.*got 877"):
             processor.get_mm_data([], embeddings)
 
     def test_accepts_exact_length_precomputed_embeddings(self):

--- a/test/registered/unit/multimodal/test_base_processor_get_mm_data.py
+++ b/test/registered/unit/multimodal/test_base_processor_get_mm_data.py
@@ -1,0 +1,45 @@
+import unittest
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _StubProcessor(BaseMultimodalProcessor):
+    IM_START_TOKEN_ID = 1
+    IM_END_TOKEN_ID = 2
+    IM_TOKEN_ID = 3
+
+    def __init__(self, num_tokens):
+        self.num_tokens = num_tokens
+
+    def build_input_ids(self, prompt, **kwargs):
+        return prompt, [(0, self.num_tokens - 1)], [Modality.IMAGE]
+
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
+
+
+class TestGetMmData(unittest.TestCase):
+    def test_rejects_short_precomputed_embeddings(self):
+        processor = _StubProcessor(num_tokens=4010)
+        embeddings = {Modality.IMAGE: torch.empty(877, 16)}
+
+        with self.assertRaisesRegex(ValueError, "expected 4010.*got 877"):
+            processor.get_mm_data([], embeddings)
+
+    def test_accepts_exact_length_precomputed_embeddings(self):
+        processor = _StubProcessor(num_tokens=3)
+        embeddings = {Modality.IMAGE: torch.empty(3, 16)}
+
+        output = processor.get_mm_data([], embeddings)
+
+        self.assertEqual(output.mm_items[0].precomputed_embeddings.shape, (3, 16))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

A multimodal processor can receive fewer precomputed embedding rows than the placeholder span generated for a request. Python slicing silently returns the short tensor, allowing the mismatch to reach model execution and terminate scheduler ranks. This was observed on GLM-5.3-Flash with 4,010 placeholder tokens and 877 embedding rows.

## Modifications

- Validate each precomputed embedding slice against its expected placeholder length.
- Raise a request-scoped internal error before scheduler and model execution.
- Add CPU unit coverage for short and exact-length embeddings.

## Accuracy Tests

Valid precomputed embeddings are unchanged. The exact-length control test passes.

## Speed Tests and Profiling

Not applicable. The change adds one tensor shape comparison per multimodal item during preprocessing.

## Tests

- `python -m pytest -q test/registered/unit/multimodal/test_base_processor_get_mm_data.py`
- `pre-commit run --files python/sglang/srt/multimodal/processors/base_processor.py test/registered/unit/multimodal/test_base_processor_get_mm_data.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33225881370](https://github.com/sgl-project/sglang/actions/runs/33225881370)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33225881075](https://github.com/sgl-project/sglang/actions/runs/33225881075)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33225881249](https://github.com/sgl-project/sglang/actions/runs/33225881249)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->