### PR TITLE
[VLM] Handle EPD RDMA failures on the scheduler thread

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -899,15 +899,6 @@ class WaitingMMRequestBase(ABC):
         self._cleanup_gpu_buffer()
         self.close_recv_socket()
 
-    async def _check_encoder_responses(self, responses, endpoint: str) -> bool:
-        """Validate gathered encoder responses; on the first error, FAIL the
-        request and release its resources. Returns True if all succeeded."""
-        msg = await _extract_encoder_error(responses, endpoint, f"rid={self.rid}")
-        if msg is None:
-            return True
-        self._fail_and_release(msg)
-        return False
-
     def _is_valid_embedding_part(self, recv_obj) -> bool:
         """Check for and drop stale or out-of-sync payloads; normalize the part req_id to the original rid."""
         original_req_id = extract_original_req_id(recv_obj.req_id)
@@ -1249,6 +1240,8 @@ class WaitingRDMARequest(WaitingMMRequestBase):
         self._buffer_lock = threading.Lock()
         self._terminal = False
         self._receive_running = False
+        self._receive_error = None
+        self._receive_error_lock = threading.Lock()
 
     def send_encode_request(self):
         # Base-class hook. The tokenizer owns /encode, so this rank only pulls
@@ -1261,12 +1254,33 @@ class WaitingRDMARequest(WaitingMMRequestBase):
             asyncio.run(self._pull_meta_and_receive_embedding())
         except Exception as e:
             logger.error(f"RDMA receive failed for rid={self.rid}: {e}")
-            self._fail_and_release(str(e))
+            self._record_receive_error(str(e))
         finally:
             with self._buffer_lock:
                 self._receive_running = False
                 if self._terminal:
                     self._release_buffer_locked()
+
+    def _record_receive_error(self, error_msg, error_code=None) -> None:
+        """Pass a worker-thread failure to the scheduler thread."""
+        with self._receive_error_lock:
+            self._receive_error = (error_msg, error_code)
+
+    def _try_recv_mm_data(self):
+        with self._receive_error_lock:
+            receive_error, self._receive_error = self._receive_error, None
+        if receive_error is not None:
+            self._fail_and_release(*receive_error)
+            return
+        super()._try_recv_mm_data()
+
+    async def _check_encoder_responses(self, responses, endpoint: str) -> bool:
+        """Record network failures for the scheduler thread to consume."""
+        msg = await _extract_encoder_error(responses, endpoint, f"rid={self.rid}")
+        if msg is None:
+            return True
+        self._record_receive_error(msg)
+        return False
 
     async def _pull_meta_and_receive_embedding(self):
         """Pull per-part sizes, allocate the landing buffer, then drive /send.
@@ -1334,7 +1348,7 @@ class WaitingRDMARequest(WaitingMMRequestBase):
                     )
                     if alloc_result is None:
                         # Oversize or alloc timeout — fatal for this request.
-                        self._fail_and_release(
+                        self._record_receive_error(
                             f"EmbeddingPool could not allocate "
                             f"{total_bytes // (1024 * 1024)}MB (oversize or "
                             f"timeout). Raise SGLANG_EMBEDDING_POOL_SIZE_MB."
@@ -2200,6 +2214,7 @@ class MMReceiverBase(ABC):
             else:  # status_value == WaitingMMRequestStatus.PENDING
                 new_waiting.append(waiting_req)
                 continue
+            waiting_req.close_recv_socket()
             self.waiting_by_rid.pop(waiting_req.rid, None)
 
         self.waiting_list = new_waiting

--- a/test/registered/unit/disaggregation/test_encode_receiver.py
+++ b/test/registered/unit/disaggregation/test_encode_receiver.py
@@ -1,10 +1,17 @@
 """Unit tests for request construction in the encode-disaggregation path."""
 
+import asyncio
+import threading
 import unittest
 from array import array
 from types import SimpleNamespace
+from unittest.mock import patch
 
-from sglang.srt.disaggregation.encoder.receiver import MMReceiverBase
+from sglang.srt.disaggregation.encoder.receiver import (
+    MMReceiverBase,
+    WaitingMMRequestStatus,
+    WaitingRDMARequest,
+)
 from sglang.srt.disaggregation.utils import DisaggregationMode
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -55,6 +62,97 @@ class TestEncodeReceiverRequestConstruction(CustomTestCase):
 
         self.assertEqual(req.extra_key, "classification")
         self.assertEqual(req.cache_salt, "tenant-a")
+
+    def test_rdma_worker_error_is_released_on_scheduler_thread(self):
+        scheduler_thread = threading.get_ident()
+
+        class ThreadCheckedSocket:
+            closed_by = None
+
+            def close(self):
+                self.closed_by = threading.get_ident()
+
+        recv_socket = ThreadCheckedSocket()
+        request = WaitingRDMARequest.__new__(WaitingRDMARequest)
+        request.rid = "request-1"
+        request.status = WaitingMMRequestStatus.PENDING
+        request.error_msg = None
+        request.error_code = None
+        request.recv_socket = recv_socket
+        request._receive_error = None
+        request._receive_error_lock = threading.Lock()
+        request._buffer_lock = threading.Lock()
+        request._terminal = False
+        request._receive_running = False
+        request.embeddings_buffer = None
+        request._pool_slot_id = None
+        request.embedding_pool = None
+        request._mm_finalizer = None
+
+        worker = threading.Thread(
+            target=lambda: asyncio.run(
+                request._check_encoder_responses(
+                    [ConnectionError("encoder unavailable")], "/send"
+                )
+            )
+        )
+        worker.start()
+        worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(request.status, WaitingMMRequestStatus.PENDING)
+        self.assertIsNone(request.recv_socket.closed_by)
+
+        request._try_recv_mm_data()
+
+        self.assertEqual(request.status, WaitingMMRequestStatus.FAIL)
+        self.assertIsNone(request.recv_socket)
+        self.assertTrue(request._terminal)
+        self.assertEqual(recv_socket.closed_by, scheduler_thread)
+
+    def test_tp_peer_failure_closes_local_receive_socket(self):
+        class WaitingRequest:
+            rid = "request-1"
+            recv_req = SimpleNamespace(rid=rid)
+            status = WaitingMMRequestStatus.PENDING
+            error_msg = "peer failed"
+            error_code = None
+            start_time = 0
+            released = False
+            closed = False
+
+            def _try_recv_mm_data(self):
+                pass
+
+            def release_resources(self):
+                self.released = True
+
+            def close_recv_socket(self):
+                self.closed = True
+
+        waiting_req = WaitingRequest()
+        receiver = SimpleNamespace(
+            waiting_list=[waiting_req],
+            waiting_by_rid={waiting_req.rid: waiting_req},
+            scheduler_recv_socket=None,
+            wait_timeout=float("inf"),
+            tp_group=SimpleNamespace(cpu_group=object()),
+            _drain_scheduler_embeddings=lambda: None,
+            _sync_fail_info_across_tp=lambda request: None,
+            create_req=lambda request: request,
+        )
+
+        def force_peer_failure(status, **kwargs):
+            status.fill_(WaitingMMRequestStatus.FAIL)
+
+        with patch("torch.distributed.all_reduce", force_peer_failure):
+            _, abort_reqs = MMReceiverBase._process_waiting_requests(
+                receiver, [], waiting_cls=None
+            )
+
+        self.assertTrue(waiting_req.released)
+        self.assertTrue(waiting_req.closed)
+        self.assertEqual(len(abort_reqs), 1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- hand Mooncake/RDMA receive-worker failures back to the scheduler thread
- release GPU buffers and close scheduler-owned ZMQ sockets only from the scheduler
- close local receive sockets when TP consensus forces a peer's request to fail

## Why

`WaitingRDMARequest` creates its receive socket on the scheduler thread but previously called `_fail_and_release()` directly from its background receive thread. A request-level network, metadata, pool-allocation, or transfer exception could therefore close a ZMQ socket from the wrong thread while the scheduler was polling it. ZMQ sockets are thread-affine, and this also raced request success/resource ownership.

The worker now records the first receive error under a lock. The next scheduler tick converts it into the existing request-local failure path before TP-wide status consensus. Buffer cleanup and socket closure consequently happen at the scheduler's safe point. CUDA/NCCL/global-state failures are not swallowed.

## Validation

NVIDIA H200 devbox:

- `test_encode_receiver.py` + `test_kimi_k3_encoder_mode.py`: 30 passed
- `test_encode_server.py` + `test_encoder_health.py`: 19 passed
- `python3 test/registered/unit/disaggregation/test_encode_receiver.py -f`: passed
- pre-commit on modified files: passed

Regression tests verify both worker-to-scheduler error handoff/thread ownership and socket cleanup when only a TP peer reports failure.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33237034366](https://github.com/sgl-project/sglang/actions/runs/33237034366)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33237792051](https://github.com/sgl-project/sglang/actions/runs/33237792051)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33237034243](https://github.com/sgl-project/sglang/actions/runs/33237034243)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->