### PR TITLE
[Test] Run SM120 FlashMLA backend coverage on 5090 CI

### DIFF
--- a/test/registered/kernels/ops/attention/test_flash_mla_backends.py
+++ b/test/registered/kernels/ops/attention/test_flash_mla_backends.py
@@ -53,7 +53,7 @@ from sglang.srt.runtime_context import get_resources
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.test_utils import CustomTestCase
 
-register_cuda_ci(est_time=45, stage="base-b", runner_config="1-gpu-large")
+register_cuda_ci(est_time=45, stage="base-b", runner_config="1-gpu-small")
 
 
 # Per-token byte layout
@@ -475,12 +475,22 @@ class TestEntryPointDispatch(CustomTestCase):
         """FlashInfer SM120 sparse MLA decode matches Triton reference."""
         import importlib
 
-        if importlib.util.find_spec("flashinfer.sparse_mla_sm120") is None:
+        try:
+            flashinfer_sm120_spec = importlib.util.find_spec(
+                "flashinfer.mla._sparse_mla_sm120"
+            )
+        except (AttributeError, ImportError):
+            flashinfer_sm120_spec = None
+        if flashinfer_sm120_spec is None:
             self.skipTest("FlashInfer SM120 sparse MLA not available")
 
         k_cache, _ = _build_kvcache(4, 64, device=self.device, seed=5)
-        q, indices = _build_q_indices(1, 4, 32, 4, 64, device=self.device, seed=13)
-        topk_length = torch.tensor([32], dtype=torch.int32, device=self.device)
+        # Smallest FlashInfer DSV4 decode specialization: (num_heads, topk)=(8, 128).
+        q, indices = _build_q_indices(1, 8, 128, 4, 64, device=self.device, seed=13)
+        # Avoid saturated synthetic logits where harmless backend rounding can
+        # select a different near-tied token and dominate the output comparison.
+        q.mul_(0.001)
+        topk_length = torch.tensor([128], dtype=torch.int32, device=self.device)
 
         kwargs = dict(
             q=q,


### PR DESCRIPTION
## Motivation

`test_flash_mla_backends.py` contains SM120-gated tests, but the suite was registered on the `1-gpu-large` runner (H100/SM90), so the SM120 coverage was skipped. The FlashInfer availability probe also used a module path that does not match the current runtime import.

## Modifications

- Run the suite on the `1-gpu-small` RTX 5090 runner.
- Probe `flashinfer.mla._sparse_mla_sm120`, with compatibility handling for older module layouts.
- Exercise the smallest supported FlashInfer DSV4 decode specialization, `(num_heads, topk) = (8, 128)`.
- Scale the synthetic query values to avoid saturated logits and unstable near-tied token selection in the cross-backend comparison.

## Tests

- RTX 5090 (SM120), CUDA 13.0, FlashInfer 0.6.15.post1: full test file passed, `Ran 14 tests in 1.655s`, `OK`.
- `ruff check test/registered/kernels/ops/attention/test_flash_mla_backends.py`
- `black --check test/registered/kernels/ops/attention/test_flash_mla_backends.py`
- Python bytecode compilation
- CI registration check: `base-b-test-1-gpu-small`, estimated time 45 seconds

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33293638824](https://github.com/sgl-project/sglang/actions/runs/33293638824)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33293638566](https://github.com/sgl-project/sglang/actions/runs/33293638566)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33293638678](https://github.com/sgl-project/sglang/actions/runs/33293638678)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->