### PR TITLE
fix(mimo-v2): reduce audio encoder attention over the attn-TP group

### DIFF
--- a/python/sglang/srt/models/mimo_audio.py
+++ b/python/sglang/srt/models/mimo_audio.py
@@ -21,6 +21,7 @@ from transformers.models.qwen2.configuration_qwen2 import Qwen2Config
 from transformers.models.qwen2.modeling_qwen2 import Qwen2Model
 
 from sglang.srt.layers.attention.vision import VisionAttention
+from sglang.srt.layers.dp_attention import is_dp_attention_enabled
 from sglang.srt.layers.quantization.base_config import QuantizationConfig
 from sglang.srt.runtime_context import (
     get_model,
@@ -503,6 +504,13 @@ class AudioEncoderAttention(nn.Module):
         self.window_size = window_size
         self.causal = causal
 
+        # The audio encoder weights are sharded over the attention-TP group
+        # (see _remap_audio_tokenizer_state_dict), so its output projection
+        # must reduce over that same group. Without this flag the reduce runs
+        # on the full TP group, which deadlocks under DP attention whenever
+        # only one DP group's batch contains audio items (the other group
+        # never enters the collective), and silently sums partials across
+        # unrelated DP groups even when both do.
         self.attn = VisionAttention(
             embed_dim=embed_dim,
             num_heads=num_heads,
@@ -513,6 +521,7 @@ class AudioEncoderAttention(nn.Module):
             flatten_batch=True,
             window_size=window_size,
             customized_position_embedding_applier=_audio_rope_applier,
+            use_dp_attention_reduce=is_dp_attention_enabled(),
             prefix="attn",
         )
 

--- a/test/registered/e2e/models/test_mimo_v2.py
+++ b/test/registered/e2e/models/test_mimo_v2.py
@@ -1,13 +1,17 @@
+import os
 import unittest
+
+import requests
 
 from sglang.srt.environ import envs
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.eval_accuracy_kit import GSM8KMixin
 from sglang.test.server_fixtures.mmmu_fixture import MMMUServerBase
+from sglang.test.vlm_utils import AUDIO_TRUMP_SPEECH_URL
 
 register_cuda_ci(est_time=317, stage="base-c", runner_config="8-gpu-h200")
 
-MIMO_V2_MODEL = "XiaomiMiMo/MiMo-V2.5"
+MIMO_V2_MODEL = os.environ.get("SGLANG_TEST_MIMO_V2_MODEL", "XiaomiMiMo/MiMo-V2.5")
 MIMO_V2_OTHER_ARGS = [
     "--tp",
     "8",
@@ -54,6 +58,36 @@ class TestMiMoV2(GSM8KMixin, MMMUServerBase):
     def setUpClass(cls):
         with envs.SGLANG_ENABLE_UNIFIED_RADIX_TREE.override(True):
             super().setUpClass()
+
+    def test_audio_request_with_dp_attention(self):
+        audio_url = os.environ.get("SGLANG_TEST_AUDIO_PATH", AUDIO_TRUMP_SPEECH_URL)
+        response = requests.post(
+            f"{self.base_url}/v1/chat/completions",
+            json={
+                "model": "default",
+                "messages": [
+                    {
+                        "role": "user",
+                        "content": [
+                            {"type": "audio_url", "audio_url": {"url": audio_url}},
+                            {"type": "text", "text": "Transcribe this audio."},
+                        ],
+                    }
+                ],
+                "temperature": 0,
+                "max_tokens": 1,
+                "routed_dp_rank": 0,
+            },
+            timeout=120,
+        )
+
+        self.assertEqual(response.status_code, 200, response.text)
+        response_json = response.json()
+        self.assertEqual(len(response_json["choices"]), 1)
+
+        usage_details = response_json["usage"].get("prompt_tokens_details")
+        self.assertIsNotNone(usage_details, "prompt carried no multimodal tokens")
+        self.assertGreater(usage_details.get("audio_tokens", 0), 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

Fixes #37059.

MiMo-V2.5 can deadlock on an audio request when it is served with TP8/DP2 and DP attention. The audio-tokenizer encoder attention weights are sharded over the attention-TP group, but its output projection defaults to reducing over the full TP group. When an audio request is routed to one DP rank, the other DP group never enters that collective, so the server wedges. If both DP groups contain audio, the same full-TP reduction can also mix unrelated batches.

## Changes

- Pass `use_dp_attention_reduce=is_dp_attention_enabled()` to the audio encoder's `VisionAttention`, so the output projection reduces over the same attention-TP group as its sharded weights. Non-DP-attention behavior is unchanged.
- Rebase the change onto current `main` at `ccf9fe6590ee7437005d8353c3c67d2dc4d25fcb` (candidate commit `a565eac941c89d993c64ec5d20637c79547545f8`).
- Extend the existing registered MiMo-V2 test on `base-c / 8-gpu-h200` with one audio request pinned to `routed_dp_rank=0`. The test uses `max_tokens=1` and a 120-second client timeout, checks that the request returns HTTP 200 with one choice, and verifies that `prompt_tokens_details.audio_tokens` is greater than zero so it cannot pass without exercising the audio path. Model and audio paths can be overridden for offline test environments.

`mimo_v2_asr.py` inherits the fix through `AudioEncoderMixin`.

## Verification

### Existing 8×H200 validation

The same fix was previously tested with `--tp 8 --dp 2 --enable-dp-attention --enable-dp-lm-head --mm-enable-dp-encoder`. Each post-fix run covered six AV cases with two samples each: text only, audio only, video without audio, video with an audio track, video with a short audio track, and video plus a separate WAV file.

| Configuration | Before | After |
|---|---|---|
| TP8/DP2, official FP8 | The first audio request hung for 600 seconds and the NCCL watchdog killed the server | 12/12 cases passed; 0 NCCL watchdog timeouts |
| TP8/DP2, BF16 export | The first audio request reproduced the same hang | 12/12 cases passed; 0 NCCL watchdog timeouts |
| TP4/DP1, FP8 control | Not affected by the DP-attention bug | 12/12 cases passed; 0 NCCL watchdog timeouts |

Audio transcription from the fixed TP8/DP2 runs matched the TP4/DP1 reference output.

### Current-main registered regression

<!-- current-main-infra-result:start -->
Candidate `a565eac941c89d993c64ec5d20637c79547545f8` (parent `ccf9fe6590ee7437005d8353c3c67d2dc4d25fcb`) passed the registered single-audio regression on 8×H200 with TP8/DP2 and DP attention. The request pinned to DP rank 0 returned HTTP 200 with one choice and a positive `prompt_tokens_details.audio_tokens` count; no NCCL collective-timeout signature appeared in the complete log. The test took 962.276 seconds including model loading, CUDA initialization, and server shutdown. The job verified the candidate archive and both changed-file SHA-256 hashes before launch.
<!-- current-main-infra-result:end -->

## Checklist

- [x] Rebased onto current `main`
- [x] Added a registered multi-DP-group audio regression test
- [x] Documented existing FP8, BF16, and non-DP H200 validation
- [x] Record the current-main 8×H200 regression result
- [x] Documentation changes are not needed

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34452233269](https://github.com/sgl-project/sglang/actions/runs/34452233269)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34452233147](https://github.com/sgl-project/sglang/actions/runs/34452233147)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34452233204](https://github.com/sgl-project/sglang/actions/runs/34452233204)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
