### PR TITLE
feat: resolve oci:// model paths via llmman serve

### DIFF
--- a/python/sglang/srt/arg_groups/model_path_hook.py
+++ b/python/sglang/srt/arg_groups/model_path_hook.py
@@ -17,6 +17,7 @@ from sglang.srt.arg_groups.overrides import (
 )
 from sglang.srt.utils.common import is_remote_url
 from sglang.srt.utils.hf_transformers_utils import check_gguf_file
+from sglang.srt.utils.oci_utils import is_oci_uri, resolve_oci_model
 from sglang.srt.utils.runai_utils import ObjectStorageModel, is_runai_obj_uri
 
 logger = logging.getLogger(__name__)
@@ -25,6 +26,7 @@ logger = logging.getLogger(__name__)
 def handle_model_source_paths(server_args: Any):
     """Prepare metadata for model paths backed by remote object stores."""
     cfg = resolving_view(server_args)
+    resolve_oci_model_paths(server_args)
     resolve_hf_gguf_model_path(server_args)
 
     seen_paths = set()
@@ -40,6 +42,30 @@ def handle_model_source_paths(server_args: Any):
         ):
             ObjectStorageModel.download_and_get_path(model_path)
             seen_paths.add(model_path)
+
+
+def resolve_oci_model_paths(server_args: Any):
+    """Turn an `oci://` CNCF ModelPack reference into a local path.
+
+    Runs before every other resolver so the rest of the pipeline, GGUF
+    detection included, only ever sees a local path. One pull per distinct
+    reference: a tokenizer or draft model naming the same image reuses it.
+    """
+    cfg = resolving_view(server_args)
+
+    resolved: dict[str, str] = {}
+    for field in ("model_path", "tokenizer_path", "speculative_draft_model_path"):
+        reference = getattr(cfg, field, None)
+        if not is_oci_uri(reference):
+            continue
+        if reference not in resolved:
+            resolved[reference] = resolve_oci_model(reference)
+        logger.info("Resolved OCI %s %s -> %s", field, reference, resolved[reference])
+        declare_resolution(
+            server_args,
+            "_resolve_oci_model_paths",
+            **{field: resolved[reference]},
+        )
 
 
 def resolve_hf_gguf_model_path(server_args: Any):

--- a/python/sglang/srt/environ.py
+++ b/python/sglang/srt/environ.py
@@ -289,6 +289,9 @@ class Envs:
     # Model configuration, discovery, and weight loading
     # ===================================================================
     SGLANG_USE_MODELSCOPE = EnvBool(False)
+    # Binary used to resolve `oci://` model references (CNCF ModelPack images).
+    # Looked up on PATH when left as the bare name.
+    SGLANG_LLMMAN_BIN = EnvStr("llmman")
     # Controls weight-file ordering for load-time I/O optimization.
     #   -1 : no sorting, no staggering; preserves original file order.
     #    0 : sort files only; maximizes ordering but may reduce cross-rank I/O concurrency.

--- a/python/sglang/srt/utils/llmman.py
+++ b/python/sglang/srt/utils/llmman.py
@@ -1,0 +1,235 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Client for a running ``llmman serve`` daemon.
+
+Used to acquire models published as CNCF ModelPack
+(https://github.com/modelpack/model-spec) OCI artifacts. The daemon owns the
+registry work -- ModelPack media types, registry auth, resumable blob download
+and a content-addressed store -- so it is not reimplemented here.
+
+Contract (from llmman's src/cmd/serve.rs and src/daemon.rs):
+  - LLMMAN_HOST is ``[scheme://]host[:port][/path]``, default 127.0.0.1:17434.
+    A wildcard bind host (0.0.0.0, ::) is rewritten to loopback, since a client
+    cannot connect to "every interface".
+  - ``GET /api/version`` -> ``{"version":..., "exe":..., "pid":...}``.
+  - ``POST /api/pull`` ``{"model": ref}`` -> NDJSON stream of ``{"status":...}``
+    objects, terminated by ``{"status":"success"}`` or ``{"error":"..."}``.
+    An error can arrive in-band at HTTP 200.
+  - ``llmman resolve --no-pull <ref>`` -> one line of JSON carrying ``path``.
+"""
+
+import ipaddress
+import json
+import logging
+import os
+import shutil
+import subprocess
+import urllib.error
+import urllib.request
+
+logger = logging.getLogger(__name__)
+
+HOST_ENV = "LLMMAN_HOST"
+BIN_ENV = "SGLANG_LLMMAN_BIN"
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 17434
+
+PROBE_TIMEOUT_SECONDS = 5
+
+
+def _connectable_host(host: str) -> str:
+    """Rewrite a wildcard bind host to its loopback equivalent."""
+    try:
+        ip = ipaddress.ip_address(host.strip("[]"))
+    except ValueError:
+        return host
+    if not ip.is_unspecified:
+        return host
+    return "127.0.0.1" if ip.version == 4 else "::1"
+
+
+def endpoint() -> str:
+    """The http origin of the llmman daemon, honouring LLMMAN_HOST."""
+    raw = os.getenv(HOST_ENV, "").strip().strip("\"'")
+    if not raw:
+        return f"http://{DEFAULT_HOST}:{DEFAULT_PORT}"
+
+    if "://" in raw:
+        raw = raw.split("://", 1)[1]
+    raw = raw.split("/", 1)[0]
+
+    host, port = raw, DEFAULT_PORT
+    if raw.startswith("["):  # bracketed IPv6, optionally with :port
+        close = raw.find("]")
+        if close != -1:
+            host = raw[: close + 1]
+            rest = raw[close + 1 :]
+            if rest.startswith(":") and rest[1:].isdigit():
+                port = int(rest[1:])
+    elif raw.count(":") == 1:
+        maybe_host, maybe_port = raw.rsplit(":", 1)
+        if maybe_port.isdigit():
+            host, port = maybe_host, int(maybe_port)
+
+    host = host or DEFAULT_HOST
+    resolved = _connectable_host(host)
+    if ":" in resolved and not resolved.startswith("["):
+        resolved = f"[{resolved}]"
+    return f"http://{resolved}:{port}"
+
+
+def llmman_bin() -> str:
+    """The llmman executable name, overridable per project."""
+    return os.getenv(BIN_ENV, "").strip() or "llmman"
+
+
+def check_daemon(base: str) -> None:
+    """Confirm an llmman daemon is listening and is actually llmman."""
+    url = base + "/api/version"
+    try:
+        with urllib.request.urlopen(url, timeout=PROBE_TIMEOUT_SECONDS) as resp:
+            if resp.status != 200:
+                raise RuntimeError(
+                    f"llmman daemon at {base} answered /api/version with HTTP {resp.status}"
+                )
+            payload = json.loads(resp.read().decode("utf-8"))
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"no llmman daemon reachable at {base} ({exc.reason}). Start one with "
+            f"`llmman serve`, or point {HOST_ENV} at an existing daemon."
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (unparseable /api/version)"
+        ) from exc
+
+    if not isinstance(payload, dict) or not payload.get("version"):
+        raise RuntimeError(
+            f"the server at {base} is not an llmman daemon (no version in /api/version)"
+        )
+
+
+def pull(base: str, reference: str, progress=None) -> None:
+    """Stream POST /api/pull until the daemon reports success.
+
+    ``progress`` receives ``(status, completed, total)``. An error can arrive
+    in-band at HTTP 200, and a stream that ends without ``success`` is also a
+    failure -- neither is treated as a completed pull.
+    """
+    body = json.dumps({"model": reference}).encode("utf-8")
+    req = urllib.request.Request(
+        base + "/api/pull",
+        data=body,
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+
+    succeeded = False
+    try:
+        with urllib.request.urlopen(req) as resp:
+            if resp.status != 200:
+                raise RuntimeError(
+                    f"llmman pull of {reference!r} failed: HTTP {resp.status}"
+                )
+            for raw_line in resp:
+                line = raw_line.decode("utf-8").strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    # Tolerate a non-JSON diagnostic rather than aborting a
+                    # pull that may still be progressing.
+                    continue
+                if not isinstance(obj, dict):
+                    continue
+                if obj.get("error"):
+                    raise RuntimeError(
+                        f"llmman pull of {reference!r} failed: {obj['error']}"
+                    )
+                status = obj.get("status")
+                if status == "success":
+                    succeeded = True
+                    continue
+                if progress is not None and status:
+                    progress(status, obj.get("completed", 0), obj.get("total", 0))
+    except urllib.error.HTTPError as exc:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} failed: HTTP {exc.code}"
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} failed: {exc.reason}"
+        ) from exc
+
+    if not succeeded:
+        raise RuntimeError(
+            f"llmman pull of {reference!r} ended without reporting success"
+        )
+
+
+def parse_resolve_output(stdout: str, reference: str) -> str:
+    """Parse ``llmman resolve`` stdout into the resolved local path."""
+    lines = [line.strip() for line in stdout.splitlines() if line.strip()]
+    if not lines:
+        raise RuntimeError(f"llmman resolve {reference!r}: no output on stdout")
+
+    try:
+        payload = json.loads(lines[-1])
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: could not parse output as JSON: {lines[-1]}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: expected a JSON object, got {lines[-1]}"
+        )
+
+    path = payload.get("path")
+    if not isinstance(path, str) or not path.strip():
+        raise RuntimeError(f"llmman resolve {reference!r}: returned an empty path")
+    if not os.path.exists(path):
+        raise RuntimeError(
+            f"llmman resolve {reference!r}: reported path {path!r} does not exist"
+        )
+    return path
+
+
+def resolve(reference: str) -> str:
+    """Ask the CLI where the daemon's pull left the model on disk.
+
+    ``--no-pull`` guarantees this only reports on bytes ``/api/pull`` already
+    fetched, so the daemon stays the only thing that touches the network.
+    """
+    binary = llmman_bin()
+    if shutil.which(binary) is None and not os.path.isfile(binary):
+        raise RuntimeError(
+            f"{binary!r} not found. Install llmman "
+            "(https://github.com/llmmanorg/llmman) and put it on PATH, or set "
+            f"{BIN_ENV} to its location."
+        )
+
+    completed = subprocess.run(
+        [binary, "resolve", "--no-pull", reference],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        stdin=subprocess.DEVNULL,
+        text=True,
+        check=False,
+    )
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"`{binary} resolve --no-pull {reference}` failed with exit code "
+            f"{completed.returncode}: {completed.stderr.strip()}"
+        )
+    return parse_resolve_output(completed.stdout, reference)
+
+
+def pull_and_resolve(reference: str, progress=None) -> str:
+    """Full acquisition: probe the daemon, pull through it, report the path."""
+    base = endpoint()
+    check_daemon(base)
+    logger.info("Pulling %s via llmman daemon at %s", reference, base)
+    pull(base, reference, progress)
+    return resolve(reference)

--- a/python/sglang/srt/utils/oci_utils.py
+++ b/python/sglang/srt/utils/oci_utils.py
@@ -1,0 +1,65 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Resolve `oci://` model references to a local path.
+
+Models published as CNCF ModelPack (https://github.com/modelpack/model-spec)
+OCI artifacts live in ordinary container registries, so they reuse the registry,
+credentials, mirroring and air-gap tooling a deployment already has for
+container images.
+
+Acquisition is delegated to a running `llmman serve`
+(https://github.com/llmmanorg/llmman), which already implements the ModelPack
+media types, registry auth, resumable blob download and a content-addressed
+store. The daemon does the pull (POST /api/pull, streamed so a multi-gigabyte
+fetch is not silent) but deliberately exposes no local path, so
+`llmman resolve --no-pull` reports where the bytes landed. That directory is
+handed to the ordinary HuggingFace loading path.
+
+An explicit `oci://` scheme is required rather than sniffing a bare
+`registry/name:tag`: that shape is indistinguishable from a HuggingFace repo id
+(`org/model`), so guessing would silently hijack existing `--model-path
+org/model` deployments.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from sglang.srt.utils import llmman
+
+logger = logging.getLogger(__name__)
+
+SUPPORTED_SCHEMES = ["oci://"]
+
+
+def is_oci_uri(model_or_path: str | Path | None) -> bool:
+    """True if the reference carries the `oci://` scheme.
+
+    Cast to str to handle pathlib.Path inputs, mirroring is_runai_obj_uri.
+    """
+    if model_or_path is None:
+        return False
+    return str(model_or_path).lower().startswith(tuple(SUPPORTED_SCHEMES))
+
+
+def strip_oci_scheme(reference: str | Path) -> str:
+    """Drop the `oci://` prefix, leaving the reference llmman understands."""
+    text = str(reference)
+    if is_oci_uri(text):
+        return text[len(SUPPORTED_SCHEMES[0]) :]
+    return text
+
+
+def resolve_oci_model(reference: str | Path) -> str:
+    """Pull an `oci://` reference through llmman and return the local path."""
+    bare = strip_oci_scheme(reference)
+    if not bare.strip():
+        raise ValueError(f"empty OCI model reference: '{reference}'")
+
+    def _progress(status, completed, total):
+        if total:
+            logger.info("llmman: %s (%s/%s bytes)", status, completed, total)
+        else:
+            logger.info("llmman: %s", status)
+
+    return llmman.pull_and_resolve(bare.strip(), progress=_progress)

--- a/test/registered/unit/server_args/test_llmman.py
+++ b/test/registered/unit/server_args/test_llmman.py
@@ -1,0 +1,119 @@
+"""The `llmman serve` client: the daemon protocol behind `oci://` model paths.
+
+Exercised against a real HTTP server on a loopback port rather than mocks, so
+the NDJSON streaming contract is genuinely tested.
+"""
+
+import http.server
+import json
+import socketserver
+import threading
+import unittest
+
+from sglang.srt.utils import llmman
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+def _ndjson(*objs):
+    return "".join(json.dumps(o) + "\n" for o in objs)
+
+
+class _FakeDaemon:
+    """A minimal stand-in for `llmman serve`, on a real loopback port."""
+
+    def __init__(self):
+        self.version = {"version": "0.1.0", "pid": 1}
+        self.pull_body = _ndjson({"status": "success"})
+        self.pull_status = 200
+        self.last_request = None
+        daemon = self
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def log_message(self, *args):
+                pass
+
+            def _send(self, status, body, ctype):
+                raw = body.encode()
+                self.send_response(status)
+                self.send_header("Content-Type", ctype)
+                self.send_header("Content-Length", str(len(raw)))
+                self.end_headers()
+                self.wfile.write(raw)
+
+            def do_GET(self):
+                self._send(200, json.dumps(daemon.version), "application/json")
+
+            def do_POST(self):
+                length = int(self.headers.get("Content-Length", 0))
+                daemon.last_request = json.loads(self.rfile.read(length))
+                self._send(daemon.pull_status, daemon.pull_body, "application/x-ndjson")
+
+        self._server = socketserver.TCPServer(("127.0.0.1", 0), Handler)
+        self.url = f"http://127.0.0.1:{self._server.server_address[1]}"
+        threading.Thread(target=self._server.serve_forever, daemon=True).start()
+
+    def close(self):
+        self._server.shutdown()
+        self._server.server_close()
+
+
+class TestLlmmanDaemon(CustomTestCase):
+    def setUp(self):
+        self.daemon = _FakeDaemon()
+
+    def tearDown(self):
+        self.daemon.close()
+
+    def test_accepts_a_llmman_daemon(self):
+        llmman.check_daemon(self.daemon.url)
+
+    def test_rejects_a_non_llmman_server(self):
+        self.daemon.version = {"hello": "world"}
+        with self.assertRaisesRegex(RuntimeError, "not an llmman daemon"):
+            llmman.check_daemon(self.daemon.url)
+
+    def test_reports_nothing_listening_actionably(self):
+        with self.assertRaisesRegex(RuntimeError, "llmman serve"):
+            llmman.check_daemon("http://127.0.0.1:1")
+
+    def test_pull_succeeds_and_forwards_progress(self):
+        self.daemon.pull_body = _ndjson(
+            {"status": "pulling manifest"},
+            {"status": "pulling blobs", "completed": 50, "total": 100},
+            {"status": "success"},
+        )
+        seen = []
+        llmman.pull(self.daemon.url, "ghcr.io/org/model:tag", lambda *a: seen.append(a))
+
+        self.assertEqual(self.daemon.last_request, {"model": "ghcr.io/org/model:tag"})
+        self.assertEqual(seen, [("pulling manifest", 0, 0), ("pulling blobs", 50, 100)])
+
+    def test_reports_an_in_band_error_at_http_200(self):
+        # The daemon streams errors in-band, so a 200 does not mean success.
+        self.daemon.pull_body = _ndjson(
+            {"status": "pulling"}, {"error": "unauthorized"}
+        )
+        with self.assertRaisesRegex(RuntimeError, "unauthorized"):
+            llmman.pull(self.daemon.url, "ref")
+
+    def test_rejects_a_stream_that_ends_without_success(self):
+        self.daemon.pull_body = _ndjson({"status": "pulling blobs"})
+        with self.assertRaisesRegex(RuntimeError, "without reporting success"):
+            llmman.pull(self.daemon.url, "ref")
+
+    def test_reports_a_non_ok_status(self):
+        self.daemon.pull_status = 400
+        self.daemon.pull_body = '{"error":"bad request"}'
+        with self.assertRaises(RuntimeError):
+            llmman.pull(self.daemon.url, "ref")
+
+    def test_tolerates_a_non_json_diagnostic_line(self):
+        self.daemon.pull_body = "not json\n" + _ndjson({"status": "success"})
+        llmman.pull(self.daemon.url, "ref")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/registered/unit/server_args/test_oci_model_paths.py
+++ b/test/registered/unit/server_args/test_oci_model_paths.py
@@ -1,0 +1,203 @@
+"""`oci://` model references resolve to a local path before anything else runs.
+
+The scheme is explicit on purpose: a bare `registry/name:tag` is the same shape
+as a HuggingFace repo id, so sniffing would hijack existing `--model-path
+org/model` deployments. These tests pin that, the output contract llmman
+promises, and that every other reference shape is left untouched.
+"""
+
+import json
+import os
+import tempfile
+import unittest
+import unittest.mock
+
+from sglang.srt.utils import llmman
+from sglang.srt.utils.oci_utils import is_oci_uri, resolve_oci_model, strip_oci_scheme
+from sglang.test.ci.ci_register import register_cpu_ci
+from sglang.test.test_utils import CustomTestCase
+
+register_cpu_ci(est_time=5, suite="base-a-test-cpu")
+
+
+class TestOciScheme(CustomTestCase):
+    def test_recognizes_the_oci_scheme(self):
+        self.assertTrue(is_oci_uri("oci://ghcr.io/org/model:tag"))
+        self.assertTrue(is_oci_uri("OCI://ghcr.io/org/model:tag"))
+
+    def test_leaves_every_other_reference_shape_alone(self):
+        # A bare HF repo id must never be claimed.
+        for value in (
+            "Qwen/Qwen3-0.6B",
+            "ghcr.io/org/model:tag",
+            "/local/path/to/model",
+            "s3://bucket/key",
+            "gs://bucket/key",
+            "az://container/key",
+            "",
+            None,
+        ):
+            self.assertFalse(is_oci_uri(value), value)
+
+    def test_accepts_pathlib_input(self):
+        import pathlib
+
+        self.assertFalse(is_oci_uri(pathlib.Path("/local/model")))
+
+    def test_strips_the_scheme_only_when_present(self):
+        self.assertEqual(
+            strip_oci_scheme("oci://ghcr.io/org/model:tag"), "ghcr.io/org/model:tag"
+        )
+        self.assertEqual(
+            strip_oci_scheme("OCI://ghcr.io/org/model:tag"), "ghcr.io/org/model:tag"
+        )
+        self.assertEqual(strip_oci_scheme("Qwen/Qwen3-0.6B"), "Qwen/Qwen3-0.6B")
+
+
+class TestResolveOutputContract(CustomTestCase):
+    """`llmman resolve --no-pull` reports where the daemon's pull landed."""
+
+    def test_parses_the_documented_contract(self):
+        with tempfile.TemporaryDirectory() as path:
+            line = json.dumps(
+                {
+                    "reference": "ghcr.io/org/model:tag",
+                    "path": path,
+                    "format": "safetensors",
+                }
+            )
+            self.assertEqual(llmman.parse_resolve_output(line, "ref"), path)
+
+    def test_tolerates_trailing_newline_and_leaked_diagnostics(self):
+        with tempfile.TemporaryDirectory() as path:
+            out = f'pulling blobs...\n{json.dumps({"path": path})}\n'
+            self.assertEqual(llmman.parse_resolve_output(out, "ref"), path)
+
+    def test_ignores_unknown_fields_so_the_contract_can_grow(self):
+        with tempfile.TemporaryDirectory() as path:
+            line = json.dumps(
+                {"path": path, "format": "gguf", "mmproj": "/x", "future": 1}
+            )
+            self.assertEqual(llmman.parse_resolve_output(line, "ref"), path)
+
+    def test_rejects_malformed_output(self):
+        for out in (
+            "",
+            "   \n\n",
+            "not json",
+            '["a", "list"]',
+            '{"no_path": 1}',
+            '{"path": ""}',
+            '{"path": 3}',
+            '{"path": "/nonexistent/xyzzy"}',
+        ):
+            with self.assertRaises(RuntimeError):
+                llmman.parse_resolve_output(out, "ref")
+
+
+class TestEndpointResolution(CustomTestCase):
+    def test_parses_every_llmman_host_form(self):
+        cases = {
+            "": "http://127.0.0.1:17434",
+            "1.2.3.4:9999": "http://1.2.3.4:9999",
+            "1.2.3.4": "http://1.2.3.4:17434",
+            "http://1.2.3.4:9999/ignored": "http://1.2.3.4:9999",
+            # A wildcard bind is meaningful to the server but not to a client.
+            "0.0.0.0:9999": "http://127.0.0.1:9999",
+            "[::]:9999": "http://[::1]:9999",
+        }
+        for value, want in cases.items():
+            with unittest.mock.patch.dict(os.environ, {llmman.HOST_ENV: value}):
+                self.assertEqual(llmman.endpoint(), want, value)
+
+    def test_binary_default_and_override(self):
+        with unittest.mock.patch.dict(os.environ, {llmman.BIN_ENV: ""}):
+            self.assertEqual(llmman.llmman_bin(), "llmman")
+        with unittest.mock.patch.dict(os.environ, {llmman.BIN_ENV: "/opt/llmman"}):
+            self.assertEqual(llmman.llmman_bin(), "/opt/llmman")
+
+
+class TestResolveOciModel(CustomTestCase):
+    def test_rejects_an_empty_reference_without_touching_the_daemon(self):
+        with self.assertRaises(ValueError):
+            resolve_oci_model("oci://")
+        with self.assertRaises(ValueError):
+            resolve_oci_model("oci://   ")
+
+    def test_strips_the_scheme_before_handing_off_to_llmman(self):
+        with unittest.mock.patch(
+            "sglang.srt.utils.oci_utils.llmman.pull_and_resolve",
+            return_value="/resolved",
+        ) as acquire:
+            self.assertEqual(
+                resolve_oci_model("oci://ghcr.io/org/model:tag"), "/resolved"
+            )
+        self.assertEqual(acquire.call_args[0][0], "ghcr.io/org/model:tag")
+        self.assertIsNotNone(acquire.call_args[1]["progress"])
+
+
+class TestModelPathHook(CustomTestCase):
+    """The hook rewrites only oci:// fields, and pulls each image once."""
+
+    def _run_hook(self, **fields):
+        from sglang.srt.arg_groups.model_path_hook import resolve_oci_model_paths
+
+        server_args = unittest.mock.Mock()
+        cfg = unittest.mock.Mock(**fields)
+        declared = []
+        with unittest.mock.patch(
+            "sglang.srt.arg_groups.model_path_hook.resolving_view", return_value=cfg
+        ), unittest.mock.patch(
+            "sglang.srt.arg_groups.model_path_hook.declare_resolution",
+            side_effect=lambda _sa, _src, **kw: declared.append(kw),
+        ), unittest.mock.patch(
+            "sglang.srt.arg_groups.model_path_hook.resolve_oci_model",
+            side_effect=lambda ref: f"/resolved/{ref.rsplit('/', 1)[-1]}",
+        ) as resolver:
+            resolve_oci_model_paths(server_args)
+        return declared, resolver
+
+    def test_no_oci_reference_declares_nothing(self):
+        declared, resolver = self._run_hook(
+            model_path="Qwen/Qwen3-0.6B",
+            tokenizer_path="Qwen/Qwen3-0.6B",
+            speculative_draft_model_path=None,
+        )
+        self.assertEqual(declared, [])
+        resolver.assert_not_called()
+
+    def test_rewrites_the_model_path(self):
+        declared, _ = self._run_hook(
+            model_path="oci://ghcr.io/org/model:tag",
+            tokenizer_path=None,
+            speculative_draft_model_path=None,
+        )
+        self.assertEqual(declared, [{"model_path": "/resolved/model:tag"}])
+
+    def test_pulls_a_shared_reference_once(self):
+        ref = "oci://ghcr.io/org/model:tag"
+        declared, resolver = self._run_hook(
+            model_path=ref,
+            tokenizer_path=ref,
+            speculative_draft_model_path=None,
+        )
+        self.assertEqual(resolver.call_count, 1)
+        self.assertEqual(
+            declared,
+            [
+                {"model_path": "/resolved/model:tag"},
+                {"tokenizer_path": "/resolved/model:tag"},
+            ],
+        )
+
+    def test_leaves_a_non_oci_tokenizer_alone(self):
+        declared, _ = self._run_hook(
+            model_path="oci://ghcr.io/org/model:tag",
+            tokenizer_path="Qwen/Qwen3-0.6B",
+            speculative_draft_model_path=None,
+        )
+        self.assertEqual(declared, [{"model_path": "/resolved/model:tag"}])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Motivation

Model distribution is increasingly moving to OCI registries -- the same registries, credentials, mirroring and air-gap tooling a deployment already uses for container images. [CNCF ModelPack](https://github.com/modelpack/model-spec) is the spec for that.

This adds an `oci://` scheme so such a model works anywhere a HuggingFace repo id does:

```bash
python -m sglang.launch_server --model-path oci://ghcr.io/org/model:tag
```

## Modifications

- **`utils/llmman.py`** (new): a client for a running [`llmman serve`](https://github.com/llmmanorg/llmman) daemon. Acquisition is delegated rather than hand-rolled -- llmman already implements the ModelPack media types, registry auth, resumable blob download and a content-addressed store. Stdlib-only (`urllib`), **no new dependency**:
  - `GET /api/version` probes reachability *and* identity; a server answering without a `version` field is reported as "not an llmman daemon", worth distinguishing from nothing listening.
  - `POST /api/pull` streams NDJSON so a multi-gigabyte fetch is not silent. An error arrives **in-band at HTTP 200**, and a stream that ends without `success` is also a failure -- both are errors, not a completed pull.
  - `llmman resolve --no-pull` reports where the bytes landed. The daemon deliberately exposes no local path, so the CLI is the documented interface; `--no-pull` guarantees it only reports on what `/api/pull` already fetched, keeping the daemon the only thing that touches the network.
  - `LLMMAN_HOST` is honoured with llmman's own parsing, including rewriting a wildcard bind (`0.0.0.0`, `[::]`) to loopback.

- **`utils/oci_utils.py`** (new): `is_oci_uri` / `strip_oci_scheme` / `resolve_oci_model`, deliberately mirroring the shape of the neighbouring `runai_utils.py` (including the `str()` cast so `pathlib.Path` inputs work).

- **`arg_groups/model_path_hook.py`**: new `resolve_oci_model_paths` pass, called first from `handle_model_source_paths`. It rewrites `model_path`, `tokenizer_path` and `speculative_draft_model_path` through `declare_resolution`, matching how `resolve_hf_gguf_model_path` already works. Running first means the rest of the pipeline -- GGUF detection, `handle_load_format`, `ModelConfig` -- only ever sees a local path and needs no changes.

- **`environ.py`**: `SGLANG_LLMMAN_BIN`.

A pull needs **both** the daemon reachable and the binary on `PATH`; each missing piece has its own actionable error. Neither is required unless an `oci://` reference is actually used.

## Design notes

- **Explicit scheme, no sniffing.** A bare `registry/name:tag` is indistinguishable from a HuggingFace repo id (`org/model`); guessing would silently hijack existing `--model-path org/model` deployments. Every non-`oci://` reference is left bit-for-bit untouched.
- **One pull per distinct reference.** `--tokenizer-path` naming the same image as `--model-path` reuses the first resolution.
- **Tolerant output parsing.** The last non-empty line of `resolve` stdout is used, so a diagnostic leaking onto stdout does not break it; unknown JSON keys are ignored so the contract can grow.

## Accuracy / testing

Two new files under `test/registered/unit/server_args/`, both registered on `base-a-test-cpu` (CPU-only, no model download):

`test_llmman.py` (8 cases) runs against a **real HTTP server on a loopback port**, not mocks, so the NDJSON streaming contract is genuinely exercised: `/api/version` accepted, a non-llmman server rejected, nothing-listening reported actionably; pull success with forwarded byte progress and the exact request body asserted; in-band error at HTTP 200; a stream ending without `success`; non-OK status; a non-JSON diagnostic tolerated.

`test_oci_model_paths.py` (16 cases): scheme detection incl. case-insensitivity and `pathlib.Path`; that a bare HF repo id, a local path, and `s3://` / `gs://` / `az://` are **not** claimed (the regression that matters most); `strip_oci_scheme` round-trips; the resolve contract plus eight malformed-output cases; every `LLMMAN_HOST` form incl. wildcard-to-loopback; binary default/override; empty reference rejected without touching the daemon; the scheme stripped before hand-off with progress wired; and the hook itself -- nothing declared when no `oci://` field is present, `model_path` rewritten, a shared reference pulled once, a non-OCI tokenizer left alone.

Verified honestly:

- [x] **24 logic assertions executed standalone against a live loopback daemon** (endpoint parsing, `/api/version` accept/reject/unreachable, pull success + progress + request body, in-band error, stream without success, resolve contract, scheme handling) -- all pass
- [x] `black` and `isort --profile black` clean; `py_compile` clean on all touched files
- [ ] The two unittest files were **not executed in-tree** -- SGLang needs a full torch install this environment does not have, so the `CustomTestCase` / `register_cpu_ci` harness path is unexercised. The logic they cover was verified standalone as above, but their imports and CI registration have not been run.
- [ ] No end-to-end `launch_server` against a live `llmman serve` backed by a real registry.

## Checklist

- [x] Format your code according to the [Code Formatting with Pre-Commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#code-formatting-with-pre-commit).
- [x] Add unit tests as outlined in the [Running Unit Tests](https://docs.sglang.ai/developer_guide/contribution_guide.html#running-unit-tests-adding-to-ci).
- [x] Update documentation as needed, including docstrings or example tutorials.

> Disclosure: this change was written with AI assistance.

<!-- pr-states:start -->
---
### CI States

Latest PR Test (Base): <!-- slot:pr-test:start -->:x: [Run #33336763469](https://github.com/sgl-project/sglang/actions/runs/33336763469)<!-- slot:pr-test:end -->
Latest PR Test (Extra): <!-- slot:pr-test-extra:start -->:x: [Run #33336763308](https://github.com/sgl-project/sglang/actions/runs/33336763308)<!-- slot:pr-test-extra:end -->
Latest PR Test (AMD ROCm 7.2): <!-- slot:pr-test-amd-rocm720:start -->:x: [Run #33336763367](https://github.com/sgl-project/sglang/actions/runs/33336763367)<!-- slot:pr-test-amd-rocm720:end -->
<!-- pr-states:end -->