### PR TITLE
[VLM] Release GPU feature leases after reconstruction failure

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -509,6 +509,22 @@ class MultimodalDataItem(msgspec.Struct, kw_only=True, dict=True, array_like=Tru
             )
             self.feature.acknowledge_consumption(consumer_count)
 
+    def release_transport_proxies(self, consumer_count: int = 1) -> None:
+        """Best-effort release of proxies left by an abandoned request."""
+        values = [self.feature, self.precomputed_embeddings]
+        values.extend(self.model_specific_data.values())
+        for value in values:
+            if not isinstance(value, CudaIpcTensorTransportProxy):
+                continue
+            count = self._resolve_transport_consumer_count(value, consumer_count)
+            try:
+                value.release_without_reconstruction(count)
+            except Exception:
+                logger.warning(
+                    "Failed to release an abandoned multimodal transport proxy",
+                    exc_info=True,
+                )
+
     @staticmethod
     def _resolve_transport_consumer_count(proxy, requested_count: int) -> int:
         """Clamp a group acknowledgement to the proxy's actual consumer set."""
@@ -653,14 +669,19 @@ class MultimodalInputs:
 
         # try reconstructing from cuda-ipc
         reconstruct_device = None
-        for mm_item in mm_items:
-            if (
-                mm_item.has_cuda_ipc_proxy()
-                and not mm_item.can_defer_cuda_ipc_feature_reconstruction()
-            ):
-                if reconstruct_device is None:
-                    reconstruct_device = torch.cuda.current_device()
-                mm_item.reconstruct(reconstruct_device)
+        try:
+            for mm_item in mm_items:
+                if (
+                    mm_item.has_cuda_ipc_proxy()
+                    and not mm_item.can_defer_cuda_ipc_feature_reconstruction()
+                ):
+                    if reconstruct_device is None:
+                        reconstruct_device = torch.cuda.current_device()
+                    mm_item.reconstruct(reconstruct_device)
+        except BaseException:
+            for mm_item in mm_items:
+                mm_item.release_transport_proxies()
+            raise
 
         if envs.SGLANG_MM_BUFFER_SIZE_MB.get() > 0:
             # Multi-modal feature hashing optimization:

--- a/python/sglang/srt/multimodal/transport/cuda_ipc.py
+++ b/python/sglang/srt/multimodal/transport/cuda_ipc.py
@@ -310,6 +310,10 @@ class CudaIpcTensorTransportProxy(StreamOrderedPoolConsumerMixin):
             )
         self._retain_storage_until_stream_completes(storage, device_id)
 
+    def release_without_reconstruction(self, consumer_count: int = 1) -> None:
+        """Release a pool slice when its request abandons this proxy."""
+        self.acknowledge_consumption(consumer_count)
+
     def reconstruct_on_target_device(
         self,
         rebuild_device_idx,

--- a/python/sglang/srt/utils/cuda_vmm_transport_utils.py
+++ b/python/sglang/srt/utils/cuda_vmm_transport_utils.py
@@ -903,6 +903,13 @@ class CudaVmmPackedTensorTransportProxy(CudaVmmTensorTransportProxy):
             "Packed CUDA VMM features must be reconstructed before release"
         )
 
+    def release_without_reconstruction(self, consumer_count: int | None = None) -> None:
+        """Release the shared packed allocation when its request is abandoned."""
+        if self._consumer_acknowledged:
+            return
+        self._packed_owner.acknowledge_consumption(consumer_count)
+        self._consumer_acknowledged = True
+
     def reconstruct_on_target_device(
         self, rebuild_device_idx, consumer_count: int | None = None
     ):

--- a/test/registered/unit/multimodal/test_cuda_ipc_transport.py
+++ b/test/registered/unit/multimodal/test_cuda_ipc_transport.py
@@ -14,6 +14,12 @@ from unittest.mock import Mock, patch
 
 import torch
 
+from sglang.srt.managers.schedule_batch import (
+    Modality,
+    MultimodalDataItem,
+    MultimodalInputs,
+    MultimodalProcessorOutput,
+)
 from sglang.srt.multimodal.transport.cuda_ipc import (
     CudaIpcTensorTransportProxy,
     MmItemMemoryPool,
@@ -106,6 +112,74 @@ class TestCudaIpcTransport(CustomTestCase):
             # consumer exits quickly, so it must close the mapping before the
             # producer destroys the shared allocation.
             del reconstructed, proxy
+            _pool_handle_cache_clear()
+            gc.collect()
+            torch.cuda.ipc_collect()
+            consumer_done.set()
+            producer.join(timeout=60)
+            try:
+                if producer_result is None:
+                    producer_result = producer_results.get(timeout=5)
+                status, payload = producer_result
+                self.assertEqual(status, "ok", payload)
+            finally:
+                if producer.is_alive():
+                    producer.terminate()
+                    producer.join(timeout=10)
+            self.assertEqual(producer.exitcode, 0)
+
+    def test_failed_reconstruction_releases_pooled_tensor(self):
+        ctx = mp.get_context("spawn")
+        proxy_queue = ctx.Queue()
+        producer_results = ctx.Queue()
+        consumer_done = ctx.Event()
+        producer = ctx.Process(
+            target=_produce_pooled_tensor,
+            args=(proxy_queue, consumer_done, producer_results),
+        )
+        producer.start()
+        proxy = None
+        producer_result = None
+        original_empty = torch.empty
+        try:
+            try:
+                proxy, _expected = proxy_queue.get(timeout=60)
+            except queue.Empty:
+                producer_result = producer_results.get(timeout=5)
+                _status, payload = producer_result
+                self.fail(
+                    f"CUDA IPC producer failed before sending its proxy: {payload}"
+                )
+
+            output_shape = proxy.proxy_state["ipc_extra"]["recons_shape"]
+
+            def fail_destination_allocation(size, *args, **kwargs):
+                if isinstance(size, (tuple, torch.Size)) and tuple(size) == tuple(
+                    output_shape
+                ):
+                    raise RuntimeError("forced reconstruction failure")
+                return original_empty(size, *args, **kwargs)
+
+            item = MultimodalDataItem(
+                modality=Modality.IMAGE,
+                hash=1,
+                pad_value=1,
+                feature=proxy,
+            )
+            output = MultimodalProcessorOutput(input_ids=[1], mm_items=[item])
+            with (
+                patch(
+                    "sglang.srt.multimodal.transport.cuda_ipc.torch.empty",
+                    side_effect=fail_destination_allocation,
+                ),
+                self.assertRaisesRegex(RuntimeError, "forced reconstruction failure"),
+            ):
+                MultimodalInputs.from_processor_output(output)
+
+            torch.cuda.synchronize()
+            self.assertTrue(proxy._consumer_acknowledged)
+        finally:
+            del proxy
             _pool_handle_cache_clear()
             gc.collect()
             torch.cuda.ipc_collect()

--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -11,6 +11,86 @@ register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 
 class TestCudaVmmFeatureTransport(unittest.TestCase):
+    def test_failed_consumer_reconstruction_releases_remaining_proxies(self):
+        from sglang.srt.managers.schedule_batch import (
+            Modality,
+            MultimodalDataItem,
+            MultimodalInputs,
+            MultimodalProcessorOutput,
+        )
+        from sglang.srt.multimodal.transport.cuda_ipc import (
+            CudaIpcTensorTransportProxy,
+        )
+
+        class FakeProxy(CudaIpcTensorTransportProxy):
+            def __init__(self, *, fail_reconstruct=False, fail_release=False):
+                self.fail_reconstruct = fail_reconstruct
+                self.fail_release = fail_release
+                self.released = False
+
+            def reconstruct_on_target_device(self, _device, consumer_count=1):
+                if self.fail_reconstruct:
+                    raise RuntimeError("reconstruct failed")
+                return torch.ones(1)
+
+            def release_without_reconstruction(self, consumer_count=1):
+                self.released = True
+                if self.fail_release:
+                    raise RuntimeError("release failed")
+
+        reconstructed = FakeProxy()
+        failed = FakeProxy(fail_reconstruct=True, fail_release=True)
+        remaining = FakeProxy()
+        items = [
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                hash=1,
+                pad_value=1,
+                feature=reconstructed,
+            ),
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                hash=2,
+                pad_value=2,
+                feature=failed,
+            ),
+            MultimodalDataItem(
+                modality=Modality.IMAGE,
+                hash=3,
+                pad_value=3,
+                feature=remaining,
+            ),
+        ]
+        output = MultimodalProcessorOutput(input_ids=[1], mm_items=items)
+
+        with (
+            patch(
+                "sglang.srt.managers.schedule_batch.torch.cuda.current_device",
+                return_value=0,
+            ),
+            self.assertRaisesRegex(RuntimeError, "reconstruct failed"),
+        ):
+            MultimodalInputs.from_processor_output(output)
+
+        self.assertIsInstance(items[0].feature, torch.Tensor)
+        self.assertTrue(failed.released)
+        self.assertTrue(remaining.released)
+
+    def test_abandoned_packed_proxy_releases_shared_owner(self):
+        from sglang.srt.utils.cuda_vmm_transport_utils import (
+            CudaVmmPackedTensorTransportProxy,
+        )
+
+        owner = MagicMock()
+        proxy = object.__new__(CudaVmmPackedTensorTransportProxy)
+        proxy._packed_owner = owner
+        proxy._consumer_acknowledged = False
+
+        proxy.release_without_reconstruction(consumer_count=2)
+
+        owner.acknowledge_consumption.assert_called_once_with(2)
+        self.assertTrue(proxy._consumer_acknowledged)
+
     def test_partial_pool_release_can_be_retried(self):
         from sglang.srt.utils import cuda_vmm_transport_utils as vmm
 


### PR DESCRIPTION
## Summary

Release every unconsumed CUDA IPC or CUDA VMM feature proxy when scheduler-side multimodal reconstruction fails.

## Why

Reconstruction previously stopped at the first exception. Remaining media proxies never acknowledged their bounded pool leases, so repeated malformed or failed requests could exhaust the tokenizer GPU feature pool.

## Coverage

Covers multi-item and model-specific proxies, ordinary CUDA IPC, standalone CUDA VMM, and packed CUDA VMM allocations. Cleanup is best effort and preserves the original request failure.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33251494477](https://github.com/sgl-project/sglang/actions/runs/33251494477)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33251494402](https://github.com/sgl-project/sglang/actions/runs/33251494402)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33251494467](https://github.com/sgl-project/sglang/actions/runs/33251494467)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->