### PR TITLE
[VLM] Release feature transports when requests abort

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1890,7 +1890,9 @@ class Req(ReqDllmMixin):
     def set_finish_with_abort(self, error_msg: str):
         if get_parallel().tp_rank == 0:
             logger.error(f"{error_msg}, {self.rid=}")
-        if self.multimodal_inputs is not None:
+        # Session requests share historical multimodal inputs with their prior
+        # request. The session owns and releases those features when it closes.
+        if self.multimodal_inputs is not None and self.session is None:
             self.multimodal_inputs.release_features()
         self.multimodal_inputs = None
         self.grammar = None

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -643,7 +643,18 @@ class MultimodalInputs:
     def release_features(self):
         """Release feature tensors to free GPU memory."""
         for item in self.mm_items:
-            item.feature = None
+            try:
+                # A request can be rejected before a deferred GPU feature is
+                # reconstructed. Acknowledge that transport lease before the
+                # proxy is dropped so the tokenizer pool can reuse its slice.
+                item.acknowledge_deferred_cuda_ipc_feature()
+            except Exception:
+                logger.warning(
+                    "Failed to release an unused multimodal feature transport",
+                    exc_info=True,
+                )
+            finally:
+                item.feature = None
 
     @staticmethod
     def from_processor_output(obj: MultimodalProcessorOutput):
@@ -1879,6 +1890,8 @@ class Req(ReqDllmMixin):
     def set_finish_with_abort(self, error_msg: str):
         if get_parallel().tp_rank == 0:
             logger.error(f"{error_msg}, {self.rid=}")
+        if self.multimodal_inputs is not None:
+            self.multimodal_inputs.release_features()
         self.multimodal_inputs = None
         self.grammar = None
         self.origin_input_ids = array(

--- a/test/registered/unit/managers/test_multimodal_abort_cleanup.py
+++ b/test/registered/unit/managers/test_multimodal_abort_cleanup.py
@@ -1,0 +1,68 @@
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    Req,
+)
+from sglang.srt.multimodal.transport.cuda_ipc import CudaIpcTensorTransportProxy
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+def _deferred_proxy():
+    proxy = object.__new__(CudaIpcTensorTransportProxy)
+    proxy.total_consumer_count = 1
+    proxy.acknowledge_consumption = MagicMock()
+    return proxy
+
+
+def test_release_features_acknowledges_deferred_transport():
+    proxy = _deferred_proxy()
+    item = MultimodalDataItem(modality=Modality.IMAGE, feature=proxy)
+    mm_inputs = MultimodalInputs(mm_items=[item])
+
+    mm_inputs.release_features()
+
+    proxy.acknowledge_consumption.assert_called_once_with(1)
+    assert item.feature is None
+
+
+def test_release_features_keeps_cleanup_error_request_local():
+    proxy = _deferred_proxy()
+    proxy.acknowledge_consumption.side_effect = RuntimeError("ack failed")
+    item = MultimodalDataItem(modality=Modality.IMAGE, feature=proxy)
+    mm_inputs = MultimodalInputs(mm_items=[item])
+
+    mm_inputs.release_features()
+
+    assert item.feature is None
+
+
+def test_request_abort_releases_multimodal_features():
+    mm_inputs = MagicMock()
+    req = object.__new__(Req)
+    req.rid = "rejected-vlm-request"
+    req.multimodal_inputs = mm_inputs
+    req.grammar = object()
+    req.return_logprob = True
+    req.logprob_start_len = 0
+
+    with patch(
+        "sglang.srt.managers.schedule_batch.get_parallel",
+        return_value=SimpleNamespace(tp_rank=1),
+    ):
+        req.set_finish_with_abort("invalid multimodal request")
+
+    mm_inputs.release_features.assert_called_once_with()
+    assert req.multimodal_inputs is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/test/registered/unit/managers/test_multimodal_abort_cleanup.py
+++ b/test/registered/unit/managers/test_multimodal_abort_cleanup.py
@@ -49,6 +49,7 @@ def test_request_abort_releases_multimodal_features():
     mm_inputs = MagicMock()
     req = object.__new__(Req)
     req.rid = "rejected-vlm-request"
+    req.session = None
     req.multimodal_inputs = mm_inputs
     req.grammar = object()
     req.return_logprob = True
@@ -61,6 +62,26 @@ def test_request_abort_releases_multimodal_features():
         req.set_finish_with_abort("invalid multimodal request")
 
     mm_inputs.release_features.assert_called_once_with()
+    assert req.multimodal_inputs is None
+
+
+def test_session_abort_preserves_shared_multimodal_features():
+    mm_inputs = MagicMock()
+    req = object.__new__(Req)
+    req.rid = "rejected-session-turn"
+    req.session = object()
+    req.multimodal_inputs = mm_inputs
+    req.grammar = object()
+    req.return_logprob = True
+    req.logprob_start_len = 0
+
+    with patch(
+        "sglang.srt.managers.schedule_batch.get_parallel",
+        return_value=SimpleNamespace(tp_rank=1),
+    ):
+        req.set_finish_with_abort("invalid session turn")
+
+    mm_inputs.release_features.assert_not_called()
     assert req.multimodal_inputs is None
 
 

--- a/test/registered/unit/multimodal/test_cuda_ipc_transport.py
+++ b/test/registered/unit/multimodal/test_cuda_ipc_transport.py
@@ -14,6 +14,11 @@ from unittest.mock import Mock, patch
 
 import torch
 
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+)
 from sglang.srt.multimodal.transport.cuda_ipc import (
     CudaIpcTensorTransportProxy,
     MmItemMemoryPool,
@@ -136,6 +141,44 @@ class TestCudaIpcTransport(CustomTestCase):
 
         stream.synchronize.assert_called_once_with()
         self.assertIsNone(proxy._pool_storage)
+
+    def test_rejected_request_releases_unconsumed_pool_slice(self):
+        ctx = mp.get_context("spawn")
+        proxy_queue = ctx.Queue()
+        producer_results = ctx.Queue()
+        consumer_done = ctx.Event()
+        producer = ctx.Process(
+            target=_produce_pooled_tensor,
+            args=(proxy_queue, consumer_done, producer_results),
+        )
+        producer.start()
+        proxy = None
+        producer_result = None
+        try:
+            proxy, _ = proxy_queue.get(timeout=60)
+            item = MultimodalDataItem(modality=Modality.IMAGE, feature=proxy)
+            mm_inputs = MultimodalInputs(mm_items=[item])
+
+            mm_inputs.release_features()
+            torch.cuda.synchronize()
+
+            self.assertIsNone(item.feature)
+        finally:
+            del proxy
+            _pool_handle_cache_clear()
+            gc.collect()
+            torch.cuda.ipc_collect()
+            consumer_done.set()
+            producer.join(timeout=60)
+            try:
+                producer_result = producer_results.get(timeout=5)
+                status, payload = producer_result
+                self.assertEqual(status, "ok", payload)
+            finally:
+                if producer.is_alive():
+                    producer.terminate()
+                    producer.join(timeout=10)
+            self.assertEqual(producer.exitcode, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- acknowledge unconsumed GPU multimodal feature transports before clearing request features
- release multimodal features before `Req.set_finish_with_abort` drops their owner
- keep transport-cleanup failures request-local while preserving diagnostics

## Why

A scheduler-side rejection, such as an overlong prompt after multimodal token expansion, could discard a deferred CUDA IPC or CUDA VMM proxy without acknowledging its tokenizer-owned pool slice. Repeated invalid VLM requests could exhaust the bounded feature pool and degrade healthy traffic.

## Coverage

Adds request-abort and cleanup-failure regressions, plus a spawned-process CUDA test that exercises the real stream-ordered pool acknowledgement and reclamation path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33250333144](https://github.com/sgl-project/sglang/actions/runs/33250333144)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33250333042](https://github.com/sgl-project/sglang/actions/runs/33250333042)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33250333091](https://github.com/sgl-project/sglang/actions/runs/33250333091)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->