### PR TITLE
[Fix] Fall back to the process-group broadcast for DSA topk when PyNCCL is absent

### DIFF
--- a/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
+++ b/python/sglang/srt/layers/attention/dsa/dsa_indexer.py
@@ -154,11 +154,14 @@ def _broadcast_indexer_topk_from_rank0_impl(topk_indices: torch.Tensor) -> None:
     if group.world_size == 1:
         return
 
-    if topk_indices.device.type == "cuda" and torch.cuda.is_current_stream_capturing():
-        if group.pynccl_comm is None:
-            raise RuntimeError(
-                "SGLANG_DSA_TOPK_BROADCAST requires PyNCCL during CUDA graph capture."
-            )
+    # PyNCCL is the faster path under capture, but it is not a precondition:
+    # a split attn-TP group is built without one (parallel_state.py), and the
+    # process-group broadcast captures and replays correctly.
+    if (
+        topk_indices.device.type == "cuda"
+        and torch.cuda.is_current_stream_capturing()
+        and group.pynccl_comm is not None
+    ):
         with group.pynccl_comm.change_state(enable=True):
             group.pynccl_comm.broadcast(topk_indices, src=0)
     else:


### PR DESCRIPTION
`SGLANG_DSA_TOPK_BROADCAST=1` cannot start under DP attention whenever attention is TP-sharded (`attn_tp_size > 1` and `< tp_size`, e.g. `--tp 4 --dp 2`). A split attn-TP group is built without a PyNCCL communicator, and the capture path raised instead of falling back:

```
RuntimeError: SGLANG_DSA_TOPK_BROADCAST requires PyNCCL during CUDA graph capture.
RuntimeError: Rank 0 scheduler died during initialization
```

PyNCCL is not a precondition here — the process-group broadcast captures and replays correctly. With the fallback the same config boots, captures the decode graph, and at temperature 0 produces output token-identical to the same build with the broadcast disabled. PyNCCL stays the preferred path where it exists; measured in graph replay it is 8.82 us vs 10.57 us for a 64 KB broadcast.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33234794122](https://github.com/sgl-project/sglang/actions/runs/33234794122)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33234793994](https://github.com/sgl-project/sglang/actions/runs/33234793994)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33234794054](https://github.com/sgl-project/sglang/actions/runs/33234794054)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->