### PR TITLE
[Docker] Install AI Dynamo nightly

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -570,6 +570,10 @@ elif [ "${CUDA_VERSION%%.*}" = "13" ]; then \
     python3 -m pip install "cuda-python>=13,<14" ; \
 fi
 
+# Install the latest available AI Dynamo prerelease from NVIDIA's package index.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    python3 -m pip install --pre --extra-index-url https://pypi.nvidia.com/ ai-dynamo
+
 # Add yank script
 COPY --chown=root:root --chmod=755 docker/configs/yank /usr/local/bin/yank
 


### PR DESCRIPTION
<!-- codex-pr-description:start -->
Install the latest available AI Dynamo prerelease in the standard SGLang Docker image. This lets the image run Dynamo components without a separate package-install step.

### How This Was Implemented
- Add a cached pip layer after the CUDA-specific NIXL installation.
- Resolve `ai-dynamo` with `--pre` and NVIDIA's package index, while retaining PyPI as the primary index.

<details>
<summary>Walkthrough</summary>

The framework stage first installs SGLang's CUDA-specific runtime dependencies, including the correct NIXL package for CUDA 12 or 13. The added layer then installs the highest available prerelease of `ai-dynamo` and its runtime wheel from `https://pypi.nvidia.com/`; it is inherited by the final image stage.

The package is intentionally unpinned, so a cache miss selects the newest available prerelease at build time. A cached Docker layer will retain the previously selected nightly until that layer is invalidated or the image is rebuilt without cache.

This does not install Dynamo's optional `sglang` extra or change the existing CUDA/NIXL selection logic.

</details>

### Validation
- `docker buildx build --check --file docker/Dockerfile .`
- `uv pip install --dry-run --system --python-version 3.12 --python-platform x86_64-manylinux_2_28 --prerelease allow --extra-index-url https://pypi.nvidia.com/ -e ./python ai-dynamo`
- Not completed: full `framework` Docker target build; the environment's 30-second command window stopped it while retrieving the uncached CUDA base image.
<!-- codex-pr-description:end -->

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33229814938](https://github.com/sgl-project/sglang/actions/runs/33229814938)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33229814865](https://github.com/sgl-project/sglang/actions/runs/33229814865)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->