### PR TITLE
[HiCache] Drop the parallel KV-event hash chain

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -547,9 +547,10 @@ class HiCacheController:
         # Rollback-safe init: if creation fails, keep controller state consistent
         # for future attach attempts.
         self.storage_backend_type = storage_backend
-        from sglang.srt.mem_cache.utils import get_hash_str
+        from sglang.srt.mem_cache.utils import chain_prior_hash, get_hash_str
 
         self.get_hash_str = get_hash_str
+        self.chain_prior_hash = chain_prior_hash
         self.storage_config = self._generate_storage_config(
             model_name, storage_backend_extra_config
         )
@@ -1175,7 +1176,9 @@ class HiCacheController:
         storage_query_count = 0
         hash_value = []
         page_hashes = self.get_hash_str(
-            tokens_to_fetch, last_hash, page_size=self.page_size
+            tokens_to_fetch,
+            self.chain_prior_hash(tokens_to_fetch, last_hash),
+            page_size=self.page_size,
         )
         operation.all_hash_values = page_hashes
 

--- a/python/sglang/srt/mem_cache/events.py
+++ b/python/sglang/srt/mem_cache/events.py
@@ -29,7 +29,6 @@ from sglang.srt.disaggregation.kv_events import (
     StorageMedium,
 )
 from sglang.srt.mem_cache.utils import (
-    compute_node_event_hash_values,
     compute_node_hash_values,
     hash_str_to_int64,
 )
@@ -89,25 +88,19 @@ class KVCacheEventRecorder:
         """Hash values to publish for ``node``, computing them if not yet set."""
         if node.hash_value is None:
             node.hash_value = compute_node_hash_values(node, self.page_size)
-        if node.key.cache_salt is not None:
-            return compute_node_event_hash_values(node, self.page_size)
         return node.hash_value
 
     def _parent_block_hash(self, node: Any) -> Optional[int]:
         """The hash the first page of ``node`` links back to.
 
         ``None`` when the parent is the tree root: a root carries an empty
-        ``hash_value`` and no event hash, so it contributes no link. Every other
-        node on the path has a parent, which is what distinguishes the two.
+        ``hash_value``, so it contributes no link. Every other node on the path
+        has a parent, which is what distinguishes the two.
         """
         parent = node.parent
         if parent is None or parent.parent is None:
             return None
-        if node.key.cache_salt is not None:
-            parent_hash_values = parent.event_hash_value
-            assert parent_hash_values is not None
-        else:
-            parent_hash_values = parent.hash_value
+        parent_hash_values = parent.hash_value
         if not parent_hash_values:
             return None
         return hash_str_to_int64(parent_hash_values[-1])

--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1906,9 +1906,6 @@ class HiRadixCache(RadixCache):
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
         )
-        new_node.event_hash_value, child.event_hash_value = split_node_hash_value(
-            child.event_hash_value, split_len, self.page_size
-        )
         child.parent = new_node
         child.key = child.key[split_len:]
         new_node.parent.children[key.child_key(self.page_size)] = new_node

--- a/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
+++ b/python/sglang/srt/mem_cache/hybrid_cache/hybrid_cache_controller.py
@@ -577,7 +577,9 @@ class HybridCacheController(BaseHiCacheController):
 
     def _storage_hit_query(self, operation) -> tuple[list[str], int]:
         hash_value = self.get_hash_str(
-            operation.token_ids, operation.last_hash, page_size=self.page_size
+            operation.token_ids,
+            self.chain_prior_hash(operation.token_ids, operation.last_hash),
+            page_size=self.page_size,
         )
         operation.all_hash_values = hash_value
 

--- a/python/sglang/srt/mem_cache/mamba_radix_cache.py
+++ b/python/sglang/srt/mem_cache/mamba_radix_cache.py
@@ -105,7 +105,6 @@ class TreeNode:
         # store hash values of each pages
         self.hash_value: Optional[List[str]] = None
         # Namespace-aware hashes used only for external KV events.
-        self.event_hash_value: Optional[List[str]] = None
 
         # for lru list, invariant:
         # 1. prev has greater last_access_time
@@ -1230,9 +1229,6 @@ class MambaRadixCache(BasePrefixCache):
         new_node.parent.children[key.child_key(self.page_size)] = new_node
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
-        )
-        new_node.event_hash_value, child.event_hash_value = split_node_hash_value(
-            child.event_hash_value, split_len, self.page_size
         )
 
         # insert the new node and child into the full lru list, insert

--- a/python/sglang/srt/mem_cache/radix_cache.py
+++ b/python/sglang/srt/mem_cache/radix_cache.py
@@ -258,7 +258,6 @@ class TreeNode:
         # store hash values of each pages
         self.hash_value: Optional[List[str]] = None
         # Namespace-aware hashes used only for external KV events.
-        self.event_hash_value: Optional[List[str]] = None
         # priority for priority-aware eviction
         self.priority = priority
 
@@ -720,9 +719,6 @@ class RadixCache(BasePrefixCache):
         # Split hash_value if it was already computed, otherwise leave as None
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
-        )
-        new_node.event_hash_value, child.event_hash_value = split_node_hash_value(
-            child.event_hash_value, split_len, self.page_size
         )
 
         return new_node

--- a/python/sglang/srt/mem_cache/swa_radix_cache.py
+++ b/python/sglang/srt/mem_cache/swa_radix_cache.py
@@ -81,7 +81,6 @@ class TreeNode:
         # store hash values of each page
         self.hash_value: Optional[List[str]] = None
         # Namespace-aware hashes used only for external KV events.
-        self.event_hash_value: Optional[List[str]] = None
 
         # for lru list, invariant:
         # 1. prev has greater last_access_time
@@ -1059,12 +1058,6 @@ class SWARadixCache(BasePrefixCache):
                 node.hash_value = list(node.hash_value) + list(child.hash_value)
             else:
                 node.hash_value = None
-            if node.event_hash_value is not None and child.event_hash_value is not None:
-                node.event_hash_value = list(node.event_hash_value) + list(
-                    child.event_hash_value
-                )
-            else:
-                node.event_hash_value = None
 
             self.full_lru_list.remove_node(child)
             if not child.swa_tombstone:
@@ -1135,9 +1128,6 @@ class SWARadixCache(BasePrefixCache):
         new_node.parent.children[key.child_key(self.page_size)] = new_node
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
-        )
-        new_node.event_hash_value, child.event_hash_value = split_node_hash_value(
-            child.event_hash_value, split_len, self.page_size
         )
 
         # insert the new node and child into the lru lists, insert

--- a/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
+++ b/python/sglang/srt/mem_cache/unified_cache/unified_tree_core.py
@@ -120,7 +120,6 @@ class UnifiedTreeNode:
         self.creation_time = get_and_increase_time_counter()
         self.hash_value = None
         # Namespace-aware hashes used only for external KV events.
-        self.event_hash_value: Optional[list[str]] = None
         self.hit_count = 0
         self.priority = priority
         self.lru_prev: list[UnifiedTreeNode | None] = [None] * (
@@ -1093,9 +1092,6 @@ class UnifiedTreeCore(UnifiedTreeCoreInterface):
         child.key = child.key[split_len:]
         new_node.hash_value, child.hash_value = split_node_hash_value(
             child.hash_value, split_len, self.page_size
-        )
-        new_node.event_hash_value, child.event_hash_value = split_node_hash_value(
-            child.event_hash_value, split_len, self.page_size
         )
 
         for component in self.components:

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -14,7 +14,7 @@
 """Common utilities."""
 
 import hashlib
-from typing import Any, Callable, List, Optional, Tuple
+from typing import TYPE_CHECKING, Any, Callable, List, Optional, Tuple
 
 from sglang.kernels.ops.kvcache.mla_buffer import (
     get_mla_kv_buffer_kernel as get_mla_kv_buffer_kernel,
@@ -52,6 +52,9 @@ from sglang.srt.mem_cache.evict_policy import (
     PriorityStrategy,
     SLRUStrategy,
 )
+
+if TYPE_CHECKING:
+    from sglang.srt.mem_cache.radix_cache import RadixKey
 
 _EVICTION_POLICY_FACTORIES: dict[str, Callable[[], EvictionStrategy]] = {
     "lru": LRUStrategy,
@@ -113,6 +116,40 @@ def get_hash_str(
     return get_native_hash(token_ids, prior_digest, page_size)
 
 
+# Domain separator for the namespace seed; bump it to invalidate salted L3 entries.
+_CACHE_NAMESPACE_DOMAIN = b"sglang-cache-namespace-v1"
+
+
+def namespace_seed(key: "RadixKey") -> Optional[str]:
+    """The digest a page-hash chain starts from, or None for the default namespace.
+
+    Page hashes cover token ids only, so a chain that starts unseeded names the
+    same L3 page for every namespace. Seeding the head with extra_key/cache_salt
+    keeps those namespaces apart. Each part is hashed with a presence byte and
+    its length, so ('a', 'bc') cannot alias ('ab', 'c') and an absent part cannot
+    alias an empty one.
+    """
+    if key.extra_key is None and key.cache_salt is None:
+        return None
+
+    digest = hashlib.sha256(_CACHE_NAMESPACE_DOMAIN)
+    for part in (key.extra_key, key.cache_salt):
+        if part is None:
+            digest.update(b"\x00")
+            continue
+        encoded = part.encode("utf-8")
+        digest.update(b"\x01")
+        digest.update(len(encoded).to_bytes(8, "little"))
+        digest.update(encoded)
+    return digest.hexdigest()
+
+
+def chain_prior_hash(key: "RadixKey", prior_hash: Optional[str]) -> Optional[str]:
+    """What this page-hash chain links back to: the prior page when the chain
+    continues, else the seed that scopes a fresh chain to its namespace."""
+    return prior_hash if prior_hash else namespace_seed(key)
+
+
 def hash_str_to_int64(hash_str: str) -> int:
     """Convert SHA256 hex string to signed 64-bit integer for events.
 
@@ -130,6 +167,7 @@ def compute_node_hash_values(node: Any, page_size: int) -> List[str]:
     if node.parent is not None and node.parent.hash_value is not None:
         if len(node.parent.key) > 0 and len(node.parent.hash_value) > 0:
             parent_hash = node.parent.hash_value[-1]
+    parent_hash = chain_prior_hash(node.key, parent_hash)
 
     hash_values = get_hash_str(node.key, parent_hash, page_size=page_size)
     assert isinstance(hash_values, list)

--- a/python/sglang/srt/mem_cache/utils.py
+++ b/python/sglang/srt/mem_cache/utils.py
@@ -174,54 +174,6 @@ def compute_node_hash_values(node: Any, page_size: int) -> List[str]:
     return hash_values
 
 
-def compute_node_event_hash_values(node: Any, page_size: int) -> List[str]:
-    """Compute and memoize namespace-aware external KV-event hashes."""
-    cache_salt = node.key.cache_salt
-    if cache_salt is None:
-        return compute_node_hash_values(node, page_size)
-
-    if node.event_hash_value is not None:
-        return node.event_hash_value
-
-    missing_nodes = []
-    current = node
-    while (
-        current is not None
-        and current.key is not None
-        and len(current.key) > 0
-        and current.event_hash_value is None
-    ):
-        if current.key.cache_salt != cache_salt:
-            raise ValueError("Radix path contains mismatched cache_salt values")
-        missing_nodes.append(current)
-        current = current.parent
-
-    if (
-        current is not None
-        and current.key is not None
-        and len(current.key) > 0
-        and current.key.cache_salt != cache_salt
-    ):
-        raise ValueError("Radix path contains mismatched cache_salt values")
-
-    if current is not None and current.event_hash_value:
-        parent_hash = current.event_hash_value[-1]
-    else:
-        parent_hash = hashlib.sha256(
-            b"sglang-cache-salt-v1\0" + cache_salt.encode("utf-8")
-        ).hexdigest()
-
-    for missing_node in reversed(missing_nodes):
-        hash_values = get_hash_str(missing_node.key, parent_hash, page_size=page_size)
-        assert isinstance(hash_values, list)
-        missing_node.event_hash_value = hash_values
-        if hash_values:
-            parent_hash = hash_values[-1]
-
-    assert node.event_hash_value is not None
-    return node.event_hash_value
-
-
 def split_node_hash_value(
     child_hash_value: Optional[List[str]], split_len: int, page_size: int
 ) -> tuple[Optional[List[str]], Optional[List[str]]]:

--- a/test/registered/unit/mem_cache/test_mem_cache_utils.py
+++ b/test/registered/unit/mem_cache/test_mem_cache_utils.py
@@ -56,10 +56,11 @@ def _legacy_page_hashes(key, page_size, prior_hash=None):
 
 
 class _HashKey:
-    def __init__(self, token_ids, is_bigram=False, cache_salt=None):
+    def __init__(self, token_ids, is_bigram=False, cache_salt=None, extra_key=None):
         self.token_ids = token_ids
         self.is_bigram = is_bigram
         self.cache_salt = cache_salt
+        self.extra_key = extra_key
 
     def __len__(self):
         if self.is_bigram:
@@ -75,8 +76,13 @@ class _HashKey:
                     self.token_ids[start : stop + 1],
                     is_bigram=True,
                     cache_salt=self.cache_salt,
+                    extra_key=self.extra_key,
                 )
-            return _HashKey(self.token_ids[start:stop], cache_salt=self.cache_salt)
+            return _HashKey(
+                self.token_ids[start:stop],
+                cache_salt=self.cache_salt,
+                extra_key=self.extra_key,
+            )
         if self.is_bigram:
             return (self.token_ids[index], self.token_ids[index + 1])
         return self.token_ids[index]
@@ -333,16 +339,38 @@ class TestComputeNodeHashValues(unittest.TestCase):
             compute_node_event_hash_values(self._make_node(key), page_size=8),
             _legacy_page_hashes(key, page_size=8, prior_hash=seed),
         )
-        self.assertEqual(
-            compute_node_hash_values(self._make_node(key), page_size=8),
-            _legacy_page_hashes(key, page_size=8),
-        )
 
         other = _HashKey(array("q", range(1, 17)), cache_salt="tenant-b")
         self.assertNotEqual(
             compute_node_event_hash_values(self._make_node(key), page_size=8),
             compute_node_event_hash_values(self._make_node(other), page_size=8),
         )
+
+    def test_storage_hash_chain_is_namespaced(self):
+        """Requests whose extra_key or cache_salt differ must not name the same
+        L3 storage page even when their token ids are identical (#26747). The
+        ('a', 'bc') / ('ab', 'c') pair additionally pins that the two parts stay
+        distinguishable once concatenated."""
+        tokens = array("q", range(1, 17))
+        namespaced = [
+            _HashKey(tokens, extra_key="tenant-a"),
+            _HashKey(tokens, extra_key="tenant-b"),
+            _HashKey(tokens, cache_salt="tenant-a"),
+            _HashKey(tokens, extra_key="tenant-a", cache_salt="tenant-a"),
+            _HashKey(tokens, extra_key="a", cache_salt="bc"),
+            _HashKey(tokens, extra_key="ab", cache_salt="c"),
+        ]
+
+        hashes = [
+            tuple(compute_node_hash_values(self._make_node(key), page_size=8))
+            for key in namespaced
+        ]
+        default = tuple(
+            compute_node_hash_values(self._make_node(_HashKey(tokens)), page_size=8)
+        )
+
+        self.assertEqual(len(set(hashes)), len(hashes))
+        self.assertNotIn(default, set(hashes))
 
     def test_cache_salt_event_hashes_are_memoized(self):
         node = self._make_node(

--- a/test/registered/unit/mem_cache/test_mem_cache_utils.py
+++ b/test/registered/unit/mem_cache/test_mem_cache_utils.py
@@ -5,7 +5,6 @@ import sys
 import types
 import unittest
 from array import array
-from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from sglang.srt.mem_cache.evict_policy import (
@@ -18,12 +17,12 @@ from sglang.srt.mem_cache.evict_policy import (
     SLRUStrategy,
 )
 from sglang.srt.mem_cache.utils import (
-    compute_node_event_hash_values,
     compute_node_hash_values,
     get_eviction_strategy,
     get_hash_str,
     hash_str_to_int64,
     maybe_init_custom_mem_pool,
+    namespace_seed,
     split_node_hash_value,
 )
 from sglang.test.ci.ci_register import register_cpu_ci
@@ -311,7 +310,6 @@ class TestComputeNodeHashValues(unittest.TestCase):
         node = MagicMock()
         node.key = key
         node.parent = parent
-        node.event_hash_value = None
         if parent is not None:
             parent.hash_value = parent_hash_values
         return node
@@ -332,18 +330,14 @@ class TestComputeNodeHashValues(unittest.TestCase):
                     _legacy_page_hashes(key, page_size=page_size),
                 )
 
-    def test_cache_salt_seeds_root_hash_chain(self):
+    def test_namespaced_chain_matches_reference_chaining(self):
+        """A namespaced chain must still agree page-for-page with the Python
+        reference, so the seed is applied to the chain head only and not folded
+        into every page."""
         key = _HashKey(array("q", range(1, 17)), cache_salt="tenant-a")
-        seed = hashlib.sha256(b"sglang-cache-salt-v1\0tenant-a").hexdigest()
         self.assertEqual(
-            compute_node_event_hash_values(self._make_node(key), page_size=8),
-            _legacy_page_hashes(key, page_size=8, prior_hash=seed),
-        )
-
-        other = _HashKey(array("q", range(1, 17)), cache_salt="tenant-b")
-        self.assertNotEqual(
-            compute_node_event_hash_values(self._make_node(key), page_size=8),
-            compute_node_event_hash_values(self._make_node(other), page_size=8),
+            compute_node_hash_values(self._make_node(key), page_size=8),
+            _legacy_page_hashes(key, page_size=8, prior_hash=namespace_seed(key)),
         )
 
     def test_storage_hash_chain_is_namespaced(self):
@@ -371,42 +365,6 @@ class TestComputeNodeHashValues(unittest.TestCase):
 
         self.assertEqual(len(set(hashes)), len(hashes))
         self.assertNotIn(default, set(hashes))
-
-    def test_cache_salt_event_hashes_are_memoized(self):
-        node = self._make_node(
-            _HashKey(array("q", range(1, 17)), cache_salt="tenant-a")
-        )
-        with patch(
-            "sglang.srt.mem_cache.utils.get_hash_str", wraps=get_hash_str
-        ) as mock_get_hash_str:
-            first = compute_node_event_hash_values(node, page_size=8)
-            second = compute_node_event_hash_values(node, page_size=8)
-
-        self.assertIs(first, second)
-        mock_get_hash_str.assert_called_once()
-
-    def test_cache_salt_event_hash_walk_is_iterative(self):
-        root = SimpleNamespace(
-            key=_HashKey(array("q")),
-            parent=None,
-            hash_value=[],
-            event_hash_value=None,
-        )
-        node = root
-        path = []
-        for token_id in range(1, 1102):
-            node = SimpleNamespace(
-                key=_HashKey(array("q", [token_id]), cache_salt="tenant-a"),
-                parent=node,
-                hash_value=None,
-                event_hash_value=None,
-            )
-            path.append(node)
-
-        result = compute_node_event_hash_values(node, page_size=1)
-
-        self.assertEqual(len(result), 1)
-        self.assertTrue(all(item.event_hash_value is not None for item in path))
 
     def test_parent_hash_is_used_only_when_parent_has_nonempty_key_and_hash(self):
         parent = MagicMock()

--- a/test/registered/unit/mem_cache/test_radix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_radix_cache_unit.py
@@ -750,7 +750,7 @@ class TestRadixCache(unittest.TestCase):
         ]
         self.assertNotEqual(unsalted_hashes, stored[0].block_hashes)
 
-    def test_cache_salt_event_hashes_are_preserved_across_node_split(self):
+    def test_cache_salt_hashes_are_preserved_across_node_split(self):
         cache = RadixCache.create_simulated(page_size=2, enable_kv_cache_events=True)
         original = RadixKey(array("q", [1, 2, 3, 4]), cache_salt="tenant-a")
         cache.insert(
@@ -762,7 +762,7 @@ class TestRadixCache(unittest.TestCase):
         original_node = cache.match_prefix(
             MatchPrefixParams(key=original)
         ).last_device_node
-        original_hashes = list(original_node.event_hash_value)
+        original_hashes = list(original_node.hash_value)
 
         cache.insert(
             InsertParams(
@@ -776,7 +776,7 @@ class TestRadixCache(unittest.TestCase):
         split_parent = split_child.parent
 
         self.assertEqual(
-            split_parent.event_hash_value + split_child.event_hash_value,
+            split_parent.hash_value + split_child.hash_value,
             original_hashes,
         )
 


### PR DESCRIPTION
**Stacked on #37058** — review the second commit only; the first is that PR.

## Motivation

Every tree node carries two page-hash chains. `hash_value` keys L3 storage;
`event_hash_value` feeds KV events. The second one exists only because
`hash_value` used to start unseeded while events needed a namespace seed.

#37058 seeds `hash_value` with the request namespace, so the two chains now
carry the same information and the parallel one is dead weight. Keeping it is
not free: the chains must be kept in sync through every node split and merge,
which is the failure mode behind bugs like #36696.

## Modifications

Delete `compute_node_event_hash_values`, the `event_hash_value` field on all
four node classes, and the split call in each of the five split sites — in every
one it duplicates the `hash_value` call directly above it. `events.py` reads the
one chain, and `split_node_hash_value` stays, still serving `hash_value`.

Salted requests' KV-event block hashes move from the old salt-only seed to the
shared namespace seed. That is the only observable change; the block-hash
namespacing itself is unchanged.

## Tests

Two cases go with the mechanism they covered: memoization of the shadow chain,
and its iterative parent walk (there is no walk now). The split-preservation
case now guards the surviving chain, and
`test_cache_salt_is_included_in_store_and_remove_events` still pins that salted
and unsalted events differ.

Baseline diff on an H200 devbox, #37058 vs this branch, same command:
`unit/mem_cache/` 1852 -> 1850 passed (exactly the two deleted cases), 1207
skipped and 211 subtests unchanged; `unit/managers/` 593 / 4 / 610 on both.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33298136985](https://github.com/sgl-project/sglang/actions/runs/33298136985)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:white_check_mark: [Run #33300826584](https://github.com/sgl-project/sglang/actions/runs/33300826584)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33298136940](https://github.com/sgl-project/sglang/actions/runs/33298136940)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->