### PR TITLE
Fix Kitchen INT8 CPU staging with layerwise offload

### DIFF
--- a/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
+++ b/python/sglang/multimodal_gen/runtime/loader/component_loaders/transformer_loader.py
@@ -5,12 +5,14 @@ from contextlib import nullcontext
 from typing import Any
 
 import torch
-
 from sglang.multimodal_gen.runtime.distributed import get_local_torch_device
 from sglang.multimodal_gen.runtime.layers.attention.selector import (
     component_attn_backend_context_manager,
     get_component_forced_attn_backend,
     get_global_forced_attn_backend,
+)
+from sglang.multimodal_gen.runtime.layers.quantization.configs.kitchen_int8_config import (
+    KitchenInt8Config,
 )
 from sglang.multimodal_gen.runtime.loader.component_loaders.component_loader import (
     ComponentLoader,
@@ -60,6 +62,16 @@ def _resolve_checkpoint_load_device(
     ):
         return torch.device("cpu")
     return runtime_device
+
+
+def _can_stage_online_kitchen_int8_on_cpu(
+    *, component_starts_on_cpu: bool, runtime_quant_config: object | None
+) -> bool:
+    return bool(
+        component_starts_on_cpu
+        and isinstance(runtime_quant_config, KitchenInt8Config)
+        and not runtime_quant_config.is_checkpoint_int8_serialized
+    )
 
 
 def _minimax_h3_adaln_cache_key_filter(name: str) -> bool:
@@ -395,6 +407,14 @@ class TransformerLoader(ComponentLoader):
             )
 
         local_torch_device = get_local_torch_device()
+        # Online kitchen_int8 already round-trips one layer at a time through CUDA
+        # in process_weights_after_loading(). Keep the BF16 source model on CPU
+        # when layerwise offload starts the component there; moving the complete
+        # model to CUDA first defeats that bounded-memory implementation.
+        online_kitchen_int8_cpu_staging = _can_stage_online_kitchen_int8_on_cpu(
+            component_starts_on_cpu=component_starts_on_cpu,
+            runtime_quant_config=runtime_quant_config,
+        )
         checkpoint_load_device = (
             torch.device("cpu")
             if cpu_offload_flag
@@ -403,7 +423,8 @@ class TransformerLoader(ComponentLoader):
                 component_starts_on_cpu=component_starts_on_cpu,
                 runtime_quant_config=quant_spec.runtime_quant_config,
                 quantized_cpu_load_supported=(
-                    quant_spec.gguf_file is not None
+                    online_kitchen_int8_cpu_staging
+                    or quant_spec.gguf_file is not None
                     or quant_spec.is_serialized_kitchen_int8
                     or quant_spec.is_serialized_kitchen_w4a8
                 ),
@@ -418,7 +439,10 @@ class TransformerLoader(ComponentLoader):
             )
         weight_load_plan = WeightLoadPlan.for_component(
             checkpoint_load_device=checkpoint_load_device,
-            needs_device_weight_postprocess=quant_spec.needs_device_weight_postprocess,
+            needs_device_weight_postprocess=(
+                quant_spec.needs_device_weight_postprocess
+                and not online_kitchen_int8_cpu_staging
+            ),
             component_starts_on_cpu=component_starts_on_cpu,
             load_full_state_dict_on_device=direct_gpu_weight_loading,
             mps_layerwise_cpu_staging=bool(

--- a/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_quant.py
@@ -85,6 +85,7 @@ from sglang.multimodal_gen.runtime.layers.quantization.mxfp8 import MXFP8Config
 from sglang.multimodal_gen.runtime.loader.component_loaders import transformer_loader
 from sglang.multimodal_gen.runtime.loader.component_loaders.transformer_loader import (
     TransformerLoader,
+    _can_stage_online_kitchen_int8_on_cpu,
     _default_quantized_attention_backend,
     _resolve_checkpoint_load_device,
     _warn_if_expected_param_dtype_missing,
@@ -831,6 +832,30 @@ class TestTransformerQuantHelpers(unittest.TestCase):
         )
 
         self.assertTrue(plan.load_full_state_dict_on_device)
+
+    def test_online_kitchen_int8_stages_on_cpu_for_offloaded_component(self):
+        self.assertTrue(
+            _can_stage_online_kitchen_int8_on_cpu(
+                component_starts_on_cpu=True,
+                runtime_quant_config=KitchenInt8Config(),
+            )
+        )
+
+    def test_online_kitchen_int8_stays_on_device_for_resident_component(self):
+        self.assertFalse(
+            _can_stage_online_kitchen_int8_on_cpu(
+                component_starts_on_cpu=False,
+                runtime_quant_config=KitchenInt8Config(),
+            )
+        )
+
+    def test_serialized_kitchen_int8_does_not_use_online_cpu_staging(self):
+        self.assertFalse(
+            _can_stage_online_kitchen_int8_on_cpu(
+                component_starts_on_cpu=True,
+                runtime_quant_config=KitchenInt8Config(layer_markers={}),
+            )
+        )
 
     def test_unquantized_cpu_offload_loads_checkpoint_on_cpu(self):
         device = _resolve_checkpoint_load_device(


### PR DESCRIPTION
## Motivation

Online `kitchen_int8` already quantizes one layer at a time by moving each BF16 weight CUDA -> quantize -> home device. However, when layerwise offload starts the transformer on CPU, the generic load plan still chooses CUDA for the checkpoint and defers CPU placement until all postprocessing finishes.

That materializes the complete online-quantized MiniMax-H3 DiT on GPU before layerwise offload is configured. The documented 24 GB recipe works, but a 15.44 GiB RTX 5080 reached 15.39 GiB and failed while allocating the next 294 MiB tensor.

## Modifications

- recognize non-serialized online `KitchenInt8Config` as safe for CPU checkpoint staging when the component starts on CPU
- skip the generic whole-model device postprocess move in that case; `KitchenInt8LinearMethod.process_weights_after_loading()` keeps doing its existing per-layer CUDA round trip
- preserve the existing device path for resident transformers and serialized Kitchen INT8
- add focused tests for all three decisions

## Accuracy Tests

No quantization math or model forward code changes. The same Kitchen INT8 per-layer postprocessing runs; only the BF16 source weight's home device changes from CUDA to CPU for an already-offloaded component.

Focused unit tests:

```text
5 passed, 55 deselected
```

## Speed Tests and Profiling

This path trades model load speed for bounded peak VRAM only when layerwise offload already requests CPU residency. On MiniMax-H3 / RTX 5080 15.44 GiB, the patched loader completed online quantization of 209 linear layers (37.38 GiB BF16 -> 18.69 GiB INT8), loaded the full pipeline, and entered denoising. The prior path consistently OOMed during transformer loading.

## Checklist

- [x] Format code according to project style (`ruff` import formatting; `git diff --check`)
- [x] Add focused unit tests
- [ ] Documentation update is not needed; this fixes the existing documented layerwise behavior
- [x] Provide accuracy/speed impact above
- [x] Follow SGLang code style guidance

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33301350061](https://github.com/sgl-project/sglang/actions/runs/33301350061)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33301349980](https://github.com/sgl-project/sglang/actions/runs/33301349980)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33301350101](https://github.com/sgl-project/sglang/actions/runs/33301350101)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->