### PR TITLE
[VLM][EPD] Isolate invalid requests from encoder batches

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -222,6 +222,16 @@ class EncoderScheduler:
             return f"hashes must be list/scalar, got {type(h).__name__}"
         return None
 
+    @staticmethod
+    def _batch_failed_with_client_error(results: List[Tuple]) -> bool:
+        return bool(results) and all(
+            result[4] is not None
+            and HTTPStatus.BAD_REQUEST
+            <= int(result[4])
+            < HTTPStatus.INTERNAL_SERVER_ERROR
+            for result in results
+        )
+
     async def _dispatch_group(
         self, group: List[PendingRequest], modality: Modality
     ) -> None:
@@ -307,6 +317,18 @@ class EncoderScheduler:
             for p in group:
                 if not p.future.done():
                     p.future.set_exception(err)
+            return
+
+        if len(group) > 1 and self._batch_failed_with_client_error(results):
+            # The fused processor reports one error for the entire batch, so
+            # retry separately to keep one invalid media input from failing
+            # otherwise valid requests that happened to be coalesced with it.
+            logger.warning(
+                "Encoder batch hit a client error; retrying %d requests "
+                "individually",
+                len(group),
+            )
+            await self._dispatch_per_request(group, modality)
             return
 
         for p, result in zip(group, results):

--- a/test/registered/unit/disaggregation/test_encoder_scheduler.py
+++ b/test/registered/unit/disaggregation/test_encoder_scheduler.py
@@ -8,6 +8,7 @@ from sglang.srt.disaggregation.encoder.runtime import (
     PendingRequest,
     _resolve_encoder_batch_policy,
 )
+from sglang.srt.managers.schedule_batch import Modality
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -16,6 +17,19 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 def _pending(modality: str = "image") -> PendingRequest:
     return PendingRequest(
         {"req_id": f"{modality}-request", "modality": modality},
+        asyncio.get_running_loop(),
+    )
+
+
+def _encoder_pending(req_id: str) -> PendingRequest:
+    return PendingRequest(
+        {
+            "req_id": req_id,
+            "modality": "image",
+            "mm_items": [object()],
+            "num_parts": 1,
+            "part_idx": 0,
+        },
         asyncio.get_running_loop(),
     )
 
@@ -104,6 +118,76 @@ def test_scheduler_coalesces_concurrent_submissions():
 
         assert encoder.batches == [["image-0", "image-1"]]
         assert results == [(1, 2, 3, None, None)] * 2
+
+    asyncio.run(run_test())
+
+
+def test_scheduler_isolates_client_error_from_encoder_batch():
+    success = (1, 2, 3, None, None)
+    bad_request = (0, 0, 0, "invalid media", 400)
+
+    class FakeEncoder:
+        def __init__(self):
+            self.encode_dispatch_lock = asyncio.Lock()
+            self.batches = []
+            self.individual_requests = []
+
+        async def batch_encode(self, requests, _modality):
+            self.batches.append([request["req_id"] for request in requests])
+            return [bad_request] * len(requests)
+
+        async def encode(self, *, req_id, **_kwargs):
+            self.individual_requests.append(req_id)
+            return bad_request if req_id == "bad" else success
+
+    async def run_test():
+        encoder = FakeEncoder()
+        scheduler = EncoderScheduler(
+            encoder=encoder,
+            send_sockets=[],
+            max_batch_size=2,
+        )
+        group = [_encoder_pending(req_id) for req_id in ("bad", "good")]
+
+        await scheduler._dispatch_group(group, Modality.IMAGE)
+
+        assert encoder.batches == [["bad", "good"]]
+        assert encoder.individual_requests == ["bad", "good"]
+        assert [pending.future.result() for pending in group] == [
+            bad_request,
+            success,
+        ]
+
+    asyncio.run(run_test())
+
+
+def test_scheduler_does_not_retry_internal_batch_error():
+    internal_error = (0, 0, 0, "encoder failure", 500)
+
+    class FakeEncoder:
+        def __init__(self):
+            self.encode_dispatch_lock = asyncio.Lock()
+
+        async def batch_encode(self, requests, _modality):
+            return [internal_error] * len(requests)
+
+        async def encode(self, **_kwargs):
+            raise AssertionError("internal failures must not be retried")
+
+    async def run_test():
+        scheduler = EncoderScheduler(
+            encoder=FakeEncoder(),
+            send_sockets=[],
+            max_batch_size=2,
+        )
+        group = [_encoder_pending(f"request-{index}") for index in range(2)]
+
+        await scheduler._dispatch_group(group, Modality.IMAGE)
+
+        assert [pending.future.result() for pending in group] == [
+            internal_error,
+            internal_error,
+        ]
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary

- detect client-input failures reported for an entire fused encoder batch
- retry only those failed multi-request batches through the existing per-request TP path
- keep 5xx encoder failures fail-fast without automatic replay

## Why

A single malformed media request could make the fused processor reject every otherwise valid request coalesced into the same encoder batch. The retry isolates request-scoped 4xx failures without masking systemic encoder failures.

## Coverage

- mixed invalid and valid image requests in one encoder batch
- internal encoder errors are not retried
- existing encoder scheduler and Kimi-K3 encoder-mode coverage

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33247004246](https://github.com/sgl-project/sglang/actions/runs/33247004246)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33247008200](https://github.com/sgl-project/sglang/actions/runs/33247008200)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33247004240](https://github.com/sgl-project/sglang/actions/runs/33247004240)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->