### PR TITLE
[HiCache] Test device-anchored storage prefetch

### DIFF
--- a/test/registered/unit/managers/test_scheduler_hicache_prefetch.py
+++ b/test/registered/unit/managers/test_scheduler_hicache_prefetch.py
@@ -1,0 +1,68 @@
+"""Regression tests for scheduler-driven HiCache storage prefetch."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase, maybe_stub_sgl_kernel
+
+maybe_stub_sgl_kernel()
+
+from sglang.srt.managers.scheduler import Scheduler
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+
+class TestSchedulerHiCachePrefetch(CustomTestCase):
+    @patch("sglang.srt.managers.scheduler.get_memory")
+    def test_buffer_mode_prefetch_extends_device_prefix(self, get_memory):
+        """A remote suffix must extend the matching device-only prefix."""
+        get_memory.return_value = SimpleNamespace(
+            hicache_host_memory_mode="buffer_only"
+        )
+
+        root_node = object()
+        device_node = object()
+        tree_cache = MagicMock()
+        tree_cache.hicache_storage_pass_prefix_keys = True
+        tree_cache.is_root.side_effect = lambda node: node is root_node
+        tree_cache.is_backuped.return_value = False
+        tree_cache.get_last_hash_value.side_effect = (
+            lambda node: "device-hash" if node is device_node else "root-hash"
+        )
+        tree_cache.get_prefix_hash_values.side_effect = (
+            lambda node: ["device-prefix-key"] if node is device_node else []
+        )
+
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.enable_hicache_storage = True
+        scheduler.tree_cache = tree_cache
+
+        req = SimpleNamespace(
+            rid="request-id",
+            last_host_node=root_node,
+            last_node=device_node,
+            prefix_indices=[0, 1],
+            host_hit_length=0,
+            full_untruncated_fill_ids=[10, 11, 12, 13, 14, 15],
+            extra_key=None,
+            cache_salt=None,
+            init_next_round_input=MagicMock(),
+            _compute_max_prefix_len=MagicMock(return_value=5),
+        )
+
+        scheduler._prefetch_kvcache(req)
+
+        tree_cache.prefetch_from_storage.assert_called_once()
+        args = tree_cache.prefetch_from_storage.call_args.args
+        kwargs = tree_cache.prefetch_from_storage.call_args.kwargs
+        self.assertIs(args[1], device_node)
+        self.assertEqual(args[2], [12, 13, 14])
+        self.assertEqual(args[3], "device-hash")
+        self.assertEqual(args[4], ["device-prefix-key"])
+        self.assertEqual(kwargs["matched_prefix_tokens"], [10, 11])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# [HiCache] Add scheduler regression coverage for device-anchored storage prefetch

## Motivation

In HiCache buffer-only mode, a request can match a device-resident prefix while
its host-cache match remains at the root. The scheduler must start the remote
suffix lookup from the device node so the insertion anchor, previous hash,
prefix-key chain, and matched token boundary all describe the same prefix.

This behavior was introduced with buffer-only mode in #34798. Existing unified
cache tests cover a staged remote suffix after the correct device anchor has
already been supplied, but they do not verify that the scheduler selects that
anchor. A scheduler regression could therefore restart the hash chain at the
root without failing the lower-level tests.

## Modifications

- Add one CPU-only scheduler unit test for a device-only prefix followed by a
  remote suffix.
- Verify that storage prefetch receives the device node, its last hash and
  prefix keys, the suffix after the device hit, and the matching prefix tokens.

No production code is changed.

## Accuracy Tests

Not applicable. This is a test-only change and does not affect model outputs.

## Speed Tests and Profiling

Not applicable. The new test uses mocks, launches no server, and requires no
GPU.

## Test Plan

Linux CI command:

```text
python test/registered/unit/managers/test_scheduler_hicache_prefetch.py
```

Local verification completed:

- Python syntax compilation passed.
- `git diff --check` passed.
- A semantic replay of `_prefetch_kvcache` passed on current `main` and
  detected the root-anchor regression on the parent of #34798.

## Checklist

- [x] Pass local syntax and whitespace checks; repository pre-commit remains a
  CI gate.
- [x] Add a focused unit test registered in `base-a-test-cpu`.
- [x] Documentation update is not required for this test-only change.
- [x] Accuracy and speed benchmarks are not applicable.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33261204617](https://github.com/sgl-project/sglang/actions/runs/33261204617)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33261204531](https://github.com/sgl-project/sglang/actions/runs/33261204531)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33261204607](https://github.com/sgl-project/sglang/actions/runs/33261204607)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->