### PR TITLE
[VLM][EPD] Roll back failed fused embedding staging

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/server.py
+++ b/python/sglang/srt/disaggregation/encoder/server.py
@@ -350,15 +350,8 @@ class MooncakeDelivery(EncoderDelivery):
 
     async def release(self, state: ReqState) -> None:
         mm_data = state.embedding_data
-        if mm_data is not None and mm_data._mr_ptr is not None:
-            try:
-                self.encoder.engine.deregister(mm_data._mr_ptr)
-            except Exception as dereg_err:
-                logger.warning(
-                    f"Shared-MR deregister failed for {state.req_id}: {dereg_err}"
-                )
-            finally:
-                mm_data._mr_ptr = None
+        if mm_data is not None:
+            self.encoder._deregister_shared_mr(mm_data)
 
 
 class ZmqDelivery(EncoderDelivery):
@@ -646,7 +639,7 @@ class MMEncoder:
         if should_release:
             await self.release_request(state.req_id)
 
-    def _stage_embedding(self, mm_data: EmbeddingData) -> None:
+    def _embedding_state_for_stage(self, mm_data: EmbeddingData) -> ReqState:
         state = self._require_active_encode_state(mm_data.req_id)
         metadata = state.embedding_data
         if (
@@ -660,8 +653,20 @@ class MMEncoder:
                 f"expected={metadata.shape}/{metadata.dtype}, "
                 f"actual={mm_data.shape}/{mm_data.dtype}"
             )
+        return state
+
+    def _stage_embedding(self, mm_data: EmbeddingData) -> None:
+        state = self._embedding_state_for_stage(mm_data)
         state.embedding_data = mm_data
         state.embedding_ready.set()
+
+    def _stage_embedding_batch(self, embeddings: List[EmbeddingData]) -> None:
+        """Validate the whole fused batch before publishing any result."""
+        states = [self._embedding_state_for_stage(mm_data) for mm_data in embeddings]
+        for state, mm_data in zip(states, embeddings):
+            state.embedding_data = mm_data
+        for state in states:
+            state.embedding_ready.set()
 
     async def _wait_for_embedding(self, state: ReqState) -> EmbeddingData:
         await state.embedding_ready.wait()
@@ -1694,6 +1699,18 @@ class MMEncoder:
                 f"falling back to per-/send register: {reg_err}"
             )
 
+    def _deregister_shared_mr(self, mm_data: EmbeddingData) -> None:
+        if mm_data._mr_ptr is None:
+            return
+        try:
+            self.engine.deregister(mm_data._mr_ptr)
+        except Exception as dereg_err:
+            logger.warning(
+                f"Shared-MR deregister failed for {mm_data.req_id}: {dereg_err}"
+            )
+        finally:
+            mm_data._mr_ptr = None
+
     def _stage_embeddings(
         self,
         ctx: EncodeContext,
@@ -1714,46 +1731,58 @@ class MMEncoder:
 
         results = []
         staged_embeddings = []
-        item_offset = 0
-        token_offset = 0
-        for req, num_items in zip(requests, ctx.items_per_req):
-            item_end = item_offset + num_items
-            num_tokens = sum(ctx.preprocess_result.token_counts[item_offset:item_end])
-            embedding = mm_embedding[token_offset : token_offset + num_tokens]
-            if keep_on_gpu and len(requests) > 1:
-                # A view would pin the whole batch tensor until the last transfer.
-                embedding = embedding.clone()
-            req_aux_data = dict(ctx.aux_data)
-            if ctx.aux_data.get("original_image_sizes") is not None:
-                req_aux_data["original_image_sizes"] = ctx.aux_data[
-                    "original_image_sizes"
-                ][item_offset:item_end]
-            mm_data = EmbeddingData(
-                req["req_id"],
-                req["num_parts"],
-                req["part_idx"],
-                ctx.preprocess_result.grid_thw[item_offset:item_end],
-                ctx.modality,
-                embedding,
-                **req_aux_data,
-            )
-            # Global-cache embeddings keep registering per /send instead.
-            if keep_on_gpu and not ctx.use_global_cache:
-                self._register_shared_mr(mm_data, embedding)
-            staged_embeddings.append(mm_data)
-            results.append(
-                (embedding.nbytes, embedding.shape[0], embedding.shape[1], None, None)
-            )
-            item_offset = item_end
-            token_offset += num_tokens
+        try:
+            item_offset = 0
+            token_offset = 0
+            for req, num_items in zip(requests, ctx.items_per_req):
+                item_end = item_offset + num_items
+                num_tokens = sum(
+                    ctx.preprocess_result.token_counts[item_offset:item_end]
+                )
+                embedding = mm_embedding[token_offset : token_offset + num_tokens]
+                if keep_on_gpu and len(requests) > 1:
+                    # A view would pin the whole batch tensor until the last transfer.
+                    embedding = embedding.clone()
+                req_aux_data = dict(ctx.aux_data)
+                if ctx.aux_data.get("original_image_sizes") is not None:
+                    req_aux_data["original_image_sizes"] = ctx.aux_data[
+                        "original_image_sizes"
+                    ][item_offset:item_end]
+                mm_data = EmbeddingData(
+                    req["req_id"],
+                    req["num_parts"],
+                    req["part_idx"],
+                    ctx.preprocess_result.grid_thw[item_offset:item_end],
+                    ctx.modality,
+                    embedding,
+                    **req_aux_data,
+                )
+                # Global-cache embeddings keep registering per /send instead.
+                if keep_on_gpu and not ctx.use_global_cache:
+                    self._register_shared_mr(mm_data, embedding)
+                staged_embeddings.append(mm_data)
+                results.append(
+                    (
+                        embedding.nbytes,
+                        embedding.shape[0],
+                        embedding.shape[1],
+                        None,
+                        None,
+                    )
+                )
+                item_offset = item_end
+                token_offset += num_tokens
 
-        # transfer_sync bypasses CUDA streams, so GPU writes (forward and the
-        # per-request clones) must land before /send reads the buffers.
-        if keep_on_gpu and mm_embedding.is_cuda:
-            torch.cuda.current_stream(mm_embedding.device).synchronize()
-        for mm_data in staged_embeddings:
-            self._stage_embedding(mm_data)
-        return results
+            # transfer_sync bypasses CUDA streams, so GPU writes (forward and the
+            # per-request clones) must land before /send reads the buffers.
+            if keep_on_gpu and mm_embedding.is_cuda:
+                torch.cuda.current_stream(mm_embedding.device).synchronize()
+            self._stage_embedding_batch(staged_embeddings)
+            return results
+        except BaseException:
+            for mm_data in staged_embeddings:
+                self._deregister_shared_mr(mm_data)
+            raise
 
     def _stage_errors(
         self, requests: List[dict], modality: Modality, exc: Exception

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -228,7 +228,9 @@ class TestEncoderDelivery(CustomTestCase):
         encoder = MMEncoder.__new__(MMEncoder)
         encoder.rank = 0
         events = []
-        encoder._stage_embedding = lambda mm_data: events.append("ready")
+        state = ReqState("req", active_encodes=1)
+        state.embedding_ready = SimpleNamespace(set=lambda: events.append("ready"))
+        encoder.req_states = {"req": state}
         ctx = SimpleNamespace(
             req_id="req",
             modality=Modality.IMAGE,

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -2,7 +2,7 @@ import asyncio
 import pickle
 import unittest
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import numpy as np
 import torch
@@ -251,6 +251,58 @@ class TestEncoderDelivery(CustomTestCase):
             )
 
         self.assertEqual(events, ["sync", "ready"])
+
+    def test_fused_staging_rolls_back_mrs_before_any_result_is_published(self):
+        encoder = MMEncoder.__new__(MMEncoder)
+        encoder.rank = 0
+        encoder.engine = Mock()
+        first_state = ReqState("req-0", active_encodes=1)
+        second_metadata = EmbeddingData(
+            "req-1",
+            1,
+            0,
+            [[1, 1, 1]],
+            Modality.IMAGE,
+            embedding_shape=[2, 4],
+            dtype=torch.float32,
+        )
+        second_state = ReqState(
+            "req-1", embedding_data=second_metadata, active_encodes=1
+        )
+        encoder.req_states = {"req-0": first_state, "req-1": second_state}
+        ctx = SimpleNamespace(
+            req_id="req-0",
+            modality=Modality.IMAGE,
+            items_per_req=[1, 1],
+            preprocess_result=SimpleNamespace(
+                token_counts=[1, 1],
+                grid_thw=[[1, 1, 1], [1, 1, 1]],
+            ),
+            aux_data={},
+            use_global_cache=False,
+        )
+        requests = [
+            {"req_id": "req-0", "num_parts": 1, "part_idx": 0},
+            {"req_id": "req-1", "num_parts": 1, "part_idx": 0},
+        ]
+
+        with self.assertRaisesRegex(InternalError, "Embedding metadata mismatch"):
+            encoder._stage_embeddings(
+                ctx, requests, torch.ones((2, 4)), keep_on_gpu=True
+            )
+
+        registered_ptrs = [
+            call.args[0] for call in encoder.engine.register.call_args_list
+        ]
+        deregistered_ptrs = [
+            call.args[0] for call in encoder.engine.deregister.call_args_list
+        ]
+        self.assertEqual(len(registered_ptrs), 2)
+        self.assertCountEqual(deregistered_ptrs, registered_ptrs)
+        self.assertIsNone(first_state.embedding_data)
+        self.assertIs(second_state.embedding_data, second_metadata)
+        self.assertFalse(first_state.embedding_ready.is_set())
+        self.assertFalse(second_state.embedding_ready.is_set())
 
     def test_stage_embedding_does_not_resurrect_missing_state(self):
         encoder = MMEncoder.__new__(MMEncoder)


### PR DESCRIPTION
## Summary

- Validate every request in a fused encoder batch before publishing any embedding.
- Roll back all shared Mooncake memory registrations if construction, CUDA synchronization, or batch publication fails.
- Reuse one idempotent shared-MR cleanup path for normal release and staging rollback.

## Why

Fused EPD staging registered each request incrementally. A later request failure could overwrite earlier staged data with an error while losing its registered GPU pointer, leaving a stale Mooncake registration and potentially exposing a partial batch to concurrent senders. Repeated request-local failures could accumulate process-wide transport state.

## Coverage

- Partial fused-batch failure after multiple MR registrations.
- No request visibility before whole-batch validation succeeds.
- Shared cleanup behavior for normal release and rollback.
- Existing encoder delivery, batching, and Kimi-K3 EPD paths.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33248611861](https://github.com/sgl-project/sglang/actions/runs/33248611861)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33248634121](https://github.com/sgl-project/sglang/actions/runs/33248634121)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33248611900](https://github.com/sgl-project/sglang/actions/runs/33248611900)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->