### PR TITLE
[Fix] Share the MTP draft's embed/lm_head before the KV pool is profiled

### DIFF
--- a/python/sglang/srt/managers/scheduler.py
+++ b/python/sglang/srt/managers/scheduler.py
@@ -1008,6 +1008,11 @@ class Scheduler(
 
     def init_memory_pools(self):
         """Allocate KV cache pools for target and draft workers."""
+        if self.draft_worker is not None:
+            # Before the target pool is sized: the draft's duplicate,
+            # vocab-sized embed/lm_head are released here, so the profiler
+            # counts those bytes as free and gives them to the KV cache.
+            self.draft_worker.share_target_embed_and_head()
         self.init_target_memory_pool()
         # Lands the retraction backend on the disagg bag before the draft
         # worker's HiCache plan reads it.

--- a/python/sglang/srt/speculative/base_spec_worker.py
+++ b/python/sglang/srt/speculative/base_spec_worker.py
@@ -58,6 +58,7 @@ class EagleDraftWorkerBase(ABC):
     # topk=1 chain constants for draft_forward's fast path; None when topk > 1.
     _topk1_parents_prealloc: Optional[torch.Tensor] = None
     _topk1_score_indices_prealloc: Optional[torch.Tensor] = None
+    _embed_and_head_shared: bool = False
 
     def __init__(self) -> None:
         self._specialized_graph_memory_usage: dict[str, float] = {}
@@ -101,6 +102,23 @@ class EagleDraftWorkerBase(ABC):
 
     def alloc_memory_pool(self, **kwargs):
         pass
+
+    def share_target_embed_and_head(self) -> None:
+        """Bind the target's embedding/lm_head into the draft model(s).
+
+        MTP-style drafts build their own vocab-sized embed + lm_head while
+        loading and hand both back here (2 * vocab * hidden / tp bytes -- 2.4
+        GiB for a 248k vocab at tp=2). The scheduler calls this before the
+        target KV pool is sized so those bytes reach the KV cache instead of
+        being stranded; alloc_memory_pool() calls it again and hits the guard.
+        """
+        if self._embed_and_head_shared:
+            return
+        self._embed_and_head_shared = True
+        init_token_map = getattr(self, "init_token_map", None)
+        if init_token_map is not None:
+            init_token_map()
+        self.init_lm_head()
 
     def init_attention_backends(self):
         """Subclasses wrap this with their context managers (draft_tp_context,
@@ -186,6 +204,14 @@ class BaseSpecWorker(ABC):
         # dflash / dspark drive the draft model through a plain TpModelWorker;
         # ngram has no draft worker at all (returns None via its override).
         return self._draft_worker
+
+    def share_target_embed_and_head(self) -> None:
+        """Hand the target's embedding/lm_head to the draft worker, if it wants
+        them. No-op for algorithms whose draft owns its own vocab layers (or has
+        no draft worker at all)."""
+        share = getattr(self.draft_worker, "share_target_embed_and_head", None)
+        if share is not None:
+            share()
 
     @property
     def graph_memory_usage(self) -> dict[str, float]:

--- a/python/sglang/srt/speculative/eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/eagle_worker_v2.py
@@ -209,8 +209,7 @@ class EagleDraftWorker(EagleDraftWorkerBase):
             req_to_token_pool=req_to_token_pool,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
-        self.init_token_map()
-        self.init_lm_head()
+        self.share_target_embed_and_head()
 
         if get_spec().speculative_use_rejection_sampling:
             target_vocab_size = self.target_worker.model_config.vocab_size

--- a/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
+++ b/python/sglang/srt/speculative/multi_layer_eagle_worker_v2.py
@@ -209,7 +209,7 @@ class MultiLayerEagleDraftWorker(EagleDraftWorkerBase):
             req_to_token_pool=req_to_token_pool,
             token_to_kv_pool_allocator=token_to_kv_pool_allocator,
         )
-        self.init_lm_head()
+        self.share_target_embed_and_head()
         self._init_boundary_kv_fix_state()
 
     def init_attention_backends(self):


### PR DESCRIPTION
## Motivation

On MTP-style speculative decoding the draft model builds its **own** vocab-sized
`embed_tokens` + `ParallelLMHead` while loading, and gives both back to the target's
tensors in `EagleDraftWorker.init_lm_head()` → `set_embed_and_head()`. That release
currently happens **inside** `alloc_memory_pool()`, i.e. **after**
`Scheduler.init_target_memory_pool()` has already profiled free memory and sized the
KV cache. The freed bytes are therefore never offered to the KV cache — they stay
unused for the lifetime of the process.

The cost is `2 * vocab_size * hidden_size * dtype / tp` per rank, so it grows with the
vocabulary. On `Qwen3.8-27B-NVFP4` (vocab 248320, hidden 5120, tp=2) that is **2.4 GiB
per GPU**. The server log shows it directly — memory appears out of nowhere right after
the pool has been carved up:

```
Memory pool end.                          avail mem=0.29 GB
Capture target verify CUDA graph begin.   avail mem=2.12 GB   <- 1.83 GB arrived too late
...
max_total_num_tokens=13303, context_len=8192, available_gpu_mem=1.82 GB
```

On a 2x16 GB box this is the difference between an 8k and a 128k context: the same model
served by vLLM with `--speculative-config '{"method": "mtp", ...}'` reaches
`--max-model-len 131072`, because vLLM binds the shared vocab layers at construction time.

## Modifications

Move the share to just before the target pool is profiled, and make the existing call
site idempotent:

- `EagleDraftWorkerBase.share_target_embed_and_head()` — new, guarded by
  `_embed_and_head_shared`; runs `init_token_map()` (when the subclass has one) and
  `init_lm_head()`.
- `BaseSpecWorker.share_target_embed_and_head()` — delegates to the draft worker when it
  implements the hook. No-op for NGRAM (no draft worker) and for DFlash/DSpark, whose
  draft is a plain `TpModelWorker`.
- `Scheduler.init_memory_pools()` — calls the hook before `init_target_memory_pool()`.
- `EagleDraftWorker.alloc_memory_pool()` / `MultiLayerEagleDraftWorker.alloc_memory_pool()`
  — call the hook instead of `init_lm_head()` directly; the guard makes it a no-op.

No change for drafts that keep their own vocab layers: `StandaloneDraftWorker.init_lm_head()`
is already a no-op override, and `FrozenKVMTPDraftWorker` binds in `__init__`, before
profiling, which is exactly the ordering this PR generalises.

## Accuracy Tests

Not applicable — no change to any forward path or to which tensors the draft ends up
using, only to *when* the duplicates are released. Output of the shared server before
and after is produced by the same weights; `spec_accept_length` was 2.9–3.0 in both.

## Speed Tests and Profiling

Measured on 2x RTX 5070 Ti (16 GB, tp=2, no NVLink), `unsloth/Qwen3.8-27B-NVFP4`,
`--speculative-algorithm EAGLE --speculative-num-steps 3 --speculative-eagle-topk 1
--speculative-num-draft-tokens 4 --kv-cache-dtype fp8_e4m3`:

| | before | after |
|---|---|---|
| `max_total_num_tokens` | 13303 | **136047** |
| largest usable `--context-length` | 8192 | **131072** |
| stranded VRAM per GPU | 1.82 GB | 0.21 GB |

A 115573-token prompt is served in 61 s after the change; before it is rejected because
the pool cannot hold it. Decode throughput at short context is unchanged (~93 tok/s).

Regression-checked on the same box that the hook stays a no-op where it should:
`--speculative-algorithm NGRAM` still starts normally (`max_total_num_tokens=106396`).

**Note on provenance:** the numbers above were produced with the identical change applied
to the v0.5.17 release running on that hardware; the diff here is the same design ported
to `main`, where the affected code is unchanged.

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [x] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [x] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TsVjhGJomr7tEt5LHegz1f

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33329331493](https://github.com/sgl-project/sglang/actions/runs/33329331493)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33329331376](https://github.com/sgl-project/sglang/actions/runs/33329331376)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33329331490](https://github.com/sgl-project/sglang/actions/runs/33329331490)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->