### PR TITLE
fix: warn when --dtype auto guesses float16 for a config with no declared dtype

### DIFF
--- a/python/sglang/srt/configs/model_config.py
+++ b/python/sglang/srt/configs/model_config.py
@@ -1840,6 +1840,7 @@ def _get_and_verify_dtype(
     else:
         config_dtype = getattr(config, "dtype", None)
         model_type = getattr(config, "model_type", "")
+    config_dtype_is_missing = config_dtype is None
     if isinstance(config_dtype, str):
         config_dtype = _STR_DTYPE_TO_TORCH_DTYPE.get(config_dtype, None)
     if config_dtype is None:
@@ -1864,6 +1865,15 @@ def _get_and_verify_dtype(
                     # Following the common practice, we use float16 for float32
                     # models.
                     torch_dtype = torch.float16
+                    if config_dtype_is_missing:
+                        logger.warning(
+                            "The model config declares no dtype/torch_dtype, so "
+                            "`--dtype auto` assumes float32 and downcasts to "
+                            "float16. If the checkpoint was trained in bfloat16, "
+                            "pass `--dtype bfloat16` explicitly to avoid a silent "
+                            "precision change (float16's narrow exponent range "
+                            "can overflow activations that bfloat16 handles)."
+                        )
             else:
                 torch_dtype = config_dtype
         else:

--- a/test/registered/unit/configs/test_model_config.py
+++ b/test/registered/unit/configs/test_model_config.py
@@ -2,9 +2,13 @@
 
 import unittest
 from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
 
 from sglang.srt.configs.model_config import (
     ModelConfig,
+    _get_and_verify_dtype,
     get_hybrid_layer_ids,
     is_embedding_gemma,
 )
@@ -12,6 +16,33 @@ from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestGetAndVerifyDtype(CustomTestCase):
+    def test_missing_config_dtype_warns_for_auto_downcast(self):
+        """An implicit float32-to-float16 choice warns when dtype is absent."""
+        with patch("sglang.srt.configs.model_config.logger.warning") as warning:
+            dtype = _get_and_verify_dtype({}, "auto")
+
+        self.assertIs(dtype, torch.float16)
+        warning.assert_called_once()
+        self.assertIn("declares no dtype/torch_dtype", warning.call_args.args[0])
+
+    def test_auto_downcast_warning_requires_missing_config_dtype(self):
+        """Declared or explicitly requested dtypes do not report a missing dtype."""
+        cases = (
+            ("declared-float32", {"dtype": "float32"}, "auto", torch.float16),
+            ("explicit-dtype", {}, "bfloat16", torch.bfloat16),
+            ("unknown-config-dtype", {"dtype": "unknown"}, "auto", torch.float16),
+        )
+
+        for name, config, requested_dtype, expected_dtype in cases:
+            with self.subTest(name=name):
+                with patch("sglang.srt.configs.model_config.logger.warning") as warning:
+                    dtype = _get_and_verify_dtype(config, requested_dtype)
+
+                self.assertIs(dtype, expected_dtype)
+                warning.assert_not_called()
 
 
 class TestHybridLayerIds(CustomTestCase):


### PR DESCRIPTION
## Motivation

When a model config declares neither `dtype` nor `torch_dtype`, `_get_and_verify_dtype` falls back to float32. With the default `--dtype auto`, non-Gemma models are then silently downcast to float16. The existing `logger.debug` message is hidden at the default log level, so a bfloat16-trained checkpoint with an omitted dtype can be evaluated or served at the wrong precision without any visible indication.

The missing-field state must be captured before dtype string normalization. Normalization also maps an unrecognized string to `None`, but that field was present and should not be reported as absent.

## Modifications

- Record whether the config dtype field is missing before normalizing dtype strings.
- Warn when `--dtype auto` makes the non-Gemma float32-to-float16 guess for a config with no declared dtype.
- Keep the existing behavior for declared float32, explicit dtype arguments, and unrecognized config dtype strings; an unrecognized string no longer triggers the misleading missing-dtype warning.
- Add focused CPU unit coverage for the warning boundary.

## Testing

`TestGetAndVerifyDtype` covers four cases:

- missing config dtype with `--dtype auto`: resolves to float16 and warns;
- declared float32 with `--dtype auto`: resolves to float16 without the missing-dtype warning;
- an explicit bfloat16 argument: resolves to bfloat16 without the warning;
- an unrecognized config dtype string with `--dtype auto`: preserves the existing float16 fallback without claiming that the field is missing.

Focused behavior verification and the repository pre-commit hooks pass locally.

## Checklist

- [x] Change follows surrounding style
- [x] Focused CPU unit tests added
- [x] Documentation: n/a

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33982265428](https://github.com/sgl-project/sglang/actions/runs/33982265428)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33982265345](https://github.com/sgl-project/sglang/actions/runs/33982265345)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33982265485](https://github.com/sgl-project/sglang/actions/runs/33982265485)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
