### PR TITLE
perf(moe): fuse SwiGLU clamp activation in DeepGEMM

### DIFF
--- a/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
+++ b/python/sglang/srt/layers/moe/moe_runner/deep_gemm.py
@@ -8,7 +8,10 @@ import torch
 import triton
 import triton.language as tl
 
-from sglang.kernels.ops.attention.dsv4 import silu_and_mul_masked_post_quant
+from sglang.kernels.ops.attention.dsv4 import (
+    silu_and_mul_clamp,
+    silu_and_mul_masked_post_quant,
+)
 from sglang.kernels.ops.quantization import per_token_group_quant
 
 logger = logging.getLogger(__name__)
@@ -422,19 +425,25 @@ class DeepGemmRunnerCore(MoeRunnerCore):
                 sglang_per_token_group_quant_fp8,
             )
 
-            if self.swiglu_limit is not None:
-                gateup_output = _apply_swiglu_limit(
-                    gateup_output, swiglu_limit=self.swiglu_limit
-                )
-
             if not _is_musa:
                 down_input = torch.empty(
                     (all_tokens, N // 2),
                     device=gateup_output.device,
                     dtype=torch.bfloat16,
                 )
-                _legacy_silu_and_mul(gateup_output.view(-1, N), down_input)
+                if self.swiglu_limit is not None:
+                    silu_and_mul_clamp(
+                        gateup_output.view(-1, N),
+                        down_input,
+                        self.swiglu_limit,
+                    )
+                else:
+                    _legacy_silu_and_mul(gateup_output.view(-1, N), down_input)
             else:
+                if self.swiglu_limit is not None:
+                    gateup_output = _apply_swiglu_limit(
+                        gateup_output, swiglu_limit=self.swiglu_limit
+                    )
                 down_input = _silu_and_mul_musa(gateup_output.view(-1, N))
             del gateup_output
 


### PR DESCRIPTION
## Summary

- reuse the existing `silu_and_mul_clamp` kernel in the DeepGEMM MoE activation path when `swiglu_limit` is enabled
- fuse clamp, SiLU, and multiply instead of materializing separately clamped gate/up tensors and concatenating them
- preserve the existing unclamped CUDA path and the MUSA fallback

## Motivation

GLM-5.3-Flash uses `swiglu_limit=10`. The previous DeepGEMM path applied `_apply_swiglu_limit` first and then invoked the legacy SiLU-and-multiply kernel. This change preserves the clamp semantics while removing the standalone clamp/cat work from the CUDA path.

## Validation

- `python -m py_compile python/sglang/srt/layers/moe/moe_runner/deep_gemm.py`
- `git diff --check`
- B300 numerical comparison against the previous path across 1, 7, 256, 1024, and 4096 rows:
  - differing values: 21 / 11,026,432 (`1.90e-6` fraction)
  - maximum absolute difference: `1.19e-7`
- GLM-5.3-Flash, 2x B300, TP2/EP2, batch 28, 16K input / 1 output, DeepGEMM:
  - before: `37,478.02` input tok/s
  - after: `46,462.46` input tok/s (`+23.97%`)
  - repeated after result: `46,291.87` input tok/s

The benchmark used TRT-LLM DSA prefill, DSA context parallelism, FlashKDA prefill, FP8 KV cache, and disabled radix cache/CUDA Graph. The PR itself changes only the DeepGEMM activation path.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33312442776](https://github.com/sgl-project/sglang/actions/runs/33312442776)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33312442608](https://github.com/sgl-project/sglang/actions/runs/33312442608)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33312442731](https://github.com/sgl-project/sglang/actions/runs/33312442731)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->