### PR TITLE
[VLM] Isolate CUDA VMM reconstruction failures across TP ranks

### DIFF
--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -1897,7 +1897,12 @@ class Req(ReqDllmMixin):
         logger.info(f"{prefix}: {self.time_stats.convert_to_duration()}")
         self.has_log_time_stats = True
 
-    def set_finish_with_abort(self, error_msg: str):
+    def set_finish_with_abort(
+        self,
+        error_msg: str,
+        status_code: int = HTTPStatus.BAD_REQUEST,
+        err_type: str = "BadRequestError",
+    ):
         if get_parallel().tp_rank == 0:
             logger.error(f"{error_msg}, {self.rid=}")
         self.multimodal_inputs = None
@@ -1907,9 +1912,7 @@ class Req(ReqDllmMixin):
         )  # set it to one token to skip the long prefill
         self.return_logprob = False
         self.logprob_start_len = -1
-        self.to_finish = FINISH_ABORT(
-            error_msg, HTTPStatus.BAD_REQUEST, "BadRequestError"
-        )
+        self.to_finish = FINISH_ABORT(error_msg, status_code, err_type)
 
     def update_reasoning_tokens(self, token_id, think_end_ids):
         if self._is_reasoning_over:

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1954,11 +1954,12 @@ class Scheduler(
     def process_input_requests(self, recv_reqs: List):
         now = time.monotonic()
         self.session_controller.maybe_reap(now)
-        if get_mm().mm_feature_transport == "cuda_vmm":
-            for recv_req in recv_reqs:
-                self._materialize_cuda_vmm_inputs(recv_req)
 
         for recv_req in recv_reqs:
+            vmm_errors = None
+            if get_mm().mm_feature_transport == "cuda_vmm":
+                vmm_errors = self._materialize_cuda_vmm_inputs(recv_req)
+
             # Skip health check when server is busy — ongoing requests already carry health info.
             if is_health_check_generate_req(recv_req) and not self.is_fully_idle(
                 for_health_check=True
@@ -1966,6 +1967,10 @@ class Scheduler(
                 self.return_health_check_ipcs.append(
                     getattr(recv_req, "http_worker_ipc", None)
                 )
+                continue
+
+            if vmm_errors is not None and any(vmm_errors):
+                self._dispatch_tokenized_mm_requests(recv_req, vmm_errors)
                 continue
 
             output = self._request_dispatcher(recv_req)
@@ -1985,26 +1990,87 @@ class Scheduler(
         if self.external_corpus_manager is not None:
             self.external_corpus_manager.check_pending_load()
 
-    def _materialize_cuda_vmm_inputs(self, recv_req):
-        """Release VMM slices before request handling can reject the request."""
+    @staticmethod
+    def _tokenized_requests(recv_req):
         if isinstance(
             recv_req, (TokenizedGenerateReqInput, TokenizedEmbeddingReqInput)
         ):
-            tokenized_reqs = (recv_req,)
-        elif isinstance(
+            return (recv_req,)
+        if isinstance(
             recv_req,
             (BatchTokenizedGenerateReqInput, BatchTokenizedEmbeddingReqInput),
         ):
-            tokenized_reqs = recv_req
-        else:
-            return
+            return tuple(recv_req)
+        return ()
 
+    def _gather_vmm_materialization_errors(
+        self, local_error: Optional[str]
+    ) -> List[Optional[str]]:
+        if not (
+            torch.distributed.is_available()
+            and torch.distributed.is_initialized()
+            and self.dp_tp_cpu_group is not None
+        ):
+            return [local_error]
+
+        world_size = torch.distributed.get_world_size(group=self.dp_tp_cpu_group)
+        errors = [None] * world_size
+        torch.distributed.all_gather_object(
+            errors,
+            local_error,
+            group=self.dp_tp_cpu_group,
+        )
+        return errors
+
+    def _materialize_cuda_vmm_inputs(self, recv_req) -> Optional[List[Optional[str]]]:
+        """Materialize each request and agree on failures across TP ranks."""
+        tokenized_reqs = self._tokenized_requests(recv_req)
+        if not tokenized_reqs:
+            return None
+
+        request_errors = []
         for tokenized_req in tokenized_reqs:
-            if tokenized_req.mm_inputs is not None and not isinstance(
-                tokenized_req.mm_inputs, MultimodalInputs
-            ):
-                tokenized_req.mm_inputs = MultimodalInputs.from_processor_output(
-                    tokenized_req.mm_inputs
+            local_error = None
+            try:
+                if tokenized_req.mm_inputs is not None and not isinstance(
+                    tokenized_req.mm_inputs, MultimodalInputs
+                ):
+                    tokenized_req.mm_inputs = MultimodalInputs.from_processor_output(
+                        tokenized_req.mm_inputs
+                    )
+            except Exception as error:
+                local_error = f"{type(error).__name__}: {error}"
+
+            rank_errors = self._gather_vmm_materialization_errors(local_error)
+            failed_ranks = [
+                rank for rank, error in enumerate(rank_errors) if error is not None
+            ]
+            if failed_ranks:
+                details = "; ".join(
+                    f"rank {rank}: {rank_errors[rank]}" for rank in failed_ranks
+                )
+                error_msg = f"Multimodal feature reconstruction failed ({details})"
+                logger.error(error_msg)
+                tokenized_req.mm_inputs = None
+                request_errors.append(error_msg)
+            else:
+                request_errors.append(None)
+        return request_errors
+
+    def _dispatch_tokenized_mm_requests(
+        self, recv_req, errors: List[Optional[str]]
+    ) -> None:
+        tokenized_reqs = self._tokenized_requests(recv_req)
+        if len(tokenized_reqs) != len(errors):
+            raise RuntimeError("VMM materialization results do not match requests")
+        for tokenized_req, error in zip(tokenized_reqs, errors, strict=True):
+            if isinstance(tokenized_req, TokenizedGenerateReqInput):
+                self.handle_generate_request(tokenized_req, mm_input_error=error)
+            elif isinstance(tokenized_req, TokenizedEmbeddingReqInput):
+                self.handle_embedding_request(tokenized_req, mm_input_error=error)
+            else:
+                raise TypeError(
+                    f"Unsupported tokenized request type: {type(tokenized_req).__name__}"
                 )
 
     def init_profiler(self) -> None:
@@ -2486,6 +2552,8 @@ class Scheduler(
     def handle_generate_request(
         self,
         recv_req: TokenizedGenerateReqInput,
+        *,
+        mm_input_error: Optional[str] = None,
     ):
         # Route: normal request / session request / session-not-found
         session_id = (
@@ -2633,6 +2701,16 @@ class Scheduler(
             return
 
         self._maybe_namespace_elastic_radix_cache(req)
+
+        if mm_input_error is not None:
+            req.set_finish_with_abort(
+                mm_input_error,
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                err_type="InternalServerError",
+            )
+            self.init_req_max_new_tokens(req)
+            self._add_request_to_queue(req)
+            return
 
         if self.spec_algorithm.is_dflash_family():
             error_msg = validate_dflash_request(req, self.enable_overlap)
@@ -3024,6 +3102,8 @@ class Scheduler(
     def handle_embedding_request(
         self,
         recv_req: TokenizedEmbeddingReqInput,
+        *,
+        mm_input_error: Optional[str] = None,
     ):
         req = Req(
             recv_req.rid,
@@ -3043,6 +3123,15 @@ class Scheduler(
         )
         req.tokenizer = self.tokenizer
         self._maybe_namespace_elastic_radix_cache(req)
+
+        if mm_input_error is not None:
+            req.set_finish_with_abort(
+                mm_input_error,
+                status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                err_type="InternalServerError",
+            )
+            self._add_request_to_queue(req)
+            return
 
         # Handle multimodal inputs
         if recv_req.mm_inputs is not None:

--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -600,6 +600,58 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
         scheduler.flush_wrapper = SimpleNamespace(check_pending=MagicMock())
         scheduler.external_corpus_manager = None
 
+    @staticmethod
+    def _materialize_with_rank_errors(local_exception=None, remote_error=None):
+        from sglang.srt.managers import scheduler as scheduler_module
+
+        class TokenizedRequest:
+            def __init__(self):
+                self.mm_inputs = object()
+
+        scheduler = object.__new__(scheduler_module.Scheduler)
+        scheduler.dp_tp_cpu_group = object()
+        request = TokenizedRequest()
+
+        def gather_errors(errors, local_error, **_kwargs):
+            errors[:] = [local_error, remote_error]
+
+        materialize = MagicMock(
+            side_effect=local_exception,
+            return_value=object(),
+        )
+        with (
+            patch.object(
+                scheduler_module, "TokenizedGenerateReqInput", TokenizedRequest
+            ),
+            patch.object(
+                scheduler_module, "TokenizedEmbeddingReqInput", TokenizedRequest
+            ),
+            patch.object(
+                scheduler_module.MultimodalInputs,
+                "from_processor_output",
+                materialize,
+            ),
+            patch.object(
+                scheduler_module.torch.distributed, "is_available", return_value=True
+            ),
+            patch.object(
+                scheduler_module.torch.distributed,
+                "is_initialized",
+                return_value=True,
+            ),
+            patch.object(
+                scheduler_module.torch.distributed, "get_world_size", return_value=2
+            ),
+            patch.object(
+                scheduler_module.torch.distributed,
+                "all_gather_object",
+                side_effect=gather_errors,
+            ),
+        ):
+            errors = scheduler._materialize_cuda_vmm_inputs(request)
+
+        return request, errors
+
     def test_materializes_inputs_directly_before_base_dispatch(self):
         from sglang.srt.managers import scheduler as scheduler_module
 
@@ -707,6 +759,107 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
             self.assertIs(scheduler._get_multimodal_inputs(mm_inputs), mm_inputs)
 
         process_and_broadcast.assert_not_called()
+
+    def test_vmm_materialization_consensus_rejects_any_rank_failure(self):
+        cases = (
+            (None, "RuntimeError: remote failure", "rank 1: RuntimeError"),
+            (ValueError("bad proxy"), None, "rank 0: ValueError: bad proxy"),
+        )
+        for local_exception, remote_error, expected in cases:
+            with self.subTest(expected=expected):
+                request, errors = self._materialize_with_rank_errors(
+                    local_exception, remote_error
+                )
+                self.assertIn(expected, errors[0])
+                self.assertIsNone(request.mm_inputs)
+
+    def test_vmm_batch_dispatches_good_and_failed_requests_individually(self):
+        from sglang.srt.managers import scheduler as scheduler_module
+
+        class TokenizedRequest:
+            pass
+
+        class EmbeddingRequest:
+            pass
+
+        class BatchRequest:
+            def __init__(self, requests):
+                self.requests = requests
+
+            def __iter__(self):
+                return iter(self.requests)
+
+        scheduler = object.__new__(scheduler_module.Scheduler)
+        self._publish(mm_feature_transport="cuda_vmm")
+        self._prepare_scheduler(scheduler)
+        scheduler.is_fully_idle = MagicMock(return_value=True)
+        scheduler.return_health_check_ipcs = []
+        scheduler.handle_generate_request = MagicMock()
+        scheduler.handle_embedding_request = MagicMock()
+        scheduler._materialize_cuda_vmm_inputs = MagicMock(
+            return_value=[None, "reconstruction failed"]
+        )
+        requests = [TokenizedRequest(), TokenizedRequest()]
+        batch = BatchRequest(requests)
+
+        with (
+            patch.object(
+                scheduler_module, "TokenizedGenerateReqInput", TokenizedRequest
+            ),
+            patch.object(
+                scheduler_module, "TokenizedEmbeddingReqInput", EmbeddingRequest
+            ),
+            patch.object(
+                scheduler_module, "BatchTokenizedGenerateReqInput", BatchRequest
+            ),
+            patch.object(scheduler_module, "BatchTokenizedEmbeddingReqInput", tuple),
+            patch.object(
+                scheduler_module, "is_health_check_generate_req", return_value=False
+            ),
+        ):
+            scheduler.process_input_requests([batch])
+
+        self.assertEqual(
+            scheduler.handle_generate_request.call_args_list,
+            [
+                call(requests[0], mm_input_error=None),
+                call(requests[1], mm_input_error="reconstruction failed"),
+            ],
+        )
+        scheduler.handle_embedding_request.assert_not_called()
+        scheduler._request_dispatcher.assert_not_called()
+
+    def test_vmm_materialization_abort_reports_internal_error(self):
+        from sglang.srt.managers import schedule_batch
+
+        req = object.__new__(schedule_batch.Req)
+        req.rid = "request-id"
+        req.multimodal_inputs = object()
+        req.grammar = object()
+        req.origin_input_ids = [1, 2]
+        req.return_logprob = True
+        req.logprob_start_len = 0
+        req.to_finish = None
+
+        with patch.object(
+            schedule_batch, "get_parallel", return_value=SimpleNamespace(tp_rank=1)
+        ):
+            req.set_finish_with_abort(
+                "reconstruction failed",
+                status_code=500,
+                err_type="InternalServerError",
+            )
+
+        self.assertEqual(
+            req.to_finish.to_json(),
+            {
+                "type": "abort",
+                "message": "reconstruction failed",
+                "status_code": 500,
+                "err_type": "InternalServerError",
+            },
+        )
+        self.assertIsNone(req.multimodal_inputs)
 
 
 class TestVmmConsumerCount(unittest.TestCase):


### PR DESCRIPTION
## Summary

- Materialize CUDA VMM multimodal features per request.
- Exchange reconstruction errors across the request TP group.
- Abort only the failed request with an internal-error response while continuing other requests in the batch.

## Why

A rank-local VMM reconstruction exception could terminate one scheduler while peer TP ranks continued dispatching the request, causing a distributed hang and retaining unrelated requests behind it.

## Coverage

- Local and remote TP-rank reconstruction failures.
- Mixed successful and failed requests in one tokenized batch.
- Internal-error finish metadata.
- Existing CUDA IPC/VMM feature transport and lease rollback cases.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33252003788](https://github.com/sgl-project/sglang/actions/runs/33252003788)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33252003644](https://github.com/sgl-project/sglang/actions/runs/33252003644)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33252003747](https://github.com/sgl-project/sglang/actions/runs/33252003747)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->