### PR TITLE
[VLM] Release encoder state when error reporting fails

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -1064,6 +1064,29 @@ def _record_pipeline_result(modality: Modality, status: str) -> None:
         )
 
 
+async def _publish_pipeline_error(req_id: str, error_msg: str) -> bool:
+    """Report a request error without letting reporting block cleanup."""
+    try:
+        await server_module.meta_registry.publish(req_id, 0, 0, 0, error=error_msg)
+        return True
+    except Exception:
+        logger.exception("Failed to publish encoder error for req_id=%s", req_id)
+        return False
+
+
+async def _release_failed_request(
+    enc: MMEncoder,
+    req_id: str,
+    *,
+    preserve_metadata: bool = False,
+) -> None:
+    """Release request resources without hiding the original request error."""
+    try:
+        await enc.release_request(req_id, preserve_metadata=preserve_metadata)
+    except Exception:
+        logger.exception("Failed to release encoder resources for req_id=%s", req_id)
+
+
 async def execute_encode_pipeline(
     enc: MMEncoder,
     sched: Optional[EncoderScheduler],
@@ -1126,24 +1149,36 @@ async def execute_encode_pipeline(
     except asyncio.TimeoutError:
         error_msg = "encoder batch timed out"
         time_stats.trace_ctx.abort(abort_info={"reason": error_msg})
-        await server_module.meta_registry.publish(req_id, 0, 0, 0, error=error_msg)
-        await enc.release_request(req_id, preserve_metadata=backend == "mooncake")
+        error_published = await _publish_pipeline_error(req_id, error_msg)
+        await _release_failed_request(
+            enc,
+            req_id,
+            preserve_metadata=backend == "mooncake" and error_published,
+        )
         _record_pipeline_result(modality, "error")
         raise
     except Exception as e:
         error_msg = str(e)
         time_stats.trace_ctx.abort(abort_info={"reason": error_msg})
-        await server_module.meta_registry.publish(req_id, 0, 0, 0, error=error_msg)
-        await enc.release_request(req_id, preserve_metadata=backend == "mooncake")
+        error_published = await _publish_pipeline_error(req_id, error_msg)
+        await _release_failed_request(
+            enc,
+            req_id,
+            preserve_metadata=backend == "mooncake" and error_published,
+        )
         _record_pipeline_result(modality, "error")
         raise
 
     nbytes, embedding_len, embedding_dim, error_msg, error_code = result
     if error_msg:
         time_stats.trace_ctx.abort(abort_info={"reason": error_msg})
-        await server_module.meta_registry.publish(req_id, 0, 0, 0, error=error_msg)
+        error_published = await _publish_pipeline_error(req_id, error_msg)
         if backend == "mooncake":
-            await enc.release_request(req_id, preserve_metadata=True)
+            await _release_failed_request(
+                enc,
+                req_id,
+                preserve_metadata=error_published,
+            )
         else:
             try:
                 await _push_embedding_to_prefill(
@@ -1156,6 +1191,7 @@ async def execute_encode_pipeline(
                     f"Error-send failed for req_id={req_id}: {send_err}",
                     exc_info=True,
                 )
+                await _release_failed_request(enc, req_id)
         _record_pipeline_result(modality, "error")
         raise MMError(error_msg, code=error_code or HTTPStatus.INTERNAL_SERVER_ERROR)
 

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -14,6 +14,7 @@ from sglang.srt.disaggregation.encoder.server import (
     EncoderDelivery,
     InternalError,
     MMEncoder,
+    MMError,
     MooncakeDelivery,
     ReqState,
     SendDestination,
@@ -427,6 +428,64 @@ class TestEncoderDelivery(CustomTestCase):
                 ["metadata_published", "encode_completed", "send", "release"],
             )
             publish.assert_awaited_once_with("req", 16, 2, 4)
+
+        asyncio.run(run())
+
+    def test_pipeline_releases_request_when_error_publish_fails(self):
+        async def run():
+            encoder = MMEncoder.__new__(MMEncoder)
+            encoder.transfer_backend = "mooncake"
+            encoder.encode = AsyncMock(side_effect=RuntimeError("encode failed"))
+            encoder.release_request = AsyncMock()
+            request = {
+                "req_id": "req",
+                "mm_items": ["item"],
+                "modality": "image",
+                "num_parts": 1,
+                "part_idx": 0,
+            }
+
+            with patch.object(
+                meta_registry,
+                "publish",
+                AsyncMock(side_effect=RuntimeError("registry failed")),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "encode failed"):
+                    await execute_encode_pipeline(encoder, None, request)
+
+            encoder.release_request.assert_awaited_once_with(
+                "req", preserve_metadata=False
+            )
+
+        asyncio.run(run())
+
+    def test_pipeline_releases_error_result_when_error_send_fails(self):
+        async def run():
+            encoder = MMEncoder.__new__(MMEncoder)
+            encoder.transfer_backend = "zmq_to_scheduler"
+            encoder.encode = AsyncMock(return_value=(0, 0, 0, "bad image", 400))
+            encoder.release_request = AsyncMock()
+            request = {
+                "req_id": "req",
+                "mm_items": ["item"],
+                "modality": "image",
+                "num_parts": 1,
+                "part_idx": 0,
+            }
+
+            with (
+                patch.object(meta_registry, "publish", AsyncMock()),
+                patch(
+                    "sglang.srt.disaggregation.encoder.runtime._push_embedding_to_prefill",
+                    AsyncMock(side_effect=RuntimeError("send failed")),
+                ),
+            ):
+                with self.assertRaisesRegex(MMError, "bad image"):
+                    await execute_encode_pipeline(encoder, None, request)
+
+            encoder.release_request.assert_awaited_once_with(
+                "req", preserve_metadata=False
+            )
 
         asyncio.run(run())
 


### PR DESCRIPTION
## Summary

Always release encoder request state even if publishing the error metadata or sending the staged error to the prefill worker also fails.

The old error path performed reporting before cleanup. A metadata-registry exception therefore skipped release_request entirely, and a failed non-Mooncake error send had the same leak. For Mooncake, metadata is preserved only when the error publication actually succeeded, avoiding stale success-shaped metadata.

## Validation

- Added regressions for an encode exception plus metadata-publication failure.
- Added a regression for a staged processor error plus transfer failure.
- 19 focused encoder tests passed.
- Pre-commit passed on both changed files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33230131079](https://github.com/sgl-project/sglang/actions/runs/33230131079)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33230134138](https://github.com/sgl-project/sglang/actions/runs/33230134138)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33230131093](https://github.com/sgl-project/sglang/actions/runs/33230131093)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->