### PR TITLE
[BugFix] Handle CPU-only and XPU environments in check_env

### DIFF
--- a/python/sglang/check_env.py
+++ b/python/sglang/check_env.py
@@ -2,6 +2,7 @@
 
 import importlib.metadata
 import os
+import platform
 import resource
 import subprocess
 import sys
@@ -10,7 +11,7 @@ from collections import OrderedDict, defaultdict
 
 import torch
 
-from sglang.srt.utils import is_hip, is_mps, is_musa, is_npu
+from sglang.srt.utils import is_hip, is_mps, is_musa, is_npu, is_xpu
 
 
 def is_cuda_v2():
@@ -138,6 +139,19 @@ class BaseEnv:
 
         for k, v in env_info.items():
             print(f"{k}: {v}")
+
+
+class CPUEnv(BaseEnv):
+    """Environment checker for CPU-only systems."""
+
+    def get_info(self):
+        return {
+            "CPU Architecture": platform.machine(),
+            "CPU Count": os.cpu_count(),
+        }
+
+    def get_topology(self):
+        return {}
 
 
 class GPUEnv(BaseEnv):
@@ -294,6 +308,31 @@ class HIPEnv(BaseEnv):
             }
         except subprocess.SubprocessError:
             return {}
+
+
+class XPUEnv(BaseEnv):
+    """Environment checker for Intel XPU."""
+
+    def get_info(self):
+        xpu_info = {"XPU available": torch.xpu.is_available()}
+
+        if xpu_info["XPU available"]:
+            xpu_info["XPU count"] = torch.xpu.device_count()
+            xpu_info.update(self.get_device_info())
+
+        return xpu_info
+
+    def get_device_info(self):
+        devices = defaultdict(list)
+        for k in range(torch.xpu.device_count()):
+            devices[torch.xpu.get_device_name(k)].append(str(k))
+
+        return {
+            f"XPU {','.join(device_ids)}": name for name, device_ids in devices.items()
+        }
+
+    def get_topology(self):
+        return {}
 
 
 class NPUEnv(BaseEnv):
@@ -580,15 +619,21 @@ class MPSEnv(BaseEnv):
         return {}
 
 
-if __name__ == "__main__":
+def _get_env():
     if is_cuda_v2():
-        env = GPUEnv()
-    elif is_hip():
-        env = HIPEnv()
-    elif is_npu():
-        env = NPUEnv()
-    elif is_musa():
-        env = MUSAEnv()
-    elif is_mps():
-        env = MPSEnv()
-    env.check_env()
+        return GPUEnv()
+    if is_hip():
+        return HIPEnv()
+    if is_npu():
+        return NPUEnv()
+    if is_musa():
+        return MUSAEnv()
+    if is_xpu():
+        return XPUEnv()
+    if is_mps():
+        return MPSEnv()
+    return CPUEnv()
+
+
+if __name__ == "__main__":
+    _get_env().check_env()

--- a/test/registered/unit/test_check_env.py
+++ b/test/registered/unit/test_check_env.py
@@ -1,0 +1,57 @@
+"""Regression tests for environment checker backend selection."""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import sglang.check_env as check_env
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestCheckEnvBackendSelection(CustomTestCase):
+    def _get_env(self, *, xpu_available: bool):
+        predicates = {
+            "is_cuda_v2": False,
+            "is_hip": False,
+            "is_npu": False,
+            "is_musa": False,
+            "is_xpu": xpu_available,
+            "is_mps": False,
+        }
+        with patch.multiple(
+            check_env,
+            **{name: Mock(return_value=value) for name, value in predicates.items()},
+        ):
+            return check_env._get_env()
+
+    def test_cpu_fallback_without_accelerator(self):
+        """CPU-only environments must still select a checker instead of crashing."""
+        self.assertIsInstance(
+            self._get_env(xpu_available=False),
+            check_env.CPUEnv,
+        )
+
+    def test_xpu_backend_selection(self):
+        """An available Intel XPU must select its checker instead of falling through."""
+        xpu = Mock()
+        xpu.is_available.return_value = True
+        xpu.device_count.return_value = 2
+        xpu.get_device_name.side_effect = ["Intel GPU", "Intel GPU"]
+
+        with patch.object(check_env.torch, "xpu", xpu, create=True):
+            env = self._get_env(xpu_available=True)
+            self.assertIsInstance(env, check_env.XPUEnv)
+            self.assertEqual(
+                env.get_info(),
+                {
+                    "XPU available": True,
+                    "XPU count": 2,
+                    "XPU 0,1": "Intel GPU",
+                },
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`python -m sglang.check_env` leaves `env` undefined when no existing accelerator predicate matches. This crashes on CPU-only installations and on Intel XPU hosts because the dispatcher has neither a CPU fallback nor an XPU branch.

Related to #35144, which reports the XPU form of this failure.

The closed, unmerged draft #29568 previously proposed the CPU fallback. This PR carries that fallback forward and additionally adds Intel XPU selection and device reporting, with tests following the current `CustomTestCase` requirement.

## Modifications

- Add `CPUEnv` to report CPU architecture and logical CPU count.
- Add `XPUEnv` to report XPU availability, device count, and grouped device names.
- Reuse the existing `is_xpu()` platform predicate in environment selection.
- Move backend selection into `_get_env()` and always return a checker, falling back to `CPUEnv`.
- Add CPU CI regression coverage for CPU-only fallback and mocked XPU selection/device enumeration.

## Accuracy Tests

N/A. This only changes environment diagnostics and does not affect model outputs.

## Speed Tests and Profiling

N/A. No inference or performance-critical path is changed.

## Tests

- CPU regression test file: 2 tests passed with dependency-isolated imports.
- `python3 -m py_compile python/sglang/check_env.py test/registered/unit/test_check_env.py`
- `ruff check --select=F401,F821,UP037 python/sglang/check_env.py test/registered/unit/test_check_env.py`
- `black --check python/sglang/check_env.py test/registered/unit/test_check_env.py`
- `isort --check-only --settings-path .isort.cfg python/sglang/check_env.py test/registered/unit/test_check_env.py`
- CI registration parser: `base-a-test-cpu`, main entry present.
- `git diff origin/main...HEAD --check`

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html). (N/A: no user-facing interface changes.)
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html). (N/A: diagnostics-only change.)
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33253812907](https://github.com/sgl-project/sglang/actions/runs/33253812907)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33253812700](https://github.com/sgl-project/sglang/actions/runs/33253812700)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33253812977](https://github.com/sgl-project/sglang/actions/runs/33253812977)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->