### PR TITLE
[AMD] Flag when the miles ROCm nightly falls back to a stale image

### DIFF
--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -51,6 +51,7 @@ jobs:
           repo="rocm/sgl-dev"
           base="miles-rocm720-mi35x"
           tag="${{ inputs.image_tag }}"
+          age=""
           if [ -z "${tag}" ]; then
             # Walk back from today; the build job pushes a dated tag at 12:00 UTC.
             # Probe with `manifest inspect` so we don't pull a multi-GB image just
@@ -60,6 +61,7 @@ jobs:
               candidate="${base}-${d}"
               if docker manifest inspect "${repo}:${candidate}" >/dev/null 2>&1; then
                 tag="${candidate}"
+                age="${i}"
                 break
               fi
             done
@@ -70,6 +72,16 @@ jobs:
           fi
           echo "MILES_IMAGE=${repo}:${tag}" >> "$GITHUB_ENV"
           echo "Using miles image: ${repo}:${tag}"
+          echo "Miles image: \`${repo}:${tag}\`" >> "$GITHUB_STEP_SUMMARY"
+          # Falling back to an older tag means the 12:00 UTC build failed, so this run
+          # reports on code that was never built. Without an annotation that reads as a
+          # normal green nightly and the build outage goes unnoticed for days.
+          if [ -n "${age}" ] && [ "${age}" -gt 0 ]; then
+            echo "::warning::Newest ${base} image is ${age} day(s) old (${tag}); the nightly image build has been failing since then, so these results do not cover the last ${age} day(s) of commits"
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            echo "> [!WARNING]" >> "$GITHUB_STEP_SUMMARY"
+            echo "> Image is **${age} day(s) old**: the newer \`${base}\` builds failed, so these results do not cover the last ${age} day(s) of commits." >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       - name: Ensure VRAM is clear
         run: bash scripts/ci/amd/ensure_vram_clear.sh rocm

--- a/.github/workflows/nightly-test-amd-miles-rocm720.yml
+++ b/.github/workflows/nightly-test-amd-miles-rocm720.yml
@@ -73,14 +73,16 @@ jobs:
           echo "MILES_IMAGE=${repo}:${tag}" >> "$GITHUB_ENV"
           echo "Using miles image: ${repo}:${tag}"
           echo "Miles image: \`${repo}:${tag}\`" >> "$GITHUB_STEP_SUMMARY"
-          # Falling back to an older tag means the 12:00 UTC build failed, so this run
-          # reports on code that was never built. Without an annotation that reads as a
-          # normal green nightly and the build outage goes unnoticed for days.
+          # Falling back to an older tag means this run reports on code that was never
+          # built. For the 17:30 UTC schedule that implies the 12:00 UTC build failed;
+          # a manual dispatch before 12:00 UTC is simply a day behind. Either way the
+          # results do not cover the newest commits, and without an annotation that
+          # reads as a normal green nightly.
           if [ -n "${age}" ] && [ "${age}" -gt 0 ]; then
-            echo "::warning::Newest ${base} image is ${age} day(s) old (${tag}); the nightly image build has been failing since then, so these results do not cover the last ${age} day(s) of commits"
+            echo "::warning::Newest ${base} image is ${age} day(s) old (${tag}); no newer image has been published, so these results do not cover commits merged since then"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "> [!WARNING]" >> "$GITHUB_STEP_SUMMARY"
-            echo "> Image is **${age} day(s) old**: the newer \`${base}\` builds failed, so these results do not cover the last ${age} day(s) of commits." >> "$GITHUB_STEP_SUMMARY"
+            echo "> Image is **${age} day(s) old**: no newer \`${base}\` image has been published, so these results do not cover commits merged since then." >> "$GITHUB_STEP_SUMMARY"
           fi
 
       - name: Ensure VRAM is clear


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

`nightly-test-amd-miles-rocm720.yml` resolves its image by walking back up to 7 days for a dated `miles-rocm720-mi35x-<date>` tag and taking the first one that exists. When today's tag is missing it silently uses an older one, so a run that covers none of the last few days of commits is indistinguishable from a normal nightly.

That is not hypothetical. Three consecutive nightlies ran on a four-day-old image because the intervening 12:00 UTC builds had failed:

| nightly | resolved image | image builds that day |
| --- | --- | --- |
| 2026-08-24 | `miles-rocm720-mi35x-20260824` | success |
| 2026-08-25 | `miles-rocm720-mi35x-20260824` | failure |
| 2026-08-26 | `miles-rocm720-mi35x-20260824` | failure at 12:14 |
| 2026-08-27 | `miles-rocm720-mi35x-20260824` | failure |
| 2026-08-28 | `miles-rocm720-mi35x-20260828` | success |

The consequence: a Megatron checkpointing change that landed in miles on 08-24 broke `--async-save` on ROCm, and the nightly did not notice until 08-28, when a fresh image was finally built. Four nights of coverage were lost to a failure mode nothing reported. Run [33265909152](https://github.com/sgl-project/sglang/actions/runs/33265909152) is the first one where the resulting `tests/e2e/ckpt/test_qwen3_4B_ckpt.py` failure is visible; the fix for the regression itself lives in miles ([radixark/miles#2816](https://github.com/radixark/miles/pull/2816)).

## Modifications

`Resolve newest miles ROCm 7.2 image` now records how many days it walked back and, when that is more than zero:

- emits a `::warning::` annotation naming the age and the tag, so it shows on the run page even when every test passes;
- adds a `> [!WARNING]` callout to the job summary, next to the existing test summary that step already appends.

The resolved tag is written to the job summary unconditionally, so it is possible to tell after the fact which image a given nightly actually ran on without digging through raw logs.

Deliberately a warning rather than a hard failure: a stale image still produces useful signal, and failing the job would replace a silent-wrong-answer problem with a red nightly that hides whatever the tests did find. An explicit `image_tag` workflow input is never flagged, since that image was asked for by name.

The message states only what the step can actually establish — that no newer image was published, so the results miss commits merged since. For the 17:30 UTC schedule that does imply the 12:00 UTC build failed, but a manual dispatch before 12:00 UTC is legitimately a day behind with nothing broken, so the annotation does not assert a cause.

## Accuracy Tests

Not applicable, CI-only change.

## Speed Tests and Profiling

Not applicable, CI-only change.

## Verification

Ran on a real MI35X runner as part of [actions/runs/33305121208](https://github.com/sgl-project/sglang/actions/runs/33305121208), dispatched at 09:53 UTC when only the previous day's image existed:

```
Using miles image: rocm/sgl-dev:miles-rocm720-mi35x-20260829
##[warning]Newest miles-rocm720-mi35x image is 1 day(s) old (miles-rocm720-mi35x-20260829);
no newer image has been published, so these results do not cover commits merged since then
```

`MILES_IMAGE` was set identically to before and the container started normally, so the added lines do not disturb the resolve path. That run is also what prompted dropping the causal claim from the wording: at 09:53 UTC the one-day-old image is expected, not a build failure.

The remaining branches were driven by replaying the step's shell with a stubbed `docker manifest inspect`, since they need registry states that cannot be arranged on demand:

| scenario | result |
| --- | --- |
| today's tag exists | no annotation; summary records the tag |
| newest tag is 3 days old | `::warning::` with `age=3`; summary gets the callout |
| nothing within 7 days | unchanged `::error::` and exit 1 |
| explicit `image_tag` input | no staleness annotation |

The diff is purely additive, with no change to the existing resolve or error paths.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6cc494e6-b41c-446a-a4ba-f2422b453d8b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6cc494e6-b41c-446a-a4ba-f2422b453d8b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33306200014](https://github.com/sgl-project/sglang/actions/runs/33306200014)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33306199905](https://github.com/sgl-project/sglang/actions/runs/33306199905)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->