### PR TITLE
[VLM][EPD] Validate video requests before TP dispatch

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -91,6 +91,22 @@ def _resolve_encoder_batch_policy(
     return max_batch_size, coalesce_same_turn
 
 
+def _validate_encode_request_shape(request: dict) -> Optional[str]:
+    """Validate fields required before an encoder request reaches TP workers."""
+    if not isinstance(request, dict):
+        return f"request is not a dict: {type(request).__name__}"
+    if not request.get("req_id"):
+        return "missing req_id"
+    if not request.get("mm_items"):
+        return "missing or empty mm_items"
+    if "num_parts" not in request or "part_idx" not in request:
+        return "missing num_parts / part_idx"
+    hashes = request.get("hashes")
+    if hashes is not None and not isinstance(hashes, (list, tuple, str, int, bytes)):
+        return f"hashes must be list/scalar, got {type(hashes).__name__}"
+    return None
+
+
 # Minimal 32x32 black PNG for health check dummy encode
 MINIMUM_PNG_PICTURE_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAACXBIWXMAAA7EAAAOxAGVKw4bAAAAbUlEQVRYhe3VsQ2AMAxE0Y/lIgNQULD/OqyCMgCihCKSG4yRuKuiNH6JLsoEbMACOGBcua9HOR7Y6w6swBwMy0qLTpkeI77qdEBpBFAHBBDAGH8WrwJKI4AAegUCfAKgEgpQDvh3CR3oQCuav58qlAw73kKCSgAAAABJRU5ErkJggg=="
 
@@ -203,25 +219,6 @@ class EncoderScheduler:
                     if not p.future.done():
                         p.future.set_exception(e)
 
-    @staticmethod
-    def _validate_request_shape(req: dict) -> Optional[str]:
-        # Cheap pre-broadcast checks: shape errors that don't require running
-        # the HF processor. Once a request reaches TP workers they enter
-        # batch_encode and expect to join its collectives — a malformed batch
-        # that makes rank-0 bail mid-flight would deadlock the workers.
-        if not isinstance(req, dict):
-            return f"request is not a dict: {type(req).__name__}"
-        if not req.get("req_id"):
-            return "missing req_id"
-        if not req.get("mm_items"):
-            return "missing or empty mm_items"
-        if "num_parts" not in req or "part_idx" not in req:
-            return "missing num_parts / part_idx"
-        h = req.get("hashes")
-        if h is not None and not isinstance(h, (list, tuple, str, int, bytes)):
-            return f"hashes must be list/scalar, got {type(h).__name__}"
-        return None
-
     async def _dispatch_group(
         self, group: List[PendingRequest], modality: Modality
     ) -> None:
@@ -241,7 +238,7 @@ class EncoderScheduler:
         # abandoned.
         valid: List[PendingRequest] = []
         for p in group:
-            err = self._validate_request_shape(p.request)
+            err = _validate_encode_request_shape(p.request)
             if err is None:
                 valid.append(p)
                 continue
@@ -1077,6 +1074,11 @@ async def execute_encode_pipeline(
     and keeps the result until follow-up /send calls complete. ZMQ has no early
     consumer: it waits for encode, sends the embedding, releases it, then returns.
     """
+    # Reject malformed requests before broadcasting them to TP followers. In
+    # particular, video bypasses EncoderScheduler batching and its validation.
+    if error := _validate_encode_request_shape(request):
+        raise server_module.BadRequestError(error)
+
     req_id = request["req_id"]
     time_stats_json = request.pop("time_stats_json", None)
     time_stats = EncoderReqTimeStats()

--- a/test/registered/unit/disaggregation/test_encoder_scheduler.py
+++ b/test/registered/unit/disaggregation/test_encoder_scheduler.py
@@ -7,7 +7,9 @@ from sglang.srt.disaggregation.encoder.runtime import (
     EncoderScheduler,
     PendingRequest,
     _resolve_encoder_batch_policy,
+    execute_encode_pipeline,
 )
+from sglang.srt.disaggregation.encoder.server import BadRequestError
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -106,6 +108,31 @@ def test_scheduler_coalesces_concurrent_submissions():
         assert results == [(1, 2, 3, None, None)] * 2
 
     asyncio.run(run_test())
+
+
+def test_invalid_video_request_is_rejected_before_tp_broadcast(monkeypatch):
+    sent_requests = []
+    monkeypatch.setattr(
+        "sglang.srt.disaggregation.encoder.runtime.sock_send",
+        lambda _socket, request: sent_requests.append(request),
+    )
+
+    async def run_test():
+        with pytest.raises(BadRequestError, match="missing or empty mm_items"):
+            await execute_encode_pipeline(
+                enc=object(),
+                sched=None,
+                request={
+                    "req_id": "invalid-video",
+                    "modality": "video",
+                    "num_parts": 1,
+                    "part_idx": 0,
+                },
+                send_sockets=[object()],
+            )
+
+    asyncio.run(run_test())
+    assert sent_requests == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- share request-shape validation between batched and direct encoder paths
- reject malformed video requests before broadcasting them to TP followers
- return a request-local bad-request error instead of degrading the encoder group

## Why

Video bypasses encoder batching because per-video preprocessing parameters vary. The direct path previously broadcast the request before reading required fields locally, so one malformed video request could terminate TP follower control loops with a `KeyError`.

## Coverage

Adds a regression that verifies a video request without media is rejected before `sock_send`, alongside the existing encoder scheduler, encoder server, and Kimi-K3 encoder-mode suites.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33249659223](https://github.com/sgl-project/sglang/actions/runs/33249659223)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33249659074](https://github.com/sgl-project/sglang/actions/runs/33249659074)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33249659191](https://github.com/sgl-project/sglang/actions/runs/33249659191)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->