### PR TITLE
[ROCm] hicache: let MLA fp8 rows reach the read JIT, and retune the block quota

### DIFF
--- a/python/sglang/kernels/jit/csrc/kvcacheio/hicache.cuh
+++ b/python/sglang/kernels/jit/csrc/kvcacheio/hicache.cuh
@@ -39,6 +39,28 @@ inline constexpr auto get_mem_package() {
 template <int kUnit>
 using PackageType = decltype(get_mem_package<kUnit>());
 
+// A worker of num_threads lanes copies one element in rounds of `group` bytes,
+// each lane moving group / num_threads bytes as a single vector package -- so
+// that quotient has to be a package the hardware has. 128 B rounds are what the
+// element sizes reaching this kernel were tuned around, so they stay first
+// choice; the narrower rounds only catch sizes 128 does not divide, such as
+// MLA's 576 B kv_lora+rope row in fp8, which tiles as 64 B x 9.
+inline constexpr bool group_fits(int64_t bytes, uint32_t num_threads, uint32_t group) {
+  if (group % num_threads != 0 || bytes % static_cast<int64_t>(group) != 0) {
+    return false;
+  }
+  const uint32_t package = group / num_threads;
+  return package == 4 || package == 8 || package == 16;
+}
+
+inline constexpr uint32_t pick_group_bytes(int64_t bytes, uint32_t num_threads) {
+  return group_fits(bytes, num_threads, 128)  ? 128u
+         : group_fits(bytes, num_threads, 64) ? 64u
+         : group_fits(bytes, num_threads, 32) ? 32u
+         : group_fits(bytes, num_threads, 16) ? 16u
+                                              : 0u;
+}
+
 // NVIDIA exposes an explicit "do not allocate in L1" cache hint via PTX. ROCm
 // has no equivalent PTX, but non-temporal (streaming) loads/stores express the
 // same intent for one-shot HiCache write-back traffic that should not pollute
@@ -125,10 +147,10 @@ SGL_DEVICE void store_nc(uint4* __restrict__ dst, const uint4& value) {
 
 template <int64_t kBytes, uint32_t kNumThreads>
 SGL_DEVICE auto load_vec(const void* __restrict__ src) {
-  static_assert(kBytes % 128 == 0, "kBytes must be multiple of 128 bytes");
-  static_assert(128 % kNumThreads == 0, "kNumThreads must divide 128 bytes");
-  constexpr uint32_t kLoopCount = kBytes / 128;
-  using Package = details::PackageType<128 / kNumThreads>;
+  constexpr uint32_t kGroupBytes = details::pick_group_bytes(kBytes, kNumThreads);
+  static_assert(kGroupBytes != 0, "no 4/8/16 B package tiles kBytes across kNumThreads lanes");
+  constexpr uint32_t kLoopCount = kBytes / kGroupBytes;
+  using Package = details::PackageType<kGroupBytes / kNumThreads>;
   using Storage = details::LocalStorage<Package, kLoopCount>;
 
   const auto src_packed = static_cast<const Package*>(src);

--- a/python/sglang/kernels/ops/kvcache/hicache.py
+++ b/python/sglang/kernels/ops/kvcache/hicache.py
@@ -3,14 +3,33 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
-from sglang.kernels.jit.utils import cache_once, load_jit, make_cpp_args
+from sglang.kernels.jit.utils import (
+    cache_once,
+    is_hip_runtime,
+    load_jit,
+    make_cpp_args,
+)
 from sglang.kernels.kernel_api_logging import debug_kernel_api
 
 if TYPE_CHECKING:
     import torch
     from tvm_ffi.module import Module
 
-DEFAULT_BLOCK_QUOTA = 2
+# Grid cap on the transfer kernels, bounding interference with model compute. ROCm
+# needs 16: 2, 8 and 16 blocks leave the same GEMM throughput, 16 just ends sooner.
+DEFAULT_BLOCK_QUOTA = 16 if is_hip_runtime() else 2
+
+# Mirrors device::kWarpThreads in sgl_kernel/utils.cuh: the lane group a worker
+# is carved out of, 32 on both CUDA and ROCm.
+WARP_THREADS = 32
+
+# Bytes a worker moves per round; the kernel supports all four, widest first.
+# Rounds below 128 B are what let element sizes like MLA's 576 B fp8 row use the
+# JIT at all, but they only pay off against a quota that keeps the grid fed, and
+# the quota above is only retuned on ROCm. Enabling them on CUDA would newly
+# route those sizes through a 2-block grid, which is slower than not using the
+# JIT at all -- so CUDA keeps the original 128 B requirement.
+GROUP_BYTES = (128, 64, 32, 16) if is_hip_runtime() else (128,)
 
 
 @cache_once
@@ -72,11 +91,11 @@ def can_use_hicache_jit_kernel(
     block_quota: int | None = None,  # can be tuned for less interference
 ) -> bool:
     logger = logging.getLogger(__name__)
-    if element_size % 128 != 0:
+    unroll = unroll or _default_unroll(element_size)
+    if not _tiles_across_lanes(element_size, unroll):
         logger.warning(f"Unsupported {element_size = } for JIT HiCache kernel")
         return False
     try:
-        unroll = unroll or _default_unroll(element_size)
         block_quota = block_quota or DEFAULT_BLOCK_QUOTA
         _jit_hicache_module(
             element_size=element_size,
@@ -111,6 +130,23 @@ def can_use_write_back_jit_kernel(
     except Exception as e:
         logger.warning(f"Failed to load staged JIT HiCache kernel: {e}")
         return False
+
+
+def _tiles_across_lanes(
+    element_size: int, unroll: int, groups: tuple[int, ...] = GROUP_BYTES
+) -> bool:
+    """Mirror of pick_group_bytes() in kvcacheio/hicache.cuh.
+
+    ``groups`` is a parameter so both platforms' tables stay testable from a
+    runner of either kind; callers take the default.
+    """
+    num_threads = WARP_THREADS // unroll
+    return any(
+        group % num_threads == 0
+        and element_size % group == 0
+        and group // num_threads in (4, 8, 16)
+        for group in groups
+    )
 
 
 def _default_unroll(element_size: int) -> int:

--- a/test/registered/unit/mem_cache/test_hicache_jit_gate.py
+++ b/test/registered/unit/mem_cache/test_hicache_jit_gate.py
@@ -1,0 +1,77 @@
+import unittest
+
+from sglang.kernels.jit.utils import is_hip_runtime
+from sglang.kernels.ops.kvcache.hicache import (
+    GROUP_BYTES,
+    WARP_THREADS,
+    _default_unroll,
+    _tiles_across_lanes,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=1, suite="base-a-test-cpu")
+
+# MLA's kv_lora (512) + rope (64) row, one byte per element under fp8_e4m3.
+MLA_FP8_ROW_BYTES = 576
+
+# The two tables GROUP_BYTES resolves to. Named here rather than read off the
+# runtime so a runner of either kind covers both.
+ROCM_GROUPS = (128, 64, 32, 16)
+OTHER_GROUPS = (128,)
+
+
+class TestHiCacheJitGate(CustomTestCase):
+    """The gate deciding whether a row size can use the HiCache read JIT.
+
+    A size the gate rejects falls back to the non-JIT path silently, so a wrong
+    gate costs throughput without failing anything.
+    """
+
+    def test_group_table_matches_the_runtime(self):
+        self.assertEqual(GROUP_BYTES, ROCM_GROUPS if is_hip_runtime() else OTHER_GROUPS)
+
+    def test_mla_fp8_row_reaches_the_jit_only_with_the_narrow_rounds(self):
+        # 128 does not divide 576, so before the narrow rounds the read JIT was
+        # silently off on every DeepSeek/GLM-shaped model served with
+        # --kv-cache-dtype fp8_e4m3.
+        unroll = _default_unroll(MLA_FP8_ROW_BYTES)
+        self.assertTrue(
+            _tiles_across_lanes(MLA_FP8_ROW_BYTES, unroll, ROCM_GROUPS),
+            "576 B row should tile as 64 B x 9",
+        )
+        self.assertFalse(
+            _tiles_across_lanes(MLA_FP8_ROW_BYTES, unroll, OTHER_GROUPS),
+            "platforms keeping the 128 B round must still reject 576 B",
+        )
+
+    def test_sizes_128_divides_are_unaffected_by_the_narrow_rounds(self):
+        # The narrow rounds must not change the shape of anything that already
+        # worked: 128 stays first choice on every platform.
+        for element_size in (128, 256, 512, 1024, 2048):
+            for unroll in (1, 2, 4):
+                with self.subTest(element_size=element_size, unroll=unroll):
+                    self.assertTrue(
+                        _tiles_across_lanes(element_size, unroll, OTHER_GROUPS)
+                    )
+                    self.assertTrue(
+                        _tiles_across_lanes(element_size, unroll, ROCM_GROUPS)
+                    )
+                    self.assertIn(128 // (WARP_THREADS // unroll), (4, 8, 16))
+
+    def test_every_accepted_round_yields_a_package_the_kernel_instantiates(self):
+        # Mirrors get_mem_package() in kvcacheio/hicache.cuh, which only
+        # instantiates uint1/uint2/uint4.
+        for unroll in (1, 2, 4):
+            num_threads = WARP_THREADS // unroll
+            for group in ROCM_GROUPS:
+                if group % num_threads or not _tiles_across_lanes(
+                    group, unroll, (group,)
+                ):
+                    continue
+                with self.subTest(unroll=unroll, group=group):
+                    self.assertIn(group // num_threads, (4, 8, 16))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem

Two issues in the HiCache transfer path, both only visible at the sizes and
transfer lengths a real deployment sees.

**The read JIT was silently off for MLA in fp8.** The read kernel required
`element_size % 128 == 0`. MLA in fp8 is a 576 B row (kv_lora 512 + rope 64, one
byte each), so on every DeepSeek/GLM-shaped model served with
`--kv-cache-dtype fp8_e4m3` reads fell back to the non-JIT path. Writes were
never affected — their gate is `% 16`, which 576 passes — so reads and writes
were taking different paths with nothing saying so.

**The block quota was tuned on the wrong transfer length.** `DEFAULT_BLOCK_QUOTA`
caps the transfer grid to bound interference with model compute. Interference is
blocks × duration, so shrinking it past the point where reads saturate backfires:
on MI355X a 2-block read runs ~4x longer and costs more concurrent GEMM
throughput than a wider one, not less. The block count needed to saturate also
scales with transfer length, and `start_loading` merges the whole queue into one
launch per layer, so a real prefix hit is tens of thousands of tokens rather than
the few thousand a microbenchmark uses.

| tokens | quota | read bandwidth |
|---|---|---|
| 65536 | 8 | 28 GiB/s |
| 65536 | 16 | saturates |
| — | non-JIT path | 49 GiB/s |

At quota 8 the JIT path was *slower than the path it replaces*. 16 saturates and
costs no more compute than 2 or 8 do.

## Fix

`load_vec` picks its round from `{128, 64, 32, 16}`, widest first, instead of
hardcoding 128 B — so 576 B tiles as 64 B × 9. Sizes 128 divides keep the round
they had: for every unroll the kernel uses, 128 B still yields a 4, 8 or 16 B
package and is still chosen first.

## Platform scope

Both changes are gated to ROCm. **Every other platform keeps exactly what it
had** — the 128 B round and a quota of 2. Enabling the narrow rounds on CUDA
would newly route 576 B rows onto a 2-block grid, which measures far slower than
not using the JIT at all.

The gate is policy and lives in Python; `pick_group_bytes()` in the kernel is
mechanism and has no platform test of its own. That is safe because
`hicache_transfer_per_layer` and `hicache_transfer_all_layer` are the only
instantiations of `load_vec`, and `can_use_hicache_jit_kernel` is the only way to
reach them — `relayout.cuh`, `staged_write_back.cuh` and `transfer_mamba.cuh`
include this header but do not use it. `can_use_write_back_jit_kernel` keeps its
own `% 16` gate and is unaffected.

Happy to move the platform test into the kernel instead if you'd rather have the
two sides symmetric.

## Test

`test/registered/unit/mem_cache/test_hicache_jit_gate.py` — the gate rather than
the transfer, since the failure mode is a silent fallback that costs throughput
without failing anything.

`_tiles_across_lanes` takes the group table as an argument so both platforms'
tables are exercised from a runner of either kind, rather than only whichever one
the runner happens to be. The test asserts:

- the MLA fp8 row is admitted with the narrow rounds and rejected without them
- sizes 128 divides are unchanged by either table
- every accepted round yields a package `get_mem_package()` instantiates
- the module constant matches the runtime

4 tests, 21 subtests. Reverting `GROUP_BYTES` to `(128,)` fails it.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33306406041](https://github.com/sgl-project/sglang/actions/runs/33306406041)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33306405911](https://github.com/sgl-project/sglang/actions/runs/33306405911)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33306406081](https://github.com/sgl-project/sglang/actions/runs/33306406081)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->