### PR TITLE
Fix AITER DSA output allocation for FP8 queries

### DIFF
--- a/python/sglang/srt/layers/attention/dsa_backend.py
+++ b/python/sglang/srt/layers/attention/dsa_backend.py
@@ -160,6 +160,16 @@ else:
     )
 
 
+def _new_aiter_mla_output(q: torch.Tensor, shape: tuple[int, ...]) -> torch.Tensor:
+    """Allocate the output tensor required by AITER MLA kernels.
+
+    AITER MLA writes BF16 output even when the query is FP8. Deriving the
+    output dtype from ``q`` would under-allocate the destination by one byte
+    per element and let the kernel write past the end of the buffer.
+    """
+    return torch.empty(shape, dtype=torch.bfloat16, device=q.device)
+
+
 def _to_2d_context_lens(seqlens_32: torch.Tensor, batch_size: int) -> torch.Tensor:
     # Always normalize to (N_total, 1) layout, to avoid deadlock at deep_gemm.fp8_paged_mqa_logits
     if seqlens_32.dim() == 2:
@@ -2950,20 +2960,23 @@ class DeepseekSparseAttnBackend(
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
 
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((q.shape[0], layer.tp_q_head_num * layer.v_head_dim))
+            o = _new_aiter_mla_output(
+                q, (q.shape[0], layer.tp_q_head_num * layer.v_head_dim)
+            )
         else:
-            o = torch.empty_like(q)
+            o = _new_aiter_mla_output(q, q.shape)
 
         if self.need_pad_heads:
             q_kernel = q.view(
                 -1, layer.tp_q_head_num, layer.head_dim
             ).repeat_interleave(self.head_repeat_factor, dim=1)
-            o_kernel = q.new_empty(
+            o_kernel = _new_aiter_mla_output(
+                q,
                 (
                     q.shape[0],
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)
@@ -3028,20 +3041,23 @@ class DeepseekSparseAttnBackend(
         q = q_all.reshape(-1, layer.tp_q_head_num * layer.head_dim)
 
         if layer.head_dim != layer.v_head_dim:
-            o = q.new_empty((num_tokens, layer.tp_q_head_num * layer.v_head_dim))
+            o = _new_aiter_mla_output(
+                q, (num_tokens, layer.tp_q_head_num * layer.v_head_dim)
+            )
         else:
-            o = torch.empty_like(q)
+            o = _new_aiter_mla_output(q, q.shape)
 
         if self.need_pad_heads:
             q_kernel = q.view(
                 -1, layer.tp_q_head_num, layer.head_dim
             ).repeat_interleave(self.head_repeat_factor, dim=1)
-            o_kernel = q.new_empty(
+            o_kernel = _new_aiter_mla_output(
+                q,
                 (
                     num_tokens,
                     layer.tp_q_head_num * self.head_repeat_factor,
                     layer.v_head_dim,
-                )
+                ),
             )
         else:
             q_kernel = q.view(-1, layer.tp_q_head_num, layer.head_dim)

--- a/test/registered/attention/unittests/dsa/test_dsa.py
+++ b/test/registered/attention/unittests/dsa/test_dsa.py
@@ -2,6 +2,7 @@ import unittest
 
 import torch
 
+from sglang.srt.layers.attention.dsa_backend import _new_aiter_mla_output
 from sglang.srt.model_executor.forward_batch_info import ForwardMode
 from sglang.test.ci.ci_register import register_cuda_ci
 from sglang.test.kits.attention_unittest.attention_methods.dsa_attention import (
@@ -38,6 +39,15 @@ register_cuda_ci(est_time=25, stage="base-b", runner_config="1-gpu-large")
 class TestDSAAttentionBackendCorrectness(CustomTestCase):
     CASES = make_dsa_dense_fallback_cases("dsa")
     SPARSE_CASES = make_dsa_sparse_cases("dsa")
+
+    def test_aiter_mla_output_allocation_contract(self):
+        q = torch.empty((2, 16, 576), dtype=torch.float8_e4m3fn)
+        output = _new_aiter_mla_output(q, (2, 16, 512))
+
+        self.assertEqual(output.shape, (2, 16, 512))
+        self.assertEqual(output.dtype, torch.bfloat16)
+        self.assertEqual(output.element_size(), 2)
+
     # PCG/BCG split-op extend coverage is *not* added here — DSA's
     # MHA_ONE_SHOT dense fallback passes K as concatenated prefix+extend
     # (length = sum(seq_lens)) to `module.attn`, but


### PR DESCRIPTION
## Motivation

The DSA AITER paths allocate attention output with `q.new_empty()` or
`torch.empty_like(q)`. When the absorbed query is FP8, this creates a one-byte
destination, but AITER MLA writes a 16-bit attention output. In the
non-persistent single-split path, the assembly kernel can alias its logits to
that output and write BF16 values past the end of the allocation.

This reproduced on MI350X with GLM-5.2, FP8 KV, AITER DSA prefill,
non-persistent MLA, a 16K prefill chunk, and a 22K-token prompt. The unpatched
server raised a GPU memory-access fault in `mla_decode_fwd`; the same workload
completed after allocating the output as BF16.

The corresponding AITER defense-in-depth guard is ROCm/aiter#5120.

## Modifications

- Add one helper that encodes the AITER MLA BF16 output contract.
- Use it for decode and extend, with and without head padding.
- Add a regression test that verifies an FP8 query receives a two-byte BF16
  output allocation.

## Accuracy Tests

- Unpatched serialized repro: GPU memory-access fault in AITER
  `mla_decode_fwd`.
- Patched production-like graph-on run: 22,025 prompt tokens completed and
  returned a coherent response without a memory fault.
- TileLang control with the same prompt and model settings also completed.

## Speed Tests and Profiling

No kernel or dispatch behavior changes. For the reproduced TP4 16K-token
prefill shape, the correct BF16 destination uses about 128 MiB/GPU more than
the invalid FP8-sized destination.

## Checklist

- [ ] Format your code according to the contribution guide. (The environment
  used for the patch did not have `ruff`; `compileall` and `git diff --check`
  pass.)
- [x] Add unit tests according to the contribution guide.
- [x] Documentation update is not required for this internal allocation fix.
- [x] Provide accuracy and speed benchmark results.
- [x] Follow the SGLang code style guidance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33304639887](https://github.com/sgl-project/sglang/actions/runs/33304639887)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33304639850](https://github.com/sgl-project/sglang/actions/runs/33304639850)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33304639884](https://github.com/sgl-project/sglang/actions/runs/33304639884)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->