### PR TITLE
Fix marlin device-capability check for XPU (None capability)

### DIFF
--- a/python/sglang/srt/layers/quantization/marlin_utils.py
+++ b/python/sglang/srt/layers/quantization/marlin_utils.py
@@ -88,7 +88,7 @@ def query_marlin_supported_quant_types(
 ):
     if device_capability is None:
         major, minor = get_device_capability()
-        capability = major * 10 + minor
+        capability = major * 10 + minor if major is not None else None
         device_capability = -1 if capability is None else capability
 
     if device_capability < 80:
@@ -126,7 +126,7 @@ def _check_marlin_supported(
 
     if device_capability is None:
         major, minor = get_device_capability()
-        capability = major * 10 + minor
+        capability = major * 10 + minor if major is not None else None
         device_capability = -1 if capability is None else capability
 
     supported_types = query_marlin_supported_quant_types(


### PR DESCRIPTION
## Summary

Fixes a `TypeError` crash in the Marlin device-capability check on XPU.

On XPU, `get_device_capability()` returns `(None, None)` because the XPU
version string carries no compute-capability information (see
`python/sglang/srt/utils/common.py`). The existing code then does:

```python
major, minor = get_device_capability()
capability = major * 10 + minor          # TypeError: NoneType * int
device_capability = -1 if capability is None else capability
```

The `capability is None` fallback is unreachable: `major * 10 + minor`
raises `TypeError` before it can be evaluated. So the intended "report
Marlin as unsupported" path never runs.

## Repro

On an Intel Arc (XPU) box, load any GPTQ/AWQ (Marlin) checkpoint with
SGLang. During model init the capability probe crashes:

```
TypeError: unsupported operand type(s) for *: 'NoneType' and 'int'
  File ".../layers/quantization/marlin_utils.py", in query_marlin_supported_quant_types
    capability = major * 10 + minor
```

## Fix

Guard the arithmetic so a `None` capability falls through to the existing
`-1` path, which cleanly reports Marlin as unsupported on XPU instead of
crashing. Two-line change, both call sites:

```python
capability = major * 10 + minor if major is not None else None
```

With this, Marlin is correctly rejected on XPU and GPTQ/AWQ models fall
back to the non-Marlin kernels (QServe W4A8 / AWQ-dequant / FP8 / bf16)
that the XPU `sgl_kernel` build actually provides.

## Testing

- Verified on 4x Arc Pro B70 (Xe3) with SGLang on XPU: the capability
  probe now returns "unsupported" instead of raising, and the server
  proceeds to the non-Marlin path.
- No behavior change on CUDA/ROCm/HPU, where `major` is always an int.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33287397743](https://github.com/sgl-project/sglang/actions/runs/33287397743)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33287397647](https://github.com/sgl-project/sglang/actions/runs/33287397647)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33287397715](https://github.com/sgl-project/sglang/actions/runs/33287397715)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->