### PR TITLE
[VLM][EPD] Fail gRPC receive registration promptly

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -1200,6 +1200,12 @@ class WaitingZmqRequestGrpc(WaitingZmqRequest):
                     logger.error(f"Request {i} failed: {result}")
                 else:
                     logger.debug(f"Request {i} succeeded.")
+            failed = [result for result in results if isinstance(result, BaseException)]
+            if failed:
+                self._fail_and_release(
+                    f"Failed to register receive URL with encoder: {failed[0]!r}",
+                    int(HTTPStatus.BAD_GATEWAY),
+                )
 
         asyncio.run(
             send_embedding_port(

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -6,7 +6,7 @@ import time
 from array import array
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 import torch
@@ -24,6 +24,7 @@ from sglang.srt.disaggregation.encoder.receiver import (
     EmbeddingData,
     MMReceiverHTTP,
     MultiModalEmbeddingData,
+    WaitingZmqRequestGrpc,
     _encoder_media_item,
     _select_mm_processor_prompt,
 )
@@ -770,6 +771,27 @@ def test_epd_scheduler_routes_many_requests_over_one_receive_socket():
         sender.close(linger=0)
         receiver.scheduler_recv_socket.close(linger=0)
         context.term()
+
+
+def test_epd_grpc_registration_failure_aborts_without_waiting_for_timeout():
+    waiting_req = WaitingZmqRequestGrpc.__new__(WaitingZmqRequestGrpc)
+    waiting_req.num_items_assigned = {Modality.IMAGE: [1]}
+    waiting_req.encoder_urls = ["grpc://127.0.0.1:1234"]
+    waiting_req.recv_req = SimpleNamespace(rid="request-id")
+    waiting_req.receive_count = 1
+    waiting_req.host_name = "127.0.0.1"
+    waiting_req.embedding_port = 4321
+    waiting_req._fail_and_release = MagicMock()
+
+    with patch(
+        "sglang.srt.disaggregation.encoder.receiver._grpc_scheduler_receive_url",
+        side_effect=RuntimeError("registration failed"),
+    ):
+        waiting_req.send_encode_request()
+
+    error_msg, error_code = waiting_req._fail_and_release.call_args.args
+    assert "registration failed" in error_msg
+    assert error_code == 502
 
 
 def test_epd_encoder_reuses_scheduler_zmq_peer():


### PR DESCRIPTION
## Summary

- mark an EPD gRPC receive request failed when destination registration fails
- release its receiver resources immediately
- reuse the existing TP-wide request failure path

## Why

The HTTP receiver path already terminalizes failed destination registration. The gRPC path only logged the exception and left the request pending, so all decoder TP ranks could wait until the full encoder timeout after a known registration failure.

## Coverage

- gRPC SchedulerReceiveUrl failure
- immediate BAD_GATEWAY request status
- receiver resource cleanup through the common failure path

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33253694360](https://github.com/sgl-project/sglang/actions/runs/33253694360)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33253694213](https://github.com/sgl-project/sglang/actions/runs/33253694213)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33253694345](https://github.com/sgl-project/sglang/actions/runs/33253694345)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->