### PR TITLE
[VLM][EPD] Drop malformed shared embedding frames

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -732,6 +732,34 @@ def extract_original_req_id(part_req_id: str) -> str:
     return part_req_id
 
 
+def _embedding_part_matches_request(
+    embedding_data: object, expected_req_id: str
+) -> bool:
+    """Normalize a matching part ID; reject stale data from a reused socket."""
+    if not isinstance(embedding_data, EmbeddingData):
+        logger.warning(
+            "Dropping non-embedding data for expected rid=%s", expected_req_id
+        )
+        return False
+    if not isinstance(embedding_data.req_id, str):
+        logger.warning(
+            "Dropping embedding data with a non-string req_id for expected rid=%s",
+            expected_req_id,
+        )
+        return False
+    original_req_id = extract_original_req_id(embedding_data.req_id)
+    if original_req_id != expected_req_id:
+        logger.warning(
+            "Dropping stale embedding data: expected rid=%s, got rid=%s "
+            "(likely from ZMQ port reuse)",
+            expected_req_id,
+            embedding_data.req_id,
+        )
+        return False
+    embedding_data.req_id = original_req_id
+    return True
+
+
 def _encoder_media_item(mm_item: dict):
     """Keep per-media options aligned while preserving the legacy URL shape."""
     item = {
@@ -860,14 +888,14 @@ class WaitingMMRequestBase(ABC):
 
         try:
             recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
+            if not self._is_valid_embedding_part(recv_obj):
+                return
             if getattr(recv_obj, "error_msg", None) is not None:
                 logger.warning(
                     f"Received error signal from encoder for {self.rid}: "
                     f"{recv_obj.error_msg} {recv_obj.error_code = }"
                 )
                 self._fail_and_release(recv_obj.error_msg, recv_obj.error_code)
-                return
-            if not self._is_valid_embedding_part(recv_obj):
                 return
             # ZMQ materializes frame 1; RDMA already wrote the registered buffer.
             self._extract_embedding_from_buffer(recv_obj, parts)
@@ -910,15 +938,7 @@ class WaitingMMRequestBase(ABC):
 
     def _is_valid_embedding_part(self, recv_obj) -> bool:
         """Check for and drop stale or out-of-sync payloads; normalize the part req_id to the original rid."""
-        original_req_id = extract_original_req_id(recv_obj.req_id)
-        if original_req_id != self.recv_req.rid:
-            logger.warning(
-                f"Dropping stale embedding data: expected rid={self.recv_req.rid}, "
-                f"got rid={recv_obj.req_id} (likely from ZMQ port reuse)"
-            )
-            return False
-        recv_obj.req_id = original_req_id
-        return True
+        return _embedding_part_matches_request(recv_obj, self.recv_req.rid)
 
     @abstractmethod
     def _extract_embedding_from_buffer(self, recv_obj, parts) -> None:
@@ -1967,6 +1987,8 @@ class MMReceiverBase(ABC):
                 if not parts:
                     continue
                 recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
+                if not _embedding_part_matches_request(recv_obj, req_id):
+                    continue
                 if getattr(recv_obj, "error_msg", None) is not None:
                     logger.warning(
                         f"Encoder error for req_id={req_id}: {recv_obj.error_msg} "
@@ -1974,8 +1996,6 @@ class MMReceiverBase(ABC):
                     )
                     return None
                 logger.debug("recv_obj=%s", recv_obj)
-                # Normalize the part req_id to the original for aggregation.
-                recv_obj.req_id = extract_original_req_id(recv_obj.req_id)
                 if len(parts) < 2:
                     logger.error(
                         "zmq_to_tokenizer expected 2-part message, got %d parts",

--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -732,32 +732,39 @@ def extract_original_req_id(part_req_id: str) -> str:
     return part_req_id
 
 
-def _embedding_part_matches_request(
-    embedding_data: object, expected_req_id: str
-) -> bool:
-    """Normalize a matching part ID; reject stale data from a reused socket."""
+def _resolve_embedding_part_request_id(
+    embedding_data: object, expected_req_id: Optional[str] = None
+) -> Optional[str]:
+    """Validate and normalize an embedding part ID for safe routing."""
+    expected = (
+        f" for expected rid={expected_req_id}" if expected_req_id is not None else ""
+    )
     if not isinstance(embedding_data, EmbeddingData):
-        logger.warning(
-            "Dropping non-embedding data for expected rid=%s", expected_req_id
-        )
-        return False
+        logger.warning("Dropping non-embedding data%s", expected)
+        return None
     if not isinstance(embedding_data.req_id, str):
-        logger.warning(
-            "Dropping embedding data with a non-string req_id for expected rid=%s",
-            expected_req_id,
-        )
-        return False
+        logger.warning("Dropping embedding data with a non-string req_id%s", expected)
+        return None
     original_req_id = extract_original_req_id(embedding_data.req_id)
-    if original_req_id != expected_req_id:
+    if expected_req_id is not None and original_req_id != expected_req_id:
         logger.warning(
             "Dropping stale embedding data: expected rid=%s, got rid=%s "
             "(likely from ZMQ port reuse)",
             expected_req_id,
             embedding_data.req_id,
         )
-        return False
+        return None
     embedding_data.req_id = original_req_id
-    return True
+    return original_req_id
+
+
+def _embedding_part_matches_request(
+    embedding_data: object, expected_req_id: str
+) -> bool:
+    """Normalize a matching part ID; reject stale data from a reused socket."""
+    return (
+        _resolve_embedding_part_request_id(embedding_data, expected_req_id) is not None
+    )
 
 
 def _encoder_media_item(mm_item: dict):
@@ -2113,8 +2120,18 @@ class MMReceiverBase(ABC):
             except zmq.Again:
                 return
 
-            recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
-            rid = extract_original_req_id(recv_obj.req_id)
+            try:
+                recv_obj: EmbeddingData = safe_pickle_loads(parts[0])
+            except Exception as error:
+                logger.warning(
+                    "Dropping malformed embedding data from the shared "
+                    "scheduler socket: %s",
+                    error,
+                )
+                continue
+            rid = _resolve_embedding_part_request_id(recv_obj)
+            if rid is None:
+                continue
             waiting_req = self.waiting_by_rid.get(rid)
             if waiting_req is None:
                 logger.warning(

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -6,7 +6,7 @@ import time
 from array import array
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import torch
@@ -24,6 +24,8 @@ from sglang.srt.disaggregation.encoder.receiver import (
     EmbeddingData,
     MMReceiverHTTP,
     MultiModalEmbeddingData,
+    WaitingMMRequestStatus,
+    WaitingZmqRequest,
     _encoder_media_item,
     _select_mm_processor_prompt,
 )
@@ -732,6 +734,80 @@ def test_epd_scheduler_uses_token_ids_for_tokenized_mm_processors():
         )
         == "unexpanded prompt"
     )
+
+
+def test_epd_scheduler_ignores_foreign_error_part():
+    waiting = WaitingZmqRequest.__new__(WaitingZmqRequest)
+    waiting.rid = "current"
+    waiting.recv_req = SimpleNamespace(rid="current")
+    waiting.status = WaitingMMRequestStatus.PENDING
+    waiting._fail_and_release = Mock()
+    stale_error = EmbeddingData(
+        req_id="stale_local_part_0",
+        num_parts=1,
+        part_idx=0,
+        grid_dim=None,
+        modality=Modality.IMAGE,
+        error_msg="stale failure",
+        error_code=500,
+    )
+
+    waiting.consume_parts([pickle.dumps("not embedding data")])
+    waiting.consume_parts([pickle.dumps(stale_error)])
+
+    assert waiting.status == WaitingMMRequestStatus.PENDING
+    waiting._fail_and_release.assert_not_called()
+
+
+def test_epd_tokenizer_ignores_foreign_part_before_current_embedding():
+    class FakeSocket:
+        def __init__(self, messages):
+            self.messages = list(messages)
+            self.closed = False
+
+        async def recv_multipart(self, copy=False):
+            return self.messages.pop(0)
+
+        def close(self):
+            self.closed = True
+
+    async def run_test():
+        stale_error = EmbeddingData(
+            req_id="stale_local_part_0",
+            num_parts=1,
+            part_idx=0,
+            grid_dim=None,
+            modality=Modality.IMAGE,
+            error_msg="stale failure",
+            error_code=500,
+        )
+        embedding = torch.tensor([[1.0, 2.0]])
+        current = EmbeddingData(
+            req_id="current_local_part_0",
+            num_parts=1,
+            part_idx=0,
+            grid_dim=None,
+            modality=Modality.IMAGE,
+            embedding=embedding,
+        )
+        socket = FakeSocket(
+            [
+                [pickle.dumps(stale_error)],
+                [pickle.dumps(current.copy_without_embedding()), embedding.numpy()],
+            ]
+        )
+        receiver = MMReceiverHTTP.__new__(MMReceiverHTTP)
+        receiver.model_type = None
+        processor = SimpleNamespace(
+            get_mm_data=lambda _prompt, embeddings, **_kwargs: embeddings
+        )
+
+        result = await receiver._recv_mm_data("current", socket, processor, "prompt")
+
+        torch.testing.assert_close(result[Modality.IMAGE], embedding)
+        assert socket.closed
+
+    asyncio.run(run_test())
 
 
 def test_epd_scheduler_routes_many_requests_over_one_receive_socket():

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -825,6 +825,8 @@ def test_epd_scheduler_routes_many_requests_over_one_receive_socket():
     sender = context.socket(zmq.PUSH)
     try:
         sender.connect(f"tcp://127.0.0.1:{port}")
+        sender.send_multipart([b"not a pickle"])
+        sender.send_multipart([pickle.dumps("not embedding data")])
         for i in range(32):
             mm_data = EmbeddingData(
                 req_id=f"rid-{i}_local_part_0",


### PR DESCRIPTION
## Summary

- validate shared-socket embedding envelopes before request routing
- drop payloads that cannot be safely deserialized or identified
- extend the request-ID validator introduced by #37020

## Why

The shared scheduler socket deserialized each frame and read `req_id` before entering the existing request-local `consume_parts` exception boundary. A malformed pickle or non-embedding object could therefore escape the scheduler tick and terminate the process.

## Coverage

- malformed pickle frames
- deserializable non-embedding frames
- valid frames following invalid frames on the same shared socket

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33254163868](https://github.com/sgl-project/sglang/actions/runs/33254163868)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33254163753](https://github.com/sgl-project/sglang/actions/runs/33254163753)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33254163988](https://github.com/sgl-project/sglang/actions/runs/33254163988)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->