### PR TITLE
[VLM] Retire abandoned encoder DP requests

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -76,6 +76,7 @@ class PendingRequest:
 # vary per request and can't merge into one HF processor call.
 _BATCHABLE_MODALITIES = {Modality.IMAGE, Modality.AUDIO}
 _KIMI_K3_DEFAULT_ENCODER_MAX_BATCH_SIZE = 2
+_DP_RELEASE_AFTER_ENCODE = "release_after_encode"
 
 
 def _resolve_encoder_batch_policy(
@@ -380,6 +381,7 @@ class DPDispatcher:
         self,
         dp_size: int,
         dispatch_sockets: List,
+        release_sockets: List,
         result_socket,
         worker_processes: List[mp.Process],
         enable_metrics: bool = False,
@@ -387,6 +389,7 @@ class DPDispatcher:
     ):
         self.dp_size = dp_size
         self.dispatch_sockets = dispatch_sockets
+        self.release_sockets = release_sockets
         self.result_socket = result_socket
         self.worker_processes = worker_processes
         # Key = req_id for encode/broadcast, or a per-control-request key for
@@ -404,6 +407,9 @@ class DPDispatcher:
         self._pending_send_at: Dict[str, float] = {}
         # Set when _result_listener gives up; makes alive_ranks report empty.
         self._listener_failed = False
+        # Keep fire-and-forget release notifications alive after an HTTP
+        # handler is cancelled.
+        self._background_tasks: Set[asyncio.Task] = set()
 
         # Prometheus gauge: pending requests per DP rank. Lives in the main
         # process (the dispatcher), unlike the per-worker EncoderMetricsCollector.
@@ -452,6 +458,28 @@ class DPDispatcher:
         self.pending_futures[rank].pop(req_id, None)
         self.req_id_to_rank.pop(req_id, None)
         self._update_pending_gauge()
+
+    def _release_abandoned_encode(self, rank: int, req_id: str) -> None:
+        """Tell the owning worker to release an encode that lost its caller."""
+
+        async def notify_worker() -> None:
+            try:
+                await async_sock_send(
+                    self.release_sockets[rank],
+                    wrap_as_pickle(
+                        {"_dp_type": _DP_RELEASE_AFTER_ENCODE, "req_id": req_id}
+                    ),
+                )
+            except Exception:
+                logger.exception(
+                    "Failed to retire abandoned encoder DP request %s on rank %s",
+                    req_id,
+                    rank,
+                )
+
+        task = asyncio.create_task(notify_worker())
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     @staticmethod
     def _send_req_key(req_id: str, request: dict) -> str:
@@ -538,6 +566,7 @@ class DPDispatcher:
         future = asyncio.get_running_loop().create_future()
         self.pending_futures[rank][req_id] = future
         self._update_pending_gauge()
+        dispatched = False
         logger.info(
             f"MM-Encoder DP dispatch: req_id={req_id}, "
             f"modality={request.get('modality', 'image')}, "
@@ -555,6 +584,7 @@ class DPDispatcher:
                     await async_sock_send(
                         self.dispatch_sockets[rank], wrap_as_pickle(request)
                     )
+                    dispatched = True
                 except BaseException:
                     self._drop_pending_and_mapping(rank, req_id)
                     self._mapping_condition.notify_all()
@@ -566,6 +596,8 @@ class DPDispatcher:
                 future, timeout=server_module.ENCODER_REQ_TIMEOUT
             )
         except asyncio.TimeoutError:
+            if dispatched:
+                self._release_abandoned_encode(rank, req_id)
             self._drop_pending_and_mapping(rank, req_id)
             return self._timeout_envelope(
                 req_id,
@@ -573,6 +605,8 @@ class DPDispatcher:
                 f"Encoder DP rank={rank} timed out after {server_module.ENCODER_REQ_TIMEOUT}s",
             )
         except BaseException:
+            if dispatched:
+                self._release_abandoned_encode(rank, req_id)
             self._drop_pending_and_mapping(rank, req_id)
             raise
 
@@ -1364,11 +1398,27 @@ async def _dp_worker_handle_request(
         )
 
 
+async def _retire_abandoned_encode(
+    enc: MMEncoder,
+    encode_task: Optional[asyncio.Task],
+    req_id: str,
+) -> None:
+    """Retire an abandoned request without interrupting its encode work."""
+    try:
+        if encode_task is not None and not encode_task.done():
+            await enc.abandon_request(req_id)
+        else:
+            await enc.release_request(req_id)
+    except Exception:
+        logger.exception("Failed to release abandoned encoder DP request %s", req_id)
+
+
 async def run_dp_worker(
     server_args: ServerArgs,
     dp_rank: int,
     gpu_id: int,
     dispatch_path: str,
+    release_path: str,
     result_path: str,
 ):
     logger.info(
@@ -1410,9 +1460,34 @@ async def run_dp_worker(
 
     ctx = zmq.asyncio.Context(2)
     recv_sock = get_zmq_socket(ctx, zmq.PULL, dispatch_path, False)
+    release_sock = get_zmq_socket(ctx, zmq.PULL, release_path, False)
     send_sock = get_zmq_socket(ctx, zmq.PUSH, result_path, False)
     send_lock = asyncio.Lock()
     inflight: Set[asyncio.Task] = set()
+    encode_tasks: Dict[str, asyncio.Task] = {}
+    release_tasks: Set[asyncio.Task] = set()
+
+    async def listen_for_releases() -> None:
+        # Cleanup must not wait behind the bounded encode queue: under a
+        # cancellation burst every normal worker slot may already be occupied.
+        while True:
+            try:
+                request = await async_sock_recv(release_sock)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.error(f"DP worker {dp_rank} release recv error", exc_info=True)
+                continue
+            if not isinstance(request, dict) or not request.get("req_id"):
+                logger.error(f"DP worker {dp_rank} received malformed release request")
+                continue
+            req_id = request["req_id"]
+            task = asyncio.create_task(
+                _retire_abandoned_encode(enc, encode_tasks.get(req_id), req_id)
+            )
+            release_tasks.add(task)
+            task.add_done_callback(release_tasks.discard)
+
     # Acquire-before-recv → back-pressure propagates to the dispatcher
     # PUSH buffer. Must be at least max_batch_size or batching degrades.
     max_inflight = envs.SGLANG_ENCODER_DP_WORKER_MAX_INFLIGHT.get()
@@ -1424,6 +1499,7 @@ async def run_dp_worker(
         )
     inflight_sem = asyncio.Semaphore(max_inflight)
     sched.start()
+    release_listener_task = asyncio.create_task(listen_for_releases())
     logger.info(f"DP worker {dp_rank} ready")
 
     try:
@@ -1458,12 +1534,30 @@ async def run_dp_worker(
                 spawned = True
                 inflight.add(task)
                 task.add_done_callback(inflight.discard)
+                if dp_type == "encode":
+                    req_id = request["req_id"]
+                    encode_tasks[req_id] = task
+
+                    def forget_encode_task(
+                        completed_task: asyncio.Task, request_id: str = req_id
+                    ) -> None:
+                        if encode_tasks.get(request_id) is completed_task:
+                            encode_tasks.pop(request_id, None)
+                        enc.clear_abandoned_request(request_id)
+
+                    task.add_done_callback(forget_encode_task)
             finally:
                 if not spawned:
                     inflight_sem.release()
     finally:
+        release_listener_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await release_listener_task
         for task in inflight:
             task.cancel()
+        for task in release_tasks:
+            task.cancel()
+        await asyncio.gather(*inflight, *release_tasks, return_exceptions=True)
         ctx.destroy(linger=0)
 
 
@@ -1472,13 +1566,21 @@ def launch_dp_worker(
     dp_rank: int,
     gpu_id: int,
     dispatch_path: str,
+    release_path: str,
     result_path: str,
 ):
     publish(server_args, role="encoder")
     try:
         configure_logger(server_args, prefix=f" encode_dp_worker[{dp_rank}]")
         asyncio.run(
-            run_dp_worker(server_args, dp_rank, gpu_id, dispatch_path, result_path)
+            run_dp_worker(
+                server_args,
+                dp_rank,
+                gpu_id,
+                dispatch_path,
+                release_path,
+                result_path,
+            )
         )
     except KeyboardInterrupt:
         logger.info(f"DP worker {dp_rank} exiting")
@@ -1595,6 +1697,12 @@ def launch_dp_runtime(server_args: ServerArgs) -> DPDispatcher:
         )
         for r in range(dp_size)
     ]
+    release_sockets: List[zmq.asyncio.Socket] = [
+        get_zmq_socket(
+            async_zmq_ctx, zmq.PUSH, f"ipc:///tmp/{ipc_prefix}_dp_release_{r}", True
+        )
+        for r in range(dp_size)
+    ]
 
     worker_processes: List[mp.Process] = []
 
@@ -1624,6 +1732,7 @@ def launch_dp_runtime(server_args: ServerArgs) -> DPDispatcher:
                     dp_rank,
                     gpu_id,
                     f"ipc:///tmp/{ipc_prefix}_dp_dispatch_{dp_rank}",
+                    f"ipc:///tmp/{ipc_prefix}_dp_release_{dp_rank}",
                     result_path,
                 ),
                 daemon=False,
@@ -1637,6 +1746,7 @@ def launch_dp_runtime(server_args: ServerArgs) -> DPDispatcher:
     return DPDispatcher(
         dp_size,
         dispatch_sockets,
+        release_sockets,
         result_socket,
         worker_processes,
         enable_metrics=get_observability().enable_metrics,

--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -96,6 +96,15 @@ async def _get_receive_condition(req_id: str) -> asyncio.Condition:
         return rid_to_cond[req_id]
 
 
+async def _notify_receive_waiters(req_id: str) -> None:
+    """Wake an existing destination waiter without creating new state."""
+    async with cond_dict_lock:
+        cond = rid_to_cond.get(req_id)
+    if cond is not None:
+        async with cond:
+            cond.notify_all()
+
+
 ENCODER_MAX_BATCH_SIZE = envs.SGLANG_ENCODER_MAX_BATCH_SIZE.get()
 ENCODER_MAX_BATCH_SIZE_EXPLICIT = envs.SGLANG_ENCODER_MAX_BATCH_SIZE.is_set()
 # Watchdog: max time to wait for a batched /encode result. Bounds HTTP latency
@@ -589,6 +598,9 @@ class MMEncoder:
                     )
 
             self.req_states: Dict[str, ReqState] = {}
+            # A DP caller can disappear before its encode creates ReqState.
+            # Preserve that release intent until _acquire_encode_ref runs.
+            self.abandoned_req_ids: Set[str] = set()
             # Need to ensure the NCCL launch order on rank0 matches the dispatch order rank>0
             self.encode_dispatch_lock = asyncio.Lock()
 
@@ -633,7 +645,21 @@ class MMEncoder:
             state = ReqState(req_id)
             self.req_states[req_id] = state
         state.active_encodes += 1
+        if req_id in self.abandoned_req_ids:
+            state.release_requested = True
+            self.abandoned_req_ids.discard(req_id)
         return state
+
+    async def abandon_request(self, req_id: str) -> None:
+        """Release now, or remember the release until encode state exists."""
+        self.abandoned_req_ids.add(req_id)
+        if req_id in self.req_states:
+            self.abandoned_req_ids.discard(req_id)
+            await self.release_request(req_id)
+
+    def clear_abandoned_request(self, req_id: str) -> None:
+        """Drop an unused release marker after the worker task exits."""
+        self.abandoned_req_ids.discard(req_id)
 
     async def _release_encode_ref(self, state: Optional[ReqState]) -> None:
         if state is None:
@@ -698,8 +724,16 @@ class MMEncoder:
         async with state.lifecycle_condition:
             state.release_requested = True
             state.preserve_metadata_on_release |= preserve_metadata
-            if state.active_encodes > 0:
-                return
+            encode_is_active = state.active_encodes > 0
+
+        # ``send_with_url`` may be waiting for a destination that will never
+        # arrive after its HTTP caller disappears. Wake it so the worker slot
+        # is retired together with the staged embedding.
+        await _notify_receive_waiters(req_id)
+        if encode_is_active:
+            return
+
+        async with state.lifecycle_condition:
             await state.lifecycle_condition.wait_for(lambda: state.active_sends == 0)
             if self.req_states.get(req_id) is not state:
                 return
@@ -1885,6 +1919,9 @@ class MMEncoder:
 
         try:
             while True:
+                if state.release_requested:
+                    break
+
                 async with rid_lock:
                     current_targets = rid_to_receive_endpoint.get(req_id, set()).copy()
                     expected_count = rid_to_receive_count.get(req_id)

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -9,7 +9,12 @@ import torch
 
 from sglang.srt.disaggregation.encoder.preprocessor import EncoderPreprocessor
 from sglang.srt.disaggregation.encoder.receiver import EmbeddingData
-from sglang.srt.disaggregation.encoder.runtime import execute_encode_pipeline
+from sglang.srt.disaggregation.encoder.runtime import (
+    _DP_RELEASE_AFTER_ENCODE,
+    DPDispatcher,
+    _retire_abandoned_encode,
+    execute_encode_pipeline,
+)
 from sglang.srt.disaggregation.encoder.server import (
     EncoderDelivery,
     InternalError,
@@ -23,6 +28,7 @@ from sglang.srt.disaggregation.encoder.server import (
     rid_to_receive_count,
     rid_to_receive_endpoint,
 )
+from sglang.srt.managers.io_struct import unwrap_from_pickle
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.utils.common import safe_pickle_loads
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -166,6 +172,7 @@ class TestEncoderDelivery(CustomTestCase):
             encoder = MMEncoder.__new__(MMEncoder)
             encoder.rank = 0
             encoder.req_states = {}
+            encoder.abandoned_req_ids = set()
             encoder._embedding_dims = {Modality.IMAGE: 8}
             encoder._embedding_dtype = torch.float16
             encoder._element_size = 2
@@ -300,6 +307,7 @@ class TestEncoderDelivery(CustomTestCase):
             encoder = MMEncoder.__new__(MMEncoder)
             encoder.rank = 0
             encoder.req_states = {}
+            encoder.abandoned_req_ids = set()
             encoder.delivery = SimpleNamespace(release=AsyncMock())
 
             state = encoder._acquire_encode_ref("req")
@@ -336,6 +344,38 @@ class TestEncoderDelivery(CustomTestCase):
             encoder.delivery.release.assert_awaited_once_with(state)
             discard.assert_awaited_once_with("req")
             self.assertIsNone(state.embedding_data)
+            self.assertNotIn("req", encoder.req_states)
+
+        asyncio.run(run())
+
+    def test_abandon_before_encode_is_applied_when_state_is_created(self):
+        async def run():
+            encoder = MMEncoder.__new__(MMEncoder)
+            encoder.rank = 0
+            encoder.req_states = {}
+            encoder.abandoned_req_ids = set()
+            encoder.delivery = SimpleNamespace(release=AsyncMock())
+
+            await encoder.abandon_request("req")
+            self.assertIn("req", encoder.abandoned_req_ids)
+
+            state = encoder._acquire_encode_ref("req")
+            self.assertTrue(state.release_requested)
+            self.assertNotIn("req", encoder.abandoned_req_ids)
+            encoder._stage_embedding(
+                EmbeddingData(
+                    "req",
+                    1,
+                    0,
+                    None,
+                    Modality.IMAGE,
+                    embedding=torch.ones((1, 1)),
+                )
+            )
+            with patch.object(meta_registry, "discard", AsyncMock()):
+                await encoder._release_encode_ref(state)
+
+            encoder.delivery.release.assert_awaited_once_with(state)
             self.assertNotIn("req", encoder.req_states)
 
         asyncio.run(run())
@@ -435,6 +475,7 @@ class TestEncoderDelivery(CustomTestCase):
             encoder = MMEncoder.__new__(MMEncoder)
             encoder.rank = 0
             encoder.req_states = {}
+            encoder.abandoned_req_ids = set()
             state = encoder._acquire_encode_ref("req")
             state.embedding_data = EmbeddingData(
                 "req",
@@ -531,6 +572,157 @@ class TestEncoderDelivery(CustomTestCase):
             self.assertIs(embedding_seen_by_release[0], embedding)
             self.assertIsNone(state.embedding_data)
             self.assertNotIn("req", encoder.req_states)
+
+        asyncio.run(run())
+
+    def test_release_wakes_destination_waiter(self):
+        async def run():
+            req_id = "test-release-wakes-destination-waiter"
+            await meta_registry.discard(req_id)
+
+            encoder = MMEncoder.__new__(MMEncoder)
+            encoder.req_states = {req_id: ReqState(req_id)}
+            encoder.send_timeout = 60
+            encoder.delivery = ZmqDelivery(encoder, cleanup_receive_state=True)
+
+            send_task = asyncio.create_task(encoder.send_with_url(req_id))
+            await asyncio.sleep(0)
+            self.assertFalse(send_task.done())
+
+            await asyncio.wait_for(encoder.release_request(req_id), timeout=1)
+            await asyncio.wait_for(send_task, timeout=1)
+
+            self.assertNotIn(req_id, encoder.req_states)
+            self.assertNotIn(req_id, rid_to_cond)
+            self.assertNotIn(req_id, rid_to_receive_endpoint)
+            self.assertNotIn(req_id, rid_to_receive_count)
+
+        asyncio.run(run())
+
+
+class TestEncoderDPAbandonedRequest(CustomTestCase):
+    @staticmethod
+    def _make_dispatcher():
+        return DPDispatcher(
+            dp_size=1,
+            dispatch_sockets=[object()],
+            release_sockets=[object()],
+            result_socket=object(),
+            worker_processes=[],
+        )
+
+    def test_dispatch_timeout_notifies_worker_to_release(self):
+        async def run():
+            dispatcher = self._make_dispatcher()
+            sent = []
+            release_sent = asyncio.Event()
+
+            async def send(socket, payload):
+                message = unwrap_from_pickle(payload)
+                sent.append((socket, message))
+                if message.get("_dp_type") == _DP_RELEASE_AFTER_ENCODE:
+                    release_sent.set()
+
+            request = {"req_id": "timed-out", "modality": "image"}
+            with (
+                patch(
+                    "sglang.srt.disaggregation.encoder.runtime.async_sock_send",
+                    side_effect=send,
+                ),
+                patch(
+                    "sglang.srt.disaggregation.encoder.runtime.server_module.ENCODER_REQ_TIMEOUT",
+                    0.01,
+                ),
+            ):
+                result = await dispatcher.dispatch(request)
+                await asyncio.wait_for(release_sent.wait(), timeout=1)
+
+            self.assertEqual(result["_error_type"], "TimeoutError")
+            self.assertIs(sent[0][0], dispatcher.dispatch_sockets[0])
+            self.assertEqual(sent[0][1], request)
+            self.assertIs(sent[1][0], dispatcher.release_sockets[0])
+            self.assertEqual(
+                sent[1][1],
+                {
+                    "_dp_type": _DP_RELEASE_AFTER_ENCODE,
+                    "req_id": "timed-out",
+                },
+            )
+            self.assertEqual(dispatcher.pending_counts, [0])
+            self.assertNotIn("timed-out", dispatcher.req_id_to_rank)
+
+        asyncio.run(run())
+
+    def test_dispatch_cancellation_notifies_worker_to_release(self):
+        async def run():
+            dispatcher = self._make_dispatcher()
+            encode_sent = asyncio.Event()
+            release_sent = asyncio.Event()
+
+            async def send(_socket, payload):
+                message = unwrap_from_pickle(payload)
+                if message.get("_dp_type") == _DP_RELEASE_AFTER_ENCODE:
+                    release_sent.set()
+                else:
+                    encode_sent.set()
+
+            with patch(
+                "sglang.srt.disaggregation.encoder.runtime.async_sock_send",
+                side_effect=send,
+            ):
+                task = asyncio.create_task(
+                    dispatcher.dispatch({"req_id": "cancelled", "modality": "image"})
+                )
+                await encode_sent.wait()
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+                await asyncio.wait_for(release_sent.wait(), timeout=1)
+
+            self.assertEqual(dispatcher.pending_counts, [0])
+            self.assertNotIn("cancelled", dispatcher.req_id_to_rank)
+
+        asyncio.run(run())
+
+    def test_worker_marks_running_encode_abandoned(self):
+        async def run():
+            async def encode():
+                await asyncio.Event().wait()
+
+            encode_task = asyncio.create_task(encode())
+            encoder = SimpleNamespace(
+                abandon_request=AsyncMock(),
+                release_request=AsyncMock(),
+            )
+            await _retire_abandoned_encode(encoder, encode_task, "abandoned")
+
+            encoder.abandon_request.assert_awaited_once_with("abandoned")
+            encoder.release_request.assert_not_awaited()
+            encode_task.cancel()
+            await asyncio.gather(encode_task, return_exceptions=True)
+
+        asyncio.run(run())
+
+    def test_worker_release_survives_encode_failure(self):
+        async def run():
+            async def encode():
+                raise RuntimeError("bad image")
+
+            encode_task = asyncio.create_task(encode())
+            await asyncio.sleep(0)
+            encoder = SimpleNamespace(
+                abandon_request=AsyncMock(),
+                release_request=AsyncMock(),
+            )
+            await _retire_abandoned_encode(
+                encoder,
+                encode_task,
+                "failed",
+            )
+
+            encoder.release_request.assert_awaited_once_with("failed")
+            encoder.abandon_request.assert_not_awaited()
+            await asyncio.gather(encode_task, return_exceptions=True)
 
         asyncio.run(run())
 


### PR DESCRIPTION
## Motivation

In encoder-DP mode, an HTTP cancellation or dispatcher timeout removed the dispatcher mapping but did not retire work already dispatched to the worker. The ViT result and destination waiter could remain alive until `SGLANG_ENCODER_SEND_TIMEOUT` (180 seconds by default). A cancellation burst could therefore retain GPU embeddings and exhaust all worker inflight slots.

## Changes

- Send an explicit release notification after a dispatched `/encode` loses its caller.
- Use a dedicated per-rank cleanup channel so release cannot wait behind a saturated encode queue.
- Never cancel active preprocessing, ViT, or collectives. A tombstone defers release until active encode work reaches a safe point.
- Wake `zmq_to_scheduler` destination waiters when a request is released, then free transfer state and the staged embedding through the existing lifecycle.
- Keep cleanup idempotent across early cancellation, late results, failures, and concurrent release.

## Correctness

The release intent is recorded before request state exists and inherited atomically when encode begins. If encode is already active, resources remain pinned until its encode ref reaches zero. New sends are rejected after release starts, active sends drain before storage is cleared, and a late worker result is dropped by the dispatcher because its future no longer exists.

## Validation

- `python3 test/registered/unit/disaggregation/test_encode_server.py -f`: 23 passed.
- Pre-commit on all three changed files: passed.
- NVIDIA H200, real `Qwen3-VL-2B-Instruct`, encoder-only DP2, TP1, `zmq_to_scheduler`.
- Stress condition: `SGLANG_ENCODER_DP_WORKER_MAX_INFLIGHT=1`, request timeout 1 second, send timeout 30 seconds.
- Four requests without a destination returned 504 in 1.074/1.001/1.001/1.001 seconds; total 4.096 seconds rather than blocking a worker for 30 seconds.
- Each request was cleaned immediately, HBM returned to the same baseline, and the following functional VLM `/health` completed in 50 ms with HTTP 200.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33243664896](https://github.com/sgl-project/sglang/actions/runs/33243664896)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33243668524](https://github.com/sgl-project/sglang/actions/runs/33243668524)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33243664871](https://github.com/sgl-project/sglang/actions/runs/33243664871)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->