### PR TITLE
feat(moe): support SM120 blockwise FP8 with FlashInfer

### DIFF
--- a/python/sglang/kernels/jit/csrc/moe/pack_flashinfer_scales.cuh
+++ b/python/sglang/kernels/jit/csrc/moe/pack_flashinfer_scales.cuh
@@ -1,0 +1,381 @@
+#pragma once
+
+#include <sgl_kernel/tensor.h>  // For TensorMatcher and symbolic metadata
+#include <sgl_kernel/utils.h>   // For RuntimeCheck
+
+#include <sgl_kernel/math.cuh>     // For FP8_E4M3_MAX
+#include <sgl_kernel/runtime.cuh>  // For get_sm_count
+#include <sgl_kernel/type.cuh>     // For packed CUDA types
+#include <sgl_kernel/utils.cuh>    // For LaunchKernel and FP8 types
+#include <sgl_kernel/vec.cuh>      // For AlignedVector
+#include <sgl_kernel/warp.cuh>     // For subgroup reductions
+
+#include <sgl_kernel/deepseek_v4/fp8_utils.cuh>  // For pack_fp8
+
+#include <tvm/ffi/container/tensor.h>
+
+#include <cstdint>
+
+namespace sglang {
+
+constexpr int kPackFlashInferScalesThreads = 256;
+
+SGL_DEVICE int64_t
+get_flashinfer_source_row(const int32_t* __restrict__ expert_offsets, int64_t padded_row, int num_experts) {
+  int lo = 0;
+  int hi = num_experts;
+  while (lo < hi) {
+    const int mid = (lo + hi) / 2;
+    const int64_t next_padded_start = (static_cast<int64_t>(expert_offsets[mid + 1]) + 3LL * (mid + 1)) / 4 * 4;
+    if (padded_row < next_padded_start) {
+      hi = mid;
+    } else {
+      lo = mid + 1;
+    }
+  }
+
+  if (lo < num_experts) {
+    const int64_t expert_start = expert_offsets[lo];
+    const int64_t padded_expert_start = (expert_start + 3LL * lo) / 4 * 4;
+    const int64_t source_row = expert_start + padded_row - padded_expert_start;
+    if (source_row >= expert_start && source_row < expert_offsets[lo + 1]) {
+      return source_row;
+    }
+  }
+  return -1;
+}
+
+SGL_DEVICE float get_packed_scale(
+    const float* __restrict__ input,
+    const int32_t* __restrict__ expert_offsets,
+    int64_t k_blocks,
+    int64_t k_block,
+    int64_t padded_row,
+    int num_experts,
+    const int32_t* __restrict__ row_map = nullptr) {
+  const int64_t source_row = get_flashinfer_source_row(expert_offsets, padded_row, num_experts);
+  if (source_row >= 0) {
+    const int64_t input_row = row_map == nullptr ? source_row : row_map[source_row];
+    return input[input_row * k_blocks + k_block];
+  }
+  return 0.0f;
+}
+
+__global__ void pack_flashinfer_moe_scales_kernel(
+    const float* __restrict__ input,
+    const int32_t* __restrict__ expert_offsets,
+    float* __restrict__ output,
+    int64_t k_blocks,
+    int64_t padded_rows,
+    int num_experts) {
+  const int64_t active_rows = expert_offsets[num_experts];
+  const int64_t active_padded_rows = ((active_rows + 3LL * num_experts) / 4) * 4;
+  const int64_t total_elements = active_padded_rows * k_blocks;
+  for (int64_t linear_idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; linear_idx < total_elements;
+       linear_idx += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    const int64_t k_block = linear_idx / active_padded_rows;
+    const int64_t padded_row = linear_idx - k_block * active_padded_rows;
+    output[k_block * padded_rows + padded_row] =
+        get_packed_scale(input, expert_offsets, k_blocks, k_block, padded_row, num_experts);
+  }
+}
+
+__global__ void shuffle_rows_and_pack_flashinfer_moe_scales_kernel(
+    const fp8_e4m3_t* __restrict__ input,
+    const float* __restrict__ input_scales,
+    const int32_t* __restrict__ row_map,
+    const int32_t* __restrict__ expert_offsets,
+    fp8_e4m3_t* __restrict__ output,
+    float* __restrict__ output_scales,
+    int64_t output_rows,
+    int64_t hidden_size,
+    int64_t k_blocks,
+    int64_t padded_rows,
+    int num_experts) {
+  const int64_t active_rows = expert_offsets[num_experts];
+  const int64_t active_padded_rows = ((active_rows + 3LL * num_experts) / 4) * 4;
+  const int64_t output_elements = active_rows * hidden_size;
+  const int64_t scale_elements = active_padded_rows * k_blocks;
+
+  for (int64_t linear_idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; linear_idx < output_elements;
+       linear_idx += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    const int64_t output_row = linear_idx / hidden_size;
+    const int64_t col = linear_idx - output_row * hidden_size;
+    output[linear_idx] = input[static_cast<int64_t>(row_map[output_row]) * hidden_size + col];
+  }
+
+  for (int64_t linear_idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x; linear_idx < scale_elements;
+       linear_idx += static_cast<int64_t>(gridDim.x) * blockDim.x) {
+    const int64_t k_block = linear_idx / active_padded_rows;
+    const int64_t padded_row = linear_idx - k_block * active_padded_rows;
+    output_scales[k_block * padded_rows + padded_row] =
+        get_packed_scale(input_scales, expert_offsets, k_blocks, k_block, padded_row, num_experts, row_map);
+  }
+}
+
+struct SiluAndMulQuantPackFlashInferMoeParams {
+  const bf16_t* __restrict__ input;
+  const int32_t* __restrict__ expert_offsets;
+  fp8_e4m3_t* __restrict__ output;
+  float* __restrict__ output_scales;
+  float swiglu_limit;
+  int64_t hidden_size;
+  int64_t padded_rows;
+  int num_experts;
+};
+
+__global__ __launch_bounds__(1024, 2) void silu_and_mul_quant_pack_flashinfer_moe_kernel(
+    const SiluAndMulQuantPackFlashInferMoeParams __grid_constant__ params) {
+  using namespace device;
+  using deepseek_v4::fp8::pack_fp8;
+
+  constexpr int kGroupSize = 128;
+  constexpr int kValuesPerThread = 8;
+  constexpr int kThreadsPerGroup = kGroupSize / kValuesPerThread;
+  using InputVec = AlignedVector<bf16x2_t, kValuesPerThread / 2>;
+  using OutputVec = AlignedVector<fp8x2_e4m3_t, kValuesPerThread / 2>;
+
+  const int64_t active_rows = params.expert_offsets[params.num_experts];
+  const int64_t active_padded_rows = ((active_rows + 3LL * params.num_experts) / 4) * 4;
+  const int64_t num_groups = params.hidden_size / kGroupSize;
+  const int64_t group = threadIdx.x / kThreadsPerGroup;
+  const int group_lane = threadIdx.x % kThreadsPerGroup;
+
+  for (int64_t padded_row = blockIdx.x; padded_row < active_padded_rows; padded_row += gridDim.x) {
+    const int64_t source_row = get_flashinfer_source_row(params.expert_offsets, padded_row, params.num_experts);
+    if (source_row < 0) {
+      if (group_lane == 0) {
+        params.output_scales[group * params.padded_rows + padded_row] = 0.0f;
+      }
+      continue;
+    }
+
+    const auto input = params.input + source_row * params.hidden_size * 2;
+    const auto output = params.output + source_row * params.hidden_size;
+    InputVec up_vec, gate_vec;
+    up_vec.load(input, threadIdx.x);
+    gate_vec.load(input, threadIdx.x + blockDim.x);
+
+    float local_max = 0.0f;
+    float results[kValuesPerThread];
+#pragma unroll
+    for (int i = 0; i < kValuesPerThread / 2; ++i) {
+      auto gate = __hmin2(gate_vec[i], bf16x2_t{params.swiglu_limit, params.swiglu_limit});
+      auto up = __hmax2(up_vec[i], bf16x2_t{-params.swiglu_limit, -params.swiglu_limit});
+      up = __hmin2(up, bf16x2_t{params.swiglu_limit, params.swiglu_limit});
+      const auto [gate0, gate1] = cast<fp32x2_t>(gate);
+      const auto [up0, up1] = cast<fp32x2_t>(up);
+      // Match the Triton runner's BF16 intermediate semantics before the
+      // second FP8 quantization. SiLU and multiplication are evaluated in
+      // FP32, then rounded to BF16 before computing the FP8 group scale.
+      const float value0 = gate0 / (1.0f + __expf(-gate0)) * up0;
+      const float value1 = gate1 / (1.0f + __expf(-gate1)) * up1;
+      const auto [rounded0, rounded1] = cast<fp32x2_t>(cast<bf16x2_t>(fp32x2_t{value0, value1}));
+      results[2 * i] = rounded0;
+      results[2 * i + 1] = rounded1;
+      local_max = fmaxf(local_max, fmaxf(fabsf(rounded0), fabsf(rounded1)));
+    }
+
+    local_max = warp::reduce_max<kThreadsPerGroup>(local_max);
+    const float scale = fmaxf(local_max, 1e-10f) / math::FP8_E4M3_MAX;
+    const float inv_scale = 1.0f / scale;
+    OutputVec output_vec;
+#pragma unroll
+    for (int i = 0; i < kValuesPerThread / 2; ++i) {
+      output_vec[i] = pack_fp8(results[2 * i] * inv_scale, results[2 * i + 1] * inv_scale);
+    }
+    output_vec.store(output, threadIdx.x);
+    if (group_lane == 0) {
+      params.output_scales[group * params.padded_rows + padded_row] = scale;
+    }
+  }
+}
+
+struct PackFlashInferMoeScalesKernel {
+  static void run(tvm::ffi::TensorView input, tvm::ffi::TensorView expert_offsets, tvm::ffi::TensorView output) {
+    using namespace host;
+
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    auto total_rows = SymbolicSize{"total_rows"};
+    auto k_blocks = SymbolicSize{"k_blocks"};
+    auto num_offsets = SymbolicSize{"num_offsets"};
+    auto padded_rows = SymbolicSize{"padded_rows"};
+
+    TensorMatcher({total_rows, k_blocks})
+        .with_strides({k_blocks, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(input);
+    TensorMatcher({num_offsets}).with_strides({1}).with_dtype<int32_t>().with_device(device).verify(expert_offsets);
+    TensorMatcher({k_blocks, padded_rows})
+        .with_strides({padded_rows, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(output);
+
+    const int64_t rows = total_rows.unwrap();
+    const int64_t blocks = k_blocks.unwrap();
+    const int experts = static_cast<int>(num_offsets.unwrap()) - 1;
+    const int64_t padded = padded_rows.unwrap();
+    RuntimeCheck(experts > 0, "expert_offsets must contain at least two entries");
+    RuntimeCheck(
+        padded == ((rows + 3 * experts) / 4) * 4, "output padded-row dimension does not match FlashInfer layout");
+
+    const int64_t elements = padded * blocks;
+    if (elements == 0) return;
+    const int64_t requested_blocks = (elements + kPackFlashInferScalesThreads - 1) / kPackFlashInferScalesThreads;
+    const int64_t max_blocks = host::runtime::get_sm_count(device.unwrap().device_id) * 8LL;
+    const auto grid = dim3(requested_blocks < max_blocks ? requested_blocks : max_blocks);
+    LaunchKernel(grid, dim3(kPackFlashInferScalesThreads), device.unwrap())(
+        pack_flashinfer_moe_scales_kernel,
+        static_cast<const float*>(input.data_ptr()),
+        static_cast<const int32_t*>(expert_offsets.data_ptr()),
+        static_cast<float*>(output.data_ptr()),
+        blocks,
+        padded,
+        experts);
+  }
+};
+
+struct ShuffleRowsAndPackFlashInferMoeScalesKernel {
+  static void
+  run(tvm::ffi::TensorView input,
+      tvm::ffi::TensorView input_scales,
+      tvm::ffi::TensorView row_map,
+      tvm::ffi::TensorView expert_offsets,
+      tvm::ffi::TensorView output,
+      tvm::ffi::TensorView output_scales) {
+    using namespace host;
+
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    auto input_rows = SymbolicSize{"input_rows"};
+    auto output_rows = SymbolicSize{"output_rows"};
+    auto hidden_size = SymbolicSize{"hidden_size"};
+    auto k_blocks = SymbolicSize{"k_blocks"};
+    auto num_offsets = SymbolicSize{"num_offsets"};
+    auto padded_rows = SymbolicSize{"padded_rows"};
+
+    TensorMatcher({input_rows, hidden_size})
+        .with_strides({hidden_size, 1})
+        .with_dtype<fp8_e4m3_t>()
+        .with_device(device)
+        .verify(input);
+    TensorMatcher({input_rows, k_blocks})
+        .with_strides({k_blocks, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(input_scales);
+    TensorMatcher({output_rows}).with_strides({1}).with_dtype<int32_t>().with_device(device).verify(row_map);
+    TensorMatcher({num_offsets}).with_strides({1}).with_dtype<int32_t>().with_device(device).verify(expert_offsets);
+    TensorMatcher({output_rows, hidden_size})
+        .with_strides({hidden_size, 1})
+        .with_dtype<fp8_e4m3_t>()
+        .with_device(device)
+        .verify(output);
+    TensorMatcher({k_blocks, padded_rows})
+        .with_strides({padded_rows, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(output_scales);
+
+    const int64_t rows = output_rows.unwrap();
+    const int64_t hidden = hidden_size.unwrap();
+    const int64_t blocks = k_blocks.unwrap();
+    const int experts = static_cast<int>(num_offsets.unwrap()) - 1;
+    const int64_t padded = padded_rows.unwrap();
+    RuntimeCheck(experts > 0, "expert_offsets must contain at least two entries");
+    RuntimeCheck(hidden == blocks * 128, "input scale width must equal hidden_size / 128");
+    RuntimeCheck(
+        padded == ((rows + 3 * experts) / 4) * 4, "output padded-row dimension does not match FlashInfer layout");
+
+    const int64_t output_elements = rows * hidden;
+    const int64_t scale_elements = padded * blocks;
+    const int64_t elements = output_elements > scale_elements ? output_elements : scale_elements;
+    if (elements == 0) return;
+    const int64_t requested_blocks = (elements + kPackFlashInferScalesThreads - 1) / kPackFlashInferScalesThreads;
+    const int64_t max_blocks = host::runtime::get_sm_count(device.unwrap().device_id) * 8LL;
+    const auto grid = dim3(requested_blocks < max_blocks ? requested_blocks : max_blocks);
+    LaunchKernel(grid, dim3(kPackFlashInferScalesThreads), device.unwrap())(
+        shuffle_rows_and_pack_flashinfer_moe_scales_kernel,
+        static_cast<const fp8_e4m3_t*>(input.data_ptr()),
+        static_cast<const float*>(input_scales.data_ptr()),
+        static_cast<const int32_t*>(row_map.data_ptr()),
+        static_cast<const int32_t*>(expert_offsets.data_ptr()),
+        static_cast<fp8_e4m3_t*>(output.data_ptr()),
+        static_cast<float*>(output_scales.data_ptr()),
+        rows,
+        hidden,
+        blocks,
+        padded,
+        experts);
+  }
+};
+
+struct SiluAndMulQuantPackFlashInferMoeKernel {
+  static void
+  run(tvm::ffi::TensorView input,
+      tvm::ffi::TensorView expert_offsets,
+      tvm::ffi::TensorView output,
+      tvm::ffi::TensorView output_scales,
+      double swiglu_limit) {
+    using namespace host;
+
+    auto device = SymbolicDevice{};
+    device.set_options<kDLCUDA>();
+    auto rows = SymbolicSize{"rows"};
+    auto gate_up_size = SymbolicSize{"gate_up_size"};
+    auto hidden_size = SymbolicSize{"hidden_size"};
+    auto num_offsets = SymbolicSize{"num_offsets"};
+    auto num_groups = SymbolicSize{"num_groups"};
+    auto padded_rows = SymbolicSize{"padded_rows"};
+
+    TensorMatcher({rows, gate_up_size})
+        .with_strides({gate_up_size, 1})
+        .with_dtype<bf16_t>()
+        .with_device(device)
+        .verify(input);
+    TensorMatcher({num_offsets}).with_strides({1}).with_dtype<int32_t>().with_device(device).verify(expert_offsets);
+    TensorMatcher({rows, hidden_size})
+        .with_strides({hidden_size, 1})
+        .with_dtype<fp8_e4m3_t>()
+        .with_device(device)
+        .verify(output);
+    TensorMatcher({num_groups, padded_rows})
+        .with_strides({padded_rows, 1})
+        .with_dtype<float>()
+        .with_device(device)
+        .verify(output_scales);
+
+    const int experts = static_cast<int>(num_offsets.unwrap()) - 1;
+    const int64_t hidden = hidden_size.unwrap();
+    const int64_t capacity_rows = rows.unwrap();
+    const int64_t padded = padded_rows.unwrap();
+    RuntimeCheck(experts > 0, "expert_offsets must contain at least two entries");
+    RuntimeCheck(gate_up_size.unwrap() == 2 * hidden, "input must contain [up, gate]");
+    RuntimeCheck(hidden % 128 == 0, "hidden size must be divisible by 128");
+    RuntimeCheck(hidden / 128 == num_groups.unwrap(), "invalid output scale groups");
+    RuntimeCheck(hidden / 8 <= 1024, "hidden size is too large for one block");
+    RuntimeCheck(
+        padded == ((capacity_rows + 3LL * experts) / 4) * 4,
+        "output padded-row dimension does not match FlashInfer layout");
+
+    const int64_t requested_blocks = padded;
+    const int64_t max_blocks = host::runtime::get_sm_count(device.unwrap().device_id) * 8LL;
+    const auto grid = dim3(requested_blocks < max_blocks ? requested_blocks : max_blocks);
+    const auto params = SiluAndMulQuantPackFlashInferMoeParams{
+        .input = static_cast<const bf16_t*>(input.data_ptr()),
+        .expert_offsets = static_cast<const int32_t*>(expert_offsets.data_ptr()),
+        .output = static_cast<fp8_e4m3_t*>(output.data_ptr()),
+        .output_scales = static_cast<float*>(output_scales.data_ptr()),
+        .swiglu_limit = static_cast<float>(swiglu_limit),
+        .hidden_size = hidden,
+        .padded_rows = padded,
+        .num_experts = experts,
+    };
+    LaunchKernel(grid, dim3(hidden / 8), device.unwrap())(silu_and_mul_quant_pack_flashinfer_moe_kernel, params);
+  }
+};
+
+}  // namespace sglang

--- a/python/sglang/kernels/ops/moe/pack_flashinfer_scales.py
+++ b/python/sglang/kernels/ops/moe/pack_flashinfer_scales.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+@cache_once
+def _pack_flashinfer_scales_module() -> Module:
+    return load_jit(
+        "pack_flashinfer_moe_scales",
+        cuda_files=["moe/pack_flashinfer_scales.cuh"],
+        cuda_wrappers=[
+            ("pack_flashinfer_moe_scales", "PackFlashInferMoeScalesKernel::run"),
+            (
+                "shuffle_rows_and_pack_flashinfer_moe_scales",
+                "ShuffleRowsAndPackFlashInferMoeScalesKernel::run",
+            ),
+            (
+                "silu_and_mul_quant_pack_flashinfer_moe",
+                "SiluAndMulQuantPackFlashInferMoeKernel::run",
+            ),
+        ],
+    )
+
+
+def pack_flashinfer_moe_scales(
+    scales: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Pack row-major FP32 scales into FlashInfer's padded expert layout."""
+    assert scales.ndim == 2 and scales.dtype == torch.float32
+    assert expert_offsets.ndim == 1 and expert_offsets.dtype == torch.int32
+    assert scales.is_contiguous() and expert_offsets.is_contiguous()
+
+    total_rows, k_blocks = scales.shape
+    num_experts = expert_offsets.numel() - 1
+    padded_rows = ((total_rows + 3 * num_experts) // 4) * 4
+    if out is None:
+        out = torch.empty(
+            (k_blocks, padded_rows), device=scales.device, dtype=scales.dtype
+        )
+    else:
+        assert out.shape == (k_blocks, padded_rows)
+        assert out.dtype == scales.dtype and out.device == scales.device
+        assert out.is_contiguous()
+
+    _pack_flashinfer_scales_module().pack_flashinfer_moe_scales(
+        scales, expert_offsets, out
+    )
+    return out
+
+
+def shuffle_rows_and_pack_flashinfer_moe_scales(
+    values: torch.Tensor,
+    scales: torch.Tensor,
+    row_map: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    out: Optional[torch.Tensor] = None,
+    out_scales: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Shuffle FP8 rows and pack their scales for FlashInfer in one launch."""
+    assert values.ndim == scales.ndim == 2
+    assert values.dtype == torch.float8_e4m3fn and scales.dtype == torch.float32
+    assert values.shape[0] == scales.shape[0]
+    assert row_map.ndim == expert_offsets.ndim == 1
+    assert row_map.dtype == expert_offsets.dtype == torch.int32
+    assert all(
+        tensor.is_contiguous() for tensor in (values, scales, row_map, expert_offsets)
+    )
+
+    output_rows = row_map.numel()
+    num_experts = expert_offsets.numel() - 1
+    padded_rows = ((output_rows + 3 * num_experts) // 4) * 4
+    if out is None:
+        out = torch.empty(
+            (output_rows, values.shape[1]), dtype=values.dtype, device=values.device
+        )
+    else:
+        assert out.shape == (output_rows, values.shape[1])
+        assert out.dtype == values.dtype and out.device == values.device
+        assert out.is_contiguous()
+    if out_scales is None:
+        out_scales = torch.empty(
+            (scales.shape[1], padded_rows), dtype=scales.dtype, device=scales.device
+        )
+    else:
+        assert out_scales.shape == (scales.shape[1], padded_rows)
+        assert out_scales.dtype == scales.dtype and out_scales.device == scales.device
+        assert out_scales.is_contiguous()
+    _pack_flashinfer_scales_module().shuffle_rows_and_pack_flashinfer_moe_scales(
+        values, scales, row_map, expert_offsets, out, out_scales
+    )
+    return out, out_scales
+
+
+def silu_and_mul_quant_pack_flashinfer_moe(
+    gate_up: torch.Tensor,
+    expert_offsets: torch.Tensor,
+    swiglu_limit: float,
+    out: Optional[torch.Tensor] = None,
+    out_scales: Optional[torch.Tensor] = None,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Apply clamped SwiGLU, FP8-quantize, and pack scales in one launch."""
+    assert gate_up.ndim == 2 and gate_up.dtype == torch.bfloat16
+    assert gate_up.shape[1] % 256 == 0
+    assert expert_offsets.ndim == 1 and expert_offsets.dtype == torch.int32
+    assert gate_up.is_contiguous() and expert_offsets.is_contiguous()
+
+    rows, gate_up_size = gate_up.shape
+    hidden_size = gate_up_size // 2
+    num_experts = expert_offsets.numel() - 1
+    padded_rows = ((rows + 3 * num_experts) // 4) * 4
+    if out is None:
+        out = torch.empty(
+            (rows, hidden_size), dtype=torch.float8_e4m3fn, device=gate_up.device
+        )
+    else:
+        assert out.shape == (rows, hidden_size)
+        assert out.dtype == torch.float8_e4m3fn and out.device == gate_up.device
+        assert out.is_contiguous()
+    if out_scales is None:
+        out_scales = torch.empty(
+            (hidden_size // 128, padded_rows),
+            dtype=torch.float32,
+            device=gate_up.device,
+        )
+    else:
+        assert out_scales.shape == (hidden_size // 128, padded_rows)
+        assert out_scales.dtype == torch.float32 and out_scales.device == gate_up.device
+        assert out_scales.is_contiguous()
+
+    _pack_flashinfer_scales_module().silu_and_mul_quant_pack_flashinfer_moe(
+        gate_up, expert_offsets, out, out_scales, swiglu_limit
+    )
+    return out, out_scales

--- a/python/sglang/srt/arg_groups/moe_hook.py
+++ b/python/sglang/srt/arg_groups/moe_hook.py
@@ -36,11 +36,12 @@ def handle_moe_kernel_config(server_args: Any):
     view = resolved_view(server_args)
     if view.moe_runner_backend == "flashinfer_cutlass":
         assert view.quantization in [
+            "fp8",
             "modelopt_fp4",
             "modelopt_fp8",
             "modelopt_mixed",
             None,
-        ], f"Invalid quantization '{view.quantization}'. \nFlashInfer Cutlass MOE supports only: 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
+        ], f"Invalid quantization '{view.quantization}'. \nFlashInfer Cutlass MOE supports only: 'fp8', 'modelopt_fp4', 'modelopt_fp8', 'modelopt_mixed', or bfloat16 (None)."
         assert view.ep_size in [
             1,
             cfg.tp_size,

--- a/python/sglang/srt/layers/moe/moe_runner/base.py
+++ b/python/sglang/srt/layers/moe/moe_runner/base.py
@@ -63,6 +63,9 @@ class MoeRunnerConfig:
     gate_up_interleaved: bool = True
     layer: Optional[torch.nn.Module] = None
     use_tp_all_gather_activation: bool = False
+    # None preserves the backend default. Quantization methods can override it
+    # when one backend exposes kernels with different expert-ID contracts.
+    accepts_global_expert_ids: Optional[bool] = None
 
 
 @dataclass

--- a/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
+++ b/python/sglang/srt/layers/moe/moe_runner/flashinfer_cutlass.py
@@ -1,6 +1,6 @@
 """FlashInfer CUTLASS MoE fused funcs.
 
-This module owns the FlashInfer ``cutlass_fused_moe`` calls used by the
+This module owns FlashInfer CUTLASS MoE calls used by blockwise FP8,
 unquantized, ModelOpt FP8, ModelOpt NVFP4, and MXFP4 MoE paths.
 Quantization methods prepare a small quant_info payload and route through
 ``MoeRunner``.
@@ -59,6 +59,19 @@ class FlashInferCutlassMoeQuantInfo(MoeQuantInfo):
     moe_ep_size: int = 1
     moe_ep_rank: int = 0
     apply_routed_scaling_factor: bool = True
+
+
+@dataclass
+class FlashInferSm120Fp8MoeQuantInfo(MoeQuantInfo):
+    """Payload for FlashInfer's native SM120 blockwise-FP8 grouped GEMM."""
+
+    w13_weight: torch.Tensor  # FP8 [E, 2*N, K], loaded as [up, gate]
+    w2_weight: torch.Tensor  # FP8 [E, K, N]
+    w13_weight_scale: torch.Tensor  # FP32 [E, K/128, 2*N/128]
+    w2_weight_scale: torch.Tensor  # FP32 [E, N/128, K/128]
+    expert_offsets: torch.Tensor  # int32 [E + 1]
+    problem_sizes1: torch.Tensor  # int32 [E, 3]
+    problem_sizes2: torch.Tensor  # int32 [E, 3]
 
 
 @dataclass
@@ -248,6 +261,137 @@ def _run_flashinfer_cutlass(
     return output
 
 
+def _run_flashinfer_sm120_fp8(
+    *,
+    dispatch_output,
+    quant_info: FlashInferSm120Fp8MoeQuantInfo,
+    runner_config: MoeRunnerConfig,
+) -> torch.Tensor:
+    """Run the SM120-only FlashInfer blockwise-FP8 grouped-GEMM path."""
+    if not is_flashinfer_available():
+        raise RuntimeError(
+            "flashinfer_cutlass blockwise FP8 requires flashinfer to be installed"
+        )
+    from flashinfer.grouped_mm import moe_gemm_fp8_nt_groupwise
+    from sgl_kernel import apply_shuffle_mul_sum, prepare_moe_input
+
+    from sglang.kernels.ops.moe.pack_flashinfer_scales import (
+        pack_flashinfer_moe_scales,
+        shuffle_rows_and_pack_flashinfer_moe_scales,
+        silu_and_mul_quant_pack_flashinfer_moe,
+    )
+    from sglang.kernels.ops.quantization.fp8_kernel import (
+        sglang_per_token_group_quant_fp8,
+    )
+
+    x = dispatch_output.hidden_states
+    topk_weights = dispatch_output.topk_output.topk_weights
+    topk_ids = dispatch_output.topk_output.topk_ids
+    assert x.dtype == torch.bfloat16, "SM120 FlashInfer FP8 MoE requires BF16 input"
+    assert runner_config.is_gated and runner_config.activation == "silu"
+    assert not runner_config.apply_router_weight_on_input
+    assert runner_config.gemm1_alpha is None
+    assert runner_config.gemm1_clamp_limit is None
+    assert topk_weights.shape == topk_ids.shape
+
+    w13_weight = quant_info.w13_weight
+    w2_weight = quant_info.w2_weight
+    assert w13_weight.dtype == w2_weight.dtype == torch.float8_e4m3fn
+    assert w13_weight.shape[0] == w2_weight.shape[0]
+    assert quant_info.w13_weight_scale.dtype == torch.float32
+    assert quant_info.w2_weight_scale.dtype == torch.float32
+
+    num_experts = w13_weight.shape[0]
+    hidden_size = x.shape[1]
+    intermediate_size = w2_weight.shape[2]
+    total_rows = topk_ids.numel()
+    assert total_rows > 0
+
+    # topk_ids have already been mapped to local expert IDs by the standard
+    # dispatcher. Non-local EP routes use -1 and are redirected to a zero sink.
+    a_map = torch.zeros(total_rows, dtype=torch.int32, device=x.device)
+    # Keep a dedicated zero row outside the GEMM output. Reusing the last GEMM
+    # row as the sink corrupts an actual route when every selected expert is
+    # local (for example EP=1).
+    c_map = torch.full((total_rows,), total_rows, dtype=torch.int32, device=x.device)
+    prepare_moe_input(
+        topk_ids,
+        quant_info.expert_offsets,
+        quant_info.problem_sizes1,
+        quant_info.problem_sizes2,
+        a_map,
+        c_map,
+        num_experts,
+        intermediate_size,
+        hidden_size,
+    )
+
+    x_q, x_scale = sglang_per_token_group_quant_fp8(x, 128)
+    repeated_x_q, packed_x_scale = shuffle_rows_and_pack_flashinfer_moe_scales(
+        x_q, x_scale, a_map, quant_info.expert_offsets
+    )
+
+    swiglu_limit = runner_config.swiglu_limit
+    gate_up = torch.empty(
+        (
+            total_rows,
+            intermediate_size if swiglu_limit is None else 2 * intermediate_size,
+        ),
+        dtype=torch.bfloat16,
+        device=x.device,
+    )
+    moe_gemm_fp8_nt_groupwise(
+        repeated_x_q,
+        w13_weight,
+        packed_x_scale,
+        quant_info.w13_weight_scale,
+        quant_info.expert_offsets,
+        out=gate_up,
+        is_gated=swiglu_limit is None,
+    )
+
+    if swiglu_limit is None:
+        intermediate_q, intermediate_scale = sglang_per_token_group_quant_fp8(
+            gate_up, 128
+        )
+        packed_intermediate_scale = pack_flashinfer_moe_scales(
+            intermediate_scale, quant_info.expert_offsets
+        )
+    else:
+        intermediate_q, packed_intermediate_scale = (
+            silu_and_mul_quant_pack_flashinfer_moe(
+                gate_up,
+                quant_info.expert_offsets,
+                swiglu_limit,
+            )
+        )
+    expert_output_with_sink = torch.empty(
+        (total_rows + 1, hidden_size), dtype=torch.bfloat16, device=x.device
+    )
+    expert_output = expert_output_with_sink[:total_rows]
+    expert_output_with_sink[-1].zero_()
+    moe_gemm_fp8_nt_groupwise(
+        intermediate_q,
+        w2_weight,
+        packed_intermediate_scale,
+        quant_info.w2_weight_scale,
+        quant_info.expert_offsets,
+        out=expert_output,
+        is_gated=False,
+    )
+
+    with use_symmetric_memory(get_tp_group(), disabled=not is_allocation_symmetric()):
+        output = torch.empty_like(x)
+    apply_shuffle_mul_sum(
+        expert_output_with_sink, output, c_map, topk_weights.to(torch.bfloat16)
+    )
+    # Keep the same runner contract as Triton: CUDA MoE runners own the routed
+    # scaling factor rather than leaving it to the model wrapper.
+    if runner_config.routed_scaling_factor is not None:
+        output.mul_(runner_config.routed_scaling_factor)
+    return output
+
+
 @register_fused_func("none", "flashinfer_cutlass")
 def fused_experts_none_to_flashinfer_cutlass(
     dispatch_output: StandardDispatchOutput,
@@ -255,6 +399,14 @@ def fused_experts_none_to_flashinfer_cutlass(
     runner_config: MoeRunnerConfig,
 ) -> StandardCombineInput:
     from sglang.srt.layers.moe.token_dispatcher.standard import StandardCombineInput
+
+    if isinstance(quant_info, FlashInferSm120Fp8MoeQuantInfo):
+        output = _run_flashinfer_sm120_fp8(
+            dispatch_output=dispatch_output,
+            quant_info=quant_info,
+            runner_config=runner_config,
+        )
+        return StandardCombineInput(hidden_states=output)
 
     assert isinstance(
         quant_info, FlashInferCutlassMoeQuantInfo

--- a/python/sglang/srt/layers/moe/token_dispatcher/standard.py
+++ b/python/sglang/srt/layers/moe/token_dispatcher/standard.py
@@ -112,7 +112,7 @@ class StandardDispatcher(BaseDispatcher):
         # - cutlass / cutedsl / trtllm_routed handle EP internally
         # - mxfp4 dispatcher mapping is already global
         # - hpc_ops consumes global ids together with rank_ep / num_expert_total
-        self.skip_local_expert_mapping = (
+        backend_accepts_global_expert_ids = (
             backend.is_flashinfer_cutlass()
             or backend.is_flashinfer_cutedsl()
             or backend.is_flashinfer_trtllm()
@@ -120,6 +120,11 @@ class StandardDispatcher(BaseDispatcher):
             or backend.is_flashinfer_trtllm_routed()
             or backend.is_hpc_ops()
             or self.enable_flashinfer_mxfp4_moe
+        )
+        self.skip_local_expert_mapping = (
+            backend_accepts_global_expert_ids
+            if moe_runner_config.accepts_global_expert_ids is None
+            else moe_runner_config.accepts_global_expert_ids
         )
         self.num_experts = moe_runner_config.num_experts
         self.num_local_experts = moe_runner_config.num_local_experts

--- a/python/sglang/srt/layers/quantization/fp8.py
+++ b/python/sglang/srt/layers/quantization/fp8.py
@@ -1074,6 +1074,11 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         quant_config: The quantization config.
     """
 
+    @property
+    def load_up_proj_weight_first(self) -> bool:
+        """Load W13 as [up, gate] for FlashInfer's fused gated GEMM."""
+        return get_moe_runner_backend().is_flashinfer_cutlass()
+
     def __init__(self, quant_config: Fp8Config):
         self.quant_config = quant_config
         self.use_mxfp8 = getattr(self.quant_config, "use_mxfp8", False)
@@ -1096,6 +1101,21 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             assert (
                 is_sm100_supported() or is_sm90_supported() or is_sm120_supported()
             ), "cutlass_fp8 MoE requires SM90, SM100, or SM120 GPUs"
+        if get_moe_runner_backend().is_flashinfer_cutlass():
+            assert (
+                is_sm120_supported()
+            ), "blockwise FP8 with flashinfer_cutlass requires an SM120/SM121 GPU"
+            assert (
+                not self.is_fp4_expert and self.block_quant
+            ), "flashinfer_cutlass FP8 MoE requires blockwise FP8 weights"
+            assert tuple(self.weight_block_size) == (
+                128,
+                128,
+            ), "flashinfer_cutlass FP8 MoE requires weight_block_size=[128, 128]"
+            assert get_moe_a2a_backend().is_none(), (
+                "flashinfer_cutlass blockwise FP8 currently supports only "
+                "--moe-a2a-backend none"
+            )
 
     @staticmethod
     def is_deepgemm_moe_runner_backend_enabled(
@@ -1430,9 +1450,15 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         if (
             not self.is_fp4_expert
             and self.block_quant
-            and get_moe_runner_backend().is_cutlass()
+            and (
+                get_moe_runner_backend().is_cutlass()
+                or get_moe_runner_backend().is_flashinfer_cutlass()
+            )
         ):
-            self._ensure_cutlass_buffers_initialized(layer)
+            if get_moe_runner_backend().is_cutlass():
+                self._ensure_cutlass_buffers_initialized(layer)
+            else:
+                self._ensure_flashinfer_sm120_buffers_initialized(layer)
 
     def process_weights_after_loading_block_quant(self, layer: Module) -> None:
         # AMD FP4 experts: use aiter's native MXFP4 MoE path
@@ -1722,6 +1748,19 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                         use_deepgemm_runner=will_use_deepgemm,
                         output_dtype=torch.bfloat16,
                         weight_shape=weight.shape[-2:],
+                    )
+
+                if get_moe_runner_backend().is_flashinfer_cutlass():
+                    # FlashInfer consumes B scales as [E, K_blocks, N_blocks].
+                    layer.register_buffer(
+                        "flashinfer_w13_weight_scale",
+                        layer.w13_weight_scale_inv.transpose(1, 2).contiguous(),
+                        persistent=False,
+                    )
+                    layer.register_buffer(
+                        "flashinfer_w2_weight_scale",
+                        layer.w2_weight_scale_inv.transpose(1, 2).contiguous(),
+                        persistent=False,
                     )
 
     def _convert_mxfp8_moe_to_block_fp8(self, layer: Module) -> None:
@@ -2352,8 +2391,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
             or moe_runner_backend.is_aiter()
             or moe_runner_backend.is_flashinfer_trtllm()
             or moe_runner_backend.is_flashinfer_trtllm_routed()
+            or moe_runner_backend.is_flashinfer_cutlass()
             or moe_runner_backend.is_hpc_ops()
         ):
+            if moe_runner_backend.is_flashinfer_cutlass():
+                import sglang.srt.layers.moe.moe_runner.flashinfer_cutlass  # noqa: F401
+
+                assert (
+                    moe_runner_config.params_dtype == torch.bfloat16
+                ), "flashinfer_cutlass blockwise FP8 requires bfloat16 model dtype"
+                assert (
+                    moe_runner_config.is_gated
+                    and moe_runner_config.activation == "silu"
+                    and moe_runner_config.gemm1_alpha is None
+                    and moe_runner_config.gemm1_clamp_limit is None
+                ), "flashinfer_cutlass blockwise FP8 supports SwiGLU only"
+                # The native SM120 grouped GEMM consumes local expert IDs.
+                moe_runner_config.accepts_global_expert_ids = False
             self.runner = MoeRunner(moe_runner_backend, moe_runner_config)
             self._owns_moe_runner = True
         else:
@@ -2509,6 +2563,22 @@ class Fp8MoEMethod(FusedMoEMethodBase):
                 enable_es=(use_mxfp8, use_mxfp8),
             )
             return StandardCombineInput(hidden_states=output)
+
+        if self.runner.runner_backend.is_flashinfer_cutlass():
+            from sglang.srt.layers.moe.moe_runner.flashinfer_cutlass import (
+                FlashInferSm120Fp8MoeQuantInfo,
+            )
+
+            quant_info = FlashInferSm120Fp8MoeQuantInfo(
+                w13_weight=layer.w13_weight,
+                w2_weight=layer.w2_weight,
+                w13_weight_scale=layer.flashinfer_w13_weight_scale,
+                w2_weight_scale=layer.flashinfer_w2_weight_scale,
+                expert_offsets=self.expert_offsets,
+                problem_sizes1=self.problem_sizes1,
+                problem_sizes2=self.problem_sizes2,
+            )
+            return self.runner.run(dispatch_output, quant_info)
 
         if self.runner.runner_backend.is_deep_gemm():
 
@@ -2671,6 +2741,23 @@ class Fp8MoEMethod(FusedMoEMethodBase):
         )
 
         self._cutlass_buffers_ready = True
+
+    def _ensure_flashinfer_sm120_buffers_initialized(self, layer: Module) -> None:
+        if getattr(self, "_flashinfer_sm120_buffers_ready", False):
+            return
+
+        device = layer.w13_weight.device
+        num_experts = layer.w13_weight.shape[0]
+        self.expert_offsets = torch.empty(
+            num_experts + 1, device=device, dtype=torch.int32
+        )
+        self.problem_sizes1 = torch.empty(
+            num_experts, 3, device=device, dtype=torch.int32
+        )
+        self.problem_sizes2 = torch.empty(
+            num_experts, 3, device=device, dtype=torch.int32
+        )
+        self._flashinfer_sm120_buffers_ready = True
 
     def maybe_get_hip_aiter_quant_info(
         self,


### PR DESCRIPTION
## Motivation

SGLang has no optimized non-Triton MoE runner for 128x128 blockwise-FP8 checkpoints on SM120. DeepGEMM has no SM120 path, and the existing `flashinfer_cutlass` runner does not accept blockwise-FP8 experts even though FlashInfer provides a native SM120 grouped-GEMM implementation.

Consequently, models such as GLM-5.3-Flash must use the slower Triton MoE path on SM120. This PR connects FlashInfer's existing grouped GEMM through SGLang's MoE abstractions and fuses the SGLang-side activation processing needed by that path.

This differs from #28125, which adds SM120 dispatch to the `sgl-kernel` CUTLASS grouped-GEMM path.

## Modifications

- Add a blockwise-FP8 quant payload to the existing `flashinfer_cutlass` MoE runner.
- Reuse the standard token dispatcher and request local expert IDs for this path under EP.
- Validate the supported contract at runner creation: SM120, BF16 activations, FP8 E4M3 weights, dynamic activation quantization, and 128x128 weight blocks.
- Convert checkpoint weight scales once to FlashInfer's required layout and load W13 in `[up, gate]` order.
- Add CUDA Graph-compatible JIT kernels to:
  - shuffle routed FP8 rows and pack activation scales in one launch;
  - fuse clamped SwiGLU, BF16 intermediate rounding, the second FP8 activation quantization, and FlashInfer scale packing over active rows.
- Preserve GLM-5.3-Flash `swiglu_limit` and `routed_scaling_factor` semantics.

## Accuracy Tests

Configuration:

- 8 x NVIDIA RTX PRO 5000 Blackwell (SM120), TP=8, EP=8
- GLM-5.3-Flash
- BF16 KV cache; TileLang DSA
- identical prompts and decoding settings for FlashInfer and Triton

Out-of-tree targeted SM120 validation: `9/9 passed`. Coverage includes scale packing, active-row bounds, clamped SwiGLU and BF16 intermediate semantics, FP8 quantization, native grouped GEMM, routed scaling, empty/non-local routes, and CUDA Graph replay.

GSM8K paired regression run, fixed first 500 questions, 5-shot, temperature 0, parallelism 16:

| Result | Questions |
| --- | ---: |
| Both correct | 436 |
| Both incorrect | 31 |
| FlashInfer only correct | 16 |
| Triton only correct | 17 |

| Backend | Correct | Invalid responses | Latency | Output throughput |
| --- | ---: | ---: | ---: | ---: |
| FlashInfer | 452/500 (90.4%) | 0 | 725.5 s | 63.55 tok/s |
| Triton | 453/500 (90.6%) | 0 | 827.5 s | 55.87 tok/s |

The aggregate difference is one question. Among the 33 discordant questions, FlashInfer wins 16 and Triton wins 17; the exact paired two-sided binomial test gives `p=1.0`. This does not indicate a systematic accuracy regression. Per-question predictions and the complete state dumps were retained for review.

## Speed Tests and Profiling

Workload:

- random token IDs; 256 input tokens and 64 output tokens
- `ignore_eos=true`; temperature 0; fixed seed
- decode CUDA Graph disabled and speculative decoding disabled
- cache flush and one warmup before each case
- three repetitions; each displayed value is the median of the three per-run means
- only `--moe-runner-backend` differs between runs

| Concurrency | FlashInfer throughput (tok/s) | Triton throughput (tok/s) | Throughput change | FlashInfer TTFT (ms) | Triton TTFT (ms) | TTFT change | FlashInfer TPOT (ms) | Triton TPOT (ms) | TPOT change |
| ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| 1 | 7.030 | 6.178 | +13.79% | 648.72 | 688.44 | -5.77% | 133.96 | 153.16 | -12.54% |
| 16 | 64.660 | 57.193 | +13.05% | 3796.82 | 3957.26 | -4.05% | 190.69 | 220.85 | -13.66% |

Lower TTFT and TPOT are better. The runs used the same host, model, integration source, server flags, workload, and measurement procedure, but were executed sequentially rather than interleaved. The table is end-to-end serving evidence, not an isolated grouped-GEMM kernel ranking.

## Dependencies and validation boundary

- Native GLM-5.3-Flash model support comes from #36507; the end-to-end validation used that PR plus this change.
- The currently tested SM120 environment also needs a TileLang DSA launch-configuration fallback because the default kernel requests more dynamic shared memory than SM120 permits. That attention change is independent of this MoE PR and is not included here.
- The test image exposed a development Transformers checkout newer than SGLang's pinned version. An external startup shim removed duplicate Qwen3-ASR registrations; it did not modify SGLang or the model execution path.
- Runtime support in this PR is intentionally limited to the physically validated SM120 128x128 blockwise-FP8 contract. SM121 is not claimed without hardware validation.

## Checklist

- [x] Format changed files with the repository pre-commit configuration.
- [x] Follow the existing MoE runner, dispatcher, quantization, and JIT-kernel abstractions.
- [x] No user documentation change is required: this enables an existing backend option and adds no CLI flag.
- [x] Keep this as an implementation-only change with no benchmark or test files.
- [x] Provide out-of-tree physical-SM120 correctness and serving-performance results.
- [x] Complete an expanded paired accuracy gate with per-question artifacts.

## Suggested review focus

- Runner/dispatcher ownership and local expert IDs under EP.
- FP8 checkpoint scale layout and W13 `[up, gate]` ordering.
- GLM `swiglu_limit=10`, BF16 intermediate rounding, and `routed_scaling_factor` semantics.
- Active-row bounds, empty/non-local routes, and CUDA Graph safety.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33238628171](https://github.com/sgl-project/sglang/actions/runs/33238628171)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33238628080](https://github.com/sgl-project/sglang/actions/runs/33238628080)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33238628177](https://github.com/sgl-project/sglang/actions/runs/33238628177)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->