### PR TITLE
[Diffusion] Infer replacement transformer quantization

### DIFF
--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -150,6 +150,11 @@ to override the method inferred by the transformer loader, and
 `--quantization-ignored-layers` to keep matching transformer layers
 unquantized during online quantization.
 
+For a replacement transformer weight set, an adjacent `config.json` and
+safetensors quantization metadata take precedence over the base component.
+Compatible serialized formats are inferred automatically; do not combine them
+with an online `--quantization` override.
+
 For a native text encoder:
 
 - `--component-paths.text_encoder {MODEL}` replaces the text-encoder checkpoint; `--text-encoder-path {MODEL}` is its shorter alias

--- a/python/sglang/multimodal_gen/configs/models/dits/base.py
+++ b/python/sglang/multimodal_gen/configs/models/dits/base.py
@@ -26,6 +26,7 @@ class DiTArchConfig(ArchConfig):
 
     # Reverse mapping for saving checkpoints: custom -> hf
     reverse_param_names_mapping: dict = field(default_factory=dict)
+    quant_ignore_remap: dict = field(default_factory=dict)
     hidden_size: int = 0
     num_attention_heads: int = 0
     num_channels_latents: int = 0

--- a/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
+++ b/python/sglang/multimodal_gen/runtime/loader/transformer_load_utils.py
@@ -920,6 +920,8 @@ def _build_transformer_quant_adapters(
 
 def _resolve_quant_config_from_transformer_override(
     override_config_path: str,
+    reverse_param_names_mapping: dict | None = None,
+    quant_ignore_remap: dict | None = None,
 ) -> Optional[QuantizationConfig]:
     """Resolve quant config from an override transformer repo or directory."""
     with open(override_config_path, encoding="utf-8") as f:
@@ -928,6 +930,8 @@ def _resolve_quant_config_from_transformer_override(
     return get_quant_config(
         override_hf_config,
         os.path.dirname(override_config_path),
+        reverse_param_names_mapping=reverse_param_names_mapping,
+        quant_ignore_remap=quant_ignore_remap,
     )
 
 
@@ -943,8 +947,38 @@ def _resolve_quant_config(
     resolve quant config from checkpoints' metadata
     priority: explicit --quantization flag -> model config.json -> safetensors metadata -> format-specific fallback
     """
+    arch_config = server_args.pipeline_config.dit_config.arch_config
+    param_names_mapping_dict = arch_config.param_names_mapping
+    reverse_param_names_mapping_dict = arch_config.reverse_param_names_mapping
+    quant_ignore_remap_dict = arch_config.quant_ignore_remap
+
+    replacement_quant_config = None
+    has_replacement_weights = (
+        server_args.transformer_weights_path is not None
+        and server_args.nunchaku_config is None
+    )
+    if has_replacement_weights:
+        if transformer_override_config_path is not None:
+            replacement_quant_config = _resolve_quant_config_from_transformer_override(
+                transformer_override_config_path,
+                reverse_param_names_mapping_dict,
+                quant_ignore_remap_dict,
+            )
+        if replacement_quant_config is None:
+            for safetensors_file in safetensors_list:
+                replacement_quant_config = get_quant_config_from_safetensors_metadata(
+                    safetensors_file
+                )
+                if replacement_quant_config is not None:
+                    break
+
     # priority: explicit --quantization flag (e.g. mxfp8, mxfp4_npu, modelslim)
     if server_args.quantization is not None:
+        if replacement_quant_config is not None:
+            raise ValueError(
+                "Replacement checkpoint already declares quantization; do not also "
+                "set an online --quantization override"
+            )
         from sglang.multimodal_gen.runtime.layers.quantization import (
             get_quantization_config,
         )
@@ -976,24 +1010,15 @@ def _resolve_quant_config(
             )
         return quant_cls(**quant_kwargs)
 
-    quant_config = get_quant_config(hf_config, component_model_path)
-    if quant_config is None and server_args.transformer_weights_path:
-        for safetensors_file in safetensors_list:
-            quant_config = get_quant_config_from_safetensors_metadata(safetensors_file)
-            if quant_config is not None:
-                return quant_config
-
-    arch_config = server_args.pipeline_config.dit_config.arch_config
-    param_names_mapping_dict = arch_config.param_names_mapping
-    reverse_param_names_mapping_dict = getattr(
-        arch_config, "reverse_param_names_mapping", None
-    )
-    quant_ignore_remap_dict = getattr(arch_config, "quant_ignore_remap", None)
-    quant_config = get_quant_config(
-        hf_config,
-        component_model_path,
-        reverse_param_names_mapping=reverse_param_names_mapping_dict,
-        quant_ignore_remap=quant_ignore_remap_dict,
+    quant_config = (
+        replacement_quant_config
+        if has_replacement_weights
+        else get_quant_config(
+            hf_config,
+            component_model_path,
+            reverse_param_names_mapping=reverse_param_names_mapping_dict,
+            quant_ignore_remap=quant_ignore_remap_dict,
+        )
     )
     quant_config_name = _get_quant_config_name(quant_config)
     inferred_nvfp4_config = None
@@ -1008,22 +1033,7 @@ def _resolve_quant_config(
             fallback_group_size,
         )
     quant_config = _merge_modelopt_fp4_configs(quant_config, inferred_nvfp4_config)
-    if quant_config is not None or transformer_override_config_path is None:
-        return quant_config
-
-    quant_config = _resolve_quant_config_from_transformer_override(
-        transformer_override_config_path,
-    )
-    quant_config = _merge_modelopt_fp4_configs(quant_config, inferred_nvfp4_config)
-    if quant_config is not None:
-        return quant_config
-
-    for safetensors_file in safetensors_list:
-        quant_config = get_quant_config_from_safetensors_metadata(safetensors_file)
-        if quant_config is not None:
-            return quant_config
-
-    return inferred_nvfp4_config
+    return quant_config
 
 
 def _resolve_target_param_dtype(

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -148,6 +148,105 @@ def _make_quant_config(name: str, **attrs):
 
 
 class TestTransformerQuantHelpers(unittest.TestCase):
+    def _make_server_args(self, **overrides):
+        defaults = dict(
+            transformer_weights_path=None,
+            pipeline_config=SimpleNamespace(
+                dit_precision="bf16",
+                dit_config=SimpleNamespace(
+                    arch_config=SimpleNamespace(
+                        param_names_mapping={},
+                        reverse_param_names_mapping={},
+                        quant_ignore_remap={},
+                    )
+                ),
+            ),
+            nunchaku_config=None,
+            quantization=None,
+            quantization_ignored_layers=None,
+            revision="test-revision",
+            tp_size=1,
+            dit_cpu_offload=False,
+            direct_gpu_weight_loading=False,
+            text_encoder_cpu_offload=False,
+        )
+        defaults.update(overrides)
+        return SimpleNamespace(**defaults)
+
+    def test_replacement_config_overrides_base_quantization(self):
+        with tempfile.TemporaryDirectory() as directory:
+            weights = f"{directory}/model.safetensors"
+            config = f"{directory}/config.json"
+            save_file({"block.weight": torch.ones((2, 2))}, weights)
+            with open(config, "w", encoding="utf-8") as stream:
+                json.dump(
+                    {
+                        "quantization_config": {
+                            "quant_method": "fp8",
+                            "activation_scheme": "dynamic",
+                        }
+                    },
+                    stream,
+                )
+
+            quant_config = _resolve_quant_config(
+                hf_config={
+                    "quantization_config": {
+                        "quant_method": "fp8",
+                        "activation_scheme": "static",
+                    }
+                },
+                server_args=self._make_server_args(transformer_weights_path=weights),
+                safetensors_list=[weights],
+                component_model_path="/base",
+                transformer_override_config_path=config,
+            )
+
+        self.assertIsInstance(quant_config, Fp8Config)
+        self.assertEqual(quant_config.activation_scheme, "dynamic")
+
+    def test_unquantized_replacement_does_not_inherit_base_quantization(self):
+        with tempfile.TemporaryDirectory() as directory:
+            weights = f"{directory}/model.safetensors"
+            config = f"{directory}/config.json"
+            save_file({"block.weight": torch.ones((2, 2))}, weights)
+            with open(config, "w", encoding="utf-8") as stream:
+                json.dump({}, stream)
+
+            quant_config = _resolve_quant_config(
+                hf_config={"quantization_config": {"quant_method": "fp8"}},
+                server_args=self._make_server_args(transformer_weights_path=weights),
+                safetensors_list=[weights],
+                component_model_path="/base",
+                transformer_override_config_path=config,
+            )
+
+        self.assertIsNone(quant_config)
+
+    def test_replacement_metadata_rejects_online_quantization(self):
+        with tempfile.TemporaryDirectory() as directory:
+            weights = f"{directory}/model.safetensors"
+            save_file(
+                {"block.weight": torch.ones((2, 2))},
+                weights,
+                metadata={
+                    "quantization_config": json.dumps(
+                        {"quant_method": "fp8", "activation_scheme": "dynamic"}
+                    )
+                },
+            )
+
+            with self.assertRaisesRegex(ValueError, "already declares quantization"):
+                _resolve_quant_config(
+                    hf_config={},
+                    server_args=self._make_server_args(
+                        transformer_weights_path=weights,
+                        quantization="fp8",
+                    ),
+                    safetensors_list=[weights],
+                    component_model_path="/base",
+                )
+
     def test_autoround_config_is_inferred_and_remapped_to_native_prefixes(self):
         layer_config = {
             "bits": 4,
@@ -205,27 +304,6 @@ class TestTransformerQuantHelpers(unittest.TestCase):
                 ),
                 {},
             )
-
-    def _make_server_args(self, **overrides):
-        defaults = dict(
-            transformer_weights_path=None,
-            pipeline_config=SimpleNamespace(
-                dit_precision="bf16",
-                dit_config=SimpleNamespace(
-                    arch_config=SimpleNamespace(param_names_mapping={})
-                ),
-            ),
-            nunchaku_config=None,
-            quantization=None,
-            quantization_ignored_layers=None,
-            revision="test-revision",
-            tp_size=1,
-            dit_cpu_offload=False,
-            direct_gpu_weight_loading=False,
-            text_encoder_cpu_offload=False,
-        )
-        defaults.update(overrides)
-        return SimpleNamespace(**defaults)
 
     def test_modelopt_fp4_uses_fa_by_default_on_blackwell(self):
         quant_spec = TransformerQuantLoadSpec([], _FakeQuantConfig(), None, None)


### PR DESCRIPTION
## Summary
- make the selected replacement transformer checkpoint authoritative for serialized quantization metadata
- preserve model-specific checkpoint-name remapping for that selected config
- refuse a conflicting online `--quantization` flag rather than double-quantizing
- document the existing generic component-weight entry point

The scope is every component that uses the native `TransformerLoader` (primary, video, audio, and secondary transformer components); it is not model-specific.

## Validation
- full `pre-commit run --files` for the changed files: passed
- focused coverage added for replacement config precedence, plain replacement isolation, and header-vs-online conflict
- no local pytest/e2e per diffusion development policy; request NVIDIA CI

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33254577126](https://github.com/sgl-project/sglang/actions/runs/33254577126)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33254587594](https://github.com/sgl-project/sglang/actions/runs/33254587594)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33254577064](https://github.com/sgl-project/sglang/actions/runs/33254577064)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->