### PR TITLE
[NPU] Add ModelSlim MoE prefix regression tests

### DIFF
--- a/test/registered/unit/layers/quantization/test_modelslim_moe_prefixes.py
+++ b/test/registered/unit/layers/quantization/test_modelslim_moe_prefixes.py
@@ -1,0 +1,49 @@
+"""Unit tests for ModelSlim MoE checkpoint projection-name resolution."""
+
+import unittest
+
+import torch
+
+from sglang.srt.layers.quantization.modelslim.modelslim import ModelSlimConfig
+from sglang.srt.layers.quantization.modelslim.schemes import (
+    ModelSlimW8A8Int8MoE,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestModelSlimMoEPrefixes(CustomTestCase):
+    def test_projection_name_families_resolve_to_fused_weight_groups(self):
+        """Bug regression: ModelSlim checkpoints may describe experts with
+        gate_proj/up_proj/down_proj or MiniMax-style w1/w3/w2 names. Both must
+        select the W13 and W2 schemes instead of reporting missing metadata.
+        """
+        prefix = "model.layers.0.mlp.experts"
+        projection_name_families = [
+            ("gate_proj", "up_proj", "down_proj"),
+            ("w1", "w3", "w2"),
+        ]
+
+        for gate_name, up_name, down_name in projection_name_families:
+            with self.subTest(
+                gate_name=gate_name, up_name=up_name, down_name=down_name
+            ):
+                quant_description = {
+                    f"{prefix}.0.{gate_name}.weight": "W8A8_DYNAMIC",
+                    f"{prefix}.0.{up_name}.weight": "W8A8_DYNAMIC",
+                    f"{prefix}.0.{down_name}.weight": "W8A8_DYNAMIC",
+                }
+                config = ModelSlimConfig(quant_description)
+
+                w13_scheme, w2_scheme = config.get_moe_scheme(torch.nn.Module(), prefix)
+
+                self.assertIsInstance(w13_scheme, ModelSlimW8A8Int8MoE)
+                self.assertIsInstance(w2_scheme, ModelSlimW8A8Int8MoE)
+                self.assertEqual(w13_scheme.weight_prefix, "w13")
+                self.assertEqual(w2_scheme.weight_prefix, "w2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/layers/quantization/test_modelslim_moe_prefixes.py
+++ b/test/registered/unit/layers/quantization/test_modelslim_moe_prefixes.py
@@ -1,6 +1,7 @@
 """Unit tests for ModelSlim MoE checkpoint projection-name resolution."""
 
 import unittest
+from unittest.mock import patch
 
 import torch
 
@@ -15,7 +16,16 @@ register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class TestModelSlimMoEPrefixes(CustomTestCase):
-    def test_projection_name_families_resolve_to_fused_weight_groups(self):
+    # ModelSlimW8A8Int8MoE.__init__ builds NPUW8A8Int8MoEMethod, which resolves
+    # torch.ops.npu.npu_dynamic_quant - absent on the CPU runner. Only that
+    # construction is mocked; prefix resolution and scheme selection stay real.
+    @patch(
+        "sglang.srt.layers.quantization.modelslim.schemes."
+        "modelslim_w8a8_int8_moe.NPUW8A8Int8MoEMethod"
+    )
+    def test_projection_name_families_resolve_to_fused_weight_groups(
+        self, _mock_npu_moe_method
+    ):
         """Bug regression: ModelSlim checkpoints may describe experts with
         gate_proj/up_proj/down_proj or MiniMax-style w1/w3/w2 names. Both must
         select the W13 and W2 schemes instead of reporting missing metadata.


### PR DESCRIPTION
## Motivation

ModelSlim MoE checkpoints use either `gate_proj/up_proj/down_proj` or MiniMax-style `w1/w3/w2` projection names. PR #31456 added MiniMax support but lacked per-commit regression coverage.

Closes #31570.

## Modifications

- Add a CPU regression test for both projection-name families.
- Assert that they resolve to the fused W13 and W2 schemes.
- Register the test in `base-a-test-cpu`.
- Mock only NPU operator construction so the test runs without `torch_npu`.

No production code is changed.

## Accuracy Tests

In a CI-like CPU environment without `torch_npu`, all 536 suite files were launched and this PR's test passed:

```
{"file": "test/registered/unit/layers/quantization/test_modelslim_moe_prefixes.py", "passed": true, "elapsed": 17}
```

Nine unrelated files failed locally because of the `libz3` ABI or unavailable network access. Negative mutation checks fail as expected, and the test also passed on Ascend A3 with real MiniMax-M2.5 W8A8 metadata.

## Speed Tests and Profiling

Not applicable; this is a CPU-only unit test.

## Checklist

- [x] Format the code with the repository pre-commit hooks.
- [x] Add a unit test registered in per-commit CI.
- [x] Documentation is not affected.
- [x] Accuracy and speed impact are documented.
- [x] Follow the SGLang code style guidance.

## Note for maintainers

Could an authorized maintainer run `/tag-and-rerun-ci`?

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33243667159](https://github.com/sgl-project/sglang/actions/runs/33243667159)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33243667126](https://github.com/sgl-project/sglang/actions/runs/33243667126)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33243667155](https://github.com/sgl-project/sglang/actions/runs/33243667155)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
