### PR TITLE
[AMD] Enable GLM shared-expert fusion on gfx942

### DIFF
--- a/python/sglang/srt/models/glm5_next.py
+++ b/python/sglang/srt/models/glm5_next.py
@@ -100,6 +100,7 @@ from sglang.srt.models.deepseek_common.deepseek_weight_loader import (
 from sglang.srt.models.deepseek_common.utils import (
     _device_sm,
     _is_cuda,
+    _use_aiter,
     _use_aiter_gfx95,
 )
 from sglang.srt.models.deepseek_v2 import DeepseekV2AttentionMLA
@@ -120,6 +121,7 @@ from sglang.srt.multimodal.mm_utils import (
 )
 from sglang.srt.runtime_context import get_forward, get_parallel, get_server_args
 from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.utils import is_gfx942_supported
 from sglang.srt.utils.common import (
     BumpAllocator,
     LazyValue,
@@ -136,6 +138,7 @@ if _use_aiter_gfx95:
 
 logger = logging.getLogger(__name__)
 _GLM_AITER_FUSED_MHC_LOGGED = False
+_use_aiter_gfx942 = _use_aiter and is_gfx942_supported()
 
 
 @torch.compile
@@ -1400,7 +1403,7 @@ class Glm5NextForConditionalGeneration(nn.Module):
         text_config = getattr(hf_config, "text_config", hf_config)
         if not getattr(text_config, "n_shared_experts", None):
             return "No shared experts are defined in the config."
-        if not (_is_cuda or _use_aiter_gfx95):
+        if not (_is_cuda or _use_aiter_gfx942 or _use_aiter_gfx95):
             return (
                 "Shared experts fusion requires CUDA or the supported "
                 "AITER ROCm path."

--- a/test/registered/unit/models/test_shared_experts_fusion_gates.py
+++ b/test/registered/unit/models/test_shared_experts_fusion_gates.py
@@ -200,6 +200,7 @@ class TestGlm5NextGate(_FusionGateCase):
         self,
         *,
         is_cuda=False,
+        use_aiter_gfx942=False,
         use_aiter_gfx95=False,
         device_sm=None,
         moe_ep_size=1,
@@ -210,6 +211,9 @@ class TestGlm5NextGate(_FusionGateCase):
         backend = SimpleNamespace(is_deepep=lambda: deepep)
         with (
             unittest.mock.patch.object(glm5_next, "_is_cuda", is_cuda),
+            unittest.mock.patch.object(
+                glm5_next, "_use_aiter_gfx942", use_aiter_gfx942
+            ),
             unittest.mock.patch.object(glm5_next, "_use_aiter_gfx95", use_aiter_gfx95),
             unittest.mock.patch.object(glm5_next, "_device_sm", device_sm),
             unittest.mock.patch.object(
@@ -222,7 +226,8 @@ class TestGlm5NextGate(_FusionGateCase):
                 moe_ep_size=moe_ep_size,
             )
 
-    def test_aiter_gfx95_enables_shared_expert_fusion(self):
+    def test_supported_aiter_rocm_paths_enable_shared_expert_fusion(self):
+        self.assertIsNone(self._reason_for_backend(use_aiter_gfx942=True))
         self.assertIsNone(self._reason_for_backend(use_aiter_gfx95=True))
 
     def test_unsupported_non_cuda_backend_disables_shared_expert_fusion(self):
@@ -238,13 +243,13 @@ class TestGlm5NextGate(_FusionGateCase):
     def test_expert_parallelism_still_disables_shared_expert_fusion(self):
         self.assertIn(
             "expert parallelism",
-            self._reason_for_backend(use_aiter_gfx95=True, moe_ep_size=2),
+            self._reason_for_backend(use_aiter_gfx942=True, moe_ep_size=2),
         )
 
     def test_deepep_still_disables_shared_expert_fusion(self):
         self.assertIn(
             "Deepep",
-            self._reason_for_backend(use_aiter_gfx95=True, deepep=True),
+            self._reason_for_backend(use_aiter_gfx942=True, deepep=True),
         )
 
 


### PR DESCRIPTION
## Motivation

GLM-5.3-Flash can fold its single shared expert into the routed AITER MoE on gfx942. The feature branch currently permits this fusion on CUDA and gfx95 but disables the already validated gfx942 path, leaving a separate shared-expert computation in every layer.

This draft targets the active `xinyuan/glm-5.3-flash-support` branch so it can be reviewed alongside #36507.

## Modifications

- Add an explicit gfx942 AITER gate for GLM-5.3-Flash shared-expert fusion.
- Preserve the current CUDA and gfx95 paths.
- Keep expert-parallel and DeepEP exclusions unchanged.
- Extend the fusion-gate unit test for gfx942 and gfx95.

The gate is deliberately architecture-specific; it does not enable shared-expert fusion for every ROCm/AITER device.

## Accuracy Tests

Measured on 8x MI300X against GLM-5.3-Flash source `e1887489c4427a4f30c5d5356bfcc1da5589a9b2`:

- Paired 1,000-question control: **91.90%**
- Paired 1,000-question candidate: **91.60%**
- One-sided 95% lower confidence bound: **-1.45 percentage points**
- Preregistered non-inferiority margin: **-2.00 percentage points**
- Non-inferiority passed.

The patch has been rebased to current feature head `7fa1924c04487feffc3f5f111a424ec1f0b22362`. A matched GPU rerun on that moving head remains pending.

## Speed Tests and Profiling

8x MI300X, TP8, FP8 checkpoint:

- Exact c16 before fusion: **333.572 output tok/s**
- Exact c16 with fusion: **404.226 output tok/s** (**+21.18%**)
- Mixed c16 with fusion: **459.428 output tok/s**

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33261759296](https://github.com/sgl-project/sglang/actions/runs/33261759296)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33261759293](https://github.com/sgl-project/sglang/actions/runs/33261759293)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33261759190](https://github.com/sgl-project/sglang/actions/runs/33261759190)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->