### PR TITLE
fix(qsa): support EAGLE draft-extend row bounds

### DIFF
--- a/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
+++ b/python/sglang/srt/layers/attention/qwen_sparse_attn_backend.py
@@ -287,7 +287,10 @@ class QwenSparseAttnBackend(AttentionBackend):
             )
             return max(1, int(sequence_lengths.max()))
         spec_info = forward_batch.spec_info
-        draft_window = int(spec_info.draft_token_num) if spec_info is not None else 0
+        # This is the canonical row width for both target verification and
+        # draft-extend. EagleVerifyInput initializes it from draft_token_num;
+        # EagleDraftExtendInput carries it directly.
+        draft_window = int(spec_info.num_tokens_per_req) if spec_info is not None else 0
         return max(1, int(seq_lens_cpu.max()) + draft_window)
 
     @staticmethod

--- a/test/registered/kernels/test_qsa.py
+++ b/test/registered/kernels/test_qsa.py
@@ -31,6 +31,7 @@ from sglang.srt.layers.attention.qwen_sparse_attn_backend import (
     QwenSparseMultiStepDraftBackend,
 )
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
+from sglang.srt.speculative.eagle_info import EagleDraftExtendInput
 from sglang.test.ci.ci_register import register_cuda_ci
 
 register_cuda_ci(est_time=60, stage="base-b-kernel-unit", runner_config="1-gpu-large")
@@ -763,6 +764,22 @@ def test_qsa_cuda_graph_target_verify_ignores_capture_bucket_requests():
     assert row_lengths.tolist() == [10, 11, 12, 13, 1, 1, 1, 1]
     assert row_req_pool_indices.tolist() == [3] * 8
     assert row_prefix_lengths.tolist() == [9, 9, 9, 9, 0, 0, 0, 0]
+
+
+def test_qsa_speculative_row_bound_supports_eagle_draft_extend_input():
+    """Draft-extend warmup must not read verify-only metadata."""
+
+    forward_batch = SimpleNamespace(
+        seq_lens_cpu=torch.tensor([11, 21], dtype=torch.int32),
+        spec_info=EagleDraftExtendInput(num_tokens_per_req=4),
+    )
+
+    max_row_length = QwenSparseAttnBackend._speculative_max_row_length(
+        forward_batch,
+        torch.tensor([11, 21], dtype=torch.int32),
+    )
+
+    assert max_row_length == 25
 
 
 def test_qsa_target_verify_rejects_branching_speculation():


### PR DESCRIPTION
## Summary

- use the canonical `num_tokens_per_req` row width for both EAGLE target verification and draft-extend
- keep strict field access instead of a defensive `getattr` fallback
- add a regression test using a real `EagleDraftExtendInput`

## Problem

`QwenSparseAttnBackend._speculative_max_row_length` reads `spec_info.draft_token_num` unconditionally. `EagleVerifyInput` initializes its canonical `num_tokens_per_req` from `draft_token_num`, while the following `EagleDraftExtendInput` carries `num_tokens_per_req` directly and has no `draft_token_num` field.

Qwen3.8-Flash-Next QSA + synchronous NEXTN therefore fails during warmup before serving a request when draft-extend reaches this row-bound calculation.

## Change

Use `spec_info.num_tokens_per_req` directly. This preserves target-verify sizing because `EagleVerifyInput.__post_init__` sets that field from `draft_token_num`, and it supports the draft-extend input without phase-specific reflection.

The regression test constructs `EagleDraftExtendInput(num_tokens_per_req=4)` and verifies that request lengths `[11, 21]` produce a maximum row length of `25`. The pre-fix implementation raises `AttributeError` on this input.

## Runtime validation

Validated on 2x GB10 (TP2), `RadixArk/Qwen3.8-Flash-Next-NVFP4`, NEXTN 3/1/4, eager execution, FP32 Mamba state, and overlap disabled.

Before the change, warmup exited on the missing `draft_token_num` attribute. After the change, the service passed text, tool, vision, reasoning, non-looping output, 25K marker retrieval, and bounded concurrency checks. A 16,384-token continuous generation completed, followed by a successful short request, with both ranks at zero restarts.

Reproduction notes and the sanitized deployment matrix are available at https://github.com/hellojiaru/qwen38-flash-next-dual-gb10.

## Test status

- Python syntax for the changed files passes locally.
- The public companion repository runs harness unit tests, shell syntax/lint, immutable-image checks, and guarded patch application in CI.
- The focused upstream pytest is added here but has not yet executed in SGLang's Linux test matrix because this PR is stacked on the open `qwen4-main-squashed` support branch and the maintenance gate currently skips the relevant jobs.

This PR does not claim validation on current `main`; the target QSA implementation currently lives in the Qwen3.8 support branch.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #34829366855](https://github.com/sgl-project/sglang/actions/runs/34829366855)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #34829366658](https://github.com/sgl-project/sglang/actions/runs/34829366658)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 10): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #34829366861](https://github.com/sgl-project/sglang/actions/runs/34829366861)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->
