### PR TITLE
[PD] Centralize drain-aware abort acknowledgements

### DIFF
--- a/python/sglang/srt/disaggregation/base/conn.py
+++ b/python/sglang/srt/disaggregation/base/conn.py
@@ -248,6 +248,10 @@ class BaseKVReceiver(ABC):
         """
         pass
 
+    def abort_for_deferred_release(self) -> None:
+        """Abort using the backend's native behavior."""
+        self.abort()
+
 
 class BaseKVBootstrapServer(ABC):
     @abstractmethod

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -9,6 +9,7 @@ import time
 from collections import defaultdict
 from typing import Dict, List, Optional, Set, Tuple, Union
 
+import msgspec
 import numpy as np
 import numpy.typing as npt
 import requests
@@ -146,8 +147,7 @@ class PrefillRankInfo:
         self.rank_port = int(self.rank_port)
 
 
-@dataclasses.dataclass(frozen=True)
-class AbortNotification:
+class AbortNotification(msgspec.Struct, frozen=True):
     room: int
     decode_ip: Optional[str] = None
     decode_port: Optional[int] = None
@@ -189,8 +189,7 @@ class AbortNotification:
         return frames
 
 
-@dataclasses.dataclass(frozen=True)
-class AbortAck:
+class AbortAck(msgspec.Struct, frozen=True):
     room: int
     prefill_rank: int
 

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -7,7 +7,7 @@ import logging
 import threading
 import time
 from collections import defaultdict
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, NamedTuple, Optional, Set, Tuple, Union
 
 import msgspec
 import numpy as np
@@ -147,10 +147,17 @@ class PrefillRankInfo:
         self.rank_port = int(self.rank_port)
 
 
+class AckTarget(NamedTuple):
+    ip: str
+    port: int
+    generation: int
+
+
 class AbortNotification(msgspec.Struct, frozen=True):
     room: int
     decode_ip: Optional[str] = None
     decode_port: Optional[int] = None
+    generation: Optional[int] = None
 
     @classmethod
     def from_zmq(cls, msg: List[bytes]) -> Optional[AbortNotification]:
@@ -168,14 +175,24 @@ class AbortNotification(msgspec.Struct, frozen=True):
             return cls(room=room)
 
         try:
-            return cls(
-                room=room,
-                decode_ip=msg[2].decode("ascii"),
-                decode_port=int(msg[3].decode("ascii")),
-            )
+            decode_ip = msg[2].decode("ascii")
+            decode_port = int(msg[3].decode("ascii"))
         except (ValueError, UnicodeDecodeError):
             logger.warning("Malformed ABORT message: invalid return address")
             return cls(room=room)
+
+        generation = None
+        if len(msg) >= 5:
+            try:
+                generation = int(msg[4].decode("ascii"))
+            except (ValueError, UnicodeDecodeError):
+                logger.warning("Malformed ABORT message: invalid generation")
+        return cls(
+            room=room,
+            decode_ip=decode_ip,
+            decode_port=decode_port,
+            generation=generation,
+        )
 
     def to_zmq(self) -> List[bytes]:
         frames = [ABORT_TAG, str(self.room).encode("ascii")]
@@ -186,12 +203,26 @@ class AbortNotification(msgspec.Struct, frozen=True):
                     str(self.decode_port).encode("ascii"),
                 ]
             )
+            if self.generation is not None:
+                frames.append(str(self.generation).encode("ascii"))
         return frames
+
+    def deferred_ack_target(self) -> Optional[AckTarget]:
+        if self.decode_ip is None or self.decode_port is None:
+            return None
+        if self.generation is None:
+            logger.warning_once(
+                "Generation-less ABORT received; deferred ACK is unavailable. "
+                "Mixed SGLang versions may wait for the KV release timeout."
+            )
+            return None
+        return AckTarget(self.decode_ip, self.decode_port, self.generation)
 
 
 class AbortAck(msgspec.Struct, frozen=True):
     room: int
     prefill_rank: int
+    generation: Optional[int] = None
 
     @classmethod
     def from_zmq(cls, msg: List[bytes]) -> Optional[AbortAck]:
@@ -202,17 +233,26 @@ class AbortAck(msgspec.Struct, frozen=True):
             return cls(
                 room=int(msg[1].decode("ascii")),
                 prefill_rank=int(msg[2].decode("ascii")),
+                generation=(int(msg[3].decode("ascii")) if len(msg) >= 4 else None),
             )
         except (ValueError, UnicodeDecodeError):
             logger.warning("Malformed ABORT_ACK received")
             return None
 
     def to_zmq(self) -> List[bytes]:
-        return [
+        frames = [
             ABORT_ACK_TAG,
             str(self.room).encode("ascii"),
             str(self.prefill_rank).encode("ascii"),
         ]
+        if self.generation is not None:
+            frames.append(str(self.generation).encode("ascii"))
+        return frames
+
+
+class DeferredAbortAckState(msgspec.Struct):
+    generation: int
+    prefill_ranks: Set[int]
 
 
 class CommonKVManager(BaseKVManager):
@@ -295,6 +335,11 @@ class CommonKVManager(BaseKVManager):
         self._socket_lock = threading.Lock()
         self.failure_records: Dict[int, str] = {}
         self.failure_lock = threading.Lock()
+        self._staging_outstanding: Dict[int, int] = defaultdict(int)
+        self._deferred_ack_targets: Dict[int, AckTarget] = {}
+        # A poisoned room has a permanently outstanding transfer whose backend
+        # can no longer prove quiescent. A new room lifecycle clears this state.
+        self._deferred_ack_poisoned_rooms: Set[int] = set()
 
         if self.disaggregation_mode == DisaggregationMode.PREFILL:
             # When SGLANG_DISAGGREGATION_ALL_CP_RANKS_TRANSFER is True, all CP ranks
@@ -313,9 +358,6 @@ class CommonKVManager(BaseKVManager):
             )
             self.register_to_bootstrap()
             self.transfer_infos = {}
-            # Deferred KV release: aborted room -> (decode_ip, decode_port);
-            # ack held until the transfer drains.
-            self._deferred_ack_targets: Dict[int, Tuple[str, int]] = {}
             self.req_to_decode_prefix_len: Dict[int, int] = {}
             self.decode_kv_args_table = {}
             self.pp_group = get_pp_group()
@@ -334,10 +376,11 @@ class CommonKVManager(BaseKVManager):
             self.session_pool_lock = threading.Lock()
             self.addr_to_rooms_tracker: Dict[str, Set[int]] = defaultdict(set)
             self.prefill_response_tracker: Dict[int, Set[int]] = defaultdict(set)
-            # Deferred KV release: room -> prefill ranks that acked their transfer
-            # drained. Entry exists only while the room is held, so a stale/late
-            # ack for a reused bootstrap_room is dropped.
-            self._deferred_abort_ack_tracker: Dict[int, Set[int]] = {}
+            # Deferred KV release: room -> current generation and ranks that
+            # ACKed. The generation rejects an old request's late ACK after room
+            # reuse.
+            self._deferred_abort_ack_tracker: Dict[int, DeferredAbortAckState] = {}
+            self._deferred_abort_generation = 0
             # Heartbeat interval should be at least 2 seconds
             self.heartbeat_interval = max(
                 envs.SGLANG_DISAGGREGATION_HEARTBEAT_INTERVAL.get(), 2.0
@@ -442,6 +485,9 @@ class CommonKVManager(BaseKVManager):
             # pollute a future request that reuses the same bootstrap_room.
             if status == KVPoll.Failed:
                 return
+            self._deferred_ack_targets.pop(bootstrap_room, None)
+            self._deferred_ack_poisoned_rooms.discard(bootstrap_room)
+            self._staging_outstanding.pop(bootstrap_room, None)
             self.request_status[bootstrap_room] = status
         else:
             if status == KVPoll.Failed:
@@ -455,17 +501,23 @@ class CommonKVManager(BaseKVManager):
         with self.failure_lock:
             self.failure_records[bootstrap_room] = failure_reason
 
-    def register_deferred_abort_room(self, bootstrap_room: int) -> None:
-        """Arm drain-ack accounting for a held room; a fresh set wipes stale acks
-        from a prior request that reused this bootstrap_room."""
-        self._deferred_abort_ack_tracker[bootstrap_room] = set()
+    def register_deferred_abort_room(self, bootstrap_room: int) -> int:
+        """Arm a new generation for a held room and return its wire id."""
+        self._deferred_abort_generation += 1
+        generation = self._deferred_abort_generation
+        self._deferred_abort_ack_tracker[bootstrap_room] = DeferredAbortAckState(
+            generation=generation,
+            prefill_ranks=set(),
+        )
+        return generation
 
-    def note_abort_ack(self, bootstrap_room: int, prefill_rank: int) -> None:
-        """Record a prefill rank's drain ack (decode receiver thread). Only counts
-        while the room is held; grabs the set by reference to avoid racing clear."""
-        acks = self._deferred_abort_ack_tracker.get(bootstrap_room)
-        if acks is not None:
-            acks.add(prefill_rank)
+    def note_abort_ack(
+        self, bootstrap_room: int, prefill_rank: int, generation: int
+    ) -> None:
+        """Record an ACK only for the generation currently holding the room."""
+        state = self._deferred_abort_ack_tracker.get(bootstrap_room)
+        if state is not None and state.generation == generation:
+            state.prefill_ranks.add(prefill_rank)
 
     def handle_abort_ack_message(self, msg: List[bytes]) -> bool:
         """Consume an ABORT_ACK and record it for an armed decode room."""
@@ -474,16 +526,22 @@ class CommonKVManager(BaseKVManager):
         if not self.enable_deferred_decode_kv_release:
             return True
         ack = AbortAck.from_zmq(msg)
-        if ack is not None:
-            self.note_abort_ack(ack.room, ack.prefill_rank)
+        if ack is None:
+            return True
+        if ack.generation is None:
+            logger.warning_once(
+                "Generation-less ABORT_ACK received; ignoring it. "
+                "Mixed SGLang versions may wait for the KV release timeout."
+            )
+            return True
+        self.note_abort_ack(ack.room, ack.prefill_rank, ack.generation)
         return True
 
     def is_abort_release_safe(self, bootstrap_room: int, required_acks: int) -> bool:
         """True once every prefill rank that could still write these pages has acked."""
-        return (
-            len(self._deferred_abort_ack_tracker.get(bootstrap_room, ()))
-            >= required_acks
-        )
+        state = self._deferred_abort_ack_tracker.get(bootstrap_room)
+        acks = state.prefill_ranks if state is not None else ()
+        return len(acks) >= required_acks
 
     def clear_deferred_abort_state(self, bootstrap_room: int) -> None:
         self._deferred_abort_ack_tracker.pop(bootstrap_room, None)
@@ -496,13 +554,13 @@ class CommonKVManager(BaseKVManager):
             + self.attn_cp_rank
         )
 
-    def _send_abort_ack(self, decode_ip: str, decode_port: int, room: int) -> None:
+    def _send_abort_ack(self, room: int, target: AckTarget) -> None:
         """Best-effort ack that this rank's transfer for an aborted room drained."""
         try:
-            na = NetworkAddress(decode_ip, decode_port)
+            na = NetworkAddress(target.ip, target.port)
             self._send_multipart_locked(
                 na.to_tcp(),
-                AbortAck(room, self._prefill_unique_rank()).to_zmq(),
+                AbortAck(room, self._prefill_unique_rank(), target.generation).to_zmq(),
                 is_ipv6=na.is_ipv6,
             )
         except Exception as e:
@@ -515,15 +573,21 @@ class CommonKVManager(BaseKVManager):
             return
         target = self._deferred_ack_targets.pop(room, None)
         if target is not None:
-            self._send_abort_ack(target[0], target[1], room)
+            self._send_abort_ack(room, target)
 
-    def register_deferred_ack_target(
-        self, room: int, decode_ip: str, decode_port: int
-    ) -> None:
-        """Hold this room's ack until its transfer drains. Callers must mark the
-        room Failed FIRST -- registering while it still accepts chunks lets the
-        worker ack, then a new chunk writes pages the decode already released."""
-        self._deferred_ack_targets[room] = (decode_ip, decode_port)
+    def register_deferred_ack_target(self, room: int, target: AckTarget) -> None:
+        """Hold this generation's ACK until the room's transfer drains.
+
+        Active-room callers must mark the room Failed before registering so no
+        new chunk can be accepted after the ACK is sent.
+        """
+        if room not in self._deferred_ack_poisoned_rooms:
+            self._deferred_ack_targets[room] = target
+
+    def poison_deferred_ack_room(self, room: int) -> None:
+        """Drop an ACK target when the backend cannot prove the room drained."""
+        self._deferred_ack_targets.pop(room, None)
+        self._deferred_ack_poisoned_rooms.add(room)
 
     def get_kv_replica_factor(self) -> int:
         if self._kv_replica_factor is None:
@@ -1416,13 +1480,11 @@ class CommonKVSender(BaseKVSender):
 
     def clear(self) -> None:
         self.kv_mgr.request_status.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "req_to_decode_prefix_len"):
-            self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "transfer_infos"):
-            self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
-        if hasattr(self.kv_mgr, "_deferred_ack_targets"):
-            # Drop a held ack target if the room concluded without draining
-            # (e.g. aborted before any chunk enqueued); else it leaks on prefill.
+        self.kv_mgr.req_to_decode_prefix_len.pop(self.bootstrap_room, None)
+        self.kv_mgr.transfer_infos.pop(self.bootstrap_room, None)
+        # A sender can be cleared while a counted transfer is still writing.
+        # Keep its target so the transfer worker can ACK after it drains.
+        if self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) <= 0:
             self.kv_mgr._deferred_ack_targets.pop(self.bootstrap_room, None)
 
     def abort(self):
@@ -1454,6 +1516,7 @@ class CommonKVReceiver(BaseKVReceiver):
         self.require_staging: bool = False
         self.init_time: Optional[float] = None
         self.abort_notified: bool = False
+        self._abort_generation: Optional[int] = None
         self._connection_pool_entries: Dict[str, List[Dict]] = {}
         self.kv_mgr.addr_to_rooms_tracker[self.bootstrap_addr].add(self.bootstrap_room)
         self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Bootstrapping)
@@ -1718,8 +1781,10 @@ class CommonKVReceiver(BaseKVReceiver):
 
     def abort_for_deferred_release(self) -> None:
         """Arm ACK aggregation before the backend can emit an immediate ACK."""
-        if self.kv_mgr.enable_deferred_decode_kv_release:
-            self.kv_mgr.register_deferred_abort_room(self.bootstrap_room)
+        if self.kv_mgr.enable_deferred_decode_kv_release and not self.abort_notified:
+            self._abort_generation = self.kv_mgr.register_deferred_abort_room(
+                self.bootstrap_room
+            )
         self.abort()
 
     def _send_abort_notification(self):
@@ -1733,6 +1798,7 @@ class CommonKVReceiver(BaseKVReceiver):
                             room=self.bootstrap_room,
                             decode_ip=self.kv_mgr.local_ip,
                             decode_port=self.kv_mgr.rank_port,
+                            generation=self._abort_generation,
                         ).to_zmq()
                     )
                 logger.debug(

--- a/python/sglang/srt/disaggregation/common/conn.py
+++ b/python/sglang/srt/disaggregation/common/conn.py
@@ -50,6 +50,9 @@ from sglang.srt.utils.network import (
 
 logger = logging.getLogger(__name__)
 
+ABORT_TAG = b"ABORT"
+ABORT_ACK_TAG = b"ABORT_ACK"
+
 
 # Reuse a keep-alive session per bootstrap_addr for decode-side bootstrap queries
 # so we don't open a fresh TCP connection per query (that churns short-lived
@@ -141,6 +144,76 @@ class PrefillRankInfo:
     def __post_init__(self):
         self.rank_ip = str(self.rank_ip)
         self.rank_port = int(self.rank_port)
+
+
+@dataclasses.dataclass(frozen=True)
+class AbortNotification:
+    room: int
+    decode_ip: Optional[str] = None
+    decode_port: Optional[int] = None
+
+    @classmethod
+    def from_zmq(cls, msg: List[bytes]) -> Optional[AbortNotification]:
+        if len(msg) < 2:
+            logger.warning("Malformed ABORT message: too few frames (%d)", len(msg))
+            return None
+
+        try:
+            room = int(msg[1].decode("ascii"))
+        except (ValueError, UnicodeDecodeError):
+            logger.warning("Malformed ABORT message: invalid room field %r", msg[1])
+            return None
+
+        if len(msg) < 4:
+            return cls(room=room)
+
+        try:
+            return cls(
+                room=room,
+                decode_ip=msg[2].decode("ascii"),
+                decode_port=int(msg[3].decode("ascii")),
+            )
+        except (ValueError, UnicodeDecodeError):
+            logger.warning("Malformed ABORT message: invalid return address")
+            return cls(room=room)
+
+    def to_zmq(self) -> List[bytes]:
+        frames = [ABORT_TAG, str(self.room).encode("ascii")]
+        if self.decode_ip is not None and self.decode_port is not None:
+            frames.extend(
+                [
+                    self.decode_ip.encode("ascii"),
+                    str(self.decode_port).encode("ascii"),
+                ]
+            )
+        return frames
+
+
+@dataclasses.dataclass(frozen=True)
+class AbortAck:
+    room: int
+    prefill_rank: int
+
+    @classmethod
+    def from_zmq(cls, msg: List[bytes]) -> Optional[AbortAck]:
+        if len(msg) < 3:
+            logger.warning("Incomplete ABORT_ACK received")
+            return None
+        try:
+            return cls(
+                room=int(msg[1].decode("ascii")),
+                prefill_rank=int(msg[2].decode("ascii")),
+            )
+        except (ValueError, UnicodeDecodeError):
+            logger.warning("Malformed ABORT_ACK received")
+            return None
+
+    def to_zmq(self) -> List[bytes]:
+        return [
+            ABORT_ACK_TAG,
+            str(self.room).encode("ascii"),
+            str(self.prefill_rank).encode("ascii"),
+        ]
 
 
 class CommonKVManager(BaseKVManager):
@@ -395,6 +468,17 @@ class CommonKVManager(BaseKVManager):
         if acks is not None:
             acks.add(prefill_rank)
 
+    def handle_abort_ack_message(self, msg: List[bytes]) -> bool:
+        """Consume an ABORT_ACK and record it for an armed decode room."""
+        if not msg or msg[0] != ABORT_ACK_TAG:
+            return False
+        if not self.enable_deferred_decode_kv_release:
+            return True
+        ack = AbortAck.from_zmq(msg)
+        if ack is not None:
+            self.note_abort_ack(ack.room, ack.prefill_rank)
+        return True
+
     def is_abort_release_safe(self, bootstrap_room: int, required_acks: int) -> bool:
         """True once every prefill rank that could still write these pages has acked."""
         return (
@@ -419,11 +503,7 @@ class CommonKVManager(BaseKVManager):
             na = NetworkAddress(decode_ip, decode_port)
             self._send_multipart_locked(
                 na.to_tcp(),
-                [
-                    b"ABORT_ACK",
-                    str(room).encode("ascii"),
-                    str(self._prefill_unique_rank()).encode("ascii"),
-                ],
+                AbortAck(room, self._prefill_unique_rank()).to_zmq(),
                 is_ipv6=na.is_ipv6,
             )
         except Exception as e:
@@ -1637,6 +1717,12 @@ class CommonKVReceiver(BaseKVReceiver):
             self._send_abort_notification()
             self.abort_notified = True
 
+    def abort_for_deferred_release(self) -> None:
+        """Arm ACK aggregation before the backend can emit an immediate ACK."""
+        if self.kv_mgr.enable_deferred_decode_kv_release:
+            self.kv_mgr.register_deferred_abort_room(self.bootstrap_room)
+        self.abort()
+
     def _send_abort_notification(self):
         for bootstrap_info in self.bootstrap_infos:
             # Best-effort notification to prefill side that this request was aborted.
@@ -1644,12 +1730,11 @@ class CommonKVReceiver(BaseKVReceiver):
                 sock, lock = self._connect_to_bootstrap_server(bootstrap_info)
                 with lock:
                     sock.send_multipart(
-                        [
-                            b"ABORT",
-                            str(self.bootstrap_room).encode("ascii"),
-                            self.kv_mgr.local_ip.encode("ascii"),
-                            str(self.kv_mgr.rank_port).encode("ascii"),
-                        ]
+                        AbortNotification(
+                            room=self.bootstrap_room,
+                            decode_ip=self.kv_mgr.local_ip,
+                            decode_port=self.kv_mgr.rank_port,
+                        ).to_zmq()
                     )
                 logger.debug(
                     f"Sent abort notification for room {self.bootstrap_room} "

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -228,9 +228,6 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             self.failed_sessions = set()
             self.session_lock = threading.Lock()
             self.start_prefill_thread()
-            # Per-room count of chunks not yet transferred; teardown waits for
-            # zero so a deferred chunk is not dropped by an early conclude.
-            self._staging_outstanding = defaultdict(int)
             # Determine the number of threads to use for kv sender
             cpu_count = os.cpu_count()
             transfer_thread_pool_size = (
@@ -1716,8 +1713,9 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             )
 
         while True:
+            kv_chunk: Optional[TransferKVChunk] = None
             try:
-                kv_chunk: TransferKVChunk = queue.get()
+                kv_chunk = queue.get()
                 if self.enable_trace:
                     kv_chunk.trace_ctx.rebuild_thread_context()
                     kv_chunk.trace_ctx.trace_slice_start(
@@ -2057,6 +2055,8 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
 
             except Exception as e:
                 # NOTE(shangming): Remove this when we make sure the transfer thread is bug-free
+                if kv_chunk is not None:
+                    self.poison_deferred_ack_room(kv_chunk.room)
                 raise RuntimeError(
                     f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
                 )
@@ -2086,20 +2086,17 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
         if room_active:
             self.update_status(room, KVPoll.Failed)
 
-        if notification.decode_ip is None or notification.decode_port is None:
+        ack_target = notification.deferred_ack_target()
+        if ack_target is None:
             return
+        self.register_deferred_ack_target(room, ack_target)
+        self._maybe_ack_drained_abort(room)
         if room_active:
-            self.register_deferred_ack_target(
-                room, notification.decode_ip, notification.decode_port
-            )
-            self._maybe_ack_drained_abort(room)
             logger.debug(
                 "Received abort notification for room %s, marked as Failed; "
                 "ACK deferred until transfer drains",
                 room,
             )
-        elif self._staging_outstanding.get(room, 0) == 0:
-            self._send_abort_ack(notification.decode_ip, notification.decode_port, room)
 
     def _handle_legacy_abort_notification(
         self, notification: AbortNotification, room_active: bool

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -17,6 +17,9 @@ from prometheus_client import Counter
 
 from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, StateType
 from sglang.srt.disaggregation.common.conn import (
+    ABORT_ACK_TAG,
+    ABORT_TAG,
+    AbortNotification,
     CommonKVBootstrapServer,
     CommonKVManager,
     CommonKVReceiver,
@@ -2058,6 +2061,78 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     f"Transfer thread failed because of {e}. Prefill instance with bootstrap_port={self.bootstrap_port} is dead."
                 )
 
+    def _handle_abort_notification(self, msg: List[bytes]) -> bool:
+        if not msg or msg[0] != ABORT_TAG:
+            return False
+
+        notification = AbortNotification.from_zmq(msg)
+        if notification is None:
+            return True
+        room = notification.room
+        room_active = (
+            room in self.request_status and self.check_status(room) != KVPoll.Success
+        )
+
+        if self.enable_deferred_decode_kv_release:
+            self._handle_deferred_abort_notification(notification, room_active)
+        else:
+            self._handle_legacy_abort_notification(notification, room_active)
+        return True
+
+    def _handle_deferred_abort_notification(
+        self, notification: AbortNotification, room_active: bool
+    ) -> None:
+        if notification.decode_ip is None or notification.decode_port is None:
+            return
+        room = notification.room
+        if room_active:
+            self.update_status(room, KVPoll.Failed)
+            self.register_deferred_ack_target(
+                room, notification.decode_ip, notification.decode_port
+            )
+            self._maybe_ack_drained_abort(room)
+            logger.debug(
+                "Received abort notification for room %s, marked as Failed; "
+                "ACK deferred until transfer drains",
+                room,
+            )
+        elif self._staging_outstanding.get(room, 0) == 0:
+            self._send_abort_ack(notification.decode_ip, notification.decode_port, room)
+
+    def _handle_legacy_abort_notification(
+        self, notification: AbortNotification, room_active: bool
+    ) -> None:
+        room = notification.room
+        if room_active:
+            self.update_status(room, KVPoll.Failed)
+            logger.debug(
+                "Received abort notification for room %s, marked as Failed", room
+            )
+        else:
+            logger.debug(
+                "Received abort notification for room %s, ignoring "
+                "(already completed or unknown)",
+                room,
+            )
+
+        if notification.decode_ip is None or notification.decode_port is None:
+            return
+        try:
+            na = NetworkAddress(notification.decode_ip, notification.decode_port)
+            self._send_multipart_locked(
+                na.to_tcp(),
+                [ABORT_ACK_TAG, str(room).encode("ascii")],
+                is_ipv6=na.is_ipv6,
+            )
+            logger.debug(
+                "Sent ABORT_ACK for room %s to %s:%s",
+                room,
+                notification.decode_ip,
+                notification.decode_port,
+            )
+        except Exception as exc:
+            logger.debug("Failed to send ABORT_ACK for room %s: %s", room, exc)
+
     def start_prefill_thread(self):
         def bootstrap_thread():
             """This thread recvs pre-alloc notification from the decode engine"""
@@ -2073,74 +2148,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                 if room == "STAGING_RSP":
                     handle_staging_rsp(waiting_req_bytes, self.transfer_infos)
                     continue
-                # Decode-side abort notification: mark room as failed and ACK
-                if room == "ABORT":
-                    room_to_be_aborted = int(waiting_req_bytes[1].decode("ascii"))
-                    decode_ip = waiting_req_bytes[2].decode("ascii")
-                    decode_port = int(waiting_req_bytes[3].decode("ascii"))
-                    room_active = (
-                        room_to_be_aborted in self.request_status
-                        and self.check_status(room_to_be_aborted) != KVPoll.Success
-                    )
-                    if self.enable_deferred_decode_kv_release:
-                        # Mark Failed FIRST (stops add_transfer_request enqueuing
-                        # new chunks), THEN register the ack target: registering
-                        # first would let the worker drain+ack while the room is
-                        # not yet Failed, so a newly enqueued chunk could still
-                        # write to the freed pages. The worker (not this thread)
-                        # acks once its in-flight write drains; if nothing is in
-                        # flight, decode falls back to the release timeout.
-                        if room_active:
-                            self.update_status(room_to_be_aborted, KVPoll.Failed)
-                            self.register_deferred_ack_target(
-                                room_to_be_aborted, decode_ip, decode_port
-                            )
-                            # Try once: the room may already be quiescent and
-                            # never revisited by the worker.
-                            self._maybe_ack_drained_abort(room_to_be_aborted)
-                            logger.debug(
-                                f"Received abort notification for room {room_to_be_aborted}, "
-                                f"marked as Failed; ACK deferred until transfer drains"
-                            )
-                        elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
-                            # Concluded/unknown AND quiescent: ack now. A cleared
-                            # room is not automatically quiescent -- clear() can
-                            # drop a room whose chunk is still transferring.
-                            self._send_abort_ack(
-                                decode_ip, decode_port, room_to_be_aborted
-                            )
-                        continue
-                    # No need to abort the room if it has already succeeded
-                    if room_active:
-                        self.update_status(room_to_be_aborted, KVPoll.Failed)
-                        logger.debug(
-                            f"Received abort notification for room {room_to_be_aborted}, "
-                            f"marked as Failed"
-                        )
-                    else:
-                        logger.debug(
-                            f"Received abort notification for room {room_to_be_aborted}, "
-                            f"ignoring (already completed or unknown)"
-                        )
-                    # Send ACK back to decode endpoint
-                    try:
-                        na = NetworkAddress(decode_ip, decode_port)
-                        self._send_multipart_locked(
-                            na.to_tcp(),
-                            [
-                                b"ABORT_ACK",
-                                str(room_to_be_aborted).encode("ascii"),
-                            ],
-                            is_ipv6=na.is_ipv6,
-                        )
-                        logger.debug(
-                            f"Sent ABORT_ACK for room {room_to_be_aborted} to "
-                            f"{decode_ip}:{decode_port}"
-                        )
-                    except Exception as e:
-                        logger.debug(
-                            f"Failed to send ABORT_ACK for room {room_to_be_aborted}: {e}"
-                        )
+                if self._handle_abort_notification(waiting_req_bytes):
                     continue
                 mooncake_session_id = waiting_req_bytes[3].decode("ascii")
                 if room == "None":
@@ -2224,16 +2232,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
                     self._handle_staging_req(msg)
                     continue
 
-                # Prefill acknowledges abort notification
-                if msg[0] == b"ABORT_ACK":
-                    ack_aborted_room = int(msg[1].decode("ascii"))
-                    logger.debug(f"Received ABORT_ACK for room {ack_aborted_room}")
-                    # Deferred release: the 3-frame ack carries the prefill rank
-                    # and means its transfer drained; aggregate for is_abort_release_safe.
-                    if self.enable_deferred_decode_kv_release and len(msg) >= 3:
-                        self.note_abort_ack(
-                            ack_aborted_room, int(msg[2].decode("ascii"))
-                        )
+                if self.handle_abort_ack_message(msg):
                     continue
 
                 bootstrap_room, status, prefill_rank = msg

--- a/python/sglang/srt/disaggregation/mooncake/conn.py
+++ b/python/sglang/srt/disaggregation/mooncake/conn.py
@@ -2082,11 +2082,13 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
     def _handle_deferred_abort_notification(
         self, notification: AbortNotification, room_active: bool
     ) -> None:
-        if notification.decode_ip is None or notification.decode_port is None:
-            return
         room = notification.room
         if room_active:
             self.update_status(room, KVPoll.Failed)
+
+        if notification.decode_ip is None or notification.decode_port is None:
+            return
+        if room_active:
             self.register_deferred_ack_target(
                 room, notification.decode_ip, notification.decode_port
             )
@@ -2119,6 +2121,7 @@ class MooncakeKVManager(StagingManagerMixin, CommonKVManager):
             return
         try:
             na = NetworkAddress(notification.decode_ip, notification.decode_port)
+            # Deferred ACKs carry a rank; the feature-off wire format does not.
             self._send_multipart_locked(
                 na.to_tcp(),
                 [ABORT_ACK_TAG, str(room).encode("ascii")],

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -30,8 +30,8 @@ from mori.io import (
 from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
 from sglang.srt.disaggregation.common.conn import (
     ABORT_TAG,
-    AckTarget,
     AbortNotification,
+    AckTarget,
     CommonKVBootstrapServer,
     CommonKVManager,
     CommonKVReceiver,

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -300,6 +300,16 @@ class _MoriTransferSubmissionError(RuntimeError):
         self.statuses = statuses
 
 
+class _SubmissionLocal(threading.local):
+    """Per-thread sink for statuses issued by a submission still in progress.
+
+    `statuses` is None outside a tracked submission, so a leaf that records
+    into it is a no-op on threads that are not submitting.
+    """
+
+    statuses: Optional[List[TransferStatus]] = None
+
+
 class MoriKVManager(CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
 
@@ -317,7 +327,7 @@ class MoriKVManager(CommonKVManager):
         self.aux_mem_descs: List[MemoryDesc] = []
         self.state_mem_descs: List[List[MemoryDesc]] = []
         self.transfer_lock = threading.Lock()
-        self._submission_local = threading.local()
+        self._submission_local = _SubmissionLocal()
         self._zmq_ctx = zmq.Context()
         self._socket_local = threading.local()
         self._send_aux_rdma = envs.SGLANG_MORI_SEND_AUX_RDMA.get()
@@ -607,7 +617,7 @@ class MoriKVManager(CommonKVManager):
                 list(self._submission_local.statuses),
             ) from exc
         finally:
-            del self._submission_local.statuses
+            self._submission_local.statuses = None
 
     def _enqueue_transfer_drain(
         self,
@@ -1150,7 +1160,7 @@ class MoriKVManager(CommonKVManager):
         return statuses
 
     def _record_submitted_statuses(self, statuses: List[TransferStatus]) -> None:
-        active_statuses = getattr(self._submission_local, "statuses", None)
+        active_statuses = self._submission_local.statuses
         if active_statuses is not None:
             active_statuses.extend(statuses)
 

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -7,6 +7,8 @@ import struct
 import threading
 import time
 import uuid
+from collections import defaultdict
+from queue import Queue
 from typing import Dict, List, Optional, Tuple
 
 import msgspec
@@ -51,6 +53,7 @@ from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 logger = logging.getLogger(__name__)
 MORI_GUARD = b"MoriMsgGuard"
 _TAG_ABORT = b"ABORT"
+_TAG_ABORT_ACK = b"ABORT_ACK"
 
 
 def _normalize_state_indices_per_component(
@@ -291,6 +294,12 @@ class TransferTarget:
     peer_info: KVArgsRegisterInfo
 
 
+class _MoriTransferSubmissionError(RuntimeError):
+    def __init__(self, message: str, statuses: List[TransferStatus]):
+        super().__init__(message)
+        self.statuses = statuses
+
+
 class MoriKVManager(CommonKVManager):
     AUX_DATA_HEADER = b"AUX_DATA"
 
@@ -308,6 +317,7 @@ class MoriKVManager(CommonKVManager):
         self.aux_mem_descs: List[MemoryDesc] = []
         self.state_mem_descs: List[List[MemoryDesc]] = []
         self.transfer_lock = threading.Lock()
+        self._submission_local = threading.local()
         self._zmq_ctx = zmq.Context()
         self._socket_local = threading.local()
         self._send_aux_rdma = envs.SGLANG_MORI_SEND_AUX_RDMA.get()
@@ -319,8 +329,18 @@ class MoriKVManager(CommonKVManager):
             ]
             self._wait_poll_ms = envs.SGLANG_MORI_WAIT_POLL_MS.get()
             self._transfer_timeout_ms = envs.SGLANG_MORI_TRANSFER_TIMEOUT_MS.get()
+            self._staging_outstanding = defaultdict(int)
+            self._abort_ack_lock = threading.Lock()
             self._room_status_notified: Dict[int, bool] = {}
             self._room_notify_lock = threading.Lock()
+            if self.enable_deferred_decode_kv_release:
+                self._drain_queue: Queue[
+                    Tuple[
+                        TransferKVChunk,
+                        List[TransferStatus],
+                        Optional[str],
+                    ]
+                ] = Queue(maxsize=self._num_shards)
             for shard, queue in enumerate(self._transfer_queues):
                 threading.Thread(
                     target=self._transfer_worker,
@@ -331,6 +351,15 @@ class MoriKVManager(CommonKVManager):
                         f"tp{self.attn_tp_rank}-s{shard}"
                     ),
                 ).start()
+                if self.enable_deferred_decode_kv_release:
+                    threading.Thread(
+                        target=self._drain_worker,
+                        daemon=True,
+                        name=(
+                            f"mori-drain-dp{self.system_dp_rank}-"
+                            f"tp{self.attn_tp_rank}-s{shard}"
+                        ),
+                    ).start()
             self._start_bootstrap_thread()
         elif self.disaggregation_mode == DisaggregationMode.DECODE:
             self.room_to_bootstrap_addr: Dict[int, str] = {}
@@ -428,11 +457,27 @@ class MoriKVManager(CommonKVManager):
             return
         super().update_status(bootstrap_room, status)
 
+    def reset_deferred_abort_room(self, bootstrap_room: int) -> None:
+        """Arm a new abort before its notifications can produce an ACK."""
+        self._deferred_abort_ack_tracker[bootstrap_room] = set()
+
+    def register_deferred_abort_room(self, bootstrap_room: int) -> None:
+        """Keep ACKs that arrived between notification and scheduler deferral."""
+        self._deferred_abort_ack_tracker.setdefault(bootstrap_room, set())
+
     def _transfer_worker(self, queue: FastQueue) -> None:
         while True:
             kv_chunk = queue.get()
+            self._mark_transfer_started(kv_chunk)
             try:
-                self._process_transfer_chunk(kv_chunk)
+                is_quiescent = self._process_transfer_chunk(kv_chunk)
+            except _MoriTransferSubmissionError as exc:
+                logger.exception(
+                    "Mori transfer submission failed for room %s",
+                    kv_chunk.room,
+                )
+                self._handle_submission_failure(kv_chunk, exc)
+                continue
             except Exception as exc:
                 failure_reason = f"transfer worker raised: {exc!r}"
                 try:
@@ -452,42 +497,161 @@ class MoriKVManager(CommonKVManager):
                         )
                     except Exception:
                         pass
+                self._mark_transfer_quiescent(kv_chunk)
+                continue
 
-    def _process_transfer_chunk(self, kv_chunk: TransferKVChunk) -> None:
+            if is_quiescent:
+                self._mark_transfer_quiescent(kv_chunk)
+
+    def _handle_submission_failure(
+        self, kv_chunk: TransferKVChunk, exc: _MoriTransferSubmissionError
+    ) -> None:
+        failure_reason = str(exc)
+        if exc.statuses:
+            self._enqueue_transfer_drain(kv_chunk, exc.statuses, failure_reason)
+            return
+        self._mark_transfer_quiescent(kv_chunk)
+        self._conclude_room_failure(kv_chunk.room, failure_reason)
+
+    def _mark_transfer_started(self, kv_chunk: TransferKVChunk) -> None:
+        if not self.enable_deferred_decode_kv_release:
+            return
+        with self._abort_ack_lock:
+            self._staging_outstanding[kv_chunk.room] += 1
+
+    def _mark_transfer_quiescent(self, kv_chunk: TransferKVChunk) -> None:
+        if not self.enable_deferred_decode_kv_release:
+            return
+
+        room = kv_chunk.room
+        target = None
+        with self._abort_ack_lock:
+            self._staging_outstanding[room] -= 1
+            if self._staging_outstanding[room] <= 0:
+                self._staging_outstanding.pop(room)
+                target = self._deferred_ack_targets.pop(room, None)
+        if target is not None:
+            self._send_abort_ack(target[0], target[1], room)
+
+    def _process_transfer_chunk(self, kv_chunk: TransferKVChunk) -> bool:
         room = kv_chunk.room
         if self._should_skip_transfer(room):
-            return
+            return True
 
         if kv_chunk.wait_event is not None:
             kv_chunk.wait_event.synchronize()
 
         if self._should_skip_transfer(room):
-            return
+            return True
 
-        statuses, target_infos = self._submit_kv_transfer(
-            room,
-            kv_chunk.prefill_kv_indices,
-            kv_chunk.index_slice,
-            kv_chunk.is_last_chunk,
-            aux_index=kv_chunk.prefill_aux_index,
-            state_indices=kv_chunk.state_indices,
+        statuses, target_infos = self._submit_transfer_chunk(kv_chunk)
+
+        if (
+            self._should_skip_transfer(room)
+            and not self.enable_deferred_decode_kv_release
+        ):
+            return True
+
+        failure_reason, is_quiescent = self._wait_for_chunk_completion(
+            kv_chunk, statuses
         )
-
         if self._should_skip_transfer(room):
-            return
-
-        failure_reason = self._wait_transfer_completion(statuses)
-        if self._should_skip_transfer(room):
-            return
+            return is_quiescent
         if failure_reason is not None:
-            self._conclude_room_failure(room, failure_reason)
-            return
+            if is_quiescent:
+                self._conclude_room_failure(room, failure_reason)
+            return is_quiescent
 
         if kv_chunk.is_last_chunk:
             self._notify_decode_for_room(
                 room, KVPoll.Success, target_infos=target_infos
             )
             self.update_status(room, KVPoll.Success)
+        return is_quiescent
+
+    def _wait_for_chunk_completion(
+        self, kv_chunk: TransferKVChunk, statuses: List[TransferStatus]
+    ) -> Tuple[Optional[str], bool]:
+        try:
+            failure_reason = self._wait_transfer_completion(statuses)
+            is_quiescent = not self.enable_deferred_decode_kv_release or not any(
+                status.InProgress() for status in statuses
+            )
+        except Exception as exc:
+            if not self.enable_deferred_decode_kv_release:
+                raise
+            failure_reason = f"Transfer completion failed: {exc!r}"
+            is_quiescent = False
+
+        if not is_quiescent:
+            self._enqueue_transfer_drain(kv_chunk, statuses, failure_reason)
+        return failure_reason, is_quiescent
+
+    def _submit_transfer_chunk(
+        self, kv_chunk: TransferKVChunk
+    ) -> Tuple[List[TransferStatus], Optional[List[TransferInfo]]]:
+        if not self.enable_deferred_decode_kv_release:
+            return self._submit_kv_transfer(
+                kv_chunk.room,
+                kv_chunk.prefill_kv_indices,
+                kv_chunk.index_slice,
+                kv_chunk.is_last_chunk,
+                aux_index=kv_chunk.prefill_aux_index,
+                state_indices=kv_chunk.state_indices,
+            )
+
+        self._submission_local.statuses = []
+        try:
+            return self._submit_kv_transfer(
+                kv_chunk.room,
+                kv_chunk.prefill_kv_indices,
+                kv_chunk.index_slice,
+                kv_chunk.is_last_chunk,
+                aux_index=kv_chunk.prefill_aux_index,
+                state_indices=kv_chunk.state_indices,
+            )
+        except Exception as exc:
+            raise _MoriTransferSubmissionError(
+                f"Transfer submission failed: {exc}",
+                list(self._submission_local.statuses),
+            ) from exc
+        finally:
+            del self._submission_local.statuses
+
+    def _enqueue_transfer_drain(
+        self,
+        kv_chunk: TransferKVChunk,
+        statuses: List[TransferStatus],
+        failure_reason: Optional[str],
+    ) -> None:
+        self._drain_queue.put((kv_chunk, statuses, failure_reason))
+
+    def _drain_worker(self) -> None:
+        while True:
+            kv_chunk, statuses, failure_reason = self._drain_queue.get()
+            while True:
+                try:
+                    self._drain_transfer_statuses(kv_chunk, statuses, failure_reason)
+                    break
+                except Exception:
+                    logger.exception(
+                        "Mori transfer drainer failed for room %s; retrying",
+                        kv_chunk.room,
+                    )
+                    time.sleep(max(self._wait_poll_ms, 1) / 1000)
+
+    def _drain_transfer_statuses(
+        self,
+        kv_chunk: TransferKVChunk,
+        statuses: List[TransferStatus],
+        failure_reason: Optional[str],
+    ) -> None:
+        for status in statuses:
+            if status.InProgress():
+                status.Wait()
+        if failure_reason is not None:
+            self._conclude_room_failure(kv_chunk.room, failure_reason)
+        self._mark_transfer_quiescent(kv_chunk)
 
     def _should_skip_transfer(self, room: int) -> bool:
         if room not in self.request_status or self.check_status(room) == KVPoll.Failed:
@@ -712,38 +876,71 @@ class MoriKVManager(CommonKVManager):
             return None
         return payload
 
-    def _handle_abort_message(self, msg: List[bytes]) -> None:
-        """Handle best-effort ABORT notifications from the decode side."""
+    def _parse_abort_message(
+        self, msg: List[bytes]
+    ) -> Optional[Tuple[int, Optional[str], Optional[int]]]:
         if len(msg) < 2:
             logger.warning("Malformed ABORT message: too few frames (%d)", len(msg))
-            return
+            return None
 
         try:
             bootstrap_room = int(msg[1].decode("ascii"))
         except (ValueError, UnicodeDecodeError):
             logger.warning("Malformed ABORT message: invalid room field %r", msg[1])
+            return None
+
+        if len(msg) < 4:
+            return bootstrap_room, None, None
+
+        try:
+            return (
+                bootstrap_room,
+                msg[2].decode("ascii"),
+                int(msg[3].decode("ascii")),
+            )
+        except (ValueError, UnicodeDecodeError):
+            logger.warning("Malformed ABORT message: invalid return address")
+            return bootstrap_room, None, None
+
+    def _handle_abort_message(self, msg: List[bytes]) -> None:
+        """Handle ABORT and defer its ACK until this rank's writes drain."""
+        parsed = self._parse_abort_message(msg)
+        if parsed is None:
             return
+        bootstrap_room, decode_ip, decode_port = parsed
 
         with self.transfer_lock:
             current = self.request_status.get(bootstrap_room)
-            if current is None:
-                logger.debug(
-                    "ABORT for room %s is not tracked; ignoring",
-                    bootstrap_room,
-                )
-                return
-            if current == KVPoll.Success:
-                logger.debug(
-                    "ABORT for room %s already succeeded; ignoring",
-                    bootstrap_room,
-                )
-                return
-            if current == KVPoll.Failed:
-                return
+            room_active = current is not None and current != KVPoll.Success
+            if room_active and current != KVPoll.Failed:
+                self.update_status(bootstrap_room, KVPoll.Failed)
 
-            self.update_status(bootstrap_room, KVPoll.Failed)
+        if room_active:
+            logger.debug("Room %s marked Failed via ABORT from decode", bootstrap_room)
+        else:
+            logger.debug(
+                "ABORT for room %s is already complete or not tracked",
+                bootstrap_room,
+            )
 
-        logger.debug("Room %s marked Failed via ABORT from decode", bootstrap_room)
+        self._arm_abort_ack(bootstrap_room, decode_ip, decode_port)
+
+    def _arm_abort_ack(
+        self,
+        bootstrap_room: int,
+        decode_ip: Optional[str],
+        decode_port: Optional[int],
+    ) -> None:
+        if not self.enable_deferred_decode_kv_release:
+            return
+        if decode_ip is None or decode_port is None:
+            return
+
+        with self._abort_ack_lock:
+            if self._staging_outstanding.get(bootstrap_room, 0) > 0:
+                self._deferred_ack_targets[bootstrap_room] = (decode_ip, decode_port)
+                return
+        self._send_abort_ack(decode_ip, decode_port, bootstrap_room)
 
     def _start_bootstrap_thread(self) -> None:
         def bootstrap_worker():
@@ -781,6 +978,18 @@ class MoriKVManager(CommonKVManager):
                 if not rooms:
                     self.addr_to_rooms_tracker.pop(bootstrap_addr, None)
 
+    def _handle_abort_ack_message(self, msg: List[bytes]) -> None:
+        if len(msg) < 3:
+            logger.warning("Incomplete ABORT_ACK received")
+            return
+        try:
+            bootstrap_room = int(msg[1].decode("ascii"))
+            prefill_rank = int(msg[2].decode("ascii"))
+        except (ValueError, UnicodeDecodeError):
+            logger.warning("Malformed ABORT_ACK received")
+            return
+        self.note_abort_ack(bootstrap_room, prefill_rank)
+
     def _start_decode_thread(self) -> None:
         def decode_worker():
             while True:
@@ -788,6 +997,9 @@ class MoriKVManager(CommonKVManager):
                     msg = self.server_socket.recv_multipart()
                     if msg and msg[0] == MoriKVManager.AUX_DATA_HEADER:
                         self._handle_aux_data(msg)
+                        continue
+                    if msg and msg[0] == _TAG_ABORT_ACK:
+                        self._handle_abort_ack_message(msg)
                         continue
 
                     if not msg or msg[0] != MORI_GUARD:
@@ -982,7 +1194,13 @@ class MoriKVManager(CommonKVManager):
             [plan.sizes],
             [transfer_uid],
         )
+        self._record_submitted_statuses(statuses)
         return statuses
+
+    def _record_submitted_statuses(self, statuses: List[TransferStatus]) -> None:
+        active_statuses = getattr(self._submission_local, "statuses", None)
+        if active_statuses is not None:
+            active_statuses.extend(statuses)
 
     def _build_contiguous_transfer_plan(
         self, grouped_plan: GroupedIndexPlan, item_len: int
@@ -1219,11 +1437,13 @@ class MoriKVManager(CommonKVManager):
             remote_offsets.append([dst_aux_index * item_len])
             sizes.append([item_len])
             uids.append(self.engine.allocate_transfer_uid())
-        return list(
+        statuses = list(
             self.engine.batch_write(
                 src_descs, local_offsets, dst_descs, remote_offsets, sizes, uids
             )
         )
+        self._record_submitted_statuses(statuses)
+        return statuses
 
     def send_aux_tcp(
         self,
@@ -1432,6 +1652,7 @@ class MoriKVManager(CommonKVManager):
                 [[size]],
                 [transfer_uid],
             )
+            self._record_submitted_statuses(batch_statuses)
             statuses.extend(batch_statuses)
 
         return statuses
@@ -1706,7 +1927,20 @@ class MoriKVSender(CommonKVSender):
         return status
 
     def clear(self) -> None:
-        super().clear()
+        if self.kv_mgr.enable_deferred_decode_kv_release:
+            with self.kv_mgr._abort_ack_lock:
+                # Keep the endpoint while a drainer can still produce its ACK.
+                target = self.kv_mgr._deferred_ack_targets.pop(
+                    self.bootstrap_room, None
+                )
+                super().clear()
+                if (
+                    target is not None
+                    and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
+                ):
+                    self.kv_mgr._deferred_ack_targets[self.bootstrap_room] = target
+        else:
+            super().clear()
         with self.kv_mgr._room_notify_lock:
             self.kv_mgr._room_status_notified.pop(self.bootstrap_room, None)
 
@@ -1735,6 +1969,7 @@ class MoriKVReceiver(CommonKVReceiver):
     ):
         super().__init__(mgr, bootstrap_addr, bootstrap_room)
         self.init_time: Optional[float] = None
+        self.metadata_published = False
 
     def init(
         self,
@@ -1849,6 +2084,7 @@ class MoriKVReceiver(CommonKVReceiver):
                 self.conclude_state = KVPoll.Failed
                 self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
                 return
+        self.metadata_published = True
         self.init_time = time.time()
 
     def poll(self) -> KVPoll:
@@ -1886,6 +2122,12 @@ class MoriKVReceiver(CommonKVReceiver):
         raise KVTransferError(
             self.bootstrap_room, failure_reason, is_from_another_rank=is_propagated
         )
+
+    def _send_abort_notification(self):
+        if self.kv_mgr.enable_deferred_decode_kv_release and self.metadata_published:
+            # The peer can ACK immediately, before the scheduler defers release.
+            self.kv_mgr.reset_deferred_abort_room(self.bootstrap_room)
+        super()._send_abort_notification()
 
     def abort(self):
         if self.bootstrap_room is None:

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -7,7 +7,6 @@ import struct
 import threading
 import time
 import uuid
-from collections import defaultdict
 from queue import Queue
 from typing import Dict, List, Optional, Tuple
 
@@ -31,6 +30,7 @@ from mori.io import (
 from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
 from sglang.srt.disaggregation.common.conn import (
     ABORT_TAG,
+    AckTarget,
     AbortNotification,
     CommonKVBootstrapServer,
     CommonKVManager,
@@ -329,7 +329,6 @@ class MoriKVManager(CommonKVManager):
             ]
             self._wait_poll_ms = envs.SGLANG_MORI_WAIT_POLL_MS.get()
             self._transfer_timeout_ms = envs.SGLANG_MORI_TRANSFER_TIMEOUT_MS.get()
-            self._staging_outstanding = defaultdict(int)
             self._abort_ack_lock = threading.Lock()
             self._room_status_notified: Dict[int, bool] = {}
             self._room_notify_lock = threading.Lock()
@@ -523,7 +522,7 @@ class MoriKVManager(CommonKVManager):
                 self._staging_outstanding.pop(room)
                 target = self._deferred_ack_targets.pop(room, None)
         if target is not None:
-            self._send_abort_ack(target[0], target[1], room)
+            self._send_abort_ack(room, target)
 
     def _process_transfer_chunk(self, kv_chunk: TransferKVChunk) -> bool:
         room = kv_chunk.room
@@ -889,26 +888,24 @@ class MoriKVManager(CommonKVManager):
                 bootstrap_room,
             )
 
-        self._arm_abort_ack(
-            bootstrap_room, notification.decode_ip, notification.decode_port
-        )
+        self._arm_abort_ack(bootstrap_room, notification)
 
     def _arm_abort_ack(
         self,
         bootstrap_room: int,
-        decode_ip: Optional[str],
-        decode_port: Optional[int],
+        notification: AbortNotification,
     ) -> None:
         if not self.enable_deferred_decode_kv_release:
             return
-        if decode_ip is None or decode_port is None:
+        ack_target: Optional[AckTarget] = notification.deferred_ack_target()
+        if ack_target is None:
             return
 
         with self._abort_ack_lock:
             if self._staging_outstanding.get(bootstrap_room, 0) > 0:
-                self._deferred_ack_targets[bootstrap_room] = (decode_ip, decode_port)
+                self._deferred_ack_targets[bootstrap_room] = ack_target
                 return
-        self._send_abort_ack(decode_ip, decode_port, bootstrap_room)
+        self._send_abort_ack(bootstrap_room, ack_target)
 
     def _start_bootstrap_thread(self) -> None:
         def bootstrap_worker():
@@ -1875,16 +1872,7 @@ class MoriKVSender(CommonKVSender):
     def clear(self) -> None:
         if self.kv_mgr.enable_deferred_decode_kv_release:
             with self.kv_mgr._abort_ack_lock:
-                # Keep the endpoint while a drainer can still produce its ACK.
-                target = self.kv_mgr._deferred_ack_targets.pop(
-                    self.bootstrap_room, None
-                )
                 super().clear()
-                if (
-                    target is not None
-                    and self.kv_mgr._staging_outstanding.get(self.bootstrap_room, 0) > 0
-                ):
-                    self.kv_mgr._deferred_ack_targets[self.bootstrap_room] = target
         else:
             super().clear()
         with self.kv_mgr._room_notify_lock:

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -30,6 +30,8 @@ from mori.io import (
 
 from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll
 from sglang.srt.disaggregation.common.conn import (
+    ABORT_TAG,
+    AbortNotification,
     CommonKVBootstrapServer,
     CommonKVManager,
     CommonKVReceiver,
@@ -52,8 +54,6 @@ from sglang.srt.utils.network import NetworkAddress, get_local_ip_auto
 
 logger = logging.getLogger(__name__)
 MORI_GUARD = b"MoriMsgGuard"
-_TAG_ABORT = b"ABORT"
-_TAG_ABORT_ACK = b"ABORT_ACK"
 
 
 def _normalize_state_indices_per_component(
@@ -456,14 +456,6 @@ class MoriKVManager(CommonKVManager):
             # Failed is terminal — never overwrite with non-Failed.
             return
         super().update_status(bootstrap_room, status)
-
-    def reset_deferred_abort_room(self, bootstrap_room: int) -> None:
-        """Arm a new abort before its notifications can produce an ACK."""
-        self._deferred_abort_ack_tracker[bootstrap_room] = set()
-
-    def register_deferred_abort_room(self, bootstrap_room: int) -> None:
-        """Keep ACKs that arrived between notification and scheduler deferral."""
-        self._deferred_abort_ack_tracker.setdefault(bootstrap_room, set())
 
     def _transfer_worker(self, queue: FastQueue) -> None:
         while True:
@@ -876,38 +868,12 @@ class MoriKVManager(CommonKVManager):
             return None
         return payload
 
-    def _parse_abort_message(
-        self, msg: List[bytes]
-    ) -> Optional[Tuple[int, Optional[str], Optional[int]]]:
-        if len(msg) < 2:
-            logger.warning("Malformed ABORT message: too few frames (%d)", len(msg))
-            return None
-
-        try:
-            bootstrap_room = int(msg[1].decode("ascii"))
-        except (ValueError, UnicodeDecodeError):
-            logger.warning("Malformed ABORT message: invalid room field %r", msg[1])
-            return None
-
-        if len(msg) < 4:
-            return bootstrap_room, None, None
-
-        try:
-            return (
-                bootstrap_room,
-                msg[2].decode("ascii"),
-                int(msg[3].decode("ascii")),
-            )
-        except (ValueError, UnicodeDecodeError):
-            logger.warning("Malformed ABORT message: invalid return address")
-            return bootstrap_room, None, None
-
     def _handle_abort_message(self, msg: List[bytes]) -> None:
         """Handle ABORT and defer its ACK until this rank's writes drain."""
-        parsed = self._parse_abort_message(msg)
-        if parsed is None:
+        notification = AbortNotification.from_zmq(msg)
+        if notification is None:
             return
-        bootstrap_room, decode_ip, decode_port = parsed
+        bootstrap_room = notification.room
 
         with self.transfer_lock:
             current = self.request_status.get(bootstrap_room)
@@ -923,7 +889,9 @@ class MoriKVManager(CommonKVManager):
                 bootstrap_room,
             )
 
-        self._arm_abort_ack(bootstrap_room, decode_ip, decode_port)
+        self._arm_abort_ack(
+            bootstrap_room, notification.decode_ip, notification.decode_port
+        )
 
     def _arm_abort_ack(
         self,
@@ -951,7 +919,7 @@ class MoriKVManager(CommonKVManager):
                         continue
 
                     tag = msg[0]
-                    if tag == _TAG_ABORT:
+                    if tag == ABORT_TAG:
                         self._handle_abort_message(msg)
                         continue
 
@@ -978,18 +946,6 @@ class MoriKVManager(CommonKVManager):
                 if not rooms:
                     self.addr_to_rooms_tracker.pop(bootstrap_addr, None)
 
-    def _handle_abort_ack_message(self, msg: List[bytes]) -> None:
-        if len(msg) < 3:
-            logger.warning("Incomplete ABORT_ACK received")
-            return
-        try:
-            bootstrap_room = int(msg[1].decode("ascii"))
-            prefill_rank = int(msg[2].decode("ascii"))
-        except (ValueError, UnicodeDecodeError):
-            logger.warning("Malformed ABORT_ACK received")
-            return
-        self.note_abort_ack(bootstrap_room, prefill_rank)
-
     def _start_decode_thread(self) -> None:
         def decode_worker():
             while True:
@@ -998,8 +954,7 @@ class MoriKVManager(CommonKVManager):
                     if msg and msg[0] == MoriKVManager.AUX_DATA_HEADER:
                         self._handle_aux_data(msg)
                         continue
-                    if msg and msg[0] == _TAG_ABORT_ACK:
-                        self._handle_abort_ack_message(msg)
+                    if self.handle_abort_ack_message(msg):
                         continue
 
                     if not msg or msg[0] != MORI_GUARD:
@@ -1969,7 +1924,6 @@ class MoriKVReceiver(CommonKVReceiver):
     ):
         super().__init__(mgr, bootstrap_addr, bootstrap_room)
         self.init_time: Optional[float] = None
-        self.metadata_published = False
 
     def init(
         self,
@@ -2084,7 +2038,6 @@ class MoriKVReceiver(CommonKVReceiver):
                 self.conclude_state = KVPoll.Failed
                 self.kv_mgr.update_status(self.bootstrap_room, KVPoll.Failed)
                 return
-        self.metadata_published = True
         self.init_time = time.time()
 
     def poll(self) -> KVPoll:
@@ -2122,12 +2075,6 @@ class MoriKVReceiver(CommonKVReceiver):
         raise KVTransferError(
             self.bootstrap_room, failure_reason, is_from_another_rank=is_propagated
         )
-
-    def _send_abort_notification(self):
-        if self.kv_mgr.enable_deferred_decode_kv_release and self.metadata_published:
-            # The peer can ACK immediately, before the scheduler defers release.
-            self.kv_mgr.reset_deferred_abort_room(self.bootstrap_room)
-        super()._send_abort_notification()
 
     def abort(self):
         if self.bootstrap_room is None:

--- a/python/sglang/srt/disaggregation/mori/conn.py
+++ b/python/sglang/srt/disaggregation/mori/conn.py
@@ -1751,46 +1751,37 @@ class MoriKVManager(CommonKVManager):
                 target_infos_snapshot = list(transfer_infos.values())
 
         result_statuses: List[TransferStatus] = []
-        try:
-            for target in targets:
-                info = target.info
-                peer_info = target.peer_info
+        for target in targets:
+            info = target.info
+            peer_info = target.peer_info
 
-                if not info.is_dummy:
-                    dst_indices_chunk = info.dst_kv_indices[index_slice]
-                    result_statuses.extend(
-                        self.send_kvcache(peer_info, kv_indices, dst_indices_chunk)
-                    )
+            if not info.is_dummy:
+                dst_indices_chunk = info.dst_kv_indices[index_slice]
+                result_statuses.extend(
+                    self.send_kvcache(peer_info, kv_indices, dst_indices_chunk)
+                )
 
-                if (
-                    is_last_chunk
-                    and state_indices is not None
-                    and not info.is_dummy
-                    and self.state_mem_descs
-                ):
-                    result_statuses.extend(
-                        self.send_state(
-                            peer_info, state_indices, info.dst_state_indices
-                        )
-                    )
+            if (
+                is_last_chunk
+                and state_indices is not None
+                and not info.is_dummy
+                and self.state_mem_descs
+            ):
+                result_statuses.extend(
+                    self.send_state(peer_info, state_indices, info.dst_state_indices)
+                )
 
-                if (
-                    is_last_chunk
-                    and aux_index is not None
-                    and info.dst_aux_index >= 0
-                    and self.pp_group.is_last_rank
-                ):
-                    result_statuses.extend(
-                        self.send_aux(
-                            peer_info, aux_index, info.dst_aux_index, bootstrap_room
-                        )
+            if (
+                is_last_chunk
+                and aux_index is not None
+                and info.dst_aux_index >= 0
+                and self.pp_group.is_last_rank
+            ):
+                result_statuses.extend(
+                    self.send_aux(
+                        peer_info, aux_index, info.dst_aux_index, bootstrap_room
                     )
-        except Exception as e:
-            logger.exception(
-                "Mori KV transfer submission failed for bootstrap_room=%s",
-                bootstrap_room,
-            )
-            raise RuntimeError(f"Transfer submission failed: {e}") from e
+                )
 
         return result_statuses, target_infos_snapshot
 

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 from sglang.srt.disaggregation.base.conn import KVArgs, KVPoll, StateType
 from sglang.srt.disaggregation.common.conn import (
+    ABORT_TAG,
+    AbortNotification,
     CommonKVBootstrapServer,
     CommonKVManager,
     CommonKVReceiver,
@@ -605,12 +607,7 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 if msg[0] == b"STAGING_REQ":
                     self._handle_staging_req(msg)
                     continue
-                if msg[0] == b"ABORT_ACK":
-                    # Drain ack for an aborted room; aggregate per prefill rank.
-                    if len(msg) >= 3:
-                        self.note_abort_ack(
-                            int(msg[1].decode("ascii")), int(msg[2].decode("ascii"))
-                        )
+                if self.handle_abort_ack_message(msg):
                     continue
                 logger.warning(
                     "decode_listener_thread: unexpected message tag %s",
@@ -2759,16 +2756,13 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
         return self.transfer_statuses[room].is_done()
 
     def _handle_abort_notification(self, msg: List[bytes]) -> bool:
-        if not msg or msg[0] != b"ABORT":
+        if not msg or msg[0] != ABORT_TAG:
             return False
 
-        try:
-            room_to_be_aborted = int(msg[1].decode("ascii"))
-            decode_ip = msg[2].decode("ascii") if len(msg) > 2 else None
-            decode_port = int(msg[3].decode("ascii")) if len(msg) > 3 else None
-        except Exception as e:
-            logger.debug(f"Ignoring malformed abort notification: {e}")
+        notification = AbortNotification.from_zmq(msg)
+        if notification is None:
             return True
+        room_to_be_aborted = notification.room
 
         room_active = (
             room_to_be_aborted in self.request_status
@@ -2790,22 +2784,37 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 f"ignoring (already completed or unknown)"
             )
 
+        self._handle_deferred_abort_ack(notification, room_active)
+        return True
+
+    def _handle_deferred_abort_ack(
+        self, notification: AbortNotification, room_active: bool
+    ) -> None:
+        room_to_be_aborted = notification.room
         # Deferred KV release: register only after the status flip above (see
         # register_deferred_ack_target), then try once -- the room may already be
         # quiescent and never revisited by the worker. A concluded/unknown room is
         # acked only when nothing is still counted for it: the ERR path abandons
         # sibling handles that may still be writing and clear() then drops the
         # room, so "unknown" alone does not imply quiescent.
-        if self.enable_deferred_decode_kv_release and decode_port is not None:
+        if (
+            self.enable_deferred_decode_kv_release
+            and notification.decode_ip is not None
+            and notification.decode_port is not None
+        ):
             if room_active:
                 self.register_deferred_ack_target(
-                    room_to_be_aborted, decode_ip, decode_port
+                    room_to_be_aborted,
+                    notification.decode_ip,
+                    notification.decode_port,
                 )
                 self._maybe_ack_drained_abort(room_to_be_aborted)
             elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
-                self._send_abort_ack(decode_ip, decode_port, room_to_be_aborted)
-
-        return True
+                self._send_abort_ack(
+                    notification.decode_ip,
+                    notification.decode_port,
+                    room_to_be_aborted,
+                )
 
     def _start_bootstrap_thread(self):
         def bootstrap_thread():

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -498,8 +498,6 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 FastQueue() for _ in range(transfer_queue_size)
             ]
             self.exceptions: Dict[int, Exception] = {}
-            # Per-room count of chunks not yet transferred; teardown waits for
-            # zero so a deferred chunk is not dropped by an early conclude.
             # Mirror mooncake: one staging buffer per worker queue, all
             # built before workers spawn so each worker owns a private
             # buffer (no cross-worker contention on the staging ring).

--- a/python/sglang/srt/disaggregation/nixl/conn.py
+++ b/python/sglang/srt/disaggregation/nixl/conn.py
@@ -500,7 +500,6 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
             self.exceptions: Dict[int, Exception] = {}
             # Per-room count of chunks not yet transferred; teardown waits for
             # zero so a deferred chunk is not dropped by an early conclude.
-            self._staging_outstanding = defaultdict(int)
             # Mirror mooncake: one staging buffer per worker queue, all
             # built before workers spawn so each worker owns a private
             # buffer (no cross-worker contention on the staging ring).
@@ -1409,7 +1408,9 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 self.record_failure(room, str(e))
                 self.update_status(room, KVPoll.Failed)
                 # No ack here on purpose: the DONE barrier bails on the first
-                # ERR, so siblings may still be writing; fall back to the timeout.
+                # ERR, so siblings may still be writing. The target cannot ever
+                # produce a safe ACK; discard it and fall back to the timeout.
+                self.poison_deferred_ack_room(room)
 
     def register_buffer_to_engine(self):
         self.kv_descs = []
@@ -2784,37 +2785,23 @@ class NixlKVManager(StagingManagerMixin, CommonKVManager):
                 f"ignoring (already completed or unknown)"
             )
 
-        self._handle_deferred_abort_ack(notification, room_active)
+        self._handle_deferred_abort_ack(notification)
         return True
 
-    def _handle_deferred_abort_ack(
-        self, notification: AbortNotification, room_active: bool
-    ) -> None:
+    def _handle_deferred_abort_ack(self, notification: AbortNotification) -> None:
         room_to_be_aborted = notification.room
-        # Deferred KV release: register only after the status flip above (see
-        # register_deferred_ack_target), then try once -- the room may already be
-        # quiescent and never revisited by the worker. A concluded/unknown room is
-        # acked only when nothing is still counted for it: the ERR path abandons
-        # sibling handles that may still be writing and clear() then drops the
-        # room, so "unknown" alone does not imply quiescent.
-        if (
-            self.enable_deferred_decode_kv_release
-            and notification.decode_ip is not None
-            and notification.decode_port is not None
-        ):
-            if room_active:
-                self.register_deferred_ack_target(
-                    room_to_be_aborted,
-                    notification.decode_ip,
-                    notification.decode_port,
-                )
-                self._maybe_ack_drained_abort(room_to_be_aborted)
-            elif self._staging_outstanding.get(room_to_be_aborted, 0) == 0:
-                self._send_abort_ack(
-                    notification.decode_ip,
-                    notification.decode_port,
-                    room_to_be_aborted,
-                )
+        if not self.enable_deferred_decode_kv_release:
+            return
+        ack_target = notification.deferred_ack_target()
+        if ack_target is None:
+            return
+
+        # The active-room status flip happens before registration. Success or a
+        # missing status does not imply quiescence: clear() can remove the room
+        # while a counted handle is still writing. The immediate retry closes
+        # both races where the worker drains before or during registration.
+        self.register_deferred_ack_target(room_to_be_aborted, ack_target)
+        self._maybe_ack_drained_abort(room_to_be_aborted)
 
     def _start_bootstrap_thread(self):
         def bootstrap_thread():

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -5239,20 +5239,7 @@ class Scheduler(
                 if recv_req.abort_all or decode_req.req.rid.startswith(recv_req.rid):
                     logger.debug(f"Abort transfer queue request. {decode_req.req.rid=}")
                     receiver = decode_req.kv_receiver
-                    receiver.abort()
-                    # Arm drain-ack accounting once the ABORT is sent, so acks
-                    # arriving before this req is deferred (e.g. during the next
-                    # forward step) are captured. A fresh set also drops stale acks
-                    # from a prior request that reused this bootstrap_room. A
-                    # redundant abort only re-wipes -- holds longer, never releases
-                    # early -- so no transition guard is needed.
-                    if (
-                        receiver.kv_mgr.enable_deferred_decode_kv_release
-                        and receiver.abort_notified
-                    ):
-                        receiver.kv_mgr.register_deferred_abort_room(
-                            decode_req.req.bootstrap_room
-                        )
+                    receiver.abort_for_deferred_release()
 
             # Abort requests whose KV is already backed up for retraction.
             if self.disagg_decode_prealloc_queue.retracted_queue:

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -13,8 +13,18 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from sglang.srt.disaggregation import decode as decode_mod
-from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import (
+    ABORT_ACK_TAG,
+    ABORT_TAG,
+    AbortAck,
+    AbortNotification,
+    CommonKVManager,
+    CommonKVReceiver,
+)
 from sglang.srt.disaggregation.decode import DecodeTransferQueue
+from sglang.srt.disaggregation.fake.conn import FakeKVReceiver
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
@@ -26,7 +36,136 @@ def _make_manager():
     touch (avoids the heavy real __init__)."""
     mgr = CommonKVManager.__new__(CommonKVManager)
     mgr._deferred_abort_ack_tracker = {}
+    mgr.enable_deferred_decode_kv_release = True
     return mgr
+
+
+class _TestReceiver(CommonKVReceiver):
+    def poll(self):
+        raise NotImplementedError
+
+    def failure_exception(self):
+        raise NotImplementedError
+
+
+class TestAbortWireFormat(CustomTestCase):
+    def test_abort_notification_round_trip(self):
+        notification = AbortNotification(100, "10.0.0.1", 5000)
+
+        self.assertEqual(
+            AbortNotification.from_zmq(notification.to_zmq()), notification
+        )
+
+    def test_legacy_abort_without_return_address(self):
+        self.assertEqual(
+            AbortNotification.from_zmq([ABORT_TAG, b"101"]),
+            AbortNotification(room=101),
+        )
+
+    def test_malformed_abort_is_rejected(self):
+        self.assertIsNone(AbortNotification.from_zmq([ABORT_TAG, b"bad-room"]))
+
+    def test_abort_ack_round_trip(self):
+        ack = AbortAck(room=102, prefill_rank=3)
+
+        self.assertEqual(AbortAck.from_zmq(ack.to_zmq()), ack)
+
+
+class TestCommonAbortAckDispatch(CustomTestCase):
+    def test_abort_ack_message_is_aggregated(self):
+        mgr = _make_manager()
+        mgr.register_deferred_abort_room(103)
+
+        claimed = mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"103", b"4"])
+
+        self.assertTrue(claimed)
+        self.assertEqual(mgr._deferred_abort_ack_tracker[103], {4})
+
+    def test_non_ack_message_is_not_claimed(self):
+        mgr = _make_manager()
+
+        self.assertFalse(mgr.handle_abort_ack_message([b"STATUS", b"103", b"4"]))
+
+    def test_malformed_abort_ack_is_ignored(self):
+        mgr = _make_manager()
+        mgr.register_deferred_abort_room(103)
+
+        self.assertTrue(
+            mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"bad-room", b"4"])
+        )
+        self.assertFalse(mgr.is_abort_release_safe(103, required_acks=1))
+
+    def test_abort_for_deferred_release_arms_before_abort(self):
+        mgr = _make_manager()
+        receiver = _TestReceiver.__new__(_TestReceiver)
+        receiver.kv_mgr = mgr
+        receiver.bootstrap_room = 104
+        observed = []
+        receiver.abort = lambda: observed.append(104 in mgr._deferred_abort_ack_tracker)
+
+        receiver.abort_for_deferred_release()
+
+        self.assertEqual(observed, [True])
+
+    def test_abort_for_deferred_release_skips_tracker_when_disabled(self):
+        mgr = _make_manager()
+        mgr.enable_deferred_decode_kv_release = False
+        receiver = _TestReceiver.__new__(_TestReceiver)
+        receiver.kv_mgr = mgr
+        receiver.bootstrap_room = 105
+        receiver.abort = lambda: None
+
+        receiver.abort_for_deferred_release()
+
+        self.assertNotIn(105, mgr._deferred_abort_ack_tracker)
+
+    def test_base_receiver_falls_back_to_plain_abort(self):
+        receiver = FakeKVReceiver.__new__(FakeKVReceiver)
+        receiver.conclude_state = None
+
+        receiver.abort_for_deferred_release()
+
+        self.assertEqual(receiver.conclude_state, KVPoll.Failed)
+
+
+class TestMooncakeAbortNotification(CustomTestCase):
+    @staticmethod
+    def _manager(status=KVPoll.WaitingForInput):
+        mgr = MooncakeKVManager.__new__(MooncakeKVManager)
+        mgr.enable_deferred_decode_kv_release = True
+        mgr.request_status = {} if status is None else {106: status}
+        mgr._deferred_ack_targets = {}
+        mgr._staging_outstanding = {}
+        mgr.check_status = lambda room: mgr.request_status[room]
+        mgr.update_status = lambda room, value: mgr.request_status.__setitem__(
+            room, value
+        )
+        mgr._sent = []
+        mgr._send_abort_ack = lambda ip, port, room: mgr._sent.append((ip, port, room))
+        return mgr
+
+    def test_active_room_defers_ack_until_transport_drains(self):
+        mgr = self._manager()
+        mgr._staging_outstanding[106] = 1
+
+        claimed = mgr._handle_abort_notification(
+            AbortNotification(106, "10.0.0.2", 6000).to_zmq()
+        )
+
+        self.assertTrue(claimed)
+        self.assertEqual(mgr.request_status[106], KVPoll.Failed)
+        self.assertEqual(mgr._deferred_ack_targets[106], ("10.0.0.2", 6000))
+        self.assertEqual(mgr._sent, [])
+
+    def test_untracked_quiescent_room_acks_immediately(self):
+        mgr = self._manager(status=None)
+
+        claimed = mgr._handle_abort_notification(
+            AbortNotification(106, "10.0.0.2", 6000).to_zmq()
+        )
+
+        self.assertTrue(claimed)
+        self.assertEqual(mgr._sent, [("10.0.0.2", 6000, 106)])
 
 
 class TestAbortAckAggregation(CustomTestCase):

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -18,9 +18,9 @@ from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import (
     ABORT_ACK_TAG,
     ABORT_TAG,
-    AckTarget,
     AbortAck,
     AbortNotification,
+    AckTarget,
     CommonKVManager,
     CommonKVReceiver,
     CommonKVSender,

--- a/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
+++ b/test/registered/unit/disaggregation/test_deferred_decode_kv_release.py
@@ -10,6 +10,7 @@ fires. See DecodeTransferQueue.resolve_deferred_releases.
 
 import unittest
 from types import SimpleNamespace
+from typing import NamedTuple
 from unittest.mock import patch
 
 from sglang.srt.disaggregation import decode as decode_mod
@@ -17,18 +18,70 @@ from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import (
     ABORT_ACK_TAG,
     ABORT_TAG,
+    AckTarget,
     AbortAck,
     AbortNotification,
     CommonKVManager,
     CommonKVReceiver,
+    CommonKVSender,
 )
 from sglang.srt.disaggregation.decode import DecodeTransferQueue
 from sglang.srt.disaggregation.fake.conn import FakeKVReceiver
-from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
 register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+ABORT_GENERATION = 7
+
+
+class AbortScenario(NamedTuple):
+    name: str
+    status: KVPoll | None
+    outstanding: int
+    expected_status: KVPoll | None
+
+
+ABORT_SCENARIOS = (
+    AbortScenario(
+        name="active transfer",
+        status=KVPoll.Transferring,
+        outstanding=1,
+        expected_status=KVPoll.Failed,
+    ),
+    # Window 2: no worker will revisit a room that is already quiescent.
+    AbortScenario(
+        name="active quiescent room",
+        status=KVPoll.WaitingForInput,
+        outstanding=0,
+        expected_status=KVPoll.Failed,
+    ),
+    AbortScenario(
+        name="completed transfer",
+        status=KVPoll.Success,
+        outstanding=1,
+        expected_status=KVPoll.Success,
+    ),
+    AbortScenario(
+        name="completed quiescent room",
+        status=KVPoll.Success,
+        outstanding=0,
+        expected_status=KVPoll.Success,
+    ),
+    # clear() can remove request_status before a counted write drains.
+    AbortScenario(
+        name="untracked transfer",
+        status=None,
+        outstanding=1,
+        expected_status=None,
+    ),
+    AbortScenario(
+        name="untracked quiescent room",
+        status=None,
+        outstanding=0,
+        expected_status=None,
+    ),
+)
 
 
 def _make_manager():
@@ -36,7 +89,22 @@ def _make_manager():
     touch (avoids the heavy real __init__)."""
     mgr = CommonKVManager.__new__(CommonKVManager)
     mgr._deferred_abort_ack_tracker = {}
+    mgr._deferred_abort_generation = 0
     mgr.enable_deferred_decode_kv_release = True
+    return mgr
+
+
+def _make_prefill_manager():
+    mgr = CommonKVManager.__new__(CommonKVManager)
+    mgr.enable_deferred_decode_kv_release = True
+    mgr.request_status = {}
+    mgr.req_to_decode_prefix_len = {}
+    mgr.transfer_infos = {}
+    mgr._deferred_ack_targets = {}
+    mgr._deferred_ack_poisoned_rooms = set()
+    mgr._staging_outstanding = {}
+    mgr._sent = []
+    mgr._send_abort_ack = lambda *args: mgr._sent.append(args)
     return mgr
 
 
@@ -48,9 +116,115 @@ class _TestReceiver(CommonKVReceiver):
         raise NotImplementedError
 
 
+class _TestSender(CommonKVSender):
+    def poll(self):
+        raise NotImplementedError
+
+    def failure_exception(self):
+        raise NotImplementedError
+
+
+class DeferredAbortNotificationScenarios:
+    room: int
+    decode_ip: str
+    decode_port: int
+
+    def _make_abort_manager(self, status: KVPoll | None):
+        raise NotImplementedError
+
+    def _dispatch_abort(self, manager) -> None:
+        claimed = manager._handle_abort_notification(self._abort_message())
+        self.assertTrue(claimed)
+
+    def _start_test_transfer(self, manager) -> None:
+        manager._staging_outstanding[self.room] = 1
+
+    def _drain_test_transfer(self, manager) -> None:
+        manager._staging_outstanding[self.room] -= 1
+        manager._maybe_ack_drained_abort(self.room)
+
+    def _abort_message(self) -> list[bytes]:
+        return AbortNotification(
+            self.room,
+            self.decode_ip,
+            self.decode_port,
+            ABORT_GENERATION,
+        ).to_zmq()
+
+    def test_deferred_ack_follows_room_status_and_outstanding_transfers(self):
+        target = AckTarget(
+            self.decode_ip,
+            self.decode_port,
+            ABORT_GENERATION,
+        )
+        for case in ABORT_SCENARIOS:
+            with self.subTest(name=case.name):
+                manager = self._make_abort_manager(case.status)
+                if case.outstanding:
+                    self._start_test_transfer(manager)
+
+                self._dispatch_abort(manager)
+
+                self.assertEqual(
+                    manager.request_status.get(self.room), case.expected_status
+                )
+                if case.outstanding:
+                    self.assertEqual(manager._deferred_ack_targets[self.room], target)
+                    self.assertEqual(manager._sent, [])
+                    self._drain_test_transfer(manager)
+                self.assertNotIn(self.room, manager._deferred_ack_targets)
+                self.assertEqual(manager._sent, [(self.room, target)])
+
+
+class TaggedAbortNotificationScenarios:
+    room: int
+
+    def test_non_abort_message_is_not_claimed(self):
+        manager = self._make_abort_manager(KVPoll.WaitingForInput)
+
+        self.assertFalse(
+            manager._handle_abort_notification(
+                [b"STAGING_REQ", str(self.room).encode()]
+            )
+        )
+
+
+class WorkerFailureAbortScenarios:
+    room: int
+    decode_ip: str
+    decode_port: int
+
+    def _provoke_worker_failure(self, manager) -> None:
+        raise NotImplementedError
+
+    def test_worker_exception_poison_is_reset_for_reused_room(self):
+        target = AckTarget(
+            self.decode_ip,
+            self.decode_port,
+            ABORT_GENERATION,
+        )
+        manager = self._make_abort_manager(KVPoll.WaitingForInput)
+        manager._deferred_ack_targets[self.room] = target
+
+        self._provoke_worker_failure(manager)
+
+        self.assertEqual(manager._staging_outstanding[self.room], 1)
+        self.assertNotIn(self.room, manager._deferred_ack_targets)
+
+        self._dispatch_abort(manager)
+        self.assertNotIn(self.room, manager._deferred_ack_targets)
+        self.assertEqual(manager._sent, [])
+
+        manager.request_status.pop(self.room, None)
+        CommonKVManager.update_status(manager, self.room, KVPoll.Bootstrapping)
+        self._dispatch_abort(manager)
+        self.assertNotIn(self.room, manager._deferred_ack_targets)
+        self.assertEqual(manager._sent, [(self.room, target)])
+
+
 class TestAbortWireFormat(CustomTestCase):
     def test_abort_notification_round_trip(self):
-        notification = AbortNotification(100, "10.0.0.1", 5000)
+        notification = AbortNotification(100, "10.0.0.1", 5000, 7)
 
         self.assertEqual(
             AbortNotification.from_zmq(notification.to_zmq()), notification
@@ -65,8 +239,18 @@ class TestAbortWireFormat(CustomTestCase):
     def test_malformed_abort_is_rejected(self):
         self.assertIsNone(AbortNotification.from_zmq([ABORT_TAG, b"bad-room"]))
 
+    def test_malformed_abort_generation_is_dropped(self):
+        notification = AbortNotification.from_zmq(
+            [ABORT_TAG, b"101", b"10.0.0.1", b"5000", b"bad-generation"]
+        )
+
+        self.assertEqual(
+            notification,
+            AbortNotification(room=101, decode_ip="10.0.0.1", decode_port=5000),
+        )
+
     def test_abort_ack_round_trip(self):
-        ack = AbortAck(room=102, prefill_rank=3)
+        ack = AbortAck(room=102, prefill_rank=3, generation=7)
 
         self.assertEqual(AbortAck.from_zmq(ack.to_zmq()), ack)
 
@@ -74,12 +258,12 @@ class TestAbortWireFormat(CustomTestCase):
 class TestCommonAbortAckDispatch(CustomTestCase):
     def test_abort_ack_message_is_aggregated(self):
         mgr = _make_manager()
-        mgr.register_deferred_abort_room(103)
+        generation = mgr.register_deferred_abort_room(103)
 
-        claimed = mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"103", b"4"])
+        claimed = mgr.handle_abort_ack_message(AbortAck(103, 4, generation).to_zmq())
 
         self.assertTrue(claimed)
-        self.assertEqual(mgr._deferred_abort_ack_tracker[103], {4})
+        self.assertEqual(mgr._deferred_abort_ack_tracker[103].prefill_ranks, {4})
 
     def test_non_ack_message_is_not_claimed(self):
         mgr = _make_manager()
@@ -91,15 +275,45 @@ class TestCommonAbortAckDispatch(CustomTestCase):
         mgr.register_deferred_abort_room(103)
 
         self.assertTrue(
-            mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"bad-room", b"4"])
+            mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"bad-room", b"4", b"1"])
         )
         self.assertFalse(mgr.is_abort_release_safe(103, required_acks=1))
+
+    def test_generationless_abort_ack_warns_and_is_ignored(self):
+        mgr = _make_manager()
+        mgr.register_deferred_abort_room(103)
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.logger.warning_once"
+        ) as warning:
+            claimed = mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"103", b"4"])
+
+        self.assertTrue(claimed)
+        self.assertFalse(mgr.is_abort_release_safe(103, required_acks=1))
+        warning.assert_called_once()
+
+    def test_stale_generation_ack_is_ignored_after_room_reuse(self):
+        mgr = _make_manager()
+        mgr.register_deferred_abort_room(103)
+        mgr.clear_deferred_abort_state(103)
+        mgr.register_deferred_abort_room(103)
+
+        claimed = mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"103", b"4", b"1"])
+
+        self.assertTrue(claimed)
+        self.assertFalse(mgr.is_abort_release_safe(103, required_acks=1))
+
+        claimed = mgr.handle_abort_ack_message([ABORT_ACK_TAG, b"103", b"4", b"2"])
+
+        self.assertTrue(claimed)
+        self.assertTrue(mgr.is_abort_release_safe(103, required_acks=1))
 
     def test_abort_for_deferred_release_arms_before_abort(self):
         mgr = _make_manager()
         receiver = _TestReceiver.__new__(_TestReceiver)
         receiver.kv_mgr = mgr
         receiver.bootstrap_room = 104
+        receiver.abort_notified = False
         observed = []
         receiver.abort = lambda: observed.append(104 in mgr._deferred_abort_ack_tracker)
 
@@ -113,6 +327,7 @@ class TestCommonAbortAckDispatch(CustomTestCase):
         receiver = _TestReceiver.__new__(_TestReceiver)
         receiver.kv_mgr = mgr
         receiver.bootstrap_room = 105
+        receiver.abort_notified = False
         receiver.abort = lambda: None
 
         receiver.abort_for_deferred_release()
@@ -128,80 +343,102 @@ class TestCommonAbortAckDispatch(CustomTestCase):
         self.assertEqual(receiver.conclude_state, KVPoll.Failed)
 
 
-class TestMooncakeAbortNotification(CustomTestCase):
-    @staticmethod
-    def _manager(status=KVPoll.WaitingForInput):
-        mgr = MooncakeKVManager.__new__(MooncakeKVManager)
-        mgr.enable_deferred_decode_kv_release = True
-        mgr.request_status = {} if status is None else {106: status}
-        mgr._deferred_ack_targets = {}
-        mgr._staging_outstanding = {}
-        mgr.check_status = lambda room: mgr.request_status[room]
-        mgr.update_status = lambda room, value: mgr.request_status.__setitem__(
-            room, value
-        )
-        mgr._sent = []
-        mgr._send_abort_ack = lambda ip, port, room: mgr._sent.append((ip, port, room))
-        return mgr
+class TestDeferredAckTargets(CustomTestCase):
+    def test_ack_held_until_outstanding_drains(self):
+        mgr = _make_prefill_manager()
+        target = AckTarget("10.0.0.1", 5000, 9)
+        mgr.register_deferred_ack_target(7, target)
 
-    def test_active_room_defers_ack_until_transport_drains(self):
-        mgr = self._manager()
-        mgr._staging_outstanding[106] = 1
-
-        claimed = mgr._handle_abort_notification(
-            AbortNotification(106, "10.0.0.2", 6000).to_zmq()
-        )
-
-        self.assertTrue(claimed)
-        self.assertEqual(mgr.request_status[106], KVPoll.Failed)
-        self.assertEqual(mgr._deferred_ack_targets[106], ("10.0.0.2", 6000))
+        mgr._staging_outstanding[7] = 1
+        mgr._maybe_ack_drained_abort(7)
         self.assertEqual(mgr._sent, [])
 
-    def test_untracked_quiescent_room_acks_immediately(self):
-        mgr = self._manager(status=None)
+        mgr._staging_outstanding[7] = 0
+        mgr._maybe_ack_drained_abort(7)
+        self.assertEqual(mgr._sent, [(7, target)])
 
-        claimed = mgr._handle_abort_notification(
-            AbortNotification(106, "10.0.0.2", 6000).to_zmq()
-        )
+    def test_ack_fires_at_most_once(self):
+        mgr = _make_prefill_manager()
+        target = AckTarget("10.0.0.2", 5001, 10)
+        mgr.register_deferred_ack_target(8, target)
 
-        self.assertTrue(claimed)
-        self.assertEqual(mgr._sent, [("10.0.0.2", 6000, 106)])
+        mgr._maybe_ack_drained_abort(8)
+        mgr._maybe_ack_drained_abort(8)
+
+        self.assertEqual(mgr._sent, [(8, target)])
+        self.assertNotIn(8, mgr._deferred_ack_targets)
+
+    def test_unregistered_room_is_noop(self):
+        mgr = _make_prefill_manager()
+
+        mgr._maybe_ack_drained_abort(999)
+
+        self.assertEqual(mgr._sent, [])
+
+    def test_sender_clear_keeps_target_until_outstanding_transfer_drains(self):
+        mgr = _make_prefill_manager()
+        mgr.request_status = {7: KVPoll.Failed}
+        target = AckTarget("10.0.0.1", 5000, 9)
+        mgr.register_deferred_ack_target(7, target)
+        mgr._staging_outstanding[7] = 1
+        sender = _TestSender.__new__(_TestSender)
+        sender.kv_mgr = mgr
+        sender.bootstrap_room = 7
+
+        sender.clear()
+
+        self.assertEqual(mgr._deferred_ack_targets[7], target)
+        mgr._staging_outstanding[7] = 0
+        mgr._maybe_ack_drained_abort(7)
+        self.assertEqual(mgr._sent, [(7, target)])
+
+    def test_sender_clear_discards_target_without_outstanding_transfer(self):
+        mgr = _make_prefill_manager()
+        mgr.request_status = {7: KVPoll.Failed}
+        mgr.register_deferred_ack_target(7, AckTarget("10.0.0.1", 5000, 9))
+        sender = _TestSender.__new__(_TestSender)
+        sender.kv_mgr = mgr
+        sender.bootstrap_room = 7
+
+        sender.clear()
+
+        self.assertNotIn(7, mgr._deferred_ack_targets)
+
+    def test_prefill_unique_rank_formula(self):
+        mgr = CommonKVManager.__new__(CommonKVManager)
+        mgr.attn_tp_rank, mgr.pp_size, mgr.attn_cp_size = 2, 3, 4
+        mgr.pp_rank, mgr.attn_cp_rank = 1, 3
+
+        self.assertEqual(mgr._prefill_unique_rank(), 31)
 
 
 class TestAbortAckAggregation(CustomTestCase):
     def test_release_safe_only_after_all_required_ranks_ack(self):
         mgr = _make_manager()
         room = 100
-        mgr.register_deferred_abort_room(room)
+        generation = mgr.register_deferred_abort_room(room)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
 
-        mgr.note_abort_ack(room, 0)
+        mgr.note_abort_ack(room, 0, generation)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
 
-        mgr.note_abort_ack(room, 1)
+        mgr.note_abort_ack(room, 1, generation)
         self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
 
     def test_duplicate_rank_ack_does_not_over_count(self):
         mgr = _make_manager()
         room = 101
-        mgr.register_deferred_abort_room(room)
-        mgr.note_abort_ack(room, 0)
-        mgr.note_abort_ack(room, 0)  # same rank twice
+        generation = mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0, generation)
+        mgr.note_abort_ack(room, 0, generation)  # same rank twice
         # Two acks arrived but from one rank: not safe for a 2-rank prefill.
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
-
-    def test_single_rank_fast_path(self):
-        mgr = _make_manager()
-        room = 102
-        mgr.register_deferred_abort_room(room)
-        mgr.note_abort_ack(room, 0)
-        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=1))
 
     def test_clear_deferred_abort_state(self):
         mgr = _make_manager()
         room = 103
-        mgr.register_deferred_abort_room(room)
-        mgr.note_abort_ack(room, 0)
+        generation = mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0, generation)
         mgr.clear_deferred_abort_state(room)
         self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
@@ -211,41 +448,16 @@ class TestAbortAckAggregation(CustomTestCase):
         # would otherwise pollute a later request reusing the same room).
         mgr = _make_manager()
         room = 104
-        mgr.note_abort_ack(room, 0)  # no register yet
+        mgr.note_abort_ack(room, 0, 1)  # no register yet
         self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
         self.assertFalse(mgr.is_abort_release_safe(room, required_acks=1))
-
-    def test_late_ack_after_release_does_not_pollute_reused_room(self):
-        # Regression for bootstrap_room reuse: req A (room R) releases, then a
-        # late ack from A arrives, then req B reuses room R. B must start from a
-        # clean slate and not inherit A's ack (which would release B early while
-        # its transfer is still in flight -> KV corruption).
-        mgr = _make_manager()
-        room = 105
-
-        # Req A: held, one of two ranks acks, then released (e.g. timed out).
-        mgr.register_deferred_abort_room(room)
-        mgr.note_abort_ack(room, 0)
-        mgr.clear_deferred_abort_state(room)
-
-        # Late ack from A's other rank arrives after release -> dropped.
-        mgr.note_abort_ack(room, 1)
-        self.assertNotIn(room, mgr._deferred_abort_ack_tracker)
-
-        # Req B reuses room R.
-        mgr.register_deferred_abort_room(room)
-        # Only B's rank-0 has acked so far; a 2-rank prefill is NOT safe yet.
-        mgr.note_abort_ack(room, 0)
-        self.assertFalse(mgr.is_abort_release_safe(room, required_acks=2))
-        mgr.note_abort_ack(room, 1)
-        self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
 
     def test_register_resets_stale_acks(self):
         mgr = _make_manager()
         room = 106
-        mgr.register_deferred_abort_room(room)
-        mgr.note_abort_ack(room, 0)
-        mgr.note_abort_ack(room, 1)
+        generation = mgr.register_deferred_abort_room(room)
+        mgr.note_abort_ack(room, 0, generation)
+        mgr.note_abort_ack(room, 1, generation)
         self.assertTrue(mgr.is_abort_release_safe(room, required_acks=2))
         # Re-registering (a later reuse) wipes the prior acks.
         mgr.register_deferred_abort_room(room)
@@ -301,7 +513,7 @@ class TestResolveDeferredReleases(CustomTestCase):
         dreq = _make_decode_req(room, idx, mgr, n_prefill_ranks=2)
         # In production the room is armed in abort_request when the ABORT is
         # sent, before the scheduler defers here.
-        mgr.register_deferred_abort_room(room)
+        generation = mgr.register_deferred_abort_room(room)
         q._defer_release(dreq)
 
         with patch.object(decode_mod, "release_kv_cache") as rel:
@@ -311,13 +523,13 @@ class TestResolveDeferredReleases(CustomTestCase):
             self.assertEqual(len(q._deferred_releases), 1)
 
             # One of two ranks acked -> still held.
-            mgr.note_abort_ack(room, 0)
+            mgr.note_abort_ack(room, 0, generation)
             q.resolve_deferred_releases()
             rel.assert_not_called()
             self.assertEqual(len(q._deferred_releases), 1)
 
             # Both ranks acked -> released exactly once.
-            mgr.note_abort_ack(room, 1)
+            mgr.note_abort_ack(room, 1, generation)
             q.resolve_deferred_releases()
             rel.assert_called_once_with(dreq.req, q.tree_cache, is_insert=False)
 

--- a/test/registered/unit/disaggregation/test_mooncake_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_mooncake_deferred_kv_release.py
@@ -9,6 +9,11 @@ from collections import defaultdict
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+from test_deferred_decode_kv_release import (
+    DeferredAbortNotificationScenarios,
+    TaggedAbortNotificationScenarios,
+    WorkerFailureAbortScenarios,
+)
 
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import (
@@ -20,12 +25,6 @@ from sglang.srt.disaggregation.common.utils import TransferKVChunk
 from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
-
-from test_deferred_decode_kv_release import (
-    DeferredAbortNotificationScenarios,
-    TaggedAbortNotificationScenarios,
-    WorkerFailureAbortScenarios,
-)
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 

--- a/test/registered/unit/disaggregation/test_mooncake_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_mooncake_deferred_kv_release.py
@@ -1,0 +1,145 @@
+"""Deferred decode-side KV release on the Mooncake backend.
+
+The bootstrap thread records the ACK target while a transfer is outstanding.
+Only the transfer worker can send that ACK after its write has drained.
+"""
+
+import unittest
+from collections import defaultdict
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import (
+    ABORT_ACK_TAG,
+    ABORT_TAG,
+    AbortNotification,
+)
+from sglang.srt.disaggregation.common.utils import TransferKVChunk
+from sglang.srt.disaggregation.mooncake.conn import MooncakeKVManager
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+from test_deferred_decode_kv_release import (
+    DeferredAbortNotificationScenarios,
+    TaggedAbortNotificationScenarios,
+    WorkerFailureAbortScenarios,
+)
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+ROOM = 106
+DECODE_IP = "10.0.0.2"
+DECODE_PORT = 6000
+
+
+def _manager(
+    *, enabled: bool = True, status: KVPoll | None = KVPoll.WaitingForInput
+) -> MooncakeKVManager:
+    manager = MooncakeKVManager.__new__(MooncakeKVManager)
+    manager.enable_deferred_decode_kv_release = enabled
+    manager.request_status = {} if status is None else {ROOM: status}
+    manager._deferred_ack_targets = {}
+    manager._deferred_ack_poisoned_rooms = set()
+    manager._staging_outstanding = {}
+    manager.check_status = lambda room: manager.request_status[room]
+    manager.update_status = lambda room, value: manager.request_status.__setitem__(
+        room, value
+    )
+    manager._sent = []
+    manager._send_abort_ack = lambda *args: manager._sent.append(args)
+    manager._send_multipart_locked = MagicMock()
+    return manager
+
+
+def _chunk() -> TransferKVChunk:
+    return TransferKVChunk(
+        room=ROOM,
+        prefill_kv_indices=np.array([1], dtype=np.int32),
+        index_slice=slice(0, 1),
+        is_last_chunk=False,
+        chunk_id=0,
+        prefill_aux_index=None,
+        state_indices=None,
+    )
+
+
+class TestMooncakeAbortNotification(
+    DeferredAbortNotificationScenarios,
+    TaggedAbortNotificationScenarios,
+    WorkerFailureAbortScenarios,
+    CustomTestCase,
+):
+    room = ROOM
+    decode_ip = DECODE_IP
+    decode_port = DECODE_PORT
+
+    def _make_abort_manager(self, status: KVPoll | None):
+        return _manager(status=status)
+
+    def _provoke_worker_failure(self, manager) -> None:
+        manager.enable_trace = False
+        manager.bootstrap_port = 8998
+        manager._staging_outstanding = defaultdict(int)
+        manager.check_status = MagicMock(side_effect=RuntimeError("worker error"))
+        queue = MagicMock()
+        queue.get.return_value = _chunk()
+
+        with self.assertRaisesRegex(RuntimeError, "Transfer thread failed"):
+            manager.transfer_worker(queue, MagicMock())
+        manager.check_status = lambda room: manager.request_status[room]
+
+    def test_generationless_abort_warns_and_falls_back_to_timeout(self):
+        manager = _manager()
+        message = AbortNotification(ROOM, DECODE_IP, DECODE_PORT).to_zmq()
+
+        with patch(
+            "sglang.srt.disaggregation.common.conn.logger.warning_once"
+        ) as warning:
+            claimed = manager._handle_abort_notification(message)
+
+        self.assertTrue(claimed)
+        self.assertEqual(manager.request_status[ROOM], KVPoll.Failed)
+        self.assertEqual(manager._deferred_ack_targets, {})
+        self.assertEqual(manager._sent, [])
+        warning.assert_called_once()
+
+    def test_abort_without_valid_return_address_still_marks_room_failed(self):
+        messages = (
+            ("missing", [ABORT_TAG, str(ROOM).encode("ascii")]),
+            (
+                "malformed port",
+                [
+                    ABORT_TAG,
+                    str(ROOM).encode("ascii"),
+                    DECODE_IP.encode("ascii"),
+                    b"bad",
+                ],
+            ),
+        )
+
+        for name, message in messages:
+            with self.subTest(name=name):
+                manager = _manager()
+
+                claimed = manager._handle_abort_notification(message)
+
+                self.assertTrue(claimed)
+                self.assertEqual(manager.request_status[ROOM], KVPoll.Failed)
+                self.assertEqual(manager._deferred_ack_targets, {})
+                self.assertEqual(manager._sent, [])
+
+    def test_feature_off_sends_legacy_ack(self):
+        manager = _manager(enabled=False)
+
+        claimed = manager._handle_abort_notification(self._abort_message())
+
+        self.assertTrue(claimed)
+        self.assertEqual(manager.request_status[ROOM], KVPoll.Failed)
+        payload = manager._send_multipart_locked.call_args.args[1]
+        self.assertEqual(payload, [ABORT_ACK_TAG, str(ROOM).encode("ascii")])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
@@ -1,0 +1,466 @@
+"""Deferred decode-side KV release on the Mori backend."""
+
+import importlib
+import sys
+import threading
+import types
+import unittest
+from collections import defaultdict
+from enum import IntEnum
+from queue import Queue
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+
+
+def _install_mori_stubs() -> None:
+    try:
+        importlib.import_module("mori.cpp")
+        importlib.import_module("mori.io")
+        return
+    except (ImportError, OSError):
+        pass
+
+    mori = types.ModuleType("mori")
+    mori.__path__ = []
+    mori_cpp = types.ModuleType("mori.cpp")
+    mori_io = types.ModuleType("mori.io")
+
+    class FakeStatusCode(IntEnum):
+        SUCCESS = 0
+        IN_PROGRESS = 1
+        FAILED = 2
+
+    mori_cpp.TransferStatus = object
+    for name in (
+        "BackendType",
+        "EngineDesc",
+        "IOEngine",
+        "IOEngineConfig",
+        "MemoryDesc",
+        "MemoryLocationType",
+        "PollCqMode",
+        "RdmaBackendConfig",
+    ):
+        setattr(mori_io, name, object)
+    mori_io.StatusCode = FakeStatusCode
+    mori.cpp = mori_cpp
+    mori.io = mori_io
+    sys.modules["mori"] = mori
+    sys.modules["mori.cpp"] = mori_cpp
+    sys.modules["mori.io"] = mori_io
+
+
+_install_mori_stubs()
+
+from sglang.srt.disaggregation.base.conn import KVPoll
+from sglang.srt.disaggregation.common.conn import CommonKVReceiver
+from sglang.srt.disaggregation.common.utils import TransferKVChunk
+from sglang.srt.disaggregation.mori.conn import (
+    _TAG_ABORT,
+    _TAG_ABORT_ACK,
+    MoriKVManager,
+    MoriKVReceiver,
+    MoriKVSender,
+    StatusCode,
+    _MoriTransferSubmissionError,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _manager(enabled: bool = True) -> MoriKVManager:
+    manager = MoriKVManager.__new__(MoriKVManager)
+    manager.enable_deferred_decode_kv_release = enabled
+    manager.request_status = {}
+    manager.transfer_lock = threading.Lock()
+    manager._abort_ack_lock = threading.Lock()
+    manager._deferred_ack_targets = {}
+    manager._deferred_abort_ack_tracker = {}
+    manager._staging_outstanding = defaultdict(int)
+    manager._drain_queue = Queue(maxsize=1)
+    manager._submission_local = threading.local()
+    manager.req_to_decode_prefix_len = {}
+    manager.transfer_infos = {}
+    manager._room_notify_lock = threading.Lock()
+    manager._room_status_notified = {}
+    manager.failure_lock = threading.Lock()
+    manager.failure_records = {}
+    manager._sent = []
+    manager._send_abort_ack = lambda ip, port, room: manager._sent.append(
+        (ip, port, room)
+    )
+    manager._wait_poll_ms = 0
+    manager._transfer_timeout_ms = 0
+    return manager
+
+
+def _abort_message(room: int = 11) -> list[bytes]:
+    return [_TAG_ABORT, str(room).encode(), b"10.0.0.3", b"6000"]
+
+
+def _chunk(room: int = 11) -> TransferKVChunk:
+    return TransferKVChunk(
+        room=room,
+        prefill_kv_indices=np.array([1], dtype=np.int32),
+        index_slice=slice(0, 1),
+        is_last_chunk=False,
+        prefill_aux_index=None,
+        state_indices=None,
+    )
+
+
+class TestMoriAbortAck(unittest.TestCase):
+    def test_active_write_defers_ack_until_quiescent(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Transferring
+        chunk = _chunk()
+        manager._mark_transfer_started(chunk)
+
+        manager._handle_abort_message(_abort_message())
+
+        self.assertEqual(manager.request_status[11], KVPoll.Failed)
+        self.assertEqual(manager._sent, [])
+        self.assertEqual(manager._deferred_ack_targets[11], ("10.0.0.3", 6000))
+
+        manager._mark_transfer_quiescent(chunk)
+        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+        self.assertNotIn(11, manager._deferred_ack_targets)
+        self.assertNotIn(11, manager._staging_outstanding)
+
+    def test_idle_active_room_acks_immediately(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.WaitingForInput
+
+        manager._handle_abort_message(_abort_message())
+
+        self.assertEqual(manager.request_status[11], KVPoll.Failed)
+        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+
+    def test_completed_room_acks_immediately(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Success
+
+        manager._handle_abort_message(_abort_message())
+
+        self.assertEqual(manager.request_status[11], KVPoll.Success)
+        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+
+    def test_completed_room_with_outstanding_write_defers_ack(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Success
+        chunk = _chunk()
+        manager._mark_transfer_started(chunk)
+
+        manager._handle_abort_message(_abort_message())
+
+        self.assertEqual(manager._sent, [])
+        self.assertEqual(manager._deferred_ack_targets[11], ("10.0.0.3", 6000))
+        manager._mark_transfer_quiescent(chunk)
+        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+
+    def test_legacy_abort_without_return_address_only_marks_failed(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.WaitingForInput
+
+        manager._handle_abort_message([_TAG_ABORT, b"11"])
+
+        self.assertEqual(manager.request_status[11], KVPoll.Failed)
+        self.assertEqual(manager._sent, [])
+        self.assertEqual(manager._deferred_ack_targets, {})
+
+    def test_feature_off_preserves_abort_without_ack(self):
+        manager = _manager(enabled=False)
+        manager.request_status[11] = KVPoll.WaitingForInput
+
+        manager._handle_abort_message(_abort_message())
+
+        self.assertEqual(manager.request_status[11], KVPoll.Failed)
+        self.assertEqual(manager._sent, [])
+        self.assertEqual(manager._deferred_ack_targets, {})
+
+    def test_invalid_return_address_still_marks_room_failed(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.WaitingForInput
+
+        manager._handle_abort_message([_TAG_ABORT, b"11", b"10.0.0.3", b"bad"])
+
+        self.assertEqual(manager.request_status[11], KVPoll.Failed)
+        self.assertEqual(manager._sent, [])
+
+    def test_abort_after_submit_waits_for_terminal_status(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Transferring
+        status = MagicMock()
+        status.InProgress.return_value = False
+        manager._submit_kv_transfer = MagicMock(return_value=([status], None))
+        wait_results = iter((StatusCode.IN_PROGRESS, StatusCode.SUCCESS))
+
+        def wait_all(*args, **kwargs):
+            result = next(wait_results)
+            if result == StatusCode.IN_PROGRESS:
+                manager._handle_abort_message(_abort_message())
+                self.assertEqual(manager._sent, [])
+            return result
+
+        manager.engine = MagicMock()
+        manager.engine.wait_all.side_effect = wait_all
+        chunk = _chunk()
+        manager._mark_transfer_started(chunk)
+
+        is_quiescent = manager._process_transfer_chunk(chunk)
+
+        self.assertTrue(is_quiescent)
+        self.assertEqual(manager.engine.wait_all.call_count, 2)
+        self.assertEqual(manager._sent, [])
+        manager._mark_transfer_quiescent(chunk)
+        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+
+    def test_sla_failure_acks_after_status_drains(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Transferring
+        manager._transfer_timeout_ms = 1
+        manager.engine = MagicMock()
+        manager.engine.wait_all.return_value = StatusCode.IN_PROGRESS
+        status = MagicMock()
+        status.InProgress.return_value = True
+        manager._submit_kv_transfer = MagicMock(return_value=([status], None))
+        manager._conclude_room_failure = MagicMock()
+        chunk = _chunk()
+        manager._mark_transfer_started(chunk)
+
+        with patch(
+            "sglang.srt.disaggregation.mori.conn.time.perf_counter",
+            side_effect=(0.0, 0.002),
+        ):
+            is_quiescent = manager._process_transfer_chunk(chunk)
+
+        self.assertFalse(is_quiescent)
+        manager.engine.wait_all.assert_called_once()
+        self.assertEqual(manager._sent, [])
+        self.assertEqual(manager._staging_outstanding[11], 1)
+        manager._conclude_room_failure.assert_not_called()
+        manager._handle_abort_message(_abort_message())
+        queued_chunk, queued_statuses, failure_reason = (
+            manager._drain_queue.get_nowait()
+        )
+        manager._drain_transfer_statuses(queued_chunk, queued_statuses, failure_reason)
+
+        status.Wait.assert_called_once_with()
+        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+        self.assertNotIn(11, manager._staging_outstanding)
+        manager._conclude_room_failure.assert_called_once_with(
+            11, "KV transfer exceeded SLA 1ms"
+        )
+
+    def test_sla_failure_keeps_legacy_early_return_when_disabled(self):
+        manager = _manager(enabled=False)
+        manager._transfer_timeout_ms = 1
+        manager.engine = MagicMock()
+        manager.engine.wait_all.side_effect = (
+            StatusCode.IN_PROGRESS,
+            StatusCode.SUCCESS,
+        )
+
+        with patch(
+            "sglang.srt.disaggregation.mori.conn.time.perf_counter",
+            side_effect=(0.0, 0.002),
+        ):
+            failure = manager._wait_transfer_completion([object()])
+
+        self.assertEqual(failure, "KV transfer exceeded SLA 1ms")
+        self.assertEqual(manager.engine.wait_all.call_count, 1)
+
+    def test_sender_clear_preserves_ack_target_until_write_drains(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Failed
+        chunk = _chunk()
+        manager._mark_transfer_started(chunk)
+        manager._handle_abort_message(_abort_message())
+        sender = MoriKVSender.__new__(MoriKVSender)
+        sender.kv_mgr = manager
+        sender.bootstrap_room = 11
+
+        sender.clear()
+
+        self.assertEqual(manager._deferred_ack_targets[11], ("10.0.0.3", 6000))
+        manager._mark_transfer_quiescent(chunk)
+        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+
+    def test_wait_event_failure_releases_outstanding_count(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Transferring
+        manager._conclude_room_failure = MagicMock()
+        chunk = _chunk()
+        chunk.wait_event = MagicMock()
+        chunk.wait_event.synchronize.side_effect = RuntimeError("event failed")
+        queue = MagicMock()
+        queue.get.side_effect = (chunk, KeyboardInterrupt())
+
+        with patch("sglang.srt.disaggregation.mori.conn.logger.exception"):
+            with self.assertRaises(KeyboardInterrupt):
+                manager._transfer_worker(queue)
+
+        self.assertNotIn(11, manager._staging_outstanding)
+        manager._conclude_room_failure.assert_called_once()
+
+    def test_wait_all_exception_keeps_status_for_draining(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Transferring
+        status = MagicMock()
+        manager._submit_kv_transfer = MagicMock(return_value=([status], None))
+        manager.engine = MagicMock()
+        manager.engine.wait_all.side_effect = RuntimeError("wait failed")
+        manager._conclude_room_failure = MagicMock()
+
+        is_quiescent = manager._process_transfer_chunk(_chunk())
+
+        self.assertFalse(is_quiescent)
+        queued_chunk, queued_statuses, failure_reason = (
+            manager._drain_queue.get_nowait()
+        )
+        self.assertEqual(queued_chunk.room, 11)
+        self.assertEqual(queued_statuses, [status])
+        self.assertEqual(
+            failure_reason, "Transfer completion failed: RuntimeError('wait failed')"
+        )
+        manager._conclude_room_failure.assert_not_called()
+
+    def test_partial_submission_failure_transfers_ownership_to_drainer(self):
+        manager = _manager()
+        manager.request_status[11] = KVPoll.Transferring
+        status = MagicMock()
+
+        def submit(*args, **kwargs):
+            manager._record_submitted_statuses([status])
+            raise RuntimeError("later target failed")
+
+        manager._submit_kv_transfer = submit
+        manager._conclude_room_failure = MagicMock()
+        chunk = _chunk()
+        manager._mark_transfer_started(chunk)
+
+        with self.assertRaises(_MoriTransferSubmissionError) as raised:
+            manager._process_transfer_chunk(chunk)
+        manager._handle_submission_failure(chunk, raised.exception)
+
+        queued_chunk, queued_statuses, failure_reason = (
+            manager._drain_queue.get_nowait()
+        )
+        self.assertIs(queued_chunk, chunk)
+        self.assertEqual(queued_statuses, [status])
+        self.assertEqual(
+            failure_reason,
+            "Transfer submission failed: later target failed",
+        )
+        self.assertEqual(manager._staging_outstanding[11], 1)
+        manager._conclude_room_failure.assert_not_called()
+
+    def test_drain_worker_retries_same_item_after_exception(self):
+        manager = _manager()
+        manager._wait_poll_ms = 0
+        chunk = _chunk()
+        status = MagicMock()
+        manager._drain_queue = MagicMock()
+        manager._drain_queue.get.side_effect = (
+            (chunk, [status], None),
+            KeyboardInterrupt(),
+        )
+        manager._drain_transfer_statuses = MagicMock(
+            side_effect=(RuntimeError("transient wait failure"), None)
+        )
+
+        with patch("sglang.srt.disaggregation.mori.conn.logger.exception") as log:
+            with patch("sglang.srt.disaggregation.mori.conn.time.sleep"):
+                with self.assertRaises(KeyboardInterrupt):
+                    manager._drain_worker()
+
+        self.assertEqual(manager._drain_transfer_statuses.call_count, 2)
+        log.assert_called_once()
+
+    def test_failure_notification_precedes_ownership_release(self):
+        manager = _manager()
+        chunk = _chunk()
+        status = MagicMock()
+        status.InProgress.return_value = False
+        manager._conclude_room_failure = MagicMock(
+            side_effect=(RuntimeError("notification failed"), None)
+        )
+        manager._mark_transfer_quiescent = MagicMock()
+
+        with self.assertRaises(RuntimeError):
+            manager._drain_transfer_statuses(chunk, [status], "transfer failed")
+        manager._mark_transfer_quiescent.assert_not_called()
+
+        manager._drain_transfer_statuses(chunk, [status], "transfer failed")
+
+        self.assertEqual(manager._conclude_room_failure.call_count, 2)
+        manager._mark_transfer_quiescent.assert_called_once_with(chunk)
+
+
+class TestMoriDecodeAbortAck(unittest.TestCase):
+    def test_ack_is_recorded_for_held_room(self):
+        manager = _manager()
+        manager.register_deferred_abort_room(21)
+
+        manager._handle_abort_ack_message([_TAG_ABORT_ACK, b"21", b"3"])
+
+        self.assertTrue(manager.is_abort_release_safe(21, required_acks=1))
+        self.assertEqual(manager._deferred_abort_ack_tracker[21], {3})
+
+    def test_receiver_arms_tracker_before_sending_abort(self):
+        manager = _manager()
+        manager.request_status[21] = KVPoll.WaitingForInput
+        receiver = MoriKVReceiver.__new__(MoriKVReceiver)
+        receiver.kv_mgr = manager
+        receiver.bootstrap_room = 21
+        receiver.bootstrap_infos = [{"rank": 3}]
+        receiver.abort_notified = False
+        receiver.conclude_state = None
+        receiver.init_time = 1.0
+        receiver.metadata_published = True
+        receiver.clear = MagicMock()
+
+        with patch.object(
+            CommonKVReceiver,
+            "_send_abort_notification",
+            side_effect=lambda: manager._handle_abort_ack_message(
+                [_TAG_ABORT_ACK, b"21", b"3"]
+            ),
+        ):
+            receiver.abort()
+        manager.register_deferred_abort_room(21)
+
+        self.assertEqual(manager._deferred_abort_ack_tracker[21], {3})
+        receiver.clear.assert_called_once_with()
+
+    def test_preallocation_abort_does_not_arm_deferred_tracker(self):
+        manager = _manager()
+        manager.request_status[21] = KVPoll.Bootstrapping
+        receiver = MoriKVReceiver.__new__(MoriKVReceiver)
+        receiver.kv_mgr = manager
+        receiver.bootstrap_room = 21
+        receiver.bootstrap_infos = [{"rank": 3}]
+        receiver.abort_notified = False
+        receiver.conclude_state = None
+        receiver.init_time = None
+        receiver.metadata_published = False
+        receiver.clear = MagicMock()
+
+        with patch.object(CommonKVReceiver, "_send_abort_notification"):
+            receiver.abort()
+
+        self.assertNotIn(21, manager._deferred_abort_ack_tracker)
+
+    def test_malformed_ack_is_ignored(self):
+        manager = _manager()
+        manager.register_deferred_abort_room(21)
+
+        manager._handle_abort_ack_message([_TAG_ABORT_ACK, b"bad", b"3"])
+
+        self.assertFalse(manager.is_abort_release_safe(21, required_acks=1))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
@@ -54,13 +54,10 @@ def _install_mori_stubs() -> None:
 _install_mori_stubs()
 
 from sglang.srt.disaggregation.base.conn import KVPoll
-from sglang.srt.disaggregation.common.conn import CommonKVReceiver
+from sglang.srt.disaggregation.common.conn import ABORT_TAG
 from sglang.srt.disaggregation.common.utils import TransferKVChunk
 from sglang.srt.disaggregation.mori.conn import (
-    _TAG_ABORT,
-    _TAG_ABORT_ACK,
     MoriKVManager,
-    MoriKVReceiver,
     MoriKVSender,
     StatusCode,
     _MoriTransferSubmissionError,
@@ -97,7 +94,7 @@ def _manager(enabled: bool = True) -> MoriKVManager:
 
 
 def _abort_message(room: int = 11) -> list[bytes]:
-    return [_TAG_ABORT, str(room).encode(), b"10.0.0.3", b"6000"]
+    return [ABORT_TAG, str(room).encode(), b"10.0.0.3", b"6000"]
 
 
 def _chunk(room: int = 11) -> TransferKVChunk:
@@ -164,7 +161,7 @@ class TestMoriAbortAck(unittest.TestCase):
         manager = _manager()
         manager.request_status[11] = KVPoll.WaitingForInput
 
-        manager._handle_abort_message([_TAG_ABORT, b"11"])
+        manager._handle_abort_message([ABORT_TAG, b"11"])
 
         self.assertEqual(manager.request_status[11], KVPoll.Failed)
         self.assertEqual(manager._sent, [])
@@ -184,7 +181,7 @@ class TestMoriAbortAck(unittest.TestCase):
         manager = _manager()
         manager.request_status[11] = KVPoll.WaitingForInput
 
-        manager._handle_abort_message([_TAG_ABORT, b"11", b"10.0.0.3", b"bad"])
+        manager._handle_abort_message([ABORT_TAG, b"11", b"10.0.0.3", b"bad"])
 
         self.assertEqual(manager.request_status[11], KVPoll.Failed)
         self.assertEqual(manager._sent, [])
@@ -397,69 +394,6 @@ class TestMoriAbortAck(unittest.TestCase):
 
         self.assertEqual(manager._conclude_room_failure.call_count, 2)
         manager._mark_transfer_quiescent.assert_called_once_with(chunk)
-
-
-class TestMoriDecodeAbortAck(unittest.TestCase):
-    def test_ack_is_recorded_for_held_room(self):
-        manager = _manager()
-        manager.register_deferred_abort_room(21)
-
-        manager._handle_abort_ack_message([_TAG_ABORT_ACK, b"21", b"3"])
-
-        self.assertTrue(manager.is_abort_release_safe(21, required_acks=1))
-        self.assertEqual(manager._deferred_abort_ack_tracker[21], {3})
-
-    def test_receiver_arms_tracker_before_sending_abort(self):
-        manager = _manager()
-        manager.request_status[21] = KVPoll.WaitingForInput
-        receiver = MoriKVReceiver.__new__(MoriKVReceiver)
-        receiver.kv_mgr = manager
-        receiver.bootstrap_room = 21
-        receiver.bootstrap_infos = [{"rank": 3}]
-        receiver.abort_notified = False
-        receiver.conclude_state = None
-        receiver.init_time = 1.0
-        receiver.metadata_published = True
-        receiver.clear = MagicMock()
-
-        with patch.object(
-            CommonKVReceiver,
-            "_send_abort_notification",
-            side_effect=lambda: manager._handle_abort_ack_message(
-                [_TAG_ABORT_ACK, b"21", b"3"]
-            ),
-        ):
-            receiver.abort()
-        manager.register_deferred_abort_room(21)
-
-        self.assertEqual(manager._deferred_abort_ack_tracker[21], {3})
-        receiver.clear.assert_called_once_with()
-
-    def test_preallocation_abort_does_not_arm_deferred_tracker(self):
-        manager = _manager()
-        manager.request_status[21] = KVPoll.Bootstrapping
-        receiver = MoriKVReceiver.__new__(MoriKVReceiver)
-        receiver.kv_mgr = manager
-        receiver.bootstrap_room = 21
-        receiver.bootstrap_infos = [{"rank": 3}]
-        receiver.abort_notified = False
-        receiver.conclude_state = None
-        receiver.init_time = None
-        receiver.metadata_published = False
-        receiver.clear = MagicMock()
-
-        with patch.object(CommonKVReceiver, "_send_abort_notification"):
-            receiver.abort()
-
-        self.assertNotIn(21, manager._deferred_abort_ack_tracker)
-
-    def test_malformed_ack_is_ignored(self):
-        manager = _manager()
-        manager.register_deferred_abort_room(21)
-
-        manager._handle_abort_ack_message([_TAG_ABORT_ACK, b"bad", b"3"])
-
-        self.assertFalse(manager.is_abort_release_safe(21, required_acks=1))
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
@@ -53,11 +53,16 @@ def _install_mori_stubs() -> None:
 
 _install_mori_stubs()
 
+from test_deferred_decode_kv_release import (
+    ABORT_GENERATION,
+    DeferredAbortNotificationScenarios,
+)
+
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import (
     ABORT_TAG,
-    AckTarget,
     AbortNotification,
+    AckTarget,
 )
 from sglang.srt.disaggregation.common.utils import TransferKVChunk
 from sglang.srt.disaggregation.mori.conn import (
@@ -67,11 +72,6 @@ from sglang.srt.disaggregation.mori.conn import (
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
-
-from test_deferred_decode_kv_release import (
-    ABORT_GENERATION,
-    DeferredAbortNotificationScenarios,
-)
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 

--- a/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
@@ -54,15 +54,24 @@ def _install_mori_stubs() -> None:
 _install_mori_stubs()
 
 from sglang.srt.disaggregation.base.conn import KVPoll
-from sglang.srt.disaggregation.common.conn import ABORT_TAG
+from sglang.srt.disaggregation.common.conn import (
+    ABORT_TAG,
+    AckTarget,
+    AbortNotification,
+)
 from sglang.srt.disaggregation.common.utils import TransferKVChunk
 from sglang.srt.disaggregation.mori.conn import (
     MoriKVManager,
-    MoriKVSender,
     StatusCode,
     _MoriTransferSubmissionError,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+from test_deferred_decode_kv_release import (
+    ABORT_GENERATION,
+    DeferredAbortNotificationScenarios,
+)
 
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
@@ -74,6 +83,7 @@ def _manager(enabled: bool = True) -> MoriKVManager:
     manager.transfer_lock = threading.Lock()
     manager._abort_ack_lock = threading.Lock()
     manager._deferred_ack_targets = {}
+    manager._deferred_ack_poisoned_rooms = set()
     manager._deferred_abort_ack_tracker = {}
     manager._staging_outstanding = defaultdict(int)
     manager._drain_queue = Queue(maxsize=1)
@@ -85,16 +95,14 @@ def _manager(enabled: bool = True) -> MoriKVManager:
     manager.failure_lock = threading.Lock()
     manager.failure_records = {}
     manager._sent = []
-    manager._send_abort_ack = lambda ip, port, room: manager._sent.append(
-        (ip, port, room)
-    )
+    manager._send_abort_ack = lambda *args: manager._sent.append(args)
     manager._wait_poll_ms = 0
     manager._transfer_timeout_ms = 0
     return manager
 
 
 def _abort_message(room: int = 11) -> list[bytes]:
-    return [ABORT_TAG, str(room).encode(), b"10.0.0.3", b"6000"]
+    return AbortNotification(room, "10.0.0.3", 6000, ABORT_GENERATION).to_zmq()
 
 
 def _chunk(room: int = 11) -> TransferKVChunk:
@@ -108,64 +116,42 @@ def _chunk(room: int = 11) -> TransferKVChunk:
     )
 
 
-class TestMoriAbortAck(unittest.TestCase):
-    def test_active_write_defers_ack_until_quiescent(self):
+class TestMoriAbortAck(DeferredAbortNotificationScenarios, CustomTestCase):
+    room = 11
+    decode_ip = "10.0.0.3"
+    decode_port = 6000
+
+    def _make_abort_manager(self, status: KVPoll | None):
         manager = _manager()
-        manager.request_status[11] = KVPoll.Transferring
-        chunk = _chunk()
-        manager._mark_transfer_started(chunk)
+        if status is not None:
+            manager.request_status[self.room] = status
+        return manager
 
-        manager._handle_abort_message(_abort_message())
+    def _dispatch_abort(self, manager) -> None:
+        manager._handle_abort_message(self._abort_message())
 
-        self.assertEqual(manager.request_status[11], KVPoll.Failed)
-        self.assertEqual(manager._sent, [])
-        self.assertEqual(manager._deferred_ack_targets[11], ("10.0.0.3", 6000))
+    def _start_test_transfer(self, manager) -> None:
+        manager._mark_transfer_started(_chunk(self.room))
 
-        manager._mark_transfer_quiescent(chunk)
-        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
-        self.assertNotIn(11, manager._deferred_ack_targets)
-        self.assertNotIn(11, manager._staging_outstanding)
+    def _drain_test_transfer(self, manager) -> None:
+        manager._mark_transfer_quiescent(_chunk(self.room))
 
-    def test_idle_active_room_acks_immediately(self):
-        manager = _manager()
-        manager.request_status[11] = KVPoll.WaitingForInput
+    def test_abort_without_valid_return_address_marks_failed_without_ack(self):
+        messages = (
+            ("missing", [ABORT_TAG, b"11"]),
+            ("malformed port", [ABORT_TAG, b"11", b"10.0.0.3", b"bad"]),
+        )
 
-        manager._handle_abort_message(_abort_message())
+        for name, message in messages:
+            with self.subTest(name=name):
+                manager = _manager()
+                manager.request_status[11] = KVPoll.WaitingForInput
 
-        self.assertEqual(manager.request_status[11], KVPoll.Failed)
-        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+                manager._handle_abort_message(message)
 
-    def test_completed_room_acks_immediately(self):
-        manager = _manager()
-        manager.request_status[11] = KVPoll.Success
-
-        manager._handle_abort_message(_abort_message())
-
-        self.assertEqual(manager.request_status[11], KVPoll.Success)
-        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
-
-    def test_completed_room_with_outstanding_write_defers_ack(self):
-        manager = _manager()
-        manager.request_status[11] = KVPoll.Success
-        chunk = _chunk()
-        manager._mark_transfer_started(chunk)
-
-        manager._handle_abort_message(_abort_message())
-
-        self.assertEqual(manager._sent, [])
-        self.assertEqual(manager._deferred_ack_targets[11], ("10.0.0.3", 6000))
-        manager._mark_transfer_quiescent(chunk)
-        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
-
-    def test_legacy_abort_without_return_address_only_marks_failed(self):
-        manager = _manager()
-        manager.request_status[11] = KVPoll.WaitingForInput
-
-        manager._handle_abort_message([ABORT_TAG, b"11"])
-
-        self.assertEqual(manager.request_status[11], KVPoll.Failed)
-        self.assertEqual(manager._sent, [])
-        self.assertEqual(manager._deferred_ack_targets, {})
+                self.assertEqual(manager.request_status[11], KVPoll.Failed)
+                self.assertEqual(manager._sent, [])
+                self.assertEqual(manager._deferred_ack_targets, {})
 
     def test_feature_off_preserves_abort_without_ack(self):
         manager = _manager(enabled=False)
@@ -176,15 +162,6 @@ class TestMoriAbortAck(unittest.TestCase):
         self.assertEqual(manager.request_status[11], KVPoll.Failed)
         self.assertEqual(manager._sent, [])
         self.assertEqual(manager._deferred_ack_targets, {})
-
-    def test_invalid_return_address_still_marks_room_failed(self):
-        manager = _manager()
-        manager.request_status[11] = KVPoll.WaitingForInput
-
-        manager._handle_abort_message([ABORT_TAG, b"11", b"10.0.0.3", b"bad"])
-
-        self.assertEqual(manager.request_status[11], KVPoll.Failed)
-        self.assertEqual(manager._sent, [])
 
     def test_abort_after_submit_waits_for_terminal_status(self):
         manager = _manager()
@@ -212,7 +189,10 @@ class TestMoriAbortAck(unittest.TestCase):
         self.assertEqual(manager.engine.wait_all.call_count, 2)
         self.assertEqual(manager._sent, [])
         manager._mark_transfer_quiescent(chunk)
-        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+        self.assertEqual(
+            manager._sent,
+            [(11, AckTarget("10.0.0.3", 6000, ABORT_GENERATION))],
+        )
 
     def test_sla_failure_acks_after_status_drains(self):
         manager = _manager()
@@ -245,7 +225,10 @@ class TestMoriAbortAck(unittest.TestCase):
         manager._drain_transfer_statuses(queued_chunk, queued_statuses, failure_reason)
 
         status.Wait.assert_called_once_with()
-        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
+        self.assertEqual(
+            manager._sent,
+            [(11, AckTarget("10.0.0.3", 6000, ABORT_GENERATION))],
+        )
         self.assertNotIn(11, manager._staging_outstanding)
         manager._conclude_room_failure.assert_called_once_with(
             11, "KV transfer exceeded SLA 1ms"
@@ -268,22 +251,6 @@ class TestMoriAbortAck(unittest.TestCase):
 
         self.assertEqual(failure, "KV transfer exceeded SLA 1ms")
         self.assertEqual(manager.engine.wait_all.call_count, 1)
-
-    def test_sender_clear_preserves_ack_target_until_write_drains(self):
-        manager = _manager()
-        manager.request_status[11] = KVPoll.Failed
-        chunk = _chunk()
-        manager._mark_transfer_started(chunk)
-        manager._handle_abort_message(_abort_message())
-        sender = MoriKVSender.__new__(MoriKVSender)
-        sender.kv_mgr = manager
-        sender.bootstrap_room = 11
-
-        sender.clear()
-
-        self.assertEqual(manager._deferred_ack_targets[11], ("10.0.0.3", 6000))
-        manager._mark_transfer_quiescent(chunk)
-        self.assertEqual(manager._sent, [("10.0.0.3", 6000, 11)])
 
     def test_wait_event_failure_releases_outstanding_count(self):
         manager = _manager()

--- a/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_mori_deferred_kv_release.py
@@ -69,6 +69,7 @@ from sglang.srt.disaggregation.mori.conn import (
     MoriKVManager,
     StatusCode,
     _MoriTransferSubmissionError,
+    _SubmissionLocal,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
@@ -87,7 +88,7 @@ def _manager(enabled: bool = True) -> MoriKVManager:
     manager._deferred_abort_ack_tracker = {}
     manager._staging_outstanding = defaultdict(int)
     manager._drain_queue = Queue(maxsize=1)
-    manager._submission_local = threading.local()
+    manager._submission_local = _SubmissionLocal()
     manager.req_to_decode_prefix_len = {}
     manager.transfer_infos = {}
     manager._room_notify_lock = threading.Lock()

--- a/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
@@ -1,187 +1,145 @@
 """Deferred decode-side KV release on the NIXL backend.
 
-When a decode request is aborted while its prefill->decode transfer may still be
-in flight, the decode holds its KV pages until every prefill rank acks that its
-transfer drained. NIXL transfers are asynchronous (agent.transfer() posts, the
-worker polls check_xfer_state), so the ack must come from the transfer worker
-after its DONE barrier -- never from the bootstrap thread for an active room.
+NIXL posts transfers asynchronously and the worker polls their handles. The
+bootstrap thread records the ACK target while a transfer is outstanding; only
+the worker can send that ACK after every handle reaches DONE.
 """
 
 import unittest
-from unittest.mock import MagicMock
+from collections import defaultdict
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import numpy as np
 
 from sglang.srt.disaggregation.base.conn import KVPoll
-from sglang.srt.disaggregation.common.conn import CommonKVManager
+from sglang.srt.disaggregation.common.conn import (
+    ABORT_TAG,
+    AckTarget,
+)
+from sglang.srt.disaggregation.common.utils import TransferKVChunk
 from sglang.srt.disaggregation.nixl.conn import NixlKVManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
 
+from test_deferred_decode_kv_release import (
+    ABORT_GENERATION,
+    DeferredAbortNotificationScenarios,
+    TaggedAbortNotificationScenarios,
+    WorkerFailureAbortScenarios,
+)
+
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 
-
-def _prefill_mgr(cls=CommonKVManager, enabled=True):
-    """Bare manager carrying only the prefill-side deferred-ack state."""
-    mgr = cls.__new__(cls)
-    mgr.enable_deferred_decode_kv_release = enabled
-    mgr._deferred_ack_targets = {}
-    mgr._staging_outstanding = {}
-    mgr.request_status = {}
-    mgr._sent = []
-    # Capture acks instead of opening a socket.
-    mgr._send_abort_ack = lambda ip, port, room: mgr._sent.append((ip, port, room))
-    return mgr
+ROOM = 11
+DECODE_IP = "10.0.0.3"
+DECODE_PORT = 6000
 
 
-class TestDeferredAckTargets(CustomTestCase):
-    def test_ack_held_until_outstanding_drains(self):
-        mgr = _prefill_mgr()
-        mgr.register_deferred_ack_target(7, "10.0.0.1", 5000)
-
-        mgr._staging_outstanding[7] = 1
-        mgr._maybe_ack_drained_abort(7)
-        self.assertEqual(mgr._sent, [])  # still writing -> no ack
-
-        mgr._staging_outstanding[7] = 0
-        mgr._maybe_ack_drained_abort(7)
-        self.assertEqual(mgr._sent, [("10.0.0.1", 5000, 7)])
-
-    def test_ack_fires_at_most_once(self):
-        mgr = _prefill_mgr()
-        mgr.register_deferred_ack_target(8, "10.0.0.2", 5001)
-        mgr._maybe_ack_drained_abort(8)
-        mgr._maybe_ack_drained_abort(8)
-        self.assertEqual(len(mgr._sent), 1)
-        self.assertNotIn(8, mgr._deferred_ack_targets)
-
-    def test_unregistered_room_is_noop(self):
-        mgr = _prefill_mgr()
-        mgr._maybe_ack_drained_abort(999)
-        self.assertEqual(mgr._sent, [])
-
-    def test_prefill_unique_rank_matches_success_sync_formula(self):
-        mgr = CommonKVManager.__new__(CommonKVManager)
-        mgr.attn_tp_rank, mgr.pp_size, mgr.attn_cp_size = 2, 3, 4
-        mgr.pp_rank, mgr.attn_cp_rank = 1, 3
-        self.assertEqual(mgr._prefill_unique_rank(), 2 * (3 * 4) + 1 * 4 + 3)
+def _manager(
+    *, enabled: bool = True, status: KVPoll | None = KVPoll.WaitingForInput
+) -> NixlKVManager:
+    manager = NixlKVManager.__new__(NixlKVManager)
+    manager.enable_deferred_decode_kv_release = enabled
+    manager._deferred_ack_targets = {}
+    manager._deferred_ack_poisoned_rooms = set()
+    manager._staging_outstanding = {}
+    manager.request_status = {} if status is None else {ROOM: status}
+    manager._sent = []
+    manager._send_abort_ack = lambda *args: manager._sent.append(args)
+    manager.record_failure = MagicMock()
+    manager.update_status = MagicMock(
+        side_effect=lambda room, value: manager.request_status.__setitem__(room, value)
+    )
+    manager.check_status = lambda room: manager.request_status[room]
+    return manager
 
 
-class TestNixlAbortNotification(CustomTestCase):
-    """_handle_abort_notification is the prefill bootstrap-thread entry point."""
+def _chunk() -> TransferKVChunk:
+    return TransferKVChunk(
+        room=ROOM,
+        prefill_kv_indices=np.array([1], dtype=np.int32),
+        index_slice=slice(0, 1),
+        is_last_chunk=False,
+        chunk_id=0,
+        prefill_aux_index=None,
+        state_indices=None,
+    )
 
-    @staticmethod
-    def _abort_msg(room=11, ip="10.0.0.3", port=6000):
-        return [
-            b"ABORT",
-            str(room).encode("ascii"),
-            ip.encode("ascii"),
-            str(port).encode("ascii"),
-        ]
 
-    def _mgr(self, enabled=True, room=11, status=KVPoll.WaitingForInput):
-        mgr = _prefill_mgr(NixlKVManager, enabled=enabled)
-        if status is not None:
-            mgr.request_status[room] = status
-        mgr.record_failure = MagicMock()
-        mgr.update_status = MagicMock(
-            side_effect=lambda r, s: mgr.request_status.__setitem__(r, s)
+class TestNixlAbortNotification(
+    DeferredAbortNotificationScenarios,
+    TaggedAbortNotificationScenarios,
+    WorkerFailureAbortScenarios,
+    CustomTestCase,
+):
+    room = ROOM
+    decode_ip = DECODE_IP
+    decode_port = DECODE_PORT
+
+    def _make_abort_manager(self, status: KVPoll | None):
+        return _manager(status=status)
+
+    def _provoke_worker_failure(self, manager) -> None:
+        manager.enable_staging = False
+        manager._staging_ctx = None
+        manager._staging_outstanding = defaultdict(int)
+        manager.transfer_infos = {ROOM: {}}
+        manager.exceptions = {}
+        manager.check_status = MagicMock(side_effect=RuntimeError("worker error"))
+        queue = SimpleNamespace(
+            get=MagicMock(side_effect=(_chunk(), KeyboardInterrupt()))
         )
-        mgr.check_status = lambda r: mgr.request_status[r]
-        return mgr
 
-    def test_in_flight_room_registers_target_and_does_not_ack_yet(self):
-        # A counted chunk holds the ack: only the worker knows when it landed.
-        mgr = self._mgr()
-        mgr._staging_outstanding[11] = 1
-        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+        with patch("sglang.srt.disaggregation.nixl.conn.logger.exception"):
+            with self.assertRaises(KeyboardInterrupt):
+                manager.transfer_worker(queue)
+        manager.check_status = lambda room: manager.request_status[room]
 
-        self.assertEqual(mgr._deferred_ack_targets[11], ("10.0.0.3", 6000))
-        self.assertEqual(mgr._sent, [])
-        # Marked Failed first, so no new chunk can be enqueued for the room.
-        self.assertEqual(mgr.request_status[11], KVPoll.Failed)
+    def test_worker_skip_between_failure_and_target_registration_still_acks(self):
+        manager = _manager()
+        manager._staging_outstanding[ROOM] = 1
+        update_status = manager.update_status.side_effect
 
-    def test_quiescent_active_room_acks_without_waiting_for_a_worker_visit(self):
-        # Window 2: chunks already drained with none left to come, so the worker
-        # never revisits the room -- acking here keeps it off the timeout path.
-        mgr = self._mgr()
-        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+        def fail_then_skip(room, status):
+            update_status(room, status)
+            # Window 1: the worker skips after Failed but before target
+            # registration, so the bootstrap thread must observe zero and ACK.
+            manager._staging_outstanding.pop(room, None)
+            manager._maybe_ack_drained_abort(room)
 
-        self.assertEqual(mgr._sent, [("10.0.0.3", 6000, 11)])
-        self.assertEqual(mgr._deferred_ack_targets, {})
+        manager.update_status = MagicMock(side_effect=fail_then_skip)
 
-    def test_worker_skip_before_registration_still_acks(self):
-        # Window 1: the worker can pass its skip point between the Failed flip
-        # and registration; the ack attempt at registration covers that.
-        mgr = self._mgr()
-        mgr._staging_outstanding[11] = 1
+        claimed = manager._handle_abort_notification(self._abort_message())
 
-        real_update = mgr.update_status.side_effect
+        self.assertTrue(claimed)
+        self.assertEqual(
+            manager._sent,
+            [(ROOM, AckTarget(DECODE_IP, DECODE_PORT, ABORT_GENERATION))],
+        )
+        self.assertEqual(manager._deferred_ack_targets, {})
 
-        def failed_then_worker_skips(room, status):
-            real_update(room, status)
-            # Worker dequeues, sees Failed, uncounts, and finds no target yet.
-            mgr._staging_outstanding.pop(room, None)
-            mgr._maybe_ack_drained_abort(room)
+    def test_feature_off_marks_failed_without_ack(self):
+        manager = _manager(enabled=False)
 
-        mgr.update_status = MagicMock(side_effect=failed_then_worker_skips)
-        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+        claimed = manager._handle_abort_notification(self._abort_message())
 
-        self.assertEqual(mgr._sent, [("10.0.0.3", 6000, 11)])
-        self.assertEqual(mgr._deferred_ack_targets, {})
+        self.assertTrue(claimed)
+        self.assertEqual(manager.request_status[ROOM], KVPoll.Failed)
+        self.assertEqual(manager._deferred_ack_targets, {})
+        self.assertEqual(manager._sent, [])
 
-    def test_concluded_room_acks_immediately(self):
-        # Concluded and quiescent: ack straight away.
-        mgr = self._mgr(status=None)
-        mgr.check_status = lambda r: KVPoll.Success
-        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
+    def test_legacy_abort_without_return_address_is_tolerated(self):
+        manager = _manager()
 
-        self.assertEqual(mgr._sent, [("10.0.0.3", 6000, 11)])
-        self.assertEqual(mgr._deferred_ack_targets, {})
+        claimed = manager._handle_abort_notification(
+            [ABORT_TAG, str(ROOM).encode("ascii")]
+        )
 
-    def test_cleared_room_with_outstanding_chunk_does_not_ack(self):
-        # The ERR path abandons sibling handles that may still be writing and
-        # leaves the chunk counted; clear() then drops the room. Acking on
-        # "unknown room" alone would release decode pages under those writes.
-        mgr = self._mgr(status=None)  # room absent == cleared/unknown
-        mgr._staging_outstanding[11] = 1
-        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
-
-        self.assertEqual(mgr._sent, [])
-        self.assertEqual(mgr._deferred_ack_targets, {})
-
-    def test_feature_off_registers_nothing_and_acks_nothing(self):
-        mgr = self._mgr(enabled=False)
-        self.assertTrue(mgr._handle_abort_notification(self._abort_msg()))
-
-        self.assertEqual(mgr._deferred_ack_targets, {})
-        self.assertEqual(mgr._sent, [])
-        # Legacy behavior preserved: the room is still failed.
-        self.assertEqual(mgr.request_status[11], KVPoll.Failed)
-
-    def test_legacy_two_frame_abort_is_tolerated(self):
-        # Older peers send [ABORT, room] with no return address.
-        mgr = self._mgr()
-        self.assertTrue(mgr._handle_abort_notification([b"ABORT", b"11"]))
-        self.assertEqual(mgr._deferred_ack_targets, {})
-        self.assertEqual(mgr._sent, [])
-
-    def test_non_abort_message_is_not_claimed(self):
-        mgr = self._mgr()
-        self.assertFalse(mgr._handle_abort_notification([b"STAGING_REQ", b"11"]))
-
-
-class TestNixlDecodeAckIngest(CustomTestCase):
-    def test_abort_ack_is_aggregated_per_rank(self):
-        # Mirrors the decode listener thread's ABORT_ACK branch.
-        mgr = CommonKVManager.__new__(CommonKVManager)
-        mgr._deferred_abort_ack_tracker = {}
-        mgr.register_deferred_abort_room(21)
-
-        for rank in (b"0", b"1", b"1"):
-            msg = [b"ABORT_ACK", b"21", rank]
-            mgr.note_abort_ack(int(msg[1].decode()), int(msg[2].decode()))
-
-        self.assertFalse(mgr.is_abort_release_safe(21, required_acks=3))
-        self.assertTrue(mgr.is_abort_release_safe(21, required_acks=2))
+        self.assertTrue(claimed)
+        self.assertEqual(manager.request_status[ROOM], KVPoll.Failed)
+        self.assertEqual(manager._deferred_ack_targets, {})
+        self.assertEqual(manager._sent, [])
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
+++ b/test/registered/unit/disaggregation/test_nixl_deferred_kv_release.py
@@ -11,6 +11,12 @@ from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import numpy as np
+from test_deferred_decode_kv_release import (
+    ABORT_GENERATION,
+    DeferredAbortNotificationScenarios,
+    TaggedAbortNotificationScenarios,
+    WorkerFailureAbortScenarios,
+)
 
 from sglang.srt.disaggregation.base.conn import KVPoll
 from sglang.srt.disaggregation.common.conn import (
@@ -21,13 +27,6 @@ from sglang.srt.disaggregation.common.utils import TransferKVChunk
 from sglang.srt.disaggregation.nixl.conn import NixlKVManager
 from sglang.test.ci.ci_register import register_cpu_ci
 from sglang.test.test_utils import CustomTestCase
-
-from test_deferred_decode_kv_release import (
-    ABORT_GENERATION,
-    DeferredAbortNotificationScenarios,
-    TaggedAbortNotificationScenarios,
-    WorkerFailureAbortScenarios,
-)
 
 register_cpu_ci(est_time=11, suite="base-a-test-cpu")
 

--- a/test/registered/unit/disaggregation/test_nixl_sender_failure_cleanup.py
+++ b/test/registered/unit/disaggregation/test_nixl_sender_failure_cleanup.py
@@ -22,12 +22,19 @@ class TestNixlSenderFailureCleanup(unittest.TestCase):
             prefetched_rooms={room, 8},
             prefetch_requested={(room, 0, "session-a"), (8, 0, "session-b")},
         )
+        # This stub mirrors CommonKVManager's field set by hand, so any new
+        # field touched by CommonKVSender.clear() fails here with an
+        # AttributeError instead of a meaningful assertion. If that keeps
+        # happening, spy on clear() here and test its contents where clear()
+        # is tested, or build a real manager instance.
         sender.kv_mgr = SimpleNamespace(
             enable_staging=True,
             _staging_ctx=staging_ctx,
             request_status={room: object()},
             req_to_decode_prefix_len={room: 3},
             transfer_infos={room: object()},
+            _staging_outstanding={},
+            _deferred_ack_targets={},
             exceptions={room: expected_exc},
             failure_records={room: "transfer failed"},
             failure_lock=threading.Lock(),


### PR DESCRIPTION
## Summary

When decode aborts a request, it needs to release the KV cache pages that prefill was writing into. But prefill might still have in-flight RDMA writes targeting those pages. Releasing before the writes finish corrupts memory.

This PR adds an `ABORT_ACK` protocol to the Mori backend, then extracts the shared pieces into the common disaggregation layer so all three backends (Mooncake, NIXL, Mori) use the same deferred-ACK wire format, ACK ingestion, and tracker ordering.

### Mori sender side

A per-room outstanding counter (`_staging_outstanding`) tracks chunks from dequeue to terminal status. When an ABORT arrives:

- If outstanding is zero, ACK immediately.
- If outstanding is positive, stash the decode return address and ACK when the last chunk drains.

The room is marked Failed before the ACK target is registered, so no new RDMA writes for that room can be submitted after prefill observes the abort.

Writes that don't reach terminal status before the SLA timeout, or that throw during `wait_all`, go to a bounded drain queue. The drain worker calls `status.Wait()` on each remaining `IN_PROGRESS` status and retries indefinitely (abandoning would let decode reuse pages with live RDMA writes).

Partial submission failures (some targets submitted, then an exception) capture the already-issued `TransferStatus` objects via a thread-local so they drain too.

Sender cleanup (`clear()`) preserves a pending ACK target while the room still has counted transfers.

### Common protocol extraction

The common layer is extracted from what Mori established:

- `AbortNotification` / `AbortAck`: shared ZMQ wire format and parsing, used by all three backends.
- `handle_abort_ack_message`: decode-side dispatch that records rank-qualified ACKs for armed rooms.
- `abort_for_deferred_release`: arms the ACK tracker *before* the backend sends ABORT, closing the race in the old scheduler code where ACKs could arrive between notification and arming.
- Some error handling at the ZMQ boundary. Those were not all presented in Mooncake/Nixl code but feel appropriate. `ValueError` and `UnicodeDecodeError` from malformed room, port, or rank frames.

The preallocation queue continues to call plain `abort()`. Deferred ACK tracking starts only after a request enters the transfer queue, whose abort path calls `abort_for_deferred_release()`.

Each backend keeps its own transport-specific quiescence checks. The deferred ACK wire format carries a single rank frame (the legacy Mooncake feature-off ACK still carries two).

### When the feature is off

The bounded drain queue and drain worker threads are created only when `SGLANG_DISAGGREGATION_DEFERRED_DECODE_KV_RELEASE` is enabled. With the flag disabled, the new bookkeeping paths are bypassed and existing ABORT behavior is unchanged.

Related to #33861 and #34510.

## Testing

Refactored test into four files, 
- `test_deferred_decode_kv_release.py` tests common behaviour.
- `test_mooncake_deferred_kv_release.py`,`test_nixl_deferred_kv_release.py` and `test_mori_deferred_kv_release.py` test backend specific behaviour separately.

Passed 1P1D H200 test on mooncake and nixl backend. 


<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34167559751](https://github.com/sgl-project/sglang/actions/runs/34167559751)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34167559600](https://github.com/sgl-project/sglang/actions/runs/34167559600)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34167559752](https://github.com/sgl-project/sglang/actions/runs/34167559752)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
