### PR TITLE
[VLM] Roll back failed CUDA IPC feature batches

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -37,6 +37,7 @@ from sglang.srt.multimodal.processors.executor import MultimodalProcessorExecuto
 from sglang.srt.multimodal.transport.cuda_ipc import (
     MM_FEATURE_CACHE_SIZE,
     MM_ITEM_MEMORY_POOL_RECYCLE_INTERVAL,
+    CudaIpcTensorTransportProxy,
     MmItemMemoryPool,
     get_mm_feature_pool_size_per_worker,
 )
@@ -1842,19 +1843,41 @@ class BaseMultimodalProcessor(ABC):
     def _prepare_mm_items_for_transport(
         self, mm_items: List[MultimodalDataItem]
     ) -> List[MultimodalDataItem]:
-        """Wrap final GPU features for dispatch to the scheduler."""
+        """Wrap final GPU features, rolling back every lease if one wrap fails."""
         if not self.use_cuda_ipc:
             return mm_items
 
         # Pool misses fall back to plain CPU tensors. The scheduler copies out
         # and releases each successful pool slice.
-        for item in mm_items:
-            if isinstance(item.feature, torch.Tensor):
-                item.feature = self._wrap_tensor_for_cuda_ipc(item.feature)
-            if isinstance(item.precomputed_embeddings, torch.Tensor):
-                item.precomputed_embeddings = self._wrap_tensor_for_cuda_ipc(
-                    item.precomputed_embeddings
+        updates = []
+        try:
+            for item in mm_items:
+                fields = (
+                    ("feature", item.feature),
+                    ("precomputed_embeddings", item.precomputed_embeddings),
                 )
+                for field, tensor in fields:
+                    if not isinstance(tensor, torch.Tensor):
+                        continue
+                    wrapped = self._wrap_tensor_for_cuda_ipc(tensor)
+                    setattr(item, field, wrapped)
+                    updates.append((item, field, tensor, wrapped))
+        except BaseException as error:
+            rollback_errors = []
+            for item, field, tensor, wrapped in reversed(updates):
+                try:
+                    if isinstance(wrapped, CudaIpcTensorTransportProxy):
+                        self.cudaipc_mmfeature_pool.cancel_proxy(wrapped)
+                except BaseException as rollback_error:
+                    rollback_errors.append(rollback_error)
+                finally:
+                    setattr(item, field, tensor)
+            if rollback_errors:
+                error.add_note(
+                    f"{len(rollback_errors)} CUDA IPC rollback operation(s) also failed"
+                )
+                raise error from rollback_errors[0]
+            raise
         return mm_items
 
     async def process_and_combine_mm_data_async(

--- a/python/sglang/srt/multimodal/processors/kimi_k3.py
+++ b/python/sglang/srt/multimodal/processors/kimi_k3.py
@@ -645,8 +645,6 @@ class KimiK3ImageProcessor(
                 model_specific_data=model_specific_data,
             )
             item.set_hash(artifact.feature_hash)
-            if self.use_cuda_ipc and isinstance(item.feature, torch.Tensor):
-                item.feature = self._wrap_tensor_for_cuda_ipc(item.feature)
             if self.keep_mm_features_on_device and item.feature is not None:
                 item.model_specific_data[DEFER_CUDA_IPC_FEATURE_RECONSTRUCTION_KEY] = (
                     True
@@ -655,7 +653,7 @@ class KimiK3ImageProcessor(
 
         return MultimodalProcessorOutput(
             input_ids=input_ids.tolist(),
-            mm_items=items,
+            mm_items=self._prepare_mm_items_for_transport(items),
             im_token_id=self.mm_tokens.image_token_id,
         )
 

--- a/python/sglang/srt/multimodal/processors/moss_vl.py
+++ b/python/sglang/srt/multimodal/processors/moss_vl.py
@@ -545,14 +545,7 @@ class MossVLImageProcessor(SGLangBaseProcessor):
             if mm_items and vision_token_info:
                 mm_items[0].set("vision_token_info", vision_token_info[0])
 
-            if self.use_cuda_ipc:
-                for item in mm_items:
-                    if isinstance(item.feature, torch.Tensor):
-                        item.feature = self._wrap_tensor_for_cuda_ipc(item.feature)
-                    if isinstance(item.precomputed_embeddings, torch.Tensor):
-                        item.precomputed_embeddings = self._wrap_tensor_for_cuda_ipc(
-                            item.precomputed_embeddings
-                        )
+            mm_items = self._prepare_mm_items_for_transport(mm_items)
 
             return MultimodalProcessorOutput(
                 input_ids=input_ids.tolist(),

--- a/python/sglang/srt/multimodal/transport/cuda_ipc.py
+++ b/python/sglang/srt/multimodal/transport/cuda_ipc.py
@@ -150,6 +150,17 @@ class MmItemMemoryPool:
             use_pool_handle_cache=use_pool_handle_cache,
         )
 
+    def cancel_proxy(self, proxy: "CudaIpcTensorTransportProxy") -> None:
+        """Return a published slice when its request was never dispatched."""
+        ipc_extra = proxy.proxy_state["ipc_extra"]
+        if tuple(ipc_extra["pool_handle"]) != tuple(self._pool_ipc_handle):
+            raise RuntimeError("CUDA IPC proxy does not belong to this pool")
+        self._pool.cancel_lease(
+            ready_byte_offset=proxy.ready_byte_offset,
+            ack_byte_offset=proxy.ack_byte_offset,
+            generation=proxy.generation,
+        )
+
     def _warn_pool_full_once(self, nbytes: int):
         if self._pool_full_warned:
             return

--- a/python/sglang/srt/multimodal/transport/memory_pool.py
+++ b/python/sglang/srt/multimodal/transport/memory_pool.py
@@ -361,6 +361,50 @@ class StreamOrderedMmFeaturePool:
             raise
         return lease, destination
 
+    def cancel_lease(
+        self,
+        *,
+        ready_byte_offset: int,
+        ack_byte_offset: int,
+        generation: int,
+    ) -> None:
+        """Acknowledge every consumer for a lease that was not dispatched."""
+        slot_stride = self.control_words_per_slot * CONTROL_WORD_BYTES
+        if (
+            ready_byte_offset % slot_stride != 0
+            or ack_byte_offset != ready_byte_offset + CONTROL_WORD_BYTES
+        ):
+            raise RuntimeError(f"Invalid {self.transport_name} pool lease offsets")
+        slot = ready_byte_offset // slot_stride
+
+        with self._lock:
+            lease = self._occupied.get(slot)
+            if (
+                lease is None
+                or lease.generation != generation
+                or lease.ready_byte_offset != ready_byte_offset
+                or lease.ack_byte_offset != ack_byte_offset
+            ):
+                raise RuntimeError(
+                    f"Cannot cancel inactive {self.transport_name} pool lease "
+                    f"(slot={slot}, generation={generation})"
+                )
+
+            with torch.cuda.device(self.device_id):
+                stream_wait_value32(
+                    self.device_id,
+                    self.base_address + ready_byte_offset,
+                    generation,
+                    self.transport_name,
+                )
+                for rank in range(self.consumer_count):
+                    stream_write_value32(
+                        self.device_id,
+                        self.base_address + ack_byte_offset + rank * CONTROL_WORD_BYTES,
+                        generation,
+                        self.transport_name,
+                    )
+
     def shutdown(self) -> None:
         self._recycler_stop_event.set()
         if self._recycle_thread.is_alive():

--- a/test/registered/unit/managers/test_mm_process_config.py
+++ b/test/registered/unit/managers/test_mm_process_config.py
@@ -486,6 +486,38 @@ class TestStreamOrderedMmFeaturePool(CustomTestCase):
         self.assertFalse(pool._recycle_thread.is_alive())
 
 
+class TestCudaIpcProcessorRollback(CustomTestCase):
+    def test_partial_wrap_failure_restores_items_and_cancels_proxy(self):
+        from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+        from sglang.srt.multimodal.processors.base_processor import (
+            BaseMultimodalProcessor,
+        )
+        from sglang.srt.multimodal.transport.cuda_ipc import (
+            CudaIpcTensorTransportProxy,
+        )
+
+        with patch.object(BaseMultimodalProcessor, "__abstractmethods__", set()):
+            processor = BaseMultimodalProcessor.__new__(BaseMultimodalProcessor)
+        processor.use_cuda_ipc = True
+        processor.cudaipc_mmfeature_pool = MagicMock()
+        proxy = object.__new__(CudaIpcTensorTransportProxy)
+        processor._wrap_tensor_for_cuda_ipc = MagicMock(
+            side_effect=[proxy, RuntimeError("wrap failed")]
+        )
+        features = [torch.ones(2), torch.ones(3)]
+        items = [
+            MultimodalDataItem(modality=Modality.IMAGE, feature=feature)
+            for feature in features
+        ]
+
+        with self.assertRaisesRegex(RuntimeError, "wrap failed"):
+            processor._prepare_mm_items_for_transport(items)
+
+        processor.cudaipc_mmfeature_pool.cancel_proxy.assert_called_once_with(proxy)
+        self.assertIs(items[0].feature, features[0])
+        self.assertIs(items[1].feature, features[1])
+
+
 class TestPrecomputeHashBeforeCpuTransfer(CustomTestCase):
     @staticmethod
     def _processor(enabled):

--- a/test/registered/unit/multimodal/test_cuda_ipc_transport.py
+++ b/test/registered/unit/multimodal/test_cuda_ipc_transport.py
@@ -137,6 +137,45 @@ class TestCudaIpcTransport(CustomTestCase):
         stream.synchronize.assert_called_once_with()
         self.assertIsNone(proxy._pool_storage)
 
+    def test_failed_item_batch_releases_undispatched_pool_slice(self):
+        from sglang.srt.managers.schedule_batch import Modality, MultimodalDataItem
+        from sglang.srt.multimodal.processors.base_processor import (
+            BaseMultimodalProcessor,
+        )
+
+        pool = MmItemMemoryPool(
+            memory_size=1 << 20,
+            recycle_interval=0.01,
+            base_gpu_id=0,
+            consumer_count=4,
+        )
+        with patch.object(BaseMultimodalProcessor, "__abstractmethods__", set()):
+            processor = BaseMultimodalProcessor.__new__(BaseMultimodalProcessor)
+        processor.use_cuda_ipc = True
+        processor.use_ipc_pool_handle_cache = True
+        processor.cudaipc_mmfeature_pool = pool
+        features = [
+            torch.ones(16, device="cuda"),
+            torch.empty(0, device="cuda"),
+        ]
+        items = [
+            MultimodalDataItem(modality=Modality.IMAGE, feature=feature)
+            for feature in features
+        ]
+
+        try:
+            with self.assertRaisesRegex(ValueError, "empty tensor"):
+                processor._prepare_mm_items_for_transport(items)
+
+            deadline = time.monotonic() + 5
+            while pool.active_lease_count and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertEqual(pool.active_lease_count, 0)
+            self.assertIs(items[0].feature, features[0])
+            self.assertIs(items[1].feature, features[1])
+        finally:
+            pool.shutdown()
+
 
 if __name__ == "__main__":
     unittest.main(verbosity=2)


### PR DESCRIPTION
## Summary

- make CUDA IPC wrapping transactional across every feature in a multimodal request
- stream-order cancellation of undispatched pool leases without synchronizing the normal path
- route Kimi-K3 and MOSS-VL through the shared transport transaction

## Why

If a later image or embedding failed during transport preparation, earlier CUDA IPC slices were never dispatched and therefore never acknowledged. Repeated malformed VLM requests could exhaust the bounded feature pool and force healthy traffic onto the CPU fallback.

## Coverage

Adds processor rollback coverage and a CUDA pool test with multiple expected consumers. Existing Kimi-K3, MOSS-VL, and cross-process CUDA IPC lifecycle suites cover the shared normal path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33245631032](https://github.com/sgl-project/sglang/actions/runs/33245631032)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33245637453](https://github.com/sgl-project/sglang/actions/runs/33245637453)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33245631048](https://github.com/sgl-project/sglang/actions/runs/33245631048)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->