### PR TITLE
[Diffusion] Make native-only components explicit

### DIFF
--- a/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/base.py
@@ -200,6 +200,9 @@ class PipelineConfig:
 
     task_type: ModelTaskType = ModelTaskType.I2I
     skip_input_image_preprocess: bool = False
+    # Components that cannot fall back to a native Transformers/Diffusers
+    # implementation because their pipeline requires SGLang-specific behavior.
+    native_only_components: tuple[str, ...] = ()
 
     model_path: str = ""
     pipeline_config_path: str | None = None

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan3d.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/hunyuan3d.py
@@ -35,7 +35,7 @@ class Hunyuan3D2PipelineConfig(PipelineConfig):
         default_factory=lambda: (CLIPTextConfig(),)
     )
     text_encoder_precisions: tuple[str, ...] = ("fp16",)
-    native_only_components = ("delight_text_encoder",)
+    native_only_components: tuple[str, ...] = ("delight_text_encoder",)
 
     # Shape model configuration
     shape_model_path: Optional[str] = None

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2_5.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/ltx_2_5.py
@@ -43,7 +43,7 @@ class LTX25PipelineConfig(LTX2PipelineConfig):
     # One checkpoint drives both T2V and image-conditioned generation, so this
     # must stay TI2V -- T2V rejects `--image-path` outright.
     task_type: ModelTaskType = ModelTaskType.TI2V
-    native_only_components = ("diffusion_decoder",)
+    native_only_components: tuple[str, ...] = ("diffusion_decoder",)
 
     dit_config: LTX25Config = field(default_factory=LTX25Config)
     vae_config: LTX25VideoVAEConfig = field(default_factory=LTX25VideoVAEConfig)

--- a/python/sglang/multimodal_gen/configs/pipeline_configs/minimax_h3.py
+++ b/python/sglang/multimodal_gen/configs/pipeline_configs/minimax_h3.py
@@ -45,7 +45,7 @@ class MiniMaxH3PipelineConfig(PipelineConfig):
     # generic TI2V image resize would both duplicate that work and overwrite
     # the already-resolved target canvas.
     skip_input_image_preprocess: bool = True
-    native_only_components = (
+    native_only_components: tuple[str, ...] = (
         "text_encoder",
         "transformer",
         "video_vae",

--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/component_loader.py
@@ -171,10 +171,7 @@ class ComponentLoader(ABC):
     def should_raise_customized_load_error(
         self, server_args: ServerArgs, component_name: str
     ) -> bool:
-        native_only_components = getattr(
-            server_args.pipeline_config, "native_only_components", ()
-        )
-        return component_name in native_only_components
+        return component_name in server_args.pipeline_config.native_only_components
 
     def _load_customized_with_context(
         self,

--- a/python/sglang/multimodal_gen/test/unit/test_vae_loader.py
+++ b/python/sglang/multimodal_gen/test/unit/test_vae_loader.py
@@ -277,6 +277,12 @@ class TestVAELoader(unittest.TestCase):
 
         native_load.assert_not_called()
 
+    def test_pipeline_config_declares_an_empty_native_only_default(self):
+        loader = vae_loader.VAELoader()
+        server_args = _FakeServerArgs(QwenImagePipelineConfig())
+
+        self.assertFalse(loader.should_raise_customized_load_error(server_args, "vae"))
+
     def test_backfill_ltx2_audio_vae_latent_stats_maps_official_keys(self):
         loaded = {
             "per_channel_statistics.mean-of-means": torch.tensor([1.0, 2.0]),


### PR DESCRIPTION
## Summary

- make `native_only_components` an explicit `PipelineConfig` contract instead of probing it with `getattr`
- preserve the three model-specific native-only declarations as type-checked dataclass overrides
- cover the empty default used by ordinary pipelines

## Validation

- `pre-commit run --files`
- NVIDIA CI requested via labels

No local pytest/e2e was run per diffusion development policy.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33256464944](https://github.com/sgl-project/sglang/actions/runs/33256464944)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33256739553](https://github.com/sgl-project/sglang/actions/runs/33256739553)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33256464898](https://github.com/sgl-project/sglang/actions/runs/33256464898)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->