### PR TITLE
Use cuda_graph_backend_prefill in scripted chunked-prefill tests

### DIFF
--- a/python/sglang/test/scripted_runtime/http_server.py
+++ b/python/sglang/test/scripted_runtime/http_server.py
@@ -231,7 +231,7 @@ def _spawn_server_process(
         kv_canary="raise",
         kv_canary_real_data="partial",
         kv_canary_sweep_interval=100,
-        disable_prefill_cuda_graph=True,
+        cuda_graph_backend_prefill="disabled",
     )
     launch_kwargs.update(engine_kwargs)
     http_port = launch_kwargs["port"]

--- a/test/manual/chunked_prefill/test_scripted_hybrid_swa.py
+++ b/test/manual/chunked_prefill/test_scripted_hybrid_swa.py
@@ -19,7 +19,7 @@ class TestSWABasic(ScriptedTestCase):
         model_path=_SWA_MODEL,
         chunked_prefill_size=DEFAULT_CHUNK_SIZE,
         mem_fraction_static=0.70,
-        disable_piecewise_cuda_graph=True,
+        cuda_graph_backend_prefill="disabled",
     )
 
     def test_naive_swa_chunked(self):
@@ -112,7 +112,7 @@ class TestSWAHalfWindowChunk(ScriptedTestCase):
         model_path=_SWA_MODEL,
         chunked_prefill_size=_SWA_WINDOW // 2,
         mem_fraction_static=0.70,
-        disable_piecewise_cuda_graph=True,
+        cuda_graph_backend_prefill="disabled",
     )
 
     def test_swa_prompt_2x_window_half_chunks(self):
@@ -134,7 +134,7 @@ class TestSWAChunkSizeExceedsWindow(ScriptedTestCase):
         model_path=_SWA_MODEL,
         chunked_prefill_size=_SWA_WINDOW * 2,
         mem_fraction_static=0.70,
-        disable_piecewise_cuda_graph=True,
+        cuda_graph_backend_prefill="disabled",
     )
 
     def test_swa_chunk_size_exceeds_window(self):
@@ -155,7 +155,7 @@ class TestSWARadix(ScriptedTestCase):
         chunked_prefill_size=DEFAULT_CHUNK_SIZE,
         mem_fraction_static=0.70,
         disable_radix_cache=False,
-        disable_piecewise_cuda_graph=True,
+        cuda_graph_backend_prefill="disabled",
     )
 
     def test_swa_radix_partial_hit_straddles_window(self):

--- a/test/manual/chunked_prefill/test_scripted_regression.py
+++ b/test/manual/chunked_prefill/test_scripted_regression.py
@@ -496,7 +496,7 @@ class TestRegressionGptOss(ScriptedTestCase):
         chunked_prefill_size=DEFAULT_CHUNK_SIZE,
         model_path="openai/gpt-oss-20b",
         mem_fraction_static=0.70,
-        disable_piecewise_cuda_graph=True,
+        cuda_graph_backend_prefill="disabled",
     )
 
     def test_chunked_stash_bounded_by_kv_committed_len(self):


### PR DESCRIPTION
## Motivation

Fixes the #36478 breakage in the scripted chunked-prefill tests: they passed
`disable_piecewise_cuda_graph`, which no longer exists as a `ServerArgs` kwarg, so every
one of these test classes raised `TypeError` at `setUpClass`.

## Modifications

- 5 call sites: `disable_piecewise_cuda_graph=True` -> `cuda_graph_backend_prefill="disabled"`,
  the same per-phase selector the deprecated CLI alias maps to.
- `scripted_runtime/http_server.py`: harness default moves to that key too, so per-test
  kwargs override it instead of duplicating it.

## Accuracy Tests

N/A - test-only kwarg spelling.

## Speed Tests and Profiling

N/A

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33252744700](https://github.com/sgl-project/sglang/actions/runs/33252744700)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33252744536](https://github.com/sgl-project/sglang/actions/runs/33252744536)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33252744736](https://github.com/sgl-project/sglang/actions/runs/33252744736)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->