### PR TITLE
[Spec] Allow pipeline parallelism with speculative decoding on the PD-prefill role

### DIFF
--- a/python/sglang/srt/arg_groups/speculative_hook.py
+++ b/python/sglang/srt/arg_groups/speculative_hook.py
@@ -391,9 +391,11 @@ def _handle_dspark(server_args: ServerArgs) -> None:
                 f"(got {cfg.speculative_moe_a2a_backend!r})."
             )
 
-    if cfg.pp_size != 1:
+    if cfg.pp_size != 1 and cfg.disaggregation_mode != "prefill":
         raise ValueError(
-            "Currently DSpark speculative decoding only supports pp_size == 1."
+            "Currently DSpark speculative decoding only supports pp_size == 1, "
+            "except on the PD-disaggregated prefill role, where the draft head "
+            "runs whole on the last pipeline stage."
         )
 
     if cfg.speculative_draft_model_path is None:
@@ -661,6 +663,19 @@ def _handle_eagle_family(server_args: ServerArgs) -> None:
 
     cfg = resolving_view(server_args)
 
+    if cfg.pp_size != 1:
+        # `check_server_args` allows pp_size > 1 with speculative decoding on the
+        # PD-prefill role, where the draft runs whole on the last stage. The
+        # eagle family cannot use that exception yet: `init_lm_head` pulls the
+        # target's `get_embed_and_head()`, and a pipeline-split target holds
+        # `embed_tokens` only on the first stage (`PPMissingLayer` elsewhere), so
+        # the last stage -- the one hosting the draft -- raises AttributeError.
+        raise ValueError(
+            "Currently eagle-family speculative decoding only supports "
+            "pp_size == 1: the draft head shares the target's embed_tokens and "
+            "lm_head, which a pipeline-split target does not hold on one stage."
+        )
+
     if (
         cfg.speculative_algorithm == "STANDALONE"
         and resolved_view(server_args).enable_dp_attention
@@ -838,6 +853,16 @@ def _handle_ngram(server_args: ServerArgs) -> None:
     if cfg.device not in ("cuda", "cpu"):
         raise ValueError(
             "Ngram speculative decoding only supports CUDA or CPU devices."
+        )
+
+    if cfg.pp_size != 1:
+        # `check_server_args` allows pp_size > 1 with speculative decoding on the
+        # PD-prefill role, but the pipeline relay of the draft tensors assumes an
+        # `EagleDraftInput`-shaped draft input (topk_p / accept_tokens), which
+        # `NgramVerifyInput` does not provide.
+        raise ValueError(
+            "Currently ngram speculative decoding only supports pp_size == 1: "
+            "the pipeline draft-tensor relay expects an eagle-shaped draft input."
         )
 
     _disable_overlap_schedule_for_cpu(server_args)

--- a/python/sglang/srt/arg_groups/validation_hook.py
+++ b/python/sglang/srt/arg_groups/validation_hook.py
@@ -50,8 +50,14 @@ def check_server_args(server_args: Any):
 
     if cfg.pp_size > 1:
         assert (
-            cfg.disable_overlap_schedule and cfg.speculative_algorithm is None
-        ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
+            cfg.disable_overlap_schedule
+        ), "Pipeline parallelism is not compatible with overlap schedule"
+        if cfg.speculative_algorithm is not None:
+            assert cfg.disaggregation_mode == "prefill", (
+                "Pipeline parallelism + speculative decoding is only supported on "
+                "the PD-disaggregated prefill role, where the draft head runs "
+                "whole on the last pipeline stage."
+            )
         assert cfg.min_free_slots_delay is None, (
             "--min-free-slots-delay is not supported with pipeline "
             "parallelism: allocatable slots per microbatch are bounded by "

--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -965,6 +965,22 @@ class Scheduler(
             self.external_corpus_manager = None
             return
 
+        # PD-prefill with pipeline parallelism: the draft head is a pp_size=1
+        # runner that reads the target's `lm_head` / `embed_tokens`, which only
+        # the last stage holds (`PPMissingLayer` elsewhere). Non-last stages
+        # therefore run target-only; every init and forward path below already
+        # guards on `draft_worker is not None`.
+        # NOTE: self.disaggregation_mode is assigned later than
+        # init_model_worker(), so read the config bag directly here.
+        if (
+            self.ps.pp_size > 1
+            and self.ps.pp_rank != self.ps.pp_size - 1
+            and get_disagg().disaggregation_mode == "prefill"
+        ):
+            self.draft_worker = None
+            self.external_corpus_manager = None
+            return
+
         # Launch a draft worker for speculative decoding. It builds its draft
         # from this process's own config: what differs for the draft — the
         # target's context length, the draft load format, its attention backend
@@ -1064,7 +1080,10 @@ class Scheduler(
             model_runner.post_capture_elastic_ep_recover()
 
         # Dispatch the model worker
-        if self.spec_algorithm.is_none():
+        if self.spec_algorithm.is_none() or self.draft_worker is None:
+            # A live spec algorithm with no draft worker means this rank is a
+            # non-last PD-prefill pipeline stage (see maybe_init_draft_worker):
+            # it runs target-only, so the target worker is the model worker.
             self.model_worker = self.tp_worker
         else:
             self.model_worker = self.draft_worker
@@ -3995,7 +4014,7 @@ class Scheduler(
                 self._relay_forward_payload(batch, batch.req_pool_indices, batch_result)
                 batch.input_ids = None
                 self._copy_auxiliary_output_to_cpu(batch, batch_result)
-            elif not batch.spec_algorithm.is_none():
+            elif not batch.spec_algorithm.is_none() and self.draft_worker is not None:
                 # Non-overlap: drive the V2 worker synchronously (no
                 # future_map relay / on_publish).
                 resolve_forward_inputs(batch, self.future_map)
@@ -4022,9 +4041,13 @@ class Scheduler(
                         return_hidden_states=batch.return_hidden_states,
                     )
             else:
+                # A spec algorithm with no draft worker on this rank is a
+                # non-last PD-prefill pipeline stage: it runs the target only
+                # and therefore needs the pipeline proxy tensors, exactly like
+                # the non-spec path.
                 kwargs = (
                     {"pp_proxy_tensors": pp_proxy_tensors}
-                    if self.spec_algorithm.is_none()
+                    if self.spec_algorithm.is_none() or self.draft_worker is None
                     else {}
                 )
                 resolve_forward_inputs(batch, self.future_map)

--- a/python/sglang/srt/managers/scheduler_pp_mixin.py
+++ b/python/sglang/srt/managers/scheduler_pp_mixin.py
@@ -1196,6 +1196,13 @@ class SchedulerPPMixin:
                 num_tokens_for_logprob_per_req=1,
             )
             batch.spec_info = next_draft_input
+        elif batch.spec_info is not None:
+            # DSpark's draft input carries no topk_p/hidden_states (the target
+            # hidden is injected into the draft KV instead), so the ring has
+            # nothing to rebuild from. run_batch already stored this iteration's
+            # draft input on the batch, and the PD result processor asserts the
+            # result and the batch hold the same object.
+            next_draft_input = batch.spec_info
 
         # PP rank 0 also relays into output_tokens_buf so the next iter's
         # resolve_forward_inputs finds these tokens for the decode portion

--- a/python/sglang/srt/mem_cache/kv_cache_configurator.py
+++ b/python/sglang/srt/mem_cache/kv_cache_configurator.py
@@ -26,7 +26,7 @@ from sglang.srt.configs.model_config import (
     is_deepseek_v4,
     is_minimax_sparse,
 )
-from sglang.srt.distributed.parallel_state import get_world_group
+from sglang.srt.distributed.parallel_state import get_tp_group, get_world_group
 from sglang.srt.distributed.utils import get_pp_indices
 from sglang.srt.environ import envs
 from sglang.srt.layers.quantization.fp4_kv_cache_quant_method import (
@@ -1831,6 +1831,19 @@ class KVCacheConfigurator:
                     )
         return token_to_kv_pool_allocator
 
+    def _pool_sync_group(self):
+        """Group over which pool-sizing collectives are reduced.
+
+        Normally the WORLD group, so every rank agrees on one pool size. A draft
+        runner under pipeline parallelism is the exception: it exists only on the
+        stage(s) that build a draft (PD-prefill builds it on the last stage
+        only), so a WORLD reduction would be issued by a subset of ranks and
+        desynchronize the group. Its stage-local TP group is the correct scope.
+        """
+        if self.is_draft_worker and get_parallel().pp_size > 1:
+            return get_tp_group()
+        return get_world_group()
+
     def _profile_available_bytes(self, pre_model_load_memory: int) -> int:
         # KV pool budget = currently-free GPU memory minus the non-static runtime
         # slack (pre_model_load_memory * (1 - mem_fraction_static)). Whatever is
@@ -1841,11 +1854,12 @@ class KVCacheConfigurator:
         # measured against an understated free-memory figure and the pool can be
         # sized orders of magnitude too small while GPU memory sits idle.
         gc.collect()
+        sync_group = self._pool_sync_group()
         available_gpu_memory = get_available_gpu_memory(
             self.device,
             self.gpu_id,
-            distributed=get_world_group().world_size > 1,
-            cpu_group=get_world_group().cpu_group,
+            distributed=sync_group.world_size > 1,
+            cpu_group=sync_group.cpu_group,
         )
 
         slack_gb = pre_model_load_memory * (1 - get_schedule().mem_fraction_static)
@@ -1934,8 +1948,10 @@ class KVCacheConfigurator:
                 )
             token_capacity = min(token_capacity, user_limit)
 
-        # Sync across PP ranks (each may have different layer counts)
-        if get_parallel().pp_size > 1:
+        # Sync across PP ranks (each may have different layer counts). A draft
+        # runner is always pp_size=1, so it has nothing to reconcile and must not
+        # join a group it may not be present on every rank of.
+        if get_parallel().pp_size > 1 and not self.is_draft_worker:
             tensor = torch.tensor(token_capacity, dtype=torch.int64)
             torch.distributed.all_reduce(
                 tensor,

--- a/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
+++ b/python/sglang/srt/model_executor/model_runner_components/layer_setup.py
@@ -197,6 +197,13 @@ def _assert_pp_mtp_compat(
     num_effective_layers: int,
     model_num_layers: int,
 ) -> None:
+    from sglang.srt.runtime_context import get_disagg
+
+    # PD-prefill is the one role where a pipeline-split target may coexist with
+    # speculative decoding: the draft head runs as its own pp_size=1 runner on
+    # the last stage, so the target stages never need the MTP layer themselves.
+    if get_disagg().disaggregation_mode == "prefill":
+        return
     assert (
         (not model_has_mtp_layers)
         or (spec_algorithm.is_none())

--- a/python/sglang/srt/speculative/draft_worker_common.py
+++ b/python/sglang/srt/speculative/draft_worker_common.py
@@ -65,6 +65,7 @@ def build_draft_tp_worker(
     algo_label: str,
     attention_backend_override: Optional[str] = None,
     draft_worker_cls: type[TpModelWorker] = TpModelWorker,
+    random_seed: Optional[int] = None,
 ) -> DraftWorkerBundle:
     # An override names a draft-specific backend the caller has already
     # validated (e.g. a self-drafting architecture); it skips the generic
@@ -89,6 +90,10 @@ def build_draft_tp_worker(
             # The draft runs at absolute target positions.
             context_length=target_model_config.context_len,
             draft_attention_backend=draft_backend,
+            # A draft built on only some pipeline stages cannot join the WORLD
+            # seed broadcast; the caller hands over the target's already
+            # broadcast seed instead (see TpModelWorker.__init__).
+            random_seed=random_seed,
         )
 
     draft_model_runner = draft_worker.model_runner

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -142,6 +142,7 @@ class DSparkWorkerV2(BaseSpecWorker):
                     DSV4_DRAFT_ATTENTION_BACKEND if self._draft_is_moe else None
                 ),
                 draft_worker_cls=draft_worker_cls,
+                random_seed=target_worker.random_seed,
             )
         self._draft_worker = bundle.draft_worker
         self.draft_model_runner = bundle.draft_model_runner

--- a/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
+++ b/python/sglang/srt/speculative/dspark_components/dspark_worker_v2.py
@@ -467,26 +467,34 @@ class DSparkWorkerV2(BaseSpecWorker):
         batch: ScheduleBatch,
         on_publish=None,
         grammar_barrier=None,
+        pp_proxy_tensors=None,
     ) -> GenerationBatchResult:
         if batch.forward_mode.is_extend() or batch.is_extend_in_batch:
             self._verify_planner.note_non_decode_step()
             self._observers.note_prefill_step()
-            return self._forward_prefill(batch, on_publish)
+            return self._forward_prefill(batch, on_publish, pp_proxy_tensors)
 
         return self._forward_decode(batch, on_publish, grammar_barrier)
 
     def _forward_prefill(
-        self, batch: ScheduleBatch, on_publish
+        self, batch: ScheduleBatch, on_publish, pp_proxy_tensors=None
     ) -> GenerationBatchResult:
+        # Under PD-prefill PP the target runs across stages, so its forward
+        # needs the proxy tensors handed down by the previous stage. The draft
+        # head is not pipeline-parallel and never takes them.
         if batch.forward_mode.is_idle():
             if get_parallel().enable_dp_attention:
                 self.target_worker.forward_batch_generation(
-                    batch, capture_hidden_mode=CaptureHiddenMode.FULL
+                    batch,
+                    capture_hidden_mode=CaptureHiddenMode.FULL,
+                    pp_proxy_tensors=pp_proxy_tensors,
                 )
             return self._decode_idle_result(on_publish=on_publish)
 
         batch_output = self.target_worker.forward_batch_generation(
-            batch, capture_hidden_mode=CaptureHiddenMode.FULL
+            batch,
+            capture_hidden_mode=CaptureHiddenMode.FULL,
+            pp_proxy_tensors=pp_proxy_tensors,
         )
         logits_output = batch_output.logits_output
         next_token_ids = batch_output.next_token_ids

--- a/test/registered/unit/server_args/test_server_args_pp_speculative.py
+++ b/test/registered/unit/server_args/test_server_args_pp_speculative.py
@@ -1,0 +1,226 @@
+"""Unit tests for the pipeline-parallelism + speculative-decoding gate.
+
+The gate is two layers and this file pins both:
+
+* ``arg_groups/validation_hook.check_server_args`` -- model-agnostic policy:
+  ``pp_size > 1`` requires ``disable_overlap_schedule``, and if a speculative
+  algorithm is set it additionally requires the PD-disaggregated *prefill* role.
+* the per-algorithm hooks in ``arg_groups/speculative_hook`` -- each narrows the
+  policy to what its own draft path can actually do. Only DSpark takes the
+  prefill exception; the eagle family and ngram still require ``pp_size == 1``.
+
+The two layers need different drivers: ``model_path="dummy"`` short-circuits
+``run_resolution_pipeline`` (pipeline.py, right after the hardware validation),
+so a dummy-model record reaches ``check_server_args`` but never reaches the
+per-algorithm hooks. The second class therefore calls
+``handle_speculative_decoding`` directly, the same way
+``unit/spec/test_spec_cpu_overlap_constraint.py`` does.
+
+Why a unit test and not only an e2e one: the policy is a matrix (pp x algorithm
+x disaggregation role x overlap schedule) that costs nothing to check on CPU,
+while the e2e test can only afford one point of it.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.arg_groups.speculative_hook import handle_speculative_decoding
+from sglang.srt.server_args import ServerArgs
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestPipelineParallelSpeculativeGate(CustomTestCase):
+    """``check_server_args`` accepts PP + spec only on the PD prefill role."""
+
+    @classmethod
+    def setUpClass(cls):
+        # CPU-only runners have no CUDA device; the gate under test does not
+        # care, but resolution upstream of it does.
+        cls._device_patch = patch(
+            "sglang.srt.arg_groups.serving_hook.get_device", return_value="cuda"
+        )
+        cls._device_patch.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, "_device_patch"):
+            cls._device_patch.stop()
+
+    @staticmethod
+    def _validate(**overrides):
+        """Run the full arg validation on an otherwise minimal ServerArgs.
+
+        ``served_model_name``, ``chunked_prefill_size`` and ``page_size`` are
+        normally derived from the model config and the device; with a dummy
+        model path they stay ``None`` and trip unrelated checks *after* the gate
+        (a colon test on the served name, a divisibility test on the chunk
+        size). Pinning them keeps a failure here attributable to the gate.
+        """
+        args = ServerArgs(
+            model_path="dummy",
+            served_model_name="dummy",
+            chunked_prefill_size=8192,
+            page_size=1,
+            **overrides,
+        )
+        args.resolve_once()
+        args.check_server_args()
+
+    # ---- accepted ----------------------------------------------------------
+
+    def test_prefill_role_accepts_pp_with_speculative_decoding(self):
+        self._validate(
+            pp_size=2,
+            speculative_algorithm="NGRAM",
+            disaggregation_mode="prefill",
+            disable_overlap_schedule=True,
+        )
+
+    def test_pp_size_one_is_unaffected(self):
+        # The default, non-pipelined path must not have become stricter.
+        self._validate(pp_size=1, speculative_algorithm="NGRAM")
+
+    def test_pp_without_speculative_decoding_is_unaffected(self):
+        self._validate(pp_size=2, disable_overlap_schedule=True)
+
+    # ---- rejected ----------------------------------------------------------
+
+    def test_decode_role_still_rejects_pp_with_speculative_decoding(self):
+        with self.assertRaisesRegex(AssertionError, "prefill role"):
+            self._validate(
+                pp_size=2,
+                speculative_algorithm="NGRAM",
+                disaggregation_mode="decode",
+                disable_overlap_schedule=True,
+            )
+
+    def test_non_disaggregated_still_rejects_pp_with_speculative_decoding(self):
+        with self.assertRaisesRegex(AssertionError, "prefill role"):
+            self._validate(
+                pp_size=2,
+                speculative_algorithm="NGRAM",
+                disaggregation_mode="null",
+                disable_overlap_schedule=True,
+            )
+
+    def test_overlap_schedule_requirement_survives_the_split(self):
+        # The overlap-schedule and speculative-decoding halves used to be one
+        # assertion. Splitting them must not have dropped the overlap half.
+        with self.assertRaisesRegex(AssertionError, "overlap schedule"):
+            self._validate(
+                pp_size=2,
+                speculative_algorithm="NGRAM",
+                disaggregation_mode="prefill",
+                disable_overlap_schedule=False,
+            )
+
+    def test_overlap_schedule_requirement_holds_without_speculative_decoding(self):
+        with self.assertRaisesRegex(AssertionError, "overlap schedule"):
+            self._validate(pp_size=2, disable_overlap_schedule=False)
+
+    # ---- algorithm-agnostic ------------------------------------------------
+
+    def test_policy_layer_is_not_specific_to_one_algorithm(self):
+        # This layer keys off `speculative_algorithm is not None`, nothing more;
+        # which algorithms can actually use the prefill exception is decided one
+        # layer down, in TestPipelineParallelSpeculativePerAlgorithmGate.
+        for algorithm in ("NGRAM", "EAGLE", "DSPARK"):
+            with self.subTest(algorithm=algorithm):
+                self._validate(
+                    pp_size=2,
+                    speculative_algorithm=algorithm,
+                    disaggregation_mode="prefill",
+                    disable_overlap_schedule=True,
+                )
+                with self.assertRaisesRegex(AssertionError, "prefill role"):
+                    self._validate(
+                        pp_size=2,
+                        speculative_algorithm=algorithm,
+                        disaggregation_mode="decode",
+                        disable_overlap_schedule=True,
+                    )
+
+
+class TestPipelineParallelSpeculativePerAlgorithmGate(CustomTestCase):
+    """Only DSpark takes the PD-prefill exception to ``pp_size == 1``."""
+
+    @staticmethod
+    def _hook_error(algorithm, **overrides):
+        """Return the message the per-algorithm hook raises, or None.
+
+        The stand-in ``_model_config`` is enough for the ``pp_size`` guards,
+        which all run before any real model introspection; a hook that gets past
+        its guard may still trip on an unrelated check further down, so callers
+        assert on *which* message came back rather than on raising at all.
+        """
+        args = ServerArgs(model_path="dummy")
+        args.speculative_algorithm = algorithm
+        args.device = "cuda"
+        args.speculative_num_steps = 3
+        args.speculative_eagle_topk = 1
+        args.speculative_num_draft_tokens = 4
+        args._model_config = SimpleNamespace(
+            hf_config=SimpleNamespace(
+                architectures=["LlamaForCausalLM"],
+                get_text_config=lambda: SimpleNamespace(),
+            )
+        )
+        for key, value in overrides.items():
+            setattr(args, key, value)
+
+        try:
+            handle_speculative_decoding(args)
+        except ValueError as error:
+            return str(error)
+        return None
+
+    def _assert_rejects_pp(self, algorithm, **overrides):
+        message = self._hook_error(algorithm, pp_size=2, **overrides)
+        self.assertIsNotNone(
+            message, f"{algorithm} accepted pp_size=2 at the hook layer"
+        )
+        self.assertIn("pp_size == 1", message)
+
+    def _assert_accepts_pp(self, algorithm, **overrides):
+        # Equivalence rather than "did not raise": with a stand-in model config
+        # the hook trips on a later, unrelated check either way, so the claim
+        # under test is that pp_size=2 gets the *same* outcome as pp_size=1.
+        self.assertEqual(
+            self._hook_error(algorithm, pp_size=2, **overrides),
+            self._hook_error(algorithm, pp_size=1, **overrides),
+        )
+
+    def test_dspark_accepts_pp_on_the_prefill_role(self):
+        self._assert_accepts_pp("DSPARK", disaggregation_mode="prefill")
+
+    def test_dspark_rejects_pp_on_the_decode_role(self):
+        self._assert_rejects_pp("DSPARK", disaggregation_mode="decode")
+
+    def test_dspark_rejects_pp_without_disaggregation(self):
+        self._assert_rejects_pp("DSPARK", disaggregation_mode="null")
+
+    def test_eagle_rejects_pp_even_on_the_prefill_role(self):
+        # The draft head shares the target's embed_tokens / lm_head, which a
+        # pipeline-split target does not hold on any single stage.
+        for mode in ("prefill", "decode", "null"):
+            with self.subTest(disaggregation_mode=mode):
+                self._assert_rejects_pp("EAGLE", disaggregation_mode=mode)
+
+    def test_ngram_rejects_pp_even_on_the_prefill_role(self):
+        # The pipeline relay of the draft tensors expects an EagleDraftInput.
+        for mode in ("prefill", "decode", "null"):
+            with self.subTest(disaggregation_mode=mode):
+                self._assert_rejects_pp("NGRAM", disaggregation_mode=mode)
+
+    def test_dflash_pp_rejection_is_untouched(self):
+        # Pre-existing guard; here so relaxing the policy layer cannot silently
+        # widen an algorithm that was never validated for pipeline parallelism.
+        self._assert_rejects_pp("DFLASH", disaggregation_mode="prefill")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/spec/test_draft_placement_pp.py
+++ b/test/registered/unit/spec/test_draft_placement_pp.py
@@ -1,0 +1,107 @@
+"""Where the draft worker lands when the PD-prefill role runs pipeline parallel.
+
+The draft head is a ``pp_size == 1`` runner that reads the target's
+``lm_head`` / ``embed_tokens``, and a pipeline-split target holds those on the
+last stage only. So on a PD-prefill role with ``pp_size > 1`` exactly one stage
+builds a draft worker and the rest run target-only.
+
+``maybe_init_draft_worker`` is the single decision point for that placement, and
+it reads only a handful of fields off the scheduler, so this drives it on a
+stand-in record (same pattern as ``test_draft_construction_isolation.py``'s
+``ModelRunner.__new__``) rather than standing up a real scheduler.
+"""
+
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from sglang.srt.managers.scheduler import Scheduler
+from sglang.srt.speculative.spec_info import SpeculativeAlgorithm
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class _StandInDraftWorker:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+
+
+class TestDraftPlacementUnderPipelineParallel(CustomTestCase):
+    def _decide(self, *, pp_size, pp_rank, disaggregation_mode, algorithm="DSPARK"):
+        """Run the placement decision; return the scheduler it decided for."""
+        scheduler = Scheduler.__new__(Scheduler)
+        scheduler.spec_algorithm = SpeculativeAlgorithm.from_string(algorithm)
+        scheduler.ps = SimpleNamespace(pp_size=pp_size, pp_rank=pp_rank, gpu_id=0)
+        scheduler.server_args = SimpleNamespace()
+        scheduler.nccl_port = 0
+        scheduler.tp_worker = object()
+        scheduler.ipc_channels = SimpleNamespace(
+            send_to_tokenizer=SimpleNamespace(send_output=None)
+        )
+
+        with patch.object(
+            SpeculativeAlgorithm, "create_worker", return_value=_StandInDraftWorker
+        ), patch(
+            "sglang.srt.managers.scheduler.get_disagg",
+            return_value=SimpleNamespace(disaggregation_mode=disaggregation_mode),
+        ):
+            scheduler.maybe_init_draft_worker()
+
+        return scheduler
+
+    def test_the_last_prefill_stage_hosts_the_draft(self):
+        scheduler = self._decide(pp_size=2, pp_rank=1, disaggregation_mode="prefill")
+        self.assertIsInstance(scheduler.draft_worker, _StandInDraftWorker)
+        # It drafts off this stage's own target, not a separately loaded one.
+        self.assertIs(
+            scheduler.draft_worker.kwargs["target_worker"], scheduler.tp_worker
+        )
+
+    def test_earlier_prefill_stages_run_target_only(self):
+        scheduler = self._decide(pp_size=2, pp_rank=0, disaggregation_mode="prefill")
+        self.assertIsNone(scheduler.draft_worker)
+        # The ngram corpus manager hangs off the draft worker, so it has to go
+        # too; leaving a stale one behind would be a null dereference later.
+        self.assertIsNone(scheduler.external_corpus_manager)
+
+    def test_only_the_last_of_four_prefill_stages_hosts_the_draft(self):
+        placement = [
+            self._decide(
+                pp_size=4, pp_rank=rank, disaggregation_mode="prefill"
+            ).draft_worker
+            is not None
+            for rank in range(4)
+        ]
+        self.assertEqual(placement, [False, False, False, True])
+
+    def test_a_single_stage_prefill_role_is_unaffected(self):
+        self.assertIsNotNone(
+            self._decide(
+                pp_size=1, pp_rank=0, disaggregation_mode="prefill"
+            ).draft_worker
+        )
+
+    def test_the_skip_is_scoped_to_the_prefill_role(self):
+        # The decode role and the non-disaggregated path still reject pp > 1 with
+        # speculative decoding at the arg layer; if that ever relaxes, this skip
+        # must not silently apply to them, because only prefill was validated.
+        for mode in ("decode", "null"):
+            with self.subTest(disaggregation_mode=mode):
+                self.assertIsNotNone(
+                    self._decide(
+                        pp_size=2, pp_rank=0, disaggregation_mode=mode
+                    ).draft_worker
+                )
+
+    def test_no_speculative_algorithm_still_short_circuits_first(self):
+        self.assertIsNone(
+            self._decide(
+                pp_size=2, pp_rank=1, disaggregation_mode="prefill", algorithm="NONE"
+            ).draft_worker
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Allow pipeline parallelism with speculative decoding on the PD-prefill role

## Motivation

`pp_size > 1` and `--speculative-algorithm` are mutually exclusive today, everywhere:

```python
# python/sglang/srt/arg_groups/validation_hook.py
if cfg.pp_size > 1:
    assert (
        cfg.disable_overlap_schedule and cfg.speculative_algorithm is None
    ), "Pipeline parallelism is not compatible with overlap schedule, speculative decoding"
```

That is stricter than it needs to be for **PD-disaggregated serving**, where the two roles have
genuinely different needs:

- the **prefill** role wants pipeline parallelism, because splitting a large target across stages
  raises aggregate prefill throughput on a fixed number of GPUs;
- the **decode** role wants speculative decoding, because that is where accept length converts
  into TPOT.

Under PD these are separate processes with separate topologies, so the prefill role can be
pipeline-parallel while the decode role stays `pp_size == 1`. But the current gate is global: the
moment `--speculative-algorithm` is set anywhere, the prefill role cannot use PP at all. Operators
running a large MoE target with a bundled draft head are forced to give up one or the other.

Note the prefill role still needs the draft weights loaded even though it does not run
verification: it produces the hidden states the decode role's draft consumes.

This PR relaxes the gate for the prefill role only, and adds the plumbing that makes it correct.

## What this PR does

Three commits, reviewable independently.

### 1. `fix: keep a stage-local draft off WORLD collectives`

A draft worker that exists on only some pipeline stages must not issue collectives over the WORLD
group: the ranks without a draft never reach the matching call, so the group deadlocks.

Two places did:

- `KVCacheConfigurator` profiled available bytes and reduced pool capacity over
  `get_world_group()`. For a draft runner under `pp_size > 1` the sync group is now the TP group,
  and the capacity `all_reduce` is target-only.
- `build_draft_tp_worker` let the draft join the seed broadcast. It now takes the target's
  already-broadcast `random_seed` from the caller, so the draft is seeded identically without a
  second collective.

The `kv_cache_configurator` half is a latent bug independent of this feature — it holds for any
draft runner whose rank set is narrower than WORLD.

3 files, +27/-5.

### 2. `Run the draft on the last PD-prefill pipeline stage only`

The draft head is a `pp_size == 1` runner that reads the target's `lm_head` / `embed_tokens`, and a
pipeline-split target holds those on the last stage only. So exactly one stage builds a draft
worker and the earlier stages run target-only.

- `maybe_init_draft_worker` returns early on a non-last prefill stage, leaving `draft_worker` and
  `external_corpus_manager` unset.
- The three downstream dispatches that keyed off `spec_algorithm` alone now also test
  `draft_worker is not None`: the model worker is the target on a target-only stage, the
  synchronous V2 draft drive is skipped there, and the pipeline proxy tensors are passed exactly as
  on the non-spec path.
- `DSparkWorkerV2.forward_batch_generation` threads `pp_proxy_tensors` down to the target's prefill
  forward; the draft never takes them.
- `_assert_pp_mtp_compat` exempts the prefill role, whose target stages do not need the MTP layer
  themselves.

No behavior change at this commit: the arg-level gate still rejects `pp_size > 1` with speculative
decoding everywhere. Verified — probing `ServerArgs` at this commit still raises from the
pre-existing assertion.

4 files, +52/-7.

### 3. `Allow pipeline parallelism with speculative decoding on the PD-prefill role`

Two layers of gate, because "which pp topologies are legal" and "which draft paths survive one"
are different questions.

The model-agnostic policy in `check_server_args` splits its single assertion in two: `pp_size > 1`
still requires `disable_overlap_schedule`, and with a speculative algorithm it now additionally
requires `disaggregation_mode == "prefill"` rather than rejecting outright.

Each algorithm then narrows that to what its own draft can do:

- **DSpark** takes the exception. Its draft input carries no `topk_p` / hidden states — the target
  hidden is injected into the draft KV instead — so the pipeline relay has nothing eagle-shaped to
  rebuild and the relay path is simply a pass-through.
- **The eagle family** still requires `pp_size == 1`: `init_lm_head` pulls the target's
  `get_embed_and_head()`, and a pipeline-split target holds `embed_tokens` on the first stage only
  (`PPMissingLayer` elsewhere), so the last stage — the one hosting the draft — raises
  `AttributeError` mid-init.
- **Ngram** still requires `pp_size == 1`: the pipeline draft-tensor relay reads `topk_p` and
  `accept_tokens`, which `NgramVerifyInput` does not provide.

Both rejections are explicit `ValueError`s in the per-algorithm hooks rather than a crash during
init.

Plus the CPU tests described below. 4 files, +368/-4.

## Validation

All hardware numbers are from H20 (8 × 96 GB per node), `DeepSeek-V4-Flash-DSpark`, mooncake
transfer backend, `sglang_router.launch_router --pd-disaggregation --mini-lb`:

- prefill: `tp4 × pp2` on node A, `--disable-overlap-schedule`, `--speculative-algorithm DSPARK`
- decode: `tp8 × pp1` on node B

### Draft placement is what the design intends

From the prefill log, on the 8 prefill ranks (`PP{0,1} × TP{0..3}`):

```
[PP1 TP0] Initialized DSpark draft runner. attention_backend=dsv4,
          model=DeepseekV4ForCausalLMDSpark, gamma=5, verify_num_draft_tokens=6, ...
```

- `Initialized DSpark draft runner` appears **once**, on `PP1 TP0`
- `Overriding draft attention backend to dsv4` appears **4 times**, on `PP1 TP0-3` only
- memory follows: GPU 0-3 (stage 0) 78.4-78.9 GB vs GPU 4-7 (stage 1) 87.5-88.0 GB, a ~9 GB delta
  that is the draft
- `Scheduler hit an exception` = 0

### Correctness

gsm8k, 200 questions, 5-shot, temperature 0:

- this PR, prefill `tp4 × pp2` + DSpark: **Accuracy 0.970, Invalid 0.000**
- same tree, prefill `tp8 × pp1` control: Accuracy 0.960, Invalid 0.000
- non-PD `tp8` reference for this checkpoint: Accuracy 0.965

All three within the ±2% band; PP does not move accuracy.

### Under load

`sglang.benchmark.serving --dataset-name random-ids --random-range-ratio 1.0`, 500 requests each:

**A — concurrency 32, 1k in / 1k out**

- accept length 4.80, duration 218.02 s
- output throughput 2348.41 tok/s
- mean TPOT 7.26 ms, median 6.91 ms
- mean TTFT 6281.84 ms

**B — concurrency 2, 64k in / 1k out** (exercises chunked prefill across both stages: 8 × 8192)

- accept length 5.07, duration 3631.03 s
- input throughput 9024.44 tok/s, output 141.01 tok/s
- mean TPOT 1.96 ms, median 1.83 ms

B matters most: a 64k prompt is chunked across both pipeline stages, and accept length does not
degrade (server-side per-step accept: p50 6.00 of max 6, mean 5.36 over 2365 samples). The relay of
draft state across stage boundaries is not losing information.

### Speculative decoding is actually paying off through this path

Matched pair, 100 requests, concurrency 32, 1k in / 1k out, **only `--speculative-algorithm`
toggled**, same prefill `tp4 × pp2` topology, same decode instance:

| | with DSpark | without | delta |
|---|---|---|---|
| mean TPOT | 7.30 ms | 14.85 ms | **−51%** |
| median TPOT | 6.97 ms | 15.93 ms | −56% |
| output throughput | 2493.85 tok/s | 1213.52 tok/s | **+105%** |
| wall clock | 41.06 s | 84.38 s | −51% |
| accept length | 5.03 | n/a | |

Spec-off was verified from the logs on both roles, not assumed: `speculative_algorithm: None`,
zero draft-runner inits, zero `accept len` lines.

### CI tests (CPU, `base-a-test-cpu`)

- `test/registered/unit/server_args/test_server_args_pp_speculative.py` — 14 cases. The policy
  matrix (pp × algorithm × role × overlap schedule) and the per-algorithm narrowing. The two layers
  need different drivers: `model_path="dummy"` short-circuits `run_resolution_pipeline` before
  `handle_speculative_decoding`, so a dummy record reaches `check_server_args` but never reaches
  the hooks; the second class calls `handle_speculative_decoding` directly, the way
  `unit/spec/test_spec_cpu_overlap_constraint.py` does.

  DSpark's "accepted" assertion is `pp_size=2` outcome **equals** `pp_size=1` outcome rather than
  "did not raise" — with a stand-in model config both sides trip on a later unrelated dspark check,
  so the claim worth pinning is that pp makes no difference.

- `test/registered/unit/spec/test_draft_placement_pp.py` — 6 cases. `maybe_init_draft_worker` puts
  the draft on the last prefill stage and nowhere else (`pp_size=4` yields
  `[False, False, False, True]`), clears `external_corpus_manager` alongside it, and the skip does
  not leak to the decode or non-disaggregated paths.

Neighbour regressions green: `unit/spec/test_spec_cpu_overlap_constraint` +
`unit/spec/test_spec_registry` (32), `unit/server_args/test_server_args` (185).
`black --check` and `isort --check-only` clean.

## Limitations

1. **Prefill role only.** The decode role and the non-disaggregated path still reject
   `pp_size > 1` with speculative decoding. Nothing here was designed or tested for a
   pipeline-parallel verify step.
2. **DSpark only, among current algorithms.** The eagle family and ngram are explicitly rejected
   for the reasons above. This is not an oversight — the pipeline draft-tensor relay assumes an
   `EagleDraftInput`-shaped draft input, so the relaxation is not algorithm-agnostic.
3. **Unblocking the eagle family needs an `init_lm_head` fix**, so the draft can obtain
   `embed_tokens` / `lm_head` from the stage that holds them instead of from its own stage. Not
   attempted here.
4. **Unblocking ngram needs the relay generalized**, past at least two distinct failure points
   (`draft_input.topk_p`, then `payload.accept_tokens`). A `getattr` workaround for the first was
   tried and reverted: it only replaced a loud `AttributeError` with a later, more confusing one.
5. **`--disable-overlap-schedule` is still required** with `pp_size > 1`, unchanged from before.
6. **One dispatch has no CI coverage.** The `model_worker = tp_worker` selection on a target-only
   stage is exercised only by the hardware runs above; there is no CI-available
   model × algorithm combination that can run prefill PP with speculative decoding end to end.
7. **No e2e CI test accompanies this PR** for the same reason. The CPU tests pin the placement
   decision and the gate matrix, not a full forward pass.
8. **Single checkpoint, single topology.** Validated at `tp4 × pp2` on one DSpark checkpoint. Other
   stage counts are covered only by the unit test's placement vector, not by a real run.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33328107475](https://github.com/sgl-project/sglang/actions/runs/33328107475)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33328107351](https://github.com/sgl-project/sglang/actions/runs/33328107351)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33328107469](https://github.com/sgl-project/sglang/actions/runs/33328107469)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->