### PR TITLE
[VLM] Recover failed global embedding cache copies

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -1021,9 +1021,7 @@ async def _push_embedding_to_prefill(
     if backend == "zmq_to_scheduler" and request.get("embedding_port") is None:
         send_coro = enc.send_with_url(req_id=req_id)
         if background_url_send:
-            task = asyncio.create_task(send_coro)
-            enc.background_tasks.add(task)
-            task.add_done_callback(enc.background_tasks.discard)
+            enc._create_background_task(send_coro)
         else:
             await send_coro
         return

--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -607,6 +607,21 @@ class MMEncoder:
 
         logger.info(f"rank {rank} init finish ")
 
+    def _background_task_done(self, task: asyncio.Task) -> None:
+        self.background_tasks.discard(task)
+        try:
+            task.result()
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.exception("MMEncoder background task failed")
+
+    def _create_background_task(self, awaitable: Awaitable[Any]) -> asyncio.Task:
+        task = asyncio.create_task(awaitable)
+        self.background_tasks.add(task)
+        task.add_done_callback(self._background_task_done)
+        return task
+
     def supports_modality(self, modality: Modality) -> bool:
         return self.preprocessor.supports_modality(modality)
 
@@ -1131,9 +1146,7 @@ class MMEncoder:
                 ctx.modality,
             )
 
-        task = asyncio.create_task(_background_insert())
-        self.background_tasks.add(task)
-        task.add_done_callback(self.background_tasks.discard)
+        self._create_background_task(_background_insert())
 
     @staticmethod
     def _as_2d_tensor(tensor: torch.Tensor) -> torch.Tensor:

--- a/python/sglang/srt/mem_cache/embedding_cache_controller.py
+++ b/python/sglang/srt/mem_cache/embedding_cache_controller.py
@@ -979,13 +979,32 @@ class EmbeddingCacheController:
         handles: List[Tuple["EmbeddingCacheEntry", "AsyncCopyHandle"]],
     ):
         """Wait for async D2H copies and mark entries READY."""
+        completed = []
+        errors = []
         for entry, handle in handles:
-            handle.wait()
+            try:
+                handle.wait()
+                completed.append(True)
+            except BaseException as error:
+                completed.append(False)
+                errors.append(error)
+
         with self.lock:
-            for entry, handle in handles:
+            for (entry, _), success in zip(handles, completed, strict=True):
                 current = self.entries.get(entry.hash)
                 if current is entry and current.state == EntryState.FILLING:
-                    self._mark_ready(current)
+                    if success:
+                        self._mark_ready(current)
+                    else:
+                        self._evict_entry(entry.hash)
+
+        if errors:
+            first_error = errors[0]
+            if len(errors) > 1:
+                first_error.add_note(
+                    f"{len(errors) - 1} additional embedding copy operation(s) failed"
+                )
+            raise first_error
 
     def _copy_tensor_to_pool(
         self, tensor: torch.Tensor, entry: EmbeddingCacheEntry, pool: EmbeddingPool

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -130,6 +130,27 @@ class TestEncoderPreprocessorKimiGrid(CustomTestCase):
 
 
 class TestEncoderDelivery(CustomTestCase):
+    def test_background_task_failure_is_observed(self):
+        async def run():
+            encoder = MMEncoder.__new__(MMEncoder)
+            encoder.background_tasks = set()
+
+            async def fail():
+                raise RuntimeError("background failure")
+
+            with patch(
+                "sglang.srt.disaggregation.encoder.server.logger.exception"
+            ) as log_exception:
+                task = encoder._create_background_task(fail())
+                await asyncio.sleep(0)
+                await asyncio.sleep(0)
+
+            self.assertTrue(task.done())
+            self.assertNotIn(task, encoder.background_tasks)
+            log_exception.assert_called_once_with("MMEncoder background task failed")
+
+        asyncio.run(run())
+
     def test_contract_has_two_direct_implementations(self):
         self.assertEqual(EncoderDelivery.__abstractmethods__, {"send", "release"})
         self.assertEqual(

--- a/test/registered/unit/mem_cache/test_embedding_cache_controller.py
+++ b/test/registered/unit/mem_cache/test_embedding_cache_controller.py
@@ -250,6 +250,35 @@ class TestStoreToPool(unittest.TestCase):
         with self.assertRaises(ValueError):
             ctrl.store_to_pool_async(["h"], [tensor], Modality.IMAGE)
 
+    def test_wait_store_isolates_failed_copy_and_waits_for_the_rest(self):
+        ctrl = _make_controller(num_pages=4, dim=4, page_size=2)
+        entries = []
+        for mm_hash in ("first", "failed", "last"):
+            page_runs = ctrl.vision_pool.allocator.allocate(2, 2)
+            entry = EmbeddingCacheEntry(
+                hash=mm_hash,
+                modality=Modality.IMAGE,
+                num_tokens=2,
+                dim=4,
+                page_runs=page_runs,
+                state=EntryState.FILLING,
+            )
+            ctrl.entries[mm_hash] = entry
+            entries.append(entry)
+
+        handles = [MagicMock(), MagicMock(), MagicMock()]
+        handles[1].wait.side_effect = RuntimeError("D2H copy failed")
+
+        with self.assertRaisesRegex(RuntimeError, "D2H copy failed"):
+            ctrl.wait_store_to_pool(list(zip(entries, handles)))
+
+        for handle in handles:
+            handle.wait.assert_called_once_with()
+        self.assertEqual(ctrl.entries["first"].state, EntryState.READY)
+        self.assertNotIn("failed", ctrl.entries)
+        self.assertEqual(ctrl.entries["last"].state, EntryState.READY)
+        self.assertEqual(ctrl.vision_pool.allocator.free_pages, 2)
+
 
 def _insert_ready_entry(ctrl, mm_hash, tensor, modality=Modality.IMAGE):
     """Manually write tensor into pool pages and create a READY entry."""


### PR DESCRIPTION
## Summary

- wait every VLM global-cache D2H handle even when one copy fails
- retain successful local entries while removing failed `FILLING` entries and returning their host pages
- track encoder background tasks through one helper that consumes and reports failures

## Why

The previous wait loop stopped at the first copy error. Later copies were left unjoined and every entry in that batch remained `FILLING`, permanently removing those pages from the VLM embedding cache while the background-task exception went unobserved.

## Coverage

Adds partial-copy lifecycle coverage with successful entries on both sides of a failed handle, plus background-task failure observation coverage.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33245927258](https://github.com/sgl-project/sglang/actions/runs/33245927258)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33245932598](https://github.com/sgl-project/sglang/actions/runs/33245932598)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33245927217](https://github.com/sgl-project/sglang/actions/runs/33245927217)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->