### PR TITLE
config: the dead record parameters go

### DIFF
--- a/python/sglang/srt/arg_groups/cuda_graph_hook.py
+++ b/python/sglang/srt/arg_groups/cuda_graph_hook.py
@@ -376,7 +376,7 @@ def apply_deepep_adjustments(server_args: Any):
         if bs is None:
             # 2048 = documented prefill default; max_bs unresolved here.
             max_bs = cfg.cuda_graph_config.prefill.max_bs or 2048
-            bs = generate_prefill_cuda_graph_batch_sizes(server_args, max_bs)
+            bs = generate_prefill_cuda_graph_batch_sizes(max_bs)
         aligned = sorted({((b + 7) // 8) * 8 for b in bs})
         if aligned != sorted(bs):
             logger.info(
@@ -473,7 +473,7 @@ def validate_cuda_graph_config(server_args: Any):
             )
 
 
-def generate_prefill_cuda_graph_batch_sizes(server_args: Any, max_bs: int):
+def generate_prefill_cuda_graph_batch_sizes(max_bs: int):
     """
     Generate the list of batch sizes for prefill CUDA graph capture
     based on max_bs. For tc_piecewise prefill, bs carries the

--- a/python/sglang/srt/arg_groups/memory_hook.py
+++ b/python/sglang/srt/arg_groups/memory_hook.py
@@ -206,7 +206,7 @@ def handle_gpu_memory_settings(server_args: Any, gpu_mem):
 
     if prefill_cuda_graph_config.bs is None:
         prefill_cuda_graph_config.bs = generate_prefill_cuda_graph_batch_sizes(
-            server_args, prefill_cuda_graph_config.max_bs
+            prefill_cuda_graph_config.max_bs
         )
 
     if cuda_graph_config != cfg.cuda_graph_config:

--- a/python/sglang/srt/arg_groups/model_hook.py
+++ b/python/sglang/srt/arg_groups/model_hook.py
@@ -786,7 +786,7 @@ def handle_model_capability_adjustments(server_args: Any):
                 }
                 if (Phase.PREFILL, "bs") not in cuda_graph_config_locked:
                     sizing["bs"] = generate_prefill_cuda_graph_batch_sizes(
-                        server_args, sizing["max_bs"]
+                        sizing["max_bs"]
                     )
                 declare_resolution(
                     server_args,

--- a/python/sglang/srt/arg_groups/parallel_hook.py
+++ b/python/sglang/srt/arg_groups/parallel_hook.py
@@ -221,7 +221,7 @@ def handle_data_parallelism(server_args: Any):
             clamped = {"max_bs": cfg.chunked_prefill_size}
             if (Phase.PREFILL, "bs") not in server_args._cuda_graph_config_locked:
                 clamped["bs"] = generate_prefill_cuda_graph_batch_sizes(
-                    server_args, clamped["max_bs"]
+                    clamped["max_bs"]
                 )
             declare_resolution(
                 server_args,
@@ -370,9 +370,7 @@ def handle_elastic_ep(server_args: Any):
             declare_resolution(
                 server_args,
                 "_handle_elastic_ep",
-                mooncake_ib_device=validate_ib_devices(
-                    server_args, cfg.mooncake_ib_device
-                ),
+                mooncake_ib_device=validate_ib_devices(cfg.mooncake_ib_device),
             )
     if cfg.ep_join_mode is not None:
         assert (

--- a/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
+++ b/python/sglang/srt/arg_groups/pd_disaggregation_hook.py
@@ -218,9 +218,7 @@ def handle_encoder_disaggregation(server_args: Any):
         declare_resolution(
             server_args,
             "_handle_encoder_disaggregation",
-            disaggregation_ib_device=validate_ib_devices(
-                server_args, cfg.disaggregation_ib_device
-            ),
+            disaggregation_ib_device=validate_ib_devices(cfg.disaggregation_ib_device),
         )
 
     # Validate model type for encoder disaggregation

--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -104,7 +104,7 @@ def run_resolution_pipeline(server_args: Any) -> None:
         handle_hardware_runtime_validation,
     )
 
-    handle_hardware_runtime_validation(server_args)
+    handle_hardware_runtime_validation()
     if cfg.model_path.lower() in ["none", "dummy"]:
         return
 

--- a/python/sglang/srt/arg_groups/platform_hook.py
+++ b/python/sglang/srt/arg_groups/platform_hook.py
@@ -17,7 +17,7 @@ from sglang.srt.utils.common import is_cuda, is_hip, is_host_cpu_arm64, is_npu
 logger = logging.getLogger(__name__)
 
 
-def handle_hardware_runtime_validation(server_args: Any):
+def handle_hardware_runtime_validation():
     # This is intentionally independent of `server_args.device`: setting
     # SGLANG_USE_MLX opts into the MLX backend and must fail immediately if
     # the environment cannot honor that request. With the flag unset,

--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -122,12 +122,8 @@ def check_server_args(server_args: Any):
     assert cfg.detokenizer_worker_num > 0, "Detokenizer worker num must >= 1"
     assert cfg.mm_processor_worker_num >= 0, "Multimodal processor worker num must >= 0"
     assert cfg.mm_io_worker_num >= 0, "Multimodal I/O worker num must >= 0"
-    validate_buckets_rule(
-        server_args, "--prompt-tokens-buckets", cfg.prompt_tokens_buckets
-    )
-    validate_buckets_rule(
-        server_args, "--generation-tokens-buckets", cfg.generation_tokens_buckets
-    )
+    validate_buckets_rule("--prompt-tokens-buckets", cfg.prompt_tokens_buckets)
+    validate_buckets_rule("--generation-tokens-buckets", cfg.generation_tokens_buckets)
 
     # Check scheduling policy
     if cfg.enable_priority_scheduling:
@@ -222,7 +218,7 @@ def check_server_args(server_args: Any):
     check_load_publish_args(server_args)
 
 
-def validate_buckets_rule(server_args: Any, arg_name: str, buckets_rule: List[str]):
+def validate_buckets_rule(arg_name: str, buckets_rule: List[str]):
     if not buckets_rule:
         return
 
@@ -313,7 +309,7 @@ def check_load_publish_args(server_args: Any):
         raise ValueError(reason)
 
 
-def validate_ib_devices(server_args: Any, device_str: Optional[str]) -> Optional[str]:
+def validate_ib_devices(device_str: Optional[str]) -> Optional[str]:
     """
     Validate IB devices before passing to mooncake.
 

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -148,7 +148,6 @@ class HiRadixCache(RadixCache):
             attach_hybrid_dsa_pool_to_hiradix_cache(
                 self,
                 params,
-                server_args,
                 extra_config=extra_config,
                 prefetch_threshold=prefetch_threshold,
                 enable_storage_metrics=self.enable_storage_metrics,
@@ -162,7 +161,6 @@ class HiRadixCache(RadixCache):
             attach_hybrid_minimax_sparse_pool_to_hiradix_cache(
                 self,
                 params,
-                server_args,
                 extra_config=extra_config,
                 prefetch_threshold=prefetch_threshold,
                 enable_storage_metrics=self.enable_storage_metrics,

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_pool_assembler.py
@@ -289,7 +289,6 @@ def build_hybrid_swa_group(
 def build_kv_only_stack(
     *,
     params: CacheInitParams,
-    server_args: ServerArgs,
     kv_pool: Any,
     full_layer_mapping: dict[int, int],
     load_cache_event,
@@ -335,7 +334,6 @@ def build_kv_only_stack(
 def build_hybrid_swa_stack(
     *,
     params: CacheInitParams,
-    server_args: ServerArgs,
     full_kv_pool: Any,
     swa_kv_pool: Any,
     full_layer_mapping: dict[int, int],
@@ -437,7 +435,6 @@ def _dsv4_compressed_region_buffers(kvcache: Any, ratio: int) -> tuple[list, int
 def build_deepseek_v4_hicache_stack(
     *,
     params: CacheInitParams,
-    server_args: ServerArgs,
     kvcache: Any,
     load_cache_event,
     storage_backend: Optional[str],
@@ -687,7 +684,6 @@ def build_deepseek_v4_hicache_stack(
 def build_hybrid_mamba_stack(
     *,
     params: CacheInitParams,
-    server_args: ServerArgs,
     kv_pool: Any,
     mamba_pool: Any,
     full_layer_mapping: dict[int, int],
@@ -781,7 +777,6 @@ def build_hybrid_mamba_stack(
 def build_hybrid_mamba_swa_stack(
     *,
     params: CacheInitParams,
-    server_args: ServerArgs,
     full_kv_pool: Any,
     swa_kv_pool: Any,
     mamba_pool: Any,
@@ -893,7 +888,6 @@ def build_hybrid_mamba_swa_stack(
 def build_anchor_sidecar_stack(
     *,
     params: CacheInitParams,
-    server_args: ServerArgs,
     kv_pool: Any,
     sidecar_pool_name: PoolName,
     full_layer_mapping: dict[int, int],
@@ -1214,7 +1208,6 @@ class _DeepSeekV4Strategy(StackStrategy):
     ):
         host_pool_group, cache_controller = build_deepseek_v4_hicache_stack(
             params=params,
-            server_args=server_args,
             kvcache=kvcache,
             load_cache_event=load_cache_event,
             storage_backend=storage_backend,
@@ -1290,7 +1283,6 @@ class _MambaStrategy(StackStrategy):
         mamba_layer_mapping = dict(params.req_to_token_pool.mamba_map)
         host_pool_group, cache_controller = build_hybrid_mamba_stack(
             params=params,
-            server_args=server_args,
             kv_pool=kvcache.full_kv_pool,
             mamba_pool=params.req_to_token_pool.mamba_pool,
             full_layer_mapping=full_layer_mapping,
@@ -1356,7 +1348,6 @@ class _SwaStrategy(StackStrategy):
         full_layer_mapping, swa_layer_mapping = _swa_layer_mappings(kvcache)
         host_pool_group, cache_controller = build_hybrid_swa_stack(
             params=params,
-            server_args=server_args,
             full_kv_pool=kvcache.full_kv_pool,
             swa_kv_pool=kvcache.swa_kv_pool,
             full_layer_mapping=full_layer_mapping,
@@ -1417,7 +1408,6 @@ class _MambaSwaStrategy(StackStrategy):
         mamba_layer_mapping = dict(params.req_to_token_pool.mamba_map)
         host_pool_group, cache_controller = build_hybrid_mamba_swa_stack(
             params=params,
-            server_args=server_args,
             full_kv_pool=kvcache.full_kv_pool,
             swa_kv_pool=kvcache.swa_kv_pool,
             mamba_pool=params.req_to_token_pool.mamba_pool,
@@ -1485,7 +1475,6 @@ class _DsaStrategy(StackStrategy):
         full_layer_mapping = {i: i for i in range(full_kv_pool.layer_num)}
         host_pool_group, cache_controller = build_anchor_sidecar_stack(
             params=params,
-            server_args=server_args,
             kv_pool=full_kv_pool,
             sidecar_pool_name=PoolName.INDEXER,
             full_layer_mapping=full_layer_mapping,
@@ -1621,7 +1610,6 @@ class _PlainKvStrategy(StackStrategy):
         full_layer_mapping = {i: i for i in range(full_kv_pool.layer_num)}
         host_pool_group, cache_controller = build_kv_only_stack(
             params=params,
-            server_args=server_args,
             kv_pool=full_kv_pool,
             full_layer_mapping=full_layer_mapping,
             load_cache_event=load_cache_event,
@@ -1828,7 +1816,6 @@ def build_minimax_sparse_hicache_stack(
 def attach_hybrid_minimax_sparse_pool_to_hiradix_cache(
     radix_cache: HiRadixCache,
     params: CacheInitParams,
-    server_args: ServerArgs,
     *,
     extra_config: dict,
     prefetch_threshold: int,
@@ -1856,7 +1843,6 @@ def attach_hybrid_minimax_sparse_pool_to_hiradix_cache(
         if sparse_pool.index_k_pool is None:
             host_pool_group, cache_controller = build_kv_only_stack(
                 params=params,
-                server_args=server_args,
                 kv_pool=main_pool,
                 full_layer_mapping={
                     layer_id: layer_id for layer_id in range(main_pool.layer_num)
@@ -1902,7 +1888,6 @@ def attach_hybrid_minimax_sparse_pool_to_hiradix_cache(
 def attach_hybrid_dsa_pool_to_hiradix_cache(
     radix_cache: HiRadixCache,
     params: CacheInitParams,
-    server_args: ServerArgs,
     *,
     extra_config: dict,
     prefetch_threshold: int,
@@ -1918,7 +1903,6 @@ def attach_hybrid_dsa_pool_to_hiradix_cache(
         layer_mapping = {layer_id: layer_id for layer_id in range(kv.layer_num)}
         host_pool_group, cache_controller = build_anchor_sidecar_stack(
             params=params,
-            server_args=server_args,
             kv_pool=kv,
             sidecar_pool_name=PoolName.INDEXER,
             full_layer_mapping=layer_mapping,

--- a/test/registered/cpu/test_server_args_backend.py
+++ b/test/registered/cpu/test_server_args_backend.py
@@ -47,7 +47,6 @@ class TestServerArgsCPUBackend(unittest.TestCase):
 
 class TestServerArgsIBDeviceValidation(unittest.TestCase):
     def _validate_ib_devices(self, device_str, available_devices=None):
-        server_args = ServerArgs.__new__(ServerArgs)
         available_devices = available_devices or [
             "mlx5_0",
             "mlx5_1",
@@ -70,7 +69,7 @@ class TestServerArgsIBDeviceValidation(unittest.TestCase):
                 else real_listdir(path)
             ),
         ):
-            return validate_ib_devices(server_args, device_str)
+            return validate_ib_devices(device_str)
 
     def test_validate_ib_devices_accepts_comma_separated(self):
         self.assertEqual(


### PR DESCRIPTION
## The series

Stacked, each PR based on the one above it. Read them in order; every boundary is
self-sufficient and green on its own.

1. [#36896](https://github.com/sgl-project/sglang/pull/36896) — the resolution pipeline's dispatcher leaves the record
2. [#36972](https://github.com/sgl-project/sglang/pull/36972) — the callbacks into the record go to zero
3. [#36973](https://github.com/sgl-project/sglang/pull/36973) — six more runtime readers ask the bags
4. [#36974](https://github.com/sgl-project/sglang/pull/36974) — the dead record parameters go ← **you are here**
5. [#36975](https://github.com/sgl-project/sglang/pull/36975) — the lazy imports that buy nothing become eager
- [#36925](https://github.com/sgl-project/sglang/pull/36925) — CI vehicle — runs the whole series against `main`, not for merge

## Motivation

Once a function stops reading the record, the parameter it was handed is dead weight — and a dead
`server_args` parameter is worse than noise, because the next reader assumes the function consults
the configuration when it does not.

## Modifications

A census of the tree finds 256 functions that take a `server_args` they never read. **Most are not
dead**, and the distinction matters:

- `multimodal_gen`'s pipeline stages take it as an *interface contract* — 72 implementations of
  `forward` use it and 33 do not, so the parameter belongs to the signature, not to the body.
  `component_uses` is 16 to 29, `create_pipeline_stages` 13 to 31.
- The same holds for `SRTPlatform.apply_server_args_defaults` (implemented in other
  distributions), `CustomSpecAlgo.handle_server_args`, the model-override providers, and the
  `StackStrategy.build` family.

Ten in `srt/` are genuinely dead — free functions called by name, nothing polymorphic about them:

```
generate_prefill_cuda_graph_batch_sizes   validate_ib_devices
validate_buckets_rule                     handle_hardware_runtime_validation
build_kv_only_stack         build_hybrid_swa_stack
build_hybrid_mamba_stack    build_hybrid_mamba_swa_stack
build_anchor_sidecar_stack  build_deepseek_v4_hicache_stack
```

The parameter goes from each, and the argument from all eighteen call sites.

The helper that fed a dropped parameter goes too: `_validate_ib_devices` in the CPU backend test
still built a bare `ServerArgs.__new__(ServerArgs)` for a call that stopped taking one.

Removing one uncovers the next. `test_dead_server_args_parameter_ratchet` — added by an earlier
round of this series with a baseline of zero — caught two functions this PR created:
`attach_hybrid_minimax_sparse_pool_to_hiradix_cache` and its DSA sibling only carried a record to
pass along to the `build_*_stack` functions above, so they became dead the moment those did. The
removal is iterated to a fixed point now, which is what the ratchet's own docstring asks for.

An eleventh candidate was not dead, and it became #36921 rather than part of this PR:
`create_kt_config_from_server_args` reached the record through `server_args.get_hf_config()`, a
method `ServerArgs` does not have and never had, under a bare `except Exception: pass`. The call
raised `AttributeError` every time, `num_layers` was always `None`, and the branch that stops the
model's last MoE layer from deferring experts had never fired.

## Accuracy Tests

The 62-shape resolution probe is byte-identical to the base commit. The suites that cover the
touched files report the same failure set as `main` — the five `test_fp8_blockwise_linear_backends`
failures are a PyTorch interpreter assert present on both sides.

## Speed Tests and Profiling

None.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

Pure deletion; the only thing to check is the interface/free-function split above. On this tree
the ratchet's own scan reports 0 hits over 268 files, and the `@_register_for` override helpers
(`_gemma2_gemma3_overrides`, `_exaone_overrides`) still take an unused record because that is their
registration contract — the same reason the polymorphic surfaces are left alone.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33249912287](https://github.com/sgl-project/sglang/actions/runs/33249912287)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33249912199](https://github.com/sgl-project/sglang/actions/runs/33249912199)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33249912252](https://github.com/sgl-project/sglang/actions/runs/33249912252)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->