### PR TITLE
[Diffusion] Reject unmanaged component residency

### DIFF
--- a/docs/docs/sglang-diffusion/api/cli.mdx
+++ b/docs/docs/sglang-diffusion/api/cli.mdx
@@ -300,7 +300,7 @@ Selectors match exact loaded component keys from `model_index.json`, including n
 
 The existing `--dit-cpu-offload`, `--text-encoder-cpu-offload`, `--image-encoder-cpu-offload`, `--vae-cpu-offload`, and `--cpu-offload-components` options remain supported. New and legacy options may be mixed: `--component-residency` wins only for components it matches, while unmatched legacy settings remain effective. Legacy layerwise selectors take precedence over legacy component-offload selectors for the same component. Explicit `--dit-layerwise-offload false` makes the DiT resident unless another explicit DiT selector, such as `--dit-cpu-offload true` or `--component-residency dit=component-offload`, selects a different mode.
 
-Layerwise selection is strict. A native weighted component selected for `layerwise-offload` must declare its layer structure; otherwise startup fails with the unsupported component name instead of silently changing modes. FSDP applies only to resident components. The Diffusers backend supports only pipeline-wide `all=resident` and `all=component-offload`.
+Layerwise selection is strict. A native weighted component selected for `layerwise-offload` must declare its layer structure; otherwise startup fails with the unsupported component name instead of silently changing modes. Explicit non-resident placement also requires a request-time component-use declaration, so it cannot silently select a module that the pipeline does not manage. FSDP applies only to resident components. The Diffusers backend supports only pipeline-wide `all=resident` and `all=component-offload`.
 
 ### Layerwise Offload Tuning
 

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
@@ -203,8 +203,9 @@ class ComponentResidencyManager:
         if unmanaged_components:
             names = ", ".join(repr(name) for name in unmanaged_components)
             raise ComponentResidencyError(
-                "Explicit component residency requires a request-time "
-                f"ComponentUse declaration; {names} has none in this pipeline"
+                "Explicit component residency requires "
+                f"{names} to have a request-time ComponentUse declaration; "
+                "none appears in this pipeline"
             )
 
     @staticmethod

--- a/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
+++ b/python/sglang/multimodal_gen/runtime/managers/memory_managers/component_manager.py
@@ -178,6 +178,34 @@ class ComponentResidencyManager:
         self._ordered_uses = tuple(
             use for uses in self._stage_uses_by_index for use in uses
         )
+        self._validate_explicit_nonresident_components()
+
+    def _validate_explicit_nonresident_components(self) -> None:
+        """Reject explicit offload selectors with no request-time use site.
+
+        Component placement is enacted by the request timeline, not merely by
+        choosing an initial load device. An explicit non-resident module with
+        no declared ``ComponentUse`` would otherwise be accepted but never
+        moved to the device before a forward pass.
+        """
+        if not isinstance(self.server_args, ServerArgs):
+            return
+
+        declared_components = {use.component_name for use in self._ordered_uses}
+        unmanaged_components = sorted(
+            component_name
+            for component_name, module in self.pipeline.modules.items()
+            if isinstance(module, nn.Module)
+            and self.server_args.explicit_residency_mode(component_name)
+            in (COMPONENT_OFFLOAD, LAYERWISE_OFFLOAD)
+            and component_name not in declared_components
+        )
+        if unmanaged_components:
+            names = ", ".join(repr(name) for name in unmanaged_components)
+            raise ComponentResidencyError(
+                "Explicit component residency requires a request-time "
+                f"ComponentUse declaration; {names} has none in this pipeline"
+            )
 
     @staticmethod
     def _is_warmup_batch(batch: ResidencyBatch | list[ResidencyBatch]) -> bool:

--- a/python/sglang/multimodal_gen/test/unit/test_component_residency.py
+++ b/python/sglang/multimodal_gen/test/unit/test_component_residency.py
@@ -1,12 +1,16 @@
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
 import torch
 
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_manager import (
     ComponentResidencyManager,
     ComponentUse,
     ResidencyState,
+)
+from sglang.multimodal_gen.runtime.managers.memory_managers.component_residency import (
+    ComponentResidencyError,
 )
 from sglang.multimodal_gen.runtime.managers.memory_managers.component_residency_strategies import (
     ComponentOffloadStrategy,
@@ -15,6 +19,7 @@ from sglang.multimodal_gen.runtime.managers.memory_managers.component_residency_
 from sglang.multimodal_gen.runtime.pipelines_core.stages.realtime.text_encoding import (
     RealtimeTextEncodingStage,
 )
+from sglang.multimodal_gen.runtime.server_args import ServerArgs
 
 
 def test_component_offload_releases_preferred_component_after_request():
@@ -169,6 +174,44 @@ def _manager_for_stage(stage, modules):
     manager.refresh_pipeline(pipeline)
     manager.begin_request([stage], SimpleNamespace(is_warmup=False), server_args)
     return manager, server_args
+
+
+def _server_args_with_component_offload(component_name):
+    server_args = ServerArgs.__new__(ServerArgs)
+    server_args.component_residency = {component_name: "component-offload"}
+    return server_args
+
+
+def test_explicit_component_offload_requires_a_declared_request_use():
+    stage = _Stage()
+    pipeline = SimpleNamespace(
+        modules={"auxiliary": torch.nn.Linear(2, 2)},
+        _stage_name_mapping={"stage": stage},
+        component_residency_strategies={},
+    )
+    server_args = _server_args_with_component_offload("auxiliary")
+    manager = ComponentResidencyManager(pipeline, server_args)
+    manager.refresh_pipeline(pipeline)
+
+    with pytest.raises(
+        ComponentResidencyError,
+        match="'auxiliary'.*ComponentUse declaration",
+    ):
+        manager.begin_request([stage], SimpleNamespace(is_warmup=False), server_args)
+
+
+def test_declared_component_use_admits_explicit_component_offload():
+    stage = _Stage(ComponentUse("stage", "auxiliary"))
+    pipeline = SimpleNamespace(
+        modules={"auxiliary": torch.nn.Linear(2, 2)},
+        _stage_name_mapping={"stage": stage},
+        component_residency_strategies={},
+    )
+    server_args = _server_args_with_component_offload("auxiliary")
+    manager = ComponentResidencyManager(pipeline, server_args)
+    manager.refresh_pipeline(pipeline)
+
+    manager.begin_request([stage], SimpleNamespace(is_warmup=False), server_args)
 
 
 def test_single_component_stage_is_prepared_at_stage_entry():


### PR DESCRIPTION
## Summary

- reject explicit component-offload or layerwise-offload selections when an already-loaded `nn.Module` has no request-time `ComponentUse` declaration
- keep resident and unconfigured components unchanged
- document the lifecycle admission contract and cover both reject and declared-use cases

## Validation

- `pre-commit run --files`
- NVIDIA CI requested via labels

No local pytest/e2e was run per diffusion development policy.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33256923980](https://github.com/sgl-project/sglang/actions/runs/33256923980)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33256923953](https://github.com/sgl-project/sglang/actions/runs/33256923953)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33256924185](https://github.com/sgl-project/sglang/actions/runs/33256924185)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->