### PR TITLE
perf(mtp): fuse trailing TP all-reduce with final RMSNorm

### DIFF
--- a/python/sglang/srt/layers/communicator.py
+++ b/python/sglang/srt/layers/communicator.py
@@ -809,6 +809,17 @@ class LayerCommunicator:
     def should_fuse_mlp_allreduce_with_next_layer(
         self, forward_batch: ForwardBatch
     ) -> bool:
+        return self._should_fuse_mlp_allreduce(forward_batch, final_norm_consumer=False)
+
+    # NOTE: This function will cause torch recompilation
+    def should_fuse_mlp_allreduce_with_final_norm(
+        self, forward_batch: ForwardBatch
+    ) -> bool:
+        return self._should_fuse_mlp_allreduce(forward_batch, final_norm_consumer=True)
+
+    def _should_fuse_mlp_allreduce(
+        self, forward_batch: ForwardBatch, *, final_norm_consumer: bool
+    ) -> bool:
         # When MOE_FULL is active (moe_cp allgather), fusion must be disabled because
         # the fusion path skips postprocess_layer which contains the moe_cp scatter.
         # Without scatter, hidden_states remain at MOE_FULL size while residual is at
@@ -826,6 +837,12 @@ class LayerCommunicator:
         # silently return under-reduced activations.
         parallel = get_parallel()
         if parallel.moe_ep_size > 1 and parallel.moe_tp_size > 1:
+            return False
+        # The NextN final norm consumes a plain TP all-reduce.  Do not let it
+        # absorb an EP reduction or a TP1 no-op under the same marker.
+        if final_norm_consumer and (
+            parallel.moe_ep_size != 1 or parallel.moe_tp_size <= 1
+        ):
             return False
 
         if (
@@ -861,7 +878,7 @@ class LayerCommunicator:
                     and get_exec().comm.enable_aiter_allreduce_fusion
                 )
             )
-            and (not self.is_last_layer)
+            and (self.is_last_layer == final_norm_consumer)
             and (self._context.tp_size > 1)
         )
 

--- a/python/sglang/srt/layers/layernorm.py
+++ b/python/sglang/srt/layers/layernorm.py
@@ -237,6 +237,11 @@ def _forward_with_allreduce_fusion(
                 if fused_result[0] is not None:
                     return fused_result
 
+                # Every caller reaches this helper with the producer's
+                # reduction still owed, so a backend decline must materialize it.
+                x = tensor_model_parallel_all_reduce(x)
+                return norm_module.forward(x, residual, None)
+
             # For AITER route, preserve correctness when fused path is unavailable.
             if _use_aiter and get_exec().comm.enable_aiter_allreduce_fusion:
                 x = tensor_model_parallel_all_reduce(x)

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -274,8 +274,22 @@ class DeepseekModelNextN(nn.Module):
                 )
             if not forward_batch.forward_mode.is_idle():
                 if residual is not None:
-                    hidden_states, _ = self.shared_head.norm(hidden_states, residual)
+                    if getattr(hidden_states, "_sglang_needs_allreduce_fusion", False):
+                        hidden_states, _ = (
+                            self.shared_head.norm.forward_with_allreduce_fusion(
+                                hidden_states,
+                                residual,
+                                use_attn_tp_group=False,
+                            )
+                        )
+                    else:
+                        hidden_states, _ = self.shared_head.norm(
+                            hidden_states, residual
+                        )
                 else:
+                    assert not getattr(
+                        hidden_states, "_sglang_needs_allreduce_fusion", False
+                    )
                     hidden_states = self.shared_head.norm(hidden_states)
 
                 if use_cp_v1:

--- a/python/sglang/srt/models/deepseek_v2.py
+++ b/python/sglang/srt/models/deepseek_v2.py
@@ -2519,11 +2519,18 @@ class DeepseekV2DecoderLayer(nn.Module):
             hidden_states, residual, forward_batch
         )
 
-        fuse_mlp_allreduce = (
-            self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
-                forward_batch
+        if self.is_nextn:
+            fuse_mlp_allreduce = (
+                self.layer_communicator.should_fuse_mlp_allreduce_with_final_norm(
+                    forward_batch
+                )
             )
-        )
+        else:
+            fuse_mlp_allreduce = (
+                self.layer_communicator.should_fuse_mlp_allreduce_with_next_layer(
+                    forward_batch
+                )
+            )
 
         # For DP with padding, reduce scatter can be used instead of all-reduce.
         mlp_reduce_scatter = self.layer_communicator.should_use_reduce_scatter(

--- a/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
+++ b/test/registered/unit/layers/test_layer_communicator_fusion_gate.py
@@ -11,13 +11,19 @@ from sglang.test.test_utils import CustomTestCase
 register_cpu_ci(est_time=5, suite="base-a-test-cpu")
 
 
-def _fake_communicator():
-    return types.SimpleNamespace(
+def _fake_communicator(
+    *, is_last_layer=False, mlp_mode=ScatterMode.TP_ATTN_FULL, tp_size=4
+):
+    fake = types.SimpleNamespace(
         _speculative_algo=None,
-        layer_scatter_modes=types.SimpleNamespace(mlp_mode=ScatterMode.TP_ATTN_FULL),
-        is_last_layer=False,
-        _context=types.SimpleNamespace(tp_size=4),
+        layer_scatter_modes=types.SimpleNamespace(mlp_mode=mlp_mode),
+        is_last_layer=is_last_layer,
+        _context=types.SimpleNamespace(tp_size=tp_size),
     )
+    fake._should_fuse_mlp_allreduce = types.MethodType(
+        LayerCommunicator._should_fuse_mlp_allreduce, fake
+    )
+    return fake
 
 
 class TestFuseMlpAllReduceGate(CustomTestCase):
@@ -31,24 +37,62 @@ class TestFuseMlpAllReduceGate(CustomTestCase):
     Qwen3-30B-A3B with --tp-size 4 --ep-size 2.
     """
 
-    def _should_fuse(self, *, moe_ep_size, moe_tp_size):
+    def _should_fuse(
+        self,
+        *,
+        moe_ep_size,
+        moe_tp_size,
+        is_last_layer=False,
+        final_norm_consumer=False,
+        backend_available=True,
+        input_scattered=False,
+        moe_cp_allgather=False,
+        mlp_mode=ScatterMode.TP_ATTN_FULL,
+        tp_size=4,
+    ):
         forward_batch = types.SimpleNamespace(
             input_ids=types.SimpleNamespace(shape=(8,))
         )
         with (
-            patch.object(comm, "is_enable_moe_cp_allgather", return_value=False),
-            patch.object(comm, "apply_flashinfer_allreduce_fusion", return_value=True),
+            patch.object(
+                comm,
+                "is_enable_moe_cp_allgather",
+                return_value=moe_cp_allgather,
+            ),
+            patch.object(
+                comm,
+                "apply_flashinfer_allreduce_fusion",
+                return_value=backend_available,
+            ),
             patch.object(
                 comm,
                 "get_attn_tp_context",
-                return_value=types.SimpleNamespace(input_scattered=False),
+                return_value=types.SimpleNamespace(input_scattered=input_scattered),
             ),
             get_parallel().override(
-                moe_ep_size=moe_ep_size, moe_tp_size=moe_tp_size, tp_size=4
+                moe_ep_size=moe_ep_size,
+                moe_tp_size=moe_tp_size,
+                tp_size=tp_size,
             ),
         ):
+            fake = _fake_communicator(
+                is_last_layer=is_last_layer,
+                mlp_mode=mlp_mode,
+                tp_size=tp_size,
+            )
+            if final_norm_consumer:
+                method = getattr(
+                    LayerCommunicator,
+                    "should_fuse_mlp_allreduce_with_final_norm",
+                    None,
+                )
+                self.assertIsNotNone(
+                    method,
+                    "final MTP norm needs an explicit fusion-eligibility API",
+                )
+                return method(fake, forward_batch)
             return LayerCommunicator.should_fuse_mlp_allreduce_with_next_layer(
-                _fake_communicator(), forward_batch
+                fake, forward_batch
             )
 
     def test_hybrid_ep_tp_does_not_fuse(self):
@@ -59,6 +103,43 @@ class TestFuseMlpAllReduceGate(CustomTestCase):
 
     def test_pure_ep_still_fuses(self):
         self.assertTrue(self._should_fuse(moe_ep_size=4, moe_tp_size=1))
+
+    def test_last_layer_still_does_not_claim_a_next_layer_consumer(self):
+        self.assertFalse(
+            self._should_fuse(
+                moe_ep_size=1,
+                moe_tp_size=4,
+                is_last_layer=True,
+            )
+        )
+
+    def test_final_norm_consumer_gate(self):
+        cases = {
+            "eligible_last_layer": ({}, True),
+            "middle_layer": ({"is_last_layer": False}, False),
+            "hybrid_ep_tp": ({"moe_ep_size": 2, "moe_tp_size": 2}, False),
+            "pure_ep_not_in_first_scope": (
+                {"moe_ep_size": 4, "moe_tp_size": 1},
+                False,
+            ),
+            "backend_unavailable": ({"backend_available": False}, False),
+            "tp1": ({"moe_tp_size": 1, "tp_size": 1}, False),
+            "scattered_input": ({"input_scattered": True}, False),
+            "moe_cp_allgather": ({"moe_cp_allgather": True}, False),
+            "scattered_mlp": ({"mlp_mode": ScatterMode.SCATTERED}, False),
+        }
+        defaults = {
+            "moe_ep_size": 1,
+            "moe_tp_size": 4,
+            "is_last_layer": True,
+            "final_norm_consumer": True,
+        }
+        for name, (overrides, expected) in cases.items():
+            with self.subTest(name=name):
+                self.assertEqual(
+                    self._should_fuse(**(defaults | overrides)),
+                    expected,
+                )
 
 
 if __name__ == "__main__":

--- a/test/registered/unit/layers/test_layernorm_allreduce_fallback.py
+++ b/test/registered/unit/layers/test_layernorm_allreduce_fallback.py
@@ -1,0 +1,55 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import torch
+
+from sglang.srt.layers import layernorm
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _Norm:
+    variance_epsilon = 1e-6
+
+    def forward(self, hidden_states, residual=None, post_residual_addition=None):
+        return hidden_states + residual, residual
+
+
+def test_flashinfer_runtime_decline_materializes_owned_reduction():
+    hidden_states = torch.tensor([[1.0, 2.0]])
+    residual = torch.tensor([[3.0, 4.0]])
+
+    with (
+        patch.object(layernorm, "_use_aiter", False),
+        patch.object(
+            layernorm,
+            "get_parallel",
+            return_value=SimpleNamespace(
+                attn_tp_size=2,
+                moe_ep_size=1,
+                moe_tp_size=2,
+            ),
+        ),
+        patch(
+            "sglang.srt.layers.flashinfer_comm_fusion."
+            "flashinfer_allreduce_residual_rmsnorm",
+            return_value=(None, None),
+        ),
+        patch(
+            "sglang.srt.distributed.tensor_model_parallel_all_reduce",
+            return_value=hidden_states + 10,
+        ) as all_reduce,
+    ):
+        output, output_residual = layernorm._forward_with_allreduce_fusion(
+            _Norm(),
+            hidden_states,
+            residual,
+            post_residual_addition=None,
+            weight=torch.ones(2),
+            use_attn_tp_group=False,
+        )
+
+    all_reduce.assert_called_once_with(hidden_states)
+    torch.testing.assert_close(output, torch.tensor([[14.0, 16.0]]))
+    torch.testing.assert_close(output_residual, residual)

--- a/test/registered/unit/models/test_deepseek_nextn_final_norm.py
+++ b/test/registered/unit/models/test_deepseek_nextn_final_norm.py
@@ -1,0 +1,123 @@
+from contextlib import nullcontext
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+import torch
+
+from sglang.srt.models import deepseek_nextn
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=20, suite="base-a-test-cpu")
+
+
+class _Decoder:
+    def __init__(self, *, publish_marker, return_residual=True):
+        self.publish_marker = publish_marker
+        self.return_residual = return_residual
+
+    def __call__(self, *args, **kwargs):
+        output = torch.tensor([[1.0, 2.0]])
+        if self.publish_marker:
+            output._sglang_needs_allreduce_fusion = True
+        residual = torch.tensor([[3.0, 4.0]]) if self.return_residual else None
+        return output, residual, None
+
+
+class _FinalNorm:
+    def __init__(self):
+        self.plain_calls = 0
+        self.fused_groups = []
+
+    def __call__(self, hidden_states, residual=None):
+        self.plain_calls += 1
+        if residual is None:
+            return hidden_states
+        return hidden_states + residual, residual
+
+    def forward_with_allreduce_fusion(
+        self, hidden_states, residual, *, use_attn_tp_group
+    ):
+        self.fused_groups.append(use_attn_tp_group)
+        return hidden_states + residual, residual
+
+
+class _TopKState:
+    topk_indices = None
+    should_publish = False
+
+    def update(self, topk_indices):
+        pass
+
+    def publish(self):
+        pass
+
+
+def _run(*, publish_marker, return_residual=True):
+    final_norm = _FinalNorm()
+    model = SimpleNamespace(
+        quant_config=None,
+        rot_weight=None,
+        enorm=lambda value: value,
+        hnorm=lambda value: value,
+        eh_proj=lambda value: value,
+        decoder=_Decoder(
+            publish_marker=publish_marker,
+            return_residual=return_residual,
+        ),
+        shared_head=SimpleNamespace(norm=final_norm),
+        dsa_enable_prefill_cp=False,
+        mla_enable_prefill_cp=False,
+    )
+    forward_batch = SimpleNamespace(
+        spec_info=SimpleNamespace(hidden_states=torch.tensor([[5.0, 6.0]])),
+        forward_mode=SimpleNamespace(is_idle=lambda: False),
+    )
+
+    with (
+        patch.object(deepseek_nextn, "_is_cuda", False),
+        patch.object(deepseek_nextn, "_is_npu", False),
+        patch.object(deepseek_nextn, "is_cp_v2_active", return_value=False),
+        patch.object(deepseek_nextn, "dsa_use_prefill_cp", return_value=False),
+        patch.object(deepseek_nextn, "mla_use_prefill_cp", return_value=False),
+        patch.object(
+            deepseek_nextn.IndexTopKShareState,
+            "from_mtp_carry",
+            return_value=_TopKState(),
+        ),
+        patch.object(
+            deepseek_nextn,
+            "get_global_expert_distribution_recorder",
+            return_value=SimpleNamespace(disable_this_region=nullcontext),
+        ),
+    ):
+        output = deepseek_nextn.DeepseekModelNextN.forward(
+            model,
+            input_ids=torch.tensor([1]),
+            positions=torch.tensor([0]),
+            forward_batch=forward_batch,
+            input_embeds=torch.tensor([[7.0, 8.0]]),
+        )
+
+    return output, final_norm
+
+
+def test_owned_reduction_uses_moe_group_fused_final_norm():
+    output, norm = _run(publish_marker=True)
+
+    assert norm.plain_calls == 0
+    assert norm.fused_groups == [False]
+    torch.testing.assert_close(output, torch.tensor([[4.0, 6.0]]))
+
+
+def test_unmarked_output_keeps_plain_final_norm():
+    output, norm = _run(publish_marker=False)
+
+    assert norm.plain_calls == 1
+    assert norm.fused_groups == []
+    torch.testing.assert_close(output, torch.tensor([[4.0, 6.0]]))
+
+
+def test_owned_reduction_without_residual_fails_loudly():
+    with pytest.raises(AssertionError):
+        _run(publish_marker=True, return_residual=False)


### PR DESCRIPTION
# Proposed PR: Fuse the trailing NextN TP AllReduce with final RMSNorm

## Motivation

The final DeepSeek/GLM NextN decoder layer currently materializes its post-MoE TP reduction and then executes the shared-head residual RMSNorm as a separate boundary. SGLang already fuses the same pattern between ordinary decoder layers, but deliberately excludes the last layer because there is no next decoder-layer consumer.

This change gives the NextN shared-head norm an explicit final consumer path. The producer may defer the reduction only when a strict pure-TP gate proves that the consumer can take ownership; every path must still reduce exactly once.

## Changes

- Reuse `LayerCommunicator`'s existing fusion gate through a separate final-norm consumer API.
- Permit only the last NextN layer in pure TP with TP > 1, a supported backend, full/non-scattered layout, and no incompatible DP-attention, CP, MoE-CP all-gather, A2A, or hybrid EP+TP mode.
- Publish the existing `_sglang_needs_allreduce_fusion` ownership marker from the final NextN producer and consume it in `DeepseekModelNextN.shared_head.norm` with the MoE TP group.
- Fail loudly if a marked partial result reaches the final norm without a residual.
- If the FlashInfer runtime declines after ownership has moved, materialize the owed AllReduce before the ordinary norm.

The last fallback is the same correctness issue independently identified and implemented by @b8zhong in Draft PR #34134. It is included here because the new final-norm consumer has the same ownership obligation. If maintainers prefer #34134 to land first, I can remove these five lines and rebase this PR on it.

## Correctness

On 2×H20 with the official 11.7GB `lmsys/DeepSeek-V3-0324-NextN` checkpoint:

- BF16 output allclose passed with max absolute difference `0.015625` (`rtol=atol=1e-2`).
- Baseline executed one explicit post-experts reduction per iteration; candidate executed one fused final-norm collective and zero explicit reductions. Across the measured run, 30 explicit reductions/rank became 30 fused calls/rank.
- CUDA Graph capture and replay passed with changing inputs.
- Negative gates cover TP1, pure EP, hybrid EP+TP, scattered input/MLP, unavailable backend, MoE-CP all-gather, and non-last layers.
- A mocked runtime-decline regression failed before the fallback (zero reductions) and passes after it (one explicit reduction).

Focused CPU results in the matching SGLang environment: `8 passed` plus `9 subtests`. The rebased runtime-decline test additionally passes on current main. Ruff (`F401/F821/UP037`), isort, Black, `py_compile`, and `git diff --check` pass.

## Performance

Hardware: 2×NVIDIA H20, TP2, BF16, hidden size 7168.

| Measurement | Split baseline | Fused candidate | Result |
|---|---:|---:|---:|
| AR → RMSNorm operator, 1–128 tokens | about 10–29 us | about 5–12 us | `1.77×–2.49×` |
| Real NextN batch-1 boundary | about 10 us | about 5 us | about `2.0×`, saves about 5 us |
| Real NextN core | about 3 ms | run-to-run noise dominates | no stable measurable E2E gain |

Nsight confirms that the standalone collective/norm boundary is replaced by the fused final-norm call. The boundary is only about `0.33%` of the batch-1 NextN core, so Amdahl predicts about `0.17%` whole-core gain; I therefore do not claim the noisy aggregate `1.57%` observation as a stable result or claim full-model GLM-5.2 serving improvement.

## Scope

Production diff: four files, `+49/-6`; no new kernel, CLI flag, workspace, or generic communication protocol. The full GLM-5.2 Hopper FP8 recipe requires approximately TP8/89GB per GPU, so the available 2×/4×H20 setup cannot provide a truthful full-model TTFT/ITL result. This PR reports the exact real NextN-layer path and operator/boundary evidence only.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33301037660](https://github.com/sgl-project/sglang/actions/runs/33301037660)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33301037436](https://github.com/sgl-project/sglang/actions/runs/33301037436)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33301037503](https://github.com/sgl-project/sglang/actions/runs/33301037503)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->