### PR TITLE
[VLM][EPD] Surface Mooncake memory registration failures

### DIFF
--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -142,25 +142,27 @@ class MooncakeTransferEngine:
             self.hostname, self.engine.get_rpc_port()
         ).to_host_port_str()
 
-    def register(self, ptr, length):
+    def register(self, ptr, length) -> None:
         try:
             ret_value = self.engine.register_memory(ptr, length)
-        except Exception:
-            # Mark register as failed
-            ret_value = -1
+        except Exception as exc:
+            raise RuntimeError(f"Mooncake memory registration failed: {ptr}") from exc
 
         if ret_value != 0:
-            logger.debug("Mooncake memory registration %s failed.", ptr)
+            raise RuntimeError(
+                f"Mooncake memory registration failed: {ptr} (ret={ret_value})"
+            )
 
-    def deregister(self, ptr):
+    def deregister(self, ptr) -> None:
         try:
             ret_value = self.engine.unregister_memory(ptr)
-        except Exception:
-            # Mark deregister as failed
-            ret_value = -1
+        except Exception as exc:
+            raise RuntimeError(f"Mooncake memory deregistration failed: {ptr}") from exc
 
         if ret_value != 0:
-            logger.debug("Mooncake memory deregistration %s failed.", ptr)
+            raise RuntimeError(
+                f"Mooncake memory deregistration failed: {ptr} (ret={ret_value})"
+            )
 
     def batch_register(self, ptrs: List[int], lengths: List[int]) -> int:
         """Batch register multiple memory regions."""

--- a/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
+++ b/python/sglang/srt/distributed/device_communicators/mooncake_transfer_engine.py
@@ -146,22 +146,20 @@ class MooncakeTransferEngine:
         try:
             ret_value = self.engine.register_memory(ptr, length)
         except Exception as exc:
-            raise RuntimeError(f"Mooncake memory registration failed: {ptr}") from exc
+            raise RuntimeError("Mooncake memory registration failed") from exc
 
         if ret_value != 0:
-            raise RuntimeError(
-                f"Mooncake memory registration failed: {ptr} (ret={ret_value})"
-            )
+            raise RuntimeError(f"Mooncake memory registration failed (ret={ret_value})")
 
     def deregister(self, ptr) -> None:
         try:
             ret_value = self.engine.unregister_memory(ptr)
         except Exception as exc:
-            raise RuntimeError(f"Mooncake memory deregistration failed: {ptr}") from exc
+            raise RuntimeError("Mooncake memory deregistration failed") from exc
 
         if ret_value != 0:
             raise RuntimeError(
-                f"Mooncake memory deregistration failed: {ptr} (ret={ret_value})"
+                f"Mooncake memory deregistration failed (ret={ret_value})"
             )
 
     def batch_register(self, ptrs: List[int], lengths: List[int]) -> int:

--- a/test/registered/unit/disaggregation/test_encode_server.py
+++ b/test/registered/unit/disaggregation/test_encode_server.py
@@ -23,6 +23,9 @@ from sglang.srt.disaggregation.encoder.server import (
     rid_to_receive_count,
     rid_to_receive_endpoint,
 )
+from sglang.srt.distributed.device_communicators.mooncake_transfer_engine import (
+    MooncakeTransferEngine,
+)
 from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.utils.common import safe_pickle_loads
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -251,6 +254,19 @@ class TestEncoderDelivery(CustomTestCase):
             )
 
         self.assertEqual(events, ["sync", "ready"])
+
+    def test_shared_mr_registration_failure_keeps_send_fallback_enabled(self):
+        encoder = MMEncoder.__new__(MMEncoder)
+        encoder.engine = unittest.mock.Mock()
+        encoder.engine.register.side_effect = RuntimeError("register failed")
+        embedding = torch.ones((2, 4))
+        mm_data = EmbeddingData(
+            "req", 1, 0, [[1, 1, 1]], Modality.IMAGE, embedding=embedding
+        )
+
+        encoder._register_shared_mr(mm_data, embedding)
+
+        self.assertIsNone(mm_data._mr_ptr)
 
     def test_stage_embedding_does_not_resurrect_missing_state(self):
         encoder = MMEncoder.__new__(MMEncoder)
@@ -533,6 +549,27 @@ class TestEncoderDelivery(CustomTestCase):
             self.assertNotIn("req", encoder.req_states)
 
         asyncio.run(run())
+
+
+class TestMooncakeRegistration(CustomTestCase):
+    def setUp(self):
+        self.engine = MooncakeTransferEngine.__new__(MooncakeTransferEngine)
+        self.engine.engine = unittest.mock.Mock()
+
+    def test_register_raises_on_nonzero_status(self):
+        self.engine.engine.register_memory.return_value = -1
+
+        with self.assertRaisesRegex(RuntimeError, "registration failed.*ret=-1"):
+            self.engine.register(1234, 4096)
+
+    def test_deregister_preserves_backend_failure(self):
+        backend_error = OSError("backend failed")
+        self.engine.engine.unregister_memory.side_effect = backend_error
+
+        with self.assertRaisesRegex(RuntimeError, "deregistration failed") as ctx:
+            self.engine.deregister(1234)
+
+        self.assertIs(ctx.exception.__cause__, backend_error)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- Raise when Mooncake single-region registration or deregistration reports a backend failure.
- Let encoder shared-MR setup retain its existing per-send fallback instead of recording an unregistered pointer as shared.
- Propagate receiver-side registration failures into the existing request-local cleanup path.

## Why

The Mooncake wrapper previously swallowed exceptions and nonzero statuses. VLM EPD then marked failed registrations as successful, skipped its fallback, and attempted GPU-direct transfer through an invalid memory region. Deregistration failures were also reported as success, hiding leaked transport state.

## Coverage

- Nonzero registration status.
- Backend deregistration exception and preserved cause.
- Encoder shared-registration fallback selection.
- Existing encoder delivery and Kimi-K3 EPD paths.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33248937682](https://github.com/sgl-project/sglang/actions/runs/33248937682)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33248945737](https://github.com/sgl-project/sglang/actions/runs/33248945737)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33248937672](https://github.com/sgl-project/sglang/actions/runs/33248937672)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->