### PR TITLE
[HiCache] Skip KV-derived sidecars when clamping the HiRadixCache prefetch prefix

### DIFF
--- a/python/sglang/srt/mem_cache/hiradix_cache.py
+++ b/python/sglang/srt/mem_cache/hiradix_cache.py
@@ -1696,26 +1696,30 @@ class HiRadixCache(RadixCache):
         self,
         operation: PrefetchOperation,
     ) -> int:
-        """Determine the minimal number of tokens from full KV hits and sidecar hits.
+        """The usable prefix length: the shared minimum of the Full KV completion
+        and every sidecar that reports its own hit count.
 
-        HiRadixCache only wires DSA-style stacks (Full attention + a KV-derived
-        ALL_PAGES sidecar such as the DSA / MiniMax indexer); For the DSA case we *clamp*
-        to the minimum fetched prefix shared by the Full KV pool and every
-        sidecar rather than discarding everything. With no sidecar (FULL-only)
-        this is just Full KV completion.
+        A KV-derived sidecar (the DSA / MiniMax indexer, ``indices_from_pool=KV``)
+        rides the KV host slots and is read inside
+        ``HiCacheController._page_transfer_kv_batch``, which already clamps
+        ``completed_tokens`` to ``min(kv_hits, sidecar_hits)``. It never reports
+        into ``pool_storage_result``, so counting it here would read as zero hits
+        and discard the whole fetch -- host slots in
+        ``[usable, completed_tokens)`` belong to no one and leak. Only sidecars
+        with independent slots (SWA / Mamba, filled by
+        ``HybridCacheController._page_transfer_sidecar``) are clamped here.
         """
-        # Sync completed tokens and per-pool hit pages across ATTN groups, taking
-        # the minimum so every rank agrees on the same usable prefix length.
-        pool_transfers = getattr(operation, "pool_transfers", None) or []
+        pool_transfers = [
+            transfer
+            for transfer in getattr(operation, "pool_transfers", None) or []
+            if transfer.indices_from_pool != PoolName.KV
+        ]
         hit_pages = (
             operation.pool_storage_result.extra_pool_hit_pages if pool_transfers else {}
         )
         completed_tokens = operation.completed_tokens
         pool_hit_pages = [hit_pages.get(t.name, 0) for t in pool_transfers]
 
-        # Clamp to the shared minimum prefix of the Full KV completion and each
-        # KV-derived ALL_PAGES sidecar (e.g. the DSA indexer). FULL-only has no
-        # sidecar, so the usable prefix is just the Full KV completion.
         usable_pages = completed_tokens // self.page_size
         if pool_transfers:
             usable_pages = min(usable_pages, *pool_hit_pages)

--- a/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
+++ b/test/registered/unit/mem_cache/test_hiradix_cache_unit.py
@@ -1,4 +1,5 @@
-"""Unit tests for srt/mem_cache/hiradix_cache.py KV cache events."""
+"""Unit tests for srt/mem_cache/hiradix_cache.py KV cache events and
+storage-prefetch host-slot ownership."""
 
 import os
 import unittest
@@ -10,7 +11,9 @@ from sglang.srt.disaggregation.kv_events import BlockStored, StorageMedium
 from sglang.srt.mem_cache.allocator import TokenToKVPoolAllocator
 from sglang.srt.mem_cache.base_prefix_cache import InsertParams, MatchPrefixParams
 from sglang.srt.mem_cache.cache_init_params import CacheInitParams
+from sglang.srt.mem_cache.hicache_storage import PoolHitPolicy, PoolName, PoolTransfer
 from sglang.srt.mem_cache.hiradix_cache import HiRadixCache
+from sglang.srt.mem_cache.hybrid_cache.hybrid_cache_controller import PrefetchOperation
 from sglang.srt.mem_cache.memory_pool import MHATokenToKVPool, ReqToTokenPool
 from sglang.srt.mem_cache.radix_cache import RadixKey
 from sglang.srt.server_args import ServerArgs, set_global_server_args_for_scheduler
@@ -23,60 +26,65 @@ register_amd_ci(est_time=15, stage="stage-b", runner_config="1-gpu-small-amd")
 PAGE_SIZE = 2
 
 
+def _require_cuda_and_process_group():
+    if not torch.cuda.is_available():
+        raise unittest.SkipTest("CUDA is required for HiRadixCache tests.")
+    os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
+    os.environ.setdefault("MASTER_PORT", "29601")
+    if not torch.distributed.is_initialized():
+        torch.distributed.init_process_group(backend="gloo", rank=0, world_size=1)
+
+
+def _build_cache():
+    server_args = ServerArgs(
+        model_path="dummy",
+        page_size=PAGE_SIZE,
+        hicache_io_backend="direct",
+        hicache_mem_layout="layer_first",
+        hicache_write_policy="write_through",
+    )
+    set_global_server_args_for_scheduler(server_args)
+    req_to_token_pool = ReqToTokenPool(
+        size=10,
+        max_context_len=512,
+        device="cuda",
+        enable_memory_saver=False,
+    )
+    kv_pool = MHATokenToKVPool(
+        size=256,
+        page_size=PAGE_SIZE,
+        dtype=torch.bfloat16,
+        head_num=2,
+        head_dim=64,
+        layer_num=4,
+        device="cuda",
+        enable_memory_saver=False,
+    )
+    allocator = TokenToKVPoolAllocator(
+        size=256,
+        dtype=torch.bfloat16,
+        device="cuda",
+        kvcache=kv_pool,
+        need_sort=False,
+    )
+    params = CacheInitParams(
+        req_to_token_pool=req_to_token_pool,
+        token_to_kv_pool_allocator=allocator,
+        page_size=PAGE_SIZE,
+        disable=False,
+        enable_kv_cache_events=True,
+        tp_cache_group=torch.distributed.group.WORLD,
+    )
+    cache = HiRadixCache(params, server_args)
+    # Disable hit-count-driven write-through; tests back up explicitly.
+    cache.write_through_threshold = 1 << 30
+    return cache, allocator
+
+
 class TestHiRadixCacheKVEvents(CustomTestCase):
     @classmethod
     def setUpClass(cls):
-        if not torch.cuda.is_available():
-            raise unittest.SkipTest("CUDA is required for HiRadixCache tests.")
-        os.environ.setdefault("MASTER_ADDR", "127.0.0.1")
-        os.environ.setdefault("MASTER_PORT", "29601")
-        if not torch.distributed.is_initialized():
-            torch.distributed.init_process_group(backend="gloo", rank=0, world_size=1)
-
-    def _build_cache(self):
-        server_args = ServerArgs(
-            model_path="dummy",
-            page_size=PAGE_SIZE,
-            hicache_io_backend="direct",
-            hicache_mem_layout="layer_first",
-            hicache_write_policy="write_through",
-        )
-        set_global_server_args_for_scheduler(server_args)
-        req_to_token_pool = ReqToTokenPool(
-            size=10,
-            max_context_len=512,
-            device="cuda",
-            enable_memory_saver=False,
-        )
-        kv_pool = MHATokenToKVPool(
-            size=256,
-            page_size=PAGE_SIZE,
-            dtype=torch.bfloat16,
-            head_num=2,
-            head_dim=64,
-            layer_num=4,
-            device="cuda",
-            enable_memory_saver=False,
-        )
-        allocator = TokenToKVPoolAllocator(
-            size=256,
-            dtype=torch.bfloat16,
-            device="cuda",
-            kvcache=kv_pool,
-            need_sort=False,
-        )
-        params = CacheInitParams(
-            req_to_token_pool=req_to_token_pool,
-            token_to_kv_pool_allocator=allocator,
-            page_size=PAGE_SIZE,
-            disable=False,
-            enable_kv_cache_events=True,
-            tp_cache_group=torch.distributed.group.WORLD,
-        )
-        cache = HiRadixCache(params, server_args)
-        # Disable hit-count-driven write-through; tests back up explicitly.
-        cache.write_through_threshold = 1 << 30
-        return cache, allocator
+        _require_cuda_and_process_group()
 
     def _insert(self, cache, allocator, tokens):
         key = RadixKey(array("q", tokens))
@@ -97,7 +105,7 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
         ]
 
     def test_split_pending_write_through_publishes_fragments(self):
-        cache, allocator = self._build_cache()
+        cache, allocator = _build_cache()
         cache.take_events()
 
         self._insert(cache, allocator, [1, 2, 3, 4])
@@ -117,6 +125,109 @@ class TestHiRadixCacheKVEvents(CustomTestCase):
         self.assertEqual(list(stored_cpu[0].token_ids), [1, 2, 3, 4])
         self.assertIsNone(stored_cpu[0].parent_block_hash)
         self.assertEqual(len(stored_cpu[0].block_hashes), 2)
+
+
+class TestHiRadixCachePrefetchHostOwnership(CustomTestCase):
+    """A storage prefetch on a DSA / MiniMax stack must publish its fetched span
+    and leave no host slot stranded.
+
+    Regression: the fetch completed, but nothing reached the tree and the host
+    slots it held could never be reclaimed -- L3 hit rate read as zero while the
+    host pool drained away request by request.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        _require_cuda_and_process_group()
+
+    @staticmethod
+    def _kv_derived_indexer_transfer():
+        """The transfer HiRadixCache._get_extra_pools builds for DSA / MiniMax."""
+        return PoolTransfer(
+            name=PoolName.INDEXER,
+            hit_policy=PoolHitPolicy.ALL_PAGES,
+            indices_from_pool=PoolName.KV,
+        )
+
+    def _prefetch_operation(self, prefetch_key, completed_tokens, pool_transfers):
+        operation = PrefetchOperation(
+            "rid-0",
+            prefetch_key,
+            pool_transfers=pool_transfers,
+        )
+        operation.completed_tokens = completed_tokens
+        # Hex digests: the KV cache event path parses these back into int64.
+        operation.hash_value = [
+            f"{i:032x}" for i in range(completed_tokens // PAGE_SIZE)
+        ]
+        return operation
+
+    def test_independent_sidecar_still_clamps_the_usable_prefix(self):
+        """A sidecar owning its own slots (SWA / Mamba) still shortens the prefix.
+
+        Guards the opposite degradation from the leak below: dropping the clamp
+        altogether would publish pages the sidecar never fetched.
+        """
+        cache, _ = _build_cache()
+        completed_tokens = 4 * PAGE_SIZE
+        swa_transfer = PoolTransfer(
+            name=PoolName.SWA,
+            host_indices=torch.arange(PAGE_SIZE, dtype=torch.int64),
+            hit_policy=PoolHitPolicy.TRAILING_PAGES,
+        )
+        operation = self._prefetch_operation(
+            RadixKey(array("q", list(range(completed_tokens)))),
+            completed_tokens,
+            [swa_transfer],
+        )
+        operation.pool_storage_result.update_extra_pool_hit_pages({PoolName.SWA: 1})
+
+        self.assertEqual(cache._clamp_prefetch_result(operation), PAGE_SIZE)
+
+    def test_prefetch_with_kv_derived_sidecar_leaks_no_host_slots(self):
+        cache, allocator = _build_cache()
+        host_pool = cache.cache_controller.mem_pool_host
+
+        # Device-resident prefix; the fetched suffix grafts underneath it.
+        prefix_tokens = [1, 2, 3, 4]
+        value = allocator.alloc(len(prefix_tokens))
+        self.assertIsNotNone(value)
+        cache.insert(InsertParams(key=RadixKey(array("q", prefix_tokens)), value=value))
+        anchor = cache.match_prefix(
+            MatchPrefixParams(key=RadixKey(array("q", prefix_tokens)))
+        ).last_device_node
+        self.assertIsNot(anchor, cache.root_node)
+
+        available_before = host_pool.available_size()
+
+        completed_tokens = 4 * PAGE_SIZE
+        prefetch_key = RadixKey(array("q", list(range(100, 100 + completed_tokens))))
+        operation = self._prefetch_operation(
+            prefetch_key, completed_tokens, [self._kv_derived_indexer_transfer()]
+        )
+        host_indices = host_pool.alloc(completed_tokens)
+        self.assertIsNotNone(host_indices)
+        operation.host_indices = host_indices
+
+        anchor.protect_host()
+        cache.ongoing_prefetch["rid-0"] = (anchor, prefetch_key, operation)
+        # Only initialized once a storage backend is attached; seed it the way
+        # prefetch_from_storage would.
+        cache.cache_controller.prefetch_tokens_occupied = len(prefetch_key)
+
+        cache._handle_prefetch_result(operation)
+        # The completed_req ack releases the untransferred tail.
+        host_pool.free(operation.host_indices[operation.completed_tokens :])
+
+        # The whole fetched span reached the tree.
+        self.assertEqual(cache.pop_prefetch_loaded_tokens("rid-0"), completed_tokens)
+        self.assertEqual(anchor.host_ref_counter, 0)
+        self.assertEqual(cache.cache_controller.prefetch_tokens_occupied, 0)
+
+        # Ownership conservation: every slot the prefetch took is reclaimable
+        # through the normal host-eviction path.
+        cache.evict_host(completed_tokens)
+        self.assertEqual(host_pool.available_size(), available_before)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Motivation

`829138a31` ([HiCache] Fix PP inconsistency with HiCache L3, #27010) moved the read of a KV-derived sidecar — the DSA / MiniMax indexer, `indices_from_pool=PoolName.KV`, which rides the KV host slots — into `HiCacheController._page_transfer_kv_batch`, where its hit count is already folded into `completed_tokens`:

```python
# managers/cache_controller.py: _page_transfer_kv_batch
return min([kv_hits, *sidecar_hits.values()])
```

The same commit narrowed `HybridCacheController._page_transfer_sidecar` to non-KV-derived pools only, so a KV-derived sidecar no longer reports into `operation.pool_storage_result`. That established a new invariant, which `unified_radix_cache.py:1988` states and honors:

> Skip KV-derived pools, which do not report hits in `operation.pool_storage_result`. Their hit lengths are stored in `completed_tokens`.

`HiRadixCache._clamp_prefetch_result` was not updated. It still counts every entry of `operation.pool_transfers`, so the indexer reads back as `hit_pages.get(PoolName.INDEXER, 0) == 0` and clamps the usable prefix to zero: nothing reaches the tree, and the host slots in `[0, completed_tokens)` are owned by nobody — `_handle_prefetch_result` frees only `[:matched_length]` and the `completed_req` ack frees only `[completed_tokens:]`.

**Scope, stated plainly:** this is latent, not a live data-plane failure. `default_radix_cache_factory` has not constructed `HiRadixCache` since #35081 (2026-08-21) — every branch terminates at `_create_unified_radix_cache`, and `--radix-cache-backend` has only `flexkv` registered in tree. #35081 landed four days before #27010, which is presumably why only the unified copy was updated. Verified empirically on a DSA model with `--enable-hierarchical-cache --hicache-storage-backend file`: the server logs `Attached hybrid pool stack to UnifiedRadixCache: pools=KV + INDEXER` and `impl=UnifiedRadixCache`. No release branch carries #27010 (`git branch -r --contains 829138a31` is `upstream/main` alone).

So this PR restores consistency between the two copies of one invariant and pins it with a regression test. If the intent is that `hiradix_cache.py` is now dead code, deleting the file would be the better fix and I am happy to close this in favor of that — I did not want to presume.

## Modifications

- `HiRadixCache._clamp_prefetch_result` filters out `indices_from_pool == PoolName.KV` before clamping, matching `UnifiedRadixCache`. Sidecars with independent slots (SWA / Mamba, filled by `HybridCacheController._page_transfer_sidecar`) are still clamped.
- New `TestHiRadixCachePrefetchHostOwnership` with two cases:
  - `test_prefetch_with_kv_derived_sidecar_leaks_no_host_slots` — the whole fetched span reaches the tree, `host_ref_counter` and `prefetch_tokens_occupied` return to zero, and `evict_host` restores `available_size()` to its pre-prefetch value.
  - `test_independent_sidecar_still_clamps_the_usable_prefix` — guards the opposite degradation: an SWA sidecar that owns its own slots must still shorten the prefix.
- The CUDA / process-group setup and cache fixture are lifted to module scope so both test classes share them. No behavior change to the existing case.

## Accuracy Tests

Not applicable — no change to model outputs.

## Speed Tests and Profiling

Not applicable — the change removes list entries before a `min()`.

## Tests

On one H200, `test/registered/unit/mem_cache/test_hiradix_cache_unit.py`:

| | pre-fix | post-fix |
|---|---|---|
| `test_prefetch_with_kv_derived_sidecar_leaks_no_host_slots` | FAILED, `AssertionError: 0 != 8` | PASSED |
| `test_independent_sidecar_still_clamps_the_usable_prefix` | PASSED | PASSED |

A probe over the same scenario, quantifying both halves:

```
=== pre-fix ===                     === post-fix ===
clamped_usable_tokens = 0           clamped_usable_tokens = 8
loaded_from_storage   = 0 (exp 8)   loaded_from_storage   = 8 (exp 8)
host_avail_before     = 514         host_avail_before     = 514
host_avail_after_evict= 506         host_avail_after_evict= 514
LEAKED_HOST_SLOTS     = 8           LEAKED_HOST_SLOTS     = 0
```

Whole-directory baseline diff, same command on both trees, `test/registered/unit/mem_cache/` (`--ignore` on `test_umbp_store.py`, which needs `mori`):

```
baseline   1851 passed, 1207 skipped, 211 subtests, 0 failed
this PR    1853 passed, 1207 skipped, 211 subtests, 0 failed
```

The delta is exactly the two new cases.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33321251892](https://github.com/sgl-project/sglang/actions/runs/33321251892)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33321251679](https://github.com/sgl-project/sglang/actions/runs/33321251679)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33321251752](https://github.com/sgl-project/sglang/actions/runs/33321251752)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->