### PR TITLE
[VLM] Validate EPD embeddings before prefix caching

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -1400,6 +1400,17 @@ class MMEncoder:
                         time.perf_counter() - forward_start, modality=modality_str
                     )
 
+            try:
+                self._validate_embedding_token_count(ctx, mm_embedding)
+            except InternalError:
+                # Old releases could cache a malformed result before the
+                # outer validation ran. Do not make that entry permanently
+                # poison every request for the same media.
+                if cache_hit:
+                    async with self.mm_cache_lock:
+                        self.mm_cache.free(mm_hash, None)
+                raise
+
             # Per-request cache hit metrics: tokens = embedding rows.
             if use_mm_cache and encoder_metrics_collector is not None:
                 total_tokens = int(mm_embedding.shape[0])
@@ -1478,18 +1489,21 @@ class MMEncoder:
             mm_embedding = await self._compute_global_cache_embedding(
                 ctx, keep_on_gpu=keep_on_gpu
             )
-        else:
-            mm_embedding = await self._compute_direct_embedding(
-                ctx, keep_on_gpu=keep_on_gpu
-            )
+            if mm_embedding is not None:
+                self._validate_embedding_token_count(ctx, mm_embedding)
+            return mm_embedding
+        return await self._compute_direct_embedding(ctx, keep_on_gpu=keep_on_gpu)
 
+    @staticmethod
+    def _validate_embedding_token_count(
+        ctx: EncodeContext, mm_embedding: torch.Tensor
+    ) -> None:
         expected_tokens = sum(ctx.preprocess_result.token_counts)
-        if mm_embedding is not None and mm_embedding.shape[0] != expected_tokens:
+        if mm_embedding.shape[0] != expected_tokens:
             raise InternalError(
                 f"Encoder produced {mm_embedding.shape[0]} tokens, but "
                 f"preprocessor metadata expected {expected_tokens}"
             )
-        return mm_embedding
 
     async def _publish_preprocess_metadata(
         self, ctx: EncodeContext, requests: List[dict]

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -2,7 +2,7 @@ import asyncio
 import pickle
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import numpy as np
 import torch
@@ -24,6 +24,10 @@ from sglang.srt.disaggregation.encoder.server import (
     rid_to_receive_endpoint,
 )
 from sglang.srt.managers.schedule_batch import Modality
+from sglang.srt.mem_cache.multimodal_cache import (
+    EmbeddingResult,
+    MultiModalStaticCache,
+)
 from sglang.srt.utils.common import safe_pickle_loads
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -130,6 +134,98 @@ class TestEncoderPreprocessorKimiGrid(CustomTestCase):
 
 
 class TestEncoderDelivery(CustomTestCase):
+    @staticmethod
+    def _make_prefix_cache_encoder_and_context(get_feature_fn):
+        encoder = MMEncoder.__new__(MMEncoder)
+        encoder.mm_cache = MultiModalStaticCache(1024 * 1024)
+        encoder.mm_cache_lock = asyncio.Lock()
+        item = SimpleNamespace(hash=123, set_pad_value=lambda: None)
+        encoder._build_model_mm_items = Mock(return_value=[item])
+        ctx = SimpleNamespace(
+            req_id="req",
+            modality=Modality.IMAGE,
+            num_items=1,
+            mm_feature=None,
+            preprocess_result=SimpleNamespace(token_counts=[2], mm_inputs={}),
+            get_feature_fn=get_feature_fn,
+            is_health_check=False,
+            items_per_req=[1],
+            aux_data={},
+        )
+        return encoder, ctx
+
+    def test_invalid_fresh_embedding_is_not_cached(self):
+        async def run():
+            for actual_tokens in (1, 3):
+                with self.subTest(actual_tokens=actual_tokens):
+                    get_feature_fn = Mock(return_value=torch.zeros((actual_tokens, 4)))
+                    encoder, ctx = self._make_prefix_cache_encoder_and_context(
+                        get_feature_fn
+                    )
+
+                    with (
+                        patch(
+                            "sglang.srt.disaggregation.encoder.server.get_mm",
+                            return_value=SimpleNamespace(enable_prefix_mm_cache=True),
+                        ),
+                        self.assertRaisesRegex(
+                            InternalError,
+                            f"Encoder produced {actual_tokens} tokens, but "
+                            "preprocessor metadata expected 2",
+                        ),
+                    ):
+                        await encoder._compute_direct_embedding(ctx, keep_on_gpu=False)
+
+                    self.assertEqual(len(encoder.mm_cache), 0)
+                    get_feature_fn.assert_called_once()
+
+        asyncio.run(run())
+
+    def test_valid_fresh_embedding_is_cached_and_reused(self):
+        async def run():
+            get_feature_fn = Mock(return_value=torch.zeros((2, 4)))
+            encoder, ctx = self._make_prefix_cache_encoder_and_context(get_feature_fn)
+
+            with patch(
+                "sglang.srt.disaggregation.encoder.server.get_mm",
+                return_value=SimpleNamespace(enable_prefix_mm_cache=True),
+            ):
+                first = await encoder._compute_direct_embedding(ctx, keep_on_gpu=False)
+                second = await encoder._compute_direct_embedding(ctx, keep_on_gpu=False)
+
+            torch.testing.assert_close(first, second)
+            self.assertEqual(len(encoder.mm_cache), 1)
+            get_feature_fn.assert_called_once()
+
+        asyncio.run(run())
+
+    def test_invalid_cached_embedding_is_evicted(self):
+        async def run():
+            get_feature_fn = Mock()
+            encoder, ctx = self._make_prefix_cache_encoder_and_context(get_feature_fn)
+            mm_hash = MultiModalStaticCache.combine_hashes([123])
+            encoder.mm_cache.set(
+                mm_hash,
+                EmbeddingResult(embedding=torch.zeros((1, 4))),
+            )
+
+            with (
+                patch(
+                    "sglang.srt.disaggregation.encoder.server.get_mm",
+                    return_value=SimpleNamespace(enable_prefix_mm_cache=True),
+                ),
+                self.assertRaisesRegex(
+                    InternalError,
+                    "Encoder produced 1 tokens, but preprocessor metadata expected 2",
+                ),
+            ):
+                await encoder._compute_direct_embedding(ctx, keep_on_gpu=False)
+
+            self.assertEqual(len(encoder.mm_cache), 0)
+            get_feature_fn.assert_not_called()
+
+        asyncio.run(run())
+
     def test_contract_has_two_direct_implementations(self):
         self.assertEqual(EncoderDelivery.__abstractmethods__, {"send", "release"})
         self.assertEqual(


### PR DESCRIPTION
## Summary

- validate direct EPD encoder output against preprocess token metadata before inserting it into the prefix multimodal cache
- evict malformed entries created by older versions when they are encountered
- keep the global-cache path validation at its output boundary

## Correctness

Previously, a fresh direct-path embedding was inserted into the prefix MM cache before the outer token-count check. A short or overlong encoder result could therefore poison every later request for the same media until eviction or flush. This change makes malformed fresh output non-cacheable and makes an invalid existing hit self-healing by evicting it before returning the request-level error.

## Validation

- `python3 test/registered/unit/disaggregation/test_encode_server.py -f`: 20 passed
- pre-commit on changed files: passed
- H200, real `Qwen3-VL-2B-Instruct`, encoder-only with `--enable-prefix-mm-cache`: two sequential valid image requests returned HTTP 200; post-request `/health` returned HTTP 200 in 19 ms
- unit coverage verifies short and overlong fresh embeddings are not cached, malformed legacy hits are evicted without rerunning forward, and valid output is inserted then reused

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33244123036](https://github.com/sgl-project/sglang/actions/runs/33244123036)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33244126839](https://github.com/sgl-project/sglang/actions/runs/33244126839)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33244123019](https://github.com/sgl-project/sglang/actions/runs/33244123019)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->