### PR TITLE
ci: update checkout, setup-python, and setup-node to current majors

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -30,7 +30,7 @@ jobs:
           fi
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v7
         with:
           python-version: "3.12"
 
@@ -59,7 +59,7 @@ jobs:
       # are NOT required to install `mint` for local pre-commit. External links
       # are covered separately by the nightly lychee job (no --check-external here).
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: "20"
 


### PR DESCRIPTION
Updates the lint workflow to current action majors.

Changes:
- actions/checkout v4 -> v7
- actions/setup-python v4 -> v7
- actions/setup-node v4 -> v7

Validation:
- actionlint 1.7.12 passes on the updated workflow
- no removed inputs are used (setup-python v7 dropped pip-install, which this workflow does not use)
- python 3.12 and node 20 are supported by the new majors; third-party actions in this file are left untouched

Scope: .github/workflows/lint.yml only.

Note: this PR comes from a fork. If workflow runs show action_required, they need a maintainer approval click; I will not retry-push to force it.

Commit author katsugtgz, unsigned.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:white_check_mark: [Run #33299428762](https://github.com/sgl-project/sglang/actions/runs/33299428762)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33299428665](https://github.com/sgl-project/sglang/actions/runs/33299428665)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:heavy_minus_sign: **No AMD PR run found for this commit**.<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->