### PR TITLE
Feat[DCP] Support decode context parallelism for DSA models with the flashmla_kv backend

### DIFF
--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -277,6 +277,10 @@ def _correct_attn_cp_out_kernel(
     # Apply correction and store
     output = tl.load(outputs_ptr + output_offsets)
     output = output * factor
+    # A zero-weight rank's raw output can be NaN (e.g. a degenerate DCP shard
+    # with no owned tokens); NaN * 0.0 == NaN, so guard explicitly rather than
+    # trust the multiply.
+    output = tl.where(factor == 0.0, 0.0, output)
     tl.store(new_output_ptr + new_output_offsets, output)
 
 

--- a/python/sglang/kernels/ops/attention/dcp_kernels.py
+++ b/python/sglang/kernels/ops/attention/dcp_kernels.py
@@ -557,9 +557,12 @@ def _dcp_lse_combine_kernel(
             + d_offsets * recv_output_stride_D
         )
         partial_out = tl.load(recv_output_ptr + o_offsets).to(tl.float32)
-        acc += partial_out * w
+        # Empty shards may return NaN outputs; NaN * 0 is not zero.
+        acc += tl.where(w == 0.0, 0.0, partial_out * w)
 
-    acc = acc / weight_sum
+    has_valid_weight = weight_sum > 0.0
+    weight_sum = tl.where(has_valid_weight, weight_sum, 1.0)
+    acc = tl.where(has_valid_weight, acc / weight_sum, 0.0)
 
     out_offsets = (
         batch_idx * out_stride_B + head_idx * out_stride_H + d_offsets * out_stride_D
@@ -571,6 +574,7 @@ def _dcp_lse_combine_kernel(
             global_lse = tl.log(weight_sum) + lse_max
         else:
             global_lse = tl.log2(weight_sum) + lse_max
+        global_lse = tl.where(has_valid_weight, global_lse, -float("inf"))
         out_lse_offset = batch_idx * recv_lse_stride_B + head_idx * recv_lse_stride_H
         tl.store(out_lse_ptr + out_lse_offset, global_lse)
 
@@ -664,7 +668,16 @@ def _lse_weighted_combine_cpu(
         weights = torch.pow(2.0, centered)
 
     weight_sum = weights.sum(dim=0, keepdim=True)
-    weights = weights / weight_sum
+    has_valid_weight = weight_sum > 0
+    safe_weight_sum = torch.where(
+        has_valid_weight, weight_sum, torch.ones_like(weight_sum)
+    )
+    weights = torch.where(
+        has_valid_weight,
+        weights / safe_weight_sum,
+        torch.zeros_like(weights),
+    )
 
-    combined = (partial_outputs * weights.unsqueeze(-1)).sum(dim=0)
+    weights = weights.unsqueeze(-1)
+    combined = torch.where(weights == 0, 0.0, partial_outputs * weights).sum(dim=0)
     return combined

--- a/python/sglang/kernels/ops/attention/dsa/transform_index.py
+++ b/python/sglang/kernels/ops/attention/dsa/transform_index.py
@@ -49,6 +49,8 @@ def transform_index_page_table_decode_kernel(
     result_ptr: torch.Tensor,
     page_size: tl.constexpr,
     page_table_row_stride: tl.constexpr,
+    dcp_size: tl.constexpr,
+    dcp_rank: tl.constexpr,
 ):
     TOPK: tl.constexpr = 2048
     req_id = tl.program_id(0)
@@ -60,6 +62,10 @@ def transform_index_page_table_decode_kernel(
     loaded_topk_indices = tl.load(topk_indices_ptr + offset)
     mask = loaded_topk_indices >= 0
     loaded_kv_indices = tl.load(page_table_ptr + loaded_topk_indices, mask=mask)
+    if dcp_size > 1:
+        # Keep slots owned by this rank as local rows; others become -1.
+        mask = mask & (loaded_kv_indices % dcp_size == dcp_rank)
+        loaded_kv_indices = loaded_kv_indices // dcp_size
     tl.store(result_ptr + offset, loaded_kv_indices, mask=mask)
     tl.store(result_ptr + offset, -1, mask=~mask)
 
@@ -80,6 +86,8 @@ def transform_index_page_table_prefill_kernel(
     TOPK: tl.constexpr,
     BLOCK_Q: tl.constexpr,
     BLOCK_TOPK: tl.constexpr,
+    dcp_size: tl.constexpr,
+    dcp_rank: tl.constexpr,
 ):
     request_id = tl.program_id(0)
     query_offsets = tl.program_id(1) * BLOCK_Q + tl.arange(0, BLOCK_Q)
@@ -113,6 +121,10 @@ def transform_index_page_table_prefill_kernel(
         mask=valid_topk_mask,
         other=-1,
     )
+    if dcp_size > 1:
+        # DCP owner filter: keep slots on this rank, map global -> local row.
+        owned_mask = valid_topk_mask & (loaded_kv_indices % dcp_size == dcp_rank)
+        loaded_kv_indices = tl.where(owned_mask, loaded_kv_indices // dcp_size, -1)
     tl.store(
         result_ptr
         + token_indices[:, None] * result_stride_0
@@ -127,6 +139,8 @@ def transform_index_page_table_decode_fast(
     topk_indices: torch.Tensor,
     result: Optional[torch.Tensor] = None,
     page_size: int = 1,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
 ) -> torch.Tensor:
     """
     Transform the page table according to topk indices for sparse topk attention.
@@ -151,6 +165,8 @@ def transform_index_page_table_decode_fast(
         result,
         page_size,
         page_table_row_stride=page_table.stride(0),
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
     )
     return result
 
@@ -163,6 +179,8 @@ def transform_index_page_table_prefill_fast(
     output_num_tokens: Optional[int] = None,
     page_table_is_expanded: bool = False,
     cu_seqlens_q: Optional[torch.Tensor] = None,
+    dcp_size: int = 1,
+    dcp_rank: int = 0,
 ) -> torch.Tensor:
     assert page_size == 1
     assert topk_indices.shape[1] == 2048
@@ -200,6 +218,8 @@ def transform_index_page_table_prefill_fast(
         TOPK=topk_indices.shape[1],
         BLOCK_Q=block_q,
         BLOCK_TOPK=block_topk,
+        dcp_size=dcp_size,
+        dcp_rank=dcp_rank,
         num_warps=4,
     )
     return result

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -350,13 +350,11 @@ class DeepseekSparseAttnBackend(
         self.dcp_enabled = parallel.dcp_enabled
         self.dcp_size = parallel.attn_dcp_size if self.dcp_enabled else 1
         self.dcp_rank = parallel.attn_dcp_rank if self.dcp_enabled else 0
-        if self.num_q_heads <= 64:
-            self.flashmla_kv_num_q_heads = 64
-        elif self.num_q_heads <= 128:
-            self.flashmla_kv_num_q_heads = 128
-        else:
-            # Keep original head count if it exceeds current padded variants.
-            self.flashmla_kv_num_q_heads = self.num_q_heads
+        decode_q_heads = self.num_q_heads
+        if parallel.enable_cp_decode_attn_tp:
+            decode_q_heads //= parallel.attn_cp_size
+        # The decode kernel sees the Q head shards gathered across the DCP group.
+        self.flashmla_decode_q_heads = decode_q_heads * self.dcp_size
         self.enable_auto_select_prefill_impl = self.dsa_prefill_impl == "flashmla_auto"
 
         self._arange_buf = torch.arange(16384, device=self.device, dtype=torch.int32)
@@ -434,13 +432,22 @@ class DeepseekSparseAttnBackend(
                 )
             if self.hisparse_coordinator is not None:
                 raise ValueError("DSA with DCP does not support HiSparse.")
+            if is_cuda() and model_runner.server_args.speculative_algorithm is not None:
+                raise ValueError(
+                    "DSA with flashmla_kv DCP does not currently support "
+                    "speculative decoding on CUDA. Disable speculative decoding "
+                    "or set --dcp-size 1."
+                )
             if model_runner.server_args.enable_dp_attention:
                 # Keep each DCP group inside one attention-DP shard so the
                 # replicated indexer sees identical requests group-wide.
-                if parallel.attn_tp_size % self.dcp_size != 0:
+                attn_dp_shard_size = parallel.attn_tp_size * parallel.attn_cp_size
+                if attn_dp_shard_size % self.dcp_size != 0:
                     raise ValueError(
-                        f"dcp_size ({self.dcp_size}) must divide attn_tp_size "
-                        f"({parallel.attn_tp_size}) under dp-attention."
+                        f"dcp_size ({self.dcp_size}) must divide the attention-DP "
+                        f"shard size ({attn_dp_shard_size} = attn_tp_size "
+                        f"{parallel.attn_tp_size} * attn_cp_size "
+                        f"{parallel.attn_cp_size})."
                     )
             if self.use_fused_topk:
                 # The fused v2 transform does not yet compose with DCP owner
@@ -868,6 +875,7 @@ class DeepseekSparseAttnBackend(
         # We use bs_idx_cpu to mark which sequences are finally selected by the current cp rank,
         # a default value of None indicates that all sequences are selected.
         bs_idx_cpu = None
+        bs_idx = None
         # seq_len_cpu of selected sequences
         indexer_seq_lens_cpu = forward_batch.seq_lens_cpu
         indexer_seq_lens = forward_batch.seq_lens
@@ -1093,7 +1101,9 @@ class DeepseekSparseAttnBackend(
             if dcp_meta is None or dcp_meta.dcp_kv_buffer is None:
                 raise RuntimeError("DSA CP+DCP prefill requires a gathered KV buffer.")
             dcp_page_table_1 = self._build_dcp_prefill_page_table(
-                indexer_seq_lens_cpu, dcp_meta
+                indexer_seq_lens_cpu,
+                dcp_meta,
+                selected_batch_indices=bs_idx,
             )
 
         metadata = DSAMetadata(
@@ -1110,6 +1120,9 @@ class DeepseekSparseAttnBackend(
                 self._compute_flashmla_metadata(
                     cache_seqlens=dsa_cache_seqlens_int32,
                     seq_len_q=1,
+                    num_q_heads=(
+                        self.num_q_heads if dsa_use_prefill_cp(forward_batch) else None
+                    ),
                 )
                 if use_flashmla_kv
                 else None
@@ -1934,24 +1947,27 @@ class DeepseekSparseAttnBackend(
         self,
         seq_lens: torch.Tensor,
         dcp_meta: DecodeContextParallelMetadata,
+        selected_batch_indices: Union[List[int], torch.Tensor],
     ) -> torch.Tensor:
         """Map request-local positions into the CP+DCP gathered KV buffer."""
         kv_indices = dcp_meta.dcp_kv_indices
         kv_indptr = dcp_meta.dcp_kv_indptr
         if kv_indices is None or kv_indptr is None:
             raise RuntimeError("DSA CP+DCP prefill requires KV indices and indptr.")
-        if kv_indptr.numel() != seq_lens.numel() + 1:
-            raise RuntimeError(
-                "DSA CP+DCP KV indptr does not match the selected batch: "
-                f"indptr={kv_indptr.numel()}, batch={seq_lens.numel()}."
-            )
         device = kv_indices.device
+        batch_indices = torch.as_tensor(
+            selected_batch_indices, device=device, dtype=torch.int64
+        )
+        if batch_indices.numel() != seq_lens.numel():
+            raise RuntimeError(
+                "DSA CP+DCP selected batch does not match its sequence lengths: "
+                f"selected={batch_indices.numel()}, batch={seq_lens.numel()}."
+            )
         max_seq_len = max(int(seq_lens.max().item()), 1) if seq_lens.numel() else 1
         seq_lens = seq_lens.to(device=device, dtype=torch.int64)
-        batch_size = seq_lens.numel()
         positions = torch.arange(max_seq_len, device=device, dtype=torch.int64)
         valid = positions.unsqueeze(0) < seq_lens.unsqueeze(1)
-        flat_offsets = kv_indptr[:-1].to(torch.int64).unsqueeze(1)
+        flat_offsets = kv_indptr.to(torch.int64)[batch_indices].unsqueeze(1)
         flat_offsets = torch.where(valid, flat_offsets + positions, 0)
 
         page_table = torch.full_like(flat_offsets, -1, dtype=torch.int32)
@@ -2927,7 +2943,7 @@ class DeepseekSparseAttnBackend(
         # TODO the 2nd dim is seq_len_q, need to be >1 when MTP
         q_all = q_all.reshape(q_all.shape[0], 1, -1, layer.head_dim)
         num_q_heads = q_all.shape[2]
-        target_q_heads = self.flashmla_kv_num_q_heads
+        target_q_heads = self._flashmla_q_head_bucket(num_q_heads)
         if target_q_heads != num_q_heads:
             q_input = q_all.new_zeros(
                 q_all.shape[0],
@@ -2943,8 +2959,7 @@ class DeepseekSparseAttnBackend(
         use_packed_fp8_kv = self.dsa_kv_cache_store_fp8
         if use_packed_fp8_kv and kv_cache.dtype != torch.float8_e4m3fn:
             raise RuntimeError(
-                "Packed DSA KV must use torch.float8_e4m3fn, "
-                f"got {kv_cache.dtype}."
+                "Packed DSA KV must use torch.float8_e4m3fn, " f"got {kv_cache.dtype}."
             )
         kv_dim = (
             self.kv_cache_dim
@@ -3553,10 +3568,26 @@ class DeepseekSparseAttnBackend(
             force_unfused_topk=force_unfused,
         )
 
-    def _compute_flashmla_metadata(self, cache_seqlens: torch.Tensor, seq_len_q: int):
+    @staticmethod
+    def _flashmla_q_head_bucket(num_q_heads: int) -> int:
+        if num_q_heads <= 64:
+            return 64
+        if num_q_heads <= 128:
+            return 128
+        return num_q_heads
+
+    def _compute_flashmla_metadata(
+        self,
+        cache_seqlens: torch.Tensor,
+        seq_len_q: int,
+        *,
+        num_q_heads: Optional[int] = None,
+    ):
         from sgl_kernel.flash_mla import get_mla_metadata
 
-        num_heads_q = self.flashmla_kv_num_q_heads
+        if num_q_heads is None:
+            num_q_heads = self.flashmla_decode_q_heads
+        num_heads_q = self._flashmla_q_head_bucket(num_q_heads)
 
         flashmla_metadata, num_splits = get_mla_metadata(
             cache_seqlens=cache_seqlens,

--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -10,6 +10,7 @@ from typing import (
     Optional,
     Tuple,
     TypeAlias,
+    Union,
 )
 
 import torch
@@ -28,6 +29,7 @@ from sglang.kernels.ops.attention.dsa.transform_index import (
     transform_index_page_table_decode,
     transform_index_page_table_prefill,
 )
+from sglang.kernels.ops.attention.fixup_zero_kv import fixup_zero_kv_rows
 from sglang.kernels.ops.attention.utils import (
     concat_mla_absorb_q_general,
     mla_quantize_and_rope_for_fp8,
@@ -64,6 +66,7 @@ from sglang.srt.layers.attention.trtllm_mla_backend import (
 )
 from sglang.srt.layers.cp.base import get_cp_strategy
 from sglang.srt.layers.cp.utils import is_cp_v2_active
+from sglang.srt.layers.dcp.metadata import DecodeContextParallelMetadata
 from sglang.srt.layers.utils.cp_utils import (
     cp_all_gather_rerange_output,
     cp_split_and_rebuild_position,
@@ -239,6 +242,8 @@ class DSAMetadata:
     # The offset of topk indices in ragged kv, prefill only
     # shape: (seq_lens_sum,)
     topk_indices_offset: Optional[torch.Tensor] = None
+    # Request-local positions mapped into the CP+DCP gathered KV buffer.
+    dcp_page_table_1: Optional[torch.Tensor] = None
 
     # k_start and k_end in kv cache for each token.
     indexer_k_start_end: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
@@ -341,6 +346,10 @@ class DeepseekSparseAttnBackend(
         self.dsa_topk_backend: DSATopKBackend = DSATopKBackend(
             model_runner.server_args.dsa_topk_backend
         )
+        parallel = get_parallel()
+        self.dcp_enabled = parallel.dcp_enabled
+        self.dcp_size = parallel.attn_dcp_size if self.dcp_enabled else 1
+        self.dcp_rank = parallel.attn_dcp_rank if self.dcp_enabled else 0
         if self.num_q_heads <= 64:
             self.flashmla_kv_num_q_heads = 64
         elif self.num_q_heads <= 128:
@@ -403,6 +412,42 @@ class DeepseekSparseAttnBackend(
         self.device_capability = torch.cuda.get_device_capability()
         self.device_sm_major = self.device_capability[0]
         self.kv_cache_dtype = model_runner.kv_cache_dtype
+
+        if self.dcp_enabled:
+            if (
+                self.dsa_decode_impl != "flashmla_kv"
+                or self.dsa_prefill_impl != "flashmla_kv"
+            ):
+                raise ValueError(
+                    "DSA with DCP currently supports only flashmla_kv for both "
+                    "prefill and decode; got "
+                    f"prefill={self.dsa_prefill_impl!r}, "
+                    f"decode={self.dsa_decode_impl!r}."
+                )
+            if (
+                parallel.attn_cp_size > 1
+                and not model_runner.server_args.enable_cp_decode_attn_tp
+            ):
+                raise ValueError(
+                    "DSA with both context parallelism and DCP requires "
+                    "--enable-cp-decode-attn-tp when using flashmla_kv."
+                )
+            if self.hisparse_coordinator is not None:
+                raise ValueError("DSA with DCP does not support HiSparse.")
+            if model_runner.server_args.enable_dp_attention:
+                # Keep each DCP group inside one attention-DP shard so the
+                # replicated indexer sees identical requests group-wide.
+                if parallel.attn_tp_size % self.dcp_size != 0:
+                    raise ValueError(
+                        f"dcp_size ({self.dcp_size}) must divide attn_tp_size "
+                        f"({parallel.attn_tp_size}) under dp-attention."
+                    )
+            if self.use_fused_topk:
+                # The fused v2 transform does not yet compose with DCP owner
+                # filtering, and DCP extend deliberately emits unfused logical
+                # positions. Keep the producer/consumer contract consistent.
+                print_warning_once("Disabling fused DSA top-k under DCP.")
+                self.use_fused_topk = False
 
         # `flashmla_sparse_q8` = the native FP8 SM90 sparse-prefill kernel. It always
         # runs FP8 (requires fp8_e4m3 KV) and is SM90-only, so validate both at
@@ -1038,6 +1083,19 @@ class DeepseekSparseAttnBackend(
                 paged_mqa_ctx_lens_2d, 64, deep_gemm.get_num_sms()
             )
 
+        dcp_page_table_1 = None
+        if self.dcp_enabled and dsa_use_prefill_cp(forward_batch):
+            if indexer_seq_lens_cpu is None:
+                raise RuntimeError(
+                    "DSA CP+DCP prefill requires host-side sequence lengths."
+                )
+            dcp_meta = forward_batch.attn_dcp_metadata
+            if dcp_meta is None or dcp_meta.dcp_kv_buffer is None:
+                raise RuntimeError("DSA CP+DCP prefill requires a gathered KV buffer.")
+            dcp_page_table_1 = self._build_dcp_prefill_page_table(
+                indexer_seq_lens_cpu, dcp_meta
+            )
+
         metadata = DSAMetadata(
             page_size=self.real_page_size,
             cache_seqlens_int32=cache_seqlens_int32,
@@ -1071,6 +1129,7 @@ class DeepseekSparseAttnBackend(
             indexer_seq_lens=indexer_seq_lens,
             token_to_batch_idx=token_to_batch_idx,
             topk_v2_plan=self._build_topk_v2_plan(seqlens_expanded),
+            dcp_page_table_1=dcp_page_table_1,
         )
         self.forward_metadata = metadata
 
@@ -1871,6 +1930,36 @@ class DeepseekSparseAttnBackend(
 
         self.forward_metadata = metadata
 
+    def _build_dcp_prefill_page_table(
+        self,
+        seq_lens: torch.Tensor,
+        dcp_meta: DecodeContextParallelMetadata,
+    ) -> torch.Tensor:
+        """Map request-local positions into the CP+DCP gathered KV buffer."""
+        kv_indices = dcp_meta.dcp_kv_indices
+        kv_indptr = dcp_meta.dcp_kv_indptr
+        if kv_indices is None or kv_indptr is None:
+            raise RuntimeError("DSA CP+DCP prefill requires KV indices and indptr.")
+        if kv_indptr.numel() != seq_lens.numel() + 1:
+            raise RuntimeError(
+                "DSA CP+DCP KV indptr does not match the selected batch: "
+                f"indptr={kv_indptr.numel()}, batch={seq_lens.numel()}."
+            )
+        device = kv_indices.device
+        max_seq_len = max(int(seq_lens.max().item()), 1) if seq_lens.numel() else 1
+        seq_lens = seq_lens.to(device=device, dtype=torch.int64)
+        batch_size = seq_lens.numel()
+        positions = torch.arange(max_seq_len, device=device, dtype=torch.int64)
+        valid = positions.unsqueeze(0) < seq_lens.unsqueeze(1)
+        flat_offsets = kv_indptr[:-1].to(torch.int64).unsqueeze(1)
+        flat_offsets = torch.where(valid, flat_offsets + positions, 0)
+
+        page_table = torch.full_like(flat_offsets, -1, dtype=torch.int32)
+        if kv_indices.numel() > 0:
+            gathered_indices = kv_indices[flat_offsets]
+            page_table = torch.where(valid, gathered_indices, page_table)
+        return page_table
+
     def forward_extend(
         self,
         q: torch.Tensor,
@@ -1952,15 +2041,25 @@ class DeepseekSparseAttnBackend(
 
         # Do absorbed multi-latent attention (MLA path)
         assert q_rope is not None
-        kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        use_dcp_full_kv = (
+            self.dcp_enabled
+            and dsa_use_prefill_cp(forward_batch)
+            and forward_batch.attn_dcp_metadata is not None
+            and forward_batch.attn_dcp_metadata.dcp_kv_buffer is not None
+        )
+        kv_cache = (
+            forward_batch.attn_dcp_metadata.dcp_kv_buffer
+            if use_dcp_full_kv
+            else self.token_to_kv_pool.get_key_buffer(layer.layer_id)
+        )
 
         if q_rope is not None:
-            q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
-            q_rope = q_rope.view(
-                -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
+            q_nope = q.reshape(q.shape[0], -1, layer.v_head_dim)
+            q_rope = q_rope.reshape(
+                q_rope.shape[0], -1, layer.head_dim - layer.v_head_dim
             )
         else:
-            q_all = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+            q_all = q.contiguous().view(q.shape[0], -1, layer.head_dim)
             q_nope = q_all[:, :, : layer.v_head_dim]
             q_rope = q_all[:, :, layer.v_head_dim :]
 
@@ -1969,7 +2068,7 @@ class DeepseekSparseAttnBackend(
             forward_batch.forward_mode
         )
 
-        if self.use_fused_topk:
+        if self.use_fused_topk and not self.dcp_enabled:
             if topk_indices is not None:
                 topk_indices = self._pad_topk_indices(topk_indices, q_nope.shape[0])
 
@@ -1991,8 +2090,20 @@ class DeepseekSparseAttnBackend(
                 )
             elif topk_transform_method == TopkTransformMethod.PAGED:
                 assert metadata.dsa_extend_seq_lens_list is not None
+                if use_dcp_full_kv:
+                    if metadata.dcp_page_table_1 is None:
+                        raise RuntimeError(
+                            "DSA CP+DCP prefill page table was not initialized."
+                        )
+                    transform_page_table = metadata.dcp_page_table_1
+                    transform_dcp_size = 1
+                    transform_dcp_rank = 0
+                else:
+                    transform_page_table = metadata.page_table_1
+                    transform_dcp_size = self.dcp_size
+                    transform_dcp_rank = self.dcp_rank
                 page_table_1 = transform_index_page_table_prefill(
-                    page_table=metadata.page_table_1,
+                    page_table=transform_page_table,
                     topk_indices=topk_indices,
                     extend_lens_cpu=metadata.dsa_extend_seq_lens_list,
                     page_size=1,
@@ -2002,6 +2113,8 @@ class DeepseekSparseAttnBackend(
                         or forward_batch.forward_mode.is_draft_extend_v2()
                     ),
                     cu_seqlens_q=metadata.cu_seqlens_q,
+                    dcp_size=transform_dcp_size,
+                    dcp_rank=transform_dcp_rank,
                 )
 
         # todo hisparse: to cover more backends
@@ -2151,6 +2264,7 @@ class DeepseekSparseAttnBackend(
                 layer=layer,
                 metadata=metadata,
                 page_table_1=page_table_1,
+                has_dcp_global_kv=use_dcp_full_kv,
             )
         elif dsa_impl == "fa3":
             return self._forward_fa3(
@@ -2237,9 +2351,9 @@ class DeepseekSparseAttnBackend(
         # Do absorbed multi-latent attention
         kv_cache = self.token_to_kv_pool.get_key_buffer(layer.layer_id)
         if q_rope is not None:
-            q_nope = q.view(-1, layer.tp_q_head_num, layer.v_head_dim)
-            q_rope = q_rope.view(
-                -1, layer.tp_q_head_num, layer.head_dim - layer.v_head_dim
+            q_nope = q.reshape(q.shape[0], -1, layer.v_head_dim)
+            q_rope = q_rope.reshape(
+                q_rope.shape[0], -1, layer.head_dim - layer.v_head_dim
             )
             # Caller passed split q_nope / q_rope; we'll need to concat below if
             # the chosen impl wants q_all.
@@ -2248,7 +2362,7 @@ class DeepseekSparseAttnBackend(
             # Caller passed already-concatenated q (q_all = q). Reuse it directly
             # via a zero-copy view; the impl-specific blocks below will skip the
             # otherwise redundant concat_mla_absorb_q_general call.
-            q_all = q.contiguous().view(-1, layer.tp_q_head_num, layer.head_dim)
+            q_all = q.contiguous().view(q.shape[0], -1, layer.head_dim)
             q_nope = q_all[:, :, : layer.v_head_dim]
             q_rope = q_all[:, :, layer.v_head_dim :]
 
@@ -2270,6 +2384,8 @@ class DeepseekSparseAttnBackend(
                 page_table=metadata.page_table_1,
                 topk_indices=topk_indices,
                 page_size=1,
+                dcp_size=self.dcp_size,
+                dcp_rank=self.dcp_rank,
             )
 
         if self.dsa_decode_impl == "flashmla_sparse":
@@ -2798,41 +2914,59 @@ class DeepseekSparseAttnBackend(
         kv_cache: torch.Tensor,
         v_head_dim: int,
         sm_scale: float,
-        layer,
+        layer: RadixAttention,
         metadata: DSAMetadata,
-        page_table_1,
-    ) -> torch.Tensor:
+        page_table_1: torch.Tensor,
+        has_dcp_global_kv: bool = False,
+    ) -> Union[torch.Tensor, Tuple[torch.Tensor, torch.Tensor]]:
         from sgl_kernel.flash_mla import flash_mla_with_kvcache
 
         cache_seqlens = metadata.dsa_cache_seqlens_int32
         assert metadata.flashmla_metadata is not None
 
         # TODO the 2nd dim is seq_len_q, need to be >1 when MTP
-        q_all = q_all.view(-1, 1, layer.tp_q_head_num, layer.head_dim)
+        q_all = q_all.reshape(q_all.shape[0], 1, -1, layer.head_dim)
         num_q_heads = q_all.shape[2]
         target_q_heads = self.flashmla_kv_num_q_heads
         if target_q_heads != num_q_heads:
-            # Pad q heads to match FlashMLA decode supported head-count variants.
             q_input = q_all.new_zeros(
-                q_all.shape[0], q_all.shape[1], target_q_heads, q_all.shape[3]
+                q_all.shape[0],
+                q_all.shape[1],
+                target_q_heads,
+                q_all.shape[3],
             )
             q_input[:, :, :num_q_heads, :] = q_all
         else:
             q_input = q_all
 
-        kv_cache = kv_cache.view(-1, self.real_page_size, 1, self.kv_cache_dim)
         assert self.real_page_size == 64, "only page size 64 is supported"
-
-        if not self.dsa_kv_cache_store_fp8:
-            # inefficiently quantize the whole cache
+        use_packed_fp8_kv = self.dsa_kv_cache_store_fp8
+        if use_packed_fp8_kv and kv_cache.dtype != torch.float8_e4m3fn:
+            raise RuntimeError(
+                "Packed DSA KV must use torch.float8_e4m3fn, "
+                f"got {kv_cache.dtype}."
+            )
+        kv_dim = (
+            self.kv_cache_dim
+            if use_packed_fp8_kv
+            else self.kv_lora_rank + self.qk_rope_head_dim
+        )
+        kv_cache = kv_cache.view(-1, self.real_page_size, 1, kv_dim)
+        if not use_packed_fp8_kv:
             kv_cache = quantize_k_cache(kv_cache)
 
+        needs_dcp_reduce = self.dcp_enabled and not has_dcp_global_kv
+        local_kv_counts = (
+            (page_table_1 >= 0).sum(dim=-1, dtype=torch.int32)
+            if needs_dcp_reduce
+            else None
+        )
         indices = page_table_1.unsqueeze(1)
         assert (
             indices.shape[-1] == self.dsa_index_topk
-        )  # requirement of FlashMLA decode kernel
+        ), "requirement of FlashMLA decode kernel"
 
-        o, _ = flash_mla_with_kvcache(
+        o, lse = flash_mla_with_kvcache(
             q=q_input,
             k_cache=kv_cache,
             cache_seqlens=cache_seqlens,
@@ -2841,15 +2975,31 @@ class DeepseekSparseAttnBackend(
             num_splits=metadata.flashmla_metadata.num_splits,
             softmax_scale=sm_scale,
             indices=indices,
-            # doc says it is not used, but if pass in None then error
+            # FlashMLA currently requires a block table argument even when
+            # sparse indices provide the actual KV selection.
             block_table=torch.empty(
                 (q_all.shape[0], 0), dtype=torch.int32, device=q_all.device
             ),
             is_fp8_kvcache=True,
         )
-
         if target_q_heads != num_q_heads:
             o = o[:, :, :num_q_heads, :]
+            lse = lse[:, :num_q_heads, :]
+
+        if needs_dcp_reduce:
+            out = o[:, 0, :, :].contiguous()
+            lse = lse[:, :, 0].contiguous()
+            assert local_kv_counts is not None
+            # FlashMLA can return undefined values for rows with no local KV.
+            # Normalize them before the cross-rank LSE combine.
+            fixup_zero_kv_rows(
+                out,
+                lse,
+                local_kv_counts,
+                self.get_device_int32_arange(out.shape[0] + 1),
+                max_seq_len=1,
+            )
+            return out, lse
 
         return o
 
@@ -3338,6 +3488,7 @@ class DeepseekSparseAttnBackend(
                 and sum_seq_lens
                 <= forward_batch.get_max_chunk_capacity()  # Fits in chunk
                 and (not is_dsa_enable_prefill_cp())  # CP not enabled
+                and (not self.dcp_enabled)  # DCP extend uses the sparse MLA path
                 and (self.hisparse_coordinator is None)
             )
         else:

--- a/python/sglang/srt/layers/dcp/comm.py
+++ b/python/sglang/srt/layers/dcp/comm.py
@@ -275,46 +275,115 @@ def all_gather_kv_cache_for_mla_extend(
     k_nope,
     k_pe,
 ):
-    cache_k_nope, cache_k_rope = token_to_kv_pool.get_mla_kv_buffer(
-        attn_mqa,
-        dcp_local_prefix_kv_indices,
-    )
-    extend_prefix_lens_cpu = torch.tensor(extend_prefix_lens_cpu)
-    # all gather kv cache into forward_batch.attn_dcp_metadata.dcp_kv_buffer
-    gathered_kv = all_gather_kv_cache_for_dcp(
-        cache_k_nope,
-        cache_k_rope,
-        extend_prefix_lens_cpu,
-        prefix_starts_cpu=torch.zeros_like(extend_prefix_lens_cpu),
-    )
-    dcp_kv_buffer[:dcp_extend_prefix_lens_sum] = gathered_kv
+    """Gather prefix KV and append the current CP-full extend KV.
 
-    # copy local kv cache into forward_batch.attn_dcp_metadata.dcp_kv_buffer
-    dcp_kv_buffer[
-        dcp_extend_prefix_lens_sum:,
-        ...,
-        :kv_lora_rank,
-    ] = k_nope
-    dcp_kv_buffer[
-        dcp_extend_prefix_lens_sum:,
-        ...,
-        kv_lora_rank:,
-    ] = k_pe
+    FlashMLA-KV preserves packed FP8 rows byte-exactly; other paths use the
+    latent representation. The temporary buffer mirrors the persistent pool's
+    row layout and dtype.
+    """
+    use_packed_fp8_buffer = bool(
+        getattr(token_to_kv_pool, "dsa_kv_cache_store_fp8", False)
+    )
+    prefix_tokens = sum(int(x) for x in extend_prefix_lens_cpu)
+    extend_prefix_lens = torch.tensor(extend_prefix_lens_cpu, dtype=torch.int32)
+    if prefix_tokens == 0:
+        gathered_kv = (
+            dcp_kv_buffer.view(torch.uint8)[:0]
+            if use_packed_fp8_buffer
+            else dcp_kv_buffer[:0]
+        )
+    elif use_packed_fp8_buffer:
+        # A packed row mixes FP8 values, FP32 scales and BF16 RoPE bytes.
+        # Gather it as uint8 so NCCL cannot reinterpret or convert any field.
+        persistent_kv = token_to_kv_pool.get_key_buffer(attn_mqa.layer_id)
+        local_prefix = persistent_kv.view(torch.uint8)[dcp_local_prefix_kv_indices]
+        gathered_kv = all_gather_kv_cache_for_dcp(
+            local_prefix,
+            None,
+            extend_prefix_lens,
+            prefix_starts_cpu=torch.zeros_like(extend_prefix_lens),
+        )
+    else:
+        cache_k_nope, cache_k_rope = token_to_kv_pool.get_mla_kv_buffer(
+            attn_mqa,
+            dcp_local_prefix_kv_indices,
+            dst_dtype=k_nope.dtype,
+        )
+        gathered_kv = all_gather_kv_cache_for_dcp(
+            cache_k_nope,
+            cache_k_rope,
+            extend_prefix_lens,
+            prefix_starts_cpu=torch.zeros_like(extend_prefix_lens),
+        )
+    if gathered_kv.shape[0] != dcp_extend_prefix_lens_sum:
+        raise RuntimeError(
+            "DCP gathered prefix length mismatch: "
+            f"gathered={gathered_kv.shape[0]}, "
+            f"expected={dcp_extend_prefix_lens_sum}."
+        )
+    if use_packed_fp8_buffer:
+        dcp_kv_buffer.view(torch.uint8)[:dcp_extend_prefix_lens_sum] = gathered_kv
+    else:
+        dcp_kv_buffer[:dcp_extend_prefix_lens_sum] = gathered_kv
+
+    current_end = dcp_extend_prefix_lens_sum + k_nope.shape[0]
+    if current_end > dcp_kv_buffer.shape[0]:
+        raise RuntimeError(
+            "DCP temporary KV buffer is too small: "
+            f"required={current_end}, allocated={dcp_kv_buffer.shape[0]}."
+        )
+    if use_packed_fp8_buffer:
+        from sglang.kernels.ops.attention.dsa.quant_k_cache import (
+            quantize_k_cache_separate,
+        )
+
+        current_nope, current_rope = quantize_k_cache_separate(k_nope, k_pe)
+        current_buffer = dcp_kv_buffer.view(torch.uint8)[
+            dcp_extend_prefix_lens_sum:current_end
+        ]
+        nope_bytes = current_nope.shape[-1]
+        if current_buffer.shape[-1] != nope_bytes + current_rope.shape[-1]:
+            raise RuntimeError(
+                "Packed FP8 temporary KV row width mismatch: "
+                f"buffer={current_buffer.shape[-1]}, "
+                f"packed={nope_bytes + current_rope.shape[-1]}."
+            )
+        current_buffer[..., :nope_bytes] = current_nope
+        current_buffer[..., nope_bytes:] = current_rope
+    else:
+        dcp_kv_buffer[
+            dcp_extend_prefix_lens_sum:current_end,
+            ...,
+            :kv_lora_rank,
+        ] = k_nope
+        dcp_kv_buffer[
+            dcp_extend_prefix_lens_sum:current_end,
+            ...,
+            kv_lora_rank:,
+        ] = k_pe
+
+    if current_end < dcp_kv_buffer.shape[0]:
+        dcp_kv_buffer[current_end:].zero_()
 
 
 # all gather kv cache and re-org to query orders
 def all_gather_kv_cache_for_dcp(
     prefix_kv_a: torch.Tensor,
-    prefix_k_pe: torch.Tensor,
+    prefix_k_pe: Optional[torch.Tensor],
     prefix_kv_lens_cpu: torch.Tensor,
     prefix_starts_cpu: torch.Tensor = None,
 ):
     """
-    prefix_kv_a and prefix_k_pe should have same shape, expect for last dim
+    When prefix_k_pe is provided, the two latent parts must have the same shape
+    except for the last dimension. Passing None gathers already-packed KV rows.
     """
     parallel = get_parallel()
     if not parallel.dcp_enabled:
-        return torch.cat([prefix_kv_a, prefix_k_pe], dim=-1)
+        return (
+            prefix_kv_a
+            if prefix_k_pe is None
+            else torch.cat([prefix_kv_a, prefix_k_pe], dim=-1)
+        )
     # 1. compute max kv_lens for each seq
     dcp_world_size = parallel.dcp_size
     dcp_rank = parallel.dcp_rank
@@ -340,7 +409,11 @@ def all_gather_kv_cache_for_dcp(
     local_kv_lens_cu[1:] = torch.cumsum(local_kv_lens, dim=0)
 
     padded_kv_cache_arr = []
-    prefix_kv_cache = torch.cat([prefix_kv_a, prefix_k_pe], dim=-1)
+    prefix_kv_cache = (
+        prefix_kv_a
+        if prefix_k_pe is None
+        else torch.cat([prefix_kv_a, prefix_k_pe], dim=-1)
+    )
     for req_idx in range(len(prefix_kv_lens_cpu)):
         padded_tensor = prefix_kv_cache.new_empty(
             (padded_lens[req_idx].item(),) + prefix_kv_cache.size()[1:]

--- a/python/sglang/srt/layers/dcp/planner.py
+++ b/python/sglang/srt/layers/dcp/planner.py
@@ -41,6 +41,7 @@ def prepare_decode_context_parallel_metadata(
     kv_cache_dtype,
     kv_cache_device,
     create_chunked_prefix_cache_kv_indices_fn,
+    kv_buffer_token_padding: int = 1,
 ) -> Optional[DecodeContextParallelMetadata]:
     parallel = get_parallel()
     if not parallel.dcp_enabled:
@@ -114,9 +115,12 @@ def prepare_decode_context_parallel_metadata(
         dcp_prefix_kv_indices[parallel.dcp_rank :: parallel.dcp_size]
         // parallel.dcp_size
     )
+    padded_buffer_tokens = (
+        (seq_lens_sum + kv_buffer_token_padding - 1) // kv_buffer_token_padding
+    ) * kv_buffer_token_padding
     dcp_kv_buffer = torch.empty(
         (
-            seq_lens_sum,
+            padded_buffer_tokens,
             *kv_buffer_shape[1:],
         ),
         dtype=kv_cache_dtype,

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -1143,7 +1143,9 @@ class KVCacheConfigurator:
         PoolCls = current_platform.get_dsa_kv_pool_cls()
         token_to_kv_pool = PoolCls(
             max_total_num_tokens,
-            page_size=self.pool_page_size,
+            # DSA kernels keep the physical page size even when a replicated
+            # DCP draft uses a wider virtual location space.
+            page_size=get_schedule().page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,
@@ -1347,7 +1349,9 @@ class KVCacheConfigurator:
             ]
         token_to_kv_pool = PoolCls(
             max_total_num_tokens,
-            page_size=self.pool_page_size,
+            # DSA kernels keep the physical page size even when a replicated
+            # DCP draft uses a wider virtual location space.
+            page_size=get_schedule().page_size,
             dtype=self.kv_cache_dtype,
             kv_lora_rank=self.model_config.kv_lora_rank,
             qk_rope_head_dim=self.model_config.qk_rope_head_dim,

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4475,10 +4475,11 @@ class DSATokenToKVPool(MLATokenToKVPool):
             index_buf_size = size
             parallel = get_parallel()
             if parallel.dcp_enabled:
-                # The indexer K cache is not sharded under DCP: every rank
-                # keeps index_k for every token (global-slot addressed) so
-                # all ranks compute identical top-k.
-                index_buf_size = size * parallel.attn_dcp_size
+                # IndexKeyCache computes num_pages as
+                # (index_buf_size + page_size + 1) // page_size, which already
+                # adds one physical page. Subtract it here so the final capacity
+                # is exactly (size + page_size) * dcp_size.
+                index_buf_size = (size + page_size) * parallel.attn_dcp_size - page_size
         self.index_buf_size = index_buf_size
         # num head == 1 and head dim == 128 for index_k in DSA
         assert index_head_dim == 128

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -4473,6 +4473,12 @@ class DSATokenToKVPool(MLATokenToKVPool):
         self.index_head_dim = index_head_dim
         if index_buf_size is None:
             index_buf_size = size
+            parallel = get_parallel()
+            if parallel.dcp_enabled:
+                # The indexer K cache is not sharded under DCP: every rank
+                # keeps index_k for every token (global-slot addressed) so
+                # all ranks compute identical top-k.
+                index_buf_size = size * parallel.attn_dcp_size
         self.index_buf_size = index_buf_size
         # num head == 1 and head dim == 128 for index_k in DSA
         assert index_head_dim == 128

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -410,7 +410,11 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 num_indexer_layers = len(active_indexer_layers)
 
         return int(
-            indexer_size_per_token * num_indexer_layers * element_size * indexer_ratio
+            indexer_size_per_token
+            * num_indexer_layers
+            * element_size
+            * indexer_ratio
+            * get_parallel().attn_dcp_size
         )
 
     def calculate_pool_sizes(

--- a/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
+++ b/python/sglang/srt/models/deepseek_common/attention_forward_methods/forward_mla.py
@@ -102,8 +102,50 @@ def is_dcp_mla_decode_phase(forward_batch: ForwardBatch) -> bool:
     )
 
 
+def is_dsa_tp_dcp_prefill_phase(
+    forward_batch: ForwardBatch, *, use_dsa: bool
+) -> bool:
+    """Whether DSA TP+DCP prefill attends rank-local KV after gathering Q."""
+    return (
+        use_dsa
+        and get_parallel().dcp_enabled
+        and forward_batch.forward_mode.is_extend(include_draft_extend_v2=True)
+        and not dsa_use_prefill_cp(forward_batch)
+    )
+
+
 def is_mla_dcp_lse_base_on_e(attention_backend: Optional[str]) -> bool:
     return attention_backend in {"flashmla", "cutedsl_mla"}
+
+
+def is_dsa_dcp_lse_base_on_e(forward_batch: ForwardBatch) -> bool:
+    """Whether the active DSA implementation returns natural-log LSE."""
+    dsa_backend = get_attn_backend()
+    forward_mode = forward_batch.forward_mode
+    use_decode_impl = (
+        forward_mode.is_decode_or_idle()
+        or forward_mode.is_target_verify()
+        or forward_mode.is_draft_extend_v2()
+    )
+    dsa_impl = (
+        dsa_backend.dsa_decode_impl
+        if use_decode_impl
+        else dsa_backend.dsa_prefill_impl
+    )
+    return dsa_impl == "flashmla_kv"
+
+
+def _zero_dsa_dcp_padding(
+    attn_output: torch.Tensor, forward_batch: ForwardBatch
+) -> None:
+    """Clear attention-TP padding from DSA DCP outputs."""
+    num_valid_tokens = (
+        forward_batch.extend_num_tokens
+        if get_attn_tp_context().input_scattered
+        else forward_batch.num_token_non_padded_cpu
+    )
+    if num_valid_tokens is not None and num_valid_tokens < attn_output.shape[0]:
+        attn_output[num_valid_tokens:] = 0
 
 
 if _is_cuda:
@@ -154,6 +196,10 @@ class DeepseekMLAForwardMixin:
         if not is_graph_dsa_split_op_surface(forward_batch):
             return False
         if not self.use_dsa:
+            return False
+        # DCP must receive each rank's local LSE so it can combine partial
+        # attention outputs. The composite graph op only returns the output.
+        if get_parallel().dcp_enabled:
             return False
         if self.use_deep_gemm_bmm:
             return False
@@ -617,7 +663,8 @@ class DeepseekMLAForwardMixin:
                 k_pe,
             )
 
-        # all_gather q_pe, q_nope_out,take tp8 as an example， q_pe [B, H, ROPE_DIM], q_nope_out [B, H, NOPE_DIM] gathered to [B, H * dcp_world_size, ROPE_DIM] [B, H * dcp_world_size, NOPE_DIM] for decode batch, and all gather k_pe, k_nope for extend batch.
+        # Decode and DSA TP-prefill gather Q and reduce partial attention with
+        # LSE. DSA CP-prefill (like dense MLA prefill) gathers KV instead.
         if get_parallel().dcp_enabled:
             if is_dcp_mla_decode_phase(forward_batch):
                 if not q_replicate_active:
@@ -625,19 +672,26 @@ class DeepseekMLAForwardMixin:
                         q_nope_out=q_nope_out,
                         q_pe=q_pe,
                     )
-            elif forward_batch.forward_mode.is_extend():
-                # for extend, gather kv
-                all_gather_kv_cache_for_mla_extend(
-                    get_token_to_kv_pool(),
-                    self.attn_mqa,
-                    forward_batch.extend_prefix_lens_cpu,
-                    forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
-                    forward_batch.attn_dcp_metadata.dcp_extend_prefix_lens_sum,
-                    forward_batch.attn_dcp_metadata.dcp_kv_buffer,
-                    self.kv_lora_rank,
-                    k_nope,
-                    k_pe,
-                )
+            elif forward_batch.forward_mode.is_extend(include_draft_extend_v2=True):
+                if is_dsa_tp_dcp_prefill_phase(
+                    forward_batch, use_dsa=self.use_dsa
+                ):
+                    q_nope_out, q_pe = all_gather_q_for_mla_decode(
+                        q_nope_out=q_nope_out,
+                        q_pe=q_pe,
+                    )
+                else:
+                    all_gather_kv_cache_for_mla_extend(
+                        get_token_to_kv_pool(),
+                        self.attn_mqa,
+                        forward_batch.extend_prefix_lens_cpu,
+                        forward_batch.attn_dcp_metadata.dcp_local_prefix_kv_indices,
+                        forward_batch.attn_dcp_metadata.dcp_extend_prefix_lens_sum,
+                        forward_batch.attn_dcp_metadata.dcp_kv_buffer,
+                        self.kv_lora_rank,
+                        k_nope,
+                        k_pe,
+                    )
             else:
                 logger.warning(
                     f"not supported forward_mode {forward_batch.forward_mode}"
@@ -670,6 +724,9 @@ class DeepseekMLAForwardMixin:
         fusion_plan: Optional[MlaBmmFusionPlan] = None,
     ):
         save_kv_cache = True
+        # Set only by the DCP attention branches; the combine below asserts on
+        # it so a fusion path silently skipping the LSE fails loudly.
+        lse = None
 
         if self.current_attention_backend in FORWARD_ABSORB_CORE_ATTENTION_BACKENDS:
             extra_args = {}
@@ -702,8 +759,13 @@ class DeepseekMLAForwardMixin:
                     topk_indices=topk_indices,
                 )
                 attn_output = fusion_plan.attn_output_buf
-            elif is_dcp_mla_decode_phase(forward_batch):
-                # set return_lse=True to correct attn_output
+            elif is_dcp_mla_decode_phase(
+                forward_batch
+            ) or is_dsa_tp_dcp_prefill_phase(
+                forward_batch, use_dsa=self.use_dsa
+            ):
+                # Q-gather DCP (decode and TP+DCP extend) attends each rank's
+                # local KV shard and returns an LSE for cross-rank combine.
                 attn_output, lse = self.attn_mqa_for_dcp_decode(
                     q_nope_out,
                     k_nope,
@@ -749,9 +811,17 @@ class DeepseekMLAForwardMixin:
                 save_kv_cache=save_kv_cache,
                 **(dict(topk_indices=topk_indices) if topk_indices is not None else {}),
             )
+        if self.use_dsa and get_parallel().dcp_enabled:
+            _zero_dsa_dcp_padding(attn_output, forward_batch)
 
         # correct attn_output with respect to lse from other ranks
-        if is_dcp_mla_decode_phase(forward_batch):
+        if is_dcp_mla_decode_phase(
+            forward_batch
+        ) or is_dsa_tp_dcp_prefill_phase(forward_batch, use_dsa=self.use_dsa):
+            assert lse is not None, (
+                "DCP LSE combine reached without an LSE — the attention call "
+                "above must go through the attn_mqa_for_dcp_decode branch."
+            )
             attn_output = attn_output.view(
                 -1,
                 self.num_local_heads * get_parallel().attn_dcp_size,
@@ -766,11 +836,13 @@ class DeepseekMLAForwardMixin:
                 )
             else:
                 dcp_comm_backend = get_parallel().dcp_comm_backend
-                is_lse_base_on_e = is_mla_dcp_lse_base_on_e(
-                    self.current_attention_backend
+                is_lse_base_on_e = (
+                    is_dsa_dcp_lse_base_on_e(forward_batch)
+                    if self.use_dsa
+                    else is_mla_dcp_lse_base_on_e(self.current_attention_backend)
                 )
                 if dcp_comm_backend in ("a2a", "fi_a2a"):
-                    # A2A exchange of head partials + LSE, then local Triton combine.
+                    # Exchange head partials + LSE, then combine locally.
                     attn_output = dcp_a2a_lse_reduce(
                         attn_output.contiguous(),
                         lse.contiguous(),

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -153,7 +153,10 @@ from sglang.srt.model_executor.cuda_graph_config import (
     check_cuda_graph_backend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardBatch, PPProxyTensors
-from sglang.srt.model_executor.forward_context import get_attn_backend
+from sglang.srt.model_executor.forward_context import (
+    get_attn_backend,
+    get_token_to_kv_pool,
+)
 from sglang.srt.model_executor.runner import get_is_capture_mode
 from sglang.srt.model_executor.runner_backend_utils.breakable_cuda_graph.context import (
     is_in_breakable_cuda_graph,
@@ -3213,6 +3216,17 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
         kv_cache_device,
         create_chunked_prefix_cache_kv_indices_fn,
     ):
+        kv_buffer_token_padding = 1
+        if is_deepseek_dsa(self.config):
+            # DSA TP+DCP uses Q gather and does not need a temporary KV view.
+            # CP+DCP gathers KV into a temporary buffer whose row layout and
+            # dtype match the token-to-KV pool values supplied by the caller.
+            if not (is_dsa_enable_prefill_cp() and get_parallel().attn_cp_size > 1):
+                return None
+            token_to_kv_pool = get_token_to_kv_pool()
+            # FlashMLA reshapes the flat gathered storage into physical pages.
+            # Logical DCP indices cover only the valid rows; padding is storage-only.
+            kv_buffer_token_padding = token_to_kv_pool.page_size
         return prepare_decode_context_parallel_metadata(
             seq_lens=seq_lens,
             extend_prefix_lens=extend_prefix_lens,
@@ -3225,6 +3239,7 @@ class DeepseekV2ForCausalLM(nn.Module, DeepseekV2WeightLoaderMixin):
             kv_cache_dtype=kv_cache_dtype,
             kv_cache_device=kv_cache_device,
             create_chunked_prefix_cache_kv_indices_fn=create_chunked_prefix_cache_kv_indices_fn,
+            kv_buffer_token_padding=kv_buffer_token_padding,
         )
 
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4045,12 +4045,6 @@ class ServerArgs:
                 "requires --dcp-size / --decode-context-parallel-size > 1, but "
                 f"got dcp_size={self.dcp_size}."
             )
-        if self.dcp_size > 1 and is_cuda() and self.speculative_algorithm is not None:
-            raise ValueError(
-                "Decode context parallel (--dcp-size > 1) does not currently "
-                "support speculative decoding on CUDA. Disable speculative "
-                "decoding or set --dcp-size 1."
-            )
         if self.dcp_comm_backend == "fi_a2a" and not is_cuda():
             raise ValueError(
                 "--dcp-comm-backend fi_a2a delegates the exchange to FlashInfer's "
@@ -6618,6 +6612,16 @@ class ServerArgs:
         if self.enable_prefill_cp and self.cp_strategy is None:
             raise ValueError(
                 "--cp-strategy must be set when --enable-prefill-cp is enabled."
+            )
+
+        if (
+            self.enable_prefill_cp
+            and self.dcp_size > 1
+            and self.cp_strategy != "interleave"
+        ):
+            raise ValueError(
+                "DCP with prefill CP currently supports only "
+                "--cp-strategy interleave."
             )
 
         if (

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -4045,6 +4045,12 @@ class ServerArgs:
                 "requires --dcp-size / --decode-context-parallel-size > 1, but "
                 f"got dcp_size={self.dcp_size}."
             )
+        if self.dcp_size > 1 and is_cuda() and self.speculative_algorithm is not None:
+            raise ValueError(
+                "Decode context parallel (--dcp-size > 1) does not currently "
+                "support speculative decoding on CUDA. Disable speculative "
+                "decoding or set --dcp-size 1."
+            )
         if self.dcp_comm_backend == "fi_a2a" and not is_cuda():
             raise ValueError(
                 "--dcp-comm-backend fi_a2a delegates the exchange to FlashInfer's "

--- a/test/registered/attention/unittests/dsa/test_dsa.py
+++ b/test/registered/attention/unittests/dsa/test_dsa.py
@@ -1,8 +1,15 @@
 import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
 
 import torch
 
+from sglang.srt.layers.attention.dsa_backend import DeepseekSparseAttnBackend
+from sglang.srt.layers.dcp.metadata import DecodeContextParallelMetadata
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.models.deepseek_common.attention_forward_methods import (
+    forward_mla,
+)
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.dsa_attention import (
     DSA_DECODE_IMPL_VARIANTS,
@@ -32,6 +39,66 @@ from sglang.test.test_utils import CustomTestCase
 
 register_cuda_ci(est_time=25, stage="base-b", runner_config="4-gpu-b200")
 register_cuda_ci(est_time=25, stage="base-b", runner_config="1-gpu-large")
+
+
+class TestDSADCPRouting(CustomTestCase):
+    def test_tp_dcp_prefill_selects_q_gather_phase(self):
+        batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+        with (
+            patch.object(
+                forward_mla,
+                "get_parallel",
+                return_value=SimpleNamespace(dcp_enabled=True),
+            ),
+            patch.object(forward_mla, "dsa_use_prefill_cp", return_value=False),
+        ):
+            self.assertTrue(
+                forward_mla.is_dsa_tp_dcp_prefill_phase(batch, use_dsa=True)
+            )
+
+    def test_cp_dcp_prefill_does_not_enter_q_gather_phase(self):
+        batch = SimpleNamespace(forward_mode=ForwardMode.EXTEND)
+        with (
+            patch.object(
+                forward_mla,
+                "get_parallel",
+                return_value=SimpleNamespace(dcp_enabled=True),
+            ),
+            patch.object(forward_mla, "dsa_use_prefill_cp", return_value=True),
+        ):
+            self.assertFalse(
+                forward_mla.is_dsa_tp_dcp_prefill_phase(batch, use_dsa=True)
+            )
+
+    def test_decode_topk_rejects_extra_rank_rows(self):
+        backend = DeepseekSparseAttnBackend.__new__(DeepseekSparseAttnBackend)
+        topk_indices = torch.zeros((8, 4), dtype=torch.int32)
+
+        with self.assertRaisesRegex(
+            AssertionError,
+            r"topk_indices rows \(8\) > num_tokens \(4\)",
+        ):
+            backend._pad_topk_indices(topk_indices, num_tokens=4)
+
+
+class TestDSACPDCPPrefillPageTable(CustomTestCase):
+    def test_builds_cp_dcp_page_table_for_gathered_kv(self):
+        backend = DeepseekSparseAttnBackend.__new__(DeepseekSparseAttnBackend)
+        metadata = DecodeContextParallelMetadata(
+            dcp_kv_indptr=torch.tensor([0, 3, 5], dtype=torch.int32),
+            dcp_kv_indices=torch.tensor([0, 1, 2, 3, 4], dtype=torch.int32),
+        )
+
+        page_table = backend._build_dcp_prefill_page_table(
+            torch.tensor([3, 2], dtype=torch.int32), metadata
+        )
+
+        torch.testing.assert_close(
+            page_table,
+            torch.tensor([[0, 1, 2], [3, 4, -1]], dtype=torch.int32),
+            rtol=0,
+            atol=0,
+        )
 
 
 @unittest.skipIf(not torch.cuda.is_available(), "CUDA is required")

--- a/test/registered/dcp/test_dsa_dcp_kv_gather.py
+++ b/test/registered/dcp/test_dsa_dcp_kv_gather.py
@@ -8,6 +8,8 @@ import torch
 
 from sglang.srt.layers.dcp import comm as dcp_comm
 from sglang.srt.layers.dcp import planner as dcp_planner
+from sglang.srt.mem_cache.memory_pool import DSATokenToKVPool
+from sglang.srt.runtime_context import get_parallel
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -89,6 +91,93 @@ class TestDSADCPMetadataPlanner(CustomTestCase):
                 torch.testing.assert_close(
                     metadata.dcp_local_prefix_kv_indices,
                     torch.tensor([0, 2], dtype=torch.int32),
+                    rtol=0,
+                    atol=0,
+                )
+
+    def test_indexer_cache_covers_widened_allocator_padding(self):
+        size = 4 * 64
+        page_size = 64
+        dcp_size = 8
+        with get_parallel().override(
+            dcp_enabled=True,
+            attn_dcp_size=dcp_size,
+        ):
+            pool = DSATokenToKVPool(
+                size=size,
+                page_size=page_size,
+                kv_lora_rank=KV_LORA_RANK,
+                dtype=torch.bfloat16,
+                qk_rope_head_dim=QK_ROPE_HEAD_DIM,
+                layer_num=1,
+                device="cpu",
+                index_head_dim=128,
+                enable_memory_saver=False,
+                kv_cache_dim=RAW_KV_ROW_WIDTH,
+            )
+
+        indexer_capacity = pool.index_k_with_scale_buffer[0].shape[0] * page_size
+        self.assertEqual(indexer_capacity, (size + page_size) * dcp_size)
+
+    def test_flashmla_metadata_uses_kernel_head_bucket(self):
+        from sglang.srt.layers.attention.dsa_backend import (
+            DeepseekSparseAttnBackend,
+        )
+
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        backend.dsa_index_topk = 2048
+        cache_seqlens = torch.ones(2, dtype=torch.int32)
+        # Default decode heads may differ from an explicit CP-prefill layout.
+        for decode_heads, prefill_heads, expected in (
+            (128, None, 128),
+            (32, None, 64),
+            (32, 128, 128),
+            (8, None, 64),
+        ):
+            with (
+                self.subTest(decode=decode_heads, prefill=prefill_heads),
+                patch(
+                    "sgl_kernel.flash_mla.get_mla_metadata", return_value=(None, None)
+                ) as get_metadata,
+            ):
+                backend.flashmla_decode_q_heads = decode_heads
+                backend._compute_flashmla_metadata(
+                    cache_seqlens, seq_len_q=1, num_q_heads=prefill_heads
+                )
+                self.assertEqual(get_metadata.call_args.kwargs["num_heads_q"], expected)
+                self.assertEqual(
+                    get_metadata.call_args.kwargs["num_q_tokens_per_head_k"], expected
+                )
+
+    def test_prefill_page_table_preserves_original_batch_segments(self):
+        from sglang.srt.layers.attention.dsa_backend import (
+            DeepseekSparseAttnBackend,
+        )
+
+        backend = object.__new__(DeepseekSparseAttnBackend)
+        dcp_meta = SimpleNamespace(
+            dcp_kv_indptr=torch.tensor([0, 2, 5, 6], dtype=torch.int32),
+            dcp_kv_indices=torch.tensor([4, 5, 10, 11, 12, 20], dtype=torch.int32),
+        )
+
+        for batch_indices, seq_lens, expected in (
+            (
+                [0, 1, 2],
+                [2, 3, 1],
+                [[4, 5, -1], [10, 11, 12], [20, -1, -1]],
+            ),
+            ([1, 2], [3, 1], [[10, 11, 12], [20, -1, -1]]),
+        ):
+            with self.subTest(batch_indices=batch_indices):
+                page_table = backend._build_dcp_prefill_page_table(
+                    seq_lens=torch.tensor(seq_lens, dtype=torch.int32),
+                    dcp_meta=dcp_meta,
+                    selected_batch_indices=batch_indices,
+                )
+
+                torch.testing.assert_close(
+                    page_table,
+                    torch.tensor(expected, dtype=torch.int32),
                     rtol=0,
                     atol=0,
                 )

--- a/test/registered/dcp/test_dsa_dcp_kv_gather.py
+++ b/test/registered/dcp/test_dsa_dcp_kv_gather.py
@@ -1,0 +1,243 @@
+"""Tests for the temporary KV buffer used by DSA CP+DCP prefill."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
+
+from sglang.srt.layers.dcp import comm as dcp_comm
+from sglang.srt.layers.dcp import planner as dcp_planner
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+KV_LORA_RANK = 512
+QK_ROPE_HEAD_DIM = 64
+RAW_KV_ROW_WIDTH = KV_LORA_RANK + QK_ROPE_HEAD_DIM
+PACKED_NOPE_ROW_BYTES = 528
+PACKED_ROPE_ROW_BYTES = 128
+PACKED_KV_ROW_WIDTH = PACKED_NOPE_ROW_BYTES + PACKED_ROPE_ROW_BYTES
+
+
+class _FakeTritonKernel:
+    def __init__(self, callback):
+        self.callback = callback
+
+    def __getitem__(self, _grid):
+        return self.callback
+
+
+class TestDSADCPMetadataPlanner(CustomTestCase):
+    def _prepare_metadata(self, kv_dtype: torch.dtype, row_width: int):
+        prefix_indices = torch.tensor([0, 1, 4, 5], dtype=torch.int32)
+
+        def fill_prefix_indices(*args, **_kwargs):
+            args[5].copy_(prefix_indices)
+
+        def fill_dcp_indices(*args, **_kwargs):
+            args[5].copy_(torch.arange(args[5].numel(), dtype=torch.int32))
+
+        parallel = SimpleNamespace(dcp_enabled=True, dcp_size=2, dcp_rank=1)
+        device = SimpleNamespace(device=torch.device("cpu"))
+        with (
+            patch.object(dcp_planner, "get_parallel", return_value=parallel),
+            patch.object(dcp_planner, "get_device", return_value=device),
+            patch.object(
+                dcp_planner,
+                "create_dcp_kv_indices",
+                _FakeTritonKernel(fill_dcp_indices),
+            ),
+        ):
+            return dcp_planner.prepare_decode_context_parallel_metadata(
+                seq_lens=torch.tensor([3, 2], dtype=torch.int32),
+                extend_prefix_lens=torch.tensor([2, 2], dtype=torch.int32),
+                extend_prefix_lens_cpu=[2, 2],
+                extend_seq_lens=torch.tensor([1, 0], dtype=torch.int32),
+                req_pool_indices=torch.tensor([0, 1], dtype=torch.int32),
+                req_to_token=torch.empty((2, 8), dtype=torch.int32),
+                seq_lens_sum=5,
+                kv_buffer_shape=torch.Size([128, 1, row_width]),
+                kv_cache_dtype=kv_dtype,
+                kv_cache_device=torch.device("cpu"),
+                create_chunked_prefix_cache_kv_indices_fn=_FakeTritonKernel(
+                    fill_prefix_indices
+                ),
+                kv_buffer_token_padding=64,
+            )
+
+    def test_preserves_raw_and_packed_kv_buffer_layouts(self):
+        cases = [
+            (torch.float16, RAW_KV_ROW_WIDTH),
+            (torch.bfloat16, RAW_KV_ROW_WIDTH),
+        ]
+        if hasattr(torch, "float8_e4m3fn"):
+            cases.append((torch.float8_e4m3fn, PACKED_KV_ROW_WIDTH))
+
+        for kv_dtype, row_width in cases:
+            with self.subTest(kv_dtype=kv_dtype, row_width=row_width):
+                metadata = self._prepare_metadata(kv_dtype, row_width)
+                self.assertEqual(metadata.dcp_kv_buffer.shape, (64, 1, row_width))
+                self.assertEqual(metadata.dcp_kv_buffer.dtype, kv_dtype)
+                torch.testing.assert_close(
+                    metadata.dcp_kv_indptr,
+                    torch.tensor([0, 3, 5], dtype=torch.int32),
+                    rtol=0,
+                    atol=0,
+                )
+                torch.testing.assert_close(
+                    metadata.dcp_local_prefix_kv_indices,
+                    torch.tensor([0, 2], dtype=torch.int32),
+                    rtol=0,
+                    atol=0,
+                )
+
+
+class TestDSADCPKVBufferGather(CustomTestCase):
+    def test_dcp_gather_restores_request_order(self):
+        local_prefix = torch.tensor([0, 2, 10], dtype=torch.float16).view(3, 1, 1)
+        gathered_padded = torch.tensor(
+            [0, 1, 2, 99, 10, 11], dtype=torch.float16
+        ).view(6, 1, 1)
+        parallel = SimpleNamespace(dcp_enabled=True, dcp_size=2, dcp_rank=0)
+
+        with (
+            patch.object(dcp_comm, "get_parallel", return_value=parallel),
+            patch.object(
+                dcp_comm,
+                "_all_gather_dcp_kv_cache",
+                return_value=gathered_padded,
+            ),
+        ):
+            actual = dcp_comm.all_gather_kv_cache_for_dcp(
+                prefix_kv_a=local_prefix,
+                prefix_k_pe=None,
+                prefix_kv_lens_cpu=torch.tensor([3, 2], dtype=torch.int32),
+            )
+
+        expected = torch.tensor([0, 1, 2, 10, 11], dtype=torch.float16)
+        torch.testing.assert_close(actual.flatten(), expected, rtol=0, atol=0)
+
+    def test_raw_kv_gather_preserves_dtype_and_appends_extend_tokens(self):
+        for kv_dtype in (torch.float16, torch.bfloat16):
+            with self.subTest(kv_dtype=kv_dtype):
+                prefix = torch.arange(2 * RAW_KV_ROW_WIDTH, dtype=torch.float32)
+                prefix = prefix.view(2, 1, RAW_KV_ROW_WIDTH).to(kv_dtype)
+                cache_nope = torch.empty((1, 1, KV_LORA_RANK), dtype=kv_dtype)
+                cache_rope = torch.empty((1, 1, QK_ROPE_HEAD_DIM), dtype=kv_dtype)
+                pool = SimpleNamespace(
+                    dsa_kv_cache_store_fp8=False,
+                    get_mla_kv_buffer=MagicMock(
+                        return_value=(cache_nope, cache_rope)
+                    ),
+                )
+                attn_mqa = SimpleNamespace(layer_id=3)
+                k_nope = torch.full((2, 1, KV_LORA_RANK), 7, dtype=kv_dtype)
+                k_pe = torch.full((2, 1, QK_ROPE_HEAD_DIM), 11, dtype=kv_dtype)
+                buffer = torch.full((8, 1, RAW_KV_ROW_WIDTH), 19, dtype=kv_dtype)
+
+                with patch.object(
+                    dcp_comm, "all_gather_kv_cache_for_dcp", return_value=prefix
+                ):
+                    dcp_comm.all_gather_kv_cache_for_mla_extend(
+                        pool,
+                        attn_mqa,
+                        extend_prefix_lens_cpu=[2],
+                        dcp_local_prefix_kv_indices=torch.tensor(
+                            [0], dtype=torch.int32
+                        ),
+                        dcp_extend_prefix_lens_sum=2,
+                        dcp_kv_buffer=buffer,
+                        kv_lora_rank=KV_LORA_RANK,
+                        k_nope=k_nope,
+                        k_pe=k_pe,
+                    )
+
+                pool.get_mla_kv_buffer.assert_called_once()
+                self.assertEqual(
+                    pool.get_mla_kv_buffer.call_args.kwargs["dst_dtype"], kv_dtype
+                )
+                torch.testing.assert_close(buffer[:2], prefix)
+                torch.testing.assert_close(
+                    buffer[2:4, ..., :KV_LORA_RANK], k_nope
+                )
+                torch.testing.assert_close(
+                    buffer[2:4, ..., KV_LORA_RANK:], k_pe
+                )
+                self.assertEqual(torch.count_nonzero(buffer[4:]).item(), 0)
+
+    @unittest.skipUnless(
+        hasattr(torch, "float8_e4m3fn"), "PyTorch FP8 support is required."
+    )
+    def test_packed_fp8_gather_is_byte_exact(self):
+        persistent_bytes = (
+            torch.arange(8 * PACKED_KV_ROW_WIDTH, dtype=torch.int64)
+            .remainder(251)
+            .to(torch.uint8)
+            .view(8, 1, PACKED_KV_ROW_WIDTH)
+        )
+        persistent = persistent_bytes.view(torch.float8_e4m3fn)
+        pool = SimpleNamespace(
+            dsa_kv_cache_store_fp8=True,
+            get_key_buffer=MagicMock(return_value=persistent),
+        )
+        attn_mqa = SimpleNamespace(layer_id=5)
+        gathered_prefix = persistent_bytes[[1, 3]].clone()
+        current_nope = torch.full(
+            (2, 1, PACKED_NOPE_ROW_BYTES), 17, dtype=torch.uint8
+        )
+        current_rope = torch.full(
+            (2, 1, PACKED_ROPE_ROW_BYTES), 29, dtype=torch.uint8
+        )
+        buffer = torch.empty(
+            (8, 1, PACKED_KV_ROW_WIDTH), dtype=torch.float8_e4m3fn
+        )
+        buffer.view(torch.uint8).fill_(255)
+
+        with (
+            patch.object(
+                dcp_comm,
+                "all_gather_kv_cache_for_dcp",
+                return_value=gathered_prefix,
+            ) as gather_mock,
+            patch(
+                "sglang.kernels.ops.attention.dsa.quant_k_cache."
+                "quantize_k_cache_separate",
+                return_value=(current_nope, current_rope),
+            ),
+        ):
+            dcp_comm.all_gather_kv_cache_for_mla_extend(
+                pool,
+                attn_mqa,
+                extend_prefix_lens_cpu=[2],
+                dcp_local_prefix_kv_indices=torch.tensor([1, 3]),
+                dcp_extend_prefix_lens_sum=2,
+                dcp_kv_buffer=buffer,
+                kv_lora_rank=KV_LORA_RANK,
+                k_nope=torch.empty((2, 1, KV_LORA_RANK), dtype=torch.bfloat16),
+                k_pe=torch.empty((2, 1, QK_ROPE_HEAD_DIM), dtype=torch.bfloat16),
+            )
+
+        pool.get_key_buffer.assert_called_once_with(5)
+        gathered_input = gather_mock.call_args.args[0]
+        self.assertEqual(gathered_input.dtype, torch.uint8)
+        self.assertTrue(torch.equal(gathered_input, gathered_prefix))
+
+        buffer_bytes = buffer.view(torch.uint8)
+        self.assertTrue(torch.equal(buffer_bytes[:2], gathered_prefix))
+        self.assertTrue(
+            torch.equal(
+                buffer_bytes[2:4, ..., :PACKED_NOPE_ROW_BYTES], current_nope
+            )
+        )
+        self.assertTrue(
+            torch.equal(
+                buffer_bytes[2:4, ..., PACKED_NOPE_ROW_BYTES:], current_rope
+            )
+        )
+        self.assertEqual(torch.count_nonzero(buffer_bytes[4:]).item(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/kernels/ops/attention/test_dsa_transform_index.py
+++ b/test/registered/kernels/ops/attention/test_dsa_transform_index.py
@@ -84,6 +84,14 @@ class TestDSATransformIndex(CustomTestCase):
         expected[:real_num_tokens][real_topk < 0] = -1
         return expected
 
+    def _expected_dcp_rank(
+        self, global_indices: torch.Tensor, dcp_size: int, dcp_rank: int
+    ) -> torch.Tensor:
+        owned = (global_indices >= 0) & (
+            global_indices.remainder(dcp_size) == dcp_rank
+        )
+        return torch.where(owned, global_indices // dcp_size, -1)
+
     def _check_decode_case(
         self,
         batch_size: int,
@@ -230,6 +238,66 @@ class TestDSATransformIndex(CustomTestCase):
     def test_decode_fast_correctness_and_strides(self):
         self._check_decode_case(17, 8192, provide_result=True)
         self._check_decode_case(17, 8192, zero_row_stride=True)
+
+    def test_decode_filters_and_localizes_dcp_owned_slots(self):
+        batch_size = 3
+        context_length = 4096
+        dcp_size = 4
+        page_table = self._make_page_table(batch_size, context_length)
+        topk_indices = self._make_topk(batch_size, context_length)
+        global_indices = torch.empty(
+            (batch_size, TOPK), dtype=torch.int32, device=self.device
+        )
+        torch.gather(
+            page_table,
+            dim=1,
+            index=topk_indices.clamp(min=0),
+            out=global_indices,
+        )
+        global_indices[topk_indices < 0] = -1
+
+        for dcp_rank in range(dcp_size):
+            with self.subTest(dcp_rank=dcp_rank):
+                actual = transform_index_page_table_decode_fast(
+                    page_table=page_table,
+                    topk_indices=topk_indices,
+                    dcp_size=dcp_size,
+                    dcp_rank=dcp_rank,
+                )
+                expected = self._expected_dcp_rank(
+                    global_indices, dcp_size, dcp_rank
+                )
+                torch.cuda.synchronize()
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
+
+    def test_prefill_filters_and_localizes_dcp_owned_slots(self):
+        extend_lens_cpu = [2, 1]
+        context_length = 4096
+        dcp_size = 4
+        page_table = self._make_page_table(len(extend_lens_cpu), context_length)
+        topk_indices = self._make_topk(sum(extend_lens_cpu), context_length)
+        global_indices = self._expected(
+            page_table,
+            topk_indices,
+            extend_lens_cpu,
+            sum(extend_lens_cpu),
+            page_table_is_expanded=False,
+        )
+
+        for dcp_rank in range(dcp_size):
+            with self.subTest(dcp_rank=dcp_rank):
+                actual = transform_index_page_table_prefill_fast(
+                    page_table=page_table,
+                    topk_indices=topk_indices,
+                    extend_lens_cpu=extend_lens_cpu,
+                    dcp_size=dcp_size,
+                    dcp_rank=dcp_rank,
+                )
+                expected = self._expected_dcp_rank(
+                    global_indices, dcp_size, dcp_rank
+                )
+                torch.cuda.synchronize()
+                torch.testing.assert_close(actual, expected, rtol=0, atol=0)
 
     def test_decode_fast_extreme_shapes(self):
         self._check_decode_case(8192, 4096)

--- a/test/registered/kernels/test_dcp_lse_combine.py
+++ b/test/registered/kernels/test_dcp_lse_combine.py
@@ -238,6 +238,59 @@ class TestLSECombineEdgeCases(CustomTestCase):
             triton_result.float().cpu(), expected.cpu(), atol=1e-2, rtol=1e-2
         )
 
+    def test_all_invalid_lse_returns_zero_output(self):
+        from sglang.kernels.ops.attention.dcp_kernels import dcp_lse_combine_triton
+
+        partial_outputs = torch.randn(
+            4, 2, 3, 64, device=self.device, dtype=torch.bfloat16
+        )
+        partial_outputs[1].fill_(float("nan"))
+        partial_outputs[2].fill_(float("inf"))
+        partial_lses = torch.full(
+            (4, 2, 3),
+            float("-inf"),
+            device=self.device,
+            dtype=torch.float32,
+        )
+
+        for is_base_e in (True, False):
+            with self.subTest(is_base_e=is_base_e):
+                output, lse = dcp_lse_combine_triton(
+                    partial_outputs,
+                    partial_lses,
+                    is_lse_base_on_e=is_base_e,
+                    return_lse=True,
+                )
+
+                self.assertTrue(torch.equal(output, torch.zeros_like(output)))
+                self.assertIsNotNone(lse)
+                self.assertTrue(torch.isneginf(lse).all())
+
+    def test_zero_weight_shards_ignore_nonfinite_outputs(self):
+        from sglang.kernels.ops.attention.dcp_kernels import dcp_lse_combine_triton
+
+        outputs = torch.full(
+            (4, 2, 3, 64), float("nan"), device=self.device, dtype=torch.bfloat16
+        )
+        outputs[0].fill_(2.0)
+        outputs[2].fill_(6.0)
+        outputs[3].fill_(float("inf"))
+        lses = torch.full((4, 2, 3), float("-inf"), device=self.device)
+        lses[0].zero_()
+        lses[2].zero_()
+
+        for is_base_e in (True, False):
+            with self.subTest(is_base_e=is_base_e):
+                output, lse = dcp_lse_combine_triton(
+                    outputs, lses, is_lse_base_on_e=is_base_e, return_lse=True
+                )
+
+                torch.testing.assert_close(output, torch.full_like(output, 4.0))
+                self.assertIsNotNone(lse)
+                total_weight = torch.full_like(lse, 2.0)
+                expected_lse = total_weight.log() if is_base_e else total_weight.log2()
+                torch.testing.assert_close(lse, expected_lse)
+
 
 class TestCPUReference(CustomTestCase):
     """Test the CPU reference implementation independently."""
@@ -252,6 +305,41 @@ class TestCPUReference(CustomTestCase):
         result = _lse_weighted_combine_cpu(outputs, lses, is_lse_base_on_e=True)
         self.assertEqual(result.shape, (B, H, D))
         self.assertFalse(torch.isnan(result).any())
+
+    def test_all_invalid_lse_returns_zero_output(self):
+        from sglang.kernels.ops.attention.dcp_kernels import _lse_weighted_combine_cpu
+
+        outputs = torch.randn(4, 2, 3, 8)
+        outputs[1].fill_(float("nan"))
+        outputs[2].fill_(float("inf"))
+        lses = torch.full((4, 2, 3), float("-inf"))
+
+        for is_base_e in (True, False):
+            with self.subTest(is_base_e=is_base_e):
+                result = _lse_weighted_combine_cpu(
+                    outputs, lses, is_lse_base_on_e=is_base_e
+                )
+
+                self.assertTrue(torch.equal(result, torch.zeros_like(result)))
+
+    def test_zero_weight_shards_ignore_nonfinite_outputs(self):
+        from sglang.kernels.ops.attention.dcp_kernels import _lse_weighted_combine_cpu
+
+        outputs = torch.full((4, 2, 3, 8), float("nan"))
+        outputs[0].fill_(2.0)
+        outputs[2].fill_(6.0)
+        outputs[3].fill_(float("inf"))
+        lses = torch.full((4, 2, 3), float("-inf"))
+        lses[0].zero_()
+        lses[2].zero_()
+
+        for is_base_e in (True, False):
+            with self.subTest(is_base_e=is_base_e):
+                result = _lse_weighted_combine_cpu(
+                    outputs, lses, is_lse_base_on_e=is_base_e
+                )
+
+                torch.testing.assert_close(result, torch.full_like(result, 4.0))
 
     def test_base2_vs_base_e(self):
         from sglang.kernels.ops.attention.dcp_kernels import _lse_weighted_combine_cpu

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -20,7 +20,7 @@ register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 
 @contextlib.contextmanager
-def mock_cpu_env(kv_size=2, tp_size=1, swa_eviction_interval=4):
+def mock_cpu_env(kv_size=2, tp_size=1, dcp_size=1, swa_eviction_interval=4):
     """Mock GPU-dependent functions for CPU-only testing.
 
     swa_eviction_interval pins SGLANG_SWA_EVICTION_INTERVAL (decode batches between
@@ -31,7 +31,10 @@ def mock_cpu_env(kv_size=2, tp_size=1, swa_eviction_interval=4):
 
     with (
         patch("torch._utils._element_size", return_value=kv_size),
-        get_parallel().override(attn_tp_size=tp_size),
+        get_parallel().override(
+            attn_tp_size=tp_size,
+            attn_dcp_size=dcp_size,
+        ),
         envs.SGLANG_SWA_EVICTION_INTERVAL.override(swa_eviction_interval),
     ):
         yield
@@ -287,6 +290,35 @@ class TestDefaultConfigurator(CustomTestCase):
         self.assertEqual(raw_configurator._cell_size, (576 + 132) * num_layers)
         self.assertEqual(packed_configurator._cell_size, (656 + 132) * num_layers)
         self.assertEqual(mock_calculate_mla_kv_cache_dim.call_count, 2)
+
+    @patch(
+        "sglang.srt.mem_cache.kv_cache_configurator.calculate_mla_kv_cache_dim",
+        return_value=576,
+    )
+    def test_dsa_dcp_prices_replicated_indexer_cache(
+        self,
+        _mock_calculate_mla_kv_cache_dim,
+    ):
+        num_layers = 2
+        dcp_size = 8
+        runner = _make_model_runner(
+            self,
+            num_layers=num_layers,
+            use_mla_backend=True,
+        )
+        _configure_dsa_model(runner)
+
+        with mock_cpu_env(kv_size=1, dcp_size=dcp_size):
+            from sglang.srt.model_executor.pool_configurator import (
+                DefaultPoolConfigurator,
+            )
+
+            configurator = DefaultPoolConfigurator(runner)
+
+        self.assertEqual(
+            configurator._cell_size,
+            (576 + 132 * dcp_size) * num_layers,
+        )
 
 
 class TestHybridSWAConfigurator(CustomTestCase):

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -497,6 +497,18 @@ class TestMultimodalFeatureTransport(CustomTestCase):
             server_args._handle_multimodal_feature_transport()
 
 
+class TestDCPValidation(unittest.TestCase):
+    @patch("sglang.srt.server_args.is_cuda", return_value=True)
+    def test_cuda_dcp_speculative_is_not_rejected_globally(self, _mock_is_cuda):
+        server_args = ServerArgs(
+            model_path="dummy",
+            dcp_size=8,
+            speculative_algorithm="EAGLE",
+        )
+
+        server_args._handle_dcp_validation()
+
+
 class TestMambaCacheStochasticRounding(unittest.TestCase):
     def test_rejects_fp32_ssm_cache(self):
         server_args = ServerArgs(
@@ -892,6 +904,7 @@ class TestContextParallelServerArgs(CustomTestCase):
             attn_cp_size=1,
             tp_size=1,
             dp_size=1,
+            dcp_size=1,
             moe_dp_size=1,
             ep_size=1,
             pp_size=1,
@@ -965,6 +978,43 @@ class TestContextParallelServerArgs(CustomTestCase):
 
         self.assertTrue(is_cp_enabled())
         self.assertTrue(is_interleave())
+
+    def test_dcp_prefill_cp_rejects_zigzag(self):
+        server_args = self._new_cp_args(
+            enable_prefill_cp=True,
+            cp_strategy="zigzag",
+            attn_cp_size=2,
+            tp_size=2,
+            dcp_size=2,
+        )
+        for cp_v2 in (False, True):
+            with (
+                self.subTest(cp_v2=cp_v2),
+                envs.SGLANG_ENABLE_CP_V2.override(cp_v2),
+                self.assertRaisesRegex(ValueError, "--cp-strategy interleave"),
+            ):
+                server_args._handle_context_parallelism()
+
+    def test_dcp_cp_strategy_validation_preserves_supported_configs(self):
+        for dcp_size, enable_prefill_cp, cp_strategy in (
+            (2, True, "interleave"),
+            (1, True, "zigzag"),
+            (2, False, None),
+        ):
+            with self.subTest(
+                dcp_size=dcp_size,
+                enable_prefill_cp=enable_prefill_cp,
+                cp_strategy=cp_strategy,
+            ):
+                server_args = self._new_cp_args(
+                    enable_prefill_cp=enable_prefill_cp,
+                    cp_strategy=cp_strategy,
+                    attn_cp_size=2 if enable_prefill_cp else 1,
+                    tp_size=2,
+                    dcp_size=dcp_size,
+                )
+                server_args._handle_context_parallelism()
+                self.assertEqual(is_cp_enabled(), enable_prefill_cp)
 
     def test_registered_cp_legacy_args_map_to_unified_strategy(self):
         cases = [


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

co-author：https://github.com/Lai-JX

## Motivation

Inspired by PR #31821, this PR builds on it to improve DCP support for NSA models.The main changes introduced in this PR are as follows:
-  DCP support is available for DSA models such as GLM-5.2. On Hopper-architecture hardware, only the flashmla_kv backend is currently supported.
- DCP supports both TP-DCP (all_gather q)and CP-DCP (all_gather kv). CP-DCP is compatible with Decode Slice and outperforms TP-DCP when KV cache capacity is not the bottleneck.
-  Both FP16 and FP8 KV cache formats are supported. When the KV cache uses FP8, the DCP temporary buffer uses the same data type as the persistent KV cache—packed FP8—avoiding quantization and dequantization overhead.
- Add unit tests covering various scenarios

## Accuracy Tests
**tp (baseline)**
server command
```
python -m sglang.launch_server \
  --model-path /home/admin/GLM-5.2-W4AFP8 \
  --quantization w4afp8 \
  --disable-shared-experts-fusion \
  --tp 8 \
  --kv-cache-dtype fp8_e4m3 \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --chunked-prefill-size 8192 \
  --max-running-requests 64 \
  --page-size 64 \
  --mem-fraction-static 0.70 \
  --trust-remote-code \
  --attention-backend nsa \
  --port 30100 \
  --dsa-decode-backend flashmla_kv \
  --dsa-prefill-backend flashmla_kv
```
accuracy result
```
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1314/1314 [11:30<00:00,  1.90it/s]
Total latency: 690.054 s
Score: 0.948
Output throughput: 194.914 token/s
[METRIC] gsm8k_score=0.9482496194824962 labels={"model": "/home/admin/GLM-5.2-W4AFP8", "eval": "gsm8k"}
[METRIC] gsm8k_latency=690.0544659122825 labels={"model": "/home/admin/GLM-5.2-W4AFP8", "eval": "gsm8k"}
====================
Speculative decoding: no per-request spec_accept_length in responses (non-speculative server, or --api completion which lacks return_meta_info).
====================
```
**cp-dcp** 
server command
```
export SGLANG_ENABLE_CP_V2=1
python -m sglang.launch_server \
  --model-path /home/admin/GLM-5.2-W4AFP8 \
  --quantization w4afp8 \
  --disable-shared-experts-fusion \
  --tp 8 \
  --attn-cp-size 8 \
  --enable-prefill-cp \
  --cp-strategy interleave \
  --dcp-size 8 \
  --enable-cp-decode-attn-tp \
  --kv-cache-dtype fp8_e4m3 \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --chunked-prefill-size 8192 \
  --max-running-requests 64 \
  --page-size 64 \
  --mem-fraction-static 0.70 \
  --trust-remote-code \
  --attention-backend nsa \
  --port 30100 \
  --dsa-decode-backend flashmla_kv \
  --dsa-prefill-backend flashmla_kv
```
accuracy result
```
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1314/1314 [23:31<00:00,  1.07s/it]
Total latency: 1411.064 s
Score: 0.951
Output throughput: 96.001 token/s
[METRIC] gsm8k_score=0.9512937595129376 labels={"model": "/home/admin/GLM-5.2-W4AFP8", "eval": "gsm8k"}
[METRIC] gsm8k_latency=1411.0640860423446 labels={"model": "/home/admin/GLM-5.2-W4AFP8", "eval": "gsm8k"}
====================
Speculative decoding: no per-request spec_accept_length in responses (non-speculative server, or --api completion which lacks return_meta_info).
====================
```
**tp-dcp** 
server command
```
python -m sglang.launch_server \
  --model-path /home/admin/GLM-5.2-W4AFP8 \
  --quantization w4afp8 \
  --disable-shared-experts-fusion \
  --tp 8 \
  --dcp-size 8 \
  --kv-cache-dtype fp8_e4m3 \
  --reasoning-parser glm45 \
  --tool-call-parser glm47 \
  --chunked-prefill-size 8192 \
  --max-running-requests 64 \
  --page-size 64 \
  --mem-fraction-static 0.70 \
  --trust-remote-code \
  --attention-backend nsa \
  --port 30100 \
  --dsa-decode-backend flashmla_kv \
  --dsa-prefill-backend flashmla_kv
```
accuracy result
```
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 1314/1314 [17:29<00:00,  1.25it/s]
Total latency: 1049.677 s
Score: 0.944
Output throughput: 128.980 token/s
[METRIC] gsm8k_score=0.9444444444444444 labels={"model": "/home/admin/GLM-5.2-W4AFP8", "eval": "gsm8k"}
[METRIC] gsm8k_latency=1049.677041195333 labels={"model": "/home/admin/GLM-5.2-W4AFP8", "eval": "gsm8k"}
====================
Speculative decoding: no per-request spec_accept_length in responses (non-speculative server, or --api completion which lacks return_meta_info).
====================
```

## Speed Tests and Profiling

The tests were conducted using an open-source agent workload dataset: [Inferact/codex_swebenchpro_traces](https://huggingface.co/datasets/Inferact/codex_swebenchpro_traces).
Here, Concurrency refers to the number of concurrent sessions, while Turns refers to the number of interaction rounds.

<img width="3572" height="2177" alt="image" src="https://github.com/user-attachments/assets/22effcce-fcdf-42f1-b1ff-c0a479f0c541" />
More detailed performance metrics, such as TTFT and TPOT.
**Latency summary (Concurrency = 8， Turns = 10)**
<img width="1410" height="436" alt="image" src="https://github.com/user-attachments/assets/ad7b6af6-1405-4a56-b296-563781509ac4" />
**Latency summary (Concurrency = 6， Turns = 10)**
<img width="1398" height="442" alt="image" src="https://github.com/user-attachments/assets/6759be72-015c-4c55-adcb-2bf4663d1095" />


## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: **Missing `run-ci` label** -- add it to run CI tests.<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: **Blocked** -- `run-ci` is required first.<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->