### PR TITLE
[VLM] Return LLaVA media errors to the requester

### DIFF
--- a/python/sglang/srt/multimodal/processors/llava.py
+++ b/python/sglang/srt/multimodal/processors/llava.py
@@ -28,7 +28,13 @@ from sglang.srt.multimodal.mm_utils import (
     process_anyres_image,
 )
 from sglang.srt.multimodal.processors.base_processor import BaseMultimodalProcessor
-from sglang.srt.utils import ImageData, get_image_bytes, load_image, logger
+from sglang.srt.utils import (
+    CLIENT_MEDIA_EXCEPTIONS,
+    ImageData,
+    get_image_bytes,
+    load_image,
+    logger,
+)
 from sglang.utils import get_exception_traceback
 
 
@@ -93,6 +99,8 @@ class LlavaImageProcessor(BaseMultimodalProcessor):
                     pixel_values = pixel_values.astype(np.float16)
 
                 return pixel_values, image_hash, image.size
+        except CLIENT_MEDIA_EXCEPTIONS as error:
+            raise ValueError(f"Error while processing image: {error}") from error
         except Exception:
             logger.error("Exception in TokenizerManager:\n" + get_exception_traceback())
             raise

--- a/python/sglang/srt/multimodal/processors/llava.py
+++ b/python/sglang/srt/multimodal/processors/llava.py
@@ -95,6 +95,7 @@ class LlavaImageProcessor(BaseMultimodalProcessor):
                 return pixel_values, image_hash, image.size
         except Exception:
             logger.error("Exception in TokenizerManager:\n" + get_exception_traceback())
+            raise
 
     async def _fetch_remote_image_bytes(self, url):
         # Fetch a remote image's compressed bytes in the io thread pool, retrying

--- a/test/registered/unit/models/test_llava.py
+++ b/test/registered/unit/models/test_llava.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest.mock import patch
 
+from PIL import UnidentifiedImageError
+
 from sglang.srt.models.llava import AutoModel, LlavaForConditionalGeneration
 from sglang.srt.multimodal.processors.llava import LlavaImageProcessor
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -90,18 +92,20 @@ class TestLlavaForConditionalGeneration(CustomTestCase):
 
 class TestLlavaImageProcessor(CustomTestCase):
     @patch("sglang.srt.multimodal.processors.llava.load_image")
-    def test_preprocess_preserves_media_error(self, mock_load_image):
-        media_error = ValueError("invalid image payload")
+    def test_preprocess_reports_invalid_media_as_client_error(self, mock_load_image):
+        media_error = UnidentifiedImageError("invalid image payload")
         mock_load_image.side_effect = media_error
 
-        with self.assertRaises(ValueError) as raised:
+        with self.assertRaisesRegex(
+            ValueError, "Error while processing image: invalid image payload"
+        ) as raised:
             LlavaImageProcessor._preprocess_image_task(
                 b"invalid",
                 image_hash=1,
                 processor=unittest.mock.Mock(),
             )
 
-        self.assertIs(raised.exception, media_error)
+        self.assertIs(raised.exception.__cause__, media_error)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_llava.py
+++ b/test/registered/unit/models/test_llava.py
@@ -2,6 +2,7 @@ import unittest
 from unittest.mock import patch
 
 from sglang.srt.models.llava import AutoModel, LlavaForConditionalGeneration
+from sglang.srt.multimodal.processors.llava import LlavaImageProcessor
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -85,6 +86,22 @@ class TestLlavaForConditionalGeneration(CustomTestCase):
     def test_other_voxtral_mapping_failures_still_raise(self):
         with self.assertRaisesRegex(ValueError, "some other failure"):
             self._build_mapping(FakeMapping(ValueError("some other failure")))
+
+
+class TestLlavaImageProcessor(CustomTestCase):
+    @patch("sglang.srt.multimodal.processors.llava.load_image")
+    def test_preprocess_preserves_media_error(self, mock_load_image):
+        media_error = ValueError("invalid image payload")
+        mock_load_image.side_effect = media_error
+
+        with self.assertRaises(ValueError) as raised:
+            LlavaImageProcessor._preprocess_image_task(
+                b"invalid",
+                image_hash=1,
+                processor=unittest.mock.Mock(),
+            )
+
+        self.assertIs(raised.exception, media_error)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- propagate LLaVA decode and image preprocessing failures instead of returning an empty worker result
- classify corrupt client-provided images as bad requests
- preserve unexpected processor failures as internal errors

## Why

The LLaVA preprocessing worker logged media failures and implicitly returned `None`, hiding the original error behind a later unpacking failure. Corrupt client media was also reported as an internal server error.

## Coverage

- corrupt image decode error classification
- original media exception retained as the error cause

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33246681325](https://github.com/sgl-project/sglang/actions/runs/33246681325)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33246687635](https://github.com/sgl-project/sglang/actions/runs/33246687635)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33246681307](https://github.com/sgl-project/sglang/actions/runs/33246681307)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->