### PR TITLE
[VLM] Release staged EPD embeddings after send failure

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/http_server.py
+++ b/python/sglang/srt/disaggregation/encoder/http_server.py
@@ -32,6 +32,7 @@ from sglang.srt.disaggregation.encoder.runtime import (
     execute_encode_pipeline,
     launch_dp_runtime,
     launch_local_runtime,
+    send_staged_embedding,
 )
 from sglang.srt.disaggregation.encoder.server import (
     EncoderProfiler,
@@ -351,7 +352,6 @@ async def handle_send_request(request: dict):
     """Mooncake-only: drive the RDMA push of a staged embedding. The zmq
     backends deliver embeddings inline during /encode and never call /send."""
     req_id = request["req_id"]
-    receive_count = request.get("receive_count")
     if dp_dispatcher is not None:
         try:
             result = await dp_dispatcher.dispatch_send(request)
@@ -373,13 +373,23 @@ async def handle_send_request(request: dict):
                 status_code=status_code,
             )
         return ORJSONResponse(content=result.get("content"))
-    sent = await encoder.send(
-        req_id=req_id,
-        prefill_host=request["prefill_host"],
-        embedding_port=request["embedding_port"],
-        session_id=request["session_id"],
-        buffer_address=request["buffer_address"],
-    )
+    try:
+        sent = await send_staged_embedding(
+            encoder,
+            request,
+            # A pre-refcount decoder may have sibling ranks still to send.
+            release_without_count=False,
+        )
+    except Exception as error:
+        logger.error("Mooncake send failed for req_id=%s: %s", req_id, error)
+        return ORJSONResponse(
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            content={
+                "status": "error",
+                "message": str(error),
+                "req_id": req_id,
+            },
+        )
     if not sent:
         # No transfer happened: fail fast rather than 200 + a phantom count.
         return ORJSONResponse(
@@ -390,11 +400,6 @@ async def handle_send_request(request: dict):
                 "req_id": req_id,
             },
         )
-    # Sibling ranks share this embedding, so free it only once all have sent.
-    # No count means a pre-refcount decoder: leave it to the sweep, as when
-    # some rank never sends at all.
-    if receive_count:
-        await server_module.meta_registry.note_send_done(req_id, receive_count)
     return ORJSONResponse(content=None)
 
 

--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -1057,6 +1057,39 @@ async def _push_embedding_to_prefill(
             await enc.release_request(req_id)
 
 
+async def send_staged_embedding(
+    enc: MMEncoder,
+    request: dict,
+    *,
+    release_without_count: bool,
+) -> bool:
+    """Send one Mooncake embedding and retire its state on any failure."""
+    req_id = request["req_id"]
+    try:
+        sent = await enc.send(
+            req_id=req_id,
+            prefill_host=request["prefill_host"],
+            embedding_port=request["embedding_port"],
+            session_id=request["session_id"],
+            buffer_address=request["buffer_address"],
+        )
+        if not sent:
+            return False
+
+        receive_count = request.get("receive_count")
+        if receive_count:
+            await server_module.meta_registry.note_send_done(req_id, receive_count)
+        elif release_without_count:
+            await enc.release_request(req_id)
+        return True
+    except BaseException as error:
+        try:
+            await enc.release_request(req_id)
+        except Exception as cleanup_error:
+            error.add_note(f"Failed to release encoder request: {cleanup_error}")
+        raise
+
+
 def _record_pipeline_result(modality: Modality, status: str) -> None:
     if server_module.encoder_metrics_collector is not None:
         server_module.encoder_metrics_collector.inc_requests_total(
@@ -1282,12 +1315,10 @@ async def _dp_worker_handle_request(
                 ) from e
         elif dp_type == "send":
             req_id = request["req_id"]
-            sent = await enc.send(
-                req_id=req_id,
-                prefill_host=request["prefill_host"],
-                embedding_port=request["embedding_port"],
-                session_id=request["session_id"],
-                buffer_address=request["buffer_address"],
+            sent = await send_staged_embedding(
+                enc,
+                request,
+                release_without_count=True,
             )
             if not sent:
                 # Error envelope, not 200 + phantom count: the decoder must
@@ -1296,13 +1327,6 @@ async def _dp_worker_handle_request(
                     f"no staged embedding for /send req_id={req_id} "
                     f"(already released)"
                 )
-            # Releasing on the first /send breaks decoder TP > 1. No count means
-            # a pre-refcount decoder: stay eager rather than pin until the sweep.
-            receive_count = request.get("receive_count")
-            if receive_count:
-                await server_module.meta_registry.note_send_done(req_id, receive_count)
-            else:
-                await enc.release_request(req_id)
             content = None
         else:
             content = await execute_encode_pipeline(enc, sched, request)

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -9,7 +9,10 @@ import torch
 
 from sglang.srt.disaggregation.encoder.preprocessor import EncoderPreprocessor
 from sglang.srt.disaggregation.encoder.receiver import EmbeddingData
-from sglang.srt.disaggregation.encoder.runtime import execute_encode_pipeline
+from sglang.srt.disaggregation.encoder.runtime import (
+    execute_encode_pipeline,
+    send_staged_embedding,
+)
 from sglang.srt.disaggregation.encoder.server import (
     EncoderDelivery,
     InternalError,
@@ -139,6 +142,87 @@ class TestEncoderDelivery(CustomTestCase):
                 ZmqDelivery,
             },
         )
+
+    def test_failed_staged_send_releases_request(self):
+        async def run():
+            encoder = SimpleNamespace(
+                send=AsyncMock(side_effect=RuntimeError("transfer failed")),
+                release_request=AsyncMock(),
+            )
+            request = {
+                "req_id": "req",
+                "prefill_host": "127.0.0.1",
+                "embedding_port": 1,
+                "session_id": "session",
+                "buffer_address": 2,
+            }
+
+            with self.assertRaisesRegex(RuntimeError, "transfer failed"):
+                await send_staged_embedding(
+                    encoder, request, release_without_count=False
+                )
+
+            encoder.release_request.assert_awaited_once_with("req")
+
+        asyncio.run(run())
+
+    def test_cancelled_staged_send_releases_request(self):
+        async def run():
+            encoder = SimpleNamespace(
+                send=AsyncMock(side_effect=asyncio.CancelledError()),
+                release_request=AsyncMock(),
+            )
+            request = {
+                "req_id": "req",
+                "prefill_host": "127.0.0.1",
+                "embedding_port": 1,
+                "session_id": "session",
+                "buffer_address": 2,
+            }
+
+            with self.assertRaises(asyncio.CancelledError):
+                await send_staged_embedding(
+                    encoder, request, release_without_count=False
+                )
+
+            encoder.release_request.assert_awaited_once_with("req")
+
+        asyncio.run(run())
+
+    def test_staged_send_uses_refcount_or_legacy_release_policy(self):
+        async def run():
+            request = {
+                "req_id": "req",
+                "prefill_host": "127.0.0.1",
+                "embedding_port": 1,
+                "session_id": "session",
+                "buffer_address": 2,
+                "receive_count": 2,
+            }
+            encoder = SimpleNamespace(
+                send=AsyncMock(return_value=True),
+                release_request=AsyncMock(),
+            )
+
+            note_send_done = AsyncMock()
+            with patch.object(meta_registry, "note_send_done", note_send_done):
+                self.assertTrue(
+                    await send_staged_embedding(
+                        encoder, request, release_without_count=True
+                    )
+                )
+            note_send_done.assert_awaited_once_with("req", 2)
+            encoder.release_request.assert_not_awaited()
+
+            request.pop("receive_count")
+            self.assertTrue(
+                await send_staged_embedding(
+                    encoder, request, release_without_count=True
+                )
+            )
+            encoder.release_request.assert_awaited_once_with("req")
+
+        asyncio.run(run())
 
     def test_zmq_delivery_cleanup_is_configurable(self):
         async def run():


### PR DESCRIPTION
## Summary

- use one lifecycle helper for Mooncake `/send` in local and encoder-DP modes
- immediately release the staged embedding when transfer, cancellation, or send-refcount accounting fails
- preserve decoder TP refcount behavior on successful sends
- return a request-level HTTP 500 for local send failures

## Why

A failed VLM EPD `/send` previously returned an error without releasing `ReqState`. The GPU embedding and shared Mooncake MR stayed resident until the timeout sweeper; repeated transfer failures could accumulate HBM and registration state. Encoder-DP had the same gap.

The helper treats failure as terminal for that request. `release_request` is idempotent and waits for sibling sends already in flight before freeing their shared embedding. Cleanup errors are attached to, rather than replacing, the original transfer error.

## Validation

- `python3 test/registered/unit/disaggregation/test_encode_server.py -f`: 20 passed on H200 environment
- pre-commit on changed files: passed
- tests cover transfer exception, task cancellation, TP receive-count completion, and legacy no-count cleanup policy

This changes only VLM EPD send error handling; successful transfer data and model execution are unchanged.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33244820831](https://github.com/sgl-project/sglang/actions/runs/33244820831)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33244825872](https://github.com/sgl-project/sglang/actions/runs/33244825872)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33244820804](https://github.com/sgl-project/sglang/actions/runs/33244820804)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->