### PR TITLE
[VLM] Drain timed-out EPD encoder health probes

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/http_server.py
+++ b/python/sglang/srt/disaggregation/encoder/http_server.py
@@ -600,6 +600,10 @@ async def health_generate():
         drain_task = asyncio.create_task(
             _drain_health_encode(encoder, encode_task, req_id)
         )
+        # wait_for(shield(...)) leaves the drain running after a timeout. Keep
+        # a strong reference until it releases the TP dispatch lock.
+        encoder.background_tasks.add(drain_task)
+        drain_task.add_done_callback(encoder.background_tasks.discard)
         # The drain task now owns the lock and request state. A probe timeout or
         # client disconnect must not let a later request overtake its TP work.
         owns_dispatch_lock = False

--- a/python/sglang/srt/disaggregation/encoder/http_server.py
+++ b/python/sglang/srt/disaggregation/encoder/http_server.py
@@ -260,6 +260,27 @@ def _summarise_dp_broadcast(results: List[dict]) -> Response:
     )
 
 
+async def _drain_health_encode(
+    health_encoder: MMEncoder, encode_task: asyncio.Task, req_id: str
+):
+    """Finish a dispatched TP probe before releasing its state and lock."""
+    result = None
+    cleanup_failed = False
+    try:
+        result = await asyncio.shield(encode_task)
+    except Exception:
+        logger.exception("Encoder health check failed for req_id=%s", req_id)
+    finally:
+        try:
+            await asyncio.shield(health_encoder.release_request(req_id))
+        except Exception:
+            cleanup_failed = True
+            logger.exception("Encoder health cleanup failed for req_id=%s", req_id)
+        finally:
+            health_encoder.encode_dispatch_lock.release()
+    return None if cleanup_failed else result
+
+
 @app.post("/encode")
 async def handle_encode_request(request: dict):
     req_id = request["req_id"]
@@ -544,10 +565,10 @@ async def health_generate():
         # No processor available, fall back to liveness check only
         return Response(status_code=200)
 
+    # uuid keeps rids unique across workers; a bare time.time() can collide.
+    req_id = f"{HEALTH_CHECK_RID_PREFIX}_{uuid.uuid4().hex}"
+    owns_dispatch_lock = False
     try:
-        # uuid keeps rids unique across workers; a bare time.time() can collide.
-        req_id = f"{HEALTH_CHECK_RID_PREFIX}_{uuid.uuid4().hex}"
-
         dummy_request = {
             "mm_items": mm_items,
             "modality": modality.name,
@@ -560,25 +581,36 @@ async def health_generate():
         # request. Serialize its broadcast and rank-0 forward with every other
         # collective dispatch, then recheck whether traffic made the probe
         # unnecessary while it waited for the lock.
-        async with encoder.encode_dispatch_lock:
-            if encoder.has_pending_embeddings():
-                return Response(status_code=200)
-            for socket in send_sockets:
-                sock_send(socket, wrap_as_pickle(dummy_request))
+        await encoder.encode_dispatch_lock.acquire()
+        owns_dispatch_lock = True
+        if encoder.has_pending_embeddings():
+            return Response(status_code=200)
+        for socket in send_sockets:
+            sock_send(socket, wrap_as_pickle(dummy_request))
 
-            _, _, _, error_msg, _ = await asyncio.wait_for(
-                encoder.encode(
-                    mm_items=mm_items,
-                    modality=modality,
-                    req_id=req_id,
-                    num_parts=1,
-                    part_idx=0,
-                ),
-                timeout=HEALTH_CHECK_TIMEOUT,
+        encode_task = asyncio.create_task(
+            encoder.encode(
+                mm_items=mm_items,
+                modality=modality,
+                req_id=req_id,
+                num_parts=1,
+                part_idx=0,
             )
+        )
+        drain_task = asyncio.create_task(
+            _drain_health_encode(encoder, encode_task, req_id)
+        )
+        # The drain task now owns the lock and request state. A probe timeout or
+        # client disconnect must not let a later request overtake its TP work.
+        owns_dispatch_lock = False
+        result = await asyncio.wait_for(
+            asyncio.shield(drain_task),
+            timeout=HEALTH_CHECK_TIMEOUT,
+        )
 
-        # Clean up stored embedding
-        await encoder.release_request(req_id)
+        if result is None:
+            return Response(status_code=503)
+        _, _, _, error_msg, _ = result
 
         if error_msg:
             logger.error(f"Encoder health check failed: {error_msg}")
@@ -592,6 +624,9 @@ async def health_generate():
     except Exception as e:
         logger.error(f"Encoder health check failed: {e}")
         return Response(status_code=503)
+    finally:
+        if owns_dispatch_lock:
+            encoder.encode_dispatch_lock.release()
 
 
 @app.api_route("/start_profile", methods=["GET", "POST"])

--- a/test/registered/unit/disaggregation/test_encoder_health.py
+++ b/test/registered/unit/disaggregation/test_encoder_health.py
@@ -17,6 +17,8 @@ class _FakeEncoder:
         self.embedding_to_send = {}
         self.encode_dispatch_lock = asyncio.Lock()
         self.encode_calls = []
+        self.released = []
+        self.release_event = asyncio.Event()
 
     def has_pending_embeddings(self):
         return bool(self.embedding_to_send)
@@ -28,8 +30,9 @@ class _FakeEncoder:
         self.encode_calls.append(kwargs)
         return 1, 1, 1, None, None
 
-    async def release_request(self, _req_id):
-        return None
+    async def release_request(self, req_id):
+        self.released.append(req_id)
+        self.release_event.set()
 
 
 def _install_tp_encoder(monkeypatch, encoder):
@@ -80,6 +83,88 @@ def test_health_encode_rechecks_busy_state_after_waiting(monkeypatch):
         assert response.status_code == 200
         assert broadcasts == []
         assert encoder.encode_calls == []
+
+    asyncio.run(run_test())
+
+
+def test_health_timeout_keeps_dispatch_order_until_encode_drains(monkeypatch):
+    async def run_test():
+        encoder = _FakeEncoder()
+        _install_tp_encoder(monkeypatch, encoder)
+        encode_started = asyncio.Event()
+        finish_encode = asyncio.Event()
+
+        async def encode(**kwargs):
+            encoder.encode_calls.append(kwargs)
+            encode_started.set()
+            await finish_encode.wait()
+            return 1, 1, 1, None, None
+
+        encoder.encode = encode
+        monkeypatch.setattr(http_server, "HEALTH_CHECK_TIMEOUT", 0.01)
+
+        response = await http_server.health_generate()
+        assert response.status_code == 503
+        assert encode_started.is_set()
+        assert encoder.encode_dispatch_lock.locked()
+        assert encoder.released == []
+
+        finish_encode.set()
+        await asyncio.wait_for(encoder.release_event.wait(), timeout=1)
+        await asyncio.wait_for(encoder.encode_dispatch_lock.acquire(), timeout=1)
+        encoder.encode_dispatch_lock.release()
+        assert len(encoder.released) == 1
+
+    asyncio.run(run_test())
+
+
+def test_cancelled_health_request_does_not_cancel_dispatched_encode(monkeypatch):
+    async def run_test():
+        encoder = _FakeEncoder()
+        _install_tp_encoder(monkeypatch, encoder)
+        encode_started = asyncio.Event()
+        finish_encode = asyncio.Event()
+
+        async def encode(**kwargs):
+            encoder.encode_calls.append(kwargs)
+            encode_started.set()
+            await finish_encode.wait()
+            return 1, 1, 1, None, None
+
+        encoder.encode = encode
+        task = asyncio.create_task(http_server.health_generate())
+        await asyncio.wait_for(encode_started.wait(), timeout=1)
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert encoder.encode_dispatch_lock.locked()
+        assert encoder.released == []
+
+        finish_encode.set()
+        await asyncio.wait_for(encoder.release_event.wait(), timeout=1)
+        await asyncio.wait_for(encoder.encode_dispatch_lock.acquire(), timeout=1)
+        encoder.encode_dispatch_lock.release()
+        assert len(encoder.released) == 1
+
+    asyncio.run(run_test())
+
+
+def test_health_cleanup_failure_releases_dispatch_lock(monkeypatch):
+    async def run_test():
+        encoder = _FakeEncoder()
+        _install_tp_encoder(monkeypatch, encoder)
+
+        async def release_request(req_id):
+            encoder.released.append(req_id)
+            raise RuntimeError("cleanup failed")
+
+        encoder.release_request = release_request
+        response = await http_server.health_generate()
+
+        assert response.status_code == 503
+        assert not encoder.encode_dispatch_lock.locked()
+        assert len(encoder.released) == 1
 
     asyncio.run(run_test())
 

--- a/test/registered/unit/disaggregation/test_encoder_health.py
+++ b/test/registered/unit/disaggregation/test_encoder_health.py
@@ -17,6 +17,7 @@ class _FakeEncoder:
         self.embedding_to_send = {}
         self.encode_dispatch_lock = asyncio.Lock()
         self.encode_calls = []
+        self.background_tasks = set()
         self.released = []
         self.release_event = asyncio.Event()
 
@@ -107,12 +108,15 @@ def test_health_timeout_keeps_dispatch_order_until_encode_drains(monkeypatch):
         assert response.status_code == 503
         assert encode_started.is_set()
         assert encoder.encode_dispatch_lock.locked()
+        assert len(encoder.background_tasks) == 1
         assert encoder.released == []
 
         finish_encode.set()
         await asyncio.wait_for(encoder.release_event.wait(), timeout=1)
         await asyncio.wait_for(encoder.encode_dispatch_lock.acquire(), timeout=1)
         encoder.encode_dispatch_lock.release()
+        await asyncio.sleep(0)
+        assert encoder.background_tasks == set()
         assert len(encoder.released) == 1
 
     asyncio.run(run_test())
@@ -139,12 +143,15 @@ def test_cancelled_health_request_does_not_cancel_dispatched_encode(monkeypatch)
         with pytest.raises(asyncio.CancelledError):
             await task
         assert encoder.encode_dispatch_lock.locked()
+        assert len(encoder.background_tasks) == 1
         assert encoder.released == []
 
         finish_encode.set()
         await asyncio.wait_for(encoder.release_event.wait(), timeout=1)
         await asyncio.wait_for(encoder.encode_dispatch_lock.acquire(), timeout=1)
         encoder.encode_dispatch_lock.release()
+        await asyncio.sleep(0)
+        assert encoder.background_tasks == set()
         assert len(encoder.released) == 1
 
     asyncio.run(run_test())


### PR DESCRIPTION
## Motivation

The encoder health endpoint launches the same TP collective sequence as a real VLM request. `asyncio.wait_for` previously cancelled rank 0 on timeout, released the dispatch lock, and allowed a later request to overtake TP peers that were still finishing the probe. This can turn a health timeout into a process-wide NCCL hang.

## Changes

- Shield an already-dispatched health encode from handler timeout/cancellation.
- Keep the drain task strongly referenced after the handler returns.
- Release encoder request state and the TP dispatch lock only after the encode reaches a safe point.
- Still return 503 immediately when the health deadline expires.

## Validation

- `pre-commit` on both changed files.
- H200 environment: `test_encoder_health.py`: 5 passed.
- Real Qwen3-VL-2B-Instruct, H200 TP2 encoder-only: consecutive health probes returned 200.
- Fault-injected 10 ms deadline: the first probe returned 503 in 13.7 ms; an immediate second probe waited 1.23 s for the first TP drain; after that, the next probe acquired the lock immediately. All GPU processes were gone after shutdown.

Normal requests do not enter this path; the additional task exists only for functional encoder health probes.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33242059044](https://github.com/sgl-project/sglang/actions/runs/33242059044)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33242219628](https://github.com/sgl-project/sglang/actions/runs/33242219628)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33242059026](https://github.com/sgl-project/sglang/actions/runs/33242059026)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->