### PR TITLE
[Test] Add slow rank detector unit coverage

### DIFF
--- a/test/registered/unit/utils/test_slow_rank_detector.py
+++ b/test/registered/unit/utils/test_slow_rank_detector.py
@@ -1,0 +1,117 @@
+"""CPU unit tests for the slow-rank detector."""
+
+import unittest
+from unittest import mock
+
+from sglang.srt.utils import slow_rank_detector as detector
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSlowRankDetector(CustomTestCase):
+    def test_execute_on_root_gathers_and_analyzes_all_ranks(self):
+        """Rank 0 must provide receive storage and analyze the gathered metrics."""
+
+        gathered_metrics = [
+            {"gemm": 1.0, "elementwise": 2.0},
+            {"gemm": 1.1, "elementwise": 2.1},
+            {"gemm": 1.2, "elementwise": 2.2},
+        ]
+
+        def gather_object(local_metrics, receive_buffer):
+            self.assertEqual(local_metrics, {"gemm": 3.0, "elementwise": 4.0})
+            self.assertEqual(receive_buffer, [None, None, None])
+            receive_buffer[:] = gathered_metrics
+
+        with (
+            mock.patch.object(detector.dist, "get_rank", return_value=0),
+            mock.patch.object(detector.dist, "get_world_size", return_value=3),
+            mock.patch.object(
+                detector,
+                "_compute_local_metric",
+                side_effect=lambda name: {"gemm": 3.0, "elementwise": 4.0}[name],
+            ) as compute,
+            mock.patch.object(
+                detector.dist, "gather_object", side_effect=gather_object
+            ) as gather,
+            mock.patch.object(detector, "_analyze_metrics") as analyze,
+        ):
+            detector.execute()
+
+        self.assertEqual(
+            compute.call_args_list, [mock.call("gemm"), mock.call("elementwise")]
+        )
+        gather.assert_called_once()
+        analyze.assert_called_once_with(gathered_metrics)
+
+    def test_execute_on_non_root_only_sends_local_metrics(self):
+        """Non-root ranks must join the collective without a receive buffer."""
+
+        with (
+            mock.patch.object(detector.dist, "get_rank", return_value=2),
+            mock.patch.object(detector.dist, "get_world_size", return_value=3),
+            mock.patch.object(
+                detector,
+                "_compute_local_metric",
+                side_effect=lambda name: {"gemm": 3.0, "elementwise": 4.0}[name],
+            ),
+            mock.patch.object(detector.dist, "gather_object") as gather,
+            mock.patch.object(detector, "_analyze_metrics") as analyze,
+        ):
+            detector.execute()
+
+        gather.assert_called_once_with({"gemm": 3.0, "elementwise": 4.0}, None)
+        analyze.assert_not_called()
+
+    def test_compute_local_metric_uses_mean_cudagraph_benchmark(self):
+        """Each metric must use the stable mean over the configured repetitions."""
+
+        executor = mock.Mock()
+        executor_cls = mock.Mock(return_value=executor)
+        with (
+            mock.patch.dict(
+                detector._EXECUTOR_CLS_OF_BENCH, {"gemm": executor_cls}, clear=True
+            ),
+            mock.patch.object(
+                detector.triton.testing,
+                "do_bench_cudagraph",
+                return_value=7.5,
+            ) as do_bench,
+        ):
+            metric = detector._compute_local_metric("gemm")
+
+        self.assertEqual(metric, 7.5)
+        executor_cls.assert_called_once_with()
+        do_bench.assert_called_once_with(executor, return_mode="mean", rep=20)
+
+    def test_analyze_metrics_warns_for_a_slow_rank(self):
+        """A rank below 90% of the fastest peer must trigger a warning."""
+
+        metrics = [
+            {"gemm": 1.0, "elementwise": 2.0},
+            {"gemm": 1.25, "elementwise": 2.1},
+        ]
+        with mock.patch.object(detector.logger, "warning") as warning:
+            detector._analyze_metrics(metrics)
+
+        warning.assert_called_once_with(
+            "[slow_rank_detector] Some ranks are too slow compared with others"
+        )
+
+    def test_analyze_metrics_accepts_close_ranks(self):
+        """Normal benchmark noise above the threshold must not warn."""
+
+        metrics = [
+            {"gemm": 1.0, "elementwise": 2.0},
+            {"gemm": 1.05, "elementwise": 2.1},
+        ]
+        with mock.patch.object(detector.logger, "warning") as warning:
+            detector._analyze_metrics(metrics)
+
+        warning.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`slow_rank_detector.py` coordinates per-rank benchmark metrics through `gather_object` and warns when a rank falls below 90% of the fastest peer. This control flow did not have focused unit coverage.

This is part of #20865.

## Modifications

- Add CPU-only unit coverage for the rank-0 gather and analysis path.
- Verify non-root ranks participate in the collective without a receive buffer.
- Verify local metrics use the mean CUDA-graph benchmark with the configured repetitions.
- Cover both sides of the slow-rank warning threshold.
- Register the test in `base-a-test-cpu`.

## Accuracy Tests

Not applicable. This is a test-only change and does not affect model outputs.

Validation performed:

- Focused unit cases: 5 passed in an isolated CPU harness against the current source.
- `ruff check test/registered/unit/utils/test_slow_rank_detector.py`
- `ruff format --check test/registered/unit/utils/test_slow_rank_detector.py`
- Python syntax compilation and `git diff --check`

## Speed Tests and Profiling

Not applicable. Production code and inference paths are unchanged. The test is CPU-only and registered with `est_time=1`.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). (Not applicable for a test-only change.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). (Not applicable for a test-only change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33231838463](https://github.com/sgl-project/sglang/actions/runs/33231838463)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33231838408](https://github.com/sgl-project/sglang/actions/runs/33231838408)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33231838416](https://github.com/sgl-project/sglang/actions/runs/33231838416)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->