### PR TITLE
[Docs] Restore the AIME25 label so GLM-5.3 FP8 and BF16 scores render again

### DIFF
--- a/docs/src/snippets/configs/zai-org/glm-5.3.jsx
+++ b/docs/src/snippets/configs/zai-org/glm-5.3.jsx
@@ -73,12 +73,21 @@ sgl-eval run aime26 \\
   --temperature 1.0 --top-p 0.95 --thinking \\
   --out-dir /sgl-workspace/logs \\
   --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1`,
+      aime25_pct:
+`# To install sgl-eval: pip install git+https://github.com/sgl-project/sgl-eval
+sgl-eval run aime25 \\
+  --model {{MODEL_NAME}} --api-key <api-key> \\
+  --n-repeats 16 --max-tokens 64000 \\
+  --temperature 1.0 --top-p 0.95 --thinking \\
+  --out-dir /sgl-workspace/logs \\
+  --base-url http://{{CURL_HOST}}:{{CURL_PORT}}/v1`,
     },
     numPromptsByConc: { 1: 8, 16: 64, 64: 128, 256: 512, 1024: 2048, 4096: 8192 },
   },
 
   accuracyLabels: [
     ["aime26_pct", "AIME26",         "%"],
+    ["aime25_pct", "AIME25",         "%"],
     ["gsm8k_pct", "GSM8K (1-shot)", "%"],
   ],
 


### PR DESCRIPTION
## Summary

Restore the AIME25 label so GLM-5.3 FP8 and BF16 scores render again

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33231270303](https://github.com/sgl-project/sglang/actions/runs/33231270303)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33231270214](https://github.com/sgl-project/sglang/actions/runs/33231270214)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->