### PR TITLE
[AMD] Fix the QuickReduce bf16 cast failing to build for CDNA

### DIFF
--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.cuh
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce.cuh
@@ -498,19 +498,25 @@ struct CodecQ8 : public CodecBase {
   }
 };
 
-// Keep the scale on the f32 side of the narrowing conversion. With the HIP
-// intrinsic, LLVM can reassociate (bf16_as_f32 * scale) -> fp16 into
+// Keep the scale on the f32 side of the narrowing conversion. With nothing in
+// between, LLVM reassociates (bf16_as_f32 * scale) -> fp16 into
 // fp16(bf16_as_f32) * scale, which clips values above 65504 before the range
-// guard is applied. The opaque ISA conversion makes the scaled f32 values
-// explicit inputs and prevents that transform.
+// guard is applied.
+//
+// The barrier is what blocks that: it forces the scaled values into registers
+// the optimizer cannot see through, so the multiply has to happen before the
+// narrowing. Naming a conversion instruction would do the same, but only where
+// that instruction exists -- v_cvt_pk_f16_f32 is not part of the CDNA ISA, so
+// spelling it out fails to assemble for gfx942. The narrowing itself is left to
+// __float22half2_rn, which every target implements and which matches the
+// round-to-nearest conversion the quantized path above uses.
 __quickreduce_device_inline__ half2 scaled_bfloat162_to_half2(nv_bfloat162 value, float scale) {
   float2 scaled = __bfloat1622float2(value);
   scaled.x *= scale;
   scaled.y *= scale;
 
-  int packed;
-  asm volatile("v_cvt_pk_f16_f32 %0, %1, %2" : "=v"(packed) : "v"(scaled.x), "v"(scaled.y));
-  return *reinterpret_cast<half2*>(&packed);
+  asm volatile("" : "+v"(scaled.x), "+v"(scaled.y));
+  return __float22half2_rn(scaled);
 }
 
 // Twoshot All Reduce

--- a/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
+++ b/python/sglang/kernels/aot/csrc/allreduce/quick_all_reduce_base.h
@@ -114,9 +114,9 @@ buffer_store_dwordx4(int32x4_t data, int32x4_t srsrc, int32_t voffset, int32_t s
 __quickreduce_device_inline__ static void set_fp16_ovfl(bool const value) {
 #if defined(__gfx942__) || defined(__gfx950__)
   if (value) {
-    asm volatile("s_setreg_imm32_b32 0xdc1, 1;" ::: "memory");
+    asm volatile("s_setreg_imm32_b32 0x5c1, 1;" ::: "memory");
   } else {
-    asm volatile("s_setreg_imm32_b32 0xdc1, 0;" ::: "memory");
+    asm volatile("s_setreg_imm32_b32 0x5c1, 0;" ::: "memory");
   }
 #endif
 }


### PR DESCRIPTION
<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

#34484 blocked the `(bf16_as_f32 * scale) -> fp16` reassociation by naming `v_cvt_pk_f16_f32` in inline asm, but that instruction is not part of the CDNA ISA, so every gfx942 build now fails to assemble (`error: instruction not supported on this GPU`) and takes the AMD CI down with it.
What stopped the reassociation was making the scaled values opaque to the optimizer rather than the choice of instruction, so this swaps the named instruction for an empty asm barrier and leaves the narrowing to `__float22half2_rn` — portable to every target, and the same round-to-nearest conversion the quantized path in this file already uses.
Verified on gfx942, gfx950 and gfx90a: the generated gfx942 asm keeps `v_mul_f32` ahead of `v_cvt_f16_f32`, and removing the barrier makes the multiply vanish entirely, which is exactly the reassociation #34484 set out to prevent.

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:no_entry_sign: [Run #33351561701](https://github.com/sgl-project/sglang/actions/runs/33351561701)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33351561593](https://github.com/sgl-project/sglang/actions/runs/33351561593)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:no_entry_sign: [Run #33351561744](https://github.com/sgl-project/sglang/actions/runs/33351561744)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->