### PR TITLE
[AMD] Enable AITER mHC on gfx942

### DIFF
--- a/python/sglang/kernels/ops/layernorm/mhc.py
+++ b/python/sglang/kernels/ops/layernorm/mhc.py
@@ -16,7 +16,7 @@ from sglang.srt.environ import envs
 from sglang.srt.layers.attention.dsa.utils import is_dsa_prefill_cp_round_robin_split
 from sglang.srt.layers.dp_attention import is_allocation_symmetric
 from sglang.srt.layers.utils.common import strict_contiguous
-from sglang.srt.utils import is_gfx95_supported, is_hip
+from sglang.srt.utils import is_gfx95_supported, is_gfx942_supported, is_hip
 from sglang.srt.utils.common import get_bool_env_var
 
 logger = logging.getLogger(__name__)
@@ -30,7 +30,7 @@ def _use_aiter_mhc() -> bool:
     return (
         not _AITER_MHC_RUNTIME_DISABLED
         and is_hip()
-        and is_gfx95_supported()
+        and (is_gfx942_supported() or is_gfx95_supported())
         and get_bool_env_var("SGLANG_USE_AITER")
     )
 
@@ -84,7 +84,7 @@ def _try_aiter_mhc_pre(
         return None
 
     if not _AITER_MHC_ACTIVE_LOGGED:
-        logger.info("Using AITER gfx950 mHC pre/post kernels")
+        logger.info("Using AITER gfx9 mHC pre/post kernels")
         _AITER_MHC_ACTIVE_LOGGED = True
     return result
 

--- a/test/registered/unit/models/test_glm5_next_aiter_mhc.py
+++ b/test/registered/unit/models/test_glm5_next_aiter_mhc.py
@@ -31,25 +31,29 @@ def _fake_aiter_mhc_module(*, mhc_pre=None, mhc_post=None):
     }
 
 
-def test_aiter_mhc_gate_is_rocm_gfx95_only():
-    with (
-        patch.object(mhc, "is_hip", return_value=True),
-        patch.object(mhc, "is_gfx95_supported", return_value=True),
-        patch.object(mhc, "get_bool_env_var", return_value=True),
-        patch.object(mhc, "_AITER_MHC_RUNTIME_DISABLED", False),
-    ):
-        assert mhc._use_aiter_mhc()
+def test_aiter_mhc_gate_supports_rocm_gfx942_and_gfx95():
+    for is_gfx942, is_gfx95 in ((True, False), (False, True)):
+        with (
+            patch.object(mhc, "is_hip", return_value=True),
+            patch.object(mhc, "is_gfx942_supported", return_value=is_gfx942),
+            patch.object(mhc, "is_gfx95_supported", return_value=is_gfx95),
+            patch.object(mhc, "get_bool_env_var", return_value=True),
+            patch.object(mhc, "_AITER_MHC_RUNTIME_DISABLED", False),
+        ):
+            assert mhc._use_aiter_mhc()
 
-    for is_hip, is_gfx95, use_aiter in (
-        (False, True, True),
-        (True, False, True),
-        (True, True, False),
+    for is_hip, is_gfx942, is_gfx95, use_aiter, runtime_disabled in (
+        (False, True, False, True, False),
+        (True, False, False, True, False),
+        (True, True, False, False, False),
+        (True, True, False, True, True),
     ):
         with (
             patch.object(mhc, "is_hip", return_value=is_hip),
+            patch.object(mhc, "is_gfx942_supported", return_value=is_gfx942),
             patch.object(mhc, "is_gfx95_supported", return_value=is_gfx95),
             patch.object(mhc, "get_bool_env_var", return_value=use_aiter),
-            patch.object(mhc, "_AITER_MHC_RUNTIME_DISABLED", False),
+            patch.object(mhc, "_AITER_MHC_RUNTIME_DISABLED", runtime_disabled),
         ):
             assert not mhc._use_aiter_mhc()
 


### PR DESCRIPTION
## Motivation

The GLM-5.3-Flash feature branch already uses AITER mHC kernels on gfx95. The same AITER implementation is correct and substantially faster than the Torch fallback on gfx942 (MI300X), but the architecture gate currently prevents that path from running.

This draft targets the active `xinyuan/glm-5.3-flash-support` branch so it can be reviewed alongside #36507 instead of competing with it.

## Modifications

- Admit gfx942 in the existing AITER mHC pre/post dispatch gate.
- Preserve the existing gfx95 behavior and runtime fallback.
- Generalize the one-time log message from gfx950 to gfx9.
- Extend the CPU gate test to cover gfx942, gfx95, disabled AITER, unsupported devices, and runtime disablement.

## Accuracy Tests

Measured on 8x MI300X against GLM-5.3-Flash source `e1887489c4427a4f30c5d5356bfcc1da5589a9b2`:

- Primitive pre/post outputs passed `rtol=atol=1e-2`.
- 100-question serving gate: 90/100, zero invalid outputs.

The patch has been rebased to current feature head `7fa1924c04487feffc3f5f111a424ec1f0b22362`. A matched GPU rerun on that moving head remains pending.

## Speed Tests and Profiling

8x MI300X, TP8, FP8 checkpoint, exact batch 8:

- Torch fallback serving: **123.169 output tok/s**
- gfx942 AITER mHC: **296.569 output tok/s** (**2.41x**)
- Primitive mHC pre: **18.952x** faster
- Primitive mHC post: **2.323x** faster

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33261726580](https://github.com/sgl-project/sglang/actions/runs/33261726580)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33261726530](https://github.com/sgl-project/sglang/actions/runs/33261726530)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33261726584](https://github.com/sgl-project/sglang/actions/runs/33261726584)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->