### PR TITLE
[MLX] Fix startup crash when reporting preloaded weights

### DIFF
--- a/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
+++ b/python/sglang/srt/hardware_backend/mlx/model_runner_stub.py
@@ -107,6 +107,16 @@ class MlxModelRunnerStub(ModelRunner):
     # that path working instead of raising AttributeError.
     prefill_aware_swa = False
 
+    @property
+    def preloaded_weights_bytes(self) -> int:
+        """Return zero for the base Torch loader accounting hook.
+
+        The native MLX runner materializes weights before sizing its own KV
+        pool. This stub has no Torch ``ModelLoader`` or Torch-owned weights to
+        report.
+        """
+        return 0
+
     @staticmethod
     def validate_startup_weight_load_mode(server_args) -> None:
         if server_args.is_startup_weight_load_overlap:

--- a/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
+++ b/test/registered/unit/hardware_backend/mlx/test_mlx_runner_pool_contract.py
@@ -11,8 +11,11 @@ attention backend named by ``server_args.attention_backend``; MLX never
 uses one, and some backends read real KV buffers in ``__init__``, which
 crashes on ``_DummyKVCache``.
 
-The checks are signature/identity-only and MLX-gated because importing
-the stub pulls in ``mlx.core``.
+The base ``preloaded_weights_bytes`` property reads the Torch model loader.
+The MLX stub never creates one because its native runner owns model loading
+and KV sizing, so it must report zero for the Torch accounting hook.
+
+The checks are MLX-gated because importing the stub pulls in ``mlx.core``.
 """
 
 from __future__ import annotations
@@ -22,6 +25,7 @@ import inspect
 import unittest
 
 from sglang.test.ci.ci_register import register_cpu_ci, register_mlx_ci
+from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=1, suite="base-a-test-cpu")
 register_mlx_ci(est_time=1, suite="stage-a-unit-test-mlx")
@@ -35,8 +39,15 @@ if _HAS_MLX:
 
 
 @unittest.skipUnless(_HAS_MLX, _SKIP_REASON)
-class TestMlxRunnerPoolContract(unittest.TestCase):
-    """``MlxModelRunnerStub.alloc_memory_pool`` must override the base."""
+class TestMlxRunnerPoolContract(CustomTestCase):
+    """Guard the stub's scheduler-facing ``ModelRunner`` contracts."""
+
+    def test_stub_reports_no_preloaded_torch_weights(self):
+        runner = object.__new__(MlxModelRunnerStub)
+        runner.pre_model_load_memory = 1.0
+        self.assertEqual(runner.preloaded_weights_bytes, 0)
+        runner.account_preloaded_weights(runner.preloaded_weights_bytes)
+        self.assertEqual(runner.pre_model_load_memory, 1.0)
 
     def test_stub_overrides_base_alloc_memory_pool(self):
         self.assertIn(


### PR DESCRIPTION
## Motivation

I hit an MLX startup crash after #34053. The scheduler reads `preloaded_weights_bytes`, but the inherited property accesses `self.loader`. `MlxModelRunnerStub` intentionally has no Torch `ModelLoader`.

Fixes #37031.

## Modifications

- Report 0 bytes for the base Torch loader accounting hook.
- Document why this is correct: the native MLX runner materializes weights before sizing its own KV pool.
- Add a regression test using the registered-test `CustomTestCase`.

## Accuracy Tests

Not applicable. Model outputs are unchanged.

## Speed Tests and Profiling

Not applicable. The inference path is unchanged.

## Tests

- `SGLANG_USE_MLX=1 uv run --python 3.12 python -m pytest -q test/registered/unit/hardware_backend/mlx` — 221 passed, 4 skipped, 23 subtests passed
- `uvx pre-commit run --files ...` — passed
- Manual MLX startup and generation with `HuggingFaceTB/SmolLM2-135M-Instruct`

## Checklist

- [x] Formatting and pre-commit checks pass.
- [x] Added a unit test.
- [x] No documentation change is needed.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Followed the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33253560035](https://github.com/sgl-project/sglang/actions/runs/33253560035)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33253559941](https://github.com/sgl-project/sglang/actions/runs/33253559941)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33253560015](https://github.com/sgl-project/sglang/actions/runs/33253560015)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->