### PR TITLE
Enforce parallel_tool_calls=false at parse time for unconstrained tool emissions

### DIFF
--- a/python/sglang/srt/entrypoints/openai/serving_chat.py
+++ b/python/sglang/srt/entrypoints/openai/serving_chat.py
@@ -1935,6 +1935,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     finish_reason,
                     request.tool_choice,
                     history_tool_calls_cnt,
+                    parallel_tool_calls=request.parallel_tool_calls,
                 )
 
             # Extract prompt_token_ids if requested
@@ -2090,6 +2091,7 @@ class OpenAIServingChat(OpenAIServingBase):
         finish_reason: Dict[str, Any],
         tool_choice: Optional[Union[str, ToolChoice]] = None,
         history_tool_calls_cnt: int = 0,
+        parallel_tool_calls: bool = True,
     ) -> ToolCallProcessingResult:
         """Process tool calls in the response"""
 
@@ -2100,7 +2102,10 @@ class OpenAIServingChat(OpenAIServingBase):
         # as constraint (mirrors the streaming path). For auto: always try.
         if self.tool_call_parser:
             parser = FunctionCallParser(
-                tools, self.tool_call_parser, tokenizer=self.tokenizer_manager.tokenizer
+                tools,
+                self.tool_call_parser,
+                tokenizer=self.tokenizer_manager.tokenizer,
+                parallel_tool_calls=parallel_tool_calls,
             )
             detector_owns_format = (
                 parser.detector.supports_structural_tag()
@@ -2538,6 +2543,7 @@ class OpenAIServingChat(OpenAIServingBase):
                         tools=effective_tools,
                         tool_call_parser=self.tool_call_parser,
                         tokenizer=self.tokenizer_manager.tokenizer,
+                        parallel_tool_calls=request.parallel_tool_calls,
                     )
                     use_native_parser = (
                         probe.detector.supports_structural_tag()
@@ -2552,6 +2558,7 @@ class OpenAIServingChat(OpenAIServingBase):
                     tools=effective_tools,
                     tool_call_parser=self.tool_call_parser,
                     tokenizer=self.tokenizer_manager.tokenizer,
+                    parallel_tool_calls=request.parallel_tool_calls,
                 )
 
         parser = parser_dict[index]

--- a/python/sglang/srt/function_call/function_call_parser.py
+++ b/python/sglang/srt/function_call/function_call_parser.py
@@ -104,7 +104,22 @@ class FunctionCallParser:
         "inkling": InklingDetector,
     }
 
-    def __init__(self, tools: List[Tool], tool_call_parser: str, tokenizer=None):
+    def __init__(
+        self,
+        tools: List[Tool],
+        tool_call_parser: str,
+        tokenizer=None,
+        parallel_tool_calls: bool = True,
+    ):
+        # parallel_tool_calls=False (OpenAI semantics: at most one tool call
+        # per assistant turn) is honored by grammar constraints only in the
+        # required/strict-auto modes; plain-auto emissions were previously
+        # unconstrained AND unenforced, so clients that set the flag could
+        # still receive several calls. Enforce it at parse time: non-stream
+        # keeps the first call; streaming locks onto the first tool_index
+        # and drops items for later ones.
+        self.parallel_tool_calls = parallel_tool_calls
+        self._single_call_locked_index: Optional[int] = None
         detector_class = self.ToolCallParserEnum.get(tool_call_parser)
         if detector_class:
             kwargs = {}
@@ -135,6 +150,18 @@ class FunctionCallParser:
             return False
         return self.detector.has_tool_call(text)
 
+    def _enforce_single_call(
+        self, calls: list[ToolCallItem]
+    ) -> list[ToolCallItem]:
+        """With parallel_tool_calls=False, pass through only the first tool
+        call's streaming items (a call spans several chunks sharing one
+        tool_index) and drop items belonging to any later call."""
+        if self.parallel_tool_calls or not calls:
+            return calls
+        if self._single_call_locked_index is None:
+            self._single_call_locked_index = calls[0].tool_index
+        return [c for c in calls if c.tool_index == self._single_call_locked_index]
+
     def parse_non_stream(self, full_text: str) -> Tuple[str, list[ToolCallItem]]:
         """
         One-time parsing of the full text to extract tool calls.
@@ -152,6 +179,8 @@ class FunctionCallParser:
         has_tool_call = self.detector.has_tool_call(full_text)
         parsed_result = self.detector.detect_and_parse(full_text, self.tools)
         tool_call_list = parsed_result.calls
+        if not self.parallel_tool_calls and len(tool_call_list) > 1:
+            tool_call_list = tool_call_list[:1]
         if tool_call_list or has_tool_call:
             return parsed_result.normal_text, tool_call_list
         else:
@@ -181,7 +210,7 @@ class FunctionCallParser:
             final_calls.extend(sp_result.calls)
             final_normal_text = sp_result.normal_text
 
-        return final_normal_text, final_calls
+        return final_normal_text, self._enforce_single_call(final_calls)
 
     def parse_stream_end(self) -> Tuple[str, list[ToolCallItem]]:
         """Flush detector state once the stream ends.
@@ -192,7 +221,7 @@ class FunctionCallParser:
         if not self.tools:
             return "", []
         sp_result = self.detector.finish(self.tools)
-        return sp_result.normal_text, sp_result.calls
+        return sp_result.normal_text, self._enforce_single_call(sp_result.calls)
 
     def get_legacy_structural_tag(
         self, at_least_one: bool = False

--- a/test/registered/unit/function_call/test_function_call_parser.py
+++ b/test/registered/unit/function_call/test_function_call_parser.py
@@ -5830,3 +5830,62 @@ class TestTopLevelCompositeToolSchema(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestParallelToolCallsFalse(unittest.TestCase):
+    """parallel_tool_calls=False must yield at most one tool call even for
+    plain-auto emissions that no grammar constraint covered."""
+
+    def setUp(self):
+        self.tools = [
+            Tool(
+                type="function",
+                function=Function(
+                    name="get_weather",
+                    description="Get weather",
+                    parameters={
+                        "type": "object",
+                        "properties": {"city": {"type": "string"}},
+                        "required": ["city"],
+                    },
+                ),
+            )
+        ]
+        # pythonic detector: multi-call text is trivially constructable
+        self.multi_call_text = '[get_weather(city="Boston"), get_weather(city="Tokyo")]'
+
+    def test_non_stream_truncates_to_first_call(self):
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
+        parser = FunctionCallParser(
+            self.tools, "pythonic", parallel_tool_calls=False
+        )
+        _, calls = parser.parse_non_stream(self.multi_call_text)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("Boston", calls[0].parameters)
+
+    def test_non_stream_default_keeps_all_calls(self):
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
+        parser = FunctionCallParser(self.tools, "pythonic")
+        _, calls = parser.parse_non_stream(self.multi_call_text)
+        self.assertEqual(len(calls), 2)
+
+    def test_stream_locks_first_tool_index(self):
+        from sglang.srt.function_call.core_types import ToolCallItem
+        from sglang.srt.function_call.function_call_parser import FunctionCallParser
+
+        parser = FunctionCallParser(
+            self.tools, "pythonic", parallel_tool_calls=False
+        )
+        first = parser._enforce_single_call(
+            [ToolCallItem(tool_index=0, name="get_weather", parameters="{")]
+        )
+        self.assertEqual(len(first), 1)
+        mixed = parser._enforce_single_call(
+            [
+                ToolCallItem(tool_index=0, name=None, parameters='"city": "B"}'),
+                ToolCallItem(tool_index=1, name="get_weather", parameters="{}"),
+            ]
+        )
+        self.assertEqual([c.tool_index for c in mixed], [0])


### PR DESCRIPTION
## Motivation

`parallel_tool_calls: false` (OpenAI semantics: at most one tool call per assistant turn) is currently honored only where a grammar constraint applies (`tool_choice=required` / strict-auto). For plain-auto emissions with non-strict tools there is no constraint, and the flag is also not enforced at parse time — so a client that sets `parallel_tool_calls: false` can still receive several tool calls in one response. Reproduced on recent nightlies with DeepSeek-V4-class checkpoints (`tool_choice=auto`, two-city weather prompt → two `tool_calls` despite the flag).

## Modifications

- `FunctionCallParser` gains `parallel_tool_calls: bool = True`; when false, `parse_non_stream` keeps only the first parsed call, and the streaming paths lock onto the first `tool_index` and drop items belonging to later calls (a call spans several chunks sharing one index, so index-locking preserves the first call's argument fragments).
- `serving_chat.py` plumbs `request.parallel_tool_calls` into the four `FunctionCallParser` construction sites.
- Default behavior (`true`) unchanged.

## Checklist

- [x] Unit tests added (`TestParallelToolCallsFalse`: non-stream truncation, default pass-through, streaming index-locking)

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33330890387](https://github.com/sgl-project/sglang/actions/runs/33330890387)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33330890301](https://github.com/sgl-project/sglang/actions/runs/33330890301)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33330890510](https://github.com/sgl-project/sglang/actions/runs/33330890510)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->