### PR TITLE
[Bug] benchmark: launch server child with spawn to avoid dead CUDA/XPU context

### DIFF
--- a/python/sglang/benchmark/endpoint.py
+++ b/python/sglang/benchmark/endpoint.py
@@ -48,14 +48,9 @@ def _launch_server_target(launch_server_func: Callable, server_args: ServerArgs)
 
 
 def launch_or_reuse_server(launch_server_func: Callable, server_args: ServerArgs):
-    # Resolve in the parent, before the fork. The pipeline probes the device
-    # (the default attention backend reads the CUDA capability), and a forked
-    # child cannot re-initialize CUDA once this process has.
-    server_args.resolve_once()
-
     base_url = resolve_base_url("", server_args.host, server_args.port)
 
-    # Reuse an already-running server instead of forking a second one onto the
+    # Reuse an already-running server instead of launching a second one onto the
     # occupied port, where it would orphan, compete for the GPU, and OOM.
     if server_is_up(base_url, timeout=5):
         print(
@@ -64,7 +59,14 @@ def launch_or_reuse_server(launch_server_func: Callable, server_args: ServerArgs
         )
         return None, base_url
 
-    proc = multiprocessing.Process(
+    # Launch in a fresh *spawn* process. The parent CLI may have already
+    # initialized the accelerator (CUDA/XPU) while resolving ``ServerArgs``; a
+    # forked child would inherit that dead device context and fail with
+    # "Cannot re-initialize CUDA in forked subprocess" the moment it touches the
+    # device (e.g. image preprocessing during a multimodal warmup). Spawn gives
+    # the child a clean process that initializes its own device context. See #34709.
+    ctx = multiprocessing.get_context("spawn")
+    proc = ctx.Process(
         target=_launch_server_target,
         args=(
             launch_server_func,

--- a/test/srt/test_benchmark_endpoint.py
+++ b/test/srt/test_benchmark_endpoint.py
@@ -1,0 +1,59 @@
+"""CPU unit test for benchmark server launch start method.
+
+Regression guard for #34709: ``launch_or_reuse_server`` must start the child
+server process with the *spawn* start method, not the platform-default ``fork``.
+
+With ``fork``, the child inherits the accelerator context (CUDA/XPU) that the
+parent CLI initialized while resolving ``ServerArgs`` and fails with
+"Cannot re-initialize CUDA in forked subprocess" as soon as it touches the
+device. Spawn gives the child a clean process.
+
+Run: python3 test/srt/test_benchmark_endpoint.py
+"""
+
+import multiprocessing
+import unittest
+from unittest import mock
+
+from sglang.benchmark.endpoint import launch_or_reuse_server
+
+
+class _FakeServerArgs:
+    """Minimal ServerArgs stand-in: only host/port are read before launch."""
+
+    host = "127.0.0.1"
+    port = 0
+
+    def resolve_once(self):
+        # The real resolution happens inside the spawned child; we never call it.
+        pass
+
+
+class LaunchUsesSpawnTest(unittest.TestCase):
+    def test_launch_uses_spawn_not_fork(self):
+        spawn_ctx = mock.MagicMock()
+        spawn_proc = mock.MagicMock()
+        spawn_proc.is_alive.return_value = True
+        spawn_ctx.Process.return_value = spawn_proc
+
+        with (
+            mock.patch.object(
+                multiprocessing,
+                "get_context",
+                side_effect=lambda method: spawn_ctx if method == "spawn" else None,
+            ),
+            mock.patch(
+                "sglang.benchmark.endpoint.server_is_up", side_effect=[False, True]
+            ),
+            mock.patch("sglang.benchmark.endpoint.time.sleep"),
+        ):
+            launch_or_reuse_server(lambda server_args: None, _FakeServerArgs())
+
+        # The child must be launched via the spawn context, not the default fork.
+        spawn_ctx.Process.assert_called_once()
+        _, kwargs = spawn_ctx.Process.call_args
+        self.assertIsNotNone(kwargs.get("target"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #34709.

`launch_or_reuse_server` started the server child with the platform-default
`fork` start method (Linux). By that point the parent CLI had already
initialized the accelerator while resolving `ServerArgs`, so the forked child
inherited a **dead device context** and crashed the moment it touched the
device:

- CUDA: `Cannot re-initialize CUDA in forked subprocess` (latent on text-only
  models; surfaces on multimodal warmup where `image.to(device)` runs).
- XPU: `Cannot re-initialize XPU in forked subprocess` (breaks outright).

This change launches the child with the **spawn** start method, giving it a
clean process that initializes its own device context.

## Changes

- `python/sglang/benchmark/endpoint.py`: replace `multiprocessing.Process(...)`
  with `multiprocessing.get_context("spawn").Process(...)`. Drop the
  now-unneeded pre-fork `server_args.resolve_once()` in the parent (the child
  resolves `ServerArgs` itself inside `launch_server`).
- `test/srt/test_benchmark_endpoint.py`: CPU regression test that mocks the
  server launch and asserts the child is started via the spawn context (a
  revert to `fork` fails the assertion).

## Test plan

- [x] `python3 test/srt/test_benchmark_endpoint.py` (CPU, mocked launch)
- [ ] Linux GPU CI (CUDA + XPU) — this path can only be exercised on a real
      device, so the regression test guards the start-method choice while CI
      covers the actual launch.

The benchmark entrypoint (`one_batch_server.py`) only consumes
`endpoint.base_url` after `acquire_endpoint`, so removing the parent-side
resolution is behavior-preserving.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33244505059](https://github.com/sgl-project/sglang/actions/runs/33244505059)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33244504876](https://github.com/sgl-project/sglang/actions/runs/33244504876)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33244505003](https://github.com/sgl-project/sglang/actions/runs/33244505003)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->