### PR TITLE
Fix tokenize max_model_len serialization

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_tokenize.py
+++ b/python/sglang/srt/entrypoints/openai/serving_tokenize.py
@@ -44,7 +44,7 @@ class OpenAIServingTokenize(OpenAIServingBase):
     ) -> Union[TokenizeResponse, ErrorResponse]:
         try:
             tokenizer = self.tokenizer_manager.tokenizer
-            max_model_len = getattr(tokenizer, "model_max_length", -1)
+            max_model_len = self.tokenizer_manager.model_config.context_len
 
             if request.messages is not None:
                 token_ids = self._tokenize_chat_request(request)

--- a/test/registered/unit/entrypoints/openai/test_serving_tokenize.py
+++ b/test/registered/unit/entrypoints/openai/test_serving_tokenize.py
@@ -1,0 +1,48 @@
+import json
+import unittest
+from types import SimpleNamespace
+
+from fastapi.responses import ORJSONResponse
+
+from sglang.srt.entrypoints.openai.protocol import TokenizeRequest
+from sglang.srt.entrypoints.openai.serving_tokenize import OpenAIServingTokenize
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+
+class _Tokenizer:
+    # Hugging Face uses int(1e30) when a tokenizer has no defined maximum.
+    model_max_length = int(1e30)
+
+    def encode(self, text, add_special_tokens=True):
+        return [101, 7592, 102] if add_special_tokens else [7592]
+
+
+class OpenAIServingTokenizeTest(unittest.IsolatedAsyncioTestCase):
+    async def test_uses_effective_context_length_in_serializable_response(self):
+        tokenizer_manager = SimpleNamespace(
+            tokenizer=_Tokenizer(),
+            model_config=SimpleNamespace(context_len=65_536),
+            server_args=SimpleNamespace(),
+        )
+        serving = OpenAIServingTokenize(tokenizer_manager)
+        request = TokenizeRequest(prompt="hello")
+
+        response = await serving._handle_non_streaming_request(
+            request, request, raw_request=None
+        )
+        body = ORJSONResponse(content=response.model_dump()).body
+
+        self.assertEqual(
+            json.loads(body),
+            {
+                "tokens": [101, 7592, 102],
+                "count": 3,
+                "max_model_len": 65_536,
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`/v1/tokenize` currently copies `tokenizer.model_max_length` into the response. Hugging Face uses `int(1e30)` as a sentinel when a tokenizer has no declared maximum, and FastAPI's `ORJSONResponse` rejects that value with `TypeError: Integer exceeds 64-bit range`. This is the root cause reported for GPT-OSS in #16718 and also affects other tokenizers that use the sentinel.

The response should report the effective context length configured by the running SGLang server, consistent with `/v1/models` and the gRPC tokenize response.

## Modifications

- Populate `TokenizeResponse.max_model_len` from `TokenizerManager.model_config.context_len`.
- Add a CPU-only regression test that passes a tokenizer with the Hugging Face sentinel through the tokenize handler and serializes the resulting response with `ORJSONResponse`.

The test fails on `main` with the exact `Integer exceeds 64-bit range` exception and passes with this change. It does not load a model or require a GPU.

## Accuracy Tests

Not applicable; token IDs are unchanged.

## Speed Tests and Profiling

Not applicable; this only changes the metadata source used in the tokenize response.

## Tests

```bash
PYTHONPATH=python python -m unittest test/registered/unit/entrypoints/openai/test_serving_tokenize.py -v
pre-commit run --files python/sglang/srt/entrypoints/openai/serving_tokenize.py test/registered/unit/entrypoints/openai/test_serving_tokenize.py
```

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [x] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations). No documentation change is needed because the existing field now returns the server's effective value.
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed). Neither applies to this response-metadata fix.
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33259588274](https://github.com/sgl-project/sglang/actions/runs/33259588274)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33259588200](https://github.com/sgl-project/sglang/actions/runs/33259588200)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33259588284](https://github.com/sgl-project/sglang/actions/runs/33259588284)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->