### PR TITLE
[Fix] Balance NVTX ranges when forward raises

### DIFF
--- a/python/sglang/srt/utils/nvtx_pytorch_hooks.py
+++ b/python/sglang/srt/utils/nvtx_pytorch_hooks.py
@@ -284,7 +284,8 @@ class PytHooks(object):
                 continue
 
             module.register_forward_pre_hook(self.module_fwd_pre_hook)
-            module.register_forward_hook(self.module_fwd_hook)
+            # Keep the range balanced when forward exits through an exception.
+            module.register_forward_hook(self.module_fwd_hook, always_call=True)
             if module not in self.module_to_name_map:
                 self.module_to_name_map[module] = name
             else:

--- a/test/registered/unit/utils/test_nvtx_pytorch_hooks.py
+++ b/test/registered/unit/utils/test_nvtx_pytorch_hooks.py
@@ -4,6 +4,7 @@ import unittest
 from unittest.mock import patch
 
 import torch
+
 from sglang.srt.utils import nvtx_pytorch_hooks
 from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
 from sglang.test.ci.ci_register import register_cpu_ci

--- a/test/registered/unit/utils/test_nvtx_pytorch_hooks.py
+++ b/test/registered/unit/utils/test_nvtx_pytorch_hooks.py
@@ -1,0 +1,61 @@
+"""CPU-only tests for the SRT NVTX forward hooks."""
+
+import unittest
+from unittest.mock import patch
+
+import torch
+from sglang.srt.utils import nvtx_pytorch_hooks
+from sglang.srt.utils.nvtx_pytorch_hooks import PytHooks
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _ExplodingModule(torch.nn.Module):
+    def forward(self, value):
+        raise RuntimeError("forward failed")
+
+
+class TestPytHooks(CustomTestCase):
+    def test_forward_pushes_and_pops_each_registered_module(self):
+        model = torch.nn.Sequential(torch.nn.Linear(2, 2), torch.nn.ReLU())
+        PytHooks().register_hooks(model)
+
+        with (
+            patch.object(nvtx_pytorch_hooks.nvtx, "range_push") as range_push,
+            patch.object(nvtx_pytorch_hooks.nvtx, "range_pop") as range_pop,
+        ):
+            model(torch.ones(1, 2))
+
+        self.assertEqual(range_push.call_count, 3)
+        self.assertEqual(range_pop.call_count, 3)
+
+    def test_forward_exception_still_pops_nvtx_range(self):
+        """A failed forward must not leave a half-open NVTX range."""
+        model = _ExplodingModule()
+        PytHooks().register_hooks(model)
+
+        with (
+            patch.object(nvtx_pytorch_hooks.nvtx, "range_push") as range_push,
+            patch.object(nvtx_pytorch_hooks.nvtx, "range_pop") as range_pop,
+            self.assertRaisesRegex(RuntimeError, "forward failed"),
+        ):
+            model(torch.ones(1))
+
+        range_push.assert_called_once()
+        range_pop.assert_called_once()
+
+    def test_dropout_modules_remain_unregistered(self):
+        dropout = torch.nn.Dropout()
+        model = torch.nn.Sequential(dropout)
+        hooks = PytHooks()
+
+        hooks.register_hooks(model)
+
+        self.assertIn(model, hooks.module_to_name_map)
+        self.assertNotIn(dropout, hooks.module_to_name_map)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`PytHooks` pushes an NVTX range from its forward pre-hook, but its regular forward hook is skipped when `forward()` raises. This leaves a half-open NVTX range after failures such as an OOM or assertion and can corrupt the nesting of subsequent profiler ranges.

The multimodal NVTX hook implementation already protects the same lifecycle with `always_call=True`; the SRT implementation should provide the same exception safety.

Related to #20865.

## Modifications

- Register the SRT NVTX post-hook with `always_call=True` so `range_pop()` still runs when `forward()` raises.
- Add focused CPU-only tests for:
  - balanced ranges during a normal nested forward;
  - balanced ranges when forward raises;
  - preservation of the existing Dropout skip behavior.

No server, model weights, network access, GPU, or real NVTX calls are required by the tests.

## Accuracy Tests

Not applicable. This change does not affect model outputs.

## Speed Tests and Profiling

Not applicable. The behavior change only affects module forwards that exit through an exception.

## Test Results

- Focused CPU tests: 3 passed using an isolated package bootstrap on Windows.
- `ruff check test/registered/unit/utils/test_nvtx_pytorch_hooks.py`: passed.
- `ruff format --check` for both changed files: passed.
- `py_compile` for both changed files: passed.
- `git diff --check`: passed.

The repository's native pytest collection is Linux-oriented and imports the Unix-only `resource` module before collecting this test, so the registered Linux CPU CI remains the authoritative full-environment run.

## Checklist

- [x] Format the changed code.
- [x] Add registered CPU unit tests.
- [x] Follow the existing SGLang code style and NVTX lifecycle precedent.
- [x] Confirm no documentation, accuracy, or speed update is required for this exception-path fix.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33721107894](https://github.com/sgl-project/sglang/actions/runs/33721107894)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33721107739](https://github.com/sgl-project/sglang/actions/runs/33721107739)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33721107939](https://github.com/sgl-project/sglang/actions/runs/33721107939)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->