### PR TITLE
[2/4][Kernels] Add MXFP4 KV cache codec (Triton quantize/dequant)

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/combine.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/combine.cuh
@@ -1,0 +1,220 @@
+#include <cute/tensor.hpp>
+#include <cutlass/array.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_types.h>
+
+#include "flashmla_utils.h"
+#include "kerutils/kerutils.cuh"
+#include "params.h"
+#include <math_constants.h>
+
+using namespace cute;
+
+namespace smxx::decode {
+
+template <typename ElementT, int HEAD_DIM_V, int BLOCK_SIZE_M, int MAX_SPLITS, int NUM_THREADS>
+__global__ void __launch_bounds__(NUM_THREADS)
+    flash_fwd_mla_combine_kernel(__grid_constant__ const CombineParams params) {
+  // grid_shape: [batch_size*s_q, 1, h_q/BLOCK_SIZE_M]
+  // Each CTA gathers the activation of some heads from one batch, do scaling & accumulation, and save the result
+  static_assert(NUM_THREADS / 32 == BLOCK_SIZE_M);  // The number of warps == block_size_m
+  const int batch_s_q_idx = blockIdx.x;
+  const int batch_idx = batch_s_q_idx / params.s_q;
+  const int s_q_idx = batch_s_q_idx - batch_idx * params.s_q;
+  const int h_block_idx = blockIdx.z;
+  const int warp_idx = threadIdx.x / 32;
+  const int lane_idx = threadIdx.x % 32;
+
+  int num_valid_heads = std::min(BLOCK_SIZE_M, params.h_q - BLOCK_SIZE_M * h_block_idx);
+  if (warp_idx >= num_valid_heads) {
+    return;
+  }
+
+  const int start_split_idx = __ldg(params.num_splits_ptr + batch_idx);
+  const int end_split_idx = __ldg(params.num_splits_ptr + batch_idx + 1);
+  const int my_num_splits = end_split_idx - start_split_idx;
+  if (my_num_splits == 1) {
+    return;
+  }
+
+  FLASH_DEVICE_ASSERT(my_num_splits <= MAX_SPLITS);
+
+  Tensor gLseAccum = make_tensor(
+      make_gmem_ptr(
+          (float*)params.lse_accum + start_split_idx * params.stride_lse_accum_split +
+          s_q_idx * params.stride_lse_accum_s_q + h_block_idx * BLOCK_SIZE_M),
+      Shape<Int<MAX_SPLITS>, Int<BLOCK_SIZE_M>>{},
+      make_stride(params.stride_lse_accum_split, _1{}));
+  Tensor gLse = make_tensor(
+      make_gmem_ptr(
+          (float*)params.lse + batch_idx * params.stride_lse_b + s_q_idx * params.stride_lse_s_q +
+          h_block_idx * BLOCK_SIZE_M),
+      Shape<Int<BLOCK_SIZE_M>>{},
+      Stride<_1>{});
+
+  __shared__ float smem_buf[BLOCK_SIZE_M][MAX_SPLITS];
+
+  // Wait for the previous kernel (the MLA kernel) to finish
+  cudaGridDependencySynchronize();
+
+  // Prefetch
+  static_assert(HEAD_DIM_V % (32 * 4) == 0);
+  constexpr int ELEMS_PER_THREAD = HEAD_DIM_V / (32 * 4);
+  float* oaccum_ptr = params.o_accum + start_split_idx * params.stride_o_accum_split +
+                      s_q_idx * params.stride_o_accum_s_q +
+                      (h_block_idx * BLOCK_SIZE_M + warp_idx) * params.stride_o_accum_h_q;
+  float4 datas[ELEMS_PER_THREAD];
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+    datas[i] = *(float4*)(oaccum_ptr + lane_idx * 4 +
+                          i * 128);  // NOTE We don't use __ldg here since it is incompatible with PDL
+  }
+
+  // Warp #i gathers LseAccum for seq #i
+  {
+    constexpr int NUM_LSE_PER_THREAD = cute::ceil_div(MAX_SPLITS, 32);
+    float local_lse[NUM_LSE_PER_THREAD];
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i) {
+      const int split_idx = i * 32 + lane_idx;
+      local_lse[i] = split_idx < my_num_splits ? gLseAccum(split_idx, warp_idx) : -INFINITY;
+    }
+
+    float max_lse = -INFINITY;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i)
+      max_lse = max(max_lse, local_lse[i]);
+    CUTLASS_PRAGMA_UNROLL
+    for (int offset = 16; offset >= 1; offset /= 2)
+      max_lse = max(max_lse, __shfl_xor_sync(uint32_t(-1), max_lse, offset));
+    max_lse = max_lse == -INFINITY ? 0.0f : max_lse;  // In case all local LSEs are -inf
+
+    float sum_lse = 0;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i)
+      sum_lse = sum_lse + exp2f(local_lse[i] - max_lse);
+    CUTLASS_PRAGMA_UNROLL
+    for (int offset = 16; offset >= 1; offset /= 2)
+      sum_lse = sum_lse + __shfl_xor_sync(uint32_t(-1), sum_lse, offset);
+
+    float global_lse = (sum_lse == 0.f || sum_lse == -INFINITY) ? INFINITY : log2f(sum_lse) + max_lse;
+    if (lane_idx == 0) gLse(warp_idx) = global_lse / (float)M_LOG2E;
+
+    if (params.attn_sink != nullptr) {
+      int q_head_idx = h_block_idx * BLOCK_SIZE_M + warp_idx;
+      float attn_sink = __ldg(params.attn_sink + q_head_idx);
+      if (global_lse != INFINITY) {
+        // If attn_sink is +inf, global_lse will be +inf and scale factors will be exp2f(local_lse - inf) = 0 (since
+        // local_lse never becomes +inf) If attn_sink is -inf, this has no effect on global_lse
+        global_lse += log2f(1 + exp2f(attn_sink * CUDART_L2E_F - global_lse));
+      } else {
+        // We have no tokens to attend, so global lse should be attn_sink*CUDART_L2E_F (+inf if it's -inf or +inf)
+        global_lse = attn_sink == -INFINITY ? +INFINITY : attn_sink * CUDART_L2E_F;
+      }
+    }
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i) {
+      const int split_idx = i * 32 + lane_idx;
+      smem_buf[warp_idx][split_idx] = exp2f(local_lse[i] - global_lse);
+    }
+  }
+
+  __syncwarp();
+
+  // Warp #i accumulates activation for seq #i
+  {
+    float4 result[ELEMS_PER_THREAD];
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < ELEMS_PER_THREAD; ++i)
+      result[i] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+#pragma unroll 1
+    for (int split = 0; split < my_num_splits; ++split) {
+      float lse_scale = smem_buf[warp_idx][split];
+      // if (lse_scale != 0.f) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+        result[i].x += lse_scale * datas[i].x;
+        result[i].y += lse_scale * datas[i].y;
+        result[i].z += lse_scale * datas[i].z;
+        result[i].w += lse_scale * datas[i].w;
+        if (split != my_num_splits - 1) {
+          datas[i] = *(float4*)(oaccum_ptr + (split + 1) * params.stride_o_accum_split + lane_idx * 4 + i * 128);
+        }
+      }
+      // }
+    }
+
+    const int h_q_idx = h_block_idx * BLOCK_SIZE_M + warp_idx;
+    ElementT* o_ptr = (ElementT*)params.out + batch_idx * params.stride_o_b + s_q_idx * params.stride_o_s_q +
+                      h_q_idx * params.stride_o_h_q;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+      float4 data = result[i];
+      ElementT data_converted[4];
+      data_converted[0] = (ElementT)(data.x);
+      data_converted[1] = (ElementT)(data.y);
+      data_converted[2] = (ElementT)(data.z);
+      data_converted[3] = (ElementT)(data.w);
+      static_assert(sizeof(ElementT) == 2);
+      *(uint64_t*)(o_ptr + lane_idx * 4 + i * 128) = *(uint64_t*)data_converted;
+    }
+  }
+}
+
+#define MLA_NUM_SPLITS_SWITCH(NUM_SPLITS, NAME, ...) \
+  [&] {                                              \
+    if (NUM_SPLITS <= 32) {                          \
+      constexpr static int NAME = 32;                \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 64) {                   \
+      constexpr static int NAME = 64;                \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 96) {                   \
+      constexpr static int NAME = 96;                \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 128) {                  \
+      constexpr static int NAME = 128;               \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 160) {                  \
+      constexpr static int NAME = 160;               \
+      return __VA_ARGS__();                          \
+    } else {                                         \
+      FLASH_ASSERT(false);                           \
+    }                                                \
+  }()
+
+template <typename ElementT>
+void run_flash_mla_combine_kernel(CombineParams& params) {
+  static constexpr int HEAD_DIM_V = 512;  // Since only this head dimension is supported by Flash MLA
+  FLASH_ASSERT(params.d_v == HEAD_DIM_V);
+  MLA_NUM_SPLITS_SWITCH(params.num_sm_parts, NUM_SPLITS, [&] {
+    constexpr int BLOCK_SIZE_M = 8;
+    constexpr int NUM_THREADS = BLOCK_SIZE_M * 32;
+    constexpr size_t smem_size = BLOCK_SIZE_M * (NUM_SPLITS + 1) * sizeof(float);
+    auto combine_kernel = &flash_fwd_mla_combine_kernel<ElementT, HEAD_DIM_V, BLOCK_SIZE_M, NUM_SPLITS, NUM_THREADS>;
+    CHECK_CUDA(cudaFuncSetAttribute(combine_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+    // Use cudaLaunchKernelEx to enable PDL (Programmatic Dependent Launch)
+    cudaLaunchAttribute attribute[1];
+    attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attribute[0].val.programmaticStreamSerializationAllowed = 1;
+    cudaLaunchConfig_t combine_kernel_config = {
+        dim3(params.b * params.s_q, 1, ku::ceil_div(params.h_q, BLOCK_SIZE_M)),
+        dim3(NUM_THREADS, 1, 1),
+        0,
+        params.stream,
+        attribute,
+        1};
+    CHECK_CUDA(cudaLaunchKernelEx(&combine_kernel_config, combine_kernel, params));
+  });
+  CHECK_CUDA_KERNEL_LAUNCH();
+}
+
+template void run_flash_mla_combine_kernel<cutlass::bfloat16_t>(CombineParams& params);
+
+#ifndef FLASH_MLA_DISABLE_FP16
+template void run_flash_mla_combine_kernel<cutlass::half_t>(CombineParams& params);
+#endif
+
+}  // namespace smxx::decode

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/components/helpers.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/components/helpers.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "../config.h"
+#include <cooperative_groups.h>
+
+using namespace cute;
+
+namespace sm90::decode::sparse_mxfp4_dsv4 {
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in two particular rows. This
+// function converts the local_row_idx (0~1) to the actual row_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+__forceinline__ __device__ int get_AorC_row_idx(int local_row_idx, int idx_in_warpgroup) {
+  int row_idx = (idx_in_warpgroup / 32) * 16 + local_row_idx * 8 + (idx_in_warpgroup % 32 / 4);
+  return row_idx;
+}
+
+// Adapted from
+// https://github.com/Dao-AILab/flash-attention/blob/cdaf2de6e95cb05400959b5ab984f66e4c7df317/hopper/utils.h
+template <
+    bool zero_init = false,
+    int wg_wait = 0,
+    bool arrive = true,
+    bool commit = true,
+    typename Tensor0,
+    typename Tensor1,
+    typename Tensor2,
+    typename TiledMma>
+__forceinline__ __device__ void gemm(TiledMma& tiled_mma, Tensor0 const& tCrA, Tensor1 const& tCrB, Tensor2& tCrC) {
+  constexpr bool Is_RS = !cute::is_base_of<cute::GMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value;
+  // Need to cast away const on tCrA since warpgroup_fence_operand doesn't take const
+  if constexpr (Is_RS) {
+    cute::warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+  warpgroup_fence_operand(tCrC);
+  if constexpr (arrive) {
+    warpgroup_arrive();
+  }
+  if constexpr (zero_init) {
+    tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+    // Unroll the K mode manually to set scale D to 1
+    CUTLASS_PRAGMA_UNROLL
+    for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+      cute::gemm(tiled_mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tCrC);
+      tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+    }
+  } else {
+    // cute::gemm(tiled_mma, tCrA, tCrB, tCrC);
+    // Unroll the K mode manually to set scale D to 1
+    CUTLASS_PRAGMA_UNROLL
+    for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+      cute::gemm(tiled_mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tCrC);
+      tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+    }
+  }
+  if constexpr (commit) {
+    warpgroup_commit_batch();
+  }
+  if constexpr (wg_wait >= 0) {
+    warpgroup_wait<wg_wait>();
+  }
+  warpgroup_fence_operand(tCrC);
+  if constexpr (Is_RS) {
+    warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+}
+
+template <typename TMA, typename Tensor0, typename Tensor1>
+CUTE_DEVICE void launch_tma_copy(
+    const TMA& tma_copy,
+    const Tensor0& src,
+    Tensor1& dst,
+    transac_bar_t& bar,
+    const cute::TMA::CacheHintSm90& cache_hint = cute::TMA::CacheHintSm90::EVICT_NORMAL,
+    const uint16_t& multicast_mask = 0) {
+  auto thr_tma = tma_copy.get_slice(_0{});
+  cute::copy(
+      tma_copy.with(reinterpret_cast<typename transac_bar_t::ValueType&>(bar), multicast_mask, cache_hint),
+      thr_tma.partition_S(src),
+      thr_tma.partition_D(dst));
+}
+
+template <typename T>
+CUTE_DEVICE static void st_async_128b(void* dst_ptr, const T& data, const transac_bar_t* mbar_ptr) {
+  long2 data_long2 = *reinterpret_cast<const long2*>(&data);
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(mbar_ptr);
+  asm volatile("st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.v2.s64 [%0], {%1, %2}, [%3]; \n"
+               :
+               : "r"(dst_addr), "l"(data_long2.x), "l"(data_long2.y), "r"(mbar_addr));
+}
+
+CUTE_DEVICE
+static void cp_async_bulk_shared_cta_shared_cluster(void* dst_ptr, void* src_ptr, int size, transac_bar_t* mbar_ptr) {
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t src_addr = cute::cast_smem_ptr_to_uint(src_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(mbar_ptr);
+  asm volatile("cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3]; \n"
+               :
+               : "r"(dst_addr), "r"(src_addr), "r"(size), "r"(mbar_addr));
+}
+
+static constexpr int PEER_ADDR_MASK = 16777216;  // peer_addr = my_addr ^ PEER_ADDR_MASK.
+template <typename T>
+CUTE_DEVICE T* get_peer_addr(T* p) {
+  return (T*)((int64_t)(p) ^ PEER_ADDR_MASK);
+}
+
+}  // namespace sm90::decode::sparse_mxfp4_dsv4

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/defines.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/defines.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cutlass/arch/barrier.h>
+#include <cutlass/bfloat16.h>
+
+using bf16 = cutlass::bfloat16_t;
+using fp8 = cutlass::float_e4m3_t;
+using transac_bar_t = cutlass::arch::ClusterTransactionBarrier;
+using cutlass::arch::fence_barrier_init;
+using cutlass::arch::fence_view_async_shared;
+using cutlass::arch::NamedBarrier;
+
+struct int32x8_t {
+  int a0, a1, a2, a3, a4, a5, a6, a7;
+};
+
+struct float8 {
+  float2 a01, a23, a45, a67;
+};
+
+struct bf16x8 {
+  __nv_bfloat162 a01;
+  __nv_bfloat162 a23;
+  __nv_bfloat162 a45;
+  __nv_bfloat162 a67;
+};

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/flashmla_utils.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/flashmla_utils.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "utils.h"

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/common/common.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/common/common.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace kerutils {}
+
+#define KU_PRINTLN(fmt, ...)         \
+  {                                  \
+    cute::print(fmt, ##__VA_ARGS__); \
+    print("\n");                     \
+  }
+
+namespace ku = kerutils;

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/common.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/common.h
@@ -1,0 +1,60 @@
+/*
+Common data types and macros that are used across the kerutils library.
+*/
+#pragma once
+
+#include <cute/config.hpp>  // For CUTE_DEVICE
+#include <cutlass/arch/barrier.h>
+#include <cutlass/bfloat16.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+namespace kerutils {
+
+// Cache hints
+enum class CacheHint { EVICT_FIRST, EVICT_NORMAL, EVICT_LAST, EVICT_UNCHANGED, NO_ALLOCATE };
+
+// Prefetch size
+enum class PrefetchSize { B64, B128, B256 };
+
+using nvbf16 = __nv_bfloat16;
+using nvbf16x2 = __nv_bfloat162;
+using nve4m3 = __nv_fp8_e4m3;
+using nve4m3x2 = __nv_fp8x2_e4m3;
+using nve4m3x4 = __nv_fp8x4_e4m3;
+
+using bf16 = cutlass::bfloat16_t;
+using transac_bar_t = cutlass::arch::ClusterTransactionBarrier;
+
+}  // namespace kerutils
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+#define KERUTILS_ENABLE_SM80
+#elif (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+static_assert(false, "kerutils doesn't support SM architectures below SM80");
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#define KERUTILS_ENABLE_SM90
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000))
+#define KERUTILS_ENABLE_SM90A
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000))
+#define KERUTILS_ENABLE_SM100
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000 && __CUDA_ARCH__ < 1200))
+#define KERUTILS_ENABLE_SM100A
+#endif
+
+#if (defined(__CLION_IDE__) || defined(__VSCODE_IDE__))
+#define KERUTILS_ENABLE_SM80
+#define KERUTILS_ENABLE_SM90
+#define KERUTILS_ENABLE_SM90A
+#define KERUTILS_ENABLE_SM100
+#define KERUTILS_ENABLE_SM100A
+#endif

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/device.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/device.cuh
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "../common/common.h"
+#include "common.h"
+#include "sm80/helpers.cuh"
+#include "sm80/intrinsics.cuh"
+#include "sm90/helpers.cuh"
+#include "sm90/intrinsics.cuh"

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/helpers.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/helpers.cuh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../common.h"
+#include "intrinsics.cuh"
+
+namespace kerutils {
+
+// Retrieve the value of `%smid` and check its range
+CUTE_DEVICE
+uint32_t get_sm_id_with_range_check(uint32_t num_physical_sms) {
+  uint32_t sm_id = get_sm_id();
+  if (!(sm_id < num_physical_sms)) {
+    trap();
+  }
+  return sm_id;
+}
+
+#ifndef KU_TRAP_ONLY_DEVICE_ASSERT
+#define KU_TRAP_ONLY_DEVICE_ASSERT(cond) \
+  do {                                   \
+    if (not(cond)) asm("trap;");         \
+  } while (0)
+#endif
+
+// Construct a `float2` from a single `float` by duplicating the value
+CUTE_DEVICE
+float2 float2float2(const float& x) {
+  return float2{x, x};
+}
+
+CUTE_DEVICE
+void st_shared(void* ptr, __int128_t val) {
+  asm volatile("st.shared.b128 [%0], %1;" ::"l"(__cvta_generic_to_shared(ptr)), "q"(val));
+}
+
+CUTE_DEVICE
+void st_shared(void* ptr, float4 val) {
+  st_shared(ptr, *(__int128_t*)&val);
+}
+
+CUTE_DEVICE
+__int128_t ld_shared(void* ptr) {
+  __int128_t val;
+  asm volatile("ld.shared.b128 %0, [%1];" : "=q"(val) : "l"(__cvta_generic_to_shared(ptr)));
+  return val;
+}
+
+CUTE_DEVICE
+float4 ld_shared_float4(void* ptr) {
+  __int128_t temp = ld_shared(ptr);
+  return *(float4*)&temp;
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/intrinsics.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/intrinsics.cuh
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "../common.h"
+
+namespace kerutils {
+
+// cp.async.cg (cache global) with prefetch and predicate
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async)
+template <PrefetchSize PREFETCH_SIZE = PrefetchSize::B128>
+CUTE_DEVICE void cp_async_cacheglobal(const void* src, void* dst, bool pred = true) {
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst);
+  if constexpr (PREFETCH_SIZE == PrefetchSize::B64) {
+    asm volatile(
+        "cp.async.cg.shared.global.L2::64B [%0], [%1], 16, %2;\n" ::"r"(dst_addr), "l"(src), "r"(pred ? 16 : 0));
+  } else if constexpr (PREFETCH_SIZE == PrefetchSize::B128) {
+    asm volatile(
+        "cp.async.cg.shared.global.L2::128B [%0], [%1], 16, %2;\n" ::"r"(dst_addr), "l"(src), "r"(pred ? 16 : 0));
+  } else if constexpr (PREFETCH_SIZE == PrefetchSize::B256) {
+    asm volatile(
+        "cp.async.cg.shared.global.L2::256B [%0], [%1], 16, %2;\n" ::"r"(dst_addr), "l"(src), "r"(pred ? 16 : 0));
+  } else {
+    static_assert(
+        PREFETCH_SIZE == PrefetchSize::B64 || PREFETCH_SIZE == PrefetchSize::B128 ||
+            PREFETCH_SIZE == PrefetchSize::B256,
+        "Unsupported prefetch size for cp_async_cacheglobal.");
+  }
+}
+
+// Create fraction-based cache policy
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-createpolicy)
+template <CacheHint PRIMARY_PRIORITY, CacheHint SECONDARY_PRIORITY>
+CUTE_DEVICE int64_t create_fraction_based_cache_policy(float fraction = 1.0f) {
+  int64_t result;
+#define EMIT(PRIMARY_PRIORITY_STR, SECONDARY_PRIORITY_STR)                                                         \
+  asm volatile("createpolicy.fractional.L2::" PRIMARY_PRIORITY_STR ".L2::" SECONDARY_PRIORITY_STR ".b64 %0, %1;\n" \
+               : "=l"(result)                                                                                      \
+               : "f"(fraction));
+#define EMIT2(PRIMARY_PRIORITY_STR)                                                                         \
+  {                                                                                                         \
+    if constexpr (SECONDARY_PRIORITY == CacheHint::EVICT_FIRST) {                                           \
+      EMIT(PRIMARY_PRIORITY_STR, "evict_first")                                                             \
+    } else if constexpr (SECONDARY_PRIORITY == CacheHint::EVICT_UNCHANGED) {                                \
+      EMIT(PRIMARY_PRIORITY_STR, "evict_unchanged")                                                         \
+    } else {                                                                                                \
+      static_assert(                                                                                        \
+          SECONDARY_PRIORITY == CacheHint::EVICT_FIRST || SECONDARY_PRIORITY == CacheHint::EVICT_UNCHANGED, \
+          "Unsupported secondary cache hint for create_fraction_based_cache_policy.");                      \
+    }                                                                                                       \
+  }
+  if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_FIRST) {
+    EMIT2("evict_first");
+  } else if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_NORMAL) {
+    EMIT2("evict_normal");
+  } else if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_LAST) {
+    EMIT2("evict_last");
+  } else if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_UNCHANGED) {
+    EMIT2("evict_unchanged");
+  } else {
+    static_assert(
+        PRIMARY_PRIORITY == CacheHint::EVICT_FIRST || PRIMARY_PRIORITY == CacheHint::EVICT_NORMAL ||
+            PRIMARY_PRIORITY == CacheHint::EVICT_LAST || PRIMARY_PRIORITY == CacheHint::EVICT_UNCHANGED,
+        "Unsupported primary cache hint for create_fraction_based_cache_policy.");
+  }
+#undef EMIT
+#undef EMIT2
+  return result;
+}
+
+// Create a simple cache policy (equivalent to create_fraction_based_cache_policy(1.0f))
+// The same as cute::TMA::CacheHintSmXX
+template <CacheHint CACHE_HINT>
+CUTE_DEVICE constexpr int64_t create_simple_cache_policy() {
+  if constexpr (CACHE_HINT == CacheHint::EVICT_FIRST) {
+    return 0x12F0000000000000;  // Result of createpolicy.fractional.L2::evict_first.b64
+  } else if constexpr (CACHE_HINT == CacheHint::EVICT_NORMAL) {
+    return 0x1000000000000000;  // Copied from CuTe. Unsure about the exact meaning. (TODO Change to
+                                // 0x16F0000000000000?)
+  } else if constexpr (CACHE_HINT == CacheHint::EVICT_LAST) {
+    return 0x14F0000000000000;  // Result of createpolicy.fractional.L2::evict_last.b64
+  } else {
+    static_assert(
+        CACHE_HINT == CacheHint::EVICT_FIRST || CACHE_HINT == CacheHint::EVICT_NORMAL ||
+            CACHE_HINT == CacheHint::EVICT_LAST,
+        "Unsupported cache hint for create_simple_cache_policy.");
+  }
+}
+
+// AtomicAdd
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-red)
+CUTE_DEVICE
+void atomicadd_f32_with_policy_and_pred(
+    void* global_addr, const float& data, int64_t cache_policy, uint32_t pred = true) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "setp.eq.u32 p, %3, 1;\n\t"
+      "@p red.relaxed.gpu.global.add.L2::cache_hint.f32 [%1], %0, %2; \n\t"
+      "}"
+      :
+      : "f"(data), "l"((int64_t)global_addr), "l"(cache_policy), "r"(pred));
+}
+
+// Get the id of the current SM
+// About %smid (https://docs.nvidia.com/cuda/parallel-thread-execution/#special-registers-smid): PTX document says that
+// %smid ranges from 0 to %nsmid-1, while "The SM identifier numbering is not guaranteed to be contiguous, so %nsmid may
+// be larger than the physical number of SMs in the device.". However, result shows that, at least for sm90 and sm100f,
+// %nsmid is the number of physical SMs - 1. For the sake of safety, I recommend you to check the return of get_sm_id
+// manually or call `get_sm_id_with_range_check()` defined in `device/sm80/helpers.cuh`. Besides, PTX document also says
+// that this number may change due to preemption, but currently this never happens according to [DATEN GELÖSCHT]
+CUTE_DEVICE
+uint32_t get_sm_id() {
+  uint32_t ret;
+  asm volatile("mov.u32 %0, %%smid;\n" : "=r"(ret));
+  return ret;
+}
+
+// trap (https://docs.nvidia.com/cuda/parallel-thread-execution/#miscellaneous-instructions-trap)
+CUTE_DEVICE
+void trap() {
+  asm volatile("trap;\n");
+}
+
+// LDG.128 or LDG.128 with non-coherent cache
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-ld) We use macro
+// instead of function here, since we need a multi-level recursive dispatch based on template parameters if using
+// function NC_STR should be either "" or ".nc" L1_CACHE_HINT_STR should be either "evict_first", "evict_normal",
+// "evict_last", "evict_unchanged", or "no_allocate" L2_PREFETCH_SIZE_STR should be either "64B", "128B", or "256B" L2
+// cache hint is not supported since it's only supported for LDG.256
+#define KU_LDG_128(global_addr, result, NC_STR, L1_CACHE_HINT_STR, L2_PREFETCH_SIZE_STR)                               \
+  {                                                                                                                    \
+    static_assert(                                                                                                     \
+        std::is_pointer_v<decltype(global_addr)> || std::is_array_v<decltype(global_addr)>,                            \
+        "`global_addr` must be a pointer");                                                                            \
+    static_assert(                                                                                                     \
+        std::is_pointer_v<decltype(result)> || std::is_array_v<decltype(result)>, "`result` must be a pointer");       \
+    uint64_t* result_as_uint64_ptr = (uint64_t*)(result);                                                              \
+    asm volatile("ld.global" NC_STR ".L1::" L1_CACHE_HINT_STR ".L2::" L2_PREFETCH_SIZE_STR ".v2.u64 {%0, %1}, [%2];\n" \
+                 : "=l"(result_as_uint64_ptr[0]), "=l"(result_as_uint64_ptr[1])                                        \
+                 : "l"(global_addr));                                                                                  \
+  }
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/helpers.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/helpers.cuh
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "../common.h"
+
+namespace kerutils {
+
+template <typename TMA, typename Tensor0, typename Tensor1>
+CUTE_DEVICE void launch_tma_copy(
+    const TMA& tma_copy,
+    Tensor0 src,
+    Tensor1 dst,
+    transac_bar_t& bar,
+    const cute::TMA::CacheHintSm90& cache_hint = cute::TMA::CacheHintSm90::EVICT_NORMAL) {
+  auto thr_tma = tma_copy.get_slice(cute::_0{});
+  cute::copy(
+      tma_copy.with(reinterpret_cast<typename transac_bar_t::ValueType&>(bar), 0, cache_hint),
+      thr_tma.partition_S(src),
+      thr_tma.partition_D(dst));
+}
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in two particular rows. This
+// function converts the local_row_idx (0~2) to the actual row_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+CUTE_DEVICE
+int get_AorC_row_idx(int local_row_idx, int idx_in_warpgroup) {
+  int row_idx = (idx_in_warpgroup / 32) * 16 + local_row_idx * 8 + (idx_in_warpgroup % 32 / 4);
+  return row_idx;
+}
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in some rows. This function
+// converts the local_elem_idx to the actual col_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+CUTE_DEVICE
+int get_AorC_col_idx(int local_elem_idx, int idx_in_warpgroup) {
+  int col_idx = 8 * (local_elem_idx / 4) + (idx_in_warpgroup % 4) * 2 + (local_elem_idx & 1);
+  return col_idx;
+}
+
+template <bool commit = true, typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma(TiledMma& tiled_mma, Tensor0 const& tCrA, Tensor1 const& tCrB, Tensor2& tCrC, bool zero_init) {
+  using namespace cute;
+  constexpr bool Is_RS = !cute::is_base_of<cute::GMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value;
+  // Need to cast away const on tCrA since warpgroup_fence_operand doesn't take const
+  if constexpr (Is_RS) {
+    cute::warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+  warpgroup_fence_operand(tCrC);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = zero_init ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  // Unroll the K mode manually to set scale D to 1
+  CUTLASS_PRAGMA_UNROLL
+  for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+    cute::gemm(tiled_mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tCrC);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  if constexpr (commit) {
+    warpgroup_commit_batch();
+  }
+  warpgroup_fence_operand(tCrC);
+  if constexpr (Is_RS) {
+    warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+}
+
+template <typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma_ss(
+    bool clear_accum,
+    TiledMma tiled_mma,
+    Tensor0 const& sA,
+    Tensor1 const& sB,
+    Tensor2& rC_frag,
+    int idx_in_warpgroup) {
+  using namespace cute;
+  ThrMMA thr_mma = tiled_mma.get_slice(idx_in_warpgroup);
+  Tensor sA_frag = thr_mma.partition_fragment_A(sA);
+  Tensor sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(sA_frag) == size<2>(sB_frag));
+
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = clear_accum ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  CUTLASS_PRAGMA_UNROLL
+  for (int k = 0; k < size<2>(sA_frag); ++k) {
+    cute::gemm(tiled_mma, sA_frag(_, _, k), sB_frag(_, _, k), rC_frag);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  warpgroup_fence_operand(rC_frag);
+}
+
+template <typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma_rs(
+    bool clear_accum, TiledMma tiled_mma, Tensor0 rA_frag, Tensor1 const& sB, Tensor2& rC_frag, int idx_in_warpgroup) {
+  using namespace cute;
+  ThrMMA thr_mma = tiled_mma.get_slice(idx_in_warpgroup);
+  Tensor sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(rA_frag) == size<2>(sB_frag));
+
+  warpgroup_fence_operand(const_cast<Tensor0&>(rA_frag));
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = clear_accum ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  CUTLASS_PRAGMA_UNROLL
+  for (int k = 0; k < size<2>(rA_frag); ++k) {
+    cute::gemm(tiled_mma, rA_frag(_, _, k), sB_frag(_, _, k), rC_frag);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_fence_operand(const_cast<Tensor0&>(rA_frag));
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/intrinsics.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/intrinsics.cuh
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "../common.h"
+
+namespace kerutils {
+
+// st.async (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-st-async)
+template <typename T>
+CUTE_DEVICE static void st_async(void* dst_ptr, const T& data, transac_bar_t& mbar) {
+  static_assert(sizeof(T) == 16, "Data type must be 16 bytes (128 bits) for st_async.");
+  long2 data_long2 = *reinterpret_cast<const long2*>(&data);
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(&mbar);
+  asm volatile("st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.v2.s64 [%0], {%1, %2}, [%3]; \n"
+               :
+               : "r"(dst_addr), "l"(data_long2.x), "l"(data_long2.y), "r"(mbar_addr));
+}
+
+static constexpr int PEER_ADDR_MASK = 16777216;
+
+// Given an address in the current CTA, return the corresponding address in the peer CTA
+template <typename T>
+CUTE_DEVICE T* get_peer_addr(const T* p) {
+  return (T*)((int64_t)(p) ^ PEER_ADDR_MASK);
+}
+
+// Given an address in the current CTA, return the corresponding address in the peer CTA (if the current CTA_id%2 == 1)
+// or the address itself (if CTA_id%2 == 0)
+template <typename T>
+CUTE_DEVICE T* get_cta0_addr(const T* p) {
+  constexpr int CTA0_ADDR_MASK = 0xFEFFFFFF;
+  return (T*)((int64_t)(p)&CTA0_ADDR_MASK);
+}
+
+// TMA bulk reduce add (cp.reduce.async.bulk), shared to global, float32, add.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-reduce-async-bulk)
+CUTE_DEVICE
+void tma_bulk_reduce_add(void const* src_ptr, void* dst_ptr, int32_t store_bytes) {
+  uint32_t smem_int_ptr = cute::cast_smem_ptr_to_uint(src_ptr);
+  asm volatile("cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f32 [%0], [%1], %2;\n"
+               :
+               : "l"(dst_ptr), "r"(smem_int_ptr), "r"(store_bytes)
+               : "memory");
+}
+
+// Cluster barrier arrive with .release modifier.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-barrier-cluster)
+CUTE_DEVICE
+void barrier_cluster_arrive_release() {
+  asm volatile("barrier.cluster.arrive.release;" : : : "memory");
+}
+
+// Cluster barrier arrive with .relaxed modifier.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-barrier-cluster)
+CUTE_DEVICE
+void barrier_cluster_arrive_relaxed() {
+  asm volatile("barrier.cluster.arrive.relaxed;" : : :);
+}
+
+// Cluster barrier wait with .acquire modifier.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-barrier-cluster)
+CUTE_DEVICE
+void barrier_cluster_wait_acquire() {
+  asm volatile("barrier.cluster.wait.acquire;" : : : "memory");
+}
+
+// mbarrier.arrive with .relaxed.cluster qualifier
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-arrive)
+CUTE_DEVICE
+void mbarrier_arrive_relaxed_cluster(transac_bar_t& mbar) {
+  uint32_t smem_addr = cute::cast_smem_ptr_to_uint(&mbar);
+  asm volatile(
+      "{\n\t"
+      "mbarrier.arrive.relaxed.cluster.shared::cta.b64 _, [%0];\n\t"
+      "}"
+      :
+      : "r"(smem_addr));
+}
+
+// AtomicAdd with v4.f32 type
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-red)
+CUTE_DEVICE
+void atomicadd_f32x4_with_policy_and_pred(
+    void* global_addr, const float4& data, int64_t cache_policy, uint32_t pred = true) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "setp.eq.u32 p, %6, 1;\n\t"
+      "@p red.relaxed.gpu.global.add.L2::cache_hint.v4.f32 [%4], {%0, %1, %2, %3}, %5; \n\t"
+      "}"
+      :
+      : "f"(data.x), "f"(data.y), "f"(data.z), "f"(data.w), "l"((int64_t)global_addr), "l"(cache_policy), "r"(pred));
+}
+
+// cp.async.bulk, from .shared::cta to .shared::cluster
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async-bulk)
+CUTE_DEVICE
+void cp_async_bulk_shared_cta_to_shared_cluster(
+    void* dst_ptr, const void* src_ptr, int32_t load_bytes, transac_bar_t& mbar) {
+  uint32_t dst_smem_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t src_smem_addr = cute::cast_smem_ptr_to_uint(src_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(&mbar);
+  asm volatile("cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3]; \n"
+               :
+               : "r"(dst_smem_addr), "r"(src_smem_addr), "r"(load_bytes), "r"(mbar_addr));
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/host/host.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/host/host.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <cutlass/cuda_host_adapter.hpp>
+
+#include "../common/common.h"
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <exception>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace kerutils {
+
+class KUException final : public std::exception {
+  std::string message = {};
+
+ public:
+  template <typename... Args>
+  explicit KUException(const char* name, const char* file, const int line, Args&&... args) {
+    std::ostringstream oss;
+
+    oss << name << " error (" << file << ":" << line << "): ";
+    (oss << ... << args);
+    message = oss.str();
+  }
+
+  const char* what() const noexcept override {
+    return message.c_str();
+  }
+};
+
+#define THROW_KU_EXCEPTION(name, ...) throw kerutils::KUException(name, __FILE__, __LINE__, __VA_ARGS__)
+
+#define KU_CUDA_CHECK(call)                                                                         \
+  do {                                                                                              \
+    cudaError_t status_ = call;                                                                     \
+    if (status_ != cudaSuccess) {                                                                   \
+      fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__, cudaGetErrorString(status_)); \
+      THROW_KU_EXCEPTION("CUDA", "CUDA error: ", cudaGetErrorString(status_));                      \
+    }                                                                                               \
+  } while (0)
+
+#define KU_CUTLASS_CHECK(call)                                                                       \
+  do {                                                                                               \
+    cutlass::Status status_ = call;                                                                  \
+    if (status_ != cutlass::Status::kSuccess) {                                                      \
+      fprintf(stderr, "CUTLASS error (%s:%d): %d\n", __FILE__, __LINE__, static_cast<int>(status_)); \
+      THROW_KU_EXCEPTION("CUTLASS", "CUTLASS error: ", static_cast<int>(status_));                   \
+    }                                                                                                \
+  } while (0)
+
+// This `KU_ASSERT` is triggered no matter if the code is compiled with `-DNDEBUG` or not.
+#define KU_ASSERT(cond, ...)                                                         \
+  do {                                                                               \
+    if (not(cond)) {                                                                 \
+      fprintf(stderr, "Assertion `%s` failed (%s:%d): ", #cond, __FILE__, __LINE__); \
+      if constexpr (sizeof(#__VA_ARGS__) > 1) {                                      \
+        fprintf(stderr, ", " __VA_ARGS__);                                           \
+      }                                                                              \
+      fprintf(stderr, "\n");                                                         \
+      THROW_KU_EXCEPTION("Assertion", "Assertion `", #cond, "` failed.");            \
+    }                                                                                \
+  } while (0)
+
+#define KU_CHECK_KERNEL_LAUNCH() KU_CUDA_CHECK(cudaGetLastError())
+
+template <typename T>
+inline __host__ __device__ constexpr T ceil_div(const T& a, const T& b) {
+  return (a + b - 1) / b;
+}
+
+template <typename T>
+inline __host__ __device__ constexpr T ceil(const T& a, const T& b) {
+  return (a + b - 1) / b * b;
+}
+
+// A wrapper for make_tensor_map
+static inline CUtensorMap make_tensor_map(
+    const std::vector<uint64_t>& size,
+    const std::vector<uint64_t>& strides,  // PAY ATTENTION: In BYTES
+    const std::vector<uint32_t>& box_size,
+    void* global_ptr,
+    CUtensorMapDataType data_type,
+    CUtensorMapSwizzle swizzle_mode,
+    CUtensorMapL2promotion l2_promotion,
+    CUtensorMapInterleave interleave_mode = CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+    CUtensorMapFloatOOBfill oob_fill = CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    const std::vector<uint32_t>& element_strides_ = {}) {
+  int dim = size.size();
+  KU_ASSERT(dim >= 1);
+
+  std::vector<uint32_t> element_strides;
+  if (element_strides_.empty()) {
+    for (int i = 0; i < dim; ++i)
+      element_strides.push_back(1);
+  } else {
+    element_strides = element_strides_;
+  }
+  KU_ASSERT(
+      strides.size() == (uint32_t)dim - 1 && box_size.size() == (uint32_t)dim &&
+      element_strides.size() == (uint32_t)dim);
+
+  CUtensorMap result;
+  CUresult ret_code = CUTLASS_CUDA_DRIVER_WRAPPER_CALL(cuTensorMapEncodeTiled)(
+      &result,
+      data_type,
+      dim,
+      global_ptr,
+      size.data(),
+      strides.data(),
+      box_size.data(),
+      element_strides.data(),
+      interleave_mode,
+      swizzle_mode,
+      l2_promotion,
+      oob_fill);
+  if (ret_code != CUresult::CUDA_SUCCESS) {
+    auto print_vector = [&](auto t, const char* fmt, const char end = '\n') {
+      for (auto elem : t) {
+        printf(fmt, elem);
+      }
+      printf("%c", end);
+    };
+    fprintf(stderr, "Failed to create tensormap\n");
+    fprintf(stderr, "Dim: %d\n", dim);
+    printf("size: ");
+    print_vector(size, "%lu ");
+    printf("strides: ");
+    print_vector(strides, "%lu ");
+    printf("box_size: ");
+    print_vector(box_size, "%u ");
+    printf("element_strides: ");
+    print_vector(element_strides, "%u ");
+    printf("global ptr: 0x%lx\n", (int64_t)global_ptr);
+    printf("data_type: %d\n", (int)data_type);
+    printf("swizzle_mode: %d\n", (int)swizzle_mode);
+    printf("l2_promotion: %d\n", (int)l2_promotion);
+    printf("interleave_mode: %d\n", (int)interleave_mode);
+    printf("oob_fill: %d\n", (int)oob_fill);
+    KU_ASSERT(false);
+  }
+  return result;
+}
+
+// Given strides (in number of elements), this function converts their datatype in uint64_t and then multiplies by
+// elem_size
+template <typename T>
+static inline std::vector<uint64_t> make_stride_helper(const std::vector<T>& strides_in_elems, size_t elem_size) {
+  std::vector<uint64_t> res;
+  for (auto stride : strides_in_elems) {
+    res.push_back(((uint64_t)stride) * elem_size);
+  }
+  return res;
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/kerutils.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/kerutils.cuh
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "device/device.cuh"
+#include "host/host.h"

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/params.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/params.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include "cutlass/bfloat16.h"
+
+enum class ModelType { V32, MODEL1 };
+
+struct __align__(4 * 8) DecodingSchedMeta {
+  int begin_req_idx, end_req_idx;      // Both inclusive
+  int begin_block_idx, end_block_idx;  // Inclusive, exclusive
+  int begin_split_idx;
+  int is_first_req_splitted, is_last_req_splitted;
+  int _pad[1];
+};
+static constexpr int DecodingSchedMetaSize = sizeof(DecodingSchedMeta);
+
+struct DenseAttnDecodeParams {  // TODO Change name to DenseAttnDecodeParams
+  using index_t = int64_t;
+
+  int b;  // batch size
+  int s_q;
+  int q_seq_per_hk;   // The number of q(s) per KV head, = h_q / h_k * s_q
+  int d, d_v;         // K/V dimension
+  int h_q, h_k;       // The number of Q/K heads
+  int num_blocks;     // Number of blocks in total
+  int q_head_per_hk;  // The number of q_head(s) per KV head, = h_q / h_k
+  bool is_causal;
+  float scale_softmax, scale_softmax_log2;
+
+  void* __restrict__ q_ptr;
+  void* __restrict__ k_ptr;
+  void* __restrict__ o_ptr;
+  float* __restrict__ softmax_lse_ptr;
+
+  index_t q_batch_stride;
+  index_t k_batch_stride;
+  index_t o_batch_stride;
+  index_t q_row_stride;
+  index_t k_row_stride;
+  index_t o_row_stride;
+  index_t q_head_stride;
+  index_t k_head_stride;
+  index_t o_head_stride;
+
+  int* __restrict__ block_table;
+  index_t block_table_batch_stride;
+  int page_block_size;
+  int* __restrict__ seqlens_k_ptr;
+
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;
+  int num_sm_parts;
+  int* __restrict__ num_splits_ptr;
+
+  int total_num_splits;
+  float* __restrict__ softmax_lseaccum_ptr;
+  float* __restrict__ oaccum_ptr;
+
+  cudaStream_t stream;
+};
+
+struct SparseAttnDecodeParams {
+  int b, s_q;
+  int h_q, h_kv;
+  int d_qk, d_v;
+  float sm_scale, sm_scale_div_log2;
+  int num_blocks, page_block_size, topk;
+  ModelType model_type;
+
+  cutlass::bfloat16_t* __restrict__ q;   // [b, s_q, h_q, d_qk]
+  cutlass::bfloat16_t* __restrict__ kv;  // [num_blocks, page_block_size, d_qk]
+  int* __restrict__ indices;             // [b, s_q, topk]
+  int* __restrict__ topk_length;         // [b], may be nullptr
+  float* __restrict__ attn_sink;         // [h_q], may be nullptr
+
+  float* __restrict__ lse;                // [b, s_q, h_q]
+  cutlass::bfloat16_t* __restrict__ out;  // [b, s_q, h_q, d_v]
+
+  int extra_num_blocks, extra_page_block_size, extra_topk;
+  cutlass::bfloat16_t* __restrict__ extra_kv;  // [extra_num_blocks, extra_page_block_size, d_qk]
+  int* __restrict__ extra_indices;             // [b, s_q, extra_topk]
+  int* __restrict__ extra_topk_length;         // [b], may be nullptr
+
+  int stride_q_b, stride_q_s_q, stride_q_h_q;
+  int stride_kv_block, stride_kv_row;
+  int stride_indices_b, stride_indices_s_q;
+  int stride_lse_b, stride_lse_s_q;
+  int stride_o_b, stride_o_s_q, stride_o_h_q;
+  int stride_extra_kv_block, stride_extra_kv_row;
+  int stride_extra_indices_b, stride_extra_indices_s_q;
+
+  cudaStream_t stream;
+
+  // SplitKV-related parameters
+  float* __restrict__ lse_accum;  // [num_splits, s_q, h_q]
+  float* __restrict__ o_accum;    // [num_splits, s_q, h_q, d_v]
+  int stride_lse_accum_split, stride_lse_accum_s_q;
+  int stride_o_accum_split, stride_o_accum_s_q, stride_o_accum_h_q;
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;  // [num_sm_parts, ], contiguous
+  int* __restrict__ num_splits_ptr;                             // [batch_size+1, ], contiguous
+  int num_sm_parts;
+};
+
+struct CombineParams {
+  int b, s_q, h_q, d_v;
+
+  float* __restrict__ lse;  // [b, s_q, h_q]
+  void* __restrict__ out;   // [b, s_q, h_q, d_v]
+  int stride_lse_b, stride_lse_s_q;
+  int stride_o_b, stride_o_s_q, stride_o_h_q;
+
+  float* __restrict__ lse_accum;  // [num_splits, s_q, h_q]
+  float* __restrict__ o_accum;    // [num_splits, s_q, h_q, d_v]
+  int stride_lse_accum_split, stride_lse_accum_s_q;
+  int stride_o_accum_split, stride_o_accum_s_q, stride_o_accum_h_q;
+
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;  // [num_sm_parts, ], contiguous
+  int* __restrict__ num_splits_ptr;                             // [batch_size+1, ], contiguous
+  int num_sm_parts;
+
+  float* attn_sink;  // [h_q], may be nullptr
+
+  cudaStream_t stream;
+};
+
+struct GetDecodeSchedMetaParams {
+  int b;  // batch size
+  int s_q;
+  int block_size_n;
+  int fixed_overhead_num_blocks;
+
+  int topk, extra_topk;  // -1 if sparse attention (or extra topk) is disabled
+  int* __restrict__ topk_length, * __restrict__ extra_topk_length;
+
+  int* __restrict__ seqlens_k_ptr;  // Only necessary for dense attention
+
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;
+  int* __restrict__ num_splits_ptr;
+  int num_sm_parts;
+
+  cudaStream_t stream;
+};
+
+struct SparseAttnFwdParams {
+  int s_q, s_kv, h_q, h_kv, d_qk, d_v, topk;
+  float sm_scale, sm_scale_div_log2;
+
+  // Input tensors
+  cutlass::bfloat16_t* __restrict__ q;   // [s_q, h_q, d_qk]
+  cutlass::bfloat16_t* __restrict__ kv;  // [s_kv, h_kv, d_qk]
+  int* __restrict__ indices;             // [s_q, h_kv, topk]
+  float* __restrict__ attn_sink;         // [h_q], may be nullptr
+  int* __restrict__ topk_length;         // [s_q], may be nullptr
+
+  // Strides
+  int stride_q_s_q;
+  int stride_q_h_q;
+  int stride_kv_s_kv;
+  int stride_kv_h_kv;
+  int stride_indices_s_q;
+  int stride_indices_h_kv;
+
+  // Output tensors
+  cutlass::bfloat16_t* __restrict__ out;  // [s_q, h_q, d_v]
+  float* __restrict__ max_logits;         // [s_q, h_q]
+  float* __restrict__ lse;                // [s_q, h_q]
+
+  int num_sm;
+  cudaStream_t stream;
+};
+
+// We have some kernels that implement both prefill and decode modes in a single kernel (with different template
+// instantiations). The following enum helps to distinguish the modes.
+enum class SparseAttnFwdMode {
+  Prefill,            // Normal prefill mode
+  DecodeWithSplitKV,  // To trigger decoding mode for kernels that support both prefill and decode
+};
+
+template <SparseAttnFwdMode FWD_MODE>
+inline constexpr bool is_decode_v = std::bool_constant<FWD_MODE == SparseAttnFwdMode::DecodeWithSplitKV>::value;
+
+template <SparseAttnFwdMode FWD_MODE>
+using SparseFwdArgT = std::conditional_t<is_decode_v<FWD_MODE>, SparseAttnDecodeParams, SparseAttnFwdParams>;

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/utils.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/utils.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstdint>
+
+#define CHECK_CUDA(call)                                                                            \
+  do {                                                                                              \
+    cudaError_t status_ = call;                                                                     \
+    if (status_ != cudaSuccess) {                                                                   \
+      fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__, cudaGetErrorString(status_)); \
+      exit(1);                                                                                      \
+    }                                                                                               \
+  } while (0)
+
+#define CHECK_CUDA_KERNEL_LAUNCH() CHECK_CUDA(cudaGetLastError())
+
+#define FLASH_ASSERT(cond)                                                          \
+  do {                                                                              \
+    if (not(cond)) {                                                                \
+      fprintf(stderr, "Assertion failed (%s:%d): %s\n", __FILE__, __LINE__, #cond); \
+      exit(1);                                                                      \
+    }                                                                               \
+  } while (0)
+
+#define FLASH_DEVICE_ASSERT(cond)                                          \
+  do {                                                                     \
+    if (not(cond)) {                                                       \
+      printf("Assertion failed (%s:%d): %s\n", __FILE__, __LINE__, #cond); \
+      asm("trap;");                                                        \
+    }                                                                      \
+  } while (0)
+
+#define println(fmt, ...)      \
+  {                            \
+    print(fmt, ##__VA_ARGS__); \
+    print("\n");               \
+  }
+
+template <typename T>
+__inline__ __host__ __device__ T ceil_div(const T& a, const T& b) {
+  return (a + b - 1) / b;
+}
+
+#ifndef TRAP_ONLY_DEVICE_ASSERT
+#define TRAP_ONLY_DEVICE_ASSERT(cond) \
+  do {                                \
+    if (not(cond)) asm("trap;");      \
+  } while (0)
+#endif
+
+#ifndef TRAP_ONLY_DEVICE_ASSERT
+#define TRAP_ONLY_DEVICE_ASSERT(cond) \
+  do {                                \
+    if (not(cond)) asm("trap;");      \
+  } while (0)
+#endif
+
+struct RingBufferState {
+  uint32_t cur_block_idx = 0u;
+
+  __device__ __forceinline__ void update() {
+    cur_block_idx += 1;
+  }
+
+  template <uint32_t NUM_STAGES>
+  __device__ __forceinline__ std::pair<uint32_t, bool> get() const {
+    uint32_t stage_idx = cur_block_idx % NUM_STAGES;
+    bool phase = (cur_block_idx / NUM_STAGES) & 1;
+    return {stage_idx, phase};
+  }
+
+  __device__ __forceinline__ RingBufferState offset_by(const int offset) const {
+    // Must guarantee no underflow
+    uint32_t new_block_idx = static_cast<uint32_t>(static_cast<int>(cur_block_idx) + offset);
+    RingBufferState new_state;
+    new_state.cur_block_idx = new_block_idx;
+    return new_state;
+  }
+};

--- a/python/sglang/kernels/ops/attention/dsv4/mxfp4_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsv4/mxfp4_k_cache.py
@@ -1,0 +1,628 @@
+"""MXFP4 codec for DeepSeek V4 attention KV entries.
+
+Each token occupies one 368-byte row::
+
+    [224 B packed E2M1 | 14 B E8M0 + 2 B pad | 128 B BF16 RoPE]
+
+Only the 448-dimensional nope vector is quantized (block-32, E8M0 scale).
+The 64-dimensional RoPE vector stays in bfloat16.  E8M0 covers the full
+FP range (2⁻¹²⁷ to 2¹²⁷) without a separate global scale, so the API is
+simpler than the NVFP4 codec.
+
+Decode consumes the layout directly via the fused JIT CUDA kernel.
+Sparse prefill dequantizes selected entries to BF16 on the fly.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MXFP4_GROUP_SIZE = 32
+MXFP4_NOPE_DIM = 448
+MXFP4_ROPE_DIM = 64
+MXFP4_TOTAL_DIM = MXFP4_NOPE_DIM + MXFP4_ROPE_DIM  # 512
+MXFP4_NUM_GROUPS = MXFP4_NOPE_DIM // MXFP4_GROUP_SIZE  # 14
+MXFP4_PACKED_NOPE_BYTES = MXFP4_NOPE_DIM // 2  # 224
+MXFP4_SCALE_BYTES = MXFP4_NUM_GROUPS + 2  # 16 (14 + 2 pad)
+MXFP4_ROPE_BYTES = MXFP4_ROPE_DIM * 2  # 128
+MXFP4_BYTES_PER_TOKEN = (
+    MXFP4_PACKED_NOPE_BYTES + MXFP4_SCALE_BYTES + MXFP4_ROPE_BYTES
+)  # 368
+
+_E2M1_MAX = 6.0
+
+# Triton requires tl.arange ranges to be powers of two; we always use
+# power-of-two tile sizes and mask to the actual group count (14).
+_MAX_GROUPS = 16  # next power of two >= 14
+_NOPE_TILE = 512  # next power of two >= 448, used for output masking
+
+# Launch config: one CTA owns a complete token row for small batches;
+# split across 2 CTAs for large prefill workloads.
+_QUANTIZE_SMALL_BATCH_THRESHOLD = 64
+_QUANTIZE_SMALL_GROUPS_PER_PROGRAM = 16  # one CTA per token (16 ≥ 14)
+_QUANTIZE_SMALL_NUM_WARPS = 4
+_QUANTIZE_LARGE_GROUPS_PER_PROGRAM = 8  # two CTAs per token
+_QUANTIZE_LARGE_NUM_WARPS = 2
+
+
+def _quantize_launch_config(num_tokens: int) -> tuple[int, int]:
+    if num_tokens <= _QUANTIZE_SMALL_BATCH_THRESHOLD:
+        return _QUANTIZE_SMALL_GROUPS_PER_PROGRAM, _QUANTIZE_SMALL_NUM_WARPS
+    return _QUANTIZE_LARGE_GROUPS_PER_PROGRAM, _QUANTIZE_LARGE_NUM_WARPS
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers (following PR #31269 NVFP4 pattern)
+# ---------------------------------------------------------------------------
+
+
+def _as_feature_matrix(x: torch.Tensor, dim: int, name: str) -> torch.Tensor:
+    if x.ndim == 3 and x.shape[1] == 1:
+        x = x[:, 0, :]
+    if x.ndim != 2 or x.shape[1] != dim:
+        raise ValueError(
+            f"{name} must have shape [num_tokens, {dim}] or "
+            f"[num_tokens, 1, {dim}], got {tuple(x.shape)}"
+        )
+    if x.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise TypeError(f"{name} must use bfloat16, float16, or float32, got {x.dtype}")
+    if x.stride(1) != 1:
+        x = x.contiguous()
+    return x
+
+
+def _as_rows(kv_buffer: torch.Tensor, page_size: int) -> torch.Tensor:
+    if kv_buffer.dtype != torch.uint8:
+        raise TypeError(f"MXFP4 buffer must be uint8, got {kv_buffer.dtype}")
+    if kv_buffer.ndim != 2:
+        raise ValueError(
+            f"MXFP4 buffer must be [num_pages, bytes_per_page], "
+            f"got {tuple(kv_buffer.shape)}"
+        )
+    expected = page_size * MXFP4_BYTES_PER_TOKEN
+    if kv_buffer.shape[1] != expected:
+        raise ValueError(
+            f"MXFP4 page must contain {expected} bytes, " f"got {kv_buffer.shape[1]}"
+        )
+    if not kv_buffer.is_contiguous():
+        raise ValueError("MXFP4 buffer must be contiguous")
+    return kv_buffer.view(-1, MXFP4_BYTES_PER_TOKEN)
+
+
+def _validate_loc(loc: torch.Tensor, rows: torch.Tensor) -> torch.Tensor:
+    loc = loc.reshape(-1)
+    if loc.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"loc must be int32 or int64, got {loc.dtype}")
+    if loc.device != rows.device:
+        raise ValueError("loc and KV buffer must be on one device")
+    return loc.contiguous()
+
+
+def _split_k(cache_k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if cache_k.ndim == 3 and cache_k.shape[1] == 1:
+        cache_k = cache_k[:, 0, :]
+    if cache_k.ndim != 2 or cache_k.shape[1] != MXFP4_TOTAL_DIM:
+        raise ValueError(
+            "cache_k must be [num_tokens, 512] or [num_tokens, 1, 512], "
+            f"got {tuple(cache_k.shape)}"
+        )
+    return (
+        _as_feature_matrix(cache_k[:, :MXFP4_NOPE_DIM], MXFP4_NOPE_DIM, "k_nope"),
+        _as_feature_matrix(cache_k[:, MXFP4_NOPE_DIM:], MXFP4_ROPE_DIM, "k_rope"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# E2M1 helpers
+# ---------------------------------------------------------------------------
+
+_E2M1_LUT = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def _e2m1_rne_scaled_torch(x: torch.Tensor, denominator: torch.Tensor) -> torch.Tensor:
+    """E2M1 RNE encoding using scaled-midpoint comparisons (no division).
+
+    Compares original magnitudes against midpoints derived from the stored
+    scale to avoid reciprocal-induced FP32 ulp drift.
+    """
+    magnitude = x.abs()
+    code = (
+        (magnitude > denominator * 0.25).to(torch.uint8)
+        + (magnitude >= denominator * 0.75).to(torch.uint8)
+        + (magnitude > denominator * 1.25).to(torch.uint8)
+        + (magnitude >= denominator * 1.75).to(torch.uint8)
+        + (magnitude > denominator * 2.5).to(torch.uint8)
+        + (magnitude >= denominator * 3.5).to(torch.uint8)
+        + (magnitude > denominator * 5.0).to(torch.uint8)
+    )
+    return code | (torch.signbit(x).to(torch.uint8) << 3)
+
+
+def _decode_e2m1_torch(code: torch.Tensor) -> torch.Tensor:
+    return _E2M1_LUT.to(code.device)[code.long()]
+
+
+# ---------------------------------------------------------------------------
+# Triton helper: E2M1 RNE (scaled-midpoint, no division)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _e2m1_rne_scaled_triton(x, denominator):
+    magnitude = tl.abs(x)
+    code = (
+        (magnitude > denominator * 0.25).to(tl.uint8)
+        + (magnitude >= denominator * 0.75).to(tl.uint8)
+        + (magnitude > denominator * 1.25).to(tl.uint8)
+        + (magnitude >= denominator * 1.75).to(tl.uint8)
+        + (magnitude > denominator * 2.5).to(tl.uint8)
+        + (magnitude >= denominator * 3.5).to(tl.uint8)
+        + (magnitude > denominator * 5.0).to(tl.uint8)
+    )
+    sign = ((x.to(tl.uint32, bitcast=True) >> 31).to(tl.uint8)) << 3
+    return (code | sign).to(tl.uint8)
+
+
+@triton.jit
+def _decode_e2m1_triton(code):
+    magnitude_code = code & 0x07
+    magnitude = tl.where(
+        magnitude_code == 0,
+        0.0,
+        tl.where(
+            magnitude_code == 1,
+            0.5,
+            tl.where(
+                magnitude_code == 2,
+                1.0,
+                tl.where(
+                    magnitude_code == 3,
+                    1.5,
+                    tl.where(
+                        magnitude_code == 4,
+                        2.0,
+                        tl.where(
+                            magnitude_code == 5,
+                            3.0,
+                            tl.where(magnitude_code == 6, 4.0, 6.0),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    return tl.where((code & 0x08) != 0, -magnitude, magnitude)
+
+
+# ---------------------------------------------------------------------------
+# Triton quantize kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _quantize_mxfp4_k_cache_into_kernel(
+    k_nope_ptr,
+    k_rope_ptr,
+    packed_out_ptr,
+    scale_out_ptr,
+    rope_out_ptr,
+    loc_ptr,
+    num_rows,
+    k_nope_stride_0: tl.constexpr,
+    k_rope_stride_0: tl.constexpr,
+    packed_out_stride_0: tl.constexpr,
+    scale_out_stride_0: tl.constexpr,
+    rope_out_stride_0: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    GROUPS_PER_PROGRAM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    part_id = tl.program_id(1)
+    dst_row = tl.load(loc_ptr + token_id).to(tl.int64)
+    valid_dst = (dst_row >= 0) & (dst_row < num_rows)
+    safe_row = tl.where(valid_dst, dst_row, 0)
+
+    group_start = part_id * GROUPS_PER_PROGRAM
+    # tl.arange demands a power-of-two range; GROUPS_PER_PROGRAM ∈ {8, 16}.
+    group_ids = group_start + tl.arange(0, GROUPS_PER_PROGRAM)  # [GROUPS_PER_PROGRAM]
+    valid_group = group_ids < NUM_GROUPS
+    elem_ids = tl.arange(0, GROUP_SIZE)  # [32]  ← power of two
+
+    # Load [GROUPS_PER_PROGRAM, 32] elements of k_nope
+    input_offsets = group_ids[:, None] * GROUP_SIZE + elem_ids[None, :]
+    x = tl.load(
+        k_nope_ptr + token_id * k_nope_stride_0 + input_offsets,
+        mask=valid_dst & valid_group[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    # E8M0 scale: byte = ceil(log2(amax / 6)) + 127.  ceil (the MX-format
+    # convention, cf. the NVFP4 paths) guarantees the group amax stays
+    # representable: the largest E2M1 code is 6, so scale = 2^round(log2
+    # ratio) clamps every element of groups whose amax lands in
+    # (6·2^k, 6·2^k·√2] — up to 29% off the max element.
+    amax = tl.max(tl.abs(x), axis=1)
+    log2_ratio = tl.math.log2(tl.maximum(amax, 1e-40)) - 2.584962500721156  # log₂6
+    scale_byte_raw = tl.math.ceil(log2_ratio).to(tl.int32) + 127
+    # tl.clamp(·, 0, 255) on int32 is unsupported; use min/max.  255 is the
+    # reserved NaN encoding and is unreachable for finite inputs, but clamp
+    # below it anyway so a stray byte can never decode as NaN.
+    scale_byte = tl.minimum(tl.maximum(scale_byte_raw, 0), 254).to(tl.uint8)
+
+    # E2M1 RNE: compare original values against scaled midpoints (no division).
+    # Build 2^(byte-127) from the FP32 exponent bits instead of exp2, for the
+    # same reason as the dequant kernel below: byte 0 is 2^-127, a subnormal,
+    # and ex2.approx flushes it to zero.  A zero denominator flips the RNE
+    # ladder's `magnitude >= denominator * midpoint` rungs at magnitude 0 and
+    # encodes an all-zero block as E2M1 code 3 instead of code 0.
+    sb = scale_byte.to(tl.int32)
+    scale_normal = (tl.where(sb == 0, 1, sb) << 23).to(tl.float32, bitcast=True)
+    scale_float = tl.where(sb == 0, scale_normal * 0.5, scale_normal)
+    denominator = tl.expand_dims(scale_float, 1)
+    codes = _e2m1_rne_scaled_triton(x, denominator)  # [GROUPS_PER_PROGRAM, 32] uint8
+
+    # Pack nibbles: two adjacent E2M1 codes → one byte
+    codes_2d = tl.reshape(codes, (GROUPS_PER_PROGRAM, GROUP_SIZE // 2, 2))
+    low, high = tl.split(codes_2d)  # each [GROUPS_PER_PROGRAM, 16]
+    packed = low | (high << 4)
+
+    # Store packed nope: [GROUPS_PER_PROGRAM, 16] bytes per token
+    byte_ids = tl.arange(0, GROUP_SIZE // 2)  # [16]
+    packed_offsets = group_ids[:, None] * (GROUP_SIZE // 2) + byte_ids[None, :]
+    tl.store(
+        packed_out_ptr + safe_row * packed_out_stride_0 + packed_offsets,
+        packed,
+        mask=valid_dst & valid_group[:, None],
+    )
+    tl.store(
+        scale_out_ptr + safe_row * scale_out_stride_0 + group_ids,
+        scale_byte,
+        mask=valid_dst & valid_group,
+    )
+
+    # RoPE: written once by the last part
+    num_parts = tl.cdiv(NUM_GROUPS, GROUPS_PER_PROGRAM)
+    if part_id == num_parts - 1:
+        rope_offsets = tl.arange(0, ROPE_DIM)  # [64]  ← power of two
+        rope = tl.load(
+            k_rope_ptr + token_id * k_rope_stride_0 + rope_offsets,
+            mask=valid_dst,
+            other=0.0,
+        )
+        tl.store(
+            rope_out_ptr + safe_row * rope_out_stride_0 + rope_offsets,
+            rope,
+            mask=valid_dst,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Triton dequant kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _dequantize_mxfp4_k_cache_paged_kernel(
+    packed_ptr,
+    scale_ptr,
+    rope_ptr,
+    token_indices_ptr,
+    output_ptr,
+    num_rows,
+    packed_stride_0: tl.constexpr,
+    scale_stride_0: tl.constexpr,
+    rope_stride_0: tl.constexpr,
+    output_stride_0: tl.constexpr,
+    MAX_GROUPS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    NOPE_TILE: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    src_row = tl.load(token_indices_ptr + token_id).to(tl.int64)
+    valid_src = (src_row >= 0) & (src_row < num_rows)
+
+    # Load packed nope as [MAX_GROUPS, GROUP_SIZE//2] bytes.
+    # MAX_GROUPS = 16 ≥ the real 14 groups; the extra 2 groups land in the
+    # scale / rope region and are masked away after decode.
+    group_ids = tl.arange(0, MAX_GROUPS)[:, None]  # [16, 1]  ← power of two
+    byte_ids = tl.arange(0, GROUP_SIZE // 2)[None, :]  # [1, 16]  ← power of two
+    packed_offsets = group_ids * (GROUP_SIZE // 2) + byte_ids  # [16, 16]
+    packed = tl.load(
+        packed_ptr + src_row * packed_stride_0 + packed_offsets,
+        mask=valid_src,
+        other=0,
+    ).to(tl.uint8)
+
+    # Load scales: [MAX_GROUPS] with mask, last 2 are padding
+    scale_offsets = tl.arange(0, MAX_GROUPS)  # [16]  ← power of two
+    scale_byte = tl.load(
+        scale_ptr + src_row * scale_stride_0 + scale_offsets,
+        mask=valid_src & (scale_offsets < NOPE_DIM // GROUP_SIZE),
+        other=127,  # scale = 2^(127-127) = 1.0 (harmless for masked groups)
+    ).to(tl.uint8)
+    # E8M0 bytes 0..254 are 2^-127..2^127 (no zero encoding; 255 is the
+    # reserved NaN).  Build the value from the FP32 exponent pattern instead
+    # of exp2: 2^-127 lies below the normal range and ex2.approx flushes the
+    # denormal to zero.  Byte 0 is built from the 2^-126 pattern halved.
+    sb = scale_byte.to(tl.int32)
+    scale_normal = (tl.where(sb == 0, 1, sb) << 23).to(tl.float32, bitcast=True)
+    scale = tl.where(sb == 0, scale_normal * 0.5, scale_normal)
+
+    # Unpack nibbles → decode E2M1 → apply scale
+    low = _decode_e2m1_triton(packed & 0x0F) * scale[:, None]  # [16, 16]
+    high = _decode_e2m1_triton(packed >> 4) * scale[:, None]  # [16, 16]
+    nope_all = tl.reshape(tl.join(low, high), (NOPE_TILE,))  # [512]
+
+    # Store nope: NOPE_TILE=512 ≥ NOPE_DIM=448; mask trims to the real dim.
+    # Invalid rows are written as zeros so out-of-range indices cannot leak
+    # stale or uninitialized memory into the output (the API guarantees zero
+    # rows for them).
+    nope_offsets = tl.arange(0, NOPE_TILE)  # [512]  ← power of two
+    tl.store(
+        output_ptr + token_id * output_stride_0 + nope_offsets,
+        tl.where(valid_src, nope_all, 0.0),
+        mask=nope_offsets < NOPE_DIM,
+    )
+
+    # RoPE: ROPE_DIM=64 is a power of two, no masking needed
+    rope_offsets = tl.arange(0, ROPE_DIM)
+    rope = tl.load(
+        rope_ptr + src_row * rope_stride_0 + rope_offsets,
+        mask=valid_src,
+        other=0.0,
+    )
+    tl.store(
+        output_ptr + token_id * output_stride_0 + NOPE_DIM + rope_offsets,
+        tl.where(valid_src, rope, 0.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PyTorch reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _quantize_mxfp4_reference(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    packed_rows: torch.Tensor,
+    scale_rows: torch.Tensor,
+    rope_rows: torch.Tensor,
+    loc: torch.Tensor,
+) -> None:
+    """CPU reference: quantize + scatter into destination views."""
+    blocks = k_nope.float().reshape(-1, MXFP4_NUM_GROUPS, MXFP4_GROUP_SIZE)
+    amax = blocks.abs().amax(dim=-1)  # [N, 14]
+    log2_ratio = torch.log2(amax.clamp(min=1e-40)) - 2.584962500721156
+    # ceil matches the Triton kernel and the MX convention (never saturate
+    # the group amax); 255 is the reserved NaN encoding.
+    scale_byte = (torch.ceil(log2_ratio).long() + 127).clamp(0, 254).to(torch.uint8)
+    scale_float = torch.pow(2.0, (scale_byte.float() - 127.0))
+    denominator = scale_float.unsqueeze(-1)
+    codes = _e2m1_rne_scaled_torch(blocks, denominator).reshape(-1, MXFP4_NOPE_DIM)
+    packed = codes[:, 0::2] | (codes[:, 1::2] << 4)
+
+    valid = (loc >= 0) & (loc < packed_rows.shape[0])
+    if bool(valid.any()):
+        dst = loc[valid].long()
+        packed_rows[dst] = packed[valid]
+        scale_rows[dst, :MXFP4_NUM_GROUPS] = scale_byte[valid]
+        rope_rows[dst] = k_rope[valid].to(torch.bfloat16)
+
+
+def _dequantize_mxfp4_reference(
+    packed_rows: torch.Tensor,
+    scale_rows: torch.Tensor,
+    rope_rows: torch.Tensor,
+    token_indices: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    """CPU reference: gather + dequantize."""
+    out.zero_()
+    valid = (token_indices >= 0) & (token_indices < packed_rows.shape[0])
+    if not bool(valid.any()):
+        return
+
+    selected_packed = packed_rows[token_indices[valid].long()]  # [V, 224]
+    codes = torch.zeros(
+        selected_packed.shape[0],
+        MXFP4_NOPE_DIM,
+        dtype=torch.uint8,
+        device=selected_packed.device,
+    )
+    codes[:, 0::2] = selected_packed & 0x0F
+    codes[:, 1::2] = selected_packed >> 4
+
+    selected_scales = scale_rows[
+        token_indices[valid].long(), :MXFP4_NUM_GROUPS
+    ].float()  # [V, 14]
+    scale = torch.pow(2.0, selected_scales - 127.0)
+
+    nope = (
+        _decode_e2m1_torch(codes).reshape(-1, MXFP4_NUM_GROUPS, MXFP4_GROUP_SIZE)
+        * scale.unsqueeze(-1)
+    ).reshape(-1, MXFP4_NOPE_DIM)
+
+    rope = rope_rows[token_indices[valid].long()].to(torch.bfloat16)
+    out[valid, 0, :MXFP4_NOPE_DIM] = nope.to(torch.bfloat16)
+    out[valid, 0, MXFP4_NOPE_DIM:] = rope
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def quantize_dsv4_mxfp4_k_cache_into(
+    cache_k: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    loc: torch.Tensor,
+    page_size: int,
+) -> None:
+    """Quantize BF16/FP16/FP32 DSV4 keys → MXFP4 and scatter by token ID.
+
+    Args:
+        cache_k:  [num_tokens, 512] or [num_tokens, 1, 512] — input K (nope+rope).
+        kv_buffer: [num_pages, page_size * 368] uint8 — destination pool.
+        loc:       [num_tokens] int32/int64 — flat row index per token.
+        page_size: tokens per page (typically 128 or 256).
+    """
+    k_nope, k_rope = _split_k(cache_k)
+    rows = _as_rows(kv_buffer, page_size)
+    loc = _validate_loc(loc, rows)
+    if k_nope.shape[0] != loc.numel():
+        raise ValueError(
+            f"cache_k and loc token counts differ: "
+            f"{k_nope.shape[0]} vs {loc.numel()}"
+        )
+    if not (k_nope.device == k_rope.device == rows.device):
+        raise ValueError("cache_k and KV buffer must be on one device")
+    if loc.numel() == 0:
+        return
+
+    packed_rows = rows[:, :MXFP4_PACKED_NOPE_BYTES]
+    scale_rows = rows[
+        :,
+        MXFP4_PACKED_NOPE_BYTES : MXFP4_PACKED_NOPE_BYTES + MXFP4_SCALE_BYTES,
+    ]
+    rope_rows = rows[:, -MXFP4_ROPE_BYTES:].view(torch.bfloat16)
+
+    if rows.is_cuda:
+        groups_per_program, num_warps = _quantize_launch_config(loc.numel())
+        num_parts = triton.cdiv(MXFP4_NUM_GROUPS, groups_per_program)
+        _quantize_mxfp4_k_cache_into_kernel[(loc.numel(), num_parts)](
+            k_nope,
+            k_rope,
+            packed_rows,
+            scale_rows,
+            rope_rows,
+            loc,
+            rows.shape[0],
+            k_nope.stride(0),
+            k_rope.stride(0),
+            packed_rows.stride(0),
+            scale_rows.stride(0),
+            rope_rows.stride(0),
+            NUM_GROUPS=MXFP4_NUM_GROUPS,
+            GROUP_SIZE=MXFP4_GROUP_SIZE,
+            GROUPS_PER_PROGRAM=groups_per_program,
+            ROPE_DIM=MXFP4_ROPE_DIM,
+            num_warps=num_warps,
+        )
+    else:
+        _quantize_mxfp4_reference(
+            k_nope, k_rope, packed_rows, scale_rows, rope_rows, loc
+        )
+
+
+def dequantize_dsv4_mxfp4_k_cache_paged(
+    kv_buffer: torch.Tensor,
+    token_indices: torch.Tensor,
+    page_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Gather and dequantize selected MXFP4 cache rows → BF16.
+
+    Args:
+        kv_buffer:     [num_pages, page_size * 368] uint8.
+        token_indices: [num_tokens] int32/int64 — flat row indices to gather.
+        page_size:     tokens per page.
+        out:           optional [num_tokens, 1, 512] BF16 output tensor.
+
+    Returns:
+        [num_tokens, 1, 512] BF16 tensor.
+    """
+    rows = _as_rows(kv_buffer, page_size)
+    token_indices = _validate_loc(token_indices, rows)
+    shape = (token_indices.numel(), 1, MXFP4_TOTAL_DIM)
+    if out is None:
+        out = torch.empty(shape, dtype=torch.bfloat16, device=rows.device)
+    elif out.shape != shape or out.dtype != torch.bfloat16:
+        raise ValueError(
+            f"out must be BF16 with shape {shape}, got {out.dtype} {tuple(out.shape)}"
+        )
+    elif out.device != rows.device or not out.is_contiguous():
+        raise ValueError("out and KV buffer must be contiguous and on one device")
+    if token_indices.numel() == 0:
+        return out
+
+    packed_rows = rows[:, :MXFP4_PACKED_NOPE_BYTES]
+    scale_rows = rows[
+        :,
+        MXFP4_PACKED_NOPE_BYTES : MXFP4_PACKED_NOPE_BYTES + MXFP4_SCALE_BYTES,
+    ]
+    rope_rows = rows[:, -MXFP4_ROPE_BYTES:].view(torch.bfloat16)
+
+    if rows.is_cuda:
+        output_2d = out.view(-1, MXFP4_TOTAL_DIM)
+        _dequantize_mxfp4_k_cache_paged_kernel[(token_indices.numel(),)](
+            packed_rows,
+            scale_rows,
+            rope_rows,
+            token_indices,
+            output_2d,
+            rows.shape[0],
+            packed_rows.stride(0),
+            scale_rows.stride(0),
+            rope_rows.stride(0),
+            output_2d.stride(0),
+            MAX_GROUPS=_MAX_GROUPS,
+            GROUP_SIZE=MXFP4_GROUP_SIZE,
+            NOPE_DIM=MXFP4_NOPE_DIM,
+            NOPE_TILE=_NOPE_TILE,
+            ROPE_DIM=MXFP4_ROPE_DIM,
+            num_warps=4,
+        )
+    else:
+        _dequantize_mxfp4_reference(
+            packed_rows, scale_rows, rope_rows, token_indices, out
+        )
+
+    return out
+
+
+__all__ = [
+    "MXFP4_BYTES_PER_TOKEN",
+    "MXFP4_NOPE_DIM",
+    "MXFP4_ROPE_DIM",
+    "MXFP4_TOTAL_DIM",
+    "MXFP4_GROUP_SIZE",
+    "MXFP4_NUM_GROUPS",
+    "MXFP4_PACKED_NOPE_BYTES",
+    "MXFP4_SCALE_BYTES",
+    "MXFP4_ROPE_BYTES",
+    "quantize_dsv4_mxfp4_k_cache_into",
+    "dequantize_dsv4_mxfp4_k_cache_paged",
+]

--- a/test/registered/kernels/ops/attention/test_mxfp4_k_cache.py
+++ b/test/registered/kernels/ops/attention/test_mxfp4_k_cache.py
@@ -1,0 +1,294 @@
+"""MXFP4 codec (quantize / dequant) correctness.
+
+Verifies:
+  1. Triton kernel roundtrip quality (E2M1 is lossy, cos ≈ 0.99)
+  2. Triton matches the PyTorch reference (E8M0 rounding may differ slightly)
+  3. Empty batches, out-of-range indices, boundary cases
+  4. Pre-allocated output buffer reuse
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.mxfp4_k_cache import (
+    MXFP4_BYTES_PER_TOKEN,
+    MXFP4_GROUP_SIZE,
+    MXFP4_NOPE_DIM,
+    MXFP4_NUM_GROUPS,
+    MXFP4_TOTAL_DIM,
+    dequantize_dsv4_mxfp4_k_cache_paged,
+    quantize_dsv4_mxfp4_k_cache_into,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+# Tolerance: E2M1 (4-bit) roundtrip typically gives cos ∈ [0.98, 0.998]
+# depending on data distribution.
+_COS_MIN = 0.97
+_ERR_MAX = 5.0
+
+
+def _pool(page_size: int, num_pages: int = 4) -> torch.Tensor:
+    return torch.zeros(
+        num_pages,
+        page_size * MXFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+
+
+def test_scale_is_ceil_never_saturates_group_amax():
+    """The E8M0 byte must follow ceil(log2(amax / 6)) (MX convention).
+
+    The original round(log2(amax / 6)) picked a scale one octave too small
+    for every group whose amax lands in (6·2^k, 6·2^k·2^0.5]: the max
+    element then saturated to the largest E2M1 code (6), returning up to
+    29% short after dequantization (amax 8 decoded as 6).  ceil guarantees
+    the group amax stays representable.
+    """
+    dev = torch.device("cuda")
+    page_size = 128
+    # All values are exact in bf16.  Entries whose log2(amax/6) is an
+    # integer sit exactly on a rounding boundary — the kernel's fp32
+    # log2(amax) - log2(6) may land a ulp on either side, so either
+    # adjacent byte is accepted there (both keep the amax representable).
+    # The other entries pin the exact ceil byte, including the (6, 8.49]
+    # band the old round scale saturated.
+    amaxes = [6.0, 12.0, 0.75, 1.5, 3.0, 7.0, 8.0, 15.0, 4.0, 0.5]
+    k = torch.zeros(1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    for group, amax in enumerate(amaxes):
+        k[0, group * 32 : (group + 1) * 32] = amax / 4.0
+        k[0, group * 32] = amax  # the group's max element
+    pool = _pool(page_size, num_pages=1)
+    loc = torch.zeros(1, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)[:, 0, :].float()
+
+    grid = (0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+    for group, amax in enumerate(amaxes):
+        byte = int(pool[0, 224 + group])
+        ratio = math.log2(amax / 6.0)
+        s_low = math.ceil(ratio)
+        on_boundary = ratio == math.floor(ratio)
+        if on_boundary:
+            assert byte in (s_low + 127, s_low + 128), (
+                f"group {group} amax {amax}: byte {byte} escaped the "
+                f"({s_low + 127}, {s_low + 128}) boundary pair"
+            )
+        else:
+            assert (
+                byte == s_low + 127
+            ), f"group {group} amax {amax}: byte {byte} != {s_low + 127}"
+        s = byte - 127
+        recovered = out[0, group * 32].item()
+        scaled = amax / 2.0**s
+        if scaled in grid:
+            # amax/2^s on the E2M1 grid: the max element roundtrips exactly.
+            assert recovered == amax, f"group {group}: {amax} -> {recovered}"
+        else:
+            # scaled ∈ (3, 6) off-grid (7/2 = 3.5 tie, 15/4 = 3.75): RNE
+            # lands on the 4 code — never on the 6·2^(s-1) clamp the round
+            # scale produced.
+            assert (
+                recovered == 4.0 * 2.0**s
+            ), f"group {group}: amax {amax} recovered as {recovered}"
+
+
+def test_e8m0_byte_zero_decodes_as_2_pow_minus_127():
+    """E8M0 has no zero encoding: byte 0 is 2^-127 (bytes 0..254 = 2^-127
+    .. 2^127, 255 reserved NaN), matching the fused decode kernel's
+    e8m0_bits_to_float.  The dequantizer must apply that exact exponent
+    rather than treating the byte as a zero scale."""
+    dev = torch.device("cuda")
+    page_size = 128
+    k = torch.zeros(1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size, num_pages=1)
+    loc = torch.zeros(1, dtype=torch.int32, device=dev)
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    # Hand-craft the first group: E2M1 code 0b101 (=3.0) in every nibble
+    # with scale byte 0 — the byte lives at row offset 224.
+    pool[0, 0:16] = torch.full((16,), 0x55, dtype=torch.uint8, device=dev)
+    pool[0, 224] = 0
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)[:, 0, :].float()
+    expected = torch.full((32,), 3.0 * 2.0**-127, device=dev)
+    assert torch.equal(out[0, :32], expected)
+
+
+def test_all_zero_block_quantizes_to_zero_codes():
+    """An all-zero block must quantize to E2M1 code 0 with scale byte 0 and
+    round-trip to exactly zero (regression: the quantizer derived the RNE
+    denominator from tl.math.exp2, which flushes the subnormal 2^-127 to
+    zero; the `magnitude >= denominator * midpoint` rungs then all held at
+    magnitude 0 and zero inputs were encoded as code 3 — nonzero packed
+    nibbles that also diverged from the PyTorch reference).  All-zero rows
+    occur in production: idle dummy stores write them into the pool."""
+    dev = torch.device("cuda")
+    page_size, num_tokens = 128, 4
+    k = torch.zeros(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+
+    rows = pool.view(-1, MXFP4_BYTES_PER_TOKEN)[:num_tokens]
+    packed = rows[:, : MXFP4_NOPE_DIM // 2]
+    scales = rows[:, MXFP4_NOPE_DIM // 2 : MXFP4_NOPE_DIM // 2 + MXFP4_NUM_GROUPS]
+    assert torch.equal(packed, torch.zeros_like(packed))
+    assert torch.equal(scales, torch.zeros_like(scales))
+
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+    nope = out[:, 0, :MXFP4_NOPE_DIM].float()
+    assert torch.equal(nope, torch.zeros_like(nope))
+
+    # The same must hold for a zero group inside an otherwise healthy row:
+    # its packed bytes and its scale byte stay zero while the row's other
+    # groups encode normally.
+    torch.manual_seed(3)
+    k = torch.randn(1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    k[0, :MXFP4_GROUP_SIZE] = 0
+    pool = _pool(page_size)
+    loc = torch.zeros(1, dtype=torch.int32, device=dev)
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    row = pool.view(-1, MXFP4_BYTES_PER_TOKEN)[0]
+    group_bytes = MXFP4_GROUP_SIZE // 2
+    assert torch.equal(
+        row[:group_bytes], torch.zeros(group_bytes, dtype=torch.uint8, device=dev)
+    )
+    assert row[MXFP4_NOPE_DIM // 2] == 0
+    assert not torch.equal(
+        row[group_bytes : MXFP4_NOPE_DIM // 2],
+        torch.zeros(MXFP4_NOPE_DIM // 2 - group_bytes, dtype=torch.uint8, device=dev),
+    )
+
+
+def test_roundtrip_quality():
+    """Triton quantize → dequant roundtrip preserves signal."""
+    torch.manual_seed(1)
+    page_size, num_tokens = 128, 32
+    dev = torch.device("cuda")
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+
+    cos = torch.nn.functional.cosine_similarity(
+        k.float().flatten(), out[:, 0, :].float().flatten(), dim=0
+    ).item()
+    max_err = (k.float() - out[:, 0, :].float()).abs().max().item()
+
+    assert cos > _COS_MIN, f"cos {cos} below threshold {_COS_MIN}"
+    assert max_err < _ERR_MAX, f"max_err {max_err} above threshold {_ERR_MAX}"
+
+
+def test_triton_vs_reference():
+    """Triton output matches PyTorch reference (CPU fallback)."""
+    torch.manual_seed(2)
+    page_size, num_tokens = 64, 8
+    dev = torch.device("cuda")
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+
+    # Triton path
+    pool_triton = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+    quantize_dsv4_mxfp4_k_cache_into(k, pool_triton, loc, page_size)
+    out_triton = dequantize_dsv4_mxfp4_k_cache_paged(pool_triton, loc, page_size)
+
+    # CPU reference path (move data to CPU, quantize, move back)
+    k_cpu = k.cpu()
+    pool_cpu = torch.zeros(
+        1,
+        page_size * MXFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+    )
+    loc_cpu = torch.arange(num_tokens, dtype=torch.int32)
+    quantize_dsv4_mxfp4_k_cache_into(k_cpu, pool_cpu, loc_cpu, page_size)
+    out_ref = dequantize_dsv4_mxfp4_k_cache_paged(pool_cpu, loc_cpu, page_size)
+
+    out_cpu = out_ref[:, 0, :].to(dev).float()
+    out_gpu = out_triton[:, 0, :].float()
+
+    diff = (out_cpu - out_gpu).abs()
+    max_diff = diff.max().item()
+    cos = torch.nn.functional.cosine_similarity(
+        out_cpu.flatten(), out_gpu.flatten(), dim=0
+    ).item()
+
+    # Quantization decisions (E8M0 rounding) may differ slightly between
+    # PyTorch and Triton due to FP32 order-of-operations.
+    assert cos > 0.999, f"cos {cos} too low"
+    assert max_diff < 1e-3, f"max_diff {max_diff} too high"
+
+
+def test_empty_batch():
+    """Zero-token batch produces no-op."""
+    page_size = 128
+    k = torch.empty(0, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device="cuda")
+    pool = _pool(page_size)
+    loc = torch.empty(0, dtype=torch.int32, device="cuda")
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+
+    assert out.shape == (0, 1, MXFP4_TOTAL_DIM)
+
+
+def test_oob_indices():
+    """Out-of-bounds indices yield zero rows (padded graph batch).
+
+    The output is pre-filled with non-zero values so stale memory (or a
+    reused pre-allocated buffer) cannot mask a missing zero write.
+    """
+    torch.manual_seed(3)
+    page_size, num_tokens = 32, 16
+    dev = torch.device("cuda")
+    num_rows = 4 * page_size
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev) - 4  # [-4 .. 11]
+    loc[0] = num_rows + 17  # above capacity
+    loc[1] = -100  # negative
+    assert (loc < 0).any() and (loc >= num_rows).any()
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+
+    out = torch.full(
+        (num_tokens, 1, MXFP4_TOTAL_DIM), 7.5, dtype=torch.bfloat16, device=dev
+    )
+    dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size, out=out)
+
+    oob = (loc < 0) | (loc >= num_rows)
+    assert (
+        out[oob] == 0
+    ).all(), f"OOB rows should be zero, got {(out[oob] != 0).sum().item()} non-zero"
+    # In-range rows still dequantize (nonzero signal).
+    assert (out[~oob] != 0).any()
+
+
+def test_pre_allocated_output():
+    """Using a pre-allocated output tensor (no allocation in dequant)."""
+    torch.manual_seed(4)
+    page_size, num_tokens = 64, 8
+    dev = torch.device("cuda")
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+
+    out1 = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+    out2 = torch.empty(num_tokens, 1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    out3 = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size, out=out2)
+
+    assert out3 is out2, "Should return the passed-in tensor"
+    assert (out1 == out2).all(), "Pre-allocated output mismatches default-allocated"


### PR DESCRIPTION
## Motivation

Part 2/4 of splitting up #32741 (MXFP4 KV cache decode for DeepSeek V4 on Hopper). Standalone codec; the serving stack wires it up in part 4 (#37138). Depends on nothing; independent of #37135.

## Modifications

- Add `sglang/kernels/ops/attention/dsv4/mxfp4_k_cache.py` (next to the existing FP8 K-cache codecs): Triton quantize-into-paged-pool and paged dequantize for the 368 B/token MXFP4 KV row — `[224 B packed E2M1 | 14 B E8M0 block-32 scales + 2 B pad | 128 B BF16 RoPE]` — plus PyTorch references for validation. Only the 448-dim nope part is quantized; RoPE stays BF16; E8M0 needs no global scale.
- Add a 5-case codec unit test (roundtrip quality vs reference, empty/out-of-range inputs, output-buffer reuse).

## Accuracy Tests

`test/registered/kernels/ops/attention/test_mxfp4_k_cache.py` (needs 1 GPU): E2M1 roundtrip cos ≈ 0.99, Triton vs PyTorch reference parity.

## Speed Tests and Profiling

Not applicable for this PR; end-to-end numbers reported in part 4.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33313787974](https://github.com/sgl-project/sglang/actions/runs/33313787974)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33313787844](https://github.com/sgl-project/sglang/actions/runs/33313787844)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33313788092](https://github.com/sgl-project/sglang/actions/runs/33313788092)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->