### PR TITLE
[BugFix] Preserve chunked prefill progress without radix insert

### DIFF
--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -385,7 +385,7 @@ class BasePrefixCache(ABC, PrefixCacheTrait):
         pass
 
     @abstractmethod
-    def cache_unfinished_req(self, req: Req, **kwargs):
+    def cache_unfinished_req(self, req: Req, is_insert: bool = True, **kwargs):
         pass
 
     def free_kv_row(self, kv: Any, ranges: list[tuple[int, int]]) -> None:

--- a/python/sglang/srt/mem_cache/chunk_cache.py
+++ b/python/sglang/srt/mem_cache/chunk_cache.py
@@ -83,7 +83,9 @@ class ChunkCache(BasePrefixCache):
         # The protected prefix is not this req's to free.
         self.free_kv_row(req.kv, [(req.kv.cache_protected_len, kv_len_to_handle)])
 
-    def cache_unfinished_req(self, req: Req, chunked=False):
+    def cache_unfinished_req(
+        self, req: Req, chunked: bool = False, is_insert: bool = True
+    ):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.kv.req_pool_idx, : req.extend_range.end
         ]

--- a/python/sglang/srt/mem_cache/common.py
+++ b/python/sglang/srt/mem_cache/common.py
@@ -143,10 +143,11 @@ def free_kv_row_segments(
 
 
 def maybe_cache_unfinished_req(req: Req, tree_cache: BasePrefixCache, **kwargs):
-    if getattr(req, "skip_radix_cache_insert", False):
-        return
-
-    tree_cache.cache_unfinished_req(req, **kwargs)
+    tree_cache.cache_unfinished_req(
+        req,
+        is_insert=not getattr(req, "skip_radix_cache_insert", False),
+        **kwargs,
+    )
 
 
 def evict_from_tree_cache(tree_cache: BasePrefixCache | None, num_tokens: int):

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -685,7 +685,9 @@ class MambaRadixCache(BasePrefixCache):
 
         self.dec_lock_ref(req.last_node)
 
-    def cache_unfinished_req(self, req: Req, chunked=False) -> None:
+    def cache_unfinished_req(
+        self, req: Req, chunked: bool = False, is_insert: bool = True
+    ) -> None:
         """Cache request when it is unfinished."""
 
         def _skip_cache_unfinished_req(req: Req) -> None:
@@ -708,7 +710,7 @@ class MambaRadixCache(BasePrefixCache):
         )
         if not self.enable_mamba_extra_buffer and spec_write_pos is not None:
             cache_len -= int(spec_write_pos[req.kv.req_pool_idx].item())
-        if self.disable or cache_len is None:
+        if not is_insert or self.disable or cache_len is None:
             return _skip_cache_unfinished_req(req)
 
         kv_indices_orig = self.req_to_token_pool.req_to_token[

--- a/python/sglang/srt/mem_cache/pure_swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/pure_swa_radix_cache.py
@@ -138,10 +138,10 @@ class PureSWARadixCache(RadixCache):
         if req.last_node is not None:
             self.dec_lock_ref(req.last_node)
 
-    def cache_unfinished_req(self, req: Req, chunked=False):
+    def cache_unfinished_req(self, req: Req, chunked=False, is_insert: bool = True):
         """During chunked prefill, swa_evicted_seqlen is 0 and no SWA eviction
         has happened yet, so standard RadixCache logic is correct."""
-        super().cache_unfinished_req(req, chunked=chunked)
+        super().cache_unfinished_req(req, chunked=chunked, is_insert=is_insert)
 
     def available_and_evictable_str(self) -> str:
         allocator = self.token_to_kv_pool_allocator

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -536,7 +536,9 @@ class RadixCache(BasePrefixCache):
         if req.last_node is not None:
             self.dec_lock_ref(req.last_node)
 
-    def cache_unfinished_req(self, req: Req, chunked=False):
+    def cache_unfinished_req(
+        self, req: Req, chunked: bool = False, is_insert: bool = True
+    ):
         """Cache request when it is unfinished."""
         if self.disable:
             return
@@ -545,6 +547,14 @@ class RadixCache(BasePrefixCache):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.kv.req_pool_idx, : len(token_ids)
         ]
+
+        if not is_insert:
+            # Keep chunked-prefill progress request-owned without publishing it
+            # to the radix tree. cache_protected_len intentionally remains at
+            # the previously matched tree prefix so cache_finished_req can free
+            # this request-owned range when it finishes.
+            req.prefix_indices = kv_indices.to(dtype=torch.int64, copy=True)
+            return
 
         radix_key = RadixKey(
             token_ids,

--- a/python/sglang/srt/mem_cache/radix_cache_cpp.py
+++ b/python/sglang/srt/mem_cache/radix_cache_cpp.py
@@ -193,7 +193,12 @@ class RadixCacheCpp(BasePrefixCache):
 
         # NOTE: our C++ implementation don't need `token_ids` and `kv_indices` to be page-aligned
         # it will automatically align them, but length of them should be equal
-        old_prefix_len = len(req.prefix_indices) // self.page_size * self.page_size
+        if is_insert:
+            old_prefix_len = len(req.prefix_indices) // self.page_size * self.page_size
+        else:
+            # Skipped unfinished inserts advance prefix_indices for scheduling,
+            # but cache_protected_len remains the tree-owned boundary.
+            old_prefix_len = req.kv.cache_protected_len
         page_aligned_overall_len = kv_len_to_handle // self.page_size * self.page_size
 
         if is_insert:
@@ -220,7 +225,7 @@ class RadixCacheCpp(BasePrefixCache):
         # Remove req slot release the cache lock
         self.dec_lock_ref(req.last_node)
 
-    def cache_unfinished_req(self, req: Req, chunked=False):
+    def cache_unfinished_req(self, req: Req, chunked=False, is_insert: bool = True):
         """Cache request when it is unfinished."""
         self._reject_cache_salt(req.cache_salt)
         assert req.kv.holds_kv
@@ -229,6 +234,13 @@ class RadixCacheCpp(BasePrefixCache):
         kv_indices = self.req_to_token_pool.req_to_token[
             req.kv.req_pool_idx, :prefill_len
         ].to(dtype=torch.int64, copy=True)
+
+        if not is_insert:
+            # Keep chunked-prefill progress request-owned without publishing it
+            # to the C++ radix tree. cache_finished_req later frees everything
+            # after cache_protected_len.
+            req.prefix_indices = kv_indices
+            return
 
         # NOTE: our C++ implementation don't need `token_ids` and `kv_indices` to be page-aligned
         # it will automatically align them, but length of them should be equal

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -505,9 +505,11 @@ class SWARadixCache(BasePrefixCache):
         )
         req.swa_prefix_lock_released = False
 
-    def cache_unfinished_req(self, req: Req, chunked=False) -> None:
+    def cache_unfinished_req(
+        self, req: Req, chunked=False, is_insert: bool = True
+    ) -> None:
         """Cache request when it is unfinished."""
-        if self.disable:
+        if not is_insert or self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
                 req.kv.req_pool_idx, : req.extend_range.end
             ]

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -1004,13 +1004,21 @@ class UnifiedRadixCache(BasePrefixCache):
             ):
                 self.session_refs.register_session_ref(req)
 
-    def cache_unfinished_req(self, req: Req, chunked: bool = False, **kwargs) -> None:
-        if self.session.try_cache_unfinished_req(req, chunked=chunked, **kwargs):
+    def cache_unfinished_req(
+        self,
+        req: Req,
+        chunked: bool = False,
+        is_insert: bool = True,
+        **kwargs,
+    ) -> None:
+        if self.session.try_cache_unfinished_req(
+            req, chunked=chunked, is_insert=is_insert, **kwargs
+        ):
             return
 
         token_ids = req.get_fill_ids()
 
-        if self.disable:
+        if not is_insert or self.disable:
             kv_indices = self.req_to_token_pool.req_to_token[
                 req.kv.req_pool_idx, : len(token_ids)
             ]

--- a/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_cpp_unit.py
@@ -1,10 +1,15 @@
-"""Unit tests for fail-closed C++ radix-cache request validation."""
+"""Unit tests for C++ radix-cache request handling."""
 
 import importlib
 import sys
 import types
 import unittest
-from unittest.mock import patch
+from array import array
+from contextlib import contextmanager
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import torch
 
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -12,8 +17,9 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
 
-class TestRadixCacheCppCacheSalt(CustomTestCase):
-    def test_cache_salt_is_rejected_without_loading_cpp_extension(self):
+class TestRadixCacheCpp(CustomTestCase):
+    @contextmanager
+    def _import_with_fake_extension(self):
         extension_name = "sglang.srt.mem_cache.cpp_radix_tree.radix_tree"
         module_name = "sglang.srt.mem_cache.radix_cache_cpp"
         fake_extension = types.ModuleType(extension_name)
@@ -24,14 +30,57 @@ class TestRadixCacheCppCacheSalt(CustomTestCase):
         original_module = sys.modules.pop(module_name, None)
         try:
             with patch.dict(sys.modules, {extension_name: fake_extension}):
-                module = importlib.import_module(module_name)
-                module.RadixCacheCpp._reject_cache_salt(None)
-                with self.assertRaisesRegex(ValueError, "experimental C\\+\\+"):
-                    module.RadixCacheCpp._reject_cache_salt("tenant-a")
+                yield importlib.import_module(module_name)
         finally:
             sys.modules.pop(module_name, None)
             if original_module is not None:
                 sys.modules[module_name] = original_module
+
+    def test_cache_salt_is_rejected_without_loading_cpp_extension(self):
+        with self._import_with_fake_extension() as module:
+            module.RadixCacheCpp._reject_cache_salt(None)
+            with self.assertRaisesRegex(ValueError, "experimental C\\+\\+"):
+                module.RadixCacheCpp._reject_cache_salt("tenant-a")
+
+    def test_skip_insert_keeps_progress_request_owned(self):
+        """Skipped publication must advance progress and free only request-owned KV."""
+        with self._import_with_fake_extension() as module:
+            kv_indices = torch.tensor([[401, 402, 403, 404, 405, 406]])
+            cache = module.RadixCacheCpp.__new__(module.RadixCacheCpp)
+            cache.page_size = 1
+            cache.req_to_token_pool = SimpleNamespace(req_to_token=kv_indices)
+            cache.token_to_kv_pool_allocator = MagicMock()
+            cache._insert = MagicMock()
+            cache.dec_lock_ref = MagicMock()
+
+            last_node = object()
+            req = SimpleNamespace(
+                cache_salt=None,
+                kv=SimpleNamespace(
+                    req_pool_idx=0, cache_protected_len=2, holds_kv=True
+                ),
+                prefix_indices=kv_indices[0, :2].clone(),
+                origin_input_ids=array("q", [1, 2, 3, 4, 5, 6]),
+                output_ids=array("q"),
+                extra_key=None,
+                last_node=last_node,
+                get_fill_ids=lambda: array("q", [1, 2, 3, 4, 5, 6]),
+            )
+
+            cache.cache_unfinished_req(req, chunked=True, is_insert=False)
+
+            torch.testing.assert_close(req.prefix_indices, kv_indices[0])
+            self.assertEqual(req.kv.cache_protected_len, 2)
+            cache._insert.assert_not_called()
+
+            cache.cache_finished_req(req, is_insert=False, kv_len_to_handle=6)
+
+            cache.token_to_kv_pool_allocator.free.assert_called_once()
+            torch.testing.assert_close(
+                cache.token_to_kv_pool_allocator.free.call_args.args[0],
+                kv_indices[0, 2:],
+            )
+            cache.dec_lock_ref.assert_called_once_with(last_node)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/mem_cache/test_skip_radix_cache_insert.py
+++ b/test/registered/unit/mem_cache/test_skip_radix_cache_insert.py
@@ -1,0 +1,163 @@
+"""Regression coverage for chunked prefill with radix insertion disabled."""
+
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import torch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.schedule_policy import PrefillAdder  # noqa: E402
+from sglang.srt.mem_cache.chunk_cache import ChunkCache  # noqa: E402
+from sglang.srt.mem_cache.common import maybe_cache_unfinished_req  # noqa: E402
+from sglang.srt.mem_cache.pure_swa_radix_cache import PureSWARadixCache  # noqa: E402
+from sglang.srt.mem_cache.radix_cache import RadixCache  # noqa: E402
+from sglang.srt.mem_cache.swa_radix_cache import SWARadixCache  # noqa: E402
+
+register_cpu_ci(est_time=3, suite="base-a-test-cpu")
+
+
+class TestSkipRadixCacheInsert(CustomTestCase):
+    def test_chunked_request_advances_across_scheduling_rounds(self):
+        chunk_size = 1024
+        num_tokens = 3 * chunk_size
+        kv_indices = torch.arange(num_tokens).unsqueeze(0)
+        cache = RadixCache.__new__(RadixCache)
+        cache.disable = False
+        cache.evictable_size_ = 0
+        cache.req_to_token_pool = SimpleNamespace(req_to_token=kv_indices)
+
+        req = SimpleNamespace(
+            skip_radix_cache_insert=True,
+            kv=SimpleNamespace(req_pool_idx=0, cache_protected_len=0),
+            prefix_indices=torch.empty(0, dtype=torch.int64),
+            full_untruncated_fill_ids=array("q", range(num_tokens)),
+            output_ids=array("q"),
+            sampling_params=SimpleNamespace(max_new_tokens=1),
+            retracted_stain=False,
+        )
+        req.set_extend_range = lambda start, end: setattr(
+            req,
+            "extend_range",
+            SimpleNamespace(start=start, end=end, length=end - start),
+        )
+        req.get_fill_ids = lambda: req.full_untruncated_fill_ids[: req.extend_range.end]
+
+        starts = []
+        chunked_req = req
+        for _ in range(3):
+            allocator = MagicMock()
+            allocator.available_size.return_value = num_tokens + chunk_size
+            adder = PrefillAdder(
+                page_size=1,
+                tree_cache=cache,
+                token_to_kv_pool_allocator=allocator,
+                running_batch=None,
+                new_token_ratio=0,
+                rem_input_tokens=num_tokens,
+                rem_chunk_tokens=chunk_size,
+            )
+
+            chunked_req = adder.add_chunked_req(chunked_req)
+            starts.append(req.extend_range.start)
+            if chunked_req is not None:
+                maybe_cache_unfinished_req(req, cache, chunked=True)
+
+        self.assertEqual(starts, [0, chunk_size, 2 * chunk_size])
+        self.assertIsNone(chunked_req)
+
+    def test_chunked_request_advances_without_inserting(self):
+        kv_indices = torch.tensor([[101, 102, 103, 104, 105, 106]])
+        cache = RadixCache.__new__(RadixCache)
+        cache.disable = False
+        cache.disable_finished_insert = False
+        cache.page_size = 1
+        cache.is_eagle = False
+        cache.req_to_token_pool = SimpleNamespace(req_to_token=kv_indices)
+        cache.token_to_kv_pool_allocator = MagicMock()
+        cache.insert = MagicMock()
+        cache.match_prefix = MagicMock()
+        cache.dec_lock_ref = MagicMock()
+        cache.inc_lock_ref = MagicMock()
+
+        last_node = object()
+        req = SimpleNamespace(
+            skip_radix_cache_insert=True,
+            kv=SimpleNamespace(req_pool_idx=0, cache_protected_len=2),
+            prefix_indices=kv_indices[0, :2].clone(),
+            last_node=last_node,
+            origin_input_ids=array("q", [1, 2, 3, 4, 5, 6]),
+            output_ids=array("q"),
+            extra_key=None,
+            cache_salt=None,
+            get_fill_ids=lambda: array("q", [1, 2, 3, 4, 5, 6]),
+        )
+
+        maybe_cache_unfinished_req(req, cache, chunked=True)
+
+        torch.testing.assert_close(req.prefix_indices, kv_indices[0])
+        self.assertEqual(req.kv.cache_protected_len, 2)
+        self.assertIs(req.last_node, last_node)
+        cache.insert.assert_not_called()
+        cache.match_prefix.assert_not_called()
+        cache.token_to_kv_pool_allocator.free_segment.assert_not_called()
+        cache.dec_lock_ref.assert_not_called()
+        cache.inc_lock_ref.assert_not_called()
+
+        cache.cache_finished_req(req, is_insert=False, kv_len_to_handle=6)
+
+        freed_segments = cache.token_to_kv_pool_allocator.free_segments.call_args.args[
+            0
+        ]
+        torch.testing.assert_close(freed_segments[0][0], kv_indices[0, 2:])
+        self.assertEqual(freed_segments[0][1], 2)
+        self.assertEqual(freed_segments[1][0].numel(), 0)
+        cache.dec_lock_ref.assert_called_once_with(last_node)
+
+    def test_chunk_cache_still_advances_with_skip_flag(self):
+        kv_indices = torch.tensor([[201, 202, 203, 204, 205, 206]])
+        cache = ChunkCache.__new__(ChunkCache)
+        cache.req_to_token_pool = SimpleNamespace(req_to_token=kv_indices)
+        req = SimpleNamespace(
+            skip_radix_cache_insert=True,
+            kv=SimpleNamespace(req_pool_idx=0),
+            prefix_indices=kv_indices[0, :2].clone(),
+            extend_range=SimpleNamespace(end=6),
+        )
+
+        maybe_cache_unfinished_req(req, cache, chunked=True)
+
+        torch.testing.assert_close(req.prefix_indices, kv_indices[0])
+
+    def test_swa_backends_advance_without_publishing(self):
+        """Skipping publication must still advance chunked-prefill ownership."""
+        kv_indices = torch.tensor([[301, 302, 303, 304, 305, 306]])
+
+        for cache_cls in (PureSWARadixCache, SWARadixCache):
+            with self.subTest(cache_cls=cache_cls.__name__):
+                cache = cache_cls.__new__(cache_cls)
+                cache.disable = False
+                cache.req_to_token_pool = SimpleNamespace(req_to_token=kv_indices)
+                cache.insert = MagicMock()
+                req = SimpleNamespace(
+                    skip_radix_cache_insert=True,
+                    kv=SimpleNamespace(req_pool_idx=0, cache_protected_len=2),
+                    prefix_indices=kv_indices[0, :2].clone(),
+                    extend_range=SimpleNamespace(end=6),
+                    get_fill_ids=lambda: array("q", [1, 2, 3, 4, 5, 6]),
+                )
+
+                maybe_cache_unfinished_req(req, cache, chunked=True)
+
+                torch.testing.assert_close(req.prefix_indices, kv_indices[0])
+                self.assertEqual(req.kv.cache_protected_len, 2)
+                cache.insert.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## Motivation

Fixes #36855.

`skip_radix_cache_insert` previously returned before `cache_unfinished_req`, so chunked prefill never advanced `req.prefix_indices`. The scheduler repeatedly prefetched the same chunk and consumed unowned KV slots until OOM.

## Modifications

- Thread an `is_insert` flag through unfinished-request cache handling.
- Advance request-owned KV progress while skipping radix-tree publication.
- Cover RadixCache, ChunkCache, MambaRadixCache, UnifiedRadixCache, and streaming-session delegation.
- Add CPU regression coverage for progress, ownership, and final KV cleanup.

## Accuracy Tests

N/A. This only changes KV-cache bookkeeping for requests that explicitly skip radix insertion.

## Speed Tests and Profiling

N/A. The normal radix insertion path is unchanged.

## Tests

- `pytest -q test/registered/unit/mem_cache/test_skip_radix_cache_insert.py test/registered/unit/mem_cache/test_pure_swa_chunk_cache.py` — 4 passed
- `ruff check --ignore E402` on modified files — passed
- `py_compile` on modified files — passed

GPU end-to-end testing was not run because the current environment has no visible `nvidia-smi`; no GPU workload was launched without first being able to verify occupancy.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34503016716](https://github.com/sgl-project/sglang/actions/runs/34503016716)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34503016057](https://github.com/sgl-project/sglang/actions/runs/34503016057)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34503016431](https://github.com/sgl-project/sglang/actions/runs/34503016431)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->