### PR TITLE
添加DSpark ASD接受适配器，用于近似的投机解码

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -102,6 +102,23 @@ logger = logging.getLogger(__name__)
 _MEDIA_CONTENT_PART_TYPES = frozenset({"image_url", "video_url", "audio_url"})
 
 
+def _meta_info_with_output_token_ids(
+    ret_item: Dict[str, Any],
+) -> Dict[str, Any]:
+    """Expose scheduler-produced token IDs without decoding and retokenizing."""
+
+    meta_info = dict(ret_item["meta_info"])
+    output_token_ids = [int(token_id) for token_id in ret_item["output_ids"]]
+    completion_tokens = int(meta_info["completion_tokens"])
+    if len(output_token_ids) != completion_tokens:
+        raise RuntimeError(
+            "non-streaming output token ID count does not match completion_tokens: "
+            f"{len(output_token_ids)} != {completion_tokens}"
+        )
+    meta_info["output_token_ids"] = output_token_ids
+    return meta_info
+
+
 def normalize_tool_content(role: str, content):
     """Normalize tool message content from OpenAI array format to plain string.
 
@@ -1948,7 +1965,9 @@ class OpenAIServingChat(OpenAIServingBase):
             )
 
             choice_meta_info = (
-                ret_item["meta_info"] if request.return_meta_info else None
+                _meta_info_with_output_token_ids(ret_item)
+                if request.return_meta_info
+                else None
             )
             # NOTE: content should not be None but empty string to make sure retokenize consistency.
             reasoning_text, tool_calls = self._get_parsed_response_fields(

--- a/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
+++ b/python/sglang/srt/managers/scheduler_components/batch_result_processor.py
@@ -328,6 +328,13 @@ class SchedulerBatchResultProcessor:
                         self._maybe_update_reasoning_tokens(req, next_token_id)
 
                         req.update_finish_state()
+                    if req.finished() and isinstance(self.draft_worker, BaseSpecWorker):
+                        self.draft_worker.note_request_finished(
+                            rid=req.rid,
+                            natural_stop=isinstance(
+                                req.finished_reason, FINISH_MATCHED_TOKEN
+                            ),
+                        )
                     if req.finished():
                         self._maybe_collect_routed_experts(req)
                         self._maybe_collect_indexer_topk(req)

--- a/python/sglang/srt/speculative/dspark_components/asd_dspark.py
+++ b/python/sglang/srt/speculative/dspark_components/asd_dspark.py
@@ -1,0 +1,772 @@
+"""ASD acceptance adapter for the fixed greedy DSpark verify seam.
+
+The adapter is deliberately the only place that knows both the engine-neutral
+ASD rule and DSpark's candidate/logit/request-slot layout.  Its hot interface
+returns the same ``(correct_len, bonus, cap_trim_lens)`` tuple as the native
+greedy verifier, so the existing finalization, KV commit, request-token, next
+draft input, and metrics paths all consume one authoritative accepted length.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Callable, Mapping, Optional
+
+import msgspec
+import torch
+
+try:
+    from asd.reproduce.dspark.asd_config import DSparkASDConfig
+    from asd.reproduce.dspark.torch_rule import choose_prefix_batch
+except ImportError:
+    # Optional research dependency, not published to PyPI; install from the
+    # ASD source repository only when enabling ASD acceptance. A missing
+    # install keeps DSpark fully native (ASD_ENABLED=0, no trace).
+    DSparkASDConfig = None
+    choose_prefix_batch = None
+
+
+ASD_MODE_DISABLED = "disabled"
+ASD_MODE_CALIBRATION = "calibration"
+ASD_MODE_ENABLED = "enabled"
+_ASD_MODES = {
+    ASD_MODE_DISABLED,
+    ASD_MODE_CALIBRATION,
+    ASD_MODE_ENABLED,
+}
+
+_ENABLED_ENV = "ASD_ENABLED"
+_CALIBRATION_TRACE_ENV = "SGLANG_DSPARK_ASD_CALIBRATION_TRACE"
+_LEGACY_MODE_ENV = "SGLANG_DSPARK_ASD_MODE"
+_CONFIG_JSON_ENV = "SGLANG_DSPARK_ASD_CONFIG_JSON"
+_CONFIG_PATH_ENV = "SGLANG_DSPARK_ASD_CONFIG_PATH"
+_TRACE_CAPACITY_ENV = "SGLANG_DSPARK_ASD_TRACE_CAPACITY"
+_DEFAULT_TRACE_CAPACITY = 65536
+
+
+class DSparkASDSettings(msgspec.Struct, frozen=True):
+    """Process-start settings for one of the three experiment behaviours."""
+
+    mode: str = ASD_MODE_DISABLED
+    config: Optional[DSparkASDConfig] = None
+    trace_capacity: int = _DEFAULT_TRACE_CAPACITY
+
+    def __post_init__(self) -> None:
+        if self.mode not in _ASD_MODES:
+            raise ValueError(
+                f"internal ASD mode must be one of {sorted(_ASD_MODES)}, "
+                f"got {self.mode!r}; experiment arms use {_ENABLED_ENV}=0|1"
+            )
+        if self.mode == ASD_MODE_ENABLED and self.config is None:
+            raise ValueError("ASD enabled mode requires a decode configuration")
+        if self.mode != ASD_MODE_ENABLED and self.config is not None:
+            raise ValueError(
+                "an ASD decode configuration is valid only in enabled mode"
+            )
+        if (
+            isinstance(self.trace_capacity, bool)
+            or not isinstance(self.trace_capacity, int)
+            or self.trace_capacity <= 0
+        ):
+            raise ValueError("trace_capacity must be a positive integer")
+
+    @classmethod
+    def from_environ(
+        cls, environ: Optional[Mapping[str, str]] = None
+    ) -> "DSparkASDSettings":
+        """Resolve immutable settings without touching config in native mode."""
+
+        env = os.environ if environ is None else environ
+        if _LEGACY_MODE_ENV in env:
+            raise ValueError(
+                f"{_LEGACY_MODE_ENV} is not an experiment arm switch; use "
+                f"{_ENABLED_ENV}=0|1 and {_CALIBRATION_TRACE_ENV}=0|1"
+            )
+
+        enabled_raw = env.get(_ENABLED_ENV, "0")
+        trace_raw = env.get(_CALIBRATION_TRACE_ENV, "0")
+        if enabled_raw not in {"0", "1"}:
+            raise ValueError(f"{_ENABLED_ENV} must be exactly 0 or 1")
+        if trace_raw not in {"0", "1"}:
+            raise ValueError(f"{_CALIBRATION_TRACE_ENV} must be exactly 0 or 1")
+        enabled = enabled_raw == "1"
+        trace = trace_raw == "1"
+        if enabled and trace:
+            raise ValueError(
+                f"{_ENABLED_ENV}=1 conflicts with " f"{_CALIBRATION_TRACE_ENV}=1"
+            )
+
+        inline = env.get(_CONFIG_JSON_ENV)
+        path = env.get(_CONFIG_PATH_ENV)
+        if not enabled and (inline or path):
+            raise ValueError("ASD config is invalid when ASD_ENABLED=0")
+        if trace:
+            raw_capacity = env.get(_TRACE_CAPACITY_ENV, str(_DEFAULT_TRACE_CAPACITY))
+            try:
+                capacity = int(raw_capacity)
+            except ValueError as error:
+                raise ValueError(f"{_TRACE_CAPACITY_ENV} must be an integer") from error
+            return cls(mode=ASD_MODE_CALIBRATION, trace_capacity=capacity)
+        if not enabled:
+            return cls(mode=ASD_MODE_DISABLED)
+
+        if bool(inline) == bool(path):
+            raise ValueError(
+                "ASD enabled mode requires exactly one of "
+                f"{_CONFIG_JSON_ENV} or {_CONFIG_PATH_ENV}"
+            )
+
+        if DSparkASDConfig is None:
+            raise RuntimeError(
+                f"{_ENABLED_ENV}=1 requires the optional ASD package; "
+                "install it from the ASD source repository or unset "
+                f"{_ENABLED_ENV} to run DSpark with strict verification"
+            )
+
+        if path:
+            payload = json.loads(Path(path).read_text(encoding="utf-8"))
+        else:
+            payload = json.loads(inline)
+        if not isinstance(payload, Mapping):
+            raise ValueError("ASD config JSON must be an object")
+        return cls(
+            mode=ASD_MODE_ENABLED,
+            config=DSparkASDConfig.from_mapping(payload),
+        )
+
+    @property
+    def active(self) -> bool:
+        return self.mode != ASD_MODE_DISABLED
+
+    @property
+    def fingerprint(self) -> Optional[str]:
+        return None if self.config is None else self.config.fingerprint()
+
+
+class DSparkASDAdapter:
+    """Deep adapter at the DSpark native-vs-ASD acceptance seam.
+
+    Request identities are bound at prefill/finish lifecycle points.  The
+    decode interface uses only request-pool device indices, compact score
+    tensors, and device state.  Snapshot conversion is intentionally separate
+    and may synchronize only when an arm/calibration run is being sealed.
+    """
+
+    _PROPOSALS = 0
+    _DRAFTS_VERIFIABLE = 1
+    _STRICT_ACCEPTED = 2
+    _ASD_ACCEPTED = 3
+    _RELAXED_MISMATCHES = 4
+    _CAP_TRIMS = 5
+    _BUDGET_EXHAUSTIONS = 6
+    _REQUESTS_INITIALIZED = 7
+    _REQUESTS_FINISHED = 8
+    _REQUESTS_NON_NATURAL = 9
+    _SLOT_REUSE_RESETS = 10
+    _INT_COUNTER_COUNT = 11
+
+    _REGRET_CHARGED = 0
+    _COMPLETED_REMAINING_BUDGET = 1
+    _FLOAT_COUNTER_COUNT = 2
+
+    _TRACE_VALID = 0
+    _TRACE_PROPOSAL = 1
+    _TRACE_SLOT = 2
+    _TRACE_REQUEST_SERIAL = 3
+    _TRACE_FORWARD = 4
+    _TRACE_BARRIER = 5
+    _TRACE_INT_FIELD_COUNT = 6
+
+    _TRACE_REGRET = 0
+    _TRACE_VALUE = 1
+    _TRACE_RATIO = 2
+    _TRACE_FLOAT_FIELD_COUNT = 3
+
+    def __init__(
+        self,
+        *,
+        settings: DSparkASDSettings,
+        gamma: int,
+        verify_num_draft_tokens: int,
+        device: torch.device | str,
+    ) -> None:
+        self.settings = settings
+        self.gamma = int(gamma)
+        self.verify_num_draft_tokens = int(verify_num_draft_tokens)
+        self.device = torch.device(device)
+        if self.gamma <= 0:
+            raise ValueError("DSpark gamma must be positive")
+        if self.verify_num_draft_tokens != self.gamma + 1:
+            raise ValueError(
+                "DSpark ASD requires verify_num_draft_tokens == gamma + 1, "
+                f"got {self.verify_num_draft_tokens} and {self.gamma}"
+            )
+        if settings.config is not None:
+            settings.config.validate_block_size(self.gamma)
+
+        self._remaining_budget: Optional[torch.Tensor] = None
+        self._active_slots: Optional[torch.Tensor] = None
+        self._request_serial_by_slot: Optional[torch.Tensor] = None
+        self._int_counters: Optional[torch.Tensor] = None
+        self._float_counters: Optional[torch.Tensor] = None
+        self._accepted_by_position: Optional[torch.Tensor] = None
+        self._trace_cursor: Optional[torch.Tensor] = None
+        self._trace_dropped: Optional[torch.Tensor] = None
+        self._trace_int: Optional[torch.Tensor] = None
+        self._trace_float: Optional[torch.Tensor] = None
+
+        self._rid_to_slot: dict[str, int] = {}
+        self._slot_to_rid: dict[int, str] = {}
+        self._serial_to_rid: dict[int, str] = {}
+        self._next_request_serial = 1
+
+    @property
+    def active(self) -> bool:
+        return self.settings.active
+
+    def identity(self) -> dict:
+        return {
+            "mode": self.settings.mode,
+            "experiment_switches": {
+                "ASD_ENABLED": (1 if self.settings.mode == ASD_MODE_ENABLED else 0),
+                "SGLANG_DSPARK_ASD_CALIBRATION_TRACE": (
+                    1 if self.settings.mode == ASD_MODE_CALIBRATION else 0
+                ),
+            },
+            "config": (
+                None
+                if self.settings.config is None
+                else self.settings.config.to_mapping()
+            ),
+            "config_fingerprint": self.settings.fingerprint,
+            "gamma": self.gamma,
+            "verify_num_draft_tokens": self.verify_num_draft_tokens,
+            "candidate_alignment": {
+                "anchor_index": 0,
+                "draft_indices": [1, self.verify_num_draft_tokens],
+                "target_draft_logit_indices": [0, self.gamma],
+            },
+            "score_seam": (
+                "native full-vocab next_token_logits after the existing "
+                "LogitsProcessor TP all-gather; ASD adds no TP collective"
+            ),
+        }
+
+    def require_supported_runtime(
+        self,
+        *,
+        disable_cuda_graph: bool,
+        disable_overlap_schedule: bool,
+        ragged_verify_mode: str,
+        simulate_accept_length: float,
+    ) -> None:
+        """Fail loudly instead of silently bypassing an active ASD mode."""
+
+        if not self.active:
+            return
+        unsupported = []
+        if not disable_cuda_graph:
+            unsupported.append("CUDA graph")
+        if not disable_overlap_schedule:
+            unsupported.append("overlap schedule")
+        if ragged_verify_mode != "static":
+            unsupported.append(
+                f"ragged verify mode {ragged_verify_mode!r} (requires 'static')"
+            )
+        if simulate_accept_length > 0:
+            unsupported.append("simulated acceptance length")
+        if unsupported:
+            raise ValueError(
+                "DSpark ASD calibration/enabled mode supports only the frozen "
+                "eager static greedy experiment path; disable " + ", ".join(unsupported)
+            )
+
+    def require_unfolded_accept(self) -> None:
+        if self.active:
+            raise RuntimeError(
+                "active DSpark ASD mode cannot use folded native acceptance"
+            )
+
+    def _allocate_state(self, pool_capacity: int) -> None:
+        if self._remaining_budget is not None:
+            if self._remaining_budget.shape[0] != pool_capacity:
+                raise RuntimeError(
+                    "request-pool capacity changed after ASD state allocation"
+                )
+            return
+        if pool_capacity <= 1:
+            raise ValueError("request-pool capacity must include at least one slot")
+
+        self._remaining_budget = torch.zeros(
+            (pool_capacity,), dtype=torch.float64, device=self.device
+        )
+        self._active_slots = torch.zeros(
+            (pool_capacity,), dtype=torch.bool, device=self.device
+        )
+        self._request_serial_by_slot = torch.full(
+            (pool_capacity,), -1, dtype=torch.int64, device=self.device
+        )
+        self._int_counters = torch.zeros(
+            (self._INT_COUNTER_COUNT,), dtype=torch.int64, device=self.device
+        )
+        self._float_counters = torch.zeros(
+            (self._FLOAT_COUNTER_COUNT,), dtype=torch.float64, device=self.device
+        )
+        self._accepted_by_position = torch.zeros(
+            (self.gamma,), dtype=torch.int64, device=self.device
+        )
+        if self.settings.mode == ASD_MODE_CALIBRATION:
+            capacity = self.settings.trace_capacity
+            self._trace_cursor = torch.zeros((), dtype=torch.int64, device=self.device)
+            self._trace_dropped = torch.zeros((), dtype=torch.int64, device=self.device)
+            self._trace_int = torch.zeros(
+                (capacity + 1, self._TRACE_INT_FIELD_COUNT),
+                dtype=torch.int64,
+                device=self.device,
+            )
+            self._trace_float = torch.zeros(
+                (capacity + 1, self._TRACE_FLOAT_FIELD_COUNT),
+                dtype=torch.float64,
+                device=self.device,
+            )
+
+    @staticmethod
+    def _pool_capacity(batch) -> int:
+        pool = batch.req_to_token_pool
+        if hasattr(pool, "_alloc_size"):
+            return int(pool._alloc_size)
+        return int(pool.size) + 1
+
+    @staticmethod
+    def _cpu_slots(batch) -> list[int]:
+        mirror = batch.req_pool_indices_cpu
+        if mirror is not None:
+            return [int(value) for value in mirror]
+        slots = [req.req_pool_idx for req in batch.reqs]
+        if any(slot is None for slot in slots):
+            raise RuntimeError("ASD prefill lifecycle saw an unallocated request")
+        return [int(slot) for slot in slots]
+
+    def bind_batch(self, batch) -> None:
+        """Bind stable request identities at the low-frequency prefill seam."""
+
+        if not self.active or not batch.reqs:
+            return
+        self._allocate_state(self._pool_capacity(batch))
+        slots = self._cpu_slots(batch)
+        if len(slots) != len(batch.reqs):
+            raise RuntimeError("request and request-pool slot counts differ")
+
+        for req, slot in zip(batch.reqs, slots):
+            rid = str(req.rid)
+            old_slot = self._rid_to_slot.get(rid)
+            if old_slot is not None and old_slot != slot:
+                self._clear_slot(old_slot)
+                self._slot_to_rid.pop(old_slot, None)
+                self._rid_to_slot.pop(rid, None)
+
+            old_rid = self._slot_to_rid.get(slot)
+            if old_rid == rid:
+                continue
+            if old_rid is not None:
+                self._rid_to_slot.pop(old_rid, None)
+                self._clear_slot(slot)
+                self._int_counters[self._SLOT_REUSE_RESETS].add_(1)
+
+            serial = self._next_request_serial
+            self._next_request_serial += 1
+            self._rid_to_slot[rid] = slot
+            self._slot_to_rid[slot] = rid
+            self._serial_to_rid[serial] = rid
+            slot_tensor = torch.tensor([slot], dtype=torch.int64, device=self.device)
+            self._active_slots.index_fill_(0, slot_tensor, True)
+            self._request_serial_by_slot.index_fill_(0, slot_tensor, serial)
+            initial_budget = (
+                0.0
+                if self.settings.config is None
+                else self.settings.config.risk_budget
+            )
+            self._remaining_budget.index_fill_(0, slot_tensor, initial_budget)
+            self._int_counters[self._REQUESTS_INITIALIZED].add_(1)
+
+    def _clear_slot(self, slot: int) -> None:
+        if self._remaining_budget is None:
+            return
+        slot_tensor = torch.tensor([slot], dtype=torch.int64, device=self.device)
+        self._remaining_budget.index_fill_(0, slot_tensor, 0.0)
+        self._active_slots.index_fill_(0, slot_tensor, False)
+        self._request_serial_by_slot.index_fill_(0, slot_tensor, -1)
+
+    def note_request_finished(self, *, rid: str, natural_stop: bool) -> None:
+        """Clear request-owned device state on finish, cancellation, or abort."""
+
+        if not self.active:
+            return
+        slot = self._rid_to_slot.pop(rid, None)
+        if slot is None:
+            return
+        self._slot_to_rid.pop(slot, None)
+        slot_tensor = torch.tensor([slot], dtype=torch.int64, device=self.device)
+        if self.settings.mode == ASD_MODE_ENABLED:
+            self._float_counters[self._COMPLETED_REMAINING_BUDGET].add_(
+                self._remaining_budget.index_select(0, slot_tensor).sum()
+            )
+        self._int_counters[self._REQUESTS_FINISHED].add_(1)
+        if not natural_stop:
+            self._int_counters[self._REQUESTS_NON_NATURAL].add_(1)
+        self._clear_slot(slot)
+
+    def _assert_bound(self, req_pool_indices: torch.Tensor) -> None:
+        if self._active_slots is None:
+            raise RuntimeError(
+                "active ASD mode reached decode before prefill lifecycle binding"
+            )
+        active = self._active_slots.index_select(0, req_pool_indices.to(torch.int64))
+        torch._assert_async(
+            active.all(),
+            "DSpark ASD decode saw an inactive/reused request-pool slot",
+        )
+
+    def _compact_scores(
+        self,
+        *,
+        candidates: torch.Tensor,
+        target_logits: torch.Tensor,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        if candidates.ndim != 2:
+            raise ValueError("DSpark ASD candidates must be [batch, verify_width]")
+        bs, width = candidates.shape
+        if width != self.verify_num_draft_tokens:
+            raise ValueError(
+                f"expected candidate width {self.verify_num_draft_tokens}, got {width}"
+            )
+        if target_logits.ndim != 2:
+            raise ValueError("DSpark target logits must be [batch*verify_width, vocab]")
+        if target_logits.shape[0] != bs * width:
+            raise ValueError(
+                "target logits row count does not match DSpark candidate layout"
+            )
+        logits = target_logits.view(bs, width, -1)
+        top_logits, top_token_ids = logits.max(dim=-1)
+        draft_token_ids = candidates[:, 1:]
+        draft_logits = logits[:, : self.gamma].gather(
+            dim=-1, index=draft_token_ids.unsqueeze(-1)
+        )
+        return top_logits, top_token_ids, draft_logits.squeeze(-1)
+
+    def _strict_uncapped(
+        self, *, draft_token_ids: torch.Tensor, top_token_ids: torch.Tensor
+    ) -> torch.Tensor:
+        return (
+            (draft_token_ids == top_token_ids[:, : self.gamma])
+            .to(torch.int32)
+            .cumprod(dim=1)
+            .sum(dim=1)
+        )
+
+    def _max_verifiable_drafts(
+        self,
+        *,
+        bs: int,
+        device: torch.device,
+        cutoff_verify_lens: Optional[torch.Tensor],
+    ) -> torch.Tensor:
+        if cutoff_verify_lens is None:
+            return torch.full((bs,), self.gamma, dtype=torch.int32, device=device)
+        return (cutoff_verify_lens.to(device=device, dtype=torch.int32) - 1).clamp_(
+            min=0, max=self.gamma
+        )
+
+    def _record_calibration(
+        self,
+        *,
+        req_pool_indices: torch.Tensor,
+        forward_ct: int,
+        strict_uncapped: torch.Tensor,
+        max_verifiable: torch.Tensor,
+        top_logits: torch.Tensor,
+        draft_logits: torch.Tensor,
+    ) -> None:
+        bs = strict_uncapped.shape[0]
+        regrets = (
+            top_logits[:, : self.gamma].to(torch.float64)
+            - draft_logits.to(torch.float64)
+        ).clamp_min_(0.0)
+        values = torch.arange(
+            self.gamma,
+            0,
+            -1,
+            dtype=torch.float64,
+            device=regrets.device,
+        ) / float(self.gamma)
+        barrier = strict_uncapped.to(torch.int64)
+        safe_barrier = barrier.clamp(max=self.gamma - 1)
+        row = torch.arange(bs, dtype=torch.int64, device=regrets.device)
+        barrier_regret = regrets[row, safe_barrier]
+        barrier_value = values[safe_barrier]
+        valid = (
+            (barrier < self.gamma)
+            & (barrier < max_verifiable.to(torch.int64))
+            & (barrier_regret > 0.0)
+        )
+
+        ordinal = self._trace_cursor + torch.arange(
+            bs, dtype=torch.int64, device=regrets.device
+        )
+        in_capacity = ordinal < self.settings.trace_capacity
+        # Keep overflow writes on a device-only sentinel row.  Clamping to the
+        # last real row would let later proposals corrupt the final retained
+        # calibration record, while a host-side capacity branch would
+        # synchronize the decode hot path.
+        safe_ordinal = ordinal.clamp(max=self.settings.trace_capacity)
+        serial = self._request_serial_by_slot.index_select(
+            0, req_pool_indices.to(torch.int64)
+        )
+        self._trace_int[safe_ordinal, self._TRACE_VALID] = (valid & in_capacity).to(
+            torch.int64
+        )
+        self._trace_int[safe_ordinal, self._TRACE_PROPOSAL] = ordinal
+        self._trace_int[safe_ordinal, self._TRACE_SLOT] = req_pool_indices
+        self._trace_int[safe_ordinal, self._TRACE_REQUEST_SERIAL] = serial
+        self._trace_int[safe_ordinal, self._TRACE_FORWARD] = int(forward_ct)
+        self._trace_int[safe_ordinal, self._TRACE_BARRIER] = barrier
+        self._trace_float[safe_ordinal, self._TRACE_REGRET] = barrier_regret
+        self._trace_float[safe_ordinal, self._TRACE_VALUE] = barrier_value
+        self._trace_float[safe_ordinal, self._TRACE_RATIO] = (
+            barrier_regret / barrier_value
+        )
+        self._trace_cursor.add_(bs)
+        self._trace_dropped.add_((~in_capacity).to(torch.int64).sum())
+
+    def accept_or_native(
+        self,
+        *,
+        candidates: torch.Tensor,
+        target_logits: Optional[torch.Tensor],
+        cutoff_verify_lens: Optional[torch.Tensor],
+        req_pool_indices: torch.Tensor,
+        forward_ct: int,
+        all_greedy: bool,
+        native_accept: Callable[[], tuple[torch.Tensor, torch.Tensor, torch.Tensor]],
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """Choose one acceptance implementation and return its authoritative tuple."""
+
+        if not self.active:
+            return native_accept()
+        if not all_greedy:
+            raise ValueError(
+                "DSpark ASD calibration/enabled mode supports greedy verify only"
+            )
+        if target_logits is None:
+            raise RuntimeError("DSpark ASD requires target logits")
+        self._assert_bound(req_pool_indices)
+
+        top_logits, top_token_ids, draft_logits = self._compact_scores(
+            candidates=candidates,
+            target_logits=target_logits,
+        )
+        draft_token_ids = candidates[:, 1:]
+        strict_uncapped = self._strict_uncapped(
+            draft_token_ids=draft_token_ids,
+            top_token_ids=top_token_ids,
+        )
+        max_verifiable = self._max_verifiable_drafts(
+            bs=candidates.shape[0],
+            device=candidates.device,
+            cutoff_verify_lens=cutoff_verify_lens,
+        )
+
+        if self.settings.mode == ASD_MODE_CALIBRATION:
+            native_result = native_accept()
+            self._record_calibration(
+                req_pool_indices=req_pool_indices,
+                forward_ct=forward_ct,
+                strict_uncapped=strict_uncapped,
+                max_verifiable=max_verifiable,
+                top_logits=top_logits,
+                draft_logits=draft_logits,
+            )
+            return native_result
+
+        remaining_before = self._remaining_budget.index_select(
+            0, req_pool_indices.to(torch.int64)
+        )
+        decision = choose_prefix_batch(
+            draft_token_ids=draft_token_ids,
+            top_logits=top_logits[:, : self.gamma],
+            top_token_ids=top_token_ids[:, : self.gamma],
+            draft_logits=draft_logits,
+            remaining_budget=remaining_before,
+            config=self.settings.config,
+        )
+        uncapped = decision.accepted.to(torch.int32)
+        accepted = torch.minimum(uncapped, max_verifiable)
+        cap_trim_lens = uncapped - accepted
+
+        positions = torch.arange(
+            self.gamma, dtype=torch.int32, device=candidates.device
+        ).unsqueeze(0)
+        committed = positions < accepted.unsqueeze(1)
+        committed_mismatches = committed & decision.mismatched
+        charged = torch.where(
+            committed_mismatches,
+            decision.regrets,
+            torch.zeros_like(decision.regrets),
+        ).sum(dim=1)
+        relaxed = committed_mismatches.to(torch.int64).sum(dim=1)
+        remaining_after = (remaining_before.to(torch.float64) - charged).clamp_min(0.0)
+        self._remaining_budget.index_copy_(
+            0, req_pool_indices.to(torch.int64), remaining_after
+        )
+
+        row = torch.arange(
+            candidates.shape[0], dtype=torch.int64, device=candidates.device
+        )
+        bonus = top_token_ids[row, accepted.to(torch.int64)].to(torch.int64)
+
+        strict_capped = torch.minimum(
+            strict_uncapped, max_verifiable.to(strict_uncapped.dtype)
+        )
+        self._int_counters[self._PROPOSALS].add_(candidates.shape[0])
+        self._int_counters[self._DRAFTS_VERIFIABLE].add_(
+            max_verifiable.to(torch.int64).sum()
+        )
+        self._int_counters[self._STRICT_ACCEPTED].add_(
+            strict_capped.to(torch.int64).sum()
+        )
+        self._int_counters[self._ASD_ACCEPTED].add_(accepted.to(torch.int64).sum())
+        self._int_counters[self._RELAXED_MISMATCHES].add_(relaxed.sum())
+        self._int_counters[self._CAP_TRIMS].add_(cap_trim_lens.to(torch.int64).sum())
+        self._int_counters[self._BUDGET_EXHAUSTIONS].add_(
+            ((remaining_before > 0.0) & (remaining_after <= 0.0) & (charged > 0.0))
+            .to(torch.int64)
+            .sum()
+        )
+        self._float_counters[self._REGRET_CHARGED].add_(charged.sum())
+        self._accepted_by_position.add_(committed.to(torch.int64).sum(dim=0))
+        return accepted, bonus, cap_trim_lens
+
+    @staticmethod
+    def _cpu_scalar(tensor: torch.Tensor) -> int | float:
+        return tensor.detach().cpu().item()
+
+    def snapshot(self) -> dict:
+        """Bulk-copy counters/traces after an arm; never called per proposal."""
+
+        out = {
+            **self.identity(),
+            "counter_schema_version": 1,
+            "proposals": 0,
+            "draft_tokens_verifiable": 0,
+            "strict_accepted_draft_tokens": 0,
+            "asd_accepted_draft_tokens": 0,
+            "asd_accepted_draft_tokens_by_position": [0] * self.gamma,
+            "relaxed_mismatches": 0,
+            "regret_charged": 0.0,
+            "cap_trim_lens": 0,
+            "budget_exhaustion_events": 0,
+            "remaining_budget_total": 0.0,
+            "requests_initialized": 0,
+            "requests_finished": 0,
+            "requests_non_natural": 0,
+            "slot_reuse_resets": 0,
+            "active_request_states": len(self._rid_to_slot),
+            "state_leaks": len(self._rid_to_slot),
+            "remaining_budget_by_request": [],
+            "strict_rejection_trace": [],
+            "trace_rows_seen": 0,
+            "trace_rows_dropped": 0,
+        }
+        if self._int_counters is None:
+            return out
+
+        ints = self._int_counters.detach().cpu().tolist()
+        floats = self._float_counters.detach().cpu().tolist()
+        out.update(
+            proposals=int(ints[self._PROPOSALS]),
+            draft_tokens_verifiable=int(ints[self._DRAFTS_VERIFIABLE]),
+            strict_accepted_draft_tokens=int(ints[self._STRICT_ACCEPTED]),
+            asd_accepted_draft_tokens=int(ints[self._ASD_ACCEPTED]),
+            asd_accepted_draft_tokens_by_position=[
+                int(value)
+                for value in self._accepted_by_position.detach().cpu().tolist()
+            ],
+            relaxed_mismatches=int(ints[self._RELAXED_MISMATCHES]),
+            regret_charged=float(floats[self._REGRET_CHARGED]),
+            cap_trim_lens=int(ints[self._CAP_TRIMS]),
+            budget_exhaustion_events=int(ints[self._BUDGET_EXHAUSTIONS]),
+            requests_initialized=int(ints[self._REQUESTS_INITIALIZED]),
+            requests_finished=int(ints[self._REQUESTS_FINISHED]),
+            requests_non_natural=int(ints[self._REQUESTS_NON_NATURAL]),
+            slot_reuse_resets=int(ints[self._SLOT_REUSE_RESETS]),
+        )
+
+        if self.settings.mode == ASD_MODE_ENABLED:
+            active_items = sorted(self._rid_to_slot.items())
+            if active_items:
+                slots = torch.tensor(
+                    [slot for _, slot in active_items],
+                    dtype=torch.int64,
+                    device=self.device,
+                )
+                budgets = (
+                    self._remaining_budget.index_select(0, slots)
+                    .detach()
+                    .cpu()
+                    .tolist()
+                )
+                out["remaining_budget_by_request"] = [
+                    {"rid": rid, "slot": slot, "remaining_budget": float(budget)}
+                    for (rid, slot), budget in zip(active_items, budgets)
+                ]
+                active_remaining = float(sum(budgets))
+            else:
+                active_remaining = 0.0
+            out["remaining_budget_total"] = (
+                float(floats[self._COMPLETED_REMAINING_BUDGET]) + active_remaining
+            )
+
+        if self.settings.mode == ASD_MODE_CALIBRATION:
+            seen = int(self._cpu_scalar(self._trace_cursor))
+            dropped = int(self._cpu_scalar(self._trace_dropped))
+            stored = min(seen, self.settings.trace_capacity)
+            trace_int = self._trace_int[:stored].detach().cpu().tolist()
+            trace_float = self._trace_float[:stored].detach().cpu().tolist()
+            records = []
+            for ints_row, floats_row in zip(trace_int, trace_float):
+                if not ints_row[self._TRACE_VALID]:
+                    continue
+                serial = int(ints_row[self._TRACE_REQUEST_SERIAL])
+                records.append(
+                    {
+                        "proposal_ordinal": int(ints_row[self._TRACE_PROPOSAL]),
+                        "request_serial": serial,
+                        "rid": self._serial_to_rid.get(serial),
+                        "request_pool_slot": int(ints_row[self._TRACE_SLOT]),
+                        "forward_ct": int(ints_row[self._TRACE_FORWARD]),
+                        "barrier_position": int(ints_row[self._TRACE_BARRIER]),
+                        "regret": float(floats_row[self._TRACE_REGRET]),
+                        "value": float(floats_row[self._TRACE_VALUE]),
+                        "regret_per_value": float(floats_row[self._TRACE_RATIO]),
+                    }
+                )
+            out["strict_rejection_trace"] = records
+            out["trace_rows_seen"] = seen
+            out["trace_rows_dropped"] = dropped
+        return out
+
+    def clear_metrics(self) -> None:
+        """Reset arm-level evidence without resetting live request budgets."""
+
+        if self._int_counters is None:
+            return
+        self._int_counters.zero_()
+        self._float_counters.zero_()
+        self._accepted_by_position.zero_()
+        if self._trace_cursor is not None:
+            self._trace_cursor.zero_()
+            self._trace_dropped.zero_()
+            self._trace_int.zero_()
+            self._trace_float.zero_()

--- a/python/sglang/srt/speculative/dspark_components/dspark_verify.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_verify.py
@@ -115,6 +115,9 @@ class TargetVerifyExecutor:
         layout: Optional[RaggedVerifyLayout],
         prefix_lens: torch.Tensor,
         draft_tokens: torch.Tensor,
+        asd_adapter=None,
+        req_pool_indices: Optional[torch.Tensor] = None,
+        forward_ct: int = 0,
     ) -> AcceptOuts:
         """Produce the per-request accept outcome after target verify.
 
@@ -124,18 +127,38 @@ class TargetVerifyExecutor:
         override.
         """
         if folded_accept:
+            if asd_adapter is not None:
+                asd_adapter.require_unfolded_accept()
             return self.verify_epilogue.read_accept(bs)
 
-        correct_len, bonus, cap_trim_lens = accept_draft_tokens(
-            candidates=verify_ids_2d,
-            target_logits=target_logits,
-            draft_block=draft_block,
-            sampling_info=sampling_info,
-            draft_input=draft_input,
-            gamma=self.gamma,
-            verify_num_draft_tokens=self.verify_num_draft_tokens,
-            cutoff_layout=layout,
-        )
+        def native_accept():
+            return accept_draft_tokens(
+                candidates=verify_ids_2d,
+                target_logits=target_logits,
+                draft_block=draft_block,
+                sampling_info=sampling_info,
+                draft_input=draft_input,
+                gamma=self.gamma,
+                verify_num_draft_tokens=self.verify_num_draft_tokens,
+                cutoff_layout=layout,
+            )
+
+        if asd_adapter is None:
+            correct_len, bonus, cap_trim_lens = native_accept()
+        else:
+            if req_pool_indices is None:
+                raise RuntimeError(
+                    "DSpark ASD acceptance requires request-pool indices"
+                )
+            correct_len, bonus, cap_trim_lens = asd_adapter.accept_or_native(
+                candidates=verify_ids_2d,
+                target_logits=target_logits,
+                cutoff_verify_lens=(None if layout is None else layout.verify_lens),
+                req_pool_indices=req_pool_indices,
+                forward_ct=forward_ct,
+                all_greedy=(sampling_info is None or sampling_info.is_all_greedy),
+                native_accept=native_accept,
+            )
         if self._simulate_acc_len > 0:
             correct_len = self._simulated_correct_len(
                 bs=bs, dtype=correct_len.dtype, device=correct_len.device

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -38,6 +38,10 @@ from sglang.srt.speculative.draft_worker_common import (
     make_draft_block_spec_info,
     make_draft_sampler_capture_hook,
 )
+from sglang.srt.speculative.dspark_components.asd_dspark import (
+    DSparkASDAdapter,
+    DSparkASDSettings,
+)
 from sglang.srt.speculative.dspark_components.dspark_config import (
     DSV4_DRAFT_ATTENTION_BACKEND,
     draft_is_deepseek_v4,
@@ -310,6 +314,24 @@ class DSparkWorkerV2(BaseSpecWorker):
                 f"{self._simulate_acc_len}."
             )
 
+        self._asd_adapter = DSparkASDAdapter(
+            settings=DSparkASDSettings.from_environ(),
+            gamma=self.gamma,
+            verify_num_draft_tokens=self.verify_num_draft_tokens,
+            device=self.device,
+        )
+        self._asd_adapter.require_supported_runtime(
+            disable_cuda_graph=server_args.disable_cuda_graph,
+            disable_overlap_schedule=server_args.disable_overlap_schedule,
+            ragged_verify_mode=self._verify_planner.mode_value,
+            simulate_accept_length=self._simulate_acc_len,
+        )
+        if self.ps.tp_rank == 0:
+            logger.info(
+                "Initialized DSpark ASD adapter: %s",
+                self._asd_adapter.identity(),
+            )
+
         self._verify_executor = TargetVerifyExecutor(
             target_worker=self.target_worker,
             gamma=self.gamma,
@@ -450,16 +472,22 @@ class DSparkWorkerV2(BaseSpecWorker):
         self._verify_planner.set_forced_budget_frac(frac)
 
     def dump_info_records(self) -> Optional[dict]:
-        return self._observers.dump_info_records()
+        record = self._observers.dump_info_records()
+        if record is None:
+            record = {}
+        record["asd"] = self._asd_adapter.snapshot()
+        return record
 
     def clear_info_records(self) -> None:
         self._observers.clear_info_records()
+        self._asd_adapter.clear_metrics()
 
     def block_accept_estimate_log_suffix(self) -> Optional[str]:
         return self._observers.block_accept_estimate_log_suffix()
 
     def note_request_finished(self, *, rid: str, natural_stop: bool) -> None:
         self._observers.note_request_finished(rid=rid, natural_stop=natural_stop)
+        self._asd_adapter.note_request_finished(rid=rid, natural_stop=natural_stop)
 
     def forward_batch_generation(
         self,
@@ -484,6 +512,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                 )
             return self._decode_idle_result(on_publish=on_publish)
 
+        self._asd_adapter.bind_batch(batch)
         batch_output = self.target_worker.forward_batch_generation(
             batch, capture_hidden_mode=CaptureHiddenMode.FULL
         )
@@ -760,6 +789,9 @@ class DSparkWorkerV2(BaseSpecWorker):
             layout=layout,
             prefix_lens=prefix_lens,
             draft_tokens=draft_tokens,
+            asd_adapter=(self._asd_adapter if self._asd_adapter.active else None),
+            req_pool_indices=batch.req_pool_indices,
+            forward_ct=int(batch.forward_iter),
         )
         if batch.return_logprob:
             compute_spec_logprobs(

--- a/test/registered/unit/spec/test_asd_dspark_settings.py
+++ b/test/registered/unit/spec/test_asd_dspark_settings.py
@@ -1,0 +1,157 @@
+"""Unit tests for the DSpark ASD adapter settings and env parsing.
+
+Covers the environment-variable contract of DSparkASDSettings: the
+disabled-by-default arm switch, the calibration trace arm, and the
+validation rules that keep accidental misconfiguration loud. The
+optional-ASD-package degradation path is exercised only when the
+research package is not installed (the default CI environment).
+"""
+
+import unittest
+
+from sglang.srt.speculative.dspark_components.asd_dspark import (
+    _DEFAULT_TRACE_CAPACITY,
+    ASD_MODE_CALIBRATION,
+    ASD_MODE_DISABLED,
+    DSparkASDSettings,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestDisabledByDefault(CustomTestCase):
+    def test_empty_env_is_disabled(self):
+        settings = DSparkASDSettings.from_environ(environ={})
+        self.assertEqual(settings.mode, ASD_MODE_DISABLED)
+        self.assertFalse(settings.active)
+        self.assertIsNone(settings.config)
+
+    def test_enabled_zero_is_disabled(self):
+        settings = DSparkASDSettings.from_environ(environ={"ASD_ENABLED": "0"})
+        self.assertEqual(settings.mode, ASD_MODE_DISABLED)
+        self.assertFalse(settings.active)
+
+
+class TestCalibrationArm(CustomTestCase):
+    def test_trace_flag_selects_calibration(self):
+        settings = DSparkASDSettings.from_environ(
+            environ={"SGLANG_DSPARK_ASD_CALIBRATION_TRACE": "1"}
+        )
+        self.assertEqual(settings.mode, ASD_MODE_CALIBRATION)
+        self.assertTrue(settings.active)
+        self.assertEqual(settings.trace_capacity, _DEFAULT_TRACE_CAPACITY)
+
+    def test_trace_capacity_is_parsed(self):
+        settings = DSparkASDSettings.from_environ(
+            environ={
+                "SGLANG_DSPARK_ASD_CALIBRATION_TRACE": "1",
+                "SGLANG_DSPARK_ASD_TRACE_CAPACITY": "128",
+            }
+        )
+        self.assertEqual(settings.trace_capacity, 128)
+
+    def test_non_integer_capacity_raises(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(
+                environ={
+                    "SGLANG_DSPARK_ASD_CALIBRATION_TRACE": "1",
+                    "SGLANG_DSPARK_ASD_TRACE_CAPACITY": "not-a-number",
+                }
+            )
+
+    def test_trace_conflicts_with_enabled(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(
+                environ={
+                    "SGLANG_DSPARK_ASD_CALIBRATION_TRACE": "1",
+                    "ASD_ENABLED": "1",
+                }
+            )
+
+
+class TestEnabledArmValidation(CustomTestCase):
+    def test_enabled_requires_exactly_one_config_source(self):
+        # No config source at all.
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(environ={"ASD_ENABLED": "1"})
+
+        # Both sources at once.
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(
+                environ={
+                    "ASD_ENABLED": "1",
+                    "SGLANG_DSPARK_ASD_CONFIG_JSON": "{}",
+                    "SGLANG_DSPARK_ASD_CONFIG_PATH": "config.json",
+                }
+            )
+
+    def test_config_is_invalid_when_disabled(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(
+                environ={
+                    "ASD_ENABLED": "0",
+                    "SGLANG_DSPARK_ASD_CONFIG_JSON": "{}",
+                }
+            )
+
+    def test_enabled_must_be_binary(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(environ={"ASD_ENABLED": "true"})
+
+    def test_trace_flag_must_be_binary(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(
+                environ={"SGLANG_DSPARK_ASD_CALIBRATION_TRACE": "yes"}
+            )
+
+    def test_legacy_mode_env_is_rejected(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings.from_environ(
+                environ={"SGLANG_DSPARK_ASD_MODE": "enabled"}
+            )
+
+
+class TestSettingsInvariants(CustomTestCase):
+    def test_unknown_mode_is_rejected(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings(mode="bogus")
+
+    def test_enabled_mode_requires_a_config(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings(mode="enabled")
+
+    def test_config_is_invalid_outside_enabled_mode(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings(mode=ASD_MODE_DISABLED, config=object())
+
+    def test_trace_capacity_must_be_a_positive_integer(self):
+        with self.assertRaises(ValueError):
+            DSparkASDSettings(trace_capacity=0)
+        with self.assertRaises(ValueError):
+            DSparkASDSettings(trace_capacity=True)
+
+
+class TestOptionalPackageDegradation(CustomTestCase):
+    """ASD_ENABLED=1 without the research package must fail loudly, not
+    silently fall back or crash with an ImportError in the hot path."""
+
+    def test_missing_package_raises_clear_runtime_error(self):
+        from sglang.srt.speculative.dspark_components import asd_dspark
+
+        if asd_dspark.DSparkASDConfig is not None:
+            self.skipTest("ASD package installed; degradation path not exercised")
+
+        with self.assertRaises(RuntimeError) as ctx:
+            DSparkASDSettings.from_environ(
+                environ={
+                    "ASD_ENABLED": "1",
+                    "SGLANG_DSPARK_ASD_CONFIG_JSON": '{"budget": 8}',
+                }
+            )
+        self.assertIn("ASD package", str(ctx.exception))
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=3)


### PR DESCRIPTION
Integrate the Approximate Speculative Decoding (ASD) verifier-side policy into the DSpark speculative decoding path. ASD is a training-free greedy verification relaxation with token-, block-, and request-level regret budgets; B=0 or m=0 recovers strict greedy verification.

- add asd_dspark.py: DSparkASDAdapter/DSparkASDSettings bridging the engine-neutral ASD rule to DSpark's candidate/logit/slot layout; the external ASD package is an optional dependency (lazy import), so DSpark stays fully native when it is not installed
- dspark_verify.py: route acceptance through the ASD adapter at the full-vocabulary verification seam
- dspark_worker_v2.py: adapter lifecycle, per-request budget tracking, and acceptance metrics snapshot
- batch_result_processor.py: notify the draft worker on request finish
- serving_chat.py: expose scheduler-produced output token IDs in meta_info without retokenization
- add registered CPU unit tests for DSparkASDSettings env parsing, experiment-arm validation, and the missing-package degradation path

Settings use msgspec.Struct per code-style guidance.

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33300425457](https://github.com/sgl-project/sglang/actions/runs/33300425457)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33300425174](https://github.com/sgl-project/sglang/actions/runs/33300425174)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33300425472](https://github.com/sgl-project/sglang/actions/runs/33300425472)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->