### PR TITLE
[Spec][Ngram] Expand SAM match length beyond max_trie_depth

### DIFF
--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -772,6 +772,11 @@ Enable it with:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>18</code></td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-ngram-max-sam-match-depth</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum suffix length matched by external suffix automata. Increasing this value does not increase trie depth or trie memory usage.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Same as <code>--speculative-ngram-max-trie-depth</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-ngram-capacity</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Cache capacity (number of entries).</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>10,000,000</code></td>
@@ -998,6 +1003,12 @@ Below is a comprehensive list of all speculative decoding parameters available i
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>int</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>18</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum suffix length stored and matched by the ngram trie</td>
+    </tr>
+    <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-ngram-max-sam-match-depth</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}><code>int</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>Same as <code>--speculative-ngram-max-trie-depth</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Maximum suffix length matched by external suffix automata without increasing trie depth</td>
     </tr>
     <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-ngram-capacity</code></td>

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -22,6 +22,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
   NgramCorpusObj(
       int64_t capacity,
       int64_t max_trie_depth,
+      int64_t max_sam_match_depth,
       int64_t min_bfs_breadth,
       int64_t max_bfs_breadth,
       int64_t draft_token_num,
@@ -32,6 +33,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     param.enable = true;
     param.enable_router_mode = false;
     param.max_trie_depth = static_cast<size_t>(max_trie_depth);
+    param.max_sam_match_depth = static_cast<size_t>(max_sam_match_depth);
     param.min_bfs_breadth = static_cast<size_t>(min_bfs_breadth);
     param.max_bfs_breadth = static_cast<size_t>(max_bfs_breadth);
     param.draft_token_num = static_cast<size_t>(draft_token_num);
@@ -155,7 +157,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
 void register_ngram_corpus() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<NgramCorpusObj>()
-      .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
+      .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)
       .def("erase_match_state", &NgramCorpusObj::erase_match_state)

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
@@ -20,6 +20,7 @@ struct Param {
   size_t min_bfs_breadth;
   size_t max_bfs_breadth;
   size_t max_trie_depth;
+  size_t max_sam_match_depth;
   size_t draft_token_num;
   size_t external_sam_budget = 0;
   size_t external_corpus_max_tokens = 10000000;
@@ -95,8 +96,8 @@ struct Param {
     std::stringstream ss;
     ss << "enable = " << enable << ", enable_router_mode = " << enable_router_mode
        << ", min_bfs_breadth = " << min_bfs_breadth << ", max_bfs_breadth = " << max_bfs_breadth
-       << ", max_trie_depth = " << max_trie_depth << ", draft_token_num = " << draft_token_num
-       << ", external_sam_budget = " << external_sam_budget
+       << ", max_trie_depth = " << max_trie_depth << ", max_sam_match_depth = " << max_sam_match_depth
+       << ", draft_token_num = " << draft_token_num << ", external_sam_budget = " << external_sam_budget
        << ", external_corpus_max_tokens = " << external_corpus_max_tokens << ", match_type = " << match_type;
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
@@ -181,7 +181,7 @@ std::vector<SamAnchor> SuffixAutomaton::match(const int32_t* context, size_t len
 Result SuffixAutomaton::buildRecency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
   auto anchors = match(context, len, param.max_sam_match_depth);
-  const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_sam_match_depth) - 1);
+  const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_trie_depth) - 1);
   const double bfs_breadth_scale = double(param.max_bfs_breadth - param.min_bfs_breadth) / max_match_depth;
   std::vector<Node> tree(draft_token_num + 1);
   int root = 0;
@@ -189,8 +189,9 @@ Result SuffixAutomaton::buildRecency(
 
   for (const auto& anchor : anchors) {
     std::queue<std::tuple<int, double, int>> queue;
+    const auto breadth_match_depth = std::min<int32_t>(anchor.matched_len, max_match_depth);
     queue.push(
-        {root, (max_match_depth - anchor.matched_len) * bfs_breadth_scale + param.min_bfs_breadth, anchor.state});
+        {root, (max_match_depth - breadth_match_depth) * bfs_breadth_scale + param.min_bfs_breadth, anchor.state});
     while (!queue.empty() && cursor <= static_cast<int>(draft_token_num)) {
       auto [parent, cur_breadth, state] = queue.front();
       queue.pop();

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
@@ -180,8 +180,8 @@ std::vector<SamAnchor> SuffixAutomaton::match(const int32_t* context, size_t len
 
 Result SuffixAutomaton::buildRecency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
-  auto anchors = match(context, len, param.max_trie_depth);
-  const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_trie_depth - 1));
+  auto anchors = match(context, len, param.max_sam_match_depth);
+  const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_sam_match_depth) - 1);
   const double bfs_breadth_scale = double(param.max_bfs_breadth - param.min_bfs_breadth) / max_match_depth;
   std::vector<Node> tree(draft_token_num + 1);
   int root = 0;
@@ -216,7 +216,7 @@ Result SuffixAutomaton::buildRecency(
 
 Result SuffixAutomaton::buildFrequency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
-  auto anchors = match(context, len, param.max_trie_depth);
+  auto anchors = match(context, len, param.max_sam_match_depth);
   struct CompareByProb {
     bool operator()(
         const std::tuple<int, int32_t, int, double>& lhs, const std::tuple<int, int32_t, int, double>& rhs) const {

--- a/python/sglang/kernels/ops/speculative/ngram_corpus.py
+++ b/python/sglang/kernels/ops/speculative/ngram_corpus.py
@@ -46,6 +46,7 @@ def get_ngram_corpus_cls():
             self,
             capacity: int,
             max_trie_depth: int,
+            max_sam_match_depth: int,
             min_bfs_breadth: int,
             max_bfs_breadth: int,
             draft_token_num: int,
@@ -61,6 +62,7 @@ def get_ngram_corpus_cls():
             self.__ffi_init__(
                 capacity,
                 max_trie_depth,
+                max_sam_match_depth,
                 min_bfs_breadth,
                 max_bfs_breadth,
                 draft_token_num,

--- a/python/sglang/srt/arg_groups/field_order.py
+++ b/python/sglang/srt/arg_groups/field_order.py
@@ -301,6 +301,7 @@ POSITIONAL_FIELD_ORDER = (
     "speculative_ngram_max_bfs_breadth",
     "speculative_ngram_match_type",
     "speculative_ngram_max_trie_depth",
+    "speculative_ngram_max_sam_match_depth",
     "speculative_ngram_capacity",
     "speculative_ngram_external_corpus_path",
     "speculative_ngram_external_sam_budget",

--- a/python/sglang/srt/arg_groups/fields/spec.py
+++ b/python/sglang/srt/arg_groups/fields/spec.py
@@ -242,6 +242,10 @@ class Spec:
         int,
         "The max trie depth for ngram speculative decoding.",
     ] = 18
+    speculative_ngram_max_sam_match_depth: A[
+        Optional[int],
+        "The maximum suffix match length for external SAMs in ngram speculative decoding. Defaults to --speculative-ngram-max-trie-depth.",
+    ] = None
     speculative_ngram_capacity: A[
         int,
         "The cache capacity for ngram speculative decoding.",

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -1014,6 +1014,16 @@ def _handle_ngram(server_args: ServerArgs) -> None:
         "_handle_ngram",
         speculative_eagle_topk=cfg.speculative_ngram_max_bfs_breadth,
     )
+    max_sam_match_depth = cfg.speculative_ngram_max_sam_match_depth
+    if max_sam_match_depth is None:
+        max_sam_match_depth = cfg.speculative_ngram_max_trie_depth
+        declare_resolution(
+            server_args,
+            "_handle_ngram",
+            speculative_ngram_max_sam_match_depth=max_sam_match_depth,
+        )
+    if max_sam_match_depth <= 0:
+        raise ValueError("--speculative-ngram-max-sam-match-depth must be positive.")
     if cfg.speculative_num_draft_tokens is None:
         declare_resolution(
             server_args,

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -15,6 +15,7 @@ class NgramCorpus:
     def __init__(
         self,
         max_trie_depth=18,
+        max_sam_match_depth=None,
         min_bfs_breadth=1,
         max_bfs_breadth=8,
         draft_token_num=8,
@@ -23,10 +24,13 @@ class NgramCorpus:
         external_sam_budget=0,
         external_corpus_max_tokens=10000000,
     ) -> None:
+        if max_sam_match_depth is None:
+            max_sam_match_depth = max_trie_depth
         cls = get_ngram_corpus_cls()
         self._obj = cls(
             capacity=capacity,
             max_trie_depth=max_trie_depth,
+            max_sam_match_depth=max_sam_match_depth,
             min_bfs_breadth=min_bfs_breadth,
             max_bfs_breadth=max_bfs_breadth,
             draft_token_num=draft_token_num,

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -99,6 +99,10 @@ class NGRAMWorker(BaseSpecWorker):
         self.page_size = get_schedule().page_size
         self.draft_token_num: int = get_spec().speculative_num_draft_tokens
         self.max_trie_depth: int = get_spec().speculative_ngram_max_trie_depth
+        self.max_match_depth: int = max(
+            self.max_trie_depth,
+            get_spec().speculative_ngram_max_sam_match_depth,
+        )
         self.speculative_num_draft_tokens = get_spec().speculative_num_draft_tokens
         self.topk = get_spec().speculative_eagle_topk
         self.speculative_num_steps = get_spec().speculative_num_steps
@@ -118,6 +122,7 @@ class NGRAMWorker(BaseSpecWorker):
             match_type=get_spec().speculative_ngram_match_type,
             capacity=get_spec().speculative_ngram_capacity,
             max_trie_depth=get_spec().speculative_ngram_max_trie_depth,
+            max_sam_match_depth=get_spec().speculative_ngram_max_sam_match_depth,
             draft_token_num=get_spec().speculative_num_draft_tokens,
             external_sam_budget=get_spec().speculative_ngram_external_sam_budget,
             external_corpus_max_tokens=get_spec().speculative_ngram_external_corpus_max_tokens,
@@ -254,13 +259,14 @@ class NGRAMWorker(BaseSpecWorker):
 
         # Accept-independent prep, hoisted above the blocking .cpu() below.
         req_ids = [req.rid for req in batch.reqs]
-        # Only the last max_trie_depth tokens can match; the ids are
-        # array.array, so list() the tails for list concat below.
+        # Trie and SAM cap their own matches independently. Preserve enough
+        # context for both; the ids are array.array, so list() the tails for
+        # list concat below.
         input_tails = [
-            list(req.origin_input_ids[-self.max_trie_depth :]) for req in batch.reqs
+            list(req.origin_input_ids[-self.max_match_depth :]) for req in batch.reqs
         ]
         output_tails = [
-            list(req.output_ids[-self.max_trie_depth :]) for req in batch.reqs
+            list(req.output_ids[-self.max_match_depth :]) for req in batch.reqs
         ]
         base_lens = [
             len(req.origin_input_ids) + len(req.output_ids) for req in batch.reqs
@@ -296,7 +302,7 @@ class NGRAMWorker(BaseSpecWorker):
             check_token = self._efficient_concat_last_n(
                 input_tails[i],
                 output_tails[i] + prev_tokens,
-                self.max_trie_depth,
+                self.max_match_depth,
             )
             batch_tokens.append(check_token)
             total_lens.append(base_lens[i] + len(prev_tokens))

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1520,6 +1520,7 @@ class TestNgramExternalSamArgs(CustomTestCase):
         args.speculative_algorithm = "NGRAM"
         args.speculative_num_draft_tokens = 12
         args.device = "cuda"
+        args.page_size = 1
         for key, value in overrides.items():
             setattr(args, key, value)
         return args
@@ -1533,6 +1534,37 @@ class TestNgramExternalSamArgs(CustomTestCase):
         with self.assertRaises(ValueError) as context:
             handle_speculative_decoding(args)
         self.assertIn("speculative_num_draft_tokens - 1", str(context.exception))
+
+    def test_sam_match_depth_defaults_to_trie_depth(self):
+        args = self._make_dummy_ngram_args(
+            speculative_ngram_max_trie_depth=32,
+        )
+        handle_speculative_decoding(args)
+        self.assertEqual(
+            resolution_result(args, "speculative_ngram_max_sam_match_depth"), 32
+        )
+
+    def test_sam_match_depth_must_be_positive(self):
+        args = self._make_dummy_ngram_args(
+            speculative_ngram_max_sam_match_depth=0,
+        )
+        with self.assertRaisesRegex(ValueError, "max-sam-match-depth"):
+            handle_speculative_decoding(args)
+
+    def test_sam_match_depth_cli_flag_round_trip(self):
+        args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--speculative-algorithm",
+                "NGRAM",
+                "--speculative-ngram-max-sam-match-depth",
+                "64",
+            ]
+        )
+        self.assertEqual(
+            resolution_result(args, "speculative_ngram_max_sam_match_depth"), 64
+        )
 
     def test_external_corpus_max_tokens_must_be_positive(self):
         args = self._make_dummy_ngram_args(

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -576,6 +576,31 @@ class TestNgramCorpusIncremental(CustomTestCase):
 class TestNgramCorpusExternalSam(CustomTestCase):
     """Verify external SAM loading and fixed-budget composition."""
 
+    def test_sam_match_depth_is_independent_of_trie_depth(self):
+        documents = [
+            [101, 1, 2, 3, 4, 10],
+            [202, 1, 2, 3, 4, 20],
+        ]
+        common_kwargs = dict(
+            draft_token_num=2,
+            max_trie_depth=4,
+            min_bfs_breadth=1,
+            max_bfs_breadth=1,
+            external_sam_budget=1,
+            external_corpus_documents=documents,
+        )
+
+        legacy_depth = _make_corpus("BFS", **common_kwargs)
+        expanded_depth = _make_corpus("BFS", max_sam_match_depth=5, **common_kwargs)
+
+        # The four-token suffix is shared, so recency selects the second
+        # document. The preceding token disambiguates the first document only
+        # when SAM is allowed to match beyond max_trie_depth.
+        legacy_ids, _ = _batch_get(legacy_depth, [[101, 1, 2, 3, 4]])
+        expanded_ids, _ = _batch_get(expanded_depth, [[101, 1, 2, 3, 4]])
+        self.assertEqual(legacy_ids.tolist(), [4, 20])
+        self.assertEqual(expanded_ids.tolist(), [4, 10])
+
     def test_external_corpus_iterator_streams_documents(self):
         corpus = _make_corpus(
             "BFS",


### PR DESCRIPTION
## Motivation

Part of the NGRAM speculative decoding roadmap: #21052.

External SAM matching is currently capped by `max_trie_depth` in both the Python worker and the C++ suffix automaton. This prevents SAM from using a longer context independently of Trie depth.

## Modifications

- Add `--speculative-ngram-max-sam-match-depth`.
- Default it to `--speculative-ngram-max-trie-depth` for backward compatibility.
- Preserve enough request context for both Trie and SAM matching.
- Use the independent SAM depth in both BFS and PROB matching.
- Keep Trie insertion and matching capped by `max_trie_depth`.
- Add argument validation, unit tests, and documentation.

## Accuracy Tests

Verify with these tests locally:

```bash
pytest test/registered/unit/server_args/test_server_args.py::TestNgramExternalSamArgs
pytest test/registered/unit/spec/test_ngram_corpus.py
pytest test/registered/spec/test_ngram_speculative_decoding.py
```

### Local E2E

Tested with Qwen3-0.6B on one NVIDIA RTX 4090.

The corpus contains two entries with similar context that require a longer SAM match to disambiguate:

```text
France is a country whose capital city is Paris
Germany is a country whose capital city is Berlin
```

Prompt:

```text
France is a country whose capital city
```

Both configurations use `max_trie_depth=7` and `max_bfs_breadth=1`.

```text
                      SAM depth 7       SAM depth 8
Target output         " is Paris, and" " is Paris, and"
Accepted drafts       0                 1
Spec accept length    1.3333            2.0
Verify count          3                 2
```

Increasing SAM depth from 7 to 8 disambiguates the France entry and drafts `Paris`, while preserving identical target output.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35716706966](https://github.com/sgl-project/sglang/actions/runs/35716706966)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35716706677](https://github.com/sgl-project/sglang/actions/runs/35716706677)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35716706910](https://github.com/sgl-project/sglang/actions/runs/35716706910)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->