### PR TITLE
perf(attention): reuse TRTLLM MHA split metadata across layers

### DIFF
--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -98,6 +98,16 @@ class TRTLLMMHAMetadata:
     encoder_cache_seqlens: torch.Tensor = None
     encoder_page_table: torch.Tensor = None
     encoder_row_map: torch.Tensor = None
+    # Host-selected execution variant; this is a Python capture/eager scalar,
+    # not device metadata.
+    decode_seq_len_splits: int = 1
+    # Decode/verify request order and read-only metadata shared by every
+    # attention layer in one forward. Preparing these once avoids repeating
+    # the same sort and page-table gathers in each layer.
+    decode_seq_len_order: torch.Tensor = None
+    decode_sorted_seq_lens: torch.Tensor = None
+    decode_sorted_page_table: torch.Tensor = None
+    decode_sorted_swa_page_table: torch.Tensor = None
 
 
 class TRTLLMHAAttnBackend(FlashInferAttnBackend):
@@ -397,6 +407,95 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 return swa_pt
         return self.forward_metadata.page_table
 
+    def _get_sorted_layer_page_table(
+        self, layer: RadixAttention
+    ) -> Optional[torch.Tensor]:
+        """Return the pre-sorted page table for the given layer, if prepared."""
+        metadata = self.forward_metadata
+        if metadata.swa_page_table is not None:
+            _, is_swa = self._swa_kv_pool.layers_mapping[layer.layer_id]
+            if is_swa:
+                return metadata.decode_sorted_swa_page_table
+        return metadata.decode_sorted_page_table
+
+    def _prepare_decode_seq_len_splits(self, metadata: TRTLLMMHAMetadata) -> None:
+        """Build request ordering and sorted read metadata once per forward."""
+        if (
+            metadata.decode_seq_len_splits == 1
+            or metadata.is_ragged_verify
+            or metadata.cache_seqlens_int32 is None
+            or metadata.page_table is None
+        ):
+            return
+        if metadata.decode_seq_len_order is None:
+            sorted_seq_lens, order = torch.sort(metadata.cache_seqlens_int32)
+            metadata.decode_seq_len_order = order
+            metadata.decode_sorted_seq_lens = sorted_seq_lens
+            metadata.decode_sorted_page_table = metadata.page_table.index_select(
+                0, order
+            )
+        else:
+            torch.sort(
+                metadata.cache_seqlens_int32,
+                out=(
+                    metadata.decode_sorted_seq_lens,
+                    metadata.decode_seq_len_order,
+                ),
+            )
+            torch.index_select(
+                metadata.page_table,
+                0,
+                metadata.decode_seq_len_order,
+                out=metadata.decode_sorted_page_table,
+            )
+        if metadata.swa_page_table is not None:
+            if metadata.decode_sorted_swa_page_table is None:
+                metadata.decode_sorted_swa_page_table = (
+                    metadata.swa_page_table.index_select(
+                        0, metadata.decode_seq_len_order
+                    )
+                )
+            else:
+                torch.index_select(
+                    metadata.swa_page_table,
+                    0,
+                    metadata.decode_seq_len_order,
+                    out=metadata.decode_sorted_swa_page_table,
+                )
+
+    def _add_decode_split_graph_buffers(
+        self, source: dict, max_bs: int, max_num_pages: int
+    ) -> None:
+        if self.decode_seq_len_splits == 1:
+            return
+        source["decode_seq_len_order"] = torch.empty(
+            max_bs, dtype=torch.int64, device=self.device
+        )
+        source["decode_sorted_seq_lens"] = torch.empty(
+            max_bs, dtype=torch.int32, device=self.device
+        )
+        source["decode_sorted_page_table"] = torch.empty(
+            max_bs, max_num_pages, dtype=torch.int32, device=self.device
+        )
+        if self.use_sliding_window_kv_pool:
+            source["decode_sorted_swa_page_table"] = torch.empty(
+                max_bs, max_num_pages, dtype=torch.int32, device=self.device
+            )
+
+    @staticmethod
+    def _bind_decode_split_graph_buffers(
+        metadata: TRTLLMMHAMetadata, source: dict, bs: int
+    ) -> None:
+        order = source.get("decode_seq_len_order")
+        if order is None:
+            return
+        metadata.decode_seq_len_order = order[:bs]
+        metadata.decode_sorted_seq_lens = source["decode_sorted_seq_lens"][:bs]
+        metadata.decode_sorted_page_table = source["decode_sorted_page_table"][:bs, :]
+        sorted_swa = source.get("decode_sorted_swa_page_table")
+        if sorted_swa is not None:
+            metadata.decode_sorted_swa_page_table = sorted_swa[:bs, :]
+
     def _maybe_build_cp_zigzag_page_tables(
         self,
         metadata: TRTLLMMHAMetadata,
@@ -473,6 +572,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             ),
             "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
         }
+        self._add_decode_split_graph_buffers(
+            self.decode_cuda_graph_metadata, max_bs, max_num_pages
+        )
 
         # SWA write-target buffer; bound as a [:num_tokens] view in
         # _build_cuda_graph_metadata and refilled by the fused metadata kernel.
@@ -528,6 +630,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 ),
                 "swa_page_table": self._alloc_swa_page_table(max_bs, max_num_pages),
             }
+            self._add_decode_split_graph_buffers(
+                self.target_verify_metadata, max_bs, max_num_pages
+            )
             if self.expand_encoder_only_verify:
                 max_verify_rows = max_bs * self.speculative_num_draft_tokens
                 self.target_verify_metadata["encoder_cache_seqlens"] = torch.zeros(
@@ -593,6 +698,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     "swa_page_table_draft_decode",
                     bs,
                 )
+                self._bind_decode_split_graph_buffers(
+                    metadata, self.decode_cuda_graph_metadata, bs
+                )
                 self.decode_cuda_graph_metadata[bs] = metadata
             else:
                 # Normal Decode
@@ -613,6 +721,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     self.decode_cuda_graph_metadata,
                     "swa_page_table",
                     bs,
+                )
+                self._bind_decode_split_graph_buffers(
+                    metadata, self.decode_cuda_graph_metadata, bs
                 )
                 self.decode_cuda_graph_metadata[bs] = metadata
         elif forward_mode.is_target_verify():
@@ -640,6 +751,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                 self.target_verify_metadata,
                 "swa_page_table",
                 bs,
+            )
+            self._bind_decode_split_graph_buffers(
+                metadata, self.target_verify_metadata, bs
             )
             if self._needs_encoder_only_expand(forward_mode, metadata):
                 verify_rows = bs * metadata.max_seq_len_q
@@ -941,6 +1055,11 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             spec_info=forward_batch.spec_info,
             out_cache_loc=forward_batch.out_cache_loc,
         )
+        if forward_batch.forward_mode.is_decode_or_idle() or (
+            forward_batch.forward_mode.is_target_verify()
+            and not self.forward_metadata.is_ragged_verify
+        ):
+            self._prepare_decode_seq_len_splits(self.forward_metadata)
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Initialize the metadata for a forward pass."""
@@ -1048,6 +1167,12 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         )
         self._maybe_build_cp_zigzag_page_tables(metadata, forward_batch)
 
+        if forward_batch.forward_mode.is_decode_or_idle() or (
+            forward_batch.forward_mode.is_target_verify()
+            and not metadata.is_ragged_verify
+        ):
+            self._prepare_decode_seq_len_splits(metadata)
+
         if self._needs_encoder_only_expand(forward_batch.forward_mode, metadata):
             row_map = (
                 torch.arange(batch_size * metadata.max_seq_len_q, device=device)
@@ -1103,6 +1228,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         sinks: Optional[torch.Tensor],
         q_len_per_req: int = 1,
         kv_cache_sf=None,
+        request_order: Optional[torch.Tensor] = None,
+        sorted_block_tables: Optional[torch.Tensor] = None,
+        sorted_seq_lens: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Run decode, optionally sorting and splitting requests by KV length."""
 
@@ -1133,28 +1261,41 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         if num_splits == 1:
             return run_group(query, block_tables, seq_lens)
 
-        order = torch.argsort(seq_lens)
+        order = request_order
+        if order is None:
+            order = torch.argsort(seq_lens)
+            sorted_block_tables = block_tables.index_select(0, order)
+            sorted_seq_lens = seq_lens.index_select(0, order)
+        else:
+            assert sorted_block_tables is not None
+            assert sorted_seq_lens is not None
         query_by_request = query.view(
             num_requests, q_len_per_req, query.shape[-2], query.shape[-1]
         )
+        query_by_request = query_by_request.index_select(0, order)
         output_by_request = torch.empty(
             query_by_request.shape,
             dtype=self.q_data_type,
             device=query.device,
         )
-        for indices in torch.tensor_split(order, num_splits):
+        base_size, remainder = divmod(num_requests, num_splits)
+        start = 0
+        for split_index in range(num_splits):
+            end = start + base_size + (split_index < remainder)
+            indices = order[start:end]
             group_output = run_group(
-                query_by_request.index_select(0, indices).reshape(
+                query_by_request[start:end].reshape(
                     -1, query.shape[-2], query.shape[-1]
                 ),
-                block_tables.index_select(0, indices),
-                seq_lens.index_select(0, indices),
+                sorted_block_tables[start:end],
+                sorted_seq_lens[start:end],
             )
             output_by_request.index_copy_(
                 0,
                 indices,
                 group_output.view(-1, q_len_per_req, query.shape[-2], query.shape[-1]),
             )
+            start = end
         return output_by_request.view(-1, query.shape[-2], query.shape[-1])
 
     def _get_nvfp4_decode_kv_cache(self, layer: RadixAttention) -> tuple[
@@ -1242,6 +1383,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
         attention_sink = kwargs.get("sinks", None)
 
         page_table = self._get_layer_page_table(layer, forward_batch)
+        sorted_page_table = self._get_sorted_layer_page_table(layer)
 
         o = self._run_fixed_q_len_decode(
             q,
@@ -1253,6 +1395,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             window_left=layer.sliding_window_size,
             sinks=attention_sink,
             kv_cache_sf=kv_cache_block_scales,
+            request_order=self.forward_metadata.decode_seq_len_order,
+            sorted_block_tables=sorted_page_table,
+            sorted_seq_lens=self.forward_metadata.decode_sorted_seq_lens,
         )
         if self.is_nvfp4_kvcache and o.dtype != self.q_data_type:
             o = o.to(self.q_data_type)
@@ -1412,6 +1557,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     multi_ctas_kv_counter_buffer=self._multi_ctas_kv_counter_buffer,
                 )
             else:
+                sorted_page_table = self._get_sorted_layer_page_table(layer)
                 o = self._run_fixed_q_len_decode(
                     q,
                     kv_cache,
@@ -1422,6 +1568,9 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
                     window_left=layer.sliding_window_size,
                     sinks=attention_sink,
                     q_len_per_req=self.forward_metadata.max_seq_len_q,
+                    request_order=self.forward_metadata.decode_seq_len_order,
+                    sorted_block_tables=sorted_page_table,
+                    sorted_seq_lens=self.forward_metadata.decode_sorted_seq_lens,
                 )
         elif self.use_fmha_v2 and not cp_v2_active:
             # CP-v2 must go through cp_strategy.run_attention (per-shard

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -98,9 +98,6 @@ class TRTLLMMHAMetadata:
     encoder_cache_seqlens: torch.Tensor = None
     encoder_page_table: torch.Tensor = None
     encoder_row_map: torch.Tensor = None
-    # Host-selected execution variant; this is a Python capture/eager scalar,
-    # not device metadata.
-    decode_seq_len_splits: int = 1
     # Decode/verify request order and read-only metadata shared by every
     # attention layer in one forward. Preparing these once avoids repeating
     # the same sort and page-table gathers in each layer.
@@ -421,7 +418,7 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
     def _prepare_decode_seq_len_splits(self, metadata: TRTLLMMHAMetadata) -> None:
         """Build request ordering and sorted read metadata once per forward."""
         if (
-            metadata.decode_seq_len_splits == 1
+            self.decode_seq_len_splits == 1
             or metadata.is_ragged_verify
             or metadata.cache_seqlens_int32 is None
             or metadata.page_table is None

--- a/python/sglang/srt/layers/attention/trtllm_mha_backend.py
+++ b/python/sglang/srt/layers/attention/trtllm_mha_backend.py
@@ -424,6 +424,8 @@ class TRTLLMHAAttnBackend(FlashInferAttnBackend):
             or metadata.page_table is None
         ):
             return
+        if metadata.cache_seqlens_int32.shape[0] <= 1:
+            return
         if metadata.decode_seq_len_order is None:
             sorted_seq_lens, order = torch.sort(metadata.cache_seqlens_int32)
             metadata.decode_seq_len_order = order

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -29,7 +29,9 @@ DEVICE = "cuda"
 PAGE_SIZE = 128
 
 
-def _make_backend_for_hook_test(speculative_num_draft_tokens=None):
+def _make_backend_for_hook_test(
+    speculative_num_draft_tokens=None, decode_seq_len_splits=1
+):
     backend = TRTLLMHAAttnBackend.__new__(TRTLLMHAAttnBackend)
     backend.device = torch.device("cpu")
     backend.max_context_len = 1024
@@ -42,6 +44,7 @@ def _make_backend_for_hook_test(speculative_num_draft_tokens=None):
     backend.speculative_step_id = 0
     backend.speculative_num_draft_tokens = speculative_num_draft_tokens
     backend.expand_encoder_only_verify = False
+    backend.decode_seq_len_splits = decode_seq_len_splits
     backend.decode_cuda_graph_metadata = {}
     backend.target_verify_metadata = {}
     backend.draft_extend_metadata = {}
@@ -176,7 +179,7 @@ def test_metadata_update_records_inside_cuda_graph():
     if not torch.cuda.is_available():
         pytest.skip("CUDA required")
 
-    backend = _make_backend_for_hook_test()
+    backend = _make_backend_for_hook_test(decode_seq_len_splits=2)
     backend.device = torch.device(DEVICE)
     backend.page_size = 2
     backend.max_num_pages = 4
@@ -203,13 +206,33 @@ def test_metadata_update_records_inside_cuda_graph():
     with torch.cuda.graph(graph):
         backend.init_forward_metadata_in_graph(fb)
 
-    fb.seq_lens.copy_(torch.tensor([5, 6], dtype=torch.int32, device=DEVICE))
+    fb.seq_lens.copy_(torch.tensor([6, 5], dtype=torch.int32, device=DEVICE))
     graph.replay()
     torch.cuda.synchronize()
 
     torch.testing.assert_close(
         backend.forward_metadata.cache_seqlens_int32,
+        torch.tensor([6, 5], dtype=torch.int32, device=DEVICE),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        backend.forward_metadata.decode_sorted_seq_lens,
         torch.tensor([5, 6], dtype=torch.int32, device=DEVICE),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        backend.forward_metadata.decode_seq_len_order,
+        torch.tensor([1, 0], dtype=torch.int64, device=DEVICE),
+        rtol=0,
+        atol=0,
+    )
+    torch.testing.assert_close(
+        backend.forward_metadata.decode_sorted_page_table,
+        backend.forward_metadata.page_table.index_select(
+            0, backend.forward_metadata.decode_seq_len_order
+        ),
         rtol=0,
         atol=0,
     )

--- a/test/registered/attention/test_trtllm_mha_graph_metadata.py
+++ b/test/registered/attention/test_trtllm_mha_graph_metadata.py
@@ -86,6 +86,26 @@ def test_cuda_graph_metadata_launch_runs_in_graph_hook(monkeypatch):
     assert backend.forward_metadata is backend.decode_cuda_graph_metadata[2]
 
 
+def test_single_request_skips_decode_split_preparation():
+    backend = _make_backend_for_hook_test(decode_seq_len_splits=2)
+    metadata = SimpleNamespace(
+        is_ragged_verify=False,
+        cache_seqlens_int32=torch.tensor([7], dtype=torch.int32),
+        page_table=torch.tensor([[1, 2]], dtype=torch.int32),
+        swa_page_table=None,
+        decode_seq_len_order=None,
+        decode_sorted_seq_lens=None,
+        decode_sorted_page_table=None,
+        decode_sorted_swa_page_table=None,
+    )
+
+    backend._prepare_decode_seq_len_splits(metadata)
+
+    assert metadata.decode_seq_len_order is None
+    assert metadata.decode_sorted_seq_lens is None
+    assert metadata.decode_sorted_page_table is None
+
+
 def test_draft_extend_in_graph_uses_captured_static_q_stride(monkeypatch):
     calls = []
 

--- a/test/registered/attention/unittests/dense/test_trtllm_mha.py
+++ b/test/registered/attention/unittests/dense/test_trtllm_mha.py
@@ -190,8 +190,11 @@ class TestTRTLLMMHADenseAttentionBackendCorrectness(CustomTestCase):
                 )
 
     def test_runner_mode_cuda_graph_decode_cases(self):
-        for case in self.CUDA_GRAPH_DECODE_CASES:
-            with self.subTest(case=case.name, backend=case.backend):
+        for case_index, case in enumerate(self.CUDA_GRAPH_DECODE_CASES):
+            splits = 2 if case_index == 0 else 1
+            with self.subTest(
+                case=case.name, backend=case.backend
+            ), envs.SGLANG_TRTLLM_MHA_DECODE_SEQ_LEN_SPLITS.override(splits):
                 run_dense_cuda_graph_decode_case(
                     self,
                     case,


### PR DESCRIPTION
## Motivation

When TRTLLM MHA decode is split by sequence length, every full-attention layer currently repeats the same request sort and page-table gathers. These tensors depend on the forward batch rather than the layer, so rebuilding them per layer adds avoidable host launches and GPU work to every decode step.

## Modifications

Prepare the request order, sorted sequence lengths, and sorted full/SWA page tables once per decode or non-ragged target-verify forward and reuse them across attention layers. The CUDA Graph path allocates stable output buffers and records their refresh after the existing graph-safe metadata update; the eager path retains the same behavior with per-forward tensors. The existing graph-metadata test now verifies that replay updates the cached order, lengths, and page table after sequence lengths change.

## Accuracy Tests

GSM8K was run before and after on Qwen3.5-397B-A17B-NVFP4-V2 with 200 examples, 5 shots, `max_tokens=16384`, 128 threads, temperature 0.6, top-p 0.95, and top-k 20. Both runs used natural speculative acceptance, returned exactly 200 metadata samples, and completed with no runtime error markers.

| Version | Job | GSM8K | Mean speculative accept length |
|---|---:|---:|---:|
| Upstream main `24c9251ac5` | `3394632` | 0.990 | 4.6123 |
| This PR `1b59ad754c` | `3394849` | 0.990 | 4.6187 |

Both scores pass the 0.95 gate with no observed accuracy regression.

## Speed Tests and Profiling

The performance A/B used direct SGLang on one GB300 node with DP4/TP4/EP4, 28 running requests per rank, identical fixed inputs, OSL 1200, simulated acceptance length 4.8, and decode CUDA Graph enabled. The candidate ran first and control second on the same node, so persistent host page cache favors control. Both arms passed 112/112 HTTP 200, exact OSL1200, four-rank coverage, exact B28, CUDA Graph, and zero queue at the selected intervals; control retained 21/21/22/22 exact-B28 rows per rank and the candidate retained 24/24/24/24. Decode authority uses 16-point interpolation over each rank's common full-token range.

The control used upstream `main@24c9251ac52ada1660f372922c72c1d3af722247`; the candidate used this PR at `1b59ad754c99f05181af581e643af5c8da94ab5c`. The following are the in-container commands used for both arms after mounting the respective source revision. The fixed input SHA256 was `f5f77db4ffee3b457b6d1dfa738006ff86ffc829eef18cb7e791f40aff93a9d3`, and the fixed-cohort driver SHA256 was `27712294ba602274757add830799bb76b0e748d2c3d9f092a287d895daab9429`.

```bash
export SGLANG_TRTLLM_MHA_DECODE_SEQ_LEN_SPLITS=4 SGLANG_SIMULATE_ACC_LEN=4.80 SGLANG_SIMULATE_ACC_METHOD=match-expected SGLANG_SIMULATE_ACC_TOKEN_MODE=fixed SGLANG_SIMULATE_ACC_TOKEN_ID=64 SGLANG_ENABLE_SPEC_V2=1 SGLANG_ENABLE_FLASHINFER_GEMM=true SGLANG_FLASHINFER_FP4_GEMM_BACKEND=cutlass SGLANG_USE_SYMM_MEM_DP_SYNC=true SGLANG_QWEN_DEEPEP_SHARED_OVERLAP=true SGLANG_MOE_NVFP4_DISPATCH=1 SGLANG_CUTEDSL_MOE_NVFP4_DISPATCH=1 SGLANG_NVFP4_CKPT_FP8_NEXTN_MOE=1 SGLANG_LOG_FORWARD_ITERS=1 SGLANG_RECORD_STEP_TIME=true
python3 -m sglang.launch_server --model-path /model --served-model-name Qwen3.5-397B-A17B-NVFP4-V2 --host 0.0.0.0 --port 8000 --attention-backend trtllm_mha --chunked-prefill-size 32768 --cuda-graph-bs 1 2 4 8 16 24 32 --cuda-graph-max-bs 32 --data-parallel-size 4 --decode-log-interval 10 --deepep-mode auto --disable-shared-experts-fusion --disable-prefill-cuda-graph --enable-cache-report --enable-dp-attention --enable-dp-lm-head --enable-linear-replayssm-spec --enable-metrics --ep-dispatch-algorithm static --eplb-algorithm deepseek --expert-parallel-size 4 --kv-cache-dtype fp8_e4m3 --linear-attn-decode-backend triton --linear-replayssm-cache-len 32 --load-balance-method round_robin --mamba-max-states-per-path 3 --mamba-scheduler-strategy extra_buffer --mamba-ssm-dtype bfloat16 --mamba-track-interval 8192 --max-mamba-cache-size 448 --max-prefill-tokens 32768 --max-running-requests 128 --mem-fraction-static 0.7 --moe-a2a-backend flashinfer --moe-dense-tp-size 1 --moe-runner-backend flashinfer_cutedsl --page-size 64 --pipeline-parallel-size 1 --quantization modelopt_fp4 --speculative-algorithm NEXTN --speculative-eagle-topk 1 --speculative-moe-a2a-backend deepep --speculative-moe-runner-backend deep_gemm --speculative-num-draft-tokens 6 --speculative-num-steps 5 --stream-interval 30 --tensor-parallel-size 4 --trust-remote-code --watchdog-timeout 1000000 --weight-loader-prefetch-checkpoints --weight-loader-prefetch-num-threads 4
python3 /opt/agentx-one-shot/run_one_shot_decode_cohort.py --inputs /configs/decode-only-b28/inputs.json --url http://127.0.0.1:8000/v1/chat/completions --output /logs/one-shot/cohort.json --model Qwen3.5-397B-A17B-NVFP4-V2 --routed-dp-size 4 --direct-sglang-routing --primer-output-tokens 1 --warmup-requests 112 --warmup-output-tokens 64 --measurement-requests 112 --measurement-output-tokens 1200 --between-phases-seconds 2
```

| Metric | Control | This PR | Change |
|---|---:|---:|---:|
| Matched-context step time | 35.8037 ms | 32.6769 ms | -8.73% |
| Fixed-AL4.8 output throughput/GPU | 3,753.807 tok/s | 4,113.002 tok/s | +9.57% |
| Fixed-AL4.8 TPS/user | 134.065 tok/s | 146.893 tok/s | +9.57% |

The `+9.57%` value is the observed result from same-node job `3395429`, but it is not yet treated as a robust final magnitude because control rank 3 was slower than the other control ranks (`38.879 ms` versus approximately `34.19 ms`), producing a control rank CV of `5.34%`; the candidate rank CV was `0.03%`. The three non-outlier control ranks versus their candidate counterparts imply approximately `+4.7%` throughput, an earlier corrected-head OSL860 pair reproduced the direction at `+5.81%` but retained only 10 control rows per rank, and a separate final-stack fixed-B28 A/B measured `+4.52%`. These results support a real improvement in the approximate `4.5%–5.8%` range, while a clean upstream-main repeat with rank CV at most 2% is needed before treating `9.57%` as authoritative. The pre-accuracy `+22.25%` result is intentionally omitted because that head failed the natural GSM8K gate and consumed uninitialized split metadata.

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33242253954](https://github.com/sgl-project/sglang/actions/runs/33242253954)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33242253846](https://github.com/sgl-project/sglang/actions/runs/33242253846)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33242253949](https://github.com/sgl-project/sglang/actions/runs/33242253949)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->