### PR TITLE
[Speculative] Reuse Prefill radix prefixes with compact Qwen DFlash

### DIFF
--- a/python/sglang/kernels/ops/speculative/cache_locs.py
+++ b/python/sglang/kernels/ops/speculative/cache_locs.py
@@ -327,6 +327,85 @@ def rebuild_compact_draft_req_to_token_func(
 
 
 @triton.jit
+def rebuild_compact_physical_draft_req_to_token(
+    draft_req_to_token,
+    req_pool_indices,
+    suffix_start,
+    draft_prefix_lens,
+    physical_out_cache_loc,
+    physical_loc_stride,
+    draft_pool_len: tl.constexpr,
+    owner_span: tl.constexpr,
+    guard_rows: tl.constexpr,
+    window_size: tl.constexpr,
+    block_size: tl.constexpr,
+):
+    """Build the chronological draft view directly from bounded physical IDs.
+
+    Committed prefix positions use the owner's modulo ring. Verify positions
+    use the owner's disjoint stable scratch rows and are also returned to the
+    caller. The fixed grid and device-side lengths avoid a decode-path D2H sync.
+    """
+    BLOCK: tl.constexpr = 256
+    pid = tl.program_id(axis=0)
+    req = tl.load(req_pool_indices + pid).to(tl.int64)
+    start = tl.load(suffix_start + pid).to(tl.int64)
+    prefix_len = tl.load(draft_prefix_lens + pid).to(tl.int64)
+    total = prefix_len + block_size
+
+    owner_base = (req - 1) * owner_span
+    committed_base = owner_base + guard_rows
+    scratch_base = committed_base + window_size
+    dst_row = draft_req_to_token + req * draft_pool_len
+    physical_row = physical_out_cache_loc + pid * physical_loc_stride
+
+    offs = tl.arange(0, BLOCK).to(tl.int64)
+    num_loop = tl.cdiv(total, BLOCK)
+    for i in range(num_loop):
+        col = offs + i * BLOCK
+        in_prefix = col < prefix_len
+        in_block = (col >= prefix_len) & (col < total)
+        committed = committed_base + (start + col) % window_size
+        scratch_offset = col - prefix_len
+        scratch = scratch_base + scratch_offset
+        value = tl.where(in_prefix, committed, scratch)
+        tl.store(dst_row + col, value, mask=in_prefix | in_block)
+        tl.store(
+            physical_row + scratch_offset,
+            scratch,
+            mask=in_block,
+        )
+
+
+def rebuild_compact_physical_draft_req_to_token_func(
+    *,
+    draft_req_to_token: torch.Tensor,
+    req_pool_indices: torch.Tensor,
+    suffix_start: torch.Tensor,
+    draft_prefix_lens: torch.Tensor,
+    physical_out_cache_loc_2d: torch.Tensor,
+    batch_size: int,
+    block_size: int,
+    owner_span: int,
+    guard_rows: int,
+    window_size: int,
+) -> None:
+    rebuild_compact_physical_draft_req_to_token[(batch_size,)](
+        draft_req_to_token,
+        req_pool_indices,
+        suffix_start,
+        draft_prefix_lens,
+        physical_out_cache_loc_2d,
+        physical_out_cache_loc_2d.stride(0),
+        draft_req_to_token.shape[1],
+        owner_span,
+        guard_rows,
+        window_size,
+        block_size,
+    )
+
+
+@triton.jit
 def assign_extend_cache_locs(
     req_pool_indices,
     req_to_token,

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -146,6 +146,18 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
                 cfg.speculative_algorithm,
             )
 
+    if getattr(cfg, "speculative_dflash_compact_cache", False):
+        if cfg.speculative_algorithm != "DFLASH":
+            raise ValueError(
+                "--speculative-dflash-compact-cache requires "
+                "--speculative-algorithm DFLASH"
+            )
+        if cfg.speculative_draft_window_size is None:
+            raise ValueError(
+                "--speculative-dflash-compact-cache requires "
+                "--speculative-draft-window-size"
+            )
+
     algo = None
     if cfg.speculative_algorithm is not None:
         from sglang.srt.speculative.spec_info import SpeculativeAlgorithm

--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -158,6 +158,27 @@ def handle_speculative_decoding(server_args: ServerArgs) -> None:
                 "--speculative-draft-window-size"
             )
 
+    dflash_sidecar_tokens = int(
+        getattr(cfg, "speculative_dflash_radix_sidecar_tokens", 0) or 0
+    )
+    if dflash_sidecar_tokens < 0:
+        raise ValueError(
+            "--speculative-dflash-radix-sidecar-tokens must be nonnegative, "
+            f"got {dflash_sidecar_tokens}"
+        )
+    if dflash_sidecar_tokens > 0 and not getattr(
+        cfg, "speculative_dflash_compact_cache", False
+    ):
+        raise ValueError(
+            "--speculative-dflash-radix-sidecar-tokens requires "
+            "--speculative-dflash-compact-cache"
+        )
+    declare_resolution(
+        server_args,
+        "handle_speculative_decoding",
+        speculative_dflash_radix_sidecar_tokens=dflash_sidecar_tokens,
+    )
+
     algo = None
     if cfg.speculative_algorithm is not None:
         from sglang.srt.speculative.spec_info import SpeculativeAlgorithm

--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -17,6 +17,8 @@ if TYPE_CHECKING:
 class StateType(str, enum.Enum):
     MAMBA = "mamba"
     SWA = "swa"
+    # DFlash draft K/V addressed by the visible absolute-position suffix.
+    DRAFT_SWA = "draft_swa"
     DSA = "dsa"
     MINIMAX_INDEX_K = "minimax_index_k"
     # DeepSeek-V4 unified_kv SWA ring: addressed per-row by ring slot
@@ -42,6 +44,8 @@ class KVTransferMetric:
 
 class KVArgs:
     engine_rank: int
+    draft_swa_suffix_enabled: bool
+    draft_swa_window_size: int
     kv_data_ptrs: List[int]
     kv_data_lens: List[int]
     kv_item_lens: List[int]
@@ -152,6 +156,9 @@ class BaseKVSender(ABC):
 
     def should_send_kv_chunk(self, num_pages: int, last_chunk: bool) -> bool:
         return num_pages > 0
+
+    def can_send_draft_swa_suffix(self) -> bool:
+        return False
 
     @abstractmethod
     def get_transfer_metric(self) -> KVTransferMetric:

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -154,7 +154,8 @@ class CommonKVManager(BaseKVManager):
         self.kv_args = args
         self.kv_cache_dtype_str = args.kv_cache_dtype_str
         self.kv_item_lens_sum = sum(args.kv_item_lens)
-        self.state_item_lens_sum = sum(x for comp in args.state_item_lens for x in comp)
+        self.state_item_lens_sums = [sum(comp) for comp in args.state_item_lens]
+        self.state_item_lens_sum = sum(self.state_item_lens_sums)
         self.is_mla_backend = is_mla_backend
         # Per-sender fan-out of a KV copy onto N decode destinations
         # (MLA under Prefill-CP + Decode-TP, or decode_tp > prefill_tp).
@@ -244,6 +245,7 @@ class CommonKVManager(BaseKVManager):
             # Deferred KV release: aborted room -> (decode_ip, decode_port);
             # ack held until the transfer drains.
             self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
+            self._deferred_ack_send_failures: Dict[int, int] = defaultdict(int)
             self.req_to_decode_prefix_len: Dict[int, int] = {}
             self.decode_kv_args_table = {}
             self.pp_group = get_pp_group()
@@ -266,6 +268,7 @@ class CommonKVManager(BaseKVManager):
             # drained. Entry exists only while the room is held, so a stale/late
             # ack for a reused bootstrap_room is dropped.
             self._deferred_abort_ack_tracker: Dict[int, Set[int]] = {}
+            self._receiver_armed_abort_rooms: Set[int] = set()
             # Heartbeat interval should be at least 2 seconds
             self.heartbeat_interval = max(
                 envs.SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL.get(), 2.0
@@ -372,6 +375,10 @@ class CommonKVManager(BaseKVManager):
                 return
             self.request_status[bootstrap_room] = status
         else:
+            if self.request_status[bootstrap_room] == KVPoll.Failed:
+                # Failure is terminal. A worker that was already past its abort
+                # check must not resurrect the room with a late Success.
+                return
             if status == KVPoll.Failed:
                 self.request_status[bootstrap_room] = KVPoll.Failed
             else:
@@ -386,7 +393,20 @@ class CommonKVManager(BaseKVManager):
     def register_deferred_abort_room(self, bootstrap_room: int) -> None:
         """Arm drain-ack accounting for a held room; a fresh set wipes stale acks
         from a prior request that reused this bootstrap_room."""
+        # A receiver arms before sending ABORT so a synchronous ack cannot be
+        # lost. The scheduler's historical post-send registration must then be
+        # idempotent instead of wiping that ack.
+        if bootstrap_room in getattr(self, "_receiver_armed_abort_rooms", ()):
+            return
         self._deferred_abort_ack_tracker[bootstrap_room] = set()
+
+    def arm_deferred_abort_room(self, bootstrap_room: int) -> None:
+        """Reset stale state for a new owner and arm before notifying prefill."""
+        armed = getattr(self, "_receiver_armed_abort_rooms", None)
+        if armed is None:
+            armed = self._receiver_armed_abort_rooms = set()
+        self._deferred_abort_ack_tracker[bootstrap_room] = set()
+        armed.add(bootstrap_room)
 
     def note_abort_ack(self, bootstrap_room: int, prefill_rank: int) -> None:
         """Record a prefill rank's drain ack (decode receiver thread). Only counts
@@ -404,6 +424,7 @@ class CommonKVManager(BaseKVManager):
 
     def clear_deferred_abort_state(self, bootstrap_room: int) -> None:
         self._deferred_abort_ack_tracker.pop(bootstrap_room, None)
+        getattr(self, "_receiver_armed_abort_rooms", set()).discard(bootstrap_room)
 
     def _prefill_unique_rank(self) -> int:
         """Stable per-sender id, matching what the transfer worker syncs on Success."""
@@ -413,8 +434,8 @@ class CommonKVManager(BaseKVManager):
             + self.attn_cp_rank
         )
 
-    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
-        """Best-effort ack that this rank's transfer for an aborted room drained."""
+    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> bool:
+        """Ack that this rank drained; return success so failures remain retryable."""
         try:
             na = NetworkAddress(decode_ip, decode_port)
             self._send_multipart_locked(
@@ -426,24 +447,62 @@ class CommonKVManager(BaseKVManager):
                 ],
                 is_ipv6=na.is_ipv6,
             )
+            return True
         except Exception as e:
-            logger.debug(f"Failed to send drained ABORT_ACK for room {room}: {e}")
+            failures = getattr(self, "_deferred_ack_send_failures", None)
+            if failures is None:
+                failures = self._deferred_ack_send_failures = defaultdict(int)
+            failures[room] = failures.get(room, 0) + 1
+            logger.warning(
+                "Failed to send drained ABORT_ACK for room %s (attempt %s): %s",
+                room,
+                failures[room],
+                e,
+            )
+            return False
 
     def _maybe_ack_drained_abort(self, room: int) -> None:
-        """Send the deferred ack once an aborted room's chunks have drained
-        (outstanding == 0). pop() makes it fire at most once."""
+        """Send a drained ack; retain the target until delivery succeeds."""
         if self._staging_outstanding.get(room, 0) > 0:
             return
-        target = self._deferred_ack_targets.pop(room, None)
+        target = self._deferred_ack_targets.get(room)
         if target is not None:
-            self._send_abort_ack(target[0], target[1], room)
+            # Older/test transports return None after a successful send. Only an
+            # explicit False means delivery failed and should remain retryable.
+            delivered = self._send_abort_ack(target[0], target[1], room)
+            if delivered is False:
+                return
+            if self._deferred_ack_targets.get(room) == target:
+                self._deferred_ack_targets.pop(room, None)
+                getattr(self, "_deferred_ack_send_failures", {}).pop(room, None)
+
+    def retry_deferred_abort_acks(self) -> None:
+        for room in list(self._deferred_ack_targets):
+            self._maybe_ack_drained_abort(room)
+
+    def handle_deferred_abort_notification(
+        self, room: int, decode_ip: str, decode_port: int
+    ) -> bool:
+        """Stop an active room and retain an ack target through source drain."""
+        room_active = (
+            room in self.request_status and self.check_status(room) != KVPoll.Success
+        )
+        if room_active:
+            self.update_status(room, KVPoll.Failed)
+        # A Success room can still have the worker between its last write and
+        # outstanding cleanup. It must also retain the ack target until zero.
+        self.register_deferred_ack_target(room, decode_ip, decode_port)
+        self._maybe_ack_drained_abort(room)
+        return room_active
 
     def register_deferred_ack_target(
         self, room: int, decode_ip: str, decode_port: int
     ) -> None:
-        """Hold this room's ack until its transfer drains. Callers must mark the
-        room Failed FIRST -- registering while it still accepts chunks lets the
-        worker ack, then a new chunk writes pages the decode already released."""
+        """Hold this room's ack until its transfer drains.
+
+        Active rooms must be marked Failed first. Already-Success rooms remain
+        terminal but still need this target while their final worker cleanup runs.
+        """
         self._deferred_ack_targets[room] = (decode_ip, decode_port)
 
     def get_kv_replica_factor(self) -> int:
@@ -1193,7 +1252,7 @@ class CommonKVSender(BaseKVSender):
         self.conclude_state: Optional[KVPoll] = None
         self._transfer_metric = KVTransferMetric()
         self._transfer_num_kv_indices = 0
-        self._transfer_num_state_indices = 0
+        self._transfer_num_state_indices: List[int] = []
         # inner state
         self.curr_idx = 0
         self.init_time: Optional[float] = None
@@ -1256,8 +1315,21 @@ class CommonKVSender(BaseKVSender):
 
     def get_transfer_metric(self) -> KVTransferMetric:
         total_bytes = self._transfer_num_kv_indices * self.kv_mgr.kv_item_lens_sum
-        total_bytes += (
-            self._transfer_num_state_indices * self.kv_mgr.state_item_lens_sum
+        state_counts = self._transfer_num_state_indices
+        if isinstance(state_counts, int):
+            state_counts = [state_counts] if state_counts else []
+        state_item_lens_sums = getattr(
+            self.kv_mgr,
+            "state_item_lens_sums",
+            [getattr(self.kv_mgr, "state_item_lens_sum", 0)],
+        )
+        if len(state_counts) > len(state_item_lens_sums):
+            raise RuntimeError(
+                "Transfer metric state component count exceeds registered layout: "
+                f"counts={len(state_counts)}, components={len(state_item_lens_sums)}"
+            )
+        total_bytes += sum(
+            count * state_item_lens_sums[i] for i, count in enumerate(state_counts)
         )
         # Pinned to 1 for MHA (disjoint slices); only MLA replication makes it > 1.
         total_bytes *= self.kv_mgr.get_kv_replica_factor()
@@ -1271,9 +1343,16 @@ class CommonKVSender(BaseKVSender):
     ):
         self._transfer_num_kv_indices += len(kv_indices)
         if state_indices:
-            for component_indices in state_indices:
+            if isinstance(self._transfer_num_state_indices, int):
+                old_count = self._transfer_num_state_indices
+                self._transfer_num_state_indices = [old_count] if old_count else []
+            if len(self._transfer_num_state_indices) < len(state_indices):
+                self._transfer_num_state_indices.extend(
+                    [0] * (len(state_indices) - len(self._transfer_num_state_indices))
+                )
+            for i, component_indices in enumerate(state_indices):
                 if component_indices is not None:
-                    self._transfer_num_state_indices += len(component_indices)
+                    self._transfer_num_state_indices[i] += len(component_indices)
 
     def _prepare_send_indices(
         self,
@@ -1377,6 +1456,13 @@ class CommonKVReceiver(BaseKVReceiver):
         self.init_time: Optional[float] = None
         self.abort_notified: bool = False
         self._connection_pool_entries: Dict[str, List[Dict]] = {}
+        if (
+            getattr(self.kv_mgr, "enable_deferred_decode_kv_release", False)
+            and self.bootstrap_room is not None
+        ):
+            # Explicit slot/room reuse boundary. Any prior owner must already
+            # have released before this receiver is constructed.
+            self.kv_mgr.clear_deferred_abort_state(self.bootstrap_room)
         self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
 
@@ -1639,6 +1725,10 @@ class CommonKVReceiver(BaseKVReceiver):
             self.abort_notified = True
 
     def _send_abort_notification(self):
+        if getattr(self.kv_mgr, "enable_deferred_decode_kv_release", False):
+            # Arm before the first socket send. A loopback/mock or a quiescent
+            # prefill can acknowledge synchronously.
+            self.kv_mgr.arm_deferred_abort_room(self.bootstrap_room)
         for bootstrap_info in self.bootstrap_infos:
             # Best-effort notification to prefill side that this request was aborted.
             try:

--- a/python/sglang/srt/disaggregation/common/utils.py
+++ b/python/sglang/srt/disaggregation/common/utils.py
@@ -34,6 +34,8 @@ class TransferKVChunk:
     staging_counted: bool = False
     # Mori early-send: CUDA event to synchronize before RDMA (optional).
     wait_event: Optional[object] = None
+    # Optional compact DFlash state-only transfer capability.
+    draft_swa_suffix: bool = False
 
 
 def pack_list_of_buffers(buffers: List[bytes]) -> bytes:

--- a/python/sglang/srt/disaggregation/decode.py
+++ b/python/sglang/srt/disaggregation/decode.py
@@ -53,8 +53,11 @@ from sglang.srt.disaggregation.utils import (
     _is_fake_transfer,
     build_kv_layer_ids,
     build_staging_slot_metadata,
+    get_dflash_draft_kv_transfer_locs,
+    get_dflash_draft_kv_transfer_spec,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_legacy_draft_kv_buf_infos,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
     poll_and_all_reduce,
@@ -217,7 +220,8 @@ class DecodeReqToTokenPool:
 
     def clear(self):
         self.free_slots = list(range(1, self._alloc_size))
-        self.req_generation.zero_()
+        # Generations are lifetime-monotonic. Resetting here creates an ABA
+        # collision for request-owned side pools after a global clear.
 
 
 class HybridMambaDecodeReqToTokenPool(HybridReqToTokenPool):
@@ -366,6 +370,9 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
         self.pp_size = scheduler.ps.pp_size
         self.num_reserved_decode_tokens = num_reserved_decode_tokens
         self.transfer_backend = transfer_backend
+        self.draft_kv_transfer_spec = get_dflash_draft_kv_transfer_spec(
+            scheduler, draft_token_to_kv_pool, transfer_backend
+        )
         # Queue for requests pending pre-allocation
         self.queue: List[DecodeRequest] = []
         self.retracted_queue: List[Req] = []
@@ -542,25 +549,38 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_data_lens += device_kv_data_lens[c4_layer_num:]
             kv_item_lens += device_kv_item_lens[c4_layer_num:]
             kv_data_mem_kinds += ["VRAM"] * len(device_kv_data_ptrs[c4_layer_num:])
+        draft_kv_pool = None
         num_draft_entries = 0
-        if self.draft_token_to_kv_pool is not None:
+        legacy_draft_infos = get_legacy_draft_kv_buf_infos(
+            self.draft_token_to_kv_pool, self.draft_kv_transfer_spec
+        )
+        if legacy_draft_infos is not None:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
-                self.draft_token_to_kv_pool.get_contiguous_buf_infos()
+                legacy_draft_infos
             )
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
             kv_data_mem_kinds += ["VRAM"] * len(draft_kv_data_ptrs)
             num_draft_entries = len(draft_kv_data_ptrs)
+            draft_kv_pool = self.draft_token_to_kv_pool
 
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
+        kv_args.draft_swa_suffix_enabled = bool(
+            self.draft_kv_transfer_spec and self.draft_kv_transfer_spec.suffix_enabled
+        )
+        kv_args.draft_swa_window_size = (
+            self.draft_kv_transfer_spec.window_size
+            if self.draft_kv_transfer_spec
+            else 0
+        )
         kv_args.kv_layer_ids = build_kv_layer_ids(
             token_to_kv_pool=self.token_to_kv_pool,
-            draft_token_to_kv_pool=self.draft_token_to_kv_pool,
+            draft_token_to_kv_pool=draft_kv_pool,
             num_draft_entries=num_draft_entries,
             num_hidden_layers=self.scheduler.model_config.num_hidden_layers,
         )
@@ -576,6 +596,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
             kv_args,
             self.token_to_kv_pool,
             self.draft_token_to_kv_pool,
+            draft_kv_transfer_spec=self.draft_kv_transfer_spec,
             total_kv_layers=self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=getattr(self, "req_to_token_pool", None),
         )
@@ -606,7 +627,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                     kv_layer_ids=kv_args.kv_layer_ids,
                     num_draft_entries=num_draft_entries,
                     kv_pool=kv_pool,
-                    draft_kv_pool=self.draft_token_to_kv_pool,
+                    draft_kv_pool=draft_kv_pool,
                 )
                 if staging_slots is not None:
                     k_buffers, v_buffers, slot_layer_ids = staging_slots
@@ -1419,6 +1440,21 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 device_page_size = self.token_to_kv_pool.page_size
                 return kv_to_page_indices(kv_indices_full, device_page_size)
 
+            def _draft_swa_payload():
+                spec = self.draft_kv_transfer_spec
+                if spec is None:
+                    raise RuntimeError(
+                        "draft SWA state was registered without a local transfer spec"
+                    )
+                draft_indices = get_dflash_draft_kv_transfer_locs(
+                    self.scheduler.draft_worker,
+                    int(decode_req.req.req_pool_idx),
+                    seq_len,
+                    spec,
+                    page_size,
+                )
+                return kv_to_page_indices(draft_indices, page_size)
+
             def _swa_ring_payload():
                 # Mirror of prefill _swa_ring_payload using this side's req_pool_idx.
                 # Same window positions and order -> positional match with prefill.
@@ -1456,6 +1492,7 @@ class DecodePreallocQueue(DecodeHiCachePreallocMixin):
                 StateType.C128_STATE: _c128_state_payload,
                 StateType.BLOCK_SCALE: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE_SWA: _swa_payload,
+                StateType.DRAFT_SWA: _draft_swa_payload,
             }
             if _is_npu and isinstance(self.token_to_kv_pool, DeepSeekV4TokenToKVPool):
                 from sglang.srt.hardware_backend.npu.dsv4.dsv4_common_hooks import (
@@ -2046,6 +2083,10 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
         self.deferred_kv_release_timeout = (
             envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE_TIMEOUT.get()
         )
+        self.require_drain_ack_for_deferred_release = bool(
+            scheduler.spec_algorithm.is_dflash()
+            and envs.SGLANG_DFLASH_PD_DRAFT_SWA_SUFFIX.get()
+        )
         # Aborted-mid-transfer requests whose KV pages/slot are held until drained
         # or timed out. Entries: (decode_req, deadline, metadata_idx, required_acks).
         self._deferred_releases: List[Tuple[DecodeRequest, float, int, int]] = []
@@ -2406,9 +2447,30 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
     def has_pending_deferred_releases(self) -> bool:
         return bool(self._deferred_releases)
 
+    def has_pending_kv_ownership(self) -> bool:
+        """Whether this queue still owns KV pages or reusable request slots.
+
+        Entries in ``queue`` may still be transfer destinations.  Entries in
+        ``_deferred_releases`` have left the visible transfer queue, but retain
+        the same ownership until every required drain ack arrives.  Both states
+        must block cache flushes and KV-memory teardown.
+        """
+        return bool(self.queue) or self.has_pending_deferred_releases()
+
+    def assert_memory_release_safe(self) -> None:
+        """Fail closed if releasing the decode KV pool could race an RDMA write."""
+        active_transfers = len(self.queue)
+        deferred_holds = len(self._deferred_releases)
+        if active_transfers or deferred_holds:
+            raise RuntimeError(
+                "Cannot release decode KV memory while transfer destinations "
+                "are still owned: "
+                f"active_transfers={active_transfers}, "
+                f"deferred_drain_ack_holds={deferred_holds}."
+            )
+
     def resolve_deferred_releases(self) -> None:
-        """Release held requests once every prefill rank acks the drain, or the
-        hold times out."""
+        """Release held requests after drain ack (or legacy timeout policy)."""
         if not self._deferred_releases:
             return
         now = time.monotonic()
@@ -2418,10 +2480,30 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
             room = decode_req.req.bootstrap_room
             kv_mgr = decode_req.kv_receiver.kv_mgr
             drained = kv_mgr.is_abort_release_safe(room, required_acks)
-            if not drained and now < deadline:
+            if drained:
+                to_release.append((decode_req, idx, room, True))
+            elif now < deadline:
                 still_held.append((decode_req, deadline, idx, required_acks))
+            elif getattr(self, "require_drain_ack_for_deferred_release", False):
+                # A draft suffix row is owned by a reusable request slot in both
+                # compact and legacy-physical layouts.  An old RDMA write after
+                # timeout could corrupt the next owner, so timeout is diagnostic
+                # only; extend it for periodic logging.
+                logger.error(
+                    f"Deferred KV release for DFlash suffix room {room} timed "
+                    f"out after {self.deferred_kv_release_timeout}s without a "
+                    "full drain ack from prefill; continuing to hold."
+                )
+                still_held.append(
+                    (
+                        decode_req,
+                        now + self.deferred_kv_release_timeout,
+                        idx,
+                        required_acks,
+                    )
+                )
             else:
-                to_release.append((decode_req, idx, room, drained))
+                to_release.append((decode_req, idx, room, False))
         # Commit the survivors before releasing so a _do_release exception can't
         # leave a released entry in the list (double-free / None receiver on retry).
         self._deferred_releases = still_held
@@ -2439,13 +2521,17 @@ class DecodeTransferQueue(DecodeHiCacheTransferMixin):
                 logger.exception(f"Deferred KV release failed for room {room}")
 
     def release_memory_occupation(self):
-        """Clean up in-flight transfers before releasing GPU memory."""
-        self.queue.clear()
-        # Pool is being torn down; drop held entries without per-request release.
-        self._deferred_releases.clear()
+        """Validate that the decode KV pool can be released safely.
+
+        Active transfers and deferred drain-ack holds own physical destinations;
+        clearing either collection would only forget that ownership while remote
+        writes can still arrive.  The scheduler's idle gate normally guarantees
+        both are empty, and this second check protects forced/exceptional callers.
+        """
+        self.assert_memory_release_safe()
 
     def resume_memory_occupation(self):
-        """Queues are already cleared on release; new transfers can be accepted."""
+        """No transfer-queue state is discarded while memory is released."""
         pass
 
 

--- a/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
+++ b/python/sglang/srt/disaggregation/decode_schedule_batch_mixin.py
@@ -85,6 +85,11 @@ class ScheduleBatchDisaggregationDecodeMixin:
             req_pool_indices, dtype=torch.int64, device=self.device
         )
         self.req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+        # PREBUILT performs no model forward. Keep first-bind authority for the
+        # first real decode forward after the transferred state is admitted.
+        uses_owner_metadata = getattr(self, "uses_dflash_owner_metadata", None)
+        if uses_owner_metadata is not None and uses_owner_metadata():
+            self.set_req_pool_owner_metadata([True] * len(reqs))
         self.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=self.device)
         self.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
         self.orig_seq_lens = torch.tensor(

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import concurrent.futures
 import dataclasses
+import json
 import logging
 import os
 import struct
@@ -15,7 +16,12 @@ import numpy.typing as npt
 import zmq
 from prometheus_client import Counter
 
-from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, StateType
+from sglang.srt.disaggregation.base.conn import (
+    KVArgs,
+    KVPoll,
+    KVTransferMetric,
+    StateType,
+)
 from sglang.srt.disaggregation.common.conn import (
     CommonKVBootstrapServer,
     CommonKVManager,
@@ -150,6 +156,15 @@ class KVArgsRegisterInfo:
     staging_base_ptr: int = 0
     staging_total_size: int = 0
     staging: Optional[StagingRegisterInfo] = None
+    # Optional trailing wire capability. Older peers omit these frames.
+    draft_swa_suffix_enabled: bool = False
+    draft_swa_window_size: int = 0
+    draft_swa_page_size: int = 0
+    # Exact registered byte ranges for fail-closed main/draft isolation. These
+    # are optional trailing frames so legacy peers still deserialize, but a peer
+    # advertising the suffix protocol must provide them.
+    dst_kv_data_lens: List[int] = dataclasses.field(default_factory=list)
+    dst_state_data_lens: List[List[int]] = dataclasses.field(default_factory=list)
 
     @classmethod
     def from_zmq(cls, msg: List[bytes]):
@@ -194,8 +209,28 @@ class KVArgsRegisterInfo:
             dst_dcp_rank=(
                 int(msg[17].decode("ascii")) if len(msg) > 17 and msg[17] != b"" else 0
             ),
-            # Note: always put the staging field at the final
+            # Keep the upstream staging capability at frame 18 so an older
+            # peer can ignore the compact-suffix extension safely.
             staging=StagingRegisterInfo.from_zmq_fields(msg, 14, slot_ids_index=18),
+            draft_swa_suffix_enabled=(
+                msg[19] == b"1" if len(msg) > 19 and msg[19] != b"" else False
+            ),
+            draft_swa_window_size=(
+                int(msg[20].decode("ascii")) if len(msg) > 20 and msg[20] != b"" else 0
+            ),
+            draft_swa_page_size=(
+                int(msg[21].decode("ascii")) if len(msg) > 21 and msg[21] != b"" else 0
+            ),
+            dst_kv_data_lens=(
+                list(struct.unpack(f"{len(msg[22]) // 8}Q", msg[22]))
+                if len(msg) > 22 and msg[22] != b""
+                else []
+            ),
+            dst_state_data_lens=(
+                unpack_int_lists(msg[23], "Q")
+                if len(msg) > 23 and msg[23] != b""
+                else []
+            ),
         )
 
 
@@ -266,6 +301,12 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     ),
                     daemon=True,
                 ).start()
+            if self.enable_deferred_decode_kv_release:
+                threading.Thread(
+                    target=self._deferred_ack_retry_loop,
+                    name="MooncakeDeferredAbortAckRetry",
+                    daemon=True,
+                ).start()
             self.enable_failed_session_probe = (
                 envs.SGLANG_ENABLE_FAILED_SESSION_PROBE.get()
             )
@@ -286,8 +327,132 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 self._staging_handler = None
             self.start_decode_thread()
 
+    def can_use_draft_swa_suffix(self, info: KVArgsRegisterInfo) -> bool:
+        """Whether one decode rank has the exact DFlash draft state layout."""
+        if not (
+            getattr(self.kv_args, "draft_swa_suffix_enabled", False)
+            and info.draft_swa_suffix_enabled
+            and info.dst_attn_tp_size == self.attn_tp_size
+            and self.dcp_size == 1
+            and info.dst_dcp_size == 1
+            and info.draft_swa_window_size == self.kv_args.draft_swa_window_size
+            and info.draft_swa_page_size == self.kv_args.page_size
+        ):
+            return False
+        try:
+            component = self.kv_args.state_types.index(StateType.DRAFT_SWA)
+        except ValueError:
+            return False
+        if (
+            component >= len(self.kv_args.state_data_ptrs)
+            or component >= len(self.kv_args.state_data_lens)
+            or component >= len(self.kv_args.state_item_lens)
+            or component >= len(self.kv_args.state_layer_ids)
+            or component >= len(info.dst_state_data_ptrs)
+            or component >= len(info.dst_state_data_lens)
+            or component >= len(info.dst_state_item_lens)
+            or component >= len(info.dst_state_layer_ids)
+        ):
+            return False
+
+        src_ptrs = self.kv_args.state_data_ptrs[component]
+        src_lens = self.kv_args.state_data_lens[component]
+        dst_ptrs = info.dst_state_data_ptrs[component]
+        dst_lens = info.dst_state_data_lens[component]
+        num_entries = len(src_ptrs)
+        return (
+            num_entries > 0
+            and num_entries == len(dst_ptrs)
+            and num_entries == len(src_lens)
+            and num_entries == len(dst_lens)
+            and self.kv_args.state_item_lens[component]
+            == info.dst_state_item_lens[component]
+            and self.kv_args.state_layer_ids[component]
+            == info.dst_state_layer_ids[component]
+            # Draft suffix rows must be state-only.  Main KV and draft KV have
+            # independent buffer ownership even when legacy DFlash happens to
+            # use target allocator indices for both physical pools.
+            and self._buffer_regions_are_disjoint(
+                self.kv_args.kv_data_ptrs,
+                self.kv_args.kv_data_lens,
+                src_ptrs,
+                src_lens,
+            )
+            and self._buffer_regions_are_disjoint(
+                info.dst_kv_ptrs,
+                info.dst_kv_data_lens,
+                dst_ptrs,
+                dst_lens,
+            )
+        )
+
+    @staticmethod
+    def _buffer_regions_are_disjoint(
+        left_ptrs: List[int],
+        left_lens: List[int],
+        right_ptrs: List[int],
+        right_lens: List[int],
+    ) -> bool:
+        """Check exact half-open byte ranges, rejecting missing/invalid metadata."""
+        if (
+            not left_ptrs
+            or not right_ptrs
+            or len(left_ptrs) != len(left_lens)
+            or len(right_ptrs) != len(right_lens)
+        ):
+            return False
+        left = []
+        right = []
+        for ptr, length in zip(left_ptrs, left_lens):
+            ptr, length = int(ptr), int(length)
+            if ptr <= 0 or length <= 0:
+                return False
+            left.append((ptr, ptr + length))
+        for ptr, length in zip(right_ptrs, right_lens):
+            ptr, length = int(ptr), int(length)
+            if ptr <= 0 or length <= 0:
+                return False
+            right.append((ptr, ptr + length))
+        return all(
+            left_end <= right_start or right_end <= left_start
+            for left_start, left_end in left
+            for right_start, right_end in right
+        )
+
+    def room_has_draft_swa_suffix_peer(self, room: int) -> bool:
+        """Whether any non-dummy decode peer advertises the suffix wire layout."""
+        for transfer_info in self.transfer_infos.get(room, {}).values():
+            if transfer_info.is_dummy:
+                continue
+            registration = self.decode_kv_args_table.get(
+                transfer_info.mooncake_session_id
+            )
+            if registration is not None and registration.draft_swa_suffix_enabled:
+                return True
+        return False
+
+    def can_use_draft_swa_suffix_for_room(self, room: int) -> bool:
+        """Negotiate across every non-dummy destination rank in one room."""
+        infos = self.transfer_infos.get(room, {})
+        found_peer = False
+        for transfer_info in infos.values():
+            if transfer_info.is_dummy:
+                continue
+            found_peer = True
+            registration = self.decode_kv_args_table.get(
+                transfer_info.mooncake_session_id
+            )
+            if registration is None or not self.can_use_draft_swa_suffix(registration):
+                return False
+        return found_peer
+
     def init_engine(self):
         self.engine = get_mooncake_transfer_engine()
+
+    def _deferred_ack_retry_loop(self) -> None:
+        while True:
+            time.sleep(1.0)
+            self.retry_deferred_abort_acks()
 
     def _registerable_regions(self) -> List[Tuple[int, int]]:
         """(ptr, len) regions to (de)register, exact duplicates removed.
@@ -845,10 +1010,20 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         still drain the running ones before returning (no write may outlive this
         call, which the drain-ack relies on). Off: original early-return."""
         ret = 0
+        first_exception = None
         for future in concurrent.futures.as_completed(futures):
             try:
                 status = future.result()
             except concurrent.futures.CancelledError:
+                continue
+            except Exception as exc:
+                if first_exception is None:
+                    first_exception = exc
+                    for pending in futures:
+                        pending.cancel()
+                # as_completed still waits for every already-running future.
+                # Only after that drain may the worker decrement outstanding
+                # and publish an abort ack for owner reuse.
                 continue
             if status != 0 and ret == 0:
                 ret = status
@@ -856,6 +1031,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     f.cancel()
                 if not self.enable_deferred_decode_kv_release:
                     return ret
+        if first_exception is not None:
+            raise first_exception
         return ret
 
     def send_kvcache(
@@ -1276,6 +1453,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         (not the mamba-state path); subclasses extend for hardware components."""
         return st in (
             StateType.SWA,
+            StateType.DRAFT_SWA,
             StateType.DSA,
             StateType.SWA_RING,
             StateType.C128_STATE,
@@ -1285,7 +1463,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
 
     def _requires_exact_state_index_match(self, st: StateType) -> bool:
         """State types whose page lists are positional and must not be truncated."""
-        return st in (StateType.SWA_RING, StateType.C128_STATE)
+        return st in (StateType.DRAFT_SWA, StateType.SWA_RING, StateType.C128_STATE)
 
     def maybe_send_extra(
         self,
@@ -1447,6 +1625,13 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         dst_data_indices=np.array(dst_indices_local, dtype=np.int32),
                         executor=executor,
                         state_type=st,
+                        force_flat=st == StateType.DRAFT_SWA,
+                        src_layer_ids=(
+                            src_state_layer_ids if st == StateType.DRAFT_SWA else None
+                        ),
+                        dst_layer_ids=(
+                            dst_state_layer_ids if st == StateType.DRAFT_SWA else None
+                        ),
                     )
                     or rc
                 )
@@ -1638,6 +1823,20 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             is_ipv6=na.is_ipv6,
         )
 
+    def _finish_outstanding_chunk(self, kv_chunk: TransferKVChunk) -> None:
+        """Mark one dequeued chunk terminal and publish a possible drain ack."""
+        if not getattr(kv_chunk, "staging_counted", False):
+            return
+        room = kv_chunk.room
+        remaining = self._staging_outstanding.get(room, 0) - 1
+        if remaining > 0:
+            self._staging_outstanding[room] = remaining
+        else:
+            self._staging_outstanding.pop(room, None)
+        kv_chunk.staging_counted = False
+        if self.enable_deferred_decode_kv_release:
+            self._maybe_ack_drained_abort(room)
+
     def transfer_worker(
         self,
         queue: FastQueue,
@@ -1654,6 +1853,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             )
 
         while True:
+            kv_chunk = None
             try:
                 kv_chunk: TransferKVChunk = queue.get()
                 if self.enable_trace:
@@ -1684,10 +1884,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                             MooncakeRequestStage.MOONCAKE_WORKER_SEND.level,
                             thread_finish_flag=True,
                         )
-                    self._staging_outstanding.pop(kv_chunk.room, None)
-                    if self.enable_deferred_decode_kv_release:
-                        # Skipped => nothing written for this aborted room; ack.
-                        self._maybe_ack_drained_abort(kv_chunk.room)
+                    # Skipped => nothing written for this aborted room; ack.
+                    self._finish_outstanding_chunk(kv_chunk)
                     continue
 
                 if (
@@ -1735,6 +1933,15 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         target_rank_registration_info: KVArgsRegisterInfo = (
                             self.decode_kv_args_table[req.mooncake_session_id]
                         )
+                        if (
+                            kv_chunk.draft_swa_suffix
+                            and not self.can_use_draft_swa_suffix(
+                                target_rank_registration_info
+                            )
+                        ):
+                            raise RuntimeError(
+                                "draft SWA suffix capability changed after room negotiation"
+                            )
                         is_dcp_transfer = (
                             target_rank_registration_info.requires_dcp_relayout
                         )
@@ -1917,6 +2124,15 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                                     )
                                     break
 
+                            if (
+                                req.room not in self.request_status
+                                or self.check_status(req.room) == KVPoll.Failed
+                            ):
+                                # Decode abort raced the already-running KV/state
+                                # copy. Drain accounting below will publish ACK;
+                                # do not send aux or a stale Success meanwhile.
+                                break
+
                             # Only the last chunk we need to send the aux data
                             ret = self.send_aux(
                                 req,
@@ -1930,8 +2146,17 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
 
                             # Only sync status when all the dst ranks have received the kvcache
                             if len(polls) == req.required_dst_info_num:
-                                status = KVPoll.Success if all(polls) else KVPoll.Failed
+                                status = (
+                                    KVPoll.Failed
+                                    if self.check_status(req.room) == KVPoll.Failed
+                                    else (
+                                        KVPoll.Success if all(polls) else KVPoll.Failed
+                                    )
+                                )
                                 self.update_status(req.room, status)
+                                # Failed is sticky; publish the authoritative
+                                # post-update value if ABORT raced this block.
+                                status = self.check_status(req.room)
                                 for endpoint, dst_port, room in dst_ranks_infos:
                                     self.sync_status_to_decode_endpoint(
                                         endpoint,
@@ -1963,11 +2188,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 if staging_deferred:
                     continue
 
-                self._staging_outstanding[kv_chunk.room] -= 1
-                if self.enable_deferred_decode_kv_release:
-                    # In-flight write finished; if aborted and nothing outstanding,
-                    # the pages are idle -> release the held ack.
-                    self._maybe_ack_drained_abort(kv_chunk.room)
+                # In-flight write finished; if aborted and nothing outstanding,
+                # the pages are idle and this publishes the held ack.
+                self._finish_outstanding_chunk(kv_chunk)
                 # Tear down only when no chunk is still outstanding and the room
                 # has concluded: already cleared, Success, or a Failed *last*
                 # chunk. A non-last Failed chunk keeps the room (more chunks may
@@ -1994,6 +2217,11 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         self._staging_ctx.prefetched_rooms.discard(kv_chunk.room)
 
             except Exception as e:
+                # No exceptional path may leave the source owner appearing
+                # in-flight forever. The sender still observes Failed/timeout,
+                # but drain accounting is terminal before the worker exits.
+                if kv_chunk is not None:
+                    self._finish_outstanding_chunk(kv_chunk)
                 # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
                 raise RuntimeError(
                     f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
@@ -2024,32 +2252,15 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                         and self.check_status(room_to_be_aborted) != KVPoll.Success
                     )
                     if self.enable_deferred_decode_kv_release:
-                        # Mark Failed FIRST (stops add_transfer_request enqueuing
-                        # new chunks), THEN register the ack target: registering
-                        # first would let the worker drain+ack while the room is
-                        # not yet Failed, so a newly enqueued chunk could still
-                        # write to the freed pages. The worker (not this thread)
-                        # acks once its in-flight write drains; if nothing is in
-                        # flight, decode falls back to the release timeout.
-                        if room_active:
-                            self.update_status(room_to_be_aborted, KVPoll.Failed)
-                            self.register_deferred_ack_target(
-                                room_to_be_aborted, decode_ip, decode_port
-                            )
-                            # Try once: the room may already be quiescent and
-                            # never revisited by the worker.
-                            self._maybe_ack_drained_abort(room_to_be_aborted)
-                            logger.debug(
-                                f"Received abort notification for room {room_to_be_aborted}, "
-                                f"marked as Failed; ACK deferred until transfer drains"
-                            )
-                        elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
-                            # Concluded/unknown AND quiescent: ack now. A cleared
-                            # room is not automatically quiescent -- clear() can
-                            # drop a room whose chunk is still transferring.
-                            self._send_abort_ack(
-                                decode_ip, decode_port, room_to_be_aborted
-                            )
+                        room_active = self.handle_deferred_abort_notification(
+                            room_to_be_aborted, decode_ip, decode_port
+                        )
+                        logger.debug(
+                            "Received abort notification for room %s; active=%s, "
+                            "ACK retained until transfer drain and delivery",
+                            room_to_be_aborted,
+                            room_active,
+                        )
                         continue
                     # No need to abort the room if it has already succeeded
                     if room_active:
@@ -2216,6 +2427,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         aux_index: Optional[int] = None,
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
+        draft_swa_suffix: bool = False,
         trace_ctx: Optional[Union[TraceReqContext, TraceNullContext]] = None,
     ):
         assert self.disaggregation_mode == DisaggregationMode.PREFILL
@@ -2255,6 +2467,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 prefill_aux_index=aux_index,
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
+                draft_swa_suffix=draft_swa_suffix,
                 trace_ctx=trace_ctx,
             )
         )
@@ -2355,7 +2568,53 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         )
         self.conclude_state = None
         self.init_time = time.time()
+        self._draft_swa_suffix_active: Optional[bool] = None
+        self._full_draft_indices_omitted = 0
+        self._draft_swa_suffix_state_indices_sent = 0
+        self._draft_swa_suffix_completion_logged = False
         self._init_trace_ctx()
+
+    def can_send_draft_swa_suffix(self) -> bool:
+        local_required = bool(
+            getattr(self.kv_mgr.kv_args, "draft_swa_suffix_enabled", False)
+        )
+        if self._draft_swa_suffix_active is None:
+            self._draft_swa_suffix_active = (
+                self.kv_mgr.can_use_draft_swa_suffix_for_room(self.bootstrap_room)
+            )
+            if local_required:
+                logger.info(
+                    "DFLASH_PD_SUFFIX_JSON %s",
+                    json.dumps(
+                        {
+                            "event": "negotiated",
+                            "active": self._draft_swa_suffix_active,
+                            "bootstrap_room": self.bootstrap_room,
+                            "window_size": self.kv_mgr.kv_args.draft_swa_window_size,
+                            "page_size": self.kv_mgr.kv_args.page_size,
+                        },
+                        sort_keys=True,
+                        separators=(",", ":"),
+                    ),
+                )
+        peer_required = self.kv_mgr.room_has_draft_swa_suffix_peer(self.bootstrap_room)
+        if peer_required and not local_required:
+            raise RuntimeError(
+                "DFlash PD decode peer requires the draft SWA suffix protocol "
+                "but prefill has it disabled; refusing incompatible full-pool "
+                "transfer"
+            )
+        if local_required and not self._draft_swa_suffix_active:
+            raise RuntimeError(
+                "DFlash PD peer did not negotiate the required "
+                "draft SWA suffix protocol; refusing legacy full-pool transfer"
+            )
+        return bool(self._draft_swa_suffix_active)
+
+    def get_transfer_metric(self) -> KVTransferMetric:
+        # Draft suffix buffers are absent from the main KV registration, so
+        # CommonKVSender already accounts target rows plus exact state rows.
+        return super().get_transfer_metric()
 
     @mooncake_trace_func(MooncakeRequestStage.MOONCAKE_SEND)
     def send(
@@ -2364,11 +2623,29 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
         state_indices: Optional[List] = None,
         num_kv_tokens: Optional[int] = None,
     ):
+        draft_swa_suffix_active = self.can_send_draft_swa_suffix()
         kv_indices, index_slice, is_last_chunk, should_skip = (
             self._prepare_send_indices(kv_indices, state_indices)
         )
         if should_skip:
             return
+
+        if draft_swa_suffix_active:
+            # These are the rows that the legacy full-draft route would have
+            # addressed once for every draft K/V entry.
+            self._full_draft_indices_omitted += len(kv_indices)
+            if is_last_chunk:
+                component = self.kv_mgr.kv_args.state_types.index(StateType.DRAFT_SWA)
+                if state_indices is None or component >= len(state_indices):
+                    raise RuntimeError(
+                        "DFlash PD final chunk is missing draft SWA state"
+                    )
+                draft_indices = state_indices[component]
+                if draft_indices is None:
+                    raise RuntimeError(
+                        "DFlash PD final chunk has no draft SWA suffix indices"
+                    )
+                self._draft_swa_suffix_state_indices_sent += len(draft_indices)
 
         if not is_last_chunk:
             self.kv_mgr.add_transfer_request(
@@ -2377,6 +2654,7 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
                 index_slice,
                 False,
                 num_kv_tokens=num_kv_tokens,
+                draft_swa_suffix=draft_swa_suffix_active,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
             )
         else:
@@ -2388,23 +2666,56 @@ class MooncakeKVSender(MooncakeFailureExceptionMixin, CommonKVSender):
                 aux_index=self.aux_index,
                 state_indices=state_indices,
                 num_kv_tokens=num_kv_tokens,
+                draft_swa_suffix=draft_swa_suffix_active,
                 trace_ctx=self.trace_ctx.copy_for_thread(),
             )
         self._record_transfer_indices(kv_indices, state_indices)
 
     def poll(self) -> KVPoll:
+        if getattr(self.kv_mgr, "enable_deferred_decode_kv_release", False):
+            self.kv_mgr._maybe_ack_drained_abort(self.bootstrap_room)
+        if (
+            self.conclude_state in (KVPoll.Success, KVPoll.Failed)
+            and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
+        ):
+            # abort() can latch Failed locally before the transfer worker stops
+            # reading source rows. Do not publish any terminal state until the
+            # owner is no longer in flight.
+            return KVPoll.Transferring
         if self.conclude_state is None:
             status = self.kv_mgr.check_status(self.bootstrap_room)
             # Hold Success until all staging chunks transferred: a deferred
             # chunk can still be pending, and concluding now would drop it.
             if (
-                status == KVPoll.Success
+                status in (KVPoll.Success, KVPoll.Failed)
                 and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
             ):
                 return KVPoll.Transferring
             if status in (KVPoll.Success, KVPoll.Failed):
                 self.conclude_state = status
                 self.trace_ctx.trace_req_finish()
+                if (
+                    status == KVPoll.Success
+                    and self._draft_swa_suffix_active
+                    and not self._draft_swa_suffix_completion_logged
+                ):
+                    self._draft_swa_suffix_completion_logged = True
+                    metric = self.get_transfer_metric()
+                    logger.info(
+                        "DFLASH_PD_SUFFIX_JSON %s",
+                        json.dumps(
+                            {
+                                "event": "completed",
+                                "active": True,
+                                "bootstrap_room": self.bootstrap_room,
+                                "draft_state_indices": self._draft_swa_suffix_state_indices_sent,
+                                "full_draft_indices_omitted": self._full_draft_indices_omitted,
+                                "transfer_total_bytes": metric.transfer_total_bytes,
+                            },
+                            sort_keys=True,
+                            separators=(",", ":"),
+                        ),
+                    )
             elif status == KVPoll.Bootstrapping:
                 timeout_result = self._check_bootstrap_timeout()
                 if timeout_result is not None:
@@ -2466,6 +2777,12 @@ class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):
             packed_state_layer_ids = pack_int_lists(
                 self.kv_mgr.kv_args.state_layer_ids, "I"
             )
+            packed_kv_data_lens = b"".join(
+                struct.pack("Q", length) for length in self.kv_mgr.kv_args.kv_data_lens
+            )
+            packed_state_data_lens = pack_int_lists(
+                self.kv_mgr.kv_args.state_data_lens, "Q"
+            )
             packed_kv_layer_ids = b"".join(
                 struct.pack("I", layer_id)
                 for layer_id in self.kv_mgr.kv_args.kv_layer_ids
@@ -2524,6 +2841,25 @@ class MooncakeKVReceiver(MooncakeFailureExceptionMixin, CommonKVReceiver):
                             dst_dcp_size,
                             dst_dcp_rank,
                             packed_staging_slot_layer_ids,
+                            (
+                                b"1"
+                                if getattr(
+                                    self.kv_mgr.kv_args,
+                                    "draft_swa_suffix_enabled",
+                                    False,
+                                )
+                                else b"0"
+                            ),
+                            str(
+                                getattr(
+                                    self.kv_mgr.kv_args,
+                                    "draft_swa_window_size",
+                                    0,
+                                )
+                            ).encode("ascii"),
+                            str(self.kv_mgr.kv_args.page_size).encode("ascii"),
+                            packed_kv_data_lens,
+                            packed_state_data_lens,
                         ]
                     )
             except zmq.ZMQError:

--- a/python/sglang/srt/disaggregation/prefill.py
+++ b/python/sglang/srt/disaggregation/prefill.py
@@ -45,8 +45,11 @@ from sglang.srt.disaggregation.utils import (
     TransferBackend,
     build_kv_layer_ids,
     build_staging_slot_metadata,
+    get_dflash_draft_kv_transfer_locs,
+    get_dflash_draft_kv_transfer_spec,
     get_dsv4_c128_state_indices,
     get_kv_class,
+    get_legacy_draft_kv_buf_infos,
     is_aborted,
     is_dsv4_c128_online_enabled,
     is_mla_backend,
@@ -169,6 +172,9 @@ class PrefillBootstrapQueue:
             self.scheduler.tp_worker.model_runner.effective_max_total_num_tokens
         )
         self.transfer_backend = transfer_backend
+        self.draft_kv_transfer_spec = get_dflash_draft_kv_transfer_spec(
+            scheduler, draft_token_to_kv_pool, transfer_backend
+        )
         if envs.SGLANG_DISAGG_STAGING_BUFFER.get():
             if self.is_mla_backend:
                 raise RuntimeError(
@@ -240,22 +246,43 @@ class PrefillBootstrapQueue:
             else getattr(self.token_to_kv_pool, "end_layer", None)
         )
 
-        draft_kv_pool = self.draft_token_to_kv_pool if transfer_draft_cache else None
+        draft_kv_pool = None
         num_draft_entries = 0
-        if draft_kv_pool is not None:
+        legacy_draft_infos = (
+            get_legacy_draft_kv_buf_infos(
+                self.draft_token_to_kv_pool, self.draft_kv_transfer_spec
+            )
+            if transfer_draft_cache
+            else None
+        )
+        if legacy_draft_infos is not None:
             # We should also transfer draft model kv cache. The indices are
             # always shared with a target model.
             draft_kv_data_ptrs, draft_kv_data_lens, draft_kv_item_lens = (
-                draft_kv_pool.get_contiguous_buf_infos()
+                legacy_draft_infos
             )
+            draft_kv_pool = self.draft_token_to_kv_pool
             kv_data_ptrs += draft_kv_data_ptrs
             kv_data_lens += draft_kv_data_lens
             kv_item_lens += draft_kv_item_lens
             num_draft_entries = len(draft_kv_data_ptrs)
 
+        if self.draft_kv_transfer_spec is not None and not transfer_draft_cache:
+            raise RuntimeError(
+                "DFlash PD draft suffix state cannot be omitted by layer sharding"
+            )
+
         kv_args.kv_data_ptrs = kv_data_ptrs
         kv_args.kv_data_lens = kv_data_lens
         kv_args.kv_item_lens = kv_item_lens
+        kv_args.draft_swa_suffix_enabled = bool(
+            self.draft_kv_transfer_spec and self.draft_kv_transfer_spec.suffix_enabled
+        )
+        kv_args.draft_swa_window_size = (
+            self.draft_kv_transfer_spec.window_size
+            if self.draft_kv_transfer_spec
+            else 0
+        )
         kv_args.kv_layer_ids = build_kv_layer_ids(
             token_to_kv_pool=self.token_to_kv_pool,
             draft_token_to_kv_pool=draft_kv_pool,
@@ -280,7 +307,10 @@ class PrefillBootstrapQueue:
             kv_args,
             self.token_to_kv_pool,
             self.draft_token_to_kv_pool if transfer_draft_cache else None,
-            self.scheduler.model_config.num_hidden_layers,
+            draft_kv_transfer_spec=(
+                self.draft_kv_transfer_spec if transfer_draft_cache else None
+            ),
+            total_kv_layers=self.scheduler.model_config.num_hidden_layers,
             req_to_token_pool=req_to_token_pool,
         )
 
@@ -1242,6 +1272,23 @@ class SchedulerDisaggregationPrefillMixin:
                 ]
                 return kv_to_page_indices(kv_indices_full, page_size)
 
+            def _draft_swa_payload():
+                if not req.disagg_kv_sender.can_send_draft_swa_suffix():
+                    return None
+                spec = self.disagg_prefill_bootstrap_queue.draft_kv_transfer_spec
+                if spec is None:
+                    raise RuntimeError(
+                        "draft SWA suffix was negotiated without a local transfer spec"
+                    )
+                draft_indices = get_dflash_draft_kv_transfer_locs(
+                    self.draft_worker,
+                    int(req.req_pool_idx),
+                    seq_len,
+                    spec,
+                    page_size,
+                )
+                return kv_to_page_indices(draft_indices, page_size)
+
             def _swa_ring_payload():
                 # Unified_kv SWA ring rows (req_pool_idx*ring_stride + pos%ring_stride)
                 # for the last `window` positions, in ascending position order so
@@ -1283,6 +1330,7 @@ class SchedulerDisaggregationPrefillMixin:
                 StateType.C128_STATE: _c128_state_payload,
                 StateType.BLOCK_SCALE: _full_kv_pages_payload,
                 StateType.BLOCK_SCALE_SWA: _swa_payload,
+                StateType.DRAFT_SWA: _draft_swa_payload,
             }
             if _is_npu and isinstance(
                 self.token_to_kv_pool_allocator.get_kvcache(),

--- a/python/sglang/srt/disaggregation/utils.py
+++ b/python/sglang/srt/disaggregation/utils.py
@@ -9,6 +9,7 @@ from typing import (
     Iterable,
     List,
     Literal,
+    NamedTuple,
     Optional,
     Tuple,
     Type,
@@ -24,6 +25,9 @@ from sglang.srt.disaggregation.base import KVPoll
 from sglang.srt.environ import envs
 from sglang.srt.runtime_context import (
     get_disagg,
+    get_memory,
+    get_parallel,
+    get_schedule,
 )
 from sglang.srt.utils import is_hip, is_npu
 
@@ -581,6 +585,148 @@ class TransferBackend(Enum):
     FAKE = "fake"
 
 
+class DraftKVTransferSpec(NamedTuple):
+    window_size: int
+    layer_ids: Tuple[int, ...]
+    suffix_enabled: bool
+    compact_physical: bool = True
+
+
+def draft_swa_suffix_start(seq_len: int, window_size: int, page_size: int) -> int:
+    """First page-aligned absolute position in the visible draft suffix."""
+    if seq_len < 0 or window_size <= 0 or page_size <= 0:
+        raise ValueError(
+            f"Invalid draft SWA geometry: seq_len={seq_len}, "
+            f"window_size={window_size}, page_size={page_size}"
+        )
+    visible = min(seq_len, window_size)
+    return ((seq_len - visible) // page_size) * page_size
+
+
+def get_dflash_draft_kv_transfer_locs(
+    draft_worker,
+    req_pool_idx: int,
+    seq_len: int,
+    transfer_spec: DraftKVTransferSpec,
+    page_size: int,
+):
+    """Resolve the exact visible suffix in this role's draft physical pool."""
+    window_start = draft_swa_suffix_start(seq_len, transfer_spec.window_size, page_size)
+    if transfer_spec.compact_physical:
+        return draft_worker.compact_physical_transfer_locs(
+            int(req_pool_idx), window_start, seq_len
+        )
+    return draft_worker.legacy_physical_transfer_locs(
+        int(req_pool_idx), window_start, seq_len
+    )
+
+
+def get_legacy_draft_kv_buf_infos(
+    draft_token_to_kv_pool,
+    draft_kv_transfer_spec: Optional[DraftKVTransferSpec],
+):
+    """Return full-draft buffers only for the legacy shared-index route."""
+    if draft_token_to_kv_pool is None or draft_kv_transfer_spec is not None:
+        return None
+    return draft_token_to_kv_pool.get_contiguous_buf_infos()
+
+
+def get_dflash_draft_kv_transfer_spec(
+    scheduler, draft_token_to_kv_pool, transfer_backend
+) -> Optional[DraftKVTransferSpec]:
+    """Resolve the fail-closed DFlash PD suffix capability.
+
+    Compact mode maps absolute positions into owner-local rings.  The legacy
+    physical pool uses the role-local target ``req_to_token`` row as its draft
+    index space.  Both modes register draft K/V as an independent DRAFT_SWA
+    state component so target KV pointers never share draft index semantics.
+    """
+    draft_worker = getattr(scheduler, "draft_worker", None)
+    compact_requested = bool(
+        draft_worker is not None
+        and getattr(draft_worker, "use_compact_draft_cache", False)
+    )
+    suffix_requested = bool(
+        scheduler.spec_algorithm.is_dflash()
+        and envs.SGLANG_DFLASH_PD_DRAFT_SWA_SUFFIX.get()
+    )
+    if not compact_requested and not suffix_requested:
+        return None
+
+    def reject(reason: str):
+        physical_mode = "compact" if compact_requested else "legacy-physical"
+        raise RuntimeError(
+            f"{physical_mode} DFlash PD cannot use the legacy full-pool route: "
+            + reason
+        )
+
+    if not envs.SGLANG_DFLASH_PD_DRAFT_SWA_SUFFIX.get():
+        return reject("draft suffix protocol is disabled")
+    if not envs.SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE.get():
+        return reject("deferred decode KV release must be enabled")
+    if transfer_backend != TransferBackend.MOONCAKE:
+        return reject("transfer backend is not Mooncake")
+    if not scheduler.spec_algorithm.is_dflash():
+        return reject("speculative algorithm is not DFlash")
+    if draft_token_to_kv_pool is None or draft_worker is None:
+        return reject("draft pool or worker is missing")
+
+    parallel = get_parallel()
+    memory = get_memory()
+    disagg = get_disagg()
+    if parallel.pp_size != 1:
+        return reject("pipeline parallelism must be 1")
+    if parallel.dp_size != 1:
+        return reject("data parallelism must be 1")
+    if parallel.attn_dcp_size != 1:
+        return reject("DCP must be 1")
+    if parallel.attn_cp_size != 1:
+        return reject("context parallelism must be 1")
+    if int(disagg.disaggregation_decode_extra_slots or 0) != 0:
+        return reject("decode extra slots must be 0")
+    if not memory.disable_radix_cache:
+        return reject("radix cache must be disabled")
+    if disagg.disaggregation_decode_enable_radix_cache:
+        return reject("decode radix cache must be disabled")
+    if memory.enable_hierarchical_cache or memory.hicache_storage_backend is not None:
+        return reject("HiCache must be disabled")
+    if memory.enable_unified_memory:
+        return reject("unified memory is unsupported")
+
+    window_size = getattr(draft_worker, "draft_window_size", None)
+    layers = getattr(getattr(draft_worker, "draft_model", None), "layers", ())
+    if not layers:
+        return reject("draft layers are missing")
+    layer_windows = tuple(
+        int(getattr(layer.self_attn, "sliding_window_size", -1)) + 1 for layer in layers
+    )
+    if any(window <= 0 for window in layer_windows) or len(set(layer_windows)) != 1:
+        return reject("draft layer windows are invalid or heterogeneous")
+    checkpoint_window = layer_windows[0]
+    if window_size is None or int(window_size) != checkpoint_window:
+        return reject("runtime and checkpoint draft windows differ")
+    if int(getattr(draft_token_to_kv_pool, "layer_num", -1)) != len(layers):
+        return reject("draft pool layer count mismatch")
+    if getattr(draft_token_to_kv_pool, "use_hnd", False):
+        return reject("HND draft pool layout is unsupported")
+
+    target_page_size = int(get_schedule().page_size)
+    draft_page_size = int(getattr(draft_token_to_kv_pool, "page_size", -1))
+    if target_page_size != 1 or draft_page_size != 1:
+        return reject("target and draft page_size must both be 1")
+
+    layer_ids = tuple(
+        int(getattr(layer.self_attn.attn, "layer_id", i))
+        for i, layer in enumerate(layers)
+    )
+    return DraftKVTransferSpec(
+        checkpoint_window,
+        layer_ids + layer_ids,
+        True,
+        compact_requested,
+    )
+
+
 class KVClassType(Enum):
     KVARGS = "kvargs"
     MANAGER = "manager"
@@ -1073,6 +1219,8 @@ def setup_state_kv_args(
     draft_token_to_kv_pool=None,
     total_kv_layers: int = None,
     req_to_token_pool=None,
+    *,
+    draft_kv_transfer_spec: Optional[DraftKVTransferSpec] = None,
 ) -> None:
     """Populate ``kv_args`` state-buffer fields from the given pool.
     Shared by prefill and decode bootstrap paths so the state_type dispatch
@@ -1237,6 +1385,25 @@ def setup_state_kv_args(
                 c128_lens,
                 c128_item_lens,
             )
+
+    if draft_kv_transfer_spec is not None:
+        draft_ptrs, draft_lens, draft_item_lens = (
+            draft_token_to_kv_pool.get_contiguous_buf_infos()
+        )
+        if len(draft_ptrs) != len(draft_kv_transfer_spec.layer_ids):
+            raise RuntimeError(
+                "DFlash draft state layer metadata mismatch: "
+                f"entries={len(draft_ptrs)}, "
+                f"layer_ids={len(draft_kv_transfer_spec.layer_ids)}"
+            )
+        append_state_component(
+            kv_args,
+            StateType.DRAFT_SWA,
+            draft_ptrs,
+            draft_lens,
+            draft_item_lens,
+            layer_ids=list(draft_kv_transfer_spec.layer_ids),
+        )
 
     # DSV4 NextN shares the target allocator, so target and draft use the same
     # local SWA indices. Keep draft buffers in a separate positional component

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -1189,6 +1189,8 @@ class Envs:
     SGLANG_OPT_FUSED_KDA_VERIFY = EnvBool(False)
     # A/B: keep the DFLASH draft greedy head eager (not folded in-graph).
     SGLANG_DFLASH_EAGER_DRAFT_SAMPLER = EnvBool(False)
+    # Negotiated Mooncake transfer of only the visible DFlash draft suffix.
+    SGLANG_DFLASH_PD_DRAFT_SWA_SUFFIX = EnvBool(False)
     SGLANG_RAGGED_VERIFY_MODE = EnvStr("static")
     SGLANG_TEST_RAGGED_VERIFY_FORCE_UNIFORM_CAPTURE = EnvBool(False)
     # Skip draft_extend while adaptive spec is at steps=0 (drafting disabled).

--- a/python/sglang/srt/managers/schedule_batch.py
+++ b/python/sglang/srt/managers/schedule_batch.py
@@ -2116,6 +2116,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     # CPU mirror of req_pool_indices; schedule-path only (used in overlap_utils,
     # not read by ForwardBatch), stale in spec draft window
     req_pool_indices_cpu: torch.Tensor = None  # shape: [b], int64
+    # Exact request-slot generations captured when this batch was prepared.
+    # acquire_owner_mask grants one-shot authority to bind newly allocated rows.
+    expected_req_generations_cpu: Optional[torch.Tensor] = None  # [b], int64 CPU
+    acquire_owner_mask: Optional[torch.Tensor] = None  # [b], bool CPU
 
     # Forward-pass metrics
     fpm_start_time: float = 0.0
@@ -2302,6 +2306,40 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
     def batch_size(self):
         return len(self.reqs)
 
+    def uses_dflash_owner_metadata(self) -> bool:
+        """Whether this batch needs compact DFlash owner-generation checks."""
+        is_dflash = getattr(self.spec_algorithm, "is_dflash", None)
+        return bool(is_dflash is not None and is_dflash())
+
+    def set_req_pool_owner_metadata(self, acquire_mask) -> None:
+        """Snapshot exact pool generations for compact request-owned caches."""
+        if self.req_pool_indices_cpu is None:
+            raise RuntimeError("request pool owner metadata requires CPU indices")
+        indices = self.req_pool_indices_cpu.to(dtype=torch.int64, device="cpu").reshape(
+            -1
+        )
+        if indices.numel() != len(self.reqs):
+            raise RuntimeError(
+                "request pool owner metadata shape mismatch: "
+                f"indices={indices.numel()}, requests={len(self.reqs)}"
+            )
+        generations = self.req_to_token_pool.req_generation[indices].to(
+            dtype=torch.int64, device="cpu"
+        )
+        if bool(torch.any(generations <= 0)):
+            raise RuntimeError(
+                "request pool owner metadata requires positive generations: "
+                f"generations={generations.tolist()}"
+            )
+        mask = torch.as_tensor(acquire_mask, dtype=torch.bool, device="cpu").reshape(-1)
+        if mask.numel() != len(self.reqs):
+            raise RuntimeError(
+                "request pool acquire mask shape mismatch: "
+                f"mask={mask.numel()}, requests={len(self.reqs)}"
+            )
+        self.expected_req_generations_cpu = generations.clone()
+        self.acquire_owner_mask = mask.clone()
+
     def is_empty(self):
         return len(self.reqs) == 0
 
@@ -2448,6 +2486,7 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
 
         # Init tensors
         reqs = self.reqs
+        fresh_req_slots = [r.req_pool_idx is None for r in reqs]
         input_ids = [r.get_fill_ids()[len(r.prefix_indices) :] for r in reqs]
         extend_num_tokens = sum(len(ids) for ids in input_ids)
         seq_lens = [r.extend_range.end for r in reqs]
@@ -2642,6 +2681,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.prefill_input_ids_cpu = pinned_input_ids
         self.req_pool_indices = req_pool_indices_tensor
         self.req_pool_indices_cpu = req_pool_indices_cpu
+        if self.uses_dflash_owner_metadata():
+            self.set_req_pool_owner_metadata(fresh_req_slots)
         self.orig_seq_lens = orig_seq_lens_tensor
         self.out_cache_loc = out_cache_loc
         self.input_embeds = (
@@ -3078,6 +3119,8 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.out_cache_loc = torch.empty(0, dtype=torch.int64, device=self.device)
         self.req_pool_indices = torch.empty(0, dtype=torch.int64, device=self.device)
         self.req_pool_indices_cpu = torch.empty(0, dtype=torch.int64)
+        self.expected_req_generations_cpu = torch.empty(0, dtype=torch.int64)
+        self.acquire_owner_mask = torch.empty(0, dtype=torch.bool)
         self.seq_lens_sum = 0
         self.extend_num_tokens = 0
         self.sampling_info = SamplingBatchInfo.from_schedule_batch(
@@ -3292,6 +3335,10 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             # Filter out all requests. Stale tensors are left as-is: is_empty()
             # keys off reqs, so callers drop the batch before a forward reads them.
             self.reqs = []
+            if self.expected_req_generations_cpu is not None:
+                self.expected_req_generations_cpu = torch.empty(0, dtype=torch.int64)
+            if self.acquire_owner_mask is not None:
+                self.acquire_owner_mask = torch.empty(0, dtype=torch.bool)
             self.return_hidden_states = False
             self.return_hidden_states_mode = CaptureHiddenMode.NULL
             return
@@ -3315,6 +3362,12 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             self.multimodal_inputs = [self.multimodal_inputs[i] for i in keep_indices]
         self.req_pool_indices = self.req_pool_indices[keep_indices_device]
         self.req_pool_indices_cpu = self.req_pool_indices_cpu[keep_indices]
+        if self.expected_req_generations_cpu is not None:
+            self.expected_req_generations_cpu = self.expected_req_generations_cpu[
+                keep_indices
+            ].clone()
+        if self.acquire_owner_mask is not None:
+            self.acquire_owner_mask = self.acquire_owner_mask[keep_indices].clone()
         self.seq_lens = self.seq_lens[keep_indices_device]
         self.orig_seq_lens = self.orig_seq_lens[keep_indices_device]
         self.out_cache_loc = None
@@ -3375,6 +3428,31 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
         self.req_pool_indices_cpu = torch.cat(
             [self.req_pool_indices_cpu, other.req_pool_indices_cpu]
         )
+        if (
+            self.expected_req_generations_cpu is None
+            or other.expected_req_generations_cpu is None
+            or self.acquire_owner_mask is None
+            or other.acquire_owner_mask is None
+        ):
+            if not (
+                self.expected_req_generations_cpu is None
+                and other.expected_req_generations_cpu is None
+                and self.acquire_owner_mask is None
+                and other.acquire_owner_mask is None
+            ):
+                raise RuntimeError(
+                    "cannot merge partially populated request pool owner metadata"
+                )
+        else:
+            self.expected_req_generations_cpu = torch.cat(
+                [
+                    self.expected_req_generations_cpu,
+                    other.expected_req_generations_cpu,
+                ]
+            )
+            self.acquire_owner_mask = torch.cat(
+                [self.acquire_owner_mask, other.acquire_owner_mask]
+            )
         self.seq_lens = torch.cat([self.seq_lens, other.seq_lens])
         self.orig_seq_lens = torch.cat([self.orig_seq_lens, other.orig_seq_lens])
         self.out_cache_loc = None
@@ -3437,6 +3515,21 @@ class ScheduleBatch(ScheduleBatchDisaggregationDecodeMixin):
             prefix_lens=self.prefix_lens,
             req_to_token_pool=self.req_to_token_pool,
             req_pool_indices=self.req_pool_indices,
+            req_pool_indices_cpu=(
+                self.req_pool_indices_cpu.clone()
+                if self.req_pool_indices_cpu is not None
+                else None
+            ),
+            expected_req_generations_cpu=(
+                self.expected_req_generations_cpu.clone()
+                if self.expected_req_generations_cpu is not None
+                else None
+            ),
+            acquire_owner_mask=(
+                self.acquire_owner_mask.clone()
+                if self.acquire_owner_mask is not None
+                else None
+            ),
             model_config=self.model_config,
             forward_mode=self.forward_mode,
             out_cache_loc=self.out_cache_loc,

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3166,6 +3166,9 @@ class Scheduler(
             req_pool_indices, dtype=torch.int64, device=device
         )
         batch.req_pool_indices_cpu = torch.tensor(req_pool_indices, dtype=torch.int64)
+        is_dflash = getattr(self.spec_algorithm, "is_dflash", None)
+        if is_dflash is not None and is_dflash():
+            batch.set_req_pool_owner_metadata([True] * len(reqs))
         seq_lens = [len(r.origin_input_ids) + len(r.output_ids) - 1 for r in reqs]
         batch.seq_lens = torch.tensor(seq_lens, dtype=torch.int64, device=device)
         batch.seq_lens_cpu = torch.tensor(seq_lens, dtype=torch.int64)
@@ -3857,6 +3860,13 @@ class Scheduler(
             else:
                 batch.sampling_info = sched_sampling_info
 
+    @staticmethod
+    def _complete_req_pool_owner_acquisition(batch: ScheduleBatch) -> None:
+        """Consume one-shot compact owner binding authority after a forward."""
+        acquire_owner_mask = getattr(batch, "acquire_owner_mask", None)
+        if acquire_owner_mask is not None:
+            batch.acquire_owner_mask = torch.zeros_like(acquire_owner_mask)
+
     @scheduler_nvtx_method("scheduler.run_batch")
     def run_batch(
         self,
@@ -4083,6 +4093,7 @@ class Scheduler(
                     can_run_cuda_graph=can_run_cuda_graph,
                 )
 
+        self._complete_req_pool_owner_acquisition(batch)
         self._maybe_report_active_ranks()
 
         return ret
@@ -4433,7 +4444,13 @@ class Scheduler(
             if self.disaggregation_mode == DisaggregationMode.DECODE:
                 idle &= len(self.disagg_decode_prealloc_queue.queue) == 0
                 idle &= len(self.disagg_decode_prealloc_queue.retracted_queue) == 0
-                idle &= len(self.disagg_decode_transfer_queue.queue) == 0
+                # Queue-removed aborts can still own KV pages / a compact draft
+                # request row while waiting for the remote drain ack.  Treat the
+                # visible transfers and those deferred holds as one ownership
+                # domain for every destructive idle consumer (flush/release).
+                idle &= not (
+                    self.disagg_decode_transfer_queue.has_pending_kv_ownership()
+                )
                 if self.decode_offload_manager is not None:
                     idle &= len(self.decode_offload_manager.ongoing_offload) == 0
 

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -3586,6 +3586,7 @@ class Scheduler(
                 # lifecycle and freeing them here causes double-free.
                 added = len(adder.can_run_list) > 0 and req is adder.can_run_list[-1]
                 if not added:
+                    self._release_rejected_dflash_match(self.tree_cache, req)
                     # init_next_round_input() may stage deferred Mamba COW/clear
                     # metadata before add_one_req() rejects the request.
                     req.mamba_cow_src_index = None
@@ -3866,6 +3867,13 @@ class Scheduler(
         acquire_owner_mask = getattr(batch, "acquire_owner_mask", None)
         if acquire_owner_mask is not None:
             batch.acquire_owner_mask = torch.zeros_like(acquire_owner_mask)
+
+    @staticmethod
+    def _release_rejected_dflash_match(tree_cache, req) -> None:
+        """Drop a short restore pin when admission rejects its candidate."""
+        release = getattr(tree_cache, "release_dflash_draft_match_pin", None)
+        if release is not None:
+            release(req.rid)
 
     @scheduler_nvtx_method("scheduler.run_batch")
     def run_batch(

--- a/python/sglang/srt/managers/scheduler_components/weight_updater.py
+++ b/python/sglang/srt/managers/scheduler_components/weight_updater.py
@@ -209,14 +209,32 @@ class SchedulerWeightUpdaterManager:
             )
 
     def release_memory_occupation(self, recv_req: ReleaseMemoryOccupationReqInput):
-        assert (
-            self.is_fully_idle()
-        ), "release_memory_occupation should be called only when server is idle."
+        if not self.is_fully_idle():
+            raise RuntimeError(
+                "release_memory_occupation should be called only when server is "
+                "idle."
+            )
 
         tags = recv_req.tags
 
         if tags is None or len(tags) == 0:
             tags = GPU_MEMORY_ALL_TYPES
+
+        # Preflight before changing offload_tags or pausing any allocation.  The
+        # scheduler idle predicate is the normal gate; this queue-local check is
+        # deliberately redundant so a forced/mocked caller still fails closed
+        # instead of forgetting an active compact owner.
+        if GPU_MEMORY_TYPE_KV_CACHE in tags:
+            scheduler = self.scheduler
+            if (
+                scheduler is not None
+                and scheduler.disaggregation_mode == DisaggregationMode.DECODE
+            ):
+                transfer_queue = getattr(
+                    scheduler, "disagg_decode_transfer_queue", None
+                )
+                if transfer_queue is not None:
+                    transfer_queue.assert_memory_release_safe()
 
         for tag in tags:
             self.offload_tags.add(tag)

--- a/python/sglang/srt/mem_cache/base_prefix_cache.py
+++ b/python/sglang/srt/mem_cache/base_prefix_cache.py
@@ -57,6 +57,16 @@ class MatchPrefixParams:
     cow_mamba: bool = False
     req: Optional[Req] = None
 
+    # Qwen compact DFlash only. Internal cache maintenance rematches must not
+    # retain a restore pin; admission matches keep the default behavior.
+    pin_dflash_restore: bool = True
+
+    # Internal cache maintenance rematches transfer ownership of target FULL
+    # and MAMBA rows back to the request, but never restore draft KV.  They must
+    # therefore ignore DRAFT coverage while normal admission keeps requiring
+    # FULL+MAMBA+DRAFT consensus.
+    require_dflash_draft: bool = True
+
 
 @dataclasses.dataclass
 class InsertParams:
@@ -70,6 +80,12 @@ class InsertParams:
 
     # DSV4 NPU C128 sidecar pages, one page id per physical C128 page group.
     c128_value: Optional[torch.Tensor] = None
+
+    # Device-only Qwen DFlash radix content rows. The tensor covers the
+    # contiguous token interval beginning at draft_start_seqlen.
+    draft_value: Optional[torch.Tensor] = None
+    draft_start_seqlen: int = 0
+    draft_processed: Optional[torch.Tensor] = None
 
     # SWA specific
     prev_prefix_len: int = 0
@@ -103,6 +119,7 @@ class EvictParams:
     num_tokens: int = 0
     swa_num_tokens: int = 0
     mamba_num: int = 0
+    draft_num_tokens: int = 0
 
 
 @dataclasses.dataclass
@@ -112,6 +129,7 @@ class EvictResult:
     num_tokens_evicted: int = 0
     swa_num_tokens_evicted: int = 0
     mamba_num_evicted: int = 0
+    draft_num_tokens_evicted: int = 0
 
 
 @dataclasses.dataclass
@@ -207,16 +225,26 @@ class MatchResult(NamedTuple):
     mamba_branching_seqlen: Optional[int] = None
     cache_protected_len: Optional[int] = None
     full_kv_hit_length: int = 0
+    # RID owning a short-lived DFlash content pin, if one was acquired.
+    dflash_match_rid: Optional[str] = None
     # Actions the Controller applies: CacheActions itself, ComponentActions routed to the owning component.
     cache_actions: Sequence[CacheAction | ComponentAction] = ()
 
 
 def zero_match_result(
-    tree_cache, match_result: MatchResult, extra_key: Optional[str] = None
+    tree_cache,
+    match_result: MatchResult,
+    extra_key: Optional[str] = None,
+    rid: Optional[str] = None,
 ) -> MatchResult:
     if tree_cache.is_chunk_cache():
         # Chunk caches' match_prefix already returns a miss; no root_node to walk back to.
         return match_result
+    rid = rid if rid is not None else match_result.dflash_match_rid
+    if rid is not None:
+        release_pin = getattr(tree_cache, "release_dflash_draft_match_pin", None)
+        if release_pin is not None:
+            release_pin(rid)
     root = tree_cache.root_node_handle(extra_key=extra_key)
     return match_result._replace(
         # [:0] keeps dtype and device of the original tensor (e.g. CUDA int64)
@@ -229,6 +257,7 @@ def zero_match_result(
         swa_host_hit_length=0,
         mamba_host_hit_length=0,
         full_kv_hit_length=0,
+        dflash_match_rid=None,
     )
 
 

--- a/python/sglang/srt/mem_cache/cache_init_params.py
+++ b/python/sglang/srt/mem_cache/cache_init_params.py
@@ -12,6 +12,9 @@ if TYPE_CHECKING:
     from sglang.srt.mem_cache.unified_cache.components.tree_component import (
         TreeComponent,
     )
+    from sglang.srt.speculative.dflash_draft_content_allocator import (
+        DFlashDraftContentAllocator,
+    )
 
 
 @dataclasses.dataclass
@@ -55,3 +58,7 @@ class CacheInitParams:
     )
 
     mtp_draft_device_pools: tuple[object, ...] = ()
+
+    # Qwen DFlash compact radix content is bound to a fixed device subrange.
+    dflash_draft_content_allocator: Optional[DFlashDraftContentAllocator] = None
+    dflash_draft_window_size: Optional[int] = None

--- a/python/sglang/srt/mem_cache/memory_pool.py
+++ b/python/sglang/srt/mem_cache/memory_pool.py
@@ -344,7 +344,9 @@ class ReqToTokenPool:
 
     def clear(self):
         self.free_slots = list(range(1, self._alloc_size))
-        self.req_generation.zero_()
+        # Keep generations monotonic across a global clear. Resetting permits
+        # an ABA collision (old generation 1 -> clear -> new generation 1), so
+        # request-owned side pools could accept stale state after slot reuse.
         if self._aux_cache is not None:
             self._aux_cache.clear()
 

--- a/python/sglang/srt/mem_cache/registry.py
+++ b/python/sglang/srt/mem_cache/registry.py
@@ -18,7 +18,7 @@ from sglang.srt.environ import envs
 from sglang.srt.hardware_backend.mlx.runtime import use_mlx
 from sglang.srt.mem_cache.base_prefix_cache import BasePrefixCache
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
-from sglang.srt.runtime_context import get_disagg, get_memory, get_serving
+from sglang.srt.runtime_context import get_disagg, get_memory, get_serving, get_spec
 
 if TYPE_CHECKING:
     from sglang.srt.configs.model_config import ModelConfig
@@ -164,6 +164,8 @@ def _create_unified_radix_cache(
     if ctx.is_hybrid_ssm:
         tree_components.append(ComponentType.MAMBA)
 
+    _attach_qwen_dflash_draft_component(ctx, params, tree_components)
+
     if hasattr(params.req_to_token_pool, "req_to_c128_sidecar"):
         from sglang.srt.hardware_backend.npu.dsv4.c128_sidecar_component import (
             C128SidecarComponent,
@@ -194,6 +196,64 @@ def _create_unified_radix_cache(
             cache.cache_controller.layer_done_counter
         )
     return cache
+
+
+def _attach_qwen_dflash_draft_component(
+    ctx: TreeCacheBuildContext,
+    params: CacheInitParams,
+    tree_components: list,
+) -> None:
+    """Bind the fixed compact-DFlash content subrange to a Qwen target tree."""
+    from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
+
+    spec_aux_config = getattr(ctx.tp_worker.model_runner, "spec_aux_config", None)
+    content_tokens = getattr(spec_aux_config, "dflash_radix_sidecar_tokens", 0)
+    if not isinstance(content_tokens, int) or content_tokens <= 0:
+        return
+
+    model_type = getattr(ctx.model_config.hf_text_config, "model_type", None)
+    unsupported = []
+    if model_type != "qwen3_5_text":
+        unsupported.append(f"target model_type={model_type!r}")
+    if not ctx.is_hybrid_ssm or ctx.is_hybrid_swa:
+        unsupported.append("target tree is not FULL+MAMBA")
+    if ctx.disable_radix_cache:
+        unsupported.append("radix cache is disabled")
+    if ctx.enable_hierarchical_cache:
+        unsupported.append("HiCache is enabled")
+    if bool(getattr(ctx.server_args, "enable_unified_memory", False)):
+        unsupported.append("unified memory is enabled")
+    if unsupported:
+        raise ValueError(
+            "Qwen DFlash radix sidecar has unsupported configuration: "
+            + ", ".join(unsupported)
+        )
+
+    owner_count = getattr(spec_aux_config, "dflash_compact_owner_count", None)
+    window_size = get_spec().speculative_draft_window_size
+    block_size = get_spec().speculative_num_draft_tokens
+    from sglang.srt.speculative.dflash_compact_physical_layout import (
+        CompactDFlashPhysicalLayout,
+    )
+    from sglang.srt.speculative.dflash_draft_content_allocator import (
+        DFlashDraftContentAllocator,
+    )
+
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=int(owner_count),
+        window_size=int(window_size),
+        block_size=int(block_size),
+        page_size=int(params.page_size),
+        content_tokens=content_tokens,
+    )
+    params.dflash_draft_content_allocator = DFlashDraftContentAllocator(
+        start=layout.content_start,
+        size=layout.content_tokens,
+        device=params.token_to_kv_pool_allocator.device,
+    )
+    params.dflash_draft_window_size = layout.window_size
+    # DRAFT finalization pins restore sources before Mamba COW can evict.
+    tree_components.insert(1, ComponentType.DRAFT)
 
 
 def create_tree_cache(ctx: TreeCacheBuildContext) -> BasePrefixCache:

--- a/python/sglang/srt/mem_cache/unified_cache/component_type.py
+++ b/python/sglang/srt/mem_cache/unified_cache/component_type.py
@@ -10,6 +10,7 @@ class ComponentType(int, Enum):
     SWA = 1
     MAMBA = 2
     C128 = 3
+    DRAFT = 4
 
     def __str__(self) -> str:  # keep human-readable logging
         return self.name.lower()
@@ -25,6 +26,10 @@ class ComponentType(int, Enum):
     @property
     def is_mamba(self) -> bool:
         return self == ComponentType.MAMBA
+
+    @property
+    def is_draft(self) -> bool:
+        return self == ComponentType.DRAFT
 
 
 BASE_COMPONENT_TYPE = ComponentType.FULL

--- a/python/sglang/srt/mem_cache/unified_cache/components/dflash_draft_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/dflash_draft_component.py
@@ -1,0 +1,566 @@
+"""Device-only radix content component for compact Qwen DFlash."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Callable, Optional
+
+import msgspec
+import torch
+
+from sglang.srt.mem_cache.base_prefix_cache import (
+    DecLockRefParams,
+    IncLockRefResult,
+    InsertParams,
+    InsertResult,
+    MatchPrefixParams,
+    MatchResult,
+)
+from sglang.srt.mem_cache.unified_cache.cache_action import FreeComponentDeviceSlot
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    ComponentType,
+    EvictLayer,
+    LRURefreshPhase,
+    TreeComponent,
+    next_component_uuid,
+)
+
+if TYPE_CHECKING:
+    from sglang.srt.managers.schedule_batch import Req
+    from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+    from sglang.srt.mem_cache.unified_cache.cache_action import (
+        CacheAction,
+        ComponentAction,
+    )
+    from sglang.srt.mem_cache.unified_radix_cache import (
+        NodeId,
+        UnifiedRadixCache,
+        UnifiedTreeNode,
+    )
+    from sglang.srt.speculative.dflash_draft_content_allocator import (
+        DFlashDraftContentAllocator,
+    )
+
+logger = logging.getLogger(__name__)
+
+
+class DFlashDraftMatchPlan(msgspec.Struct, frozen=True):
+    source_rows: torch.Tensor
+    node_id: int
+    boundary_uuid: int
+    matched_tokens: int
+
+
+class DFlashDraftPendingPublish(msgspec.Struct, frozen=True):
+    start_seqlen: int
+    rows: torch.Tensor
+
+
+class DFlashDraftComponent(TreeComponent):
+    """Canonical committed draft KV stored alongside the target radix tree."""
+
+    component_type = ComponentType.DRAFT
+    _MATCH_UUID_KEY = "dflash_match_uuid"
+
+    def __init__(self, cache: UnifiedRadixCache, params: CacheInitParams):
+        super().__init__(cache, params)
+        if params.enable_session_radix_cache:
+            raise ValueError("Qwen DFlash radix sidecar does not support sessions")
+        if params.dflash_draft_content_allocator is None:
+            raise ValueError("DFlashDraftComponent requires a content allocator")
+        if not params.dflash_draft_window_size or params.dflash_draft_window_size <= 0:
+            raise ValueError("DFlashDraftComponent requires a positive draft window")
+        self.allocator: DFlashDraftContentAllocator = (
+            params.dflash_draft_content_allocator
+        )
+        self.window_size = int(params.dflash_draft_window_size)
+        self._match_plans: dict[str, DFlashDraftMatchPlan] = {}
+        self._pending_publishes: dict[str, DFlashDraftPendingPublish] = {}
+        self._evict_device_cursor = None
+        self._published_tokens = 0
+        self._evicted_tokens = 0
+
+    def reset_component_state(self) -> None:
+        self._match_plans.clear()
+        self._pending_publishes.clear()
+        self._evict_device_cursor = None
+        self._published_tokens = 0
+        self._evicted_tokens = 0
+        self.allocator.clear()
+
+    def reset_session_state(self) -> None:
+        super().reset_session_state()
+
+    def _dec_session_coverage(self, session_id: str, leaf: UnifiedTreeNode) -> None:
+        raise AssertionError("DFlash draft sessions are disabled")
+
+    def _advance_session_coverage(
+        self,
+        session_id: str,
+        leaf: UnifiedTreeNode,
+        old_ancestor: Optional[UnifiedTreeNode],
+    ) -> None:
+        raise AssertionError("DFlash draft sessions are disabled")
+
+    def _recede_session_coverage(
+        self,
+        session_id: str,
+        leaf: UnifiedTreeNode,
+        fallback: Optional[UnifiedTreeNode],
+    ) -> None:
+        raise AssertionError("DFlash draft sessions are disabled")
+
+    def refresh_lru(
+        self,
+        phase: LRURefreshPhase,
+        node: UnifiedTreeNode,
+        root_node: UnifiedTreeNode,
+    ) -> None:
+        if phase is LRURefreshPhase.WALKDOWN:
+            return
+        self.tree_core.lru_lists[
+            self.component_type
+        ].reset_node_and_window_ancestors_mru(
+            node,
+            root_node,
+            self.window_size + self.tree_core.page_size,
+            self.node_has_component_data,
+        )
+
+    def create_match_validator(
+        self, match_device_only: bool = False
+    ) -> Callable[[UnifiedTreeNode], bool]:
+        state = {"covered": float("inf")}
+        ct = self.component_type
+
+        def validator(node: UnifiedTreeNode) -> bool:
+            value = node.component_data[ct].value
+            if value is None:
+                state["covered"] = 0
+                return False
+            state["covered"] += len(value)
+            return state["covered"] >= self.window_size
+
+        return validator
+
+    def finalize_match_result_in_cache(
+        self, params: MatchPrefixParams, result: MatchResult
+    ) -> MatchResult:
+        req = params.req
+        rid = getattr(req, "rid", None) if req is not None else None
+        if rid is None:
+            return result
+        self.release_match_pin(rid)
+        if params.pin_dflash_restore and not params.require_dflash_draft:
+            raise RuntimeError("DFlash restore pin requires DRAFT coverage validation")
+        if not params.pin_dflash_restore:
+            return result
+        if result.device_indices.numel() == 0:
+            return result
+        required_tokens = min(self.window_size, int(result.device_indices.numel()))
+        self._pin_match(rid, result.best_match_node, required_tokens)
+        return result._replace(dflash_match_rid=rid)
+
+    def _pin_match(
+        self, rid: str, node_id: NodeId, required_tokens: int
+    ) -> DFlashDraftMatchPlan:
+        root = self.tree_core.root_node
+        node = self.tree_core.node_by_id(node_id)
+        chunks: list[torch.Tensor] = []
+        locked_nodes: list[UnifiedTreeNode] = []
+        covered = 0
+        while node is not root and covered < required_tokens:
+            cd = node.component_data[self.component_type]
+            if cd.value is None:
+                raise RuntimeError("DFlash match lost content before it was pinned")
+            chunks.append(cd.value)
+            locked_nodes.append(node)
+            covered += len(cd.value)
+            node = node.parent
+        if covered < required_tokens:
+            raise RuntimeError("DFlash match has insufficient trailing coverage")
+
+        boundary = locked_nodes[-1]
+        boundary_cd = boundary.component_data[self.component_type]
+        boundary_uuid = boundary_cd.metadata.get(self._MATCH_UUID_KEY)
+        create_boundary_uuid = boundary_uuid is None
+        if create_boundary_uuid:
+            boundary_uuid = next_component_uuid()
+
+        chunks.reverse()
+        source_rows = torch.cat(chunks)[-required_tokens:].clone()
+        self.allocator.assert_allocated(source_rows)
+        plan = DFlashDraftMatchPlan(
+            source_rows=source_rows,
+            node_id=int(node_id),
+            boundary_uuid=int(boundary_uuid),
+            matched_tokens=required_tokens,
+        )
+        acquired_nodes: list[UnifiedTreeNode] = []
+        boundary_uuid_published = False
+        try:
+            for locked in locked_nodes:
+                cd = locked.component_data[self.component_type]
+                if cd.lock_ref == 0:
+                    size = len(cd.value)
+                    self.tree_core.component_evictable_size_[
+                        self.component_type
+                    ] -= size
+                    self.tree_core.component_protected_size_[
+                        self.component_type
+                    ] += size
+                cd.lock_ref += 1
+                acquired_nodes.append(locked)
+                self.tree_core._update_evictable_leaf_sets(locked)
+
+            if create_boundary_uuid:
+                boundary_cd.metadata[self._MATCH_UUID_KEY] = boundary_uuid
+                boundary_uuid_published = True
+            self._match_plans[rid] = plan
+        except BaseException:
+            if (
+                boundary_uuid_published
+                and boundary_cd.metadata.get(self._MATCH_UUID_KEY) == boundary_uuid
+            ):
+                boundary_cd.metadata.pop(self._MATCH_UUID_KEY)
+            for locked in reversed(acquired_nodes):
+                cd = locked.component_data[self.component_type]
+                cd.lock_ref -= 1
+                if cd.lock_ref == 0:
+                    size = len(cd.value)
+                    self.tree_core.component_protected_size_[
+                        self.component_type
+                    ] -= size
+                    self.tree_core.component_evictable_size_[
+                        self.component_type
+                    ] += size
+                self.tree_core._update_evictable_leaf_sets(locked)
+            raise
+        return plan
+
+    def get_match_plan(self, rid: str) -> Optional[DFlashDraftMatchPlan]:
+        return self._match_plans.get(rid)
+
+    def stage_pending_publish(
+        self, rid: str, start_seqlen: int, rows: torch.Tensor
+    ) -> None:
+        if rid in self._pending_publishes:
+            raise RuntimeError(f"DFlash request {rid!r} already has pending content")
+        if start_seqlen < 0 or rows.numel() == 0:
+            raise ValueError(
+                "DFlash pending publish requires a nonnegative start and rows"
+            )
+        self.allocator.claim_lease(rows)
+        try:
+            self._pending_publishes[rid] = DFlashDraftPendingPublish(
+                start_seqlen=int(start_seqlen), rows=rows
+            )
+        except BaseException:
+            # Once claim_lease succeeds the worker no longer owns a lease. Keep
+            # stage atomic by returning the rows here if publishing cannot finish.
+            self.allocator.free(rows)
+            raise
+
+    def free_unstaged_content(self, rows: torch.Tensor) -> None:
+        self.allocator.free_lease(rows)
+
+    def release_match_pin(self, rid: str) -> bool:
+        plan = self._match_plans.pop(rid, None)
+        if plan is None:
+            return False
+        root = self.tree_core.root_node
+        node = self.tree_core.node_by_id(plan.node_id)
+        while node is not root:
+            cd = node.component_data[self.component_type]
+            if cd.value is not None and cd.lock_ref > 0:
+                cd.lock_ref -= 1
+                if cd.lock_ref == 0:
+                    size = len(cd.value)
+                    self.tree_core.component_protected_size_[
+                        self.component_type
+                    ] -= size
+                    self.tree_core.component_evictable_size_[
+                        self.component_type
+                    ] += size
+                self.tree_core._update_evictable_leaf_sets(node)
+            if cd.metadata.get(self._MATCH_UUID_KEY) == plan.boundary_uuid:
+                return True
+            node = node.parent
+        raise RuntimeError("DFlash match pin boundary disappeared before release")
+
+    def release_request_state(self, rid: str) -> None:
+        try:
+            self.release_match_pin(rid)
+        finally:
+            # Abort/teardown must not leak pending content even if a corrupted
+            # pin boundary makes release_match_pin raise.
+            pending = self._pending_publishes.pop(rid, None)
+            if pending is not None:
+                self.allocator.free(pending.rows)
+
+    def discard_pending_publish(self, rid: str) -> bool:
+        pending = self._pending_publishes.pop(rid, None)
+        if pending is None:
+            return False
+        self.allocator.free(pending.rows)
+        return True
+
+    @staticmethod
+    def _incoming_span(
+        params: InsertParams, span_start: int, span_len: int
+    ) -> tuple[int, int, int, torch.Tensor] | None:
+        if params.draft_value is None:
+            return None
+        publish_start = int(params.draft_start_seqlen)
+        publish_end = publish_start + len(params.draft_value)
+        start = max(span_start, publish_start)
+        end = min(span_start + span_len, publish_end)
+        if start >= end:
+            return None
+        value_start = start - publish_start
+        return (
+            start - span_start,
+            end - start,
+            value_start,
+            params.draft_value[value_start : value_start + end - start],
+        )
+
+    @staticmethod
+    def _mark_processed(params: InsertParams, start: int, count: int) -> None:
+        if params.draft_processed is None:
+            raise RuntimeError("DFlash draft insert requires a processed bitmap")
+        if len(params.draft_processed) != len(params.draft_value):
+            raise RuntimeError("DFlash draft processed bitmap length mismatch")
+        processed = params.draft_processed[start : start + count]
+        if bool(torch.any(processed)):
+            raise RuntimeError("DFlash draft rows were processed more than once")
+        processed[:] = True
+
+    def _attach_span(
+        self,
+        node: UnifiedTreeNode,
+        span_start: int,
+        params: InsertParams,
+        cache_actions: list[CacheAction | ComponentAction],
+    ) -> None:
+        incoming = self._incoming_span(params, span_start, len(node.key))
+        if incoming is None:
+            return
+        start_offset, count, value_start, rows = incoming
+        if start_offset:
+            _, action = self.tree_core._split_node(node.key, node, start_offset)
+            if action is not None:
+                cache_actions.append(action)
+            span_start += start_offset
+        target = node
+        if count < len(node.key):
+            target, action = self.tree_core._split_node(node.key, node, count)
+            if action is not None:
+                cache_actions.append(action)
+
+        cd = target.component_data[self.component_type]
+        if cd.value is None:
+            cd.value = rows.clone()
+            self.tree_core.component_evictable_size_[self.component_type] += len(rows)
+            self._published_tokens += len(rows)
+            logger.debug(
+                "DFLASH_RADIX published node_id=%s span_start=%d tokens=%d "
+                "published_total=%d",
+                target.id,
+                span_start,
+                len(rows),
+                self._published_tokens,
+            )
+            lru = self.tree_core.lru_lists[self.component_type]
+            if not lru.in_list(target):
+                lru.insert_mru(target)
+        else:
+            cache_actions.append(
+                FreeComponentDeviceSlot(
+                    indices=[rows], component_type=self.component_type
+                )
+            )
+        self._mark_processed(params, value_start, count)
+
+    def update_component_on_insert_overlap(
+        self,
+        node: UnifiedTreeNode,
+        prefix_len: int,
+        total_prefix_len: int,
+        value_slice: torch.Tensor,
+        params: InsertParams,
+        cache_actions: list[CacheAction | ComponentAction],
+    ) -> int:
+        self._attach_span(node, total_prefix_len, params, cache_actions)
+        return prefix_len
+
+    def commit_insert_component_data(
+        self,
+        node: UnifiedTreeNode,
+        is_new_leaf: bool,
+        params: InsertParams,
+        result: InsertResult,
+        cache_actions: list[CacheAction | ComponentAction],
+    ) -> None:
+        if is_new_leaf:
+            self._attach_span(node, result.prefix_len, params, cache_actions)
+
+    def cleanup_pending_rows(self, params: InsertParams) -> None:
+        if params.draft_value is None:
+            return
+        if params.draft_processed is None:
+            self.allocator.free(params.draft_value)
+            params.draft_value = None
+            return
+        pending = params.draft_value[~params.draft_processed.to(torch.bool)]
+        self.allocator.free(pending)
+        params.draft_processed[:] = True
+
+    def cleanup_after_caching_req(
+        self,
+        req: Req,
+        is_finished: bool,
+        insert_result: Optional[InsertResult] = None,
+        insert_params: Optional[InsertParams] = None,
+    ) -> None:
+        if is_finished:
+            # is_insert=False (skip-radix, abort, or teardown) bypasses prepare,
+            # so a staged publish can still be owned by the request here.
+            self.release_request_state(req.rid)
+        if insert_params is not None:
+            self.cleanup_pending_rows(insert_params)
+
+    def prepare_for_caching_req(
+        self,
+        req: Req,
+        insert_params: InsertParams,
+        token_ids_len: int,
+        is_finished: bool,
+    ) -> Optional[int]:
+        pending = self._pending_publishes.pop(req.rid, None)
+        if pending is None:
+            return None
+        end_seqlen = pending.start_seqlen + len(pending.rows)
+        if end_seqlen > token_ids_len:
+            self.allocator.free(pending.rows)
+            raise RuntimeError(
+                "DFlash pending content exceeds the cacheable request prefix: "
+                f"rid={req.rid!r}, end={end_seqlen}, token_ids_len={token_ids_len}"
+            )
+        insert_params.draft_start_seqlen = pending.start_seqlen
+        insert_params.draft_value = pending.rows
+        insert_params.draft_processed = torch.zeros(
+            len(pending.rows), dtype=torch.bool, device="cpu"
+        )
+        return None
+
+    def redistribute_on_node_split(
+        self, new_parent: UnifiedTreeNode, child: UnifiedTreeNode
+    ) -> None:
+        ct = self.component_type
+        parent_cd = new_parent.component_data[ct]
+        child_cd = child.component_data[ct]
+        parent_cd.lock_ref = child_cd.lock_ref
+        parent_cd.session_ref = child_cd.session_ref
+        value = child_cd.value
+        if value is not None:
+            split_len = len(new_parent.key)
+            parent_cd.value = value[:split_len].clone()
+            child_cd.value = value[split_len:].clone()
+        uuid = child_cd.metadata.pop(self._MATCH_UUID_KEY, None)
+        if uuid is not None:
+            parent_cd.metadata[self._MATCH_UUID_KEY] = uuid
+
+    def evict_component(
+        self,
+        node: UnifiedTreeNode,
+        device_frees: dict[ComponentType, list[torch.Tensor]],
+        host_frees: dict[ComponentType, list[torch.Tensor]],
+        target: EvictLayer = EvictLayer.DEVICE,
+    ) -> tuple[int, int]:
+        cd = node.component_data[self.component_type]
+        if EvictLayer.HOST in target and cd.host_value is not None:
+            raise AssertionError("DFlash draft sidecar must remain device-only")
+        if EvictLayer.DEVICE not in target or cd.value is None:
+            return 0, 0
+        if cd.lock_ref:
+            raise RuntimeError("attempted to evict pinned DFlash draft content")
+        value = cd.value
+        cd.value = None
+        device_frees[self.component_type].append(value)
+        self.tree_core.component_evictable_size_[self.component_type] -= len(value)
+        self._evicted_tokens += len(value)
+        logger.debug(
+            "DFLASH_RADIX evicted node_id=%s tokens=%d evicted_total=%d",
+            node.id,
+            len(value),
+            self._evicted_tokens,
+        )
+        return len(value), 0
+
+    def eviction_priority(self, is_leaf: bool) -> int:
+        return 0
+
+    def _evict_device_start(self, request_cnt: int) -> None:
+        self._evict_device_request_cnt = int(request_cnt)
+        self._evict_device_cursor = self.tree_core.lru_lists[
+            self.component_type
+        ].get_lru_no_lock()
+
+    def _evict_device_next_node(
+        self,
+        tracker: dict[ComponentType, int],
+        device_frees: dict[ComponentType, list[torch.Tensor]],
+        host_frees: dict[ComponentType, list[torch.Tensor]],
+    ) -> Optional[NodeId]:
+        ct = self.component_type
+        lru = self.tree_core.lru_lists[ct]
+        node = self._evict_device_cursor
+        if tracker[ct] >= self._evict_device_request_cnt or node is None:
+            return None
+        previous = lru.get_prev_no_lock(node)
+        self.tree_core._evict_component_and_detach_lru(
+            node,
+            self,
+            target=EvictLayer.DEVICE,
+            tracker=tracker,
+            device_frees=device_frees,
+            host_frees=host_frees,
+        )
+        self.tree_core._update_evictable_leaf_sets(node)
+        self._evict_device_cursor = previous
+        # DRAFT eviction never returns a leaf for whole-node deletion.
+        return None
+
+    def _evict_device_end(self) -> None:
+        self._evict_device_cursor = None
+
+    def acquire_component_lock(
+        self,
+        node: UnifiedTreeNode,
+        result: IncLockRefResult,
+        lock_host: bool = False,
+    ) -> IncLockRefResult:
+        # Match finalization owns a short-lived, DRAFT-only restore pin.
+        return result
+
+    def release_component_lock(
+        self,
+        node: UnifiedTreeNode,
+        params: Optional[DecLockRefParams],
+        lock_host: bool = False,
+    ) -> None:
+        return None
+
+    def free_host_values(self, host_values: list[torch.Tensor]) -> None:
+        if host_values:
+            raise AssertionError("DFlash draft sidecar has no host pool")
+
+    def apply_component_action(self, action: ComponentAction) -> None:
+        if isinstance(action, FreeComponentDeviceSlot):
+            for indices in action.indices:
+                self.allocator.free(indices)
+            return
+        raise AssertionError(
+            f"DFlashDraftComponent: unhandled action {type(action).__name__}"
+        )

--- a/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
+++ b/python/sglang/srt/mem_cache/unified_cache/components/tree_component.py
@@ -125,6 +125,10 @@ class TreeComponent(ABC):
     def reset_session_state(self) -> None:
         self._session_leaves = defaultdict(set)
 
+    def reset_component_state(self) -> None:
+        """Reset component-owned state before the tree arena is rebuilt."""
+        return None
+
     def session_ref(self, node: UnifiedTreeNode) -> int:
         return node.component_data[self.component_type].session_ref
 

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -654,7 +654,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             best_match_device_value_len,
             full_kv_hit_length,
             action,
-        ) = self._match_prefix_helper(key)
+        ) = self._match_prefix_helper(
+            key, require_dflash_draft=params.require_dflash_draft
+        )
         return self._match_post_processor(
             params,
             value,
@@ -665,7 +667,9 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
             action,
         )
 
-    def _match_prefix_helper(self, key: RadixKey) -> tuple[
+    def _match_prefix_helper(
+        self, key: RadixKey, *, require_dflash_draft: bool = True
+    ) -> tuple[
         list[torch.Tensor],
         UnifiedTreeNode,
         UnifiedTreeNode,
@@ -686,18 +690,25 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         full_kv_hit_length = 0
         action: Optional[CacheAction | ComponentAction] = None
         separate_device_match = self.enable_hicache
-        if separate_device_match:
-            validators = tuple(
-                comp.create_match_validator() for comp in self.components
+        components = (
+            self.components
+            if require_dflash_draft
+            else tuple(
+                comp
+                for comp in self.components
+                if comp.component_type != ComponentType.DRAFT
             )
+        )
+        if separate_device_match:
+            validators = tuple(comp.create_match_validator() for comp in components)
             device_validators = tuple(
                 comp.create_match_validator(match_device_only=True)
-                for comp in self.components
+                for comp in components
             )
         else:
             validators = tuple(
                 comp.create_match_validator(match_device_only=True)
-                for comp in self.components
+                for comp in components
             )
 
         def _all_valid(validators, node):

--- a/python/sglang/srt/mem_cache/unified_radix_cache.py
+++ b/python/sglang/srt/mem_cache/unified_radix_cache.py
@@ -67,6 +67,9 @@ from sglang.srt.mem_cache.unified_cache.components import (
     SWAComponent,
     TreeComponent,
 )
+from sglang.srt.mem_cache.unified_cache.components.dflash_draft_component import (
+    DFlashDraftComponent,
+)
 from sglang.srt.mem_cache.unified_cache.session_ref_tracker import (
     UnifiedSessionRefTracker,
 )
@@ -112,6 +115,7 @@ _COMPONENT_POOL_LABEL = {
 COMPONENT_REGISTRY: dict[ComponentType, type[TreeComponent]] = {
     ComponentType.FULL: FullComponent,
     ComponentType.MAMBA: MambaComponent,
+    ComponentType.DRAFT: DFlashDraftComponent,
     ComponentType.SWA: SWAComponent,
 }
 
@@ -341,6 +345,8 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def _reset_full(self) -> None:
         """Full reset: destroy entire tree and all state."""
+        for component in self._components_tuple:
+            component.reset_component_state()
         self.tree_core.reset()
         self.session_refs.reset()
 
@@ -367,6 +373,11 @@ class UnifiedRadixCache(BasePrefixCache):
 
     def init_hicache(self, server_args: ServerArgs, params: CacheInitParams) -> None:
         """Initialize HiCache infrastructure."""
+        if ComponentType.DRAFT in self.tree_components:
+            raise ValueError(
+                "Qwen DFlash radix sidecar is device-only and cannot be combined "
+                "with HiCache"
+            )
         self.host_memory_mode = get_memory().hicache_host_memory_mode
         if self.host_memory_mode == "buffer_only":
             # FULL and FULL+SWA only: Mamba has no state-handoff channel on
@@ -508,8 +519,15 @@ class UnifiedRadixCache(BasePrefixCache):
         # Apply the walk's actions (e.g. a pending write-through relocation on
         # a split) before the finalizers, which can evict or raise.
         self._apply_cache_actions(result.cache_actions)
-        for component in self._components_tuple:
-            result = component.finalize_match_result_in_cache(params, result)
+        try:
+            for component in self._components_tuple:
+                result = component.finalize_match_result_in_cache(params, result)
+        except Exception:
+            req = params.req
+            rid = getattr(req, "rid", None) if req is not None else None
+            if rid is not None:
+                self.release_dflash_draft_match_pin(rid)
+            raise
         # Finalizers must not emit actions; the walk's were applied above.
         assert not result.cache_actions
         return result
@@ -565,6 +583,7 @@ class UnifiedRadixCache(BasePrefixCache):
             ComponentType.SWA: params.swa_num_tokens,
             ComponentType.MAMBA: params.mamba_num,
             ComponentType.C128: 0,
+            ComponentType.DRAFT: params.draft_num_tokens,
         }
 
     def _component_available_size(self, component_type: ComponentType) -> int:
@@ -581,6 +600,8 @@ class UnifiedRadixCache(BasePrefixCache):
             return self.token_to_kv_pool_allocator.swa_available_size()
         if component_type == ComponentType.MAMBA:
             return self.req_to_token_pool.mamba_allocator.schedulable_available_size()
+        if component_type == ComponentType.DRAFT:
+            return self.components[ComponentType.DRAFT].allocator.available_size()
         raise ValueError(f"Unsupported cache component: {component_type}")
 
     def _evict(
@@ -612,7 +633,51 @@ class UnifiedRadixCache(BasePrefixCache):
             num_tokens_evicted=tracker[BASE_COMPONENT_TYPE],
             swa_num_tokens_evicted=tracker.get(ComponentType.SWA, 0),
             mamba_num_evicted=tracker.get(ComponentType.MAMBA, 0),
+            draft_num_tokens_evicted=tracker.get(ComponentType.DRAFT, 0),
         )
+
+    def get_dflash_draft_match_plan(self, rid: str):
+        component = self.components.get(ComponentType.DRAFT)
+        return None if component is None else component.get_match_plan(rid)
+
+    def release_dflash_draft_match_pin(self, rid: str) -> bool:
+        component = self.components.get(ComponentType.DRAFT)
+        return False if component is None else component.release_match_pin(rid)
+
+    def alloc_dflash_draft_content(self, num_tokens: int):
+        component = self.components.get(ComponentType.DRAFT)
+        if (
+            component is None
+            or num_tokens <= 0
+            or num_tokens > component.allocator.size
+        ):
+            return None
+        rows = component.allocator.alloc(num_tokens)
+        if rows is not None:
+            return rows
+        shortfall = num_tokens - component.allocator.available_size()
+        self.evict_for_alloc(EvictParams(draft_num_tokens=shortfall))
+        return component.allocator.alloc(num_tokens)
+
+    def stage_dflash_draft_publish(
+        self, rid: str, start_seqlen: int, rows: torch.Tensor
+    ) -> None:
+        component = self.components.get(ComponentType.DRAFT)
+        if component is None:
+            raise RuntimeError(
+                "DFlash draft content was staged without DRAFT component"
+            )
+        component.stage_pending_publish(rid, start_seqlen, rows)
+
+    def discard_dflash_draft_publish(self, rid: str) -> bool:
+        component = self.components.get(ComponentType.DRAFT)
+        return False if component is None else component.discard_pending_publish(rid)
+
+    def free_unstaged_dflash_draft_content(self, rows: torch.Tensor) -> None:
+        component = self.components.get(ComponentType.DRAFT)
+        if component is None:
+            raise RuntimeError("DFlash draft content has no owning component")
+        component.free_unstaged_content(rows)
 
     def _free_values(
         self,
@@ -840,39 +905,49 @@ class UnifiedRadixCache(BasePrefixCache):
                 priority=getattr(req, "priority", 0) or 0,
             )
 
-            # components prepare insert data + return effective cache_len
-            effective_cache_len = len(token_ids)
-            for comp in self._components_tuple:
-                cl = comp.prepare_for_caching_req(
-                    req=req,
-                    insert_params=insert_params,
-                    token_ids_len=len(token_ids),
-                    is_finished=True,
-                )
-                if cl is not None:
-                    effective_cache_len = min(effective_cache_len, cl)
+            try:
+                # components prepare insert data + return effective cache_len
+                effective_cache_len = len(token_ids)
+                for comp in self._components_tuple:
+                    cl = comp.prepare_for_caching_req(
+                        req=req,
+                        insert_params=insert_params,
+                        token_ids_len=len(token_ids),
+                        is_finished=True,
+                    )
+                    if cl is not None:
+                        effective_cache_len = min(effective_cache_len, cl)
 
-            # Truncate if needed; the tail free is deferred and batched with
-            # the unaligned tail below so a shared boundary page is emitted once.
-            kv_indices_full = kv_indices
-            tail_free_start = None
-            if effective_cache_len < len(token_ids):
-                tail_free_start = max(effective_cache_len, req.cache_protected_len)
-                token_ids = token_ids[:effective_cache_len]
-                kv_indices = kv_indices[:effective_cache_len]
+                # Truncate if needed; the tail free is deferred and batched with
+                # the unaligned tail below so a shared boundary page is emitted once.
+                kv_indices_full = kv_indices
+                tail_free_start = None
+                if effective_cache_len < len(token_ids):
+                    tail_free_start = max(effective_cache_len, req.cache_protected_len)
+                    token_ids = token_ids[:effective_cache_len]
+                    kv_indices = kv_indices[:effective_cache_len]
 
-            radix_key = RadixKey(
-                token_ids,
-                req.extra_key,
-                is_bigram=self.tree_core.is_eagle,
-                cache_salt=req.cache_salt,
-            ).page_aligned(self.page_size)
-            page_aligned_len = len(radix_key)
-            values = kv_indices[:page_aligned_len].to(dtype=torch.int64, copy=True)
+                radix_key = RadixKey(
+                    token_ids,
+                    req.extra_key,
+                    is_bigram=self.tree_core.is_eagle,
+                    cache_salt=req.cache_salt,
+                ).page_aligned(self.page_size)
+                page_aligned_len = len(radix_key)
+                values = kv_indices[:page_aligned_len].to(dtype=torch.int64, copy=True)
 
-            insert_params.key = radix_key
-            insert_params.value = values
-            result = self.insert(insert_params)
+                insert_params.key = radix_key
+                insert_params.value = values
+                result = self.insert(insert_params)
+            except Exception:
+                for comp in self._components_tuple:
+                    comp.cleanup_after_caching_req(
+                        req,
+                        is_finished=True,
+                        insert_result=result,
+                        insert_params=insert_params,
+                    )
+                raise
 
             # Free unaligned tail (+ deferred truncation tail)
             segments = [(kv_indices[page_aligned_len:], page_aligned_len)]
@@ -927,54 +1002,74 @@ class UnifiedRadixCache(BasePrefixCache):
             chunked=chunked,
             priority=getattr(req, "priority", 0) or 0,
         )
-        effective_cache_len = len(token_ids)
-        for comp in self._components_tuple:
-            cl = comp.prepare_for_caching_req(
-                req=req,
-                insert_params=insert_params,
-                token_ids_len=len(token_ids),
-                is_finished=False,
-            )
-            if cl is not None:
-                effective_cache_len = min(effective_cache_len, cl)
-
-        radix_key = RadixKey(
-            token_ids[:effective_cache_len],
-            req.extra_key,
-            is_bigram=self.tree_core.is_eagle,
-            cache_salt=req.cache_salt,
-        )
-
-        if envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS.get():
-            # The frontier lands a page below page_floor(pre_len + 1), which has to
-            # be where the insert stops, or the leaf it creates keeps less than a
-            # sliding window of live SWA and the match after the insert rejects it.
-            # The insert stops at page_floor(len(radix_key)), and a bigram key is
-            # one shorter than the tokens it spans, so measure the key.
+        result = None
+        try:
+            effective_cache_len = len(token_ids)
             for comp in self._components_tuple:
-                comp.free_out_of_window_slots(req, len(radix_key) - 1, insert_params)
+                cl = comp.prepare_for_caching_req(
+                    req=req,
+                    insert_params=insert_params,
+                    token_ids_len=len(token_ids),
+                    is_finished=False,
+                )
+                if cl is not None:
+                    effective_cache_len = min(effective_cache_len, cl)
 
-        if effective_cache_len <= 0:
-            req.prefix_indices = kv_indices_orig.to(dtype=torch.int64, copy=True)
+            radix_key = RadixKey(
+                token_ids[:effective_cache_len],
+                req.extra_key,
+                is_bigram=self.tree_core.is_eagle,
+                cache_salt=req.cache_salt,
+            )
+
+            if envs.SGLANG_OPT_UNIFIED_CACHE_FREE_OUT_OF_WINDOW_SLOTS.get():
+                # The frontier lands a page below page_floor(pre_len + 1), which has to
+                # be where the insert stops, or the leaf it creates keeps less than a
+                # sliding window of live SWA and the match after the insert rejects it.
+                # The insert stops at page_floor(len(radix_key)), and a bigram key is
+                # one shorter than the tokens it spans, so measure the key.
+                for comp in self._components_tuple:
+                    comp.free_out_of_window_slots(
+                        req, len(radix_key) - 1, insert_params
+                    )
+
+            if effective_cache_len <= 0:
+                req.prefix_indices = kv_indices_orig.to(dtype=torch.int64, copy=True)
+                for comp in self._components_tuple:
+                    comp.cleanup_after_caching_req(
+                        req, is_finished=False, insert_params=insert_params
+                    )
+                return
+
+            kv_indices = kv_indices_orig[:effective_cache_len]
+
+            radix_key = radix_key.page_aligned(self.page_size)
+            page_aligned_len = len(radix_key)
+            values = kv_indices[:page_aligned_len].to(dtype=torch.int64, copy=True)
+
+            insert_params.key = radix_key
+            insert_params.value = values
+            result = self.insert(insert_params)
+        except Exception:
             for comp in self._components_tuple:
                 comp.cleanup_after_caching_req(
-                    req, is_finished=False, insert_params=insert_params
+                    req,
+                    is_finished=False,
+                    insert_result=result,
+                    insert_params=insert_params,
                 )
-            return
-
-        kv_indices = kv_indices_orig[:effective_cache_len]
-
-        radix_key = radix_key.page_aligned(self.page_size)
-        page_aligned_len = len(radix_key)
-        values = kv_indices[:page_aligned_len].to(dtype=torch.int64, copy=True)
-
-        insert_params.key = radix_key
-        insert_params.value = values
-        result = self.insert(insert_params)
+            raise
 
         # Match prefix. SWA insertion retains one extra window before the
         # page-aligned boundary, so the normal match remains safe to repoint.
-        match_result = self.match_prefix(MatchPrefixParams(key=radix_key, req=req))
+        match_result = self.match_prefix(
+            MatchPrefixParams(
+                key=radix_key,
+                req=req,
+                pin_dflash_restore=False,
+                require_dflash_draft=False,
+            )
+        )
         new_indices = match_result.device_indices
         new_last_node = match_result.last_device_node
         new_prefix_len = result.prefix_len
@@ -2070,6 +2165,9 @@ class UnifiedRadixCache(BasePrefixCache):
 
     @rank_consensus(same_params=True)
     def release_aborted_request(self, rid: str) -> None:
+        draft_component = self.components.get(ComponentType.DRAFT)
+        if draft_component is not None:
+            draft_component.release_request_state(rid)
         self.prefetch_loaded_tokens_by_reqid.pop(rid, None)
         self._storage_prefetch_missed_rids.discard(rid)
         if (

--- a/python/sglang/srt/model_executor/model_runner.py
+++ b/python/sglang/srt/model_executor/model_runner.py
@@ -565,6 +565,7 @@ class ModelRunner:
                 model_config=self.model_config,
                 spec_algorithm=self.spec_algorithm,
                 is_draft_worker=self.is_draft_worker,
+                attn_dp_size=self.ps.attn_dp_size,
             )
         )
 

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -7,8 +7,10 @@ import msgspec
 
 from sglang.srt.configs.model_config import ModelConfig
 from sglang.srt.runtime_context import (
+    get_disagg,
     get_model,
     get_parallel,
+    get_schedule,
     get_spec,
 )
 
@@ -44,6 +46,8 @@ class SpecAuxHiddenStateConfig(msgspec.Struct, kw_only=True):
     dflash_target_layer_ids: Any = None
     # DFLASH draft KV bytes/token; None when unresolved.
     dflash_draft_cell_size_per_token: int | None = None
+    # Fixed per-rank draft KV allocation, including the pool sentinel page.
+    dflash_draft_fixed_bytes: int = 0
 
 
 def resolve_spec_aux_hidden_state_config(
@@ -52,6 +56,7 @@ def resolve_spec_aux_hidden_state_config(
     model_config: ModelConfig,
     spec_algorithm: SpeculativeAlgorithm,
     is_draft_worker: bool,
+    attn_dp_size: int,
 ) -> SpecAuxHiddenStateConfig:
     config = SpecAuxHiddenStateConfig()
     _resolve_eagle_aux_hidden_state(
@@ -66,6 +71,7 @@ def resolve_spec_aux_hidden_state_config(
         model_config=model_config,
         spec_algorithm=spec_algorithm,
         is_draft_worker=is_draft_worker,
+        attn_dp_size=attn_dp_size,
     )
     return config
 
@@ -132,8 +138,14 @@ def _resolve_dflash_aux_hidden_state(
     model_config: ModelConfig,
     spec_algorithm: SpeculativeAlgorithm,
     is_draft_worker: bool,
+    attn_dp_size: int,
 ) -> None:
     if spec_algorithm.is_dflash_family() and not is_draft_worker:
+        if _compact_dflash_enabled() and not spec_algorithm.is_dflash():
+            raise RuntimeError(
+                "Compact DFlash cache supports the DFLASH algorithm only, "
+                f"got speculative_algorithm={spec_algorithm}"
+            )
         from sglang.srt.speculative.dflash_utils import parse_dflash_draft_config
 
         # Select target layers to capture for building draft context features.
@@ -202,10 +214,101 @@ def _resolve_dflash_aux_hidden_state(
         config.dflash_use_aux_hidden_state = True
         config.dflash_draft_num_layers = int(draft_num_layers)
         config.dflash_target_layer_ids = target_layer_ids
-        config.dflash_draft_cell_size_per_token = _resolve_dflash_draft_cell_size(
+        legacy_draft_cell_size = _resolve_dflash_draft_cell_size(
             draft_model_config=draft_model_config,
             draft_num_layers=int(draft_num_layers),
         )
+        config.dflash_draft_cell_size_per_token = legacy_draft_cell_size
+        if _compact_dflash_enabled():
+            config.dflash_draft_cell_size_per_token = _compact_dflash_linear_budget(
+                legacy_draft_cell_size
+            )
+            config.dflash_draft_fixed_bytes = _compact_dflash_fixed_bytes(
+                legacy_draft_cell_size,
+                owner_count=_compact_dflash_owner_count(attn_dp_size=attn_dp_size),
+                window_size=get_spec().speculative_draft_window_size,
+                block_size=get_spec().speculative_num_draft_tokens,
+                page_size=get_schedule().page_size,
+            )
+
+
+def _compact_dflash_owner_count(*, attn_dp_size: int) -> int:
+    """Return request-owner rows for this precomputed attention-DP shard."""
+    requested = get_schedule().max_running_requests
+    if requested is None:
+        raise RuntimeError(
+            "Compact DFlash physical mode requires an explicit resolved "
+            "max_running_requests"
+        )
+    requested = int(requested)
+    attn_dp_size = int(attn_dp_size)
+    if requested <= 0 or attn_dp_size <= 0 or requested % attn_dp_size:
+        raise RuntimeError(
+            "Compact DFlash owner budget requires max_running_requests to be "
+            "evenly sharded by attention DP: "
+            f"max_running_requests={requested}, attn_dp_size={attn_dp_size}"
+        )
+    owner_count = requested // attn_dp_size
+    if get_disagg().disaggregation_mode == "decode":
+        extra_slots = int(get_disagg().disaggregation_decode_extra_slots or 0)
+        if extra_slots < 0:
+            raise RuntimeError(
+                "Compact DFlash owner budget requires non-negative decode "
+                f"extra slots, got disaggregation_decode_extra_slots={extra_slots}"
+            )
+        owner_count += extra_slots
+    return owner_count
+
+
+def _compact_dflash_linear_budget(legacy_bytes_per_token: int | None) -> int | None:
+    """Replace the legacy capacity-linear term only in compact mode."""
+    return 0 if _compact_dflash_enabled() else legacy_bytes_per_token
+
+
+def _compact_dflash_enabled() -> bool:
+    return bool(getattr(get_spec(), "speculative_dflash_compact_cache", False))
+
+
+def _compact_dflash_fixed_bytes(
+    legacy_bytes_per_token: int | None,
+    *,
+    owner_count: int | None,
+    window_size: int | None,
+    block_size: int | None,
+    page_size: int,
+) -> int:
+    """Exact per-rank bytes allocated by the compact draft pool."""
+    if not _compact_dflash_enabled():
+        return 0
+    values = {
+        "legacy_bytes_per_token": legacy_bytes_per_token,
+        "owner_count": owner_count,
+        "window_size": window_size,
+        "block_size": block_size,
+        "page_size": page_size,
+    }
+    if any(value is None or int(value) <= 0 for value in values.values()):
+        raise RuntimeError(
+            "Compact DFlash fixed-pool budget requires resolved positive geometry: "
+            f"{values}"
+        )
+    if int(page_size) != 1:
+        raise RuntimeError(
+            "Compact DFlash physical mode requires page_size=1; larger pages "
+            "can make one attention window address aliased modulo-ring rows"
+        )
+    from sglang.srt.speculative.dflash_compact_physical_layout import (
+        CompactDFlashPhysicalLayout,
+    )
+
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=int(owner_count),
+        window_size=int(window_size),
+        block_size=int(block_size),
+        page_size=int(page_size),
+    )
+    # TokenToKVPool allocates one sentinel page in addition to usable rows.
+    return (layout.physical_tokens + int(page_size)) * int(legacy_bytes_per_token)
 
 
 def _resolve_dflash_draft_cell_size(

--- a/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
+++ b/python/sglang/srt/model_executor/model_runner_components/spec_aux_hidden_state.py
@@ -48,6 +48,10 @@ class SpecAuxHiddenStateConfig(msgspec.Struct, kw_only=True):
     dflash_draft_cell_size_per_token: int | None = None
     # Fixed per-rank draft KV allocation, including the pool sentinel page.
     dflash_draft_fixed_bytes: int = 0
+    # Frozen request-owner geometry used to solve the compact fixed allocation.
+    dflash_compact_owner_count: int | None = None
+    # Internal, page-aligned DFlash radix content cap. Public API is not frozen.
+    dflash_radix_sidecar_tokens: int = 0
 
 
 def resolve_spec_aux_hidden_state_config(
@@ -220,15 +224,36 @@ def _resolve_dflash_aux_hidden_state(
         )
         config.dflash_draft_cell_size_per_token = legacy_draft_cell_size
         if _compact_dflash_enabled():
+            sidecar_tokens = int(
+                getattr(get_spec(), "speculative_dflash_radix_sidecar_tokens", 0) or 0
+            )
+            if sidecar_tokens < 0:
+                raise RuntimeError(
+                    "Compact DFlash radix sidecar tokens must be nonnegative, "
+                    f"got {sidecar_tokens}"
+                )
+            # PR2 is Prefill-device-radix only. A P/D decode role keeps PR1's
+            # request ring and receives no content subrange.
+            if get_disagg().disaggregation_mode == "decode":
+                sidecar_tokens = 0
+            page_size = int(get_schedule().page_size)
+            if sidecar_tokens:
+                sidecar_tokens = (
+                    (sidecar_tokens + page_size - 1) // page_size
+                ) * page_size
+            compact_owner_count = _compact_dflash_owner_count(attn_dp_size=attn_dp_size)
+            config.dflash_compact_owner_count = compact_owner_count
+            config.dflash_radix_sidecar_tokens = sidecar_tokens
             config.dflash_draft_cell_size_per_token = _compact_dflash_linear_budget(
                 legacy_draft_cell_size
             )
             config.dflash_draft_fixed_bytes = _compact_dflash_fixed_bytes(
                 legacy_draft_cell_size,
-                owner_count=_compact_dflash_owner_count(attn_dp_size=attn_dp_size),
+                owner_count=compact_owner_count,
                 window_size=get_spec().speculative_draft_window_size,
                 block_size=get_spec().speculative_num_draft_tokens,
-                page_size=get_schedule().page_size,
+                page_size=page_size,
+                content_tokens=sidecar_tokens,
             )
 
 
@@ -276,6 +301,7 @@ def _compact_dflash_fixed_bytes(
     window_size: int | None,
     block_size: int | None,
     page_size: int,
+    content_tokens: int = 0,
 ) -> int:
     """Exact per-rank bytes allocated by the compact draft pool."""
     if not _compact_dflash_enabled():
@@ -306,6 +332,7 @@ def _compact_dflash_fixed_bytes(
         window_size=int(window_size),
         block_size=int(block_size),
         page_size=int(page_size),
+        content_tokens=int(content_tokens),
     )
     # TokenToKVPool allocates one sentinel page in addition to usable rows.
     return (layout.physical_tokens + int(page_size)) * int(legacy_bytes_per_token)

--- a/python/sglang/srt/model_executor/pool_configurator.py
+++ b/python/sglang/srt/model_executor/pool_configurator.py
@@ -101,6 +101,31 @@ def _dflash_draft_cell_size(kvc: KVCacheConfigurator) -> int:
     return int(cell_size) * get_parallel().attn_dcp_size
 
 
+def _dflash_draft_fixed_bytes(kvc: KVCacheConfigurator) -> int:
+    """Fixed per-rank DFlash allocation removed before target KV solving."""
+    if kvc.is_draft_worker or not kvc.spec_algorithm.is_dflash_family():
+        return 0
+    fixed_bytes = getattr(kvc.spec_aux_config, "dflash_draft_fixed_bytes", 0)
+    if fixed_bytes is None:
+        return 0
+    fixed_bytes = int(fixed_bytes)
+    if fixed_bytes < 0:
+        raise ValueError(f"DFlash fixed-pool bytes must be nonnegative: {fixed_bytes}")
+    return fixed_bytes
+
+
+def _subtract_fixed_pool_bytes(available_bytes: int, fixed_bytes: int) -> int:
+    if fixed_bytes == 0:
+        return available_bytes
+    remaining = int(available_bytes) - int(fixed_bytes)
+    if remaining <= 0:
+        raise RuntimeError(
+            "DFlash fixed draft pool leaves no memory for target KV: "
+            f"available_bytes={available_bytes}, fixed_draft_bytes={fixed_bytes}"
+        )
+    return remaining
+
+
 def _get_dsv4_compress_state_dtype_sizes() -> tuple[int, int]:
     dtype_name = envs.SGLANG_DSV4_COMPRESS_STATE_DTYPE.get().strip().lower()
     if dtype_name in ("float32", "fp32"):
@@ -148,6 +173,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
 
     def __init__(self, kvc: KVCacheConfigurator):
         self.kv_cache_dtype_str = kvc.kv_cache_dtype_str
+        self._fixed_bytes = _dflash_draft_fixed_bytes(kvc)
         # Determine effective number of layers for KV cache
         if mambaish := mambaish_config(kvc.model_config):
             effective_layer_ids = [
@@ -229,13 +255,17 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
                 and int(draft_num_layers) > 0
                 and int(num_layers) > 0
             ):
-                self._cell_size = scale_kv_cell_size_per_token_for_dflash(
-                    target_cell_size_per_token=self._cell_size,
-                    target_num_layers=int(num_layers),
-                    draft_num_layers=int(draft_num_layers)
-                    * get_parallel().attn_dcp_size,
-                    draft_cell_size_per_token=_dflash_draft_cell_size(kvc) or None,
-                )
+                draft_cell_size = _dflash_draft_cell_size(kvc)
+                # A resolved zero selects the fixed compact pool.  None/unknown
+                # retains the upstream layer-count fallback.
+                if draft_cell_size != 0:
+                    self._cell_size = scale_kv_cell_size_per_token_for_dflash(
+                        target_cell_size_per_token=self._cell_size,
+                        target_num_layers=int(num_layers),
+                        draft_num_layers=int(draft_num_layers)
+                        * get_parallel().attn_dcp_size,
+                        draft_cell_size_per_token=draft_cell_size or None,
+                    )
 
     def _compute_cell_size(self, kvc: KVCacheConfigurator, num_layers: int) -> int:
         """Compute per-token KV cache cost in bytes. Subclasses can override."""
@@ -419,6 +449,7 @@ class DefaultPoolConfigurator(MemoryPoolConfigurator):
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
+        available_bytes = _subtract_fixed_pool_bytes(available_bytes, self._fixed_bytes)
         max_total_num_tokens = (
             available_bytes // self._cell_size
             if self._cell_size
@@ -443,6 +474,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
 
     def __init__(self, kvc: KVCacheConfigurator):
         self.kv_cache_dtype_str = kvc.kv_cache_dtype_str
+        self._fixed_bytes = _dflash_draft_fixed_bytes(kvc)
         model_config = kvc.model_config
         kv_cache_dtype = kvc.kv_cache_dtype
         kv_size = torch._utils._element_size(kv_cache_dtype)
@@ -622,6 +654,7 @@ class HybridSWAPoolConfigurator(MemoryPoolConfigurator):
     def calculate_pool_sizes(
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
+        available_bytes = _subtract_fixed_pool_bytes(available_bytes, self._fixed_bytes)
         max_total_num_tokens = int(available_bytes // self._cell_size)
         return self._solve_pool_sizes(max_total_num_tokens, page_size)
 
@@ -702,6 +735,7 @@ class SWAChunkCapPoolConfigurator(HybridSWAPoolConfigurator):
         self, available_bytes: int, page_size: int
     ) -> MemoryPoolConfig:
         # SWA pool sized tightly from the cap; the rest of the budget goes to full.
+        available_bytes = _subtract_fixed_pool_bytes(available_bytes, self._fixed_bytes)
         swa_tokens = ceil_align(self._swa_cap, page_size)
         fixed_swa_bytes = (
             swa_tokens

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2215,11 +2215,22 @@ class ServerArgs:
     speculative_dflash_compact_cache: A[
         bool,
         "Allocate a bounded physical draft KV cache for DFLASH. Requires "
-        "--speculative-draft-window-size, page size 1, and radix cache disabled. "
+        "--speculative-draft-window-size and page size 1. With the default "
+        "--speculative-dflash-radix-sidecar-tokens=0, radix cache must remain "
+        "disabled; a positive sidecar cap enables Prefill device radix. "
         "The committed visible suffix and verify scratch use disjoint rows, and "
         "the fixed allocation is deducted from target-KV capacity solving.",
         NS("spec"),
     ] = False
+    speculative_dflash_radix_sidecar_tokens: A[
+        int,
+        "Fixed device token cap for the Qwen DFLASH compact Prefill radix "
+        "sidecar. 0 preserves the compact-cache radix fail-closed behavior. "
+        "A positive value requires --speculative-dflash-compact-cache, is "
+        "page-aligned at startup, and is included exactly in the fixed draft "
+        "KV byte budget. Decode P/D workers resolve the cap to 0.",
+        NS("spec"),
+    ] = 0
     speculative_moe_runner_backend: A[
         Optional[str],
         Arg(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2212,6 +2212,14 @@ class ServerArgs:
         "Sliding window size for the draft model. Honored by Llama EAGLE-3 (`LlamaForCausalLMEagle3`) and DFLASH only; other EAGLE-3 backends (e.g. MLA-based drafters) silently ignore it. For Llama EAGLE-3, the drafter only attends to the most recent N keys (verifier hidden states + its own outputs); the verifier is unaffected. For DFLASH, the draft worker keeps a recent target-token window in its local KV cache (paged backends may retain up to one extra page on the left for alignment). Default is full attention/context.",
         NS("spec"),
     ] = None
+    speculative_dflash_compact_cache: A[
+        bool,
+        "Allocate a bounded physical draft KV cache for DFLASH. Requires "
+        "--speculative-draft-window-size, page size 1, and radix cache disabled. "
+        "The committed visible suffix and verify scratch use disjoint rows, and "
+        "the fixed allocation is deducted from target-KV capacity solving.",
+        NS("spec"),
+    ] = False
     speculative_moe_runner_backend: A[
         Optional[str],
         Arg(

--- a/python/sglang/srt/speculative/dflash_compact_physical_layout.py
+++ b/python/sglang/srt/speculative/dflash_compact_physical_layout.py
@@ -1,0 +1,197 @@
+"""Bounded physical layout for a windowed DFlash draft KV cache.
+
+Absolute token positions remain the semantic anchor.  Every live request owns
+three disjoint regions: a guard, a modulo-addressed committed window, and
+stable verify scratch.  Generation checks prevent a recycled request slot from
+silently inheriting an earlier owner's side cache.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import torch
+
+
+def _align_up(value: int, alignment: int) -> int:
+    if value < 0 or alignment <= 0:
+        raise ValueError(
+            f"invalid alignment geometry: value={value}, alignment={alignment}"
+        )
+    return ((value + alignment - 1) // alignment) * alignment
+
+
+@dataclass(frozen=True)
+class CompactDFlashPhysicalLayout:
+    owner_count: int
+    window_size: int
+    scratch_rows: int
+    guard_rows: int
+    page_size: int
+    owner_span: int
+    physical_tokens: int
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        owner_count: int,
+        window_size: int,
+        block_size: int,
+        page_size: int,
+        scratch_blocks: int = 2,
+        guard_blocks: int = 2,
+    ) -> CompactDFlashPhysicalLayout:
+        values = {
+            "owner_count": owner_count,
+            "window_size": window_size,
+            "block_size": block_size,
+            "page_size": page_size,
+            "scratch_blocks": scratch_blocks,
+            "guard_blocks": guard_blocks,
+        }
+        if any(int(value) <= 0 for value in values.values()):
+            raise ValueError(f"compact DFlash layout values must be positive: {values}")
+        if window_size % page_size:
+            raise ValueError(
+                f"window_size must be page aligned: window={window_size}, page={page_size}"
+            )
+        if window_size < block_size:
+            raise ValueError(
+                "window_size must cover one complete DFlash commit block: "
+                f"window={window_size}, block={block_size}"
+            )
+        scratch_rows = _align_up(block_size * scratch_blocks, page_size)
+        guard_rows = _align_up(block_size * guard_blocks, page_size)
+        owner_span = _align_up(guard_rows + window_size + scratch_rows, page_size)
+        return cls(
+            owner_count=int(owner_count),
+            window_size=int(window_size),
+            scratch_rows=scratch_rows,
+            guard_rows=guard_rows,
+            page_size=int(page_size),
+            owner_span=owner_span,
+            physical_tokens=int(owner_count) * owner_span,
+        )
+
+    def _owner_bases(self, req_pool_indices: torch.Tensor) -> torch.Tensor:
+        indices = req_pool_indices.to(torch.int64)
+        if indices.numel() == 0:
+            return indices
+        valid = (indices >= 1) & (indices <= self.owner_count)
+        if indices.is_cuda:
+            torch._assert_async(
+                torch.all(valid),
+                "request slot is outside compact DFlash owner range",
+            )
+        elif not bool(torch.all(valid)):
+            raise ValueError(
+                "request slot is outside compact DFlash owner range: "
+                f"min={int(indices.min())}, max={int(indices.max())}, "
+                f"owner_count={self.owner_count}"
+            )
+        return (indices - 1) * self.owner_span
+
+    def committed_locs(
+        self, req_pool_indices: torch.Tensor, absolute_positions: torch.Tensor
+    ) -> torch.Tensor:
+        if req_pool_indices.shape != absolute_positions.shape:
+            raise ValueError(
+                "owner/position shape mismatch: "
+                f"owners={tuple(req_pool_indices.shape)}, "
+                f"positions={tuple(absolute_positions.shape)}"
+            )
+        positions = absolute_positions.to(torch.int64)
+        if positions.numel():
+            if positions.is_cuda:
+                torch._assert_async(
+                    torch.all(positions >= 0),
+                    "absolute token positions must be nonnegative",
+                )
+            elif bool(torch.any(positions < 0)):
+                raise ValueError("absolute token positions must be nonnegative")
+        locs = (
+            self._owner_bases(req_pool_indices)
+            + self.guard_rows
+            + torch.remainder(positions, self.window_size)
+        )
+        self.assert_in_bounds(locs)
+        return locs
+
+    def scratch_locs(self, req_pool_indices: torch.Tensor, width: int) -> torch.Tensor:
+        if width <= 0 or width > self.scratch_rows:
+            raise ValueError(
+                f"scratch width outside reserved range: width={width}, "
+                f"reserved={self.scratch_rows}"
+            )
+        bases = self._owner_bases(req_pool_indices.reshape(-1)).unsqueeze(1)
+        offsets = torch.arange(width, device=bases.device, dtype=torch.int64).unsqueeze(
+            0
+        )
+        locs = bases + self.guard_rows + self.window_size + offsets
+        self.assert_in_bounds(locs)
+        return locs
+
+    def bind_first_use_or_assert_generation(
+        self,
+        req_pool_indices: torch.Tensor,
+        owner_generation: torch.Tensor,
+        current_generation: torch.Tensor,
+        expected_generation: torch.Tensor,
+        acquire_owner_mask: torch.Tensor,
+    ) -> int:
+        indices = req_pool_indices.to(torch.int64).reshape(-1).cpu()
+        self._owner_bases(indices)
+        if torch.unique(indices).numel() != indices.numel():
+            raise RuntimeError("compact DFlash batch contains duplicate owner slots")
+        expected = expected_generation.to(torch.int64).reshape(-1).cpu()
+        acquire = acquire_owner_mask.to(torch.bool).reshape(-1).cpu()
+        if expected.shape != indices.shape or acquire.shape != indices.shape:
+            raise RuntimeError(
+                "compact DFlash owner metadata shape mismatch: "
+                f"indices={tuple(indices.shape)}, expected={tuple(expected.shape)}, "
+                f"acquire={tuple(acquire.shape)}"
+            )
+        actual = current_generation[indices].to(torch.int64).cpu()
+        if bool(torch.any(actual <= 0)) or bool(torch.any(expected <= 0)):
+            raise RuntimeError(
+                "compact DFlash owner has invalid allocation metadata: "
+                f"expected={expected.tolist()}, actual={actual.tolist()}"
+            )
+        if not torch.equal(actual, expected):
+            raise RuntimeError(
+                "compact DFlash request generation mismatch: "
+                f"expected={expected.tolist()}, actual={actual.tolist()}"
+            )
+
+        bound = owner_generation[indices].to(torch.int64).cpu()
+        non_acquire_mismatch = (~acquire) & (bound != expected)
+        if bool(torch.any(non_acquire_mismatch)):
+            raise RuntimeError(
+                "compact DFlash owner is not bound to the expected generation: "
+                f"bound={bound.tolist()}, expected={expected.tolist()}, "
+                f"acquire={acquire.tolist()}"
+            )
+
+        reused = acquire & (bound != 0) & (bound != expected)
+        reuse_count = int(reused.sum().item())
+        if bool(torch.any(acquire)):
+            owner_generation[indices[acquire]] = expected[acquire]
+        return reuse_count
+
+    def assert_in_bounds(self, locs: torch.Tensor) -> None:
+        if locs.numel() == 0:
+            return
+        valid = (locs >= 0) & (locs < self.physical_tokens)
+        if locs.is_cuda:
+            torch._assert_async(
+                torch.all(valid),
+                "compact DFlash physical location is out of bounds",
+            )
+            return
+        minimum, maximum = int(locs.min()), int(locs.max())
+        if minimum < 0 or maximum >= self.physical_tokens:
+            raise RuntimeError(
+                f"compact DFlash loc OOB: min={minimum}, max={maximum}, "
+                f"physical_tokens={self.physical_tokens}"
+            )

--- a/python/sglang/srt/speculative/dflash_compact_physical_layout.py
+++ b/python/sglang/srt/speculative/dflash_compact_physical_layout.py
@@ -29,6 +29,9 @@ class CompactDFlashPhysicalLayout:
     guard_rows: int
     page_size: int
     owner_span: int
+    request_tokens: int
+    content_start: int
+    content_tokens: int
     physical_tokens: int
 
     @classmethod
@@ -39,6 +42,7 @@ class CompactDFlashPhysicalLayout:
         window_size: int,
         block_size: int,
         page_size: int,
+        content_tokens: int = 0,
         scratch_blocks: int = 2,
         guard_blocks: int = 2,
     ) -> CompactDFlashPhysicalLayout:
@@ -64,6 +68,12 @@ class CompactDFlashPhysicalLayout:
         scratch_rows = _align_up(block_size * scratch_blocks, page_size)
         guard_rows = _align_up(block_size * guard_blocks, page_size)
         owner_span = _align_up(guard_rows + window_size + scratch_rows, page_size)
+        if int(content_tokens) < 0:
+            raise ValueError(
+                f"content_tokens must be nonnegative, got {content_tokens}"
+            )
+        request_tokens = int(owner_count) * owner_span
+        aligned_content_tokens = _align_up(int(content_tokens), int(page_size))
         return cls(
             owner_count=int(owner_count),
             window_size=int(window_size),
@@ -71,7 +81,10 @@ class CompactDFlashPhysicalLayout:
             guard_rows=guard_rows,
             page_size=int(page_size),
             owner_span=owner_span,
-            physical_tokens=int(owner_count) * owner_span,
+            request_tokens=request_tokens,
+            content_start=request_tokens,
+            content_tokens=aligned_content_tokens,
+            physical_tokens=request_tokens + aligned_content_tokens,
         )
 
     def _owner_bases(self, req_pool_indices: torch.Tensor) -> torch.Tensor:
@@ -115,7 +128,7 @@ class CompactDFlashPhysicalLayout:
             + self.guard_rows
             + torch.remainder(positions, self.window_size)
         )
-        self.assert_in_bounds(locs)
+        self.assert_request_locs(locs)
         return locs
 
     def scratch_locs(self, req_pool_indices: torch.Tensor, width: int) -> torch.Tensor:
@@ -129,8 +142,28 @@ class CompactDFlashPhysicalLayout:
             0
         )
         locs = bases + self.guard_rows + self.window_size + offsets
-        self.assert_in_bounds(locs)
+        self.assert_request_locs(locs)
         return locs
+
+    @property
+    def content_end(self) -> int:
+        return self.content_start + self.content_tokens
+
+    def assert_request_locs(self, locs: torch.Tensor) -> None:
+        self._assert_in_range(
+            locs,
+            start=0,
+            end=self.request_tokens,
+            region_name="request",
+        )
+
+    def assert_content_locs(self, locs: torch.Tensor) -> None:
+        self._assert_in_range(
+            locs,
+            start=self.content_start,
+            end=self.content_end,
+            region_name="content",
+        )
 
     def bind_first_use_or_assert_generation(
         self,
@@ -180,18 +213,29 @@ class CompactDFlashPhysicalLayout:
         return reuse_count
 
     def assert_in_bounds(self, locs: torch.Tensor) -> None:
+        self._assert_in_range(
+            locs,
+            start=0,
+            end=self.physical_tokens,
+            region_name="physical",
+        )
+
+    @staticmethod
+    def _assert_in_range(
+        locs: torch.Tensor, *, start: int, end: int, region_name: str
+    ) -> None:
         if locs.numel() == 0:
             return
-        valid = (locs >= 0) & (locs < self.physical_tokens)
+        valid = (locs >= start) & (locs < end)
         if locs.is_cuda:
             torch._assert_async(
                 torch.all(valid),
-                "compact DFlash physical location is out of bounds",
+                f"compact DFlash {region_name} location is out of bounds",
             )
             return
         minimum, maximum = int(locs.min()), int(locs.max())
-        if minimum < 0 or maximum >= self.physical_tokens:
+        if minimum < start or maximum >= end:
             raise RuntimeError(
-                f"compact DFlash loc OOB: min={minimum}, max={maximum}, "
-                f"physical_tokens={self.physical_tokens}"
+                f"compact DFlash {region_name} loc OOB: min={minimum}, "
+                f"max={maximum}, valid=[{start},{end})"
             )

--- a/python/sglang/srt/speculative/dflash_draft_content_allocator.py
+++ b/python/sglang/srt/speculative/dflash_draft_content_allocator.py
@@ -1,0 +1,120 @@
+"""Allocator for the device-only DFlash radix content subrange."""
+
+from __future__ import annotations
+
+import torch
+
+
+class DFlashDraftContentAllocator:
+    """Own exactly one fixed, contiguous subrange of draft KV row indices."""
+
+    def __init__(self, *, start: int, size: int, device: str | torch.device):
+        if start < 0 or size < 0:
+            raise ValueError(
+                f"invalid DFlash content range: start={start}, size={size}"
+            )
+        self.start = int(start)
+        self.size = int(size)
+        self.end = self.start + self.size
+        self.device = torch.device(device)
+        self.clear()
+
+    def clear(self) -> None:
+        self._free_rows = torch.arange(
+            self.start, self.end, dtype=torch.int64, device="cpu"
+        )
+        self._is_free = torch.ones(self.size, dtype=torch.bool, device="cpu")
+        # Hold returned tensors strongly so their Python ids remain unique while
+        # the one-shot unstaged allocation leases are outstanding.
+        self._leases: dict[int, tuple[torch.Tensor, torch.Tensor]] = {}
+
+    def available_size(self) -> int:
+        return int(self._free_rows.numel())
+
+    def alloc(self, need_size: int) -> torch.Tensor | None:
+        need_size = int(need_size)
+        if need_size < 0:
+            raise ValueError(f"allocation size must be nonnegative, got {need_size}")
+        if need_size > self.available_size():
+            return None
+        rows = self._free_rows[:need_size]
+        self._free_rows = self._free_rows[need_size:]
+        if rows.numel():
+            offsets = rows - self.start
+            if not bool(torch.all(self._is_free[offsets])):
+                raise RuntimeError("DFlash content allocator free-list corruption")
+            self._is_free[offsets] = False
+        device_rows = rows.to(self.device)
+        if device_rows.numel():
+            self._leases[id(device_rows)] = (device_rows, rows.clone())
+        return device_rows
+
+    def _take_lease(self, rows: torch.Tensor) -> torch.Tensor:
+        record = self._leases.get(id(rows))
+        if record is None or record[0] is not rows:
+            raise RuntimeError(
+                "DFlash content rows are not a current one-shot allocation lease"
+            )
+        del self._leases[id(rows)]
+        cpu_rows = record[1]
+        if bool(torch.any(self._is_free[cpu_rows - self.start])):
+            raise RuntimeError("DFlash content allocation lease refers to a free row")
+        return cpu_rows
+
+    def claim_lease(self, rows: torch.Tensor) -> None:
+        """Consume exactly one fresh allocation lease for publication."""
+        self._take_lease(rows)
+
+    def free_lease(self, rows: torch.Tensor) -> None:
+        """Return an allocation that failed before publication staging."""
+        self._free_cpu_rows(self._take_lease(rows))
+
+    def free(self, rows: torch.Tensor) -> None:
+        record = self._leases.pop(id(rows), None)
+        if record is not None and record[0] is rows:
+            cpu_rows = record[1]
+        else:
+            cpu_rows = rows.detach().to(device="cpu", dtype=torch.int64).reshape(-1)
+        if cpu_rows.numel() == 0:
+            return
+        # Arbitrary test/debug frees may overlap a larger lease. Production
+        # unstaged cleanup uses free_lease and never invalidates a partial lease.
+        for lease_id, (_, lease_rows) in list(self._leases.items()):
+            if bool(torch.isin(lease_rows, cpu_rows).any()):
+                del self._leases[lease_id]
+        self._free_cpu_rows(cpu_rows)
+
+    def _free_cpu_rows(self, rows: torch.Tensor) -> None:
+        if torch.unique(rows).numel() != rows.numel():
+            raise RuntimeError("DFlash content allocator received duplicate rows")
+        if bool(torch.any(rows < self.start)) or bool(torch.any(rows >= self.end)):
+            raise RuntimeError(
+                "DFlash content row is outside allocator range: "
+                f"valid=[{self.start},{self.end}), rows={rows.tolist()}"
+            )
+        offsets = rows - self.start
+        if bool(torch.any(self._is_free[offsets])):
+            raise RuntimeError(
+                f"DFlash content row was freed twice: rows={rows.tolist()}"
+            )
+        self._is_free[offsets] = True
+        self._free_rows = torch.cat((self._free_rows, rows))
+
+    def assert_allocated(self, rows: torch.Tensor) -> None:
+        if rows.is_cuda:
+            # Tree publication can only consume a one-shot allocator lease, and
+            # the match plan pins those rows against eviction. Keep the hot match
+            # path sync-free while still rejecting a corrupted physical range.
+            valid = (rows >= self.start) & (rows < self.end)
+            torch._assert_async(
+                torch.all(valid),
+                "DFlash content source is outside the content subrange",
+            )
+            return
+        rows = rows.detach().to(device="cpu", dtype=torch.int64).reshape(-1)
+        if rows.numel() == 0:
+            return
+        if bool(torch.any(rows < self.start)) or bool(torch.any(rows >= self.end)):
+            raise RuntimeError("DFlash content source is outside the content subrange")
+        if bool(torch.any(self._is_free[rows - self.start])):
+            raise RuntimeError("DFlash content source refers to an unallocated row")

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -370,6 +370,15 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.draft_window_size: Optional[int] = get_spec().speculative_draft_window_size
         self.use_draft_window = self.draft_window_size is not None
         self.use_compact_draft_cache = bool(get_spec().speculative_dflash_compact_cache)
+        spec_aux_config = getattr(target_worker.model_runner, "spec_aux_config", None)
+        self.dflash_radix_sidecar_tokens = int(
+            getattr(
+                spec_aux_config,
+                "dflash_radix_sidecar_tokens",
+                0,
+            )
+            or 0
+        )
         self.device = target_worker.device
         self._compact_physical_layout: Optional[CompactDFlashPhysicalLayout] = None
         self._compact_owner_generation: Optional[torch.Tensor] = None
@@ -382,7 +391,11 @@ class DFlashWorkerV2(BaseSpecWorker):
                 "Compact DFlash cache requires page_size=1; larger pages "
                 "can expose two absolute positions that alias one modulo-ring row"
             )
-        if self.use_compact_draft_cache and not get_memory().disable_radix_cache:
+        if (
+            self.use_compact_draft_cache
+            and not get_memory().disable_radix_cache
+            and self.dflash_radix_sidecar_tokens <= 0
+        ):
             raise RuntimeError(
                 "Compact DFlash cache requires --disable-radix-cache; "
                 "owner-local draft rings do not preserve target prefix-cache state"
@@ -597,12 +610,26 @@ class DFlashWorkerV2(BaseSpecWorker):
                 raise RuntimeError(
                     "Compact DFlash cache needs target pool config and request pool"
                 )
-            owner_count = int(req_to_token_pool.req_to_token.shape[0]) - 1
+            actual_owner_count = int(req_to_token_pool.req_to_token.shape[0]) - 1
+            owner_count = int(
+                getattr(
+                    self._target_worker.model_runner.spec_aux_config,
+                    "dflash_compact_owner_count",
+                    0,
+                )
+                or 0
+            )
+            if owner_count <= 0 or actual_owner_count > owner_count:
+                raise RuntimeError(
+                    "Compact DFlash request-owner geometry exceeds its frozen "
+                    f"budget: actual={actual_owner_count}, budgeted={owner_count}"
+                )
             self._compact_physical_layout = CompactDFlashPhysicalLayout.build(
                 owner_count=owner_count,
                 window_size=int(self.draft_window_size),
                 block_size=int(self.block_size),
                 page_size=int(self.page_size),
+                content_tokens=self.dflash_radix_sidecar_tokens,
             )
             self._compact_owner_generation = torch.zeros(
                 owner_count + 1, dtype=torch.int64, device="cpu"
@@ -633,11 +660,15 @@ class DFlashWorkerV2(BaseSpecWorker):
                 )
             logger.info(
                 "Allocated bounded DFlash draft cache: owners=%d, owner_span=%d, "
-                "physical_rows=%d, bytes=%d",
+                "request_rows=%d, content_rows=%d, physical_rows=%d, bytes=%d, "
+                "target_kv_tokens=%d",
                 owner_count,
                 self._compact_physical_layout.owner_span,
+                self._compact_physical_layout.request_tokens,
+                self._compact_physical_layout.content_tokens,
                 self._compact_physical_layout.physical_tokens,
                 physical_bytes,
+                memory_pool_config.max_total_num_tokens,
             )
             return
 
@@ -1906,6 +1937,249 @@ class DFlashWorkerV2(BaseSpecWorker):
     ) -> DFlashDraftInputV2:
         return make_draft_input_v2(bonus_tokens=bonus_tokens, new_seq_lens=seq_lens)
 
+    def _restore_compact_radix_prefix(self, batch: ScheduleBatch) -> int:
+        layout = self._compact_physical_layout
+        if layout is None or layout.content_tokens <= 0:
+            return 0
+        tree_cache = batch.tree_cache
+        get_plan = getattr(tree_cache, "get_dflash_draft_match_plan", None)
+        release_pin = getattr(tree_cache, "release_dflash_draft_match_pin", None)
+        if get_plan is None or release_pin is None:
+            raise RuntimeError("Compact DFlash radix sidecar has no DRAFT component")
+
+        source_parts = []
+        destination_parts = []
+        restore_details = []
+        plans = []
+        failed = False
+        try:
+            acquire = batch.acquire_owner_mask.to(torch.bool).reshape(-1).cpu()
+            if acquire.numel() != len(batch.reqs):
+                raise RuntimeError(
+                    "Compact DFlash radix restore acquire-mask mismatch: "
+                    f"mask={acquire.numel()}, requests={len(batch.reqs)}"
+                )
+            for req in batch.reqs:
+                plans.append((req, get_plan(req.rid)))
+            for row, (req, plan) in enumerate(plans):
+                # A continuing chunk keeps the same generation-bound owner ring.
+                # Only a newly acquired owner needs radix content restored.
+                if not bool(acquire[row]):
+                    continue
+                prefix_len = int(batch.prefix_lens[row])
+                if plan is None:
+                    if prefix_len:
+                        raise RuntimeError(
+                            "Compact DFlash radix hit has no protected DRAFT source: "
+                            f"rid={req.rid!r}, prefix_len={prefix_len}"
+                        )
+                    continue
+                expected = min(int(self.draft_window_size), prefix_len)
+                if (
+                    int(plan.matched_tokens) != expected
+                    or int(plan.source_rows.numel()) != expected
+                ):
+                    raise RuntimeError(
+                        "Compact DFlash radix source coverage mismatch: "
+                        f"rid={req.rid!r}, expected={expected}, "
+                        f"matched={plan.matched_tokens}, rows={plan.source_rows.numel()}"
+                    )
+                layout.assert_content_locs(plan.source_rows)
+                positions = torch.arange(
+                    prefix_len - expected,
+                    prefix_len,
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+                owners = batch.req_pool_indices[row].expand(expected)
+                destination_parts.append(layout.committed_locs(owners, positions))
+                source_parts.append(plan.source_rows.to(self.device, non_blocking=True))
+                restore_details.append((req.rid, prefix_len, expected))
+
+            if not source_parts:
+                return 0
+            source_rows = torch.cat(source_parts)
+            destination_rows = torch.cat(destination_parts)
+            self.draft_model_runner.token_to_kv_pool.move_kv_cache(
+                destination_rows, source_rows
+            )
+            restored_tokens = int(source_rows.numel())
+            ps = self.__dict__.get("ps")
+            if ps is None or ps.tp_rank == 0:
+                logger.debug(
+                    "DFLASH_RADIX restored restored_tokens=%d details=%s",
+                    restored_tokens,
+                    restore_details,
+                )
+            return restored_tokens
+        except BaseException:
+            failed = True
+            raise
+        finally:
+            release_error = None
+            known_pinned_rids = {req.rid for req, plan in plans if plan is not None}
+            # Plans are pinned by radix match, before this adapter reads them.
+            # Release every request even when validating the mask or retrieving
+            # the kth plan fails; release is an idempotent no-op without a pin.
+            for req in batch.reqs:
+                try:
+                    released = release_pin(req.rid)
+                    if released is False and req.rid in known_pinned_rids:
+                        raise RuntimeError(
+                            "Compact DFlash radix source pin disappeared before "
+                            f"restore cleanup: rid={req.rid!r}"
+                        )
+                except Exception as error:
+                    if release_error is None:
+                        release_error = error
+            if release_error is not None and not failed:
+                raise release_error
+
+    def _materialize_compact_prefill_with_sidecar(
+        self,
+        *,
+        batch: ScheduleBatch,
+        target_hidden: torch.Tensor,
+        positions: torch.Tensor,
+    ) -> bool:
+        layout = self._compact_physical_layout
+        if layout is None or layout.content_tokens <= 0:
+            return False
+        tree_cache = batch.tree_cache
+        alloc_content = getattr(tree_cache, "alloc_dflash_draft_content", None)
+        stage_publish = getattr(tree_cache, "stage_dflash_draft_publish", None)
+        discard_publish = getattr(tree_cache, "discard_dflash_draft_publish", None)
+        free_unstaged = getattr(tree_cache, "free_unstaged_dflash_draft_content", None)
+        if None in (alloc_content, stage_publish, discard_publish, free_unstaged):
+            raise RuntimeError("Compact DFlash radix sidecar cache API is incomplete")
+
+        hidden_parts = []
+        position_parts = []
+        projection_locs = []
+        owner_locs_for_copy = []
+        content_locs_for_copy = []
+        pending = []
+        owned_rows = []
+        staged_count = 0
+        try:
+            decoding_req_ids = {
+                id(req) for req in (getattr(batch, "decoding_reqs", None) or ())
+            }
+            owner_segments = {
+                row: (packed_start, packed_end, absolute_start)
+                for row, packed_start, packed_end, absolute_start in _compact_prefill_visible_segments(
+                    batch.prefix_lens,
+                    batch.extend_lens,
+                    int(self.draft_window_size),
+                )
+            }
+            for (
+                row,
+                part_start,
+                part_end,
+                absolute_start,
+            ) in _compact_prefill_visible_segments(
+                batch.prefix_lens,
+                batch.extend_lens,
+                layout.content_tokens,
+            ):
+                part_positions = positions[part_start:part_end]
+                req = batch.reqs[row]
+                owner = batch.req_pool_indices[row]
+                owner_start, owner_end, owner_absolute_start = owner_segments[row]
+                owner_positions = positions[owner_start:owner_end]
+                owner_locs = layout.committed_locs(
+                    owner.expand(owner_end - owner_start), owner_positions
+                )
+                # Decode rows in a mixed extend batch and requests that opt out
+                # of radix insertion still need their private owner ring updated,
+                # but must never allocate or publish DRAFT radix content.
+                if id(req) in decoding_req_ids or getattr(
+                    req, "skip_radix_cache_insert", False
+                ):
+                    hidden_parts.append(target_hidden[owner_start:owner_end])
+                    position_parts.append(owner_positions)
+                    projection_locs.append(owner_locs)
+                    continue
+
+                content_locs = alloc_content(part_end - part_start)
+                if content_locs is not None:
+                    # Track ownership immediately: range validation below may
+                    # fail before this allocation becomes a publish candidate.
+                    owned_rows.append(content_locs)
+                if content_locs is None:
+                    hidden_parts.append(target_hidden[owner_start:owner_end])
+                    position_parts.append(owner_positions)
+                    projection_locs.append(owner_locs)
+                    continue
+                layout.assert_content_locs(content_locs)
+
+                # Canonical content may cover more history than the request ring.
+                # Project it once, then copy only the intersection with the last W
+                # visible owner rows. If N < W, project the uncovered older owner
+                # rows directly instead of aliasing content through the modulo ring.
+                hidden_parts.append(target_hidden[part_start:part_end])
+                position_parts.append(part_positions)
+                projection_locs.append(content_locs)
+
+                overlap_absolute_start = max(absolute_start, owner_absolute_start)
+                content_offset = overlap_absolute_start - absolute_start
+                owner_offset = overlap_absolute_start - owner_absolute_start
+                overlap_len = part_end - part_start - content_offset
+                if overlap_len:
+                    content_locs_for_copy.append(
+                        content_locs[content_offset : content_offset + overlap_len]
+                    )
+                    owner_locs_for_copy.append(
+                        owner_locs[owner_offset : owner_offset + overlap_len]
+                    )
+                if owner_absolute_start < absolute_start:
+                    direct_len = absolute_start - owner_absolute_start
+                    hidden_parts.append(
+                        target_hidden[owner_start : owner_start + direct_len]
+                    )
+                    position_parts.append(owner_positions[:direct_len])
+                    projection_locs.append(owner_locs[:direct_len])
+                pending.append((req.rid, absolute_start, content_locs))
+
+            if hidden_parts:
+                self._append_target_hidden_to_draft_kv_by_loc(
+                    target_hidden=torch.cat(hidden_parts),
+                    cache_loc=torch.cat(projection_locs),
+                    positions=torch.cat(position_parts),
+                )
+            if content_locs_for_copy:
+                self.draft_model_runner.token_to_kv_pool.move_kv_cache(
+                    torch.cat(owner_locs_for_copy),
+                    torch.cat(content_locs_for_copy),
+                )
+            for rid, start_seqlen, rows in pending:
+                stage_publish(rid, start_seqlen, rows)
+                staged_count += 1
+            return True
+        except Exception as primary_error:
+            cleanup_errors = []
+            for rid, _, _ in pending[:staged_count]:
+                try:
+                    discarded = discard_publish(rid)
+                    if discarded is False:
+                        raise RuntimeError(
+                            "Compact DFlash staged publish disappeared during "
+                            f"rollback: rid={rid!r}"
+                        )
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            for rows in owned_rows[staged_count:]:
+                try:
+                    free_unstaged(rows)
+                except Exception as cleanup_error:
+                    cleanup_errors.append(cleanup_error)
+            for cleanup_error in cleanup_errors:
+                primary_error.add_note(
+                    "Compact DFlash sidecar rollback also failed: " f"{cleanup_error!r}"
+                )
+            raise
+
     def _make_next_draft_input_decode(
         self,
         *,
@@ -1932,17 +2206,37 @@ class DFlashWorkerV2(BaseSpecWorker):
                 raise RuntimeError(
                     "compact DFlash requires request-pool generation metadata"
                 )
-            self._compact_physical_layout.bind_first_use_or_assert_generation(
-                (
-                    batch.req_pool_indices_cpu
-                    if batch.req_pool_indices_cpu is not None
-                    else batch.req_pool_indices
-                ),
-                self._compact_owner_generation,
-                self.model_runner.req_to_token_pool.req_generation,
-                batch.expected_req_generations_cpu,
-                batch.acquire_owner_mask,
-            )
+            try:
+                self._compact_physical_layout.bind_first_use_or_assert_generation(
+                    (
+                        batch.req_pool_indices_cpu
+                        if batch.req_pool_indices_cpu is not None
+                        else batch.req_pool_indices
+                    ),
+                    self._compact_owner_generation,
+                    self.model_runner.req_to_token_pool.req_generation,
+                    batch.expected_req_generations_cpu,
+                    batch.acquire_owner_mask,
+                )
+            except BaseException as primary_error:
+                if is_extend and self._compact_physical_layout.content_tokens > 0:
+                    release_pin = getattr(
+                        batch.tree_cache,
+                        "release_dflash_draft_match_pin",
+                        None,
+                    )
+                    if release_pin is not None:
+                        for req in batch.reqs:
+                            try:
+                                release_pin(req.rid)
+                            except Exception as cleanup_error:
+                                primary_error.add_note(
+                                    "Compact DFlash generation-bind rollback also "
+                                    f"failed: {cleanup_error!r}"
+                                )
+                raise
+            if is_extend:
+                self._restore_compact_radix_prefix(batch)
 
         if is_extend:
             # Target prefill: capture DFlash aux hidden states for prompt tokens.
@@ -1957,7 +2251,11 @@ class DFlashWorkerV2(BaseSpecWorker):
                 batch_output.next_token_ids,
             )
             batch_output.new_seq_lens = batch.seq_lens
-            if on_publish is not None:
+            use_radix_sidecar = (
+                self._compact_physical_layout is not None
+                and self._compact_physical_layout.content_tokens > 0
+            )
+            if on_publish is not None and not use_radix_sidecar:
                 on_publish(batch_output.new_seq_lens)
 
             if logits_output.hidden_states is None:
@@ -1991,32 +2289,43 @@ class DFlashWorkerV2(BaseSpecWorker):
                 int(sum(batch.extend_lens)),
             )
             if self._compact_physical_layout is not None:
-                hidden_parts = []
-                position_parts = []
-                owner_parts = []
-                for row, part_start, part_end, _ in _compact_prefill_visible_segments(
-                    batch.prefix_lens,
-                    batch.extend_lens,
-                    int(self.draft_window_size),
-                ):
-                    owner = batch.req_pool_indices[row]
-                    hidden_parts.append(
-                        logits_output.hidden_states[part_start:part_end]
-                    )
-                    position_parts.append(positions[part_start:part_end])
-                    owner_parts.append(owner.expand(part_end - part_start))
-                if hidden_parts:
-                    compact_hidden = torch.cat(hidden_parts)
-                    compact_positions = torch.cat(position_parts)
-                    compact_owners = torch.cat(owner_parts)
-                    compact_locs = self._compact_physical_layout.committed_locs(
-                        compact_owners, compact_positions
-                    )
-                    self._append_target_hidden_to_draft_kv_by_loc(
-                        target_hidden=compact_hidden,
-                        cache_loc=compact_locs,
-                        positions=compact_positions,
-                    )
+                handled = self._materialize_compact_prefill_with_sidecar(
+                    batch=batch,
+                    target_hidden=logits_output.hidden_states,
+                    positions=positions,
+                )
+                if not handled:
+                    hidden_parts = []
+                    position_parts = []
+                    owner_parts = []
+                    for (
+                        row,
+                        part_start,
+                        part_end,
+                        _,
+                    ) in _compact_prefill_visible_segments(
+                        batch.prefix_lens,
+                        batch.extend_lens,
+                        int(self.draft_window_size),
+                    ):
+                        owner = batch.req_pool_indices[row]
+                        hidden_parts.append(
+                            logits_output.hidden_states[part_start:part_end]
+                        )
+                        position_parts.append(positions[part_start:part_end])
+                        owner_parts.append(owner.expand(part_end - part_start))
+                    if hidden_parts:
+                        compact_hidden = torch.cat(hidden_parts)
+                        compact_positions = torch.cat(position_parts)
+                        compact_owners = torch.cat(owner_parts)
+                        compact_locs = self._compact_physical_layout.committed_locs(
+                            compact_owners, compact_positions
+                        )
+                        self._append_target_hidden_to_draft_kv_by_loc(
+                            target_hidden=compact_hidden,
+                            cache_loc=compact_locs,
+                            positions=compact_positions,
+                        )
             else:
                 self._append_target_hidden_to_draft_kv_by_loc(
                     target_hidden=logits_output.hidden_states,
@@ -2026,6 +2335,9 @@ class DFlashWorkerV2(BaseSpecWorker):
 
             # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
             logits_output.hidden_states = None
+
+            if on_publish is not None and use_radix_sidecar:
+                on_publish(batch_output.new_seq_lens)
 
             batch_output.next_draft_input = self._make_next_draft_input_prefill(
                 bonus_tokens=next_token_ids,

--- a/python/sglang/srt/speculative/dflash_worker_v2.py
+++ b/python/sglang/srt/speculative/dflash_worker_v2.py
@@ -8,6 +8,7 @@ import torch
 from sglang.kernels.ops.speculative.cache_locs import (
     assign_extend_cache_locs_func,
     rebuild_compact_draft_req_to_token_func,
+    rebuild_compact_physical_draft_req_to_token_func,
 )
 from sglang.kernels.ops.speculative.dflash import (
     _compute_dflash_accept_bonus_triton_unchecked,
@@ -35,12 +36,16 @@ from sglang.srt.model_executor.forward_batch_info import (
 )
 from sglang.srt.runtime_context import (
     get_exec,
+    get_memory,
     get_schedule,
     get_spec,
     mamba_track_grid,
 )
 from sglang.srt.server_args import ServerArgs
 from sglang.srt.speculative.base_spec_worker import BaseSpecWorker
+from sglang.srt.speculative.dflash_compact_physical_layout import (
+    CompactDFlashPhysicalLayout,
+)
 from sglang.srt.speculative.dflash_info import DFlashVerifyInput
 from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
 from sglang.srt.speculative.dflash_utils import (
@@ -178,6 +183,73 @@ def _commit_accept(candidates, accept_len, bonus_tokens):
     return out_tokens, accept_len.to(torch.int32) + 1
 
 
+def _compact_prefill_visible_segments(
+    prefix_lens, extend_lens, window_size: int
+) -> List[Tuple[int, int, int, int]]:
+    """Return packed slices of newly-prefilled tokens still visible in the window.
+
+    Each tuple is ``(batch_row, packed_start, packed_end, absolute_start)``.
+    ``packed_start:packed_end`` indexes the packed extend tensors. Keeping this
+    arithmetic on host inputs makes chunked-prefill behavior explicit without a
+    device synchronization; physical ring wrap is handled later from the absolute
+    token positions.
+    """
+    if len(prefix_lens) != len(extend_lens):
+        raise ValueError(
+            "DFLASH compact prefill length mismatch: "
+            f"prefix_lens={len(prefix_lens)}, extend_lens={len(extend_lens)}."
+        )
+    window_size = int(window_size)
+    if window_size <= 0:
+        raise ValueError(
+            f"DFLASH compact prefill window must be positive, got {window_size}."
+        )
+
+    segments = []
+    packed_offset = 0
+    for row, (prefix_len, extend_len) in enumerate(zip(prefix_lens, extend_lens)):
+        prefix_len, extend_len = int(prefix_len), int(extend_len)
+        if prefix_len < 0 or extend_len < 0:
+            raise ValueError(
+                "DFLASH compact prefill lengths must be nonnegative: "
+                f"row={row}, prefix_len={prefix_len}, extend_len={extend_len}."
+            )
+        total_len = prefix_len + extend_len
+        absolute_start = max(prefix_len, total_len - window_size)
+        packed_start = packed_offset + absolute_start - prefix_len
+        packed_end = packed_offset + extend_len
+        if packed_end > packed_start:
+            segments.append((row, packed_start, packed_end, absolute_start))
+        packed_offset += extend_len
+    return segments
+
+
+def _compact_verify_committed_locs(
+    layout: CompactDFlashPhysicalLayout,
+    req_pool_indices: torch.Tensor,
+    positions_2d: torch.Tensor,
+) -> torch.Tensor:
+    """Map every dense verify position to its owner-local committed ring row."""
+    if req_pool_indices.ndim != 1:
+        raise ValueError(
+            "DFLASH compact verify owners must be 1D, "
+            f"got shape={tuple(req_pool_indices.shape)}."
+        )
+    if positions_2d.ndim != 2:
+        raise ValueError(
+            "DFLASH compact verify positions must be 2D, "
+            f"got shape={tuple(positions_2d.shape)}."
+        )
+    if int(req_pool_indices.shape[0]) != int(positions_2d.shape[0]):
+        raise ValueError(
+            "DFLASH compact verify batch mismatch: "
+            f"owners={tuple(req_pool_indices.shape)}, "
+            f"positions={tuple(positions_2d.shape)}."
+        )
+    owners_2d = req_pool_indices.to(torch.int64)[:, None].expand_as(positions_2d)
+    return layout.committed_locs(owners_2d, positions_2d)
+
+
 def _resolve_dflash_embedding_module(draft_model, target_model):
     if getattr(draft_model, "is_nemotron_35_draft", False):
         embed_module = draft_model.get_input_embeddings()
@@ -296,8 +368,25 @@ class DFlashWorkerV2(BaseSpecWorker):
         self.page_size = get_schedule().page_size
         # Normalized in arg_groups.speculative_hook.handle_speculative_decoding.
         self.draft_window_size: Optional[int] = get_spec().speculative_draft_window_size
-        self.use_compact_draft_cache = self.draft_window_size is not None
+        self.use_draft_window = self.draft_window_size is not None
+        self.use_compact_draft_cache = bool(get_spec().speculative_dflash_compact_cache)
         self.device = target_worker.device
+        self._compact_physical_layout: Optional[CompactDFlashPhysicalLayout] = None
+        self._compact_owner_generation: Optional[torch.Tensor] = None
+        if self.use_compact_draft_cache and not self.use_draft_window:
+            raise RuntimeError(
+                "Compact DFlash cache requires --speculative-draft-window-size"
+            )
+        if self.use_compact_draft_cache and self.page_size != 1:
+            raise RuntimeError(
+                "Compact DFlash cache requires page_size=1; larger pages "
+                "can expose two absolute positions that alias one modulo-ring row"
+            )
+        if self.use_compact_draft_cache and not get_memory().disable_radix_cache:
+            raise RuntimeError(
+                "Compact DFlash cache requires --disable-radix-cache; "
+                "owner-local draft rings do not preserve target prefix-cache state"
+            )
 
         self._warned_sampling_fallback = False
         self._draft_probs_buf = None
@@ -380,6 +469,9 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_verify_out_cache_loc_buf: Optional[torch.Tensor] = (
             None  # [cap_bs, block_size]
         )
+        self._draft_physical_out_cache_loc_buf: Optional[torch.Tensor] = (
+            None  # [cap_bs, block_size]
+        )
         self._draft_block_end_buf: Optional[torch.Tensor] = None  # [cap_bs]
         self._selector_sample: Optional[Tuple[torch.Tensor, torch.Tensor]] = None
         self._draft_seq_lens_cpu_buf: Optional[torch.Tensor] = None  # [cap_bs] on CPU
@@ -432,6 +524,63 @@ class DFlashWorkerV2(BaseSpecWorker):
             self.draft_model_runner.attn_backend,
         )
 
+    def compact_physical_transfer_locs(
+        self, req_pool_idx: int, start: int, end: int
+    ) -> torch.Tensor:
+        """Resolve absolute draft positions to this role's compact KV rows."""
+        if self._compact_physical_layout is None:
+            raise RuntimeError("compact DFlash physical layout is not active")
+        if start < 0 or end < start:
+            raise ValueError(f"invalid transfer range: start={start}, end={end}")
+        positions = torch.arange(start, end, dtype=torch.int64, device=self.device)
+        owners = torch.full_like(positions, int(req_pool_idx))
+        return self._compact_physical_layout.committed_locs(owners, positions)
+
+    def legacy_physical_transfer_locs(
+        self, req_pool_idx: int, start: int, end: int
+    ) -> torch.Tensor:
+        """Resolve absolute draft positions in the legacy full physical pool.
+
+        Non-compact DFlash materializes draft K/V at the target allocator's
+        physical indices.  Prefill and decode request-slot/allocator choices are
+        role-local, so each peer must gather its own ``req_to_token`` suffix;
+        sending either role's raw indices to the other would address unrelated
+        rows.  Slot zero is the padding sentinel and is never a valid transfer
+        destination.
+        """
+        if self._compact_physical_layout is not None:
+            raise RuntimeError(
+                "legacy DFlash transfer locations requested while compact physical "
+                "layout is active"
+            )
+        if start < 0 or end < start:
+            raise ValueError(f"invalid transfer range: start={start}, end={end}")
+
+        req_to_token = self.model_runner.req_to_token_pool.req_to_token
+        num_owners, table_width = req_to_token.shape
+        if req_pool_idx <= 0 or req_pool_idx >= int(num_owners):
+            raise ValueError(
+                "invalid DFlash transfer owner: "
+                f"owner={req_pool_idx}, valid=[1,{int(num_owners) - 1}]"
+            )
+        if end > int(table_width):
+            raise ValueError(
+                "DFlash transfer range exceeds req_to_token width: "
+                f"end={end}, width={int(table_width)}"
+            )
+
+        locations = req_to_token[int(req_pool_idx), start:end].to(torch.int64)
+        if int(locations.numel()) != end - start:
+            raise RuntimeError(
+                "DFlash legacy suffix length mismatch: "
+                f"expected={end - start}, actual={int(locations.numel())}"
+            )
+        if bool(torch.any(locations <= 0).item()):
+            raise RuntimeError(
+                "DFlash legacy suffix contains an unallocated/padding KV slot"
+            )
+        return locations
+
     def alloc_memory_pool(
         self,
         memory_pool_config=None,
@@ -443,12 +592,68 @@ class DFlashWorkerV2(BaseSpecWorker):
         # enabled, the draft worker keeps a private compact req->token table
         # over the same global KV index space, so radix-cache/prefix-hit KV
         # remains reusable while draft attention sees only the recent window.
+        if self.use_compact_draft_cache:
+            if memory_pool_config is None or req_to_token_pool is None:
+                raise RuntimeError(
+                    "Compact DFlash cache needs target pool config and request pool"
+                )
+            owner_count = int(req_to_token_pool.req_to_token.shape[0]) - 1
+            self._compact_physical_layout = CompactDFlashPhysicalLayout.build(
+                owner_count=owner_count,
+                window_size=int(self.draft_window_size),
+                block_size=int(self.block_size),
+                page_size=int(self.page_size),
+            )
+            self._compact_owner_generation = torch.zeros(
+                owner_count + 1, dtype=torch.int64, device="cpu"
+            )
+            compact_config = replace(
+                memory_pool_config,
+                max_total_num_tokens=self._compact_physical_layout.physical_tokens,
+                full_max_total_num_tokens=None,
+                swa_max_total_num_tokens=None,
+            )
+            self._draft_worker.alloc_memory_pool(
+                memory_pool_config=compact_config,
+                req_to_token_pool=None,
+                token_to_kv_pool_allocator=None,
+            )
+            physical_bytes = self._pool_bytes(self.draft_model_runner.token_to_kv_pool)
+            budgeted_fixed_bytes = int(
+                getattr(
+                    self._target_worker.model_runner.spec_aux_config,
+                    "dflash_draft_fixed_bytes",
+                    0,
+                )
+            )
+            if budgeted_fixed_bytes <= 0 or physical_bytes != budgeted_fixed_bytes:
+                raise RuntimeError(
+                    "Compact DFlash fixed-pool budget mismatch: "
+                    f"budgeted={budgeted_fixed_bytes}, allocated={physical_bytes}"
+                )
+            logger.info(
+                "Allocated bounded DFlash draft cache: owners=%d, owner_span=%d, "
+                "physical_rows=%d, bytes=%d",
+                owner_count,
+                self._compact_physical_layout.owner_span,
+                self._compact_physical_layout.physical_tokens,
+                physical_bytes,
+            )
+            return
+
         self._draft_worker.alloc_memory_pool(
             memory_pool_config=memory_pool_config,
-            req_to_token_pool=(
-                None if self.use_compact_draft_cache else req_to_token_pool
-            ),
+            req_to_token_pool=(None if self.use_draft_window else req_to_token_pool),
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
+        )
+
+    @staticmethod
+    def _pool_bytes(pool) -> int:
+        raw_bytes = pool.get_kv_size_bytes()
+        return (
+            sum(int(value) for value in raw_bytes)
+            if isinstance(raw_bytes, tuple)
+            else int(raw_bytes)
         )
 
     def init_attention_backends(self):
@@ -670,6 +875,9 @@ class DFlashWorkerV2(BaseSpecWorker):
         self._draft_verify_out_cache_loc_buf = torch.empty(
             (new_cap, block_size), dtype=torch.int64, device=device
         )
+        self._draft_physical_out_cache_loc_buf = torch.empty(
+            (new_cap, block_size), dtype=torch.int64, device=device
+        )
         self._draft_block_end_buf = torch.empty(
             (new_cap,), dtype=torch.int32, device=device
         )
@@ -826,10 +1034,58 @@ class DFlashWorkerV2(BaseSpecWorker):
         verify_out_cache_loc_2d: torch.Tensor,
         bs: int,
         block_size: int,
-    ) -> None:
+    ) -> torch.Tensor:
         """Write the draft-local compact req->token rows: the committed suffix
         window at [0, draft_prefix_len) plus the verify block slots after it."""
         suffix_start = prefix_lens.to(torch.int64) - draft_prefix_lens.to(torch.int64)
+        if self._compact_physical_layout is not None:
+            if self._use_triton_compact_rebuild:
+                assert self._draft_physical_out_cache_loc_buf is not None
+                physical_out_cache_loc_2d = self._draft_physical_out_cache_loc_buf[:bs]
+                rebuild_compact_physical_draft_req_to_token_func(
+                    draft_req_to_token=self.draft_model_runner.req_to_token_pool.req_to_token,
+                    req_pool_indices=req_pool_indices,
+                    suffix_start=suffix_start,
+                    draft_prefix_lens=draft_prefix_lens,
+                    physical_out_cache_loc_2d=physical_out_cache_loc_2d,
+                    batch_size=bs,
+                    block_size=block_size,
+                    owner_span=self._compact_physical_layout.owner_span,
+                    guard_rows=self._compact_physical_layout.guard_rows,
+                    window_size=self._compact_physical_layout.window_size,
+                )
+                return physical_out_cache_loc_2d
+            max_len = int(draft_prefix_lens.max().item()) if bs else 0
+            offsets = torch.arange(max_len, device=self.device, dtype=torch.int64)
+            absolute_positions = suffix_start[:, None] + offsets[None, :]
+            mask = offsets[None, :] < draft_prefix_lens.to(torch.int64)[:, None]
+            owners = req_pool_indices.to(torch.int64)[:, None].expand(-1, max_len)
+            committed = self._compact_physical_layout.committed_locs(
+                owners, absolute_positions
+            )
+            assign_req_to_token_pool_func(
+                req_pool_indices,
+                self.draft_model_runner.req_to_token_pool.req_to_token,
+                torch.zeros_like(draft_prefix_lens),
+                draft_prefix_lens,
+                committed[mask],
+                bs,
+            )
+            scratch = self._compact_physical_layout.scratch_locs(
+                req_pool_indices, block_size
+            )
+            assert self._draft_block_end_buf is not None
+            block_end = self._draft_block_end_buf[:bs]
+            torch.add(draft_prefix_lens, block_size, out=block_end)
+            assign_req_to_token_pool_func(
+                req_pool_indices,
+                self.draft_model_runner.req_to_token_pool.req_to_token,
+                draft_prefix_lens,
+                block_end,
+                scratch.reshape(-1),
+                bs,
+            )
+            return scratch
         if self._use_triton_compact_rebuild:
             rebuild_compact_draft_req_to_token_func(
                 draft_req_to_token=self.draft_model_runner.req_to_token_pool.req_to_token,
@@ -868,6 +1124,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 verify_out_cache_loc_2d.reshape(-1),
                 bs,
             )
+        return verify_out_cache_loc_2d
 
     def _resolve_mask_token_id(
         self, *, mask_token: str, mask_token_id: Optional[int] = None
@@ -1665,8 +1922,29 @@ class DFlashWorkerV2(BaseSpecWorker):
         pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
         self._validate_phase1_sampling_support(batch)
+        is_extend = batch.forward_mode.is_extend() or batch.is_extend_in_batch
+        if self._compact_physical_layout is not None:
+            assert self._compact_owner_generation is not None
+            if (
+                batch.expected_req_generations_cpu is None
+                or batch.acquire_owner_mask is None
+            ):
+                raise RuntimeError(
+                    "compact DFlash requires request-pool generation metadata"
+                )
+            self._compact_physical_layout.bind_first_use_or_assert_generation(
+                (
+                    batch.req_pool_indices_cpu
+                    if batch.req_pool_indices_cpu is not None
+                    else batch.req_pool_indices
+                ),
+                self._compact_owner_generation,
+                self.model_runner.req_to_token_pool.req_generation,
+                batch.expected_req_generations_cpu,
+                batch.acquire_owner_mask,
+            )
 
-        if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
+        if is_extend:
             # Target prefill: capture DFlash aux hidden states for prompt tokens.
             batch_output = self.target_worker.forward_batch_generation(
                 batch,
@@ -1712,11 +1990,39 @@ class DFlashWorkerV2(BaseSpecWorker):
                 ctx_lens,
                 int(sum(batch.extend_lens)),
             )
-            self._append_target_hidden_to_draft_kv_by_loc(
-                target_hidden=logits_output.hidden_states,
-                cache_loc=batch.out_cache_loc,
-                positions=positions,
-            )
+            if self._compact_physical_layout is not None:
+                hidden_parts = []
+                position_parts = []
+                owner_parts = []
+                for row, part_start, part_end, _ in _compact_prefill_visible_segments(
+                    batch.prefix_lens,
+                    batch.extend_lens,
+                    int(self.draft_window_size),
+                ):
+                    owner = batch.req_pool_indices[row]
+                    hidden_parts.append(
+                        logits_output.hidden_states[part_start:part_end]
+                    )
+                    position_parts.append(positions[part_start:part_end])
+                    owner_parts.append(owner.expand(part_end - part_start))
+                if hidden_parts:
+                    compact_hidden = torch.cat(hidden_parts)
+                    compact_positions = torch.cat(position_parts)
+                    compact_owners = torch.cat(owner_parts)
+                    compact_locs = self._compact_physical_layout.committed_locs(
+                        compact_owners, compact_positions
+                    )
+                    self._append_target_hidden_to_draft_kv_by_loc(
+                        target_hidden=compact_hidden,
+                        cache_loc=compact_locs,
+                        positions=compact_positions,
+                    )
+            else:
+                self._append_target_hidden_to_draft_kv_by_loc(
+                    target_hidden=logits_output.hidden_states,
+                    cache_loc=batch.out_cache_loc,
+                    positions=positions,
+                )
 
             # Avoid copying large hidden-state buffers to CPU in overlap scheduling.
             logits_output.hidden_states = None
@@ -1786,6 +2092,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         assert self._draft_block_positions_buf is not None
         assert self._draft_block_tokens_buf is not None
         assert self._draft_verify_out_cache_loc_buf is not None
+        assert self._draft_physical_out_cache_loc_buf is not None
         assert self._draft_block_end_buf is not None
         assert self._draft_seq_lens_cpu_buf is not None
 
@@ -1858,7 +2165,7 @@ class DFlashWorkerV2(BaseSpecWorker):
         verify_out_cache_loc = verify_out_cache_loc_2d.reshape(-1)
 
         seq_lens_cpu = self._draft_seq_lens_cpu_buf[:bs]
-        if self.use_compact_draft_cache:
+        if self.use_draft_window:
             # Rebuild the draft-local sliding-window view from committed target state.
             draft_prefix_lens = self._compute_compact_draft_seq_lens(prefix_lens)
             self._fill_compact_seq_lens_cpu_bound(
@@ -1867,7 +2174,7 @@ class DFlashWorkerV2(BaseSpecWorker):
                 draft_prefix_lens=draft_prefix_lens,
                 out=seq_lens_cpu,
             )
-            self._rebuild_compact_draft_cache(
+            draft_out_cache_loc_2d = self._rebuild_compact_draft_cache(
                 req_pool_indices=batch.req_pool_indices,
                 prefix_lens=prefix_lens,
                 draft_prefix_lens=draft_prefix_lens,
@@ -1875,6 +2182,13 @@ class DFlashWorkerV2(BaseSpecWorker):
                 bs=bs,
                 block_size=block_size,
             )
+            physical_out_cache_loc_2d = self._draft_physical_out_cache_loc_buf[:bs]
+            if (
+                draft_out_cache_loc_2d.data_ptr()
+                != physical_out_cache_loc_2d.data_ptr()
+            ):
+                physical_out_cache_loc_2d.copy_(draft_out_cache_loc_2d)
+            draft_out_cache_loc_2d = physical_out_cache_loc_2d
             draft_seq_lens = draft_prefix_lens
             draft_seq_lens_sum = int(seq_lens_cpu.sum().item())
         else:
@@ -1894,6 +2208,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             else:
                 seq_lens_cpu.copy_(prefix_lens.to("cpu", dtype=torch.int32))
                 draft_seq_lens_sum = int(prefix_lens.sum().item())
+            draft_out_cache_loc_2d = verify_out_cache_loc_2d
 
         forward_batch = ForwardBatch(
             forward_mode=ForwardMode.TARGET_VERIFY,
@@ -1901,7 +2216,7 @@ class DFlashWorkerV2(BaseSpecWorker):
             input_ids=block_ids.flatten(),
             req_pool_indices=batch.req_pool_indices,
             seq_lens=draft_seq_lens,
-            out_cache_loc=verify_out_cache_loc,
+            out_cache_loc=draft_out_cache_loc_2d.reshape(-1),
             seq_lens_sum=draft_seq_lens_sum,
             seq_lens_cpu=seq_lens_cpu,
             positions=positions,
@@ -2153,10 +2468,17 @@ class DFlashWorkerV2(BaseSpecWorker):
             )
         hidden = hidden.view(bs, int(self.block_size), -1)
 
+        committed_cache_loc_2d = verify_out_cache_loc_2d
+        if self._compact_physical_layout is not None:
+            committed_cache_loc_2d = _compact_verify_committed_locs(
+                self._compact_physical_layout,
+                batch.req_pool_indices,
+                positions_2d,
+            )
         self._append_target_hidden_to_draft_kv_by_loc(
             target_hidden=hidden.reshape(-1, hidden.shape[-1]),
-            cache_loc=verify_out_cache_loc,
-            cache_loc_2d=verify_out_cache_loc_2d,
+            cache_loc=committed_cache_loc_2d.reshape(-1),
+            cache_loc_2d=committed_cache_loc_2d,
             positions=positions,
             commit_lens=commit_lens,
         )

--- a/python/sglang/srt/speculative/spec_info.py
+++ b/python/sglang/srt/speculative/spec_info.py
@@ -190,6 +190,14 @@ class SpeculativeAlgorithm(Enum):
             return build_dspark_disagg_draft_input(
                 batch, last_tokens_tensor, future_map
             )
+        if self.is_dflash():
+            from sglang.srt.speculative.dflash_disaggregation import (
+                build_dflash_family_disagg_draft_input,
+            )
+
+            return build_dflash_family_disagg_draft_input(
+                batch, last_tokens_tensor, future_map
+            )
         return None
 
     def need_topk(self) -> bool:

--- a/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
+++ b/test/registered/unit/disaggregation/test_decode_queue_cleanup.py
@@ -378,7 +378,9 @@ class TestDecodeQueueCleanup(CustomTestCase):
         scheduler.disagg_decode_prealloc_queue = SimpleNamespace(
             queue=[], retracted_queue=[object()]
         )
-        scheduler.disagg_decode_transfer_queue = SimpleNamespace(queue=[])
+        scheduler.disagg_decode_transfer_queue = SimpleNamespace(
+            queue=[], has_pending_kv_ownership=lambda: False
+        )
         scheduler.decode_offload_manager = None
         scheduler.enable_hisparse = False
         scheduler.enable_hierarchical_cache = False

--- a/test/registered/unit/disaggregation/test_dflash_compact_lifecycle_guards.py
+++ b/test/registered/unit/disaggregation/test_dflash_compact_lifecycle_guards.py
@@ -1,0 +1,145 @@
+"""CPU regressions for decode transfer ownership across destructive lifecycle calls."""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from sglang.srt.constants import GPU_MEMORY_TYPE_KV_CACHE
+from sglang.srt.disaggregation.decode import DecodeTransferQueue
+from sglang.srt.disaggregation.utils import DisaggregationMode
+from sglang.srt.distributed.parallel_state_wrapper import ParallelState
+from sglang.srt.managers.io_struct import ReleaseMemoryOccupationReqInput
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.managers.scheduler_components.weight_updater import (
+    SchedulerWeightUpdaterManager,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _make_transfer_queue(*, active=0, deferred=0):
+    queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+    queue.queue = [object() for _ in range(active)]
+    queue._deferred_releases = [object() for _ in range(deferred)]
+    return queue
+
+
+def _make_idle_decode_scheduler(transfer_queue):
+    scheduler = Scheduler.__new__(Scheduler)
+    scheduler.running_batch = MagicMock()
+    scheduler.running_batch.is_empty.return_value = True
+    scheduler.running_batch.reqs = []
+    scheduler.chunked_req = None
+    scheduler.dllm_manager = MagicMock()
+    scheduler.dllm_manager.any_staging_reqs.return_value = False
+    scheduler.last_batch = None
+    scheduler.cur_batch_for_debug = object()
+    scheduler.enable_overlap = False
+    scheduler.ps = ParallelState.trivial()
+    scheduler.running_mbs = []
+    scheduler.waiting_queue = []
+    scheduler.grammar_manager = MagicMock()
+    scheduler.grammar_manager.grammar_queue = []
+    scheduler.disaggregation_mode = DisaggregationMode.DECODE
+    scheduler.disagg_decode_prealloc_queue = SimpleNamespace(
+        queue=[], retracted_queue=[]
+    )
+    scheduler.disagg_decode_transfer_queue = transfer_queue
+    scheduler.decode_offload_manager = None
+    scheduler.enable_hisparse = False
+    scheduler.enable_hierarchical_cache = False
+
+    # Destructive flush collaborators.  Tests assert these remain untouched
+    # when either visible transfers or queue-removed deferred holds exist.
+    scheduler.tree_cache = MagicMock()
+    scheduler.req_to_token_pool = MagicMock()
+    scheduler.token_to_kv_pool_allocator = MagicMock()
+    scheduler.metrics_reporter = MagicMock()
+    scheduler.metrics_reporter.is_stats_logging_rank = False
+    scheduler.draft_worker = MagicMock()
+    return scheduler
+
+
+class TestCompactDecodeLifecycleGuards(CustomTestCase):
+    def test_visible_transfer_and_deferred_hold_both_block_fully_idle(self):
+        for active, deferred in ((1, 0), (0, 1), (1, 1)):
+            with self.subTest(active=active, deferred=deferred):
+                scheduler = _make_idle_decode_scheduler(
+                    _make_transfer_queue(active=active, deferred=deferred)
+                )
+                self.assertFalse(scheduler.is_fully_idle())
+
+        scheduler = _make_idle_decode_scheduler(_make_transfer_queue())
+        self.assertTrue(scheduler.is_fully_idle())
+
+    def test_flush_preserves_deferred_owner_and_all_pools(self):
+        transfer_queue = _make_transfer_queue(deferred=1)
+        held_owner = transfer_queue._deferred_releases[0]
+        scheduler = _make_idle_decode_scheduler(transfer_queue)
+
+        self.assertFalse(scheduler.flush_cache())
+
+        self.assertEqual(transfer_queue._deferred_releases, [held_owner])
+        scheduler.tree_cache.reset.assert_not_called()
+        scheduler.req_to_token_pool.clear.assert_not_called()
+        scheduler.token_to_kv_pool_allocator.clear.assert_not_called()
+        scheduler.draft_worker.clear_cache_pool.assert_not_called()
+
+    def test_queue_memory_release_fails_closed_without_forgetting_owners(self):
+        for active, deferred in ((1, 0), (0, 1), (1, 1)):
+            with self.subTest(active=active, deferred=deferred):
+                transfer_queue = _make_transfer_queue(active=active, deferred=deferred)
+                active_owners = list(transfer_queue.queue)
+                deferred_owners = list(transfer_queue._deferred_releases)
+
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    rf"active_transfers={active}.*deferred_drain_ack_holds={deferred}",
+                ):
+                    transfer_queue.release_memory_occupation()
+
+                self.assertEqual(transfer_queue.queue, active_owners)
+                self.assertEqual(transfer_queue._deferred_releases, deferred_owners)
+
+        # An actually idle queue needs no destructive cleanup and is accepted.
+        _make_transfer_queue().release_memory_occupation()
+
+    def test_forced_weight_release_preflight_does_not_pause_or_mutate_state(self):
+        transfer_queue = _make_transfer_queue(deferred=1)
+        held_owner = transfer_queue._deferred_releases[0]
+        prealloc_queue = MagicMock()
+        scheduler = SimpleNamespace(
+            disaggregation_mode=DisaggregationMode.DECODE,
+            disagg_decode_transfer_queue=transfer_queue,
+            disagg_decode_prealloc_queue=prealloc_queue,
+        )
+        memory_saver = MagicMock()
+        flush_cache = MagicMock()
+        updater = SchedulerWeightUpdaterManager(
+            tp_worker=MagicMock(),
+            draft_worker=None,
+            tp_cpu_group=MagicMock(),
+            memory_saver_adapter=memory_saver,
+            flush_cache=flush_cache,
+            # Simulate an erroneous/forced upper-level idle result.  The local
+            # ownership preflight must still reject the teardown.
+            is_fully_idle=MagicMock(return_value=True),
+            scheduler=scheduler,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "deferred_drain_ack_holds=1"):
+            updater.release_memory_occupation(
+                ReleaseMemoryOccupationReqInput(tags=[GPU_MEMORY_TYPE_KV_CACHE])
+            )
+
+        self.assertEqual(transfer_queue._deferred_releases, [held_owner])
+        self.assertEqual(updater.offload_tags, set())
+        prealloc_queue.release_memory_occupation.assert_not_called()
+        memory_saver.pause.assert_not_called()
+        flush_cache.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_dflash_compact_pd_transfer.py
+++ b/test/registered/unit/disaggregation/test_dflash_compact_pd_transfer.py
@@ -1,0 +1,851 @@
+import concurrent.futures
+import inspect
+import logging
+import os
+import struct
+import threading
+from types import SimpleNamespace
+from unittest.mock import Mock, patch
+
+import numpy as np
+import pytest
+import torch
+
+import sglang.srt.disaggregation.decode as decode_mod
+import sglang.srt.disaggregation.utils as disagg_utils
+from sglang.srt.disaggregation.base.conn import KVPoll, StateType
+from sglang.srt.disaggregation.common.conn import CommonKVManager, CommonKVReceiver
+from sglang.srt.disaggregation.common.utils import pack_int_lists
+from sglang.srt.disaggregation.decode import DecodeTransferQueue
+from sglang.srt.disaggregation.decode_schedule_batch_mixin import (
+    ScheduleBatchDisaggregationDecodeMixin,
+)
+from sglang.srt.disaggregation.mooncake.conn import (
+    KVArgsRegisterInfo,
+    MooncakeKVManager,
+    MooncakeKVSender,
+)
+from sglang.srt.disaggregation.utils import (
+    DraftKVTransferSpec,
+    TransferBackend,
+    draft_swa_suffix_start,
+    get_dflash_draft_kv_transfer_locs,
+    get_dflash_draft_kv_transfer_spec,
+    get_legacy_draft_kv_buf_infos,
+    setup_state_kv_args,
+)
+from sglang.srt.speculative.dflash_info_v2 import DFlashDraftInputV2
+from sglang.srt.speculative.dflash_worker_v2 import DFlashWorkerV2
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.srt.speculative.spec_utils import spec_prepare_for_decode
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=30, suite="base-a-test-cpu")
+
+
+SUFFIX_ENV = "SGLANG_DFLASH_PD_DRAFT_SWA_SUFFIX"
+DEFERRED_ENV = "SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE"
+
+
+def _scheduler(*, compact=True):
+    layers = [
+        SimpleNamespace(
+            self_attn=SimpleNamespace(
+                sliding_window_size=2047,
+                attn=SimpleNamespace(layer_id=i),
+            )
+        )
+        for i in range(5)
+    ]
+    return SimpleNamespace(
+        spec_algorithm=SimpleNamespace(is_dflash=lambda: True),
+        draft_worker=SimpleNamespace(
+            use_compact_draft_cache=compact,
+            draft_window_size=2048,
+            draft_model=SimpleNamespace(layers=layers),
+        ),
+    )
+
+
+def _runtime_bags():
+    return SimpleNamespace(
+        parallel=SimpleNamespace(pp_size=1, dp_size=1, attn_dcp_size=1, attn_cp_size=1),
+        memory=SimpleNamespace(
+            disable_radix_cache=True,
+            enable_hierarchical_cache=False,
+            hicache_storage_backend=None,
+            enable_unified_memory=False,
+        ),
+        disagg=SimpleNamespace(
+            disaggregation_decode_enable_radix_cache=False,
+            disaggregation_decode_extra_slots=0,
+        ),
+        schedule=SimpleNamespace(page_size=1),
+    )
+
+
+def _bag_patches(bags):
+    return patch.multiple(
+        disagg_utils,
+        get_parallel=Mock(return_value=bags.parallel),
+        get_memory=Mock(return_value=bags.memory),
+        get_disagg=Mock(return_value=bags.disagg),
+        get_schedule=Mock(return_value=bags.schedule),
+    )
+
+
+def _registration(**overrides):
+    values = dict(
+        room="None",
+        endpoint="127.0.0.1",
+        dst_port=1,
+        mooncake_session_id="session",
+        dst_kv_ptrs=[21, 22],
+        dst_kv_data_lens=[64, 64],
+        dst_aux_ptrs=[],
+        dst_state_data_ptrs=[[201, 202]],
+        dst_state_data_lens=[[32, 32]],
+        dst_tp_rank=0,
+        dst_attn_tp_size=2,
+        dst_kv_item_len=8,
+        dst_state_item_lens=[[4, 4]],
+        dst_state_dim_per_tensor=[[]],
+        dst_kv_layer_ids=[],
+        dst_state_layer_ids=[[0, 0]],
+        draft_swa_suffix_enabled=True,
+        draft_swa_window_size=2048,
+        draft_swa_page_size=1,
+    )
+    values.update(overrides)
+    return KVArgsRegisterInfo(**values)
+
+
+def _capability_manager():
+    mgr = MooncakeKVManager.__new__(MooncakeKVManager)
+    mgr.attn_tp_size = 2
+    mgr.dcp_size = 1
+    mgr.kv_args = SimpleNamespace(
+        draft_swa_suffix_enabled=True,
+        draft_swa_window_size=2048,
+        page_size=1,
+        state_types=[StateType.DRAFT_SWA],
+        state_data_ptrs=[[101, 102]],
+        state_data_lens=[[32, 32]],
+        state_item_lens=[[4, 4]],
+        state_layer_ids=[[0, 0]],
+        kv_data_ptrs=[11, 12],
+        kv_data_lens=[64, 64],
+        kv_item_lens=[8, 8],
+    )
+    return mgr
+
+
+def test_registration_wire_defaults_legacy_and_reads_suffix_extension():
+    legacy = [
+        b"room",
+        b"127.0.0.1",
+        b"1234",
+        b"session",
+        struct.pack("Q", 0x1000),
+        b"",
+        b"",
+        b"0",
+        b"2",
+        b"8",
+        b"",
+        b"",
+        b"",
+        b"",
+        b"",
+        b"0",
+        b"1",
+        b"0",
+    ]
+    legacy_info = KVArgsRegisterInfo.from_zmq(legacy)
+    assert legacy_info.draft_swa_suffix_enabled is False
+    assert legacy_info.draft_swa_window_size == 0
+    assert legacy_info.draft_swa_page_size == 0
+    assert legacy_info.dst_kv_data_lens == []
+    assert legacy_info.dst_state_data_lens == []
+
+    # Frame 18 is the upstream staging slot metadata. Compact suffix
+    # capabilities are appended after it so older peers can ignore them.
+    suffix_info = KVArgsRegisterInfo.from_zmq(legacy + [b"", b"1", b"2048", b"1"])
+    assert suffix_info.draft_swa_suffix_enabled is True
+    assert suffix_info.draft_swa_window_size == 2048
+    assert suffix_info.draft_swa_page_size == 1
+    assert suffix_info.dst_kv_data_lens == []
+    assert suffix_info.dst_state_data_lens == []
+
+    ranged_info = KVArgsRegisterInfo.from_zmq(
+        legacy
+        + [
+            b"",
+            b"1",
+            b"2048",
+            b"1",
+            struct.pack("2Q", 64, 96),
+            pack_int_lists([[32, 48]], "Q"),
+        ]
+    )
+    assert ranged_info.dst_kv_data_lens == [64, 96]
+    assert ranged_info.dst_state_data_lens == [[32, 48]]
+
+    empty_extension = KVArgsRegisterInfo.from_zmq(legacy + [b"", b"", b"", b""])
+    assert empty_extension.draft_swa_suffix_enabled is False
+    assert empty_extension.draft_swa_window_size == 0
+    assert empty_extension.draft_swa_page_size == 0
+
+
+def test_suffix_start_and_role_local_compact_locs_are_exact():
+    spec = DraftKVTransferSpec(2048, (0, 0), True)
+
+    class Worker:
+        def __init__(self, offset):
+            self.offset = offset
+            self.calls = []
+
+        def compact_physical_transfer_locs(self, owner, start, end):
+            self.calls.append((owner, start, end))
+            return np.arange(start, end, dtype=np.int64) + self.offset
+
+    source = Worker(10_000)
+    destination = Worker(20_000)
+    source_locs = get_dflash_draft_kv_transfer_locs(source, 7, 3000, spec, 1)
+    destination_locs = get_dflash_draft_kv_transfer_locs(destination, 9, 3000, spec, 1)
+
+    assert draft_swa_suffix_start(3000, 2048, 1) == 952
+    assert source.calls == [(7, 952, 3000)]
+    assert destination.calls == [(9, 952, 3000)]
+    assert source_locs[0] == 10_952
+    assert destination_locs[0] == 20_952
+    assert len(source_locs) == len(destination_locs) == 2048
+
+
+def test_role_local_legacy_physical_locs_are_exact_and_independent():
+    class DraftTableMustNotBeRead:
+        @property
+        def req_to_token(self):
+            raise AssertionError("legacy suffix locs must read only the target table")
+
+    def worker_with_table(rows):
+        worker = DFlashWorkerV2.__new__(DFlashWorkerV2)
+        worker._compact_physical_layout = None
+        worker.model_runner = SimpleNamespace(
+            req_to_token_pool=SimpleNamespace(
+                req_to_token=torch.tensor(rows, dtype=torch.int64)
+            )
+        )
+        worker.draft_model_runner = SimpleNamespace(
+            req_to_token_pool=DraftTableMustNotBeRead()
+        )
+        return worker
+
+    source = worker_with_table(
+        [
+            [0, 0, 0, 0, 0, 0],
+            [301, 307, 311, 313, 317, 331],
+            [101, 103, 107, 109, 113, 127],
+        ]
+    )
+    destination = worker_with_table(
+        [
+            [0, 0, 0, 0, 0, 0],
+            [211, 223, 227, 229, 233, 239],
+            [401, 409, 419, 421, 431, 433],
+        ]
+    )
+    spec = DraftKVTransferSpec(4, (0, 0), True, False)
+
+    source_locs = get_dflash_draft_kv_transfer_locs(source, 2, 6, spec, 1)
+    destination_locs = get_dflash_draft_kv_transfer_locs(destination, 1, 6, spec, 1)
+
+    assert source_locs.tolist() == [107, 109, 113, 127]
+    assert destination_locs.tolist() == [227, 229, 233, 239]
+    assert set(source_locs.tolist()).isdisjoint(destination_locs.tolist())
+
+
+def test_legacy_physical_locs_reject_padding_sentinel():
+    worker = DFlashWorkerV2.__new__(DFlashWorkerV2)
+    worker._compact_physical_layout = None
+    worker.model_runner = SimpleNamespace(
+        req_to_token_pool=SimpleNamespace(
+            req_to_token=torch.tensor([[0, 0], [11, 0]], dtype=torch.int64)
+        )
+    )
+    spec = DraftKVTransferSpec(2, (0, 0), True, False)
+    with pytest.raises(RuntimeError, match="unallocated/padding"):
+        get_dflash_draft_kv_transfer_locs(worker, 1, 2, spec, 1)
+
+
+@patch.dict(os.environ, {SUFFIX_ENV: "1", DEFERRED_ENV: "1"})
+def test_static_compact_gate_uses_runtime_config_bags():
+    bags = _runtime_bags()
+    pool = SimpleNamespace(layer_num=5, page_size=1, use_hnd=False)
+    with _bag_patches(bags):
+        spec = get_dflash_draft_kv_transfer_spec(
+            _scheduler(), pool, TransferBackend.MOONCAKE
+        )
+    assert spec == DraftKVTransferSpec(2048, tuple(range(5)) * 2, True)
+
+
+@patch.dict(os.environ, {SUFFIX_ENV: "1", DEFERRED_ENV: "1"})
+def test_static_legacy_physical_gate_uses_same_suffix_capability():
+    bags = _runtime_bags()
+    pool = SimpleNamespace(layer_num=5, page_size=1, use_hnd=False)
+    with _bag_patches(bags):
+        spec = get_dflash_draft_kv_transfer_spec(
+            _scheduler(compact=False), pool, TransferBackend.MOONCAKE
+        )
+
+    assert spec == DraftKVTransferSpec(2048, tuple(range(5)) * 2, True, False)
+
+
+@pytest.mark.parametrize(
+    ("bag", "field", "value", "message"),
+    [
+        ("parallel", "pp_size", 2, "pipeline parallelism"),
+        ("parallel", "dp_size", 2, "data parallelism"),
+        ("parallel", "attn_dcp_size", 2, "DCP"),
+        ("parallel", "attn_cp_size", 2, "context parallelism"),
+        ("disagg", "disaggregation_decode_extra_slots", 1, "extra slots"),
+        ("memory", "disable_radix_cache", False, "radix cache"),
+        (
+            "disagg",
+            "disaggregation_decode_enable_radix_cache",
+            True,
+            "decode radix cache",
+        ),
+        ("memory", "enable_hierarchical_cache", True, "HiCache"),
+    ],
+)
+@patch.dict(os.environ, {SUFFIX_ENV: "1", DEFERRED_ENV: "1"})
+def test_static_compact_gate_rejects_unsupported_bags(bag, field, value, message):
+    bags = _runtime_bags()
+    setattr(getattr(bags, bag), field, value)
+    pool = SimpleNamespace(layer_num=5, page_size=1, use_hnd=False)
+    with _bag_patches(bags), pytest.raises(RuntimeError, match=message):
+        get_dflash_draft_kv_transfer_spec(_scheduler(), pool, TransferBackend.MOONCAKE)
+
+
+def test_static_compact_gate_requires_suffix_and_deferred_release(monkeypatch):
+    bags = _runtime_bags()
+    pool = SimpleNamespace(layer_num=5, page_size=1, use_hnd=False)
+    monkeypatch.delenv(SUFFIX_ENV, raising=False)
+    monkeypatch.setenv(DEFERRED_ENV, "1")
+    with _bag_patches(bags), pytest.raises(RuntimeError, match="suffix protocol"):
+        get_dflash_draft_kv_transfer_spec(_scheduler(), pool, TransferBackend.MOONCAKE)
+
+    monkeypatch.setenv(SUFFIX_ENV, "1")
+    monkeypatch.delenv(DEFERRED_ENV, raising=False)
+    with _bag_patches(bags), pytest.raises(RuntimeError, match="deferred decode"):
+        get_dflash_draft_kv_transfer_spec(_scheduler(), pool, TransferBackend.MOONCAKE)
+
+    # With suffix mode disabled, non-compact DFlash retains the historical
+    # full-pool route for backward compatibility.
+    monkeypatch.delenv(SUFFIX_ENV, raising=False)
+    noncompact = _scheduler(compact=False)
+    assert (
+        get_dflash_draft_kv_transfer_spec(noncompact, pool, TransferBackend.MOONCAKE)
+        is None
+    )
+
+    # Once suffix mode is selected, legacy physical slots need the same drain
+    # ownership guarantee as compact owner-local slots.
+    monkeypatch.setenv(SUFFIX_ENV, "1")
+    with _bag_patches(bags), pytest.raises(RuntimeError, match="deferred decode"):
+        get_dflash_draft_kv_transfer_spec(noncompact, pool, TransferBackend.MOONCAKE)
+
+
+@patch.dict(os.environ, {SUFFIX_ENV: "1", DEFERRED_ENV: "1"})
+def test_static_compact_gate_rejects_backend_and_page_size():
+    bags = _runtime_bags()
+    pool = SimpleNamespace(layer_num=5, page_size=1, use_hnd=False)
+    with _bag_patches(bags), pytest.raises(RuntimeError, match="not Mooncake"):
+        get_dflash_draft_kv_transfer_spec(_scheduler(), pool, TransferBackend.NIXL)
+
+    bags.schedule.page_size = 16
+    pool.page_size = 16
+    with _bag_patches(bags), pytest.raises(RuntimeError, match="page_size"):
+        get_dflash_draft_kv_transfer_spec(_scheduler(), pool, TransferBackend.MOONCAKE)
+
+
+def test_draft_transfer_spec_is_keyword_only_and_state_is_independent():
+    parameter = inspect.signature(setup_state_kv_args).parameters[
+        "draft_kv_transfer_spec"
+    ]
+    assert parameter.kind is inspect.Parameter.KEYWORD_ONLY
+
+    args = SimpleNamespace()
+    draft_pool = SimpleNamespace(
+        get_contiguous_buf_infos=lambda: ([101, 102], [1000, 1000], [4, 4])
+    )
+    setup_state_kv_args(
+        args,
+        object(),
+        draft_pool,
+        draft_kv_transfer_spec=DraftKVTransferSpec(2048, (3, 3), True),
+    )
+    assert args.state_types == [StateType.DRAFT_SWA]
+    assert args.state_data_ptrs == [[101, 102]]
+    assert args.state_item_lens == [[4, 4]]
+    assert args.state_layer_ids == [[3, 3]]
+
+
+def test_suffix_main_kv_excludes_both_physical_draft_layouts():
+    infos = ([101, 102], [1000, 1000], [4, 4])
+    draft_pool = SimpleNamespace(get_contiguous_buf_infos=Mock(return_value=infos))
+    compact_spec = DraftKVTransferSpec(2048, (3, 3), True)
+    legacy_physical_spec = DraftKVTransferSpec(2048, (3, 3), True, False)
+
+    assert get_legacy_draft_kv_buf_infos(draft_pool, compact_spec) is None
+    assert get_legacy_draft_kv_buf_infos(draft_pool, legacy_physical_spec) is None
+    draft_pool.get_contiguous_buf_infos.assert_not_called()
+    assert get_legacy_draft_kv_buf_infos(draft_pool, None) == infos
+    draft_pool.get_contiguous_buf_infos.assert_called_once_with()
+
+
+def test_dflash_prebuilt_builds_first_decode_spec_info():
+    batch = SimpleNamespace(
+        seq_lens=torch.tensor([9, 17], dtype=torch.int64),
+        enable_overlap=False,
+    )
+    bonus_tokens = torch.tensor([41, 42], dtype=torch.int64)
+    future_map = Mock()
+
+    spec_info = SpeculativeAlgorithm.DFLASH.build_disagg_draft_input(
+        batch, bonus_tokens, future_map
+    )
+
+    assert isinstance(spec_info, DFlashDraftInputV2)
+    assert spec_info.bonus_tokens.tolist() == [41, 42]
+    assert spec_info.new_seq_lens.tolist() == [9, 17]
+    assert spec_info.future_indices is None
+    future_map.publish.assert_not_called()
+    future_map.stash.assert_not_called()
+
+
+def test_process_prebuilt_dispatches_dflash_prepare_for_decode():
+    req = SimpleNamespace(
+        output_ids=[41],
+        grammar=None,
+        skip_radix_cache_insert=False,
+    )
+    batch = SimpleNamespace(
+        reqs=[req],
+        tree_cache=SimpleNamespace(cache_unfinished_req=Mock()),
+        device=torch.device("cpu"),
+        spec_algorithm=SpeculativeAlgorithm.DFLASH,
+        req_pool_indices=torch.tensor([2], dtype=torch.int64),
+        seq_lens=torch.tensor([9], dtype=torch.int64),
+        enable_overlap=False,
+    )
+    future_map = Mock()
+
+    ScheduleBatchDisaggregationDecodeMixin.process_prebuilt(batch, future_map)
+
+    assert isinstance(batch.spec_info, DFlashDraftInputV2)
+    with patch.object(
+        DFlashDraftInputV2, "prepare_for_decode", autospec=True
+    ) as prepare, patch(
+        "sglang.srt.speculative.spec_utils.mamba_extra_buffer_lazy_enabled",
+        return_value=False,
+    ):
+        spec_prepare_for_decode(batch)
+    prepare.assert_called_once_with(batch.spec_info, batch)
+
+
+def test_peer_gate_is_per_room_equal_tp_and_state_only():
+    mgr = _capability_manager()
+    assert mgr.can_use_draft_swa_suffix(_registration())
+    assert not mgr.can_use_draft_swa_suffix(_registration(dst_attn_tp_size=1))
+    assert not mgr.can_use_draft_swa_suffix(_registration(dst_dcp_size=2))
+    assert not mgr.can_use_draft_swa_suffix(_registration(dst_state_layer_ids=[[1, 1]]))
+    assert not mgr.can_use_draft_swa_suffix(_registration(dst_state_item_lens=[[8, 8]]))
+    # Distinct base pointers are insufficient: byte ranges must not overlap.
+    assert not mgr.can_use_draft_swa_suffix(
+        _registration(dst_kv_ptrs=[21, 190], dst_kv_data_lens=[64, 32])
+    )
+    assert not mgr.can_use_draft_swa_suffix(_registration(dst_kv_data_lens=[]))
+    assert not mgr.can_use_draft_swa_suffix(_registration(dst_state_data_lens=[]))
+    assert not mgr.can_use_draft_swa_suffix(
+        _registration(draft_swa_suffix_enabled=False)
+    )
+
+    mgr.transfer_infos = {
+        17: {
+            "session-a": SimpleNamespace(
+                is_dummy=False, mooncake_session_id="session-a"
+            ),
+            "dummy": SimpleNamespace(is_dummy=True, mooncake_session_id="dummy"),
+        }
+    }
+    mgr.decode_kv_args_table = {
+        "session-a": _registration(mooncake_session_id="session-a")
+    }
+    assert mgr.can_use_draft_swa_suffix_for_room(17)
+    mgr.decode_kv_args_table["session-a"] = _registration(dst_attn_tp_size=1)
+    assert not mgr.can_use_draft_swa_suffix_for_room(17)
+
+
+def test_compact_sender_rejects_dynamic_negotiation_failure():
+    sender = MooncakeKVSender.__new__(MooncakeKVSender)
+    sender.bootstrap_room = 17
+    sender._draft_swa_suffix_active = None
+    sender.kv_mgr = SimpleNamespace(
+        kv_args=SimpleNamespace(
+            draft_swa_suffix_enabled=True,
+            draft_swa_window_size=2048,
+            page_size=1,
+        ),
+        can_use_draft_swa_suffix_for_room=Mock(return_value=False),
+        room_has_draft_swa_suffix_peer=Mock(return_value=False),
+    )
+    with pytest.raises(RuntimeError, match="refusing legacy full-pool transfer"):
+        sender.can_send_draft_swa_suffix()
+
+
+def test_prefill_without_suffix_rejects_decode_suffix_wire_layout():
+    sender = MooncakeKVSender.__new__(MooncakeKVSender)
+    sender.bootstrap_room = 18
+    sender._draft_swa_suffix_active = None
+    sender.kv_mgr = SimpleNamespace(
+        kv_args=SimpleNamespace(draft_swa_suffix_enabled=False),
+        can_use_draft_swa_suffix_for_room=Mock(return_value=False),
+        room_has_draft_swa_suffix_peer=Mock(return_value=True),
+    )
+
+    for _ in range(2):
+        with pytest.raises(RuntimeError, match="decode peer requires"):
+            sender.can_send_draft_swa_suffix()
+
+
+def test_draft_state_send_is_exact_flat_and_layer_paired():
+    mgr = _capability_manager()
+    mgr.is_mla_backend = False
+    mgr.pp_size = 1
+    mgr.kv_args.state_dim_per_tensor = [[]]
+    mgr.kv_args.state_conv_shard_groups = [[]]
+    mgr.kv_args.state_slice_outer_counts = [[]]
+    mgr._send_kvcache_generic = Mock(return_value=0)
+    req = SimpleNamespace(mooncake_session_id="session", dst_state_indices=[[7, 8]])
+    registration = _registration()
+
+    assert mgr.maybe_send_extra(req, [[3, 4]], None, registration) == 0
+    kwargs = mgr._send_kvcache_generic.call_args.kwargs
+    assert kwargs["src_data_ptrs"] == [101, 102]
+    assert kwargs["dst_data_ptrs"] == [201, 202]
+    assert kwargs["force_flat"] is True
+    assert kwargs["src_layer_ids"] == [0, 0]
+    assert kwargs["dst_layer_ids"] == [0, 0]
+    np.testing.assert_array_equal(kwargs["prefill_data_indices"], [3, 4])
+    np.testing.assert_array_equal(kwargs["dst_data_indices"], [7, 8])
+
+    with pytest.raises(RuntimeError, match="index length mismatch"):
+        mgr.maybe_send_extra(req, [[3]], None, registration)
+
+
+def test_transfer_metric_counts_each_state_component_layout_once():
+    sender = MooncakeKVSender.__new__(MooncakeKVSender)
+    sender._transfer_num_kv_indices = 4
+    sender._transfer_num_state_indices = [2, 5]
+    sender._transfer_metric = SimpleNamespace(transfer_total_bytes=0)
+    sender.kv_mgr = SimpleNamespace(
+        kv_item_lens_sum=16,
+        state_item_lens_sums=[8, 3],
+        get_kv_replica_factor=lambda: 1,
+    )
+    assert sender.get_transfer_metric().transfer_total_bytes == 95
+
+
+@pytest.mark.parametrize("latched", [False, True])
+def test_sender_failed_status_waits_for_source_drain(latched):
+    sender = MooncakeKVSender.__new__(MooncakeKVSender)
+    sender.bootstrap_room = 23
+    sender.conclude_state = KVPoll.Failed if latched else None
+    sender.trace_ctx = Mock()
+    sender._draft_swa_suffix_active = False
+    sender._draft_swa_suffix_completion_logged = False
+    sender.kv_mgr = SimpleNamespace(
+        _staging_outstanding={23: 1},
+        check_status=Mock(return_value=KVPoll.Failed),
+    )
+    assert sender.poll() == KVPoll.Transferring
+    sender.kv_mgr._staging_outstanding.clear()
+    assert sender.poll() == KVPoll.Failed
+
+
+def test_sender_records_compact_completion(caplog):
+    sender = MooncakeKVSender.__new__(MooncakeKVSender)
+    sender.bootstrap_room = 24
+    sender.conclude_state = None
+    sender.trace_ctx = Mock()
+    sender._draft_swa_suffix_active = True
+    sender._draft_swa_suffix_completion_logged = False
+    sender._draft_swa_suffix_state_indices_sent = 2048
+    sender._full_draft_indices_omitted = 3000
+    sender._transfer_num_kv_indices = 3000
+    sender._transfer_num_state_indices = [2048]
+    sender._transfer_metric = SimpleNamespace(transfer_total_bytes=0)
+    sender.kv_mgr = SimpleNamespace(
+        _staging_outstanding={},
+        check_status=Mock(return_value=KVPoll.Success),
+        kv_item_lens_sum=16,
+        state_item_lens_sums=[8],
+        get_kv_replica_factor=lambda: 1,
+    )
+    with caplog.at_level(logging.INFO):
+        assert sender.poll() == KVPoll.Success
+    assert sender._draft_swa_suffix_completion_logged
+    assert '"event":"completed"' in caplog.text
+    assert '"draft_state_indices":2048' in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("require_drain_ack", "expect_release"), [(True, False), (False, True)]
+)
+def test_deferred_release_timeout_holds_suffix_but_releases_legacy_full_route(
+    require_drain_ack, expect_release, caplog
+):
+    queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+    queue.deferred_kv_release_timeout = 30.0
+    queue.require_drain_ack_for_deferred_release = require_drain_ack
+    queue._do_release = Mock()
+    kv_mgr = SimpleNamespace(is_abort_release_safe=Mock(return_value=False))
+    decode_req = SimpleNamespace(
+        req=SimpleNamespace(bootstrap_room=31),
+        kv_receiver=SimpleNamespace(kv_mgr=kv_mgr),
+    )
+    queue._deferred_releases = [(decode_req, 50.0, 7, 2)]
+
+    with patch.object(
+        decode_mod.time, "monotonic", return_value=100.0
+    ), caplog.at_level(logging.ERROR):
+        queue.resolve_deferred_releases()
+
+    assert queue._do_release.called is expect_release
+    if require_drain_ack:
+        assert len(queue._deferred_releases) == 1
+        assert queue._deferred_releases[0][1] == 130.0
+        assert "continuing to hold" in caplog.text
+    else:
+        assert queue._deferred_releases == []
+
+
+@patch.dict(os.environ, {SUFFIX_ENV: "1", DEFERRED_ENV: "1"})
+def test_legacy_physical_suffix_requires_permanent_drain_ack_hold():
+    queue = DecodeTransferQueue(
+        gloo_group=None,
+        req_to_metadata_buffer_idx_allocator=None,
+        tp_rank=0,
+        metadata_buffers=None,
+        scheduler=_scheduler(compact=False),
+        tree_cache=None,
+    )
+    assert queue.require_drain_ack_for_deferred_release is True
+
+
+def test_outstanding_chunk_terminal_cleanup_is_idempotent():
+    mgr = MooncakeKVManager.__new__(MooncakeKVManager)
+    mgr._staging_outstanding = {41: 1}
+    mgr.enable_deferred_decode_kv_release = True
+    mgr._maybe_ack_drained_abort = Mock()
+    chunk = SimpleNamespace(room=41, staging_counted=True)
+
+    mgr._finish_outstanding_chunk(chunk)
+    mgr._finish_outstanding_chunk(chunk)
+
+    assert mgr._staging_outstanding == {}
+    assert chunk.staging_counted is False
+    mgr._maybe_ack_drained_abort.assert_called_once_with(41)
+
+
+def test_future_exception_drains_running_rdma_before_outstanding_ack():
+    mgr = MooncakeKVManager.__new__(MooncakeKVManager)
+    mgr.enable_deferred_decode_kv_release = True
+    mgr._staging_outstanding = {42: 1}
+    mgr._maybe_ack_drained_abort = Mock()
+    chunk = SimpleNamespace(room=42, staging_counted=True)
+    blocked_started = threading.Event()
+    release_blocked = threading.Event()
+    controller_done = threading.Event()
+
+    def blocked_transfer():
+        blocked_started.set()
+        release_blocked.wait(timeout=5)
+        return 0
+
+    def failed_transfer():
+        raise RuntimeError("rdma failed")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=2) as executor:
+        blocked = executor.submit(blocked_transfer)
+        assert blocked_started.wait(timeout=1)
+        failed = executor.submit(failed_transfer)
+
+        def await_then_finish():
+            try:
+                mgr._await_transfer_futures([failed, blocked])
+            except RuntimeError:
+                pass
+            finally:
+                mgr._finish_outstanding_chunk(chunk)
+                controller_done.set()
+
+        controller = threading.Thread(target=await_then_finish)
+        controller.start()
+        assert not controller_done.wait(timeout=0.1)
+        assert mgr._staging_outstanding == {42: 1}
+        mgr._maybe_ack_drained_abort.assert_not_called()
+
+        release_blocked.set()
+        assert controller_done.wait(timeout=2)
+        controller.join(timeout=1)
+
+    assert mgr._staging_outstanding == {}
+    mgr._maybe_ack_drained_abort.assert_called_once_with(42)
+
+
+def _abort_test_manager(room):
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.enable_deferred_decode_kv_release = True
+    mgr._deferred_abort_ack_tracker = {}
+    mgr._receiver_armed_abort_rooms = set()
+    mgr.request_status = {room: KVPoll.WaitingForInput}
+    mgr.failure_records = {}
+    mgr.failure_lock = threading.Lock()
+    mgr.local_ip = "127.0.0.1"
+    mgr.rank_port = 9000
+    return mgr
+
+
+class _ConcreteReceiver(CommonKVReceiver):
+    def poll(self):
+        raise NotImplementedError
+
+    def failure_exception(self):
+        raise NotImplementedError
+
+
+def _receiver_with_synchronous_ack(room, mgr):
+    receiver = _ConcreteReceiver.__new__(_ConcreteReceiver)
+    receiver.bootstrap_room = room
+    receiver.kv_mgr = mgr
+    receiver.bootstrap_infos = [{"rank_ip": "127.0.0.1", "rank_port": 8000}]
+    receiver.abort_notified = False
+    receiver.conclude_state = None
+    receiver.init_time = 0.0
+    receiver.invalidate_cached_bootstrap_infos = Mock()
+
+    class Socket:
+        def send_multipart(self, _frames):
+            mgr.note_abort_ack(room, 0)
+
+    receiver._connect_to_bootstrap_server = Mock(
+        return_value=(Socket(), threading.Lock())
+    )
+    return receiver
+
+
+def test_receiver_abort_arms_before_synchronous_ack():
+    room = 51
+    mgr = _abort_test_manager(room)
+    receiver = _receiver_with_synchronous_ack(room, mgr)
+
+    receiver.abort()
+
+    assert receiver.abort_notified
+    assert mgr.is_abort_release_safe(room, required_acks=1)
+    # The scheduler's historical post-send registration is now idempotent.
+    mgr.register_deferred_abort_room(room)
+    assert mgr.is_abort_release_safe(room, required_acks=1)
+
+
+def test_waiting_timeout_arms_ack_and_allows_final_deferred_release():
+    room = 52
+    mgr = _abort_test_manager(room)
+    mgr.waiting_timeout = 1.0
+    receiver = _receiver_with_synchronous_ack(room, mgr)
+    with patch("sglang.srt.disaggregation.common.conn.time.time", return_value=10.0):
+        assert receiver._check_waiting_timeout() == KVPoll.Failed
+    assert mgr.is_abort_release_safe(room, required_acks=1)
+
+    queue = DecodeTransferQueue.__new__(DecodeTransferQueue)
+    queue.deferred_kv_release_timeout = 30.0
+    queue.require_drain_ack_for_deferred_release = True
+    queue._do_release = Mock()
+    decode_req = SimpleNamespace(
+        req=SimpleNamespace(bootstrap_room=room),
+        kv_receiver=SimpleNamespace(kv_mgr=mgr),
+    )
+    queue._deferred_releases = [(decode_req, 100.0, 7, 1)]
+    with patch.object(decode_mod.time, "monotonic", return_value=20.0):
+        queue.resolve_deferred_releases()
+    queue._do_release.assert_called_once_with(decode_req, 7)
+    assert queue._deferred_releases == []
+
+
+def test_success_room_with_outstanding_write_retains_abort_ack_target():
+    room = 53
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.request_status = {room: KVPoll.Success}
+    mgr._staging_outstanding = {room: 1}
+    mgr._deferred_ack_targets = {}
+    mgr._deferred_ack_send_failures = {}
+    mgr._send_abort_ack = Mock(return_value=True)
+
+    assert not mgr.handle_deferred_abort_notification(room, "127.0.0.1", 9000)
+    assert mgr.request_status[room] == KVPoll.Success
+    assert mgr._deferred_ack_targets[room] == ("127.0.0.1", 9000)
+    mgr._send_abort_ack.assert_not_called()
+
+    mgr._staging_outstanding.clear()
+    mgr._maybe_ack_drained_abort(room)
+    mgr._send_abort_ack.assert_called_once_with("127.0.0.1", 9000, room)
+    assert room not in mgr._deferred_ack_targets
+
+
+def test_abort_during_running_transfer_keeps_failed_sticky_until_drain_ack():
+    room = 55
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.request_status = {room: KVPoll.Transferring}
+    mgr._staging_outstanding = {room: 1}
+    mgr._deferred_ack_targets = {}
+    mgr._deferred_ack_send_failures = {}
+    mgr._send_abort_ack = Mock(return_value=True)
+
+    assert mgr.handle_deferred_abort_notification(room, "127.0.0.1", 9000)
+    assert mgr.request_status[room] == KVPoll.Failed
+    # Simulate the already-running last-chunk worker reaching its old Success.
+    mgr.update_status(room, KVPoll.Success)
+    assert mgr.request_status[room] == KVPoll.Failed
+    mgr._send_abort_ack.assert_not_called()
+
+    mgr._staging_outstanding.clear()
+    mgr._maybe_ack_drained_abort(room)
+    mgr._send_abort_ack.assert_called_once_with("127.0.0.1", 9000, room)
+
+
+def test_abort_ack_send_failure_is_retained_and_retried():
+    room = 54
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.attn_tp_rank = 0
+    mgr.pp_size = 1
+    mgr.attn_cp_size = 1
+    mgr.pp_rank = 0
+    mgr.attn_cp_rank = 0
+    mgr._staging_outstanding = {}
+    mgr._deferred_ack_targets = {room: ("127.0.0.1", 9000)}
+    mgr._deferred_ack_send_failures = {}
+    mgr._send_multipart_locked = Mock(
+        side_effect=[RuntimeError("temporary send failure"), None]
+    )
+
+    mgr._maybe_ack_drained_abort(room)
+    assert room in mgr._deferred_ack_targets
+    assert mgr._deferred_ack_send_failures[room] == 1
+
+    mgr.retry_deferred_abort_acks()
+    assert room not in mgr._deferred_ack_targets
+    assert room not in mgr._deferred_ack_send_failures
+    assert mgr._send_multipart_locked.call_count == 2

--- a/test/registered/unit/managers/test_schedule_batch_compact_owner.py
+++ b/test/registered/unit/managers/test_schedule_batch_compact_owner.py
@@ -1,0 +1,118 @@
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+
+from sglang.srt.managers.schedule_batch import ScheduleBatch
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.model_executor.forward_batch_info import CaptureHiddenMode, ForwardMode
+from sglang.srt.speculative.dflash_compact_physical_layout import (
+    CompactDFlashPhysicalLayout,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _req(index: int):
+    return SimpleNamespace(
+        rid=f"req-{index}",
+        req_pool_idx=index,
+        grammar=None,
+        return_logprob=False,
+        return_hidden_states=False,
+        return_hidden_states_mode=CaptureHiddenMode.NULL,
+        is_prefill_only=False,
+        finished=lambda: False,
+        beam_group=None,
+    )
+
+
+def _batch(indices, generations, acquire):
+    reqs = [_req(index) for index in indices]
+    batch = ScheduleBatch(reqs=reqs)
+    batch.device = "cpu"
+    batch.model_config = SimpleNamespace(is_encoder_decoder=False)
+    batch.req_to_token_pool = SimpleNamespace(
+        req_generation=torch.tensor([0, *generations], dtype=torch.int64)
+    )
+    batch.req_pool_indices = torch.tensor(indices, dtype=torch.int64)
+    batch.req_pool_indices_cpu = torch.tensor(indices, dtype=torch.int64)
+    batch.expected_req_generations_cpu = torch.tensor(generations, dtype=torch.int64)
+    batch.acquire_owner_mask = torch.tensor(acquire, dtype=torch.bool)
+    batch.seq_lens = torch.arange(1, len(reqs) + 1, dtype=torch.int64)
+    batch.seq_lens_cpu = batch.seq_lens.clone()
+    batch.orig_seq_lens = batch.seq_lens.to(torch.int32)
+    batch.input_ids = torch.arange(len(reqs), dtype=torch.int64)
+    batch.multimodal_inputs = None
+    batch.sampling_info = MagicMock()
+    batch.spec_info = None
+    batch.return_logprob = False
+    batch.return_hidden_states = False
+    batch.return_hidden_states_mode = CaptureHiddenMode.NULL
+    batch.has_grammar = False
+    batch.is_prefill_only = False
+    batch.forward_mode = ForwardMode.DECODE
+    return batch
+
+
+def test_owner_snapshot_reads_pool_generation_and_validates_shape():
+    batch = _batch([1, 2], [7, 11], [False, False])
+    batch.set_req_pool_owner_metadata([True, False])
+    assert batch.expected_req_generations_cpu.tolist() == [7, 11]
+    assert batch.acquire_owner_mask.tolist() == [True, False]
+
+    with pytest.raises(RuntimeError, match="acquire mask shape mismatch"):
+        batch.set_req_pool_owner_metadata([True])
+
+
+def test_filter_merge_and_copy_keep_owner_metadata_aligned_and_isolated():
+    batch = _batch([1, 2, 3], [11, 13, 17], [True, False, True])
+    original_expected = batch.expected_req_generations_cpu
+    original_acquire = batch.acquire_owner_mask
+
+    batch.filter_batch(keep_indices=[2, 0])
+    assert batch.expected_req_generations_cpu.tolist() == [17, 11]
+    assert batch.acquire_owner_mask.tolist() == [True, True]
+    assert batch.expected_req_generations_cpu.data_ptr() != original_expected.data_ptr()
+    assert batch.acquire_owner_mask.data_ptr() != original_acquire.data_ptr()
+
+    copied = batch.copy()
+    assert copied.expected_req_generations_cpu.tolist() == [17, 11]
+    assert copied.acquire_owner_mask.tolist() == [True, True]
+    assert (
+        copied.expected_req_generations_cpu.data_ptr()
+        != batch.expected_req_generations_cpu.data_ptr()
+    )
+
+    other = _batch([1], [23], [False])
+    batch.merge_batch(other)
+    assert batch.expected_req_generations_cpu.tolist() == [17, 11, 23]
+    assert batch.acquire_owner_mask.tolist() == [True, True, False]
+
+
+def test_stale_batch_generation_is_rejected_before_owner_rebind():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1, window_size=8, block_size=4, page_size=1
+    )
+    owner_generation = torch.tensor([0, 7], dtype=torch.int64)
+    current_generation = torch.tensor([0, 8], dtype=torch.int64)
+
+    with pytest.raises(RuntimeError, match="request generation mismatch"):
+        layout.bind_first_use_or_assert_generation(
+            torch.tensor([1]),
+            owner_generation,
+            current_generation,
+            torch.tensor([7]),
+            torch.tensor([True]),
+        )
+    assert owner_generation.tolist() == [0, 7]
+
+
+def test_success_consumes_acquire_authority_out_of_place():
+    batch = _batch([1], [7], [True])
+    original = batch.acquire_owner_mask
+    Scheduler._complete_req_pool_owner_acquisition(batch)
+    assert batch.acquire_owner_mask.tolist() == [False]
+    assert batch.acquire_owner_mask.data_ptr() != original.data_ptr()

--- a/test/registered/unit/managers/test_schedule_batch_compact_owner.py
+++ b/test/registered/unit/managers/test_schedule_batch_compact_owner.py
@@ -116,3 +116,17 @@ def test_success_consumes_acquire_authority_out_of_place():
     Scheduler._complete_req_pool_owner_acquisition(batch)
     assert batch.acquire_owner_mask.tolist() == [False]
     assert batch.acquire_owner_mask.data_ptr() != original.data_ptr()
+
+
+def test_rejected_candidate_releases_dflash_restore_pin_feature_safely():
+    released = []
+    req = SimpleNamespace(rid="rejected")
+    Scheduler._release_rejected_dflash_match(
+        SimpleNamespace(
+            release_dflash_draft_match_pin=lambda rid: released.append(rid)
+        ),
+        req,
+    )
+    assert released == ["rejected"]
+
+    Scheduler._release_rejected_dflash_match(SimpleNamespace(), req)

--- a/test/registered/unit/mem_cache/test_dflash_draft_component.py
+++ b/test/registered/unit/mem_cache/test_dflash_draft_component.py
@@ -1,0 +1,767 @@
+import unittest
+from array import array
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.managers.schedule_batch import Req
+from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
+from sglang.srt.mem_cache.base_prefix_cache import (
+    EvictParams,
+    IncLockRefResult,
+    InsertParams,
+    MatchPrefixParams,
+    zero_match_result,
+)
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.mem_cache.radix_cache import RadixKey
+from sglang.srt.mem_cache.unified_cache.components import ComponentType
+from sglang.srt.mem_cache.unified_cache.components.tree_component import (
+    EvictLayer,
+    TreeComponent,
+)
+from sglang.srt.mem_cache.unified_radix_cache import UnifiedRadixCache
+from sglang.srt.sampling.sampling_params import SamplingParams
+from sglang.srt.speculative.dflash_draft_content_allocator import (
+    DFlashDraftContentAllocator,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _CheckpointBoundaryComponent(TreeComponent):
+    """Test oracle for Mamba's boundary-only checkpoint semantics."""
+
+    component_type = ComponentType.MAMBA
+
+    def create_match_validator(self, match_device_only=False):
+        return lambda node: node.component_data[self.component_type].value is not None
+
+    def commit_insert_component_data(
+        self, node, is_new_leaf, params, result, cache_actions
+    ):
+        if params.mamba_value is None:
+            return
+        cd = node.component_data[self.component_type]
+        if cd.value is None:
+            cd.value = params.mamba_value.clone()
+            self.tree_core.lru_lists[self.component_type].insert_mru(node)
+            self.tree_core.component_evictable_size_[self.component_type] += 1
+
+    def redistribute_on_node_split(self, new_parent, child):
+        # A Mamba checkpoint remains only at the original deeper boundary.
+        new_parent.component_data[self.component_type].value = None
+
+    def evict_component(self, node, device_frees, host_frees, target=EvictLayer.DEVICE):
+        return 0, 0
+
+    def acquire_component_lock(self, node, result: IncLockRefResult, lock_host=False):
+        return result
+
+    def release_component_lock(self, node, params, lock_host=False):
+        return None
+
+    def _evict_device_start(self, request_cnt):
+        return None
+
+    def _evict_device_next_node(self, tracker, device_frees, host_frees):
+        return None
+
+    def _evict_device_end(self):
+        return None
+
+    def _dec_session_coverage(self, session_id, leaf):
+        return None
+
+    def _advance_session_coverage(self, session_id, leaf, old_ancestor):
+        return None
+
+    def _recede_session_coverage(self, session_id, leaf, fallback):
+        return None
+
+
+class _FailingFinalizeComponent(_CheckpointBoundaryComponent):
+    def finalize_match_result_in_cache(self, params, result):
+        raise RuntimeError("injected Mamba finalizer failure")
+
+
+class _FailingPrepareComponent(_CheckpointBoundaryComponent):
+    def prepare_for_caching_req(self, req, insert_params, token_ids_len, is_finished):
+        raise RuntimeError("injected Mamba prepare failure")
+
+
+class _CachingCheckpointBoundaryComponent(_CheckpointBoundaryComponent):
+    def prepare_for_caching_req(self, req, insert_params, token_ids_len, is_finished):
+        insert_params.mamba_value = torch.tensor([1])
+        return None
+
+
+class _RejectingPlanRegistry(dict):
+    def __setitem__(self, key, value):
+        raise RuntimeError("injected DFlash plan registration failure")
+
+
+class TestDFlashDraftComponent(CustomTestCase):
+    def setUp(self):
+        self.full_allocator = TokenToKVPoolAllocator(
+            size=64,
+            dtype=torch.bfloat16,
+            device="cpu",
+            kvcache=None,
+            need_sort=False,
+        )
+        self.content_allocator = DFlashDraftContentAllocator(
+            start=100, size=16, device="cpu"
+        )
+        self.cache = UnifiedRadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=ReqToTokenPool(
+                    size=4,
+                    max_context_len=32,
+                    device="cpu",
+                    enable_memory_saver=False,
+                ),
+                token_to_kv_pool_allocator=self.full_allocator,
+                page_size=1,
+                tree_components=(ComponentType.FULL, ComponentType.DRAFT),
+                dflash_draft_content_allocator=self.content_allocator,
+                dflash_draft_window_size=4,
+            )
+        )
+        self.component = self.cache.components[ComponentType.DRAFT]
+
+    @staticmethod
+    def _key(token_ids):
+        return RadixKey(array("q", token_ids))
+
+    def _insert(self, token_ids, *, draft_start):
+        full_rows = self.full_allocator.alloc(len(token_ids))
+        draft_count = len(token_ids) - draft_start
+        draft_rows = self.content_allocator.alloc(draft_count)
+        self.assertIsNotNone(full_rows)
+        self.assertIsNotNone(draft_rows)
+        self.content_allocator.claim_lease(draft_rows)
+        params = InsertParams(
+            key=self._key(token_ids),
+            value=full_rows,
+            draft_value=draft_rows,
+            draft_start_seqlen=draft_start,
+            draft_processed=torch.zeros(draft_count, dtype=torch.bool),
+        )
+        result = self.cache.insert(params)
+        self.component.cleanup_pending_rows(params)
+        self.assertTrue(bool(torch.all(params.draft_processed)))
+        return result, draft_rows.clone()
+
+    def _match(self, token_ids, rid):
+        return self.cache.match_prefix(
+            MatchPrefixParams(
+                key=self._key(token_ids),
+                req=SimpleNamespace(rid=rid, session=None),
+            )
+        )
+
+    def test_common_match_requires_one_contiguous_draft_window(self):
+        _, draft_rows = self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        result = self._match([1, 2, 3, 4, 5, 6], "warm")
+        self.assertEqual(result.device_indices.numel(), 6)
+        plan = self.component.get_match_plan("warm")
+        self.assertTrue(torch.equal(plan.source_rows, draft_rows))
+        self.assertEqual(plan.matched_tokens, 4)
+        self.assertTrue(self.cache.release_dflash_draft_match_pin("warm"))
+
+        self.cache.reset()
+        _, short_rows = self._insert([1, 2, 3], draft_start=0)
+        result = self._match([1, 2, 3], "short-prefix")
+        plan = self.component.get_match_plan("short-prefix")
+        self.assertEqual(result.device_indices.numel(), 3)
+        self.assertEqual(plan.matched_tokens, 3)
+        self.assertTrue(torch.equal(plan.source_rows, short_rows))
+        self.component.release_match_pin("short-prefix")
+
+        self.cache.reset()
+        self._insert([1, 2, 3, 4, 5, 6], draft_start=3)
+        result = self._match([1, 2, 3, 4, 5, 6], "short")
+        self.assertEqual(result.device_indices.numel(), 0)
+        self.assertIsNone(self.component.get_match_plan("short"))
+
+    def test_cap_history_preserves_an_earlier_long_prompt_branch_window(self):
+        _, rows = self._insert(list(range(1, 11)), draft_start=0)
+
+        result = self._match([1, 2, 3, 4, 5, 6, 99], "earlier-branch")
+        self.assertEqual(result.device_indices.numel(), 6)
+        plan = self.component.get_match_plan("earlier-branch")
+        self.assertEqual(plan.matched_tokens, 4)
+        torch.testing.assert_close(plan.source_rows, rows[2:6])
+        self.component.release_match_pin("earlier-branch")
+
+    def test_match_pin_survives_split_and_releases_exactly(self):
+        self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        self._match([1, 2, 3, 4, 5, 6], "split")
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 4
+        )
+
+        self._insert([1, 2, 3, 4, 9, 10], draft_start=2)
+        self.assertTrue(self.component.release_match_pin("split"))
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+        self.assertEqual(
+            self.cache.tree_core.component_evictable_size(ComponentType.DRAFT), 6
+        )
+
+    def test_match_pin_failure_is_atomic_before_and_after_locking(self):
+        self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        draft_evictable = self.cache.tree_core.component_evictable_size(
+            ComponentType.DRAFT
+        )
+
+        with patch.object(
+            self.content_allocator,
+            "assert_allocated",
+            side_effect=RuntimeError("injected DFlash source validation failure"),
+        ):
+            with self.assertRaisesRegex(RuntimeError, "source validation failure"):
+                self._match([1, 2, 3, 4, 5, 6], "validate-failure")
+
+        self.assertIsNone(self.component.get_match_plan("validate-failure"))
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+        self.assertEqual(
+            self.cache.tree_core.component_evictable_size(ComponentType.DRAFT),
+            draft_evictable,
+        )
+
+        original_registry = self.component._match_plans
+        self.component._match_plans = _RejectingPlanRegistry()
+        try:
+            with self.assertRaisesRegex(RuntimeError, "plan registration failure"):
+                self._match([1, 2, 3, 4, 5, 6], "register-failure")
+        finally:
+            self.component._match_plans = original_registry
+
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+        self.assertEqual(
+            self.cache.tree_core.component_evictable_size(ComponentType.DRAFT),
+            draft_evictable,
+        )
+        recovered = self._match([1, 2, 3, 4, 5, 6], "recovered")
+        self.assertEqual(recovered.device_indices.numel(), 6)
+        self.assertTrue(self.component.release_match_pin("recovered"))
+
+    def test_restore_pin_requires_draft_validation(self):
+        self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        with self.assertRaisesRegex(RuntimeError, "requires DRAFT coverage"):
+            self.cache.match_prefix(
+                MatchPrefixParams(
+                    key=self._key([1, 2, 3, 4, 5, 6]),
+                    req=SimpleNamespace(rid="invalid-flags", session=None),
+                    require_dflash_draft=False,
+                )
+            )
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+
+    def test_shared_pins_survive_two_splits_and_release_independently(self):
+        self._insert([1, 2, 3, 4, 5, 6, 7, 8], draft_start=0)
+        self._match([1, 2, 3, 4, 5, 6, 7, 8], "first-pin")
+        self._match([1, 2, 3, 4, 5, 6, 7, 8], "second-pin")
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 8
+        )
+
+        self._insert([1, 2, 3, 4, 9, 10], draft_start=2)
+        self._insert([1, 2, 11, 12], draft_start=0)
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 8
+        )
+
+        self.assertTrue(self.component.release_match_pin("first-pin"))
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 8
+        )
+        self.assertTrue(self.component.release_match_pin("second-pin"))
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+        self.assertEqual(
+            self.cache.tree_core.component_evictable_size(ComponentType.DRAFT), 12
+        )
+
+    def test_draft_eviction_never_deletes_full_tree_data(self):
+        result, _ = self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        node = self.cache.tree_core.node_by_id(result.last_device_node)
+        full_value = node.component_data[ComponentType.FULL].value.clone()
+
+        self._match([1, 2, 3, 4, 5, 6], "pinned")
+        blocked = self.cache.evict(EvictParams(draft_num_tokens=1))
+        self.assertEqual(blocked.draft_num_tokens_evicted, 0)
+        self.component.release_match_pin("pinned")
+
+        evicted = self.cache.evict(EvictParams(draft_num_tokens=1))
+        self.assertEqual(evicted.num_tokens_evicted, 0)
+        self.assertEqual(evicted.draft_num_tokens_evicted, 4)
+        self.assertTrue(
+            torch.equal(node.component_data[ComponentType.FULL].value, full_value)
+        )
+        self.assertIsNone(node.component_data[ComponentType.DRAFT].value)
+
+    def test_content_allocation_pressure_evicts_only_draft_rows(self):
+        result, _ = self._insert(list(range(1, 17)), draft_start=0)
+        node = self.cache.tree_core.node_by_id(result.last_device_node)
+        full_value = node.component_data[ComponentType.FULL].value.clone()
+        self.assertEqual(self.content_allocator.available_size(), 0)
+
+        rows = self.cache.alloc_dflash_draft_content(4)
+
+        self.assertIsNotNone(rows)
+        self.assertEqual(len(rows), 4)
+        self.assertEqual(self.content_allocator.available_size(), 12)
+        self.assertTrue(
+            torch.equal(node.component_data[ComponentType.FULL].value, full_value)
+        )
+        self.assertIsNone(node.component_data[ComponentType.DRAFT].value)
+        self.cache.free_unstaged_dflash_draft_content(rows)
+        self.assertEqual(self.content_allocator.available_size(), 16)
+
+    def test_draft_eviction_preserves_full_and_mamba_components(self):
+        cache = UnifiedRadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=ReqToTokenPool(
+                    size=4,
+                    max_context_len=32,
+                    device="cpu",
+                    enable_memory_saver=False,
+                ),
+                token_to_kv_pool_allocator=self.full_allocator,
+                page_size=1,
+                tree_components=(
+                    ComponentType.FULL,
+                    ComponentType.DRAFT,
+                    ComponentType.MAMBA,
+                ),
+                component_registry_override={
+                    ComponentType.MAMBA: _CheckpointBoundaryComponent
+                },
+                dflash_draft_content_allocator=self.content_allocator,
+                dflash_draft_window_size=4,
+            )
+        )
+        component = cache.components[ComponentType.DRAFT]
+        draft_rows = self.content_allocator.alloc(4)
+        self.content_allocator.claim_lease(draft_rows)
+        params = InsertParams(
+            key=self._key([1, 2, 3, 4, 5, 6]),
+            value=self.full_allocator.alloc(6),
+            mamba_value=torch.tensor([1]),
+            draft_value=draft_rows,
+            draft_start_seqlen=2,
+            draft_processed=torch.zeros(4, dtype=torch.bool),
+        )
+        result = cache.insert(params)
+        component.cleanup_pending_rows(params)
+        node = cache.tree_core.node_by_id(result.last_device_node)
+
+        evicted = cache.evict(EvictParams(draft_num_tokens=1))
+        self.assertEqual(evicted.draft_num_tokens_evicted, 4)
+        self.assertEqual(evicted.num_tokens_evicted, 0)
+        self.assertIsNotNone(node.component_data[ComponentType.FULL].value)
+        self.assertIsNotNone(node.component_data[ComponentType.MAMBA].value)
+        self.assertIsNone(node.component_data[ComponentType.DRAFT].value)
+
+    def test_publish_accepts_only_allocated_content_rows(self):
+        with self.assertRaisesRegex(RuntimeError, "one-shot allocation lease"):
+            self.component.stage_pending_publish(
+                "request-or-scratch", 0, torch.tensor([99, 116])
+            )
+        with self.assertRaisesRegex(RuntimeError, "one-shot allocation lease"):
+            self.component.stage_pending_publish("free-content", 0, torch.tensor([100]))
+
+        rows = self.content_allocator.alloc(1)
+        self.component.stage_pending_publish("canonical", 0, rows)
+        with self.assertRaisesRegex(RuntimeError, "one-shot allocation lease"):
+            self.component.stage_pending_publish("duplicate-owner", 0, rows)
+        self.component.release_request_state("canonical")
+
+        _, tree_rows = self._insert([1, 2, 3, 4], draft_start=0)
+        with self.assertRaisesRegex(RuntimeError, "one-shot allocation lease"):
+            self.component.stage_pending_publish("tree-owned", 0, tree_rows)
+        self.cache.reset()
+        self.assertEqual(self.content_allocator.available_size(), 16)
+
+    def test_overlap_frees_duplicate_rows_and_keeps_branch_content(self):
+        _, first_rows = self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        _, second_rows = self._insert([1, 2, 3, 4, 9, 10], draft_start=2)
+        self.assertEqual(self.content_allocator.available_size(), 10)
+
+        result = self._match([1, 2, 3, 4, 9, 10], "branch")
+        plan = self.component.get_match_plan("branch")
+        expected = torch.cat((first_rows[:2], second_rows[2:]))
+        self.assertEqual(result.device_indices.numel(), 6)
+        self.assertTrue(torch.equal(plan.source_rows, expected))
+        self.component.release_match_pin("branch")
+
+    def test_pending_abort_and_reset_return_all_content_rows(self):
+        pending = self.content_allocator.alloc(4)
+        params = InsertParams(
+            draft_value=pending,
+            draft_start_seqlen=8,
+            draft_processed=torch.zeros(4, dtype=torch.bool),
+        )
+        self.component.cleanup_pending_rows(params)
+        self.assertEqual(self.content_allocator.available_size(), 16)
+
+        self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        self.assertEqual(self.content_allocator.available_size(), 12)
+        self.cache.reset()
+        self.assertEqual(self.content_allocator.available_size(), 16)
+
+    def test_reset_clears_tree_pending_and_active_pin_together(self):
+        self._insert([1, 2, 3, 4], draft_start=0)
+        self._match([1, 2, 3, 4], "pinned")
+        pending = self.cache.alloc_dflash_draft_content(4)
+        self.cache.stage_dflash_draft_publish("pending", 4, pending)
+        self.assertEqual(self.content_allocator.available_size(), 8)
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 4
+        )
+
+        self.cache.reset()
+
+        self.assertEqual(self.content_allocator.available_size(), 16)
+        self.assertIsNone(self.component.get_match_plan("pinned"))
+        self.assertFalse(self.component.discard_pending_publish("pending"))
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+        self.assertEqual(
+            self.cache.tree_core.component_evictable_size(ComponentType.DRAFT), 0
+        )
+
+    def test_staged_abort_and_forced_miss_release_component_state(self):
+        rows = self.cache.alloc_dflash_draft_content(4)
+        self.cache.stage_dflash_draft_publish("abort", 8, rows)
+        self.cache.release_aborted_request("abort")
+        self.assertEqual(self.content_allocator.available_size(), 16)
+
+        self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        result = self._match([1, 2, 3, 4, 5, 6], "forced-miss")
+        self.assertIsNotNone(self.component.get_match_plan("forced-miss"))
+        missed = zero_match_result(
+            self.cache, result, extra_key=None, rid="forced-miss"
+        )
+        self.assertEqual(missed.device_indices.numel(), 0)
+        self.assertIsNone(self.component.get_match_plan("forced-miss"))
+
+    def test_finished_without_insert_returns_staged_publish(self):
+        rows = self.cache.alloc_dflash_draft_content(4)
+        self.cache.stage_dflash_draft_publish("skip-or-abort", 8, rows)
+        self.assertEqual(self.content_allocator.available_size(), 12)
+
+        self.component.cleanup_after_caching_req(
+            SimpleNamespace(rid="skip-or-abort"),
+            is_finished=True,
+            insert_params=None,
+        )
+
+        self.assertEqual(self.content_allocator.available_size(), 16)
+        self.assertFalse(self.component.discard_pending_publish("skip-or-abort"))
+
+    def test_internal_maintenance_match_does_not_create_restore_pin(self):
+        self._insert([1, 2, 3, 4, 5, 6], draft_start=2)
+        result = self.cache.match_prefix(
+            MatchPrefixParams(
+                key=self._key([1, 2, 3, 4, 5, 6]),
+                req=SimpleNamespace(rid="maintenance", session=None),
+                pin_dflash_restore=False,
+            )
+        )
+
+        self.assertEqual(result.device_indices.numel(), 6)
+        self.assertIsNone(self.component.get_match_plan("maintenance"))
+        self.assertEqual(
+            self.cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+
+    def test_partial_draft_maintenance_rematch_preserves_full_ownership(self):
+        req_to_token_pool = ReqToTokenPool(
+            size=4,
+            max_context_len=32,
+            device="cpu",
+            enable_memory_saver=False,
+        )
+        content_allocator = DFlashDraftContentAllocator(start=100, size=3, device="cpu")
+        cache = UnifiedRadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=req_to_token_pool,
+                token_to_kv_pool_allocator=self.full_allocator,
+                page_size=1,
+                tree_components=(
+                    ComponentType.FULL,
+                    ComponentType.DRAFT,
+                    ComponentType.MAMBA,
+                ),
+                component_registry_override={
+                    ComponentType.MAMBA: _CachingCheckpointBoundaryComponent
+                },
+                dflash_draft_content_allocator=content_allocator,
+                dflash_draft_window_size=4,
+            )
+        )
+
+        prompt = array("q", [1, 2, 3, 4, 5, 6])
+        req = Req(
+            rid="partial-draft-owner",
+            origin_input_text="",
+            origin_input_ids=prompt,
+            sampling_params=SamplingParams(temperature=0, max_new_tokens=2),
+        )
+        req_to_token_pool.alloc([req])
+        req.full_untruncated_fill_ids = prompt
+        req.set_extend_range(0, len(prompt))
+        req.last_node = cache.root_node_handle()
+        req.cache_protected_len = 0
+        req.swa_uuid_for_lock = None
+        req.extra_key = None
+        prompt_rows = self.full_allocator.alloc(len(prompt))
+        req_to_token_pool.write((req.req_pool_idx, slice(0, len(prompt))), prompt_rows)
+        req.kv_committed_len = len(prompt)
+
+        draft_rows = cache.alloc_dflash_draft_content(3)
+        cache.stage_dflash_draft_publish(req.rid, 3, draft_rows)
+        cache.cache_unfinished_req(req)
+
+        self.assertEqual(req.cache_protected_len, len(prompt))
+        torch.testing.assert_close(req.prefix_indices, prompt_rows)
+        self.assertEqual(cache.full_protected_size(), len(prompt))
+
+        # Admission still requires a complete trailing draft window.  Only the
+        # internal ownership rematch is allowed to ignore DRAFT coverage.
+        admission = cache.match_prefix(
+            MatchPrefixParams(
+                key=self._key(prompt),
+                req=SimpleNamespace(rid="partial-admission", session=None),
+            )
+        )
+        self.assertEqual(admission.device_indices.numel(), 0)
+
+        req.output_ids = array("q", [7, 8])
+        req.full_untruncated_fill_ids = prompt + req.output_ids
+        req.set_extend_range(len(prompt), len(req.full_untruncated_fill_ids))
+        output_rows = self.full_allocator.alloc(len(req.output_ids))
+        req_to_token_pool.write(
+            (
+                req.req_pool_idx,
+                slice(len(prompt), len(req.full_untruncated_fill_ids)),
+            ),
+            output_rows,
+        )
+        req.kv_committed_len = len(req.full_untruncated_fill_ids)
+        cache.cache_finished_req(
+            req, is_insert=True, kv_len_to_handle=req.kv_committed_len
+        )
+
+        all_rows = torch.cat([prompt_rows, output_rows])
+        self.assertEqual(self.full_allocator.available_size(), 64 - len(all_rows))
+        self.assertEqual(cache.full_evictable_size(), len(all_rows))
+        self.assertEqual(cache.full_protected_size(), 0)
+        self.assertFalse(
+            bool(torch.any(torch.isin(all_rows, self.full_allocator.free_pages)))
+        )
+        cache.sanity_check()
+
+    def test_later_component_finalizer_failure_releases_restore_pin(self):
+        cache = UnifiedRadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=ReqToTokenPool(
+                    size=4,
+                    max_context_len=32,
+                    device="cpu",
+                    enable_memory_saver=False,
+                ),
+                token_to_kv_pool_allocator=self.full_allocator,
+                page_size=1,
+                tree_components=(
+                    ComponentType.FULL,
+                    ComponentType.DRAFT,
+                    ComponentType.MAMBA,
+                ),
+                component_registry_override={
+                    ComponentType.MAMBA: _FailingFinalizeComponent
+                },
+                dflash_draft_content_allocator=self.content_allocator,
+                dflash_draft_window_size=4,
+            )
+        )
+        component = cache.components[ComponentType.DRAFT]
+        draft_rows = self.content_allocator.alloc(4)
+        self.content_allocator.claim_lease(draft_rows)
+        params = InsertParams(
+            key=self._key([1, 2, 3, 4, 5, 6]),
+            value=self.full_allocator.alloc(6),
+            mamba_value=torch.tensor([1]),
+            draft_value=draft_rows,
+            draft_start_seqlen=2,
+            draft_processed=torch.zeros(4, dtype=torch.bool),
+        )
+        cache.insert(params)
+        component.cleanup_pending_rows(params)
+
+        with self.assertRaisesRegex(RuntimeError, "injected Mamba"):
+            cache.match_prefix(
+                MatchPrefixParams(
+                    key=self._key([1, 2, 3, 4, 5, 6]),
+                    req=SimpleNamespace(rid="finalizer-error", session=None),
+                )
+            )
+        self.assertIsNone(component.get_match_plan("finalizer-error"))
+        self.assertEqual(
+            cache.tree_core.component_protected_size_[ComponentType.DRAFT], 0
+        )
+
+    def test_cache_prepare_failure_returns_finished_and_unfinished_rows(self):
+        for is_finished in (False, True):
+            content_allocator = DFlashDraftContentAllocator(
+                start=100, size=8, device="cpu"
+            )
+            req_pool = ReqToTokenPool(
+                size=2,
+                max_context_len=32,
+                device="cpu",
+                enable_memory_saver=False,
+            )
+            cache = UnifiedRadixCache(
+                CacheInitParams(
+                    disable=False,
+                    req_to_token_pool=req_pool,
+                    token_to_kv_pool_allocator=self.full_allocator,
+                    page_size=1,
+                    tree_components=(
+                        ComponentType.FULL,
+                        ComponentType.DRAFT,
+                        ComponentType.MAMBA,
+                    ),
+                    component_registry_override={
+                        ComponentType.MAMBA: _FailingPrepareComponent
+                    },
+                    dflash_draft_content_allocator=content_allocator,
+                    dflash_draft_window_size=4,
+                )
+            )
+            full_rows = self.full_allocator.alloc(4)
+            req_pool.req_to_token[1, :4] = full_rows
+            req = SimpleNamespace(
+                rid=f"prepare-error-{is_finished}",
+                session=None,
+                req_pool_idx=1,
+                cache_protected_len=0,
+                priority=0,
+                extra_key=None,
+                cache_salt=None,
+                origin_input_ids=[1, 2, 3, 4],
+                output_ids=[],
+                get_fill_ids=lambda: [1, 2, 3, 4],
+            )
+            rows = cache.alloc_dflash_draft_content(4)
+            cache.stage_dflash_draft_publish(req.rid, 0, rows)
+
+            with self.assertRaisesRegex(RuntimeError, "injected Mamba prepare"):
+                if is_finished:
+                    cache.cache_finished_req(req, is_insert=True, kv_len_to_handle=4)
+                else:
+                    cache.cache_unfinished_req(req)
+            self.assertEqual(content_allocator.available_size(), 8)
+
+    def test_full_mamba_draft_common_boundary_never_overreports(self):
+        cache = UnifiedRadixCache(
+            CacheInitParams(
+                disable=False,
+                req_to_token_pool=ReqToTokenPool(
+                    size=4,
+                    max_context_len=32,
+                    device="cpu",
+                    enable_memory_saver=False,
+                ),
+                token_to_kv_pool_allocator=self.full_allocator,
+                page_size=1,
+                tree_components=(
+                    ComponentType.FULL,
+                    ComponentType.DRAFT,
+                    ComponentType.MAMBA,
+                ),
+                component_registry_override={
+                    ComponentType.MAMBA: _CheckpointBoundaryComponent
+                },
+                dflash_draft_content_allocator=self.content_allocator,
+                dflash_draft_window_size=4,
+            )
+        )
+        component = cache.components[ComponentType.DRAFT]
+
+        def insert(tokens, *, draft_start, has_mamba):
+            draft_rows = self.content_allocator.alloc(len(tokens) - draft_start)
+            self.content_allocator.claim_lease(draft_rows)
+            params = InsertParams(
+                key=self._key(tokens),
+                value=self.full_allocator.alloc(len(tokens)),
+                mamba_value=torch.tensor([1]) if has_mamba else None,
+                draft_value=draft_rows,
+                draft_start_seqlen=draft_start,
+                draft_processed=torch.zeros(len(draft_rows), dtype=torch.bool),
+            )
+            cache.insert(params)
+            component.cleanup_pending_rows(params)
+
+        insert([1, 2, 3, 4, 5, 6], draft_start=2, has_mamba=True)
+        hit = cache.match_prefix(
+            MatchPrefixParams(
+                key=self._key([1, 2, 3, 4, 5, 6]),
+                req=SimpleNamespace(rid="all", session=None),
+            )
+        )
+        self.assertEqual(hit.device_indices.numel(), 6)
+        component.release_match_pin("all")
+
+        insert([1, 2, 3, 4, 9, 10], draft_start=2, has_mamba=False)
+        missing_mamba = cache.match_prefix(
+            MatchPrefixParams(
+                key=self._key([1, 2, 3, 4, 9, 10]),
+                req=SimpleNamespace(rid="missing-mamba", session=None),
+            )
+        )
+        self.assertEqual(missing_mamba.device_indices.numel(), 0)
+        maintenance_missing_mamba = cache.match_prefix(
+            MatchPrefixParams(
+                key=self._key([1, 2, 3, 4, 9, 10]),
+                req=SimpleNamespace(rid="maintenance-missing-mamba", session=None),
+                pin_dflash_restore=False,
+                require_dflash_draft=False,
+            )
+        )
+        self.assertEqual(maintenance_missing_mamba.device_indices.numel(), 0)
+
+        insert([7, 8, 9, 10, 11, 12], draft_start=3, has_mamba=True)
+        missing_draft = cache.match_prefix(
+            MatchPrefixParams(
+                key=self._key([7, 8, 9, 10, 11, 12]),
+                req=SimpleNamespace(rid="missing-draft", session=None),
+            )
+        )
+        self.assertEqual(missing_draft.device_indices.numel(), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/mem_cache/test_registry.py
+++ b/test/registered/unit/mem_cache/test_registry.py
@@ -5,17 +5,21 @@ from sglang.test.ci.ci_register import register_cpu_ci
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 import unittest
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
+from sglang.srt.mem_cache.cache_init_params import CacheInitParams
 from sglang.srt.mem_cache.registry import (
     _RADIX_CACHE_REGISTRY,
     TreeCacheBuildContext,
+    _attach_qwen_dflash_draft_component,
     create_tree_cache,
     default_radix_cache_factory,
     get_radix_cache_factory,
     register_radix_cache_backend,
     registered_radix_cache_backends,
 )
+from sglang.srt.mem_cache.unified_cache.component_type import ComponentType
 from sglang.test.test_utils import CustomTestCase
 
 
@@ -172,6 +176,80 @@ class TestDefaultRadixCacheFactory(CustomTestCase):
     the class at its definition site to verify routing without depending
     on each cache's real constructor or runtime state.
     """
+
+    def test_qwen_dflash_sidecar_binds_exact_content_subrange(self):
+        params = CacheInitParams(
+            disable=False,
+            req_to_token_pool=None,
+            token_to_kv_pool_allocator=SimpleNamespace(device="cpu"),
+            page_size=1,
+        )
+        ctx = SimpleNamespace(
+            tp_worker=SimpleNamespace(
+                model_runner=SimpleNamespace(
+                    spec_aux_config=SimpleNamespace(
+                        dflash_radix_sidecar_tokens=5,
+                        dflash_compact_owner_count=2,
+                    )
+                )
+            ),
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(model_type="qwen3_5_text")
+            ),
+            server_args=SimpleNamespace(enable_unified_memory=False),
+            is_hybrid_ssm=True,
+            is_hybrid_swa=False,
+            disable_radix_cache=False,
+            enable_hierarchical_cache=False,
+        )
+        components = [ComponentType.FULL, ComponentType.MAMBA]
+        with patch(
+            "sglang.srt.mem_cache.registry.get_spec",
+            return_value=SimpleNamespace(
+                speculative_draft_window_size=4,
+                speculative_num_draft_tokens=2,
+            ),
+        ):
+            _attach_qwen_dflash_draft_component(ctx, params, components)
+
+        self.assertEqual(
+            components,
+            [ComponentType.FULL, ComponentType.DRAFT, ComponentType.MAMBA],
+        )
+        self.assertEqual(params.dflash_draft_window_size, 4)
+        allocator = params.dflash_draft_content_allocator
+        self.assertEqual(allocator.size, 5)
+        self.assertGreater(allocator.start, 0)
+
+    def test_qwen_dflash_sidecar_rejects_non_qwen_target(self):
+        params = CacheInitParams(
+            disable=False,
+            req_to_token_pool=None,
+            token_to_kv_pool_allocator=SimpleNamespace(device="cpu"),
+            page_size=1,
+        )
+        ctx = SimpleNamespace(
+            tp_worker=SimpleNamespace(
+                model_runner=SimpleNamespace(
+                    spec_aux_config=SimpleNamespace(
+                        dflash_radix_sidecar_tokens=4,
+                        dflash_compact_owner_count=1,
+                    )
+                )
+            ),
+            model_config=SimpleNamespace(
+                hf_text_config=SimpleNamespace(model_type="other")
+            ),
+            server_args=SimpleNamespace(enable_unified_memory=False),
+            is_hybrid_ssm=True,
+            is_hybrid_swa=False,
+            disable_radix_cache=False,
+            enable_hierarchical_cache=False,
+        )
+        with self.assertRaisesRegex(ValueError, "target model_type"):
+            _attach_qwen_dflash_draft_component(
+                ctx, params, [ComponentType.FULL, ComponentType.MAMBA]
+            )
 
     def test_chunk_cache_when_chunked_prefill_and_disable_radix(self):
         ctx = _make_ctx(

--- a/test/registered/unit/model_executor/test_pool_configurator.py
+++ b/test/registered/unit/model_executor/test_pool_configurator.py
@@ -172,6 +172,7 @@ def _make_model_runner(
         eagle_draft_num_layers=None,
         eagle_draft_swa_num_layers=None,
         dflash_draft_num_layers=None,
+        dflash_draft_fixed_bytes=0,
     )
 
     return mr
@@ -975,6 +976,43 @@ class TestDflashDraftKvBudget(CustomTestCase):
                     cfg._cell_size,
                     target_kv_per_token + draft_kv_per_token * dcp_size,
                 )
+
+        mr.spec_aux_config.dflash_draft_cell_size_per_token = 0
+        with mock_cpu_env():
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            compact_cfg = create_memory_pool_configurator(mr)
+        self.assertEqual(compact_cfg._cell_size, target_kv_per_token)
+
+    def test_compact_fixed_pool_is_subtracted_before_target_solver(self):
+        fixed_draft_bytes = 42_608_640
+        target_tokens = 10_000
+        mr = _make_model_runner(self)
+        mr.spec_algorithm.is_dflash_family.return_value = True
+        mr.spec_aux_config = SimpleNamespace(
+            eagle_draft_num_layers=None,
+            dflash_draft_num_layers=5,
+            dflash_draft_cell_size_per_token=0,
+            dflash_draft_fixed_bytes=fixed_draft_bytes,
+        )
+        target_kv_per_token = 4 * (64 + 64) * 32 * KV_SIZE
+        available = fixed_draft_bytes + target_tokens * target_kv_per_token
+
+        with mock_cpu_env():
+            from sglang.srt.model_executor.pool_configurator import (
+                create_memory_pool_configurator,
+            )
+
+            cfg = create_memory_pool_configurator(mr)
+            config = cfg.calculate_pool_sizes(available, page_size=1)
+
+        self.assertEqual(cfg._cell_size, target_kv_per_token)
+        self.assertEqual(cfg._fixed_bytes, fixed_draft_bytes)
+        self.assertEqual(config.max_total_num_tokens, target_tokens)
+        with self.assertRaisesRegex(RuntimeError, "leaves no memory"):
+            cfg.calculate_pool_sizes(fixed_draft_bytes, page_size=1)
 
     def test_hybrid_swa_budget_shrinks_by_draft_pool(self):
         """HybridSWA carried no draft term, so the draft pool fell outside the budget."""

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1612,6 +1612,37 @@ class TestNgramExternalSamArgs(CustomTestCase):
         self.assertIn("external-corpus-max-tokens", str(context.exception))
 
 
+class TestDFlashCompactCacheArgs(CustomTestCase):
+    def test_compact_cache_cli_round_trip(self):
+        args = prepare_server_args(
+            [
+                "--model-path",
+                "dummy",
+                "--speculative-dflash-compact-cache",
+                "--speculative-draft-window-size",
+                "2048",
+            ]
+        )
+        self.assertTrue(args.speculative_dflash_compact_cache)
+        self.assertEqual(args.speculative_draft_window_size, 2048)
+
+    def test_compact_cache_requires_dflash(self):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = "EAGLE"
+        args.speculative_dflash_compact_cache = True
+        args.speculative_draft_window_size = 2048
+        with self.assertRaisesRegex(ValueError, "requires.*DFLASH"):
+            handle_speculative_decoding(args)
+
+    def test_compact_cache_requires_window(self):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = "DFLASH"
+        args.speculative_dflash_compact_cache = True
+        args.speculative_draft_window_size = None
+        with self.assertRaisesRegex(ValueError, "requires.*draft-window-size"):
+            handle_speculative_decoding(args)
+
+
 class TestDecoupledSpecArgs(CustomTestCase):
     """Decoupled speculative-decoding CLI flags.
 

--- a/test/registered/unit/server_args/test_server_args.py
+++ b/test/registered/unit/server_args/test_server_args.py
@@ -1621,10 +1621,13 @@ class TestDFlashCompactCacheArgs(CustomTestCase):
                 "--speculative-dflash-compact-cache",
                 "--speculative-draft-window-size",
                 "2048",
+                "--speculative-dflash-radix-sidecar-tokens",
+                "4097",
             ]
         )
         self.assertTrue(args.speculative_dflash_compact_cache)
         self.assertEqual(args.speculative_draft_window_size, 2048)
+        self.assertEqual(args.speculative_dflash_radix_sidecar_tokens, 4097)
 
     def test_compact_cache_requires_dflash(self):
         args = ServerArgs(model_path="dummy")
@@ -1641,6 +1644,42 @@ class TestDFlashCompactCacheArgs(CustomTestCase):
         args.speculative_draft_window_size = None
         with self.assertRaisesRegex(ValueError, "requires.*draft-window-size"):
             handle_speculative_decoding(args)
+
+    def test_dflash_radix_sidecar_defaults_off(self):
+        args = ServerArgs(model_path="dummy")
+        self.assertEqual(args.speculative_dflash_radix_sidecar_tokens, 0)
+
+    def test_dflash_radix_sidecar_rejects_negative_cap(self):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_dflash_radix_sidecar_tokens = -1
+        with self.assertRaisesRegex(ValueError, "must be nonnegative"):
+            handle_speculative_decoding(args)
+
+    def test_dflash_radix_sidecar_requires_compact_cache(self):
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = "DFLASH"
+        args.speculative_draft_window_size = 2048
+        args.speculative_dflash_radix_sidecar_tokens = 4096
+        with self.assertRaisesRegex(ValueError, "requires.*compact-cache"):
+            handle_speculative_decoding(args)
+
+    def test_dflash_radix_sidecar_accepts_confirmed_interface(self):
+        args = ServerArgs(model_path="dummy")
+        args.device = "cuda"
+        args.speculative_algorithm = "DFLASH"
+        args.speculative_draft_model_path = "dummy-draft"
+        args.speculative_num_draft_tokens = 8
+        args.speculative_draft_window_size = 2048
+        args.speculative_dflash_compact_cache = True
+        args.speculative_dflash_radix_sidecar_tokens = 4096
+
+        with patch(
+            "sglang.srt.arg_groups.speculative_hook._resolve_speculative_algorithm_alias",
+            return_value="DFLASH",
+        ):
+            handle_speculative_decoding(args)
+
+        self.assertEqual(args.speculative_dflash_radix_sidecar_tokens, 4096)
 
 
 class TestDecoupledSpecArgs(CustomTestCase):

--- a/test/registered/unit/spec/test_dflash_compact_physical_layout.py
+++ b/test/registered/unit/spec/test_dflash_compact_physical_layout.py
@@ -1,0 +1,218 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.disaggregation.decode import DecodeReqToTokenPool
+from sglang.srt.mem_cache.memory_pool import ReqToTokenPool
+from sglang.srt.model_executor.model_runner_components import spec_aux_hidden_state
+from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state import (
+    _compact_dflash_fixed_bytes,
+    _compact_dflash_linear_budget,
+)
+from sglang.srt.speculative.dflash_compact_physical_layout import (
+    CompactDFlashPhysicalLayout,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _layout(*, owners=2, window=2048, block=8, page=1):
+    return CompactDFlashPhysicalLayout.build(
+        owner_count=owners,
+        window_size=window,
+        block_size=block,
+        page_size=page,
+    )
+
+
+def _enable_compact_budget(monkeypatch):
+    monkeypatch.setattr(
+        spec_aux_hidden_state,
+        "get_spec",
+        lambda: SimpleNamespace(speculative_dflash_compact_cache=True),
+    )
+
+
+def test_tp2_geometry_and_fixed_bytes(monkeypatch):
+    value = _layout()
+    assert value.guard_rows == 16
+    assert value.scratch_rows == 16
+    assert value.owner_span == 2080
+    assert value.physical_tokens == 4160
+
+    _enable_compact_budget(monkeypatch)
+    assert _compact_dflash_linear_budget(10_240) == 0
+    assert (
+        _compact_dflash_fixed_bytes(
+            10_240,
+            owner_count=2,
+            window_size=2048,
+            block_size=8,
+            page_size=1,
+        )
+        == 42_608_640
+    )
+
+
+def test_fixed_bytes_include_one_sentinel_page(monkeypatch):
+    _enable_compact_budget(monkeypatch)
+    layout = _layout(owners=3, window=2048, block=8, page=1)
+    assert (
+        _compact_dflash_fixed_bytes(
+            10_240,
+            owner_count=3,
+            window_size=2048,
+            block_size=8,
+            page_size=1,
+        )
+        == (layout.physical_tokens + 1) * 10_240
+    )
+
+
+def test_fixed_budget_rejects_paged_modulo_aliasing(monkeypatch):
+    _enable_compact_budget(monkeypatch)
+    with pytest.raises(RuntimeError, match="requires page_size=1"):
+        _compact_dflash_fixed_bytes(
+            10_240,
+            owner_count=3,
+            window_size=2048,
+            block_size=8,
+            page_size=16,
+        )
+
+
+def test_owner_budget_uses_local_attention_dp_and_decode_extra_slots(monkeypatch):
+    monkeypatch.setattr(
+        spec_aux_hidden_state,
+        "get_schedule",
+        lambda: SimpleNamespace(max_running_requests=8),
+    )
+    monkeypatch.setattr(
+        spec_aux_hidden_state,
+        "get_disagg",
+        lambda: SimpleNamespace(
+            disaggregation_mode="decode", disaggregation_decode_extra_slots=3
+        ),
+    )
+    assert spec_aux_hidden_state._compact_dflash_owner_count(attn_dp_size=2) == 7
+
+
+@pytest.mark.parametrize("max_running_requests", [None, 7])
+def test_owner_budget_rejects_unresolved_or_uneven_geometry(
+    monkeypatch, max_running_requests
+):
+    monkeypatch.setattr(
+        spec_aux_hidden_state,
+        "get_schedule",
+        lambda: SimpleNamespace(max_running_requests=max_running_requests),
+    )
+    with pytest.raises(RuntimeError, match="max_running_requests"):
+        spec_aux_hidden_state._compact_dflash_owner_count(attn_dp_size=2)
+
+
+@pytest.mark.parametrize("page_size", [1, 2, 4, 8, 16])
+@pytest.mark.parametrize("owner_count", [1, 2, 7])
+def test_regions_are_bounded_disjoint_and_periodic(page_size, owner_count):
+    value = _layout(owners=owner_count, window=32, block=8, page=page_size)
+    all_regions = []
+    for owner in range(1, owner_count + 1):
+        positions = torch.arange(32)
+        owners = torch.full_like(positions, owner)
+        committed = value.committed_locs(owners, positions)
+        assert torch.equal(committed, value.committed_locs(owners, positions + 352))
+        scratch = value.scratch_locs(torch.tensor([owner]), 8).reshape(-1)
+        region = torch.cat((committed, scratch))
+        assert torch.unique(region).numel() == region.numel()
+        assert 0 <= int(region.min()) <= int(region.max()) < value.physical_tokens
+        all_regions.append(region)
+    combined = torch.cat(all_regions)
+    assert torch.unique(combined).numel() == combined.numel()
+
+
+def test_generation_reuse_fails_closed_and_explicit_rebind_is_counted():
+    value = _layout()
+    owner_generation = torch.zeros(3, dtype=torch.int64)
+    current = torch.tensor([0, 3, 9], dtype=torch.int64)
+    assert (
+        value.bind_first_use_or_assert_generation(
+            torch.tensor([1, 2]),
+            owner_generation,
+            current,
+            torch.tensor([3, 9]),
+            torch.tensor([True, True]),
+        )
+        == 0
+    )
+    current[1] += 1
+    with pytest.raises(RuntimeError, match="generation mismatch"):
+        value.bind_first_use_or_assert_generation(
+            torch.tensor([1]),
+            owner_generation,
+            current,
+            torch.tensor([3]),
+            torch.tensor([False]),
+        )
+    assert (
+        value.bind_first_use_or_assert_generation(
+            torch.tensor([1]),
+            owner_generation,
+            current,
+            torch.tensor([4]),
+            torch.tensor([True]),
+        )
+        == 1
+    )
+
+
+def test_request_generation_is_monotonic_across_clear():
+    pool = ReqToTokenPool(
+        size=1, max_context_len=4, device="cpu", enable_memory_saver=False
+    )
+    first = SimpleNamespace(req_pool_idx=None)
+    assert pool.alloc([first]) == [1]
+    first_generation = int(pool.req_generation[1])
+    pool.clear()
+    second = SimpleNamespace(req_pool_idx=None)
+    assert pool.alloc([second]) == [1]
+    assert int(pool.req_generation[1]) == first_generation + 1
+
+
+def test_decode_request_generation_is_monotonic_across_clear():
+    pool = DecodeReqToTokenPool(
+        size=1,
+        max_context_len=4,
+        device="cpu",
+        enable_memory_saver=False,
+        pre_alloc_size=0,
+    )
+    first = SimpleNamespace(req_pool_idx=None)
+    assert pool.alloc([first]) == [1]
+    first_generation = int(pool.req_generation[1])
+    pool.clear()
+    second = SimpleNamespace(req_pool_idx=None)
+    assert pool.alloc([second]) == [1]
+    assert int(pool.req_generation[1]) == first_generation + 1
+
+
+def test_invalid_geometry_fails_closed(monkeypatch):
+    _enable_compact_budget(monkeypatch)
+    with pytest.raises(RuntimeError, match="resolved positive geometry"):
+        _compact_dflash_fixed_bytes(
+            10_240,
+            owner_count=None,
+            window_size=2048,
+            block_size=8,
+            page_size=1,
+        )
+    with pytest.raises(ValueError):
+        _layout(owners=1, window=2049, block=8, page=16)
+    with pytest.raises(ValueError, match="cover one complete DFlash commit block"):
+        _layout(owners=1, window=4, block=8, page=1)
+
+
+def test_window_equal_to_commit_block_has_unique_rows():
+    layout = _layout(owners=1, window=8, block=8, page=1)
+    locs = layout.committed_locs(torch.ones(8), torch.arange(8))
+    assert torch.unique(locs).numel() == 8

--- a/test/registered/unit/spec/test_dflash_compact_physical_layout.py
+++ b/test/registered/unit/spec/test_dflash_compact_physical_layout.py
@@ -13,17 +13,21 @@ from sglang.srt.model_executor.model_runner_components.spec_aux_hidden_state imp
 from sglang.srt.speculative.dflash_compact_physical_layout import (
     CompactDFlashPhysicalLayout,
 )
+from sglang.srt.speculative.dflash_draft_content_allocator import (
+    DFlashDraftContentAllocator,
+)
 from sglang.test.ci.ci_register import register_cpu_ci
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
 
 
-def _layout(*, owners=2, window=2048, block=8, page=1):
+def _layout(*, owners=2, window=2048, block=8, page=1, content=0):
     return CompactDFlashPhysicalLayout.build(
         owner_count=owners,
         window_size=window,
         block_size=block,
         page_size=page,
+        content_tokens=content,
     )
 
 
@@ -69,6 +73,63 @@ def test_fixed_bytes_include_one_sentinel_page(monkeypatch):
         )
         == (layout.physical_tokens + 1) * 10_240
     )
+
+
+def test_content_region_is_page_aligned_disjoint_and_budgeted(monkeypatch):
+    layout = _layout(owners=2, window=32, block=8, page=4, content=13)
+    assert layout.content_start == layout.request_tokens
+    assert layout.content_tokens == 16
+    assert layout.content_end == layout.physical_tokens
+
+    request_rows = torch.cat(
+        (
+            layout.committed_locs(torch.ones(32), torch.arange(32)),
+            layout.scratch_locs(torch.tensor([1]), 8).reshape(-1),
+        )
+    )
+    content_rows = torch.arange(layout.content_start, layout.content_end)
+    assert not bool(torch.isin(request_rows, content_rows).any())
+    layout.assert_content_locs(content_rows)
+    with pytest.raises(RuntimeError, match="content loc OOB"):
+        layout.assert_content_locs(request_rows[:1])
+
+    _enable_compact_budget(monkeypatch)
+    assert (
+        _compact_dflash_fixed_bytes(
+            32,
+            owner_count=2,
+            window_size=32,
+            block_size=8,
+            page_size=1,
+            content_tokens=13,
+        )
+        == (_layout(owners=2, window=32, block=8, content=13).physical_tokens + 1) * 32
+    )
+
+
+def test_content_allocator_exhaustion_free_double_free_and_clear():
+    allocator = DFlashDraftContentAllocator(start=100, size=5, device="cpu")
+    first = allocator.alloc(3)
+    second = allocator.alloc(2)
+    assert first.tolist() == [100, 101, 102]
+    assert second.tolist() == [103, 104]
+    assert allocator.available_size() == 0
+    assert allocator.alloc(1) is None
+    allocator.assert_allocated(torch.tensor([100, 104]))
+
+    allocator.free(torch.tensor([101, 103]))
+    assert allocator.available_size() == 2
+    with pytest.raises(RuntimeError, match="freed twice"):
+        allocator.free(torch.tensor([101]))
+    with pytest.raises(RuntimeError, match="outside allocator range"):
+        allocator.free(torch.tensor([99]))
+
+    reused = allocator.alloc(2)
+    assert reused.tolist() == [101, 103]
+    allocator.clear()
+    assert allocator.available_size() == 5
+    with pytest.raises(RuntimeError, match="unallocated row"):
+        allocator.assert_allocated(torch.tensor([100]))
 
 
 def test_fixed_budget_rejects_paged_modulo_aliasing(monkeypatch):

--- a/test/registered/unit/spec/test_dflash_compact_worker_runtime.py
+++ b/test/registered/unit/spec/test_dflash_compact_worker_runtime.py
@@ -1,0 +1,366 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.speculative.dflash_compact_physical_layout import (
+    CompactDFlashPhysicalLayout,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+def _worker_module():
+    from sglang.srt.speculative import dflash_worker_v2
+
+    return dflash_worker_v2
+
+
+def _bare_worker(*, target_table: torch.Tensor, draft_table: torch.Tensor):
+    worker_mod = _worker_module()
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._target_worker = SimpleNamespace()
+    worker.device = torch.device("cpu")
+    worker.model_runner = SimpleNamespace(
+        req_to_token_pool=SimpleNamespace(req_to_token=target_table)
+    )
+    worker.draft_model_runner = SimpleNamespace(
+        req_to_token_pool=SimpleNamespace(req_to_token=draft_table)
+    )
+    worker._draft_block_end_buf = torch.empty(2, dtype=torch.int32)
+    return worker
+
+
+def _assign_req_to_token_cpu(
+    req_pool_indices,
+    req_to_token,
+    start_offset,
+    end_offset,
+    out_cache_loc,
+    batch_size,
+):
+    """Small CPU stand-in for the runtime kernel, including ragged packing."""
+    packed_offset = 0
+    for batch_idx in range(batch_size):
+        req_idx = int(req_pool_indices[batch_idx])
+        start = int(start_offset[batch_idx])
+        end = int(end_offset[batch_idx])
+        length = end - start
+        req_to_token[req_idx, start:end].copy_(
+            out_cache_loc[packed_offset : packed_offset + length].to(req_to_token.dtype)
+        )
+        packed_offset += length
+    assert packed_offset == out_cache_loc.numel()
+
+
+@pytest.mark.parametrize(
+    ("prefix_lens", "extend_lens", "window_size", "expected"),
+    [
+        ([0], [6], 8, [(0, 0, 6, 0)]),
+        ([0], [12], 8, [(0, 4, 12, 4)]),
+        (
+            [0, 0],
+            [4, 12],
+            8,
+            [(0, 0, 4, 0), (1, 8, 16, 4)],
+        ),
+    ],
+)
+def test_compact_prefill_visible_segments_slice_packed_prompt_suffix(
+    prefix_lens, extend_lens, window_size, expected
+):
+    worker_mod = _worker_module()
+
+    assert (
+        worker_mod._compact_prefill_visible_segments(
+            prefix_lens, extend_lens, window_size
+        )
+        == expected
+    )
+
+
+def test_compact_prefill_chunk_crosses_ring_wrap_with_absolute_positions():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1, window_size=8, block_size=4, page_size=1
+    )
+
+    first = worker_mod._compact_prefill_visible_segments([0], [6], 8)
+    second = worker_mod._compact_prefill_visible_segments([6], [6], 8)
+    assert first == [(0, 0, 6, 0)]
+    assert second == [(0, 0, 6, 6)]
+
+    _, packed_start, packed_end, absolute_start = second[0]
+    positions = torch.arange(
+        absolute_start,
+        absolute_start + packed_end - packed_start,
+        dtype=torch.int64,
+    )
+    owners = torch.ones_like(positions)
+    torch.testing.assert_close(
+        layout.committed_locs(owners, positions),
+        torch.tensor([14, 15, 8, 9, 10, 11]),
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_commit_accept_covers_zero_accept_and_full_commit_block():
+    worker_mod = _worker_module()
+    candidates = torch.tensor([[10, 11, 12, 13], [20, 21, 22, 23]])
+
+    out_tokens, commit_lens = worker_mod._commit_accept(
+        candidates,
+        accept_len=torch.tensor([0, 3]),
+        bonus_tokens=torch.tensor([90, 99]),
+    )
+
+    torch.testing.assert_close(commit_lens, torch.tensor([1, 4], dtype=torch.int32))
+    torch.testing.assert_close(
+        out_tokens,
+        torch.tensor([[90, 12, 13, 0], [21, 22, 23, 99]]),
+    )
+
+
+def test_compact_verify_locs_and_prefix_valid_writer_keep_zero_and_full_lens():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2, window_size=8, block_size=4, page_size=1
+    )
+    owners = torch.tensor([1, 2], dtype=torch.int64)
+    positions_2d = torch.tensor([[6, 7, 8, 9], [14, 15, 16, 17]])
+    committed_locs = worker_mod._compact_verify_committed_locs(
+        layout, owners, positions_2d
+    )
+    torch.testing.assert_close(
+        committed_locs,
+        torch.tensor([[14, 15, 8, 9], [38, 39, 32, 33]]),
+        rtol=0,
+        atol=0,
+    )
+
+    class PrefixPool:
+        def __init__(self):
+            self.calls = []
+            self.written_locs = []
+
+        def set_kv_buffer_prefix_valid(
+            self, attn, cache_loc_2d, commit_lens, k, v, k_scale, v_scale
+        ):
+            self.calls.append((cache_loc_2d.clone(), commit_lens.clone(), k, v))
+            for row, commit_len in enumerate(commit_lens.tolist()):
+                self.written_locs.extend(cache_loc_2d[row, :commit_len].tolist())
+
+    pool = PrefixPool()
+    inner_attn = SimpleNamespace(k_scale=1.0, v_scale=1.0)
+    attn = SimpleNamespace(
+        attn=inner_attn,
+        num_kv_heads=1,
+        head_dim=2,
+        kv_proj_only=lambda hidden: (hidden, hidden + 100),
+        apply_k_norm=lambda k: k,
+        apply_k_rope=lambda positions, k: k,
+    )
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker.model_runner = SimpleNamespace(device=torch.device("cpu"))
+    worker.draft_model_runner = SimpleNamespace(token_to_kv_pool=pool)
+    worker.draft_model = SimpleNamespace(
+        layers=[SimpleNamespace(self_attn=attn)],
+        project_target_hidden=lambda hidden: hidden,
+        prepare_context_hidden_for_kv=lambda layer, hidden: hidden,
+    )
+    worker._use_fused_kv_materialize = False
+    worker._fused_kv_helper = None
+    commit_lens = torch.tensor([0, 4], dtype=torch.int32)
+
+    worker_mod.DFlashWorkerV2._append_target_hidden_to_draft_kv_by_loc(
+        worker,
+        target_hidden=torch.arange(16, dtype=torch.float32).view(8, 2),
+        cache_loc=committed_locs.reshape(-1),
+        cache_loc_2d=committed_locs,
+        positions=positions_2d.reshape(-1),
+        commit_lens=commit_lens,
+    )
+
+    assert len(pool.calls) == 1
+    torch.testing.assert_close(pool.calls[0][0], committed_locs)
+    torch.testing.assert_close(pool.calls[0][1], commit_lens)
+    assert pool.written_locs == committed_locs[1].tolist()
+
+
+def test_compact_rebuild_returns_scratch_and_writes_physical_mapping(monkeypatch):
+    worker_mod = _worker_module()
+    monkeypatch.setattr(
+        worker_mod, "assign_req_to_token_pool_func", _assign_req_to_token_cpu
+    )
+
+    target_table = torch.full((3, 16), -1, dtype=torch.int64)
+    draft_table = torch.full_like(target_table, -1)
+    worker = _bare_worker(target_table=target_table, draft_table=draft_table)
+    worker._compact_physical_layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2, window_size=8, block_size=2, page_size=1
+    )
+    worker._use_triton_compact_rebuild = False
+
+    req_pool_indices = torch.tensor([1, 2], dtype=torch.int64)
+    prefix_lens = torch.tensor([10, 9], dtype=torch.int32)
+    draft_prefix_lens = torch.tensor([4, 3], dtype=torch.int32)
+    verify_locs = torch.tensor([[901, 902], [903, 904]], dtype=torch.int64)
+
+    actual = worker_mod.DFlashWorkerV2._rebuild_compact_draft_cache(
+        worker,
+        req_pool_indices=req_pool_indices,
+        prefix_lens=prefix_lens,
+        draft_prefix_lens=draft_prefix_lens,
+        verify_out_cache_loc_2d=verify_locs,
+        bs=2,
+        block_size=2,
+    )
+
+    expected_scratch = worker._compact_physical_layout.scratch_locs(req_pool_indices, 2)
+    torch.testing.assert_close(actual, expected_scratch, rtol=0, atol=0)
+    torch.testing.assert_close(draft_table[1, :6], torch.tensor([10, 11, 4, 5, 12, 13]))
+    torch.testing.assert_close(draft_table[2, :5], torch.tensor([26, 27, 20, 28, 29]))
+    assert not torch.isin(verify_locs, draft_table).any()
+
+
+def test_compact_triton_rebuild_branch_is_sync_free_and_uses_static_geometry(
+    monkeypatch,
+):
+    worker_mod = _worker_module()
+    target_table = torch.full((3, 16), -1, dtype=torch.int64)
+    draft_table = torch.full_like(target_table, -1)
+    worker = _bare_worker(target_table=target_table, draft_table=draft_table)
+    worker._compact_physical_layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2, window_size=8, block_size=2, page_size=1
+    )
+    worker._use_triton_compact_rebuild = True
+    worker._draft_physical_out_cache_loc_buf = torch.empty((2, 2), dtype=torch.int64)
+    calls = []
+
+    def fake_rebuild(**kwargs):
+        calls.append(kwargs)
+        layout = worker._compact_physical_layout
+        for row in range(kwargs["batch_size"]):
+            owner = int(kwargs["req_pool_indices"][row])
+            start = int(kwargs["suffix_start"][row])
+            length = int(kwargs["draft_prefix_lens"][row])
+            positions = torch.arange(start, start + length)
+            owners = torch.full_like(positions, owner)
+            committed = layout.committed_locs(owners, positions)
+            scratch = layout.scratch_locs(torch.tensor([owner]), 2).view(-1)
+            draft_table[owner, : length + 2] = torch.cat((committed, scratch))
+            kwargs["physical_out_cache_loc_2d"][row].copy_(scratch)
+
+    monkeypatch.setattr(
+        worker_mod,
+        "rebuild_compact_physical_draft_req_to_token_func",
+        fake_rebuild,
+    )
+    req_pool_indices = torch.tensor([1, 2], dtype=torch.int64)
+    prefix_lens = torch.tensor([10, 9], dtype=torch.int32)
+    draft_prefix_lens = torch.tensor([4, 3], dtype=torch.int32)
+
+    actual = worker_mod.DFlashWorkerV2._rebuild_compact_draft_cache(
+        worker,
+        req_pool_indices=req_pool_indices,
+        prefix_lens=prefix_lens,
+        draft_prefix_lens=draft_prefix_lens,
+        verify_out_cache_loc_2d=torch.full((2, 2), -1, dtype=torch.int64),
+        bs=2,
+        block_size=2,
+    )
+
+    assert actual.data_ptr() == worker._draft_physical_out_cache_loc_buf.data_ptr()
+    assert len(calls) == 1
+    assert calls[0]["owner_span"] == worker._compact_physical_layout.owner_span
+    assert calls[0]["guard_rows"] == worker._compact_physical_layout.guard_rows
+    assert calls[0]["window_size"] == 8
+    torch.testing.assert_close(
+        actual,
+        worker._compact_physical_layout.scratch_locs(req_pool_indices, 2),
+    )
+
+
+def test_legacy_rebuild_returns_verify_locs_and_preserves_target_suffix(monkeypatch):
+    worker_mod = _worker_module()
+    monkeypatch.setattr(
+        worker_mod, "assign_req_to_token_pool_func", _assign_req_to_token_cpu
+    )
+
+    target_table = torch.stack(
+        (
+            torch.arange(16),
+            torch.arange(100, 116),
+            torch.arange(200, 216),
+        )
+    )
+    draft_table = torch.full((3, 16), -1, dtype=torch.int64)
+    worker = _bare_worker(target_table=target_table, draft_table=draft_table)
+    worker._compact_physical_layout = None
+    worker._use_triton_compact_rebuild = False
+
+    req_pool_indices = torch.tensor([1, 2], dtype=torch.int64)
+    prefix_lens = torch.tensor([10, 9], dtype=torch.int32)
+    draft_prefix_lens = torch.tensor([4, 3], dtype=torch.int32)
+    verify_locs = torch.tensor([[901, 902], [903, 904]], dtype=torch.int64)
+
+    actual = worker_mod.DFlashWorkerV2._rebuild_compact_draft_cache(
+        worker,
+        req_pool_indices=req_pool_indices,
+        prefix_lens=prefix_lens,
+        draft_prefix_lens=draft_prefix_lens,
+        verify_out_cache_loc_2d=verify_locs,
+        bs=2,
+        block_size=2,
+    )
+
+    assert actual is verify_locs
+    torch.testing.assert_close(
+        draft_table[1, :6], torch.tensor([106, 107, 108, 109, 901, 902])
+    )
+    torch.testing.assert_close(
+        draft_table[2, :5], torch.tensor([206, 207, 208, 903, 904])
+    )
+
+
+@pytest.mark.parametrize(
+    ("page_size", "disable_radix_cache", "message"),
+    [
+        (16, True, "requires page_size=1"),
+        (1, False, "requires --disable-radix-cache"),
+    ],
+)
+def test_compact_worker_rejects_unsafe_cache_geometry_before_draft_load(
+    monkeypatch, page_size, disable_radix_cache, message
+):
+    worker_mod = _worker_module()
+    monkeypatch.setattr(
+        worker_mod,
+        "get_schedule",
+        lambda: SimpleNamespace(page_size=page_size),
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "get_spec",
+        lambda: SimpleNamespace(
+            speculative_draft_window_size=2048,
+            speculative_dflash_compact_cache=True,
+        ),
+    )
+    monkeypatch.setattr(
+        worker_mod,
+        "get_memory",
+        lambda: SimpleNamespace(disable_radix_cache=disable_radix_cache),
+    )
+    target_worker = SimpleNamespace(model_runner=SimpleNamespace(), device="cpu")
+
+    with pytest.raises(RuntimeError, match=message):
+        worker_mod.DFlashWorkerV2(
+            server_args=SimpleNamespace(),
+            gpu_id=0,
+            ps=SimpleNamespace(),
+            nccl_port=1,
+            target_worker=target_worker,
+        )

--- a/test/registered/unit/spec/test_dflash_compact_worker_runtime.py
+++ b/test/registered/unit/spec/test_dflash_compact_worker_runtime.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 import pytest
 import torch
 
+from sglang.srt.model_executor.pool_configurator import MemoryPoolConfig
 from sglang.srt.speculative.dflash_compact_physical_layout import (
     CompactDFlashPhysicalLayout,
 )
@@ -29,6 +30,21 @@ def _bare_worker(*, target_table: torch.Tensor, draft_table: torch.Tensor):
         req_to_token_pool=SimpleNamespace(req_to_token=draft_table)
     )
     worker._draft_block_end_buf = torch.empty(2, dtype=torch.int32)
+    return worker
+
+
+def _bare_sidecar_worker(layout, *, project=None, move=None):
+    worker_mod = _worker_module()
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._compact_physical_layout = layout
+    worker.draft_window_size = layout.window_size
+    worker.device = torch.device("cpu")
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(
+            move_kv_cache=move or (lambda destination, source: None)
+        )
+    )
+    worker._append_target_hidden_to_draft_kv_by_loc = project or (lambda **kwargs: None)
     return worker
 
 
@@ -187,6 +203,781 @@ def test_compact_verify_locs_and_prefix_valid_writer_keep_zero_and_full_lens():
     torch.testing.assert_close(pool.calls[0][0], committed_locs)
     torch.testing.assert_close(pool.calls[0][1], commit_lens)
     assert pool.written_locs == committed_locs[1].tolist()
+
+
+def test_compact_radix_restore_copies_content_to_owner_and_releases_pin():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1,
+        window_size=4,
+        block_size=2,
+        page_size=1,
+        content_tokens=8,
+    )
+    moves = []
+    released = []
+    source = torch.arange(layout.content_start, layout.content_start + 4)
+    plan = SimpleNamespace(source_rows=source, matched_tokens=4)
+    tree_cache = SimpleNamespace(
+        get_dflash_draft_match_plan=lambda rid: plan if rid == "warm" else None,
+        release_dflash_draft_match_pin=lambda rid: released.append(rid),
+    )
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._compact_physical_layout = layout
+    worker.draft_window_size = 4
+    worker.device = torch.device("cpu")
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(
+            move_kv_cache=lambda dst, src: moves.append((dst.clone(), src.clone()))
+        )
+    )
+    batch = SimpleNamespace(
+        tree_cache=tree_cache,
+        reqs=[SimpleNamespace(rid="warm")],
+        prefix_lens=[6],
+        req_pool_indices=torch.tensor([1]),
+        acquire_owner_mask=torch.tensor([True]),
+    )
+
+    restored = worker_mod.DFlashWorkerV2._restore_compact_radix_prefix(worker, batch)
+
+    assert restored == 4
+    assert released == ["warm"]
+    assert len(moves) == 1
+    torch.testing.assert_close(moves[0][1], source)
+    torch.testing.assert_close(
+        moves[0][0],
+        layout.committed_locs(torch.ones(4, dtype=torch.int64), torch.arange(2, 6)),
+    )
+
+
+@pytest.mark.parametrize("bad_source", [False, True])
+def test_compact_radix_restore_coverage_or_range_failure_releases_pin(bad_source):
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1,
+        window_size=4,
+        block_size=2,
+        page_size=1,
+        content_tokens=4,
+    )
+    source = (
+        torch.arange(4)
+        if bad_source
+        else torch.arange(layout.content_start, layout.content_start + 3)
+    )
+    plan = SimpleNamespace(
+        source_rows=source,
+        matched_tokens=4 if bad_source else 3,
+    )
+    released = []
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._compact_physical_layout = layout
+    worker.draft_window_size = 4
+    worker.device = torch.device("cpu")
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(move_kv_cache=lambda dst, src: None)
+    )
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            get_dflash_draft_match_plan=lambda rid: plan,
+            release_dflash_draft_match_pin=lambda rid: released.append(rid),
+        ),
+        reqs=[SimpleNamespace(rid="bad")],
+        prefix_lens=[6],
+        req_pool_indices=torch.tensor([1]),
+        acquire_owner_mask=torch.tensor([True]),
+    )
+
+    message = "content loc OOB" if bad_source else "coverage mismatch"
+    with pytest.raises(RuntimeError, match=message):
+        worker_mod.DFlashWorkerV2._restore_compact_radix_prefix(worker, batch)
+    assert released == ["bad"]
+
+
+def test_compact_radix_restore_skips_continuing_owner_without_plan():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1,
+        window_size=4,
+        block_size=2,
+        page_size=1,
+        content_tokens=4,
+    )
+    moves = []
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._compact_physical_layout = layout
+    worker.draft_window_size = 4
+    worker.device = torch.device("cpu")
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(
+            move_kv_cache=lambda dst, src: moves.append((dst, src))
+        )
+    )
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            get_dflash_draft_match_plan=lambda rid: None,
+            release_dflash_draft_match_pin=lambda rid: None,
+        ),
+        reqs=[SimpleNamespace(rid="next-chunk")],
+        prefix_lens=[6],
+        req_pool_indices=torch.tensor([1]),
+        acquire_owner_mask=torch.tensor([False]),
+    )
+
+    assert worker_mod.DFlashWorkerV2._restore_compact_radix_prefix(worker, batch) == 0
+    assert not moves
+
+
+def test_compact_radix_restore_get_plan_failure_releases_every_batch_rid():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=3,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=6,
+    )
+    source = torch.arange(layout.content_start, layout.content_start + 2)
+    plan = SimpleNamespace(source_rows=source, matched_tokens=2)
+    get_calls = []
+    released = []
+
+    def get_plan(rid):
+        get_calls.append(rid)
+        if rid == "second":
+            raise ValueError("get-plan boom")
+        return plan
+
+    worker = _bare_sidecar_worker(layout)
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            get_dflash_draft_match_plan=get_plan,
+            release_dflash_draft_match_pin=lambda rid: released.append(rid) or True,
+        ),
+        reqs=[
+            SimpleNamespace(rid="first"),
+            SimpleNamespace(rid="second"),
+            SimpleNamespace(rid="third"),
+        ],
+        prefix_lens=[2, 2, 2],
+        req_pool_indices=torch.tensor([1, 2, 3]),
+        acquire_owner_mask=torch.tensor([True, True, True]),
+    )
+
+    with pytest.raises(ValueError, match="get-plan boom"):
+        _worker_module().DFlashWorkerV2._restore_compact_radix_prefix(worker, batch)
+
+    assert get_calls == ["first", "second"]
+    assert released == ["first", "second", "third"]
+
+
+def test_compact_radix_restore_mask_failure_releases_every_batch_rid():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=4,
+    )
+    released = []
+    worker = _bare_sidecar_worker(layout)
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            get_dflash_draft_match_plan=lambda rid: pytest.fail(
+                "mask validation must precede plan lookup"
+            ),
+            release_dflash_draft_match_pin=lambda rid: released.append(rid) or True,
+        ),
+        reqs=[SimpleNamespace(rid="first"), SimpleNamespace(rid="second")],
+        prefix_lens=[2, 2],
+        req_pool_indices=torch.tensor([1, 2]),
+        acquire_owner_mask=torch.tensor([True]),
+    )
+
+    with pytest.raises(RuntimeError, match="acquire-mask mismatch"):
+        _worker_module().DFlashWorkerV2._restore_compact_radix_prefix(worker, batch)
+
+    assert released == ["first", "second"]
+
+
+def test_compact_radix_restore_preserves_copy_error_and_attempts_all_releases():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=4,
+    )
+    source = torch.arange(layout.content_start, layout.content_start + 2)
+    plan = SimpleNamespace(source_rows=source, matched_tokens=2)
+    released = []
+
+    def release(rid):
+        released.append(rid)
+        if rid == "first":
+            raise RuntimeError("release boom")
+        return True
+
+    def move(destination, source):
+        raise ValueError("copy boom")
+
+    worker = _bare_sidecar_worker(layout, move=move)
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            get_dflash_draft_match_plan=lambda rid: plan,
+            release_dflash_draft_match_pin=release,
+        ),
+        reqs=[SimpleNamespace(rid="first"), SimpleNamespace(rid="second")],
+        prefix_lens=[2, 2],
+        req_pool_indices=torch.tensor([1, 2]),
+        acquire_owner_mask=torch.tensor([True, True]),
+    )
+
+    with pytest.raises(ValueError, match="copy boom"):
+        _worker_module().DFlashWorkerV2._restore_compact_radix_prefix(worker, batch)
+
+    assert released == ["first", "second"]
+
+
+def test_compact_prefill_sidecar_projects_each_visible_token_once_and_falls_back():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2,
+        window_size=4,
+        block_size=2,
+        page_size=1,
+        content_tokens=4,
+    )
+    content_rows = torch.arange(layout.content_start, layout.content_end)
+    allocations = [content_rows, None]
+    staged = []
+    moves = []
+    projections = []
+    tree_cache = SimpleNamespace(
+        alloc_dflash_draft_content=lambda count: allocations.pop(0),
+        stage_dflash_draft_publish=lambda rid, start, rows: staged.append(
+            (rid, start, rows.clone())
+        ),
+        discard_dflash_draft_publish=lambda rid: None,
+        free_unstaged_dflash_draft_content=lambda rows: None,
+    )
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._compact_physical_layout = layout
+    worker.draft_window_size = 4
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(
+            move_kv_cache=lambda dst, src: moves.append((dst.clone(), src.clone()))
+        )
+    )
+    worker._append_target_hidden_to_draft_kv_by_loc = (
+        lambda **kwargs: projections.append(kwargs)
+    )
+    positions = torch.tensor([0, 1, 2, 3, 4, 5, 4, 5], dtype=torch.int64)
+    hidden = torch.arange(16, dtype=torch.float32).view(8, 2)
+    batch = SimpleNamespace(
+        tree_cache=tree_cache,
+        reqs=[SimpleNamespace(rid="published"), SimpleNamespace(rid="fallback")],
+        prefix_lens=[0, 4],
+        extend_lens=[6, 2],
+        req_pool_indices=torch.tensor([1, 2]),
+    )
+
+    handled = worker_mod.DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+        worker, batch=batch, target_hidden=hidden, positions=positions
+    )
+
+    assert handled
+    assert len(projections) == 1
+    torch.testing.assert_close(
+        projections[0]["target_hidden"], torch.cat((hidden[2:6], hidden[6:8]))
+    )
+    assert projections[0]["target_hidden"].shape[0] == 6
+    torch.testing.assert_close(projections[0]["cache_loc"][:4], content_rows)
+    fallback_locs = layout.committed_locs(torch.full((2,), 2), torch.tensor([4, 5]))
+    torch.testing.assert_close(projections[0]["cache_loc"][4:], fallback_locs)
+    assert len(moves) == 1
+    torch.testing.assert_close(moves[0][1], content_rows)
+    assert staged[0][0:2] == ("published", 2)
+    torch.testing.assert_close(staged[0][2], content_rows)
+
+
+def test_compact_prefill_sidecar_publishes_cap_history_but_copies_only_owner_window():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1,
+        window_size=4,
+        block_size=2,
+        page_size=1,
+        content_tokens=8,
+    )
+    content_rows = torch.arange(layout.content_start, layout.content_end)
+    staged = []
+    moves = []
+    projections = []
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._compact_physical_layout = layout
+    worker.draft_window_size = 4
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(
+            move_kv_cache=lambda dst, src: moves.append((dst.clone(), src.clone()))
+        )
+    )
+    worker._append_target_hidden_to_draft_kv_by_loc = (
+        lambda **kwargs: projections.append(kwargs)
+    )
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            alloc_dflash_draft_content=lambda count: content_rows,
+            stage_dflash_draft_publish=lambda rid, start, rows: staged.append(
+                (rid, start, rows.clone())
+            ),
+            discard_dflash_draft_publish=lambda rid: None,
+            free_unstaged_dflash_draft_content=lambda rows: None,
+        ),
+        reqs=[SimpleNamespace(rid="long-system")],
+        prefix_lens=[0],
+        extend_lens=[10],
+        req_pool_indices=torch.tensor([1]),
+    )
+    hidden = torch.arange(20, dtype=torch.float32).view(10, 2)
+    positions = torch.arange(10, dtype=torch.int64)
+
+    assert worker_mod.DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+        worker, batch=batch, target_hidden=hidden, positions=positions
+    )
+
+    assert len(projections) == 1
+    torch.testing.assert_close(projections[0]["target_hidden"], hidden[2:10])
+    torch.testing.assert_close(projections[0]["cache_loc"], content_rows)
+    assert staged[0][0:2] == ("long-system", 2)
+    torch.testing.assert_close(staged[0][2], content_rows)
+    assert len(moves) == 1
+    torch.testing.assert_close(moves[0][1], content_rows[4:8])
+    torch.testing.assert_close(
+        moves[0][0],
+        layout.committed_locs(torch.ones(4, dtype=torch.int64), torch.arange(6, 10)),
+    )
+
+
+def test_compact_prefill_sidecar_cap_below_window_projects_uncovered_owner_rows():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1,
+        window_size=4,
+        block_size=2,
+        page_size=1,
+        content_tokens=2,
+    )
+    content_rows = torch.arange(layout.content_start, layout.content_end)
+    moves = []
+    projections = []
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker._compact_physical_layout = layout
+    worker.draft_window_size = 4
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(
+            move_kv_cache=lambda dst, src: moves.append((dst.clone(), src.clone()))
+        )
+    )
+    worker._append_target_hidden_to_draft_kv_by_loc = (
+        lambda **kwargs: projections.append(kwargs)
+    )
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            alloc_dflash_draft_content=lambda count: content_rows,
+            stage_dflash_draft_publish=lambda rid, start, rows: None,
+            discard_dflash_draft_publish=lambda rid: None,
+            free_unstaged_dflash_draft_content=lambda rows: None,
+        ),
+        reqs=[SimpleNamespace(rid="small-cap")],
+        prefix_lens=[0],
+        extend_lens=[6],
+        req_pool_indices=torch.tensor([1]),
+    )
+    hidden = torch.arange(12, dtype=torch.float32).view(6, 2)
+    positions = torch.arange(6, dtype=torch.int64)
+
+    assert worker_mod.DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+        worker, batch=batch, target_hidden=hidden, positions=positions
+    )
+
+    assert len(projections) == 1
+    torch.testing.assert_close(
+        projections[0]["target_hidden"], torch.cat((hidden[4:6], hidden[2:4]))
+    )
+    torch.testing.assert_close(projections[0]["cache_loc"][:2], content_rows)
+    torch.testing.assert_close(
+        projections[0]["cache_loc"][2:],
+        layout.committed_locs(torch.ones(2, dtype=torch.int64), torch.arange(2, 4)),
+    )
+    torch.testing.assert_close(moves[0][1], content_rows)
+    torch.testing.assert_close(
+        moves[0][0],
+        layout.committed_locs(torch.ones(2, dtype=torch.int64), torch.arange(4, 6)),
+    )
+
+
+def test_compact_prefill_projection_failure_frees_every_unstaged_lease():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=4,
+    )
+    allocations = [
+        torch.arange(layout.content_start, layout.content_start + 2),
+        torch.arange(layout.content_start + 2, layout.content_end),
+    ]
+    allocated = [rows.clone() for rows in allocations]
+    freed = []
+    staged = []
+
+    def project(**kwargs):
+        raise ValueError("projection boom")
+
+    worker = _bare_sidecar_worker(layout, project=project)
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            alloc_dflash_draft_content=lambda count: allocations.pop(0),
+            stage_dflash_draft_publish=lambda rid, start, rows: staged.append(rid),
+            discard_dflash_draft_publish=lambda rid: True,
+            free_unstaged_dflash_draft_content=lambda rows: freed.append(rows.clone()),
+        ),
+        reqs=[SimpleNamespace(rid="first"), SimpleNamespace(rid="second")],
+        decoding_reqs=None,
+        prefix_lens=[0, 0],
+        extend_lens=[2, 2],
+        req_pool_indices=torch.tensor([1, 2]),
+    )
+
+    with pytest.raises(ValueError, match="projection boom"):
+        _worker_module().DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+            worker,
+            batch=batch,
+            target_hidden=torch.arange(8, dtype=torch.float32).view(4, 2),
+            positions=torch.tensor([0, 1, 0, 1]),
+        )
+
+    assert not staged
+    assert len(freed) == 2
+    for actual, expected in zip(freed, allocated):
+        torch.testing.assert_close(actual, expected)
+
+
+def test_compact_prefill_stage_failure_partitions_staged_and_unstaged_rows():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=3,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=6,
+    )
+    allocations = [
+        torch.arange(layout.content_start + offset, layout.content_start + offset + 2)
+        for offset in (0, 2, 4)
+    ]
+    expected = [rows.clone() for rows in allocations]
+    staged = []
+    discarded = []
+    freed = []
+
+    def stage(rid, start, rows):
+        if rid == "second":
+            raise ValueError("stage boom")
+        staged.append(rid)
+
+    worker = _bare_sidecar_worker(layout)
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            alloc_dflash_draft_content=lambda count: allocations.pop(0),
+            stage_dflash_draft_publish=stage,
+            discard_dflash_draft_publish=lambda rid: discarded.append(rid) or True,
+            free_unstaged_dflash_draft_content=lambda rows: freed.append(rows.clone()),
+        ),
+        reqs=[
+            SimpleNamespace(rid="first"),
+            SimpleNamespace(rid="second"),
+            SimpleNamespace(rid="third"),
+        ],
+        decoding_reqs=None,
+        prefix_lens=[0, 0, 0],
+        extend_lens=[2, 2, 2],
+        req_pool_indices=torch.tensor([1, 2, 3]),
+    )
+
+    with pytest.raises(ValueError, match="stage boom"):
+        _worker_module().DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+            worker,
+            batch=batch,
+            target_hidden=torch.arange(12, dtype=torch.float32).view(6, 2),
+            positions=torch.tensor([0, 1, 0, 1, 0, 1]),
+        )
+
+    assert staged == ["first"]
+    assert discarded == ["first"]
+    assert len(freed) == 2
+    torch.testing.assert_close(freed[0], expected[1])
+    torch.testing.assert_close(freed[1], expected[2])
+
+
+def test_compact_prefill_rollback_is_best_effort_and_preserves_primary_error():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=3,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=6,
+    )
+    allocations = [
+        torch.arange(layout.content_start + offset, layout.content_start + offset + 2)
+        for offset in (0, 2, 4)
+    ]
+    cleanup_calls = []
+
+    def stage(rid, start, rows):
+        if rid == "second":
+            raise ValueError("primary stage boom")
+
+    def discard(rid):
+        cleanup_calls.append(("discard", rid))
+        raise RuntimeError("discard boom")
+
+    def free(rows):
+        cleanup_calls.append(("free", int(rows[0])))
+        if len([call for call in cleanup_calls if call[0] == "free"]) == 1:
+            raise RuntimeError("free boom")
+
+    worker = _bare_sidecar_worker(layout)
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            alloc_dflash_draft_content=lambda count: allocations.pop(0),
+            stage_dflash_draft_publish=stage,
+            discard_dflash_draft_publish=discard,
+            free_unstaged_dflash_draft_content=free,
+        ),
+        reqs=[
+            SimpleNamespace(rid="first"),
+            SimpleNamespace(rid="second"),
+            SimpleNamespace(rid="third"),
+        ],
+        decoding_reqs=None,
+        prefix_lens=[0, 0, 0],
+        extend_lens=[2, 2, 2],
+        req_pool_indices=torch.tensor([1, 2, 3]),
+    )
+
+    with pytest.raises(ValueError, match="primary stage boom") as exc_info:
+        _worker_module().DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+            worker,
+            batch=batch,
+            target_hidden=torch.arange(12, dtype=torch.float32).view(6, 2),
+            positions=torch.tensor([0, 1, 0, 1, 0, 1]),
+        )
+
+    assert cleanup_calls == [
+        ("discard", "first"),
+        ("free", layout.content_start + 2),
+        ("free", layout.content_start + 4),
+    ]
+    assert len(exc_info.value.__notes__) == 2
+
+
+def test_compact_prefill_content_range_failure_frees_fresh_allocation():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=2,
+    )
+    invalid_rows = torch.arange(layout.content_start - 1, layout.content_start + 1)
+    freed = []
+    worker = _bare_sidecar_worker(layout)
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            alloc_dflash_draft_content=lambda count: invalid_rows,
+            stage_dflash_draft_publish=lambda rid, start, rows: None,
+            discard_dflash_draft_publish=lambda rid: True,
+            free_unstaged_dflash_draft_content=lambda rows: freed.append(rows.clone()),
+        ),
+        reqs=[SimpleNamespace(rid="bad-range")],
+        decoding_reqs=None,
+        prefix_lens=[0],
+        extend_lens=[2],
+        req_pool_indices=torch.tensor([1]),
+    )
+
+    with pytest.raises(RuntimeError, match="content loc OOB"):
+        _worker_module().DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+            worker,
+            batch=batch,
+            target_hidden=torch.arange(4, dtype=torch.float32).view(2, 2),
+            positions=torch.tensor([0, 1]),
+        )
+
+    assert len(freed) == 1
+    torch.testing.assert_close(freed[0], invalid_rows)
+
+
+def test_compact_prefill_mixed_decode_and_skip_rows_only_update_owner_ring():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=3,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=2,
+    )
+    content_rows = torch.arange(layout.content_start, layout.content_end)
+    allocations = []
+    staged = []
+    projections = []
+    prefill = SimpleNamespace(rid="prefill")
+    decode = SimpleNamespace(rid="decode")
+    skipped = SimpleNamespace(rid="skip", skip_radix_cache_insert=True)
+    worker = _bare_sidecar_worker(
+        layout, project=lambda **kwargs: projections.append(kwargs)
+    )
+    batch = SimpleNamespace(
+        tree_cache=SimpleNamespace(
+            alloc_dflash_draft_content=lambda count: allocations.append(count)
+            or content_rows,
+            stage_dflash_draft_publish=lambda rid, start, rows: staged.append(rid),
+            discard_dflash_draft_publish=lambda rid: True,
+            free_unstaged_dflash_draft_content=lambda rows: None,
+        ),
+        reqs=[prefill, decode, skipped],
+        decoding_reqs=[decode],
+        prefix_lens=[0, 4, 0],
+        extend_lens=[2, 1, 2],
+        req_pool_indices=torch.tensor([1, 2, 3]),
+    )
+    positions = torch.tensor([0, 1, 4, 0, 1])
+
+    assert _worker_module().DFlashWorkerV2._materialize_compact_prefill_with_sidecar(
+        worker,
+        batch=batch,
+        target_hidden=torch.arange(10, dtype=torch.float32).view(5, 2),
+        positions=positions,
+    )
+
+    assert allocations == [2]
+    assert staged == ["prefill"]
+    assert len(projections) == 1
+    expected_owner_locs = torch.cat(
+        (
+            layout.committed_locs(torch.tensor([2]), torch.tensor([4])),
+            layout.committed_locs(torch.tensor([3, 3]), torch.tensor([0, 1])),
+        )
+    )
+    torch.testing.assert_close(projections[0]["cache_loc"][:2], content_rows)
+    torch.testing.assert_close(projections[0]["cache_loc"][2:], expected_owner_locs)
+
+
+def test_compact_generation_bind_failure_releases_radix_pin():
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=1,
+        window_size=2,
+        block_size=2,
+        page_size=1,
+        content_tokens=2,
+    )
+    released = []
+    worker = _bare_sidecar_worker(layout)
+    worker._compact_owner_generation = torch.tensor([0, 4], dtype=torch.int64)
+    worker.model_runner = SimpleNamespace(
+        req_to_token_pool=SimpleNamespace(
+            req_generation=torch.tensor([0, 5], dtype=torch.int64)
+        )
+    )
+    batch = SimpleNamespace(
+        sampling_info=None,
+        forward_mode=SimpleNamespace(is_extend=lambda: True),
+        is_extend_in_batch=False,
+        expected_req_generations_cpu=torch.tensor([4]),
+        acquire_owner_mask=torch.tensor([True]),
+        req_pool_indices_cpu=torch.tensor([1]),
+        req_pool_indices=torch.tensor([1]),
+        tree_cache=SimpleNamespace(
+            release_dflash_draft_match_pin=lambda rid: released.append(rid) or True
+        ),
+        reqs=[SimpleNamespace(rid="stale")],
+    )
+
+    with pytest.raises(RuntimeError, match="generation mismatch"):
+        _worker_module().DFlashWorkerV2.forward_batch_generation(worker, batch)
+
+    assert released == ["stale"]
+
+
+def test_compact_pool_uses_frozen_owner_and_sidecar_geometry_for_exact_bytes():
+    worker_mod = _worker_module()
+    layout = CompactDFlashPhysicalLayout.build(
+        owner_count=2,
+        window_size=4,
+        block_size=2,
+        page_size=1,
+        content_tokens=5,
+    )
+    cell_bytes = 32
+    allocated_bytes = (layout.physical_tokens + 1) * cell_bytes
+    calls = []
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker.use_compact_draft_cache = True
+    worker.draft_window_size = 4
+    worker.block_size = 2
+    worker.page_size = 1
+    worker.dflash_radix_sidecar_tokens = 5
+    worker._target_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            spec_aux_config=SimpleNamespace(
+                dflash_compact_owner_count=2,
+                dflash_draft_fixed_bytes=allocated_bytes,
+            )
+        )
+    )
+    worker._draft_worker = SimpleNamespace(
+        alloc_memory_pool=lambda **kwargs: calls.append(kwargs)
+    )
+    worker.draft_model_runner = SimpleNamespace(
+        token_to_kv_pool=SimpleNamespace(get_kv_size_bytes=lambda: allocated_bytes)
+    )
+    req_pool = SimpleNamespace(req_to_token=torch.empty((2, 16), dtype=torch.int64))
+
+    worker_mod.DFlashWorkerV2.alloc_memory_pool(
+        worker,
+        memory_pool_config=MemoryPoolConfig(max_total_num_tokens=999),
+        req_to_token_pool=req_pool,
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["memory_pool_config"].max_total_num_tokens == layout.physical_tokens
+    assert worker._compact_physical_layout == layout
+    assert worker._compact_owner_generation.shape[0] == 3
+
+
+def test_compact_pool_rejects_actual_request_slots_above_frozen_owner_budget():
+    worker_mod = _worker_module()
+    worker = object.__new__(worker_mod.DFlashWorkerV2)
+    worker.use_compact_draft_cache = True
+    worker.draft_window_size = 4
+    worker.block_size = 2
+    worker.page_size = 1
+    worker.dflash_radix_sidecar_tokens = 0
+    worker._target_worker = SimpleNamespace(
+        model_runner=SimpleNamespace(
+            spec_aux_config=SimpleNamespace(dflash_compact_owner_count=1)
+        )
+    )
+    worker._draft_worker = SimpleNamespace(alloc_memory_pool=lambda **kwargs: None)
+    req_pool = SimpleNamespace(req_to_token=torch.empty((3, 16), dtype=torch.int64))
+
+    with pytest.raises(RuntimeError, match="exceeds its frozen budget"):
+        worker_mod.DFlashWorkerV2.alloc_memory_pool(
+            worker,
+            memory_pool_config=MemoryPoolConfig(max_total_num_tokens=999),
+            req_to_token_pool=req_pool,
+        )
 
 
 def test_compact_rebuild_returns_scratch_and_writes_physical_mapping(monkeypatch):


### PR DESCRIPTION
> [!IMPORTANT]

> This is a Draft stacked on #36995 and is not independently mergeable yet.
> The PR2-only change is the top commit `1c5b8c176f1e94aad9531465e3635368e525d767`: 1 commit / 21 files.
> Clean PR2-only diff: https://github.com/Destination2020/sglang/pull/1
> Until #36995 lands, GitHub shows the combined 3-commit / 41-file stack against `main`.
> Heavy CI is intentionally not requested while this PR remains stacked.

## Motivation

The bounded Qwen DFlash cache from #36995 keeps committed draft KV in a
request-private ring. That preserves target KV capacity, but compact mode must
currently disable radix cache because a new request cannot restore the draft
KV corresponding to a cached target prefix.

This change adds a fixed, device-only content sidecar for canonical committed
draft KV. A compact request can now reuse every Prefill prefix already accepted
by the target FULL+MAMBA cache, provided the sidecar still covers the trailing
draft attention window. It does not create or densify Mamba checkpoints.

## Changes

- Add `--speculative-dflash-radix-sidecar-tokens N`:
  - `N=0` preserves the compact+radix fail-closed behavior;
  - `N>0` enables Qwen DFlash compact Prefill device radix and reserves a
    page-aligned fixed content cap.
- Add a Qwen-only, device-only `DRAFT` UnifiedTree component with trailing
  window validation, split/overlap hooks, short-lived restore pins, and
  independent DRAFT-only LRU eviction.
- Split the compact draft backing into disjoint request and content subranges;
  include the exact physical bytes in target-KV capacity solving and verify the
  runtime allocation against the frozen budget.
- Project canonical Prefill draft KV at most once, publish only committed
  content rows, and restore the trailing window into a newly generation-bound
  request owner with the existing D2D `move_kv_cache` path.
- Keep verify scratch, proposals, rejected tokens, Decode rows, owner IDs, and
  generations out of radix publication.
- Separate the internal post-insert FULL+MAMBA ownership rematch from normal
  FULL+MAMBA+DRAFT admission validation, so a cap smaller than the draft window
  falls back to zero hit without double-freeing target KV.
- Make publication, match pinning, restore, abort, reset, and worker rollback
  failure-atomic.

## Scope

Supported:

- CUDA, Qwen3.8-27B + DFlash2;
- compact DFlash cache, page size 1;
- Prefill device radix only;
- FULL+MAMBA target cache;
- fixed device sidecar cap.

Not supported by this change:

- Decode radix or Decode publication;
- HiCache/L2/L3/storage;
- NIXL, MORI, or a new P/D backend;
- unified memory;
- DSv4/DSpark or EAGLE generalization;
- target Mamba checkpoint-density changes.

Unsupported combinations fail closed. Decode P/D roles resolve the sidecar cap
to zero.

## Capacity

TP2 H20, Qwen3.8-27B + DFlash2, bf16 draft KV, two owners, window 2048,
`mem-fraction-static=0.82`:

| Configuration | Target KV tokens/rank | Draft rows/rank | Draft bytes/rank |
| --- | ---: | ---: | ---: |
| Legacy/noncompact radix | 1,823,964 | 1,823,964 | full-size pool |
| Compact, sidecar 8192 | 2,390,092 | 12,352 | 126,494,720 |
| Compact, sidecar 1024 | 2,392,332 | 5,184 | 53,094,400 |
| Compact, sidecar off | 2,745,002 | 4,160 | 42,608,640 |

The runtime draft allocation exactly matched the solver's frozen byte budget.
Even with the 8192-token content cap, target KV capacity remained above the
legacy full draft-pool configuration.

## Correctness validation

- CPU:
  - complete UnifiedRadix CPU files plus all directly affected suites:
    `1354 passed, 1149 skipped, 17 warnings`;
  - fault injection covers projection, staging, D2D restore, generation bind,
    match plan registration, cleanup callbacks, and allocator ownership;
  - isort, Black, compileall, and `git diff --check` pass on all 21 changed
    Python files.
- TP2 H20:
  - compact radix, compact no-radix, and legacy/noncompact cold outputs have
    exact text, token ID, chosen-logprob, and native top-5 parity;
  - after the target Mamba branch checkpoint exists, compact radix reports
    `cached_tokens=4097` and restores exactly 2048 DRAFT rows for a one-token
    extension;
  - DRAFT-only LRU pressure evicts sidecar rows without evicting target
    FULL/MAMBA content;
  - six sequential 4097-token requests with sidecar cap 1024 safely return
    `cached_tokens=0`, identical outputs, and no allocator invariant or stale
    read.
  - on the same 4098-token branch after Mamba checkpoint warmup, compact radix
    and legacy each report 4097 cached / 1 Prefill token, while compact
    no-radix reports 0 cached / 4098 Prefill tokens; their eight output token
    IDs, text, and finish reason are identical.
  - single-shot loopback streaming TTFT was 0.128722 s for compact radix,
    0.861948 s for compact no-radix, and 0.127057 s for legacy. These values
    are diagnostic observations, not a statistical performance claim.

## Fresh two-node feature-off evidence

The prepared validation source was clean at
`fe3542a466d1bdbe9daf958064ff80460ef22739`, with current-main base
`6afb5e17712e2e90b60ba8456ca893e529316869`, and passed 54 focused
P/D/current-main CPU tests. Fresh TP2 Mooncake runs then completed on Node A
Prefill and Node B Decode with radix disabled in both configurations:

- legacy/noncompact baseline: `pr2_pd_baseline_fe354_20260830_01`;
- compact, sidecar-default-zero candidate:
  `pr2_pd_candidate_fe354_20260830_02`;
- one short request, one 2047-token boundary request, and four strictly
  sequential 2057-token slot-release/reuse requests all passed in each run;
- all six baseline/candidate request pairs had exact text, token IDs, finish
  reason, chosen logprobs, and native top-5 logprobs at zero float tolerance;
- the compact candidate allocated 4,160 request rows, zero content rows, and
  42,608,640 draft bytes per rank, preserving 2,745,002 target-KV tokens;
- both successful runs completed hardened two-node cleanup with empty run
  process sets and planned ports.

An earlier candidate launch, `pr2_pd_candidate_fe354_20260830_01`, stopped
fail-closed when the hardened readiness probe observed an SGLang child changing
its process title during a snapshot. It produced no request evidence, its
automatic cleanup passed on both nodes, and one clean rerun succeeded without
changing product code or relaxing the probe.

The temporary bidirectional SSH authorizations, both node-local private keys,
and the isolated Node A agent were removed after validation. The immutable
branch and fork-local stacked PR were published only after explicit approval.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33266112069](https://github.com/sgl-project/sglang/actions/runs/33266112069)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33266111952](https://github.com/sgl-project/sglang/actions/runs/33266111952)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33266112067](https://github.com/sgl-project/sglang/actions/runs/33266112067)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->