### PR TITLE
[VLM] Broadcast multimodal preprocessing failures across TP

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -372,6 +372,16 @@ STEP_MAX_US = 2_000_000
 LOAD_STALL_REFRESH_S = 0.05
 
 
+@dataclasses.dataclass(frozen=True)
+class _MultimodalInputBroadcast:
+    inputs: Optional[MultimodalInputs] = None
+    error: Optional[str] = None
+
+
+class _MultimodalInputProcessingError(RuntimeError):
+    pass
+
+
 def _accumulate_decode_moment(
     totals: list[float],
     batch_size: int,
@@ -2411,6 +2421,11 @@ class Scheduler(
 
         Returns:
             MultimodalInputs | None
+
+        Raises:
+            _MultimodalInputProcessingError: The entry rank could not build the
+                request's multimodal inputs. The same error is broadcast to all
+                ranks before it is raised.
         """
         if raw_mm_inputs is None:
             return None
@@ -2436,18 +2451,29 @@ class Scheduler(
         # Since the Scheduler is single-threaded, any large CPU cost will impact
         # handling of other messages. For example, CPU hits 99.9% can significantly
         # increase the CUDA kernel launch time.
+        result = None
         if self.dp_tp_group.rank_in_group == 0:
-            # Only the entry rank materializes once from dict.
-            image_inputs = MultimodalInputs.from_processor_output(raw_mm_inputs)
-            # Broadcast to other TP ranks (use src=0 within the group).
+            try:
+                result = _MultimodalInputBroadcast(
+                    inputs=MultimodalInputs.from_processor_output(raw_mm_inputs)
+                )
+            except Exception as error:
+                result = _MultimodalInputBroadcast(
+                    error=(
+                        "Multimodal input processing failed on the TP entry rank: "
+                        f"{type(error).__name__}: {error}"
+                    )
+                )
+
+            # Broadcast either the prepared inputs or the request-local error.
             if group_world_size > 1:
-                obj_list = [image_inputs]
+                obj_list = [result]
                 torch.distributed.broadcast_object_list(
                     obj_list,
                     src=self.dp_tp_group.first_rank,
                     group=self.dp_tp_cpu_group,
                 )
-                image_inputs = obj_list[0]
+                result = obj_list[0]
         else:
             # Non-entry ranks: receive if group size > 1; otherwise materialize locally.
             if group_world_size > 1:
@@ -2457,11 +2483,15 @@ class Scheduler(
                     src=self.dp_tp_group.first_rank,
                     group=self.dp_tp_cpu_group,
                 )
-                image_inputs = obj_list[0]
+                result = obj_list[0]
             else:
-                image_inputs = MultimodalInputs.from_processor_output(raw_mm_inputs)
+                result = _MultimodalInputBroadcast(
+                    inputs=MultimodalInputs.from_processor_output(raw_mm_inputs)
+                )
 
-        return image_inputs
+        if result.error is not None:
+            raise _MultimodalInputProcessingError(result.error)
+        return result.inputs
 
     def _get_multimodal_inputs(self, mm_inputs):
         if isinstance(mm_inputs, MultimodalInputs):
@@ -2771,7 +2801,17 @@ class Scheduler(
 
         # Handle multimodal inputs
         if recv_req.mm_inputs is not None:
-            image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs)
+            try:
+                image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs)
+            except _MultimodalInputProcessingError as error:
+                req.set_finish_with_abort(
+                    str(error),
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    err_type="InternalServerError",
+                )
+                self.init_req_max_new_tokens(req)
+                self._add_request_to_queue(req)
+                return
 
             SessionController.adjust_mm_offsets(recv_req, req, image_inputs)
 
@@ -3135,7 +3175,16 @@ class Scheduler(
 
         # Handle multimodal inputs
         if recv_req.mm_inputs is not None:
-            image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs)
+            try:
+                image_inputs = self._get_multimodal_inputs(recv_req.mm_inputs)
+            except _MultimodalInputProcessingError as error:
+                req.set_finish_with_abort(
+                    str(error),
+                    status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+                    err_type="InternalServerError",
+                )
+                self._add_request_to_queue(req)
+                return
             # Expand a single image token into multiple dummy tokens for receiving image embeddings
             # The `pad_input_ids_func` is model-specific and may be None for
             # embedding models or models not requiring special padding.

--- a/test/registered/unit/multimodal/test_gpu_feature_transport.py
+++ b/test/registered/unit/multimodal/test_gpu_feature_transport.py
@@ -760,6 +760,120 @@ class TestSchedulerMmTransportBoundary(unittest.TestCase):
 
         process_and_broadcast.assert_not_called()
 
+    def test_broadcast_mm_inputs_sends_entry_rank_processing_error(self):
+        from sglang.srt.managers import scheduler as scheduler_module
+
+        scheduler = object.__new__(scheduler_module.Scheduler)
+        scheduler.dp_tp_group = SimpleNamespace(rank_in_group=0, first_rank=0)
+        scheduler.dp_tp_cpu_group = object()
+
+        with (
+            patch.object(
+                scheduler_module.MultimodalInputs,
+                "from_processor_output",
+                side_effect=ValueError("bad image"),
+            ),
+            patch.object(
+                scheduler_module.torch.distributed, "is_available", return_value=True
+            ),
+            patch.object(
+                scheduler_module.torch.distributed,
+                "is_initialized",
+                return_value=True,
+            ),
+            patch.object(
+                scheduler_module.torch.distributed, "get_world_size", return_value=2
+            ),
+            patch.object(
+                scheduler_module.torch.distributed, "broadcast_object_list"
+            ) as broadcast,
+            self.assertRaisesRegex(
+                scheduler_module._MultimodalInputProcessingError,
+                "ValueError: bad image",
+            ),
+        ):
+            scheduler._process_and_broadcast_mm_inputs(object())
+
+        payload = broadcast.call_args.args[0][0]
+        self.assertIn("ValueError: bad image", payload.error)
+
+    def test_broadcast_mm_inputs_peer_rank_receives_processing_error(self):
+        from sglang.srt.managers import scheduler as scheduler_module
+
+        scheduler = object.__new__(scheduler_module.Scheduler)
+        scheduler.dp_tp_group = SimpleNamespace(rank_in_group=1, first_rank=0)
+        scheduler.dp_tp_cpu_group = object()
+
+        def receive_error(obj_list, **_kwargs):
+            obj_list[0] = scheduler_module._MultimodalInputBroadcast(error="bad image")
+
+        with (
+            patch.object(
+                scheduler_module.MultimodalInputs, "from_processor_output"
+            ) as materialize,
+            patch.object(
+                scheduler_module.torch.distributed, "is_available", return_value=True
+            ),
+            patch.object(
+                scheduler_module.torch.distributed,
+                "is_initialized",
+                return_value=True,
+            ),
+            patch.object(
+                scheduler_module.torch.distributed, "get_world_size", return_value=2
+            ),
+            patch.object(
+                scheduler_module.torch.distributed,
+                "broadcast_object_list",
+                side_effect=receive_error,
+            ),
+            self.assertRaisesRegex(
+                scheduler_module._MultimodalInputProcessingError, "bad image"
+            ),
+        ):
+            scheduler._process_and_broadcast_mm_inputs(object())
+
+        materialize.assert_not_called()
+
+    def test_embedding_request_aborts_broadcast_processing_error(self):
+        from sglang.srt.managers import scheduler as scheduler_module
+
+        scheduler = object.__new__(scheduler_module.Scheduler)
+        scheduler.tokenizer = object()
+        scheduler._maybe_namespace_elastic_radix_cache = MagicMock()
+        scheduler._add_request_to_queue = MagicMock()
+        scheduler._get_multimodal_inputs = MagicMock(
+            side_effect=scheduler_module._MultimodalInputProcessingError("bad image")
+        )
+        req = MagicMock()
+        recv_req = SimpleNamespace(
+            rid="request-id",
+            input_text="prompt",
+            input_ids=[1],
+            sampling_params=object(),
+            positional_embed_overrides=None,
+            token_type_ids=None,
+            routed_dp_rank=None,
+            priority=None,
+            dimensions=None,
+            lora_id=None,
+            http_worker_ipc=None,
+            time_stats=None,
+            return_pooled_hidden_states=False,
+            multi_item_delimiter_indices=None,
+            mm_inputs=object(),
+        )
+
+        with patch.object(scheduler_module, "Req", return_value=req):
+            scheduler.handle_embedding_request(recv_req)
+
+        req.set_finish_with_abort.assert_called_once_with(
+            "bad image",
+            status_code=500,
+            err_type="InternalServerError",
+        )
+        scheduler._add_request_to_queue.assert_called_once_with(req)
+
     def test_vmm_materialization_consensus_rejects_any_rank_failure(self):
         cases = (
             (None, "RuntimeError: remote failure", "rank 1: RuntimeError"),


### PR DESCRIPTION
## Summary

- Broadcast either prepared multimodal inputs or a typed processing-error envelope from the TP entry rank.
- Convert the synchronized error into a request-level internal-error response on every rank.
- Keep generation and embedding schedulers alive for later requests.

## Why

With `--enable-broadcast-mm-inputs-process`, an exception on the TP entry rank occurred before the object broadcast. Peer ranks waited forever in `broadcast_object_list`, turning one invalid multimodal request into a distributed scheduler hang.

## Coverage

- Entry-rank processor failure and transmitted error payload.
- Peer-rank error receipt without duplicate preprocessing.
- Request-level embedding abort metadata.
- Existing CUDA IPC/VMM scheduler-boundary cases.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33252268398](https://github.com/sgl-project/sglang/actions/runs/33252268398)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33252268218](https://github.com/sgl-project/sglang/actions/runs/33252268218)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33252268322](https://github.com/sgl-project/sglang/actions/runs/33252268322)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->