### PR TITLE
fix(scheduler): advance the input-logprob offset for skipped prefill requests

### DIFF
--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -307,6 +307,19 @@ class SchedulerBatchResultProcessor:
                 if (
                     req.finished() and req.inflight_middle_chunks <= 0
                 ) or req.is_retracted:
+                    # The flat input-logprob array carries a block for every
+                    # request in the batch, including this one, so step over it
+                    # or every later request reads a shifted slice.
+                    if batch.return_logprob:
+                        assert extend_input_len_per_req is not None
+                        assert extend_logprob_start_len_per_req is not None
+                        logprob_pt += (
+                            self.logprob_result_processor.calculate_num_input_logprobs(
+                                req,
+                                extend_input_len_per_req[i],
+                                extend_logprob_start_len_per_req[i],
+                            )
+                        )
                     # Decode req in a mixed batch, or a retracted req. Keep an
                     # aborted middle chunk in the chunked branch long enough to
                     # drain its accounting without streaming it.

--- a/test/registered/unit/managers/test_batch_result_processor_logprobs.py
+++ b/test/registered/unit/managers/test_batch_result_processor_logprobs.py
@@ -1,0 +1,161 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import torch
+
+from sglang.srt.managers.schedule_batch import ReqLogprob
+from sglang.srt.managers.scheduler_components.batch_result_processor import (
+    SchedulerBatchResultProcessor,
+)
+from sglang.srt.managers.scheduler_components.logprob_result_processor import (
+    SchedulerLogprobResultProcessor,
+)
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode
+from sglang.srt.runtime_context import get_context
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _PrefillReq:
+    def __init__(self, *, rid, origin_input_ids, is_retracted=False):
+        self.rid = rid
+        self.origin_input_ids = origin_input_ids
+        self.logprob_start_len = 0
+        self.is_retracted = is_retracted
+        self.inflight_middle_chunks = 0
+        self.return_logprob = True
+        self.logprob = ReqLogprob(
+            top_logprobs_num=0,
+            token_ids_logprob=None,
+            output_token_logprobs_val=[],
+            output_token_logprobs_idx=[],
+        )
+        self.multi_item_delimiter_indices = None
+        self.return_flat_raw_top_logprobs = False
+        self.input_token_logprobs = None
+        self.temp_input_top_logprobs_val = None
+        self.temp_input_top_logprobs_idx = None
+        self.temp_input_token_ids_logprobs_val = None
+        self.temp_input_token_ids_logprobs_idx = None
+        self.hidden_states = []
+        self.output_ids = []
+        self.time_stats = Mock()
+        self.return_hidden_states = False
+        self.return_sampling_mask = False
+        self.grammar = None
+        self.require_reasoning = False
+        self.customized_info = None
+        self.beam_group = None
+
+    def finished(self):
+        return False
+
+    def update_finish_state(self):
+        return None
+
+
+def _make_processor(case):
+    override = get_context().override_server_args()
+    override.install()
+    case.addCleanup(override.restore)
+    metrics_reporter = Mock()
+    metrics_reporter.num_generated_tokens = 0
+    metrics_reporter.forward_ct_decode = 0
+    model_config = SimpleNamespace(think_end_ids=None, vocab_size=1000)
+    return SchedulerBatchResultProcessor(
+        is_generation=True,
+        disaggregation_mode=None,
+        enable_overlap=False,
+        enable_overlap_mlx=False,
+        model_config=model_config,
+        token_to_kv_pool_allocator=Mock(),
+        tree_cache=None,
+        hisparse_coordinator=None,
+        req_to_token_pool=None,
+        decode_offload_manager=None,
+        metrics_collector=None,
+        metrics_reporter=metrics_reporter,
+        draft_worker=None,
+        model_worker=Mock(),
+        logprob_result_processor=SchedulerLogprobResultProcessor(
+            model_config=model_config,
+        ),
+        output_streamer=Mock(),
+        beam_coordinator=Mock(),
+        abort_request=lambda *args, **kwargs: None,
+    )
+
+
+class TestPrefillLogprobOffsets(CustomTestCase):
+    def test_retracted_request_advances_offset_for_later_requests(self):
+        retracted = _PrefillReq(
+            rid="retracted", origin_input_ids=[101, 102], is_retracted=True
+        )
+        active = _PrefillReq(rid="active", origin_input_ids=[201, 202, 203])
+
+        # The flat array holds one block per request in batch order, whether or
+        # not that request is skipped below: retracted owns the first two
+        # entries, active owns the last three.
+        input_token_logprobs = torch.tensor([-1.0, -2.0, -30.0, -31.0, -32.0])
+
+        batch = SimpleNamespace(
+            reqs=[retracted, active],
+            decoding_reqs=[],
+            return_logprob=True,
+            return_hidden_states=False,
+            return_hidden_states_mode=CaptureHiddenMode.NULL,
+            spec_info=None,
+            prefill_stats=None,
+            dp_cooperation_info=None,
+        )
+        result = SimpleNamespace(
+            copy_done=None,
+            auxiliary_host_output=None,
+            routed_experts_output=None,
+            indexer_topk_output=None,
+            logits_output=SimpleNamespace(
+                hidden_states=None,
+                customized_info=None,
+                input_token_logprobs=input_token_logprobs,
+                next_token_logprobs=torch.tensor([-0.5, -0.6]),
+                input_top_logprobs_val=None,
+                input_top_logprobs_idx=None,
+                input_token_ids_logprobs_val=None,
+                input_token_ids_logprobs_idx=None,
+                next_token_top_logprobs_val=None,
+                next_token_top_logprobs_idx=None,
+                next_token_token_ids_logprobs_val=None,
+                next_token_token_ids_logprobs_idx=None,
+            ),
+            next_token_ids=torch.tensor([7, 8]),
+            extend_input_len_per_req=[2, 3],
+            extend_logprob_start_len_per_req=[0, 0],
+            grammar_advanced=False,
+            can_run_cuda_graph=False,
+            skipped_output_comm=False,
+        )
+
+        processor = _make_processor(self)
+        with (
+            patch(
+                "sglang.srt.managers.scheduler_components."
+                "batch_result_processor.maybe_cache_unfinished_req"
+            ),
+            patch(
+                "sglang.srt.managers.scheduler_components."
+                "batch_result_processor.get_memory",
+                return_value=SimpleNamespace(enable_hisparse=False),
+            ),
+        ):
+            processor.process_batch_result_prefill(batch, result)
+
+        # _process_input_token_logprobs drops the sampling token and prepends
+        # None, so active's three-entry block surfaces as its first two values.
+        self.assertEqual(active.logprob.input_token_logprobs_val, [None, -30.0, -31.0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

I was reading the two prefill result loops side by side, because `disaggregation/prefill.py:703` defines `advance_logprob_pt()` and calls it on all three of its skip paths, and the loop in `batch_result_processor.py` has no equivalent. It needs one.

The flat input-logprob array holds one block per request in the batch, whether or not that request asked for logprobs. `_apply_prefill_logprobs` is written that way on purpose: it advances `logprob_pt` outside its `return_logprob` guard, so the cursor tracks positions rather than interest. The producer agrees, building `extend_logprob_pruned_lens_cpu` from every sequence in the batch with the same `extend_len - start_len` formula the consumer uses.

The finished-in-a-mixed-batch and retracted branch at line 307 skips a request without advancing that cursor. Every later request in the batch then reads a shifted slice and is served another request's prompt logprobs.

Nothing raises. The check in `logprob_result_processor.py` validates the slice length, not its offset, and the shift is always backwards so it never runs off the end. `input_top_logprobs_val[i]` is indexed per request and stays correct while `input_token_logprobs` is sliced by the cursor and goes wrong, which is the diagnostic signature and probably why this has been quiet.

It bites when the skipped request itself asked for input logprobs. At the default `logprob_start_len` of `-1` its block is zero rows and the skip is harmless. Overlap scheduling is on by default and retraction is ordinary under KV pressure, so no unusual flag is involved.

Reported in https://github.com/sgl-project/sglang/issues/36938.

Two open PRs touch this block without covering this path:

- [#34153](https://github.com/sgl-project/sglang/pull/34153) applies the same consume-the-slice idea to the `req.to_finish` path. That is a pending finish, so `req.finished()` is false and it routes through the normal branch, not this skip.
- [#36724](https://github.com/sgl-project/sglang/pull/36724) adds a `deferred_mm_abort` branch immediately above this `continue` and advances the cursor there, leaving this branch alone.

## Modifications

Advance `logprob_pt` by the skipped request's block before the `continue`.

I used `calculate_num_input_logprobs` rather than subtracting the lengths directly because it keeps multi-item scoring batches correct, where only delimiter positions have logprobs. If you would rather keep the skip path cheap and do the plain subtraction, that is a one-line change and I am happy either way.

Added `test/registered/unit/managers/test_batch_result_processor_logprobs.py`, built on the harness in the existing `test_batch_result_processor_hidden_states.py` and registered as `register_cpu_ci(est_time=2, suite="base-a-test-cpu")`. It drives the real `process_batch_result_prefill` with a retracted request in position 0 and asserts the following request gets its own block.

## Accuracy Tests

Two prefill requests, the first retracted, `extend_input_len_per_req=[2, 3]`, `extend_logprob_start_len_per_req=[0, 0]`, over a flat array of `[-1.0, -2.0, -30.0, -31.0, -32.0]`:

```
                  input_token_logprobs_val on the active request
before            [None,  -1.0,  -2.0]      the retracted request's values
after             [None, -30.0, -31.0]      its own
```

Checking out the previous revision of the source file while keeping the new test reproduces the first row.

`test/registered/unit/managers/` on CPU: 572 passed before, 573 after, the extra one being this test. The 2 failures and 3 errors in that directory (`test_mm_process_config.py`, `test_customized_info_streaming.py`) are present either way.

## Speed Tests and Profiling

N/A. One integer add per skipped request, and only when `batch.return_logprob` is set.

## Checklist

- [x] Format the code with `pre-commit`. isort 7.0.0, black 26.1.0 and ruff 0.15.1 are clean on both files.
- [x] Added a unit test that fails without the fix.
- [x] The change is scoped to the reported defect.

The new test runs on CPU in about 8 seconds and needs no GPU.
