### PR TITLE
[Fix] Fix transformer loader fallback test fixture

### DIFF
--- a/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
+++ b/python/sglang/multimodal_gen/test/unit/test_transformer_loader_fallback.py
@@ -40,6 +40,7 @@ class TestTransformerLoaderFallbackAdmission(unittest.TestCase):
             "dp_size": 1,
             "use_fsdp_inference": False,
             "resolve_component_attention_backend": mock.Mock(return_value=(None, None)),
+            "should_direct_gpu_weight_load_component": mock.Mock(return_value=False),
             "should_use_fsdp_for_component": mock.Mock(return_value=fsdp_requested),
         }
         values.update(overrides)


### PR DESCRIPTION
## Summary

- Add the missing `should_direct_gpu_weight_load_component` mock to the transformer-loader fallback fixture.
- Restore the unit tests after [#37049](https://github.com/sgl-project/sglang/pull/37049) introduced the fail-closed component helper.

## Test plan

- `git diff --check`
- Upstream CI (local targeted collection is blocked by a missing `cloudpickle` dependency)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33319218109](https://github.com/sgl-project/sglang/actions/runs/33319218109)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33319217998](https://github.com/sgl-project/sglang/actions/runs/33319217998)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33319218070](https://github.com/sgl-project/sglang/actions/runs/33319218070)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->