### PR TITLE
[VLM][EPD] Reject stale encoder messages before handling

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -732,6 +732,34 @@ def extract_original_req_id(part_req_id: str) -> str:
     return part_req_id
 
 
+def _embedding_part_matches_request(
+    embedding_data: object, expected_req_id: str
+) -> bool:
+    """Normalize a matching part ID; reject stale data from a reused socket."""
+    if not isinstance(embedding_data, EmbeddingData):
+        logger.warning(
+            "Dropping non-embedding data for expected rid=%s", expected_req_id
+        )
+        return False
+    if not isinstance(embedding_data.req_id, str):
+        logger.warning(
+            "Dropping embedding data with a non-string req_id for expected rid=%s",
+            expected_req_id,
+        )
+        return False
+    original_req_id = extract_original_req_id(embedding_data.req_id)
+    if original_req_id != expected_req_id:
+        logger.warning(
+            "Dropping stale embedding data: expected rid=%s, got rid=%s "
+            "(likely from ZMQ port reuse)",
+            expected_req_id,
+            embedding_data.req_id,
+        )
+        return False
+    embedding_data.req_id = original_req_id
+    return True
+
+
 def _encoder_media_item(mm_item: dict):
     """Keep per-media options aligned while preserving the legacy URL shape."""
     item = {
@@ -860,14 +888,14 @@ class WaitingMMRequestBase(ABC):
 
         try:
             recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
+            if not self._is_valid_embedding_part(recv_obj):
+                return
             if getattr(recv_obj, "error_msg", None) is not None:
                 logger.warning(
                     f"Received error signal from encoder for {self.rid}: "
                     f"{recv_obj.error_msg} {recv_obj.error_code = }"
                 )
                 self._fail_and_release(recv_obj.error_msg, recv_obj.error_code)
-                return
-            if not self._is_valid_embedding_part(recv_obj):
                 return
             # ZMQ materializes frame 1; RDMA already wrote the registered buffer.
             self._extract_embedding_from_buffer(recv_obj, parts)
@@ -910,15 +938,7 @@ class WaitingMMRequestBase(ABC):
 
     def _is_valid_embedding_part(self, recv_obj) -> bool:
         """Check for and drop stale or out-of-sync payloads; normalize the part req_id to the original rid."""
-        original_req_id = extract_original_req_id(recv_obj.req_id)
-        if original_req_id != self.recv_req.rid:
-            logger.warning(
-                f"Dropping stale embedding data: expected rid={self.recv_req.rid}, "
-                f"got rid={recv_obj.req_id} (likely from ZMQ port reuse)"
-            )
-            return False
-        recv_obj.req_id = original_req_id
-        return True
+        return _embedding_part_matches_request(recv_obj, self.recv_req.rid)
 
     @abstractmethod
     def _extract_embedding_from_buffer(self, recv_obj, parts) -> None:
@@ -1967,6 +1987,8 @@ class MMReceiverBase(ABC):
                 if not parts:
                     continue
                 recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
+                if not _embedding_part_matches_request(recv_obj, req_id):
+                    continue
                 if getattr(recv_obj, "error_msg", None) is not None:
                     logger.warning(
                         f"Encoder error for req_id={req_id}: {recv_obj.error_msg} "
@@ -1974,8 +1996,6 @@ class MMReceiverBase(ABC):
                     )
                     return None
                 logger.debug("recv_obj=%s", recv_obj)
-                # Normalize the part req_id to the original for aggregation.
-                recv_obj.req_id = extract_original_req_id(recv_obj.req_id)
                 if len(parts) < 2:
                     logger.error(
                         "zmq_to_tokenizer expected 2-part message, got %d parts",

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -6,7 +6,7 @@ import time
 from array import array
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import torch
@@ -24,6 +24,8 @@ from sglang.srt.disaggregation.encoder.receiver import (
     EmbeddingData,
     MMReceiverHTTP,
     MultiModalEmbeddingData,
+    WaitingMMRequestStatus,
+    WaitingZmqRequest,
     _encoder_media_item,
     _select_mm_processor_prompt,
 )
@@ -732,6 +734,80 @@ def test_epd_scheduler_uses_token_ids_for_tokenized_mm_processors():
         )
         == "unexpanded prompt"
     )
+
+
+def test_epd_scheduler_ignores_foreign_error_part():
+    waiting = WaitingZmqRequest.__new__(WaitingZmqRequest)
+    waiting.rid = "current"
+    waiting.recv_req = SimpleNamespace(rid="current")
+    waiting.status = WaitingMMRequestStatus.PENDING
+    waiting._fail_and_release = Mock()
+    stale_error = EmbeddingData(
+        req_id="stale_local_part_0",
+        num_parts=1,
+        part_idx=0,
+        grid_dim=None,
+        modality=Modality.IMAGE,
+        error_msg="stale failure",
+        error_code=500,
+    )
+
+    waiting.consume_parts([pickle.dumps("not embedding data")])
+    waiting.consume_parts([pickle.dumps(stale_error)])
+
+    assert waiting.status == WaitingMMRequestStatus.PENDING
+    waiting._fail_and_release.assert_not_called()
+
+
+def test_epd_tokenizer_ignores_foreign_part_before_current_embedding():
+    class FakeSocket:
+        def __init__(self, messages):
+            self.messages = list(messages)
+            self.closed = False
+
+        async def recv_multipart(self, copy=False):
+            return self.messages.pop(0)
+
+        def close(self):
+            self.closed = True
+
+    async def run_test():
+        stale_error = EmbeddingData(
+            req_id="stale_local_part_0",
+            num_parts=1,
+            part_idx=0,
+            grid_dim=None,
+            modality=Modality.IMAGE,
+            error_msg="stale failure",
+            error_code=500,
+        )
+        embedding = torch.tensor([[1.0, 2.0]])
+        current = EmbeddingData(
+            req_id="current_local_part_0",
+            num_parts=1,
+            part_idx=0,
+            grid_dim=None,
+            modality=Modality.IMAGE,
+            embedding=embedding,
+        )
+        socket = FakeSocket(
+            [
+                [pickle.dumps(stale_error)],
+                [pickle.dumps(current.copy_without_embedding()), embedding.numpy()],
+            ]
+        )
+        receiver = MMReceiverHTTP.__new__(MMReceiverHTTP)
+        receiver.model_type = None
+        processor = SimpleNamespace(
+            get_mm_data=lambda _prompt, embeddings, **_kwargs: embeddings
+        )
+
+        result = await receiver._recv_mm_data("current", socket, processor, "prompt")
+
+        torch.testing.assert_close(result[Modality.IMAGE], embedding)
+        assert socket.closed
+
+    asyncio.run(run_test())
 
 
 def test_epd_scheduler_routes_many_requests_over_one_receive_socket():


### PR DESCRIPTION
## Summary

- Validate and normalize encoder part request IDs at one shared receive boundary.
- Apply the same stale-message rejection to scheduler and tokenizer EPD transports.
- Reject foreign error envelopes before they can fail the current request.

## Why

The Kimi-K3 TP8 auto profile uses `zmq_to_tokenizer`. That receiver previously rewrote every incoming part to the current request ID without checking its original owner. A delayed message on a reused ZMQ port could therefore inject another request’s vision embedding or error into the current request. The scheduler path checked normal embeddings, but handled foreign error envelopes before that check.

## Coverage

- Foreign and non-embedding scheduler messages.
- Foreign error envelopes.
- Tokenizer receive with a stale part followed by the current embedding.
- Existing Kimi-K3 EPD routing and transport paths.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33249170209](https://github.com/sgl-project/sglang/actions/runs/33249170209)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33249175376](https://github.com/sgl-project/sglang/actions/runs/33249175376)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33249170345](https://github.com/sgl-project/sglang/actions/runs/33249170345)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->