### PR TITLE
[Diffusion] Rollout API: support return only SDE latents

### DIFF
--- a/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
+++ b/python/sglang/multimodal_gen/runtime/entrypoints/post_training/rollout_api.py
@@ -140,6 +140,7 @@ def _slice_rollout_trajectory_for_sample(
             latents=_extract_single_sample_tensor(dit.latents, sample_idx, batch_size),
             timesteps=dit.timesteps,
             sigmas=dit.sigmas,
+            latent_step_indices=dit.latent_step_indices,
         )
     return RolloutTrajectoryData(
         rollout_log_probs=log_probs,
@@ -194,6 +195,11 @@ def _serialize_rollout_trajectory(
             ),
             "timesteps": serialized_dit_timesteps,
             "sigmas": serialized_dit_sigmas,
+            "latent_step_indices": (
+                _maybe_serialize(dit.latent_step_indices)
+                if dit.latent_step_indices is not None
+                else None
+            ),
         }
     return (
         serialized_log_probs,
@@ -360,6 +366,7 @@ async def rollout_generate(request: RolloutRequest):
         ) from exc
     if output_batch.error:
         raise HTTPException(status_code=500, detail=output_batch.error)
+
     def _serialize_response() -> list[bytes]:
         with stamps.span("build"):
             rollout_responses = _build_response(

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/minimax_h3_rollout.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/minimax_h3_rollout.py
@@ -168,13 +168,27 @@ class MiniMaxH3RolloutCollector:
     """Accumulates video-target trajectory and per-step log probs."""
 
     sigmas_video: list[float]
+    return_step_indices: set[int] | None = None
     latent_steps: list[torch.Tensor] = field(default_factory=list)
+    latent_step_indices: list[int] = field(default_factory=list)
     log_prob_sums: list[torch.Tensor] = field(default_factory=list)
     log_prob_counts: list[torch.Tensor] = field(default_factory=list)
     pos_cond_kwargs: dict[str, Any] = field(default_factory=dict)
+    _next_latent_index: int = 0
+
+    def _record_latent(self, video_target: torch.Tensor) -> None:
+        index = self._next_latent_index
+        self._next_latent_index += 1
+        if (
+            self.return_step_indices is not None
+            and index not in self.return_step_indices
+        ):
+            return
+        self.latent_steps.append(video_target.detach().cpu().clone())
+        self.latent_step_indices.append(index)
 
     def record_initial(self, video_target: torch.Tensor) -> None:
-        self.latent_steps.append(video_target.detach().cpu().clone())
+        self._record_latent(video_target)
 
     def record_step(
         self,
@@ -182,7 +196,7 @@ class MiniMaxH3RolloutCollector:
         log_prob_sum: torch.Tensor,
         log_prob_count: torch.Tensor,
     ) -> None:
-        self.latent_steps.append(video_target.detach().cpu().clone())
+        self._record_latent(video_target)
         self.log_prob_sums.append(log_prob_sum.detach().cpu())
         self.log_prob_counts.append(log_prob_count.detach().cpu())
 
@@ -191,7 +205,7 @@ class MiniMaxH3RolloutCollector:
         stacked = torch.stack(self.latent_steps, dim=0).unsqueeze(0)
         divisor = 1000.0
         step_sigmas = torch.tensor(
-            [float(s) for s in self.sigmas_video[:-1]],
+            [float(s) for s in self.sigmas_video],
             dtype=torch.float32,
         )
         timesteps = step_sigmas * divisor
@@ -214,6 +228,9 @@ class MiniMaxH3RolloutCollector:
                 latents=stacked,
                 timesteps=timesteps,
                 sigmas=sigmas,
+                latent_step_indices=torch.tensor(
+                    self.latent_step_indices, dtype=torch.long
+                ),
             ),
         )
 

--- a/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
+++ b/python/sglang/multimodal_gen/runtime/pipelines_core/stages/model_specific_stages/minimax_h3/stages/denoising.py
@@ -679,7 +679,17 @@ class MiniMaxH3DenoisingStage(DenoisingStage):
                 if isinstance(seed, list):
                     seed = seed[0]
                 generator.manual_seed(int(seed))
-                collector = MiniMaxH3RolloutCollector(sigmas_video=sigmas_video)
+                return_step_indices = getattr(
+                    batch, "rollout_return_step_indices", None
+                )
+                collector = MiniMaxH3RolloutCollector(
+                    sigmas_video=sigmas_video,
+                    return_step_indices=(
+                        set(return_step_indices)
+                        if return_step_indices is not None
+                        else None
+                    ),
+                )
                 packed_cpu = {
                     k: (v.detach().cpu() if isinstance(v, torch.Tensor) else v)
                     for k, v in packed.items()

--- a/python/sglang/multimodal_gen/runtime/post_training/rl_dataclasses.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/rl_dataclasses.py
@@ -51,9 +51,12 @@ class RolloutDitTrajectory:
     # [B, T+1, ...]: per-step noisy latents x_{t_0..t_{T-1}} followed by the
     # final denoised latent x_{t_T} (last scheduler.step output).
     latents: torch.Tensor | None = None
-    timesteps: torch.Tensor | None = None  # [T]
+    timesteps: torch.Tensor | None = None  # [T+1], includes the terminal timestep
     # [T+1] scheduler.sigmas snapshot (post-shift, includes terminal 0).
     sigmas: torch.Tensor | None = None
+    # [K] original step index of each kept latent (0..T); None means the full
+    # 0..T trajectory. Set whenever rollout_return_step_indices filtered it.
+    latent_step_indices: torch.Tensor | None = None
 
 
 @dataclass

--- a/python/sglang/multimodal_gen/runtime/post_training/rollout_denoising_mixin.py
+++ b/python/sglang/multimodal_gen/runtime/post_training/rollout_denoising_mixin.py
@@ -139,6 +139,7 @@ class RolloutDenoisingMixin:
         batch._rollout_denoising_env_state = {
             "env": env,
             "step_latents": [],
+            "step_latent_indices": [],
             "step_timesteps": [],
             "pos_cond_kwargs_src": pos_src,
             "neg_cond_kwargs_src": neg_src,
@@ -157,12 +158,13 @@ class RolloutDenoisingMixin:
         if state is None:
             return
 
+        state["step_timesteps"].append(timestep_value.detach().cpu())
         return_step_indices = getattr(batch, "rollout_return_step_indices", None)
         if return_step_indices is not None and step_index not in return_step_indices:
             return
 
         state["step_latents"].append(latents.detach())
-        state["step_timesteps"].append(timestep_value.detach().cpu())
+        state["step_latent_indices"].append(step_index)
 
     def _maybe_finalize_denoising_env_collection(self, batch, pipeline_config) -> None:
         state = getattr(batch, "_rollout_denoising_env_state", None)
@@ -187,6 +189,9 @@ class RolloutDenoisingMixin:
                 latents=step_latents_tensor.cpu(),
                 timesteps=torch.stack(step_timesteps, dim=0).cpu(),
                 sigmas=batch.scheduler.sigmas.detach().cpu().clone(),
+                latent_step_indices=torch.tensor(
+                    state["step_latent_indices"], dtype=torch.long
+                ),
             )
 
         if env is not None and batch.rollout_return_denoising_env:


### PR DESCRIPTION
## Motivation

`/rollout/generate` returns the whole `0..T` denoising trajectory, but flowGRPO training consumes only the SDE window: for each SDE step `s` it needs `x_s`, `x_{s+1}` and `log_prob_s`. On a 10-step schedule with a 2-step window that is 3 of the 11 latents; the other 8 can be thrown away, cutting trajectory payload size **down by ~72%**. These latents are fp32 and, for video models, dominate the response body — a MiniMax H3 t2va microgroup carries hundreds of MB of them.

`rollout_return_step_indices` already existed for this, but it was not usable:

- the trainer could not tell which original step each surviving latent came from, so pairing `x_s` with `x_{s+1}` relied on the array being the full contiguous `0..T`;
- `timesteps` was filtered together with the latents, so the trainer lost the schedule entries it indexes by step number;
- the MiniMax H3 path ignored the field entirely — its own collector recorded every step unconditionally.

## Modifications

- `RolloutDitTrajectory` gains `latent_step_indices`: the original step index of each returned latent (`None` = the full `0..T` trajectory). Serialized alongside the trajectory and carried through the per-sample split.
- `RolloutDenoisingMixin`: latents keep honoring `rollout_return_step_indices` and now record their provenance; `timesteps` is appended before the filter, so the schedule always comes back full-length. Scalar-sized arrays (`timesteps`, `rollout_log_probs`) are indexed by original step number, only the latents are filtered.
- `MiniMaxH3RolloutCollector`: same filtering and provenance, so H3 stops ignoring the request; its `timesteps` now spans the full `[T+1]` including the terminal entry, matching `sigmas` and the generic path.

The consumer side lives in radixark/miles_diffusion#216: it requests `S ∪ (S+1)` for an SDE window `S` and pairs latents by the echoed provenance instead of by array position, so a non-contiguous window is correct by construction and a request/response disagreement raises instead of silently mispairing.

## Accuracy Tests

Joint end-to-end runs with radixark/miles_diffusion#216 pinned to this branch — **all e2e stages green** ([run 33244938347](https://github.com/radixark/miles_diffusion/actions/runs/33244938347)): `stage-b-3-gpu-h200`, `stage-b-5-gpu-h200`, `stage-c-3-gpu-h200`, `stage-c-5-gpu-h200`.

Every one of those recipes runs a step strategy, so all of them exercised the filtered transport, and each reproduced its pre-existing recorded metric standard **bit for bit** (strict comparison, `--deterministic-mode`):

| Recipe | SDE index set | Result |
| :--- | :--- | :--- |
| `test_sd3_ocr_grpo_2xGPU` | contiguous window | bitwise identical to standard |
| `test_qwenimage_pickscore_grpo_5xGPU` | contiguous window | bitwise identical to standard |
| `test_ltx23_pickscore_grpo_4xGPU` | non-contiguous candidates | bitwise identical to standard |
| `test_wan22_pickscore_grpo_17xGPU_single_node_4xGPU_proxy` | non-contiguous candidates | bitwise identical to standard |

Two further e2e CIs are being added for the models this PR touches. Each recorded its standard off this branch, then reproduced it on top of it:

| New e2e | SDE index set | Result on this branch |
| :--- | :--- | :--- |
| `test_h3_t2va_grpo_2xGPU` ([miles_diffusion#217](https://github.com/radixark/miles_diffusion/pull/217)) | non-contiguous candidates | standard recorded with the stock `sglang-miles-h3` engine; all 8 metric series identical to the last digit, and that baseline passes in CI ([run 33271965673](https://github.com/radixark/miles_diffusion/actions/runs/33271965673), 1490 s) |
| `test_cosmos3_pickscore_grpo_t2i_4xGPU` ([miles_diffusion#219](https://github.com/radixark/miles_diffusion/pull/219)) | window 8-11, does not start at step 0 | standard recorded on `sglang main`; all 10 metric series bitwise identical here ([run](https://github.com/radixark/miles_diffusion/actions/runs/33282614870)). On the stock engine the same run instead fails in rollout to train conversion: `trajectory lacks latents for steps [10, 11, 12] (have [0, 1, 2])` ([run](https://github.com/radixark/miles_diffusion/actions/runs/33273142927)) |

cosmos3 is the case that cannot pass without the provenance echo: its Karras grid puts the useful window at steps 8-11, so array position never coincides with step number and pairing by position would silently pair `x_10` with `x_0`. Its `train/model_output_{mean_abs_diff,rel_max}` compare the raw DiT outputs between engine and trainer, so the equality covers the tensors themselves rather than a reward summary.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit). — run on the touched files; black reformatting is included in the commit
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests). — **no new unit test**; the filter and provenance were verified behaviourally against the H3 collector and the generic mixin, and by the bitwise e2e comparisons above
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). — **not needed**, the field is described where it is declared
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33282596522](https://github.com/sgl-project/sglang/actions/runs/33282596522)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33282596363](https://github.com/sgl-project/sglang/actions/runs/33282596363)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33282596623](https://github.com/sgl-project/sglang/actions/runs/33282596623)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->

