### PR TITLE
[3/4][Kernel] Fused MXFP4 DSV4 decode attention for SM90 (FlashMLA-style, JIT)

### DIFF
--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/combine.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/combine.cuh
@@ -1,0 +1,220 @@
+#include <cute/tensor.hpp>
+#include <cutlass/array.h>
+#include <cutlass/cutlass.h>
+#include <cutlass/numeric_types.h>
+
+#include "flashmla_utils.h"
+#include "kerutils/kerutils.cuh"
+#include "params.h"
+#include <math_constants.h>
+
+using namespace cute;
+
+namespace smxx::decode {
+
+template <typename ElementT, int HEAD_DIM_V, int BLOCK_SIZE_M, int MAX_SPLITS, int NUM_THREADS>
+__global__ void __launch_bounds__(NUM_THREADS)
+    flash_fwd_mla_combine_kernel(__grid_constant__ const CombineParams params) {
+  // grid_shape: [batch_size*s_q, 1, h_q/BLOCK_SIZE_M]
+  // Each CTA gathers the activation of some heads from one batch, do scaling & accumulation, and save the result
+  static_assert(NUM_THREADS / 32 == BLOCK_SIZE_M);  // The number of warps == block_size_m
+  const int batch_s_q_idx = blockIdx.x;
+  const int batch_idx = batch_s_q_idx / params.s_q;
+  const int s_q_idx = batch_s_q_idx - batch_idx * params.s_q;
+  const int h_block_idx = blockIdx.z;
+  const int warp_idx = threadIdx.x / 32;
+  const int lane_idx = threadIdx.x % 32;
+
+  int num_valid_heads = std::min(BLOCK_SIZE_M, params.h_q - BLOCK_SIZE_M * h_block_idx);
+  if (warp_idx >= num_valid_heads) {
+    return;
+  }
+
+  const int start_split_idx = __ldg(params.num_splits_ptr + batch_idx);
+  const int end_split_idx = __ldg(params.num_splits_ptr + batch_idx + 1);
+  const int my_num_splits = end_split_idx - start_split_idx;
+  if (my_num_splits == 1) {
+    return;
+  }
+
+  FLASH_DEVICE_ASSERT(my_num_splits <= MAX_SPLITS);
+
+  Tensor gLseAccum = make_tensor(
+      make_gmem_ptr(
+          (float*)params.lse_accum + start_split_idx * params.stride_lse_accum_split +
+          s_q_idx * params.stride_lse_accum_s_q + h_block_idx * BLOCK_SIZE_M),
+      Shape<Int<MAX_SPLITS>, Int<BLOCK_SIZE_M>>{},
+      make_stride(params.stride_lse_accum_split, _1{}));
+  Tensor gLse = make_tensor(
+      make_gmem_ptr(
+          (float*)params.lse + batch_idx * params.stride_lse_b + s_q_idx * params.stride_lse_s_q +
+          h_block_idx * BLOCK_SIZE_M),
+      Shape<Int<BLOCK_SIZE_M>>{},
+      Stride<_1>{});
+
+  __shared__ float smem_buf[BLOCK_SIZE_M][MAX_SPLITS];
+
+  // Wait for the previous kernel (the MLA kernel) to finish
+  cudaGridDependencySynchronize();
+
+  // Prefetch
+  static_assert(HEAD_DIM_V % (32 * 4) == 0);
+  constexpr int ELEMS_PER_THREAD = HEAD_DIM_V / (32 * 4);
+  float* oaccum_ptr = params.o_accum + start_split_idx * params.stride_o_accum_split +
+                      s_q_idx * params.stride_o_accum_s_q +
+                      (h_block_idx * BLOCK_SIZE_M + warp_idx) * params.stride_o_accum_h_q;
+  float4 datas[ELEMS_PER_THREAD];
+  CUTLASS_PRAGMA_UNROLL
+  for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+    datas[i] = *(float4*)(oaccum_ptr + lane_idx * 4 +
+                          i * 128);  // NOTE We don't use __ldg here since it is incompatible with PDL
+  }
+
+  // Warp #i gathers LseAccum for seq #i
+  {
+    constexpr int NUM_LSE_PER_THREAD = cute::ceil_div(MAX_SPLITS, 32);
+    float local_lse[NUM_LSE_PER_THREAD];
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i) {
+      const int split_idx = i * 32 + lane_idx;
+      local_lse[i] = split_idx < my_num_splits ? gLseAccum(split_idx, warp_idx) : -INFINITY;
+    }
+
+    float max_lse = -INFINITY;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i)
+      max_lse = max(max_lse, local_lse[i]);
+    CUTLASS_PRAGMA_UNROLL
+    for (int offset = 16; offset >= 1; offset /= 2)
+      max_lse = max(max_lse, __shfl_xor_sync(uint32_t(-1), max_lse, offset));
+    max_lse = max_lse == -INFINITY ? 0.0f : max_lse;  // In case all local LSEs are -inf
+
+    float sum_lse = 0;
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i)
+      sum_lse = sum_lse + exp2f(local_lse[i] - max_lse);
+    CUTLASS_PRAGMA_UNROLL
+    for (int offset = 16; offset >= 1; offset /= 2)
+      sum_lse = sum_lse + __shfl_xor_sync(uint32_t(-1), sum_lse, offset);
+
+    float global_lse = (sum_lse == 0.f || sum_lse == -INFINITY) ? INFINITY : log2f(sum_lse) + max_lse;
+    if (lane_idx == 0) gLse(warp_idx) = global_lse / (float)M_LOG2E;
+
+    if (params.attn_sink != nullptr) {
+      int q_head_idx = h_block_idx * BLOCK_SIZE_M + warp_idx;
+      float attn_sink = __ldg(params.attn_sink + q_head_idx);
+      if (global_lse != INFINITY) {
+        // If attn_sink is +inf, global_lse will be +inf and scale factors will be exp2f(local_lse - inf) = 0 (since
+        // local_lse never becomes +inf) If attn_sink is -inf, this has no effect on global_lse
+        global_lse += log2f(1 + exp2f(attn_sink * CUDART_L2E_F - global_lse));
+      } else {
+        // We have no tokens to attend, so global lse should be attn_sink*CUDART_L2E_F (+inf if it's -inf or +inf)
+        global_lse = attn_sink == -INFINITY ? +INFINITY : attn_sink * CUDART_L2E_F;
+      }
+    }
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < NUM_LSE_PER_THREAD; ++i) {
+      const int split_idx = i * 32 + lane_idx;
+      smem_buf[warp_idx][split_idx] = exp2f(local_lse[i] - global_lse);
+    }
+  }
+
+  __syncwarp();
+
+  // Warp #i accumulates activation for seq #i
+  {
+    float4 result[ELEMS_PER_THREAD];
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < ELEMS_PER_THREAD; ++i)
+      result[i] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+#pragma unroll 1
+    for (int split = 0; split < my_num_splits; ++split) {
+      float lse_scale = smem_buf[warp_idx][split];
+      // if (lse_scale != 0.f) {
+      CUTLASS_PRAGMA_UNROLL
+      for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+        result[i].x += lse_scale * datas[i].x;
+        result[i].y += lse_scale * datas[i].y;
+        result[i].z += lse_scale * datas[i].z;
+        result[i].w += lse_scale * datas[i].w;
+        if (split != my_num_splits - 1) {
+          datas[i] = *(float4*)(oaccum_ptr + (split + 1) * params.stride_o_accum_split + lane_idx * 4 + i * 128);
+        }
+      }
+      // }
+    }
+
+    const int h_q_idx = h_block_idx * BLOCK_SIZE_M + warp_idx;
+    ElementT* o_ptr = (ElementT*)params.out + batch_idx * params.stride_o_b + s_q_idx * params.stride_o_s_q +
+                      h_q_idx * params.stride_o_h_q;
+
+    CUTLASS_PRAGMA_UNROLL
+    for (int i = 0; i < ELEMS_PER_THREAD; ++i) {
+      float4 data = result[i];
+      ElementT data_converted[4];
+      data_converted[0] = (ElementT)(data.x);
+      data_converted[1] = (ElementT)(data.y);
+      data_converted[2] = (ElementT)(data.z);
+      data_converted[3] = (ElementT)(data.w);
+      static_assert(sizeof(ElementT) == 2);
+      *(uint64_t*)(o_ptr + lane_idx * 4 + i * 128) = *(uint64_t*)data_converted;
+    }
+  }
+}
+
+#define MLA_NUM_SPLITS_SWITCH(NUM_SPLITS, NAME, ...) \
+  [&] {                                              \
+    if (NUM_SPLITS <= 32) {                          \
+      constexpr static int NAME = 32;                \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 64) {                   \
+      constexpr static int NAME = 64;                \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 96) {                   \
+      constexpr static int NAME = 96;                \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 128) {                  \
+      constexpr static int NAME = 128;               \
+      return __VA_ARGS__();                          \
+    } else if (NUM_SPLITS <= 160) {                  \
+      constexpr static int NAME = 160;               \
+      return __VA_ARGS__();                          \
+    } else {                                         \
+      FLASH_ASSERT(false);                           \
+    }                                                \
+  }()
+
+template <typename ElementT>
+void run_flash_mla_combine_kernel(CombineParams& params) {
+  static constexpr int HEAD_DIM_V = 512;  // Since only this head dimension is supported by Flash MLA
+  FLASH_ASSERT(params.d_v == HEAD_DIM_V);
+  MLA_NUM_SPLITS_SWITCH(params.num_sm_parts, NUM_SPLITS, [&] {
+    constexpr int BLOCK_SIZE_M = 8;
+    constexpr int NUM_THREADS = BLOCK_SIZE_M * 32;
+    constexpr size_t smem_size = BLOCK_SIZE_M * (NUM_SPLITS + 1) * sizeof(float);
+    auto combine_kernel = &flash_fwd_mla_combine_kernel<ElementT, HEAD_DIM_V, BLOCK_SIZE_M, NUM_SPLITS, NUM_THREADS>;
+    CHECK_CUDA(cudaFuncSetAttribute(combine_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+    // Use cudaLaunchKernelEx to enable PDL (Programmatic Dependent Launch)
+    cudaLaunchAttribute attribute[1];
+    attribute[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+    attribute[0].val.programmaticStreamSerializationAllowed = 1;
+    cudaLaunchConfig_t combine_kernel_config = {
+        dim3(params.b * params.s_q, 1, ku::ceil_div(params.h_q, BLOCK_SIZE_M)),
+        dim3(NUM_THREADS, 1, 1),
+        0,
+        params.stream,
+        attribute,
+        1};
+    CHECK_CUDA(cudaLaunchKernelEx(&combine_kernel_config, combine_kernel, params));
+  });
+  CHECK_CUDA_KERNEL_LAUNCH();
+}
+
+template void run_flash_mla_combine_kernel<cutlass::bfloat16_t>(CombineParams& params);
+
+#ifndef FLASH_MLA_DISABLE_FP16
+template void run_flash_mla_combine_kernel<cutlass::half_t>(CombineParams& params);
+#endif
+
+}  // namespace smxx::decode

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/components/helpers.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/components/helpers.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "../config.h"
+#include <cooperative_groups.h>
+
+using namespace cute;
+
+namespace sm90::decode::sparse_mxfp4_dsv4 {
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in two particular rows. This
+// function converts the local_row_idx (0~1) to the actual row_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+__forceinline__ __device__ int get_AorC_row_idx(int local_row_idx, int idx_in_warpgroup) {
+  int row_idx = (idx_in_warpgroup / 32) * 16 + local_row_idx * 8 + (idx_in_warpgroup % 32 / 4);
+  return row_idx;
+}
+
+// Adapted from
+// https://github.com/Dao-AILab/flash-attention/blob/cdaf2de6e95cb05400959b5ab984f66e4c7df317/hopper/utils.h
+template <
+    bool zero_init = false,
+    int wg_wait = 0,
+    bool arrive = true,
+    bool commit = true,
+    typename Tensor0,
+    typename Tensor1,
+    typename Tensor2,
+    typename TiledMma>
+__forceinline__ __device__ void gemm(TiledMma& tiled_mma, Tensor0 const& tCrA, Tensor1 const& tCrB, Tensor2& tCrC) {
+  constexpr bool Is_RS = !cute::is_base_of<cute::GMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value;
+  // Need to cast away const on tCrA since warpgroup_fence_operand doesn't take const
+  if constexpr (Is_RS) {
+    cute::warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+  warpgroup_fence_operand(tCrC);
+  if constexpr (arrive) {
+    warpgroup_arrive();
+  }
+  if constexpr (zero_init) {
+    tiled_mma.accumulate_ = GMMA::ScaleOut::Zero;
+    // Unroll the K mode manually to set scale D to 1
+    CUTLASS_PRAGMA_UNROLL
+    for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+      cute::gemm(tiled_mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tCrC);
+      tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+    }
+  } else {
+    // cute::gemm(tiled_mma, tCrA, tCrB, tCrC);
+    // Unroll the K mode manually to set scale D to 1
+    CUTLASS_PRAGMA_UNROLL
+    for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+      cute::gemm(tiled_mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tCrC);
+      tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+    }
+  }
+  if constexpr (commit) {
+    warpgroup_commit_batch();
+  }
+  if constexpr (wg_wait >= 0) {
+    warpgroup_wait<wg_wait>();
+  }
+  warpgroup_fence_operand(tCrC);
+  if constexpr (Is_RS) {
+    warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+}
+
+template <typename TMA, typename Tensor0, typename Tensor1>
+CUTE_DEVICE void launch_tma_copy(
+    const TMA& tma_copy,
+    const Tensor0& src,
+    Tensor1& dst,
+    transac_bar_t& bar,
+    const cute::TMA::CacheHintSm90& cache_hint = cute::TMA::CacheHintSm90::EVICT_NORMAL,
+    const uint16_t& multicast_mask = 0) {
+  auto thr_tma = tma_copy.get_slice(_0{});
+  cute::copy(
+      tma_copy.with(reinterpret_cast<typename transac_bar_t::ValueType&>(bar), multicast_mask, cache_hint),
+      thr_tma.partition_S(src),
+      thr_tma.partition_D(dst));
+}
+
+template <typename T>
+CUTE_DEVICE static void st_async_128b(void* dst_ptr, const T& data, const transac_bar_t* mbar_ptr) {
+  long2 data_long2 = *reinterpret_cast<const long2*>(&data);
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(mbar_ptr);
+  asm volatile("st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.v2.s64 [%0], {%1, %2}, [%3]; \n"
+               :
+               : "r"(dst_addr), "l"(data_long2.x), "l"(data_long2.y), "r"(mbar_addr));
+}
+
+CUTE_DEVICE
+static void cp_async_bulk_shared_cta_shared_cluster(void* dst_ptr, void* src_ptr, int size, transac_bar_t* mbar_ptr) {
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t src_addr = cute::cast_smem_ptr_to_uint(src_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(mbar_ptr);
+  asm volatile("cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3]; \n"
+               :
+               : "r"(dst_addr), "r"(src_addr), "r"(size), "r"(mbar_addr));
+}
+
+static constexpr int PEER_ADDR_MASK = 16777216;  // peer_addr = my_addr ^ PEER_ADDR_MASK.
+template <typename T>
+CUTE_DEVICE T* get_peer_addr(T* p) {
+  return (T*)((int64_t)(p) ^ PEER_ADDR_MASK);
+}
+
+}  // namespace sm90::decode::sparse_mxfp4_dsv4

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/config.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/config.h
@@ -1,0 +1,245 @@
+#pragma once
+
+#include <cute/tensor.hpp>
+#include <cutlass/arch/barrier.h>
+#include <cutlass/numeric_types.h>
+
+#include "defines.h"
+#include "kerutils/kerutils.cuh"
+#include "params.h"
+
+using namespace cute;
+
+namespace sm90::decode::sparse_mxfp4_dsv4 {
+
+template <int NUM_HEADS>
+class KernelTemplate {
+ public:
+  static_assert(NUM_HEADS == 64 || NUM_HEADS == 128);
+  static constexpr int NUM_M_BLOCKS = NUM_HEADS / 64;
+  static constexpr int CLUSTER_SIZE = NUM_M_BLOCKS;
+
+  static constexpr int HEAD_DIM_K = 512;
+  static constexpr int HEAD_DIM_V = 512;
+  static constexpr int HEAD_DIM_ROPE = 64;
+  static constexpr int HEAD_DIM_NOPE = 448;
+  static constexpr int PACKED_NOPE_BYTES = HEAD_DIM_NOPE / 2;
+  // One E8M0 scale per 32 NoPE dims.
+  static constexpr int SCALE_BLOCK_SIZE = 32;
+  static constexpr int NUM_SCALES = HEAD_DIM_NOPE / SCALE_BLOCK_SIZE;
+  // The scale area is padded to 16 bytes so the RoPE payload starts at a
+  // 4-byte boundary (224 + 14 + 2 = 240).
+  static constexpr int PAD_BYTES = 2;
+  static constexpr int ROPE_BYTES = HEAD_DIM_ROPE * sizeof(bf16);
+  static constexpr int BYTES_PER_TOKEN = PACKED_NOPE_BYTES + NUM_SCALES + PAD_BYTES + ROPE_BYTES;
+
+  static_assert(PACKED_NOPE_BYTES == 224);
+  static_assert(NUM_SCALES == 14);
+  static_assert(BYTES_PER_TOKEN == 368);
+
+  static constexpr int NUM_THREADS = 128 * 3;
+  static constexpr int BLOCK_M = 64;
+  static constexpr int TOPK_BLOCK_SIZE = 64;
+  static constexpr int NUM_K_BUFS = 2;
+
+  using SmemLayoutQTile =
+      decltype(tile_to_shape(GMMA::Layout_SW128_Atom<bf16, GMMA::Major::K>{}, Shape<Int<BLOCK_M>, Int<64>>{}));
+
+  template <int NUM_TILES>
+  using SmemLayoutQTiles =
+      decltype(tile_to_shape(SmemLayoutQTile{}, Shape<Int<BLOCK_M>, Int<64 * NUM_TILES>>{}, Step<_1, _2>{}));
+
+  using SmemLayoutQ = SmemLayoutQTiles<HEAD_DIM_K / 64>;
+
+  using SmemLayoutKTile = decltype(tile_to_shape(
+      GMMA::Layout_INTER_Atom<bf16, GMMA::Major::K>{}, Shape<Int<TOPK_BLOCK_SIZE>, _64>{}, Step<_1, _2>{}));
+
+  template <int NUM_TILES>
+  using SmemLayoutKTiles =
+      decltype(tile_to_shape(SmemLayoutKTile{}, Shape<Int<TOPK_BLOCK_SIZE>, Int<64 * NUM_TILES>>{}, Step<_1, _2>{}));
+
+  template <int NUM_TILES>
+  using SmemLayoutKTilesTransposed = decltype(composition(
+      SmemLayoutKTiles<NUM_TILES>{},
+      Layout<Shape<Int<64 * NUM_TILES>, Int<TOPK_BLOCK_SIZE>>, Stride<Int<TOPK_BLOCK_SIZE>, _1>>{}));
+
+  static constexpr int OBUF_SW = 64;
+  using SmemLayoutOBufAtom = GMMA::Layout_K_SW128_Atom<bf16>;
+  using SmemLayoutOBuf =
+      decltype(tile_to_shape(SmemLayoutOBufAtom{}, Shape<Int<BLOCK_M>, Int<HEAD_DIM_V>>{}, Step<_1, _2>{}));
+
+  using SmemLayoutOAccumBuf = Layout<
+      Shape<Int<BLOCK_M>, Int<HEAD_DIM_V>>,
+      Stride<Int<520>, _1>  // We use stride = 520 here to avoid bank conflict
+      >;
+
+  using SmemLayoutK = SmemLayoutKTiles<HEAD_DIM_K / 64>;
+  using SmemLayoutV = SmemLayoutKTilesTransposed<HEAD_DIM_V / 64>;
+  using SmemLayoutHalfV = SmemLayoutKTilesTransposed<HEAD_DIM_V / 64 / 2>;
+
+  using SmemLayoutS =
+      decltype(tile_to_shape(GMMA::Layout_K_SW128_Atom<bf16>{}, Shape<Int<BLOCK_M>, Int<TOPK_BLOCK_SIZE>>{}));
+
+  struct SharedMemoryPlan {
+    array_aligned<bf16, cosize_v<SmemLayoutQ>> q;
+    union {
+      array_aligned<bf16, cosize_v<SmemLayoutK>> k[NUM_K_BUFS];
+      array_aligned<bf16, cosize_v<SmemLayoutOBuf>> oBuf;
+      array_aligned<float, cosize_v<SmemLayoutOAccumBuf>> oAccumBuf;
+    } u;
+    CUTE_ALIGNAS(1024) array_aligned<bf16, cosize_v<SmemLayoutS>> s;
+    bool is_kv_valid[NUM_K_BUFS][TOPK_BLOCK_SIZE];
+
+    float sM[BLOCK_M], sL[BLOCK_M], sScale[BLOCK_M], sOScale[BLOCK_M];
+    transac_bar_t bar_q, bar_k_local_ready[NUM_K_BUFS], bar_k_remote_ready[NUM_K_BUFS], bar_k_avail[NUM_K_BUFS];
+    // WG0/WG1 arrive once per request after store_o (which writes the oBuf
+    // union overlay of the K buffers); the producer waits it before writing
+    // the next request's K so a fast producer can never overwrite the
+    // epilogue in flight.
+    transac_bar_t bar_o_done;
+  };
+
+  template <typename Shape_Q, typename TMA_Q>
+  struct TmaParams {
+    Shape_Q shape_Q;
+    TMA_Q tma_Q;
+    CUtensorMap tensor_map_o;
+  };
+
+  using TiledMMA_QK = decltype(make_tiled_mma(
+      GMMA::MMA_64x64x16_F32BF16BF16_SS<GMMA::Major::K, GMMA::Major::K>{}, Layout<Shape<_1, _1, _1>>{}));
+
+  using TiledMMA_QK_rQ = decltype(make_tiled_mma(
+      GMMA::MMA_64x64x16_F32BF16BF16_RS<GMMA::Major::K, GMMA::Major::K>{}, Layout<Shape<_1, _1, _1>>{}));
+
+  using TiledMMA_PV_LocalP = decltype(make_tiled_mma(
+      GMMA::MMA_64x256x16_F32BF16BF16_RS<GMMA::Major::K, GMMA::Major::MN>{}, Layout<Shape<_1, _1, _1>>{}));
+
+  using TiledMMA_PV_RemoteP = decltype(make_tiled_mma(
+      GMMA::MMA_64x256x16_F32BF16BF16_SS<GMMA::Major::K, GMMA::Major::MN>{}, Layout<Shape<_1, _1, _1>>{}));
+
+  enum NamedBarriers : uint32_t {
+    sScale_and_sS_ready = 0,
+    sScale_and_sS_free = 1,
+    oBuf_free_and_sL_ready = 2,
+    epilogue_r2s_ready = 3,
+    batch_loop_sync = 4,
+    warpgroup0_sync = 5
+  };
+
+  // Synchronize all threads within the cluster (which processes one q token)
+  static __forceinline__ __device__ void sync_all_threads_in_cluster() {
+    if constexpr (CLUSTER_SIZE == 1) {
+      __syncthreads();
+    } else {
+      ku::barrier_cluster_arrive_relaxed();
+      ku::barrier_cluster_wait_acquire();
+    }
+  }
+
+  // Save rPb (64x64, bfloat16) to sP using the stmatrix instruction
+  template <typename Tensor0, typename Tensor1>
+  static __forceinline__ __device__ void save_rPb_to_sP(Tensor0 const& rPb, Tensor1 const& sP, int idx_in_warpgroup) {
+    auto r2s_copy = make_tiled_copy_C(Copy_Atom<SM90_U32x4_STSM_N, bf16>{}, TiledMMA_QK{});
+    ThrCopy thr_copy = r2s_copy.get_slice(idx_in_warpgroup);
+    Tensor thr_copy_rPb = thr_copy.retile_S(rPb);
+    Tensor thr_copy_sP = thr_copy.partition_D(sP);
+    cute::copy(r2s_copy, thr_copy_rPb, thr_copy_sP);
+  }
+
+  template <
+      bool IS_NO_SPLIT,
+      typename TMAParams,
+      typename Tensor0,
+      typename Tensor1,
+      typename Tensor2,
+      typename Tensor3>
+  static __forceinline__ __device__ void store_o(
+      Tensor0& rO,         // ((2, 2, 32), 1, 1)
+      Tensor1& gOorAccum,  // (BLOCK_SIZE_M, HEAD_DIM_V)
+      Tensor2& sOutputBuf,
+      Tensor3& sOutputAccumBuf,
+      SharedMemoryPlan& plan,
+      float o_scales[2],
+      TMAParams& tma_params,
+      int batch_idx,
+      int s_q_idx,
+      int head_block_idx,
+      int num_valid_seq_q,
+      int warpgroup_idx,
+      int idx_in_warpgroup) {
+    using cutlass::arch::NamedBarrier;
+    if constexpr (IS_NO_SPLIT) {
+      // Should convert the output to bfloat16 / float16, and save it to O
+      // Here we don't pipeline STSM and tma store because it's slower
+      Tensor sMyOutputBuf = local_tile(sOutputBuf, Shape<_64, _256>{}, make_coord(_0{}, warpgroup_idx));
+
+      // Calculate "base" ptrs in advance
+      // Each STSM fills a chunk of shape 16x16, while we are using SW-OBUF_SW, so we need OBUF_SW/16 base pointers
+      constexpr int NUM_CHUNKS_IN_SW_ATOM = OBUF_SW / 16;
+      bf16* base_output_buf_ptrs[NUM_CHUNKS_IN_SW_ATOM];
+      CUTE_UNROLL
+      for (int i = 0; i < NUM_CHUNKS_IN_SW_ATOM; ++i) {
+        base_output_buf_ptrs[i] = &sMyOutputBuf(
+            (idx_in_warpgroup / 32) * 16 + idx_in_warpgroup % 16, idx_in_warpgroup % 32 / 16 * 8 + i * 16);
+      }
+
+      CUTE_UNROLL
+      for (int idx = 0; idx < (HEAD_DIM_V / 2) / 16; idx += 1) {
+        // In each iteration we deal with a chunk of shape 16x16
+        using bf16x2 = __nv_bfloat162;
+        bf16x2 a01 = __float22bfloat162_rn(float2{rO(idx * 8 + 0) * o_scales[0], rO(idx * 8 + 1) * o_scales[0]});
+        bf16x2 a23 = __float22bfloat162_rn(float2{rO(idx * 8 + 2) * o_scales[1], rO(idx * 8 + 3) * o_scales[1]});
+        bf16x2 a45 = __float22bfloat162_rn(float2{rO(idx * 8 + 4) * o_scales[0], rO(idx * 8 + 5) * o_scales[0]});
+        bf16x2 a67 = __float22bfloat162_rn(float2{rO(idx * 8 + 6) * o_scales[1], rO(idx * 8 + 7) * o_scales[1]});
+        SM90_U32x4_STSM_N::copy(
+            *reinterpret_cast<uint32_t*>(&a01),
+            *reinterpret_cast<uint32_t*>(&a23),
+            *reinterpret_cast<uint32_t*>(&a45),
+            *reinterpret_cast<uint32_t*>(&a67),
+            *reinterpret_cast<uint128_t*>(base_output_buf_ptrs[idx % 4] + (idx / 4 * 4) * 16 * 64));
+      }
+
+      cutlass::arch::fence_view_async_shared();
+      NamedBarrier::arrive_and_wait(256, NamedBarriers::epilogue_r2s_ready);
+
+      if (threadIdx.x == 0) {
+        SM90_TMA_STORE_5D::copy(
+            &tma_params.tensor_map_o, plan.u.oBuf.data(), 0, head_block_idx * 64, 0, s_q_idx, batch_idx);
+        cute::tma_store_arrive();
+      }
+    } else {
+      // Should save the result to OAccum
+      CUTLASS_PRAGMA_UNROLL
+      for (int idx = 0; idx < size(rO); idx += 2) {
+        int row = (idx_in_warpgroup / 32) * 16 + (idx_in_warpgroup % 32 / 4) + (idx % 4 >= 2 ? 8 : 0);
+        int col = warpgroup_idx * 256 + (idx_in_warpgroup % 4) * 2 + idx / 4 * 8;
+        *(float2*)(&(sOutputAccumBuf(row, col))) = float2{
+            rO(idx) * o_scales[idx % 4 >= 2],
+            rO(idx + 1) * o_scales[idx % 4 >= 2],
+        };
+      }
+      cutlass::arch::fence_view_async_shared();
+
+      NamedBarrier::arrive_and_wait(256, NamedBarriers::epilogue_r2s_ready);
+
+      if (elect_one_sync()) {
+        CUTLASS_PRAGMA_UNROLL
+        for (int local_row = 0; local_row < BLOCK_M / (256 / 32); ++local_row) {
+          int row = local_row * (256 / 32) + (threadIdx.x / 32);
+          if (row < num_valid_seq_q) {
+            SM90_BULK_COPY_S2G::copy(&sOutputAccumBuf(row, _0{}), &gOorAccum(row, _0{}), HEAD_DIM_V * sizeof(float));
+          }
+        }
+        cute::tma_store_arrive();
+      }
+    }
+  }
+
+  template <typename TMAParams>
+  static __device__ __forceinline__ void devfunc(const SparseAttnDecodeParams& params, const TMAParams& tma_params);
+
+  static void run(const SparseAttnDecodeParams& params);
+};
+
+}  // namespace sm90::decode::sparse_mxfp4_dsv4

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/defines.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/defines.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <cutlass/arch/barrier.h>
+#include <cutlass/bfloat16.h>
+
+using bf16 = cutlass::bfloat16_t;
+using fp8 = cutlass::float_e4m3_t;
+using transac_bar_t = cutlass::arch::ClusterTransactionBarrier;
+using cutlass::arch::fence_barrier_init;
+using cutlass::arch::fence_view_async_shared;
+using cutlass::arch::NamedBarrier;
+
+struct int32x8_t {
+  int a0, a1, a2, a3, a4, a5, a6, a7;
+};
+
+struct float8 {
+  float2 a01, a23, a45, a67;
+};
+
+struct bf16x8 {
+  __nv_bfloat162 a01;
+  __nv_bfloat162 a23;
+  __nv_bfloat162 a45;
+  __nv_bfloat162 a67;
+};

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/dequant.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/dequant.h
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 SGLang Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include "layout.h"
+#include <cstdint>
+#include <cuda_bf16.h>
+
+namespace sm90::nvfp4 {
+
+__device__ __forceinline__ uint64_t load_packed_e2m1x16(const void* address) {
+  uint64_t value;
+  asm volatile("ld.global.nc.L1::evict_last.L2::128B.u64 %0, [%1];" : "=l"(value) : "l"(address));
+  return value;
+}
+
+struct E2M1Bf16Lut {
+  // The low and high bytes of the eight positive E2M1 magnitudes, split into
+  // two four-byte PRMT sources.  Keeping the table in registers is much
+  // cheaper than synthesizing 16 FP32 values and multiplying them one by one.
+  uint32_t low_0_3;
+  uint32_t low_4_7;
+  uint32_t high_0_3;
+  uint32_t high_4_7;
+};
+
+struct bf16x16 {
+  bf16x8 lo;
+  bf16x8 hi;
+};
+
+__device__ __forceinline__ uint32_t cvt_bf16x2_bits(float lo, float hi) {
+  const __nv_bfloat162 values = __float22bfloat162_rn(make_float2(lo, hi));
+  return *reinterpret_cast<const uint32_t*>(&values);
+}
+
+__device__ __forceinline__ E2M1Bf16Lut make_e2m1_bf16_lut(float scale) {
+  // E2M1's positive magnitudes are {0, .5, 1, 1.5, 2, 3, 4, 6}.  Computing
+  // each scaled BF16 value once reduces sixteen FP32 multiplies/conversions
+  // to four packed conversions.  Multiplication is deliberately performed
+  // in FP32 before the BF16 rounding, matching the scalar implementation.
+  const uint32_t pair_0_1 = cvt_bf16x2_bits(0.0f * scale, 0.5f * scale);
+  const uint32_t pair_2_3 = cvt_bf16x2_bits(1.0f * scale, 1.5f * scale);
+  const uint32_t pair_4_5 = cvt_bf16x2_bits(2.0f * scale, 3.0f * scale);
+  const uint32_t pair_6_7 = cvt_bf16x2_bits(4.0f * scale, 6.0f * scale);
+
+  return {
+      __byte_perm(pair_0_1, pair_2_3, 0x6420),
+      __byte_perm(pair_4_5, pair_6_7, 0x6420),
+      __byte_perm(pair_0_1, pair_2_3, 0x7531),
+      __byte_perm(pair_4_5, pair_6_7, 0x7531),
+  };
+}
+
+__device__ __forceinline__ uint32_t e2m1_signs_0_1(uint32_t packed) {
+  // Move nibble sign bits 3 and 7 to the sign bits of two packed BF16s.
+  return ((packed & 0x00000008u) << 12) | ((packed & 0x00000080u) << 24);
+}
+
+__device__ __forceinline__ uint32_t e2m1_signs_2_3(uint32_t packed) {
+  // Move nibble sign bits 11 and 15 to the sign bits of two packed BF16s.
+  return ((packed & 0x00000800u) << 4) | ((packed & 0x00008000u) << 16);
+}
+
+__device__ __forceinline__ bf16x8 dequant_e2m1x8(uint32_t packed, const E2M1Bf16Lut& lut) {
+  bf16x8 result;
+  uint32_t* result_pairs = reinterpret_cast<uint32_t*>(&result);
+
+  // A PRMT selector consists of four nibbles.  The E2M1 magnitude is already
+  // a three-bit LUT index, so masking away the sign makes the packed source
+  // directly usable as a selector for four values at once.
+  const uint32_t selector_lo = packed & 0x00007777u;
+  const uint32_t low_bytes_lo = __byte_perm(lut.low_0_3, lut.low_4_7, selector_lo);
+  const uint32_t high_bytes_lo = __byte_perm(lut.high_0_3, lut.high_4_7, selector_lo);
+  result_pairs[0] = __byte_perm(low_bytes_lo, high_bytes_lo, 0x5140) ^ e2m1_signs_0_1(packed);
+  result_pairs[1] = __byte_perm(low_bytes_lo, high_bytes_lo, 0x7362) ^ e2m1_signs_2_3(packed);
+
+  packed >>= 16;
+  const uint32_t selector_hi = packed & 0x00007777u;
+  const uint32_t low_bytes_hi = __byte_perm(lut.low_0_3, lut.low_4_7, selector_hi);
+  const uint32_t high_bytes_hi = __byte_perm(lut.high_0_3, lut.high_4_7, selector_hi);
+  result_pairs[2] = __byte_perm(low_bytes_hi, high_bytes_hi, 0x5140) ^ e2m1_signs_0_1(packed);
+  result_pairs[3] = __byte_perm(low_bytes_hi, high_bytes_hi, 0x7362) ^ e2m1_signs_2_3(packed);
+  return result;
+}
+
+__device__ __forceinline__ bf16x16 dequant_e2m1x16(uint64_t packed, float scale) {
+  const E2M1Bf16Lut lut = make_e2m1_bf16_lut(scale);
+  return {
+      dequant_e2m1x8(static_cast<uint32_t>(packed), lut),
+      dequant_e2m1x8(static_cast<uint32_t>(packed >> 32), lut),
+  };
+}
+
+}  // namespace sm90::nvfp4
+
+namespace sm90::mxfp4 {
+
+// MXFP4 rows carry one E8M0 block scale byte per 32 NoPE dims. Per the
+// E8M0 (FP8 8-bit exponent) encoding, bytes 0..254 are 2^-127..2^127 and
+// 255 is reserved as NaN — there is no zero encoding.
+__device__ __forceinline__ uint8_t load_scale_bits(const void* address) {
+  uint32_t value;
+  asm volatile("ld.global.nc.L1::evict_last.L2::128B.u8 %0, [%1];" : "=r"(value) : "l"(address));
+  return static_cast<uint8_t>(value);
+}
+
+__device__ __forceinline__ float e8m0_bits_to_float(uint8_t bits) {
+  if (bits == 0) return __int_as_float(0x400000u);           // 2^-127: below the FP32 normal range, a denormal
+  if (bits == 255) return __int_as_float(0x7fffffffu);       // reserved NaN
+  return __int_as_float(static_cast<uint32_t>(bits) << 23);  // 2^(bits-127)
+}
+
+}  // namespace sm90::mxfp4

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/entry.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/entry.cuh
@@ -1,0 +1,369 @@
+/*!
+ * \brief TVM-FFI entry point for the fused MXFP4 DeepSeek-V4 sparse decode.
+ *
+ * Wraps the FlashMLA-style three-stage split-KV decode (scheduler metadata
+ * kernel, persistent main kernel, combine kernel) so it can be JIT-compiled
+ * as a single translation unit. All output and scratch tensors are allocated
+ * on the Python side; this entry only parses shapes, fills the parameter
+ * structs, and launches.
+ *
+ * The kernel sources under this directory are vendored from:
+ *   - the SGLang reference PR #31269 (sparse_nvfp4_dsv4 + dequant/layout),
+ *   - FlashMLA upstream @ 05e26647 (params.h, defines.h, utils.h, kerutils/,
+ *     and the combine kernel),
+ * with the MXFP4 (E8M0 block-32 scale) variant developed for DSV4 on Hopper.
+ * See the PR body for the full provenance list.
+ */
+
+#pragma once
+
+#include <dlpack/dlpack.h>
+#include <tvm/ffi/container/tensor.h>
+#include <tvm/ffi/error.h>
+#include <tvm/ffi/extra/c_env_api.h>
+
+#include "combine.cuh"
+#include "config.h"
+#include "splitkv_mla.cuh"
+#include <cuda_runtime.h>
+#include <math_constants.h>
+
+namespace sm90::decode::sparse_mxfp4_dsv4 {
+
+// Split-K scheduler constants, shared by the metadata kernel and the
+// host-side dispatch.
+constexpr int kTopkBlockSize = 64;
+constexpr int kFixedOverheadNumBlocks = 5;
+
+// Explicit instantiations for the two supported query-head counts.
+template void run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel_impl<64>(const SparseAttnDecodeParams& params);
+template void run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel_impl<128>(const SparseAttnDecodeParams& params);
+
+namespace {
+
+__device__ __forceinline__ int clamp_length(const int* lengths, int request_idx, int width) {
+  const int value = lengths == nullptr ? width : __ldg(lengths + request_idx);
+  return max(0, min(value, width));
+}
+
+__device__ __forceinline__ int effective_length(const GetDecodeSchedMetaParams& params, int request_idx) {
+  int primary = clamp_length(params.topk_length, request_idx, params.topk);
+  // Keep one all-masked primary block for a zero-length request, matching the
+  // FlashMLA consumer's progress invariant.
+  primary = max(primary, 1);
+  if (params.extra_topk > 0) {
+    primary = ((primary + kTopkBlockSize - 1) / kTopkBlockSize) * kTopkBlockSize;
+    primary += clamp_length(params.extra_topk_length, request_idx, params.extra_topk);
+  }
+  return primary;
+}
+
+__global__ void get_dsv4_mxfp4_decoding_sched_meta_kernel(__grid_constant__ const GetDecodeSchedMetaParams params) {
+  if (threadIdx.x != 0) {
+    return;
+  }
+
+  int total_num_blocks = 0;
+  for (int request_idx = 0; request_idx < params.b; ++request_idx) {
+    const int length = effective_length(params, request_idx);
+    const int num_blocks = (length + kTopkBlockSize - 1) / kTopkBlockSize;
+    total_num_blocks += num_blocks + kFixedOverheadNumBlocks;
+  }
+
+  const int payload = (total_num_blocks + params.num_sm_parts - 1) / params.num_sm_parts + kFixedOverheadNumBlocks;
+  int request_idx = 0;
+  int block_idx = 0;
+  int request_split_idx = 0;
+  int cumulative_num_splits = 0;
+  params.num_splits_ptr[0] = 0;
+
+  for (int part = 0; part < params.num_sm_parts; ++part) {
+    if (request_idx >= params.b) {
+      DecodingSchedMeta invalid = {};
+      invalid.begin_req_idx = params.b;
+      invalid.end_req_idx = params.b;
+      params.tile_scheduler_metadata_ptr[part] = invalid;
+      continue;
+    }
+
+    DecodingSchedMeta metadata = {};
+    metadata.begin_req_idx = request_idx;
+    metadata.begin_block_idx = block_idx;
+    metadata.begin_split_idx = request_split_idx;
+    metadata.is_first_req_splitted = block_idx != 0;
+
+    int remaining_payload = payload;
+    while (request_idx < params.b) {
+      const int length = effective_length(params, request_idx);
+      const int num_blocks = (length + kTopkBlockSize - 1) / kTopkBlockSize;
+      const int remaining_blocks = num_blocks - block_idx;
+      if (remaining_payload >= remaining_blocks + kFixedOverheadNumBlocks) {
+        cumulative_num_splits += request_split_idx + 1;
+        params.num_splits_ptr[request_idx + 1] = cumulative_num_splits;
+        remaining_payload -= remaining_blocks + kFixedOverheadNumBlocks;
+        ++request_idx;
+        block_idx = 0;
+        request_split_idx = 0;
+      } else {
+        if (remaining_payload > kFixedOverheadNumBlocks) {
+          block_idx += remaining_payload - kFixedOverheadNumBlocks;
+          ++request_split_idx;
+        }
+        break;
+      }
+    }
+
+    metadata.end_req_idx = block_idx > 0 ? request_idx : request_idx - 1;
+    if (block_idx > 0) {
+      metadata.end_block_idx = block_idx;
+      const int length = effective_length(params, metadata.end_req_idx);
+      const int last_block_idx = (length + kTopkBlockSize - 1) / kTopkBlockSize - 1;
+      metadata.is_last_req_splitted = metadata.end_block_idx != last_block_idx + 1;
+    } else {
+      const int length = effective_length(params, metadata.end_req_idx);
+      metadata.end_block_idx = (length + kTopkBlockSize - 1) / kTopkBlockSize;
+      metadata.is_last_req_splitted = false;
+    }
+    if (metadata.begin_req_idx == metadata.end_req_idx) {
+      const int is_split = metadata.is_first_req_splitted || metadata.is_last_req_splitted;
+      metadata.is_first_req_splitted = is_split;
+      metadata.is_last_req_splitted = is_split;
+    }
+    params.tile_scheduler_metadata_ptr[part] = metadata;
+  }
+
+  // Requests the partition loop never reached (batch not evenly divisible by
+  // the per-part payload) get zero splits so the combine kernel reads a
+  // defined prefix sum instead of whatever the buffer held before.
+  for (int i = request_idx + 1; i <= params.b; ++i) {
+    params.num_splits_ptr[i] = cumulative_num_splits;
+  }
+}
+
+}  // namespace
+
+void run_get_dsv4_mxfp4_decoding_sched_meta_kernel(const GetDecodeSchedMetaParams& params) {
+  get_dsv4_mxfp4_decoding_sched_meta_kernel<<<1, 1, 0, params.stream>>>(params);
+  KU_CHECK_KERNEL_LAUNCH();
+}
+
+void run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel(const SparseAttnDecodeParams& params) {
+  if (params.h_q == 64) {
+    run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel_impl<64>(params);
+  } else if (params.h_q == 128) {
+    run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel_impl<128>(params);
+  } else {
+    KU_ASSERT(false, "DeepSeek V4 MXFP4 sparse decode supports 64 or 128 query heads");
+  }
+}
+
+}  // namespace sm90::decode::sparse_mxfp4_dsv4
+
+namespace sglang {
+
+namespace {
+
+constexpr int kHeadDimQk = 512;
+constexpr int kHeadDimV = 512;
+constexpr int kMxfp4BytesPerToken = 368;
+
+// Optional tensors arrive as empty (0-element) tensors from the Python side.
+static inline bool is_empty(tvm::ffi::TensorView t) {
+  return t.numel() == 0;
+}
+
+// Raise a Python-visible ValueError instead of exiting: this entry runs
+// inside a serving process, and a contract violation must surface as an
+// exception the caller can handle, not kill the process.
+[[noreturn]] static inline void fail(const char* msg) {
+  TVM_FFI_THROW(ValueError) << "mxfp4_dsv4_decode: " << msg;
+}
+
+}  // namespace
+
+//! \brief Fused DSV4 MXFP4 decode (scheduler + main + combine) for one step.
+void mxfp4_dsv4_decode_dispatch(
+    tvm::ffi::TensorView q,
+    tvm::ffi::TensorView k_cache,
+    tvm::ffi::TensorView indices,
+    tvm::ffi::TensorView topk_length,
+    tvm::ffi::TensorView attn_sink,
+    tvm::ffi::TensorView tile_scheduler_metadata,
+    tvm::ffi::TensorView num_splits,
+    tvm::ffi::TensorView extra_k_cache,
+    tvm::ffi::TensorView extra_indices,
+    tvm::ffi::TensorView extra_topk_length,
+    tvm::ffi::TensorView lse_accum,
+    tvm::ffi::TensorView o_accum,
+    tvm::ffi::TensorView out,
+    tvm::ffi::TensorView lse,
+    int64_t head_dim_v,
+    double sm_scale,
+    int64_t generate_sched_meta) {
+  if (head_dim_v != kHeadDimV) {
+    fail("d_v must be 512");
+  }
+  if (!(sm_scale > 0.0)) {
+    fail("sm_scale must be finite and positive");
+  }
+
+  DLDevice dev = q.device();
+  if (dev.device_type != kDLCUDA) {
+    fail("q must be a CUDA tensor");
+  }
+  cudaSetDevice(dev.device_id);
+  // Resolve the torch current stream (which is the capture stream during
+  // CUDA-graph capture) on the C++ side; fetching it from Python costs
+  // ~100us per call.
+  cudaStream_t stream = static_cast<cudaStream_t>(::TVMFFIEnvGetStream(kDLCUDA, dev.device_id));
+
+  // One-time SM90 gate per device: cudaDeviceGetAttribute is a driver
+  // round-trip and would cost microseconds on every decode step. A process
+  // may span heterogeneous GPUs, so the cached verdict is keyed by the
+  // device it was computed for rather than decided once for the process.
+  static int sm90_checked_device = -1;
+  static bool is_sm90 = false;
+  if (sm90_checked_device != static_cast<int>(dev.device_id)) {
+    int major = 0;
+    cudaDeviceGetAttribute(&major, cudaDevAttrComputeCapabilityMajor, dev.device_id);
+    is_sm90 = (major == 9);
+    sm90_checked_device = static_cast<int>(dev.device_id);
+  }
+  if (!is_sm90) {
+    fail("mxfp4_dsv4_decode only supports SM90 (Hopper)");
+  }
+
+  const int b = static_cast<int>(q.shape()[0]);
+  const int s_q = static_cast<int>(q.shape()[1]);
+  const int h_q = static_cast<int>(q.shape()[2]);
+  const int topk = static_cast<int>(indices.shape()[2]);
+  if (b <= 0 || s_q <= 0) {
+    fail("q batch and sequence dimensions must be positive");
+  }
+  if (h_q != 64 && h_q != 128) {
+    fail("q must contain 64 or 128 heads");
+  }
+
+  const bool have_extra = !is_empty(extra_k_cache);
+  const int extra_num_blocks = have_extra ? static_cast<int>(extra_k_cache.shape()[0]) : 0;
+  const int extra_page_block_size = have_extra ? static_cast<int>(extra_k_cache.shape()[1]) : 0;
+  const int extra_topk = have_extra ? static_cast<int>(extra_indices.shape()[2]) : 0;
+
+  const int num_sm_parts = static_cast<int>(tile_scheduler_metadata.shape()[0]);
+
+  // The scheduler metadata kernel runs only when the caller signals a fresh
+  // metadata buffer (first use, or a new buffer captured into a CUDA graph).
+  // Replays and steady-state decode steps reuse the previously generated
+  // metadata, matching the AOT behavior and avoiding a per-step serial
+  // 1-CTA kernel. During graph capture the caller hands a fresh buffer, so
+  // the generation kernel is captured into the graph and re-executes on
+  // every replay with the replayed (clamped) top-k lengths.
+  GetDecodeSchedMetaParams sched_params = {};
+  if (generate_sched_meta) {
+    sched_params.b = b;
+    sched_params.s_q = s_q;
+    sched_params.block_size_n = sm90::decode::sparse_mxfp4_dsv4::kTopkBlockSize;
+    sched_params.fixed_overhead_num_blocks = sm90::decode::sparse_mxfp4_dsv4::kFixedOverheadNumBlocks;
+    sched_params.topk = topk;
+    sched_params.extra_topk = have_extra ? extra_topk : 0;
+    sched_params.topk_length = is_empty(topk_length) ? nullptr : static_cast<int*>(topk_length.data_ptr());
+    sched_params.extra_topk_length =
+        is_empty(extra_topk_length) ? nullptr : static_cast<int*>(extra_topk_length.data_ptr());
+    sched_params.tile_scheduler_metadata_ptr = reinterpret_cast<DecodingSchedMeta*>(tile_scheduler_metadata.data_ptr());
+    sched_params.num_splits_ptr = static_cast<int*>(num_splits.data_ptr());
+    sched_params.num_sm_parts = num_sm_parts;
+    sched_params.stream = stream;
+    sm90::decode::sparse_mxfp4_dsv4::run_get_dsv4_mxfp4_decoding_sched_meta_kernel(sched_params);
+  }
+
+  const int num_blocks = static_cast<int>(k_cache.shape()[0]);
+  const int page_block_size = static_cast<int>(k_cache.shape()[1]);
+
+  SparseAttnDecodeParams params = {};
+  params.b = b;
+  params.s_q = s_q;
+  params.h_q = h_q;
+  params.h_kv = 1;
+  params.d_qk = kHeadDimQk;
+  params.d_v = kHeadDimV;
+  params.sm_scale = static_cast<float>(sm_scale);
+  params.sm_scale_div_log2 = static_cast<float>(sm_scale) * M_LOG2E;
+  params.num_blocks = num_blocks;
+  params.page_block_size = page_block_size;
+  params.topk = topk;
+  params.model_type = ModelType::MODEL1;
+
+  params.q = reinterpret_cast<cutlass::bfloat16_t*>(q.data_ptr());
+  params.kv = reinterpret_cast<cutlass::bfloat16_t*>(k_cache.data_ptr());
+  params.indices = static_cast<int*>(indices.data_ptr());
+  params.topk_length = is_empty(topk_length) ? nullptr : static_cast<int*>(topk_length.data_ptr());
+  params.attn_sink = is_empty(attn_sink) ? nullptr : static_cast<float*>(attn_sink.data_ptr());
+  params.lse = static_cast<float*>(lse.data_ptr());
+  params.out = reinterpret_cast<cutlass::bfloat16_t*>(out.data_ptr());
+
+  params.extra_num_blocks = extra_num_blocks;
+  params.extra_page_block_size = extra_page_block_size;
+  params.extra_topk = extra_topk;
+  params.extra_kv = have_extra ? reinterpret_cast<cutlass::bfloat16_t*>(extra_k_cache.data_ptr()) : nullptr;
+  params.extra_indices = have_extra ? static_cast<int*>(extra_indices.data_ptr()) : nullptr;
+  params.extra_topk_length = is_empty(extra_topk_length) ? nullptr : static_cast<int*>(extra_topk_length.data_ptr());
+
+  params.stride_q_b = h_q * kHeadDimQk;
+  params.stride_q_s_q = h_q * kHeadDimQk;
+  params.stride_q_h_q = kHeadDimQk;
+  params.stride_kv_block = page_block_size * kMxfp4BytesPerToken;
+  params.stride_kv_row = kMxfp4BytesPerToken;
+  params.stride_indices_b = s_q * topk;
+  params.stride_indices_s_q = topk;
+  params.stride_lse_b = s_q * h_q;
+  params.stride_lse_s_q = h_q;
+  params.stride_o_b = h_q * kHeadDimV;
+  params.stride_o_s_q = h_q * kHeadDimV;
+  params.stride_o_h_q = kHeadDimV;
+  params.stride_extra_kv_block = have_extra ? extra_page_block_size * kMxfp4BytesPerToken : 0;
+  params.stride_extra_kv_row = kMxfp4BytesPerToken;
+  params.stride_extra_indices_b = have_extra ? s_q * extra_topk : 0;
+  params.stride_extra_indices_s_q = have_extra ? extra_topk : 0;
+  params.stream = stream;
+
+  params.lse_accum = static_cast<float*>(lse_accum.data_ptr());
+  params.o_accum = static_cast<float*>(o_accum.data_ptr());
+  params.stride_lse_accum_split = s_q * h_q;
+  params.stride_lse_accum_s_q = h_q;
+  params.stride_o_accum_split = s_q * h_q * kHeadDimV;
+  params.stride_o_accum_s_q = h_q * kHeadDimV;
+  params.stride_o_accum_h_q = kHeadDimV;
+  params.tile_scheduler_metadata_ptr = reinterpret_cast<DecodingSchedMeta*>(tile_scheduler_metadata.data_ptr());
+  params.num_splits_ptr = static_cast<int*>(num_splits.data_ptr());
+  params.num_sm_parts = num_sm_parts;
+
+  sm90::decode::sparse_mxfp4_dsv4::run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel(params);
+
+  CombineParams combine_params = {};
+  combine_params.b = b;
+  combine_params.s_q = s_q;
+  combine_params.h_q = h_q;
+  combine_params.d_v = kHeadDimV;
+  combine_params.lse = params.lse;
+  combine_params.out = params.out;
+  combine_params.stride_lse_b = params.stride_lse_b;
+  combine_params.stride_lse_s_q = params.stride_lse_s_q;
+  combine_params.stride_o_b = params.stride_o_b;
+  combine_params.stride_o_s_q = params.stride_o_s_q;
+  combine_params.stride_o_h_q = params.stride_o_h_q;
+  combine_params.lse_accum = params.lse_accum;
+  combine_params.o_accum = params.o_accum;
+  combine_params.stride_lse_accum_split = params.stride_lse_accum_split;
+  combine_params.stride_lse_accum_s_q = params.stride_lse_accum_s_q;
+  combine_params.stride_o_accum_split = params.stride_o_accum_split;
+  combine_params.stride_o_accum_s_q = params.stride_o_accum_s_q;
+  combine_params.stride_o_accum_h_q = params.stride_o_accum_h_q;
+  combine_params.tile_scheduler_metadata_ptr = params.tile_scheduler_metadata_ptr;
+  combine_params.num_splits_ptr = params.num_splits_ptr;
+  combine_params.num_sm_parts = params.num_sm_parts;
+  combine_params.attn_sink = params.attn_sink;
+  combine_params.stream = params.stream;
+  smxx::decode::run_flash_mla_combine_kernel<cutlass::bfloat16_t>(combine_params);
+}
+
+}  // namespace sglang

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/flashmla_utils.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/flashmla_utils.h
@@ -1,0 +1,3 @@
+#pragma once
+
+#include "utils.h"

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/common/common.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/common/common.h
@@ -1,0 +1,11 @@
+#pragma once
+
+namespace kerutils {}
+
+#define KU_PRINTLN(fmt, ...)         \
+  {                                  \
+    cute::print(fmt, ##__VA_ARGS__); \
+    print("\n");                     \
+  }
+
+namespace ku = kerutils;

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/common.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/common.h
@@ -1,0 +1,60 @@
+/*
+Common data types and macros that are used across the kerutils library.
+*/
+#pragma once
+
+#include <cute/config.hpp>  // For CUTE_DEVICE
+#include <cutlass/arch/barrier.h>
+#include <cutlass/bfloat16.h>
+
+#include <cuda_bf16.h>
+#include <cuda_fp8.h>
+
+namespace kerutils {
+
+// Cache hints
+enum class CacheHint { EVICT_FIRST, EVICT_NORMAL, EVICT_LAST, EVICT_UNCHANGED, NO_ALLOCATE };
+
+// Prefetch size
+enum class PrefetchSize { B64, B128, B256 };
+
+using nvbf16 = __nv_bfloat16;
+using nvbf16x2 = __nv_bfloat162;
+using nve4m3 = __nv_fp8_e4m3;
+using nve4m3x2 = __nv_fp8x2_e4m3;
+using nve4m3x4 = __nv_fp8x4_e4m3;
+
+using bf16 = cutlass::bfloat16_t;
+using transac_bar_t = cutlass::arch::ClusterTransactionBarrier;
+
+}  // namespace kerutils
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 800))
+#define KERUTILS_ENABLE_SM80
+#elif (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ < 800))
+static_assert(false, "kerutils doesn't support SM architectures below SM80");
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900))
+#define KERUTILS_ENABLE_SM90
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 900 && __CUDA_ARCH__ < 1000))
+#define KERUTILS_ENABLE_SM90A
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000))
+#define KERUTILS_ENABLE_SM100
+#endif
+
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ >= 1000 && __CUDA_ARCH__ < 1200))
+#define KERUTILS_ENABLE_SM100A
+#endif
+
+#if (defined(__CLION_IDE__) || defined(__VSCODE_IDE__))
+#define KERUTILS_ENABLE_SM80
+#define KERUTILS_ENABLE_SM90
+#define KERUTILS_ENABLE_SM90A
+#define KERUTILS_ENABLE_SM100
+#define KERUTILS_ENABLE_SM100A
+#endif

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/device.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/device.cuh
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "../common/common.h"
+#include "common.h"
+#include "sm80/helpers.cuh"
+#include "sm80/intrinsics.cuh"
+#include "sm90/helpers.cuh"
+#include "sm90/intrinsics.cuh"

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/helpers.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/helpers.cuh
@@ -1,0 +1,54 @@
+#pragma once
+
+#include "../common.h"
+#include "intrinsics.cuh"
+
+namespace kerutils {
+
+// Retrieve the value of `%smid` and check its range
+CUTE_DEVICE
+uint32_t get_sm_id_with_range_check(uint32_t num_physical_sms) {
+  uint32_t sm_id = get_sm_id();
+  if (!(sm_id < num_physical_sms)) {
+    trap();
+  }
+  return sm_id;
+}
+
+#ifndef KU_TRAP_ONLY_DEVICE_ASSERT
+#define KU_TRAP_ONLY_DEVICE_ASSERT(cond) \
+  do {                                   \
+    if (not(cond)) asm("trap;");         \
+  } while (0)
+#endif
+
+// Construct a `float2` from a single `float` by duplicating the value
+CUTE_DEVICE
+float2 float2float2(const float& x) {
+  return float2{x, x};
+}
+
+CUTE_DEVICE
+void st_shared(void* ptr, __int128_t val) {
+  asm volatile("st.shared.b128 [%0], %1;" ::"l"(__cvta_generic_to_shared(ptr)), "q"(val));
+}
+
+CUTE_DEVICE
+void st_shared(void* ptr, float4 val) {
+  st_shared(ptr, *(__int128_t*)&val);
+}
+
+CUTE_DEVICE
+__int128_t ld_shared(void* ptr) {
+  __int128_t val;
+  asm volatile("ld.shared.b128 %0, [%1];" : "=q"(val) : "l"(__cvta_generic_to_shared(ptr)));
+  return val;
+}
+
+CUTE_DEVICE
+float4 ld_shared_float4(void* ptr) {
+  __int128_t temp = ld_shared(ptr);
+  return *(float4*)&temp;
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/intrinsics.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm80/intrinsics.cuh
@@ -1,0 +1,142 @@
+#pragma once
+
+#include "../common.h"
+
+namespace kerutils {
+
+// cp.async.cg (cache global) with prefetch and predicate
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async)
+template <PrefetchSize PREFETCH_SIZE = PrefetchSize::B128>
+CUTE_DEVICE void cp_async_cacheglobal(const void* src, void* dst, bool pred = true) {
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst);
+  if constexpr (PREFETCH_SIZE == PrefetchSize::B64) {
+    asm volatile(
+        "cp.async.cg.shared.global.L2::64B [%0], [%1], 16, %2;\n" ::"r"(dst_addr), "l"(src), "r"(pred ? 16 : 0));
+  } else if constexpr (PREFETCH_SIZE == PrefetchSize::B128) {
+    asm volatile(
+        "cp.async.cg.shared.global.L2::128B [%0], [%1], 16, %2;\n" ::"r"(dst_addr), "l"(src), "r"(pred ? 16 : 0));
+  } else if constexpr (PREFETCH_SIZE == PrefetchSize::B256) {
+    asm volatile(
+        "cp.async.cg.shared.global.L2::256B [%0], [%1], 16, %2;\n" ::"r"(dst_addr), "l"(src), "r"(pred ? 16 : 0));
+  } else {
+    static_assert(
+        PREFETCH_SIZE == PrefetchSize::B64 || PREFETCH_SIZE == PrefetchSize::B128 ||
+            PREFETCH_SIZE == PrefetchSize::B256,
+        "Unsupported prefetch size for cp_async_cacheglobal.");
+  }
+}
+
+// Create fraction-based cache policy
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-createpolicy)
+template <CacheHint PRIMARY_PRIORITY, CacheHint SECONDARY_PRIORITY>
+CUTE_DEVICE int64_t create_fraction_based_cache_policy(float fraction = 1.0f) {
+  int64_t result;
+#define EMIT(PRIMARY_PRIORITY_STR, SECONDARY_PRIORITY_STR)                                                         \
+  asm volatile("createpolicy.fractional.L2::" PRIMARY_PRIORITY_STR ".L2::" SECONDARY_PRIORITY_STR ".b64 %0, %1;\n" \
+               : "=l"(result)                                                                                      \
+               : "f"(fraction));
+#define EMIT2(PRIMARY_PRIORITY_STR)                                                                         \
+  {                                                                                                         \
+    if constexpr (SECONDARY_PRIORITY == CacheHint::EVICT_FIRST) {                                           \
+      EMIT(PRIMARY_PRIORITY_STR, "evict_first")                                                             \
+    } else if constexpr (SECONDARY_PRIORITY == CacheHint::EVICT_UNCHANGED) {                                \
+      EMIT(PRIMARY_PRIORITY_STR, "evict_unchanged")                                                         \
+    } else {                                                                                                \
+      static_assert(                                                                                        \
+          SECONDARY_PRIORITY == CacheHint::EVICT_FIRST || SECONDARY_PRIORITY == CacheHint::EVICT_UNCHANGED, \
+          "Unsupported secondary cache hint for create_fraction_based_cache_policy.");                      \
+    }                                                                                                       \
+  }
+  if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_FIRST) {
+    EMIT2("evict_first");
+  } else if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_NORMAL) {
+    EMIT2("evict_normal");
+  } else if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_LAST) {
+    EMIT2("evict_last");
+  } else if constexpr (PRIMARY_PRIORITY == CacheHint::EVICT_UNCHANGED) {
+    EMIT2("evict_unchanged");
+  } else {
+    static_assert(
+        PRIMARY_PRIORITY == CacheHint::EVICT_FIRST || PRIMARY_PRIORITY == CacheHint::EVICT_NORMAL ||
+            PRIMARY_PRIORITY == CacheHint::EVICT_LAST || PRIMARY_PRIORITY == CacheHint::EVICT_UNCHANGED,
+        "Unsupported primary cache hint for create_fraction_based_cache_policy.");
+  }
+#undef EMIT
+#undef EMIT2
+  return result;
+}
+
+// Create a simple cache policy (equivalent to create_fraction_based_cache_policy(1.0f))
+// The same as cute::TMA::CacheHintSmXX
+template <CacheHint CACHE_HINT>
+CUTE_DEVICE constexpr int64_t create_simple_cache_policy() {
+  if constexpr (CACHE_HINT == CacheHint::EVICT_FIRST) {
+    return 0x12F0000000000000;  // Result of createpolicy.fractional.L2::evict_first.b64
+  } else if constexpr (CACHE_HINT == CacheHint::EVICT_NORMAL) {
+    return 0x1000000000000000;  // Copied from CuTe. Unsure about the exact meaning. (TODO Change to
+                                // 0x16F0000000000000?)
+  } else if constexpr (CACHE_HINT == CacheHint::EVICT_LAST) {
+    return 0x14F0000000000000;  // Result of createpolicy.fractional.L2::evict_last.b64
+  } else {
+    static_assert(
+        CACHE_HINT == CacheHint::EVICT_FIRST || CACHE_HINT == CacheHint::EVICT_NORMAL ||
+            CACHE_HINT == CacheHint::EVICT_LAST,
+        "Unsupported cache hint for create_simple_cache_policy.");
+  }
+}
+
+// AtomicAdd
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-red)
+CUTE_DEVICE
+void atomicadd_f32_with_policy_and_pred(
+    void* global_addr, const float& data, int64_t cache_policy, uint32_t pred = true) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "setp.eq.u32 p, %3, 1;\n\t"
+      "@p red.relaxed.gpu.global.add.L2::cache_hint.f32 [%1], %0, %2; \n\t"
+      "}"
+      :
+      : "f"(data), "l"((int64_t)global_addr), "l"(cache_policy), "r"(pred));
+}
+
+// Get the id of the current SM
+// About %smid (https://docs.nvidia.com/cuda/parallel-thread-execution/#special-registers-smid): PTX document says that
+// %smid ranges from 0 to %nsmid-1, while "The SM identifier numbering is not guaranteed to be contiguous, so %nsmid may
+// be larger than the physical number of SMs in the device.". However, result shows that, at least for sm90 and sm100f,
+// %nsmid is the number of physical SMs - 1. For the sake of safety, I recommend you to check the return of get_sm_id
+// manually or call `get_sm_id_with_range_check()` defined in `device/sm80/helpers.cuh`. Besides, PTX document also says
+// that this number may change due to preemption, but currently this never happens according to [DATEN GELÖSCHT]
+CUTE_DEVICE
+uint32_t get_sm_id() {
+  uint32_t ret;
+  asm volatile("mov.u32 %0, %%smid;\n" : "=r"(ret));
+  return ret;
+}
+
+// trap (https://docs.nvidia.com/cuda/parallel-thread-execution/#miscellaneous-instructions-trap)
+CUTE_DEVICE
+void trap() {
+  asm volatile("trap;\n");
+}
+
+// LDG.128 or LDG.128 with non-coherent cache
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-ld) We use macro
+// instead of function here, since we need a multi-level recursive dispatch based on template parameters if using
+// function NC_STR should be either "" or ".nc" L1_CACHE_HINT_STR should be either "evict_first", "evict_normal",
+// "evict_last", "evict_unchanged", or "no_allocate" L2_PREFETCH_SIZE_STR should be either "64B", "128B", or "256B" L2
+// cache hint is not supported since it's only supported for LDG.256
+#define KU_LDG_128(global_addr, result, NC_STR, L1_CACHE_HINT_STR, L2_PREFETCH_SIZE_STR)                               \
+  {                                                                                                                    \
+    static_assert(                                                                                                     \
+        std::is_pointer_v<decltype(global_addr)> || std::is_array_v<decltype(global_addr)>,                            \
+        "`global_addr` must be a pointer");                                                                            \
+    static_assert(                                                                                                     \
+        std::is_pointer_v<decltype(result)> || std::is_array_v<decltype(result)>, "`result` must be a pointer");       \
+    uint64_t* result_as_uint64_ptr = (uint64_t*)(result);                                                              \
+    asm volatile("ld.global" NC_STR ".L1::" L1_CACHE_HINT_STR ".L2::" L2_PREFETCH_SIZE_STR ".v2.u64 {%0, %1}, [%2];\n" \
+                 : "=l"(result_as_uint64_ptr[0]), "=l"(result_as_uint64_ptr[1])                                        \
+                 : "l"(global_addr));                                                                                  \
+  }
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/helpers.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/helpers.cuh
@@ -1,0 +1,113 @@
+#pragma once
+
+#include <cute/tensor.hpp>
+
+#include "../common.h"
+
+namespace kerutils {
+
+template <typename TMA, typename Tensor0, typename Tensor1>
+CUTE_DEVICE void launch_tma_copy(
+    const TMA& tma_copy,
+    Tensor0 src,
+    Tensor1 dst,
+    transac_bar_t& bar,
+    const cute::TMA::CacheHintSm90& cache_hint = cute::TMA::CacheHintSm90::EVICT_NORMAL) {
+  auto thr_tma = tma_copy.get_slice(cute::_0{});
+  cute::copy(
+      tma_copy.with(reinterpret_cast<typename transac_bar_t::ValueType&>(bar), 0, cache_hint),
+      thr_tma.partition_S(src),
+      thr_tma.partition_D(dst));
+}
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in two particular rows. This
+// function converts the local_row_idx (0~2) to the actual row_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+CUTE_DEVICE
+int get_AorC_row_idx(int local_row_idx, int idx_in_warpgroup) {
+  int row_idx = (idx_in_warpgroup / 32) * 16 + local_row_idx * 8 + (idx_in_warpgroup % 32 / 4);
+  return row_idx;
+}
+
+// In the layout of fragment A and fragment C during WGMMA, data each thread holds resides in some rows. This function
+// converts the local_elem_idx to the actual col_idx You may refer to this link for the detailed layout:
+// https://docs.nvidia.com/cuda/parallel-thread-execution/#wgmma-64n16-a
+CUTE_DEVICE
+int get_AorC_col_idx(int local_elem_idx, int idx_in_warpgroup) {
+  int col_idx = 8 * (local_elem_idx / 4) + (idx_in_warpgroup % 4) * 2 + (local_elem_idx & 1);
+  return col_idx;
+}
+
+template <bool commit = true, typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma(TiledMma& tiled_mma, Tensor0 const& tCrA, Tensor1 const& tCrB, Tensor2& tCrC, bool zero_init) {
+  using namespace cute;
+  constexpr bool Is_RS = !cute::is_base_of<cute::GMMA::DescriptorIterator, typename TiledMma::FrgTypeA>::value;
+  // Need to cast away const on tCrA since warpgroup_fence_operand doesn't take const
+  if constexpr (Is_RS) {
+    cute::warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+  warpgroup_fence_operand(tCrC);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = zero_init ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  // Unroll the K mode manually to set scale D to 1
+  CUTLASS_PRAGMA_UNROLL
+  for (int k_block = 0; k_block < size<2>(tCrA); ++k_block) {
+    cute::gemm(tiled_mma, tCrA(_, _, k_block), tCrB(_, _, k_block), tCrC);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  if constexpr (commit) {
+    warpgroup_commit_batch();
+  }
+  warpgroup_fence_operand(tCrC);
+  if constexpr (Is_RS) {
+    warpgroup_fence_operand(const_cast<Tensor0&>(tCrA));
+  }
+}
+
+template <typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma_ss(
+    bool clear_accum,
+    TiledMma tiled_mma,
+    Tensor0 const& sA,
+    Tensor1 const& sB,
+    Tensor2& rC_frag,
+    int idx_in_warpgroup) {
+  using namespace cute;
+  ThrMMA thr_mma = tiled_mma.get_slice(idx_in_warpgroup);
+  Tensor sA_frag = thr_mma.partition_fragment_A(sA);
+  Tensor sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(sA_frag) == size<2>(sB_frag));
+
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = clear_accum ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  CUTLASS_PRAGMA_UNROLL
+  for (int k = 0; k < size<2>(sA_frag); ++k) {
+    cute::gemm(tiled_mma, sA_frag(_, _, k), sB_frag(_, _, k), rC_frag);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  warpgroup_fence_operand(rC_frag);
+}
+
+template <typename Tensor0, typename Tensor1, typename Tensor2, typename TiledMma>
+CUTE_DEVICE void wgmma_rs(
+    bool clear_accum, TiledMma tiled_mma, Tensor0 rA_frag, Tensor1 const& sB, Tensor2& rC_frag, int idx_in_warpgroup) {
+  using namespace cute;
+  ThrMMA thr_mma = tiled_mma.get_slice(idx_in_warpgroup);
+  Tensor sB_frag = thr_mma.partition_fragment_B(sB);
+  static_assert(size<2>(rA_frag) == size<2>(sB_frag));
+
+  warpgroup_fence_operand(const_cast<Tensor0&>(rA_frag));
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_arrive();
+  tiled_mma.accumulate_ = clear_accum ? GMMA::ScaleOut::Zero : GMMA::ScaleOut::One;
+  CUTLASS_PRAGMA_UNROLL
+  for (int k = 0; k < size<2>(rA_frag); ++k) {
+    cute::gemm(tiled_mma, rA_frag(_, _, k), sB_frag(_, _, k), rC_frag);
+    tiled_mma.accumulate_ = GMMA::ScaleOut::One;
+  }
+  warpgroup_fence_operand(rC_frag);
+  warpgroup_fence_operand(const_cast<Tensor0&>(rA_frag));
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/intrinsics.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/device/sm90/intrinsics.cuh
@@ -1,0 +1,108 @@
+#pragma once
+
+#include "../common.h"
+
+namespace kerutils {
+
+// st.async (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-st-async)
+template <typename T>
+CUTE_DEVICE static void st_async(void* dst_ptr, const T& data, transac_bar_t& mbar) {
+  static_assert(sizeof(T) == 16, "Data type must be 16 bytes (128 bits) for st_async.");
+  long2 data_long2 = *reinterpret_cast<const long2*>(&data);
+  uint32_t dst_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(&mbar);
+  asm volatile("st.async.weak.shared::cluster.mbarrier::complete_tx::bytes.v2.s64 [%0], {%1, %2}, [%3]; \n"
+               :
+               : "r"(dst_addr), "l"(data_long2.x), "l"(data_long2.y), "r"(mbar_addr));
+}
+
+static constexpr int PEER_ADDR_MASK = 16777216;
+
+// Given an address in the current CTA, return the corresponding address in the peer CTA
+template <typename T>
+CUTE_DEVICE T* get_peer_addr(const T* p) {
+  return (T*)((int64_t)(p) ^ PEER_ADDR_MASK);
+}
+
+// Given an address in the current CTA, return the corresponding address in the peer CTA (if the current CTA_id%2 == 1)
+// or the address itself (if CTA_id%2 == 0)
+template <typename T>
+CUTE_DEVICE T* get_cta0_addr(const T* p) {
+  constexpr int CTA0_ADDR_MASK = 0xFEFFFFFF;
+  return (T*)((int64_t)(p)&CTA0_ADDR_MASK);
+}
+
+// TMA bulk reduce add (cp.reduce.async.bulk), shared to global, float32, add.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-reduce-async-bulk)
+CUTE_DEVICE
+void tma_bulk_reduce_add(void const* src_ptr, void* dst_ptr, int32_t store_bytes) {
+  uint32_t smem_int_ptr = cute::cast_smem_ptr_to_uint(src_ptr);
+  asm volatile("cp.reduce.async.bulk.global.shared::cta.bulk_group.add.f32 [%0], [%1], %2;\n"
+               :
+               : "l"(dst_ptr), "r"(smem_int_ptr), "r"(store_bytes)
+               : "memory");
+}
+
+// Cluster barrier arrive with .release modifier.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-barrier-cluster)
+CUTE_DEVICE
+void barrier_cluster_arrive_release() {
+  asm volatile("barrier.cluster.arrive.release;" : : : "memory");
+}
+
+// Cluster barrier arrive with .relaxed modifier.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-barrier-cluster)
+CUTE_DEVICE
+void barrier_cluster_arrive_relaxed() {
+  asm volatile("barrier.cluster.arrive.relaxed;" : : :);
+}
+
+// Cluster barrier wait with .acquire modifier.
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-barrier-cluster)
+CUTE_DEVICE
+void barrier_cluster_wait_acquire() {
+  asm volatile("barrier.cluster.wait.acquire;" : : : "memory");
+}
+
+// mbarrier.arrive with .relaxed.cluster qualifier
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-mbarrier-arrive)
+CUTE_DEVICE
+void mbarrier_arrive_relaxed_cluster(transac_bar_t& mbar) {
+  uint32_t smem_addr = cute::cast_smem_ptr_to_uint(&mbar);
+  asm volatile(
+      "{\n\t"
+      "mbarrier.arrive.relaxed.cluster.shared::cta.b64 _, [%0];\n\t"
+      "}"
+      :
+      : "r"(smem_addr));
+}
+
+// AtomicAdd with v4.f32 type
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#parallel-synchronization-and-communication-instructions-red)
+CUTE_DEVICE
+void atomicadd_f32x4_with_policy_and_pred(
+    void* global_addr, const float4& data, int64_t cache_policy, uint32_t pred = true) {
+  asm volatile(
+      "{\n\t"
+      ".reg .pred p;\n\t"
+      "setp.eq.u32 p, %6, 1;\n\t"
+      "@p red.relaxed.gpu.global.add.L2::cache_hint.v4.f32 [%4], {%0, %1, %2, %3}, %5; \n\t"
+      "}"
+      :
+      : "f"(data.x), "f"(data.y), "f"(data.z), "f"(data.w), "l"((int64_t)global_addr), "l"(cache_policy), "r"(pred));
+}
+
+// cp.async.bulk, from .shared::cta to .shared::cluster
+// (https://docs.nvidia.com/cuda/parallel-thread-execution/#data-movement-and-conversion-instructions-cp-async-bulk)
+CUTE_DEVICE
+void cp_async_bulk_shared_cta_to_shared_cluster(
+    void* dst_ptr, const void* src_ptr, int32_t load_bytes, transac_bar_t& mbar) {
+  uint32_t dst_smem_addr = cute::cast_smem_ptr_to_uint(dst_ptr);
+  uint32_t src_smem_addr = cute::cast_smem_ptr_to_uint(src_ptr);
+  uint32_t mbar_addr = cute::cast_smem_ptr_to_uint(&mbar);
+  asm volatile("cp.async.bulk.shared::cluster.shared::cta.mbarrier::complete_tx::bytes [%0], [%1], %2, [%3]; \n"
+               :
+               : "r"(dst_smem_addr), "r"(src_smem_addr), "r"(load_bytes), "r"(mbar_addr));
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/host/host.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/host/host.h
@@ -1,0 +1,157 @@
+#pragma once
+
+#include <cutlass/cuda_host_adapter.hpp>
+
+#include "../common/common.h"
+#include <cuda.h>
+#include <cuda_runtime_api.h>
+#include <exception>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace kerutils {
+
+class KUException final : public std::exception {
+  std::string message = {};
+
+ public:
+  template <typename... Args>
+  explicit KUException(const char* name, const char* file, const int line, Args&&... args) {
+    std::ostringstream oss;
+
+    oss << name << " error (" << file << ":" << line << "): ";
+    (oss << ... << args);
+    message = oss.str();
+  }
+
+  const char* what() const noexcept override {
+    return message.c_str();
+  }
+};
+
+#define THROW_KU_EXCEPTION(name, ...) throw kerutils::KUException(name, __FILE__, __LINE__, __VA_ARGS__)
+
+#define KU_CUDA_CHECK(call)                                                                         \
+  do {                                                                                              \
+    cudaError_t status_ = call;                                                                     \
+    if (status_ != cudaSuccess) {                                                                   \
+      fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__, cudaGetErrorString(status_)); \
+      THROW_KU_EXCEPTION("CUDA", "CUDA error: ", cudaGetErrorString(status_));                      \
+    }                                                                                               \
+  } while (0)
+
+#define KU_CUTLASS_CHECK(call)                                                                       \
+  do {                                                                                               \
+    cutlass::Status status_ = call;                                                                  \
+    if (status_ != cutlass::Status::kSuccess) {                                                      \
+      fprintf(stderr, "CUTLASS error (%s:%d): %d\n", __FILE__, __LINE__, static_cast<int>(status_)); \
+      THROW_KU_EXCEPTION("CUTLASS", "CUTLASS error: ", static_cast<int>(status_));                   \
+    }                                                                                                \
+  } while (0)
+
+// This `KU_ASSERT` is triggered no matter if the code is compiled with `-DNDEBUG` or not.
+#define KU_ASSERT(cond, ...)                                                         \
+  do {                                                                               \
+    if (not(cond)) {                                                                 \
+      fprintf(stderr, "Assertion `%s` failed (%s:%d): ", #cond, __FILE__, __LINE__); \
+      if constexpr (sizeof(#__VA_ARGS__) > 1) {                                      \
+        fprintf(stderr, ", " __VA_ARGS__);                                           \
+      }                                                                              \
+      fprintf(stderr, "\n");                                                         \
+      THROW_KU_EXCEPTION("Assertion", "Assertion `", #cond, "` failed.");            \
+    }                                                                                \
+  } while (0)
+
+#define KU_CHECK_KERNEL_LAUNCH() KU_CUDA_CHECK(cudaGetLastError())
+
+template <typename T>
+inline __host__ __device__ constexpr T ceil_div(const T& a, const T& b) {
+  return (a + b - 1) / b;
+}
+
+template <typename T>
+inline __host__ __device__ constexpr T ceil(const T& a, const T& b) {
+  return (a + b - 1) / b * b;
+}
+
+// A wrapper for make_tensor_map
+static inline CUtensorMap make_tensor_map(
+    const std::vector<uint64_t>& size,
+    const std::vector<uint64_t>& strides,  // PAY ATTENTION: In BYTES
+    const std::vector<uint32_t>& box_size,
+    void* global_ptr,
+    CUtensorMapDataType data_type,
+    CUtensorMapSwizzle swizzle_mode,
+    CUtensorMapL2promotion l2_promotion,
+    CUtensorMapInterleave interleave_mode = CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+    CUtensorMapFloatOOBfill oob_fill = CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE,
+    const std::vector<uint32_t>& element_strides_ = {}) {
+  int dim = size.size();
+  KU_ASSERT(dim >= 1);
+
+  std::vector<uint32_t> element_strides;
+  if (element_strides_.empty()) {
+    for (int i = 0; i < dim; ++i)
+      element_strides.push_back(1);
+  } else {
+    element_strides = element_strides_;
+  }
+  KU_ASSERT(
+      strides.size() == (uint32_t)dim - 1 && box_size.size() == (uint32_t)dim &&
+      element_strides.size() == (uint32_t)dim);
+
+  CUtensorMap result;
+  CUresult ret_code = CUTLASS_CUDA_DRIVER_WRAPPER_CALL(cuTensorMapEncodeTiled)(
+      &result,
+      data_type,
+      dim,
+      global_ptr,
+      size.data(),
+      strides.data(),
+      box_size.data(),
+      element_strides.data(),
+      interleave_mode,
+      swizzle_mode,
+      l2_promotion,
+      oob_fill);
+  if (ret_code != CUresult::CUDA_SUCCESS) {
+    auto print_vector = [&](auto t, const char* fmt, const char end = '\n') {
+      for (auto elem : t) {
+        printf(fmt, elem);
+      }
+      printf("%c", end);
+    };
+    fprintf(stderr, "Failed to create tensormap\n");
+    fprintf(stderr, "Dim: %d\n", dim);
+    printf("size: ");
+    print_vector(size, "%lu ");
+    printf("strides: ");
+    print_vector(strides, "%lu ");
+    printf("box_size: ");
+    print_vector(box_size, "%u ");
+    printf("element_strides: ");
+    print_vector(element_strides, "%u ");
+    printf("global ptr: 0x%lx\n", (int64_t)global_ptr);
+    printf("data_type: %d\n", (int)data_type);
+    printf("swizzle_mode: %d\n", (int)swizzle_mode);
+    printf("l2_promotion: %d\n", (int)l2_promotion);
+    printf("interleave_mode: %d\n", (int)interleave_mode);
+    printf("oob_fill: %d\n", (int)oob_fill);
+    KU_ASSERT(false);
+  }
+  return result;
+}
+
+// Given strides (in number of elements), this function converts their datatype in uint64_t and then multiplies by
+// elem_size
+template <typename T>
+static inline std::vector<uint64_t> make_stride_helper(const std::vector<T>& strides_in_elems, size_t elem_size) {
+  std::vector<uint64_t> res;
+  for (auto stride : strides_in_elems) {
+    res.push_back(((uint64_t)stride) * elem_size);
+  }
+  return res;
+}
+
+}  // namespace kerutils

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/kerutils.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/kerutils/kerutils.cuh
@@ -1,0 +1,4 @@
+#pragma once
+
+#include "device/device.cuh"
+#include "host/host.h"

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/layout.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/layout.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2026 SGLang Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+namespace sm90::nvfp4 {
+
+static constexpr int kLatentDim = 512;
+static constexpr int kRopeDim = 64;
+static constexpr int kBlockSize = 16;
+static constexpr int kPackedLatentBytes = kLatentDim / 2;
+static constexpr int kScaleBytes = kLatentDim / kBlockSize;
+static constexpr int kRopeBytes = kRopeDim * 2;
+static constexpr int kBytesPerToken = kPackedLatentBytes + kScaleBytes + kRopeBytes;
+
+static_assert(kPackedLatentBytes == 256);
+static_assert(kScaleBytes == 32);
+static_assert(kBytesPerToken == 416);
+
+}  // namespace sm90::nvfp4

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/params.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/params.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include "cutlass/bfloat16.h"
+
+enum class ModelType { V32, MODEL1 };
+
+struct __align__(4 * 8) DecodingSchedMeta {
+  int begin_req_idx, end_req_idx;      // Both inclusive
+  int begin_block_idx, end_block_idx;  // Inclusive, exclusive
+  int begin_split_idx;
+  int is_first_req_splitted, is_last_req_splitted;
+  int _pad[1];
+};
+static constexpr int DecodingSchedMetaSize = sizeof(DecodingSchedMeta);
+
+struct DenseAttnDecodeParams {  // TODO Change name to DenseAttnDecodeParams
+  using index_t = int64_t;
+
+  int b;  // batch size
+  int s_q;
+  int q_seq_per_hk;   // The number of q(s) per KV head, = h_q / h_k * s_q
+  int d, d_v;         // K/V dimension
+  int h_q, h_k;       // The number of Q/K heads
+  int num_blocks;     // Number of blocks in total
+  int q_head_per_hk;  // The number of q_head(s) per KV head, = h_q / h_k
+  bool is_causal;
+  float scale_softmax, scale_softmax_log2;
+
+  void* __restrict__ q_ptr;
+  void* __restrict__ k_ptr;
+  void* __restrict__ o_ptr;
+  float* __restrict__ softmax_lse_ptr;
+
+  index_t q_batch_stride;
+  index_t k_batch_stride;
+  index_t o_batch_stride;
+  index_t q_row_stride;
+  index_t k_row_stride;
+  index_t o_row_stride;
+  index_t q_head_stride;
+  index_t k_head_stride;
+  index_t o_head_stride;
+
+  int* __restrict__ block_table;
+  index_t block_table_batch_stride;
+  int page_block_size;
+  int* __restrict__ seqlens_k_ptr;
+
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;
+  int num_sm_parts;
+  int* __restrict__ num_splits_ptr;
+
+  int total_num_splits;
+  float* __restrict__ softmax_lseaccum_ptr;
+  float* __restrict__ oaccum_ptr;
+
+  cudaStream_t stream;
+};
+
+struct SparseAttnDecodeParams {
+  int b, s_q;
+  int h_q, h_kv;
+  int d_qk, d_v;
+  float sm_scale, sm_scale_div_log2;
+  int num_blocks, page_block_size, topk;
+  ModelType model_type;
+
+  cutlass::bfloat16_t* __restrict__ q;   // [b, s_q, h_q, d_qk]
+  cutlass::bfloat16_t* __restrict__ kv;  // [num_blocks, page_block_size, d_qk]
+  int* __restrict__ indices;             // [b, s_q, topk]
+  int* __restrict__ topk_length;         // [b], may be nullptr
+  float* __restrict__ attn_sink;         // [h_q], may be nullptr
+
+  float* __restrict__ lse;                // [b, s_q, h_q]
+  cutlass::bfloat16_t* __restrict__ out;  // [b, s_q, h_q, d_v]
+
+  int extra_num_blocks, extra_page_block_size, extra_topk;
+  cutlass::bfloat16_t* __restrict__ extra_kv;  // [extra_num_blocks, extra_page_block_size, d_qk]
+  int* __restrict__ extra_indices;             // [b, s_q, extra_topk]
+  int* __restrict__ extra_topk_length;         // [b], may be nullptr
+
+  int stride_q_b, stride_q_s_q, stride_q_h_q;
+  int stride_kv_block, stride_kv_row;
+  int stride_indices_b, stride_indices_s_q;
+  int stride_lse_b, stride_lse_s_q;
+  int stride_o_b, stride_o_s_q, stride_o_h_q;
+  int stride_extra_kv_block, stride_extra_kv_row;
+  int stride_extra_indices_b, stride_extra_indices_s_q;
+
+  cudaStream_t stream;
+
+  // SplitKV-related parameters
+  float* __restrict__ lse_accum;  // [num_splits, s_q, h_q]
+  float* __restrict__ o_accum;    // [num_splits, s_q, h_q, d_v]
+  int stride_lse_accum_split, stride_lse_accum_s_q;
+  int stride_o_accum_split, stride_o_accum_s_q, stride_o_accum_h_q;
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;  // [num_sm_parts, ], contiguous
+  int* __restrict__ num_splits_ptr;                             // [batch_size+1, ], contiguous
+  int num_sm_parts;
+};
+
+struct CombineParams {
+  int b, s_q, h_q, d_v;
+
+  float* __restrict__ lse;  // [b, s_q, h_q]
+  void* __restrict__ out;   // [b, s_q, h_q, d_v]
+  int stride_lse_b, stride_lse_s_q;
+  int stride_o_b, stride_o_s_q, stride_o_h_q;
+
+  float* __restrict__ lse_accum;  // [num_splits, s_q, h_q]
+  float* __restrict__ o_accum;    // [num_splits, s_q, h_q, d_v]
+  int stride_lse_accum_split, stride_lse_accum_s_q;
+  int stride_o_accum_split, stride_o_accum_s_q, stride_o_accum_h_q;
+
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;  // [num_sm_parts, ], contiguous
+  int* __restrict__ num_splits_ptr;                             // [batch_size+1, ], contiguous
+  int num_sm_parts;
+
+  float* attn_sink;  // [h_q], may be nullptr
+
+  cudaStream_t stream;
+};
+
+struct GetDecodeSchedMetaParams {
+  int b;  // batch size
+  int s_q;
+  int block_size_n;
+  int fixed_overhead_num_blocks;
+
+  int topk, extra_topk;  // -1 if sparse attention (or extra topk) is disabled
+  int* __restrict__ topk_length, * __restrict__ extra_topk_length;
+
+  int* __restrict__ seqlens_k_ptr;  // Only necessary for dense attention
+
+  DecodingSchedMeta* __restrict__ tile_scheduler_metadata_ptr;
+  int* __restrict__ num_splits_ptr;
+  int num_sm_parts;
+
+  cudaStream_t stream;
+};
+
+struct SparseAttnFwdParams {
+  int s_q, s_kv, h_q, h_kv, d_qk, d_v, topk;
+  float sm_scale, sm_scale_div_log2;
+
+  // Input tensors
+  cutlass::bfloat16_t* __restrict__ q;   // [s_q, h_q, d_qk]
+  cutlass::bfloat16_t* __restrict__ kv;  // [s_kv, h_kv, d_qk]
+  int* __restrict__ indices;             // [s_q, h_kv, topk]
+  float* __restrict__ attn_sink;         // [h_q], may be nullptr
+  int* __restrict__ topk_length;         // [s_q], may be nullptr
+
+  // Strides
+  int stride_q_s_q;
+  int stride_q_h_q;
+  int stride_kv_s_kv;
+  int stride_kv_h_kv;
+  int stride_indices_s_q;
+  int stride_indices_h_kv;
+
+  // Output tensors
+  cutlass::bfloat16_t* __restrict__ out;  // [s_q, h_q, d_v]
+  float* __restrict__ max_logits;         // [s_q, h_q]
+  float* __restrict__ lse;                // [s_q, h_q]
+
+  int num_sm;
+  cudaStream_t stream;
+};
+
+// We have some kernels that implement both prefill and decode modes in a single kernel (with different template
+// instantiations). The following enum helps to distinguish the modes.
+enum class SparseAttnFwdMode {
+  Prefill,            // Normal prefill mode
+  DecodeWithSplitKV,  // To trigger decoding mode for kernels that support both prefill and decode
+};
+
+template <SparseAttnFwdMode FWD_MODE>
+inline constexpr bool is_decode_v = std::bool_constant<FWD_MODE == SparseAttnFwdMode::DecodeWithSplitKV>::value;
+
+template <SparseAttnFwdMode FWD_MODE>
+using SparseFwdArgT = std::conditional_t<is_decode_v<FWD_MODE>, SparseAttnDecodeParams, SparseAttnFwdParams>;

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/splitkv_mla.cuh
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/splitkv_mla.cuh
@@ -1,0 +1,804 @@
+#pragma once
+
+#include <cutlass/arch/barrier.h>
+#include <cutlass/arch/reg_reconfig.h>
+#include <cutlass/barrier.h>
+#include <cutlass/cluster_launch.hpp>
+
+#include "components/helpers.h"
+#include "config.h"
+#include "dequant.h"
+#include "flashmla_utils.h"
+#include "kerutils/kerutils.cuh"
+#include "splitkv_mla.h"
+#include <math_constants.h>
+using namespace cute;
+
+namespace sm90::decode::sparse_mxfp4_dsv4 {
+
+static constexpr float MAX_INIT_VAL = -1e30;  // Prevent (-inf) - (-inf) = nan
+using cutlass::arch::fence_view_async_shared;
+using cutlass::arch::NamedBarrier;
+
+// Every 368-byte MXFP4 row (and its page-block stride) is a multiple of 16
+// bytes, so the NoPE and RoPE payloads can be loaded with single aligned
+// vector loads.
+__device__ __forceinline__ bf16x8 load_bf16x8(const void* address) {
+  uint4 value;
+  asm volatile("ld.global.nc.L1::evict_last.L2::128B.v4.u32 {%0, %1, %2, %3}, [%4];"
+               : "=r"(value.x), "=r"(value.y), "=r"(value.z), "=r"(value.w)
+               : "l"(address));
+  bf16x8 result;
+  *reinterpret_cast<uint4*>(&result) = value;
+  return result;
+}
+
+template <typename Tensor0, typename Tensor1, typename Tensor2>
+__forceinline__ __device__ void scale_softmax(
+    Tensor0& rP,
+    Tensor1& rS,
+    Tensor2& rO,
+    float scale_softmax_log2,
+    float sScale[],
+    float rM[2],
+    float rL[2],
+    bool is_kv_valid[],
+    int block_idx,
+    int idx_in_warpgroup) {
+  float scale_for_olds[2];
+  CUTE_UNROLL
+  for (int local_row_idx = 0; local_row_idx < 2; ++local_row_idx) {
+    Tensor cur_rP = flatten(rP(make_coord(_, local_row_idx, _), _, _));
+    Tensor cur_rS = flatten(rS(make_coord(_, local_row_idx, _), _, _));
+    Tensor cur_rO = flatten(rO(make_coord(_, local_row_idx, _), _, _));
+
+    float cur_max = -INFINITY;
+    CUTE_UNROLL
+    for (int i = 0; i < size(cur_rP); ++i) {
+      if (!is_kv_valid[(i & 1) + (i / 2) * 8 + (idx_in_warpgroup % 4) * 2]) cur_rP(i) = -INFINITY;
+      cur_max = max(cur_max, cur_rP(i));
+    }
+    cur_max = max(cur_max, __shfl_xor_sync(0xffffffff, cur_max, 1));
+    cur_max = max(cur_max, __shfl_xor_sync(0xffffffff, cur_max, 2));
+
+    cur_max *= scale_softmax_log2;
+    float old_max = rM[local_row_idx];
+    rM[local_row_idx] = max(cur_max, old_max);
+    float scale_for_old = exp2f(old_max - rM[local_row_idx]);
+    scale_for_olds[local_row_idx] = scale_for_old;
+
+    CUTE_UNROLL
+    for (int i = 0; i < size(cur_rO); ++i) {
+      cur_rO(i) *= scale_for_old;
+    }
+
+    float cur_sum = 0;
+    CUTE_UNROLL
+    for (int i = 0; i < size(cur_rP); ++i) {
+      cur_rP(i) = exp2f(cur_rP(i) * scale_softmax_log2 - rM[local_row_idx]);
+      cur_rS(i) = (bf16)cur_rP(i);
+      cur_sum += cur_rP(i);
+    }
+
+    rL[local_row_idx] = rL[local_row_idx] * scale_for_old + cur_sum;
+  }
+  if (idx_in_warpgroup % 4 == 0) *(float2*)(sScale + 2 * (idx_in_warpgroup / 4)) = *(float2*)(scale_for_olds);
+}
+
+template <int NUM_HEADS>
+template <typename TMAParams>
+__device__ void KernelTemplate<NUM_HEADS>::devfunc(const SparseAttnDecodeParams& params, const TMAParams& tma_params) {
+#if (defined(__CUDA_ARCH__) && (__CUDA_ARCH__ == 900)) || (defined(__CLION_IDE__) || defined(__VSCODE_IDE__))
+  const int head_block_idx = NUM_M_BLOCKS == 1 ? 0 : blockIdx.x;
+  const int s_q_idx = blockIdx.y;
+  const int partition_idx = blockIdx.z;
+  const int idx_in_cluster = CLUSTER_SIZE == 1 ? 0 : head_block_idx % 2;
+  const int warpgroup_idx = cutlass::canonical_warp_group_idx();
+  const int idx_in_warpgroup = threadIdx.x % 128;
+  const int warp_idx = cutlass::canonical_warp_idx_sync();
+
+  // Define shared tensors
+  extern __shared__ char wksp_buf[];
+  SharedMemoryPlan& plan = *reinterpret_cast<SharedMemoryPlan*>(wksp_buf);
+  Tensor sQ = make_tensor(make_smem_ptr(plan.q.data()), SmemLayoutQ{});
+  Tensor sOBuf = make_tensor(make_smem_ptr(plan.u.oBuf.data()), SmemLayoutOBuf{});
+  Tensor sOAccumBuf = make_tensor(make_smem_ptr(plan.u.oAccumBuf.data()), SmemLayoutOAccumBuf{});
+  Tensor sS = make_tensor(make_smem_ptr(plan.s.data()), SmemLayoutS{});
+  float* sM = plan.sM;
+  float* sL = plan.sL;
+  float* sScale = plan.sScale;
+
+  // Prefetch TMA descriptors
+  if (warp_idx == 0 && elect_one_sync()) {
+    cute::prefetch_tma_descriptor(tma_params.tma_Q.get_tma_descriptor());
+    cute::prefetch_tma_descriptor(&tma_params.tensor_map_o);
+  }
+
+  // Initialize TMA barriers
+  if (warp_idx == 0 && elect_one_sync()) {
+    plan.bar_q.init(1);
+    if constexpr (CLUSTER_SIZE == 2) {
+      CUTE_UNROLL
+      for (int i = 0; i < NUM_K_BUFS; ++i) {
+        plan.bar_k_local_ready[i].init(128);
+        plan.bar_k_remote_ready[i].init(1);
+        plan.bar_k_avail[i].init(4);
+      }
+    } else {
+      CUTE_UNROLL
+      for (int i = 0; i < NUM_K_BUFS; ++i) {
+        plan.bar_k_local_ready[i].init(128);
+        plan.bar_k_avail[i].init(256);
+      }
+    }
+    plan.bar_o_done.init(256);
+    cutlass::arch::fence_barrier_init();
+  }
+  ku::barrier_cluster_arrive_relaxed();
+
+  int bar_phase_k = 0;  // Don't use array here to prevent using local memory
+  int bar_phase_o = 0;  // phase tracker for bar_o_done (epilogue drain)
+
+  // Programmatic Dependent Launch: Wait for the previous kernel to finish
+  // Don't use PDL because of compiler bugs!
+  // cudaGridDependencySynchronize();
+
+  DecodingSchedMeta sched_meta = params.tile_scheduler_metadata_ptr[partition_idx];
+
+  if (sched_meta.begin_req_idx >= params.b) return;
+
+  // The barrier init above is performed by one elected warp-0 lane while
+  // arrive_relaxed only asynchronously signals arrival. Issue the first TMA
+  // (which arrives on bar_q) only after the cluster-wide acquire so every
+  // barrier init is visible — otherwise bar_q can be used uninitialized.
+  ku::barrier_cluster_wait_acquire();
+
+  if (warp_idx == 0 && elect_one_sync()) {
+    Tensor gQ = flat_divide(
+        tma_params.tma_Q.get_tma_tensor(tma_params.shape_Q)(_, _, s_q_idx, sched_meta.begin_req_idx),
+        Tile<Int<BLOCK_M>, Int<HEAD_DIM_K>>{})(_, _, head_block_idx, _0{});
+    launch_tma_copy(tma_params.tma_Q, gQ, sQ, plan.bar_q, TMA::CacheHintSm90::EVICT_FIRST);
+    plan.bar_q.arrive_and_expect_tx(BLOCK_M * HEAD_DIM_K * sizeof(bf16));
+  }
+
+  struct MainloopArgs {
+    int start_block_idx, end_block_idx;
+    bool is_no_split;
+
+    int topk_length, extra_topk_length, num_orig_kv_blocks;
+  };
+  auto get_cur_req_info = [&](int batch_idx) -> MainloopArgs {
+    MainloopArgs args;
+    int topk_length = params.topk_length ? __ldg(params.topk_length + batch_idx) : params.topk;
+    topk_length = max(0, min(topk_length, params.topk));
+    int orig_topk_padded = max(ku::ceil(topk_length, (int)TOPK_BLOCK_SIZE), (int)TOPK_BLOCK_SIZE);
+    int extra_topk_length = params.extra_topk_length ? __ldg(params.extra_topk_length + batch_idx) : params.extra_topk;
+    extra_topk_length = max(0, min(extra_topk_length, params.extra_topk));
+    int total_topk_padded = orig_topk_padded + ku::ceil(extra_topk_length, (int)TOPK_BLOCK_SIZE);
+    args.topk_length = topk_length;
+    args.extra_topk_length = extra_topk_length;
+    args.num_orig_kv_blocks = orig_topk_padded / TOPK_BLOCK_SIZE;
+
+    args.start_block_idx = batch_idx == sched_meta.begin_req_idx ? sched_meta.begin_block_idx : 0;
+    args.end_block_idx =
+        batch_idx == sched_meta.end_req_idx ? sched_meta.end_block_idx : total_topk_padded / TOPK_BLOCK_SIZE;
+    args.is_no_split = batch_idx == sched_meta.begin_req_idx
+                           ? !sched_meta.is_first_req_splitted
+                           : (batch_idx == sched_meta.end_req_idx ? !sched_meta.is_last_req_splitted : true);
+
+    return args;
+  };
+
+  if (warpgroup_idx == 0) {
+    cutlass::arch::warpgroup_reg_alloc<192>();
+
+    TiledMMA tiled_mma_QK = TiledMMA_QK{};
+    ThrMMA thr_mma_QK = tiled_mma_QK.get_slice(idx_in_warpgroup);
+    TiledMMA tiled_mma_PV = TiledMMA_PV_LocalP{};
+    ThrMMA thr_mma_PV = tiled_mma_PV.get_slice(idx_in_warpgroup);
+
+    float rL[2], rM[2];
+    Tensor rO = partition_fragment_C(TiledMMA_PV_LocalP{}, Shape<Int<BLOCK_M>, Int<HEAD_DIM_V / 2>>{});
+    Tensor rP = partition_fragment_C(TiledMMA_QK{}, Shape<Int<BLOCK_M>, Int<TOPK_BLOCK_SIZE>>{});
+    Tensor rS = make_tensor<bf16>(partition_shape_A(TiledMMA_PV_LocalP{}, Shape<Int<BLOCK_M>, Int<TOPK_BLOCK_SIZE>>{}));
+
+    float rAttn_sink[2] = {-CUDART_INF_F, -CUDART_INF_F};
+    if (params.attn_sink != nullptr) {
+      for (int i = 0; i < 2; ++i) {
+        int head_idx = head_block_idx * BLOCK_M + get_AorC_row_idx(i, idx_in_warpgroup);
+        rAttn_sink[i] = __ldg((float*)params.attn_sink + head_idx) * CUDART_L2E_F;
+      }
+    }
+
+#pragma unroll 1
+    for (int batch_idx = sched_meta.begin_req_idx; batch_idx <= sched_meta.end_req_idx; ++batch_idx) {
+      MainloopArgs args = get_cur_req_info(batch_idx);
+
+      rL[0] = rL[1] = 0.0f;
+      rM[0] = rM[1] = MAX_INIT_VAL;
+      cute::fill(rO, 0.);
+
+      // Wait for Q
+      plan.bar_q.wait((sched_meta.begin_req_idx - batch_idx) & 1);
+
+      CUTE_NO_UNROLL
+      for (int block_idx = args.start_block_idx; block_idx < args.end_block_idx; block_idx++) {
+        int buf_idx = (block_idx - args.start_block_idx) % NUM_K_BUFS;
+        Tensor sK = make_tensor(make_smem_ptr(plan.u.k[buf_idx].data()), SmemLayoutK{});
+        Tensor sV = make_tensor(make_smem_ptr(plan.u.k[buf_idx].data()), SmemLayoutHalfV{});
+
+        // Wait, issue WGMMA
+        plan.bar_k_local_ready[buf_idx].wait(bar_phase_k >> buf_idx & 1);
+        if constexpr (CLUSTER_SIZE == 2) {
+          plan.bar_k_remote_ready[buf_idx].wait(bar_phase_k >> buf_idx & 1);
+        }
+
+        gemm<true, -1>(tiled_mma_QK, thr_mma_QK.partition_fragment_A(sQ), thr_mma_QK.partition_fragment_B(sK), rP);
+
+        bar_phase_k ^= 1 << buf_idx;
+
+        cute::warpgroup_wait<0>();
+
+        // Calculate S = softmax(mask(scale(P)))
+        if (block_idx != args.start_block_idx)
+          NamedBarrier::arrive_and_wait(
+              256, NamedBarriers::sScale_and_sS_free);  // Make sure that sScale and sS is free
+
+        // Since in our case TOPK_BLOCK_SIZE == BLOCK_M, so we only need to do OOB checking for the last 2 blocks
+        scale_softmax(
+            rP,
+            rS,
+            rO,
+            params.sm_scale_div_log2,
+            sScale,
+            rM,
+            rL,
+            plan.is_kv_valid[buf_idx],
+            block_idx,
+            idx_in_warpgroup);
+
+        // Store S into shared, inform warpgroup 1
+        save_rPb_to_sP(rS, sS, idx_in_warpgroup);
+        fence_view_async_shared();
+
+        // Issue O += S @ V
+        gemm<false, -1>(tiled_mma_PV, rS, thr_mma_PV.partition_fragment_B(sV), rO);
+
+        NamedBarrier::arrive(256, NamedBarriers::sScale_and_sS_ready);
+
+        cute::warpgroup_wait<0>();
+
+        if constexpr (CLUSTER_SIZE == 2) {
+          plan.bar_k_avail[buf_idx].arrive(0, idx_in_warpgroup == 32);
+          plan.bar_k_avail[buf_idx].arrive(1, idx_in_warpgroup == 64);
+        } else {
+          plan.bar_k_avail[buf_idx].arrive();
+        }
+      }
+
+      // Copy the next q
+      if (threadIdx.x / 32 == 0 && elect_one_sync()) {
+        if (batch_idx != sched_meta.end_req_idx) {
+          Tensor gQ = flat_divide(
+              tma_params.tma_Q.get_tma_tensor(tma_params.shape_Q)(_, _, s_q_idx, batch_idx + 1),
+              Tile<Int<BLOCK_M>, Int<HEAD_DIM_K>>{})(_, _, head_block_idx, _0{});
+          launch_tma_copy(tma_params.tma_Q, gQ, sQ, plan.bar_q, TMA::CacheHintSm90::EVICT_FIRST);
+          plan.bar_q.arrive_and_expect_tx(BLOCK_M * HEAD_DIM_K * sizeof(bf16));
+        }
+      }
+
+      // Synchronize L and M across warpgroups
+      rL[0] += __shfl_xor_sync(0xffffffff, rL[0], 1);
+      rL[0] += __shfl_xor_sync(0xffffffff, rL[0], 2);
+      rL[1] += __shfl_xor_sync(0xffffffff, rL[1], 1);
+      rL[1] += __shfl_xor_sync(0xffffffff, rL[1], 2);
+
+      if (idx_in_warpgroup % 4 == 0) {
+        CUTE_UNROLL
+        for (int i = 0; i < 2; ++i) {
+          int row = get_AorC_row_idx(i, idx_in_warpgroup);
+          sL[row] = rL[i];
+          sM[row] = rM[i];
+        }
+      }
+
+      float o_scales[2];
+      CUTE_UNROLL
+      for (int i = 0; i < 2; ++i) {
+        if (args.is_no_split) {
+          o_scales[i] = rL[i] == 0.0f ? 0.0f : __fdividef(1.0f, rL[i] + exp2f(rAttn_sink[i] - rM[i]));
+        } else {
+          o_scales[i] = rL[i] == 0.0f ? 0.0f : __fdividef(1.0f, rL[i]);
+        }
+        if (idx_in_warpgroup % 4 == 0) {
+          int row = get_AorC_row_idx(i, idx_in_warpgroup);
+          plan.sOScale[row] = o_scales[i];
+        }
+      }
+
+      // This is a synchronization point for warpgroup 0/1.
+      // Warpgroup 0 should wait wg 1 for oBuf/oAccumBuf (overlapped with k) to be free
+      // Warpgroup 1 should wait wg 0 for sL to be ready
+      NamedBarrier::arrive_and_wait(256, NamedBarriers::oBuf_free_and_sL_ready);
+
+      CUTE_UNROLL
+      for (int i = 0; i < 2; ++i)
+        rL[i] = rL[i] == 0.0f ? 1.0f : rL[i];
+
+      int start_head_idx = head_block_idx * BLOCK_M;
+      int num_valid_seq_q = min(params.h_q - start_head_idx, BLOCK_M);
+      if (args.is_no_split) {
+        bf16* o_ptr = (bf16*)params.out + batch_idx * params.stride_o_b + s_q_idx * params.stride_o_s_q +
+                      start_head_idx * params.stride_o_h_q;  // (BLOCK_M, HEAD_DIM_V) : (params.stride_o_h_q, 1)
+        Tensor gO = make_tensor(
+            make_gmem_ptr(o_ptr),
+            make_layout(Shape<Int<BLOCK_M>, Int<HEAD_DIM_V>>{}, make_stride(params.stride_o_h_q, _1{})));
+        float* gSoftmaxLse = (float*)params.lse + batch_idx * params.stride_lse_b + s_q_idx * params.stride_lse_s_q +
+                             start_head_idx;  // (BLOCK_M) : (1)
+
+        store_o<true>(
+            rO,
+            gO,
+            sOBuf,
+            sOAccumBuf,
+            plan,
+            o_scales,
+            tma_params,
+            batch_idx,
+            s_q_idx,
+            head_block_idx,
+            num_valid_seq_q,
+            warpgroup_idx,
+            idx_in_warpgroup);
+
+        int i = threadIdx.x;
+        if (i < num_valid_seq_q) {
+          float cur_L = sL[i];
+          gSoftmaxLse[i] = cur_L == 0.0f ? INFINITY : logf(cur_L) + sM[i] / (float)M_LOG2E;
+        }
+
+        cute::tma_store_wait<0>();
+      } else {
+        int n_split_idx = batch_idx == sched_meta.begin_req_idx ? sched_meta.begin_split_idx : 0;
+        int split_idx = __ldg(params.num_splits_ptr + batch_idx) + n_split_idx;
+        float* oaccum_ptr =
+            (float*)params.o_accum + split_idx * params.stride_o_accum_split + s_q_idx * params.stride_o_accum_s_q +
+            start_head_idx * params.stride_o_accum_h_q;  // (BLOCK_M, HEAD_DIM_V) : (params.stride_o_accum_h_q, 1)
+        float* gSoftmaxLseAccum = (float*)params.lse_accum + split_idx * params.stride_lse_accum_split +
+                                  s_q_idx * params.stride_lse_accum_s_q + start_head_idx;  // (BLOCK_M) : (1)
+        Tensor gOAccum = make_tensor(
+            make_gmem_ptr(oaccum_ptr),
+            make_layout(Shape<Int<BLOCK_M>, Int<HEAD_DIM_V>>{}, make_stride(params.stride_o_accum_h_q, _1{})));
+        store_o<false>(
+            rO,
+            gOAccum,
+            sOBuf,
+            sOAccumBuf,
+            plan,
+            o_scales,
+            tma_params,
+            batch_idx,
+            s_q_idx,
+            head_block_idx,
+            num_valid_seq_q,
+            warpgroup_idx,
+            idx_in_warpgroup);
+
+        int i = threadIdx.x;
+        if (i < num_valid_seq_q) {
+          float cur_L = sL[i];
+          gSoftmaxLseAccum[i] = cur_L == 0.0f ? -INFINITY : log2f(cur_L) + sM[i];
+        }
+
+        cute::tma_store_wait<0>();
+      }
+
+      // Tell the producer that the epilogue (oBuf) has fully drained the K
+      // buffer overlay before it starts writing the next request's rows.
+      plan.bar_o_done.arrive();
+
+      // Signal programmatic launch completion as soon as the epilogue has
+      // drained o_accum/lse_accum (tma_store_wait above); combine can start
+      // while the remaining threads still reach the cluster sync below.
+      if (batch_idx == sched_meta.end_req_idx && threadIdx.x / 32 == 0 && elect_one_sync()) {
+        cudaTriggerProgrammaticLaunchCompletion();
+      }
+
+      sync_all_threads_in_cluster();
+    }
+  } else if (warpgroup_idx == 1) {
+    cutlass::arch::warpgroup_reg_dealloc<160>();
+
+    TiledMMA tiled_mma_PV = TiledMMA_PV_RemoteP{};
+    ThrMMA thr_mma_PV = tiled_mma_PV.get_slice(idx_in_warpgroup);
+    Tensor rO = partition_fragment_C(tiled_mma_PV, Shape<Int<BLOCK_M>, Int<HEAD_DIM_V / 2>>{});
+
+#pragma unroll 1
+    for (int batch_idx = sched_meta.begin_req_idx; batch_idx <= sched_meta.end_req_idx; ++batch_idx) {
+      MainloopArgs args = get_cur_req_info(batch_idx);
+      cute::fill(rO, 0.);
+
+      CUTE_NO_UNROLL
+      for (int block_idx = args.start_block_idx; block_idx < args.end_block_idx; block_idx++) {
+        int buf_idx = (block_idx - args.start_block_idx) % NUM_K_BUFS;
+        Tensor sV =
+            make_tensor(make_smem_ptr(plan.u.k[buf_idx].data() + (SmemLayoutV{})(_256{}, _0{})), SmemLayoutHalfV{});
+
+        // Wait for S and sScale
+        NamedBarrier::arrive_and_wait(256, NamedBarriers::sScale_and_sS_ready);
+
+        // Scale O
+        float cur_scales[2];
+        *(float2*)cur_scales = *(float2*)(sScale + (idx_in_warpgroup / 4) * 2);
+        CUTE_UNROLL
+        for (int local_row_idx = 0; local_row_idx < 2; ++local_row_idx) {
+          Tensor cur_rO = flatten(rO(make_coord(_, local_row_idx, _), _, _));
+          CUTE_UNROLL
+          for (int i = 0; i < size(cur_rO); ++i) {
+            cur_rO(i) *= cur_scales[local_row_idx];
+          }
+        }
+
+        // Issue O += S @ V, and wait
+        gemm<false, -1>(tiled_mma_PV, thr_mma_PV.partition_fragment_A(sS), thr_mma_PV.partition_fragment_B(sV), rO);
+        cute::warpgroup_wait<0>();
+
+        if constexpr (CLUSTER_SIZE == 2) {
+          plan.bar_k_avail[buf_idx].arrive(0, idx_in_warpgroup == 32);
+          plan.bar_k_avail[buf_idx].arrive(1, idx_in_warpgroup == 64);
+        } else {
+          plan.bar_k_avail[buf_idx].arrive();
+        }
+
+        if (block_idx != args.end_block_idx - 1)
+          NamedBarrier::arrive(256, NamedBarriers::sScale_and_sS_free);  // Tell WG0 that sScale and sS are available
+      }
+
+      NamedBarrier::arrive_and_wait(256, NamedBarriers::oBuf_free_and_sL_ready);
+
+      float o_scales[2];
+      CUTE_UNROLL
+      for (int i = 0; i < 2; ++i) {
+        int row = get_AorC_row_idx(i, idx_in_warpgroup);
+        o_scales[i] = plan.sOScale[row];
+      }
+
+      int start_head_idx = head_block_idx * BLOCK_M;
+      int num_valid_seq_q = min(params.h_q - start_head_idx, BLOCK_M);
+      if (args.is_no_split) {
+        bf16* o_ptr = (bf16*)params.out + batch_idx * params.stride_o_b + s_q_idx * params.stride_o_s_q +
+                      start_head_idx * params.stride_o_h_q;  // (BLOCK_M, HEAD_DIM_V) : (params.stride_o_h_q, 1)
+        Tensor gO = make_tensor(
+            make_gmem_ptr(o_ptr),
+            make_layout(Shape<Int<BLOCK_M>, Int<HEAD_DIM_V>>{}, make_stride(params.stride_o_h_q, _1{})));
+
+        store_o<true>(
+            rO,
+            gO,
+            sOBuf,
+            sOAccumBuf,
+            plan,
+            o_scales,
+            tma_params,
+            batch_idx,
+            s_q_idx,
+            head_block_idx,
+            num_valid_seq_q,
+            warpgroup_idx,
+            idx_in_warpgroup);
+
+        cute::tma_store_wait<0>();
+      } else {
+        int n_split_idx = batch_idx == sched_meta.begin_req_idx ? sched_meta.begin_split_idx : 0;
+        int split_idx = __ldg(params.num_splits_ptr + batch_idx) + n_split_idx;
+        float* oaccum_ptr =
+            (float*)params.o_accum + split_idx * params.stride_o_accum_split + s_q_idx * params.stride_o_accum_s_q +
+            start_head_idx * params.stride_o_accum_h_q;  // (BLOCK_M, HEAD_DIM_V) : (params.stride_o_accum_h_q, 1)
+        Tensor gOAccum = make_tensor(
+            make_gmem_ptr(oaccum_ptr),
+            make_layout(Shape<Int<BLOCK_M>, Int<HEAD_DIM_V>>{}, make_stride(params.stride_o_accum_h_q, _1{})));
+        store_o<false>(
+            rO,
+            gOAccum,
+            sOBuf,
+            sOAccumBuf,
+            plan,
+            o_scales,
+            tma_params,
+            batch_idx,
+            s_q_idx,
+            head_block_idx,
+            num_valid_seq_q,
+            warpgroup_idx,
+            idx_in_warpgroup);
+
+        cute::tma_store_wait<0>();
+      }
+
+      // Same epilogue-drain signal as warpgroup 0 (256 arrivals per request).
+      plan.bar_o_done.arrive();
+
+      sync_all_threads_in_cluster();
+    }
+  } else {
+    // Producer warpgroup. Each group of four lanes owns one selected token;
+    // each lane dequantizes one 16-element E2M1 block at a time.
+    cutlass::arch::warpgroup_reg_dealloc<152>();
+
+    static_assert(CLUSTER_SIZE == 1 || CLUSTER_SIZE == 2);
+    static constexpr int NUM_TOKENS_PER_THREAD = CLUSTER_SIZE == 1 ? 2 : 1;
+    static constexpr int NUM_TOKENS_PER_ROUND = 32;
+    const int producer_warp_idx = __shfl_sync(0xffffffff, idx_in_warpgroup / 32, 0);
+    const int lane_idx = idx_in_warpgroup % 32;
+    const int my_token_idx_base = producer_warp_idx * 8 + lane_idx % 8;
+
+    CUTE_NO_UNROLL
+    for (int batch_idx = sched_meta.begin_req_idx; batch_idx <= sched_meta.end_req_idx; ++batch_idx) {
+      MainloopArgs args = get_cur_req_info(batch_idx);
+      // A fast producer must not overwrite the K buffers while the consumer
+      // warpgroups' epilogue is still draining oBuf from the previous request.
+      // (The first request has no prior epilogue; the phase then advances one
+      // flip per request, matching the 256 consumer arrivals above.)
+      if (batch_idx != sched_meta.begin_req_idx) {
+        plan.bar_o_done.wait(bar_phase_o);
+        bar_phase_o ^= 1;
+      }
+
+      int* gIndices = params.indices + batch_idx * params.stride_indices_b + s_q_idx * params.stride_indices_s_q;
+      int* gExtraIndices = params.extra_indices == nullptr
+                               ? nullptr
+                               : params.extra_indices + batch_idx * params.stride_extra_indices_b +
+                                     s_q_idx * params.stride_extra_indices_s_q;
+
+      struct IsOrigBlock {};
+      struct IsExtraBlock {};
+
+      auto process_one_block = [&](int block_idx, auto is_extra_block_t) {
+        static constexpr bool IS_EXTRA_BLOCK = std::is_same_v<decltype(is_extra_block_t), IsExtraBlock>;
+        const int buf_idx = (block_idx - args.start_block_idx) % NUM_K_BUFS;
+        const int rel_block_idx = IS_EXTRA_BLOCK ? block_idx - args.num_orig_kv_blocks : block_idx;
+        int* const indices_base = (IS_EXTRA_BLOCK ? gExtraIndices : gIndices) + rel_block_idx * TOPK_BLOCK_SIZE;
+        const int page_block_size = IS_EXTRA_BLOCK ? params.extra_page_block_size : params.page_block_size;
+        const int num_blocks = IS_EXTRA_BLOCK ? params.extra_num_blocks : params.num_blocks;
+        const int topk_length = IS_EXTRA_BLOCK ? args.extra_topk_length : args.topk_length;
+        const int64_t k_block_stride = IS_EXTRA_BLOCK ? params.stride_extra_kv_block : params.stride_kv_block;
+        const int64_t k_row_stride = IS_EXTRA_BLOCK ? params.stride_extra_kv_row : params.stride_kv_row;
+        const uint8_t* const k_ptr = reinterpret_cast<const uint8_t*>(IS_EXTRA_BLOCK ? params.extra_kv : params.kv);
+        const int64_t token_capacity = static_cast<int64_t>(num_blocks) * page_block_size;
+        transac_bar_t* const peer_bar_k_remote_ready = get_peer_addr(&plan.bar_k_remote_ready[buf_idx]);
+
+        CUTE_UNROLL
+        for (int round = 0; round < NUM_TOKENS_PER_THREAD; ++round) {
+          const int my_token_idx = my_token_idx_base + round * NUM_TOKENS_PER_ROUND;
+          const int selected_pos =
+              rel_block_idx * TOPK_BLOCK_SIZE + idx_in_cluster * (TOPK_BLOCK_SIZE / 2) + my_token_idx;
+          const int token_index = selected_pos < topk_length
+                                      ? __ldg(indices_base + idx_in_cluster * (TOPK_BLOCK_SIZE / 2) + my_token_idx)
+                                      : -1;
+          const bool token_is_valid = token_index >= 0 && static_cast<int64_t>(token_index) < token_capacity;
+          const int safe_token_index = token_is_valid ? token_index : 0;
+          const uint8_t* gK_base = nullptr;
+          if (token_is_valid) {
+            const int block_index =
+                page_block_size > 0
+                    ? static_cast<int>(static_cast<uint32_t>(safe_token_index) / static_cast<uint32_t>(page_block_size))
+                    : 0;
+            const int rel_idx_in_block =
+                page_block_size > 0
+                    ? static_cast<int>(static_cast<uint32_t>(safe_token_index) % static_cast<uint32_t>(page_block_size))
+                    : 0;
+            gK_base = k_ptr + block_index * k_block_stride + rel_idx_in_block * k_row_stride;
+          }
+
+          bf16* const sK_nope_base = plan.u.k[buf_idx].data() +
+                                     (idx_in_cluster * (TOPK_BLOCK_SIZE / 2) + my_token_idx) * 8 +
+                                     ((lane_idx / 8) * 16) * TOPK_BLOCK_SIZE;
+          bf16* const sK_nope_peer_base = get_peer_addr(sK_nope_base);
+
+          // The buffer can overlap with the prior consumer. Do not
+          // write any K/V data until both consumer warpgroups release it.
+          if (round == 0) {
+            plan.bar_k_avail[buf_idx].wait((bar_phase_k >> buf_idx & 1) ^ 1);
+          }
+
+          if constexpr (CLUSTER_SIZE == 2) {
+            if (round == 0 && idx_in_warpgroup == 0) {
+              plan.bar_k_remote_ready[buf_idx].arrive_and_expect_tx(
+                  (TOPK_BLOCK_SIZE / 2) * (HEAD_DIM_NOPE + HEAD_DIM_ROPE) * sizeof(bf16));
+            }
+          }
+
+          CUTE_UNROLL
+          for (int dim_idx = 0; dim_idx < HEAD_DIM_NOPE / 64; ++dim_idx) {
+            // Each lane group owns 16 consecutive NoPE dims within the 64-dim
+            // tile; SCALE_BLOCK_SIZE only groups the E8M0 scale bytes below.
+            const int logical_dim = dim_idx * 64 + (lane_idx / 8) * 16;
+            uint64_t packed = 0;
+            uint8_t block_scale_bits = 0;
+            if (token_is_valid) {
+              packed = nvfp4::load_packed_e2m1x16(gK_base + logical_dim / 2);
+              block_scale_bits = mxfp4::load_scale_bits(gK_base + PACKED_NOPE_BYTES + logical_dim / SCALE_BLOCK_SIZE);
+            }
+            const float effective_scale = token_is_valid ? mxfp4::e8m0_bits_to_float(block_scale_bits) : 0.0f;
+            const nvfp4::bf16x16 dequant = nvfp4::dequant_e2m1x16(packed, effective_scale);
+            const int smem_offset = dim_idx * 64 * TOPK_BLOCK_SIZE;
+
+            *reinterpret_cast<__int128_t*>(sK_nope_base + smem_offset) =
+                *reinterpret_cast<const __int128_t*>(&dequant.lo);
+            *reinterpret_cast<__int128_t*>(sK_nope_base + smem_offset + 8 * TOPK_BLOCK_SIZE) =
+                *reinterpret_cast<const __int128_t*>(&dequant.hi);
+            if constexpr (CLUSTER_SIZE == 2) {
+              st_async_128b(sK_nope_peer_base + smem_offset, dequant.lo, peer_bar_k_remote_ready);
+              st_async_128b(sK_nope_peer_base + smem_offset + 8 * TOPK_BLOCK_SIZE, dequant.hi, peer_bar_k_remote_ready);
+            }
+          }
+
+          const uint8_t* const gK_rope =
+              token_is_valid ? gK_base + PACKED_NOPE_BYTES + NUM_SCALES + PAD_BYTES + (lane_idx / 8) * 8 * sizeof(bf16)
+                             : nullptr;
+          bf16* const sK_rope_base = plan.u.k[buf_idx].data() +
+                                     (idx_in_cluster * (TOPK_BLOCK_SIZE / 2) + my_token_idx) * 8 +
+                                     ((lane_idx / 8) * 8) * TOPK_BLOCK_SIZE;
+          bf16* const sK_rope_peer_base = get_peer_addr(sK_rope_base);
+
+          CUTE_UNROLL
+          for (int dim_idx = 0; dim_idx < HEAD_DIM_ROPE / 32; ++dim_idx) {
+            bf16x8 rope = {};
+            if (token_is_valid) {
+              rope = load_bf16x8(gK_rope + dim_idx * 32 * sizeof(bf16));
+            }
+            const int smem_offset = (HEAD_DIM_NOPE + dim_idx * 32) * TOPK_BLOCK_SIZE;
+            *reinterpret_cast<__int128_t*>(sK_rope_base + smem_offset) = *reinterpret_cast<const __int128_t*>(&rope);
+            if constexpr (CLUSTER_SIZE == 2) {
+              st_async_128b(sK_rope_peer_base + smem_offset, rope, peer_bar_k_remote_ready);
+            }
+          }
+        }
+
+        fence_view_async_shared();
+
+        if (idx_in_warpgroup < 32) {
+          const int pos0 = rel_block_idx * TOPK_BLOCK_SIZE + lane_idx * 2;
+          const int pos1 = pos0 + 1;
+          const int selected0 = pos0 < topk_length ? __ldg(indices_base + lane_idx * 2) : -1;
+          const int selected1 = pos1 < topk_length ? __ldg(indices_base + lane_idx * 2 + 1) : -1;
+          *reinterpret_cast<char2*>(&plan.is_kv_valid[buf_idx][lane_idx * 2]) = {
+              selected0 >= 0 && static_cast<int64_t>(selected0) < token_capacity,
+              selected1 >= 0 && static_cast<int64_t>(selected1) < token_capacity,
+          };
+        }
+
+        plan.bar_k_local_ready[buf_idx].arrive();
+        bar_phase_k ^= 1 << buf_idx;
+      };
+
+      CUTE_NO_UNROLL
+      for (int block_idx = args.start_block_idx; block_idx < min(args.num_orig_kv_blocks, args.end_block_idx);
+           ++block_idx) {
+        process_one_block(block_idx, IsOrigBlock{});
+      }
+
+      CUTE_NO_UNROLL
+      for (int block_idx = max(args.start_block_idx, args.num_orig_kv_blocks); block_idx < args.end_block_idx;
+           ++block_idx) {
+        process_one_block(block_idx, IsExtraBlock{});
+      }
+
+      sync_all_threads_in_cluster();
+    }
+  }
+#else
+  if (cute::thread0()) {
+    CUTE_INVALID_CONTROL_PATH("This kernel only supports sm90");
+  }
+#endif
+}
+
+template <typename Kernel, typename TMAParams>
+__global__ void __launch_bounds__(Kernel::NUM_THREADS, 1, Kernel::CLUSTER_SIZE)
+    flash_fwd_splitkv_mla_mxfp4_dsv4_scaled_sparse_kernel(
+        __grid_constant__ const SparseAttnDecodeParams params, __grid_constant__ const TMAParams tma_params) {
+  Kernel::devfunc(params, tma_params);
+}
+
+template <int NUM_HEADS>
+void KernelTemplate<NUM_HEADS>::run(const SparseAttnDecodeParams& params) {
+  KU_ASSERT(params.h_kv == 1);
+  KU_ASSERT(params.topk % TOPK_BLOCK_SIZE == 0);
+  KU_ASSERT(params.extra_topk % TOPK_BLOCK_SIZE == 0);
+  KU_ASSERT(params.d_qk == HEAD_DIM_K);
+  KU_ASSERT(params.d_v == HEAD_DIM_V);
+  KU_ASSERT(params.h_q == NUM_HEADS);
+  KU_ASSERT(params.page_block_size > 0);
+  KU_ASSERT(params.num_blocks > 0);
+  KU_ASSERT(params.kv != nullptr);
+  KU_ASSERT(
+      params.stride_kv_row == BYTES_PER_TOKEN,
+      "Each primary MXFP4 KV row must match the specialization's contiguous byte width");
+  if (params.extra_kv != nullptr) {
+    KU_ASSERT(params.extra_indices != nullptr);
+    KU_ASSERT(params.extra_page_block_size > 0);
+    KU_ASSERT(params.extra_num_blocks > 0);
+    KU_ASSERT(
+        params.stride_extra_kv_row == BYTES_PER_TOKEN,
+        "Each extra MXFP4 KV row must contain exactly 368 contiguous bytes");
+  } else {
+    KU_ASSERT(params.extra_indices == nullptr);
+    KU_ASSERT(params.extra_topk == 0);
+  }
+
+  auto shape_Q = make_shape(params.h_q, params.d_qk, params.s_q, params.b);
+  auto tma_Q = cute::make_tma_copy(
+      SM90_TMA_LOAD{},
+      make_tensor(
+          make_gmem_ptr((bf16*)params.q),
+          make_layout(shape_Q, make_stride(params.stride_q_h_q, _1{}, params.stride_q_s_q, params.stride_q_b))),
+      SmemLayoutQ{});
+
+  CUtensorMap tensor_map_o;
+  {
+    // Here we manually construct TMA descriptor to store O, in order to leverage 5D TMA
+    uint64_t size[5] = {
+        OBUF_SW, (unsigned long)params.h_q, HEAD_DIM_V / OBUF_SW, (unsigned long)params.s_q, (unsigned long)params.b};
+    uint64_t stride[4] = {
+        params.stride_o_h_q * sizeof(bf16),
+        OBUF_SW * sizeof(bf16),
+        params.stride_o_s_q * sizeof(bf16),
+        params.stride_o_b * sizeof(bf16)};
+    uint32_t box_size[5] = {OBUF_SW, BLOCK_M, HEAD_DIM_V / OBUF_SW, 1, 1};
+    uint32_t elem_stride[5] = {1, 1, 1, 1, 1};
+    CUresult res = CUTLASS_CUDA_DRIVER_WRAPPER_CALL(cuTensorMapEncodeTiled)(
+        &tensor_map_o,
+        CUtensorMapDataType::CU_TENSOR_MAP_DATA_TYPE_BFLOAT16,
+        5,
+        params.out,
+        size,
+        stride,
+        box_size,
+        elem_stride,
+        CUtensorMapInterleave::CU_TENSOR_MAP_INTERLEAVE_NONE,
+        OBUF_SW == 64   ? CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_128B
+        : OBUF_SW == 32 ? CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_64B
+        : OBUF_SW == 16 ? CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_32B
+                        : CUtensorMapSwizzle::CU_TENSOR_MAP_SWIZZLE_NONE,
+        CUtensorMapL2promotion::CU_TENSOR_MAP_L2_PROMOTION_L2_256B,
+        CUtensorMapFloatOOBfill::CU_TENSOR_MAP_FLOAT_OOB_FILL_NONE);
+    KU_ASSERT(res == CUresult::CUDA_SUCCESS);
+  }
+
+  TmaParams<decltype(shape_Q), decltype(tma_Q)> tma_params = {shape_Q, tma_Q, tensor_map_o};
+  auto mla_kernel =
+      &flash_fwd_splitkv_mla_mxfp4_dsv4_scaled_sparse_kernel<KernelTemplate<NUM_HEADS>, decltype(tma_params)>;
+
+  constexpr size_t smem_size = sizeof(SharedMemoryPlan);
+  KU_CUDA_CHECK(cudaFuncSetAttribute(mla_kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, smem_size));
+
+  // NOTE Don't use PDL because of potential compiler bugs!
+  // cudaLaunchAttribute mla_kernel_attributes[1];
+  // mla_kernel_attributes[0].id = cudaLaunchAttributeProgrammaticStreamSerialization;
+  // mla_kernel_attributes[0].val.programmaticStreamSerializationAllowed = 1;
+  // cudaLaunchConfig_t mla_kernel_config = {
+  //     dim3(num_m_block, params.h_k, params.num_sm_parts),
+  //     dim3(NUM_THREADS, 1, 1),
+  //     smem_size,
+  //     stream,
+  //     mla_kernel_attributes,
+  //     1
+  // };
+  // cudaLaunchKernelEx(&mla_kernel_config, mla_kernel, params, tma_params);
+  cutlass::ClusterLaunchParams launch_params = {
+      dim3(NUM_M_BLOCKS, params.s_q, params.num_sm_parts),
+      dim3(NUM_THREADS, 1, 1),
+      dim3(CLUSTER_SIZE, 1, 1),
+      smem_size,
+      params.stream};
+  cutlass::launch_kernel_on_cluster(launch_params, (void*)mla_kernel, params, tma_params);
+  KU_CHECK_KERNEL_LAUNCH();
+}
+
+template <int NUM_HEADS>
+void run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel_impl(const SparseAttnDecodeParams& params) {
+  KernelTemplate<NUM_HEADS>::run(params);
+}
+
+}  // namespace sm90::decode::sparse_mxfp4_dsv4

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/splitkv_mla.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/splitkv_mla.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include "params.h"
+
+namespace sm90::decode::sparse_mxfp4_dsv4 {
+
+// Launch the DeepSeek V4 SM90 sparse decode kernel. The primary and optional
+// extra caches retain SparseAttnDecodeParams' independent runtime page sizes,
+// capacities, indices, and dynamic top-k lengths.
+void run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel(const SparseAttnDecodeParams& params);
+
+// Generate split-K metadata with device-side length clamping. The upstream
+// scheduler assumes every topk_length is already within the corresponding
+// indices width; this private entry point makes that safety property explicit
+// for graph-replayed DSV4 inputs.
+void run_get_dsv4_mxfp4_decoding_sched_meta_kernel(const GetDecodeSchedMetaParams& params);
+
+template <int NUM_HEADS>
+void run_flash_splitkv_mla_mxfp4_dsv4_sparse_kernel_impl(const SparseAttnDecodeParams& params);
+
+}  // namespace sm90::decode::sparse_mxfp4_dsv4

--- a/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/utils.h
+++ b/python/sglang/kernels/jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/utils.h
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <cstdint>
+
+#define CHECK_CUDA(call)                                                                            \
+  do {                                                                                              \
+    cudaError_t status_ = call;                                                                     \
+    if (status_ != cudaSuccess) {                                                                   \
+      fprintf(stderr, "CUDA error (%s:%d): %s\n", __FILE__, __LINE__, cudaGetErrorString(status_)); \
+      exit(1);                                                                                      \
+    }                                                                                               \
+  } while (0)
+
+#define CHECK_CUDA_KERNEL_LAUNCH() CHECK_CUDA(cudaGetLastError())
+
+#define FLASH_ASSERT(cond)                                                          \
+  do {                                                                              \
+    if (not(cond)) {                                                                \
+      fprintf(stderr, "Assertion failed (%s:%d): %s\n", __FILE__, __LINE__, #cond); \
+      exit(1);                                                                      \
+    }                                                                               \
+  } while (0)
+
+#define FLASH_DEVICE_ASSERT(cond)                                          \
+  do {                                                                     \
+    if (not(cond)) {                                                       \
+      printf("Assertion failed (%s:%d): %s\n", __FILE__, __LINE__, #cond); \
+      asm("trap;");                                                        \
+    }                                                                      \
+  } while (0)
+
+#define println(fmt, ...)      \
+  {                            \
+    print(fmt, ##__VA_ARGS__); \
+    print("\n");               \
+  }
+
+template <typename T>
+__inline__ __host__ __device__ T ceil_div(const T& a, const T& b) {
+  return (a + b - 1) / b;
+}
+
+#ifndef TRAP_ONLY_DEVICE_ASSERT
+#define TRAP_ONLY_DEVICE_ASSERT(cond) \
+  do {                                \
+    if (not(cond)) asm("trap;");      \
+  } while (0)
+#endif
+
+#ifndef TRAP_ONLY_DEVICE_ASSERT
+#define TRAP_ONLY_DEVICE_ASSERT(cond) \
+  do {                                \
+    if (not(cond)) asm("trap;");      \
+  } while (0)
+#endif
+
+struct RingBufferState {
+  uint32_t cur_block_idx = 0u;
+
+  __device__ __forceinline__ void update() {
+    cur_block_idx += 1;
+  }
+
+  template <uint32_t NUM_STAGES>
+  __device__ __forceinline__ std::pair<uint32_t, bool> get() const {
+    uint32_t stage_idx = cur_block_idx % NUM_STAGES;
+    bool phase = (cur_block_idx / NUM_STAGES) & 1;
+    return {stage_idx, phase};
+  }
+
+  __device__ __forceinline__ RingBufferState offset_by(const int offset) const {
+    // Must guarantee no underflow
+    uint32_t new_block_idx = static_cast<uint32_t>(static_cast<int>(cur_block_idx) + offset);
+    RingBufferState new_state;
+    new_state.cur_block_idx = new_block_idx;
+    return new_state;
+  }
+};

--- a/python/sglang/kernels/ops/attention/dsv4/mxfp4_dsv4_decode_sm90.py
+++ b/python/sglang/kernels/ops/attention/dsv4/mxfp4_dsv4_decode_sm90.py
@@ -1,0 +1,498 @@
+"""JIT-compiled MXFP4 KV-cache decode attention for DeepSeek-V4 on SM90.
+
+Fused three-stage split-KV decode over the MXFP4 (E8M0 block-32 scale + E2M1
+mantissa) KV cache: a one-CTA scheduler-metadata kernel, a persistent WGMMA
+main kernel, and the combine kernel. One call covers the SWA source plus an
+optional compressed (C4/C128) source and the attention sink in a single
+online softmax.
+
+The kernel is a JIT adaptation of the FlashMLA-style split-KV sparse decode
+(from the SGLang reference PR #31269, ported to MXFP4). It requires SM90
+(Hopper) and bf16 queries with head dim 512.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional, Tuple
+
+import msgspec
+import torch
+
+from sglang.kernels.jit.utils import cache_once, load_jit
+
+if TYPE_CHECKING:
+    from tvm_ffi.module import Module
+
+
+# ---------------------------------------------------------------------------
+# Build flags
+# ---------------------------------------------------------------------------
+
+
+def _mxfp4_cuda_flags() -> list[str]:
+    # Mirrors the verified AOT flag set for this FlashMLA-derived kernel
+    # (FlashMLA setup.py + the DSV4 build): --use_fast_math only. The Q8KV8
+    # prefill kernel's -DCUTE_USE_PACKED_TUPLE=1 was ablated here and caused
+    # a measurable slowdown (~1.3-1.7x), so it is deliberately omitted.
+    return [
+        "-O3",
+        "-DNDEBUG",
+        "--expt-extended-lambda",
+        "--use_fast_math",
+    ]
+
+
+@cache_once
+def _jit_mxfp4_dsv4_decode_module() -> Module:
+    """Compile and cache the MXFP4 DSV4 decode module (one translation unit)."""
+    if torch.cuda.get_device_capability()[0] != 9:
+        raise RuntimeError("MXFP4 DSV4 decode requires SM90 (Hopper)")
+    return load_jit(
+        "mxfp4_dsv4_decode_sm90",
+        cuda_files=["deepseek_v4/mxfp4_dsv4_decode_sm90/entry.cuh"],
+        cuda_wrappers=[("mxfp4_dsv4_decode_dispatch", "mxfp4_dsv4_decode_dispatch")],
+        extra_cuda_cflags=_mxfp4_cuda_flags(),
+        extra_dependencies=["cutlass"],
+    )
+
+
+# Pre-resolve the FFI entry point once; per-call module attribute lookup is
+# measurable at decode-step granularity.
+_resolved_dispatch: Optional[callable] = None
+
+
+def _get_dispatch() -> callable:
+    global _resolved_dispatch
+    if _resolved_dispatch is None:
+        _resolved_dispatch = _jit_mxfp4_dsv4_decode_module().mxfp4_dsv4_decode_dispatch
+    return _resolved_dispatch
+
+
+# Optional tensors are passed as empty tensors; cache them per device to avoid
+# a torch.empty call on every decode step.
+_EMPTY_I32: dict[int, torch.Tensor] = {}
+_EMPTY_F32: dict[int, torch.Tensor] = {}
+
+
+def _empty_i32(device: torch.device) -> torch.Tensor:
+    cached = _EMPTY_I32.get(device.index)
+    if cached is None:
+        cached = torch.empty(0, dtype=torch.int32, device=device)
+        _EMPTY_I32[device.index] = cached
+    return cached
+
+
+def _empty_f32(device: torch.device) -> torch.Tensor:
+    cached = _EMPTY_F32.get(device.index)
+    if cached is None:
+        cached = torch.empty(0, dtype=torch.float32, device=device)
+        _EMPTY_F32[device.index] = cached
+    return cached
+
+
+# Split-K accumulators are per-step internal scratch. Reuse them across calls
+# with the same geometry: fixed addresses are also CUDA-graph friendly.
+#
+# This module-global cache is only a fallback for standalone callers (tests,
+# benchmarks): it keeps one (b + num_sm_parts)-row FP32 pair per geometry
+# forever, which across a CUDA-graph capture sweep (one entry per captured
+# batch size) holds hundreds of MiB of dead weight, and two runners sharing
+# a geometry would race on the same tensors.  Production callers (the DSV4
+# attention backend) pass their own per-runner workspace via
+# ``split_accum_buffers`` instead.
+_SCRATCH: dict[tuple, tuple[torch.Tensor, torch.Tensor]] = {}
+
+
+def _get_scratch(b: int, s_q: int, h_q: int, device: torch.device, head_dim_v: int):
+    key = (b, s_q, h_q, device.index, head_dim_v)
+    cached = _SCRATCH.get(key)
+    if cached is None:
+        total_num_splits = b + _num_sm_parts(b, s_q, h_q, device)
+        lse_accum = torch.empty(
+            (total_num_splits, s_q, h_q), dtype=torch.float32, device=device
+        )
+        o_accum = torch.empty(
+            (total_num_splits, s_q, h_q, head_dim_v),
+            dtype=torch.float32,
+            device=device,
+        )
+        cached = (lse_accum, o_accum)
+        _SCRATCH[key] = cached
+    return cached
+
+
+def _slice_accum_buffers(
+    lse_arena: torch.Tensor,
+    o_arena: torch.Tensor,
+    total_num_splits: int,
+    b: int,
+    s_q: int,
+    h_q: int,
+    head_dim_v: int,
+    device: torch.device,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Prefix-slice a caller-owned split-K workspace for one call.
+
+    Every batch size only ever touches accumulator rows ``[0, b + parts)``, so
+    a single arena sized for the largest batch serves all smaller batches as a
+    prefix slice — one stable allocation instead of one per geometry.
+    """
+    if lse_arena.dtype != torch.float32 or o_arena.dtype != torch.float32:
+        raise ValueError("split_accum_buffers must be float32 tensors")
+    if lse_arena.device != device or o_arena.device != device:
+        raise ValueError("split_accum_buffers must live on the query device")
+    if lse_arena.ndim != 3 or o_arena.ndim != 4:
+        raise ValueError(
+            "split_accum_buffers must be (rows, s_q, h_q) and "
+            "(rows, s_q, h_q, head_dim_v)"
+        )
+    if lse_arena.shape[0] < total_num_splits or o_arena.shape[0] < total_num_splits:
+        raise ValueError(
+            f"split_accum_buffers need at least {total_num_splits} rows "
+            f"(batch {b} + sm parts), got {lse_arena.shape[0]}"
+        )
+    if lse_arena.shape[1:] != (s_q, h_q) or o_arena.shape[1:] != (s_q, h_q, head_dim_v):
+        raise ValueError(
+            f"split_accum_buffers trailing dims must be ({s_q}, {h_q}) and "
+            f"({s_q}, {h_q}, {head_dim_v}), got {lse_arena.shape[1:]} and "
+            f"{o_arena.shape[1:]}"
+        )
+    return lse_arena[:total_num_splits], o_arena[:total_num_splits]
+
+
+# ---------------------------------------------------------------------------
+# Scheduler metadata container (shape-keyed, replayable across CUDA graphs)
+# ---------------------------------------------------------------------------
+
+
+class FlashMLASchedMeta(msgspec.Struct):
+    """Tile scheduler metadata for the DSV4 MXFP4 decode.
+
+    Holds the split-K scheduler tensors across calls. A single instance is
+    only valid for one (batch, cache-page, top-k) geometry; reuse a matching
+    instance to let CUDA graphs replay the captured scheduler kernels.
+    """
+
+    class Config(msgspec.Struct):
+        b: int
+        s_q: int
+        h_q: int
+        page_block_size: int
+        h_k: int
+        causal: bool
+        is_fp8_kvcache: bool
+        topk: Optional[int]
+        extra_page_block_size: Optional[int]
+        extra_topk: Optional[int]
+
+    have_initialized: bool = False
+    config: Optional[Config] = None
+    tile_scheduler_metadata: Optional[torch.Tensor] = None
+    num_splits: Optional[torch.Tensor] = None
+
+
+def _num_sm_parts(b: int, s_q: int, h_q: int, device: torch.device) -> int:
+    """Split-K partition count, matching the native FlashMLA layout."""
+    mpc = torch.cuda.get_device_properties(device).multi_processor_count
+    return max(mpc // s_q // (h_q // 64), 1)
+
+
+def _validate_core_inputs(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    indices: torch.Tensor,
+    head_dim_v: int,
+) -> None:
+    """Reject inputs the SM90 kernel cannot consume safely.
+
+    The kernel hardcodes head dim 512 (QK and V), int32 indices, contiguous
+    row-major layouts, and 128-bit vector loads of the 368-byte cache rows;
+    every deviation must fail here as a Python exception rather than read
+    out of bounds on the device.
+    """
+    if q.dtype != torch.bfloat16:
+        raise RuntimeError("q must have dtype bfloat16")
+    if q.ndim != 4 or k_cache.ndim != 4 or indices.ndim != 3:
+        raise ValueError(
+            "Expected q [B, S_Q, H_Q, D], cache [pages, page_size, H_K, 368], "
+            f"and indices [B, S_Q, topk], got {q.shape=}, {k_cache.shape=}, "
+            f"{indices.shape=}"
+        )
+    b, s_q, h_q, d_qk = q.shape
+    if b <= 0 or s_q <= 0:
+        raise ValueError(
+            f"q batch and sequence dimensions must be positive, got {b=} {s_q=}"
+        )
+    if h_q not in (64, 128):
+        raise ValueError(f"q must contain 64 or 128 heads, got {h_q}")
+    if d_qk != 512 or head_dim_v != 512:
+        raise ValueError(
+            "Query head dim and head_dim_v must both be 512, got "
+            f"d_qk={d_qk}, head_dim_v={head_dim_v}"
+        )
+    if indices.shape[:2] != (b, s_q):
+        raise ValueError(
+            f"indices must have shape [{b}, {s_q}, topk], got {tuple(indices.shape)}"
+        )
+    if indices.shape[-1] % 64 != 0:
+        raise RuntimeError(
+            f"indices top-k width must be a multiple of 64, got {indices.shape[-1]}"
+        )
+    if indices.dtype != torch.int32:
+        raise ValueError(f"indices must be int32, got {indices.dtype}")
+    if k_cache.shape[2] != 1 or k_cache.shape[3] != 368:
+        raise ValueError(
+            "DeepSeek V4 MXFP4 cache must have shape "
+            f"[pages, page_size, 1, 368], got {tuple(k_cache.shape)}"
+        )
+    # 368 = 23 * 16, so per-row strides preserve 128-bit vector-load
+    # alignment only when the base pointer itself is 16-byte aligned.
+    if k_cache.data_ptr() % 16 != 0:
+        raise RuntimeError("k_cache must be 16-byte aligned for 128-bit vector loads")
+    if k_cache.device != q.device or indices.device != q.device:
+        raise ValueError(
+            f"All tensors must live on the query device {q.device}, got "
+            f"k_cache {k_cache.device} and indices {indices.device}"
+        )
+    if (
+        not q.is_contiguous()
+        or not k_cache.is_contiguous()
+        or not indices.is_contiguous()
+    ):
+        raise ValueError("q, k_cache, and indices must be contiguous")
+
+
+def _validate_lengths_vector(
+    t: torch.Tensor, name: str, b: int, device: torch.device
+) -> None:
+    """Validate a per-request top-k length vector (int32 [B] on-device)."""
+    if t.dtype != torch.int32:
+        raise ValueError(f"{name} must be int32, got {t.dtype}")
+    if t.shape != (b,):
+        raise ValueError(
+            f"{name} must have shape [{b}] (one entry per request), got "
+            f"{tuple(t.shape)}"
+        )
+    if t.device != device:
+        raise ValueError(f"{name} must live on the query device, got {t.device}")
+    if not t.is_contiguous():
+        raise ValueError(f"{name} must be contiguous")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def flash_mla_with_kvcache_dsv4_mxfp4(
+    q: torch.Tensor,
+    k_cache: torch.Tensor,
+    indices: torch.Tensor,
+    topk_length: Optional[torch.Tensor],
+    attn_sink: Optional[torch.Tensor],
+    tile_scheduler_metadata: FlashMLASchedMeta,
+    head_dim_v: int = 512,
+    softmax_scale: Optional[float] = None,
+    extra_k_cache: Optional[torch.Tensor] = None,
+    extra_indices_in_kvcache: Optional[torch.Tensor] = None,
+    extra_topk_length: Optional[torch.Tensor] = None,
+    split_accum_buffers: Optional[Tuple[torch.Tensor, torch.Tensor]] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Run fused SM90 DeepSeek-V4 sparse decode on an MXFP4 KV cache.
+
+    ``k_cache`` stores one 368-byte DeepSeek-V4 entry per token and has the
+    page-major shape ``[num_pages, page_size, 1, 368]``. C0 uses only this
+    source. C4/C128 additionally pass a compressed cache, its indices, and
+    valid top-k lengths. MXFP4 rows carry their own E8M0 block-32 scales, so
+    no global FP32 scale is required (unlike the NVFP4 path).
+
+    Scheduler tensors are allocated on first call and cached in
+    ``tile_scheduler_metadata`` for CUDA-graph replay.
+
+    ``split_accum_buffers`` optionally supplies a caller-owned split-K
+    workspace ``(lse_accum_rows, o_accum_rows)`` sized for the caller's
+    largest batch (``batch + num_sm_parts`` rows); each call prefix-slices
+    it.  Passing it avoids the module-global per-geometry scratch cache —
+    required from long-lived runners so a CUDA-graph capture sweep does not
+    pin one accumulator pair per captured batch size, and so two runners
+    never share scratch tensors.
+    """
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+
+    if not isinstance(tile_scheduler_metadata, FlashMLASchedMeta):
+        raise TypeError(
+            "DeepSeek V4 MXFP4 decode requires FlashMLASchedMeta, got "
+            f"{type(tile_scheduler_metadata).__name__}"
+        )
+    _validate_core_inputs(q, k_cache, indices, head_dim_v)
+    if topk_length is not None:
+        _validate_lengths_vector(topk_length, "topk_length", q.shape[0], q.device)
+    if attn_sink is not None:
+        if attn_sink.dtype != torch.float32:
+            raise ValueError(f"attn_sink must be float32, got {attn_sink.dtype}")
+        if attn_sink.device != q.device:
+            raise ValueError(
+                f"attn_sink must live on the query device, got {attn_sink.device}"
+            )
+        if not attn_sink.is_contiguous():
+            raise ValueError("attn_sink must be contiguous")
+
+    have_extra_cache = extra_k_cache is not None
+    have_extra_indices = extra_indices_in_kvcache is not None
+    have_extra_length = extra_topk_length is not None
+    if not (have_extra_cache == have_extra_indices == have_extra_length):
+        raise ValueError(
+            "extra_k_cache, extra_indices_in_kvcache, and extra_topk_length "
+            "must be provided together"
+        )
+    if have_extra_cache:
+        assert extra_indices_in_kvcache is not None
+        if extra_k_cache.ndim != 4 or extra_indices_in_kvcache.ndim != 3:
+            raise ValueError(
+                "Expected extra cache [pages, page_size, H_K, 368] and extra "
+                f"indices [B, S_Q, topk], got {extra_k_cache.shape=} and "
+                f"{extra_indices_in_kvcache.shape=}"
+            )
+        if extra_k_cache.shape[2] != 1 or extra_k_cache.shape[3] != 368:
+            raise ValueError(
+                "DeepSeek V4 extra MXFP4 cache must have shape "
+                "[pages, page_size, 1, 368], got "
+                f"{tuple(extra_k_cache.shape)}"
+            )
+        if extra_k_cache.data_ptr() % 16 != 0:
+            raise RuntimeError(
+                "extra_k_cache must be 16-byte aligned for 128-bit vector loads"
+            )
+        if extra_indices_in_kvcache.shape[:2] != (q.shape[0], q.shape[1]):
+            raise ValueError(
+                "extra_indices_in_kvcache must have shape "
+                f"[{q.shape[0]}, {q.shape[1]}, topk], got "
+                f"{tuple(extra_indices_in_kvcache.shape)}"
+            )
+        if extra_indices_in_kvcache.shape[-1] % 64 != 0:
+            raise RuntimeError(
+                "extra indices top-k width must be a multiple of 64, got "
+                f"{extra_indices_in_kvcache.shape[-1]}"
+            )
+        if extra_indices_in_kvcache.dtype != torch.int32:
+            raise ValueError(
+                f"extra_indices_in_kvcache must be int32, got "
+                f"{extra_indices_in_kvcache.dtype}"
+            )
+        if (
+            extra_k_cache.device != q.device
+            or extra_indices_in_kvcache.device != q.device
+        ):
+            raise ValueError(
+                f"Extra-source tensors must live on the query device {q.device}, "
+                f"got cache {extra_k_cache.device} and indices "
+                f"{extra_indices_in_kvcache.device}"
+            )
+        if (
+            not extra_k_cache.is_contiguous()
+            or not extra_indices_in_kvcache.is_contiguous()
+        ):
+            raise ValueError("extra_k_cache and extra_indices must be contiguous")
+        _validate_lengths_vector(
+            extra_topk_length, "extra_topk_length", q.shape[0], q.device
+        )
+
+    sched_meta = tile_scheduler_metadata
+    topk = indices.shape[-1]
+    extra_page_block_size = (
+        extra_k_cache.shape[1] if extra_k_cache is not None else None
+    )
+    extra_topk = (
+        extra_indices_in_kvcache.shape[-1]
+        if extra_indices_in_kvcache is not None
+        else None
+    )
+    config = FlashMLASchedMeta.Config(
+        b=q.shape[0],
+        s_q=q.shape[1],
+        h_q=q.shape[2],
+        page_block_size=k_cache.shape[1],
+        h_k=k_cache.shape[2],
+        causal=False,
+        # The scheduler geometry is shared with the FP8 path; MXFP4 only
+        # differs in the per-row storage format.
+        is_fp8_kvcache=True,
+        topk=topk,
+        extra_page_block_size=extra_page_block_size,
+        extra_topk=extra_topk,
+    )
+    if not sched_meta.have_initialized:
+        sched_meta.have_initialized = True
+        sched_meta.config = config
+    else:
+        helper_msg = (
+            " Input arguments are inconsistent with FlashMLASchedMeta. Reuse a "
+            "scheduler only for matching tensor shapes and sparse settings."
+        )
+        assert sched_meta.config == config, helper_msg
+
+    device = q.device
+    b, s_q, h_q = q.shape[0], q.shape[1], q.shape[2]
+    need_buffer = sched_meta.tile_scheduler_metadata is None
+    if need_buffer:
+        num_sm_parts = _num_sm_parts(b, s_q, h_q, device)
+        # DecodingSchedMeta is 8 int32 (32 bytes, 4*8 aligned).
+        sched_meta.tile_scheduler_metadata = torch.empty(
+            (num_sm_parts, 8), dtype=torch.int32, device=device
+        )
+        sched_meta.num_splits = torch.empty((b + 1,), dtype=torch.int32, device=device)
+    num_sm_parts = sched_meta.tile_scheduler_metadata.shape[0]
+    # The split assignment depends on the per-call top-k lengths, which in
+    # eager mode change every step (a growing sequence crosses 64-token block
+    # boundaries), so the scheduler re-runs on every eager call with the
+    # buffers reused. During CUDA-graph capture the caller supplies a fresh
+    # buffer, so the generation kernel is recorded once and re-executed on
+    # every replay with the replayed lengths.
+    generate_sched_meta = need_buffer or not torch.cuda.is_current_stream_capturing()
+
+    # Outputs are per-call (returned to the caller); split-K accumulators are
+    # internal scratch reused across calls of the same geometry. The scheduler
+    # metadata kernels run inside CUDA-graph capture, so address stability is
+    # what matters — the cached scratch and metadata buffers provide it.
+    out = torch.empty((b, s_q, h_q, head_dim_v), dtype=torch.bfloat16, device=device)
+    lse = torch.empty((b, s_q, h_q), dtype=torch.float32, device=device)
+    total_num_splits = b + num_sm_parts
+    if split_accum_buffers is not None:
+        lse_accum, o_accum = _slice_accum_buffers(
+            split_accum_buffers[0],
+            split_accum_buffers[1],
+            total_num_splits,
+            b,
+            s_q,
+            h_q,
+            head_dim_v,
+            device,
+        )
+    else:
+        lse_accum, o_accum = _get_scratch(b, s_q, h_q, device, head_dim_v)
+
+    _get_dispatch()(
+        q,
+        k_cache,
+        indices,
+        topk_length if topk_length is not None else _empty_i32(device),
+        attn_sink if attn_sink is not None else _empty_f32(device),
+        sched_meta.tile_scheduler_metadata,
+        sched_meta.num_splits,
+        extra_k_cache if extra_k_cache is not None else _empty_i32(device),
+        (
+            extra_indices_in_kvcache
+            if extra_indices_in_kvcache is not None
+            else _empty_i32(device)
+        ),
+        extra_topk_length if extra_topk_length is not None else _empty_i32(device),
+        lse_accum,
+        o_accum,
+        out,
+        lse,
+        head_dim_v,
+        softmax_scale,
+        generate_sched_meta,
+    )
+    return out, lse.transpose(1, 2)

--- a/python/sglang/kernels/ops/attention/dsv4/mxfp4_k_cache.py
+++ b/python/sglang/kernels/ops/attention/dsv4/mxfp4_k_cache.py
@@ -1,0 +1,628 @@
+"""MXFP4 codec for DeepSeek V4 attention KV entries.
+
+Each token occupies one 368-byte row::
+
+    [224 B packed E2M1 | 14 B E8M0 + 2 B pad | 128 B BF16 RoPE]
+
+Only the 448-dimensional nope vector is quantized (block-32, E8M0 scale).
+The 64-dimensional RoPE vector stays in bfloat16.  E8M0 covers the full
+FP range (2⁻¹²⁷ to 2¹²⁷) without a separate global scale, so the API is
+simpler than the NVFP4 codec.
+
+Decode consumes the layout directly via the fused JIT CUDA kernel.
+Sparse prefill dequantizes selected entries to BF16 on the fly.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MXFP4_GROUP_SIZE = 32
+MXFP4_NOPE_DIM = 448
+MXFP4_ROPE_DIM = 64
+MXFP4_TOTAL_DIM = MXFP4_NOPE_DIM + MXFP4_ROPE_DIM  # 512
+MXFP4_NUM_GROUPS = MXFP4_NOPE_DIM // MXFP4_GROUP_SIZE  # 14
+MXFP4_PACKED_NOPE_BYTES = MXFP4_NOPE_DIM // 2  # 224
+MXFP4_SCALE_BYTES = MXFP4_NUM_GROUPS + 2  # 16 (14 + 2 pad)
+MXFP4_ROPE_BYTES = MXFP4_ROPE_DIM * 2  # 128
+MXFP4_BYTES_PER_TOKEN = (
+    MXFP4_PACKED_NOPE_BYTES + MXFP4_SCALE_BYTES + MXFP4_ROPE_BYTES
+)  # 368
+
+_E2M1_MAX = 6.0
+
+# Triton requires tl.arange ranges to be powers of two; we always use
+# power-of-two tile sizes and mask to the actual group count (14).
+_MAX_GROUPS = 16  # next power of two >= 14
+_NOPE_TILE = 512  # next power of two >= 448, used for output masking
+
+# Launch config: one CTA owns a complete token row for small batches;
+# split across 2 CTAs for large prefill workloads.
+_QUANTIZE_SMALL_BATCH_THRESHOLD = 64
+_QUANTIZE_SMALL_GROUPS_PER_PROGRAM = 16  # one CTA per token (16 ≥ 14)
+_QUANTIZE_SMALL_NUM_WARPS = 4
+_QUANTIZE_LARGE_GROUPS_PER_PROGRAM = 8  # two CTAs per token
+_QUANTIZE_LARGE_NUM_WARPS = 2
+
+
+def _quantize_launch_config(num_tokens: int) -> tuple[int, int]:
+    if num_tokens <= _QUANTIZE_SMALL_BATCH_THRESHOLD:
+        return _QUANTIZE_SMALL_GROUPS_PER_PROGRAM, _QUANTIZE_SMALL_NUM_WARPS
+    return _QUANTIZE_LARGE_GROUPS_PER_PROGRAM, _QUANTIZE_LARGE_NUM_WARPS
+
+
+# ---------------------------------------------------------------------------
+# Validation helpers (following PR #31269 NVFP4 pattern)
+# ---------------------------------------------------------------------------
+
+
+def _as_feature_matrix(x: torch.Tensor, dim: int, name: str) -> torch.Tensor:
+    if x.ndim == 3 and x.shape[1] == 1:
+        x = x[:, 0, :]
+    if x.ndim != 2 or x.shape[1] != dim:
+        raise ValueError(
+            f"{name} must have shape [num_tokens, {dim}] or "
+            f"[num_tokens, 1, {dim}], got {tuple(x.shape)}"
+        )
+    if x.dtype not in (torch.bfloat16, torch.float16, torch.float32):
+        raise TypeError(f"{name} must use bfloat16, float16, or float32, got {x.dtype}")
+    if x.stride(1) != 1:
+        x = x.contiguous()
+    return x
+
+
+def _as_rows(kv_buffer: torch.Tensor, page_size: int) -> torch.Tensor:
+    if kv_buffer.dtype != torch.uint8:
+        raise TypeError(f"MXFP4 buffer must be uint8, got {kv_buffer.dtype}")
+    if kv_buffer.ndim != 2:
+        raise ValueError(
+            f"MXFP4 buffer must be [num_pages, bytes_per_page], "
+            f"got {tuple(kv_buffer.shape)}"
+        )
+    expected = page_size * MXFP4_BYTES_PER_TOKEN
+    if kv_buffer.shape[1] != expected:
+        raise ValueError(
+            f"MXFP4 page must contain {expected} bytes, " f"got {kv_buffer.shape[1]}"
+        )
+    if not kv_buffer.is_contiguous():
+        raise ValueError("MXFP4 buffer must be contiguous")
+    return kv_buffer.view(-1, MXFP4_BYTES_PER_TOKEN)
+
+
+def _validate_loc(loc: torch.Tensor, rows: torch.Tensor) -> torch.Tensor:
+    loc = loc.reshape(-1)
+    if loc.dtype not in (torch.int32, torch.int64):
+        raise TypeError(f"loc must be int32 or int64, got {loc.dtype}")
+    if loc.device != rows.device:
+        raise ValueError("loc and KV buffer must be on one device")
+    return loc.contiguous()
+
+
+def _split_k(cache_k: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    if cache_k.ndim == 3 and cache_k.shape[1] == 1:
+        cache_k = cache_k[:, 0, :]
+    if cache_k.ndim != 2 or cache_k.shape[1] != MXFP4_TOTAL_DIM:
+        raise ValueError(
+            "cache_k must be [num_tokens, 512] or [num_tokens, 1, 512], "
+            f"got {tuple(cache_k.shape)}"
+        )
+    return (
+        _as_feature_matrix(cache_k[:, :MXFP4_NOPE_DIM], MXFP4_NOPE_DIM, "k_nope"),
+        _as_feature_matrix(cache_k[:, MXFP4_NOPE_DIM:], MXFP4_ROPE_DIM, "k_rope"),
+    )
+
+
+# ---------------------------------------------------------------------------
+# E2M1 helpers
+# ---------------------------------------------------------------------------
+
+_E2M1_LUT = torch.tensor(
+    [
+        0.0,
+        0.5,
+        1.0,
+        1.5,
+        2.0,
+        3.0,
+        4.0,
+        6.0,
+        -0.0,
+        -0.5,
+        -1.0,
+        -1.5,
+        -2.0,
+        -3.0,
+        -4.0,
+        -6.0,
+    ],
+    dtype=torch.float32,
+)
+
+
+def _e2m1_rne_scaled_torch(x: torch.Tensor, denominator: torch.Tensor) -> torch.Tensor:
+    """E2M1 RNE encoding using scaled-midpoint comparisons (no division).
+
+    Compares original magnitudes against midpoints derived from the stored
+    scale to avoid reciprocal-induced FP32 ulp drift.
+    """
+    magnitude = x.abs()
+    code = (
+        (magnitude > denominator * 0.25).to(torch.uint8)
+        + (magnitude >= denominator * 0.75).to(torch.uint8)
+        + (magnitude > denominator * 1.25).to(torch.uint8)
+        + (magnitude >= denominator * 1.75).to(torch.uint8)
+        + (magnitude > denominator * 2.5).to(torch.uint8)
+        + (magnitude >= denominator * 3.5).to(torch.uint8)
+        + (magnitude > denominator * 5.0).to(torch.uint8)
+    )
+    return code | (torch.signbit(x).to(torch.uint8) << 3)
+
+
+def _decode_e2m1_torch(code: torch.Tensor) -> torch.Tensor:
+    return _E2M1_LUT.to(code.device)[code.long()]
+
+
+# ---------------------------------------------------------------------------
+# Triton helper: E2M1 RNE (scaled-midpoint, no division)
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _e2m1_rne_scaled_triton(x, denominator):
+    magnitude = tl.abs(x)
+    code = (
+        (magnitude > denominator * 0.25).to(tl.uint8)
+        + (magnitude >= denominator * 0.75).to(tl.uint8)
+        + (magnitude > denominator * 1.25).to(tl.uint8)
+        + (magnitude >= denominator * 1.75).to(tl.uint8)
+        + (magnitude > denominator * 2.5).to(tl.uint8)
+        + (magnitude >= denominator * 3.5).to(tl.uint8)
+        + (magnitude > denominator * 5.0).to(tl.uint8)
+    )
+    sign = ((x.to(tl.uint32, bitcast=True) >> 31).to(tl.uint8)) << 3
+    return (code | sign).to(tl.uint8)
+
+
+@triton.jit
+def _decode_e2m1_triton(code):
+    magnitude_code = code & 0x07
+    magnitude = tl.where(
+        magnitude_code == 0,
+        0.0,
+        tl.where(
+            magnitude_code == 1,
+            0.5,
+            tl.where(
+                magnitude_code == 2,
+                1.0,
+                tl.where(
+                    magnitude_code == 3,
+                    1.5,
+                    tl.where(
+                        magnitude_code == 4,
+                        2.0,
+                        tl.where(
+                            magnitude_code == 5,
+                            3.0,
+                            tl.where(magnitude_code == 6, 4.0, 6.0),
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    return tl.where((code & 0x08) != 0, -magnitude, magnitude)
+
+
+# ---------------------------------------------------------------------------
+# Triton quantize kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _quantize_mxfp4_k_cache_into_kernel(
+    k_nope_ptr,
+    k_rope_ptr,
+    packed_out_ptr,
+    scale_out_ptr,
+    rope_out_ptr,
+    loc_ptr,
+    num_rows,
+    k_nope_stride_0: tl.constexpr,
+    k_rope_stride_0: tl.constexpr,
+    packed_out_stride_0: tl.constexpr,
+    scale_out_stride_0: tl.constexpr,
+    rope_out_stride_0: tl.constexpr,
+    NUM_GROUPS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    GROUPS_PER_PROGRAM: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    part_id = tl.program_id(1)
+    dst_row = tl.load(loc_ptr + token_id).to(tl.int64)
+    valid_dst = (dst_row >= 0) & (dst_row < num_rows)
+    safe_row = tl.where(valid_dst, dst_row, 0)
+
+    group_start = part_id * GROUPS_PER_PROGRAM
+    # tl.arange demands a power-of-two range; GROUPS_PER_PROGRAM ∈ {8, 16}.
+    group_ids = group_start + tl.arange(0, GROUPS_PER_PROGRAM)  # [GROUPS_PER_PROGRAM]
+    valid_group = group_ids < NUM_GROUPS
+    elem_ids = tl.arange(0, GROUP_SIZE)  # [32]  ← power of two
+
+    # Load [GROUPS_PER_PROGRAM, 32] elements of k_nope
+    input_offsets = group_ids[:, None] * GROUP_SIZE + elem_ids[None, :]
+    x = tl.load(
+        k_nope_ptr + token_id * k_nope_stride_0 + input_offsets,
+        mask=valid_dst & valid_group[:, None],
+        other=0.0,
+    ).to(tl.float32)
+
+    # E8M0 scale: byte = ceil(log2(amax / 6)) + 127.  ceil (the MX-format
+    # convention, cf. the NVFP4 paths) guarantees the group amax stays
+    # representable: the largest E2M1 code is 6, so scale = 2^round(log2
+    # ratio) clamps every element of groups whose amax lands in
+    # (6·2^k, 6·2^k·√2] — up to 29% off the max element.
+    amax = tl.max(tl.abs(x), axis=1)
+    log2_ratio = tl.math.log2(tl.maximum(amax, 1e-40)) - 2.584962500721156  # log₂6
+    scale_byte_raw = tl.math.ceil(log2_ratio).to(tl.int32) + 127
+    # tl.clamp(·, 0, 255) on int32 is unsupported; use min/max.  255 is the
+    # reserved NaN encoding and is unreachable for finite inputs, but clamp
+    # below it anyway so a stray byte can never decode as NaN.
+    scale_byte = tl.minimum(tl.maximum(scale_byte_raw, 0), 254).to(tl.uint8)
+
+    # E2M1 RNE: compare original values against scaled midpoints (no division).
+    # Build 2^(byte-127) from the FP32 exponent bits instead of exp2, for the
+    # same reason as the dequant kernel below: byte 0 is 2^-127, a subnormal,
+    # and ex2.approx flushes it to zero.  A zero denominator flips the RNE
+    # ladder's `magnitude >= denominator * midpoint` rungs at magnitude 0 and
+    # encodes an all-zero block as E2M1 code 3 instead of code 0.
+    sb = scale_byte.to(tl.int32)
+    scale_normal = (tl.where(sb == 0, 1, sb) << 23).to(tl.float32, bitcast=True)
+    scale_float = tl.where(sb == 0, scale_normal * 0.5, scale_normal)
+    denominator = tl.expand_dims(scale_float, 1)
+    codes = _e2m1_rne_scaled_triton(x, denominator)  # [GROUPS_PER_PROGRAM, 32] uint8
+
+    # Pack nibbles: two adjacent E2M1 codes → one byte
+    codes_2d = tl.reshape(codes, (GROUPS_PER_PROGRAM, GROUP_SIZE // 2, 2))
+    low, high = tl.split(codes_2d)  # each [GROUPS_PER_PROGRAM, 16]
+    packed = low | (high << 4)
+
+    # Store packed nope: [GROUPS_PER_PROGRAM, 16] bytes per token
+    byte_ids = tl.arange(0, GROUP_SIZE // 2)  # [16]
+    packed_offsets = group_ids[:, None] * (GROUP_SIZE // 2) + byte_ids[None, :]
+    tl.store(
+        packed_out_ptr + safe_row * packed_out_stride_0 + packed_offsets,
+        packed,
+        mask=valid_dst & valid_group[:, None],
+    )
+    tl.store(
+        scale_out_ptr + safe_row * scale_out_stride_0 + group_ids,
+        scale_byte,
+        mask=valid_dst & valid_group,
+    )
+
+    # RoPE: written once by the last part
+    num_parts = tl.cdiv(NUM_GROUPS, GROUPS_PER_PROGRAM)
+    if part_id == num_parts - 1:
+        rope_offsets = tl.arange(0, ROPE_DIM)  # [64]  ← power of two
+        rope = tl.load(
+            k_rope_ptr + token_id * k_rope_stride_0 + rope_offsets,
+            mask=valid_dst,
+            other=0.0,
+        )
+        tl.store(
+            rope_out_ptr + safe_row * rope_out_stride_0 + rope_offsets,
+            rope,
+            mask=valid_dst,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Triton dequant kernel
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def _dequantize_mxfp4_k_cache_paged_kernel(
+    packed_ptr,
+    scale_ptr,
+    rope_ptr,
+    token_indices_ptr,
+    output_ptr,
+    num_rows,
+    packed_stride_0: tl.constexpr,
+    scale_stride_0: tl.constexpr,
+    rope_stride_0: tl.constexpr,
+    output_stride_0: tl.constexpr,
+    MAX_GROUPS: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    NOPE_DIM: tl.constexpr,
+    NOPE_TILE: tl.constexpr,
+    ROPE_DIM: tl.constexpr,
+):
+    token_id = tl.program_id(0)
+    src_row = tl.load(token_indices_ptr + token_id).to(tl.int64)
+    valid_src = (src_row >= 0) & (src_row < num_rows)
+
+    # Load packed nope as [MAX_GROUPS, GROUP_SIZE//2] bytes.
+    # MAX_GROUPS = 16 ≥ the real 14 groups; the extra 2 groups land in the
+    # scale / rope region and are masked away after decode.
+    group_ids = tl.arange(0, MAX_GROUPS)[:, None]  # [16, 1]  ← power of two
+    byte_ids = tl.arange(0, GROUP_SIZE // 2)[None, :]  # [1, 16]  ← power of two
+    packed_offsets = group_ids * (GROUP_SIZE // 2) + byte_ids  # [16, 16]
+    packed = tl.load(
+        packed_ptr + src_row * packed_stride_0 + packed_offsets,
+        mask=valid_src,
+        other=0,
+    ).to(tl.uint8)
+
+    # Load scales: [MAX_GROUPS] with mask, last 2 are padding
+    scale_offsets = tl.arange(0, MAX_GROUPS)  # [16]  ← power of two
+    scale_byte = tl.load(
+        scale_ptr + src_row * scale_stride_0 + scale_offsets,
+        mask=valid_src & (scale_offsets < NOPE_DIM // GROUP_SIZE),
+        other=127,  # scale = 2^(127-127) = 1.0 (harmless for masked groups)
+    ).to(tl.uint8)
+    # E8M0 bytes 0..254 are 2^-127..2^127 (no zero encoding; 255 is the
+    # reserved NaN).  Build the value from the FP32 exponent pattern instead
+    # of exp2: 2^-127 lies below the normal range and ex2.approx flushes the
+    # denormal to zero.  Byte 0 is built from the 2^-126 pattern halved.
+    sb = scale_byte.to(tl.int32)
+    scale_normal = (tl.where(sb == 0, 1, sb) << 23).to(tl.float32, bitcast=True)
+    scale = tl.where(sb == 0, scale_normal * 0.5, scale_normal)
+
+    # Unpack nibbles → decode E2M1 → apply scale
+    low = _decode_e2m1_triton(packed & 0x0F) * scale[:, None]  # [16, 16]
+    high = _decode_e2m1_triton(packed >> 4) * scale[:, None]  # [16, 16]
+    nope_all = tl.reshape(tl.join(low, high), (NOPE_TILE,))  # [512]
+
+    # Store nope: NOPE_TILE=512 ≥ NOPE_DIM=448; mask trims to the real dim.
+    # Invalid rows are written as zeros so out-of-range indices cannot leak
+    # stale or uninitialized memory into the output (the API guarantees zero
+    # rows for them).
+    nope_offsets = tl.arange(0, NOPE_TILE)  # [512]  ← power of two
+    tl.store(
+        output_ptr + token_id * output_stride_0 + nope_offsets,
+        tl.where(valid_src, nope_all, 0.0),
+        mask=nope_offsets < NOPE_DIM,
+    )
+
+    # RoPE: ROPE_DIM=64 is a power of two, no masking needed
+    rope_offsets = tl.arange(0, ROPE_DIM)
+    rope = tl.load(
+        rope_ptr + src_row * rope_stride_0 + rope_offsets,
+        mask=valid_src,
+        other=0.0,
+    )
+    tl.store(
+        output_ptr + token_id * output_stride_0 + NOPE_DIM + rope_offsets,
+        tl.where(valid_src, rope, 0.0),
+    )
+
+
+# ---------------------------------------------------------------------------
+# PyTorch reference implementations
+# ---------------------------------------------------------------------------
+
+
+def _quantize_mxfp4_reference(
+    k_nope: torch.Tensor,
+    k_rope: torch.Tensor,
+    packed_rows: torch.Tensor,
+    scale_rows: torch.Tensor,
+    rope_rows: torch.Tensor,
+    loc: torch.Tensor,
+) -> None:
+    """CPU reference: quantize + scatter into destination views."""
+    blocks = k_nope.float().reshape(-1, MXFP4_NUM_GROUPS, MXFP4_GROUP_SIZE)
+    amax = blocks.abs().amax(dim=-1)  # [N, 14]
+    log2_ratio = torch.log2(amax.clamp(min=1e-40)) - 2.584962500721156
+    # ceil matches the Triton kernel and the MX convention (never saturate
+    # the group amax); 255 is the reserved NaN encoding.
+    scale_byte = (torch.ceil(log2_ratio).long() + 127).clamp(0, 254).to(torch.uint8)
+    scale_float = torch.pow(2.0, (scale_byte.float() - 127.0))
+    denominator = scale_float.unsqueeze(-1)
+    codes = _e2m1_rne_scaled_torch(blocks, denominator).reshape(-1, MXFP4_NOPE_DIM)
+    packed = codes[:, 0::2] | (codes[:, 1::2] << 4)
+
+    valid = (loc >= 0) & (loc < packed_rows.shape[0])
+    if bool(valid.any()):
+        dst = loc[valid].long()
+        packed_rows[dst] = packed[valid]
+        scale_rows[dst, :MXFP4_NUM_GROUPS] = scale_byte[valid]
+        rope_rows[dst] = k_rope[valid].to(torch.bfloat16)
+
+
+def _dequantize_mxfp4_reference(
+    packed_rows: torch.Tensor,
+    scale_rows: torch.Tensor,
+    rope_rows: torch.Tensor,
+    token_indices: torch.Tensor,
+    out: torch.Tensor,
+) -> None:
+    """CPU reference: gather + dequantize."""
+    out.zero_()
+    valid = (token_indices >= 0) & (token_indices < packed_rows.shape[0])
+    if not bool(valid.any()):
+        return
+
+    selected_packed = packed_rows[token_indices[valid].long()]  # [V, 224]
+    codes = torch.zeros(
+        selected_packed.shape[0],
+        MXFP4_NOPE_DIM,
+        dtype=torch.uint8,
+        device=selected_packed.device,
+    )
+    codes[:, 0::2] = selected_packed & 0x0F
+    codes[:, 1::2] = selected_packed >> 4
+
+    selected_scales = scale_rows[
+        token_indices[valid].long(), :MXFP4_NUM_GROUPS
+    ].float()  # [V, 14]
+    scale = torch.pow(2.0, selected_scales - 127.0)
+
+    nope = (
+        _decode_e2m1_torch(codes).reshape(-1, MXFP4_NUM_GROUPS, MXFP4_GROUP_SIZE)
+        * scale.unsqueeze(-1)
+    ).reshape(-1, MXFP4_NOPE_DIM)
+
+    rope = rope_rows[token_indices[valid].long()].to(torch.bfloat16)
+    out[valid, 0, :MXFP4_NOPE_DIM] = nope.to(torch.bfloat16)
+    out[valid, 0, MXFP4_NOPE_DIM:] = rope
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def quantize_dsv4_mxfp4_k_cache_into(
+    cache_k: torch.Tensor,
+    kv_buffer: torch.Tensor,
+    loc: torch.Tensor,
+    page_size: int,
+) -> None:
+    """Quantize BF16/FP16/FP32 DSV4 keys → MXFP4 and scatter by token ID.
+
+    Args:
+        cache_k:  [num_tokens, 512] or [num_tokens, 1, 512] — input K (nope+rope).
+        kv_buffer: [num_pages, page_size * 368] uint8 — destination pool.
+        loc:       [num_tokens] int32/int64 — flat row index per token.
+        page_size: tokens per page (typically 128 or 256).
+    """
+    k_nope, k_rope = _split_k(cache_k)
+    rows = _as_rows(kv_buffer, page_size)
+    loc = _validate_loc(loc, rows)
+    if k_nope.shape[0] != loc.numel():
+        raise ValueError(
+            f"cache_k and loc token counts differ: "
+            f"{k_nope.shape[0]} vs {loc.numel()}"
+        )
+    if not (k_nope.device == k_rope.device == rows.device):
+        raise ValueError("cache_k and KV buffer must be on one device")
+    if loc.numel() == 0:
+        return
+
+    packed_rows = rows[:, :MXFP4_PACKED_NOPE_BYTES]
+    scale_rows = rows[
+        :,
+        MXFP4_PACKED_NOPE_BYTES : MXFP4_PACKED_NOPE_BYTES + MXFP4_SCALE_BYTES,
+    ]
+    rope_rows = rows[:, -MXFP4_ROPE_BYTES:].view(torch.bfloat16)
+
+    if rows.is_cuda:
+        groups_per_program, num_warps = _quantize_launch_config(loc.numel())
+        num_parts = triton.cdiv(MXFP4_NUM_GROUPS, groups_per_program)
+        _quantize_mxfp4_k_cache_into_kernel[(loc.numel(), num_parts)](
+            k_nope,
+            k_rope,
+            packed_rows,
+            scale_rows,
+            rope_rows,
+            loc,
+            rows.shape[0],
+            k_nope.stride(0),
+            k_rope.stride(0),
+            packed_rows.stride(0),
+            scale_rows.stride(0),
+            rope_rows.stride(0),
+            NUM_GROUPS=MXFP4_NUM_GROUPS,
+            GROUP_SIZE=MXFP4_GROUP_SIZE,
+            GROUPS_PER_PROGRAM=groups_per_program,
+            ROPE_DIM=MXFP4_ROPE_DIM,
+            num_warps=num_warps,
+        )
+    else:
+        _quantize_mxfp4_reference(
+            k_nope, k_rope, packed_rows, scale_rows, rope_rows, loc
+        )
+
+
+def dequantize_dsv4_mxfp4_k_cache_paged(
+    kv_buffer: torch.Tensor,
+    token_indices: torch.Tensor,
+    page_size: int,
+    out: Optional[torch.Tensor] = None,
+) -> torch.Tensor:
+    """Gather and dequantize selected MXFP4 cache rows → BF16.
+
+    Args:
+        kv_buffer:     [num_pages, page_size * 368] uint8.
+        token_indices: [num_tokens] int32/int64 — flat row indices to gather.
+        page_size:     tokens per page.
+        out:           optional [num_tokens, 1, 512] BF16 output tensor.
+
+    Returns:
+        [num_tokens, 1, 512] BF16 tensor.
+    """
+    rows = _as_rows(kv_buffer, page_size)
+    token_indices = _validate_loc(token_indices, rows)
+    shape = (token_indices.numel(), 1, MXFP4_TOTAL_DIM)
+    if out is None:
+        out = torch.empty(shape, dtype=torch.bfloat16, device=rows.device)
+    elif out.shape != shape or out.dtype != torch.bfloat16:
+        raise ValueError(
+            f"out must be BF16 with shape {shape}, got {out.dtype} {tuple(out.shape)}"
+        )
+    elif out.device != rows.device or not out.is_contiguous():
+        raise ValueError("out and KV buffer must be contiguous and on one device")
+    if token_indices.numel() == 0:
+        return out
+
+    packed_rows = rows[:, :MXFP4_PACKED_NOPE_BYTES]
+    scale_rows = rows[
+        :,
+        MXFP4_PACKED_NOPE_BYTES : MXFP4_PACKED_NOPE_BYTES + MXFP4_SCALE_BYTES,
+    ]
+    rope_rows = rows[:, -MXFP4_ROPE_BYTES:].view(torch.bfloat16)
+
+    if rows.is_cuda:
+        output_2d = out.view(-1, MXFP4_TOTAL_DIM)
+        _dequantize_mxfp4_k_cache_paged_kernel[(token_indices.numel(),)](
+            packed_rows,
+            scale_rows,
+            rope_rows,
+            token_indices,
+            output_2d,
+            rows.shape[0],
+            packed_rows.stride(0),
+            scale_rows.stride(0),
+            rope_rows.stride(0),
+            output_2d.stride(0),
+            MAX_GROUPS=_MAX_GROUPS,
+            GROUP_SIZE=MXFP4_GROUP_SIZE,
+            NOPE_DIM=MXFP4_NOPE_DIM,
+            NOPE_TILE=_NOPE_TILE,
+            ROPE_DIM=MXFP4_ROPE_DIM,
+            num_warps=4,
+        )
+    else:
+        _dequantize_mxfp4_reference(
+            packed_rows, scale_rows, rope_rows, token_indices, out
+        )
+
+    return out
+
+
+__all__ = [
+    "MXFP4_BYTES_PER_TOKEN",
+    "MXFP4_NOPE_DIM",
+    "MXFP4_ROPE_DIM",
+    "MXFP4_TOTAL_DIM",
+    "MXFP4_GROUP_SIZE",
+    "MXFP4_NUM_GROUPS",
+    "MXFP4_PACKED_NOPE_BYTES",
+    "MXFP4_SCALE_BYTES",
+    "MXFP4_ROPE_BYTES",
+    "quantize_dsv4_mxfp4_k_cache_into",
+    "dequantize_dsv4_mxfp4_k_cache_paged",
+]

--- a/test/registered/kernels/benchmark/attention/bench_mxfp4_dsv4_decode.py
+++ b/test/registered/kernels/benchmark/attention/bench_mxfp4_dsv4_decode.py
@@ -1,0 +1,166 @@
+"""Benchmark: JIT MXFP4 DSV4 decode vs the FP8 sparse decode (FlashMLA).
+
+Same query shapes, same indices, same load; only the cache format differs.
+Each case covers one layer kind: C0 (SWA only), C4 (SWA + 64-token compressed
+cache) and C128 (SWA + 1024-token compressed cache), at two batch sizes.
+Timed with CUDA events over the full call (scheduler + main + combine).
+"""
+
+import math
+
+import torch
+from sgl_kernel.flash_mla import FlashMLASchedMeta as Fp8SchedMeta
+from sgl_kernel.flash_mla import flash_mla_with_kvcache as fp8_decode
+
+from sglang.kernels.jit.benchmark import marker
+from sglang.kernels.ops.attention.dsv4.mxfp4_dsv4_decode_sm90 import (
+    FlashMLASchedMeta as Mxfp4SchedMeta,
+)
+from sglang.kernels.ops.attention.dsv4.mxfp4_dsv4_decode_sm90 import (
+    flash_mla_with_kvcache_dsv4_mxfp4 as mxfp4_decode,
+)
+from sglang.kernels.ops.attention.dsv4.mxfp4_k_cache import (
+    MXFP4_BYTES_PER_TOKEN,
+    quantize_dsv4_mxfp4_k_cache_into,
+)
+from sglang.kernels.ops.attention.dsv4.quant_k_cache import (
+    quant_to_nope_fp8_rope_bf16_pack_triton,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(
+    est_time=30, stage="base-b-kernel-benchmark", runner_config="1-gpu-large"
+)
+
+_HEAD_DIM = 512
+_FP8_BYTES_PER_TOKEN = 584
+
+
+def _pack_fp8(k_bf16: torch.Tensor) -> torch.Tensor:
+    """BF16 [N, 512] -> FlashMLA fp8 row [N, 584] uint8."""
+    pack = quant_to_nope_fp8_rope_bf16_pack_triton(k_bf16)
+    n = k_bf16.shape[0]
+    row = torch.empty(
+        (n, _FP8_BYTES_PER_TOKEN), dtype=torch.uint8, device=k_bf16.device
+    )
+    row[:, :448] = pack.k_nope_fp8.view(torch.uint8)
+    row[:, 448:576] = pack.k_rope_bf16.view(torch.uint8)
+    row[:, 576:583] = pack.scale_k_nope_ue8m0
+    return row
+
+
+def _make_caches(num_pages: int, page_size: int, gen):
+    dev = torch.device("cuda")
+    cap = num_pages * page_size
+    src = (
+        torch.randn((cap, _HEAD_DIM), dtype=torch.bfloat16, device=dev, generator=gen)
+        / 10
+    )
+    loc = torch.arange(cap, dtype=torch.int32, device=dev)
+
+    mxfp4_raw = torch.zeros(
+        (num_pages, page_size * MXFP4_BYTES_PER_TOKEN), dtype=torch.uint8, device=dev
+    )
+    quantize_dsv4_mxfp4_k_cache_into(
+        cache_k=src, kv_buffer=mxfp4_raw, loc=loc, page_size=page_size
+    )
+    mxfp4_4d = mxfp4_raw.view(num_pages, page_size, 1, MXFP4_BYTES_PER_TOKEN)
+
+    fp8_row = _pack_fp8(src)
+    fp8_4d = fp8_row.view(num_pages, page_size, 1, _FP8_BYTES_PER_TOKEN)
+    return mxfp4_4d, fp8_4d
+
+
+def _make_indices(b: int, width: int, capacity: int, gen):
+    dev = torch.device("cuda")
+    rows, lengths = [], []
+    for i in range(b):
+        begin = i * width
+        row = torch.arange(begin, begin + width, dtype=torch.int32, device=dev)
+        row = row[torch.randperm(width, device=dev, generator=gen)]
+        rows.append(row)
+        lengths.append(width)
+    return torch.stack(rows).unsqueeze(1).contiguous(), torch.tensor(
+        lengths, dtype=torch.int32, device=dev
+    )
+
+
+def _make_case(h_q: int, b: int, swa_pages: int, extra_cfg):
+    """Build (mxfp4 args, fp8 args) for one layer configuration."""
+    dev = torch.device("cuda")
+    gen = torch.Generator(device=dev).manual_seed(7)
+    sm = 1.0 / math.sqrt(_HEAD_DIM)
+
+    swa_page_size = 256
+    swa_topk = 128
+    mxfp4_swa, fp8_swa = _make_caches(swa_pages, swa_page_size, gen)
+    swa_idx, swa_len = _make_indices(b, swa_topk, swa_pages * swa_page_size, gen)
+    q = torch.randn((b, 1, h_q, _HEAD_DIM), dtype=torch.bfloat16, device=dev) / 10
+    attn_sink = torch.zeros(h_q, dtype=torch.float32, device=dev)
+
+    ex_mx = ex_f8 = ex_idx = ex_len = None
+    if extra_cfg is not None:
+        e_page, e_topk = extra_cfg
+        e_pages = max((b * e_topk + e_page - 1) // e_page, 1)
+        ex_mx, ex_f8 = _make_caches(e_pages, e_page, gen)
+        ex_idx, ex_len = _make_indices(b, e_topk, e_pages * e_page, gen)
+
+    mx_meta = Mxfp4SchedMeta()
+    f8_meta = Fp8SchedMeta()
+    return dict(
+        mxfp4=lambda: mxfp4_decode(
+            q=q,
+            k_cache=mxfp4_swa,
+            indices=swa_idx,
+            topk_length=swa_len,
+            attn_sink=attn_sink,
+            tile_scheduler_metadata=mx_meta,
+            softmax_scale=sm,
+            extra_k_cache=ex_mx,
+            extra_indices_in_kvcache=ex_idx,
+            extra_topk_length=ex_len,
+        ),
+        fp8=lambda: fp8_decode(
+            q=q,
+            k_cache=fp8_swa,
+            head_dim_v=_HEAD_DIM,
+            block_table=None,
+            cache_seqlens=None,
+            tile_scheduler_metadata=f8_meta,
+            softmax_scale=sm,
+            is_fp8_kvcache=True,
+            indices=swa_idx,
+            topk_length=swa_len,
+            attn_sink=attn_sink,
+            extra_k_cache=ex_f8,
+            extra_indices_in_kvcache=ex_idx,
+            extra_topk_length=ex_len,
+        ),
+    )
+
+
+_CASES = {
+    "c0_b8": dict(h_q=64, b=8, swa_pages=8, extra_cfg=None),
+    "c4_b8": dict(h_q=64, b=8, swa_pages=8, extra_cfg=(64, 512)),
+    "c128_b8": dict(h_q=128, b=8, swa_pages=8, extra_cfg=(2, 1024)),
+    "c4_b32": dict(h_q=64, b=32, swa_pages=16, extra_cfg=(64, 512)),
+}
+
+
+@marker.parametrize("case", list(_CASES), ["c4_b8", "c4_b32"])
+@marker.benchmark("impl", ["mxfp4", "fp8"], unit="us")
+def benchmark(case: str, impl: str):
+    fns = _make_case(**_CASES[case])
+    return marker.do_bench(
+        fns[impl],
+        # Closure-based fns take no args; the JIT scheduler holds its own
+        # buffers, so memory accounting is skipped (both impls are compared
+        # under identical L2 conditions).
+        memory_args=(),
+        memory_output=(),
+        graph_clone_args=(),
+    )
+
+
+if __name__ == "__main__":
+    benchmark.run()

--- a/test/registered/kernels/ops/attention/test_mxfp4_dsv4_decode.py
+++ b/test/registered/kernels/ops/attention/test_mxfp4_dsv4_decode.py
@@ -1,0 +1,1030 @@
+"""Correctness coverage for the JIT-compiled MXFP4 DSV4 decode kernel.
+
+The kernel (python/sglang/kernels/jit/csrc/mxfp4_dsv4_decode_sm90/) consumes
+the production 368-byte MXFP4 DSV4 cache row and applies one online softmax
+over the SWA cache, the optional compressed (C4/C128) cache, and the attention
+sink. References start from the exactly dequantized physical cache rather than
+the pre-quantization BF16 keys. Covers three layer kinds (C0/C4/C128) x flash
+vs. profiling semantics, invalid-contract rejection, and CUDA-graph replay.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Callable, Optional
+
+import msgspec
+import pytest
+import torch
+
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+try:
+    from sglang.kernels.ops.attention.dsv4.mxfp4_dsv4_decode_sm90 import (
+        FlashMLASchedMeta,
+        flash_mla_with_kvcache_dsv4_mxfp4,
+    )
+except Exception as exc:
+    FlashMLASchedMeta = None
+    flash_mla_with_kvcache_dsv4_mxfp4 = None
+    _flashmla_import_error = exc
+else:
+    _flashmla_import_error = None
+
+try:
+    from sglang.kernels.ops.attention.dsv4.mxfp4_k_cache import (
+        MXFP4_BYTES_PER_TOKEN,
+        dequantize_dsv4_mxfp4_k_cache_paged,
+        quantize_dsv4_mxfp4_k_cache_into,
+    )
+except Exception as exc:
+    MXFP4_BYTES_PER_TOKEN = 368
+    dequantize_dsv4_mxfp4_k_cache_paged = None
+    quantize_dsv4_mxfp4_k_cache_into = None
+    _codec_import_error = exc
+else:
+    _codec_import_error = None
+
+
+_HEAD_DIM = 512
+_SWA_PAGE_SIZE = 256
+_SWA_TOPK = 128
+_OUTPUT_ATOL = 8e-4
+_OUTPUT_RTOL = 2.01 / 128
+_LSE_ATOL = 2e-4
+_LSE_RTOL = 8.01 / 65536
+
+
+def _is_sm90_supported() -> bool:
+    if not torch.cuda.is_available():
+        return False
+    if torch.cuda.get_device_capability() != (9, 0):
+        return False
+    if torch.version.cuda is None:
+        return False
+    version = tuple(int(part) for part in torch.version.cuda.split(".")[:2])
+    return version >= (12, 5)
+
+
+def _require_native() -> Callable:
+    if flash_mla_with_kvcache_dsv4_mxfp4 is None:
+        pytest.fail(
+            f"DSV4 MXFP4 FlashMLA wrapper is unavailable: {_flashmla_import_error}"
+        )
+    return flash_mla_with_kvcache_dsv4_mxfp4
+
+
+def _require_codec() -> tuple[Callable, Callable]:
+    if (
+        quantize_dsv4_mxfp4_k_cache_into is None
+        or dequantize_dsv4_mxfp4_k_cache_paged is None
+    ):
+        pytest.fail(f"DSV4 MXFP4 codec is unavailable: {_codec_import_error}")
+    return (
+        quantize_dsv4_mxfp4_k_cache_into,
+        dequantize_dsv4_mxfp4_k_cache_paged,
+    )
+
+
+class _DecodeCase(msgspec.Struct):
+    q: torch.Tensor
+    kv: torch.Tensor
+    indices: torch.Tensor
+    topk_length: torch.Tensor
+    attn_sink: torch.Tensor
+    dequantized_kv: torch.Tensor
+    sm_scale: float
+    extra_kv: Optional[torch.Tensor] = None
+    extra_indices: Optional[torch.Tensor] = None
+    extra_topk_length: Optional[torch.Tensor] = None
+    dequantized_extra_kv: Optional[torch.Tensor] = None
+
+
+def _make_cache(
+    *,
+    page_size: int,
+    minimum_tokens: int,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    quantize, dequantize = _require_codec()
+    device = torch.device("cuda")
+    num_pages = math.ceil(minimum_tokens / page_size)
+    capacity = num_pages * page_size
+    raw = torch.zeros(
+        (num_pages, page_size * MXFP4_BYTES_PER_TOKEN),
+        dtype=torch.uint8,
+        device=device,
+    )
+    source = (
+        torch.randn(
+            (capacity, _HEAD_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        / 10
+    )
+    physical_rows = torch.arange(capacity, dtype=torch.int32, device=device)
+    quantize(
+        cache_k=source,
+        kv_buffer=raw,
+        loc=physical_rows,
+        page_size=page_size,
+    )
+    dequantized = dequantize(
+        raw,
+        physical_rows,
+        page_size=page_size,
+    ).squeeze(1)
+    cache_4d = raw.view(num_pages, page_size, 1, MXFP4_BYTES_PER_TOKEN)
+    return cache_4d, dequantized
+
+
+def _make_indices(
+    *,
+    batch_size: int,
+    width: int,
+    capacity: int,
+    generator: torch.Generator,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    assert width % 64 == 0
+    assert capacity >= batch_size * width
+    device = torch.device("cuda")
+    rows = []
+    lengths = []
+    for batch_idx in range(batch_size):
+        begin = batch_idx * width
+        row = torch.arange(begin, begin + width, dtype=torch.int32, device=device)
+        row = row[torch.randperm(width, device=device, generator=generator)]
+        length = width - 1 if batch_idx == 0 else max(1, width * 3 // 5)
+
+        # Invalid entries inside the active prefix test the physical-capacity
+        # mask.  The inactive suffix is deliberately all out of range so the
+        # topk-length mask must run before any cache dereference.
+        row[1] = -1
+        row[3] = capacity + 17
+        row[length:] = capacity + 31
+        rows.append(row)
+        lengths.append(length)
+    return (
+        torch.stack(rows).unsqueeze(1).contiguous(),
+        torch.tensor(lengths, dtype=torch.int32, device=device),
+    )
+
+
+def _build_case(
+    *,
+    h_q: int,
+    batch_size: int = 2,
+    extra_page_size: Optional[int] = None,
+    extra_topk: int = 0,
+    seed: int = 20260714,
+) -> _DecodeCase:
+    assert h_q in (64, 128)
+    assert (extra_page_size is None) == (extra_topk == 0)
+    device = torch.device("cuda")
+    generator = torch.Generator(device=device).manual_seed(seed + h_q + extra_topk)
+
+    q = (
+        torch.randn(
+            (batch_size, 1, h_q, _HEAD_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=generator,
+        )
+        / 10
+    )
+    kv, dequantized_kv = _make_cache(
+        page_size=_SWA_PAGE_SIZE,
+        minimum_tokens=batch_size * _SWA_TOPK,
+        generator=generator,
+    )
+    kv_capacity = kv.shape[0] * kv.shape[1]
+    indices, topk_length = _make_indices(
+        batch_size=batch_size,
+        width=_SWA_TOPK,
+        capacity=kv_capacity,
+        generator=generator,
+    )
+    attn_sink = torch.linspace(-0.75, 0.25, h_q, dtype=torch.float32, device=device)
+    case = _DecodeCase(
+        q=q,
+        kv=kv,
+        indices=indices,
+        topk_length=topk_length,
+        attn_sink=attn_sink,
+        dequantized_kv=dequantized_kv,
+        sm_scale=1.0 / math.sqrt(_HEAD_DIM),
+    )
+
+    if extra_page_size is not None:
+        extra_kv, dequantized_extra = _make_cache(
+            page_size=extra_page_size,
+            minimum_tokens=batch_size * extra_topk,
+            generator=generator,
+        )
+        extra_capacity = extra_kv.shape[0] * extra_kv.shape[1]
+        extra_indices, extra_topk_length = _make_indices(
+            batch_size=batch_size,
+            width=extra_topk,
+            capacity=extra_capacity,
+            generator=generator,
+        )
+        case.extra_kv = extra_kv
+        case.extra_indices = extra_indices
+        case.extra_topk_length = extra_topk_length
+        case.dequantized_extra_kv = dequantized_extra
+    return case
+
+
+def _selected_rows(
+    cache: torch.Tensor, indices: torch.Tensor, length: int
+) -> torch.Tensor:
+    length = max(0, min(length, indices.numel()))
+    active = indices[:length]
+    valid = (active >= 0) & (active < cache.shape[0])
+    return cache.index_select(0, active[valid].long())
+
+
+def _reference(case: _DecodeCase) -> tuple[torch.Tensor, torch.Tensor]:
+    batch_size, _, h_q, _ = case.q.shape
+    out = torch.empty(
+        (batch_size, 1, h_q, _HEAD_DIM),
+        dtype=torch.float32,
+        device=case.q.device,
+    )
+    lse = torch.empty((batch_size, h_q, 1), dtype=torch.float32, device=case.q.device)
+    primary = case.dequantized_kv.float()
+    extra = (
+        case.dequantized_extra_kv.float()
+        if case.dequantized_extra_kv is not None
+        else None
+    )
+
+    for batch_idx in range(batch_size):
+        selected = [
+            _selected_rows(
+                primary,
+                case.indices[batch_idx, 0],
+                int(case.topk_length[batch_idx].item()),
+            )
+        ]
+        if extra is not None:
+            assert case.extra_indices is not None
+            assert case.extra_topk_length is not None
+            selected.append(
+                _selected_rows(
+                    extra,
+                    case.extra_indices[batch_idx, 0],
+                    int(case.extra_topk_length[batch_idx].item()),
+                )
+            )
+        selected_kv = torch.cat(selected, dim=0)
+        logits = case.q[batch_idx, 0].float() @ selected_kv.transpose(0, 1)
+        logits *= case.sm_scale
+        logits_with_sink = torch.cat((logits, case.attn_sink[:, None]), dim=-1)
+        probabilities = torch.softmax(logits_with_sink, dim=-1, dtype=torch.float32)
+        out[batch_idx, 0] = probabilities[:, :-1] @ selected_kv
+        # Preserve FlashMLA's established ABI: the sink participates in the
+        # output normalization, while the returned LSE describes selected KV
+        # logits only (the combine kernel merges the sink after storing LSE).
+        lse[batch_idx, :, 0] = torch.logsumexp(logits, dim=-1)
+    return out.to(torch.bfloat16), lse
+
+
+def _run_native(
+    native: Callable,
+    case: _DecodeCase,
+    sched_meta,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    return native(
+        q=case.q,
+        k_cache=case.kv,
+        indices=case.indices,
+        topk_length=case.topk_length,
+        attn_sink=case.attn_sink,
+        tile_scheduler_metadata=sched_meta,
+        head_dim_v=_HEAD_DIM,
+        softmax_scale=case.sm_scale,
+        extra_k_cache=case.extra_kv,
+        extra_indices_in_kvcache=case.extra_indices,
+        extra_topk_length=case.extra_topk_length,
+    )
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@pytest.mark.parametrize(
+    ("name", "batch_size", "h_q", "extra_page_size", "extra_topk"),
+    [
+        ("c0_flash_b1", 1, 64, None, 0),
+        ("c0_flash_b2", 2, 64, None, 0),
+        ("c0_pro", 2, 128, None, 0),
+        ("c4_flash", 2, 64, 64, 512),
+        ("c4_pro", 2, 128, 64, 1024),
+        ("c128_flash", 2, 64, 2, 1024),
+        ("c128_pro_b1", 1, 128, 2, 1024),
+    ],
+)
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_dual_source_correctness(
+    name: str,
+    batch_size: int,
+    h_q: int,
+    extra_page_size: Optional[int],
+    extra_topk: int,
+) -> None:
+    del name
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    case = _build_case(
+        h_q=h_q,
+        batch_size=batch_size,
+        extra_page_size=extra_page_size,
+        extra_topk=extra_topk,
+    )
+    out, lse = _run_native(native, case, FlashMLASchedMeta())
+    out_ref, lse_ref = _reference(case)
+
+    assert out.shape == out_ref.shape == (batch_size, 1, h_q, _HEAD_DIM)
+    assert lse.shape == lse_ref.shape == (batch_size, h_q, 1)
+    assert bool(torch.isfinite(out).all())
+    assert bool(torch.isfinite(lse).all())
+    torch.testing.assert_close(out, out_ref, atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL)
+    torch.testing.assert_close(lse, lse_ref, atol=_LSE_ATOL, rtol=_LSE_RTOL)
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_caller_accum_workspace_bounds_vram() -> None:
+    """A caller-supplied split-K workspace must replace the module-global
+    per-geometry scratch.
+
+    The global cache pinned one (batch + sm parts)-row FP32 accumulator pair
+    per geometry forever: a stock CUDA-graph capture sweep (one entry per
+    captured batch size) left ~0.5 GiB resident at h_q=64 (~0.85 GiB at
+    h_q=128) per runner, and two runners sharing a geometry would race on
+    the same tensors.  A runner-sized arena prefix-sliced per batch pins one
+    allocation instead; every batch size only touches accumulator rows
+    [0, batch + parts), so all captured graphs share the arena's base
+    address and replays stay correct.
+    """
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    from sglang.kernels.ops.attention.dsv4.mxfp4_dsv4_decode_sm90 import (
+        _SCRATCH,
+        _num_sm_parts,
+    )
+
+    h_q = 64
+    num_sm_parts = _num_sm_parts(1, 1, h_q, torch.device("cuda"))
+    capture_bs = [1, 2, 4, 8, 16, 24, 32, 48, 64, 96, 128, 192, 256, 384, 512]
+    rows = capture_bs[-1] + num_sm_parts
+    lse_arena = torch.empty((rows, 1, h_q), dtype=torch.float32, device="cuda")
+    o_arena = torch.empty((rows, 1, h_q, _HEAD_DIM), dtype=torch.float32, device="cuda")
+
+    # Lean sweep fixtures: one max-batch cache/query sliced per batch (no
+    # dequantized reference — that FP32 copy would dwarf the scratch being
+    # measured).
+    quantize, _ = _require_codec()
+    device = torch.device("cuda")
+    gen = torch.Generator(device=device).manual_seed(20260818)
+    max_capacity = capture_bs[-1] * _SWA_TOPK
+    raw = torch.zeros(
+        (max_capacity // _SWA_PAGE_SIZE, _SWA_PAGE_SIZE * MXFP4_BYTES_PER_TOKEN),
+        dtype=torch.uint8,
+        device=device,
+    )
+    src = (
+        torch.randn(
+            (max_capacity, _HEAD_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=gen,
+        )
+        / 10
+    )
+    quantize(
+        cache_k=src,
+        kv_buffer=raw,
+        loc=torch.arange(max_capacity, dtype=torch.int32, device=device),
+        page_size=_SWA_PAGE_SIZE,
+    )
+    del src
+    kv = raw.view(-1, _SWA_PAGE_SIZE, 1, MXFP4_BYTES_PER_TOKEN)
+    q_max = (
+        torch.randn(
+            (capture_bs[-1], 1, h_q, _HEAD_DIM),
+            dtype=torch.bfloat16,
+            device=device,
+            generator=gen,
+        )
+        / 10
+    )
+    indices_max = torch.arange(max_capacity, dtype=torch.int32, device=device).view(
+        capture_bs[-1], 1, _SWA_TOPK
+    )
+
+    _SCRATCH.clear()
+    for b in capture_bs:
+        out, lse = native(
+            q=q_max[:b],
+            k_cache=kv,
+            indices=indices_max[:b],
+            topk_length=None,
+            attn_sink=None,
+            tile_scheduler_metadata=FlashMLASchedMeta(),
+            head_dim_v=_HEAD_DIM,
+            split_accum_buffers=(lse_arena, o_arena),
+        )
+        assert bool(torch.isfinite(out).all()) and bool(torch.isfinite(lse).all())
+
+    # The caller-owned arena fully replaces the module-global scratch: the
+    # sweep over 15 captured batch sizes leaves it empty.  The default path
+    # (no buffers — standalone callers) pins one accumulator pair per
+    # geometry instead, which is exactly the unbounded accumulation the
+    # arena exists to avoid (~440 MiB of FP32 across this sweep at h_q=64).
+    assert not _SCRATCH
+    for b in (2, 8, 32):
+        native(
+            q=q_max[:b],
+            k_cache=kv,
+            indices=indices_max[:b],
+            topk_length=None,
+            attn_sink=None,
+            tile_scheduler_metadata=FlashMLASchedMeta(),
+            head_dim_v=_HEAD_DIM,
+        )
+    assert len(_SCRATCH) == 3
+    _SCRATCH.clear()
+
+    # Same arena, second sweep: results identical to the global-scratch path
+    # (the prefix slicing must not change numerics), and the arena tensors
+    # are reused, not reallocated.
+    out_ref, _ = _run_native(
+        native, _build_case(h_q=h_q, batch_size=8), FlashMLASchedMeta()
+    )
+    case8 = _build_case(h_q=h_q, batch_size=8)
+    out_arena, _ = native(
+        q=case8.q,
+        k_cache=case8.kv,
+        indices=case8.indices,
+        topk_length=case8.topk_length,
+        attn_sink=case8.attn_sink,
+        tile_scheduler_metadata=FlashMLASchedMeta(),
+        head_dim_v=_HEAD_DIM,
+        softmax_scale=case8.sm_scale,
+        split_accum_buffers=(lse_arena, o_arena),
+    )
+    torch.testing.assert_close(out_arena, out_ref, atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL)
+
+    # An undersized or wrong-shaped arena must fail loudly, never truncate
+    # silently.
+    with pytest.raises(ValueError, match="rows"):
+        native(
+            q=case8.q,
+            k_cache=case8.kv,
+            indices=case8.indices,
+            topk_length=case8.topk_length,
+            attn_sink=case8.attn_sink,
+            tile_scheduler_metadata=FlashMLASchedMeta(),
+            split_accum_buffers=(lse_arena[:4], o_arena[:4]),
+        )
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_multirequest_parts_no_deadlock() -> None:
+    """Batches larger than the SM-part count used to deadlock the GPU.
+
+    The tile scheduler caps each SM part at a fixed block payload, so a part
+    can serve more than one request. The producer's epilogue-drain barrier
+    then waited on the wrong phase parity (one phase past the one the
+    consumers had completed) and never released, spinning the persistent
+    kernel forever. b = num_sm_parts + 1 guarantees every active part serves
+    two requests; 2 * num_sm_parts exactly fills the per-part capacity.
+    """
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    from sglang.kernels.ops.attention.dsv4.mxfp4_dsv4_decode_sm90 import _num_sm_parts
+
+    num_sm_parts = _num_sm_parts(1, 1, 64, torch.device("cuda"))
+    for batch_size in (num_sm_parts + 1, 2 * num_sm_parts):
+        case = _build_case(h_q=64, batch_size=batch_size)
+        out, lse = _run_native(native, case, FlashMLASchedMeta())
+        out_ref, lse_ref = _reference(case)
+
+        assert out.shape == out_ref.shape == (batch_size, 1, 64, _HEAD_DIM)
+        assert bool(torch.isfinite(out).all())
+        assert bool(torch.isfinite(lse).all())
+        torch.testing.assert_close(out, out_ref, atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL)
+        torch.testing.assert_close(lse, lse_ref, atol=_LSE_ATOL, rtol=_LSE_RTOL)
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_rejects_invalid_contracts() -> None:
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    case = _build_case(h_q=64, batch_size=1)
+
+    with pytest.raises(RuntimeError, match="q must have dtype bfloat16"):
+        native(
+            case.q.float(),
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    with pytest.raises(RuntimeError, match="multiple of 64"):
+        native(
+            case.q,
+            case.kv,
+            case.indices[..., :-1].contiguous(),
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    bad_cache = torch.empty(
+        (1, _SWA_PAGE_SIZE, 1, MXFP4_BYTES_PER_TOKEN - 1),
+        dtype=torch.uint8,
+        device=case.q.device,
+    )
+    with pytest.raises((RuntimeError, ValueError), match="368"):
+        native(
+            case.q,
+            bad_cache,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    cache_numel = case.kv.numel()
+    misaligned_storage = torch.empty(
+        cache_numel + 16, dtype=torch.uint8, device=case.q.device
+    )
+    # Offsets 1 and 4 cover both a fully misaligned base and one that only
+    # satisfies the old 4-byte contract (4 % 4 == 0 but 4 % 16 != 0 — the
+    # kernel's 128-bit vector loads would fault).
+    for misaligned_by in (1, 4):
+        misaligned_cache = misaligned_storage[
+            misaligned_by : misaligned_by + cache_numel
+        ].view_as(case.kv)
+        assert misaligned_cache.data_ptr() % 16 == misaligned_by
+        with pytest.raises(RuntimeError, match="16-byte aligned"):
+            native(
+                case.q,
+                misaligned_cache,
+                case.indices,
+                case.topk_length,
+                case.attn_sink,
+                FlashMLASchedMeta(),
+            )
+
+    with pytest.raises((AssertionError, RuntimeError, ValueError)):
+        native(
+            case.q,
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+            extra_k_cache=case.kv,
+        )
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_dispatch_raises_instead_of_exiting() -> None:
+    """The C++ entry point runs inside a serving process.
+
+    Its contract violations used to fprintf + exit(1), killing the whole
+    server on a bad input; they must raise a Python exception instead. The
+    public wrapper rejects bad inputs first, so this drives the raw FFI
+    dispatch with an invalid head_dim_v — the entry's first check.
+    """
+    from sglang.kernels.ops.attention.dsv4.mxfp4_dsv4_decode_sm90 import _get_dispatch
+
+    device = torch.device("cuda")
+    empty_i32 = torch.empty(0, dtype=torch.int32, device=device)
+    empty_f32 = torch.empty(0, dtype=torch.float32, device=device)
+    q = torch.empty((1, 1, 64, 512), dtype=torch.bfloat16, device=device)
+    with pytest.raises((ValueError, RuntimeError), match="512"):
+        _get_dispatch()(
+            q,
+            q,  # k_cache placeholder; the head_dim_v check fires first
+            empty_i32,  # indices
+            empty_i32,  # topk_length
+            empty_f32,  # attn_sink
+            empty_i32,  # tile_scheduler_metadata
+            empty_i32,  # num_splits
+            empty_i32,  # extra_k_cache
+            empty_i32,  # extra_indices
+            empty_i32,  # extra_topk_length
+            empty_f32,  # lse_accum
+            empty_f32,  # o_accum
+            empty_f32,  # out
+            empty_f32,  # lse
+            256,  # head_dim_v
+            1.0,  # sm_scale
+            0,  # generate_sched_meta
+        )
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_rejects_unsafe_kernel_contracts() -> None:
+    """Guard the wrapper contract for values the SM90 kernel hardcodes.
+
+    The kernel fixes head dim 512, 64/128 query heads, int32 index and length
+    tensors, [B, S_Q] index geometry matching q, same-device placement, and
+    contiguous layouts. Before these checks, a 256-wide bf16 q or an int64
+    indices tensor passed validation and the kernel read memory with
+    hardcoded 512-element int32 strides — an out-of-bounds or reinterpreted
+    read instead of an exception.
+    """
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    case = _build_case(h_q=64, batch_size=1)
+
+    # Head dims: a 256-wide q and a non-512 head_dim_v both sailed through
+    # every earlier check while the kernel addresses q with 512 strides.
+    narrow_q = case.q[..., :256].contiguous()
+    with pytest.raises(ValueError, match="512"):
+        native(
+            narrow_q,
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+    with pytest.raises(ValueError, match="512"):
+        native(
+            case.q,
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+            head_dim_v=256,
+        )
+
+    wide_q = case.q.repeat(1, 1, 3, 1)  # 192 heads
+    with pytest.raises(ValueError, match="64 or 128"):
+        native(
+            wide_q,
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    # Index tensors: int64 reinterpreted as int32 by the kernel.
+    with pytest.raises(ValueError, match="int32"):
+        native(
+            case.q,
+            case.kv,
+            case.indices.long(),
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+    with pytest.raises(ValueError, match="int32"):
+        native(
+            case.q,
+            case.kv,
+            case.indices,
+            case.topk_length.long(),
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    # Length-vector geometry: the scheduler kernel reads lengths[request] for
+    # every request in the batch.
+    with pytest.raises(ValueError, match="topk_length"):
+        native(
+            case.q,
+            case.kv,
+            case.indices,
+            case.topk_length.repeat(2),
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    # Batch/sequence geometry mismatch between q and indices.
+    with pytest.raises(ValueError, match="indices"):
+        native(
+            case.q,
+            case.kv,
+            case.indices.repeat(2, 1, 1),
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    # A strided q view: shape and dtype pass, but the kernel addresses q with
+    # hardcoded contiguous strides.
+    strided_q = torch.empty(
+        (1, 1, 64, 1024), dtype=torch.bfloat16, device=case.q.device
+    )[..., ::2]
+    assert not strided_q.is_contiguous()
+    with pytest.raises(ValueError, match="contiguous"):
+        native(
+            strided_q,
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    # Cross-device tensors: only q's device was ever checked before.
+    cpu_cache = torch.empty_like(case.kv, device="cpu")
+    with pytest.raises(ValueError, match="query device"):
+        native(
+            case.q,
+            cpu_cache,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+        )
+
+    # Extra source: an unaligned extra width and int64 extra indices.
+    with pytest.raises(RuntimeError, match="multiple of 64"):
+        native(
+            case.q,
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+            extra_k_cache=case.kv,
+            extra_indices_in_kvcache=case.indices[..., :32].contiguous(),
+            extra_topk_length=case.topk_length,
+        )
+    with pytest.raises(ValueError, match="int32"):
+        native(
+            case.q,
+            case.kv,
+            case.indices,
+            case.topk_length,
+            case.attn_sink,
+            FlashMLASchedMeta(),
+            extra_k_cache=case.kv,
+            extra_indices_in_kvcache=case.indices.long(),
+            extra_topk_length=case.topk_length,
+        )
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_clamps_graph_replayed_lengths() -> None:
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    case = _build_case(h_q=64, extra_page_size=64, extra_topk=512)
+    assert case.extra_indices is not None
+    assert case.extra_topk_length is not None
+
+    # Warm lazy extension state outside capture. A fresh metadata object below
+    # makes the private scheduler itself part of the captured graph.
+    _run_native(native, case, FlashMLASchedMeta())
+    torch.cuda.synchronize()
+
+    capture_meta = FlashMLASchedMeta()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out, graph_lse = _run_native(native, case, capture_meta)
+
+    out_ptr = graph_out.data_ptr()
+    lse_ptr = graph_lse.data_ptr()
+    int32 = torch.iinfo(torch.int32)
+
+    # Length tensors are graph-replayed device inputs. Exercise both signs on
+    # both sources: request 0 attends the clamped-full primary and empty extra;
+    # request 1 attends the empty primary and clamped-full extra. The scheduler
+    # and producer must agree without ever indexing beyond either padded width.
+    case.topk_length.copy_(
+        torch.tensor(
+            [int32.max, int32.min],
+            dtype=torch.int32,
+            device=case.q.device,
+        )
+    )
+    case.extra_topk_length.copy_(
+        torch.tensor(
+            [int32.min, int32.max],
+            dtype=torch.int32,
+            device=case.q.device,
+        )
+    )
+
+    graph.replay()
+    torch.cuda.synchronize()
+    out_ref, lse_ref = _reference(case)
+
+    assert graph_out.data_ptr() == out_ptr
+    assert graph_lse.data_ptr() == lse_ptr
+    assert bool(torch.isfinite(graph_out).all())
+    assert bool(torch.isfinite(graph_lse).all())
+    torch.testing.assert_close(graph_out, out_ref, atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL)
+    torch.testing.assert_close(graph_lse, lse_ref, atol=_LSE_ATOL, rtol=_LSE_RTOL)
+
+
+def _widen_primary_indices(case: _DecodeCase) -> _DecodeCase:
+    """Double the primary top-k width (128 -> 256) so lengths can cross a
+    second 64-token block boundary while reusing one FlashMLASchedMeta."""
+    capacity = case.kv.shape[0] * case.kv.shape[1]
+    wide = torch.cat(
+        [case.indices, (case.indices + capacity) % capacity], dim=-1
+    ).contiguous()
+    case.indices = wide
+    return case
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_eager_refreshes_stale_scheduler() -> None:
+    """Eager (non-graph) calls with one FlashMLASchedMeta re-run the scheduler.
+
+    The split assignment depends on the per-call top-k lengths; a growing
+    sequence crossing a 64-token block boundary must not reuse the previous
+    call's assignment (regression: the scheduler only ran on a fresh buffer,
+    so the newly added KV block was silently dropped).
+    """
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    case = _widen_primary_indices(_build_case(h_q=64, batch_size=2))
+    assert case.indices.shape[-1] == 256
+    device = case.q.device
+
+    meta = FlashMLASchedMeta()
+    case.topk_length.copy_(torch.tensor([128, 96], dtype=torch.int32, device=device))
+    out1, _ = _run_native(native, case, meta)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        out1, _reference(case)[0], atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL
+    )
+
+    # Same scheduler instance, lengths now spanning three 64-token blocks.
+    case.topk_length.copy_(torch.tensor([192, 160], dtype=torch.int32, device=device))
+    out2, _ = _run_native(native, case, meta)
+    torch.cuda.synchronize()
+    torch.testing.assert_close(
+        out2, _reference(case)[0], atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL
+    )
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_fresh_meta_per_capture() -> None:
+    """A second CUDA-graph capture with the same geometry gets a fresh
+    scheduler (regression: the backend's capture dict reused the first
+    graph's instance, so the second graph never recorded the scheduler
+    kernel and replayed with a stale split assignment)."""
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    case = _widen_primary_indices(_build_case(h_q=64, batch_size=2))
+    device = case.q.device
+
+    # Warm lazy extension state (as the backend does before capture).
+    _run_native(native, case, FlashMLASchedMeta())
+    torch.cuda.synchronize()
+
+    graph1 = torch.cuda.CUDAGraph()
+    meta1 = FlashMLASchedMeta()
+    case.topk_length.copy_(torch.tensor([128, 96], dtype=torch.int32, device=device))
+    with torch.cuda.graph(graph1):
+        _run_native(native, case, meta1)
+
+    # The backend clears its capture dict at the start of a new capture
+    # session, so the second graph records its own scheduler generation.
+    graph2 = torch.cuda.CUDAGraph()
+    meta2 = FlashMLASchedMeta()
+    case.topk_length.copy_(torch.tensor([128, 96], dtype=torch.int32, device=device))
+    with torch.cuda.graph(graph2):
+        graph2_out, graph2_lse = _run_native(native, case, meta2)
+
+    # Replay the second graph with lengths crossing the 64-block boundary.
+    case.topk_length.copy_(torch.tensor([192, 160], dtype=torch.int32, device=device))
+    graph2.replay()
+    torch.cuda.synchronize()
+    out_ref, lse_ref = _reference(case)
+    torch.testing.assert_close(
+        graph2_out, out_ref, atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL
+    )
+    torch.testing.assert_close(graph2_lse, lse_ref, atol=_LSE_ATOL, rtol=_LSE_RTOL)
+
+
+@pytest.mark.skipif(not _is_sm90_supported(), reason="SM90 and CUDA >= 12.5 required")
+@pytest.mark.parametrize(
+    ("name", "h_q", "extra_page_size", "extra_topk"),
+    [
+        ("c0_flash", 64, None, 0),
+        ("c0_pro", 128, None, 0),
+        ("c4_flash", 64, 64, 512),
+        ("c4_pro", 128, 64, 1024),
+        ("c128_flash", 64, 2, 1024),
+        ("c128_pro", 128, 2, 1024),
+    ],
+)
+@torch.inference_mode()
+def test_flashmla_dsv4_mxfp4_cuda_graph_replay(
+    name: str, h_q: int, extra_page_size: Optional[int], extra_topk: int
+) -> None:
+    del name
+    native = _require_native()
+    assert FlashMLASchedMeta is not None
+    case = _build_case(
+        h_q=h_q,
+        extra_page_size=extra_page_size,
+        extra_topk=extra_topk,
+    )
+
+    # Warm lazy extension state with a different metadata object.  The fresh
+    # object used during capture intentionally records scheduler generation in
+    # the graph, so replay can consume updated per-request top-k lengths.
+    _run_native(native, case, FlashMLASchedMeta())
+    torch.cuda.synchronize()
+
+    static_case = _DecodeCase(
+        q=torch.zeros_like(case.q),
+        kv=case.kv,
+        indices=case.indices.clone(),
+        topk_length=case.topk_length.clone(),
+        attn_sink=case.attn_sink,
+        dequantized_kv=case.dequantized_kv,
+        sm_scale=case.sm_scale,
+        extra_kv=case.extra_kv,
+        extra_indices=(
+            case.extra_indices.clone() if case.extra_indices is not None else None
+        ),
+        extra_topk_length=(
+            case.extra_topk_length.clone()
+            if case.extra_topk_length is not None
+            else None
+        ),
+        dequantized_extra_kv=case.dequantized_extra_kv,
+    )
+    capture_meta = FlashMLASchedMeta()
+    graph = torch.cuda.CUDAGraph()
+    with torch.cuda.graph(graph):
+        graph_out, graph_lse = _run_native(native, static_case, capture_meta)
+
+    out_ptr = graph_out.data_ptr()
+    lse_ptr = graph_lse.data_ptr()
+    captured_out = graph_out.clone()
+    captured_lse = graph_lse.clone()
+
+    static_case.q.copy_(case.q)
+    static_case.indices.copy_(torch.roll(case.indices, shifts=7, dims=-1))
+    if case.extra_indices is not None:
+        assert case.extra_topk_length is not None
+        assert static_case.extra_indices is not None
+        assert static_case.extra_topk_length is not None
+        # Exercise clamping inside the scheduler kernel recorded by the graph,
+        # not only in the eager safety test above. Request 1 still has valid
+        # extra KV after its negative primary length is clamped to zero.
+        static_case.topk_length.copy_(
+            torch.tensor(
+                [case.indices.shape[-1] + 17, -9],
+                dtype=torch.int32,
+                device=case.q.device,
+            )
+        )
+        static_case.extra_indices.copy_(
+            torch.roll(case.extra_indices, shifts=11, dims=-1)
+        )
+        static_case.extra_topk_length.copy_(
+            torch.tensor(
+                [extra_topk + 33, 37],
+                dtype=torch.int32,
+                device=case.q.device,
+            )
+        )
+    else:
+        static_case.topk_length.copy_(
+            torch.tensor([65, 127], dtype=torch.int32, device=case.q.device)
+        )
+
+    graph.replay()
+    torch.cuda.synchronize()
+    out_ref, lse_ref = _reference(static_case)
+
+    assert graph_out.data_ptr() == out_ptr
+    assert graph_lse.data_ptr() == lse_ptr
+    assert not torch.equal(graph_out, captured_out)
+    assert not torch.equal(graph_lse, captured_lse)
+    torch.testing.assert_close(graph_out, out_ref, atol=_OUTPUT_ATOL, rtol=_OUTPUT_RTOL)
+    torch.testing.assert_close(graph_lse, lse_ref, atol=_LSE_ATOL, rtol=_LSE_RTOL)
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__]))

--- a/test/registered/kernels/ops/attention/test_mxfp4_k_cache.py
+++ b/test/registered/kernels/ops/attention/test_mxfp4_k_cache.py
@@ -1,0 +1,294 @@
+"""MXFP4 codec (quantize / dequant) correctness.
+
+Verifies:
+  1. Triton kernel roundtrip quality (E2M1 is lossy, cos ≈ 0.99)
+  2. Triton matches the PyTorch reference (E8M0 rounding may differ slightly)
+  3. Empty batches, out-of-range indices, boundary cases
+  4. Pre-allocated output buffer reuse
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+from sglang.kernels.ops.attention.dsv4.mxfp4_k_cache import (
+    MXFP4_BYTES_PER_TOKEN,
+    MXFP4_GROUP_SIZE,
+    MXFP4_NOPE_DIM,
+    MXFP4_NUM_GROUPS,
+    MXFP4_TOTAL_DIM,
+    dequantize_dsv4_mxfp4_k_cache_paged,
+    quantize_dsv4_mxfp4_k_cache_into,
+)
+from sglang.test.ci.ci_register import register_cuda_ci
+
+register_cuda_ci(est_time=30, stage="base-b-kernel-unit", runner_config="1-gpu-large")
+
+# Tolerance: E2M1 (4-bit) roundtrip typically gives cos ∈ [0.98, 0.998]
+# depending on data distribution.
+_COS_MIN = 0.97
+_ERR_MAX = 5.0
+
+
+def _pool(page_size: int, num_pages: int = 4) -> torch.Tensor:
+    return torch.zeros(
+        num_pages,
+        page_size * MXFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+        device="cuda",
+    )
+
+
+def test_scale_is_ceil_never_saturates_group_amax():
+    """The E8M0 byte must follow ceil(log2(amax / 6)) (MX convention).
+
+    The original round(log2(amax / 6)) picked a scale one octave too small
+    for every group whose amax lands in (6·2^k, 6·2^k·2^0.5]: the max
+    element then saturated to the largest E2M1 code (6), returning up to
+    29% short after dequantization (amax 8 decoded as 6).  ceil guarantees
+    the group amax stays representable.
+    """
+    dev = torch.device("cuda")
+    page_size = 128
+    # All values are exact in bf16.  Entries whose log2(amax/6) is an
+    # integer sit exactly on a rounding boundary — the kernel's fp32
+    # log2(amax) - log2(6) may land a ulp on either side, so either
+    # adjacent byte is accepted there (both keep the amax representable).
+    # The other entries pin the exact ceil byte, including the (6, 8.49]
+    # band the old round scale saturated.
+    amaxes = [6.0, 12.0, 0.75, 1.5, 3.0, 7.0, 8.0, 15.0, 4.0, 0.5]
+    k = torch.zeros(1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    for group, amax in enumerate(amaxes):
+        k[0, group * 32 : (group + 1) * 32] = amax / 4.0
+        k[0, group * 32] = amax  # the group's max element
+    pool = _pool(page_size, num_pages=1)
+    loc = torch.zeros(1, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)[:, 0, :].float()
+
+    grid = (0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+    for group, amax in enumerate(amaxes):
+        byte = int(pool[0, 224 + group])
+        ratio = math.log2(amax / 6.0)
+        s_low = math.ceil(ratio)
+        on_boundary = ratio == math.floor(ratio)
+        if on_boundary:
+            assert byte in (s_low + 127, s_low + 128), (
+                f"group {group} amax {amax}: byte {byte} escaped the "
+                f"({s_low + 127}, {s_low + 128}) boundary pair"
+            )
+        else:
+            assert (
+                byte == s_low + 127
+            ), f"group {group} amax {amax}: byte {byte} != {s_low + 127}"
+        s = byte - 127
+        recovered = out[0, group * 32].item()
+        scaled = amax / 2.0**s
+        if scaled in grid:
+            # amax/2^s on the E2M1 grid: the max element roundtrips exactly.
+            assert recovered == amax, f"group {group}: {amax} -> {recovered}"
+        else:
+            # scaled ∈ (3, 6) off-grid (7/2 = 3.5 tie, 15/4 = 3.75): RNE
+            # lands on the 4 code — never on the 6·2^(s-1) clamp the round
+            # scale produced.
+            assert (
+                recovered == 4.0 * 2.0**s
+            ), f"group {group}: amax {amax} recovered as {recovered}"
+
+
+def test_e8m0_byte_zero_decodes_as_2_pow_minus_127():
+    """E8M0 has no zero encoding: byte 0 is 2^-127 (bytes 0..254 = 2^-127
+    .. 2^127, 255 reserved NaN), matching the fused decode kernel's
+    e8m0_bits_to_float.  The dequantizer must apply that exact exponent
+    rather than treating the byte as a zero scale."""
+    dev = torch.device("cuda")
+    page_size = 128
+    k = torch.zeros(1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size, num_pages=1)
+    loc = torch.zeros(1, dtype=torch.int32, device=dev)
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    # Hand-craft the first group: E2M1 code 0b101 (=3.0) in every nibble
+    # with scale byte 0 — the byte lives at row offset 224.
+    pool[0, 0:16] = torch.full((16,), 0x55, dtype=torch.uint8, device=dev)
+    pool[0, 224] = 0
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)[:, 0, :].float()
+    expected = torch.full((32,), 3.0 * 2.0**-127, device=dev)
+    assert torch.equal(out[0, :32], expected)
+
+
+def test_all_zero_block_quantizes_to_zero_codes():
+    """An all-zero block must quantize to E2M1 code 0 with scale byte 0 and
+    round-trip to exactly zero (regression: the quantizer derived the RNE
+    denominator from tl.math.exp2, which flushes the subnormal 2^-127 to
+    zero; the `magnitude >= denominator * midpoint` rungs then all held at
+    magnitude 0 and zero inputs were encoded as code 3 — nonzero packed
+    nibbles that also diverged from the PyTorch reference).  All-zero rows
+    occur in production: idle dummy stores write them into the pool."""
+    dev = torch.device("cuda")
+    page_size, num_tokens = 128, 4
+    k = torch.zeros(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+
+    rows = pool.view(-1, MXFP4_BYTES_PER_TOKEN)[:num_tokens]
+    packed = rows[:, : MXFP4_NOPE_DIM // 2]
+    scales = rows[:, MXFP4_NOPE_DIM // 2 : MXFP4_NOPE_DIM // 2 + MXFP4_NUM_GROUPS]
+    assert torch.equal(packed, torch.zeros_like(packed))
+    assert torch.equal(scales, torch.zeros_like(scales))
+
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+    nope = out[:, 0, :MXFP4_NOPE_DIM].float()
+    assert torch.equal(nope, torch.zeros_like(nope))
+
+    # The same must hold for a zero group inside an otherwise healthy row:
+    # its packed bytes and its scale byte stay zero while the row's other
+    # groups encode normally.
+    torch.manual_seed(3)
+    k = torch.randn(1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    k[0, :MXFP4_GROUP_SIZE] = 0
+    pool = _pool(page_size)
+    loc = torch.zeros(1, dtype=torch.int32, device=dev)
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    row = pool.view(-1, MXFP4_BYTES_PER_TOKEN)[0]
+    group_bytes = MXFP4_GROUP_SIZE // 2
+    assert torch.equal(
+        row[:group_bytes], torch.zeros(group_bytes, dtype=torch.uint8, device=dev)
+    )
+    assert row[MXFP4_NOPE_DIM // 2] == 0
+    assert not torch.equal(
+        row[group_bytes : MXFP4_NOPE_DIM // 2],
+        torch.zeros(MXFP4_NOPE_DIM // 2 - group_bytes, dtype=torch.uint8, device=dev),
+    )
+
+
+def test_roundtrip_quality():
+    """Triton quantize → dequant roundtrip preserves signal."""
+    torch.manual_seed(1)
+    page_size, num_tokens = 128, 32
+    dev = torch.device("cuda")
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+
+    cos = torch.nn.functional.cosine_similarity(
+        k.float().flatten(), out[:, 0, :].float().flatten(), dim=0
+    ).item()
+    max_err = (k.float() - out[:, 0, :].float()).abs().max().item()
+
+    assert cos > _COS_MIN, f"cos {cos} below threshold {_COS_MIN}"
+    assert max_err < _ERR_MAX, f"max_err {max_err} above threshold {_ERR_MAX}"
+
+
+def test_triton_vs_reference():
+    """Triton output matches PyTorch reference (CPU fallback)."""
+    torch.manual_seed(2)
+    page_size, num_tokens = 64, 8
+    dev = torch.device("cuda")
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+
+    # Triton path
+    pool_triton = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+    quantize_dsv4_mxfp4_k_cache_into(k, pool_triton, loc, page_size)
+    out_triton = dequantize_dsv4_mxfp4_k_cache_paged(pool_triton, loc, page_size)
+
+    # CPU reference path (move data to CPU, quantize, move back)
+    k_cpu = k.cpu()
+    pool_cpu = torch.zeros(
+        1,
+        page_size * MXFP4_BYTES_PER_TOKEN,
+        dtype=torch.uint8,
+    )
+    loc_cpu = torch.arange(num_tokens, dtype=torch.int32)
+    quantize_dsv4_mxfp4_k_cache_into(k_cpu, pool_cpu, loc_cpu, page_size)
+    out_ref = dequantize_dsv4_mxfp4_k_cache_paged(pool_cpu, loc_cpu, page_size)
+
+    out_cpu = out_ref[:, 0, :].to(dev).float()
+    out_gpu = out_triton[:, 0, :].float()
+
+    diff = (out_cpu - out_gpu).abs()
+    max_diff = diff.max().item()
+    cos = torch.nn.functional.cosine_similarity(
+        out_cpu.flatten(), out_gpu.flatten(), dim=0
+    ).item()
+
+    # Quantization decisions (E8M0 rounding) may differ slightly between
+    # PyTorch and Triton due to FP32 order-of-operations.
+    assert cos > 0.999, f"cos {cos} too low"
+    assert max_diff < 1e-3, f"max_diff {max_diff} too high"
+
+
+def test_empty_batch():
+    """Zero-token batch produces no-op."""
+    page_size = 128
+    k = torch.empty(0, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device="cuda")
+    pool = _pool(page_size)
+    loc = torch.empty(0, dtype=torch.int32, device="cuda")
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+    out = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+
+    assert out.shape == (0, 1, MXFP4_TOTAL_DIM)
+
+
+def test_oob_indices():
+    """Out-of-bounds indices yield zero rows (padded graph batch).
+
+    The output is pre-filled with non-zero values so stale memory (or a
+    reused pre-allocated buffer) cannot mask a missing zero write.
+    """
+    torch.manual_seed(3)
+    page_size, num_tokens = 32, 16
+    dev = torch.device("cuda")
+    num_rows = 4 * page_size
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev) - 4  # [-4 .. 11]
+    loc[0] = num_rows + 17  # above capacity
+    loc[1] = -100  # negative
+    assert (loc < 0).any() and (loc >= num_rows).any()
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+
+    out = torch.full(
+        (num_tokens, 1, MXFP4_TOTAL_DIM), 7.5, dtype=torch.bfloat16, device=dev
+    )
+    dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size, out=out)
+
+    oob = (loc < 0) | (loc >= num_rows)
+    assert (
+        out[oob] == 0
+    ).all(), f"OOB rows should be zero, got {(out[oob] != 0).sum().item()} non-zero"
+    # In-range rows still dequantize (nonzero signal).
+    assert (out[~oob] != 0).any()
+
+
+def test_pre_allocated_output():
+    """Using a pre-allocated output tensor (no allocation in dequant)."""
+    torch.manual_seed(4)
+    page_size, num_tokens = 64, 8
+    dev = torch.device("cuda")
+
+    k = torch.randn(num_tokens, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    pool = _pool(page_size)
+    loc = torch.arange(num_tokens, dtype=torch.int32, device=dev)
+
+    quantize_dsv4_mxfp4_k_cache_into(k, pool, loc, page_size)
+
+    out1 = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size)
+    out2 = torch.empty(num_tokens, 1, MXFP4_TOTAL_DIM, dtype=torch.bfloat16, device=dev)
+    out3 = dequantize_dsv4_mxfp4_k_cache_paged(pool, loc, page_size, out=out2)
+
+    assert out3 is out2, "Should return the passed-in tensor"
+    assert (out1 == out2).all(), "Pre-allocated output mismatches default-allocated"


### PR DESCRIPTION
## Motivation

Part 3/4 of splitting up #32741. The decode kernel itself: a JIT-compiled (TVM-FFI, first-use compile, no sgl-kernel wheel change) port of the FlashMLA three-stage split-KV design to the MXFP4 cache layout. Depends on #37135 (vendored FlashMLA headers) and #37136 (codec constants used by tests).

## Modifications

- `jit/csrc/deepseek_v4/mxfp4_dsv4_decode_sm90/`: scheduler-metadata kernel (1 CTA × 1 thread, device-side length clamping → CUDA-graph safe), persistent WGMMA main kernel (384 threads, 3 warp groups: producer dequant→SMEM / local QK+PV / remote PV; E8M0 dequant via `bits << 23`, E2M1 via LUT+PRMT), and PDL combine kernel. One call covers SWA + compressed C4/C128 sources plus attn_sink in a single online softmax; explicit instantiations for h_q 64/128.
- Provenance: `config.h` / `dequant.h` / `layout.h` / `components/helpers.h` and the splitkv skeleton are carried from the NVFP4 reference #31269; the MXFP4 `splitkv_mla.cuh` variant and the TVM-FFI `entry.cuh` are new. CUTLASS comes from the JIT build's `extra_dependencies=[cutlass]`.
- Op wrapper `kernels/ops/attention/dsv4/mxfp4_dsv4_decode_sm90.py` (per-geometry scratch reuse, C++-side stream resolution), a 17-case kernel unit suite (C0/C4/C128 × geometries, graph replay + length clamping, invalid contracts), and a kernel benchmark.

## Accuracy Tests

`test/registered/kernels/ops/attention/test_mxfp4_dsv4_decode.py` — 17/17 pass on Hopper (validated on 8×H20, will confirm on CI).

## Speed Tests and Profiling

Kernel benchmark included (`bench_mxfp4_dsv4_decode.py`); end-to-end numbers reported in part 4. Kernel SASS was byte-identical to the AOT (cmake) build of the same sources at port time.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33322692108](https://github.com/sgl-project/sglang/actions/runs/33322692108)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33322691880](https://github.com/sgl-project/sglang/actions/runs/33322691880)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33322692096](https://github.com/sgl-project/sglang/actions/runs/33322692096)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->