### PR TITLE
fix(arg_groups): reject NGRAM with --enable-linear-replayssm-spec

### DIFF
--- a/python/sglang/srt/arg_groups/pipeline.py
+++ b/python/sglang/srt/arg_groups/pipeline.py
@@ -94,9 +94,11 @@ def run_resolution_pipeline(server_args: Any) -> None:
     from sglang.srt.arg_groups.validation_hook import (
         validate_experimental_sgl_marlin,
         validate_prefill_decode_interval,
+        validate_replayssm_spec_algorithm,
     )
 
     validate_prefill_decode_interval(server_args)
+    validate_replayssm_spec_algorithm(server_args)
 
     # Reject an explicitly enabled but incompatible hardware runtime before
     # model path resolution, downloads, or the dummy-model short circuit.

--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -402,6 +402,31 @@ def validate_prefill_decode_interval(server_args: Any):
         raise ValueError("--prefill-decode-interval must be non-negative.")
 
 
+def validate_replayssm_spec_algorithm(server_args: Any):
+    """Reject NGRAM with --enable-linear-replayssm-spec.
+
+    NGRAM always builds a tree mask (retrieve_parent_token is set), but the
+    fold-every-commit verify requires a strict linear chain
+    (retrieve_parent_token is None). This runs before the dummy-model short
+    circuit so the config contradiction is caught even for config-check /
+    dummy validation, not only on a real model.
+    """
+    cfg = resolving_view(server_args)
+    if not cfg.enable_linear_replayssm_spec:
+        return
+    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+
+    if SpeculativeAlgorithm.from_string(cfg.speculative_algorithm).is_ngram():
+        raise ValueError(
+            "--enable-linear-replayssm-spec does not support NGRAM: "
+            "NGRAM always builds a tree mask (retrieve_parent_token is "
+            "set), but the fold-every-commit verify requires a strict "
+            "linear chain (retrieve_parent_token is None). Use a "
+            "linear-chain draft (EAGLE with --speculative-eagle-topk 1, "
+            "DFLASH, or DSPARK) or drop --enable-linear-replayssm-spec."
+        )
+
+
 def check_two_batch_overlap(server_args: Any):
     # With no EP a2a backend, two-batch-overlap is only valid on the non-EP
     # DP TP-MoE path (overlapping the DP all_gatherv / reduce_scatterv with

--- a/test/registered/unit/server_args/test_ngram_replayssm_validation.py
+++ b/test/registered/unit/server_args/test_ngram_replayssm_validation.py
@@ -1,0 +1,70 @@
+"""Unit tests for the --enable-linear-replayssm-spec + NGRAM validation.
+
+NGRAM always builds a tree mask (retrieve_parent_token is set), but the
+fold-every-commit verify path requires a strict linear chain
+(retrieve_parent_token is None). The validation must reject the combination
+up front instead of letting the first forward crash with the gdn_backend
+assert.
+"""
+
+import unittest
+from unittest.mock import patch
+
+from sglang.srt.server_args import prepare_server_args
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+# Force the CUDA path so resolution runs the same hooks on CPU-only CI
+# runners, matching the pattern used in test_server_args.py.
+patch("sglang.srt.arg_groups.serving_hook.is_cuda", return_value=True).start()
+
+
+class TestNgramReplayssmValidation(CustomTestCase):
+    def _args(self, **kw):
+        base = [
+            "--model-path",
+            "dummy",
+            "--enable-linear-replayssm-spec",
+            "--linear-attn-decode-backend",
+            "triton",
+        ]
+        for key, value in kw.items():
+            base.append(f"--{key.replace('_', '-')}")
+            if value is not None:
+                base.append(str(value))
+        return prepare_server_args(base)
+
+    def test_ngram_replayssm_rejected(self):
+        args = self._args(speculative_algorithm="NGRAM")
+        with self.assertRaisesRegex(ValueError, "does not support NGRAM"):
+            args.resolve_once()
+
+    def test_dflash_replayssm_not_rejected_by_ngram_check(self):
+        args = self._args(speculative_algorithm="DFLASH")
+        # Should not raise the NGRAM-specific error during resolution.
+        try:
+            args.resolve_once()
+        except ValueError as exc:
+            self.assertNotIn("does not support NGRAM", str(exc))
+
+    def test_ngram_without_replayssm_not_rejected(self):
+        args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--speculative-algorithm",
+                "NGRAM",
+                "--linear-attn-decode-backend",
+                "triton",
+            ]
+        )
+        try:
+            args.resolve_once()
+        except ValueError as exc:
+            self.assertNotIn("does not support NGRAM", str(exc))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

`--enable-linear-replayssm-spec` on a GDN hybrid model (e.g. Qwen3.8-27B) crashes at
runtime when combined with `--speculative-algorithm NGRAM`, even though the
configuration passes validation:

```
AssertionError: ReplaySSM fold-every-commit supports a linear draft chain only
(topk <= 1); EAGLE tree verify must use the recurrent verify.
  at python/sglang/srt/layers/attention/linear/gdn_backend.py:782
  (assert retrieve_parent_token is None, in _replayssm_fold_target_verify)
```

Root cause: NGRAM always builds a tree mask (`retrieve_parent_token` is set), but the
fold-every-commit verify path requires a strict linear chain (`retrieve_parent_token
is None`). The existing validation for `--enable-linear-replayssm-spec` only checks
`speculative_eagle_topk in (None, 1)`; NGRAM's topk is `None`, so it passes validation
and then crashes on the first forward.

This PR turns that into a clean, actionable startup error instead of a runtime crash.

## Changes

`python/sglang/srt/arg_groups/validation_hook.py` (+18 lines): a new
`validate_replayssm_spec_algorithm()` rejects `--speculative-algorithm NGRAM` when
`--enable-linear-replayssm-spec` is set:

```python
def validate_replayssm_spec_algorithm(server_args: Any):
    cfg = resolving_view(server_args)
    if not cfg.enable_linear_replayssm_spec:
        return
    from sglang.srt.speculative.spec_info import SpeculativeAlgorithm

    if SpeculativeAlgorithm.from_string(cfg.speculative_algorithm).is_ngram():
        raise ValueError(
            "--enable-linear-replayssm-spec does not support NGRAM: "
            "NGRAM always builds a tree mask (retrieve_parent_token is "
            "set), but the fold-every-commit verify requires a strict "
            "linear chain (retrieve_parent_token is None). Use a "
            "linear-chain draft (EAGLE with --speculative-eagle-topk 1, "
            "DFLASH, or DSPARK) or drop --enable-linear-replayssm-spec."
        )
```

Wired into `run_resolution_pipeline()` right after
`validate_prefill_decode_interval()`, **before the dummy-model short circuit** — a
config-contradiction error like this must fail fast for config-check / dummy
validation too, not only on a real model. (The earlier draft put this check inside
`handle_linear_attn_backend`, which runs after the dummy-model early return and so
never fired for `--model-path dummy`; the test caught that and this placement fixes
it.)

The existing `speculative_eagle_topk in (None, 1)` check in
`attention_hook.handle_linear_attn_backend` stays in place.

## Reproduction (4x A800, sglang main source)

Model: Qwen3.8-27B (GDN hybrid linear attention). Before this change:

```bash
python -m sglang.launch_server --model Qwen3.8-27B --tp 2 \
  --speculative-algorithm NGRAM --speculative-num-draft-tokens 8 \
  --enable-linear-replayssm-spec --linear-attn-decode-backend triton \
  --mem-fraction-static 0.8
# boots, then crashes on the first forward (warmup) with the AssertionError above
```

After this change, the same command fails fast at startup with the clear ValueError
(no model loading, no runtime crash). Also verified on a real Llama-3.1-8B path.

## Verification

- `NGRAM + --enable-linear-replayssm-spec` → rejected with the new message (unit test,
  dummy path, + real-model path)
- `DFLASH + --enable-linear-replayssm-spec` → still accepted (no regression; DFLASH is
  the supported fold family, verified working with accept length 4.5875 under 1P1D PD)
- `NGRAM` without `--enable-linear-replayssm-spec` → still accepted (NGRAM alone works,
  avg_spec_accept_length 2.475)

## Tests

- `test/registered/unit/server_args/test_ngram_replayssm_validation.py` (CPU, base-a-test-cpu):
  NGRAM + replayssm-spec rejected during `resolve_once()`; DFLASH + replayssm-spec and
  NGRAM-alone not rejected by this check. Uses `prepare_server_args()` and the
  `serving_hook.is_cuda` mock pattern matching `test_server_args.py` (the older
  `server_args.get_device` mock target no longer exists on current main).
  Fails on the pre-fix code, passes on the fix.

## Related

- The fold-every-commit GDN ReplaySSM path is also the subject of
  https://github.com/sgl-project/sglang/pull/35725 (DFlash/DSpark fold routing); this
  validation gap is orthogonal but worth closing alongside it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #35493076291](https://github.com/sgl-project/sglang/actions/runs/35493076291)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #35493076132](https://github.com/sgl-project/sglang/actions/runs/35493076132)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd:start -->:x: [Run #35493076228](https://github.com/sgl-project/sglang/actions/runs/35493076228)<!-- slot:pr-test-amd:end -->
<!-- pr-states:end -->
