### PR TITLE
fix(vlm): contain malformed EPD embedding parts

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -610,6 +610,7 @@ class MultiModalEmbeddingData(EmbeddingData):
         model_type: Optional[str] = None,
     ):
         """Create MultiModalEmbeddingData from an EmbeddingData instance."""
+        _validate_embedding_part(embedding_data)
         # Only forward known optional attrs (e.g. video metadata) so they land on the instance
         extra = {}
         for attr in video_meta_attrs_for(model_type):
@@ -677,13 +678,7 @@ class MultiModalEmbeddingData(EmbeddingData):
         return kwargs
 
     def add(self, embedding_data: EmbeddingData):
-        if self.req_id != embedding_data.req_id:
-            logger.warning(
-                f"Dropping embedding data with mismatched req_id: "
-                f"expected {self.req_id}, got {embedding_data.req_id}"
-            )
-            return False
-        assert not self.ready_list[embedding_data.part_idx]
+        _validate_embedding_part(embedding_data, current=self)
         pid = embedding_data.part_idx
         self.ready_list[pid] = True
         self.modality_list[pid] = embedding_data.modality
@@ -694,6 +689,45 @@ class MultiModalEmbeddingData(EmbeddingData):
             self._set_video_meta_for_part(pid, embedding_data)
         if embedding_data.modality == Modality.IMAGE:
             self._set_image_meta_for_part(pid, embedding_data)
+
+
+def _validate_embedding_part(
+    embedding_data: EmbeddingData,
+    current: Optional[MultiModalEmbeddingData] = None,
+) -> None:
+    """Reject malformed part metadata before indexing aggregation buffers."""
+    if not isinstance(embedding_data, EmbeddingData):
+        raise ValueError(f"expected EmbeddingData, got {type(embedding_data).__name__}")
+    if (
+        not isinstance(embedding_data.num_parts, int)
+        or isinstance(embedding_data.num_parts, bool)
+        or embedding_data.num_parts <= 0
+    ):
+        raise ValueError("num_parts must be a positive integer")
+    if (
+        not isinstance(embedding_data.part_idx, int)
+        or isinstance(embedding_data.part_idx, bool)
+        or embedding_data.part_idx < 0
+        or embedding_data.part_idx >= embedding_data.num_parts
+    ):
+        raise ValueError(
+            f"part_idx must be in [0, {embedding_data.num_parts}), "
+            f"got {embedding_data.part_idx}"
+        )
+    if current is None:
+        return
+    if current.req_id != embedding_data.req_id:
+        raise ValueError(
+            f"embedding req_id mismatch: expected {current.req_id}, "
+            f"got {embedding_data.req_id}"
+        )
+    if current.num_parts != embedding_data.num_parts:
+        raise ValueError(
+            f"num_parts changed from {current.num_parts} to "
+            f"{embedding_data.num_parts}"
+        )
+    if current.ready_list[embedding_data.part_idx]:
+        raise ValueError(f"duplicate embedding part {embedding_data.part_idx}")
 
 
 def _aggregate_embedding_part(current, recv_obj, model_type):
@@ -1999,6 +2033,11 @@ class MMReceiverBase(ABC):
                 recv_embedding,
                 **recv_embedding_data.get_mm_extra_meta(),
             )
+        except Exception:
+            logger.exception(
+                "Failed to receive encoder embeddings for req_id=%s", req_id
+            )
+            return None
         finally:
             recv_socket.close()
 

--- a/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
+++ b/test/registered/unit/disaggregation/test_kimi_k3_encoder_mode.py
@@ -6,7 +6,7 @@ import time
 from array import array
 from concurrent.futures import ThreadPoolExecutor
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 import torch
@@ -24,6 +24,8 @@ from sglang.srt.disaggregation.encoder.receiver import (
     EmbeddingData,
     MMReceiverHTTP,
     MultiModalEmbeddingData,
+    WaitingMMRequestStatus,
+    WaitingZmqRequest,
     _encoder_media_item,
     _select_mm_processor_prompt,
 )
@@ -593,6 +595,109 @@ def test_kimi_k3_epd_aggregates_original_image_sizes_in_part_order():
         [1536, 1024],
         [1024, 1536],
     ]
+
+
+@pytest.mark.parametrize(
+    ("num_parts", "part_idx", "error"),
+    [
+        (0, 0, "num_parts must be a positive integer"),
+        (2, -1, "part_idx must be in"),
+        (2, 2, "part_idx must be in"),
+    ],
+)
+def test_epd_embedding_aggregation_rejects_invalid_part_metadata(
+    num_parts, part_idx, error
+):
+    part = EmbeddingData(
+        req_id="request",
+        num_parts=num_parts,
+        part_idx=part_idx,
+        grid_dim=torch.tensor([[1, 2, 2]]),
+        modality=Modality.IMAGE,
+        embedding=torch.ones(1, 2),
+    )
+
+    with pytest.raises(ValueError, match=error):
+        MultiModalEmbeddingData.from_embedding_data(part)
+
+
+def test_epd_embedding_aggregation_rejects_duplicate_and_inconsistent_parts():
+    def make_part(num_parts, part_idx):
+        return EmbeddingData(
+            req_id="request",
+            num_parts=num_parts,
+            part_idx=part_idx,
+            grid_dim=torch.tensor([[1, 2, 2]]),
+            modality=Modality.IMAGE,
+            embedding=torch.ones(1, 2),
+        )
+
+    combined = MultiModalEmbeddingData.from_embedding_data(make_part(2, 0))
+    with pytest.raises(ValueError, match="duplicate embedding part 0"):
+        combined.add(make_part(2, 0))
+    with pytest.raises(ValueError, match="num_parts changed from 2 to 3"):
+        combined.add(make_part(3, 1))
+
+
+def test_epd_scheduler_contains_invalid_embedding_part_metadata():
+    waiting = WaitingZmqRequest.__new__(WaitingZmqRequest)
+    waiting.rid = "request"
+    waiting.recv_req = SimpleNamespace(rid="request")
+    waiting.status = WaitingMMRequestStatus.PENDING
+    waiting.recv_embedding_data = None
+    waiting.model_type = None
+    waiting._fail_and_release = Mock()
+    invalid = EmbeddingData(
+        req_id="request_local_part_2",
+        num_parts=2,
+        part_idx=2,
+        grid_dim=None,
+        modality=Modality.IMAGE,
+        embedding=torch.ones(1, 2),
+    )
+
+    waiting.consume_parts(
+        [pickle.dumps(invalid.copy_without_embedding()), invalid.embedding.numpy()]
+    )
+
+    waiting._fail_and_release.assert_called_once()
+
+
+def test_epd_tokenizer_contains_duplicate_embedding_part():
+    class FakeSocket:
+        def __init__(self, messages):
+            self.messages = messages
+            self.closed = False
+
+        async def recv_multipart(self, copy=False):
+            return self.messages.pop(0)
+
+        def close(self):
+            self.closed = True
+
+    async def run_test():
+        embedding = torch.tensor([[1.0, 2.0]])
+        part = EmbeddingData(
+            req_id="request_local_part_0",
+            num_parts=2,
+            part_idx=0,
+            grid_dim=torch.tensor([[1, 2, 2]]),
+            modality=Modality.IMAGE,
+            embedding=embedding,
+        )
+        frame = [pickle.dumps(part.copy_without_embedding()), embedding.numpy()]
+        socket = FakeSocket([frame, frame])
+        receiver = MMReceiverHTTP.__new__(MMReceiverHTTP)
+        receiver.model_type = None
+
+        result = await receiver._recv_mm_data(
+            "request", socket, SimpleNamespace(), "prompt"
+        )
+
+        assert result is None
+        assert socket.closed
+
+    asyncio.run(run_test())
 
 
 def test_kimi_k3_encoder_prefers_grid_thws_and_uses_temporal_pool_length():


### PR DESCRIPTION
## Summary

- validate EPD embedding part counts, indices, duplicates, and cross-part consistency before aggregation
- contain tokenizer-side decode, materialization, aggregation, and request reconstruction failures at the current VLM request
- replace the duplicate-part assertion with an explicit runtime error

## Why

`zmq_to_tokenizer` trusted deserialized encoder metadata. A malformed index, duplicate part, inconsistent part count, invalid tensor frame, or processor reconstruction failure could escape the receive coroutine instead of following the normal missing-embedding request error path.

## Coverage

- invalid `num_parts` and `part_idx`
- duplicate and inconsistent parts
- scheduler-side request containment
- tokenizer-side request containment and socket cleanup

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33254690907](https://github.com/sgl-project/sglang/actions/runs/33254690907)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33254690933](https://github.com/sgl-project/sglang/actions/runs/33254690933)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33254690860](https://github.com/sgl-project/sglang/actions/runs/33254690860)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->