### PR TITLE
[VLM] Clean up failed MOSS video normalization

### DIFF
--- a/python/sglang/srt/multimodal/processors/moss_vl.py
+++ b/python/sglang/srt/multimodal/processors/moss_vl.py
@@ -413,9 +413,16 @@ class MossVLImageProcessor(SGLangBaseProcessor):
     def _write_video_bytes_to_tempfile(
         self, video_bytes: bytes, suffix: str = ".mp4"
     ) -> str:
-        with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as f:
-            f.write(video_bytes)
-            return f.name
+        temp_path = None
+        try:
+            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as f:
+                temp_path = f.name
+                f.write(video_bytes)
+            return temp_path
+        except BaseException:
+            if temp_path is not None:
+                self._remove_temp_video_paths([temp_path])
+            raise
 
     def _normalize_video_string(self, value: str) -> Tuple[str, Optional[str]]:
         if value.startswith("file://"):
@@ -428,9 +435,8 @@ class MossVLImageProcessor(SGLangBaseProcessor):
             timeout = int(os.getenv("REQUEST_TIMEOUT", "10"))
             content = download_remote_media(value, timeout=timeout)
             suffix = os.path.splitext(urlparse(value).path)[1] or ".mp4"
-            with tempfile.NamedTemporaryFile(delete=False, suffix=suffix) as f:
-                f.write(content)
-                return f.name, f.name
+            temp_path = self._write_video_bytes_to_tempfile(content, suffix=suffix)
+            return temp_path, temp_path
 
         if value.startswith("data:"):
             header, encoded = value.split(",", 1)
@@ -483,14 +489,45 @@ class MossVLImageProcessor(SGLangBaseProcessor):
             )
             for v in video_data
         ]
-        results = await asyncio.gather(*futures)
+        gather_task = asyncio.gather(*futures, return_exceptions=True)
+        cancelled_error = None
+        try:
+            results = await asyncio.shield(gather_task)
+        except asyncio.CancelledError as error:
+            cancelled_error = error
+            results = await gather_task
 
         normalized_inputs: List[Union[str, Dict]] = []
         temp_paths: List[str] = []
-        for normalized_input, created_paths in results:
+        errors = []
+        for result in results:
+            if isinstance(result, BaseException):
+                errors.append(result)
+                continue
+            normalized_input, created_paths = result
             normalized_inputs.append(normalized_input)
             temp_paths.extend(created_paths)
+
+        if cancelled_error is not None or errors:
+            self._remove_temp_video_paths(temp_paths)
+            if cancelled_error is not None:
+                raise cancelled_error
+            first_error = errors[0]
+            if len(errors) > 1:
+                first_error.add_note(
+                    f"{len(errors) - 1} additional video input(s) failed"
+                )
+            raise first_error
+
         return normalized_inputs, temp_paths
+
+    @staticmethod
+    def _remove_temp_video_paths(temp_paths: List[str]) -> None:
+        for temp_path in temp_paths:
+            try:
+                os.unlink(temp_path)
+            except FileNotFoundError:
+                pass
 
     async def process_mm_data_async(
         self,
@@ -569,8 +606,4 @@ class MossVLImageProcessor(SGLangBaseProcessor):
                 visible_frame_counts=visible_frame_counts,
             )
         finally:
-            for temp_path in temp_video_paths:
-                try:
-                    os.unlink(temp_path)
-                except FileNotFoundError:
-                    pass
+            self._remove_temp_video_paths(temp_video_paths)

--- a/test/registered/unit/models/test_moss_vl_processor.py
+++ b/test/registered/unit/models/test_moss_vl_processor.py
@@ -1,4 +1,7 @@
+import asyncio
 import re
+import threading
+from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
 
 import pytest
@@ -79,6 +82,64 @@ def test_moss_vl_accepts_matching_vision_metadata_and_tokens():
     assert vision_positions.shape == (3, 1, 16)
     assert updated_positions.shape == position_ids.shape
     assert rope_deltas.shape == (1,)
+
+
+def test_video_normalization_cleans_sibling_temp_file_on_failure(tmp_path):
+    processor = _processor()
+    processor.io_executor = ThreadPoolExecutor(max_workers=2)
+    temp_path = tmp_path / "normalized.mp4"
+    created = threading.Event()
+
+    def normalize(value):
+        if value == "good":
+            temp_path.write_bytes(b"video")
+            created.set()
+            return str(temp_path), [str(temp_path)]
+        assert created.wait(timeout=5)
+        raise ValueError("invalid video")
+
+    processor._normalize_single_video_input = normalize
+    try:
+        with pytest.raises(ValueError, match="invalid video"):
+            asyncio.run(processor._normalize_video_inputs_async(["good", "bad"]))
+    finally:
+        processor.io_executor.shutdown()
+
+    assert not temp_path.exists()
+
+
+def test_video_normalization_waits_for_worker_cleanup_when_cancelled(tmp_path):
+    processor = _processor()
+    processor.io_executor = ThreadPoolExecutor(max_workers=1)
+    temp_path = tmp_path / "cancelled.mp4"
+    created = threading.Event()
+    finish = threading.Event()
+
+    def normalize(_value):
+        temp_path.write_bytes(b"video")
+        created.set()
+        assert finish.wait(timeout=5)
+        return str(temp_path), [str(temp_path)]
+
+    processor._normalize_single_video_input = normalize
+
+    async def run():
+        task = asyncio.create_task(
+            processor._normalize_video_inputs_async(["cancelled"])
+        )
+        assert await asyncio.to_thread(created.wait, 5)
+        task.cancel()
+        finish.set()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    try:
+        asyncio.run(run())
+    finally:
+        finish.set()
+        processor.io_executor.shutdown()
+
+    assert not temp_path.exists()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- join all parallel MOSS video normalization workers on request failure or cancellation
- remove every temporary video created by sibling workers before propagating the original error
- clean partially written temporary files and share cleanup logic between normal and error paths

## Why

Failed or cancelled multi-video requests could leave temporary media files behind and eventually exhaust local disk space.

## Coverage

- parallel normalization with a sibling failure
- request cancellation while a normalization worker is active

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33246144163](https://github.com/sgl-project/sglang/actions/runs/33246144163)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33246151503](https://github.com/sgl-project/sglang/actions/runs/33246151503)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33246144146](https://github.com/sgl-project/sglang/actions/runs/33246144146)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->