### PR TITLE
[VLM] Validate EPD embedding layouts before scheduling

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -964,8 +964,8 @@ class WaitingMMRequestBase(ABC):
         return True
 
     def _finish_assemble(self, recv_embedding) -> None:
-        """get_mm_data → bind pool slot → publish onto recv_req → SUCCESS."""
-        mm_inputs = self.mm_processor.get_mm_data(
+        """Build validated mm data, bind its pool slot, then publish it."""
+        mm_inputs = self.mm_processor.get_validated_mm_data(
             _select_mm_processor_prompt(self.recv_req, self.mm_processor),
             recv_embedding,
             **self.recv_embedding_data.get_mm_extra_meta(),
@@ -1994,7 +1994,7 @@ class MMReceiverBase(ABC):
                 )
 
             recv_embedding = recv_embedding_data.get_embedding(is_concat=True)
-            return mm_processor.get_mm_data(
+            return mm_processor.get_validated_mm_data(
                 prompt,
                 recv_embedding,
                 **recv_embedding_data.get_mm_extra_meta(),

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -609,6 +609,69 @@ class BaseMultimodalProcessor(ABC):
             video_token_id=getattr(self, "VIDEO_TOKEN_ID", None),
         )
 
+    def get_validated_mm_data(
+        self,
+        prompt,
+        embeddings: Dict[Modality, torch.Tensor],
+        **kwargs,
+    ) -> MultimodalProcessorOutput:
+        """Build EPD multimodal inputs and validate the embedding layout.
+
+        Model processors may override ``get_mm_data`` to rebuild their prompt
+        layout. This shared wrapper ensures every override consumes exactly the
+        encoder rows it received before the result reaches the scheduler.
+        """
+        output = self.get_mm_data(prompt, embeddings, **kwargs)
+        self._validate_precomputed_embedding_layout(output, embeddings)
+        return output
+
+    @staticmethod
+    def _validate_precomputed_embedding_layout(
+        output: MultimodalProcessorOutput,
+        embeddings: Dict[Modality, torch.Tensor],
+    ) -> None:
+        consumed_per_modality = {modality: 0 for modality in embeddings}
+
+        for item in output.mm_items:
+            embedding = item.precomputed_embeddings
+            if not isinstance(embedding, torch.Tensor):
+                raise RuntimeError(
+                    "EPD multimodal items must contain tensor embeddings; "
+                    f"got {type(embedding).__name__} for "
+                    f"{item.modality.name.lower()}"
+                )
+
+            num_rows = embedding.shape[0]
+            if item.offsets is not None:
+                expected_rows = sum(end - start + 1 for start, end in item.offsets)
+                if num_rows != expected_rows:
+                    raise RuntimeError(
+                        "Precomputed multimodal embedding length mismatch for "
+                        f"{item.modality.name.lower()}: expected {expected_rows} "
+                        f"rows from prompt offsets, got {num_rows}"
+                    )
+
+            if item.modality not in consumed_per_modality:
+                raise RuntimeError(
+                    "EPD processor returned an unexpected embedding modality: "
+                    f"{item.modality.name.lower()}"
+                )
+            consumed_per_modality[item.modality] += num_rows
+
+        for modality, embedding in embeddings.items():
+            if not isinstance(embedding, torch.Tensor):
+                raise RuntimeError(
+                    "EPD encoder output must contain tensor embeddings; "
+                    f"got {type(embedding).__name__} for {modality.name.lower()}"
+                )
+            consumed_rows = consumed_per_modality[modality]
+            if consumed_rows != embedding.shape[0]:
+                raise RuntimeError(
+                    "Precomputed multimodal embedding consumption mismatch for "
+                    f"{modality.name.lower()}: received {embedding.shape[0]} rows, "
+                    f"consumed {consumed_rows}"
+                )
+
     def _resolve_processor(self, processor=None):
         if processor is None:
             return self._processor, self._tokenizer

--- a/python/sglang/srt/multimodal/processors/interns1pro.py
+++ b/python/sglang/srt/multimodal/processors/interns1pro.py
@@ -26,7 +26,7 @@ class InternS1_1ImageProcessor(QwenVLImageProcessor):
             MultimodalDataItem(
                 modality=Modality.IMAGE,
                 offsets=offsets,
-                precomputed_embeddings=embeddings,
+                precomputed_embeddings=embeddings[Modality.IMAGE],
             )
         ]
 

--- a/test/registered/unit/models/test_interns1pro_processor.py
+++ b/test/registered/unit/models/test_interns1pro_processor.py
@@ -1,0 +1,39 @@
+"""CPU tests for InternS1-Pro multimodal processor behavior."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+import torch
+
+from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.multimodal.processors.interns1pro import InternS1_1ImageProcessor
+
+
+def test_epd_stores_the_image_tensor_in_the_mm_item():
+    processor = object.__new__(InternS1_1ImageProcessor)
+    processor.build_input_ids = Mock(return_value=([1, 2, 3], [(1, 2)]))
+    processor.IM_START_TOKEN_ID = 10
+    processor.IM_END_TOKEN_ID = 11
+    processor.mm_tokens = SimpleNamespace(
+        image_token_id=12,
+        video_token_id=13,
+        audio_token_id=14,
+    )
+    image_embedding = torch.zeros(2, 4)
+
+    output = processor.get_validated_mm_data(
+        [1, 2, 3],
+        {Modality.IMAGE: image_embedding},
+        img_grid_thw=torch.tensor([[1, 2, 2]]),
+    )
+
+    assert output.mm_items[0].precomputed_embeddings is image_embedding
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/models/test_kimi_k25.py
+++ b/test/registered/unit/models/test_kimi_k25.py
@@ -727,7 +727,7 @@ def test_kimi_k3_epd_rebuild_uses_the_same_media_contract():
     processor._tokenizer = _Tokenizer()
     embeddings = {Modality.IMAGE: torch.arange(20, dtype=torch.float32).reshape(5, 4)}
 
-    output = processor.get_mm_data(
+    output = processor.get_validated_mm_data(
         [1, 99, 2, 99, 3],
         embeddings,
         img_grid_thw=torch.tensor([[1, 2, 6], [1, 2, 4]]),

--- a/test/registered/unit/multimodal/test_precomputed_embedding_validation.py
+++ b/test/registered/unit/multimodal/test_precomputed_embedding_validation.py
@@ -1,0 +1,90 @@
+"""Tests for the common EPD precomputed-embedding boundary."""
+
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+import unittest
+
+import torch
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalProcessorOutput,
+)
+from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
+
+
+class _StubProcessor(BaseMultimodalProcessor):
+    async def process_mm_data_async(self, *args, **kwargs):
+        raise NotImplementedError
+
+    def get_mm_data(self, prompt, embeddings, **kwargs):
+        return self.output
+
+
+def _item(modality, rows, offsets):
+    return MultimodalDataItem(
+        modality=modality,
+        offsets=offsets,
+        precomputed_embeddings=torch.zeros(rows, 4),
+    )
+
+
+class TestPrecomputedEmbeddingValidation(unittest.TestCase):
+    def setUp(self):
+        self.processor = object.__new__(_StubProcessor)
+
+    def _validate(self, items, embeddings):
+        self.processor.output = MultimodalProcessorOutput(
+            input_ids=[1, 2, 3],
+            mm_items=items,
+        )
+        return self.processor.get_validated_mm_data([], embeddings)
+
+    def test_accepts_exact_multi_item_layout(self):
+        image_embedding = torch.zeros(5, 4)
+        audio_embedding = torch.zeros(2, 4)
+        output = self._validate(
+            [
+                _item(Modality.IMAGE, 2, [(1, 2)]),
+                _item(Modality.IMAGE, 3, [(4, 6)]),
+                _item(Modality.AUDIO, 2, [(8, 9)]),
+            ],
+            {
+                Modality.IMAGE: image_embedding,
+                Modality.AUDIO: audio_embedding,
+            },
+        )
+
+        self.assertEqual(len(output.mm_items), 3)
+
+    def test_rejects_item_shorter_than_prompt_offsets(self):
+        with self.assertRaisesRegex(RuntimeError, "expected 3 rows.*got 2"):
+            self._validate(
+                [_item(Modality.IMAGE, 2, [(1, 3)])],
+                {Modality.IMAGE: torch.zeros(2, 4)},
+            )
+
+    def test_rejects_unconsumed_trailing_rows(self):
+        with self.assertRaisesRegex(RuntimeError, "received 3 rows, consumed 2"):
+            self._validate(
+                [_item(Modality.IMAGE, 2, [(1, 2)])],
+                {Modality.IMAGE: torch.zeros(3, 4)},
+            )
+
+    def test_rejects_missing_modality(self):
+        with self.assertRaisesRegex(RuntimeError, "received 2 rows, consumed 0"):
+            self._validate([], {Modality.VIDEO: torch.zeros(2, 4)})
+
+    def test_rejects_unexpected_modality(self):
+        with self.assertRaisesRegex(RuntimeError, "unexpected embedding modality"):
+            self._validate(
+                [_item(Modality.VIDEO, 2, [(1, 2)])],
+                {Modality.IMAGE: torch.zeros(2, 4)},
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Why

EPD model processors rebuild prompt-specific multimodal items from encoder embeddings. A short slice, an unconsumed trailing row, or an override that returns the wrong value can otherwise reach the scheduler and fail much later. The base-only check in #36936 does not cover K3, Qwen-VL, Kimi, MiMo, or other processors that override get_mm_data.

## What

- route both EPD receive paths through one shared validation boundary
- require each item embedding rows to match its prompt offsets
- require every modality to consume exactly all rows received from the encoder
- reject missing, extra, or non-tensor embedding payloads before publishing the request
- fix InternS1-Pro EPD to store the image tensor instead of the modality dictionary

A validation failure stays request-local: scheduler-side receive marks that request failed and releases its receive resources before TP status synchronization; tokenizer-side receive propagates the error through that request API path.

## Coverage

Adds model-independent short/long/missing/extra-modality cases plus Kimi-K3 and InternS1-Pro EPD processor coverage.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33241206019](https://github.com/sgl-project/sglang/actions/runs/33241206019)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33241205917](https://github.com/sgl-project/sglang/actions/runs/33241205917)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33241205958](https://github.com/sgl-project/sglang/actions/runs/33241205958)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->