### PR TITLE
[CI] Temporarily disable GB300 jobs

### DIFF
--- a/.github/workflows/_pr-test-stage.yml
+++ b/.github/workflows/_pr-test-stage.yml
@@ -100,8 +100,10 @@ jobs:
   run:
     name: ${{ inputs.self_name }} (${{ matrix.partition }})
     # Runs on schedule / parallel-dispatch / non-failed PR with main_package or sgl_kernel changes.
+    # Temporarily skip the broken GB300 runner before GitHub tries to allocate it.
     if: |
       always() &&
+      inputs.runner_config != '4-gpu-gb300' &&
       ((github.event_name == 'schedule' || fromJson(inputs.caller_inputs).test_parallel_dispatch == true) || (!failure() && !cancelled())) &&
       (fromJson(inputs.check_changes).main_package == 'true' || fromJson(inputs.check_changes).sgl_kernel == 'true')
     # runs-on resolved from runs_on_map; check-changes already substituted

--- a/.github/workflows/release-whl-deepgemm.yml
+++ b/.github/workflows/release-whl-deepgemm.yml
@@ -194,9 +194,10 @@ jobs:
           # - arch_label: sm120
           #   runner: 1-gpu-5090
           #   wheel_arch: x86_64
-          - arch_label: sm100-aarch64
-            runner: 4-gpu-gb300
-            wheel_arch: aarch64
+          # Temporarily disabled while the GB300 runner is unavailable.
+          # - arch_label: sm100-aarch64
+          #   runner: 4-gpu-gb300
+          #   wheel_arch: aarch64
     runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     steps:

--- a/.github/workflows/rerun-test.yml
+++ b/.github/workflows/rerun-test.yml
@@ -87,7 +87,8 @@ permissions:
 
 jobs:
   rerun-test-cuda:
-    if: inputs.mode == 'cuda'
+    # Temporarily reject reruns targeting the broken GB300 runner.
+    if: inputs.mode == 'cuda' && inputs.runs_on != '4-gpu-gb300'
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 120
     permissions:
@@ -199,7 +200,8 @@ jobs:
         if: failure()
 
   rerun-test-multimodal-gen:
-    if: inputs.mode == 'multimodal_gen'
+    # Temporarily reject reruns targeting the broken GB300 runner.
+    if: inputs.mode == 'multimodal_gen' && inputs.runs_on != '4-gpu-gb300'
     runs-on: ${{ inputs.runs_on }}
     timeout-minutes: 120
     permissions:


### PR DESCRIPTION
## Motivation

The 4-gpu-gb300 runner is currently unavailable. Prevent CI and release workflows from waiting for or allocating the broken runner until it is restored.

## Modifications

- Skip 4-gpu-gb300 in the shared CUDA stage before runner allocation, covering PR and nightly suites.
- Reject CUDA and multimodal reruns that target 4-gpu-gb300.
- Temporarily remove the GB300 aarch64 entry from the DeepGEMM CUDA 13 test matrix.
- Keep GB300 suite and test registrations intact for a small, safe rollback when the machine returns.

## Accuracy Tests

Not applicable. This PR only changes workflow scheduling and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. This PR only disables jobs assigned to an unavailable runner.

## Verification

- pre-commit on all three changed workflow files
- actionlint on all three changed workflow files
- targeted assertions: one shared guard, two rerun guards, two protected PR/nightly callers, and zero active direct GB300 runner allocations

## Checklist

- [x] Format your code according to the Format code with pre-commit guidance.
- [x] Unit tests are not applicable; temporary workflow configuration was validated with pre-commit, actionlint, and targeted assertions.
- [x] Documentation is not applicable; existing registrations remain unchanged for restoration.
- [x] Accuracy and speed benchmarks are not applicable to workflow scheduling.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33239394310](https://github.com/sgl-project/sglang/actions/runs/33239394310)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33239394241](https://github.com/sgl-project/sglang/actions/runs/33239394241)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->