### PR TITLE
[VLM][EPD] Validate requests before encoder TP dispatch

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/runtime.py
+++ b/python/sglang/srt/disaggregation/encoder/runtime.py
@@ -78,6 +78,22 @@ _BATCHABLE_MODALITIES = {Modality.IMAGE, Modality.AUDIO}
 _KIMI_K3_DEFAULT_ENCODER_MAX_BATCH_SIZE = 2
 
 
+def _validate_encode_request(req: dict) -> Optional[str]:
+    """Reject malformed requests before any encoder TP rank sees them."""
+    if not isinstance(req, dict):
+        return f"request is not a dict: {type(req).__name__}"
+    if not req.get("req_id"):
+        return "missing req_id"
+    if not req.get("mm_items"):
+        return "missing or empty mm_items"
+    if "num_parts" not in req or "part_idx" not in req:
+        return "missing num_parts / part_idx"
+    hashes = req.get("hashes")
+    if hashes is not None and not isinstance(hashes, (list, tuple, str, int, bytes)):
+        return f"hashes must be list/scalar, got {type(hashes).__name__}"
+    return None
+
+
 def _resolve_encoder_batch_policy(
     model_type: str,
     configured_max_batch_size: int,
@@ -203,25 +219,6 @@ class EncoderScheduler:
                     if not p.future.done():
                         p.future.set_exception(e)
 
-    @staticmethod
-    def _validate_request_shape(req: dict) -> Optional[str]:
-        # Cheap pre-broadcast checks: shape errors that don't require running
-        # the HF processor. Once a request reaches TP workers they enter
-        # batch_encode and expect to join its collectives — a malformed batch
-        # that makes rank-0 bail mid-flight would deadlock the workers.
-        if not isinstance(req, dict):
-            return f"request is not a dict: {type(req).__name__}"
-        if not req.get("req_id"):
-            return "missing req_id"
-        if not req.get("mm_items"):
-            return "missing or empty mm_items"
-        if "num_parts" not in req or "part_idx" not in req:
-            return "missing num_parts / part_idx"
-        h = req.get("hashes")
-        if h is not None and not isinstance(h, (list, tuple, str, int, bytes)):
-            return f"hashes must be list/scalar, got {type(h).__name__}"
-        return None
-
     async def _dispatch_group(
         self, group: List[PendingRequest], modality: Modality
     ) -> None:
@@ -241,7 +238,7 @@ class EncoderScheduler:
         # abandoned.
         valid: List[PendingRequest] = []
         for p in group:
-            err = self._validate_request_shape(p.request)
+            err = _validate_encode_request(p.request)
             if err is None:
                 valid.append(p)
                 continue
@@ -1077,6 +1074,9 @@ async def execute_encode_pipeline(
     and keeps the result until follow-up /send calls complete. ZMQ has no early
     consumer: it waits for encode, sends the embedding, releases it, then returns.
     """
+    if error := _validate_encode_request(request):
+        raise server_module.BadRequestError(error)
+
     req_id = request["req_id"]
     time_stats_json = request.pop("time_stats_json", None)
     time_stats = EncoderReqTimeStats()

--- a/test/registered/unit/disaggregation/test_encoder_scheduler.py
+++ b/test/registered/unit/disaggregation/test_encoder_scheduler.py
@@ -1,5 +1,6 @@
 import asyncio
 import sys
+from unittest.mock import patch
 
 import pytest
 
@@ -7,7 +8,9 @@ from sglang.srt.disaggregation.encoder.runtime import (
     EncoderScheduler,
     PendingRequest,
     _resolve_encoder_batch_policy,
+    execute_encode_pipeline,
 )
+from sglang.srt.disaggregation.encoder.server import BadRequestError
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
@@ -104,6 +107,28 @@ def test_scheduler_coalesces_concurrent_submissions():
 
         assert encoder.batches == [["image-0", "image-1"]]
         assert results == [(1, 2, 3, None, None)] * 2
+
+    asyncio.run(run_test())
+
+
+def test_pipeline_rejects_malformed_video_before_tp_dispatch():
+    async def run_test():
+        request = {
+            "req_id": "bad-video",
+            "modality": "video",
+            "num_parts": 1,
+            "part_idx": 0,
+        }
+        with patch("sglang.srt.disaggregation.encoder.runtime.sock_send") as send_mock:
+            with pytest.raises(BadRequestError, match="missing or empty mm_items"):
+                await execute_encode_pipeline(
+                    enc=object(),
+                    sched=None,
+                    request=request,
+                    send_sockets=[object()],
+                )
+
+        send_mock.assert_not_called()
 
     asyncio.run(run_test())
 


### PR DESCRIPTION
## Summary

- reuse one structural validator for all multimodal encoder requests
- reject malformed image, audio, and video requests before TP dispatch
- keep invalid requests out of encoder collectives

## Why

Video requests bypass the image/audio batch scheduler. A malformed video request could therefore be sent to encoder TP followers before rank 0 discovered a missing field, terminating a follower process instead of returning a request-level error.

## Coverage

- non-batchable video requests with missing media
- no TP socket dispatch after validation failure
- existing image/audio batch validation

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33253500051](https://github.com/sgl-project/sglang/actions/runs/33253500051)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33253499919](https://github.com/sgl-project/sglang/actions/runs/33253499919)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33253500073](https://github.com/sgl-project/sglang/actions/runs/33253500073)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->