### PR TITLE
[Kernel] Gate SM90 rowwise FP8 routing on M

### DIFF
--- a/python/sglang/kernels/ops/gemm/__init__.py
+++ b/python/sglang/kernels/ops/gemm/__init__.py
@@ -63,11 +63,9 @@ def _prefer_torch_rowwise_fp8(
     ):
         return False
 
-    # Tuned on H100 over MiniMax-H3's complete dense shape set: four
-    # production sequence lengths and TP1/2/4/8 (64 shapes). This selector
-    # chose the measured winner for every shape while retaining the AOT kernel
-    # for the smaller-K projections where NVJet loses.
-    return (k >= 5376 and n >= 3584) or (k >= 3584 and m >= 8192)
+    # Tuned on H100 over MiniMax-H3's large prefill shapes. Keep decode and
+    # other small-M callers on the AOT kernel, where NVJet can be slower.
+    return k >= 3584 and m >= 8192
 
 
 class Fp8ScaledMMOp(BaseFusedOp):


### PR DESCRIPTION
## Summary

- require `M >= 8192` before routing SM90 row/column-scaled FP8 GEMMs to `torch._scaled_mm`
- keep decode and other small-M callers on the SGLang AOT kernel
- simplify the selector after applying the M gate: adding `M >= 8192` to the first clause makes it a subset of the existing `(K >= 3584 and M >= 8192)` clause

## Motivation

Follow-up to #34318 and [the reported H100 W8A8 decode regression](https://github.com/sgl-project/sglang/pull/34318#issuecomment-5460790412).

The original selector allowed `(M=1, K=14336, N=4096)` down projections through its `(K >= 5376 and N >= 3584)` clause. That routes decode to Torch even though the AOT kernel is faster there, reducing the registered W8A8 throughput test from about 215 tok/s to about 190 tok/s.

The original tuning data covered large MiniMax-H3 prefill shapes. Reusing its existing `M >= 8192` boundary limits the optimized route to that measured regime.

## Validation

- `uvx pre-commit run --files python/sglang/kernels/ops/gemm/__init__.py`
- `python3 -m py_compile python/sglang/kernels/ops/gemm/__init__.py`
- checked routing boundaries and representative shapes:
  - `(M=1, K=14336, N=4096)` -> AOT
  - `M=8191` -> AOT; `M=8192` -> Torch when `K >= 3584`
  - `K=3583` -> AOT; `K=3584` -> Torch when `M >= 8192`
  - all five MiniMax-H3 shapes listed in #34318 remain routed to Torch

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33246552972](https://github.com/sgl-project/sglang/actions/runs/33246552972)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33246552800](https://github.com/sgl-project/sglang/actions/runs/33246552800)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33246552868](https://github.com/sgl-project/sglang/actions/runs/33246552868)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->