### PR TITLE
[VLM][EPD] Isolate receiver startup failures across TP ranks

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -2105,6 +2105,7 @@ class MMReceiverBase(ABC):
 
     def _process_waiting_requests(self, recv_reqs, waiting_cls, **extra_kwargs):
         new_recv_reqs = []
+        abort_reqs = []
         for recv_req in recv_reqs:
             if (
                 isinstance(recv_req, TokenizedGenerateReqInput)
@@ -2117,31 +2118,82 @@ class MMReceiverBase(ABC):
                 # tokenizer never set encoder_urls (legacy / static path).
                 encode_urls = recv_req.encoder_urls or list(self.encode_urls)
 
-                waiting_req = waiting_cls(
-                    rid=recv_req.rid,
-                    recv_req=recv_req,
-                    mm_processor=self.mm_processor,
-                    encoder_urls=encode_urls,
-                    model_type=self.model_type,
-                    host_name=self.hostname,
-                    receive_count=self.tp_size,
-                    zmq_context=(
-                        None
-                        if self.scheduler_recv_socket is not None
-                        else self.scheduler_context
-                    ),
-                    embedding_port=self.scheduler_embedding_port,
-                    **extra_kwargs,
+                waiting_req = None
+                local_error = None
+                try:
+                    waiting_req = waiting_cls(
+                        rid=recv_req.rid,
+                        recv_req=recv_req,
+                        mm_processor=self.mm_processor,
+                        encoder_urls=encode_urls,
+                        model_type=self.model_type,
+                        host_name=self.hostname,
+                        receive_count=self.tp_size,
+                        zmq_context=(
+                            None
+                            if self.scheduler_recv_socket is not None
+                            else self.scheduler_context
+                        ),
+                        embedding_port=self.scheduler_embedding_port,
+                        **extra_kwargs,
+                    )
+                    if self.scheduler_recv_socket is not None:
+                        self.waiting_by_rid[waiting_req.rid] = waiting_req
+                    waiting_req.send_encode_request()
+                except Exception as error:
+                    local_error = f"{type(error).__name__}: {error}"
+                    logger.exception(
+                        "Failed to start multimodal receive for rid=%s", recv_req.rid
+                    )
+
+                # The status all-reduce below requires every TP rank to append
+                # exactly the same requests. Agree on startup before appending.
+                rank_errors = (
+                    [local_error]
+                    if self.tp_size <= 1
+                    else self.tp_group.all_gather_object(local_error)
                 )
-                if self.scheduler_recv_socket is not None:
-                    self.waiting_by_rid[waiting_req.rid] = waiting_req
-                waiting_req.send_encode_request()
+                failed_ranks = [
+                    rank for rank, error in enumerate(rank_errors) if error is not None
+                ]
+                if failed_ranks:
+                    details = "; ".join(
+                        f"rank {rank}: {rank_errors[rank]}" for rank in failed_ranks
+                    )
+                    error_msg = f"Failed to start multimodal receive ({details})"
+                    logger.error(error_msg)
+                    if waiting_req is not None:
+                        try:
+                            waiting_req.release_resources()
+                        except Exception:
+                            logger.exception(
+                                "Failed to release multimodal receive resources "
+                                "for rid=%s",
+                                waiting_req.rid,
+                            )
+                        try:
+                            waiting_req.close_recv_socket()
+                        except Exception:
+                            logger.exception(
+                                "Failed to close multimodal receive socket for rid=%s",
+                                waiting_req.rid,
+                            )
+                        self.waiting_by_rid.pop(waiting_req.rid, None)
+                    abort_reqs.append(
+                        (
+                            self.create_req(recv_req),
+                            error_msg,
+                            HTTPStatus.INTERNAL_SERVER_ERROR,
+                        )
+                    )
+                    continue
+
                 self.waiting_list.append(waiting_req)
             else:
                 new_recv_reqs.append(recv_req)
 
         if len(self.waiting_list) == 0:
-            return new_recv_reqs, []
+            return new_recv_reqs, abort_reqs
 
         self._drain_scheduler_embeddings()
         current_time = time.time()
@@ -2165,7 +2217,6 @@ class MMReceiverBase(ABC):
         )
 
         new_waiting = []
-        abort_reqs = []
         for i, waiting_req in enumerate(self.waiting_list):
             status_value = local_status[i].item()
             if status_value == WaitingMMRequestStatus.SUCCESS:

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -6,7 +6,7 @@ import time
 from array import array
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import torch
@@ -770,6 +770,84 @@ def test_epd_scheduler_routes_many_requests_over_one_receive_socket():
         sender.close(linger=0)
         receiver.scheduler_recv_socket.close(linger=0)
         context.term()
+
+
+def _receiver_for_startup_failure(rank_errors):
+    receiver = MMReceiverHTTP.__new__(MMReceiverHTTP)
+    receiver.mm_processor = object()
+    receiver.model_type = "kimi_k3"
+    receiver.hostname = "127.0.0.1"
+    receiver.tp_size = 2
+    receiver.tp_group = MagicMock()
+    receiver.tp_group.all_gather_object.side_effect = rank_errors
+    receiver.scheduler_recv_socket = object()
+    receiver.scheduler_context = object()
+    receiver.scheduler_embedding_port = 1234
+    receiver.encode_urls = ["http://encoder"]
+    receiver.waiting_by_rid = {}
+    receiver.waiting_list = []
+    receiver.create_req = MagicMock(return_value=object())
+    return receiver
+
+
+def test_epd_receiver_startup_rejects_remote_rank_failure():
+    receiver = _receiver_for_startup_failure(
+        lambda local_error: [local_error, "RuntimeError: bind failed"]
+    )
+    waiting_req = MagicMock()
+    waiting_req.rid = "request-id"
+    waiting_cls = MagicMock(return_value=waiting_req)
+
+    class TokenizedRequest:
+        rid = "request-id"
+        need_wait_for_mm_inputs = True
+        encoder_urls = ["http://encoder"]
+
+    with patch(
+        "sglang.srt.disaggregation.encoder.receiver.TokenizedGenerateReqInput",
+        TokenizedRequest,
+    ):
+        ready, aborts = receiver._process_waiting_requests(
+            [TokenizedRequest()], waiting_cls
+        )
+
+    assert ready == []
+    assert len(aborts) == 1
+    assert "rank 1: RuntimeError: bind failed" in aborts[0][1]
+    assert aborts[0][2] == 500
+    waiting_req.send_encode_request.assert_called_once_with()
+    waiting_req.release_resources.assert_called_once_with()
+    waiting_req.close_recv_socket.assert_called_once_with()
+    assert receiver.waiting_list == []
+    assert receiver.waiting_by_rid == {}
+
+
+def test_epd_receiver_startup_shares_local_constructor_failure():
+    def gather_local_error(local_error):
+        assert "RuntimeError: socket failed" in local_error
+        return [local_error, None]
+
+    receiver = _receiver_for_startup_failure(gather_local_error)
+    waiting_cls = MagicMock(side_effect=RuntimeError("socket failed"))
+
+    class TokenizedRequest:
+        rid = "request-id"
+        need_wait_for_mm_inputs = True
+        encoder_urls = ["http://encoder"]
+
+    with patch(
+        "sglang.srt.disaggregation.encoder.receiver.TokenizedGenerateReqInput",
+        TokenizedRequest,
+    ):
+        ready, aborts = receiver._process_waiting_requests(
+            [TokenizedRequest()], waiting_cls
+        )
+
+    assert ready == []
+    assert len(aborts) == 1
+    assert "rank 0: RuntimeError: socket failed" in aborts[0][1]
+    assert aborts[0][2] == 500
+    assert receiver.waiting_list == []
 
 
 def test_epd_encoder_reuses_scheduler_zmq_peer():


### PR DESCRIPTION
## Summary

- synchronize multimodal receiver startup errors across tensor-parallel scheduler ranks
- clean up locally created receive resources when any rank fails
- abort only the affected request before it enters the shared waiting list

## Why

A rank-local socket construction or synchronous encoder dispatch failure could leave TP ranks with different waiting-list lengths. The next status collective would then hang or terminate the scheduler processes instead of returning a request error.

## Coverage

- remote-rank receiver startup failure
- local receiver construction failure
- resource and receive-socket cleanup before request abort

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33253180988](https://github.com/sgl-project/sglang/actions/runs/33253180988)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33253180805](https://github.com/sgl-project/sglang/actions/runs/33253180805)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33253180950](https://github.com/sgl-project/sglang/actions/runs/33253180950)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->