### PR TITLE
[AMD] Remove silent x0.85 mem_fraction_static derate for aiter + ctx>8K

### DIFF
--- a/python/sglang/srt/arg_groups/attention_hook.py
+++ b/python/sglang/srt/arg_groups/attention_hook.py
@@ -173,15 +173,6 @@ def handle_attention_backend_compatibility(server_args: Any):
 
     run_post_process_pass(server_args, _fa4_page_constraint)
 
-    # AMD platforms backends
-    if resolved_view(server_args).attention_backend == "aiter":
-        if model_config.context_len > 8192:
-            declare_resolution(
-                server_args,
-                "_handle_attention_backend_compatibility",
-                mem_fraction_static=cfg.mem_fraction_static * 0.85,
-            )
-
     # Other platforms backends
     run_post_process_pass(server_args, _attention_backend_platform_fallbacks)
 


### PR DESCRIPTION
A user who passes `--mem-fraction-static` gets a different number than the one
they asked for, with nothing in the log saying so.

The derate fires on `attention_backend == aiter` and `context_len > 8192` —
every long-context ROCm run — and silently costs 15% of the KV pool. At
ISL=100K that is the difference between a batch rung being reachable and not.

If a backend needs more headroom the right place to say so is the default, or a
warning, not a quiet multiply on an explicit user value.

### Note for reviewers

This removes headroom that was presumably added for a reason. If aiter at long
context genuinely needs it, a warning that names the adjusted value would fix
the accountability problem without changing behaviour — say the word and I'll
send that instead.

Applying the derate only when `mem_fraction_static` was *not* explicitly passed
would be the better shape, but `handle_gpu_memory_settings` runs before
`handle_attention_backend_compatibility`, so by that point the field is already
filled and the two cases are indistinguishable without a new explicitly-set flag.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33312225980](https://github.com/sgl-project/sglang/actions/runs/33312225980)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33312225870](https://github.com/sgl-project/sglang/actions/runs/33312225870)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33312225972](https://github.com/sgl-project/sglang/actions/runs/33312225972)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->