### PR TITLE
[VLM] Release Mooncake fallback registrations on send failure

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -1550,21 +1550,35 @@ class MMEncoder:
             mr_already_registered = mm_data._mr_ptr == embedding.data_ptr()
             if not mr_already_registered:
                 self.engine.register(embedding.data_ptr(), embedding.nbytes)
-            _t_xfer_start = time.monotonic()
-            xfer_ret = await asyncio.to_thread(
-                self.engine.transfer_sync,
-                session_id,
-                embedding.data_ptr(),
-                buffer_address,
-                embedding.nbytes,
-            )
+            transfer_error = None
+            try:
+                _t_xfer_start = time.monotonic()
+                xfer_ret = await self._run_mooncake_transfer(
+                    session_id,
+                    embedding.data_ptr(),
+                    buffer_address,
+                    embedding.nbytes,
+                )
+            except BaseException as error:
+                transfer_error = error
+                raise
+            finally:
+                if not mr_already_registered:
+                    try:
+                        self.engine.deregister(embedding.data_ptr())
+                    except Exception:
+                        if transfer_error is None:
+                            raise
+                        logger.exception(
+                            "Per-send MR deregistration also failed for %s; "
+                            "preserving the transfer error",
+                            req_id,
+                        )
             xfer_ms = (time.monotonic() - _t_xfer_start) * 1000.0
             if encoder_metrics_collector is not None:
                 encoder_metrics_collector.observe_transfer(
                     xfer_ms / 1000.0, backend="mooncake"
                 )
-            if not mr_already_registered:
-                self.engine.deregister(embedding.data_ptr())
             if xfer_ret < 0:
                 raise InternalError(
                     f"Mooncake transfer_sync failed for {req_id} "
@@ -1682,6 +1696,32 @@ class MMEncoder:
                 time.perf_counter() - transfer_start,
                 backend=get_disagg().encoder_transfer_backend,
             )
+
+    async def _run_mooncake_transfer(
+        self,
+        session_id,
+        source_address: int,
+        destination_address: int,
+        size: int,
+    ) -> int:
+        """Keep the send active until its blocking transfer stops using the MR."""
+        transfer_task = asyncio.create_task(
+            asyncio.to_thread(
+                self.engine.transfer_sync,
+                session_id,
+                source_address,
+                destination_address,
+                size,
+            )
+        )
+        try:
+            return await asyncio.shield(transfer_task)
+        except asyncio.CancelledError:
+            try:
+                await transfer_task
+            except Exception:
+                pass
+            raise
 
     def _register_shared_mr(self, mm_data: EmbeddingData, embedding: torch.Tensor):
         """Register one MR shared by every rank's /send; _send re-registers on failure."""

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -1,5 +1,6 @@
 import asyncio
 import pickle
+import threading
 import unittest
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -139,6 +140,116 @@ class TestEncoderDelivery(CustomTestCase):
                 ZmqDelivery,
             },
         )
+
+    @staticmethod
+    def _make_mooncake_send(engine):
+        embedding = torch.zeros((2, 4), dtype=torch.float32)
+        mm_data = EmbeddingData(
+            "req",
+            1,
+            0,
+            None,
+            Modality.IMAGE,
+            embedding=embedding,
+        )
+        encoder = MMEncoder.__new__(MMEncoder)
+        encoder._element_size = embedding.element_size()
+        encoder.engine = engine
+        return encoder, embedding, mm_data
+
+    def test_mooncake_fallback_registration_is_released_after_transfer_error(self):
+        async def run():
+            events = []
+
+            def register(*_):
+                events.append("register")
+
+            def transfer_sync(*_):
+                events.append("transfer")
+                raise RuntimeError("transfer failed")
+
+            def deregister(*_):
+                events.append("deregister")
+
+            engine = SimpleNamespace(
+                register=register,
+                transfer_sync=transfer_sync,
+                deregister=deregister,
+            )
+            encoder, embedding, mm_data = self._make_mooncake_send(engine)
+
+            with (
+                patch(
+                    "sglang.srt.disaggregation.encoder.server.get_disagg",
+                    return_value=SimpleNamespace(encoder_transfer_backend="mooncake"),
+                ),
+                self.assertRaisesRegex(RuntimeError, "transfer failed"),
+            ):
+                await encoder._send(
+                    embedding,
+                    mm_data,
+                    session_id="session",
+                    buffer_address=1,
+                )
+
+            self.assertEqual(events, ["register", "transfer", "deregister"])
+
+        asyncio.run(run())
+
+    def test_mooncake_cancel_waits_before_releasing_fallback_registration(self):
+        async def run():
+            events = []
+            transfer_started = threading.Event()
+            finish_transfer = threading.Event()
+
+            def register(*_):
+                events.append("register")
+
+            def transfer_sync(*_):
+                events.append("transfer-start")
+                transfer_started.set()
+                finish_transfer.wait(timeout=2)
+                events.append("transfer-finish")
+                return 0
+
+            def deregister(*_):
+                events.append("deregister")
+
+            engine = SimpleNamespace(
+                register=register,
+                transfer_sync=transfer_sync,
+                deregister=deregister,
+            )
+            encoder, embedding, mm_data = self._make_mooncake_send(engine)
+
+            with patch(
+                "sglang.srt.disaggregation.encoder.server.get_disagg",
+                return_value=SimpleNamespace(encoder_transfer_backend="mooncake"),
+            ):
+                send_task = asyncio.create_task(
+                    encoder._send(
+                        embedding,
+                        mm_data,
+                        session_id="session",
+                        buffer_address=1,
+                    )
+                )
+                self.assertTrue(await asyncio.to_thread(transfer_started.wait, 1))
+                send_task.cancel()
+                await asyncio.sleep(0)
+                self.assertFalse(send_task.done())
+                self.assertNotIn("deregister", events)
+
+                finish_transfer.set()
+                with self.assertRaises(asyncio.CancelledError):
+                    await send_task
+
+            self.assertEqual(
+                events,
+                ["register", "transfer-start", "transfer-finish", "deregister"],
+            )
+
+        asyncio.run(run())
 
     def test_zmq_delivery_cleanup_is_configurable(self):
         async def run():


### PR DESCRIPTION
## Summary

- always deregister an EPD Mooncake per-send MR when transfer fails
- keep a cancelled async send alive until the blocking `transfer_sync` thread has stopped using the registration
- preserve the original transfer/cancellation error if cleanup also fails

## Why

When shared MR registration fails, EPD falls back to registering the embedding for one send. Previously an exception from `transfer_sync` skipped `deregister`, leaking that registration across requests. Cancellation had a second race: `asyncio.to_thread` keeps running after its awaiter is cancelled, so releasing the MR immediately could invalidate memory still used by the transfer thread.

## Validation

- `python3 test/registered/unit/disaggregation/test_encode_server.py -f`: 19 passed on H200 environment
- pre-commit on changed files: passed
- tests cover transfer exception cleanup and cancellation ordering (`transfer-finish` before `deregister`)

This is limited to the VLM EPD Mooncake send path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33244436377](https://github.com/sgl-project/sglang/actions/runs/33244436377)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33244443297](https://github.com/sgl-project/sglang/actions/runs/33244443297)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33244436299](https://github.com/sgl-project/sglang/actions/runs/33244436299)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->