### PR TITLE
[Diffusion] Reject invalid distributed transformer fallback

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -176,6 +176,12 @@ class ComponentLoader(ABC):
         )
         return component_name in native_only_components
 
+    def validate_native_fallback(
+        self, _server_args: ServerArgs, _component_name: str
+    ) -> None:
+        """Validate that fallback preserves the exact component's runtime contract."""
+        pass
+
     def _load_customized_with_context(
         self,
         component_model_path: str,
@@ -289,6 +295,7 @@ class ComponentLoader(ABC):
                     f"Failed to load customized {component_name}; native fallback "
                     "is disabled for this component configuration."
                 ) from e
+            self.validate_native_fallback(server_args, component_name)
             if native_loader_required:
                 logger.info("%s", e)
             elif "Unsupported model architecture" in str(e):

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -177,10 +177,15 @@ class ComponentLoader(ABC):
         return component_name in native_only_components
 
     def validate_native_fallback(
-        self, _server_args: ServerArgs, _component_name: str
+        self, server_args: ServerArgs, component_name: str
     ) -> None:
         """Validate that fallback preserves the exact component's runtime contract."""
-        pass
+        if server_args.should_use_fsdp_for_component(component_name):
+            raise RuntimeError(
+                f"Native fallback for component {component_name!r} cannot honor "
+                "requested FSDP. Use an SGLang-native implementation or disable "
+                "FSDP for this component."
+            )
 
     def _load_customized_with_context(
         self,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -192,6 +192,40 @@ class TransformerLoader(ComponentLoader):
             or component_server_args.quantization is not None
         )
 
+    def validate_native_fallback(
+        self, server_args: ServerArgs, component_name: str
+    ) -> None:
+        requested_distributed_execution = []
+        if server_args.tp_size is not None and server_args.tp_size > 1:
+            requested_distributed_execution.append(f"tp_size={server_args.tp_size}")
+        if server_args.sp_degree is not None and server_args.sp_degree > 1:
+            requested_distributed_execution.append(f"sp_degree={server_args.sp_degree}")
+        if server_args.ulysses_degree is not None and server_args.ulysses_degree > 1:
+            requested_distributed_execution.append(
+                f"ulysses_degree={server_args.ulysses_degree}"
+            )
+        if server_args.ring_degree is not None and server_args.ring_degree > 1:
+            requested_distributed_execution.append(
+                f"ring_degree={server_args.ring_degree}"
+            )
+        if (
+            server_args.kv_gather_degree is not None
+            and server_args.kv_gather_degree > 1
+        ):
+            requested_distributed_execution.append(
+                f"kv_gather_degree={server_args.kv_gather_degree}"
+            )
+        if server_args.should_use_fsdp_for_component(component_name):
+            requested_distributed_execution.append("FSDP")
+        if requested_distributed_execution:
+            raise RuntimeError(
+                f"Native Diffusers fallback for transformer component "
+                f"{component_name!r} cannot honor requested distributed execution: "
+                f"{', '.join(requested_distributed_execution)}. Use an SGLang-native "
+                "transformer implementation or set tp_size, sp_degree, "
+                "ulysses_degree, ring_degree, and kv_gather_degree to 1 without FSDP."
+            )
+
     def load_customized(
         self,
         component_model_path: str,

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -195,6 +195,7 @@ class TransformerLoader(ComponentLoader):
     def validate_native_fallback(
         self, server_args: ServerArgs, component_name: str
     ) -> None:
+        super().validate_native_fallback(server_args, component_name)
         requested_distributed_execution = []
         if server_args.tp_size is not None and server_args.tp_size > 1:
             requested_distributed_execution.append(f"tp_size={server_args.tp_size}")
@@ -215,15 +216,13 @@ class TransformerLoader(ComponentLoader):
             requested_distributed_execution.append(
                 f"kv_gather_degree={server_args.kv_gather_degree}"
             )
-        if server_args.should_use_fsdp_for_component(component_name):
-            requested_distributed_execution.append("FSDP")
         if requested_distributed_execution:
             raise RuntimeError(
                 f"Native Diffusers fallback for transformer component "
                 f"{component_name!r} cannot honor requested distributed execution: "
                 f"{', '.join(requested_distributed_execution)}. Use an SGLang-native "
                 "transformer implementation or set tp_size, sp_degree, "
-                "ulysses_degree, ring_degree, and kv_gather_degree to 1 without FSDP."
+                "ulysses_degree, ring_degree, and kv_gather_degree to 1."
             )
 
     def load_customized(

--- a/python/sglang/multimodal_gen/test/unit/test_image_encoder_loader.py
+++ b/python/sglang/multimodal_gen/test/unit/test_image_encoder_loader.py
@@ -41,6 +41,7 @@ class TestImageEncoderQuantizationAdmission(unittest.TestCase):
             component_quantizations={},
             encoder_parallel="replicate",
             resolve_component_attention_backend=lambda _name: (None, None),
+            should_use_fsdp_for_component=lambda _name: False,
         )
 
     def _component_config(self, architecture, *, quantized):

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
@@ -1,0 +1,116 @@
+import re
+import unittest
+from types import SimpleNamespace
+from unittest import mock
+
+from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader import (
+    NativeComponentLoaderRequired,
+)
+from sglang.multimodal_gen.runtime.loader.component_loaders.transformer_loader import (
+    TransformerLoader,
+)
+
+
+class TestTransformerLoaderFallbackAdmission(unittest.TestCase):
+    @staticmethod
+    def _server_args(*, fsdp_requested=False, **overrides):
+        values = {
+            "component_quantizations": {},
+            "component_weights_paths": {},
+            "component_quantization_ignored_layers": {},
+            "transformer_weights_path": None,
+            "nunchaku_config": None,
+            "quantization": None,
+            "pipeline_config": SimpleNamespace(native_only_components=()),
+            "tp_size": 1,
+            "sp_degree": 1,
+            "ulysses_degree": 1,
+            "ring_degree": 1,
+            "kv_gather_degree": 1,
+            "enable_cfg_parallel": False,
+            "dp_size": 1,
+            "use_fsdp_inference": False,
+            "resolve_component_attention_backend": mock.Mock(return_value=(None, None)),
+            "should_use_fsdp_for_component": mock.Mock(return_value=fsdp_requested),
+        }
+        values.update(overrides)
+        return SimpleNamespace(**values)
+
+    @staticmethod
+    def _mocked_load(loader):
+        customized_load = mock.patch.object(
+            loader,
+            "_load_customized_with_context",
+            side_effect=NativeComponentLoaderRequired("native loader required"),
+        )
+        native_load = mock.patch.object(
+            loader, "_load_native_with_context", return_value=object()
+        )
+        available_memory = mock.patch(
+            "sglang.multimodal_gen.runtime.loader.component_loaders."
+            "component_loader.current_platform.get_available_gpu_memory",
+            return_value=0.0,
+        )
+        return customized_load, native_load, available_memory
+
+    def test_distributed_execution_rejects_before_native_load(self):
+        cases = (
+            ("tp_size", 2, "tp_size=2"),
+            ("sp_degree", 2, "sp_degree=2"),
+            ("ulysses_degree", 2, "ulysses_degree=2"),
+            ("ring_degree", 2, "ring_degree=2"),
+            ("kv_gather_degree", 2, "kv_gather_degree=2"),
+            ("fsdp_requested", True, "FSDP"),
+        )
+
+        for field, value, expected_error in cases:
+            with self.subTest(field=field):
+                loader = TransformerLoader()
+                server_args = self._server_args(**{field: value})
+                customized_load, native_load, available_memory = self._mocked_load(
+                    loader
+                )
+
+                with customized_load, native_load as native, available_memory:
+                    with self.assertRaisesRegex(
+                        RuntimeError, re.escape(expected_error)
+                    ):
+                        loader.load(
+                            "/model/transformer_2",
+                            server_args,
+                            "transformer_2",
+                            "diffusers",
+                        )
+
+                native.assert_not_called()
+                server_args.should_use_fsdp_for_component.assert_called_once_with(
+                    "transformer_2"
+                )
+
+    def test_replicated_cfg_and_dp_keep_native_fallback(self):
+        loader = TransformerLoader()
+        server_args = self._server_args(
+            enable_cfg_parallel=True,
+            dp_size=2,
+            use_fsdp_inference=True,
+        )
+        customized_load, native_load, available_memory = self._mocked_load(loader)
+
+        with customized_load, native_load as native, available_memory:
+            component, consumed = loader.load(
+                "/model/transformer_2",
+                server_args,
+                "transformer_2",
+                "diffusers",
+            )
+
+        self.assertIsNotNone(component)
+        self.assertEqual(consumed, 0.0)
+        native.assert_called_once()
+        server_args.should_use_fsdp_for_component.assert_called_once_with(
+            "transformer_2"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest import mock
 
 from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader import (
+    ComponentLoader,
     NativeComponentLoaderRequired,
 )
 from sglang.multimodal_gen.runtime.loader.component_loaders.transformer_loader import (
@@ -15,6 +16,7 @@ class TestTransformerLoaderFallbackAdmission(unittest.TestCase):
     @staticmethod
     def _server_args(*, fsdp_requested=False, **overrides):
         values = {
+            "component_precisions": {},
             "component_quantizations": {},
             "component_weights_paths": {},
             "component_quantization_ignored_layers": {},
@@ -109,6 +111,25 @@ class TestTransformerLoaderFallbackAdmission(unittest.TestCase):
         native.assert_called_once()
         server_args.should_use_fsdp_for_component.assert_called_once_with(
             "transformer_2"
+        )
+
+    def test_generic_native_fallback_rejects_component_fsdp(self):
+        loader = ComponentLoader()
+        server_args = self._server_args(fsdp_requested=True)
+        customized_load, native_load, available_memory = self._mocked_load(loader)
+
+        with customized_load, native_load as native, available_memory:
+            with self.assertRaisesRegex(RuntimeError, "FSDP"):
+                loader.load(
+                    "/model/condition_image_encoder",
+                    server_args,
+                    "condition_image_encoder",
+                    "diffusers",
+                )
+
+        native.assert_not_called()
+        server_args.should_use_fsdp_for_component.assert_called_once_with(
+            "condition_image_encoder"
         )
 
 

--- a/python/sglang/multimodal_gen/test/unit/test_vae_loader.py
+++ b/python/sglang/multimodal_gen/test/unit/test_vae_loader.py
@@ -51,6 +51,9 @@ class _FakeServerArgs:
     def should_start_component_on_cpu(self, _component_name):
         return False
 
+    def should_use_fsdp_for_component(self, _component_name):
+        return False
+
     def should_configure_layerwise_offload_for_lazy_component(self, component_name):
         return component_name in self.layerwise_components
 


### PR DESCRIPTION
## Summary
- prevent native fallback for **any** component when its exact placement requires SGLang FSDP: native Transformers/Diffusers loaders do not install that wrapper
- prevent native Diffusers fallback for transformer components when TP, SP, Ulysses, Ring, or KV-gather is selected
- preserve native fallback for replicated CFG parallel and data parallel execution
- make the fallback contract an explicit hook in the shared component loader

This is generic to component loading. It does not claim that every component implements model-parallel layouts; it rejects a fallback that would otherwise silently drop them.

## Validation
- full `pre-commit run --files` for changed files: passed
- regression coverage drives each transformer distributed selector and generic component FSDP through real `ComponentLoader.load()` fallback, asserting native load is not reached
- no local pytest/e2e per diffusion development policy; NVIDIA CI requested

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33256271771](https://github.com/sgl-project/sglang/actions/runs/33256271771)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33256345214](https://github.com/sgl-project/sglang/actions/runs/33256345214)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33256271690](https://github.com/sgl-project/sglang/actions/runs/33256271690)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->