### PR TITLE
Fix HiCache backup writer selection with context parallelism

### DIFF
--- a/python/sglang/srt/managers/cache_controller.py
+++ b/python/sglang/srt/managers/cache_controller.py
@@ -50,6 +50,13 @@ logger = logging.getLogger(__name__)
 device_module = get_device_module()
 
 
+def _should_skip_rank_replicated_backup(
+    is_rank_replicated: bool, attn_tp_rank: int
+) -> bool:
+    """Keep one writer per attention-TP replica group, not per global TP group."""
+    return is_rank_replicated and attn_tp_rank != 0
+
+
 class LayerLoadingEvent:
     def __init__(self, num_layers: int):
         self._num_layers = num_layers
@@ -553,11 +560,12 @@ class HiCacheController:
         self.storage_config = self._generate_storage_config(
             model_name, storage_backend_extra_config
         )
-        # for MLA models, only one rank needs to backup the KV cache
-        self.backup_skip = (
-            self.storage_config.is_mla_model
-            # todo: load balancing
-            and self.storage_config.tp_rank != 0
+        # Rank-replicated KV is identical only within an attention-TP group.
+        # Context-parallel ranks own distinct physical shards, so rank 0 of
+        # every attention-TP group must back up its shard independently.
+        self.backup_skip = _should_skip_rank_replicated_backup(
+            self.storage_config.is_mla_model,
+            get_parallel().attn_tp_rank,
         )
 
         # Use storage backend factory for dynamic backend creation

--- a/test/registered/unit/mem_cache/test_cache_controller_cp_backup.py
+++ b/test/registered/unit/mem_cache/test_cache_controller_cp_backup.py
@@ -1,0 +1,24 @@
+import unittest
+
+from sglang.srt.managers.cache_controller import (
+    _should_skip_rank_replicated_backup,
+)
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestContextParallelBackupWriter(CustomTestCase):
+    def test_every_context_parallel_shard_has_a_writer(self):
+        self.assertFalse(_should_skip_rank_replicated_backup(True, 0))
+
+    def test_attention_tp_replica_still_skips_backup(self):
+        self.assertTrue(_should_skip_rank_replicated_backup(True, 1))
+
+    def test_non_replicated_cache_never_skips_backup(self):
+        self.assertFalse(_should_skip_rank_replicated_backup(False, 7))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- elect the HiCache backup writer from `attn_tp_rank` instead of the global storage TP rank
- keep one writer for rank-replicated KV inside each attention-TP replica group
- add CPU regression coverage for context-parallel shards, attention-TP replicas, and non-replicated caches

## Problem

HiCache currently skips backup for rank-replicated KV when `storage_config.tp_rank != 0`. That is correct for plain tensor parallelism, but not when context parallelism is enabled: different CP ranks own different physical KV shards, while `storage_config.tp_rank` is still the global TP coordinate.

As a result, only global TP rank 0 writes to L3. On a fresh reader, rank 0 can report a full existence hit while the other CP ranks miss their physical shards. The cross-rank `MIN` synchronization then reduces the storage hit prefix to zero, so prefetch is revoked before `batch_get`.

## Fix

Use `get_parallel().attn_tp_rank` for writer election. CP creates a separate attention-TP group for each CP coordinate, so rank 0 of every group writes its physical shard. Plain TP still has exactly one writer for the replicated KV.

## Validation

- Added three CPU unit tests for the writer-selection invariant.
- The tests pass in the target SGLang runtime image.
- In an 8-rank CP end-to-end run, the pre-fix behavior had writes only on rank 0 and no reads. After the change, all 8 ranks issued storage writes; a fresh process observed existence hits and `batch_get` on all 8 ranks, followed by positive HiCache loaded/cached-token counts.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33484909902](https://github.com/sgl-project/sglang/actions/runs/33484909902)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33484909661](https://github.com/sgl-project/sglang/actions/runs/33484909661)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33484909790](https://github.com/sgl-project/sglang/actions/runs/33484909790)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->