### PR TITLE
[Diffusion] Reject unused component attention overrides

### DIFF
--- a/docs/docs/sglang-diffusion/attention_backends.mdx
+++ b/docs/docs/sglang-diffusion/attention_backends.mdx
@@ -9,7 +9,7 @@ This document describes the attention backends available in sglang diffusion (`s
 
 Attention backends are defined by `AttentionBackendEnum` (`sglang.multimodal_gen.runtime.platforms.interface.AttentionBackendEnum`) and selected via the CLI flag `--attention-backend`.
 
-Backend selection is performed by the shared attention layers (e.g. `LocalAttention` / `USPAttention` / `UlyssesAttention` in `sglang.multimodal_gen.runtime.layers.attention.layer`). `--attention-backend` is strict for the diffusion transformer / DiT. Auxiliary components such as encoders and VAEs use it when compatible, then fall back to a component default or a platform-compatible backend. Use `--component-attention-backends` when an auxiliary component must use a specific backend; incompatible component overrides fail unless a sparse backend is being replaced for cross-attention.
+Backend selection is performed by the shared attention layers (e.g. `LocalAttention` / `USPAttention` / `UlyssesAttention` in `sglang.multimodal_gen.runtime.layers.attention.layer`). `--attention-backend` is strict for the diffusion transformer / DiT. Auxiliary components such as encoders and VAEs use it when compatible, then fall back to a component default or a platform-compatible backend. Use `--component-attention-backends` when an auxiliary component must use a specific backend; incompatible overrides, including an override for a component that constructs no SGLang attention layer, fail unless a sparse backend is being replaced for cross-attention.
 
 When using the diffusers backend, `--attention-backend` is passed through to diffusers'
 `set_attention_backend` (e.g., `flash`, `_flash_3_hub`, `sage`, `xformers`, `native`).

--- a/python/sglang/multimodal_gen/runtime/layers/attention/selector.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/selector.py
@@ -130,6 +130,13 @@ def _record_component_attn_backend(backend_name: str, reason: str | None) -> boo
     return True
 
 
+def record_component_attn_backend(
+    backend: AttentionBackendEnum, reason: str | None = None
+) -> bool:
+    """Record a component backend selected outside layer construction."""
+    return _record_component_attn_backend(backend.name.lower(), reason)
+
+
 def _log_component_attn_backend_summary(
     context: ComponentAttnBackendContext | None,
 ) -> None:

--- a/python/sglang/multimodal_gen/runtime/layers/attention/selector.py
+++ b/python/sglang/multimodal_gen/runtime/layers/attention/selector.py
@@ -378,12 +378,31 @@ def component_attn_backend_context_manager(
             allow_global_backend_fallback,
         )
     )
+    unused_component_name: str | None = None
+    unused_backend_name: str | None = None
+    completed = False
     try:
         yield
+        completed = True
     finally:
         context = component_attn_backend_context.get()
+        unused_component_override = completed and (
+            context is not None
+            and context.backend is not None
+            and context.component_name is not None
+            and not context.selected_backends
+        )
+        if unused_component_override:
+            unused_component_name = context.component_name
+            unused_backend_name = context.backend.name.lower()
         _log_component_attn_backend_summary(context)
         component_attn_backend_context.reset(token)
+    if unused_component_name is not None and unused_backend_name is not None:
+        raise ValueError(
+            f"Attention backend {unused_backend_name!r} was requested for component "
+            f"{unused_component_name!r}, but that component "
+            "did not construct an SGLang attention layer."
+        )
 
 
 @contextmanager

--- a/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/minimax_h3.py
@@ -55,6 +55,7 @@ from sglang.multimodal_gen.runtime.layers.attention.selector import (
     get_attn_backend,
     get_component_forced_attn_backend,
     get_global_forced_attn_backend,
+    record_component_attn_backend,
 )
 from sglang.multimodal_gen.runtime.layers.linear import (
     ColumnParallelLinear,
@@ -2011,6 +2012,11 @@ class MiniMaxH3DiTModel(BaseDiT, LayerwiseOffloadableModuleMixin):
         # Component overrides disappear when the loader context exits. Preserve
         # only that selection; process-wide overrides are resolved at first use.
         self._component_attention_backend_override = get_component_forced_attn_backend()
+        if self._component_attention_backend_override is not None:
+            record_component_attn_backend(
+                self._component_attention_backend_override,
+                "deferred model-specific resolution",
+            )
         self._resolved_attention_backend: AttentionBackendEnum | None = None
         self._mark_missing_params_required()
 

--- a/python/sglang/multimodal_gen/test/unit/test_attention_backend_selector.py
+++ b/python/sglang/multimodal_gen/test/unit/test_attention_backend_selector.py
@@ -164,6 +164,26 @@ class TestAttentionBackendFallback(unittest.TestCase):
         self.assertIs(backend, _FakeFABackend)
         self.assertIsNone(_FakePlatform.selected_backend)
 
+    def test_component_override_requires_an_sglang_attention_layer(self):
+        with self.assertRaisesRegex(
+            ValueError, "did not construct an SGLang attention layer"
+        ):
+            with component_attn_backend_context_manager(
+                AttentionBackendEnum.FA, component_name="vae"
+            ):
+                pass
+
+        self.assertIsNone(get_component_attn_backend_context())
+
+    def test_component_override_preserves_load_error_and_resets_context(self):
+        with self.assertRaisesRegex(RuntimeError, "component failed"):
+            with component_attn_backend_context_manager(
+                AttentionBackendEnum.FA, component_name="vae"
+            ):
+                raise RuntimeError("component failed")
+
+        self.assertIsNone(get_component_attn_backend_context())
+
     def test_implicit_preference_falls_back_for_missing_capability(self):
         backend = self._resolve(
             AttentionBackendEnum.AITER,


### PR DESCRIPTION
## Summary
- reject a `--component-attention-backends` override when the selected component never constructs an SGLang attention layer
- preserve the original component-load error when construction fails, and always reset the scoped selection context
- document the fail-closed boundary for component-local attention selection

This is a generic component-loader contract: actual attention layers continue to select and report their backend as before. It does not add a backend to components that do not implement one.

## Validation
- `pre-commit run --files` for all changed files: passed
- coverage verifies unused explicit override rejection, context reset, and preservation of the original load error
- NVIDIA CI requested; no local pytest/e2e under the diffusion development policy

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33256688821](https://github.com/sgl-project/sglang/actions/runs/33256688821)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33256688622](https://github.com/sgl-project/sglang/actions/runs/33256688622)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33256688682](https://github.com/sgl-project/sglang/actions/runs/33256688682)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->