### PR TITLE
[Fix] Return 400 instead of 500 when input_embeds is empty

### DIFF
--- a/python/sglang/srt/managers/io_struct.py
+++ b/python/sglang/srt/managers/io_struct.py
@@ -457,6 +457,8 @@ class GenerateReqInput:
                 self.batch_size = len(self.input_ids)
             self.input_embeds = None
         else:
+            if not self.input_embeds or not self.input_embeds[0]:
+                raise ValueError("input_embeds cannot be empty.")
             if isinstance(self.input_embeds[0][0], float):
                 self.is_single = True
                 self.batch_size = 1

--- a/test/registered/unit/managers/test_io_struct.py
+++ b/test/registered/unit/managers/test_io_struct.py
@@ -741,6 +741,14 @@ class TestGenerateReqInputNormalization(CustomTestCase):
         self.assertFalse(req.is_single)
         self.assertEqual(req.batch_size, 2)
 
+    def test_empty_input_embeds_raises_value_error(self):
+        """Empty input_embeds must raise ValueError (HTTP 400), not IndexError (HTTP 500)."""
+        for empty_embeds in ([], [[]]):
+            with self.subTest(input_embeds=empty_embeds):
+                req = GenerateReqInput(input_embeds=empty_embeds)
+                with self.assertRaisesRegex(ValueError, "input_embeds cannot be empty"):
+                    req.normalize_batch_and_arguments()
+
     def test_input_embeds_with_parallel_sampling(self):
         """Test input_embeds normalization with parallel sampling (n > 1)."""
         # Test single input_embeds with parallel sampling


### PR DESCRIPTION
## Motivation

When a request is sent to `/generate` with an empty `input_embeds` (e.g. `[]` or `[[]]`) and no `text`/`input_ids`, `GenerateReqInput._determine_batch_size` accesses `self.input_embeds[0][0]` directly and raises an `IndexError`, which surfaces as an HTTP 500 Internal Server Error. An empty input is a client error and should return 400.

## Modifications

- Added an emptiness check for `input_embeds` in `_determine_batch_size`, raising `ValueError("input_embeds cannot be empty.")` so the HTTP layer returns 400. This mirrors the existing empty-`input_ids` check right above.

## Verification

- Before: `curl -X POST http://localhost:30000/generate -d '{"input_embeds": [], "sampling_params": {"max_new_tokens": 8}}'` returns 500 (IndexError).
- After: the same request returns 400 with message `input_embeds cannot be empty.`
- Non-empty `input_embeds` requests are unaffected.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33290206196](https://github.com/sgl-project/sglang/actions/runs/33290206196)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33290206139](https://github.com/sgl-project/sglang/actions/runs/33290206139)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33290206219](https://github.com/sgl-project/sglang/actions/runs/33290206219)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->