### PR TITLE
[Spec] Let the ngram external SAM match past max_trie_depth

### DIFF
--- a/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/ngram_corpus_ffi.cpp
@@ -27,7 +27,8 @@ struct NgramCorpusObj : public tvm::ffi::Object {
       int64_t draft_token_num,
       int64_t match_type,
       int64_t external_sam_budget,
-      int64_t external_corpus_max_tokens) {
+      int64_t external_corpus_max_tokens,
+      int64_t max_sam_match_depth) {
     ngram::Param param;
     param.enable = true;
     param.enable_router_mode = false;
@@ -38,6 +39,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
     param.match_type = (match_type == 0) ? "BFS" : "PROB";
     param.external_sam_budget = static_cast<size_t>(external_sam_budget);
     param.external_corpus_max_tokens = static_cast<size_t>(external_corpus_max_tokens);
+    param.max_sam_match_depth = static_cast<size_t>(max_sam_match_depth);
     ngram_ = std::make_unique<ngram::Ngram>(static_cast<size_t>(capacity), param);
   }
 
@@ -155,7 +157,7 @@ struct NgramCorpusObj : public tvm::ffi::Object {
 void register_ngram_corpus() {
   namespace refl = tvm::ffi::reflection;
   refl::ObjectDef<NgramCorpusObj>()
-      .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
+      .def(refl::init<int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t, int64_t>(), "__init__")
       .def("async_insert", &NgramCorpusObj::async_insert)
       .def("batch_match_stateful", &NgramCorpusObj::batch_match_stateful)
       .def("erase_match_state", &NgramCorpusObj::erase_match_state)

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/param.h
@@ -23,6 +23,9 @@ struct Param {
   size_t draft_token_num;
   size_t external_sam_budget = 0;
   size_t external_corpus_max_tokens = 10000000;
+  // The SAM stores the whole corpus, so it can match a suffix longer than the
+  // trie's structural depth limit. 0 keeps it capped at max_trie_depth.
+  size_t max_sam_match_depth = 0;
   std::string match_type;
 
   std::vector<size_t> batch_draft_token_num;
@@ -96,7 +99,7 @@ struct Param {
     ss << "enable = " << enable << ", enable_router_mode = " << enable_router_mode
        << ", min_bfs_breadth = " << min_bfs_breadth << ", max_bfs_breadth = " << max_bfs_breadth
        << ", max_trie_depth = " << max_trie_depth << ", draft_token_num = " << draft_token_num
-       << ", external_sam_budget = " << external_sam_budget
+       << ", external_sam_budget = " << external_sam_budget << ", max_sam_match_depth = " << max_sam_match_depth
        << ", external_corpus_max_tokens = " << external_corpus_max_tokens << ", match_type = " << match_type;
     ss << ", batch_draft_token_num(" << batch_draft_token_num.size() << ") = ";
     for (int i = 0; i < batch_draft_token_num.size(); ++i) {

--- a/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
+++ b/python/sglang/kernels/jit/csrc/ngram_corpus/suffix_automaton.cpp
@@ -11,6 +11,14 @@ namespace sglang {
 
 namespace ngram {
 
+namespace {
+
+size_t samMatchDepth(const Param& param) {
+  return param.max_sam_match_depth > 0 ? param.max_sam_match_depth : param.max_trie_depth;
+}
+
+}  // namespace
+
 SuffixAutomaton::SuffixAutomaton() {
   reset_();
 }
@@ -180,7 +188,7 @@ std::vector<SamAnchor> SuffixAutomaton::match(const int32_t* context, size_t len
 
 Result SuffixAutomaton::buildRecency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
-  auto anchors = match(context, len, param.max_trie_depth);
+  auto anchors = match(context, len, samMatchDepth(param));
   const auto max_match_depth = std::max<int32_t>(1, static_cast<int32_t>(param.max_trie_depth - 1));
   const double bfs_breadth_scale = double(param.max_bfs_breadth - param.min_bfs_breadth) / max_match_depth;
   std::vector<Node> tree(draft_token_num + 1);
@@ -189,8 +197,10 @@ Result SuffixAutomaton::buildRecency(
 
   for (const auto& anchor : anchors) {
     std::queue<std::tuple<int, double, int>> queue;
-    queue.push(
-        {root, (max_match_depth - anchor.matched_len) * bfs_breadth_scale + param.min_bfs_breadth, anchor.state});
+    // A match deeper than max_match_depth is the most confident case there is;
+    // clamp so it lands on min_bfs_breadth instead of underflowing the scale.
+    const auto breadth_len = std::min<int32_t>(anchor.matched_len, max_match_depth);
+    queue.push({root, (max_match_depth - breadth_len) * bfs_breadth_scale + param.min_bfs_breadth, anchor.state});
     while (!queue.empty() && cursor <= static_cast<int>(draft_token_num)) {
       auto [parent, cur_breadth, state] = queue.front();
       queue.pop();
@@ -216,7 +226,7 @@ Result SuffixAutomaton::buildRecency(
 
 Result SuffixAutomaton::buildFrequency(
     const int32_t* context, size_t len, int32_t last_token, size_t draft_token_num, const Param& param) const {
-  auto anchors = match(context, len, param.max_trie_depth);
+  auto anchors = match(context, len, samMatchDepth(param));
   struct CompareByProb {
     bool operator()(
         const std::tuple<int, int32_t, int, double>& lhs, const std::tuple<int, int32_t, int, double>& rhs) const {

--- a/python/sglang/kernels/ops/speculative/ngram_corpus.py
+++ b/python/sglang/kernels/ops/speculative/ngram_corpus.py
@@ -52,6 +52,7 @@ def get_ngram_corpus_cls():
             match_type: str,
             external_sam_budget: int = 0,
             external_corpus_max_tokens: int = 10000000,
+            max_sam_match_depth: int = 0,
         ) -> None:
             mt = _MATCH_TYPE_MAP.get(match_type)
             if mt is None:
@@ -67,6 +68,7 @@ def get_ngram_corpus_cls():
                 mt,
                 external_sam_budget,
                 external_corpus_max_tokens,
+                max_sam_match_depth,
             )
             self._draft_token_num = draft_token_num
 

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2318,6 +2318,11 @@ class ServerArgs:
     speculative_ngram_max_trie_depth: A[
         int, "The max trie depth for ngram speculative decoding.", NS("spec")
     ] = 18
+    speculative_ngram_max_sam_match_depth: A[
+        int,
+        "How far back the external SAM may match, in tokens. The SAM holds the whole corpus, so unlike the trie it is not bound by max_trie_depth. 0 caps it at max_trie_depth, which is the historical behavior.",
+        NS("spec"),
+    ] = 0
     speculative_ngram_capacity: A[
         int, "The cache capacity for ngram speculative decoding.", NS("spec")
     ] = (10 * 1000 * 1000)

--- a/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
+++ b/python/sglang/srt/speculative/cpp_ngram/ngram_corpus.py
@@ -22,6 +22,7 @@ class NgramCorpus:
         capacity=1000000,
         external_sam_budget=0,
         external_corpus_max_tokens=10000000,
+        max_sam_match_depth=0,
     ) -> None:
         cls = get_ngram_corpus_cls()
         self._obj = cls(
@@ -33,6 +34,7 @@ class NgramCorpus:
             match_type=match_type,
             external_sam_budget=external_sam_budget,
             external_corpus_max_tokens=external_corpus_max_tokens,
+            max_sam_match_depth=max_sam_match_depth,
         )
         self.draft_token_num = draft_token_num
         self.external_corpus_max_tokens = external_corpus_max_tokens

--- a/python/sglang/srt/speculative/ngram_worker.py
+++ b/python/sglang/srt/speculative/ngram_worker.py
@@ -99,6 +99,11 @@ class NGRAMWorker(BaseSpecWorker):
         self.page_size = get_schedule().page_size
         self.draft_token_num: int = get_spec().speculative_num_draft_tokens
         self.max_trie_depth: int = get_spec().speculative_ngram_max_trie_depth
+        # The query tail handed to batch_get must cover whichever matcher reaches
+        # furthest back; the trie clamps anything longer than max_trie_depth itself.
+        self.max_match_depth: int = max(
+            self.max_trie_depth, get_spec().speculative_ngram_max_sam_match_depth
+        )
         self.speculative_num_draft_tokens = get_spec().speculative_num_draft_tokens
         self.topk = get_spec().speculative_eagle_topk
         self.speculative_num_steps = get_spec().speculative_num_steps
@@ -121,6 +126,7 @@ class NGRAMWorker(BaseSpecWorker):
             draft_token_num=get_spec().speculative_num_draft_tokens,
             external_sam_budget=get_spec().speculative_ngram_external_sam_budget,
             external_corpus_max_tokens=get_spec().speculative_ngram_external_corpus_max_tokens,
+            max_sam_match_depth=get_spec().speculative_ngram_max_sam_match_depth,
         )
         if get_spec().speculative_ngram_external_corpus_path is not None:
             from sglang.srt.speculative.cpp_ngram.external_corpus import (
@@ -254,13 +260,13 @@ class NGRAMWorker(BaseSpecWorker):
 
         # Accept-independent prep, hoisted above the blocking .cpu() below.
         req_ids = [req.rid for req in batch.reqs]
-        # Only the last max_trie_depth tokens can match; the ids are
+        # Only the last max_match_depth tokens can match; the ids are
         # array.array, so list() the tails for list concat below.
         input_tails = [
-            list(req.origin_input_ids[-self.max_trie_depth :]) for req in batch.reqs
+            list(req.origin_input_ids[-self.max_match_depth :]) for req in batch.reqs
         ]
         output_tails = [
-            list(req.output_ids[-self.max_trie_depth :]) for req in batch.reqs
+            list(req.output_ids[-self.max_match_depth :]) for req in batch.reqs
         ]
         base_lens = [
             len(req.origin_input_ids) + len(req.output_ids) for req in batch.reqs
@@ -296,7 +302,7 @@ class NGRAMWorker(BaseSpecWorker):
             check_token = self._efficient_concat_last_n(
                 input_tails[i],
                 output_tails[i] + prev_tokens,
-                self.max_trie_depth,
+                self.max_match_depth,
             )
             batch_tokens.append(check_token)
             total_lens.append(base_lens[i] + len(prev_tokens))

--- a/test/registered/unit/spec/test_ngram_corpus.py
+++ b/test/registered/unit/spec/test_ngram_corpus.py
@@ -975,5 +975,47 @@ class TestMultiSamHttpMock(CustomTestCase):
         self.assertEqual(data["corpus_token_counts"], {"a": 100, "b": 200})
 
 
+class TestNgramCorpusSamMatchDepth(CustomTestCase):
+    """Verify how far back the external SAM is allowed to match."""
+
+    # Two documents that share a six-token tail and only differ before it, so
+    # nothing shorter than the shared tail can tell them apart.
+    BOILERPLATE = [700, 701, 702, 703, 704, 705]
+    DOC_A = [901, 902, 903] + BOILERPLATE + [801, 802]
+    DOC_B = [911, 912, 913] + BOILERPLATE + [811, 812]
+    QUERY = [901, 902, 903] + BOILERPLATE
+
+    def _leaf_paths(self, **kwargs):
+        corpus = _make_corpus(
+            "BFS",
+            max_trie_depth=len(self.BOILERPLATE),
+            draft_token_num=4,
+            external_sam_budget=3,
+            external_corpus_documents=[self.DOC_A, self.DOC_B],
+            **kwargs,
+        )
+        ids, masks = _batch_get(corpus, [self.QUERY])
+        return corpus.leaf_paths_from_mask(ids.tolist(), masks.reshape(4, 4).tolist())
+
+    def test_default_caps_sam_at_max_trie_depth(self):
+        # The query only sees the shared tail, so it cannot tell DOC_A from
+        # DOC_B and the more recent document wins.
+        leaf_paths = self._leaf_paths()
+        self.assertIn([705, 811, 812], leaf_paths)
+        self.assertNotIn([705, 801, 802], leaf_paths)
+
+    def test_longer_match_depth_reaches_older_context(self):
+        # Matching past the shared tail identifies DOC_A, so its continuation
+        # is drafted instead.
+        leaf_paths = self._leaf_paths(max_sam_match_depth=len(self.QUERY))
+        self.assertIn([705, 801, 802], leaf_paths)
+
+    def test_zero_is_equivalent_to_max_trie_depth(self):
+        self.assertEqual(
+            self._leaf_paths(),
+            self._leaf_paths(max_sam_match_depth=len(self.BOILERPLATE)),
+        )
+
+
 if __name__ == "__main__":
     unittest.main(verbosity=3)


### PR DESCRIPTION
Picks up "Expand SAM match length (currently still cap by max_trie_depth)" from the ngram roadmap (#21052).

## Why

The trie is bounded by `max_trie_depth` because it only stores paths that deep. The SAM is not. It holds the whole external corpus and can match an arbitrarily long suffix in O(len) with no extra memory, which is most of the reason to have it for corpus lookup. It was capped at `max_trie_depth` anyway, in three places:

- `ngram_worker.py:260,263` slices the input/output tails to `max_trie_depth`
- `ngram_worker.py:302` trims again in `_efficient_concat_last_n`
- `suffix_automaton.cpp:183,219` passes `param.max_trie_depth` into `match()`

So the SAM never saw more context than the trie, and only the first two mattered — patching the C++ alone would have been a no-op.

## What

Adds `--speculative-ngram-max-sam-match-depth`, default `0` meaning "stay capped at `max_trie_depth`". Nothing changes unless you set it. When set, the worker carries a correspondingly longer query tail and the SAM matches against the larger bound.

The trie is unaffected by the longer tail: `rebuildMatchState_` assigns anchors with `std::min(len, max_trie_depth)` and `Trie::match` compares against `std::min(processed_total_len, max_trie_depth)`, so both the stateless rebuild and the per-anchor stateful advance clamp on their own. The insert path still uses `max_trie_depth`.

One thing that is easy to miss: `buildRecency` also derives its BFS breadth interpolation from `max_trie_depth`.

```cpp
const auto max_match_depth = std::max<int32_t>(1, int32_t(param.max_trie_depth - 1));
const double bfs_breadth_scale = double(max_bfs_breadth - min_bfs_breadth) / max_match_depth;
```

Once `matched_len` can exceed `max_trie_depth` the starting breadth goes negative and gets clamped to 1, so a longer, more confident match would degenerate into a single chain. This clamps the length feeding the interpolation instead, so a deep match lands on `min_bfs_breadth`, which is where the existing curve was already heading. The curve itself is unchanged.

## Numbers

Synthetic corpus, 64 passages, each 8 unique tokens + 12 shared boilerplate + 8 unique continuation. The query is a passage prefix plus the boilerplate, so only context older than the boilerplate says which passage to continue. Metric is the longest prefix of the true continuation reachable in the draft tree, `draft_token_num=8`, bfs_breadth 1..4:

```
match_depth   mean accept len   passages fully drafted
     4            0.125               1/64
     8            0.125               1/64
    12            0.125               1/64
    16            8.000              64/64
    32            8.000              64/64
```

The cliff sits exactly at the boilerplate length. This is a constructed worst case, not a claim about any real workload — I do not have numbers on a real corpus yet, which is also why the default is off.

## Tests

Three cases added to `test/registered/unit/spec/test_ngram_corpus.py` (CPU CI), built on two documents that share a six-token tail and differ only before it:

- default stays capped, so the more recent document wins and the correct continuation is not drafted
- with a match depth past the shared tail, the correct continuation is drafted
- `0` and an explicit `max_trie_depth` produce identical trees

`test_ngram_corpus.py` passes locally, 40 tests.

## Open question

Should the default stay `0`? Turning it on by default would cost a slightly longer tail per request on every decode step, and I would rather see numbers on a real corpus before arguing for that. Happy to flip it if you would rather have it on.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33276023594](https://github.com/sgl-project/sglang/actions/runs/33276023594)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33276023433](https://github.com/sgl-project/sglang/actions/runs/33276023433)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33276023602](https://github.com/sgl-project/sglang/actions/runs/33276023602)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->