### PR TITLE
[VLM][EPD] Keep receive failures within scheduler ownership

### DIFF
--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -62,6 +62,22 @@ if TYPE_CHECKING:
     from sglang.srt.managers.scheduler import Scheduler
 
 
+class _ReceiveRegistrationRunner:
+    """Run encoder receive-URL registration off the scheduler thread."""
+
+    def __init__(self, name: str):
+        self.loop = asyncio.new_event_loop()
+        self.thread = threading.Thread(target=self._run, daemon=True, name=name)
+        self.thread.start()
+
+    def _run(self) -> None:
+        asyncio.set_event_loop(self.loop)
+        self.loop.run_forever()
+
+    def submit(self, coroutine):
+        return asyncio.run_coroutine_threadsafe(coroutine, self.loop)
+
+
 def _mark_keep_device_embedding(mm_inputs) -> None:
     """Tell general_mm_embed_routine not to copy embeddings back to CPU."""
     if mm_inputs is None:
@@ -356,15 +372,15 @@ def _normalize_embedding_ports(embedding_port):
     return [embedding_port]
 
 
-def _grpc_scheduler_receive_url(target, req_id, receive_url, receive_count):
+async def _grpc_scheduler_receive_url(target, req_id, receive_url, receive_count):
     import grpc
     from smg_grpc_proto import sglang_encoder_pb2, sglang_encoder_pb2_grpc
 
     timeout_secs = envs.SGLANG_ENCODER_GRPC_TIMEOUT_SECS.get()
-    channel = grpc.insecure_channel(target)
+    channel = grpc.aio.insecure_channel(target)
     stub = sglang_encoder_pb2_grpc.SglangEncoderStub(channel)
     try:
-        stub.SchedulerReceiveUrl(
+        await stub.SchedulerReceiveUrl(
             sglang_encoder_pb2.SchedulerReceiveUrlRequest(
                 req_id=req_id,
                 receive_url=receive_url,
@@ -373,7 +389,7 @@ def _grpc_scheduler_receive_url(target, req_id, receive_url, receive_count):
             timeout=timeout_secs,
         )
     finally:
-        channel.close()
+        await channel.close()
 
 
 def _grpc_encode_request(target, encode_request):
@@ -784,6 +800,7 @@ class WaitingMMRequestBase(ABC):
         embedding_pool: Optional["EmbeddingPool"] = None,
         zmq_context=None,
         embedding_port=None,
+        registration_runner: Optional[_ReceiveRegistrationRunner] = None,
     ):
         self.rid = rid
         self.recv_req = recv_req
@@ -820,6 +837,10 @@ class WaitingMMRequestBase(ABC):
         # Success-path finalizer handle so abort can release the slot early.
         self._mm_finalizer: Optional[weakref.finalize] = None
         self._pool_full_warned = False
+        self.registration_runner = registration_runner
+        self.registration_future = None
+        self.registration_error = None
+        self.registration_lock = threading.Lock()
 
     @abstractmethod
     def send_encode_request(self) -> None:
@@ -827,6 +848,15 @@ class WaitingMMRequestBase(ABC):
 
     def _try_recv_mm_data(self):
         if self.status != WaitingMMRequestStatus.PENDING:
+            return
+
+        with self.registration_lock:
+            registration_error, self.registration_error = (
+                self.registration_error,
+                None,
+            )
+        if registration_error is not None:
+            self._fail_and_release(*registration_error)
             return
 
         # A complete request can remain pending while the GPU pool is full.
@@ -896,7 +926,7 @@ class WaitingMMRequestBase(ABC):
         self.error_msg = error_msg
         self.error_code = error_code
         self.status = WaitingMMRequestStatus.FAIL
-        self._cleanup_gpu_buffer()
+        self.release_resources()
         self.close_recv_socket()
 
     async def _check_encoder_responses(self, responses, endpoint: str) -> bool:
@@ -1005,6 +1035,12 @@ class WaitingMMRequestBase(ABC):
 
     def release_resources(self):
         """Free pool/GPU resources on abort/fail/timeout. Idempotent."""
+        registration_future, self.registration_future = (
+            self.registration_future,
+            None,
+        )
+        if registration_future is not None and not registration_future.done():
+            registration_future.cancel()
         self._cleanup_gpu_buffer()
         finalizer, self._mm_finalizer = self._mm_finalizer, None
         if finalizer is not None:
@@ -1014,8 +1050,37 @@ class WaitingMMRequestBase(ABC):
 # For zmq_to_scheduler: embedding parts arrive as ZMQ payload frames and
 # are optionally staged into the GPU EmbeddingPool.
 class WaitingZmqRequest(WaitingMMRequestBase):
-    def send_encode_request(self):
+    def _start_registration(self, coroutine) -> None:
+        if self.registration_runner is None:
+            coroutine.close()
+            self._fail_and_release(
+                "Encoder receive registration runner is unavailable",
+                int(HTTPStatus.INTERNAL_SERVER_ERROR),
+            )
+            return
 
+        self.registration_future = self.registration_runner.submit(coroutine)
+        self.registration_future.add_done_callback(self._on_registration_done)
+
+    def _on_registration_done(self, future) -> None:
+        if future.cancelled():
+            return
+        error = future.exception()
+        if error is None:
+            return
+        logger.error(
+            "Failed to register encoder receive URL for rid=%s: %s",
+            self.rid,
+            error,
+            exc_info=error,
+        )
+        with self.registration_lock:
+            self.registration_error = (
+                f"Failed to register receive URL with encoder: {error}",
+                int(HTTPStatus.BAD_GATEWAY),
+            )
+
+    def send_encode_request(self):
         async def _send_single_request(session, url, payload):
             try:
                 async with session.post(url, json=payload) as response:
@@ -1053,7 +1118,7 @@ class WaitingZmqRequest(WaitingMMRequestBase):
                         encoder_url = self.encoder_urls[idx]
                         target_url = f"{encoder_url}/scheduler_receive_url"
                         payload = {
-                            "req_id": part_req_id,  # use part_req_id to match encode request
+                            "req_id": part_req_id,
                             "receive_count": receive_count,
                             "receive_url": NetworkAddress(
                                 host_name, embedding_port
@@ -1091,15 +1156,9 @@ class WaitingZmqRequest(WaitingMMRequestBase):
                         logger.debug(f"Request {i} succeeded.")
                 failed = [r for r in results if isinstance(r, BaseException)]
                 if failed:
-                    # A rank without a registered receive URL can never be
-                    # pushed to; fail via the normal completion path now
-                    # instead of pending until the embedding wait times out.
-                    self._fail_and_release(
-                        f"Failed to register receive URL with encoder: {failed[0]!r}",
-                        int(HTTPStatus.BAD_GATEWAY),
-                    )
+                    raise failed[0]
 
-        asyncio.run(
+        self._start_registration(
             send_embedding_port(
                 self.recv_req.rid,
                 self.receive_count,
@@ -1180,8 +1239,7 @@ class WaitingZmqRequestGrpc(WaitingZmqRequest):
                 target_url = f"{encoder_url}/SchedulerReceiveUrl"
                 logger.info(f"Preparing to send to {target_url}")
                 tasks.append(
-                    asyncio.to_thread(
-                        _grpc_scheduler_receive_url,
+                    _grpc_scheduler_receive_url(
                         _grpc_target(encoder_url),
                         req_id,
                         receive_url,
@@ -1200,8 +1258,11 @@ class WaitingZmqRequestGrpc(WaitingZmqRequest):
                     logger.error(f"Request {i} failed: {result}")
                 else:
                     logger.debug(f"Request {i} succeeded.")
+            failed = [r for r in results if isinstance(r, BaseException)]
+            if failed:
+                raise failed[0]
 
-        asyncio.run(
+        self._start_registration(
             send_embedding_port(
                 self.recv_req.rid,
                 self.receive_count,
@@ -1740,12 +1801,16 @@ class MMReceiverBase(ABC):
         self.hostname = get_local_ip_auto()
         self.waiting_list: List[WaitingMMRequestBase] = []
         self.waiting_by_rid: Dict[str, WaitingMMRequestBase] = {}
+        self.registration_runner = None
         self.scheduler_embedding_port = None
         self.scheduler_recv_socket = None
         if (
             self.encoder_transfer_backend == "zmq_to_scheduler"
             and scheduler is not None
         ):
+            self.registration_runner = _ReceiveRegistrationRunner(
+                f"encoder-receive-registration-{tp_rank}"
+            )
             (
                 self.scheduler_embedding_port,
                 self.scheduler_recv_socket,
@@ -2423,7 +2488,10 @@ class MMReceiverHTTP(MMReceiverBase):
                 embedding_pool=self.embedding_pool,
             )
         return self._process_waiting_requests(
-            recv_reqs, WaitingZmqRequest, embedding_pool=self.embedding_pool
+            recv_reqs,
+            WaitingZmqRequest,
+            embedding_pool=self.embedding_pool,
+            registration_runner=self.registration_runner,
         )
 
     async def encode(
@@ -2552,7 +2620,11 @@ class MMReceiverGrpc(MMReceiverBase):
 
     # For zmq_to_scheduler
     def process_waiting_requests(self, recv_reqs):
-        return self._process_waiting_requests(recv_reqs, WaitingZmqRequestGrpc)
+        return self._process_waiting_requests(
+            recv_reqs,
+            WaitingZmqRequestGrpc,
+            registration_runner=self.registration_runner,
+        )
 
     async def encode(
         self,

--- a/python/sglang/srt/disaggregation/encoder/receiver.py
+++ b/python/sglang/srt/disaggregation/encoder/receiver.py
@@ -929,15 +929,6 @@ class WaitingMMRequestBase(ABC):
         self.release_resources()
         self.close_recv_socket()
 
-    async def _check_encoder_responses(self, responses, endpoint: str) -> bool:
-        """Validate gathered encoder responses; on the first error, FAIL the
-        request and release its resources. Returns True if all succeeded."""
-        msg = await _extract_encoder_error(responses, endpoint, f"rid={self.rid}")
-        if msg is None:
-            return True
-        self._fail_and_release(msg)
-        return False
-
     def _is_valid_embedding_part(self, recv_obj) -> bool:
         """Check for and drop stale or out-of-sync payloads; normalize the part req_id to the original rid."""
         original_req_id = extract_original_req_id(recv_obj.req_id)
@@ -1310,6 +1301,8 @@ class WaitingRDMARequest(WaitingMMRequestBase):
         self._buffer_lock = threading.Lock()
         self._terminal = False
         self._receive_running = False
+        self._receive_error = None
+        self._receive_error_lock = threading.Lock()
 
     def send_encode_request(self):
         # Base-class hook. The tokenizer owns /encode, so this rank only pulls
@@ -1322,12 +1315,33 @@ class WaitingRDMARequest(WaitingMMRequestBase):
             asyncio.run(self._pull_meta_and_receive_embedding())
         except Exception as e:
             logger.error(f"RDMA receive failed for rid={self.rid}: {e}")
-            self._fail_and_release(str(e))
+            self._record_receive_error(str(e))
         finally:
             with self._buffer_lock:
                 self._receive_running = False
                 if self._terminal:
                     self._release_buffer_locked()
+
+    def _record_receive_error(self, error_msg, error_code=None) -> None:
+        """Pass a worker-thread failure to the scheduler thread."""
+        with self._receive_error_lock:
+            self._receive_error = (error_msg, error_code)
+
+    def _try_recv_mm_data(self):
+        with self._receive_error_lock:
+            receive_error, self._receive_error = self._receive_error, None
+        if receive_error is not None:
+            self._fail_and_release(*receive_error)
+            return
+        super()._try_recv_mm_data()
+
+    async def _check_encoder_responses(self, responses, endpoint: str) -> bool:
+        """Record network failures for the scheduler thread to consume."""
+        msg = await _extract_encoder_error(responses, endpoint, f"rid={self.rid}")
+        if msg is None:
+            return True
+        self._record_receive_error(msg)
+        return False
 
     async def _pull_meta_and_receive_embedding(self):
         """Pull per-part sizes, allocate the landing buffer, then drive /send.
@@ -1395,7 +1409,7 @@ class WaitingRDMARequest(WaitingMMRequestBase):
                     )
                     if alloc_result is None:
                         # Oversize or alloc timeout — fatal for this request.
-                        self._fail_and_release(
+                        self._record_receive_error(
                             f"EmbeddingPool could not allocate "
                             f"{total_bytes // (1024 * 1024)}MB (oversize or "
                             f"timeout). Raise SGLANG_EMBEDDING_POOL_SIZE_MB."
@@ -2265,6 +2279,7 @@ class MMReceiverBase(ABC):
             else:  # status_value == WaitingMMRequestStatus.PENDING
                 new_waiting.append(waiting_req)
                 continue
+            waiting_req.close_recv_socket()
             self.waiting_by_rid.pop(waiting_req.rid, None)
 
         self.waiting_list = new_waiting

--- a/test/registered/unit/disaggregation/test_encode_receiver.py
+++ b/test/registered/unit/disaggregation/test_encode_receiver.py
@@ -12,6 +12,7 @@ from unittest.mock import patch
 from sglang.srt.disaggregation.encoder.receiver import (
     MMReceiverBase,
     WaitingMMRequestStatus,
+    WaitingRDMARequest,
     WaitingZmqRequest,
     WaitingZmqRequestGrpc,
     _ReceiveRegistrationRunner,
@@ -205,6 +206,97 @@ class TestEncodeReceiverRequestConstruction(CustomTestCase):
 
         self.assertEqual(req.extra_key, "classification")
         self.assertEqual(req.cache_salt, "tenant-a")
+
+    def test_rdma_worker_error_is_released_on_scheduler_thread(self):
+        scheduler_thread = threading.get_ident()
+
+        class ThreadCheckedSocket:
+            closed_by = None
+
+            def close(self):
+                self.closed_by = threading.get_ident()
+
+        recv_socket = ThreadCheckedSocket()
+        request = WaitingRDMARequest.__new__(WaitingRDMARequest)
+        request.rid = "request-1"
+        request.status = WaitingMMRequestStatus.PENDING
+        request.error_msg = None
+        request.error_code = None
+        request.recv_socket = recv_socket
+        request._receive_error = None
+        request._receive_error_lock = threading.Lock()
+        request._buffer_lock = threading.Lock()
+        request._terminal = False
+        request._receive_running = False
+        request.embeddings_buffer = None
+        request._pool_slot_id = None
+        request.embedding_pool = None
+        request._mm_finalizer = None
+
+        worker = threading.Thread(
+            target=lambda: asyncio.run(
+                request._check_encoder_responses(
+                    [ConnectionError("encoder unavailable")], "/send"
+                )
+            )
+        )
+        worker.start()
+        worker.join(timeout=1)
+
+        self.assertFalse(worker.is_alive())
+        self.assertEqual(request.status, WaitingMMRequestStatus.PENDING)
+        self.assertIsNone(request.recv_socket.closed_by)
+
+        request._try_recv_mm_data()
+
+        self.assertEqual(request.status, WaitingMMRequestStatus.FAIL)
+        self.assertIsNone(request.recv_socket)
+        self.assertTrue(request._terminal)
+        self.assertEqual(recv_socket.closed_by, scheduler_thread)
+
+    def test_tp_peer_failure_closes_local_receive_socket(self):
+        class WaitingRequest:
+            rid = "request-1"
+            recv_req = SimpleNamespace(rid=rid)
+            status = WaitingMMRequestStatus.PENDING
+            error_msg = "peer failed"
+            error_code = None
+            start_time = 0
+            released = False
+            closed = False
+
+            def _try_recv_mm_data(self):
+                pass
+
+            def release_resources(self):
+                self.released = True
+
+            def close_recv_socket(self):
+                self.closed = True
+
+        waiting_req = WaitingRequest()
+        receiver = SimpleNamespace(
+            waiting_list=[waiting_req],
+            waiting_by_rid={waiting_req.rid: waiting_req},
+            scheduler_recv_socket=None,
+            wait_timeout=float("inf"),
+            tp_group=SimpleNamespace(cpu_group=object()),
+            _drain_scheduler_embeddings=lambda: None,
+            _sync_fail_info_across_tp=lambda request: None,
+            create_req=lambda request: request,
+        )
+
+        def force_peer_failure(status, **kwargs):
+            status.fill_(WaitingMMRequestStatus.FAIL)
+
+        with patch("torch.distributed.all_reduce", force_peer_failure):
+            _, abort_reqs = MMReceiverBase._process_waiting_requests(
+                receiver, [], waiting_cls=None
+            )
+
+        self.assertTrue(waiting_req.released)
+        self.assertTrue(waiting_req.closed)
+        self.assertEqual(len(abort_reqs), 1)
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_encode_receiver.py
+++ b/test/registered/unit/disaggregation/test_encode_receiver.py
@@ -1,16 +1,166 @@
-"""Unit tests for request construction in the encode-disaggregation path."""
+"""Unit tests for the encode-disaggregation receiver."""
 
+import asyncio
+import threading
+import time
 import unittest
 from array import array
+from http import HTTPStatus
 from types import SimpleNamespace
+from unittest.mock import patch
 
-from sglang.srt.disaggregation.encoder.receiver import MMReceiverBase
+from sglang.srt.disaggregation.encoder.receiver import (
+    MMReceiverBase,
+    WaitingMMRequestStatus,
+    WaitingZmqRequest,
+    WaitingZmqRequestGrpc,
+    _ReceiveRegistrationRunner,
+)
 from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.managers.schedule_batch import Modality
 from sglang.srt.sampling.sampling_params import SamplingParams
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+def _make_registration_request(request_cls):
+    request = request_cls.__new__(request_cls)
+    request.rid = "registration-test"
+    request.registration_runner = _ReceiveRegistrationRunner(
+        "test-encoder-receive-registration"
+    )
+    request.registration_future = None
+    request.registration_error = None
+    request.registration_lock = threading.Lock()
+    request.status = WaitingMMRequestStatus.PENDING
+    request.error_msg = None
+    request.error_code = None
+    request.embedding_pool = None
+    request.embeddings_buffer = None
+    request.recv_embedding_data = None
+    request._pool_slot_id = None
+    request._mm_finalizer = None
+    request.recv_socket = None
+    request.recv_req = SimpleNamespace(rid=request.rid)
+    request.num_items_assigned = {Modality.IMAGE: [1]}
+    request.encoder_urls = ["http://encoder"]
+    request.host_name = "127.0.0.1"
+    request.receive_count = 1
+    request.embedding_port = 12345
+    return request
+
+
+def _cancel_registration(request):
+    future = request.registration_future
+    request.release_resources()
+    deadline = time.monotonic() + 1
+    while not future.done() and time.monotonic() < deadline:
+        time.sleep(0.01)
+    assert future.cancelled()
+
+
+class BlockingResponse:
+    def __init__(self, started):
+        self.started = started
+
+    async def __aenter__(self):
+        self.started.set()
+        await asyncio.Event().wait()
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class BlockingSession:
+    started = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return False
+
+    def post(self, *args, **kwargs):
+        return BlockingResponse(self.started)
+
+
+class FailingResponse:
+    async def __aenter__(self):
+        raise ConnectionError("encoder unavailable")
+
+    async def __aexit__(self, *args):
+        return False
+
+
+class FailingSession(BlockingSession):
+    def post(self, *args, **kwargs):
+        return FailingResponse()
+
+
+class TestReceiveRegistration(CustomTestCase):
+    def test_http_registration_does_not_block_scheduler(self):
+        started = threading.Event()
+        BlockingSession.started = started
+        request = _make_registration_request(WaitingZmqRequest)
+        with patch(
+            "sglang.srt.disaggregation.encoder.receiver.aiohttp.ClientSession",
+            BlockingSession,
+        ):
+            scheduler_call = threading.Thread(
+                target=request.send_encode_request, daemon=True
+            )
+            scheduler_call.start()
+            self.assertTrue(started.wait(timeout=1))
+            scheduler_call.join(timeout=0.1)
+
+        self.assertFalse(scheduler_call.is_alive())
+        self.assertEqual(request.status, WaitingMMRequestStatus.PENDING)
+        _cancel_registration(request)
+
+    def test_grpc_registration_does_not_block_scheduler(self):
+        started = threading.Event()
+
+        async def blocking_registration(*args, **kwargs):
+            started.set()
+            await asyncio.Event().wait()
+
+        request = _make_registration_request(WaitingZmqRequestGrpc)
+        with patch(
+            "sglang.srt.disaggregation.encoder.receiver._grpc_scheduler_receive_url",
+            blocking_registration,
+        ):
+            scheduler_call = threading.Thread(
+                target=request.send_encode_request, daemon=True
+            )
+            scheduler_call.start()
+            self.assertTrue(started.wait(timeout=1))
+            scheduler_call.join(timeout=0.1)
+
+        self.assertFalse(scheduler_call.is_alive())
+        self.assertEqual(request.status, WaitingMMRequestStatus.PENDING)
+        _cancel_registration(request)
+
+    def test_failure_is_request_local(self):
+        request = _make_registration_request(WaitingZmqRequest)
+        with patch(
+            "sglang.srt.disaggregation.encoder.receiver.aiohttp.ClientSession",
+            FailingSession,
+        ):
+            request.send_encode_request()
+            deadline = time.monotonic() + 1
+            while request.status == WaitingMMRequestStatus.PENDING:
+                self.assertLess(time.monotonic(), deadline)
+                request._try_recv_mm_data()
+                time.sleep(0.01)
+
+        self.assertEqual(request.status, WaitingMMRequestStatus.FAIL)
+        self.assertEqual(request.error_code, HTTPStatus.BAD_GATEWAY)
+        self.assertIn("encoder unavailable", request.error_msg)
 
 
 class TestEncodeReceiverRequestConstruction(CustomTestCase):


### PR DESCRIPTION
## Summary

- combine the scheduler-blocking receive URL registration fix from #36965 with the background RDMA failure handoff from #36967
- keep all scheduler-owned ZMQ socket closure, request release, and TP consensus on the scheduler thread
- report background control-plane and RDMA failures as request-local errors at the scheduler safe point

## Thread-ownership design

Receive URL registration may block on remote encoder availability, so it runs on a background asyncio loop. RDMA receive work likewise runs outside the scheduler. Neither background path closes a scheduler-owned ZMQ socket or releases request resources: it stores the first failure, and the scheduler consumes it on its next tick before TP-wide consensus. This preserves the ownership model introduced by #30398 and prevents a worker thread from racing the scheduler poll loop.

Supersedes #36965 and #36967.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:hourglass_flowing_sand: [Run #33258446231](https://github.com/sgl-project/sglang/actions/runs/33258446231)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33258446172](https://github.com/sgl-project/sglang/actions/runs/33258446172)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:hourglass_flowing_sand: [Run #33258446234](https://github.com/sgl-project/sglang/actions/runs/33258446234)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->