### PR TITLE
fix: retry post-warmup freeze_gc so --skip-server-warmup doesn't race server startup

### DIFF
--- a/python/sglang/srt/entrypoints/http_server.py
+++ b/python/sglang/srt/entrypoints/http_server.py
@@ -2374,16 +2374,28 @@ def _freeze_gc_after_server_warmup(server_args: ServerArgs):
     freeze_headers = {}
     if freeze_key:
         freeze_headers["Authorization"] = f"Bearer {freeze_key}"
-    try:
-        res = requests.post(
-            server_args.url() + "/freeze_gc",
-            headers=freeze_headers,
-            timeout=10,
-            verify=ssl_verify_of(server_args),
-        )
-        res.raise_for_status()
-    except requests.exceptions.RequestException:
-        logger.warning("post-warmup freeze_gc failed", exc_info=True)
+    # --skip-server-warmup bypasses the wait-for-server loop, so this request
+    # can race uvicorn binding its socket. The connect timeout and retry delay
+    # bound repeated connection failures to about 30 seconds.
+    max_attempts = 15
+    for attempt in range(max_attempts):
+        try:
+            res = requests.post(
+                server_args.url() + "/freeze_gc",
+                headers=freeze_headers,
+                timeout=(1, 10),
+                verify=ssl_verify_of(server_args),
+            )
+            res.raise_for_status()
+            return
+        except requests.exceptions.ConnectionError:
+            if attempt == max_attempts - 1:
+                logger.warning("post-warmup freeze_gc failed", exc_info=True)
+                return
+            time.sleep(1)
+        except requests.exceptions.RequestException:
+            logger.warning("post-warmup freeze_gc failed", exc_info=True)
+            return
 
 
 def _wait_and_warmup(

--- a/test/registered/unit/entrypoints/test_freeze_gc_after_warmup.py
+++ b/test/registered/unit/entrypoints/test_freeze_gc_after_warmup.py
@@ -1,0 +1,67 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import requests
+
+from sglang.srt.entrypoints.http_server import _freeze_gc_after_server_warmup
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=2, suite="base-a-test-cpu")
+
+_MODULE = "sglang.srt.entrypoints.http_server"
+
+
+class TestFreezeGCAfterWarmup(CustomTestCase):
+    def setUp(self):
+        super().setUp()
+        self.server_args = SimpleNamespace(
+            api_key=None,
+            admin_api_key=None,
+            url=lambda: "http://localhost:30000",
+            ssl_ca_certs=None,
+            ssl_certfile=None,
+        )
+        self.post = self.enterContext(patch(f"{_MODULE}.requests.post"))
+        self.sleep = self.enterContext(patch(f"{_MODULE}.time.sleep"))
+        self.warning = self.enterContext(patch(f"{_MODULE}.logger.warning"))
+
+    def test_retries_connection_failure_then_succeeds(self):
+        response = Mock()
+        self.post.side_effect = [requests.ConnectionError("not ready"), response]
+
+        _freeze_gc_after_server_warmup(self.server_args)
+
+        self.assertEqual(self.post.call_count, 2)
+        self.sleep.assert_called_once_with(1)
+        response.raise_for_status.assert_called_once_with()
+        self.warning.assert_not_called()
+
+    def test_warns_once_after_connection_retries_are_exhausted(self):
+        self.post.side_effect = requests.ConnectionError("not ready")
+
+        _freeze_gc_after_server_warmup(self.server_args)
+
+        self.assertEqual(self.post.call_count, 15)
+        self.assertEqual(self.sleep.call_count, 14)
+        self.warning.assert_called_once_with(
+            "post-warmup freeze_gc failed", exc_info=True
+        )
+
+    def test_does_not_retry_non_connection_error(self):
+        response = Mock()
+        response.raise_for_status.side_effect = requests.HTTPError("503")
+        self.post.return_value = response
+
+        _freeze_gc_after_server_warmup(self.server_args)
+
+        self.post.assert_called_once()
+        self.sleep.assert_not_called()
+        self.warning.assert_called_once_with(
+            "post-warmup freeze_gc failed", exc_info=True
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

With `--skip-server-warmup`, the startup thread's only wait-for-server logic — the 120 s `/model_info` poll at the top of `_execute_server_warmup` — is skipped entirely, so `_freeze_gc_after_server_warmup` runs concurrently with uvicorn startup. Its single POST frequently lands before the server socket is listening. The result on every `--skip-server-warmup` launch in our serving runs (8×H200, v0.5.18, code unchanged on `main`):

```
[...] INFO:     Application startup complete.
[...] INFO:     Uvicorn running on http://127.0.0.1:31000 (Press CTRL+C to quit)
[...] post-warmup freeze_gc failed
Traceback (most recent call last):
  ...
ConnectionRefusedError: [Errno 111] Connection refused
[...] The server is fired up and ready to roll!
```

Two consequences: a scary traceback during an otherwise healthy startup, and the GC freeze is silently lost, leaving static objects in later gen2 collections.

## Modifications

- Retry only `requests.exceptions.ConnectionError`, which covers the local listener startup race. Use a 1 s connect timeout, a 10 s read timeout, 15 attempts, and a 1 s delay after each of the first 14 failures. Repeated connect timeouts are therefore bounded to about 29 s rather than multiplying the 10 s read timeout across every attempt.
- Log one warning after connection retries are exhausted. `HTTPError`, `ReadTimeout`, and other non-connection request failures still warn immediately and are not retried.
- Preserve the current `ssl_verify_of(server_args)` path from `main`.

## Tests

Added three registered CPU regression tests covering:

- a connection failure followed by success;
- exhausted connection retries with exactly one warning;
- an HTTP error warning immediately without retry.

The checked-in tests pass in the isolated CPU harness (`3 passed`); no live server or GPU is required.

## Checklist

- [x] Change follows surrounding style; CI lint will confirm
- [x] Documentation: n/a

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33982381902](https://github.com/sgl-project/sglang/actions/runs/33982381902)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33982381691](https://github.com/sgl-project/sglang/actions/runs/33982381691)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33982381801](https://github.com/sgl-project/sglang/actions/runs/33982381801)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->