### PR TITLE
feat(rust-server): support OpenAI embedding requests

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2237,7 +2237,9 @@ def _execute_server_warmup(server_args: ServerArgs):
         else:
             request_name = "/generate"
     else:
-        request_name = "/encode"
+        request_name = (
+            "/v1/embeddings" if envs.SGLANG_RUST_SERVER.get() else "/encode"
+        )
     max_new_tokens = 8 if model_info["is_generation"] else 1
     json_data = {
         "sampling_params": {
@@ -2304,6 +2306,13 @@ def _execute_server_warmup(server_args: ServerArgs):
             server_args.debug_tensor_dump_input_file
         ).tolist()
         json_data["sampling_params"]["max_new_tokens"] = 0
+
+    if envs.SGLANG_RUST_SERVER.get() and not model_info["is_generation"]:
+        embedding_input = json_data.get("input_ids", json_data.get("text"))
+        json_data = {
+            "model": model_info.get("served_model_name", get_serving().served_model_name),
+            "input": embedding_input,
+        }
 
     # Send a warmup request
     warmup_timeout = envs.SGLANG_WARMUP_TIMEOUT.get()

--- a/python/sglang/srt/managers/rust_server.py
+++ b/python/sglang/srt/managers/rust_server.py
@@ -14,6 +14,7 @@ import importlib
 import json
 import logging
 import os
+import sys
 from array import array
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Dict, FrozenSet, List, Optional, Tuple
@@ -43,7 +44,7 @@ from sglang.version import __version__
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
-    from sglang.srt.managers.io_struct import BatchTokenIDOutput
+    from sglang.srt.managers.io_struct import BatchEmbeddingOutput, BatchTokenIDOutput
     from sglang.srt.managers.scheduler import Scheduler
     from sglang.srt.rust_extensions._server import MmSpec, Server, ServerArgs
     from sglang.srt.server_args import ServerArgs
@@ -716,6 +717,82 @@ class RustServer:
                 len(rids),
             )
 
+    def push_embedding(self, payload: BatchEmbeddingOutput) -> None:
+        """Push one finished dense-embedding batch using msgpack metadata plus
+        contiguous little-endian f32 values.
+
+        Unsupported sparse/scalar/nested outputs fail their own RIDs explicitly;
+        they are never coerced into a plausible but incorrect dense vector.
+        """
+        columns = (
+            payload.rids or [],
+            payload.finished_reasons or [],
+            payload.embeddings or [],
+            payload.prompt_tokens or [],
+        )
+        sizes = [len(column) for column in columns]
+        if len(set(sizes)) != 1:
+            message = f"malformed BatchEmbeddingOutput column lengths: {sizes}"
+            for rid in columns[0]:
+                self.server.push_error(rid, message)
+            logger.error(message)
+            return
+
+        rids = []
+        reasons = []
+        prompt_tokens = []
+        lengths = []
+        values = array("f")
+        for rid, reason, embedding, tokens in zip(*columns):
+            # Scheduler validation failures carry no numeric result but do carry
+            # an abort reason/status. Preserve that terminal metadata so Rust can
+            # return the original client-facing error instead of replacing it.
+            if (
+                embedding is None
+                and isinstance(reason, dict)
+                and reason.get("type") == "abort"
+            ):
+                rids.append(rid)
+                reasons.append(reason)
+                prompt_tokens.append(tokens)
+                lengths.append(0)
+                continue
+            if not isinstance(embedding, (list, tuple, array)):
+                self.server.push_error(
+                    rid,
+                    "Rust OpenAI embeddings support dense 1-D float vectors only",
+                )
+                continue
+            if any(
+                isinstance(value, (list, tuple, dict, array)) for value in embedding
+            ):
+                self.server.push_error(
+                    rid,
+                    "Rust OpenAI embeddings do not support nested or sparse outputs",
+                )
+                continue
+            try:
+                dense = array("f", embedding)
+            except (TypeError, ValueError, OverflowError) as error:
+                self.server.push_error(rid, f"invalid dense embedding output: {error}")
+                continue
+            rids.append(rid)
+            reasons.append(reason)
+            prompt_tokens.append(tokens)
+            lengths.append(len(dense))
+            values.extend(dense)
+
+        if not rids:
+            return
+        if sys.byteorder != "little":
+            values.byteswap()
+        header = msgspec.msgpack.encode([rids, reasons, prompt_tokens, lengths])
+        if not self.server.push_embedding(header, values.tobytes()):
+            logger.warning(
+                "Rust egress closed; dropped embedding batch of %d requests during shutdown",
+                len(rids),
+            )
+
     @staticmethod
     def _build_mm_spec(spec: NativeMmSpec) -> MmSpec:
         """The typed MM handoff for ``Server.start_mm_workers``: the
@@ -788,6 +865,10 @@ class RustServer:
                 context_len=mc.context_len,
                 vocab_size=mc.vocab_size,
                 is_multimodal=mc.is_multimodal,
+                is_generation=mc.is_generation,
+                is_matryoshka=bool(mc.is_matryoshka),
+                matryoshka_dimensions=mc.matryoshka_dimensions or [],
+                hidden_size=mc.hidden_size,
                 # Resolved default sampling params (generation_config.json when
                 # `--sampling-defaults model`, {} otherwise). The rust server
                 # consumes these for omitted temperature/top_p in chat

--- a/python/sglang/srt/managers/scheduler_components/output_streamer.py
+++ b/python/sglang/srt/managers/scheduler_components/output_streamer.py
@@ -292,22 +292,24 @@ class SchedulerOutputStreamer:
                 # Non-stacked: some requests don't have PHS (None entries).
                 stacked_phs = phs_list
 
-        self.send_to_detokenizer.send_output(
-            BatchEmbeddingOutput(
-                rids=rids,
-                http_worker_ipcs=http_worker_ipcs,
-                time_stats=wrap_as_pickle(time_stats),
-                finished_reasons=finished_reasons,
-                embeddings=embeddings,
-                prompt_tokens=prompt_tokens,
-                cached_tokens=cached_tokens,
-                cached_tokens_details=cached_tokens_details,
-                placeholder_tokens_idx=None,
-                placeholder_tokens_val=None,
-                retraction_counts=retraction_counts,
-                pooled_hidden_states=stacked_phs,
-            )
+        payload = BatchEmbeddingOutput(
+            rids=rids,
+            http_worker_ipcs=http_worker_ipcs,
+            time_stats=wrap_as_pickle(time_stats),
+            finished_reasons=finished_reasons,
+            embeddings=embeddings,
+            prompt_tokens=prompt_tokens,
+            cached_tokens=cached_tokens,
+            cached_tokens_details=cached_tokens_details,
+            placeholder_tokens_idx=None,
+            placeholder_tokens_val=None,
+            retraction_counts=retraction_counts,
+            pooled_hidden_states=stacked_phs,
         )
+        if self.rust_server is not None:
+            self.rust_server.push_embedding(payload)
+        else:
+            self.send_to_detokenizer.send_output(payload)
 
 
 @dataclass(slots=True, kw_only=True)

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -3703,6 +3703,7 @@ dependencies = [
  "arc-swap",
  "async-stream",
  "axum 0.8.9",
+ "base64 0.22.1",
  "bytemuck",
  "bytes",
  "core_affinity",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -17,6 +17,7 @@ license = "Apache-2.0"
 [workspace.dependencies]
 async-stream = "0.3"
 bytes = "1"
+base64 = "0.22"
 futures = "0.3"
 pyo3 = { version = "0.29.0", features = ["extension-module"] }
 serde = { version = "1", features = ["derive"] }

--- a/rust/sglang-server/Cargo.toml
+++ b/rust/sglang-server/Cargo.toml
@@ -20,6 +20,7 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 async-stream = { workspace = true }
 bytes = { workspace = true }
+base64 = { workspace = true }
 futures = { workspace = true }
 pyo3 = { workspace = true }
 serde = { workspace = true }

--- a/rust/sglang-server/src/api_server/common.rs
+++ b/rust/sglang-server/src/api_server/common.rs
@@ -63,7 +63,8 @@ async fn await_control_result(
         // A control request never receives generation frames or service-call data.
         Some(ResponseItem::Frame(_))
         | Some(ResponseItem::Done(_))
-        | Some(ResponseItem::Data(_)) => Err((
+        | Some(ResponseItem::Data(_))
+        | Some(ResponseItem::Embedding(_)) => Err((
             StatusCode::INTERNAL_SERVER_ERROR,
             "unexpected generation output for control request",
         )
@@ -73,14 +74,21 @@ async fn await_control_result(
 }
 
 /// `GET /get_model_info` (+ `/model_info` alias) — static model metadata from
-/// `server_args` (no scheduler round-trip); `is_generation` always true.
+/// `server_args` (no scheduler round-trip).
+///
+/// Under `SGLANG_RUST_SERVER=1` this is the only `/model_info` a client can
+/// reach — `launch_server` never mounts the Python app — so it answers the same
+/// keys. It answers them from the launch blob, which is the whole of this
+/// server's config knowledge: `server_args` is parsed once at boot and held
+/// behind an `Arc`, and no route mounted here changes weights or parsers, so
+/// the launch values are also the current ones.
 async fn model_info(State(state): State<Arc<AppState>>) -> Response {
     let sa = &state.server_args;
     let body = serde_json::json!({
         "model_path": sa.model_path,
         "served_model_name": sa.served_model_name,
         "tokenizer_path": sa.tokenizer_path,
-        "is_generation": true,
+        "is_generation": sa.model_config.is_generation,
         // Python's `TokenizerManager` merges this into every request
         // (`{**preferred, **client}`); this server has no equivalent yet, so
         // `RustServer.launch` REFUSES to start when it is set. It can therefore

--- a/rust/sglang-server/src/api_server/native_api.rs
+++ b/rust/sglang-server/src/api_server/native_api.rs
@@ -31,7 +31,7 @@ use super::frame::{
 use super::guard::AbortGuard;
 use super::submit::submit;
 use crate::message::ids::Rid;
-use crate::message::request::{GenerateBody, GenerateRequest, RequestKind};
+use crate::message::request::{EmbeddingRequest, GenerateBody, GenerateRequest, RequestKind};
 use crate::message::response::{ChunkEvent, ResponseItem};
 use crate::message::sampling::SamplingParams;
 use crate::utils::{
@@ -141,27 +141,36 @@ async fn health_generate(
     // On a PD node the scheduler 400-aborts room-less requests, so inject the
     // same fake bootstrap pair Python uses (`FAKE_BOOTSTRAP_HOST` / room 0).
     let pd = state.server_args.is_disaggregation();
-    let probe = GenerateRequest {
-        // The `HEALTH_CHECK_<uuid>` rid form
-        rid: Rid::new_health_check(),
-        input_ids: Some(vec![0]),
-        // One greedy token: the cheapest round-trip that still produces a frame.
-        sampling_params: SamplingParams {
-            max_new_tokens: Some(1),
-            temperature: 0.0,
+    let rid = Rid::new_health_check();
+    let probe = if state.server_args.model_config.is_generation {
+        RequestKind::Generate(Box::new(GenerateRequest {
+            rid,
+            input_ids: Some(vec![0]),
+            // One greedy token: the cheapest round-trip that still produces a frame.
+            sampling_params: SamplingParams {
+                max_new_tokens: Some(1),
+                temperature: 0.0,
+                ..Default::default()
+            },
+            stream: false,
+            bootstrap_host: pd.then(|| FAKE_BOOTSTRAP_HOST.into()),
+            bootstrap_room: pd.then_some(0),
             ..Default::default()
-        },
-        stream: false,
-        bootstrap_host: pd.then(|| FAKE_BOOTSTRAP_HOST.into()),
-        bootstrap_room: pd.then_some(0),
-        ..Default::default()
+        }))
+    } else {
+        RequestKind::Embedding(Box::new(EmbeddingRequest::new(
+            rid,
+            None,
+            Some(vec![0]),
+            None,
+            None,
+        )))
     };
-    let (rid, _keepalive) =
-        match submit(&state, RequestKind::Generate(Box::new(probe)), false).await {
-            // Hold the receiver so the probe's sink stays open until it completes.
-            Ok(v) => v,
-            Err(resp) => return resp,
-        };
+    let (rid, _keepalive) = match submit(&state, probe, false).await {
+        // Hold the receiver so the probe's sink stays open until it completes.
+        Ok(v) => v,
+        Err(resp) => return resp,
+    };
     // Deregister on drop (never disarmed): a busy-skipped probe has no terminal
     // frame, so without this abort it leaks one detok entry per call.
     let _abort_guard = AbortGuard::new(state.senders.clone(), rid);
@@ -320,7 +329,9 @@ async fn drain_unary(
                     StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
                 return (status, error_value(code, &e.to_string()), true);
             }
-            ResponseItem::Control(_) | ResponseItem::Data(_) => continue, // never on `/generate`
+            ResponseItem::Control(_) | ResponseItem::Data(_) | ResponseItem::Embedding(_) => {
+                continue;
+            } // never on `/generate`
         }
     }
     // Sender dropped without a terminal item: the shard dropped this request (a
@@ -478,7 +489,9 @@ fn generation_event_stream(
                         timings[i].finish();
                         failed = Some(e);
                     }
-                    ResponseItem::Control(_) | ResponseItem::Data(_) => {} // never on /generate
+                    ResponseItem::Control(_)
+                    | ResponseItem::Data(_)
+                    | ResponseItem::Embedding(_) => {} // never on /generate
                 }
             }
 

--- a/rust/sglang-server/src/api_server/openai.rs
+++ b/rust/sglang-server/src/api_server/openai.rs
@@ -11,6 +11,7 @@ use tokio::sync::mpsc;
 
 mod chat;
 mod completions;
+mod embeddings;
 mod models;
 mod reasoning;
 mod template;
@@ -36,6 +37,7 @@ pub(super) fn routes() -> Router<Arc<AppState>> {
     Router::new()
         .merge(models::routes())
         .merge(completions::routes())
+        .merge(embeddings::routes())
         .merge(chat::routes())
 }
 
@@ -135,7 +137,9 @@ async fn collect_output(
                     .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
                 return Err((status, error.to_string()));
             }
-            Some(ResponseItem::Control(_)) | Some(ResponseItem::Data(_)) => {}
+            Some(ResponseItem::Control(_))
+            | Some(ResponseItem::Data(_))
+            | Some(ResponseItem::Embedding(_)) => {}
             None => {
                 return Err((
                     StatusCode::INTERNAL_SERVER_ERROR,

--- a/rust/sglang-server/src/api_server/openai/chat.rs
+++ b/rust/sglang-server/src/api_server/openai/chat.rs
@@ -596,7 +596,9 @@ pub(super) fn chat_event_stream(
                     };
                     continue;
                 }
-                ResponseItem::Control(_) | ResponseItem::Data(_) => continue,
+                ResponseItem::Control(_)
+                | ResponseItem::Data(_)
+                | ResponseItem::Embedding(_) => continue,
             };
             if let Some((code, message)) = output
                 .finish_reason

--- a/rust/sglang-server/src/api_server/openai/completions.rs
+++ b/rust/sglang-server/src/api_server/openai/completions.rs
@@ -557,7 +557,9 @@ pub(super) fn completion_event_stream(
                     yield error_payload(StatusCode::from_u16(error.http_status()).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR), error.to_string()).to_string();
                     continue;
                 }
-                ResponseItem::Control(_) | ResponseItem::Data(_) => continue,
+                ResponseItem::Control(_)
+                | ResponseItem::Data(_)
+                | ResponseItem::Embedding(_) => continue,
             };
 
             if let Some((code, message)) = output

--- a/rust/sglang-server/src/api_server/openai/embeddings.rs
+++ b/rust/sglang-server/src/api_server/openai/embeddings.rs
@@ -100,7 +100,7 @@ async fn embeddings(
             return openai_error(StatusCode::BAD_REQUEST, error.body_text(), false);
         }
     };
-    let parsed = match validate_request(request, &state) {
+    let parsed = match validate_request(request) {
         Ok(parsed) => parsed,
         Err((status, message)) => return openai_error(status, message, false),
     };
@@ -202,7 +202,7 @@ async fn embeddings(
     Json(CreateEmbeddingResponse {
         object: "list".into(),
         data,
-        model: state.server_args.served_model_name.clone(),
+        model: state.server_args.model_path.clone(),
         usage: EmbeddingUsage {
             prompt_tokens,
             total_tokens: prompt_tokens,
@@ -238,15 +238,7 @@ async fn wait_embedding(
 
 fn validate_request(
     request: CreateEmbeddingRequest,
-    state: &AppState,
 ) -> Result<ValidatedEmbeddingRequest, (StatusCode, String)> {
-    if request.model != "default" && request.model != state.server_args.served_model_name {
-        return Err((
-            StatusCode::NOT_FOUND,
-            format!("The model `{}` does not exist", request.model),
-        ));
-    }
-
     reject_unsupported_fields(&request)?;
     let (items, is_batch) = parse_input(request.input)?;
     if items.len() > *MAX_BATCH_REQS_PER_HTTP_REQ {
@@ -307,7 +299,11 @@ fn normalize_embedding_rids(
 }
 
 fn reject_unsupported_fields(request: &CreateEmbeddingRequest) -> Result<(), (StatusCode, String)> {
-    if request.lora_path.is_some() {
+    let model_selects_lora = request
+        .model
+        .split_once(':')
+        .is_some_and(|(_, adapter)| !adapter.trim().is_empty());
+    if request.lora_path.is_some() || model_selects_lora {
         return bad("LoRA embeddings are not supported by the Rust frontend");
     }
     if request.embed_override_token_id.is_some() || request.embed_overrides.is_some() {
@@ -479,8 +475,7 @@ mod tests {
             "rid": ["left-rid", "right-rid"],
         }))
         .unwrap();
-        let state = app_state(live_senders().0);
-        let validated = validate_request(request, &state).unwrap();
+        let validated = validate_request(request).unwrap();
         assert_eq!(validated.rids[0].client_facing(), "left-rid");
         assert_eq!(validated.rids[1].client_facing(), "right-rid");
     }
@@ -608,6 +603,7 @@ mod tests {
             json!({"model": "model", "input": "ok", "return_pooled_hidden_states": true}),
             json!({"model": "model", "input": [{"text": "ok"}]}),
             json!({"model": "model", "input": "ok", "lora_path": "adapter"}),
+            json!({"model": "model:adapter", "input": "ok"}),
             json!({"model": "model", "input": ["a", "b"], "rid": ["only-one"]}),
             json!({"model": "model", "input": ["a", "b"], "rid": ["same", "same"]}),
             json!({"model": "model", "input": "ok", "unknown": true}),
@@ -616,13 +612,49 @@ mod tests {
             assert_eq!(response.status(), StatusCode::BAD_REQUEST);
             assert!(body_json(response).await["error"].is_object());
         }
-        let unknown = post_json(
-            app,
-            "/v1/embeddings",
-            json!({"model": "unknown", "input": "ok"}),
-        )
-        .await;
-        assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn handler_accepts_python_model_names_and_returns_model_path() {
+        use crate::message::config::ServerArgs;
+
+        let (senders, tm_rx, _abort_rx) = live_senders();
+        let mut state = app_state(senders);
+        Arc::get_mut(&mut state).unwrap().server_args = Arc::new(ServerArgs {
+            model_path: "org/base-model".into(),
+            served_model_name: "embedding-alias".into(),
+            ..Default::default()
+        });
+        let app = routes().with_state(state);
+        let responder = tokio::spawn(async move {
+            for _ in 0..4 {
+                let TmEvent::Intake(request) = tm_rx.recv_async().await.unwrap() else {
+                    panic!("expected ingress")
+                };
+                let event = EmbeddingEvent {
+                    rid: request.rid,
+                    embedding: vec![0.5],
+                    prompt_tokens: 1,
+                    finish_reason: None,
+                };
+                let ResponseSink::Local(sink) = request.sink;
+                sink.send(ResponseItem::Embedding(event)).await.unwrap();
+            }
+        });
+
+        for body in [
+            json!({"input": "omitted model"}),
+            json!({"model": "org/base-model", "input": "model path"}),
+            json!({"model": "embedding-alias", "input": "served alias"}),
+            json!({"model": "unrelated-name", "input": "arbitrary name"}),
+        ] {
+            let response = post_json(app.clone(), "/v1/embeddings", body).await;
+            assert_eq!(response.status(), StatusCode::OK);
+            let body: CreateEmbeddingResponse =
+                serde_json::from_value(body_json(response).await).unwrap();
+            assert_eq!(body.model, "org/base-model");
+        }
+        responder.await.unwrap();
     }
 
     #[tokio::test]

--- a/rust/sglang-server/src/api_server/openai/embeddings.rs
+++ b/rust/sglang-server/src/api_server/openai/embeddings.rs
@@ -1,0 +1,687 @@
+//! OpenAI-compatible dense embedding endpoint backed by the existing Python
+//! scheduler.
+
+use std::collections::HashSet;
+use std::sync::{Arc, LazyLock};
+
+use axum::{
+    Json, Router,
+    extract::{State, rejection::JsonRejection},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::post,
+};
+use base64::Engine;
+use dynamo_protocols::types::{
+    CreateEmbeddingResponse, Embedding, EmbeddingInput, EmbeddingUsage, EmbeddingVector,
+    EncodingFormat,
+};
+use futures::{StreamExt, stream::FuturesUnordered};
+use serde::Deserialize;
+use tokio::sync::mpsc;
+
+use super::{AppState, openai_error};
+use crate::api_server::guard::AbortGuard;
+use crate::api_server::submit::submit;
+use crate::message::ids::Rid;
+use crate::message::request::{EmbeddingRequest as SchedulerEmbeddingRequest, RequestKind};
+use crate::message::response::{EmbeddingEvent, ResponseItem};
+use crate::message::types::OneOrMany;
+use crate::utils::environ::env_u64;
+
+static MAX_BATCH_REQS_PER_HTTP_REQ: LazyLock<usize> =
+    LazyLock::new(|| env_u64("SGLANG_MAX_BATCH_REQS_PER_HTTP_REQ", 4096) as usize);
+const MAX_RID_BROADCAST_BYTES: usize = 64 << 20;
+
+pub(super) fn routes() -> Router<Arc<AppState>> {
+    Router::new().route("/v1/embeddings", post(embeddings))
+}
+
+#[derive(Debug, Deserialize)]
+struct MultimodalEmbeddingInput {
+    #[allow(dead_code)]
+    text: Option<String>,
+    #[allow(dead_code)]
+    image: Option<String>,
+    #[allow(dead_code)]
+    video: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+enum EmbeddingRequestInput {
+    OpenAi(EmbeddingInput),
+    Multimodal(Vec<MultimodalEmbeddingInput>),
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateEmbeddingRequest {
+    input: EmbeddingRequestInput,
+    #[serde(default = "default_model")]
+    model: String,
+    #[serde(default)]
+    encoding_format: EncodingFormat,
+    dimensions: Option<u32>,
+    #[allow(dead_code)]
+    user: Option<String>,
+    rid: Option<OneOrMany<String>>,
+    priority: Option<i64>,
+    lora_path: Option<OneOrMany<Option<String>>>,
+    embed_override_token_id: Option<i32>,
+    embed_overrides: Option<Vec<Option<Vec<Vec<f32>>>>>,
+}
+
+fn default_model() -> String {
+    "default".into()
+}
+
+#[derive(Debug)]
+enum InputItem {
+    Text(String),
+    TokenIds(Vec<i32>),
+}
+
+struct ValidatedEmbeddingRequest {
+    items: Vec<InputItem>,
+    rids: Vec<Rid>,
+    encoding_format: EncodingFormat,
+    dimensions: Option<i64>,
+    priority: Option<i64>,
+}
+
+async fn embeddings(
+    State(state): State<Arc<AppState>>,
+    body: Result<Json<CreateEmbeddingRequest>, JsonRejection>,
+) -> Response {
+    let Json(request) = match body {
+        Ok(request) => request,
+        Err(error) => {
+            return openai_error(StatusCode::BAD_REQUEST, error.body_text(), false);
+        }
+    };
+    let parsed = match validate_request(request, &state) {
+        Ok(parsed) => parsed,
+        Err((status, message)) => return openai_error(status, message, false),
+    };
+
+    let mut guard = AbortGuard::new_empty(state.senders.clone());
+    let mut pending = FuturesUnordered::new();
+    let count = parsed.items.len();
+    for (index, (item, rid)) in parsed.items.into_iter().zip(parsed.rids).enumerate() {
+        let (text, input_ids) = match item {
+            InputItem::Text(text) => (Some(text), None),
+            InputItem::TokenIds(ids) => (None, Some(ids)),
+        };
+        let request = SchedulerEmbeddingRequest::new(
+            rid,
+            text,
+            input_ids,
+            parsed.dimensions,
+            parsed.priority,
+        );
+        let (rid, rx) = match submit(&state, RequestKind::Embedding(Box::new(request)), false).await
+        {
+            Ok(submitted) => submitted,
+            Err(_) => {
+                return openai_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "service unavailable",
+                    false,
+                );
+            }
+        };
+        guard.arm(rid.clone());
+        pending.push(wait_embedding(index, rid, rx));
+    }
+
+    let mut results: Vec<Option<EmbeddingEvent>> = (0..count).map(|_| None).collect();
+    while let Some((index, rid, result)) = pending.next().await {
+        guard.disarm(&rid);
+        let event = match result {
+            Ok(event) => event,
+            Err((status, message)) => return openai_error(status, message, false),
+        };
+        if let Some((code, message)) = event
+            .finish_reason
+            .as_ref()
+            .and_then(|reason| reason.abort_status())
+        {
+            let status = StatusCode::from_u16(code).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            return openai_error(status, message, false);
+        }
+        results[index] = Some(event);
+    }
+
+    let mut prompt_tokens = 0u32;
+    let mut data = Vec::with_capacity(count);
+    for (index, event) in results.into_iter().enumerate() {
+        let Some(event) = event else {
+            return openai_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "embedding response truncated before completion",
+                false,
+            );
+        };
+        prompt_tokens = match prompt_tokens.checked_add(event.prompt_tokens) {
+            Some(total) => total,
+            None => {
+                return openai_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "embedding token usage overflowed the OpenAI response type",
+                    false,
+                );
+            }
+        };
+        let embedding = match parsed.encoding_format {
+            EncodingFormat::Float => EmbeddingVector::Float(event.embedding),
+            EncodingFormat::Base64 => {
+                let mut bytes = Vec::with_capacity(event.embedding.len() * 4);
+                for value in event.embedding {
+                    bytes.extend_from_slice(&value.to_le_bytes());
+                }
+                EmbeddingVector::Base64(base64::engine::general_purpose::STANDARD.encode(bytes))
+            }
+        };
+        let index = match u32::try_from(index) {
+            Ok(index) => index,
+            Err(_) => {
+                return openai_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "embedding index overflowed the OpenAI response type",
+                    false,
+                );
+            }
+        };
+        data.push(Embedding {
+            object: "embedding".into(),
+            embedding,
+            index,
+        });
+    }
+    Json(CreateEmbeddingResponse {
+        object: "list".into(),
+        data,
+        model: state.server_args.served_model_name.clone(),
+        usage: EmbeddingUsage {
+            prompt_tokens,
+            total_tokens: prompt_tokens,
+        },
+    })
+    .into_response()
+}
+
+async fn wait_embedding(
+    index: usize,
+    rid: Rid,
+    mut rx: mpsc::Receiver<ResponseItem>,
+) -> (usize, Rid, Result<EmbeddingEvent, (StatusCode, String)>) {
+    let result = loop {
+        match rx.recv().await {
+            Some(ResponseItem::Embedding(event)) => break Ok(event),
+            Some(ResponseItem::Error(error)) => {
+                let status = StatusCode::from_u16(error.http_status())
+                    .unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+                break Err((status, error.to_string()));
+            }
+            Some(_) => continue,
+            None => {
+                break Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "embedding response truncated before completion".into(),
+                ));
+            }
+        }
+    };
+    (index, rid, result)
+}
+
+fn validate_request(
+    request: CreateEmbeddingRequest,
+    state: &AppState,
+) -> Result<ValidatedEmbeddingRequest, (StatusCode, String)> {
+    if request.model != "default" && request.model != state.server_args.served_model_name {
+        return Err((
+            StatusCode::NOT_FOUND,
+            format!("The model `{}` does not exist", request.model),
+        ));
+    }
+
+    reject_unsupported_fields(&request)?;
+    let (items, is_batch) = parse_input(request.input)?;
+    if items.len() > *MAX_BATCH_REQS_PER_HTTP_REQ {
+        return bad(format!(
+            "batch size {} exceeds the maximum of {}",
+            items.len(),
+            *MAX_BATCH_REQS_PER_HTTP_REQ
+        ));
+    }
+    let rids = normalize_embedding_rids(request.rid, items.len(), is_batch)?;
+
+    Ok(ValidatedEmbeddingRequest {
+        items,
+        rids,
+        encoding_format: request.encoding_format,
+        dimensions: request.dimensions.map(i64::from),
+        priority: request.priority,
+    })
+}
+
+fn normalize_embedding_rids(
+    rid: Option<OneOrMany<String>>,
+    n: usize,
+    is_batch: bool,
+) -> Result<Vec<Rid>, (StatusCode, String)> {
+    match rid {
+        None => Ok((0..n).map(|_| Rid::default()).collect()),
+        Some(OneOrMany::One(rid)) if !is_batch => Ok(vec![Rid::from_client(&rid)]),
+        Some(OneOrMany::One(rid)) => {
+            if rid.len().saturating_mul(n) > MAX_RID_BROADCAST_BYTES {
+                return bad(format!(
+                    "rid ({} bytes) broadcast to {n} inputs would exceed the \
+                     {MAX_RID_BROADCAST_BYTES}-byte limit",
+                    rid.len()
+                ));
+            }
+            Ok((0..n)
+                .map(|index| Rid::from_client(&format!("{rid}_{index}")))
+                .collect())
+        }
+        Some(OneOrMany::Many(rids)) => {
+            if !is_batch || rids.len() != n {
+                return bad(format!(
+                    "rid list length {} does not match batch size {n}",
+                    rids.len()
+                ));
+            }
+            let mut seen = HashSet::with_capacity(rids.len());
+            let duplicates: Vec<&String> = rids.iter().filter(|rid| !seen.insert(*rid)).collect();
+            if !duplicates.is_empty() {
+                return bad(format!(
+                    "duplicate request IDs detected within the request: {duplicates:?}"
+                ));
+            }
+            Ok(rids.iter().map(|rid| Rid::from_client(rid)).collect())
+        }
+    }
+}
+
+fn reject_unsupported_fields(request: &CreateEmbeddingRequest) -> Result<(), (StatusCode, String)> {
+    if request.lora_path.is_some() {
+        return bad("LoRA embeddings are not supported by the Rust frontend");
+    }
+    if request.embed_override_token_id.is_some() || request.embed_overrides.is_some() {
+        return bad("embed_overrides are not supported by the Rust frontend");
+    }
+    Ok(())
+}
+
+fn parse_input(
+    input: EmbeddingRequestInput,
+) -> Result<(Vec<InputItem>, bool), (StatusCode, String)> {
+    match input {
+        EmbeddingRequestInput::Multimodal(items) if items.is_empty() => {
+            bad("input batch cannot be empty")
+        }
+        EmbeddingRequestInput::Multimodal(_) => bad("multimodal embedding input is not supported"),
+        EmbeddingRequestInput::OpenAi(EmbeddingInput::String(text)) => {
+            validate_text(&text)?;
+            Ok((vec![InputItem::Text(text)], false))
+        }
+        EmbeddingRequestInput::OpenAi(EmbeddingInput::StringArray(texts)) => {
+            if texts.is_empty() {
+                return bad("input batch cannot be empty");
+            }
+            let items = texts
+                .into_iter()
+                .map(|text| {
+                    validate_text(&text)?;
+                    Ok(InputItem::Text(text))
+                })
+                .collect::<Result<_, _>>()?;
+            Ok((items, true))
+        }
+        EmbeddingRequestInput::OpenAi(EmbeddingInput::IntegerArray(ids)) => {
+            if ids.is_empty() {
+                return bad("token ID input cannot be empty");
+            }
+            Ok((vec![InputItem::TokenIds(convert_token_ids(ids)?)], false))
+        }
+        EmbeddingRequestInput::OpenAi(EmbeddingInput::ArrayOfIntegerArray(id_lists)) => {
+            if id_lists.is_empty() {
+                return bad("input batch cannot be empty");
+            }
+            let items = id_lists
+                .into_iter()
+                .map(|ids| {
+                    if ids.is_empty() {
+                        return bad("token ID sequences cannot be empty");
+                    }
+                    convert_token_ids(ids).map(InputItem::TokenIds)
+                })
+                .collect::<Result<_, _>>()?;
+            Ok((items, true))
+        }
+    }
+}
+
+fn convert_token_ids(ids: Vec<u32>) -> Result<Vec<i32>, (StatusCode, String)> {
+    ids.into_iter()
+        .map(|id| {
+            i32::try_from(id).map_err(|_| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    format!("token ID {id} is out of range"),
+                )
+            })
+        })
+        .collect()
+}
+
+fn validate_text(text: &str) -> Result<(), (StatusCode, String)> {
+    if text.trim().is_empty() {
+        return bad("input strings cannot be empty or whitespace-only");
+    }
+    Ok(())
+}
+
+fn bad<T>(message: impl Into<String>) -> Result<T, (StatusCode, String)> {
+    Err((StatusCode::BAD_REQUEST, message.into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::routes;
+    use super::super::test_utils::{app_state, body_json, post_json};
+    use super::*;
+    use crate::message::response::ResponseSink;
+    use crate::tokenizer_manager::wiring::{AbortSource, Senders, TmEvent};
+    use crate::utils::error::Error;
+    use serde_json::json;
+
+    fn live_senders() -> (
+        Senders,
+        flume::Receiver<TmEvent>,
+        flume::Receiver<AbortSource>,
+    ) {
+        let (tm, tm_rx) = flume::unbounded();
+        let (abort, abort_rx) = flume::unbounded();
+        let (tok, _tok_rx) = flume::unbounded();
+        (
+            Senders {
+                tok_manager_tx: tm,
+                abort_tx: abort,
+                tokenizer_tx: tok,
+                detokenizer_tx: vec![],
+            },
+            tm_rx,
+            abort_rx,
+        )
+    }
+
+    #[test]
+    fn input_shapes_are_unambiguous() {
+        let input = |value| serde_json::from_value::<EmbeddingRequestInput>(value).unwrap();
+        assert!(matches!(
+            parse_input(input(json!([1, 2, 3]))).unwrap(),
+            (items, false) if matches!(items.as_slice(), [InputItem::TokenIds(ids)] if ids == &[1, 2, 3])
+        ));
+        let (nested, nested_is_batch) = parse_input(input(json!([[1, 2], [3, 4]]))).unwrap();
+        assert_eq!(nested.len(), 2);
+        assert!(nested_is_batch);
+        let (strings, strings_are_batch) = parse_input(input(json!(["hello", "world"]))).unwrap();
+        assert_eq!(strings.len(), 2);
+        assert!(strings_are_batch);
+    }
+
+    #[test]
+    fn invalid_input_shapes_are_rejected() {
+        for value in [json!(["ok", 1]), json!([1, [2]]), json!([-1])] {
+            assert!(serde_json::from_value::<EmbeddingRequestInput>(value).is_err());
+        }
+        for value in [
+            json!([]),
+            json!("  "),
+            json!([[1], []]),
+            json!([{"image": "x"}]),
+        ] {
+            let input: EmbeddingRequestInput = serde_json::from_value(value).unwrap();
+            assert!(parse_input(input).is_err());
+        }
+    }
+
+    #[test]
+    fn request_defaults_and_extensions_are_typed() {
+        let request: CreateEmbeddingRequest = serde_json::from_value(json!({
+            "input": "hello",
+            "rid": "client-rid",
+            "priority": 7,
+        }))
+        .unwrap();
+        assert_eq!(request.model, "default");
+        assert_eq!(request.encoding_format, EncodingFormat::Float);
+        assert!(matches!(request.rid, Some(OneOrMany::One(rid)) if rid == "client-rid"));
+        assert_eq!(request.priority, Some(7));
+
+        assert!(
+            serde_json::from_value::<CreateEmbeddingRequest>(json!({
+                "input": "hello",
+                "unknown": true,
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn request_rid_list_is_normalized_per_item() {
+        let request: CreateEmbeddingRequest = serde_json::from_value(json!({
+            "input": ["left", "right"],
+            "rid": ["left-rid", "right-rid"],
+        }))
+        .unwrap();
+        let state = app_state(live_senders().0);
+        let validated = validate_request(request, &state).unwrap();
+        assert_eq!(validated.rids[0].client_facing(), "left-rid");
+        assert_eq!(validated.rids[1].client_facing(), "right-rid");
+    }
+
+    #[test]
+    fn base64_is_little_endian_f32() {
+        let values = [0.5f32, -2.0];
+        let mut bytes = Vec::new();
+        for value in values {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&bytes);
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(encoded)
+                .unwrap(),
+            bytes
+        );
+    }
+
+    #[tokio::test]
+    async fn handler_preserves_order_usage_and_float_values() {
+        let (senders, tm_rx, _abort_rx) = live_senders();
+        let app = routes().with_state(app_state(senders));
+        let responder = tokio::spawn(async move {
+            let mut requests = Vec::new();
+            for _ in 0..2 {
+                let TmEvent::Intake(request) = tm_rx.recv_async().await.unwrap() else {
+                    panic!("expected ingress")
+                };
+                let RequestKind::Embedding(embedding) = &request.kind else {
+                    panic!("expected embedding request")
+                };
+                assert_eq!(embedding.dimensions, Some(64));
+                requests.push(request);
+            }
+            assert_eq!(requests[0].rid.client_facing(), "embed-batch_0");
+            assert_eq!(requests[1].rid.client_facing(), "embed-batch_1");
+            // Deliberately complete in reverse scheduler order.
+            for (value, tokens, request) in [
+                (2.0, 5, requests.pop().unwrap()),
+                (1.0, 3, requests.pop().unwrap()),
+            ] {
+                let event = EmbeddingEvent {
+                    rid: request.rid,
+                    embedding: vec![value, value + 0.5],
+                    prompt_tokens: tokens,
+                    finish_reason: None,
+                };
+                let ResponseSink::Local(sink) = request.sink;
+                sink.send(ResponseItem::Embedding(event)).await.unwrap();
+            }
+        });
+        let response = post_json(
+            app,
+            "/v1/embeddings",
+            json!({
+                "model": "model",
+                "input": ["first", "second"],
+                "dimensions": 64,
+                "rid": "embed-batch",
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: CreateEmbeddingResponse =
+            serde_json::from_value(body_json(response).await).unwrap();
+        assert_eq!(body.model, "model");
+        assert_eq!(body.data[0].index, 0);
+        assert_eq!(
+            body.data[0].embedding,
+            EmbeddingVector::Float(vec![1.0, 1.5])
+        );
+        assert_eq!(body.data[1].index, 1);
+        assert_eq!(
+            body.data[1].embedding,
+            EmbeddingVector::Float(vec![2.0, 2.5])
+        );
+        assert_eq!(body.usage.prompt_tokens, 8);
+        assert_eq!(body.usage.total_tokens, 8);
+        responder.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn handler_base64_and_validation_errors() {
+        let (senders, tm_rx, _abort_rx) = live_senders();
+        let app = routes().with_state(app_state(senders));
+        tokio::spawn(async move {
+            let TmEvent::Intake(request) = tm_rx.recv_async().await.unwrap() else {
+                panic!("expected ingress")
+            };
+            let event = EmbeddingEvent {
+                rid: request.rid,
+                embedding: vec![0.5, -2.0],
+                prompt_tokens: 2,
+                finish_reason: None,
+            };
+            let ResponseSink::Local(sink) = request.sink;
+            sink.send(ResponseItem::Embedding(event)).await.unwrap();
+        });
+        let response = post_json(
+            app.clone(),
+            "/v1/embeddings",
+            json!({"model": "model", "input": [1, 2], "encoding_format": "base64"}),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body: CreateEmbeddingResponse =
+            serde_json::from_value(body_json(response).await).unwrap();
+        let EmbeddingVector::Base64(encoded) = &body.data[0].embedding else {
+            panic!("expected base64 embedding")
+        };
+        let decoded = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .unwrap();
+        assert_eq!(&decoded[..4], &0.5f32.to_le_bytes());
+        assert_eq!(&decoded[4..], &(-2.0f32).to_le_bytes());
+
+        for invalid in [
+            json!({"model": "model", "input": " "}),
+            json!({"model": "model", "input": ["ok", 1]}),
+            json!({"model": "model", "input": [1, [2]]}),
+            json!({"model": "model", "input": "ok", "encoding_format": "hex"}),
+            json!({"model": "model", "input": "ok", "dimensions": -1}),
+            json!({"model": "model", "input": "ok", "return_pooled_hidden_states": true}),
+            json!({"model": "model", "input": [{"text": "ok"}]}),
+            json!({"model": "model", "input": "ok", "lora_path": "adapter"}),
+            json!({"model": "model", "input": ["a", "b"], "rid": ["only-one"]}),
+            json!({"model": "model", "input": ["a", "b"], "rid": ["same", "same"]}),
+            json!({"model": "model", "input": "ok", "unknown": true}),
+        ] {
+            let response = post_json(app.clone(), "/v1/embeddings", invalid).await;
+            assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+            assert!(body_json(response).await["error"].is_object());
+        }
+        let unknown = post_json(
+            app,
+            "/v1/embeddings",
+            json!({"model": "unknown", "input": "ok"}),
+        )
+        .await;
+        assert_eq!(unknown.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn scheduler_error_aborts_other_submitted_items() {
+        let (senders, tm_rx, abort_rx) = live_senders();
+        let app = routes().with_state(app_state(senders));
+        let responder = tokio::spawn(async move {
+            let TmEvent::Intake(first) = tm_rx.recv_async().await.unwrap() else {
+                panic!("expected ingress")
+            };
+            let TmEvent::Intake(second) = tm_rx.recv_async().await.unwrap() else {
+                panic!("expected ingress")
+            };
+            let second_rid = second.rid.clone();
+            let ResponseSink::Local(sink) = first.sink;
+            sink.send(ResponseItem::Error(Error::Internal(
+                "scheduler failed".into(),
+            )))
+            .await
+            .unwrap();
+            second_rid
+        });
+        let response = post_json(
+            app,
+            "/v1/embeddings",
+            json!({"model": "model", "input": ["first", "second"]}),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+        let second_rid = responder.await.unwrap();
+        let aborted = abort_rx.recv_async().await.unwrap();
+        assert!(matches!(aborted, AbortSource::Guard(rid) if rid == second_rid));
+    }
+
+    #[tokio::test]
+    async fn client_disconnect_aborts_submitted_embedding() {
+        let (senders, tm_rx, abort_rx) = live_senders();
+        let app = routes().with_state(app_state(senders));
+        let handler = tokio::spawn(async move {
+            post_json(
+                app,
+                "/v1/embeddings",
+                json!({"model": "model", "input": "hello"}),
+            )
+            .await
+        });
+
+        let TmEvent::Intake(request) = tm_rx.recv_async().await.unwrap() else {
+            panic!("expected ingress")
+        };
+        let rid = request.rid;
+        handler.abort();
+        assert!(handler.await.unwrap_err().is_cancelled());
+
+        let aborted =
+            tokio::time::timeout(std::time::Duration::from_secs(1), abort_rx.recv_async())
+                .await
+                .expect("disconnect must trigger abort")
+                .unwrap();
+        assert!(matches!(aborted, AbortSource::Guard(aborted) if aborted == rid));
+    }
+}

--- a/rust/sglang-server/src/api_server/openai/test_utils.rs
+++ b/rust/sglang-server/src/api_server/openai/test_utils.rs
@@ -92,6 +92,7 @@ pub(super) fn chat_submitted(
 
 pub(super) fn server_args() -> Arc<ServerArgs> {
     Arc::new(ServerArgs {
+        model_path: "model".into(),
         served_model_name: "model".into(),
         ..Default::default()
     })

--- a/rust/sglang-server/src/api_server/submit.rs
+++ b/rust/sglang-server/src/api_server/submit.rs
@@ -28,6 +28,7 @@ pub(super) async fn submit(
         // Generate rids are already final: `GenerateBody::into_requests` normalized the
         // client's, or minted one. Control requests have no client-facing rid.
         RequestKind::Generate(g) => g.rid.clone(),
+        RequestKind::Embedding(e) => e.rid.clone(),
         RequestKind::Control(c) => c.rid().into(),
         // Internal service call — no client-facing rid; mint a fresh one.
         RequestKind::Detokenize { .. } => Rid::new(),

--- a/rust/sglang-server/src/lib.rs
+++ b/rust/sglang-server/src/lib.rs
@@ -185,6 +185,16 @@ impl Server {
         )
     }
 
+    /// Push a whole dense embedding batch as one columnar frame. Numeric values
+    /// are contiguous little-endian f32 bytes and never enter msgpack/PyO3 one
+    /// element at a time.
+    fn push_embedding(&self, py: Python<'_>, header: &[u8], data: PyBackedBytes) -> bool {
+        self.push_frame(
+            py,
+            crate::message::response::frame_egress_embedding(header, data.as_ref()),
+        )
+    }
+
     /// Push a control-request result. Blocks for backpressure; `False` only on
     /// shutdown.
     fn push_control_result(&self, py: Python<'_>, rid: &str, payload: &[u8]) -> bool {

--- a/rust/sglang-server/src/message/config.rs
+++ b/rust/sglang-server/src/message/config.rs
@@ -325,6 +325,14 @@ pub struct ModelConfig {
     /// in to-scheduler; `false` silently ignores mm fields, as the Python
     /// `TokenizerManager` does with `mm_processor is None`.
     pub is_multimodal: bool,
+    /// False for embedding/pooling models launched with `--is-embedding`.
+    pub is_generation: bool,
+    /// Whether the model supports truncating its embedding dimension.
+    pub is_matryoshka: bool,
+    /// Explicit dimensions accepted by the model, when configured.
+    pub matryoshka_dimensions: Vec<i64>,
+    /// Full dense embedding width, when exposed by the model config.
+    pub hidden_size: Option<u64>,
     /// Resolved default sampling parameters, from Python's
     /// `ModelConfig.get_default_sampling_params()`. Already gated on
     /// `--sampling-defaults`: holds the model's generation_config.json values
@@ -337,17 +345,25 @@ pub struct ModelConfig {
 #[pyo3::pymethods]
 impl ModelConfig {
     #[new]
-    #[pyo3(signature = (*, context_len, vocab_size, is_multimodal, default_sampling_params))]
+    #[pyo3(signature = (*, context_len, vocab_size, is_multimodal, is_generation, is_matryoshka, matryoshka_dimensions, hidden_size, default_sampling_params))]
     fn py_new(
         context_len: u64,
         vocab_size: u64,
         is_multimodal: bool,
+        is_generation: bool,
+        is_matryoshka: bool,
+        matryoshka_dimensions: Vec<i64>,
+        hidden_size: Option<u64>,
         default_sampling_params: DefaultSamplingParams,
     ) -> Self {
         Self {
             context_len,
             vocab_size,
             is_multimodal,
+            is_generation,
+            is_matryoshka,
+            matryoshka_dimensions,
+            hidden_size,
             default_sampling_params,
         }
     }
@@ -360,6 +376,10 @@ impl Default for ModelConfig {
             context_len: 2048,
             vocab_size: 1000,
             is_multimodal: false,
+            is_generation: true,
+            is_matryoshka: false,
+            matryoshka_dimensions: Vec::new(),
+            hidden_size: None,
             default_sampling_params: DefaultSamplingParams::default(),
         }
     }

--- a/rust/sglang-server/src/message/detok.rs
+++ b/rust/sglang-server/src/message/detok.rs
@@ -1,7 +1,7 @@
 //! Messages to a Detokenizer shard.
 
 use super::ids::Rid;
-use super::response::{ChunkEvent, ResponseSink};
+use super::response::{ChunkEvent, EmbeddingEvent, ResponseSink};
 
 /// Messages to a Detokenizer shard. `Register` carries the per-request sink for
 /// the shard's local `rid -> sink` map. The rid STRING is the identity: `Rid::hash`
@@ -24,6 +24,8 @@ pub enum DetokMsg {
     /// One decode step's chunks for *this shard*. Batched because `from-scheduler` blocks
     /// per send.
     Chunks(Vec<ChunkEvent>),
+    /// Terminal embedding outputs for this shard. No token decoder is involved.
+    Embeddings(Vec<EmbeddingEvent>),
     /// Decode a complete token-id sequence — the backend of
     /// [`RequestKind::Detokenize`](super::RequestKind::Detokenize), the one
     /// request kind the detok stage itself answers (it never reaches the

--- a/rust/sglang-server/src/message/io_struct.rs
+++ b/rust/sglang-server/src/message/io_struct.rs
@@ -6,7 +6,7 @@
 use bytes::Bytes;
 use serde::Serialize;
 
-use super::request::GenerateRequest;
+use super::request::{EmbeddingRequest, GenerateRequest};
 use super::sampling::SamplingParams;
 use super::types::TokenIds;
 use super::types::{Tagged, control_messages, wire_struct};
@@ -53,6 +53,48 @@ wire_struct! {
         decode_tp_size: Option<i64>,
         routed_dp_rank: Option<i64>,
         disagg_prefill_dp_rank: Option<i64>,
+    }
+}
+
+wire_struct! {
+    /// Exact positional mirror of Python's array-like
+    /// `TokenizedEmbeddingReqInput`. Do not reorder: this is a wire ABI.
+    pub(super) TokenizedEmbeddingReqInput<'a> {
+        input_text: Option<&'a str>,
+        /// Nil in msgpack; ids use the ring's raw int64 column.
+        input_ids: (),
+        mm_inputs: (),
+        token_type_ids: (),
+        sampling_params: &'a SamplingParams,
+        lora_id: (),
+        positional_embed_overrides: (),
+        routed_dp_rank: (),
+        priority: Option<i64>,
+        dimensions: Option<i64>,
+        return_pooled_hidden_states: bool,
+        multi_item_delimiter_indices: (),
+        time_stats: (),
+    }
+}
+
+impl<'a> From<&'a EmbeddingRequest> for TokenizedEmbeddingReqInput<'a> {
+    fn from(req: &'a EmbeddingRequest) -> Self {
+        Self {
+            rid: &req.rid,
+            input_text: req.text.as_deref(),
+            input_ids: (),
+            mm_inputs: (),
+            token_type_ids: (),
+            sampling_params: &req.sampling_params,
+            lora_id: (),
+            positional_embed_overrides: (),
+            routed_dp_rank: (),
+            priority: req.priority,
+            dimensions: req.dimensions,
+            return_pooled_hidden_states: false,
+            multi_item_delimiter_indices: (),
+            time_stats: (),
+        }
     }
 }
 
@@ -138,6 +180,36 @@ impl AbortReq {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::message::ids::Rid;
+
+    #[test]
+    fn embedding_header_matches_python_positional_abi() {
+        let req = EmbeddingRequest::new(
+            Rid::from_client("embd-r1"),
+            Some("hello".into()),
+            Some(vec![1, 2]),
+            Some(128),
+            Some(7),
+        );
+        let bytes = TokenizedEmbeddingReqInput::from(&req).encode().unwrap();
+        let value = rmpv::decode::read_value(&mut &bytes[..]).unwrap();
+        let a = value.as_array().unwrap();
+        assert_eq!(a.len(), 16);
+        assert_eq!(a[0].as_str(), Some("TokenizedEmbeddingReqInput"));
+        assert_eq!(a[1].as_str(), Some(req.rid.as_str()));
+        assert!(a[2].is_nil());
+        assert_eq!(a[3].as_str(), Some("hello"));
+        assert!(a[4].is_nil(), "input_ids must remain columnar");
+        assert!(a[5].is_nil());
+        assert!(a[6].is_nil());
+        let sampling = a[7].as_array().unwrap();
+        assert_eq!(sampling.last().and_then(|v| v.as_bool()), Some(true));
+        assert_eq!(a[11].as_i64(), Some(7));
+        assert_eq!(a[12].as_i64(), Some(128));
+        assert_eq!(a[13].as_bool(), Some(false));
+        assert!(a[14].is_nil());
+        assert!(a[15].is_nil());
+    }
 
     #[test]
     fn abort_req_msgpack_shape() {

--- a/rust/sglang-server/src/message/request.rs
+++ b/rust/sglang-server/src/message/request.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use itertools::izip;
 use serde::Deserialize;
 
-use super::io_struct::{ControlRequest, TokenizedGenerateReqInput};
+use super::io_struct::{ControlRequest, TokenizedEmbeddingReqInput, TokenizedGenerateReqInput};
 use super::response::ResponseSink;
 use super::sampling::{SamplingParams, SamplingParamsInput};
 use super::types::{OneOrMany, OneOrManyItem, TokenIds};
@@ -573,6 +573,9 @@ pub struct SchedulerRequest {
 pub enum RequestKind {
     /// `/generate`: tokenize (if needed) then push a `TokenizedGenerateReqInput`.
     Generate(Box<GenerateRequest>),
+    /// `/v1/embeddings`: tokenize (if needed), then push a real
+    /// `TokenizedEmbeddingReqInput` to the existing Python scheduler.
+    Embedding(Box<EmbeddingRequest>),
     /// A control endpoint (e.g. `/server_info`, `/health`): no tokenization, and
     /// the response is a single non-streamed JSON result.
     Control(Box<ControlRequest>),
@@ -583,6 +586,63 @@ pub enum RequestKind {
     /// (the raw UTF-8 text). First caller: `/v1/completions` `echo` for
     /// token-id prompts; a future `/detokenize` parity endpoint maps 1:1.
     Detokenize { token_ids: TokenIds },
+}
+
+/// One item of an OpenAI embedding request. Batch requests are fanned out at
+/// the HTTP boundary so every item has its own scheduler lifecycle and RID.
+#[derive(Debug)]
+pub struct EmbeddingRequest {
+    pub rid: Rid,
+    pub text: Option<String>,
+    pub input_ids: Option<TokenIds>,
+    pub dimensions: Option<i64>,
+    pub priority: Option<i64>,
+    /// Scheduler ABI filler. Embeddings do not sample, but the Python request
+    /// struct requires a SamplingParams value with zero generated tokens.
+    pub sampling_params: SamplingParams,
+}
+
+impl EmbeddingRequest {
+    pub fn new(
+        rid: Rid,
+        text: Option<String>,
+        input_ids: Option<TokenIds>,
+        dimensions: Option<i64>,
+        priority: Option<i64>,
+    ) -> Self {
+        Self {
+            rid,
+            text,
+            input_ids,
+            dimensions,
+            priority,
+            sampling_params: SamplingParams {
+                max_new_tokens: Some(0),
+                // The Rust ingress intentionally skips generation normalization.
+                // Keep Python's msgspec __post_init__ from resetting the already
+                // materialized internal stop lists back to None on decode.
+                is_normalized: true,
+                ..Default::default()
+            },
+        }
+    }
+
+    pub fn already_tokenized(&self) -> bool {
+        self.input_ids.as_ref().is_some_and(|ids| !ids.is_empty())
+    }
+
+    pub fn encode_header(&self) -> Result<Bytes, Error> {
+        TokenizedEmbeddingReqInput::from(self).encode()
+    }
+
+    pub fn encode_data_buf(&self) -> Bytes {
+        let ids = self.input_ids.as_deref().unwrap_or(&[]);
+        let mut buf = Vec::with_capacity(ids.len() * 8);
+        for &id in ids {
+            buf.extend_from_slice(&(id as i64).to_le_bytes());
+        }
+        Bytes::from(buf)
+    }
 }
 
 /// A single in-flight `/generate` request (per-item from

--- a/rust/sglang-server/src/message/response.rs
+++ b/rust/sglang-server/src/message/response.rs
@@ -58,6 +58,8 @@ pub enum ResponseItem {
     /// client-bound JSON like `Control` and not a generation frame. Generation
     /// and control drains never see it.
     Data(Bytes),
+    /// One terminal dense embedding. It bypasses token decoding entirely.
+    Embedding(EmbeddingEvent),
     /// Terminal failure: handler emits an error frame (stream) or status (unary).
     Error(Error),
 }
@@ -71,6 +73,104 @@ pub const DISPATCH_TAG_BATCH: u8 = 2;
 /// A per-request failure `[rid, message]`: the Python drain couldn't decode a
 /// header, so it routes a 400 back to that request instead of crashing the loop.
 pub const DISPATCH_TAG_ERROR: u8 = 3;
+/// Dense embedding batch: compact msgpack metadata plus contiguous LE f32 data.
+pub const DISPATCH_TAG_EMBEDDING: u8 = 4;
+
+#[derive(Debug, Clone)]
+pub struct EmbeddingEvent {
+    pub rid: Rid,
+    pub embedding: Vec<f32>,
+    pub prompt_tokens: u32,
+    pub finish_reason: Option<FinishReason>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct EmbeddingHeader {
+    pub rids: Vec<String>,
+    pub finished_reasons: Vec<Option<FinishReason>>,
+    pub prompt_tokens: Vec<u32>,
+    pub embedding_lengths: Vec<u32>,
+}
+
+/// Frame an embedding batch without putting vectors through msgpack.
+pub fn frame_egress_embedding(header: &[u8], data: &[u8]) -> Bytes {
+    let mut buf = Vec::with_capacity(1 + 4 + header.len() + data.len());
+    buf.push(DISPATCH_TAG_EMBEDDING);
+    buf.extend_from_slice(&(header.len() as u32).to_le_bytes());
+    buf.extend_from_slice(header);
+    buf.extend_from_slice(data);
+    Bytes::from(buf)
+}
+
+/// Strict, atomic decoder for a columnar dense-embedding frame (tag stripped).
+/// The callback is invoked only after the entire header and data buffer validate.
+pub fn for_each_embedding(body: &[u8], mut route: impl FnMut(EmbeddingEvent)) -> Decoded {
+    let mut decoded = Decoded::default();
+    if body.len() < 4 {
+        return decoded;
+    }
+    let hlen = u32::from_le_bytes([body[0], body[1], body[2], body[3]]) as usize;
+    let Some(header_bytes) = body.get(4..4usize.saturating_add(hlen)) else {
+        return decoded;
+    };
+    let mut header = match rmp_serde::from_slice::<EmbeddingHeader>(header_bytes) {
+        Ok(header) => header,
+        Err(_) => {
+            decoded.rids = recover_rids(header_bytes);
+            return decoded;
+        }
+    };
+    let n = header.rids.len();
+    decoded.rids = header
+        .rids
+        .iter()
+        .map(|rid| Rid::from(rid.as_str()))
+        .collect();
+    if header.finished_reasons.len() != n
+        || header.prompt_tokens.len() != n
+        || header.embedding_lengths.len() != n
+    {
+        return decoded;
+    }
+    let Some(values) = header
+        .embedding_lengths
+        .iter()
+        .try_fold(0usize, |sum, &len| sum.checked_add(len as usize))
+    else {
+        return decoded;
+    };
+    let Some(expected_bytes) = values.checked_mul(4) else {
+        return decoded;
+    };
+    let data = &body[4 + hlen..];
+    if data.len() != expected_bytes {
+        return decoded;
+    }
+
+    // Validate and materialize everything before routing any item.
+    let mut events = Vec::with_capacity(n);
+    let mut offset = 0usize;
+    for i in 0..n {
+        let Some(embedding) = take_f32(data, &mut offset, header.embedding_lengths[i] as usize)
+        else {
+            return decoded;
+        };
+        events.push(EmbeddingEvent {
+            rid: std::mem::take(&mut header.rids[i]).into(),
+            embedding,
+            prompt_tokens: header.prompt_tokens[i],
+            finish_reason: header.finished_reasons[i].take(),
+        });
+    }
+    if offset != data.len() {
+        return decoded;
+    }
+    for event in events {
+        route(event);
+    }
+    decoded.ok = true;
+    decoded
+}
 
 /// Read `n` little-endian f32s from `data` at `*off`, advancing `*off`. `None` when
 /// the range runs past the buffer (a malformed / positional-ABI-drifted frame): the
@@ -629,6 +729,70 @@ mod tests {
         );
         assert_eq!(&multi[5..8], &header); // header
         assert_eq!(&multi[8..], &[10, 11, 12, 13, 14]); // columns end-to-end
+    }
+
+    fn embedding_frame(lengths: Vec<u32>, values: &[f32]) -> Bytes {
+        let header = EmbeddingHeader {
+            rids: (0..lengths.len()).map(|i| format!("e{i}")).collect(),
+            finished_reasons: vec![None; lengths.len()],
+            prompt_tokens: (0..lengths.len()).map(|i| i as u32 + 1).collect(),
+            embedding_lengths: lengths,
+        };
+        let encoded = rmp_serde::to_vec(&header).unwrap();
+        let mut data = Vec::with_capacity(values.len() * 4);
+        for value in values {
+            data.extend_from_slice(&value.to_le_bytes());
+        }
+        frame_egress_embedding(&encoded, &data)
+    }
+
+    #[test]
+    fn embedding_round_trip_and_ragged_lengths() {
+        let frame = embedding_frame(vec![2, 1], &[0.5, -2.0, 7.0]);
+        let mut events = Vec::new();
+        let decoded = for_each_embedding(&frame[1..], |event| events.push(event));
+        assert!(decoded.ok);
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0].rid.as_str(), "e0");
+        assert_eq!(events[0].embedding, vec![0.5, -2.0]);
+        assert_eq!(events[0].prompt_tokens, 1);
+        assert_eq!(events[1].embedding, vec![7.0]);
+        assert_eq!(events[1].prompt_tokens, 2);
+    }
+
+    #[test]
+    fn empty_embedding_is_valid() {
+        let frame = embedding_frame(vec![0], &[]);
+        let mut events = Vec::new();
+        let decoded = for_each_embedding(&frame[1..], |event| events.push(event));
+        assert!(decoded.ok);
+        assert!(events[0].embedding.is_empty());
+    }
+
+    #[test]
+    fn malformed_embedding_frame_is_atomic_and_recovers_rids() {
+        for frame in [
+            embedding_frame(vec![2, 2], &[1.0, 2.0, 3.0]),
+            embedding_frame(vec![1], &[1.0, 2.0]),
+        ] {
+            let mut delivered = 0;
+            let decoded = for_each_embedding(&frame[1..], |_| delivered += 1);
+            assert!(!decoded.ok);
+            assert_eq!(delivered, 0, "malformed frame must not partially deliver");
+            assert!(!decoded.rids.is_empty());
+        }
+
+        let header = rmp_serde::to_vec(&(
+            vec!["a", "b"],
+            vec![Option::<FinishReason>::None],
+            vec![1u32, 2],
+            vec![1u32, 1],
+        ))
+        .unwrap();
+        let frame = frame_egress_embedding(&header, &[0; 8]);
+        let decoded = for_each_embedding(&frame[1..], |_| panic!("partial delivery"));
+        assert!(!decoded.ok);
+        assert_eq!(decoded.rids, vec![Rid::from("a"), Rid::from("b")]);
     }
 
     /// A batch frame (the fast path) decodes into per-request ChunkEvents, with

--- a/rust/sglang-server/src/tokenizer_manager/detokenizer.rs
+++ b/rust/sglang-server/src/tokenizer_manager/detokenizer.rs
@@ -212,6 +212,11 @@ impl Runnable for DetokenizerWorker {
                         handle_chunk(&mut table, ev, &self.backend, &self.abort);
                     }
                 }
+                DetokMsg::Embeddings(events) => {
+                    for event in events {
+                        handle_embedding(&mut table, event);
+                    }
+                }
                 DetokMsg::Decode { rid, token_ids } => {
                     handle_decode(&mut table, &rid, &token_ids, &self.backend)
                 }
@@ -224,6 +229,18 @@ impl Runnable for DetokenizerWorker {
                 }
             }
         }
+    }
+}
+
+/// Embeddings are already final numeric results. Route through the shard only
+/// because it owns the RID table/sink, then remove the state immediately.
+fn handle_embedding(
+    table: &mut HashMap<Rid, DetokState>,
+    event: crate::message::response::EmbeddingEvent,
+) {
+    if let Some(mut state) = table.remove(&event.rid) {
+        let _ = state.sink.try_send(ResponseItem::Embedding(event));
+        state.fsm = RequestState::Completed;
     }
 }
 
@@ -437,6 +454,36 @@ fn trim_stop_str(text: &mut String, stop: &str, no_stop_trim: bool) {
 mod tests {
     use super::*;
     use tokio::sync::mpsc;
+
+    #[test]
+    fn embedding_bypasses_decode_and_consumes_rid_state() {
+        let (tx, mut rx) = mpsc::channel::<ResponseItem>(1);
+        let mut table = HashMap::new();
+        table.insert(
+            Rid::from("embedding"),
+            DetokState {
+                sink: ResponseSink::Local(tx),
+                decode_logprob_text: false,
+                no_stop_trim: false,
+                decoder: None,
+                fsm: RequestState::Queued,
+            },
+        );
+        handle_embedding(
+            &mut table,
+            crate::message::response::EmbeddingEvent {
+                rid: Rid::from("embedding"),
+                embedding: vec![0.5, -1.0],
+                prompt_tokens: 3,
+                finish_reason: None,
+            },
+        );
+        assert!(!table.contains_key(&Rid::from("embedding")));
+        let ResponseItem::Embedding(event) = rx.try_recv().unwrap() else {
+            panic!("expected embedding output")
+        };
+        assert_eq!(event.embedding, vec![0.5, -1.0]);
+    }
 
     /// A non-terminal chunk that can't be delivered (sink full → client
     /// backpressure) drops the request AND aborts scheduler work — it does not

--- a/rust/sglang-server/src/tokenizer_manager/from_scheduler.rs
+++ b/rust/sglang-server/src/tokenizer_manager/from_scheduler.rs
@@ -9,7 +9,8 @@ use bytes::Bytes;
 use crate::message::detok::DetokMsg;
 use crate::message::ids::Rid;
 use crate::message::response::{
-    ChunkEvent, DISPATCH_TAG_BATCH, DISPATCH_TAG_ERROR, DISPATCH_TAG_RESULT, for_each_chunk,
+    ChunkEvent, DISPATCH_TAG_BATCH, DISPATCH_TAG_EMBEDDING, DISPATCH_TAG_ERROR,
+    DISPATCH_TAG_RESULT, EmbeddingEvent, for_each_chunk, for_each_embedding,
 };
 use crate::runtime::Runnable;
 use crate::tokenizer_manager::channel::FromSchedulerRx;
@@ -51,6 +52,8 @@ impl Runnable for Dispatcher {
         // Reused across frames (`clear` keeps capacity) — steady state allocates nothing.
         let shards = self.senders.detokenizer_tx.len();
         let mut buckets: Vec<Vec<ChunkEvent>> = (0..shards).map(|_| Vec::new()).collect();
+        let mut embedding_buckets: Vec<Vec<EmbeddingEvent>> =
+            (0..shards).map(|_| Vec::new()).collect();
 
         while let Some(bytes) = recv(self.from_scheduler_rx.receiver(), &self.shutdown) {
             let Some((&tag, body)) = bytes.split_first() else {
@@ -123,6 +126,41 @@ impl Runnable for Dispatcher {
                         }
                     }
                     // Any frame off the ring = the scheduler produced output → alive.
+                    self.activity.fetch_add(1, Ordering::Relaxed);
+                }
+                DISPATCH_TAG_EMBEDDING => {
+                    for bucket in &mut embedding_buckets {
+                        bucket.clear();
+                    }
+                    let decoded = for_each_embedding(body, |event| {
+                        embedding_buckets[event.rid.shard(shards)].push(event);
+                    });
+                    if !decoded.ok {
+                        for bucket in &mut embedding_buckets {
+                            bucket.clear();
+                        }
+                        if decoded.rids.is_empty() {
+                            tracing::error!("egress: malformed embedding frame named no requests");
+                        }
+                        for rid in decoded.rids {
+                            let shard = rid.shard(shards);
+                            let _ = self.senders.detokenizer_tx[shard].send(DetokMsg::Fail {
+                                rid,
+                                message: "internal error: malformed scheduler embedding frame"
+                                    .into(),
+                            });
+                        }
+                        continue;
+                    }
+                    for (shard, bucket) in embedding_buckets.iter_mut().enumerate() {
+                        if !bucket.is_empty()
+                            && self.senders.detokenizer_tx[shard]
+                                .send(DetokMsg::Embeddings(std::mem::take(bucket)))
+                                .is_err()
+                        {
+                            tracing::error!("egress: detok shard closed");
+                        }
+                    }
                     self.activity.fetch_add(1, Ordering::Relaxed);
                 }
                 DISPATCH_TAG_RESULT => {

--- a/rust/sglang-server/src/tokenizer_manager/to_scheduler.rs
+++ b/rust/sglang-server/src/tokenizer_manager/to_scheduler.rs
@@ -784,10 +784,10 @@ fn check_embedding_tokens(
     let input_len = ids.len() as u64 + limits.num_reserved_tokens;
     if input_len >= limits.context_len {
         if limits.allow_auto_truncate {
-            let keep = limits
-                .context_len
-                .saturating_sub(limits.num_reserved_tokens + 1) as usize;
-            ids.truncate(keep);
+            // Match Python's `_validate_one_request`: reserved tokens decide
+            // whether truncation runs, but the input itself is sliced only at
+            // `context_len` (`del input_ids[context_len:]`).
+            ids.truncate(limits.context_len as usize);
             if ids.is_empty() {
                 return Err(Error::Validation(
                     "input cannot fit the model context".into(),
@@ -1045,6 +1045,41 @@ mod tests {
             unreachable!()
         };
         assert!(check_embedding_tokens(request, &embedding_limits).is_err());
+    }
+
+    /// Embeddings request zero generated tokens, so auto-truncation must not
+    /// reserve an extra generation slot. This matches Python's
+    /// `TokenizerManager._validate_one_request`, which keeps an input already at
+    /// the context boundary when `allow_auto_truncate` is enabled.
+    #[test]
+    fn embedding_auto_truncate_keeps_the_full_context_window() {
+        for (input_len, reserved_tokens, expected_len) in [
+            (8, 0, 8), // exact context boundary remains intact
+            (9, 0, 8), // only tokens beyond context_len are removed
+            (7, 2, 7), // reserved tokens trigger the branch but do not shrink input
+            (9, 2, 8), // reserved tokens do not move the truncation boundary
+        ] {
+            let limits = Limits {
+                context_len: 8,
+                num_reserved_tokens: reserved_tokens,
+                allow_auto_truncate: true,
+                is_generation: false,
+                ..test_limits()
+            };
+            let mut request = embedding_req(Some((1..=input_len).collect()), None);
+            validate(&mut request, &limits).unwrap();
+            let RequestKind::Embedding(embedding) = &mut request.kind else {
+                unreachable!()
+            };
+
+            check_embedding_tokens(embedding, &limits).unwrap();
+
+            assert_eq!(
+                embedding.input_ids.as_ref().map(Vec::len),
+                Some(expected_len),
+                "input_len={input_len}, reserved_tokens={reserved_tokens}"
+            );
+        }
     }
 
     /// `input + max_new_tokens` past the context window is an actionable 400, not a

--- a/rust/sglang-server/src/tokenizer_manager/to_scheduler.rs
+++ b/rust/sglang-server/src/tokenizer_manager/to_scheduler.rs
@@ -72,6 +72,10 @@ pub struct Limits {
     pub allow_auto_truncate: bool,
     /// Whether the server can produce hidden states at all.
     pub enable_return_hidden_states: bool,
+    pub is_generation: bool,
+    pub is_matryoshka: bool,
+    pub matryoshka_dimensions: Vec<i64>,
+    pub hidden_size: Option<u64>,
 }
 
 impl From<&ServerArgs> for Limits {
@@ -83,6 +87,10 @@ impl From<&ServerArgs> for Limits {
             num_reserved_tokens: sa.num_reserved_tokens,
             allow_auto_truncate: sa.allow_auto_truncate,
             enable_return_hidden_states: sa.enable_return_hidden_states,
+            is_generation: sa.model_config.is_generation,
+            is_matryoshka: sa.model_config.is_matryoshka,
+            matryoshka_dimensions: sa.model_config.matryoshka_dimensions.clone(),
+            hidden_size: sa.model_config.hidden_size,
         }
     }
 }
@@ -218,6 +226,14 @@ impl Intake {
                     RequestKind::Generate(_) => {
                         let _ = req.state.apply(Event::NeedsNormalize);
                     }
+                    RequestKind::Embedding(e) => {
+                        let outcome = if e.already_tokenized() {
+                            ValidationOutcome::AlreadyTokenized
+                        } else {
+                            ValidationOutcome::NeedsTokenize
+                        };
+                        let _ = req.state.apply(Event::Validated(outcome));
+                    }
                 },
                 // Normalize + verify sampling params (off the scheduler loop), then
                 // pick the branch; a bad param becomes `Failed`.
@@ -324,6 +340,12 @@ impl Intake {
                         let _ = req.state.apply(Event::Error(e)); // → Failed
                         continue;
                     }
+                    if let RequestKind::Embedding(e) = &mut req.kind
+                        && let Err(error) = check_embedding_tokens(e, &self.limits)
+                    {
+                        let _ = req.state.apply(Event::Error(error));
+                        continue;
+                    }
                     let _ = req.state.apply(Event::PreSendValidated); // → Queued
                 }
                 // Hand the request to the stage that answers it: the scheduler
@@ -334,6 +356,7 @@ impl Intake {
                     // discriminant and `req` can be moved into each push.
                     match req.kind {
                         RequestKind::Generate(_) => self.push_to_ring(req),
+                        RequestKind::Embedding(_) => self.push_to_ring(req),
                         RequestKind::Control(_) => self.push_control_to_ring(req),
                         RequestKind::Detokenize { .. } => self.push_detokenize_to_shard(req),
                     }
@@ -369,7 +392,9 @@ impl Intake {
                 g.return_text_in_logprobs.unwrap_or(false),
                 g.sampling_params.no_stop_trim,
             ),
-            RequestKind::Control(_) | RequestKind::Detokenize { .. } => (false, false),
+            RequestKind::Embedding(_)
+            | RequestKind::Control(_)
+            | RequestKind::Detokenize { .. } => (false, false),
         };
         self.senders
             .detok_for(&req.rid)
@@ -516,8 +541,12 @@ impl Intake {
                 .encode_header()
                 .map(|header| (header, g.encode_data_buf())),
             RequestKind::Generate(_) => Err(Error::Tokenize("empty input_ids".into())),
+            RequestKind::Embedding(e) if e.already_tokenized() => e
+                .encode_header()
+                .map(|header| (header, e.encode_data_buf())),
+            RequestKind::Embedding(_) => Err(Error::Tokenize("empty input_ids".into())),
             _ => Err(Error::Internal(
-                "non-generate request reached push_to_ring".into(),
+                "non-scheduler request reached push_to_ring".into(),
             )),
         };
         let (header, ids) = match serialized {
@@ -561,9 +590,12 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
             "rid is {client_rid_len} bytes, over the {MAX_RID_LEN}-byte limit"
         )));
     }
-    if skip_tokenizer_init
-        && matches!(&req.kind, RequestKind::Generate(g) if !g.already_tokenized())
-    {
+    let needs_tokenizer = match &req.kind {
+        RequestKind::Generate(g) => !g.already_tokenized(),
+        RequestKind::Embedding(e) => !e.already_tokenized(),
+        _ => false,
+    };
+    if skip_tokenizer_init && needs_tokenizer {
         // `Validation` (400), not `Tokenize` (500): the client sent a request this
         // server cannot serve, which is their error to fix — Python 400s it too.
         return Err(Error::Validation(
@@ -593,6 +625,53 @@ fn validate(req: &mut Request, limits: &Limits) -> Result<(), Error> {
                          {id}; valid range is [0, {vocab_size})"
                     )));
                 }
+            }
+        }
+    }
+
+    if let RequestKind::Embedding(e) = &req.kind {
+        if limits.is_generation {
+            return Err(Error::Validation(
+                "This is a generation model. Launch with `--is-embedding` to serve embedding requests."
+                    .into(),
+            ));
+        }
+        if let Some(ids) = &e.input_ids {
+            for &id in ids {
+                if id < 0 || id as u64 >= vocab_size {
+                    return Err(Error::Validation(format!(
+                        "input contains out-of-vocabulary token id {id}; valid range is [0, {vocab_size})"
+                    )));
+                }
+            }
+        }
+        if let Some(dimensions) = e.dimensions {
+            if dimensions <= 0 {
+                return Err(Error::Validation(
+                    "dimensions must be greater than 0".into(),
+                ));
+            }
+            if !limits.is_matryoshka {
+                return Err(Error::Validation(
+                    "dimensions is only supported for Matryoshka embedding models".into(),
+                ));
+            }
+            if !limits.matryoshka_dimensions.is_empty()
+                && !limits.matryoshka_dimensions.contains(&dimensions)
+            {
+                return Err(Error::Validation(format!(
+                    "dimensions must be one of {:?}",
+                    limits.matryoshka_dimensions
+                )));
+            }
+            if limits
+                .hidden_size
+                .is_some_and(|hidden| dimensions as u64 > hidden)
+            {
+                return Err(Error::Validation(format!(
+                    "dimensions ({dimensions}) cannot exceed hidden_size ({})",
+                    limits.hidden_size.unwrap()
+                )));
             }
         }
     }
@@ -689,10 +768,45 @@ fn check_total_tokens(g: &mut GenerateRequest, limits: &Limits) -> Result<(), Er
     Ok(())
 }
 
+fn check_embedding_tokens(
+    e: &mut crate::message::request::EmbeddingRequest,
+    limits: &Limits,
+) -> Result<(), Error> {
+    let ids = e
+        .input_ids
+        .as_mut()
+        .ok_or_else(|| Error::Tokenize("empty input_ids".into()))?;
+    if ids.is_empty() {
+        return Err(Error::Validation(
+            "input cannot tokenize to an empty sequence".into(),
+        ));
+    }
+    let input_len = ids.len() as u64 + limits.num_reserved_tokens;
+    if input_len >= limits.context_len {
+        if limits.allow_auto_truncate {
+            let keep = limits
+                .context_len
+                .saturating_sub(limits.num_reserved_tokens + 1) as usize;
+            ids.truncate(keep);
+            if ids.is_empty() {
+                return Err(Error::Validation(
+                    "input cannot fit the model context".into(),
+                ));
+            }
+        } else {
+            return Err(Error::Validation(format!(
+                "The input ({input_len} tokens) is longer than the model's context length ({} tokens).",
+                limits.context_len
+            )));
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::message::request::GenerateRequest;
+    use crate::message::request::{EmbeddingRequest, GenerateRequest};
     use crate::message::response::ResponseSink;
     use crate::message::sampling::SamplingParams;
     use crate::tokenizer_manager::channel::{ToSchedulerRx, to_scheduler};
@@ -851,6 +965,10 @@ mod tests {
             num_reserved_tokens: 0,
             allow_auto_truncate: false,
             enable_return_hidden_states: false,
+            is_generation: true,
+            is_matryoshka: false,
+            matryoshka_dimensions: Vec::new(),
+            hidden_size: None,
         }
     }
 
@@ -867,6 +985,66 @@ mod tests {
                 ..Default::default()
             })),
         }
+    }
+
+    fn embedding_req(ids: Option<Vec<i32>>, dimensions: Option<i64>) -> Request {
+        let (tx, _rx) = mpsc::channel(8);
+        let rid = Rid::from("embedding-test");
+        Request {
+            rid: rid.clone(),
+            state: RequestState::Received,
+            sink: ResponseSink::Local(tx),
+            kind: RequestKind::Embedding(Box::new(EmbeddingRequest::new(
+                rid,
+                ids.is_none().then(|| "hello world".into()),
+                ids,
+                dimensions,
+                None,
+            ))),
+        }
+    }
+
+    #[test]
+    fn embedding_model_vocab_context_and_dimensions_are_validated() {
+        let mut embedding_limits = Limits {
+            is_generation: false,
+            is_matryoshka: true,
+            matryoshka_dimensions: vec![64, 128],
+            hidden_size: Some(128),
+            context_len: 8,
+            ..test_limits()
+        };
+        let mut valid = embedding_req(Some(vec![1, 2, 3]), Some(64));
+        validate(&mut valid, &embedding_limits).unwrap();
+        let RequestKind::Embedding(request) = &mut valid.kind else {
+            unreachable!()
+        };
+        check_embedding_tokens(request, &embedding_limits).unwrap();
+        let header = request.encode_header().unwrap();
+        let value = rmpv::decode::read_value(&mut &header[..]).unwrap();
+        assert_eq!(
+            value.as_array().unwrap()[0].as_str(),
+            Some("TokenizedEmbeddingReqInput")
+        );
+
+        let mut generation_model = embedding_req(Some(vec![1]), None);
+        assert!(validate(&mut generation_model, &test_limits()).is_err());
+
+        let mut bad_id = embedding_req(Some(vec![1000]), None);
+        embedding_limits.is_matryoshka = false;
+        assert!(validate(&mut bad_id, &embedding_limits).is_err());
+
+        for dimensions in [Some(0), Some(32), Some(256)] {
+            let mut request = embedding_req(Some(vec![1]), dimensions);
+            assert!(validate(&mut request, &embedding_limits).is_err());
+        }
+
+        let mut too_long = embedding_req(Some(vec![1; 8]), None);
+        validate(&mut too_long, &embedding_limits).unwrap();
+        let RequestKind::Embedding(request) = &mut too_long.kind else {
+            unreachable!()
+        };
+        assert!(check_embedding_tokens(request, &embedding_limits).is_err());
     }
 
     /// `input + max_new_tokens` past the context window is an actionable 400, not a

--- a/rust/sglang-server/src/tokenizer_manager/tokenizer.rs
+++ b/rust/sglang-server/src/tokenizer_manager/tokenizer.rs
@@ -185,6 +185,24 @@ impl TokenizerWorker {
 impl Runnable for TokenizerWorker {
     fn run(self) {
         while let Ok(mut req) = self.rx.recv() {
+            // Embeddings share the tokenizer pool but do not run any generation
+            // normalization (stop windows or automatic-special stripping).
+            if let RequestKind::Embedding(e) = &mut req.kind {
+                let event = match self.tokenizer.encode(e.text.as_deref().unwrap_or("")) {
+                    Ok(ids) => {
+                        e.input_ids = Some(ids);
+                        Event::TokenizeDone
+                    }
+                    Err(err) => Event::Error(err),
+                };
+                let _ = req.state.apply(event);
+                if self.tm.send(TmEvent::Tokenized(req)).is_err() {
+                    tracing::error!("tm inbox closed; dropping request");
+                    break;
+                }
+                continue;
+            }
+
             // The tokenizer pool only ever receives generate requests. Encode,
             // then advance the FSM: `TokenizeDone` on success (→ PreSendValidating).
             let event = {
@@ -230,7 +248,8 @@ impl Runnable for TokenizerWorker {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::message::request::{GenerateRequest, RequestKind};
+    use crate::message::ids::Rid;
+    use crate::message::request::{EmbeddingRequest, GenerateRequest, RequestKind};
     use crate::message::response::ResponseSink;
     use crate::message::sampling::SamplingParams;
     use crate::utils::fsm::RequestState;
@@ -243,6 +262,39 @@ mod tests {
         fn encode(&self, text: &str) -> Result<TokenIds, Error> {
             Ok(text.split_whitespace().map(|_| 1i32).collect())
         }
+    }
+
+    #[test]
+    fn embedding_text_is_tokenized_without_generation_logic() {
+        let (req_tx, req_rx) = flume::unbounded::<Request>();
+        let (tm_tx, tm_rx) = flume::unbounded::<TmEvent>();
+        let worker = TokenizerWorker::new(req_rx, tm_tx, Arc::new(WordTokenizer));
+        let (sink, _source) = mpsc::channel(1);
+        let rid = Rid::from("embedding-tokenize");
+        req_tx
+            .send(Request {
+                rid: rid.clone(),
+                state: RequestState::Tokenizing,
+                sink: ResponseSink::Local(sink),
+                kind: RequestKind::Embedding(Box::new(EmbeddingRequest::new(
+                    rid,
+                    Some("hello world".into()),
+                    None,
+                    None,
+                    None,
+                ))),
+            })
+            .unwrap();
+        drop(req_tx);
+        worker.run();
+        let TmEvent::Tokenized(request) = tm_rx.recv().unwrap() else {
+            panic!("expected tokenized request")
+        };
+        assert!(matches!(request.state, RequestState::PreSendValidating));
+        let RequestKind::Embedding(embedding) = request.kind else {
+            panic!("expected embedding")
+        };
+        assert_eq!(embedding.input_ids, Some(vec![1, 1]));
     }
 
     /// The scheduler's stop-match window must reach the wire as a TOKEN count, as

--- a/rust/sglang-server/src/utils/fsm.rs
+++ b/rust/sglang-server/src/utils/fsm.rs
@@ -118,6 +118,7 @@ impl RequestState {
             // Generate requests pass through Normalizing (sampling-param
             // normalize/verify); control requests skip it, having none.
             (Validating, NeedsNormalize) => Normalizing,
+            (Validating, Validated(NeedsTokenize)) => Tokenizing,
             (Validating, Validated(AlreadyTokenized)) => PreSendValidating,
             (Normalizing, Validated(HasMultimodal)) => Encoding,
             (Normalizing, Validated(NeedsTokenize)) => Tokenizing,

--- a/test/registered/prefill_only/test_openai_embedding.py
+++ b/test/registered/prefill_only/test_openai_embedding.py
@@ -24,7 +24,7 @@ from sglang.test.test_utils import (
 
 register_cuda_ci(est_time=91, stage="base-b", runner_config="1-gpu-small")
 register_amd_ci(est_time=141, suite="stage-b-test-1-gpu-small-amd")
-register_cpu_ci(est_time=91, suite="base-c-test-cpu")
+register_cpu_ci(est_time=180, suite="base-c-test-cpu")
 
 
 class TestOpenAIEmbedding(CustomTestCase):

--- a/test/registered/prefill_only/test_openai_embedding.py
+++ b/test/registered/prefill_only/test_openai_embedding.py
@@ -1,7 +1,11 @@
+import base64
 import json
+import struct
 import unittest
+from typing import ClassVar
 
 import openai
+import requests
 
 from sglang.srt.utils import kill_process_tree
 from sglang.test.ci.ci_register import (
@@ -14,6 +18,7 @@ from sglang.test.test_utils import (
     DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
     DEFAULT_URL_FOR_TEST,
     CustomTestCase,
+    is_rust_server_built,
     popen_launch_server,
 )
 
@@ -23,6 +28,8 @@ register_cpu_ci(est_time=91, suite="base-c-test-cpu")
 
 
 class TestOpenAIEmbedding(CustomTestCase):
+    env = None
+
     @classmethod
     def setUpClass(cls):
         cls.model = DEFAULT_SMALL_EMBEDDING_MODEL_NAME_FOR_TEST
@@ -37,6 +44,7 @@ class TestOpenAIEmbedding(CustomTestCase):
             timeout=DEFAULT_TIMEOUT_FOR_SERVER_LAUNCH,
             api_key=cls.api_key,
             other_args=other_args,
+            env=cls.env,
         )
         cls.base_url += "/v1"
 
@@ -58,8 +66,31 @@ class TestOpenAIEmbedding(CustomTestCase):
             model=self.model, input=["Hello world", "Test text"]
         )
         self.assertEqual(len(response.data), 2)
+        self.assertEqual([item.index for item in response.data], [0, 1])
         self.assertTrue(len(response.data[0].embedding) > 0)
         self.assertTrue(len(response.data[1].embedding) > 0)
+        self.assertEqual(response.usage.prompt_tokens, response.usage.total_tokens)
+
+    def test_embedding_base64(self):
+        response = requests.post(
+            self.base_url + "/embeddings",
+            headers={"Authorization": f"Bearer {self.api_key}"},
+            json={
+                "model": self.model,
+                "input": ["Hello world", "Test text"],
+                "encoding_format": "base64",
+            },
+            timeout=30,
+        )
+        response.raise_for_status()
+        body = response.json()
+        self.assertEqual([item["index"] for item in body["data"]], [0, 1])
+        for item in body["data"]:
+            raw = base64.b64decode(item["embedding"])
+            self.assertGreater(len(raw), 0)
+            self.assertEqual(len(raw) % 4, 0)
+            struct.unpack(f"<{len(raw) // 4}f", raw)
+        self.assertEqual(body["usage"]["prompt_tokens"], body["usage"]["total_tokens"])
 
     def test_embedding_single_batch_str(self):
         """Test embedding with a List[str] and length equals to 1"""
@@ -199,6 +230,16 @@ class TestMatryoshkaEmbeddingModel(CustomTestCase):
                     dimensions=dimensions,
                 )
             self.assertEqual(cm.exception.status_code, 400)
+
+
+@unittest.skipUnless(
+    is_rust_server_built(),
+    "embedded rust server extension not built",
+)
+class TestOpenAIEmbeddingWithRust(TestOpenAIEmbedding):
+    """Run the same server fixture and matrix with only the frontend switched."""
+
+    env: ClassVar[dict[str, str]] = {"SGLANG_RUST_SERVER": "1"}
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/multimodal/rust/shared/test_embedding_bridge.py
+++ b/test/registered/unit/multimodal/rust/shared/test_embedding_bridge.py
@@ -1,0 +1,67 @@
+import struct
+import unittest
+from types import SimpleNamespace
+
+import msgspec
+from sglang.srt.managers.rust_server import RustServer
+
+
+class _FakeServer:
+    def __init__(self):
+        self.embedding_calls = []
+        self.errors = []
+
+    def push_embedding(self, header, data):
+        self.embedding_calls.append((bytes(header), bytes(data)))
+        return True
+
+    def push_error(self, rid, message):
+        self.errors.append((rid, message))
+        return True
+
+
+class TestEmbeddingBridge(unittest.TestCase):
+    def _bridge(self):
+        bridge = RustServer.__new__(RustServer)
+        bridge.server = _FakeServer()
+        return bridge
+
+    def test_dense_batch_is_one_columnar_f32_call(self):
+        bridge = self._bridge()
+        bridge.push_embedding(
+            SimpleNamespace(
+                rids=["a", "b"],
+                finished_reasons=[{"type": "stop"}, {"type": "stop"}],
+                embeddings=[[0.5, -2.0], [7.0]],
+                prompt_tokens=[3, 4],
+            )
+        )
+        self.assertEqual(len(bridge.server.embedding_calls), 1)
+        header, data = bridge.server.embedding_calls[0]
+        self.assertEqual(
+            msgspec.msgpack.decode(header),
+            [
+                ["a", "b"],
+                [{"type": "stop"}, {"type": "stop"}],
+                [3, 4],
+                [2, 1],
+            ],
+        )
+        self.assertEqual(struct.unpack("<3f", data), (0.5, -2.0, 7.0))
+
+    def test_sparse_nested_and_scalar_outputs_fail_explicitly(self):
+        bridge = self._bridge()
+        bridge.push_embedding(
+            SimpleNamespace(
+                rids=["sparse", "nested", "scalar"],
+                finished_reasons=[None, None, None],
+                embeddings=[{1: 0.5}, [[1.0]], 0.25],
+                prompt_tokens=[1, 1, 1],
+            )
+        )
+        self.assertEqual(len(bridge.server.errors), 3)
+        self.assertEqual(bridge.server.embedding_calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/multimodal/rust/shared/test_embedding_bridge.py
+++ b/test/registered/unit/multimodal/rust/shared/test_embedding_bridge.py
@@ -4,6 +4,10 @@ from types import SimpleNamespace
 
 import msgspec
 from sglang.srt.managers.rust_server import RustServer
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
 class _FakeServer:
@@ -20,7 +24,7 @@ class _FakeServer:
         return True
 
 
-class TestEmbeddingBridge(unittest.TestCase):
+class TestEmbeddingBridge(CustomTestCase):
     def _bridge(self):
         bridge = RustServer.__new__(RustServer)
         bridge.server = _FakeServer()


### PR DESCRIPTION
## Motivation

Add OpenAI-compatible embedding request support to the Rust server frontend while preserving Python server behavior.

A part of https://github.com/sgl-project/sglang/issues/23206

## Modifications

- Add `/v1/embeddings` request parsing, validation, and response formatting in the Rust server.
- Carry embedding requests and outputs across the Rust/Python scheduler bridge.
- Support batched inputs, float and base64 encodings, token usage, and error propagation.
- Add Rust unit tests, Python bridge tests, and endpoint parity coverage. The new bridge unit test is registered in CI (`base-a-test-cpu`), and `test_openai_embedding.py`'s CPU `est_time` is doubled (91 -> 180) because `TestOpenAIEmbeddingWithRust` launches a second server and re-runs the same matrix.
- Fix `/model_info` hard-coded `is_generation: true`, switch startup warmup to `/v1/embeddings`, normalize embedding sampling metadata across the msgspec ABI, and make `/health_generate` send embedding probes.

## Accuracy Tests

Self-review and post-rebase validation are in progress (rebased onto latest `main`; the two alignment fixes are included in this branch).

Integration parity report from the fork draft PR ([qiuhuiming/sglang#2](https://github.com/qiuhuiming/sglang/pull/2), run on the pre-rebase head with both frontends, model `Alibaba-NLP/gte-Qwen2-1.5B-instruct`, RTX 3070 8 GiB, FP16, Triton attention, CUDA graphs disabled):

- The Rust embedding server completes startup warmup and the embedding-aware `/health_generate` probe successfully.
- Parity results for five request shapes: minimum cosine similarity 0.999998564-1.000000000, max absolute differences up to 2.44e-4 for batch text (attributed to FP16 variance).
- Validation parity: 400 status matched for empty string, whitespace-only string, empty batch, dimensions on non-Matryoshka model, and mixed input shape. Overall HTTP status parity was **10/11 cases** - the exception being unknown model names, where Python returns 200 and Rust returns 404.
- An OOV token-ID probe was excluded since Rust rejects with 400 while the Python baseline reaches the CUDA kernel and crashes.
- 263 Rust library tests pass; `cargo fmt` / `clippy` and the Python bridge tests pass.

## Speed Tests and Profiling

Not run yet. This PR only adds the Rust frontend endpoint; the Python server path is unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33240190288](https://github.com/sgl-project/sglang/actions/runs/33240190288)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:hourglass_flowing_sand: [Run #33240190209](https://github.com/sgl-project/sglang/actions/runs/33240190209)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33240190260](https://github.com/sgl-project/sglang/actions/runs/33240190260)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->