### PR TITLE
fix(vlm): classify malformed lazy image decode as bad request

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/preprocessor.py
+++ b/python/sglang/srt/disaggregation/encoder/preprocessor.py
@@ -37,6 +37,7 @@ from sglang.srt.runtime_context import (
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.utils import (
     CLIENT_MEDIA_EXCEPTIONS,
+    fully_load_pil_image,
     load_audio,
     load_image,
     load_video,
@@ -317,12 +318,8 @@ class EncoderPreprocessor:
                     else False
                 )
                 img, _ = load_image(data, gpu_image_decode)
-                if (
-                    discard_alpha_channel
-                    and not isinstance(img, torch.Tensor)
-                    and img.mode != "RGB"
-                ):
-                    img = img.convert("RGB")
+                if discard_alpha_channel and not isinstance(img, torch.Tensor):
+                    img = fully_load_pil_image(img, mode="RGB")
                 if (
                     media_metadata
                     and self.encoder_media_processor_config.preserve_media_metadata

--- a/python/sglang/srt/multimodal/cache/identity.py
+++ b/python/sglang/srt/multimodal/cache/identity.py
@@ -72,8 +72,9 @@ class MediaSnapshot:
 
 
 def _snapshot_pil(image: Image.Image) -> MediaSnapshot:
-    snapshot = image.copy()
-    snapshot.load()
+    from sglang.srt.utils import fully_load_pil_image
+
+    snapshot = fully_load_pil_image(image).copy()
     payload = snapshot.tobytes()
     palette = snapshot.palette.tobytes() if snapshot.palette is not None else b""
     palette_mode = (

--- a/python/sglang/srt/multimodal/media_artifacts/base.py
+++ b/python/sglang/srt/multimodal/media_artifacts/base.py
@@ -42,7 +42,7 @@ from sglang.srt.multimodal.cache import (
     parse_content_hash,
     snapshot_media,
 )
-from sglang.srt.utils import load_image
+from sglang.srt.utils import fully_load_pil_image, load_image
 
 
 @runtime_checkable
@@ -155,11 +155,8 @@ class MediaArtifactCacheMixin:
         if isinstance(data, np.ndarray):
             return torch.from_numpy(data)
         if isinstance(data, Image.Image):
-            data.load()
-            return data
+            return fully_load_pil_image(data)
         image, _ = load_image(data, self.gpu_image_decode)
-        if isinstance(image, Image.Image):
-            image.load()
         return image
 
     def snapshot_media_source(self, source: Any, modality: Modality) -> MediaSnapshot:

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -860,9 +860,12 @@ class BaseMultimodalProcessor(ABC):
                     return img  # JPEG already decoded on GPU by nvJPEG
                 # PIL decodes lazily; do it here in the io worker so the decode
                 # doesn't run later on the event-loop thread.
-                if discard_alpha_channel and img.mode != "RGB":
-                    return img.convert("RGB")
-                img.load()
+                try:
+                    if discard_alpha_channel and img.mode != "RGB":
+                        return img.convert("RGB")
+                    img.load()
+                except OSError as e:
+                    raise ValueError(f"Could not decode image: {e}") from e
                 return img
             elif modality == Modality.VIDEO:
                 return load_video(data, frame_count_limit)

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -45,6 +45,7 @@ from sglang.srt.utils import (
     CLIENT_MEDIA_EXCEPTIONS,
     configure_media_url_security,
     envs,
+    fully_load_pil_image,
     is_cpu,
     is_npu,
     is_xpu,
@@ -858,15 +859,9 @@ class BaseMultimodalProcessor(ABC):
                 img, _ = load_image(data, cls.gpu_image_decode)
                 if isinstance(img, torch.Tensor):
                     return img  # JPEG already decoded on GPU by nvJPEG
-                # PIL decodes lazily; do it here in the io worker so the decode
-                # doesn't run later on the event-loop thread.
-                try:
-                    if discard_alpha_channel and img.mode != "RGB":
-                        return img.convert("RGB")
-                    img.load()
-                except OSError as e:
-                    raise ValueError(f"Could not decode image: {e}") from e
-                return img
+                return fully_load_pil_image(
+                    img, mode="RGB" if discard_alpha_channel else None
+                )
             elif modality == Modality.VIDEO:
                 return load_video(data, frame_count_limit)
             elif modality == Modality.AUDIO:

--- a/python/sglang/srt/multimodal/processors/transformers_auto.py
+++ b/python/sglang/srt/multimodal/processors/transformers_auto.py
@@ -11,7 +11,7 @@ from sglang.srt.multimodal.processors.base_processor import (
     BaseMultimodalProcessor,
     MultimodalSpecialTokens,
 )
-from sglang.srt.utils import load_image
+from sglang.srt.utils import fully_load_pil_image, load_image
 
 
 def _first_attr(obj, names: tuple[str, ...], default=None):
@@ -102,9 +102,7 @@ class TransformersAutoMultimodalProcessor(BaseMultimodalProcessor):
         images = []
         for data in image_data:
             img, _ = load_image(data)
-            if img.mode != "RGB":
-                img = img.convert("RGB")
-            images.append(img)
+            images.append(fully_load_pil_image(img, mode="RGB"))
         return images
 
     def _apply_hf_processor(self, text: str, images=None, videos=None):

--- a/python/sglang/srt/utils/common.py
+++ b/python/sglang/srt/utils/common.py
@@ -1854,7 +1854,29 @@ def _load_image(
                     "Failed to decode JPEG on GPU, falling back to CPU. Error: %s",
                     e,
                 )
-    return Image.open(BytesIO(image_bytes))
+    try:
+        image = Image.open(BytesIO(image_bytes))
+    except (OSError, SyntaxError) as e:
+        if isinstance(e, OSError) and e.errno is not None:
+            raise
+        raise ValueError(f"Could not decode image: {e}") from e
+    return fully_load_pil_image(image)
+
+
+def fully_load_pil_image(
+    image: Image.Image, *, mode: Optional[str] = None
+) -> Image.Image:
+    """Eagerly decode a PIL image and classify malformed client media."""
+    try:
+        image.load()
+        if mode is not None and image.mode != mode:
+            image = image.convert(mode)
+            image.load()
+    except (OSError, SyntaxError) as e:
+        if isinstance(e, OSError) and e.errno is not None:
+            raise
+        raise ValueError(f"Could not decode image: {e}") from e
+    return image
 
 
 def load_image(
@@ -1871,7 +1893,7 @@ def load_image(
     image = None
     image_size: Optional[tuple[int, int]] = None
     if isinstance(image_file, Image.Image):
-        image = image_file
+        image = fully_load_pil_image(image_file)
         image_size = (image.width, image.height)
     elif isinstance(image_file, bytes):
         image = _load_image(image_bytes=image_file, gpu_image_decode=gpu_image_decode)

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -1,4 +1,5 @@
 import asyncio
+import base64
 import pickle
 import sys
 import threading
@@ -27,7 +28,7 @@ from sglang.srt.disaggregation.encoder.receiver import (
     _encoder_media_item,
     _select_mm_processor_prompt,
 )
-from sglang.srt.disaggregation.encoder.server import MMEncoder
+from sglang.srt.disaggregation.encoder.server import BadRequestError, MMEncoder
 from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
 from sglang.srt.managers.tokenizer_manager import (
     _reject_missing_dispatched_encoder_embedding,
@@ -502,6 +503,17 @@ def test_kimi_k3_epd_selects_matching_jpeg_decode_mode(
 
     assert output is expected
     load.assert_called_once_with(b"jpeg", expected_decode_mode)
+
+
+def test_kimi_k3_epd_rejects_lazy_pil_decode_failure():
+    malformed_png = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJSwAAAABJRU5ErkJggg=="
+    )
+    encoder = _encoder()
+    encoder.preprocessor.use_image_processor_gpu = False
+
+    with pytest.raises(BadRequestError, match="Could not decode image"):
+        encoder.preprocessor._load_single_item(malformed_png, Modality.IMAGE)
 
 
 def test_kimi_k3_epd_verifies_content_hash_before_decode():

--- a/test/registered/unit/multimodal/test_base_processor_bad_input.py
+++ b/test/registered/unit/multimodal/test_base_processor_bad_input.py
@@ -8,6 +8,7 @@ from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
+import base64
 import binascii
 import unittest
 from unittest.mock import MagicMock, patch
@@ -62,6 +63,14 @@ class TestBadInputIsClientError(CustomTestCase):
         # PIL raises UnidentifiedImageError, an OSError -- not a ValueError.
         self._assert_client_error(b"definitely not an image", Modality.IMAGE)
 
+    def test_malformed_image_bytes(self):
+        image = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJSwAAAABJRU5ErkJggg=="
+        )
+        with self.assertRaises(ValueError) as ctx:
+            _StubProcessor._load_single_item(image, Modality.IMAGE)
+        self.assertIsInstance(ctx.exception.__cause__.__cause__, OSError)
+
     def test_undecodable_audio_bytes(self):
         # soundfile raises LibsndfileError, a RuntimeError -- not a ValueError.
         self._assert_client_error(b"definitely not audio", Modality.AUDIO)
@@ -90,6 +99,14 @@ class TestServerFaultStaysServerError(CustomTestCase):
 
     def test_decoder_oom(self):
         self._assert_server_error(MemoryError("out of memory"))
+
+    def test_image_loader_os_error(self):
+        with patch(
+            "sglang.srt.multimodal.processors.base_processor.load_image",
+            side_effect=OSError("too many open files"),
+        ):
+            with self.assertRaises(RuntimeError):
+                _StubProcessor._load_single_item(b"payload", Modality.IMAGE)
 
 
 class TestClientMediaExceptions(CustomTestCase):

--- a/test/registered/unit/multimodal/test_base_processor_bad_input.py
+++ b/test/registered/unit/multimodal/test_base_processor_bad_input.py
@@ -67,9 +67,15 @@ class TestBadInputIsClientError(CustomTestCase):
         image = base64.b64decode(
             "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJSwAAAABJRU5ErkJggg=="
         )
-        with self.assertRaises(ValueError) as ctx:
-            _StubProcessor._load_single_item(image, Modality.IMAGE)
-        self.assertIsInstance(ctx.exception.__cause__.__cause__, OSError)
+        for discard_alpha_channel in (True, False):
+            with self.subTest(discard_alpha_channel=discard_alpha_channel):
+                with self.assertRaises(ValueError) as ctx:
+                    _StubProcessor._load_single_item(
+                        image,
+                        Modality.IMAGE,
+                        discard_alpha_channel=discard_alpha_channel,
+                    )
+                self.assertIsInstance(ctx.exception.__cause__.__cause__, OSError)
 
     def test_undecodable_audio_bytes(self):
         # soundfile raises LibsndfileError, a RuntimeError -- not a ValueError.

--- a/test/registered/unit/multimodal/test_base_processor_bad_input.py
+++ b/test/registered/unit/multimodal/test_base_processor_bad_input.py
@@ -10,6 +10,7 @@ register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 import base64
 import binascii
+import errno
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +18,9 @@ import requests
 
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+from sglang.srt.multimodal.processors.transformers_auto import (
+    TransformersAutoMultimodalProcessor,
+)
 from sglang.srt.utils.common import CLIENT_MEDIA_EXCEPTIONS
 from sglang.test.test_utils import CustomTestCase
 
@@ -77,6 +81,13 @@ class TestBadInputIsClientError(CustomTestCase):
                     )
                 self.assertIsInstance(ctx.exception.__cause__.__cause__, OSError)
 
+    def test_transformers_loader_rejects_lazy_decode_failure(self):
+        image = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJSwAAAABJRU5ErkJggg=="
+        )
+        with self.assertRaisesRegex(ValueError, "Could not decode image"):
+            TransformersAutoMultimodalProcessor._load_images(None, [image])
+
     def test_undecodable_audio_bytes(self):
         # soundfile raises LibsndfileError, a RuntimeError -- not a ValueError.
         self._assert_client_error(b"definitely not audio", Modality.AUDIO)
@@ -112,6 +123,40 @@ class TestServerFaultStaysServerError(CustomTestCase):
             side_effect=OSError("too many open files"),
         ):
             with self.assertRaises(RuntimeError):
+                _StubProcessor._load_single_item(b"payload", Modality.IMAGE)
+
+    def test_image_load_resource_error(self):
+        image = MagicMock()
+        image.load.side_effect = OSError(errno.EMFILE, "too many open files")
+        with patch(
+            "sglang.srt.multimodal.processors.base_processor.load_image",
+            return_value=(image, None),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                _StubProcessor._load_single_item(b"payload", Modality.IMAGE)
+        self.assertEqual(ctx.exception.__cause__.errno, errno.EMFILE)
+
+    def test_image_convert_resource_error(self):
+        image = MagicMock()
+        image.mode = "RGBA"
+        image.convert.side_effect = OSError(errno.ENOMEM, "out of memory")
+        with patch(
+            "sglang.srt.multimodal.processors.base_processor.load_image",
+            return_value=(image, None),
+        ):
+            with self.assertRaises(RuntimeError) as ctx:
+                _StubProcessor._load_single_item(b"payload", Modality.IMAGE)
+        self.assertEqual(ctx.exception.__cause__.errno, errno.ENOMEM)
+
+    def test_image_convert_decode_error(self):
+        image = MagicMock()
+        image.mode = "RGBA"
+        image.convert.side_effect = OSError("broken image stream")
+        with patch(
+            "sglang.srt.multimodal.processors.base_processor.load_image",
+            return_value=(image, None),
+        ):
+            with self.assertRaisesRegex(ValueError, "Could not decode image"):
                 _StubProcessor._load_single_item(b"payload", Modality.IMAGE)
 
 

--- a/test/registered/unit/multimodal/test_preprocess_cache.py
+++ b/test/registered/unit/multimodal/test_preprocess_cache.py
@@ -1,5 +1,6 @@
 import asyncio
 import base64
+import io
 import os
 import tempfile
 import unittest
@@ -29,6 +30,13 @@ register_cpu_ci(est_time=2, suite="base-a-test-cpu")
 
 
 class TestMediaIdentity(unittest.TestCase):
+    def test_lazy_pil_decode_failure_is_client_error(self):
+        malformed_png = base64.b64decode(
+            "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQIHWP4z8DwHwAFgAI/ScLJSwAAAABJRU5ErkJggg=="
+        )
+        with self.assertRaisesRegex(ValueError, "Could not decode image"):
+            snapshot_media(Image.open(io.BytesIO(malformed_png)))
+
     def test_hash_format_is_strict_and_normalized(self):
         digest = "AB" * 32
         self.assertEqual(


### PR DESCRIPTION
## Motivation

Pillow decodes images lazily. A truncated or malformed request image can open successfully and then raise `OSError` during RGB conversion or `load()`. That exception currently becomes an internal runtime error and returns HTTP 500 instead of rejecting malformed client media.

## Modifications

- Force and classify lazy Pillow conversion/load failures in the image I/O worker.
- Convert only post-load image decode `OSError` failures to client `ValueError`.
- Preserve loader and system `OSError` failures as internal errors.
- Add CPU regression coverage for conversion, loading, and loader-level failures.

## Accuracy Tests

Valid image decoding is unchanged.

## Speed Tests and Profiling

Not applicable. Pillow loading was already forced before returning from the I/O worker.

## Tests

- `python -m pytest -q test/registered/unit/multimodal/test_base_processor_bad_input.py::TestBadInputIsClientError::test_malformed_image_bytes test/registered/unit/multimodal/test_base_processor_bad_input.py::TestServerFaultStaysServerError::test_image_loader_os_error`
- `pre-commit run --files python/sglang/srt/multimodal/processors/base_processor.py test/registered/unit/multimodal/test_base_processor_bad_input.py`

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33272219392](https://github.com/sgl-project/sglang/actions/runs/33272219392)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33272219241](https://github.com/sgl-project/sglang/actions/runs/33272219241)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33272219360](https://github.com/sgl-project/sglang/actions/runs/33272219360)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->