### PR TITLE
perf(spec): add vocab-parallel MTP local argmax

### DIFF
--- a/docs/docs/advanced_features/server_arguments.mdx
+++ b/docs/docs/advanced_features/server_arguments.mdx
@@ -1597,6 +1597,12 @@ Please consult the documentation below and [server_args.py](https://github.com/s
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: float</td>
     </tr>
         <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-draft-local-argmax`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>For high-batch greedy EAGLE/NEXTN drafting with tensor parallelism, reduce one local maximum per rank instead of gathering the full vocabulary logits.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`False`</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Type: bool</td>
+    </tr>
+        <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}>`--speculative-token-map`</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>The path of the draft model's small vocab table.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}>`None`</td>

--- a/docs/docs/advanced_features/speculative_decoding.mdx
+++ b/docs/docs/advanced_features/speculative_decoding.mdx
@@ -193,6 +193,11 @@ To enable EAGLE speculative decoding the following parameters are relevant:
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>1.0</code></td>
     </tr>
     <tr>
+      <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-draft-local-argmax</code></td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>For supported DeepSeek/GLM NextN models with greedy TP drafting, skip the full-vocabulary all-gather and reduce one local maximum per rank. This opt-in path targets high-batch workloads; incompatible configurations fall back to the ordinary logits path.</td>
+      <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>False</code></td>
+    </tr>
+    <tr>
       <td style={{padding: "9px 12px", fontWeight: 500, backgroundColor: "rgba(255,255,255,0.02)"}}><code>--speculative-attention-mode</code></td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.05)"}}>Attention mode for speculative operations (<code>prefill</code> or <code>decode</code>), affecting both target verification and draft extension.</td>
       <td style={{padding: "9px 12px", backgroundColor: "rgba(255,255,255,0.02)"}}><code>"prefill"</code></td>

--- a/python/sglang/srt/layers/logits_processor.py
+++ b/python/sglang/srt/layers/logits_processor.py
@@ -154,6 +154,53 @@ def should_apply_lm_head_quant_method(lm_head, quant_method) -> bool:
     return True
 
 
+def _vocab_parallel_argmax(
+    local_logits: torch.Tensor,
+    valid_vocab_size: int,
+    global_vocab_start: int,
+    tp_group,
+) -> torch.Tensor:
+    """Return global greedy ids without gathering every vocabulary logit.
+
+    Values and ids share one FP32 collective.  FP32 represents every integer
+    vocabulary id below 2**24 exactly, which covers the model configurations
+    admitted by the draft-model construction gate.
+    """
+    max_exact_fp32_id = 2**24 - 1
+    output_shape = local_logits.shape[:-1]
+    if valid_vocab_size:
+        local_values, local_ids = local_logits[..., :valid_vocab_size].max(dim=-1)
+        local_ids = local_ids.add(global_vocab_start)
+    else:
+        local_values = local_logits.new_full(output_shape, float("-inf"))
+        local_ids = torch.full(
+            output_shape,
+            max_exact_fp32_id,
+            dtype=torch.long,
+            device=local_logits.device,
+        )
+
+    if tp_group.world_size == 1:
+        return local_ids.unsqueeze(-1)
+
+    local_pair = torch.stack((local_values.float(), local_ids.float()), dim=-1)
+    gathered_pairs = tp_group.all_gather(local_pair, dim=-1).reshape(
+        *output_shape, tp_group.world_size, 2
+    )
+    gathered_values = gathered_pairs[..., 0]
+    gathered_ids = gathered_pairs[..., 1]
+    max_values = gathered_values.max(dim=-1, keepdim=True).values
+    return (
+        torch.where(
+            gathered_values == max_values,
+            gathered_ids,
+            max_exact_fp32_id,
+        )
+        .min(dim=-1, keepdim=True)
+        .values.long()
+    )
+
+
 # FlashInfer autotune skips the unprofiled LM-head all-gather; its
 # [batch * dp_size, vocab] output can OOM under tight DP-attention memory.
 _in_autotune_dummy_run = False
@@ -417,6 +464,17 @@ class LogitsProcessor(nn.Module):
         )
 
         self.input_logprob_processor = InputLogprobProcessor()
+
+    def _vocab_parallel_argmax(
+        self, local_logits: torch.Tensor, lm_head: VocabParallelEmbedding
+    ) -> torch.Tensor:
+        shard = lm_head.shard_indices
+        return _vocab_parallel_argmax(
+            local_logits,
+            shard.num_org_elements,
+            shard.org_vocab_start_index,
+            get_tp_group(),
+        )
 
     def forward(
         self,

--- a/python/sglang/srt/models/deepseek_nextn.py
+++ b/python/sglang/srt/models/deepseek_nextn.py
@@ -60,7 +60,7 @@ from sglang.srt.model_executor.forward_batch_info import ForwardBatch
 from sglang.srt.models.deepseek_common.utils import enable_nextn_moe_bf16_cast_to_fp8
 from sglang.srt.models.deepseek_v2 import DeepseekV2DecoderLayer, DeepseekV3ForCausalLM
 from sglang.srt.models.utils import WeightsMapper
-from sglang.srt.runtime_context import get_model, get_parallel, get_spec
+from sglang.srt.runtime_context import get_lora, get_model, get_parallel, get_spec
 from sglang.srt.utils import BumpAllocator, add_prefix, is_cuda, is_npu
 
 
@@ -96,6 +96,35 @@ logger = logging.getLogger(__name__)
 
 _is_cuda = is_cuda()
 _is_npu = is_npu()
+
+
+def _can_use_draft_local_argmax(
+    requested: bool,
+    cuda_backend: bool,
+    tp_size: int,
+    spec,
+    parallel,
+    num_added_embeddings: int,
+    lora_enabled: bool,
+    supported_lm_head: bool,
+    vocab_size: int,
+) -> bool:
+    return (
+        requested
+        and cuda_backend
+        and tp_size > 1
+        and (spec.speculative_algorithm or "").upper() in ("EAGLE", "NEXTN")
+        and spec.speculative_eagle_topk == 1
+        and not spec.speculative_use_rejection_sampling
+        and spec.speculative_token_map is None
+        and not parallel.enable_dp_attention
+        and not parallel.enable_dp_lm_head
+        and not parallel.enable_tp_lm_head_all_to_all
+        and num_added_embeddings == 0
+        and not lora_enabled
+        and supported_lm_head
+        and vocab_size < 2**24
+    )
 
 
 class DeepseekModelNextN(nn.Module):
@@ -368,7 +397,31 @@ class DeepseekV3ForCausalLMNextN(DeepseekV3ForCausalLM):
             prefix=add_prefix("model.shared_head.head", prefix),
             use_attn_tp_group=get_parallel().enable_dp_lm_head,
         )
-        self.logits_processor = LogitsProcessor(config)
+        parallel = get_parallel()
+        spec = get_spec()
+        self._draft_local_argmax_enabled = _can_use_draft_local_argmax(
+            spec.speculative_draft_local_argmax,
+            _is_cuda,
+            self.tp_size,
+            spec,
+            parallel,
+            self.lm_head.num_added_embeddings,
+            get_lora().enable_lora,
+            isinstance(self.lm_head, ParallelLMHead),
+            config.vocab_size,
+        )
+        self.logits_processor = LogitsProcessor(
+            config, skip_all_gather=self._draft_local_argmax_enabled
+        )
+
+    @property
+    def _draft_vocab_parallel_argmax_fn(self):
+        if not self._draft_local_argmax_enabled:
+            return None
+        return self._draft_vocab_parallel_argmax
+
+    def _draft_vocab_parallel_argmax(self, local_logits: torch.Tensor) -> torch.Tensor:
+        return self.logits_processor._vocab_parallel_argmax(local_logits, self.lm_head)
 
     @torch.no_grad()
     def forward(

--- a/python/sglang/srt/server_args.py
+++ b/python/sglang/srt/server_args.py
@@ -2149,6 +2149,12 @@ class ServerArgs:
         "Use rejection sampling for speculative decoding (requires topk=1).",
         NS("spec"),
     ] = False
+    speculative_draft_local_argmax: A[
+        bool,
+        "For greedy EAGLE/NEXTN drafting with tensor parallelism, reduce one "
+        "local maximum per rank instead of gathering the full vocabulary logits.",
+        NS("spec"),
+    ] = False
     speculative_token_map: A[
         Optional[str], "The path of the draft model's small vocab table.", NS("spec")
     ] = None

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -185,6 +185,9 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         # Alias for better readability
         self.draft_runner = self.draft_worker.model_runner
+        self._draft_vocab_parallel_argmax = getattr(
+            self.draft_runner.model, "_draft_vocab_parallel_argmax_fn", None
+        )
         self._init_dsa_index_share_state()
         # Eager draft-extend seed buffer (graph paths use their own static ones).
         self.dsa_extend_topk_buf: Optional[torch.Tensor] = None
@@ -194,6 +197,21 @@ class EagleDraftWorker(EagleDraftWorkerBase):
         self.tree_mask_mode = default_tree_mask_mode()
 
         self.plan_stream, self.plan_stream_ctx = get_plan_stream(self.device)
+
+    def _local_argmax_proposal(
+        self,
+        local_logits: torch.Tensor,
+        positions: Optional[torch.Tensor] = None,
+        token_buffer: Optional[torch.Tensor] = None,
+        token_column: int = 0,
+    ):
+        topk_index = self._draft_vocab_parallel_argmax(local_logits)
+        topk_p = torch.ones_like(topk_index, dtype=torch.float32)
+        if positions is not None:
+            positions.add_(1)
+        if token_buffer is not None:
+            token_buffer[:, token_column].copy_(topk_index.flatten())
+        return topk_p, topk_index
 
     def alloc_memory_pool(
         self,
@@ -684,6 +702,13 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                     )
                     draft_probs_list.append(probs)
                     forward_batch.positions.add_(1)
+                elif self._draft_vocab_parallel_argmax is not None:
+                    topk_p, topk_index = self._local_argmax_proposal(
+                        logits_output.next_token_logits,
+                        forward_batch.positions,
+                        draft_tokens_topk1,
+                        i + 1,
+                    )
                 elif self.topk == 1 and not _is_hip:
                     if _is_cuda:
                         topk_p, topk_index = draft_topk1_postprocess(
@@ -706,11 +731,16 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                     )
                     topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
                     forward_batch.positions.add_(1)
+                output_vocab_size = (
+                    self.draft_runner.model.config.vocab_size
+                    if self._draft_vocab_parallel_argmax is not None
+                    else logits_output.next_token_logits.shape[-1]
+                )
                 maybe_detect_oob(
                     topk_index,
                     0,
-                    logits_output.next_token_logits.shape[-1],
-                    f"draft_forward step {i}: topk_index OOB vs vocab_size={logits_output.next_token_logits.shape[-1]}",
+                    output_vocab_size,
+                    f"draft_forward step {i}: topk_index OOB vs vocab_size={output_vocab_size}",
                 )
                 if self.hot_token_id is not None:
                     topk_index = self.hot_token_id[topk_index]
@@ -871,15 +901,21 @@ class EagleDraftWorker(EagleDraftWorkerBase):
 
         # Assemble the next-iter draft spec_info from the extend output.
         use_rejection_sampling = get_spec().speculative_use_rejection_sampling
-        probs = renorm_draft_probs(
-            logits_output.next_token_logits,
-            batch.sampling_info,
-            use_rejection_sampling,
-        )
-        if use_rejection_sampling:
-            topk_p, topk_index = fast_sample(probs, num_samples=1)
+        if self._draft_vocab_parallel_argmax is not None:
+            probs = None
+            topk_p, topk_index = self._local_argmax_proposal(
+                logits_output.next_token_logits
+            )
         else:
-            topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
+            probs = renorm_draft_probs(
+                logits_output.next_token_logits,
+                batch.sampling_info,
+                use_rejection_sampling,
+            )
+            if use_rejection_sampling:
+                topk_p, topk_index = fast_sample(probs, num_samples=1)
+            else:
+                topk_p, topk_index = fast_topk(probs, self.topk, dim=-1)
         return EagleDraftInput(
             topk_p=topk_p,
             topk_index=topk_index,
@@ -1021,6 +1057,11 @@ class EagleDraftWorker(EagleDraftWorkerBase):
                 draft_logits_output.next_token_logits,
                 batch.sampling_info.temperatures,
             )
+        elif self._draft_vocab_parallel_argmax is not None:
+            ret_topk_p, ret_topk_index = self._local_argmax_proposal(
+                draft_logits_output.next_token_logits
+            )
+            ret_draft_probs = None
         elif self.topk == 1 and not _is_hip:
             # Gated to CUDA: see #26358 — ROCm's argmax tie-break corrupts
             # MTP draft selection on FP8 logits.

--- a/test/registered/unit/layers/test_logits_processor_local_argmax.py
+++ b/test/registered/unit/layers/test_logits_processor_local_argmax.py
@@ -1,0 +1,179 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from sglang.srt.layers.logits_processor import _vocab_parallel_argmax
+from sglang.srt.models.deepseek_nextn import _can_use_draft_local_argmax
+from sglang.srt.server_args import ServerArgs
+from sglang.srt.speculative.eagle_worker_v2 import EagleDraftWorker
+from sglang.test.ci.ci_register import register_cpu_ci
+
+register_cpu_ci(est_time=10, suite="base-a-test-cpu")
+
+
+class _FakeGroup:
+    def __init__(self, gathered_values=None, gathered_ids=None):
+        self.world_size = 1 if gathered_values is None else gathered_values.shape[-1]
+        self.calls = []
+        self._output = (
+            None
+            if gathered_values is None
+            else torch.stack(
+                (gathered_values.float(), gathered_ids.float()), dim=-1
+            ).flatten(-2)
+        )
+
+    def all_gather(self, value, dim=-1):
+        self.calls.append((value.clone(), dim))
+        assert self._output.device == value.device
+        assert self._output.dtype == value.dtype
+        return self._output
+
+
+def _gate_inputs(**overrides):
+    values = {
+        "requested": True,
+        "cuda_backend": True,
+        "tp_size": 2,
+        "algorithm": "EAGLE",
+        "topk": 1,
+        "rejection": False,
+        "token_map": None,
+        "dp_attention": False,
+        "dp_lm_head": False,
+        "tp_lm_head_all_to_all": False,
+        "added_vocab": 0,
+        "lora_enabled": False,
+        "supported_lm_head": True,
+        "vocab_size": 151936,
+    }
+    values.update(overrides)
+    spec = SimpleNamespace(
+        speculative_algorithm=values["algorithm"],
+        speculative_eagle_topk=values["topk"],
+        speculative_use_rejection_sampling=values["rejection"],
+        speculative_token_map=values["token_map"],
+    )
+    parallel = SimpleNamespace(
+        enable_dp_attention=values["dp_attention"],
+        enable_dp_lm_head=values["dp_lm_head"],
+        enable_tp_lm_head_all_to_all=values["tp_lm_head_all_to_all"],
+    )
+    return values, spec, parallel
+
+
+def _can_use(**overrides):
+    values, spec, parallel = _gate_inputs(**overrides)
+    return _can_use_draft_local_argmax(
+        values["requested"],
+        values["cuda_backend"],
+        values["tp_size"],
+        spec,
+        parallel,
+        values["added_vocab"],
+        values["lora_enabled"],
+        values["supported_lm_head"],
+        values["vocab_size"],
+    )
+
+
+def _tp2_candidates(shard0, shard1):
+    values = torch.stack((shard0.max(-1).values, shard1.max(-1).values), dim=-1)
+    ids = torch.stack(
+        (shard0.argmax(-1), shard1.argmax(-1).add(shard0.shape[-1])), dim=-1
+    )
+    return values, ids
+
+
+def test_vocab_parallel_argmax_excludes_padding_and_applies_global_offset():
+    logits = torch.tensor([[1.0, 3.0, 100.0]])
+    actual = _vocab_parallel_argmax(logits, 2, 8, _FakeGroup())
+    torch.testing.assert_close(actual, torch.tensor([[9]]))
+
+
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_vocab_parallel_argmax_matches_full_vocab_and_first_max(dtype):
+    shard0 = torch.tensor([[5.0, 1.0], [2.0, 8.0]], dtype=dtype)
+    shard1 = torch.tensor([[5.0, 0.0], [9.0, 1.0]], dtype=dtype)
+    values, ids = _tp2_candidates(shard0, shard1)
+
+    actual = _vocab_parallel_argmax(shard1, 2, 2, _FakeGroup(values, ids))
+    expected = torch.cat((shard0, shard1), dim=-1).argmax(-1, keepdim=True)
+    torch.testing.assert_close(actual, expected)
+
+
+def test_vocab_parallel_argmax_matches_random_tp2_full_vocab():
+    generator = torch.Generator().manual_seed(17)
+    shard0 = torch.randn(32, 8, generator=generator)
+    shard1 = torch.randn(32, 8, generator=generator)
+    values, ids = _tp2_candidates(shard0, shard1)
+    group = _FakeGroup(values, ids)
+
+    actual = _vocab_parallel_argmax(shard1, 8, 8, group)
+    expected = torch.cat((shard0, shard1), dim=-1).argmax(-1, keepdim=True)
+
+    torch.testing.assert_close(actual, expected)
+    assert len(group.calls) == 1
+    assert group.calls[0][0].shape == (32, 2)
+    assert group.calls[0][1] == -1
+
+
+def test_vocab_parallel_argmax_empty_shard_cannot_win():
+    logits = torch.empty((2, 0))
+    gathered_values = torch.tensor([[3.0, float("-inf")], [4.0, float("-inf")]])
+    gathered_ids = torch.tensor([[1, 2**24 - 1], [2, 2**24 - 1]])
+    actual = _vocab_parallel_argmax(
+        logits, 0, 8, _FakeGroup(gathered_values, gathered_ids)
+    )
+    torch.testing.assert_close(actual, torch.tensor([[1], [2]]))
+
+
+@pytest.mark.parametrize(
+    "override",
+    [
+        {"requested": False},
+        {"cuda_backend": False},
+        {"tp_size": 1},
+        {"algorithm": None},
+        {"algorithm": "NGRAM"},
+        {"topk": 2},
+        {"rejection": True},
+        {"token_map": "token-map.json"},
+        {"dp_attention": True},
+        {"dp_lm_head": True},
+        {"tp_lm_head_all_to_all": True},
+        {"added_vocab": 1},
+        {"lora_enabled": True},
+        {"supported_lm_head": False},
+        {"vocab_size": 2**24},
+    ],
+)
+def test_local_argmax_gate_fails_closed(override):
+    assert not _can_use(**override)
+
+
+@pytest.mark.parametrize("algorithm", ["EAGLE", "eagle", "NEXTN", "nextn"])
+def test_local_argmax_gate_accepts_supported_greedy_tp_path(algorithm):
+    assert _can_use(algorithm=algorithm)
+
+
+def test_local_argmax_proposal_preserves_chain_bookkeeping():
+    expected_ids = torch.tensor([[3], [7]])
+    worker = object.__new__(EagleDraftWorker)
+    worker._draft_vocab_parallel_argmax = lambda _: expected_ids
+    positions = torch.tensor([11, 19])
+    token_buffer = torch.zeros((2, 3), dtype=torch.long)
+
+    topk_p, topk_index = worker._local_argmax_proposal(
+        torch.empty((2, 4)), positions, token_buffer, 2
+    )
+
+    torch.testing.assert_close(topk_index, expected_ids)
+    torch.testing.assert_close(topk_p, torch.ones((2, 1)))
+    torch.testing.assert_close(positions, torch.tensor([12, 20]))
+    torch.testing.assert_close(token_buffer[:, 2], expected_ids.flatten())
+
+
+def test_local_argmax_is_explicitly_disabled_by_default():
+    assert ServerArgs.speculative_draft_local_argmax is False


### PR DESCRIPTION
## Motivation

DeepSeek/GLM NextN draft models use a tensor-parallel LM head. Today the greedy
`topk=1` path first all-gathers every rank's local vocabulary logits and only
then computes argmax. For this narrow mode, the worker only needs one global
token id, so communicating the full vocabulary is unnecessary.

This PR adds an **opt-in, high-batch fast path** that reduces one local maximum
candidate per rank instead. It remains disabled by default because the packed
collective has a roughly 45--48 us fixed cost on H20 and regresses small row
counts.

## What changes

- Compute each rank's local `(max_logit, global_token_id)` after excluding
  vocabulary padding.
- Pack value and id into one FP32 all-gather. Token ids are exact because the
  path is gated to `vocab_size < 2**24`.
- Select the maximum value and, on equal values, the smallest global token id,
  matching full-vocabulary `torch.argmax` tie-breaking.
- Expose the capability from `DeepseekV3ForCausalLMNextN` and consume it in all
  three proposal sites: draft-decode, prefill seed, and draft-extend.
- Add `--speculative-draft-local-argmax`, disabled by default.
- Fail closed for TP1, non-CUDA backends, `topk != 1`, rejection sampling,
  token maps, DP attention/LM-head modes, TP LM-head all-to-all, added
  vocabulary, LoRA, unsupported heads, and oversized vocabularies.

## Runtime flow

```mermaid
flowchart TD
    A["EagleDraftWorker proposal phase"] --> B["DeepseekV3ForCausalLMNextN.forward"]
    B --> C["ParallelLMHead produces local-vocab logits"]
    C --> D{"opt-in eligibility gate"}
    D -->|"disabled or unsupported"| E["existing full-vocab AllGather"]
    E --> F["existing top-1 postprocess"]
    D -->|"greedy TP fast path"| G["local max and global token id"]
    G --> H["one packed FP32 candidate AllGather"]
    H --> I["deterministic global max with first-id tie-break"]
    F --> J["draft token and existing bookkeeping"]
    I --> J
    class G,H,I changed;
    classDef changed stroke-dasharray:5 5,stroke-width:2px;
```

The model decides at construction time whether it may skip the full-logits
gather. The worker then uses the same capability in every place that consumes
the draft logits. Unsupported configurations retain the existing full-logits
path.

## Correctness and validation

GPU/runtime validation was collected on
`3e61fa357e8cf82244d305f1e25f6e7886ca924b`. The current PR head
`939ffe8240f63e55c9b993521e731edb80284600` differs only by repository-required
Black formatting and `register_cpu_ci` metadata; the runtime behavior is
unchanged.

- Focused suite: **27 passed** in a compatible SGLang environment.
- TP2 full-vocabulary parity for FP16/BF16/FP32, including cross-rank ties,
  padded and empty shards, shard offsets, and random inputs.
- Exactly one packed collective per proposal.
- Draft-decode, prefill-seed, and draft-extend bookkeeping coverage.
- Production CUDA Graph capture/replay parity and stable tensor shapes.
- Fail-closed matrix for every unsupported mode listed above.
- Fresh pre-submission checks: `compileall`, Ruff `F401/F821/UP037`, and
  `git diff --check` pass.

The local laptop's PyTorch 2.4.1 cannot collect current SGLang because it lacks
`torch.distributed._symmetric_memory`; the 27-test result above is from the same
source SHA on the H20 SGLang environment.

## H20 performance

Environment: 2 x H20 96 GB, CUDA 13, BF16 logits, vocabulary 151,552, CUDA
Graph steady state, 20 warmups, 100 operations per repeat, 10 interleaved A/B
repeats. Reported latency is the median of the slowest TP rank.

| Rows | Full-vocab baseline | Packed candidate | Speedup |
|---:|---:|---:|---:|
| 1 | 15.072 us | 43.472 us | 0.347x |
| 8 | 23.371 us | 44.977 us | 0.520x |
| 16 | 34.080 us | 44.720 us | 0.762x |
| 32 | 55.258 us | 45.074 us | **1.226x** |
| 64 | 93.586 us | 45.628 us | **2.051x** |
| 128 | 185.442 us | 48.470 us | **3.826x** |

At 128 rows, each rank's logical receive payload falls from 19,398,656 bytes
to 1,024 bytes (**18,944x smaller**). Nsight Systems confirms that the fast
path replaces the full-vocabulary gather/argmax boundary with the packed
candidate collective.

These are TP operator results, not full GLM-5.2 serving results. The PR does not
claim an end-to-end throughput gain, and the feature remains off by default
until representative production workloads justify a default heuristic.

## Relationship to nearby work

- #26235 skips full-vocabulary softmax after logits have already been gathered.
- #30947 fuses the existing top-1 postprocess on full logits.
- Open #31465 extends that postprocess to draft-extend selected rows.

This PR changes the earlier LM-head communication boundary: it prevents the
full-vocabulary TP gather in the first place. It reuses the existing worker
bookkeeping and does not replace the postprocess kernels in those PRs.

## Review focus

I would especially appreciate feedback on whether the construction-time
capability contract is the right integration boundary, and whether maintainers
prefer to keep this as an explicit experimental flag or add a backend-specific
high-batch dispatch heuristic later.
