### PR TITLE
[VLM] Isolate stale EPD metadata cleanup

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -120,6 +120,7 @@ class EncoderMetaRegistry:
         self._rid_to_send_done: Dict[str, int] = {}
         self._pending_at: Dict[str, float] = {}
         self._sweeper_task: Optional[asyncio.Task] = None
+        self._stale_release_tasks: Dict[str, asyncio.Task] = {}
         # Set only where the embedding also lives; None in the DP main process.
         self.on_release: Optional[Callable[[str], Awaitable[None]]] = None
 
@@ -148,7 +149,23 @@ class EncoderMetaRegistry:
                 if now - ts > self.sweep_timeout
             ]
             for rid in stale:
-                await self._release(rid)
+                if rid in self._stale_release_tasks:
+                    continue
+                self._stale_release_tasks[rid] = asyncio.create_task(
+                    self._release_stale(rid)
+                )
+
+    async def _release_stale(self, req_id: str) -> None:
+        """Release one stale request without blocking the registry sweeper."""
+        try:
+            await self._release(req_id)
+        except Exception:
+            logger.exception("Failed to release stale encoder request %s", req_id)
+            async with rid_lock:
+                if req_id in self._pending_at:
+                    self._pending_at[req_id] = time.monotonic()
+        finally:
+            self._stale_release_tasks.pop(req_id, None)
 
     async def publish(
         self,

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -12,6 +12,7 @@ from sglang.srt.disaggregation.encoder.receiver import EmbeddingData
 from sglang.srt.disaggregation.encoder.runtime import execute_encode_pipeline
 from sglang.srt.disaggregation.encoder.server import (
     EncoderDelivery,
+    EncoderMetaRegistry,
     InternalError,
     MMEncoder,
     MooncakeDelivery,
@@ -29,6 +30,79 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class TestEncoderMetaRegistry(CustomTestCase):
+    def test_stale_releases_do_not_block_each_other(self):
+        async def run():
+            registry = EncoderMetaRegistry(wait_timeout=1, sweep_timeout=0.04)
+            registry._pending_at = {"blocked": 0, "fast": 0}
+            blocked_started = asyncio.Event()
+            unblock = asyncio.Event()
+            fast_released = asyncio.Event()
+
+            async def release(req_id):
+                if req_id == "blocked":
+                    blocked_started.set()
+                    await unblock.wait()
+                else:
+                    fast_released.set()
+
+            registry.on_release = release
+            sweeper = asyncio.create_task(registry._sweep_loop())
+            try:
+                await asyncio.wait_for(blocked_started.wait(), timeout=1)
+                await asyncio.wait_for(fast_released.wait(), timeout=1)
+                await asyncio.sleep(0)
+
+                self.assertIn("blocked", registry._pending_at)
+                self.assertNotIn("fast", registry._pending_at)
+                self.assertFalse(sweeper.done())
+
+                unblock.set()
+                while "blocked" in registry._pending_at:
+                    await asyncio.sleep(0)
+            finally:
+                unblock.set()
+                sweeper.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await sweeper
+
+        asyncio.run(run())
+
+    def test_stale_release_error_is_retried(self):
+        async def run():
+            registry = EncoderMetaRegistry(wait_timeout=1, sweep_timeout=0.04)
+            registry._pending_at = {"retry": 0}
+            released = asyncio.Event()
+            attempts = 0
+
+            async def release(req_id):
+                nonlocal attempts
+                attempts += 1
+                if attempts == 1:
+                    raise RuntimeError("transient cleanup failure")
+                released.set()
+
+            registry.on_release = release
+            sweeper = asyncio.create_task(registry._sweep_loop())
+            try:
+                with patch(
+                    "sglang.srt.disaggregation.encoder.server.logger.exception"
+                ) as log_exception:
+                    await asyncio.wait_for(released.wait(), timeout=1)
+                while "retry" in registry._pending_at:
+                    await asyncio.sleep(0)
+
+                self.assertEqual(attempts, 2)
+                log_exception.assert_called_once()
+                self.assertFalse(sweeper.done())
+            finally:
+                sweeper.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await sweeper
+
+        asyncio.run(run())
 
 
 class TestEncoderPreprocessorKimiGrid(CustomTestCase):


### PR DESCRIPTION
## Summary

- release stale EPD metadata requests independently instead of serially awaiting each cleanup
- keep the registry sweeper alive when one request cleanup fails
- deduplicate in-flight cleanup per request and delay failed cleanup before retrying

## Why

A stalled encoder release previously blocked cleanup for every later stale VLM request. An exception also terminated the long-lived sweeper, leaving subsequent EPD metadata and staged embeddings unreclaimed.

## Coverage

Adds registry lifecycle coverage for a blocked release alongside an independent request, and for retry after a transient cleanup error.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33245120001](https://github.com/sgl-project/sglang/actions/runs/33245120001)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33245124223](https://github.com/sgl-project/sglang/actions/runs/33245124223)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33245120141](https://github.com/sgl-project/sglang/actions/runs/33245120141)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->