### PR TITLE
[Diffusion] Cache Qwen-Image modulation across serial CFG branches

### DIFF
--- a/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
+++ b/python/sglang/multimodal_gen/runtime/models/dits/qwen_image.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import functools
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import diffusers
@@ -107,6 +108,60 @@ def _local_seq_len(seq_len: int, sp_world_size: int) -> int:
 
 
 _get_qkv_projections = get_qkv_projections
+
+
+def _safe_tensor_version(tensor: torch.Tensor) -> Optional[int]:
+    """Read a tensor version counter without rejecting inference tensors."""
+    return None if tensor.is_inference() else tensor._version
+
+
+@dataclass(frozen=True, eq=False)
+class _QwenModulationCacheKey:
+    timestep: torch.Tensor
+    timestep_version: Optional[int]
+    additional_t_cond: Optional[torch.Tensor]
+    additional_t_cond_version: Optional[int]
+    hidden_dtype: torch.dtype
+    hidden_device: torch.device
+
+    def matches(self, other: "_QwenModulationCacheKey") -> bool:
+        return (
+            self.timestep is other.timestep
+            and self.timestep_version == other.timestep_version
+            and self.additional_t_cond is other.additional_t_cond
+            and self.additional_t_cond_version == other.additional_t_cond_version
+            and self.hidden_dtype == other.hidden_dtype
+            and self.hidden_device == other.hidden_device
+        )
+
+
+def _qwen_modulation_cache_key(
+    timestep: Optional[torch.Tensor],
+    additional_t_cond: Optional[torch.Tensor],
+    hidden_states: torch.Tensor,
+) -> Optional[_QwenModulationCacheKey]:
+    """Build the key shared by the two serial CFG forwards at one timestep."""
+    if (
+        not isinstance(timestep, torch.Tensor)
+        or torch.is_grad_enabled()
+        or torch.compiler.is_compiling()
+        or is_in_breakable_cuda_graph()
+        or (timestep.device.type == "cuda" and torch.cuda.is_current_stream_capturing())
+    ):
+        return None
+
+    return _QwenModulationCacheKey(
+        timestep=timestep,
+        timestep_version=_safe_tensor_version(timestep),
+        additional_t_cond=additional_t_cond,
+        additional_t_cond_version=(
+            _safe_tensor_version(additional_t_cond)
+            if isinstance(additional_t_cond, torch.Tensor)
+            else None
+        ),
+        hidden_dtype=hidden_states.dtype,
+        hidden_device=hidden_states.device,
+    )
 
 
 class QwenTimestepProjEmbeddings(nn.Module):
@@ -977,6 +1032,13 @@ class QwenImageTransformerBlock(nn.Module):
         self.fused_res_ln_ss_gate_select01 = (
             FusedResidualLayerNormScaleShiftGateSelect01()
         )
+        self._modulation_cache: Optional[
+            Tuple[
+                _QwenModulationCacheKey,
+                torch.Tensor,
+                torch.Tensor,
+            ]
+        ] = None
 
         nunchaku_enabled = (
             quant_config is not None
@@ -1057,6 +1119,30 @@ class QwenImageTransformerBlock(nn.Module):
         self, a: torch.Tensor, b: torch.Tensor, c: torch.Tensor, k: int = 0
     ) -> torch.Tensor:
         return self.fuse_mul_add(a, b, c, k)
+
+    def _get_modulation_params(
+        self,
+        temb_img_silu: torch.Tensor,
+        temb_txt_silu: torch.Tensor,
+        cache_key: Optional[_QwenModulationCacheKey],
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        cached = self._modulation_cache
+        if (
+            cache_key is not None
+            and cached is not None
+            and cached[0].matches(cache_key)
+        ):
+            self._modulation_cache = None
+            return cached[1], cached[2]
+
+        img_mod_params, _ = self.img_mod[1](temb_img_silu)
+        txt_mod_params, _ = self.txt_mod[1](temb_txt_silu)
+        self._modulation_cache = (
+            (cache_key, img_mod_params, txt_mod_params)
+            if cache_key is not None
+            else None
+        )
+        return img_mod_params, txt_mod_params
 
     def _modulate(
         self,
@@ -1165,10 +1251,14 @@ class QwenImageTransformerBlock(nn.Module):
         image_rotary_emb: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
         joint_attention_kwargs: Optional[Dict[str, Any]] = None,
         modulate_index: Optional[torch.Tensor] = None,
+        modulation_cache_key: Optional[_QwenModulationCacheKey] = None,
     ) -> Tuple[torch.Tensor, torch.Tensor]:
         # Get modulation parameters for both streams
-        img_mod_params, _ = self.img_mod[1](temb_img_silu)  # [B, 6*dim]
-        txt_mod_params, _ = self.txt_mod[1](temb_txt_silu)  # [B, 6*dim]
+        img_mod_params, txt_mod_params = self._get_modulation_params(
+            temb_img_silu,
+            temb_txt_silu,
+            modulation_cache_key,
+        )
 
         if (
             self.quant_config is not None
@@ -1512,6 +1602,12 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
 
         hidden_states, _ = self.img_in(hidden_states)
 
+        modulation_cache_key = _qwen_modulation_cache_key(
+            timestep,
+            additional_t_cond,
+            hidden_states,
+        )
+
         timestep = (timestep / 1000).to(hidden_states.dtype)
 
         if self.zero_cond_t:
@@ -1611,6 +1707,7 @@ class QwenImageTransformer2DModel(CachableDiT, LayerwiseOffloadableModuleMixin):
                 image_rotary_emb=image_rotary_emb,
                 joint_attention_kwargs=block_attention_kwargs,
                 modulate_index=modulate_index,
+                modulation_cache_key=modulation_cache_key,
             )
 
             # controlnet residual

--- a/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
+++ b/test/registered/kernels/ops/diffusion/test_model_fast_paths.py
@@ -95,6 +95,10 @@ from sglang.multimodal_gen.runtime.models.dits.longcat_image import (
     _apply_longcat_qknorm_rope,
 )
 from sglang.multimodal_gen.runtime.models.dits.ltx_2 import _ltx2_rms_norm_modulate
+from sglang.multimodal_gen.runtime.models.dits.qwen_image import (
+    QwenImageTransformerBlock,
+    _qwen_modulation_cache_key,
+)
 from sglang.multimodal_gen.runtime.models.dits.sana import (
     _eager_ln_modulate as _sana_eager_ln_modulate,
 )
@@ -289,6 +293,117 @@ class TestFlux2EagerFusions(CustomTestCase):
         expected = F.silu(second[..., :384]) * second[..., 384:]
         self.assertTrue(torch.equal(actual, expected))
         self.assertEqual(len(flux2._FLUX2_SWIGLU_SIGS), 1)
+
+
+# -------------------------------------------------------------------------
+# Qwen-Image -- reuse timestep-only modulation across serial CFG branches
+# -------------------------------------------------------------------------
+
+
+class _CountingProjection(nn.Module):
+    def __init__(self, offset: float):
+        super().__init__()
+        self.offset = offset
+        self.calls = 0
+
+    def forward(self, x):
+        self.calls += 1
+        return x + self.offset, None
+
+
+class TestQwenImageModulationCache(CustomTestCase):
+    def _block(self):
+        block = QwenImageTransformerBlock.__new__(QwenImageTransformerBlock)
+        nn.Module.__init__(block)
+        block.img_mod = nn.ModuleList([nn.Identity(), _CountingProjection(1.0)])
+        block.txt_mod = nn.ModuleList([nn.Identity(), _CountingProjection(2.0)])
+        block._modulation_cache = None
+        return block
+
+    def _key(self, timestep, hidden, additional_t_cond=None):
+        with torch.no_grad():
+            return _qwen_modulation_cache_key(
+                timestep,
+                additional_t_cond,
+                hidden,
+            )
+
+    def test_matching_cfg_key_reuses_both_modulation_projections(self):
+        block = self._block()
+        timestep = torch.tensor([500.0], device="cuda")
+        hidden = torch.empty(1, 17, 32, device="cuda", dtype=torch.bfloat16)
+        img_temb = torch.randn(1, 32, device="cuda", dtype=torch.bfloat16)
+        txt_temb = torch.randn_like(img_temb)
+        key = self._key(timestep, hidden)
+
+        first = block._get_modulation_params(img_temb, txt_temb, key)
+        second = block._get_modulation_params(img_temb, txt_temb, key)
+
+        self.assertIs(first[0], second[0])
+        self.assertIs(first[1], second[1])
+        self.assertIsNone(block._modulation_cache)
+        self.assertEqual(block.img_mod[1].calls, 1)
+        self.assertEqual(block.txt_mod[1].calls, 1)
+
+    def test_tensor_identity_version_and_condition_invalidate_cache(self):
+        block = self._block()
+        timestep = torch.tensor([500.0], device="cuda")
+        hidden = torch.empty(1, 17, 32, device="cuda", dtype=torch.bfloat16)
+        temb = torch.randn(1, 32, device="cuda", dtype=torch.bfloat16)
+        key = self._key(timestep, hidden)
+        block._get_modulation_params(temb, temb, key)
+
+        with torch.no_grad():
+            timestep.add_(1)
+        mutated = self._key(timestep, hidden)
+        block._get_modulation_params(temb, temb, mutated)
+        self.assertEqual(block.img_mod[1].calls, 2)
+
+        same_value_new_tensor = self._key(timestep.clone(), hidden)
+        block._get_modulation_params(temb, temb, same_value_new_tensor)
+        self.assertEqual(block.img_mod[1].calls, 3)
+
+        condition = torch.tensor([1], device="cuda")
+        conditioned = self._key(timestep, hidden, condition)
+        block._get_modulation_params(temb, temb, conditioned)
+        self.assertEqual(block.img_mod[1].calls, 4)
+
+    def test_grad_enabled_path_disables_and_clears_cache(self):
+        block = self._block()
+        timestep = torch.tensor([500.0], device="cuda")
+        hidden = torch.empty(1, 17, 32, device="cuda", dtype=torch.bfloat16)
+        temb = torch.randn(1, 32, device="cuda", dtype=torch.bfloat16)
+        key = self._key(timestep, hidden)
+        block._get_modulation_params(temb, temb, key)
+
+        self.assertIsNone(_qwen_modulation_cache_key(timestep, None, hidden))
+        block._get_modulation_params(temb, temb, None)
+
+        self.assertIsNone(block._modulation_cache)
+        self.assertEqual(block.img_mod[1].calls, 2)
+
+    def test_inference_tensors_cache_and_graph_path_falls_back(self):
+        block = self._block()
+        with torch.inference_mode():
+            timestep = torch.tensor([500.0], device="cuda")
+            hidden = torch.empty(1, 17, 32, device="cuda", dtype=torch.bfloat16)
+            temb = torch.randn(1, 32, device="cuda", dtype=torch.bfloat16)
+            key = _qwen_modulation_cache_key(timestep, None, hidden)
+
+            first = block._get_modulation_params(temb, temb, key)
+            second = block._get_modulation_params(temb, temb, key)
+
+        self.assertIs(first[0], second[0])
+        self.assertEqual(block.img_mod[1].calls, 1)
+
+        with (
+            patch(
+                "sglang.multimodal_gen.runtime.models.dits.qwen_image.is_in_breakable_cuda_graph",
+                return_value=True,
+            ),
+            torch.no_grad(),
+        ):
+            self.assertIsNone(_qwen_modulation_cache_key(timestep, None, hidden))
 
 
 # -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Cache Qwen-Image's timestep-only image/text modulation projections across the two serial classifier-free-guidance forwards at one denoising step.
- Key the one-slot cache by tensor identity/version plus the conditioning tensor and activation dtype/device, and consume the entry after the matching second pass.
- Keep training, `torch.compile`, breakable CUDA graph, and active CUDA stream-capture paths on the existing uncached implementation.
- Add focused coverage for cache hits, invalidation, inference tensors, grad-enabled execution, and graph fallback.

This implements the Qwen-Image CFG modulation reuse described in [Agentic Kernels in Production](https://www.baseten.co/blog/agentic-kernels-in-production/). The modulation projections depend on the timestep embedding and fixed block weights, not prompt conditioning, so the conditional and unconditional branches produce the same values.

## Execution flow

```mermaid
flowchart TD
    A["DenoisingStage._predict_noise_with_cfg"] --> B["conditional model forward"]
    B --> C["QwenImageTransformer2DModel.forward builds cache key"]:::changed
    C --> D{"QwenImageTransformerBlock cache match"}:::changed
    D -->|"miss on first CFG branch"| E["run img_mod and txt_mod projections"]
    E --> F["store one cache entry per block"]:::changed
    F --> G["finish conditional prediction"]
    G --> H["unconditional model forward with same timestep object"]
    H --> D
    D -->|"hit on second CFG branch"| I["reuse modulation outputs and clear entry"]:::changed
    I --> J["run prompt-dependent attention and MLP normally"]
    D -->|"training, compile, or graph path"| K["existing uncached path"]

    L["Legend: dashed border = added or modified by this PR"]:::changed
    classDef changed stroke-dasharray:5 5,stroke-width:2px;
```

The default serial CFG policy runs the conditional branch first and the unconditional branch second with the same `timestep` tensor. The first branch populates each block's one-slot cache; the second consumes it. Prompt-dependent hidden states, attention, and MLP computation remain separate. A new timestep, an in-place version change, a different additional condition, or a different dtype/device misses the cache and recomputes.

## GB300 NVFP4 benchmark

| Item | Value |
|---|---|
| GPU | NVIDIA GB300, 284208 MiB, driver 580.105.08 |
| Software | PyTorch 2.13.0+cu130, CUDA 13.0 |
| Model | `lmsys/qwen-image-2512-modelopt-nvfp4-sglang` |
| Base | `5b7c62d5d685f0b14859ac26db8d3cacbd50ffa7` |
| PR | `d7ee6536304a20a94e659e0a201627f65a6ae8bb` |
| Backend | Native SGLang, eager/lossless, one GPU, resident DiT/text encoder/VAE |
| Workload | 1024x1024, 50 steps, true CFG 4.0, seed 20260830 |
| Protocol | 1 request warmup per process; 5 saved main and 5 saved PR requests in balanced `A-B-B-A / B-A-A-B / A-B` order |

| Metric (5 runs, mean) | main | PR | Change |
|---|---:|---:|---:|
| Denoising / step | 489.88 ± 9.25 ms | 461.71 ± 11.37 ms | **-5.75% (1.061x)** |
| Denoising stage | 24,493.77 ± 462.55 ms | 23,085.66 ± 568.29 ms | **-5.75% (1.061x)** |
| Saved-request end-to-end | 24,617.93 ± 464.68 ms | 23,209.89 ± 571.71 ms | **-5.72% (1.061x)** |

All accepted logs passed the native-backend gate: none contains `Falling back to diffusers backend`, `Using diffusers backend`, or `Loaded diffusers pipeline`.

### Profiler attribution

A separate `torch.profiler` run (not used for the latency claim) captured two active denoising steps on each revision:

| Trace event | main | PR | Removed |
|---|---:|---:|---:|
| NVFP4 GEMM kernel launches | 3,136 | 2,912 | 224 |
| Unquantized `aten::addmm` launches | 248 | 232 | 16 |
| Total CUDA kernel launches | 13,618 | 12,930 | 688 (-5.05%) |

The 224 quantized plus 16 unquantized GEMMs equal 240 removed modulation projections over two captured steps, or exactly **120 per denoising step**: 60 transformer blocks × two image/text modulation projections skipped on the second CFG branch.

## Accuracy and generated-image comparison

The ten saved lossless outputs (five main + five PR) are byte-identical.

| Metric | Result |
|---|---:|
| SHA256 (main and PR) | `aa47c777db234bac5336a865de0e5af9d9c1300c91244c5b4cc33038af511f2c` |
| Exact pixel equality | `true` |
| Max / mean absolute pixel difference | `0 / 0` |
| MSE | `0` |
| PSNR | `inf` |
| SSIM | `1.000000` |
| LPIPS | `0` |

![Qwen-Image NVFP4 main vs PR](https://raw.githubusercontent.com/BBuf/sglang/pr-media/diffusion-prs/qwen-cfg-modulation/main-vs-pr.png)

Both panels use the exact same prompt, negative prompt, seed, scheduler, dimensions, steps, and checkpoint.

## Validation

```text
CUDA_VISIBLE_DEVICES=0 PYTHONPATH=<repo>/python \
  python3 -m pytest \
  test/registered/kernels/ops/diffusion/test_model_fast_paths.py \
  -k QwenImageModulationCache -q

4 passed, 42 deselected
```

- `ruff format --check` passed.
- `ruff check` passed.
- `git diff --check` passed.
- `python3 -m py_compile` passed for both touched files.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33295933959](https://github.com/sgl-project/sglang/actions/runs/33295933959)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33323102670](https://github.com/sgl-project/sglang/actions/runs/33323102670)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33295933793](https://github.com/sgl-project/sglang/actions/runs/33295933793)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->