### PR TITLE
Support Mooncake L3 storage under DSA cache layer split

### DIFF
--- a/python/sglang/srt/arg_groups/hicache_hook.py
+++ b/python/sglang/srt/arg_groups/hicache_hook.py
@@ -145,6 +145,17 @@ def resolve_storage_layout_compatibility(server_args: Any):
     ):
         return
 
+    if getattr(cfg, "enable_dsa_cache_layer_split", False):
+        # DSA cache layer split shards the KV/indexer layers across CP ranks.
+        # Its direct-backend host<->device transfer only supports layer_first,
+        # while kernel+page_first requires the JIT one-layer kernel, which
+        # does not cover all element sizes (e.g. 656B for GLM DSA). Rewriting
+        # layer_first away here would leave layer-split deployments with no
+        # valid layout/backend combination at all. The Mooncake MLA path can
+        # serve layer_first pages through the multi-buffer interface (one key,
+        # per-layer buffers), so keep the requested layout.
+        return
+
     if cfg.hicache_io_backend == "direct":
         new_layout = "page_first_direct"
     elif cfg.hicache_io_backend == "kernel":

--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -553,11 +553,15 @@ class HiCacheController:
         self.storage_config = self._generate_storage_config(
             model_name, storage_backend_extra_config
         )
-        # for MLA models, only one rank needs to backup the KV cache
+        # For MLA models the KV cache is rank-replicated, so only one rank
+        # needs to back it up -- except under DSA cache layer split, where
+        # each CP rank owns a disjoint layer slice and every rank must back
+        # up its own shard.
         self.backup_skip = (
             self.storage_config.is_mla_model
             # todo: load balancing
             and self.storage_config.tp_rank != 0
+            and not self.storage_config.is_dsa_layer_split
         )
 
         # Use storage backend factory for dynamic backend creation
@@ -725,6 +729,15 @@ class HiCacheController:
 
         attn_cp_rank, attn_cp_size = self.get_attn_cp_rank_and_size()
 
+        from sglang.srt.mem_cache.dsa_cache_layer_split import (
+            LayerSplitDSATokenToKVPool,
+        )
+
+        is_dsa_layer_split = (
+            isinstance(self.mem_pool_device, LayerSplitDSATokenToKVPool)
+            and attn_cp_size > 1
+        )
+
         return HiCacheStorageConfig(
             tp_rank=self.tp_rank,
             tp_size=self.tp_size,
@@ -739,6 +752,7 @@ class HiCacheController:
             model_name=model_name,
             tp_lcm_size=tp_lcm_size,
             should_split_heads=should_split_heads,
+            is_dsa_layer_split=is_dsa_layer_split,
             extra_config=storage_backend_extra_config,
         )
 

--- a/python/sglang/srt/mem_cache/hicache_storage.py
+++ b/python/sglang/srt/mem_cache/hicache_storage.py
@@ -37,6 +37,10 @@ class HiCacheStorageConfig:
     model_name: Optional[str]
     tp_lcm_size: Optional[int] = None
     should_split_heads: bool = False
+    # True when the device pool shards KV/indexer layers across CP ranks
+    # (DSA cache layer split): each rank then owns a disjoint layer slice
+    # and L3 objects must be sharded per rank.
+    is_dsa_layer_split: bool = False
     extra_config: Optional[dict] = None
 
 

--- a/python/sglang/srt/mem_cache/pool_host/dsa.py
+++ b/python/sglang/srt/mem_cache/pool_host/dsa.py
@@ -458,6 +458,26 @@ class DSAIndexerPoolHost(HostKVCache):
     def get_page_buffer_meta(self, indices):
         """Meta data for zero-copy storage I/O."""
         assert len(indices) % self.page_size == 0
+        if self.layout == "layer_first":
+            # One buffer per (page, layer); the storage backend packs them into
+            # a single multi-buffer object per page key. Ordering matches the
+            # MLA host pool convention: page-major outer, layer inner.
+            per_layer_bytes = (
+                self.indexer_page_stride_size * self.indexer_dtype.itemsize
+            )
+            layer_stride_bytes = self.indexer_page_num * per_layer_bytes
+            base_ptr = self.index_k_with_scale_buffer.data_ptr()
+            idx = indices.tolist()
+            ptr_list = []
+            for i in range(0, len(idx), self.page_size):
+                page_index = int(idx[i]) // self.page_size
+                for layer_id in range(self.layer_num):
+                    ptr_list.append(
+                        base_ptr
+                        + layer_id * layer_stride_bytes
+                        + page_index * per_layer_bytes
+                    )
+            return ptr_list, [per_layer_bytes] * len(ptr_list)
         if self.layout not in ["page_first", "page_first_direct"]:
             raise ValueError(f"Unsupported layout: {self.layout}")
         ptr_list = []

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -580,6 +580,21 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 self.mha_suffix = f"{self.local_rank}"
                 self.mla_suffix = ""
 
+            # DSA cache layer split: each CP rank only holds a disjoint layer
+            # slice, so L3 objects must be sharded per rank. With a shared key
+            # ranks would overwrite each other (first-writer-wins) and a
+            # self-read would return another rank's slice. The rank suffix
+            # also keeps these objects out of the key space of non-sharded
+            # instances of the same model, whose page objects have a
+            # different intra-page byte layout.
+            if (
+                storage_config is not None
+                and storage_config.is_mla_model
+                and getattr(storage_config, "is_dsa_layer_split", False)
+                and self.attn_cp_size > 1
+            ):
+                self.mla_suffix = f"{self.mla_suffix}_ls{self.attn_cp_rank}"
+
             self.storage_config = storage_config
             self.should_split_heads = storage_config.should_split_heads
             self.split_factor = 0

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -595,6 +595,19 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             ):
                 self.mla_suffix = f"{self.mla_suffix}_ls{self.attn_cp_rank}"
 
+            # Optional cross-layout L3 fallback (experimental): let a
+            # layer-sharded instance serve misses from the canonical page
+            # objects written by a non-sharded instance of the same model,
+            # and vice versa. Opt-in via extra_config because it assumes
+            # both instances share one store and one model checkpoint.
+            _xcfg = extra_config or {}
+            self.cross_layout_fallback = bool(
+                _xcfg.get("enable_cross_layout_fallback", False)
+            )
+            self.cross_layout_shard_size = int(
+                _xcfg.get("cross_layout_shard_size", 0) or 0
+            )
+
             self.storage_config = storage_config
             self.should_split_heads = storage_config.should_split_heads
             self.split_factor = 0
@@ -865,6 +878,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             )
             component_keys = self._tag_keys(component_keys)
             ex = self._batch_exist(component_keys)
+            ex = self._cross_layout_exists_fallback(component_keys, ex)
             if key_multiplier > 0:
                 page_exists = [
                     all(
@@ -944,6 +958,14 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             else:
                 io_results = self._get_batch_zero_copy_impl(
                     key_strs, ptr_list, element_size_list
+                )
+                io_results = self._cross_layout_get_fallback(
+                    key_strs,
+                    ptr_list,
+                    element_size_list,
+                    io_results,
+                    token_major=False,
+                    full_layer_num=getattr(host_pool, "layer_num", 0),
                 )
             results[transfer.name] = self._batch_postprocess(
                 io_results, is_set_operate=is_set, key_multiplier=key_multiplier
@@ -1067,6 +1089,247 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             for group in result_groups
         ]
 
+    def _cross_layout_active(self) -> bool:
+        if not getattr(self, "cross_layout_fallback", False):
+            return False
+        if not self.is_mla_backend:
+            return False
+        if "_ls" in (self.mla_suffix or ""):
+            return True  # sharded reader, canonical peer objects
+        return self.cross_layout_shard_size > 1  # canonical reader, shards
+
+    @staticmethod
+    def _cross_layout_key_tail(key: str) -> Optional[str]:
+        for tail in ("_k", "_indexer"):
+            if key.endswith(tail):
+                return tail
+        return None
+
+    def _cross_layout_get_batch(self, keys: List[str], chunk: int) -> List[bytes]:
+        """get_batch with per-key retry: large batches have been observed to
+        return empty payloads for a subset of keys, so refetch holes
+        individually before treating them as misses."""
+        blobs: List[bytes] = []
+        for c in range(0, len(keys), chunk):
+            part = keys[c : c + chunk]
+            try:
+                blobs.extend(self.store.get_batch(part))
+            except Exception:
+                blobs.extend([b""] * len(part))
+        for j, b in enumerate(blobs):
+            if b is None or len(b) == 0:
+                try:
+                    blobs[j] = self.store.get(keys[j])
+                except Exception:
+                    pass
+        return [bytes(b or b"") for b in blobs]
+
+    def _cross_layout_exists_fallback(self, query_keys, exist_result):
+        """Treat a page as present when the peer layout's object(s) exist."""
+        if not self._cross_layout_active():
+            return exist_result
+        fixed = list(exist_result)
+        sharded_self = "_ls" in (self.mla_suffix or "")
+        miss = [
+            i
+            for i, r in enumerate(fixed)
+            if r != 1 and self._cross_layout_key_tail(query_keys[i]) is not None
+        ]
+        if sharded_self:
+            miss = [i for i in miss if self.mla_suffix in query_keys[i]]
+            if not miss:
+                return fixed
+            plain = [
+                query_keys[i].replace(self.mla_suffix, "", 1) for i in miss
+            ]
+            pex = self._batch_exist(plain)
+            for i, pe in zip(miss, pex):
+                if pe == 1:
+                    fixed[i] = 1
+            return fixed
+        n = self.cross_layout_shard_size
+        miss = [i for i in miss if "_ls" not in query_keys[i]]
+        if not miss:
+            return fixed
+        probe = []
+        for i in miss:
+            tail = self._cross_layout_key_tail(query_keys[i])
+            probe.extend(
+                query_keys[i][: -len(tail)] + f"_ls{r}" + tail for r in range(n)
+            )
+        pex = self._batch_exist(probe)
+        for j, i in enumerate(miss):
+            if all(pex[j * n + r] == 1 for r in range(n)):
+                fixed[i] = 1
+        return fixed
+
+    def _cross_layout_get_fallback(
+        self,
+        key_strs,
+        ptr_list,
+        element_size_list,
+        io_results,
+        token_major: bool,
+        full_layer_num: int,
+    ):
+        """Serve get() misses from the peer layout's L3 objects.
+
+        Canonical MLA KV page objects are token-major
+        (page_size, layers, record); sidecar pools such as the DSA indexer
+        are layer-major (layers, page_stride). Layer shards written by a
+        layer-sharded instance are contiguous layer ranges of the same
+        per-layer page bytes (see get_layer_shard_range), so translating
+        between the two is a deterministic gather/scatter. Correctness was
+        validated byte-for-byte against real objects; deeper layers may
+        differ numerically between engines of different parallel topologies
+        (reduction order under fp8), which is semantically benign -- PD
+        disaggregation consumes cross-engine KV the same way.
+        """
+        if not self._cross_layout_active():
+            return io_results
+        import ctypes
+
+        import numpy as np
+
+        sharded_self = "_ls" in (self.mla_suffix or "")
+        page_tokens = getattr(self.mem_pool_host, "page_size", 64)
+        fixed = list(io_results)
+        todo = []
+        for i, res in enumerate(io_results):
+            if res > 0:
+                continue
+            key = key_strs[i]
+            tail = self._cross_layout_key_tail(key)
+            if tail is None:
+                continue
+            if sharded_self:
+                if self.mla_suffix not in key:
+                    continue
+                todo.append((i, key.replace(self.mla_suffix, "", 1), tail))
+            else:
+                if "_ls" in key:
+                    continue
+                todo.append((i, key, tail))
+        if not todo:
+            return fixed
+        t0 = time.perf_counter()
+        filled = 0
+        if sharded_self:
+            rank, size = self.attn_cp_rank, self.attn_cp_size
+            blobs = self._cross_layout_get_batch([pk for _, pk, _ in todo], 8)
+            for (i, pk, tail), obj in zip(todo, blobs):
+                if not obj:
+                    continue
+                ptrs = ptr_list[i]
+                sizes = element_size_list[i]
+                if not isinstance(ptrs, (list, tuple)):
+                    ptrs, sizes = [ptrs], [sizes]
+                block_bytes = int(sizes[0])
+                if block_bytes <= 0 or len(obj) % block_bytes:
+                    continue
+                total_layers = len(obj) // block_bytes
+                base, rem = total_layers // size, total_layers % size
+                start = rank * base + min(rank, rem)
+                own = base + (1 if rank < rem else 0)
+                ok = True
+                if token_major:
+                    rec = block_bytes // page_tokens
+                    arr = np.frombuffer(obj, dtype=np.uint8).reshape(
+                        page_tokens, total_layers, rec
+                    )
+                    for b in range(len(ptrs)):
+                        if b >= own:
+                            continue  # trailing padding blocks stay empty
+                        blk = np.ascontiguousarray(arr[:, start + b, :])
+                        if blk.nbytes != int(sizes[b]):
+                            ok = False
+                            break
+                        ctypes.memmove(int(ptrs[b]), blk.ctypes.data, blk.nbytes)
+                else:
+                    for b in range(len(ptrs)):
+                        if b >= own:
+                            continue
+                        off = (start + b) * block_bytes
+                        blk = obj[off : off + block_bytes]
+                        if len(blk) != int(sizes[b]):
+                            ok = False
+                            break
+                        ctypes.memmove(
+                            int(ptrs[b]),
+                            (ctypes.c_char * len(blk)).from_buffer_copy(blk),
+                            len(blk),
+                        )
+                if ok:
+                    fixed[i] = 1
+                    filled += 1
+        else:
+            n = self.cross_layout_shard_size
+            flat = []
+            for i, key, tail in todo:
+                flat.extend(
+                    key[: -len(tail)] + f"_ls{r}" + tail for r in range(n)
+                )
+            blobs = self._cross_layout_get_batch(flat, 48)
+            base, rem = full_layer_num // n, full_layer_num % n
+            for t, (i, key, tail) in enumerate(todo):
+                shards = blobs[t * n : (t + 1) * n]
+                if any(len(b) == 0 for b in shards):
+                    continue
+                ptrs = ptr_list[i]
+                sizes = element_size_list[i]
+                if isinstance(ptrs, (list, tuple)):
+                    if len(ptrs) != 1:
+                        continue
+                    ptrs, sizes = ptrs[0], sizes[0]
+                expected = int(sizes)
+                if full_layer_num <= 0 or expected % full_layer_num:
+                    continue
+                block_bytes = expected // full_layer_num
+                ok = True
+                if token_major:
+                    rec = block_bytes // page_tokens
+                    out = np.empty(
+                        (page_tokens, full_layer_num, rec), dtype=np.uint8
+                    )
+                    for r in range(n):
+                        own = base + (1 if r < rem else 0)
+                        start = r * base + min(r, rem)
+                        if len(shards[r]) < own * block_bytes:
+                            ok = False
+                            break
+                        arr = np.frombuffer(
+                            shards[r][: own * block_bytes], dtype=np.uint8
+                        ).reshape(own, page_tokens, rec)
+                        for b in range(own):
+                            out[:, start + b, :] = arr[b]
+                    blob = out.tobytes() if ok else b""
+                else:
+                    parts = []
+                    for r in range(n):
+                        own = base + (1 if r < rem else 0)
+                        if len(shards[r]) < own * block_bytes:
+                            ok = False
+                            break
+                        parts.append(shards[r][: own * block_bytes])
+                    blob = b"".join(parts) if ok else b""
+                if not ok or len(blob) != expected:
+                    continue
+                ctypes.memmove(
+                    int(ptrs),
+                    (ctypes.c_char * len(blob)).from_buffer_copy(blob),
+                    len(blob),
+                )
+                fixed[i] = 1
+                filled += 1
+        if filled:
+            logger.debug(
+                "cross-layout fallback filled %d/%d pages in %.2fs",
+                filled,
+                len(todo),
+                time.perf_counter() - t0,
+            )
+        return fixed
+
     def batch_get_v1(
         self,
         keys: List[str],
@@ -1085,6 +1348,14 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
         start_time = time.perf_counter()
         get_results = self._get_batch_zero_copy_impl(
             key_strs, buffer_ptrs, buffer_sizes
+        )
+        get_results = self._cross_layout_get_fallback(
+            key_strs,
+            buffer_ptrs,
+            buffer_sizes,
+            get_results,
+            token_major=True,
+            full_layer_num=getattr(self.mem_pool_host, "layer_num", 0),
         )
         end_time = time.perf_counter()
 
@@ -1301,6 +1572,7 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
                 key_multiplier = 2
 
         exist_result = self._batch_exist(query_keys)
+        exist_result = self._cross_layout_exists_fallback(query_keys, exist_result)
         for i in range(len(query_keys)):
             if exist_result[i] != 1:
                 return i // key_multiplier

--- a/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
+++ b/python/sglang/srt/mem_cache/storage/mooncake_store/mooncake_store.py
@@ -899,7 +899,11 @@ class MooncakeStore(HiCacheStorage, MooncakeBaseStore):
             )
             key_strs = self._tag_keys(key_strs)
             ptr_list, element_size_list = host_pool.get_page_buffer_meta(host_indices)
-            if transfer.name == PoolName.DEEPSEEK_V4_C4:
+            # layer_first pools return one buffer per (page, layer); pack them
+            # into a single multi-buffer object per page key.
+            if transfer.name == PoolName.DEEPSEEK_V4_C4 or (
+                len(ptr_list) > len(key_strs)
+            ):
                 ptr_list, element_size_list = self._pack_multi_buffer_meta(
                     key_strs, ptr_list, element_size_list
                 )


### PR DESCRIPTION
## Motivation

`--enable-dsa-cache-layer-split` (added in #29421 for prefill context parallelism) currently has **no working layout/backend combination** with the Mooncake storage backend:

| io-backend | layout after arg resolution | result |
|---|---|---|
| `direct` | `layer_first` → force-rewritten to `page_first_direct` | `ValueError: Layer-sharded direct HiCache backup only supports layer_first layout` |
| `kernel` | `page_first` | requires the JIT one-layer kernel, which rejects element sizes such as 656B (GLM DSA MLA record); the non-JIT fallback raises |

Every layer-split + Mooncake deployment crashes at the first backup. Even with the layout deadlock bypassed, two more gates keep it broken: the MLA key scheme is rank-agnostic while each CP rank only owns a disjoint layer slice (first-writer-wins corruption on self-read), and `backup_skip` gates backup to `tp_rank == 0` — correct for rank-replicated MLA, wrong for layer-sharded pools.

Reproduced on GLM-5.3 (753B, 78 layers, CP8 prefill, PD disaggregation, Mooncake 0.3.13).

Related: #21846 (the storage "group semantics" roadmap item anticipates per-rank key splitting), #22757 (DSA + Mooncake direct crashes, closed inactive), #31600 (element_size 656 JIT warning).

## Changes

**Commit 1 — fix(hicache): support `layer_first` host layout for DSA layer split with Mooncake**

- Keep the requested `layer_first` layout when layer split is enabled instead of force-rewriting it (the Mooncake MLA path already supports `layer_first` via the multi-buffer interface — one key, per-layer buffers).
- Add the missing `layer_first` branch to the DSA indexer host pool `get_page_buffer_meta` (one buffer per `(page, layer)`, page-major outer / layer inner, matching the MLA host pool convention).
- Generalize the v2 batch-IO multi-buffer packing to any pool whose buffer meta returns more buffers than keys (previously only `DEEPSEEK_V4_C4` was packed, so `layer_first` KV/indexer pools raised `Unsupported layout`).

**Commit 2 — feat(hicache): per-rank sharded L3 objects for DSA cache layer split**

- Plumb `is_dsa_layer_split` through `HiCacheStorageConfig` (detected from the device pool type in the cache controller).
- Open the backup gate so every rank backs up its own layer shard.
- Append a `_ls{attn_cp_rank}` suffix to the MLA component keys so each rank stores/fetches its own contiguous layer slice (per `get_layer_shard_range`). This reuses the "multiple keys per page" idea of the MHA `{rank}_k`/`{rank}_v` scheme. It also structurally separates layer-sharded objects from the (token-major) canonical page objects written by non-sharded instances of the same model — the two have different intra-page byte layouts, and sharing a key silently corrupts output.

**Commit 3 — feat(hicache): optional cross-layout L3 fallback (experimental, opt-in)**

Enabled via the Mooncake extra config:

```json
{"enable_cross_layout_fallback": true, "cross_layout_shard_size": 8}
```

In a mixed deployment one prefill pool may run DSA cache layer split (e.g. a long-context CP worker) while another serves bulk traffic without it. Both compute bit-compatible KV records but store them under different L3 object layouts, so a session migrating between pools pays a full re-prefill of its prefix — on a production-shaped benchmark this tax measured ~110k recomputed tokens per migrated request.

With the fallback enabled, each side serves `get()`/`exists()` misses from the peer layout:

- a layer-sharded instance reads the canonical full-page object and scatters its own contiguous layer slice (token-major transpose for the MLA KV pool, direct layer slice for layer-major sidecar pools such as the DSA indexer);
- a non-sharded instance gathers all shards and reassembles the canonical page.

The translation is a deterministic gather/scatter derived from `get_layer_shard_range`. Also includes a per-key retry after `store.get_batch()`: large batches were observed to return empty payloads for a subset of keys.

## Validation

All results from a production 8×H200-node cluster running GLM-5.3 with PD disaggregation and Mooncake 0.3.13.

**Self-loop (commits 1–2):**

- Engine starts cleanly (previously: scheduler crash at first backup), backup thread clean.
- All 8 shards present per page, audited with an independent Mooncake client: KV 10×41,984B + indexer 10×8,448B per rank (78 layers over 8 ranks → 10/10/10/10/10/10/9/9, trailing padding blocks left empty).
- `/flush_cache` + re-request of a 32k-token needle prompt: served fully from L3 (`cached_tokens` 31,872/31,902), needle retrieved correctly.

**Cross-layout fallback (commit 3):**

- Translation validated byte-for-byte against real objects: a canonical page reassembled from the 8 shards is identical to the genuinely written canonical page.
- Deeper layers can differ numerically between engines of different parallel topologies (fp8 reduction order). This is semantically benign — PD disaggregation consumes cross-engine KV the same way — and was verified end-to-end by needle retrieval in both directions (`cached_tokens` ≈ full prompt, correct answer).
- Mixed benchmark (32 sessions/min, 80k median context, requests >120k tokens routed to the CP8 worker): migrated-route median recompute **110k → 1.6k tokens**, route TTFT p50 9.0s → 1.9s, p99 107.7s → 19.8s, zero errors on the route, overall cache hit rate restored to the trace design value.

## Notes for reviewers

- Commit 3 is separable: commits 1–2 alone make layer-split deployments work (self-loop only). Happy to split it into a follow-up PR if preferred.
- The `_ls{rank}` suffix could instead ride on the storage group-semantics API from #21846; happy to migrate if that is the preferred shape.
- The `get_batch` partial-empty behaviour likely deserves its own investigation on the Mooncake side; the retry here is a defensive workaround.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [ ] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-writing-documentation).
- [x] Update documentation / docstrings as needed.
- [x] Provide throughput / latency benchmark results and accuracy evaluation results as needed.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33308409025](https://github.com/sgl-project/sglang/actions/runs/33308409025)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33308408909](https://github.com/sgl-project/sglang/actions/runs/33308408909)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33308408918](https://github.com/sgl-project/sglang/actions/runs/33308408918)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->