### PR TITLE
[VLM] Recover LLaVA preprocessing after worker failure

### DIFF
--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -501,8 +501,25 @@ class BaseMultimodalProcessor(ABC):
             if self.cpu_executor is not failed_executor:
                 return
             self.cpu_executor = self._create_cpu_executor()
-        failed_executor.shutdown(wait=False, cancel_futures=True)
         logger.warning("Replaced a broken multimodal CPU preprocess pool")
+        threading.Thread(
+            target=self._shutdown_broken_cpu_executor,
+            args=(failed_executor,),
+            name="sglang-mm-cpu-pool-cleanup",
+            daemon=True,
+        ).start()
+
+    @staticmethod
+    def _shutdown_broken_cpu_executor(
+        failed_executor: concurrent.futures.ProcessPoolExecutor,
+    ) -> None:
+        try:
+            failed_executor.shutdown(wait=False, cancel_futures=True)
+        except Exception:
+            logger.warning(
+                "Failed to shut down a broken multimodal CPU preprocess pool",
+                exc_info=True,
+            )
 
     def compute_mrope_positions(self, input_ids, mm_items):
         """Compute M-RoPE positions from expanded input_ids and multimodal items.

--- a/python/sglang/srt/multimodal/processors/base_processor.py
+++ b/python/sglang/srt/multimodal/processors/base_processor.py
@@ -5,6 +5,7 @@ import dataclasses
 import multiprocessing as mp
 import os
 import re
+import threading
 from abc import ABC, abstractmethod
 from contextlib import contextmanager
 from typing import (
@@ -364,13 +365,8 @@ class BaseMultimodalProcessor(ABC):
                 self.mm_processor_worker_num,
                 "auto" if requested_mm_processor_worker_num == 0 else "explicit",
             )
-        cpu_worker_start_method = (
-            "spawn" if self.mm_feature_transport == "cuda_vmm" else "fork"
-        )
-        self.cpu_executor = concurrent.futures.ProcessPoolExecutor(
-            mp_context=mp.get_context(cpu_worker_start_method),
-            max_workers=int(os.environ.get("SGLANG_CPU_WORKERS", os.cpu_count())),
-        )
+        self._cpu_executor_lock = threading.Lock()
+        self.cpu_executor = self._create_cpu_executor()
 
         # Mapping from attribute names to modality types
         self.ATTR_NAME_TO_MODALITY = {
@@ -489,6 +485,24 @@ class BaseMultimodalProcessor(ABC):
         self.cpu_executor.shutdown(wait=False, cancel_futures=True)
         if self.mm_processor_executor is not None:
             self.mm_processor_executor.shutdown()
+
+    def _create_cpu_executor(self) -> concurrent.futures.ProcessPoolExecutor:
+        start_method = "spawn" if self.mm_feature_transport == "cuda_vmm" else "fork"
+        return concurrent.futures.ProcessPoolExecutor(
+            mp_context=mp.get_context(start_method),
+            max_workers=int(os.environ.get("SGLANG_CPU_WORKERS", os.cpu_count())),
+        )
+
+    def _replace_broken_cpu_executor(
+        self, failed_executor: concurrent.futures.ProcessPoolExecutor
+    ) -> None:
+        """Replace a failed preprocess pool once across concurrent requests."""
+        with self._cpu_executor_lock:
+            if self.cpu_executor is not failed_executor:
+                return
+            self.cpu_executor = self._create_cpu_executor()
+        failed_executor.shutdown(wait=False, cancel_futures=True)
+        logger.warning("Replaced a broken multimodal CPU preprocess pool")
 
     def compute_mrope_positions(self, input_ids, mm_items):
         """Compute M-RoPE positions from expanded input_ids and multimodal items.

--- a/python/sglang/srt/multimodal/processors/llava.py
+++ b/python/sglang/srt/multimodal/processors/llava.py
@@ -139,19 +139,29 @@ class LlavaImageProcessor(BaseMultimodalProcessor):
         if self.cpu_executor is not None:
             loop = asyncio.get_running_loop()
             executor = self.cpu_executor
+            timeout = int(os.environ.get("REQUEST_TIMEOUT", "10"))
+            deadline = loop.time() + timeout
             try:
-                fut = loop.run_in_executor(
-                    executor,
-                    LlavaImageProcessor._preprocess_image_task,
-                    image_input,
-                    image_hash,
-                    aspect_ratio,
-                    grid_pinpoints,
-                    self._processor,
+                # ProcessPoolExecutor.submit() can itself block after a worker
+                # exits. Keep submission off the request event loop so the
+                # timeout can still replace the failed pool.
+                process_future = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        executor.submit,
+                        LlavaImageProcessor._preprocess_image_task,
+                        image_input,
+                        image_hash,
+                        aspect_ratio,
+                        grid_pinpoints,
+                        self._processor,
+                    ),
+                    timeout=timeout,
                 )
-                timeout = int(os.environ.get("REQUEST_TIMEOUT", "10"))
-                return await asyncio.wait_for(fut, timeout=timeout)
-            except BrokenProcessPool:
+                remaining = max(0.0, deadline - loop.time())
+                return await asyncio.wait_for(
+                    asyncio.wrap_future(process_future), timeout=remaining
+                )
+            except (BrokenProcessPool, asyncio.TimeoutError):
                 self._replace_broken_cpu_executor(executor)
                 raise
         else:

--- a/python/sglang/srt/multimodal/processors/llava.py
+++ b/python/sglang/srt/multimodal/processors/llava.py
@@ -1,5 +1,6 @@
 import asyncio
 import os
+from concurrent.futures.process import BrokenProcessPool
 from typing import Dict, List, Optional, Union
 
 import numpy as np
@@ -137,17 +138,22 @@ class LlavaImageProcessor(BaseMultimodalProcessor):
 
         if self.cpu_executor is not None:
             loop = asyncio.get_running_loop()
-            fut = loop.run_in_executor(
-                self.cpu_executor,
-                LlavaImageProcessor._preprocess_image_task,
-                image_input,
-                image_hash,
-                aspect_ratio,
-                grid_pinpoints,
-                self._processor,
-            )
-            timeout = int(os.environ.get("REQUEST_TIMEOUT", "10"))
-            return await asyncio.wait_for(fut, timeout=timeout)
+            executor = self.cpu_executor
+            try:
+                fut = loop.run_in_executor(
+                    executor,
+                    LlavaImageProcessor._preprocess_image_task,
+                    image_input,
+                    image_hash,
+                    aspect_ratio,
+                    grid_pinpoints,
+                    self._processor,
+                )
+                timeout = int(os.environ.get("REQUEST_TIMEOUT", "10"))
+                return await asyncio.wait_for(fut, timeout=timeout)
+            except BrokenProcessPool:
+                self._replace_broken_cpu_executor(executor)
+                raise
         else:
             return LlavaImageProcessor._preprocess_image_task(
                 image_input,

--- a/test/registered/unit/models/test_llava_processor_pool.py
+++ b/test/registered/unit/models/test_llava_processor_pool.py
@@ -18,6 +18,15 @@ class _BrokenExecutor(concurrent.futures.Executor):
         raise BrokenProcessPool("worker exited")
 
 
+class _BlockingExecutor(concurrent.futures.Executor):
+    def __init__(self):
+        self.release = threading.Event()
+
+    def submit(self, _fn, /, *_args, **_kwargs):
+        self.release.wait(timeout=5)
+        return concurrent.futures.Future()
+
+
 def _exit_worker_process():
     os._exit(1)
 
@@ -31,6 +40,35 @@ def test_llava_replaces_broken_pool_without_replaying_request():
     with pytest.raises(BrokenProcessPool, match="worker exited"):
         asyncio.run(processor._process_single_image(b"image", "pad", None))
 
+    processor._replace_broken_cpu_executor.assert_called_once_with(
+        processor.cpu_executor
+    )
+
+
+def test_llava_times_out_blocked_pool_submission_without_freezing_loop(monkeypatch):
+    monkeypatch.setenv("REQUEST_TIMEOUT", "1")
+    processor = object.__new__(LlavaImageProcessor)
+    processor.cpu_executor = _BlockingExecutor()
+    processor._processor = Mock()
+    processor._replace_broken_cpu_executor = Mock()
+
+    async def run_test():
+        heartbeat = asyncio.Event()
+
+        async def keep_loop_responsive():
+            await asyncio.sleep(0.01)
+            heartbeat.set()
+
+        heartbeat_task = asyncio.create_task(keep_loop_responsive())
+        try:
+            with pytest.raises(asyncio.TimeoutError):
+                await processor._process_single_image(b"image", "pad", None)
+            assert heartbeat.is_set()
+        finally:
+            processor.cpu_executor.release.set()
+            await heartbeat_task
+
+    asyncio.run(run_test())
     processor._replace_broken_cpu_executor.assert_called_once_with(
         processor.cpu_executor
     )

--- a/test/registered/unit/models/test_llava_processor_pool.py
+++ b/test/registered/unit/models/test_llava_processor_pool.py
@@ -1,5 +1,6 @@
 import asyncio
 import concurrent.futures
+import os
 import threading
 from concurrent.futures.process import BrokenProcessPool
 from unittest.mock import Mock
@@ -15,6 +16,10 @@ register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 class _BrokenExecutor(concurrent.futures.Executor):
     def submit(self, _fn, /, *_args, **_kwargs):
         raise BrokenProcessPool("worker exited")
+
+
+def _exit_worker_process():
+    os._exit(1)
 
 
 def test_llava_replaces_broken_pool_without_replaying_request():
@@ -45,6 +50,23 @@ def test_broken_pool_is_replaced_once_for_concurrent_failures():
     assert processor.cpu_executor is replacement_executor
     processor._create_cpu_executor.assert_called_once_with()
     failed_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+
+
+def test_replacement_pool_runs_after_real_worker_exit(monkeypatch):
+    monkeypatch.setenv("SGLANG_CPU_WORKERS", "1")
+    processor = object.__new__(LlavaImageProcessor)
+    processor.mm_feature_transport = "cpu"
+    processor._cpu_executor_lock = threading.Lock()
+    failed_executor = processor._create_cpu_executor()
+    processor.cpu_executor = failed_executor
+
+    try:
+        with pytest.raises(BrokenProcessPool):
+            failed_executor.submit(_exit_worker_process).result(timeout=5)
+        processor._replace_broken_cpu_executor(failed_executor)
+        assert processor.cpu_executor.submit(abs, -1).result(timeout=5) == 1
+    finally:
+        processor.cpu_executor.shutdown(wait=True, cancel_futures=True)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/models/test_llava_processor_pool.py
+++ b/test/registered/unit/models/test_llava_processor_pool.py
@@ -1,0 +1,51 @@
+import asyncio
+import concurrent.futures
+import threading
+from concurrent.futures.process import BrokenProcessPool
+from unittest.mock import Mock
+
+import pytest
+
+from sglang.srt.multimodal.processors.llava import LlavaImageProcessor
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class _BrokenExecutor(concurrent.futures.Executor):
+    def submit(self, _fn, /, *_args, **_kwargs):
+        raise BrokenProcessPool("worker exited")
+
+
+def test_llava_replaces_broken_pool_without_replaying_request():
+    processor = object.__new__(LlavaImageProcessor)
+    processor.cpu_executor = _BrokenExecutor()
+    processor._processor = Mock()
+    processor._replace_broken_cpu_executor = Mock()
+
+    with pytest.raises(BrokenProcessPool, match="worker exited"):
+        asyncio.run(processor._process_single_image(b"image", "pad", None))
+
+    processor._replace_broken_cpu_executor.assert_called_once_with(
+        processor.cpu_executor
+    )
+
+
+def test_broken_pool_is_replaced_once_for_concurrent_failures():
+    processor = object.__new__(LlavaImageProcessor)
+    failed_executor = Mock()
+    replacement_executor = Mock()
+    processor.cpu_executor = failed_executor
+    processor._cpu_executor_lock = threading.Lock()
+    processor._create_cpu_executor = Mock(return_value=replacement_executor)
+
+    processor._replace_broken_cpu_executor(failed_executor)
+    processor._replace_broken_cpu_executor(failed_executor)
+
+    assert processor.cpu_executor is replacement_executor
+    processor._create_cpu_executor.assert_called_once_with()
+    failed_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/models/test_llava_processor_pool.py
+++ b/test/registered/unit/models/test_llava_processor_pool.py
@@ -43,12 +43,15 @@ def test_broken_pool_is_replaced_once_for_concurrent_failures():
     processor.cpu_executor = failed_executor
     processor._cpu_executor_lock = threading.Lock()
     processor._create_cpu_executor = Mock(return_value=replacement_executor)
+    shutdown_called = threading.Event()
+    failed_executor.shutdown.side_effect = lambda **_kwargs: shutdown_called.set()
 
     processor._replace_broken_cpu_executor(failed_executor)
     processor._replace_broken_cpu_executor(failed_executor)
 
     assert processor.cpu_executor is replacement_executor
     processor._create_cpu_executor.assert_called_once_with()
+    assert shutdown_called.wait(timeout=5)
     failed_executor.shutdown.assert_called_once_with(wait=False, cancel_futures=True)
 
 


### PR DESCRIPTION
## Summary

- Move LLaVA process-pool submission off the request event loop and bound submission plus execution with the existing request timeout.
- Atomically replace a broken or timed-out multimodal preprocess pool without replaying the current request.
- Clean up the old pool in a daemon thread so pool shutdown cannot stall request handling.

## Why

A preprocessing worker exit can leave `ProcessPoolExecutor.submit()` blocked, freezing LLaVA image requests and requiring a service restart. The failed request should remain isolated while later requests recover on a fresh pool.

## Coverage

- Broken-pool propagation without request replay.
- Event-loop responsiveness while pool submission is blocked.
- One-time replacement under concurrent failures.
- Real child-process exit followed by successful work on the replacement pool.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33248077146](https://github.com/sgl-project/sglang/actions/runs/33248077146)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33248081729](https://github.com/sgl-project/sglang/actions/runs/33248081729)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33248077142](https://github.com/sgl-project/sglang/actions/runs/33248077142)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->